### PR TITLE
feat(onedrive-helper): Phase 3 — policy editor tab, library picker, device panel, fleet rollup

### DIFF
--- a/apps/api/src/routes/onedrive.state.test.ts
+++ b/apps/api/src/routes/onedrive.state.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const ORG_A = '11111111-1111-1111-1111-111111111111';
+const ORG_B = '22222222-2222-2222-2222-222222222222';
+const DEVICE_1 = '33333333-3333-3333-3333-333333333333';
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+// --- mutable auth state, set per-test ---
+let authState: {
+  scope: 'organization' | 'partner' | 'system';
+  orgId?: string | null;
+  accessibleOrgIds?: string[] | null;
+  canAccessOrg?: (orgId: string) => boolean;
+  user?: { id: string } | null;
+};
+
+// Mock only authMiddleware + requirePermission (thin passthrough); requireScope
+// and resolveScopedOrgId (./c2c/helpers) are left as the REAL implementations so
+// the cross-tenant test exercises actual org-access enforcement, not a stub.
+vi.mock('../middleware/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../middleware/auth')>();
+  return {
+    ...actual,
+    authMiddleware: vi.fn((c: any, next: any) => {
+      c.set('auth', authState);
+      return next();
+    }),
+    requirePermission: vi.fn(() => (_c: any, next: any) => next()),
+  };
+});
+
+import { db } from '../db';
+import { onedriveRoutes } from './onedrive';
+
+describe('GET /onedrive/devices/:deviceId/state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState = {
+      scope: 'organization',
+      orgId: ORG_A,
+      accessibleOrgIds: [ORG_A],
+      canAccessOrg: (orgId: string) => orgId === ORG_A,
+      user: { id: 'user-1' },
+    };
+  });
+
+  it('returns the state row for an accessible device', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: DEVICE_1, orgId: ORG_A }]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                deviceId: DEVICE_1,
+                orgId: ORG_A,
+                signedIn: true,
+                filesOnDemandOn: true,
+                oneDriveVersion: '24.100',
+                kfmFolderStates: { Desktop: 'redirected' },
+                mountedLibraries: [],
+                entitledLibraries: [],
+                driftEntries: [],
+                lastReportedAt: new Date('2026-07-01T00:00:00Z'),
+              },
+            ]),
+          }),
+        }),
+      } as any);
+
+    const res = await onedriveRoutes.request(`/devices/${DEVICE_1}/state`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.state).toMatchObject({ signedIn: true, deviceId: DEVICE_1 });
+  });
+
+  it('returns state:null when the agent has not reported yet', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: DEVICE_1, orgId: ORG_A }]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as any);
+
+    const res = await onedriveRoutes.request(`/devices/${DEVICE_1}/state`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.state).toBeNull();
+  });
+
+  it('404s for a device in an inaccessible org', async () => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: DEVICE_1, orgId: ORG_B }]),
+        }),
+      }),
+    } as any);
+
+    const res = await onedriveRoutes.request(`/devices/${DEVICE_1}/state`);
+    expect(res.status).toBe(404);
+    expect(db.select).toHaveBeenCalledTimes(1); // no second (state) query
+  });
+});
+
+describe('GET /onedrive/state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState = {
+      scope: 'organization',
+      orgId: ORG_A,
+      accessibleOrgIds: [ORG_A],
+      canAccessOrg: (orgId: string) => orgId === ORG_A,
+      user: { id: 'user-1' },
+    };
+  });
+
+  it('returns per-device rows + stats for the org', async () => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              deviceId: 'device-1',
+              hostname: 'host-1',
+              signedIn: true,
+              filesOnDemandOn: true,
+              oneDriveVersion: '24.100',
+              kfmFolderStates: { Desktop: 'redirected', Documents: 'redirected' },
+              mountedLibraries: [],
+              entitledLibraries: [],
+              driftEntries: [{ library: 'Documents', reason: 'missing' }],
+              lastReportedAt: new Date('2026-07-01T00:00:00Z'),
+            },
+            {
+              deviceId: 'device-2',
+              hostname: 'host-2',
+              signedIn: false,
+              filesOnDemandOn: false,
+              oneDriveVersion: null,
+              kfmFolderStates: {},
+              mountedLibraries: [],
+              entitledLibraries: [],
+              driftEntries: [],
+              lastReportedAt: new Date('2026-07-01T00:00:00Z'),
+            },
+          ]),
+        }),
+      }),
+    } as any);
+
+    const res = await onedriveRoutes.request(`/state?orgId=${ORG_A}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.devices).toHaveLength(2);
+    expect(body.stats).toEqual({ total: 2, signedIn: 1, kfmProtected: 1, withDrift: 1 });
+  });
+
+  it('400s when no org resolvable', async () => {
+    const res = await onedriveRoutes.request(`/state?orgId=${ORG_B}`);
+    expect(res.status).toBe(400);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/onedrive.state.test.ts
+++ b/apps/api/src/routes/onedrive.state.test.ts
@@ -11,12 +11,15 @@ vi.mock('../db', () => ({
   },
 }));
 
+const ORG_C = '44444444-4444-4444-4444-444444444444';
+
 // --- mutable auth state, set per-test ---
 let authState: {
   scope: 'organization' | 'partner' | 'system';
   orgId?: string | null;
   accessibleOrgIds?: string[] | null;
   canAccessOrg?: (orgId: string) => boolean;
+  orgCondition?: (col: unknown) => unknown;
   user?: { id: string } | null;
 };
 
@@ -136,7 +139,7 @@ describe('GET /onedrive/state', () => {
     };
   });
 
-  it('returns per-device rows + stats for the org', async () => {
+  it('returns per-device rows + stats for an explicitly-requested org', async () => {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
         innerJoin: vi.fn().mockReturnValue({
@@ -177,9 +180,69 @@ describe('GET /onedrive/state', () => {
     expect(body.stats).toEqual({ total: 2, signedIn: 1, kfmProtected: 1, withDrift: 1 });
   });
 
-  it('400s when no org resolvable', async () => {
+  it('400s when an explicitly-requested org is inaccessible', async () => {
     const res = await onedriveRoutes.request(`/state?orgId=${ORG_B}`);
     expect(res.status).toBe(400);
     expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('aggregates across all accessible orgs when no orgId is given (partner scope, multi-org)', async () => {
+    const cond = { sentinel: 'partner-accessible-orgs' };
+    const orgConditionSpy = vi.fn().mockReturnValue(cond);
+    authState = {
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [ORG_A, ORG_C],
+      canAccessOrg: (orgId: string) => orgId === ORG_A || orgId === ORG_C,
+      orgCondition: orgConditionSpy,
+      user: { id: 'user-1' },
+    };
+
+    // These rows stand in for what Postgres would already have filtered down
+    // to via the where(orgCondition) clause (+ RLS backstop) — one device from
+    // each of the caller's two accessible orgs, ORG_B's rows never surface.
+    const whereSpy = vi.fn().mockResolvedValue([
+      {
+        deviceId: 'device-1',
+        hostname: 'host-1',
+        signedIn: true,
+        filesOnDemandOn: true,
+        oneDriveVersion: '24.100',
+        kfmFolderStates: { Desktop: 'redirected' },
+        mountedLibraries: [],
+        entitledLibraries: [],
+        driftEntries: [],
+        lastReportedAt: new Date('2026-07-01T00:00:00Z'),
+      },
+      {
+        deviceId: 'device-3',
+        hostname: 'host-3',
+        signedIn: true,
+        filesOnDemandOn: true,
+        oneDriveVersion: '24.100',
+        kfmFolderStates: { Desktop: 'redirected' },
+        mountedLibraries: [],
+        entitledLibraries: [],
+        driftEntries: [],
+        lastReportedAt: new Date('2026-07-01T00:00:00Z'),
+      },
+    ]);
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: whereSpy,
+        }),
+      }),
+    } as any);
+
+    const res = await onedriveRoutes.request('/state');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.devices).toHaveLength(2);
+    expect(body.stats).toEqual({ total: 2, signedIn: 2, kfmProtected: 2, withDrift: 0 });
+    // Proves the route delegates org-scoping to auth.orgCondition (the vuln
+    // fleet-stats pattern) rather than requiring a single resolvable org.
+    expect(orgConditionSpy).toHaveBeenCalledTimes(1);
+    expect(whereSpy).toHaveBeenCalledWith(cond);
   });
 });

--- a/apps/api/src/routes/onedrive.state.test.ts
+++ b/apps/api/src/routes/onedrive.state.test.ts
@@ -23,6 +23,10 @@ let authState: {
   user?: { id: string } | null;
 };
 
+// Site-scope permissions context, set per-test. null allowedSiteIds =
+// unrestricted (the common case); the site-restriction tests narrow it.
+let permsState: { allowedSiteIds: string[] | null };
+
 // Mock only authMiddleware + requirePermission (thin passthrough); requireScope
 // and resolveScopedOrgId (./c2c/helpers) are left as the REAL implementations so
 // the cross-tenant test exercises actual org-access enforcement, not a stub.
@@ -34,7 +38,13 @@ vi.mock('../middleware/auth', async (importOriginal) => {
       c.set('auth', authState);
       return next();
     }),
-    requirePermission: vi.fn(() => (_c: any, next: any) => next()),
+    // The real requirePermission populates c.get('permissions'), which the
+    // canonical site-scope gate (getDeviceWithOrgAndSiteCheck) requires and
+    // fails loud (500) without — mirror that here.
+    requirePermission: vi.fn(() => (c: any, next: any) => {
+      c.set('permissions', permsState);
+      return next();
+    }),
   };
 });
 
@@ -44,6 +54,7 @@ import { onedriveRoutes } from './onedrive';
 describe('GET /onedrive/devices/:deviceId/state', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    permsState = { allowedSiteIds: null };
     authState = {
       scope: 'organization',
       orgId: ORG_A,
@@ -125,11 +136,27 @@ describe('GET /onedrive/devices/:deviceId/state', () => {
     expect(res.status).toBe(404);
     expect(db.select).toHaveBeenCalledTimes(1); // no second (state) query
   });
+
+  it('403s for a site-restricted tech when the device is in another site', async () => {
+    permsState = { allowedSiteIds: ['site-allowed'] };
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: DEVICE_1, orgId: ORG_A, siteId: 'site-other' }]),
+        }),
+      }),
+    } as any);
+
+    const res = await onedriveRoutes.request(`/devices/${DEVICE_1}/state`);
+    expect(res.status).toBe(403);
+    expect(db.select).toHaveBeenCalledTimes(1); // no second (state) query
+  });
 });
 
 describe('GET /onedrive/state', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    permsState = { allowedSiteIds: null };
     authState = {
       scope: 'organization',
       orgId: ORG_A,
@@ -178,6 +205,51 @@ describe('GET /onedrive/state', () => {
     const body = await res.json();
     expect(body.devices).toHaveLength(2);
     expect(body.stats).toEqual({ total: 2, signedIn: 1, kfmProtected: 1, withDrift: 1 });
+  });
+
+  it('narrows the rollup to the allowed sites for a site-restricted tech (stats follow)', async () => {
+    permsState = { allowedSiteIds: ['site-allowed'] };
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              deviceId: 'device-1',
+              hostname: 'host-1',
+              siteId: 'site-allowed',
+              signedIn: true,
+              filesOnDemandOn: true,
+              oneDriveVersion: '24.100',
+              kfmFolderStates: {},
+              mountedLibraries: [],
+              entitledLibraries: [],
+              driftEntries: [],
+              lastReportedAt: new Date('2026-07-01T00:00:00Z'),
+            },
+            {
+              deviceId: 'device-2',
+              hostname: 'host-2',
+              siteId: 'site-other',
+              signedIn: true,
+              filesOnDemandOn: false,
+              oneDriveVersion: null,
+              kfmFolderStates: {},
+              mountedLibraries: [],
+              entitledLibraries: [],
+              driftEntries: [],
+              lastReportedAt: new Date('2026-07-01T00:00:00Z'),
+            },
+          ]),
+        }),
+      }),
+    } as any);
+
+    const res = await onedriveRoutes.request(`/state?orgId=${ORG_A}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.devices).toHaveLength(1);
+    expect(body.devices[0].deviceId).toBe('device-1');
+    expect(body.stats.total).toBe(1); // stats computed AFTER narrowing
   });
 
   it('400s when an explicitly-requested org is inaccessible', async () => {

--- a/apps/api/src/routes/onedrive.ts
+++ b/apps/api/src/routes/onedrive.ts
@@ -70,15 +70,29 @@ onedriveRoutes.get(
   }
 );
 
-// Org rollup: entitled-vs-mounted / drift / KFM across the fleet.
+// Org rollup: entitled-vs-mounted / drift / KFM across the fleet. With an
+// explicit ?orgId= we validate + narrow to that one org (400 if inaccessible,
+// same as every other resolveScopedOrgId consumer). Without one — the case
+// OneDriveFleetPage actually calls for partner techs with >1 accessible org —
+// we aggregate across every org the caller can see via auth.orgCondition,
+// mirroring the vuln fleet /stats route (routes/vulnerabilities.ts). System
+// scope with no explicit org yields no condition = every org; RLS backstops
+// this regardless of what the app layer computes.
 onedriveRoutes.get(
   '/state',
   requireScope('organization', 'partner', 'system'),
   requireDevicesRead,
   async (c) => {
     const auth = c.get('auth');
-    const orgId = resolveScopedOrgId(auth, c.req.query('orgId'));
-    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+    const requestedOrgId = c.req.query('orgId');
+    let orgCond;
+    if (requestedOrgId) {
+      const orgId = resolveScopedOrgId(auth, requestedOrgId);
+      if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+      orgCond = eq(onedriveDeviceState.orgId, orgId);
+    } else {
+      orgCond = auth.orgCondition(onedriveDeviceState.orgId);
+    }
 
     const rows = await db
       .select({
@@ -95,7 +109,7 @@ onedriveRoutes.get(
       })
       .from(onedriveDeviceState)
       .innerJoin(devices, eq(onedriveDeviceState.deviceId, devices.id))
-      .where(eq(onedriveDeviceState.orgId, orgId));
+      .where(orgCond);
 
     const kfmProtected = (kfm: unknown) => {
       const entries = Object.values((kfm ?? {}) as Record<string, string>);

--- a/apps/api/src/routes/onedrive.ts
+++ b/apps/api/src/routes/onedrive.ts
@@ -5,11 +5,15 @@
  */
 
 import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
 import { authMiddleware, requirePermission, requireScope } from '../middleware/auth';
 import { PERMISSIONS } from '../services/permissions';
 import { resolveScopedOrgId } from './c2c/helpers';
 import { hasDirectM365Connection } from '../services/m365DirectGraph';
 import { listSharePointLibraries } from '../services/onedriveGraph';
+import { db } from '../db';
+import { devices } from '../db/schema/devices';
+import { onedriveDeviceState } from '../db/schema/onedriveHelper';
 
 export const onedriveRoutes = new Hono();
 
@@ -41,4 +45,68 @@ onedriveRoutes.get(
     }
     return c.json(res.data);
   },
+);
+
+// Per-device OneDrive state for the device detail panel. Registered BEFORE
+// '/state' below for clarity — the two paths don't shadow each other under
+// Hono's router, but device-scoped-first keeps the group readable.
+onedriveRoutes.get(
+  '/devices/:deviceId/state',
+  requireScope('organization', 'partner', 'system'),
+  requireDevicesRead,
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('deviceId')!;
+    const [device] = await db
+      .select({ id: devices.id, orgId: devices.orgId })
+      .from(devices).where(eq(devices.id, deviceId)).limit(1);
+    if (!device || !resolveScopedOrgId(auth, device.orgId)) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+    const [state] = await db
+      .select().from(onedriveDeviceState)
+      .where(eq(onedriveDeviceState.deviceId, deviceId)).limit(1);
+    return c.json({ state: state ?? null });
+  }
+);
+
+// Org rollup: entitled-vs-mounted / drift / KFM across the fleet.
+onedriveRoutes.get(
+  '/state',
+  requireScope('organization', 'partner', 'system'),
+  requireDevicesRead,
+  async (c) => {
+    const auth = c.get('auth');
+    const orgId = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+
+    const rows = await db
+      .select({
+        deviceId: onedriveDeviceState.deviceId,
+        hostname: devices.hostname,
+        signedIn: onedriveDeviceState.signedIn,
+        filesOnDemandOn: onedriveDeviceState.filesOnDemandOn,
+        oneDriveVersion: onedriveDeviceState.oneDriveVersion,
+        kfmFolderStates: onedriveDeviceState.kfmFolderStates,
+        mountedLibraries: onedriveDeviceState.mountedLibraries,
+        entitledLibraries: onedriveDeviceState.entitledLibraries,
+        driftEntries: onedriveDeviceState.driftEntries,
+        lastReportedAt: onedriveDeviceState.lastReportedAt,
+      })
+      .from(onedriveDeviceState)
+      .innerJoin(devices, eq(onedriveDeviceState.deviceId, devices.id))
+      .where(eq(onedriveDeviceState.orgId, orgId));
+
+    const kfmProtected = (kfm: unknown) => {
+      const entries = Object.values((kfm ?? {}) as Record<string, string>);
+      return entries.length > 0 && entries.every((v) => v === 'redirected');
+    };
+    const stats = {
+      total: rows.length,
+      signedIn: rows.filter((r) => r.signedIn).length,
+      kfmProtected: rows.filter((r) => kfmProtected(r.kfmFolderStates)).length,
+      withDrift: rows.filter((r) => Array.isArray(r.driftEntries) && (r.driftEntries as unknown[]).length > 0).length,
+    };
+    return c.json({ devices: rows, stats });
+  }
 );

--- a/apps/api/src/routes/onedrive.ts
+++ b/apps/api/src/routes/onedrive.ts
@@ -7,13 +7,14 @@
 import { Hono } from 'hono';
 import { eq } from 'drizzle-orm';
 import { authMiddleware, requirePermission, requireScope } from '../middleware/auth';
-import { PERMISSIONS } from '../services/permissions';
+import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { resolveScopedOrgId } from './c2c/helpers';
 import { hasDirectM365Connection } from '../services/m365DirectGraph';
 import { listSharePointLibraries } from '../services/onedriveGraph';
 import { db } from '../db';
 import { devices } from '../db/schema/devices';
 import { onedriveDeviceState } from '../db/schema/onedriveHelper';
+import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './devices/helpers';
 
 export const onedriveRoutes = new Hono();
 
@@ -57,10 +58,14 @@ onedriveRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     const deviceId = c.req.param('deviceId')!;
-    const [device] = await db
-      .select({ id: devices.id, orgId: devices.orgId })
-      .from(devices).where(eq(devices.id, deviceId)).limit(1);
-    if (!device || !resolveScopedOrgId(auth, device.orgId)) {
+    // Canonical org + site-scope gate (site-scope-coverage contract): a
+    // site-restricted tech must not read OneDrive state for devices in
+    // other sites of the same org.
+    const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
+    if (device === SITE_ACCESS_DENIED) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+    if (!device) {
       return c.json({ error: 'Device not found' }, 404);
     }
     const [state] = await db
@@ -94,10 +99,11 @@ onedriveRoutes.get(
       orgCond = auth.orgCondition(onedriveDeviceState.orgId);
     }
 
-    const rows = await db
+    const allRows = await db
       .select({
         deviceId: onedriveDeviceState.deviceId,
         hostname: devices.hostname,
+        siteId: devices.siteId,
         signedIn: onedriveDeviceState.signedIn,
         filesOnDemandOn: onedriveDeviceState.filesOnDemandOn,
         oneDriveVersion: onedriveDeviceState.oneDriveVersion,
@@ -110,6 +116,14 @@ onedriveRoutes.get(
       .from(onedriveDeviceState)
       .innerJoin(devices, eq(onedriveDeviceState.deviceId, devices.id))
       .where(orgCond);
+
+    // Site-scope narrowing (site-scope-coverage contract): a site-restricted
+    // tech only sees devices in their allowed sites. `permissions` is live —
+    // populated by the requireDevicesRead (requirePermission) middleware above.
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const rows = perms?.allowedSiteIds
+      ? allRows.filter((r) => typeof r.siteId === 'string' && canAccessSite(perms, r.siteId))
+      : allRows;
 
     const kfmProtected = (kfm: unknown) => {
       const entries = Object.values((kfm ?? {}) as Record<string, string>);

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
@@ -21,6 +21,7 @@ import {
   LifeBuoy,
   Monitor,
   ListChecks,
+  Cloud,
   Info,
 } from 'lucide-react';
 import Breadcrumbs from '../layout/Breadcrumbs';
@@ -54,6 +55,7 @@ import HelperTab from './featureTabs/HelperTab';
 import RemoteAccessTab from './featureTabs/RemoteAccessTab';
 import PamTab from './featureTabs/PamTab';
 import VulnerabilityTab from './featureTabs/VulnerabilityTab';
+import OneDriveHelperTab from './featureTabs/OneDriveHelperTab';
 import ComplianceStatusTab from './ComplianceStatusTab';
 
 type Tab = 'overview' | FeatureType | 'assignments' | 'compliance_status';
@@ -98,6 +100,7 @@ const featureTabIcons: Record<FeatureType, React.ReactNode> = {
   remote_access: <Monitor className="h-4 w-4" />,
   pam: <KeyRound className="h-4 w-4" />,
   vulnerability: <ShieldAlert className="h-4 w-4" />,
+  onedrive_helper: <Cloud className="h-4 w-4" />,
 };
 
 // Which feature tabs the editor renders, in display order. Derived from
@@ -351,6 +354,7 @@ export default function ConfigPolicyDetailPage({ policyId }: ConfigPolicyDetailP
       case 'remote_access': return <RemoteAccessTab {...props} />;
       case 'pam': return <PamTab {...props} />;
       case 'vulnerability': return <VulnerabilityTab {...props} />;
+      case 'onedrive_helper': return <OneDriveHelperTab {...props} />;
     }
   };
 

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
@@ -335,6 +335,7 @@ export default function ConfigPolicyDetailPage({ policyId }: ConfigPolicyDetailP
       onLinkChanged: handleLinkChanged,
       linkedPolicyId,
       parentLink: parentLinkFor(ft),
+      orgId: policy?.orgId ?? null,
     };
     switch (ft) {
       case 'patch': return <PatchTab {...props} />;

--- a/apps/web/src/components/configurationPolicies/featureTabs/FeatureTabShell.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/FeatureTabShell.tsx
@@ -14,6 +14,12 @@ type FeatureTabShellProps = {
    */
   configuredButInactive?: boolean;
   saving: boolean;
+  /**
+   * When true, the Save (and Override) button is disabled independent of the
+   * saving state — used by tabs with client-side validation (e.g. an invalid
+   * library targeting row) to block a save the server would 400 on anyway.
+   */
+  saveDisabled?: boolean;
   error?: string;
   onSave: () => void;
   onRemove?: () => void;
@@ -33,6 +39,7 @@ export default function FeatureTabShell({
   isConfigured,
   configuredButInactive,
   saving,
+  saveDisabled,
   error,
   onSave,
   onRemove,
@@ -99,7 +106,8 @@ export default function FeatureTabShell({
               <button
                 type="button"
                 onClick={onOverride}
-                className="inline-flex items-center gap-2 rounded-md border border-primary/40 px-3 py-2 text-sm font-medium text-primary transition hover:bg-primary/10"
+                disabled={saveDisabled}
+                className="inline-flex items-center gap-2 rounded-md border border-primary/40 px-3 py-2 text-sm font-medium text-primary transition hover:bg-primary/10 disabled:opacity-50"
               >
                 <PenLine className="h-4 w-4" />
                 Override
@@ -132,7 +140,7 @@ export default function FeatureTabShell({
             <button
               type="button"
               onClick={onSave}
-              disabled={saving}
+              disabled={saving || saveDisabled}
               className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
             >
               {saving && <Loader2 className="h-4 w-4 animate-spin" />}

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.test.tsx
@@ -234,6 +234,17 @@ describe('OneDriveHelperTab', () => {
     expect(screen.getByText(/requires a group/i)).toBeTruthy();
   });
 
+  it('threads the policy orgId into the picker (partner-scoped tech, no ambient auth.orgId)', async () => {
+    mockedStatus.mockResolvedValue(true);
+    mockedLibraries.mockResolvedValue({ libraries: [], skippedSites: [] });
+
+    render(<OneDriveHelperTab {...baseProps} existingLink={undefined} orgId="org-99" />);
+
+    fireEvent.click(screen.getByTestId('onedrive-add-library-btn'));
+
+    await waitFor(() => expect(mockedStatus).toHaveBeenCalledWith('org-99'));
+  });
+
   it('inherited (parentLink only) shows Override and no direct Save', () => {
     const parentLink: FeatureLink = {
       id: 'parent-link',

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.test.tsx
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import OneDriveHelperTab from './OneDriveHelperTab';
 import type { FeatureLink } from './types';
+import * as onedriveApi from '../../../lib/api/onedrive';
+import type { OneDriveLibrary } from '../../../lib/api/onedrive';
 
 const saveMock = vi.fn();
 const removeMock = vi.fn();
@@ -17,6 +19,32 @@ vi.mock('./useFeatureLink', () => ({
     clearError: clearErrorMock,
   }),
 }));
+
+// The add-library flow now runs through OneDriveLibraryPicker, which calls the
+// onedrive api module. Mock it so the tab tests drive the REAL picker.
+vi.mock('../../../lib/api/onedrive', () => ({
+  fetchM365ConnectionStatus: vi.fn(),
+  fetchOneDriveLibraries: vi.fn(),
+}));
+
+const mockedStatus = vi.mocked(onedriveApi.fetchM365ConnectionStatus);
+const mockedLibraries = vi.mocked(onedriveApi.fetchOneDriveLibraries);
+
+function graphLib(overrides: Partial<OneDriveLibrary> = {}): OneDriveLibrary {
+  return {
+    siteId: 'sp!composite',
+    siteName: 'Finance Site',
+    siteUrl: 'https://contoso.sharepoint.com/sites/finance',
+    driveId: 'drive-1',
+    listId: 'l1',
+    libraryName: 'Finance',
+    tenantId: 't1',
+    webId: 'w1',
+    spSiteId: 's1',
+    autoMountValue: 'tenantId=t1&siteId=s1&webId=w1&listId=l1',
+    ...overrides,
+  };
+}
 
 const baseProps = {
   policyId: 'policy-1',
@@ -117,19 +145,19 @@ describe('OneDriveHelperTab', () => {
     });
   });
 
-  it('adding a manual library then saving includes it with targetingMode everyone', async () => {
+  it('adding a library via the Graph picker then saving includes it with targetingMode everyone', async () => {
+    mockedStatus.mockResolvedValue(true);
+    mockedLibraries.mockResolvedValue({ libraries: [graphLib()], skippedSites: [] });
+
     render(<OneDriveHelperTab {...baseProps} existingLink={undefined} />);
 
+    // Open the picker and pick a Graph library.
     fireEvent.click(screen.getByTestId('onedrive-add-library-btn'));
-    fireEvent.change(screen.getByTestId('onedrive-manual-library-id'), {
-      target: { value: 'tenantId=t1&siteId=s1&webId=w1&listId=l1' },
-    });
-    fireEvent.change(screen.getByTestId('onedrive-manual-display-name'), {
-      target: { value: 'Finance' },
-    });
-    fireEvent.click(screen.getByTestId('onedrive-manual-add-submit'));
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-add-drive-1')).toBeTruthy());
+    fireEvent.click(screen.getByTestId('onedrive-picker-add-drive-1'));
 
-    // Row now visible.
+    // Close the picker; the row is now on the tab.
+    fireEvent.click(screen.getByTestId('onedrive-picker-close'));
     expect(screen.getByTestId('onedrive-lib-row-0')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
@@ -143,25 +171,36 @@ describe('OneDriveHelperTab', () => {
     expect(payload.inlineSettings.libraries[0]).toMatchObject({
       libraryId: 'tenantId=t1&siteId=s1&webId=w1&listId=l1',
       displayName: 'Finance',
+      siteId: 's1', // spSiteId (bare GUID) flows through
+      webId: 'w1',
+      listId: 'l1',
       targetingMode: 'everyone',
       hiveScope: 'hkcu',
       enabled: true,
     });
   });
 
-  it('rejects a manual library whose id does not start with tenantId=', () => {
+  it('picker manual fallback rejects an id that does not start with tenantId=', async () => {
+    // Disconnected → picker surfaces the manual-paste fallback directly.
+    mockedStatus.mockResolvedValue(false);
+
     render(<OneDriveHelperTab {...baseProps} existingLink={undefined} />);
 
     fireEvent.click(screen.getByTestId('onedrive-add-library-btn'));
-    fireEvent.change(screen.getByTestId('onedrive-manual-library-id'), {
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-manual-id')).toBeTruthy());
+
+    // Disconnected → libraries never fetched.
+    expect(mockedLibraries).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByTestId('onedrive-picker-manual-id'), {
       target: { value: 'not-a-composite-id' },
     });
-    fireEvent.change(screen.getByTestId('onedrive-manual-display-name'), {
+    fireEvent.change(screen.getByTestId('onedrive-picker-manual-name'), {
       target: { value: 'Bad' },
     });
-    fireEvent.click(screen.getByTestId('onedrive-manual-add-submit'));
+    fireEvent.click(screen.getByTestId('onedrive-picker-manual-submit'));
 
-    // Not added.
+    // Not added to the tab.
     expect(screen.queryByTestId('onedrive-lib-row-0')).toBeNull();
     expect(screen.getByText(/must start with/i)).toBeTruthy();
   });

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.test.tsx
@@ -1,0 +1,213 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OneDriveHelperTab from './OneDriveHelperTab';
+import type { FeatureLink } from './types';
+
+const saveMock = vi.fn();
+const removeMock = vi.fn();
+const clearErrorMock = vi.fn();
+
+vi.mock('./useFeatureLink', () => ({
+  useFeatureLink: () => ({
+    save: saveMock,
+    remove: removeMock,
+    saving: false,
+    error: undefined,
+    clearError: clearErrorMock,
+  }),
+}));
+
+const baseProps = {
+  policyId: 'policy-1',
+  linkedPolicyId: null,
+  onLinkChanged: vi.fn(),
+};
+
+describe('OneDriveHelperTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveMock.mockResolvedValue({
+      id: 'link-1',
+      featureType: 'onedrive_helper',
+      featurePolicyId: null,
+      inlineSettings: {},
+    });
+  });
+
+  it('renders defaults when no link exists (KFM off hides folder checkboxes)', () => {
+    render(<OneDriveHelperTab {...baseProps} existingLink={undefined} />);
+
+    // Base toggles present.
+    expect(screen.getByTestId('onedrive-toggle-silent')).toBeTruthy();
+    expect(screen.getByTestId('onedrive-toggle-fod')).toBeTruthy();
+    expect(screen.getByTestId('onedrive-toggle-kfm')).toBeTruthy();
+    expect(screen.getByTestId('onedrive-toggle-restart')).toBeTruthy();
+
+    // KFM is off by default -> folder checkboxes + tenant association hidden.
+    expect(screen.queryByTestId('onedrive-kfm-folder-Desktop')).toBeNull();
+    expect(screen.queryByTestId('onedrive-tenant-association')).toBeNull();
+
+    // No libraries yet.
+    expect(screen.queryByTestId('onedrive-lib-row-0')).toBeNull();
+  });
+
+  it('seeds state from existingLink.inlineSettings', () => {
+    const existingLink: FeatureLink = {
+      id: 'link-1',
+      featureType: 'onedrive_helper',
+      featurePolicyId: null,
+      inlineSettings: {
+        silentAccountConfig: true,
+        filesOnDemand: true,
+        kfmSilentOptIn: true,
+        kfmFolders: ['Desktop', 'Documents'],
+        kfmBlockOptOut: true,
+        tenantAssociationId: 'tenant-guid-123',
+        restartOnChange: false,
+        libraries: [
+          {
+            libraryId: 'tenantId=t1&siteId=s1',
+            displayName: 'Marketing Share',
+            siteUrl: 'https://contoso.sharepoint.com/sites/marketing',
+            targetingMode: 'everyone',
+            hiveScope: 'hkcu',
+            enabled: true,
+          },
+        ],
+      },
+    };
+
+    render(<OneDriveHelperTab {...baseProps} existingLink={existingLink} />);
+
+    // KFM on -> folder checkboxes + tenant association visible and seeded.
+    const desktop = screen.getByTestId('onedrive-kfm-folder-Desktop') as HTMLInputElement;
+    const pictures = screen.getByTestId('onedrive-kfm-folder-Pictures') as HTMLInputElement;
+    expect(desktop.checked).toBe(true);
+    expect(pictures.checked).toBe(false);
+    expect((screen.getByTestId('onedrive-tenant-association') as HTMLInputElement).value).toBe('tenant-guid-123');
+
+    // Library row seeded.
+    expect(screen.getByTestId('onedrive-lib-row-0')).toBeTruthy();
+    expect(screen.getByText('Marketing Share')).toBeTruthy();
+  });
+
+  it('Save posts the full allowlisted payload', async () => {
+    render(<OneDriveHelperTab {...baseProps} existingLink={undefined} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+
+    const [linkId, payload] = saveMock.mock.calls[0] as [
+      string | null,
+      { featureType: string; featurePolicyId: string | null; inlineSettings: Record<string, unknown> },
+    ];
+    expect(linkId).toBeNull();
+    expect(payload.featureType).toBe('onedrive_helper');
+    expect(payload.featurePolicyId).toBeNull();
+    expect(payload.inlineSettings).toEqual({
+      silentAccountConfig: true,
+      filesOnDemand: true,
+      kfmSilentOptIn: false,
+      kfmFolders: ['Desktop', 'Documents', 'Pictures'],
+      kfmBlockOptOut: false,
+      tenantAssociationId: null,
+      restartOnChange: true,
+      libraries: [],
+    });
+  });
+
+  it('adding a manual library then saving includes it with targetingMode everyone', async () => {
+    render(<OneDriveHelperTab {...baseProps} existingLink={undefined} />);
+
+    fireEvent.click(screen.getByTestId('onedrive-add-library-btn'));
+    fireEvent.change(screen.getByTestId('onedrive-manual-library-id'), {
+      target: { value: 'tenantId=t1&siteId=s1&webId=w1&listId=l1' },
+    });
+    fireEvent.change(screen.getByTestId('onedrive-manual-display-name'), {
+      target: { value: 'Finance' },
+    });
+    fireEvent.click(screen.getByTestId('onedrive-manual-add-submit'));
+
+    // Row now visible.
+    expect(screen.getByTestId('onedrive-lib-row-0')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+
+    const [, payload] = saveMock.mock.calls[0] as [
+      string | null,
+      { inlineSettings: { libraries: Array<Record<string, unknown>> } },
+    ];
+    expect(payload.inlineSettings.libraries).toHaveLength(1);
+    expect(payload.inlineSettings.libraries[0]).toMatchObject({
+      libraryId: 'tenantId=t1&siteId=s1&webId=w1&listId=l1',
+      displayName: 'Finance',
+      targetingMode: 'everyone',
+      hiveScope: 'hkcu',
+      enabled: true,
+    });
+  });
+
+  it('rejects a manual library whose id does not start with tenantId=', () => {
+    render(<OneDriveHelperTab {...baseProps} existingLink={undefined} />);
+
+    fireEvent.click(screen.getByTestId('onedrive-add-library-btn'));
+    fireEvent.change(screen.getByTestId('onedrive-manual-library-id'), {
+      target: { value: 'not-a-composite-id' },
+    });
+    fireEvent.change(screen.getByTestId('onedrive-manual-display-name'), {
+      target: { value: 'Bad' },
+    });
+    fireEvent.click(screen.getByTestId('onedrive-manual-add-submit'));
+
+    // Not added.
+    expect(screen.queryByTestId('onedrive-lib-row-0')).toBeNull();
+    expect(screen.getByText(/must start with/i)).toBeTruthy();
+  });
+
+  it('graph_group mode without group id or name disables Save and shows a hint', () => {
+    const existingLink: FeatureLink = {
+      id: 'link-1',
+      featureType: 'onedrive_helper',
+      featurePolicyId: null,
+      inlineSettings: {
+        libraries: [
+          {
+            libraryId: 'tenantId=t1&siteId=s1',
+            displayName: 'Marketing',
+            targetingMode: 'everyone',
+            hiveScope: 'hkcu',
+            enabled: true,
+          },
+        ],
+      },
+    };
+
+    render(<OneDriveHelperTab {...baseProps} existingLink={existingLink} />);
+
+    fireEvent.change(screen.getByTestId('onedrive-lib-targeting-0'), {
+      target: { value: 'graph_group' },
+    });
+
+    const save = screen.getByRole('button', { name: /^Save$/i }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+    expect(screen.getByText(/requires a group/i)).toBeTruthy();
+  });
+
+  it('inherited (parentLink only) shows Override and no direct Save', () => {
+    const parentLink: FeatureLink = {
+      id: 'parent-link',
+      featureType: 'onedrive_helper',
+      featurePolicyId: null,
+      inlineSettings: { silentAccountConfig: false },
+    };
+
+    render(
+      <OneDriveHelperTab {...baseProps} existingLink={undefined} parentLink={parentLink} />,
+    );
+
+    expect(screen.getByRole('button', { name: /Override/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /^Save$/i })).toBeNull();
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.tsx
@@ -101,7 +101,7 @@ function siteHint(siteUrl?: string | null): string | null {
   }
 }
 
-export default function OneDriveHelperTab({ policyId, existingLink, onLinkChanged, linkedPolicyId, parentLink }: FeatureTabProps) {
+export default function OneDriveHelperTab({ policyId, existingLink, onLinkChanged, linkedPolicyId, parentLink, orgId }: FeatureTabProps) {
   const { save, remove, saving, error, clearError } = useFeatureLink(policyId);
   const isInherited = !!parentLink && !existingLink;
   const effectiveLink = existingLink ?? parentLink;
@@ -323,7 +323,7 @@ export default function OneDriveHelperTab({ policyId, existingLink, onLinkChange
           </div>
 
           {showPicker && (
-            <OneDriveLibraryPicker onAdd={handlePickerAdd} onClose={() => setShowPicker(false)} />
+            <OneDriveLibraryPicker orgId={orgId ?? undefined} onAdd={handlePickerAdd} onClose={() => setShowPicker(false)} />
           )}
 
           {settings.libraries.length === 0 && (

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.tsx
@@ -4,6 +4,7 @@ import type { FeatureTabProps } from './types';
 import { FEATURE_META } from './types';
 import { useFeatureLink } from './useFeatureLink';
 import FeatureTabShell from './FeatureTabShell';
+import OneDriveLibraryPicker, { type PickedLibrary } from './OneDriveLibraryPicker';
 
 type TargetingMode = 'everyone' | 'graph_group' | 'local_ad_group';
 type KfmFolder = 'Desktop' | 'Documents' | 'Pictures';
@@ -108,10 +109,7 @@ export default function OneDriveHelperTab({ policyId, existingLink, onLinkChange
     mergeSettings(defaults, effectiveLink?.inlineSettings as Partial<OneDriveHelperSettings> | undefined),
   );
 
-  const [showAddForm, setShowAddForm] = useState(false);
-  const [manualId, setManualId] = useState('');
-  const [manualName, setManualName] = useState('');
-  const [manualError, setManualError] = useState<string | null>(null);
+  const [showPicker, setShowPicker] = useState(false);
 
   useEffect(() => {
     const link = existingLink ?? parentLink;
@@ -140,29 +138,24 @@ export default function OneDriveHelperTab({ policyId, existingLink, onLinkChange
   const removeLibrary = (index: number) =>
     setSettings((prev) => ({ ...prev, libraries: prev.libraries.filter((_, i) => i !== index) }));
 
-  // Task-3 manual-entry add. The Graph picker (Task 4) will swap this internal
-  // form for OneDriveLibraryPicker; keep the add-flow isolated so that's a small
-  // change (append the returned mapping via addLibrary and drop this form).
-  const addLibrary = (lib: LibraryMapping) =>
-    setSettings((prev) => ({ ...prev, libraries: [...prev.libraries, lib] }));
-
-  const submitManual = () => {
-    const libraryId = manualId.trim();
-    const displayName = manualName.trim();
-    if (!libraryId.startsWith('tenantId=')) {
-      setManualError('Library ID must start with "tenantId=" (paste the composite ID from SharePoint).');
-      return;
-    }
-    if (!displayName) {
-      setManualError('Display name is required.');
-      return;
-    }
-    addLibrary(normalizeLibrary({ libraryId, displayName }));
-    setManualId('');
-    setManualName('');
-    setManualError(null);
-    setShowAddForm(false);
-  };
+  // The Graph picker (OneDriveLibraryPicker) owns the whole add-flow — Graph
+  // browse AND the manual composite-ID paste fallback. It hands back a resolved
+  // library, which we normalize into a full mapping row (default targeting).
+  const handlePickerAdd = (lib: PickedLibrary) =>
+    setSettings((prev) => ({
+      ...prev,
+      libraries: [
+        ...prev.libraries,
+        normalizeLibrary({
+          libraryId: lib.libraryId,
+          displayName: lib.displayName,
+          siteUrl: lib.siteUrl || null,
+          siteId: lib.siteId || null,
+          webId: lib.webId || null,
+          listId: lib.listId || null,
+        }),
+      ],
+    }));
 
   // EventLogTab-style allowlist: build the wire payload from known keys only so
   // legacy/unknown fields on an older link are never re-persisted.
@@ -321,10 +314,7 @@ export default function OneDriveHelperTab({ policyId, existingLink, onLinkChange
             <button
               type="button"
               data-testid="onedrive-add-library-btn"
-              onClick={() => {
-                setShowAddForm((v) => !v);
-                setManualError(null);
-              }}
+              onClick={() => setShowPicker(true)}
               className="inline-flex items-center gap-2 rounded-md border border-primary/40 px-3 py-2 text-sm font-medium text-primary transition hover:bg-primary/10"
             >
               <Plus className="h-4 w-4" />
@@ -332,46 +322,11 @@ export default function OneDriveHelperTab({ policyId, existingLink, onLinkChange
             </button>
           </div>
 
-          {showAddForm && (
-            <div className="space-y-3 rounded-md border border-dashed bg-muted/30 px-4 py-4">
-              <div>
-                <label className="text-sm font-medium">Composite library ID</label>
-                <input
-                  type="text"
-                  data-testid="onedrive-manual-library-id"
-                  value={manualId}
-                  onChange={(e) => setManualId(e.target.value)}
-                  placeholder="tenantId=…&siteId=…&webId=…&listId=…"
-                  className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-                />
-                <p className="mt-1 text-xs text-muted-foreground">Paste the composite ID from SharePoint. A Graph picker replaces this soon.</p>
-              </div>
-              <div>
-                <label className="text-sm font-medium">Display name</label>
-                <input
-                  type="text"
-                  data-testid="onedrive-manual-display-name"
-                  value={manualName}
-                  onChange={(e) => setManualName(e.target.value)}
-                  placeholder="e.g. Marketing Share"
-                  className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-                />
-              </div>
-              {manualError && <p className="text-xs text-destructive">{manualError}</p>}
-              <div className="flex justify-end">
-                <button
-                  type="button"
-                  data-testid="onedrive-manual-add-submit"
-                  onClick={submitManual}
-                  className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90"
-                >
-                  Add
-                </button>
-              </div>
-            </div>
+          {showPicker && (
+            <OneDriveLibraryPicker onAdd={handlePickerAdd} onClose={() => setShowPicker(false)} />
           )}
 
-          {settings.libraries.length === 0 && !showAddForm && (
+          {settings.libraries.length === 0 && (
             <p className="rounded-md border border-dashed px-4 py-6 text-center text-sm text-muted-foreground">
               No libraries mapped yet.
             </p>

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.tsx
@@ -1,0 +1,503 @@
+import { useState, useEffect } from 'react';
+import { Cloud, Plus, Trash2 } from 'lucide-react';
+import type { FeatureTabProps } from './types';
+import { FEATURE_META } from './types';
+import { useFeatureLink } from './useFeatureLink';
+import FeatureTabShell from './FeatureTabShell';
+
+type TargetingMode = 'everyone' | 'graph_group' | 'local_ad_group';
+type KfmFolder = 'Desktop' | 'Documents' | 'Pictures';
+
+type LibraryMapping = {
+  libraryId: string;
+  displayName: string;
+  siteUrl?: string | null;
+  siteId?: string | null;
+  webId?: string | null;
+  listId?: string | null;
+  targetingMode: TargetingMode;
+  groupId?: string | null;
+  groupName?: string | null;
+  hiveScope: 'hkcu' | 'hklm';
+  enabled: boolean;
+};
+
+type OneDriveHelperSettings = {
+  silentAccountConfig: boolean;
+  filesOnDemand: boolean;
+  kfmSilentOptIn: boolean;
+  kfmFolders: KfmFolder[];
+  kfmBlockOptOut: boolean;
+  tenantAssociationId?: string | null;
+  restartOnChange: boolean;
+  libraries: LibraryMapping[];
+};
+
+const KFM_FOLDERS: KfmFolder[] = ['Desktop', 'Documents', 'Pictures'];
+
+const defaults: OneDriveHelperSettings = {
+  silentAccountConfig: true,
+  filesOnDemand: true,
+  kfmSilentOptIn: false,
+  kfmFolders: ['Desktop', 'Documents', 'Pictures'],
+  kfmBlockOptOut: false,
+  tenantAssociationId: null,
+  restartOnChange: true,
+  libraries: [],
+};
+
+const targetingOptions: { value: TargetingMode; label: string }[] = [
+  { value: 'everyone', label: 'Everyone' },
+  { value: 'graph_group', label: 'Entra (Graph) group' },
+  { value: 'local_ad_group', label: 'Local / AD group' },
+];
+
+// Mirrors the server-side zod superRefine on onedriveLibraryMappingSchema so an
+// invalid targeting row blocks Save client-side instead of eating a 400.
+function libraryError(lib: LibraryMapping): string | null {
+  if (lib.targetingMode === 'graph_group' && !lib.groupId?.trim() && !lib.groupName?.trim()) {
+    return 'Graph group targeting requires a group ID or group name.';
+  }
+  if (lib.targetingMode === 'local_ad_group' && !lib.groupName?.trim()) {
+    return 'Local/AD group targeting requires a group name.';
+  }
+  return null;
+}
+
+function normalizeLibrary(raw: Partial<LibraryMapping>): LibraryMapping {
+  return {
+    libraryId: raw.libraryId ?? '',
+    displayName: raw.displayName ?? '',
+    siteUrl: raw.siteUrl ?? null,
+    siteId: raw.siteId ?? null,
+    webId: raw.webId ?? null,
+    listId: raw.listId ?? null,
+    targetingMode: raw.targetingMode ?? 'everyone',
+    groupId: raw.groupId ?? null,
+    groupName: raw.groupName ?? null,
+    hiveScope: raw.hiveScope ?? 'hkcu',
+    enabled: raw.enabled ?? true,
+  };
+}
+
+function mergeSettings(base: OneDriveHelperSettings, stored?: Partial<OneDriveHelperSettings>): OneDriveHelperSettings {
+  const merged = { ...base, ...stored };
+  merged.kfmFolders = Array.isArray(merged.kfmFolders)
+    ? merged.kfmFolders.filter((f): f is KfmFolder => (KFM_FOLDERS as string[]).includes(f))
+    : [...base.kfmFolders];
+  merged.libraries = Array.isArray(merged.libraries) ? merged.libraries.map(normalizeLibrary) : [];
+  return merged;
+}
+
+// Decode a friendly SharePoint site hint from a full site URL for the row.
+function siteHint(siteUrl?: string | null): string | null {
+  if (!siteUrl) return null;
+  try {
+    const url = new URL(siteUrl);
+    return `${url.host}${url.pathname}`.replace(/\/$/, '');
+  } catch {
+    return siteUrl;
+  }
+}
+
+export default function OneDriveHelperTab({ policyId, existingLink, onLinkChanged, linkedPolicyId, parentLink }: FeatureTabProps) {
+  const { save, remove, saving, error, clearError } = useFeatureLink(policyId);
+  const isInherited = !!parentLink && !existingLink;
+  const effectiveLink = existingLink ?? parentLink;
+  const [settings, setSettings] = useState<OneDriveHelperSettings>(() =>
+    mergeSettings(defaults, effectiveLink?.inlineSettings as Partial<OneDriveHelperSettings> | undefined),
+  );
+
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [manualId, setManualId] = useState('');
+  const [manualName, setManualName] = useState('');
+  const [manualError, setManualError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const link = existingLink ?? parentLink;
+    if (link?.inlineSettings) {
+      setSettings((prev) => mergeSettings(prev, link.inlineSettings as Partial<OneDriveHelperSettings>));
+    }
+  }, [existingLink, parentLink]);
+
+  const update = <K extends keyof OneDriveHelperSettings>(key: K, value: OneDriveHelperSettings[K]) =>
+    setSettings((prev) => ({ ...prev, [key]: value }));
+
+  const toggleFolder = (folder: KfmFolder) =>
+    setSettings((prev) => ({
+      ...prev,
+      kfmFolders: prev.kfmFolders.includes(folder)
+        ? prev.kfmFolders.filter((f) => f !== folder)
+        : [...prev.kfmFolders, folder],
+    }));
+
+  const updateLibrary = (index: number, patch: Partial<LibraryMapping>) =>
+    setSettings((prev) => ({
+      ...prev,
+      libraries: prev.libraries.map((lib, i) => (i === index ? { ...lib, ...patch } : lib)),
+    }));
+
+  const removeLibrary = (index: number) =>
+    setSettings((prev) => ({ ...prev, libraries: prev.libraries.filter((_, i) => i !== index) }));
+
+  // Task-3 manual-entry add. The Graph picker (Task 4) will swap this internal
+  // form for OneDriveLibraryPicker; keep the add-flow isolated so that's a small
+  // change (append the returned mapping via addLibrary and drop this form).
+  const addLibrary = (lib: LibraryMapping) =>
+    setSettings((prev) => ({ ...prev, libraries: [...prev.libraries, lib] }));
+
+  const submitManual = () => {
+    const libraryId = manualId.trim();
+    const displayName = manualName.trim();
+    if (!libraryId.startsWith('tenantId=')) {
+      setManualError('Library ID must start with "tenantId=" (paste the composite ID from SharePoint).');
+      return;
+    }
+    if (!displayName) {
+      setManualError('Display name is required.');
+      return;
+    }
+    addLibrary(normalizeLibrary({ libraryId, displayName }));
+    setManualId('');
+    setManualName('');
+    setManualError(null);
+    setShowAddForm(false);
+  };
+
+  // EventLogTab-style allowlist: build the wire payload from known keys only so
+  // legacy/unknown fields on an older link are never re-persisted.
+  const toPayload = (s: OneDriveHelperSettings) => ({
+    silentAccountConfig: s.silentAccountConfig,
+    filesOnDemand: s.filesOnDemand,
+    kfmSilentOptIn: s.kfmSilentOptIn,
+    kfmFolders: s.kfmFolders,
+    kfmBlockOptOut: s.kfmBlockOptOut,
+    tenantAssociationId: s.tenantAssociationId?.trim() ? s.tenantAssociationId.trim() : null,
+    restartOnChange: s.restartOnChange,
+    libraries: s.libraries.map((lib) => ({
+      libraryId: lib.libraryId,
+      displayName: lib.displayName,
+      siteUrl: lib.siteUrl ?? null,
+      siteId: lib.siteId ?? null,
+      webId: lib.webId ?? null,
+      listId: lib.listId ?? null,
+      targetingMode: lib.targetingMode,
+      groupId: lib.groupId ?? null,
+      groupName: lib.groupName ?? null,
+      hiveScope: lib.hiveScope,
+      enabled: lib.enabled,
+    })),
+  });
+
+  const hasInvalidLibrary = settings.libraries.some((lib) => libraryError(lib) !== null);
+
+  const persist = async (existingId: string | null) => {
+    clearError();
+    const result = await save(existingId, {
+      featureType: 'onedrive_helper',
+      featurePolicyId: linkedPolicyId,
+      inlineSettings: toPayload(settings),
+    });
+    if (result) onLinkChanged(result, 'onedrive_helper');
+  };
+
+  const handleSave = () => persist(existingLink?.id ?? null);
+  const handleOverride = () => persist(null);
+
+  const handleRemove = async () => {
+    if (!existingLink) return;
+    const ok = await remove(existingLink.id);
+    if (ok) onLinkChanged(null, 'onedrive_helper');
+  };
+
+  const meta = FEATURE_META.onedrive_helper;
+
+  return (
+    <FeatureTabShell
+      title={meta.label}
+      description={meta.description}
+      icon={<Cloud className="h-5 w-5" />}
+      isConfigured={!!existingLink || isInherited}
+      saving={saving}
+      saveDisabled={hasInvalidLibrary}
+      error={error}
+      onSave={handleSave}
+      onRemove={existingLink && !linkedPolicyId ? handleRemove : undefined}
+      isInherited={isInherited}
+      onOverride={isInherited ? handleOverride : undefined}
+      onRevert={!isInherited && !!linkedPolicyId && !!existingLink ? handleRemove : undefined}
+    >
+      <div className="space-y-6">
+        {/* Base toggles */}
+        <div className="space-y-3">
+          <ToggleRow
+            testId="onedrive-toggle-silent"
+            title="Silent account configuration"
+            description="Sign the user into OneDrive automatically with their Windows (Entra) identity — no prompt."
+            checked={settings.silentAccountConfig}
+            onChange={(v) => update('silentAccountConfig', v)}
+          />
+          <ToggleRow
+            testId="onedrive-toggle-fod"
+            title="Files On-Demand"
+            description="Keep files online-only until opened, saving local disk space."
+            checked={settings.filesOnDemand}
+            onChange={(v) => update('filesOnDemand', v)}
+          />
+          <ToggleRow
+            testId="onedrive-toggle-kfm"
+            title="Known Folder Move (KFM)"
+            description="Silently redirect Desktop, Documents, and Pictures into OneDrive."
+            checked={settings.kfmSilentOptIn}
+            onChange={(v) => update('kfmSilentOptIn', v)}
+          />
+
+          {/* KFM sub-options — only meaningful when KFM is enabled. */}
+          {settings.kfmSilentOptIn && (
+            <div className="ml-4 space-y-4 rounded-md border border-muted bg-muted/30 px-4 py-4">
+              <div>
+                <h3 className="text-sm font-semibold">Redirected folders</h3>
+                <div className="mt-2 grid grid-cols-3 gap-2">
+                  {KFM_FOLDERS.map((folder) => (
+                    <label key={folder} className="flex items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm cursor-pointer">
+                      <input
+                        type="checkbox"
+                        data-testid={`onedrive-kfm-folder-${folder}`}
+                        checked={settings.kfmFolders.includes(folder)}
+                        onChange={() => toggleFolder(folder)}
+                        className="h-4 w-4 rounded border-border"
+                      />
+                      {folder}
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <label className="flex items-center gap-3 rounded-md border bg-background px-4 py-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  data-testid="onedrive-kfm-block-optout"
+                  checked={settings.kfmBlockOptOut}
+                  onChange={(e) => update('kfmBlockOptOut', e.target.checked)}
+                  className="h-4 w-4 rounded border-border"
+                />
+                <div>
+                  <p className="text-sm font-medium">Block opt-out</p>
+                  <p className="text-xs text-muted-foreground">Prevent users from moving their known folders back out of OneDrive.</p>
+                </div>
+              </label>
+
+              <div>
+                <label className="text-sm font-medium">Tenant association ID</label>
+                <input
+                  type="text"
+                  data-testid="onedrive-tenant-association"
+                  value={settings.tenantAssociationId ?? ''}
+                  onChange={(e) => update('tenantAssociationId', e.target.value)}
+                  placeholder="Tenant GUID (optional — scopes KFM to your tenant)"
+                  className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">Restricts KFM to accounts in this tenant. Leave blank to allow any.</p>
+              </div>
+            </div>
+          )}
+
+          <ToggleRow
+            testId="onedrive-toggle-restart"
+            title="Restart OneDrive on change"
+            description="Restart the OneDrive client after applying policy changes so they take effect immediately."
+            checked={settings.restartOnChange}
+            onChange={(v) => update('restartOnChange', v)}
+          />
+        </div>
+
+        {/* SharePoint libraries */}
+        <div className="space-y-3 border-t pt-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-sm font-semibold">SharePoint libraries</h3>
+              <p className="text-xs text-muted-foreground">Auto-mount these document libraries for targeted users.</p>
+            </div>
+            <button
+              type="button"
+              data-testid="onedrive-add-library-btn"
+              onClick={() => {
+                setShowAddForm((v) => !v);
+                setManualError(null);
+              }}
+              className="inline-flex items-center gap-2 rounded-md border border-primary/40 px-3 py-2 text-sm font-medium text-primary transition hover:bg-primary/10"
+            >
+              <Plus className="h-4 w-4" />
+              Add library
+            </button>
+          </div>
+
+          {showAddForm && (
+            <div className="space-y-3 rounded-md border border-dashed bg-muted/30 px-4 py-4">
+              <div>
+                <label className="text-sm font-medium">Composite library ID</label>
+                <input
+                  type="text"
+                  data-testid="onedrive-manual-library-id"
+                  value={manualId}
+                  onChange={(e) => setManualId(e.target.value)}
+                  placeholder="tenantId=…&siteId=…&webId=…&listId=…"
+                  className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">Paste the composite ID from SharePoint. A Graph picker replaces this soon.</p>
+              </div>
+              <div>
+                <label className="text-sm font-medium">Display name</label>
+                <input
+                  type="text"
+                  data-testid="onedrive-manual-display-name"
+                  value={manualName}
+                  onChange={(e) => setManualName(e.target.value)}
+                  placeholder="e.g. Marketing Share"
+                  className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                />
+              </div>
+              {manualError && <p className="text-xs text-destructive">{manualError}</p>}
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  data-testid="onedrive-manual-add-submit"
+                  onClick={submitManual}
+                  className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+          )}
+
+          {settings.libraries.length === 0 && !showAddForm && (
+            <p className="rounded-md border border-dashed px-4 py-6 text-center text-sm text-muted-foreground">
+              No libraries mapped yet.
+            </p>
+          )}
+
+          <div className="space-y-3">
+            {settings.libraries.map((lib, idx) => {
+              const rowError = libraryError(lib);
+              const hint = siteHint(lib.siteUrl);
+              return (
+                <div
+                  key={idx}
+                  data-testid={`onedrive-lib-row-${idx}`}
+                  className="space-y-3 rounded-md border bg-background px-4 py-4"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">{lib.displayName}</p>
+                      {hint && <p className="truncate text-xs text-muted-foreground">{hint}</p>}
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
+                        <input
+                          type="checkbox"
+                          data-testid={`onedrive-lib-enabled-${idx}`}
+                          checked={lib.enabled}
+                          onChange={(e) => updateLibrary(idx, { enabled: e.target.checked })}
+                          className="h-4 w-4 rounded border-border"
+                        />
+                        Enabled
+                      </label>
+                      <button
+                        type="button"
+                        data-testid={`onedrive-lib-remove-${idx}`}
+                        onClick={() => removeLibrary(idx)}
+                        className="inline-flex items-center justify-center rounded-md border border-destructive/40 p-2 text-destructive transition hover:bg-destructive/10"
+                        aria-label="Remove library"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div>
+                      <label className="text-xs font-medium">Targeting</label>
+                      <select
+                        data-testid={`onedrive-lib-targeting-${idx}`}
+                        value={lib.targetingMode}
+                        onChange={(e) => updateLibrary(idx, { targetingMode: e.target.value as TargetingMode })}
+                        className="mt-1 h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                      >
+                        {targetingOptions.map((o) => (
+                          <option key={o.value} value={o.value}>{o.label}</option>
+                        ))}
+                      </select>
+                    </div>
+
+                    {lib.targetingMode === 'graph_group' && (
+                      <div>
+                        <label className="text-xs font-medium">Group ID</label>
+                        <input
+                          type="text"
+                          data-testid={`onedrive-lib-groupid-${idx}`}
+                          value={lib.groupId ?? ''}
+                          onChange={(e) => updateLibrary(idx, { groupId: e.target.value })}
+                          placeholder="Entra group object ID"
+                          className="mt-1 h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                        />
+                      </div>
+                    )}
+
+                    {(lib.targetingMode === 'graph_group' || lib.targetingMode === 'local_ad_group') && (
+                      <div>
+                        <label className="text-xs font-medium">Group name</label>
+                        <input
+                          type="text"
+                          data-testid={`onedrive-lib-groupname-${idx}`}
+                          value={lib.groupName ?? ''}
+                          onChange={(e) => updateLibrary(idx, { groupName: e.target.value })}
+                          placeholder={lib.targetingMode === 'local_ad_group' ? 'AD / local group name' : 'Entra group display name'}
+                          className="mt-1 h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                        />
+                      </div>
+                    )}
+                  </div>
+
+                  {rowError && <p className="text-xs text-destructive">{rowError}</p>}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </FeatureTabShell>
+  );
+}
+
+function ToggleRow({
+  testId,
+  title,
+  description,
+  checked,
+  onChange,
+}: {
+  testId: string;
+  title: string;
+  description: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between rounded-md border bg-background px-4 py-3">
+      <div className="pr-4">
+        <p className="text-sm font-medium">{title}</p>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <button
+        type="button"
+        data-testid={testId}
+        aria-pressed={checked}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border transition ${checked ? 'bg-emerald-500/80' : 'bg-muted'}`}
+      >
+        <span className={`inline-block h-5 w-5 rounded-full bg-white transition ${checked ? 'translate-x-5' : 'translate-x-1'}`} />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveLibraryPicker.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveLibraryPicker.test.tsx
@@ -52,6 +52,27 @@ describe('OneDriveLibraryPicker', () => {
     expect(mockedLibraries).not.toHaveBeenCalled();
   });
 
+  it('connection probe 404s (M365 flag disabled server-side) → disconnected state, not error, libraries never fetched', async () => {
+    // fetchM365ConnectionStatus never throws for a non-ok response (see onedrive.ts) —
+    // a flag-disabled 404 resolves to `false` here, same as any other disconnected probe.
+    mockedStatus.mockResolvedValue(false);
+
+    render(<OneDriveLibraryPicker onAdd={onAdd} onClose={onClose} />);
+
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-no-connection')).toBeTruthy());
+
+    // Manual-paste fallback is reachable — this is the whole point of the fix.
+    expect(screen.getByTestId('onedrive-picker-manual-id')).toBeTruthy();
+    expect(screen.getByTestId('onedrive-picker-manual-name')).toBeTruthy();
+
+    // Must NOT land in the error state.
+    expect(screen.queryByTestId('onedrive-picker-error')).toBeNull();
+    expect(screen.queryByTestId('onedrive-picker-retry')).toBeNull();
+
+    // Libraries never fetched when disconnected.
+    expect(mockedLibraries).not.toHaveBeenCalled();
+  });
+
   it('manual fallback rejects an id that does not start with tenantId=', async () => {
     mockedStatus.mockResolvedValue(false);
 

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveLibraryPicker.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveLibraryPicker.test.tsx
@@ -1,0 +1,180 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OneDriveLibraryPicker from './OneDriveLibraryPicker';
+import * as api from '../../../lib/api/onedrive';
+import type { OneDriveLibrary } from '../../../lib/api/onedrive';
+
+vi.mock('../../../lib/api/onedrive', () => ({
+  fetchM365ConnectionStatus: vi.fn(),
+  fetchOneDriveLibraries: vi.fn(),
+}));
+
+const mockedStatus = vi.mocked(api.fetchM365ConnectionStatus);
+const mockedLibraries = vi.mocked(api.fetchOneDriveLibraries);
+
+function lib(overrides: Partial<OneDriveLibrary> = {}): OneDriveLibrary {
+  return {
+    siteId: 'sp!site-guid',
+    siteName: 'Marketing',
+    siteUrl: 'https://contoso.sharepoint.com/sites/marketing',
+    driveId: 'drive-1',
+    listId: 'list-1',
+    libraryName: 'Documents',
+    tenantId: 'tenant-1',
+    webId: 'web-1',
+    spSiteId: 'site-guid-bare',
+    autoMountValue: 'tenantId=tenant-1&siteId=site-guid-bare&webId=web-1&listId=list-1',
+    ...overrides,
+  };
+}
+
+describe('OneDriveLibraryPicker', () => {
+  const onAdd = vi.fn();
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('no connection → shows manual fallback and does NOT fetch libraries', async () => {
+    mockedStatus.mockResolvedValue(false);
+
+    render(<OneDriveLibraryPicker onAdd={onAdd} onClose={onClose} />);
+
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-no-connection')).toBeTruthy());
+
+    // Manual fallback visible.
+    expect(screen.getByTestId('onedrive-picker-manual-id')).toBeTruthy();
+    expect(screen.getByTestId('onedrive-picker-manual-name')).toBeTruthy();
+
+    // Libraries never fetched when disconnected.
+    expect(mockedLibraries).not.toHaveBeenCalled();
+  });
+
+  it('manual fallback rejects an id that does not start with tenantId=', async () => {
+    mockedStatus.mockResolvedValue(false);
+
+    render(<OneDriveLibraryPicker onAdd={onAdd} onClose={onClose} />);
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-manual-id')).toBeTruthy());
+
+    fireEvent.change(screen.getByTestId('onedrive-picker-manual-id'), { target: { value: 'nope' } });
+    fireEvent.change(screen.getByTestId('onedrive-picker-manual-name'), { target: { value: 'Bad' } });
+    fireEvent.click(screen.getByTestId('onedrive-picker-manual-submit'));
+
+    expect(onAdd).not.toHaveBeenCalled();
+    expect(screen.getByText(/must start with/i)).toBeTruthy();
+  });
+
+  it('manual fallback adds a valid composite id via onAdd', async () => {
+    mockedStatus.mockResolvedValue(false);
+
+    render(<OneDriveLibraryPicker onAdd={onAdd} onClose={onClose} />);
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-manual-id')).toBeTruthy());
+
+    fireEvent.change(screen.getByTestId('onedrive-picker-manual-id'), {
+      target: { value: 'tenantId=t1&siteId=s1' },
+    });
+    fireEvent.change(screen.getByTestId('onedrive-picker-manual-name'), { target: { value: 'Finance' } });
+    fireEvent.click(screen.getByTestId('onedrive-picker-manual-submit'));
+
+    expect(onAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ libraryId: 'tenantId=t1&siteId=s1', displayName: 'Finance' }),
+    );
+  });
+
+  it('connected → renders libraries grouped by site; Add maps autoMountValue/spSiteId', async () => {
+    mockedStatus.mockResolvedValue(true);
+    mockedLibraries.mockResolvedValue({
+      libraries: [
+        lib({ driveId: 'drive-1', siteName: 'Marketing', libraryName: 'Documents' }),
+        lib({ driveId: 'drive-2', siteName: 'Finance', libraryName: 'Reports', spSiteId: 'finance-guid' }),
+      ],
+      skippedSites: [],
+    });
+
+    render(<OneDriveLibraryPicker onAdd={onAdd} onClose={onClose} />);
+
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-add-drive-1')).toBeTruthy());
+
+    // Grouped-by-site headings.
+    expect(screen.getByText('Marketing')).toBeTruthy();
+    expect(screen.getByText('Finance')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('onedrive-picker-add-drive-1'));
+
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    const arg = onAdd.mock.calls[0][0];
+    expect(arg.libraryId).toBe('tenantId=tenant-1&siteId=site-guid-bare&webId=web-1&listId=list-1');
+    expect(arg.siteId).toBe('site-guid-bare'); // spSiteId (bare GUID), NOT siteId
+    expect(arg.displayName).toBe('Documents');
+    expect(arg.webId).toBe('web-1');
+    expect(arg.listId).toBe('list-1');
+  });
+
+  it('connected → search filters the library rows', async () => {
+    mockedStatus.mockResolvedValue(true);
+    mockedLibraries.mockResolvedValue({
+      libraries: [
+        lib({ driveId: 'drive-1', siteName: 'Marketing', libraryName: 'Documents' }),
+        lib({ driveId: 'drive-2', siteName: 'Finance', libraryName: 'Reports' }),
+      ],
+      skippedSites: [],
+    });
+
+    render(<OneDriveLibraryPicker onAdd={onAdd} onClose={onClose} />);
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-add-drive-1')).toBeTruthy());
+
+    fireEvent.change(screen.getByTestId('onedrive-picker-search'), { target: { value: 'report' } });
+
+    expect(screen.queryByTestId('onedrive-picker-add-drive-1')).toBeNull();
+    expect(screen.getByTestId('onedrive-picker-add-drive-2')).toBeTruthy();
+  });
+
+  it('connected → row with empty autoMountValue is disabled', async () => {
+    mockedStatus.mockResolvedValue(true);
+    mockedLibraries.mockResolvedValue({
+      libraries: [lib({ driveId: 'drive-x', autoMountValue: '' })],
+      skippedSites: [],
+    });
+
+    render(<OneDriveLibraryPicker onAdd={onAdd} onClose={onClose} />);
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-add-drive-x')).toBeTruthy());
+
+    const btn = screen.getByTestId('onedrive-picker-add-drive-x') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('connected → skippedSites renders a warning line', async () => {
+    mockedStatus.mockResolvedValue(true);
+    mockedLibraries.mockResolvedValue({
+      libraries: [lib()],
+      skippedSites: [
+        { siteId: 'a', code: 'forbidden' },
+        { siteId: 'b', code: 'error' },
+      ],
+    });
+
+    render(<OneDriveLibraryPicker onAdd={onAdd} onClose={onClose} />);
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-skipped-warning')).toBeTruthy());
+
+    expect(screen.getByText(/2 sites could not be read/i)).toBeTruthy();
+  });
+
+  it('error while fetching libraries → error + retry re-fetches', async () => {
+    mockedStatus.mockResolvedValue(true);
+    mockedLibraries.mockRejectedValueOnce(new Error('Graph exploded')).mockResolvedValueOnce({
+      libraries: [lib()],
+      skippedSites: [],
+    });
+
+    render(<OneDriveLibraryPicker onAdd={onAdd} onClose={onClose} />);
+
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-error')).toBeTruthy());
+    expect(screen.getByText(/Graph exploded/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('onedrive-picker-retry'));
+
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-add-drive-1')).toBeTruthy());
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveLibraryPicker.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveLibraryPicker.tsx
@@ -1,0 +1,363 @@
+import { useState, useMemo, useEffect, useCallback } from 'react';
+import { X, Search, Cloud, Loader2, Plus, AlertTriangle, CloudOff } from 'lucide-react';
+import {
+  fetchM365ConnectionStatus,
+  fetchOneDriveLibraries,
+  type OneDriveLibrary,
+} from '../../../lib/api/onedrive';
+
+export type PickedLibrary = {
+  libraryId: string;
+  displayName: string;
+  siteUrl: string;
+  siteId: string;
+  webId: string;
+  listId: string;
+};
+
+type OneDriveLibraryPickerProps = {
+  orgId?: string;
+  onAdd: (lib: PickedLibrary) => void;
+  onClose: () => void;
+};
+
+type SkippedSite = { siteId: string; code: string };
+
+// State machine: while we don't yet know the connection status we're 'checking';
+// a false status short-circuits to 'disconnected' WITHOUT ever fetching
+// libraries (Graph call would 409). A true status flips us into the library
+// list, which has its own loading/error/ready phases.
+type Phase = 'checking' | 'disconnected' | 'loading' | 'error' | 'ready';
+
+// Map a Graph library row to the wire shape the tab persists. libraryId is the
+// composite autoMountValue; siteId is the BARE GUID (spSiteId), matching the DB
+// column meaning — NOT the `siteId` field (which is the composite Graph id).
+function toPicked(lib: OneDriveLibrary): PickedLibrary {
+  return {
+    libraryId: lib.autoMountValue,
+    displayName: lib.libraryName,
+    siteUrl: lib.siteUrl,
+    siteId: lib.spSiteId,
+    webId: lib.webId,
+    listId: lib.listId,
+  };
+}
+
+export default function OneDriveLibraryPicker({ orgId, onAdd, onClose }: OneDriveLibraryPickerProps) {
+  const [phase, setPhase] = useState<Phase>('checking');
+  const [error, setError] = useState<string>();
+  const [libraries, setLibraries] = useState<OneDriveLibrary[]>([]);
+  const [skippedSites, setSkippedSites] = useState<SkippedSite[]>([]);
+  const [query, setQuery] = useState('');
+  const [manualOpen, setManualOpen] = useState(false);
+
+  const loadLibraries = useCallback(async () => {
+    setPhase('loading');
+    setError(undefined);
+    try {
+      const { libraries: libs, skippedSites: skipped } = await fetchOneDriveLibraries(orgId);
+      setLibraries(libs);
+      setSkippedSites(skipped);
+      setPhase('ready');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load libraries.');
+      setPhase('error');
+    }
+  }, [orgId]);
+
+  // Check connection FIRST; only fetch libraries when actually connected.
+  const checkConnection = useCallback(async () => {
+    setPhase('checking');
+    setError(undefined);
+    try {
+      const connected = await fetchM365ConnectionStatus(orgId);
+      if (connected) {
+        await loadLibraries();
+      } else {
+        setPhase('disconnected');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to check the Microsoft 365 connection.');
+      setPhase('error');
+    }
+  }, [orgId, loadLibraries]);
+
+  useEffect(() => {
+    void checkConnection();
+  }, [checkConnection]);
+
+  // Group filtered libraries by site name, preserving first-seen order.
+  const groups = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    const matches = libraries.filter((lib) => {
+      if (!normalized) return true;
+      return (
+        lib.libraryName.toLowerCase().includes(normalized) ||
+        lib.siteName.toLowerCase().includes(normalized) ||
+        lib.siteUrl.toLowerCase().includes(normalized)
+      );
+    });
+    const bySite = new Map<string, OneDriveLibrary[]>();
+    for (const lib of matches) {
+      const bucket = bySite.get(lib.siteName);
+      if (bucket) bucket.push(lib);
+      else bySite.set(lib.siteName, [lib]);
+    }
+    return Array.from(bySite.entries());
+  }, [libraries, query]);
+
+  const handleAddLibrary = (lib: OneDriveLibrary) => onAdd(toPicked(lib));
+
+  return (
+    <div
+      data-testid="onedrive-picker"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-8"
+    >
+      <div className="flex max-h-[80vh] w-full max-w-2xl flex-col overflow-hidden rounded-lg border bg-card shadow-lg">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b px-6 py-4">
+          <div className="flex items-center gap-3">
+            <Cloud className="h-5 w-5 text-primary" />
+            <div>
+              <h2 className="text-lg font-semibold">Add SharePoint library</h2>
+              <p className="text-sm text-muted-foreground">
+                Pick a document library to auto-mount, or paste a composite library ID.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            data-testid="onedrive-picker-close"
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Search (only meaningful in the connected list view) */}
+        {phase === 'ready' && (
+          <div className="border-b px-6 py-3">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <input
+                type="search"
+                data-testid="onedrive-picker-search"
+                placeholder="Search libraries or sites…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="h-9 w-full rounded-md border bg-background pl-9 pr-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {(phase === 'checking' || phase === 'loading') && (
+            <div data-testid="onedrive-picker-loading" className="flex items-center justify-center py-12">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          )}
+
+          {phase === 'error' && (
+            <div className="space-y-3 py-8 text-center">
+              <div
+                data-testid="onedrive-picker-error"
+                className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+              >
+                {error}
+              </div>
+              <button
+                type="button"
+                data-testid="onedrive-picker-retry"
+                onClick={() => void checkConnection()}
+                className="inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition hover:bg-muted"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+
+          {phase === 'disconnected' && (
+            <div data-testid="onedrive-picker-no-connection" className="space-y-4">
+              <div className="flex items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3">
+                <CloudOff className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+                <div className="text-sm">
+                  <p className="font-medium">No Microsoft 365 connection</p>
+                  <p className="mt-1 text-muted-foreground">
+                    Connect this organization to Microsoft 365 to browse its SharePoint libraries. In the
+                    meantime you can paste a composite library ID below.
+                  </p>
+                  <a
+                    href="/settings/integrations"
+                    className="mt-2 inline-block font-medium text-primary hover:underline"
+                  >
+                    Open Microsoft 365 connection settings →
+                  </a>
+                </div>
+              </div>
+              <ManualPaste onAdd={onAdd} />
+            </div>
+          )}
+
+          {phase === 'ready' && (
+            <div className="space-y-4">
+              {skippedSites.length > 0 && (
+                <div
+                  data-testid="onedrive-picker-skipped-warning"
+                  className="flex items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700"
+                >
+                  <AlertTriangle className="h-4 w-4 shrink-0" />
+                  {skippedSites.length} {skippedSites.length === 1 ? 'site' : 'sites'} could not be read.
+                </div>
+              )}
+
+              {groups.length === 0 ? (
+                <p className="py-8 text-center text-sm text-muted-foreground">
+                  {libraries.length === 0 ? 'No document libraries found.' : 'No libraries match your search.'}
+                </p>
+              ) : (
+                groups.map(([siteName, libs]) => (
+                  <div key={siteName} className="space-y-2">
+                    <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {siteName}
+                    </h3>
+                    <div className="space-y-2">
+                      {libs.map((lib) => {
+                        const disabled = !lib.autoMountValue;
+                        return (
+                          <div
+                            key={lib.driveId}
+                            className="flex items-center justify-between gap-3 rounded-lg border bg-background p-3"
+                          >
+                            <div className="min-w-0">
+                              <p className="truncate text-sm font-medium">{lib.libraryName}</p>
+                              {disabled ? (
+                                <p className="truncate text-xs text-amber-600">
+                                  This library has no mountable ID and can't be added.
+                                </p>
+                              ) : (
+                                <p className="truncate text-xs text-muted-foreground">{lib.siteUrl}</p>
+                              )}
+                            </div>
+                            <button
+                              type="button"
+                              data-testid={`onedrive-picker-add-${lib.driveId}`}
+                              onClick={() => handleAddLibrary(lib)}
+                              disabled={disabled}
+                              className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-primary/40 px-3 py-1.5 text-sm font-medium text-primary transition hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-40"
+                            >
+                              <Plus className="h-4 w-4" />
+                              Add
+                            </button>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))
+              )}
+
+              {/* Manual paste stays available as a secondary path in the connected view. */}
+              <div className="border-t pt-3">
+                <button
+                  type="button"
+                  data-testid="onedrive-picker-manual-toggle"
+                  onClick={() => setManualOpen((v) => !v)}
+                  className="text-sm font-medium text-muted-foreground hover:text-foreground"
+                >
+                  {manualOpen ? 'Hide manual entry' : 'Paste a library ID instead'}
+                </button>
+                {manualOpen && (
+                  <div className="mt-3">
+                    <ManualPaste onAdd={onAdd} />
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end border-t px-6 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-10 rounded-md border px-4 text-sm font-medium text-muted-foreground transition hover:text-foreground"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Composite-ID paste fallback. Validates the `tenantId=` prefix (mirrors the
+// server-side library-id format) so bad input is caught before it reaches Save.
+function ManualPaste({ onAdd }: { onAdd: (lib: PickedLibrary) => void }) {
+  const [manualId, setManualId] = useState('');
+  const [manualName, setManualName] = useState('');
+  const [manualError, setManualError] = useState<string | null>(null);
+
+  const submit = () => {
+    const libraryId = manualId.trim();
+    const displayName = manualName.trim();
+    if (!libraryId.startsWith('tenantId=')) {
+      setManualError('Library ID must start with "tenantId=" (paste the composite ID from SharePoint).');
+      return;
+    }
+    if (!displayName) {
+      setManualError('Display name is required.');
+      return;
+    }
+    onAdd({ libraryId, displayName, siteUrl: '', siteId: '', webId: '', listId: '' });
+    setManualId('');
+    setManualName('');
+    setManualError(null);
+  };
+
+  return (
+    <div className="space-y-3 rounded-md border border-dashed bg-muted/30 px-4 py-4">
+      <div>
+        <label className="text-sm font-medium">Composite library ID</label>
+        <input
+          type="text"
+          data-testid="onedrive-picker-manual-id"
+          value={manualId}
+          onChange={(e) => setManualId(e.target.value)}
+          placeholder="tenantId=…&siteId=…&webId=…&listId=…"
+          className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+        />
+      </div>
+      <div>
+        <label className="text-sm font-medium">Display name</label>
+        <input
+          type="text"
+          data-testid="onedrive-picker-manual-name"
+          value={manualName}
+          onChange={(e) => setManualName(e.target.value)}
+          placeholder="e.g. Marketing Share"
+          className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+        />
+      </div>
+      {manualError && (
+        <p data-testid="onedrive-picker-manual-error" className="text-xs text-destructive">
+          {manualError}
+        </p>
+      )}
+      <div className="flex justify-end">
+        <button
+          type="button"
+          data-testid="onedrive-picker-manual-submit"
+          onClick={submit}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveLibraryPicker.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveLibraryPicker.tsx
@@ -191,7 +191,7 @@ export default function OneDriveLibraryPicker({ orgId, onAdd, onClose }: OneDriv
                     meantime you can paste a composite library ID below.
                   </p>
                   <a
-                    href="/settings/integrations"
+                    href="/integrations#m365"
                     className="mt-2 inline-block font-medium text-primary hover:underline"
                   >
                     Open Microsoft 365 connection settings →

--- a/apps/web/src/components/configurationPolicies/featureTabs/featureTypeParity.test.ts
+++ b/apps/web/src/components/configurationPolicies/featureTabs/featureTypeParity.test.ts
@@ -33,4 +33,13 @@ describe('config-policy editor feature-type parity (#2004)', () => {
       expect(CONFIG_FEATURE_TYPES).toContain(excluded);
     }
   });
+
+  it('excludes nothing — every canonical feature type has an editor tab', () => {
+    // onedrive_helper gained its editor tab in the phase-3 work, emptying the
+    // exclusion list. The mechanism is retained (see types.ts) but currently
+    // exposes the full canonical set; assert that so a stray re-exclusion is
+    // caught here rather than silently hiding a tab.
+    expect([...EDITOR_EXCLUDED_FEATURE_TYPES]).toEqual([]);
+    expect(Object.keys(FEATURE_META).sort()).toEqual([...CONFIG_FEATURE_TYPES].sort());
+  });
 });

--- a/apps/web/src/components/configurationPolicies/featureTabs/types.ts
+++ b/apps/web/src/components/configurationPolicies/featureTabs/types.ts
@@ -2,15 +2,19 @@ import type { ConfigFeatureType } from '@breeze/shared';
 
 // Derived from the canonical CONFIG_FEATURE_TYPES (single source of truth in
 // @breeze/shared) so the config-policy editor's feature tabs can't silently
-// drift from the registry. `onedrive_helper` is deliberately excluded: it has
-// no editor tab (the OneDrive Helper is configured elsewhere). Deriving via
-// Exclude means a new canonical feature type makes FEATURE_META below fail to
-// compile until a tab entry is added, and featureTypeParity.test.ts asserts the
-// exclusion stays honest. (#2004)
+// drift from the registry. Deriving via Exclude means a new canonical feature
+// type makes FEATURE_META below fail to compile until a tab entry is added, and
+// featureTypeParity.test.ts asserts the exclusion stays honest. (#2004)
+//
+// The exclusion list is currently EMPTY — every canonical feature type has an
+// editor tab (onedrive_helper gained one in the OneDrive Helper phase-3 work).
+// The mechanism (const tuple + Exclude) is intentionally retained so a future
+// feature type that legitimately has no tab can be excluded here in one place
+// without re-plumbing the type derivation.
 //
 // FeatureType is sourced FROM this tuple (not a parallel literal) so the runtime
 // exclusion list and the compile-time Exclude can't drift from each other.
-export const EDITOR_EXCLUDED_FEATURE_TYPES = ['onedrive_helper'] as const;
+export const EDITOR_EXCLUDED_FEATURE_TYPES = [] as const;
 export type FeatureType = Exclude<ConfigFeatureType, typeof EDITOR_EXCLUDED_FEATURE_TYPES[number]>;
 
 export type FeatureLink = {
@@ -54,4 +58,5 @@ export const FEATURE_META: Record<FeatureType, {
   remote_access: { label: 'Remote Access',  fetchUrl: null,                   description: 'Remote desktop, proxy tunnels, and session limits' },
   pam:         { label: 'Privileged Access', fetchUrl: null,              description: 'Windows UAC elevation prompt capture (PAM)' },
   vulnerability: { label: 'Vulnerability Scanning', fetchUrl: null,       description: 'Enable per-device CVE correlation (vulnerability detection)' },
+  onedrive_helper: { label: 'OneDrive Helper', fetchUrl: null, description: 'Silently sign in OneDrive, enforce Files On-Demand and Known Folder Move, and auto-mount SharePoint libraries per user.' },
 };

--- a/apps/web/src/components/configurationPolicies/featureTabs/types.ts
+++ b/apps/web/src/components/configurationPolicies/featureTabs/types.ts
@@ -34,6 +34,13 @@ export type FeatureTabProps = {
   linkedPolicyId: string | null;
   /** Parent policy's feature link for this tab (for inheritance display) */
   parentLink?: FeatureLink | undefined;
+  /**
+   * Org this policy is scoped to (null for partner-wide policies — #1724).
+   * Optional: only tabs that need to make an org-scoped fetch on behalf of
+   * the policy (e.g. OneDriveHelperTab -> OneDriveLibraryPicker's M365/Graph
+   * calls) destructure it; every other tab ignores it.
+   */
+  orgId?: string | null;
 };
 
 export const FEATURE_META: Record<FeatureType, {

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -27,6 +27,7 @@ import {
   HeartPulse,
   ShieldCheck,
   Link2,
+  Cloud,
 } from 'lucide-react';
 import { formatUptime } from '../../lib/utils';
 import type { Device, DeviceStatus } from './DeviceList';
@@ -37,6 +38,7 @@ import DeviceHardwareInventory from './DeviceHardwareInventory';
 import DeviceSoftwareInventory from './DeviceSoftwareInventory';
 import DevicePatchStatusTab from './DevicePatchStatusTab';
 import DeviceVulnerabilitiesTab from './DeviceVulnerabilitiesTab';
+import DeviceOneDriveTab from './DeviceOneDriveTab';
 import DeviceSecurityTab from './DeviceSecurityTab';
 import DeviceAlertHistory from './DeviceAlertHistory';
 import DeviceActivityFeed from './DeviceActivityFeed';
@@ -75,6 +77,7 @@ type Tab =
   | 'security'
   | 'management'
   | 'effective-config'
+  | 'onedrive'
   | 'alerts'
   | 'anomalies'
   | 'scripts'
@@ -139,7 +142,7 @@ function formatLastSeen(dateString: string, timezone?: string): string {
 
 const VALID_TABS: Tab[] = [
   'overview', 'details', 'hardware', 'software', 'patches', 'vulnerabilities', 'security',
-  'management', 'effective-config', 'alerts', 'scripts', 'performance',
+  'management', 'effective-config', 'onedrive', 'alerts', 'scripts', 'performance',
   'anomalies', 'eventlog', 'monitoring', 'compliance', 'activities', 'connections', 'filesystem', 'ip-history',
   'boot-performance', 'playbooks', 'peripherals', 'backup', 'linked-profiles', 'tickets',
 ];
@@ -206,6 +209,7 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
     { id: 'scripts', label: 'Scripts', icon: <Terminal className="h-4 w-4" />, separator: true, title: 'Script execution history' },
     { id: 'management', label: 'Management', icon: <Server className="h-4 w-4" />, title: 'Agent settings and device management' },
     { id: 'effective-config', label: 'Config', icon: <Layers className="h-4 w-4" />, title: 'Resolved configuration from all assigned policies' },
+    { id: 'onedrive', label: 'OneDrive', icon: <Cloud className="h-4 w-4" />, title: 'OneDrive/SharePoint sign-in, Known Folder Move, and library drift' },
     { id: 'security', label: 'Security', icon: <Shield className="h-4 w-4" /> },
     { id: 'playbooks', label: 'Playbooks', icon: <Activity className="h-4 w-4" />, title: 'Automated remediation playbook runs' },
     // --- History & Network ---
@@ -376,6 +380,10 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
 
       {activeTab === 'management' && (
         <DeviceManagementTab deviceId={device.id} />
+      )}
+
+      {activeTab === 'onedrive' && (
+        <DeviceOneDriveTab deviceId={device.id} />
       )}
 
       {activeTab === 'effective-config' && (

--- a/apps/web/src/components/devices/DeviceOneDriveTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceOneDriveTab.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+
+import { DeviceOneDriveTab } from './DeviceOneDriveTab';
+import * as api from '../../lib/api/onedrive';
+import type { OneDriveDeviceState } from '../../lib/api/onedrive';
+
+vi.mock('../../lib/api/onedrive', () => ({
+  fetchDeviceOneDriveState: vi.fn(),
+}));
+
+// A signed-in device with: Desktop redirected, Documents not redirected,
+// Pictures absent (→ rendered as unknown), one entitled composite whose
+// human label is decoded from its webUrl= segment, one mounted path, and one
+// drift entry.
+const ENTITLED_COMPOSITE =
+  'tenantId=abc&siteId={s1}&webId={w1}&listId={l1}' +
+  '&webUrl=https%3A%2F%2Fcontoso.sharepoint.com%2Fsites%2FFinance%2FShared%20Documents&version=1';
+
+const STATE: OneDriveDeviceState = {
+  deviceId: 'd1',
+  signedIn: true,
+  oneDriveVersion: '24.126.0625.0002',
+  filesOnDemandOn: true,
+  kfmFolderStates: { Desktop: 'redirected', Documents: 'not_redirected' },
+  mountedLibraries: ['C:\\Users\\bob\\Contoso\\Finance'],
+  entitledLibraries: [ENTITLED_COMPOSITE],
+  driftEntries: [{ libraryId: 'lib-1', displayName: 'Finance Library', reason: 'entitled but not mounted' }],
+  lastReportedAt: '2026-07-09T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(api.fetchDeviceOneDriveState).mockResolvedValue(STATE);
+});
+
+describe('DeviceOneDriveTab', () => {
+  it('renders status chips, KFM badges, entitled label and drift rows after loading', async () => {
+    render(<DeviceOneDriveTab deviceId="d1" />);
+
+    // Header chips
+    const header = await screen.findByTestId('device-onedrive-header');
+    expect(header).toHaveTextContent(/Signed in/i);
+    expect(header).toHaveTextContent(/Files On-Demand/i);
+    expect(header).toHaveTextContent('24.126.0625.0002');
+
+    // KFM badges — Pictures is absent from the map and renders as unknown
+    expect(screen.getByTestId('onedrive-kfm-Desktop')).toHaveTextContent(/Redirected/i);
+    expect(screen.getByTestId('onedrive-kfm-Documents')).toHaveTextContent(/Not redirected/i);
+    expect(screen.getByTestId('onedrive-kfm-Pictures')).toHaveTextContent(/Unknown/i);
+
+    // Entitled composite decoded to a human label (host + path tail), full
+    // composite retained in the title attribute.
+    const entitled = screen.getByTestId('onedrive-entitled-0');
+    expect(entitled).toHaveTextContent('contoso.sharepoint.com/sites/Finance/Shared Documents');
+    expect(entitled).toHaveAttribute('title', ENTITLED_COMPOSITE);
+
+    // Mounted path listed as-is
+    expect(screen.getByTestId('onedrive-mounted-0')).toHaveTextContent('C:\\Users\\bob\\Contoso\\Finance');
+  });
+
+  it('renders a drift row with its reason text', async () => {
+    render(<DeviceOneDriveTab deviceId="d1" />);
+    const drift = await screen.findByTestId('onedrive-drift-0');
+    expect(within(drift).getByText(/Finance Library/)).toBeInTheDocument();
+    expect(drift).toHaveTextContent('entitled but not mounted');
+  });
+
+  it('shows the empty state when no OneDrive state has been reported', async () => {
+    vi.mocked(api.fetchDeviceOneDriveState).mockResolvedValue(null);
+    render(<DeviceOneDriveTab deviceId="d1" />);
+    const empty = await screen.findByTestId('device-onedrive-empty');
+    expect(empty).toHaveTextContent(/No OneDrive state reported yet/i);
+  });
+
+  it('shows the error state when the fetch rejects', async () => {
+    vi.mocked(api.fetchDeviceOneDriveState).mockRejectedValue(new Error('boom'));
+    render(<DeviceOneDriveTab deviceId="d1" />);
+    const err = await screen.findByTestId('device-onedrive-error');
+    expect(err).toHaveTextContent('boom');
+  });
+});

--- a/apps/web/src/components/devices/DeviceOneDriveTab.tsx
+++ b/apps/web/src/components/devices/DeviceOneDriveTab.tsx
@@ -1,0 +1,248 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Cloud, CloudOff, HardDriveDownload, Clock, AlertTriangle } from 'lucide-react';
+
+import { fetchDeviceOneDriveState, type OneDriveDeviceState } from '../../lib/api/onedrive';
+import { formatRelativeTime } from '../../lib/utils';
+
+type DeviceOneDriveTabProps = {
+  deviceId: string;
+};
+
+// The three Known Folder Move targets the agent reports on. Any folder absent
+// from `kfmFolderStates` is treated as `unknown` rather than dropped.
+const KFM_FOLDERS = ['Desktop', 'Documents', 'Pictures'] as const;
+
+const KFM_BADGES: Record<string, { label: string; className: string }> = {
+  redirected: { label: 'Redirected', className: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' },
+  not_redirected: { label: 'Not redirected', className: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' },
+  unknown: { label: 'Unknown', className: 'bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300' },
+};
+
+/**
+ * Entitled libraries arrive as raw `TenantAutoMount` registry composites
+ * (`tenantId=…&siteId=…&webUrl=<encoded>&version=1`). Decode the `webUrl=`
+ * segment into a readable `host/path` label; the full composite stays in the
+ * row's `title` attribute so the exact value is still inspectable.
+ */
+function entitledLabel(composite: string): string {
+  const match = /webUrl=([^&]*)/.exec(composite);
+  if (!match || !match[1]) return composite;
+  try {
+    return decodeURIComponent(match[1]).replace(/^https?:\/\//i, '');
+  } catch {
+    return composite;
+  }
+}
+
+function StatusChip({
+  icon,
+  label,
+  className,
+  testId,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  className: string;
+  testId?: string;
+}) {
+  return (
+    <span
+      data-testid={testId}
+      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium ${className}`}
+    >
+      {icon}
+      {label}
+    </span>
+  );
+}
+
+export function DeviceOneDriveTab({ deviceId }: DeviceOneDriveTabProps) {
+  const [state, setState] = useState<OneDriveDeviceState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchDeviceOneDriveState(deviceId);
+      setState(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load OneDrive state');
+    } finally {
+      setLoading(false);
+    }
+  }, [deviceId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (error) {
+    return (
+      <div
+        data-testid="device-onedrive-error"
+        className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300"
+      >
+        {error}
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div data-testid="device-onedrive-loading" className="px-4 py-12 text-center text-sm text-muted-foreground">
+        Loading OneDrive state…
+      </div>
+    );
+  }
+
+  if (state === null) {
+    return (
+      <div
+        data-testid="device-onedrive-empty"
+        className="rounded-md border border-dashed px-4 py-12 text-center text-sm text-muted-foreground"
+      >
+        No OneDrive state reported yet — the agent reports on its next heartbeat after a policy applies.
+      </div>
+    );
+  }
+
+  const lastReported = new Date(state.lastReportedAt);
+  const lastReportedLabel = Number.isNaN(lastReported.getTime())
+    ? state.lastReportedAt
+    : formatRelativeTime(lastReported);
+
+  return (
+    <div className="space-y-6">
+      {/* Status header chips */}
+      <div data-testid="device-onedrive-header" className="flex flex-wrap items-center gap-2">
+        {state.signedIn ? (
+          <StatusChip
+            testId="device-onedrive-signedin"
+            icon={<Cloud className="h-3.5 w-3.5" />}
+            label="Signed in"
+            className="bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+          />
+        ) : (
+          <StatusChip
+            testId="device-onedrive-signedin"
+            icon={<CloudOff className="h-3.5 w-3.5" />}
+            label="Not signed in"
+            className="bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300"
+          />
+        )}
+        <StatusChip
+          testId="device-onedrive-fod"
+          icon={<HardDriveDownload className="h-3.5 w-3.5" />}
+          label={`Files On-Demand: ${state.filesOnDemandOn ? 'On' : 'Off'}`}
+          className={
+            state.filesOnDemandOn
+              ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300'
+              : 'bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300'
+          }
+        />
+        <StatusChip
+          testId="device-onedrive-version"
+          icon={<Cloud className="h-3.5 w-3.5" />}
+          label={`OneDrive ${state.oneDriveVersion ?? 'unknown'}`}
+          className="bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300"
+        />
+        <StatusChip
+          testId="device-onedrive-lastreported"
+          icon={<Clock className="h-3.5 w-3.5" />}
+          label={`Reported ${lastReportedLabel}`}
+          className="bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300"
+        />
+      </div>
+
+      {/* Known Folder Move */}
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold">Known Folder Move</h3>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+          {KFM_FOLDERS.map((folder) => {
+            const stateVal = state.kfmFolderStates[folder] ?? 'unknown';
+            const badge = KFM_BADGES[stateVal] ?? KFM_BADGES.unknown;
+            return (
+              <div key={folder} className="rounded-md border bg-card px-3 py-2">
+                <div className="text-xs text-muted-foreground">{folder}</div>
+                <span
+                  data-testid={`onedrive-kfm-${folder}`}
+                  className={`mt-1 inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${badge.className}`}
+                >
+                  {badge.label}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Libraries */}
+      <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold">Entitled libraries</h3>
+          {state.entitledLibraries.length === 0 ? (
+            <p className="text-sm text-muted-foreground">None entitled.</p>
+          ) : (
+            <ul className="space-y-1">
+              {state.entitledLibraries.map((composite, idx) => (
+                <li
+                  key={composite}
+                  data-testid={`onedrive-entitled-${idx}`}
+                  title={composite}
+                  className="truncate rounded-md border bg-card px-3 py-2 text-sm"
+                >
+                  {entitledLabel(composite)}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold">Mounted paths</h3>
+          {state.mountedLibraries.length === 0 ? (
+            <p className="text-sm text-muted-foreground">None mounted.</p>
+          ) : (
+            <ul className="space-y-1">
+              {state.mountedLibraries.map((path, idx) => (
+                <li
+                  key={path}
+                  data-testid={`onedrive-mounted-${idx}`}
+                  className="truncate rounded-md border bg-card px-3 py-2 text-sm"
+                >
+                  {path}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+
+      {/* Drift */}
+      {state.driftEntries.length > 0 && (
+        <section className="space-y-2">
+          <h3 className="text-sm font-semibold">Drift</h3>
+          <div className="space-y-1">
+            {state.driftEntries.map((entry, idx) => (
+              <div
+                key={entry.libraryId}
+                data-testid={`onedrive-drift-${idx}`}
+                className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-300"
+              >
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                <div>
+                  <div className="font-medium">{entry.displayName}</div>
+                  <div className="text-xs">{entry.reason}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+export default DeviceOneDriveTab;

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -171,6 +171,7 @@ const topLevelNav: NavItem[] = [
   { name: 'Scripts', href: '/scripts', icon: FileCode, requiredPermission: { resource: 'scripts', action: 'read' } },
   { name: 'Patches', href: '/patches', icon: Download, requiredPermission: { resource: 'devices', action: 'read' } },
   { name: 'Vulnerabilities', href: '/vulnerabilities', icon: Bug, requiredPermission: { resource: 'devices', action: 'read' } },
+  { name: 'OneDrive', href: '/onedrive', icon: Cloud, requiredPermission: { resource: 'devices', action: 'read' } },
 ];
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/components/onedrive/OneDriveFleetPage.test.tsx
+++ b/apps/web/src/components/onedrive/OneDriveFleetPage.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, waitFor, fireEvent } from '@testing-library/react';
+
+import { OneDriveFleetPage } from './OneDriveFleetPage';
+import * as api from '../../lib/api/onedrive';
+import type { OneDriveFleetRow, OneDriveFleetStats } from '../../lib/api/onedrive';
+
+vi.mock('../../lib/api/onedrive', () => ({
+  fetchOneDriveFleetState: vi.fn(),
+}));
+
+// d1: fully protected (all 3 KFM redirected), signed in, no drift.
+// d2: KFM gap (Desktop redirected only), signed in, one drift entry.
+// d3: not signed in, no KFM, no drift.
+const DEVICES: OneDriveFleetRow[] = [
+  {
+    deviceId: 'd1',
+    hostname: 'alpha',
+    signedIn: true,
+    oneDriveVersion: '24.126.0625.0002',
+    filesOnDemandOn: true,
+    kfmFolderStates: { Desktop: 'redirected', Documents: 'redirected', Pictures: 'redirected' },
+    mountedLibraries: ['C:\\a', 'C:\\b'],
+    entitledLibraries: ['x', 'y'],
+    driftEntries: [],
+    lastReportedAt: '2026-07-09T00:00:00.000Z',
+  },
+  {
+    deviceId: 'd2',
+    hostname: 'bravo',
+    signedIn: true,
+    oneDriveVersion: '24.126.0625.0002',
+    filesOnDemandOn: false,
+    kfmFolderStates: { Desktop: 'redirected', Documents: 'not_redirected' },
+    mountedLibraries: ['C:\\a'],
+    entitledLibraries: ['x', 'y'],
+    driftEntries: [{ libraryId: 'lib-1', displayName: 'Finance', reason: 'entitled but not mounted' }],
+    lastReportedAt: '2026-07-09T00:00:00.000Z',
+  },
+  {
+    deviceId: 'd3',
+    hostname: 'charlie',
+    signedIn: false,
+    oneDriveVersion: null,
+    filesOnDemandOn: false,
+    kfmFolderStates: {},
+    mountedLibraries: [],
+    entitledLibraries: [],
+    driftEntries: [],
+    lastReportedAt: '2026-07-09T00:00:00.000Z',
+  },
+];
+
+const STATS: OneDriveFleetStats = { total: 3, signedIn: 2, kfmProtected: 1, withDrift: 1 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(api.fetchOneDriveFleetState).mockResolvedValue({ devices: DEVICES, stats: STATS });
+});
+
+describe('OneDriveFleetPage', () => {
+  it('renders the four stat tiles from the mocked fleet stats', async () => {
+    render(<OneDriveFleetPage />);
+
+    expect(await screen.findByTestId('onedrive-stat-total')).toHaveTextContent('3');
+    expect(screen.getByTestId('onedrive-stat-signed-in')).toHaveTextContent('2');
+    expect(screen.getByTestId('onedrive-stat-kfm')).toHaveTextContent('1');
+    expect(screen.getByTestId('onedrive-stat-drift')).toHaveTextContent('1');
+  });
+
+  it('filters rows when a stat tile is clicked', async () => {
+    render(<OneDriveFleetPage />);
+
+    const desktop = await screen.findByTestId('responsive-table-desktop');
+    // All three devices visible by default.
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d1')).toBeInTheDocument();
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d2')).toBeInTheDocument();
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d3')).toBeInTheDocument();
+
+    // Drift tile → only the device with drift entries.
+    fireEvent.click(screen.getByTestId('onedrive-stat-drift'));
+    await waitFor(() => {
+      expect(within(desktop).queryByTestId('onedrive-fleet-row-d1')).not.toBeInTheDocument();
+    });
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d2')).toBeInTheDocument();
+    expect(within(desktop).queryByTestId('onedrive-fleet-row-d3')).not.toBeInTheDocument();
+
+    // Signed-in tile → only signed-in devices.
+    fireEvent.click(screen.getByTestId('onedrive-stat-signed-in'));
+    await waitFor(() => {
+      expect(within(desktop).getByTestId('onedrive-fleet-row-d1')).toBeInTheDocument();
+    });
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d2')).toBeInTheDocument();
+    expect(within(desktop).queryByTestId('onedrive-fleet-row-d3')).not.toBeInTheDocument();
+
+    // KFM tile → devices NOT fully protected (kfm-gap).
+    fireEvent.click(screen.getByTestId('onedrive-stat-kfm'));
+    await waitFor(() => {
+      expect(within(desktop).queryByTestId('onedrive-fleet-row-d1')).not.toBeInTheDocument();
+    });
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d2')).toBeInTheDocument();
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d3')).toBeInTheDocument();
+  });
+
+  it('renders the drift count in amber for a drifting device', async () => {
+    render(<OneDriveFleetPage />);
+    const desktop = await screen.findByTestId('responsive-table-desktop');
+    const drift = within(desktop).getByTestId('onedrive-fleet-drift-d2');
+    expect(drift).toHaveTextContent('1');
+    expect(drift.className).toMatch(/amber/);
+  });
+
+  it('shows the empty state when no devices are reporting', async () => {
+    vi.mocked(api.fetchOneDriveFleetState).mockResolvedValue({
+      devices: [],
+      stats: { total: 0, signedIn: 0, kfmProtected: 0, withDrift: 0 },
+    });
+    render(<OneDriveFleetPage />);
+    const empty = await screen.findByTestId('onedrive-fleet-empty');
+    expect(empty).toHaveTextContent(/OneDrive Helper/i);
+  });
+});

--- a/apps/web/src/components/onedrive/OneDriveFleetPage.test.tsx
+++ b/apps/web/src/components/onedrive/OneDriveFleetPage.test.tsx
@@ -11,7 +11,11 @@ vi.mock('../../lib/api/onedrive', () => ({
 
 // d1: fully protected (all 3 KFM redirected), signed in, no drift.
 // d2: KFM gap (Desktop redirected only), signed in, one drift entry.
-// d3: not signed in, no KFM, no drift.
+// d3: not signed in, no KFM (empty folder set), no drift.
+// d4: fully protected off a 2-key folder set (mirrors the server's "at least
+//     one entry and every value redirected" math, not a hard-coded count of 3).
+// d5: signed in but reports zero KFM folder keys — must NOT count as
+//     protected (empty set), and the label must render the empty-value style.
 const DEVICES: OneDriveFleetRow[] = [
   {
     deviceId: 'd1',
@@ -49,9 +53,33 @@ const DEVICES: OneDriveFleetRow[] = [
     driftEntries: [],
     lastReportedAt: '2026-07-09T00:00:00.000Z',
   },
+  {
+    deviceId: 'd4',
+    hostname: 'delta',
+    signedIn: true,
+    oneDriveVersion: '24.126.0625.0002',
+    filesOnDemandOn: true,
+    kfmFolderStates: { Desktop: 'redirected', Documents: 'redirected' },
+    mountedLibraries: ['C:\\a'],
+    entitledLibraries: ['x'],
+    driftEntries: [],
+    lastReportedAt: '2026-07-09T00:00:00.000Z',
+  },
+  {
+    deviceId: 'd5',
+    hostname: 'echo',
+    signedIn: true,
+    oneDriveVersion: '24.126.0625.0002',
+    filesOnDemandOn: true,
+    kfmFolderStates: {},
+    mountedLibraries: [],
+    entitledLibraries: [],
+    driftEntries: [],
+    lastReportedAt: '2026-07-09T00:00:00.000Z',
+  },
 ];
 
-const STATS: OneDriveFleetStats = { total: 3, signedIn: 2, kfmProtected: 1, withDrift: 1 };
+const STATS: OneDriveFleetStats = { total: 5, signedIn: 4, kfmProtected: 2, withDrift: 1 };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -62,9 +90,9 @@ describe('OneDriveFleetPage', () => {
   it('renders the four stat tiles from the mocked fleet stats', async () => {
     render(<OneDriveFleetPage />);
 
-    expect(await screen.findByTestId('onedrive-stat-total')).toHaveTextContent('3');
-    expect(screen.getByTestId('onedrive-stat-signed-in')).toHaveTextContent('2');
-    expect(screen.getByTestId('onedrive-stat-kfm')).toHaveTextContent('1');
+    expect(await screen.findByTestId('onedrive-stat-total')).toHaveTextContent('5');
+    expect(screen.getByTestId('onedrive-stat-signed-in')).toHaveTextContent('4');
+    expect(screen.getByTestId('onedrive-stat-kfm')).toHaveTextContent('2');
     expect(screen.getByTestId('onedrive-stat-drift')).toHaveTextContent('1');
   });
 
@@ -72,10 +100,12 @@ describe('OneDriveFleetPage', () => {
     render(<OneDriveFleetPage />);
 
     const desktop = await screen.findByTestId('responsive-table-desktop');
-    // All three devices visible by default.
+    // All five devices visible by default.
     expect(within(desktop).getByTestId('onedrive-fleet-row-d1')).toBeInTheDocument();
     expect(within(desktop).getByTestId('onedrive-fleet-row-d2')).toBeInTheDocument();
     expect(within(desktop).getByTestId('onedrive-fleet-row-d3')).toBeInTheDocument();
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d4')).toBeInTheDocument();
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d5')).toBeInTheDocument();
 
     // Drift tile → only the device with drift entries.
     fireEvent.click(screen.getByTestId('onedrive-stat-drift'));
@@ -84,6 +114,8 @@ describe('OneDriveFleetPage', () => {
     });
     expect(within(desktop).getByTestId('onedrive-fleet-row-d2')).toBeInTheDocument();
     expect(within(desktop).queryByTestId('onedrive-fleet-row-d3')).not.toBeInTheDocument();
+    expect(within(desktop).queryByTestId('onedrive-fleet-row-d4')).not.toBeInTheDocument();
+    expect(within(desktop).queryByTestId('onedrive-fleet-row-d5')).not.toBeInTheDocument();
 
     // Signed-in tile → only signed-in devices.
     fireEvent.click(screen.getByTestId('onedrive-stat-signed-in'));
@@ -92,14 +124,51 @@ describe('OneDriveFleetPage', () => {
     });
     expect(within(desktop).getByTestId('onedrive-fleet-row-d2')).toBeInTheDocument();
     expect(within(desktop).queryByTestId('onedrive-fleet-row-d3')).not.toBeInTheDocument();
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d4')).toBeInTheDocument();
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d5')).toBeInTheDocument();
 
-    // KFM tile → devices NOT fully protected (kfm-gap).
+    // KFM tile → devices NOT fully protected (kfm-gap). d1 (3/3) and d4 (2/2)
+    // are fully protected off their reported folder sets and must drop out;
+    // d2 (partial), d3 (empty set) and d5 (empty set) remain.
     fireEvent.click(screen.getByTestId('onedrive-stat-kfm'));
     await waitFor(() => {
       expect(within(desktop).queryByTestId('onedrive-fleet-row-d1')).not.toBeInTheDocument();
     });
-    expect(within(desktop).getByTestId('onedrive-fleet-row-d2')).toBeInTheDocument();
-    expect(within(desktop).getByTestId('onedrive-fleet-row-d3')).toBeInTheDocument();
+    expect(within(desktop).queryByTestId('onedrive-fleet-row-d4')).not.toBeInTheDocument();
+    const kfmGapHostnames = within(desktop)
+      .getAllByTestId(/^onedrive-fleet-row-/)
+      .map((row) => row.textContent ?? '');
+    expect(kfmGapHostnames).toHaveLength(3);
+    expect(kfmGapHostnames.some((t) => t.includes('bravo'))).toBe(true);
+    expect(kfmGapHostnames.some((t) => t.includes('charlie'))).toBe(true);
+    expect(kfmGapHostnames.some((t) => t.includes('echo'))).toBe(true);
+  });
+
+  it('mirrors the server KFM math: a fully redirected 2-folder set counts as protected', async () => {
+    render(<OneDriveFleetPage />);
+    const desktop = await screen.findByTestId('responsive-table-desktop');
+
+    // d4 reports only 2 KFM folders, both redirected — the label reflects the
+    // reported set (2/2), not a hard-coded denominator of 3.
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d4')).toHaveTextContent('2/2 redirected');
+
+    // Being fully protected off a 2-key set means it must NOT show up under
+    // the kfm-gap filter.
+    fireEvent.click(screen.getByTestId('onedrive-stat-kfm'));
+    await waitFor(() => {
+      expect(within(desktop).queryByTestId('onedrive-fleet-row-d1')).not.toBeInTheDocument();
+    });
+    expect(within(desktop).queryByTestId('onedrive-fleet-row-d4')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty-value style when a device reports zero KFM folder keys', async () => {
+    render(<OneDriveFleetPage />);
+    const desktop = await screen.findByTestId('responsive-table-desktop');
+
+    // d5 signs in but reports an empty kfmFolderStates — not protected, and
+    // the label falls back to the empty-value style rather than "0/0".
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d5')).toHaveTextContent('—');
+    expect(within(desktop).getByTestId('onedrive-fleet-row-d5')).not.toHaveTextContent('redirected');
   });
 
   it('renders the drift count in amber for a drifting device', async () => {

--- a/apps/web/src/components/onedrive/OneDriveFleetPage.tsx
+++ b/apps/web/src/components/onedrive/OneDriveFleetPage.tsx
@@ -1,0 +1,291 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, CheckCircle2, Cloud, ShieldCheck } from 'lucide-react';
+
+import SecurityStatCard from '../security/SecurityStatCard';
+import { ResponsiveTable, DataCard, CardField } from '../shared/ResponsiveTable';
+import { formatRelativeTime } from '../../lib/utils';
+import { cn } from '@/lib/utils';
+import { fetchOneDriveFleetState, type OneDriveFleetRow } from '../../lib/api/onedrive';
+
+// The three Known Folder Move targets the agent reports on — a device is
+// "fully protected" only when all three are redirected. Any other value (or an
+// absent folder) leaves a gap.
+const KFM_FOLDER_COUNT = 3;
+
+// Row filters, one per stat tile (Devices reporting → all). "kfm-gap" is every
+// device that is NOT fully protected; "drift" is every device with drift
+// entries. Clicking the active tile toggles back to "all".
+type FleetFilter = 'all' | 'signed-in' | 'kfm-gap' | 'drift';
+
+// Keyboard focus ring for the stat-card shortcut buttons; hover + pressed
+// styling lives on the card itself (SecurityStatCard interactive/active).
+const STAT_BUTTON =
+  'block h-full w-full rounded-lg text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background';
+
+/** Count of KFM folders currently redirected — the numerator of "x/3 redirected". */
+function kfmRedirectedCount(row: OneDriveFleetRow): number {
+  return Object.values(row.kfmFolderStates).filter((v) => v === 'redirected').length;
+}
+
+function isFullyProtected(row: OneDriveFleetRow): boolean {
+  return kfmRedirectedCount(row) >= KFM_FOLDER_COUNT;
+}
+
+function matchesFilter(row: OneDriveFleetRow, filter: FleetFilter): boolean {
+  switch (filter) {
+    case 'signed-in':
+      return row.signedIn;
+    case 'kfm-gap':
+      return !isFullyProtected(row);
+    case 'drift':
+      return row.driftEntries.length > 0;
+    case 'all':
+    default:
+      return true;
+  }
+}
+
+function SignedInBadge({ signedIn }: { signedIn: boolean }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium',
+        signedIn
+          ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300'
+          : 'bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300',
+      )}
+    >
+      {signedIn ? 'Signed in' : 'Not signed in'}
+    </span>
+  );
+}
+
+function lastReportedLabel(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : formatRelativeTime(d);
+}
+
+export function OneDriveFleetPage() {
+  const [devices, setDevices] = useState<OneDriveFleetRow[]>([]);
+  const [stats, setStats] = useState<{ total: number; signedIn: number; kfmProtected: number; withDrift: number } | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<FleetFilter>('all');
+  const [retryKey, setRetryKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchOneDriveFleetState()
+      .then((res) => {
+        if (cancelled) return;
+        setDevices(res.devices);
+        setStats(res.stats);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load OneDrive fleet state');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [retryKey]);
+
+  // Clicking the active tile returns to the unfiltered view (toggle).
+  const toggleFilter = (next: FleetFilter) => setFilter((cur) => (cur === next ? 'all' : next));
+
+  const filtered = useMemo(() => devices.filter((d) => matchesFilter(d, filter)), [devices, filter]);
+
+  const total = stats?.total ?? 0;
+  const kfmWarning = stats !== null && stats.kfmProtected < stats.signedIn;
+
+  const renderDriftCount = (row: OneDriveFleetRow) => {
+    const n = row.driftEntries.length;
+    return (
+      <span
+        data-testid={`onedrive-fleet-drift-${row.deviceId}`}
+        className={cn('tabular-nums', n > 0 && 'font-medium text-amber-600')}
+      >
+        {n}
+      </span>
+    );
+  };
+
+  const table = (
+    <table className="min-w-full divide-y">
+      <thead className="bg-muted/40">
+        <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          <th className="px-4 py-3">Device</th>
+          <th className="px-4 py-3">OneDrive</th>
+          <th className="px-4 py-3">Files On-Demand</th>
+          <th className="px-4 py-3">Known Folder Move</th>
+          <th className="px-4 py-3">Mounted</th>
+          <th className="px-4 py-3">Entitled</th>
+          <th className="px-4 py-3">Drift</th>
+          <th className="px-4 py-3">Last reported</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y">
+        {filtered.map((row) => (
+          <tr key={row.deviceId} data-testid={`onedrive-fleet-row-${row.deviceId}`} className="hover:bg-muted/40">
+            <td className="whitespace-nowrap px-4 py-3 text-sm font-medium">
+              <a className="hover:text-foreground hover:underline" href={`/devices/${row.deviceId}#onedrive`}>
+                {row.hostname}
+              </a>
+            </td>
+            <td className="px-4 py-3 text-sm"><SignedInBadge signedIn={row.signedIn} /></td>
+            <td className="px-4 py-3 text-sm">{row.filesOnDemandOn ? 'On' : 'Off'}</td>
+            <td className="px-4 py-3 text-sm tabular-nums">{kfmRedirectedCount(row)}/{KFM_FOLDER_COUNT} redirected</td>
+            <td className="px-4 py-3 text-sm tabular-nums">{row.mountedLibraries.length}</td>
+            <td className="px-4 py-3 text-sm tabular-nums">{row.entitledLibraries.length}</td>
+            <td className="px-4 py-3 text-sm">{renderDriftCount(row)}</td>
+            <td className="whitespace-nowrap px-4 py-3 text-sm text-muted-foreground">{lastReportedLabel(row.lastReportedAt)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+  const cards = filtered.map((row) => (
+    <DataCard key={row.deviceId}>
+      <div className="flex items-center justify-between gap-2">
+        <a className="min-w-0 flex-1 truncate text-sm font-semibold hover:underline" href={`/devices/${row.deviceId}#onedrive`}>
+          {row.hostname}
+        </a>
+        <SignedInBadge signedIn={row.signedIn} />
+      </div>
+      <div className="mt-3 space-y-2 border-t pt-3">
+        <CardField label="Files On-Demand"><span className="text-sm">{row.filesOnDemandOn ? 'On' : 'Off'}</span></CardField>
+        <CardField label="Known Folder Move">
+          <span className="text-sm tabular-nums">{kfmRedirectedCount(row)}/{KFM_FOLDER_COUNT} redirected</span>
+        </CardField>
+        <CardField label="Mounted"><span className="text-sm tabular-nums">{row.mountedLibraries.length}</span></CardField>
+        <CardField label="Entitled"><span className="text-sm tabular-nums">{row.entitledLibraries.length}</span></CardField>
+        <CardField label="Drift">{renderDriftCount(row)}</CardField>
+        <CardField label="Last reported"><span className="text-sm text-muted-foreground">{lastReportedLabel(row.lastReportedAt)}</span></CardField>
+      </div>
+    </DataCard>
+  ));
+
+  return (
+    <div className="space-y-4">
+      {/* 1 → 2 → 4 columns: the 2-col step keeps the cards comfortable around
+          tablet widths; h-full keeps the row's card heights even. */}
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <button
+          type="button"
+          data-testid="onedrive-stat-total"
+          className={STAT_BUTTON}
+          aria-pressed={filter === 'all'}
+          onClick={() => setFilter('all')}
+        >
+          <SecurityStatCard
+            icon={Cloud}
+            label="Devices reporting"
+            value={stats?.total ?? '—'}
+            detail={stats ? 'devices with OneDrive state' : undefined}
+            loading={loading}
+            interactive
+            active={filter === 'all'}
+          />
+        </button>
+        <button
+          type="button"
+          data-testid="onedrive-stat-signed-in"
+          className={STAT_BUTTON}
+          aria-pressed={filter === 'signed-in'}
+          onClick={() => toggleFilter('signed-in')}
+        >
+          <SecurityStatCard
+            icon={CheckCircle2}
+            label="Signed in"
+            value={stats?.signedIn ?? '—'}
+            variant="success"
+            detail={stats ? `of ${stats.total} reporting` : undefined}
+            loading={loading}
+            interactive
+            active={filter === 'signed-in'}
+          />
+        </button>
+        <button
+          type="button"
+          data-testid="onedrive-stat-kfm"
+          className={STAT_BUTTON}
+          aria-pressed={filter === 'kfm-gap'}
+          onClick={() => toggleFilter('kfm-gap')}
+        >
+          <SecurityStatCard
+            icon={ShieldCheck}
+            label="KFM protected"
+            value={stats?.kfmProtected ?? '—'}
+            variant={kfmWarning ? 'warning' : 'success'}
+            detail={stats ? `of ${stats.signedIn} signed in` : undefined}
+            loading={loading}
+            interactive
+            active={filter === 'kfm-gap'}
+          />
+        </button>
+        <button
+          type="button"
+          data-testid="onedrive-stat-drift"
+          className={STAT_BUTTON}
+          aria-pressed={filter === 'drift'}
+          onClick={() => toggleFilter('drift')}
+        >
+          <SecurityStatCard
+            icon={AlertTriangle}
+            label="Drift"
+            value={stats?.withDrift ?? '—'}
+            variant={stats && stats.withDrift > 0 ? 'danger' : 'success'}
+            detail={stats ? 'devices with mount drift' : undefined}
+            loading={loading}
+            interactive
+            active={filter === 'drift'}
+          />
+        </button>
+      </div>
+
+      {error && (
+        <div
+          data-testid="onedrive-fleet-error"
+          className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300"
+        >
+          <p>{error}</p>
+          <button
+            type="button"
+            data-testid="onedrive-fleet-retry"
+            className="mt-2 inline-flex items-center rounded-md border border-red-300 px-3 py-1 text-sm font-medium transition hover:bg-red-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary dark:border-red-800 dark:hover:bg-red-900/40"
+            onClick={() => setRetryKey((k) => k + 1)}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {loading && !error && (
+        <div data-testid="onedrive-fleet-loading" className="px-4 py-12 text-center text-sm text-muted-foreground">
+          Loading OneDrive fleet state…
+        </div>
+      )}
+
+      {!loading && !error && total === 0 && (
+        <div
+          data-testid="onedrive-fleet-empty"
+          className="rounded-md border border-dashed px-4 py-12 text-center text-sm text-muted-foreground"
+        >
+          No devices are reporting OneDrive state yet. Enable the OneDrive Helper feature on a configuration policy and
+          assign it to your devices — they report on the next heartbeat after the policy applies.
+        </div>
+      )}
+
+      {!loading && !error && total > 0 && <ResponsiveTable table={table} cards={cards} />}
+    </div>
+  );
+}
+
+export default OneDriveFleetPage;

--- a/apps/web/src/components/onedrive/OneDriveFleetPage.tsx
+++ b/apps/web/src/components/onedrive/OneDriveFleetPage.tsx
@@ -7,11 +7,6 @@ import { formatRelativeTime } from '../../lib/utils';
 import { cn } from '@/lib/utils';
 import { fetchOneDriveFleetState, type OneDriveFleetRow } from '../../lib/api/onedrive';
 
-// The three Known Folder Move targets the agent reports on — a device is
-// "fully protected" only when all three are redirected. Any other value (or an
-// absent folder) leaves a gap.
-const KFM_FOLDER_COUNT = 3;
-
 // Row filters, one per stat tile (Devices reporting → all). "kfm-gap" is every
 // device that is NOT fully protected; "drift" is every device with drift
 // entries. Clicking the active tile toggles back to "all".
@@ -22,13 +17,27 @@ type FleetFilter = 'all' | 'signed-in' | 'kfm-gap' | 'drift';
 const STAT_BUTTON =
   'block h-full w-full rounded-lg text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background';
 
-/** Count of KFM folders currently redirected — the numerator of "x/3 redirected". */
-function kfmRedirectedCount(row: OneDriveFleetRow): number {
-  return Object.values(row.kfmFolderStates).filter((v) => v === 'redirected').length;
+/**
+ * Count of KFM folders redirected vs. the total the device reported — mirrors
+ * the server's `kfmProtected` stat (apps/api/src/routes/onedrive.ts), which
+ * derives "protected" from whatever folder keys the device actually reports
+ * rather than a fixed count of 3.
+ */
+function kfmFolderCounts(row: OneDriveFleetRow): { redirected: number; total: number } {
+  const values = Object.values(row.kfmFolderStates);
+  return { redirected: values.filter((v) => v === 'redirected').length, total: values.length };
 }
 
+/** A device is "fully protected" when it reports at least one KFM folder and every one is redirected. */
 function isFullyProtected(row: OneDriveFleetRow): boolean {
-  return kfmRedirectedCount(row) >= KFM_FOLDER_COUNT;
+  const { redirected, total } = kfmFolderCounts(row);
+  return total > 0 && redirected === total;
+}
+
+/** "x/y redirected" label for the reported folder set, or an em dash when no folders are reported. */
+function kfmLabel(row: OneDriveFleetRow): string {
+  const { redirected, total } = kfmFolderCounts(row);
+  return total > 0 ? `${redirected}/${total} redirected` : '—';
 }
 
 function matchesFilter(row: OneDriveFleetRow, filter: FleetFilter): boolean {
@@ -140,7 +149,7 @@ export function OneDriveFleetPage() {
             </td>
             <td className="px-4 py-3 text-sm"><SignedInBadge signedIn={row.signedIn} /></td>
             <td className="px-4 py-3 text-sm">{row.filesOnDemandOn ? 'On' : 'Off'}</td>
-            <td className="px-4 py-3 text-sm tabular-nums">{kfmRedirectedCount(row)}/{KFM_FOLDER_COUNT} redirected</td>
+            <td className="px-4 py-3 text-sm tabular-nums">{kfmLabel(row)}</td>
             <td className="px-4 py-3 text-sm tabular-nums">{row.mountedLibraries.length}</td>
             <td className="px-4 py-3 text-sm tabular-nums">{row.entitledLibraries.length}</td>
             <td className="px-4 py-3 text-sm">{renderDriftCount(row)}</td>
@@ -162,7 +171,7 @@ export function OneDriveFleetPage() {
       <div className="mt-3 space-y-2 border-t pt-3">
         <CardField label="Files On-Demand"><span className="text-sm">{row.filesOnDemandOn ? 'On' : 'Off'}</span></CardField>
         <CardField label="Known Folder Move">
-          <span className="text-sm tabular-nums">{kfmRedirectedCount(row)}/{KFM_FOLDER_COUNT} redirected</span>
+          <span className="text-sm tabular-nums">{kfmLabel(row)}</span>
         </CardField>
         <CardField label="Mounted"><span className="text-sm tabular-nums">{row.mountedLibraries.length}</span></CardField>
         <CardField label="Entitled"><span className="text-sm tabular-nums">{row.entitledLibraries.length}</span></CardField>

--- a/apps/web/src/lib/api/onedrive.test.ts
+++ b/apps/web/src/lib/api/onedrive.test.ts
@@ -1,0 +1,155 @@
+// apps/web/src/lib/api/onedrive.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+
+import {
+  fetchM365ConnectionStatus,
+  fetchOneDriveLibraries,
+  fetchDeviceOneDriveState,
+  fetchOneDriveFleetState,
+} from './onedrive';
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+});
+
+describe('onedrive api client', () => {
+  describe('fetchM365ConnectionStatus', () => {
+    it('hits /m365/connection with no query when orgId omitted', async () => {
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ connected: true })));
+      await fetchM365ConnectionStatus();
+      expect(fetchWithAuth).toHaveBeenCalledWith('/m365/connection');
+    });
+
+    it('appends orgId when provided', async () => {
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ connected: true })));
+      await fetchM365ConnectionStatus('org-1');
+      expect(fetchWithAuth).toHaveBeenCalledWith('/m365/connection?orgId=org-1');
+    });
+
+    it('returns true only when connected is strictly true', async () => {
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ connected: true })));
+      expect(await fetchM365ConnectionStatus()).toBe(true);
+    });
+
+    it('returns false when connected is false', async () => {
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ connected: false })));
+      expect(await fetchM365ConnectionStatus()).toBe(false);
+    });
+
+    it('returns false when connected field is missing', async () => {
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({})));
+      expect(await fetchM365ConnectionStatus()).toBe(false);
+    });
+
+    it('returns false when connected is truthy but not boolean true', async () => {
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ connected: 'true' })));
+      expect(await fetchM365ConnectionStatus()).toBe(false);
+    });
+  });
+
+  describe('fetchOneDriveLibraries', () => {
+    it('hits /onedrive/libraries with no query when orgId omitted', async () => {
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ libraries: [], skippedSites: [] })));
+      await fetchOneDriveLibraries();
+      expect(fetchWithAuth).toHaveBeenCalledWith('/onedrive/libraries');
+    });
+
+    it('appends orgId when provided', async () => {
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ libraries: [], skippedSites: [] })));
+      await fetchOneDriveLibraries('org-1');
+      expect(fetchWithAuth).toHaveBeenCalledWith('/onedrive/libraries?orgId=org-1');
+    });
+
+    it('returns libraries and skippedSites on success', async () => {
+      const libraries = [
+        {
+          siteId: 's1', siteName: 'Site 1', siteUrl: 'https://x', driveId: 'd1', listId: 'l1',
+          libraryName: 'Docs', tenantId: 't1', webId: 'w1', spSiteId: 'sp1', autoMountValue: 'auto',
+        },
+      ];
+      const skippedSites = [{ siteId: 's2', code: 'accessDenied' }];
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ libraries, skippedSites })));
+      const result = await fetchOneDriveLibraries('org-1');
+      expect(result).toEqual({ libraries, skippedSites });
+    });
+
+    it('throws with the server error message on a 409 no-connection response', async () => {
+      fetchWithAuth.mockResolvedValue(
+        new Response(JSON.stringify({ error: 'This organization has no Microsoft 365 connection. Connect M365 first.' }), {
+          status: 409,
+        }),
+      );
+      await expect(fetchOneDriveLibraries('org-1')).rejects.toThrow(
+        'This organization has no Microsoft 365 connection. Connect M365 first.',
+      );
+    });
+  });
+
+  describe('fetchDeviceOneDriveState', () => {
+    it('hits /onedrive/devices/:id/state', async () => {
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ state: null })));
+      await fetchDeviceOneDriveState('dev-1');
+      expect(fetchWithAuth).toHaveBeenCalledWith('/onedrive/devices/dev-1/state');
+    });
+
+    it('passes through null state', async () => {
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ state: null })));
+      expect(await fetchDeviceOneDriveState('dev-1')).toBeNull();
+    });
+
+    it('returns the state row when present', async () => {
+      const state = {
+        deviceId: 'dev-1', signedIn: true, oneDriveVersion: '1.0', filesOnDemandOn: true,
+        kfmFolderStates: {}, mountedLibraries: [], entitledLibraries: [], driftEntries: [],
+        lastReportedAt: '2026-07-01T00:00:00Z',
+      };
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ state })));
+      expect(await fetchDeviceOneDriveState('dev-1')).toEqual(state);
+    });
+
+    it('throws on a non-ok response', async () => {
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ error: 'Device not found' }), { status: 404 }));
+      await expect(fetchDeviceOneDriveState('dev-1')).rejects.toThrow('Device not found');
+    });
+  });
+
+  describe('fetchOneDriveFleetState', () => {
+    it('hits /onedrive/state with no query when orgId omitted', async () => {
+      fetchWithAuth.mockResolvedValue(
+        new Response(JSON.stringify({ devices: [], stats: { total: 0, signedIn: 0, kfmProtected: 0, withDrift: 0 } })),
+      );
+      await fetchOneDriveFleetState();
+      expect(fetchWithAuth).toHaveBeenCalledWith('/onedrive/state');
+    });
+
+    it('appends orgId when provided', async () => {
+      fetchWithAuth.mockResolvedValue(
+        new Response(JSON.stringify({ devices: [], stats: { total: 0, signedIn: 0, kfmProtected: 0, withDrift: 0 } })),
+      );
+      await fetchOneDriveFleetState('org-1');
+      expect(fetchWithAuth).toHaveBeenCalledWith('/onedrive/state?orgId=org-1');
+    });
+
+    it('returns devices and stats on success', async () => {
+      const devices = [
+        {
+          deviceId: 'dev-1', hostname: 'host-1', signedIn: true, oneDriveVersion: '1.0', filesOnDemandOn: true,
+          kfmFolderStates: {}, mountedLibraries: [], entitledLibraries: [], driftEntries: [],
+          lastReportedAt: '2026-07-01T00:00:00Z',
+        },
+      ];
+      const stats = { total: 1, signedIn: 1, kfmProtected: 0, withDrift: 0 };
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ devices, stats })));
+      const result = await fetchOneDriveFleetState('org-1');
+      expect(result).toEqual({ devices, stats });
+    });
+
+    it('throws on a non-ok response', async () => {
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ error: 'orgId is required for this scope' }), { status: 400 }));
+      await expect(fetchOneDriveFleetState()).rejects.toThrow('orgId is required for this scope');
+    });
+  });
+});

--- a/apps/web/src/lib/api/onedrive.test.ts
+++ b/apps/web/src/lib/api/onedrive.test.ts
@@ -48,6 +48,18 @@ describe('onedrive api client', () => {
       fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ connected: 'true' })));
       expect(await fetchM365ConnectionStatus()).toBe(false);
     });
+
+    it('resolves false (does not throw) on a 404 when the M365 flag is disabled server-side', async () => {
+      fetchWithAuth.mockResolvedValue(
+        new Response(JSON.stringify({ error: 'Microsoft 365 integration is not enabled' }), { status: 404 }),
+      );
+      await expect(fetchM365ConnectionStatus()).resolves.toBe(false);
+    });
+
+    it('resolves false (does not throw) on any other non-ok response', async () => {
+      fetchWithAuth.mockResolvedValue(new Response(JSON.stringify({ error: 'boom' }), { status: 500 }));
+      await expect(fetchM365ConnectionStatus()).resolves.toBe(false);
+    });
   });
 
   describe('fetchOneDriveLibraries', () => {

--- a/apps/web/src/lib/api/onedrive.ts
+++ b/apps/web/src/lib/api/onedrive.ts
@@ -43,7 +43,12 @@ async function extractError(res: Response): Promise<string> {
 
 export async function fetchM365ConnectionStatus(orgId?: string): Promise<boolean> {
   const res = await fetchWithAuth(`/m365/connection${orgQuery(orgId)}`);
-  if (!res.ok) throw new Error(await extractError(res));
+  // A non-ok response (including the 404 the server returns for the whole
+  // m365Routes group when the M365 integration feature-flag is off) simply
+  // means "cannot browse via Graph right now" — treat it as disconnected
+  // rather than throwing, so the UI falls back to manual library-ID paste
+  // instead of showing an error state with no way forward.
+  if (!res.ok) return false;
   const data = (await res.json()) as { connected?: unknown };
   return data.connected === true;
 }

--- a/apps/web/src/lib/api/onedrive.ts
+++ b/apps/web/src/lib/api/onedrive.ts
@@ -1,0 +1,80 @@
+// apps/web/src/lib/api/onedrive.ts
+import { fetchWithAuth } from '../../stores/auth';
+
+export type OneDriveLibrary = {
+  siteId: string;
+  siteName: string;
+  siteUrl: string;
+  driveId: string;
+  listId: string;
+  libraryName: string;
+  tenantId: string;
+  webId: string;
+  spSiteId: string;
+  autoMountValue: string;
+};
+
+export type OneDriveDeviceState = {
+  deviceId: string;
+  signedIn: boolean;
+  oneDriveVersion: string | null;
+  filesOnDemandOn: boolean;
+  kfmFolderStates: Record<string, string>;
+  mountedLibraries: string[];
+  entitledLibraries: string[];
+  driftEntries: Array<{ libraryId: string; displayName: string; reason: string }>;
+  lastReportedAt: string;
+};
+
+export type OneDriveFleetRow = OneDriveDeviceState & { hostname: string };
+
+export type OneDriveFleetStats = { total: number; signedIn: number; kfmProtected: number; withDrift: number };
+
+function orgQuery(orgId?: string): string {
+  return orgId ? `?orgId=${encodeURIComponent(orgId)}` : '';
+}
+
+/** Extract a server-provided error message, falling back to statusText. */
+async function extractError(res: Response): Promise<string> {
+  const json = await res.json().catch(() => ({}));
+  const errorText = (json as Record<string, unknown>).error;
+  return typeof errorText === 'string' && errorText ? errorText : res.statusText;
+}
+
+export async function fetchM365ConnectionStatus(orgId?: string): Promise<boolean> {
+  const res = await fetchWithAuth(`/m365/connection${orgQuery(orgId)}`);
+  if (!res.ok) throw new Error(await extractError(res));
+  const data = (await res.json()) as { connected?: unknown };
+  return data.connected === true;
+}
+
+export async function fetchOneDriveLibraries(
+  orgId?: string,
+): Promise<{ libraries: OneDriveLibrary[]; skippedSites: Array<{ siteId: string; code: string }> }> {
+  const res = await fetchWithAuth(`/onedrive/libraries${orgQuery(orgId)}`);
+  if (!res.ok) throw new Error(await extractError(res));
+  const data = (await res.json()) as {
+    libraries?: OneDriveLibrary[];
+    skippedSites?: Array<{ siteId: string; code: string }>;
+  };
+  return { libraries: data.libraries ?? [], skippedSites: data.skippedSites ?? [] };
+}
+
+export async function fetchDeviceOneDriveState(deviceId: string): Promise<OneDriveDeviceState | null> {
+  const res = await fetchWithAuth(`/onedrive/devices/${encodeURIComponent(deviceId)}/state`);
+  if (!res.ok) throw new Error(await extractError(res));
+  const data = (await res.json()) as { state?: OneDriveDeviceState | null };
+  return data.state ?? null;
+}
+
+export async function fetchOneDriveFleetState(
+  orgId?: string,
+): Promise<{ devices: OneDriveFleetRow[]; stats: OneDriveFleetStats }> {
+  const res = await fetchWithAuth(`/onedrive/state${orgQuery(orgId)}`);
+  if (!res.ok) throw new Error(await extractError(res));
+  const data = (await res.json()) as { devices?: OneDriveFleetRow[]; stats?: OneDriveFleetStats };
+  return {
+    devices: data.devices ?? [],
+    stats: data.stats ?? { total: 0, signedIn: 0, kfmProtected: 0, withDrift: 0 },
+  };
+}

--- a/apps/web/src/pages/onedrive.astro
+++ b/apps/web/src/pages/onedrive.astro
@@ -1,0 +1,16 @@
+---
+import DashboardLayout from '../layouts/DashboardLayout.astro';
+import OneDriveFleetPage from '../components/onedrive/OneDriveFleetPage';
+---
+
+<DashboardLayout title="OneDrive">
+  <div class="space-y-6">
+    <div>
+      <h1 class="text-2xl font-semibold">OneDrive</h1>
+      <p class="max-w-prose text-sm text-muted-foreground">
+        Fleet OneDrive posture — sign-in, Known Folder Move protection, and library mount drift.
+      </p>
+    </div>
+    <OneDriveFleetPage client:load />
+  </div>
+</DashboardLayout>

--- a/docs/superpowers/plans/2026-07-09-onedrive-helper-phase3-web-ui.md
+++ b/docs/superpowers/plans/2026-07-09-onedrive-helper-phase3-web-ui.md
@@ -1,0 +1,269 @@
+# OneDrive Helper — Phase 3 (Web UI) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the OneDrive Helper its UI: a config-policy **feature tab** (base toggles + library list + Graph picker), a **per-device OneDrive status panel**, and an **org-level rollup page** — plus the two read-only API endpoints the panels need.
+
+**Architecture:** The policy editor becomes a normal feature tab (DECISION 2026-07-09: remove `onedrive_helper` from `EDITOR_EXCLUDED_FEATURE_TYPES`; the compile-enforced registries force every registration in one change). The tab uses `useFeatureLink` + `FeatureTabShell` (the `EventLogTab` pattern). Device panel follows `DeviceVulnerabilitiesTab` (fetch/loading/error/testids); rollup follows `VulnerabilityFleetPage` (Astro island + `SecurityStatCard` tiles + `ResponsiveTable`). New reads mount on the existing `onedriveRoutes` group.
+
+**Tech Stack:** Astro + React islands, Tailwind, Vitest + jsdom (+ jest-dom), Hono + Drizzle (two read endpoints), no new tables/migrations.
+
+## Global Constraints
+
+- **Node:** prefix node/pnpm/vitest commands with `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH`.
+- **Branch base:** `feat/onedrive-helper-phase3` (stacked on Phase 2 — the write path, picker route `GET /onedrive/libraries` returning `{libraries:[{siteId,siteName,siteUrl,driveId,listId,libraryName,tenantId,webId,spSiteId,autoMountValue}],skippedSites}`, and `onedrive_device_state` ingest all exist).
+- **Org-scoped-only stands:** `onedrive_helper` stays in `ORG_SCOPED_ONLY_FEATURE_TYPES`. The tab needs NO ownerScope selector; partner-wide gating comes free from `ConfigPolicyDetailPage`'s existing `isGatedFeature` logic.
+- **Wire shapes (fixed, do not invent):** feature-link inlineSettings = the `onedriveHelperInlineSettingsSchema` shape `{silentAccountConfig,filesOnDemand,kfmSilentOptIn,kfmFolders,kfmBlockOptOut,tenantAssociationId,restartOnChange,libraries:[{libraryId,displayName,siteUrl?,siteId?,webId?,listId?,targetingMode,groupId?,groupName?,hiveScope,enabled}]}`. Device state row = `{deviceId,orgId,signedIn,oneDriveVersion,filesOnDemandOn,kfmFolderStates,mountedLibraries,entitledLibraries,driftEntries,lastReportedAt,updatedAt}`.
+- **M365 connection check** for the picker empty state: `GET /m365/connection?orgId=` → `{connected:boolean,...}` (matches the table the picker 409s on). NOT the c2c connections list.
+- **Mutation conventions:** feature-link saves go through `useFeatureLink` (self-managed error state rendered by `FeatureTabShell` — no toast). Any other mutation uses `runAction`. New handlers must not trip `no-silent-mutations.test.ts`.
+- **URL state:** hash-based tabs only (`window.location.hash`), never query params.
+- **Tests:** jsdom; scope `ResponsiveTable` queries to `data-testid="responsive-table-desktop"` (both surfaces render simultaneously); mock `useFeatureLink` for tab tests (EventLogTab.test.tsx idiom) and api-client modules for panel tests (DeviceVulnerabilitiesTab.test.tsx idiom); `data-testid`-based queries (E2E convention).
+- **No migrations, no schema changes, no partner-wide work, no unmount actions** (Sub-project B).
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/web/src/lib/api/onedrive.ts` — typed client: `fetchOneDriveLibraries`, `fetchM365ConnectionStatus`, `fetchDeviceOneDriveState`, `fetchOneDriveFleetState`
+- `apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.tsx` — the feature tab
+- `apps/web/src/components/configurationPolicies/featureTabs/OneDriveLibraryPicker.tsx` — picker modal (Graph browse + manual paste)
+- `apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.test.tsx`
+- `apps/web/src/components/devices/DeviceOneDriveTab.tsx` — per-device status panel
+- `apps/web/src/components/devices/DeviceOneDriveTab.test.tsx`
+- `apps/web/src/components/onedrive/OneDriveFleetPage.tsx` — org rollup island
+- `apps/web/src/components/onedrive/OneDriveFleetPage.test.tsx`
+- `apps/web/src/pages/onedrive.astro` — rollup page
+- `apps/api/src/routes/onedrive.state.test.ts` — new-endpoint route tests
+
+**Modify:**
+- `apps/api/src/routes/onedrive.ts` — add `GET /devices/:deviceId/state` and `GET /state`
+- `apps/web/src/components/configurationPolicies/featureTabs/types.ts` — remove exclusion; add `FEATURE_META.onedrive_helper`
+- `apps/web/src/components/configurationPolicies/featureTabs/featureTypeParity.test.ts` — exclusion list now empty
+- `apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx` — icon entry + `renderFeatureTab` case
+- `apps/web/src/components/devices/DeviceDetails.tsx` — new tab registration
+- Sidebar/nav registration for `/onedrive` (find where `/vulnerabilities` is registered in the dashboard nav and mirror it)
+
+---
+
+## Task 1: Read endpoints — device state + org rollup
+
+**Files:**
+- Modify: `apps/api/src/routes/onedrive.ts`
+- Test: `apps/api/src/routes/onedrive.state.test.ts`
+
+**Interfaces:**
+- Produces: `GET /onedrive/devices/:deviceId/state` → 200 `{state: <row|null>}` (404 if device not visible); `GET /onedrive/state?orgId=` → 200 `{devices:[{deviceId,hostname,signedIn,filesOnDemandOn,oneDriveVersion,kfmFolderStates,mountedLibraries,entitledLibraries,driftEntries,lastReportedAt}],stats:{total,signedIn,kfmProtected,withDrift}}`. Same auth chain as `/libraries` (`requireScope` + `requirePermission(DEVICES_READ)`, `resolveScopedOrgId`).
+
+- [ ] **Step 1: Write the failing route tests**
+
+Copy the harness from the existing `apps/api/src/routes/onedrive.test.ts` (same mocking approach for auth middleware; mock the db module the way sibling route tests in that directory do — read one first). Required cases:
+
+```typescript
+// apps/api/src/routes/onedrive.state.test.ts — shape only; adopt the sibling harness verbatim
+describe('GET /onedrive/devices/:deviceId/state', () => {
+  it('returns the state row for an accessible device', async () => { /* mock device lookup (org A) + state row; expect 200 {state:{signedIn:true,...}} */ });
+  it('returns state:null when the agent has not reported yet', async () => { /* device exists, no row → 200 {state:null} */ });
+  it('404s for a device in an inaccessible org', async () => { /* device.orgId = org B, canAccessOrg false → 404, no state query */ });
+});
+describe('GET /onedrive/state', () => {
+  it('returns per-device rows + stats for the org', async () => {
+    /* two devices: one signedIn w/ drift, one not signed in →
+       stats {total:2, signedIn:1, withDrift:1}; kfmProtected counts devices whose
+       kfmFolderStates values are ALL 'redirected' (non-empty) */
+  });
+  it('400s when no org resolvable', async () => { /* cross-tenant orgId → 400 */ });
+});
+```
+
+- [ ] **Step 2: Run to confirm they fail** — `PATH=... pnpm --filter @breeze/api exec vitest run src/routes/onedrive.state.test.ts` → FAIL (routes don't exist).
+
+- [ ] **Step 3: Implement** (append to `apps/api/src/routes/onedrive.ts`; reuse its existing imports/auth chain):
+
+```typescript
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { devices } from '../db/schema/devices';
+import { onedriveDeviceState } from '../db/schema/onedriveHelper';
+
+// Per-device OneDrive state for the device detail panel.
+onedriveRoutes.get(
+  '/devices/:deviceId/state',
+  requireScope('organization', 'partner', 'system'),
+  requireDevicesRead,
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('deviceId');
+    const [device] = await db
+      .select({ id: devices.id, orgId: devices.orgId })
+      .from(devices).where(eq(devices.id, deviceId)).limit(1);
+    if (!device || !resolveScopedOrgId(auth, device.orgId)) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+    const [state] = await db
+      .select().from(onedriveDeviceState)
+      .where(eq(onedriveDeviceState.deviceId, deviceId)).limit(1);
+    return c.json({ state: state ?? null });
+  }
+);
+
+// Org rollup: entitled-vs-mounted / drift / KFM across the fleet.
+onedriveRoutes.get(
+  '/state',
+  requireScope('organization', 'partner', 'system'),
+  requireDevicesRead,
+  async (c) => {
+    const auth = c.get('auth');
+    const orgId = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if (!orgId) return c.json({ error: 'orgId is required for this scope' }, 400);
+
+    const rows = await db
+      .select({
+        deviceId: onedriveDeviceState.deviceId,
+        hostname: devices.hostname,
+        signedIn: onedriveDeviceState.signedIn,
+        filesOnDemandOn: onedriveDeviceState.filesOnDemandOn,
+        oneDriveVersion: onedriveDeviceState.oneDriveVersion,
+        kfmFolderStates: onedriveDeviceState.kfmFolderStates,
+        mountedLibraries: onedriveDeviceState.mountedLibraries,
+        entitledLibraries: onedriveDeviceState.entitledLibraries,
+        driftEntries: onedriveDeviceState.driftEntries,
+        lastReportedAt: onedriveDeviceState.lastReportedAt,
+      })
+      .from(onedriveDeviceState)
+      .innerJoin(devices, eq(onedriveDeviceState.deviceId, devices.id))
+      .where(eq(onedriveDeviceState.orgId, orgId));
+
+    const kfmProtected = (kfm: unknown) => {
+      const entries = Object.values((kfm ?? {}) as Record<string, string>);
+      return entries.length > 0 && entries.every((v) => v === 'redirected');
+    };
+    const stats = {
+      total: rows.length,
+      signedIn: rows.filter((r) => r.signedIn).length,
+      kfmProtected: rows.filter((r) => kfmProtected(r.kfmFolderStates)).length,
+      withDrift: rows.filter((r) => Array.isArray(r.driftEntries) && (r.driftEntries as unknown[]).length > 0).length,
+    };
+    return c.json({ devices: rows, stats });
+  }
+);
+```
+
+> `resolveScopedOrgId(auth, device.orgId)` doubles as the access check on the device route (returns null for an org the caller can't access). Adapt exact db-mocking to whatever the sibling tests do — the route contract above is binding.
+
+- [ ] **Step 4: Run tests green + typecheck** — the Step-2 command (PASS) + `pnpm --filter @breeze/api exec tsc --noEmit`.
+- [ ] **Step 5: Commit** — `feat(onedrive-helper): device-state + fleet-state read endpoints`
+
+---
+
+## Task 2: Web API client — `apps/web/src/lib/api/onedrive.ts`
+
+**Interfaces:**
+- Produces (consumed by Tasks 3–6):
+
+```typescript
+export type OneDriveLibrary = { siteId: string; siteName: string; siteUrl: string; driveId: string; listId: string; libraryName: string; tenantId: string; webId: string; spSiteId: string; autoMountValue: string };
+export type OneDriveDeviceState = { deviceId: string; signedIn: boolean; oneDriveVersion: string | null; filesOnDemandOn: boolean; kfmFolderStates: Record<string, string>; mountedLibraries: string[]; entitledLibraries: string[]; driftEntries: Array<{ libraryId: string; displayName: string; reason: string }>; lastReportedAt: string };
+export type OneDriveFleetRow = OneDriveDeviceState & { hostname: string };
+export type OneDriveFleetStats = { total: number; signedIn: number; kfmProtected: number; withDrift: number };
+
+export async function fetchM365ConnectionStatus(orgId?: string): Promise<boolean>;            // GET /m365/connection[?orgId] → data.connected === true
+export async function fetchOneDriveLibraries(orgId?: string): Promise<{ libraries: OneDriveLibrary[]; skippedSites: Array<{siteId:string;code:string}> }>; // GET /onedrive/libraries — throw with the response error message on !ok (409 → "connect M365" message)
+export async function fetchDeviceOneDriveState(deviceId: string): Promise<OneDriveDeviceState | null>;  // GET /onedrive/devices/:id/state → data.state
+export async function fetchOneDriveFleetState(orgId?: string): Promise<{ devices: OneDriveFleetRow[]; stats: OneDriveFleetStats }>; // GET /onedrive/state
+```
+
+All read-only via `fetchWithAuth` (from `../../stores/auth`) + `friendlyFetchError`-style error surfacing — copy the exact fetch/error idiom from `apps/web/src/lib/api/vulnerabilities.ts` reads. No `runAction` (no mutations here). Include a small vitest (`onedrive.test.ts` alongside) asserting URL construction (incl. `orgId` query passthrough) and the `state:null` passthrough, using the `fetchWithAuth` mock idiom.
+
+Steps: failing test → implement → green → commit `feat(onedrive-helper): web api client for onedrive endpoints`.
+
+---
+
+## Task 3: Policy-editor feature tab — registration + `OneDriveHelperTab`
+
+The compile-enforced un-exclusion. **All registries change in one task** (the `Exclude<>` type forces it).
+
+**Files:**
+- Modify: `featureTabs/types.ts` — `EDITOR_EXCLUDED_FEATURE_TYPES = [] as const` (keep the const + comment explaining it's now empty and why it exists); add `FEATURE_META.onedrive_helper = { label: 'OneDrive Helper', fetchUrl: null, description: 'Silently sign in OneDrive, enforce Files On-Demand and Known Folder Move, and auto-mount SharePoint libraries per user.' }`
+- Modify: `featureTypeParity.test.ts` — update the exclusion assertion (now empty)
+- Modify: `ConfigPolicyDetailPage.tsx` — `featureTabIcons.onedrive_helper` (use the `Cloud` icon, matching `DeviceEffectiveConfigTab`), `renderFeatureTab` case returning `<OneDriveHelperTab {...featureTabProps} />`
+- Create: `OneDriveHelperTab.tsx` + `OneDriveHelperTab.test.tsx`
+
+**Interfaces:**
+- Consumes: `FeatureTabProps`, `useFeatureLink`, `FeatureTabShell` (exact contracts quoted in the research brief), `onedriveHelperInlineSettingsSchema` shape.
+- Produces: a tab that (a) renders base toggles — Silent sign-in, Files On-Demand, KFM opt-in (+ folder checkboxes Desktop/Documents/Pictures + Block opt-out + tenant-association text input, all only when KFM on), Restart on change; (b) renders the libraries list (display name, site URL, targeting mode select `everyone|graph_group|local_ad_group`, group id/name inputs shown per mode, enabled toggle, remove button, `data-testid="onedrive-lib-row-<idx>"`); (c) "Add library" opens `OneDriveLibraryPicker` (Task 4 — in THIS task render a manual-entry inline form: paste `libraryId` composite + display name; the picker replaces/augments it in Task 4); (d) saves via `useFeatureLink.save(existingLink?.id ?? null, { featureType: 'onedrive_helper', featurePolicyId: null, inlineSettings: toPayload(state) })` with an EventLogTab-style `toPayload` allowlist; (e) inherited/override/revert semantics identical to EventLogTab.
+
+**Required tests** (mock `useFeatureLink` per the EventLogTab.test.tsx idiom):
+1. renders defaults when no link exists; 2. seeds state from `existingLink.inlineSettings`; 3. Save posts the full allowlisted payload (assert `saveMock.mock.calls[0]` deep shape incl. libraries array); 4. adding a manual library then saving includes it with `targetingMode` default `everyone`; 5. `graph_group` mode without group id/name disables Save (client-side mirror of the zod superRefine — show inline hint); 6. inherited (parentLink only) shows Override affordance and no direct Save.
+
+Steps: failing tests → registration edits (typecheck will drive completeness — run `pnpm --filter @breeze/web exec tsc --noEmit` or the repo's web typecheck and fix every forced site) → component → green (whole featureTabs test dir + parity test) → commit `feat(onedrive-helper): config-policy editor feature tab`.
+
+---
+
+## Task 4: Graph library picker — `OneDriveLibraryPicker.tsx`
+
+**Interfaces:**
+- Consumes: `fetchOneDriveLibraries`, `fetchM365ConnectionStatus` (Task 2). Props: `{ orgId?: string; onAdd: (lib: { libraryId: string; displayName: string; siteUrl: string; siteId: string; webId: string; listId: string }) => void; onClose: () => void }` — `libraryId` = `autoMountValue`; `siteId` = `spSiteId` (bare GUID, the DB column meaning).
+- Produces: a modal/panel with three states: (1) **no M365 connection** → explainer + link to the M365 connection settings surface + "paste a library ID instead" manual fallback (composite text input + display name — validate it starts with `tenantId=`); (2) **connected** → grouped-by-site list of libraries with search filter, each row an "Add" button (`data-testid="onedrive-picker-add-<driveId>"`), rows with empty `autoMountValue` disabled with a hint; `skippedSites.length > 0` renders a warning line "N sites could not be read"; (3) loading/error states.
+- The tab (Task 3) swaps its inline manual form for this picker; manual paste stays available inside the picker.
+
+**Required tests:** connection-false → manual fallback visible, no libraries fetch; connected → libraries listed grouped by `siteName`, Add invokes `onAdd` with `libraryId === autoMountValue` and `siteId === spSiteId`; disabled row when `autoMountValue` empty; skippedSites warning renders.
+
+Steps: failing tests → implement → green → integrate into `OneDriveHelperTab` (replace the Task-3 inline form; keep its tests passing by updating them to open the picker) → whole featureTabs dir green → commit `feat(onedrive-helper): Graph library picker with manual-paste fallback`.
+
+---
+
+## Task 5: Per-device OneDrive panel — `DeviceOneDriveTab`
+
+**Files:**
+- Modify: `DeviceDetails.tsx` — `Tab` union + `VALID_TABS` + `tabs[]` entry `{ id: 'onedrive', label: 'OneDrive', icon: Cloud }` + conditional render `{activeTab === 'onedrive' && <DeviceOneDriveTab deviceId={device.id} />}`
+- Create: `DeviceOneDriveTab.tsx` + test
+
+**Interfaces:**
+- Consumes: `fetchDeviceOneDriveState` (Task 2).
+- Produces: panel with (a) status header chips — Signed in / Files On-Demand / OneDrive version / last reported (relative time, existing util if present); (b) KFM grid: the three folders with `redirected`/`not_redirected`/`unknown` states as colored badges; (c) Libraries section: entitled list (parse `displayName` is NOT in entitled — it's raw composites; show a shortened composite with the `webUrl=` segment decoded as the human label) vs mounted paths, and a **Drift** list from `driftEntries` (amber warning rows, `data-testid="onedrive-drift-<idx>"`); (d) `state === null` → empty state "No OneDrive state reported yet — the agent reports on its next heartbeat after a policy applies" (`data-testid="device-onedrive-empty"`); (e) loading + error states (`data-testid="device-onedrive-error"`), fetch pattern copied from `DeviceVulnerabilitiesTab` (`useCallback` load + `useEffect`).
+
+**Required tests** (mock the api module): loading→data render (chips + KFM badges + drift rows); null state → empty message; error → error testid; a device with drift shows the amber row with reason text.
+
+Steps: failing tests → implement + register → green (+ any existing DeviceDetails test still passing) → commit `feat(onedrive-helper): per-device OneDrive status panel`.
+
+---
+
+## Task 6: Org rollup — `onedrive.astro` + `OneDriveFleetPage`
+
+**Files:**
+- Create: `apps/web/src/pages/onedrive.astro` (copy `vulnerabilities.astro` shape: `DashboardLayout` + `<OneDriveFleetPage client:load />`, title "OneDrive", intro line "Fleet OneDrive posture — sign-in, Known Folder Move protection, and library mount drift.")
+- Create: `OneDriveFleetPage.tsx` + test
+- Modify: the dashboard sidebar/nav — find where the `/vulnerabilities` nav item is registered (grep the layout/nav component) and add an equivalent `/onedrive` entry with the `Cloud` icon, adjacent to it.
+
+**Interfaces:**
+- Consumes: `fetchOneDriveFleetState` (Task 2).
+- Produces: (a) four `SecurityStatCard` tiles — Devices reporting (`total`), Signed in (`signedIn`, variant success), KFM protected (`kfmProtected`, warning when `< signedIn`), Drift (`withDrift`, danger when `> 0`) — clickable tiles filter the table (all/signed-in/kfm-gap/drift), mirroring `VulnerabilityFleetPage`'s interactive-tile pattern; (b) `ResponsiveTable` of devices: hostname (link to `/devices#...`? use however device links are built elsewhere — copy an existing hostname-link cell), signed-in badge, FOD, KFM summary (`3/3 redirected` style), mounted/entitled counts, drift count (amber when >0), last reported; mobile `DataCard` variant with `CardField`s; (c) org selector: none — rely on the caller's scope (partner users see their scoped org resolution; pass no orgId and let `resolveScopedOrgId` fall back, matching how other fleet pages handle it — check `VulnerabilityFleetPage` and copy exactly); (d) loading/error/empty (`data-testid="onedrive-fleet-empty"` when `total === 0` with a pointer to enabling the policy feature).
+
+**Required tests:** stats tiles render from mocked fleet response; tile click filters rows (scope queries to `responsive-table-desktop`); drift row shows amber count; empty state.
+
+Steps: failing tests → implement island + astro page + nav entry → green → commit `feat(onedrive-helper): org OneDrive rollup page`.
+
+---
+
+## Task 7: Live verification on the wt-stack (browser)
+
+No new code. Rebuild and drive the real UI against the still-enrolled VM device:
+
+- [ ] `PATH=... pnpm wt-stack up --rebuild` (web + api containers pick up the branch)
+- [ ] Playwright MCP / browser at `baseUrl` from `.breeze-stack.json` (admin creds there): log in →
+  - Config policy "OneDrive E2E" → OneDrive Helper tab shows the Phase-2-created settings (base toggles + 1 library); toggle something, Save, confirm PATCH succeeds and normalized rows update (psql check)
+  - Library picker opens; with no M365 connection on the stack org it must show the connect-first + manual-paste state (the 409 path)
+  - Device `WIN-DHQNR1F8LO2` → OneDrive tab shows live state (signed in, FOD, 3× KFM redirected, mounted + entitled, no drift)
+  - `/onedrive` page → tiles `total=1, signedIn=1, kfmProtected=1, withDrift=0`; table row links to the device
+- [ ] Log results in `docs/testing/FEATURE_TEST_LOG.md` (local-only, do not commit)
+
+---
+
+## Self-Review (completed during authoring)
+
+**Spec §5 coverage:** policy editor (base toggles, library list, picker-or-paste, per-library targeting) → Tasks 3–4. Per-device panel (signed-in/FOD/KFM/mounted-vs-entitled/drift) → Task 5. Org rollup (entitled-vs-mounted, drift, "KFM not protected") → Task 6 (KFM-gap tile). Missing read APIs discovered during planning → Task 1. Picker's M365-absent degradation (spike doc's assisted-paste fallback) → Task 4 state 1.
+
+**Placeholder scan:** Tasks 3–6 specify contracts + named template files with exact idioms (quoted at length in the research handed to each implementer) rather than full JSX — deliberate for UI components where the repo's live templates (EventLogTab, DeviceVulnerabilitiesTab, VulnerabilityFleetPage) are stronger sources of truth than transcribed code; every payload shape, endpoint, state, testid, and test case is pinned. Task 1 carries full route code.
+
+**Type consistency:** `OneDriveLibrary.autoMountValue → onAdd.libraryId`, `spSiteId → siteId` column mapping stated in both Task 2 and Task 4; inlineSettings payload shape identical in Global Constraints and Task 3; fleet stats keys identical in Task 1 response and Task 6 tiles.


### PR DESCRIPTION
## Summary

**Stacked on #2311 (Phase 2)** — merge that first, then retarget/merge this. Plan: `docs/superpowers/plans/2026-07-09-onedrive-helper-phase3-web-ui.md`.

Gives the OneDrive Helper its UI:

- **Policy editor feature tab** — reverses the Phase-1 `EDITOR_EXCLUDED_FEATURE_TYPES` exclusion (compile-enforced registration: FEATURE_META, icons, render switch, parity test). Base toggles (silent sign-in, FOD, KFM w/ folder set + block-opt-out + tenant ID, restart-on-change) + library list with per-library targeting (everyone / Graph group / local AD group), client-side mirrors of the server zod constraints (invalid rows disable Save). Org-scoped-only gating engages generically on partner-wide policies.
- **Graph library picker** — browses SharePoint libraries via `GET /onedrive/libraries` (grouped by site, search, prebuilt AutoMount composite per row); no-M365 (or flag-disabled) deployments degrade to a manual-paste fallback with a `/integrations#m365` deep-link. Policy `orgId` threaded through for partner-scoped techs.
- **Per-device OneDrive tab** — signed-in/FOD/version/last-reported chips, KFM per-folder badges, entitled (decoded labels) vs mounted paths, amber drift rows.
- **Fleet rollup `/onedrive`** — nav entry beside Vulnerabilities; interactive stat tiles (reporting / signed-in / KFM-protected / drift) filtering a ResponsiveTable; KFM math mirrors the server exactly; partner scope aggregates across accessible orgs via `auth.orgCondition` (vuln-stats pattern).
- **Two read endpoints** — `GET /onedrive/devices/:id/state` (404-before-query on inaccessible devices) and `GET /onedrive/state` (org filter + partner aggregation), on the existing `onedriveRoutes` auth chain.

No migrations; no mutations outside `useFeatureLink` (no-silent-mutations untouched).

## Validation

- Per-task reviews + final whole-branch review (Fable) with 3 pre-merge fixes: partner-scope fleet aggregation, picker orgId threading, flag-disabled M365 probe → manual-paste fallback (this one caught **live**)
- **Live browser verification** on a real stack + enrolled Windows agent: tab save round-trip persisted to normalized tables; rollup tiles/table correct against real heartbeat data; device panel correct; fixed picker disconnected state re-verified after rebuild
- Suites: API + web vitest green, both `tsc --noEmit` clean

## Follow-ups (non-blocking, tracked in session ledger)

kfmProtected tile caption ("of signed in" vs unconditioned stat) · value-based React keys in device tab · device-state endpoint over-wide select · `#onedrive_helper` hash doesn't preselect the tab (pre-existing overflow-tab behavior) · Override button `saving` gate (shell-wide) · picker unmount guards · Phase 4 = agent UPN reporting → server-side graph_group tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)