### PR TITLE
fix(automations): clamp config-policy subset device resolution to policy partner (#2286)

### DIFF
--- a/apps/api/src/__tests__/integration/automationWorkerPartnerResolution.integration.test.ts
+++ b/apps/api/src/__tests__/integration/automationWorkerPartnerResolution.integration.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Automation worker SUBSET resolution — partner re-clamp (#2286, sibling of
+ * the patch-scheduler fix in PR #2285 / #2280 review).
+ *
+ * `resolveDeviceIdsForAssignment` (apps/api/src/jobs/automationWorker.ts)
+ * resolves which devices a config-policy automation assignment targets. For a
+ * partner-owned policy (policyOrgId null) carrying an org/site/group/device
+ * SUBSET assignment, the target org was only verified to belong to the
+ * policy's partner at ASSIGN time (validateAssignmentTarget). If that org is
+ * later reparented to a different partner, the stale assignment row would
+ * otherwise keep resolving those devices — a TOCTOU hole. The fix threads the
+ * policy's partnerId into resolution and re-verifies it on every run via an
+ * inner join on organizations, the same re-verification the partner-wide
+ * 'partner' level branch already does for assignmentTargetId.
+ *
+ * The unit suite (automationWorker.resolveAssignment.test.ts) proves the query
+ * SHAPE (join + where args) against a mocked db. This proves the join actually
+ * ENFORCES the clamp against real Postgres — per the CLAUDE.md config-policy
+ * partner-wide playbook item 5, a worker's partner-wide fan-out must be
+ * proven against real Postgres, not just asserted at the mock layer.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import {
+  db,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import {
+  configurationPolicies,
+  configPolicyFeatureLinks,
+  configPolicyAssignments,
+  devices,
+  organizations,
+} from '../../db/schema';
+import { __testOnly } from '../../jobs/automationWorker';
+import { createPartner, createOrganization, createSite } from './db-utils';
+
+const { resolveDeviceIdsForAssignment } = __testOnly;
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+const createdPolicies: string[] = [];
+
+afterEach(async () => {
+  if (createdPolicies.length === 0) return;
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    for (const id of createdPolicies) {
+      await db.delete(configurationPolicies).where(eq(configurationPolicies.id, id));
+    }
+  });
+  createdPolicies.length = 0;
+});
+
+async function seedDevice(orgId: string, siteId: string) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [d] = await db
+      .insert(devices)
+      .values({
+        orgId,
+        siteId,
+        agentId: `agent-${randomUUID()}`,
+        hostname: `host-${randomUUID().slice(0, 8)}`,
+        osType: 'windows',
+        osVersion: '1.0',
+        architecture: 'amd64',
+        agentVersion: '1.0.0',
+        status: 'online',
+        deviceRole: 'workstation',
+      })
+      .returning();
+    return d!;
+  });
+}
+
+/** Partner-owned (org_id NULL) policy with an 'automation' feature link — the #2280 library shape. */
+async function seedPartnerAutomationPolicy(partnerId: string): Promise<string> {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [policy] = await db
+      .insert(configurationPolicies)
+      .values({ orgId: null, partnerId, name: 'Partner-wide automation library policy', status: 'active' })
+      .returning();
+    createdPolicies.push(policy!.id);
+    await db.insert(configPolicyFeatureLinks).values({
+      configPolicyId: policy!.id,
+      featureType: 'automation',
+      inlineSettings: {},
+    });
+    return policy!.id;
+  });
+}
+
+async function assignOrg(policyId: string, orgId: string) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    await db.insert(configPolicyAssignments).values({
+      configPolicyId: policyId,
+      level: 'organization',
+      targetId: orgId,
+      priority: 0,
+    });
+  });
+}
+
+describe('automation worker SUBSET resolution — partner re-clamp (#2286)', () => {
+  it('resolves an org-level SUBSET assignment on a partner-owned policy to ONLY the assigned org, not a sibling org (fan-out contract)', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const siteA = await createSite({ orgId: orgA!.id });
+    const siteB = await createSite({ orgId: orgB!.id });
+    const deviceA = await seedDevice(orgA!.id, siteA!.id);
+    await seedDevice(orgB!.id, siteB!.id); // sibling org under the SAME partner — must NOT resolve
+
+    const policyId = await seedPartnerAutomationPolicy(partner.id);
+    // Subset assignment: organization level, org A only — deliberately no
+    // assignment for org B, so org B has nothing pointing at this policy.
+    await assignOrg(policyId, orgA!.id);
+
+    const ids = await withSystemDbAccessContext(() =>
+      resolveDeviceIdsForAssignment('organization', orgA!.id, null, partner.id)
+    );
+
+    expect(ids).toEqual([deviceA.id]);
+  });
+
+  it('stops resolving a SUBSET assignment once its org is reparented to a different partner (TOCTOU re-clamp)', async () => {
+    const partner = await createPartner();
+    const otherPartner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org!.id });
+    const device = await seedDevice(org!.id, site!.id);
+
+    const policyId = await seedPartnerAutomationPolicy(partner.id);
+    await assignOrg(policyId, org!.id);
+
+    // Sanity check: resolves normally while the org still belongs to the
+    // policy's partner.
+    const before = await withSystemDbAccessContext(() =>
+      resolveDeviceIdsForAssignment('organization', org!.id, null, partner.id)
+    );
+    expect(before).toEqual([device.id]);
+
+    // Reparent the org to a DIFFERENT partner. The assignment row is now
+    // stale — it was only ever verified to belong to `partner` at ASSIGN
+    // time (validateAssignmentTarget), and nothing re-checks it afterwards
+    // except this resolution join.
+    await withDbAccessContext(SYSTEM_CTX, async () => {
+      await db
+        .update(organizations)
+        .set({ partnerId: otherPartner.id })
+        .where(eq(organizations.id, org!.id));
+    });
+
+    const after = await withSystemDbAccessContext(() =>
+      resolveDeviceIdsForAssignment('organization', org!.id, null, partner.id)
+    );
+
+    // Must NOT still resolve devices for the policy's now-stale partner.
+    expect(after).toEqual([]);
+  });
+});

--- a/apps/api/src/jobs/automationWorker.resolveAssignment.test.ts
+++ b/apps/api/src/jobs/automationWorker.resolveAssignment.test.ts
@@ -64,7 +64,7 @@ import { __testOnly } from './automationWorker';
 import { db } from '../db';
 import { organizations } from '../db/schema';
 
-const { resolveDeviceIdsForAssignment } = __testOnly;
+const { resolveDeviceIdsForAssignment, processTriggerConfigPolicySchedule } = __testOnly;
 
 // Drizzle's `eq`/`and` build a real SQL AST (queryChunks tree), even though our
 // mocked schema columns are plain strings rather than real Column objects —
@@ -212,11 +212,108 @@ describe('automationWorker resolveDeviceIdsForAssignment — partner re-clamp (#
     expect(whereArgs).toContain('partner-123');
   });
 
+  it('clamps an org-owned policy subset resolution to the POLICY org even when the target differs (cross-org forge)', async () => {
+    // Target id and policyOrgId are deliberately DIFFERENT strings so this
+    // test fails if the `if (policyOrgId) conditions.push(...)` clamp is
+    // dropped — the org-owned tests above use the same id for both and
+    // cannot distinguish the target filter from the org clamp.
+    const chain: any = {
+      from: vi.fn(() => chain),
+      where: vi.fn(() => Promise.resolve([])),
+    };
+    vi.mocked(db.select).mockReturnValueOnce(chain);
+
+    const ids = await resolveDeviceIdsForAssignment('site', 'site-x', 'org-y', null);
+
+    expect(ids).toEqual([]);
+    const whereArgs = collectSqlLeafStrings(chain.where.mock.calls[0][0]);
+    expect(whereArgs).toContain('site-x');
+    expect(whereArgs).toContain('org-y');
+  });
+
   it('returns [] for an unknown assignment level without querying', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const ids = await resolveDeviceIdsForAssignment('bogus', 'x', null, null);
     expect(ids).toEqual([]);
     expect(vi.mocked(db.select)).not.toHaveBeenCalled();
     warn.mockRestore();
+  });
+});
+
+describe('processTriggerConfigPolicySchedule — run-time policy-owner load (#2286)', () => {
+  beforeEach(() => {
+    vi.mocked(db.select).mockReset();
+  });
+
+  const jobData = {
+    type: 'trigger-config-policy-schedule',
+    configPolicyAutomationId: 'cp-auto-1',
+    slotKey: '2026-01-01T10:00',
+    assignmentTargets: [{ level: 'organization', targetId: 'org-x' }],
+  } as any;
+
+  it("skips with 'config_policy_not_found' when the featureLink→policy join resolves nothing", async () => {
+    // Chain 1: cpAutomation lookup — found and enabled.
+    const cpChain: any = {
+      from: vi.fn(() => cpChain),
+      where: vi.fn(() => cpChain),
+      limit: vi.fn(() => Promise.resolve([{ id: 'cp-auto-1', featureLinkId: 'fl-1' }])),
+    };
+    // Chain 2: policy-owner join — empty (policy/feature link deleted between
+    // enqueue and run; race window only, given FK cascades).
+    const ownerChain: any = {
+      from: vi.fn(() => ownerChain),
+      innerJoin: vi.fn(() => ownerChain),
+      where: vi.fn(() => ownerChain),
+      limit: vi.fn(() => Promise.resolve([])),
+    };
+    vi.mocked(db.select).mockReturnValueOnce(cpChain).mockReturnValueOnce(ownerChain);
+
+    const result = await processTriggerConfigPolicySchedule(jobData);
+
+    expect(result).toEqual({ skipped: 'config_policy_not_found' });
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2);
+  });
+
+  it('threads the LOADED policy ownership into device resolution (partner clamp reaches the resolver)', async () => {
+    // This is the seam that wires the clamp into the run path: if a refactor
+    // dropped the policy-owner load or passed (null, null) through, the
+    // resolver-level tests above would stay green while the TOCTOU hole
+    // silently reopened. Prove the partnerId loaded from the DB (NOT from job
+    // data — the job carries no ownership) lands in the resolver's WHERE.
+    const cpChain: any = {
+      from: vi.fn(() => cpChain),
+      where: vi.fn(() => cpChain),
+      limit: vi.fn(() => Promise.resolve([{ id: 'cp-auto-1', featureLinkId: 'fl-1' }])),
+    };
+    // Partner-owned library policy: orgId null, partnerId set.
+    const ownerChain: any = {
+      from: vi.fn(() => ownerChain),
+      innerJoin: vi.fn(() => ownerChain),
+      where: vi.fn(() => ownerChain),
+      limit: vi.fn(() => Promise.resolve([{ orgId: null, partnerId: 'partner-123' }])),
+    };
+    // Chain 3: the resolver's clamped organization branch. Resolves no devices
+    // so the handler stops at 'no_target_devices' — before the maintenance
+    // filter and BullMQ enqueue, which are irrelevant to this seam.
+    const resolveChain: any = {
+      from: vi.fn(() => resolveChain),
+      innerJoin: vi.fn(() => resolveChain),
+      where: vi.fn(() => Promise.resolve([])),
+    };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(cpChain)
+      .mockReturnValueOnce(ownerChain)
+      .mockReturnValueOnce(resolveChain);
+
+    const result = await processTriggerConfigPolicySchedule(jobData);
+
+    expect(result).toEqual({ skipped: 'no_target_devices' });
+    // Partner-owned → the subset branch re-clamps via the organizations join.
+    expect(resolveChain.innerJoin).toHaveBeenCalledTimes(1);
+    expect(resolveChain.innerJoin.mock.calls[0][0]).toBe(organizations);
+    const whereArgs = collectSqlLeafStrings(resolveChain.where.mock.calls[0][0]);
+    expect(whereArgs).toContain('org-x');
+    expect(whereArgs).toContain('partner-123');
   });
 });

--- a/apps/api/src/jobs/automationWorker.resolveAssignment.test.ts
+++ b/apps/api/src/jobs/automationWorker.resolveAssignment.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Unit coverage for automationWorker's config-policy assignment device
+// resolution (#2286) — the automation-run sibling of the patch-scheduler
+// TOCTOU clamp added in PR #2285 (#2280 review). These tests prove the query
+// SHAPE: that a partner-owned library policy's SUBSET assignment resolution
+// joins organizations and carries BOTH the target filter and the policy's
+// partner clamp in its WHERE predicate, and that an org-owned policy keeps its
+// org clamp without the join. The real-Postgres enforcement proof lives in
+// __tests__/integration/automationWorkerPartnerResolution.integration.test.ts.
+
+vi.mock('../db', () => ({
+  db: { select: vi.fn() },
+  withSystemDbAccessContext: <T>(fn: () => Promise<T>) => fn(),
+}));
+
+// Thin schema stub — the worker imports many tables but the unit under test
+// only references them as opaque column handles passed to the mocked db chain.
+vi.mock('../db/schema', () => ({
+  automations: {},
+  configPolicyAutomations: {},
+  configPolicyFeatureLinks: {},
+  configurationPolicies: {},
+  devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId' },
+  deviceGroupMemberships: {
+    deviceId: 'deviceGroupMemberships.deviceId',
+    groupId: 'deviceGroupMemberships.groupId',
+    orgId: 'deviceGroupMemberships.orgId',
+  },
+  organizations: { id: 'organizations.id', partnerId: 'organizations.partnerId' },
+}));
+
+// Side-effect-heavy imports the module pulls in at load time — stub so importing
+// the worker doesn't spin up Redis/BullMQ or the full resolver graph.
+vi.mock('bullmq', () => ({ Queue: class {}, Worker: class {}, Job: class {} }));
+vi.mock('../services/eventBus', () => ({ getEventBus: vi.fn() }));
+vi.mock('../services/automationRuntime', () => ({
+  createAutomationRunRecord: vi.fn(),
+  executeAutomationRun: vi.fn(),
+  executeConfigPolicyAutomationRun: vi.fn(),
+  formatScheduleTriggerKey: vi.fn(),
+  isCronDue: vi.fn(),
+  normalizeAutomationTrigger: vi.fn(),
+}));
+vi.mock('../services/featureConfigResolver', () => ({
+  scanScheduledAutomations: vi.fn(),
+  resolveAutomationsForDevice: vi.fn(),
+  resolveMaintenanceConfigForDevice: vi.fn(),
+  isInMaintenanceWindow: vi.fn(),
+}));
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({})),
+  isRedisAvailable: vi.fn(),
+}));
+vi.mock('../services/bullmqUtils', () => ({ isReusableState: vi.fn() }));
+vi.mock('../services/bullmqValidation', () => ({
+  assertQueueJobName: vi.fn(),
+  parseQueueJobData: vi.fn(),
+}));
+vi.mock('./queueSchemas', () => ({ automationQueueJobDataSchema: {} }));
+vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
+
+import { __testOnly } from './automationWorker';
+import { db } from '../db';
+import { organizations } from '../db/schema';
+
+const { resolveDeviceIdsForAssignment } = __testOnly;
+
+// Drizzle's `eq`/`and` build a real SQL AST (queryChunks tree), even though our
+// mocked schema columns are plain strings rather than real Column objects —
+// `sql\`${left} = ${right}\`` inserts both raw operands directly into
+// queryChunks (they don't satisfy isDriverValueEncoder, so neither side gets
+// wrapped in a Param). That means the exact identifiers passed to eq()/and()
+// are recoverable by walking the tree, which lets a test assert on the ACTUAL
+// filter values a `.where(...)` call was built with, instead of trusting a
+// mock that returns a fixed row regardless of what was asked for.
+function collectSqlLeafStrings(node: unknown, seen = new Set<unknown>(), acc: string[] = []): string[] {
+  if (typeof node === 'string') {
+    acc.push(node);
+    return acc;
+  }
+  if (node === null || typeof node !== 'object' || seen.has(node)) return acc;
+  seen.add(node);
+  if (Array.isArray(node)) {
+    for (const item of node) collectSqlLeafStrings(item, seen, acc);
+    return acc;
+  }
+  const queryChunks = (node as { queryChunks?: unknown[] }).queryChunks;
+  if (Array.isArray(queryChunks)) {
+    for (const item of queryChunks) collectSqlLeafStrings(item, seen, acc);
+  }
+  return acc;
+}
+
+describe('automationWorker resolveDeviceIdsForAssignment — partner re-clamp (#2286)', () => {
+  beforeEach(() => {
+    vi.mocked(db.select).mockReset();
+  });
+
+  it('does NOT partner-clamp an org-owned policy (policyOrgId set) — org clamp only, no join', async () => {
+    // The mock chain below has no `.innerJoin`, so attempting the organizations
+    // join would throw — proving the org-owned path stays join-free.
+    const chain: any = {
+      from: vi.fn(() => chain),
+      where: vi.fn(() => Promise.resolve([{ id: 'dev-a' }])),
+    };
+    vi.mocked(db.select).mockReturnValueOnce(chain);
+
+    const ids = await resolveDeviceIdsForAssignment('organization', 'org-x', 'org-x', null);
+
+    expect(ids).toEqual(['dev-a']);
+    const whereArgs = collectSqlLeafStrings(chain.where.mock.calls[0][0]);
+    expect(whereArgs).toContain('org-x');
+  });
+
+  it('re-clamps an ORGANIZATION-level SUBSET assignment on a partner-owned library policy to the policy partner', async () => {
+    // Partner-owned policies can carry org/site/group/device SUBSET assignments
+    // (#2280 library model); a null policyOrgId is the NORMAL case for those.
+    // The target org was partner-scoped at ASSIGN time only — if it's later
+    // reparented to a different partner, a stale assignment row must not keep
+    // resolving those devices.
+    const chain: any = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn(() => Promise.resolve([{ id: 'dev-a' }])),
+    };
+    vi.mocked(db.select).mockReturnValueOnce(chain);
+
+    const ids = await resolveDeviceIdsForAssignment('organization', 'org-x', null, 'partner-123');
+
+    expect(ids).toEqual(['dev-a']);
+    expect(chain.innerJoin).toHaveBeenCalledTimes(1);
+    expect(chain.innerJoin.mock.calls[0][0]).toBe(organizations);
+    // The where() predicate carries BOTH the target-org filter and the partner
+    // clamp — not just one or the other, and not a fixed mock return.
+    const whereArgs = collectSqlLeafStrings(chain.where.mock.calls[0][0]);
+    expect(whereArgs).toContain('org-x');
+    expect(whereArgs).toContain('partner-123');
+  });
+
+  it('re-clamps a SITE-level SUBSET assignment on a partner-owned library policy to the policy partner', async () => {
+    const chain: any = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn(() => Promise.resolve([{ id: 'dev-a' }])),
+    };
+    vi.mocked(db.select).mockReturnValueOnce(chain);
+
+    const ids = await resolveDeviceIdsForAssignment('site', 'site-x', null, 'partner-123');
+
+    expect(ids).toEqual(['dev-a']);
+    expect(chain.innerJoin).toHaveBeenCalledTimes(1);
+    expect(chain.innerJoin.mock.calls[0][0]).toBe(organizations);
+    const whereArgs = collectSqlLeafStrings(chain.where.mock.calls[0][0]);
+    expect(whereArgs).toContain('site-x');
+    expect(whereArgs).toContain('partner-123');
+  });
+
+  it('re-clamps a DEVICE_GROUP-level SUBSET assignment on a partner-owned library policy to the policy partner', async () => {
+    const chain: any = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn(() => Promise.resolve([{ deviceId: 'dev-a' }])),
+    };
+    vi.mocked(db.select).mockReturnValueOnce(chain);
+
+    const ids = await resolveDeviceIdsForAssignment('device_group', 'group-x', null, 'partner-123');
+
+    expect(ids).toEqual(['dev-a']);
+    expect(chain.innerJoin).toHaveBeenCalledTimes(1);
+    expect(chain.innerJoin.mock.calls[0][0]).toBe(organizations);
+    const whereArgs = collectSqlLeafStrings(chain.where.mock.calls[0][0]);
+    expect(whereArgs).toContain('group-x');
+    expect(whereArgs).toContain('partner-123');
+  });
+
+  it('re-clamps a DEVICE-level SUBSET assignment on a partner-owned library policy to the policy partner', async () => {
+    // The device branch additionally chains .limit(1) after .where(), unlike
+    // the site/device_group/organization branches above.
+    const chain: any = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      limit: vi.fn(() => Promise.resolve([{ id: 'dev-a' }])),
+    };
+    vi.mocked(db.select).mockReturnValueOnce(chain);
+
+    const ids = await resolveDeviceIdsForAssignment('device', 'dev-x', null, 'partner-123');
+
+    expect(ids).toEqual(['dev-a']);
+    expect(chain.innerJoin).toHaveBeenCalledTimes(1);
+    expect(chain.innerJoin.mock.calls[0][0]).toBe(organizations);
+    const whereArgs = collectSqlLeafStrings(chain.where.mock.calls[0][0]);
+    expect(whereArgs).toContain('dev-x');
+    expect(whereArgs).toContain('partner-123');
+  });
+
+  it('resolves a partner-level assignment via a single organizations join on the target partner', async () => {
+    const chain: any = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn(() => Promise.resolve([{ id: 'dev-a' }, { id: 'dev-b' }])),
+    };
+    vi.mocked(db.select).mockReturnValueOnce(chain);
+
+    const ids = await resolveDeviceIdsForAssignment('partner', 'partner-123', null, 'partner-123');
+
+    expect(ids).toEqual(['dev-a', 'dev-b']);
+    expect(chain.innerJoin).toHaveBeenCalledTimes(1);
+    expect(chain.innerJoin.mock.calls[0][0]).toBe(organizations);
+    const whereArgs = collectSqlLeafStrings(chain.where.mock.calls[0][0]);
+    expect(whereArgs).toContain('partner-123');
+  });
+
+  it('returns [] for an unknown assignment level without querying', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const ids = await resolveDeviceIdsForAssignment('bogus', 'x', null, null);
+    expect(ids).toEqual([]);
+    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/apps/api/src/jobs/automationWorker.ts
+++ b/apps/api/src/jobs/automationWorker.ts
@@ -1000,4 +1000,5 @@ export async function shutdownAutomationWorker(): Promise<void> {
 // resolution (#2286). Internal helper, not part of the worker's public surface.
 export const __testOnly = {
   resolveDeviceIdsForAssignment,
+  processTriggerConfigPolicySchedule,
 };

--- a/apps/api/src/jobs/automationWorker.ts
+++ b/apps/api/src/jobs/automationWorker.ts
@@ -8,9 +8,17 @@
  */
 
 import { Job, Queue, Worker } from 'bullmq';
-import { and, eq, inArray, isNull, or } from 'drizzle-orm';
+import { and, eq, isNull, or } from 'drizzle-orm';
 import * as dbModule from '../db';
-import { automations, configPolicyAutomations, devices, deviceGroupMemberships, organizations } from '../db/schema';
+import {
+  automations,
+  configPolicyAutomations,
+  configPolicyFeatureLinks,
+  configurationPolicies,
+  devices,
+  deviceGroupMemberships,
+  organizations,
+} from '../db/schema';
 import { type BreezeEvent, getEventBus } from '../services/eventBus';
 import {
   type AutomationTrigger,
@@ -504,56 +512,125 @@ async function processExecuteRun(data: ExecuteRunJobData): Promise<{ runId: stri
 async function resolveDeviceIdsForAssignment(
   assignmentLevel: string,
   assignmentTargetId: string,
+  // null for partner-owned library policies (#1724, #2280) — they have no
+  // single owning org and may carry a partner-level assignment (resolved
+  // across all the partner's orgs) AND/OR org/site/group/device-level SUBSET
+  // assignments into individual orgs under the partner.
+  policyOrgId: string | null,
+  // The policy's own partnerId (set for partner-owned policies, null for
+  // org-owned ones). Used ONLY to re-clamp subset (org/site/group/device)
+  // resolution below when policyOrgId is null — see the comment above the
+  // switch for why this exists (#2286, mirroring the patch-scheduler fix in
+  // PR #2285).
+  policyPartnerId: string | null,
 ): Promise<string[]> {
+  if (assignmentLevel === 'partner') {
+    // A partner-wide policy (policyOrgId null, #1724) resolves EVERY device
+    // under the assigned partner. A legacy org-owned policy at partner level
+    // (now rejected at assign time) still clamps to its own org as a backstop.
+    const conditions = [eq(organizations.partnerId, assignmentTargetId)];
+    if (policyOrgId) conditions.push(eq(devices.orgId, policyOrgId));
+    const partnerDevices = await db
+      .select({ id: devices.id })
+      .from(devices)
+      .innerJoin(organizations, eq(devices.orgId, organizations.id))
+      .where(and(...conditions));
+    return partnerDevices.map((d) => d.id);
+  }
+
+  // Every remaining level is org/site/group/device-scoped. For an org-owned
+  // policy, policyOrgId clamps the target to the policy's own org as
+  // defense-in-depth. For a partner-owned library policy (#2280) resolving a
+  // SUBSET assignment — org/site/group/device, not the partner-wide 'partner'
+  // level above — policyOrgId is null: there is no single owning org to clamp
+  // to, since the same policy can carry subset assignments into several of the
+  // partner's orgs. The target itself was partner-scoped at ASSIGN time
+  // (validateAssignmentTarget), but that check is a point-in-time snapshot —
+  // if the target org is later reparented to a different partner, the stale
+  // assignment row would otherwise still resolve those devices (TOCTOU). So
+  // every subset branch below re-clamps to the policy's partner on every run
+  // via an inner join on organizations, the same re-verification the
+  // 'partner' branch above already does for assignmentTargetId (#2286).
+  const needsPartnerClamp = !policyOrgId && Boolean(policyPartnerId);
+
   switch (assignmentLevel) {
     case 'device': {
-      // Verify device exists
+      if (needsPartnerClamp) {
+        const [device] = await db
+          .select({ id: devices.id })
+          .from(devices)
+          .innerJoin(organizations, eq(devices.orgId, organizations.id))
+          .where(and(eq(devices.id, assignmentTargetId), eq(organizations.partnerId, policyPartnerId!)))
+          .limit(1);
+        return device ? [device.id] : [];
+      }
+      const conditions = [eq(devices.id, assignmentTargetId)];
+      if (policyOrgId) conditions.push(eq(devices.orgId, policyOrgId));
       const [device] = await db
         .select({ id: devices.id })
         .from(devices)
-        .where(eq(devices.id, assignmentTargetId))
+        .where(and(...conditions))
         .limit(1);
       return device ? [device.id] : [];
     }
 
     case 'device_group': {
+      if (needsPartnerClamp) {
+        const members = await db
+          .select({ deviceId: deviceGroupMemberships.deviceId })
+          .from(deviceGroupMemberships)
+          .innerJoin(organizations, eq(deviceGroupMemberships.orgId, organizations.id))
+          .where(
+            and(
+              eq(deviceGroupMemberships.groupId, assignmentTargetId),
+              eq(organizations.partnerId, policyPartnerId!),
+            ),
+          );
+        return members.map((m) => m.deviceId);
+      }
+      const conditions = [eq(deviceGroupMemberships.groupId, assignmentTargetId)];
+      if (policyOrgId) conditions.push(eq(deviceGroupMemberships.orgId, policyOrgId));
       const members = await db
         .select({ deviceId: deviceGroupMemberships.deviceId })
         .from(deviceGroupMemberships)
-        .where(eq(deviceGroupMemberships.groupId, assignmentTargetId));
+        .where(and(...conditions));
       return members.map((m) => m.deviceId);
     }
 
     case 'site': {
+      if (needsPartnerClamp) {
+        const siteDevices = await db
+          .select({ id: devices.id })
+          .from(devices)
+          .innerJoin(organizations, eq(devices.orgId, organizations.id))
+          .where(and(eq(devices.siteId, assignmentTargetId), eq(organizations.partnerId, policyPartnerId!)));
+        return siteDevices.map((d) => d.id);
+      }
+      const conditions = [eq(devices.siteId, assignmentTargetId)];
+      if (policyOrgId) conditions.push(eq(devices.orgId, policyOrgId));
       const siteDevices = await db
         .select({ id: devices.id })
         .from(devices)
-        .where(eq(devices.siteId, assignmentTargetId));
+        .where(and(...conditions));
       return siteDevices.map((d) => d.id);
     }
 
     case 'organization': {
+      if (needsPartnerClamp) {
+        const orgDevices = await db
+          .select({ id: devices.id })
+          .from(devices)
+          .innerJoin(organizations, eq(devices.orgId, organizations.id))
+          .where(and(eq(devices.orgId, assignmentTargetId), eq(organizations.partnerId, policyPartnerId!)));
+        return orgDevices.map((d) => d.id);
+      }
+      const conditions = [eq(devices.orgId, assignmentTargetId)];
+      if (policyOrgId) conditions.push(eq(devices.orgId, policyOrgId));
       const orgDevices = await db
         .select({ id: devices.id })
         .from(devices)
-        .where(eq(devices.orgId, assignmentTargetId));
+        .where(and(...conditions));
       return orgDevices.map((d) => d.id);
-    }
-
-    case 'partner': {
-      // Get all orgs for this partner, then all devices for those orgs
-      const partnerOrgs = await db
-        .select({ id: organizations.id })
-        .from(organizations)
-        .where(eq(organizations.partnerId, assignmentTargetId));
-      const orgIds = partnerOrgs.map((o) => o.id);
-      if (orgIds.length === 0) return [];
-
-      const partnerDevices = await db
-        .select({ id: devices.id })
-        .from(devices)
-        .where(inArray(devices.orgId, orgIds));
-      return partnerDevices.map((d) => d.id);
     }
 
     default:
@@ -576,6 +653,25 @@ async function processTriggerConfigPolicySchedule(
     return { skipped: 'config_policy_automation_not_found_or_disabled' };
   }
 
+  // Re-load the owning policy's ownership (orgId/partnerId) at RUN time — not
+  // from the queued job data — so device resolution below re-verifies against
+  // current truth. The assignment targets were only partner/org-scoped at
+  // ASSIGN time; without this clamp a target reparented to a different partner
+  // after assignment would still resolve its devices (TOCTOU, #2286).
+  const [policyOwner] = await db
+    .select({
+      orgId: configurationPolicies.orgId,
+      partnerId: configurationPolicies.partnerId,
+    })
+    .from(configPolicyFeatureLinks)
+    .innerJoin(configurationPolicies, eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id))
+    .where(eq(configPolicyFeatureLinks.id, cpAutomation.featureLinkId))
+    .limit(1);
+
+  if (!policyOwner) {
+    return { skipped: 'config_policy_not_found' };
+  }
+
   const assignmentTargets =
     data.assignmentTargets && data.assignmentTargets.length > 0
       ? data.assignmentTargets
@@ -590,7 +686,12 @@ async function processTriggerConfigPolicySchedule(
   // Resolve target devices across all assignment targets, then deduplicate.
   const allDeviceIdSet = new Set<string>();
   for (const target of assignmentTargets) {
-    const ids = await resolveDeviceIdsForAssignment(target.level, target.targetId);
+    const ids = await resolveDeviceIdsForAssignment(
+      target.level,
+      target.targetId,
+      policyOwner.orgId,
+      policyOwner.partnerId,
+    );
     for (const id of ids) {
       allDeviceIdSet.add(id);
     }
@@ -894,3 +995,9 @@ export async function shutdownAutomationWorker(): Promise<void> {
 
   console.log('[AutomationWorker] Automation worker shut down');
 }
+
+// Exported for unit/integration tests of config-policy assignment device
+// resolution (#2286). Internal helper, not part of the worker's public surface.
+export const __testOnly = {
+  resolveDeviceIdsForAssignment,
+};


### PR DESCRIPTION
## Summary

`automationWorker`'s `resolveDeviceIdsForAssignment` resolved config-policy assignment targets purely by target id, with no clamp to the owning policy's partner — the automation-run analogue of the patch-scheduler TOCTOU gap fixed in PR #2285 (#2280). If a subset target (org/site/group/device) was reparented to a different partner after the assignment row was written, the stale row still resolved those devices, so an automation from partner A's policy could run against devices now under partner B.

## Fix (mirrors PR #2285's patch-scheduler clamp)

- `processTriggerConfigPolicySchedule` now re-loads the owning policy's `orgId`/`partnerId` at RUN time (featureLink → configurationPolicies join), never from queued job data, and threads both into `resolveDeviceIdsForAssignment`.
- When the policy is partner-owned (`orgId` null), every subset branch re-clamps to the policy's partner via `innerJoin(organizations)` + `eq(organizations.partnerId, policyPartnerId)` — flat partner scope, no tree traversal.
- Org-owned policies get the same defense-in-depth org clamp the patch scheduler has; the `partner`-level branch keeps its existing semantics (now a single join instead of a two-query fan-out).
- Worker runs in a system DB context, so these clamps live in the SQL (RLS does not scope system-context reads).

## Tests

- `apps/api/src/jobs/automationWorker.resolveAssignment.test.ts` — mocked-db unit suite proving the query shape: subset branches join `organizations` and the WHERE predicate carries BOTH the target filter and the partner clamp; org-owned path stays join-free with its org clamp.
- `apps/api/src/__tests__/integration/automationWorkerPartnerResolution.integration.test.ts` — real-Postgres proof: an org-level subset assignment on a partner-owned policy resolves only the assigned org, and resolves `[]` once the org is reparented to a different partner (TOCTOU re-clamp).

## Verification

- `vitest run` automationWorker suites: 3 files, 14 tests passed.
- Integration suite against dedicated Postgres 16: 2/2 passed.
- `tsc --noEmit`: clean.

Closes #2286

🤖 Generated with [Claude Code](https://claude.com/claude-code)