### PR TITLE
feat(config-policy): partner-owned policies as reusable library — assign to a selectable subset of orgs (#2280)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 # SR-007: least-privilege default. CI runs on every PR (including forks) and
 # only needs to read the repo. Any job needing more must opt in per-job.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
           cache-dependency-path: agent/go.sum
 
       - name: Initialize CodeQL

--- a/.github/workflows/dev-build-agent.yml
+++ b/.github/workflows/dev-build-agent.yml
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   build-arm64:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 # Least-privilege default; the SARIF-uploading job opts into
 # security-events: write per-job below.

--- a/apps/api/src/__tests__/integration/configurationPoliciesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/configurationPoliciesPartnerRls.integration.test.ts
@@ -20,9 +20,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { eq, type SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import { db, withDbAccessContext, type DbAccessContext } from '../../db';
-import { configurationPolicies } from '../../db/schema';
+import { configurationPolicies, configPolicyAssignments } from '../../db/schema';
 import { listConfigPolicies } from '../../services/configurationPolicy';
 import { createOrganization, createPartner } from './db-utils';
+import { pgErrorCode } from '../../utils/pgErrors';
 
 const created: string[] = [];
 
@@ -338,5 +339,54 @@ describe('configuration_policies RLS — dual-axis (2026-06-27 migration)', () =
       .where(eq(configurationPolicies.id, id));
 
     expect(rows).toEqual([]);
+  });
+
+  it('rejects a forged assignment linking another partner\'s policy to an out-of-partner org (#2280, 42501)', async () => {
+    // config_policy_assignments_org_isolation gates solely on access to the
+    // PARENT policy (config_policy_assignments -> configuration_policies EXISTS
+    // check), not on the target_id. So the attack this guards against is a
+    // partner with NO access to policyP1 (owned by partnerP1) trying to point an
+    // assignment row at it — e.g. to "claim" a partner-wide policy they don't
+    // own by assigning it into their own org.
+    //
+    // Unlike the sibling forge tests above (which insert directly into
+    // configuration_policies), this WITH CHECK evaluates a nested EXISTS
+    // against configuration_policies itself, another RLS-forced table. The
+    // forced failure is isolated in a nested `db.transaction` (postgres.js
+    // SAVEPOINT) rather than let it reject the outer withDbAccessContext call
+    // directly — the same defense-in-depth pattern proven in
+    // dbSavepointErrorIsolation.integration.test.ts (#2189): each
+    // `sql.savepoint`/`db.transaction` scope tracks its own uncaughtError, so
+    // catching the error on the SAVEPOINT-scoped `tx` here means the outer
+    // transaction commits cleanly instead of carrying a raw driver error to
+    // its own commit — keeping this isolation-sensitive forge test from ever
+    // being able to affect the pooled connection a co-run sibling test picks
+    // up next. The RLS assertion itself is unchanged: still a real INSERT
+    // through the real breeze_app driver, still required to fail with 42501.
+    const partnerP1 = await createPartner();
+    const partnerQ = await createPartner();
+    const orgQ = await createOrganization({ partnerId: partnerQ.id });
+    const policyP1 = await seedPartnerPolicy(partnerP1.id);
+
+    let caught: unknown;
+    await withDbAccessContext(partnerContext(partnerQ.id, [orgQ.id]), async () => {
+      try {
+        await db.transaction((tx) =>
+          tx
+            .insert(configPolicyAssignments)
+            .values({
+              configPolicyId: policyP1,
+              level: 'organization',
+              targetId: orgQ.id,
+              priority: 0,
+            })
+            .returning(),
+        );
+      } catch (err) {
+        caught = err;
+      }
+    });
+
+    expect(pgErrorCode(caught)).toBe('42501');
   });
 });

--- a/apps/api/src/__tests__/integration/configurationPolicyPartnerResolution.integration.test.ts
+++ b/apps/api/src/__tests__/integration/configurationPolicyPartnerResolution.integration.test.ts
@@ -191,4 +191,30 @@ describe('partner-wide configuration policy resolution (#1724)', () => {
     expect(resolved?.features.security?.sourcePolicyId).toBe(orgPolicyId);
     expect(resolved?.features.security?.sourceLevel).toBe('organization');
   });
+
+  it('a partner-owned policy assigned to ONE org resolves only for that org, not a sibling org (#2280)', async () => {
+    // Partner-owned policies are a reusable library (#2280): assigning one at
+    // 'organization' level to a SINGLE org must not leak to sibling orgs of the
+    // same partner that were never assigned — subset resolution, not fan-out.
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const siteA = await createSite({ orgId: orgA!.id });
+    const siteB = await createSite({ orgId: orgB!.id });
+    const deviceA = await seedDevice(orgA!.id, siteA!.id, 'windows', 'server');
+    const deviceB = await seedDevice(orgB!.id, siteB!.id, 'windows', 'server');
+
+    const { policyId } = await seedPartnerPolicyWithFeature(partner.id);
+    // Subset assignment: organization level, org A only — deliberately NO
+    // partner-level assignment, so org B has nothing pointing at this policy.
+    await assign(policyId, 'organization', orgA!.id);
+
+    const resolvedA = await withSystemDbAccessContext(() => resolveEffectiveConfig(deviceA.id, systemAuth()));
+    const resolvedB = await withSystemDbAccessContext(() => resolveEffectiveConfig(deviceB.id, systemAuth()));
+
+    expect(resolvedA?.features.security?.sourcePolicyId).toBe(policyId);
+    expect(resolvedA?.features.security?.sourceLevel).toBe('organization');
+    // Sibling org under the same partner was never assigned this policy — must NOT inherit it.
+    expect(resolvedB?.features.security).toBeUndefined();
+  });
 });

--- a/apps/api/src/__tests__/integration/patchSchedulerPartnerResolution.integration.test.ts
+++ b/apps/api/src/__tests__/integration/patchSchedulerPartnerResolution.integration.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Patch scheduler SUBSET resolution — partner re-clamp (#2280 review, PR #2285).
+ *
+ * `resolveDeviceIdsForAssignment` (apps/api/src/jobs/patchSchedulerWorker.ts)
+ * resolves which devices a config-policy assignment targets. For a
+ * partner-owned policy (policyOrgId null) carrying an org/site/group/device
+ * SUBSET assignment, the target org was only verified to belong to the
+ * policy's partner at ASSIGN time (validateAssignmentTarget). If that org is
+ * later reparented to a different partner, the stale assignment row would
+ * otherwise keep resolving those devices — a TOCTOU hole. The fix threads the
+ * policy's partnerId into resolution and re-verifies it on every run via an
+ * inner join on organizations, the same re-verification the partner-wide
+ * 'partner' level branch already does for assignmentTargetId.
+ *
+ * The unit suite (patchSchedulerWorker.test.ts) proves the query SHAPE
+ * (join + where args) against a mocked db. This proves the join actually
+ * ENFORCES the clamp against real Postgres — per the CLAUDE.md config-policy
+ * partner-wide playbook item 5, a worker's partner-wide fan-out must be
+ * proven against real Postgres, not just asserted at the mock layer.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import {
+  db,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import {
+  configurationPolicies,
+  configPolicyFeatureLinks,
+  configPolicyAssignments,
+  devices,
+  organizations,
+} from '../../db/schema';
+import { __testOnly } from '../../jobs/patchSchedulerWorker';
+import { createPartner, createOrganization, createSite } from './db-utils';
+
+const { resolveDeviceIdsForAssignment } = __testOnly;
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+const createdPolicies: string[] = [];
+
+afterEach(async () => {
+  if (createdPolicies.length === 0) return;
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    for (const id of createdPolicies) {
+      await db.delete(configurationPolicies).where(eq(configurationPolicies.id, id));
+    }
+  });
+  createdPolicies.length = 0;
+});
+
+async function seedDevice(orgId: string, siteId: string) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [d] = await db
+      .insert(devices)
+      .values({
+        orgId,
+        siteId,
+        agentId: `agent-${randomUUID()}`,
+        hostname: `host-${randomUUID().slice(0, 8)}`,
+        osType: 'windows',
+        osVersion: '1.0',
+        architecture: 'amd64',
+        agentVersion: '1.0.0',
+        status: 'online',
+        deviceRole: 'workstation',
+      })
+      .returning();
+    return d!;
+  });
+}
+
+/** Partner-owned (org_id NULL) policy with a 'patch' feature link — the #2280 library shape. */
+async function seedPartnerPatchPolicy(partnerId: string): Promise<string> {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [policy] = await db
+      .insert(configurationPolicies)
+      .values({ orgId: null, partnerId, name: 'Partner-wide patch library policy', status: 'active' })
+      .returning();
+    createdPolicies.push(policy!.id);
+    await db.insert(configPolicyFeatureLinks).values({
+      configPolicyId: policy!.id,
+      featureType: 'patch',
+      inlineSettings: {},
+    });
+    return policy!.id;
+  });
+}
+
+async function assignOrg(policyId: string, orgId: string) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    await db.insert(configPolicyAssignments).values({
+      configPolicyId: policyId,
+      level: 'organization',
+      targetId: orgId,
+      priority: 0,
+    });
+  });
+}
+
+describe('patch scheduler SUBSET resolution — partner re-clamp (#2280 review)', () => {
+  it('resolves an org-level SUBSET assignment on a partner-owned policy to ONLY the assigned org, not a sibling org (fan-out contract)', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const siteA = await createSite({ orgId: orgA!.id });
+    const siteB = await createSite({ orgId: orgB!.id });
+    const deviceA = await seedDevice(orgA!.id, siteA!.id);
+    await seedDevice(orgB!.id, siteB!.id); // sibling org under the SAME partner — must NOT resolve
+
+    const policyId = await seedPartnerPatchPolicy(partner.id);
+    // Subset assignment: organization level, org A only — deliberately no
+    // assignment for org B, so org B has nothing pointing at this policy.
+    await assignOrg(policyId, orgA!.id);
+
+    const ids = await withSystemDbAccessContext(() =>
+      resolveDeviceIdsForAssignment('organization', orgA!.id, null, partner.id)
+    );
+
+    expect(ids).toEqual([deviceA.id]);
+  });
+
+  it('stops resolving a SUBSET assignment once its org is reparented to a different partner (TOCTOU re-clamp)', async () => {
+    const partner = await createPartner();
+    const otherPartner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org!.id });
+    const device = await seedDevice(org!.id, site!.id);
+
+    const policyId = await seedPartnerPatchPolicy(partner.id);
+    await assignOrg(policyId, org!.id);
+
+    // Sanity check: resolves normally while the org still belongs to the
+    // policy's partner.
+    const before = await withSystemDbAccessContext(() =>
+      resolveDeviceIdsForAssignment('organization', org!.id, null, partner.id)
+    );
+    expect(before).toEqual([device.id]);
+
+    // Reparent the org to a DIFFERENT partner. The assignment row is now
+    // stale — it was only ever verified to belong to `partner` at ASSIGN
+    // time (validateAssignmentTarget), and nothing re-checks it afterwards
+    // except this resolution join.
+    await withDbAccessContext(SYSTEM_CTX, async () => {
+      await db
+        .update(organizations)
+        .set({ partnerId: otherPartner.id })
+        .where(eq(organizations.id, org!.id));
+    });
+
+    const after = await withSystemDbAccessContext(() =>
+      resolveDeviceIdsForAssignment('organization', org!.id, null, partner.id)
+    );
+
+    // Must NOT still resolve devices for the policy's now-stale partner.
+    expect(after).toEqual([]);
+  });
+});

--- a/apps/api/src/jobs/patchSchedulerWorker.test.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.test.ts
@@ -70,6 +70,33 @@ import { captureException } from '../services/sentry';
 
 const { loadDeviceSchedulingContexts, enqueueScanResults, resolveDeviceIdsForAssignment } = __testOnly;
 
+// Drizzle's `eq`/`and` build a real SQL AST (queryChunks tree), even though our
+// mocked schema columns are plain strings rather than real Column objects —
+// `sql\`${left} = ${right}\`` inserts both raw operands directly into
+// queryChunks (they don't satisfy isDriverValueEncoder, so neither side gets
+// wrapped in a Param). That means the exact identifiers passed to eq()/and()
+// are recoverable by walking the tree, which lets a test assert on the ACTUAL
+// filter values a `.where(...)` call was built with, instead of trusting a
+// mock that returns a fixed row regardless of what was asked for (the gap
+// this suite is closing, #2280 review).
+function collectSqlLeafStrings(node: unknown, seen = new Set<unknown>(), acc: string[] = []): string[] {
+  if (typeof node === 'string') {
+    acc.push(node);
+    return acc;
+  }
+  if (node === null || typeof node !== 'object' || seen.has(node)) return acc;
+  seen.add(node);
+  if (Array.isArray(node)) {
+    for (const item of node) collectSqlLeafStrings(item, seen, acc);
+    return acc;
+  }
+  const queryChunks = (node as { queryChunks?: unknown[] }).queryChunks;
+  if (Array.isArray(queryChunks)) {
+    for (const item of queryChunks) collectSqlLeafStrings(item, seen, acc);
+  }
+  return acc;
+}
+
 describe('resolveDeviceIdsForAssignment (partner-wide patch, #1724)', () => {
   beforeEach(() => {
     mockRows = [];
@@ -86,20 +113,16 @@ describe('resolveDeviceIdsForAssignment (partner-wide patch, #1724)', () => {
     const ids = await resolveDeviceIdsForAssignment(
       'partner',
       '88888888-8888-4888-8888-888888888888',
+      null,
       null
     );
     expect(ids).toEqual(['dev-a', 'dev-b']);
   });
 
-  it('resolves an ORGANIZATION-level SUBSET assignment on a partner-owned library policy (policyOrgId null, #2280)', async () => {
-    // Partner-owned policies can now carry org/site/group/device SUBSET
-    // assignments (#2280 library model), not just the partner-wide 'partner'
-    // level. A null policyOrgId here is the NORMAL case for those — resolution
-    // must NOT no-op; it queries devices by the target org alone (no extra
-    // clamp, since there's no single owning org for a library policy). This
-    // branch's query shape is `.from(devices).where(...)` directly (no
-    // innerJoin), which the shared module-level mock doesn't model, so this
-    // test overrides db.select for its one call.
+  it('does NOT partner-clamp an org-owned policy (policyOrgId set) — existing org clamp only, no join', async () => {
+    // Baseline/regression guard for the pre-#2280 org-owned path: no partner is
+    // threaded through, and the resolver must not attempt an organizations join
+    // (the mock chain below has no `.innerJoin`, so calling it would throw).
     const { db } = await import('../db');
     const chain: any = {
       from: vi.fn(() => chain),
@@ -107,8 +130,42 @@ describe('resolveDeviceIdsForAssignment (partner-wide patch, #1724)', () => {
     };
     vi.mocked(db.select).mockReturnValueOnce(chain);
 
-    const ids = await resolveDeviceIdsForAssignment('organization', 'org-x', null);
+    const ids = await resolveDeviceIdsForAssignment('organization', 'org-x', 'org-x', null);
+
     expect(ids).toEqual(['dev-a']);
+    const whereArgs = collectSqlLeafStrings(chain.where.mock.calls[0][0]);
+    expect(whereArgs).toContain('org-x');
+  });
+
+  it('re-clamps an ORGANIZATION-level SUBSET assignment on a partner-owned library policy to the policy partner (TOCTOU re-clamp, #2280 review)', async () => {
+    // Partner-owned policies can now carry org/site/group/device SUBSET
+    // assignments (#2280 library model), not just the partner-wide 'partner'
+    // level. A null policyOrgId here is the NORMAL case for those. The target
+    // org was partner-scoped at ASSIGN time only — if it's later reparented to
+    // a different partner, a stale assignment row must not keep resolving those
+    // devices. So resolution now re-verifies via an inner join on organizations
+    // and clamps to the policy's partnerId on every run, mirroring the
+    // 'partner' branch's re-verification of assignmentTargetId.
+    const { db } = await import('../db');
+    const { organizations } = await import('../db/schema');
+    const chain: any = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn(() => Promise.resolve([{ id: 'dev-a' }])),
+    };
+    vi.mocked(db.select).mockReturnValueOnce(chain);
+
+    const ids = await resolveDeviceIdsForAssignment('organization', 'org-x', null, 'partner-123');
+
+    expect(ids).toEqual(['dev-a']);
+    // Joined against organizations specifically (not some other table).
+    expect(chain.innerJoin).toHaveBeenCalledTimes(1);
+    expect(chain.innerJoin.mock.calls[0][0]).toBe(organizations);
+    // The where() predicate actually carries BOTH the target-org filter and the
+    // partner clamp — not just one or the other, and not a fixed mock return.
+    const whereArgs = collectSqlLeafStrings(chain.where.mock.calls[0][0]);
+    expect(whereArgs).toContain('org-x');
+    expect(whereArgs).toContain('partner-123');
   });
 });
 

--- a/apps/api/src/jobs/patchSchedulerWorker.test.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.test.ts
@@ -39,7 +39,11 @@ vi.mock('../db/schema', () => ({
   configPolicyAssignments: {},
   patchJobs: {},
   devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId' },
-  deviceGroupMemberships: {},
+  deviceGroupMemberships: {
+    deviceId: 'deviceGroupMemberships.deviceId',
+    groupId: 'deviceGroupMemberships.groupId',
+    orgId: 'deviceGroupMemberships.orgId',
+  },
   organizations: { id: 'organizations.id', partnerId: 'organizations.partnerId', settings: 'organizations.settings' },
   partners: { id: 'partners.id', timezone: 'partners.timezone', settings: 'partners.settings' },
   sites: { id: 'sites.id', timezone: 'sites.timezone' },
@@ -165,6 +169,72 @@ describe('resolveDeviceIdsForAssignment (partner-wide patch, #1724)', () => {
     // partner clamp — not just one or the other, and not a fixed mock return.
     const whereArgs = collectSqlLeafStrings(chain.where.mock.calls[0][0]);
     expect(whereArgs).toContain('org-x');
+    expect(whereArgs).toContain('partner-123');
+  });
+
+  it('re-clamps a SITE-level SUBSET assignment on a partner-owned library policy to the policy partner (#2280 review)', async () => {
+    // Structurally parallel to the organization-level re-clamp above: the site
+    // branch also joins organizations and must carry BOTH the site filter and
+    // the partner clamp in its WHERE predicate.
+    const { db } = await import('../db');
+    const { organizations } = await import('../db/schema');
+    const chain: any = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn(() => Promise.resolve([{ id: 'dev-a' }])),
+    };
+    vi.mocked(db.select).mockReturnValueOnce(chain);
+
+    const ids = await resolveDeviceIdsForAssignment('site', 'site-x', null, 'partner-123');
+
+    expect(ids).toEqual(['dev-a']);
+    expect(chain.innerJoin).toHaveBeenCalledTimes(1);
+    expect(chain.innerJoin.mock.calls[0][0]).toBe(organizations);
+    const whereArgs = collectSqlLeafStrings(chain.where.mock.calls[0][0]);
+    expect(whereArgs).toContain('site-x');
+    expect(whereArgs).toContain('partner-123');
+  });
+
+  it('re-clamps a DEVICE_GROUP-level SUBSET assignment on a partner-owned library policy to the policy partner (#2280 review)', async () => {
+    const { db } = await import('../db');
+    const { organizations } = await import('../db/schema');
+    const chain: any = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn(() => Promise.resolve([{ deviceId: 'dev-a' }])),
+    };
+    vi.mocked(db.select).mockReturnValueOnce(chain);
+
+    const ids = await resolveDeviceIdsForAssignment('device_group', 'group-x', null, 'partner-123');
+
+    expect(ids).toEqual(['dev-a']);
+    expect(chain.innerJoin).toHaveBeenCalledTimes(1);
+    expect(chain.innerJoin.mock.calls[0][0]).toBe(organizations);
+    const whereArgs = collectSqlLeafStrings(chain.where.mock.calls[0][0]);
+    expect(whereArgs).toContain('group-x');
+    expect(whereArgs).toContain('partner-123');
+  });
+
+  it('re-clamps a DEVICE-level SUBSET assignment on a partner-owned library policy to the policy partner (#2280 review)', async () => {
+    // The device branch additionally chains .limit(1) after .where(), unlike
+    // the site/device_group/organization branches above.
+    const { db } = await import('../db');
+    const { organizations } = await import('../db/schema');
+    const chain: any = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      limit: vi.fn(() => Promise.resolve([{ id: 'dev-a' }])),
+    };
+    vi.mocked(db.select).mockReturnValueOnce(chain);
+
+    const ids = await resolveDeviceIdsForAssignment('device', 'dev-x', null, 'partner-123');
+
+    expect(ids).toEqual(['dev-a']);
+    expect(chain.innerJoin).toHaveBeenCalledTimes(1);
+    expect(chain.innerJoin.mock.calls[0][0]).toBe(organizations);
+    const whereArgs = collectSqlLeafStrings(chain.where.mock.calls[0][0]);
+    expect(whereArgs).toContain('dev-x');
     expect(whereArgs).toContain('partner-123');
   });
 });

--- a/apps/api/src/jobs/patchSchedulerWorker.test.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.test.ts
@@ -91,14 +91,24 @@ describe('resolveDeviceIdsForAssignment (partner-wide patch, #1724)', () => {
     expect(ids).toEqual(['dev-a', 'dev-b']);
   });
 
-  it('returns [] without querying for an org-scoped level when the policy has no owning org', async () => {
-    // Org/site/group/device levels are never carried by a partner-wide policy
-    // (validateAssignmentTarget rejects them); a null policyOrgId here is a
-    // no-op, guarded before the org-equality queries run.
+  it('resolves an ORGANIZATION-level SUBSET assignment on a partner-owned library policy (policyOrgId null, #2280)', async () => {
+    // Partner-owned policies can now carry org/site/group/device SUBSET
+    // assignments (#2280 library model), not just the partner-wide 'partner'
+    // level. A null policyOrgId here is the NORMAL case for those — resolution
+    // must NOT no-op; it queries devices by the target org alone (no extra
+    // clamp, since there's no single owning org for a library policy). This
+    // branch's query shape is `.from(devices).where(...)` directly (no
+    // innerJoin), which the shared module-level mock doesn't model, so this
+    // test overrides db.select for its one call.
     const { db } = await import('../db');
+    const chain: any = {
+      from: vi.fn(() => chain),
+      where: vi.fn(() => Promise.resolve([{ id: 'dev-a' }])),
+    };
+    vi.mocked(db.select).mockReturnValueOnce(chain);
+
     const ids = await resolveDeviceIdsForAssignment('organization', 'org-x', null);
-    expect(ids).toEqual([]);
-    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+    expect(ids).toEqual(['dev-a']);
   });
 });
 

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -189,7 +189,12 @@ async function resolveDeviceIdsForAssignment(
   // single owning org and may carry a partner-level assignment (resolved
   // across all the partner's orgs) AND/OR org/site/group/device-level SUBSET
   // assignments into individual orgs under the partner.
-  policyOrgId: string | null
+  policyOrgId: string | null,
+  // The policy's own partnerId (set for partner-owned policies, null for
+  // org-owned ones). Used ONLY to re-clamp subset (org/site/group/device)
+  // resolution below when policyOrgId is null — see the comment above the
+  // switch for why this exists (#2280 review finding).
+  policyPartnerId: string | null
 ): Promise<string[]> {
   if (assignmentLevel === 'partner') {
     // A partner-wide policy (policyOrgId null, #1724) resolves EVERY device
@@ -219,14 +224,26 @@ async function resolveDeviceIdsForAssignment(
   // SUBSET assignment — org/site/group/device, not the partner-wide 'partner'
   // level above — policyOrgId is null: there is no single owning org to clamp
   // to, since the same policy can carry subset assignments into several of the
-  // partner's orgs. The target itself is already partner-scoped
-  // (validateAssignmentTarget confirmed it belongs to this partner at assign
-  // time), so it's trusted here without an extra clamp — the same trust model
-  // the 'partner' branch above already uses for assignmentTargetId. Silently
-  // no-op'ing on a null policyOrgId (the old behavior, pre-#2280) would create
-  // a patch-compliance hole for every partner-owned subset assignment.
+  // partner's orgs. The target itself was partner-scoped at ASSIGN time
+  // (validateAssignmentTarget), but that check is a point-in-time snapshot —
+  // if the target org is later reparented to a different partner, the stale
+  // assignment row would otherwise still resolve those devices (TOCTOU). So
+  // every subset branch below re-clamps to the policy's partner on every run
+  // via an inner join on organizations, the same re-verification the
+  // 'partner' branch above already does for assignmentTargetId.
+  const needsPartnerClamp = !policyOrgId && Boolean(policyPartnerId);
+
   switch (assignmentLevel) {
     case 'device': {
+      if (needsPartnerClamp) {
+        const [device] = await db
+          .select({ id: devices.id })
+          .from(devices)
+          .innerJoin(organizations, eq(devices.orgId, organizations.id))
+          .where(and(eq(devices.id, assignmentTargetId), eq(organizations.partnerId, policyPartnerId!)))
+          .limit(1);
+        return device ? [device.id] : [];
+      }
       const conditions = [eq(devices.id, assignmentTargetId)];
       if (policyOrgId) conditions.push(eq(devices.orgId, policyOrgId));
       const [device] = await db
@@ -238,6 +255,19 @@ async function resolveDeviceIdsForAssignment(
     }
 
     case 'device_group': {
+      if (needsPartnerClamp) {
+        const members = await db
+          .select({ deviceId: deviceGroupMemberships.deviceId })
+          .from(deviceGroupMemberships)
+          .innerJoin(organizations, eq(deviceGroupMemberships.orgId, organizations.id))
+          .where(
+            and(
+              eq(deviceGroupMemberships.groupId, assignmentTargetId),
+              eq(organizations.partnerId, policyPartnerId!)
+            )
+          );
+        return members.map((m) => m.deviceId);
+      }
       const conditions = [eq(deviceGroupMemberships.groupId, assignmentTargetId)];
       if (policyOrgId) conditions.push(eq(deviceGroupMemberships.orgId, policyOrgId));
       const members = await db
@@ -248,6 +278,14 @@ async function resolveDeviceIdsForAssignment(
     }
 
     case 'site': {
+      if (needsPartnerClamp) {
+        const siteDevices = await db
+          .select({ id: devices.id })
+          .from(devices)
+          .innerJoin(organizations, eq(devices.orgId, organizations.id))
+          .where(and(eq(devices.siteId, assignmentTargetId), eq(organizations.partnerId, policyPartnerId!)));
+        return siteDevices.map((d) => d.id);
+      }
       const conditions = [eq(devices.siteId, assignmentTargetId)];
       if (policyOrgId) conditions.push(eq(devices.orgId, policyOrgId));
       const siteDevices = await db
@@ -258,6 +296,14 @@ async function resolveDeviceIdsForAssignment(
     }
 
     case 'organization': {
+      if (needsPartnerClamp) {
+        const orgDevices = await db
+          .select({ id: devices.id })
+          .from(devices)
+          .innerJoin(organizations, eq(devices.orgId, organizations.id))
+          .where(and(eq(devices.orgId, assignmentTargetId), eq(organizations.partnerId, policyPartnerId!)));
+        return orgDevices.map((d) => d.id);
+      }
       const conditions = [eq(devices.orgId, assignmentTargetId)];
       if (policyOrgId) conditions.push(eq(devices.orgId, policyOrgId));
       const orgDevices = await db
@@ -372,6 +418,7 @@ async function scanAndCreateJobs(): Promise<{
       configPolicyId: configurationPolicies.id,
       policyName: configurationPolicies.name,
       policyOrgId: configurationPolicies.orgId,
+      policyPartnerId: configurationPolicies.partnerId,
       featureLinkId: configPolicyFeatureLinks.id,
     })
     .from(configPolicyFeatureLinks)
@@ -393,6 +440,7 @@ async function scanAndCreateJobs(): Promise<{
       // policyOrgId is null for those; resolveDeviceIdsForAssignment resolves the
       // partner-level assignment across all the partner's devices.
       const policyOrgId = row.policyOrgId;
+      const policyPartnerId = row.policyPartnerId;
 
       const policyLocal = await runWithSystemDbAccess(() => loadPolicyLocalPatchConfig(row.configPolicyId));
       if (!policyLocal) continue;
@@ -419,7 +467,7 @@ async function scanAndCreateJobs(): Promise<{
       const allDeviceIds = new Set<string>();
       for (const assignment of assignments) {
         const ids = await runWithSystemDbAccess(() =>
-          resolveDeviceIdsForAssignment(assignment.level, assignment.targetId, policyOrgId)
+          resolveDeviceIdsForAssignment(assignment.level, assignment.targetId, policyOrgId, policyPartnerId)
         );
         for (const id of ids) allDeviceIds.add(id);
       }

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -185,8 +185,10 @@ function getDueOccurrenceKey(settings: PatchInlineSettings, timezone: string, no
 async function resolveDeviceIdsForAssignment(
   assignmentLevel: string,
   assignmentTargetId: string,
-  // null for partner-wide policies (#1724) — they have no owning org and can
-  // only carry a partner-level assignment, resolved across all the partner's orgs.
+  // null for partner-owned library policies (#1724, #2280) — they have no
+  // single owning org and may carry a partner-level assignment (resolved
+  // across all the partner's orgs) AND/OR org/site/group/device-level SUBSET
+  // assignments into individual orgs under the partner.
   policyOrgId: string | null
 ): Promise<string[]> {
   if (assignmentLevel === 'partner') {
@@ -211,55 +213,57 @@ async function resolveDeviceIdsForAssignment(
     return partnerDevices.map((d) => d.id);
   }
 
-  // Every remaining level is org-scoped and clamps to the policy's owning org.
-  // A partner-wide policy never carries one (validateAssignmentTarget rejects),
-  // so a null policyOrgId here should be unreachable — but if a future path
-  // bypasses assignment validation, silently scheduling ZERO patch jobs is a
-  // patch-compliance hole, so make the no-op loud.
-  if (!policyOrgId) {
-    console.warn(
-      `[PatchScheduler] ${assignmentLevel}-level assignment on a policy with no owning org — resolving no devices`,
-      { assignmentLevel, assignmentTargetId }
-    );
-    return [];
-  }
-
+  // Every remaining level is org/site/group/device-scoped. For an org-owned
+  // policy, policyOrgId clamps the target to the policy's own org as
+  // defense-in-depth. For a partner-owned library policy (#2280) resolving a
+  // SUBSET assignment — org/site/group/device, not the partner-wide 'partner'
+  // level above — policyOrgId is null: there is no single owning org to clamp
+  // to, since the same policy can carry subset assignments into several of the
+  // partner's orgs. The target itself is already partner-scoped
+  // (validateAssignmentTarget confirmed it belongs to this partner at assign
+  // time), so it's trusted here without an extra clamp — the same trust model
+  // the 'partner' branch above already uses for assignmentTargetId. Silently
+  // no-op'ing on a null policyOrgId (the old behavior, pre-#2280) would create
+  // a patch-compliance hole for every partner-owned subset assignment.
   switch (assignmentLevel) {
     case 'device': {
+      const conditions = [eq(devices.id, assignmentTargetId)];
+      if (policyOrgId) conditions.push(eq(devices.orgId, policyOrgId));
       const [device] = await db
         .select({ id: devices.id })
         .from(devices)
-        .where(and(eq(devices.id, assignmentTargetId), eq(devices.orgId, policyOrgId)))
+        .where(and(...conditions))
         .limit(1);
       return device ? [device.id] : [];
     }
 
     case 'device_group': {
+      const conditions = [eq(deviceGroupMemberships.groupId, assignmentTargetId)];
+      if (policyOrgId) conditions.push(eq(deviceGroupMemberships.orgId, policyOrgId));
       const members = await db
         .select({ deviceId: deviceGroupMemberships.deviceId })
         .from(deviceGroupMemberships)
-        .where(
-          and(
-            eq(deviceGroupMemberships.groupId, assignmentTargetId),
-            eq(deviceGroupMemberships.orgId, policyOrgId)
-          )
-        );
+        .where(and(...conditions));
       return members.map((m) => m.deviceId);
     }
 
     case 'site': {
+      const conditions = [eq(devices.siteId, assignmentTargetId)];
+      if (policyOrgId) conditions.push(eq(devices.orgId, policyOrgId));
       const siteDevices = await db
         .select({ id: devices.id })
         .from(devices)
-        .where(and(eq(devices.siteId, assignmentTargetId), eq(devices.orgId, policyOrgId)));
+        .where(and(...conditions));
       return siteDevices.map((d) => d.id);
     }
 
     case 'organization': {
+      const conditions = [eq(devices.orgId, assignmentTargetId)];
+      if (policyOrgId) conditions.push(eq(devices.orgId, policyOrgId));
       const orgDevices = await db
         .select({ id: devices.id })
         .from(devices)
-        .where(and(eq(devices.orgId, assignmentTargetId), eq(devices.orgId, policyOrgId)));
+        .where(and(...conditions));
       return orgDevices.map((d) => d.id);
     }
 

--- a/apps/api/src/routes/configurationPolicies/assignments.test.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.test.ts
@@ -8,6 +8,7 @@ const {
   listAssignmentsMock,
   listAssignmentsForTargetMock,
   validateAssignmentTargetMock,
+  canManagePartnerWideMock,
 } = vi.hoisted(() => ({
   getConfigPolicyMock: vi.fn(),
   assignPolicyMock: vi.fn(),
@@ -15,11 +16,13 @@ const {
   listAssignmentsMock: vi.fn(),
   listAssignmentsForTargetMock: vi.fn(),
   validateAssignmentTargetMock: vi.fn(),
+  canManagePartnerWideMock: vi.fn(),
 }));
 
 vi.mock('../../services/configurationPolicy', async (importOriginal) => {
-  // Spread the original so canManagePartnerWidePolicies (the real capability
-  // gate) and PARTNER_WIDE_WRITE_DENIED_MESSAGE flow through unmocked.
+  // Spread the original so PARTNER_WIDE_WRITE_DENIED_MESSAGE flows through
+  // unmocked; canManagePartnerWidePolicies is mocked so each test controls
+  // the capability outcome directly instead of depending on real auth shape.
   const original = await importOriginal<typeof import('../../services/configurationPolicy')>();
   return {
     ...original,
@@ -29,6 +32,7 @@ vi.mock('../../services/configurationPolicy', async (importOriginal) => {
     listAssignments: listAssignmentsMock,
     listAssignmentsForTarget: listAssignmentsForTargetMock,
     validateAssignmentTarget: validateAssignmentTargetMock,
+    canManagePartnerWidePolicies: canManagePartnerWideMock,
   };
 });
 
@@ -170,6 +174,7 @@ describe('configurationPolicies assignment routes', () => {
 
   it('derives the partner target server-side for a partner-wide assignment (#1724)', async () => {
     getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Partner-wide' });
+    canManagePartnerWideMock.mockReturnValue(true);
     validateAssignmentTargetMock.mockResolvedValue({ valid: true });
     assignPolicyMock.mockResolvedValue({
       id: '55555555-5555-5555-5555-555555555555',
@@ -220,6 +225,7 @@ describe('configurationPolicies assignment routes', () => {
     // to make a partner-level assignment that would push config to ALL orgs under
     // the partner — including orgs they cannot access.
     getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Partner-wide' });
+    canManagePartnerWideMock.mockReturnValue(false);
 
     const appPartnerSelected = new Hono();
     appPartnerSelected.use('*', async (c, next) => {
@@ -243,6 +249,7 @@ describe('configurationPolicies assignment routes', () => {
 
   it('denies partner-level assignment when orgAccess is "none"', async () => {
     getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Partner-wide' });
+    canManagePartnerWideMock.mockReturnValue(false);
 
     const appPartnerNone = new Hono();
     appPartnerNone.use('*', async (c, next) => {
@@ -264,6 +271,7 @@ describe('configurationPolicies assignment routes', () => {
 
   it('allows partner-level assignment when orgAccess is "all" (legit partner admin)', async () => {
     getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Partner-wide' });
+    canManagePartnerWideMock.mockReturnValue(true);
     validateAssignmentTargetMock.mockResolvedValue({ valid: true });
     assignPolicyMock.mockResolvedValue({
       id: '55555555-5555-5555-5555-555555555555',
@@ -334,6 +342,7 @@ describe('configurationPolicies assignment routes', () => {
     // the partner — same blast radius as assigning, same capability gate.
     const AID = '77777777-7777-7777-7777-777777777777';
     getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Partner-wide' });
+    canManagePartnerWideMock.mockReturnValue(false);
 
     const appPartnerSelected = new Hono();
     appPartnerSelected.use('*', async (c, next) => {
@@ -353,6 +362,7 @@ describe('configurationPolicies assignment routes', () => {
   it('allows unassigning a partner-wide policy with full partner org access', async () => {
     const AID = '77777777-7777-7777-7777-777777777777';
     getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Partner-wide' });
+    canManagePartnerWideMock.mockReturnValue(true);
     unassignPolicyMock.mockResolvedValue({ id: AID, level: 'partner', targetId: PARTNER_ID });
 
     const appPartnerAll = new Hono();
@@ -368,5 +378,59 @@ describe('configurationPolicies assignment routes', () => {
 
     expect(res.status).toBe(200);
     expect(unassignPolicyMock).toHaveBeenCalledWith(AID, POLICY_ID);
+  });
+
+  // ============================================================
+  // Security: partner-owned policy assignment gate, any level (#2280)
+  // ============================================================
+
+  it('rejects an org-level assignment on a partner-owned policy without partner-wide access (403)', async () => {
+    getConfigPolicyMock.mockResolvedValue({
+      id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Library Policy',
+    });
+    canManagePartnerWideMock.mockReturnValue(false);
+    validateAssignmentTargetMock.mockResolvedValue({ valid: true });
+
+    const appPartnerSelected = new Hono();
+    appPartnerSelected.use('*', async (c, next) => {
+      c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [ORG_ID], partnerOrgAccess: 'selected' }));
+      c.set('permissions', makePermissions({ scope: 'partner', partnerId: PARTNER_ID, orgId: null, orgAccess: 'selected', allowedOrgIds: [ORG_ID] }));
+      await next();
+    });
+    appPartnerSelected.route('/', assignmentRoutes);
+
+    const res = await appPartnerSelected.request(`/${POLICY_ID}/assignments`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ level: 'organization', targetId: ORG_ID, priority: 0 }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(assignPolicyMock).not.toHaveBeenCalled();
+  });
+
+  it('allows an org-level assignment on a partner-owned policy with partner-wide access (201)', async () => {
+    getConfigPolicyMock.mockResolvedValue({
+      id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Library Policy',
+    });
+    canManagePartnerWideMock.mockReturnValue(true);
+    validateAssignmentTargetMock.mockResolvedValue({ valid: true });
+    assignPolicyMock.mockResolvedValue({ id: 'assign-1', level: 'organization', targetId: ORG_ID });
+
+    const appPartnerAll = new Hono();
+    appPartnerAll.use('*', async (c, next) => {
+      c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, partnerOrgAccess: 'all' }));
+      c.set('permissions', makePermissions({ scope: 'partner', partnerId: PARTNER_ID, orgId: null, orgAccess: 'all' }));
+      await next();
+    });
+    appPartnerAll.route('/', assignmentRoutes);
+
+    const res = await appPartnerAll.request(`/${POLICY_ID}/assignments`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ level: 'organization', targetId: ORG_ID, priority: 0 }),
+    });
+
+    expect(res.status).toBe(201);
   });
 });

--- a/apps/api/src/routes/configurationPolicies/assignments.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.ts
@@ -95,7 +95,7 @@ assignmentRoutes.post(
       targetId
     );
     if (!targetValidation.valid) {
-      return c.json({ error: targetValidation.error ?? 'Assignment target is not valid for this policy organization' }, 403);
+      return c.json({ error: targetValidation.error }, 403);
     }
 
     // assignPolicy returns null (instead of throwing) on a duplicate — see the

--- a/apps/api/src/routes/configurationPolicies/assignments.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.ts
@@ -59,6 +59,15 @@ assignmentRoutes.post(
     const policy = await getConfigPolicy(id, auth);
     if (!policy) return c.json({ error: 'Configuration policy not found' }, 404);
 
+    // Partner-owned policies (org_id NULL) are the partner library (#2280).
+    // ANY assignment on one — at any level — pushes config into orgs the caller
+    // may not fully control, so all writes require full partner org access, the
+    // same capability that gates partner-wide create/update/delete. This
+    // supersedes the per-level check that used to live only in the partner block.
+    if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
     // Partner-level assignments are only valid for partner-OWNED policies, and
     // the target is the partner itself, derived server-side (#1724) — never
     // trust a client-supplied partner id. It's the policy's own partner_id (or
@@ -74,16 +83,6 @@ assignmentRoutes.post(
         targetId = auth.partnerId;
       } else {
         return c.json({ error: 'Partner-wide assignments require partner scope' }, 403);
-      }
-      // Guard: partner-level assignments push config to ALL orgs under the partner.
-      // A user with orgAccess='selected' or 'none' only has visibility into a subset
-      // of orgs — permitting a partner-level assignment would silently propagate
-      // config (remote_access, PAM, monitoring, patch) to orgs they cannot access.
-      // Only orgAccess='all' partner users (and system scope) may assign at
-      // partner level — the same capability that gates partner-wide policy
-      // create/update/delete and feature-link writes.
-      if (!canManagePartnerWidePolicies(auth)) {
-        return c.json({ error: 'Partner-level assignments require full partner org access (orgAccess must be "all")' }, 403);
       }
     }
     if (!targetId) {

--- a/apps/api/src/routes/configurationPolicies/assignments.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.ts
@@ -145,9 +145,10 @@ assignmentRoutes.delete(
     const policy = await getConfigPolicy(id, auth);
     if (!policy) return c.json({ error: 'Configuration policy not found' }, 404);
 
-    // Unassigning a partner-wide policy strips config from ALL orgs under the
-    // partner (its only assignment is the partner-level one) — the same blast
-    // radius as assigning, so the same capability gate applies.
+    // Any assignment on a partner-owned library policy (#2280) — partner-level
+    // (all orgs) or a narrower org/site/group/device row — is a partner-wide-
+    // access capability: the delete may strip config from one org or every org
+    // under the partner. Same blast radius as assigning, so the same gate applies.
     if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
       return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }

--- a/apps/api/src/routes/configurationPolicies/crud.test.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.test.ts
@@ -269,7 +269,7 @@ describe('configurationPolicies CRUD routes', () => {
       expect(res.status).toBe(400);
     });
 
-    it('creates a partner-wide policy with server-derived partner for partner scope (#1724)', async () => {
+    it('creates a partner-owned policy WITHOUT auto-assigning it to all orgs (#2280 library model)', async () => {
       const policy = { id: POLICY_ID, name: 'Partner-wide', orgId: null, partnerId: PARTNER_ID, status: 'active' };
       createConfigPolicyMock.mockResolvedValue(policy);
 
@@ -295,9 +295,10 @@ describe('configurationPolicies CRUD routes', () => {
         expect.objectContaining({ name: 'Partner-wide' }),
         'user-1'
       );
-      // The matching partner-level assignment is seeded automatically so the
-      // policy actually applies to all orgs immediately (no orphaned ownership).
-      expect(assignPolicyMock).toHaveBeenCalledWith(POLICY_ID, 'partner', PARTNER_ID, 0, 'user-1');
+      // Library policies start empty — no partner-level (or any) assignment is
+      // seeded. The policy is applied later via explicit assignments on the
+      // Organizations panel (#2280 library model).
+      expect(assignPolicyMock).not.toHaveBeenCalled();
     });
 
     it('does not auto-assign for an org-owned policy (assignment stays manual)', async () => {
@@ -418,25 +419,6 @@ describe('configurationPolicies CRUD routes', () => {
       appPartner.route('/', crudRoutes);
       return appPartner;
     }
-
-    it('surfaces a 500 when the auto-assign fails, WITHOUT a compensating delete (request transaction rolls back)', async () => {
-      const policy = { id: POLICY_ID, name: 'Partner-wide', orgId: null, partnerId: PARTNER_ID, status: 'active' };
-      createConfigPolicyMock.mockResolvedValue(policy);
-      assignPolicyMock.mockRejectedValue(new Error('RLS 0-row write'));
-
-      const res = await partnerCreateApp().request('/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: 'Partner-wide', ownerScope: 'partner' }),
-      });
-
-      // Both inserts share the request-level withDbAccessContext transaction, so
-      // the failed seed rolls the policy insert back automatically — the handler
-      // must NOT issue an explicit compensating delete (which would double-handle
-      // rollback and, on a UNIQUE violation, run against an already-aborted txn).
-      expect(res.status).toBe(500);
-      expect(deleteConfigPolicyMock).not.toHaveBeenCalled();
-    });
 
     it('rejects ownerScope:partner for an org-scope caller (no partner) (#1724)', async () => {
       const appOrg = new Hono();

--- a/apps/api/src/routes/configurationPolicies/crud.test.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.test.ts
@@ -409,17 +409,6 @@ describe('configurationPolicies CRUD routes', () => {
       expect(createConfigPolicyMock).toHaveBeenCalledWith({ orgId: ORG_ID }, expect.objectContaining({ name: 'Policy' }), 'user-1');
     });
 
-    function partnerCreateApp() {
-      const appPartner = new Hono();
-      appPartner.use('*', async (c, next) => {
-        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, partnerOrgAccess: 'all' }));
-        c.set('permissions', makePermissions({ scope: 'partner', partnerId: PARTNER_ID, orgId: null, orgAccess: 'all' }));
-        await next();
-      });
-      appPartner.route('/', crudRoutes);
-      return appPartner;
-    }
-
     it('rejects ownerScope:partner for an org-scope caller (no partner) (#1724)', async () => {
       const appOrg = new Hono();
       appOrg.use('*', async (c, next) => {

--- a/apps/api/src/routes/configurationPolicies/crud.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.ts
@@ -132,10 +132,11 @@ crudRoutes.post(
       if (!org) return c.json({ error: 'Organization not found' }, 404);
     }
 
-    // Org-owned policies are intentionally NOT auto-assigned (unlike partner-wide
-    // above): an org policy is commonly meant for a specific site/group/device,
-    // so auto-assigning it at the org level would silently over-apply to every
-    // device in the org. The user picks the assignment target explicitly.
+    // Org-owned policies are intentionally NOT auto-assigned: an org policy is
+    // commonly meant for a specific site/group/device, so auto-assigning it at
+    // the org level would silently over-apply to every device in the org.
+    // Library policies (#2280) — org-owned or partner-owned — are always
+    // created empty; the user assigns them to a target explicitly afterward.
     const policy = await createConfigPolicy({ orgId: orgId as string }, data, auth.user.id);
 
     writeRouteAudit(c, {

--- a/apps/api/src/routes/configurationPolicies/crud.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.ts
@@ -13,7 +13,6 @@ import {
   listConfigPolicies,
   updateConfigPolicy,
   deleteConfigPolicy,
-  assignPolicy,
   canManagePartnerWidePolicies,
   PartnerWideWriteDeniedError,
 } from '../../services/configurationPolicy';
@@ -80,26 +79,15 @@ crudRoutes.post(
         return c.json({ error: 'Partner-wide policies require full partner org access (orgAccess must be "all")' }, 403);
       }
       const policy = await createConfigPolicy({ partnerId: auth.partnerId }, data, auth.user.id);
-      // Seed the matching partner-level assignment so the policy actually
-      // applies the moment it's created. Ownership ("Scope: All organizations")
-      // and the assignment that drives resolution are kept in lockstep —
-      // otherwise a partner-wide policy resolves to NO devices until the user
-      // separately discovers the Assignments tab (#1724 follow-up).
-      //
-      // Both writes run inside the request-level transaction: authMiddleware
-      // wraps the handler in withDbAccessContext, which is a single
-      // baseDb.transaction. If this seed throws, the policy insert above rolls
-      // back with it — a committed-but-unassigned partner-wide policy (the exact
-      // "resolves to no devices" state this feature prevents) can't be left
-      // behind, and no compensating delete is needed.
-      await assignPolicy(policy.id, 'partner', auth.partnerId, 0, auth.user.id);
       writeRouteAudit(c, {
         orgId: null,
         action: 'config_policy.create',
         resourceType: 'configuration_policy',
         resourceId: policy.id,
         resourceName: policy.name,
-        details: { ownerScope: 'partner', partnerId: auth.partnerId, autoAssignedPartnerWide: true },
+        // Library model (#2280): partner-owned policies are created empty and
+        // applied via explicit assignments on the Organizations panel.
+        details: { ownerScope: 'partner', partnerId: auth.partnerId },
       });
       return c.json(policy, 201);
     }

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -1049,6 +1049,11 @@ describe('org routes', () => {
       expect(countWhereArg).toBeDefined();
       expect(JSON.stringify(countWhereArg)).toContain('org-1');
       expect(JSON.stringify(countWhereArg)).toContain('org-2');
+
+      // The search term itself must also be ANDed into the WHERE — the
+      // assertions above only prove scope survives, not that the ilike
+      // condition was actually applied.
+      expect(JSON.stringify(countWhereArg)).toContain('contoso');
     });
 
     it('returns 200 without error when a search param is supplied for an org-scope caller (moot but must not error)', async () => {

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -1014,6 +1014,72 @@ describe('org routes', () => {
       expect(body.pagination.total).toBe(1);
     });
 
+    // A partner with >50 orgs can't reach org #51+ via page/limit alone (#2280
+    // review finding) — the panel needs server-side search to narrow within its
+    // own tenant scope, not a client-side filter over one fetched page.
+    it('narrows results by search within the caller scope, without loosening tenant scoping', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123', accessibleOrgIds: ['org-1', 'org-2'] });
+      const whereSpy = vi.fn().mockResolvedValue([{ count: 1 }]);
+      const orderBySpy = vi.fn().mockResolvedValue([{ id: 'org-1', name: 'Contoso Ltd' }]);
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({ where: whereSpy })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({ orderBy: orderBySpy })
+              })
+            })
+          })
+        } as any);
+
+      const res = await app.request('/orgs/organizations?search=contoso');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+      expect(body.pagination.total).toBe(1);
+
+      // The WHERE condition passed to both the count and data queries must still
+      // include the tenant scoping (inArray over accessibleOrgIds) alongside the
+      // search filter — search must never be able to widen scope.
+      const countWhereArg = whereSpy.mock.calls[0]?.[0];
+      expect(countWhereArg).toBeDefined();
+      expect(JSON.stringify(countWhereArg)).toContain('org-1');
+      expect(JSON.stringify(countWhereArg)).toContain('org-2');
+    });
+
+    it('returns 200 without error when a search param is supplied for an org-scope caller (moot but must not error)', async () => {
+      setAuthContext({ scope: 'organization', orgId: 'org-123' });
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 1 }])
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  orderBy: vi.fn().mockResolvedValue([
+                    { id: 'org-123', name: 'Acme Corp', slug: 'acme', status: 'active' }
+                  ])
+                })
+              })
+            })
+          })
+        } as any);
+
+      const res = await app.request('/orgs/organizations?search=anything');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+    });
+
     // #1245 residual: org-scope users (Org Admin/Technician/Viewer) lack the
     // organizations:read permission, but the tickets UI needs this route on
     // cold load just to render their own org's name. The route skips the

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -3,7 +3,7 @@ import { HTTPException } from 'hono/http-exception';
 import type { Context, Next } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, eq, inArray, isNull, ne, or, sql } from 'drizzle-orm';
+import { and, eq, ilike, inArray, isNull, ne, or, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { partners, organizations, sites, devices, agentVersions } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, requirePartner, type AuthContext } from '../middleware/auth';
@@ -914,8 +914,14 @@ orgRoutes.delete('/partners/:id', requireScope('system'), requireOrgWrite, requi
 const listOrganizationsSchema = z.object({
   partnerId: z.string().guid().optional(),
   page: z.string().optional(),
-  limit: z.string().optional()
+  limit: z.string().optional(),
+  search: z.string().optional()
 });
+
+// Escape ILIKE wildcards so a search term is matched literally, not as a pattern.
+function escapeIlike(value: string): string {
+  return value.replace(/[%_\\]/g, '\\$&');
+}
 
 // Org-scope callers may read their OWN org's name-level row without the
 // organizations:read permission (UI shell / tickets cold load, #1245 residual)
@@ -932,8 +938,12 @@ const requireOrgReadUnlessOwnOrg = async (c: Context, next: Next) => {
 
 orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'), requireOrgReadUnlessOwnOrg, zValidator('query', listOrganizationsSchema), async (c) => {
   const auth = c.get('auth') as AuthContext;
-  const { partnerId: queryPartnerId, ...pagination } = c.req.valid('query');
+  const { partnerId: queryPartnerId, search, ...pagination } = c.req.valid('query');
   const { page, limit, offset } = getPagination(pagination);
+  const trimmedSearch = search?.trim();
+  const searchCondition = trimmedSearch
+    ? ilike(organizations.name, `%${escapeIlike(trimmedSearch)}%`)
+    : undefined;
 
   if (auth.scope === 'organization') {
     // Organization-scoped users can only see their own organization, and —
@@ -976,11 +986,11 @@ orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'
         pagination: { page, limit, total: 0 }
       });
     }
-    conditions = and(inArray(organizations.id, orgIds), isNull(organizations.deletedAt));
+    conditions = and(inArray(organizations.id, orgIds), isNull(organizations.deletedAt), searchCondition);
   } else {
     conditions = queryPartnerId
-      ? and(eq(organizations.partnerId, queryPartnerId), isNull(organizations.deletedAt))
-      : isNull(organizations.deletedAt);
+      ? and(eq(organizations.partnerId, queryPartnerId), isNull(organizations.deletedAt), searchCondition)
+      : and(isNull(organizations.deletedAt), searchCondition);
   }
 
   const countResult = await db

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -20,6 +20,7 @@ import {
 import { applyOrganizationOrder, sanitizeOrganizationOrder } from '../services/orgOrdering';
 import { captureException } from '../services/sentry';
 import { encryptColumnValueForWrite } from '../services/encryptedColumnRegistry';
+import { escapeLike } from '../utils/sql';
 import { isAllowedLauncherScheme, isValidIanaTimezone, canonicalizeTimezone, isValidMaintenanceWindow, MAINTENANCE_WINDOW_ERROR_MESSAGE, normalizeVersionPin, PINNABLE_COMPONENTS, agentVersionPinsSchema } from '@breeze/shared';
 import type { IpAllowlistStatus } from '@breeze/shared';
 import { isValidIpOrCidr } from '../services/ipMatch';
@@ -918,11 +919,6 @@ const listOrganizationsSchema = z.object({
   search: z.string().optional()
 });
 
-// Escape ILIKE wildcards so a search term is matched literally, not as a pattern.
-function escapeIlike(value: string): string {
-  return value.replace(/[%_\\]/g, '\\$&');
-}
-
 // Org-scope callers may read their OWN org's name-level row without the
 // organizations:read permission (UI shell / tickets cold load, #1245 residual)
 // — every org user implicitly needs their org's name to render the app shell.
@@ -942,7 +938,7 @@ orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'
   const { page, limit, offset } = getPagination(pagination);
   const trimmedSearch = search?.trim();
   const searchCondition = trimmedSearch
-    ? ilike(organizations.name, `%${escapeIlike(trimmedSearch)}%`)
+    ? ilike(organizations.name, `%${escapeLike(trimmedSearch)}%`)
     : undefined;
 
   if (auth.scope === 'organization') {

--- a/apps/api/src/services/aiToolsConfigPolicy.test.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.test.ts
@@ -397,6 +397,52 @@ describe('configuration policy AI tools', () => {
     );
   });
 
+  it('apply_configuration_policy denies an ORGANIZATION-level assignment on a partner-owned policy without partner-wide capability (#2280)', async () => {
+    // The library-model gate applies to ANY assignment level on a partner-owned
+    // policy (org_id NULL), not just the 'partner' level — mirrors the HTTP
+    // route's gate in routes/configurationPolicies/assignments.ts.
+    mockSelectRows([{ id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Library Policy' }]);
+    canManagePartnerWidePoliciesMock.mockReturnValue(false);
+
+    const tools = new Map<string, any>();
+    registerConfigPolicyTools(tools);
+
+    const output = await tools.get('apply_configuration_policy')!.handler({
+      configPolicyId: POLICY_ID,
+      level: 'organization',
+      targetId: ORG_ID,
+    }, makePartnerAuth());
+
+    expect(JSON.parse(output)).toEqual({ error: 'partner-wide write denied' });
+    expect(assignPolicyMock).not.toHaveBeenCalled();
+  });
+
+  it('apply_configuration_policy allows an ORGANIZATION-level (subset) assignment on a partner-owned policy with partner-wide capability (#2280)', async () => {
+    mockSelectRows([{ id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Library Policy' }]);
+    canManagePartnerWidePoliciesMock.mockReturnValue(true);
+    validateAssignmentTargetMock.mockResolvedValue({ valid: true });
+    assignPolicyMock.mockResolvedValue({ id: 'assignment-1', level: 'organization', targetId: ORG_ID });
+
+    const tools = new Map<string, any>();
+    registerConfigPolicyTools(tools);
+
+    const output = await tools.get('apply_configuration_policy')!.handler({
+      configPolicyId: POLICY_ID,
+      level: 'organization',
+      targetId: ORG_ID,
+    }, makePartnerAuth());
+
+    expect(JSON.parse(output).success).toBe(true);
+    expect(validateAssignmentTargetMock).toHaveBeenCalledWith(
+      { orgId: null, partnerId: PARTNER_ID },
+      'organization',
+      ORG_ID
+    );
+    expect(assignPolicyMock).toHaveBeenCalledWith(
+      POLICY_ID, 'organization', ORG_ID, 0, 'user-1', undefined, undefined
+    );
+  });
+
   it('remove_configuration_policy_assignment denies removing a partner-wide assignment without capability', async () => {
     mockSelectRows([{
       id: 'assignment-1',
@@ -419,10 +465,9 @@ describe('configuration policy AI tools', () => {
     expect(unassignPolicyMock).not.toHaveBeenCalled();
   });
 
-  it('manage_configuration_policy create ownerScope=partner makes a partner-owned policy and seeds the partner assignment', async () => {
+  it('manage_configuration_policy create ownerScope=partner makes a partner-owned policy WITHOUT auto-assigning it (#2280 library model)', async () => {
     mockSelectRows([]); // duplicate-name check → none
     createConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'All-Orgs Baseline' });
-    assignPolicyMock.mockResolvedValue({ id: 'assignment-1' });
 
     const tools = new Map<string, any>();
     registerConfigPolicyTools(tools);
@@ -440,7 +485,10 @@ describe('configuration policy AI tools', () => {
       { name: 'All-Orgs Baseline', description: 'baseline for every org', status: 'active' },
       'user-1'
     );
-    expect(assignPolicyMock).toHaveBeenCalledWith(POLICY_ID, 'partner', PARTNER_ID, 0, 'user-1');
+    // Library policies start empty — no partner-level (or any) assignment is
+    // seeded. The policy is applied later via explicit apply_configuration_policy
+    // calls (#2280 library model), mirroring the HTTP create route.
+    expect(assignPolicyMock).not.toHaveBeenCalled();
   });
 
   it('manage_configuration_policy create ownerScope=partner is denied without partner-wide capability', async () => {

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -213,22 +213,27 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
       const [policy] = await db.select().from(configurationPolicies).where(and(...conditions)).limit(1);
       if (!policy) return JSON.stringify({ error: 'Configuration policy not found or access denied' });
 
+      // Partner-owned policies (org_id NULL) are the partner library (#2280).
+      // ANY assignment on one — at any level, not just 'partner' — pushes
+      // config into orgs the caller may not fully control, so all writes
+      // require full partner org access. Mirrors the HTTP route's gate
+      // (routes/configurationPolicies/assignments.ts).
+      if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+        return JSON.stringify({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+      }
+
       // At the partner level the target is the partner itself, derived
       // server-side — never from a client-supplied value (#1724). It's the
       // policy's own partner (or the caller's, for a fresh partner-owned
       // policy). An org-owned policy also reaches this block, but its
       // auth.partnerId fallback target is rejected downstream by
       // validateAssignmentTarget, so the fallback only ever serves partner-owned
-      // policies. Partner-level assignments push config to ALL orgs under the
-      // partner, so they carry the same capability gate as the HTTP route.
+      // policies.
       let targetId = input.targetId as string;
       if (input.level === 'partner') {
         const derived = policy.partnerId ?? auth.partnerId;
         if (!derived) {
           return JSON.stringify({ error: 'Partner-wide assignments require partner scope' });
-        }
-        if (!canManagePartnerWidePolicies(auth)) {
-          return JSON.stringify({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
         }
         targetId = derived;
       }
@@ -417,12 +422,12 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
             status: (input.status as 'active' | 'inactive' | 'archived') ?? 'active',
           }, auth.user.id);
 
-          // Seed the partner-level assignment so the policy applies immediately —
-          // ownership and the assignment that drives resolution stay in lockstep,
-          // mirroring the HTTP create route (otherwise it resolves to no devices
-          // until it is separately assigned via apply_configuration_policy).
-          await assignPolicy(policy.id, 'partner', auth.partnerId, 0, auth.user.id);
-
+          // Library model (#2280): partner-owned policies are created EMPTY —
+          // no auto-seeded assignment. It's applied to orgs later via explicit
+          // apply_configuration_policy calls (partner-wide, or a subset of
+          // orgs). Mirrors the HTTP create route
+          // (routes/configurationPolicies/crud.ts), which stopped auto-seeding
+          // the partner-level assignment for the same reason.
           return JSON.stringify({ success: true, policy });
         }
 

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -189,7 +189,7 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
     tier: 2,
     definition: {
       name: 'apply_configuration_policy',
-      description: 'Assign a configuration policy to a target (partner, organization, site, device group, or device). Use roleFilter and osFilter to scope the assignment to specific device types. The "partner" level is reserved for partner-OWNED ("all organizations") policies — an org-owned policy can only be assigned at organization/site/device_group/device level.',
+      description: 'Assign a configuration policy to a target (partner, organization, site, device group, or device). Use roleFilter and osFilter to scope the assignment to specific device types. The "partner" level is reserved for partner-OWNED policies (a reusable library, #2280, assignable to all orgs or a subset) — an org-owned policy can only be assigned at organization/site/device_group/device level.',
       input_schema: {
         type: 'object' as const,
         properties: {
@@ -247,7 +247,7 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
         targetId
       );
       if (!targetValidation.valid) {
-        return JSON.stringify({ error: targetValidation.error ?? 'Assignment target is not valid for this policy organization' });
+        return JSON.stringify({ error: targetValidation.error });
       }
 
       // assignPolicy returns null (instead of throwing) on a duplicate — see
@@ -315,8 +315,10 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
 
       if (!assignment) return JSON.stringify({ error: 'Assignment not found' });
 
-      // Unassigning a partner-wide policy strips config from ALL orgs under the
-      // partner — same blast radius and capability gate as assigning it.
+      // Any assignment on a partner-owned library policy (#2280) — partner-level
+      // (all orgs) or a narrower org/site/group/device row — is a partner-wide-
+      // access capability: the delete may strip config from one org or every org
+      // under the partner. Same blast radius as assigning, so the same gate applies.
       if (assignment.policyOrgId === null && !canManagePartnerWidePolicies(auth)) {
         return JSON.stringify({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
       }
@@ -367,7 +369,7 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
     tier: 1,
     definition: {
       name: 'manage_configuration_policy',
-      description: 'Create, update, activate, deactivate, or delete configuration policies. Configuration policies bundle feature settings (patch, alert, compliance, etc.) and are assigned to targets in the hierarchy. On create, ownerScope "partner" makes a partner-wide ("all organizations") policy that applies to every org under the partner (requires full partner org access); "organization" (default) owns it in a single org.',
+      description: 'Create, update, activate, deactivate, or delete configuration policies. Configuration policies bundle feature settings (patch, alert, compliance, etc.) and are assigned to targets in the hierarchy. On create, ownerScope "partner" makes a reusable partner-owned library policy that applies to NO organizations until assigned (partner-wide, or a subset of orgs) via apply_configuration_policy (requires full partner org access); "organization" (default) owns it in a single org.',
       input_schema: {
         type: 'object' as const,
         properties: {
@@ -376,7 +378,7 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
           name: { type: 'string', description: 'Policy name (required for create)' },
           description: { type: 'string', description: 'Policy description' },
           status: { type: 'string', enum: ['active', 'inactive', 'archived'], description: 'Policy status (for create/update)' },
-          ownerScope: { type: 'string', enum: ['organization', 'partner'], description: 'Ownership for create: "organization" (default, owned by one org) or "partner" (partner-wide "all orgs" template applying to every org under the partner; requires full partner org access)' },
+          ownerScope: { type: 'string', enum: ['organization', 'partner'], description: 'Ownership for create: "organization" (default, owned by one org) or "partner" (a reusable partner-owned library policy, created empty and applied to orgs later via apply_configuration_policy; requires full partner org access)' },
           orgId: { type: 'string', description: 'Organization UUID (for org-scoped create; defaults to current org). Ignored when ownerScope is "partner".' },
         },
         required: ['action'],

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -1171,17 +1171,69 @@ export async function validateAssignmentTarget(
 ): Promise<{ valid: boolean; error?: string }> {
   const policyOrgId = policyOwner.orgId;
 
-  // Partner-owned policies (#1724) span all of the partner's orgs and may only
-  // carry a partner-level assignment targeting their own partner. Org/site/
-  // group/device assignments are nonsensical for a policy with no owning org.
+  // Partner-owned policies (#1724, #2280) are reusable libraries: a partner-level
+  // assignment applies them to ALL orgs, and org/site/group/device assignments
+  // apply them to a chosen subset. Every non-partner target must resolve to an org
+  // owned by THIS partner (organizations.partner_id) — cross-partner targets are
+  // rejected here (defense-in-depth; RLS is the real backstop).
   if (policyOwner.partnerId) {
-    if (level !== 'partner') {
-      return { valid: false, error: 'Partner-wide policies can only be assigned at the Partner level' };
+    const partnerId = policyOwner.partnerId;
+    switch (level) {
+      case 'partner':
+        return targetId === partnerId
+          ? { valid: true }
+          : { valid: false, error: 'A partner-wide policy can only target its own partner' };
+
+      case 'organization': {
+        const [org] = await db
+          .select({ id: organizations.id })
+          .from(organizations)
+          .where(and(eq(organizations.id, targetId), eq(organizations.partnerId, partnerId)))
+          .limit(1);
+        return org
+          ? { valid: true }
+          : { valid: false, error: 'Target organization is not in this partner' };
+      }
+
+      case 'site': {
+        const [site] = await db
+          .select({ id: sites.id })
+          .from(sites)
+          .innerJoin(organizations, eq(sites.orgId, organizations.id))
+          .where(and(eq(sites.id, targetId), eq(organizations.partnerId, partnerId)))
+          .limit(1);
+        return site
+          ? { valid: true }
+          : { valid: false, error: 'Target site is not in this partner' };
+      }
+
+      case 'device_group': {
+        const [group] = await db
+          .select({ id: deviceGroups.id })
+          .from(deviceGroups)
+          .innerJoin(organizations, eq(deviceGroups.orgId, organizations.id))
+          .where(and(eq(deviceGroups.id, targetId), eq(organizations.partnerId, partnerId)))
+          .limit(1);
+        return group
+          ? { valid: true }
+          : { valid: false, error: 'Target device group is not in this partner' };
+      }
+
+      case 'device': {
+        const [device] = await db
+          .select({ id: devices.id })
+          .from(devices)
+          .innerJoin(organizations, eq(devices.orgId, organizations.id))
+          .where(and(eq(devices.id, targetId), eq(organizations.partnerId, partnerId)))
+          .limit(1);
+        return device
+          ? { valid: true }
+          : { valid: false, error: 'Target device is not in this partner' };
+      }
+
+      default:
+        return { valid: false, error: 'Unsupported assignment target level' };
     }
-    if (targetId !== policyOwner.partnerId) {
-      return { valid: false, error: 'A partner-wide policy can only target its own partner' };
-    }
-    return { valid: true };
   }
 
   // Org-owned policies: org_id is guaranteed non-null by the ownership CHECK.

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -89,6 +89,11 @@ export { CONFIG_FEATURE_TYPES };
 export type { ConfigFeatureType };
 export type ConfigAssignmentLevel = 'partner' | 'organization' | 'site' | 'device_group' | 'device';
 
+// Discriminated union so a valid result can't carry a stray error string and
+// an invalid result can't omit one — every `return` in validateAssignmentTarget
+// below conforms.
+export type AssignmentTargetValidation = { valid: true } | { valid: false; error: string };
+
 const LEVEL_PRIORITY: Record<ConfigAssignmentLevel, number> = {
   device: 5,
   device_group: 4,
@@ -1168,7 +1173,7 @@ export async function validateAssignmentTarget(
   policyOwner: { orgId: string | null; partnerId: string | null },
   level: ConfigAssignmentLevel,
   targetId: string
-): Promise<{ valid: boolean; error?: string }> {
+): Promise<AssignmentTargetValidation> {
   const policyOrgId = policyOwner.orgId;
 
   // Partner-owned policies (#1724, #2280) are reusable libraries: a partner-level
@@ -1295,7 +1300,7 @@ export async function validateAssignmentTarget(
       // *looks* partner-wide but resolution still clamps it to its single
       // owning org (org_id = device.orgId), so it silently reaches only that
       // one org. True cross-org propagation requires a partner-OWNED policy
-      // (created via the "All organizations" scope). Reject it outright rather
+      // (created via the "Partner library" scope). Reject it outright rather
       // than let it masquerade as fleet-wide (#1724 follow-up).
       return {
         valid: false,

--- a/apps/api/src/services/configurationPolicy.validateAssignment.test.ts
+++ b/apps/api/src/services/configurationPolicy.validateAssignment.test.ts
@@ -39,7 +39,7 @@ describe('validateAssignmentTarget — ownership gating', () => {
       PARTNER_ID
     );
     expect(result.valid).toBe(false);
-    expect(result.error).toMatch(/Only partner-wide policies can be assigned at the Partner level/i);
+    if (!result.valid) expect(result.error).toMatch(/Only partner-wide policies can be assigned at the Partner level/i);
     // Pure early return — no DB lookup for this illegal combination.
     expect(selectMock).not.toHaveBeenCalled();
   });
@@ -63,7 +63,7 @@ describe('validateAssignmentTarget — ownership gating', () => {
       'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
     );
     expect(result.valid).toBe(false);
-    expect(result.error).toMatch(/not in this partner/i);
+    if (!result.valid) expect(result.error).toMatch(/not in this partner/i);
   });
 
   it('accepts a partner-owned policy assigned to an in-partner device', async () => {
@@ -93,6 +93,6 @@ describe('validateAssignmentTarget — ownership gating', () => {
       'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
     );
     expect(result.valid).toBe(false);
-    expect(result.error).toMatch(/can only target its own partner/i);
+    if (!result.valid) expect(result.error).toMatch(/can only target its own partner/i);
   });
 });

--- a/apps/api/src/services/configurationPolicy.validateAssignment.test.ts
+++ b/apps/api/src/services/configurationPolicy.validateAssignment.test.ts
@@ -11,6 +11,19 @@ vi.mock('../db', () => ({
 
 import { validateAssignmentTarget } from './configurationPolicy';
 
+// Build a drizzle-style select chain that resolves to `rows`. Covers both the
+// no-join org lookup and the innerJoin site/group/device lookups — every branch
+// ends in `.limit(1)` returning an array.
+function mockSelectResolving(rows: unknown[]) {
+  const chain: any = {
+    from: () => chain,
+    innerJoin: () => chain,
+    where: () => chain,
+    limit: () => Promise.resolve(rows),
+  };
+  selectMock.mockReturnValue(chain);
+}
+
 const ORG_ID = '11111111-1111-1111-1111-111111111111';
 const PARTNER_ID = '22222222-2222-2222-2222-222222222222';
 
@@ -31,15 +44,36 @@ describe('validateAssignmentTarget — ownership gating', () => {
     expect(selectMock).not.toHaveBeenCalled();
   });
 
-  it('rejects a partner-owned policy assigned below the Partner level', async () => {
+  it('accepts a partner-owned policy assigned to an in-partner organization', async () => {
+    mockSelectResolving([{ id: ORG_ID }]);
     const result = await validateAssignmentTarget(
       { orgId: null, partnerId: PARTNER_ID },
       'organization',
       ORG_ID
     );
+    expect(result.valid).toBe(true);
+    expect(selectMock).toHaveBeenCalled();
+  });
+
+  it('rejects a partner-owned policy assigned to an out-of-partner organization', async () => {
+    mockSelectResolving([]); // org exists but not under this partner → no row
+    const result = await validateAssignmentTarget(
+      { orgId: null, partnerId: PARTNER_ID },
+      'organization',
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    );
     expect(result.valid).toBe(false);
-    expect(result.error).toMatch(/can only be assigned at the Partner level/i);
-    expect(selectMock).not.toHaveBeenCalled();
+    expect(result.error).toMatch(/not in this partner/i);
+  });
+
+  it('accepts a partner-owned policy assigned to an in-partner device', async () => {
+    mockSelectResolving([{ id: '33333333-3333-3333-3333-333333333333' }]);
+    const result = await validateAssignmentTarget(
+      { orgId: null, partnerId: PARTNER_ID },
+      'device',
+      '33333333-3333-3333-3333-333333333333'
+    );
+    expect(result.valid).toBe(true);
   });
 
   it('accepts a partner-owned policy targeting its own partner', async () => {

--- a/apps/api/src/services/configurationPolicy.validateAssignment.test.ts
+++ b/apps/api/src/services/configurationPolicy.validateAssignment.test.ts
@@ -76,6 +76,59 @@ describe('validateAssignmentTarget — ownership gating', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('rejects a partner-owned policy assigned to an out-of-partner device', async () => {
+    mockSelectResolving([]); // device exists but its org isn't under this partner → no row
+    const result = await validateAssignmentTarget(
+      { orgId: null, partnerId: PARTNER_ID },
+      'device',
+      '33333333-3333-3333-3333-333333333333'
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toMatch(/not in this partner/i);
+  });
+
+  it('accepts a partner-owned policy assigned to an in-partner site', async () => {
+    mockSelectResolving([{ id: '44444444-4444-4444-4444-444444444444' }]);
+    const result = await validateAssignmentTarget(
+      { orgId: null, partnerId: PARTNER_ID },
+      'site',
+      '44444444-4444-4444-4444-444444444444'
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a partner-owned policy assigned to an out-of-partner site', async () => {
+    mockSelectResolving([]); // site exists but its org isn't under this partner → no row
+    const result = await validateAssignmentTarget(
+      { orgId: null, partnerId: PARTNER_ID },
+      'site',
+      '44444444-4444-4444-4444-444444444444'
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toMatch(/not in this partner/i);
+  });
+
+  it('accepts a partner-owned policy assigned to an in-partner device group', async () => {
+    mockSelectResolving([{ id: '55555555-5555-5555-5555-555555555555' }]);
+    const result = await validateAssignmentTarget(
+      { orgId: null, partnerId: PARTNER_ID },
+      'device_group',
+      '55555555-5555-5555-5555-555555555555'
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a partner-owned policy assigned to an out-of-partner device group', async () => {
+    mockSelectResolving([]); // group exists but its org isn't under this partner → no row
+    const result = await validateAssignmentTarget(
+      { orgId: null, partnerId: PARTNER_ID },
+      'device_group',
+      '55555555-5555-5555-5555-555555555555'
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toMatch(/not in this partner/i);
+  });
+
   it('accepts a partner-owned policy targeting its own partner', async () => {
     const result = await validateAssignmentTarget(
       { orgId: null, partnerId: PARTNER_ID },

--- a/apps/web/src/components/configurationPolicies/AssignmentsTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/AssignmentsTab.test.tsx
@@ -4,13 +4,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const fetchWithAuth = vi.fn();
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args) }));
-// AssignmentsTab renders OrganizationScopePanel for partner-owned policies,
-// which pulls organizations from useOrgStore — mock it so the real store
-// module (and its registerOrgIdProvider side effect) never loads here.
-vi.mock('../../stores/orgStore', () => ({
-  useOrgStore: (sel: (s: { organizations: { id: string; name: string }[] }) => unknown) =>
-    sel({ organizations: [{ id: 'org-acme', name: 'Acme Corp' }, { id: 'org-contoso', name: 'Contoso Ltd' }] }),
-}));
 
 import AssignmentsTab from './AssignmentsTab';
 
@@ -56,6 +49,12 @@ describe('AssignmentsTab — partner-OWNED policy (all organizations library, #2
   });
 
   it('lists the partner organizations as a checklist', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(jsonResponse({ data: [] })) // assignments
+      .mockResolvedValueOnce(jsonResponse({
+        data: [{ id: 'org-acme', name: 'Acme Corp' }, { id: 'org-contoso', name: 'Contoso Ltd' }],
+        pagination: { page: 1, limit: 100, total: 2 },
+      })); // org list
     render(<AssignmentsTab policyId={POLICY_ID} orgId={null} partnerId={PARTNER_ID} />);
 
     expect(await screen.findByRole('checkbox', { name: 'Acme Corp' })).toBeInTheDocument();

--- a/apps/web/src/components/configurationPolicies/AssignmentsTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/AssignmentsTab.test.tsx
@@ -4,6 +4,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const fetchWithAuth = vi.fn();
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args) }));
+// AssignmentsTab renders OrganizationScopePanel for partner-owned policies,
+// which pulls organizations from useOrgStore — mock it so the real store
+// module (and its registerOrgIdProvider side effect) never loads here.
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (sel: (s: { organizations: { id: string; name: string }[] }) => unknown) =>
+    sel({ organizations: [{ id: 'org-acme', name: 'Acme Corp' }, { id: 'org-contoso', name: 'Contoso Ltd' }] }),
+}));
 
 import AssignmentsTab from './AssignmentsTab';
 
@@ -31,75 +38,39 @@ beforeEach(() => {
   fetchWithAuth.mockResolvedValue(jsonResponse({ data: [] }));
 });
 
-describe('AssignmentsTab — partner-OWNED policy (all organizations)', () => {
-  it('shows the partner-wide banner and no level/target picker', async () => {
+describe('AssignmentsTab — partner-OWNED policy (all organizations library, #2280)', () => {
+  it('delegates to OrganizationScopePanel — no level/target picker, no partner-wide banner', async () => {
     render(<AssignmentsTab policyId={POLICY_ID} orgId={null} partnerId={PARTNER_ID} />);
-    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
 
+    // OrganizationScopePanel's own heading + master toggle render instead of
+    // the old fixed "all organizations" copy and add-assignment card.
+    expect(await screen.findByRole('heading', { name: 'Organizations' })).toBeInTheDocument();
     expect(
-      screen.getByText('This policy applies to all organizations in your partner.')
+      screen.getByRole('checkbox', { name: /All organizations \(partner-wide\)/i })
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText('This policy applies to all organizations in your partner.')
+    ).not.toBeInTheDocument();
     // The org-owned "Level" picker must not exist for a partner-owned policy.
     expect(screen.queryByText('Level')).not.toBeInTheDocument();
   });
 
-  it('POSTs a partner assignment with no targetId (server-derived) when re-assigning', async () => {
+  it('lists the partner organizations as a checklist', async () => {
     render(<AssignmentsTab policyId={POLICY_ID} orgId={null} partnerId={PARTNER_ID} />);
-    // Wait for the empty-assignments add card to appear.
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: /Assign to all organizations/i })).toBeInTheDocument()
-    );
 
-    fetchWithAuth.mockResolvedValueOnce(jsonResponse({ id: 'a1', level: 'partner' }, 201));
-    fireEvent.click(screen.getByRole('button', { name: /Assign to all organizations/i }));
-
-    await waitFor(() => {
-      const post = findPost();
-      expect(post).toBeTruthy();
-      const body = JSON.parse(String((post![1] as RequestInit).body));
-      expect(body.level).toBe('partner');
-      expect(body).not.toHaveProperty('targetId');
-    });
-    // The system-scoped partner-list call must NEVER be made.
-    const urls = fetchWithAuth.mock.calls.map((c) => String(c[0]));
-    expect(urls.some((u) => u.includes('/orgs/partners'))).toBe(false);
+    expect(await screen.findByRole('checkbox', { name: 'Acme Corp' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Contoso Ltd' })).toBeInTheDocument();
   });
 
-  it('hides the re-assign card once a partner assignment exists', async () => {
+  it('checks the All-orgs toggle when a partner-level assignment already exists', async () => {
     fetchWithAuth.mockResolvedValue(
       jsonResponse({ data: [{ id: 'a1', level: 'partner', targetId: PARTNER_ID, priority: 0 }] })
     );
     render(<AssignmentsTab policyId={POLICY_ID} orgId={null} partnerId={PARTNER_ID} />);
 
-    await waitFor(() => expect(screen.getByText('All Organizations')).toBeInTheDocument());
-    expect(
-      screen.queryByRole('button', { name: /Assign to all organizations/i })
-    ).not.toBeInTheDocument();
-  });
-
-  it('includes priority and role/OS filters in the partner re-assign POST body', async () => {
-    render(<AssignmentsTab policyId={POLICY_ID} orgId={null} partnerId={PARTNER_ID} />);
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: /Assign to all organizations/i })).toBeInTheDocument()
+      expect(screen.getByRole('checkbox', { name: /All organizations \(partner-wide\)/i })).toBeChecked()
     );
-
-    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '5' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Workstation' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Windows' }));
-
-    fetchWithAuth.mockResolvedValueOnce(jsonResponse({ id: 'a1', level: 'partner' }, 201));
-    fireEvent.click(screen.getByRole('button', { name: /Assign to all organizations/i }));
-
-    await waitFor(() => {
-      const post = findPost();
-      expect(post).toBeTruthy();
-      const body = JSON.parse(String((post![1] as RequestInit).body));
-      expect(body.level).toBe('partner');
-      expect(body).not.toHaveProperty('targetId');
-      expect(body.priority).toBe(5);
-      expect(body.roleFilter).toEqual(['workstation']);
-      expect(body.osFilter).toEqual(['windows']);
-    });
   });
 });
 

--- a/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
+++ b/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
@@ -5,6 +5,7 @@ import { extractApiError } from '@/lib/apiError';
 import { fetchWithAuth } from '../../stores/auth';
 import { DEVICE_ROLES, getDeviceRoleLabel } from '@/lib/deviceRoles';
 import HelpTooltip from '../shared/HelpTooltip';
+import OrganizationScopePanel from './OrganizationScopePanel';
 
 type Assignment = {
   id: string;
@@ -469,57 +470,13 @@ export default function AssignmentsTab({ policyId, orgId, orgName, partnerId }: 
     </div>
   );
 
-  // Partner-OWNED policies ("all organizations"): no level/target picker — the
-  // policy is intrinsically partner-wide. We surface the auto-created partner
-  // assignment in the list below and only show the add card when none exists
-  // (e.g. it was deleted, or the policy predates auto-seeding). Only one partner
-  // row is ever reachable: the server pins the target to the policy's own
-  // partner, and UNIQUE(policy, level, target) then forbids a duplicate.
-  if (isPartnerOwned) {
-    return (
-      <div className="space-y-6">
-        {error && (
-          <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-            {error}
-          </div>
-        )}
-
-        <div className="rounded-md border border-primary/30 bg-primary/5 p-4 text-sm">
-          <p className="font-medium">This policy applies to all organizations in your partner.</p>
-          <p className="mt-1 text-muted-foreground">
-            Scope was set to <span className="font-medium">All organizations</span> when the policy was created,
-            so it&apos;s assigned partner-wide automatically — there&apos;s nothing to assign here. To limit it to
-            certain device roles or operating systems, remove the assignment below and re-add it with filters.
-          </p>
-        </div>
-
-        {assignments.length === 0 && !assignmentsLoading && (
-          <div className="rounded-lg border bg-card p-6 shadow-xs">
-            <h2 className="text-lg font-semibold">Assign to all organizations</h2>
-            <p className="mt-1 text-sm text-muted-foreground">
-              This policy isn&apos;t currently assigned. Re-assign it partner-wide below.
-            </p>
-            <div className="mt-4 grid gap-4 sm:grid-cols-3">
-              {priorityField}
-            </div>
-            <div className="mt-4">{filterFields}</div>
-            <div className="mt-4 flex justify-end">
-              <button
-                type="button"
-                onClick={handleAddAssignment}
-                disabled={addingAssignment}
-                className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
-              >
-                <Plus className="h-4 w-4" />
-                {addingAssignment ? 'Assigning...' : 'Assign to all organizations'}
-              </button>
-            </div>
-          </div>
-        )}
-
-        {renderAssignmentsList()}
-      </div>
-    );
+  // Partner-OWNED policies ("all organizations" library, #2280): scoping is a
+  // subset of the partner's organizations, not a fixed all-orgs assignment —
+  // delegate to the dedicated master-toggle + org-checklist panel. The
+  // advanced site/group/device flow below remains reachable only for
+  // org-owned policies.
+  if (isPartnerOwned && partnerId) {
+    return <OrganizationScopePanel policyId={policyId} partnerId={partnerId} />;
   }
 
   return (

--- a/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
+++ b/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
@@ -21,8 +21,9 @@ type TargetOption = { id: string; name: string; extra?: string };
 // Org-owned policies can only narrow within their owning org. The Partner-Wide
 // level is intentionally absent here — assigning an org-owned policy partner-wide
 // is a footgun (resolution still clamps it to the one owning org), so the API
-// rejects it and the picker must not offer it. Partner-OWNED policies use a
-// dedicated, separate flow below (no level picker — they're always all-orgs).
+// rejects it and the picker must not offer it. Partner-OWNED policies are a
+// reusable library (#2280) — assignment scope (all orgs or a subset) is handled
+// by the dedicated OrganizationScopePanel below, not this level picker.
 const orgOwnedAssignmentLevels = [
   { value: 'organization', label: 'Organization' },
   { value: 'site', label: 'Site' },
@@ -47,7 +48,8 @@ type Props = {
   // Owning org's name (org-owned policies only) — shown in the locked
   // organization-level target field.
   orgName?: string | null;
-  // Set when the policy is partner-OWNED (all-orgs). Drives the partner-wide UI.
+  // Set when the policy is partner-OWNED (a reusable library, #2280). Drives
+  // delegation to OrganizationScopePanel.
   partnerId?: string | null;
 };
 
@@ -56,8 +58,8 @@ export default function AssignmentsTab({ policyId, orgId, orgName, partnerId }: 
   const [assignments, setAssignments] = useState<Assignment[]>([]);
   const [assignmentsLoading, setAssignmentsLoading] = useState(false);
   const [error, setError] = useState<string>();
-  // Partner-owned policies are always assigned at the partner level (all orgs);
-  // org-owned policies default to the organization level.
+  // Only used by the org-owned assignment form below; partner-owned policies
+  // delegate to OrganizationScopePanel before this state is ever rendered.
   const [newLevel, setNewLevel] = useState(isPartnerOwned ? 'partner' : 'organization');
   const [newTargetId, setNewTargetId] = useState('');
   const [newPriority, setNewPriority] = useState('0');
@@ -476,7 +478,7 @@ export default function AssignmentsTab({ policyId, orgId, orgName, partnerId }: 
   // advanced site/group/device flow below remains reachable only for
   // org-owned policies.
   if (isPartnerOwned && partnerId) {
-    return <OrganizationScopePanel policyId={policyId} />;
+    return <OrganizationScopePanel policyId={policyId} partnerId={partnerId} />;
   }
 
   return (

--- a/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
+++ b/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
@@ -476,7 +476,7 @@ export default function AssignmentsTab({ policyId, orgId, orgName, partnerId }: 
   // advanced site/group/device flow below remains reachable only for
   // org-owned policies.
   if (isPartnerOwned && partnerId) {
-    return <OrganizationScopePanel policyId={policyId} partnerId={partnerId} />;
+    return <OrganizationScopePanel policyId={policyId} />;
   }
 
   return (

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.test.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.test.tsx
@@ -163,6 +163,14 @@ describe('ConfigPolicyCreatePage — owner scope (#1724)', () => {
     ).toBe(false);
   });
 
+  it('labels the partner option as a reusable library, not "all organizations"', () => {
+    startNewPolicy();
+    expect(screen.getByText(/Partner library/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/applies to no organizations until you assign it/i)
+    ).toBeInTheDocument();
+  });
+
   it('hides the owner picker for an org-scope creator and POSTs orgId only', async () => {
     getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'org-9' });
     orgState.current = { currentOrgId: 'org-9', allOrgs: false, organizations: [] };

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.test.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.test.tsx
@@ -171,6 +171,14 @@ describe('ConfigPolicyCreatePage — owner scope (#1724)', () => {
     ).toBeInTheDocument();
   });
 
+  it('notes that backup settings are unavailable on partner-owned policies', () => {
+    startNewPolicy();
+    expect(screen.getByTestId('policy-owner-partner')).toBeChecked();
+    expect(
+      screen.getByText(/Backup settings aren.t available on partner-owned policies/i)
+    ).toBeInTheDocument();
+  });
+
   it('hides the owner picker for an org-scope creator and POSTs orgId only', async () => {
     getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'org-9' });
     orgState.current = { currentOrgId: 'org-9', allOrgs: false, organizations: [] };

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx
@@ -250,7 +250,7 @@ export default function ConfigPolicyCreatePage() {
                     onChange={() => setOwnerScope('partner')}
                     data-testid="policy-owner-partner"
                   />
-                  All organizations <span className="text-muted-foreground">(partner-wide)</span>
+                  Partner library <span className="text-muted-foreground">(assign to organizations after creating)</span>
                 </label>
                 <label className="flex items-center gap-2 text-sm">
                   <input
@@ -283,10 +283,9 @@ export default function ConfigPolicyCreatePage() {
                   </div>
                 )}
                 {ownerScope === 'partner' && (
-                  <p className="pl-6 text-xs text-muted-foreground">
-                    Applies to every organization under your partner — it&apos;s assigned partner-wide
-                    automatically, so you don&apos;t need to add an assignment (you can still add role or OS
-                    filters on the Assignments tab). Backup settings aren&apos;t available on partner-wide policies.
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Create a reusable policy owned by your partner. It applies to no
+                    organizations until you assign it on the policy&apos;s Organizations tab.
                   </p>
                 )}
               </fieldset>

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx
@@ -286,6 +286,7 @@ export default function ConfigPolicyCreatePage() {
                   <p className="mt-2 text-sm text-muted-foreground">
                     Create a reusable policy owned by your partner. It applies to no
                     organizations until you assign it on the policy&apos;s Organizations tab.
+                    Backup settings aren&apos;t available on partner-owned policies.
                   </p>
                 )}
               </fieldset>

--- a/apps/web/src/components/configurationPolicies/OrganizationScopePanel.test.tsx
+++ b/apps/web/src/components/configurationPolicies/OrganizationScopePanel.test.tsx
@@ -145,6 +145,62 @@ describe('OrganizationScopePanel', () => {
   // "Assigned" section must always render it, resolving its name by id even
   // when it's absent from the currently loaded/searched page — and unchecking
   // it must still fire the DELETE.
+  it('DELETEs the org assignment when an assigned org (in the current page) is unchecked', async () => {
+    fetchWithAuthMock
+      .mockImplementationOnce(() => assignmentsRes([{ id: 'a1', level: 'organization', targetId: 'org-acme', priority: 0 }]))
+      .mockImplementationOnce(() => orgsPageRes([{ id: 'org-acme', name: 'Acme Corp' }, { id: 'org-contoso', name: 'Contoso Ltd' }]));
+
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    const acme = await screen.findByRole('checkbox', { name: /Acme Corp/i });
+    expect(acme).toBeChecked();
+
+    fireEvent.click(acme);
+
+    await waitFor(() => expect(findCall('/configuration-policies/p1/assignments/a1', 'DELETE')).toBeTruthy());
+  });
+
+  it('DELETEs the partner assignment when "All organizations" is turned off', async () => {
+    fetchWithAuthMock
+      .mockImplementationOnce(() => assignmentsRes([{ id: 'ap1', level: 'partner', targetId: PARTNER_ID, priority: 0 }]))
+      .mockImplementationOnce(() => orgsPageRes([{ id: 'org-acme', name: 'Acme Corp' }]));
+
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    const allOrgs = await screen.findByRole('checkbox', { name: /All organizations/i });
+    expect(allOrgs).toBeChecked();
+
+    fireEvent.click(allOrgs);
+
+    await waitFor(() => expect(findCall('/configuration-policies/p1/assignments/ap1', 'DELETE')).toBeTruthy());
+  });
+
+  it('surfaces an error and still refetches assignments when a mutation fails mid-sequence', async () => {
+    fetchWithAuthMock
+      .mockImplementationOnce(() => assignmentsRes([]))
+      .mockImplementationOnce(() => orgsPageRes([{ id: 'org-contoso', name: 'Contoso Ltd' }]));
+
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    const contoso = await screen.findByRole('checkbox', { name: /Contoso Ltd/i });
+
+    fetchWithAuthMock.mockImplementationOnce(() => jsonRes({ error: 'Simulated failure' }, false, 500));
+
+    fireEvent.click(contoso);
+
+    await waitFor(() => expect(screen.getByText(/Simulated failure/i)).toBeInTheDocument());
+
+    // The `run()` finally-block refetch (#2280 hardening) must still fire a
+    // fresh GET for assignments after the failed mutation, not just the one
+    // at mount — this is what keeps the checklist state truthful after a
+    // failed toggle instead of leaving optimistic/stale UI in place.
+    await waitFor(() => {
+      const getCalls = fetchWithAuthMock.mock.calls.filter(
+        (c) =>
+          String(c[0]).includes('/configuration-policies/p1/assignments') &&
+          !(c[1] as RequestInit | undefined)?.method
+      );
+      expect(getCalls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
   it('always renders an assigned org that is not in the current page, and can unassign it', async () => {
     fetchWithAuthMock
       .mockImplementationOnce(() => assignmentsRes([{ id: 'a-51', level: 'organization', targetId: 'org-51', priority: 0 }]))
@@ -182,5 +238,34 @@ describe('OrganizationScopePanel', () => {
       },
       { timeout: 2000 }
     );
+  });
+
+  it('shows a searching indicator while a search refetch is in flight and orgs are already loaded', async () => {
+    fetchWithAuthMock
+      .mockImplementationOnce(() => assignmentsRes([]))
+      .mockImplementationOnce(() => orgsPageRes([{ id: 'org-1', name: 'Org One' }]));
+
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    await screen.findByRole('checkbox', { name: 'Org One' });
+    expect(screen.queryByText(/Searching…/i)).not.toBeInTheDocument();
+
+    let resolveSearch: (value: unknown) => void = () => {};
+    fetchWithAuthMock.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveSearch = resolve; })
+    );
+
+    const searchBox = screen.getByPlaceholderText('Search organizations...');
+    fireEvent.change(searchBox, { target: { value: 'acme' } });
+
+    await screen.findByText(/Searching…/i, undefined, { timeout: 2000 });
+
+    resolveSearch({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({ data: [{ id: 'org-acme', name: 'Acme Corp' }], pagination: { page: 1, limit: 100, total: 1 } }),
+    });
+
+    await waitFor(() => expect(screen.queryByText(/Searching…/i)).not.toBeInTheDocument());
   });
 });

--- a/apps/web/src/components/configurationPolicies/OrganizationScopePanel.test.tsx
+++ b/apps/web/src/components/configurationPolicies/OrganizationScopePanel.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import OrganizationScopePanel from './OrganizationScopePanel';
+
+const fetchWithAuthMock = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuthMock(...a) }));
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (sel: (s: unknown) => unknown) =>
+    sel({ organizations: [
+      { id: 'org-acme', name: 'Acme Corp' },
+      { id: 'org-contoso', name: 'Contoso Ltd' },
+    ] }),
+}));
+
+const PARTNER_ID = '22222222-2222-2222-2222-222222222222';
+
+function jsonRes(body: unknown, ok = true, status = 200) {
+  return Promise.resolve({ ok, status, json: () => Promise.resolve(body) });
+}
+
+beforeEach(() => {
+  fetchWithAuthMock.mockReset();
+});
+
+describe('OrganizationScopePanel', () => {
+  it('checks orgs that already have an organization-level assignment', async () => {
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonRes({ data: [{ id: 'a1', level: 'organization', targetId: 'org-acme', priority: 0 }] })
+    );
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    const acme = await screen.findByRole('checkbox', { name: /Acme Corp/i });
+    expect(acme).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Contoso Ltd/i })).not.toBeChecked();
+  });
+
+  it('POSTs an organization assignment when an org is checked', async () => {
+    fetchWithAuthMock
+      .mockReturnValueOnce(jsonRes({ data: [] }))                       // initial list
+      .mockReturnValueOnce(jsonRes({ id: 'a2', level: 'organization', targetId: 'org-contoso' }, true, 201)) // POST
+      .mockReturnValueOnce(jsonRes({ data: [{ id: 'a2', level: 'organization', targetId: 'org-contoso', priority: 0 }] })); // refetch
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    const contoso = await screen.findByRole('checkbox', { name: /Contoso Ltd/i });
+    fireEvent.click(contoso);
+    await waitFor(() =>
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/configuration-policies/p1/assignments',
+        expect.objectContaining({ method: 'POST' })
+      )
+    );
+    const body = JSON.parse((fetchWithAuthMock.mock.calls[1][1] as RequestInit).body as string);
+    expect(body).toMatchObject({ level: 'organization', targetId: 'org-contoso' });
+  });
+
+  it('POSTs a partner assignment (no targetId) when All orgs is toggled on', async () => {
+    fetchWithAuthMock
+      .mockReturnValueOnce(jsonRes({ data: [] }))
+      .mockReturnValueOnce(jsonRes({ id: 'ap', level: 'partner', targetId: PARTNER_ID }, true, 201))
+      .mockReturnValueOnce(jsonRes({ data: [{ id: 'ap', level: 'partner', targetId: PARTNER_ID, priority: 0 }] }));
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    const allOrgs = await screen.findByRole('checkbox', { name: /All organizations/i });
+    fireEvent.click(allOrgs);
+    await waitFor(() => {
+      const body = JSON.parse((fetchWithAuthMock.mock.calls[1][1] as RequestInit).body as string);
+      expect(body.level).toBe('partner');
+      expect(body).not.toHaveProperty('targetId');
+    });
+  });
+});

--- a/apps/web/src/components/configurationPolicies/OrganizationScopePanel.test.tsx
+++ b/apps/web/src/components/configurationPolicies/OrganizationScopePanel.test.tsx
@@ -4,13 +4,6 @@ import OrganizationScopePanel from './OrganizationScopePanel';
 
 const fetchWithAuthMock = vi.fn();
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuthMock(...a) }));
-vi.mock('../../stores/orgStore', () => ({
-  useOrgStore: (sel: (s: unknown) => unknown) =>
-    sel({ organizations: [
-      { id: 'org-acme', name: 'Acme Corp' },
-      { id: 'org-contoso', name: 'Contoso Ltd' },
-    ] }),
-}));
 
 const PARTNER_ID = '22222222-2222-2222-2222-222222222222';
 
@@ -18,16 +11,41 @@ function jsonRes(body: unknown, ok = true, status = 200) {
   return Promise.resolve({ ok, status, json: () => Promise.resolve(body) });
 }
 
+function assignmentsRes(data: Array<{ id: string; level: string; targetId: string; priority: number }>) {
+  return jsonRes({ data });
+}
+
+function orgsPageRes(orgs: Array<{ id: string; name: string }>, total?: number, page = 1) {
+  return jsonRes({ data: orgs, pagination: { page, limit: 100, total: total ?? orgs.length } });
+}
+
+// Helper: find a POST/DELETE call by URL substring + method, regardless of
+// exact call index — the panel now fires an extra org-list fetch alongside
+// the assignments fetch, so index-based assertions would be brittle.
+function findCall(urlIncludes: string, method?: string) {
+  return fetchWithAuthMock.mock.calls.find((c) => {
+    const url = String(c[0]);
+    const opts = c[1] as RequestInit | undefined;
+    return url.includes(urlIncludes) && (!method || opts?.method === method);
+  });
+}
+
 beforeEach(() => {
   fetchWithAuthMock.mockReset();
+  // Safe default for any call not explicitly stubbed by a test (e.g. a
+  // refetch-after-mutation) so the queue never underflows into `undefined`.
+  fetchWithAuthMock.mockImplementation(() =>
+    jsonRes({ data: [], pagination: { page: 1, limit: 100, total: 0 } })
+  );
 });
 
 describe('OrganizationScopePanel', () => {
   it('checks orgs that already have an organization-level assignment', async () => {
-    fetchWithAuthMock.mockReturnValueOnce(
-      jsonRes({ data: [{ id: 'a1', level: 'organization', targetId: 'org-acme', priority: 0 }] })
-    );
-    render(<OrganizationScopePanel policyId="p1" />);
+    fetchWithAuthMock
+      .mockImplementationOnce(() => assignmentsRes([{ id: 'a1', level: 'organization', targetId: 'org-acme', priority: 0 }]))
+      .mockImplementationOnce(() => orgsPageRes([{ id: 'org-acme', name: 'Acme Corp' }, { id: 'org-contoso', name: 'Contoso Ltd' }]));
+
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
     const acme = await screen.findByRole('checkbox', { name: /Acme Corp/i });
     expect(acme).toBeChecked();
     expect(screen.getByRole('checkbox', { name: /Contoso Ltd/i })).not.toBeChecked();
@@ -35,32 +53,32 @@ describe('OrganizationScopePanel', () => {
 
   it('POSTs an organization assignment when an org is checked', async () => {
     fetchWithAuthMock
-      .mockReturnValueOnce(jsonRes({ data: [] }))                       // initial list
-      .mockReturnValueOnce(jsonRes({ id: 'a2', level: 'organization', targetId: 'org-contoso' }, true, 201)) // POST
-      .mockReturnValueOnce(jsonRes({ data: [{ id: 'a2', level: 'organization', targetId: 'org-contoso', priority: 0 }] })); // refetch
-    render(<OrganizationScopePanel policyId="p1" />);
+      .mockImplementationOnce(() => assignmentsRes([]))
+      .mockImplementationOnce(() => orgsPageRes([{ id: 'org-acme', name: 'Acme Corp' }, { id: 'org-contoso', name: 'Contoso Ltd' }]));
+
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
     const contoso = await screen.findByRole('checkbox', { name: /Contoso Ltd/i });
     fireEvent.click(contoso);
-    await waitFor(() =>
-      expect(fetchWithAuthMock).toHaveBeenCalledWith(
-        '/configuration-policies/p1/assignments',
-        expect.objectContaining({ method: 'POST' })
-      )
-    );
-    const body = JSON.parse((fetchWithAuthMock.mock.calls[1][1] as RequestInit).body as string);
+
+    await waitFor(() => expect(findCall('/configuration-policies/p1/assignments', 'POST')).toBeTruthy());
+    const post = findCall('/configuration-policies/p1/assignments', 'POST')!;
+    const body = JSON.parse((post[1] as RequestInit).body as string);
     expect(body).toMatchObject({ level: 'organization', targetId: 'org-contoso' });
   });
 
   it('POSTs a partner assignment (no targetId) when All orgs is toggled on', async () => {
     fetchWithAuthMock
-      .mockReturnValueOnce(jsonRes({ data: [] }))
-      .mockReturnValueOnce(jsonRes({ id: 'ap', level: 'partner', targetId: PARTNER_ID }, true, 201))
-      .mockReturnValueOnce(jsonRes({ data: [{ id: 'ap', level: 'partner', targetId: PARTNER_ID, priority: 0 }] }));
-    render(<OrganizationScopePanel policyId="p1" />);
+      .mockImplementationOnce(() => assignmentsRes([]))
+      .mockImplementationOnce(() => orgsPageRes([{ id: 'org-acme', name: 'Acme Corp' }]));
+
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
     const allOrgs = await screen.findByRole('checkbox', { name: /All organizations/i });
     fireEvent.click(allOrgs);
+
     await waitFor(() => {
-      const body = JSON.parse((fetchWithAuthMock.mock.calls[1][1] as RequestInit).body as string);
+      const post = findCall('/configuration-policies/p1/assignments', 'POST');
+      expect(post).toBeTruthy();
+      const body = JSON.parse((post![1] as RequestInit).body as string);
       expect(body.level).toBe('partner');
       expect(body).not.toHaveProperty('targetId');
     });
@@ -68,39 +86,101 @@ describe('OrganizationScopePanel', () => {
 
   it('deletes every existing org assignment before POSTing the partner row when multiple orgs are assigned and All orgs is toggled on', async () => {
     fetchWithAuthMock
-      .mockReturnValueOnce(jsonRes({ data: [
+      .mockImplementationOnce(() => assignmentsRes([
         { id: 'a1', level: 'organization', targetId: 'org-acme', priority: 0 },
         { id: 'a2', level: 'organization', targetId: 'org-contoso', priority: 0 },
-      ] })) // initial list
-      .mockReturnValueOnce(jsonRes({ success: true })) // DELETE a1
-      .mockReturnValueOnce(jsonRes({ success: true })) // DELETE a2
-      .mockReturnValueOnce(jsonRes({ id: 'ap', level: 'partner', targetId: PARTNER_ID }, true, 201)) // POST partner
-      .mockReturnValueOnce(jsonRes({ data: [{ id: 'ap', level: 'partner', targetId: PARTNER_ID, priority: 0 }] })); // refetch
+      ]))
+      .mockImplementationOnce(() => orgsPageRes([
+        { id: 'org-acme', name: 'Acme Corp' },
+        { id: 'org-contoso', name: 'Contoso Ltd' },
+      ]));
 
-    render(<OrganizationScopePanel policyId="p1" />);
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
     const acme = await screen.findByRole('checkbox', { name: /Acme Corp/i });
     expect(acme).toBeChecked();
 
     const allOrgs = screen.getByRole('checkbox', { name: /All organizations/i });
     fireEvent.click(allOrgs);
 
-    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(5));
+    await waitFor(() => expect(findCall('/configuration-policies/p1/assignments', 'POST')).toBeTruthy());
 
-    const calls = fetchWithAuthMock.mock.calls;
-    // Index 0 is the initial GET; the two DELETEs must both land before the partner POST.
-    expect(calls[1][0]).toBe('/configuration-policies/p1/assignments/a1');
-    expect((calls[1][1] as RequestInit).method).toBe('DELETE');
-    expect(calls[2][0]).toBe('/configuration-policies/p1/assignments/a2');
-    expect((calls[2][1] as RequestInit).method).toBe('DELETE');
+    const del1 = findCall('/configuration-policies/p1/assignments/a1', 'DELETE');
+    const del2 = findCall('/configuration-policies/p1/assignments/a2', 'DELETE');
+    const post = findCall('/configuration-policies/p1/assignments', 'POST');
+    expect(del1).toBeTruthy();
+    expect(del2).toBeTruthy();
 
-    const deleteCallIndices = [1, 2];
-    const postCallIndex = calls.findIndex(
-      (c) => (c[1] as RequestInit | undefined)?.method === 'POST'
-    );
-    expect(postCallIndex).toBeGreaterThan(Math.max(...deleteCallIndices));
+    const delIndex1 = fetchWithAuthMock.mock.calls.indexOf(del1!);
+    const delIndex2 = fetchWithAuthMock.mock.calls.indexOf(del2!);
+    const postIndex = fetchWithAuthMock.mock.calls.indexOf(post!);
+    expect(postIndex).toBeGreaterThan(Math.max(delIndex1, delIndex2));
 
-    const postBody = JSON.parse((calls[postCallIndex][1] as RequestInit).body as string);
+    const postBody = JSON.parse((post![1] as RequestInit).body as string);
     expect(postBody).toMatchObject({ level: 'partner', priority: 0 });
     expect(postBody).not.toHaveProperty('targetId');
+  });
+
+  it('reaches orgs beyond the first page via "Load more"', async () => {
+    fetchWithAuthMock
+      .mockImplementationOnce(() => assignmentsRes([]))
+      .mockImplementationOnce(() => orgsPageRes([{ id: 'org-1', name: 'Org One' }], 2, 1))
+      .mockImplementationOnce(() => orgsPageRes([{ id: 'org-2', name: 'Org Two' }], 2, 2));
+
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    await screen.findByRole('checkbox', { name: 'Org One' });
+    expect(screen.queryByRole('checkbox', { name: 'Org Two' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Load more organizations/i }));
+
+    const orgTwo = await screen.findByRole('checkbox', { name: 'Org Two' });
+    expect(orgTwo).toBeInTheDocument();
+    // Both page fetches must have hit the partner-scoped org list endpoint.
+    expect(findCall('/orgs/organizations?partnerId=')).toBeTruthy();
+    const page2Call = fetchWithAuthMock.mock.calls.find((c) => String(c[0]).includes('page=2'));
+    expect(page2Call).toBeTruthy();
+  });
+
+  // The bug this fix targets: a partner with >50 orgs couldn't reach or
+  // un-assign an organization-level assignment beyond the first page. The
+  // "Assigned" section must always render it, resolving its name by id even
+  // when it's absent from the currently loaded/searched page — and unchecking
+  // it must still fire the DELETE.
+  it('always renders an assigned org that is not in the current page, and can unassign it', async () => {
+    fetchWithAuthMock
+      .mockImplementationOnce(() => assignmentsRes([{ id: 'a-51', level: 'organization', targetId: 'org-51', priority: 0 }]))
+      .mockImplementationOnce(() => orgsPageRes([{ id: 'org-1', name: 'Org One' }], 51, 1))
+      .mockImplementationOnce(() => jsonRes({ id: 'org-51', name: 'Org 51' })); // individual lookup
+
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+
+    const org51 = await screen.findByRole('checkbox', { name: 'Org 51' });
+    expect(org51).toBeChecked();
+
+    fireEvent.click(org51);
+
+    await waitFor(() => expect(findCall('/configuration-policies/p1/assignments/a-51', 'DELETE')).toBeTruthy());
+  });
+
+  it('issues a server-side search request and resets to page 1', async () => {
+    fetchWithAuthMock
+      .mockImplementationOnce(() => assignmentsRes([]))
+      .mockImplementationOnce(() => orgsPageRes([{ id: 'org-1', name: 'Org One' }]));
+
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    await screen.findByRole('checkbox', { name: 'Org One' });
+
+    fetchWithAuthMock.mockImplementationOnce(() => orgsPageRes([{ id: 'org-acme', name: 'Acme Corp' }]));
+
+    const searchBox = screen.getByPlaceholderText('Search organizations...');
+    fireEvent.change(searchBox, { target: { value: 'acme' } });
+
+    await waitFor(
+      () => {
+        const call = fetchWithAuthMock.mock.calls.find((c) => String(c[0]).includes('search=acme'));
+        expect(call).toBeTruthy();
+        expect(String(call![0])).toContain('page=1');
+      },
+      { timeout: 2000 }
+    );
   });
 });

--- a/apps/web/src/components/configurationPolicies/OrganizationScopePanel.test.tsx
+++ b/apps/web/src/components/configurationPolicies/OrganizationScopePanel.test.tsx
@@ -65,4 +65,42 @@ describe('OrganizationScopePanel', () => {
       expect(body).not.toHaveProperty('targetId');
     });
   });
+
+  it('deletes every existing org assignment before POSTing the partner row when multiple orgs are assigned and All orgs is toggled on', async () => {
+    fetchWithAuthMock
+      .mockReturnValueOnce(jsonRes({ data: [
+        { id: 'a1', level: 'organization', targetId: 'org-acme', priority: 0 },
+        { id: 'a2', level: 'organization', targetId: 'org-contoso', priority: 0 },
+      ] })) // initial list
+      .mockReturnValueOnce(jsonRes({ success: true })) // DELETE a1
+      .mockReturnValueOnce(jsonRes({ success: true })) // DELETE a2
+      .mockReturnValueOnce(jsonRes({ id: 'ap', level: 'partner', targetId: PARTNER_ID }, true, 201)) // POST partner
+      .mockReturnValueOnce(jsonRes({ data: [{ id: 'ap', level: 'partner', targetId: PARTNER_ID, priority: 0 }] })); // refetch
+
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    const acme = await screen.findByRole('checkbox', { name: /Acme Corp/i });
+    expect(acme).toBeChecked();
+
+    const allOrgs = screen.getByRole('checkbox', { name: /All organizations/i });
+    fireEvent.click(allOrgs);
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(5));
+
+    const calls = fetchWithAuthMock.mock.calls;
+    // Index 0 is the initial GET; the two DELETEs must both land before the partner POST.
+    expect(calls[1][0]).toBe('/configuration-policies/p1/assignments/a1');
+    expect((calls[1][1] as RequestInit).method).toBe('DELETE');
+    expect(calls[2][0]).toBe('/configuration-policies/p1/assignments/a2');
+    expect((calls[2][1] as RequestInit).method).toBe('DELETE');
+
+    const deleteCallIndices = [1, 2];
+    const postCallIndex = calls.findIndex(
+      (c) => (c[1] as RequestInit | undefined)?.method === 'POST'
+    );
+    expect(postCallIndex).toBeGreaterThan(Math.max(...deleteCallIndices));
+
+    const postBody = JSON.parse((calls[postCallIndex][1] as RequestInit).body as string);
+    expect(postBody).toMatchObject({ level: 'partner', priority: 0 });
+    expect(postBody).not.toHaveProperty('targetId');
+  });
 });

--- a/apps/web/src/components/configurationPolicies/OrganizationScopePanel.test.tsx
+++ b/apps/web/src/components/configurationPolicies/OrganizationScopePanel.test.tsx
@@ -27,7 +27,7 @@ describe('OrganizationScopePanel', () => {
     fetchWithAuthMock.mockReturnValueOnce(
       jsonRes({ data: [{ id: 'a1', level: 'organization', targetId: 'org-acme', priority: 0 }] })
     );
-    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    render(<OrganizationScopePanel policyId="p1" />);
     const acme = await screen.findByRole('checkbox', { name: /Acme Corp/i });
     expect(acme).toBeChecked();
     expect(screen.getByRole('checkbox', { name: /Contoso Ltd/i })).not.toBeChecked();
@@ -38,7 +38,7 @@ describe('OrganizationScopePanel', () => {
       .mockReturnValueOnce(jsonRes({ data: [] }))                       // initial list
       .mockReturnValueOnce(jsonRes({ id: 'a2', level: 'organization', targetId: 'org-contoso' }, true, 201)) // POST
       .mockReturnValueOnce(jsonRes({ data: [{ id: 'a2', level: 'organization', targetId: 'org-contoso', priority: 0 }] })); // refetch
-    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    render(<OrganizationScopePanel policyId="p1" />);
     const contoso = await screen.findByRole('checkbox', { name: /Contoso Ltd/i });
     fireEvent.click(contoso);
     await waitFor(() =>
@@ -56,7 +56,7 @@ describe('OrganizationScopePanel', () => {
       .mockReturnValueOnce(jsonRes({ data: [] }))
       .mockReturnValueOnce(jsonRes({ id: 'ap', level: 'partner', targetId: PARTNER_ID }, true, 201))
       .mockReturnValueOnce(jsonRes({ data: [{ id: 'ap', level: 'partner', targetId: PARTNER_ID, priority: 0 }] }));
-    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    render(<OrganizationScopePanel policyId="p1" />);
     const allOrgs = await screen.findByRole('checkbox', { name: /All organizations/i });
     fireEvent.click(allOrgs);
     await waitFor(() => {
@@ -77,7 +77,7 @@ describe('OrganizationScopePanel', () => {
       .mockReturnValueOnce(jsonRes({ id: 'ap', level: 'partner', targetId: PARTNER_ID }, true, 201)) // POST partner
       .mockReturnValueOnce(jsonRes({ data: [{ id: 'ap', level: 'partner', targetId: PARTNER_ID, priority: 0 }] })); // refetch
 
-    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    render(<OrganizationScopePanel policyId="p1" />);
     const acme = await screen.findByRole('checkbox', { name: /Acme Corp/i });
     expect(acme).toBeChecked();
 

--- a/apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx
+++ b/apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Search } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { extractApiError } from '@/lib/apiError';
@@ -66,7 +66,14 @@ export default function OrganizationScopePanel({ policyId, partnerId }: Props) {
     return () => clearTimeout(t);
   }, [search]);
 
+  // Guards against out-of-order responses: a "Load more" (page N, append)
+  // fetch that resolves AFTER a later search-triggered page-1 fetch must not
+  // clobber/append onto the fresher list (#2280 re-review). Each call claims
+  // the next id; a response only commits state if it's still the latest.
+  const reqIdRef = useRef(0);
+
   const fetchOrgs = useCallback(async (pageToFetch: number, searchTerm: string, append: boolean) => {
+    const myReq = ++reqIdRef.current;
     setOrgsLoading(true);
     try {
       const params = new URLSearchParams({
@@ -78,13 +85,15 @@ export default function OrganizationScopePanel({ policyId, partnerId }: Props) {
       const res = await fetchWithAuth(`/orgs/organizations?${params.toString()}`);
       if (!res.ok) throw new Error(extractApiError(await res.json().catch(() => null), 'Failed to load organizations'));
       const data = await res.json();
+      if (myReq !== reqIdRef.current) return;
       const rows: OrgSummary[] = Array.isArray(data.data) ? data.data : [];
       setOrgs((prev) => (append ? [...prev, ...rows] : rows));
       setTotal(Number(data.pagination?.total ?? rows.length));
     } catch (err) {
+      if (myReq !== reqIdRef.current) return;
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
-      setOrgsLoading(false);
+      if (myReq === reqIdRef.current) setOrgsLoading(false);
     }
   }, [partnerId]);
 
@@ -120,6 +129,7 @@ export default function OrganizationScopePanel({ policyId, partnerId }: Props) {
     let cancelled = false;
     (async () => {
       for (const id of missingIds) {
+        if (cancelled) break;
         try {
           const res = await fetchWithAuth(`/orgs/organizations/${id}`);
           if (!res.ok) continue;

--- a/apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx
+++ b/apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx
@@ -1,28 +1,48 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Search } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
-import { useOrgStore } from '../../stores/orgStore';
 import { extractApiError } from '@/lib/apiError';
 
 type Assignment = { id: string; level: string; targetId: string; priority: number };
+type OrgSummary = { id: string; name: string };
 
-type Props = { policyId: string };
+type Props = { policyId: string; partnerId: string };
+
+const PAGE_SIZE = 100;
+const SEARCH_DEBOUNCE_MS = 300;
 
 // Partner-owned policies (#2280) are a reusable library. "All organizations"
 // (a single partner-level assignment) and a subset (N organization-level
 // assignments) are mutually exclusive: turning on All orgs removes per-org
 // rows; checking any org removes the partner row. Site/group/device precision
 // lives in the advanced Assignments tab.
-export default function OrganizationScopePanel({ policyId }: Props) {
-  const organizations = useOrgStore((s) => s.organizations);
+//
+// This panel fetches its OWN paginated, server-searched org list (never the
+// nav org store, which silently truncates at 50) — see #2285 review: a
+// partner with >50 orgs couldn't reach or un-assign orgs beyond #50. Every
+// org with an existing organization-level assignment is resolved and always
+// rendered in the "Assigned" section at the top, regardless of whether it's
+// in the currently loaded/searched page, so an assignment can never become
+// invisible or un-removable.
+export default function OrganizationScopePanel({ policyId, partnerId }: Props) {
   const [assignments, setAssignments] = useState<Assignment[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [assignmentsLoading, setAssignmentsLoading] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null); // org id or '__all__'
   const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const [error, setError] = useState<string>();
 
+  const [orgs, setOrgs] = useState<OrgSummary[]>([]);
+  const [orgsLoading, setOrgsLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+
+  // Names resolved (by id lookup) for assigned orgs that fall outside the
+  // currently loaded/searched page — the fix for the invisible-assignment bug.
+  const [assignedOrgNames, setAssignedOrgNames] = useState<Record<string, string>>({});
+
   const fetchAssignments = useCallback(async () => {
-    setLoading(true);
+    setAssignmentsLoading(true);
     try {
       const res = await fetchWithAuth(`/configuration-policies/${policyId}/assignments`);
       if (!res.ok) throw new Error(extractApiError(await res.json().catch(() => null), 'Failed to load assignments'));
@@ -31,11 +51,50 @@ export default function OrganizationScopePanel({ policyId }: Props) {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
-      setLoading(false);
+      setAssignmentsLoading(false);
     }
   }, [policyId]);
 
   useEffect(() => { fetchAssignments(); }, [fetchAssignments]);
+
+  // Debounce the search box, then reset paging to page 1.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(1);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  const fetchOrgs = useCallback(async (pageToFetch: number, searchTerm: string, append: boolean) => {
+    setOrgsLoading(true);
+    try {
+      const params = new URLSearchParams({
+        partnerId,
+        limit: String(PAGE_SIZE),
+        page: String(pageToFetch),
+      });
+      if (searchTerm.trim()) params.set('search', searchTerm.trim());
+      const res = await fetchWithAuth(`/orgs/organizations?${params.toString()}`);
+      if (!res.ok) throw new Error(extractApiError(await res.json().catch(() => null), 'Failed to load organizations'));
+      const data = await res.json();
+      const rows: OrgSummary[] = Array.isArray(data.data) ? data.data : [];
+      setOrgs((prev) => (append ? [...prev, ...rows] : rows));
+      setTotal(Number(data.pagination?.total ?? rows.length));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setOrgsLoading(false);
+    }
+  }, [partnerId]);
+
+  useEffect(() => { fetchOrgs(1, debouncedSearch, false); }, [fetchOrgs, debouncedSearch]);
+
+  const loadMore = () => {
+    const nextPage = page + 1;
+    setPage(nextPage);
+    fetchOrgs(nextPage, debouncedSearch, true);
+  };
 
   const partnerAssignment = assignments.find((a) => a.level === 'partner');
   const allOrgs = !!partnerAssignment;
@@ -44,6 +103,37 @@ export default function OrganizationScopePanel({ policyId }: Props) {
     assignments.filter((a) => a.level === 'organization').forEach((a) => m.set(a.targetId, a));
     return m;
   }, [assignments]);
+
+  const orgsById = useMemo(() => {
+    const m = new Map<string, OrgSummary>();
+    orgs.forEach((o) => m.set(o.id, o));
+    return m;
+  }, [orgs]);
+
+  // Resolve names for assigned orgs the current page/search doesn't cover —
+  // e.g. org #51+ when only the first 100 are loaded. Best-effort: if a
+  // lookup fails the org still renders (keyed by id) and remains removable.
+  useEffect(() => {
+    const missingIds = Array.from(orgAssignmentByOrgId.keys())
+      .filter((id) => !orgsById.has(id) && !(id in assignedOrgNames));
+    if (missingIds.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      for (const id of missingIds) {
+        try {
+          const res = await fetchWithAuth(`/orgs/organizations/${id}`);
+          if (!res.ok) continue;
+          const org = await res.json();
+          if (!cancelled && org?.id) {
+            setAssignedOrgNames((prev) => ({ ...prev, [org.id]: org.name ?? org.id }));
+          }
+        } catch {
+          // Swallow — the row still renders below via the `?? id` fallback.
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [orgAssignmentByOrgId, orgsById, assignedOrgNames]);
 
   const post = (body: Record<string, unknown>) =>
     fetchWithAuth(`/configuration-policies/${policyId}/assignments`, {
@@ -96,8 +186,23 @@ export default function OrganizationScopePanel({ policyId }: Props) {
       }
     });
 
-  const filtered = organizations.filter((o) =>
-    o.name.toLowerCase().includes(search.toLowerCase()));
+  // Assigned section: every org with a current organization-level assignment,
+  // regardless of whether it's in the loaded/searched page. This is what
+  // guarantees an assignment to org #51+ is always visible and removable.
+  const assignedOrgs = useMemo(
+    () => Array.from(orgAssignmentByOrgId.keys()).map((id) => ({
+      id,
+      name: orgsById.get(id)?.name ?? assignedOrgNames[id] ?? id,
+    })),
+    [orgAssignmentByOrgId, orgsById, assignedOrgNames]
+  );
+  const assignedIds = useMemo(() => new Set(assignedOrgs.map((o) => o.id)), [assignedOrgs]);
+
+  // Browsable list excludes orgs already surfaced in the Assigned section above.
+  const browsableOrgs = orgs.filter((o) => !assignedIds.has(o.id));
+
+  const rowsDisabled = assignmentsLoading || busyId !== null;
+  const initialLoading = assignmentsLoading || (orgs.length === 0 && orgsLoading);
 
   return (
     <div className="space-y-4">
@@ -115,11 +220,31 @@ export default function OrganizationScopePanel({ policyId }: Props) {
             type="checkbox"
             aria-label="All organizations (partner-wide)"
             checked={allOrgs}
-            disabled={loading || busyId !== null}
+            disabled={rowsDisabled}
             onChange={toggleAllOrgs}
           />
           <span className="text-sm font-medium">All organizations (partner-wide)</span>
         </label>
+
+        {!allOrgs && assignedOrgs.length > 0 && (
+          <div className="mt-4">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Assigned</h3>
+            <div className="mt-2 divide-y rounded-md border">
+              {assignedOrgs.map((org) => (
+                <label key={org.id} className="flex items-center gap-3 px-3 py-2 text-sm">
+                  <input
+                    type="checkbox"
+                    aria-label={org.name}
+                    checked
+                    disabled={rowsDisabled}
+                    onChange={() => toggleOrg(org.id)}
+                  />
+                  <span>{org.name}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
 
         <div className="mt-4 flex items-center rounded-md border px-3 py-2">
           <Search className="mr-2 h-4 w-4 text-muted-foreground" />
@@ -131,28 +256,42 @@ export default function OrganizationScopePanel({ policyId }: Props) {
           />
         </div>
 
-        {loading ? (
+        {initialLoading ? (
           <div className="flex items-center justify-center py-8">
             <div className="h-6 w-6 animate-spin rounded-full border-4 border-primary border-t-transparent" />
           </div>
         ) : (
-          <div className="mt-3 max-h-80 divide-y overflow-y-auto rounded-md border">
-            {filtered.map((org) => (
-              <label key={org.id} className="flex items-center gap-3 px-3 py-2 text-sm">
-                <input
-                  type="checkbox"
-                  aria-label={org.name}
-                  checked={allOrgs || orgAssignmentByOrgId.has(org.id)}
-                  disabled={allOrgs || loading || busyId !== null}
-                  onChange={() => toggleOrg(org.id)}
-                />
-                <span>{org.name}</span>
-              </label>
-            ))}
-            {filtered.length === 0 && (
-              <p className="px-3 py-4 text-sm text-muted-foreground">No organizations match your search.</p>
+          <>
+            <div className="mt-3 max-h-80 divide-y overflow-y-auto rounded-md border">
+              {browsableOrgs.map((org) => (
+                <label key={org.id} className="flex items-center gap-3 px-3 py-2 text-sm">
+                  <input
+                    type="checkbox"
+                    aria-label={org.name}
+                    checked={allOrgs || orgAssignmentByOrgId.has(org.id)}
+                    disabled={allOrgs || rowsDisabled}
+                    onChange={() => toggleOrg(org.id)}
+                  />
+                  <span>{org.name}</span>
+                </label>
+              ))}
+              {browsableOrgs.length === 0 && assignedOrgs.length === 0 && (
+                <p className="px-3 py-4 text-sm text-muted-foreground">No organizations match your search.</p>
+              )}
+            </div>
+            {orgs.length < total && (
+              <div className="mt-2 flex justify-center">
+                <button
+                  type="button"
+                  onClick={loadMore}
+                  disabled={orgsLoading || rowsDisabled}
+                  className="rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted/50 disabled:opacity-50"
+                >
+                  {orgsLoading ? 'Loading…' : 'Load more organizations'}
+                </button>
+              </div>
             )}
-          </div>
+          </>
         )}
         {allOrgs && (
           <p className="mt-2 text-xs text-muted-foreground">

--- a/apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx
+++ b/apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx
@@ -6,14 +6,14 @@ import { extractApiError } from '@/lib/apiError';
 
 type Assignment = { id: string; level: string; targetId: string; priority: number };
 
-type Props = { policyId: string; partnerId: string };
+type Props = { policyId: string };
 
 // Partner-owned policies (#2280) are a reusable library. "All organizations"
 // (a single partner-level assignment) and a subset (N organization-level
 // assignments) are mutually exclusive: turning on All orgs removes per-org
 // rows; checking any org removes the partner row. Site/group/device precision
 // lives in the advanced Assignments tab.
-export default function OrganizationScopePanel({ policyId, partnerId }: Props) {
+export default function OrganizationScopePanel({ policyId }: Props) {
   const organizations = useOrgStore((s) => s.organizations);
   const [assignments, setAssignments] = useState<Assignment[]>([]);
   const [loading, setLoading] = useState(false);
@@ -143,7 +143,7 @@ export default function OrganizationScopePanel({ policyId, partnerId }: Props) {
                   type="checkbox"
                   aria-label={org.name}
                   checked={allOrgs || orgAssignmentByOrgId.has(org.id)}
-                  disabled={allOrgs || busyId !== null}
+                  disabled={allOrgs || loading || busyId !== null}
                   onChange={() => toggleOrg(org.id)}
                 />
                 <span>{org.name}</span>

--- a/apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx
+++ b/apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx
@@ -99,10 +99,16 @@ export default function OrganizationScopePanel({ policyId, partnerId }: Props) {
 
   useEffect(() => { fetchOrgs(1, debouncedSearch, false); }, [fetchOrgs, debouncedSearch]);
 
+  // Tracks whether the in-flight fetch is a "Load more" append vs. a
+  // search/page-1 reset, so the two loading cues below never both fire for
+  // the same request.
+  const [appending, setAppending] = useState(false);
+
   const loadMore = () => {
     const nextPage = page + 1;
     setPage(nextPage);
-    fetchOrgs(nextPage, debouncedSearch, true);
+    setAppending(true);
+    fetchOrgs(nextPage, debouncedSearch, true).finally(() => setAppending(false));
   };
 
   const partnerAssignment = assignments.find((a) => a.level === 'partner');
@@ -213,6 +219,12 @@ export default function OrganizationScopePanel({ policyId, partnerId }: Props) {
 
   const rowsDisabled = assignmentsLoading || busyId !== null;
   const initialLoading = assignmentsLoading || (orgs.length === 0 && orgsLoading);
+  // A search-triggered refetch while the (stale) list from a prior fetch is
+  // still showing: `initialLoading` stays false (orgs.length > 0), so without
+  // this the checklist looks idle while it's actually about to change out
+  // from under the user (#2285 review). Excludes "Load more" appends, which
+  // have their own inline spinner on the button.
+  const searchRefetching = orgsLoading && orgs.length > 0 && !appending;
 
   return (
     <div className="space-y-4">
@@ -264,6 +276,16 @@ export default function OrganizationScopePanel({ policyId, partnerId }: Props) {
             placeholder="Search organizations..."
             className="w-full bg-transparent text-sm outline-hidden placeholder:text-muted-foreground"
           />
+          {searchRefetching && (
+            <span
+              role="status"
+              aria-live="polite"
+              className="ml-2 flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground"
+            >
+              <span className="h-3 w-3 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+              Searching…
+            </span>
+          )}
         </div>
 
         {initialLoading ? (

--- a/apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx
+++ b/apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx
@@ -56,9 +56,9 @@ export default function OrganizationScopePanel({ policyId, partnerId }: Props) {
   const run = async (id: string, fn: () => Promise<void>) => {
     setBusyId(id);
     setError(undefined);
-    try { await fn(); await fetchAssignments(); }
+    try { await fn(); }
     catch (err) { setError(err instanceof Error ? err.message : 'An error occurred'); }
-    finally { setBusyId(null); }
+    finally { await fetchAssignments(); setBusyId(null); }
   };
 
   const toggleAllOrgs = () =>
@@ -115,7 +115,7 @@ export default function OrganizationScopePanel({ policyId, partnerId }: Props) {
             type="checkbox"
             aria-label="All organizations (partner-wide)"
             checked={allOrgs}
-            disabled={busyId !== null}
+            disabled={loading || busyId !== null}
             onChange={toggleAllOrgs}
           />
           <span className="text-sm font-medium">All organizations (partner-wide)</span>

--- a/apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx
+++ b/apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx
@@ -1,0 +1,165 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Search } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
+import { extractApiError } from '@/lib/apiError';
+
+type Assignment = { id: string; level: string; targetId: string; priority: number };
+
+type Props = { policyId: string; partnerId: string };
+
+// Partner-owned policies (#2280) are a reusable library. "All organizations"
+// (a single partner-level assignment) and a subset (N organization-level
+// assignments) are mutually exclusive: turning on All orgs removes per-org
+// rows; checking any org removes the partner row. Site/group/device precision
+// lives in the advanced Assignments tab.
+export default function OrganizationScopePanel({ policyId, partnerId }: Props) {
+  const organizations = useOrgStore((s) => s.organizations);
+  const [assignments, setAssignments] = useState<Assignment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null); // org id or '__all__'
+  const [search, setSearch] = useState('');
+  const [error, setError] = useState<string>();
+
+  const fetchAssignments = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetchWithAuth(`/configuration-policies/${policyId}/assignments`);
+      if (!res.ok) throw new Error(extractApiError(await res.json().catch(() => null), 'Failed to load assignments'));
+      const data = await res.json();
+      setAssignments(Array.isArray(data.data) ? data.data : []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  }, [policyId]);
+
+  useEffect(() => { fetchAssignments(); }, [fetchAssignments]);
+
+  const partnerAssignment = assignments.find((a) => a.level === 'partner');
+  const allOrgs = !!partnerAssignment;
+  const orgAssignmentByOrgId = useMemo(() => {
+    const m = new Map<string, Assignment>();
+    assignments.filter((a) => a.level === 'organization').forEach((a) => m.set(a.targetId, a));
+    return m;
+  }, [assignments]);
+
+  const post = (body: Record<string, unknown>) =>
+    fetchWithAuth(`/configuration-policies/${policyId}/assignments`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  const del = (aid: string) =>
+    fetchWithAuth(`/configuration-policies/${policyId}/assignments/${aid}`, { method: 'DELETE' });
+
+  const run = async (id: string, fn: () => Promise<void>) => {
+    setBusyId(id);
+    setError(undefined);
+    try { await fn(); await fetchAssignments(); }
+    catch (err) { setError(err instanceof Error ? err.message : 'An error occurred'); }
+    finally { setBusyId(null); }
+  };
+
+  const toggleAllOrgs = () =>
+    run('__all__', async () => {
+      if (allOrgs) {
+        if (partnerAssignment) {
+          const r = await del(partnerAssignment.id);
+          if (!r.ok) throw new Error(extractApiError(await r.json().catch(() => null), 'Failed to remove'));
+        }
+      } else {
+        // Clear any per-org rows first, then apply partner-wide.
+        for (const a of orgAssignmentByOrgId.values()) {
+          const r = await del(a.id);
+          if (!r.ok) throw new Error(extractApiError(await r.json().catch(() => null), 'Failed to remove'));
+        }
+        const r = await post({ level: 'partner', priority: 0 }); // server derives targetId (#1724)
+        if (!r.ok) throw new Error(extractApiError(await r.json().catch(() => null), 'Failed to assign all orgs'));
+      }
+    });
+
+  const toggleOrg = (orgId: string) =>
+    run(orgId, async () => {
+      const existing = orgAssignmentByOrgId.get(orgId);
+      if (existing) {
+        const r = await del(existing.id);
+        if (!r.ok) throw new Error(extractApiError(await r.json().catch(() => null), 'Failed to remove'));
+      } else {
+        // Checking a specific org drops the all-orgs row so the two never coexist.
+        if (partnerAssignment) {
+          const r = await del(partnerAssignment.id);
+          if (!r.ok) throw new Error(extractApiError(await r.json().catch(() => null), 'Failed to narrow'));
+        }
+        const r = await post({ level: 'organization', targetId: orgId, priority: 0 });
+        if (!r.ok) throw new Error(extractApiError(await r.json().catch(() => null), 'Failed to assign org'));
+      }
+    });
+
+  const filtered = organizations.filter((o) =>
+    o.name.toLowerCase().includes(search.toLowerCase()));
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+      )}
+      <div className="rounded-lg border bg-card p-6 shadow-xs">
+        <h2 className="text-lg font-semibold">Organizations</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          This partner library policy applies only to the organizations you select.
+        </p>
+
+        <label className="mt-4 flex items-center gap-3 rounded-md border bg-muted/30 p-3">
+          <input
+            type="checkbox"
+            aria-label="All organizations (partner-wide)"
+            checked={allOrgs}
+            disabled={busyId !== null}
+            onChange={toggleAllOrgs}
+          />
+          <span className="text-sm font-medium">All organizations (partner-wide)</span>
+        </label>
+
+        <div className="mt-4 flex items-center rounded-md border px-3 py-2">
+          <Search className="mr-2 h-4 w-4 text-muted-foreground" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search organizations..."
+            className="w-full bg-transparent text-sm outline-hidden placeholder:text-muted-foreground"
+          />
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <div className="h-6 w-6 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+          </div>
+        ) : (
+          <div className="mt-3 max-h-80 divide-y overflow-y-auto rounded-md border">
+            {filtered.map((org) => (
+              <label key={org.id} className="flex items-center gap-3 px-3 py-2 text-sm">
+                <input
+                  type="checkbox"
+                  aria-label={org.name}
+                  checked={allOrgs || orgAssignmentByOrgId.has(org.id)}
+                  disabled={allOrgs || busyId !== null}
+                  onChange={() => toggleOrg(org.id)}
+                />
+                <span>{org.name}</span>
+              </label>
+            ))}
+            {filtered.length === 0 && (
+              <p className="px-3 py-4 text-sm text-muted-foreground">No organizations match your search.</p>
+            )}
+          </div>
+        )}
+        {allOrgs && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            Applied to all organizations. Uncheck &ldquo;All organizations&rdquo; to pick a subset.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/docs/superpowers/plans/2026-07-08-partner-owned-policy-selective-org-assignment.md
+++ b/docs/superpowers/plans/2026-07-08-partner-owned-policy-selective-org-assignment.md
@@ -1,0 +1,825 @@
+# Partner-owned Config Policy — Selective Org Assignment (Library Model) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a partner-owned configuration policy act as a reusable library — created empty, then assigned to a selectable subset of organizations (and lower levels) instead of the current all-orgs-or-nothing.
+
+**Architecture:** The resolver already resolves partner-owned policies that carry `organization`-level assignments; only a write-side guard (`validateAssignmentTarget`) blocks creating them, an auto-seed forces new partner policies to all-orgs, and the UI hides the picker. This plan relaxes the validator (with an in-partner target check), adds a route auth gate, removes the create-time auto-seed, relabels the create option, and adds an "Organizations" multi-select panel. No schema change, no migration.
+
+**Tech Stack:** Hono + TypeScript API, Drizzle ORM, Vitest (unit + integration), React + Tailwind web, Zustand (`useOrgStore`).
+
+**Spec:** `docs/superpowers/specs/2026-07-07-partner-owned-policy-selective-org-assignment-design.md` · **Issue:** #2280
+
+## Global Constraints
+
+- Repo: `LanternOps/breeze`. Work on branch `ToddHebebrand/config-policy-epic` (current).
+- Tenant isolation: `config_policy_assignments` RLS is the real backstop; app-layer checks are defense-in-depth. Never weaken RLS.
+- Partner-wide write capability gate is `canManagePartnerWidePolicies(auth)` — single source of truth in `apps/api/src/services/partnerWideAccess.ts`. Do not reimplement it.
+- Partner axis is flat — never traverse a partner tree. `organizations.partner_id` is the join column.
+- Web mutations go through `fetchWithAuth` + surface errors (existing AssignmentsTab pattern); reuse it.
+- Commit after each task. Do not merge or close the issue.
+- Run API tests single-fork where noted (integration DB on `:5433`).
+
+---
+
+### Task 1: Relax `validateAssignmentTarget` for partner-owned lower-level targets
+
+**Files:**
+- Modify: `apps/api/src/services/configurationPolicy.ts:1167-1257` (the `validateAssignmentTarget` function; partner-owned branch at `:1177-1185`)
+- Test: `apps/api/src/services/configurationPolicy.validateAssignment.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new. Uses already-imported `organizations`, `sites`, `deviceGroups`, `devices` tables and `and`, `eq` from drizzle (all already imported in this file).
+- Produces: `validateAssignmentTarget(policyOwner: { orgId: string | null; partnerId: string | null }, level: ConfigAssignmentLevel, targetId: string): Promise<{ valid: boolean; error?: string }>` — signature unchanged; partner-owned policies now return `{ valid: true }` for `organization`/`site`/`device_group`/`device` when the target's owning org has `partner_id === policyOwner.partnerId`.
+
+- [ ] **Step 1: Update the existing unit tests to the new contract**
+
+In `configurationPolicy.validateAssignment.test.ts`, the current test *"rejects a partner-owned policy assigned below the Partner level"* (`:34-43`) asserts the old behavior. Replace it and add coverage. First add a chainable-select mock helper at the top of the file (after the existing `selectMock` hoist):
+
+```typescript
+// Build a drizzle-style select chain that resolves to `rows`. Covers both the
+// no-join org lookup and the innerJoin site/group/device lookups — every branch
+// ends in `.limit(1)` returning an array.
+function mockSelectResolving(rows: unknown[]) {
+  const chain: any = {
+    from: () => chain,
+    innerJoin: () => chain,
+    where: () => chain,
+    limit: () => Promise.resolve(rows),
+  };
+  selectMock.mockReturnValue(chain);
+}
+```
+
+Replace the `:34-43` test with:
+
+```typescript
+it('accepts a partner-owned policy assigned to an in-partner organization', async () => {
+  mockSelectResolving([{ id: ORG_ID }]);
+  const result = await validateAssignmentTarget(
+    { orgId: null, partnerId: PARTNER_ID },
+    'organization',
+    ORG_ID
+  );
+  expect(result.valid).toBe(true);
+  expect(selectMock).toHaveBeenCalled();
+});
+
+it('rejects a partner-owned policy assigned to an out-of-partner organization', async () => {
+  mockSelectResolving([]); // org exists but not under this partner → no row
+  const result = await validateAssignmentTarget(
+    { orgId: null, partnerId: PARTNER_ID },
+    'organization',
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+  );
+  expect(result.valid).toBe(false);
+  expect(result.error).toMatch(/not in this partner/i);
+});
+
+it('accepts a partner-owned policy assigned to an in-partner device', async () => {
+  mockSelectResolving([{ id: '33333333-3333-3333-3333-333333333333' }]);
+  const result = await validateAssignmentTarget(
+    { orgId: null, partnerId: PARTNER_ID },
+    'device',
+    '33333333-3333-3333-3333-333333333333'
+  );
+  expect(result.valid).toBe(true);
+});
+```
+
+Keep the three unchanged tests (org-owned-at-partner footgun, partner-owned targeting own partner, partner-owned targeting a different partner) — they still pass and guard the pure-early-return branches.
+
+- [ ] **Step 2: Run the tests to verify the two new positive/negative cases fail**
+
+Run: `pnpm --filter @breeze/api test -- configurationPolicy.validateAssignment`
+Expected: FAIL — "accepts a partner-owned policy assigned to an in-partner organization" fails because the current code returns `{ valid: false, error: 'Partner-wide policies can only be assigned at the Partner level' }`.
+
+- [ ] **Step 3: Rewrite the partner-owned branch in `validateAssignmentTarget`**
+
+Replace the current partner-owned block (`configurationPolicy.ts:1174-1185`):
+
+```typescript
+  // Partner-owned policies (#1724) span all of the partner's orgs and may only
+  // carry a partner-level assignment targeting their own partner. Org/site/
+  // group/device assignments are nonsensical for a policy with no owning org.
+  if (policyOwner.partnerId) {
+    if (level !== 'partner') {
+      return { valid: false, error: 'Partner-wide policies can only be assigned at the Partner level' };
+    }
+    if (targetId !== policyOwner.partnerId) {
+      return { valid: false, error: 'A partner-wide policy can only target its own partner' };
+    }
+    return { valid: true };
+  }
+```
+
+with:
+
+```typescript
+  // Partner-owned policies (#1724, #2280) are reusable libraries: a partner-level
+  // assignment applies them to ALL orgs, and org/site/group/device assignments
+  // apply them to a chosen subset. Every non-partner target must resolve to an org
+  // owned by THIS partner (organizations.partner_id) — cross-partner targets are
+  // rejected here (defense-in-depth; RLS is the real backstop).
+  if (policyOwner.partnerId) {
+    const partnerId = policyOwner.partnerId;
+    switch (level) {
+      case 'partner':
+        return targetId === partnerId
+          ? { valid: true }
+          : { valid: false, error: 'A partner-wide policy can only target its own partner' };
+
+      case 'organization': {
+        const [org] = await db
+          .select({ id: organizations.id })
+          .from(organizations)
+          .where(and(eq(organizations.id, targetId), eq(organizations.partnerId, partnerId)))
+          .limit(1);
+        return org
+          ? { valid: true }
+          : { valid: false, error: 'Target organization is not in this partner' };
+      }
+
+      case 'site': {
+        const [site] = await db
+          .select({ id: sites.id })
+          .from(sites)
+          .innerJoin(organizations, eq(sites.orgId, organizations.id))
+          .where(and(eq(sites.id, targetId), eq(organizations.partnerId, partnerId)))
+          .limit(1);
+        return site
+          ? { valid: true }
+          : { valid: false, error: 'Target site is not in this partner' };
+      }
+
+      case 'device_group': {
+        const [group] = await db
+          .select({ id: deviceGroups.id })
+          .from(deviceGroups)
+          .innerJoin(organizations, eq(deviceGroups.orgId, organizations.id))
+          .where(and(eq(deviceGroups.id, targetId), eq(organizations.partnerId, partnerId)))
+          .limit(1);
+        return group
+          ? { valid: true }
+          : { valid: false, error: 'Target device group is not in this partner' };
+      }
+
+      case 'device': {
+        const [device] = await db
+          .select({ id: devices.id })
+          .from(devices)
+          .innerJoin(organizations, eq(devices.orgId, organizations.id))
+          .where(and(eq(devices.id, targetId), eq(organizations.partnerId, partnerId)))
+          .limit(1);
+        return device
+          ? { valid: true }
+          : { valid: false, error: 'Target device is not in this partner' };
+      }
+
+      default:
+        return { valid: false, error: 'Unsupported assignment target level' };
+    }
+  }
+```
+
+- [ ] **Step 4: Run the unit tests to verify they pass**
+
+Run: `pnpm --filter @breeze/api test -- configurationPolicy.validateAssignment`
+Expected: PASS (all 6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/configurationPolicy.ts apps/api/src/services/configurationPolicy.validateAssignment.test.ts
+git commit -m "feat(config-policy): allow partner-owned policy assignment to in-partner org/site/group/device (#2280)"
+```
+
+---
+
+### Task 2: Gate partner-owned assignment writes at every level
+
+**Files:**
+- Modify: `apps/api/src/routes/configurationPolicies/assignments.ts:54-134` (POST handler)
+- Test: `apps/api/src/routes/configurationPolicies/assignments.test.ts`
+
+**Interfaces:**
+- Consumes: `canManagePartnerWidePolicies`, `PARTNER_WIDE_WRITE_DENIED_MESSAGE` (both already imported in this route), `getConfigPolicy` returning `{ orgId, partnerId, ... }`.
+- Produces: POST `/:id/assignments` returns `403` for any assignment on a partner-owned policy (`policy.orgId === null`) when `!canManagePartnerWidePolicies(auth)`, regardless of level.
+
+- [ ] **Step 1: Write the failing route test**
+
+Add to `assignments.test.ts` (follow the existing `describe`/mock setup in that file — it already mocks `getConfigPolicy` and `validateAssignmentTarget`; check whether it mocks `canManagePartnerWidePolicies` and, if not, add it to the existing `vi.mock('../../services/configurationPolicy', ...)` factory as `canManagePartnerWidePolicies: canManagePartnerWideMock`, with `const { canManagePartnerWideMock } = vi.hoisted(() => ({ canManagePartnerWideMock: vi.fn() }))`):
+
+```typescript
+it('rejects an org-level assignment on a partner-owned policy without partner-wide access (403)', async () => {
+  getConfigPolicyMock.mockResolvedValue({
+    id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Library Policy',
+  });
+  canManagePartnerWideMock.mockReturnValue(false);
+  validateAssignmentTargetMock.mockResolvedValue({ valid: true });
+
+  const res = await app.request(`/${POLICY_ID}/assignments`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ level: 'organization', targetId: ORG_ID, priority: 0 }),
+  });
+
+  expect(res.status).toBe(403);
+});
+
+it('allows an org-level assignment on a partner-owned policy with partner-wide access (201)', async () => {
+  getConfigPolicyMock.mockResolvedValue({
+    id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Library Policy',
+  });
+  canManagePartnerWideMock.mockReturnValue(true);
+  validateAssignmentTargetMock.mockResolvedValue({ valid: true });
+  assignPolicyMock.mockResolvedValue({ id: 'assign-1', level: 'organization', targetId: ORG_ID });
+
+  const res = await app.request(`/${POLICY_ID}/assignments`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ level: 'organization', targetId: ORG_ID, priority: 0 }),
+  });
+
+  expect(res.status).toBe(201);
+});
+```
+
+Reuse the file's existing constants/mocks (`app`, `POLICY_ID`, `ORG_ID`, `PARTNER_ID`, `getConfigPolicyMock`, `assignPolicyMock`, `validateAssignmentTargetMock`); add any missing ones alongside the existing declarations. The auth mock must present a partner-scope user — copy the pattern from the existing POST tests in the same file.
+
+- [ ] **Step 2: Run the test to verify the 403 case fails**
+
+Run: `pnpm --filter @breeze/api test -- routes/configurationPolicies/assignments`
+Expected: FAIL — "rejects an org-level assignment on a partner-owned policy without partner-wide access" returns 201, not 403, because the current gate only fires for `level === 'partner'`.
+
+- [ ] **Step 3: Add the top-level guard and remove the now-redundant inner check**
+
+In the POST handler, immediately after the 404 check (`assignments.ts:60`, right after `if (!policy) return ...404`), insert:
+
+```typescript
+    // Partner-owned policies (org_id NULL) are the partner library (#2280).
+    // ANY assignment on one — at any level — pushes config into orgs the caller
+    // may not fully control, so all writes require full partner org access, the
+    // same capability that gates partner-wide create/update/delete. This
+    // supersedes the per-level check that used to live only in the partner block.
+    if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+```
+
+Then, in the existing `if (data.level === 'partner')` block, **remove** the now-redundant inner capability sub-check (`assignments.ts:78-87`, the comment plus `if (!canManagePartnerWidePolicies(auth)) { return c.json(... 403); }`). Keep the `targetId` derivation (`:70-77`) intact — that logic is still needed to pin the partner target server-side.
+
+- [ ] **Step 4: Run the route tests to verify they pass**
+
+Run: `pnpm --filter @breeze/api test -- routes/configurationPolicies/assignments`
+Expected: PASS (new 403/201 tests plus all existing assignment tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/configurationPolicies/assignments.ts apps/api/src/routes/configurationPolicies/assignments.test.ts
+git commit -m "feat(config-policy): require partner-wide access for any partner-owned policy assignment (#2280)"
+```
+
+---
+
+### Task 3: Stop auto-seeding the partner-level assignment on create
+
+**Files:**
+- Modify: `apps/api/src/routes/configurationPolicies/crud.ts:82-104` (partner-owned create branch)
+- Test: `apps/api/src/routes/configurationPolicies/crud.test.ts`
+
+**Interfaces:**
+- Consumes: `createConfigPolicy`, `writeRouteAudit` (unchanged).
+- Produces: creating a partner-owned policy performs exactly one write (the policy insert) and **no** assignment insert; audit `details` no longer contains `autoAssignedPartnerWide`.
+
+- [ ] **Step 1: Write / update the failing test**
+
+In `crud.test.ts`, find the test covering partner-owned create (it currently asserts `assignPolicy` was called with `'partner'`). Replace that assertion with the empty-create contract:
+
+```typescript
+it('creates a partner-owned policy WITHOUT auto-assigning it to all orgs (#2280 library model)', async () => {
+  canManagePartnerWideMock.mockReturnValue(true);
+  createConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Lib' });
+
+  const res = await app.request('/', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name: 'Lib', ownerScope: 'partner' }),
+  });
+
+  expect(res.status).toBe(201);
+  // Library policies start empty — no partner-level (or any) assignment seeded.
+  expect(assignPolicyMock).not.toHaveBeenCalled();
+});
+```
+
+Reuse the file's existing mocks/constants (`app`, `POLICY_ID`, `PARTNER_ID`, `createConfigPolicyMock`, `assignPolicyMock`, `canManagePartnerWideMock`, and the partner-scope auth mock). If the old test name still exists, delete it.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @breeze/api test -- routes/configurationPolicies/crud`
+Expected: FAIL — `assignPolicyMock` was called once (current code seeds the partner assignment at `crud.ts:95`).
+
+- [ ] **Step 3: Remove the auto-seed**
+
+In `crud.ts`, partner-owned branch, delete the seed and its comment (`:83-95`, the block from `// Seed the matching partner-level assignment ...` through `await assignPolicy(policy.id, 'partner', auth.partnerId, 0, auth.user.id);`). Update the audit `details` (`:102`) from:
+
+```typescript
+        details: { ownerScope: 'partner', partnerId: auth.partnerId, autoAssignedPartnerWide: true },
+```
+
+to:
+
+```typescript
+        // Library model (#2280): partner-owned policies are created empty and
+        // applied via explicit assignments on the Organizations panel.
+        details: { ownerScope: 'partner', partnerId: auth.partnerId },
+```
+
+Leave `const policy = await createConfigPolicy({ partnerId: auth.partnerId }, data, auth.user.id);` and the `return c.json(policy, 201);` intact. If `assignPolicy` is now unused in this file, remove it from the import at `crud.ts:16`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @breeze/api test -- routes/configurationPolicies/crud`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/configurationPolicies/crud.ts apps/api/src/routes/configurationPolicies/crud.test.ts
+git commit -m "feat(config-policy): create partner-owned policies empty, no auto-seed (#2280)"
+```
+
+---
+
+### Task 4: Relabel the create-form partner option
+
+**Files:**
+- Modify: `apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx:247-266`
+- Test: `apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.test.tsx`
+
+**Interfaces:**
+- Consumes/Produces: no field change — the radio still sets `ownerScope: 'partner'`. Only visible copy changes.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `ConfigPolicyCreatePage.test.tsx` (match the file's existing render helper / partner-scope setup):
+
+```typescript
+it('labels the partner option as a reusable library, not "all organizations"', async () => {
+  renderCreatePage({ scope: 'partner' }); // use the file's existing render helper
+  expect(await screen.findByText(/Partner library/i)).toBeInTheDocument();
+  expect(
+    screen.getByText(/applies to no organizations until you assign it/i)
+  ).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @breeze/web test -- ConfigPolicyCreatePage`
+Expected: FAIL — text "Partner library" not found (current label is "All organizations (partner-wide)").
+
+- [ ] **Step 3: Update the label and helper copy**
+
+In `ConfigPolicyCreatePage.tsx`, change the partner radio label (`:253`) from:
+
+```tsx
+                  All organizations <span className="text-muted-foreground">(partner-wide)</span>
+```
+
+to:
+
+```tsx
+                  Partner library <span className="text-muted-foreground">(assign to organizations after creating)</span>
+```
+
+And replace the `{ownerScope === 'partner' && (...)}` helper block (`:285`+) body with:
+
+```tsx
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Create a reusable policy owned by your partner. It applies to no
+                    organizations until you assign it on the policy&apos;s Organizations tab.
+                  </p>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @breeze/web test -- ConfigPolicyCreatePage`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.test.tsx
+git commit -m "feat(config-policy): relabel partner create option as reusable library (#2280)"
+```
+
+---
+
+### Task 5: "Organizations" multi-select panel for partner-owned policies
+
+**Files:**
+- Create: `apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx`
+- Create: `apps/web/src/components/configurationPolicies/OrganizationScopePanel.test.tsx`
+- Modify: `apps/web/src/components/configurationPolicies/AssignmentsTab.tsx:478-523` (replace the `isPartnerOwned` branch body with `<OrganizationScopePanel .../>`)
+
+**Interfaces:**
+- Consumes: `useOrgStore((s) => s.organizations)` → `Organization[]` with `{ id: string; name: string }` (already loaded for the partner; same source the create page uses). `fetchWithAuth` for `GET/POST/DELETE /configuration-policies/:id/assignments`. `extractApiError` for messages.
+- Produces: `OrganizationScopePanel({ policyId, partnerId }: { policyId: string; partnerId: string })` default export — renders the master "All orgs" toggle + org checklist, writing `partner`/`organization`-level assignments.
+
+- [ ] **Step 1: Write the failing component test**
+
+`OrganizationScopePanel.test.tsx`:
+
+```typescript
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import OrganizationScopePanel from './OrganizationScopePanel';
+
+const fetchWithAuthMock = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuthMock(...a) }));
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (sel: (s: unknown) => unknown) =>
+    sel({ organizations: [
+      { id: 'org-acme', name: 'Acme Corp' },
+      { id: 'org-contoso', name: 'Contoso Ltd' },
+    ] }),
+}));
+
+const PARTNER_ID = '22222222-2222-2222-2222-222222222222';
+
+function jsonRes(body: unknown, ok = true, status = 200) {
+  return Promise.resolve({ ok, status, json: () => Promise.resolve(body) });
+}
+
+beforeEach(() => {
+  fetchWithAuthMock.mockReset();
+});
+
+describe('OrganizationScopePanel', () => {
+  it('checks orgs that already have an organization-level assignment', async () => {
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonRes({ data: [{ id: 'a1', level: 'organization', targetId: 'org-acme', priority: 0 }] })
+    );
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    const acme = await screen.findByRole('checkbox', { name: /Acme Corp/i });
+    expect(acme).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Contoso Ltd/i })).not.toBeChecked();
+  });
+
+  it('POSTs an organization assignment when an org is checked', async () => {
+    fetchWithAuthMock
+      .mockReturnValueOnce(jsonRes({ data: [] }))                       // initial list
+      .mockReturnValueOnce(jsonRes({ id: 'a2', level: 'organization', targetId: 'org-contoso' }, true, 201)) // POST
+      .mockReturnValueOnce(jsonRes({ data: [{ id: 'a2', level: 'organization', targetId: 'org-contoso', priority: 0 }] })); // refetch
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    const contoso = await screen.findByRole('checkbox', { name: /Contoso Ltd/i });
+    fireEvent.click(contoso);
+    await waitFor(() =>
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/configuration-policies/p1/assignments',
+        expect.objectContaining({ method: 'POST' })
+      )
+    );
+    const body = JSON.parse((fetchWithAuthMock.mock.calls[1][1] as RequestInit).body as string);
+    expect(body).toMatchObject({ level: 'organization', targetId: 'org-contoso' });
+  });
+
+  it('POSTs a partner assignment (no targetId) when All orgs is toggled on', async () => {
+    fetchWithAuthMock
+      .mockReturnValueOnce(jsonRes({ data: [] }))
+      .mockReturnValueOnce(jsonRes({ id: 'ap', level: 'partner', targetId: PARTNER_ID }, true, 201))
+      .mockReturnValueOnce(jsonRes({ data: [{ id: 'ap', level: 'partner', targetId: PARTNER_ID, priority: 0 }] }));
+    render(<OrganizationScopePanel policyId="p1" partnerId={PARTNER_ID} />);
+    const allOrgs = await screen.findByRole('checkbox', { name: /All organizations/i });
+    fireEvent.click(allOrgs);
+    await waitFor(() => {
+      const body = JSON.parse((fetchWithAuthMock.mock.calls[1][1] as RequestInit).body as string);
+      expect(body.level).toBe('partner');
+      expect(body).not.toHaveProperty('targetId');
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @breeze/web test -- OrganizationScopePanel`
+Expected: FAIL — module `./OrganizationScopePanel` not found.
+
+- [ ] **Step 3: Implement the panel**
+
+Create `OrganizationScopePanel.tsx`:
+
+```tsx
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Search } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
+import { extractApiError } from '@/lib/apiError';
+
+type Assignment = { id: string; level: string; targetId: string; priority: number };
+
+type Props = { policyId: string; partnerId: string };
+
+// Partner-owned policies (#2280) are a reusable library. "All organizations"
+// (a single partner-level assignment) and a subset (N organization-level
+// assignments) are mutually exclusive: turning on All orgs removes per-org
+// rows; checking any org removes the partner row. Site/group/device precision
+// lives in the advanced Assignments tab.
+export default function OrganizationScopePanel({ policyId, partnerId }: Props) {
+  const organizations = useOrgStore((s) => s.organizations);
+  const [assignments, setAssignments] = useState<Assignment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null); // org id or '__all__'
+  const [search, setSearch] = useState('');
+  const [error, setError] = useState<string>();
+
+  const fetchAssignments = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetchWithAuth(`/configuration-policies/${policyId}/assignments`);
+      if (!res.ok) throw new Error(extractApiError(await res.json().catch(() => null), 'Failed to load assignments'));
+      const data = await res.json();
+      setAssignments(Array.isArray(data.data) ? data.data : []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  }, [policyId]);
+
+  useEffect(() => { fetchAssignments(); }, [fetchAssignments]);
+
+  const partnerAssignment = assignments.find((a) => a.level === 'partner');
+  const allOrgs = !!partnerAssignment;
+  const orgAssignmentByOrgId = useMemo(() => {
+    const m = new Map<string, Assignment>();
+    assignments.filter((a) => a.level === 'organization').forEach((a) => m.set(a.targetId, a));
+    return m;
+  }, [assignments]);
+
+  const post = (body: Record<string, unknown>) =>
+    fetchWithAuth(`/configuration-policies/${policyId}/assignments`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  const del = (aid: string) =>
+    fetchWithAuth(`/configuration-policies/${policyId}/assignments/${aid}`, { method: 'DELETE' });
+
+  const run = async (id: string, fn: () => Promise<void>) => {
+    setBusyId(id);
+    setError(undefined);
+    try { await fn(); await fetchAssignments(); }
+    catch (err) { setError(err instanceof Error ? err.message : 'An error occurred'); }
+    finally { setBusyId(null); }
+  };
+
+  const toggleAllOrgs = () =>
+    run('__all__', async () => {
+      if (allOrgs) {
+        if (partnerAssignment) {
+          const r = await del(partnerAssignment.id);
+          if (!r.ok) throw new Error(extractApiError(await r.json().catch(() => null), 'Failed to remove'));
+        }
+      } else {
+        // Clear any per-org rows first, then apply partner-wide.
+        for (const a of orgAssignmentByOrgId.values()) {
+          const r = await del(a.id);
+          if (!r.ok) throw new Error(extractApiError(await r.json().catch(() => null), 'Failed to remove'));
+        }
+        const r = await post({ level: 'partner', priority: 0 }); // server derives targetId (#1724)
+        if (!r.ok) throw new Error(extractApiError(await r.json().catch(() => null), 'Failed to assign all orgs'));
+      }
+    });
+
+  const toggleOrg = (orgId: string) =>
+    run(orgId, async () => {
+      const existing = orgAssignmentByOrgId.get(orgId);
+      if (existing) {
+        const r = await del(existing.id);
+        if (!r.ok) throw new Error(extractApiError(await r.json().catch(() => null), 'Failed to remove'));
+      } else {
+        // Checking a specific org drops the all-orgs row so the two never coexist.
+        if (partnerAssignment) {
+          const r = await del(partnerAssignment.id);
+          if (!r.ok) throw new Error(extractApiError(await r.json().catch(() => null), 'Failed to narrow'));
+        }
+        const r = await post({ level: 'organization', targetId: orgId, priority: 0 });
+        if (!r.ok) throw new Error(extractApiError(await r.json().catch(() => null), 'Failed to assign org'));
+      }
+    });
+
+  const filtered = organizations.filter((o) =>
+    o.name.toLowerCase().includes(search.toLowerCase()));
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+      )}
+      <div className="rounded-lg border bg-card p-6 shadow-xs">
+        <h2 className="text-lg font-semibold">Organizations</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          This partner library policy applies only to the organizations you select.
+        </p>
+
+        <label className="mt-4 flex items-center gap-3 rounded-md border bg-muted/30 p-3">
+          <input
+            type="checkbox"
+            aria-label="All organizations (partner-wide)"
+            checked={allOrgs}
+            disabled={busyId !== null}
+            onChange={toggleAllOrgs}
+          />
+          <span className="text-sm font-medium">All organizations (partner-wide)</span>
+        </label>
+
+        <div className="mt-4 flex items-center rounded-md border px-3 py-2">
+          <Search className="mr-2 h-4 w-4 text-muted-foreground" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search organizations..."
+            className="w-full bg-transparent text-sm outline-hidden placeholder:text-muted-foreground"
+          />
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <div className="h-6 w-6 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+          </div>
+        ) : (
+          <div className="mt-3 max-h-80 divide-y overflow-y-auto rounded-md border">
+            {filtered.map((org) => (
+              <label key={org.id} className="flex items-center gap-3 px-3 py-2 text-sm">
+                <input
+                  type="checkbox"
+                  aria-label={org.name}
+                  checked={allOrgs || orgAssignmentByOrgId.has(org.id)}
+                  disabled={allOrgs || busyId !== null}
+                  onChange={() => toggleOrg(org.id)}
+                />
+                <span>{org.name}</span>
+              </label>
+            ))}
+            {filtered.length === 0 && (
+              <p className="px-3 py-4 text-sm text-muted-foreground">No organizations match your search.</p>
+            )}
+          </div>
+        )}
+        {allOrgs && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            Applied to all organizations. Uncheck &ldquo;All organizations&rdquo; to pick a subset.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @breeze/web test -- OrganizationScopePanel`
+Expected: PASS (all 3 tests).
+
+- [ ] **Step 5: Wire the panel into AssignmentsTab**
+
+In `AssignmentsTab.tsx`, add the import at the top:
+
+```tsx
+import OrganizationScopePanel from './OrganizationScopePanel';
+```
+
+Replace the entire `if (isPartnerOwned) { return ( ... ); }` block (`:478-523`) with:
+
+```tsx
+  if (isPartnerOwned && partnerId) {
+    return <OrganizationScopePanel policyId={policyId} partnerId={partnerId} />;
+  }
+```
+
+The advanced site/group/device flow stays available: the generic org-owned form below is unchanged, and per Task 1 the API now accepts those levels for partner-owned policies too (a follow-up can surface them here; out of scope for this task). Remove any now-unused helpers/imports in AssignmentsTab that were only used by the deleted partner-owned block (e.g. if `Plus`/`filterFields`/`priorityField` become unused in that branch — verify with the TypeScript build in Step 6; the org-owned branch still uses them, so likely no removal needed).
+
+- [ ] **Step 6: Run web build + AssignmentsTab tests**
+
+Run: `pnpm --filter @breeze/web test -- AssignmentsTab && pnpm --filter @breeze/web exec tsc --noEmit`
+Expected: PASS / no type errors. If `AssignmentsTab.test.tsx` asserted the old partner-owned copy ("applies to all organizations in your partner"), update those assertions to expect the `OrganizationScopePanel` (e.g. mock or assert the "Organizations" heading).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/configurationPolicies/OrganizationScopePanel.tsx apps/web/src/components/configurationPolicies/OrganizationScopePanel.test.tsx apps/web/src/components/configurationPolicies/AssignmentsTab.tsx apps/web/src/components/configurationPolicies/AssignmentsTab.test.tsx
+git commit -m "feat(config-policy): Organizations multi-select panel for partner-owned policies (#2280)"
+```
+
+---
+
+### Task 6: Integration coverage — subset resolution + cross-partner rejection
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/configurationPolicyPartnerResolution.integration.test.ts` (add subset-resolution case)
+- Modify: `apps/api/src/__tests__/integration/configurationPoliciesPartnerRls.integration.test.ts` (add cross-partner assignment forge case)
+
+**Interfaces:**
+- Consumes: the real-DB fixtures/helpers already used in those suites (partner, two orgs under it, a device per org, `withDbAccessContext`, the `breeze_app` forge helper). Reuse them — do not invent new fixtures.
+
+- [ ] **Step 1: Add the subset-resolution test**
+
+In `configurationPolicyPartnerResolution.integration.test.ts`, add (adapting names to the file's existing fixture helpers):
+
+```typescript
+it('partner-owned policy assigned to ONE org resolves only for that org (#2280)', async () => {
+  // Fixture: partner P with org A + device dA, org B + device dB (reuse suite setup).
+  const policy = await createPartnerOwnedPolicy(P, { name: 'Subset Lib' });
+  await addFeatureLink(policy.id, { featureType: 'monitoring', inlineSettings: { watches: [] } });
+  // Assign to org A only — no partner-level assignment.
+  await assignPolicy(policy.id, 'organization', orgA.id, 0, adminUserId);
+
+  const effA = await resolveEffectiveConfig(dA.id, systemAuth);
+  const effB = await resolveEffectiveConfig(dB.id, systemAuth);
+
+  expect(effA.features.monitoring?.sourcePolicyId).toBe(policy.id);
+  expect(effB.features.monitoring).toBeUndefined(); // org B was never assigned
+});
+```
+
+- [ ] **Step 2: Add the cross-partner forge test**
+
+In `configurationPoliciesPartnerRls.integration.test.ts`, add:
+
+```typescript
+it('rejects a forged assignment of a partner-owned policy to an out-of-partner org (42501)', async () => {
+  // policyP1 is partner-owned by partner P1; orgQ belongs to a DIFFERENT partner.
+  await expect(
+    forgeAsBreezeApp(() =>
+      insertAssignment({ configPolicyId: policyP1.id, level: 'organization', targetId: orgQ.id })
+    )
+  ).rejects.toThrow(/row-level security|42501/i);
+});
+```
+
+Use the suite's existing `forgeAsBreezeApp` / raw-insert helper and its cross-partner fixtures (`policyP1`, `orgQ`). If a helper name differs, match the file's actual helper.
+
+- [ ] **Step 3: Run the integration suites (real DB on :5433, single fork)**
+
+Run: `pnpm --filter @breeze/api test:integration -- configurationPolicyPartnerResolution configurationPoliciesPartnerRls`
+Expected: PASS. (If the integration DB isn't up, start it per `apps/api` integration config; see `test_integration_config_run_mechanics`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/configurationPolicyPartnerResolution.integration.test.ts apps/api/src/__tests__/integration/configurationPoliciesPartnerRls.integration.test.ts
+git commit -m "test(config-policy): subset resolution + cross-partner assignment forge (#2280)"
+```
+
+---
+
+### Task 7: Call-site sweep + full verification
+
+**Files:** none created; this task confirms nothing else assumed `partner-owned ⇒ partner-level-only`.
+
+- [ ] **Step 1: Sweep every assignment write / resolve path**
+
+Run and read each hit:
+
+```bash
+grep -rn "validateAssignmentTarget\|assignPolicy\|level: 'partner'\|autoAssignedPartnerWide\|Partner-wide policies can only" apps/api/src
+```
+
+Confirm no remaining code (a) rejects lower-level assignments for partner-owned policies, (b) re-seeds a partner assignment on create, or (c) asserts old copy. Pay attention to `apps/api/src/services/aiToolsConfigPolicy.ts:221` and `:239` (the AI `assign_policy_to_target` path uses the same `validateAssignmentTarget`, so it is unblocked automatically — verify its comment/guards don't independently reject lower levels for partner-owned) and `apps/api/src/jobs/patchSchedulerWorker.ts:215` (a comment assuming partner-wide never carries a lower assignment — update the comment if now inaccurate; confirm the code path still behaves).
+
+- [ ] **Step 2: Run the full API + web unit suites**
+
+Run: `pnpm --filter @breeze/api test && pnpm --filter @breeze/web test`
+Expected: PASS. Fix any test that encoded the old all-or-one behavior.
+
+- [ ] **Step 3: Commit any sweep fixes**
+
+```bash
+git add -A
+git commit -m "chore(config-policy): sweep call sites for partner-owned subset assignment (#2280)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Layer 0 (create path) → Tasks 3 (API) + 4 (web label). ✓
+- Layer 1 (validator relax + in-partner check) → Task 1. ✓
+- Layer 1 authorization (route gate at all levels) → Task 2. ✓
+- Layer 2 (API surface — no new endpoints) → reused in Tasks 2/5. ✓
+- Layer 3 (Organizations panel, mutual exclusivity, advanced tab still reachable) → Task 5. ✓
+- Layer 4 (RLS backstop) → Task 6 forge test. ✓
+- Layer 5 (call-site sweep, AI tools, patch scheduler) → Task 7. ✓
+- Testing matrix (validator unit, resolver, partner-RLS integration) → Tasks 1/6. ✓
+
+**Placeholder scan:** No TBD/TODO. Every code step shows concrete code. Test steps note "match the file's existing helper" only for fixture-name adaptation, which is honest given real-DB suites; the assertions themselves are concrete.
+
+**Type consistency:** `validateAssignmentTarget` signature unchanged across Tasks 1/2. `OrganizationScopePanel({ policyId, partnerId })` defined in Task 5 Step 3 and consumed identically in Step 5. Assignment shape `{ id, level, targetId, priority }` consistent between panel and API. `ownerScope: 'partner'` unchanged in Task 4.
+
+**Scope:** Single feature, one PR. No decomposition needed.

--- a/docs/superpowers/specs/2026-07-07-partner-owned-policy-selective-org-assignment-design.md
+++ b/docs/superpowers/specs/2026-07-07-partner-owned-policy-selective-org-assignment-design.md
@@ -1,0 +1,127 @@
+# Partner-owned config policies: selective org assignment (library model)
+
+- **Date:** 2026-07-07
+- **Issue:** [#2280](https://github.com/LanternOps/breeze/issues/2280)
+- **Related:** epic #2135 (partner-wide-first), #1724 (established `partner = all orgs`), #2101 (partner-wide UI 400s), #2168 (backup still org-locked)
+- **Status:** Approved — ready for implementation plan
+
+## Problem
+
+The partner-wide-first epic (#2135) gave configuration policies a reusable **ownership** axis (`org_id` XOR `partner_id`): a partner-owned policy is defined once and can span every org. It never added a **selective targeting** axis. The current assignment model forces all-or-one:
+
+- **Partner-owned** policy → `validateAssignmentTarget` (`apps/api/src/services/configurationPolicy.ts:1177-1185`) permits **only** a `partner`-level assignment, which means literally *all* of the partner's orgs.
+- **Org-owned** policy → may only be assigned within its single owning org.
+
+There is no way to define one reusable policy and apply it to a **chosen subset of orgs**. This blocks the natural MSP onboarding workflow: define the standard policy once, then assign it to each customer org as they are brought on. #1724 introduced the `partner = all orgs` constraint that this design relaxes.
+
+## Goals
+
+- A partner-owned config policy acts as a **library definition**: it reaches **zero** devices until explicitly assigned.
+- It can be assigned to a selectable subset of orgs (and to lower levels — site / group / device — within those orgs), one at a time.
+- A single "All orgs" toggle preserves the existing partner-wide behavior.
+- Cross-partner assignment remains impossible (tenant isolation).
+
+## Non-goals
+
+- Bulk org-**group** / org-**tag** targeting. That is a future convenience layer; this design ships per-org multi-select only.
+- Any change to the `backup` feature type, which is still org-locked pending #2168.
+- Changing org-owned policy behavior in any way.
+
+## Why this is low-risk
+
+Today a partner-owned policy already reaches **0 orgs** until it receives a `partner`-level assignment (creation does not auto-assign). Allowing `organization`-level (and lower) assignments is therefore **purely additive** — no existing partner-owned policy changes behavior. The resolver already resolves the new shape; only a single write-side guard blocks it.
+
+## Design
+
+### Layer 1 — Backend validator (the load-bearing change)
+
+**File:** `apps/api/src/services/configurationPolicy.ts` — `validateAssignmentTarget` (currently `:1167-1257`).
+
+Current behavior for a partner-owned policy (`policyOwner.partnerId` set):
+
+```
+if (level !== 'partner')  -> reject ("Partner-wide policies can only be assigned at the Partner level")
+if (targetId !== partnerId) -> reject
+```
+
+New behavior: keep the `partner`-level branch (target must equal the policy's own partner), and add branches for `organization` / `site` / `device_group` / `device` that validate the **target resolves to an org owned by the policy's partner**:
+
+- `organization`: target org exists AND `organizations.partner_id === policyOwner.partnerId`.
+- `site`: site exists AND its org's `partner_id === policyOwner.partnerId`.
+- `device_group`: group exists AND its org's `partner_id === policyOwner.partnerId`.
+- `device`: device exists AND its org's `partner_id === policyOwner.partnerId`.
+
+Any target whose owning org belongs to a different partner → `{ valid: false, error: 'Target is not in this partner' }`. This mirrors the existing org-owned cross-org rejection; it is the tenant-isolation backstop at the app layer (RLS is the real backstop — see Layer 4).
+
+**Unchanged:**
+- The org-owned branches (target must be within the single owning org).
+- The `partner`-level rejection for **org-owned** policies (the footgun guard at `:1241-1252`).
+- Resolution. `resolveEffectiveConfigWithExecutor` (`:1303-1391`) already:
+  - collects `organization`-level assignments for `device.orgId` (`:1354-1356`), plus site/group/device/partner levels, and
+  - admits partner-owned policies in its ownership filter (`:1389-1391`: `orgId IS NULL AND partnerId = org.partnerId`).
+  A partner-owned policy carrying an org-level assignment for the device's org already flows through untouched. **No resolver edit, no schema change, no migration.**
+
+**Authorization:** the assignment write route stays gated on `canManagePartnerWidePolicies(auth)` for partner-owned policies (assigning a partner-wide policy is partner-wide management — single source of truth in `services/partnerWideAccess.ts`).
+
+**AI tools:** `assign_policy_to_target` and `apply_configuration_policy` (`aiToolsConfigPolicy.ts`) call the same `validateAssignmentTarget`, so they are unblocked by this one change — no separate edit, but they must be covered by the sweep (see Layer 5).
+
+### Layer 2 — API surface
+
+No new endpoints. The panel is a thin client over existing routes:
+
+- Orgs for the partner: existing org list endpoint (the same source the create-time ownerScope selector uses).
+- `GET /configuration-policies/:id/assignments` — current assignments.
+- `POST /configuration-policies/:id/assignments` — add (`{ level, targetId, priority? }`).
+- `DELETE /configuration-policies/:id/assignments/:aid` — remove.
+
+### Layer 3 — Frontend "Organizations" panel
+
+**Location:** partner-owned policy detail page (`apps/web/src/components/configurationPolicies/`). Hidden entirely for org-owned policies.
+
+**Behavior:**
+- Master **"All orgs (partner-wide)"** toggle. ON → ensures the single `partner`-level assignment exists (targetId = partnerId). OFF → removes it.
+- Searchable checklist of the partner's orgs. Each checked org = one `organization`-level assignment; unchecking removes it.
+- **Mutual exclusivity:** turning "All orgs" ON removes all per-org `organization` assignments; checking any org removes the `partner` assignment. The two states never coexist, so the data model stays honest (one partner row = all, or N org rows = subset).
+- Site / group / device precision stays in the existing generic **Assignments** tab, which is now reachable for partner-owned policies (previously it would 400 on save — cf. #2101).
+- Mutations go through `runAction` so success/failure is always surfaced (per `apps/web/src/lib/runAction.ts` convention).
+
+**Empty state:** no assignments → "This policy isn't applied to any organizations yet. Toggle *All orgs* or pick organizations below."
+
+### Layer 4 — Tenant isolation (RLS)
+
+`config_policy_assignments` RLS is unchanged and remains the real backstop. The new app-layer validation is defense-in-depth, not the enforcement boundary. A cross-partner assignment insert must still fail at the DB with `42501` even if the validator were bypassed.
+
+### Layer 5 — Call-site sweep (per CLAUDE.md partner-wide playbook step 7)
+
+Before "done", grep every path that creates a config-policy assignment or resolves effective config, to confirm none carries an independent `partner-owned ⇒ partner-level-only` assumption:
+- `routes/configurationPolicies/assignments.ts`
+- `services/aiToolsConfigPolicy.ts` (both assign tools)
+- `services/configurationPolicy.ts` (`assignPolicy`, `validateAssignmentTarget`, resolver)
+- any preview/diff path (`previewConfigChange` at `:1509`)
+
+## Testing
+
+Framework: Vitest (API unit + RLS/integration).
+
+1. **`validateAssignmentTarget` unit tests** (new branches):
+   - partner-owned + `organization` target in-partner → valid.
+   - partner-owned + `organization` target out-of-partner → invalid.
+   - partner-owned + `site`/`device_group`/`device` in-partner → valid; out-of-partner → invalid.
+   - partner-owned + `partner` target = own partner → still valid; different partner → invalid (unchanged).
+   - org-owned behavior unchanged (regression guard).
+
+2. **Resolver test** (real DB):
+   - Partner-owned policy assigned to org A only → device in org A resolves the policy; device in org B (same partner, unassigned) does **not**.
+   - Same policy switched to "All orgs" (partner assignment) → both devices resolve it.
+
+3. **Partner-RLS integration suite** (`configurationPolicyAssignmentsPartnerRls.integration.test.ts` or extend the existing config-policy partner suite):
+   - Cross-partner forged assignment insert → `42501`.
+   - App-layer cross-partner assignment via route → rejected (validation error, not a silent no-op).
+
+## Rollout
+
+Additive; no migration, no data backfill, no feature flag required. Existing partner-owned policies keep their partner-level assignments and behave identically. Ship backend validator + tests first (unblocks AI tools immediately), then the Organizations panel.
+
+## Open questions
+
+None blocking. Future: bulk org-group/org-tag targeting (deliberately deferred).

--- a/docs/superpowers/specs/2026-07-07-partner-owned-policy-selective-org-assignment-design.md
+++ b/docs/superpowers/specs/2026-07-07-partner-owned-policy-selective-org-assignment-design.md
@@ -16,9 +16,9 @@ There is no way to define one reusable policy and apply it to a **chosen subset 
 
 ## Goals
 
-- A partner-owned config policy acts as a **library definition**: it reaches **zero** devices until explicitly assigned.
+- A partner-owned config policy acts as a **library definition**: it is **created empty** (reaches **zero** devices) and reaches nothing until explicitly assigned.
 - It can be assigned to a selectable subset of orgs (and to lower levels — site / group / device — within those orgs), one at a time.
-- A single "All orgs" toggle preserves the existing partner-wide behavior.
+- A single "All orgs" toggle applies it partner-wide when wanted.
 - Cross-partner assignment remains impossible (tenant isolation).
 
 ## Non-goals
@@ -27,11 +27,25 @@ There is no way to define one reusable policy and apply it to a **chosen subset 
 - Any change to the `backup` feature type, which is still org-locked pending #2168.
 - Changing org-owned policy behavior in any way.
 
-## Why this is low-risk
+## Behavior change (scoped and intentional)
 
-Today a partner-owned policy already reaches **0 orgs** until it receives a `partner`-level assignment (creation does not auto-assign). Allowing `organization`-level (and lower) assignments is therefore **purely additive** — no existing partner-owned policy changes behavior. The resolver already resolves the new shape; only a single write-side guard blocks it.
+One deliberate behavior change, plus otherwise-additive work:
+
+- **New partner-owned policies are created empty.** Today `crud.ts:95` auto-seeds a `partner`-level assignment on create, so "All organizations" ownership applies everywhere immediately. The library model removes that seed: a newly-created partner-owned policy reaches **0 devices** until assigned via the Organizations panel. The create-form option is relabeled accordingly.
+- **Existing partner-owned policies are untouched** — they keep their already-seeded `partner`-level assignment and continue to apply to all orgs. No migration, no backfill.
+- **Everything else is additive.** Allowing `organization`/`site`/`device_group`/`device` assignments for partner-owned policies changes no existing data; the resolver already resolves the new shape (only a write-side guard blocks it).
 
 ## Design
+
+### Layer 0 — Create path: stop auto-seeding the partner assignment
+
+**File:** `apps/api/src/routes/configurationPolicies/crud.ts` — POST `/` handler, partner-owned branch (`:82-104`).
+
+Remove the `assignPolicy(policy.id, 'partner', auth.partnerId, ...)` seed at `:95` and its lockstep comment (`:83-94`). The policy is created with **no** assignment. Update the audit `details` to drop `autoAssignedPartnerWide: true`. The transaction reasoning about "committed-but-unassigned" no longer applies — empty is now the intended state.
+
+**File:** `apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx` — the ownerScope radio (`:247-266`).
+
+Relabel the partner option from **"All organizations (partner-wide)"** to **"Partner library — assign to organizations after creating"** with helper copy: *"Create a reusable policy owned by your partner. It applies to no organizations until you assign it on the policy's Organizations tab."* No behavioral field change — still sends `ownerScope: 'partner'`.
 
 ### Layer 1 — Backend validator (the load-bearing change)
 
@@ -61,7 +75,7 @@ Any target whose owning org belongs to a different partner → `{ valid: false, 
   - admits partner-owned policies in its ownership filter (`:1389-1391`: `orgId IS NULL AND partnerId = org.partnerId`).
   A partner-owned policy carrying an org-level assignment for the device's org already flows through untouched. **No resolver edit, no schema change, no migration.**
 
-**Authorization:** the assignment write route stays gated on `canManagePartnerWidePolicies(auth)` for partner-owned policies (assigning a partner-wide policy is partner-wide management — single source of truth in `services/partnerWideAccess.ts`).
+**Authorization (route change required):** today the POST `/:id/assignments` route (`assignments.ts:70-88`) only gates `canManagePartnerWidePolicies(auth)` when `level === 'partner'`. Once partner-owned policies accept lower levels, that gate would be bypassed for an org-level assignment on a partner-owned policy. Extend it: for **any** partner-owned policy (`policy.orgId === null`), require `canManagePartnerWidePolicies(auth)` regardless of level — managing the partner library is a full-partner-access capability in v1. The DELETE route already applies this gate for `policy.orgId === null` (`:152`), so it needs no change. Single source of truth: `services/partnerWideAccess.ts`.
 
 **AI tools:** `assign_policy_to_target` and `apply_configuration_policy` (`aiToolsConfigPolicy.ts`) call the same `validateAssignmentTarget`, so they are unblocked by this one change — no separate edit, but they must be covered by the sweep (see Layer 5).
 
@@ -120,7 +134,7 @@ Framework: Vitest (API unit + RLS/integration).
 
 ## Rollout
 
-Additive; no migration, no data backfill, no feature flag required. Existing partner-owned policies keep their partner-level assignments and behave identically. Ship backend validator + tests first (unblocks AI tools immediately), then the Organizations panel.
+No migration, no data backfill, no feature flag. Existing partner-owned policies keep their seeded `partner`-level assignment and behave identically. The one behavior change — new partner-owned policies created empty — affects only policies created after ship. Ship order: backend validator + route auth + create-path change (with tests) first (this alone unblocks the AI tools and the empty-create model), then the Organizations panel.
 
 ## Open questions
 


### PR DESCRIPTION
## What & why

Partner-owned configuration policies (`org_id NULL`, `partner_id` set) were **all-orgs-or-nothing**: a partner-wide policy was auto-assigned to every org and could only be assigned at the partner level. There was no way to define one reusable policy and apply it to a **chosen subset of orgs** — the natural MSP onboarding flow ("define the standard policy once, assign it to each customer as I bring them on").

This makes partner-owned policies a **reusable library**: created empty, then assigned to a selectable subset of orgs (or all orgs via one toggle).

Closes #2280. Refs #2135 (partner-wide-first epic), #1724 (established `partner = all orgs`).

## The one behavior change

**New partner-owned policies are created empty** (reach 0 devices until assigned). Previously they were auto-seeded with a partner-level assignment (all orgs immediately). **Existing partner-owned policies are untouched** — they keep their seeded assignment. No migration, no backfill.

## What changed (by layer)

| Area | Change |
|---|---|
| **Validator** | `validateAssignmentTarget` now accepts `organization`/`site`/`device_group`/`device` targets for partner-owned policies, gated so the target's owning org belongs to the policy's partner (`organizations.partner_id`). Cross-partner targets rejected. |
| **Write auth** | Any assignment on a partner-owned policy (at any level) requires `canManagePartnerWidePolicies` — enforced identically on the HTTP route **and** the AI-tool path. |
| **Create** | Auto-seed removed on both create paths (HTTP + AI tool); create form relabeled "Partner library — assign to organizations after creating". |
| **UI** | New `OrganizationScopePanel` — a master "All organizations" toggle + a searchable org checklist. "All orgs" and per-org selections are mutually exclusive (one partner-level row, or N org-level rows, never both). Site/group/device precision stays in the advanced Assignments tab. |
| **Patch scheduler** | `resolveDeviceIdsForAssignment` no longer silently returns zero devices for subset assignments on `org_id NULL` policies; org-level assignments resolve only their target org (partner-level still fans out across the partner). |

No schema change, no migration. The resolver already supported the new shape — this PR relaxes the write-side guards and adds the UI + evaluation fan-out.

## Tenant isolation

RLS on `config_policy_assignments` remains the real backstop; the app-layer in-partner check is defense-in-depth. A new integration test forges a cross-partner assignment as `breeze_app` and asserts it fails with `42501`.

## Testing

- Unit: `validateAssignmentTarget` in-partner/out-of-partner branches; route auth (403/201) for partner-owned org-level assignment; empty-create contract on both paths; `OrganizationScopePanel` mutual-exclusivity incl. multi-org → All-orgs delete-ordering; patch-scheduler subset resolution.
- Integration (real Postgres): partner-owned policy assigned to one org resolves only for that org (sibling org unaffected); cross-partner forge → `42501`.
- Full suites green: API 11844, web 3127.

## Reviewed

Built task-by-task with per-task spec+quality review, plus a whole-branch review — no Critical/Important defects; the write/read/evaluate paths were verified consistent. Two deferred non-blocking follow-ups: restore a "backup unavailable on partner-wide policies" note on the create form (backup still org-locked, #2168); and minor test-hardening (assert patch-scheduler WHERE args; `site`/`device_group` validator unit tests).

Design + plan: `docs/superpowers/specs/2026-07-07-partner-owned-policy-selective-org-assignment-design.md`, `docs/superpowers/plans/2026-07-08-partner-owned-policy-selective-org-assignment.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
