### PR TITLE
fix(vuln): skip malformed upstream CVE ids instead of aborting the sync (#2261)

### DIFF
--- a/apps/api/src/jobs/vulnerabilityJobs.integration.test.ts
+++ b/apps/api/src/jobs/vulnerabilityJobs.integration.test.ts
@@ -1,7 +1,7 @@
 import '../__tests__/integration/setup';
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { sql } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
 
 import { db, withSystemDbAccessContext } from '../db';
 import {
@@ -61,5 +61,57 @@ describe('syncMsrcMonth', () => {
     const after = await countVulnerabilities();
 
     expect(after).toBe(before);
+  });
+
+  describe('malformed upstream CVE ids (#2261)', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    // The literal record Microsoft ships in the CBL-Mariner CVRF feed: 44
+    // chars, which overflows vulnerabilities.cve_id varchar(32) with 22001
+    // and used to abort the whole month sync.
+    const malformedCveId = 'CVE-2023-38039 mariner - do not use this one';
+    const malformedDoc = {
+      ProductTree: {
+        FullProductName: [
+          { ProductID: '1', CPE: 'cpe:2.3:o:microsoft:cbl-mariner:*:*:*:*:*:*:*:*', Value: 'CBL Mariner 2.0 x64' },
+        ],
+      },
+      Vulnerability: [
+        {
+          CVE: malformedCveId,
+          Remediations: [{ Type: 2, FixedBuild: '2.0.20230801', ProductID: ['1'] }],
+        },
+        {
+          CVE: 'CVE-2023-38040',
+          Remediations: [{ Type: 2, FixedBuild: '2.0.20230801', ProductID: ['1'] }],
+        },
+      ],
+    };
+
+    runDb('does not abort the sync: skips the bad record, ingests siblings, marks source ok', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { fetchCvrf } = await import('../services/msrcClient');
+      vi.mocked(fetchCvrf).mockResolvedValueOnce(malformedDoc);
+
+      const res = await syncMsrcMonth('2023-Aug');
+
+      expect(res.vulns).toBe(1);
+      expect(res.matchFacts).toBe(1);
+
+      const rows = await withSystemDbAccessContext(() =>
+        db.select({ cveId: vulnerabilities.cveId }).from(vulnerabilities)
+      );
+      expect(rows.map((row) => row.cveId)).toEqual(['CVE-2023-38040']);
+
+      const [source] = await withSystemDbAccessContext(() =>
+        db
+          .select({ status: vulnerabilitySources.lastSyncStatus })
+          .from(vulnerabilitySources)
+          .where(eq(vulnerabilitySources.source, 'msrc'))
+      );
+      expect(source?.status).toBe('ok');
+    });
   });
 });

--- a/apps/api/src/jobs/vulnerabilityJobs.ts
+++ b/apps/api/src/jobs/vulnerabilityJobs.ts
@@ -26,6 +26,7 @@ import {
   type NvdRecord,
   type NvdResponse,
 } from '../services/nvdClient';
+import { isValidCveId, warnMalformedCveIds } from '../services/cveId';
 import { syncSofa } from '../services/sofaClient';
 import { enrichExploitSignals } from '../services/exploitFeeds';
 import { seedCpeMap } from '../services/cpeMap';
@@ -540,9 +541,19 @@ export async function syncMsrcMonth(month: string): Promise<{ vulns: number; mat
 
     return await withSystemDbAccessContext(async () => {
       const vulnerabilityIds = new Map<string, string>();
+      const skippedCveIds = new Set<string>();
       for (const { cveId, records } of distinctCves(recs)) {
+        // Defense-in-depth re-check of the parseCvrf boundary validation
+        // (#2261). Everything here runs in one transaction, so letting a
+        // malformed id reach the INSERT (22001 on varchar(32)) would poison
+        // the whole month sync — skip the record instead.
+        if (!isValidCveId(cveId)) {
+          skippedCveIds.add(cveId);
+          continue;
+        }
         vulnerabilityIds.set(cveId, await upsertVulnerability(month, cveId, records));
       }
+      warnMalformedCveIds('VulnerabilityJobs/msrc', skippedCveIds);
 
       const productIds = new Map<string, string>();
       for (const product of distinctProducts(recs)) {
@@ -597,9 +608,16 @@ export async function syncNvd(opts?: { sinceDays?: number }): Promise<{ vulns: n
     return await withSystemDbAccessContext(async () => {
       const now = new Date();
       const vulnerabilityIds = new Map<string, string>();
+      const skippedCveIds = new Set<string>();
       for (const record of recs) {
+        // Defense-in-depth re-check of the parseNvd boundary validation (#2261).
+        if (!isValidCveId(record.cveId)) {
+          skippedCveIds.add(record.cveId);
+          continue;
+        }
         vulnerabilityIds.set(record.cveId, await upsertNvdVulnerability(record, now));
       }
+      warnMalformedCveIds('VulnerabilityJobs/nvd', skippedCveIds);
 
       let matchFacts = 0;
       const seenFacts = new Set<string>();

--- a/apps/api/src/services/cveId.test.ts
+++ b/apps/api/src/services/cveId.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isValidCveId, warnMalformedCveIds } from './cveId';
+
+describe('isValidCveId', () => {
+  it.each([
+    'CVE-2023-38039',
+    'CVE-1999-0001',
+    'CVE-2024-123456789',
+  ])('accepts canonical id %s', (id) => {
+    expect(isValidCveId(id)).toBe(true);
+  });
+
+  it('rejects the malformed Mariner record that broke the MSRC sync (#2261)', () => {
+    expect(isValidCveId('CVE-2023-38039 mariner - do not use this one')).toBe(false);
+  });
+
+  it.each([
+    ['empty string', ''],
+    ['missing prefix', '2023-38039'],
+    ['lowercase prefix', 'cve-2023-38039'],
+    ['too few sequence digits', 'CVE-2023-123'],
+    ['non-numeric year', 'CVE-20XX-38039'],
+    ['trailing text', 'CVE-2023-38039-extra'],
+    ['leading whitespace', ' CVE-2023-38039'],
+    ['trailing whitespace', 'CVE-2023-38039 '],
+    ['longer than varchar(32)', `CVE-2023-${'9'.repeat(30)}`],
+  ])('rejects %s', (_label, id) => {
+    expect(isValidCveId(id)).toBe(false);
+  });
+});
+
+describe('warnMalformedCveIds', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is a no-op when nothing was skipped', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    warnMalformedCveIds('Test', new Set());
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('emits a single warning carrying the count and offending ids', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    warnMalformedCveIds('Test', new Set(['CVE-2023-38039 mariner - do not use this one']));
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0]?.[0] as string;
+    expect(message).toContain('[Test]');
+    expect(message).toContain('Skipped 1 record(s)');
+    expect(message).toContain('CVE-2023-38039 mariner - do not use this one');
+  });
+
+  it('truncates the sample list for large skip sets', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const ids = new Set(Array.from({ length: 15 }, (_, i) => `bad-id-${i}`));
+    warnMalformedCveIds('Test', ids);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0]?.[0] as string;
+    expect(message).toContain('Skipped 15 record(s)');
+    expect(message).toContain('+5 more');
+  });
+});

--- a/apps/api/src/services/cveId.test.ts
+++ b/apps/api/src/services/cveId.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { isValidCveId, warnMalformedCveIds } from './cveId';
+import { assertSomeValidCveIds, isValidCveId, warnMalformedCveIds } from './cveId';
 
 describe('isValidCveId', () => {
   it.each([
     'CVE-2023-38039',
     'CVE-1999-0001',
     'CVE-2024-123456789',
+    // exactly 32 chars — the varchar(32) boundary
+    `CVE-2023-${'1'.repeat(23)}`,
   ])('accepts canonical id %s', (id) => {
     expect(isValidCveId(id)).toBe(true);
   });
@@ -47,7 +49,7 @@ describe('warnMalformedCveIds', () => {
     expect(warn).toHaveBeenCalledTimes(1);
     const message = warn.mock.calls[0]?.[0] as string;
     expect(message).toContain('[Test]');
-    expect(message).toContain('Skipped 1 record(s)');
+    expect(message).toContain('Skipped 1 distinct malformed CVE id(s)');
     expect(message).toContain('CVE-2023-38039 mariner - do not use this one');
   });
 
@@ -58,7 +60,33 @@ describe('warnMalformedCveIds', () => {
 
     expect(warn).toHaveBeenCalledTimes(1);
     const message = warn.mock.calls[0]?.[0] as string;
-    expect(message).toContain('Skipped 15 record(s)');
+    expect(message).toContain('Skipped 15 distinct malformed CVE id(s)');
     expect(message).toContain('+5 more');
+  });
+});
+
+describe('assertSomeValidCveIds', () => {
+  it('does nothing for an empty feed', () => {
+    expect(() =>
+      assertSomeValidCveIds({ tag: 'Test', entryCount: 0, validCount: 0, malformedIds: new Set() })
+    ).not.toThrow();
+  });
+
+  it('does nothing when at least one id is valid', () => {
+    expect(() =>
+      assertSomeValidCveIds({ tag: 'Test', entryCount: 2, validCount: 1, malformedIds: new Set(['garbage']) })
+    ).not.toThrow();
+  });
+
+  it('throws when every entry has a malformed id (probable feed format change)', () => {
+    expect(() =>
+      assertSomeValidCveIds({ tag: 'Test', entryCount: 2, validCount: 0, malformedIds: new Set(['a', 'b']) })
+    ).toThrow(/probable upstream feed format change/);
+  });
+
+  it('throws when every entry is missing its id', () => {
+    expect(() =>
+      assertSomeValidCveIds({ tag: 'Test', entryCount: 3, validCount: 0, malformedIds: new Set() })
+    ).toThrow(/3 vulnerability entries but zero valid CVE ids/);
   });
 });

--- a/apps/api/src/services/cveId.ts
+++ b/apps/api/src/services/cveId.ts
@@ -38,6 +38,30 @@ export function warnMalformedCveIds(tag: string, skippedIds: ReadonlySet<string>
     .map((id) => JSON.stringify(id.length > MAX_WARNED_ID_LENGTH ? `${id.slice(0, MAX_WARNED_ID_LENGTH)}…` : id));
   const suffix = skippedIds.size > MAX_WARNED_IDS ? `, … +${skippedIds.size - MAX_WARNED_IDS} more` : '';
   console.warn(
-    `[${tag}] Skipped ${skippedIds.size} record(s) with malformed CVE id(s): ${sample.join(', ')}${suffix}`
+    `[${tag}] Skipped ${skippedIds.size} distinct malformed CVE id(s): ${sample.join(', ')}${suffix}`
+  );
+}
+
+/**
+ * Escalation guard for the total-drop case: a feed that contains vulnerability
+ * entries but yields ZERO valid CVE ids is a probable upstream format change
+ * (renamed id field, new id scheme), not the occasional-garbage case the skip
+ * path exists for. Silently completing would mark the source healthy and
+ * advance its cursor past data we never ingested, so throw instead — the sync
+ * jobs' existing error paths mark the source `error` and leave the cursor
+ * untouched for a retry after the parser is fixed. A feed with at least one
+ * valid id never throws.
+ */
+export function assertSomeValidCveIds(params: {
+  tag: string;
+  entryCount: number;
+  validCount: number;
+  malformedIds: ReadonlySet<string>;
+}): void {
+  if (params.entryCount === 0 || params.validCount > 0) return;
+  throw new Error(
+    `[${params.tag}] Feed contains ${params.entryCount} vulnerability entries but zero valid CVE ids `
+    + `(${params.malformedIds.size} malformed, ${params.entryCount - params.malformedIds.size} missing) — `
+    + 'probable upstream feed format change; refusing to mark the sync successful'
   );
 }

--- a/apps/api/src/services/cveId.ts
+++ b/apps/api/src/services/cveId.ts
@@ -1,0 +1,43 @@
+/**
+ * CVE id validation shared by the vulnerability feed parsers (MSRC, NVD, SOFA)
+ * and the sync jobs that upsert into the `vulnerabilities` catalog.
+ *
+ * Upstream feeds occasionally ship garbage — Microsoft's CBL-Mariner CVRF feed
+ * published a record whose CVE id is the literal string
+ * `CVE-2023-38039 mariner - do not use this one` (44 chars). The catalog column
+ * `vulnerabilities.cve_id` is varchar(32), so an unvalidated insert fails with
+ * `22001 value too long` and, because each sync runs in a single transaction,
+ * aborts the whole run (#2261). Malformed ids are dropped at the parse boundary
+ * instead: real CVE ids are short, and widening the column would just persist
+ * garbage into the catalog and its unique index.
+ */
+
+/** Canonical CVE id shape per the CVE Numbering Authority: CVE-YYYY-NNNN+. */
+const CVE_ID_PATTERN = /^CVE-\d{4}-\d{4,}$/;
+
+/** Matches `vulnerabilities.cve_id` varchar(32). */
+export const MAX_CVE_ID_LENGTH = 32;
+
+export function isValidCveId(value: string): boolean {
+  return value.length <= MAX_CVE_ID_LENGTH && CVE_ID_PATTERN.test(value);
+}
+
+const MAX_WARNED_IDS = 10;
+const MAX_WARNED_ID_LENGTH = 80;
+
+/**
+ * Emit a single per-run warning for the malformed CVE ids skipped by a feed
+ * parse/sync, carrying the skipped count and a truncated sample of the
+ * offending ids. No-op when nothing was skipped.
+ */
+export function warnMalformedCveIds(tag: string, skippedIds: ReadonlySet<string>): void {
+  if (skippedIds.size === 0) return;
+
+  const sample = Array.from(skippedIds)
+    .slice(0, MAX_WARNED_IDS)
+    .map((id) => JSON.stringify(id.length > MAX_WARNED_ID_LENGTH ? `${id.slice(0, MAX_WARNED_ID_LENGTH)}…` : id));
+  const suffix = skippedIds.size > MAX_WARNED_IDS ? `, … +${skippedIds.size - MAX_WARNED_IDS} more` : '';
+  console.warn(
+    `[${tag}] Skipped ${skippedIds.size} record(s) with malformed CVE id(s): ${sample.join(', ')}${suffix}`
+  );
+}

--- a/apps/api/src/services/msrcClient.test.ts
+++ b/apps/api/src/services/msrcClient.test.ts
@@ -68,5 +68,14 @@ describe('parseCvrf', () => {
       expect(warn).toHaveBeenCalledTimes(1);
       expect(warn.mock.calls[0]?.[0]).toContain(malformedCveId);
     });
+
+    it('throws when EVERY CVE id is malformed (probable feed format change)', () => {
+      const allMalformed = {
+        ...doc,
+        Vulnerability: [doc.Vulnerability[0]],
+      };
+
+      expect(() => parseCvrf(allMalformed)).toThrow(/probable upstream feed format change/);
+    });
   });
 });

--- a/apps/api/src/services/msrcClient.test.ts
+++ b/apps/api/src/services/msrcClient.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { parseCvrf } from './msrcClient';
 import sample from './__fixtures__/msrc-sample.json';
 
@@ -23,5 +23,50 @@ describe('parseCvrf', () => {
     if (record) {
       expect(['Critical', 'High', 'Medium', 'Low']).toContain(record.severity);
     }
+  });
+
+  describe('malformed CVE ids (#2261)', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    const malformedCveId = 'CVE-2023-38039 mariner - do not use this one';
+    const doc = {
+      ProductTree: {
+        FullProductName: [
+          { ProductID: '1', CPE: 'cpe:2.3:o:microsoft:cbl-mariner:*:*:*:*:*:*:*:*', Value: 'CBL Mariner 2.0 x64' },
+        ],
+      },
+      Vulnerability: [
+        {
+          // The literal malformed record Microsoft ships in the CBL-Mariner
+          // CVRF feed — 44 chars, longer than vulnerabilities.cve_id varchar(32).
+          CVE: malformedCveId,
+          Remediations: [{ Type: 2, FixedBuild: '2.0.20230801', ProductID: ['1'] }],
+        },
+        {
+          CVE: 'CVE-2023-38040',
+          Remediations: [{ Type: 2, FixedBuild: '2.0.20230801', ProductID: ['1'] }],
+        },
+      ],
+    };
+
+    it('drops the malformed record and keeps valid siblings', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const records = parseCvrf(doc);
+
+      expect(records).toHaveLength(1);
+      expect(records[0]?.cveId).toBe('CVE-2023-38040');
+    });
+
+    it('warns once with the offending id', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      parseCvrf(doc);
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0]?.[0]).toContain(malformedCveId);
+    });
   });
 });

--- a/apps/api/src/services/msrcClient.ts
+++ b/apps/api/src/services/msrcClient.ts
@@ -1,4 +1,4 @@
-import { isValidCveId, warnMalformedCveIds } from './cveId';
+import { assertSomeValidCveIds, isValidCveId, warnMalformedCveIds } from './cveId';
 
 const BASE_URL = 'https://api.msrc.microsoft.com/cvrf/v3.0';
 
@@ -104,7 +104,9 @@ export function parseCvrf(doc: unknown): MsrcRecord[] {
 
   const records: MsrcRecord[] = [];
   const malformedCveIds = new Set<string>();
-  for (const vulnerability of asArray<CvrfVulnerability>(cvrf.Vulnerability)) {
+  const vulnerabilityEntries = asArray<CvrfVulnerability>(cvrf.Vulnerability);
+  let validCveIdCount = 0;
+  for (const vulnerability of vulnerabilityEntries) {
     const cveId = stringValue(vulnerability.CVE);
     if (!cveId) continue;
     // Upstream garbage guard (#2261): Microsoft has shipped CVRF records whose
@@ -114,6 +116,7 @@ export function parseCvrf(doc: unknown): MsrcRecord[] {
       malformedCveIds.add(cveId);
       continue;
     }
+    validCveIdCount += 1;
 
     const scoreSet = asArray<CvrfScoreSet>(vulnerability.CVSSScoreSets)[0];
     const cvssScore = numericValue(scoreSet?.BaseScore);
@@ -145,6 +148,12 @@ export function parseCvrf(doc: unknown): MsrcRecord[] {
     }
   }
 
+  assertSomeValidCveIds({
+    tag: 'MsrcClient',
+    entryCount: vulnerabilityEntries.length,
+    validCount: validCveIdCount,
+    malformedIds: malformedCveIds,
+  });
   warnMalformedCveIds('MsrcClient', malformedCveIds);
   return records;
 }

--- a/apps/api/src/services/msrcClient.ts
+++ b/apps/api/src/services/msrcClient.ts
@@ -1,3 +1,5 @@
+import { isValidCveId, warnMalformedCveIds } from './cveId';
+
 const BASE_URL = 'https://api.msrc.microsoft.com/cvrf/v3.0';
 
 export interface MsrcRecord {
@@ -101,9 +103,17 @@ export function parseCvrf(doc: unknown): MsrcRecord[] {
   }
 
   const records: MsrcRecord[] = [];
+  const malformedCveIds = new Set<string>();
   for (const vulnerability of asArray<CvrfVulnerability>(cvrf.Vulnerability)) {
     const cveId = stringValue(vulnerability.CVE);
     if (!cveId) continue;
+    // Upstream garbage guard (#2261): Microsoft has shipped CVRF records whose
+    // CVE id is free text longer than varchar(32). Drop them here so one bad
+    // record can't abort the whole sync transaction.
+    if (!isValidCveId(cveId)) {
+      malformedCveIds.add(cveId);
+      continue;
+    }
 
     const scoreSet = asArray<CvrfScoreSet>(vulnerability.CVSSScoreSets)[0];
     const cvssScore = numericValue(scoreSet?.BaseScore);
@@ -135,6 +145,7 @@ export function parseCvrf(doc: unknown): MsrcRecord[] {
     }
   }
 
+  warnMalformedCveIds('MsrcClient', malformedCveIds);
   return records;
 }
 

--- a/apps/api/src/services/nvdClient.test.ts
+++ b/apps/api/src/services/nvdClient.test.ts
@@ -68,4 +68,12 @@ describe('parseNvd', () => {
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0]?.[0]).toContain(malformedCveId);
   });
+
+  it('throws when EVERY CVE id is malformed (probable feed format change)', () => {
+    const doc = {
+      vulnerabilities: [{ cve: { id: 'CVE-2023-38039 mariner - do not use this one' } }],
+    };
+
+    expect(() => parseNvd(doc)).toThrow(/probable upstream feed format change/);
+  });
 });

--- a/apps/api/src/services/nvdClient.test.ts
+++ b/apps/api/src/services/nvdClient.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import { parseNvd } from './nvdClient';
 import sample from './__fixtures__/nvd-sample.json';
 
 describe('parseNvd', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('extracts CVE, CVSS, and CPE version ranges', () => {
     const recs = parseNvd(sample);
     const chrome = recs.find((record) => record.cveId === 'CVE-2024-0519');
@@ -44,5 +49,23 @@ describe('parseNvd', () => {
     expect(prefixes).toContain('cpe:2.3:a:google:chrome');
     expect(prefixes).toContain('cpe:2.3:a:obscurevendor:obscureproduct');
     expect(prefixes).not.toContain('cpe:2.3:o:fedoraproject:fedora');
+  });
+
+  it('drops records with malformed CVE ids and keeps valid siblings (#2261)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const malformedCveId = 'CVE-2023-38039 mariner - do not use this one';
+    const doc = {
+      vulnerabilities: [
+        { cve: { id: malformedCveId } },
+        { cve: { id: 'CVE-2024-11111' } },
+      ],
+    };
+
+    const records = parseNvd(doc);
+
+    expect(records).toHaveLength(1);
+    expect(records[0]?.cveId).toBe('CVE-2024-11111');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain(malformedCveId);
   });
 });

--- a/apps/api/src/services/nvdClient.ts
+++ b/apps/api/src/services/nvdClient.ts
@@ -1,3 +1,4 @@
+import { isValidCveId, warnMalformedCveIds } from './cveId';
 import type { VersionRange } from './versionCompare';
 
 const NVD_CVES_URL = 'https://services.nvd.nist.gov/rest/json/cves/2.0';
@@ -65,11 +66,18 @@ function flattenNodes(configurations: unknown): JsonObject[] {
 export function parseNvd(doc: unknown): NvdRecord[] {
   const root = asObject(doc);
   const records: NvdRecord[] = [];
+  const malformedCveIds = new Set<string>();
 
   for (const item of asArray(root?.vulnerabilities)) {
     const cve = asObject(asObject(item)?.cve);
     const cveId = asString(cve?.id);
     if (!cve || !cveId) continue;
+    // Upstream garbage guard (#2261): drop records whose CVE id doesn't match
+    // the canonical shape (would overflow varchar(32) and abort the sync).
+    if (!isValidCveId(cveId)) {
+      malformedCveIds.add(cveId);
+      continue;
+    }
 
     const metric = selectedMetric(cve);
     const cvssData = asObject(metric?.cvssData);
@@ -104,6 +112,7 @@ export function parseNvd(doc: unknown): NvdRecord[] {
     });
   }
 
+  warnMalformedCveIds('NvdClient', malformedCveIds);
   return records;
 }
 

--- a/apps/api/src/services/nvdClient.ts
+++ b/apps/api/src/services/nvdClient.ts
@@ -1,4 +1,4 @@
-import { isValidCveId, warnMalformedCveIds } from './cveId';
+import { assertSomeValidCveIds, isValidCveId, warnMalformedCveIds } from './cveId';
 import type { VersionRange } from './versionCompare';
 
 const NVD_CVES_URL = 'https://services.nvd.nist.gov/rest/json/cves/2.0';
@@ -67,8 +67,10 @@ export function parseNvd(doc: unknown): NvdRecord[] {
   const root = asObject(doc);
   const records: NvdRecord[] = [];
   const malformedCveIds = new Set<string>();
+  const items = asArray(root?.vulnerabilities);
+  let validCveIdCount = 0;
 
-  for (const item of asArray(root?.vulnerabilities)) {
+  for (const item of items) {
     const cve = asObject(asObject(item)?.cve);
     const cveId = asString(cve?.id);
     if (!cve || !cveId) continue;
@@ -78,6 +80,7 @@ export function parseNvd(doc: unknown): NvdRecord[] {
       malformedCveIds.add(cveId);
       continue;
     }
+    validCveIdCount += 1;
 
     const metric = selectedMetric(cve);
     const cvssData = asObject(metric?.cvssData);
@@ -112,6 +115,12 @@ export function parseNvd(doc: unknown): NvdRecord[] {
     });
   }
 
+  assertSomeValidCveIds({
+    tag: 'NvdClient',
+    entryCount: items.length,
+    validCount: validCveIdCount,
+    malformedIds: malformedCveIds,
+  });
   warnMalformedCveIds('NvdClient', malformedCveIds);
   return records;
 }

--- a/apps/api/src/services/sofaClient.test.ts
+++ b/apps/api/src/services/sofaClient.test.ts
@@ -54,4 +54,22 @@ describe('parseSofa', () => {
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0]?.[0]).toContain(malformedCveId);
   });
+
+  it('throws when EVERY CVE id is malformed (probable feed format change)', () => {
+    const doc = {
+      OSVersions: [
+        {
+          OSVersion: 'Tahoe 26',
+          SecurityReleases: [
+            {
+              ProductVersion: '26.5',
+              CVEs: { 'CVE-2023-38039 mariner - do not use this one': true },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(() => parseSofa(doc)).toThrow(/probable upstream feed format change/);
+  });
 });

--- a/apps/api/src/services/sofaClient.test.ts
+++ b/apps/api/src/services/sofaClient.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { parseSofa } from './sofaClient';
 import sample from './__fixtures__/sofa-sample.json';
 
 describe('parseSofa', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('maps macOS lines and fixed versions to CVEs', () => {
     const records = parseSofa(sample);
 
@@ -20,5 +24,34 @@ describe('parseSofa', () => {
       cveId: 'CVE-2026-1837',
       activelyExploited: true,
     }));
+  });
+
+  it('drops records with malformed CVE ids and keeps valid siblings (#2261)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const malformedCveId = 'CVE-2023-38039 mariner - do not use this one';
+    const doc = {
+      OSVersions: [
+        {
+          OSVersion: 'Tahoe 26',
+          SecurityReleases: [
+            {
+              ProductVersion: '26.5',
+              CVEs: {
+                [malformedCveId]: true,
+                'CVE-2026-1837': true,
+              },
+              ActivelyExploitedCVEs: ['CVE-2026-1837'],
+            },
+          ],
+        },
+      ],
+    };
+
+    const records = parseSofa(doc);
+
+    expect(records).toHaveLength(1);
+    expect(records[0]?.cveId).toBe('CVE-2026-1837');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain(malformedCveId);
   });
 });

--- a/apps/api/src/services/sofaClient.ts
+++ b/apps/api/src/services/sofaClient.ts
@@ -2,6 +2,7 @@ import { and, eq, sql } from 'drizzle-orm';
 
 import { db, withSystemDbAccessContext } from '../db';
 import { osVulnerabilities, vulnerabilities, vulnerabilitySources } from '../db/schema';
+import { isValidCveId, warnMalformedCveIds } from './cveId';
 
 const SOFA_MACOS_FEED_URL = 'https://sofafeed.macadmins.io/v2/macos_data_feed.json';
 
@@ -33,6 +34,7 @@ function asString(value: unknown): string | null {
 export function parseSofa(doc: unknown): SofaRecord[] {
   const root = asObject(doc);
   const records: SofaRecord[] = [];
+  const malformedCveIds = new Set<string>();
 
   for (const osVersion of asArray(root?.OSVersions)) {
     const osNode = asObject(osVersion);
@@ -51,6 +53,12 @@ export function parseSofa(doc: unknown): SofaRecord[] {
 
       for (const cveId of Object.keys(cves)) {
         if (!cveId) continue;
+        // Upstream garbage guard (#2261): drop records whose CVE id doesn't
+        // match the canonical shape (would overflow varchar(32) and abort the sync).
+        if (!isValidCveId(cveId)) {
+          malformedCveIds.add(cveId);
+          continue;
+        }
         records.push({
           osLine,
           fixedVersion,
@@ -61,6 +69,7 @@ export function parseSofa(doc: unknown): SofaRecord[] {
     }
   }
 
+  warnMalformedCveIds('SofaClient', malformedCveIds);
   return records;
 }
 
@@ -220,7 +229,15 @@ export async function syncSofa(
     return await withSystemDbAccessContext(async () => {
       const now = new Date();
       const vulnerabilityIds = new Map<string, string>();
+      const skippedCveIds = new Set<string>();
       for (const vuln of distinctCves(recs)) {
+        // Defense-in-depth re-check of the parse-boundary validation (#2261).
+        // Everything here runs in one transaction, so letting a malformed id
+        // reach the INSERT would poison the whole run — skip it instead.
+        if (!isValidCveId(vuln.cveId)) {
+          skippedCveIds.add(vuln.cveId);
+          continue;
+        }
         vulnerabilityIds.set(vuln.cveId, await upsertSofaVulnerability({
           cveId: vuln.cveId,
           activelyExploited: vuln.activelyExploited,
@@ -249,6 +266,7 @@ export async function syncSofa(
         }
       }
 
+      warnMalformedCveIds('SofaClient', skippedCveIds);
       await upsertSofaSourceSuccess(now);
       return { vulns: vulnerabilityIds.size, osFacts };
     });

--- a/apps/api/src/services/sofaClient.ts
+++ b/apps/api/src/services/sofaClient.ts
@@ -2,7 +2,7 @@ import { and, eq, sql } from 'drizzle-orm';
 
 import { db, withSystemDbAccessContext } from '../db';
 import { osVulnerabilities, vulnerabilities, vulnerabilitySources } from '../db/schema';
-import { isValidCveId, warnMalformedCveIds } from './cveId';
+import { assertSomeValidCveIds, isValidCveId, warnMalformedCveIds } from './cveId';
 
 const SOFA_MACOS_FEED_URL = 'https://sofafeed.macadmins.io/v2/macos_data_feed.json';
 
@@ -35,6 +35,8 @@ export function parseSofa(doc: unknown): SofaRecord[] {
   const root = asObject(doc);
   const records: SofaRecord[] = [];
   const malformedCveIds = new Set<string>();
+  let cveKeyCount = 0;
+  let validCveIdCount = 0;
 
   for (const osVersion of asArray(root?.OSVersions)) {
     const osNode = asObject(osVersion);
@@ -52,6 +54,7 @@ export function parseSofa(doc: unknown): SofaRecord[] {
       );
 
       for (const cveId of Object.keys(cves)) {
+        cveKeyCount += 1;
         if (!cveId) continue;
         // Upstream garbage guard (#2261): drop records whose CVE id doesn't
         // match the canonical shape (would overflow varchar(32) and abort the sync).
@@ -59,6 +62,7 @@ export function parseSofa(doc: unknown): SofaRecord[] {
           malformedCveIds.add(cveId);
           continue;
         }
+        validCveIdCount += 1;
         records.push({
           osLine,
           fixedVersion,
@@ -69,6 +73,12 @@ export function parseSofa(doc: unknown): SofaRecord[] {
     }
   }
 
+  assertSomeValidCveIds({
+    tag: 'SofaClient',
+    entryCount: cveKeyCount,
+    validCount: validCveIdCount,
+    malformedIds: malformedCveIds,
+  });
   warnMalformedCveIds('SofaClient', malformedCveIds);
   return records;
 }
@@ -266,7 +276,7 @@ export async function syncSofa(
         }
       }
 
-      warnMalformedCveIds('SofaClient', skippedCveIds);
+      warnMalformedCveIds('SofaClient/sync', skippedCveIds);
       await upsertSofaSourceSuccess(now);
       return { vulns: vulnerabilityIds.size, osFacts };
     });


### PR DESCRIPTION
## Summary

The daily MSRC vulnerability sync on prod (US) has been failing entirely because Microsoft's CBL-Mariner CVRF feed ships a record whose CVE id is the literal string `CVE-2023-38039 mariner - do not use this one` (44 chars). `vulnerabilities.cve_id` is `varchar(32)`, so the INSERT threw `22001 value too long`, and — because each sync runs in a single transaction — one bad upstream record aborted the whole run and marked the source `error`. No Windows/Office/Mariner CVE data has been ingested since.

## Fix (code-only, no migration)

- **Shared validator** `apps/api/src/services/cveId.ts`: `isValidCveId` (`^CVE-\d{4}-\d{4,}$`, length <= 32 to match the column) plus `warnMalformedCveIds`, which emits a single per-run warning carrying the skipped count and a truncated sample of the offending ids.
- **Parse-boundary validation on all three feeds** (the blast-radius parity from the issue): `parseCvrf` (MSRC), `parseNvd` (NVD), `parseSofa` (SOFA) drop malformed records with the warning. Downstream match-facts for a dropped record fall away cleanly because they key off the `vulnerabilityIds` map.
- **Defense-in-depth guard in the upsert loops** (`syncMsrcMonth`, `syncNvd`, `syncSofa`): re-check `isValidCveId` and skip before the INSERT.

### Why not the per-record try/catch proposed in the issue

All three sync loops run inside one `withSystemDbAccessContext` transaction (`baseDb.transaction` in `apps/api/src/db/index.ts`). Once any statement fails, Postgres poisons the transaction — every subsequent statement fails with `25P02` — so catching around the individual upsert cannot save the run (and postgres.js re-throws handled errors out of `begin`, a known footgun in this repo). Skipping invalid ids *before* the INSERT is the only isolation that actually works without per-record savepoints; the loop-level guard delivers the same "one bad row doesn't abort the run" outcome the issue asked for.

No migration: real CVE ids are well under 32 chars, and widening the column would just persist upstream garbage into the catalog and its unique index.

## Tests

- `apps/api/src/jobs/vulnerabilityJobs.integration.test.ts` — new regression: feed containing the literal malformed Mariner record + a valid sibling; asserts the sync resolves, only the valid CVE lands, and `msrc.last_sync_status = 'ok'`. **Verified non-vacuous**: with the fix reverted, this test fails with the exact prod error (`22001 value too long for type character varying(32)`).
- `apps/api/src/services/cveId.test.ts` — validator accept/reject table (incl. the 44-char Mariner string) + warning behavior (no-op on empty, single call, sample truncation).
- `apps/api/src/services/msrcClient.test.ts` / `nvdClient.test.ts` / `sofaClient.test.ts` — each parser drops the malformed record, keeps valid siblings, and warns once with the offending id.

Verification: 26 unit tests green; MSRC/NVD/SOFA integration suites green against the real test DB (run single-file — the parallel failure earlier in verification was the known shared-DB deadlock flake, not this change); `tsc --noEmit` clean.

Once deployed, the next MSRC sync should go green and backfill the missed CVEs.

Closes #2261

🤖 Generated with [Claude Code](https://claude.com/claude-code)