### PR TITLE
fix(mobile): App Store readiness — deletion URL, Lock action, iOS build number

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -14,6 +14,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.breeze.rmm",
+      "buildNumber": "1",
       "infoPlist": {
         "NSFaceIDUsageDescription": "Use Face ID to unlock the app",
         "NSCameraUsageDescription": "Camera access for QR code scanning",

--- a/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
@@ -37,6 +37,8 @@ import {
   isBiometricEnabled,
   setBiometricEnabled,
 } from '../../../services/biometrics';
+import { FALLBACK_API_BASE_URL } from '../../../services/api';
+import { getAccountDeletionUrl } from '../../../services/serverConfig';
 import { ease, duration } from '../../../lib/motion';
 import { track } from '../../../lib/analytics';
 import { relativeTime } from '../../../lib/relativeTime';
@@ -55,7 +57,6 @@ const NOTIF_KEY = 'notificationsEnabled';
 const NOTIF_CRITICAL_ONLY_KEY = 'notificationsCriticalOnly';
 const TERMS_URL = 'https://breezermm.com/legal/terms-of-service/';
 const PRIVACY_URL = 'https://breezermm.com/legal/privacy-policy/';
-const DELETE_ACCOUNT_URL = 'https://breezermm.com/account/delete';
 
 async function safeOpen(url: string) {
   try {
@@ -224,11 +225,15 @@ export function SettingsSheet({ visible, onCancel }: Props) {
         {
           text: 'Continue',
           style: 'destructive',
-          onPress: () => {
+          onPress: async () => {
             // We track the user-intent click, not the actual server-side
             // deletion request (that happens on the web flow).
             track('account_deletion_requested');
-            safeOpen(DELETE_ACCOUNT_URL);
+            // The deletion page is served on the server the user selected at
+            // sign-in (e.g. https://us.2breeze.app/account/delete), not a
+            // hardcoded marketing domain. Resolve it at tap time.
+            const url = await getAccountDeletionUrl(FALLBACK_API_BASE_URL);
+            await safeOpen(url);
           },
         },
       ],

--- a/apps/mobile/src/screens/devices/DeviceDetailScreen.tsx
+++ b/apps/mobile/src/screens/devices/DeviceDetailScreen.tsx
@@ -410,16 +410,6 @@ export function DeviceDetailScreen({ route }: Props) {
           brand={theme.brand}
         />
         <ActionButton
-          label="Lock"
-          onPress={() => handleAction('lock')}
-          loading={actionLoading === 'lock'}
-          disabled={offline || actionLoading !== null}
-          textHi={theme.textHi}
-          bg={theme.bg2}
-          border={theme.border}
-          brand={theme.brand}
-        />
-        <ActionButton
           label="Wake"
           onPress={() => handleAction('wake')}
           loading={actionLoading === 'wake'}

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -3,7 +3,8 @@ import * as SecureStore from 'expo-secure-store';
 import { getServerUrl } from './serverConfig';
 import { getOrCreateInstallationId } from './installationId';
 
-const FALLBACK_API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
+export const FALLBACK_API_BASE_URL =
+  process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 const API_PREFIX = '/api/v1/mobile';
 const API_CORE_PREFIX = '/api/v1';
 const CSRF_HEADER_NAME = 'x-breeze-csrf';
@@ -262,7 +263,7 @@ async function request<T>(
   return requestWithPrefix<T>(endpoint, API_PREFIX, options);
 }
 
-export type DeviceAction = 'reboot' | 'shutdown' | 'lock' | 'wake' | 'update';
+export type DeviceAction = 'reboot' | 'shutdown' | 'wake' | 'update';
 
 function mapAlert(alert: MobileAlertRecord): Alert {
   const normalizedSeverity: Alert['severity'] =

--- a/apps/mobile/src/services/serverConfig.test.ts
+++ b/apps/mobile/src/services/serverConfig.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn(),
+  setItemAsync: vi.fn(),
+  deleteItemAsync: vi.fn(),
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'whenUnlockedThisDeviceOnly',
+}));
+
+import * as SecureStore from 'expo-secure-store';
+
+import { buildAccountDeletionUrl, getAccountDeletionUrl } from './serverConfig';
+
+const FALLBACK = 'https://api.fallback.example';
+
+describe('buildAccountDeletionUrl', () => {
+  it('builds from the selected server base', () => {
+    expect(buildAccountDeletionUrl('https://us.2breeze.app', FALLBACK)).toBe(
+      'https://us.2breeze.app/account/delete',
+    );
+  });
+
+  it('strips a trailing slash on the stored base', () => {
+    expect(buildAccountDeletionUrl('https://eu.2breeze.app/', FALLBACK)).toBe(
+      'https://eu.2breeze.app/account/delete',
+    );
+  });
+
+  it('falls back when no server is stored (null)', () => {
+    expect(buildAccountDeletionUrl(null, FALLBACK)).toBe(
+      'https://api.fallback.example/account/delete',
+    );
+  });
+
+  it('falls back on an empty/whitespace stored value', () => {
+    expect(buildAccountDeletionUrl('   ', FALLBACK)).toBe(
+      'https://api.fallback.example/account/delete',
+    );
+  });
+
+  it('never uses the old marketing domain', () => {
+    const url = buildAccountDeletionUrl('https://us.2breeze.app', FALLBACK);
+    expect(url).not.toContain('breezermm.com');
+  });
+});
+
+describe('getAccountDeletionUrl', () => {
+  it('reads the stored server url from SecureStore', async () => {
+    vi.mocked(SecureStore.getItemAsync).mockResolvedValueOnce('https://us.2breeze.app');
+    await expect(getAccountDeletionUrl(FALLBACK)).resolves.toBe(
+      'https://us.2breeze.app/account/delete',
+    );
+  });
+
+  it('falls back to the API base when nothing is stored', async () => {
+    vi.mocked(SecureStore.getItemAsync).mockResolvedValueOnce(null);
+    await expect(getAccountDeletionUrl(FALLBACK)).resolves.toBe(
+      'https://api.fallback.example/account/delete',
+    );
+  });
+});

--- a/apps/mobile/src/services/serverConfig.ts
+++ b/apps/mobile/src/services/serverConfig.ts
@@ -28,6 +28,32 @@ export function isValidServerUrl(input: string): boolean {
   }
 }
 
+const ACCOUNT_DELETE_PATH = '/account/delete';
+
+/**
+ * Build the account-deletion web URL from the user's selected server base.
+ * Pure/testable: pass the stored server URL (may be null) and a fallback base
+ * (typically the app's API base) to use when nothing is stored.
+ */
+export function buildAccountDeletionUrl(
+  storedServerUrl: string | null | undefined,
+  fallbackBaseUrl: string,
+): string {
+  const source =
+    storedServerUrl && storedServerUrl.trim() ? storedServerUrl : fallbackBaseUrl;
+  return `${normalizeServerUrl(source)}${ACCOUNT_DELETE_PATH}`;
+}
+
+/**
+ * Resolve the account-deletion URL from the server chosen at sign-in
+ * (SecureStore key `breeze_server_url`). Falls back to `fallbackBaseUrl` when
+ * no server is stored.
+ */
+export async function getAccountDeletionUrl(fallbackBaseUrl: string): Promise<string> {
+  const stored = await getServerUrl();
+  return buildAccountDeletionUrl(stored, fallbackBaseUrl);
+}
+
 export async function getServerUrl(): Promise<string | null> {
   try {
     return await SecureStore.getItemAsync(SERVER_URL_KEY);


### PR DESCRIPTION
Pre-submission fixes for the iOS app (`apps/mobile`). Build path is local Xcode (`expo prebuild` → `BreezeRMM.xcworkspace` → archive), so no EAS config is included.

## Changes
- **Account deletion (Apple Guideline 5.1.1(v)):** the in-app "Delete account" link pointed at `breezermm.com/account/delete`, which 404s. The real page is served on the user's **selected server** (`us./eu.2breeze.app/account/delete`, 200). Now built at tap-time from the stored server URL via a new, unit-tested `buildAccountDeletionUrl` in `serverConfig.ts`. Falls back to the API base if no server is stored.
- **Device actions:** removed the unsupported **"Lock"** button — `'lock'` isn't in the API command enum (`devices/schemas.ts` `createCommandSchema`), so tapping it returned a 400. Also dropped `'lock'` from the `DeviceAction` type so a regression is a compile error. Reboot/Shutdown/Wake unchanged.
- **iOS build number:** added `ios.buildNumber` to `app.json` (flows into the prebuilt Xcode project via `expo prebuild`).

## Tests
- `apps/mobile` `serverConfig.test.ts` — 7/7 (URL builder, trailing-slash strip, null/empty fallback, no-marketing-domain assertion).
- `apps/mobile` `tsc --noEmit` — clean.
- `apps/api` `authenticator.test.ts` — 19/19 (unchanged).

## Deferred (not in this PR)
Making mobile hardware-key approver registration passwordless is intentionally **not** included — it needs a compensating control and a security review before it can be enabled. Registration keeps its existing step-up in the meantime. Tracked internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)