### PR TITLE
feat(web): surface hidden decommissioned devices on the Devices page (#2251)

### DIFF
--- a/apps/web/src/components/devices/DecommissionedHiddenHint.tsx
+++ b/apps/web/src/components/devices/DecommissionedHiddenHint.tsx
@@ -1,0 +1,34 @@
+// Discoverability hint (#2251): decommissioned devices are hidden from the
+// Devices page by default, and nothing on the page used to say so — the only
+// unhide mechanism was knowing the status filter has a "Decommissioned"
+// option. This renders a lightweight "N decommissioned hidden — show" line
+// next to the device count (list view) / above the grid (grid view), where
+// "show" applies the existing Decommissioned status filter upstream. Callers
+// gate rendering on the hidden count being non-zero and on decommissioned
+// devices not already being visible.
+export default function DecommissionedHiddenHint({
+  count,
+  onShow,
+}: {
+  count: number;
+  onShow: () => void;
+}) {
+  if (count <= 0) return null;
+  return (
+    <span
+      data-testid="decommissioned-hidden-hint"
+      className="text-sm text-muted-foreground"
+    >
+      {count} decommissioned hidden
+      {' — '}
+      <button
+        type="button"
+        data-testid="decommissioned-hidden-show"
+        onClick={onShow}
+        className="underline underline-offset-2 transition hover:text-foreground"
+      >
+        show
+      </button>
+    </span>
+  );
+}

--- a/apps/web/src/components/devices/DecommissionedHiddenHint.tsx
+++ b/apps/web/src/components/devices/DecommissionedHiddenHint.tsx
@@ -3,9 +3,10 @@
 // unhide mechanism was knowing the status filter has a "Decommissioned"
 // option. This renders a lightweight "N decommissioned hidden — show" line
 // next to the device count (list view) / above the grid (grid view), where
-// "show" applies the existing Decommissioned status filter upstream. Callers
-// gate rendering on the hidden count being non-zero and on decommissioned
-// devices not already being visible.
+// "show" applies the existing Decommissioned status filter upstream. The
+// upstream count memos return 0 when decommissioned devices are already
+// visible (includeDecommissioned), and the component renders nothing for
+// count <= 0 — so it self-dismisses once the rows are shown.
 export default function DecommissionedHiddenHint({
   count,
   onShow,

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -858,3 +858,72 @@ describe('DeviceList — linked multi-boot profiles (#2138)', () => {
     expect(screen.queryByTestId('collapse-linked-toggle')).toBeNull();
   });
 });
+
+// #2251 — the default view hides decommissioned devices; the count footer must
+// say so and offer the existing unhide mechanism (the Decommissioned status
+// filter, applied upstream via onShowDecommissioned).
+describe('DeviceList — hidden-decommissioned hint (#2251)', () => {
+  beforeEach(() => {
+    window.localStorage?.clear();
+  });
+
+  const decomDevice: Device = {
+    ...baseDevice,
+    id: '99999999-9999-9999-9999-999999999999',
+    hostname: 'host-decom',
+    status: 'decommissioned',
+  };
+
+  it('shows the hidden count and calls onShowDecommissioned when "show" is clicked', () => {
+    const onShow = vi.fn();
+    render(
+      <DeviceList
+        devices={[baseDevice, decomDevice]}
+        onShowDecommissioned={onShow}
+      />
+    );
+
+    const hint = screen.getByTestId('decommissioned-hidden-hint');
+    expect(hint).toHaveTextContent('1 decommissioned hidden');
+
+    fireEvent.click(screen.getByTestId('decommissioned-hidden-show'));
+    expect(onShow).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the footer total consistent with the hidden rows (excludes decommissioned)', () => {
+    render(
+      <DeviceList
+        devices={[baseDevice, decomDevice]}
+        onShowDecommissioned={vi.fn()}
+      />
+    );
+
+    // 1 visible of 1 non-decommissioned — the hidden row is called out by the
+    // hint instead of silently vanishing from the denominator.
+    expect(screen.getByText(/1 of 1 devices/)).toBeInTheDocument();
+  });
+
+  it('renders no hint when decommissioned devices are already visible (includeDecommissioned)', () => {
+    render(
+      <DeviceList
+        devices={[baseDevice, decomDevice]}
+        includeDecommissioned
+        onShowDecommissioned={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId('decommissioned-hidden-hint')).toBeNull();
+    // Denominator includes the now-visible decommissioned row.
+    expect(screen.getByText(/2 of 2 devices/)).toBeInTheDocument();
+  });
+
+  it('renders no hint when there are no decommissioned devices', () => {
+    render(<DeviceList devices={[baseDevice]} onShowDecommissioned={vi.fn()} />);
+    expect(screen.queryByTestId('decommissioned-hidden-hint')).toBeNull();
+  });
+
+  it('renders no hint when no onShowDecommissioned handler is wired (standalone render)', () => {
+    render(<DeviceList devices={[baseDevice, decomDevice]} />);
+    expect(screen.queryByTestId('decommissioned-hidden-hint')).toBeNull();
+  });
+});

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -859,9 +859,10 @@ describe('DeviceList — linked multi-boot profiles (#2138)', () => {
   });
 });
 
-// #2251 — the default view hides decommissioned devices; the count footer must
-// say so and offer the existing unhide mechanism (the Decommissioned status
-// filter, applied upstream via onShowDecommissioned).
+// #2251 — the default view hides decommissioned devices; the "X of Y devices"
+// count line (rendered above the table) must say so and offer the existing
+// unhide mechanism (the Decommissioned status filter, applied upstream via
+// onShowDecommissioned).
 describe('DeviceList — hidden-decommissioned hint (#2251)', () => {
   beforeEach(() => {
     window.localStorage?.clear();
@@ -890,7 +891,7 @@ describe('DeviceList — hidden-decommissioned hint (#2251)', () => {
     expect(onShow).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps the footer total consistent with the hidden rows (excludes decommissioned)', () => {
+  it('keeps the count-line total consistent with the hidden rows (excludes decommissioned)', () => {
     render(
       <DeviceList
         devices={[baseDevice, decomDevice]}

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -41,6 +41,7 @@ import {
   type LinkedProfileCollapsePreference,
 } from '@/lib/appearance';
 import { groupLinkedDevices } from './linkedDevices';
+import DecommissionedHiddenHint from './DecommissionedHiddenHint';
 import { OSIcon } from './osIcons';
 import { formatDeviceOsVersion } from './osDisplay';
 import { type ListFilters, DEFAULT_LIST_FILTERS } from './deviceListFilters';
@@ -194,6 +195,10 @@ type DeviceListProps = {
   // true only when the active filter group explicitly targets the
   // 'decommissioned' status, so filtering FOR decommissioned still shows them.
   includeDecommissioned?: boolean;
+  // Applies the Decommissioned status filter upstream (#2251) — the existing
+  // unhide mechanism. Wired by DevicesPage; when absent (standalone renders /
+  // tests) the "N decommissioned hidden — show" hint is not rendered.
+  onShowDecommissioned?: () => void;
   // Unified-list network arm (#1322). Off by default behind a build-time flag
   // (PUBLIC_ENABLE_NETWORK_DEVICES_IN_LIST); when false the Class/Type columns
   // and the All/Agent/Network facet are hidden entirely so the list is the
@@ -358,6 +363,7 @@ export default function DeviceList({
   onBulkAction,
   pageSize = 10,
   includeDecommissioned = false,
+  onShowDecommissioned,
   serverFilterIds = null,
   serverFilterLoading = false,
   networkDevicesEnabled = false,
@@ -549,6 +555,17 @@ export default function DeviceList({
       return matchesClass && matchesVpn && matchesQuery;
     });
   }, [devices, query, classFilter, vpnFilter, serverFilterIds, includeDecommissioned]);
+
+  // How many decommissioned devices the default view is hiding (#2251). Zero
+  // when they're already visible (includeDecommissioned) so the hint and the
+  // count math below stay consistent with what the table actually shows.
+  const hiddenDecommissionedCount = useMemo(
+    () =>
+      includeDecommissioned
+        ? 0
+        : devices.filter(d => d.status === 'decommissioned').length,
+    [devices, includeDecommissioned]
+  );
 
   // Providers present across the loaded set — drives the VPN facet options so
   // techs only see providers that actually exist in their fleet.
@@ -1271,12 +1288,20 @@ export default function DeviceList({
       <div className="flex flex-col gap-3">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-sm text-muted-foreground">
-            {filteredDevices.length} of {includeDecommissioned ? devices.length : devices.filter(d => d.status !== 'decommissioned').length} devices
+            {filteredDevices.length} of {devices.length - hiddenDecommissionedCount} devices
             {serverFilterIds !== null && (
               <span className="ml-2 inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
                 <Filter className="h-3 w-3" />
                 Advanced filter active
                 {serverFilterLoading && <span className="ml-1 animate-pulse">...</span>}
+              </span>
+            )}
+            {onShowDecommissioned && hiddenDecommissionedCount > 0 && (
+              <span className="ml-2">
+                <DecommissionedHiddenHint
+                  count={hiddenDecommissionedCount}
+                  onShow={onShowDecommissioned}
+                />
               </span>
             )}
           </p>

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -126,10 +126,11 @@ vi.mock('./DeviceCard', () => ({
 // the per-action buttons to drive DevicesPage.handleBulkAction directly.
 type StubDevice = { id: string; deviceClass?: string; hostname?: string; displayName?: string; watchdogVersion?: string | null };
 vi.mock('./DeviceList', () => ({
-  default: ({ devices, serverFilterIds, onBulkAction, onSelect }: { devices: StubDevice[]; serverFilterIds?: Set<string> | null; onBulkAction?: (action: string, devices: StubDevice[]) => void; onSelect?: (device: StubDevice) => void }) => (
+  default: ({ devices, serverFilterIds, onBulkAction, onSelect, onShowDecommissioned, includeDecommissioned }: { devices: StubDevice[]; serverFilterIds?: Set<string> | null; onBulkAction?: (action: string, devices: StubDevice[]) => void; onSelect?: (device: StubDevice) => void; onShowDecommissioned?: () => void; includeDecommissioned?: boolean }) => (
     <div
       data-testid="device-list"
       data-device-count={devices.length}
+      data-include-decommissioned={includeDecommissioned ? 'true' : 'false'}
       data-filter-ids={serverFilterIds ? [...serverFilterIds].sort().join(',') : ''}
       data-hostnames={devices.map(d => d.hostname ?? '').join(',')}
       data-display-names={devices.map(d => d.displayName ?? '').join(',')}
@@ -155,6 +156,15 @@ vi.mock('./DeviceList', () => ({
           select {d.id}
         </button>
       ))}
+      {onShowDecommissioned && (
+        <button
+          type="button"
+          data-testid="stub-show-decommissioned"
+          onClick={() => onShowDecommissioned()}
+        >
+          show decommissioned
+        </button>
+      )}
     </div>
   ),
 }));
@@ -643,5 +653,106 @@ describe('DevicesPage — row selection routes by device class (#1424)', () => {
     fireEvent.click(selectBtn);
 
     expect(vi.mocked(navigateTo)).toHaveBeenCalledWith(`/devices/${DEV_1}`);
+  });
+});
+
+// #2251 — decommissioned devices are hidden by default with no cue that they
+// exist. The page must surface a "N decommissioned hidden — show" hint in both
+// views, and "show" applies the Decommissioned status filter (the existing
+// unhide mechanism — includeDecommissioned flips true when the active filter
+// targets that status).
+describe('DevicesPage — hidden-decommissioned hint (#2251)', () => {
+  it('grid view shows the hint; clicking "show" applies the Decommissioned filter and reveals the rows', async () => {
+    const { decodeFilterFromHash } = await import('./filterUrl');
+    vi.mocked(decodeFilterFromHash).mockReturnValueOnce(null);
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [
+        rawDevice(DEV_1, 'host-alpha'),
+        { ...rawDevice(DEV_2, 'host-beta'), status: 'decommissioned' },
+        { ...rawDevice(DEV_3, 'host-gamma'), status: 'decommissioned' },
+      ],
+    } as never);
+    // The decommissioned status filter resolves to the two decommissioned rows.
+    vi.mocked(fetchWithAuth).mockImplementation(async (url: string) => {
+      if (url.startsWith('/filters/preview')) {
+        return jsonResponse({
+          data: { totalCount: 2, deviceIds: [DEV_2, DEV_3], evaluatedAt: new Date().toISOString() },
+        });
+      }
+      return jsonResponse({ data: [] });
+    });
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByLabelText('Grid view'));
+
+    // Hidden rows are called out; only the online card renders.
+    const hint = await screen.findByTestId('decommissioned-hidden-hint');
+    expect(hint).toHaveTextContent('2 decommissioned hidden');
+    expect(screen.getByTestId(`device-card-${DEV_1}`)).toBeTruthy();
+    expect(screen.queryByTestId(`device-card-${DEV_2}`)).toBeNull();
+
+    fireEvent.click(screen.getByTestId('decommissioned-hidden-show'));
+
+    // The status filter now targets decommissioned → those cards render, the
+    // online card drops out (filtered), and the hint disappears.
+    expect(await screen.findByTestId(`device-card-${DEV_2}`)).toBeTruthy();
+    expect(screen.getByTestId(`device-card-${DEV_3}`)).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByTestId(`device-card-${DEV_1}`)).toBeNull();
+    });
+    expect(screen.queryByTestId('decommissioned-hidden-hint')).toBeNull();
+
+    // The applied condition is the toolbar-equivalent status filter.
+    const previewCall = vi.mocked(fetchWithAuth).mock.calls.find(([url]) =>
+      String(url).startsWith('/filters/preview')
+    );
+    expect(previewCall).toBeDefined();
+    const body = JSON.parse(previewCall![1]?.body as string);
+    expect(body.conditions).toEqual({
+      operator: 'AND',
+      conditions: [{ field: 'status', operator: 'equals', value: 'decommissioned' }],
+    });
+  });
+
+  it('grid view renders no hint when no decommissioned devices exist', async () => {
+    const { decodeFilterFromHash } = await import('./filterUrl');
+    vi.mocked(decodeFilterFromHash).mockReturnValueOnce(null);
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByLabelText('Grid view'));
+
+    await screen.findByTestId(`device-card-${DEV_1}`);
+    expect(screen.queryByTestId('decommissioned-hidden-hint')).toBeNull();
+  });
+
+  it('list view: onShowDecommissioned replaces an existing status value and keeps other conditions', async () => {
+    const { decodeFilterFromHash, writeFilterToHash } = await import('./filterUrl');
+    vi.mocked(decodeFilterFromHash).mockReturnValueOnce({
+      operator: 'AND',
+      conditions: [
+        { field: 'os', operator: 'equals', value: 'windows' },
+        { field: 'status', operator: 'equals', value: 'online' },
+      ],
+    });
+
+    render(<DevicesPage />);
+    const list = await screen.findByTestId('device-list');
+    expect(list.getAttribute('data-include-decommissioned')).toBe('false');
+
+    fireEvent.click(screen.getByTestId('stub-show-decommissioned'));
+
+    // status=online is REPLACED (single-select per field, like the toolbar);
+    // the os condition is preserved.
+    await waitFor(() => {
+      const last = vi.mocked(writeFilterToHash).mock.calls.at(-1)?.[0];
+      expect(last).toEqual({
+        operator: 'AND',
+        conditions: [
+          { field: 'os', operator: 'equals', value: 'windows' },
+          { field: 'status', operator: 'equals', value: 'decommissioned' },
+        ],
+      });
+    });
+    expect(list.getAttribute('data-include-decommissioned')).toBe('true');
   });
 });

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -756,3 +756,79 @@ describe('DevicesPage — hidden-decommissioned hint (#2251)', () => {
     expect(list.getAttribute('data-include-decommissioned')).toBe('true');
   });
 });
+
+// #2251 — the two trickier handleShowDecommissioned branches: an OR sentence
+// from the Advanced drawer must be nested (not rewritten to AND, and the
+// status condition must stay top-level where the includeDecommissioned memo
+// looks), and a multi-select `in` status condition must be replaced, not
+// stacked into a contradictory AND.
+describe('DevicesPage — show-decommissioned filter rewrite edge cases (#2251)', () => {
+  it('nests an OR group and keeps the status condition top-level', async () => {
+    const { decodeFilterFromHash, writeFilterToHash } = await import('./filterUrl');
+    const orGroup = {
+      operator: 'OR' as const,
+      conditions: [
+        { field: 'os', operator: 'equals' as const, value: 'windows' },
+        { field: 'os', operator: 'equals' as const, value: 'macos' },
+      ],
+    };
+    vi.mocked(decodeFilterFromHash).mockReturnValueOnce(orGroup);
+
+    render(<DevicesPage />);
+    const list = await screen.findByTestId('device-list');
+    expect(list.getAttribute('data-include-decommissioned')).toBe('false');
+
+    fireEvent.click(screen.getByTestId('stub-show-decommissioned'));
+
+    await waitFor(() => {
+      const last = vi.mocked(writeFilterToHash).mock.calls.at(-1)?.[0];
+      expect(last).toEqual({
+        operator: 'AND',
+        conditions: [
+          orGroup,
+          { field: 'status', operator: 'equals', value: 'decommissioned' },
+        ],
+      });
+    });
+    // The top-level status condition is what flips includeDecommissioned —
+    // a condition buried inside the nested group would leave the rows hidden.
+    expect(list.getAttribute('data-include-decommissioned')).toBe('true');
+  });
+
+  it('replaces a multi-select `in` status condition and preserves nested subgroups', async () => {
+    const { decodeFilterFromHash, writeFilterToHash } = await import('./filterUrl');
+    const nestedGroup = {
+      operator: 'OR' as const,
+      conditions: [
+        { field: 'os', operator: 'equals' as const, value: 'windows' },
+        { field: 'os', operator: 'equals' as const, value: 'linux' },
+      ],
+    };
+    vi.mocked(decodeFilterFromHash).mockReturnValueOnce({
+      operator: 'AND',
+      conditions: [
+        nestedGroup,
+        { field: 'status', operator: 'in', value: ['online', 'offline'] },
+      ],
+    });
+
+    render(<DevicesPage />);
+    const list = await screen.findByTestId('device-list');
+
+    fireEvent.click(screen.getByTestId('stub-show-decommissioned'));
+
+    // A leftover `status in [...]` would AND with the new equals to an
+    // always-empty result; it must be replaced. The nested subgroup survives.
+    await waitFor(() => {
+      const last = vi.mocked(writeFilterToHash).mock.calls.at(-1)?.[0];
+      expect(last).toEqual({
+        operator: 'AND',
+        conditions: [
+          nestedGroup,
+          { field: 'status', operator: 'equals', value: 'decommissioned' },
+        ],
+      });
+    });
+    expect(list.getAttribute('data-include-decommissioned')).toBe('true');
+  });
+});

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -206,12 +206,16 @@ export default function DevicesPage() {
 
   // "Show" action for the hidden-decommissioned hint (#2251): applies the
   // Decommissioned status filter — the same unhide mechanism the toolbar's
-  // status picker uses — replacing any other status value (status is
-  // single-select per field, mirroring DeviceFilterToolbar's addCondition).
-  // Other filter conditions are preserved. If the current group is an OR
-  // sentence built in the Advanced drawer, nest it instead of rewriting it so
-  // its meaning is kept and the status condition stays top-level (where the
-  // includeDecommissioned memo looks).
+  // status picker uses — replacing any other status equals/in value. Same
+  // single-select-per-field semantics as DeviceFilterToolbar's addCondition
+  // (independent implementation; chip order may differ — the replacement is
+  // appended rather than placed in the replaced condition's slot). Other
+  // filter conditions are preserved. If the current group is an OR sentence
+  // built in the Advanced drawer, nest it instead of rewriting it so its
+  // meaning is kept and the status condition stays top-level (where the
+  // includeDecommissioned memo looks); the AND intersection can be empty if
+  // the OR sentence itself constrains status — the rows still unhide, but
+  // zero of them may match.
   const handleShowDecommissioned = useCallback(() => {
     setAdvancedFilter(prev => {
       const statusCond: FilterCondition = { field: 'status', operator: 'equals', value: 'decommissioned' };

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -3,10 +3,11 @@ import { useEventStream } from '../../hooks/useEventStream';
 import { useAdvancedFilterIds } from '../../hooks/useAdvancedFilterIds';
 import { List, Grid, Plus, AlertCircle } from 'lucide-react';
 import { showToast } from '../shared/Toast';
-import type { FilterConditionGroup } from '@breeze/shared';
+import type { FilterCondition, FilterConditionGroup } from '@breeze/shared';
 import DeviceList, { type Device, type DeviceClass, type DeviceStatus, type OSType } from './DeviceList';
 import type { DeviceRole } from '@/lib/deviceRoles';
 import DeviceCard from './DeviceCard';
+import DecommissionedHiddenHint from './DecommissionedHiddenHint';
 import ScriptPickerModal, { type Script, type ScriptRunAsSelection } from './ScriptPickerModal';
 import DeviceSettingsModal from './DeviceSettingsModal';
 import AddDeviceModal from './AddDeviceModal';
@@ -202,6 +203,27 @@ export default function DevicesPage() {
         : c.value === 'decommissioned';
     });
   }, [advancedFilter]);
+
+  // "Show" action for the hidden-decommissioned hint (#2251): applies the
+  // Decommissioned status filter — the same unhide mechanism the toolbar's
+  // status picker uses — replacing any other status value (status is
+  // single-select per field, mirroring DeviceFilterToolbar's addCondition).
+  // Other filter conditions are preserved. If the current group is an OR
+  // sentence built in the Advanced drawer, nest it instead of rewriting it so
+  // its meaning is kept and the status condition stays top-level (where the
+  // includeDecommissioned memo looks).
+  const handleShowDecommissioned = useCallback(() => {
+    setAdvancedFilter(prev => {
+      const statusCond: FilterCondition = { field: 'status', operator: 'equals', value: 'decommissioned' };
+      if (!prev) return { operator: 'AND', conditions: [statusCond] };
+      if (prev.operator === 'OR') return { operator: 'AND', conditions: [prev, statusCond] };
+      const rest = prev.conditions.filter(
+        c => 'conditions' in c || c.field !== 'status' || (c.operator !== 'equals' && c.operator !== 'in')
+      );
+      return { operator: 'AND', conditions: [...rest, statusCond] };
+    });
+  }, []);
+
   // Per-segment counts come from the full merged fleet so each segment shows its
   // true total regardless of which one is active. Gated to the network arm; with
   // the flag off the segment isn't rendered and these go unused.
@@ -220,6 +242,17 @@ export default function DevicesPage() {
       return advancedFilterIds === null ? base : base.filter(d => advancedFilterIds.has(d.id));
     },
     [classFilteredDevices, advancedFilterIds, includeDecommissioned]
+  );
+  // How many decommissioned devices the default view is hiding (#2251) — drives
+  // the grid view's hint line (the list view computes its own from the same
+  // classFilteredDevices set, so the two stay in lockstep). The page fetches
+  // with includeDecommissioned: true, so this is a cheap client-side count.
+  const hiddenDecommissionedCount = useMemo(
+    () =>
+      includeDecommissioned
+        ? 0
+        : classFilteredDevices.filter(d => d.status === 'decommissioned').length,
+    [classFilteredDevices, includeDecommissioned]
   );
 
   const fetchDevices = useCallback(async (signal?: AbortSignal) => {
@@ -1063,6 +1096,7 @@ export default function DevicesPage() {
           serverFilterIds={advancedFilterIds}
           serverFilterLoading={advancedFilterLoading}
           includeDecommissioned={includeDecommissioned}
+          onShowDecommissioned={handleShowDecommissioned}
           listFilters={listFilters}
           onListFiltersChange={setListFilters}
           onCreateGroup={() => setShowCreateGroup(true)}
@@ -1071,15 +1105,25 @@ export default function DevicesPage() {
           networkDevicesEnabled={ENABLE_NETWORK_DEVICES_IN_LIST}
         />
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {gridDevices.map(device => (
-            <DeviceCard
-              key={device.id}
-              device={device}
-              onClick={handleSelectDevice}
-              onAction={handleDeviceAction}
-            />
-          ))}
+        <div className="space-y-3">
+          {hiddenDecommissionedCount > 0 && (
+            <p>
+              <DecommissionedHiddenHint
+                count={hiddenDecommissionedCount}
+                onShow={handleShowDecommissioned}
+              />
+            </p>
+          )}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {gridDevices.map(device => (
+              <DeviceCard
+                key={device.id}
+                device={device}
+                onClick={handleSelectDevice}
+                onAction={handleDeviceAction}
+              />
+            ))}
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Decommissioned devices are hidden from the Devices page by default, and nothing on the page indicated they exist — the only unhide mechanism was knowing the status filter has a "Decommissioned" option, and the "X of Y devices" footer count silently excluded them (the exact audit blind spot from the #2230 offboarding scenario).

Following the issue's proposed fix, this adds a lightweight **"N decommissioned hidden — show"** indicator:

- **List view**: rendered next to the "X of Y devices" count footer in `DeviceList`.
- **Grid view**: rendered as a line above the card grid in `DevicesPage`.
- **"show"** applies the Decommissioned status filter through the existing advanced-filter plumbing (`setAdvancedFilter`) — the same unhide mechanism as the toolbar's status picker. It replaces any other status value (status is single-select per field, mirroring `DeviceFilterToolbar.addCondition`) and preserves all other conditions; an OR group built in the Advanced drawer is nested rather than rewritten so its meaning is kept.
- Hidden when the active filter already targets `decommissioned` (they're visible then, and `includeDecommissioned` flips true) or when the count is zero.
- No API change — the page already fetches with `includeDecommissioned: true`, so the count is a cheap client-side filter over the same `classFilteredDevices` set both views consume.

New shared component: `apps/web/src/components/devices/DecommissionedHiddenHint.tsx` (with `data-testid="decommissioned-hidden-hint"` / `decommissioned-hidden-show`).

## Tests

- `DeviceList.test.tsx`: hint renders with count and fires the callback; footer denominator stays consistent (excludes hidden rows, includes them when visible); no hint when `includeDecommissioned`, when the count is zero, or when no handler is wired (standalone renders).
- `DevicesPage.test.tsx`: grid-view hint end-to-end — count shown, clicking "show" applies the `status equals decommissioned` condition (asserted on the `/filters/preview` body), decommissioned cards render, hint disappears; list-view handler replaces an existing status value while preserving other conditions (asserted via `writeFilterToHash`) and flips `includeDecommissioned`.
- `pnpm exec vitest run` on the 5 affected suites: 98 passed. `npx tsc --noEmit` clean.

Closes #2251

🤖 Generated with [Claude Code](https://claude.com/claude-code)