### PR TITLE
fix(mcp): use zod 4 native toJSONSchema so bootstrap tools/list loads

### DIFF
--- a/apps/api/src/routes/mcpServer.test.ts
+++ b/apps/api/src/routes/mcpServer.test.ts
@@ -338,6 +338,15 @@ describe('MCP bootstrap carve-out', () => {
     const names = listBody.result.tools.map((t: any) => t.name);
     expect(names).toContain('send_deployment_invites');
 
+    // Regression: the bootstrap tool's zod schema must convert to a JSON Schema
+    // that carries a `type`. The old hand-rolled converter switched on the
+    // zod-3 `_def.typeName` (removed in zod 4) and fell through to `{}`, which
+    // MCP clients reject — failing the ENTIRE tools/list (0 tools loaded).
+    const sendTool = listBody.result.tools.find(
+      (t: any) => t.name === 'send_deployment_invites',
+    );
+    expect(sendTool?.inputSchema?.type).toBe('object');
+
     // 2) tools/call dispatches to the handler with parsed input + ctx.apiKey.
     const callRes = await mod.mcpServerRoutes.request('/message', {
       method: 'POST',

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -20,7 +20,7 @@
 import { randomBytes } from 'node:crypto';
 import { Hono, type Context, type Next } from 'hono';
 import { streamSSE } from 'hono/streaming';
-import type { z } from 'zod';
+import { z } from 'zod';
 import { MCP_OAUTH_ENABLED, OAUTH_ISSUER } from '../config/env';
 import { apiKeyAuthMiddleware, requireApiKeyScope } from '../middleware/apiKeyAuth';
 import { bearerTokenAuthMiddleware, resolvePartnerAccessibleOrgIds } from '../middleware/bearerTokenAuth';
@@ -174,69 +174,23 @@ export async function __loadMcpBootstrapForTests(): Promise<BootstrapModule | nu
 }
 
 /**
- * Minimal zod → JSON Schema converter covering the shapes used by bootstrap
- * tool input schemas (objects with string/enum/email fields). We don't pull
- * in `zod-to-json-schema` for one use-site; if future bootstrap tools need
- * richer shapes, swap this for the package.
+ * Convert a bootstrap tool's zod input schema to JSON Schema for `tools/list`,
+ * using zod 4's native `z.toJSONSchema` with input semantics (a field carrying
+ * a `.default()` is optional for the caller, so it stays out of `required`).
+ *
+ * The previous hand-rolled converter switched on `schema._def.typeName`, which
+ * zod 4 removed — so every schema fell through to `{}`, an inputSchema with no
+ * `type`. MCP clients reject that, and one bad tool schema fails the WHOLE
+ * `tools/list` (Claude Code showed "fetching tools failed", 0 tools loaded).
+ *
+ * `$schema` is stripped: an MCP inputSchema is an embedded schema object, not a
+ * standalone JSON Schema document.
  */
 function zodToJsonSchema(schema: z.ZodSchema<any>): Record<string, unknown> {
-  const def: any = (schema as any)._def;
-  if (!def) return { type: 'object' };
-  switch (def.typeName) {
-    case 'ZodObject': {
-      const shape = typeof def.shape === 'function' ? def.shape() : def.shape;
-      const properties: Record<string, unknown> = {};
-      const required: string[] = [];
-      for (const [key, value] of Object.entries(shape)) {
-        const child = value as z.ZodSchema<any>;
-        properties[key] = zodToJsonSchema(child);
-        const childDef: any = (child as any)._def;
-        if (childDef?.typeName !== 'ZodOptional' && childDef?.typeName !== 'ZodDefault') {
-          required.push(key);
-        }
-      }
-      const out: Record<string, unknown> = { type: 'object', properties };
-      if (required.length > 0) out.required = required;
-      return out;
-    }
-    case 'ZodString': {
-      const out: Record<string, unknown> = { type: 'string' };
-      for (const check of def.checks ?? []) {
-        if (check.kind === 'email') out.format = 'email';
-        if (check.kind === 'uuid') out.format = 'uuid';
-        if (check.kind === 'min') out.minLength = check.value;
-        if (check.kind === 'max') out.maxLength = check.value;
-      }
-      return out;
-    }
-    case 'ZodEnum':
-      return { type: 'string', enum: [...def.values] };
-    case 'ZodNumber':
-      return { type: 'number' };
-    case 'ZodBoolean':
-      return { type: 'boolean' };
-    case 'ZodArray': {
-      // Without this case, MCP clients (Claude.ai, ChatGPT) see `emails: {}` —
-      // an unconstrained schema interpreted as `any`, and the client coerces
-      // arrays to strings before validation. Surfaced via send_deployment_invites
-      // when its `emails: z.array(z.string().email())` declared the array shape
-      // but the converter dropped it.
-      const out: Record<string, unknown> = {
-        type: 'array',
-        items: zodToJsonSchema(def.type),
-      };
-      for (const check of def.checks ?? []) {
-        if (check.kind === 'min') out.minItems = check.value;
-        if (check.kind === 'max') out.maxItems = check.value;
-      }
-      return out;
-    }
-    case 'ZodOptional':
-    case 'ZodDefault':
-      return zodToJsonSchema(def.innerType);
-    default:
-      return {};
-  }
+  const { $schema: _dropped, ...jsonSchema } = z.toJSONSchema(schema, {
+    io: 'input',
+  }) as Record<string, unknown>;
+  return jsonSchema;
 }
 
 /**


### PR DESCRIPTION
## Problem

The `breeze-cloud` MCP server's `tools/list` fails to load any tools for API keys with the `ai:execute` scope. In Claude Code this surfaces as **"fetching tools failed" / 0 tools loaded**.

Root cause: the hand-rolled `zodToJsonSchema` in `apps/api/src/routes/mcpServer.ts` switches on `schema._def.typeName`. **Zod 4 (bundled `zod@^4.4.3`) removed `_def.typeName`**, so every schema falls through to the `default: return {}` branch — an `inputSchema` with no `type`. MCP clients reject a tool whose `inputSchema` has no `type`, and one bad tool schema fails the **entire** `tools/list`.

Only the two bootstrap auth tools `send_deployment_invites` and `configure_defaults` route through this converter (the other ~167 tools ship pre-built `input_schema`), but that's enough to break the whole list. It surfaces only to `ai:execute`-scoped keys.

## Fix

Replace the hand-rolled converter with Zod 4's native `z.toJSONSchema(schema, { io: 'input' })`:

- `io: 'input'` gives correct input semantics — a field carrying `.default()` is optional for the caller, so it stays out of `required` (verified: `send_deployment_invites` → `required: ["emails"]`, `configure_defaults` → `required: []`).
- Strips the redundant top-level `$schema` key (an MCP `inputSchema` is an embedded schema object, not a standalone JSON Schema document).
- Changes `import type { z }` → `import { z }` since `z.toJSONSchema` is a runtime call.

Produces full, correct JSON Schema (properties, `required`, `format: email`, enums, array `minItems`/`maxItems`) instead of `{}`.

## Test

`mcpServer.test.ts` previously asserted only that the tool **name** appeared in `tools/list`, so it never caught this. Added a regression assertion that the surfaced tool's `inputSchema` carries `type: 'object'` (fails on the old `{}`, passes on the fix).

## Verification (local, node 22.20.0)

- `vitest run src/routes/mcpServer.test.ts` → 37/37 pass (incl. the new assertion)
- `vitest run` the two bootstrap tool suites → 29/29 pass
- `tsc --noEmit --project apps/api/tsconfig.json` → clean
- `eslint` on both changed files → clean
- Empirically confirmed `z.toJSONSchema` output on both real tool schemas is correct MCP-compatible JSON Schema; the old converter returns `{}` for the same input.

No dependencies added (`z.toJSONSchema` ships in the already-bundled `zod@4.4.3`); no Dockerfile / Go / migration changes.
