### PR TITLE
fix(sso): PR-review follow-ups for OIDC private-network opt-in (#2295)

### DIFF
--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -45,15 +45,17 @@ export function isRecognizedSelfHostSignal(raw: string | undefined): boolean {
   return new Set(['0', 'false', 'no', 'off']).has((raw ?? '').trim().toLowerCase());
 }
 
-// Shared gate for "may this deployment reach RFC1918/ULA (and plain-HTTP)
-// targets over safeFetch?" — used by on-prem appliance integrations that
-// legitimately live on the customer LAN (Pi-hole/AdGuard DNS, on-prem PSAs,
-// internal OIDC IdPs like Authentik/Keycloak). Opens ONLY when self-host is
-// AFFIRMATIVELY declared; unset/empty/garbage/truthy IS_HOSTED stays strict
-// (#570 fail-closed lesson). Loopback, link-local, cloud metadata, and CGNAT
-// remain blocked in BOTH modes at the safeFetch/urlSafety layer regardless.
-// `!isHosted()` is implied by the falsey-set membership but kept explicit so
-// the truthy/falsey vocabularies can never drift apart silently.
+// Gate for "may this deployment reach RFC1918/ULA (and plain-HTTP) targets over
+// safeFetch?" for the internal-OIDC/SSO discovery path (issue #2293). The DNS-
+// provider (services/dnsProviders/index.ts) and PSA (services/psa/http.ts)
+// integrations currently carry their own equivalent IS_HOSTED-affirmative gates
+// — consolidating all three onto this helper is a worthwhile follow-up, but as
+// of now this function is called only by the SSO routes. Opens ONLY when
+// self-host is AFFIRMATIVELY declared; unset/empty/garbage/truthy IS_HOSTED
+// stays strict (#570 fail-closed lesson). Loopback, link-local, cloud metadata,
+// and CGNAT remain blocked in BOTH modes at the safeFetch/urlSafety layer
+// regardless. `!isHosted()` is implied by the falsey-set membership but kept
+// explicit so the truthy/falsey vocabularies can never drift apart silently.
 export function selfHostAllowsPrivateNetwork(): boolean {
   return isRecognizedSelfHostSignal(process.env.IS_HOSTED) && !isHosted();
 }

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -600,6 +600,47 @@ describe('sso routes', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.success).toBe(true);
+    // IS_HOSTED unset → strict. Guards against a revert that drops the options
+    // object from the Test-button call site (the whole point of #2293).
+    expect(discoverOIDCConfig).toHaveBeenCalledWith('https://issuer.example.com', {
+      allowPrivateNetwork: false
+    });
+  });
+
+  it('passes allowPrivateNetwork: true to discovery on the Test route when self-hosted', async () => {
+    process.env.IS_HOSTED = 'false';
+    try {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: PROVIDER_UUID,
+              orgId: ORG_UUID,
+              type: 'oidc',
+              issuer: 'https://issuer.example.com'
+            }])
+          })
+        })
+      } as any);
+      vi.mocked(discoverOIDCConfig).mockResolvedValue({
+        issuer: 'https://issuer.example.com',
+        authorization_endpoint: 'https://issuer.example.com/auth',
+        token_endpoint: 'https://issuer.example.com/token',
+        userinfo_endpoint: 'https://issuer.example.com/userinfo'
+      } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}/test`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      expect(discoverOIDCConfig).toHaveBeenCalledWith('https://issuer.example.com', {
+        allowPrivateNetwork: true
+      });
+    } finally {
+      delete process.env.IS_HOSTED;
+    }
   });
 
   it('rejects provider mutation when permission check fails', async () => {

--- a/apps/api/src/services/sso.test.ts
+++ b/apps/api/src/services/sso.test.ts
@@ -258,8 +258,10 @@ describe('sso service', () => {
 
     it('rejects hostnames that DNS-resolve to loopback (127.0.0.1)', async () => {
       lookupMock.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+      // safeFetch is authoritative for resolved-IP blocks; its specific reason
+      // is surfaced (see discoverOIDCConfig's SsrfBlockedError handling).
       await expect(discoverOIDCConfig('https://attacker.example.com')).rejects.toThrow(
-        /internal network addresses|must not resolve to internal/
+        /OIDC discovery blocked|private\/loopback\/link-local/
       );
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
@@ -267,7 +269,7 @@ describe('sso service', () => {
     it('rejects hostnames that DNS-resolve to AWS metadata (169.254.169.254)', async () => {
       lookupMock.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
       await expect(discoverOIDCConfig('https://metadata-rebind.example.com')).rejects.toThrow(
-        /internal network addresses|must not resolve to internal/
+        /OIDC discovery blocked|private\/loopback\/link-local/
       );
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
@@ -275,9 +277,18 @@ describe('sso service', () => {
     it('rejects hostnames that resolve to RFC1918 (10.x)', async () => {
       lookupMock.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
       await expect(discoverOIDCConfig('https://rebind.example.com')).rejects.toThrow(
-        /internal network addresses|must not resolve to internal/
+        /OIDC discovery blocked|private\/loopback\/link-local/
       );
       expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('surfaces the specific reason (no DNS records) rather than a generic SSRF string', async () => {
+      // A mistyped issuer must not masquerade as an HTTPS/internal-address
+      // policy rejection — the "no DNS records" reason must reach the caller.
+      lookupMock.mockResolvedValue([]);
+      await expect(discoverOIDCConfig('https://typo.example.com')).rejects.toThrow(
+        /no DNS records/
+      );
     });
 
     it('rejects IPv6 loopback resolutions', async () => {
@@ -302,9 +313,17 @@ describe('sso service', () => {
       lookupMock.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
       await expect(
         discoverOIDCConfig('https://metadata-rebind.example.com', { allowPrivateNetwork: true })
-      ).rejects.toThrow(/internal network addresses/);
+      ).rejects.toThrow(/OIDC discovery blocked|private\/loopback\/link-local/);
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
+
+    // NOTE: the POSITIVE path (RFC1918 issuer allowed through when the opt-in is
+    // set) is proven WITHOUT a live connection by: the isInternalUrl matrix
+    // below (policy allows RFC1918 in self-host mode), the route-level test that
+    // the flag propagates from IS_HOSTED, and urlSafety.test.ts (safeFetch's
+    // allowPrivateNetwork behavior). A service-level success test would dispatch
+    // a real request to a private IP (safeFetch uses http/https.request, not the
+    // mocked global fetch) and hang, so it is intentionally omitted.
 
     // NOTE: safeFetch (urlSafety.ts) owns the DNS-rebinding defense: IP pinning,
     // mixed-record handling, ENOTFOUND translation. Those cases are covered in
@@ -334,6 +353,16 @@ describe('sso service', () => {
         expect(isInternalUrl('https://169.254.169.254')).toBe(true);
       });
 
+      it('blocks the classic filter-bypass forms (CGNAT, IPv4-mapped IPv6, decimal)', () => {
+        expect(isInternalUrl('https://100.64.1.1')).toBe(true); // CGNAT 100.64/10
+        // URL normalizes ::ffff:169.254.169.254 to the hex-pair [::ffff:a9fe:a9fe];
+        // urlSafety.isPrivateIp decodes it, so the pre-check catches it too.
+        expect(isInternalUrl('https://[::ffff:169.254.169.254]')).toBe(true);
+        expect(isInternalUrl('https://[::ffff:10.0.0.1]')).toBe(true);
+        expect(isInternalUrl('https://2130706433')).toBe(true); // decimal 127.0.0.1
+        expect(isInternalUrl('https://[::]')).toBe(true); // unspecified
+      });
+
       it('allows public hostnames and IPs', () => {
         expect(isInternalUrl('https://accounts.google.com')).toBe(false);
         expect(isInternalUrl('https://8.8.8.8')).toBe(false);
@@ -361,6 +390,13 @@ describe('sso service', () => {
         expect(isInternalUrl('https://169.254.169.254', true)).toBe(true);
         expect(isInternalUrl('https://[fe80::1]', true)).toBe(true);
         expect(isInternalUrl('https://[::1]', true)).toBe(true);
+        expect(isInternalUrl('https://[::]', true)).toBe(true);
+      });
+
+      it('STILL blocks CGNAT, multicast, and mapped-metadata even with the opt-in', () => {
+        expect(isInternalUrl('https://100.64.1.1', true)).toBe(true); // CGNAT
+        expect(isInternalUrl('https://224.0.0.1', true)).toBe(true); // multicast
+        expect(isInternalUrl('https://[::ffff:169.254.169.254]', true)).toBe(true); // mapped metadata
       });
     });
   });

--- a/apps/api/src/services/sso.ts
+++ b/apps/api/src/services/sso.ts
@@ -1,6 +1,6 @@
 import { randomBytes, createHash } from 'crypto';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
-import { safeFetch, SsrfBlockedError } from './urlSafety';
+import { safeFetch, SsrfBlockedError, isPrivateIp, isAlwaysBlockedIp } from './urlSafety';
 
 // ============================================
 // Types
@@ -362,14 +362,22 @@ export interface OIDCDiscoveryDocument {
 }
 
 /**
- * Checks whether a URL points to an internal/private network address.
- * Used to prevent SSRF attacks via OIDC discovery.
+ * Fast-path SSRF pre-check for an OIDC discovery URL: rejects a bad scheme or a
+ * literal internal-IP issuer before any DNS work, so the common cases get a
+ * specific error and we avoid resolving garbage. `safeFetch` is the
+ * AUTHORITATIVE gate — it re-checks every resolved IP (with pinning) after DNS,
+ * so a hostname that resolves to an internal address is caught there even if it
+ * sails through here.
  *
- * `allowPrivateNetwork` (self-hosted deployments with an internal IdP such as
- * Authentik/Keycloak) relaxes this to permit plain-HTTP schemes and RFC1918/ULA
- * hosts — but loopback, 0.0.0.0, link-local, and cloud metadata (169.254/16,
- * fe80::/10) stay blocked in BOTH modes, mirroring urlSafety.isAlwaysBlockedIp.
- * The deeper `safeFetch` DNS/IP guard enforces the same floor after resolution.
+ * IP-range decisions delegate to urlSafety's shared predicates so this
+ * pre-check and safeFetch's post-resolution gate use IDENTICAL range logic
+ * (including CGNAT, multicast, TEST-NET, and hex-pair IPv4-mapped IPv6 — the
+ * classic filter-bypass forms a hand-rolled check tends to miss):
+ *   - strict (hosted SaaS): `isPrivateIp` blocks every private/reserved range.
+ *   - `allowPrivateNetwork` (self-hosted internal IdP, e.g. Authentik/Keycloak):
+ *     `isAlwaysBlockedIp` permits ONLY RFC1918/ULA; loopback, 0.0.0.0/8,
+ *     link-local, cloud metadata, CGNAT, multicast, etc. stay blocked. Plain
+ *     HTTP is also permitted in this mode.
  *
  * Exported for unit testing — this is the SSRF policy pre-check, so its exact
  * allow/block decisions are worth asserting directly.
@@ -385,47 +393,21 @@ export function isInternalUrl(urlStr: string, allowPrivateNetwork = false): bool
   // Hosted SaaS requires HTTPS; self-hosted may reach an internal IdP over http.
   if (url.protocol !== 'https:' && !(allowPrivateNetwork && url.protocol === 'http:')) return true;
 
-  // RFC1918/ULA ranges are blocked unless self-host affirmatively opts in.
-  const blockPrivate = !allowPrivateNetwork;
+  // URL.hostname keeps the brackets on IPv6 literals; strip them for the IP
+  // predicates below (which expect a bare address).
+  const hostname = url.hostname.replace(/^\[|\]$/g, '');
 
-  const hostname = url.hostname;
+  // `localhost` is a hostname, not an IP literal — block it explicitly.
+  if (hostname === 'localhost') return true;
 
-  // Always blocked, even for self-hosted appliances (loopback + unspecified).
-  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') return true;
-  if (hostname === '0.0.0.0') return true;
+  // Only literal IPs can be policy-decided here; a real hostname must be
+  // resolved (and pinned) by safeFetch, so let it through this fast-path and
+  // rely on the authoritative post-DNS gate. Node's URL parser has already
+  // normalized decimal/octal/hex IPv4 forms to dotted-decimal by this point.
+  const isLiteralIp = /^[0-9.]+$/.test(hostname) || hostname.includes(':');
+  if (!isLiteralIp) return false;
 
-  // IPv6 literals (bracket notation). URL.hostname keeps the brackets, so the
-  // bare-string checks above never match an IPv6 literal — handle them here.
-  if (hostname.startsWith('[')) {
-    const inner = hostname.slice(1, -1).toLowerCase();
-    if (inner === '::1' || inner === '::') return true; // loopback / unspecified — always
-    if (inner.startsWith('fe80:')) return true; // link-local — always
-    if (inner.startsWith('fc') || inner.startsWith('fd')) return blockPrivate; // ULA
-    if (inner.startsWith('::ffff:')) {
-      // IPv4-mapped IPv6 — extract and check the IPv4 part
-      const ipv4Part = inner.slice(7);
-      const v4Parts = ipv4Part.split('.').map(Number);
-      if (v4Parts.length === 4) {
-        if (v4Parts[0] === 127) return true; // loopback — always
-        if (v4Parts[0] === 169 && v4Parts[1] === 254) return true; // link-local/metadata — always
-        if (v4Parts[0] === 10) return blockPrivate;
-        if (v4Parts[0] === 172 && v4Parts[1]! >= 16 && v4Parts[1]! <= 31) return blockPrivate;
-        if (v4Parts[0] === 192 && v4Parts[1] === 168) return blockPrivate;
-      }
-    }
-  }
-
-  // IPv4 literals
-  const parts = hostname.split('.').map(Number);
-  if (parts.length === 4 && parts.every(p => !isNaN(p))) {
-    if (parts[0] === 127) return true; // 127.0.0.0/8 loopback — always
-    if (parts[0] === 169 && parts[1] === 254) return true; // 169.254.0.0/16 link-local + cloud metadata — always
-    if (parts[0] === 10) return blockPrivate; // 10.0.0.0/8
-    if (parts[0] === 172 && parts[1] !== undefined && parts[1] >= 16 && parts[1] <= 31) return blockPrivate; // 172.16.0.0/12
-    if (parts[0] === 192 && parts[1] === 168) return blockPrivate; // 192.168.0.0/16
-  }
-
-  return false;
+  return allowPrivateNetwork ? isAlwaysBlockedIp(hostname) : isPrivateIp(hostname);
 }
 
 export interface DiscoverOIDCConfigOptions {
@@ -445,10 +427,7 @@ export async function discoverOIDCConfig(
 ): Promise<OIDCDiscoveryDocument> {
   const wellKnownUrl = `${issuer.replace(/\/$/, '')}/.well-known/openid-configuration`;
 
-  // String-level SSRF pre-check: reject obvious private hostnames and
-  // non-HTTPS schemes before we do any network work. `safeFetch` enforces the
-  // same at a deeper layer (DNS resolution + connection pinning), but this
-  // keeps the error message specific and avoids hitting DNS for garbage.
+  // Fast-path SSRF pre-check (see isInternalUrl); safeFetch is authoritative.
   if (isInternalUrl(wellKnownUrl, allowPrivateNetwork)) {
     throw new Error('OIDC discovery URL must use HTTPS and must not point to internal network addresses');
   }
@@ -462,7 +441,13 @@ export async function discoverOIDCConfig(
     });
   } catch (err) {
     if (err instanceof SsrfBlockedError) {
-      throw new Error('OIDC discovery URL must use HTTPS and must not point to internal network addresses');
+      // Surface the SPECIFIC reason (bad scheme / no DNS records / blocked IP)
+      // and keep the cause — a mistyped issuer ("no DNS records for …") must
+      // not masquerade as an SSRF policy rejection. A blanket "must use HTTPS /
+      // no internal addresses" string is also wrong in self-host mode, where
+      // http + RFC1918 are permitted. The Test route relays this message to the
+      // UI verbatim, so the extra detail reaches the operator directly.
+      throw new Error(`OIDC discovery blocked: ${err.message}`, { cause: err });
     }
     throw err;
   }


### PR DESCRIPTION
Follow-up to #2293 / PR #2295 (already merged as `4b403bac0`). PR #2295 was squash-merged before this multi-agent review pass landed, so these review fixes go in as a separate PR. **No happy-path behavior change** — this hardens the SSRF pre-check and improves diagnostics.

## What the review found

A 4-agent review (code / tests / silent-failure / comments) confirmed **no live SSRF bypass** — `safeFetch` is the authoritative post-DNS gate and backstops everything — but surfaced three real issues in the merged code:

### 1. Dead code + overclaimed parity in `isInternalUrl` (services/sso.ts)
The hand-rolled `::ffff:` branch was **effectively dead**: `new URL('https://[::ffff:169.254.169.254]').hostname` normalizes to the hex-pair form `[::ffff:a9fe:a9fe]`, which the dotted-decimal-only parsing never matched — it returned "allowed", relying entirely on `safeFetch`. The JSDoc also claimed the pre-check "mirrors `isAlwaysBlockedIp`" when it actually missed CGNAT (100.64/10), multicast, TEST-NET, and most of `fe80::/10`.

**Fix:** delegate literal-IP decisions to urlSafety's shared `isPrivateIp` / `isAlwaysBlockedIp`. The pre-check now genuinely mirrors the `safeFetch` floor, the hex-pair/CGNAT/multicast forms are caught, and ~30 lines of duplicated range logic are gone. `safeFetch` stays authoritative; the pre-check is documented as a fast-path.

### 2. Misleading error message (silent-failure, HIGH)
The `SsrfBlockedError` handler collapsed four distinct reasons — including `"no DNS records for …"` (a **mistyped issuer**) — into a blanket *"must use HTTPS and must not point to internal network addresses"*, which is also wrong in self-host mode (http + RFC1918 are allowed) and dropped the `cause`.

**Fix:** surface the specific reason with `{ cause }`. The Test route relays this to the UI, so operators now see the actual failure.

### 3. Comment overclaimed shared usage (config/env.ts)
`selfHostAllowsPrivateNetwork()`'s comment said it was used by DNS/PSA integrations too; it's currently only called by the SSO routes (DNS/PSA keep their own equivalent gates). Corrected, with consolidation noted as a follow-up.

## Tests added
- Test-button route asserts the discovery call args + `allowPrivateNetwork: true` propagation from `IS_HOSTED=false` (both route sites now covered).
- `isInternalUrl` matrix extended: CGNAT, multicast, hex-pair IPv4-mapped IPv6, decimal-encoded IP, `[::]`.
- `discoverOIDCConfig` surfaces the "no DNS records" reason (typo'd issuer) rather than a generic SSRF string.

135 tests pass across env / sso (service + route); `tsc --noEmit` and eslint clean.

Refs #2293

🤖 Generated with [Claude Code](https://claude.com/claude-code)