### PR TITLE
fix(api): accept {"stopped":true} in desk-command_result schema (#2307)

### DIFF
--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -735,6 +735,33 @@ describe('agent websocket command results', () => {
     expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
   });
 
+  // #2307: fielded agents confirm desk-stop with result {"stopped": true}.
+  // The strict result schema must accept the key instead of dropping the
+  // message as a malformed desk-command_result.
+  it('accepts a desk-stop result carrying {"stopped": true} without a malformed-drop warn (#2307)', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: 'desk-stop-session-123',
+        status: 'completed',
+        result: { stopped: true }
+      })
+    } as any, ws as any);
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Dropping malformed desk-command_result')
+    );
+    // Message passes the fast-path schema and is acked like any other result.
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
+    warnSpy.mockRestore();
+  });
+
   it('rejects desktop disconnect results with mismatched session IDs', async () => {
     const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
 

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -2363,6 +2363,11 @@ const desktopCommandResultSchema = z.object({
     // prompt was allowed by the user.
     reason: z.enum(['user', 'timeout', 'no_user', 'helper_absent']).optional(),
     consentReason: z.literal('user').optional(),
+    // Desk-stop confirmations from fielded agents send {"stopped": true}
+    // (agent/internal/heartbeat/handlers_desktop.go). Not consumed
+    // server-side, but must be accepted so the result isn't dropped as
+    // malformed (#2307).
+    stopped: z.boolean().optional(),
   }).strict().optional(),
 }).passthrough();
 


### PR DESCRIPTION
## Summary

Every desktop-stop confirmation from fielded agents was being dropped by the API WS fast-path with a `[AgentWs] Dropping malformed desk-command_result ... Unrecognized key: "stopped"` warn: the agent sends `result: {"stopped": true}` (`agent/internal/heartbeat/handlers_desktop.go:311,417,425`) but `desktopCommandResultSchema.result` is `.strict()` and didn't allow the key.

Per the issue's preferred fix direction, this takes the back-compat-safe server-side accept: add `stopped: z.boolean().optional()` to the strict result schema (with a comment documenting the wire contract), so agents already in the field keep working and the misleading warn disappears from self-host logs.

## Changes

- `apps/api/src/routes/agentWs.ts` — allow optional `stopped: boolean` in `desktopCommandResultSchema.result`.
- `apps/api/src/routes/agentWs.test.ts` — regression test: a `desk-stop-*` `command_result` with `result: {"stopped": true}` passes the fast-path schema, is acked, and does not emit the malformed-drop warn.

## Verification

- `pnpm exec vitest run src/routes/agentWs.test.ts` — 36 passed.
- `npx tsc --noEmit` in `apps/api` — clean.

Closes #2307

🤖 Generated with [Claude Code](https://claude.com/claude-code)