### PR TITLE
refactor(quotes): QuoteDepositConfig as a discriminated union (#2248)

### DIFF
--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -10,7 +10,7 @@ import { acceptQuoteSchema, declineQuoteSchema } from '@breeze/shared';
 import { markQuoteViewed, declineQuoteByActor } from '../../services/quoteLifecycle';
 import { acceptQuote, emitAcceptInvoiceIssued } from '../../services/quoteAcceptService';
 import { createQuotePayLink } from '../../services/quotePay';
-import { computeQuoteTotals, type QuoteLineForMath } from '../../services/quoteMath';
+import { computeQuoteTotals, toQuoteDepositConfig, type QuoteLineForMath } from '../../services/quoteMath';
 import { readQuoteImage } from '../../services/quoteImageStorage';
 import { QuoteServiceError } from '../../services/quoteTypes';
 import { toCustomerLines } from '../../services/quoteService';
@@ -45,7 +45,7 @@ quoteRoutes.get('/quotes/:id', zValidator('param', idParam), async (c) => {
   // Derive the amount accept actually invoices (one-time only) so the customer
   // sees an accurate "due on acceptance" instead of the recurring-inclusive total,
   // plus the deposit due + per-category subtotals for the summary panel.
-  const totals = computeQuoteTotals(lines as QuoteLineForMath[], quote.taxRate ? parseFloat(quote.taxRate) : null, { type: quote.depositType, percent: quote.depositPercent });
+  const totals = computeQuoteTotals(lines as QuoteLineForMath[], quote.taxRate ? parseFloat(quote.taxRate) : null, toQuoteDepositConfig(quote.depositType, quote.depositPercent));
   return c.json({ data: { quote: { ...quote, dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal, depositDueTotal: totals.depositDueTotal, categoryBreakdown: totals.categoryBreakdown }, blocks, lines } });
 });
 
@@ -61,7 +61,7 @@ quoteRoutes.get('/quotes/:id/pdf', zValidator('param', idParam), async (c) => {
   // "Remaining balance" line matches the portal detail view instead of falling
   // back to renderQuotePdf's oneTimeTotal default (tax-exclusive on taxed
   // deposit quotes).
-  const totals = computeQuoteTotals(lines as QuoteLineForMath[], quote.taxRate ? parseFloat(quote.taxRate) : null, { type: quote.depositType, percent: quote.depositPercent });
+  const totals = computeQuoteTotals(lines as QuoteLineForMath[], quote.taxRate ? parseFloat(quote.taxRate) : null, toQuoteDepositConfig(quote.depositType, quote.depositPercent));
   // partners is a partner-axis RLS table — the portal request runs in ORG scope,
   // where breeze_has_partner_access is false. A bare read returns 0 rows with NO
   // error (the #1375 class), causing buildSellerSnapshot(undefined) to produce an

--- a/apps/api/src/routes/quotesPublic.ts
+++ b/apps/api/src/routes/quotesPublic.ts
@@ -16,7 +16,7 @@ import { toCustomerLines } from '../services/quoteService';
 import { InvoiceServiceError } from '../services/invoiceTypes';
 import { isQuoteExpired } from '../services/quoteExpiry';
 import { createQuotePayLink } from '../services/quotePay';
-import { computeQuoteTotals, type QuoteLineForMath } from '../services/quoteMath';
+import { computeQuoteTotals, toQuoteDepositConfig, type QuoteLineForMath } from '../services/quoteMath';
 import { captureException } from '../services/sentry';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 
@@ -58,7 +58,7 @@ quotesPublicRoutes.get('/:token', zValidator('param', tokenParam), async (c) => 
     // Derive the amount accept actually invoices (one-time only) so the prospect
     // sees an accurate "due on acceptance" instead of the recurring-inclusive total,
     // plus the deposit due + per-category subtotals for the summary panel.
-    const totals = computeQuoteTotals(lines as QuoteLineForMath[], quote.taxRate ? parseFloat(quote.taxRate) : null, { type: quote.depositType, percent: quote.depositPercent });
+    const totals = computeQuoteTotals(lines as QuoteLineForMath[], quote.taxRate ? parseFloat(quote.taxRate) : null, toQuoteDepositConfig(quote.depositType, quote.depositPercent));
     return { quote: { ...quote, status: quote.status === 'sent' ? 'viewed' : quote.status, dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal, depositDueTotal: totals.depositDueTotal, categoryBreakdown: totals.categoryBreakdown }, blocks, lines, branding: { partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null } };
   }));
   if (!data) return c.json({ error: 'Quote not found' }, 404);

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -5,7 +5,7 @@ import { organizations, partners } from '../db/schema/orgs';
 import { portalBranding } from '../db/schema/portal';
 import { getQuote, toCustomerLines } from './quoteService';
 import { QuoteServiceError, type QuoteActor } from './quoteTypes';
-import { validateQuoteDeposit, type QuoteLineForMath } from './quoteMath';
+import { validateQuoteDeposit, toQuoteDepositConfig, type QuoteLineForMath } from './quoteMath';
 import { allocateQuoteCounter, formatQuoteNumber } from './quoteNumbers';
 import { createQuoteAcceptToken } from './quoteAcceptToken';
 import { buildQuoteTemplate } from './quoteEmail';
@@ -96,7 +96,7 @@ export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote:
     const check = validateQuoteDeposit(
       lines as QuoteLineForMath[],
       quote.taxRate ? parseFloat(quote.taxRate) : null,
-      { type: quote.depositType, percent: quote.depositPercent },
+      toQuoteDepositConfig(quote.depositType, quote.depositPercent),
     );
     if (!check.ok) {
       throw new QuoteServiceError(`Cannot send: ${check.message}`, 409, 'DEPOSIT_INVALID');

--- a/apps/api/src/services/quoteMath.ts
+++ b/apps/api/src/services/quoteMath.ts
@@ -7,6 +7,7 @@
 export {
   computeQuoteTotals,
   validateQuoteDeposit,
+  toQuoteDepositConfig,
   type QuoteLineForMath,
   type QuoteTotals,
   type QuoteDepositConfig,

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -5,7 +5,7 @@ import { invoices } from '../db/schema/invoices';
 import { organizations, partners } from '../db/schema/orgs';
 import { catalogItems } from '../db/schema/catalog';
 import { computeLineTotal, resolveEffectiveTaxRate } from './invoiceMath';
-import { computeQuoteTotals, validateQuoteDeposit, type QuoteLineForMath } from './quoteMath';
+import { computeQuoteTotals, validateQuoteDeposit, toQuoteDepositConfig, type QuoteLineForMath } from './quoteMath';
 import { QuoteServiceError, type QuoteActor } from './quoteTypes';
 import { allocateQuoteCounter, formatQuoteNumber } from './quoteNumbers';
 import type {
@@ -65,7 +65,7 @@ async function recomputeAndPersist(quoteId: string): Promise<void> {
     depositEligible: quoteLines.depositEligible,
     itemType: quoteLines.itemType,
   }).from(quoteLines).where(eq(quoteLines.quoteId, quoteId));
-  const deposit = { type: q?.depositType ?? 'none', percent: q?.depositPercent ?? null } as const;
+  const deposit = toQuoteDepositConfig(q?.depositType, q?.depositPercent);
   const totals = computeQuoteTotals(lines as QuoteLineForMath[], q?.taxRate ? parseFloat(q.taxRate) : null, deposit);
   await db.update(quotes).set({
     subtotal: totals.subtotal,
@@ -177,7 +177,7 @@ export async function getQuote(id: string, actor: QuoteActor) {
   const totals = computeQuoteTotals(
     lines as QuoteLineForMath[],
     q.taxRate ? parseFloat(q.taxRate) : null,
-    { type: q.depositType, percent: q.depositPercent },
+    toQuoteDepositConfig(q.depositType, q.depositPercent),
   );
   return {
     quote: {
@@ -245,9 +245,11 @@ export async function updateQuote(id: string, input: UpdateQuoteInput, actor: Qu
     // validated against the stale persisted rate could pass here and then fail
     // (or silently mis-total) once the new tax rate lands via recomputeAndPersist.
     const effectiveTaxRate = (input.taxRate !== undefined ? input.taxRate : (q.taxRate ? parseFloat(q.taxRate) : null));
-    const check = validateQuoteDeposit(lines as QuoteLineForMath[], effectiveTaxRate === null ? null : Number(effectiveTaxRate), {
-      type: nextType, percent: nextPercent,
-    });
+    const check = validateQuoteDeposit(
+      lines as QuoteLineForMath[],
+      effectiveTaxRate === null ? null : Number(effectiveTaxRate),
+      toQuoteDepositConfig(nextType, nextPercent),
+    );
     if (!check.ok) throw new QuoteServiceError(check.message, 400, check.code);
     set.depositType = nextType;
     set.depositPercent = nextType === 'percent' && nextPercent != null ? Number(nextPercent).toFixed(2) : null;

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -20,7 +20,7 @@ import {
   quoteImageUrl,
 } from '../../../lib/api/quotes';
 import type { QuoteBlockInput } from '@breeze/shared';
-import { computeQuoteTotals, computeQuoteProfit, computeLineTotal, markupPct, priceFromMarkup, toCents, fromCents, type QuoteLineForMath, type QuoteProfit, type QuoteTotals, type QuoteDepositType, type QuoteDepositConfig } from '@breeze/shared';
+import { computeQuoteTotals, computeQuoteProfit, computeLineTotal, markupPct, priceFromMarkup, toCents, fromCents, toQuoteDepositConfig, type QuoteLineForMath, type QuoteProfit, type QuoteTotals, type QuoteDepositType, type QuoteDepositConfig } from '@breeze/shared';
 import { listCatalog, createCatalogItem, catalogItemImagePath, type CatalogItem } from '../../../lib/api/catalog';
 import { ecExpressStatus, ecExpressImport, type EcProduct, type EcStatus, pax8Status, pax8Import, type Pax8Product, type Pax8PriceOption } from '../../../lib/api/distributors';
 import CatalogItemPicker from '../../catalog/CatalogItemPicker';
@@ -553,10 +553,9 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
     [lines, lineDrafts],
   );
   const depositConfig = useMemo<QuoteDepositConfig>(
-    () => ({
-      type: depositType,
-      percent: depositType === 'percent' && depositPercentDraft.trim() !== '' ? Number(depositPercentDraft) : null,
-    }),
+    // A blank percent draft normalizes to NaN, which computeQuoteTotals treats
+    // as "no deposit" — the live rail simply shows no deposit row mid-edit.
+    () => toQuoteDepositConfig(depositType, depositPercentDraft.trim()),
     [depositType, depositPercentDraft],
   );
   const liveDepositTotals = useMemo(

--- a/packages/shared/src/utils/quoteMath.test.ts
+++ b/packages/shared/src/utils/quoteMath.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeQuoteTotals, computeLineTotal, toCents, fromCents, markupPct, priceFromMarkup, computeQuoteProfit, validateQuoteDeposit, type QuoteLineForMath } from './quoteMath';
+import { computeQuoteTotals, computeLineTotal, toCents, fromCents, markupPct, priceFromMarkup, computeQuoteProfit, validateQuoteDeposit, toQuoteDepositConfig, type QuoteLineForMath } from './quoteMath';
 
 const line = (over: Partial<QuoteLineForMath>): QuoteLineForMath => ({
   quantity: '1', unitPrice: '0', taxable: false, recurrence: 'one_time', customerVisible: true, ...over,
@@ -164,7 +164,11 @@ describe('quoteMath (shared)', () => {
       expect(r).toMatchObject({ ok: false, code: 'DEPOSIT_REQUIRES_ONE_TIME_LINES' });
     });
     it('rejects percent type without a usable percent', () => {
-      expect(validateQuoteDeposit([line({})], null, { type: 'percent', percent: null }))
+      // A missing/blank persisted percent normalizes to NaN — validation must
+      // still fail it (the union makes `percent: null` unrepresentable).
+      expect(validateQuoteDeposit([line({})], null, toQuoteDepositConfig('percent', null)))
+        .toMatchObject({ ok: false, code: 'DEPOSIT_PERCENT_INVALID' });
+      expect(validateQuoteDeposit([line({})], null, { type: 'percent', percent: Number.NaN }))
         .toMatchObject({ ok: false, code: 'DEPOSIT_PERCENT_INVALID' });
       expect(validateQuoteDeposit([line({})], null, { type: 'percent', percent: 100 }))
         .toMatchObject({ ok: false, code: 'DEPOSIT_PERCENT_INVALID' });
@@ -181,6 +185,39 @@ describe('quoteMath (shared)', () => {
     it('rejects deposit >= dueOnAcceptanceTotal (all lines flagged = "no deposit")', () => {
       const r = validateQuoteDeposit([line({ depositEligible: true })], null, { type: 'selected_lines' });
       expect(r).toMatchObject({ ok: false, code: 'DEPOSIT_NOT_BELOW_TOTAL' });
+    });
+  });
+
+  describe('toQuoteDepositConfig (flat DB/wire pair → union)', () => {
+    it('maps each type, coercing numeric-string percents', () => {
+      expect(toQuoteDepositConfig('none', null)).toEqual({ type: 'none' });
+      expect(toQuoteDepositConfig('selected_lines', null)).toEqual({ type: 'selected_lines' });
+      expect(toQuoteDepositConfig('percent', 30)).toEqual({ type: 'percent', percent: 30 });
+      // DB numeric columns arrive as strings.
+      expect(toQuoteDepositConfig('percent', '30.00')).toEqual({ type: 'percent', percent: 30 });
+    });
+
+    it('treats a missing type as none', () => {
+      expect(toQuoteDepositConfig(null, '30.00')).toEqual({ type: 'none' });
+      expect(toQuoteDepositConfig(undefined, null)).toEqual({ type: 'none' });
+    });
+
+    it('drops a stray percent on non-percent types (illegal state normalized away)', () => {
+      expect(toQuoteDepositConfig('selected_lines', '30.00')).toEqual({ type: 'selected_lines' });
+      expect(toQuoteDepositConfig('none', 15)).toEqual({ type: 'none' });
+    });
+
+    it('normalizes a missing/blank percent on a percent deposit to NaN (still rejected, never silently "none")', () => {
+      for (const missing of [null, undefined, ''] as const) {
+        const cfg = toQuoteDepositConfig('percent', missing);
+        expect(cfg.type).toBe('percent');
+        expect(cfg.type === 'percent' && Number.isNaN(cfg.percent)).toBe(true);
+        // Compute treats it as "no deposit"…
+        expect(computeQuoteTotals([line({ unitPrice: '100.00' })], null, cfg).depositDueTotal).toBeNull();
+        // …but validation still hard-fails it, matching the pre-union behavior.
+        expect(validateQuoteDeposit([line({ unitPrice: '100.00' })], null, cfg))
+          .toMatchObject({ ok: false, code: 'DEPOSIT_PERCENT_INVALID' });
+      }
     });
   });
 }

--- a/packages/shared/src/utils/quoteMath.test.ts
+++ b/packages/shared/src/utils/quoteMath.test.ts
@@ -195,6 +195,10 @@ describe('quoteMath (shared)', () => {
       expect(toQuoteDepositConfig('percent', 30)).toEqual({ type: 'percent', percent: 30 });
       // DB numeric columns arrive as strings.
       expect(toQuoteDepositConfig('percent', '30.00')).toEqual({ type: 'percent', percent: 30 });
+      // Zero/negative pass through as-is — the isFinite && >0 gates downstream
+      // reject them, same as the pre-union Number() coercion did.
+      expect(toQuoteDepositConfig('percent', 0)).toEqual({ type: 'percent', percent: 0 });
+      expect(toQuoteDepositConfig('percent', '-5')).toEqual({ type: 'percent', percent: -5 });
     });
 
     it('treats a missing type as none', () => {
@@ -208,7 +212,7 @@ describe('quoteMath (shared)', () => {
     });
 
     it('normalizes a missing/blank percent on a percent deposit to NaN (still rejected, never silently "none")', () => {
-      for (const missing of [null, undefined, ''] as const) {
+      for (const missing of [null, undefined, '', '  '] as const) {
         const cfg = toQuoteDepositConfig('percent', missing);
         expect(cfg.type).toBe('percent');
         expect(cfg.type === 'percent' && Number.isNaN(cfg.percent)).toBe(true);

--- a/packages/shared/src/utils/quoteMath.ts
+++ b/packages/shared/src/utils/quoteMath.ts
@@ -36,11 +36,43 @@ export function computeLineTotal(quantity: string | number, unitPrice: string | 
   return fromCents(roundHalfUp(fractionalCents));
 }
 
-export type QuoteDepositType = 'none' | 'percent' | 'selected_lines';
-export interface QuoteDepositConfig {
-  type: QuoteDepositType;
-  /** Required for type 'percent'. Whole-percent scale (30 = 30%), 2dp. */
-  percent?: number | string | null;
+/**
+ * Deposit config as a discriminated union so illegal states ({ type: 'percent' }
+ * with no percent, or a percent on a non-percent type) are unrepresentable at
+ * compile time. Mirrors the QuoteDepositValidation union below.
+ */
+export type QuoteDepositConfig =
+  /** No deposit. */
+  | { type: 'none' }
+  /** Whole-percent scale (30 = 30%), 2dp. May be NaN when normalized from a
+   *  missing/blank source value — validateQuoteDeposit rejects it and
+   *  computeQuoteTotals treats it as "no deposit" (both gate on isFinite). */
+  | { type: 'percent'; percent: number }
+  /** Eligibility lives on the lines (QuoteLineForMath.depositEligible). */
+  | { type: 'selected_lines' };
+
+export type QuoteDepositType = QuoteDepositConfig['type'];
+
+/**
+ * Normalize the flat persisted/wire pair (deposit_type, deposit_percent) into
+ * the union. The DB and API keep the flat columns/fields — this is the single
+ * read-boundary adapter, so construction sites don't hand-build literals.
+ * A missing/blank percent on a 'percent' deposit becomes NaN (NOT a silent
+ * 'none'): validateQuoteDeposit must still fail it with DEPOSIT_PERCENT_INVALID,
+ * exactly as the pre-union code did.
+ */
+export function toQuoteDepositConfig(
+  type: QuoteDepositType | null | undefined,
+  percent: number | string | null | undefined,
+): QuoteDepositConfig {
+  if (type === 'percent') {
+    return {
+      type: 'percent',
+      percent: percent === null || percent === undefined || percent === '' ? Number.NaN : Number(percent),
+    };
+  }
+  if (type === 'selected_lines') return { type: 'selected_lines' };
+  return { type: 'none' };
 }
 
 export interface QuoteLineForMath {
@@ -125,9 +157,11 @@ export function computeQuoteTotals(
 
   let depositCents: number | null = null;
   if (deposit && deposit.type === 'percent') {
-    const pct = Number(deposit.percent);
-    if (Number.isFinite(pct) && pct > 0) {
-      depositCents = Math.floor(dueOnAcceptanceCents * (pct / 100) + 0.5);
+    // The union guarantees a number, but not a *sane* one (NaN from a blank
+    // normalized source, or ≤0 from an unvalidated caller) — money code keeps
+    // the finite-positive gate rather than trusting compile-time alone.
+    if (Number.isFinite(deposit.percent) && deposit.percent > 0) {
+      depositCents = Math.floor(dueOnAcceptanceCents * (deposit.percent / 100) + 0.5);
     }
   } else if (deposit && deposit.type === 'selected_lines') {
     depositCents = eligibleCents + Math.floor(eligibleTaxableCents * rate + 0.5);
@@ -176,7 +210,7 @@ export function validateQuoteDeposit(
       message: 'A deposit needs at least one one-time, customer-visible line' };
   }
   if (deposit.type === 'percent') {
-    const pct = Number(deposit.percent);
+    const pct = deposit.percent;
     if (!Number.isFinite(pct) || pct <= 0 || pct >= 100) {
       return { ok: false, code: 'DEPOSIT_PERCENT_INVALID', message: 'Deposit percent must be between 0 and 100 (exclusive)' };
     }

--- a/packages/shared/src/utils/quoteMath.ts
+++ b/packages/shared/src/utils/quoteMath.ts
@@ -66,10 +66,9 @@ export function toQuoteDepositConfig(
   percent: number | string | null | undefined,
 ): QuoteDepositConfig {
   if (type === 'percent') {
-    return {
-      type: 'percent',
-      percent: percent === null || percent === undefined || percent === '' ? Number.NaN : Number(percent),
-    };
+    const blank = percent === null || percent === undefined
+      || (typeof percent === 'string' && percent.trim() === '');
+    return { type: 'percent', percent: blank ? Number.NaN : Number(percent) };
   }
   if (type === 'selected_lines') return { type: 'selected_lines' };
   return { type: 'none' };


### PR DESCRIPTION
## Summary

Follow-up from the #2245 review: `QuoteDepositConfig` was a flat optional-field record whose "percent is required for type 'percent'" invariant lived in a comment. This makes it a discriminated union so illegal states (`{ type: 'percent' }` with no percent, a stray percent on a non-percent type) are unrepresentable at compile time — mirroring the existing `QuoteDepositValidation` union in the same file.

**Type-safety refactor only — no wire, DB, or runtime behavior change.** #2245's runtime enforcement (the `updateQuoteSchema.refine` at the API boundary and the `quotes_deposit_*_chk` DB constraints) is untouched and remains the correctness layer.

## Changes

- `packages/shared/src/utils/quoteMath.ts`
  - `QuoteDepositConfig` → `{ type: 'none' } | { type: 'percent'; percent: number } | { type: 'selected_lines' }`; `QuoteDepositType` derived as `QuoteDepositConfig['type']`.
  - New `toQuoteDepositConfig(type, percent)` — the single read-boundary normalizer from the flat persisted/wire pair (`deposit_type`, `deposit_percent`) to the union. A missing/blank percent on a `'percent'` deposit normalizes to `NaN` (not a silent `'none'`), so `validateQuoteDeposit` still fails it with `DEPOSIT_PERCENT_INVALID` and `computeQuoteTotals` still treats it as no-deposit — byte-identical to the pre-union behavior.
  - `computeQuoteTotals` / `validateQuoteDeposit` narrow on `deposit.type` and read `deposit.percent` directly instead of `Number()`-ing an optional. The finite-positive gate in the money path stays (guards `NaN`/unvalidated callers).
- Construction sites swept to the normalizer: `recomputeAndPersist` / `getQuote` / `updateQuote` (`quoteService.ts`), `sendQuote` (`quoteLifecycle.ts`), `quotesPublic.ts`, `portal/quotes.ts`, and the web editor's live-totals rail (`QuoteEditor.tsx`).
- The API re-export hub (`apps/api/src/services/quoteMath.ts`) now also re-exports the normalizer.

## Deliberately unchanged

- **Wire/DB shape** — the quote patch keeps flat `depositType`/`depositPercent` fields; the Zod schemas in `packages/shared/src/validators/quotes.ts` validate that flat shape and need no change. No migration.
- **`quoteContentHash.ts`** — its canonical `deposit: { type, percent, amount }` object is part of the signed acceptance hash; reshaping it would invalidate existing hashes.
- `quotePdf` / `quoteAcceptService` / `aiToolsQuotes` / portal + web types — all consume the flat persisted fields, not the config object.

## Tests

- `packages/shared/src/utils/quoteMath.test.ts`: new `toQuoteDepositConfig` suite (type mapping, DB numeric-string coercion, missing-type → `'none'`, stray-percent dropped, and the NaN round-trip proving compute says "no deposit" while validate still hard-fails).
- Existing deposit-math/validation suites updated only where a now-illegal literal (`percent: null`) was constructed.

## Verification

- shared: `vitest run quoteMath.test.ts quotes.test.ts` — 53 passed
- api: 8 quote suites (`quoteMath`, `quoteService`, `quoteLifecycle`, `quoteAcceptService`, `quotePdf`, `quoteContentHash`, `aiToolsQuotes`, `portal/quotes`) — 64 passed
- web: `QuoteEditor.deposit` + `QuotesPage.deposit` — 8 passed
- `tsc --noEmit` clean in `packages/shared`, `apps/api`, `apps/web`, `apps/portal`

Closes #2248

🤖 Generated with [Claude Code](https://claude.com/claude-code)