### PR TITLE
fix(vuln): match catalog products case-insensitively in correlation

### DIFF
--- a/apps/api/src/services/vulnerabilityCorrelation.integration.test.ts
+++ b/apps/api/src/services/vulnerabilityCorrelation.integration.test.ts
@@ -175,6 +175,58 @@ describe('correlateOrg', () => {
     expect(Number(rows[0]!.riskScore)).toBe(9.8);
   });
 
+  runDb('matches a catalog product whose normalized_name is stored capitalized (MSRC-style)', async () => {
+    // The MSRC sync stores software_products.normalized_name verbatim from the
+    // CVRF product name (capitalized, not lowercased). The correlation join must
+    // still match it against the installed DisplayName, or ~all MSRC/authoritative
+    // products (thousands of them) silently never correlate. Regression for #2290.
+    const { orgId, deviceId } = await seedOrgWithDevice();
+    await withSystemDbAccessContext(async () => {
+      const [product] = await db
+        .insert(softwareProducts)
+        .values({
+          normalizedName: 'Microsoft 365 Apps for Enterprise', // capitalized, as the MSRC sync writes it
+          normalizedVendor: 'microsoft',
+          cpe: 'cpe:2.3:a:microsoft:365_apps:*:*:*:*:enterprise:*:*:*',
+          cpeConfidence: 'authoritative',
+        })
+        .returning({ id: softwareProducts.id });
+      if (!product) throw new Error('failed to seed software product');
+
+      const [vulnerability] = await db
+        .insert(vulnerabilities)
+        .values({
+          cveId: 'CVE-2025-CAPS1',
+          source: 'msrc',
+          description: 'Capitalized-name product test vulnerability',
+          severity: 'critical',
+          cvssVersion: '3.1',
+          cvssScore: '9.8',
+          knownExploited: false,
+          patchAvailable: true,
+          rawPayload: { test: true },
+        })
+        .returning({ id: vulnerabilities.id });
+      if (!vulnerability) throw new Error('failed to seed vulnerability');
+
+      await db.insert(softwareVulnerabilities).values({
+        productId: product.id,
+        vulnerabilityId: vulnerability.id,
+        versionEndExcluding: '16.0.14332.20500',
+      });
+    });
+    await seedInventory({
+      orgId,
+      deviceId,
+      name: 'Microsoft 365 Apps for Enterprise',
+      version: '16.0.14332.20481',
+    });
+
+    const res = await correlateOrg(orgId);
+
+    expect(res.created).toBe(1);
+  });
+
   runDb('does not flag a device that is already at or above FixedBuild', async () => {
     const { orgId, deviceId } = await seedOrgWithDevice();
     await seedSoftwareProductAndFact();

--- a/apps/api/src/services/vulnerabilityCorrelation.ts
+++ b/apps/api/src/services/vulnerabilityCorrelation.ts
@@ -199,7 +199,7 @@ export async function correlateOrg(
       .from(softwareInventory)
       .innerJoin(
         softwareProducts,
-        sql`${softwareProducts.normalizedName} = lower(trim(${softwareInventory.name}))`
+        sql`lower(${softwareProducts.normalizedName}) = lower(trim(${softwareInventory.name}))`
       )
       .innerJoin(
         softwareVulnerabilities,
@@ -257,7 +257,7 @@ export async function correlateOrg(
       .from(softwareInventory)
       .innerJoin(
         softwareProducts,
-        sql`${softwareProducts.normalizedName} = lower(trim(${softwareInventory.name}))`
+        sql`lower(${softwareProducts.normalizedName}) = lower(trim(${softwareInventory.name}))`
       )
       .innerJoin(
         softwareVulnerabilities,


### PR DESCRIPTION
## Problem

The device→catalog correlation join compared `softwareProducts.normalizedName` against `lower(trim(softwareInventory.name))` — lowercasing **only the inventory side**:

```
softwareProducts.normalizedName = lower(trim(softwareInventory.name))
```

The MSRC sync (`upsertSoftwareProduct`, `vulnerabilityJobs.ts:489`) stores `normalized_name` verbatim from the CVRF product name — **capitalized** (e.g. `"Microsoft Edge (Chromium-based)"`, `"Visual Studio Code"`). So every MSRC/authoritative product (thousands of rows) failed the case-sensitive join and was **silently never correlated**. Only curated products (already lowercased, e.g. `google chrome`) could match.

Observed on a production 24-device Windows fleet: the Vulnerabilities dashboard surfaced **only Google Chrome** despite **1,841 distinct installed apps** and a catalog of 3,449 CPE-bearing products.

## Fix

Lowercase **both** sides of the join, in both correlation passes (`vulnerabilityCorrelation.ts`):

```
lower(softwareProducts.normalizedName) = lower(trim(softwareInventory.name))
```

This is a pure read-side change — it re-activates the existing capitalized catalog rows immediately, with **no data backfill and no touching the `(normalized_name, normalized_vendor)` unique index**.

## Scope / what this does NOT fix

This makes the matcher case-insensitive. It does **not** address DisplayName-noise cases (`"Adobe Acrobat (64-bit)"`, `"…- en-us"`) that never equal a catalog name even after lowercasing — that needs the DisplayName-normalization + curated-map/token-resolver work tracked in #2290. This PR is the safe, migration-free first step of #2290.

## Testing

- Added a regression integration test: a catalog product stored with a capitalized `normalized_name` (MSRC-style) now correlates against installed software (RED→GREEN confirmed).
- Full correlation suite green: 18/18 across `vulnerabilityCorrelation`, `…Phase2`, and `…Gating` integration tests.

Refs #2290
