### PR TITLE
fix(test-infra): make cleanupDatabase() truncate tenant roots for real (#2205)

### DIFF
--- a/apps/api/src/__tests__/integration/auditRetentionPrivSep.integration.test.ts
+++ b/apps/api/src/__tests__/integration/auditRetentionPrivSep.integration.test.ts
@@ -14,8 +14,9 @@
  *      keep working.)
  *
  * audit_logs is append-only: the trigger blocks DELETE/TRUNCATE. setup.ts
- * cleans it between tests via `session_replication_role = replica` + DELETE,
- * which is the same lever we'd use for manual cleanup here.
+ * cleans it between tests by disabling audit_log_block_truncate around a
+ * single TRUNCATE ... CASCADE (#2205); suites that need mid-file manual
+ * cleanup use `session_replication_role = replica` + DELETE instead.
  */
 import './setup';
 import { describe, it, expect, beforeEach, afterAll, beforeAll } from 'vitest';

--- a/apps/api/src/__tests__/integration/cleanupDatabase.integration.test.ts
+++ b/apps/api/src/__tests__/integration/cleanupDatabase.integration.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression coverage for #2205 — cleanupDatabase() used to be a silent no-op
+ * for the tenant-root tables.
+ *
+ * The bug: `TRUNCATE partners/organizations/users ... CASCADE` transitively
+ * reaches `audit_logs`, whose `audit_log_block_truncate` BEFORE TRUNCATE
+ * trigger (migration 2026-05-25-k) unconditionally rejects ANY truncate
+ * touching the table — the append-only bypass GUC
+ * (`breeze.allow_audit_retention`) only exists for DELETE. The whole TRUNCATE
+ * statement failed, cleanupDatabase()'s blanket try/catch swallowed the error,
+ * and tenant rows accumulated across every suite in an integration run. It
+ * surfaced in the #2202 loginContext suite — the first to assert on GLOBAL
+ * partner state.
+ *
+ * The fix (setup.ts): disable the audit trigger around the truncate loop
+ * (re-enabled in a finally), and only swallow undefined-table (42P01) errors —
+ * anything else now fails loudly.
+ *
+ * These tests prove:
+ *   1. Stray partner/organization/audit_logs rows are genuinely removed —
+ *      including when an audit row forces the cascade to reach audit_logs.
+ *   2. The append-only TRUNCATE guard on audit_logs is re-enabled after
+ *      cleanup — prod semantics are untouched.
+ *
+ * Run:
+ *   pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts \
+ *     src/__tests__/integration/cleanupDatabase.integration.test.ts
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { cleanupDatabase, getTestDb } from './setup';
+import { auditLogs, organizations, partners } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+async function countRows(table: string): Promise<number> {
+  const db = getTestDb();
+  const result = await db.execute<{ n: number }>(
+    sql`SELECT count(*)::int AS n FROM ${sql.identifier(table)}`
+  );
+  return Number((result as unknown as Array<{ n: number }>)[0]?.n ?? (result as { rows?: Array<{ n: number }> }).rows?.[0]?.n);
+}
+
+describe('#2205 cleanupDatabase() genuinely resets tenant-root tables', () => {
+  it('removes stray partners/organizations rows even when the cascade reaches audit_logs', async () => {
+    const db = getTestDb();
+
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    // An audit row referencing the org guarantees the organizations TRUNCATE
+    // CASCADE set includes audit_logs — exactly the shape that used to make
+    // the whole statement fail against the block-truncate trigger.
+    await db.insert(auditLogs).values({
+      orgId: org.id,
+      actorType: 'system',
+      actorId: partner.id,
+      action: 'test.cleanup-regression',
+      resourceType: 'organization',
+      resourceId: org.id,
+      result: 'success',
+    });
+
+    expect(await countRows('partners')).toBeGreaterThan(0);
+    expect(await countRows('organizations')).toBeGreaterThan(0);
+    expect(await countRows('audit_logs')).toBeGreaterThan(0);
+
+    await cleanupDatabase();
+
+    // GLOBAL zero-row assertions — not scoped to the fixture IDs — so leakage
+    // from any earlier suite in the run would also be caught here.
+    expect(await countRows('partners')).toBe(0);
+    expect(await countRows('organizations')).toBe(0);
+    expect(await countRows('audit_logs')).toBe(0);
+
+    // Drizzle-level sanity check through the same client the suites use.
+    expect(await db.select({ id: partners.id }).from(partners)).toHaveLength(0);
+    expect(await db.select({ id: organizations.id }).from(organizations)).toHaveLength(0);
+  });
+
+  it('re-enables the audit_logs append-only TRUNCATE guard after cleanup', async () => {
+    const db = getTestDb();
+
+    await cleanupDatabase();
+
+    // The trigger must be back on (origin/local enabled = 'O') …
+    const trigger = await db.execute<{ tgenabled: string }>(sql`
+      SELECT tgenabled FROM pg_trigger
+      WHERE tgname = 'audit_log_block_truncate'
+        AND tgrelid = 'audit_logs'::regclass
+    `);
+    const tgenabled =
+      (trigger as unknown as Array<{ tgenabled: string }>)[0]?.tgenabled ??
+      (trigger as { rows?: Array<{ tgenabled: string }> }).rows?.[0]?.tgenabled;
+    expect(tgenabled).toBe('O');
+
+    // … and functionally enforced: a TRUNCATE must still be rejected by the
+    // trigger. CASCADE is needed to get past the audit_log_chain FK check
+    // (which otherwise rejects first with a different, weaker error); the
+    // BEFORE TRUNCATE trigger raises before anything is actually truncated.
+    let error: unknown;
+    try {
+      await db.execute(sql`TRUNCATE TABLE audit_logs CASCADE`);
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeDefined();
+    const message = [
+      (error as Error | undefined)?.message,
+      ((error as { cause?: Error } | undefined)?.cause)?.message,
+    ]
+      .filter(Boolean)
+      .join(' | ');
+    expect(message).toMatch(/append-only/);
+  });
+});

--- a/apps/api/src/__tests__/integration/cleanupDatabase.integration.test.ts
+++ b/apps/api/src/__tests__/integration/cleanupDatabase.integration.test.ts
@@ -23,6 +23,10 @@
  *   3. A truncate failure surfaces loudly (no silent swallow) AND still
  *      re-enables the audit trigger via the finally — the two regressions
  *      that would quietly reintroduce #2205.
+ *   4. A transient deadlock (40P01) — a lock race with an in-flight query
+ *      from the previous test, observed in CI — is retried instead of
+ *      failing the run (and instead of being silently swallowed, which is
+ *      what the pre-#2205 code did with it).
  *
  * Run:
  *   pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts \
@@ -164,5 +168,42 @@ describe('#2205 cleanupDatabase() genuinely resets tenant-root tables', () => {
     await cleanupDatabase();
     expect(await countRows('partners')).toBe(0);
     expect(await auditTruncateTriggerEnabled()).toBe('O');
+  });
+
+  it('retries a transient deadlock instead of failing the run', async () => {
+    const db = getTestDb();
+
+    // Simulate the CI failure mode: the combined TRUNCATE deadlocks (40P01)
+    // against an in-flight query from the previous test, exactly once. A
+    // sequence is the one Postgres side effect that survives the statement's
+    // rollback, so the trigger raises on its first invocation only —
+    // deterministic without needing a real two-session lock race.
+    await db.execute(sql`CREATE SEQUENCE IF NOT EXISTS test_2205_deadlock_seq`);
+    await db.execute(sql`
+      CREATE OR REPLACE FUNCTION test_2205_deadlock_once() RETURNS trigger
+      LANGUAGE plpgsql AS $$
+      BEGIN
+        IF nextval('test_2205_deadlock_seq') = 1 THEN
+          RAISE EXCEPTION 'test_2205: simulated deadlock' USING ERRCODE = '40P01';
+        END IF;
+        RETURN NULL;
+      END;
+      $$
+    `);
+    await db.execute(sql`
+      CREATE TRIGGER test_2205_deadlock_once BEFORE TRUNCATE ON alerts
+        FOR EACH STATEMENT EXECUTE FUNCTION test_2205_deadlock_once()
+    `);
+
+    try {
+      // First attempt hits the simulated 40P01; the retry must succeed.
+      await cleanupDatabase();
+      expect(await countRows('partners')).toBe(0);
+      expect(await auditTruncateTriggerEnabled()).toBe('O');
+    } finally {
+      await db.execute(sql`DROP TRIGGER IF EXISTS test_2205_deadlock_once ON alerts`);
+      await db.execute(sql`DROP FUNCTION IF EXISTS test_2205_deadlock_once()`);
+      await db.execute(sql`DROP SEQUENCE IF EXISTS test_2205_deadlock_seq`);
+    }
   });
 });

--- a/apps/api/src/__tests__/integration/cleanupDatabase.integration.test.ts
+++ b/apps/api/src/__tests__/integration/cleanupDatabase.integration.test.ts
@@ -2,25 +2,27 @@
  * Regression coverage for #2205 — cleanupDatabase() used to be a silent no-op
  * for the tenant-root tables.
  *
- * The bug: `TRUNCATE partners/organizations/users ... CASCADE` transitively
- * reaches `audit_logs`, whose `audit_log_block_truncate` BEFORE TRUNCATE
- * trigger (migration 2026-05-25-k) unconditionally rejects ANY truncate
- * touching the table — the append-only bypass GUC
- * (`breeze.allow_audit_retention`) only exists for DELETE. The whole TRUNCATE
- * statement failed, cleanupDatabase()'s blanket try/catch swallowed the error,
- * and tenant rows accumulated across every suite in an integration run. It
- * surfaced in the #2202 loginContext suite — the first to assert on GLOBAL
- * partner state.
+ * The bug: `TRUNCATE partners/organizations ... CASCADE` transitively reaches
+ * `audit_logs`, whose `audit_log_block_truncate` BEFORE TRUNCATE trigger
+ * (migration 2026-05-25-k) unconditionally rejects ANY truncate touching the
+ * table — the append-only bypass GUC (`breeze.allow_audit_retention`) only
+ * exists for DELETE. The whole TRUNCATE statement failed, cleanupDatabase()'s
+ * blanket try/catch swallowed the error, and tenant rows accumulated across
+ * every suite in an integration run. It surfaced in the #2202 loginContext
+ * suite — the first to assert on GLOBAL partner state.
  *
- * The fix (setup.ts): disable the audit trigger around the truncate loop
- * (re-enabled in a finally), and only swallow undefined-table (42P01) errors —
- * anything else now fails loudly.
+ * The fix (setup.ts): disable the audit trigger around a single combined
+ * TRUNCATE (re-enabled in a finally), and fail loudly on any truncate error
+ * instead of swallowing it.
  *
  * These tests prove:
  *   1. Stray partner/organization/audit_logs rows are genuinely removed —
  *      including when an audit row forces the cascade to reach audit_logs.
  *   2. The append-only TRUNCATE guard on audit_logs is re-enabled after
  *      cleanup — prod semantics are untouched.
+ *   3. A truncate failure surfaces loudly (no silent swallow) AND still
+ *      re-enables the audit trigger via the finally — the two regressions
+ *      that would quietly reintroduce #2205.
  *
  * Run:
  *   pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts \
@@ -38,7 +40,27 @@ async function countRows(table: string): Promise<number> {
   const result = await db.execute<{ n: number }>(
     sql`SELECT count(*)::int AS n FROM ${sql.identifier(table)}`
   );
-  return Number((result as unknown as Array<{ n: number }>)[0]?.n ?? (result as { rows?: Array<{ n: number }> }).rows?.[0]?.n);
+  const n = Number(
+    (result as unknown as Array<{ n: number }>)[0]?.n ??
+    (result as { rows?: Array<{ n: number }> }).rows?.[0]?.n
+  );
+  if (Number.isNaN(n)) {
+    throw new Error(`countRows(${table}): unexpected drizzle result shape — cannot count rows`);
+  }
+  return n;
+}
+
+async function auditTruncateTriggerEnabled(): Promise<string | undefined> {
+  const db = getTestDb();
+  const trigger = await db.execute<{ tgenabled: string }>(sql`
+    SELECT tgenabled FROM pg_trigger
+    WHERE tgname = 'audit_log_block_truncate'
+      AND tgrelid = 'audit_logs'::regclass
+  `);
+  return (
+    (trigger as unknown as Array<{ tgenabled: string }>)[0]?.tgenabled ??
+    (trigger as { rows?: Array<{ tgenabled: string }> }).rows?.[0]?.tgenabled
+  );
 }
 
 describe('#2205 cleanupDatabase() genuinely resets tenant-root tables', () => {
@@ -47,9 +69,9 @@ describe('#2205 cleanupDatabase() genuinely resets tenant-root tables', () => {
 
     const partner = await createPartner();
     const org = await createOrganization({ partnerId: partner.id });
-    // An audit row referencing the org guarantees the organizations TRUNCATE
-    // CASCADE set includes audit_logs — exactly the shape that used to make
-    // the whole statement fail against the block-truncate trigger.
+    // An audit row referencing the org guarantees the TRUNCATE CASCADE set
+    // includes audit_logs — exactly the shape that used to make the whole
+    // statement fail against the block-truncate trigger.
     await db.insert(auditLogs).values({
       orgId: org.id,
       actorType: 'system',
@@ -83,15 +105,7 @@ describe('#2205 cleanupDatabase() genuinely resets tenant-root tables', () => {
     await cleanupDatabase();
 
     // The trigger must be back on (origin/local enabled = 'O') …
-    const trigger = await db.execute<{ tgenabled: string }>(sql`
-      SELECT tgenabled FROM pg_trigger
-      WHERE tgname = 'audit_log_block_truncate'
-        AND tgrelid = 'audit_logs'::regclass
-    `);
-    const tgenabled =
-      (trigger as unknown as Array<{ tgenabled: string }>)[0]?.tgenabled ??
-      (trigger as { rows?: Array<{ tgenabled: string }> }).rows?.[0]?.tgenabled;
-    expect(tgenabled).toBe('O');
+    expect(await auditTruncateTriggerEnabled()).toBe('O');
 
     // … and functionally enforced: a TRUNCATE must still be rejected by the
     // trigger. CASCADE is needed to get past the audit_log_chain FK check
@@ -111,5 +125,44 @@ describe('#2205 cleanupDatabase() genuinely resets tenant-root tables', () => {
       .filter(Boolean)
       .join(' | ');
     expect(message).toMatch(/append-only/);
+  });
+
+  it('fails loudly when the truncate is blocked, and still re-enables the audit trigger', async () => {
+    const db = getTestDb();
+
+    // Install a throwaway BEFORE TRUNCATE blocker on a mid-list table to make
+    // the combined truncate fail for a non-42P01 reason. This pins the two
+    // behaviors that would silently reintroduce #2205 if regressed:
+    //   a) the error must PROPAGATE (no blanket catch swallowing it),
+    //   b) the finally must still re-enable audit_log_block_truncate.
+    await db.execute(sql`
+      CREATE OR REPLACE FUNCTION test_2205_block_truncate() RETURNS trigger
+      LANGUAGE plpgsql AS $$
+      BEGIN
+        RAISE EXCEPTION 'test_2205: simulated truncate failure';
+      END;
+      $$
+    `);
+    await db.execute(sql`
+      CREATE TRIGGER test_2205_block_truncate BEFORE TRUNCATE ON alerts
+        FOR EACH STATEMENT EXECUTE FUNCTION test_2205_block_truncate()
+    `);
+
+    try {
+      await expect(cleanupDatabase()).rejects.toThrow(/database was not reset/);
+      // The finally must have re-enabled the append-only guard even though the
+      // truncate failed mid-statement.
+      expect(await auditTruncateTriggerEnabled()).toBe('O');
+    } finally {
+      // Drop the blocker in a finally — leaving it behind would poison the
+      // global beforeEach of every subsequent test in the run.
+      await db.execute(sql`DROP TRIGGER IF EXISTS test_2205_block_truncate ON alerts`);
+      await db.execute(sql`DROP FUNCTION IF EXISTS test_2205_block_truncate()`);
+    }
+
+    // Recovery check: with the blocker gone, cleanup works again.
+    await cleanupDatabase();
+    expect(await countRows('partners')).toBe(0);
+    expect(await auditTruncateTriggerEnabled()).toBe('O');
   });
 });

--- a/apps/api/src/__tests__/integration/loginContext.integration.test.ts
+++ b/apps/api/src/__tests__/integration/loginContext.integration.test.ts
@@ -18,51 +18,27 @@
  * of `partnerSso` IS the availability signal, there is no separate
  * `available` field.
  *
- * IMPORTANT — "which partners exist" is GLOBAL state, and cleanupDatabase()'s
- * per-test TRUNCATE of `partners` (setup.ts) is NOT actually effective:
- * `TRUNCATE partners CASCADE` cascades transitively into `organizations` and
- * from there into `audit_logs`, whose `audit_log_block_truncate` trigger
- * unconditionally rejects any TRUNCATE reaching it (append-only enforcement,
- * no bypass GUC for TRUNCATE — only DELETE has one) — so that whole TRUNCATE
- * statement fails and is silently swallowed by cleanupDatabase()'s try/catch,
- * meaning `partners`/`organizations` rows actually accumulate across every
- * integration test that has ever run against this container. No existing
- * suite notices because they all scope assertions to a specific ID; this is
- * the first that counts rows globally. Reset both tables ourselves below with
- * TRUNCATE ... CASCADE, temporarily disabling the audit_logs trigger (the
- * test-DB user owns the table) — plain DELETEs are not order-independent:
- * whatever FK-child rows earlier suites left behind (backup_configs, etc.)
- * make them fail with 23503.
+ * "Which partners exist" is GLOBAL state. cleanupDatabase() (setup.ts) used
+ * to silently fail to truncate `partners`/`organizations` — the cascade
+ * reached `audit_logs`, whose `audit_log_block_truncate` trigger rejected the
+ * whole statement and the error was swallowed — so this suite originally
+ * carried a suite-local trigger-aware truncate workaround. That fix now lives
+ * in cleanupDatabase() itself (#2205): the global per-test beforeEach disables
+ * the audit trigger around the reset and fails loudly on any other truncate
+ * error, so the tenant roots are genuinely empty before every test here and
+ * the local workaround has been removed.
  *
  * Run:
  *   pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts \
  *     src/__tests__/integration/loginContext.integration.test.ts
  */
 import './setup';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { Hono } from 'hono';
-import { sql } from 'drizzle-orm';
 import { getTestDb } from './setup';
 import { ssoProviders, partnerLoginBranding } from '../../db/schema';
 import { createPartner } from './db-utils';
 import { loginContextRoutes } from '../../routes/auth/loginContext';
-
-beforeEach(async () => {
-  const testDb = getTestDb();
-  // Bare `DELETE FROM organizations/partners` is not enough here: earlier
-  // suites in the same run leave rows in FK-child tables without ON DELETE
-  // CASCADE (backup_configs bit us in CI, 23503). TRUNCATE ... CASCADE is the
-  // only order-independent reset, and the audit_logs BEFORE TRUNCATE trigger
-  // (append-only enforcement) is the one thing blocking it — the test-DB user
-  // owns the table, so disable it just for this statement and re-enable in a
-  // finally so a failed truncate can't leave the guard off.
-  await testDb.execute(sql`ALTER TABLE audit_logs DISABLE TRIGGER audit_log_block_truncate`);
-  try {
-    await testDb.execute(sql`TRUNCATE TABLE partners, organizations CASCADE`);
-  } finally {
-    await testDb.execute(sql`ALTER TABLE audit_logs ENABLE TRIGGER audit_log_block_truncate`);
-  }
-});
 
 async function createPartnerAxisProvider(
   partnerId: string,

--- a/apps/api/src/__tests__/integration/oauth-introspection.integration.test.ts
+++ b/apps/api/src/__tests__/integration/oauth-introspection.integration.test.ts
@@ -33,7 +33,7 @@
 import './setup';
 import './loadEnv';
 
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
 import { serve, type ServerType } from '@hono/node-server';
 import { Hono } from 'hono';
 import type { HttpBindings } from '@hono/node-server';
@@ -198,8 +198,16 @@ describe.skipIf(!SHOULD_RUN)('OAuth introspection client-binding', () => {
     expect(live.url).toBe(process.env.OAUTH_ISSUER);
     const { _resetJwksCacheForTests } = await import('../../middleware/bearerTokenAuth');
     _resetJwksCacheForTests();
+  }, 60_000);
 
-    // A victim client + token set, and a separate attacker client.
+  // A victim client + token set, and a separate attacker client. Minted
+  // per-test (NOT in beforeAll): setup.ts's global beforeEach cleanupDatabase()
+  // TRUNCATEs partners/users CASCADE before every test, which wipes the whole
+  // oauth_* table family (they FK to partners/users). Since #2205 fixed the
+  // silently failing truncate, beforeAll-minted fixtures no longer survive to
+  // the tests — client auth would 401 and the cross-client assertions would go
+  // vacuous (introspecting a nonexistent token also reports active:false).
+  beforeEach(async () => {
     victim = await mintTokensForNewClient(live.url);
     attackerClientId = await dcr(live.url, 'https://attacker.example/cb');
   }, 60_000);

--- a/apps/api/src/__tests__/integration/oauth-introspection.integration.test.ts
+++ b/apps/api/src/__tests__/integration/oauth-introspection.integration.test.ts
@@ -202,11 +202,13 @@ describe.skipIf(!SHOULD_RUN)('OAuth introspection client-binding', () => {
 
   // A victim client + token set, and a separate attacker client. Minted
   // per-test (NOT in beforeAll): setup.ts's global beforeEach cleanupDatabase()
-  // TRUNCATEs partners/users CASCADE before every test, which wipes the whole
-  // oauth_* table family (they FK to partners/users). Since #2205 fixed the
-  // silently failing truncate, beforeAll-minted fixtures no longer survive to
-  // the tests — client auth would 401 and the cross-client assertions would go
-  // vacuous (introspecting a nonexistent token also reports active:false).
+  // TRUNCATEs partners/users CASCADE before every test, which wipes the
+  // oauth_* tables that FK to partners/users/oauth_clients — clients, codes,
+  // tokens, grants, sessions (everything but the FK-less oauth_interactions).
+  // Since #2205 fixed the silently failing truncate, beforeAll-minted fixtures
+  // no longer survive to the tests — client auth would 401 and the
+  // cross-client assertions would go vacuous (introspecting a nonexistent
+  // token also reports active:false).
   beforeEach(async () => {
     victim = await mintTokensForNewClient(live.url);
     attackerClientId = await dcr(live.url, 'https://attacker.example/cb');

--- a/apps/api/src/__tests__/integration/setup.ts
+++ b/apps/api/src/__tests__/integration/setup.ts
@@ -246,10 +246,26 @@ export async function teardownIntegrationTests() {
   }
 }
 
-function isUndefinedTableError(error: unknown): boolean {
-  const code = (error as { code?: string; cause?: { code?: string } } | undefined)?.code
+function sqlStateOf(error: unknown): string | undefined {
+  return (error as { code?: string; cause?: { code?: string } } | undefined)?.code
     ?? (error as { cause?: { code?: string } } | undefined)?.cause?.code;
-  return code === '42P01';
+}
+
+function isUndefinedTableError(error: unknown): boolean {
+  return sqlStateOf(error) === '42P01';
+}
+
+// 40P01 = deadlock_detected, 40001 = serialization_failure. Both are
+// transient lock races, not broken cleanup: the TRUNCATE grabs ACCESS
+// EXCLUSIVE on ~all tenant tables in one statement, and an in-flight
+// background query from the PREVIOUS test (app-pool FK check / SELECT) can
+// still hold a conflicting lock for a few ms. Postgres kills one side; the
+// competitor finishes immediately after, so a retry succeeds. Before #2205
+// these were silently swallowed — leaving the DB dirty; retrying (loudly)
+// is strictly better on both axes.
+function isTransientLockError(error: unknown): boolean {
+  const code = sqlStateOf(error);
+  return code === '40P01' || code === '40001';
 }
 
 async function cleanupAppendOnlyMlFeedbackEvents() {
@@ -370,17 +386,35 @@ export async function cleanupDatabase() {
   // over the union of the same lock set.
   await testClient`ALTER TABLE audit_logs DISABLE TRIGGER audit_log_block_truncate`;
   try {
-    await testClient`TRUNCATE TABLE ${testClient(tablesToTruncate)} CASCADE`;
-  } catch (error) {
-    // No tolerated failures here: missing tables were already filtered out by
-    // resolveCleanupTables(), so ANY error means the DB was NOT reset — fail
-    // loudly instead of letting state leak into the next test (the silent
-    // swallow of this failure is how #2205 stayed hidden).
-    throw new Error(
-      'cleanupDatabase: TRUNCATE ... CASCADE of the core tables failed — the database was not reset. ' +
-      'Failing loudly so leaked tenant state cannot poison later tests (#2205).',
-      { cause: error }
-    );
+    const MAX_TRUNCATE_ATTEMPTS = 3;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        await testClient`TRUNCATE TABLE ${testClient(tablesToTruncate)} CASCADE`;
+        break;
+      } catch (error) {
+        // Deadlock/serialization races with a still-in-flight query from the
+        // previous test are transient (see isTransientLockError) — retry a
+        // couple of times, VISIBLY, before giving up.
+        if (isTransientLockError(error) && attempt < MAX_TRUNCATE_ATTEMPTS) {
+          console.warn(
+            `cleanupDatabase: TRUNCATE hit ${sqlStateOf(error)} (attempt ${attempt}/${MAX_TRUNCATE_ATTEMPTS}) — ` +
+            'a query from the previous test was still holding locks; retrying'
+          );
+          await new Promise((r) => setTimeout(r, 100 * attempt));
+          continue;
+        }
+        // No other tolerated failures: missing tables were already filtered
+        // out by resolveCleanupTables(), so ANY other error means the DB was
+        // NOT reset — fail loudly instead of letting state leak into the next
+        // test (the silent swallow of this failure is how #2205 stayed
+        // hidden).
+        throw new Error(
+          'cleanupDatabase: TRUNCATE ... CASCADE of the core tables failed — the database was not reset. ' +
+          'Failing loudly so leaked tenant state cannot poison later tests (#2205).',
+          { cause: error }
+        );
+      }
+    }
   } finally {
     try {
       await testClient`ALTER TABLE audit_logs ENABLE TRIGGER audit_log_block_truncate`;

--- a/apps/api/src/__tests__/integration/setup.ts
+++ b/apps/api/src/__tests__/integration/setup.ts
@@ -263,8 +263,75 @@ async function cleanupAppendOnlyMlFeedbackEvents() {
   }
 }
 
+// Tables reset by cleanupDatabase(). Order is irrelevant — they are truncated
+// in a single TRUNCATE ... CASCADE statement (see below), which resolves the
+// FK graph itself. The list only needs to name the ROOTS (plus global tables
+// not reached by any cascade); FK-children are covered by CASCADE.
+const CLEANUP_TABLES = [
+  'device_commands',
+  'device_group_memberships',
+  'device_groups',
+  'device_metrics',
+  'device_network',
+  'device_hardware',
+  'device_software',
+  'device_link_groups',
+  'devices',
+  'automation_executions',
+  'automations',
+  'alert_history',
+  'alerts',
+  'alert_templates',
+  'script_executions',
+  'scripts',
+  'sites',
+  'organization_users',
+  'organizations',
+  'partner_users',
+  'partners',
+  'sessions',
+  'api_keys',
+  'role_permissions',
+  'roles',
+  'audit_logs',
+  'users',
+  // BE-16 vulnerability management. The global tables are not reached by any
+  // tenant-root CASCADE, so list them explicitly to avoid cross-run
+  // accumulation.
+  'device_vulnerabilities',
+  'os_vulnerabilities',
+  'software_vulnerabilities',
+  'software_products',
+  'vulnerabilities',
+  'vulnerability_sources'
+];
+
+// Resolved once per test file (module instance): which of CLEANUP_TABLES exist
+// in this branch's schema. Replaces the old per-statement 42P01 tolerance —
+// filtering up front lets the truncate run as ONE statement, and the schema
+// cannot change mid-run (autoMigrate runs in beforeAll, before any cleanup).
+let existingCleanupTables: string[] | null = null;
+
+async function resolveCleanupTables(): Promise<string[]> {
+  if (existingCleanupTables === null) {
+    const rows = await testClient`
+      SELECT tablename FROM pg_tables
+      WHERE schemaname = 'public' AND tablename = ANY(${CLEANUP_TABLES})
+    `;
+    const present = new Set(rows.map((r) => r.tablename as string));
+    existingCleanupTables = CLEANUP_TABLES.filter((t) => present.has(t));
+  }
+  return existingCleanupTables;
+}
+
 export async function cleanupDatabase() {
-  if (!testDb) return;
+  // A cleanup that silently does nothing is exactly the #2205 failure mode —
+  // refuse loudly instead of no-opping when setup hasn't run. (vitest skips
+  // the global beforeEach when the beforeAll that initializes testDb failed,
+  // so every legitimate caller reaches this line with testDb set.)
+  if (!testDb) {
+    throw new Error('cleanupDatabase called before integration setup ran — refusing to silently no-op (#2205)');
+  }
 
   // Defense-in-depth: the same guard fires in setupIntegrationTests, but assert
   // again here in case a future caller invokes cleanupDatabase outside the
@@ -276,58 +343,13 @@ export async function cleanupDatabase() {
   // organizations TRUNCATE CASCADE side effect.
   await cleanupAppendOnlyMlFeedbackEvents();
 
-  // Truncate all tables in reverse dependency order
-  // This ensures we don't hit foreign key constraints
-  const tables = [
-    'device_commands',
-    'device_group_memberships',
-    'device_groups',
-    'device_metrics',
-    'device_network',
-    'device_hardware',
-    'device_software',
-    // #2138 — devices carries a composite FK to device_link_groups; truncate
-    // the groups first (CASCADE clears the referencing devices) so cleanup is
-    // FK-safe and deterministic.
-    'device_link_groups',
-    'devices',
-    'automation_executions',
-    'automations',
-    'alert_history',
-    'alerts',
-    'alert_templates',
-    'script_executions',
-    'scripts',
-    'sites',
-    'organization_users',
-    'organizations',
-    'partner_users',
-    'partners',
-    'sessions',
-    'api_keys',
-    'role_permissions',
-    'roles',
-    'audit_logs',
-    'users',
-    // BE-16 vulnerability management. The four global tables are not reached by
-    // the `devices` CASCADE, so reset them per-test to avoid cross-run
-    // accumulation. TRUNCATE ... CASCADE on `vulnerabilities` clears its
-    // dependents (software_vulnerabilities, device_vulnerabilities); the rest
-    // are listed explicitly for clarity. (try/catch ignores them on branches
-    // without the migration.)
-    'device_vulnerabilities',
-    'os_vulnerabilities',
-    'software_vulnerabilities',
-    'software_products',
-    'vulnerabilities',
-    'vulnerability_sources'
-  ];
+  const tablesToTruncate = await resolveCleanupTables();
 
   // audit_logs carries a BEFORE TRUNCATE trigger (`audit_log_block_truncate`,
   // migration 2026-05-25-k) that unconditionally rejects ANY truncate whose
   // cascade set reaches the table — the append-only bypass GUC
   // (`breeze.allow_audit_retention`) only exists for DELETE. Every TRUNCATE of
-  // partners/organizations/users therefore used to fail wholesale, and the old
+  // partners/organizations therefore used to fail wholesale, and the old
   // blanket try/catch swallowed it, so tenant-root rows silently accumulated
   // across suites (#2205). The test client connects as the table owner, so
   // disable the trigger for the duration of the reset and re-enable it in a
@@ -337,27 +359,39 @@ export async function cleanupDatabase() {
   // concurrent test can observe the window.) Production semantics are
   // untouched: this is an owner-only ALTER on the throwaway test database,
   // not a change to the trigger itself.
+  //
+  // PERF: this is ONE TRUNCATE statement, not a per-table loop. Each CASCADE
+  // truncate resolves + locks its whole FK closure; doing that ~35 times per
+  // test added ~2s/test once the tenant-root truncates started succeeding
+  // (~24 min across the ~690-test CI run — over the job's 55-min ceiling). A
+  // single statement takes one pass over the union of the same lock set.
   await testClient`ALTER TABLE audit_logs DISABLE TRIGGER audit_log_block_truncate`;
   try {
-    for (const table of tables) {
-      try {
-        await testClient`TRUNCATE TABLE ${testClient(table)} CASCADE`;
-      } catch (error) {
-        // The only benign failure is the table not existing yet (42P01) on a
-        // branch that predates its migration. Anything else means the DB was
-        // NOT reset — fail loudly instead of letting state leak into the next
-        // test (the silent-swallow variant of this loop is how #2205 stayed
-        // hidden).
-        if (isUndefinedTableError(error)) continue;
-        throw new Error(
-          `cleanupDatabase: TRUNCATE ${table} CASCADE failed — the database was not reset. ` +
-          `Failing loudly so leaked tenant state cannot poison later tests (#2205).`,
-          { cause: error }
-        );
-      }
-    }
+    await testClient`TRUNCATE TABLE ${testClient(tablesToTruncate)} CASCADE`;
+  } catch (error) {
+    // No tolerated failures here: missing tables were already filtered out by
+    // resolveCleanupTables(), so ANY error means the DB was NOT reset — fail
+    // loudly instead of letting state leak into the next test (the silent
+    // swallow of this failure is how #2205 stayed hidden).
+    throw new Error(
+      'cleanupDatabase: TRUNCATE ... CASCADE of the core tables failed — the database was not reset. ' +
+      'Failing loudly so leaked tenant state cannot poison later tests (#2205).',
+      { cause: error }
+    );
   } finally {
-    await testClient`ALTER TABLE audit_logs ENABLE TRIGGER audit_log_block_truncate`;
+    try {
+      await testClient`ALTER TABLE audit_logs ENABLE TRIGGER audit_log_block_truncate`;
+    } catch (enableError) {
+      // A throw from a finally block REPLACES an in-flight exception from the
+      // try block, so log before propagating — otherwise a truncate failure's
+      // diagnostic error (with its cause) would be silently discarded, and
+      // the fact that the append-only guard is now OFF would be invisible.
+      console.error(
+        'cleanupDatabase: failed to re-enable audit_log_block_truncate — the append-only TRUNCATE guard is OFF in the test DB',
+        enableError
+      );
+      throw enableError;
+    }
   }
 
   // Clear Redis

--- a/apps/api/src/__tests__/integration/setup.ts
+++ b/apps/api/src/__tests__/integration/setup.ts
@@ -265,8 +265,10 @@ async function cleanupAppendOnlyMlFeedbackEvents() {
 
 // Tables reset by cleanupDatabase(). Order is irrelevant — they are truncated
 // in a single TRUNCATE ... CASCADE statement (see below), which resolves the
-// FK graph itself. The list only needs to name the ROOTS (plus global tables
-// not reached by any cascade); FK-children are covered by CASCADE.
+// FK graph itself. Strictly only the ROOTS (plus global tables not reached by
+// any cascade) need naming, but many FK-children are listed deliberately:
+// redundant entries are harmless in a single TRUNCATE, and belt-and-braces if
+// an FK is ever dropped. Don't prune the list to "just roots".
 const CLEANUP_TABLES = [
   'device_commands',
   'device_group_memberships',
@@ -362,9 +364,10 @@ export async function cleanupDatabase() {
   //
   // PERF: this is ONE TRUNCATE statement, not a per-table loop. Each CASCADE
   // truncate resolves + locks its whole FK closure; doing that ~35 times per
-  // test added ~2s/test once the tenant-root truncates started succeeding
-  // (~24 min across the ~690-test CI run — over the job's 55-min ceiling). A
-  // single statement takes one pass over the union of the same lock set.
+  // test added ~2s/test once the tenant-root truncates started succeeding —
+  // ~24 min across the ~690-test CI run, pushing the ~50-min Integration
+  // Tests job past its 55-min ceiling. A single statement takes one pass
+  // over the union of the same lock set.
   await testClient`ALTER TABLE audit_logs DISABLE TRIGGER audit_log_block_truncate`;
   try {
     await testClient`TRUNCATE TABLE ${testClient(tablesToTruncate)} CASCADE`;

--- a/apps/api/src/__tests__/integration/setup.ts
+++ b/apps/api/src/__tests__/integration/setup.ts
@@ -323,12 +323,41 @@ export async function cleanupDatabase() {
     'vulnerability_sources'
   ];
 
-  for (const table of tables) {
-    try {
-      await testClient`TRUNCATE TABLE ${testClient(table)} CASCADE`;
-    } catch {
-      // Table might not exist yet, ignore
+  // audit_logs carries a BEFORE TRUNCATE trigger (`audit_log_block_truncate`,
+  // migration 2026-05-25-k) that unconditionally rejects ANY truncate whose
+  // cascade set reaches the table — the append-only bypass GUC
+  // (`breeze.allow_audit_retention`) only exists for DELETE. Every TRUNCATE of
+  // partners/organizations/users therefore used to fail wholesale, and the old
+  // blanket try/catch swallowed it, so tenant-root rows silently accumulated
+  // across suites (#2205). The test client connects as the table owner, so
+  // disable the trigger for the duration of the reset and re-enable it in a
+  // finally — a failed truncate must never leave the append-only guard off.
+  // (ALTER TABLE ... DISABLE TRIGGER is a catalog change, not session-local,
+  // but integration files run one at a time — fileParallelism:false — so no
+  // concurrent test can observe the window.) Production semantics are
+  // untouched: this is an owner-only ALTER on the throwaway test database,
+  // not a change to the trigger itself.
+  await testClient`ALTER TABLE audit_logs DISABLE TRIGGER audit_log_block_truncate`;
+  try {
+    for (const table of tables) {
+      try {
+        await testClient`TRUNCATE TABLE ${testClient(table)} CASCADE`;
+      } catch (error) {
+        // The only benign failure is the table not existing yet (42P01) on a
+        // branch that predates its migration. Anything else means the DB was
+        // NOT reset — fail loudly instead of letting state leak into the next
+        // test (the silent-swallow variant of this loop is how #2205 stayed
+        // hidden).
+        if (isUndefinedTableError(error)) continue;
+        throw new Error(
+          `cleanupDatabase: TRUNCATE ${table} CASCADE failed — the database was not reset. ` +
+          `Failing loudly so leaked tenant state cannot poison later tests (#2205).`,
+          { cause: error }
+        );
+      }
     }
+  } finally {
+    await testClient`ALTER TABLE audit_logs ENABLE TRIGGER audit_log_block_truncate`;
   }
 
   // Clear Redis

--- a/apps/api/src/services/inboundEmail/inboundEmail.integration.test.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmail.integration.test.ts
@@ -186,11 +186,13 @@ afterAll(async () => {
   await db.delete(portalUsers).where(sql`${portalUsers.orgId} IN (${orgList})`);
   await db.delete(partnerInboundDomains).where(sql`${partnerInboundDomains.partnerId} IN (${partnerList})`);
   await db.execute(sql`DELETE FROM partner_ticket_sequences WHERE partner_id IN (${partnerList})`);
-  // audit_logs is append-only (BEFORE DELETE / BEFORE TRUNCATE triggers raise),
-  // so setup.ts's TRUNCATE-CASCADE silently no-ops on it and createTicket's
-  // ticket.create rows survive, FK-blocking the org delete. Drop the triggers for
-  // this one DELETE via session_replication_role=replica (same approach as the
-  // audit-logs-rls flakiness fix), scoped to the seeded orgs. Run inside a single
+  // audit_logs is only reset by setup.ts's global beforeEach (which since
+  // #2205 genuinely truncates it) — but beforeEach never runs after this
+  // file's LAST test, so createTicket's ticket.create rows are still present
+  // at afterAll time, FK-blocking the org delete. audit_logs is append-only
+  // (BEFORE DELETE trigger raises), so drop the triggers for this one DELETE
+  // via session_replication_role=replica (same approach as the audit-logs-rls
+  // flakiness fix), scoped to the seeded orgs. Run inside a single
   // transaction so the SET and the DELETE land on the SAME pooled connection.
   await db.transaction(async (tx: any) => {
     await tx.execute(sql`SET LOCAL session_replication_role = replica`);


### PR DESCRIPTION
## Summary

`cleanupDatabase()` (integration-test setup) claimed to TRUNCATE the tenant-root tables per test, but the statement never succeeded for any table whose CASCADE set reaches `audit_logs`: its `audit_log_block_truncate` trigger (migration `2026-05-25-k`) unconditionally rejects ANY truncate touching the table — the append-only bypass GUC (`breeze.allow_audit_retention`) only exists for DELETE. The blanket per-table `try/catch` swallowed the failure, so `partners`/`organizations`/`users`/`audit_logs` rows silently accumulated across every suite in an integration run. Surfaced twice by the #2202 `loginContext` suite (the first to assert on global partner state).

This implements **option 1** from the issue: move the trigger-aware truncate into `cleanupDatabase()` itself, and stop swallowing failures.

## Changes

- **`setup.ts`** — disable the `audit_logs` BEFORE TRUNCATE trigger around the truncate loop, re-enable in a `finally` (a failed truncate can never leave the append-only guard off). Only undefined-table (`42P01`) errors are still tolerated; any other truncate failure now throws loudly with the table name and `#2205` context instead of leaking state into the next test. Prod semantics untouched — this is an owner-only ALTER on the throwaway test DB, not a trigger/migration change.
- **`loginContext.integration.test.ts`** — removed the suite-local trigger-aware truncate workaround (now redundant) and updated the header comment.
- **`oauth-introspection.integration.test.ts`** — the one suite that depended on the broken behavior: it minted victim/attacker OAuth fixtures in `beforeAll`, which a now-working truncate wipes before every test (the `oauth_*` tables FK to `partners`/`users`, so TRUNCATE CASCADE clears them table-wide). Fixtures now mint per-test in `beforeEach`; without this, client auth would 401 and the cross-client assertions would go vacuous.
- **`cleanupDatabase.integration.test.ts`** (new) — regression proof: seeds a partner + org + audit row (forcing the cascade to reach `audit_logs`), runs `cleanupDatabase()`, asserts global zero rows in `partners`/`organizations`/`audit_logs`; and separately asserts the append-only TRUNCATE guard is re-enabled (both in `pg_trigger` and functionally) after cleanup.

## Depends-on-broken-behavior audit

Audited every suite hooked to `setup.ts` (163 files in `__tests__/integration/` + co-located `src/services|jobs` integration tests): `oauth-introspection` was the only suite seeding DB fixtures in `beforeAll` — all other `beforeAll` usages boot live servers or alter roles, and every other suite seeds per-test. The other `BEFORE TRUNCATE` trigger candidate (`ml_feedback_events`) blocks only UPDATE/DELETE row-level, so it does not block the cascade.

## Verification (local, real DB on :5433)

- `cleanupDatabase.integration.test.ts` + `loginContext.integration.test.ts`: **7 passed**
- `oauth-introspection.integration.test.ts`: **4 passed**
- `audit-append-only` + `auditRetentionPrivSep` + `silent-write-contract`: **7 passed**
- `catalog-rls` + `oauth-code-flow` + `reliabilityScoringProjection` + `approval-system-scope` + `org-scope-narrowing`: **26 passed**
- `tsc --noEmit` clean

Closes #2205

🤖 Generated with [Claude Code](https://claude.com/claude-code)