### PR TITLE
fix(installer): Windows filename-bootstrap token lost when server URL has a nonstandard port (#2341)

### DIFF
--- a/agent/internal/agentapp/bootstrap.go
+++ b/agent/internal/agentapp/bootstrap.go
@@ -31,8 +31,12 @@ type bootstrapResult struct {
 
 // resolveBootstrapInputs decides which token/server to use. Property token +
 // server take precedence (explicit silent-install intent); otherwise the
-// [TOKEN@HOST] in the installer filename is used, with the host promoted to an
-// https:// server URL. Mirrors the macOS payload-then-filename precedence.
+// [TOKEN@HOST] in the installer filename is used, with the host (which may
+// carry a decoded `host:port`) promoted to an https:// server URL. The
+// promotion is unconditionally https — the server refuses to emit a
+// filename-token download for a non-https URL, so an http-only server never
+// reaches this path (#2341). Mirrors the macOS payload-then-filename
+// precedence.
 func resolveBootstrapInputs(data string) (token, server string, err error) {
 	parts := strings.SplitN(data, "|", 3)
 	var installerPath, propToken, propServer string

--- a/agent/internal/agentapp/bootstrap.go
+++ b/agent/internal/agentapp/bootstrap.go
@@ -33,10 +33,11 @@ type bootstrapResult struct {
 // server take precedence (explicit silent-install intent); otherwise the
 // [TOKEN@HOST] in the installer filename is used, with the host (which may
 // carry a decoded `host:port`) promoted to an https:// server URL. The
-// promotion is unconditionally https — the server refuses to emit a
-// filename-token download for a non-https URL, so an http-only server never
-// reaches this path (#2341). Mirrors the macOS payload-then-filename
-// precedence.
+// promotion is unconditionally https; servers running the #2341 fix refuse
+// to emit a filename-token download for a non-https URL, but an MSI from an
+// older self-hosted server may still embed an http-only host — redemption
+// then fails loudly (install rollback), never silently. Mirrors the macOS
+// payload-then-filename precedence.
 func resolveBootstrapInputs(data string) (token, server string, err error) {
 	parts := strings.SplitN(data, "|", 3)
 	var installerPath, propToken, propServer string

--- a/agent/internal/agentapp/bootstrap_test.go
+++ b/agent/internal/agentapp/bootstrap_test.go
@@ -30,6 +30,15 @@ func TestResolveBootstrapInputs(t *testing.T) {
 			wantServer: "https://us.2breeze.app",
 		},
 		{
+			// Self-hosted server on a nonstandard port (#2341): the filename
+			// carries `host_8443` (Windows filenames cannot contain `:`) and the
+			// resolved server URL must come back as https://host:8443.
+			name:       "paren filename token with encoded port",
+			data:       `C:\Users\me\Downloads\Breeze Agent (6KE9MDUG56@rmm.acme.example_8443).msi||`,
+			wantToken:  "6KE9MDUG56",
+			wantServer: "https://rmm.acme.example:8443",
+		},
+		{
 			name:       "property token + server wins over filename",
 			data:       `C:\dl\Breeze Agent [ABCDE12345@eu.2breeze.app].msi|ZZZZZ99999|https://us.2breeze.app`,
 			wantToken:  "ZZZZZ99999",

--- a/agent/internal/agentapp/installer_filename.go
+++ b/agent/internal/agentapp/installer_filename.go
@@ -17,7 +17,15 @@ var errNoFilenameToken = errors.New("no bootstrap token in installer filename")
 // substring (brackets are that engine's property-reference delimiter) gets
 // stripped along the way, silently dropping the token (observed in #1956).
 // Parens are not special in MSI Formatted fields, so they survive intact.
-var installerTokenParenRe = regexp.MustCompile(`\(([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\)`)
+//
+// A nonstandard server port is carried as an optional `_PORT` suffix
+// (HOST_8443), because `:` is illegal in Windows filenames — Chrome rewrites
+// it to `_` at save time, which used to make the whole match fail and the
+// install silently skip enrollment (#2341). Underscore never appears in a
+// hostname, so the suffix is unambiguous, and since it equals Chrome's
+// sanitization of the old `host:port` form, files downloaded from older
+// servers parse the same way.
+var installerTokenParenRe = regexp.MustCompile(`\(([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)(?:_([0-9]{1,5}))?\)`)
 
 // installerTokenBracketRe is the legacy form: [TOKEN@HOST] in square brackets
 // (mirrors FilenameTokenParser.swift). The current macOS path carries the token
@@ -25,18 +33,23 @@ var installerTokenParenRe = regexp.MustCompile(`\(([A-Z0-9]{10})@([a-zA-Z0-9.\-]
 // bundle name only appears under the opt-in MACOS_INSTALLER_FILENAME_TOKEN_COMPAT
 // mode. Neither macOS path passes through MSI formatting, so brackets are safe
 // there. Still accepted here for backward compatibility with older downloads.
-var installerTokenBracketRe = regexp.MustCompile(`\[([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\]`)
+var installerTokenBracketRe = regexp.MustCompile(`\[([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)(?:_([0-9]{1,5}))?\]`)
 
 // parseInstallerFilenameToken extracts the bootstrap token and API host from an
 // installer path or basename. It searches anywhere in the string, so a browser
 // "(1)" dedup suffix or a full path does not break matching. The paren form is
 // tried first (canonical Windows); the bracket form is the legacy/macOS
 // fallback. The host charset excludes spaces and the delimiter characters, so a
-// trailing " (1)" dedup suffix can never be folded into a match.
+// trailing " (1)" dedup suffix can never be folded into a match. An optional
+// `_PORT` suffix is decoded back to `host:port` (see installerTokenParenRe).
 func parseInstallerFilenameToken(name string) (token string, host string, err error) {
 	for _, re := range []*regexp.Regexp{installerTokenParenRe, installerTokenBracketRe} {
 		if m := re.FindStringSubmatch(name); m != nil {
-			return m[1], m[2], nil
+			host = m[2]
+			if m[3] != "" {
+				host += ":" + m[3]
+			}
+			return m[1], host, nil
 		}
 	}
 	return "", "", errNoFilenameToken

--- a/agent/internal/agentapp/installer_filename.go
+++ b/agent/internal/agentapp/installer_filename.go
@@ -19,12 +19,12 @@ var errNoFilenameToken = errors.New("no bootstrap token in installer filename")
 // Parens are not special in MSI Formatted fields, so they survive intact.
 //
 // A nonstandard server port is carried as an optional `_PORT` suffix
-// (HOST_8443), because `:` is illegal in Windows filenames — Chrome rewrites
-// it to `_` at save time, which used to make the whole match fail and the
-// install silently skip enrollment (#2341). Underscore never appears in a
-// hostname, so the suffix is unambiguous, and since it equals Chrome's
-// sanitization of the old `host:port` form, files downloaded from older
-// servers parse the same way.
+// (HOST_8443), because `:` is illegal in Windows filenames — Chromium-based
+// browsers rewrite it to `_` at save time, which used to make the whole match
+// fail and the install silently skip enrollment (#2341). Underscore never
+// appears in a hostname, so the suffix is unambiguous, and since it equals
+// the Chromium sanitization of the old `host:port` form, files downloaded
+// from older servers parse the same way.
 var installerTokenParenRe = regexp.MustCompile(`\(([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)(?:_([0-9]{1,5}))?\)`)
 
 // installerTokenBracketRe is the legacy form: [TOKEN@HOST] in square brackets

--- a/agent/internal/agentapp/installer_filename_test.go
+++ b/agent/internal/agentapp/installer_filename_test.go
@@ -20,11 +20,24 @@ func TestParseInstallerFilenameToken(t *testing.T) {
 		{"paren host with hyphen", "Breeze Agent (ABCDE12345@my-rmm.example).msi", "ABCDE12345", "my-rmm.example", false},
 		{"paren token too short", "Breeze Agent (ABCDE1234@host).msi", "", "", true},
 		{"paren token lowercase", "Breeze Agent (abcde12345@host).msi", "", "", true},
+		// _PORT suffix — nonstandard self-hosted port carried in the filename
+		// (issue #2341). `:` is illegal in Windows filenames, so the server
+		// encodes `host:8443` as `host_8443`; the parser reconstructs it.
+		{"paren host with port", "Breeze Agent (ABCDE12345@my-rmm.example_8443).msi", "ABCDE12345", "my-rmm.example:8443", false},
+		{"paren host with port dup suffix", "Breeze Agent (ABCDE12345@my-rmm.example_8443) (1).msi", "ABCDE12345", "my-rmm.example:8443", false},
+		{"paren host with port full path", `C:\Users\me\Downloads\Breeze Agent (6KE9MDUG56@rmm.acme.example_8443).msi`, "6KE9MDUG56", "rmm.acme.example:8443", false},
+		// Chrome-sanitized download from a pre-fix server that emitted
+		// `host:8443` in Content-Disposition: the browser substitutes `_` for
+		// the illegal `:`, which is exactly the encoded form — must parse.
+		{"paren chrome-sanitized legacy colon", "Breeze Agent (ABCDE12345@self-hosted.example_9443).msi", "ABCDE12345", "self-hosted.example:9443", false},
+		{"paren port too long", "Breeze Agent (ABCDE12345@host_123456).msi", "", "", true},
+		{"paren underscore non-numeric suffix", "Breeze Agent (ABCDE12345@host_evil).msi", "", "", true},
 		// Bracket form — legacy / macOS (.app bundle name). Still accepted.
 		{"bracket clean", "Breeze Agent [ABCDE12345@eu.2breeze.app].msi", "ABCDE12345", "eu.2breeze.app", false},
 		{"bracket browser dup suffix", "Breeze Agent [ABCDE12345@us.2breeze.app] (1).msi", "ABCDE12345", "us.2breeze.app", false},
 		{"bracket full path", `C:\Users\me\Downloads\Breeze Agent [Z9Y8X7W6V5@host.example.com].msi`, "Z9Y8X7W6V5", "host.example.com", false},
 		{"bracket host with hyphen", "Breeze Agent [ABCDE12345@my-rmm.example].msi", "ABCDE12345", "my-rmm.example", false},
+		{"bracket host with port", "Breeze Agent [ABCDE12345@my-rmm.example_8443].msi", "ABCDE12345", "my-rmm.example:8443", false},
 		{"no delimiter", "breeze-agent.msi", "", "", true},
 		{"bracket token too short", "Breeze Agent [ABCDE1234@host].msi", "", "", true},
 		{"bracket token lowercase", "Breeze Agent [abcde12345@host].msi", "", "", true},

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -928,6 +928,84 @@ describe("GET /public-download/:platform", () => {
     issueSpy.mockRestore();
   });
 
+  it("public windows download encodes a nonstandard port as host_PORT in the filename (#2341)", async () => {
+    // `:` is illegal in Windows filenames — the browser rewrites it at save
+    // time and the agent-side parser never matches, so the device installs
+    // unenrolled with no visible error. The port must ride as `_PORT`.
+    process.env.PUBLIC_API_URL = "https://self-hosted.example.com:8443";
+    const row = makeKeyRow({
+      shortCode: "pubcode1234",
+      installerPlatform: "windows",
+      maxUsage: 1,
+      usageCount: 0,
+    });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([row]),
+        }),
+      }),
+    } as any);
+
+    const issueSpy = vi
+      .spyOn(installerBootstrapTokenIssuance, "issueBootstrapTokenForKey")
+      .mockResolvedValueOnce({
+        id: "btok-1",
+        token: "ABCDE12345",
+        expiresAt: new Date(Date.now() + 3_600_000),
+        parentKeyName: "Test Key",
+      });
+
+    const res = await app.request(
+      `/enrollment-keys/public-download/windows?h=dlh_${"1".repeat(32)}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Disposition")).toBe(
+      'attachment; filename="Breeze Agent (ABCDE12345@self-hosted.example.com_8443).msi"',
+    );
+
+    issueSpy.mockRestore();
+  });
+
+  it("public windows download returns 400 for a non-https server URL without burning a token (#2341)", async () => {
+    // The agent always redeems the filename token over https, so an
+    // http-only server can never enroll through this path — fail the
+    // download with the reason instead of serving a dead MSI.
+    process.env.PUBLIC_API_URL = "http://self-hosted.example.com:8080";
+    const row = makeKeyRow({
+      shortCode: "pubcode1234",
+      installerPlatform: "windows",
+      maxUsage: 1,
+      usageCount: 0,
+    });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([row]),
+        }),
+      }),
+    } as any);
+
+    const issueSpy = vi.spyOn(
+      installerBootstrapTokenIssuance,
+      "issueBootstrapTokenForKey",
+    );
+
+    const res = await app.request(
+      `/enrollment-keys/public-download/windows?h=dlh_${"1".repeat(32)}`,
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/https/i);
+    expect(issueSpy).not.toHaveBeenCalled();
+
+    issueSpy.mockRestore();
+  });
+
   it("rejects legacy raw token query downloads by default", async () => {
     const res = await app.request(
       `/enrollment-keys/public-download/windows?token=${"a".repeat(64)}`,
@@ -1472,6 +1550,57 @@ describe("GET /:id/installer/macos — app-bundle path", () => {
     expect(res.headers.get("Content-Disposition")).toContain(
       "breeze-agent-macos.zip",
     );
+    expect(vi.mocked(renameAppInZip)).not.toHaveBeenCalled();
+    expect(issueSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to legacy zip for a nonstandard-port server URL even when the app asset exists (#2341)", async () => {
+    // The app-bundle installer's Swift-side parser accepts only a bare https
+    // host — no port form — so a ported self-hosted server could hand out a
+    // bundle that can never enroll. The route must skip the app-bundle path
+    // entirely (never even fetch the asset) and serve the legacy zip, which
+    // embeds the full server URL.
+    process.env.PUBLIC_API_URL = "https://self-hosted.example.com:8443";
+    const parentRow = makeKeyRow();
+    const childRow = makeChildKeyRow({ installerPlatform: "macos" });
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([parentRow]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as any);
+
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([childRow]),
+      }),
+    } as any);
+
+    // The asset IS available — the gate must short-circuit before fetching it.
+    vi.mocked(fetchMacosInstallerAppZip).mockResolvedValueOnce(
+      Buffer.from("fixture-app-zip"),
+    );
+
+    const res = await app.request(
+      `/enrollment-keys/${KEY_ID}/installer/macos?count=1`,
+      { headers: { authorization: "Bearer jwt" } },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Disposition")).toContain(
+      "breeze-agent-macos.zip",
+    );
+    expect(vi.mocked(fetchMacosInstallerAppZip)).not.toHaveBeenCalled();
     expect(vi.mocked(renameAppInZip)).not.toHaveBeenCalled();
     expect(issueSpy).not.toHaveBeenCalled();
   });

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -32,6 +32,11 @@ import {
 } from "../services/installerBuilder";
 import { renameAppInZip } from "../services/installerAppZip";
 import {
+  InstallerFilenameHostError,
+  macosBundleApiHost,
+  windowsFilenameApiHost,
+} from "../services/installerFilenameHost";
+import {
   issueBootstrapTokenForKey,
   BootstrapTokenIssuanceError,
 } from "../services/installerBootstrapTokenIssuance";
@@ -1048,9 +1053,17 @@ enrollmentKeyRoutes.get(
     // ----------------------------------------------------------------
     if (platform === "macos") {
       const wantLegacy = c.req.query("legacy") === "1";
-      const appZip = wantLegacy ? null : await fetchMacosInstallerAppZip();
+      // The app-bundle installer carries the API host in its bundle filename /
+      // bootstrap.json, and the installer app only accepts a bare https host —
+      // no port, no scheme (FilenameTokenParser.swift). A self-hosted server
+      // on a nonstandard port could download the bundle but never enroll
+      // through it (#2341), so fall through to the legacy zip below, which
+      // embeds the full server URL.
+      const bundleApiHost = macosBundleApiHost(serverUrl);
+      const appZip =
+        wantLegacy || !bundleApiHost ? null : await fetchMacosInstallerAppZip();
 
-      if (appZip) {
+      if (appZip && bundleApiHost) {
         // New path — bootstrap token + renamed app zip. No child enrollment key
         // is created here; the bootstrap endpoint creates it lazily on consume.
         let issued;
@@ -1069,10 +1082,9 @@ enrollmentKeyRoutes.get(
           throw err;
         }
 
-        const apiHost = new URL(serverUrl).host;
         const useLegacyFilenameToken = allowLegacyMacosInstallerFilenameToken();
         const newAppName = useLegacyFilenameToken
-          ? `Breeze Installer [${issued.token}@${apiHost}].app`
+          ? `Breeze Installer [${issued.token}@${bundleApiHost}].app`
           : "Breeze Installer.app";
         const bootstrapPayloadName = "Breeze Installer.bootstrap.json";
 
@@ -1087,7 +1099,10 @@ enrollmentKeyRoutes.get(
                   extraFiles: [
                     {
                       path: bootstrapPayloadName,
-                      data: JSON.stringify({ token: issued.token, apiHost }),
+                      data: JSON.stringify({
+                        token: issued.token,
+                        apiHost: bundleApiHost,
+                      }),
                       mode: 0o600,
                     },
                   ],
@@ -1142,6 +1157,20 @@ enrollmentKeyRoutes.get(
     // mints the child key lazily on consume (mirrors the macOS path above).
     // ----------------------------------------------------------------
     if (platform === "windows") {
+      // Encode the filename host BEFORE issuing a bootstrap token, so a URL
+      // that can never enroll (non-https, host not expressible in a Windows
+      // filename) fails loudly with the reason instead of serving an MSI
+      // that silently installs unenrolled — and doesn't burn a token (#2341).
+      let apiHost: string;
+      try {
+        apiHost = windowsFilenameApiHost(serverUrl);
+      } catch (err) {
+        if (err instanceof InstallerFilenameHostError) {
+          return c.json({ error: err.message }, 400);
+        }
+        throw err;
+      }
+
       let issued;
       try {
         issued = await issueBootstrapTokenForKey({
@@ -1166,8 +1195,6 @@ enrollmentKeyRoutes.get(
         console.error("[installer] failed to fetch signed MSI:", err);
         return c.json({ error: "MSI not available" }, 503);
       }
-
-      const apiHost = new URL(serverUrl).host;
 
       writeEnrollmentKeyAudit(c, auth, {
         orgId: parentKey.orgId,
@@ -1760,6 +1787,20 @@ async function serveInstaller(
   // No per-customer signing and no child key created here.
   // ----------------------------------------------------------------
   if (platform === "windows") {
+    // Encode the filename host BEFORE issuing a bootstrap token, so a URL
+    // that can never enroll (non-https, host not expressible in a Windows
+    // filename) fails loudly with the reason instead of serving an MSI
+    // that silently installs unenrolled — and doesn't burn a token (#2341).
+    let apiHost: string;
+    try {
+      apiHost = windowsFilenameApiHost(serverUrl);
+    } catch (err) {
+      if (err instanceof InstallerFilenameHostError) {
+        return c.json({ error: err.message }, 400);
+      }
+      throw err;
+    }
+
     let issued;
     try {
       issued = await issueBootstrapTokenForKey({
@@ -1787,8 +1828,6 @@ async function serveInstaller(
       console.error("[public-download] Failed to fetch MSI:", err);
       return c.json({ error: "MSI not available" }, 503);
     }
-
-    const apiHost = new URL(serverUrl).host;
 
     createAuditLogAsync({
       orgId: keyRow.orgId,

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -1051,6 +1051,17 @@ enrollmentKeyRoutes.get(
     //   (a) caller passed ?legacy=1, OR
     //   (b) the installer-app asset is not yet published on GitHub.
     // ----------------------------------------------------------------
+    // Why a macOS download fell through to the legacy zip — recorded in the
+    // legacy path's audit details so operators can tell "working as designed"
+    // (explicit-legacy, nonstandard-host) from an asset-pipeline regression
+    // (asset-unavailable, rename-failed).
+    let macosLegacyFallbackReason:
+      | "explicit-legacy"
+      | "nonstandard-host"
+      | "asset-unavailable"
+      | "rename-failed"
+      | null = null;
+
     if (platform === "macos") {
       const wantLegacy = c.req.query("legacy") === "1";
       // The app-bundle installer carries the API host in its bundle filename /
@@ -1060,8 +1071,17 @@ enrollmentKeyRoutes.get(
       // through it (#2341), so fall through to the legacy zip below, which
       // embeds the full server URL.
       const bundleApiHost = macosBundleApiHost(serverUrl);
-      const appZip =
-        wantLegacy || !bundleApiHost ? null : await fetchMacosInstallerAppZip();
+      if (wantLegacy) {
+        macosLegacyFallbackReason = "explicit-legacy";
+      } else if (!bundleApiHost) {
+        macosLegacyFallbackReason = "nonstandard-host";
+      }
+      const appZip = macosLegacyFallbackReason
+        ? null
+        : await fetchMacosInstallerAppZip();
+      if (!appZip && !macosLegacyFallbackReason) {
+        macosLegacyFallbackReason = "asset-unavailable";
+      }
 
       if (appZip && bundleApiHost) {
         // New path — bootstrap token + renamed app zip. No child enrollment key
@@ -1117,6 +1137,11 @@ enrollmentKeyRoutes.get(
               error: err instanceof Error ? err.message : String(err),
             },
           );
+          // The fallback still hands the user a working installer, so without
+          // a Sentry event a systemic rename regression (e.g. a corrupted
+          // release asset) would be invisible until someone reads raw logs.
+          captureException(err, c);
+          macosLegacyFallbackReason = "rename-failed";
           // Fall through to legacy path — do NOT return.
         }
 
@@ -1193,8 +1218,18 @@ enrollmentKeyRoutes.get(
         msi = await fetchRegularMsi();
       } catch (err) {
         console.error("[installer] failed to fetch signed MSI:", err);
+        captureException(err, c);
         return c.json({ error: "MSI not available" }, 503);
       }
+
+      // Build the response BEFORE the audit write — serveWindowsBootstrapMsi
+      // throws on a non-encoded host (defense in depth, #2341), and the audit
+      // trail must not record a download that never happened.
+      const response = serveWindowsBootstrapMsi(c, {
+        msi,
+        token: issued.token,
+        apiHost,
+      });
 
       writeEnrollmentKeyAudit(c, auth, {
         orgId: parentKey.orgId,
@@ -1209,7 +1244,7 @@ enrollmentKeyRoutes.get(
         },
       });
 
-      return serveWindowsBootstrapMsi(c, { msi, token: issued.token, apiHost });
+      return response;
     }
 
     // Signing-spend cap — enforce BEFORE child key creation or any signing
@@ -1317,6 +1352,9 @@ enrollmentKeyRoutes.get(
           childKeyId: childKey.id,
           shortCode,
           count: childMaxUsage,
+          ...(macosLegacyFallbackReason
+            ? { fallbackReason: macosLegacyFallbackReason }
+            : {}),
         },
       });
 
@@ -1826,8 +1864,18 @@ async function serveInstaller(
       msi = await fetchRegularMsi();
     } catch (err) {
       console.error("[public-download] Failed to fetch MSI:", err);
+      captureException(err, c);
       return c.json({ error: "MSI not available" }, 503);
     }
+
+    // Build the response BEFORE the audit write — serveWindowsBootstrapMsi
+    // throws on a non-encoded host (defense in depth, #2341), and the audit
+    // trail must not record a download that never happened.
+    const response = serveWindowsBootstrapMsi(c, {
+      msi,
+      token: issued.token,
+      apiHost,
+    });
 
     createAuditLogAsync({
       orgId: keyRow.orgId,
@@ -1842,7 +1890,7 @@ async function serveInstaller(
       result: "success",
     });
 
-    return serveWindowsBootstrapMsi(c, { msi, token: issued.token, apiHost });
+    return response;
   }
 
   // ----------------------------------------------------------------

--- a/apps/api/src/routes/enrollmentKeys_installer.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_installer.test.ts
@@ -308,6 +308,43 @@ describe('enrollment key routes — installer download', () => {
       expect(body.length).toBeGreaterThan(0);
     });
 
+    it('windows download encodes a nonstandard port as host_PORT in the filename (#2341)', async () => {
+      // `:` is illegal in Windows filenames — the browser rewrites it at save
+      // time and the agent-side parser never matches, so the device installs
+      // unenrolled with no visible error. The port must ride as `_PORT`.
+      process.env.PUBLIC_API_URL = 'https://self-hosted.example.com:8443';
+      mockSelectFromWhereLimit([makeEnrollmentKey()]);
+
+      const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-disposition')).toBe(
+        'attachment; filename="Breeze Agent (ABCDE12345@self-hosted.example.com_8443).msi"',
+      );
+    });
+
+    it('windows download returns 400 for a non-https server URL without burning a token (#2341)', async () => {
+      // The agent always redeems the filename token over https, so an
+      // http-only server can never enroll through this path — fail the
+      // download with the reason instead of serving a dead MSI.
+      process.env.PUBLIC_API_URL = 'http://self-hosted.example.com:8080';
+      mockSelectFromWhereLimit([makeEnrollmentKey()]);
+
+      const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/https/i);
+      expect(body.error).toMatch(/SERVER_URL and ENROLLMENT_KEY/);
+      expect(issueBootstrapTokenForKey).not.toHaveBeenCalled();
+    });
+
     it('windows bootstrap download does not create a child enrollment key', async () => {
       // Windows early-returns after issueBootstrapTokenForKey — no db.insert for a child key.
       mockSelectFromWhereLimit([makeEnrollmentKey()]);

--- a/apps/api/src/services/installerBuilder.test.ts
+++ b/apps/api/src/services/installerBuilder.test.ts
@@ -386,6 +386,36 @@ describe('serveWindowsBootstrapMsi', () => {
     expect(cd).not.toContain(']');
   });
 
+  it('carries a nonstandard port as host_PORT, never host:port (#2341)', () => {
+    // `:` is illegal in Windows filenames — the browser rewrites it at save
+    // time and the agent parser then never matches, so the device installs
+    // unenrolled with no visible error. The port rides as `_PORT` instead.
+    const { c, headers } = fakeContext();
+    serveWindowsBootstrapMsi(c, {
+      msi: Buffer.from('signed-msi-bytes'),
+      token: 'ABCDE12345',
+      apiHost: 'rmm.example.com_8443',
+    });
+
+    expect(headers.get('content-disposition')).toBe(
+      'attachment; filename="Breeze Agent (ABCDE12345@rmm.example.com_8443).msi"',
+    );
+  });
+
+  it('rejects an apiHost that is not Windows-filename-safe (#2341)', () => {
+    // Defense-in-depth: callers encode via windowsFilenameApiHost(), but a
+    // raw `host:port` reaching this point must throw rather than serve an
+    // MSI whose token the agent can never parse back out.
+    const { c } = fakeContext();
+    expect(() =>
+      serveWindowsBootstrapMsi(c, {
+        msi: Buffer.from('signed-msi-bytes'),
+        token: 'ABCDE12345',
+        apiHost: 'rmm.example.com:8443',
+      }),
+    ).toThrow(/not safe for a Windows installer filename/);
+  });
+
   it('serves the MSI bytes unmodified with octet-stream + no-store headers', () => {
     const { c, headers } = fakeContext();
     const msi = Buffer.from('signed-msi-bytes');

--- a/apps/api/src/services/installerBuilder.ts
+++ b/apps/api/src/services/installerBuilder.ts
@@ -13,6 +13,10 @@ import {
   getGithubReleaseRepository,
 } from './binarySource';
 import { verifyGithubReleaseArtifactBuffer } from './releaseArtifactManifest';
+import {
+  InstallerFilenameHostError,
+  isEncodedWindowsFilenameApiHost,
+} from './installerFilenameHost';
 import { isS3Configured } from './s3Storage';
 
 // --- Enrollment key validation ---
@@ -401,11 +405,22 @@ export async function probeMacosInstallerApp(): Promise<boolean> {
  * and never enroll (observed in #1956). Parens are not special in MSI Formatted
  * fields, so they survive. The agent parser (installer_filename.go) accepts
  * both forms; the macOS download carries the token in bootstrap.json instead.
+ *
+ * `apiHost` must already be in the encoded filename form produced by
+ * windowsFilenameApiHost() — `host` or `host_PORT`, never `host:port`. A `:`
+ * is illegal in Windows filenames: the browser rewrites it at save time, the
+ * agent parser stops matching, and the install silently never enrolls
+ * (#2341). Reject outright rather than serve an MSI that cannot enroll.
  */
 export function serveWindowsBootstrapMsi(
   c: Context,
   args: { msi: Buffer; token: string; apiHost: string },
 ): Response {
+  if (!isEncodedWindowsFilenameApiHost(args.apiHost)) {
+    throw new InstallerFilenameHostError(
+      `apiHost "${args.apiHost}" is not safe for a Windows installer filename`,
+    );
+  }
   const filename = `Breeze Agent (${args.token}@${args.apiHost}).msi`;
   c.header('Content-Type', 'application/octet-stream');
   c.header('Content-Disposition', `attachment; filename="${filename}"`);

--- a/apps/api/src/services/installerBuilder.ts
+++ b/apps/api/src/services/installerBuilder.ts
@@ -411,6 +411,10 @@ export async function probeMacosInstallerApp(): Promise<boolean> {
  * is illegal in Windows filenames: the browser rewrites it at save time, the
  * agent parser stops matching, and the install silently never enrolls
  * (#2341). Reject outright rather than serve an MSI that cannot enroll.
+ * Callers pre-validate via windowsFilenameApiHost(), so this throw should be
+ * unreachable; if it ever fires it surfaces through the app's generic
+ * onError handler as a 500 (with Sentry capture), not the friendly 400 the
+ * routes return for an invalid configured URL.
  */
 export function serveWindowsBootstrapMsi(
   c: Context,

--- a/apps/api/src/services/installerFilenameHost.test.ts
+++ b/apps/api/src/services/installerFilenameHost.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  InstallerFilenameHostError,
+  isEncodedWindowsFilenameApiHost,
+  macosBundleApiHost,
+  windowsFilenameApiHost,
+} from "./installerFilenameHost";
+
+describe("windowsFilenameApiHost", () => {
+  it("returns the bare hostname for a standard https URL", () => {
+    expect(windowsFilenameApiHost("https://us.2breeze.app")).toBe(
+      "us.2breeze.app",
+    );
+  });
+
+  it("elides an explicit default port", () => {
+    expect(windowsFilenameApiHost("https://rmm.example.com:443")).toBe(
+      "rmm.example.com",
+    );
+  });
+
+  it("encodes a nonstandard port as host_PORT — never host:port (#2341)", () => {
+    // `:` is illegal in Windows filenames; browsers rewrite it at save time
+    // and the agent-side parser then never matches, so the device installs
+    // unenrolled with no visible error.
+    expect(windowsFilenameApiHost("https://rmm.example.com:8443")).toBe(
+      "rmm.example.com_8443",
+    );
+  });
+
+  it("ignores path/query on the server URL", () => {
+    expect(windowsFilenameApiHost("https://rmm.example.com:8443/api?x=1")).toBe(
+      "rmm.example.com_8443",
+    );
+  });
+
+  it("throws for a non-https scheme (agent redeems over https only)", () => {
+    expect(() => windowsFilenameApiHost("http://rmm.example.com:8080")).toThrow(
+      InstallerFilenameHostError,
+    );
+  });
+
+  it("throws for a bracketed IPv6 host (not expressible in the filename)", () => {
+    expect(() => windowsFilenameApiHost("https://[2001:db8::1]:8443")).toThrow(
+      InstallerFilenameHostError,
+    );
+  });
+
+  it("error message points at the property-based install fallback", () => {
+    expect(() => windowsFilenameApiHost("http://rmm.example.com")).toThrow(
+      /SERVER_URL and ENROLLMENT_KEY/,
+    );
+  });
+});
+
+describe("isEncodedWindowsFilenameApiHost", () => {
+  it("accepts bare hosts and host_PORT", () => {
+    expect(isEncodedWindowsFilenameApiHost("us.2breeze.app")).toBe(true);
+    expect(isEncodedWindowsFilenameApiHost("rmm.example.com_8443")).toBe(true);
+  });
+
+  it("rejects host:port and other unsafe forms", () => {
+    expect(isEncodedWindowsFilenameApiHost("rmm.example.com:8443")).toBe(false);
+    expect(isEncodedWindowsFilenameApiHost("[2001:db8::1]")).toBe(false);
+    expect(isEncodedWindowsFilenameApiHost("host_notaport")).toBe(false);
+    expect(isEncodedWindowsFilenameApiHost("")).toBe(false);
+  });
+});
+
+describe("macosBundleApiHost", () => {
+  it("returns the hostname for a standard https URL", () => {
+    expect(macosBundleApiHost("https://eu.2breeze.app")).toBe("eu.2breeze.app");
+  });
+
+  it("returns null for a nonstandard port (Swift parser has no port form)", () => {
+    expect(macosBundleApiHost("https://rmm.example.com:8443")).toBeNull();
+  });
+
+  it("returns null for non-https schemes", () => {
+    expect(macosBundleApiHost("http://rmm.example.com")).toBeNull();
+  });
+
+  it("returns null for a bracketed IPv6 host", () => {
+    expect(macosBundleApiHost("https://[2001:db8::1]")).toBeNull();
+  });
+});

--- a/apps/api/src/services/installerFilenameHost.ts
+++ b/apps/api/src/services/installerFilenameHost.ts
@@ -5,12 +5,12 @@
  * the download filename — `Breeze Agent (TOKEN@HOST).msi` — and the agent's
  * bootstrap custom action parses it back out. `:` is illegal in Windows
  * filenames, so a raw `URL.host` with a nonstandard port (`host:8443`) gets
- * silently rewritten by the browser at save time (Chrome substitutes `_`),
- * the agent parser stops matching, and the device installs unenrolled with
- * no visible error (#2341).
+ * silently rewritten by the browser at save time (Chromium-based browsers
+ * substitute `_`), the agent parser stops matching, and the device installs
+ * unenrolled with no visible error (#2341).
  *
  * A nonstandard port is therefore carried as `host_PORT` — underscore never
- * appears in a hostname, and it matches Chrome's sanitization of the old
+ * appears in a hostname, and it matches the Chromium sanitization of the old
  * colon form, so files downloaded from pre-fix servers decode identically.
  * The agent-side decoder lives in
  * `agent/internal/agentapp/installer_filename.go`.
@@ -72,11 +72,12 @@ export function isEncodedWindowsFilenameApiHost(apiHost: string): boolean {
  * Host for the macOS app-bundle installer (bundle filename / bootstrap.json
  * payload), or `null` when the server URL is not expressible there.
  *
- * The macOS installer app validates the host against `[A-Za-z0-9.-]+` and
- * promotes it to `https://` (FilenameTokenParser.swift) — it has no port
- * encoding, so a nonstandard port, non-https scheme, or unsafe hostname
- * cannot ride the app-bundle path at all. Callers fall back to the legacy
- * zip installer, which embeds the full server URL and handles all of these.
+ * The macOS installer app validates the host against `[A-Za-z0-9.-]+`
+ * (FilenameTokenParser.swift) and its bootstrap client always talks https
+ * (BootstrapClient.swift) — there is no port encoding, so a nonstandard
+ * port, non-https scheme, or unsafe hostname cannot ride the app-bundle
+ * path at all. Callers fall back to the legacy zip installer, which embeds
+ * the full server URL and handles all of these.
  */
 export function macosBundleApiHost(serverUrl: string): string | null {
   const url = new URL(serverUrl);

--- a/apps/api/src/services/installerFilenameHost.ts
+++ b/apps/api/src/services/installerFilenameHost.ts
@@ -1,0 +1,91 @@
+/**
+ * Encoding of the public API host for installer download filenames.
+ *
+ * The Windows portal-download MSI carries its bootstrap enrollment token in
+ * the download filename — `Breeze Agent (TOKEN@HOST).msi` — and the agent's
+ * bootstrap custom action parses it back out. `:` is illegal in Windows
+ * filenames, so a raw `URL.host` with a nonstandard port (`host:8443`) gets
+ * silently rewritten by the browser at save time (Chrome substitutes `_`),
+ * the agent parser stops matching, and the device installs unenrolled with
+ * no visible error (#2341).
+ *
+ * A nonstandard port is therefore carried as `host_PORT` — underscore never
+ * appears in a hostname, and it matches Chrome's sanitization of the old
+ * colon form, so files downloaded from pre-fix servers decode identically.
+ * The agent-side decoder lives in
+ * `agent/internal/agentapp/installer_filename.go`.
+ *
+ * Kept free of other imports so route tests exercise the real logic without
+ * mocking (`installerBuilder` is mocked wholesale in route tests).
+ */
+
+/** Hostname shapes the agent-side filename parser accepts. */
+const FILENAME_SAFE_HOSTNAME_RE = /^[A-Za-z0-9.-]+$/;
+
+/** Full encoded form as it appears in the filename: `host` or `host_port`. */
+const ENCODED_FILENAME_HOST_RE = /^[A-Za-z0-9.-]+(_\d{1,5})?$/;
+
+/**
+ * The public server URL cannot be carried in an installer download filename
+ * that the agent would be able to redeem. Routes surface the message to the
+ * downloader as a 400.
+ */
+export class InstallerFilenameHostError extends Error {}
+
+/**
+ * Encode the public server URL's host for a Windows filename-token download.
+ * Returns `host` or `host_PORT`.
+ *
+ * Throws {@link InstallerFilenameHostError} when the download could never
+ * enroll: non-https scheme (the agent always promotes the parsed host to
+ * `https://`) or a hostname outside `[A-Za-z0-9.-]` (e.g. bracketed IPv6),
+ * which the agent parser rejects. Callers must fail the download with the
+ * error message instead of serving an MSI that installs unenrolled.
+ */
+export function windowsFilenameApiHost(serverUrl: string): string {
+  const url = new URL(serverUrl);
+  if (url.protocol !== "https:") {
+    throw new InstallerFilenameHostError(
+      "The filename-token installer requires an https server URL — the agent always redeems the token over https. " +
+        "Set an https PUBLIC_API_URL, or install with explicit MSI properties (SERVER_URL and ENROLLMENT_KEY).",
+    );
+  }
+  if (!FILENAME_SAFE_HOSTNAME_RE.test(url.hostname)) {
+    throw new InstallerFilenameHostError(
+      `The server URL host "${url.hostname}" cannot be carried in a Windows installer filename. ` +
+        "Install with explicit MSI properties (SERVER_URL and ENROLLMENT_KEY) instead.",
+    );
+  }
+  return url.port ? `${url.hostname}_${url.port}` : url.hostname;
+}
+
+/**
+ * True when `apiHost` is already in the encoded filename form emitted by
+ * {@link windowsFilenameApiHost}. Used as a defense-in-depth assertion at the
+ * single point that writes the Content-Disposition filename.
+ */
+export function isEncodedWindowsFilenameApiHost(apiHost: string): boolean {
+  return ENCODED_FILENAME_HOST_RE.test(apiHost);
+}
+
+/**
+ * Host for the macOS app-bundle installer (bundle filename / bootstrap.json
+ * payload), or `null` when the server URL is not expressible there.
+ *
+ * The macOS installer app validates the host against `[A-Za-z0-9.-]+` and
+ * promotes it to `https://` (FilenameTokenParser.swift) — it has no port
+ * encoding, so a nonstandard port, non-https scheme, or unsafe hostname
+ * cannot ride the app-bundle path at all. Callers fall back to the legacy
+ * zip installer, which embeds the full server URL and handles all of these.
+ */
+export function macosBundleApiHost(serverUrl: string): string | null {
+  const url = new URL(serverUrl);
+  if (
+    url.protocol !== "https:" ||
+    url.port !== "" ||
+    !FILENAME_SAFE_HOSTNAME_RE.test(url.hostname)
+  ) {
+    return null;
+  }
+  return url.hostname;
+}


### PR DESCRIPTION
Closes #2341

## Problem

The Windows portal-download MSI carries its bootstrap enrollment token in the download filename: `Breeze Agent (TOKEN@HOST).msi`. When a self-hosted deployment's public API URL includes a nonstandard port, the host was built from `new URL(serverUrl).host`, producing `host:8443` — and `:` is illegal in Windows filenames. The browser sanitizes it at save time (Chrome substitutes `_`), the agent's filename parser no longer matches, and the bootstrap custom action soft-exits as "no token present." The MSI reports success and the device silently never enrolls. Hosted (us./eu.) is unaffected.

## Fix

**Windows-safe port encoding, both ends.** The server now emits `Breeze Agent (TOKEN@host_8443).msi` (underscore is never valid in a hostname, and it is exactly the character Chrome substitutes for `:`), and the agent parser accepts an optional `_PORT` suffix in both the paren and bracket forms, reconstructing `https://host:port`. Because the encoding matches Chrome's sanitization, already-downloaded broken files from pre-fix servers start parsing too (once the agent binary carries the new parser).

**Server-side guard.** A new pure helper (`apps/api/src/services/installerFilenameHost.ts`) validates + encodes the host. Both Windows download sites (authenticated `GET /:id/installer/windows` and the shared public `serveInstaller`) run it **before** issuing a bootstrap token, so a URL that can never enroll — non-https scheme (the agent always redeems over https) or a hostname not expressible in a Windows filename (e.g. bracketed IPv6) — fails with a clear 400 pointing at the property-based install (`SERVER_URL` + `ENROLLMENT_KEY`) instead of serving an MSI that installs unenrolled. `serveWindowsBootstrapMsi` additionally rejects any non-encoded host as defense in depth at the single point that writes the Content-Disposition filename.

**macOS app-bundle path.** The Swift-side parser (`FilenameTokenParser.swift`) accepts only a bare https host — no port form — so a ported server could hand out an app bundle that can never enroll. The authenticated macOS branch now falls through to the legacy zip installer (which embeds the full server URL and handles ports fine) whenever the host is not expressible in the bundle.

## Tests

- `agent/internal/agentapp/installer_filename_test.go` — round-trips for `host_PORT` (paren + bracket), Chrome-sanitized legacy-colon downloads, dup-suffix and full-path forms, and rejection of over-long ports / non-numeric underscore suffixes.
- `agent/internal/agentapp/bootstrap_test.go` — encoded-port filename resolves to `https://host:8443`.
- `apps/api/src/services/installerFilenameHost.test.ts` — helper coverage (default-port elision, non-https, IPv6, encoded-form validation, macOS gate).
- `apps/api/src/services/installerBuilder.test.ts` — Content-Disposition assertion for a ported host + guard rejection of `host:port`.
- `apps/api/src/routes/enrollmentKeys_installer.test.ts` — route-level: ported `PUBLIC_API_URL` emits `host_8443` filename; http URL → 400 without burning a bootstrap token.

Verification: `go test -race ./internal/agentapp/...` + `go vet` clean; all five `enrollmentKeys*` vitest files + `installerBuilder` + new helper suite green (142 tests); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)