### PR TITLE
feat(ticketing): create a ticket from an AI conversation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 # SR-007: least-privilege default. CI runs on every PR (including forks) and
 # only needs to read the repo. Any job needing more must opt in per-job.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
           cache-dependency-path: agent/go.sum
 
       - name: Initialize CodeQL

--- a/.github/workflows/dev-build-agent.yml
+++ b/.github/workflows/dev-build-agent.yml
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   build-arm64:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '10.33.4'
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 # Least-privilege default; the SARIF-uploading job opts into
 # security-events: write per-job below.

--- a/apps/api/src/routes/ai.ticket.test.ts
+++ b/apps/api/src/routes/ai.ticket.test.ts
@@ -189,6 +189,7 @@ import { db } from '../db';
 import { getSessionMessages } from '../services/aiAgent';
 import { recordUsage } from '../services/aiCostTracker';
 import { draftTicketFromTranscript, ThinTranscriptError } from '../services/aiTicketDraft';
+import { TicketServiceError } from '../services/ticketService';
 
 const partnerAuth = authHarness.partnerAuth;
 const orgAuth = authHarness.orgAuth;
@@ -222,7 +223,7 @@ describe('POST /ai/sessions/:id/ticket-draft', () => {
     vi.mocked(db.select).mockReturnValue(selectRows([{ name: 'Acme Co' }]) as any);
   });
 
-  function postDraft(sessionId: string, auth = partnerAuth) {
+  function postDraft(sessionId: string, auth: any = partnerAuth) {
     authHarness.currentAuth.value = auth;
     return app.request(`/ai/sessions/${sessionId}/ticket-draft`, {
       method: 'POST',
@@ -280,6 +281,38 @@ describe('POST /ai/sessions/:id/ticket-draft', () => {
     expect(recordUsage).toHaveBeenCalledWith('s1', 'org1', 'claude-test', 10, 5, false);
   });
 
+  it('enriches a draft with the session device hostname', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectRows([{ name: 'Acme Co' }]) as any)
+      .mockReturnValueOnce(selectRows([{ hostname: 'WKS-04' }]) as any);
+    vi.mocked(getSessionMessages).mockResolvedValueOnce({
+      session: { id: 's1', orgId: 'org1', deviceId: 'dev1', model: null, createdAt: new Date(), contextSnapshot: null },
+      messages: [
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'fixed' },
+      ],
+    } as any);
+    vi.mocked(draftTicketFromTranscript).mockResolvedValueOnce({
+      subject: 'S',
+      problemSummary: 'P',
+      resolutionSummary: 'R',
+      wasFixed: true,
+      suggestedTimeMinutes: 15,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+
+    const res = await postDraft('s1', partnerAuth);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      data: {
+        deviceId: 'dev1',
+        deviceHostname: 'WKS-04',
+      },
+    });
+  });
+
   it('404 when the session is not reachable', async () => {
     vi.mocked(getSessionMessages).mockResolvedValueOnce(null);
 
@@ -298,6 +331,21 @@ describe('POST /ai/sessions/:id/ticket-draft', () => {
     const res = await postDraft('s1', partnerAuth);
 
     expect(res.status).toBe(422);
+  });
+
+  it('502 on a generic summarizer failure', async () => {
+    vi.mocked(getSessionMessages).mockResolvedValueOnce({
+      session: { id: 's1', orgId: 'org1', deviceId: null, model: null, createdAt: new Date(), contextSnapshot: null },
+      messages: [
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'working' },
+      ],
+    } as any);
+    vi.mocked(draftTicketFromTranscript).mockRejectedValueOnce(new Error('anthropic down'));
+
+    const res = await postDraft('s1', partnerAuth);
+
+    expect(res.status).toBe(502);
   });
 });
 
@@ -319,7 +367,7 @@ describe('POST /ai/sessions/:id/ticket', () => {
 
   const body = { subject: 'S', description: 'P', status: 'open' as const, timeMinutes: 15, billable: true };
 
-  function postTicket(sessionId: string, auth: typeof partnerAuth | typeof orgAuth = partnerAuth, payload: unknown = body) {
+  function postTicket(sessionId: string, auth: any = partnerAuth, payload: unknown = body) {
     authHarness.currentAuth.value = auth;
     return app.request(`/ai/sessions/${sessionId}/ticket`, {
       method: 'POST',
@@ -337,6 +385,14 @@ describe('POST /ai/sessions/:id/ticket', () => {
     expect(json).toMatchObject({ resolved: false, timeLogged: true });
   });
 
+  it('does not log a time entry when timeMinutes is zero', async () => {
+    const res = await postTicket('s1', partnerAuth, { ...body, timeMinutes: 0 });
+
+    expect(res.status).toBe(201);
+    expect(createTimeEntryMock).not.toHaveBeenCalled();
+    expect(await res.json()).toMatchObject({ timeLogged: false });
+  });
+
   it('resolves the ticket and sets the resolution note', async () => {
     const res = await postTicket('s1', partnerAuth, { ...body, status: 'resolved', resolutionNote: 'Fixed it.' });
     expect(res.status).toBe(201);
@@ -344,11 +400,52 @@ describe('POST /ai/sessions/:id/ticket', () => {
     expect((await res.json()).resolved).toBe(true);
   });
 
+  it('keeps the ticket when resolving fails', async () => {
+    changeStatusMock.mockRejectedValueOnce(new Error('transition failed'));
+
+    const res = await postTicket('s1', partnerAuth, { ...body, status: 'resolved', resolutionNote: 'Fixed it.' });
+
+    expect(res.status).toBe(201);
+    expect(changeStatusMock).toHaveBeenCalledWith('t1', { status: 'resolved' }, { resolutionNote: 'Fixed it.' }, expect.any(Object));
+    expect(await res.json()).toMatchObject({
+      data: { id: 't1', ticketNumber: 'ORG-1' },
+      resolved: false,
+    });
+  });
+
+  it('keeps the ticket when time entry logging fails', async () => {
+    createTimeEntryMock.mockRejectedValueOnce(new Error('rls'));
+
+    const res = await postTicket('s1', partnerAuth, body);
+
+    expect(res.status).toBe(201);
+    expect(createTimeEntryMock).toHaveBeenCalledTimes(1);
+    expect(await res.json()).toMatchObject({
+      data: { id: 't1', ticketNumber: 'ORG-1' },
+      timeLogged: false,
+    });
+  });
+
   it('does not log time for an org-scope caller', async () => {
     const res = await postTicket('s1', orgAuth, body);
     expect(res.status).toBe(201);
     expect(createTimeEntryMock).not.toHaveBeenCalled();
     expect((await res.json()).timeLogged).toBe(false);
+  });
+
+  it('logs time for a system-scope caller', async () => {
+    const systemAuth = {
+      ...partnerAuth,
+      scope: 'system' as const,
+      partnerId: null,
+      orgId: null,
+    };
+
+    const res = await postTicket('s1', systemAuth, body);
+
+    expect(res.status).toBe(201);
+    expect(createTimeEntryMock).toHaveBeenCalledTimes(1);
+    expect(await res.json()).toMatchObject({ timeLogged: true });
   });
 
   it('drops deviceId when the caller fails site scope', async () => {
@@ -364,5 +461,14 @@ describe('POST /ai/sessions/:id/ticket', () => {
 
   it('400 when resolving without a note (schema)', async () => {
     expect((await postTicket('s1', partnerAuth, { ...body, status: 'resolved' })).status).toBe(400);
+  });
+
+  it('maps TicketServiceError status codes', async () => {
+    createTicketMock.mockRejectedValueOnce(new TicketServiceError('nope', 409));
+
+    const res = await postTicket('s1', partnerAuth, body);
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: 'nope' });
   });
 });

--- a/apps/api/src/routes/ai.ticket.test.ts
+++ b/apps/api/src/routes/ai.ticket.test.ts
@@ -11,8 +11,23 @@ const authHarness = vi.hoisted(() => {
     orgCondition: () => undefined,
     canAccessOrg: (id: string) => id === 'org1',
   };
-  return { currentAuth: { value: partnerAuth }, partnerAuth };
+  const orgAuth = {
+    ...partnerAuth,
+    scope: 'organization' as const,
+    partnerId: null,
+    orgId: 'org1',
+  };
+  return { currentAuth: { value: partnerAuth as typeof partnerAuth | typeof orgAuth }, partnerAuth, orgAuth };
 });
+
+const routeMocks = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  createTicketMock: vi.fn(),
+  changeStatusMock: vi.fn(),
+  createTimeEntryMock: vi.fn(),
+  deviceInSiteScopeMock: vi.fn(),
+  writeRouteAuditMock: vi.fn(),
+}));
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
@@ -87,11 +102,12 @@ vi.mock('../middleware/auth', () => ({
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
   requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
   requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  hasPermission: vi.fn(() => false),
 }));
 
 vi.mock('../services/aiAgent', () => ({
   createSession: vi.fn(),
-  getSession: vi.fn(),
+  getSession: routeMocks.getSessionMock,
   listSessions: vi.fn(),
   closeSession: vi.fn(),
   getSessionMessages: vi.fn(),
@@ -118,6 +134,28 @@ vi.mock('../services/aiTicketDraft', () => ({
   },
 }));
 
+vi.mock('../services/ticketService', () => ({
+  createTicket: routeMocks.createTicketMock,
+  changeTicketStatus: routeMocks.changeStatusMock,
+  TicketServiceError: class TicketServiceError extends Error {
+    status: number;
+
+    constructor(message: string, status = 400) {
+      super(message);
+      this.name = 'TicketServiceError';
+      this.status = status;
+    }
+  },
+}));
+
+vi.mock('../services/timeEntryService', () => ({
+  createTimeEntry: routeMocks.createTimeEntryMock,
+}));
+
+vi.mock('./tickets/siteScope', () => ({
+  deviceInSiteScope: routeMocks.deviceInSiteScopeMock,
+}));
+
 vi.mock('../services/streamingSessionManager', () => ({
   streamingSessionManager: {
     getOrCreate: vi.fn(),
@@ -135,7 +173,7 @@ vi.mock('../services/aiAgentSdk', () => ({
 }));
 
 vi.mock('../services/auditEvents', () => ({
-  writeRouteAudit: vi.fn(),
+  writeRouteAudit: routeMocks.writeRouteAuditMock,
 }));
 
 vi.mock('../services/sentry', () => ({
@@ -153,6 +191,14 @@ import { recordUsage } from '../services/aiCostTracker';
 import { draftTicketFromTranscript, ThinTranscriptError } from '../services/aiTicketDraft';
 
 const partnerAuth = authHarness.partnerAuth;
+const orgAuth = authHarness.orgAuth;
+const {
+  getSessionMock,
+  createTicketMock,
+  changeStatusMock,
+  createTimeEntryMock,
+  deviceInSiteScopeMock,
+} = routeMocks;
 
 function selectRows(rows: unknown[]) {
   return {
@@ -251,5 +297,71 @@ describe('POST /ai/sessions/:id/ticket-draft', () => {
     const res = await postDraft('s1', partnerAuth);
 
     expect(res.status).toBe(422);
+  });
+});
+
+describe('POST /ai/sessions/:id/ticket', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authHarness.currentAuth.value = partnerAuth;
+    app = new Hono();
+    app.route('/ai', aiRoutes);
+
+    getSessionMock.mockResolvedValue({ id: 's1', orgId: 'org1', deviceId: 'dev1', model: null });
+    createTicketMock.mockResolvedValue({ id: 't1', ticketNumber: 'ORG-1', orgId: 'org1', status: 'new' });
+    deviceInSiteScopeMock.mockResolvedValue(true);
+    changeStatusMock.mockResolvedValue({ id: 't1', status: 'resolved' });
+    createTimeEntryMock.mockResolvedValue({ id: 'te1' });
+  });
+
+  const body = { subject: 'S', description: 'P', status: 'open' as const, timeMinutes: 15, billable: true };
+
+  function postTicket(sessionId: string, auth: typeof partnerAuth | typeof orgAuth = partnerAuth, payload: unknown = body) {
+    authHarness.currentAuth.value = auth;
+    return app.request(`/ai/sessions/${sessionId}/ticket`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  }
+
+  it('creates a ticket with source ai and logs time for a partner-scope caller', async () => {
+    const res = await postTicket('s1', partnerAuth, body);
+    expect(res.status).toBe(201);
+    expect(createTicketMock).toHaveBeenCalledWith(expect.objectContaining({ source: 'ai', orgId: 'org1', deviceId: 'dev1' }), expect.any(Object));
+    expect(createTimeEntryMock).toHaveBeenCalledTimes(1);
+    const json = await res.json();
+    expect(json).toMatchObject({ resolved: false, timeLogged: true });
+  });
+
+  it('resolves the ticket and sets the resolution note', async () => {
+    const res = await postTicket('s1', partnerAuth, { ...body, status: 'resolved', resolutionNote: 'Fixed it.' });
+    expect(res.status).toBe(201);
+    expect(changeStatusMock).toHaveBeenCalledWith('t1', { status: 'resolved' }, { resolutionNote: 'Fixed it.' }, expect.any(Object));
+    expect((await res.json()).resolved).toBe(true);
+  });
+
+  it('does not log time for an org-scope caller', async () => {
+    const res = await postTicket('s1', orgAuth, body);
+    expect(res.status).toBe(201);
+    expect(createTimeEntryMock).not.toHaveBeenCalled();
+    expect((await res.json()).timeLogged).toBe(false);
+  });
+
+  it('drops deviceId when the caller fails site scope', async () => {
+    deviceInSiteScopeMock.mockResolvedValue(false);
+    await postTicket('s1', partnerAuth, body);
+    expect(createTicketMock).toHaveBeenCalledWith(expect.objectContaining({ deviceId: undefined }), expect.any(Object));
+  });
+
+  it('404 when the session is unreachable', async () => {
+    getSessionMock.mockResolvedValue(null);
+    expect((await postTicket('sX', partnerAuth, body)).status).toBe(404);
+  });
+
+  it('400 when resolving without a note (schema)', async () => {
+    expect((await postTicket('s1', partnerAuth, { ...body, status: 'resolved' })).status).toBe(400);
   });
 });

--- a/apps/api/src/routes/ai.ticket.test.ts
+++ b/apps/api/src/routes/ai.ticket.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const authHarness = vi.hoisted(() => {
+  const partnerAuth = {
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    scope: 'partner' as const,
+    partnerId: 'partner-111',
+    orgId: null,
+    accessibleOrgIds: ['org1'],
+    orgCondition: () => undefined,
+    canAccessOrg: (id: string) => id === 'org1',
+  };
+  return { currentAuth: { value: partnerAuth }, partnerAuth };
+});
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  aiSessions: {
+    id: 'aiSessions.id',
+    orgId: 'aiSessions.orgId',
+    flaggedAt: 'aiSessions.flaggedAt',
+    flaggedBy: 'aiSessions.flaggedBy',
+    flagReason: 'aiSessions.flagReason',
+  },
+  aiMessages: {
+    id: 'aiMessages.id',
+    sessionId: 'aiMessages.sessionId',
+  },
+  aiToolExecutions: {
+    id: 'aiToolExecutions.id',
+    sessionId: 'aiToolExecutions.sessionId',
+    status: 'aiToolExecutions.status',
+    toolName: 'aiToolExecutions.toolName',
+    createdAt: 'aiToolExecutions.createdAt',
+    durationMs: 'aiToolExecutions.durationMs',
+    toolInput: 'aiToolExecutions.toolInput',
+    approvedBy: 'aiToolExecutions.approvedBy',
+    approvedAt: 'aiToolExecutions.approvedAt',
+    errorMessage: 'aiToolExecutions.errorMessage',
+    completedAt: 'aiToolExecutions.completedAt',
+  },
+  auditLogs: {
+    id: 'auditLogs.id',
+    orgId: 'auditLogs.orgId',
+    action: 'auditLogs.action',
+    timestamp: 'auditLogs.timestamp',
+    actorType: 'auditLogs.actorType',
+    actorEmail: 'auditLogs.actorEmail',
+    resourceType: 'auditLogs.resourceType',
+    resourceId: 'auditLogs.resourceId',
+    result: 'auditLogs.result',
+    errorMessage: 'auditLogs.errorMessage',
+    details: 'auditLogs.details',
+  },
+  aiActionPlans: {
+    id: 'aiActionPlans.id',
+    status: 'aiActionPlans.status',
+    approvedBy: 'aiActionPlans.approvedBy',
+    approvedAt: 'aiActionPlans.approvedAt',
+  },
+  organizations: {
+    id: 'organizations.id',
+    name: 'organizations.name',
+  },
+  devices: {
+    id: 'devices.id',
+    hostname: 'devices.hostname',
+  },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', authHarness.currentAuth.value);
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../services/aiAgent', () => ({
+  createSession: vi.fn(),
+  getSession: vi.fn(),
+  listSessions: vi.fn(),
+  closeSession: vi.fn(),
+  getSessionMessages: vi.fn(),
+  handleApproval: vi.fn(),
+  searchSessions: vi.fn(),
+  listM365Connections: vi.fn(),
+  resolveDefaultModel: vi.fn(() => 'claude-test'),
+}));
+
+vi.mock('../services/aiCostTracker', () => ({
+  getSessionHistory: vi.fn(),
+  getUsageSummary: vi.fn(),
+  updateBudget: vi.fn(),
+  recordUsage: vi.fn(),
+}));
+
+vi.mock('../services/aiTicketDraft', () => ({
+  draftTicketFromTranscript: vi.fn(),
+  ThinTranscriptError: class ThinTranscriptError extends Error {
+    constructor() {
+      super('Not enough conversation to draft a ticket');
+      this.name = 'ThinTranscriptError';
+    }
+  },
+}));
+
+vi.mock('../services/streamingSessionManager', () => ({
+  streamingSessionManager: {
+    getOrCreate: vi.fn(),
+    get: vi.fn(),
+    remove: vi.fn(),
+    tryTransitionToProcessing: vi.fn(),
+    interrupt: vi.fn(),
+    startTurnTimeout: vi.fn(),
+  },
+}));
+
+vi.mock('../services/aiAgentSdk', () => ({
+  runPreFlightChecks: vi.fn(),
+  abortActivePlan: vi.fn(),
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('../services/effectiveSettings', () => ({
+  assertNotLocked: vi.fn(),
+}));
+
+import { aiRoutes } from './ai';
+import { db } from '../db';
+import { getSessionMessages } from '../services/aiAgent';
+import { recordUsage } from '../services/aiCostTracker';
+import { draftTicketFromTranscript, ThinTranscriptError } from '../services/aiTicketDraft';
+
+const partnerAuth = authHarness.partnerAuth;
+
+function selectRows(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+describe('POST /ai/sessions/:id/ticket-draft', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authHarness.currentAuth.value = partnerAuth;
+    app = new Hono();
+    app.route('/ai', aiRoutes);
+
+    vi.mocked(db.select).mockReturnValue(selectRows([{ name: 'Acme Co' }]) as any);
+  });
+
+  function postDraft(sessionId: string, auth = partnerAuth) {
+    authHarness.currentAuth.value = auth;
+    return app.request(`/ai/sessions/${sessionId}/ticket-draft`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+  }
+
+  it('returns a draft assembled from the session + summarizer', async () => {
+    const createdAt = new Date(Date.now() - 25 * 60000);
+    vi.mocked(getSessionMessages).mockResolvedValueOnce({
+      session: { id: 's1', orgId: 'org1', deviceId: null, model: null, createdAt, contextSnapshot: null },
+      messages: [
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'fixed' },
+      ],
+    } as any);
+    vi.mocked(draftTicketFromTranscript).mockResolvedValueOnce({
+      subject: 'S',
+      problemSummary: 'P',
+      resolutionSummary: 'R',
+      wasFixed: true,
+      suggestedTimeMinutes: 15,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+
+    const res = await postDraft('s1', partnerAuth);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toMatchObject({
+      subject: 'S',
+      problemSummary: 'P',
+      resolutionSummary: 'R',
+      suggestedStatus: 'resolved',
+      suggestedTimeMinutes: 15,
+      orgId: 'org1',
+      orgName: 'Acme Co',
+      deviceId: null,
+      deviceHostname: null,
+    });
+    expect(getSessionMessages).toHaveBeenCalledWith('s1', partnerAuth);
+    expect(draftTicketFromTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'fixed' },
+        ],
+        contextSnapshot: null,
+        elapsedMinutes: expect.any(Number),
+        model: 'claude-test',
+      })
+    );
+    expect(recordUsage).toHaveBeenCalledWith('s1', 'org1', 'claude-test', 10, 5, false);
+  });
+
+  it('404 when the session is not reachable', async () => {
+    vi.mocked(getSessionMessages).mockResolvedValueOnce(null);
+
+    const res = await postDraft('sX', partnerAuth);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('422 on a thin transcript', async () => {
+    vi.mocked(getSessionMessages).mockResolvedValueOnce({
+      session: { id: 's1', orgId: 'org1', deviceId: null, model: null, createdAt: new Date(), contextSnapshot: null },
+      messages: [{ role: 'user', content: 'hi' }],
+    } as any);
+    vi.mocked(draftTicketFromTranscript).mockRejectedValueOnce(new ThinTranscriptError());
+
+    const res = await postDraft('s1', partnerAuth);
+
+    expect(res.status).toBe(422);
+  });
+});

--- a/apps/api/src/routes/ai.ticket.test.ts
+++ b/apps/api/src/routes/ai.ticket.test.ts
@@ -264,6 +264,7 @@ describe('POST /ai/sessions/:id/ticket-draft', () => {
       deviceId: null,
       deviceHostname: null,
     });
+    expect(body.data).not.toHaveProperty('wasFixed');
     expect(getSessionMessages).toHaveBeenCalledWith('s1', partnerAuth);
     expect(draftTicketFromTranscript).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -389,7 +389,9 @@ aiRoutes.post(
       });
     } catch (err) {
       if (err instanceof ThinTranscriptError) return c.json({ error: err.message }, 422);
-      return c.json({ error: 'Could not draft a ticket from this conversation' }, 422);
+      console.error('[AI] Ticket draft failed:', err);
+      captureException(err);
+      return c.json({ error: 'Could not draft a ticket from this conversation' }, 502);
     }
 
     // Best-effort cost accounting; never fails the request.
@@ -418,7 +420,6 @@ aiRoutes.post(
       subject: draft.subject,
       problemSummary: draft.problemSummary,
       resolutionSummary: draft.resolutionSummary,
-      wasFixed: draft.wasFixed,
       suggestedStatus: draft.wasFixed ? 'resolved' : 'open',
       suggestedTimeMinutes: draft.suggestedTimeMinutes,
       elapsedMinutes,
@@ -466,7 +467,10 @@ aiRoutes.post(
       try {
         await changeTicketStatus(ticket.id, { status: 'resolved' }, { resolutionNote: body.resolutionNote }, actor);
         resolved = true;
-      } catch { /* ticket persists; resolved:false reported */ }
+      } catch (err) {
+        console.error(`[AI] Ticket ${ticket.id} created but resolve failed:`, err);
+        captureException(err);
+      }
     }
 
     let timeLogged = false;
@@ -479,7 +483,9 @@ aiRoutes.post(
           timeActorFrom(c),
         );
         timeLogged = true;
-      } catch { /* non-fatal */ }
+      } catch (err) {
+        console.error(`[AI] Ticket ${ticket.id} created but time entry failed:`, err);
+      }
     }
 
     writeRouteAudit(c, { orgId: session.orgId, action: 'ai.session.create_ticket', resourceType: 'ticket', resourceId: ticket.id });

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -18,15 +18,16 @@ import {
   getSessionMessages,
   handleApproval,
   searchSessions,
-  listM365Connections
+  listM365Connections,
+  resolveDefaultModel
 } from '../services/aiAgent';
 import { runPreFlightChecks, abortActivePlan } from '../services/aiAgentSdk';
 import { streamingSessionManager } from '../services/streamingSessionManager';
-import { getUsageSummary, updateBudget, getSessionHistory } from '../services/aiCostTracker';
+import { getUsageSummary, updateBudget, getSessionHistory, recordUsage } from '../services/aiCostTracker';
 import { writeRouteAudit } from '../services/auditEvents';
 import { assertNotLocked } from '../services/effectiveSettings';
 import { db } from '../db';
-import { aiSessions, aiMessages, aiToolExecutions, auditLogs } from '../db/schema';
+import { aiSessions, aiMessages, aiToolExecutions, auditLogs, organizations, devices } from '../db/schema';
 import { eq, and, desc, gte, lte, count, avg, sql as drizzleSql } from 'drizzle-orm';
 import { PERMISSIONS } from '../services/permissions';
 import {
@@ -42,6 +43,8 @@ import { captureException } from '../services/sentry';
 import { getConfig } from '../config/validate';
 import { OpenAICompatibleProvider } from '../services/llm/openaiCompatibleProvider';
 import { OpenAISessionManager } from '../services/llm/openaiSessionManager';
+import { draftTicketFromTranscript, ThinTranscriptError } from '../services/aiTicketDraft';
+import type { AiTicketDraft } from '@breeze/shared';
 
 // Provider check that tolerates an unvalidated config: route unit tests never
 // call validateConfig(), and getConfig() throws in that state. Without a
@@ -115,6 +118,7 @@ function generateSessionTitle(content: string): string {
 export const aiRoutes = new Hono();
 const requireAiRead = requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action);
 const requireAiWrite = requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action);
+const requireTicketsWrite = requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action);
 
 aiRoutes.use('*', authMiddleware);
 
@@ -352,6 +356,74 @@ aiRoutes.delete(
     });
 
     return c.json({ success: true });
+  }
+);
+
+// POST /sessions/:id/ticket-draft - Draft a support ticket from an AI conversation
+aiRoutes.post(
+  '/sessions/:id/ticket-draft',
+  requireScope('organization', 'partner', 'system'),
+  requireTicketsWrite,
+  async (c) => {
+    const auth = c.get('auth');
+    const sessionId = c.req.param('id')!;
+
+    const loaded = await getSessionMessages(sessionId, auth);
+    if (!loaded) return c.json({ error: 'Session not found' }, 404);
+    const { session, messages } = loaded;
+
+    const elapsedMinutes = Math.max(0, Math.round((Date.now() - new Date(session.createdAt).getTime()) / 60000));
+    const model = session.model ?? resolveDefaultModel();
+
+    let draft;
+    try {
+      draft = await draftTicketFromTranscript({
+        messages: messages.map((m) => ({ role: m.role, content: m.content })),
+        contextSnapshot: session.contextSnapshot,
+        elapsedMinutes,
+        model,
+      });
+    } catch (err) {
+      if (err instanceof ThinTranscriptError) return c.json({ error: err.message }, 422);
+      return c.json({ error: 'Could not draft a ticket from this conversation' }, 422);
+    }
+
+    // Best-effort cost accounting; never fails the request.
+    try {
+      await recordUsage(sessionId, session.orgId, model, draft.inputTokens, draft.outputTokens, false);
+    } catch {
+      // non-fatal
+    }
+
+    const [org] = await db
+      .select({ name: organizations.name })
+      .from(organizations)
+      .where(eq(organizations.id, session.orgId))
+      .limit(1);
+    let deviceHostname: string | null = null;
+    if (session.deviceId) {
+      const [dev] = await db
+        .select({ hostname: devices.hostname })
+        .from(devices)
+        .where(eq(devices.id, session.deviceId))
+        .limit(1);
+      deviceHostname = dev?.hostname ?? null;
+    }
+
+    const payload: AiTicketDraft = {
+      subject: draft.subject,
+      problemSummary: draft.problemSummary,
+      resolutionSummary: draft.resolutionSummary,
+      wasFixed: draft.wasFixed,
+      suggestedStatus: draft.wasFixed ? 'resolved' : 'open',
+      suggestedTimeMinutes: draft.suggestedTimeMinutes,
+      elapsedMinutes,
+      orgId: session.orgId,
+      orgName: org?.name ?? null,
+      deviceId: session.deviceId ?? null,
+      deviceHostname,
+    };
+    return c.json({ data: payload });
   }
 );
 

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -24,6 +24,8 @@ import {
 import { runPreFlightChecks, abortActivePlan } from '../services/aiAgentSdk';
 import { streamingSessionManager } from '../services/streamingSessionManager';
 import { getUsageSummary, updateBudget, getSessionHistory, recordUsage } from '../services/aiCostTracker';
+import { createTicket, changeTicketStatus, TicketServiceError } from '../services/ticketService';
+import { createTimeEntry } from '../services/timeEntryService';
 import { writeRouteAudit } from '../services/auditEvents';
 import { assertNotLocked } from '../services/effectiveSettings';
 import { db } from '../db';
@@ -44,7 +46,9 @@ import { getConfig } from '../config/validate';
 import { OpenAICompatibleProvider } from '../services/llm/openaiCompatibleProvider';
 import { OpenAISessionManager } from '../services/llm/openaiSessionManager';
 import { draftTicketFromTranscript, ThinTranscriptError } from '../services/aiTicketDraft';
-import type { AiTicketDraft } from '@breeze/shared';
+import { createTicketFromChatSchema, type AiTicketDraft } from '@breeze/shared';
+import { deviceInSiteScope } from './tickets/siteScope';
+import { timeActorFrom } from './timeEntries/timeEntries';
 
 // Provider check that tolerates an unvalidated config: route unit tests never
 // call validateConfig(), and getConfig() throws in that state. Without a
@@ -424,6 +428,62 @@ aiRoutes.post(
       deviceHostname,
     };
     return c.json({ data: payload });
+  }
+);
+
+aiRoutes.post(
+  '/sessions/:id/ticket',
+  requireScope('organization', 'partner', 'system'),
+  requireTicketsWrite,
+  zValidator('json', createTicketFromChatSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const sessionId = c.req.param('id')!;
+    const body = c.req.valid('json');
+
+    const session = await getSession(sessionId, auth);
+    if (!session) return c.json({ error: 'Session not found' }, 404);
+
+    // deviceId comes from the session; drop it if a site-restricted caller can't reach the device.
+    let deviceId: string | undefined = session.deviceId ?? undefined;
+    if (deviceId && !(await deviceInSiteScope(auth, deviceId))) deviceId = undefined;
+
+    const actor = { userId: auth.user.id, name: auth.user.name, email: auth.user.email };
+
+    let ticket;
+    try {
+      ticket = await createTicket(
+        { source: 'ai', orgId: session.orgId, subject: body.subject, description: body.description, deviceId, priority: body.priority },
+        actor,
+      );
+    } catch (err) {
+      if (err instanceof TicketServiceError) return c.json({ error: err.message }, err.status ?? 400);
+      throw err;
+    }
+
+    let resolved = false;
+    if (body.status === 'resolved') {
+      try {
+        await changeTicketStatus(ticket.id, { status: 'resolved' }, { resolutionNote: body.resolutionNote }, actor);
+        resolved = true;
+      } catch { /* ticket persists; resolved:false reported */ }
+    }
+
+    let timeLogged = false;
+    if (body.timeMinutes > 0 && (auth.scope === 'partner' || auth.scope === 'system')) {
+      try {
+        const endedAt = new Date();
+        const startedAt = new Date(endedAt.getTime() - body.timeMinutes * 60_000);
+        await createTimeEntry(
+          { ticketId: ticket.id, startedAt, endedAt, description: 'Logged from AI conversation', isBillable: body.billable },
+          timeActorFrom(c),
+        );
+        timeLogged = true;
+      } catch { /* non-fatal */ }
+    }
+
+    writeRouteAudit(c, { orgId: session.orgId, action: 'ai.session.create_ticket', resourceType: 'ticket', resourceId: ticket.id });
+    return c.json({ data: ticket, resolved, timeLogged }, 201);
   }
 );
 

--- a/apps/api/src/services/aiTicketDraft.test.ts
+++ b/apps/api/src/services/aiTicketDraft.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const createMock = vi.fn();
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class { messages = { create: createMock }; },
+}));
+
+import { draftTicketFromTranscript, ThinTranscriptError } from './aiTicketDraft';
+
+function reply(json: object, inTok = 100, outTok = 50) {
+  return { content: [{ type: 'text', text: JSON.stringify(json) }], usage: { input_tokens: inTok, output_tokens: outTok } };
+}
+
+const transcript = [
+  { role: 'user', content: 'Outlook will not open on my PC' },
+  { role: 'assistant', content: 'I rebuilt your mail profile; it is working now.' },
+];
+
+beforeEach(() => createMock.mockReset());
+
+describe('draftTicketFromTranscript', () => {
+  it('returns a structured draft and maps wasFixed', async () => {
+    createMock.mockResolvedValueOnce(reply({ subject: 'Outlook would not open', problemSummary: 'Outlook would not start.', resolutionSummary: 'Rebuilt the mail profile.', wasFixed: true, suggestedTimeMinutes: 15 }));
+    const r = await draftTicketFromTranscript({ messages: transcript, contextSnapshot: null, elapsedMinutes: 25, model: 'claude-x' });
+    expect(r.wasFixed).toBe(true);
+    expect(r.subject).toBe('Outlook would not open');
+    expect(r.outputTokens).toBe(50);
+  });
+
+  it('clamps suggestedTimeMinutes to the elapsed ceiling', async () => {
+    createMock.mockResolvedValueOnce(reply({ subject: 's', problemSummary: 'p', resolutionSummary: '', wasFixed: false, suggestedTimeMinutes: 999 }));
+    const r = await draftTicketFromTranscript({ messages: transcript, contextSnapshot: null, elapsedMinutes: 25, model: 'claude-x' });
+    expect(r.suggestedTimeMinutes).toBeLessThanOrEqual(25);
+  });
+
+  it('retries once on invalid JSON then throws', async () => {
+    createMock.mockResolvedValue({ content: [{ type: 'text', text: 'not json' }], usage: {} });
+    await expect(draftTicketFromTranscript({ messages: transcript, contextSnapshot: null, elapsedMinutes: 25, model: 'claude-x' })).rejects.toThrow();
+    expect(createMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws ThinTranscriptError when there is no assistant turn', async () => {
+    await expect(draftTicketFromTranscript({ messages: [{ role: 'user', content: 'hi' }], contextSnapshot: null, elapsedMinutes: 5, model: 'claude-x' })).rejects.toBeInstanceOf(ThinTranscriptError);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiTicketDraft.test.ts
+++ b/apps/api/src/services/aiTicketDraft.test.ts
@@ -33,6 +33,24 @@ describe('draftTicketFromTranscript', () => {
     expect(r.suggestedTimeMinutes).toBeLessThanOrEqual(25);
   });
 
+  it('blanks resolutionSummary when the issue was not fixed', async () => {
+    createMock.mockResolvedValueOnce(reply({ subject: 's', problemSummary: 'p', resolutionSummary: 'leaked resolution text', wasFixed: false, suggestedTimeMinutes: 5 }));
+    const r = await draftTicketFromTranscript({ messages: transcript, contextSnapshot: null, elapsedMinutes: 25, model: 'claude-x' });
+    expect(r.resolutionSummary).toBe('');
+  });
+
+  it('recovers when retry returns valid JSON', async () => {
+    createMock
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: 'not json' }], usage: {} })
+      .mockResolvedValueOnce(reply({ subject: 'Recovered', problemSummary: 'p', resolutionSummary: 'r', wasFixed: true, suggestedTimeMinutes: 5 }));
+
+    const r = await draftTicketFromTranscript({ messages: transcript, contextSnapshot: null, elapsedMinutes: 25, model: 'claude-x' });
+
+    expect(r.subject).toBe('Recovered');
+    expect(r.resolutionSummary).toBe('r');
+    expect(createMock).toHaveBeenCalledTimes(2);
+  });
+
   it('retries once on invalid JSON then throws', async () => {
     createMock.mockResolvedValue({ content: [{ type: 'text', text: 'not json' }], usage: {} });
     await expect(draftTicketFromTranscript({ messages: transcript, contextSnapshot: null, elapsedMinutes: 25, model: 'claude-x' })).rejects.toThrow();

--- a/apps/api/src/services/aiTicketDraft.ts
+++ b/apps/api/src/services/aiTicketDraft.ts
@@ -1,0 +1,93 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { z } from 'zod';
+
+export interface DraftInput {
+  messages: Array<{ role: string; content: string | null }>;
+  contextSnapshot: unknown;
+  elapsedMinutes: number;
+  model: string;
+}
+export interface DraftResult {
+  subject: string;
+  problemSummary: string;
+  resolutionSummary: string;
+  wasFixed: boolean;
+  suggestedTimeMinutes: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+export class ThinTranscriptError extends Error {
+  constructor() { super('Not enough conversation to draft a ticket'); this.name = 'ThinTranscriptError'; }
+}
+
+const llmSchema = z.object({
+  subject: z.string().min(1).max(120),
+  problemSummary: z.string().min(1),
+  resolutionSummary: z.string(),
+  wasFixed: z.boolean(),
+  suggestedTimeMinutes: z.number().int().min(0),
+});
+
+const SYSTEM_PROMPT = [
+  'You turn an IT support chat transcript into a support ticket for a non-technical reader (a customer or office manager).',
+  'Write plain English. No jargon, no command output, no internal tool names.',
+  'Return ONLY a JSON object with keys: subject (<=120 chars), problemSummary, resolutionSummary, wasFixed (boolean), suggestedTimeMinutes (integer).',
+  'The resolution text is shown to the customer. Leave resolutionSummary as an empty string if the issue was not resolved.',
+  'Set wasFixed true ONLY if the transcript shows the issue was actually verified fixed — not merely attempted.',
+  'suggestedTimeMinutes is hands-on work time; seed it from the elapsed ceiling provided but reduce it for idle gaps or non-work chatter. Never exceed the elapsed ceiling.',
+].join(' ');
+
+function lastTextBlock(content: unknown): string | null {
+  if (!Array.isArray(content)) return null;
+  for (let i = content.length - 1; i >= 0; i--) {
+    const b = content[i] as { type?: string; text?: string };
+    if (b?.type === 'text' && typeof b.text === 'string') return b.text;
+  }
+  return null;
+}
+
+function buildUserContent(input: DraftInput): string {
+  const lines = input.messages
+    .filter((m) => (m.role === 'user' || m.role === 'assistant') && m.content && m.content.trim().length > 0)
+    .map((m) => `${m.role === 'user' ? 'Technician/User' : 'Assistant'}: ${m.content!.trim()}`);
+  const ctx = input.contextSnapshot ? `Context: ${JSON.stringify(input.contextSnapshot)}\n` : '';
+  return `${ctx}Elapsed ceiling (minutes): ${input.elapsedMinutes}\n\nTranscript:\n${lines.join('\n')}`;
+}
+
+export async function draftTicketFromTranscript(input: DraftInput): Promise<DraftResult> {
+  const hasAssistant = input.messages.some((m) => m.role === 'assistant' && m.content && m.content.trim().length > 0);
+  if (!hasAssistant) throw new ThinTranscriptError();
+
+  const client = new Anthropic();
+  const userContent = buildUserContent(input);
+  let lastErr: unknown;
+  let inTok = 0;
+  let outTok = 0;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const resp = await client.messages.create({
+      model: input.model,
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userContent }],
+    });
+    inTok = resp.usage?.input_tokens ?? 0;
+    outTok = resp.usage?.output_tokens ?? 0;
+    const text = lastTextBlock(resp.content);
+    if (text) {
+      try {
+        const parsed = llmSchema.parse(JSON.parse(text));
+        return {
+          subject: parsed.subject,
+          problemSummary: parsed.problemSummary,
+          resolutionSummary: parsed.wasFixed ? parsed.resolutionSummary : '',
+          wasFixed: parsed.wasFixed,
+          suggestedTimeMinutes: Math.min(parsed.suggestedTimeMinutes, Math.max(0, Math.round(input.elapsedMinutes))),
+          inputTokens: inTok,
+          outputTokens: outTok,
+        };
+      } catch (err) { lastErr = err; }
+    }
+  }
+  throw new Error(`Failed to draft ticket from transcript: ${String(lastErr)}`);
+}

--- a/apps/web/src/components/ai/CreateTicketFromChatModal.test.tsx
+++ b/apps/web/src/components/ai/CreateTicketFromChatModal.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AiTicketDraft } from '@breeze/shared';
+
+import CreateTicketFromChatModal, { type CreateTicketFromChatModalProps } from './CreateTicketFromChatModal';
+
+const draft: AiTicketDraft = {
+  subject: 'Outlook would not open',
+  problemSummary: 'Sarah could not open Outlook.',
+  resolutionSummary: 'Rebuilt the mail profile.',
+  wasFixed: true,
+  suggestedStatus: 'resolved',
+  suggestedTimeMinutes: 15,
+  elapsedMinutes: 25,
+  orgId: 'o1',
+  orgName: 'Acme',
+  deviceId: 'd1',
+  deviceHostname: 'WKS-04',
+};
+
+function setup(over: Partial<CreateTicketFromChatModalProps> = {}) {
+  const onSubmit = vi.fn();
+  render(
+    <CreateTicketFromChatModal
+      draft={draft}
+      orgName="Acme"
+      deviceHostname="WKS-04"
+      busy={false}
+      onCancel={() => {}}
+      onSubmit={onSubmit}
+      {...over}
+    />,
+  );
+  return { onSubmit };
+}
+
+describe('CreateTicketFromChatModal', () => {
+  it('prefills fields from the draft', () => {
+    setup();
+
+    expect((screen.getByLabelText(/subject/i) as HTMLInputElement).value).toBe('Outlook would not open');
+    expect((screen.getByLabelText(/time/i) as HTMLInputElement).value).toBe('15');
+  });
+
+  it('requires a resolution note when Resolved is selected', () => {
+    const { onSubmit } = setup({ draft: { ...draft, suggestedStatus: 'resolved', resolutionSummary: '' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /create ticket|save/i }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submits the edited payload', () => {
+    const { onSubmit } = setup({ draft: { ...draft, suggestedStatus: 'open' } });
+
+    fireEvent.change(screen.getByLabelText(/subject/i), { target: { value: 'New subject' } });
+    fireEvent.click(screen.getByRole('button', { name: /create ticket|save/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ subject: 'New subject', status: 'open' }));
+  });
+});

--- a/apps/web/src/components/ai/CreateTicketFromChatModal.test.tsx
+++ b/apps/web/src/components/ai/CreateTicketFromChatModal.test.tsx
@@ -9,7 +9,6 @@ const draft: AiTicketDraft = {
   subject: 'Outlook would not open',
   problemSummary: 'Sarah could not open Outlook.',
   resolutionSummary: 'Rebuilt the mail profile.',
-  wasFixed: true,
   suggestedStatus: 'resolved',
   suggestedTimeMinutes: 15,
   elapsedMinutes: 25,

--- a/apps/web/src/components/ai/CreateTicketFromChatModal.test.tsx
+++ b/apps/web/src/components/ai/CreateTicketFromChatModal.test.tsx
@@ -58,4 +58,24 @@ describe('CreateTicketFromChatModal', () => {
 
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ subject: 'New subject', status: 'open' }));
   });
+
+  it('supports manual entry when there is no draft', () => {
+    const { onSubmit } = setup({ draft: null, orgName: null, deviceHostname: null });
+
+    expect((screen.getByLabelText(/subject/i) as HTMLInputElement).value).toBe('');
+    expect((screen.getByLabelText(/problem/i) as HTMLTextAreaElement).value).toBe('');
+    expect(screen.getByRole('button', { name: /create ticket|save/i })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/subject/i), { target: { value: 'Manual subject' } });
+    fireEvent.click(screen.getByRole('button', { name: /create ticket|save/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      subject: 'Manual subject',
+      description: '',
+      status: 'open',
+      resolutionNote: undefined,
+      timeMinutes: 0,
+      billable: true,
+    });
+  });
 });

--- a/apps/web/src/components/ai/CreateTicketFromChatModal.tsx
+++ b/apps/web/src/components/ai/CreateTicketFromChatModal.tsx
@@ -1,0 +1,177 @@
+import { useId, useState } from 'react';
+
+import type { AiTicketDraft } from '@breeze/shared';
+
+import { Dialog } from '../shared/Dialog';
+
+const BTN =
+  'inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium transition focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50';
+
+const INPUT =
+  'mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary';
+
+export interface CreateTicketFromChatModalProps {
+  draft: AiTicketDraft | null;
+  orgName: string | null;
+  deviceHostname: string | null;
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: (payload: {
+    subject: string;
+    description: string;
+    status: 'open' | 'resolved';
+    resolutionNote?: string;
+    timeMinutes: number;
+    billable: boolean;
+  }) => void;
+}
+
+export default function CreateTicketFromChatModal({
+  draft,
+  orgName,
+  deviceHostname,
+  busy,
+  onCancel,
+  onSubmit,
+}: CreateTicketFromChatModalProps) {
+  const [subject, setSubject] = useState(draft?.subject ?? '');
+  const [description, setDescription] = useState(draft?.problemSummary ?? '');
+  const [resolutionNote, setResolutionNote] = useState(draft?.resolutionSummary ?? '');
+  const [status, setStatus] = useState<'open' | 'resolved'>(draft?.suggestedStatus ?? 'open');
+  const [timeMinutes, setTimeMinutes] = useState(String(draft?.suggestedTimeMinutes ?? 0));
+  const [billable, setBillable] = useState(true);
+  const titleId = useId();
+
+  const resolutionMissing = status === 'resolved' && resolutionNote.trim().length === 0;
+  const canSubmit = !busy && subject.trim().length > 0 && !resolutionMissing;
+
+  const submit = () => {
+    if (!canSubmit) return;
+
+    onSubmit({
+      subject: subject.trim(),
+      description: description.trim(),
+      status,
+      resolutionNote: status === 'resolved' ? resolutionNote.trim() : undefined,
+      timeMinutes: Math.max(0, Number.parseInt(timeMinutes, 10) || 0),
+      billable,
+    });
+  };
+
+  return (
+    <Dialog
+      open
+      onClose={() => {
+        if (!busy) onCancel();
+      }}
+      title="Create ticket from conversation"
+      labelledBy={titleId}
+      maxWidth="md"
+      className="p-5"
+    >
+      <div data-testid="create-ticket-from-chat-modal">
+        <h3 id={titleId} className="text-base font-semibold">Create ticket from conversation</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {orgName ?? draft?.orgName ?? 'Organization'}
+          {(deviceHostname ?? draft?.deviceHostname) ? ` - ${deviceHostname ?? draft?.deviceHostname}` : ''}
+        </p>
+
+        <div className="mt-4 space-y-3">
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Subject</span>
+            <input
+              aria-label="Subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              maxLength={255}
+              className={INPUT}
+            />
+          </label>
+
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Problem</span>
+            <textarea
+              aria-label="Problem"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              className={INPUT}
+            />
+          </label>
+
+          <fieldset>
+            <legend className="text-sm text-muted-foreground">Status</legend>
+            <div className="mt-1 flex gap-4">
+              <label className="inline-flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="create-ticket-status"
+                  checked={status === 'open'}
+                  onChange={() => setStatus('open')}
+                />
+                Open
+              </label>
+              <label className="inline-flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="create-ticket-status"
+                  checked={status === 'resolved'}
+                  onChange={() => setStatus('resolved')}
+                />
+                Resolved
+              </label>
+            </div>
+          </fieldset>
+
+          {status === 'resolved' && (
+            <label className="block text-sm">
+              <span className="text-muted-foreground">Resolution</span>
+              <textarea
+                aria-label="Resolution"
+                value={resolutionNote}
+                onChange={(e) => setResolutionNote(e.target.value)}
+                rows={3}
+                className={INPUT}
+              />
+              {resolutionMissing && (
+                <span className="mt-1 block text-xs text-red-500">A resolution note is required to resolve.</span>
+              )}
+            </label>
+          )}
+
+          <div className="flex items-center gap-4">
+            <label className="block text-sm">
+              <span className="text-muted-foreground">Time (min)</span>
+              <input
+                aria-label="Time (minutes)"
+                type="number"
+                min={0}
+                value={timeMinutes}
+                onChange={(e) => setTimeMinutes(e.target.value)}
+                className={`${INPUT} w-24`}
+              />
+            </label>
+            <label className="mt-6 inline-flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={billable} onChange={(e) => setBillable(e.target.checked)} />
+              Billable
+            </label>
+          </div>
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button type="button" className={`${BTN} hover:bg-muted`} onClick={onCancel} disabled={busy}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={`${BTN} bg-primary text-primary-foreground hover:bg-primary/90`}
+            disabled={!canSubmit}
+            onClick={submit}
+          >
+            Create ticket
+          </button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/workspace/WorkspaceChatPanel.test.tsx
+++ b/apps/web/src/components/workspace/WorkspaceChatPanel.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../ai/AiChatMessages', () => ({ default: () => <div /> }));
 vi.mock('../ai/AiChatInput', () => ({ default: () => <div /> }));
@@ -40,6 +40,10 @@ const baseTab = (over = {}) => ({
 });
 
 describe('WorkspaceChatPanel - Create Ticket button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('disables the button until there is an assistant message', () => {
     render(<WorkspaceChatPanel tab={baseTab({ messages: [{ role: 'user', content: 'hi' }] }) as any} />);
 
@@ -59,5 +63,36 @@ describe('WorkspaceChatPanel - Create Ticket button', () => {
     );
 
     expect(screen.getByRole('button', { name: /create ticket/i })).toBeEnabled();
+  });
+
+  it('opens the modal and drafts a ticket when the enabled button is clicked', async () => {
+    store.draftTicketFromChat.mockResolvedValueOnce({
+      subject: 'Outlook would not open',
+      problemSummary: 'Outlook would not start.',
+      resolutionSummary: '',
+      suggestedStatus: 'open',
+      suggestedTimeMinutes: 10,
+      elapsedMinutes: 12,
+      orgId: 'o1',
+      orgName: 'Acme',
+      deviceId: null,
+      deviceHostname: null,
+    });
+
+    render(
+      <WorkspaceChatPanel
+        tab={baseTab({
+          messages: [
+            { role: 'user', content: 'hi' },
+            { role: 'assistant', content: 'done' },
+          ],
+        }) as any}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /create ticket/i }));
+
+    await waitFor(() => expect(store.draftTicketFromChat).toHaveBeenCalledWith('t'));
+    expect(screen.getByTestId('create-ticket-from-chat-modal')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/workspace/WorkspaceChatPanel.test.tsx
+++ b/apps/web/src/components/workspace/WorkspaceChatPanel.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../ai/AiChatMessages', () => ({ default: () => <div /> }));
+vi.mock('../ai/AiChatInput', () => ({ default: () => <div /> }));
+vi.mock('../ai/AiContextBadge', () => ({ default: () => <div /> }));
+vi.mock('../ai/AiCostIndicator', () => ({ default: () => <div /> }));
+
+const store = {
+  sendMessage: vi.fn(),
+  approveExecution: vi.fn(),
+  approvePlan: vi.fn(),
+  abortPlan: vi.fn(),
+  pauseAi: vi.fn(),
+  interruptResponse: vi.fn(),
+  clearError: vi.fn(),
+  draftTicketFromChat: vi.fn(),
+  saveTicketFromChat: vi.fn(),
+};
+
+vi.mock('@/stores/workspaceStore', () => ({ useWorkspaceStore: () => store }));
+
+import WorkspaceChatPanel from './WorkspaceChatPanel';
+
+const baseTab = (over = {}) => ({
+  id: 't',
+  sessionId: 's1',
+  messages: [],
+  pageContext: null,
+  error: null,
+  isLoading: false,
+  isStreaming: false,
+  isInterrupting: false,
+  pendingApproval: null,
+  pendingPlan: null,
+  activePlan: null,
+  approvalMode: 'auto',
+  isPaused: false,
+  ...over,
+});
+
+describe('WorkspaceChatPanel - Create Ticket button', () => {
+  it('disables the button until there is an assistant message', () => {
+    render(<WorkspaceChatPanel tab={baseTab({ messages: [{ role: 'user', content: 'hi' }] }) as any} />);
+
+    expect(screen.getByRole('button', { name: /create ticket/i })).toBeDisabled();
+  });
+
+  it('enables the button once an assistant message exists', () => {
+    render(
+      <WorkspaceChatPanel
+        tab={baseTab({
+          messages: [
+            { role: 'user', content: 'hi' },
+            { role: 'assistant', content: 'done' },
+          ],
+        }) as any}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /create ticket/i })).toBeEnabled();
+  });
+});

--- a/apps/web/src/components/workspace/WorkspaceChatPanel.tsx
+++ b/apps/web/src/components/workspace/WorkspaceChatPanel.tsx
@@ -1,8 +1,13 @@
+import { useState } from 'react';
+
 import AiChatMessages from '../ai/AiChatMessages';
 import AiChatInput from '../ai/AiChatInput';
 import AiContextBadge from '../ai/AiContextBadge';
 import AiCostIndicator from '../ai/AiCostIndicator';
+import CreateTicketFromChatModal, { type CreateTicketFromChatModalProps } from '../ai/CreateTicketFromChatModal';
+import { ActionError } from '@/lib/runAction';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
+import type { AiTicketDraft } from '@breeze/shared';
 import type { TabState } from '@/stores/workspaceStore';
 
 interface WorkspaceChatPanelProps {
@@ -18,10 +23,58 @@ export default function WorkspaceChatPanel({ tab }: WorkspaceChatPanelProps) {
     pauseAi,
     interruptResponse,
     clearError,
+    draftTicketFromChat,
+    saveTicketFromChat,
   } = useWorkspaceStore();
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [draft, setDraft] = useState<AiTicketDraft | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const hasAssistantMsg = tab.messages.some((m) => m.role === 'assistant');
+  const canCreateTicket = !!tab.sessionId && hasAssistantMsg;
+
+  const openTicketModal = async () => {
+    setBusy(true);
+    setModalOpen(true);
+    try {
+      setDraft(await draftTicketFromChat(tab.id));
+    } catch {
+      setDraft(null);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const submitTicket: CreateTicketFromChatModalProps['onSubmit'] = async (payload) => {
+    setBusy(true);
+    try {
+      await saveTicketFromChat(tab.id, { ...payload, priority: undefined });
+      setModalOpen(false);
+      setDraft(null);
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) {
+        console.error('[Workspace] Create ticket failed:', err);
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="flex items-center justify-end border-b border-gray-200/50 px-4 py-1.5 dark:border-gray-700/50">
+        <button
+          type="button"
+          onClick={openTicketModal}
+          disabled={!canCreateTicket}
+          className="rounded px-2 py-1 text-xs font-medium text-blue-600 hover:bg-blue-50 disabled:opacity-40 dark:text-blue-400 dark:hover:bg-blue-950/40"
+        >
+          Create Ticket
+        </button>
+      </div>
+
       {/* Cost indicator */}
       <AiCostIndicator enabled />
 
@@ -69,6 +122,23 @@ export default function WorkspaceChatPanel({ tab }: WorkspaceChatPanelProps) {
         isStreaming={tab.isStreaming}
         isInterrupting={tab.isInterrupting}
       />
+
+      {modalOpen && (
+        <CreateTicketFromChatModal
+          key={draft ? 'draft' : 'manual'}
+          draft={draft}
+          orgName={draft?.orgName ?? null}
+          deviceHostname={draft?.deviceHostname ?? null}
+          busy={busy}
+          onCancel={() => {
+            if (!busy) {
+              setModalOpen(false);
+              setDraft(null);
+            }
+          }}
+          onSubmit={submitTicket}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/workspace/WorkspaceChatPanel.tsx
+++ b/apps/web/src/components/workspace/WorkspaceChatPanel.tsx
@@ -5,7 +5,8 @@ import AiChatInput from '../ai/AiChatInput';
 import AiContextBadge from '../ai/AiContextBadge';
 import AiCostIndicator from '../ai/AiCostIndicator';
 import CreateTicketFromChatModal, { type CreateTicketFromChatModalProps } from '../ai/CreateTicketFromChatModal';
-import { ActionError } from '@/lib/runAction';
+import { showToast } from '../shared/Toast';
+import { ActionError, handleActionError } from '@/lib/runAction';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import type { AiTicketDraft } from '@breeze/shared';
 import type { TabState } from '@/stores/workspaceStore';
@@ -39,8 +40,10 @@ export default function WorkspaceChatPanel({ tab }: WorkspaceChatPanelProps) {
     setModalOpen(true);
     try {
       setDraft(await draftTicketFromChat(tab.id));
-    } catch {
+    } catch (err) {
+      console.error('[Workspace] Ticket draft failed; falling back to manual entry:', err);
       setDraft(null);
+      showToast({ type: 'warning', message: "Couldn't auto-draft from this conversation — you can fill in the ticket manually." });
     } finally {
       setBusy(false);
     }
@@ -53,10 +56,8 @@ export default function WorkspaceChatPanel({ tab }: WorkspaceChatPanelProps) {
       setModalOpen(false);
       setDraft(null);
     } catch (err) {
-      if (err instanceof ActionError && err.status === 401) return;
-      if (!(err instanceof ActionError)) {
-        console.error('[Workspace] Create ticket failed:', err);
-      }
+      if (err instanceof ActionError) return; // already toasted by runAction
+      handleActionError(err, 'Could not create the ticket.');
     } finally {
       setBusy(false);
     }

--- a/apps/web/src/stores/workspaceStore.test.ts
+++ b/apps/web/src/stores/workspaceStore.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CreateTicketFromChatInput } from '@breeze/shared';
+
+const storageHarness = vi.hoisted(() => {
+  const data = new Map<string, string>();
+  const localStorageMock = {
+    getItem: vi.fn((key: string) => data.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      data.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      data.delete(key);
+    }),
+    clear: vi.fn(() => {
+      data.clear();
+    }),
+  };
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: localStorageMock,
+    configurable: true,
+  });
+  return { data, localStorageMock };
+});
+
+vi.mock('./auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../components/shared/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+import { showToast } from '../components/shared/Toast';
+import { fetchWithAuth } from './auth';
+import { useWorkspaceStore, type TabState } from './workspaceStore';
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const showToastMock = vi.mocked(showToast);
+
+const makeResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+function tab(over: Partial<TabState> = {}): TabState {
+  return {
+    id: 'tab-1',
+    sessionId: 'session-1',
+    title: 'Chat',
+    contextLabel: null,
+    pageContext: null,
+    messages: [],
+    isStreaming: false,
+    isLoading: false,
+    error: null,
+    pendingApproval: null,
+    pendingPlan: null,
+    activePlan: null,
+    approvalMode: 'auto_approve',
+    isPaused: false,
+    isInterrupting: false,
+    isFlagged: false,
+    unreadCount: 0,
+    hasApprovalPending: false,
+    ...over,
+  };
+}
+
+const ticketPayload: CreateTicketFromChatInput = {
+  subject: 'S',
+  description: 'P',
+  status: 'open',
+  timeMinutes: 0,
+  billable: true,
+};
+
+function warningToasts() {
+  return showToastMock.mock.calls.filter(([toast]) => toast.type === 'warning');
+}
+
+describe('workspace store ticket actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storageHarness.data.clear();
+    useWorkspaceStore.setState({
+      tabs: [tab()],
+      activeTabId: 'tab-1',
+      _readers: new Map(),
+    });
+  });
+
+  it('draftTicketFromChat throws the extracted API message on failure', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeResponse({ error: 'Draft unavailable' }, false, 502));
+
+    await expect(useWorkspaceStore.getState().draftTicketFromChat('tab-1')).rejects.toThrow('Draft unavailable');
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/ai/sessions/session-1/ticket-draft', { method: 'POST' });
+  });
+
+  it('draftTicketFromChat throws when the tab has no active session', async () => {
+    useWorkspaceStore.setState({ tabs: [tab({ sessionId: null })] });
+
+    await expect(useWorkspaceStore.getState().draftTicketFromChat('tab-1')).rejects.toThrow('No active session');
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('saveTicketFromChat maps internalNumber to ticketNumber and emits no partial-success warnings', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeResponse({ data: { internalNumber: 'INT-7' }, resolved: true, timeLogged: true }),
+    );
+
+    const result = await useWorkspaceStore.getState().saveTicketFromChat('tab-1', {
+      ...ticketPayload,
+      status: 'resolved',
+      resolutionNote: 'Fixed',
+      timeMinutes: 15,
+    });
+
+    expect(result).toEqual({ ticketNumber: 'INT-7', resolved: true, timeLogged: true });
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/ai/sessions/session-1/ticket', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...ticketPayload, status: 'resolved', resolutionNote: 'Fixed', timeMinutes: 15 }),
+    });
+    expect(warningToasts()).toHaveLength(0);
+  });
+
+  it('saveTicketFromChat warns when requested resolve does not complete', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeResponse({ data: { ticketNumber: 'ORG-1' }, resolved: false, timeLogged: false }),
+    );
+
+    await useWorkspaceStore.getState().saveTicketFromChat('tab-1', {
+      ...ticketPayload,
+      status: 'resolved',
+      resolutionNote: 'Fixed',
+    });
+
+    expect(showToastMock).toHaveBeenCalledWith({
+      type: 'warning',
+      message: 'Ticket created, but it could not be resolved automatically — please resolve it manually.',
+    });
+  });
+
+  it('saveTicketFromChat warns when requested time does not log', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeResponse({ data: { ticketNumber: 'ORG-1' }, resolved: false, timeLogged: false }),
+    );
+
+    await useWorkspaceStore.getState().saveTicketFromChat('tab-1', {
+      ...ticketPayload,
+      timeMinutes: 15,
+    });
+
+    expect(showToastMock).toHaveBeenCalledWith({
+      type: 'warning',
+      message: 'Ticket created, but the time entry could not be logged.',
+    });
+  });
+});

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -4,6 +4,7 @@ import type { AiPageContext, AiStreamEvent, AiApprovalMode, AiTicketDraft, Creat
 import { fetchWithAuth } from './auth';
 import { extractApiError } from '@/lib/apiError';
 import { runAction } from '@/lib/runAction';
+import { showToast } from '../components/shared/Toast';
 import {
   processStreamEvent,
   mapMessagesFromApi,
@@ -485,7 +486,9 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           const tab = getTab(tabId);
           if (!tab?.sessionId) throw new Error('No active session');
           const sessionId = tab.sessionId;
-          return runAction<{ ticketNumber: string; resolved: boolean; timeLogged: boolean }>({
+          const requestedResolve = payload.status === 'resolved';
+          const requestedTime = payload.timeMinutes > 0;
+          const result = await runAction<{ ticketNumber: string; resolved: boolean; timeLogged: boolean }>({
             request: () => fetchWithAuth(`/ai/sessions/${sessionId}/ticket`, {
               method: 'POST',
               headers: { 'content-type': 'application/json' },
@@ -493,11 +496,23 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             }),
             errorFallback: 'Could not create the ticket.',
             parseSuccess: (data) => {
-              const d = data as { data?: { ticketNumber?: string }; resolved?: boolean; timeLogged?: boolean };
-              return { ticketNumber: d.data?.ticketNumber ?? '', resolved: !!d.resolved, timeLogged: !!d.timeLogged };
+              const d = data as { data?: { internalNumber?: string | null; ticketNumber?: string }; resolved?: boolean; timeLogged?: boolean };
+              return {
+                ticketNumber: d.data?.internalNumber ?? d.data?.ticketNumber ?? '',
+                resolved: !!d.resolved,
+                timeLogged: !!d.timeLogged,
+              };
             },
-            successMessage: (r) => `Ticket ${r.ticketNumber} created${r.resolved ? ' and resolved' : ''}${r.timeLogged ? '' : ' (time not logged)'}`,
+            successMessage: (r) => `Ticket ${r.ticketNumber} created${r.resolved ? ' and resolved' : ''}`,
           });
+          // Partial-success warnings: only when the user asked for something that didn't happen.
+          if (requestedResolve && !result.resolved) {
+            showToast({ type: 'warning', message: 'Ticket created, but it could not be resolved automatically — please resolve it manually.' });
+          }
+          if (requestedTime && !result.timeLogged) {
+            showToast({ type: 'warning', message: 'Ticket created, but the time entry could not be logged.' });
+          }
+          return result;
         },
 
         unflagSession: async (tabId: string) => {

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -1,8 +1,9 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import type { AiPageContext, AiStreamEvent, AiApprovalMode } from '@breeze/shared';
+import type { AiPageContext, AiStreamEvent, AiApprovalMode, AiTicketDraft, CreateTicketFromChatInput } from '@breeze/shared';
 import { fetchWithAuth } from './auth';
 import { extractApiError } from '@/lib/apiError';
+import { runAction } from '@/lib/runAction';
 import {
   processStreamEvent,
   mapMessagesFromApi,
@@ -77,6 +78,8 @@ interface WorkspaceState {
   pauseAi: (tabId: string, paused: boolean) => Promise<void>;
   interruptResponse: (tabId: string) => Promise<void>;
   flagSession: (tabId: string, reason?: string) => Promise<void>;
+  draftTicketFromChat: (tabId: string) => Promise<AiTicketDraft>;
+  saveTicketFromChat: (tabId: string, payload: CreateTicketFromChatInput) => Promise<{ ticketNumber: string; resolved: boolean; timeLogged: boolean }>;
   unflagSession: (tabId: string) => Promise<void>;
   clearError: (tabId: string) => void;
 
@@ -464,6 +467,37 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             console.error('[Workspace] Flag failed:', err);
             updateTab(tabId, { error: 'Failed to flag session' });
           }
+        },
+
+        draftTicketFromChat: async (tabId) => {
+          const tab = getTab(tabId);
+          if (!tab?.sessionId) throw new Error('No active session');
+          const res = await fetchWithAuth(`/ai/sessions/${tab.sessionId}/ticket-draft`, { method: 'POST' });
+          if (!res.ok) {
+            const data = await res.json().catch(() => null);
+            throw new Error(extractApiError(data, 'Could not draft a ticket from this conversation'));
+          }
+          const body = await res.json();
+          return body.data as AiTicketDraft;
+        },
+
+        saveTicketFromChat: async (tabId, payload) => {
+          const tab = getTab(tabId);
+          if (!tab?.sessionId) throw new Error('No active session');
+          const sessionId = tab.sessionId;
+          return runAction<{ ticketNumber: string; resolved: boolean; timeLogged: boolean }>({
+            request: () => fetchWithAuth(`/ai/sessions/${sessionId}/ticket`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify(payload),
+            }),
+            errorFallback: 'Could not create the ticket.',
+            parseSuccess: (data) => {
+              const d = data as { data?: { ticketNumber?: string }; resolved?: boolean; timeLogged?: boolean };
+              return { ticketNumber: d.data?.ticketNumber ?? '', resolved: !!d.resolved, timeLogged: !!d.timeLogged };
+            },
+            successMessage: (r) => `Ticket ${r.ticketNumber} created${r.resolved ? ' and resolved' : ''}${r.timeLogged ? '' : ' (time not logged)'}`,
+          });
         },
 
         unflagSession: async (tabId: string) => {

--- a/docs/superpowers/plans/2026-07-08-create-ticket-from-ai-conversation.md
+++ b/docs/superpowers/plans/2026-07-08-create-ticket-from-ai-conversation.md
@@ -1,0 +1,1094 @@
+# Create Ticket from AI Conversation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Create Ticket" button to the web technician AI chat panel that drafts a plain-English ticket (problem + resolution + status + time) from the conversation, lets the tech review/edit in a modal, and on save creates the ticket (`source:'ai'`) against the session's org/device and logs a time entry.
+
+**Architecture:** Two new endpoints on the existing AI router — a **draft** endpoint (reads the transcript, makes one LLM summarization call, returns a non-persisted draft) and a **save** endpoint (creates the ticket via the existing `createTicket` service, optionally resolves it, and best-effort logs a time entry). A presentational modal mirrors the existing `CreateVulnTicketModal`; the store exposes thin fetch actions. No new DB table, no migration.
+
+**Tech Stack:** Hono + Zod (`@hono/zod-validator`) API, Drizzle ORM, raw `@anthropic-ai/sdk` for the one-shot LLM call, React + Zustand (`workspaceStore`) + shared `Dialog`/`runAction` on the web.
+
+## Global Constraints
+
+- **No new DB table / no migration** — writes land in existing `tickets` and `time_entries` (both already RLS-covered). Do NOT add a table or migration.
+- **Tenant scoping via session load:** always load the session with `getSession(id, auth)` or `getSessionMessages(id, auth)` — these bake `auth.orgCondition(aiSessions.orgId)` into the query; a session the caller can't reach returns `null` → respond `404`. Never trust an `orgId`/`deviceId` from the client body; derive them from the loaded session row.
+- **`ticketSourceEnum` already includes `'ai'`** (`apps/api/src/db/schema/portal.ts:8`) — create tickets with `source: 'ai'`.
+- **Permission:** both endpoints use `requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action)` and `requireScope('organization','partner','system')`.
+- **Time-entry logging is partner/system-scope only** (`time_entries` has no org-axis RLS policy). Only call `createTimeEntry` when `auth.scope === 'partner' || auth.scope === 'system'`, and wrap it in try/catch — a time-entry failure must NOT fail ticket creation.
+- **Failure model:** ticket creation is the critical atomic step; resolve + time-entry are best-effort follow-ups. The save response returns `{ data: ticket, resolved: boolean, timeLogged: boolean }`.
+- **Web mutations use `runAction`** (`apps/web/src/lib/runAction.ts`) per CLAUDE.md — the modal's Save goes through it.
+- **Test conventions:** co-locate test files next to source; follow the `breeze-testing` skill (Drizzle mock patterns, Vitest). API unit tests run under `apps/api/vitest.config.ts`; web tests under `apps/web/vitest.config.ts`.
+- **Scope guardrails (do NOT build):** web technician AI agent only (not Helper/Excel); button-triggered only (no autonomous agent tool); no category/assignee/SLA auto-fill; create-only (no attach-to-existing).
+
+## File Structure
+
+**Create:**
+- `apps/api/src/services/aiTicketDraft.ts` — transcript → structured draft (LLM call).
+- `apps/api/src/services/aiTicketDraft.test.ts` — summarizer unit test (mocked Anthropic).
+- `apps/web/src/components/ai/CreateTicketFromChatModal.tsx` — presentational modal.
+- `apps/web/src/components/ai/CreateTicketFromChatModal.test.tsx` — modal test.
+
+**Modify:**
+- `packages/shared/src/validators/tickets.ts` — add `createTicketFromChatSchema` + `CreateTicketFromChatInput`.
+- `packages/shared/src/validators/tickets.test.ts` (or the co-located ticket validator test) — schema tests.
+- `packages/shared/src/types/ai.ts` — add `AiTicketDraft` interface.
+- `apps/api/src/routes/ai.ts` — add `POST /sessions/:id/ticket-draft` and `POST /sessions/:id/ticket`.
+- `apps/api/src/routes/ai.test.ts` (or a sibling `ai.ticket.test.ts`) — route tests.
+- `apps/web/src/stores/workspaceStore.ts` — add `draftTicketFromChat` + `saveTicketFromChat` actions to `WorkspaceState`.
+- `apps/web/src/components/workspace/WorkspaceChatPanel.tsx` — add the toolbar button + modal wiring.
+
+---
+
+### Task 1: Shared validator + draft type
+
+**Files:**
+- Modify: `packages/shared/src/validators/tickets.ts`
+- Modify: `packages/shared/src/types/ai.ts`
+- Test: `packages/shared/src/validators/tickets.test.ts`
+
+**Interfaces:**
+- Produces: `createTicketFromChatSchema` (Zod) + `type CreateTicketFromChatInput`; `interface AiTicketDraft`. Consumed by Tasks 3, 4, 5, 6.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/shared/src/validators/tickets.test.ts` (create the file if it does not exist, importing `describe/it/expect` from `vitest`):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { createTicketFromChatSchema } from './tickets';
+
+describe('createTicketFromChatSchema', () => {
+  const base = { subject: 'Outlook would not open', description: 'Sarah could not open Outlook.', status: 'open' as const, timeMinutes: 15, billable: true };
+
+  it('accepts a valid open-ticket payload', () => {
+    expect(createTicketFromChatSchema.parse(base)).toMatchObject({ status: 'open', timeMinutes: 15 });
+  });
+
+  it('requires a resolutionNote when status is resolved', () => {
+    const r = createTicketFromChatSchema.safeParse({ ...base, status: 'resolved' });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts a resolved payload with a resolutionNote', () => {
+    const r = createTicketFromChatSchema.safeParse({ ...base, status: 'resolved', resolutionNote: 'Rebuilt the mail profile.' });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects negative timeMinutes and empty subject', () => {
+    expect(createTicketFromChatSchema.safeParse({ ...base, timeMinutes: -1 }).success).toBe(false);
+    expect(createTicketFromChatSchema.safeParse({ ...base, subject: '' }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @breeze/shared test -- tickets.test`
+Expected: FAIL — `createTicketFromChatSchema` is not exported.
+
+- [ ] **Step 3: Add the schema**
+
+In `packages/shared/src/validators/tickets.ts`, near the other ticket schemas (reuse the existing `ticketPrioritySchema` already defined in this file), add:
+
+```ts
+export const createTicketFromChatSchema = z
+  .object({
+    subject: z.string().min(1).max(255),
+    description: z.string().max(50_000).optional(),
+    status: z.enum(['open', 'resolved']),
+    resolutionNote: z.string().max(50_000).optional(),
+    timeMinutes: z.number().int().min(0).max(24 * 60),
+    billable: z.boolean(),
+    priority: ticketPrioritySchema.optional(),
+  })
+  .refine((v) => v.status !== 'resolved' || (v.resolutionNote?.trim().length ?? 0) > 0, {
+    message: 'A resolution note is required to resolve a ticket',
+    path: ['resolutionNote'],
+  });
+
+export type CreateTicketFromChatInput = z.infer<typeof createTicketFromChatSchema>;
+```
+
+If `ticketPrioritySchema` is not already exported/available in this file, use `z.enum(['low', 'normal', 'high', 'urgent']).optional()` inline instead.
+
+- [ ] **Step 4: Add the draft type**
+
+In `packages/shared/src/types/ai.ts` (where `AiPageContext` lives), add:
+
+```ts
+export interface AiTicketDraft {
+  subject: string;
+  problemSummary: string;
+  resolutionSummary: string;
+  wasFixed: boolean;
+  suggestedStatus: 'open' | 'resolved';
+  suggestedTimeMinutes: number;
+  elapsedMinutes: number;
+  orgId: string;
+  orgName: string | null;
+  deviceId: string | null;
+  deviceHostname: string | null;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @breeze/shared test -- tickets.test`
+Expected: PASS (4 tests).
+Also run `pnpm --filter @breeze/shared build` (or `tsc --noEmit`) to confirm the new type compiles and is exported.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/validators/tickets.ts packages/shared/src/validators/tickets.test.ts packages/shared/src/types/ai.ts
+git commit -m "feat(shared): add createTicketFromChatSchema + AiTicketDraft type"
+```
+
+---
+
+### Task 2: Summarization service (`aiTicketDraft.ts`)
+
+**Files:**
+- Create: `apps/api/src/services/aiTicketDraft.ts`
+- Test: `apps/api/src/services/aiTicketDraft.test.ts`
+
+**Interfaces:**
+- Consumes: `aiMessages` rows (`{ role, content, contentBlocks, toolName, createdAt }`), `AiPageContext`/`contextSnapshot` (jsonb), `elapsedMinutes: number`.
+- Produces:
+  ```ts
+  export interface DraftInput {
+    messages: Array<{ role: string; content: string | null }>;
+    contextSnapshot: unknown;
+    elapsedMinutes: number;
+    model: string;
+  }
+  export interface DraftResult {
+    subject: string; problemSummary: string; resolutionSummary: string;
+    wasFixed: boolean; suggestedTimeMinutes: number;
+    inputTokens: number; outputTokens: number;
+  }
+  export class ThinTranscriptError extends Error {}
+  export async function draftTicketFromTranscript(input: DraftInput): Promise<DraftResult>
+  ```
+  Consumed by Task 3.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/services/aiTicketDraft.test.ts`. Mock the Anthropic SDK so no network call happens:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const createMock = vi.fn();
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class { messages = { create: createMock }; },
+}));
+
+import { draftTicketFromTranscript, ThinTranscriptError } from './aiTicketDraft';
+
+function reply(json: object, inTok = 100, outTok = 50) {
+  return { content: [{ type: 'text', text: JSON.stringify(json) }], usage: { input_tokens: inTok, output_tokens: outTok } };
+}
+
+const transcript = [
+  { role: 'user', content: 'Outlook will not open on my PC' },
+  { role: 'assistant', content: 'I rebuilt your mail profile; it is working now.' },
+];
+
+beforeEach(() => createMock.mockReset());
+
+describe('draftTicketFromTranscript', () => {
+  it('returns a structured draft and maps wasFixed', async () => {
+    createMock.mockResolvedValueOnce(reply({ subject: 'Outlook would not open', problemSummary: 'Outlook would not start.', resolutionSummary: 'Rebuilt the mail profile.', wasFixed: true, suggestedTimeMinutes: 15 }));
+    const r = await draftTicketFromTranscript({ messages: transcript, contextSnapshot: null, elapsedMinutes: 25, model: 'claude-x' });
+    expect(r.wasFixed).toBe(true);
+    expect(r.subject).toBe('Outlook would not open');
+    expect(r.outputTokens).toBe(50);
+  });
+
+  it('clamps suggestedTimeMinutes to the elapsed ceiling', async () => {
+    createMock.mockResolvedValueOnce(reply({ subject: 's', problemSummary: 'p', resolutionSummary: '', wasFixed: false, suggestedTimeMinutes: 999 }));
+    const r = await draftTicketFromTranscript({ messages: transcript, contextSnapshot: null, elapsedMinutes: 25, model: 'claude-x' });
+    expect(r.suggestedTimeMinutes).toBeLessThanOrEqual(25);
+  });
+
+  it('retries once on invalid JSON then throws', async () => {
+    createMock.mockResolvedValue({ content: [{ type: 'text', text: 'not json' }], usage: {} });
+    await expect(draftTicketFromTranscript({ messages: transcript, contextSnapshot: null, elapsedMinutes: 25, model: 'claude-x' })).rejects.toThrow();
+    expect(createMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws ThinTranscriptError when there is no assistant turn', async () => {
+    await expect(draftTicketFromTranscript({ messages: [{ role: 'user', content: 'hi' }], contextSnapshot: null, elapsedMinutes: 5, model: 'claude-x' })).rejects.toBeInstanceOf(ThinTranscriptError);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @breeze/api test -- aiTicketDraft`
+Expected: FAIL — module `./aiTicketDraft` not found.
+
+- [ ] **Step 3: Implement the service**
+
+Create `apps/api/src/services/aiTicketDraft.ts`:
+
+```ts
+import Anthropic from '@anthropic-ai/sdk';
+import { z } from 'zod';
+
+export interface DraftInput {
+  messages: Array<{ role: string; content: string | null }>;
+  contextSnapshot: unknown;
+  elapsedMinutes: number;
+  model: string;
+}
+export interface DraftResult {
+  subject: string;
+  problemSummary: string;
+  resolutionSummary: string;
+  wasFixed: boolean;
+  suggestedTimeMinutes: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+export class ThinTranscriptError extends Error {
+  constructor() { super('Not enough conversation to draft a ticket'); this.name = 'ThinTranscriptError'; }
+}
+
+const llmSchema = z.object({
+  subject: z.string().min(1).max(120),
+  problemSummary: z.string().min(1),
+  resolutionSummary: z.string(),
+  wasFixed: z.boolean(),
+  suggestedTimeMinutes: z.number().int().min(0),
+});
+
+const SYSTEM_PROMPT = [
+  'You turn an IT support chat transcript into a support ticket for a non-technical reader (a customer or office manager).',
+  'Write plain English. No jargon, no command output, no internal tool names.',
+  'Return ONLY a JSON object with keys: subject (<=120 chars), problemSummary, resolutionSummary, wasFixed (boolean), suggestedTimeMinutes (integer).',
+  'The resolution text is shown to the customer. Leave resolutionSummary as an empty string if the issue was not resolved.',
+  'Set wasFixed true ONLY if the transcript shows the issue was actually verified fixed — not merely attempted.',
+  'suggestedTimeMinutes is hands-on work time; seed it from the elapsed ceiling provided but reduce it for idle gaps or non-work chatter. Never exceed the elapsed ceiling.',
+].join(' ');
+
+function lastTextBlock(content: unknown): string | null {
+  if (!Array.isArray(content)) return null;
+  for (let i = content.length - 1; i >= 0; i--) {
+    const b = content[i] as { type?: string; text?: string };
+    if (b?.type === 'text' && typeof b.text === 'string') return b.text;
+  }
+  return null;
+}
+
+function buildUserContent(input: DraftInput): string {
+  const lines = input.messages
+    .filter((m) => (m.role === 'user' || m.role === 'assistant') && m.content && m.content.trim().length > 0)
+    .map((m) => `${m.role === 'user' ? 'Technician/User' : 'Assistant'}: ${m.content!.trim()}`);
+  const ctx = input.contextSnapshot ? `Context: ${JSON.stringify(input.contextSnapshot)}\n` : '';
+  return `${ctx}Elapsed ceiling (minutes): ${input.elapsedMinutes}\n\nTranscript:\n${lines.join('\n')}`;
+}
+
+export async function draftTicketFromTranscript(input: DraftInput): Promise<DraftResult> {
+  const hasAssistant = input.messages.some((m) => m.role === 'assistant' && m.content && m.content.trim().length > 0);
+  if (!hasAssistant) throw new ThinTranscriptError();
+
+  const client = new Anthropic();
+  const userContent = buildUserContent(input);
+  let lastErr: unknown;
+  let inTok = 0;
+  let outTok = 0;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const resp = await client.messages.create({
+      model: input.model,
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userContent }],
+    });
+    inTok = resp.usage?.input_tokens ?? 0;
+    outTok = resp.usage?.output_tokens ?? 0;
+    const text = lastTextBlock(resp.content);
+    if (text) {
+      try {
+        const parsed = llmSchema.parse(JSON.parse(text));
+        return {
+          subject: parsed.subject,
+          problemSummary: parsed.problemSummary,
+          resolutionSummary: parsed.wasFixed ? parsed.resolutionSummary : '',
+          wasFixed: parsed.wasFixed,
+          suggestedTimeMinutes: Math.min(parsed.suggestedTimeMinutes, Math.max(0, Math.round(input.elapsedMinutes))),
+          inputTokens: inTok,
+          outputTokens: outTok,
+        };
+      } catch (err) { lastErr = err; }
+    }
+  }
+  throw new Error(`Failed to draft ticket from transcript: ${String(lastErr)}`);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @breeze/api test -- aiTicketDraft`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/aiTicketDraft.ts apps/api/src/services/aiTicketDraft.test.ts
+git commit -m "feat(api): add aiTicketDraft summarization service"
+```
+
+---
+
+### Task 3: Draft endpoint — `POST /ai/sessions/:id/ticket-draft`
+
+**Files:**
+- Modify: `apps/api/src/routes/ai.ts`
+- Test: `apps/api/src/routes/ai.ticket.test.ts` (new sibling test file)
+
+**Interfaces:**
+- Consumes: `draftTicketFromTranscript` + `ThinTranscriptError` (Task 2), `AiTicketDraft` (Task 1), `getSessionMessages(id, auth)` (`aiAgent.ts:244`), `resolveDefaultModel` (`aiAgent.ts:38`), `recordUsage(sessionId, orgId, model, inTok, outTok, isToolExecution)` (`aiCostTracker.ts:293`).
+- Produces: `POST /ai/sessions/:id/ticket-draft` → `200 { data: AiTicketDraft }` | `404` | `422`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/routes/ai.ticket.test.ts`. Mock the summarizer, the session loader, org/device lookups, and cost tracker so the route runs without a DB. Mirror how existing route tests in this repo build a Hono test app + inject an `auth` context (check `apps/api/src/routes/ai.test.ts` or a nearby route test for the exact `app.request`/auth-injection harness and copy it). The behavioral assertions:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getSessionMessagesMock = vi.fn();
+const draftMock = vi.fn();
+const recordUsageMock = vi.fn();
+
+vi.mock('../services/aiAgent', async (orig) => ({ ...(await orig()), getSessionMessages: getSessionMessagesMock, resolveDefaultModel: () => 'claude-test' }));
+vi.mock('../services/aiTicketDraft', () => ({
+  draftTicketFromTranscript: draftMock,
+  ThinTranscriptError: class ThinTranscriptError extends Error {},
+}));
+vi.mock('../services/aiCostTracker', async (orig) => ({ ...(await orig()), recordUsage: recordUsageMock }));
+
+// ...import the test app harness + a helper to POST as a given auth context...
+
+beforeEach(() => { getSessionMessagesMock.mockReset(); draftMock.mockReset(); recordUsageMock.mockReset(); });
+
+describe('POST /ai/sessions/:id/ticket-draft', () => {
+  it('returns a draft assembled from the session + summarizer', async () => {
+    getSessionMessagesMock.mockResolvedValue({ session: { id: 's1', orgId: 'org1', deviceId: null, createdAt: new Date(Date.now() - 25 * 60000), contextSnapshot: null }, messages: [{ role: 'user', content: 'hi' }, { role: 'assistant', content: 'fixed' }] });
+    draftMock.mockResolvedValue({ subject: 'S', problemSummary: 'P', resolutionSummary: 'R', wasFixed: true, suggestedTimeMinutes: 15, inputTokens: 10, outputTokens: 5 });
+    const res = await postDraft('s1', partnerAuth);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toMatchObject({ subject: 'S', suggestedStatus: 'resolved', orgId: 'org1' });
+  });
+
+  it('404 when the session is not reachable', async () => {
+    getSessionMessagesMock.mockResolvedValue(null);
+    expect((await postDraft('sX', partnerAuth)).status).toBe(404);
+  });
+
+  it('422 on a thin transcript', async () => {
+    getSessionMessagesMock.mockResolvedValue({ session: { id: 's1', orgId: 'org1', deviceId: null, createdAt: new Date(), contextSnapshot: null }, messages: [{ role: 'user', content: 'hi' }] });
+    draftMock.mockRejectedValue(new (await import('../services/aiTicketDraft')).ThinTranscriptError());
+    expect((await postDraft('s1', partnerAuth)).status).toBe(422);
+  });
+});
+```
+
+(`postDraft`, `partnerAuth`, and the app harness come from the copied test scaffold.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @breeze/api test -- ai.ticket`
+Expected: FAIL — route returns 404 for everything / handler not found.
+
+- [ ] **Step 3: Add imports to `ai.ts`**
+
+At the top of `apps/api/src/routes/ai.ts`, extend the existing imports:
+
+```ts
+// NOTE: getSession + getSessionMessages are ALREADY imported from '../services/aiAgent'
+//       (the existing named import); only ADD resolveDefaultModel to that same line:
+import { /* ...existing..., */ resolveDefaultModel } from '../services/aiAgent';
+// recordUsage is NOT yet imported — ADD it to the existing '../services/aiCostTracker' import:
+import { /* ...existing..., */ recordUsage } from '../services/aiCostTracker';
+// organizations + devices — ADD to the existing '../db/schema' import (which already has aiSessions/aiMessages):
+import { /* aiSessions, aiMessages, ... */ organizations, devices } from '../db/schema';
+// Genuinely new imports:
+import { draftTicketFromTranscript, ThinTranscriptError } from '../services/aiTicketDraft';
+import { createTicket, changeTicketStatus, TicketServiceError } from '../services/ticketService';
+import { createTimeEntry } from '../services/timeEntryService';
+import { deviceInSiteScope } from './tickets/siteScope';
+import { timeActorFrom } from './timeEntries/timeEntries';
+import { createTicketFromChatSchema, type AiTicketDraft } from '@breeze/shared';
+```
+> `db`, `eq`, `zValidator`, `z`, `requireScope`, `requirePermission`, `PERMISSIONS`, and `writeRouteAudit` are already imported in `ai.ts` — do not re-import them.
+
+Also add a permission constant near the existing `requireAiWrite`:
+
+```ts
+const requireTicketsWrite = requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action);
+```
+
+- [ ] **Step 4: Implement the draft handler**
+
+Add to `apps/api/src/routes/ai.ts` (near the other `/sessions/:id/...` routes):
+
+```ts
+aiRoutes.post(
+  '/sessions/:id/ticket-draft',
+  requireScope('organization', 'partner', 'system'),
+  requireTicketsWrite,
+  async (c) => {
+    const auth = c.get('auth');
+    const sessionId = c.req.param('id')!;
+
+    const loaded = await getSessionMessages(sessionId, auth);
+    if (!loaded) return c.json({ error: 'Session not found' }, 404);
+    const { session, messages } = loaded;
+
+    const elapsedMinutes = Math.max(0, Math.round((Date.now() - new Date(session.createdAt).getTime()) / 60000));
+    const model = session.model ?? resolveDefaultModel();
+
+    let draft;
+    try {
+      draft = await draftTicketFromTranscript({
+        messages: messages.map((m) => ({ role: m.role, content: m.content })),
+        contextSnapshot: session.contextSnapshot,
+        elapsedMinutes,
+        model,
+      });
+    } catch (err) {
+      if (err instanceof ThinTranscriptError) return c.json({ error: err.message }, 422);
+      return c.json({ error: 'Could not draft a ticket from this conversation' }, 422);
+    }
+
+    // Best-effort cost accounting; never fails the request.
+    try { await recordUsage(sessionId, session.orgId, model, draft.inputTokens, draft.outputTokens, false); } catch { /* non-fatal */ }
+
+    const [org] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, session.orgId)).limit(1);
+    let deviceHostname: string | null = null;
+    if (session.deviceId) {
+      const [dev] = await db.select({ hostname: devices.hostname }).from(devices).where(eq(devices.id, session.deviceId)).limit(1);
+      deviceHostname = dev?.hostname ?? null;
+    }
+
+    const payload: AiTicketDraft = {
+      subject: draft.subject,
+      problemSummary: draft.problemSummary,
+      resolutionSummary: draft.resolutionSummary,
+      wasFixed: draft.wasFixed,
+      suggestedStatus: draft.wasFixed ? 'resolved' : 'open',
+      suggestedTimeMinutes: draft.suggestedTimeMinutes,
+      elapsedMinutes,
+      orgId: session.orgId,
+      orgName: org?.name ?? null,
+      deviceId: session.deviceId ?? null,
+      deviceHostname,
+    };
+    return c.json({ data: payload });
+  }
+);
+```
+
+> Note: confirm `devices.hostname` is the correct column name (it is used across the ticketing/device code); if the column differs, adjust the select.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @breeze/api test -- ai.ticket`
+Expected: the three draft tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/ai.ts apps/api/src/routes/ai.ticket.test.ts
+git commit -m "feat(api): add AI conversation ticket-draft endpoint"
+```
+
+---
+
+### Task 4: Save endpoint — `POST /ai/sessions/:id/ticket`
+
+**Files:**
+- Modify: `apps/api/src/routes/ai.ts`
+- Test: `apps/api/src/routes/ai.ticket.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `getSession(id, auth)` (`aiAgent.ts:162`), `createTicket` / `changeTicketStatus` / `TicketServiceError` (`ticketService.ts`), `createTimeEntry` (`timeEntryService.ts:188`), `timeActorFrom(c)` (`timeEntries.ts:29`), `deviceInSiteScope(auth, deviceId)` (`tickets/siteScope.ts:17`), `createTicketFromChatSchema` (Task 1).
+- Produces: `POST /ai/sessions/:id/ticket` → `201 { data: ticket, resolved: boolean, timeLogged: boolean }` | `404` | `400`.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend `apps/api/src/routes/ai.ticket.test.ts`. Mock `getSession`, `createTicket`, `changeTicketStatus`, `createTimeEntry`, `deviceInSiteScope`:
+
+```ts
+const getSessionMock = vi.fn();
+const createTicketMock = vi.fn();
+const changeStatusMock = vi.fn();
+const createTimeEntryMock = vi.fn();
+const deviceInSiteScopeMock = vi.fn();
+
+// extend the existing vi.mock('../services/aiAgent', ...) to also export getSession: getSessionMock
+vi.mock('../services/ticketService', async (orig) => ({ ...(await orig()), createTicket: createTicketMock, changeTicketStatus: changeStatusMock }));
+vi.mock('../services/timeEntryService', async (orig) => ({ ...(await orig()), createTimeEntry: createTimeEntryMock }));
+vi.mock('./tickets/siteScope', () => ({ deviceInSiteScope: deviceInSiteScopeMock }));
+
+describe('POST /ai/sessions/:id/ticket', () => {
+  beforeEach(() => {
+    getSessionMock.mockResolvedValue({ id: 's1', orgId: 'org1', deviceId: 'dev1', model: null });
+    createTicketMock.mockResolvedValue({ id: 't1', ticketNumber: 'ORG-1', orgId: 'org1', status: 'new' });
+    deviceInSiteScopeMock.mockResolvedValue(true);
+    changeStatusMock.mockResolvedValue({ id: 't1', status: 'resolved' });
+    createTimeEntryMock.mockResolvedValue({ id: 'te1' });
+  });
+
+  const body = { subject: 'S', description: 'P', status: 'open', timeMinutes: 15, billable: true };
+
+  it('creates a ticket with source ai and logs time for a partner-scope caller', async () => {
+    const res = await postTicket('s1', partnerAuth, body);
+    expect(res.status).toBe(201);
+    expect(createTicketMock).toHaveBeenCalledWith(expect.objectContaining({ source: 'ai', orgId: 'org1', deviceId: 'dev1' }), expect.any(Object));
+    expect(createTimeEntryMock).toHaveBeenCalledTimes(1);
+    const json = await res.json();
+    expect(json).toMatchObject({ resolved: false, timeLogged: true });
+  });
+
+  it('resolves the ticket and sets the resolution note', async () => {
+    const res = await postTicket('s1', partnerAuth, { ...body, status: 'resolved', resolutionNote: 'Fixed it.' });
+    expect(res.status).toBe(201);
+    expect(changeStatusMock).toHaveBeenCalledWith('t1', { status: 'resolved' }, { resolutionNote: 'Fixed it.' }, expect.any(Object));
+    expect((await res.json()).resolved).toBe(true);
+  });
+
+  it('does not log time for an org-scope caller', async () => {
+    const res = await postTicket('s1', orgAuth, body); // orgAuth.scope === 'organization'
+    expect(res.status).toBe(201);
+    expect(createTimeEntryMock).not.toHaveBeenCalled();
+    expect((await res.json()).timeLogged).toBe(false);
+  });
+
+  it('drops deviceId when the caller fails site scope', async () => {
+    deviceInSiteScopeMock.mockResolvedValue(false);
+    await postTicket('s1', partnerAuth, body);
+    expect(createTicketMock).toHaveBeenCalledWith(expect.objectContaining({ deviceId: undefined }), expect.any(Object));
+  });
+
+  it('404 when the session is unreachable', async () => {
+    getSessionMock.mockResolvedValue(null);
+    expect((await postTicket('sX', partnerAuth, body)).status).toBe(404);
+  });
+
+  it('400 when resolving without a note (schema)', async () => {
+    expect((await postTicket('s1', partnerAuth, { ...body, status: 'resolved' })).status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @breeze/api test -- ai.ticket`
+Expected: FAIL — save route not implemented.
+
+- [ ] **Step 3: Implement the save handler**
+
+Add to `apps/api/src/routes/ai.ts`:
+
+```ts
+aiRoutes.post(
+  '/sessions/:id/ticket',
+  requireScope('organization', 'partner', 'system'),
+  requireTicketsWrite,
+  zValidator('json', createTicketFromChatSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const sessionId = c.req.param('id')!;
+    const body = c.req.valid('json');
+
+    const session = await getSession(sessionId, auth);
+    if (!session) return c.json({ error: 'Session not found' }, 404);
+
+    // deviceId comes from the session; drop it if a site-restricted caller can't reach the device.
+    let deviceId: string | undefined = session.deviceId ?? undefined;
+    if (deviceId && !(await deviceInSiteScope(auth, deviceId))) deviceId = undefined;
+
+    const actor = { userId: auth.user.id, name: auth.user.name, email: auth.user.email };
+
+    let ticket;
+    try {
+      ticket = await createTicket(
+        { source: 'ai', orgId: session.orgId, subject: body.subject, description: body.description, deviceId, priority: body.priority },
+        actor,
+      );
+    } catch (err) {
+      if (err instanceof TicketServiceError) return c.json({ error: err.message }, err.status ?? 400);
+      throw err;
+    }
+
+    let resolved = false;
+    if (body.status === 'resolved') {
+      try {
+        await changeTicketStatus(ticket.id, { status: 'resolved' }, { resolutionNote: body.resolutionNote }, actor);
+        resolved = true;
+      } catch { /* ticket persists; resolved:false reported */ }
+    }
+
+    let timeLogged = false;
+    if (body.timeMinutes > 0 && (auth.scope === 'partner' || auth.scope === 'system')) {
+      try {
+        const endedAt = new Date();
+        const startedAt = new Date(endedAt.getTime() - body.timeMinutes * 60_000);
+        await createTimeEntry(
+          { ticketId: ticket.id, startedAt, endedAt, description: 'Logged from AI conversation', isBillable: body.billable },
+          timeActorFrom(c),
+        );
+        timeLogged = true;
+      } catch { /* non-fatal */ }
+    }
+
+    writeRouteAudit(c, { orgId: session.orgId, action: 'ai.session.create_ticket', resourceType: 'ticket', resourceId: ticket.id });
+    return c.json({ data: ticket, resolved, timeLogged }, 201);
+  }
+);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @breeze/api test -- ai.ticket`
+Expected: all Task 3 + Task 4 tests PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter @breeze/api exec tsc --noEmit` (or the repo's `pnpm --filter @breeze/api build`).
+Expected: no type errors from the new route.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/ai.ts apps/api/src/routes/ai.ticket.test.ts
+git commit -m "feat(api): add AI conversation create-ticket save endpoint"
+```
+
+---
+
+### Task 5: Web store actions
+
+**Files:**
+- Modify: `apps/web/src/stores/workspaceStore.ts`
+
+**Interfaces:**
+- Consumes: `AiTicketDraft` + `CreateTicketFromChatInput` (`@breeze/shared`), `fetchWithAuth` (already imported in the store), `runAction`/`ActionError` (`@/lib/runAction`).
+- Produces (add to the `WorkspaceState` interface and the store object):
+  ```ts
+  draftTicketFromChat: (tabId: string) => Promise<AiTicketDraft>;
+  saveTicketFromChat: (tabId: string, payload: CreateTicketFromChatInput) => Promise<{ ticketNumber: string; resolved: boolean; timeLogged: boolean }>;
+  ```
+  Consumed by Task 7.
+
+- [ ] **Step 1: Add imports and interface members**
+
+In `apps/web/src/stores/workspaceStore.ts`:
+- Add to the top imports: `import { runAction } from '@/lib/runAction';` and extend the shared-types import with `AiTicketDraft, CreateTicketFromChatInput`.
+- Add the two signatures above to the `WorkspaceState` interface (next to `flagSession`).
+
+- [ ] **Step 2: Implement `draftTicketFromChat`**
+
+In the store object (mirror `flagSession`'s tab lookup pattern; `draft` throws so the caller can open the modal in manual-entry mode on failure):
+
+```ts
+draftTicketFromChat: async (tabId) => {
+  const tab = getTab(tabId);
+  if (!tab?.sessionId) throw new Error('No active session');
+  const res = await fetchWithAuth(`/ai/sessions/${tab.sessionId}/ticket-draft`, { method: 'POST' });
+  if (!res.ok) {
+    const data = await res.json().catch(() => null);
+    throw new Error(extractApiError(data, 'Could not draft a ticket from this conversation'));
+  }
+  const body = await res.json();
+  return body.data as AiTicketDraft;
+},
+```
+
+- [ ] **Step 3: Implement `saveTicketFromChat`**
+
+```ts
+saveTicketFromChat: async (tabId, payload) => {
+  const tab = getTab(tabId);
+  if (!tab?.sessionId) throw new Error('No active session');
+  const sessionId = tab.sessionId;
+  return runAction<{ ticketNumber: string; resolved: boolean; timeLogged: boolean }>({
+    request: () => fetchWithAuth(`/ai/sessions/${sessionId}/ticket`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    }),
+    errorFallback: 'Could not create the ticket.',
+    parseSuccess: (data) => {
+      const d = data as { data?: { ticketNumber?: string }; resolved?: boolean; timeLogged?: boolean };
+      return { ticketNumber: d.data?.ticketNumber ?? '', resolved: !!d.resolved, timeLogged: !!d.timeLogged };
+    },
+    successMessage: (r) => `Ticket ${r.ticketNumber} created${r.resolved ? ' and resolved' : ''}${r.timeLogged ? '' : ' (time not logged)'}`,
+  });
+},
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm --filter @breeze/web exec tsc --noEmit` (or `pnpm --filter @breeze/web astro check` if that's the repo's web typecheck).
+Expected: no errors. (No dedicated store unit test in this repo pattern; the actions are exercised via Task 7's component test.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/stores/workspaceStore.ts
+git commit -m "feat(web): add draft/save ticket-from-chat store actions"
+```
+
+---
+
+### Task 6: Modal component
+
+**Files:**
+- Create: `apps/web/src/components/ai/CreateTicketFromChatModal.tsx`
+- Test: `apps/web/src/components/ai/CreateTicketFromChatModal.test.tsx`
+
+**Interfaces:**
+- Consumes: shared `Dialog` (`../shared/Dialog`), `AiTicketDraft` (`@breeze/shared`).
+- Produces:
+  ```ts
+  export interface CreateTicketFromChatModalProps {
+    draft: AiTicketDraft | null;   // null => manual-entry mode (LLM failed)
+    orgName: string | null;
+    deviceHostname: string | null;
+    busy: boolean;
+    onCancel: () => void;
+    onSubmit: (payload: {
+      subject: string; description: string; status: 'open' | 'resolved';
+      resolutionNote?: string; timeMinutes: number; billable: boolean;
+    }) => void;
+  }
+  export default function CreateTicketFromChatModal(props): JSX.Element
+  ```
+  Consumed by Task 7. Presentational — the API call happens in the parent.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/ai/CreateTicketFromChatModal.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CreateTicketFromChatModal from './CreateTicketFromChatModal';
+
+const draft = {
+  subject: 'Outlook would not open', problemSummary: 'Sarah could not open Outlook.',
+  resolutionSummary: 'Rebuilt the mail profile.', wasFixed: true,
+  suggestedStatus: 'resolved' as const, suggestedTimeMinutes: 15, elapsedMinutes: 25,
+  orgId: 'o1', orgName: 'Acme', deviceId: 'd1', deviceHostname: 'WKS-04',
+};
+
+function setup(over = {}) {
+  const onSubmit = vi.fn();
+  render(<CreateTicketFromChatModal draft={draft} orgName="Acme" deviceHostname="WKS-04" busy={false} onCancel={() => {}} onSubmit={onSubmit} {...over} />);
+  return { onSubmit };
+}
+
+describe('CreateTicketFromChatModal', () => {
+  it('prefills fields from the draft', () => {
+    setup();
+    expect((screen.getByLabelText(/subject/i) as HTMLInputElement).value).toBe('Outlook would not open');
+    expect((screen.getByLabelText(/time/i) as HTMLInputElement).value).toBe('15');
+  });
+
+  it('requires a resolution note when Resolved is selected', () => {
+    const { onSubmit } = setup({ draft: { ...draft, suggestedStatus: 'resolved', resolutionSummary: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /create ticket|save/i }));
+    expect(onSubmit).not.toHaveBeenCalled(); // blocked: resolution empty
+  });
+
+  it('submits the edited payload', () => {
+    const { onSubmit } = setup({ draft: { ...draft, suggestedStatus: 'open' } });
+    fireEvent.change(screen.getByLabelText(/subject/i), { target: { value: 'New subject' } });
+    fireEvent.click(screen.getByRole('button', { name: /create ticket|save/i }));
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ subject: 'New subject', status: 'open' }));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @breeze/web test -- CreateTicketFromChatModal`
+Expected: FAIL — component does not exist.
+
+- [ ] **Step 3: Implement the modal**
+
+Create `apps/web/src/components/ai/CreateTicketFromChatModal.tsx`, mirroring `CreateVulnTicketModal.tsx` structure and the shared `Dialog`:
+
+```tsx
+import { useId, useState } from 'react';
+import { Dialog } from '../shared/Dialog';
+import type { AiTicketDraft } from '@breeze/shared';
+
+export interface CreateTicketFromChatModalProps {
+  draft: AiTicketDraft | null;
+  orgName: string | null;
+  deviceHostname: string | null;
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: (payload: { subject: string; description: string; status: 'open' | 'resolved'; resolutionNote?: string; timeMinutes: number; billable: boolean }) => void;
+}
+
+export default function CreateTicketFromChatModal({ draft, orgName, deviceHostname, busy, onCancel, onSubmit }: CreateTicketFromChatModalProps) {
+  const [subject, setSubject] = useState(draft?.subject ?? '');
+  const [description, setDescription] = useState(draft?.problemSummary ?? '');
+  const [resolutionNote, setResolutionNote] = useState(draft?.resolutionSummary ?? '');
+  const [status, setStatus] = useState<'open' | 'resolved'>(draft?.suggestedStatus ?? 'open');
+  const [timeMinutes, setTimeMinutes] = useState(String(draft?.suggestedTimeMinutes ?? 0));
+  const [billable, setBillable] = useState(true);
+  const titleId = useId();
+
+  const resolutionMissing = status === 'resolved' && resolutionNote.trim().length === 0;
+  const canSave = subject.trim().length > 0 && !resolutionMissing && !busy;
+
+  const submit = () => {
+    if (!canSave) return;
+    onSubmit({
+      subject: subject.trim(),
+      description: description.trim(),
+      status,
+      resolutionNote: status === 'resolved' ? resolutionNote.trim() : undefined,
+      timeMinutes: Math.max(0, parseInt(timeMinutes, 10) || 0),
+      billable,
+    });
+  };
+
+  return (
+    <Dialog open onClose={() => { if (!busy) onCancel(); }} title="Create ticket from conversation" labelledBy={titleId} maxWidth="md" className="p-5">
+      <h2 id={titleId} className="text-base font-semibold">Create ticket from conversation</h2>
+      <p className="mt-1 text-xs text-gray-500">{orgName ?? 'Organization'}{deviceHostname ? ` · ${deviceHostname}` : ''}</p>
+
+      <label className="mt-4 block text-xs font-medium">Subject
+        <input aria-label="Subject" className="mt-1 w-full rounded border px-2 py-1 text-sm" value={subject} onChange={(e) => setSubject(e.target.value)} maxLength={255} />
+      </label>
+
+      <label className="mt-3 block text-xs font-medium">Problem
+        <textarea aria-label="Problem" className="mt-1 w-full rounded border px-2 py-1 text-sm" rows={3} value={description} onChange={(e) => setDescription(e.target.value)} />
+      </label>
+
+      <fieldset className="mt-3">
+        <legend className="text-xs font-medium">Status</legend>
+        <label className="mr-4 text-sm"><input type="radio" name="status" checked={status === 'open'} onChange={() => setStatus('open')} /> Open</label>
+        <label className="text-sm"><input type="radio" name="status" checked={status === 'resolved'} onChange={() => setStatus('resolved')} /> Resolved</label>
+      </fieldset>
+
+      {status === 'resolved' && (
+        <label className="mt-3 block text-xs font-medium">Resolution
+          <textarea aria-label="Resolution" className="mt-1 w-full rounded border px-2 py-1 text-sm" rows={3} value={resolutionNote} onChange={(e) => setResolutionNote(e.target.value)} />
+          {resolutionMissing && <span className="mt-1 block text-xs text-red-500">A resolution note is required to resolve.</span>}
+        </label>
+      )}
+
+      <div className="mt-3 flex items-center gap-4">
+        <label className="text-xs font-medium">Time (min)
+          <input aria-label="Time (minutes)" type="number" min={0} className="ml-2 w-20 rounded border px-2 py-1 text-sm" value={timeMinutes} onChange={(e) => setTimeMinutes(e.target.value)} />
+        </label>
+        <label className="text-sm"><input type="checkbox" checked={billable} onChange={(e) => setBillable(e.target.checked)} /> Billable</label>
+      </div>
+
+      <div className="mt-5 flex justify-end gap-2">
+        <button type="button" className="rounded px-3 py-1.5 text-sm" onClick={onCancel} disabled={busy}>Cancel</button>
+        <button type="button" className="rounded bg-blue-600 px-3 py-1.5 text-sm text-white disabled:opacity-50" onClick={submit} disabled={!canSave}>Create ticket</button>
+      </div>
+    </Dialog>
+  );
+}
+```
+
+> Match the repo's existing Tailwind class conventions / button components if `CreateVulnTicketModal` uses shared `Button`/input primitives — prefer those over raw `<button>`/`<input>` for visual consistency. The `aria-label`s must stay so the tests can query fields.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @breeze/web test -- CreateTicketFromChatModal`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/ai/CreateTicketFromChatModal.tsx apps/web/src/components/ai/CreateTicketFromChatModal.test.tsx
+git commit -m "feat(web): add CreateTicketFromChatModal component"
+```
+
+---
+
+### Task 7: Wire the button into WorkspaceChatPanel
+
+**Files:**
+- Modify: `apps/web/src/components/workspace/WorkspaceChatPanel.tsx`
+- Test: `apps/web/src/components/workspace/WorkspaceChatPanel.test.tsx` (new)
+
+**Interfaces:**
+- Consumes: `draftTicketFromChat` / `saveTicketFromChat` (Task 5), `CreateTicketFromChatModal` (Task 6), `ActionError` (`@/lib/runAction`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/workspace/WorkspaceChatPanel.test.tsx`. Mock `useWorkspaceStore` to return the actions + a tab, and the child components so the test focuses on the button gating:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../ai/AiChatMessages', () => ({ default: () => <div /> }));
+vi.mock('../ai/AiChatInput', () => ({ default: () => <div /> }));
+vi.mock('../ai/AiContextBadge', () => ({ default: () => <div /> }));
+vi.mock('../ai/AiCostIndicator', () => ({ default: () => <div /> }));
+
+const store = { sendMessage: vi.fn(), approveExecution: vi.fn(), approvePlan: vi.fn(), abortPlan: vi.fn(), pauseAi: vi.fn(), interruptResponse: vi.fn(), clearError: vi.fn(), draftTicketFromChat: vi.fn(), saveTicketFromChat: vi.fn() };
+vi.mock('@/stores/workspaceStore', () => ({ useWorkspaceStore: () => store }));
+
+import WorkspaceChatPanel from './WorkspaceChatPanel';
+
+const baseTab = (over = {}) => ({ id: 't', sessionId: 's1', messages: [], pageContext: null, error: null, isLoading: false, isStreaming: false, isInterrupting: false, pendingApproval: null, pendingPlan: null, activePlan: null, approvalMode: 'auto', isPaused: false, ...over });
+
+describe('WorkspaceChatPanel — Create Ticket button', () => {
+  it('disables the button until there is an assistant message', () => {
+    render(<WorkspaceChatPanel tab={baseTab({ messages: [{ role: 'user', content: 'hi' }] }) as any} />);
+    expect(screen.getByRole('button', { name: /create ticket/i })).toBeDisabled();
+  });
+
+  it('enables the button once an assistant message exists', () => {
+    render(<WorkspaceChatPanel tab={baseTab({ messages: [{ role: 'user', content: 'hi' }, { role: 'assistant', content: 'done' }] }) as any} />);
+    expect(screen.getByRole('button', { name: /create ticket/i })).toBeEnabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @breeze/web test -- WorkspaceChatPanel`
+Expected: FAIL — no "Create Ticket" button.
+
+- [ ] **Step 3: Add the button + modal wiring**
+
+Modify `apps/web/src/components/workspace/WorkspaceChatPanel.tsx`:
+
+```tsx
+import { useState } from 'react';
+import AiChatMessages from '../ai/AiChatMessages';
+import AiChatInput from '../ai/AiChatInput';
+import AiContextBadge from '../ai/AiContextBadge';
+import AiCostIndicator from '../ai/AiCostIndicator';
+import CreateTicketFromChatModal from '../ai/CreateTicketFromChatModal';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { ActionError } from '@/lib/runAction';
+import type { AiTicketDraft } from '@breeze/shared';
+import type { TabState } from '@/stores/workspaceStore';
+
+interface WorkspaceChatPanelProps { tab: TabState; }
+
+export default function WorkspaceChatPanel({ tab }: WorkspaceChatPanelProps) {
+  const {
+    sendMessage, approveExecution, approvePlan, abortPlan, pauseAi, interruptResponse, clearError,
+    draftTicketFromChat, saveTicketFromChat,
+  } = useWorkspaceStore();
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [draft, setDraft] = useState<AiTicketDraft | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const hasAssistantMsg = tab.messages.some((m) => m.role === 'assistant');
+  const canCreateTicket = !!tab.sessionId && hasAssistantMsg;
+
+  const openTicketModal = async () => {
+    setBusy(true);
+    setModalOpen(true);
+    try {
+      setDraft(await draftTicketFromChat(tab.id));
+    } catch {
+      setDraft(null); // manual-entry mode; modal still opens
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const submitTicket = async (payload: Parameters<Parameters<typeof CreateTicketFromChatModal>[0]['onSubmit']>[0]) => {
+    setBusy(true);
+    try {
+      await saveTicketFromChat(tab.id, { ...payload, priority: undefined });
+      setModalOpen(false);
+      setDraft(null);
+    } catch (err) {
+      if (!(err instanceof ActionError)) { /* runAction already toasted ActionError */ }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="flex items-center justify-end border-b border-gray-200/50 px-4 py-1.5 dark:border-gray-700/50">
+        <button
+          type="button"
+          onClick={openTicketModal}
+          disabled={!canCreateTicket}
+          className="rounded px-2 py-1 text-xs font-medium text-blue-600 hover:bg-blue-50 disabled:opacity-40 dark:text-blue-400 dark:hover:bg-blue-950/40"
+        >
+          Create Ticket
+        </button>
+      </div>
+      <AiCostIndicator enabled />
+      {/* ...existing pageContext badge, error banner, AiChatMessages, AiChatInput unchanged... */}
+
+      {modalOpen && (
+        <CreateTicketFromChatModal
+          draft={draft}
+          orgName={draft?.orgName ?? null}
+          deviceHostname={draft?.deviceHostname ?? null}
+          busy={busy}
+          onCancel={() => { if (!busy) { setModalOpen(false); setDraft(null); } }}
+          onSubmit={submitTicket}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+Keep the existing `<AiContextBadge>` / error / `<AiChatMessages>` / `<AiChatInput>` blocks exactly as they were — only the new toolbar row, the modal, and the imports/hooks are added.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @breeze/web test -- WorkspaceChatPanel`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Typecheck the web app**
+
+Run: `pnpm --filter @breeze/web exec tsc --noEmit` (or the repo's web typecheck).
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/workspace/WorkspaceChatPanel.tsx apps/web/src/components/workspace/WorkspaceChatPanel.test.tsx
+git commit -m "feat(web): wire Create Ticket button into the AI chat panel"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the API test suite: `pnpm --filter @breeze/api test -- ai.ticket aiTicketDraft` → all PASS.
+- [ ] Run the web test suite: `pnpm --filter @breeze/web test -- CreateTicketFromChatModal WorkspaceChatPanel` → all PASS.
+- [ ] Run the shared test suite: `pnpm --filter @breeze/shared test -- tickets.test` → PASS.
+- [ ] Typecheck all three packages.
+- [ ] **Manual smoke (optional, via the `run` / `feature-testing` skill):** open the web app, start an AI conversation on a device, exchange at least one assistant message, click **Create Ticket**, confirm the modal prefills a plain-English draft, save, and verify the ticket appears with `source = ai` and (for a partner-scope login) a linked time entry.
+```
+```
+
+## Notes for the executor
+
+- The `postDraft` / `postTicket` / `partnerAuth` / `orgAuth` test helpers in Tasks 3–4 are not spelled out because the exact Hono test harness + auth-injection pattern varies; **copy it from an existing route test** in `apps/api/src/routes/` (e.g. `ai.test.ts` if present, or another `*.test.ts` that exercises an authenticated route) rather than inventing one. `partnerAuth` must have `scope: 'partner'`; `orgAuth` must have `scope: 'organization'`.
+- If `apps/web` uses `astro check` rather than `tsc --noEmit` for typechecking, use that (see the `ci_astro_check_and_integration_tests_gotchas` convention).
+- Do NOT edit any shipped migration or add a new one — this feature needs no schema change.

--- a/docs/superpowers/specs/2026-07-08-create-ticket-from-ai-conversation-design.md
+++ b/docs/superpowers/specs/2026-07-08-create-ticket-from-ai-conversation-design.md
@@ -67,12 +67,13 @@ API: load ai_messages → LLM summarization → return DRAFT (nothing written)
         │   { subject, description, resolutionNote?, status,
         │     timeMinutes, billable, priority? }
         ▼
-API (one transaction):
+API (sequential service calls):
    createTicket({ orgId, deviceId, subject, description, priority,
-                  source: 'ai' }, actor)
-   → if status === 'resolved': apply resolve transition + resolutionNote
-   → insert timeEntry(ticketId, orgId, userId, durationMinutes, isBillable)
-   → return { data: ticket }
+                  source: 'ai' }, actor)              ← critical, atomic
+   → if status === 'resolved': changeTicketStatus(id, {status:'resolved'},
+                                {resolutionNote}, actor)
+   → if timeMinutes > 0 AND scope∈{partner,system}: createTimeEntry(...)   ← best-effort
+   → return { data: ticket, resolved, timeLogged }
         ▼
 Toast "Ticket #NNNN created" + link; modal closes
 ```
@@ -97,12 +98,12 @@ client payload — a client cannot smuggle a cross-tenant device/org into the ti
   `{ subject (1–255), description (problem summary), resolutionNote? (required when status==='resolved'),
      status: 'open' | 'resolved', timeMinutes (int ≥ 0), billable (bool), priority? }`.
   Cross-field rule mirrors `changeTicketStatusSchema`: `resolutionNote` required when `status === 'resolved'`.
-- **Behavior (single transaction):**
-  1. `createTicket({ orgId: session.orgId, deviceId: session.deviceId, subject, description, priority, source: 'ai' }, actorFrom(c))`.
-  2. If `status === 'resolved'`: apply the resolve transition (sets `resolvedAt`, `resolutionNote`) — reuse the same path `changeTicketStatus`/`updateTicket` uses so SLA/comment side effects stay consistent.
-  3. Insert a `timeEntry`: `{ ticketId, orgId: session.orgId, userId: auth.user.id, durationMinutes: timeMinutes, isBillable: billable, description: 'Logged from AI conversation' }`. Skip if `timeMinutes === 0`.
-  4. Return `{ data: ticket }`.
-- **Atomicity:** all in one DB transaction so a failure never leaves a half-created ticket.
+- **Behavior (sequential service calls — the three services each own their own DB writes and do not accept a shared transaction handle):**
+  1. `createTicket({ orgId: session.orgId, deviceId, subject, description, priority, source: 'ai' }, actor)`. This is the **critical, atomic** step (a single insert internally). `deviceId` comes from `session.deviceId`, dropped if the caller fails the site-scope check.
+  2. If `status === 'resolved'`: `changeTicketStatus(ticket.id, { status: 'resolved' }, { resolutionNote }, actor)` — reuses the FSM path so `resolvedAt` and SLA/comment side effects stay consistent. `new → resolved` is a valid transition, so a freshly created ticket resolves directly.
+  3. If `timeMinutes > 0` **and** the caller's `auth.scope ∈ {partner, system}`: `createTimeEntry({ ticketId: ticket.id, startedAt: now − timeMinutes·60s, endedAt: now, description: 'Logged from AI conversation', isBillable: billable }, timeActorFrom(c))`. The time-entries surface has no org-axis RLS policy, so this is intentionally **partner/system-scope only**; wrap it in try/catch.
+  4. Return `{ data: ticket, resolved: boolean, timeLogged: boolean }`.
+- **Failure model:** ticket creation is atomic (single service call), so the ticket is never half-created. Resolve and time-entry are follow-up enrichments — if either fails (or time can't be logged for scope reasons), the ticket persists and the response's `resolved` / `timeLogged` flags report what actually happened, which the UI surfaces. A ticket without a logged time entry is a valid ticket.
 
 ## Summarization contract — `apps/api/src/services/aiTicketDraft.ts`
 
@@ -157,9 +158,10 @@ failure to a friendly modal state (see Error Handling).
 
 ## Tenancy / security
 
-- `orgId` and `deviceId` come from the session row server-side; the client cannot override them.
-- The save route re-checks `auth.canAccessOrg(session.orgId)` and `requirePermission(TICKETS_WRITE)`.
-- No new table; `tickets` and `timeEntries` RLS already covers these writes.
+- `orgId` and `deviceId` come from the session row server-side; the client cannot override them. Tenant scoping is enforced by `getSession(id, auth)` / `getSessionMessages(id, auth)`, which bake `auth.orgCondition(aiSessions.orgId)` into the load — an unreachable session returns `null` → 404 (no separate `canAccessOrg` call needed).
+- Both routes require `requirePermission(TICKETS_WRITE)`.
+- `deviceId` is additionally passed through `deviceInSiteScope(auth, session.deviceId)`; if a site-restricted caller can't reach the device, `deviceId` is dropped and the ticket is created org-only (never blocks creation).
+- Time-entry logging is gated on `auth.scope ∈ {partner, system}` (the `time_entries` table has no org-axis RLS policy). No new table; `tickets` and `time_entries` RLS already covers these writes.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-08-create-ticket-from-ai-conversation-design.md
+++ b/docs/superpowers/specs/2026-07-08-create-ticket-from-ai-conversation-design.md
@@ -1,0 +1,184 @@
+# Create Ticket from an AI Conversation — Design
+
+**Date:** 2026-07-08
+**Status:** Approved (brainstorming) → ready for implementation plan
+**Surface:** Web technician AI Agent (WorkspaceChatPanel) only
+
+## Summary
+
+Add a **"Create Ticket"** button to the technician-facing web AI chat panel. Clicking it
+uses an LLM to read the conversation transcript and produce a plain-English, customer-readable
+draft ticket — a short problem summary, a resolution summary (if the issue was fixed), a
+suggested status (open vs. resolved), and a suggested time value. The tech reviews and edits
+the draft in a **preview-and-confirm modal**, then saves. On save, the ticket is created
+against the conversation's device and org, optionally resolved, and a time entry is logged.
+
+The value: turn an ad-hoc troubleshooting conversation into a properly attributed, billable,
+customer-readable ticket in one click — with a human confirmation step before anything is written.
+
+## Decisions (from brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Create flow | **Preview & confirm modal** — AI drafts, tech edits, ticket written only on Save |
+| Time source | **Session elapsed time, AI may trim** for idle gaps / non-work chatter |
+| Surface scope | **Web technician AI Agent only** (Helper + Excel client-ai deferred) |
+| Summary style | **Plain-English, customer-readable** (problem → description, resolution → resolutionNote) |
+| Architecture | **Approach A** — dedicated draft + save endpoint pair; reuse `createTicket()` service |
+
+## What already exists (reused, not built)
+
+- `tickets` table already has `source: 'ai'` in `ticketSourceEnum` (`apps/api/src/db/schema/portal.ts`).
+- `createTicket()` service accepts `source: 'ai'` via its discriminated union (`apps/api/src/services/ticketService.ts`).
+- Ticket statuses include `resolved`; resolving requires a `resolutionNote` (`changeTicketStatusSchema`).
+- Full time-tracking subsystem: `timeEntries` table (`ticketId`, `orgId`, `userId`, `durationMinutes`, `isBillable`, `hourlyRate`, `billingStatus`) in `apps/api/src/db/schema/timeTracking.ts`.
+- `ai_sessions` already persists `orgId` (NOT NULL), `deviceId` (nullable), and `contextSnapshot` (jsonb) — device/customer linkage is free.
+- `ai_messages` holds the transcript to summarize.
+- The `manage_tickets` AI tool already performs an `action:'create'` with `source:'ai'` — the save path reuses the same `createTicket()` service, so no logic is duplicated.
+- Org/site access guards (`auth.canAccessOrg`, `requirePermission(TICKETS_WRITE)`) already exist.
+
+**No new table → no RLS migration.** Writes land in `tickets` and `timeEntries`, both already RLS-covered.
+
+## What is net-new
+
+1. Two endpoints in `apps/api/src/routes/ai.ts` (draft + save).
+2. One transcript-summarization service (`apps/api/src/services/aiTicketDraft.ts`) — there is no existing chat-transcript summarizer today.
+3. `CreateTicketFromChatModal.tsx` React component.
+4. A toolbar "Create Ticket" action in `WorkspaceChatPanel.tsx`.
+5. Two `workspaceStore` actions.
+
+## Data flow
+
+```
+[Create Ticket button in WorkspaceChatPanel]
+        │ click (disabled until ≥1 assistant message)
+        ▼
+workspaceStore.draftTicketFromSession(tabId)
+        │ POST /ai/sessions/:id/ticket-draft
+        ▼
+API: load ai_messages → LLM summarization → return DRAFT (nothing written)
+        │ { subject, problemSummary, resolutionSummary, wasFixed,
+        │   suggestedStatus, suggestedTimeMinutes,
+        │   orgId, orgName, deviceId, deviceHostname }
+        ▼
+[CreateTicketFromChatModal] renders draft, all fields editable
+        │ tech edits + clicks Save
+        │ POST /ai/sessions/:id/ticket
+        │   { subject, description, resolutionNote?, status,
+        │     timeMinutes, billable, priority? }
+        ▼
+API (one transaction):
+   createTicket({ orgId, deviceId, subject, description, priority,
+                  source: 'ai' }, actor)
+   → if status === 'resolved': apply resolve transition + resolutionNote
+   → insert timeEntry(ticketId, orgId, userId, durationMinutes, isBillable)
+   → return { data: ticket }
+        ▼
+Toast "Ticket #NNNN created" + link; modal closes
+```
+
+`orgId` and `deviceId` are always taken from the **session row server-side**, never from the
+client payload — a client cannot smuggle a cross-tenant device/org into the ticket.
+
+## Endpoint 1 — `POST /ai/sessions/:id/ticket-draft`
+
+- **Guards:** session exists and `auth.canAccessOrg(session.orgId)`; `requirePermission(TICKETS_WRITE)`.
+- **Behavior:** load the session's `ai_messages` (user/assistant/tool_result roles), compute elapsed
+  minutes (`session.createdAt → now`) as the time ceiling, call the summarizer, return the draft.
+  **No DB writes.**
+- **Thin transcript:** if there is not enough conversation to summarize (e.g. no assistant turn),
+  return `422` with a friendly message the modal surfaces as "not enough conversation to draft a ticket."
+- **Response:** the draft object (see contract below) plus resolved `orgName` / `deviceHostname` for display.
+
+## Endpoint 2 — `POST /ai/sessions/:id/ticket`
+
+- **Guards:** same as above + `zValidator('json', createTicketFromChatSchema)`.
+- **`createTicketFromChatSchema`** (new, `packages/shared/src/validators/`):
+  `{ subject (1–255), description (problem summary), resolutionNote? (required when status==='resolved'),
+     status: 'open' | 'resolved', timeMinutes (int ≥ 0), billable (bool), priority? }`.
+  Cross-field rule mirrors `changeTicketStatusSchema`: `resolutionNote` required when `status === 'resolved'`.
+- **Behavior (single transaction):**
+  1. `createTicket({ orgId: session.orgId, deviceId: session.deviceId, subject, description, priority, source: 'ai' }, actorFrom(c))`.
+  2. If `status === 'resolved'`: apply the resolve transition (sets `resolvedAt`, `resolutionNote`) — reuse the same path `changeTicketStatus`/`updateTicket` uses so SLA/comment side effects stay consistent.
+  3. Insert a `timeEntry`: `{ ticketId, orgId: session.orgId, userId: auth.user.id, durationMinutes: timeMinutes, isBillable: billable, description: 'Logged from AI conversation' }`. Skip if `timeMinutes === 0`.
+  4. Return `{ data: ticket }`.
+- **Atomicity:** all in one DB transaction so a failure never leaves a half-created ticket.
+
+## Summarization contract — `apps/api/src/services/aiTicketDraft.ts`
+
+One LLM call (reuse the agent SDK infra) with a strict prompt that must return JSON validated
+against a Zod schema:
+
+```ts
+{
+  subject: string,            // ≤120 chars
+  problemSummary: string,     // plain-English, no jargon / commands / tool output
+  resolutionSummary: string,  // "" if not fixed
+  wasFixed: boolean,          // → suggestedStatus 'resolved' vs 'open'
+  suggestedTimeMinutes: number
+}
+```
+
+**Prompt inputs:** the transcript, session `contextSnapshot`, and the computed elapsed minutes
+(passed as the ceiling / seed for `suggestedTimeMinutes`).
+
+**Prompt instructions:**
+- Write for a **non-technical reader**; the resolution text is shown to the customer — no jargon,
+  no command output, no internal tool names.
+- Only set `wasFixed: true` if the conversation shows the issue was actually **verified** fixed
+  (not merely attempted).
+- Seed `suggestedTimeMinutes` from the elapsed ceiling but trim it if the transcript shows long
+  idle gaps or non-work chatter; never exceed the elapsed ceiling.
+
+**Failure handling:** on invalid JSON, retry once, then return `422`. The route maps summarizer
+failure to a friendly modal state (see Error Handling).
+
+## UI
+
+- **`apps/web/src/components/workspace/WorkspaceChatPanel.tsx`** — add a small toolbar row near
+  `AiContextBadge` with a **"Create Ticket"** button, disabled until there is ≥1 assistant message.
+  Clicking opens the modal in a `drafting` (spinner) state while the draft endpoint runs.
+- **`apps/web/src/components/ai/CreateTicketFromChatModal.tsx`** (new) — matches the approved mockup:
+  read-only Org / Device chips; editable **Subject**, **Problem** (description), **Resolution**;
+  an **Open / Resolved** radio (selecting Resolved makes Resolution required); **Time** (number, minutes)
+  + **Billable** checkbox; optional **Priority**. Save is wrapped in `runAction`
+  (`apps/web/src/lib/runAction.ts`) per the repo's mutation-feedback rule.
+- **`apps/web/src/stores/workspaceStore.ts`** — `draftTicketFromSession(tabId)` and
+  `saveTicketFromSession(tabId, payload)` actions.
+
+## Error handling
+
+- **Thin transcript** → `422`; modal shows "not enough conversation to draft a ticket."
+- **LLM failure** → toast; modal stays open with empty editable fields so the tech can still write
+  the ticket manually (graceful degradation, not a dead end).
+- **Resolve without note** → blocked client-side in the modal (Save disabled) AND server-side by
+  `createTicketFromChatSchema`, matching `changeTicketStatusSchema`.
+- **Save failure** → surfaced by `runAction` (which also treats `{success:false}` 200 bodies as failures).
+
+## Tenancy / security
+
+- `orgId` and `deviceId` come from the session row server-side; the client cannot override them.
+- The save route re-checks `auth.canAccessOrg(session.orgId)` and `requirePermission(TICKETS_WRITE)`.
+- No new table; `tickets` and `timeEntries` RLS already covers these writes.
+
+## Testing
+
+- **API route tests** (`apps/api/src/routes/ai.*.test.ts` or sibling):
+  - draft returns a non-persisted object (no ticket row created);
+  - save creates a ticket with `source:'ai'` **and** a linked `timeEntry`;
+  - resolved path sets `resolvedAt` + `resolutionNote`;
+  - `timeMinutes === 0` creates no time entry;
+  - a session belonging to another org is rejected `403`;
+  - thin transcript returns `422`.
+- **Summarizer unit test** (`aiTicketDraft.test.ts`): mocked LLM; asserts Zod schema conformance,
+  `wasFixed → suggestedStatus` mapping, and that `suggestedTimeMinutes` never exceeds the elapsed ceiling.
+- **Web tests**: modal renders the draft; Resolved requires Resolution before Save enables; Save
+  calls the store action with the edited payload.
+- Follow `breeze-testing` conventions (Drizzle mocks, co-located test files).
+
+## Scope guardrails (YAGNI — explicitly out of v1)
+
+- Web technician AI Agent only (Breeze Helper and Excel client-ai deferred).
+- Button-triggered only — the agent does **not** autonomously offer to create a ticket.
+- No auto-population of category / assignee / SLA — the tech sets those on the ticket afterward.
+- No editing/attaching to an existing ticket from chat — create-only.

--- a/packages/shared/src/types/ai.ts
+++ b/packages/shared/src/types/ai.ts
@@ -96,6 +96,20 @@ export type AiPageContext =
   | { type: 'dashboard'; orgName?: string; deviceCount?: number; alertCount?: number }
   | { type: 'custom'; label: string; data: Record<string, unknown> };
 
+export interface AiTicketDraft {
+  subject: string;
+  problemSummary: string;
+  resolutionSummary: string;
+  wasFixed: boolean;
+  suggestedStatus: 'open' | 'resolved';
+  suggestedTimeMinutes: number;
+  elapsedMinutes: number;
+  orgId: string;
+  orgName: string | null;
+  deviceId: string | null;
+  deviceHostname: string | null;
+}
+
 // ============================================
 // SSE Event Types
 // ============================================

--- a/packages/shared/src/types/ai.ts
+++ b/packages/shared/src/types/ai.ts
@@ -100,7 +100,6 @@ export interface AiTicketDraft {
   subject: string;
   problemSummary: string;
   resolutionSummary: string;
-  wasFixed: boolean;
   suggestedStatus: 'open' | 'resolved';
   suggestedTimeMinutes: number;
   elapsedMinutes: number;

--- a/packages/shared/src/validators/tickets.test.ts
+++ b/packages/shared/src/validators/tickets.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   createTicketSchema, updateTicketSchema, changeTicketStatusSchema,
   assignTicketSchema, addTicketCommentSchema, listTicketsQuerySchema,
-  ticketCategoryInputSchema, bulkTicketActionSchema, editCommentSchema, moveTicketOrgSchema
+  ticketCategoryInputSchema, bulkTicketActionSchema, editCommentSchema, moveTicketOrgSchema,
+  createTicketFromChatSchema
 } from './tickets';
 
 describe('ticket validators', () => {
@@ -213,5 +214,28 @@ describe('ticket validators', () => {
     it('rejects a non-uuid orgId', () => {
       expect(moveTicketOrgSchema.safeParse({ orgId: 'nope' }).success).toBe(false);
     });
+  });
+});
+
+describe('createTicketFromChatSchema', () => {
+  const base = { subject: 'Outlook would not open', description: 'Sarah could not open Outlook.', status: 'open' as const, timeMinutes: 15, billable: true };
+
+  it('accepts a valid open-ticket payload', () => {
+    expect(createTicketFromChatSchema.parse(base)).toMatchObject({ status: 'open', timeMinutes: 15 });
+  });
+
+  it('requires a resolutionNote when status is resolved', () => {
+    const r = createTicketFromChatSchema.safeParse({ ...base, status: 'resolved' });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts a resolved payload with a resolutionNote', () => {
+    const r = createTicketFromChatSchema.safeParse({ ...base, status: 'resolved', resolutionNote: 'Rebuilt the mail profile.' });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects negative timeMinutes and empty subject', () => {
+    expect(createTicketFromChatSchema.safeParse({ ...base, timeMinutes: -1 }).success).toBe(false);
+    expect(createTicketFromChatSchema.safeParse({ ...base, subject: '' }).success).toBe(false);
   });
 });

--- a/packages/shared/src/validators/tickets.ts
+++ b/packages/shared/src/validators/tickets.ts
@@ -24,6 +24,23 @@ export const createTicketSchema = z.object({
   submitterEmail: z.string().email().max(255).optional()
 });
 
+export const createTicketFromChatSchema = z
+  .object({
+    subject: z.string().min(1).max(255),
+    description: z.string().max(50_000).optional(),
+    status: z.enum(['open', 'resolved']),
+    resolutionNote: z.string().max(50_000).optional(),
+    timeMinutes: z.number().int().min(0).max(24 * 60),
+    billable: z.boolean(),
+    priority: ticketPrioritySchema.optional(),
+  })
+  .refine((v) => v.status !== 'resolved' || (v.resolutionNote?.trim().length ?? 0) > 0, {
+    message: 'A resolution note is required to resolve a ticket',
+    path: ['resolutionNote'],
+  });
+
+export type CreateTicketFromChatInput = z.infer<typeof createTicketFromChatSchema>;
+
 export const updateTicketSchema = z.object({
   subject: z.string().min(1).max(255).optional(),
   description: z.string().max(50_000).optional(),


### PR DESCRIPTION
## What

Adds a **Create Ticket** button to the web technician AI chat panel. It drafts a plain-English, customer-readable ticket from the conversation transcript (problem summary, resolution, suggested open/resolved status, and a suggested time), shows it in a preview-and-confirm modal for the tech to edit, and on save creates the ticket (`source:'ai'`) against the session's org/device — optionally resolving it and logging a time entry.

Scope: **web technician AI Agent only** (Helper / Excel deferred), button-triggered, create-only.

## How

- **`POST /ai/sessions/:id/ticket-draft`** — reads the session transcript, one LLM summarization call, returns a *non-persisted* draft. `422` on a thin transcript, `502` on an upstream LLM/infra failure.
- **`POST /ai/sessions/:id/ticket`** — creates the ticket via the existing `createTicket` service, optionally resolves it, and best-effort logs a time entry. `orgId`/`deviceId` are derived **server-side** from the org-scoped session load (never trusted from the client); time-entry logging is gated to partner/system scope (`time_entries` has no org-axis RLS policy).
- New summarizer service `aiTicketDraft.ts`, `CreateTicketFromChatModal`, store actions, and shared `createTicketFromChatSchema` + `AiTicketDraft`.
- **No new table / no migration** — reuses `tickets` and `time_entries` (both already RLS-covered).

## Reuse

`source:'ai'` and `new → resolved` already existed; the save path reuses `createTicket` / `changeTicketStatus` / `createTimeEntry` and the `deviceInSiteScope` + `timeActorFrom` helpers.

## Failure model

Ticket creation is the critical, atomic step. Resolve and time-entry are best-effort follow-ups — if either fails, the ticket persists and the UI raises a distinct warning toast (and the server logs + `captureException`s the cause).

## Tests

Unit + route + component + store coverage at every layer (API 22, web 12, shared 38 — all green; `tsc` clean for api and web). Design & implementation plan under `docs/superpowers/`.

## Review

Went through a 4-agent PR review (correctness, silent-failure, test-coverage, type-design); all findings addressed in the last two commits. Tenant isolation independently confirmed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)