### PR TITLE
fix(sso): allow self-hosted internal OIDC issuers via IS_HOSTED-gated private-network opt-in

### DIFF
--- a/apps/api/src/config/env.test.ts
+++ b/apps/api/src/config/env.test.ts
@@ -116,4 +116,37 @@ describe('config env', () => {
     const mod = await loadEnv();
     expect(mod.mfaForcePartnerAdmin()).toBe(true);
   });
+
+  // Fail-closed self-host gate for private-network fetching (on-prem PSAs, DNS
+  // appliances, internal OIDC IdPs). Only an AFFIRMATIVE self-host declaration
+  // opens RFC1918/ULA; unset/garbage/truthy IS_HOSTED stays strict (#570).
+  describe('selfHostAllowsPrivateNetwork', () => {
+    afterEach(() => {
+      delete process.env.IS_HOSTED;
+    });
+
+    it('is true only for recognized self-host signals', async () => {
+      for (const value of ['false', '0', 'no', 'off', 'FALSE', ' off ']) {
+        process.env.IS_HOSTED = value;
+        vi.resetModules();
+        const mod = await loadEnv();
+        expect(mod.selfHostAllowsPrivateNetwork()).toBe(true);
+      }
+    });
+
+    it('is false when IS_HOSTED is unset (fail-closed)', async () => {
+      delete process.env.IS_HOSTED;
+      const mod = await loadEnv();
+      expect(mod.selfHostAllowsPrivateNetwork()).toBe(false);
+    });
+
+    it('is false for hosted/truthy or garbage IS_HOSTED', async () => {
+      for (const value of ['true', '1', 'yes', 'on', '', 'garbage']) {
+        process.env.IS_HOSTED = value;
+        vi.resetModules();
+        const mod = await loadEnv();
+        expect(mod.selfHostAllowsPrivateNetwork()).toBe(false);
+      }
+    });
+  });
 });

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -45,6 +45,19 @@ export function isRecognizedSelfHostSignal(raw: string | undefined): boolean {
   return new Set(['0', 'false', 'no', 'off']).has((raw ?? '').trim().toLowerCase());
 }
 
+// Shared gate for "may this deployment reach RFC1918/ULA (and plain-HTTP)
+// targets over safeFetch?" — used by on-prem appliance integrations that
+// legitimately live on the customer LAN (Pi-hole/AdGuard DNS, on-prem PSAs,
+// internal OIDC IdPs like Authentik/Keycloak). Opens ONLY when self-host is
+// AFFIRMATIVELY declared; unset/empty/garbage/truthy IS_HOSTED stays strict
+// (#570 fail-closed lesson). Loopback, link-local, cloud metadata, and CGNAT
+// remain blocked in BOTH modes at the safeFetch/urlSafety layer regardless.
+// `!isHosted()` is implied by the falsey-set membership but kept explicit so
+// the truthy/falsey vocabularies can never drift apart silently.
+export function selfHostAllowsPrivateNetwork(): boolean {
+  return isRecognizedSelfHostSignal(process.env.IS_HOSTED) && !isHosted();
+}
+
 // Public URL of the breeze-billing payment-setup landing page. Empty on
 // self-host. Consumed by the OAuth consent redirect (see Phase 2 Task 2.1
 // of docs/superpowers/plans/2026-04-29-mcp-bootstrap-cleanup.md) — the

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -456,7 +456,10 @@ describe('sso routes', () => {
     });
 
     expect(res.status).toBe(201);
-    expect(discoverOIDCConfig).toHaveBeenCalledWith('https://issuer.example.com');
+    // IS_HOSTED is unset in the test env → strict (no private-network opt-in).
+    expect(discoverOIDCConfig).toHaveBeenCalledWith('https://issuer.example.com', {
+      allowPrivateNetwork: false
+    });
     expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({
       orgId: ORG_UUID,
       name: 'Okta',

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -40,6 +40,7 @@ import { getTrustedClientIp } from '../services/clientIp';
 import { captureException } from '../services/sentry';
 import { decryptForColumn, encryptSecret } from '../services/secretCrypto';
 import { PERMISSIONS } from '../services/permissions';
+import { selfHostAllowsPrivateNetwork } from '../config/env';
 import { envFlag } from '../utils/envFlag';
 import { setRefreshTokenCookie, getCookieValue, auditLogin } from './auth/helpers';
 
@@ -525,7 +526,11 @@ ssoRoutes.post(
   // If issuer provided, try to discover endpoints
   if (body.issuer && body.type === 'oidc') {
     try {
-      const discovery = await discoverOIDCConfig(body.issuer);
+      // Self-hosted deployments (IS_HOSTED affirmatively false) may point at an
+      // internal IdP on an RFC1918 address; hosted SaaS stays strict.
+      const discovery = await discoverOIDCConfig(body.issuer, {
+        allowPrivateNetwork: selfHostAllowsPrivateNetwork()
+      });
       config.authorizationUrl = discovery.authorization_endpoint;
       config.tokenUrl = discovery.token_endpoint;
       config.userInfoUrl = discovery.userinfo_endpoint;
@@ -795,7 +800,11 @@ ssoRoutes.post(
   try {
     // Test discovery
     if (provider.issuer) {
-      const discovery = await discoverOIDCConfig(provider.issuer);
+      // Self-hosted deployments (IS_HOSTED affirmatively false) may point at an
+      // internal IdP on an RFC1918 address; hosted SaaS stays strict.
+      const discovery = await discoverOIDCConfig(provider.issuer, {
+        allowPrivateNetwork: selfHostAllowsPrivateNetwork()
+      });
       writeRouteAudit(c, {
         orgId: provider.orgId,
         action: 'sso.provider.test',

--- a/apps/api/src/services/sso.test.ts
+++ b/apps/api/src/services/sso.test.ts
@@ -6,6 +6,7 @@ import {
   assertEmailVerified,
   idpAssertedMfa,
   discoverOIDCConfig,
+  isInternalUrl,
   type OIDCConfig,
   PROVIDER_PRESETS,
   SAML_PROVIDER_PRESETS,
@@ -295,9 +296,72 @@ describe('sso service', () => {
       await expect(discoverOIDCConfig('http://issuer.example.com')).rejects.toThrow();
     });
 
+    // The metadata/loopback floor holds even with the opt-in: safeFetch's
+    // isAlwaysBlockedIp still rejects a rebind to cloud metadata.
+    it('still blocks cloud metadata even when allowPrivateNetwork is set', async () => {
+      lookupMock.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+      await expect(
+        discoverOIDCConfig('https://metadata-rebind.example.com', { allowPrivateNetwork: true })
+      ).rejects.toThrow(/internal network addresses/);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
     // NOTE: safeFetch (urlSafety.ts) owns the DNS-rebinding defense: IP pinning,
     // mixed-record handling, ENOTFOUND translation. Those cases are covered in
     // urlSafety.test.ts — we only keep sso-level checks here (string literal,
     // non-HTTPS scheme, IPv6 loopback via full integration).
+  });
+
+  describe('isInternalUrl (SSRF pre-check policy)', () => {
+    describe('strict mode (hosted SaaS — allowPrivateNetwork off)', () => {
+      it('requires HTTPS', () => {
+        expect(isInternalUrl('http://issuer.example.com')).toBe(true);
+        expect(isInternalUrl('https://issuer.example.com')).toBe(false);
+      });
+
+      it('rejects malformed URLs', () => {
+        expect(isInternalUrl('not-a-url')).toBe(true);
+      });
+
+      it('blocks loopback, unspecified, and RFC1918/ULA literals', () => {
+        expect(isInternalUrl('https://localhost')).toBe(true);
+        expect(isInternalUrl('https://127.0.0.1')).toBe(true);
+        expect(isInternalUrl('https://0.0.0.0')).toBe(true);
+        expect(isInternalUrl('https://10.0.0.5')).toBe(true);
+        expect(isInternalUrl('https://172.16.4.4')).toBe(true);
+        expect(isInternalUrl('https://192.168.1.10')).toBe(true);
+        expect(isInternalUrl('https://[fd00::1]')).toBe(true);
+        expect(isInternalUrl('https://169.254.169.254')).toBe(true);
+      });
+
+      it('allows public hostnames and IPs', () => {
+        expect(isInternalUrl('https://accounts.google.com')).toBe(false);
+        expect(isInternalUrl('https://8.8.8.8')).toBe(false);
+      });
+    });
+
+    describe('self-host mode (allowPrivateNetwork on)', () => {
+      it('permits plain HTTP', () => {
+        expect(isInternalUrl('http://authentik.internal', true)).toBe(false);
+      });
+
+      it('permits RFC1918 and ULA hosts', () => {
+        expect(isInternalUrl('https://10.0.0.5', true)).toBe(false);
+        expect(isInternalUrl('https://172.16.4.4', true)).toBe(false);
+        expect(isInternalUrl('https://192.168.1.10', true)).toBe(false);
+        expect(isInternalUrl('http://192.168.1.10', true)).toBe(false);
+        expect(isInternalUrl('https://[fd00::1]', true)).toBe(false);
+      });
+
+      it('STILL blocks loopback, unspecified, link-local, and cloud metadata', () => {
+        expect(isInternalUrl('https://localhost', true)).toBe(true);
+        expect(isInternalUrl('https://127.0.0.1', true)).toBe(true);
+        expect(isInternalUrl('http://127.0.0.2', true)).toBe(true);
+        expect(isInternalUrl('https://0.0.0.0', true)).toBe(true);
+        expect(isInternalUrl('https://169.254.169.254', true)).toBe(true);
+        expect(isInternalUrl('https://[fe80::1]', true)).toBe(true);
+        expect(isInternalUrl('https://[::1]', true)).toBe(true);
+      });
+    });
   });
 });

--- a/apps/api/src/services/sso.ts
+++ b/apps/api/src/services/sso.ts
@@ -364,8 +364,17 @@ export interface OIDCDiscoveryDocument {
 /**
  * Checks whether a URL points to an internal/private network address.
  * Used to prevent SSRF attacks via OIDC discovery.
+ *
+ * `allowPrivateNetwork` (self-hosted deployments with an internal IdP such as
+ * Authentik/Keycloak) relaxes this to permit plain-HTTP schemes and RFC1918/ULA
+ * hosts — but loopback, 0.0.0.0, link-local, and cloud metadata (169.254/16,
+ * fe80::/10) stay blocked in BOTH modes, mirroring urlSafety.isAlwaysBlockedIp.
+ * The deeper `safeFetch` DNS/IP guard enforces the same floor after resolution.
+ *
+ * Exported for unit testing — this is the SSRF policy pre-check, so its exact
+ * allow/block decisions are worth asserting directly.
  */
-function isInternalUrl(urlStr: string): boolean {
+export function isInternalUrl(urlStr: string, allowPrivateNetwork = false): boolean {
   let url: URL;
   try {
     url = new URL(urlStr);
@@ -373,52 +382,74 @@ function isInternalUrl(urlStr: string): boolean {
     return true; // Malformed URLs are rejected
   }
 
-  if (url.protocol !== 'https:') return true;
+  // Hosted SaaS requires HTTPS; self-hosted may reach an internal IdP over http.
+  if (url.protocol !== 'https:' && !(allowPrivateNetwork && url.protocol === 'http:')) return true;
+
+  // RFC1918/ULA ranges are blocked unless self-host affirmatively opts in.
+  const blockPrivate = !allowPrivateNetwork;
 
   const hostname = url.hostname;
-  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') return true;
 
-  // Block 0.0.0.0
+  // Always blocked, even for self-hosted appliances (loopback + unspecified).
+  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') return true;
   if (hostname === '0.0.0.0') return true;
 
-  // Block IPv6 private ranges (bracket notation)
+  // IPv6 literals (bracket notation). URL.hostname keeps the brackets, so the
+  // bare-string checks above never match an IPv6 literal — handle them here.
   if (hostname.startsWith('[')) {
     const inner = hostname.slice(1, -1).toLowerCase();
-    if (inner.startsWith('fc') || inner.startsWith('fd') || inner.startsWith('fe80:')) return true;
+    if (inner === '::1' || inner === '::') return true; // loopback / unspecified — always
+    if (inner.startsWith('fe80:')) return true; // link-local — always
+    if (inner.startsWith('fc') || inner.startsWith('fd')) return blockPrivate; // ULA
     if (inner.startsWith('::ffff:')) {
       // IPv4-mapped IPv6 — extract and check the IPv4 part
       const ipv4Part = inner.slice(7);
       const v4Parts = ipv4Part.split('.').map(Number);
       if (v4Parts.length === 4) {
-        if (v4Parts[0] === 10) return true;
-        if (v4Parts[0] === 172 && v4Parts[1]! >= 16 && v4Parts[1]! <= 31) return true;
-        if (v4Parts[0] === 192 && v4Parts[1] === 168) return true;
-        if (v4Parts[0] === 127) return true;
-        if (v4Parts[0] === 169 && v4Parts[1] === 254) return true;
+        if (v4Parts[0] === 127) return true; // loopback — always
+        if (v4Parts[0] === 169 && v4Parts[1] === 254) return true; // link-local/metadata — always
+        if (v4Parts[0] === 10) return blockPrivate;
+        if (v4Parts[0] === 172 && v4Parts[1]! >= 16 && v4Parts[1]! <= 31) return blockPrivate;
+        if (v4Parts[0] === 192 && v4Parts[1] === 168) return blockPrivate;
       }
     }
   }
 
-  // Check RFC 1918 and link-local ranges
+  // IPv4 literals
   const parts = hostname.split('.').map(Number);
   if (parts.length === 4 && parts.every(p => !isNaN(p))) {
-    if (parts[0] === 10) return true; // 10.0.0.0/8
-    if (parts[0] === 172 && parts[1] !== undefined && parts[1] >= 16 && parts[1] <= 31) return true; // 172.16.0.0/12
-    if (parts[0] === 192 && parts[1] === 168) return true; // 192.168.0.0/16
-    if (parts[0] === 169 && parts[1] === 254) return true; // 169.254.0.0/16 (link-local + cloud metadata)
+    if (parts[0] === 127) return true; // 127.0.0.0/8 loopback — always
+    if (parts[0] === 169 && parts[1] === 254) return true; // 169.254.0.0/16 link-local + cloud metadata — always
+    if (parts[0] === 10) return blockPrivate; // 10.0.0.0/8
+    if (parts[0] === 172 && parts[1] !== undefined && parts[1] >= 16 && parts[1] <= 31) return blockPrivate; // 172.16.0.0/12
+    if (parts[0] === 192 && parts[1] === 168) return blockPrivate; // 192.168.0.0/16
   }
 
   return false;
 }
 
-export async function discoverOIDCConfig(issuer: string): Promise<OIDCDiscoveryDocument> {
+export interface DiscoverOIDCConfigOptions {
+  /**
+   * Self-hosted opt-in for an internal IdP (Authentik/Keycloak) whose issuer
+   * resolves to an RFC1918/ULA address and/or is served over plain HTTP. Gate
+   * this on `selfHostAllowsPrivateNetwork()` at the call site — NEVER on a
+   * request-supplied value. Loopback/link-local/metadata stay blocked either
+   * way. Default false (strict, hosted-SaaS behavior).
+   */
+  allowPrivateNetwork?: boolean;
+}
+
+export async function discoverOIDCConfig(
+  issuer: string,
+  { allowPrivateNetwork = false }: DiscoverOIDCConfigOptions = {}
+): Promise<OIDCDiscoveryDocument> {
   const wellKnownUrl = `${issuer.replace(/\/$/, '')}/.well-known/openid-configuration`;
 
   // String-level SSRF pre-check: reject obvious private hostnames and
   // non-HTTPS schemes before we do any network work. `safeFetch` enforces the
   // same at a deeper layer (DNS resolution + connection pinning), but this
   // keeps the error message specific and avoids hitting DNS for garbage.
-  if (isInternalUrl(wellKnownUrl)) {
+  if (isInternalUrl(wellKnownUrl, allowPrivateNetwork)) {
     throw new Error('OIDC discovery URL must use HTTPS and must not point to internal network addresses');
   }
 
@@ -426,7 +457,8 @@ export async function discoverOIDCConfig(issuer: string): Promise<OIDCDiscoveryD
   try {
     response = await safeFetch(wellKnownUrl, {
       method: 'GET',
-      headers: { 'Accept': 'application/json' }
+      headers: { 'Accept': 'application/json' },
+      allowPrivateNetwork
     });
   } catch (err) {
     if (err instanceof SsrfBlockedError) {


### PR DESCRIPTION
Closes #2293

## Problem

Self-hosted Breeze deployments with an internal OIDC IdP (Authentik / Keycloak) whose **issuer resolves to an RFC1918/private address** cannot use the SSO provider **Test** button, nor create-time auto-discovery. `discoverOIDCConfig()` ran in strict SSRF mode and rejected any private issuer with:

> OIDC discovery URL must use HTTPS and must not point to internal network addresses

…even when the internal CA is trusted and TLS validation works. Reported by a self-hoster on Breeze 0.92.0 (Authentik over internal HTTPS).

## Root cause

Two independent blocking layers, neither with an opt-out — unlike the on-prem PSA (`services/psa/http.ts`) and Pi-hole/AdGuard (`services/dnsProviders/index.ts`) integrations, which already gate `allowPrivateNetwork` on an affirmative `IS_HOSTED` self-host declaration:

1. `isInternalUrl()` — a hand-rolled string pre-check that also hard-required HTTPS and rejected RFC1918 literals.
2. `safeFetch()` — the DNS/IP guard that supports `allowPrivateNetwork`, but `discoverOIDCConfig()` never passed it.

## Fix

Reuse the established, fail-closed self-host pattern rather than inventing a new toggle:

- **`selfHostAllowsPrivateNetwork()`** added to `config/env` — the shared gate: `IS_HOSTED ∈ {false,0,no,off} && !isHosted()`. Unset / empty / garbage / truthy `IS_HOSTED` all stay **strict** (#570 hardening lesson).
- Thread `allowPrivateNetwork` through `discoverOIDCConfig()` → `isInternalUrl()` + `safeFetch()`. When set, RFC1918/ULA and plain-HTTP issuers are permitted; **loopback, `0.0.0.0`, link-local, and cloud metadata (169.254/16, fe80::/10) stay blocked in BOTH modes**, mirroring `urlSafety.isAlwaysBlockedIp`. So this is an explicit, documented, self-host-only allowance — not a TLS bypass or a blanket SSRF disable.
- Wire both route call sites (create + Test) to `selfHostAllowsPrivateNetwork()`.

### Incidental hardening
While relaxing `isInternalUrl`, fixed a latent gap: bracketed IPv6 loopback/unspecified (`[::1]` / `[::]`) is now blocked (`URL.hostname` keeps the brackets, so the bare-string `=== '::1'` check never matched), and `127.0.0.0/8` octets are now blocked in the literal path too.

## Behavior

| `IS_HOSTED` | Private/internal OIDC issuer |
|---|---|
| `true` (hosted SaaS) | rejected (unchanged) |
| unset / garbage | rejected (fail-closed, unchanged) |
| `false`/`0`/`no`/`off` (self-host) | **allowed** (RFC1918/ULA + http) |

**No new env var** — reuses the existing v0.65+ required `IS_HOSTED`. Self-hosters already set `IS_HOSTED=false`.

## Tests
- `isInternalUrl` policy matrix — strict mode (HTTPS required, RFC1918/ULA/loopback/metadata blocked) + self-host mode (RFC1918/ULA/http allowed; loopback/link-local/metadata/`[::1]` still blocked).
- `discoverOIDCConfig` still blocks cloud metadata even with the opt-in (DNS-rebind case).
- `selfHostAllowsPrivateNetwork` fail-closed cases (recognized signals, unset, truthy/garbage).
- Updated the create-provider route call-arg assertion.

All 162 tests across `env`, `sso` (service + route), `urlSafety`, and `psa` suites pass; `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)