### PR TITLE
test(web): fix keystroke-drop flake in PamRuleModal recent-requests preview test

### DIFF
--- a/apps/web/src/components/pam/PamRuleModal.test.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.test.tsx
@@ -248,7 +248,14 @@ describe('PamRuleModal', () => {
         expect(screen.getByTestId('pam-rule-signer')).toBeInTheDocument();
       });
 
-      await user.type(screen.getByTestId('pam-rule-signer'), 'Acme Corp');
+      // Atomic set instead of user.type: mount-fetch re-renders drop keystrokes
+      // mid-type (same race as the 400-preview test below).
+      fireEvent.change(screen.getByTestId('pam-rule-signer'), {
+        target: { value: 'Acme Corp' },
+      });
+      await waitFor(() =>
+        expect(screen.getByTestId('pam-rule-signer')).toHaveValue('Acme Corp'),
+      );
       await user.click(screen.getByTestId('pam-rule-preview-btn'));
 
       await waitFor(() => {


### PR DESCRIPTION
## Summary

`PamRuleModal.test.tsx > rule preview > previews matches against recent requests` failed `Test Web` on the `b47c8e32` main push (run 29137891100, the trigger for the auto-managed red-main issue — Refs #2327), on a merge that doesn't touch PAM.

Root cause is the known keystroke-drop race fixed for this file's sibling preview tests in #2047: the modal's cascading mount fetches (orgs → sites → signer-groups) re-render mid-`user.type`, dropping characters, so `buildCriteria()` short-circuits and the preview request never fires. This one test was left on `user.type`.

## Fix

Convert the signer input to the atomic `fireEvent.change` + `toHaveValue` commit-assert pattern already used (with full rationale comment) by the 400-preview sibling test.

## Verification

`npx vitest run src/components/pam/PamRuleModal.test.tsx` — 13/13 passed, 5 consecutive runs.

Other `user.type` sites in this file are left untouched — they haven't been observed flaking; converting them speculatively can happen if they ever do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)