### PR TITLE
fix(vuln): deterministic DisplayName→CPE resolver for correlation (#2290)

### DIFF
--- a/apps/api/migrations/2026-07-08-vuln-product-resolutions.sql
+++ b/apps/api/migrations/2026-07-08-vuln-product-resolutions.sql
@@ -1,0 +1,41 @@
+-- apps/api/migrations/2026-07-08-vuln-product-resolutions.sql
+-- Global DisplayName→product resolution cache + unmatched-name log (#2290).
+-- System-only RLS, same shape as vulnerabilities/software_products.
+
+CREATE TABLE IF NOT EXISTS software_product_resolutions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  lookup_name VARCHAR(500) NOT NULL,          -- lower(trim(software_inventory.name)) — SQL join key
+  lookup_vendor VARCHAR(200),                 -- lower(trim(software_inventory.vendor))
+  normalized_name VARCHAR(500) NOT NULL,      -- post-token-strip form (observability only)
+  software_product_id UUID REFERENCES software_products(id),  -- NULL = unmatched (the log)
+  confidence VARCHAR(16) NOT NULL,            -- curated | exact | fuzzy | none
+  matched_via VARCHAR(32) NOT NULL,           -- dictionary | catalog_exact | token | unmatched
+  resolver_version INTEGER NOT NULL,
+  resolved_at TIMESTAMP NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS software_product_resolutions_key_idx
+  ON software_product_resolutions (lookup_name, lookup_vendor) NULLS NOT DISTINCT;
+
+CREATE INDEX IF NOT EXISTS software_product_resolutions_product_idx
+  ON software_product_resolutions (software_product_id);
+
+ALTER TABLE device_vulnerabilities ADD COLUMN IF NOT EXISTS match_confidence VARCHAR(16);
+
+-- System-only RLS (mirror 2026-06-22-vulnerability-management.sql). Forced RLS with a
+-- single system-scope policy; breeze_app (non-BYPASSRLS) is denied unless scope=system.
+DO $$
+BEGIN
+  EXECUTE 'ALTER TABLE software_product_resolutions ENABLE ROW LEVEL SECURITY';
+  EXECUTE 'ALTER TABLE software_product_resolutions FORCE ROW LEVEL SECURITY';
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'software_product_resolutions'
+      AND policyname = 'software_product_resolutions_system_only'
+  ) THEN
+    EXECUTE $f$CREATE POLICY software_product_resolutions_system_only ON software_product_resolutions
+      USING (current_setting('breeze.scope', true) = 'system')
+      WITH CHECK (current_setting('breeze.scope', true) = 'system')$f$;
+  END IF;
+END $$;

--- a/apps/api/scripts/regen-cpe-data.ts
+++ b/apps/api/scripts/regen-cpe-data.ts
@@ -1,0 +1,37 @@
+/*
+ * Regenerates cpe-translations.json from FleetDM's cpe_translations.json.
+ * Manual tool — NOT imported at runtime. Run: pnpm tsx scripts/regen-cpe-data.ts
+ * Requires network. Preserves the committed starter entries (union, dedup by name).
+ */
+import { writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const FLEET_URL =
+  'https://raw.githubusercontent.com/fleetdm/fleet/main/server/vulnerabilities/nvd/cpe_translations.json';
+const OUT = join(__dirname, '../src/services/__fixtures__/cpe-translations.json');
+
+interface FleetEntry {
+  software?: { name?: string[]; source?: string[] };
+  filter?: { product?: string[]; vendor?: string[]; skip?: boolean };
+}
+
+async function main(): Promise<void> {
+  const upstream = (await (await fetch(FLEET_URL)).json()) as FleetEntry[];
+  const existing = JSON.parse(readFileSync(OUT, 'utf8')) as Array<{ name: string; vendor: string; product: string }>;
+  const byName = new Map(existing.map((e) => [e.name, e]));
+
+  for (const entry of upstream) {
+    const names = entry.software?.name ?? [];
+    const product = entry.filter?.product?.[0];
+    const vendor = entry.filter?.vendor?.[0];
+    if (!product || !vendor || entry.filter?.skip) continue;
+    for (const name of names) {
+      if (name.startsWith('/')) continue;                 // skip regex-pattern entries
+      if (!byName.has(name)) byName.set(name, { name, vendor, product });
+    }
+  }
+  const merged = [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+  writeFileSync(OUT, JSON.stringify(merged, null, 2) + '\n');
+  console.log(`wrote ${merged.length} translation entries`);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -64,6 +64,7 @@ const INTENTIONAL_UNSCOPED: ReadonlySet<string> = new Set<string>([
   'software_products', // Global normalized software dimension. Forced RLS, no tenant policies → only system context.
   'software_vulnerabilities', // Global software-to-vulnerability match facts. Forced RLS, no tenant policies → only system context.
   'os_vulnerabilities', // Global OS-to-vulnerability match facts. Forced RLS, no tenant policies → only system context.
+  'software_product_resolutions', // Global DisplayName→product resolution cache/log (#2290). Forced RLS, system-only policy → only system context.
   'third_party_package_catalog', // System-wide curated catalog of third-party packages; writes gated by platform-admin role at the route layer.
   'third_party_release_tests', // System-wide release test results; references catalog (unscoped) and is platform-admin-only at the route layer.
 ]);

--- a/apps/api/src/__tests__/integration/vulnerabilityCorrelationGating.integration.test.ts
+++ b/apps/api/src/__tests__/integration/vulnerabilityCorrelationGating.integration.test.ts
@@ -16,6 +16,7 @@ import {
   sites,
   softwareInventory,
   softwareProducts,
+  softwareProductResolutions,
   softwareVulnerabilities,
   vulnerabilities,
 } from '../../db/schema';
@@ -24,6 +25,7 @@ import {
   resolveVulnerabilityEnabledForDevice,
 } from '../../services/featureConfigResolver';
 import { correlateOrg, correlateOsVulns } from '../../services/vulnerabilityCorrelation';
+import { refreshResolutionCache } from '../../services/cpeResolution';
 import { correlateEnabledOrgs } from '../../jobs/vulnerabilityJobs';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
@@ -189,6 +191,8 @@ beforeEach(async () => {
     await db.delete(deviceVulnerabilities);
     await db.delete(softwareVulnerabilities);
     await db.delete(osVulnerabilities);
+    await db.delete(softwareProductResolutions);
+    await db.delete(softwareInventory);
     await db.delete(softwareProducts);
     await db.delete(vulnerabilities);
   });
@@ -252,16 +256,19 @@ describe('correlateOrg deviceIds gating', () => {
     await seedVulnerableInventory(orgId, deviceId);
 
     // Empty set → no-op, no findings created.
+    await refreshResolutionCache();
     const none = await correlateOrg(orgId, { deviceIds: [] });
     expect(none).toEqual({ created: 0, resolved: 0 });
     expect(await openFindingCount(orgId, deviceId)).toBe(0);
 
     // Set excluding the device → still nothing.
+    await refreshResolutionCache();
     const other = await correlateOrg(orgId, { deviceIds: ['00000000-0000-0000-0000-000000000000'] });
     expect(other.created).toBe(0);
     expect(await openFindingCount(orgId, deviceId)).toBe(0);
 
     // Set including the device → one finding.
+    await refreshResolutionCache();
     const hit = await correlateOrg(orgId, { deviceIds: [deviceId] });
     expect(hit.created).toBe(1);
     expect(await openFindingCount(orgId, deviceId)).toBe(1);
@@ -270,10 +277,12 @@ describe('correlateOrg deviceIds gating', () => {
   runDb('empty deviceIds set does NOT resolve existing open findings', async () => {
     const { orgId, deviceId } = await seedOrgWithDevice();
     await seedVulnerableInventory(orgId, deviceId);
+    await refreshResolutionCache();
     await correlateOrg(orgId, { deviceIds: [deviceId] });
     expect(await openFindingCount(orgId, deviceId)).toBe(1);
 
     // A subsequent empty-set pass must be a true no-op, not a resolve-everything.
+    await refreshResolutionCache();
     const noop = await correlateOrg(orgId, { deviceIds: [] });
     expect(noop).toEqual({ created: 0, resolved: 0 });
     expect(await openFindingCount(orgId, deviceId)).toBe(1);

--- a/apps/api/src/db/schema/vulnerabilityManagement.ts
+++ b/apps/api/src/db/schema/vulnerabilityManagement.ts
@@ -7,6 +7,7 @@ import {
   boolean,
   jsonb,
   numeric,
+  integer,
   index,
   uniqueIndex
 } from 'drizzle-orm/pg-core';
@@ -69,6 +70,22 @@ export const softwareProducts = pgTable('software_products', {
   cpeIdx: index('software_products_cpe_idx').on(table.cpe),
 }));
 
+export const softwareProductResolutions = pgTable('software_product_resolutions', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  lookupName: varchar('lookup_name', { length: 500 }).notNull(),
+  lookupVendor: varchar('lookup_vendor', { length: 200 }),
+  normalizedName: varchar('normalized_name', { length: 500 }).notNull(),
+  softwareProductId: uuid('software_product_id').references(() => softwareProducts.id),
+  confidence: varchar('confidence', { length: 16 }).notNull(),
+  matchedVia: varchar('matched_via', { length: 32 }).notNull(),
+  resolverVersion: integer('resolver_version').notNull(),
+  resolvedAt: timestamp('resolved_at').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  keyIdx: uniqueIndex('software_product_resolutions_key_idx').on(table.lookupName, table.lookupVendor),
+  productIdx: index('software_product_resolutions_product_idx').on(table.softwareProductId),
+}));
+
 // Global match facts: product (+ version range) is vulnerable to a CVE
 export const softwareVulnerabilities = pgTable('software_vulnerabilities', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -103,6 +120,7 @@ export const deviceVulnerabilities = pgTable('device_vulnerabilities', {
   softwareInventoryId: uuid('software_inventory_id').references(() => softwareInventory.id),
   status: varchar('status', { length: 20 }).notNull().default('open'), // lifecycle: see VULN_STATUSES in @breeze/shared (source of truth: open|patched|mitigated|accepted)
   riskScore: numeric('risk_score', { precision: 5, scale: 2 }),         // CVSS-primary
+  matchConfidence: varchar('match_confidence', { length: 16 }),
   detectedAt: timestamp('detected_at').notNull(),
   resolvedAt: timestamp('resolved_at'),
   mitigationNote: text('mitigation_note'),

--- a/apps/api/src/db/schema/vulnerabilityManagement.ts
+++ b/apps/api/src/db/schema/vulnerabilityManagement.ts
@@ -82,7 +82,7 @@ export const softwareProductResolutions = pgTable('software_product_resolutions'
   resolvedAt: timestamp('resolved_at').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
 }, (table) => ({
-  // The migration declares this unique index NULLS NOT DISTINCT (PG16) so null-vendor
+  // The migration declares this unique index NULLS NOT DISTINCT (PG15+) so null-vendor
   // keys collapse to one row on upsert; Drizzle has no builder for that qualifier, so the
   // migration is the source of truth. Drift detection here is ledger-based, not structural.
   keyIdx: uniqueIndex('software_product_resolutions_key_idx').on(table.lookupName, table.lookupVendor),

--- a/apps/api/src/db/schema/vulnerabilityManagement.ts
+++ b/apps/api/src/db/schema/vulnerabilityManagement.ts
@@ -82,6 +82,9 @@ export const softwareProductResolutions = pgTable('software_product_resolutions'
   resolvedAt: timestamp('resolved_at').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
 }, (table) => ({
+  // The migration declares this unique index NULLS NOT DISTINCT (PG16) so null-vendor
+  // keys collapse to one row on upsert; Drizzle has no builder for that qualifier, so the
+  // migration is the source of truth. Drift detection here is ledger-based, not structural.
   keyIdx: uniqueIndex('software_product_resolutions_key_idx').on(table.lookupName, table.lookupVendor),
   productIdx: index('software_product_resolutions_product_idx').on(table.softwareProductId),
 }));

--- a/apps/api/src/jobs/vulnerabilityJobs.ts
+++ b/apps/api/src/jobs/vulnerabilityJobs.ts
@@ -827,12 +827,35 @@ export async function expireAcceptedRisks(now: Date): Promise<number> {
  * (which the worker-level handler would otherwise lack) and surfaced in the
  * returned `failedOrgs` count so a partial run is observable.
  */
-export async function correlateEnabledOrgs(): Promise<{ orgs: number; created: number; resolved: number; failedOrgs: number }> {
+export async function correlateEnabledOrgs(): Promise<{
+  orgs: number;
+  created: number;
+  resolved: number;
+  failedOrgs: number;
+  resolutionCounts: Awaited<ReturnType<typeof refreshResolutionCache>> | null;
+}> {
   const byOrg = await withSystemDbAccessContext(() => resolveAllVulnerabilityEnabledDevices());
-  // Populate the global DisplayName→product resolution cache ONCE before the per-org
-  // loop (opens its own system context). Correlation joins software_inventory→
+  // Populate the global DisplayName→product resolution cache ONCE before the per-org loop
+  // (opens its own system context). Correlation joins software_inventory→
   // software_product_resolutions, so this must run first or no org would match (#2290).
-  await refreshResolutionCache();
+  //
+  // Deliberately OUTSIDE the per-org try/catch: a refresh failure is NOT one tenant's
+  // problem. But it must not silently zero out the whole fleet's pass either — so we
+  // attribute it (Sentry) and DEGRADE GRACEFULLY, correlating against the existing
+  // (prior-cycle) resolution rows rather than aborting every org. `refreshResolutionCache`
+  // also throws on an empty catalog (feed/ingest failure) so that a fleet-wide false
+  // "all clear" surfaces here as an alert instead of a quiet zero.
+  //
+  // Freshness: because the cache refreshes once per cycle, software discovered mid-cycle is
+  // correlated on the NEXT cycle (one-cadence latency) — an accepted property of the
+  // once-per-cycle design (#2290).
+  let resolutionCounts: Awaited<ReturnType<typeof refreshResolutionCache>> | null = null;
+  try {
+    resolutionCounts = await refreshResolutionCache();
+  } catch (error) {
+    console.error('[VulnerabilityJobs] resolution cache refresh failed; correlating against the existing cache:', error);
+    captureException(error);
+  }
   let created = 0;
   let resolved = 0;
   let failedOrgs = 0;
@@ -848,7 +871,7 @@ export async function correlateEnabledOrgs(): Promise<{ orgs: number; created: n
       captureException(error);
     }
   }
-  return { orgs: byOrg.size, created, resolved, failedOrgs };
+  return { orgs: byOrg.size, created, resolved, failedOrgs, resolutionCounts };
 }
 
 function createVulnMaintenanceWorker(): Worker {

--- a/apps/api/src/jobs/vulnerabilityJobs.ts
+++ b/apps/api/src/jobs/vulnerabilityJobs.ts
@@ -11,6 +11,7 @@ import {
 } from '../db/schema';
 import { computeRiskScore } from '../services/vulnerabilityRiskScore';
 import { correlateOrg, correlateOsVulns } from '../services/vulnerabilityCorrelation';
+import { refreshResolutionCache } from '../services/cpeResolution';
 import { resolveAllVulnerabilityEnabledDevices } from '../services/featureConfigResolver';
 import { captureException } from '../services/sentry';
 import {
@@ -828,6 +829,10 @@ export async function expireAcceptedRisks(now: Date): Promise<number> {
  */
 export async function correlateEnabledOrgs(): Promise<{ orgs: number; created: number; resolved: number; failedOrgs: number }> {
   const byOrg = await withSystemDbAccessContext(() => resolveAllVulnerabilityEnabledDevices());
+  // Populate the global DisplayName→product resolution cache ONCE before the per-org
+  // loop (opens its own system context). Correlation joins software_inventory→
+  // software_product_resolutions, so this must run first or no org would match (#2290).
+  await refreshResolutionCache();
   let created = 0;
   let resolved = 0;
   let failedOrgs = 0;

--- a/apps/api/src/services/__fixtures__/cpe-dictionary.NOTICE
+++ b/apps/api/src/services/__fixtures__/cpe-dictionary.NOTICE
@@ -1,0 +1,2 @@
+Bounded slice derived from tiiuae/cpedict (official CPE dictionary mirror).
+Source: https://github.com/tiiuae/cpedict — used as a validation set only.

--- a/apps/api/src/services/__fixtures__/cpe-dictionary.NOTICE
+++ b/apps/api/src/services/__fixtures__/cpe-dictionary.NOTICE
@@ -1,2 +1,2 @@
-Bounded slice derived from tiiuae/cpedict (official CPE dictionary mirror).
-Source: https://github.com/tiiuae/cpedict — used as a validation set only.
+Bounded slice derived from tiiuae/cpedict, a curated CPE name set built from NVD data (not an official NIST mirror).
+Source: https://github.com/tiiuae/cpedict — Apache-2.0; used as a validation set only.

--- a/apps/api/src/services/__fixtures__/cpe-dictionary.json
+++ b/apps/api/src/services/__fixtures__/cpe-dictionary.json
@@ -1,0 +1,7 @@
+[
+  "google:chrome", "mozilla:firefox", "mozilla:firefox_esr",
+  "adobe:acrobat_reader", "adobe:acrobat", "7-zip:7-zip",
+  "notepad-plus-plus:notepad-plus-plus", "zoom:zoom",
+  "videolan:vlc_media_player", "microsoft:edge", "microsoft:onedrive",
+  "microsoft:teams", "git-scm:git", "nodejs:node.js", "microsoft:365_apps"
+]

--- a/apps/api/src/services/__fixtures__/cpe-translations.NOTICE
+++ b/apps/api/src/services/__fixtures__/cpe-translations.NOTICE
@@ -1,0 +1,3 @@
+Derived from FleetDM cpe_translations.json
+Source: https://github.com/fleetdm/fleet/blob/main/server/vulnerabilities/nvd/cpe_translations.json
+License: MIT. Converted to {name,vendor,product} via apps/api/scripts/regen-cpe-data.ts.

--- a/apps/api/src/services/__fixtures__/cpe-translations.json
+++ b/apps/api/src/services/__fixtures__/cpe-translations.json
@@ -1,0 +1,17 @@
+[
+  { "name": "Google Chrome", "vendor": "google", "product": "chrome" },
+  { "name": "Mozilla Firefox", "vendor": "mozilla", "product": "firefox" },
+  { "name": "Mozilla Firefox ESR", "vendor": "mozilla", "product": "firefox_esr" },
+  { "name": "Adobe Acrobat Reader", "vendor": "adobe", "product": "acrobat_reader" },
+  { "name": "Adobe Acrobat Reader DC", "vendor": "adobe", "product": "acrobat_reader" },
+  { "name": "Adobe Acrobat", "vendor": "adobe", "product": "acrobat" },
+  { "name": "7-Zip", "vendor": "7-zip", "product": "7-zip" },
+  { "name": "Notepad++", "vendor": "notepad-plus-plus", "product": "notepad-plus-plus" },
+  { "name": "Zoom", "vendor": "zoom", "product": "zoom" },
+  { "name": "VLC media player", "vendor": "videolan", "product": "vlc_media_player" },
+  { "name": "Microsoft Edge", "vendor": "microsoft", "product": "edge" },
+  { "name": "Microsoft OneDrive", "vendor": "microsoft", "product": "onedrive" },
+  { "name": "Microsoft Teams", "vendor": "microsoft", "product": "teams" },
+  { "name": "Git", "vendor": "git-scm", "product": "git" },
+  { "name": "Node.js", "vendor": "nodejs", "product": "node.js" }
+]

--- a/apps/api/src/services/cpeResolution.integration.test.ts
+++ b/apps/api/src/services/cpeResolution.integration.test.ts
@@ -48,6 +48,11 @@ describe('refreshResolutionCache', () => {
   });
 
   runDb('logs an unmatched DisplayName with NULL product', async () => {
+    // A populated catalog that simply doesn't contain this app (the real unmatched case;
+    // an empty catalog is a different, alerted failure — see the catalog-health guard).
+    await withSystemDbAccessContext(async () => {
+      await db.insert(softwareProducts).values({ normalizedName: 'chrome', normalizedVendor: 'google', cpe: 'cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*', cpeConfidence: 'authoritative' });
+    });
     await seedDeviceAndInventory('Totally Bespoke Internal Tool XYZ', 'Some Vendor');
     await refreshResolutionCache();
     const unmatched = await withSystemDbAccessContext(() =>
@@ -57,6 +62,9 @@ describe('refreshResolutionCache', () => {
   });
 
   runDb('is idempotent — re-run does not duplicate rows', async () => {
+    await withSystemDbAccessContext(async () => {
+      await db.insert(softwareProducts).values({ normalizedName: 'chrome', normalizedVendor: 'google', cpe: 'cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*', cpeConfidence: 'authoritative' });
+    });
     await seedDeviceAndInventory('Google Chrome', 'Google LLC');
     await refreshResolutionCache();
     await refreshResolutionCache();
@@ -66,9 +74,13 @@ describe('refreshResolutionCache', () => {
   });
 
   runDb('re-resolves a previously-unmatched name once the catalog grows (same resolver version)', async () => {
+    // Catalog is populated (unrelated product) but does not yet contain "Bespoke Cache Tool".
+    await withSystemDbAccessContext(async () => {
+      await db.insert(softwareProducts).values({ normalizedName: 'chrome', normalizedVendor: 'google', cpe: 'cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*', cpeConfidence: 'authoritative' });
+    });
     await seedDeviceAndInventory('Bespoke Cache Tool', 'Bespoke');
 
-    // First pass: no catalog product yet → unmatched (product NULL, confidence none).
+    // First pass: catalog lacks this product → unmatched (product NULL, confidence none).
     await refreshResolutionCache();
     const before = await withSystemDbAccessContext(() =>
       db.select().from(softwareProductResolutions).where(eq(softwareProductResolutions.lookupName, 'bespoke cache tool')));
@@ -92,5 +104,16 @@ describe('refreshResolutionCache', () => {
     expect(after[0]?.softwareProductId).not.toBeNull();
     expect(after[0]?.confidence).toBe('exact');
     expect(after[0]?.resolverVersion).toBe(RESOLVER_VERSION);
+  });
+
+  runDb('throws on an empty catalog rather than downgrading every key to unmatched', async () => {
+    // Inventory present but software_products empty (feed/ingest failure). Refusing to run
+    // prevents a fleet-wide false "all clear"; the caller (correlateEnabledOrgs) turns this
+    // into a Sentry alert and correlates against the prior cache.
+    await seedDeviceAndInventory('Google Chrome', 'Google LLC');
+    await withSystemDbAccessContext(async () => {
+      await db.delete(softwareProducts);
+    });
+    await expect(refreshResolutionCache()).rejects.toThrow(/catalog is empty/);
   });
 });

--- a/apps/api/src/services/cpeResolution.integration.test.ts
+++ b/apps/api/src/services/cpeResolution.integration.test.ts
@@ -1,0 +1,67 @@
+import '../__tests__/integration/setup';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+
+import { db, withSystemDbAccessContext } from '../db';
+import {
+  devices, organizations, partners, sites,
+  softwareInventory, softwareProducts, softwareProductResolutions,
+} from '../db/schema';
+import { refreshResolutionCache } from './cpeResolution';
+import { RESOLVER_VERSION } from './cpeResolver';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function seedDeviceAndInventory(name: string, vendor: string | null): Promise<void> {
+  await withSystemDbAccessContext(async () => {
+    const u = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const [p] = await db.insert(partners).values({ name: `P ${u}`, slug: `p-${u}`, type: 'msp', plan: 'pro', status: 'active' }).returning({ id: partners.id });
+    const [o] = await db.insert(organizations).values({ partnerId: p!.id, name: `O ${u}`, slug: `o-${u}`, type: 'customer', status: 'active' }).returning({ id: organizations.id });
+    const [s] = await db.insert(sites).values({ orgId: o!.id, name: `S ${u}` }).returning({ id: sites.id });
+    const [d] = await db.insert(devices).values({ orgId: o!.id, siteId: s!.id, agentId: `a-${u}`, hostname: `h-${u}`, osType: 'windows', osVersion: '11', architecture: 'x86_64', agentVersion: '0.0.0-test', status: 'offline' }).returning({ id: devices.id });
+    await db.insert(softwareInventory).values({ orgId: o!.id, deviceId: d!.id, name, vendor, version: '1.0' });
+  });
+}
+
+beforeEach(async () => {
+  await withSystemDbAccessContext(async () => {
+    await db.delete(softwareProductResolutions);
+    await db.delete(softwareInventory);
+    await db.delete(softwareProducts);
+  });
+});
+
+describe('refreshResolutionCache', () => {
+  runDb('resolves a curated DisplayName to a catalog product', async () => {
+    await withSystemDbAccessContext(async () => {
+      await db.insert(softwareProducts).values({ normalizedName: 'chrome', normalizedVendor: 'google', cpe: 'cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*', cpeConfidence: 'authoritative' });
+    });
+    await seedDeviceAndInventory('Google Chrome (64-bit)', 'Google LLC');
+
+    const counts = await refreshResolutionCache();
+    expect(counts.curated + counts.exact + counts.fuzzy).toBeGreaterThanOrEqual(1);
+
+    const rows = await withSystemDbAccessContext(() =>
+      db.select().from(softwareProductResolutions).where(eq(softwareProductResolutions.lookupName, 'google chrome (64-bit)')));
+    expect(rows[0]?.softwareProductId).not.toBeNull();
+    expect(rows[0]?.resolverVersion).toBe(RESOLVER_VERSION);
+  });
+
+  runDb('logs an unmatched DisplayName with NULL product', async () => {
+    await seedDeviceAndInventory('Totally Bespoke Internal Tool XYZ', 'Some Vendor');
+    await refreshResolutionCache();
+    const unmatched = await withSystemDbAccessContext(() =>
+      db.select().from(softwareProductResolutions).where(isNull(softwareProductResolutions.softwareProductId)));
+    expect(unmatched.length).toBeGreaterThanOrEqual(1);
+    expect(unmatched[0]?.confidence).toBe('none');
+  });
+
+  runDb('is idempotent — re-run does not duplicate rows', async () => {
+    await seedDeviceAndInventory('Google Chrome', 'Google LLC');
+    await refreshResolutionCache();
+    await refreshResolutionCache();
+    const rows = await withSystemDbAccessContext(() =>
+      db.select({ n: sql<number>`count(*)::int` }).from(softwareProductResolutions).where(eq(softwareProductResolutions.lookupName, 'google chrome')));
+    expect(rows[0]?.n).toBe(1);
+  });
+});

--- a/apps/api/src/services/cpeResolution.integration.test.ts
+++ b/apps/api/src/services/cpeResolution.integration.test.ts
@@ -64,4 +64,33 @@ describe('refreshResolutionCache', () => {
       db.select({ n: sql<number>`count(*)::int` }).from(softwareProductResolutions).where(eq(softwareProductResolutions.lookupName, 'google chrome')));
     expect(rows[0]?.n).toBe(1);
   });
+
+  runDb('re-resolves a previously-unmatched name once the catalog grows (same resolver version)', async () => {
+    await seedDeviceAndInventory('Bespoke Cache Tool', 'Bespoke');
+
+    // First pass: no catalog product yet → unmatched (product NULL, confidence none).
+    await refreshResolutionCache();
+    const before = await withSystemDbAccessContext(() =>
+      db.select().from(softwareProductResolutions).where(eq(softwareProductResolutions.lookupName, 'bespoke cache tool')));
+    expect(before[0]?.softwareProductId).toBeNull();
+    expect(before[0]?.confidence).toBe('none');
+
+    // Catalog grows at runtime (NVD/MSRC ingest) — no RESOLVER_VERSION bump.
+    await withSystemDbAccessContext(async () => {
+      await db.insert(softwareProducts).values({
+        normalizedName: 'bespoke cache tool',
+        normalizedVendor: 'bespoke',
+        cpe: 'cpe:2.3:a:bespoke:cache_tool:*:*:*:*:*:*:*:*',
+        cpeConfidence: 'authoritative',
+      });
+    });
+
+    // Second pass must re-resolve the unmatched row and now match it.
+    await refreshResolutionCache();
+    const after = await withSystemDbAccessContext(() =>
+      db.select().from(softwareProductResolutions).where(eq(softwareProductResolutions.lookupName, 'bespoke cache tool')));
+    expect(after[0]?.softwareProductId).not.toBeNull();
+    expect(after[0]?.confidence).toBe('exact');
+    expect(after[0]?.resolverVersion).toBe(RESOLVER_VERSION);
+  });
 });

--- a/apps/api/src/services/cpeResolution.ts
+++ b/apps/api/src/services/cpeResolution.ts
@@ -3,7 +3,7 @@ import { sql } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../db';
 import { softwareInventory, softwareProducts, softwareProductResolutions } from '../db/schema';
 import {
-  RESOLVER_VERSION, buildCatalogIndex, loadCuratedDictionary, resolve,
+  RESOLVER_VERSION, buildCatalogIndex, loadCuratedDictionary, normalizeDisplayName, resolve,
   type CatalogProduct, type ResolutionConfidence,
 } from './cpeResolver';
 
@@ -27,6 +27,17 @@ export async function refreshResolutionCache(): Promise<Record<ResolutionConfide
     const products = await db
       .select({ id: softwareProducts.id, normalizedName: softwareProducts.normalizedName, normalizedVendor: softwareProducts.normalizedVendor, cpe: softwareProducts.cpe })
       .from(softwareProducts);
+
+    // Catalog-health floor: with an empty catalog every resolve() returns 'none' and we
+    // would overwrite every key to unmatched — a fleet-wide false "all clear" for a vuln
+    // scanner, indistinguishable from a healthy no-vuln run. Refuse to touch the cache and
+    // throw so the caller attributes it (Sentry) and correlation degrades against the prior
+    // cache instead of silently downgrading everyone. A genuinely empty catalog (feed/ingest
+    // failure, accidental wipe) is a real incident, not a quiet zero.
+    if (products.length === 0) {
+      throw new Error('refreshResolutionCache aborted: software_products catalog is empty — refusing to downgrade all inventory to unmatched');
+    }
+
     const index = buildCatalogIndex(products as CatalogProduct[]);
     const curated = loadCuratedDictionary();
 
@@ -70,7 +81,9 @@ export async function refreshResolutionCache(): Promise<Record<ResolutionConfide
         .values({
           lookupName: k.lookupName,
           lookupVendor: k.lookupVendor,
-          normalizedName: r.matchedVia === 'unmatched' ? k.lookupName : k.sampleName,
+          // The post-token-strip form the resolver actually keyed on (observability): what
+          // "Google Chrome 120 (x64)" reduced to. This is what the column comment promises.
+          normalizedName: normalizeDisplayName(k.sampleName),
           softwareProductId: r.productId,
           confidence: r.confidence,
           matchedVia: r.matchedVia,

--- a/apps/api/src/services/cpeResolution.ts
+++ b/apps/api/src/services/cpeResolution.ts
@@ -10,9 +10,15 @@ import {
 /**
  * Global pass: resolve every distinct (lower(trim(name)), lower(trim(vendor))) in
  * software_inventory against the catalog and upsert into software_product_resolutions.
- * Skips keys already resolved at the current RESOLVER_VERSION; re-resolves rows from an
- * older version (self-healing as the dictionary/catalog grows). System context only —
- * software_product_resolutions and the catalog are global system-only tables.
+ *
+ * Skip only rows that are already MATCHED (software_product_id NOT NULL) at the current
+ * RESOLVER_VERSION. Unmatched rows (confidence='none', product NULL) are re-resolved every
+ * cycle: the catalog `software_products` grows at runtime as NVD/MSRC feeds ingest,
+ * independent of RESOLVER_VERSION, so an app first seen before its catalog product exists
+ * must get another chance once that product lands — otherwise its CVEs would never surface
+ * until a code redeploy. Rows from an older RESOLVER_VERSION are also re-resolved.
+ * System context only — software_product_resolutions and the catalog are global
+ * system-only tables.
  */
 export async function refreshResolutionCache(): Promise<Record<ResolutionConfidence, number>> {
   const counts: Record<ResolutionConfidence, number> = { curated: 0, exact: 0, fuzzy: 0, none: 0 };
@@ -34,16 +40,27 @@ export async function refreshResolutionCache(): Promise<Record<ResolutionConfide
       .from(softwareInventory)
       .groupBy(sql`lower(trim(${softwareInventory.name}))`, sql`lower(trim(${softwareInventory.vendor}))`);
 
-    // keys already resolved at the current version → skip
+    // Keys already MATCHED at the current version → settled, skip. Unmatched rows
+    // (software_product_id NULL) are intentionally excluded so they re-resolve as the
+    // catalog grows.
     const existing = await db
-      .select({ lookupName: softwareProductResolutions.lookupName, lookupVendor: softwareProductResolutions.lookupVendor, resolverVersion: softwareProductResolutions.resolverVersion })
+      .select({
+        lookupName: softwareProductResolutions.lookupName,
+        lookupVendor: softwareProductResolutions.lookupVendor,
+        resolverVersion: softwareProductResolutions.resolverVersion,
+        softwareProductId: softwareProductResolutions.softwareProductId,
+      })
       .from(softwareProductResolutions);
-    const currentByKey = new Map<string, number>();
-    for (const e of existing) currentByKey.set(`${e.lookupName}\0${e.lookupVendor ?? ''}`, e.resolverVersion);
+    const settledKeys = new Set<string>();
+    for (const e of existing) {
+      if (e.resolverVersion === RESOLVER_VERSION && e.softwareProductId != null) {
+        settledKeys.add(`${e.lookupName}\0${e.lookupVendor ?? ''}`);
+      }
+    }
 
     for (const k of keys) {
       const dedupeKey = `${k.lookupName}\0${k.lookupVendor ?? ''}`;
-      if (currentByKey.get(dedupeKey) === RESOLVER_VERSION) continue;
+      if (settledKeys.has(dedupeKey)) continue;
 
       const r = resolve(k.sampleName, k.lookupVendor, index, curated);
       counts[r.confidence] += 1;

--- a/apps/api/src/services/cpeResolution.ts
+++ b/apps/api/src/services/cpeResolution.ts
@@ -1,0 +1,78 @@
+import { sql } from 'drizzle-orm';
+
+import { db, withSystemDbAccessContext } from '../db';
+import { softwareInventory, softwareProducts, softwareProductResolutions } from '../db/schema';
+import {
+  RESOLVER_VERSION, buildCatalogIndex, loadCuratedDictionary, resolve,
+  type CatalogProduct, type ResolutionConfidence,
+} from './cpeResolver';
+
+/**
+ * Global pass: resolve every distinct (lower(trim(name)), lower(trim(vendor))) in
+ * software_inventory against the catalog and upsert into software_product_resolutions.
+ * Skips keys already resolved at the current RESOLVER_VERSION; re-resolves rows from an
+ * older version (self-healing as the dictionary/catalog grows). System context only —
+ * software_product_resolutions and the catalog are global system-only tables.
+ */
+export async function refreshResolutionCache(): Promise<Record<ResolutionConfidence, number>> {
+  const counts: Record<ResolutionConfidence, number> = { curated: 0, exact: 0, fuzzy: 0, none: 0 };
+
+  await withSystemDbAccessContext(async () => {
+    const products = await db
+      .select({ id: softwareProducts.id, normalizedName: softwareProducts.normalizedName, normalizedVendor: softwareProducts.normalizedVendor, cpe: softwareProducts.cpe })
+      .from(softwareProducts);
+    const index = buildCatalogIndex(products as CatalogProduct[]);
+    const curated = loadCuratedDictionary();
+
+    // distinct SQL-reproducible keys, plus a representative original name for normalization
+    const keys = await db
+      .select({
+        lookupName: sql<string>`lower(trim(${softwareInventory.name}))`,
+        lookupVendor: sql<string | null>`lower(trim(${softwareInventory.vendor}))`,
+        sampleName: sql<string>`min(${softwareInventory.name})`,
+      })
+      .from(softwareInventory)
+      .groupBy(sql`lower(trim(${softwareInventory.name}))`, sql`lower(trim(${softwareInventory.vendor}))`);
+
+    // keys already resolved at the current version → skip
+    const existing = await db
+      .select({ lookupName: softwareProductResolutions.lookupName, lookupVendor: softwareProductResolutions.lookupVendor, resolverVersion: softwareProductResolutions.resolverVersion })
+      .from(softwareProductResolutions);
+    const currentByKey = new Map<string, number>();
+    for (const e of existing) currentByKey.set(`${e.lookupName}\0${e.lookupVendor ?? ''}`, e.resolverVersion);
+
+    for (const k of keys) {
+      const dedupeKey = `${k.lookupName}\0${k.lookupVendor ?? ''}`;
+      if (currentByKey.get(dedupeKey) === RESOLVER_VERSION) continue;
+
+      const r = resolve(k.sampleName, k.lookupVendor, index, curated);
+      counts[r.confidence] += 1;
+
+      await db
+        .insert(softwareProductResolutions)
+        .values({
+          lookupName: k.lookupName,
+          lookupVendor: k.lookupVendor,
+          normalizedName: r.matchedVia === 'unmatched' ? k.lookupName : k.sampleName,
+          softwareProductId: r.productId,
+          confidence: r.confidence,
+          matchedVia: r.matchedVia,
+          resolverVersion: RESOLVER_VERSION,
+          resolvedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: [softwareProductResolutions.lookupName, softwareProductResolutions.lookupVendor],
+          set: {
+            softwareProductId: r.productId,
+            confidence: r.confidence,
+            matchedVia: r.matchedVia,
+            resolverVersion: RESOLVER_VERSION,
+            resolvedAt: new Date(),
+          },
+        });
+    }
+  });
+
+  console.log('[cpeResolution] refresh complete', counts);
+  return counts;
+}

--- a/apps/api/src/services/cpeResolver.test.ts
+++ b/apps/api/src/services/cpeResolver.test.ts
@@ -21,7 +21,7 @@ describe('tokenize', () => {
   it('splits on non-alphanumeric, lowercases, drops empties', () => {
     expect(tokenize('Adobe Acrobat_Reader-DC')).toEqual(['adobe', 'acrobat', 'reader', 'dc']);
   });
-  it('keeps ++ / - inside known product words via alnum-run split', () => {
+  it('drops ++ / - punctuation via alnum-run split', () => {
     expect(tokenize('notepad++')).toEqual(['notepad']);
   });
 });
@@ -121,6 +121,7 @@ describe('buildCatalogIndex', () => {
       cpe: null,
       cpeVendor: null,
       cpeProduct: null,
+      catalogVendor: 'acme software',
       productTokens: new Set(['internal', 'tool']),
     });
     expect(idx.wordIndex.get('acme')).toEqual(new Set(['p-internal']));
@@ -151,7 +152,34 @@ describe('resolve - Layer A', () => {
 
   it('curated hit whose CPE is absent from catalog -> productId null, matchedVia dictionary', () => {
     const r = resolve('Microsoft Teams', 'Microsoft', idx, curated);
-    expect(r).toMatchObject({ productId: null, matchedVia: 'dictionary' });
+    expect(r).toMatchObject({
+      productId: null,
+      cpe: null,
+      confidence: 'none',
+      matchedVia: 'dictionary',
+    });
+  });
+
+  it('does not trust curated entries when the supplied vendor disagrees', () => {
+    const zoomCatalog: CatalogProduct[] = [
+      {
+        id: 'p-zoom',
+        normalizedName: 'zoom_workplace',
+        normalizedVendor: 'zoom',
+        cpe: 'cpe:2.3:a:zoom:zoom:*:*:*:*:*:*:*:*',
+      },
+    ];
+    const zoomCurated = new Map([['zoom', { vendor: 'zoom', product: 'zoom' }]]);
+
+    const disagreement = resolve('Zoom', 'Acme Corp', buildCatalogIndex(zoomCatalog), zoomCurated);
+    expect(disagreement.confidence).not.toBe('curated');
+
+    const absentVendor = resolve('Zoom', null, buildCatalogIndex(zoomCatalog), zoomCurated);
+    expect(absentVendor).toMatchObject({
+      productId: 'p-zoom',
+      confidence: 'curated',
+      matchedVia: 'dictionary',
+    });
   });
 });
 
@@ -182,6 +210,30 @@ describe('resolve - Layer B (token) + guardrails', () => {
       matchedVia: 'token',
     });
     expect(r.tokensMatched).toBeGreaterThanOrEqual(1);
+  });
+
+  it('GUARDRAIL: short vendor substring does not create agreement', () => {
+    const caCatalog = buildCatalogIndex([
+      {
+        id: 'p-ca',
+        normalizedName: 'agent',
+        normalizedVendor: 'ca',
+        cpe: 'cpe:2.3:a:ca:agent:*:*:*:*:*:*:*:*',
+      },
+    ]);
+
+    const r = resolve('Canon Print Agent', 'Canon', caCatalog, new Map());
+    expect(r.confidence).toBe('none');
+    expect(r.productId).toBeNull();
+  });
+
+  it('still allows legitimate vendor token agreement', () => {
+    const r = resolve('Wireshark Protocol Analyzer', 'Wireshark Foundation', idx, new Map());
+    expect(r).toMatchObject({
+      productId: 'p-wireshark',
+      confidence: 'fuzzy',
+      matchedVia: 'token',
+    });
   });
 
   it('GUARDRAIL: Microsoft Edge against a Chrome-only catalog -> withheld (no Edge->Chrome)', () => {
@@ -220,6 +272,38 @@ describe('resolve - Layer B (token) + guardrails', () => {
     ];
     const r = resolve('Microsoft Random Tool', 'Microsoft', buildCatalogIndex(withMs), new Map());
     expect(r.confidence).toBe('none');
+  });
+
+  it('GUARDRAIL: generic stopwords do not create token confidence', () => {
+    const acmeAgent = buildCatalogIndex([
+      {
+        id: 'p-acme-agent',
+        normalizedName: 'remote_agent',
+        normalizedVendor: 'acme',
+        cpe: 'cpe:2.3:a:acme:agent:*:*:*:*:*:*:*:*',
+      },
+    ]);
+
+    const r = resolve('Acme Agent', 'Acme', acmeAgent, new Map());
+    expect(r.confidence).toBe('none');
+  });
+
+  it('uses catalog vendor for token guardrails when a catalog product has no CPE', () => {
+    const internalTool = buildCatalogIndex([
+      {
+        id: 'p-int',
+        normalizedName: 'internal_tool',
+        normalizedVendor: 'acme',
+        cpe: null,
+      },
+    ]);
+
+    const r = resolve('Acme Internal Tool', 'Acme', internalTool, new Map());
+    expect(r).toMatchObject({
+      productId: 'p-int',
+      confidence: 'fuzzy',
+      matchedVia: 'token',
+    });
   });
 
   it('vendor alias equivalence (Adobe Inc. == adobe) - via token when not curated', () => {

--- a/apps/api/src/services/cpeResolver.test.ts
+++ b/apps/api/src/services/cpeResolver.test.ts
@@ -26,7 +26,14 @@ describe('tokenize', () => {
   });
 });
 
-import { loadCuratedDictionary, loadCpeDictionary, parseCpe, isWellFormedCpe } from './cpeResolver';
+import {
+  buildCatalogIndex,
+  loadCuratedDictionary,
+  loadCpeDictionary,
+  parseCpe,
+  isWellFormedCpe,
+  type CatalogProduct,
+} from './cpeResolver';
 
 describe('parseCpe', () => {
   it('extracts vendor/product from cpe:2.3', () => {
@@ -49,5 +56,72 @@ describe('curated dictionary', () => {
     for (const [, { vendor, product }] of dict) {
       expect(cpedict.has(`${vendor}:${product}`), `${vendor}:${product} missing from cpedict`).toBe(true);
     }
+  });
+});
+
+const CATALOG: CatalogProduct[] = [
+  {
+    id: 'p-chrome',
+    normalizedName: 'chrome',
+    normalizedVendor: 'google',
+    cpe: 'cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*',
+  },
+  {
+    id: 'p-firefox',
+    normalizedName: 'firefox',
+    normalizedVendor: 'mozilla',
+    cpe: 'cpe:2.3:a:mozilla:firefox:*:*:*:*:*:*:*:*',
+  },
+  {
+    id: 'p-acrobat',
+    normalizedName: 'acrobat_reader',
+    normalizedVendor: 'adobe',
+    cpe: 'cpe:2.3:a:adobe:acrobat_reader:*:*:*:*:*:*:*:*',
+  },
+];
+
+describe('buildCatalogIndex', () => {
+  it('indexes exact name, vendor:product, and recall words', () => {
+    const idx = buildCatalogIndex(CATALOG);
+
+    expect(idx.byExactName.get('chrome')).toBe('p-chrome');
+    expect(idx.byVendorProduct.get('google:chrome')).toBe('p-chrome');
+    expect(idx.wordIndex.get('acrobat')).toEqual(new Set(['p-acrobat']));
+    expect(idx.wordIndex.get('adobe')).toEqual(new Set(['p-acrobat']));
+    expect(idx.meta.get('p-firefox')?.cpeVendor).toBe('mozilla');
+    expect(idx.meta.get('p-acrobat')?.productTokens).toEqual(new Set(['acrobat', 'reader']));
+  });
+
+  it('marks ambiguous exact names null (two products, same normalized_name)', () => {
+    const idx = buildCatalogIndex([
+      ...CATALOG,
+      {
+        id: 'p-chrome2',
+        normalizedName: 'chrome',
+        normalizedVendor: 'other',
+        cpe: 'cpe:2.3:a:other:chrome:*:*:*:*:*:*:*:*',
+      },
+    ]);
+
+    expect(idx.byExactName.get('chrome')).toBeNull();
+  });
+
+  it('uses normalized name for productTokens when no cpe while vendor still feeds recall', () => {
+    const idx = buildCatalogIndex([
+      {
+        id: 'p-internal',
+        normalizedName: 'internal_tool',
+        normalizedVendor: 'acme software',
+        cpe: null,
+      },
+    ]);
+
+    expect(idx.meta.get('p-internal')).toEqual({
+      cpe: null,
+      cpeVendor: null,
+      cpeProduct: null,
+      productTokens: new Set(['internal', 'tool']),
+    });
+    expect(idx.wordIndex.get('acme')).toEqual(new Set(['p-internal']));
   });
 });

--- a/apps/api/src/services/cpeResolver.test.ts
+++ b/apps/api/src/services/cpeResolver.test.ts
@@ -227,6 +227,20 @@ describe('resolve - Layer B (token) + guardrails', () => {
     expect(r.productId).toBeNull();
   });
 
+  it('GUARDRAIL: a shared 2-char vendor token does not create agreement (length>=3 floor)', () => {
+    // cpe vendor "bq" (2 chars). Query vendor "Anon BQ Systems" tokenizes to {anon,bq,systems};
+    // the ONLY overlap with "bq" is the 2-char token, and the query name matches the product
+    // token "reader" (score 1). Only the length>=3 floor withholds this — remove it and the
+    // 2-char "bq" collision would agree and return 'fuzzy'. This isolates that guard (the
+    // Canon case above passes regardless of the floor, since 'canon' is never in {ca}).
+    const bqCatalog = buildCatalogIndex([
+      { id: 'p-bq', normalizedName: 'reader', normalizedVendor: 'bq', cpe: 'cpe:2.3:a:bq:reader:*:*:*:*:*:*:*:*' },
+    ]);
+    const r = resolve('Anon BQ Reader', 'Anon BQ Systems', bqCatalog, new Map());
+    expect(r.confidence).toBe('none');
+    expect(r.productId).toBeNull();
+  });
+
   it('still allows legitimate vendor token agreement', () => {
     const r = resolve('Wireshark Protocol Analyzer', 'Wireshark Foundation', idx, new Map());
     expect(r).toMatchObject({

--- a/apps/api/src/services/cpeResolver.test.ts
+++ b/apps/api/src/services/cpeResolver.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeDisplayName, tokenize } from './cpeResolver';
+
+describe('normalizeDisplayName', () => {
+  const cases: Array<[string, string]> = [
+    ['Google Chrome', 'google chrome'],
+    ['Adobe Acrobat (64-bit)', 'adobe acrobat'],
+    ['Mozilla Firefox ESR 115 (x64 en-US)', 'mozilla firefox esr'],
+    ['Microsoft 365 Apps for business - en-us', 'microsoft 365 apps for business'],
+    ['7-Zip 22.01 (x64)', '7-zip'],
+    ['Notepad++ (32-bit x86)', 'notepad++'],
+    ['  VLC   media  player  ', 'vlc media player'],
+    ['Java 8 Update 351 (64-bit)', 'java 8 update'],
+  ];
+  it.each(cases)('normalizes %s', (input, expected) => {
+    expect(normalizeDisplayName(input)).toBe(expected);
+  });
+});
+
+describe('tokenize', () => {
+  it('splits on non-alphanumeric, lowercases, drops empties', () => {
+    expect(tokenize('Adobe Acrobat_Reader-DC')).toEqual(['adobe', 'acrobat', 'reader', 'dc']);
+  });
+  it('keeps ++ / - inside known product words via alnum-run split', () => {
+    expect(tokenize('notepad++')).toEqual(['notepad']);
+  });
+});

--- a/apps/api/src/services/cpeResolver.test.ts
+++ b/apps/api/src/services/cpeResolver.test.ts
@@ -154,3 +154,113 @@ describe('resolve - Layer A', () => {
     expect(r).toMatchObject({ productId: null, matchedVia: 'dictionary' });
   });
 });
+
+describe('resolve - Layer B (token) + guardrails', () => {
+  const catalog: CatalogProduct[] = [
+    ...CATALOG,
+    {
+      id: 'p-7zip',
+      normalizedName: '7-zip_file_archiver',
+      normalizedVendor: '7-zip',
+      cpe: 'cpe:2.3:a:7-zip:7-zip:*:*:*:*:*:*:*:*',
+    },
+    {
+      id: 'p-wireshark',
+      normalizedName: 'wireshark_network_protocol_analyzer',
+      normalizedVendor: 'wireshark',
+      cpe: 'cpe:2.3:a:wireshark:wireshark:*:*:*:*:*:*:*:*',
+    },
+  ];
+  const idx = buildCatalogIndex(catalog);
+  const curated = loadCuratedDictionary();
+
+  it('token match on long-tail name with vendor agreement -> fuzzy', () => {
+    const r = resolve('Wireshark 4.2.0 (64-bit)', 'Wireshark Foundation', idx, curated);
+    expect(r).toMatchObject({
+      productId: 'p-wireshark',
+      confidence: 'fuzzy',
+      matchedVia: 'token',
+    });
+    expect(r.tokensMatched).toBeGreaterThanOrEqual(1);
+  });
+
+  it('GUARDRAIL: Microsoft Edge against a Chrome-only catalog -> withheld (no Edge->Chrome)', () => {
+    const chromeOnly = buildCatalogIndex([CATALOG[0]!]);
+    const r = resolve('Microsoft Edge', 'Microsoft Corporation', chromeOnly, new Map());
+    expect(r.confidence).toBe('none');
+    expect(r.productId).toBeNull();
+  });
+
+  it('GUARDRAIL: vendor disagreement withholds even if product word overlaps', () => {
+    const r = resolve('Chrome Remover', 'Acme Software', buildCatalogIndex([CATALOG[0]!]), new Map());
+    expect(r.confidence).toBe('none');
+  });
+
+  it('GUARDRAIL: missing vendor -> Layer B withholds', () => {
+    const noExactIdx = buildCatalogIndex([
+      {
+        id: 'p-wireshark',
+        normalizedName: 'wireshark_network_protocol_analyzer',
+        normalizedVendor: 'wireshark',
+        cpe: 'cpe:2.3:a:wireshark:wireshark:*:*:*:*:*:*:*:*',
+      },
+    ]);
+    const r = resolve('Wireshark', null, noExactIdx, new Map());
+    expect(r.confidence).toBe('none');
+  });
+
+  it('GUARDRAIL: vendor-only word match (no distinctive product token) withholds', () => {
+    const withMs: CatalogProduct[] = [
+      {
+        id: 'p-ms365',
+        normalizedName: '365_apps',
+        normalizedVendor: 'microsoft',
+        cpe: 'cpe:2.3:a:microsoft:365_apps:*:*:*:*:*:*:*:*',
+      },
+    ];
+    const r = resolve('Microsoft Random Tool', 'Microsoft', buildCatalogIndex(withMs), new Map());
+    expect(r.confidence).toBe('none');
+  });
+
+  it('vendor alias equivalence (Adobe Inc. == adobe) - via token when not curated', () => {
+    const adobeCat = buildCatalogIndex([CATALOG[2]!]);
+    const r = resolve('Adobe Acrobat Reader', 'Adobe Inc.', adobeCat, new Map());
+    expect(r).toMatchObject({ productId: 'p-acrobat', confidence: 'fuzzy', matchedVia: 'token' });
+  });
+
+  it('GUARDRAIL: tied token winners withhold', () => {
+    const idxWithTie = buildCatalogIndex([
+      {
+        id: 'p-acme-admin',
+        normalizedName: 'admin_console',
+        normalizedVendor: 'acme',
+        cpe: 'cpe:2.3:a:acme:console:*:*:*:*:*:*:*:*',
+      },
+      {
+        id: 'p-acme-user',
+        normalizedName: 'user_console',
+        normalizedVendor: 'acme',
+        cpe: 'cpe:2.3:a:acme:console:*:*:*:*:*:*:*:*',
+      },
+    ]);
+    const r = resolve('Console Tool', 'Acme', idxWithTie, new Map());
+    expect(r.confidence).toBe('none');
+  });
+
+  it('GUARDRAIL: malformed winning CPE withholds', () => {
+    const malformed = buildCatalogIndex([
+      {
+        id: 'p-acme-console',
+        normalizedName: 'acme_console_manager',
+        normalizedVendor: 'acme',
+        cpe: 'cpe:2.3:a:acme:console:*:*:*:*:*:*:*:*',
+      },
+    ]);
+    malformed.meta.set('p-acme-console', {
+      ...malformed.meta.get('p-acme-console')!,
+      cpe: 'not-a-cpe',
+    });
+    const r = resolve('Acme Console', 'Acme', malformed, new Map());
+    expect(r.confidence).toBe('none');
+  });
+});

--- a/apps/api/src/services/cpeResolver.test.ts
+++ b/apps/api/src/services/cpeResolver.test.ts
@@ -32,6 +32,7 @@ import {
   loadCpeDictionary,
   parseCpe,
   isWellFormedCpe,
+  resolve,
   type CatalogProduct,
 } from './cpeResolver';
 
@@ -123,5 +124,33 @@ describe('buildCatalogIndex', () => {
       productTokens: new Set(['internal', 'tool']),
     });
     expect(idx.wordIndex.get('acme')).toEqual(new Set(['p-internal']));
+  });
+});
+
+describe('resolve - Layer A', () => {
+  const idx = buildCatalogIndex(CATALOG);
+  const curated = loadCuratedDictionary();
+
+  it('curated dict hit -> confidence curated, resolves to catalog product', () => {
+    const r = resolve('Adobe Acrobat Reader DC (64-bit)', 'Adobe Inc.', idx, curated);
+    expect(r).toMatchObject({
+      productId: 'p-acrobat',
+      confidence: 'curated',
+      matchedVia: 'dictionary',
+    });
+  });
+
+  it('exact normalized-name catalog hit -> confidence exact', () => {
+    const r = resolve('Firefox', 'Mozilla', idx, curated);
+    expect(r).toMatchObject({
+      productId: 'p-firefox',
+      confidence: 'exact',
+      matchedVia: 'catalog_exact',
+    });
+  });
+
+  it('curated hit whose CPE is absent from catalog -> productId null, matchedVia dictionary', () => {
+    const r = resolve('Microsoft Teams', 'Microsoft', idx, curated);
+    expect(r).toMatchObject({ productId: null, matchedVia: 'dictionary' });
   });
 });

--- a/apps/api/src/services/cpeResolver.test.ts
+++ b/apps/api/src/services/cpeResolver.test.ts
@@ -25,3 +25,29 @@ describe('tokenize', () => {
     expect(tokenize('notepad++')).toEqual(['notepad']);
   });
 });
+
+import { loadCuratedDictionary, loadCpeDictionary, parseCpe, isWellFormedCpe } from './cpeResolver';
+
+describe('parseCpe', () => {
+  it('extracts vendor/product from cpe:2.3', () => {
+    expect(parseCpe('cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*')).toEqual({ vendor: 'google', product: 'chrome' });
+  });
+  it('returns null for garbage', () => {
+    expect(parseCpe('not-a-cpe')).toBeNull();
+  });
+});
+
+describe('curated dictionary', () => {
+  it('is keyed by normalized display name and maps to CPE tokens', () => {
+    const dict = loadCuratedDictionary();
+    expect(dict.get('google chrome')).toEqual({ vendor: 'google', product: 'chrome' });
+    expect(dict.get('adobe acrobat')).toEqual({ vendor: 'adobe', product: 'acrobat' });
+  });
+  it('INVARIANT: every curated CPE token pair exists in the cpedict validation set', () => {
+    const dict = loadCuratedDictionary();
+    const cpedict = loadCpeDictionary();
+    for (const [, { vendor, product }] of dict) {
+      expect(cpedict.has(`${vendor}:${product}`), `${vendor}:${product} missing from cpedict`).toBe(true);
+    }
+  });
+});

--- a/apps/api/src/services/cpeResolver.ts
+++ b/apps/api/src/services/cpeResolver.ts
@@ -17,6 +17,61 @@ const PAREN_GROUP = /\([^)]*\)/g;
 const TRAILING_VERSION = /\s+\d[\d.]*\s*$/g;
 const MULTISPACE = /\s+/g;
 
+const VENDOR_ALIASES: Record<string, string> = {
+  'adobe inc.': 'adobe',
+  'adobe systems': 'adobe',
+  adobe: 'adobe',
+  mozilla: 'mozilla',
+  'mozilla corporation': 'mozilla',
+  'mozilla foundation': 'mozilla',
+  google: 'google',
+  'google llc': 'google',
+  'google inc.': 'google',
+  microsoft: 'microsoft',
+  'microsoft corporation': 'microsoft',
+  videolan: 'videolan',
+  'the videolan project': 'videolan',
+  'igor pavlov': '7-zip',
+  '7-zip': '7-zip',
+  wireshark: 'wireshark',
+  'wireshark foundation': 'wireshark',
+  'the wireshark developers': 'wireshark',
+};
+const VENDOR_SUFFIX =
+  /\b(inc|inc\.|llc|ltd|corp|corporation|gmbh|co|company|foundation|project|team|the)\b/gi;
+const STOPWORDS = new Set([
+  'the',
+  'inc',
+  'llc',
+  'ltd',
+  'corp',
+  'corporation',
+  'gmbh',
+  'co',
+  'company',
+  'software',
+  'app',
+  'application',
+  'tool',
+  'client',
+  'edition',
+]);
+const MIN_DISTINCTIVE_TOKENS = 1;
+
+function canonicalVendor(vendor: string): string {
+  const v = vendor.toLowerCase().trim();
+  if (VENDOR_ALIASES[v]) return VENDOR_ALIASES[v];
+  const stripped = v.replace(VENDOR_SUFFIX, '').replace(/\s+/g, ' ').trim();
+  return VENDOR_ALIASES[stripped] ?? stripped;
+}
+
+function vendorAgrees(invVendor: string | null, cpeVendor: string | null): boolean {
+  if (!invVendor || !cpeVendor) return false;
+  const a = canonicalVendor(invVendor);
+  const b = cpeVendor.toLowerCase();
+  return a === b || a.includes(b) || b.includes(a);
+}
+
 export function normalizeDisplayName(name: string): string {
   let s = name.toLowerCase();
   s = s.replace(PAREN_GROUP, ' ');
@@ -151,7 +206,7 @@ export const NONE: Resolution = {
 
 export function resolve(
   displayName: string,
-  _vendor: string | null,
+  vendor: string | null,
   index: CatalogIndex,
   curated: Map<string, CuratedEntry>,
 ): Resolution {
@@ -186,6 +241,49 @@ export function resolve(
     };
   }
 
-  // Layer B added in Task 5.
-  return NONE;
+  // Layer B - token inverted-index over catalog + hard guardrails.
+  const queryWords = new Set(tokenize(normName));
+  if (queryWords.size === 0) return NONE;
+
+  const candidates = new Set<string>();
+  for (const word of queryWords) {
+    for (const id of index.wordIndex.get(word) ?? []) {
+      candidates.add(id);
+    }
+  }
+
+  let best: { id: string; score: number } | null = null;
+  let runnerUp = 0;
+  for (const id of candidates) {
+    const m = index.meta.get(id);
+    if (!m || !vendorAgrees(vendor, m.cpeVendor)) continue;
+
+    let score = 0;
+    for (const word of queryWords) {
+      if (STOPWORDS.has(word)) continue;
+      if (m.productTokens.has(word)) score += 1;
+    }
+
+    if (score < MIN_DISTINCTIVE_TOKENS) continue;
+    if (!best || score > best.score) {
+      runnerUp = best ? best.score : 0;
+      best = { id, score };
+    } else if (score > runnerUp) {
+      runnerUp = score;
+    }
+  }
+
+  if (!best) return NONE;
+  if (best.score <= runnerUp) return NONE;
+
+  const m = index.meta.get(best.id);
+  if (!m) return NONE;
+  if (m.cpe && !isWellFormedCpe(m.cpe)) return NONE;
+  return {
+    productId: best.id,
+    cpe: m.cpe,
+    confidence: 'fuzzy',
+    matchedVia: 'token',
+    tokensMatched: best.score,
+  };
 }

--- a/apps/api/src/services/cpeResolver.ts
+++ b/apps/api/src/services/cpeResolver.ts
@@ -249,13 +249,11 @@ export function resolve(
         tokensMatched: 0,
       };
     }
-    const cpe = productId
-      ? index.meta.get(productId)?.cpe ?? null
-      : `cpe:2.3:a:${curatedHit.vendor}:${curatedHit.product}`;
+    // productId is guaranteed non-null here (the !productId case returned above).
     return {
       productId,
-      cpe,
-      confidence: productId ? 'curated' : 'none',
+      cpe: index.meta.get(productId)?.cpe ?? null,
+      confidence: 'curated',
       matchedVia: 'dictionary',
       tokensMatched: 0,
     };

--- a/apps/api/src/services/cpeResolver.ts
+++ b/apps/api/src/services/cpeResolver.ts
@@ -4,6 +4,9 @@
  * https://github.com/vulnerability-lookup/cpe-guesser
  */
 
+import curatedJson from './__fixtures__/cpe-translations.json';
+import cpedictJson from './__fixtures__/cpe-dictionary.json';
+
 export const RESOLVER_VERSION = 1;
 
 // Tokens stripped from a raw registry DisplayName. Architecture, then version-ish
@@ -30,4 +33,33 @@ export function tokenize(s: string): string[] {
     .toLowerCase()
     .split(/[^a-z0-9]+/)
     .filter((w) => w.length > 0);
+}
+
+export interface CuratedEntry { vendor: string; product: string; }
+
+export function parseCpe(cpe: string): { vendor: string; product: string } | null {
+  const parts = cpe.split(':');
+  // cpe:2.3:part:vendor:product:...  → parts[3]=vendor parts[4]=product
+  if (parts.length < 5 || parts[0] !== 'cpe' || parts[1] !== '2.3') return null;
+  const vendor = parts[3];
+  const product = parts[4];
+  if (!vendor || !product) return null;
+  return { vendor, product };
+}
+
+export function isWellFormedCpe(cpe: string): boolean {
+  return parseCpe(cpe) !== null;
+}
+
+export function loadCuratedDictionary(): Map<string, CuratedEntry> {
+  const rows = curatedJson as Array<{ name: string; vendor: string; product: string }>;
+  const map = new Map<string, CuratedEntry>();
+  for (const r of rows) {
+    map.set(normalizeDisplayName(r.name), { vendor: r.vendor, product: r.product });
+  }
+  return map;
+}
+
+export function loadCpeDictionary(): Set<string> {
+  return new Set(cpedictJson as string[]);
 }

--- a/apps/api/src/services/cpeResolver.ts
+++ b/apps/api/src/services/cpeResolver.ts
@@ -63,3 +63,69 @@ export function loadCuratedDictionary(): Map<string, CuratedEntry> {
 export function loadCpeDictionary(): Set<string> {
   return new Set(cpedictJson as string[]);
 }
+
+export interface CatalogProduct {
+  id: string;
+  normalizedName: string;
+  normalizedVendor: string | null;
+  cpe: string | null;
+}
+
+export interface CatalogIndex {
+  byExactName: Map<string, string | null>;
+  byVendorProduct: Map<string, string>;
+  wordIndex: Map<string, Set<string>>;
+  meta: Map<
+    string,
+    {
+      cpe: string | null;
+      cpeVendor: string | null;
+      cpeProduct: string | null;
+      productTokens: Set<string>;
+    }
+  >;
+}
+
+export function buildCatalogIndex(products: CatalogProduct[]): CatalogIndex {
+  const byExactName = new Map<string, string | null>();
+  const byVendorProduct = new Map<string, string>();
+  const wordIndex = new Map<string, Set<string>>();
+  const meta: CatalogIndex['meta'] = new Map();
+
+  for (const product of products) {
+    if (byExactName.has(product.normalizedName)) {
+      byExactName.set(product.normalizedName, null);
+    } else {
+      byExactName.set(product.normalizedName, product.id);
+    }
+
+    const cpeParts = product.cpe ? parseCpe(product.cpe) : null;
+    if (cpeParts) {
+      byVendorProduct.set(`${cpeParts.vendor}:${cpeParts.product}`, product.id);
+    }
+
+    const productTokens = new Set(
+      cpeParts ? tokenize(cpeParts.product) : tokenize(product.normalizedName),
+    );
+    const recallWords = new Set([
+      ...tokenize(product.normalizedName),
+      ...(product.normalizedVendor ? tokenize(product.normalizedVendor) : []),
+      ...(cpeParts ? [...tokenize(cpeParts.vendor), ...tokenize(cpeParts.product)] : []),
+    ]);
+
+    for (const word of recallWords) {
+      const productIds = wordIndex.get(word) ?? new Set<string>();
+      productIds.add(product.id);
+      wordIndex.set(word, productIds);
+    }
+
+    meta.set(product.id, {
+      cpe: product.cpe,
+      cpeVendor: cpeParts?.vendor ?? null,
+      cpeProduct: cpeParts?.product ?? null,
+      productTokens,
+    });
+  }
+
+  return { byExactName, byVendorProduct, wordIndex, meta };
+}

--- a/apps/api/src/services/cpeResolver.ts
+++ b/apps/api/src/services/cpeResolver.ts
@@ -129,3 +129,63 @@ export function buildCatalogIndex(products: CatalogProduct[]): CatalogIndex {
 
   return { byExactName, byVendorProduct, wordIndex, meta };
 }
+
+export type ResolutionConfidence = 'curated' | 'exact' | 'fuzzy' | 'none';
+export type ResolutionVia = 'dictionary' | 'catalog_exact' | 'token' | 'unmatched';
+
+export interface Resolution {
+  productId: string | null;
+  cpe: string | null;
+  confidence: ResolutionConfidence;
+  matchedVia: ResolutionVia;
+  tokensMatched: number;
+}
+
+export const NONE: Resolution = {
+  productId: null,
+  cpe: null,
+  confidence: 'none',
+  matchedVia: 'unmatched',
+  tokensMatched: 0,
+};
+
+export function resolve(
+  displayName: string,
+  _vendor: string | null,
+  index: CatalogIndex,
+  curated: Map<string, CuratedEntry>,
+): Resolution {
+  const normName = normalizeDisplayName(displayName);
+
+  // Layer A.1 - curated translation dictionary.
+  const curatedHit = curated.get(normName);
+  if (curatedHit) {
+    const key = `${curatedHit.vendor}:${curatedHit.product}`;
+    const productId = index.byVendorProduct.get(key) ?? null;
+    const cpe = productId
+      ? index.meta.get(productId)?.cpe ?? null
+      : `cpe:2.3:a:${curatedHit.vendor}:${curatedHit.product}`;
+    return {
+      productId,
+      cpe,
+      confidence: productId ? 'curated' : 'none',
+      matchedVia: 'dictionary',
+      tokensMatched: 0,
+    };
+  }
+
+  // Layer A.2 - exact catalog normalized-name match.
+  const exact = index.byExactName.get(normName);
+  if (exact) {
+    return {
+      productId: exact,
+      cpe: index.meta.get(exact)?.cpe ?? null,
+      confidence: 'exact',
+      matchedVia: 'catalog_exact',
+      tokensMatched: 0,
+    };
+  }
+
+  // Layer B added in Task 5.
+  return NONE;
+}

--- a/apps/api/src/services/cpeResolver.ts
+++ b/apps/api/src/services/cpeResolver.ts
@@ -2,6 +2,9 @@
  * DisplayName -> CPE resolver (#2290).
  * Layer B token index/lookup ported from CIRCL cpe-guesser (BSD-2-Clause):
  * https://github.com/vulnerability-lookup/cpe-guesser
+ * Copyright 2021-2024 Alexandre Dulaunoy
+ * Copyright 2021-2024 Esa Jokinen
+ * BSD-2-Clause redistribution retains the copyright notice and disclaimer.
  */
 
 import curatedJson from './__fixtures__/cpe-translations.json';
@@ -136,6 +139,7 @@ export function loadCuratedDictionary(): Map<string, CuratedEntry> {
   return map;
 }
 
+// Test-time validation set only: asserts curated CPEs are well-formed/real; resolve() does not consult it at runtime.
 export function loadCpeDictionary(): Set<string> {
   return new Set(cpedictJson as string[]);
 }
@@ -219,13 +223,13 @@ export interface Resolution {
   tokensMatched: number;
 }
 
-export const NONE: Resolution = {
+export const NONE: Resolution = Object.freeze({
   productId: null,
   cpe: null,
   confidence: 'none',
   matchedVia: 'unmatched',
   tokensMatched: 0,
-};
+});
 
 export function resolve(
   displayName: string,

--- a/apps/api/src/services/cpeResolver.ts
+++ b/apps/api/src/services/cpeResolver.ts
@@ -1,0 +1,33 @@
+/*
+ * DisplayName -> CPE resolver (#2290).
+ * Layer B token index/lookup ported from CIRCL cpe-guesser (BSD-2-Clause):
+ * https://github.com/vulnerability-lookup/cpe-guesser
+ */
+
+export const RESOLVER_VERSION = 1;
+
+// Tokens stripped from a raw registry DisplayName. Architecture, then version-ish
+// trailers. Order matters: strip arch/locale before trailing-number cleanup.
+const ARCH_TOKENS = /\b(64-?bit|32-?bit|x64|x86|amd64|arm64|win64|win32)\b/gi;
+const LOCALE_TOKEN = /\b[a-z]{2}-[a-z]{2}\b/gi;
+const PAREN_GROUP = /\([^)]*\)/g;
+const TRAILING_VERSION = /\s+\d[\d.]*\s*$/g;
+const MULTISPACE = /\s+/g;
+
+export function normalizeDisplayName(name: string): string {
+  let s = name.toLowerCase();
+  s = s.replace(PAREN_GROUP, ' ');
+  s = s.replace(ARCH_TOKENS, ' ');
+  s = s.replace(LOCALE_TOKEN, ' ');
+  s = s.replace(/\s-\s.*$/, ' ');
+  s = s.replace(TRAILING_VERSION, ' ');
+  s = s.replace(MULTISPACE, ' ').trim();
+  return s;
+}
+
+export function tokenize(s: string): string[] {
+  return s
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((w) => w.length > 0);
+}

--- a/apps/api/src/services/cpeResolver.ts
+++ b/apps/api/src/services/cpeResolver.ts
@@ -55,6 +55,23 @@ const STOPWORDS = new Set([
   'tool',
   'client',
   'edition',
+  'for',
+  'and',
+  'of',
+  'update',
+  'service',
+  'helper',
+  'runtime',
+  'agent',
+  'console',
+  'manager',
+  'suite',
+  'desktop',
+  'professional',
+  'standard',
+  'home',
+  'pro',
+  'plus',
 ]);
 const MIN_DISTINCTIVE_TOKENS = 1;
 
@@ -69,7 +86,11 @@ function vendorAgrees(invVendor: string | null, cpeVendor: string | null): boole
   if (!invVendor || !cpeVendor) return false;
   const a = canonicalVendor(invVendor);
   const b = cpeVendor.toLowerCase();
-  return a === b || a.includes(b) || b.includes(a);
+  if (a === b) return true;
+  const aTokens = new Set(tokenize(a));
+  const bTokens = new Set(tokenize(b));
+  for (const t of aTokens) if (t.length >= 3 && bTokens.has(t)) return true;
+  return false;
 }
 
 export function normalizeDisplayName(name: string): string {
@@ -136,6 +157,7 @@ export interface CatalogIndex {
       cpe: string | null;
       cpeVendor: string | null;
       cpeProduct: string | null;
+      catalogVendor: string | null;
       productTokens: Set<string>;
     }
   >;
@@ -178,6 +200,7 @@ export function buildCatalogIndex(products: CatalogProduct[]): CatalogIndex {
       cpe: product.cpe,
       cpeVendor: cpeParts?.vendor ?? null,
       cpeProduct: cpeParts?.product ?? null,
+      catalogVendor: product.normalizedVendor,
       productTokens,
     });
   }
@@ -214,9 +237,18 @@ export function resolve(
 
   // Layer A.1 - curated translation dictionary.
   const curatedHit = curated.get(normName);
-  if (curatedHit) {
+  if (curatedHit && (!vendor || vendorAgrees(vendor, curatedHit.vendor))) {
     const key = `${curatedHit.vendor}:${curatedHit.product}`;
     const productId = index.byVendorProduct.get(key) ?? null;
+    if (!productId) {
+      return {
+        productId: null,
+        cpe: null,
+        confidence: 'none',
+        matchedVia: 'dictionary',
+        tokensMatched: 0,
+      };
+    }
     const cpe = productId
       ? index.meta.get(productId)?.cpe ?? null
       : `cpe:2.3:a:${curatedHit.vendor}:${curatedHit.product}`;
@@ -256,7 +288,8 @@ export function resolve(
   let runnerUp = 0;
   for (const id of candidates) {
     const m = index.meta.get(id);
-    if (!m || !vendorAgrees(vendor, m.cpeVendor)) continue;
+    const candVendor = m?.cpeVendor ?? m?.catalogVendor ?? null;
+    if (!m || !vendorAgrees(vendor, candVendor)) continue;
 
     let score = 0;
     for (const word of queryWords) {

--- a/apps/api/src/services/vulnerabilityCorrelation.integration.test.ts
+++ b/apps/api/src/services/vulnerabilityCorrelation.integration.test.ts
@@ -12,10 +12,12 @@ import {
   sites,
   softwareInventory,
   softwareProducts,
+  softwareProductResolutions,
   softwareVulnerabilities,
   vulnerabilities,
 } from '../db/schema';
 import { correlateOrg } from './vulnerabilityCorrelation';
+import { refreshResolutionCache } from './cpeResolution';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
@@ -32,7 +34,9 @@ function orgCtx(orgId: string): DbAccessContext {
 beforeEach(async () => {
   await withSystemDbAccessContext(async () => {
     await db.delete(deviceVulnerabilities);
+    await db.delete(softwareProductResolutions);
     await db.delete(softwareVulnerabilities);
+    await db.delete(softwareInventory);
     await db.delete(softwareProducts);
     await db.delete(vulnerabilities);
   });
@@ -156,6 +160,7 @@ describe('correlateOrg', () => {
       version: '16.0.14332.20481',
     });
 
+    await refreshResolutionCache();
     const res = await correlateOrg(orgId);
 
     expect(res.created).toBe(1);
@@ -185,6 +190,7 @@ describe('correlateOrg', () => {
       version: '16.0.14332.20600',
     });
 
+    await refreshResolutionCache();
     const res = await correlateOrg(orgId);
 
     expect(res.created).toBe(0);
@@ -197,5 +203,101 @@ describe('correlateOrg', () => {
         .where(eq(deviceVulnerabilities.deviceId, deviceId))
     );
     expect(rows).toHaveLength(0);
+  });
+});
+
+async function seedInventoryVendored(
+  orgId: string,
+  deviceId: string,
+  name: string,
+  vendor: string | null,
+  version: string
+): Promise<void> {
+  await withSystemDbAccessContext(async () => {
+    await db.insert(softwareInventory).values({ orgId, deviceId, name, vendor, version });
+  });
+}
+
+describe('correlation via resolver', () => {
+  runDb('a noisy Windows DisplayName correlates to a catalog CVE with match_confidence', async () => {
+    const { orgId, deviceId } = await seedOrgWithDevice();
+    await withSystemDbAccessContext(async () => {
+      const [prod] = await db
+        .insert(softwareProducts)
+        .values({
+          normalizedName: 'acrobat_reader',
+          normalizedVendor: 'adobe',
+          cpe: 'cpe:2.3:a:adobe:acrobat_reader:*:*:*:*:*:*:*:*',
+          cpeConfidence: 'authoritative',
+        })
+        .returning({ id: softwareProducts.id });
+      const [vuln] = await db
+        .insert(vulnerabilities)
+        .values({
+          cveId: 'CVE-2025-0001',
+          source: 'nvd',
+          description: 'x',
+          severity: 'critical',
+          cvssVersion: '3.1',
+          cvssScore: '9.8',
+          patchAvailable: true,
+          rawPayload: { t: true },
+        })
+        .returning({ id: vulnerabilities.id });
+      await db.insert(softwareVulnerabilities).values({
+        productId: prod!.id,
+        vulnerabilityId: vuln!.id,
+        versionEndExcluding: '99.0',
+      });
+    });
+    // curated dict maps "Adobe Acrobat Reader DC" → adobe:acrobat_reader
+    await seedInventoryVendored(orgId, deviceId, 'Adobe Acrobat Reader DC (64-bit)', 'Adobe Inc.', '23.0');
+
+    await refreshResolutionCache();
+    const res = await correlateOrg(orgId, { deviceIds: [deviceId] });
+    expect(res.created).toBe(1);
+
+    const findings = await withSystemDbAccessContext(() =>
+      db.select().from(deviceVulnerabilities).where(eq(deviceVulnerabilities.orgId, orgId))
+    );
+    expect(findings[0]?.matchConfidence).toBe('curated');
+  });
+
+  runDb('Microsoft Edge against a Chrome-only catalog produces NO finding', async () => {
+    const { orgId, deviceId } = await seedOrgWithDevice();
+    await withSystemDbAccessContext(async () => {
+      const [prod] = await db
+        .insert(softwareProducts)
+        .values({
+          normalizedName: 'chrome',
+          normalizedVendor: 'google',
+          cpe: 'cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*',
+          cpeConfidence: 'authoritative',
+        })
+        .returning({ id: softwareProducts.id });
+      const [vuln] = await db
+        .insert(vulnerabilities)
+        .values({
+          cveId: 'CVE-2025-0002',
+          source: 'nvd',
+          description: 'x',
+          severity: 'high',
+          cvssVersion: '3.1',
+          cvssScore: '7.5',
+          patchAvailable: true,
+          rawPayload: { t: true },
+        })
+        .returning({ id: vulnerabilities.id });
+      await db.insert(softwareVulnerabilities).values({
+        productId: prod!.id,
+        vulnerabilityId: vuln!.id,
+        versionEndExcluding: '999.0',
+      });
+    });
+    await seedInventoryVendored(orgId, deviceId, 'Microsoft Edge', 'Microsoft Corporation', '120.0');
+
+    await refreshResolutionCache();
+    const res = await correlateOrg(orgId, { deviceIds: [deviceId] });
+    expect(res.created).toBe(0);
   });
 });

--- a/apps/api/src/services/vulnerabilityCorrelation.integration.test.ts
+++ b/apps/api/src/services/vulnerabilityCorrelation.integration.test.ts
@@ -300,4 +300,75 @@ describe('correlation via resolver', () => {
     const res = await correlateOrg(orgId, { deviceIds: [deviceId] });
     expect(res.created).toBe(0);
   });
+
+  async function seedAcrobatFact(cveId: string, fixedBuild: string): Promise<void> {
+    await withSystemDbAccessContext(async () => {
+      const [prod] = await db
+        .insert(softwareProducts)
+        .values({ normalizedName: 'acrobat_reader', normalizedVendor: 'adobe', cpe: 'cpe:2.3:a:adobe:acrobat_reader:*:*:*:*:*:*:*:*', cpeConfidence: 'authoritative' })
+        .returning({ id: softwareProducts.id });
+      const [vuln] = await db
+        .insert(vulnerabilities)
+        .values({ cveId, source: 'nvd', description: 'x', severity: 'high', cvssVersion: '3.1', cvssScore: '7.5', patchAvailable: true, rawPayload: { t: true } })
+        .returning({ id: vulnerabilities.id });
+      await db.insert(softwareVulnerabilities).values({ productId: prod!.id, vulnerabilityId: vuln!.id, versionEndExcluding: fixedBuild });
+    });
+  }
+
+  async function addDeviceToOrg(orgId: string): Promise<string> {
+    return withSystemDbAccessContext(async () => {
+      const u = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const [site] = await db.insert(sites).values({ orgId, name: `Iso Site ${u}` }).returning({ id: sites.id });
+      const [dev] = await db
+        .insert(devices)
+        .values({ orgId, siteId: site!.id, agentId: `iso-agent-${u}`, hostname: `iso-host-${u}`, osType: 'windows', osVersion: '11', architecture: 'x86_64', agentVersion: '0.0.0-test', status: 'offline' })
+        .returning({ id: devices.id });
+      return dev!.id;
+    });
+  }
+
+  runDb('a device-scoped run leaves OTHER devices open findings untouched (no mass false-negative)', async () => {
+    const { orgId, deviceId: deviceA } = await seedOrgWithDevice();
+    const deviceB = await addDeviceToOrg(orgId);
+    await seedAcrobatFact('CVE-2025-ISO', '99.0');
+    await seedInventoryVendored(orgId, deviceA, 'Adobe Acrobat Reader DC', 'Adobe Inc.', '23.0');
+    await seedInventoryVendored(orgId, deviceB, 'Adobe Acrobat Reader DC', 'Adobe Inc.', '23.0');
+
+    await refreshResolutionCache();
+    expect((await correlateOrg(orgId, { deviceIds: [deviceA, deviceB] })).created).toBe(2);
+
+    // Scoped run on A only must NOT resolve B's finding (findingDeviceFilter isolation).
+    await correlateOrg(orgId, { deviceIds: [deviceA] });
+    const bOpen = await withSystemDbAccessContext(() =>
+      db.select().from(deviceVulnerabilities).where(and(eq(deviceVulnerabilities.deviceId, deviceB), eq(deviceVulnerabilities.status, 'open'))));
+    expect(bOpen).toHaveLength(1);
+  });
+
+  runDb('re-correlation reopens a patched finding when the software is vulnerable again', async () => {
+    const { orgId, deviceId } = await seedOrgWithDevice();
+    await seedAcrobatFact('CVE-2025-REOPEN', '50.0');
+    await seedInventoryVendored(orgId, deviceId, 'Adobe Acrobat Reader DC', 'Adobe Inc.', '23.0');
+
+    await refreshResolutionCache();
+    expect((await correlateOrg(orgId, { deviceIds: [deviceId] })).created).toBe(1);
+
+    // Upgrade above the fixed build → next correlation resolves (patched).
+    await withSystemDbAccessContext(() =>
+      db.update(softwareInventory).set({ version: '99.0' }).where(eq(softwareInventory.deviceId, deviceId)));
+    await refreshResolutionCache();
+    expect((await correlateOrg(orgId, { deviceIds: [deviceId] })).resolved).toBe(1);
+
+    // Downgrade below the fixed build again → correlation must REOPEN the patched row.
+    await withSystemDbAccessContext(() =>
+      db.update(softwareInventory).set({ version: '23.0' }).where(eq(softwareInventory.deviceId, deviceId)));
+    await refreshResolutionCache();
+    await correlateOrg(orgId, { deviceIds: [deviceId] });
+
+    const rows = await withSystemDbAccessContext(() =>
+      db.select().from(deviceVulnerabilities).where(eq(deviceVulnerabilities.deviceId, deviceId)));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.status).toBe('open');
+    expect(rows[0]?.resolvedAt).toBeNull();
+    expect(rows[0]?.matchConfidence).toBe('curated');
+  });
 });

--- a/apps/api/src/services/vulnerabilityCorrelation.ts
+++ b/apps/api/src/services/vulnerabilityCorrelation.ts
@@ -6,6 +6,7 @@ import {
   deviceVulnerabilities,
   osVulnerabilities,
   softwareInventory,
+  softwareProductResolutions,
   softwareProducts,
   softwareVulnerabilities,
   vulnerabilities,
@@ -121,6 +122,7 @@ async function upsertDeviceVulnerability(args: {
   vulnerabilityId: string;
   softwareInventoryId: string | null;
   cvssScore: string | null;
+  matchConfidence: string | null;
 }): Promise<{ id: string; created: boolean }> {
   const riskScore = args.cvssScore == null ? null : String(args.cvssScore);
   const now = new Date();
@@ -144,6 +146,7 @@ async function upsertDeviceVulnerability(args: {
         ...(existing.status === 'patched' ? { status: 'open', resolvedAt: null } : {}),
         softwareInventoryId: args.softwareInventoryId,
         riskScore,
+        matchConfidence: args.matchConfidence,
         updatedAt: now,
       })
       .where(eq(deviceVulnerabilities.id, existing.id));
@@ -159,6 +162,7 @@ async function upsertDeviceVulnerability(args: {
       softwareInventoryId: args.softwareInventoryId,
       status: 'open',
       riskScore,
+      matchConfidence: args.matchConfidence,
       detectedAt: now,
     })
     .returning({ id: deviceVulnerabilities.id });
@@ -195,11 +199,17 @@ export async function correlateOrg(
         fixedBuild: softwareVulnerabilities.versionEndExcluding,
         cvssScore: vulnerabilities.cvssScore,
         cveId: vulnerabilities.cveId,
+        matchConfidence: softwareProductResolutions.confidence,
       })
       .from(softwareInventory)
       .innerJoin(
+        softwareProductResolutions,
+        sql`${softwareProductResolutions.lookupName} = lower(trim(${softwareInventory.name}))
+            AND ${softwareProductResolutions.lookupVendor} IS NOT DISTINCT FROM lower(trim(${softwareInventory.vendor}))`
+      )
+      .innerJoin(
         softwareProducts,
-        sql`${softwareProducts.normalizedName} = lower(trim(${softwareInventory.name}))`
+        eq(softwareProducts.id, softwareProductResolutions.softwareProductId)
       )
       .innerJoin(
         softwareVulnerabilities,
@@ -231,6 +241,7 @@ export async function correlateOrg(
         vulnerabilityId: candidate.vulnerabilityId,
         softwareInventoryId: candidate.inventoryId,
         cvssScore: candidate.cvssScore,
+        matchConfidence: candidate.matchConfidence,
       });
       matchedIds.add(result.id);
       if (result.created) {
@@ -253,11 +264,17 @@ export async function correlateOrg(
         versionEndExcluding: softwareVulnerabilities.versionEndExcluding,
         cvssScore: vulnerabilities.cvssScore,
         cveId: vulnerabilities.cveId,
+        matchConfidence: softwareProductResolutions.confidence,
       })
       .from(softwareInventory)
       .innerJoin(
+        softwareProductResolutions,
+        sql`${softwareProductResolutions.lookupName} = lower(trim(${softwareInventory.name}))
+            AND ${softwareProductResolutions.lookupVendor} IS NOT DISTINCT FROM lower(trim(${softwareInventory.vendor}))`
+      )
+      .innerJoin(
         softwareProducts,
-        sql`${softwareProducts.normalizedName} = lower(trim(${softwareInventory.name}))`
+        eq(softwareProducts.id, softwareProductResolutions.softwareProductId)
       )
       .innerJoin(
         softwareVulnerabilities,
@@ -291,6 +308,7 @@ export async function correlateOrg(
         vulnerabilityId: candidate.vulnerabilityId,
         softwareInventoryId: candidate.inventoryId,
         cvssScore: candidate.cvssScore,
+        matchConfidence: candidate.matchConfidence,
       });
       matchedIds.add(result.id);
       if (result.created) {
@@ -400,6 +418,7 @@ export async function correlateOsVulns(
           vulnerabilityId: fact.vulnerabilityId,
           softwareInventoryId: null,
           cvssScore: fact.cvssScore,
+          matchConfidence: null,
         });
         matchedIds.add(result.id);
         if (result.created) {

--- a/apps/api/src/services/vulnerabilityCorrelation.ts
+++ b/apps/api/src/services/vulnerabilityCorrelation.ts
@@ -202,6 +202,8 @@ export async function correlateOrg(
         matchConfidence: softwareProductResolutions.confidence,
       })
       .from(softwareInventory)
+      // Join on the SQL-reproducible cache key, not raw/observability normalized_name.
+      // IS NOT DISTINCT FROM mirrors the NULLS NOT DISTINCT unique index for null vendors.
       .innerJoin(
         softwareProductResolutions,
         sql`${softwareProductResolutions.lookupName} = lower(trim(${softwareInventory.name}))

--- a/apps/api/src/services/vulnerabilityCorrelationPhase2.integration.test.ts
+++ b/apps/api/src/services/vulnerabilityCorrelationPhase2.integration.test.ts
@@ -11,10 +11,12 @@ import {
   sites,
   softwareInventory,
   softwareProducts,
+  softwareProductResolutions,
   softwareVulnerabilities,
   vulnerabilities,
 } from '../db/schema';
 import { correlateOrg, correlateOsVulns, deriveMacosLine } from './vulnerabilityCorrelation';
+import { refreshResolutionCache } from './cpeResolution';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
@@ -166,6 +168,8 @@ describe('Phase 2 vulnerability correlation', () => {
       version: '120.0.6099.110',
     });
 
+    await refreshResolutionCache();
+
     const res = await correlateOrg(orgId);
 
     expect(res.created).toBeGreaterThanOrEqual(1);
@@ -180,6 +184,8 @@ describe('Phase 2 vulnerability correlation', () => {
       name: 'Google Chrome',
       version: '120.0.6099.300',
     });
+
+    await refreshResolutionCache();
 
     const res = await correlateOrg(orgId);
 

--- a/apps/api/src/services/vulnerabilityEvents.integration.test.ts
+++ b/apps/api/src/services/vulnerabilityEvents.integration.test.ts
@@ -13,10 +13,12 @@ import {
   sites,
   softwareInventory,
   softwareProducts,
+  softwareProductResolutions,
   softwareVulnerabilities,
   vulnerabilities,
 } from '../db/schema';
 import { correlateOrg, correlateOsVulns } from './vulnerabilityCorrelation';
+import { refreshResolutionCache } from './cpeResolution';
 import { getEventBus, type BreezeEvent } from './eventBus';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
@@ -26,6 +28,8 @@ beforeEach(async () => {
     await db.delete(deviceVulnerabilities);
     await db.delete(osVulnerabilities);
     await db.delete(softwareVulnerabilities);
+    await db.delete(softwareProductResolutions);
+    await db.delete(softwareInventory);
     await db.delete(softwareProducts);
     await db.delete(vulnerabilities);
   });
@@ -114,6 +118,8 @@ describe('vulnerability.critical_detected', () => {
     await seedSoftwareFact({ cveId: 'CVE-2025-EVT-CRIT', cvssScore: '9.8', severity: 'critical', productName: 'Critical Test App', fixedBuild: '16.0.14332.20500' });
     await seedInventory({ orgId, deviceId, name: 'Critical Test App', version: '16.0.14332.20481' });
 
+    await refreshResolutionCache();
+
     const res = await correlateOrg(orgId);
     expect(res.created).toBe(1);
 
@@ -133,6 +139,8 @@ describe('vulnerability.critical_detected', () => {
     await seedSoftwareFact({ cveId: 'CVE-2025-EVT-MED', cvssScore: '5.0', severity: 'Medium', productName: 'Medium Test App', fixedBuild: '16.0.14332.20500' });
     await seedInventory({ orgId, deviceId, name: 'Medium Test App', version: '16.0.14332.20481' });
 
+    await refreshResolutionCache();
+
     const res = await correlateOrg(orgId);
     expect(res.created).toBe(1);
     expect(events).toHaveLength(0);
@@ -142,9 +150,11 @@ describe('vulnerability.critical_detected', () => {
     const { orgId, deviceId } = await seedOrgWithDevice('windows', '11');
     await seedSoftwareFact({ cveId: 'CVE-2025-EVT-DUP', cvssScore: '9.1', severity: 'CRITICAL', productName: 'Dup Test App', fixedBuild: '16.0.14332.20500' });
     await seedInventory({ orgId, deviceId, name: 'Dup Test App', version: '16.0.14332.20481' });
+    await refreshResolutionCache();
     await correlateOrg(orgId); // first pass creates + emits
 
     const events = captureCriticalDetected(); // subscribe AFTER the first pass
+    await refreshResolutionCache();
     const res = await correlateOrg(orgId);
     expect(res.created).toBe(0);
     expect(events).toHaveLength(0);
@@ -182,6 +192,7 @@ describe('vulnerability.remediated', () => {
     const { orgId, deviceId, siteId } = await seedOrgWithDevice('windows', '11');
     await seedSoftwareFact({ cveId: 'CVE-2025-EVT-REM', cvssScore: '9.8', severity: 'critical', productName: 'Remediated Test App', fixedBuild: '16.0.14332.20500' });
     await seedInventory({ orgId, deviceId, name: 'Remediated Test App', version: '16.0.14332.20481' });
+    await refreshResolutionCache();
     const first = await correlateOrg(orgId);
     expect(first.created).toBe(1);
 
@@ -192,6 +203,7 @@ describe('vulnerability.remediated', () => {
     );
 
     const events = captureRemediated();
+    await refreshResolutionCache();
     const res = await correlateOrg(orgId);
     expect(res.resolved).toBe(1);
 

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       'src/services/vulnerability*.integration.test.ts',
       'src/services/aiToolsVulnerability.integration.test.ts',
       'src/services/cpeMap.integration.test.ts',
+      'src/services/cpeResolution.integration.test.ts',
       'src/services/exploitFeeds.integration.test.ts',
       'src/jobs/vulnerability*.integration.test.ts',
       // Warranty alert evaluator real-DB test: imports `__tests__/integration/setup`

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -39,6 +39,8 @@ export default defineConfig({
       // Co-located real-DB integration test for BE-16 Phase 2 correlation:
       // CPE range matching and macOS OS vulnerability facts.
       'src/services/vulnerabilityCorrelationPhase2.integration.test.ts',
+      // Co-located real-DB integration test for the DisplayName→CPE resolution cache (#2290).
+      'src/services/cpeResolution.integration.test.ts',
       // Co-located real-DB integration test for the curated CPE map seed loader.
       'src/services/cpeMap.integration.test.ts',
       // Co-located real-DB integration test for KEV + EPSS vulnerability enrichment.

--- a/docs/superpowers/plans/2026-07-08-vuln-displayname-cpe-resolver.md
+++ b/docs/superpowers/plans/2026-07-08-vuln-displayname-cpe-resolver.md
@@ -1,0 +1,1279 @@
+# DisplayName → CPE Resolver Implementation Plan (#2290)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make device→catalog vulnerability correlation resolve real Windows registry DisplayNames to catalog CPE products via a deterministic two-layer resolver, so the Vulnerabilities dashboard surfaces the whole installed-software surface instead of only Chrome.
+
+**Architecture:** A pure `cpeResolver.ts` normalizes a DisplayName and resolves it against (Layer A) a curated translation dictionary + exact catalog-name match, then (Layer B) a ported cpe-guesser token inverted-index over the catalog gated by hard guardrails (vendor agreement, distinctive-product-token, unique winner, score threshold) — withholding rather than guessing. A global `software_product_resolutions` cache table (system-only RLS) stores `(lookup_name, lookup_vendor) → software_product_id | NULL` keyed on the SQL-reproducible `lower(trim(...))` form; `refreshResolutionCache()` fills it once per correlation cycle; correlation joins through it and stamps `device_vulnerabilities.match_confidence`.
+
+**Tech Stack:** TypeScript, Hono API, PostgreSQL 16 + Drizzle ORM, Vitest (unit + real-DB integration on :5433), BullMQ. Vendored data: FleetDM `cpe_translations` (MIT), CIRCL cpe-guesser algorithm (BSD-2, ported), tiiuae cpedict slice.
+
+## Global Constraints
+
+- **Resolver purity:** `cpeResolver.ts` performs NO database or network access. All DB work lives in `cpeResolution.ts` / `vulnerabilityCorrelation.ts`.
+- **Deterministic only:** no similarity scoring as the match decision; Layer B is token-set logic + guardrails. A match is withheld (never guessed) when any guardrail fails.
+- **Join key is `lower(trim(name))`**, NOT the token-normalized name — full normalization runs in TS during refresh; the SQL join is a plain equality on stored lowercased keys.
+- **`software_product_resolutions` is a global system-only table** (RLS enabled + forced + `_system_only` policy: `current_setting('breeze.scope', true) = 'system'`). Accessed only under `withSystemDbAccessContext`. Registered in `INTENTIONAL_UNSCOPED` in `rls-coverage.integration.test.ts`.
+- **Read-side `lower()` invariant preserved** — do NOT rewrite/backfill `software_products.normalized_name`.
+- **cpedict guard (refinement from spec):** runtime validation = `cpe:2.3` well-formedness only; presence-in-cpedict is a TEST-TIME invariant on the curated dictionary only (a bounded slice would false-negative real catalog CPEs).
+- **Migrations:** date-prefixed `YYYY-MM-DD-<slug>.sql`, idempotent (`IF NOT EXISTS`, `pg_policies` check, `ADD COLUMN IF NOT EXISTS`), no inner `BEGIN;/COMMIT;`, never edit a shipped migration.
+- **New `*.integration.test.ts` files MUST be added to the explicit `include` array in `apps/api/vitest.integration.config.ts`** or they will not run.
+- **Public repo:** no customer names/IPs in any committed artifact. Vendored data ships with `NOTICE` attribution.
+- **Commit messages** end with: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **Working directory:** worktree `/Users/toddhebebrand/orca/workspaces/breeze/vuln-cpe-resolver`, branch `fix/vuln-cpe-resolver`. All `pnpm` commands run from `apps/api` unless noted.
+
+## File Structure
+
+- Create `apps/api/src/services/cpeResolver.ts` — pure resolver (normalize, tokenize, catalog index, resolve, curated dict + cpedict loaders).
+- Create `apps/api/src/services/cpeResolver.test.ts` — unit tests (Tasks 1,3,4,5) + curated/cpedict invariant (Task 2).
+- Create `apps/api/src/services/__fixtures__/cpe-translations.json` + `cpe-translations.NOTICE` — curated dictionary source (Task 2).
+- Create `apps/api/src/services/__fixtures__/cpe-dictionary.json` + `cpe-dictionary.NOTICE` — validation set (Task 2).
+- Create `apps/api/scripts/regen-cpe-data.ts` — provenance-documented regeneration (Task 2).
+- Create `apps/api/src/services/cpeResolution.ts` — `refreshResolutionCache()` (DB, system context) (Task 7).
+- Create `apps/api/src/services/cpeResolution.integration.test.ts` — refresh integration tests (Task 7).
+- Create `apps/api/migrations/2026-07-08-vuln-product-resolutions.sql` (Task 6).
+- Modify `apps/api/src/db/schema/vulnerabilityManagement.ts` — add `softwareProductResolutions` table + `deviceVulnerabilities.matchConfidence` (Task 6).
+- Modify `apps/api/src/services/vulnerabilityCorrelation.ts` — rewrite product joins through resolutions + stamp confidence (Task 8).
+- Modify `apps/api/src/services/vulnerabilityCorrelation.integration.test.ts` — resolver-backed correlation cases (Task 8).
+- Modify `apps/api/src/jobs/vulnerabilityJobs.ts` `correlateEnabledOrgs` — call `refreshResolutionCache()` once (Task 8).
+- Modify `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — register table (Task 6).
+- Modify `apps/api/vitest.integration.config.ts` — register new integration test (Task 7).
+
+## Interfaces (defined once, referenced throughout)
+
+```ts
+// cpeResolver.ts — public surface
+export const RESOLVER_VERSION = 1;
+export type ResolutionConfidence = 'curated' | 'exact' | 'fuzzy' | 'none';
+export type ResolutionVia = 'dictionary' | 'catalog_exact' | 'token' | 'unmatched';
+
+export interface Resolution {
+  productId: string | null;
+  cpe: string | null;
+  confidence: ResolutionConfidence;
+  matchedVia: ResolutionVia;
+  tokensMatched: number;
+}
+
+export interface CatalogProduct {
+  id: string;
+  normalizedName: string;         // catalog normalized_name (already lowercased on write)
+  normalizedVendor: string | null;
+  cpe: string | null;             // cpe:2.3:a:vendor:product:...
+}
+
+export interface CatalogIndex {
+  byExactName: Map<string, string | null>;   // normalizedName -> productId (null = ambiguous, drop)
+  byVendorProduct: Map<string, string>;       // `${cpeVendor}:${cpeProduct}` -> productId
+  wordIndex: Map<string, Set<string>>;        // word -> productIds (recall: name+vendor+cpe words)
+  meta: Map<string, { cpe: string | null; cpeVendor: string | null; cpeProduct: string | null; productTokens: Set<string> }>;
+}
+
+export interface CuratedEntry { vendor: string; product: string; }   // CPE tokens
+
+export function normalizeDisplayName(name: string): string;
+export function tokenize(s: string): string[];
+export function parseCpe(cpe: string): { vendor: string; product: string } | null;
+export function isWellFormedCpe(cpe: string): boolean;
+export function loadCuratedDictionary(): Map<string, CuratedEntry>;   // key = normalizeDisplayName(sourceName)
+export function loadCpeDictionary(): Set<string>;                     // set of `${vendor}:${product}`
+export function buildCatalogIndex(products: CatalogProduct[]): CatalogIndex;
+export function resolve(
+  displayName: string,
+  vendor: string | null,
+  index: CatalogIndex,
+  curated: Map<string, CuratedEntry>,
+): Resolution;
+```
+
+```ts
+// cpeResolution.ts — public surface
+export function refreshResolutionCache(): Promise<Record<ResolutionConfidence, number>>;
+```
+
+---
+
+### Task 1: `normalizeDisplayName` + `tokenize`
+
+**Files:**
+- Create: `apps/api/src/services/cpeResolver.ts`
+- Test: `apps/api/src/services/cpeResolver.test.ts`
+
+**Interfaces:**
+- Produces: `normalizeDisplayName(name: string): string`, `tokenize(s: string): string[]`, `RESOLVER_VERSION`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/api/src/services/cpeResolver.test.ts
+import { describe, expect, it } from 'vitest';
+import { normalizeDisplayName, tokenize } from './cpeResolver';
+
+describe('normalizeDisplayName', () => {
+  const cases: Array<[string, string]> = [
+    ['Google Chrome', 'google chrome'],
+    ['Adobe Acrobat (64-bit)', 'adobe acrobat'],
+    ['Mozilla Firefox ESR 115 (x64 en-US)', 'mozilla firefox esr'],
+    ['Microsoft 365 Apps for business - en-us', 'microsoft 365 apps for business'],
+    ['7-Zip 22.01 (x64)', '7-zip'],
+    ['Notepad++ (32-bit x86)', 'notepad++'],
+    ['  VLC   media  player  ', 'vlc media player'],
+    ['Java 8 Update 351 (64-bit)', 'java 8 update'],
+  ];
+  it.each(cases)('normalizes %s', (input, expected) => {
+    expect(normalizeDisplayName(input)).toBe(expected);
+  });
+});
+
+describe('tokenize', () => {
+  it('splits on non-alphanumeric, lowercases, drops empties', () => {
+    expect(tokenize('Adobe Acrobat_Reader-DC')).toEqual(['adobe', 'acrobat', 'reader', 'dc']);
+  });
+  it('keeps ++ / - inside known product words via alnum-run split', () => {
+    expect(tokenize('notepad++')).toEqual(['notepad']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `apps/api`): `pnpm test:run src/services/cpeResolver.test.ts`
+Expected: FAIL — `normalizeDisplayName is not a function` / module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// apps/api/src/services/cpeResolver.ts
+/*
+ * DisplayName → CPE resolver (#2290).
+ * Layer B token index/lookup ported from CIRCL cpe-guesser (BSD-2-Clause):
+ * https://github.com/vulnerability-lookup/cpe-guesser
+ */
+
+export const RESOLVER_VERSION = 1;
+
+// Tokens stripped from a raw registry DisplayName. Architecture, then version-ish
+// trailers. Order matters: strip arch/locale before trailing-number cleanup.
+const ARCH_TOKENS = /\b(64-?bit|32-?bit|x64|x86|amd64|arm64|win64|win32)\b/gi;
+const LOCALE_TOKEN = /\b[a-z]{2}-[a-z]{2}\b/gi;               // en-us, de-de
+const PAREN_GROUP = /\([^)]*\)/g;                              // (64-bit), (x64 en-US)
+const TRAILING_VERSION = /\b\d[\d.]*\b/g;                      // 22.01, 115, 351, 8, 2019
+const MULTISPACE = /\s+/g;
+
+export function normalizeDisplayName(name: string): string {
+  let s = name.toLowerCase();
+  s = s.replace(PAREN_GROUP, ' ');       // drop parenthetical noise wholesale
+  s = s.replace(ARCH_TOKENS, ' ');
+  s = s.replace(LOCALE_TOKEN, ' ');
+  s = s.replace(/\s-\s.*$/, ' ');         // drop "- <locale/edition>" suffix
+  s = s.replace(TRAILING_VERSION, ' ');   // drop standalone version/year numbers
+  s = s.replace(MULTISPACE, ' ').trim();
+  return s;
+}
+
+export function tokenize(s: string): string[] {
+  return s
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((w) => w.length > 0);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run src/services/cpeResolver.test.ts`
+Expected: PASS (8 normalize cases + 2 tokenize cases).
+
+Note: the `7-Zip 22.01` case expects `7-zip` — `TRAILING_VERSION` drops `22.01`, `PAREN_GROUP` drops `(x64)`; the hyphen in `7-zip` is preserved because `\d[\d.]*` requires a leading digit-run and `7-zip` is `7`,`-`,`zip` — verify `7` is NOT stripped by confirming the expected value in the test tolerates a leading kept token. If `normalizeDisplayName('7-Zip 22.01 (x64)')` yields `7-zip`, PASS. If it yields `-zip`, adjust `TRAILING_VERSION` to `/(?<![a-z-])\b\d[\d.]*\b/gi`. Run the test; make it green before committing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/cpeResolver.ts apps/api/src/services/cpeResolver.test.ts
+git commit -m "feat(vuln): DisplayName normalization + tokenizer for CPE resolver (#2290)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Vendored data fixtures + regen script + loaders
+
+**Files:**
+- Create: `apps/api/src/services/__fixtures__/cpe-translations.json`, `cpe-translations.NOTICE`
+- Create: `apps/api/src/services/__fixtures__/cpe-dictionary.json`, `cpe-dictionary.NOTICE`
+- Create: `apps/api/scripts/regen-cpe-data.ts`
+- Modify: `apps/api/src/services/cpeResolver.ts` (add loaders)
+- Test: `apps/api/src/services/cpeResolver.test.ts` (add loader + invariant tests)
+
+**Interfaces:**
+- Consumes: `normalizeDisplayName` (Task 1).
+- Produces: `parseCpe`, `isWellFormedCpe`, `loadCuratedDictionary`, `loadCpeDictionary`, `CuratedEntry`.
+
+- [ ] **Step 1: Create the committed starter fixtures (guaranteed offline baseline)**
+
+`apps/api/src/services/__fixtures__/cpe-translations.json` — converted to OUR shape (`{ name, vendor, product }`, CPE tokens). This starter is hand-verified; the regen script expands it from FleetDM.
+
+```json
+[
+  { "name": "Google Chrome", "vendor": "google", "product": "chrome" },
+  { "name": "Mozilla Firefox", "vendor": "mozilla", "product": "firefox" },
+  { "name": "Mozilla Firefox ESR", "vendor": "mozilla", "product": "firefox_esr" },
+  { "name": "Adobe Acrobat Reader", "vendor": "adobe", "product": "acrobat_reader" },
+  { "name": "Adobe Acrobat Reader DC", "vendor": "adobe", "product": "acrobat_reader" },
+  { "name": "Adobe Acrobat", "vendor": "adobe", "product": "acrobat" },
+  { "name": "7-Zip", "vendor": "7-zip", "product": "7-zip" },
+  { "name": "Notepad++", "vendor": "notepad-plus-plus", "product": "notepad-plus-plus" },
+  { "name": "Zoom", "vendor": "zoom", "product": "zoom" },
+  { "name": "VLC media player", "vendor": "videolan", "product": "vlc_media_player" },
+  { "name": "Microsoft Edge", "vendor": "microsoft", "product": "edge" },
+  { "name": "Microsoft OneDrive", "vendor": "microsoft", "product": "onedrive" },
+  { "name": "Microsoft Teams", "vendor": "microsoft", "product": "teams" },
+  { "name": "Git", "vendor": "git-scm", "product": "git" },
+  { "name": "Node.js", "vendor": "nodejs", "product": "node.js" }
+]
+```
+
+`apps/api/src/services/__fixtures__/cpe-dictionary.json` — bounded validation set (`vendor:product` pairs) covering the starter + integration-test products:
+
+```json
+[
+  "google:chrome", "mozilla:firefox", "mozilla:firefox_esr",
+  "adobe:acrobat_reader", "adobe:acrobat", "7-zip:7-zip",
+  "notepad-plus-plus:notepad-plus-plus", "zoom:zoom",
+  "videolan:vlc_media_player", "microsoft:edge", "microsoft:onedrive",
+  "microsoft:teams", "git-scm:git", "nodejs:node.js", "microsoft:365_apps"
+]
+```
+
+`cpe-translations.NOTICE`:
+```
+Derived from FleetDM cpe_translations.json
+Source: https://github.com/fleetdm/fleet/blob/main/server/vulnerabilities/nvd/cpe_translations.json
+License: MIT. Converted to {name,vendor,product} via apps/api/scripts/regen-cpe-data.ts.
+```
+`cpe-dictionary.NOTICE`:
+```
+Bounded slice derived from tiiuae/cpedict (official CPE dictionary mirror).
+Source: https://github.com/tiiuae/cpedict — used as a validation set only.
+```
+
+- [ ] **Step 2: Write the regen script (documents provenance; run manually, no runtime use)**
+
+```ts
+// apps/api/scripts/regen-cpe-data.ts
+/*
+ * Regenerates cpe-translations.json from FleetDM's cpe_translations.json.
+ * Manual tool — NOT imported at runtime. Run: pnpm tsx scripts/regen-cpe-data.ts
+ * Requires network. Preserves the committed starter entries (union, dedup by name).
+ */
+import { writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const FLEET_URL =
+  'https://raw.githubusercontent.com/fleetdm/fleet/main/server/vulnerabilities/nvd/cpe_translations.json';
+const OUT = join(__dirname, '../src/services/__fixtures__/cpe-translations.json');
+
+interface FleetEntry {
+  software?: { name?: string[]; source?: string[] };
+  filter?: { product?: string[]; vendor?: string[]; skip?: boolean };
+}
+
+async function main(): Promise<void> {
+  const upstream = (await (await fetch(FLEET_URL)).json()) as FleetEntry[];
+  const existing = JSON.parse(readFileSync(OUT, 'utf8')) as Array<{ name: string; vendor: string; product: string }>;
+  const byName = new Map(existing.map((e) => [e.name, e]));
+
+  for (const entry of upstream) {
+    const names = entry.software?.name ?? [];
+    const product = entry.filter?.product?.[0];
+    const vendor = entry.filter?.vendor?.[0];
+    if (!product || !vendor || entry.filter?.skip) continue;
+    for (const name of names) {
+      if (name.startsWith('/')) continue;                 // skip regex-pattern entries
+      if (!byName.has(name)) byName.set(name, { name, vendor, product });
+    }
+  }
+  const merged = [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+  writeFileSync(OUT, JSON.stringify(merged, null, 2) + '\n');
+  console.log(`wrote ${merged.length} translation entries`);
+}
+main().catch((e) => { console.error(e); process.exit(1); });
+```
+
+- [ ] **Step 3: Write the failing loader/invariant tests**
+
+```ts
+// append to apps/api/src/services/cpeResolver.test.ts
+import { loadCuratedDictionary, loadCpeDictionary, parseCpe, isWellFormedCpe } from './cpeResolver';
+
+describe('parseCpe', () => {
+  it('extracts vendor/product from cpe:2.3', () => {
+    expect(parseCpe('cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*')).toEqual({ vendor: 'google', product: 'chrome' });
+  });
+  it('returns null for garbage', () => {
+    expect(parseCpe('not-a-cpe')).toBeNull();
+  });
+});
+
+describe('curated dictionary', () => {
+  it('is keyed by normalized display name and maps to CPE tokens', () => {
+    const dict = loadCuratedDictionary();
+    expect(dict.get('google chrome')).toEqual({ vendor: 'google', product: 'chrome' });
+    expect(dict.get('adobe acrobat')).toEqual({ vendor: 'adobe', product: 'acrobat' });
+  });
+  it('INVARIANT: every curated CPE token pair exists in the cpedict validation set', () => {
+    const dict = loadCuratedDictionary();
+    const cpedict = loadCpeDictionary();
+    for (const [, { vendor, product }] of dict) {
+      expect(cpedict.has(`${vendor}:${product}`), `${vendor}:${product} missing from cpedict`).toBe(true);
+    }
+  });
+});
+```
+
+- [ ] **Step 4: Run to verify it fails**
+
+Run: `pnpm test:run src/services/cpeResolver.test.ts`
+Expected: FAIL — `loadCuratedDictionary is not a function`.
+
+- [ ] **Step 5: Implement loaders in `cpeResolver.ts`**
+
+```ts
+// add to apps/api/src/services/cpeResolver.ts
+import curatedJson from './__fixtures__/cpe-translations.json';
+import cpedictJson from './__fixtures__/cpe-dictionary.json';
+
+export interface CuratedEntry { vendor: string; product: string; }
+
+export function parseCpe(cpe: string): { vendor: string; product: string } | null {
+  const parts = cpe.split(':');
+  // cpe:2.3:part:vendor:product:...  → parts[3]=vendor parts[4]=product
+  if (parts.length < 5 || parts[0] !== 'cpe' || parts[1] !== '2.3') return null;
+  const vendor = parts[3];
+  const product = parts[4];
+  if (!vendor || !product) return null;
+  return { vendor, product };
+}
+
+export function isWellFormedCpe(cpe: string): boolean {
+  return parseCpe(cpe) !== null;
+}
+
+export function loadCuratedDictionary(): Map<string, CuratedEntry> {
+  const rows = curatedJson as Array<{ name: string; vendor: string; product: string }>;
+  const map = new Map<string, CuratedEntry>();
+  for (const r of rows) {
+    map.set(normalizeDisplayName(r.name), { vendor: r.vendor, product: r.product });
+  }
+  return map;
+}
+
+export function loadCpeDictionary(): Set<string> {
+  return new Set(cpedictJson as string[]);
+}
+```
+
+Ensure `apps/api/tsconfig.json` has `resolveJsonModule: true` (the existing `cpeMap.ts` imports JSON, so it already does — verify, no change expected).
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `pnpm test:run src/services/cpeResolver.test.ts`
+Expected: PASS. The invariant test proves every curated CPE is in the cpedict slice.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/cpeResolver.ts apps/api/src/services/cpeResolver.test.ts \
+  apps/api/src/services/__fixtures__/cpe-translations.json apps/api/src/services/__fixtures__/cpe-translations.NOTICE \
+  apps/api/src/services/__fixtures__/cpe-dictionary.json apps/api/src/services/__fixtures__/cpe-dictionary.NOTICE \
+  apps/api/scripts/regen-cpe-data.ts
+git commit -m "feat(vuln): vendored CPE translation + dictionary fixtures and loaders (#2290)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `buildCatalogIndex`
+
+**Files:**
+- Modify: `apps/api/src/services/cpeResolver.ts`
+- Test: `apps/api/src/services/cpeResolver.test.ts`
+
+**Interfaces:**
+- Consumes: `tokenize`, `parseCpe` (Tasks 1-2), `CatalogProduct`.
+- Produces: `buildCatalogIndex(products: CatalogProduct[]): CatalogIndex`, `CatalogIndex`, `CatalogProduct`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// append to cpeResolver.test.ts
+import { buildCatalogIndex, type CatalogProduct } from './cpeResolver';
+
+const CATALOG: CatalogProduct[] = [
+  { id: 'p-chrome', normalizedName: 'chrome', normalizedVendor: 'google', cpe: 'cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*' },
+  { id: 'p-firefox', normalizedName: 'firefox', normalizedVendor: 'mozilla', cpe: 'cpe:2.3:a:mozilla:firefox:*:*:*:*:*:*:*:*' },
+  { id: 'p-acrobat', normalizedName: 'acrobat_reader', normalizedVendor: 'adobe', cpe: 'cpe:2.3:a:adobe:acrobat_reader:*:*:*:*:*:*:*:*' },
+];
+
+describe('buildCatalogIndex', () => {
+  it('indexes exact name, vendor:product, and words', () => {
+    const idx = buildCatalogIndex(CATALOG);
+    expect(idx.byExactName.get('chrome')).toBe('p-chrome');
+    expect(idx.byVendorProduct.get('google:chrome')).toBe('p-chrome');
+    expect(idx.wordIndex.get('acrobat')).toEqual(new Set(['p-acrobat']));
+    expect(idx.wordIndex.get('adobe')).toEqual(new Set(['p-acrobat']));
+    expect(idx.meta.get('p-firefox')?.cpeVendor).toBe('mozilla');
+  });
+  it('marks ambiguous exact names null (two products, same normalized_name)', () => {
+    const idx = buildCatalogIndex([
+      ...CATALOG,
+      { id: 'p-chrome2', normalizedName: 'chrome', normalizedVendor: 'other', cpe: 'cpe:2.3:a:other:chrome:*:*:*:*:*:*:*:*' },
+    ]);
+    expect(idx.byExactName.get('chrome')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm test:run src/services/cpeResolver.test.ts`
+Expected: FAIL — `buildCatalogIndex is not a function`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// add to cpeResolver.ts
+export interface CatalogProduct {
+  id: string;
+  normalizedName: string;
+  normalizedVendor: string | null;
+  cpe: string | null;
+}
+
+export interface CatalogIndex {
+  byExactName: Map<string, string | null>;
+  byVendorProduct: Map<string, string>;
+  wordIndex: Map<string, Set<string>>;
+  meta: Map<string, { cpe: string | null; cpeVendor: string | null; cpeProduct: string | null; words: Set<string> }>;
+}
+
+export function buildCatalogIndex(products: CatalogProduct[]): CatalogIndex {
+  const byExactName = new Map<string, string | null>();
+  const byVendorProduct = new Map<string, string>();
+  const wordIndex = new Map<string, Set<string>>();
+  const meta: CatalogIndex['meta'] = new Map();
+
+  for (const p of products) {
+    // exact name: first wins; a second distinct product with same name marks it ambiguous (null)
+    if (byExactName.has(p.normalizedName)) {
+      byExactName.set(p.normalizedName, null);
+    } else {
+      byExactName.set(p.normalizedName, p.id);
+    }
+
+    const cpeParts = p.cpe ? parseCpe(p.cpe) : null;
+    if (cpeParts) byVendorProduct.set(`${cpeParts.vendor}:${cpeParts.product}`, p.id);
+
+    // Product-identity tokens used for scoring (must-hit-a-distinctive-product-word).
+    // Prefer the CPE product token; fall back to the catalog normalized_name.
+    const productTokens = new Set<string>(
+      cpeParts ? tokenize(cpeParts.product) : tokenize(p.normalizedName),
+    );
+
+    // Recall index: ANY word (name + vendor + cpe tokens) so candidates are discoverable.
+    const recallWords = new Set<string>([
+      ...tokenize(p.normalizedName),
+      ...(p.normalizedVendor ? tokenize(p.normalizedVendor) : []),
+      ...(cpeParts ? [...tokenize(cpeParts.vendor), ...tokenize(cpeParts.product)] : []),
+    ]);
+    for (const w of recallWords) {
+      const set = wordIndex.get(w) ?? new Set<string>();
+      set.add(p.id);
+      wordIndex.set(w, set);
+    }
+    meta.set(p.id, { cpe: p.cpe, cpeVendor: cpeParts?.vendor ?? null, cpeProduct: cpeParts?.product ?? null, productTokens });
+  }
+  return { byExactName, byVendorProduct, wordIndex, meta };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm test:run src/services/cpeResolver.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/cpeResolver.ts apps/api/src/services/cpeResolver.test.ts
+git commit -m "feat(vuln): catalog inverted index for CPE resolver (#2290)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `resolve` — Layer A (curated + exact)
+
+**Files:**
+- Modify: `apps/api/src/services/cpeResolver.ts`
+- Test: `apps/api/src/services/cpeResolver.test.ts`
+
+**Interfaces:**
+- Consumes: `normalizeDisplayName`, `loadCuratedDictionary`, `buildCatalogIndex`, `CatalogIndex`, `CuratedEntry`.
+- Produces: `resolve(displayName, vendor, index, curated): Resolution`, `Resolution`, `ResolutionConfidence`, `ResolutionVia`. (Layer B added in Task 5.)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// append to cpeResolver.test.ts
+import { resolve, loadCuratedDictionary } from './cpeResolver';
+
+describe('resolve — Layer A', () => {
+  const idx = buildCatalogIndex(CATALOG);
+  const curated = loadCuratedDictionary();
+
+  it('curated dict hit → confidence curated, resolves to catalog product', () => {
+    // "Adobe Acrobat Reader DC" → curated {adobe, acrobat_reader} → catalog p-acrobat
+    const r = resolve('Adobe Acrobat Reader DC (64-bit)', 'Adobe Inc.', idx, curated);
+    expect(r).toMatchObject({ productId: 'p-acrobat', confidence: 'curated', matchedVia: 'dictionary' });
+  });
+
+  it('exact normalized-name catalog hit → confidence exact', () => {
+    // "Firefox" normalizes to "firefox" which is a catalog normalized_name
+    const r = resolve('Firefox', 'Mozilla', idx, curated);
+    expect(r).toMatchObject({ productId: 'p-firefox', confidence: 'exact', matchedVia: 'catalog_exact' });
+  });
+
+  it('curated hit whose CPE is absent from catalog → productId null, matchedVia dictionary', () => {
+    // "Microsoft Teams" is curated but not in this CATALOG
+    const r = resolve('Microsoft Teams', 'Microsoft', idx, curated);
+    expect(r).toMatchObject({ productId: null, matchedVia: 'dictionary' });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm test:run src/services/cpeResolver.test.ts`
+Expected: FAIL — `resolve is not a function`.
+
+- [ ] **Step 3: Implement Layer A (Layer B stub withholds for now)**
+
+```ts
+// add to cpeResolver.ts
+export type ResolutionConfidence = 'curated' | 'exact' | 'fuzzy' | 'none';
+export type ResolutionVia = 'dictionary' | 'catalog_exact' | 'token' | 'unmatched';
+
+export interface Resolution {
+  productId: string | null;
+  cpe: string | null;
+  confidence: ResolutionConfidence;
+  matchedVia: ResolutionVia;
+  tokensMatched: number;
+}
+
+const NONE: Resolution = { productId: null, cpe: null, confidence: 'none', matchedVia: 'unmatched', tokensMatched: 0 };
+
+export function resolve(
+  displayName: string,
+  vendor: string | null,
+  index: CatalogIndex,
+  curated: Map<string, CuratedEntry>,
+): Resolution {
+  const normName = normalizeDisplayName(displayName);
+
+  // Layer A.1 — curated translation dictionary
+  const curatedHit = curated.get(normName);
+  if (curatedHit) {
+    const key = `${curatedHit.vendor}:${curatedHit.product}`;
+    const productId = index.byVendorProduct.get(key) ?? null;
+    const cpe = productId ? index.meta.get(productId)?.cpe ?? null : `cpe:2.3:a:${curatedHit.vendor}:${curatedHit.product}`;
+    return { productId, cpe, confidence: productId ? 'curated' : 'none', matchedVia: 'dictionary', tokensMatched: 0 };
+  }
+
+  // Layer A.2 — exact catalog normalized-name match
+  const exact = index.byExactName.get(normName);
+  if (exact) {
+    return { productId: exact, cpe: index.meta.get(exact)?.cpe ?? null, confidence: 'exact', matchedVia: 'catalog_exact', tokensMatched: 0 };
+  }
+
+  // Layer B added in Task 5.
+  return NONE;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm test:run src/services/cpeResolver.test.ts`
+Expected: PASS. (The curated-no-catalog case returns `confidence:'none'`, `matchedVia:'dictionary'`, `productId:null`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/cpeResolver.ts apps/api/src/services/cpeResolver.test.ts
+git commit -m "feat(vuln): resolver Layer A (curated dict + exact catalog match) (#2290)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `resolve` — Layer B (token index + guardrails)
+
+**Files:**
+- Modify: `apps/api/src/services/cpeResolver.ts`
+- Test: `apps/api/src/services/cpeResolver.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4.
+- Produces: Layer B behavior inside `resolve` + internal `vendorAgrees`, `VENDOR_ALIASES`, `STOPWORDS`, threshold constants.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// append to cpeResolver.test.ts
+describe('resolve — Layer B (token) + guardrails', () => {
+  // catalog with a long-tail product not covered by curated/exact
+  const catalog: CatalogProduct[] = [
+    ...CATALOG,
+    { id: 'p-7zip', normalizedName: '7-zip', normalizedVendor: '7-zip', cpe: 'cpe:2.3:a:7-zip:7-zip:*:*:*:*:*:*:*:*' },
+    { id: 'p-wireshark', normalizedName: 'wireshark', normalizedVendor: 'wireshark', cpe: 'cpe:2.3:a:wireshark:wireshark:*:*:*:*:*:*:*:*' },
+  ];
+  const idx = buildCatalogIndex(catalog);
+  const curated = loadCuratedDictionary();
+
+  it('token match on long-tail name with vendor agreement → fuzzy', () => {
+    // "Wireshark 4.2.0 (64-bit)" normalizes to "wireshark", vendor "Wireshark Foundation"
+    const r = resolve('Wireshark 4.2.0 (64-bit)', 'Wireshark Foundation', idx, curated);
+    expect(r).toMatchObject({ productId: 'p-wireshark', confidence: 'fuzzy', matchedVia: 'token' });
+    expect(r.tokensMatched).toBeGreaterThanOrEqual(1);
+  });
+
+  it('GUARDRAIL: Microsoft Edge against a Chrome-only catalog → withheld (no Edge→Chrome)', () => {
+    const chromeOnly = buildCatalogIndex([CATALOG[0]!]); // only p-chrome
+    const r = resolve('Microsoft Edge', 'Microsoft Corporation', chromeOnly, new Map());
+    expect(r.confidence).toBe('none');
+    expect(r.productId).toBeNull();
+  });
+
+  it('GUARDRAIL: vendor disagreement withholds even if product word overlaps', () => {
+    // fake "Chrome Cleanup by Acme" vendor Acme vs catalog google:chrome
+    const r = resolve('Chrome Remover', 'Acme Software', buildCatalogIndex([CATALOG[0]!]), new Map());
+    expect(r.confidence).toBe('none');
+  });
+
+  it('GUARDRAIL: missing vendor → Layer B withholds', () => {
+    const r = resolve('Wireshark', null, idx, curated);
+    expect(r.confidence).toBe('none');
+  });
+
+  it('GUARDRAIL: vendor-only word match (no distinctive product token) withholds', () => {
+    // "Microsoft Random Tool" vendor Microsoft, catalog has no such product word
+    const withMs: CatalogProduct[] = [{ id: 'p-ms365', normalizedName: '365_apps', normalizedVendor: 'microsoft', cpe: 'cpe:2.3:a:microsoft:365_apps:*:*:*:*:*:*:*:*' }];
+    const r = resolve('Microsoft Random Tool', 'Microsoft', buildCatalogIndex(withMs), new Map());
+    expect(r.confidence).toBe('none');
+  });
+
+  it('vendor alias equivalence (Adobe Inc. ≡ adobe) — via token when not curated', () => {
+    const adobeCat = buildCatalogIndex([CATALOG[2]!]); // p-acrobat adobe:acrobat_reader
+    const r = resolve('Adobe Acrobat Reader', 'Adobe Inc.', adobeCat, new Map());
+    // no curated map passed → must resolve via token with vendor alias agreement
+    expect(r).toMatchObject({ productId: 'p-acrobat', confidence: 'fuzzy' });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm test:run src/services/cpeResolver.test.ts`
+Expected: FAIL — Layer B cases return `none` (stub) where `fuzzy` is expected.
+
+- [ ] **Step 3: Implement Layer B**
+
+Replace the `// Layer B added in Task 5.` line + `return NONE;` with the token logic, and add the helpers:
+
+```ts
+// add near top of cpeResolver.ts
+const VENDOR_ALIASES: Record<string, string> = {
+  'adobe inc.': 'adobe', 'adobe systems': 'adobe', adobe: 'adobe',
+  'mozilla': 'mozilla', 'mozilla corporation': 'mozilla', 'mozilla foundation': 'mozilla',
+  'google': 'google', 'google llc': 'google', 'google inc.': 'google',
+  'microsoft': 'microsoft', 'microsoft corporation': 'microsoft',
+  'videolan': 'videolan', 'the videolan project': 'videolan',
+  'igor pavlov': '7-zip', '7-zip': '7-zip',
+  'wireshark': 'wireshark', 'wireshark foundation': 'wireshark', 'the wireshark developers': 'wireshark',
+};
+// generic corporate suffixes stripped before alias lookup
+const VENDOR_SUFFIX = /\b(inc|inc\.|llc|ltd|corp|corporation|gmbh|co|company|foundation|project|team|the)\b/gi;
+const STOPWORDS = new Set(['the', 'inc', 'llc', 'ltd', 'corp', 'corporation', 'gmbh', 'co', 'company', 'software', 'app', 'application', 'tool', 'client', 'edition']);
+const MIN_DISTINCTIVE_TOKENS = 1;
+
+function canonicalVendor(vendor: string): string {
+  const v = vendor.toLowerCase().trim();
+  if (VENDOR_ALIASES[v]) return VENDOR_ALIASES[v];
+  const stripped = v.replace(VENDOR_SUFFIX, '').replace(/\s+/g, ' ').trim();
+  return VENDOR_ALIASES[stripped] ?? stripped;
+}
+
+function vendorAgrees(invVendor: string | null, cpeVendor: string | null): boolean {
+  if (!invVendor || !cpeVendor) return false;
+  const a = canonicalVendor(invVendor);
+  const b = cpeVendor.toLowerCase();
+  return a === b || a.includes(b) || b.includes(a);
+}
+```
+
+```ts
+// replace the Layer B stub in resolve():
+  // Layer B — token inverted-index over catalog + hard guardrails.
+  const queryWords = new Set(tokenize(normName));
+  if (queryWords.size === 0) return NONE;
+
+  // Recall: candidate productIds = union of products containing any query word.
+  const candidates = new Set<string>();
+  for (const w of queryWords) for (const id of index.wordIndex.get(w) ?? []) candidates.add(id);
+
+  // Score = number of query words that match a candidate's PRODUCT tokens (not vendor-only).
+  // Using product tokens directly encodes "must hit a distinctive product word" AND still
+  // matches products whose name equals their vendor (wireshark:wireshark, 7-zip:7-zip).
+  let best: { id: string; score: number } | null = null;
+  let runnerUp = 0;
+  for (const id of candidates) {
+    const m = index.meta.get(id)!;
+    if (!vendorAgrees(vendor, m.cpeVendor)) continue;                       // vendor agreement (kills Edge→Chrome)
+    let score = 0;
+    for (const w of queryWords) {
+      if (STOPWORDS.has(w)) continue;
+      if (m.productTokens.has(w)) score += 1;                               // distinctive product-token hit
+    }
+    if (score < MIN_DISTINCTIVE_TOKENS) continue;
+    if (!best || score > best.score) {
+      runnerUp = best ? best.score : 0;
+      best = { id, score };
+    } else if (score > runnerUp) {
+      runnerUp = score;
+    }
+  }
+
+  if (!best) return NONE;
+  if (best.score <= runnerUp) return NONE;                                   // unique-winner margin (ties withhold)
+
+  const m = index.meta.get(best.id)!;
+  if (m.cpe && !isWellFormedCpe(m.cpe)) return NONE;                         // well-formedness guard
+  return { productId: best.id, cpe: m.cpe, confidence: 'fuzzy', matchedVia: 'token', tokensMatched: best.score };
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm test:run src/services/cpeResolver.test.ts`
+Expected: PASS — all Layer B + guardrail cases. Edge→Chrome and vendor-disagreement return `none`; the vendor-alias Adobe case resolves via token.
+
+- [ ] **Step 5: Run the whole resolver suite + typecheck**
+
+Run: `pnpm test:run src/services/cpeResolver.test.ts && pnpm --filter @breeze/api typecheck` (or the repo's `pnpm typecheck`).
+Expected: PASS, no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/cpeResolver.ts apps/api/src/services/cpeResolver.test.ts
+git commit -m "feat(vuln): resolver Layer B token match with vendor/uniqueness guardrails (#2290)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Schema + migration + RLS registration
+
+**Files:**
+- Create: `apps/api/migrations/2026-07-08-vuln-product-resolutions.sql`
+- Modify: `apps/api/src/db/schema/vulnerabilityManagement.ts`
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts`
+
+**Interfaces:**
+- Produces: `softwareProductResolutions` Drizzle table; `deviceVulnerabilities.matchConfidence` column.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- apps/api/migrations/2026-07-08-vuln-product-resolutions.sql
+-- Global DisplayName→product resolution cache + unmatched-name log (#2290).
+-- System-only RLS, same shape as vulnerabilities/software_products.
+
+CREATE TABLE IF NOT EXISTS software_product_resolutions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  lookup_name VARCHAR(500) NOT NULL,          -- lower(trim(software_inventory.name)) — SQL join key
+  lookup_vendor VARCHAR(200),                 -- lower(trim(software_inventory.vendor))
+  normalized_name VARCHAR(500) NOT NULL,      -- post-token-strip form (observability only)
+  software_product_id UUID REFERENCES software_products(id),  -- NULL = unmatched (the log)
+  confidence VARCHAR(16) NOT NULL,            -- curated | exact | fuzzy | none
+  matched_via VARCHAR(32) NOT NULL,           -- dictionary | catalog_exact | token | unmatched
+  resolver_version INTEGER NOT NULL,
+  resolved_at TIMESTAMP NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS software_product_resolutions_key_idx
+  ON software_product_resolutions (lookup_name, lookup_vendor) NULLS NOT DISTINCT;
+
+CREATE INDEX IF NOT EXISTS software_product_resolutions_product_idx
+  ON software_product_resolutions (software_product_id);
+
+ALTER TABLE device_vulnerabilities ADD COLUMN IF NOT EXISTS match_confidence VARCHAR(16);
+
+-- System-only RLS (mirror 2026-06-22-vulnerability-management.sql). Forced RLS with a
+-- single system-scope policy; breeze_app (non-BYPASSRLS) is denied unless scope=system.
+DO $$
+BEGIN
+  EXECUTE 'ALTER TABLE software_product_resolutions ENABLE ROW LEVEL SECURITY';
+  EXECUTE 'ALTER TABLE software_product_resolutions FORCE ROW LEVEL SECURITY';
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'software_product_resolutions'
+      AND policyname = 'software_product_resolutions_system_only'
+  ) THEN
+    EXECUTE $f$CREATE POLICY software_product_resolutions_system_only ON software_product_resolutions
+      USING (current_setting('breeze.scope', true) = 'system')
+      WITH CHECK (current_setting('breeze.scope', true) = 'system')$f$;
+  END IF;
+END $$;
+```
+
+- [ ] **Step 2: Add the Drizzle schema**
+
+```ts
+// add to apps/api/src/db/schema/vulnerabilityManagement.ts
+export const softwareProductResolutions = pgTable('software_product_resolutions', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  lookupName: varchar('lookup_name', { length: 500 }).notNull(),
+  lookupVendor: varchar('lookup_vendor', { length: 200 }),
+  normalizedName: varchar('normalized_name', { length: 500 }).notNull(),
+  softwareProductId: uuid('software_product_id').references(() => softwareProducts.id),
+  confidence: varchar('confidence', { length: 16 }).notNull(),
+  matchedVia: varchar('matched_via', { length: 32 }).notNull(),
+  resolverVersion: integer('resolver_version').notNull(),
+  resolvedAt: timestamp('resolved_at').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  keyIdx: uniqueIndex('software_product_resolutions_key_idx').on(table.lookupName, table.lookupVendor),
+  productIdx: index('software_product_resolutions_product_idx').on(table.softwareProductId),
+}));
+```
+
+Add `integer` to the `drizzle-orm/pg-core` import at the top of the file (it currently imports `numeric` etc. but confirm `integer` is present; add if missing). Add `matchConfidence: varchar('match_confidence', { length: 16 })` to the `deviceVulnerabilities` table definition (nullable — no `.notNull()`).
+
+- [ ] **Step 3: Register in the RLS contract test**
+
+In `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts`, add to the `INTENTIONAL_UNSCOPED` set (after the `os_vulnerabilities` line, ~line 66):
+
+```ts
+  'software_product_resolutions', // Global DisplayName→product resolution cache/log (#2290). Forced RLS, system-only policy → only system context.
+```
+
+- [ ] **Step 4: Verify migration + drift + RLS coverage against the test DB**
+
+```bash
+# from repo root
+docker compose -f docker-compose.test.yml up -d --wait
+cd apps/api
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5433/breeze"   # test DB (:5433)
+pnpm db:check-drift        # schema must match migrations — no drift
+pnpm test:rls-coverage     # software_product_resolutions must be recognized system-only
+```
+Expected: drift check clean; RLS coverage passes (no "table has RLS but is not registered" failure).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-07-08-vuln-product-resolutions.sql \
+  apps/api/src/db/schema/vulnerabilityManagement.ts \
+  apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+git commit -m "feat(vuln): software_product_resolutions table + match_confidence column, system-only RLS (#2290)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: `refreshResolutionCache()` (DB, system context)
+
+**Files:**
+- Create: `apps/api/src/services/cpeResolution.ts`
+- Create: `apps/api/src/services/cpeResolution.integration.test.ts`
+- Modify: `apps/api/vitest.integration.config.ts`
+
+**Interfaces:**
+- Consumes: `resolve`, `buildCatalogIndex`, `loadCuratedDictionary`, `RESOLVER_VERSION`, `CatalogProduct` (Tasks 1-5); `softwareProductResolutions`, `softwareProducts`, `softwareInventory` schema; `db`, `withSystemDbAccessContext`.
+- Produces: `refreshResolutionCache(): Promise<Record<ResolutionConfidence, number>>`.
+
+- [ ] **Step 1: Register the new integration test file**
+
+In `apps/api/vitest.integration.config.ts`, add to the `include` array (alongside the other vuln integration tests):
+
+```ts
+      // Co-located real-DB integration test for the DisplayName→CPE resolution cache (#2290).
+      'src/services/cpeResolution.integration.test.ts',
+```
+
+- [ ] **Step 2: Write the failing integration test**
+
+```ts
+// apps/api/src/services/cpeResolution.integration.test.ts
+import '../__tests__/integration/setup';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+
+import { db, withSystemDbAccessContext } from '../db';
+import {
+  devices, organizations, partners, sites,
+  softwareInventory, softwareProducts, softwareProductResolutions,
+} from '../db/schema';
+import { refreshResolutionCache } from './cpeResolution';
+import { RESOLVER_VERSION } from './cpeResolver';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function seedDeviceAndInventory(name: string, vendor: string | null): Promise<void> {
+  await withSystemDbAccessContext(async () => {
+    const u = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const [p] = await db.insert(partners).values({ name: `P ${u}`, slug: `p-${u}`, type: 'msp', plan: 'pro', status: 'active' }).returning({ id: partners.id });
+    const [o] = await db.insert(organizations).values({ partnerId: p!.id, name: `O ${u}`, slug: `o-${u}`, type: 'customer', status: 'active' }).returning({ id: organizations.id });
+    const [s] = await db.insert(sites).values({ orgId: o!.id, name: `S ${u}` }).returning({ id: sites.id });
+    const [d] = await db.insert(devices).values({ orgId: o!.id, siteId: s!.id, agentId: `a-${u}`, hostname: `h-${u}`, osType: 'windows', osVersion: '11', architecture: 'x86_64', agentVersion: '0.0.0-test', status: 'offline' }).returning({ id: devices.id });
+    await db.insert(softwareInventory).values({ orgId: o!.id, deviceId: d!.id, name, vendor, version: '1.0' });
+  });
+}
+
+beforeEach(async () => {
+  await withSystemDbAccessContext(async () => {
+    await db.delete(softwareProductResolutions);
+    await db.delete(softwareInventory);
+    await db.delete(softwareProducts);
+  });
+});
+
+describe('refreshResolutionCache', () => {
+  runDb('resolves a curated DisplayName to a catalog product', async () => {
+    await withSystemDbAccessContext(async () => {
+      await db.insert(softwareProducts).values({ normalizedName: 'chrome', normalizedVendor: 'google', cpe: 'cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*', cpeConfidence: 'authoritative' });
+    });
+    await seedDeviceAndInventory('Google Chrome (64-bit)', 'Google LLC');
+
+    const counts = await refreshResolutionCache();
+    expect(counts.curated + counts.exact + counts.fuzzy).toBeGreaterThanOrEqual(1);
+
+    const rows = await withSystemDbAccessContext(() =>
+      db.select().from(softwareProductResolutions).where(eq(softwareProductResolutions.lookupName, 'google chrome (64-bit)')));
+    expect(rows[0]?.softwareProductId).not.toBeNull();
+    expect(rows[0]?.resolverVersion).toBe(RESOLVER_VERSION);
+  });
+
+  runDb('logs an unmatched DisplayName with NULL product', async () => {
+    await seedDeviceAndInventory('Totally Bespoke Internal Tool XYZ', 'Some Vendor');
+    await refreshResolutionCache();
+    const unmatched = await withSystemDbAccessContext(() =>
+      db.select().from(softwareProductResolutions).where(isNull(softwareProductResolutions.softwareProductId)));
+    expect(unmatched.length).toBeGreaterThanOrEqual(1);
+    expect(unmatched[0]?.confidence).toBe('none');
+  });
+
+  runDb('is idempotent — re-run does not duplicate rows', async () => {
+    await seedDeviceAndInventory('Google Chrome', 'Google LLC');
+    await refreshResolutionCache();
+    await refreshResolutionCache();
+    const rows = await withSystemDbAccessContext(() =>
+      db.select({ n: sql<number>`count(*)::int` }).from(softwareProductResolutions).where(eq(softwareProductResolutions.lookupName, 'google chrome')));
+    expect(rows[0]?.n).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+```bash
+cd apps/api
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5433/breeze"
+pnpm test:integration src/services/cpeResolution.integration.test.ts
+```
+Expected: FAIL — `refreshResolutionCache` not found / module missing.
+
+- [ ] **Step 4: Implement `refreshResolutionCache`**
+
+```ts
+// apps/api/src/services/cpeResolution.ts
+import { sql } from 'drizzle-orm';
+
+import { db, withSystemDbAccessContext } from '../db';
+import { softwareInventory, softwareProducts, softwareProductResolutions } from '../db/schema';
+import {
+  RESOLVER_VERSION, buildCatalogIndex, loadCuratedDictionary, resolve,
+  type CatalogProduct, type ResolutionConfidence,
+} from './cpeResolver';
+
+/**
+ * Global pass: resolve every distinct (lower(trim(name)), lower(trim(vendor))) in
+ * software_inventory against the catalog and upsert into software_product_resolutions.
+ * Skips keys already resolved at the current RESOLVER_VERSION; re-resolves rows from an
+ * older version (self-healing as the dictionary/catalog grows). System context only —
+ * software_product_resolutions and the catalog are global system-only tables.
+ */
+export async function refreshResolutionCache(): Promise<Record<ResolutionConfidence, number>> {
+  const counts: Record<ResolutionConfidence, number> = { curated: 0, exact: 0, fuzzy: 0, none: 0 };
+
+  await withSystemDbAccessContext(async () => {
+    const products = await db
+      .select({ id: softwareProducts.id, normalizedName: softwareProducts.normalizedName, normalizedVendor: softwareProducts.normalizedVendor, cpe: softwareProducts.cpe })
+      .from(softwareProducts);
+    const index = buildCatalogIndex(products as CatalogProduct[]);
+    const curated = loadCuratedDictionary();
+
+    // distinct SQL-reproducible keys, plus a representative original name for normalization
+    const keys = await db
+      .select({
+        lookupName: sql<string>`lower(trim(${softwareInventory.name}))`,
+        lookupVendor: sql<string | null>`lower(trim(${softwareInventory.vendor}))`,
+        sampleName: sql<string>`min(${softwareInventory.name})`,
+      })
+      .from(softwareInventory)
+      .groupBy(sql`lower(trim(${softwareInventory.name}))`, sql`lower(trim(${softwareInventory.vendor}))`);
+
+    // keys already resolved at the current version → skip
+    const existing = await db
+      .select({ lookupName: softwareProductResolutions.lookupName, lookupVendor: softwareProductResolutions.lookupVendor, resolverVersion: softwareProductResolutions.resolverVersion })
+      .from(softwareProductResolutions);
+    const currentByKey = new Map<string, number>();
+    for (const e of existing) currentByKey.set(`${e.lookupName} ${e.lookupVendor ?? ''}`, e.resolverVersion);
+
+    for (const k of keys) {
+      const dedupeKey = `${k.lookupName} ${k.lookupVendor ?? ''}`;
+      if (currentByKey.get(dedupeKey) === RESOLVER_VERSION) continue;
+
+      const r = resolve(k.sampleName, k.lookupVendor, index, curated);
+      counts[r.confidence] += 1;
+
+      await db
+        .insert(softwareProductResolutions)
+        .values({
+          lookupName: k.lookupName,
+          lookupVendor: k.lookupVendor,
+          normalizedName: r.matchedVia === 'unmatched' ? k.lookupName : k.sampleName,
+          softwareProductId: r.productId,
+          confidence: r.confidence,
+          matchedVia: r.matchedVia,
+          resolverVersion: RESOLVER_VERSION,
+          resolvedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: [softwareProductResolutions.lookupName, softwareProductResolutions.lookupVendor],
+          set: {
+            softwareProductId: r.productId,
+            confidence: r.confidence,
+            matchedVia: r.matchedVia,
+            resolverVersion: RESOLVER_VERSION,
+            resolvedAt: new Date(),
+          },
+        });
+    }
+  });
+
+  console.log('[cpeResolution] refresh complete', counts);
+  return counts;
+}
+```
+
+Note on the unique index + `onConflictDoUpdate`: the index is `NULLS NOT DISTINCT`, so a null-vendor key has a single conflict target row. Drizzle emits `ON CONFLICT (lookup_name, lookup_vendor) DO UPDATE`; Postgres 16 matches the `NULLS NOT DISTINCT` unique index. If Drizzle cannot target it, fall back to `.onConflictDoUpdate({ target: sql\`(lookup_name, lookup_vendor)\`, ... })`.
+
+- [ ] **Step 5: Run to verify it passes**
+
+```bash
+pnpm test:integration src/services/cpeResolution.integration.test.ts
+```
+Expected: PASS (curated resolve, unmatched-null log, idempotent re-run).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/cpeResolution.ts apps/api/src/services/cpeResolution.integration.test.ts apps/api/vitest.integration.config.ts
+git commit -m "feat(vuln): refreshResolutionCache — global DisplayName resolution pass (#2290)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Rewrite correlation joins + stamp confidence + wire into cycle
+
+**Files:**
+- Modify: `apps/api/src/services/vulnerabilityCorrelation.ts:188-275` (the two candidate queries) + `upsertDeviceVulnerability`
+- Modify: `apps/api/src/services/vulnerabilityCorrelation.integration.test.ts`
+- Modify: `apps/api/src/jobs/vulnerabilityJobs.ts` (`correlateEnabledOrgs`, ~line 829-847)
+
+**Interfaces:**
+- Consumes: `softwareProductResolutions` schema; `refreshResolutionCache` (Task 7).
+- Produces: correlation findings carrying `match_confidence`; refresh wired ahead of per-org correlation.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```ts
+// add to apps/api/src/services/vulnerabilityCorrelation.integration.test.ts
+// (imports: add softwareProductResolutions to the schema import; import refreshResolutionCache)
+import { refreshResolutionCache } from './cpeResolution';
+import { softwareProductResolutions } from '../db/schema';
+
+// add to the beforeEach delete list: await db.delete(softwareProductResolutions);
+
+async function seedInventory(orgId: string, deviceId: string, name: string, vendor: string | null, version: string): Promise<void> {
+  await withSystemDbAccessContext(async () => {
+    await db.insert(softwareInventory).values({ orgId, deviceId, name, vendor, version });
+  });
+}
+
+describe('correlation via resolver', () => {
+  runDb('a noisy Windows DisplayName correlates to a catalog CVE with match_confidence', async () => {
+    const { orgId, deviceId } = await seedOrgWithDevice();
+    await withSystemDbAccessContext(async () => {
+      const [prod] = await db.insert(softwareProducts).values({ normalizedName: 'acrobat_reader', normalizedVendor: 'adobe', cpe: 'cpe:2.3:a:adobe:acrobat_reader:*:*:*:*:*:*:*:*', cpeConfidence: 'authoritative' }).returning({ id: softwareProducts.id });
+      const [vuln] = await db.insert(vulnerabilities).values({ cveId: 'CVE-2025-0001', source: 'nvd', description: 'x', severity: 'critical', cvssVersion: '3.1', cvssScore: '9.8', patchAvailable: true, rawPayload: { t: true } }).returning({ id: vulnerabilities.id });
+      await db.insert(softwareVulnerabilities).values({ productId: prod!.id, vulnerabilityId: vuln!.id, versionEndExcluding: '99.0' });
+    });
+    // curated dict maps "Adobe Acrobat Reader DC" → adobe:acrobat_reader
+    await seedInventory(orgId, deviceId, 'Adobe Acrobat Reader DC (64-bit)', 'Adobe Inc.', '23.0');
+
+    await refreshResolutionCache();
+    const res = await correlateOrg(orgId, { deviceIds: [deviceId] });
+    expect(res.created).toBe(1);
+
+    const findings = await withSystemDbAccessContext(() =>
+      db.select().from(deviceVulnerabilities).where(eq(deviceVulnerabilities.orgId, orgId)));
+    expect(findings[0]?.matchConfidence).toBe('curated');
+  });
+
+  runDb('Microsoft Edge against a Chrome-only catalog produces NO finding', async () => {
+    const { orgId, deviceId } = await seedOrgWithDevice();
+    await withSystemDbAccessContext(async () => {
+      const [prod] = await db.insert(softwareProducts).values({ normalizedName: 'chrome', normalizedVendor: 'google', cpe: 'cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*', cpeConfidence: 'authoritative' }).returning({ id: softwareProducts.id });
+      const [vuln] = await db.insert(vulnerabilities).values({ cveId: 'CVE-2025-0002', source: 'nvd', description: 'x', severity: 'high', cvssVersion: '3.1', cvssScore: '7.5', patchAvailable: true, rawPayload: { t: true } }).returning({ id: vulnerabilities.id });
+      await db.insert(softwareVulnerabilities).values({ productId: prod!.id, vulnerabilityId: vuln!.id, versionEndExcluding: '999.0' });
+    });
+    await seedInventory(orgId, deviceId, 'Microsoft Edge', 'Microsoft Corporation', '120.0');
+
+    await refreshResolutionCache();
+    const res = await correlateOrg(orgId, { deviceIds: [deviceId] });
+    expect(res.created).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+pnpm test:integration src/services/vulnerabilityCorrelation.integration.test.ts
+```
+Expected: FAIL — the Adobe DisplayName does not join under the current `lower(name)=lower(name)` query (created=0, expected 1); `matchConfidence` undefined.
+
+- [ ] **Step 3: Rewrite the two candidate joins through resolutions**
+
+In `vulnerabilityCorrelation.ts`, replace BOTH product-join blocks (the `fixedBuildCandidates` query at ~200-218 and the `cpeRangeCandidates` query at ~257-275). For each, replace:
+
+```ts
+      .from(softwareInventory)
+      .innerJoin(
+        softwareProducts,
+        sql`lower(${softwareProducts.normalizedName}) = lower(trim(${softwareInventory.name}))`
+      )
+```
+
+with a join through the resolution cache on the SQL-reproducible key, and select the confidence:
+
+```ts
+      .from(softwareInventory)
+      .innerJoin(
+        softwareProductResolutions,
+        sql`${softwareProductResolutions.lookupName} = lower(trim(${softwareInventory.name}))
+            AND ${softwareProductResolutions.lookupVendor} IS NOT DISTINCT FROM lower(trim(${softwareInventory.vendor}))`
+      )
+      .innerJoin(
+        softwareProducts,
+        eq(softwareProducts.id, softwareProductResolutions.softwareProductId)
+      )
+```
+
+Add `matchConfidence: softwareProductResolutions.confidence` to BOTH `.select({...})` projections, and add `softwareProductResolutions` to the schema import. (The `innerJoin` on `softwareProducts.id = resolutions.software_product_id` naturally excludes unmatched `NULL` rows.)
+
+- [ ] **Step 4: Thread `matchConfidence` into `upsertDeviceVulnerability`**
+
+Add `matchConfidence: string | null` to the `upsertDeviceVulnerability` args, set it on both insert and update:
+
+```ts
+// in the .insert(...).values({...}) add:
+      matchConfidence: args.matchConfidence,
+// in the .update(...).set({...}) add:
+      matchConfidence: args.matchConfidence,
+```
+
+and pass `matchConfidence: candidate.matchConfidence` from both correlation loops. For `correlateOsVulns` (OS findings), pass `matchConfidence: null` (OS path has no product resolution).
+
+- [ ] **Step 5: Run to verify it passes**
+
+```bash
+pnpm test:integration src/services/vulnerabilityCorrelation.integration.test.ts
+```
+Expected: PASS — Adobe DisplayName now creates 1 finding with `matchConfidence='curated'`; Edge produces 0 findings.
+
+- [ ] **Step 6: Wire `refreshResolutionCache` into the correlation cycle**
+
+In `vulnerabilityJobs.ts` `correlateEnabledOrgs` (~line 829), call `refreshResolutionCache()` ONCE before the per-org loop (it opens its own system context; call it before/outside any per-org context, consistent with the existing "each opens its own system context" comment):
+
+```ts
+// near the top of correlateEnabledOrgs, before iterating orgs:
+import { refreshResolutionCache } from '../services/cpeResolution';
+// ...
+  await refreshResolutionCache();
+```
+
+Add the import at the top of the file next to the existing `correlateOrg`/`correlateOsVulns` import.
+
+- [ ] **Step 7: Full regression — resolver unit + all vuln integration + drift**
+
+```bash
+cd apps/api
+pnpm test:run src/services/cpeResolver.test.ts
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5433/breeze"
+pnpm test:integration src/services/cpeResolution.integration.test.ts src/services/vulnerabilityCorrelation.integration.test.ts
+pnpm db:check-drift
+pnpm typecheck
+```
+Expected: all PASS; no drift; no type errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/services/vulnerabilityCorrelation.ts \
+  apps/api/src/services/vulnerabilityCorrelation.integration.test.ts \
+  apps/api/src/jobs/vulnerabilityJobs.ts
+git commit -m "feat(vuln): correlate through resolution cache + stamp match_confidence (#2290)
+
+Correlation joins software_inventory→software_product_resolutions→software_products
+on lower(trim(name)); refreshResolutionCache runs once per correlation cycle.
+Fixes the DisplayName mismatch that surfaced only Chrome for Windows fleets.
+
+Closes #2290
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Post-implementation verification (not a code task)
+
+1. **Full API suite** (single-fork to avoid the known parallel flakiness — memory `api_test_suite_parallel_flakiness`): `cd apps/api && pnpm test:run` and `pnpm test:docker` for integration.
+2. **Live read-only sanity (NO prod mutation):** after merge + a correlation cycle, re-query US prod read-only (Tailscale SSH `root@100.79.234.33`, `docker run --rm postgres:16-alpine psql "$DATABASE_URL" -c "..."`, secret stays on the droplet) to confirm the count of DISTINCT surfaced products in `device_vulnerabilities` (joined to `software_inventory.name`) jumps well beyond Chrome. Report before/after counts.
+3. **PR:** open against `main`; run `/code-review` and the pr-review-toolkit before requesting merge. Do NOT merge/close — hand back for review (per repo workflow).
+
+## Spec B (#2291) — deferred
+
+Windows OS correlation is a SEPARATE spec/plan authored after this lands, gated on #2261 (MSRC sync health). Not in scope here.

--- a/docs/superpowers/specs/2026-07-08-vuln-displayname-cpe-resolver-design.md
+++ b/docs/superpowers/specs/2026-07-08-vuln-displayname-cpe-resolver-design.md
@@ -1,0 +1,284 @@
+# DisplayName → CPE Resolver for Vulnerability Correlation (#2290)
+
+**Status:** Design approved, pre-implementation
+**Date:** 2026-07-08
+**Issue:** #2290 (this spec). Related: #2292 (merged/open — case-insensitive join, the prerequisite), #2291 (Windows OS correlation — separate Spec B), #2261 (MSRC sync health — blocks Spec B).
+
+## Problem
+
+The Vulnerabilities dashboard surfaces only Google Chrome for a 24-device Windows
+fleet despite ~1,841 distinct installed apps and a catalog of ~3,449 CPE-bearing
+`software_products`. Root cause is the device→catalog correlation, not the catalog.
+
+`correlateOrg` (`apps/api/src/services/vulnerabilityCorrelation.ts`) joins:
+
+```sql
+software_inventory JOIN software_products
+  ON lower(software_products.normalized_name) = lower(trim(software_inventory.name))
+```
+
+`software_inventory.name` is a raw Windows-registry DisplayName carrying
+locale/edition/arch/version noise — `"Adobe Acrobat (64-bit)"`,
+`"Microsoft 365 Apps for business - en-us"`, `"Mozilla Firefox ESR 115 (x64 en-US)"`.
+A catalog `normalized_name` is a clean product token (CPE-derived, e.g. `acrobat_reader`,
+`365_apps`, `firefox`). The two are never string-equal even case-insensitively, so the
+join misses nearly everything. #2292 fixed casing; this spec fixes the structural
+mismatch. Vendor is currently ignored by the join, discarding a strong disambiguator.
+
+Note: NVD sync only creates match facts (`software_vulnerabilities`) for CPEs **already
+present** in the catalog (`buildCuratedCpeProductMap` maps existing CPE → productId).
+Therefore the resolver's job is to **link an inventory DisplayName to an existing
+catalog `software_products` row**, not to mint new CPEs. Minting a CPE with no match
+facts surfaces nothing.
+
+## Non-goals
+
+- Fuzzy/similarity *scoring* as the match decision (loose matching produces false
+  positives like Edge→Chrome). Layer B uses deterministic token-set logic with hard
+  guardrails, not a similarity score that "wins" by being closest.
+- Rewriting existing `software_products.normalized_name` rows. The `(normalized_name,
+  normalized_vendor)` unique index makes bulk-lowercasing collision-prone; we keep the
+  read-side `lower()` as the normalization invariant instead (decision below).
+- Windows OS-level CVEs (#2291 — separate Spec B, gated on #2261).
+
+## Decisions (locked in brainstorming)
+
+1. **Global resolution-cache table** between inventory and catalog. Not per-inventory-row
+   FK, not inline-in-memory. DisplayNames repeat fleet-wide, so a global cache is compact,
+   cross-org, auditable, and cheap to re-run. Rows with `software_product_id IS NULL` **are**
+   the unmatched-name log.
+2. **Keep read-side `lower()` invariant** — no normalize-on-write backfill migration
+   (avoids unique-index collisions). New writes continue through the same normalizer.
+3. **Two specs.** Ship #2290 (this) first. #2291 is Spec B, gated on #2261.
+4. **Vendor bounded fixtures + port algorithm** — no runtime network. FleetDM
+   `cpe_translations` (MIT), CIRCL cpe-guesser algorithm (BSD-2, ported to TS), tiiuae
+   cpedict slice (validation set), each with attribution.
+5. **Token-matched links feed findings, stamped `fuzzy`** so the UI can badge
+   lower-confidence matches. Guardrails keep FPs near zero; below-threshold names are
+   withheld (no finding) and logged for Layer-A growth. Nothing silently hidden.
+6. **Cache populated by a global pass per correlation cycle** (`refreshResolutionCache()`
+   in `correlateEnabledOrgs`, before the per-org loop), versioned + self-healing.
+
+## Architecture
+
+```
+software_inventory.name / vendor
+        │  normalizeDisplayName() + normalizeVendor()
+        ▼
+┌─────────────────────────────────────────────┐
+│  cpeResolver.ts  (pure, no DB)               │
+│  Layer A: curated dict + exact catalog name  │
+│  Layer B: token inverted-index + guardrails  │
+└─────────────────────────────────────────────┘
+        │  writes (via refreshResolutionCache)
+        ▼
+software_product_resolutions   (NEW, global, system-only RLS)
+  (lookup_name, lookup_vendor) → software_product_id | NULL
+        │  join
+        ▼
+correlateOrg / correlateOsVulns
+  software_inventory ⋈ software_product_resolutions ⋈ software_products
+                     ⋈ software_vulnerabilities ⋈ vulnerabilities
+```
+
+### Components
+
+- **`apps/api/src/services/cpeResolver.ts`** — pure resolver. No DB access.
+  - `normalizeDisplayName(name: string): string` — deterministic token strip.
+  - `buildCatalogIndex(products): CatalogIndex` — inverted word→productId index built once.
+  - `resolve(name, vendor, index): Resolution` where
+    `Resolution = { productId: string | null; cpe: string | null;
+    confidence: 'curated' | 'exact' | 'fuzzy' | 'none';
+    matchedVia: 'dictionary' | 'catalog_exact' | 'token' | 'unmatched';
+    tokensMatched: number }`.
+  - Deterministic and unit-testable with only the vendored fixtures.
+
+- **`software_product_resolutions`** (NEW table) — the cache and the unmatched log.
+
+- **`refreshResolutionCache(): Promise<{ resolved: Record<confidence, number> }>`**
+  (new export, likely in `vulnerabilityCorrelation.ts` or a sibling `cpeResolution.ts`) —
+  global pass under `withSystemDbAccessContext`:
+  1. `SELECT DISTINCT lower(trim(name)) AS lookup_name, lower(trim(vendor)) AS lookup_vendor
+     FROM software_inventory` — the **SQL-reproducible** join key.
+  2. For each not present at the current `resolver_version` (or present but `NULL`/`fuzzy`
+     from an older version): apply full `normalizeDisplayName()` + `resolve()` in TS, then
+     upsert into `software_product_resolutions` keyed by `(lookup_name, lookup_vendor)`.
+  3. Return per-confidence counts; emit a structured log line.
+
+- **`correlateOrg` / `correlateOsVulns`** — the `lower()=lower()` product joins are
+  **replaced** by a join through `software_product_resolutions` on the SQL-reproducible key:
+  `software_inventory ⋈ software_product_resolutions
+    ON (resolutions.lookup_name = lower(trim(software_inventory.name))
+        AND resolutions.lookup_vendor IS NOT DISTINCT FROM lower(trim(software_inventory.vendor)))
+   ⋈ software_products ON software_products.id = resolutions.software_product_id`.
+  **Key design point:** the join key is `lower(trim(name))` (expressible in SQL), NOT the
+  heavily-normalized name — full token-strip normalization is a multi-step TS operation that
+  cannot run in the join. The resolver applies that normalization *during refresh* to decide
+  which `software_product_id` a raw key maps to; the SQL join is then a plain equality on the
+  stored lowercased key. Resolution `confidence` is carried onto the created
+  `device_vulnerabilities.match_confidence`.
+
+## Resolver algorithm
+
+### Normalization (`normalizeDisplayName`)
+Deterministic, order-preserving:
+- lowercase, trim, collapse internal whitespace.
+- strip architecture tokens: `64-bit`, `32-bit`, `x64`, `x86`, `amd64`, `arm64`, and their
+  parenthetical forms `(64-bit)` etc.
+- strip locale tokens: `ll-CC` pattern (`en-us`, `de-de`, …) and a bounded spelled-out
+  language list.
+- strip trailing version numbers, 4-digit years, `- <locale>` suffixes, and
+  publisher-year parentheticals.
+- **never** strip the distinctive product word(s).
+
+Unit tests pin the exact behavior with a table of real DisplayName → normalized cases.
+
+### Layer A — exact, high-confidence
+1. **Curated translation dictionary**: FleetDM `cpe_translations` merged with the existing
+   8-entry `cpe-map.json`, keyed on normalized name → CPE (+ vendor). Match ⇒
+   `confidence='curated'`, `matchedVia='dictionary'`.
+2. **Exact catalog match**: normalized name equals a catalog `normalized_name`. Match ⇒
+   `confidence='exact'`, `matchedVia='catalog_exact'`.
+
+### Layer B — token inverted-index (cpe-guesser port), long tail
+- Build once: for each catalog product, index the word-set of its `normalized_name` +
+  `normalized_vendor` (+ CPE vendor/product tokens) → productId.
+- Query word-set = normalized DisplayName words + vendor words. Rank candidates by count
+  of matching **distinctive** words (vendor-only stopwords excluded from the count).
+- **Guardrails — ALL must hold, else withhold** (`confidence='none'`, `productId=null`,
+  logged):
+  - **Vendor agreement** — normalized inventory vendor consistent with the candidate CPE
+    vendor token: equality, or via a small vendor-alias map (`adobe inc.`→`adobe`,
+    `mozilla`→`mozilla`, `microsoft corporation`→`microsoft`, …). *This kills Edge→Chrome*
+    (Microsoft ≠ google) before product tokens are even considered. If inventory vendor is
+    absent, vendor agreement cannot be established ⇒ Layer B withholds (curated/exact still
+    apply).
+  - **Distinctive-product-token agreement** — at least one non-vendor, non-stopword product
+    token must match, so a shared vendor word alone ("microsoft") never matches.
+  - **Unique winner** — the top candidate must beat the runner-up by a margin; ties withhold.
+  - **Score threshold** — minimum matched-distinctive-token count.
+- Pass all ⇒ `confidence='fuzzy'`, `matchedVia='token'`.
+
+### cpedict validation guard
+The vendored real-CPE dictionary (`cpe-dictionary.json`) is used to (1) assert at test time
+that every curated-dictionary CPE is a real CPE (guards against typo/rot), and (2) reject at
+resolve time any resolved CPE absent from cpedict. Because Layer A/B resolve to *existing*
+catalog products (already real NVD CPEs), this primarily protects the curated layer.
+
+### `resolver_version`
+A module constant bumped whenever normalization rules, the dictionary, or guardrail
+thresholds change. `refreshResolutionCache()` re-resolves rows whose `resolver_version` is
+older, and always re-attempts `NULL`/`fuzzy` rows on a bump (self-healing as data grows).
+
+## Schema
+
+New global table — **system-only RLS**, same shape as the four existing global vuln tables
+(`vulnerabilities`, `software_products`, `software_vulnerabilities`, `os_vulnerabilities`).
+It is NOT tenant-scoped; correlation reads/writes it under `withSystemDbAccessContext`.
+
+```
+software_product_resolutions
+  id                    uuid pk default gen_random_uuid()
+  lookup_name           varchar(500) not null   -- lower(trim(software_inventory.name)) — the SQL join key
+  lookup_vendor         varchar(200)            -- lower(trim(software_inventory.vendor)) — nullable
+  normalized_name       varchar(500) not null   -- post-token-strip form (debug/observability only)
+  software_product_id   uuid null references software_products(id)  -- NULL = unmatched (log)
+  confidence            varchar(16) not null     -- curated | exact | fuzzy | none
+  matched_via           varchar(32) not null     -- dictionary | catalog_exact | token | unmatched
+  resolver_version      integer not null
+  resolved_at           timestamp not null
+  created_at            timestamp not null default now()
+  UNIQUE NULLS NOT DISTINCT (lookup_name, lookup_vendor)   -- null-vendor keys collapse to one row (PG16)
+  index on (software_product_id)
+```
+
+The join/upsert key is `(lookup_name, lookup_vendor)` — the lowercased-trimmed raw values,
+reproducible in the correlation SQL. `normalized_name` is stored only for debugging and to
+show what the resolver reduced the DisplayName to; it is never a join key.
+
+Additive column on the existing org-scoped findings table:
+
+```
+device_vulnerabilities.match_confidence  varchar(16)  -- nullable; curated|exact|fuzzy
+```
+
+### Migration
+- `apps/api/migrations/2026-07-08-vuln-product-resolutions.sql` (date-prefixed).
+- Idempotent: `CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`,
+  `ALTER TABLE ... ENABLE/FORCE ROW LEVEL SECURITY`, `pg_policies` existence check before
+  `CREATE POLICY` (copy an existing system-only policy verbatim — likely from the
+  `vulnerabilities` table migration).
+- No inner `BEGIN;/COMMIT;`. Re-application is a no-op.
+- `UNIQUE NULLS NOT DISTINCT (lookup_name, lookup_vendor)` so null-vendor rows collapse to one
+  key on upsert (Postgres 15+; prod + test are PG16).
+
+### RLS contract test
+Register `software_product_resolutions` in the **system-scoped** allowlist in
+`apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` in the same PR.
+Verify as `breeze_app` that a cross-tenant read/insert is denied.
+
+## External data vendoring
+
+`apps/api/src/services/__fixtures__/`:
+- `cpe-translations.json` — converted from FleetDM `server/vulnerabilities/nvd/
+  cpe_translations.json` (MIT). Add `cpe-translations.NOTICE` with source URL + license.
+- `cpe-dictionary.json` — bounded slice of `tiiuae/cpedict` used as the validation set.
+  Attribution in a `NOTICE`.
+- `scripts/regen-cpe-data.ts` — documents provenance and regenerates both fixtures; run
+  manually, not at build/runtime. **No runtime network.**
+- cpe-guesser algorithm ported to TS inside `cpeResolver.ts` with a BSD-2 attribution
+  header. Anonymized — no customer names/IPs anywhere (repo is PUBLIC).
+
+Fixture size is bounded to keep the API bundle reasonable; the API `dts:false` build
+constraint (memory: `api_dts_build_oom`) is unaffected since these are JSON data, not types.
+
+## Observability & Layer-A growth loop
+
+`software_product_resolutions` rows with `software_product_id IS NULL` (unmatched) or
+`confidence='fuzzy'` are the log — queryable directly, ordered by fleet frequency
+(join back to `software_inventory` count), to prioritize new curated dictionary entries.
+`refreshResolutionCache()` emits a structured summary line: counts by confidence per run.
+
+## Testing (TDD — real Postgres on :5433, redis :6380)
+
+Bring up: `docker compose -f docker-compose.test.yml up -d` (setup.ts auto-migrates +
+provisions `breeze_app`). Pattern: `vulnerabilityCorrelation.integration.test.ts`.
+
+- **Unit — `cpeResolver.test.ts`**:
+  - `normalizeDisplayName` table-driven cases (arch/locale/edition/version strip; keep
+    distinctive words).
+  - Layer A curated + exact hits.
+  - Layer B token match on a realistic long-tail DisplayName.
+  - **Edge≠Chrome** and other cross-vendor FP guards return `confidence='none'`.
+  - Vendor-alias equivalence; missing-vendor ⇒ Layer B withholds.
+  - Unique-winner margin + score-threshold withholding.
+  - Invariant: every curated-dictionary CPE exists in `cpe-dictionary.json`.
+- **Integration — `cpeResolution.integration.test.ts`** (new) + additions to
+  `vulnerabilityCorrelation.integration.test.ts`:
+  - Seed `"Adobe Acrobat (64-bit)"` (vendor `"Adobe Inc."`) + catalog `acrobat_reader`
+    product + match fact ⇒ finding created with `match_confidence='curated'|'exact'`.
+  - Seed `"Mozilla Firefox ESR 115 (x64 en-US)"` ⇒ resolves to `firefox`, finding created.
+  - Seed a Microsoft Edge DisplayName against a Chrome-only catalog ⇒ **no finding**;
+    resolution row logged with `confidence='none'`.
+  - Unmatched DisplayName ⇒ `software_product_id IS NULL` row present.
+  - `refreshResolutionCache()` is idempotent and self-heals on `resolver_version` bump.
+  - RLS: `software_product_resolutions` denies cross-tenant access as `breeze_app`
+    (contract test).
+- **Live read-only sanity** (post-merge, NO prod mutation): re-query US prod read-only
+  (Tailscale SSH `root@100.79.234.33`, `docker run postgres:16-alpine psql "$DATABASE_URL"`)
+  to confirm surfaced-product variety jumps well beyond Chrome. Secret stays on the droplet.
+
+## Rollout / relationship to #2292
+
+Branch `fix/vuln-cpe-resolver` is cut off `origin/main` (pre-#2292). This spec **replaces**
+the product join wholesale, so it subsumes #2292's `lower()` change; if #2292 merges first,
+the join lines it touched are rewritten here (resolve by taking this version). The read-side
+`lower()` normalization invariant is preserved inside the resolver/refresh path.
+
+## Spec B preview (#2291 — separate)
+
+Generalize `correlateOsVulns` to a Windows path: compare `devices.os_version`/`os_build`
+against MSRC `FixedBuild` OS data via `versionCompare.isVulnerable`, producing
+`software_inventory_id IS NULL` findings. Gated on #2261 (MSRC sync healthy + populating
+Windows `os_vulnerabilities` rows). Code path built but inert until data exists. Full spec
+authored after Spec A lands.


### PR DESCRIPTION
## Why

An audit of a 24-device Windows fleet found the Vulnerabilities dashboard surfaced **only Google Chrome** despite ~1,841 distinct installed apps and a catalog of ~3,449 CPE-bearing products. Root cause is the device→catalog correlation, not the catalog: it matched a raw Windows registry DisplayName verbatim (case-insensitively, post #2292) against a CPE product token. `"Adobe Acrobat (64-bit)"` never string-equals `acrobat_reader`, so the join missed nearly everything. Vendor was also ignored.

## What

A **deterministic, two-layer DisplayName→CPE resolver** (not fuzzy scoring — loose matching is exactly what produces Edge→Chrome false positives) feeding a global resolution cache that correlation joins through.

- **Layer A** — normalize the DisplayName (strip arch/locale/edition/version noise) → curated translation dictionary (seeded from FleetDM `cpe_translations`, MIT) + exact catalog-name match.
- **Layer B** — token inverted-index over the existing catalog (algorithm ported from CIRCL `cpe-guesser`, BSD-2) for the long tail, gated by hard guardrails that **withhold rather than guess**: vendor agreement, a distinctive product-token match, a strict unique-winner tie-break, and a score threshold.
- **`software_product_resolutions`** — a new **global, system-only RLS** table mapping `(lower(trim(name)), lower(trim(vendor))) → software_product_id` (NULL = unmatched, doubling as the "grow Layer A" log). `refreshResolutionCache()` populates it once per correlation cycle; both correlation queries join through it and stamp `device_vulnerabilities.match_confidence` (`curated|exact|fuzzy`).

Guardrails keep false positives near zero: vendor disagreement kills Edge→Chrome before product tokens are considered; the read-side `lower()` invariant is preserved (no risky backfill of the `(normalized_name, normalized_vendor)` unique index).

## Design / plan

- Spec: `docs/superpowers/specs/2026-07-08-vuln-displayname-cpe-resolver-design.md`
- Plan: `docs/superpowers/plans/2026-07-08-vuln-displayname-cpe-resolver.md`

## Safety / RLS

`software_product_resolutions` is a global system-only table (RLS enabled + forced, single `breeze.scope='system'` policy), accessed only under `withSystemDbAccessContext`, registered in `INTENTIONAL_UNSCOPED`. Correlation findings always take the **device's** org; a device can only ever get a finding for its own org. Migration is idempotent (`NULLS NOT DISTINCT` unique index, PG15+).

## Testing

- Resolver unit **34/34** (normalization, catalog index, Layer A/B, every guardrail incl. Edge≠Chrome and an isolating 2-char vendor-token case).
- Real-DB integration (`:5433`): correlation via resolver, Edge→no-finding, `match_confidence` stamping, catalog-growth healing, cross-device resolve isolation, correlation reopen path, empty-catalog guard. **7 files, 35/35.**
- RLS coverage **50/50**; `db:check-drift` clean; `tsc` clean.

## Review

Three independent review passes (task-level, whole-branch, and a 5-agent `/pr-review`): **no Critical**; RLS/tenant-isolation and false-positive suppression confirmed sound. Fixed along the way: a vendor-substring false-positive (`"canon".includes("ca")`), a catalog-growth staleness bug (unmatched names now re-resolve as the catalog grows), and two silent-failure hardenings (refresh failure no longer aborts the whole fleet; an empty catalog throws instead of a fleet-wide false "all clear").

## Follow-ups (not in this PR)

- **#2291** (Windows OS-level correlation) is a separate spec, gated on **#2261** (MSRC sync health). `Refs #2291`.
- Live-verify item for deploy: real MSRC product names may not exact/token-match the catalog — read-only spot-check the MSRC path against prod before relying on it.

Closes #2290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
