### PR TITLE
fix(patches): restore third-party Patch Sources toggle in policy Patch tab

### DIFF
--- a/apps/api/src/routes/vulnerabilities.test.ts
+++ b/apps/api/src/routes/vulnerabilities.test.ts
@@ -448,6 +448,13 @@ describe('GET /vulnerabilities/devices/:deviceId/software', () => {
     expect(body.stats.critical).toBe(1);
     expect(body.stats.patchReadyFindingCount).toBe(2);
     expect(body.findings.every((f: any) => typeof f.groupKey === 'string')).toBe(true);
+    // Documented invariant of this layer: cvssVector is never surfaced here (it's
+    // catalog-only detail, not part of the device drill-down shape). Also pin the
+    // finding's groupKey to buildGroupKey's Chrome key so a regression in the
+    // grouping logic shows up as a targeted assertion, not just a count check.
+    const findingA = body.findings.find((f: any) => f.id === 'a');
+    expect(findingA.cvssVector).toBeNull();
+    expect(findingA.groupKey).toBe('sw:google chrome|');
     // fetchFleetFindingRows was called with the deviceId narrow.
     expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith(expect.objectContaining({ deviceId: ID, status: 'open' }));
   });

--- a/apps/api/src/routes/vulnerabilities.test.ts
+++ b/apps/api/src/routes/vulnerabilities.test.ts
@@ -415,6 +415,50 @@ describe('GET /vulnerabilities/software/:groupKey (drawer payload)', () => {
   });
 });
 
+describe('GET /vulnerabilities/devices/:deviceId/software', () => {
+  beforeEach(() => {
+    granted.clear();
+    granted.add('devices:read');
+    delete permissionsState.allowedSiteIds;
+    vi.mocked(db.select).mockReset();
+    vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);
+  });
+
+  it('groups a device’s findings by software and returns stats + tagged findings', async () => {
+    // assertDeviceSiteAccess: device lookup returns a row (site accessible).
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ siteId: 'site-1' }]) }),
+      }),
+    } as never);
+    vi.mocked(fetchFleetFindingRows).mockResolvedValue([
+      fleetRow({ deviceVulnerabilityId: 'a', deviceId: ID, cveId: 'CVE-1', softwareInventoryId: 'sw1', softwareName: 'Google Chrome', softwareVendor: '', severity: 'critical', patchAvailable: true, status: 'open' }),
+      fleetRow({ deviceVulnerabilityId: 'b', deviceId: ID, cveId: 'CVE-2', softwareInventoryId: 'sw1', softwareName: 'Google Chrome', softwareVendor: '', severity: 'medium', patchAvailable: true, knownExploited: false, status: 'open' }),
+      fleetRow({ deviceVulnerabilityId: 'c', deviceId: ID, cveId: 'CVE-3', softwareInventoryId: null, deviceOsType: 'windows', severity: 'high', patchAvailable: false, knownExploited: false, status: 'open' }),
+    ]);
+
+    const res = await app().request(`/vulnerabilities/devices/${ID}/software?status=open`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.groups).toHaveLength(2); // Chrome + Windows OS
+    const chrome = body.groups.find((g: any) => g.name === 'Google Chrome');
+    expect(chrome.cveCount).toBe(2);
+    expect(chrome.patchReadyFindingCount).toBe(2);
+    expect(body.stats.openTotal).toBe(3);
+    expect(body.stats.critical).toBe(1);
+    expect(body.stats.patchReadyFindingCount).toBe(2);
+    expect(body.findings.every((f: any) => typeof f.groupKey === 'string')).toBe(true);
+    // fetchFleetFindingRows was called with the deviceId narrow.
+    expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith(expect.objectContaining({ deviceId: ID, status: 'open' }));
+  });
+
+  it('404s when the device is not in the caller’s tenant/site scope', async () => {
+    // Default db.select mock: .limit() resolves [] → device not found.
+    const res = await app().request(`/vulnerabilities/devices/${ID}/software`);
+    expect(res.status).toBe(404);
+  });
+});
+
 describe('GET /vulnerabilities/:cveId/devices (CVE drawer payload)', () => {
   beforeEach(() => {
     vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);

--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -10,6 +10,7 @@ import {
   VULN_SKIP_REASON_LABELS,
   type SkippedItem,
   type VulnSkipReason,
+  type DeviceVulnFinding,
 } from '@breeze/shared';
 
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
@@ -17,7 +18,16 @@ import { deviceVulnerabilities, devices, vulnerabilities } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { remediateVulnerabilities } from '../services/vulnerabilityRemediation';
-import { buildGroupDetail, computeStats, filterFindings, groupFindings, toGroupFinding } from '../services/vulnerabilityFleetAggregation';
+import {
+  buildGroupDetail,
+  buildGroupKey,
+  computeDeviceStats,
+  computeStats,
+  filterFindings,
+  groupFindings,
+  toGroupFinding,
+  type FleetFindingRow,
+} from '../services/vulnerabilityFleetAggregation';
 import { fetchCveCatalogRecord, fetchFleetFindingRows } from '../services/vulnerabilityFleetQueries';
 import { writeRouteAudit } from '../services/auditEvents';
 import { createTicket } from '../services/ticketService';
@@ -541,6 +551,27 @@ function aggregateFleet(items: MergedItem[]): FleetRow[] {
   });
 }
 
+/** Map a fleet finding row to the per-device wire DTO, tagged with its
+ *  software groupKey so the client can cross-link a finding to its group. */
+function toDeviceFindingItem(r: FleetFindingRow): DeviceVulnFinding {
+  return {
+    id: r.deviceVulnerabilityId,
+    deviceId: r.deviceId,
+    vulnerabilityId: r.vulnerabilityId,
+    cveId: r.cveId,
+    cvssScore: r.cvssScore,
+    cvssVector: null, // fleet query layer does not carry the vector
+    severity: r.severity,
+    knownExploited: r.knownExploited,
+    epssScore: r.epssScore,
+    riskScore: r.riskScore,
+    status: r.status,
+    detectedAt: r.detectedAt,
+    patchAvailable: r.patchAvailable,
+    groupKey: buildGroupKey(r),
+  };
+}
+
 vulnerabilityRoutes.use('*', authMiddleware);
 vulnerabilityRoutes.use('*', requireScope('organization', 'partner', 'system'));
 vulnerabilityRoutes.use('*', requireVulnerabilityRead);
@@ -631,10 +662,43 @@ vulnerabilityRoutes.get(
   },
 );
 
+// Device Vulnerabilities tab payload: software-group rollup + tagged raw
+// findings + header stats, all narrowed to one device. Registered directly
+// after /devices/:deviceId (both static-first-segment) and BEFORE the
+// /:cveId/devices catch-all below, whose leading param would otherwise
+// shadow this path.
+vulnerabilityRoutes.get(
+  '/devices/:deviceId/software',
+  zValidator('param', deviceParamSchema),
+  zValidator('query', listQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const { deviceId } = c.req.valid('param');
+    const { status } = c.req.valid('query');
+    // Intra-org site gate (RLS isolates orgs, not sites).
+    const access = await assertDeviceSiteAccess(deviceId, auth);
+    if (!access.ok) {
+      return c.json({ error: access.error }, access.status);
+    }
+    const rows = await fetchFleetFindingRows({
+      status,
+      deviceId,
+      allowedSiteIds: perms?.allowedSiteIds,
+    });
+    return c.json({
+      groups: groupFindings(rows),
+      findings: rows.map(toDeviceFindingItem),
+      stats: computeDeviceStats(rows),
+    });
+  },
+);
+
 // CVE drawer payload: catalog record + fleet findings for that CVE. Registered
 // LAST among the GET routes — a param in the first path segment would
 // otherwise shadow every static-first-segment GET route above it
-// (/software, /software/:groupKey, /stats, /devices/:deviceId).
+// (/software, /software/:groupKey, /stats, /devices/:deviceId,
+// /devices/:deviceId/software).
 vulnerabilityRoutes.get('/:cveId/devices', zValidator('param', cveIdParamSchema), async (c) => {
   const { cveId } = c.req.valid('param');
   const cve = await fetchCveCatalogRecord(cveId);

--- a/apps/api/src/services/vulnerabilityFleetAggregation.test.ts
+++ b/apps/api/src/services/vulnerabilityFleetAggregation.test.ts
@@ -3,6 +3,7 @@ import {
   buildGroupKey,
   buildGroupDetail,
   computeStats,
+  computeDeviceStats,
   filterFindings,
   groupFindings,
   type FleetFindingRow,
@@ -189,6 +190,41 @@ describe('computeStats', () => {
     const stats = computeStats([], now);
     expect(stats.totalFindings).toBe(0);
     expect(stats.lastDetectedAt).toBeNull();
+  });
+});
+
+describe('computeDeviceStats', () => {
+  it('counts severity spread, unscored, KEV, and patch-ready', () => {
+    const rows = [
+      row({ deviceVulnerabilityId: 'a', cveId: 'CVE-1', severity: 'critical', knownExploited: true, patchAvailable: true, status: 'open' }),
+      row({ deviceVulnerabilityId: 'b', cveId: 'CVE-2', severity: 'high', patchAvailable: true, status: 'open' }),
+      // c/d/e explicitly turn off patchAvailable — the shared row() factory
+      // defaults it to true, and without this override all 5 rows would count
+      // as patch-ready (only a/b should, per the expected patchReadyFindingCount below).
+      row({ deviceVulnerabilityId: 'c', cveId: 'CVE-3', severity: 'medium', patchAvailable: false, status: 'open' }),
+      row({ deviceVulnerabilityId: 'd', cveId: 'CVE-4', severity: null, patchAvailable: false, status: 'open' }),
+      row({ deviceVulnerabilityId: 'e', cveId: 'CVE-5', severity: 'low', patchAvailable: false, status: 'open' }),
+    ];
+    expect(computeDeviceStats(rows)).toEqual({
+      openTotal: 5,
+      critical: 1,
+      high: 1,
+      medium: 1,
+      low: 1,
+      unscored: 1,
+      kevFindingCount: 1,
+      patchReadyFindingCount: 2,
+    });
+  });
+
+  it('patchReady counts only OPEN patch-available findings', () => {
+    const rows = [
+      row({ deviceVulnerabilityId: 'a', severity: 'high', patchAvailable: true, status: 'open' }),
+      row({ deviceVulnerabilityId: 'b', severity: 'high', patchAvailable: true, status: 'accepted' }),
+    ];
+    const s = computeDeviceStats(rows);
+    expect(s.patchReadyFindingCount).toBe(1);
+    expect(s.openTotal).toBe(2);
   });
 });
 

--- a/apps/api/src/services/vulnerabilityFleetAggregation.ts
+++ b/apps/api/src/services/vulnerabilityFleetAggregation.ts
@@ -24,6 +24,7 @@ import type {
   FleetFindingRow,
   SoftwareGroup,
   FleetVulnStats,
+  DeviceVulnStats,
   GroupCve,
   GroupFinding,
   SoftwareGroupDetail,
@@ -199,6 +200,32 @@ export function computeStats(rows: FleetFindingRow[], now: Date): FleetVulnStats
     acceptedExpiringSoon,
     totalFindings: rows.length,
     lastDetectedAt,
+  };
+}
+
+/** Per-device header summary. Counts reflect the rows passed in (the device
+ *  route pre-filters by the selected status). `patchReadyFindingCount` mirrors
+ *  the group/fleet definition: OPEN + patchAvailable. */
+export function computeDeviceStats(rows: FleetFindingRow[]): DeviceVulnStats {
+  let critical = 0, high = 0, medium = 0, low = 0, unscored = 0;
+  let kevFindingCount = 0;
+  let patchReadyFindingCount = 0;
+  for (const r of rows) {
+    switch ((r.severity ?? '').toLowerCase()) {
+      case 'critical': critical += 1; break;
+      case 'high': high += 1; break;
+      case 'medium': medium += 1; break;
+      case 'low': low += 1; break;
+      default: unscored += 1; break;
+    }
+    if (r.knownExploited) kevFindingCount += 1;
+    if (r.patchAvailable && r.status === 'open') patchReadyFindingCount += 1;
+  }
+  return {
+    openTotal: rows.length,
+    critical, high, medium, low, unscored,
+    kevFindingCount,
+    patchReadyFindingCount,
   };
 }
 

--- a/apps/api/src/services/vulnerabilityFleetQueries.ts
+++ b/apps/api/src/services/vulnerabilityFleetQueries.ts
@@ -26,10 +26,15 @@ export async function fetchFleetFindingRows(filters: {
   status: string;
   /** Site-axis narrowing; empty array = fail closed (return nothing). */
   allowedSiteIds?: string[];
+  /** When set, narrow to a single device (device tab). */
+  deviceId?: string;
 }): Promise<FleetFindingRow[]> {
   const conditions: SQL[] = [];
   if (filters.status !== 'all') {
     conditions.push(eq(deviceVulnerabilities.status, filters.status));
+  }
+  if (filters.deviceId) {
+    conditions.push(eq(deviceVulnerabilities.deviceId, filters.deviceId));
   }
   if (filters.allowedSiteIds !== undefined) {
     if (filters.allowedSiteIds.length === 0) return [];

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx
@@ -43,13 +43,48 @@ describe('PatchTab', () => {
     saveMock.mockResolvedValue({ id: 'link-1', featureType: 'patch', inlineSettings: {} });
   });
 
-  // Approval rules and patch sources now live exclusively on Update Rings.
-  it('does not render the Patch Sources section', async () => {
+  // Auto-approval rules live on Update Rings, but patch *sources* are the policy's
+  // own install-scope gate (evaluator source-filters on settings.sources). #1428
+  // wrongly stripped this control, stranding third-party patching as unreachable —
+  // it's restored as a single third-party toggle (OS is always included).
+  it('renders the Patch Sources third-party toggle, off by default', async () => {
     render(<PatchTab {...baseProps} />);
     await screen.findByText('Approval Ring');
-    expect(screen.queryByText('Patch Sources')).toBeNull();
-    expect(screen.queryByLabelText(/os updates/i)).toBeNull();
-    expect(screen.queryByLabelText(/third-party applications/i)).toBeNull();
+    expect(screen.getByText('Patch Sources')).toBeInTheDocument();
+    const toggle = screen.getByTestId('patch-third-party-sources-toggle');
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('adds third_party to sources on save when the toggle is switched on', async () => {
+    render(<PatchTab {...baseProps} />);
+    fireEvent.click(await screen.findByTestId('patch-third-party-sources-toggle'));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    const [, payload] = saveMock.mock.calls[0];
+    expect(payload.inlineSettings.sources).toEqual(['os', 'third_party']);
+  });
+
+  it('hydrates the third-party toggle on, and drops third_party back to [os] when switched off', async () => {
+    render(
+      <PatchTab
+        {...baseProps}
+        existingLink={{
+          id: 'link-1',
+          featureType: 'patch',
+          featurePolicyId: null,
+          inlineSettings: { sources: ['os', 'third_party'] },
+        }}
+      />
+    );
+    const toggle = await screen.findByTestId('patch-third-party-sources-toggle');
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    const [, payload] = saveMock.mock.calls[0];
+    expect(payload.inlineSettings.sources).toEqual(['os']);
   });
 
   it('does not render the Automatic Approval section', async () => {

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
@@ -333,6 +333,53 @@ export default function PatchTab({ policyId, existingLink, onLinkChanged, linked
         )}
       </div>
 
+      {/* Patch Sources — #1428 removed the source checkboxes intending them to
+          "live on Update Rings only", but the ring has no sources control and its
+          sources column never reaches the approval evaluator; the value that IS
+          evaluated is this policy's settings.sources, which was left stranded at
+          the default ['os']. That made third-party (winget/Homebrew) patches
+          impossible to enable through the UI — the evaluator source-filters them
+          out at patchApprovalEvaluator before app rules or ring auto-approve run.
+          Restore the switch so techs can actually opt in. OS stays always-on to
+          honour the schema's min(1) sources constraint. */}
+      <div className="mt-6">
+        <h3 className="text-sm font-semibold">Patch Sources</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          OS updates (Windows, macOS, Linux) are always included. Enable third-party to also patch
+          applications like Chrome, Firefox, and Zoom.
+        </p>
+        <div className="mt-2 flex items-center justify-between rounded-md border bg-background px-4 py-3">
+          <div className="pr-4">
+            <p className="text-sm font-medium">Include third-party software updates</p>
+            <p className="text-xs text-muted-foreground">
+              Patches third-party applications via winget (Windows) and Homebrew (macOS). Required
+              for the Application Rules below and for ring auto-approval of third-party apps to take
+              effect — without it, third-party patches are never installed by this policy.
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={settings.sources.includes('third_party')}
+            data-testid="patch-third-party-sources-toggle"
+            onClick={() =>
+              update('sources', settings.sources.includes('third_party') ? ['os'] : ['os', 'third_party'])
+            }
+            className={cn(
+              'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border transition',
+              settings.sources.includes('third_party') ? 'bg-emerald-500/80' : 'bg-muted'
+            )}
+          >
+            <span
+              className={cn(
+                'inline-block h-5 w-5 rounded-full bg-white transition',
+                settings.sources.includes('third_party') ? 'translate-x-5' : 'translate-x-1'
+              )}
+            />
+          </button>
+        </div>
+      </div>
+
       <PatchAppRulesSection apps={settings.apps} onChange={(apps) => update('apps', apps)} />
 
       {/* Schedule */}

--- a/apps/web/src/components/devices/DeviceVulnerabilitiesTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceVulnerabilitiesTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, within, waitFor, fireEvent } from '@testing-library/react';
 
 import { DeviceVulnerabilitiesTab } from './DeviceVulnerabilitiesTab';
 import * as api from '../../lib/api/vulnerabilities';
@@ -86,8 +86,11 @@ describe('DeviceVulnerabilitiesTab', () => {
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
     const toggle = await screen.findByTestId('vuln-group-toggle-sw:google chrome|');
     fireEvent.click(toggle);
-    expect(await screen.findByText('CVE-1')).toBeInTheDocument();
-    expect(screen.getByText('CVE-2')).toBeInTheDocument();
+    // ResponsiveTable renders both the desktop table and the mobile card list
+    // simultaneously in jsdom, so unscoped queries would double-match.
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    expect(await desktop.findByText('CVE-1')).toBeInTheDocument();
+    expect(desktop.getByText('CVE-2')).toBeInTheDocument();
   });
 
   it('Remediate all posts the group patch-ready open finding ids', async () => {
@@ -107,7 +110,8 @@ describe('DeviceVulnerabilitiesTab', () => {
     vi.mocked(api.remediateVuln).mockResolvedValue({ scheduled: 1, skipped: [] });
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
     fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:google chrome|'));
-    fireEvent.click(await screen.findByTestId('remediate-a'));
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    fireEvent.click(await desktop.findByTestId('remediate-a'));
     await waitFor(() => expect(api.remediateVuln).toHaveBeenCalledWith(['a']));
   });
 
@@ -160,7 +164,8 @@ describe('DeviceVulnerabilitiesTab', () => {
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
 
     fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:acme app|'));
-    const reopenBtn = await screen.findByTestId('reopen-acc1');
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    const reopenBtn = await desktop.findByTestId('reopen-acc1');
     expect(reopenBtn).toBeInTheDocument();
 
     fireEvent.click(reopenBtn);
@@ -172,10 +177,11 @@ describe('DeviceVulnerabilitiesTab', () => {
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
 
     fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:acme app|'));
-    await screen.findByTestId('reopen-acc1');
-    expect(screen.queryByTestId('remediate-acc1')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('accept-acc1')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('mitigate-acc1')).not.toBeInTheDocument();
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    await desktop.findByTestId('reopen-acc1');
+    expect(desktop.queryByTestId('remediate-acc1')).not.toBeInTheDocument();
+    expect(desktop.queryByTestId('accept-acc1')).not.toBeInTheDocument();
+    expect(desktop.queryByTestId('mitigate-acc1')).not.toBeInTheDocument();
   });
 
   it('renders a Status badge for each finding row', async () => {
@@ -188,7 +194,8 @@ describe('DeviceVulnerabilitiesTab', () => {
   it('disables Remediate button when patchAvailable is false', async () => {
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
     fireEvent.click(await screen.findByTestId('vuln-group-toggle-os:windows'));
-    const remediateBtn = await screen.findByTestId('remediate-c');
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    const remediateBtn = await desktop.findByTestId('remediate-c');
     expect(remediateBtn).toBeDisabled();
     expect(remediateBtn).toHaveAttribute('title', 'No patch available');
   });
@@ -197,7 +204,8 @@ describe('DeviceVulnerabilitiesTab', () => {
     vi.mocked(api.remediateVuln).mockResolvedValue({ scheduled: 1, skipped: [] });
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
     fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:google chrome|'));
-    const remediateBtn = await screen.findByTestId('remediate-a');
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    const remediateBtn = await desktop.findByTestId('remediate-a');
     expect(remediateBtn).not.toBeDisabled();
     expect(remediateBtn).not.toHaveAttribute('title', 'No patch available');
   });
@@ -244,10 +252,11 @@ describe('DeviceVulnerabilitiesTab', () => {
     ];
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
     fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:google chrome|'));
-    await screen.findByTestId('vulnerability-row-a');
-    expect(screen.queryByTestId('accept-a')).not.toBeInTheDocument();
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    await desktop.findByTestId('vulnerability-row-a');
+    expect(desktop.queryByTestId('accept-a')).not.toBeInTheDocument();
     // mitigate stays available on devices:write
-    expect(screen.getByTestId('mitigate-a')).toBeInTheDocument();
+    expect(desktop.getByTestId('mitigate-a')).toBeInTheDocument();
   });
 
   it('hides Reopen for accepted findings when the user lacks vulnerabilities:accept_risk', async () => {
@@ -266,6 +275,7 @@ describe('DeviceVulnerabilitiesTab', () => {
     ];
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
     fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:google chrome|'));
-    expect(await screen.findByTestId('accept-a')).toBeInTheDocument();
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    expect(await desktop.findByTestId('accept-a')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/devices/DeviceVulnerabilitiesTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceVulnerabilitiesTab.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, within, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
 import { DeviceVulnerabilitiesTab } from './DeviceVulnerabilitiesTab';
 import * as api from '../../lib/api/vulnerabilities';
+import type { DeviceVulnSoftwareResponse } from '@breeze/shared';
 
 type Perm = { resource: string; action: string };
 // Mutable grant set the mocked auth store reads from. Default = wildcard so the
@@ -19,65 +20,99 @@ vi.mock('../../stores/auth', () => ({
 }));
 
 vi.mock('../../lib/api/vulnerabilities', () => ({
-  fetchDeviceVulnerabilities: vi.fn(),
+  fetchDeviceSoftwareGroups: vi.fn(),
   remediateVuln: vi.fn(),
   acceptVulnRisk: vi.fn(),
   mitigateVuln: vi.fn(),
   reopenVuln: vi.fn(),
 }));
 
-const sampleItem: api.DeviceVulnerabilityItem = {
-  id: 'dv1',
-  deviceId: 'd1',
-  vulnerabilityId: 'v1',
-  cveId: 'CVE-2025-1',
-  cvssScore: 9.8,
-  cvssVector: null,
-  severity: 'critical',
-  knownExploited: true,
-  epssScore: 0.5,
-  riskScore: 100,
-  status: 'open',
-  detectedAt: '2026-06-23T00:00:00Z',
-  patchAvailable: true,
+// Chrome group (2 open patch-ready findings: CVE-1, CVE-2) + OS group (1
+// finding, no patch available). groupKeys match buildGroupKey in the
+// aggregation layer: software groups are `sw:<name>|<vendor>` (empty vendor
+// here), OS groups are `os:<osType>`.
+const RESPONSE: DeviceVulnSoftwareResponse = {
+  stats: { openTotal: 3, critical: 1, high: 1, medium: 1, low: 0, unscored: 0, kevFindingCount: 1, patchReadyFindingCount: 2 },
+  groups: [
+    { groupKey: 'sw:google chrome|', kind: 'software', name: 'Google Chrome', vendor: null, versions: ['126.0'], deviceCount: 1, cveCount: 2, cveIds: ['CVE-1', 'CVE-2'], worstSeverity: 'critical', maxRiskScore: 90, kevCveCount: 1, maxEpss: 0.4, patchReadyFindingCount: 2, patchReadyDeviceCount: 1, tickets: [] },
+    { groupKey: 'os:windows', kind: 'os', name: 'Windows OS updates', vendor: null, versions: [], deviceCount: 1, cveCount: 1, cveIds: ['CVE-3'], worstSeverity: 'high', maxRiskScore: 70, kevCveCount: 0, maxEpss: null, patchReadyFindingCount: 0, patchReadyDeviceCount: 0, tickets: [] },
+  ],
+  findings: [
+    { id: 'a', deviceId: 'd1', vulnerabilityId: 'v1', cveId: 'CVE-1', cvssScore: 9.1, cvssVector: null, severity: 'critical', knownExploited: true, epssScore: 0.4, riskScore: 90, status: 'open', detectedAt: '2026-06-01T00:00:00.000Z', patchAvailable: true, groupKey: 'sw:google chrome|' },
+    { id: 'b', deviceId: 'd1', vulnerabilityId: 'v2', cveId: 'CVE-2', cvssScore: 5.0, cvssVector: null, severity: 'medium', knownExploited: false, epssScore: null, riskScore: 40, status: 'open', detectedAt: '2026-06-01T00:00:00.000Z', patchAvailable: true, groupKey: 'sw:google chrome|' },
+    { id: 'c', deviceId: 'd1', vulnerabilityId: 'v3', cveId: 'CVE-3', cvssScore: 7.0, cvssVector: null, severity: 'high', knownExploited: false, epssScore: null, riskScore: 70, status: 'open', detectedAt: '2026-06-01T00:00:00.000Z', patchAvailable: false, groupKey: 'os:windows' },
+  ],
 };
 
-const noPatchItem: api.DeviceVulnerabilityItem = {
-  ...sampleItem,
-  id: 'dv3',
-  cveId: 'CVE-2025-3',
-  patchAvailable: false,
+const EMPTY_RESPONSE: DeviceVulnSoftwareResponse = {
+  stats: { openTotal: 0, critical: 0, high: 0, medium: 0, low: 0, unscored: 0, kevFindingCount: 0, patchReadyFindingCount: 0 },
+  groups: [],
+  findings: [],
 };
 
-const acceptedItem: api.DeviceVulnerabilityItem = {
-  ...sampleItem,
-  id: 'dv2',
-  status: 'accepted',
+// A single software group with one 'accepted' finding, for the reopen /
+// permission-gated tests (which previously used a flat `acceptedItem`).
+const ACCEPTED_RESPONSE: DeviceVulnSoftwareResponse = {
+  stats: { openTotal: 0, critical: 0, high: 1, medium: 0, low: 0, unscored: 0, kevFindingCount: 0, patchReadyFindingCount: 0 },
+  groups: [
+    { groupKey: 'sw:acme app|', kind: 'software', name: 'Acme App', vendor: null, versions: ['1.0'], deviceCount: 1, cveCount: 1, cveIds: ['CVE-9'], worstSeverity: 'high', maxRiskScore: 70, kevCveCount: 0, maxEpss: null, patchReadyFindingCount: 0, patchReadyDeviceCount: 0, tickets: [] },
+  ],
+  findings: [
+    { id: 'acc1', deviceId: 'd1', vulnerabilityId: 'v9', cveId: 'CVE-9', cvssScore: 7.0, cvssVector: null, severity: 'high', knownExploited: false, epssScore: null, riskScore: 70, status: 'accepted', detectedAt: '2026-06-01T00:00:00.000Z', patchAvailable: true, groupKey: 'sw:acme app|' },
+  ],
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
   authState.permissions = [{ resource: '*', action: '*' }];
-  vi.mocked(api.fetchDeviceVulnerabilities).mockResolvedValue({ items: [sampleItem] });
+  vi.mocked(api.fetchDeviceSoftwareGroups).mockResolvedValue(RESPONSE);
 });
 
 describe('DeviceVulnerabilitiesTab', () => {
-  it('renders the device findings', async () => {
+  it('renders the posture header from stats', async () => {
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    expect(await desktop.findByTestId('vulnerability-row-dv1')).toHaveTextContent('CVE-2025-1');
+    const header = await screen.findByTestId('device-vuln-stats');
+    expect(header).toHaveTextContent('1'); // critical count etc.
+    expect(header).toHaveTextContent(/Critical/i);
   });
 
-  it('calls remediate when the remediate button is clicked', async () => {
+  it('renders one row per software group, not per CVE', async () => {
+    render(<DeviceVulnerabilitiesTab deviceId="d1" />);
+    expect(await screen.findByTestId('vuln-group-sw:google chrome|')).toBeInTheDocument();
+    expect(screen.getByTestId('vuln-group-os:windows')).toBeInTheDocument();
+  });
+
+  it('expands a group to reveal its CVE findings', async () => {
+    render(<DeviceVulnerabilitiesTab deviceId="d1" />);
+    const toggle = await screen.findByTestId('vuln-group-toggle-sw:google chrome|');
+    fireEvent.click(toggle);
+    expect(await screen.findByText('CVE-1')).toBeInTheDocument();
+    expect(screen.getByText('CVE-2')).toBeInTheDocument();
+  });
+
+  it('Remediate all posts the group patch-ready open finding ids', async () => {
+    const remediate = vi.mocked(api.remediateVuln).mockResolvedValue({ scheduled: 2, skipped: [] });
+    render(<DeviceVulnerabilitiesTab deviceId="d1" />);
+    fireEvent.click(await screen.findByTestId('vuln-group-remediate-sw:google chrome|'));
+    await waitFor(() => expect(remediate).toHaveBeenCalledWith(['a', 'b']));
+  });
+
+  it('disables Remediate all when the group has no patch-ready findings', async () => {
+    render(<DeviceVulnerabilitiesTab deviceId="d1" />);
+    const btn = await screen.findByTestId('vuln-group-remediate-os:windows');
+    expect(btn).toBeDisabled();
+  });
+
+  it('calls remediate when the per-finding remediate button is clicked', async () => {
     vi.mocked(api.remediateVuln).mockResolvedValue({ scheduled: 1, skipped: [] });
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    fireEvent.click(await desktop.findByTestId('remediate-dv1'));
-    await waitFor(() => expect(api.remediateVuln).toHaveBeenCalledWith(['dv1']));
+    fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:google chrome|'));
+    fireEvent.click(await screen.findByTestId('remediate-a'));
+    await waitFor(() => expect(api.remediateVuln).toHaveBeenCalledWith(['a']));
   });
 
   it('shows the empty state when the device has no findings', async () => {
-    vi.mocked(api.fetchDeviceVulnerabilities).mockResolvedValue({ items: [] });
+    vi.mocked(api.fetchDeviceSoftwareGroups).mockResolvedValue(EMPTY_RESPONSE);
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
     expect(await screen.findByTestId('device-vulnerabilities-empty')).toBeInTheDocument();
   });
@@ -89,11 +124,11 @@ describe('DeviceVulnerabilitiesTab', () => {
   });
 
   it('refetches with the selected status when the filter changes', async () => {
-    vi.mocked(api.fetchDeviceVulnerabilities).mockResolvedValue({ items: [] });
+    vi.mocked(api.fetchDeviceSoftwareGroups).mockResolvedValue(EMPTY_RESPONSE);
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
     // Wait for initial load
     await screen.findByTestId('device-vulnerabilities-empty');
-    expect(api.fetchDeviceVulnerabilities).toHaveBeenCalledWith('d1', { status: 'open' });
+    expect(api.fetchDeviceSoftwareGroups).toHaveBeenCalledWith('d1', { status: 'open' });
 
     // Change filter to "accepted"
     fireEvent.change(screen.getByTestId('vulnerability-device-status-filter'), {
@@ -101,12 +136,12 @@ describe('DeviceVulnerabilitiesTab', () => {
     });
 
     await waitFor(() =>
-      expect(api.fetchDeviceVulnerabilities).toHaveBeenCalledWith('d1', { status: 'accepted' }),
+      expect(api.fetchDeviceSoftwareGroups).toHaveBeenCalledWith('d1', { status: 'accepted' }),
     );
   });
 
   it('refetches with status "all" when the filter is changed to All', async () => {
-    vi.mocked(api.fetchDeviceVulnerabilities).mockResolvedValue({ items: [] });
+    vi.mocked(api.fetchDeviceSoftwareGroups).mockResolvedValue(EMPTY_RESPONSE);
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
     await screen.findByTestId('device-vulnerabilities-empty');
 
@@ -115,46 +150,45 @@ describe('DeviceVulnerabilitiesTab', () => {
     });
 
     await waitFor(() =>
-      expect(api.fetchDeviceVulnerabilities).toHaveBeenCalledWith('d1', { status: 'all' }),
+      expect(api.fetchDeviceSoftwareGroups).toHaveBeenCalledWith('d1', { status: 'all' }),
     );
   });
 
   it('shows a Reopen button for accepted findings and calls reopenVuln', async () => {
-    vi.mocked(api.fetchDeviceVulnerabilities).mockResolvedValue({ items: [acceptedItem] });
+    vi.mocked(api.fetchDeviceSoftwareGroups).mockResolvedValue(ACCEPTED_RESPONSE);
     vi.mocked(api.reopenVuln).mockResolvedValue(undefined);
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
 
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    const reopenBtn = await desktop.findByTestId('reopen-dv2');
+    fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:acme app|'));
+    const reopenBtn = await screen.findByTestId('reopen-acc1');
     expect(reopenBtn).toBeInTheDocument();
 
     fireEvent.click(reopenBtn);
-    await waitFor(() => expect(api.reopenVuln).toHaveBeenCalledWith('dv2'));
+    await waitFor(() => expect(api.reopenVuln).toHaveBeenCalledWith('acc1'));
   });
 
   it('does not show Remediate/Accept/Mitigate buttons for accepted findings', async () => {
-    vi.mocked(api.fetchDeviceVulnerabilities).mockResolvedValue({ items: [acceptedItem] });
+    vi.mocked(api.fetchDeviceSoftwareGroups).mockResolvedValue(ACCEPTED_RESPONSE);
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
 
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    await desktop.findByTestId('reopen-dv2');
-    expect(desktop.queryByTestId('remediate-dv2')).not.toBeInTheDocument();
-    expect(desktop.queryByTestId('accept-dv2')).not.toBeInTheDocument();
-    expect(desktop.queryByTestId('mitigate-dv2')).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:acme app|'));
+    await screen.findByTestId('reopen-acc1');
+    expect(screen.queryByTestId('remediate-acc1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('accept-acc1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mitigate-acc1')).not.toBeInTheDocument();
   });
 
-  it('renders a Status column badge for each row', async () => {
+  it('renders a Status badge for each finding row', async () => {
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    const row = await desktop.findByTestId('vulnerability-row-dv1');
+    fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:google chrome|'));
+    const row = await screen.findByTestId('vulnerability-row-a');
     expect(row).toHaveTextContent('Open');
   });
 
   it('disables Remediate button when patchAvailable is false', async () => {
-    vi.mocked(api.fetchDeviceVulnerabilities).mockResolvedValue({ items: [noPatchItem] });
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    const remediateBtn = await desktop.findByTestId('remediate-dv3');
+    fireEvent.click(await screen.findByTestId('vuln-group-toggle-os:windows'));
+    const remediateBtn = await screen.findByTestId('remediate-c');
     expect(remediateBtn).toBeDisabled();
     expect(remediateBtn).toHaveAttribute('title', 'No patch available');
   });
@@ -162,59 +196,23 @@ describe('DeviceVulnerabilitiesTab', () => {
   it('enables Remediate button when patchAvailable is true', async () => {
     vi.mocked(api.remediateVuln).mockResolvedValue({ scheduled: 1, skipped: [] });
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    const remediateBtn = await desktop.findByTestId('remediate-dv1');
+    fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:google chrome|'));
+    const remediateBtn = await screen.findByTestId('remediate-a');
     expect(remediateBtn).not.toBeDisabled();
     expect(remediateBtn).not.toHaveAttribute('title', 'No patch available');
   });
 
   it('shows a "Patch available" indicator for open findings with patchAvailable', async () => {
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    expect(await desktop.findByTestId('patch-available-dv1')).toBeInTheDocument();
+    fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:google chrome|'));
+    expect(await screen.findByTestId('patch-available-a')).toBeInTheDocument();
   });
 
   it('does not show a "Patch available" indicator when patchAvailable is false', async () => {
-    vi.mocked(api.fetchDeviceVulnerabilities).mockResolvedValue({ items: [noPatchItem] });
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    await desktop.findByTestId('vulnerability-row-dv3');
-    expect(desktop.queryByTestId('patch-available-dv3')).not.toBeInTheDocument();
-  });
-
-  it('bulk-remediate button is disabled when no rows are selected', async () => {
-    render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const bulkBtn = await screen.findByTestId('vuln-bulk-remediate');
-    expect(bulkBtn).toBeDisabled();
-  });
-
-  it('selecting a row enables the bulk-remediate button', async () => {
-    render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    await desktop.findByTestId('vulnerability-row-dv1');
-    fireEvent.click(desktop.getByTestId('vuln-select-dv1'));
-    const bulkBtn = screen.getByTestId('vuln-bulk-remediate');
-    expect(bulkBtn).not.toBeDisabled();
-    expect(bulkBtn).toHaveTextContent('Remediate selected (1)');
-  });
-
-  it('bulk-remediate calls remediateVuln with selected ids then clears selection', async () => {
-    vi.mocked(api.remediateVuln).mockResolvedValue({ scheduled: 1, skipped: [] });
-    render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    await desktop.findByTestId('vulnerability-row-dv1');
-    fireEvent.click(desktop.getByTestId('vuln-select-dv1'));
-    fireEvent.click(screen.getByTestId('vuln-bulk-remediate'));
-    await waitFor(() => expect(api.remediateVuln).toHaveBeenCalledWith(['dv1']));
-    await waitFor(() => expect(screen.getByTestId('vuln-bulk-remediate')).toBeDisabled());
-  });
-
-  it('cannot select a row when patchAvailable is false', async () => {
-    vi.mocked(api.fetchDeviceVulnerabilities).mockResolvedValue({ items: [noPatchItem] });
-    render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    const checkbox = await desktop.findByTestId('vuln-select-dv3');
-    expect(checkbox).toBeDisabled();
+    fireEvent.click(await screen.findByTestId('vuln-group-toggle-os:windows'));
+    await screen.findByTestId('vulnerability-row-c');
+    expect(screen.queryByTestId('patch-available-c')).not.toBeInTheDocument();
   });
 
   it('has a Patched option in the status filter', async () => {
@@ -225,7 +223,7 @@ describe('DeviceVulnerabilitiesTab', () => {
   });
 
   it('refetches with status "patched" when filter changes to Patched', async () => {
-    vi.mocked(api.fetchDeviceVulnerabilities).mockResolvedValue({ items: [] });
+    vi.mocked(api.fetchDeviceSoftwareGroups).mockResolvedValue(EMPTY_RESPONSE);
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
     await screen.findByTestId('device-vulnerabilities-empty');
 
@@ -234,7 +232,7 @@ describe('DeviceVulnerabilitiesTab', () => {
     });
 
     await waitFor(() =>
-      expect(api.fetchDeviceVulnerabilities).toHaveBeenCalledWith('d1', { status: 'patched' }),
+      expect(api.fetchDeviceSoftwareGroups).toHaveBeenCalledWith('d1', { status: 'patched' }),
     );
   });
 
@@ -245,20 +243,20 @@ describe('DeviceVulnerabilitiesTab', () => {
       { resource: 'devices', action: 'execute' },
     ];
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    await desktop.findByTestId('vulnerability-row-dv1');
-    expect(desktop.queryByTestId('accept-dv1')).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:google chrome|'));
+    await screen.findByTestId('vulnerability-row-a');
+    expect(screen.queryByTestId('accept-a')).not.toBeInTheDocument();
     // mitigate stays available on devices:write
-    expect(desktop.getByTestId('mitigate-dv1')).toBeInTheDocument();
+    expect(screen.getByTestId('mitigate-a')).toBeInTheDocument();
   });
 
   it('hides Reopen for accepted findings when the user lacks vulnerabilities:accept_risk', async () => {
     authState.permissions = [{ resource: 'devices', action: 'read' }];
-    vi.mocked(api.fetchDeviceVulnerabilities).mockResolvedValue({ items: [acceptedItem] });
+    vi.mocked(api.fetchDeviceSoftwareGroups).mockResolvedValue(ACCEPTED_RESPONSE);
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    await desktop.findByTestId('vulnerability-row-dv2');
-    expect(desktop.queryByTestId('reopen-dv2')).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:acme app|'));
+    await screen.findByTestId('vulnerability-row-acc1');
+    expect(screen.queryByTestId('reopen-acc1')).not.toBeInTheDocument();
   });
 
   it('shows Accept risk when the user holds vulnerabilities:accept_risk', async () => {
@@ -267,7 +265,7 @@ describe('DeviceVulnerabilitiesTab', () => {
       { resource: 'vulnerabilities', action: 'accept_risk' },
     ];
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
-    expect(await desktop.findByTestId('accept-dv1')).toBeInTheDocument();
+    fireEvent.click(await screen.findByTestId('vuln-group-toggle-sw:google chrome|'));
+    expect(await screen.findByTestId('accept-a')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/devices/DeviceVulnerabilitiesTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceVulnerabilitiesTab.test.tsx
@@ -76,6 +76,27 @@ describe('DeviceVulnerabilitiesTab', () => {
     expect(header).toHaveTextContent(/Critical/i);
   });
 
+  it('labels the first stat tile "Open" for the default open status filter', async () => {
+    render(<DeviceVulnerabilitiesTab deviceId="d1" />);
+    const header = within(await screen.findByTestId('device-vuln-stats'));
+    expect(header.getByText('Open')).toBeInTheDocument();
+  });
+
+  it('relabels the first stat tile when the status filter changes to a non-open value', async () => {
+    vi.mocked(api.fetchDeviceSoftwareGroups).mockResolvedValue(EMPTY_RESPONSE);
+    render(<DeviceVulnerabilitiesTab deviceId="d1" />);
+    const header = within(await screen.findByTestId('device-vuln-stats'));
+    await screen.findByTestId('device-vulnerabilities-empty');
+    expect(header.getByText('Open')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('vulnerability-device-status-filter'), {
+      target: { value: 'accepted' },
+    });
+
+    await waitFor(() => expect(header.getByText('Accepted')).toBeInTheDocument());
+    expect(header.queryByText('Open')).not.toBeInTheDocument();
+  });
+
   it('renders one row per software group, not per CVE', async () => {
     render(<DeviceVulnerabilitiesTab deviceId="d1" />);
     expect(await screen.findByTestId('vuln-group-sw:google chrome|')).toBeInTheDocument();

--- a/apps/web/src/components/devices/DeviceVulnerabilitiesTab.tsx
+++ b/apps/web/src/components/devices/DeviceVulnerabilitiesTab.tsx
@@ -1,15 +1,16 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { ResponsiveTable, DataCard, CardField, CardActions } from '../shared/ResponsiveTable';
 import { handleActionError } from '../../lib/runAction';
 import { usePermissions } from '../../lib/permissions';
 import {
-  fetchDeviceVulnerabilities,
+  fetchDeviceSoftwareGroups,
   remediateVuln,
   acceptVulnRisk,
   mitigateVuln,
   reopenVuln,
-  type DeviceVulnerabilityItem,
+  type DeviceVulnFinding,
+  type DeviceVulnStats,
+  type SoftwareGroup,
 } from '../../lib/api/vulnerabilities';
 
 const SEVERITY_BADGES: Record<string, { label: string; className: string }> = {
@@ -62,14 +63,42 @@ type DeviceVulnerabilitiesTabProps = {
   timezone?: string;
 };
 
+const EMPTY_STATS: DeviceVulnStats = {
+  openTotal: 0,
+  critical: 0,
+  high: 0,
+  medium: 0,
+  low: 0,
+  unscored: 0,
+  kevFindingCount: 0,
+  patchReadyFindingCount: 0,
+};
+
+/** Group a flat array by a derived key, preserving insertion order within each group. */
+function groupBy<T>(items: T[], keyFn: (item: T) => string): Map<string, T[]> {
+  const map = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyFn(item);
+    const list = map.get(key);
+    if (list) {
+      list.push(item);
+    } else {
+      map.set(key, [item]);
+    }
+  }
+  return map;
+}
+
 export function DeviceVulnerabilitiesTab({ deviceId }: DeviceVulnerabilitiesTabProps) {
-  const [items, setItems] = useState<DeviceVulnerabilityItem[]>([]);
+  const [groups, setGroups] = useState<SoftwareGroup[]>([]);
+  const [findings, setFindings] = useState<DeviceVulnFinding[]>([]);
+  const [stats, setStats] = useState<DeviceVulnStats>(EMPTY_STATS);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [modal, setModal] = useState<ModalState>(null);
   const [statusFilter, setStatusFilter] = useState<string>('open');
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
 
   const { can } = usePermissions();
@@ -79,9 +108,10 @@ export function DeviceVulnerabilitiesTab({ deviceId }: DeviceVulnerabilitiesTabP
     setLoading(true);
     setError(null);
     try {
-      const res = await fetchDeviceVulnerabilities(deviceId, { status: statusFilter });
-      setItems(res.items);
-      setSelectedIds(new Set());
+      const res = await fetchDeviceSoftwareGroups(deviceId, { status: statusFilter });
+      setGroups(res.groups);
+      setFindings(res.findings);
+      setStats(res.stats);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load vulnerabilities');
     } finally {
@@ -92,6 +122,20 @@ export function DeviceVulnerabilitiesTab({ deviceId }: DeviceVulnerabilitiesTabP
   useEffect(() => {
     void load();
   }, [load]);
+
+  const findingsByGroup = useMemo(() => groupBy(findings, (f) => f.groupKey), [findings]);
+
+  const toggleExpanded = useCallback((groupKey: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupKey)) {
+        next.delete(groupKey);
+      } else {
+        next.add(groupKey);
+      }
+      return next;
+    });
+  }, []);
 
   const onRemediate = useCallback(async (id: string) => {
     if (busyId) return;
@@ -106,19 +150,27 @@ export function DeviceVulnerabilitiesTab({ deviceId }: DeviceVulnerabilitiesTabP
     }
   }, [busyId, load]);
 
-  const onBulkRemediate = useCallback(async () => {
-    if (bulkBusy || selectedIds.size === 0) return;
+  const groupPatchReadyIds = useCallback(
+    (groupKey: string) =>
+      (findingsByGroup.get(groupKey) ?? [])
+        .filter((f) => f.status === 'open' && f.patchAvailable)
+        .map((f) => f.id),
+    [findingsByGroup],
+  );
+
+  const onRemediateGroup = useCallback(async (groupKey: string) => {
+    const ids = groupPatchReadyIds(groupKey);
+    if (ids.length === 0 || bulkBusy) return;
     setBulkBusy(true);
     try {
-      await remediateVuln([...selectedIds]);
-      setSelectedIds(new Set());
+      await remediateVuln(ids);
       await load();
     } catch (err) {
       handleActionError(err, 'Failed to schedule remediation');
     } finally {
       setBulkBusy(false);
     }
-  }, [bulkBusy, selectedIds, load]);
+  }, [groupPatchReadyIds, bulkBusy, load]);
 
   const onReopen = useCallback(async (id: string) => {
     if (busyId) return;
@@ -151,21 +203,8 @@ export function DeviceVulnerabilitiesTab({ deviceId }: DeviceVulnerabilitiesTabP
     }
   }, [modal, load]);
 
-  const toggleSelect = useCallback((id: string, canSelect: boolean) => {
-    if (!canSelect) return;
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
-  }, []);
-
   const rowActions = useCallback(
-    (v: DeviceVulnerabilityItem) => {
+    (v: DeviceVulnFinding) => {
       const status = v.status?.toLowerCase();
       if (status === 'accepted' || status === 'mitigated') {
         return (
@@ -227,87 +266,6 @@ export function DeviceVulnerabilitiesTab({ deviceId }: DeviceVulnerabilitiesTabP
 
   const isOpenFilter = statusFilter === 'open';
 
-  const table = useMemo(
-    () => (
-      <table className="min-w-full divide-y">
-        <thead className="bg-muted/40">
-          <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            {isOpenFilter && <th className="px-4 py-3" />}
-            <th className="px-4 py-3">CVE</th>
-            <th className="px-4 py-3">Severity</th>
-            <th className="px-4 py-3">Status</th>
-            <th className="px-4 py-3">CVSS</th>
-            <th className="px-4 py-3">Risk</th>
-            <th className="px-4 py-3">KEV</th>
-            <th className="px-4 py-3 text-right">Actions</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y">
-          {items.map((v) => {
-            const canSelect = isOpenFilter && v.patchAvailable;
-            return (
-              <tr key={v.id} data-testid={`vulnerability-row-${v.id}`} className="transition hover:bg-muted/40">
-                {isOpenFilter && (
-                  <td className="px-4 py-3">
-                    <input
-                      type="checkbox"
-                      data-testid={`vuln-select-${v.id}`}
-                      checked={selectedIds.has(v.id)}
-                      disabled={!canSelect}
-                      onChange={() => toggleSelect(v.id, canSelect)}
-                      aria-label={`Select ${v.cveId}`}
-                    />
-                  </td>
-                )}
-                <td className="px-4 py-3 text-sm font-medium">
-                  {v.cveId}
-                  {isOpenFilter && v.patchAvailable && (
-                    <span
-                      data-testid={`patch-available-${v.id}`}
-                      className="ml-2 inline-flex items-center rounded-full bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-300"
-                    >
-                      Patch available
-                    </span>
-                  )}
-                </td>
-                <td className="px-4 py-3 text-sm"><SeverityBadge severity={v.severity} /></td>
-                <td className="px-4 py-3 text-sm"><StatusBadge status={v.status} /></td>
-                <td className="px-4 py-3 text-sm tabular-nums">{v.cvssScore === null ? '—' : v.cvssScore.toFixed(1)}</td>
-                <td className="px-4 py-3 text-sm tabular-nums">{v.riskScore === null ? '—' : Math.round(v.riskScore)}</td>
-                <td className="px-4 py-3 text-sm">{v.knownExploited ? 'Yes' : '—'}</td>
-                <td className="px-4 py-3 text-right">{rowActions(v)}</td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    ),
-    [items, rowActions, selectedIds, toggleSelect, isOpenFilter],
-  );
-
-  const cards = useMemo(
-    () =>
-      items.map((v) => (
-        <DataCard key={v.id}>
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-semibold">{v.cveId}</span>
-            <SeverityBadge severity={v.severity} />
-          </div>
-          <div className="mt-3 space-y-2 border-t pt-3">
-            <CardField label="Status"><StatusBadge status={v.status} /></CardField>
-            <CardField label="CVSS"><span className="text-sm tabular-nums">{v.cvssScore === null ? '—' : v.cvssScore.toFixed(1)}</span></CardField>
-            <CardField label="Risk"><span className="text-sm tabular-nums">{v.riskScore === null ? '—' : Math.round(v.riskScore)}</span></CardField>
-            <CardField label="Known exploited"><span className="text-sm">{v.knownExploited ? 'Yes' : 'No'}</span></CardField>
-            {isOpenFilter && v.patchAvailable && (
-              <CardField label="Patch"><span className="text-sm text-green-700 dark:text-green-300">Available</span></CardField>
-            )}
-          </div>
-          <CardActions className="flex flex-wrap justify-end gap-2">{rowActions(v)}</CardActions>
-        </DataCard>
-      )),
-    [items, rowActions, isOpenFilter],
-  );
-
   if (error) {
     return (
       <div data-testid="device-vulnerabilities-error" className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
@@ -316,8 +274,28 @@ export function DeviceVulnerabilitiesTab({ deviceId }: DeviceVulnerabilitiesTabP
     );
   }
 
+  const statTiles: Array<{ key: keyof DeviceVulnStats; label: string }> = [
+    { key: 'openTotal', label: 'Open' },
+    { key: 'critical', label: 'Critical' },
+    { key: 'high', label: 'High' },
+    { key: 'medium', label: 'Medium' },
+    { key: 'low', label: 'Low' },
+    { key: 'unscored', label: 'Unscored' },
+    { key: 'kevFindingCount', label: 'KEV' },
+    { key: 'patchReadyFindingCount', label: 'Patch-ready' },
+  ];
+
   return (
     <div className="space-y-4">
+      <div data-testid="device-vuln-stats" className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:grid-cols-8">
+        {statTiles.map((tile) => (
+          <div key={tile.key} className="rounded-md border bg-card px-3 py-2 text-center">
+            <div className="text-lg font-semibold tabular-nums">{stats[tile.key]}</div>
+            <div className="text-xs text-muted-foreground">{tile.label}</div>
+          </div>
+        ))}
+      </div>
+
       <div className="flex items-center gap-2">
         <label htmlFor="vulnerability-device-status-filter" className="text-sm text-muted-foreground">
           Status
@@ -337,21 +315,7 @@ export function DeviceVulnerabilitiesTab({ deviceId }: DeviceVulnerabilitiesTabP
         </select>
       </div>
 
-      {isOpenFilter && (
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            data-testid="vuln-bulk-remediate"
-            className={`${ACTION_BTN} bg-primary text-primary-foreground hover:bg-primary/90`}
-            disabled={selectedIds.size === 0 || bulkBusy}
-            onClick={() => void onBulkRemediate()}
-          >
-            Remediate selected ({selectedIds.size})
-          </button>
-        </div>
-      )}
-
-      {!loading && items.length === 0 ? (
+      {!loading && groups.length === 0 ? (
         <div data-testid="device-vulnerabilities-empty" className="rounded-md border border-dashed px-4 py-12 text-center text-sm text-muted-foreground">
           {statusFilter === 'open'
             ? 'No open vulnerabilities detected on this device.'
@@ -360,7 +324,93 @@ export function DeviceVulnerabilitiesTab({ deviceId }: DeviceVulnerabilitiesTabP
               : `No ${statusFilter} vulnerabilities on this device.`}
         </div>
       ) : (
-        <ResponsiveTable table={table} cards={cards} />
+        <div className="space-y-2">
+          {groups.map((g) => {
+            const groupFindings = findingsByGroup.get(g.groupKey) ?? [];
+            const isExpanded = expanded.has(g.groupKey);
+            const patchReadyIds = groupPatchReadyIds(g.groupKey);
+            return (
+              <div key={g.groupKey} data-testid={`vuln-group-${g.groupKey}`} className="rounded-md border bg-card">
+                <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+                  <div className="flex min-w-0 items-center gap-3">
+                    <button
+                      type="button"
+                      data-testid={`vuln-group-toggle-${g.groupKey}`}
+                      aria-expanded={isExpanded}
+                      className="rounded-md border px-2 py-1 text-xs font-medium transition hover:bg-muted/60"
+                      onClick={() => toggleExpanded(g.groupKey)}
+                    >
+                      {isExpanded ? 'Hide findings' : 'Show findings'}
+                    </button>
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium">{g.name}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {g.cveCount} CVEs · {groupFindings.length} findings · {g.patchReadyFindingCount} patch-ready
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <SeverityBadge severity={g.worstSeverity} />
+                    <button
+                      type="button"
+                      data-testid={`vuln-group-remediate-${g.groupKey}`}
+                      className={`${ACTION_BTN} bg-primary text-primary-foreground hover:bg-primary/90`}
+                      disabled={patchReadyIds.length === 0 || bulkBusy}
+                      title={patchReadyIds.length === 0 ? 'No patch available' : undefined}
+                      onClick={() => void onRemediateGroup(g.groupKey)}
+                    >
+                      Remediate all
+                    </button>
+                  </div>
+                </div>
+
+                {isExpanded && (
+                  <div className="border-t">
+                    <table className="min-w-full divide-y">
+                      <thead className="bg-muted/40">
+                        <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          <th className="px-4 py-3">CVE</th>
+                          <th className="px-4 py-3">Severity</th>
+                          <th className="px-4 py-3">Status</th>
+                          <th className="px-4 py-3">CVSS</th>
+                          <th className="px-4 py-3">Risk</th>
+                          <th className="px-4 py-3">KEV</th>
+                          <th className="px-4 py-3 text-right">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y">
+                        {groupFindings.map((v) => {
+                          const openFilterAndPatchable = isOpenFilter && v.patchAvailable;
+                          return (
+                            <tr key={v.id} data-testid={`vulnerability-row-${v.id}`} className="transition hover:bg-muted/40">
+                              <td className="px-4 py-3 text-sm font-medium">
+                                {v.cveId}
+                                {openFilterAndPatchable && (
+                                  <span
+                                    data-testid={`patch-available-${v.id}`}
+                                    className="ml-2 inline-flex items-center rounded-full bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-300"
+                                  >
+                                    Patch available
+                                  </span>
+                                )}
+                              </td>
+                              <td className="px-4 py-3 text-sm"><SeverityBadge severity={v.severity} /></td>
+                              <td className="px-4 py-3 text-sm"><StatusBadge status={v.status} /></td>
+                              <td className="px-4 py-3 text-sm tabular-nums">{v.cvssScore === null ? '—' : v.cvssScore.toFixed(1)}</td>
+                              <td className="px-4 py-3 text-sm tabular-nums">{v.riskScore === null ? '—' : Math.round(v.riskScore)}</td>
+                              <td className="px-4 py-3 text-sm">{v.knownExploited ? 'Yes' : '—'}</td>
+                              <td className="px-4 py-3 text-right">{rowActions(v)}</td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
       )}
 
       {modal && (

--- a/apps/web/src/components/devices/DeviceVulnerabilitiesTab.tsx
+++ b/apps/web/src/components/devices/DeviceVulnerabilitiesTab.tsx
@@ -21,6 +21,20 @@ const SEVERITY_BADGES: Record<string, { label: string; className: string }> = {
   low: { label: 'Low', className: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' },
 };
 
+/**
+ * `stats.openTotal` is really "count of findings in the CURRENT status
+ * filter" — the API computes it from the already-status-filtered rows, not
+ * strictly open findings. Label the total tile to match the active filter
+ * instead of hardcoding "Open" so switching filters doesn't mislabel it.
+ */
+const STATUS_TOTAL_LABELS: Record<string, string> = {
+  open: 'Open',
+  all: 'Total',
+  accepted: 'Accepted',
+  mitigated: 'Mitigated',
+  patched: 'Patched',
+};
+
 const STATUS_BADGES: Record<string, { label: string; className: string }> = {
   open: { label: 'Open', className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300' },
   accepted: { label: 'Accepted', className: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300' },
@@ -356,7 +370,7 @@ export function DeviceVulnerabilitiesTab({ deviceId }: DeviceVulnerabilitiesTabP
   }
 
   const statTiles: Array<{ key: keyof DeviceVulnStats; label: string }> = [
-    { key: 'openTotal', label: 'Open' },
+    { key: 'openTotal', label: STATUS_TOTAL_LABELS[statusFilter] ?? 'Total' },
     { key: 'critical', label: 'Critical' },
     { key: 'high', label: 'High' },
     { key: 'medium', label: 'Medium' },

--- a/apps/web/src/components/devices/DeviceVulnerabilitiesTab.tsx
+++ b/apps/web/src/components/devices/DeviceVulnerabilitiesTab.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { ResponsiveTable, DataCard, CardField, CardActions } from '../shared/ResponsiveTable';
 import { handleActionError } from '../../lib/runAction';
 import { usePermissions } from '../../lib/permissions';
 import {
@@ -266,6 +267,86 @@ export function DeviceVulnerabilitiesTab({ deviceId }: DeviceVulnerabilitiesTabP
 
   const isOpenFilter = statusFilter === 'open';
 
+  /**
+   * Desktop table for a single group's drill-down findings. Rendered inside
+   * `ResponsiveTable` alongside `renderGroupCards` so the 7-column layout
+   * (CVE / Severity / Status / CVSS / Risk / KEV / Actions) never silently
+   * clips on a phone the way a bare `<table>` does — see the fleet-wide
+   * `ResponsiveTable` doc comment. Defined as a plain function (not memoized)
+   * since it's invoked once per expanded group during render, not stored.
+   */
+  const renderGroupTable = useCallback(
+    (list: DeviceVulnFinding[]) => (
+      <table className="min-w-full divide-y">
+        <thead className="bg-muted/40">
+          <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <th className="px-4 py-3">CVE</th>
+            <th className="px-4 py-3">Severity</th>
+            <th className="px-4 py-3">Status</th>
+            <th className="px-4 py-3">CVSS</th>
+            <th className="px-4 py-3">Risk</th>
+            <th className="px-4 py-3">KEV</th>
+            <th className="px-4 py-3 text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {list.map((v) => {
+            const openFilterAndPatchable = isOpenFilter && v.patchAvailable;
+            return (
+              <tr key={v.id} data-testid={`vulnerability-row-${v.id}`} className="transition hover:bg-muted/40">
+                <td className="px-4 py-3 text-sm font-medium">
+                  {v.cveId}
+                  {openFilterAndPatchable && (
+                    <span
+                      data-testid={`patch-available-${v.id}`}
+                      className="ml-2 inline-flex items-center rounded-full bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-300"
+                    >
+                      Patch available
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-sm"><SeverityBadge severity={v.severity} /></td>
+                <td className="px-4 py-3 text-sm"><StatusBadge status={v.status} /></td>
+                <td className="px-4 py-3 text-sm tabular-nums">{v.cvssScore === null ? '—' : v.cvssScore.toFixed(1)}</td>
+                <td className="px-4 py-3 text-sm tabular-nums">{v.riskScore === null ? '—' : Math.round(v.riskScore)}</td>
+                <td className="px-4 py-3 text-sm">{v.knownExploited ? 'Yes' : '—'}</td>
+                <td className="px-4 py-3 text-right">{rowActions(v)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    ),
+    [isOpenFilter, rowActions],
+  );
+
+  /** Mobile card fallback for a single group's drill-down findings — mirrors `renderGroupTable`. */
+  const renderGroupCards = useCallback(
+    (list: DeviceVulnFinding[]) =>
+      list.map((v) => {
+        const openFilterAndPatchable = isOpenFilter && v.patchAvailable;
+        return (
+          <DataCard key={v.id}>
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-semibold">{v.cveId}</span>
+              <SeverityBadge severity={v.severity} />
+            </div>
+            <div className="mt-3 space-y-2 border-t pt-3">
+              <CardField label="Status"><StatusBadge status={v.status} /></CardField>
+              <CardField label="CVSS"><span className="text-sm tabular-nums">{v.cvssScore === null ? '—' : v.cvssScore.toFixed(1)}</span></CardField>
+              <CardField label="Risk"><span className="text-sm tabular-nums">{v.riskScore === null ? '—' : Math.round(v.riskScore)}</span></CardField>
+              <CardField label="Known exploited"><span className="text-sm">{v.knownExploited ? 'Yes' : 'No'}</span></CardField>
+              {openFilterAndPatchable && (
+                <CardField label="Patch"><span className="text-sm text-green-700 dark:text-green-300">Available</span></CardField>
+              )}
+            </div>
+            <CardActions className="flex flex-wrap justify-end gap-2">{rowActions(v)}</CardActions>
+          </DataCard>
+        );
+      }),
+    [isOpenFilter, rowActions],
+  );
+
   if (error) {
     return (
       <div data-testid="device-vulnerabilities-error" className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
@@ -365,46 +446,11 @@ export function DeviceVulnerabilitiesTab({ deviceId }: DeviceVulnerabilitiesTabP
                 </div>
 
                 {isExpanded && (
-                  <div className="border-t">
-                    <table className="min-w-full divide-y">
-                      <thead className="bg-muted/40">
-                        <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                          <th className="px-4 py-3">CVE</th>
-                          <th className="px-4 py-3">Severity</th>
-                          <th className="px-4 py-3">Status</th>
-                          <th className="px-4 py-3">CVSS</th>
-                          <th className="px-4 py-3">Risk</th>
-                          <th className="px-4 py-3">KEV</th>
-                          <th className="px-4 py-3 text-right">Actions</th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y">
-                        {groupFindings.map((v) => {
-                          const openFilterAndPatchable = isOpenFilter && v.patchAvailable;
-                          return (
-                            <tr key={v.id} data-testid={`vulnerability-row-${v.id}`} className="transition hover:bg-muted/40">
-                              <td className="px-4 py-3 text-sm font-medium">
-                                {v.cveId}
-                                {openFilterAndPatchable && (
-                                  <span
-                                    data-testid={`patch-available-${v.id}`}
-                                    className="ml-2 inline-flex items-center rounded-full bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-300"
-                                  >
-                                    Patch available
-                                  </span>
-                                )}
-                              </td>
-                              <td className="px-4 py-3 text-sm"><SeverityBadge severity={v.severity} /></td>
-                              <td className="px-4 py-3 text-sm"><StatusBadge status={v.status} /></td>
-                              <td className="px-4 py-3 text-sm tabular-nums">{v.cvssScore === null ? '—' : v.cvssScore.toFixed(1)}</td>
-                              <td className="px-4 py-3 text-sm tabular-nums">{v.riskScore === null ? '—' : Math.round(v.riskScore)}</td>
-                              <td className="px-4 py-3 text-sm">{v.knownExploited ? 'Yes' : '—'}</td>
-                              <td className="px-4 py-3 text-right">{rowActions(v)}</td>
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </table>
+                  <div className="border-t p-3">
+                    <ResponsiveTable
+                      table={renderGroupTable(groupFindings)}
+                      cards={renderGroupCards(groupFindings)}
+                    />
                   </div>
                 )}
               </div>

--- a/apps/web/src/lib/api/vulnerabilities.ts
+++ b/apps/web/src/lib/api/vulnerabilities.ts
@@ -2,6 +2,9 @@ import {
   VULN_SKIP_REASON_LABELS,
   type BulkActionResult,
   type CveCatalogRecord,
+  type DeviceVulnFinding,
+  type DeviceVulnSoftwareResponse,
+  type DeviceVulnStats,
   type FleetVulnStats,
   type GroupFinding,
   type RemediateResult,
@@ -24,6 +27,9 @@ import { runAction } from '../runAction';
 export type {
   BulkActionResult,
   CveCatalogRecord,
+  DeviceVulnFinding,
+  DeviceVulnSoftwareResponse,
+  DeviceVulnStats,
   FleetVulnStats,
   GroupCve,
   GroupFinding,
@@ -116,6 +122,28 @@ export async function fetchDeviceVulnerabilities(
   }
   const body = (await res.json()) as { items?: DeviceVulnerabilityItem[] };
   return { items: body.items ?? [] };
+}
+
+/** Device tab: software-grouped findings + posture stats for one device. */
+export async function fetchDeviceSoftwareGroups(
+  deviceId: string,
+  filters: { status?: string } = {},
+): Promise<DeviceVulnSoftwareResponse> {
+  const res = await fetchWithAuth(
+    `/vulnerabilities/devices/${deviceId}/software${buildVulnQuery({ status: filters.status })}`,
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to load device vulnerabilities (${res.status})`);
+  }
+  const body = (await res.json()) as Partial<DeviceVulnSoftwareResponse>;
+  return {
+    groups: body.groups ?? [],
+    findings: body.findings ?? [],
+    stats: body.stats ?? {
+      openTotal: 0, critical: 0, high: 0, medium: 0, low: 0, unscored: 0,
+      kevFindingCount: 0, patchReadyFindingCount: 0,
+    },
+  };
 }
 
 // ---- Fleet triage: software groups, stats, CVE detail ----

--- a/docs/superpowers/plans/2026-07-06-device-vulnerabilities-tab-reshape.md
+++ b/docs/superpowers/plans/2026-07-06-device-vulnerabilities-tab-reshape.md
@@ -1,0 +1,629 @@
+# Device Vulnerabilities Tab Reshape — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the device details Vulnerabilities tab's flat CVE list with a per-device posture header plus a software-grouped remediation list (CVEs available as a per-group drill-down).
+
+**Architecture:** Reuse the fleet view's tested aggregation (`fetchFleetFindingRows` + `groupFindings`) scoped to one device. A new endpoint `GET /vulnerabilities/devices/:deviceId/software` returns `{ groups, findings, stats }` in one round-trip; the web tab renders a header + expandable groups. No changes to the correlation pipeline or finding data.
+
+**Tech Stack:** Hono + Zod (API), Drizzle (DB), React + Tailwind (web), Vitest (api + web unit), Vitest integration (`vitest.integration.config.ts`), `@breeze/shared` for wire DTOs.
+
+## Global Constraints
+
+- Wire DTOs are single-sourced in `packages/shared/src/types/vulnerability.ts` — api + web both import them; never redefine locally.
+- The new route is **read-only** and tenant-scoped: org isolation via request RLS context; site axis via `assertDeviceSiteAccess` (RLS does NOT enforce sites). Register the route **before** the `/:cveId/devices` catch-all GET (that route's first-segment param shadows static-first-segment routes).
+- Site-axis narrowing is fail-closed: an empty `allowedSiteIds` returns nothing.
+- Follow existing file conventions; keep `DeviceVulnerabilitiesTab.tsx` cohesive (already ~450 lines — do not split it in this plan).
+- Web mutations already go through `runAction` (existing `remediateVuln`) — do not add new silent mutation paths.
+
+---
+
+## File structure
+
+- `packages/shared/src/types/vulnerability.ts` — add `DeviceVulnStats`, add a new `DeviceVulnFinding` (per-finding row + `groupKey`), add `DeviceVulnSoftwareResponse`.
+  - NOTE: the pre-existing `DeviceVulnerabilityItem` lives **web-side** in `apps/web/src/lib/api/vulnerabilities.ts` and backs the OLD `GET /vulnerabilities/devices/:deviceId` endpoint — leave it untouched. The new endpoint uses the new shared `DeviceVulnFinding` (which carries `groupKey`); the reshaped tab consumes `DeviceVulnFinding`, not `DeviceVulnerabilityItem`.
+- `apps/api/src/services/vulnerabilityFleetQueries.ts` — add optional `deviceId` filter to `fetchFleetFindingRows`.
+- `apps/api/src/services/vulnerabilityFleetAggregation.ts` — add pure `computeDeviceStats(rows)`.
+- `apps/api/src/services/vulnerabilityFleetAggregation.test.ts` — unit tests for `computeDeviceStats`.
+- `apps/api/src/routes/vulnerabilities.ts` — new `GET /vulnerabilities/devices/:deviceId/software` route + a `toDeviceFindingItem` mapper.
+- `apps/api/src/routes/vulnerabilities.test.ts` — route test (grouping + site-access gate).
+- `apps/web/src/lib/api/vulnerabilities.ts` — `fetchDeviceSoftwareGroups`, `DeviceVulnerabilityItem.groupKey`, re-export new shared types.
+- `apps/web/src/components/devices/DeviceVulnerabilitiesTab.tsx` — reshape to header + groups + drill-down.
+- `apps/web/src/components/devices/DeviceVulnerabilitiesTab.test.tsx` — update tests.
+
+---
+
+## Task 1: Shared DTOs — `DeviceVulnStats` + device software response
+
+**Files:**
+- Modify: `packages/shared/src/types/vulnerability.ts` (add after `FleetVulnStats`, ~line 255)
+- Test: none (type-only; consumed/tested by later tasks)
+
+**Interfaces:**
+- Produces:
+  - `interface DeviceVulnStats { openTotal; critical; high; medium; low; unscored; kevFindingCount; patchReadyFindingCount }` (all `number`)
+  - `interface DeviceVulnSoftwareResponse { groups: SoftwareGroup[]; findings: DeviceVulnFinding[]; stats: DeviceVulnStats }`
+  - `interface DeviceVulnFinding` — the per-(device,CVE) row with `groupKey` (single-sourced here so api + web share it).
+
+- [ ] **Step 1: Add the types**
+
+In `packages/shared/src/types/vulnerability.ts`, after the `FleetVulnStats` interface, add:
+
+```ts
+/** Per-device severity/KEV/patch summary for the device Vulnerabilities tab header.
+ *  Computed from the device's finding rows under the current status filter. */
+export interface DeviceVulnStats {
+  /** Findings in the current status filter (the "N findings" total). */
+  openTotal: number;
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  /** Severity null/unknown — the majority of real NVD findings. */
+  unscored: number;
+  /** Findings whose CVE is KEV (known exploited). */
+  kevFindingCount: number;
+  /** Open findings whose CVE has a patch available ("fixable now"). */
+  patchReadyFindingCount: number;
+}
+
+/** A per-(device, CVE) finding row for the device tab, tagged with the software
+ *  `groupKey` it rolls up under (buildGroupKey in vulnerabilityFleetAggregation).
+ *  cvssVector is not carried by the fleet query layer, so it is always null here. */
+export interface DeviceVulnFinding {
+  id: string; // device_vulnerabilities id
+  deviceId: string;
+  vulnerabilityId: string;
+  cveId: string;
+  cvssScore: number | null;
+  cvssVector: string | null;
+  severity: VulnSeverity | null;
+  knownExploited: boolean;
+  epssScore: number | null;
+  riskScore: number | null;
+  status: VulnStatus;
+  detectedAt: string;
+  patchAvailable: boolean;
+  /** The SoftwareGroup.groupKey this finding belongs to. */
+  groupKey: string;
+}
+
+/** GET /vulnerabilities/devices/:deviceId/software payload. */
+export interface DeviceVulnSoftwareResponse {
+  groups: SoftwareGroup[];
+  findings: DeviceVulnFinding[];
+  stats: DeviceVulnStats;
+}
+```
+
+- [ ] **Step 2: Verify the barrel re-exports them**
+
+`packages/shared/src/types/vulnerability.ts` is re-exported by `packages/shared/src/index.ts` (or `types/index.ts`). Confirm with:
+
+Run: `grep -rn "vulnerability" packages/shared/src/index.ts packages/shared/src/types/index.ts`
+Expected: a `export * from './types/vulnerability'` (or equivalent) line already exists — no change needed. If missing, add `export * from './vulnerability';` to `packages/shared/src/types/index.ts`.
+
+- [ ] **Step 3: Typecheck shared**
+
+Run: `pnpm --filter @breeze/shared build` (or `pnpm --filter @breeze/shared exec tsc --noEmit`)
+Expected: PASS (no type errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/shared/src/types/vulnerability.ts packages/shared/src/types/index.ts
+git commit -m "feat(shared): add DeviceVulnStats + device software response DTOs"
+```
+
+---
+
+## Task 2: API — device filter on fetch + `computeDeviceStats`
+
+**Files:**
+- Modify: `apps/api/src/services/vulnerabilityFleetQueries.ts:25-43` (add `deviceId` to filter)
+- Modify: `apps/api/src/services/vulnerabilityFleetAggregation.ts` (add `computeDeviceStats`)
+- Test: `apps/api/src/services/vulnerabilityFleetAggregation.test.ts`
+
+**Interfaces:**
+- Consumes: `FleetFindingRow` (`@breeze/shared`), `DeviceVulnStats` (Task 1).
+- Produces:
+  - `fetchFleetFindingRows({ status, allowedSiteIds?, deviceId? })` — new optional `deviceId` narrows to one device.
+  - `computeDeviceStats(rows: FleetFindingRow[]): DeviceVulnStats` — pure; counts reflect whatever rows are passed (endpoint pre-filters by status).
+
+- [ ] **Step 1: Write the failing test for `computeDeviceStats`**
+
+Add to `apps/api/src/services/vulnerabilityFleetAggregation.test.ts` (reuse the file's existing `row(...)` helper — it builds a `FleetFindingRow` with overrides):
+
+```ts
+import { computeDeviceStats } from './vulnerabilityFleetAggregation';
+
+describe('computeDeviceStats', () => {
+  it('counts severity spread, unscored, KEV, and patch-ready', () => {
+    const rows = [
+      row({ deviceVulnerabilityId: 'a', cveId: 'CVE-1', severity: 'critical', knownExploited: true, patchAvailable: true, status: 'open' }),
+      row({ deviceVulnerabilityId: 'b', cveId: 'CVE-2', severity: 'high', patchAvailable: true, status: 'open' }),
+      row({ deviceVulnerabilityId: 'c', cveId: 'CVE-3', severity: 'medium', status: 'open' }),
+      row({ deviceVulnerabilityId: 'd', cveId: 'CVE-4', severity: null, status: 'open' }),
+      row({ deviceVulnerabilityId: 'e', cveId: 'CVE-5', severity: 'low', status: 'open' }),
+    ];
+    expect(computeDeviceStats(rows)).toEqual({
+      openTotal: 5,
+      critical: 1,
+      high: 1,
+      medium: 1,
+      low: 1,
+      unscored: 1,
+      kevFindingCount: 1,
+      patchReadyFindingCount: 2,
+    });
+  });
+
+  it('patchReady counts only OPEN patch-available findings', () => {
+    const rows = [
+      row({ deviceVulnerabilityId: 'a', severity: 'high', patchAvailable: true, status: 'open' }),
+      row({ deviceVulnerabilityId: 'b', severity: 'high', patchAvailable: true, status: 'accepted' }),
+    ];
+    const s = computeDeviceStats(rows);
+    expect(s.patchReadyFindingCount).toBe(1);
+    expect(s.openTotal).toBe(2);
+  });
+});
+```
+
+If the file has no shared `row(...)` helper usable here, copy the one from the `groupFindings` describe block (it constructs a full `FleetFindingRow`). Do not invent new fields.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/vulnerabilityFleetAggregation.test.ts -t computeDeviceStats`
+Expected: FAIL with "computeDeviceStats is not a function" (or import error).
+
+- [ ] **Step 3: Implement `computeDeviceStats`**
+
+In `apps/api/src/services/vulnerabilityFleetAggregation.ts`, after `computeStats`, add:
+
+```ts
+/** Per-device header summary. Counts reflect the rows passed in (the device
+ *  route pre-filters by the selected status). `patchReadyFindingCount` mirrors
+ *  the group/fleet definition: OPEN + patchAvailable. */
+export function computeDeviceStats(rows: FleetFindingRow[]): DeviceVulnStats {
+  let critical = 0, high = 0, medium = 0, low = 0, unscored = 0;
+  let kevFindingCount = 0;
+  let patchReadyFindingCount = 0;
+  for (const r of rows) {
+    switch ((r.severity ?? '').toLowerCase()) {
+      case 'critical': critical += 1; break;
+      case 'high': high += 1; break;
+      case 'medium': medium += 1; break;
+      case 'low': low += 1; break;
+      default: unscored += 1; break;
+    }
+    if (r.knownExploited) kevFindingCount += 1;
+    if (r.patchAvailable && r.status === 'open') patchReadyFindingCount += 1;
+  }
+  return {
+    openTotal: rows.length,
+    critical, high, medium, low, unscored,
+    kevFindingCount,
+    patchReadyFindingCount,
+  };
+}
+```
+
+Add `DeviceVulnStats` to the `import type { ... } from '@breeze/shared'` block at the top of the file.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/vulnerabilityFleetAggregation.test.ts -t computeDeviceStats`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Add `deviceId` filter to `fetchFleetFindingRows`**
+
+In `apps/api/src/services/vulnerabilityFleetQueries.ts`, change the filter signature and add the condition:
+
+```ts
+export async function fetchFleetFindingRows(filters: {
+  status: string;
+  /** Site-axis narrowing; empty array = fail closed (return nothing). */
+  allowedSiteIds?: string[];
+  /** When set, narrow to a single device (device tab). */
+  deviceId?: string;
+}): Promise<FleetFindingRow[]> {
+  const conditions: SQL[] = [];
+  if (filters.status !== 'all') {
+    conditions.push(eq(deviceVulnerabilities.status, filters.status));
+  }
+  if (filters.deviceId) {
+    conditions.push(eq(deviceVulnerabilities.deviceId, filters.deviceId));
+  }
+  if (filters.allowedSiteIds !== undefined) {
+    // ...unchanged...
+```
+
+(Only add the `deviceId` field to the type and the two lines pushing the condition; leave everything below untouched.)
+
+- [ ] **Step 6: Typecheck + run the aggregation test file**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/vulnerabilityFleetAggregation.test.ts`
+Expected: PASS (all existing + new cases).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/vulnerabilityFleetQueries.ts apps/api/src/services/vulnerabilityFleetAggregation.ts apps/api/src/services/vulnerabilityFleetAggregation.test.ts
+git commit -m "feat(api): computeDeviceStats + device filter on fetchFleetFindingRows"
+```
+
+---
+
+## Task 3: API — `GET /vulnerabilities/devices/:deviceId/software`
+
+**Files:**
+- Modify: `apps/api/src/routes/vulnerabilities.ts` (new route + mapper; imports)
+- Test: `apps/api/src/routes/vulnerabilities.test.ts`
+
+**Interfaces:**
+- Consumes: `fetchFleetFindingRows` (Task 2, with `deviceId`), `groupFindings`, `computeDeviceStats` (Task 2), `buildGroupKey` (existing), `assertDeviceSiteAccess` (existing), `deviceParamSchema` + `listQuerySchema` (existing), `DeviceVulnFinding` / `DeviceVulnSoftwareResponse` (Task 1).
+- Produces: `GET /vulnerabilities/devices/:deviceId/software?status=` → `DeviceVulnSoftwareResponse`.
+
+- [ ] **Step 1: Write the failing route test**
+
+Add a new `describe` block to `apps/api/src/routes/vulnerabilities.test.ts` using the file's **existing** helpers: `app()` (mounts `vulnerabilityRoutes`), the `fleetRow(overrides)` factory, `vi.mocked(fetchFleetFindingRows)`, `vi.mocked(db.select)`, the mutable `granted` set, and `ID`. The `assertDeviceSiteAccess` gate issues one `db.select().from(devices).where(...).limit(1)` — mock that first `select` to return a device row (auth mock's `canAccessSite` is `() => true`, so any siteId passes). Cross-tenant/unknown devices fall through the default `db.select` mock (`.limit()` → `[]`) → 404, which is the isolation behavior.
+
+```ts
+describe('GET /vulnerabilities/devices/:deviceId/software', () => {
+  beforeEach(() => {
+    granted.clear();
+    granted.add('devices:read');
+    delete permissionsState.allowedSiteIds;
+    vi.mocked(db.select).mockReset();
+    vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);
+  });
+
+  it('groups a device’s findings by software and returns stats + tagged findings', async () => {
+    // assertDeviceSiteAccess: device lookup returns a row (site accessible).
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ siteId: 'site-1' }]) }),
+      }),
+    } as never);
+    vi.mocked(fetchFleetFindingRows).mockResolvedValue([
+      fleetRow({ deviceVulnerabilityId: 'a', deviceId: ID, cveId: 'CVE-1', softwareInventoryId: 'sw1', softwareName: 'Google Chrome', softwareVendor: '', severity: 'critical', patchAvailable: true, status: 'open' }),
+      fleetRow({ deviceVulnerabilityId: 'b', deviceId: ID, cveId: 'CVE-2', softwareInventoryId: 'sw1', softwareName: 'Google Chrome', softwareVendor: '', severity: 'medium', patchAvailable: true, knownExploited: false, status: 'open' }),
+      fleetRow({ deviceVulnerabilityId: 'c', deviceId: ID, cveId: 'CVE-3', softwareInventoryId: null, deviceOsType: 'windows', severity: 'high', patchAvailable: false, knownExploited: false, status: 'open' }),
+    ]);
+
+    const res = await app().request(`/vulnerabilities/devices/${ID}/software?status=open`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.groups).toHaveLength(2); // Chrome + Windows OS
+    const chrome = body.groups.find((g: any) => g.name === 'Google Chrome');
+    expect(chrome.cveCount).toBe(2);
+    expect(chrome.patchReadyFindingCount).toBe(2);
+    expect(body.stats.openTotal).toBe(3);
+    expect(body.stats.critical).toBe(1);
+    expect(body.stats.patchReadyFindingCount).toBe(2);
+    expect(body.findings.every((f: any) => typeof f.groupKey === 'string')).toBe(true);
+    // fetchFleetFindingRows was called with the deviceId narrow.
+    expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith(expect.objectContaining({ deviceId: ID, status: 'open' }));
+  });
+
+  it('404s when the device is not in the caller’s tenant/site scope', async () => {
+    // Default db.select mock: .limit() resolves [] → device not found.
+    const res = await app().request(`/vulnerabilities/devices/${ID}/software`);
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/vulnerabilities.test.ts -t "software"`
+Expected: FAIL with 404 (route not registered) or assertion errors.
+
+- [ ] **Step 3: Add the mapper + route**
+
+In `apps/api/src/routes/vulnerabilities.ts`:
+
+Add `computeDeviceStats` to the import from `../services/vulnerabilityFleetAggregation` and `buildGroupKey` (it's exported there). Add `DeviceVulnFinding` to the `@breeze/shared` type import.
+
+Add a mapper near the other helpers:
+
+```ts
+function toDeviceFindingItem(r: FleetFindingRow): DeviceVulnFinding {
+  return {
+    id: r.deviceVulnerabilityId,
+    deviceId: r.deviceId,
+    vulnerabilityId: r.vulnerabilityId,
+    cveId: r.cveId,
+    cvssScore: r.cvssScore,
+    cvssVector: null, // fleet query layer does not carry the vector
+    severity: r.severity,
+    knownExploited: r.knownExploited,
+    epssScore: r.epssScore,
+    riskScore: r.riskScore,
+    status: r.status,
+    detectedAt: r.detectedAt,
+    patchAvailable: r.patchAvailable,
+    groupKey: buildGroupKey(r),
+  };
+}
+```
+
+Register the route **immediately after** the existing `GET /devices/:deviceId` route (line ~632), so it stays above the `/:cveId/devices` catch-all:
+
+```ts
+vulnerabilityRoutes.get(
+  '/devices/:deviceId/software',
+  zValidator('param', deviceParamSchema),
+  zValidator('query', listQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const { deviceId } = c.req.valid('param');
+    const { status } = c.req.valid('query');
+    // Intra-org site gate (RLS isolates orgs, not sites).
+    const access = await assertDeviceSiteAccess(deviceId, auth);
+    if (!access.ok) {
+      return c.json({ error: access.error }, access.status);
+    }
+    const rows = await fetchFleetFindingRows({
+      status,
+      deviceId,
+      allowedSiteIds: perms?.allowedSiteIds,
+    });
+    return c.json({
+      groups: groupFindings(rows),
+      findings: rows.map(toDeviceFindingItem),
+      stats: computeDeviceStats(rows),
+    });
+  },
+);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/vulnerabilities.test.ts -t "software"`
+Expected: PASS (both new cases).
+
+- [ ] **Step 5: Run the full route test file (regression)**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/vulnerabilities.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/vulnerabilities.ts apps/api/src/routes/vulnerabilities.test.ts
+git commit -m "feat(api): device-scoped software-groups endpoint for vuln tab"
+```
+
+---
+
+## Task 4: Web — API client `fetchDeviceSoftwareGroups`
+
+**Files:**
+- Modify: `apps/web/src/lib/api/vulnerabilities.ts`
+- Test: none new (covered via the component test in Task 5; this is a thin wrapper mirroring `fetchDeviceVulnerabilities`)
+
+**Interfaces:**
+- Consumes: `DeviceVulnSoftwareResponse`, `SoftwareGroup`, `DeviceVulnFinding` (Task 1, from `@breeze/shared`).
+- Produces: `fetchDeviceSoftwareGroups(deviceId, { status }): Promise<DeviceVulnSoftwareResponse>`.
+
+- [ ] **Step 1: Re-export new shared types + add the fetch**
+
+In `apps/web/src/lib/api/vulnerabilities.ts`, add `DeviceVulnStats`, `DeviceVulnFinding`, `DeviceVulnSoftwareResponse` to the `export type { ... } from '@breeze/shared'` block. Then add, next to `fetchDeviceVulnerabilities`:
+
+```ts
+/** Device tab: software-grouped findings + posture stats for one device. */
+export async function fetchDeviceSoftwareGroups(
+  deviceId: string,
+  filters: { status?: string } = {},
+): Promise<DeviceVulnSoftwareResponse> {
+  const res = await fetchWithAuth(
+    `/vulnerabilities/devices/${deviceId}/software${buildVulnQuery({ status: filters.status })}`,
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to load device vulnerabilities (${res.status})`);
+  }
+  const body = (await res.json()) as Partial<DeviceVulnSoftwareResponse>;
+  return {
+    groups: body.groups ?? [],
+    findings: body.findings ?? [],
+    stats: body.stats ?? {
+      openTotal: 0, critical: 0, high: 0, medium: 0, low: 0, unscored: 0,
+      kevFindingCount: 0, patchReadyFindingCount: 0,
+    },
+  };
+}
+```
+
+Import `DeviceVulnSoftwareResponse` at the top's `@breeze/shared` value/type import as needed.
+
+- [ ] **Step 2: Typecheck web**
+
+Run: `pnpm --filter @breeze/web exec tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/api/vulnerabilities.ts
+git commit -m "feat(web): fetchDeviceSoftwareGroups client"
+```
+
+---
+
+## Task 5: Web — reshape `DeviceVulnerabilitiesTab`
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceVulnerabilitiesTab.tsx`
+- Test: `apps/web/src/components/devices/DeviceVulnerabilitiesTab.test.tsx`
+
+**Interfaces:**
+- Consumes: `fetchDeviceSoftwareGroups` (Task 4), `remediateVuln`, `acceptVulnRisk`, `mitigateVuln`, `reopenVuln` (existing), `SoftwareGroup` / `DeviceVulnFinding` / `DeviceVulnStats`.
+- Produces: reshaped device Vulnerabilities tab (no new exports).
+
+**Behavior spec:**
+- Header: tiles for Open total, Critical, High, Medium, Low, Unscored, KEV, Patch-ready — from `stats`. `data-testid="device-vuln-stats"`.
+- Group list: one row per `SoftwareGroup` (already sorted by the server), showing `name`, `cveCount` (as "N CVEs") + finding count, `worstSeverity` badge, `patchReadyFindingCount`, and a `[Remediate all]` button. Row `data-testid={`vuln-group-${g.groupKey}`}`.
+- Expand: clicking a group toggles a drill-down listing that group's findings (bucketed from `findings` by `groupKey`), reusing the existing per-finding row rendering + actions (Remediate / Accept risk / Mitigate / Reopen). Expand toggle `data-testid={`vuln-group-toggle-${g.groupKey}`}`.
+- "Remediate all": posts `remediateVuln(patchReadyOpenIds)` where ids = findings in the group with `status==='open' && patchAvailable`. Disabled when that set is empty (tooltip "No patch available"). `data-testid={`vuln-group-remediate-${g.groupKey}`}`.
+- Status filter, loading, error, and clean-vs-never-scanned empty states preserved.
+
+- [ ] **Step 1: Write failing component tests**
+
+Rewrite the data-fetch mock in `DeviceVulnerabilitiesTab.test.tsx` to stub `fetchDeviceSoftwareGroups` (instead of `fetchDeviceVulnerabilities`). Use an explicit fixture so `groupKey` testids are stable — Chrome group key is `sw:google chrome|` (empty vendor), OS group key is `os:windows`:
+
+```ts
+const RESPONSE = {
+  stats: { openTotal: 3, critical: 1, high: 1, medium: 1, low: 0, unscored: 0, kevFindingCount: 1, patchReadyFindingCount: 2 },
+  groups: [
+    { groupKey: 'sw:google chrome|', kind: 'software', name: 'Google Chrome', vendor: null, versions: ['126.0'], deviceCount: 1, cveCount: 2, cveIds: ['CVE-1', 'CVE-2'], worstSeverity: 'critical', maxRiskScore: 90, kevCveCount: 1, maxEpss: 0.4, patchReadyFindingCount: 2, patchReadyDeviceCount: 1, tickets: [] },
+    { groupKey: 'os:windows', kind: 'os', name: 'Windows OS updates', vendor: null, versions: [], deviceCount: 1, cveCount: 1, cveIds: ['CVE-3'], worstSeverity: 'high', maxRiskScore: 70, kevCveCount: 0, maxEpss: null, patchReadyFindingCount: 0, patchReadyDeviceCount: 0, tickets: [] },
+  ],
+  findings: [
+    { id: 'a', deviceId: 'd1', vulnerabilityId: 'v1', cveId: 'CVE-1', cvssScore: 9.1, cvssVector: null, severity: 'critical', knownExploited: true, epssScore: 0.4, riskScore: 90, status: 'open', detectedAt: '2026-06-01T00:00:00.000Z', patchAvailable: true, groupKey: 'sw:google chrome|' },
+    { id: 'b', deviceId: 'd1', vulnerabilityId: 'v2', cveId: 'CVE-2', cvssScore: 5.0, cvssVector: null, severity: 'medium', knownExploited: false, epssScore: null, riskScore: 40, status: 'open', detectedAt: '2026-06-01T00:00:00.000Z', patchAvailable: true, groupKey: 'sw:google chrome|' },
+    { id: 'c', deviceId: 'd1', vulnerabilityId: 'v3', cveId: 'CVE-3', cvssScore: 7.0, cvssVector: null, severity: 'high', knownExploited: false, epssScore: null, riskScore: 70, status: 'open', detectedAt: '2026-06-01T00:00:00.000Z', patchAvailable: false, groupKey: 'os:windows' },
+  ],
+};
+// vi.mock('../../lib/api/vulnerabilities') — fetchDeviceSoftwareGroups resolves RESPONSE;
+// keep remediateVuln/acceptVulnRisk/mitigateVuln/reopenVuln as vi.fn() mocks.
+```
+
+Then add:
+
+```ts
+// mock returns: Chrome group (2 open patch-ready findings) + OS group (1 finding, no patch)
+it('renders the posture header from stats', async () => {
+  render(<DeviceVulnerabilitiesTab deviceId="d1" />);
+  const header = await screen.findByTestId('device-vuln-stats');
+  expect(header).toHaveTextContent('1'); // critical count etc.
+  expect(header).toHaveTextContent(/Critical/i);
+});
+
+it('renders one row per software group, not per CVE', async () => {
+  render(<DeviceVulnerabilitiesTab deviceId="d1" />);
+  expect(await screen.findByTestId('vuln-group-sw:google chrome|')).toBeInTheDocument();
+  expect(screen.getByTestId('vuln-group-os:windows')).toBeInTheDocument();
+});
+
+it('expands a group to reveal its CVE findings', async () => {
+  render(<DeviceVulnerabilitiesTab deviceId="d1" />);
+  const toggle = await screen.findByTestId('vuln-group-toggle-sw:google chrome|');
+  fireEvent.click(toggle);
+  expect(await screen.findByText('CVE-1')).toBeInTheDocument();
+  expect(screen.getByText('CVE-2')).toBeInTheDocument();
+});
+
+it('Remediate all posts the group patch-ready open finding ids', async () => {
+  const remediate = vi.mocked(remediateVuln).mockResolvedValue({ scheduled: 2, skipped: [] });
+  render(<DeviceVulnerabilitiesTab deviceId="d1" />);
+  fireEvent.click(await screen.findByTestId('vuln-group-remediate-sw:google chrome|'));
+  await waitFor(() => expect(remediate).toHaveBeenCalledWith(['a', 'b']));
+});
+
+it('disables Remediate all when the group has no patch-ready findings', async () => {
+  render(<DeviceVulnerabilitiesTab deviceId="d1" />);
+  const btn = await screen.findByTestId('vuln-group-remediate-os:windows');
+  expect(btn).toBeDisabled();
+});
+```
+
+Keep/adapt the existing status-filter, empty-state, and per-finding-action tests to the new structure (per-finding action buttons now live inside an expanded group — expand first, then assert).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceVulnerabilitiesTab.test.tsx`
+Expected: FAIL (header/group testids not found; still calling old fetch).
+
+- [ ] **Step 3: Reshape the component**
+
+Rewrite `DeviceVulnerabilitiesTab.tsx`:
+
+1. State: replace `items` with `groups: SoftwareGroup[]`, `findings: DeviceVulnFinding[]`, `stats: DeviceVulnStats`, plus `expanded: Set<string>` (group keys). Keep `statusFilter`, `busyId`, `modal`, error/loading.
+2. `load()` calls `fetchDeviceSoftwareGroups(deviceId, { status: statusFilter })` and sets the three pieces.
+3. Add a `findingsByGroup = useMemo(() => groupBy(findings, f => f.groupKey))` map.
+4. Header: render `stats` as a tile row with `data-testid="device-vuln-stats"`. Suggested tiles (label + count): Open (`openTotal`), Critical, High, Medium, Low, Unscored, KEV (`kevFindingCount`), Patch-ready (`patchReadyFindingCount`). Reuse the severity color classes already in `SEVERITY_BADGES`.
+5. Group list: map `groups` to rows (`data-testid={`vuln-group-${g.groupKey}`}`), each with name, `${g.cveCount} CVEs`, `SeverityBadge severity={g.worstSeverity}`, `${g.patchReadyFindingCount} patch-ready`, an expand toggle button (`vuln-group-toggle-${g.groupKey}`), and `[Remediate all]` (`vuln-group-remediate-${g.groupKey}`).
+6. Group remediate handler:
+
+```ts
+const groupPatchReadyIds = useCallback(
+  (groupKey: string) =>
+    (findingsByGroup.get(groupKey) ?? [])
+      .filter((f) => f.status === 'open' && f.patchAvailable)
+      .map((f) => f.id),
+  [findingsByGroup],
+);
+
+const onRemediateGroup = useCallback(async (groupKey: string) => {
+  const ids = groupPatchReadyIds(groupKey);
+  if (ids.length === 0 || bulkBusy) return;
+  setBulkBusy(true);
+  try {
+    await remediateVuln(ids);
+    await load();
+  } catch (err) {
+    handleActionError(err, 'Failed to schedule remediation');
+  } finally {
+    setBulkBusy(false);
+  }
+}, [groupPatchReadyIds, bulkBusy, load]);
+```
+
+7. When a group is expanded, render its findings using the existing per-finding row markup (CVE id, `SeverityBadge`, CVSS, risk, KEV, patch badge) and the existing `rowActions(finding)` (Remediate/Accept/Mitigate/Reopen) — keep that helper, retyped to `DeviceVulnFinding`.
+8. Keep the `VulnActionModal` and its submit wiring unchanged (still keyed by finding `id` + `cveId`).
+9. Preserve error UI and the empty state: show the "clean vs never-scanned" copy when `groups.length === 0` (use `stats.openTotal`/total to distinguish, matching current wording).
+
+Add a tiny local `groupBy` helper (or inline the reduce) — do not add a dependency.
+
+- [ ] **Step 4: Run the component tests to verify they pass**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceVulnerabilitiesTab.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck web**
+
+Run: `pnpm --filter @breeze/web exec tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/devices/DeviceVulnerabilitiesTab.tsx apps/web/src/components/devices/DeviceVulnerabilitiesTab.test.tsx
+git commit -m "feat(web): reshape device vulnerabilities tab into posture header + software groups"
+```
+
+---
+
+## Task 6: Verify end-to-end + cleanup
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Run the touched test suites**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/vulnerabilityFleetAggregation.test.ts src/routes/vulnerabilities.test.ts && pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceVulnerabilitiesTab.test.tsx`
+Expected: all PASS.
+
+- [ ] **Step 2: Typecheck both packages**
+
+Run: `pnpm --filter @breeze/shared exec tsc --noEmit && pnpm --filter @breeze/api exec tsc --noEmit && pnpm --filter @breeze/web exec tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Confirm the old `GET /vulnerabilities/devices/:deviceId` route + `listVulnerabilities` are still referenced or intentionally left**
+
+Run: `grep -rn "fetchDeviceVulnerabilities\|/devices/:deviceId'" apps/web/src apps/api/src`
+Expected: the old device-findings endpoint is no longer called by the tab. Decide: leave it (still used by any other caller / API consumers) — do NOT delete in this PR unless grep shows zero consumers. If zero web consumers remain, note it for a follow-up rather than removing here (avoid scope creep + external API-consumer breakage).
+
+- [ ] **Step 4: Manual smoke (optional, if a stack is running)**
+
+Load a device with many findings; confirm the header shows the real severity spread and the group list collapses the CVE wall (e.g. one "Google Chrome" row with a large CVE count), expand works, and "Remediate all" is disabled for no-patch groups.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** posture header → Task 1 (`DeviceVulnStats`) + Task 2 (`computeDeviceStats`) + Task 5 (render); software groups → Task 3 (endpoint) + Task 5 (render); drill-down without 2nd round-trip → Task 3 (`findings[]` + `groupKey`) + Task 5 (`findingsByGroup`); Remediate-all → Task 5; site access → Task 3; status filter/empty/error preserved → Task 5. MSRC-sync + comparator explicitly out of scope (no task) per spec.
+- **Type consistency:** `computeDeviceStats`, `fetchDeviceSoftwareGroups`, `DeviceVulnStats`, `DeviceVulnFinding`, `DeviceVulnSoftwareResponse`, `toDeviceFindingItem`, `buildGroupKey` used consistently across tasks.
+- **Known nuance:** `DeviceVulnFinding.cvssVector` is always `null` (fleet query layer doesn't carry it) — the tab does not render the vector, so this is not a UI regression. Documented in Task 1.

--- a/docs/superpowers/specs/2026-07-06-device-vulnerabilities-tab-reshape-design.md
+++ b/docs/superpowers/specs/2026-07-06-device-vulnerabilities-tab-reshape-design.md
@@ -1,0 +1,166 @@
+# Device Vulnerabilities tab reshape — design
+
+**Date:** 2026-07-06
+**Status:** Approved (design), pending implementation plan
+**Area:** `apps/web` (device details), `apps/api` (vulnerabilities routes/services), `packages/shared`
+
+## Problem
+
+The device details **Vulnerabilities** tab (`apps/web/src/components/devices/DeviceVulnerabilitiesTab.tsx`)
+renders a flat, risk-score-desc-sorted, one-row-per-CVE table. On a real device this
+degenerates into a wall of near-identical rows: e.g. a device ~4 Chrome release-trains
+behind shows ~400 Chrome CVEs, the top of which all read "Critical / CVSS 9.6", because
+the risk-desc sort stacks the worst CVEs first and truncates the perceived variety.
+
+The result hides the two things a technician actually needs:
+
+1. **The shape of the problem** — how many findings, and the real severity spread
+   (most of those 400 are unscored/medium, not critical).
+2. **The remediation action** — nearly all of those findings collapse into a single
+   fix ("update Google Chrome"), which the CVE list never surfaces.
+
+This is a UI/presentation problem. The underlying finding data is correct (verified
+against NVD at source; see the "Related / out of scope" section).
+
+## Goal
+
+Replace the flat CVE list as the *front door* with:
+
+1. A **posture header** summarizing the device's findings.
+2. A **software-grouped remediation list** (one row per software product / OS), with the
+   CVE detail available as a per-group drill-down.
+
+No finding information is lost — the CVE-level view becomes an expand instead of the
+default.
+
+## Prior art we reuse
+
+The **fleet** vulnerabilities view already solved this exact modeling problem:
+
+- `apps/api/src/services/vulnerabilityFleetQueries.ts` — `fetchFleetFindingRows()` returns
+  `FleetFindingRow[]`, each carrying `softwareName / softwareVendor / softwareVersion`,
+  `deviceOsType`, severity, CVSS, EPSS, KEV, `patchAvailable`, status, riskScore.
+- `apps/api/src/services/vulnerabilityFleetAggregation.ts` — `groupFindings()` /
+  `buildGroupKey()` / `summarizeGroup()` fold those rows into `SoftwareGroup[]`
+  (`packages/shared/src/types/vulnerability.ts`): `groupKey`, `kind: 'software' | 'os'`,
+  `name`, `vendor`, `versions[]`, `deviceCount`, `cveCount`, `cveIds[]`, `worstSeverity`,
+  `maxRiskScore`, `kevCveCount`, `maxEpss`, `patchReadyFindingCount`,
+  `patchReadyDeviceCount`, `tickets[]`.
+
+The device tab simply never adopted this model. We bring it down to a single device.
+
+## Design
+
+### A. Data source — server-side, device-scoped (Approach A, chosen)
+
+Add a `deviceId` filter to the fleet finding fetch and expose a device-scoped
+software-groups endpoint, reusing the tested aggregation.
+
+- **`fetchFleetFindingRows(filters)`** (`vulnerabilityFleetQueries.ts`): add optional
+  `deviceId?: string`. When set, add `eq(deviceVulnerabilities.deviceId, deviceId)` to the
+  finding `conditions`. Everything downstream (device/org/software/catalog joins, mapping)
+  is unchanged.
+- **New route** `GET /vulnerabilities/devices/:deviceId/software`
+  (`apps/api/src/routes/vulnerabilities.ts`):
+  - Same param + site-access gate as the existing `GET /vulnerabilities/devices/:deviceId`
+    (`assertDeviceSiteAccess`), and the same `status` query param (`listQuerySchema` or a
+    focused schema).
+  - `rows = fetchFleetFindingRows({ status, deviceId, allowedSiteIds: perms?.allowedSiteIds })`.
+  - `groups = groupFindings(rows)` (already severity-then-count ordered; confirm/normalize
+    sort in the aggregation helper if needed).
+  - `stats = computeDeviceStats(rows)` (see B).
+  - Also map `rows` to the flat `DeviceVulnerabilityItem[]` (with `groupKey`) for the
+    drill-down — see section C.
+  - Register it **before** the `/:cveId/devices` catch-all GET (that route shadows
+    static-first-segment routes), and alongside the other device GET so route ordering is
+    obvious.
+  - Returns `{ groups: SoftwareGroup[], findings: DeviceVulnerabilityItem[], stats: DeviceVulnStats }`.
+
+Rationale vs. Approach B (fatten `DeviceVulnerabilityItem` + group in React): A keeps one
+tested aggregation path, keeps the device and fleet views coherent, and yields the header
+stats from the same rows for free. B duplicates grouping/severity-rollup logic and risks
+drift.
+
+### B. Posture header — `DeviceVulnStats`
+
+New shared type (`packages/shared/src/types/vulnerability.ts`), computed **per device from
+the same finding rows** (NOT the fleet-wide `/stats` endpoint):
+
+```ts
+export interface DeviceVulnStats {
+  openTotal: number;          // findings in the current status filter
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  unscored: number;           // severity null/unknown — the majority in practice
+  kevFindingCount: number;    // findings whose CVE is KEV
+  patchReadyFindingCount: number;
+}
+```
+
+A pure `computeDeviceStats(rows: FleetFindingRow[]): DeviceVulnStats` helper (unit-tested)
+lives next to `groupFindings`. Rendered as a compact tile/badge row above the group list.
+The counts reflect the selected status filter (rows are already status-filtered by the
+endpoint).
+
+### C. Group list + drill-down (web)
+
+`DeviceVulnerabilitiesTab.tsx`:
+
+- Fetch from the new endpoint via a new `fetchDeviceSoftwareGroups(deviceId, { status })`
+  in `apps/web/src/lib/api/vulnerabilities.ts`.
+- Render the header (B) + a list of group rows sorted worst-severity then finding count:
+  `name` (OS groups show the OS pseudo-name), finding count, worst-severity badge,
+  patch-ready count, `[Remediate all]`.
+- Each group row is **expandable**. On expand, show that group's CVE findings — reusing the
+  current row rendering (CVE id, severity, CVSS, risk, KEV, patch-available badge) and the
+  existing per-finding actions (Remediate / Accept risk / Mitigate / Reopen).
+  - **No second round-trip:** the endpoint returns the flat per-device findings alongside the
+    groups — `{ groups: SoftwareGroup[], findings: DeviceVulnerabilityItem[], stats }` — and
+    each finding carries its `groupKey` (added to `DeviceVulnerabilityItem`) so the web layer
+    buckets findings under their group locally on expand. This keeps the existing
+    `DeviceVulnerabilityItem` shape (and its per-finding action wiring) intact rather than
+    introducing a new drill-down type.
+
+### D. Actions
+
+- **Remediate all (group):** reuse `remediateVuln(deviceVulnerabilityIds)` with the group's
+  **patch-ready open** finding IDs. Disabled with an explanatory tooltip when
+  `patchReadyFindingCount === 0` (e.g. Chrome CVEs carry no NVD patch object — remediation
+  is a version bump, not a one-click patch), matching today's per-row disable behavior.
+- **Per-finding actions** unchanged inside the drill-down, including the Accept-risk /
+  Mitigate modal and Reopen.
+- Bulk "remediate selected" semantics remain Open-status-only.
+
+### E. Status filter, empty/loading/error
+
+- Keep the Open / Accepted / Mitigated / Patched / All selector. Header + groups both
+  recompute for the selected status (endpoint re-queries).
+- Preserve loading, error, and the empty-state wording that distinguishes a **clean**
+  device from a **never-scanned** one.
+
+## Testing
+
+- **Unit (api):** `computeDeviceStats` (severity spread incl. unscored, KEV, patch-ready);
+  `fetchFleetFindingRows` device filter narrows rows; `groupFindings` ordering.
+- **Route/integration (api):** `GET /vulnerabilities/devices/:deviceId/software` groups a
+  seeded device's findings, computes stats, and enforces `assertDeviceSiteAccess`
+  (cross-site denied).
+- **Web:** update `DeviceVulnerabilitiesTab.test.tsx` — header renders counts, group rows
+  render + expand/collapse reveals CVEs, "Remediate all" posts the group's patch-ready IDs
+  and disables at zero.
+
+## Related / out of scope
+
+From the 2026-07-06 prod investigation of the "5000 Chrome CVEs" scare
+(`vuln_findings_count_real_nvd_not_seed_and_msrc_poison`):
+
+- **MSRC sync is broken in prod** — a malformed upstream `cveId` (> `varchar(32)`) fails the
+  whole MSRC batch upsert, staling Windows/Office CVE data. This is a **data-ingestion bug**,
+  tracked separately; this UI reshape neither fixes nor depends on it.
+- The version comparator was investigated and found **correct** (findings are real). No
+  change here.
+- **Not in this scope:** an explicit "update to exact fixed version X" remediation target on
+  the group row. `SoftwareGroup` does not carry fixed-build data; this is a possible fast
+  follow, not part of this design.

--- a/packages/shared/src/types/vulnerability.ts
+++ b/packages/shared/src/types/vulnerability.ts
@@ -254,6 +254,51 @@ export interface FleetVulnStats {
   lastDetectedAt: string | null;
 }
 
+/** Per-device severity/KEV/patch summary for the device Vulnerabilities tab header.
+ *  Computed from the device's finding rows under the current status filter. */
+export interface DeviceVulnStats {
+  /** Findings in the current status filter (the "N findings" total). */
+  openTotal: number;
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  /** Severity null/unknown — the majority of real NVD findings. */
+  unscored: number;
+  /** Findings whose CVE is KEV (known exploited). */
+  kevFindingCount: number;
+  /** Open findings whose CVE has a patch available ("fixable now"). */
+  patchReadyFindingCount: number;
+}
+
+/** A per-(device, CVE) finding row for the device tab, tagged with the software
+ *  `groupKey` it rolls up under (buildGroupKey in vulnerabilityFleetAggregation).
+ *  cvssVector is not carried by the fleet query layer, so it is always null here. */
+export interface DeviceVulnFinding {
+  id: string; // device_vulnerabilities id
+  deviceId: string;
+  vulnerabilityId: string;
+  cveId: string;
+  cvssScore: number | null;
+  cvssVector: string | null;
+  severity: VulnSeverity | null;
+  knownExploited: boolean;
+  epssScore: number | null;
+  riskScore: number | null;
+  status: VulnStatus;
+  detectedAt: string;
+  patchAvailable: boolean;
+  /** The SoftwareGroup.groupKey this finding belongs to. */
+  groupKey: string;
+}
+
+/** GET /vulnerabilities/devices/:deviceId/software payload. */
+export interface DeviceVulnSoftwareResponse {
+  groups: SoftwareGroup[];
+  findings: DeviceVulnFinding[];
+  stats: DeviceVulnStats;
+}
+
 /**
  * A single reference from the CVE catalog. The `vulnerabilities.references`
  * jsonb column is source-dependent: some feeds store bare URL strings, others


### PR DESCRIPTION
## Problem

Third-party (winget / Homebrew / Chocolatey) patching is **impossible to enable through the UI** on `main`.

`#1428` (`3fe86ca42`) removed the **Patch Sources** control from the config-policy Patch tab, intending sources to "live on Update Rings only." But:
- The Update Ring has no sources UI, and its `sources` column is **never read** by the approval evaluator.
- The value the evaluator actually reads is the policy's own `settings.sources` (`config_policy_patch_settings.sources`), which was left stranded at its default `['os']` with no control to change it.

Result — with `sources = ['os']`:
- `buildAllowedPatchSources(['os'])` excludes every third-party source, so third-party patches are dropped at the `patchApprovalEvaluator` source pre-filter **before** category rules, app rules, or ring auto-approve run.
- Per-app pin/block rules can't rescue them (the source filter runs first).
- Ring auto-approve of third-party apps can't fire either — the severity exemption needs `'third_party'` literally in `sources`.

## Fix

Restore a single **"Include third-party software updates"** switch in the Patch tab that writes `settings.sources` (`['os']` ⇄ `['os','third_party']`). OS stays always-on to satisfy the schema's `min(1)` sources constraint. Approval *rules* correctly stay on Update Rings — only the source-scope control returns here.

The field is already fully plumbed server-side (`patchJobSnapshot` → `patchJobExecutor` → `patchApprovalEvaluator`); this only reconnects the missing UI writer.

## Verification

- **Unit:** 13/13 `PatchTab.test.tsx` pass (added 3 cases for render/persist/hydrate; replaced the now-incorrect "does not render the Patch Sources section" assertion). Typecheck + lint clean.
- **Live (seeded stack):** created a policy → toggled on → Save → reloaded, toggle hydrated back on → confirmed in Postgres: `config_policy_patch_settings.sources = {os,third_party}` — the exact value the evaluator reads.

Refs #1428

🤖 Generated with [Claude Code](https://claude.com/claude-code)