### PR TITLE
fix(api): scope event WS ticket to all accessible orgs by default (#2256)

### DIFF
--- a/apps/api/src/routes/eventWs.test.ts
+++ b/apps/api/src/routes/eventWs.test.ts
@@ -506,6 +506,45 @@ describe('createEventWsTicketRoute', () => {
     expect(identity).toEqual({ userId: 'user-abc', orgIds: ['org-a', 'org-b'] });
   });
 
+  // Regression guard (#2256): the All-Organizations Devices view opens the
+  // event stream WITHOUT `orgId` or `allOrgs=1`. A partner user with multiple
+  // accessible orgs must get a ticket scoped to ALL of them — the old
+  // behaviour silently narrowed to `orgIds[0]`, so live device.online/offline
+  // events for every other org were never delivered until a manual refresh.
+  it('issues a multi-org ticket for partner users by default (no orgId, no allOrgs) — #2256', async () => {
+    const { Hono } = await import('hono');
+    const app = new Hono();
+
+    app.use('*', async (c, next) => {
+      c.set('auth', {
+        user: { id: 'user-abc', email: 'a@b.com', name: 'A' },
+        orgId: null,
+        scope: 'partner',
+        partnerId: 'partner-1',
+        canAccessOrg: () => true,
+        accessibleOrgIds: ['org-a', 'org-b', 'org-c'],
+      } as any);
+      await next();
+    });
+
+    const { resolveOrgAccess } = await import('../middleware/auth');
+    vi.mocked(resolveOrgAccess).mockResolvedValueOnce({
+      type: 'multiple',
+      orgIds: ['org-a', 'org-b', 'org-c'],
+    });
+
+    const ticketApp = createEventWsTicketRoute();
+    app.route('/events', ticketApp);
+
+    // No orgId, no allOrgs — exactly what useEventStream sends.
+    const res = await app.request('/events/ws-ticket', { method: 'POST' });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    const identity = await consumeTicket(body.ticket);
+    expect(identity).toEqual({ userId: 'user-abc', orgIds: ['org-a', 'org-b', 'org-c'] });
+  });
+
   it('issued ticket is consumable with correct identity', async () => {
     const { Hono } = await import('hono');
     const app = new Hono();

--- a/apps/api/src/routes/eventWs.test.ts
+++ b/apps/api/src/routes/eventWs.test.ts
@@ -545,6 +545,70 @@ describe('createEventWsTicketRoute', () => {
     expect(identity).toEqual({ userId: 'user-abc', orgIds: ['org-a', 'org-b', 'org-c'] });
   });
 
+  // Branch-order guard: the `auth.orgId` short-circuit is the route-level
+  // defense ensuring an ORG-scoped token can never mint a multi-org ticket
+  // (org tokens carry a partnerId, and the 'multiple' branch is now strictly
+  // broader with no opt-in flag). Even if resolveOrgAccess were to return
+  // 'multiple', the ticket must stay scoped to the token's own org.
+  it('org-token users get a single-org ticket even when orgAccess resolves to multiple', async () => {
+    const { Hono } = await import('hono');
+    const app = new Hono();
+
+    app.use('*', async (c, next) => {
+      c.set('auth', {
+        user: { id: 'user-abc', email: 'a@b.com', name: 'A' },
+        orgId: 'org-x',
+        scope: 'organization',
+        partnerId: 'partner-1',
+      } as any);
+      await next();
+    });
+
+    const { resolveOrgAccess } = await import('../middleware/auth');
+    vi.mocked(resolveOrgAccess).mockResolvedValueOnce({
+      type: 'multiple',
+      orgIds: ['org-x', 'org-y'],
+    });
+
+    const ticketApp = createEventWsTicketRoute();
+    app.route('/events', ticketApp);
+
+    const res = await app.request('/events/ws-ticket', { method: 'POST' });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    const identity = await consumeTicket(body.ticket);
+    expect(identity).toEqual({ userId: 'user-abc', orgIds: ['org-x'] });
+  });
+
+  // A partner user with zero accessible orgs (just-onboarded partner) must get
+  // the intended 400, not a 500 from createEventWsTicket's empty-array throw.
+  it('returns 400 (not 500) for a partner user with zero accessible orgs', async () => {
+    const { Hono } = await import('hono');
+    const app = new Hono();
+
+    app.use('*', async (c, next) => {
+      c.set('auth', {
+        user: { id: 'user-abc', email: 'a@b.com', name: 'A' },
+        orgId: null,
+        scope: 'partner',
+        partnerId: 'partner-1',
+        canAccessOrg: () => false,
+        accessibleOrgIds: [],
+      } as any);
+      await next();
+    });
+
+    const { resolveOrgAccess } = await import('../middleware/auth');
+    vi.mocked(resolveOrgAccess).mockResolvedValueOnce({ type: 'multiple', orgIds: [] });
+
+    const ticketApp = createEventWsTicketRoute();
+    app.route('/events', ticketApp);
+
+    const res = await app.request('/events/ws-ticket', { method: 'POST' });
+    expect(res.status).toBe(400);
+  });
+
   it('issued ticket is consumable with correct identity', async () => {
     const { Hono } = await import('hono');
     const app = new Hono();

--- a/apps/api/src/routes/eventWs.ts
+++ b/apps/api/src/routes/eventWs.ts
@@ -318,7 +318,8 @@ export function createEventWsTicketRoute(): Hono {
     // (#2256: the old behaviour narrowed no-param multi-org requests to
     // `orgIds[0]` unless a legacy `allOrgs=1` flag was passed, so the
     // All-Orgs Devices view only received live status events for the first
-    // org. `allOrgs=1` is still accepted but no longer required.)
+    // org. The `allOrgs=1` param is no longer read at all — clients that
+    // still send it (e.g. the mobile app) get the same all-orgs result.)
     const requestedOrgId = c.req.query('orgId') ?? undefined;
     const orgAccess = await resolveOrgAccess(auth, requestedOrgId);
 

--- a/apps/api/src/routes/eventWs.ts
+++ b/apps/api/src/routes/eventWs.ts
@@ -309,12 +309,17 @@ export function createEventWsTicketRoute(): Hono {
     }
 
     // Resolve orgId for partner/system users who pass it as a query param.
-    // When `allOrgs=1` is passed (or no specific org is requested), partner-
-    // scoped users get a ticket scoped to ALL their accessible orgs so a
-    // single connection can receive events for the full set without the
-    // client needing to multiplex tickets.
+    // When no specific org is requested, partner-scoped users get a ticket
+    // scoped to ALL their accessible orgs so a single connection can receive
+    // events for the full set without the client needing to multiplex
+    // tickets. This matches the list endpoints' scoping: the web client
+    // (`useEventStream`) sends no params in All-Organizations mode, and
+    // `fetchWithAuth` auto-injects `orgId=` when a specific org is selected.
+    // (#2256: the old behaviour narrowed no-param multi-org requests to
+    // `orgIds[0]` unless a legacy `allOrgs=1` flag was passed, so the
+    // All-Orgs Devices view only received live status events for the first
+    // org. `allOrgs=1` is still accepted but no longer required.)
     const requestedOrgId = c.req.query('orgId') ?? undefined;
-    const allOrgs = c.req.query('allOrgs') === '1';
     const orgAccess = await resolveOrgAccess(auth, requestedOrgId);
 
     let orgIds: string[];
@@ -323,7 +328,7 @@ export function createEventWsTicketRoute(): Hono {
     } else if (orgAccess.type === 'single') {
       orgIds = [orgAccess.orgId];
     } else if (orgAccess.type === 'multiple' && orgAccess.orgIds.length > 0) {
-      orgIds = allOrgs ? orgAccess.orgIds : [orgAccess.orgIds[0]!];
+      orgIds = orgAccess.orgIds;
     } else {
       return c.json({ error: 'Organization context required — select an org first' }, 400);
     }


### PR DESCRIPTION
## Summary

Fixes the All-Organizations Devices view not receiving live `device.online` / `device.offline` events for devices outside the first accessible org (#2256).

**Root cause:** an org-scope mismatch between the Devices list fetch and the event WebSocket ticket.

- `apps/web/src/hooks/useEventStream.ts:59` requests `POST /events/ws-ticket` with no params. `fetchWithAuth` (`apps/web/src/stores/auth.ts:506`) only auto-injects `orgId=` when a specific org is selected — in All-Organizations mode nothing is injected.
- `apps/api/src/routes/eventWs.ts` narrowed that no-param request for multi-org (partner-scoped) users to `orgAccess.orgIds[0]` unless a legacy `allOrgs=1` flag was passed — despite the route's own comment saying no-specific-org should scope to ALL accessible orgs.
- Result: the list shows devices from every accessible org, but the WS connection is registered with the dispatcher for only the first org, so status events for all other orgs are silently dropped until a manual refresh.

## Fix

One-line behavior change in the ticket route's `multiple` branch: with no specific org requested, mint the ticket for the full accessible-org set (what `allOrgs=1` already did). `allOrgs=1` is still accepted but no longer required.

- **Selected-org case unchanged** — `orgId=` → `resolveOrgAccess` returns `single`.
- **Org-token users unchanged** — `auth.orgId` short-circuits first.
- **No privilege widening** — the set comes from `resolveOrgAccess` (`auth.accessibleOrgIds`), the same authorization the `allOrgs=1` path used; the per-ticket site restriction (`allowedSiteIds`) is unaffected.
- No web changes needed.

## Tests

- New regression test: partner user, no `orgId`, no `allOrgs` (exactly what `useEventStream` sends) → ticket identity carries all accessible orgs. Red before the fix (ticket carried only `org-a`), green after.
- `apps/api/src/routes/eventWs.test.ts`: 35 passed; `eventBus.test.ts` + `eventDispatcher.test.ts`: 30 passed; `tsc --noEmit` clean.

Closes #2256

🤖 Generated with [Claude Code](https://claude.com/claude-code)