### PR TITLE
fix(web): QA papercuts — remove-user confirm, email guards, refresh 5xx hardening

### DIFF
--- a/apps/web/src/components/billing/OrgBillingSettings.test.tsx
+++ b/apps/web/src/components/billing/OrgBillingSettings.test.tsx
@@ -54,6 +54,27 @@ describe('OrgBillingSettings — billing contact', () => {
     });
   });
 
+  it('blocks save on a client-invalid contact email (guards the round-trip)', async () => {
+    fetchMock.mockImplementation(async (_input: string, opts?: RequestInit) =>
+      opts?.method === 'PATCH' ? json({ data: {} }) : orgPayload());
+    render(<OrgBillingSettings orgId="org-1" />);
+    await waitFor(() => expect(screen.getByTestId('org-billing-settings')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('org-billing-contact-email'), { target: { value: 'not-an-email' } });
+
+    // Inline error shows and the Save button is disabled…
+    expect(screen.getByTestId('org-billing-contact-email-error')).toBeInTheDocument();
+    expect(screen.getByTestId('org-billing-save')).toBeDisabled();
+    // …and even clicking it issues no PATCH (save() early-returns).
+    fireEvent.click(screen.getByTestId('org-billing-save'));
+    expect(findPatch()).toBeUndefined();
+
+    // Correcting the address clears the error and re-enables save.
+    fireEvent.change(screen.getByTestId('org-billing-contact-email'), { target: { value: 'ap@customer.example' } });
+    expect(screen.queryByTestId('org-billing-contact-email-error')).not.toBeInTheDocument();
+    expect(screen.getByTestId('org-billing-save')).not.toBeDisabled();
+  });
+
   it('serializes a cleared contact email to null (never "") so the schema does not 400', async () => {
     // The linchpin of the design: orgBillingSettingsSchema rejects '' via .email();
     // clearing the field must send null. Mirrors PartnerBillingSettings' address test.

--- a/apps/web/src/components/billing/OrgBillingSettings.tsx
+++ b/apps/web/src/components/billing/OrgBillingSettings.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
+import { isValidEmail } from '@/lib/email';
 import { pctFromFraction } from './invoiceTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -68,8 +69,13 @@ export default function OrgBillingSettings({ orgId }: Props) {
 
   useEffect(() => { void load(); }, [load]);
 
+  // Contact email is optional (blank clears it), but a non-empty value must be a
+  // valid address. Guard client-side so the Save button reflects it pre-submit;
+  // the server still validates the format on PATCH.
+  const contactEmailInvalid = contactEmail.trim() !== '' && !isValidEmail(contactEmail);
+
   const save = useCallback(async () => {
-    if (saving) return;
+    if (saving || contactEmailInvalid) return;
     setSaving(true);
     try {
       const pct = taxPercent.trim();
@@ -102,7 +108,7 @@ export default function OrgBillingSettings({ orgId }: Props) {
     } finally {
       setSaving(false);
     }
-  }, [saving, taxId, taxExempt, taxPercent, contactEmail, contactName, line1, line2, city, region, postal, country, orgId, load]);
+  }, [saving, contactEmailInvalid, taxId, taxExempt, taxPercent, contactEmail, contactName, line1, line2, city, region, postal, country, orgId, load]);
 
   if (loading) return <p className="text-sm text-muted-foreground">Loading billing settings…</p>;
   if (loadError) {
@@ -150,7 +156,12 @@ export default function OrgBillingSettings({ orgId }: Props) {
         <div className="mt-4 grid gap-4 sm:grid-cols-2">
           <div>
             <label className="text-sm font-medium" htmlFor="ob-contact-email">Contact email</label>
-            <input id="ob-contact-email" type="email" maxLength={255} value={contactEmail} onChange={(e) => setContactEmail(e.target.value)} placeholder="billing@customer.example" data-testid="org-billing-contact-email" className={inputCls} />
+            <input id="ob-contact-email" type="email" maxLength={255} value={contactEmail} onChange={(e) => setContactEmail(e.target.value)} placeholder="billing@customer.example" data-testid="org-billing-contact-email" aria-invalid={contactEmailInvalid} className={`${inputCls} ${contactEmailInvalid ? 'border-destructive' : ''}`} />
+            {contactEmailInvalid && (
+              <p className="mt-1 text-xs text-destructive" data-testid="org-billing-contact-email-error">
+                Enter a valid email address
+              </p>
+            )}
           </div>
           <div>
             <label className="text-sm font-medium" htmlFor="ob-contact-name">Contact name</label>
@@ -191,7 +202,7 @@ export default function OrgBillingSettings({ orgId }: Props) {
 
       <div className="flex justify-end">
         <button
-          type="button" onClick={() => void save()} disabled={saving}
+          type="button" onClick={() => void save()} disabled={saving || contactEmailInvalid}
           data-testid="org-billing-save"
           className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
         >

--- a/apps/web/src/components/settings/OrgPortalUsersEditor.test.tsx
+++ b/apps/web/src/components/settings/OrgPortalUsersEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 
 const fetchWithAuth = vi.fn();
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: any[]) => fetchWithAuth(...a) }));
@@ -50,6 +50,51 @@ describe('OrgPortalUsersEditor', () => {
     await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith(
       `/orgs/organizations/${ORG_ID}/portal-users/invite`,
       expect.objectContaining({ method: 'POST' })
+    ));
+  });
+
+  it('guards the invite email client-side: invalid disables Send, valid enables it', async () => {
+    fetchWithAuth.mockResolvedValueOnce(ok({ data: [] }));
+    render(<OrgPortalUsersEditor orgId={ORG_ID} />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByTestId('portal-users-invite-open'));
+
+    // Empty → disabled, no error yet.
+    expect(screen.getByTestId('portal-users-invite-submit')).toBeDisabled();
+    expect(screen.queryByTestId('portal-users-invite-email-error')).not.toBeInTheDocument();
+
+    // Malformed → disabled + inline error.
+    fireEvent.change(screen.getByTestId('portal-users-invite-email'), { target: { value: 'bad-portal-email' } });
+    expect(screen.getByTestId('portal-users-invite-submit')).toBeDisabled();
+    expect(screen.getByTestId('portal-users-invite-email-error')).toBeInTheDocument();
+
+    // Valid → enabled, error gone.
+    fireEvent.change(screen.getByTestId('portal-users-invite-email'), { target: { value: 'new@acme.example' } });
+    expect(screen.getByTestId('portal-users-invite-submit')).not.toBeDisabled();
+    expect(screen.queryByTestId('portal-users-invite-email-error')).not.toBeInTheDocument();
+  });
+
+  it('confirms before removing a portal user, then issues the DELETE', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(ok({ data: [
+        { id: 'pu-1', email: 'gone@acme.example', name: 'G', status: 'active', effectiveStatus: 'active', lastLoginAt: null, invitedAt: null }
+      ] }))                                    // initial list
+      .mockResolvedValueOnce(ok({ data: {} })) // DELETE
+      .mockResolvedValueOnce(ok({ data: [] })); // reload
+    render(<OrgPortalUsersEditor orgId={ORG_ID} />);
+    await waitFor(() => expect(screen.getByText('gone@acme.example')).toBeInTheDocument());
+
+    // Clicking Remove opens a confirm dialog — it does NOT delete yet.
+    fireEvent.click(screen.getByTestId('portal-user-delete-pu-1'));
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText(/gone@acme.example/)).toBeInTheDocument();
+    expect(fetchWithAuth).toHaveBeenCalledTimes(1); // still just the initial list load
+
+    // Confirming issues the org-scoped DELETE.
+    fireEvent.click(screen.getByTestId('portal-user-delete-confirm'));
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith(
+      `/orgs/organizations/${ORG_ID}/portal-users/pu-1`,
+      expect.objectContaining({ method: 'DELETE' })
     ));
   });
 });

--- a/apps/web/src/components/settings/OrgPortalUsersEditor.tsx
+++ b/apps/web/src/components/settings/OrgPortalUsersEditor.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, ActionError } from '@/lib/runAction';
+import { isValidEmail } from '@/lib/email';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
 
 type PortalUser = {
   id: string; email: string; name: string | null; status: string;
@@ -31,6 +33,11 @@ export default function OrgPortalUsersEditor({ orgId }: { orgId: string }) {
   const [name, setName] = useState('');
   const [message, setMessage] = useState('');
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [pendingRemove, setPendingRemove] = useState<PortalUser | null>(null);
+
+  // Client-side email-format guard for the invite form (server still validates).
+  const emailValid = isValidEmail(email);
+  const showEmailError = email.trim() !== '' && !emailValid;
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -51,6 +58,7 @@ export default function OrgPortalUsersEditor({ orgId }: { orgId: string }) {
   useEffect(() => { void load(); }, [load]);
 
   const invite = async () => {
+    if (!emailValid) return;
     try {
       await runAction({
         request: () => fetchWithAuth(`${base(orgId)}/invite`, {
@@ -199,7 +207,7 @@ export default function OrgPortalUsersEditor({ orgId }: { orgId: string }) {
                       type="button"
                       data-testid={`portal-user-delete-${u.id}`}
                       disabled={busyId === u.id}
-                      onClick={() => void mutate(u.id, `/${u.id}`, 'DELETE', undefined, 'User removed')}
+                      onClick={() => setPendingRemove(u)}
                       className="rounded-md border px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-500/10 disabled:opacity-50"
                     >
                       Remove
@@ -228,8 +236,14 @@ export default function OrgPortalUsersEditor({ orgId }: { orgId: string }) {
               placeholder="customer@example.com"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+              aria-invalid={showEmailError}
+              className={`mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm ${showEmailError ? 'border-destructive' : ''}`}
             />
+            {showEmailError && (
+              <p className="mt-1 text-xs text-destructive" data-testid="portal-users-invite-email-error">
+                Enter a valid email address
+              </p>
+            )}
           </div>
           <div>
             <label className="text-sm font-medium" htmlFor="portal-users-invite-name">Name (optional)</label>
@@ -265,7 +279,7 @@ export default function OrgPortalUsersEditor({ orgId }: { orgId: string }) {
             <button
               type="button"
               data-testid="portal-users-invite-submit"
-              disabled={!email}
+              disabled={!emailValid}
               onClick={() => void invite()}
               className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
             >
@@ -274,6 +288,25 @@ export default function OrgPortalUsersEditor({ orgId }: { orgId: string }) {
           </div>
         </div>
       )}
+
+      <ConfirmDialog
+        open={pendingRemove !== null}
+        onClose={() => setPendingRemove(null)}
+        onConfirm={() => {
+          const target = pendingRemove;
+          if (!target) return;
+          void mutate(target.id, `/${target.id}`, 'DELETE', undefined, 'User removed')
+            .finally(() => setPendingRemove(null));
+        }}
+        title="Remove portal user"
+        message={pendingRemove
+          ? `Remove ${pendingRemove.email}? They lose access to this organization's portal immediately. This can't be undone — you'd need to re-invite them.`
+          : ''}
+        confirmLabel="Remove"
+        variant="destructive"
+        isLoading={busyId === pendingRemove?.id}
+        confirmTestId="portal-user-delete-confirm"
+      />
     </section>
   );
 }

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+// Client-side email-format guard, mirroring the server's `z.string().email()`
+// and the "Enter a valid email address" copy the app's react-hook-form schemas
+// already use (LoginForm, UserInviteForm, SiteForm, …). This is a pre-submit UX
+// guard for the hand-rolled (non-RHF) forms only — the API still validates every
+// payload, so this never becomes the sole line of defense.
+const emailSchema = z.string().email();
+
+/** True when `value` (trimmed) is a syntactically valid email address. */
+export function isValidEmail(value: string): boolean {
+  return emailSchema.safeParse(value.trim()).success;
+}

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -261,6 +261,53 @@ describe('auth store fetchWithAuth', () => {
     expect(useAuthStore.getState().user).toBeNull();
   });
 
+  // QA 2026-07-08: a single transient 502 on /auth/refresh must NOT boot the
+  // user — a gateway blip reaches no verdict on the refresh cookie, so we retry
+  // with backoff and recover the session instead of hard-logging-out.
+  it('retries a transient 5xx on refresh and keeps the session', async () => {
+    useAuthStore.getState().login(baseUser, baseTokens);
+    const refreshedTokens: Tokens = { accessToken: 'access-after-502', expiresInSeconds: 3600 };
+    const apiSuccess = makeResponse({ data: { ok: true } }, true, 200);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ error: 'unauthorized' }, false, 401)) // original request
+      .mockResolvedValueOnce(makeResponse({ error: 'bad gateway' }, false, 502))  // refresh blips
+      .mockResolvedValueOnce(makeResponse({ tokens: refreshedTokens }, true, 200)) // refresh recovers
+      .mockResolvedValueOnce(apiSuccess);                                          // original replayed
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await fetchWithAuth('/devices');
+
+    expect(response).toBe(apiSuccess);
+    // Session survived the blip and adopted the recovered token.
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    expect(useAuthStore.getState().tokens?.accessToken).toBe(refreshedTokens.accessToken);
+    // Two refresh attempts fired (502 then success).
+    const refreshCalls = fetchMock.mock.calls.filter(([url]) => String(url).endsWith('/api/v1/auth/refresh'));
+    expect(refreshCalls).toHaveLength(2);
+  });
+
+  // The retry is bounded: a sustained gateway outage still evicts once the
+  // backoff attempts are exhausted (no infinite hang).
+  it('logs out when refresh 5xx persists past the retry budget', async () => {
+    useAuthStore.getState().login(baseUser, baseTokens);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ error: 'unauthorized' }, false, 401)) // original request
+      .mockResolvedValue(makeResponse({ error: 'bad gateway' }, false, 502));      // every refresh 502s
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchWithAuth('/devices');
+
+    // Initial attempt + MAX_TRANSIENT_REFRESH_RETRIES (2) = 3 refresh calls, then evict.
+    const refreshCalls = fetchMock.mock.calls.filter(([url]) => String(url).endsWith('/api/v1/auth/refresh'));
+    expect(refreshCalls).toHaveLength(3);
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    expect(useAuthStore.getState().tokens).toBeNull();
+  });
+
   // Regression (0.83.1 forced-MFA enrollment hotfix): when the store is
   // authenticated but holds no in-memory access token (always true on the
   // forced-MFA page after a full-page nav) and the cookie-backed refresh

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -264,12 +264,19 @@ export function resolveApiOrigin(): string {
 const REFRESH_LOCK_NAME = 'breeze-token-refresh';
 
 // One low-level /auth/refresh attempt. Returns the new tokens on success, or a
-// discriminated result so the caller can tell a benign concurrent race (server
-// reason 'refresh_raced', #1107) — which is retryable — apart from a hard
-// failure. A raced 401 means the winning sibling already rotated the SHARED
-// refresh cookie and the server deliberately did NOT clear it or kill the
-// session family, so a retry picks up the fresh cookie.
-async function refreshFetchOnce(): Promise<{ tokens: Tokens | null; raced: boolean }> {
+// discriminated result so the caller can tell three cases apart:
+//   - raced:     a benign concurrent race (server reason 'refresh_raced',
+//                #1107) — the winning sibling already rotated the SHARED refresh
+//                cookie and the server deliberately did NOT clear it or kill the
+//                session family, so an immediate retry picks up the fresh cookie.
+//   - transient: a gateway/network blip (5xx, offline, timeout) — no verdict was
+//                reached on the refresh cookie, so the session is very likely
+//                still valid and this should be retried with backoff rather than
+//                evicting the user (QA 2026-07-08: a single 502 on /auth/refresh
+//                hard-logged-out the SPA mid-session).
+//   - neither:   a hard failure (expired/reused refresh cookie, real 401/403) —
+//                the session is unrecoverable and the caller must evict.
+async function refreshFetchOnce(): Promise<{ tokens: Tokens | null; raced: boolean; transient: boolean }> {
   const headers = new Headers({ 'Content-Type': 'application/json' });
   const csrfToken = readCookie(CSRF_COOKIE_NAME);
   if (csrfToken) {
@@ -289,24 +296,32 @@ async function refreshFetchOnce(): Promise<{ tokens: Tokens | null; raced: boole
       signal: controller.signal,
     });
   } catch {
-    return { tokens: null, raced: false };
+    // Network error, offline, or the 8s abort fired — no HTTP status reached
+    // the client, so the refresh cookie is untouched. Retryable.
+    return { tokens: null, raced: false, transient: true };
   } finally {
     clearTimeout(timeout);
   }
 
   if (refreshResponse.ok) {
     const { tokens } = await refreshResponse.json().catch(() => ({ tokens: undefined })) as { tokens?: Tokens };
-    return { tokens: tokens?.accessToken ? tokens : null, raced: false };
+    return { tokens: tokens?.accessToken ? tokens : null, raced: false, transient: false };
   }
 
   if (refreshResponse.status === 401) {
     const body = await refreshResponse.json().catch(() => null) as { reason?: string } | null;
     if (body?.reason === 'refresh_raced') {
-      return { tokens: null, raced: true };
+      return { tokens: null, raced: true, transient: false };
     }
   }
 
-  return { tokens: null, raced: false };
+  // 5xx (typically a 502/503/504 from the gateway) means the request never
+  // reached a verdict on the refresh cookie — retryable, not an auth failure.
+  if (refreshResponse.status >= 500) {
+    return { tokens: null, raced: false, transient: true };
+  }
+
+  return { tokens: null, raced: false, transient: false };
 }
 
 // Serialize refresh across tabs AND across reloads via the Web Locks API.
@@ -324,18 +339,43 @@ async function withRefreshLock<T>(fn: () => Promise<T>): Promise<T> {
   return locks.request(REFRESH_LOCK_NAME, fn) as Promise<T>;
 }
 
+// A single transient gateway/network blip must not boot the user mid-session
+// (QA 2026-07-08), so transient refresh failures get a bounded exponential
+// backoff. Kept small: enough to ride out a one-off 502, not so many that a
+// genuinely dead session hangs the UI before eviction. Worst added wait ~0.9s.
+const MAX_TRANSIENT_REFRESH_RETRIES = 2;
+const TRANSIENT_REFRESH_BASE_DELAY_MS = 300;
+
 async function requestTokenRefresh(): Promise<Tokens | null> {
   return withRefreshLock(async () => {
-    const first = await refreshFetchOnce();
-    if (first.tokens) return first.tokens;
-    if (!first.raced) return null;
+    let transientRetries = 0;
+    for (;;) {
+      const result = await refreshFetchOnce();
+      if (result.tokens) return result.tokens;
 
-    // Benign race (#1107): a sibling context won the rotation. Give the
-    // winner's rotated cookie a beat to settle in the shared jar, then retry
-    // exactly once. The retry sends the now-current cookie and succeeds.
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    const second = await refreshFetchOnce();
-    return second.tokens;
+      if (result.raced) {
+        // Benign race (#1107): a sibling context won the rotation. Give the
+        // winner's rotated cookie a beat to settle in the shared jar, then
+        // retry exactly once. The retry sends the now-current cookie.
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        const retry = await refreshFetchOnce();
+        if (retry.tokens) return retry.tokens;
+        // If the race-retry itself hit a transient blip, fall through to the
+        // backoff path below; otherwise the session is genuinely gone.
+        if (!retry.transient) return null;
+      } else if (!result.transient) {
+        // Hard failure (expired/reused refresh cookie, real 401/403): the
+        // session is unrecoverable — evict.
+        return null;
+      }
+
+      // Transient gateway/network failure. Retry with bounded exponential
+      // backoff before giving up and letting the caller evict the session.
+      if (transientRetries >= MAX_TRANSIENT_REFRESH_RETRIES) return null;
+      const delay = TRANSIENT_REFRESH_BASE_DELAY_MS * 2 ** transientRetries;
+      transientRetries += 1;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
   });
 }
 


### PR DESCRIPTION
Three UI papercuts surfaced by the **2026-07-08 UI QA sweep** (`docs/testing/FEATURE_TEST_LOG.md`). None were confirmed bugs — all are consistency/UX hardening the sweep flagged.

## 1. Portal-user Remove → confirm dialog
`OrgPortalUsersEditor` deleted a portal user's access on a single click with no confirmation, while the software-catalog delete confirms. Remove now opens the shared `ConfirmDialog` (`variant="destructive"`, names the user's email) and only issues the org-scoped `DELETE` on confirm.

## 2. Client-side email guard on two forms
Portal-invite (`OrgPortalUsersEditor`) and billing-contact (`OrgBillingSettings`) accepted a malformed email client-side and relied on the server 400 + toast. Added a shared `isValidEmail` helper (`apps/web/src/lib/email.ts`, mirroring the app's `z.string().email()` + "Enter a valid email address" copy). The submit/save button now disables and an inline error shows for a malformed address, saving the round-trip.
- Billing contact email stays **optional** — a blank field still serializes to `null` (existing clear-to-null test unaffected).

## 3. Transient `/auth/refresh` 5xx no longer hard-logs-out the SPA
The sweep hit a single `502` on `/auth/refresh` that hard-redirected the whole SPA to `/login` mid-session. `refreshFetchOnce` treated any non-`refresh_raced` failure identically to a real 401. It now discriminates a **transient** blip (5xx / offline / 8s-timeout — no verdict reached on the refresh cookie) from a **hard** auth failure, and `requestTokenRefresh` retries transient failures with bounded exponential backoff (2 retries, ~0.9s max) before letting the caller evict. A sustained outage still logs out once the budget is exhausted — the retry is bounded, no infinite hang. Real 401/403 eviction is unchanged.

## Verification
- New/updated unit tests: portal Remove confirm-then-DELETE + invite email guard; billing email guard blocks the PATCH; auth transient-retry **recover** and **exhaust-then-logout**. Affected suites: **36 pass**.
- `astro check`: **0 errors, 0 warnings**. `eslint` clean on changed files. `no-silent-mutations` guard: **77 pass**.
- Not exercised in a live browser (logic is unit-covered); the original sweep's `502` was an infra flake, not reproducible on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)