### PR TITLE
fix(api): readable string-first zValidator 400 bodies via shared wrapper (#2201)

### DIFF
--- a/apps/api/src/lib/validation.imports.test.ts
+++ b/apps/api/src/lib/validation.imports.test.ts
@@ -1,18 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 
 /**
- * Guard for issue #2201: route files must import `zValidator` from
+ * Guard for issue #2201: application code must import `zValidator` from
  * `src/lib/validation` (which installs the readable string-first 400 hook),
  * never from `@hono/zod-validator` directly — the package default returns a
  * raw serialized ZodError that is unreadable for every non-web client.
  *
- * `vi.mock('@hono/zod-validator', ...)` calls in tests are fine (they
- * intercept the wrapper's own base import), so only import statements count.
+ * Scope: all of `src/` (not just routes/) so a future validator-using
+ * middleware or shared helper can't reintroduce raw ZodError 400s. Only the
+ * wrapper itself and test files are exempt. `vi.mock('@hono/zod-validator',
+ * ...)` calls are fine regardless (they intercept the wrapper's own base
+ * import), and the regex also catches `export ... from` re-exports so the
+ * import can't be laundered through a helper.
  */
 
-const ROUTES_DIR = join(__dirname, '..', 'routes');
+const SRC_DIR = join(__dirname, '..');
+const WRAPPER = join(__dirname, 'validation.ts');
 
 function walk(dir: string): string[] {
   const out: string[] = [];
@@ -25,10 +30,15 @@ function walk(dir: string): string[] {
 }
 
 describe('zValidator import guard (#2201)', () => {
-  it('no route file imports @hono/zod-validator directly', () => {
-    const offenders = walk(ROUTES_DIR).filter((file) =>
-      /import\s[^;]*from\s+['"]@hono\/zod-validator['"]/.test(readFileSync(file, 'utf8'))
-    );
+  it('no app file imports @hono/zod-validator directly', () => {
+    const offenders = walk(SRC_DIR)
+      .filter((file) => file !== WRAPPER && !file.endsWith('.test.ts'))
+      .filter((file) =>
+        /(?:import|export)\s[^;]*from\s+['"]@hono\/zod-validator['"]/.test(
+          readFileSync(file, 'utf8')
+        )
+      )
+      .map((file) => relative(SRC_DIR, file));
     expect(
       offenders,
       `Import zValidator from src/lib/validation instead of @hono/zod-validator:\n${offenders.join('\n')}`

--- a/apps/api/src/lib/validation.imports.test.ts
+++ b/apps/api/src/lib/validation.imports.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Guard for issue #2201: route files must import `zValidator` from
+ * `src/lib/validation` (which installs the readable string-first 400 hook),
+ * never from `@hono/zod-validator` directly — the package default returns a
+ * raw serialized ZodError that is unreadable for every non-web client.
+ *
+ * `vi.mock('@hono/zod-validator', ...)` calls in tests are fine (they
+ * intercept the wrapper's own base import), so only import statements count.
+ */
+
+const ROUTES_DIR = join(__dirname, '..', 'routes');
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (entry.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+describe('zValidator import guard (#2201)', () => {
+  it('no route file imports @hono/zod-validator directly', () => {
+    const offenders = walk(ROUTES_DIR).filter((file) =>
+      /import\s[^;]*from\s+['"]@hono\/zod-validator['"]/.test(readFileSync(file, 'utf8'))
+    );
+    expect(
+      offenders,
+      `Import zValidator from src/lib/validation instead of @hono/zod-validator:\n${offenders.join('\n')}`
+    ).toEqual([]);
+  });
+});

--- a/apps/api/src/lib/validation.test.ts
+++ b/apps/api/src/lib/validation.test.ts
@@ -94,6 +94,49 @@ describe('zValidator wrapper (issue #2201)', () => {
     expect((await res.json()).error).toBe('custom email error');
   });
 
+  it('awaits an async custom hook so its Response wins', async () => {
+    const app = new Hono();
+    app.post(
+      '/custom',
+      zValidator('json', schema, async (result, c) => {
+        await Promise.resolve();
+        if (!result.success) return c.json({ error: 'async hook error' }, 422);
+      }),
+      (c) => c.json({ ok: true })
+    );
+
+    const res = await app.request('/custom', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: '', email: 'a@b.co' }),
+    });
+    expect(res.status).toBe(422);
+    expect((await res.json()).error).toBe('async hook error');
+  });
+
+  it('honors the base package {response: Response} hook return shape', async () => {
+    const app = new Hono();
+    app.post(
+      '/custom',
+      zValidator('json', schema, (result, c) => {
+        // The base @hono/zod-validator honors this wrapper shape even on
+        // SUCCESSFUL validation — dropping it would let the request proceed.
+        if (result.success && result.data.name === 'forbidden') {
+          return { response: c.json({ error: 'forbidden name' }, 403) } as unknown as Response;
+        }
+      }),
+      (c) => c.json({ ok: true })
+    );
+
+    const res = await app.request('/custom', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'forbidden', email: 'a@b.co' }),
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('forbidden name');
+  });
+
   it('falls through to the readable default when a custom hook returns nothing', async () => {
     const app = new Hono();
     app.post(
@@ -152,5 +195,55 @@ describe('formatZodError', () => {
 
   it('falls back to a generic message when there are no issues', () => {
     expect(formatZodError({ issues: [] }).error).toBe('Validation failed');
+  });
+
+  it('recurses into invalid_union branch errors instead of emitting bare "Invalid input"', async () => {
+    // Wire-level check: zod v4 buries union branch failures in a nested
+    // `errors` array and the union issue's own message is just "Invalid
+    // input" — the 400 body must surface the actionable branch messages.
+    const app = new Hono();
+    app.post(
+      '/union',
+      zValidator(
+        'json',
+        z.object({
+          target: z.union([
+            z.object({ kind: z.literal('device'), deviceId: z.string().min(1) }),
+            z.object({ kind: z.literal('org'), orgId: z.string().min(1) }),
+          ]),
+        })
+      ),
+      (c) => c.json({ ok: true })
+    );
+
+    const res = await app.request('/union', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ target: { kind: 'device' } }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    // Branch detail (the missing deviceId / wrong literal) must be present,
+    // not just the union's own generic message.
+    expect(body.error).not.toBe('target: Invalid input');
+    expect(JSON.stringify(body.details.fieldErrors)).toContain('target.deviceId');
+  });
+
+  it('collapses duplicate messages produced by identical union branches', () => {
+    const result = formatZodError({
+      issues: [
+        {
+          path: ['value'],
+          message: 'Invalid input',
+          code: 'invalid_union',
+          errors: [
+            [{ path: [], message: 'Too small' }],
+            [{ path: [], message: 'Too small' }],
+          ],
+        },
+      ],
+    });
+    expect(result.details.fieldErrors).toEqual({ value: ['Too small'] });
+    expect(result.error).toBe('value: Too small');
   });
 });

--- a/apps/api/src/lib/validation.test.ts
+++ b/apps/api/src/lib/validation.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { formatZodError, zValidator } from './validation';
+
+describe('zValidator wrapper (issue #2201)', () => {
+  const schema = z
+    .object({
+      name: z.string().min(1, 'Name is required'),
+      email: z.string().email('Invalid email'),
+    })
+    .strict();
+
+  function makeApp() {
+    const app = new Hono();
+    app.post('/things', zValidator('json', schema), (c) => {
+      const body = c.req.valid('json');
+      return c.json({ ok: true, name: body.name });
+    });
+    return app;
+  }
+
+  it('returns a readable string-first 400 body with field paths and messages', async () => {
+    const app = makeApp();
+    const res = await app.request('/things', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: '', email: 'not-an-email' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+
+    // String-first contract: `error` is a string, never a serialized ZodError.
+    expect(typeof body.error).toBe('string');
+    expect(body.error).toContain('name: Name is required');
+    expect(body.error).toContain('email: Invalid email');
+    expect(body.success).toBeUndefined();
+
+    // Structured details for programmatic consumers.
+    expect(body.details.fieldErrors).toEqual({
+      name: ['Name is required'],
+      email: ['Invalid email'],
+    });
+    expect(body.details.formErrors).toEqual([]);
+  });
+
+  it('surfaces unrecognized keys from strict schemas as formErrors', async () => {
+    const app = makeApp();
+    const res = await app.request('/things', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'a', email: 'a@b.co', maxUses: 5 }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    // The offending key name must be visible to the caller (see
+    // enrollmentKeys_strict.test.ts / issue #945).
+    expect(body.error).toContain('maxUses');
+    expect(body.details.formErrors.join(' ')).toContain('maxUses');
+  });
+
+  it('passes validated data through on success', async () => {
+    const app = makeApp();
+    const res = await app.request('/things', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Widget', email: 'a@b.co' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, name: 'Widget' });
+  });
+
+  it('lets a custom hook Response win (orgs.ts /partners/me pattern)', async () => {
+    const app = new Hono();
+    app.post(
+      '/custom',
+      zValidator('json', schema, (result, c) => {
+        if (!result.success && result.error.issues.some((i) => i.path[0] === 'email')) {
+          return c.json({ error: 'custom email error' }, 422);
+        }
+      }),
+      (c) => c.json({ ok: true })
+    );
+
+    const res = await app.request('/custom', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'a', email: 'nope' }),
+    });
+    expect(res.status).toBe(422);
+    expect((await res.json()).error).toBe('custom email error');
+  });
+
+  it('falls through to the readable default when a custom hook returns nothing', async () => {
+    const app = new Hono();
+    app.post(
+      '/custom',
+      zValidator('json', schema, (result, c) => {
+        if (!result.success && result.error.issues.some((i) => i.path[0] === 'email')) {
+          return c.json({ error: 'custom email error' }, 422);
+        }
+      }),
+      (c) => c.json({ ok: true })
+    );
+
+    const res = await app.request('/custom', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: '', email: 'a@b.co' }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('name: Name is required');
+    expect(body.details.fieldErrors).toEqual({ name: ['Name is required'] });
+  });
+
+  it('validates non-json targets (query) with the same contract', async () => {
+    const app = new Hono();
+    app.get(
+      '/list',
+      zValidator('query', z.object({ orgId: z.string().uuid('Invalid org id') })),
+      (c) => c.json({ ok: true })
+    );
+
+    const res = await app.request('/list?orgId=nope');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('orgId: Invalid org id');
+  });
+});
+
+describe('formatZodError', () => {
+  it('joins nested paths with dots and groups repeated fields', () => {
+    const result = formatZodError({
+      issues: [
+        { path: ['contacts', 0, 'email'], message: 'Invalid email' },
+        { path: ['contacts', 0, 'email'], message: 'Too short' },
+        { path: [], message: 'Unrecognized key: "extra"' },
+      ],
+    });
+    expect(result.error).toBe(
+      'Unrecognized key: "extra"; contacts.0.email: Invalid email; Too short'
+    );
+    expect(result.details).toEqual({
+      formErrors: ['Unrecognized key: "extra"'],
+      fieldErrors: { 'contacts.0.email': ['Invalid email', 'Too short'] },
+    });
+  });
+
+  it('falls back to a generic message when there are no issues', () => {
+    expect(formatZodError({ issues: [] }).error).toBe('Validation failed');
+  });
+});

--- a/apps/api/src/lib/validation.ts
+++ b/apps/api/src/lib/validation.ts
@@ -13,7 +13,7 @@
  *
  * ```json
  * {
- *   "error": "name: Required; contacts.0.email: Invalid email",
+ *   "error": "Unrecognized key: \"maxUses\"; contacts.0.email: Invalid email",
  *   "details": {
  *     "formErrors": ["Unrecognized key: \"maxUses\""],
  *     "fieldErrors": { "contacts.0.email": ["Invalid email"] }
@@ -23,15 +23,17 @@
  *
  * The web client's `extractApiError` (apps/web/src/lib/apiError.ts) already
  * understands both `{error: string}` and the flattened `details` shape — the
- * `error` string here is built with the exact join rules of its
- * `joinZodFlatten` helper so the two render identically and dedupe into a
- * single toast line.
+ * `error` string here is built with the same ordering and `'; '` join rules
+ * as its `joinZodFlatten` helper so the two render identically and dedupe
+ * into a single toast line (pinned by a contract test in apiError.test.ts).
  *
  * Route files must import `zValidator` from this module, not from
- * `@hono/zod-validator` directly. A per-route custom hook can still be passed
- * as the third argument; if it returns a Response that wins, otherwise
- * validation failures fall through to the readable default above (previously
- * a non-returning hook fell through to the raw ZodError body).
+ * `@hono/zod-validator` directly (guarded by validation.imports.test.ts).
+ * A per-route custom hook can still be passed as the third argument; a
+ * returned `Response` — or the base package's `{response: Response}` return
+ * shape — wins, otherwise validation failures fall through to the readable
+ * default above (previously a non-returning hook fell through to the raw
+ * ZodError body).
  */
 import { zValidator as baseZValidator } from '@hono/zod-validator';
 import type { Hook } from '@hono/zod-validator';
@@ -50,22 +52,49 @@ export type ValidationErrorBody = {
  * Minimal structural view of a ZodError that works across zod v3/v4 types
  * (v4 `issue.path` is `ReadonlyArray<PropertyKey>` and may contain symbols).
  */
-type ZodErrorLike = {
-  issues: ReadonlyArray<{ path: ReadonlyArray<PropertyKey>; message: string }>;
+type ZodIssueLike = {
+  path: ReadonlyArray<PropertyKey>;
+  message: string;
+  code?: string;
+  errors?: ReadonlyArray<ReadonlyArray<ZodIssueLike>>;
 };
+
+type ZodErrorLike = {
+  issues: ReadonlyArray<ZodIssueLike>;
+};
+
+function collectIssues(
+  issues: ReadonlyArray<ZodIssueLike>,
+  basePath: ReadonlyArray<PropertyKey>,
+  formErrors: string[],
+  fieldErrors: Record<string, string[]>
+): void {
+  for (const issue of issues) {
+    const fullPath = [...basePath, ...issue.path];
+
+    // zod v4 buries each union branch's real failures in a nested `errors`
+    // array-of-arrays while the union issue's own message is just "Invalid
+    // input" — recurse so union-heavy schemas still surface actionable
+    // per-field messages. Branches often fail identically, so duplicates are
+    // collapsed per bucket.
+    if (issue.code === 'invalid_union' && Array.isArray(issue.errors) && issue.errors.length > 0) {
+      for (const branch of issue.errors) {
+        collectIssues(branch, fullPath, formErrors, fieldErrors);
+      }
+      continue;
+    }
+
+    const path = fullPath.map((segment) => String(segment)).join('.');
+    const bucket = path ? (fieldErrors[path] ??= []) : formErrors;
+    if (!bucket.includes(issue.message)) bucket.push(issue.message);
+  }
+}
 
 export function formatZodError(error: ZodErrorLike): ValidationErrorBody {
   const formErrors: string[] = [];
   const fieldErrors: Record<string, string[]> = {};
 
-  for (const issue of error.issues) {
-    const path = issue.path.map((segment) => String(segment)).join('.');
-    if (path) {
-      (fieldErrors[path] ??= []).push(issue.message);
-    } else {
-      formErrors.push(issue.message);
-    }
-  }
+  collectIssues(error.issues, [], formErrors, fieldErrors);
 
   const parts = [
     ...formErrors,
@@ -105,8 +134,15 @@ export const zValidator = <
       c: Context<E, P>
     ) => {
       if (hook) {
-        const hookResult = await hook(result, c);
+        const hookResult: unknown = await hook(result, c);
         if (hookResult instanceof Response) return hookResult;
+        // Mirror @hono/zod-validator's own semantics: a hook may also return
+        // a `{response: Response}` wrapper — dropping it would silently
+        // discard the hook's rejection and let the request proceed.
+        if (hookResult && typeof hookResult === 'object' && 'response' in hookResult) {
+          const wrapped = (hookResult as { response: unknown }).response;
+          if (wrapped instanceof Response) return wrapped;
+        }
       }
       if (!result.success) {
         return c.json(formatZodError(result.error as ZodErrorLike), 400);

--- a/apps/api/src/lib/validation.ts
+++ b/apps/api/src/lib/validation.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared zValidator wrapper — readable validation 400s (issue #2201).
+ *
+ * `@hono/zod-validator`'s default 400 hook returns the raw safeParse result,
+ * so the wire body is `{success:false, error:{name:"ZodError", message:"..."}}`.
+ * Under zod v4 `ZodError.issues` is non-enumerable, so JSON serialization
+ * buries the issues inside `error.message` as a stringified array — unreadable
+ * for every consumer that expects `error` to be a string (mobile, MCP clients,
+ * scripts, portal).
+ *
+ * This wrapper installs a default hook that emits a stable, string-first
+ * contract instead:
+ *
+ * ```json
+ * {
+ *   "error": "name: Required; contacts.0.email: Invalid email",
+ *   "details": {
+ *     "formErrors": ["Unrecognized key: \"maxUses\""],
+ *     "fieldErrors": { "contacts.0.email": ["Invalid email"] }
+ *   }
+ * }
+ * ```
+ *
+ * The web client's `extractApiError` (apps/web/src/lib/apiError.ts) already
+ * understands both `{error: string}` and the flattened `details` shape — the
+ * `error` string here is built with the exact join rules of its
+ * `joinZodFlatten` helper so the two render identically and dedupe into a
+ * single toast line.
+ *
+ * Route files must import `zValidator` from this module, not from
+ * `@hono/zod-validator` directly. A per-route custom hook can still be passed
+ * as the third argument; if it returns a Response that wins, otherwise
+ * validation failures fall through to the readable default above (previously
+ * a non-returning hook fell through to the raw ZodError body).
+ */
+import { zValidator as baseZValidator } from '@hono/zod-validator';
+import type { Hook } from '@hono/zod-validator';
+import type { Context, Env, ValidationTargets } from 'hono';
+import type { z } from 'zod';
+
+export type ValidationErrorBody = {
+  error: string;
+  details: {
+    formErrors: string[];
+    fieldErrors: Record<string, string[]>;
+  };
+};
+
+/**
+ * Minimal structural view of a ZodError that works across zod v3/v4 types
+ * (v4 `issue.path` is `ReadonlyArray<PropertyKey>` and may contain symbols).
+ */
+type ZodErrorLike = {
+  issues: ReadonlyArray<{ path: ReadonlyArray<PropertyKey>; message: string }>;
+};
+
+export function formatZodError(error: ZodErrorLike): ValidationErrorBody {
+  const formErrors: string[] = [];
+  const fieldErrors: Record<string, string[]> = {};
+
+  for (const issue of error.issues) {
+    const path = issue.path.map((segment) => String(segment)).join('.');
+    if (path) {
+      (fieldErrors[path] ??= []).push(issue.message);
+    } else {
+      formErrors.push(issue.message);
+    }
+  }
+
+  const parts = [
+    ...formErrors,
+    ...Object.entries(fieldErrors).map(
+      ([field, messages]) => `${field}: ${messages.join('; ')}`
+    ),
+  ];
+
+  return {
+    error: parts.length > 0 ? parts.join('; ') : 'Validation failed',
+    details: { formErrors, fieldErrors },
+  };
+}
+
+type ValidatorHook<
+  T extends z.ZodType,
+  E extends Env,
+  P extends string,
+  Target extends keyof ValidationTargets,
+> = Hook<z.output<T>, E, P, Target, {}, T>;
+
+export const zValidator = <
+  T extends z.ZodType,
+  Target extends keyof ValidationTargets,
+  E extends Env = Env,
+  P extends string = string,
+>(
+  target: Target,
+  schema: T,
+  hook?: ValidatorHook<T, E, P, Target>
+) =>
+  baseZValidator<T, Target, E, P, ValidatorHook<T, E, P, Target>>(
+    target,
+    schema,
+    async (
+      result: Parameters<ValidatorHook<T, E, P, Target>>[0],
+      c: Context<E, P>
+    ) => {
+      if (hook) {
+        const hookResult = await hook(result, c);
+        if (hookResult instanceof Response) return hookResult;
+      }
+      if (!result.success) {
+        return c.json(formatZodError(result.error as ZodErrorLike), 400);
+      }
+    }
+  );

--- a/apps/api/src/routes/accessReviews.ts
+++ b/apps/api/src/routes/accessReviews.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, inArray } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';

--- a/apps/api/src/routes/accounting/index.ts
+++ b/apps/api/src/routes/accounting/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
 import { and, eq } from 'drizzle-orm';

--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, eq, inArray, ne } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../../db';

--- a/apps/api/src/routes/admin/tenantErasure.ts
+++ b/apps/api/src/routes/admin/tenantErasure.ts
@@ -20,7 +20,7 @@
  */
 
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../../db';

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { zValidator } from "@hono/zod-validator";
+import { zValidator } from '../lib/validation';
 import { z } from "zod";
 import { createPublicKey, verify as verifySignature } from "node:crypto";
 import { and, eq, desc } from "drizzle-orm";

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, eq, inArray } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';

--- a/apps/api/src/routes/agents/connections.ts
+++ b/apps/api/src/routes/agents/connections.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { devices, deviceConnections } from '../../db/schema';

--- a/apps/api/src/routes/agents/elevationRequests.ts
+++ b/apps/api/src/routes/agents/elevationRequests.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, inArray, isNull, or } from 'drizzle-orm';
 import { z } from 'zod';
 

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, inArray, ne, sql } from 'drizzle-orm';
 import { createHash, timingSafeEqual } from 'crypto';
 import { db, withSystemDbAccessContext } from '../../db';

--- a/apps/api/src/routes/agents/eventlogs.ts
+++ b/apps/api/src/routes/agents/eventlogs.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { devices, deviceEventLogs } from '../../db/schema';

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, desc, eq, notInArray } from 'drizzle-orm';
 import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
 import {

--- a/apps/api/src/routes/agents/inventory.ts
+++ b/apps/api/src/routes/agents/inventory.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import {

--- a/apps/api/src/routes/agents/mtls.ts
+++ b/apps/api/src/routes/agents/mtls.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, or } from 'drizzle-orm';
 import { createHash } from 'crypto';

--- a/apps/api/src/routes/agents/patches.ts
+++ b/apps/api/src/routes/agents/patches.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import type { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, sql } from 'drizzle-orm';
 import { db, type Database } from '../../db';
 import { devices, patches, devicePatches } from '../../db/schema';

--- a/apps/api/src/routes/agents/peripherals.ts
+++ b/apps/api/src/routes/agents/peripherals.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, inArray, isNull, or } from 'drizzle-orm';
 import { z } from 'zod';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';

--- a/apps/api/src/routes/agents/processSample.ts
+++ b/apps/api/src/routes/agents/processSample.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { bodyLimit } from 'hono/body-limit';
 import { db } from '../../db';
 import { deviceProcessSamples } from '../../db/schema';

--- a/apps/api/src/routes/agents/recoveryKeys.ts
+++ b/apps/api/src/routes/agents/recoveryKeys.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { devices } from '../../db/schema';

--- a/apps/api/src/routes/agents/reliability.ts
+++ b/apps/api/src/routes/agents/reliability.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { reliabilityMetricsSchema } from '@breeze/shared/validators';
 

--- a/apps/api/src/routes/agents/security.ts
+++ b/apps/api/src/routes/agents/security.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { devices } from '../../db/schema';

--- a/apps/api/src/routes/agents/sessions.ts
+++ b/apps/api/src/routes/agents/sessions.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { devices, deviceSessions } from '../../db/schema';

--- a/apps/api/src/routes/agents/state.ts
+++ b/apps/api/src/routes/agents/state.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import {

--- a/apps/api/src/routes/agents/unifiTelemetry.ts
+++ b/apps/api/src/routes/agents/unifiTelemetry.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireAgentRole } from '../../middleware/requireAgentRole';
 import { db, withSystemDbAccessContext } from '../../db';

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -6,7 +6,7 @@
  */
 
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { streamSSE } from 'hono/streaming';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';

--- a/apps/api/src/routes/alertTemplates/correlations.ts
+++ b/apps/api/src/routes/alertTemplates/correlations.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { db } from '../../db';
 import { alerts, alertCorrelations } from '../../db/schema';
 import { eq, and, or, gte, desc, sql, inArray } from 'drizzle-orm';

--- a/apps/api/src/routes/alertTemplates/rules.ts
+++ b/apps/api/src/routes/alertTemplates/rules.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { db } from '../../db';
 import { alertRules, alertTemplates, organizations } from '../../db/schema';
 import { eq, and, like, or, desc, isNull, type SQL } from 'drizzle-orm';

--- a/apps/api/src/routes/alertTemplates/templates.ts
+++ b/apps/api/src/routes/alertTemplates/templates.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { db } from '../../db';
 import { alertTemplates } from '../../db/schema';
 import { eq, and, or, ilike, desc, inArray } from 'drizzle-orm';

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, or, eq, ne, sql, desc, gte, lte, inArray, isNull, type SQL } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';

--- a/apps/api/src/routes/alerts/channels.ts
+++ b/apps/api/src/routes/alerts/channels.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, sql, desc, inArray, isNull, or } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { notificationChannels, organizations, partners } from '../../db/schema';

--- a/apps/api/src/routes/alerts/correlations.ts
+++ b/apps/api/src/routes/alerts/correlations.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, gte, inArray, or, type SQL } from 'drizzle-orm';
 

--- a/apps/api/src/routes/alerts/policies.ts
+++ b/apps/api/src/routes/alerts/policies.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, sql, desc, inArray, isNull, or } from 'drizzle-orm';
 import { db } from '../../db';
 import { escalationPolicies } from '../../db/schema';

--- a/apps/api/src/routes/alerts/routing.ts
+++ b/apps/api/src/routes/alerts/routing.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { db } from '../../db';
 import { notificationRoutingRules } from '../../db/schema';

--- a/apps/api/src/routes/alerts/rules.ts
+++ b/apps/api/src/routes/alerts/rules.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, sql, desc, inArray, isNull, or, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import { alertRules, alertTemplates, alerts, devices, organizations } from '../../db/schema';

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, sql, gte, lte, ne, inArray, isNull, or, desc, type SQL } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/apiKeys.ts
+++ b/apps/api/src/routes/apiKeys.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, sql, desc, inArray } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, eq, gt, desc, inArray, isNull, ne } from 'drizzle-orm';
 
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';

--- a/apps/api/src/routes/auditBaselines.ts
+++ b/apps/api/src/routes/auditBaselines.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, desc, eq, inArray, isNull, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../db';

--- a/apps/api/src/routes/auditLogs.ts
+++ b/apps/api/src/routes/auditLogs.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, gte, lte, ilike, inArray, not, or, sql, SQL } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/auth/accountDeletion.ts
+++ b/apps/api/src/routes/auth/accountDeletion.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, ne } from 'drizzle-orm';
 import * as dbModule from '../../db';

--- a/apps/api/src/routes/auth/invite.ts
+++ b/apps/api/src/routes/auth/invite.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import type { Context } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import * as dbModule from '../../db';
 import { users, partners, organizations } from '../../db/schema';

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import * as dbModule from '../../db';
 import { users } from '../../db/schema';

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import * as dbModule from '../../db';

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, isNull, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import * as dbModule from '../../db';

--- a/apps/api/src/routes/auth/password.ts
+++ b/apps/api/src/routes/auth/password.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import * as dbModule from '../../db';
 import { users } from '../../db/schema';

--- a/apps/api/src/routes/auth/phone.ts
+++ b/apps/api/src/routes/auth/phone.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import * as dbModule from '../../db';
 import { users, organizations } from '../../db/schema';

--- a/apps/api/src/routes/auth/register.ts
+++ b/apps/api/src/routes/auth/register.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq, sql } from 'drizzle-orm';
 import * as dbModule from '../../db';
 import { users, partners, partnerUsers } from '../../db/schema';

--- a/apps/api/src/routes/auth/verifyEmail.ts
+++ b/apps/api/src/routes/auth/verifyEmail.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import * as dbModule from '../../db';

--- a/apps/api/src/routes/authenticator.ts
+++ b/apps/api/src/routes/authenticator.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, eq, isNull } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../db';

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -1,6 +1,6 @@
 import { createHash, createHmac, randomUUID, timingSafeEqual } from 'crypto';
 import { Hono, type Context } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/backup/bmr.ts
+++ b/apps/api/src/routes/backup/bmr.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, desc, eq, inArray } from 'drizzle-orm';
 import { db } from '../../db';
 import {

--- a/apps/api/src/routes/backup/configs.ts
+++ b/apps/api/src/routes/backup/configs.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { eq, and } from 'drizzle-orm';
 import { randomUUID } from 'crypto';

--- a/apps/api/src/routes/backup/dashboard.ts
+++ b/apps/api/src/routes/backup/dashboard.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq, and, sql, gte, desc, inArray } from 'drizzle-orm';
 import { db } from '../../db';
 import { requirePermission } from '../../middleware/auth';

--- a/apps/api/src/routes/backup/encryption.ts
+++ b/apps/api/src/routes/backup/encryption.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { eq, and } from 'drizzle-orm';
 import { db } from '../../db';

--- a/apps/api/src/routes/backup/hyperv.ts
+++ b/apps/api/src/routes/backup/hyperv.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq, and, inArray } from 'drizzle-orm';
 import { db } from '../../db';
 import { backupJobs, backupSnapshots, devices, hypervVms } from '../../db/schema';

--- a/apps/api/src/routes/backup/jobs.ts
+++ b/apps/api/src/routes/backup/jobs.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq, and, desc, gte, lte, sql, inArray } from 'drizzle-orm';
 import { db } from '../../db';
 import { backupJobs, backupConfigs, devices } from '../../db/schema';

--- a/apps/api/src/routes/backup/mssql.ts
+++ b/apps/api/src/routes/backup/mssql.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq, and, inArray } from 'drizzle-orm';
 import { db } from '../../db';
 import { backupJobs, backupSnapshots, devices } from '../../db/schema';

--- a/apps/api/src/routes/backup/restore.ts
+++ b/apps/api/src/routes/backup/restore.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq, and, desc, gte, lte, sql, inArray } from 'drizzle-orm';
 import { db, runOutsideDbContext, withDbAccessContext } from '../../db';
 import { backupSnapshotFiles, backupSnapshots, restoreJobs, devices, deviceCommands } from '../../db/schema';

--- a/apps/api/src/routes/backup/sla.ts
+++ b/apps/api/src/routes/backup/sla.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { eq, and, sql, gte, lte, isNull, desc, inArray, or } from 'drizzle-orm';
 import { db } from '../../db';

--- a/apps/api/src/routes/backup/snapshots.ts
+++ b/apps/api/src/routes/backup/snapshots.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { eq, and, desc, inArray } from 'drizzle-orm';
 import { db } from '../../db';

--- a/apps/api/src/routes/backup/vault.ts
+++ b/apps/api/src/routes/backup/vault.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { eq, and, inArray } from 'drizzle-orm';
 import { db } from '../../db';

--- a/apps/api/src/routes/backup/verification.ts
+++ b/apps/api/src/routes/backup/verification.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { devices } from '../../db/schema';

--- a/apps/api/src/routes/backup/vmrestore.ts
+++ b/apps/api/src/routes/backup/vmrestore.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq, and, or, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withDbAccessContext } from '../../db';
 import {

--- a/apps/api/src/routes/backup/vss.ts
+++ b/apps/api/src/routes/backup/vss.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { devices } from '../../db/schema';

--- a/apps/api/src/routes/browserSecurity.ts
+++ b/apps/api/src/routes/browserSecurity.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, desc, eq, inArray, isNull, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../db';

--- a/apps/api/src/routes/c2c/configs.ts
+++ b/apps/api/src/routes/c2c/configs.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq, and } from 'drizzle-orm';
 import { db } from '../../db';
 import { backupConfigs, c2cBackupConfigs, c2cConnections } from '../../db/schema';

--- a/apps/api/src/routes/c2c/connections.ts
+++ b/apps/api/src/routes/c2c/connections.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq, and } from 'drizzle-orm';
 import { db } from '../../db';
 import { c2cConnections } from '../../db/schema';

--- a/apps/api/src/routes/c2c/items.ts
+++ b/apps/api/src/routes/c2c/items.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq, and, ilike, desc, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import {

--- a/apps/api/src/routes/c2c/jobs.ts
+++ b/apps/api/src/routes/c2c/jobs.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq, and, desc, gte, lte } from 'drizzle-orm';
 import { db } from '../../db';
 import { c2cBackupJobs, c2cBackupConfigs } from '../../db/schema';

--- a/apps/api/src/routes/catalog/bundles.ts
+++ b/apps/api/src/routes/catalog/bundles.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/catalog/catalog.ts
+++ b/apps/api/src/routes/catalog/catalog.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/catalog/distributors.ts
+++ b/apps/api/src/routes/catalog/distributors.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireMfa, requirePermission, requireScope, dbAccessContextFromAuth, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/catalog/enrich.ts
+++ b/apps/api/src/routes/catalog/enrich.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { partners } from '../../db/schema/orgs';

--- a/apps/api/src/routes/catalog/pricing.ts
+++ b/apps/api/src/routes/catalog/pricing.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/changes.ts
+++ b/apps/api/src/routes/changes.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, gte, inArray, lt, lte, or, sql, SQL } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/cisHardening.ts
+++ b/apps/api/src/routes/cisHardening.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, desc, eq, gte, inArray, lte, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 

--- a/apps/api/src/routes/clientAi/admin.ts
+++ b/apps/api/src/routes/clientAi/admin.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { clientAiOrgPolicies, clientAiTenantMappings } from '../../db/schema/clientAi';

--- a/apps/api/src/routes/clientAi/adminSessions.ts
+++ b/apps/api/src/routes/clientAi/adminSessions.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, asc, count, desc, eq, gte, inArray, isNotNull, isNull, lte, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import { aiSessions, aiMessages, aiToolExecutions } from '../../db/schema';

--- a/apps/api/src/routes/clientAi/adminTemplates.ts
+++ b/apps/api/src/routes/clientAi/adminTemplates.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { asc, eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { clientAiPromptTemplates } from '../../db/schema/clientAi';

--- a/apps/api/src/routes/clientAi/adminUsage.ts
+++ b/apps/api/src/routes/clientAi/adminUsage.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, asc, eq, gte, lte, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import { clientAiUsage } from '../../db/schema/clientAi';

--- a/apps/api/src/routes/clientAi/auth.ts
+++ b/apps/api/src/routes/clientAi/auth.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db, withSystemDbAccessContext } from '../../db';

--- a/apps/api/src/routes/clientAi/sessions.ts
+++ b/apps/api/src/routes/clientAi/sessions.ts
@@ -16,7 +16,7 @@
 import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { streamSSE } from 'hono/streaming';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, asc, count, desc, eq, inArray } from 'drizzle-orm';
 import { db, withDbAccessContext } from '../../db';

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { cfAccessTrustEnabled } from '../config/env';
 import { envFlag } from '../utils/envFlag';

--- a/apps/api/src/routes/configurationPolicies/assignments.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import type { AuthContext } from '../../middleware/auth';
 import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';

--- a/apps/api/src/routes/configurationPolicies/crud.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import type { AuthContext } from '../../middleware/auth';
 import { requirePermission, requireScope } from '../../middleware/auth';

--- a/apps/api/src/routes/configurationPolicies/featureLinks.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import type { AuthContext } from '../../middleware/auth';
 import { hasSatisfiedMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { backupInlineSettingsSchema, patchInlineSettingsSchema } from '@breeze/shared/validators';

--- a/apps/api/src/routes/configurationPolicies/patchJobs.ts
+++ b/apps/api/src/routes/configurationPolicies/patchJobs.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { eq, inArray } from 'drizzle-orm';
 import type { AuthContext } from '../../middleware/auth';

--- a/apps/api/src/routes/configurationPolicies/resolution.ts
+++ b/apps/api/src/routes/configurationPolicies/resolution.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono';
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import type { AuthContext } from '../../middleware/auth';
 import { requirePermission, requireScope } from '../../middleware/auth';

--- a/apps/api/src/routes/contracts/bulk.ts
+++ b/apps/api/src/routes/contracts/bulk.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { requireScope, requirePermission, dbAccessContextFromAuth, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { bulkContractIdsSchema } from '@breeze/shared';

--- a/apps/api/src/routes/contracts/contracts.ts
+++ b/apps/api/src/routes/contracts/contracts.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/contracts/generate.ts
+++ b/apps/api/src/routes/contracts/generate.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/contracts/lifecycle.ts
+++ b/apps/api/src/routes/contracts/lifecycle.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/contracts/lines.ts
+++ b/apps/api/src/routes/contracts/lines.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/customFields.ts
+++ b/apps/api/src/routes/customFields.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, inArray, or } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/deployments.ts
+++ b/apps/api/src/routes/deployments.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, inArray, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/desktopWs.ts
+++ b/apps/api/src/routes/desktopWs.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import type { WSContext } from 'hono/ws';
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';

--- a/apps/api/src/routes/devices/actuateElevation.ts
+++ b/apps/api/src/routes/devices/actuateElevation.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';

--- a/apps/api/src/routes/devices/alerts.ts
+++ b/apps/api/src/routes/devices/alerts.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { eq, and, desc, gte, lte, ne } from 'drizzle-orm';
 import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';

--- a/apps/api/src/routes/devices/anomalies.ts
+++ b/apps/api/src/routes/devices/anomalies.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, ne } from 'drizzle-orm';
 

--- a/apps/api/src/routes/devices/commands.ts
+++ b/apps/api/src/routes/devices/commands.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { eq, sql, desc, and } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, gte, like, sql, desc, inArray, type SQL } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../../db';
 import { createHash, randomBytes } from 'crypto';

--- a/apps/api/src/routes/devices/customFieldValues.ts
+++ b/apps/api/src/routes/devices/customFieldValues.ts
@@ -1,7 +1,7 @@
 import { Hono, type Context, type Next } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { and, eq } from 'drizzle-orm';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { db } from '../../db';
 import { devices } from '../../db/schema';

--- a/apps/api/src/routes/devices/eventlogs.ts
+++ b/apps/api/src/routes/devices/eventlogs.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, eq, gte, lte, desc, sql } from 'drizzle-orm';
 import { db } from '../../db';

--- a/apps/api/src/routes/devices/events.ts
+++ b/apps/api/src/routes/devices/events.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { eq, desc, and, ilike, sql, or, gte, lte, SQL } from 'drizzle-orm';
 import { db } from '../../db';

--- a/apps/api/src/routes/devices/filesystem.ts
+++ b/apps/api/src/routes/devices/filesystem.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { desc, eq } from 'drizzle-orm';
 import { db } from '../../db';

--- a/apps/api/src/routes/devices/groups.ts
+++ b/apps/api/src/routes/devices/groups.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, sql, asc, inArray } from 'drizzle-orm';
 import { db } from '../../db';
 import { devices, deviceGroups, deviceGroupMemberships, sites } from '../../db/schema';

--- a/apps/api/src/routes/devices/links.ts
+++ b/apps/api/src/routes/devices/links.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, inArray, isNull, or } from 'drizzle-orm';
 import { db } from '../../db';
 import { deviceLinkGroups, devices } from '../../db/schema';

--- a/apps/api/src/routes/devices/metrics.ts
+++ b/apps/api/src/routes/devices/metrics.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, gte, inArray, lte, sql, asc } from 'drizzle-orm';
 import { db } from '../../db';
 import { deviceMetrics, metricRollups, sites } from '../../db/schema';

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { devices, sites, organizations } from '../../db/schema';

--- a/apps/api/src/routes/devices/network.test.ts
+++ b/apps/api/src/routes/devices/network.test.ts
@@ -80,7 +80,7 @@ import { networkRoutes } from './network';
 import { authMiddleware, requireScope, requirePermission } from '../../middleware/auth';
 import { listNetworkDevicesSchema } from './schemas';
 import { db } from '../../db';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 
 /**
  * Rig the two query shapes the route uses:

--- a/apps/api/src/routes/devices/network.ts
+++ b/apps/api/src/routes/devices/network.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, inArray, isNull, ilike, or, sql, desc, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import {

--- a/apps/api/src/routes/devices/patches.ts
+++ b/apps/api/src/routes/devices/patches.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { eq, desc, inArray, and, sql, gte } from 'drizzle-orm';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { patches, devicePatches, patchApprovals, deviceCommands, users } from '../../db/schema';
 import { authMiddleware, requireMfa, requireScope, requirePermission } from '../../middleware/auth';

--- a/apps/api/src/routes/devices/processSamples.ts
+++ b/apps/api/src/routes/devices/processSamples.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, lte, gte, asc, desc } from 'drizzle-orm';
 import { db } from '../../db';
 import { deviceProcessSamples } from '../../db/schema';

--- a/apps/api/src/routes/devices/provision.ts
+++ b/apps/api/src/routes/devices/provision.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, isNull, ne, sql } from 'drizzle-orm';
 import { createHash } from 'crypto';
 import { db } from '../../db';

--- a/apps/api/src/routes/devices/sessions.ts
+++ b/apps/api/src/routes/devices/sessions.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, desc, eq, gte, or, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';

--- a/apps/api/src/routes/devices/software.ts
+++ b/apps/api/src/routes/devices/software.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, like, sql, asc } from 'drizzle-orm';
 import { db } from '../../db';
 import { softwareInventory, patches, devicePatches } from '../../db/schema';

--- a/apps/api/src/routes/devices/softwareActions.ts
+++ b/apps/api/src/routes/devices/softwareActions.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { authMiddleware, requireMfa, requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS, type UserPermissions } from '../../services/permissions';

--- a/apps/api/src/routes/discovery.ts
+++ b/apps/api/src/routes/discovery.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, desc, sql, inArray } from 'drizzle-orm';
 import type { SQL } from 'drizzle-orm';

--- a/apps/api/src/routes/dnsSecurity.ts
+++ b/apps/api/src/routes/dnsSecurity.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, gte, ilike, inArray, isNull, lte, or, sql, type SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';

--- a/apps/api/src/routes/dr.ts
+++ b/apps/api/src/routes/dr.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { eq, and, desc, asc, inArray } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
-import { zValidator } from "@hono/zod-validator";
+import { zValidator } from '../lib/validation';
 import { z } from "zod";
 import { and, eq, sql, desc, inArray, lt, isNull, or, asc } from "drizzle-orm";
 import { customAlphabet } from "nanoid";

--- a/apps/api/src/routes/enrollmentKeys_strict.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_strict.test.ts
@@ -89,10 +89,11 @@ const HEADERS = {
 } as const;
 
 /**
- * The Hono zValidator default error hook returns `c.json({ success: false,
- * error }, 400)` where `error` is the serialized ZodError. The exact JSON
- * shape isn't part of our public contract, so this helper just stringifies
- * the body and asserts the offending key name appears somewhere in it —
+ * Validation 400s go through the shared zValidator wrapper
+ * (src/lib/validation.ts, #2201), which emits `{error: string, details}`
+ * with unknown-key messages in `details.formErrors`. The exact body is
+ * pinned by the wrapper's own tests, so this helper just stringifies the
+ * body and asserts the offending key name appears somewhere in it —
  * enough to confirm the unknown-key was surfaced to the caller.
  */
 async function bodyContains(res: Response, needle: string): Promise<boolean> {

--- a/apps/api/src/routes/filters.ts
+++ b/apps/api/src/routes/filters.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, inArray } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/google.ts
+++ b/apps/api/src/routes/google.ts
@@ -10,7 +10,7 @@
  */
 
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/helper/index.ts
+++ b/apps/api/src/routes/helper/index.ts
@@ -7,7 +7,7 @@
  */
 
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { streamSSE } from 'hono/streaming';
 import { createHash } from 'crypto';

--- a/apps/api/src/routes/huntress.ts
+++ b/apps/api/src/routes/huntress.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, ilike, inArray, isNotNull, isNull, or, sql, type SQL } from 'drizzle-orm';
 import * as dbModule from '../db';

--- a/apps/api/src/routes/incidentActions.ts
+++ b/apps/api/src/routes/incidentActions.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, eq, type SQL } from 'drizzle-orm';
 import type { StatusCode } from 'hono/utils/http-status';
 import { db } from '../db';

--- a/apps/api/src/routes/incidents.ts
+++ b/apps/api/src/routes/incidents.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, desc, eq, gte, lte, sql, type SQL } from 'drizzle-orm';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { db } from '../db';

--- a/apps/api/src/routes/invoices/assembly.ts
+++ b/apps/api/src/routes/invoices/assembly.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { authMiddleware, requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/invoices/bulk.ts
+++ b/apps/api/src/routes/invoices/bulk.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { requireScope, requirePermission, dbAccessContextFromAuth, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { bulkInvoiceIdsSchema, bulkVoidInvoicesSchema } from '@breeze/shared';

--- a/apps/api/src/routes/invoices/invoices.ts
+++ b/apps/api/src/routes/invoices/invoices.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/invoices/lifecycle.ts
+++ b/apps/api/src/routes/invoices/lifecycle.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/invoices/payments.ts
+++ b/apps/api/src/routes/invoices/payments.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/invoices/pdf.ts
+++ b/apps/api/src/routes/invoices/pdf.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/invoices/settings.ts
+++ b/apps/api/src/routes/invoices/settings.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { authMiddleware, requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/invoices/stripe.ts
+++ b/apps/api/src/routes/invoices/stripe.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/lifecycle.ts
+++ b/apps/api/src/routes/lifecycle.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, gt, inArray, isNull, max, or, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';

--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, sql, type SQL } from 'drizzle-orm';
 

--- a/apps/api/src/routes/m365.ts
+++ b/apps/api/src/routes/m365.ts
@@ -10,7 +10,7 @@
  */
 
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/maintenance.ts
+++ b/apps/api/src/routes/maintenance.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { eq, and, or, isNull, lte, gte, inArray, desc, asc, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, gte, ilike, inArray, isNull, like, ne, or, sql } from 'drizzle-orm';
 import { createHash } from 'crypto';

--- a/apps/api/src/routes/monitoring.ts
+++ b/apps/api/src/routes/monitoring.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, gte, inArray, isNotNull, lte, or, sql } from 'drizzle-orm';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';

--- a/apps/api/src/routes/monitors.ts
+++ b/apps/api/src/routes/monitors.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, like, desc, sql, gte, lte, or, inArray } from 'drizzle-orm';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';

--- a/apps/api/src/routes/networkBaselines.ts
+++ b/apps/api/src/routes/networkBaselines.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, desc, eq, inArray, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../db';

--- a/apps/api/src/routes/networkChanges.ts
+++ b/apps/api/src/routes/networkChanges.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, desc, eq, gte, inArray, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../db';

--- a/apps/api/src/routes/networkKnownGuests.ts
+++ b/apps/api/src/routes/networkKnownGuests.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { eq, and } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { db } from '../db';
 import { userNotifications } from '../db/schema';

--- a/apps/api/src/routes/orgPortalSettings.ts
+++ b/apps/api/src/routes/orgPortalSettings.ts
@@ -1,5 +1,5 @@
 import type { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, eq, isNull } from 'drizzle-orm';
 import { db } from '../db';
 import { organizations, portalBranding } from '../db/schema';

--- a/apps/api/src/routes/orgPortalUsers.ts
+++ b/apps/api/src/routes/orgPortalUsers.ts
@@ -1,5 +1,5 @@
 import type { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, eq, isNull, desc, ne } from 'drizzle-orm';
 import { db } from '../db';
 import { organizations, portalUsers, tickets, ticketComments, assetCheckouts } from '../db/schema';

--- a/apps/api/src/routes/orgTicketSettings.ts
+++ b/apps/api/src/routes/orgTicketSettings.ts
@@ -1,5 +1,5 @@
 import type { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, eq, isNull } from 'drizzle-orm';
 import { db } from '../db';
 import { organizations } from '../db/schema';

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import type { Context, Next } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, ilike, inArray, isNull, ne, or, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -19,7 +19,7 @@
  * #960 admin actuate route remains the path that issues agent commands.
  */
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { SQL, and, desc, eq, gt, gte, inArray, isNull, lte, or, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import { z } from 'zod';

--- a/apps/api/src/routes/partnerLoginBranding.ts
+++ b/apps/api/src/routes/partnerLoginBranding.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/patchPolicies.ts
+++ b/apps/api/src/routes/patchPolicies.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, sql, desc } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/patches/appOptions.ts
+++ b/apps/api/src/routes/patches/appOptions.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, inArray, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';

--- a/apps/api/src/routes/patches/approvals.ts
+++ b/apps/api/src/routes/patches/approvals.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, sql, desc } from 'drizzle-orm';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { db } from '../../db';

--- a/apps/api/src/routes/patches/compliance.ts
+++ b/apps/api/src/routes/patches/compliance.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { readFile } from 'node:fs/promises';
 import { and, eq, sql, inArray } from 'drizzle-orm';
 import { requirePermission, requireScope } from '../../middleware/auth';

--- a/apps/api/src/routes/patches/list.ts
+++ b/apps/api/src/routes/patches/list.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, sql, asc, desc, type SQL, type Column } from 'drizzle-orm';
 import { requireScope } from '../../middleware/auth';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';

--- a/apps/api/src/routes/patches/operations.ts
+++ b/apps/api/src/routes/patches/operations.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, sql, inArray, desc } from 'drizzle-orm';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { db } from '../../db';

--- a/apps/api/src/routes/pax8.ts
+++ b/apps/api/src/routes/pax8.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/peripheralControl.ts
+++ b/apps/api/src/routes/peripheralControl.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, desc, eq, gte, inArray, lte, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../db';

--- a/apps/api/src/routes/playbooks.ts
+++ b/apps/api/src/routes/playbooks.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, inArray, sql, SQL } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/plugins.ts
+++ b/apps/api/src/routes/plugins.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { eq, and, ilike, sql, desc } from 'drizzle-orm';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';

--- a/apps/api/src/routes/policyManagement/actions.ts
+++ b/apps/api/src/routes/policyManagement/actions.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { automationPolicies, automationRuns, automations, organizations } from '../../db/schema';

--- a/apps/api/src/routes/policyManagement/compliance.ts
+++ b/apps/api/src/routes/policyManagement/compliance.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, desc, eq, inArray, isNotNull, isNull, sql, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import {

--- a/apps/api/src/routes/policyManagement/crud.ts
+++ b/apps/api/src/routes/policyManagement/crud.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { automationPolicies, automationPolicyCompliance, scripts } from '../../db/schema';

--- a/apps/api/src/routes/portal/assets.ts
+++ b/apps/api/src/routes/portal/assets.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, desc, eq, isNull, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { assetCheckouts, devices } from '../../db/schema';

--- a/apps/api/src/routes/portal/auth.ts
+++ b/apps/api/src/routes/portal/auth.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import type { Context, Next } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { createHash } from 'crypto';

--- a/apps/api/src/routes/portal/branding.ts
+++ b/apps/api/src/routes/portal/branding.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../../db';
 import { portalBranding } from '../../db/schema';

--- a/apps/api/src/routes/portal/devices.ts
+++ b/apps/api/src/routes/portal/devices.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { desc, eq, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { devices } from '../../db/schema';

--- a/apps/api/src/routes/portal/invoices.ts
+++ b/apps/api/src/routes/portal/invoices.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, desc, eq, ne, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { invoices, invoiceStripePayments } from '../../db/schema';

--- a/apps/api/src/routes/portal/profile.ts
+++ b/apps/api/src/routes/portal/profile.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { portalUsers } from '../../db/schema';

--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, desc, eq, ne } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { quotes, quoteBlocks, quoteLines } from '../../db/schema/quotes';

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, desc, eq, isNull, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { tickets, ticketComments, ticketStatuses } from '../../db/schema';

--- a/apps/api/src/routes/psa.ts
+++ b/apps/api/src/routes/psa.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';

--- a/apps/api/src/routes/quotes/bulk.ts
+++ b/apps/api/src/routes/quotes/bulk.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { requireScope, requirePermission, dbAccessContextFromAuth, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { bulkQuoteIdsSchema } from '@breeze/shared';

--- a/apps/api/src/routes/quotes/lifecycle.ts
+++ b/apps/api/src/routes/quotes/lifecycle.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { sendQuote } from '../../services/quoteLifecycle';

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, eq } from 'drizzle-orm';
 import { requireScope, requirePermission, type AuthContext } from '../../middleware/auth';

--- a/apps/api/src/routes/quotesPublic.ts
+++ b/apps/api/src/routes/quotesPublic.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { eq, and } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { quotes, quoteBlocks, quoteLines } from '../db/schema/quotes';

--- a/apps/api/src/routes/reliability.ts
+++ b/apps/api/src/routes/reliability.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 
 import { authMiddleware, requirePermission, requireScope } from '../middleware/auth';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';

--- a/apps/api/src/routes/remediationSuggestions.ts
+++ b/apps/api/src/routes/remediationSuggestions.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, gte, inArray, sql, type SQL } from 'drizzle-orm';
 

--- a/apps/api/src/routes/remote/sessions.ts
+++ b/apps/api/src/routes/remote/sessions.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, eq, sql, desc, gte, lte, inArray } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';

--- a/apps/api/src/routes/remote/transfers.ts
+++ b/apps/api/src/routes/remote/transfers.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, sql, desc, inArray } from 'drizzle-orm';
 import { db } from '../../db';
 import {

--- a/apps/api/src/routes/reports/core.ts
+++ b/apps/api/src/routes/reports/core.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, sql, desc, inArray } from 'drizzle-orm';
 import { db } from '../../db';
 import { reports, reportRuns } from '../../db/schema';

--- a/apps/api/src/routes/reports/data.ts
+++ b/apps/api/src/routes/reports/data.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, sql, desc, gte, lte, inArray, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import {

--- a/apps/api/src/routes/reports/generate.ts
+++ b/apps/api/src/routes/reports/generate.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { generateReport, siteScopeRequestAllowed, type ReportResult } from '../../services/reportGenerationService';

--- a/apps/api/src/routes/reports/runs.ts
+++ b/apps/api/src/routes/reports/runs.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, sql, desc, inArray } from 'drizzle-orm';
 import { db } from '../../db';
 import { reports, reportRuns } from '../../db/schema';

--- a/apps/api/src/routes/roles.ts
+++ b/apps/api/src/routes/roles.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, or, count, inArray, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';

--- a/apps/api/src/routes/scriptAi.ts
+++ b/apps/api/src/routes/scriptAi.ts
@@ -6,7 +6,7 @@
  */
 
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { streamSSE } from 'hono/streaming';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import {

--- a/apps/api/src/routes/scriptLibrary.ts
+++ b/apps/api/src/routes/scriptLibrary.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { randomUUID } from 'crypto';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { exitCodeSeverityMappingSchema } from '@breeze/shared';
 import { and, eq, sql, desc, like, inArray, or, isNull } from 'drizzle-orm';

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, ilike, inArray, isNull, or, sql } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';

--- a/apps/api/src/routes/security/compliance.ts
+++ b/apps/api/src/routes/security/compliance.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, inArray } from 'drizzle-orm';
 
 import { db } from '../../db';

--- a/apps/api/src/routes/security/dashboard.ts
+++ b/apps/api/src/routes/security/dashboard.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 
 import { requirePermission, requireScope } from '../../middleware/auth';
 import {

--- a/apps/api/src/routes/security/policies.ts
+++ b/apps/api/src/routes/security/policies.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, desc, eq, sql, type SQL } from 'drizzle-orm';
 
 import { db } from '../../db';

--- a/apps/api/src/routes/security/posture.ts
+++ b/apps/api/src/routes/security/posture.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 
 import { db } from '../../db';

--- a/apps/api/src/routes/security/recommendations.ts
+++ b/apps/api/src/routes/security/recommendations.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 
 import { db } from '../../db';
 import { auditLogs } from '../../db/schema';

--- a/apps/api/src/routes/security/recoveryKeys.ts
+++ b/apps/api/src/routes/security/recoveryKeys.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, desc, eq, inArray } from 'drizzle-orm';
 import type { Context } from 'hono';
 

--- a/apps/api/src/routes/security/scans.ts
+++ b/apps/api/src/routes/security/scans.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, desc, eq } from 'drizzle-orm';
 
 import { db } from '../../db';

--- a/apps/api/src/routes/security/status.ts
+++ b/apps/api/src/routes/security/status.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 
 import { db } from '../../db';

--- a/apps/api/src/routes/security/threats.ts
+++ b/apps/api/src/routes/security/threats.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 
 import { db } from '../../db';

--- a/apps/api/src/routes/sensitiveData.ts
+++ b/apps/api/src/routes/sensitiveData.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'crypto';
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, desc, eq, gte, inArray, sql, type SQL } from 'drizzle-orm';
 
 import { db } from '../db';

--- a/apps/api/src/routes/sentinelOne.ts
+++ b/apps/api/src/routes/sentinelOne.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, gte, inArray, isNull, lte, or, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/snmp.ts
+++ b/apps/api/src/routes/snmp.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, inArray, like, desc, sql, gte, lte, or } from 'drizzle-orm';
 import type { SQL } from 'drizzle-orm';

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, sql, desc, like, or, inArray, isNotNull, type SQL } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/softwareInventory.ts
+++ b/apps/api/src/routes/softwareInventory.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, inArray, sql, desc, asc, type SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';

--- a/apps/api/src/routes/softwarePolicies.ts
+++ b/apps/api/src/routes/softwarePolicies.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { and, desc, eq, inArray, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../db';

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { eq, and, gt, ne, isNull } from 'drizzle-orm';
 import { createHmac, timingSafeEqual } from 'crypto';

--- a/apps/api/src/routes/stripeConnect/index.ts
+++ b/apps/api/src/routes/stripeConnect/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { HTTPException } from 'hono/http-exception';
 import { authMiddleware, requireMfa, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/systemTools/eventLogs.ts
+++ b/apps/api/src/routes/systemTools/eventLogs.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { authMiddleware, requireScope } from '../../middleware/auth';
 import { executeCommand, CommandTypes } from '../../services/commandQueue';
 import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED, getPagination, asRecord, asString, asNumber, asOptionalNumber } from './helpers';

--- a/apps/api/src/routes/systemTools/fileBrowser.ts
+++ b/apps/api/src/routes/systemTools/fileBrowser.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { basename } from 'node:path';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { authMiddleware, requireScope } from '../../middleware/auth';
 import { executeCommand, CommandTypes } from '../../services/commandQueue';
 import { createAuditLog } from '../../services/auditService';

--- a/apps/api/src/routes/systemTools/processes.ts
+++ b/apps/api/src/routes/systemTools/processes.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { authMiddleware, requireScope } from '../../middleware/auth';
 import { executeCommand, CommandTypes } from '../../services/commandQueue';
 import { createAuditLog } from '../../services/auditService';

--- a/apps/api/src/routes/systemTools/registry.ts
+++ b/apps/api/src/routes/systemTools/registry.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { authMiddleware, requireScope } from '../../middleware/auth';
 import { executeCommand, CommandTypes } from '../../services/commandQueue';
 import { createAuditLog } from '../../services/auditService';

--- a/apps/api/src/routes/systemTools/scheduledTasks.ts
+++ b/apps/api/src/routes/systemTools/scheduledTasks.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { authMiddleware, requireScope } from '../../middleware/auth';
 import { executeCommand, CommandTypes } from '../../services/commandQueue';
 import { createAuditLog } from '../../services/auditService';

--- a/apps/api/src/routes/systemTools/services.ts
+++ b/apps/api/src/routes/systemTools/services.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { authMiddleware, requireScope } from '../../middleware/auth';
 import { executeCommand, CommandTypes } from '../../services/commandQueue';
 import { createAuditLog } from '../../services/auditService';

--- a/apps/api/src/routes/tags.ts
+++ b/apps/api/src/routes/tags.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/thirdPartyCatalog/list.ts
+++ b/apps/api/src/routes/thirdPartyCatalog/list.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, ilike, or, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { thirdPartyPackageCatalog } from '../../db/schema';

--- a/apps/api/src/routes/thirdPartyCatalog/operations.ts
+++ b/apps/api/src/routes/thirdPartyCatalog/operations.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';

--- a/apps/api/src/routes/ticketCategories.ts
+++ b/apps/api/src/routes/ticketCategories.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, asc, eq, inArray, type SQL } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';

--- a/apps/api/src/routes/ticketConfig.ts
+++ b/apps/api/src/routes/ticketConfig.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import type { Context, Next } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { authMiddleware, requireScope, requirePermission } from '../middleware/auth';
 import type { AuthContext } from '../middleware/auth';

--- a/apps/api/src/routes/tickets/bulk.ts
+++ b/apps/api/src/routes/tickets/bulk.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS, hasPermission, type UserPermissions } from '../../services/permissions';
 import { bulkTicketActionSchema } from '@breeze/shared';

--- a/apps/api/src/routes/tickets/export.ts
+++ b/apps/api/src/routes/tickets/export.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { billablesExportQuerySchema } from '@breeze/shared';

--- a/apps/api/src/routes/tickets/mailboxConnect.ts
+++ b/apps/api/src/routes/tickets/mailboxConnect.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
 import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
 import { authMiddleware, requireScope, requireMfa, type AuthContext } from '../../middleware/auth';

--- a/apps/api/src/routes/tickets/moveOrg.ts
+++ b/apps/api/src/routes/tickets/moveOrg.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission, requireMfa } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';

--- a/apps/api/src/routes/tickets/parts.ts
+++ b/apps/api/src/routes/tickets/parts.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db';

--- a/apps/api/src/routes/tickets/ticketResponseTemplates.ts
+++ b/apps/api/src/routes/tickets/ticketResponseTemplates.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { and, eq, asc } from 'drizzle-orm';
 import { db } from '../../db';
 import { ticketResponseTemplates } from '../../db/schema';

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, asc, desc, eq, ilike, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
 import { db } from '../../db';

--- a/apps/api/src/routes/timeEntries/timeEntries.ts
+++ b/apps/api/src/routes/timeEntries/timeEntries.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import type { AuthContext } from '../../middleware/auth';

--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, desc, inArray, isNull, or } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';

--- a/apps/api/src/routes/unifi/index.ts
+++ b/apps/api/src/routes/unifi/index.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, inArray } from 'drizzle-orm';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../../middleware/auth';

--- a/apps/api/src/routes/updateRings.ts
+++ b/apps/api/src/routes/updateRings.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, sql, desc, asc, inArray, type SQL } from 'drizzle-orm';
 import { db } from '../db';

--- a/apps/api/src/routes/userRisk.ts
+++ b/apps/api/src/routes/userRisk.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 
 import { authMiddleware, requirePermission, requireScope, resolveOrgAccess } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { bodyLimit } from 'hono/body-limit';
 import { z } from 'zod';
 import { and, eq, or } from 'drizzle-orm';

--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, gt, ilike, inArray, lte, type SQL } from 'drizzle-orm';
 

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { zValidator } from '@hono/zod-validator';
+import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, inArray, sql, type SQL } from 'drizzle-orm';
 import { randomUUID } from 'crypto';

--- a/apps/web/src/components/devices/AddDeviceModal.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.tsx
@@ -19,12 +19,13 @@ function detectUserOS(): 'windows' | 'macos' | 'linux' {
 
 /**
  * Pull a human-readable message out of an API error body. Handles three
- * shapes: a plain `{ error: string }` / `{ message: string }`, and the
- * @hono/zod-validator 400 shape `{ error: { issues: [{ message }] } }`
- * (where `error` is a serialized ZodError, not a string). Without the
- * last case, validation failures collapse to a bare status code and the
- * server's specific message (e.g. the ttlMinutes/expiresAt conflict) is
- * lost — see PR #739 review.
+ * shapes: a plain `{ error: string }` / `{ message: string }` (the shared
+ * zValidator wrapper emits string-first bodies since #2201), and the
+ * legacy pre-#2201 @hono/zod-validator 400 shape
+ * `{ error: { issues: [{ message }] } }` (where `error` is a serialized
+ * ZodError, not a string) — kept defensively for older deployed APIs.
+ * Without the last case, validation failures against those collapse to a
+ * bare status code — see PR #739 review.
  */
 function extractApiError(body: unknown): string {
   if (!body || typeof body !== 'object') return '';

--- a/apps/web/src/components/discovery/AssetDetailModal.test.tsx
+++ b/apps/web/src/components/discovery/AssetDetailModal.test.tsx
@@ -416,10 +416,11 @@ describe('AssetDetailModal — server error surfaced on save/reset (#1424)', () 
     expect(await screen.findByText('Asset not found')).toBeInTheDocument();
   });
 
-  // @hono/zod-validator's default 400 hook emits the bare ZodError object as
-  // `error`. zod v4 hides `issues` from JSON.stringify, so the wire shape is
-  // {name:'ZodError', message:'<stringified issues>'} — the exact body behind
-  // the "[object Object]" report in #2198.
+  // Legacy pre-#2201 shape: @hono/zod-validator's default 400 hook emitted the
+  // bare ZodError object as `error`. zod v4 hides `issues` from JSON.stringify,
+  // so the wire shape is {name:'ZodError', message:'<stringified issues>'} —
+  // the exact body behind the "[object Object]" report in #2198. Kept as a
+  // regression test for older deployed APIs.
   const zodErrorBody = {
     success: false,
     error: {

--- a/apps/web/src/components/pam/PamRuleModal.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.tsx
@@ -19,11 +19,12 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
 
 /**
  * Pull a human-readable message out of an API error body. The preview route
- * returns either a plain `{ error: string }` (e.g. 'Site access denied') or the
- * @hono/zod-validator 400 shape `{ success:false, error: { issues: [{ message }] } }`
+ * returns a plain `{ error: string }` (e.g. 'Site access denied', or the
+ * shared zValidator wrapper's string-first 400 body since #2201). The legacy
+ * pre-#2201 shape `{ success:false, error: { issues: [{ message }] } }`
  * (a serialized ZodError — the superRefine criterion/shape messages, the
- * sha256 hash validator). Without this, those messages collapse to a bare HTTP
- * status. Returns '' when no message can be extracted.
+ * sha256 hash validator) is kept defensively for older deployed APIs.
+ * Returns '' when no message can be extracted.
  */
 function extractApiError(body: unknown): string {
   if (!body || typeof body !== 'object') return '';

--- a/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
@@ -83,9 +83,10 @@ describe('runPartnerSave', () => {
   // Regression for #1976: a partner-settings save that fails server-side Zod
   // validation must surface the specific field message — not collapse into the
   // generic "Failed to save settings" fallback. The save flows through runAction,
-  // which (via extractApiError) recovers issues from @hono/zod-validator's default
-  // 400 body. Under zod v4 the ZodError's `issues` are non-enumerable, so they are
-  // JSON-stringified into `error.message`; this mirrors that exact wire shape.
+  // which (via extractApiError) recovers issues from the legacy pre-#2201
+  // @hono/zod-validator default 400 body (kept for older deployed APIs). Under
+  // zod v4 the ZodError's `issues` are non-enumerable, so they are
+  // JSON-stringified into `error.message`; this mirrors that legacy wire shape.
   it('surfaces the specific Zod validation message (not the generic fallback) on a 400', async () => {
     const zodValidatorBody = {
       success: false,

--- a/apps/web/src/lib/apiError.test.ts
+++ b/apps/web/src/lib/apiError.test.ts
@@ -68,6 +68,22 @@ describe('extractApiError', () => {
     expect(extractApiError({ error: { name: 'ZodError', message: 'not-json' } }, FALLBACK)).toBe(FALLBACK);
   });
 
+  it('renders the shared zValidator wrapper 400 body once, deduping error against details (#2201)', () => {
+    // Contract test: exact body emitted by apps/api/src/lib/validation.ts. The
+    // `error` string uses the same join rules as joinZodFlatten so the details
+    // rendering is identical and must dedupe to a single toast line.
+    const body = {
+      error: 'Unrecognized key: "maxUses"; contacts.0.email: Invalid email',
+      details: {
+        formErrors: ['Unrecognized key: "maxUses"'],
+        fieldErrors: { 'contacts.0.email': ['Invalid email'] },
+      },
+    };
+    expect(extractApiError(body, FALLBACK)).toBe(
+      'Unrecognized key: "maxUses"; contacts.0.email: Invalid email'
+    );
+  });
+
   it('returns body.details when only details is set', () => {
     expect(extractApiError({ details: 'phone numbers required' }, FALLBACK)).toBe('phone numbers required');
   });

--- a/apps/web/src/lib/apiError.ts
+++ b/apps/web/src/lib/apiError.ts
@@ -1,7 +1,9 @@
-// Parses error response bodies returned by the API. The API emits at least
-// four shapes today: a plain `{error: string}`, a zod-validator
-// `{error: {issues: [...]}}`, a `{error: string, details: object|array}`
-// pair from route validators, and Hono's default `{message: string}`.
+// Parses error response bodies returned by the API. Shapes handled: the
+// shared zValidator wrapper's `{error: string, details}` (every validation
+// 400 since #2201 — apps/api/src/lib/validation.ts), a plain
+// `{error: string}`, Hono's default `{message: string}`, and the legacy
+// pre-#2201 raw zod-validator `{error: {issues: [...]}}` / serialized
+// ZodError bodies (kept defensively for older deployed APIs).
 // Falling back to `new Error(obj)` produces `[object Object]` in the UI;
 // this function picks the most readable rendering of whatever we got.
 
@@ -19,9 +21,11 @@ function joinZodIssues(issues: unknown): string | null {
   return messages.length > 0 ? messages.join('; ') : null;
 }
 
-// Renders a zod `error.flatten()` payload ({formErrors: string[], fieldErrors:
-// Record<string, string[]>}) — emitted as `details` by some route validators
-// (e.g. configuration-policy feature links).
+// Renders a zod flatten payload ({formErrors: string[], fieldErrors:
+// Record<string, string[]>}) — emitted as `details` by every zValidator 400
+// via the shared wrapper (apps/api/src/lib/validation.ts, #2201; its `error`
+// string uses the same join rules so the two dedupe below) and by some route
+// validators (e.g. configuration-policy feature links).
 function joinZodFlatten(value: unknown): string | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const { formErrors, fieldErrors } = value as { formErrors?: unknown; fieldErrors?: unknown };
@@ -64,10 +68,12 @@ export function extractApiError(data: unknown, fallback: string): string {
   } else if (body.error && typeof body.error === 'object') {
     const errObj = body.error as { issues?: unknown; message?: unknown; name?: unknown };
     let fromError = joinZodIssues(errObj.issues);
-    // zod v4: ZodError.issues is a NON-enumerable property, so JSON.stringify
+    // Legacy pre-#2201 path (kept defensively for older deployed APIs):
+    // zod v4 ZodError.issues is a NON-enumerable property, so JSON.stringify
     // drops it and the issues array is JSON-stringified into error.message
-    // instead. @hono/zod-validator's default 400 hook emits the bare ZodError,
-    // so recover the issues from the message to keep validation text in the UI.
+    // instead. @hono/zod-validator's default 400 hook emitted the bare
+    // ZodError, so recover the issues from the message to keep validation
+    // text in the UI.
     if (!fromError && errObj.name === 'ZodError' && typeof errObj.message === 'string') {
       try {
         fromError = joinZodIssues(JSON.parse(errObj.message));


### PR DESCRIPTION
## Summary

`@hono/zod-validator`'s default 400 hook returns the raw safeParse result, so every validation failure hits the wire as `{success:false, error:{name:"ZodError", message:"<stringified issues>"}}` — zod v4 hides `issues` from serialization, leaving every non-web consumer (mobile, portal, MCP clients, scripts) with an unreadable object where they expect a string. Of ~1150 `zValidator(` call sites, only `orgs.ts` installed a custom hook.

This implements the fix shape proposed in the issue:

- **New `apps/api/src/lib/validation.ts`** exports a wrapped `zValidator` whose default hook emits a stable, string-first contract on validation failure (HTTP 400):

  ```json
  {
    "error": "Unrecognized key: \"maxUses\"; contacts.0.email: Invalid email",
    "details": {
      "formErrors": ["Unrecognized key: \"maxUses\""],
      "fieldErrors": { "contacts.0.email": ["Invalid email"] }
    }
  }
  ```

- **Sweep**: all 233 route files under `apps/api/src/routes/` now import `zValidator` from the shared wrapper (mechanical import rewrite; no call-site changes).
- **Custom hooks still work**: the wrapper forwards an optional per-route hook; a returned `Response` wins (the `orgs.ts` `/partners/me` 422 hook is unchanged), and non-returning failure paths now fall through to the readable default instead of the raw ZodError body.
- **Guard test**: `validation.imports.test.ts` fails if any future route file imports `@hono/zod-validator` directly.

## Consumer sweep (output-contract change)

- **Web**: no changes needed — `extractApiError` already handles `{error: string, details}`. The `error` string is built with the exact join rules of its `joinZodFlatten` helper so `error` and `details` dedupe into a single toast line (contract test added to `apiError.test.ts`). The legacy ZodError-recovery path in `apiError.ts` is intentionally kept for older deployed API versions.
- **Mobile** (`apps/mobile/src/services/api.ts`): accepts `typeof body.error === 'string'` — starts rendering validation detail for free, no change.
- **Portal**: renders `result.error` as a string everywhere — beneficiary, no change.
- **Go agent**: parses status codes, not validation bodies — unaffected.
- **API tests**: no test asserted the raw shape (string matchers couldn't have passed against it); `enrollmentKeys_strict.test.ts` asserts the offending key name appears in the body text, which the new shape preserves. Four test files that `vi.mock('@hono/zod-validator')` keep working — the mock intercepts the wrapper's own base import.
- **e2e-tests / AI tools / MCP**: no assertions on the old 400 shape found (repo-wide grep for `ZodError`, `success:false`, error-body parsing).

## Tests

- New: `apps/api/src/lib/validation.test.ts` (8 tests — field-path 400 body, strict unknown-key surfacing, success passthrough, custom-hook win + fallthrough, query target) and the import guard.
- New: web contract test pinning the wrapper body to `extractApiError` rendering.
- Full `src/routes` unit suite: **391 files, 5553 passed** locally.
- `tsc --noEmit` clean in `apps/api` and `apps/web`.

Closes #2201

Refs #2198, #2200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)