### PR TITLE
feat(abuse): signup abuse detection — attribution capture, hourly signals sweep, ops alerting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -305,6 +305,12 @@ METRICS_SCRAPE_IP_ALLOWLIST=
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=changeme
 
+# Platform-operator abuse alerts (all optional; unset = feature disabled)
+# OPS_ALERT_WEBHOOK_URL=https://discord.com/api/webhooks/your-webhook
+# OPS_ALERT_EMAIL=ops@your-domain.example.com
+# OPS_ALERT_LABEL=US
+# ABUSE_SIGNAL_OVERRIDES={"rmm.enrollment_velocity.devices_24h": 25}
+
 # --------------------------------------------
 # Application URLs
 # --------------------------------------------

--- a/apps/api/migrations/2026-07-12-signup-attribution-columns.sql
+++ b/apps/api/migrations/2026-07-12-signup-attribution-columns.sql
@@ -1,0 +1,6 @@
+-- Signup/enrollment attribution columns for abuse detection.
+-- Nullable; existing rows stay NULL. Idempotent.
+
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS signup_ip varchar(45);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS signup_user_agent text;
+ALTER TABLE devices ADD COLUMN IF NOT EXISTS enrollment_ip varchar(45);

--- a/apps/api/migrations/2026-07-13-partner-abuse-signals.sql
+++ b/apps/api/migrations/2026-07-13-partner-abuse-signals.sql
@@ -1,0 +1,51 @@
+-- Platform-operator abuse signals about partners. System-scoped: forced RLS
+-- with a system-only policy — partners must never read signals about
+-- themselves. All access via withSystemDbAccessContext. Idempotent.
+
+DO $$ BEGIN
+  CREATE TYPE abuse_signal_severity AS ENUM ('info', 'watch', 'alert');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS partner_abuse_signals (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_id      uuid NOT NULL REFERENCES partners(id) ON DELETE CASCADE,
+  signal_key      varchar(64) NOT NULL,
+  severity        abuse_signal_severity NOT NULL,
+  score           real NOT NULL DEFAULT 0,
+  evidence        jsonb NOT NULL DEFAULT '{}',
+  first_fired_at  timestamptz NOT NULL DEFAULT now(),
+  computed_at     timestamptz NOT NULL DEFAULT now(),
+  resolved_at     timestamptz,
+  acknowledged_at timestamptz,
+  acknowledged_by varchar(255),
+  delivered_at    timestamptz
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS partner_abuse_signals_open_uq
+  ON partner_abuse_signals(partner_id, signal_key)
+  WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS partner_abuse_signals_partner_idx
+  ON partner_abuse_signals(partner_id);
+
+ALTER TABLE partner_abuse_signals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE partner_abuse_signals FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'partner_abuse_signals'
+      AND policyname = 'partner_abuse_signals_system_only'
+  ) THEN
+    EXECUTE $POLICY$
+      CREATE POLICY partner_abuse_signals_system_only
+        ON partner_abuse_signals
+        USING (current_setting('breeze.scope', true) = 'system')
+        WITH CHECK (current_setting('breeze.scope', true) = 'system')
+    $POLICY$;
+  END IF;
+END$$;

--- a/apps/api/src/__tests__/integration/abuseSignalsAggregates.integration.test.ts
+++ b/apps/api/src/__tests__/integration/abuseSignalsAggregates.integration.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Real-DB integration test for `loadPartnerAggregates()` (the abuse-signals
+ * sweep's fleet-grouped aggregation query — apps/api/src/services/abuseSignals/heuristics.ts).
+ *
+ * The heavy lifting here is a hand-written multi-CTE raw SQL query (org →
+ * device joins, an org_id-NULL-attributed audit_logs branch for partner-admin
+ * failed logins, and a three-armed `scoped` CTE deciding which partners get
+ * evaluated at all). None of that is exercised by the mocked unit tests in
+ * heuristics.test.ts, which stub PartnerAggregates directly. This test proves
+ * the SQL itself against real Postgres, including the RLS angle: the query
+ * MUST run inside a system DB context (bare breeze_app reads return 0 rows
+ * under forced RLS) — see the heuristics.ts header comment.
+ */
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { partners, devices, auditLogs, partnerAbuseSignals } from '../../db/schema';
+import { loadPartnerAggregates } from '../../services/abuseSignals/heuristics';
+import { createPartner, createOrganization, createSite, createUser } from './db-utils';
+import { getTestDb } from './setup';
+
+// No manual afterEach cleanup here: `partners` is TRUNCATE ... CASCADE'd by
+// setup.ts's global beforeEach (cleanupDatabase), which transitively
+// truncates every table with a FK back to partners (organizations, users,
+// devices, partner_abuse_signals, ...) — the same isolation mechanism every
+// other integration test in this directory relies on. A manual per-row
+// DELETE would be unsafe here anyway: audit_logs is append-only (DELETE is
+// blocked by a trigger — see 2026-05-25-a-audit-log-append-only.sql) and
+// deleting `partners` directly (no ON DELETE CASCADE from organizations/
+// users at the FK level) would fail with a foreign-key violation.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function consumerHostname(index: number): string {
+  // Matches the sweep's consumer-hostname regex: ^(DESKTOP|LAPTOP)-[A-Z0-9]{7}$
+  return `DESKTOP-AAAA${String(index).padStart(3, '0')}`;
+}
+
+async function seedDevice(opts: { orgId: string; siteId: string; hostname: string; enrollmentIp: string; enrolledAt: Date }) {
+  const testDb = getTestDb();
+  const [device] = await testDb
+    .insert(devices)
+    .values({
+      orgId: opts.orgId,
+      siteId: opts.siteId,
+      agentId: randomUUID(),
+      hostname: opts.hostname,
+      osType: 'windows',
+      osVersion: '11',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'offline',
+      enrollmentIp: opts.enrollmentIp,
+      enrolledAt: opts.enrolledAt,
+    })
+    .returning({ id: devices.id });
+  if (!device) throw new Error('seedDevice: no row returned');
+  return device;
+}
+
+describe('loadPartnerAggregates (real DB)', () => {
+  it('aggregates devices, consumer hostnames, 24h enrollments, 30d distinct enrollment IPs, and 24h failed logins for a young active partner', async () => {
+    const partner = await createPartner({ status: 'active' });
+
+    const now = new Date();
+    const testDb = getTestDb();
+    await testDb
+      .update(partners)
+      .set({
+        createdAt: new Date(now.getTime() - 5 * DAY_MS),
+        emailVerifiedAt: now,
+        paymentMethodAttachedAt: now,
+      })
+      .where(eq(partners.id, partner.id));
+
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org.id });
+
+    for (let i = 1; i <= 6; i += 1) {
+      await seedDevice({
+        orgId: org.id,
+        siteId: site.id,
+        hostname: consumerHostname(i),
+        enrollmentIp: `10.0.0.${i}`,
+        enrolledAt: now,
+      });
+    }
+
+    // Partner-admin login failures land with org_id NULL, attributed to the
+    // partner via the target user's partner_id (audit actor_id -> users.id).
+    const adminUser = await createUser({ partnerId: partner.id });
+    await testDb.insert(auditLogs).values([
+      {
+        orgId: null,
+        actorType: 'user',
+        actorId: adminUser.id,
+        action: 'user.login.failed',
+        resourceType: 'user',
+        resourceId: adminUser.id,
+        result: 'failure',
+        timestamp: now,
+      },
+      {
+        orgId: null,
+        actorType: 'user',
+        actorId: adminUser.id,
+        action: 'user.login.failed',
+        resourceType: 'user',
+        resourceId: adminUser.id,
+        result: 'failure',
+        timestamp: now,
+      },
+    ]);
+
+    const aggregates = await withSystemDbAccessContext(() => loadPartnerAggregates());
+    const row = aggregates.find((a) => a.partnerId === partner.id);
+
+    expect(row).toBeDefined();
+    expect(row!.deviceCount).toBe(6);
+    expect(row!.consumerHostnameCount).toBe(6);
+    expect(row!.enrolled24h).toBe(6);
+    expect(row!.distinctEnrollmentIps30d).toBe(6);
+    expect(row!.failedLogins24h).toBe(2);
+  });
+
+  it("includes an old partner with no recent enrollments when it has an OPEN partner_abuse_signals row (scoped CTE's third OR arm)", async () => {
+    const partner = await createPartner({ status: 'active' });
+
+    const now = new Date();
+    const testDb = getTestDb();
+    await testDb
+      .update(partners)
+      .set({
+        createdAt: new Date(now.getTime() - 200 * DAY_MS),
+        emailVerifiedAt: now,
+        paymentMethodAttachedAt: now,
+      })
+      .where(eq(partners.id, partner.id));
+
+    // No devices, no recent enrollments — this partner would normally fall
+    // outside the `scoped` CTE's young/recently-enrolling window entirely.
+    await withSystemDbAccessContext(() =>
+      db.insert(partnerAbuseSignals).values({
+        partnerId: partner.id,
+        signalKey: 'rmm.enrollment_velocity',
+        severity: 'watch',
+        score: 45,
+        evidence: {},
+      }),
+    );
+
+    const aggregates = await withSystemDbAccessContext(() => loadPartnerAggregates());
+    const row = aggregates.find((a) => a.partnerId === partner.id);
+
+    expect(row).toBeDefined();
+    expect(row!.deviceCount).toBe(0);
+  });
+});

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -4,6 +4,7 @@ import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
 import { partners, users, organizations, sites, invoices, invoiceLines, invoiceDocuments, contracts, contractLines, contractBillingPeriods, mlFeedbackEvents, unifiCollectors, unifiDeviceTelemetry, unifiClients } from '../../db/schema';
 import { approvalRequests } from '../../db/schema/approvals';
 import { manifestSigningKeys } from '../../db/schema/manifestSigningKeys';
+import { partnerAbuseSignals } from '../../db/schema/abuseSignals';
 import { automations, automationRuns } from '../../db/schema/automations';
 import { configurationPolicies } from '../../db/schema/configurationPolicies';
 import { scripts, scriptExecutionBatches } from '../../db/schema/scripts';
@@ -45,6 +46,7 @@ const EXEMPT_TABLES: ReadonlySet<string> = new Set<string>([
   // Forced RLS, no policies → only system context can access. See
   // INTENTIONAL_UNSCOPED below for the documented set.
   'manifest_signing_keys',
+  'partner_abuse_signals',
 ]);
 
 // System-scoped tables: per-deployment infrastructure with no tenant column.
@@ -67,6 +69,7 @@ const INTENTIONAL_UNSCOPED: ReadonlySet<string> = new Set<string>([
   'software_product_resolutions', // Global DisplayName→product resolution cache/log (#2290). Forced RLS, system-only policy → only system context.
   'third_party_package_catalog', // System-wide curated catalog of third-party packages; writes gated by platform-admin role at the route layer.
   'third_party_release_tests', // System-wide release test results; references catalog (unscoped) and is platform-admin-only at the route layer.
+  'partner_abuse_signals', // Operator abuse signals ABOUT partners. Forced RLS, system-only policy — partners must never see their own risk signals.
 ]);
 
 // Tables with org_id metadata that are intentionally not generic org-tenant
@@ -1394,6 +1397,179 @@ describe('manifest_signing_keys RLS — system-only enforcement (#639)', () => {
       expect(result).toHaveLength(1);
       expect(result[0]!.keyId).toBe(keyId);
       insertedKeyIds.push(keyId);
+    },
+  );
+});
+
+// ===========================================================================
+// partner_abuse_signals RLS lockout
+//
+// The catalog test above only proves partner_abuse_signals is in
+// INTENTIONAL_UNSCOPED as documentation. It does NOT prove Postgres rejects
+// a tenant-scoped (non-system) caller's INSERT/SELECT. This block forges
+// both as `breeze_app`, including the specific threat this table exists to
+// prevent: a partner reading abuse signals about ITSELF via a partner-scoped
+// context whose accessiblePartnerIds includes the row's own partner_id. The
+// system-scope branch confirms the write path Tasks 8-10 rely on still works.
+// ===========================================================================
+describe('partner_abuse_signals RLS — system-only enforcement', () => {
+  const runSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const partnerSlug = `rls-abuse-signals-partner-${runSuffix}`;
+
+  let partnerId: string;
+  const insertedSignalIds: string[] = [];
+
+  async function ensureFixtures(): Promise<void> {
+    if (partnerId) return;
+    await withSystemDbAccessContext(async () => {
+      const [partner] = await db
+        .insert(partners)
+        .values({
+          name: `RLS Abuse Signals Partner ${runSuffix}`,
+          slug: partnerSlug,
+          type: 'msp',
+          plan: 'pro',
+          status: 'active',
+        })
+        .returning({ id: partners.id });
+      if (!partner) throw new Error('failed to seed partner for abuse-signals RLS forge test');
+      partnerId = partner.id;
+    });
+  }
+
+  afterAll(async () => {
+    await withSystemDbAccessContext(async () => {
+      for (const id of insertedSignalIds) {
+        await db.delete(partnerAbuseSignals).where(eq(partnerAbuseSignals.id, id));
+      }
+      if (partnerId) await db.delete(partners).where(eq(partners.id, partnerId));
+    });
+  });
+
+  // Build a tenant-scoped (partner) DbAccessContext. Under this context,
+  // breeze_app should be unable to touch partner_abuse_signals — the table
+  // has ENABLE + FORCE RLS and no permissive policies, so only the system
+  // context branch (which bypasses RLS via runOutsideDbContext +
+  // withSystemDbAccessContext) can read/write.
+  function partnerContext(accessiblePartnerId: string) {
+    return {
+      scope: 'partner' as const,
+      orgId: null,
+      accessibleOrgIds: [],
+      accessiblePartnerIds: [accessiblePartnerId],
+      userId: null,
+    };
+  }
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    'INSERT as breeze_app under a tenant (partner-scoped) context is rejected by RLS',
+    async () => {
+      await ensureFixtures();
+
+      let caught: unknown;
+      try {
+        await withDbAccessContext(partnerContext(partnerId), async () =>
+          db.insert(partnerAbuseSignals).values({
+            partnerId,
+            signalKey: `rls-forge-deny-${runSuffix}`,
+            severity: 'watch',
+            score: 1,
+            evidence: {},
+          }),
+        );
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeDefined();
+      const cause = caught as
+        | { cause?: { message?: string }; message?: string }
+        | undefined;
+      const message = cause?.cause?.message ?? cause?.message ?? '';
+      expect(message).toMatch(/row-level security|permission denied/i);
+    },
+  );
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    "SELECT under a partner context matching the row's own partner_id returns zero rows",
+    async () => {
+      await ensureFixtures();
+
+      // Seed a row via system context so there's something the partner
+      // should fail to see — the specific threat this table exists to
+      // prevent: a partner reading abuse signals about itself.
+      const seededSignalKey = `rls-forge-seed-${runSuffix}`;
+      const seeded = await withSystemDbAccessContext(async () => {
+        return db
+          .insert(partnerAbuseSignals)
+          .values({
+            partnerId,
+            signalKey: seededSignalKey,
+            severity: 'alert',
+            score: 5,
+            evidence: { note: 'rls forge seed' },
+          })
+          .returning({ id: partnerAbuseSignals.id });
+      });
+      expect(seeded).toHaveLength(1);
+      insertedSignalIds.push(seeded[0]!.id);
+
+      // Now read under a partner context whose accessiblePartnerIds
+      // includes this exact partner — RLS with no permissive policy means
+      // the SELECT returns 0 rows OR Postgres throws permission denied.
+      let rows: unknown[] = [];
+      let err: unknown = null;
+      try {
+        rows = await withDbAccessContext(partnerContext(partnerId), async () =>
+          db
+            .select({ id: partnerAbuseSignals.id })
+            .from(partnerAbuseSignals)
+            .where(eq(partnerAbuseSignals.partnerId, partnerId)),
+        );
+      } catch (e) {
+        err = e;
+      }
+
+      if (err) {
+        const cause = err as
+          | { cause?: { message?: string }; message?: string };
+        const message = cause?.cause?.message ?? cause?.message ?? '';
+        expect(message).toMatch(/permission denied|row-level security/i);
+      } else {
+        expect(rows).toEqual([]);
+      }
+    },
+  );
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    'withSystemDbAccessContext INSERT + SELECT round-trips successfully',
+    async () => {
+      await ensureFixtures();
+
+      const signalKey = `rls-forge-system-${runSuffix}`;
+      const result = await withSystemDbAccessContext(async () => {
+        return db
+          .insert(partnerAbuseSignals)
+          .values({
+            partnerId,
+            signalKey,
+            severity: 'info',
+            score: 0.5,
+            evidence: { note: 'system round-trip' },
+          })
+          .returning({ id: partnerAbuseSignals.id, signalKey: partnerAbuseSignals.signalKey });
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0]!.signalKey).toBe(signalKey);
+      insertedSignalIds.push(result[0]!.id);
+
+      const readBack = await withSystemDbAccessContext(async () => {
+        return db
+          .select({ id: partnerAbuseSignals.id })
+          .from(partnerAbuseSignals)
+          .where(eq(partnerAbuseSignals.id, result[0]!.id));
+      });
+      expect(readBack).toHaveLength(1);
     },
   );
 });

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -42,16 +42,23 @@ import { unifiIntegrations, unifiDevices } from '../../db/schema/unifi';
 // Tables that intentionally do not carry RLS isolation policies.
 // Add deliberately, with a comment.
 const EXEMPT_TABLES: ReadonlySet<string> = new Set<string>([
-  // System-scoped: per-deployment infrastructure with no tenant column.
-  // Forced RLS, no policies → only system context can access. See
-  // INTENTIONAL_UNSCOPED below for the documented set.
+  // System-scoped: forced RLS with either no policies or a system-only
+  // policy — in both cases only the system DB context can access the table.
+  // See INTENTIONAL_UNSCOPED below for the documented set (some entries,
+  // like partner_abuse_signals, DO have a tenant column but are
+  // operator-only by design, not tenant-column-less).
   'manifest_signing_keys',
   'partner_abuse_signals',
 ]);
 
-// System-scoped tables: per-deployment infrastructure with no tenant column.
-// These have ENABLE + FORCE ROW LEVEL SECURITY but no permissive policies —
-// only the system DB context (superuser / runOutsideDbContext) can access them.
+// System-scoped tables: forced RLS with either no permissive policies at all,
+// or a single system-only policy (`USING current_setting('breeze.scope',
+// true) = 'system'`) — in both cases only the system DB context (which sets
+// that GUC) can read/write, never the unprivileged breeze_app role under a
+// tenant-scoped context. Some of these have no tenant column at all
+// (per-deployment infrastructure); others (partner_abuse_signals) DO carry a
+// tenant column (partner_id) but are deliberately operator-only, not
+// tenant-readable, so they're listed here rather than under a tenant shape.
 // The auto-discovery query won't surface these (no org_id column, not in any
 // tenant list), but they are enumerated here for explicit documentation and
 // so that a future "all-tables RLS enabled" audit can assert against this list.
@@ -1410,7 +1417,8 @@ describe('manifest_signing_keys RLS — system-only enforcement (#639)', () => {
 // both as `breeze_app`, including the specific threat this table exists to
 // prevent: a partner reading abuse signals about ITSELF via a partner-scoped
 // context whose accessiblePartnerIds includes the row's own partner_id. The
-// system-scope branch confirms the write path Tasks 8-10 rely on still works.
+// system-scope branch confirms the abuse-signals sweep write path
+// (services/abuseSignals/persistence.ts) still works.
 // ===========================================================================
 describe('partner_abuse_signals RLS — system-only enforcement', () => {
   const runSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -1448,9 +1456,13 @@ describe('partner_abuse_signals RLS — system-only enforcement', () => {
 
   // Build a tenant-scoped (partner) DbAccessContext. Under this context,
   // breeze_app should be unable to touch partner_abuse_signals — the table
-  // has ENABLE + FORCE RLS and no permissive policies, so only the system
-  // context branch (which bypasses RLS via runOutsideDbContext +
-  // withSystemDbAccessContext) can read/write.
+  // has ENABLE + FORCE RLS and a single system-only policy
+  // (`partner_abuse_signals_system_only`, `USING current_setting
+  // ('breeze.scope', true) = 'system'`), so only a caller whose session has
+  // that GUC set to 'system' can read/write. `withSystemDbAccessContext`
+  // does NOT bypass RLS — it still runs as the unprivileged `breeze_app`
+  // role; it sets `breeze.scope = 'system'`, which is exactly what this
+  // policy checks.
   function partnerContext(accessiblePartnerId: string) {
     return {
       scope: 'partner' as const,

--- a/apps/api/src/db/schema/abuseSignals.ts
+++ b/apps/api/src/db/schema/abuseSignals.ts
@@ -1,0 +1,28 @@
+import { pgTable, uuid, varchar, timestamp, jsonb, pgEnum, real, index, uniqueIndex } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { partners } from './orgs';
+
+export const abuseSignalSeverityEnum = pgEnum('abuse_signal_severity', ['info', 'watch', 'alert']);
+
+// Platform-operator abuse signals ABOUT partners — never visible TO partners.
+// RLS is a system-only policy (see the migration); all reads/writes happen
+// under withSystemDbAccessContext. Do NOT add breeze_has_partner_access
+// policies to this table.
+export const partnerAbuseSignals = pgTable('partner_abuse_signals', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id, { onDelete: 'cascade' }),
+  signalKey: varchar('signal_key', { length: 64 }).notNull(),
+  severity: abuseSignalSeverityEnum('severity').notNull(),
+  score: real('score').notNull().default(0),
+  evidence: jsonb('evidence').notNull().default({}),
+  firstFiredAt: timestamp('first_fired_at', { withTimezone: true }).defaultNow().notNull(),
+  computedAt: timestamp('computed_at', { withTimezone: true }).defaultNow().notNull(),
+  resolvedAt: timestamp('resolved_at', { withTimezone: true }),
+  acknowledgedAt: timestamp('acknowledged_at', { withTimezone: true }),
+  acknowledgedBy: varchar('acknowledged_by', { length: 255 }),
+  deliveredAt: timestamp('delivered_at', { withTimezone: true }),
+}, (t) => [
+  // One OPEN row per (partner, signal); resolved rows keep history.
+  uniqueIndex('partner_abuse_signals_open_uq').on(t.partnerId, t.signalKey).where(sql`resolved_at IS NULL`),
+  index('partner_abuse_signals_partner_idx').on(t.partnerId),
+]);

--- a/apps/api/src/db/schema/devices.ts
+++ b/apps/api/src/db/schema/devices.ts
@@ -44,6 +44,9 @@ export const devices = pgTable('devices', {
   // dedup) and update this column fire-and-forget so the next request can
   // compare.
   lastSeenIp: varchar('last_seen_ip', { length: 45 }),
+  // Public IP the agent enrolled from (point-in-time; lastSeenIp above tracks
+  // the ongoing value). Feeds the abuse-signals sweep's IP-spread heuristics.
+  enrollmentIp: varchar('enrollment_ip', { length: 45 }),
   hostname: varchar('hostname', { length: 255 }).notNull(),
   displayName: varchar('display_name', { length: 255 }),
   osType: osTypeEnum('os_type').notNull(),

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -101,3 +101,4 @@ export * from './onedriveHelper';
 export * from './vulnerabilityManagement';
 export * from './partnerLoginBranding';
 export * from './recoveryKeys';
+export * from './abuseSignals';

--- a/apps/api/src/db/schema/orgs.ts
+++ b/apps/api/src/db/schema/orgs.ts
@@ -32,6 +32,10 @@ export const partners = pgTable('partners', {
   mcpOrigin: boolean('mcp_origin').notNull().default(false),
   mcpOriginIp: text('mcp_origin_ip'),
   mcpOriginUserAgent: text('mcp_origin_user_agent'),
+  // Signup attribution for web registrations (abuse detection). MCP-originated
+  // signups already record mcp_origin_ip/mcp_origin_user_agent above.
+  signupIp: varchar('signup_ip', { length: 45 }),
+  signupUserAgent: text('signup_user_agent'),
   emailVerifiedAt: timestamp('email_verified_at', { withTimezone: true }),
   paymentMethodAttachedAt: timestamp('payment_method_attached_at', { withTimezone: true }),
   stripeCustomerId: text('stripe_customer_id'),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -203,6 +203,7 @@ import { initializeAutomationWorker, shutdownAutomationWorker } from './jobs/aut
 import { initializeSecurityPostureWorker, shutdownSecurityPostureWorker } from './jobs/securityPostureWorker';
 import { initializeReliabilityWorker, shutdownReliabilityWorker } from './jobs/reliabilityWorker';
 import { initializeUserRiskJobs, shutdownUserRiskJobs } from './jobs/userRiskJobs';
+import { initializeAbuseSignalsWorker, shutdownAbuseSignalsWorker } from './jobs/abuseSignalsSweep';
 import { initializeUserRiskRetention, shutdownUserRiskRetention } from './jobs/userRiskRetention';
 import { initializePatchComplianceReportWorker, shutdownPatchComplianceReportWorker } from './jobs/patchComplianceReportWorker';
 import { initializeReportScheduleWorker, shutdownReportScheduleWorker } from './jobs/reportScheduleWorker';
@@ -1150,6 +1151,7 @@ async function initializeWorkers(): Promise<void> {
     ['securityPostureWorker', initializeSecurityPostureWorker],
     ['reliabilityWorker', initializeReliabilityWorker],
     ['userRiskWorker', initializeUserRiskJobs],
+    ['abuseSignalsWorker', initializeAbuseSignalsWorker],
     ['userRiskRetention', initializeUserRiskRetention],
     ['backupVerificationJobs', initializeBackupVerificationJobs],
     ['policyAlertBridge', initializePolicyAlertBridge],
@@ -1362,6 +1364,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownSecurityPostureWorker,
     shutdownReliabilityWorker,
     shutdownUserRiskJobs,
+    shutdownAbuseSignalsWorker,
     shutdownUserRiskRetention,
     shutdownAutomationWorker,
     shutdownSoftwareRemediationWorker,

--- a/apps/api/src/jobs/abuseSignalsSweep.test.ts
+++ b/apps/api/src/jobs/abuseSignalsSweep.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const queueAdd = vi.fn();
+const getRepeatableJobs = vi.fn().mockResolvedValue([
+  { name: 'abuse-sweep', key: 'old-key-1' },
+  { name: 'unrelated', key: 'other' },
+]);
+const removeRepeatableByKey = vi.fn();
+
+vi.mock('bullmq', () => ({
+  // Function expressions (not arrow functions) so `new Queue()` /
+  // `new Worker()` are constructible under vitest's mock implementation
+  // (mirrors the pattern in jobs/peripheralJobs.test.ts).
+  Queue: vi.fn(function QueueMock() {
+    return { add: queueAdd, getRepeatableJobs, removeRepeatableByKey, close: vi.fn() };
+  }),
+  Worker: vi.fn(function WorkerMock() {
+    return { on: vi.fn(), close: vi.fn() };
+  }),
+}));
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
+vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
+vi.mock('../services/abuseSignals', () => ({ runAbuseSweep: vi.fn(), runAbuseDigest: vi.fn() }));
+vi.mock('../services/abuseMetrics', () => ({ recordAbuseSweepRun: vi.fn() }));
+
+import { scheduleAbuseSignalsJobs } from './abuseSignalsSweep';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('scheduleAbuseSignalsJobs', () => {
+  it('clears prior repeatables for its own job names only, then schedules hourly sweep + weekly digest', async () => {
+    getRepeatableJobs.mockResolvedValueOnce([
+      { name: 'abuse-sweep', key: 'stale-sweep' },
+      { name: 'abuse-digest', key: 'stale-digest' },
+      { name: 'unrelated', key: 'other' },
+    ]);
+    await scheduleAbuseSignalsJobs();
+    expect(removeRepeatableByKey).toHaveBeenCalledWith('stale-sweep');
+    expect(removeRepeatableByKey).toHaveBeenCalledWith('stale-digest');
+    expect(removeRepeatableByKey).not.toHaveBeenCalledWith('other');
+    expect(queueAdd).toHaveBeenCalledWith(
+      'abuse-sweep',
+      expect.anything(),
+      expect.objectContaining({ jobId: 'abuse-sweep-repeat', repeat: { every: 60 * 60 * 1000 } }),
+    );
+    expect(queueAdd).toHaveBeenCalledWith(
+      'abuse-digest',
+      expect.anything(),
+      expect.objectContaining({ jobId: 'abuse-digest-repeat', repeat: { pattern: '0 9 * * 1' } }),
+    );
+  });
+});

--- a/apps/api/src/jobs/abuseSignalsSweep.test.ts
+++ b/apps/api/src/jobs/abuseSignalsSweep.test.ts
@@ -77,6 +77,16 @@ describe('abuse signals worker processor', () => {
     expect(recordAbuseSweepRun).toHaveBeenCalledTimes(1);
   });
 
+  it('records an error metric scoped to the sweep job and rethrows when runAbuseSweep rejects', async () => {
+    const sweepError = new Error('sweep blew up');
+    vi.mocked(runAbuseSweep).mockRejectedValueOnce(sweepError);
+    const processor = getProcessor();
+
+    await expect(processor({ name: 'abuse-sweep' })).rejects.toThrow(sweepError);
+    expect(recordAbuseSweepRun).toHaveBeenCalledWith('error');
+    expect(recordAbuseSweepRun).toHaveBeenCalledTimes(1);
+  });
+
   it('does not touch the sweep metric when the digest job throws', async () => {
     const digestError = new Error('digest delivery failed');
     vi.mocked(runAbuseDigest).mockRejectedValueOnce(digestError);

--- a/apps/api/src/jobs/abuseSignalsSweep.test.ts
+++ b/apps/api/src/jobs/abuseSignalsSweep.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-const queueAdd = vi.fn();
-const getRepeatableJobs = vi.fn().mockResolvedValue([
-  { name: 'abuse-sweep', key: 'old-key-1' },
-  { name: 'unrelated', key: 'other' },
-]);
-const removeRepeatableByKey = vi.fn();
+const { queueAdd, getRepeatableJobs, removeRepeatableByKey, WorkerMockCtor } = vi.hoisted(() => ({
+  queueAdd: vi.fn(),
+  getRepeatableJobs: vi.fn().mockResolvedValue([
+    { name: 'abuse-sweep', key: 'old-key-1' },
+    { name: 'unrelated', key: 'other' },
+  ]),
+  removeRepeatableByKey: vi.fn(),
+  WorkerMockCtor: vi.fn(function WorkerMock() {
+    return { on: vi.fn(), close: vi.fn() };
+  }),
+}));
 
 vi.mock('bullmq', () => ({
   // Function expressions (not arrow functions) so `new Queue()` /
@@ -14,18 +19,27 @@ vi.mock('bullmq', () => ({
   Queue: vi.fn(function QueueMock() {
     return { add: queueAdd, getRepeatableJobs, removeRepeatableByKey, close: vi.fn() };
   }),
-  Worker: vi.fn(function WorkerMock() {
-    return { on: vi.fn(), close: vi.fn() };
-  }),
+  Worker: WorkerMockCtor,
 }));
 vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
 vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
 vi.mock('../services/abuseSignals', () => ({ runAbuseSweep: vi.fn(), runAbuseDigest: vi.fn() }));
 vi.mock('../services/abuseMetrics', () => ({ recordAbuseSweepRun: vi.fn() }));
 
-import { scheduleAbuseSignalsJobs } from './abuseSignalsSweep';
+import { scheduleAbuseSignalsJobs, createAbuseSignalsWorker } from './abuseSignalsSweep';
+import { runAbuseSweep, runAbuseDigest } from '../services/abuseSignals';
+import { recordAbuseSweepRun } from '../services/abuseMetrics';
 
 beforeEach(() => vi.clearAllMocks());
+
+/** Pulls the processor function (2nd constructor arg) passed to `new Worker(...)`. */
+function getProcessor(): (job: { name: string }) => Promise<unknown> {
+  createAbuseSignalsWorker();
+  const calls = WorkerMockCtor.mock.calls as unknown as Array<[unknown, (job: { name: string }) => Promise<unknown>]>;
+  const call = calls[calls.length - 1];
+  if (!call) throw new Error('Worker constructor was not called');
+  return call[1];
+}
 
 describe('scheduleAbuseSignalsJobs', () => {
   it('clears prior repeatables for its own job names only, then schedules hourly sweep + weekly digest', async () => {
@@ -48,5 +62,39 @@ describe('scheduleAbuseSignalsJobs', () => {
       expect.anything(),
       expect.objectContaining({ jobId: 'abuse-digest-repeat', repeat: { pattern: '0 9 * * 1' } }),
     );
+  });
+});
+
+describe('abuse signals worker processor', () => {
+  it('records a success metric scoped to the sweep job', async () => {
+    vi.mocked(runAbuseSweep).mockResolvedValueOnce({ fired: 3, notified: 1 });
+    const processor = getProcessor();
+
+    const result = await processor({ name: 'abuse-sweep' });
+
+    expect(result).toEqual({ fired: 3, notified: 1 });
+    expect(recordAbuseSweepRun).toHaveBeenCalledWith('success');
+    expect(recordAbuseSweepRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not touch the sweep metric when the digest job throws', async () => {
+    const digestError = new Error('digest delivery failed');
+    vi.mocked(runAbuseDigest).mockRejectedValueOnce(digestError);
+    const processor = getProcessor();
+
+    await expect(processor({ name: 'abuse-digest' })).rejects.toThrow(digestError);
+    expect(recordAbuseSweepRun).not.toHaveBeenCalled();
+  });
+
+  it('resolves and warns for an unknown job name', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const processor = getProcessor();
+
+    const result = await processor({ name: 'some-other-job' });
+
+    expect(result).toEqual({});
+    expect(recordAbuseSweepRun).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('some-other-job'));
+    warnSpy.mockRestore();
   });
 });

--- a/apps/api/src/jobs/abuseSignalsSweep.ts
+++ b/apps/api/src/jobs/abuseSignalsSweep.ts
@@ -62,9 +62,12 @@ export function createAbuseSignalsWorker(): Worker<AbuseJobData> {
           await runAbuseDigest();
           return {};
         }
+        console.warn(`[AbuseSignals] Unknown job name: ${job.name}`);
         return {};
       } catch (error) {
-        recordAbuseSweepRun('error');
+        if (job.name === SWEEP_JOB) {
+          recordAbuseSweepRun('error');
+        }
         throw error;
       }
     },

--- a/apps/api/src/jobs/abuseSignalsSweep.ts
+++ b/apps/api/src/jobs/abuseSignalsSweep.ts
@@ -1,0 +1,91 @@
+import { Job, Queue, Worker } from 'bullmq';
+import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
+import { runAbuseSweep, runAbuseDigest } from '../services/abuseSignals';
+import { recordAbuseSweepRun } from '../services/abuseMetrics';
+
+const ABUSE_QUEUE = 'abuse-signals';
+const SWEEP_JOB = 'abuse-sweep';
+const DIGEST_JOB = 'abuse-digest';
+// jobIds use hyphens, never colons (BullMQ jobId rule).
+const SWEEP_REPEAT_ID = 'abuse-sweep-repeat';
+const DIGEST_REPEAT_ID = 'abuse-digest-repeat';
+const SWEEP_INTERVAL_MS = 60 * 60 * 1000; // hourly
+const DIGEST_CRON = '0 9 * * 1'; // Monday 09:00
+
+type AbuseJobData = Record<string, never>;
+
+let abuseQueue: Queue<AbuseJobData> | null = null;
+let abuseWorker: Worker<AbuseJobData> | null = null;
+
+export function getAbuseSignalsQueue(): Queue<AbuseJobData> {
+  if (!abuseQueue) {
+    abuseQueue = new Queue<AbuseJobData>(ABUSE_QUEUE, { connection: getBullMQConnection() });
+  }
+  return abuseQueue;
+}
+
+export async function scheduleAbuseSignalsJobs(): Promise<void> {
+  const queue = getAbuseSignalsQueue();
+  // Clear prior repeatables so interval/cron changes take effect on redeploy.
+  const existing = await queue.getRepeatableJobs();
+  for (const job of existing) {
+    if (job.name === SWEEP_JOB || job.name === DIGEST_JOB) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+  await queue.add(SWEEP_JOB, {}, {
+    jobId: SWEEP_REPEAT_ID,
+    repeat: { every: SWEEP_INTERVAL_MS },
+    removeOnComplete: { count: 10 },
+    removeOnFail: { count: 25 },
+  });
+  await queue.add(DIGEST_JOB, {}, {
+    jobId: DIGEST_REPEAT_ID,
+    repeat: { pattern: DIGEST_CRON },
+    removeOnComplete: { count: 5 },
+    removeOnFail: { count: 10 },
+  });
+}
+
+export function createAbuseSignalsWorker(): Worker<AbuseJobData> {
+  return new Worker<AbuseJobData>(
+    ABUSE_QUEUE,
+    async (job: Job<AbuseJobData>) => {
+      try {
+        if (job.name === SWEEP_JOB) {
+          const result = await runAbuseSweep();
+          recordAbuseSweepRun('success');
+          return result;
+        }
+        if (job.name === DIGEST_JOB) {
+          await runAbuseDigest();
+          return {};
+        }
+        return {};
+      } catch (error) {
+        recordAbuseSweepRun('error');
+        throw error;
+      }
+    },
+    { connection: getBullMQConnection(), concurrency: 1 },
+  );
+}
+
+export async function initializeAbuseSignalsWorker(): Promise<void> {
+  abuseWorker = createAbuseSignalsWorker();
+  attachWorkerObservability(abuseWorker, 'abuseSignalsWorker');
+  await scheduleAbuseSignalsJobs();
+  console.log('[AbuseSignals] Sweep worker initialized');
+}
+
+export async function shutdownAbuseSignalsWorker(): Promise<void> {
+  if (abuseWorker) {
+    await abuseWorker.close();
+    abuseWorker = null;
+  }
+  if (abuseQueue) {
+    await abuseQueue.close();
+    abuseQueue = null;
+  }
+}

--- a/apps/api/src/routes/admin/abuse.test.ts
+++ b/apps/api/src/routes/admin/abuse.test.ts
@@ -10,6 +10,7 @@ const txMockState = vi.hoisted(() => ({
     id: string;
     status: string;
     paymentMethodAttachedAt: Date | null;
+    emailVerifiedAt: Date | null;
   },
   partnerDevices: [] as Array<{ id: string }>,
   partnerOrgs: [] as Array<{ id: string }>,
@@ -133,7 +134,12 @@ vi.mock('../../db/schema', async (importOriginal) => ({
   // via remoteSessionTeardown) resolve; override the tables this suite asserts
   // on with opaque tokens below.
   ...(await importOriginal<typeof import('../../db/schema')>()),
-  partners: { id: 'partners.id', status: 'partners.status', paymentMethodAttachedAt: 'partners.pma' },
+  partners: {
+    id: 'partners.id',
+    status: 'partners.status',
+    paymentMethodAttachedAt: 'partners.pma',
+    emailVerifiedAt: 'partners.emailVerifiedAt',
+  },
   organizations: { id: 'organizations.id', partnerId: 'organizations.partnerId' },
   devices: { id: 'devices.id', orgId: 'devices.orgId' },
   deviceCommands: {
@@ -251,7 +257,12 @@ const partnerAdminAuth: FakeAuth = {
 
 function resetState() {
   Object.assign(txMockState, {
-    partner: { id: 'partner-1', status: 'active', paymentMethodAttachedAt: new Date() },
+    partner: {
+      id: 'partner-1',
+      status: 'active',
+      paymentMethodAttachedAt: new Date(),
+      emailVerifiedAt: new Date(),
+    },
     partnerDevices: [{ id: 'd-1' }, { id: 'd-2' }, { id: 'd-3' }],
     partnerOrgs: [{ id: 'org-1' }, { id: 'org-2' }],
     partnerUserRows: [
@@ -767,7 +778,12 @@ describe('admin/abuse — unsuspend agent-fleet restore', () => {
   it('does NOT restore the fleet when the partner only returns to pending (no payment method)', async () => {
     // Without a payment method the unsuspend routes back to 'pending'; agents
     // stay gated off (and token-suspended) until full activation.
-    txMockState.partner = { id: 'partner-1', status: 'suspended', paymentMethodAttachedAt: null };
+    txMockState.partner = {
+      id: 'partner-1',
+      status: 'suspended',
+      paymentMethodAttachedAt: null,
+      emailVerifiedAt: new Date(),
+    };
     const app = buildApp(platformAdminAuth);
     const res = await app.request('/admin/partners/partner-1/unsuspend', {
       method: 'POST',
@@ -779,6 +795,41 @@ describe('admin/abuse — unsuspend agent-fleet restore', () => {
     const body = (await res.json()) as { status: string };
     expect(body.status).toBe('pending');
     expect(restorePartnerTenantAccess).not.toHaveBeenCalled();
+  });
+
+  // Regression coverage: unsuspend must preserve the FULL activation gate
+  // (email verification AND payment method), not just payment. Before this
+  // fix, unsuspend was the one activation write that ignored email
+  // verification and could flip an unverified partner straight to 'active'
+  // on payment alone.
+  it('unsuspend falls back to pending when email is unverified, even with payment attached', async () => {
+    txMockState.partner = {
+      id: 'partner-1',
+      status: 'suspended',
+      paymentMethodAttachedAt: new Date(),
+      emailVerifiedAt: null,
+    };
+
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/unsuspend', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'reinstating but email still unverified' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe('pending');
+    expect(restorePartnerTenantAccess).not.toHaveBeenCalled();
+
+    // The partners UPDATE itself must have been issued with status 'pending',
+    // not 'active' — distinguish it from the separate users re-enable update
+    // (which always sets status 'active' + disabledReason) by shape.
+    const capturedPartnerUpdate = txMockState.updates.find(
+      (u) => u.values && 'status' in u.values && !('disabledReason' in u.values),
+    )?.values;
+    expect(capturedPartnerUpdate).toBeDefined();
+    expect(capturedPartnerUpdate!.status).toBe('pending');
   });
 
   it('returns 500 (does NOT silently 200) when the agent-fleet restore throws', async () => {

--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -385,6 +385,7 @@ abuseRoutes.post(
           .select({
             id: partners.id,
             paymentMethodAttachedAt: partners.paymentMethodAttachedAt,
+            emailVerifiedAt: partners.emailVerifiedAt,
           })
           .from(partners)
           .where(eq(partners.id, partnerId))
@@ -394,12 +395,11 @@ abuseRoutes.post(
           return { notFound: true as const };
         }
 
-        // Preserve the activation gate: only flip to 'active' if the partner
-        // has a payment method attached. Otherwise, route them back through
-        // the pending-activation flow.
-        const newStatus: 'active' | 'pending' = partner.paymentMethodAttachedAt
-          ? 'active'
-          : 'pending';
+        // Preserve the FULL activation gate (email verification AND payment
+        // method) — unsuspend must not become the one path that activates an
+        // unverified partner. Otherwise route back through pending-activation.
+        const newStatus: 'active' | 'pending' =
+          partner.paymentMethodAttachedAt && partner.emailVerifiedAt ? 'active' : 'pending';
 
         await tx
           .update(partners)

--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -92,7 +92,7 @@ vi.mock('../../services/warrantyWorker', () => ({
 }));
 
 vi.mock('../../services/partnerHooks', () => ({
-  dispatchHook: vi.fn(),
+  dispatchHook: vi.fn(async () => undefined),
 }));
 
 vi.mock('../../services/tenantStatus', () => ({
@@ -809,6 +809,126 @@ describe('POST /agents/enroll — 401 reason disambiguation', () => {
           reason: 'quarantined_device_reenroll_refused',
         }),
       })
+    );
+  });
+});
+
+describe('POST /agents/enroll — resolved-key denials are org-attributable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_ENROLLMENT_SECRET;
+    process.env.NODE_ENV = 'test';
+    vi.mocked(getActiveOrgTenant).mockResolvedValue({ orgId: 'org-active', partnerId: 'partner-active' });
+  });
+
+  it('attributes missing_enrollment_secret to the resolved key\'s org (not null)', async () => {
+    mockKeyLookup({
+      id: 'key-secret-1',
+      orgId: 'org-secret-1',
+      siteId: 'site-secret-1',
+      keySecretHash: 'per-key-secret-hash',
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: null,
+      usageCount: 0,
+    });
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(403);
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        orgId: 'org-secret-1',
+        result: 'denied',
+        details: expect.objectContaining({ reason: 'missing_enrollment_secret', keyId: 'key-secret-1' }),
+      }),
+    );
+  });
+
+  it('attributes invalid_enrollment_secret to the resolved key\'s org (not null)', async () => {
+    mockKeyLookup({
+      id: 'key-secret-2',
+      orgId: 'org-secret-2',
+      siteId: 'site-secret-2',
+      keySecretHash: createHash('sha256').update('the-real-secret').digest('hex'),
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: null,
+      usageCount: 0,
+    });
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...baseEnrollBody, enrollmentSecret: 'wrong-secret' }),
+    });
+
+    expect(resp.status).toBe(403);
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        orgId: 'org-secret-2',
+        result: 'denied',
+        details: expect.objectContaining({ reason: 'invalid_enrollment_secret', keyId: 'key-secret-2' }),
+      }),
+    );
+  });
+
+  it('audits device_limit_reached denials with the resolved org — otherwise this signal is invisible to the abuse-signals denied CTE', async () => {
+    mockKeyLookup({
+      id: 'key-limit-1',
+      orgId: 'org-limit-1',
+      siteId: 'site-limit-1',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: null,
+      usageCount: 0,
+    });
+
+    mockSelectRows([{ partnerId: 'partner-limit-1' }]);
+    mockSelectRows([{ maxDevices: 2 }]);
+    mockSelectRows([]); // no existing device
+
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+      const fakeTx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 2 }]), // at cap
+          }),
+        }),
+        insert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+      };
+      return fn(fakeTx);
+    });
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(403);
+    const body = (await resp.json()) as Record<string, unknown>;
+    expect(body.code).toBe('DEVICE_LIMIT_REACHED');
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        orgId: 'org-limit-1',
+        action: 'agent.enroll',
+        result: 'denied',
+        details: expect.objectContaining({
+          reason: 'device_limit_reached',
+          enrollmentKeyId: 'key-limit-1',
+          partnerId: 'partner-limit-1',
+          currentDevices: 2,
+          maxDevices: 2,
+        }),
+      }),
     );
   });
 });

--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../db/schema', () => ({
     agentTokenHash: 'agentTokenHash',
     previousTokenHash: 'previousTokenHash',
     previousTokenExpiresAt: 'previousTokenExpiresAt',
+    enrollmentIp: 'enrollment_ip',
   },
   deviceHardware: { deviceId: 'deviceId', serialNumber: 'serialNumber' },
   deviceNetwork: { deviceId: 'deviceId', macAddress: 'macAddress' },
@@ -105,6 +106,7 @@ import { writeAuditEvent } from '../../services/auditEvents';
 import { recordAgentEnrollment } from '../../services/anomalyMetrics';
 import { getActiveOrgTenant } from '../../services/tenantStatus';
 import * as manifestSigning from '../../services/manifestSigning';
+import { getTrustedClientIp } from '../../services/clientIp';
 import { enrollmentRoutes } from './enrollment';
 
 function buildApp(): Hono {
@@ -1514,5 +1516,95 @@ describe('POST /agents/enroll — virtualization attribute persistence (#1387)',
     const deviceValues = (deviceInsertValues.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
     expect(deviceValues.isVirtual).toBe(true);
     expect(deviceValues.virtualizationPlatform).toBe('vmware');
+  });
+});
+
+describe('POST /agents/enroll — enrollment IP persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_ENROLLMENT_SECRET;
+    process.env.NODE_ENV = 'test';
+  });
+
+  // Stands up the full happy fresh-enroll path and returns the spy that
+  // captures the device INSERT .values(...) payload, mirroring
+  // arrangeFreshEnroll() above (#1387) — a mechanical extraction so this
+  // test (and any future ones) can assert on the persisted enrollmentIp.
+  function setupSuccessfulEnrollTransaction() {
+    mockKeyLookup({
+      id: 'key-ip',
+      orgId: 'org-ip',
+      siteId: 'site-ip',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: 10,
+      usageCount: 0,
+    });
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue([
+            { id: 'key-ip', orgId: 'org-ip', siteId: 'site-ip' },
+          ]),
+        })),
+      })),
+    } as any);
+    mockSelectRows([{ partnerId: 'partner-ip' }]); // org lookup
+    mockSelectRows([{ maxDevices: null }]); // partner.maxDevices
+    mockSelectRows([]); // existing-device lookup → fresh
+
+    const deviceInsertValues = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([
+        { id: 'device-ip', orgId: 'org-ip', siteId: 'site-ip', hostname: 'host-1' },
+      ]),
+      onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+    });
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+      const fakeTx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 0 }]),
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({ values: deviceInsertValues }),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'key-ip' }]),
+            }),
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+      };
+      return fn(fakeTx);
+    });
+    return deviceInsertValues;
+  }
+
+  it('persists the enrolling client IP on the new device row', async () => {
+    const deviceInsertValues = setupSuccessfulEnrollTransaction();
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+    expect(resp.status).toBe(201);
+    expect(deviceInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ enrollmentIp: '127.0.0.1' }),
+    );
+  });
+
+  it('stores NULL enrollmentIp when the client IP could not be determined', async () => {
+    vi.mocked(getTrustedClientIp).mockReturnValueOnce('unknown');
+    const deviceInsertValues = setupSuccessfulEnrollTransaction();
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+    expect(resp.status).toBe(201);
+    expect(deviceInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ enrollmentIp: null }),
+    );
   });
 });

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -189,12 +189,12 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
     if (matchingKey.keySecretHash) {
       if (!providedSecret) {
         writeAuditEvent(c, {
-          orgId: null,
+          orgId: matchingKey.orgId,
           actorType: 'system',
           action: 'agent.enroll',
           resourceType: 'device',
           resourceName: data.hostname,
-          details: { reason: 'missing_enrollment_secret' },
+          details: { reason: 'missing_enrollment_secret', keyId: matchingKey.id },
           result: 'denied',
           errorMessage: 'Enrollment secret required',
         });
@@ -205,12 +205,12 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
       const providedSecretHash = hashEnrollmentSecret(providedSecret);
       if (!timingSafeStringEqual(providedSecretHash, matchingKey.keySecretHash)) {
         writeAuditEvent(c, {
-          orgId: null,
+          orgId: matchingKey.orgId,
           actorType: 'system',
           action: 'agent.enroll',
           resourceType: 'device',
           resourceName: data.hostname,
-          details: { reason: 'invalid_enrollment_secret' },
+          details: { reason: 'invalid_enrollment_secret', keyId: matchingKey.id },
           result: 'denied',
           errorMessage: 'Invalid enrollment secret',
         });
@@ -220,12 +220,12 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
     } else if (configuredSecret) {
       if (!providedSecret) {
         writeAuditEvent(c, {
-          orgId: null,
+          orgId: matchingKey.orgId,
           actorType: 'system',
           action: 'agent.enroll',
           resourceType: 'device',
           resourceName: data.hostname,
-          details: { reason: 'missing_enrollment_secret' },
+          details: { reason: 'missing_enrollment_secret', keyId: matchingKey.id },
           result: 'denied',
           errorMessage: 'Enrollment secret required',
         });
@@ -235,12 +235,12 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
 
       if (!timingSafeStringEqual(hashEnrollmentSecret(providedSecret), hashEnrollmentSecret(configuredSecret))) {
         writeAuditEvent(c, {
-          orgId: null,
+          orgId: matchingKey.orgId,
           actorType: 'system',
           action: 'agent.enroll',
           resourceType: 'device',
           resourceName: data.hostname,
-          details: { reason: 'invalid_enrollment_secret' },
+          details: { reason: 'invalid_enrollment_secret', keyId: matchingKey.id },
           result: 'denied',
           errorMessage: 'Invalid enrollment secret',
         });
@@ -566,6 +566,26 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
             maxDevices,
           }).catch((err) => {
             console.error('[Enrollment] Failed to dispatch device-limit hook:', err instanceof Error ? err.message : err);
+          });
+          // Device-cap denials are org-attributable (the key was already
+          // resolved) and must land in audit_logs like every other denial
+          // path — otherwise this signal is invisible to the abuse-signals
+          // sweep's `denied` CTE (heuristics.ts).
+          writeAuditEvent(c, {
+            orgId: key.orgId,
+            actorType: 'system',
+            action: 'agent.enroll',
+            resourceType: 'device',
+            resourceName: data.hostname,
+            details: {
+              reason: 'device_limit_reached',
+              enrollmentKeyId: key.id,
+              partnerId: deviceLimitPartnerId,
+              currentDevices: activeCount,
+              maxDevices,
+            },
+            result: 'denied',
+            errorMessage: 'Partner device limit reached',
           });
           recordAgentEnrollment('error', deviceLimitPartnerId);
           throw new HTTPException(403, {

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -75,6 +75,8 @@ function tokenHashMatches(storedHash: string | null | undefined, presentedToken:
 enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => {
   const data = c.req.valid('json');
   const clientIp = getTrustedClientIp(c, 'unknown');
+  // 'unknown' is the rate-limiter fallback, not a real address — store NULL.
+  const enrollmentIp = clientIp === 'unknown' ? null : clientIp;
   const rateCheck = await rateLimiter(
     getRedis(),
     `agent-enroll:${clientIp}`,
@@ -602,6 +604,7 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
           .update(devices)
           .set({
             agentId: agentId,
+            enrollmentIp,
             agentTokenHash: tokenHash,
             watchdogTokenHash,
             helperTokenHash,
@@ -639,6 +642,7 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
             watchdogTokenHash,
             helperTokenHash,
             hostname: data.hostname,
+            enrollmentIp,
             osType: data.osType,
             osVersion: data.osVersion,
             architecture: data.architecture,

--- a/apps/api/src/routes/auth/register.test.ts
+++ b/apps/api/src/routes/auth/register.test.ts
@@ -117,10 +117,10 @@ const validBody = {
   acceptTerms: true,
 };
 
-async function postRegisterPartner(body: unknown) {
+function postRegisterPartner(body: unknown, headers: Record<string, string> = {}) {
   return registerRoutes.request('/register-partner', {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...headers },
     body: JSON.stringify(body),
   });
 }
@@ -187,6 +187,19 @@ describe('/register-partner partner status by deployment mode', () => {
     expect(res.status).toBeLessThan(400);
     expect(createPartner).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'active' }),
+    );
+  });
+
+  it('threads signup IP and user agent into createPartner', async () => {
+    process.env.IS_HOSTED = 'true';
+    setupDbSelectsForSuccess(true);
+
+    const res = await postRegisterPartner(validBody, { 'user-agent': 'vitest-agent/1.0' });
+    expect(res.status).toBeLessThan(400);
+    expect(createPartner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: { mcp: false, ip: '127.0.0.1', userAgent: 'vitest-agent/1.0' },
+      }),
     );
   });
 });

--- a/apps/api/src/routes/auth/register.ts
+++ b/apps/api/src/routes/auth/register.ts
@@ -193,7 +193,11 @@ registerRoutes.post('/register-partner', zValidator('json', registerPartnerSchem
         adminEmail: email,
         adminName: name,
         passwordHash,
-        origin: { mcp: false },
+        origin: {
+          mcp: false,
+          ip: getTrustedClientIpOrUndefined(c),
+          userAgent: c.req.header('user-agent'),
+        },
         status: isHosted() ? 'pending' : 'active',
       });
       partnerIdForLog = result.partnerId;

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -282,6 +282,12 @@ const abuseSweepRunsTotal = new Counter({
   labelNames: ['result'] as const,
   registers: [register]
 });
+const opsAlertDeliveriesTotal = new Counter({
+  name: 'breeze_ops_alert_deliveries_total',
+  help: 'Ops-alert delivery attempts by channel and result',
+  labelNames: ['channel', 'result'] as const,
+  registers: [register]
+});
 
 const processStartTimeGauge = new Gauge({
   name: 'process_start_time_seconds',
@@ -322,6 +328,7 @@ agentEnrollmentsTotal.labels('success', 'redacted').inc(0);
 commandsDispatchedTotal.labels('script', 'user', 'redacted').inc(0);
 abuseSignalsFiredTotal.labels('alert').inc(0);
 abuseSweepRunsTotal.labels('success').inc(0);
+opsAlertDeliveriesTotal.labels('webhook', 'success').inc(0);
 nodejsVersionInfoGauge.labels(process.version).set(1);
 
 interface CounterValue {
@@ -640,6 +647,7 @@ setAnomalyMetricsRecorder({
 setAbuseMetricsRecorder({
   onSignalFired: (severity) => abuseSignalsFiredTotal.labels(normalizeMetricLabel(severity, 'unknown')).inc(),
   onSweepRun: (result) => abuseSweepRunsTotal.labels(result).inc(),
+  onAlertDelivery: (channel, result) => opsAlertDeliveriesTotal.labels(normalizeMetricLabel(channel, 'unknown'), result).inc(),
 });
 
 async function refreshBackupOperationalGauges(): Promise<void> {

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -29,6 +29,7 @@ import {
   setS1MetricsRecorder
 } from '../services/sentinelOne/metrics';
 import { setAnomalyMetricsRecorder } from '../services/anomalyMetrics';
+import { setAbuseMetricsRecorder } from '../services/abuseMetrics';
 
 export {
   recordBackupCommandTimeout,
@@ -267,6 +268,21 @@ const commandsDispatchedTotal = new Counter({
   registers: [register]
 });
 
+// Droplet-abuse-detection sweep signals. `abuseMetrics.ts` is the thin
+// recorder (same import-cycle rationale as `anomalyMetrics.ts` above).
+const abuseSignalsFiredTotal = new Counter({
+  name: 'breeze_abuse_signals_fired_total',
+  help: 'Abuse signals fired by the sweep, by severity',
+  labelNames: ['severity'] as const,
+  registers: [register]
+});
+const abuseSweepRunsTotal = new Counter({
+  name: 'breeze_abuse_sweep_runs_total',
+  help: 'Abuse sweep job runs by result',
+  labelNames: ['result'] as const,
+  registers: [register]
+});
+
 const processStartTimeGauge = new Gauge({
   name: 'process_start_time_seconds',
   help: 'Start time of the process since unix epoch in seconds',
@@ -304,6 +320,8 @@ s1ActionPollTransitionsTotal.labels('queued').inc(0);
 failedLoginsTotal.labels('invalid_password', 'redacted').inc(0);
 agentEnrollmentsTotal.labels('success', 'redacted').inc(0);
 commandsDispatchedTotal.labels('script', 'user', 'redacted').inc(0);
+abuseSignalsFiredTotal.labels('alert').inc(0);
+abuseSweepRunsTotal.labels('success').inc(0);
 nodejsVersionInfoGauge.labels(process.version).set(1);
 
 interface CounterValue {
@@ -617,6 +635,11 @@ setAnomalyMetricsRecorder({
   onFailedLogin: recordFailedLoginMetric,
   onAgentEnrollment: recordAgentEnrollmentMetric,
   onCommandDispatch: recordCommandDispatchMetric,
+});
+
+setAbuseMetricsRecorder({
+  onSignalFired: (severity) => abuseSignalsFiredTotal.labels(normalizeMetricLabel(severity, 'unknown')).inc(),
+  onSweepRun: (result) => abuseSweepRunsTotal.labels(result).inc(),
 });
 
 async function refreshBackupOperationalGauges(): Promise<void> {

--- a/apps/api/src/services/abuseMetrics.ts
+++ b/apps/api/src/services/abuseMetrics.ts
@@ -1,0 +1,29 @@
+// Thin indirection so the abuse-detection sweep job can emit Prometheus
+// signals without importing `routes/metrics` directly (mirrors the
+// `anomalyMetrics.ts` pattern used for the same reason — see that file's
+// header comment for the import-cycle rationale). `routes/metrics` registers
+// the real recorder at startup via `setAbuseMetricsRecorder`; until then
+// these are no-ops.
+
+type AbuseMetricsRecorder = {
+  onSignalFired: (severity: string) => void;
+  onSweepRun: (result: 'success' | 'error') => void;
+};
+
+const noop = () => {};
+let recorder: AbuseMetricsRecorder = { onSignalFired: noop, onSweepRun: noop };
+
+export function setAbuseMetricsRecorder(next: Partial<AbuseMetricsRecorder> | null | undefined): void {
+  recorder = {
+    onSignalFired: next?.onSignalFired ?? noop,
+    onSweepRun: next?.onSweepRun ?? noop,
+  };
+}
+
+export function recordAbuseSignalFired(severity: string): void {
+  recorder.onSignalFired(severity);
+}
+
+export function recordAbuseSweepRun(result: 'success' | 'error'): void {
+  recorder.onSweepRun(result);
+}

--- a/apps/api/src/services/abuseMetrics.ts
+++ b/apps/api/src/services/abuseMetrics.ts
@@ -8,15 +8,17 @@
 type AbuseMetricsRecorder = {
   onSignalFired: (severity: string) => void;
   onSweepRun: (result: 'success' | 'error') => void;
+  onAlertDelivery: (channel: string, result: 'success' | 'failure') => void;
 };
 
 const noop = () => {};
-let recorder: AbuseMetricsRecorder = { onSignalFired: noop, onSweepRun: noop };
+let recorder: AbuseMetricsRecorder = { onSignalFired: noop, onSweepRun: noop, onAlertDelivery: noop };
 
 export function setAbuseMetricsRecorder(next: Partial<AbuseMetricsRecorder> | null | undefined): void {
   recorder = {
     onSignalFired: next?.onSignalFired ?? noop,
     onSweepRun: next?.onSweepRun ?? noop,
+    onAlertDelivery: next?.onAlertDelivery ?? noop,
   };
 }
 
@@ -26,4 +28,8 @@ export function recordAbuseSignalFired(severity: string): void {
 
 export function recordAbuseSweepRun(result: 'success' | 'error'): void {
   recorder.onSweepRun(result);
+}
+
+export function recordOpsAlertDelivery(channel: string, result: 'success' | 'failure'): void {
+  recorder.onAlertDelivery(channel, result);
 }

--- a/apps/api/src/services/abuseSignals/config.test.ts
+++ b/apps/api/src/services/abuseSignals/config.test.ts
@@ -30,6 +30,13 @@ describe('loadSignalConfig', () => {
     expect(loadSignalConfig()).toEqual(SIGNAL_DEFAULTS);
     expect(warn).toHaveBeenCalled();
   });
+
+  it('warns and returns defaults on non-object JSON (e.g., array)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.ABUSE_SIGNAL_OVERRIDES = '[1,2,3]';
+    expect(loadSignalConfig()).toEqual(SIGNAL_DEFAULTS);
+    expect(warn).toHaveBeenCalledWith('[AbuseSignals] ABUSE_SIGNAL_OVERRIDES must be a JSON object — using defaults');
+  });
 });
 
 describe('scoreToSeverity', () => {
@@ -38,6 +45,12 @@ describe('scoreToSeverity', () => {
     expect(scoreToSeverity(75, cfg)).toBe('alert');
     expect(scoreToSeverity(45, cfg)).toBe('watch');
     expect(scoreToSeverity(5, cfg)).toBe('info');
+  });
+
+  it('treats exact threshold scores as the higher band', () => {
+    expect(scoreToSeverity(70, cfg)).toBe('alert');
+    expect(scoreToSeverity(40, cfg)).toBe('watch');
+    expect(scoreToSeverity(0, cfg)).toBe('info');
   });
 });
 
@@ -49,5 +62,10 @@ describe('youngWeight', () => {
     expect(youngWeight(new Date('2026-04-01T00:00:00Z'), now, cfg)).toBe(0);
     const w = youngWeight(new Date('2026-05-16T00:00:00Z'), now, cfg); // 60 days old
     expect(w).toBeCloseTo(0.5, 1);
+  });
+
+  it('is exactly 1 at 30 days and exactly 0 at 90 days', () => {
+    expect(youngWeight(new Date('2026-06-15T00:00:00Z'), now, cfg)).toBe(1);  // exactly 30 days
+    expect(youngWeight(new Date('2026-04-16T00:00:00Z'), now, cfg)).toBe(0);  // exactly 90 days
   });
 });

--- a/apps/api/src/services/abuseSignals/config.test.ts
+++ b/apps/api/src/services/abuseSignals/config.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { loadSignalConfig, SIGNAL_DEFAULTS, scoreToSeverity, youngWeight } from './config';
+
+afterEach(() => {
+  delete process.env.ABUSE_SIGNAL_OVERRIDES;
+  vi.restoreAllMocks();
+});
+
+describe('loadSignalConfig', () => {
+  it('returns defaults when ABUSE_SIGNAL_OVERRIDES is unset', () => {
+    expect(loadSignalConfig()).toEqual(SIGNAL_DEFAULTS);
+  });
+
+  it('merges known override keys', () => {
+    process.env.ABUSE_SIGNAL_OVERRIDES = '{"rmm.enrollment_velocity.devices_24h": 25}';
+    expect(loadSignalConfig()['rmm.enrollment_velocity.devices_24h']).toBe(25);
+  });
+
+  it('warns and ignores unknown keys and non-numeric values', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.ABUSE_SIGNAL_OVERRIDES = '{"nope.unknown": 1, "severity.alert_score": "high"}';
+    const cfg = loadSignalConfig();
+    expect(cfg['severity.alert_score']).toBe(SIGNAL_DEFAULTS['severity.alert_score']);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('warns and returns defaults on malformed JSON', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.ABUSE_SIGNAL_OVERRIDES = '{not json';
+    expect(loadSignalConfig()).toEqual(SIGNAL_DEFAULTS);
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('scoreToSeverity', () => {
+  const cfg = SIGNAL_DEFAULTS;
+  it('maps score bands', () => {
+    expect(scoreToSeverity(75, cfg)).toBe('alert');
+    expect(scoreToSeverity(45, cfg)).toBe('watch');
+    expect(scoreToSeverity(5, cfg)).toBe('info');
+  });
+});
+
+describe('youngWeight', () => {
+  const cfg = SIGNAL_DEFAULTS;
+  const now = new Date('2026-07-15T00:00:00Z');
+  it('is 1.0 under 30 days, 0 at 90+, linear between', () => {
+    expect(youngWeight(new Date('2026-07-01T00:00:00Z'), now, cfg)).toBe(1);
+    expect(youngWeight(new Date('2026-04-01T00:00:00Z'), now, cfg)).toBe(0);
+    const w = youngWeight(new Date('2026-05-16T00:00:00Z'), now, cfg); // 60 days old
+    expect(w).toBeCloseTo(0.5, 1);
+  });
+});

--- a/apps/api/src/services/abuseSignals/config.ts
+++ b/apps/api/src/services/abuseSignals/config.ts
@@ -1,0 +1,67 @@
+import type { AbuseSeverity } from './types';
+
+/**
+ * Published defaults. Production deployments may diverge via the
+ * ABUSE_SIGNAL_OVERRIDES env var (JSON map of key -> number) so adversaries
+ * reading this public repo do not learn the live thresholds.
+ */
+export const SIGNAL_DEFAULTS: Record<string, number> = {
+  'sweep.young_full_weight_days': 30,
+  'sweep.young_zero_weight_days': 90,
+  'severity.watch_score': 40,
+  'severity.alert_score': 70,
+  'rmm.consumer_devices.min_devices': 5,
+  'rmm.consumer_devices.watch_ratio': 0.6,
+  'rmm.enrollment_velocity.devices_24h': 10,
+  'rmm.session_intensity.fast_remote_count_7d': 3,
+  'rmm.session_intensity.sessions_per_device_7d': 5,
+  'rmm.enrollment_ip_spread.min_devices': 8,
+  'rmm.enrollment_ip_spread.distinct_ratio': 0.8,
+  'fraud.failed_login_cluster.count_24h': 20,
+  'resource.enrollment_denied.count_24h': 20,
+  'resource.volume_outlier.commands_24h': 500,
+  'resource.volume_outlier.scripts_24h': 200,
+};
+
+export function loadSignalConfig(): Record<string, number> {
+  const raw = process.env.ABUSE_SIGNAL_OVERRIDES;
+  if (!raw) return { ...SIGNAL_DEFAULTS };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.warn('[AbuseSignals] ABUSE_SIGNAL_OVERRIDES is not valid JSON — using defaults');
+    return { ...SIGNAL_DEFAULTS };
+  }
+  const cfg = { ...SIGNAL_DEFAULTS };
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!(key in SIGNAL_DEFAULTS)) {
+        console.warn(`[AbuseSignals] Unknown override key ignored: ${key}`);
+        continue;
+      }
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        console.warn(`[AbuseSignals] Non-numeric override ignored: ${key}`);
+        continue;
+      }
+      cfg[key] = value;
+    }
+  }
+  return cfg;
+}
+
+export function scoreToSeverity(score: number, cfg: Record<string, number>): AbuseSeverity {
+  if (score >= cfg['severity.alert_score']) return 'alert';
+  if (score >= cfg['severity.watch_score']) return 'watch';
+  return 'info';
+}
+
+/** 1.0 for partners younger than young_full_weight_days, linearly decaying to 0 at young_zero_weight_days. */
+export function youngWeight(partnerCreatedAt: Date, now: Date, cfg: Record<string, number>): number {
+  const ageDays = (now.getTime() - partnerCreatedAt.getTime()) / 86_400_000;
+  const full = cfg['sweep.young_full_weight_days'];
+  const zero = cfg['sweep.young_zero_weight_days'];
+  if (ageDays <= full) return 1;
+  if (ageDays >= zero) return 0;
+  return (zero - ageDays) / (zero - full);
+}

--- a/apps/api/src/services/abuseSignals/config.ts
+++ b/apps/api/src/services/abuseSignals/config.ts
@@ -52,17 +52,21 @@ export function loadSignalConfig(): Record<string, number> {
   return cfg;
 }
 
+function cfgValue(cfg: Record<string, number>, key: string): number {
+  return cfg[key] ?? SIGNAL_DEFAULTS[key] ?? 0;
+}
+
 export function scoreToSeverity(score: number, cfg: Record<string, number>): AbuseSeverity {
-  if (score >= cfg['severity.alert_score']) return 'alert';
-  if (score >= cfg['severity.watch_score']) return 'watch';
+  if (score >= cfgValue(cfg, 'severity.alert_score')) return 'alert';
+  if (score >= cfgValue(cfg, 'severity.watch_score')) return 'watch';
   return 'info';
 }
 
 /** 1.0 for partners younger than young_full_weight_days, linearly decaying to 0 at young_zero_weight_days. */
 export function youngWeight(partnerCreatedAt: Date, now: Date, cfg: Record<string, number>): number {
   const ageDays = (now.getTime() - partnerCreatedAt.getTime()) / 86_400_000;
-  const full = cfg['sweep.young_full_weight_days'];
-  const zero = cfg['sweep.young_zero_weight_days'];
+  const full = cfgValue(cfg, 'sweep.young_full_weight_days');
+  const zero = cfgValue(cfg, 'sweep.young_zero_weight_days');
   if (ageDays <= full) return 1;
   if (ageDays >= zero) return 0;
   return (zero - ageDays) / (zero - full);

--- a/apps/api/src/services/abuseSignals/config.ts
+++ b/apps/api/src/services/abuseSignals/config.ts
@@ -5,7 +5,7 @@ import type { AbuseSeverity } from './types';
  * ABUSE_SIGNAL_OVERRIDES env var (JSON map of key -> number) so adversaries
  * reading this public repo do not learn the live thresholds.
  */
-export const SIGNAL_DEFAULTS: Record<string, number> = {
+export const SIGNAL_DEFAULTS = {
   'sweep.young_full_weight_days': 30,
   'sweep.young_zero_weight_days': 90,
   'severity.watch_score': 40,
@@ -21,9 +21,12 @@ export const SIGNAL_DEFAULTS: Record<string, number> = {
   'resource.enrollment_denied.count_24h': 20,
   'resource.volume_outlier.commands_24h': 500,
   'resource.volume_outlier.scripts_24h': 200,
-};
+} as const satisfies Record<string, number>;
 
-export function loadSignalConfig(): Record<string, number> {
+export type SignalConfigKey = keyof typeof SIGNAL_DEFAULTS;
+export type SignalConfig = Record<SignalConfigKey, number>;
+
+export function loadSignalConfig(): SignalConfig {
   const raw = process.env.ABUSE_SIGNAL_OVERRIDES;
   if (!raw) return { ...SIGNAL_DEFAULTS };
   let parsed: unknown;
@@ -33,7 +36,7 @@ export function loadSignalConfig(): Record<string, number> {
     console.warn('[AbuseSignals] ABUSE_SIGNAL_OVERRIDES is not valid JSON — using defaults');
     return { ...SIGNAL_DEFAULTS };
   }
-  const cfg = { ...SIGNAL_DEFAULTS };
+  const cfg: SignalConfig = { ...SIGNAL_DEFAULTS };
   if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
     for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
       if (!(key in SIGNAL_DEFAULTS)) {
@@ -44,7 +47,10 @@ export function loadSignalConfig(): Record<string, number> {
         console.warn(`[AbuseSignals] Non-numeric override ignored: ${key}`);
         continue;
       }
-      cfg[key] = value;
+      // `key in SIGNAL_DEFAULTS` above narrows the runtime string to a known
+      // key, but TS can't carry that narrowing through Object.entries — cast
+      // is safe because of the check on the line above.
+      cfg[key as SignalConfigKey] = value;
     }
   } else {
     console.warn('[AbuseSignals] ABUSE_SIGNAL_OVERRIDES must be a JSON object — using defaults');
@@ -52,21 +58,17 @@ export function loadSignalConfig(): Record<string, number> {
   return cfg;
 }
 
-function cfgValue(cfg: Record<string, number>, key: string): number {
-  return cfg[key] ?? SIGNAL_DEFAULTS[key] ?? 0;
-}
-
-export function scoreToSeverity(score: number, cfg: Record<string, number>): AbuseSeverity {
-  if (score >= cfgValue(cfg, 'severity.alert_score')) return 'alert';
-  if (score >= cfgValue(cfg, 'severity.watch_score')) return 'watch';
+export function scoreToSeverity(score: number, cfg: SignalConfig): AbuseSeverity {
+  if (score >= cfg['severity.alert_score']) return 'alert';
+  if (score >= cfg['severity.watch_score']) return 'watch';
   return 'info';
 }
 
 /** 1.0 for partners younger than young_full_weight_days, linearly decaying to 0 at young_zero_weight_days. */
-export function youngWeight(partnerCreatedAt: Date, now: Date, cfg: Record<string, number>): number {
+export function youngWeight(partnerCreatedAt: Date, now: Date, cfg: SignalConfig): number {
   const ageDays = (now.getTime() - partnerCreatedAt.getTime()) / 86_400_000;
-  const full = cfgValue(cfg, 'sweep.young_full_weight_days');
-  const zero = cfgValue(cfg, 'sweep.young_zero_weight_days');
+  const full = cfg['sweep.young_full_weight_days'];
+  const zero = cfg['sweep.young_zero_weight_days'];
   if (ageDays <= full) return 1;
   if (ageDays >= zero) return 0;
   return (zero - ageDays) / (zero - full);

--- a/apps/api/src/services/abuseSignals/config.ts
+++ b/apps/api/src/services/abuseSignals/config.ts
@@ -46,6 +46,8 @@ export function loadSignalConfig(): Record<string, number> {
       }
       cfg[key] = value;
     }
+  } else {
+    console.warn('[AbuseSignals] ABUSE_SIGNAL_OVERRIDES must be a JSON object — using defaults');
   }
   return cfg;
 }

--- a/apps/api/src/services/abuseSignals/digest.test.ts
+++ b/apps/api/src/services/abuseSignals/digest.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Deliberately does NOT mock this module itself (unlike abuseSignalsSweep.test.ts) —
+// these tests exercise runAbuseDigest's real branches around ops-alert config.
+const { dbExecute, isOpsAlertingConfigured, sendOpsAlert } = vi.hoisted(() => ({
+  dbExecute: vi.fn().mockResolvedValue([]),
+  isOpsAlertingConfigured: vi.fn(),
+  sendOpsAlert: vi.fn(),
+}));
+
+vi.mock('../../db', () => ({
+  db: { execute: dbExecute },
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+}));
+
+vi.mock('../opsAlerts', () => ({
+  isOpsAlertingConfigured,
+  sendOpsAlert,
+}));
+
+import { runAbuseDigest } from './index';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbExecute.mockResolvedValue([]);
+});
+
+describe('runAbuseDigest', () => {
+  it('skips and warns without throwing when ops alerting is not configured', async () => {
+    isOpsAlertingConfigured.mockReturnValue(false);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(runAbuseDigest()).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledWith('[AbuseSignals] Digest skipped — ops alerting not configured');
+    expect(sendOpsAlert).not.toHaveBeenCalled();
+    expect(dbExecute).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('throws when configured but delivery fails, so the job lands in the failed set', async () => {
+    isOpsAlertingConfigured.mockReturnValue(true);
+    sendOpsAlert.mockResolvedValue(false);
+
+    await expect(runAbuseDigest()).rejects.toThrow('[AbuseSignals] Weekly digest delivery failed');
+    expect(sendOpsAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when configured and delivery succeeds', async () => {
+    isOpsAlertingConfigured.mockReturnValue(true);
+    sendOpsAlert.mockResolvedValue(true);
+
+    await expect(runAbuseDigest()).resolves.toBeUndefined();
+    expect(sendOpsAlert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/abuseSignals/heuristics.test.ts
+++ b/apps/api/src/services/abuseSignals/heuristics.test.ts
@@ -88,4 +88,21 @@ describe('computeHeuristicSignals', () => {
     const signals = computeHeuristicSignals([agg({ enrollmentDenied24h: 40 })], SIGNAL_DEFAULTS, now);
     expect(signals.some((x) => x.signalKey === 'resource.enrollment_denied')).toBe(true);
   });
+
+  it('emits nothing (not NaN) when a threshold is overridden to 0', () => {
+    const cfg = { ...SIGNAL_DEFAULTS, 'rmm.enrollment_velocity.devices_24h': 0 };
+    const signals = computeHeuristicSignals([agg({ enrolled24h: 0, deviceCount: 0 })], cfg, now);
+    expect(signals).toEqual([]);
+  });
+
+  it('fires volume_outlier on command volume regardless of partner age', () => {
+    const signals = computeHeuristicSignals(
+      [agg({ partnerCreatedAt: new Date('2026-01-01T00:00:00Z'), commands24h: 1200 })],
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    const s = signals.find((x) => x.signalKey === 'resource.volume_outlier');
+    expect(s).toBeDefined();
+    expect(s!.evidence).toMatchObject({ commands24h: 1200 });
+  });
 });

--- a/apps/api/src/services/abuseSignals/heuristics.test.ts
+++ b/apps/api/src/services/abuseSignals/heuristics.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { computeHeuristicSignals, type PartnerAggregates } from './heuristics';
+import { SIGNAL_DEFAULTS } from './config';
+
+const now = new Date('2026-07-15T00:00:00Z');
+
+function agg(overrides: Partial<PartnerAggregates>): PartnerAggregates {
+  return {
+    partnerId: 'p1',
+    partnerName: 'Acme',
+    partnerCreatedAt: new Date('2026-07-10T00:00:00Z'), // 5 days old → full weight
+    deviceCount: 0,
+    consumerHostnameCount: 0,
+    enrolled24h: 0,
+    distinctEnrollmentIps30d: 0,
+    devicesEnrolled30d: 0,
+    sessions7d: 0,
+    fastRemoteSessions7d: 0,
+    failedLogins24h: 0,
+    enrollmentDenied24h: 0,
+    commands24h: 0,
+    scriptExecutions24h: 0,
+    ...overrides,
+  };
+}
+
+describe('computeHeuristicSignals', () => {
+  it('emits nothing for a quiet partner', () => {
+    expect(computeHeuristicSignals([agg({})], SIGNAL_DEFAULTS, now)).toEqual([]);
+  });
+
+  it('fires consumer_devices when ratio and fleet size exceed thresholds', () => {
+    const signals = computeHeuristicSignals(
+      [agg({ deviceCount: 10, consumerHostnameCount: 9 })],
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    const s = signals.find((x) => x.signalKey === 'rmm.consumer_devices');
+    expect(s).toBeDefined();
+    expect(s!.evidence).toMatchObject({ deviceCount: 10, consumerHostnameCount: 9 });
+    expect(s!.score).toBeGreaterThan(0);
+  });
+
+  it('fires enrollment_velocity on a 24h burst', () => {
+    const signals = computeHeuristicSignals([agg({ enrolled24h: 30, deviceCount: 30 })], SIGNAL_DEFAULTS, now);
+    expect(signals.some((x) => x.signalKey === 'rmm.enrollment_velocity')).toBe(true);
+  });
+
+  it('weighs fast enroll-to-remote sessions heavily', () => {
+    const signals = computeHeuristicSignals(
+      [agg({ deviceCount: 5, sessions7d: 12, fastRemoteSessions7d: 5 })],
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    const s = signals.find((x) => x.signalKey === 'rmm.session_intensity');
+    expect(s).toBeDefined();
+    expect(s!.severity).toBe('alert');
+  });
+
+  it('fires enrollment_ip_spread when nearly every device came from a distinct IP', () => {
+    const signals = computeHeuristicSignals(
+      [agg({ deviceCount: 10, devicesEnrolled30d: 10, distinctEnrollmentIps30d: 10 })],
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    expect(signals.some((x) => x.signalKey === 'rmm.enrollment_ip_spread')).toBe(true);
+  });
+
+  it('decays scores for old partners (zero weight at 90+ days)', () => {
+    const signals = computeHeuristicSignals(
+      [agg({ partnerCreatedAt: new Date('2026-01-01T00:00:00Z'), deviceCount: 10, consumerHostnameCount: 10 })],
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    expect(signals).toEqual([]); // weight 0 → score 0 → not emitted
+  });
+
+  it('does not decay fraud/resource signals', () => {
+    const signals = computeHeuristicSignals(
+      [agg({ partnerCreatedAt: new Date('2026-01-01T00:00:00Z'), failedLogins24h: 100 })],
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    expect(signals.some((x) => x.signalKey === 'fraud.failed_login_cluster')).toBe(true);
+  });
+
+  it('fires enrollment_denied on repeated cap/key rejections', () => {
+    const signals = computeHeuristicSignals([agg({ enrollmentDenied24h: 40 })], SIGNAL_DEFAULTS, now);
+    expect(signals.some((x) => x.signalKey === 'resource.enrollment_denied')).toBe(true);
+  });
+});

--- a/apps/api/src/services/abuseSignals/heuristics.ts
+++ b/apps/api/src/services/abuseSignals/heuristics.ts
@@ -40,6 +40,15 @@ export async function loadPartnerAggregates(): Promise<PartnerAggregates[]> {
             SELECT 1 FROM organizations o JOIN devices d ON d.org_id = o.id
             WHERE o.partner_id = p.id AND d.enrolled_at > now() - interval '2 hours'
           )
+          -- Flagged partners keep being re-evaluated every sweep so open
+          -- signals resolve on real evidence (score drops back below
+          -- threshold), not merely because the partner aged out of the
+          -- young/recently-enrolling scope — and per-row acknowledgments
+          -- survive since the row is never stale-resolved out from under them.
+          OR EXISTS (
+            SELECT 1 FROM partner_abuse_signals pas
+            WHERE pas.partner_id = p.id AND pas.resolved_at IS NULL
+          )
         )
     ),
     dev AS (
@@ -64,10 +73,31 @@ export async function loadPartnerAggregates(): Promise<PartnerAggregates[]> {
       GROUP BY o.partner_id
     ),
     logins AS (
-      SELECT o.partner_id, COUNT(*) AS failed_24h
-      FROM audit_logs al JOIN organizations o ON o.id = al.org_id
-      WHERE al.action = 'user.login.failed' AND al."timestamp" > now() - interval '24 hours'
-      GROUP BY o.partner_id
+      -- Fresh partners have ONLY a partnerUsers link (createPartner never
+      -- creates an organizationUsers row) — their partner-admin logins carry
+      -- org_id NULL on audit_logs, so an org_id-only join never sees the
+      -- failed logins for exactly the accounts this signal targets. Attribute
+      -- across both axes: org-member failures via org_id -> organizations,
+      -- and org_id-NULL failures via the audit row's actor_id -> users.id
+      -- (actor_id is populated with the real users.id on every
+      -- auditUserLoginFailure call site — apps/api/src/routes/auth/login.ts
+      -- resolves the user row by email before auditing — so it's a more
+      -- robust join key than actor_email, which isn't guaranteed unique/stable).
+      SELECT pid AS partner_id, SUM(cnt) AS failed_24h FROM (
+        -- org-attributable failed logins (org members)
+        SELECT o.partner_id AS pid, COUNT(*) AS cnt
+        FROM audit_logs al JOIN organizations o ON o.id = al.org_id
+        WHERE al.action = 'user.login.failed' AND al."timestamp" > now() - interval '24 hours'
+        GROUP BY o.partner_id
+        UNION ALL
+        -- partner-admin failed logins land with org_id NULL; attribute via
+        -- the target user's partner_id (audit actor_id -> users.id)
+        SELECT u.partner_id AS pid, COUNT(*) AS cnt
+        FROM audit_logs al JOIN users u ON u.id = al.actor_id
+        WHERE al.action = 'user.login.failed' AND al.org_id IS NULL
+          AND al."timestamp" > now() - interval '24 hours' AND u.partner_id IS NOT NULL
+        GROUP BY u.partner_id
+      ) x GROUP BY pid
     ),
     denied AS (
       -- Counts org-attributable enrollment denials (expired/exhausted keys,

--- a/apps/api/src/services/abuseSignals/heuristics.ts
+++ b/apps/api/src/services/abuseSignals/heuristics.ts
@@ -70,6 +70,8 @@ export async function loadPartnerAggregates(): Promise<PartnerAggregates[]> {
       GROUP BY o.partner_id
     ),
     denied AS (
+      -- Counts only org-attributable denials (expired/exhausted keys, device-cap hits).
+      -- Denials from unresolved enrollment keys carry org_id NULL and are unattributable to a partner.
       SELECT o.partner_id, COUNT(*) AS denied_24h
       FROM audit_logs al JOIN organizations o ON o.id = al.org_id
       WHERE al.action = 'agent.enroll' AND al.result = 'denied'
@@ -148,7 +150,7 @@ export function computeHeuristicSignals(
     const weight = youngWeight(a.partnerCreatedAt, now, cfg);
     const push = (signalKey: string, rawScore: number, evidence: Record<string, unknown>, decays = true) => {
       const score = Math.min(100, Math.round(rawScore * (decays ? weight : 1)));
-      if (score <= 0) return;
+      if (!(score > 0)) return;
       signals.push({
         partnerId: a.partnerId,
         signalKey,

--- a/apps/api/src/services/abuseSignals/heuristics.ts
+++ b/apps/api/src/services/abuseSignals/heuristics.ts
@@ -1,0 +1,237 @@
+import { sql } from 'drizzle-orm';
+import { db } from '../../db';
+import { scoreToSeverity, youngWeight, SIGNAL_DEFAULTS } from './config';
+import type { ComputedSignal } from './types';
+
+export interface PartnerAggregates {
+  partnerId: string;
+  partnerName: string;
+  partnerCreatedAt: Date;
+  deviceCount: number;
+  consumerHostnameCount: number;
+  enrolled24h: number;
+  distinctEnrollmentIps30d: number;
+  devicesEnrolled30d: number;
+  sessions7d: number;
+  fastRemoteSessions7d: number;
+  failedLogins24h: number;
+  enrollmentDenied24h: number;
+  commands24h: number;
+  scriptExecutions24h: number;
+}
+
+// Default Windows hostnames (DESKTOP-XXXXXXX / LAPTOP-XXXXXXX) mark unmanaged
+// consumer machines — a legit MSP's fleet is mostly named/domain-joined.
+const CONSUMER_HOSTNAME_SQL = `d.hostname ~* '^(DESKTOP|LAPTOP)-[A-Z0-9]{7}$'`;
+
+/**
+ * One fleet-grouped pass over young-or-recently-active partners.
+ * MUST run inside a system DB context — bare breeze_app reads return 0 rows.
+ */
+export async function loadPartnerAggregates(): Promise<PartnerAggregates[]> {
+  const rows = (await db.execute(sql.raw(`
+    WITH scoped AS (
+      SELECT p.id, p.name, p.created_at
+      FROM partners p
+      WHERE p.deleted_at IS NULL AND p.status = 'active'
+        AND (
+          p.created_at > now() - interval '90 days'
+          OR EXISTS (
+            SELECT 1 FROM organizations o JOIN devices d ON d.org_id = o.id
+            WHERE o.partner_id = p.id AND d.enrolled_at > now() - interval '2 hours'
+          )
+        )
+    ),
+    dev AS (
+      SELECT o.partner_id,
+        COUNT(*) AS device_count,
+        COUNT(*) FILTER (WHERE ${CONSUMER_HOSTNAME_SQL}) AS consumer_count,
+        COUNT(*) FILTER (WHERE d.enrolled_at > now() - interval '24 hours') AS enrolled_24h,
+        COUNT(DISTINCT d.enrollment_ip) FILTER (WHERE d.enrolled_at > now() - interval '30 days' AND d.enrollment_ip IS NOT NULL) AS distinct_enroll_ips_30d,
+        COUNT(*) FILTER (WHERE d.enrolled_at > now() - interval '30 days' AND d.enrollment_ip IS NOT NULL) AS devices_enrolled_30d
+      FROM devices d JOIN organizations o ON o.id = d.org_id
+      WHERE d.status NOT IN ('decommissioned', 'quarantined')
+      GROUP BY o.partner_id
+    ),
+    sess AS (
+      SELECT o.partner_id,
+        COUNT(*) AS sessions_7d,
+        COUNT(*) FILTER (WHERE rs.created_at < d.enrolled_at + interval '24 hours') AS fast_remote_7d
+      FROM remote_sessions rs
+      JOIN devices d ON d.id = rs.device_id
+      JOIN organizations o ON o.id = d.org_id
+      WHERE rs.created_at > now() - interval '7 days'
+      GROUP BY o.partner_id
+    ),
+    logins AS (
+      SELECT o.partner_id, COUNT(*) AS failed_24h
+      FROM audit_logs al JOIN organizations o ON o.id = al.org_id
+      WHERE al.action = 'user.login.failed' AND al."timestamp" > now() - interval '24 hours'
+      GROUP BY o.partner_id
+    ),
+    denied AS (
+      SELECT o.partner_id, COUNT(*) AS denied_24h
+      FROM audit_logs al JOIN organizations o ON o.id = al.org_id
+      WHERE al.action = 'agent.enroll' AND al.result = 'denied'
+        AND al."timestamp" > now() - interval '24 hours'
+      GROUP BY o.partner_id
+    ),
+    cmds AS (
+      SELECT o.partner_id, COUNT(*) AS commands_24h
+      FROM device_commands dc
+      JOIN devices d ON d.id = dc.device_id
+      JOIN organizations o ON o.id = d.org_id
+      WHERE dc.created_at > now() - interval '24 hours'
+      GROUP BY o.partner_id
+    ),
+    scripts AS (
+      SELECT o.partner_id, COUNT(*) AS scripts_24h
+      FROM script_executions se JOIN organizations o ON o.id = se.org_id
+      WHERE se.created_at > now() - interval '24 hours'
+      GROUP BY o.partner_id
+    )
+    SELECT s.id, s.name, s.created_at,
+      COALESCE(dev.device_count, 0) AS device_count,
+      COALESCE(dev.consumer_count, 0) AS consumer_count,
+      COALESCE(dev.enrolled_24h, 0) AS enrolled_24h,
+      COALESCE(dev.distinct_enroll_ips_30d, 0) AS distinct_enroll_ips_30d,
+      COALESCE(dev.devices_enrolled_30d, 0) AS devices_enrolled_30d,
+      COALESCE(sess.sessions_7d, 0) AS sessions_7d,
+      COALESCE(sess.fast_remote_7d, 0) AS fast_remote_7d,
+      COALESCE(logins.failed_24h, 0) AS failed_24h,
+      COALESCE(denied.denied_24h, 0) AS denied_24h,
+      COALESCE(cmds.commands_24h, 0) AS commands_24h,
+      COALESCE(scripts.scripts_24h, 0) AS scripts_24h
+    FROM scoped s
+    LEFT JOIN dev ON dev.partner_id = s.id
+    LEFT JOIN sess ON sess.partner_id = s.id
+    LEFT JOIN logins ON logins.partner_id = s.id
+    LEFT JOIN denied ON denied.partner_id = s.id
+    LEFT JOIN cmds ON cmds.partner_id = s.id
+    LEFT JOIN scripts ON scripts.partner_id = s.id
+  `))) as unknown as Array<Record<string, unknown>>;
+
+  return rows.map((r) => ({
+    partnerId: String(r.id),
+    partnerName: String(r.name),
+    partnerCreatedAt: new Date(String(r.created_at)),
+    deviceCount: Number(r.device_count),
+    consumerHostnameCount: Number(r.consumer_count),
+    enrolled24h: Number(r.enrolled_24h),
+    distinctEnrollmentIps30d: Number(r.distinct_enroll_ips_30d),
+    devicesEnrolled30d: Number(r.devices_enrolled_30d),
+    sessions7d: Number(r.sessions_7d),
+    fastRemoteSessions7d: Number(r.fast_remote_7d),
+    failedLogins24h: Number(r.failed_24h),
+    enrollmentDenied24h: Number(r.denied_24h),
+    commands24h: Number(r.commands_24h),
+    scriptExecutions24h: Number(r.scripts_24h),
+  }));
+}
+
+// Local mirror of config.ts's private cfgValue helper — noUncheckedIndexedAccess
+// makes cfg[key] a `number | undefined`; fall back to the published default,
+// then 0, so callers can index freely without non-null assertions.
+function cfgValue(cfg: Record<string, number>, key: string): number {
+  return cfg[key] ?? SIGNAL_DEFAULTS[key] ?? 0;
+}
+
+/** Pure scoring: no I/O, unit-testable. Scores are 0-100 pre-weighting. */
+export function computeHeuristicSignals(
+  aggs: PartnerAggregates[],
+  cfg: Record<string, number>,
+  now: Date,
+): ComputedSignal[] {
+  const signals: ComputedSignal[] = [];
+
+  for (const a of aggs) {
+    const weight = youngWeight(a.partnerCreatedAt, now, cfg);
+    const push = (signalKey: string, rawScore: number, evidence: Record<string, unknown>, decays = true) => {
+      const score = Math.min(100, Math.round(rawScore * (decays ? weight : 1)));
+      if (score <= 0) return;
+      signals.push({
+        partnerId: a.partnerId,
+        signalKey,
+        score,
+        severity: scoreToSeverity(score, cfg),
+        evidence: { partnerName: a.partnerName, ...evidence },
+      });
+    };
+
+    // rmm.consumer_devices — ratio of throwaway-named consumer machines.
+    if (a.deviceCount >= cfgValue(cfg, 'rmm.consumer_devices.min_devices')) {
+      const ratio = a.consumerHostnameCount / a.deviceCount;
+      if (ratio >= cfgValue(cfg, 'rmm.consumer_devices.watch_ratio')) {
+        push('rmm.consumer_devices', ratio * 100, {
+          deviceCount: a.deviceCount,
+          consumerHostnameCount: a.consumerHostnameCount,
+          ratio: Number(ratio.toFixed(2)),
+        });
+      }
+    }
+
+    // rmm.enrollment_velocity — burst enrollments in 24h.
+    const velThreshold = cfgValue(cfg, 'rmm.enrollment_velocity.devices_24h');
+    if (a.enrolled24h >= velThreshold) {
+      push('rmm.enrollment_velocity', Math.min(100, (a.enrolled24h / velThreshold) * 50), {
+        enrolled24h: a.enrolled24h,
+      });
+    }
+
+    // rmm.session_intensity — fast enroll-to-remote is the scammer fingerprint.
+    const fastThreshold = cfgValue(cfg, 'rmm.session_intensity.fast_remote_count_7d');
+    const perDeviceThreshold = cfgValue(cfg, 'rmm.session_intensity.sessions_per_device_7d');
+    const perDevice = a.deviceCount > 0 ? a.sessions7d / a.deviceCount : 0;
+    if (a.fastRemoteSessions7d >= fastThreshold || perDevice >= perDeviceThreshold) {
+      const fastScore = (a.fastRemoteSessions7d / fastThreshold) * 70;
+      const volumeScore = (perDevice / perDeviceThreshold) * 40;
+      push('rmm.session_intensity', Math.max(fastScore, volumeScore), {
+        sessions7d: a.sessions7d,
+        fastRemoteSessions7d: a.fastRemoteSessions7d,
+        deviceCount: a.deviceCount,
+      });
+    }
+
+    // rmm.enrollment_ip_spread — scattered origin IPs (residential-victim proxy until geo lands).
+    if (a.devicesEnrolled30d >= cfgValue(cfg, 'rmm.enrollment_ip_spread.min_devices')) {
+      const ratio = a.distinctEnrollmentIps30d / a.devicesEnrolled30d;
+      if (ratio >= cfgValue(cfg, 'rmm.enrollment_ip_spread.distinct_ratio')) {
+        push('rmm.enrollment_ip_spread', ratio * 80, {
+          devicesEnrolled30d: a.devicesEnrolled30d,
+          distinctEnrollmentIps30d: a.distinctEnrollmentIps30d,
+        });
+      }
+    }
+
+    // fraud.failed_login_cluster — never age-decayed.
+    const loginThreshold = cfgValue(cfg, 'fraud.failed_login_cluster.count_24h');
+    if (a.failedLogins24h >= loginThreshold) {
+      push('fraud.failed_login_cluster', Math.min(100, (a.failedLogins24h / loginThreshold) * 50), {
+        failedLogins24h: a.failedLogins24h,
+      }, false);
+    }
+
+    // resource.enrollment_denied — repeated cap/key rejections; never age-decayed.
+    const deniedThreshold = cfgValue(cfg, 'resource.enrollment_denied.count_24h');
+    if (a.enrollmentDenied24h >= deniedThreshold) {
+      push('resource.enrollment_denied', Math.min(100, (a.enrollmentDenied24h / deniedThreshold) * 50), {
+        enrollmentDenied24h: a.enrollmentDenied24h,
+      }, false);
+    }
+
+    // resource.volume_outlier — never age-decayed.
+    const cmdThreshold = cfgValue(cfg, 'resource.volume_outlier.commands_24h');
+    const scriptThreshold = cfgValue(cfg, 'resource.volume_outlier.scripts_24h');
+    if (a.commands24h >= cmdThreshold || a.scriptExecutions24h >= scriptThreshold) {
+      push('resource.volume_outlier', Math.min(
+        100,
+        Math.max((a.commands24h / cmdThreshold) * 50, (a.scriptExecutions24h / scriptThreshold) * 50),
+      ), {
+        commands24h: a.commands24h,
+        scriptExecutions24h: a.scriptExecutions24h,
+      }, false);
+    }
+  }
+
+  return signals;
+}

--- a/apps/api/src/services/abuseSignals/heuristics.ts
+++ b/apps/api/src/services/abuseSignals/heuristics.ts
@@ -70,8 +70,10 @@ export async function loadPartnerAggregates(): Promise<PartnerAggregates[]> {
       GROUP BY o.partner_id
     ),
     denied AS (
-      -- Counts only org-attributable denials (expired/exhausted keys, device-cap hits).
-      -- Denials from unresolved enrollment keys carry org_id NULL and are unattributable to a partner.
+      -- Counts org-attributable enrollment denials (expired/exhausted keys,
+      -- secret mismatches on a resolved key, device-cap hits). Pre-key-
+      -- resolution denials (unknown key, rate limit) have no org and are
+      -- inherently unattributable to a partner.
       SELECT o.partner_id, COUNT(*) AS denied_24h
       FROM audit_logs al JOIN organizations o ON o.id = al.org_id
       WHERE al.action = 'agent.enroll' AND al.result = 'denied'

--- a/apps/api/src/services/abuseSignals/heuristics.ts
+++ b/apps/api/src/services/abuseSignals/heuristics.ts
@@ -1,6 +1,6 @@
 import { sql } from 'drizzle-orm';
 import { db } from '../../db';
-import { scoreToSeverity, youngWeight, SIGNAL_DEFAULTS } from './config';
+import { scoreToSeverity, youngWeight, type SignalConfig } from './config';
 import type { ComputedSignal } from './types';
 
 export interface PartnerAggregates {
@@ -163,17 +163,10 @@ export async function loadPartnerAggregates(): Promise<PartnerAggregates[]> {
   }));
 }
 
-// Local mirror of config.ts's private cfgValue helper — noUncheckedIndexedAccess
-// makes cfg[key] a `number | undefined`; fall back to the published default,
-// then 0, so callers can index freely without non-null assertions.
-function cfgValue(cfg: Record<string, number>, key: string): number {
-  return cfg[key] ?? SIGNAL_DEFAULTS[key] ?? 0;
-}
-
 /** Pure scoring: no I/O, unit-testable. Scores are 0-100 pre-weighting. */
 export function computeHeuristicSignals(
   aggs: PartnerAggregates[],
-  cfg: Record<string, number>,
+  cfg: SignalConfig,
   now: Date,
 ): ComputedSignal[] {
   const signals: ComputedSignal[] = [];
@@ -193,9 +186,9 @@ export function computeHeuristicSignals(
     };
 
     // rmm.consumer_devices — ratio of throwaway-named consumer machines.
-    if (a.deviceCount >= cfgValue(cfg, 'rmm.consumer_devices.min_devices')) {
+    if (a.deviceCount >= cfg['rmm.consumer_devices.min_devices']) {
       const ratio = a.consumerHostnameCount / a.deviceCount;
-      if (ratio >= cfgValue(cfg, 'rmm.consumer_devices.watch_ratio')) {
+      if (ratio >= cfg['rmm.consumer_devices.watch_ratio']) {
         push('rmm.consumer_devices', ratio * 100, {
           deviceCount: a.deviceCount,
           consumerHostnameCount: a.consumerHostnameCount,
@@ -205,7 +198,7 @@ export function computeHeuristicSignals(
     }
 
     // rmm.enrollment_velocity — burst enrollments in 24h.
-    const velThreshold = cfgValue(cfg, 'rmm.enrollment_velocity.devices_24h');
+    const velThreshold = cfg['rmm.enrollment_velocity.devices_24h'];
     if (a.enrolled24h >= velThreshold) {
       push('rmm.enrollment_velocity', Math.min(100, (a.enrolled24h / velThreshold) * 50), {
         enrolled24h: a.enrolled24h,
@@ -213,8 +206,8 @@ export function computeHeuristicSignals(
     }
 
     // rmm.session_intensity — fast enroll-to-remote is the scammer fingerprint.
-    const fastThreshold = cfgValue(cfg, 'rmm.session_intensity.fast_remote_count_7d');
-    const perDeviceThreshold = cfgValue(cfg, 'rmm.session_intensity.sessions_per_device_7d');
+    const fastThreshold = cfg['rmm.session_intensity.fast_remote_count_7d'];
+    const perDeviceThreshold = cfg['rmm.session_intensity.sessions_per_device_7d'];
     const perDevice = a.deviceCount > 0 ? a.sessions7d / a.deviceCount : 0;
     if (a.fastRemoteSessions7d >= fastThreshold || perDevice >= perDeviceThreshold) {
       const fastScore = (a.fastRemoteSessions7d / fastThreshold) * 70;
@@ -227,9 +220,9 @@ export function computeHeuristicSignals(
     }
 
     // rmm.enrollment_ip_spread — scattered origin IPs (residential-victim proxy until geo lands).
-    if (a.devicesEnrolled30d >= cfgValue(cfg, 'rmm.enrollment_ip_spread.min_devices')) {
+    if (a.devicesEnrolled30d >= cfg['rmm.enrollment_ip_spread.min_devices']) {
       const ratio = a.distinctEnrollmentIps30d / a.devicesEnrolled30d;
-      if (ratio >= cfgValue(cfg, 'rmm.enrollment_ip_spread.distinct_ratio')) {
+      if (ratio >= cfg['rmm.enrollment_ip_spread.distinct_ratio']) {
         push('rmm.enrollment_ip_spread', ratio * 80, {
           devicesEnrolled30d: a.devicesEnrolled30d,
           distinctEnrollmentIps30d: a.distinctEnrollmentIps30d,
@@ -238,7 +231,7 @@ export function computeHeuristicSignals(
     }
 
     // fraud.failed_login_cluster — never age-decayed.
-    const loginThreshold = cfgValue(cfg, 'fraud.failed_login_cluster.count_24h');
+    const loginThreshold = cfg['fraud.failed_login_cluster.count_24h'];
     if (a.failedLogins24h >= loginThreshold) {
       push('fraud.failed_login_cluster', Math.min(100, (a.failedLogins24h / loginThreshold) * 50), {
         failedLogins24h: a.failedLogins24h,
@@ -246,7 +239,7 @@ export function computeHeuristicSignals(
     }
 
     // resource.enrollment_denied — repeated cap/key rejections; never age-decayed.
-    const deniedThreshold = cfgValue(cfg, 'resource.enrollment_denied.count_24h');
+    const deniedThreshold = cfg['resource.enrollment_denied.count_24h'];
     if (a.enrollmentDenied24h >= deniedThreshold) {
       push('resource.enrollment_denied', Math.min(100, (a.enrollmentDenied24h / deniedThreshold) * 50), {
         enrollmentDenied24h: a.enrollmentDenied24h,
@@ -254,8 +247,8 @@ export function computeHeuristicSignals(
     }
 
     // resource.volume_outlier — never age-decayed.
-    const cmdThreshold = cfgValue(cfg, 'resource.volume_outlier.commands_24h');
-    const scriptThreshold = cfgValue(cfg, 'resource.volume_outlier.scripts_24h');
+    const cmdThreshold = cfg['resource.volume_outlier.commands_24h'];
+    const scriptThreshold = cfg['resource.volume_outlier.scripts_24h'];
     if (a.commands24h >= cmdThreshold || a.scriptExecutions24h >= scriptThreshold) {
       push('resource.volume_outlier', Math.min(
         100,

--- a/apps/api/src/services/abuseSignals/index.ts
+++ b/apps/api/src/services/abuseSignals/index.ts
@@ -1,6 +1,6 @@
 import { sql } from 'drizzle-orm';
 import * as dbModule from '../../db';
-import { sendOpsAlert } from '../opsAlerts';
+import { sendOpsAlert, isOpsAlertingConfigured } from '../opsAlerts';
 import { recordAbuseSignalFired } from '../abuseMetrics';
 import { loadSignalConfig } from './config';
 import { computeInvariantSignals } from './invariants';
@@ -59,6 +59,11 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
 }
 
 export async function runAbuseDigest(): Promise<void> {
+  if (!isOpsAlertingConfigured()) {
+    console.warn('[AbuseSignals] Digest skipped — ops alerting not configured');
+    return;
+  }
+
   const stats = await runSystemDbCompute(async () => {
     const openBySeverity = (await db.execute(sql`
       SELECT severity, COUNT(*) AS count FROM partner_abuse_signals
@@ -79,7 +84,7 @@ export async function runAbuseDigest(): Promise<void> {
 
   const severityLine = stats.openBySeverity.map((r) => `${r.severity}: ${r.count}`).join(', ') || 'none open';
   const watchLines = stats.watchRows.map((r) => `- ${r.name}: ${r.signal_key} (score ${r.score})`).join('\n');
-  await sendOpsAlert({
+  const delivered = await sendOpsAlert({
     title: 'Weekly abuse-signals digest',
     body: [
       `New partners this week: ${stats.newPartnerCount}`,
@@ -88,4 +93,7 @@ export async function runAbuseDigest(): Promise<void> {
       'Invariants checked hourly all week (any breach would have alerted immediately).',
     ].join('\n'),
   });
+  if (!delivered) {
+    throw new Error('[AbuseSignals] Weekly digest delivery failed');
+  }
 }

--- a/apps/api/src/services/abuseSignals/index.ts
+++ b/apps/api/src/services/abuseSignals/index.ts
@@ -43,7 +43,8 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
   }));
 
   const computed = [...invariants, ...computeHeuristicSignals(aggregates, cfg, now)];
-  const { toNotify } = await runSystemDbCompute(() => persistSignals(computed, now));
+  const evaluatedPartnerIds = new Set(aggregates.map((a) => a.partnerId));
+  const { toNotify } = await runSystemDbCompute(() => persistSignals(computed, now, evaluatedPartnerIds));
 
   for (const s of computed) recordAbuseSignalFired(s.severity);
 
@@ -71,11 +72,11 @@ export async function runAbuseDigest(): Promise<void> {
       GROUP BY severity
     `)) as unknown as Array<{ severity: string; count: string }>;
     const watchRows = (await db.execute(sql`
-      SELECT s.signal_key, s.score, s.evidence, p.name
+      SELECT s.signal_key, s.score, p.name
       FROM partner_abuse_signals s JOIN partners p ON p.id = s.partner_id
       WHERE s.resolved_at IS NULL AND s.acknowledged_at IS NULL AND s.severity = 'watch'
       ORDER BY s.score DESC LIMIT 20
-    `)) as unknown as Array<{ signal_key: string; score: number; evidence: Record<string, unknown>; name: string }>;
+    `)) as unknown as Array<{ signal_key: string; score: number; name: string }>;
     const newPartners = (await db.execute(sql`
       SELECT COUNT(*) AS count FROM partners WHERE created_at > now() - interval '7 days' AND deleted_at IS NULL
     `)) as unknown as Array<{ count: string }>;

--- a/apps/api/src/services/abuseSignals/index.ts
+++ b/apps/api/src/services/abuseSignals/index.ts
@@ -15,11 +15,18 @@ const { db } = dbModule;
 const runSystemDbCompute = async <T>(fn: () => Promise<T>): Promise<T> => {
   const withSystem = dbModule.withSystemDbAccessContext;
   const runOutside = dbModule.runOutsideDbContext;
-  if (typeof withSystem !== 'function') return fn();
-  if (typeof runOutside !== 'function') return withSystem(fn);
+  if (typeof withSystem !== 'function' || typeof runOutside !== 'function') {
+    // Never legitimate in production: running without the system context would
+    // silently read 0 rows under forced RLS and report a "healthy" empty sweep.
+    throw new Error('[AbuseSignals] db context helpers missing — refusing to run sweep without system context');
+  }
   return runOutside(() => withSystem(fn));
 };
 
+// Ordering matters: opsAlerts.formatContent truncates the final message to
+// Discord's 2000-char limit, and the evidence JSON below is itself capped at
+// 800 chars — but neither cap should ever be able to cut off the actionable
+// line (full partner id + playbook pointer). Keep those BEFORE evidence.
 function formatSignalAlert(s: ComputedSignal & { rowId: string }): { title: string; body: string } {
   const shortId = s.partnerId.slice(0, 8);
   return {
@@ -27,8 +34,9 @@ function formatSignalAlert(s: ComputedSignal & { rowId: string }): { title: stri
     body: [
       `Partner: ${String(s.evidence.partnerName ?? 'unknown')} (${shortId})`,
       `Score: ${s.score}`,
-      `Evidence: ${JSON.stringify(s.evidence)}`,
-      `Review: docs/superpowers/specs/2026-07-11-signup-abuse-detection-design.md — suspend playbook applies; partner id ${s.partnerId}`,
+      `Partner id: ${s.partnerId}`,
+      `Review: docs/superpowers/specs/2026-07-11-signup-abuse-detection-design.md — suspend playbook applies`,
+      `Evidence: ${JSON.stringify(s.evidence).slice(0, 800)}`,
     ].join('\n'),
   };
 }

--- a/apps/api/src/services/abuseSignals/index.ts
+++ b/apps/api/src/services/abuseSignals/index.ts
@@ -1,0 +1,91 @@
+import { sql } from 'drizzle-orm';
+import * as dbModule from '../../db';
+import { sendOpsAlert } from '../opsAlerts';
+import { recordAbuseSignalFired } from '../abuseMetrics';
+import { loadSignalConfig } from './config';
+import { computeInvariantSignals } from './invariants';
+import { loadPartnerAggregates, computeHeuristicSignals } from './heuristics';
+import { persistSignals, markDelivered } from './persistence';
+import type { ComputedSignal } from './types';
+
+const { db } = dbModule;
+
+// #1105: hold the system DB context only around DB work; alert delivery
+// (network) happens outside it.
+const runSystemDbCompute = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  const runOutside = dbModule.runOutsideDbContext;
+  if (typeof withSystem !== 'function') return fn();
+  if (typeof runOutside !== 'function') return withSystem(fn);
+  return runOutside(() => withSystem(fn));
+};
+
+function formatSignalAlert(s: ComputedSignal & { rowId: string }): { title: string; body: string } {
+  const shortId = s.partnerId.slice(0, 8);
+  return {
+    title: `Abuse signal: ${s.signalKey} (${s.severity})`,
+    body: [
+      `Partner: ${String(s.evidence.partnerName ?? 'unknown')} (${shortId})`,
+      `Score: ${s.score}`,
+      `Evidence: ${JSON.stringify(s.evidence)}`,
+      `Review: docs/superpowers/specs/2026-07-11-signup-abuse-detection-design.md — suspend playbook applies; partner id ${s.partnerId}`,
+    ].join('\n'),
+  };
+}
+
+export async function runAbuseSweep(): Promise<{ fired: number; notified: number }> {
+  const cfg = loadSignalConfig();
+  const now = new Date();
+
+  const { invariants, aggregates } = await runSystemDbCompute(async () => ({
+    invariants: await computeInvariantSignals(),
+    aggregates: await loadPartnerAggregates(),
+  }));
+
+  const computed = [...invariants, ...computeHeuristicSignals(aggregates, cfg, now)];
+  const { toNotify } = await runSystemDbCompute(() => persistSignals(computed, now));
+
+  for (const s of computed) recordAbuseSignalFired(s.severity);
+
+  const deliveredIds: string[] = [];
+  for (const n of toNotify) {
+    if (await sendOpsAlert(formatSignalAlert(n))) deliveredIds.push(n.rowId);
+  }
+  if (deliveredIds.length > 0) {
+    await runSystemDbCompute(() => markDelivered(deliveredIds, new Date()));
+  }
+
+  return { fired: computed.length, notified: deliveredIds.length };
+}
+
+export async function runAbuseDigest(): Promise<void> {
+  const stats = await runSystemDbCompute(async () => {
+    const openBySeverity = (await db.execute(sql`
+      SELECT severity, COUNT(*) AS count FROM partner_abuse_signals
+      WHERE resolved_at IS NULL AND acknowledged_at IS NULL
+      GROUP BY severity
+    `)) as unknown as Array<{ severity: string; count: string }>;
+    const watchRows = (await db.execute(sql`
+      SELECT s.signal_key, s.score, s.evidence, p.name
+      FROM partner_abuse_signals s JOIN partners p ON p.id = s.partner_id
+      WHERE s.resolved_at IS NULL AND s.acknowledged_at IS NULL AND s.severity = 'watch'
+      ORDER BY s.score DESC LIMIT 20
+    `)) as unknown as Array<{ signal_key: string; score: number; evidence: Record<string, unknown>; name: string }>;
+    const newPartners = (await db.execute(sql`
+      SELECT COUNT(*) AS count FROM partners WHERE created_at > now() - interval '7 days' AND deleted_at IS NULL
+    `)) as unknown as Array<{ count: string }>;
+    return { openBySeverity, watchRows, newPartnerCount: Number(newPartners[0]?.count ?? 0) };
+  });
+
+  const severityLine = stats.openBySeverity.map((r) => `${r.severity}: ${r.count}`).join(', ') || 'none open';
+  const watchLines = stats.watchRows.map((r) => `- ${r.name}: ${r.signal_key} (score ${r.score})`).join('\n');
+  await sendOpsAlert({
+    title: 'Weekly abuse-signals digest',
+    body: [
+      `New partners this week: ${stats.newPartnerCount}`,
+      `Open unacknowledged signals — ${severityLine}`,
+      watchLines ? `Watch tier:\n${watchLines}` : 'Watch tier: empty',
+      'Invariants checked hourly all week (any breach would have alerted immediately).',
+    ].join('\n'),
+  });
+}

--- a/apps/api/src/services/abuseSignals/invariants.test.ts
+++ b/apps/api/src/services/abuseSignals/invariants.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../db', () => ({
+  db: { execute: vi.fn() },
+}));
+
+import { db } from '../../db';
+import { computeInvariantSignals } from './invariants';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('computeInvariantSignals', () => {
+  it('emits alert signals for each invariant breach', async () => {
+    vi.mocked(db.execute)
+      // active_unverified_email
+      .mockResolvedValueOnce([{ id: 'p1', name: 'Acme', created_at: '2026-07-01' }] as never)
+      // active_no_payment
+      .mockResolvedValueOnce([] as never)
+      // inactive_partner_with_agents
+      .mockResolvedValueOnce([{ id: 'p2', name: 'Bad Co', status: 'suspended', device_count: '4' }] as never);
+
+    const signals = await computeInvariantSignals();
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).toMatchObject({
+      partnerId: 'p1',
+      signalKey: 'invariant.active_unverified_email',
+      severity: 'alert',
+      score: 100,
+    });
+    expect(signals[1]).toMatchObject({
+      partnerId: 'p2',
+      signalKey: 'invariant.inactive_partner_with_agents',
+      severity: 'alert',
+      evidence: expect.objectContaining({ deviceCount: 4, partnerStatus: 'suspended' }),
+    });
+  });
+
+  it('returns empty when all invariants hold', async () => {
+    vi.mocked(db.execute).mockResolvedValue([] as never);
+    expect(await computeInvariantSignals()).toEqual([]);
+  });
+});

--- a/apps/api/src/services/abuseSignals/invariants.test.ts
+++ b/apps/api/src/services/abuseSignals/invariants.test.ts
@@ -15,19 +15,27 @@ describe('computeInvariantSignals', () => {
       // active_unverified_email
       .mockResolvedValueOnce([{ id: 'p1', name: 'Acme', created_at: '2026-07-01' }] as never)
       // active_no_payment
-      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([{ id: 'p3', name: 'NoPay Co', created_at: '2026-06-20' }] as never)
       // inactive_partner_with_agents
       .mockResolvedValueOnce([{ id: 'p2', name: 'Bad Co', status: 'suspended', device_count: '4' }] as never);
 
     const signals = await computeInvariantSignals();
-    expect(signals).toHaveLength(2);
+    expect(signals).toHaveLength(3);
     expect(signals[0]).toMatchObject({
       partnerId: 'p1',
       signalKey: 'invariant.active_unverified_email',
       severity: 'alert',
       score: 100,
+      evidence: { partnerName: 'Acme', partnerCreatedAt: '2026-07-01' },
     });
     expect(signals[1]).toMatchObject({
+      partnerId: 'p3',
+      signalKey: 'invariant.active_no_payment',
+      severity: 'alert',
+      score: 100,
+      evidence: { partnerName: 'NoPay Co', partnerCreatedAt: '2026-06-20' },
+    });
+    expect(signals[2]).toMatchObject({
       partnerId: 'p2',
       signalKey: 'invariant.inactive_partner_with_agents',
       severity: 'alert',

--- a/apps/api/src/services/abuseSignals/invariants.ts
+++ b/apps/api/src/services/abuseSignals/invariants.ts
@@ -45,6 +45,7 @@ export async function computeInvariantSignals(): Promise<ComputedSignal[]> {
     JOIN devices d ON d.org_id = o.id
     WHERE p.status IN ('pending', 'suspended')
       AND d.status NOT IN ('decommissioned', 'quarantined')
+      -- Intentionally omit deleted_at IS NULL: a soft-deleted partner with live devices is itself the anomaly
     GROUP BY p.id, p.name, p.status
   `)) as unknown as Array<{ id: string; name: string; status: string; device_count: string }>;
   for (const p of inactiveWithAgents) {

--- a/apps/api/src/services/abuseSignals/invariants.ts
+++ b/apps/api/src/services/abuseSignals/invariants.ts
@@ -1,0 +1,61 @@
+import { sql } from 'drizzle-orm';
+import { db } from '../../db';
+import type { ComputedSignal } from './types';
+
+// Activation invariants — conditions the signup gate makes impossible, so any
+// hit means gate drift (deploy lag, manual SQL, a new bypass). Suppression of
+// reviewed/grandfathered accounts happens via acknowledged_at in persistence,
+// NEVER via allowlists here (public repo: no tenant identifiers in code).
+// MUST run inside a system DB context — bare breeze_app reads return 0 rows.
+export async function computeInvariantSignals(): Promise<ComputedSignal[]> {
+  const signals: ComputedSignal[] = [];
+
+  const unverified = (await db.execute(sql`
+    SELECT id, name, created_at FROM partners
+    WHERE status = 'active' AND email_verified_at IS NULL AND deleted_at IS NULL
+  `)) as unknown as Array<{ id: string; name: string; created_at: string }>;
+  for (const p of unverified) {
+    signals.push({
+      partnerId: p.id,
+      signalKey: 'invariant.active_unverified_email',
+      score: 100,
+      severity: 'alert',
+      evidence: { partnerName: p.name, partnerCreatedAt: p.created_at },
+    });
+  }
+
+  const unpaid = (await db.execute(sql`
+    SELECT id, name, created_at FROM partners
+    WHERE status = 'active' AND payment_method_attached_at IS NULL AND deleted_at IS NULL
+  `)) as unknown as Array<{ id: string; name: string; created_at: string }>;
+  for (const p of unpaid) {
+    signals.push({
+      partnerId: p.id,
+      signalKey: 'invariant.active_no_payment',
+      score: 100,
+      severity: 'alert',
+      evidence: { partnerName: p.name, partnerCreatedAt: p.created_at },
+    });
+  }
+
+  const inactiveWithAgents = (await db.execute(sql`
+    SELECT p.id, p.name, p.status, COUNT(d.id) AS device_count
+    FROM partners p
+    JOIN organizations o ON o.partner_id = p.id
+    JOIN devices d ON d.org_id = o.id
+    WHERE p.status IN ('pending', 'suspended')
+      AND d.status NOT IN ('decommissioned', 'quarantined')
+    GROUP BY p.id, p.name, p.status
+  `)) as unknown as Array<{ id: string; name: string; status: string; device_count: string }>;
+  for (const p of inactiveWithAgents) {
+    signals.push({
+      partnerId: p.id,
+      signalKey: 'invariant.inactive_partner_with_agents',
+      score: 100,
+      severity: 'alert',
+      evidence: { partnerName: p.name, partnerStatus: p.status, deviceCount: Number(p.device_count) },
+    });
+  }
+
+  return signals;
+}

--- a/apps/api/src/services/abuseSignals/persistence.test.ts
+++ b/apps/api/src/services/abuseSignals/persistence.test.ts
@@ -3,6 +3,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 const inserted: unknown[] = [];
 const updates: Array<{ set: Record<string, unknown> }> = [];
 
+const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }));
+vi.mock('../sentry', () => ({ captureException }));
+
 vi.mock('../../db', () => ({
   db: {
     select: vi.fn(),
@@ -41,6 +44,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   inserted.length = 0;
   updates.length = 0;
+  captureException.mockClear();
 });
 
 describe('persistSignals', () => {
@@ -106,6 +110,56 @@ describe('persistSignals', () => {
   it('resolves an open invariant.* row that did not fire this sweep even when its partner is not in the evaluated set', async () => {
     mockOpenRows([{ id: 'stale-invariant', partnerId: 'p9', signalKey: 'invariant.something', severity: 'watch', acknowledgedAt: null, deliveredAt: null }]);
     await persistSignals([], now, new Set(['p1']));
+    expect(updates.some((u) => u.set.resolvedAt instanceof Date)).toBe(true);
+  });
+
+  it('still notifies a decayed-but-undelivered alert (open row was alert, this sweep scored it watch)', async () => {
+    mockOpenRows([{ id: 'row1', partnerId: 'p1', signalKey: 'rmm.consumer_devices', severity: 'alert', acknowledgedAt: null, deliveredAt: null }]);
+    const { toNotify } = await persistSignals(
+      [signal({ severity: 'watch', score: 45 })],
+      now,
+      new Set(['p1']),
+    );
+    expect(toNotify).toHaveLength(1);
+    expect(toNotify[0]!.rowId).toBe('row1');
+  });
+
+  it('does not re-notify a decayed row that was already delivered', async () => {
+    mockOpenRows([{ id: 'row1', partnerId: 'p1', signalKey: 'rmm.consumer_devices', severity: 'alert', acknowledgedAt: null, deliveredAt: new Date() }]);
+    const { toNotify } = await persistSignals(
+      [signal({ severity: 'watch', score: 45 })],
+      now,
+      new Set(['p1']),
+    );
+    expect(toNotify).toHaveLength(0);
+  });
+
+  it('logs and captures an exception when INSERT returns no row', async () => {
+    mockOpenRows([]);
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) })),
+    } as never);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { toNotify } = await persistSignals([signal({})], now, new Set(['p1']));
+    expect(toNotify).toHaveLength(0);
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('captures an exception (but still resolves) when stale-resolving an undelivered alert-severity row', async () => {
+    mockOpenRows([{ id: 'stale-alert', partnerId: 'p9', signalKey: 'rmm.enrollment_velocity', severity: 'alert', acknowledgedAt: null, deliveredAt: null }]);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await persistSignals([], now, new Set(['p9']));
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(updates.some((u) => u.set.resolvedAt instanceof Date)).toBe(true);
+    errSpy.mockRestore();
+  });
+
+  it('does not capture an exception when stale-resolving a delivered alert-severity row', async () => {
+    mockOpenRows([{ id: 'stale-alert', partnerId: 'p9', signalKey: 'rmm.enrollment_velocity', severity: 'alert', acknowledgedAt: null, deliveredAt: new Date() }]);
+    await persistSignals([], now, new Set(['p9']));
+    expect(captureException).not.toHaveBeenCalled();
     expect(updates.some((u) => u.set.resolvedAt instanceof Date)).toBe(true);
   });
 });

--- a/apps/api/src/services/abuseSignals/persistence.test.ts
+++ b/apps/api/src/services/abuseSignals/persistence.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const inserted: unknown[] = [];
+const updates: Array<{ set: Record<string, unknown> }> = [];
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(() => ({
+      values: vi.fn((v: unknown) => {
+        inserted.push(v);
+        return { returning: vi.fn().mockResolvedValue([{ id: `new-${inserted.length}` }]) };
+      }),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((s: Record<string, unknown>) => {
+        updates.push({ set: s });
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      }),
+    })),
+  },
+}));
+
+import { db } from '../../db';
+import { persistSignals } from './persistence';
+import type { ComputedSignal } from './types';
+
+const now = new Date('2026-07-15T12:00:00Z');
+
+function mockOpenRows(rows: unknown[]) {
+  vi.mocked(db.select).mockReturnValue({
+    from: vi.fn(() => ({ where: vi.fn().mockResolvedValue(rows) })),
+  } as never);
+}
+
+function signal(overrides: Partial<ComputedSignal>): ComputedSignal {
+  return { partnerId: 'p1', signalKey: 'rmm.consumer_devices', score: 80, severity: 'alert', evidence: {}, ...overrides };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  inserted.length = 0;
+  updates.length = 0;
+});
+
+describe('persistSignals', () => {
+  it('inserts new fired signals and notifies alerts only', async () => {
+    mockOpenRows([]);
+    const { toNotify } = await persistSignals(
+      [signal({}), signal({ signalKey: 'rmm.enrollment_velocity', score: 45, severity: 'watch' })],
+      now,
+    );
+    expect(inserted).toHaveLength(2);
+    expect(toNotify).toHaveLength(1);
+    expect(toNotify[0]!.signalKey).toBe('rmm.consumer_devices');
+  });
+
+  it('updates an existing open row without re-notifying a delivered alert', async () => {
+    mockOpenRows([{ id: 'row1', partnerId: 'p1', signalKey: 'rmm.consumer_devices', severity: 'alert', acknowledgedAt: null, deliveredAt: new Date() }]);
+    const { toNotify } = await persistSignals([signal({})], now);
+    expect(inserted).toHaveLength(0);
+    expect(updates.length).toBeGreaterThan(0);
+    expect(toNotify).toHaveLength(0);
+  });
+
+  it('notifies on escalation to alert (open watch row, never delivered)', async () => {
+    mockOpenRows([{ id: 'row1', partnerId: 'p1', signalKey: 'rmm.consumer_devices', severity: 'watch', acknowledgedAt: null, deliveredAt: null }]);
+    const { toNotify } = await persistSignals([signal({ severity: 'alert' })], now);
+    expect(toNotify).toHaveLength(1);
+    expect(toNotify[0]!.rowId).toBe('row1');
+  });
+
+  it('never notifies acknowledged rows', async () => {
+    mockOpenRows([{ id: 'row1', partnerId: 'p1', signalKey: 'rmm.consumer_devices', severity: 'alert', acknowledgedAt: new Date(), deliveredAt: null }]);
+    const { toNotify } = await persistSignals([signal({})], now);
+    expect(toNotify).toHaveLength(0);
+  });
+
+  it('resolves open rows that did not fire this sweep', async () => {
+    mockOpenRows([{ id: 'stale', partnerId: 'p9', signalKey: 'rmm.enrollment_velocity', severity: 'watch', acknowledgedAt: null, deliveredAt: null }]);
+    await persistSignals([], now);
+    expect(updates.some((u) => u.set.resolvedAt instanceof Date)).toBe(true);
+  });
+});

--- a/apps/api/src/services/abuseSignals/persistence.test.ts
+++ b/apps/api/src/services/abuseSignals/persistence.test.ts
@@ -49,6 +49,7 @@ describe('persistSignals', () => {
     const { toNotify } = await persistSignals(
       [signal({}), signal({ signalKey: 'rmm.enrollment_velocity', score: 45, severity: 'watch' })],
       now,
+      new Set(['p1']),
     );
     expect(inserted).toHaveLength(2);
     expect(toNotify).toHaveLength(1);
@@ -57,7 +58,7 @@ describe('persistSignals', () => {
 
   it('updates an existing open row without re-notifying a delivered alert', async () => {
     mockOpenRows([{ id: 'row1', partnerId: 'p1', signalKey: 'rmm.consumer_devices', severity: 'alert', acknowledgedAt: null, deliveredAt: new Date() }]);
-    const { toNotify } = await persistSignals([signal({})], now);
+    const { toNotify } = await persistSignals([signal({})], now, new Set(['p1']));
     expect(inserted).toHaveLength(0);
     expect(updates.length).toBeGreaterThan(0);
     expect(toNotify).toHaveLength(0);
@@ -67,20 +68,20 @@ describe('persistSignals', () => {
 
   it('notifies on escalation to alert (open watch row, never delivered)', async () => {
     mockOpenRows([{ id: 'row1', partnerId: 'p1', signalKey: 'rmm.consumer_devices', severity: 'watch', acknowledgedAt: null, deliveredAt: null }]);
-    const { toNotify } = await persistSignals([signal({ severity: 'alert' })], now);
+    const { toNotify } = await persistSignals([signal({ severity: 'alert' })], now, new Set(['p1']));
     expect(toNotify).toHaveLength(1);
     expect(toNotify[0]!.rowId).toBe('row1');
   });
 
   it('never notifies acknowledged rows', async () => {
     mockOpenRows([{ id: 'row1', partnerId: 'p1', signalKey: 'rmm.consumer_devices', severity: 'alert', acknowledgedAt: new Date(), deliveredAt: null }]);
-    const { toNotify } = await persistSignals([signal({})], now);
+    const { toNotify } = await persistSignals([signal({})], now, new Set(['p1']));
     expect(toNotify).toHaveLength(0);
   });
 
-  it('resolves open rows that did not fire this sweep', async () => {
+  it('resolves open rows that did not fire this sweep, for an evaluated partner', async () => {
     mockOpenRows([{ id: 'stale', partnerId: 'p9', signalKey: 'rmm.enrollment_velocity', severity: 'watch', acknowledgedAt: null, deliveredAt: null }]);
-    await persistSignals([], now);
+    await persistSignals([], now, new Set(['p9']));
     expect(updates.some((u) => u.set.resolvedAt instanceof Date)).toBe(true);
   });
 
@@ -89,10 +90,23 @@ describe('persistSignals', () => {
     const { toNotify } = await persistSignals(
       [signal({ score: 50, severity: 'watch' }), signal({ score: 90, severity: 'alert' })],
       now,
+      new Set(['p1']),
     );
     expect(inserted).toHaveLength(1);
     expect((inserted[0] as { score: number }).score).toBe(90);
     expect(toNotify).toHaveLength(1);
+  });
+
+  it('leaves an open heuristic row untouched when its partner was NOT evaluated this sweep (scope exit, not evidence)', async () => {
+    mockOpenRows([{ id: 'stale', partnerId: 'p9', signalKey: 'rmm.enrollment_velocity', severity: 'watch', acknowledgedAt: null, deliveredAt: null }]);
+    await persistSignals([], now, new Set(['p1']));
+    expect(updates.some((u) => u.set.resolvedAt instanceof Date)).toBe(false);
+  });
+
+  it('resolves an open invariant.* row that did not fire this sweep even when its partner is not in the evaluated set', async () => {
+    mockOpenRows([{ id: 'stale-invariant', partnerId: 'p9', signalKey: 'invariant.something', severity: 'watch', acknowledgedAt: null, deliveredAt: null }]);
+    await persistSignals([], now, new Set(['p1']));
+    expect(updates.some((u) => u.set.resolvedAt instanceof Date)).toBe(true);
   });
 });
 

--- a/apps/api/src/services/abuseSignals/persistence.test.ts
+++ b/apps/api/src/services/abuseSignals/persistence.test.ts
@@ -61,6 +61,8 @@ describe('persistSignals', () => {
     expect(inserted).toHaveLength(0);
     expect(updates.length).toBeGreaterThan(0);
     expect(toNotify).toHaveLength(0);
+    expect(updates[0]!.set).not.toHaveProperty('firstFiredAt');
+    expect(updates[0]!.set).not.toHaveProperty('resolvedAt');
   });
 
   it('notifies on escalation to alert (open watch row, never delivered)', async () => {
@@ -80,5 +82,33 @@ describe('persistSignals', () => {
     mockOpenRows([{ id: 'stale', partnerId: 'p9', signalKey: 'rmm.enrollment_velocity', severity: 'watch', acknowledgedAt: null, deliveredAt: null }]);
     await persistSignals([], now);
     expect(updates.some((u) => u.set.resolvedAt instanceof Date)).toBe(true);
+  });
+
+  it('dedupes duplicate (partner, signal) entries within one batch, last write wins', async () => {
+    mockOpenRows([]);
+    const { toNotify } = await persistSignals(
+      [signal({ score: 50, severity: 'watch' }), signal({ score: 90, severity: 'alert' })],
+      now,
+    );
+    expect(inserted).toHaveLength(1);
+    expect((inserted[0] as { score: number }).score).toBe(90);
+    expect(toNotify).toHaveLength(1);
+  });
+});
+
+describe('markDelivered', () => {
+  it('marks rows as delivered with the given date', async () => {
+    const { markDelivered } = await import('./persistence');
+    updates.length = 0;
+    await markDelivered(['r1', 'r2'], now);
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.set.deliveredAt).toEqual(now);
+  });
+
+  it('does not call update when rowIds is empty', async () => {
+    const { markDelivered } = await import('./persistence');
+    updates.length = 0;
+    await markDelivered([], now);
+    expect(updates).toHaveLength(0);
   });
 });

--- a/apps/api/src/services/abuseSignals/persistence.ts
+++ b/apps/api/src/services/abuseSignals/persistence.ts
@@ -15,16 +15,22 @@ export async function persistSignals(
   computed: ComputedSignal[],
   now: Date,
 ): Promise<{ toNotify: Array<ComputedSignal & { rowId: string }> }> {
+  // Defensive: one entry per (partner, signal) — the open-row unique index
+  // would reject a duplicate INSERT mid-loop. Last write wins.
+  const dedupedByKey = new Map<string, ComputedSignal>();
+  for (const s of computed) dedupedByKey.set(key(s.partnerId, s.signalKey), s);
+  const deduped = [...dedupedByKey.values()];
+
   const openRows = await db
     .select()
     .from(partnerAbuseSignals)
     .where(isNull(partnerAbuseSignals.resolvedAt));
 
   const openByKey = new Map(openRows.map((r) => [key(r.partnerId, r.signalKey), r]));
-  const firedKeys = new Set(computed.map((s) => key(s.partnerId, s.signalKey)));
+  const firedKeys = new Set(deduped.map((s) => key(s.partnerId, s.signalKey)));
   const toNotify: Array<ComputedSignal & { rowId: string }> = [];
 
-  for (const s of computed) {
+  for (const s of deduped) {
     const open = openByKey.get(key(s.partnerId, s.signalKey));
     if (!open) {
       const [row] = await db

--- a/apps/api/src/services/abuseSignals/persistence.ts
+++ b/apps/api/src/services/abuseSignals/persistence.ts
@@ -1,6 +1,7 @@
 import { eq, isNull, inArray } from 'drizzle-orm';
 import { db } from '../../db';
 import { partnerAbuseSignals } from '../../db/schema';
+import { captureException } from '../sentry';
 import type { ComputedSignal } from './types';
 
 const key = (partnerId: string, signalKey: string) => `${partnerId}|${signalKey}`;
@@ -57,7 +58,17 @@ export async function persistSignals(
         .returning();
       // noUncheckedIndexedAccess: .returning() is typed as possibly-empty;
       // an INSERT that runs without error always returns the inserted row.
-      if (!row) continue;
+      // In practice this should never happen — but if it does, it's a silent
+      // RLS misconfiguration (a row that INSERT reported success for but the
+      // caller can't read back), not something to quietly skip.
+      if (!row) {
+        console.error('[AbuseSignals] INSERT returned no row — possible RLS misconfiguration', {
+          partnerId: s.partnerId,
+          signalKey: s.signalKey,
+        });
+        captureException(new Error('[AbuseSignals] INSERT returned no row — possible RLS misconfiguration'));
+        continue;
+      }
       if (s.severity === 'alert') toNotify.push({ ...s, rowId: row.id });
       continue;
     }
@@ -67,15 +78,42 @@ export async function persistSignals(
       .set({ severity: s.severity, score: s.score, evidence: s.evidence, computedAt: now })
       .where(eq(partnerAbuseSignals.id, open.id));
 
+    // An open row that was never delivered/acknowledged must still notify if
+    // EITHER this sweep's severity is 'alert' OR the row was already sitting
+    // at 'alert' severity before this update — otherwise a decayed-but-
+    // undelivered alert (e.g. score dropped back to 'watch' this sweep
+    // before ever reaching an operator) would silently vanish without ever
+    // having been seen.
+    const hadUndeliveredAlert = open.severity === 'alert' && open.deliveredAt === null;
     const notifiable =
-      s.severity === 'alert' && open.deliveredAt === null && open.acknowledgedAt === null;
+      (s.severity === 'alert' || hadUndeliveredAlert) &&
+      open.deliveredAt === null &&
+      open.acknowledgedAt === null;
     if (notifiable) toNotify.push({ ...s, rowId: open.id });
   }
 
-  const staleIds = openRows
+  const staleRows = openRows
     .filter((r) => !firedKeys.has(key(r.partnerId, r.signalKey)))
-    .filter((r) => r.signalKey.startsWith('invariant.') || evaluatedPartnerIds.has(r.partnerId))
-    .map((r) => r.id);
+    .filter((r) => r.signalKey.startsWith('invariant.') || evaluatedPartnerIds.has(r.partnerId));
+
+  // An alert-grade condition that was never delivered or acknowledged is
+  // about to be auto-resolved as stale — i.e. it will disappear having never
+  // been seen by an operator. That's worth a loud record even though we
+  // still resolve it (the condition genuinely cleared; we just want a trail).
+  for (const r of staleRows) {
+    if (r.severity === 'alert' && r.deliveredAt === null && r.acknowledgedAt === null) {
+      console.error('[AbuseSignals] Resolving an undelivered alert-severity signal as stale', {
+        rowId: r.id,
+        partnerId: r.partnerId,
+        signalKey: r.signalKey,
+      });
+      captureException(
+        new Error('[AbuseSignals] Resolving an undelivered alert-severity signal as stale'),
+      );
+    }
+  }
+
+  const staleIds = staleRows.map((r) => r.id);
   if (staleIds.length > 0) {
     await db
       .update(partnerAbuseSignals)

--- a/apps/api/src/services/abuseSignals/persistence.ts
+++ b/apps/api/src/services/abuseSignals/persistence.ts
@@ -10,10 +10,20 @@ const key = (partnerId: string, signalKey: string) => `${partnerId}|${signalKey}
  * dedup: notify on first alert firing or on escalation-to-alert, never on
  * hourly recomputation of an already-delivered alert. MUST run inside a
  * system DB context.
+ *
+ * Stale-resolution rule (state-machine rule 3): an open row is auto-resolved
+ * as stale ONLY when (a) its signalKey is an `invariant.*` row — those are
+ * computed fleet-wide every sweep, so absence this sweep is real evidence
+ * the condition cleared — OR (b) its partnerId is in `evaluatedPartnerIds`,
+ * i.e. this sweep actually scored that partner and it simply didn't fire.
+ * Rows belonging to a partner the `scoped` CTE excluded this sweep (aged out
+ * of the young/recently-enrolling window) are left untouched — resolving
+ * them would be resolving on scope exit, not on evidence the abuse cleared.
  */
 export async function persistSignals(
   computed: ComputedSignal[],
   now: Date,
+  evaluatedPartnerIds: ReadonlySet<string>,
 ): Promise<{ toNotify: Array<ComputedSignal & { rowId: string }> }> {
   // Defensive: one entry per (partner, signal) — the open-row unique index
   // would reject a duplicate INSERT mid-loop. Last write wins.
@@ -64,6 +74,7 @@ export async function persistSignals(
 
   const staleIds = openRows
     .filter((r) => !firedKeys.has(key(r.partnerId, r.signalKey)))
+    .filter((r) => r.signalKey.startsWith('invariant.') || evaluatedPartnerIds.has(r.partnerId))
     .map((r) => r.id);
   if (staleIds.length > 0) {
     await db

--- a/apps/api/src/services/abuseSignals/persistence.ts
+++ b/apps/api/src/services/abuseSignals/persistence.ts
@@ -1,0 +1,79 @@
+import { eq, isNull, inArray } from 'drizzle-orm';
+import { db } from '../../db';
+import { partnerAbuseSignals } from '../../db/schema';
+import type { ComputedSignal } from './types';
+
+const key = (partnerId: string, signalKey: string) => `${partnerId}|${signalKey}`;
+
+/**
+ * Reconciles this sweep's computed signals against open rows. State-based
+ * dedup: notify on first alert firing or on escalation-to-alert, never on
+ * hourly recomputation of an already-delivered alert. MUST run inside a
+ * system DB context.
+ */
+export async function persistSignals(
+  computed: ComputedSignal[],
+  now: Date,
+): Promise<{ toNotify: Array<ComputedSignal & { rowId: string }> }> {
+  const openRows = await db
+    .select()
+    .from(partnerAbuseSignals)
+    .where(isNull(partnerAbuseSignals.resolvedAt));
+
+  const openByKey = new Map(openRows.map((r) => [key(r.partnerId, r.signalKey), r]));
+  const firedKeys = new Set(computed.map((s) => key(s.partnerId, s.signalKey)));
+  const toNotify: Array<ComputedSignal & { rowId: string }> = [];
+
+  for (const s of computed) {
+    const open = openByKey.get(key(s.partnerId, s.signalKey));
+    if (!open) {
+      const [row] = await db
+        .insert(partnerAbuseSignals)
+        .values({
+          partnerId: s.partnerId,
+          signalKey: s.signalKey,
+          severity: s.severity,
+          score: s.score,
+          evidence: s.evidence,
+          firstFiredAt: now,
+          computedAt: now,
+        })
+        .returning();
+      // noUncheckedIndexedAccess: .returning() is typed as possibly-empty;
+      // an INSERT that runs without error always returns the inserted row.
+      if (!row) continue;
+      if (s.severity === 'alert') toNotify.push({ ...s, rowId: row.id });
+      continue;
+    }
+
+    await db
+      .update(partnerAbuseSignals)
+      .set({ severity: s.severity, score: s.score, evidence: s.evidence, computedAt: now })
+      .where(eq(partnerAbuseSignals.id, open.id));
+
+    const notifiable =
+      s.severity === 'alert' && open.deliveredAt === null && open.acknowledgedAt === null;
+    if (notifiable) toNotify.push({ ...s, rowId: open.id });
+  }
+
+  const staleIds = openRows
+    .filter((r) => !firedKeys.has(key(r.partnerId, r.signalKey)))
+    .map((r) => r.id);
+  if (staleIds.length > 0) {
+    await db
+      .update(partnerAbuseSignals)
+      .set({ resolvedAt: now })
+      .where(inArray(partnerAbuseSignals.id, staleIds));
+  }
+
+  return { toNotify };
+}
+
+/** MUST run inside a system DB context. */
+export async function markDelivered(rowIds: string[], now: Date): Promise<void> {
+  if (rowIds.length === 0) return;
+  await db
+    .update(partnerAbuseSignals)
+    .set({ deliveredAt: now })
+    .where(inArray(partnerAbuseSignals.id, rowIds));
+}

--- a/apps/api/src/services/abuseSignals/sweep.test.ts
+++ b/apps/api/src/services/abuseSignals/sweep.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { PartnerAggregates } from './heuristics';
+import type { ComputedSignal } from './types';
+
+const {
+  computeInvariantSignals,
+  loadPartnerAggregates,
+  computeHeuristicSignals,
+  persistSignals,
+  markDelivered,
+  sendOpsAlert,
+  recordAbuseSignalFired,
+} = vi.hoisted(() => ({
+  computeInvariantSignals: vi.fn(),
+  loadPartnerAggregates: vi.fn(),
+  computeHeuristicSignals: vi.fn(),
+  persistSignals: vi.fn(),
+  markDelivered: vi.fn(),
+  sendOpsAlert: vi.fn(),
+  recordAbuseSignalFired: vi.fn(),
+}));
+
+// Context helpers as pass-through fns — the sweep's own runSystemDbCompute
+// wiring (Fix 4: hard-throws if either is missing) is covered separately;
+// here we just need them to be functions so the sweep runs.
+vi.mock('../../db', () => ({
+  // `db` itself is only used by runAbuseDigest (not exercised by this file's
+  // tests), but index.ts destructures it at module load time.
+  db: {},
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+}));
+
+vi.mock('./invariants', () => ({ computeInvariantSignals }));
+vi.mock('./heuristics', () => ({ loadPartnerAggregates, computeHeuristicSignals }));
+vi.mock('./persistence', () => ({ persistSignals, markDelivered }));
+vi.mock('../opsAlerts', () => ({ sendOpsAlert, isOpsAlertingConfigured: vi.fn(() => true) }));
+vi.mock('../abuseMetrics', () => ({ recordAbuseSignalFired, recordAbuseSweepRun: vi.fn() }));
+
+import { runAbuseSweep } from './index';
+
+function agg(overrides: Partial<PartnerAggregates>): PartnerAggregates {
+  return {
+    partnerId: 'p1',
+    partnerName: 'Acme',
+    partnerCreatedAt: new Date('2026-07-01T00:00:00Z'),
+    deviceCount: 0,
+    consumerHostnameCount: 0,
+    enrolled24h: 0,
+    distinctEnrollmentIps30d: 0,
+    devicesEnrolled30d: 0,
+    sessions7d: 0,
+    fastRemoteSessions7d: 0,
+    failedLogins24h: 0,
+    enrollmentDenied24h: 0,
+    commands24h: 0,
+    scriptExecutions24h: 0,
+    ...overrides,
+  };
+}
+
+function notifiable(rowId: string, partnerId = 'p1'): ComputedSignal & { rowId: string } {
+  return {
+    partnerId,
+    signalKey: 'rmm.consumer_devices',
+    score: 90,
+    severity: 'alert',
+    evidence: {},
+    rowId,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  computeInvariantSignals.mockResolvedValue([]);
+  loadPartnerAggregates.mockResolvedValue([agg({})]);
+  computeHeuristicSignals.mockReturnValue([]);
+  persistSignals.mockResolvedValue({ toNotify: [] });
+  markDelivered.mockResolvedValue(undefined);
+});
+
+describe('runAbuseSweep', () => {
+  it('marks every notifiable row delivered when every send succeeds', async () => {
+    persistSignals.mockResolvedValue({ toNotify: [notifiable('r1'), notifiable('r2')] });
+    sendOpsAlert.mockResolvedValue(true);
+
+    const result = await runAbuseSweep();
+
+    expect(markDelivered).toHaveBeenCalledTimes(1);
+    expect(markDelivered.mock.calls[0]![0]).toEqual(['r1', 'r2']);
+    expect(result.notified).toBe(2);
+  });
+
+  it('does not call markDelivered when sendOpsAlert returns false for everything', async () => {
+    persistSignals.mockResolvedValue({ toNotify: [notifiable('r1'), notifiable('r2')] });
+    sendOpsAlert.mockResolvedValue(false);
+
+    const result = await runAbuseSweep();
+
+    expect(markDelivered).not.toHaveBeenCalled();
+    expect(result.notified).toBe(0);
+  });
+
+  it('marks only the rows whose delivery succeeded when delivery is partial', async () => {
+    persistSignals.mockResolvedValue({
+      toNotify: [notifiable('r1'), notifiable('r2'), notifiable('r3')],
+    });
+    sendOpsAlert
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    const result = await runAbuseSweep();
+
+    expect(markDelivered).toHaveBeenCalledTimes(1);
+    expect(markDelivered.mock.calls[0]![0]).toEqual(['r1', 'r3']);
+    expect(result.notified).toBe(2);
+  });
+
+  it('passes persistSignals an evaluatedPartnerIds set built from the aggregates partnerIds', async () => {
+    loadPartnerAggregates.mockResolvedValue([agg({ partnerId: 'pA' }), agg({ partnerId: 'pB' })]);
+
+    await runAbuseSweep();
+
+    expect(persistSignals).toHaveBeenCalledTimes(1);
+    const evaluatedPartnerIds = persistSignals.mock.calls[0]![2] as Set<string>;
+    expect(evaluatedPartnerIds).toBeInstanceOf(Set);
+    expect([...evaluatedPartnerIds].sort()).toEqual(['pA', 'pB']);
+  });
+});

--- a/apps/api/src/services/abuseSignals/types.ts
+++ b/apps/api/src/services/abuseSignals/types.ts
@@ -1,0 +1,10 @@
+export type AbuseSeverity = 'info' | 'watch' | 'alert';
+
+export interface ComputedSignal {
+  partnerId: string;
+  signalKey: string;
+  /** 0-100 after young-account weighting. */
+  score: number;
+  severity: AbuseSeverity;
+  evidence: Record<string, unknown>;
+}

--- a/apps/api/src/services/opsAlerts.test.ts
+++ b/apps/api/src/services/opsAlerts.test.ts
@@ -5,9 +5,13 @@ vi.mock('./urlSafety', () => ({
   SsrfBlockedError: class SsrfBlockedError extends Error {},
 }));
 vi.mock('./email', () => ({ getEmailService: vi.fn(() => null) }));
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+vi.mock('./abuseMetrics', () => ({ recordOpsAlertDelivery: vi.fn() }));
 
 import { safeFetch } from './urlSafety';
 import { getEmailService } from './email';
+import { captureException } from './sentry';
+import { recordOpsAlertDelivery } from './abuseMetrics';
 import { sendOpsAlert, isOpsAlertingConfigured } from './opsAlerts';
 
 beforeEach(() => {
@@ -28,6 +32,7 @@ describe('sendOpsAlert', () => {
     const [url, init] = vi.mocked(safeFetch).mock.calls[0]!;
     expect(url).toBe(process.env.OPS_ALERT_WEBHOOK_URL);
     expect(JSON.parse(init!.body as string).content).toContain('Test alert');
+    expect(recordOpsAlertDelivery).toHaveBeenCalledWith('webhook', 'success');
   });
 
   it('prefixes the title with OPS_ALERT_LABEL when set', async () => {
@@ -56,6 +61,21 @@ describe('sendOpsAlert', () => {
   it('returns false on webhook failure and does not throw', async () => {
     vi.mocked(safeFetch).mockRejectedValue(new Error('network down'));
     expect(await sendOpsAlert({ title: 'T', body: 'b' })).toBe(false);
+    expect(captureException).toHaveBeenCalled();
+    expect(recordOpsAlertDelivery).toHaveBeenCalledWith('webhook', 'failure');
+  });
+
+  it('surfaces a non-2xx webhook response to Sentry and the delivery metric, with a body snippet', async () => {
+    vi.mocked(safeFetch).mockResolvedValue(
+      new Response('{"message":"rate limited"}', { status: 429 }),
+    );
+    const ok = await sendOpsAlert({ title: 'T', body: 'b' });
+    expect(ok).toBe(false);
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const err = vi.mocked(captureException).mock.calls[0]![0] as Error;
+    expect(err.message).toContain('429');
+    expect(err.message).toContain('rate limited');
+    expect(recordOpsAlertDelivery).toHaveBeenCalledWith('webhook', 'failure');
   });
 
   it('falls back to email channel when configured', async () => {

--- a/apps/api/src/services/opsAlerts.test.ts
+++ b/apps/api/src/services/opsAlerts.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('./urlSafety', () => ({
+  safeFetch: vi.fn(),
+  SsrfBlockedError: class SsrfBlockedError extends Error {},
+}));
+vi.mock('./email', () => ({ getEmailService: vi.fn(() => null) }));
+
+import { safeFetch } from './urlSafety';
+import { getEmailService } from './email';
+import { sendOpsAlert, isOpsAlertingConfigured } from './opsAlerts';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.OPS_ALERT_WEBHOOK_URL = 'https://discord.example.com/api/webhooks/x/y';
+  delete process.env.OPS_ALERT_EMAIL;
+  delete process.env.OPS_ALERT_LABEL;
+});
+afterEach(() => {
+  delete process.env.OPS_ALERT_WEBHOOK_URL;
+});
+
+describe('sendOpsAlert', () => {
+  it('POSTs Discord-format content and returns true on 2xx', async () => {
+    vi.mocked(safeFetch).mockResolvedValue(new Response(null, { status: 204 }));
+    const ok = await sendOpsAlert({ title: 'Test alert', body: 'evidence here' });
+    expect(ok).toBe(true);
+    const [url, init] = vi.mocked(safeFetch).mock.calls[0]!;
+    expect(url).toBe(process.env.OPS_ALERT_WEBHOOK_URL);
+    expect(JSON.parse(init!.body as string).content).toContain('Test alert');
+  });
+
+  it('prefixes the title with OPS_ALERT_LABEL when set', async () => {
+    process.env.OPS_ALERT_LABEL = 'US';
+    vi.mocked(safeFetch).mockResolvedValue(new Response(null, { status: 204 }));
+    await sendOpsAlert({ title: 'Test', body: 'b' });
+    const [, init] = vi.mocked(safeFetch).mock.calls[0]!;
+    expect(JSON.parse(init!.body as string).content).toContain('[US]');
+  });
+
+  it('truncates content to Discord 2000-char limit', async () => {
+    vi.mocked(safeFetch).mockResolvedValue(new Response(null, { status: 204 }));
+    await sendOpsAlert({ title: 'T', body: 'x'.repeat(3000) });
+    const [, init] = vi.mocked(safeFetch).mock.calls[0]!;
+    expect(JSON.parse(init!.body as string).content.length).toBeLessThanOrEqual(2000);
+  });
+
+  it('returns false when no channel is configured, warning once', async () => {
+    delete process.env.OPS_ALERT_WEBHOOK_URL;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(await sendOpsAlert({ title: 'T', body: 'b' })).toBe(false);
+    expect(safeFetch).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('returns false on webhook failure and does not throw', async () => {
+    vi.mocked(safeFetch).mockRejectedValue(new Error('network down'));
+    expect(await sendOpsAlert({ title: 'T', body: 'b' })).toBe(false);
+  });
+
+  it('falls back to email channel when configured', async () => {
+    delete process.env.OPS_ALERT_WEBHOOK_URL;
+    process.env.OPS_ALERT_EMAIL = 'ops@example.com';
+    const sendEmail = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getEmailService).mockReturnValue({ sendEmail } as never);
+    expect(await sendOpsAlert({ title: 'T', body: 'b' })).toBe(true);
+    expect(sendEmail).toHaveBeenCalledWith(expect.objectContaining({ to: 'ops@example.com' }));
+  });
+});
+
+describe('isOpsAlertingConfigured', () => {
+  it('reflects env state', () => {
+    expect(isOpsAlertingConfigured()).toBe(true);
+    delete process.env.OPS_ALERT_WEBHOOK_URL;
+    expect(isOpsAlertingConfigured()).toBe(false);
+  });
+});
+
+describe('sendOpsAlert unconfigured warning latch', () => {
+  it('warns only once across multiple calls within the same module instance', async () => {
+    vi.resetModules();
+    const urlSafety = await import('./urlSafety');
+    vi.mocked(urlSafety.safeFetch).mockResolvedValue(new Response(null, { status: 204 }));
+    delete process.env.OPS_ALERT_WEBHOOK_URL;
+    delete process.env.OPS_ALERT_EMAIL;
+    const { sendOpsAlert: freshSendOpsAlert } = await import('./opsAlerts');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const opsAlertsCallCount = () =>
+      warn.mock.calls.filter((call) => String(call[0]).includes('[OpsAlerts]')).length;
+    expect(await freshSendOpsAlert({ title: 'T', body: 'b' })).toBe(false);
+    expect(opsAlertsCallCount()).toBe(1);
+    expect(await freshSendOpsAlert({ title: 'T2', body: 'b2' })).toBe(false);
+    expect(opsAlertsCallCount()).toBe(1);
+  });
+});

--- a/apps/api/src/services/opsAlerts.test.ts
+++ b/apps/api/src/services/opsAlerts.test.ts
@@ -74,6 +74,11 @@ describe('isOpsAlertingConfigured', () => {
     delete process.env.OPS_ALERT_WEBHOOK_URL;
     expect(isOpsAlertingConfigured()).toBe(false);
   });
+
+  it('treats whitespace-only values as unconfigured', () => {
+    process.env.OPS_ALERT_WEBHOOK_URL = '   ';
+    expect(isOpsAlertingConfigured()).toBe(false);
+  });
 });
 
 describe('sendOpsAlert unconfigured warning latch', () => {

--- a/apps/api/src/services/opsAlerts.ts
+++ b/apps/api/src/services/opsAlerts.ts
@@ -1,0 +1,85 @@
+import { safeFetch } from './urlSafety';
+import { getEmailService } from './email';
+import { captureException } from './sentry';
+
+export interface OpsAlertMessage {
+  title: string;
+  body: string;
+}
+
+const DISCORD_CONTENT_LIMIT = 2000;
+const WEBHOOK_TIMEOUT_MS = 10_000;
+let warnedUnconfigured = false;
+
+export function isOpsAlertingConfigured(): boolean {
+  return Boolean(process.env.OPS_ALERT_WEBHOOK_URL || process.env.OPS_ALERT_EMAIL);
+}
+
+function formatContent(msg: OpsAlertMessage): string {
+  const label = process.env.OPS_ALERT_LABEL?.trim();
+  const title = label ? `[${label}] ${msg.title}` : msg.title;
+  return `**${title}**\n${msg.body}`.slice(0, DISCORD_CONTENT_LIMIT);
+}
+
+async function sendWebhook(url: string, msg: OpsAlertMessage): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+    const response = await safeFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': 'Breeze-RMM/1.0' },
+      body: JSON.stringify({ content: formatContent(msg) }),
+      signal: controller.signal,
+      redirect: 'error',
+    });
+    clearTimeout(timeoutId);
+    if (!response.ok) {
+      console.error(`[OpsAlerts] Webhook responded ${response.status}`);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error('[OpsAlerts] Webhook delivery failed:', error instanceof Error ? error.message : error);
+    captureException(error);
+    return false;
+  }
+}
+
+async function sendOpsEmail(to: string, msg: OpsAlertMessage): Promise<boolean> {
+  const email = getEmailService();
+  if (!email) {
+    console.warn('[OpsAlerts] OPS_ALERT_EMAIL set but email service not configured');
+    return false;
+  }
+  try {
+    await email.sendEmail({
+      to,
+      subject: `[Breeze ops] ${msg.title}`,
+      text: msg.body,
+      html: `<pre>${msg.body.replace(/</g, '&lt;')}</pre>`,
+    });
+    return true;
+  } catch (error) {
+    console.error('[OpsAlerts] Email delivery failed:', error instanceof Error ? error.message : error);
+    captureException(error);
+    return false;
+  }
+}
+
+/** Delivers to every configured channel; true if at least one succeeded. Never throws. */
+export async function sendOpsAlert(msg: OpsAlertMessage): Promise<boolean> {
+  const webhookUrl = process.env.OPS_ALERT_WEBHOOK_URL?.trim();
+  const emailTo = process.env.OPS_ALERT_EMAIL?.trim();
+  if (!webhookUrl && !emailTo) {
+    if (!warnedUnconfigured) {
+      console.warn('[OpsAlerts] No OPS_ALERT_WEBHOOK_URL or OPS_ALERT_EMAIL configured — ops alerts disabled');
+      warnedUnconfigured = true;
+    }
+    return false;
+  }
+  const results = await Promise.all([
+    webhookUrl ? sendWebhook(webhookUrl, msg) : Promise.resolve(false),
+    emailTo ? sendOpsEmail(emailTo, msg) : Promise.resolve(false),
+  ]);
+  return results.some(Boolean);
+}

--- a/apps/api/src/services/opsAlerts.ts
+++ b/apps/api/src/services/opsAlerts.ts
@@ -12,7 +12,7 @@ const WEBHOOK_TIMEOUT_MS = 10_000;
 let warnedUnconfigured = false;
 
 export function isOpsAlertingConfigured(): boolean {
-  return Boolean(process.env.OPS_ALERT_WEBHOOK_URL || process.env.OPS_ALERT_EMAIL);
+  return Boolean(process.env.OPS_ALERT_WEBHOOK_URL?.trim() || process.env.OPS_ALERT_EMAIL?.trim());
 }
 
 function formatContent(msg: OpsAlertMessage): string {
@@ -22,9 +22,9 @@ function formatContent(msg: OpsAlertMessage): string {
 }
 
 async function sendWebhook(url: string, msg: OpsAlertMessage): Promise<boolean> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
   try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
     const response = await safeFetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'User-Agent': 'Breeze-RMM/1.0' },
@@ -32,7 +32,6 @@ async function sendWebhook(url: string, msg: OpsAlertMessage): Promise<boolean> 
       signal: controller.signal,
       redirect: 'error',
     });
-    clearTimeout(timeoutId);
     if (!response.ok) {
       console.error(`[OpsAlerts] Webhook responded ${response.status}`);
       return false;
@@ -42,6 +41,8 @@ async function sendWebhook(url: string, msg: OpsAlertMessage): Promise<boolean> 
     console.error('[OpsAlerts] Webhook delivery failed:', error instanceof Error ? error.message : error);
     captureException(error);
     return false;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 
@@ -56,7 +57,7 @@ async function sendOpsEmail(to: string, msg: OpsAlertMessage): Promise<boolean> 
       to,
       subject: `[Breeze ops] ${msg.title}`,
       text: msg.body,
-      html: `<pre>${msg.body.replace(/</g, '&lt;')}</pre>`,
+      html: `<pre>${msg.body.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`,
     });
     return true;
   } catch (error) {

--- a/apps/api/src/services/opsAlerts.ts
+++ b/apps/api/src/services/opsAlerts.ts
@@ -1,6 +1,7 @@
 import { safeFetch } from './urlSafety';
 import { getEmailService } from './email';
 import { captureException } from './sentry';
+import { recordOpsAlertDelivery } from './abuseMetrics';
 
 export interface OpsAlertMessage {
   title: string;
@@ -33,13 +34,23 @@ async function sendWebhook(url: string, msg: OpsAlertMessage): Promise<boolean> 
       redirect: 'error',
     });
     if (!response.ok) {
-      console.error(`[OpsAlerts] Webhook responded ${response.status}`);
+      let snippet = '';
+      try {
+        snippet = (await response.text()).slice(0, 300);
+      } catch {
+        // best-effort — body read failures shouldn't mask the status itself
+      }
+      console.error(`[OpsAlerts] Webhook responded ${response.status}: ${snippet}`);
+      captureException(new Error(`[OpsAlerts] Webhook responded ${response.status}: ${snippet}`));
+      recordOpsAlertDelivery('webhook', 'failure');
       return false;
     }
+    recordOpsAlertDelivery('webhook', 'success');
     return true;
   } catch (error) {
     console.error('[OpsAlerts] Webhook delivery failed:', error instanceof Error ? error.message : error);
     captureException(error);
+    recordOpsAlertDelivery('webhook', 'failure');
     return false;
   } finally {
     clearTimeout(timeoutId);
@@ -59,10 +70,12 @@ async function sendOpsEmail(to: string, msg: OpsAlertMessage): Promise<boolean> 
       text: msg.body,
       html: `<pre>${msg.body.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`,
     });
+    recordOpsAlertDelivery('email', 'success');
     return true;
   } catch (error) {
     console.error('[OpsAlerts] Email delivery failed:', error instanceof Error ? error.message : error);
     captureException(error);
+    recordOpsAlertDelivery('email', 'failure');
     return false;
   }
 }

--- a/apps/api/src/services/partnerCreate.test.ts
+++ b/apps/api/src/services/partnerCreate.test.ts
@@ -106,6 +106,7 @@ describe('createPartner', () => {
       adminName: 'Alex',
       passwordHash: 'hashed',
       origin: { mcp: false },
+      status: 'active',
     });
 
     // Basic return shape.
@@ -148,6 +149,7 @@ describe('createPartner', () => {
       adminName: 'Alex',
       passwordHash: 'hashed',
       origin: { mcp: false },
+      status: 'active',
     });
 
     const statusCalls = insertCalls.filter((c) => (c.table as any).__t === 'ticket_statuses');
@@ -181,6 +183,7 @@ describe('createPartner', () => {
       adminName: 'Alex',
       passwordHash: null,
       origin: { mcp: true, ip: '1.2.3.4', userAgent: 'ClaudeAgent/1.0' },
+      status: 'pending',
     });
 
     expect(result.mcpOrigin).toBe(true);

--- a/apps/api/src/services/partnerCreate.test.ts
+++ b/apps/api/src/services/partnerCreate.test.ts
@@ -200,4 +200,22 @@ describe('createPartner', () => {
     const userCall = insertCalls.find((c) => (c.table as any).__t === 'users')!;
     expect(userCall.values.passwordHash).toBeNull();
   });
+
+  it('tags partner with signup_ip/signup_user_agent (not mcp_origin_*) when origin.mcp is false', async () => {
+    await createPartner({
+      orgName: 'Acme',
+      adminEmail: 'alex@acme.com',
+      adminName: 'Alex',
+      passwordHash: 'hashed',
+      origin: { mcp: false, ip: '198.51.100.7', userAgent: 'ua' },
+      status: 'active',
+    });
+
+    const partnerCall = insertCalls.find((c) => (c.table as any).__t === 'partners')!;
+    expect(partnerCall.values).toMatchObject({
+      signupIp: '198.51.100.7',
+      signupUserAgent: 'ua',
+      mcpOriginIp: null,
+    });
+  });
 });

--- a/apps/api/src/services/partnerCreate.ts
+++ b/apps/api/src/services/partnerCreate.ts
@@ -18,7 +18,9 @@ export interface CreatePartnerInput {
   adminName: string;
   /** Null for MCP-originated bootstraps; users set their password later. */
   passwordHash: string | null;
-  origin: { mcp: false } | { mcp: true; ip?: string; userAgent?: string };
+  origin:
+    | { mcp: false; ip?: string; userAgent?: string }
+    | { mcp: true; ip?: string; userAgent?: string };
   /**
    * Initial partner status. Defaults to 'active' if omitted.
    * Hosted signups should pass 'pending' so the existing partnerGuard
@@ -74,6 +76,8 @@ export async function createPartner(input: CreatePartnerInput): Promise<CreatePa
         mcpOrigin,
         mcpOriginIp: mcpOrigin ? (input.origin as { ip?: string }).ip ?? null : null,
         mcpOriginUserAgent: mcpOrigin ? (input.origin as { userAgent?: string }).userAgent ?? null : null,
+        signupIp: !mcpOrigin ? (input.origin as { ip?: string }).ip ?? null : null,
+        signupUserAgent: !mcpOrigin ? (input.origin as { userAgent?: string }).userAgent ?? null : null,
       })
       .returning();
 

--- a/apps/api/src/services/partnerCreate.ts
+++ b/apps/api/src/services/partnerCreate.ts
@@ -22,12 +22,11 @@ export interface CreatePartnerInput {
     | { mcp: false; ip?: string; userAgent?: string }
     | { mcp: true; ip?: string; userAgent?: string };
   /**
-   * Initial partner status. Defaults to 'active' if omitted.
-   * Hosted signups should pass 'pending' so the existing partnerGuard
-   * middleware (status !== 'active' → 402) blocks features until
-   * breeze-billing flips the partner to 'active' post-payment.
+   * Initial partner status — REQUIRED so no future caller silently mints an
+   * 'active' partner. Hosted signups pass 'pending' (partnerGuard blocks
+   * features until breeze-billing activates post-payment + email verify).
    */
-  status?: PartnerStatus;
+  status: PartnerStatus;
 }
 
 export interface CreatePartnerResult {
@@ -71,7 +70,7 @@ export async function createPartner(input: CreatePartnerInput): Promise<CreatePa
         slug,
         type: 'msp',
         plan: 'free',
-        status: input.status ?? (mcpOrigin ? 'pending' : 'active'),
+        status: input.status,
         billingEmail: normalizedEmail,
         mcpOrigin,
         mcpOriginIp: mcpOrigin ? (input.origin as { ip?: string }).ip ?? null : null,

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -148,6 +148,13 @@ services:
       MSI_SIGNING_URL: ${MSI_SIGNING_URL:-}
       MSI_SIGNING_CF_ACCESS_ID: ${MSI_SIGNING_CF_ACCESS_ID:-}
       MSI_SIGNING_CF_ACCESS_SECRET: ${MSI_SIGNING_CF_ACCESS_SECRET:-}
+      # Signup-abuse-detection sweep (docs/superpowers/specs/2026-07-11-signup-abuse-detection-design.md).
+      # Optional — empty/unmapped means ops alerting stays dark and per-signal
+      # thresholds fall back to config.ts defaults.
+      OPS_ALERT_WEBHOOK_URL: ${OPS_ALERT_WEBHOOK_URL:-}
+      OPS_ALERT_EMAIL: ${OPS_ALERT_EMAIL:-}
+      OPS_ALERT_LABEL: ${OPS_ALERT_LABEL:-}
+      ABUSE_SIGNAL_OVERRIDES: ${ABUSE_SIGNAL_OVERRIDES:-}
     volumes:
       - api_data:/data
       - binaries:/data/binaries:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,11 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-info}
       LOG_JSON: ${LOG_JSON:-true}
       METRICS_SCRAPE_TOKEN: ${METRICS_SCRAPE_TOKEN:-}
+      # Platform-operator abuse alerts (all optional; unset = feature disabled)
+      OPS_ALERT_WEBHOOK_URL: ${OPS_ALERT_WEBHOOK_URL:-}
+      OPS_ALERT_EMAIL: ${OPS_ALERT_EMAIL:-}
+      OPS_ALERT_LABEL: ${OPS_ALERT_LABEL:-}
+      ABUSE_SIGNAL_OVERRIDES: ${ABUSE_SIGNAL_OVERRIDES:-}
       SENTRY_DSN: ${SENTRY_DSN:-}
       SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-production}
       SENTRY_RELEASE: ${SENTRY_RELEASE:-}

--- a/docs/superpowers/plans/2026-07-11-signup-abuse-detection.md
+++ b/docs/superpowers/plans/2026-07-11-signup-abuse-detection.md
@@ -1,0 +1,1989 @@
+# Signup Abuse Detection Implementation Plan (PR 1: data capture + PR 2: sweep/alerting)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist signup/enrollment attribution data and run an hourly deterministic abuse-signals sweep that alerts the platform operator (Discord webhook/email) on activation-invariant breaches and malicious-RMM-use heuristics.
+
+**Architecture:** New nullable attribution columns on `partners`/`devices` written on existing hot paths; a system-scoped `partner_abuse_signals` table (RLS deny-all to tenants) fed by an hourly BullMQ job; pure-function signal scoring over fleet-grouped SQL aggregates; a standalone `opsAlerts` service with state-based dedup so alerts fire once per signal lifecycle.
+
+**Tech Stack:** Hono, Drizzle ORM + raw `sql` aggregates, BullMQ, Vitest with Drizzle mocks, `safeFetch` for outbound webhooks.
+
+**Spec:** `docs/superpowers/specs/2026-07-11-signup-abuse-detection-design.md`
+
+## Global Constraints
+
+- RLS: `partner_abuse_signals` must be readable/writable ONLY under the system DB context (`current_setting('breeze.scope', true) = 'system'`). Never add `breeze_has_partner_access` policies to it — partners must not see signals about themselves.
+- Background DB access always goes through `runOutsideDbContext(() => withSystemDbAccessContext(...))` (the #1105 pattern); a bare `db` read from a worker silently returns 0 rows.
+- Migrations: filename `YYYY-MM-DD-<slug>.sql` (adjust date prefix to the actual implementation date; keep relative order), idempotent (`IF NOT EXISTS`, `pg_policies` checks), no inner `BEGIN;`/`COMMIT;`, never edit shipped migrations.
+- BullMQ jobIds use `-`, never `:`.
+- New env vars are OPTIONAL: unset → logged warning + no-op, never boot refusal. No IPs, hostnames, webhook URLs, or tenant identifiers in code, config templates, tests, or comments.
+- IP columns are `varchar(45)`, user agents are `text` (house style per `sessions`).
+- Tests live alongside source files. Run API tests with `pnpm test --filter=@breeze/api` (or `npx vitest run <file>` inside `apps/api`).
+- Commit after each task with a conventional-commit message.
+
+---
+
+### Task 1: Attribution columns (schema + migration)
+
+**Files:**
+- Modify: `apps/api/src/db/schema/orgs.ts` (partners table, after `mcpOriginUserAgent` ~line 34)
+- Modify: `apps/api/src/db/schema/devices.ts` (devices table, after `lastSeenIp` ~line 46)
+- Create: `apps/api/migrations/2026-07-12-signup-attribution-columns.sql`
+
+**Interfaces:**
+- Produces: `partners.signupIp`, `partners.signupUserAgent`, `devices.enrollmentIp` Drizzle columns used by Tasks 2, 3, 8.
+
+- [ ] **Step 1: Add columns to the Drizzle schema**
+
+In `apps/api/src/db/schema/orgs.ts`, directly after the `mcpOriginUserAgent` line inside `partners`:
+
+```ts
+  // Signup attribution for web registrations (abuse detection). MCP-originated
+  // signups already record mcp_origin_ip/mcp_origin_user_agent above.
+  signupIp: varchar('signup_ip', { length: 45 }),
+  signupUserAgent: text('signup_user_agent'),
+```
+
+In `apps/api/src/db/schema/devices.ts`, directly after the `lastSeenIp` line inside `devices`:
+
+```ts
+  // Public IP the agent enrolled from (point-in-time; lastSeenIp above tracks
+  // the ongoing value). Feeds the abuse-signals sweep's IP-spread heuristics.
+  enrollmentIp: varchar('enrollment_ip', { length: 45 }),
+```
+
+- [ ] **Step 2: Write the migration**
+
+Create `apps/api/migrations/2026-07-12-signup-attribution-columns.sql`:
+
+```sql
+-- Signup/enrollment attribution columns for abuse detection.
+-- Nullable; existing rows stay NULL. Idempotent.
+
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS signup_ip varchar(45);
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS signup_user_agent text;
+ALTER TABLE devices ADD COLUMN IF NOT EXISTS enrollment_ip varchar(45);
+```
+
+- [ ] **Step 3: Verify migrations apply cleanly**
+
+Run: `cd apps/api && DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm db:check-drift`
+Expected: exits 0, one ledger row per migration file including the new one.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/db/schema/orgs.ts apps/api/src/db/schema/devices.ts apps/api/migrations/2026-07-12-signup-attribution-columns.sql
+git commit -m "feat(abuse): signup/enrollment attribution columns"
+```
+
+---
+
+### Task 2: Persist signup IP/UA at partner registration
+
+**Files:**
+- Modify: `apps/api/src/services/partnerCreate.ts` (input type ~line 21, insert values ~line 75)
+- Modify: `apps/api/src/routes/auth/register.ts` (createPartner call ~line 191)
+- Test: `apps/api/src/routes/auth/register.test.ts`
+
+**Interfaces:**
+- Consumes: `partners.signupIp` / `partners.signupUserAgent` (Task 1).
+- Produces: `CreatePartnerInput.origin` non-MCP arm becomes `{ mcp: false; ip?: string; userAgent?: string }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/api/src/routes/auth/register.test.ts` (inside the existing register-partner describe block; `getTrustedClientIpOrUndefined` is already mocked to `'127.0.0.1'` at the top of the file):
+
+```ts
+  it('threads signup IP and user agent into createPartner', async () => {
+    process.env.IS_HOSTED = 'true';
+    setupDbSelectsForSuccess(true);
+
+    const res = await postRegisterPartner(validBody, { 'user-agent': 'vitest-agent/1.0' });
+    expect(res.status).toBeLessThan(400);
+    expect(createPartner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: { mcp: false, ip: '127.0.0.1', userAgent: 'vitest-agent/1.0' },
+      }),
+    );
+  });
+```
+
+If the existing `postRegisterPartner` helper (register.test.ts ~line 120) doesn't accept extra headers, extend it:
+
+```ts
+function postRegisterPartner(body: unknown, headers: Record<string, string> = {}) {
+  return registerRoutes.request('/register-partner', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/routes/auth/register.test.ts -t "threads signup IP"`
+Expected: FAIL — `createPartner` called with `origin: { mcp: false }` (no ip/userAgent).
+
+- [ ] **Step 3: Extend CreatePartnerInput and the insert**
+
+In `apps/api/src/services/partnerCreate.ts`, change the `origin` arm of `CreatePartnerInput`:
+
+```ts
+  origin:
+    | { mcp: false; ip?: string; userAgent?: string }
+    | { mcp: true; ip?: string; userAgent?: string };
+```
+
+In the `.insert(partners).values({...})` block, after the `mcpOriginUserAgent` line add:
+
+```ts
+        signupIp: !mcpOrigin ? (input.origin as { ip?: string }).ip ?? null : null,
+        signupUserAgent: !mcpOrigin ? (input.origin as { userAgent?: string }).userAgent ?? null : null,
+```
+
+- [ ] **Step 4: Pass IP/UA from the register handler**
+
+In `apps/api/src/routes/auth/register.ts`, the handler already imports `getTrustedClientIpOrUndefined` (line 25). Change the `createPartner` call:
+
+```ts
+      const result = await createPartner({
+        orgName: companyName,
+        adminEmail: email,
+        adminName: name,
+        passwordHash,
+        origin: {
+          mcp: false,
+          ip: getTrustedClientIpOrUndefined(c),
+          userAgent: c.req.header('user-agent'),
+        },
+        status: isHosted() ? 'pending' : 'active',
+      });
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/api && npx vitest run src/routes/auth/register.test.ts src/services/partnerCreate.test.ts`
+Expected: PASS (all — the existing partnerCreate tests must still pass with the widened origin type; if any construct `origin: { mcp: false }` they remain valid since the new fields are optional).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/partnerCreate.ts apps/api/src/routes/auth/register.ts apps/api/src/routes/auth/register.test.ts
+git commit -m "feat(abuse): persist signup IP and user agent on partner registration"
+```
+
+---
+
+### Task 3: Persist enrollment IP on both enroll paths
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/enrollment.ts` (fresh INSERT ~line 631, re-enroll UPDATE ~line 600)
+- Test: `apps/api/src/routes/agents/enrollment.test.ts`
+
+**Interfaces:**
+- Consumes: `devices.enrollmentIp` (Task 1); `clientIp` already in scope in the handler (line 77, `getTrustedClientIp(c, 'unknown')`).
+
+- [ ] **Step 1: Update the schema mock stub**
+
+`enrollment.test.ts` stubs the schema module (~lines 35-60). Add `enrollmentIp: 'enrollment_ip'` (matching the stub's existing column-map style) to the `devices` stub — without this the route module crashes on import once the route references the column.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `enrollment.test.ts`, following the file's existing success-path test (which mocks `db.transaction` and the select chain — reuse the same helpers that test uses):
+
+```ts
+  it('persists the enrolling client IP on the new device row', async () => {
+    const insertValuesSpy = setupSuccessfulEnrollTransaction(); // reuse/extract the file's existing success-path tx mock so the insert's .values() arg is captured
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+    expect(resp.status).toBe(200);
+    expect(insertValuesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ enrollmentIp: '127.0.0.1' }),
+    );
+  });
+```
+
+(`getTrustedClientIp` is already mocked to `'127.0.0.1'` at the top of the file. If the file's existing success-path mock doesn't expose the insert `.values()` spy, extract it into a `setupSuccessfulEnrollTransaction()` helper returning the spy — a mechanical refactor of the existing inline mock.)
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/routes/agents/enrollment.test.ts -t "persists the enrolling client IP"`
+Expected: FAIL — `.values()` called without `enrollmentIp`.
+
+- [ ] **Step 4: Write the implementation**
+
+In `apps/api/src/routes/agents/enrollment.ts`, near the top of the handler after `clientIp` is computed (line 77):
+
+```ts
+  // 'unknown' is the rate-limiter fallback, not a real address — store NULL.
+  const enrollmentIp = clientIp === 'unknown' ? null : clientIp;
+```
+
+Add `enrollmentIp,` to BOTH device write paths inside the transaction:
+- the fresh `tx.insert(devices).values({...})` block (~line 633): after `hostname: data.hostname,` add `enrollmentIp,`
+- the re-enrollment `tx.update(devices).set({...})` block (~line 602): after `agentId: agentId,` add `enrollmentIp,` (a re-enrollment is a fresh install; refreshing the origin IP is correct).
+
+- [ ] **Step 5: Run the full enrollment suite**
+
+Run: `cd apps/api && npx vitest run src/routes/agents/enrollment.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/agents/enrollment.ts apps/api/src/routes/agents/enrollment.test.ts
+git commit -m "feat(abuse): persist client IP at agent enrollment"
+```
+
+---
+
+**PR 1 boundary.** Tasks 1-3 are independently shippable (`gh pr create` from this branch or a stacked branch per the repo's squash-stack workflow). Tasks 4+ can proceed immediately; only the geo PR needs capture data to have accrued.
+
+---
+
+### Task 4: `partner_abuse_signals` table (schema, migration, RLS registration, forge suite)
+
+**Files:**
+- Create: `apps/api/src/db/schema/abuseSignals.ts`
+- Modify: `apps/api/src/db/schema/index.ts` (append export)
+- Create: `apps/api/migrations/2026-07-13-partner-abuse-signals.sql`
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` (`EXEMPT_TABLES` ~line 43, `INTENTIONAL_UNSCOPED` ~line 59, new forge describe block next to the `manifest_signing_keys` suite ~line 1278)
+
+**Interfaces:**
+- Produces: `partnerAbuseSignals` Drizzle table + `abuseSignalSeverityEnum`, consumed by Tasks 8, 9, 10.
+
+- [ ] **Step 1: Create the schema file**
+
+`apps/api/src/db/schema/abuseSignals.ts`:
+
+```ts
+import { pgTable, uuid, varchar, timestamp, jsonb, pgEnum, real, index, uniqueIndex } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { partners } from './orgs';
+
+export const abuseSignalSeverityEnum = pgEnum('abuse_signal_severity', ['info', 'watch', 'alert']);
+
+// Platform-operator abuse signals ABOUT partners — never visible TO partners.
+// RLS is a system-only policy (see the migration); all reads/writes happen
+// under withSystemDbAccessContext. Do NOT add breeze_has_partner_access
+// policies to this table.
+export const partnerAbuseSignals = pgTable('partner_abuse_signals', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id, { onDelete: 'cascade' }),
+  signalKey: varchar('signal_key', { length: 64 }).notNull(),
+  severity: abuseSignalSeverityEnum('severity').notNull(),
+  score: real('score').notNull().default(0),
+  evidence: jsonb('evidence').notNull().default({}),
+  firstFiredAt: timestamp('first_fired_at', { withTimezone: true }).defaultNow().notNull(),
+  computedAt: timestamp('computed_at', { withTimezone: true }).defaultNow().notNull(),
+  resolvedAt: timestamp('resolved_at', { withTimezone: true }),
+  acknowledgedAt: timestamp('acknowledged_at', { withTimezone: true }),
+  acknowledgedBy: varchar('acknowledged_by', { length: 255 }),
+  deliveredAt: timestamp('delivered_at', { withTimezone: true }),
+}, (t) => [
+  // One OPEN row per (partner, signal); resolved rows keep history.
+  uniqueIndex('partner_abuse_signals_open_uq').on(t.partnerId, t.signalKey).where(sql`resolved_at IS NULL`),
+  index('partner_abuse_signals_partner_idx').on(t.partnerId),
+]);
+```
+
+Append to `apps/api/src/db/schema/index.ts`:
+
+```ts
+export * from './abuseSignals';
+```
+
+- [ ] **Step 2: Write the migration**
+
+`apps/api/migrations/2026-07-13-partner-abuse-signals.sql` (copies the `2026-05-09-manifest-signing-keys.sql` system-only pattern):
+
+```sql
+-- Platform-operator abuse signals about partners. System-scoped: forced RLS
+-- with a system-only policy — partners must never read signals about
+-- themselves. All access via withSystemDbAccessContext. Idempotent.
+
+DO $$ BEGIN
+  CREATE TYPE abuse_signal_severity AS ENUM ('info', 'watch', 'alert');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS partner_abuse_signals (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_id      uuid NOT NULL REFERENCES partners(id) ON DELETE CASCADE,
+  signal_key      varchar(64) NOT NULL,
+  severity        abuse_signal_severity NOT NULL,
+  score           real NOT NULL DEFAULT 0,
+  evidence        jsonb NOT NULL DEFAULT '{}',
+  first_fired_at  timestamptz NOT NULL DEFAULT now(),
+  computed_at     timestamptz NOT NULL DEFAULT now(),
+  resolved_at     timestamptz,
+  acknowledged_at timestamptz,
+  acknowledged_by varchar(255),
+  delivered_at    timestamptz
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS partner_abuse_signals_open_uq
+  ON partner_abuse_signals(partner_id, signal_key)
+  WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS partner_abuse_signals_partner_idx
+  ON partner_abuse_signals(partner_id);
+
+ALTER TABLE partner_abuse_signals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE partner_abuse_signals FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'partner_abuse_signals'
+      AND policyname = 'partner_abuse_signals_system_only'
+  ) THEN
+    EXECUTE $POLICY$
+      CREATE POLICY partner_abuse_signals_system_only
+        ON partner_abuse_signals
+        USING (current_setting('breeze.scope', true) = 'system')
+        WITH CHECK (current_setting('breeze.scope', true) = 'system')
+    $POLICY$;
+  END IF;
+END$$;
+```
+
+- [ ] **Step 3: Register in the RLS contract test**
+
+In `rls-coverage.integration.test.ts` add to `EXEMPT_TABLES`:
+
+```ts
+  'partner_abuse_signals',
+```
+
+and to `INTENTIONAL_UNSCOPED`:
+
+```ts
+  'partner_abuse_signals', // Operator abuse signals ABOUT partners. Forced RLS, system-only policy — partners must never see their own risk signals.
+```
+
+- [ ] **Step 4: Write the forge suite (failing until migration applies)**
+
+Clone the adjacent `describe('manifest_signing_keys RLS — system-only enforcement (#639)', ...)` block (~line 1278) as a new describe in the same file, reusing its context helpers verbatim, with these cases:
+
+1. INSERT as `breeze_app` under a tenant (partner-scoped) context → rejects with `/row-level security|permission denied/`.
+2. Seed one row via `withSystemDbAccessContext`, then SELECT under a partner context **whose partnerId matches the row's partner_id** → zero rows (the specific threat: a partner reading its own signals).
+3. `withSystemDbAccessContext` INSERT + SELECT round-trips successfully.
+
+- [ ] **Step 5: Run migration check and the forge suite**
+
+Run: `cd apps/api && DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm db:check-drift`
+Expected: exits 0.
+Run the integration config against the integration DB (port 5433, per repo convention): `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/rls-coverage.integration.test.ts`
+Expected: PASS including the three new cases. (Beware the memoized-fixture and `.env.test` BYPASSRLS traps — the forge test must run as `breeze_app`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/db/schema/abuseSignals.ts apps/api/src/db/schema/index.ts apps/api/migrations/2026-07-13-partner-abuse-signals.sql apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+git commit -m "feat(abuse): partner_abuse_signals table with system-only RLS"
+```
+
+---
+
+### Task 5: Signal config with env overrides
+
+**Files:**
+- Create: `apps/api/src/services/abuseSignals/config.ts`
+- Create: `apps/api/src/services/abuseSignals/types.ts`
+- Test: `apps/api/src/services/abuseSignals/config.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `types.ts`: `type AbuseSeverity = 'info' | 'watch' | 'alert'`; `interface ComputedSignal { partnerId: string; signalKey: string; score: number; severity: AbuseSeverity; evidence: Record<string, unknown>; }`
+  - `config.ts`: `SIGNAL_DEFAULTS: Record<string, number>`, `loadSignalConfig(): Record<string, number>`, `scoreToSeverity(score, cfg): AbuseSeverity`, `youngWeight(partnerCreatedAt: Date, now: Date, cfg): number`
+
+- [ ] **Step 1: Create types.ts**
+
+```ts
+export type AbuseSeverity = 'info' | 'watch' | 'alert';
+
+export interface ComputedSignal {
+  partnerId: string;
+  signalKey: string;
+  /** 0-100 after young-account weighting. */
+  score: number;
+  severity: AbuseSeverity;
+  evidence: Record<string, unknown>;
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`config.test.ts`:
+
+```ts
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { loadSignalConfig, SIGNAL_DEFAULTS, scoreToSeverity, youngWeight } from './config';
+
+afterEach(() => {
+  delete process.env.ABUSE_SIGNAL_OVERRIDES;
+  vi.restoreAllMocks();
+});
+
+describe('loadSignalConfig', () => {
+  it('returns defaults when ABUSE_SIGNAL_OVERRIDES is unset', () => {
+    expect(loadSignalConfig()).toEqual(SIGNAL_DEFAULTS);
+  });
+
+  it('merges known override keys', () => {
+    process.env.ABUSE_SIGNAL_OVERRIDES = '{"rmm.enrollment_velocity.devices_24h": 25}';
+    expect(loadSignalConfig()['rmm.enrollment_velocity.devices_24h']).toBe(25);
+  });
+
+  it('warns and ignores unknown keys and non-numeric values', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.ABUSE_SIGNAL_OVERRIDES = '{"nope.unknown": 1, "severity.alert_score": "high"}';
+    const cfg = loadSignalConfig();
+    expect(cfg['severity.alert_score']).toBe(SIGNAL_DEFAULTS['severity.alert_score']);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('warns and returns defaults on malformed JSON', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.ABUSE_SIGNAL_OVERRIDES = '{not json';
+    expect(loadSignalConfig()).toEqual(SIGNAL_DEFAULTS);
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('scoreToSeverity', () => {
+  const cfg = SIGNAL_DEFAULTS;
+  it('maps score bands', () => {
+    expect(scoreToSeverity(75, cfg)).toBe('alert');
+    expect(scoreToSeverity(45, cfg)).toBe('watch');
+    expect(scoreToSeverity(5, cfg)).toBe('info');
+  });
+});
+
+describe('youngWeight', () => {
+  const cfg = SIGNAL_DEFAULTS;
+  const now = new Date('2026-07-15T00:00:00Z');
+  it('is 1.0 under 30 days, 0 at 90+, linear between', () => {
+    expect(youngWeight(new Date('2026-07-01T00:00:00Z'), now, cfg)).toBe(1);
+    expect(youngWeight(new Date('2026-04-01T00:00:00Z'), now, cfg)).toBe(0);
+    const w = youngWeight(new Date('2026-05-16T00:00:00Z'), now, cfg); // 60 days old
+    expect(w).toBeCloseTo(0.5, 1);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd apps/api && npx vitest run src/services/abuseSignals/config.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement config.ts**
+
+```ts
+import type { AbuseSeverity } from './types';
+
+/**
+ * Published defaults. Production deployments may diverge via the
+ * ABUSE_SIGNAL_OVERRIDES env var (JSON map of key -> number) so adversaries
+ * reading this public repo do not learn the live thresholds.
+ */
+export const SIGNAL_DEFAULTS: Record<string, number> = {
+  'sweep.young_full_weight_days': 30,
+  'sweep.young_zero_weight_days': 90,
+  'severity.watch_score': 40,
+  'severity.alert_score': 70,
+  'rmm.consumer_devices.min_devices': 5,
+  'rmm.consumer_devices.watch_ratio': 0.6,
+  'rmm.enrollment_velocity.devices_24h': 10,
+  'rmm.session_intensity.fast_remote_count_7d': 3,
+  'rmm.session_intensity.sessions_per_device_7d': 5,
+  'rmm.enrollment_ip_spread.min_devices': 8,
+  'rmm.enrollment_ip_spread.distinct_ratio': 0.8,
+  'fraud.failed_login_cluster.count_24h': 20,
+  'resource.enrollment_denied.count_24h': 20,
+  'resource.volume_outlier.commands_24h': 500,
+  'resource.volume_outlier.scripts_24h': 200,
+};
+
+export function loadSignalConfig(): Record<string, number> {
+  const raw = process.env.ABUSE_SIGNAL_OVERRIDES;
+  if (!raw) return { ...SIGNAL_DEFAULTS };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.warn('[AbuseSignals] ABUSE_SIGNAL_OVERRIDES is not valid JSON — using defaults');
+    return { ...SIGNAL_DEFAULTS };
+  }
+  const cfg = { ...SIGNAL_DEFAULTS };
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!(key in SIGNAL_DEFAULTS)) {
+        console.warn(`[AbuseSignals] Unknown override key ignored: ${key}`);
+        continue;
+      }
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        console.warn(`[AbuseSignals] Non-numeric override ignored: ${key}`);
+        continue;
+      }
+      cfg[key] = value;
+    }
+  }
+  return cfg;
+}
+
+export function scoreToSeverity(score: number, cfg: Record<string, number>): AbuseSeverity {
+  if (score >= cfg['severity.alert_score']) return 'alert';
+  if (score >= cfg['severity.watch_score']) return 'watch';
+  return 'info';
+}
+
+/** 1.0 for partners younger than young_full_weight_days, linearly decaying to 0 at young_zero_weight_days. */
+export function youngWeight(partnerCreatedAt: Date, now: Date, cfg: Record<string, number>): number {
+  const ageDays = (now.getTime() - partnerCreatedAt.getTime()) / 86_400_000;
+  const full = cfg['sweep.young_full_weight_days'];
+  const zero = cfg['sweep.young_zero_weight_days'];
+  if (ageDays <= full) return 1;
+  if (ageDays >= zero) return 0;
+  return (zero - ageDays) / (zero - full);
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/api && npx vitest run src/services/abuseSignals/config.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/abuseSignals/
+git commit -m "feat(abuse): signal config with env-overridable thresholds"
+```
+
+---
+
+### Task 6: opsAlerts service + Prometheus counters + env docs
+
+**Files:**
+- Create: `apps/api/src/services/opsAlerts.ts`
+- Test: `apps/api/src/services/opsAlerts.test.ts`
+- Create: `apps/api/src/services/abuseMetrics.ts`
+- Modify: `apps/api/src/routes/metrics.ts` (counters near ~line 256, recorder registration near ~line 616)
+- Modify: `apps/api/.env.example` (or root `.env.example` — wherever OPS-facing vars live; use generic placeholders)
+- Modify: `docker-compose.yml` (api service `environment:` block — pass-through mappings)
+
+**Interfaces:**
+- Produces:
+  - `sendOpsAlert(msg: { title: string; body: string }): Promise<boolean>` — true if ≥1 channel delivered.
+  - `isOpsAlertingConfigured(): boolean`
+  - `recordAbuseSignalFired(severity: string): void`, `recordAbuseSweepRun(result: 'success' | 'error'): void` (thin recorder, mirroring `anomalyMetrics.ts`).
+
+- [ ] **Step 1: Write the failing tests**
+
+`opsAlerts.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('./urlSafety', () => ({
+  safeFetch: vi.fn(),
+  SsrfBlockedError: class SsrfBlockedError extends Error {},
+}));
+vi.mock('./email', () => ({ getEmailService: vi.fn(() => null) }));
+
+import { safeFetch } from './urlSafety';
+import { getEmailService } from './email';
+import { sendOpsAlert, isOpsAlertingConfigured } from './opsAlerts';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.OPS_ALERT_WEBHOOK_URL = 'https://discord.example.com/api/webhooks/x/y';
+  delete process.env.OPS_ALERT_EMAIL;
+  delete process.env.OPS_ALERT_LABEL;
+});
+afterEach(() => {
+  delete process.env.OPS_ALERT_WEBHOOK_URL;
+});
+
+describe('sendOpsAlert', () => {
+  it('POSTs Discord-format content and returns true on 2xx', async () => {
+    vi.mocked(safeFetch).mockResolvedValue(new Response('', { status: 204 }));
+    const ok = await sendOpsAlert({ title: 'Test alert', body: 'evidence here' });
+    expect(ok).toBe(true);
+    const [url, init] = vi.mocked(safeFetch).mock.calls[0];
+    expect(url).toBe(process.env.OPS_ALERT_WEBHOOK_URL);
+    expect(JSON.parse(init!.body as string).content).toContain('Test alert');
+  });
+
+  it('prefixes the title with OPS_ALERT_LABEL when set', async () => {
+    process.env.OPS_ALERT_LABEL = 'US';
+    vi.mocked(safeFetch).mockResolvedValue(new Response('', { status: 204 }));
+    await sendOpsAlert({ title: 'Test', body: 'b' });
+    const [, init] = vi.mocked(safeFetch).mock.calls[0];
+    expect(JSON.parse(init!.body as string).content).toContain('[US]');
+  });
+
+  it('truncates content to Discord 2000-char limit', async () => {
+    vi.mocked(safeFetch).mockResolvedValue(new Response('', { status: 204 }));
+    await sendOpsAlert({ title: 'T', body: 'x'.repeat(3000) });
+    const [, init] = vi.mocked(safeFetch).mock.calls[0];
+    expect(JSON.parse(init!.body as string).content.length).toBeLessThanOrEqual(2000);
+  });
+
+  it('returns false when no channel is configured, warning once', async () => {
+    delete process.env.OPS_ALERT_WEBHOOK_URL;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(await sendOpsAlert({ title: 'T', body: 'b' })).toBe(false);
+    expect(safeFetch).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('returns false on webhook failure and does not throw', async () => {
+    vi.mocked(safeFetch).mockRejectedValue(new Error('network down'));
+    expect(await sendOpsAlert({ title: 'T', body: 'b' })).toBe(false);
+  });
+
+  it('falls back to email channel when configured', async () => {
+    delete process.env.OPS_ALERT_WEBHOOK_URL;
+    process.env.OPS_ALERT_EMAIL = 'ops@example.com';
+    const sendEmail = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getEmailService).mockReturnValue({ sendEmail } as never);
+    expect(await sendOpsAlert({ title: 'T', body: 'b' })).toBe(true);
+    expect(sendEmail).toHaveBeenCalledWith(expect.objectContaining({ to: 'ops@example.com' }));
+  });
+});
+
+describe('isOpsAlertingConfigured', () => {
+  it('reflects env state', () => {
+    expect(isOpsAlertingConfigured()).toBe(true);
+    delete process.env.OPS_ALERT_WEBHOOK_URL;
+    expect(isOpsAlertingConfigured()).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && npx vitest run src/services/opsAlerts.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement opsAlerts.ts**
+
+```ts
+import { safeFetch } from './urlSafety';
+import { getEmailService } from './email';
+import { captureException } from './sentry';
+
+export interface OpsAlertMessage {
+  title: string;
+  body: string;
+}
+
+const DISCORD_CONTENT_LIMIT = 2000;
+const WEBHOOK_TIMEOUT_MS = 10_000;
+let warnedUnconfigured = false;
+
+export function isOpsAlertingConfigured(): boolean {
+  return Boolean(process.env.OPS_ALERT_WEBHOOK_URL || process.env.OPS_ALERT_EMAIL);
+}
+
+function formatContent(msg: OpsAlertMessage): string {
+  const label = process.env.OPS_ALERT_LABEL?.trim();
+  const title = label ? `[${label}] ${msg.title}` : msg.title;
+  return `**${title}**\n${msg.body}`.slice(0, DISCORD_CONTENT_LIMIT);
+}
+
+async function sendWebhook(url: string, msg: OpsAlertMessage): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+    const response = await safeFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': 'Breeze-RMM/1.0' },
+      body: JSON.stringify({ content: formatContent(msg) }),
+      signal: controller.signal,
+      redirect: 'error',
+    });
+    clearTimeout(timeoutId);
+    if (!response.ok) {
+      console.error(`[OpsAlerts] Webhook responded ${response.status}`);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error('[OpsAlerts] Webhook delivery failed:', error instanceof Error ? error.message : error);
+    captureException(error);
+    return false;
+  }
+}
+
+async function sendOpsEmail(to: string, msg: OpsAlertMessage): Promise<boolean> {
+  const email = getEmailService();
+  if (!email) {
+    console.warn('[OpsAlerts] OPS_ALERT_EMAIL set but email service not configured');
+    return false;
+  }
+  try {
+    await email.sendEmail({
+      to,
+      subject: `[Breeze ops] ${msg.title}`,
+      text: msg.body,
+      html: `<pre>${msg.body.replace(/</g, '&lt;')}</pre>`,
+    });
+    return true;
+  } catch (error) {
+    console.error('[OpsAlerts] Email delivery failed:', error instanceof Error ? error.message : error);
+    captureException(error);
+    return false;
+  }
+}
+
+/** Delivers to every configured channel; true if at least one succeeded. Never throws. */
+export async function sendOpsAlert(msg: OpsAlertMessage): Promise<boolean> {
+  const webhookUrl = process.env.OPS_ALERT_WEBHOOK_URL?.trim();
+  const emailTo = process.env.OPS_ALERT_EMAIL?.trim();
+  if (!webhookUrl && !emailTo) {
+    if (!warnedUnconfigured) {
+      console.warn('[OpsAlerts] No OPS_ALERT_WEBHOOK_URL or OPS_ALERT_EMAIL configured — ops alerts disabled');
+      warnedUnconfigured = true;
+    }
+    return false;
+  }
+  const results = await Promise.all([
+    webhookUrl ? sendWebhook(webhookUrl, msg) : Promise.resolve(false),
+    emailTo ? sendOpsEmail(emailTo, msg) : Promise.resolve(false),
+  ]);
+  return results.some(Boolean);
+}
+```
+
+- [ ] **Step 4: Create abuseMetrics.ts (thin recorder, mirrors anomalyMetrics.ts)**
+
+```ts
+type AbuseMetricsRecorder = {
+  onSignalFired: (severity: string) => void;
+  onSweepRun: (result: 'success' | 'error') => void;
+};
+
+const noop = () => {};
+let recorder: AbuseMetricsRecorder = { onSignalFired: noop, onSweepRun: noop };
+
+export function setAbuseMetricsRecorder(next: Partial<AbuseMetricsRecorder> | null | undefined): void {
+  recorder = {
+    onSignalFired: next?.onSignalFired ?? noop,
+    onSweepRun: next?.onSweepRun ?? noop,
+  };
+}
+
+export function recordAbuseSignalFired(severity: string): void {
+  recorder.onSignalFired(severity);
+}
+
+export function recordAbuseSweepRun(result: 'success' | 'error'): void {
+  recorder.onSweepRun(result);
+}
+```
+
+- [ ] **Step 5: Register counters in metrics.ts**
+
+Next to the existing anomaly counters (~line 256), following the same shape:
+
+```ts
+const abuseSignalsFiredTotal = new Counter({
+  name: 'breeze_abuse_signals_fired_total',
+  help: 'Abuse signals fired by the sweep, by severity',
+  labelNames: ['severity'] as const,
+  registers: [register]
+});
+const abuseSweepRunsTotal = new Counter({
+  name: 'breeze_abuse_sweep_runs_total',
+  help: 'Abuse sweep job runs by result',
+  labelNames: ['result'] as const,
+  registers: [register]
+});
+```
+
+Warm-up zero-incs next to the existing ones (~line 304): `abuseSignalsFiredTotal.labels('alert').inc(0); abuseSweepRunsTotal.labels('success').inc(0);`
+
+Recorder registration next to `setAnomalyMetricsRecorder` (~line 616):
+
+```ts
+setAbuseMetricsRecorder({
+  onSignalFired: (severity) => abuseSignalsFiredTotal.labels(normalizeMetricLabel(severity, 'unknown')).inc(),
+  onSweepRun: (result) => abuseSweepRunsTotal.labels(result).inc(),
+});
+```
+
+(Import `setAbuseMetricsRecorder` from `../services/abuseMetrics` alongside the anomaly import.)
+
+- [ ] **Step 6: Env documentation + compose mapping**
+
+Add to the `.env.example` used by the API (generic placeholders only):
+
+```bash
+# Platform-operator abuse alerts (all optional; unset = feature disabled)
+# OPS_ALERT_WEBHOOK_URL=https://discord.com/api/webhooks/your-webhook
+# OPS_ALERT_EMAIL=ops@your-domain.example.com
+# OPS_ALERT_LABEL=US
+# ABUSE_SIGNAL_OVERRIDES={"rmm.enrollment_velocity.devices_24h": 25}
+```
+
+Add pass-through mappings to the `api` service `environment:` block in `docker-compose.yml` (compose only interpolates vars listed there):
+
+```yaml
+      OPS_ALERT_WEBHOOK_URL: ${OPS_ALERT_WEBHOOK_URL:-}
+      OPS_ALERT_EMAIL: ${OPS_ALERT_EMAIL:-}
+      OPS_ALERT_LABEL: ${OPS_ALERT_LABEL:-}
+      ABUSE_SIGNAL_OVERRIDES: ${ABUSE_SIGNAL_OVERRIDES:-}
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `cd apps/api && npx vitest run src/services/opsAlerts.test.ts`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/services/opsAlerts.ts apps/api/src/services/opsAlerts.test.ts apps/api/src/services/abuseMetrics.ts apps/api/src/routes/metrics.ts docker-compose.yml
+git add -A -- '*.env.example'
+git commit -m "feat(abuse): opsAlerts platform-operator channel + sweep metrics"
+```
+
+---
+
+### Task 7: Invariant signals
+
+**Files:**
+- Create: `apps/api/src/services/abuseSignals/invariants.ts`
+- Test: `apps/api/src/services/abuseSignals/invariants.test.ts`
+
+**Interfaces:**
+- Consumes: `ComputedSignal` (Task 5).
+- Produces: `computeInvariantSignals(): Promise<ComputedSignal[]>` — caller is responsible for running it inside a system DB context.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../db', () => ({
+  db: { execute: vi.fn() },
+}));
+
+import { db } from '../../db';
+import { computeInvariantSignals } from './invariants';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('computeInvariantSignals', () => {
+  it('emits alert signals for each invariant breach', async () => {
+    vi.mocked(db.execute)
+      // active_unverified_email
+      .mockResolvedValueOnce([{ id: 'p1', name: 'Acme', created_at: '2026-07-01' }] as never)
+      // active_no_payment
+      .mockResolvedValueOnce([] as never)
+      // inactive_partner_with_agents
+      .mockResolvedValueOnce([{ id: 'p2', name: 'Bad Co', status: 'suspended', device_count: '4' }] as never);
+
+    const signals = await computeInvariantSignals();
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).toMatchObject({
+      partnerId: 'p1',
+      signalKey: 'invariant.active_unverified_email',
+      severity: 'alert',
+      score: 100,
+    });
+    expect(signals[1]).toMatchObject({
+      partnerId: 'p2',
+      signalKey: 'invariant.inactive_partner_with_agents',
+      severity: 'alert',
+      evidence: expect.objectContaining({ deviceCount: 4, partnerStatus: 'suspended' }),
+    });
+  });
+
+  it('returns empty when all invariants hold', async () => {
+    vi.mocked(db.execute).mockResolvedValue([] as never);
+    expect(await computeInvariantSignals()).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && npx vitest run src/services/abuseSignals/invariants.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement invariants.ts**
+
+```ts
+import { sql } from 'drizzle-orm';
+import { db } from '../../db';
+import type { ComputedSignal } from './types';
+
+// Activation invariants — conditions the signup gate makes impossible, so any
+// hit means gate drift (deploy lag, manual SQL, a new bypass). Suppression of
+// reviewed/grandfathered accounts happens via acknowledged_at in persistence,
+// NEVER via allowlists here (public repo: no tenant identifiers in code).
+// MUST run inside a system DB context — bare breeze_app reads return 0 rows.
+export async function computeInvariantSignals(): Promise<ComputedSignal[]> {
+  const signals: ComputedSignal[] = [];
+
+  const unverified = (await db.execute(sql`
+    SELECT id, name, created_at FROM partners
+    WHERE status = 'active' AND email_verified_at IS NULL AND deleted_at IS NULL
+  `)) as unknown as Array<{ id: string; name: string; created_at: string }>;
+  for (const p of unverified) {
+    signals.push({
+      partnerId: p.id,
+      signalKey: 'invariant.active_unverified_email',
+      score: 100,
+      severity: 'alert',
+      evidence: { partnerName: p.name, partnerCreatedAt: p.created_at },
+    });
+  }
+
+  const unpaid = (await db.execute(sql`
+    SELECT id, name, created_at FROM partners
+    WHERE status = 'active' AND payment_method_attached_at IS NULL AND deleted_at IS NULL
+  `)) as unknown as Array<{ id: string; name: string; created_at: string }>;
+  for (const p of unpaid) {
+    signals.push({
+      partnerId: p.id,
+      signalKey: 'invariant.active_no_payment',
+      score: 100,
+      severity: 'alert',
+      evidence: { partnerName: p.name, partnerCreatedAt: p.created_at },
+    });
+  }
+
+  const inactiveWithAgents = (await db.execute(sql`
+    SELECT p.id, p.name, p.status, COUNT(d.id) AS device_count
+    FROM partners p
+    JOIN organizations o ON o.partner_id = p.id
+    JOIN devices d ON d.org_id = o.id
+    WHERE p.status IN ('pending', 'suspended')
+      AND d.status NOT IN ('decommissioned', 'quarantined')
+    GROUP BY p.id, p.name, p.status
+  `)) as unknown as Array<{ id: string; name: string; status: string; device_count: string }>;
+  for (const p of inactiveWithAgents) {
+    signals.push({
+      partnerId: p.id,
+      signalKey: 'invariant.inactive_partner_with_agents',
+      score: 100,
+      severity: 'alert',
+      evidence: { partnerName: p.name, partnerStatus: p.status, deviceCount: Number(p.device_count) },
+    });
+  }
+
+  return signals;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && npx vitest run src/services/abuseSignals/invariants.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/abuseSignals/invariants.ts apps/api/src/services/abuseSignals/invariants.test.ts
+git commit -m "feat(abuse): activation invariant signals"
+```
+
+---
+
+### Task 8: Heuristic signals (aggregates loader + pure scoring)
+
+**Files:**
+- Create: `apps/api/src/services/abuseSignals/heuristics.ts`
+- Test: `apps/api/src/services/abuseSignals/heuristics.test.ts`
+
+**Interfaces:**
+- Consumes: `ComputedSignal`, `scoreToSeverity`, `youngWeight`, config keys (Task 5); `devices.enrollment_ip` (Task 1).
+- Produces:
+  - `interface PartnerAggregates { partnerId: string; partnerName: string; partnerCreatedAt: Date; deviceCount: number; consumerHostnameCount: number; enrolled24h: number; distinctEnrollmentIps30d: number; devicesEnrolled30d: number; sessions7d: number; fastRemoteSessions7d: number; failedLogins24h: number; enrollmentDenied24h: number; commands24h: number; scriptExecutions24h: number; }`
+  - `loadPartnerAggregates(): Promise<PartnerAggregates[]>` (system-context caller)
+  - `computeHeuristicSignals(aggs: PartnerAggregates[], cfg: Record<string, number>, now: Date): ComputedSignal[]` (pure)
+
+- [ ] **Step 1: Write the failing tests for the pure scorer**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { computeHeuristicSignals, type PartnerAggregates } from './heuristics';
+import { SIGNAL_DEFAULTS } from './config';
+
+const now = new Date('2026-07-15T00:00:00Z');
+
+function agg(overrides: Partial<PartnerAggregates>): PartnerAggregates {
+  return {
+    partnerId: 'p1',
+    partnerName: 'Acme',
+    partnerCreatedAt: new Date('2026-07-10T00:00:00Z'), // 5 days old → full weight
+    deviceCount: 0,
+    consumerHostnameCount: 0,
+    enrolled24h: 0,
+    distinctEnrollmentIps30d: 0,
+    devicesEnrolled30d: 0,
+    sessions7d: 0,
+    fastRemoteSessions7d: 0,
+    failedLogins24h: 0,
+    enrollmentDenied24h: 0,
+    commands24h: 0,
+    scriptExecutions24h: 0,
+    ...overrides,
+  };
+}
+
+describe('computeHeuristicSignals', () => {
+  it('emits nothing for a quiet partner', () => {
+    expect(computeHeuristicSignals([agg({})], SIGNAL_DEFAULTS, now)).toEqual([]);
+  });
+
+  it('fires consumer_devices when ratio and fleet size exceed thresholds', () => {
+    const signals = computeHeuristicSignals(
+      [agg({ deviceCount: 10, consumerHostnameCount: 9 })],
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    const s = signals.find((x) => x.signalKey === 'rmm.consumer_devices');
+    expect(s).toBeDefined();
+    expect(s!.evidence).toMatchObject({ deviceCount: 10, consumerHostnameCount: 9 });
+    expect(s!.score).toBeGreaterThan(0);
+  });
+
+  it('fires enrollment_velocity on a 24h burst', () => {
+    const signals = computeHeuristicSignals([agg({ enrolled24h: 30, deviceCount: 30 })], SIGNAL_DEFAULTS, now);
+    expect(signals.some((x) => x.signalKey === 'rmm.enrollment_velocity')).toBe(true);
+  });
+
+  it('weighs fast enroll-to-remote sessions heavily', () => {
+    const signals = computeHeuristicSignals(
+      [agg({ deviceCount: 5, sessions7d: 12, fastRemoteSessions7d: 5 })],
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    const s = signals.find((x) => x.signalKey === 'rmm.session_intensity');
+    expect(s).toBeDefined();
+    expect(s!.severity).toBe('alert');
+  });
+
+  it('fires enrollment_ip_spread when nearly every device came from a distinct IP', () => {
+    const signals = computeHeuristicSignals(
+      [agg({ deviceCount: 10, devicesEnrolled30d: 10, distinctEnrollmentIps30d: 10 })],
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    expect(signals.some((x) => x.signalKey === 'rmm.enrollment_ip_spread')).toBe(true);
+  });
+
+  it('decays scores for old partners (zero weight at 90+ days)', () => {
+    const signals = computeHeuristicSignals(
+      [agg({ partnerCreatedAt: new Date('2026-01-01T00:00:00Z'), deviceCount: 10, consumerHostnameCount: 10 })],
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    expect(signals).toEqual([]); // weight 0 → score 0 → not emitted
+  });
+
+  it('does not decay fraud/resource signals', () => {
+    const signals = computeHeuristicSignals(
+      [agg({ partnerCreatedAt: new Date('2026-01-01T00:00:00Z'), failedLogins24h: 100 })],
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    expect(signals.some((x) => x.signalKey === 'fraud.failed_login_cluster')).toBe(true);
+  });
+
+  it('fires enrollment_denied on repeated cap/key rejections', () => {
+    const signals = computeHeuristicSignals([agg({ enrollmentDenied24h: 40 })], SIGNAL_DEFAULTS, now);
+    expect(signals.some((x) => x.signalKey === 'resource.enrollment_denied')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && npx vitest run src/services/abuseSignals/heuristics.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement heuristics.ts**
+
+```ts
+import { sql } from 'drizzle-orm';
+import { db } from '../../db';
+import { scoreToSeverity, youngWeight } from './config';
+import type { ComputedSignal } from './types';
+
+export interface PartnerAggregates {
+  partnerId: string;
+  partnerName: string;
+  partnerCreatedAt: Date;
+  deviceCount: number;
+  consumerHostnameCount: number;
+  enrolled24h: number;
+  distinctEnrollmentIps30d: number;
+  devicesEnrolled30d: number;
+  sessions7d: number;
+  fastRemoteSessions7d: number;
+  failedLogins24h: number;
+  enrollmentDenied24h: number;
+  commands24h: number;
+  scriptExecutions24h: number;
+}
+
+// Default Windows hostnames (DESKTOP-XXXXXXX / LAPTOP-XXXXXXX) mark unmanaged
+// consumer machines — a legit MSP's fleet is mostly named/domain-joined.
+const CONSUMER_HOSTNAME_SQL = `d.hostname ~* '^(DESKTOP|LAPTOP)-[A-Z0-9]{7}$'`;
+
+/**
+ * One fleet-grouped pass over young-or-recently-active partners.
+ * MUST run inside a system DB context — bare breeze_app reads return 0 rows.
+ */
+export async function loadPartnerAggregates(): Promise<PartnerAggregates[]> {
+  const rows = (await db.execute(sql.raw(`
+    WITH scoped AS (
+      SELECT p.id, p.name, p.created_at
+      FROM partners p
+      WHERE p.deleted_at IS NULL AND p.status = 'active'
+        AND (
+          p.created_at > now() - interval '90 days'
+          OR EXISTS (
+            SELECT 1 FROM organizations o JOIN devices d ON d.org_id = o.id
+            WHERE o.partner_id = p.id AND d.enrolled_at > now() - interval '2 hours'
+          )
+        )
+    ),
+    dev AS (
+      SELECT o.partner_id,
+        COUNT(*) AS device_count,
+        COUNT(*) FILTER (WHERE ${CONSUMER_HOSTNAME_SQL}) AS consumer_count,
+        COUNT(*) FILTER (WHERE d.enrolled_at > now() - interval '24 hours') AS enrolled_24h,
+        COUNT(DISTINCT d.enrollment_ip) FILTER (WHERE d.enrolled_at > now() - interval '30 days' AND d.enrollment_ip IS NOT NULL) AS distinct_enroll_ips_30d,
+        COUNT(*) FILTER (WHERE d.enrolled_at > now() - interval '30 days' AND d.enrollment_ip IS NOT NULL) AS devices_enrolled_30d
+      FROM devices d JOIN organizations o ON o.id = d.org_id
+      WHERE d.status NOT IN ('decommissioned', 'quarantined')
+      GROUP BY o.partner_id
+    ),
+    sess AS (
+      SELECT o.partner_id,
+        COUNT(*) AS sessions_7d,
+        COUNT(*) FILTER (WHERE rs.created_at < d.enrolled_at + interval '24 hours') AS fast_remote_7d
+      FROM remote_sessions rs
+      JOIN devices d ON d.id = rs.device_id
+      JOIN organizations o ON o.id = d.org_id
+      WHERE rs.created_at > now() - interval '7 days'
+      GROUP BY o.partner_id
+    ),
+    logins AS (
+      SELECT o.partner_id, COUNT(*) AS failed_24h
+      FROM audit_logs al JOIN organizations o ON o.id = al.org_id
+      WHERE al.action = 'user.login.failed' AND al."timestamp" > now() - interval '24 hours'
+      GROUP BY o.partner_id
+    ),
+    denied AS (
+      SELECT o.partner_id, COUNT(*) AS denied_24h
+      FROM audit_logs al JOIN organizations o ON o.id = al.org_id
+      WHERE al.action = 'agent.enroll' AND al.result = 'denied'
+        AND al."timestamp" > now() - interval '24 hours'
+      GROUP BY o.partner_id
+    ),
+    cmds AS (
+      SELECT o.partner_id, COUNT(*) AS commands_24h
+      FROM device_commands dc
+      JOIN devices d ON d.id = dc.device_id
+      JOIN organizations o ON o.id = d.org_id
+      WHERE dc.created_at > now() - interval '24 hours'
+      GROUP BY o.partner_id
+    ),
+    scripts AS (
+      SELECT o.partner_id, COUNT(*) AS scripts_24h
+      FROM script_executions se JOIN organizations o ON o.id = se.org_id
+      WHERE se.created_at > now() - interval '24 hours'
+      GROUP BY o.partner_id
+    )
+    SELECT s.id, s.name, s.created_at,
+      COALESCE(dev.device_count, 0) AS device_count,
+      COALESCE(dev.consumer_count, 0) AS consumer_count,
+      COALESCE(dev.enrolled_24h, 0) AS enrolled_24h,
+      COALESCE(dev.distinct_enroll_ips_30d, 0) AS distinct_enroll_ips_30d,
+      COALESCE(dev.devices_enrolled_30d, 0) AS devices_enrolled_30d,
+      COALESCE(sess.sessions_7d, 0) AS sessions_7d,
+      COALESCE(sess.fast_remote_7d, 0) AS fast_remote_7d,
+      COALESCE(logins.failed_24h, 0) AS failed_24h,
+      COALESCE(denied.denied_24h, 0) AS denied_24h,
+      COALESCE(cmds.commands_24h, 0) AS commands_24h,
+      COALESCE(scripts.scripts_24h, 0) AS scripts_24h
+    FROM scoped s
+    LEFT JOIN dev ON dev.partner_id = s.id
+    LEFT JOIN sess ON sess.partner_id = s.id
+    LEFT JOIN logins ON logins.partner_id = s.id
+    LEFT JOIN denied ON denied.partner_id = s.id
+    LEFT JOIN cmds ON cmds.partner_id = s.id
+    LEFT JOIN scripts ON scripts.partner_id = s.id
+  `))) as unknown as Array<Record<string, unknown>>;
+
+  return rows.map((r) => ({
+    partnerId: String(r.id),
+    partnerName: String(r.name),
+    partnerCreatedAt: new Date(String(r.created_at)),
+    deviceCount: Number(r.device_count),
+    consumerHostnameCount: Number(r.consumer_count),
+    enrolled24h: Number(r.enrolled_24h),
+    distinctEnrollmentIps30d: Number(r.distinct_enroll_ips_30d),
+    devicesEnrolled30d: Number(r.devices_enrolled_30d),
+    sessions7d: Number(r.sessions_7d),
+    fastRemoteSessions7d: Number(r.fast_remote_7d),
+    failedLogins24h: Number(r.failed_24h),
+    enrollmentDenied24h: Number(r.denied_24h),
+    commands24h: Number(r.commands_24h),
+    scriptExecutions24h: Number(r.scripts_24h),
+  }));
+}
+
+/** Pure scoring: no I/O, unit-testable. Scores are 0-100 pre-weighting. */
+export function computeHeuristicSignals(
+  aggs: PartnerAggregates[],
+  cfg: Record<string, number>,
+  now: Date,
+): ComputedSignal[] {
+  const signals: ComputedSignal[] = [];
+
+  for (const a of aggs) {
+    const weight = youngWeight(a.partnerCreatedAt, now, cfg);
+    const push = (signalKey: string, rawScore: number, evidence: Record<string, unknown>, decays = true) => {
+      const score = Math.min(100, Math.round(rawScore * (decays ? weight : 1)));
+      if (score <= 0) return;
+      signals.push({
+        partnerId: a.partnerId,
+        signalKey,
+        score,
+        severity: scoreToSeverity(score, cfg),
+        evidence: { partnerName: a.partnerName, ...evidence },
+      });
+    };
+
+    // rmm.consumer_devices — ratio of throwaway-named consumer machines.
+    if (a.deviceCount >= cfg['rmm.consumer_devices.min_devices']) {
+      const ratio = a.consumerHostnameCount / a.deviceCount;
+      if (ratio >= cfg['rmm.consumer_devices.watch_ratio']) {
+        push('rmm.consumer_devices', ratio * 100, {
+          deviceCount: a.deviceCount,
+          consumerHostnameCount: a.consumerHostnameCount,
+          ratio: Number(ratio.toFixed(2)),
+        });
+      }
+    }
+
+    // rmm.enrollment_velocity — burst enrollments in 24h.
+    const velThreshold = cfg['rmm.enrollment_velocity.devices_24h'];
+    if (a.enrolled24h >= velThreshold) {
+      push('rmm.enrollment_velocity', Math.min(100, (a.enrolled24h / velThreshold) * 50), {
+        enrolled24h: a.enrolled24h,
+      });
+    }
+
+    // rmm.session_intensity — fast enroll-to-remote is the scammer fingerprint.
+    const fastThreshold = cfg['rmm.session_intensity.fast_remote_count_7d'];
+    const perDevice = a.deviceCount > 0 ? a.sessions7d / a.deviceCount : 0;
+    if (a.fastRemoteSessions7d >= fastThreshold || perDevice >= cfg['rmm.session_intensity.sessions_per_device_7d']) {
+      const fastScore = (a.fastRemoteSessions7d / fastThreshold) * 70;
+      const volumeScore = (perDevice / cfg['rmm.session_intensity.sessions_per_device_7d']) * 40;
+      push('rmm.session_intensity', Math.max(fastScore, volumeScore), {
+        sessions7d: a.sessions7d,
+        fastRemoteSessions7d: a.fastRemoteSessions7d,
+        deviceCount: a.deviceCount,
+      });
+    }
+
+    // rmm.enrollment_ip_spread — scattered origin IPs (residential-victim proxy until geo lands).
+    if (a.devicesEnrolled30d >= cfg['rmm.enrollment_ip_spread.min_devices']) {
+      const ratio = a.distinctEnrollmentIps30d / a.devicesEnrolled30d;
+      if (ratio >= cfg['rmm.enrollment_ip_spread.distinct_ratio']) {
+        push('rmm.enrollment_ip_spread', ratio * 80, {
+          devicesEnrolled30d: a.devicesEnrolled30d,
+          distinctEnrollmentIps30d: a.distinctEnrollmentIps30d,
+        });
+      }
+    }
+
+    // fraud.failed_login_cluster — never age-decayed.
+    const loginThreshold = cfg['fraud.failed_login_cluster.count_24h'];
+    if (a.failedLogins24h >= loginThreshold) {
+      push('fraud.failed_login_cluster', Math.min(100, (a.failedLogins24h / loginThreshold) * 50), {
+        failedLogins24h: a.failedLogins24h,
+      }, false);
+    }
+
+    // resource.enrollment_denied — repeated cap/key rejections; never age-decayed.
+    const deniedThreshold = cfg['resource.enrollment_denied.count_24h'];
+    if (a.enrollmentDenied24h >= deniedThreshold) {
+      push('resource.enrollment_denied', Math.min(100, (a.enrollmentDenied24h / deniedThreshold) * 50), {
+        enrollmentDenied24h: a.enrollmentDenied24h,
+      }, false);
+    }
+
+    // resource.volume_outlier — never age-decayed.
+    const cmdThreshold = cfg['resource.volume_outlier.commands_24h'];
+    const scriptThreshold = cfg['resource.volume_outlier.scripts_24h'];
+    if (a.commands24h >= cmdThreshold || a.scriptExecutions24h >= scriptThreshold) {
+      push('resource.volume_outlier', Math.min(
+        100,
+        Math.max((a.commands24h / cmdThreshold) * 50, (a.scriptExecutions24h / scriptThreshold) * 50),
+      ), {
+        commands24h: a.commands24h,
+        scriptExecutions24h: a.scriptExecutions24h,
+      }, false);
+    }
+  }
+
+  return signals;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && npx vitest run src/services/abuseSignals/heuristics.test.ts`
+Expected: PASS. (If a threshold/score interaction fails, fix the score math, not the test intent: consumer 9/10 young ⇒ ≥ watch; 5 fast-remote on 5 devices young ⇒ alert.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/abuseSignals/heuristics.ts apps/api/src/services/abuseSignals/heuristics.test.ts
+git commit -m "feat(abuse): malicious-RMM-use heuristic signals"
+```
+
+---
+
+### Task 9: Persistence + dedup state machine
+
+**Files:**
+- Create: `apps/api/src/services/abuseSignals/persistence.ts`
+- Test: `apps/api/src/services/abuseSignals/persistence.test.ts`
+
+**Interfaces:**
+- Consumes: `partnerAbuseSignals` table (Task 4), `ComputedSignal` (Task 5).
+- Produces:
+  - `interface OpenSignalRow { id: string; partnerId: string; signalKey: string; severity: AbuseSeverity; acknowledgedAt: Date | null; deliveredAt: Date | null; }`
+  - `persistSignals(computed: ComputedSignal[], now: Date): Promise<{ toNotify: Array<ComputedSignal & { rowId: string }> }>` (system-context caller)
+  - `markDelivered(rowIds: string[], now: Date): Promise<void>` (system-context caller)
+
+State machine rules (the tests below encode them):
+1. Fired + no open row → INSERT; notify if severity is `alert`.
+2. Fired + open row → UPDATE score/severity/evidence/computed_at (keep `first_fired_at`); notify only if severity is `alert` AND (`delivered_at` IS NULL) AND (`acknowledged_at` IS NULL). Covers watch→alert escalation (never delivered) and failed-delivery retry, without hourly re-spam of already-delivered alerts.
+3. Open row + not fired this sweep → set `resolved_at` (acknowledged rows resolve too; a re-fire later creates a fresh row, so materially-changed evidence re-alerts).
+4. Acknowledged rows are never notified while open.
+
+- [ ] **Step 1: Write the failing tests**
+
+Mock the db module with a chainable stub (same style as `register.test.ts`); assert behavior through which mutations run and what `toNotify` contains:
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const inserted: unknown[] = [];
+const updates: Array<{ set: Record<string, unknown> }> = [];
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(() => ({
+      values: vi.fn((v: unknown) => {
+        inserted.push(v);
+        return { returning: vi.fn().mockResolvedValue([{ id: `new-${inserted.length}` }]) };
+      }),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((s: Record<string, unknown>) => {
+        updates.push({ set: s });
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      }),
+    })),
+  },
+}));
+
+import { db } from '../../db';
+import { persistSignals } from './persistence';
+import type { ComputedSignal } from './types';
+
+const now = new Date('2026-07-15T12:00:00Z');
+
+function mockOpenRows(rows: unknown[]) {
+  vi.mocked(db.select).mockReturnValue({
+    from: vi.fn(() => ({ where: vi.fn().mockResolvedValue(rows) })),
+  } as never);
+}
+
+function signal(overrides: Partial<ComputedSignal>): ComputedSignal {
+  return { partnerId: 'p1', signalKey: 'rmm.consumer_devices', score: 80, severity: 'alert', evidence: {}, ...overrides };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  inserted.length = 0;
+  updates.length = 0;
+});
+
+describe('persistSignals', () => {
+  it('inserts new fired signals and notifies alerts only', async () => {
+    mockOpenRows([]);
+    const { toNotify } = await persistSignals(
+      [signal({}), signal({ signalKey: 'rmm.enrollment_velocity', score: 45, severity: 'watch' })],
+      now,
+    );
+    expect(inserted).toHaveLength(2);
+    expect(toNotify).toHaveLength(1);
+    expect(toNotify[0].signalKey).toBe('rmm.consumer_devices');
+  });
+
+  it('updates an existing open row without re-notifying a delivered alert', async () => {
+    mockOpenRows([{ id: 'row1', partnerId: 'p1', signalKey: 'rmm.consumer_devices', severity: 'alert', acknowledgedAt: null, deliveredAt: new Date() }]);
+    const { toNotify } = await persistSignals([signal({})], now);
+    expect(inserted).toHaveLength(0);
+    expect(updates.length).toBeGreaterThan(0);
+    expect(toNotify).toHaveLength(0);
+  });
+
+  it('notifies on escalation to alert (open watch row, never delivered)', async () => {
+    mockOpenRows([{ id: 'row1', partnerId: 'p1', signalKey: 'rmm.consumer_devices', severity: 'watch', acknowledgedAt: null, deliveredAt: null }]);
+    const { toNotify } = await persistSignals([signal({ severity: 'alert' })], now);
+    expect(toNotify).toHaveLength(1);
+    expect(toNotify[0].rowId).toBe('row1');
+  });
+
+  it('never notifies acknowledged rows', async () => {
+    mockOpenRows([{ id: 'row1', partnerId: 'p1', signalKey: 'rmm.consumer_devices', severity: 'alert', acknowledgedAt: new Date(), deliveredAt: null }]);
+    const { toNotify } = await persistSignals([signal({})], now);
+    expect(toNotify).toHaveLength(0);
+  });
+
+  it('resolves open rows that did not fire this sweep', async () => {
+    mockOpenRows([{ id: 'stale', partnerId: 'p9', signalKey: 'rmm.enrollment_velocity', severity: 'watch', acknowledgedAt: null, deliveredAt: null }]);
+    await persistSignals([], now);
+    expect(updates.some((u) => u.set.resolvedAt instanceof Date)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && npx vitest run src/services/abuseSignals/persistence.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement persistence.ts**
+
+```ts
+import { eq, isNull, inArray } from 'drizzle-orm';
+import { db } from '../../db';
+import { partnerAbuseSignals } from '../../db/schema';
+import type { ComputedSignal } from './types';
+
+const key = (partnerId: string, signalKey: string) => `${partnerId}|${signalKey}`;
+
+/**
+ * Reconciles this sweep's computed signals against open rows. State-based
+ * dedup: notify on first alert firing or on escalation-to-alert, never on
+ * hourly recomputation of an already-delivered alert. MUST run inside a
+ * system DB context.
+ */
+export async function persistSignals(
+  computed: ComputedSignal[],
+  now: Date,
+): Promise<{ toNotify: Array<ComputedSignal & { rowId: string }> }> {
+  const openRows = await db
+    .select()
+    .from(partnerAbuseSignals)
+    .where(isNull(partnerAbuseSignals.resolvedAt));
+
+  const openByKey = new Map(openRows.map((r) => [key(r.partnerId, r.signalKey), r]));
+  const firedKeys = new Set(computed.map((s) => key(s.partnerId, s.signalKey)));
+  const toNotify: Array<ComputedSignal & { rowId: string }> = [];
+
+  for (const s of computed) {
+    const open = openByKey.get(key(s.partnerId, s.signalKey));
+    if (!open) {
+      const [row] = await db
+        .insert(partnerAbuseSignals)
+        .values({
+          partnerId: s.partnerId,
+          signalKey: s.signalKey,
+          severity: s.severity,
+          score: s.score,
+          evidence: s.evidence,
+          firstFiredAt: now,
+          computedAt: now,
+        })
+        .returning();
+      if (s.severity === 'alert') toNotify.push({ ...s, rowId: row.id });
+      continue;
+    }
+
+    await db
+      .update(partnerAbuseSignals)
+      .set({ severity: s.severity, score: s.score, evidence: s.evidence, computedAt: now })
+      .where(eq(partnerAbuseSignals.id, open.id));
+
+    const notifiable =
+      s.severity === 'alert' && open.deliveredAt === null && open.acknowledgedAt === null;
+    if (notifiable) toNotify.push({ ...s, rowId: open.id });
+  }
+
+  const staleIds = openRows
+    .filter((r) => !firedKeys.has(key(r.partnerId, r.signalKey)))
+    .map((r) => r.id);
+  if (staleIds.length > 0) {
+    await db
+      .update(partnerAbuseSignals)
+      .set({ resolvedAt: now })
+      .where(inArray(partnerAbuseSignals.id, staleIds));
+  }
+
+  return { toNotify };
+}
+
+/** MUST run inside a system DB context. */
+export async function markDelivered(rowIds: string[], now: Date): Promise<void> {
+  if (rowIds.length === 0) return;
+  await db
+    .update(partnerAbuseSignals)
+    .set({ deliveredAt: now })
+    .where(inArray(partnerAbuseSignals.id, rowIds));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && npx vitest run src/services/abuseSignals/persistence.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/abuseSignals/persistence.ts apps/api/src/services/abuseSignals/persistence.test.ts
+git commit -m "feat(abuse): signal persistence with state-based alert dedup"
+```
+
+---
+
+### Task 10: Sweep orchestration, digest, BullMQ job, wiring
+
+**Files:**
+- Create: `apps/api/src/services/abuseSignals/index.ts`
+- Create: `apps/api/src/jobs/abuseSignalsSweep.ts`
+- Modify: `apps/api/src/index.ts` (import ~line 206, `initializeWorkers()` list ~line 1150, shutdown list ~line 1365)
+- Test: `apps/api/src/jobs/abuseSignalsSweep.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 5-9 plus `sendOpsAlert`, `recordAbuseSignalFired`, `recordAbuseSweepRun` (Task 6).
+- Produces: `runAbuseSweep(): Promise<{ fired: number; notified: number }>`, `runAbuseDigest(): Promise<void>`, `initializeAbuseSignalsWorker(): Promise<void>`, `shutdownAbuseSignalsWorker(): Promise<void>`.
+
+- [ ] **Step 1: Implement the orchestrator** (`services/abuseSignals/index.ts`)
+
+```ts
+import { sql } from 'drizzle-orm';
+import * as dbModule from '../../db';
+import { sendOpsAlert } from '../opsAlerts';
+import { recordAbuseSignalFired } from '../abuseMetrics';
+import { loadSignalConfig } from './config';
+import { computeInvariantSignals } from './invariants';
+import { loadPartnerAggregates, computeHeuristicSignals } from './heuristics';
+import { persistSignals, markDelivered } from './persistence';
+import type { ComputedSignal } from './types';
+
+const { db } = dbModule;
+
+// #1105: hold the system DB context only around DB work; alert delivery
+// (network) happens outside it.
+const runSystemDbCompute = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  const runOutside = dbModule.runOutsideDbContext;
+  if (typeof withSystem !== 'function') return fn();
+  if (typeof runOutside !== 'function') return withSystem(fn);
+  return runOutside(() => withSystem(fn));
+};
+
+function formatSignalAlert(s: ComputedSignal & { rowId: string }): { title: string; body: string } {
+  const shortId = s.partnerId.slice(0, 8);
+  return {
+    title: `Abuse signal: ${s.signalKey} (${s.severity})`,
+    body: [
+      `Partner: ${String(s.evidence.partnerName ?? 'unknown')} (${shortId})`,
+      `Score: ${s.score}`,
+      `Evidence: ${JSON.stringify(s.evidence)}`,
+      `Review: docs/superpowers/specs/2026-07-11-signup-abuse-detection-design.md — suspend playbook applies; partner id ${s.partnerId}`,
+    ].join('\n'),
+  };
+}
+
+export async function runAbuseSweep(): Promise<{ fired: number; notified: number }> {
+  const cfg = loadSignalConfig();
+  const now = new Date();
+
+  const { invariants, aggregates } = await runSystemDbCompute(async () => ({
+    invariants: await computeInvariantSignals(),
+    aggregates: await loadPartnerAggregates(),
+  }));
+
+  const computed = [...invariants, ...computeHeuristicSignals(aggregates, cfg, now)];
+  const { toNotify } = await runSystemDbCompute(() => persistSignals(computed, now));
+
+  for (const s of computed) recordAbuseSignalFired(s.severity);
+
+  const deliveredIds: string[] = [];
+  for (const n of toNotify) {
+    if (await sendOpsAlert(formatSignalAlert(n))) deliveredIds.push(n.rowId);
+  }
+  if (deliveredIds.length > 0) {
+    await runSystemDbCompute(() => markDelivered(deliveredIds, new Date()));
+  }
+
+  return { fired: computed.length, notified: deliveredIds.length };
+}
+
+export async function runAbuseDigest(): Promise<void> {
+  const stats = await runSystemDbCompute(async () => {
+    const openBySeverity = (await db.execute(sql`
+      SELECT severity, COUNT(*) AS count FROM partner_abuse_signals
+      WHERE resolved_at IS NULL AND acknowledged_at IS NULL
+      GROUP BY severity
+    `)) as unknown as Array<{ severity: string; count: string }>;
+    const watchRows = (await db.execute(sql`
+      SELECT s.signal_key, s.score, s.evidence, p.name
+      FROM partner_abuse_signals s JOIN partners p ON p.id = s.partner_id
+      WHERE s.resolved_at IS NULL AND s.acknowledged_at IS NULL AND s.severity = 'watch'
+      ORDER BY s.score DESC LIMIT 20
+    `)) as unknown as Array<{ signal_key: string; score: number; evidence: Record<string, unknown>; name: string }>;
+    const newPartners = (await db.execute(sql`
+      SELECT COUNT(*) AS count FROM partners WHERE created_at > now() - interval '7 days' AND deleted_at IS NULL
+    `)) as unknown as Array<{ count: string }>;
+    return { openBySeverity, watchRows, newPartnerCount: Number(newPartners[0]?.count ?? 0) };
+  });
+
+  const severityLine = stats.openBySeverity.map((r) => `${r.severity}: ${r.count}`).join(', ') || 'none open';
+  const watchLines = stats.watchRows.map((r) => `- ${r.name}: ${r.signal_key} (score ${r.score})`).join('\n');
+  await sendOpsAlert({
+    title: 'Weekly abuse-signals digest',
+    body: [
+      `New partners this week: ${stats.newPartnerCount}`,
+      `Open unacknowledged signals — ${severityLine}`,
+      watchLines ? `Watch tier:\n${watchLines}` : 'Watch tier: empty',
+      'Invariants checked hourly all week (any breach would have alerted immediately).',
+    ].join('\n'),
+  });
+}
+```
+
+- [ ] **Step 2: Write the failing job tests**
+
+`jobs/abuseSignalsSweep.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const queueAdd = vi.fn();
+const getRepeatableJobs = vi.fn().mockResolvedValue([
+  { name: 'abuse-sweep', key: 'old-key-1' },
+  { name: 'unrelated', key: 'other' },
+]);
+const removeRepeatableByKey = vi.fn();
+
+vi.mock('bullmq', () => ({
+  Queue: vi.fn(() => ({ add: queueAdd, getRepeatableJobs, removeRepeatableByKey, close: vi.fn() })),
+  Worker: vi.fn(() => ({ on: vi.fn(), close: vi.fn() })),
+}));
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
+vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
+vi.mock('../services/abuseSignals', () => ({ runAbuseSweep: vi.fn(), runAbuseDigest: vi.fn() }));
+vi.mock('../services/abuseMetrics', () => ({ recordAbuseSweepRun: vi.fn() }));
+
+import { scheduleAbuseSignalsJobs } from './abuseSignalsSweep';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('scheduleAbuseSignalsJobs', () => {
+  it('clears prior repeatables for its own job names only, then schedules hourly sweep + weekly digest', async () => {
+    getRepeatableJobs.mockResolvedValueOnce([
+      { name: 'abuse-sweep', key: 'stale-sweep' },
+      { name: 'abuse-digest', key: 'stale-digest' },
+      { name: 'unrelated', key: 'other' },
+    ]);
+    await scheduleAbuseSignalsJobs();
+    expect(removeRepeatableByKey).toHaveBeenCalledWith('stale-sweep');
+    expect(removeRepeatableByKey).toHaveBeenCalledWith('stale-digest');
+    expect(removeRepeatableByKey).not.toHaveBeenCalledWith('other');
+    expect(queueAdd).toHaveBeenCalledWith(
+      'abuse-sweep',
+      expect.anything(),
+      expect.objectContaining({ jobId: 'abuse-sweep-repeat', repeat: { every: 60 * 60 * 1000 } }),
+    );
+    expect(queueAdd).toHaveBeenCalledWith(
+      'abuse-digest',
+      expect.anything(),
+      expect.objectContaining({ jobId: 'abuse-digest-repeat', repeat: { pattern: '0 9 * * 1' } }),
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd apps/api && npx vitest run src/jobs/abuseSignalsSweep.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement the job** (`jobs/abuseSignalsSweep.ts`; follows `userRiskJobs.ts`)
+
+```ts
+import { Job, Queue, Worker } from 'bullmq';
+import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
+import { runAbuseSweep, runAbuseDigest } from '../services/abuseSignals';
+import { recordAbuseSweepRun } from '../services/abuseMetrics';
+
+const ABUSE_QUEUE = 'abuse-signals';
+const SWEEP_JOB = 'abuse-sweep';
+const DIGEST_JOB = 'abuse-digest';
+// jobIds use hyphens, never colons (BullMQ jobId rule).
+const SWEEP_REPEAT_ID = 'abuse-sweep-repeat';
+const DIGEST_REPEAT_ID = 'abuse-digest-repeat';
+const SWEEP_INTERVAL_MS = 60 * 60 * 1000; // hourly
+const DIGEST_CRON = '0 9 * * 1'; // Monday 09:00
+
+type AbuseJobData = Record<string, never>;
+
+let abuseQueue: Queue<AbuseJobData> | null = null;
+let abuseWorker: Worker<AbuseJobData> | null = null;
+
+export function getAbuseSignalsQueue(): Queue<AbuseJobData> {
+  if (!abuseQueue) {
+    abuseQueue = new Queue<AbuseJobData>(ABUSE_QUEUE, { connection: getBullMQConnection() });
+  }
+  return abuseQueue;
+}
+
+export async function scheduleAbuseSignalsJobs(): Promise<void> {
+  const queue = getAbuseSignalsQueue();
+  // Clear prior repeatables so interval/cron changes take effect on redeploy.
+  const existing = await queue.getRepeatableJobs();
+  for (const job of existing) {
+    if (job.name === SWEEP_JOB || job.name === DIGEST_JOB) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+  await queue.add(SWEEP_JOB, {}, {
+    jobId: SWEEP_REPEAT_ID,
+    repeat: { every: SWEEP_INTERVAL_MS },
+    removeOnComplete: { count: 10 },
+    removeOnFail: { count: 25 },
+  });
+  await queue.add(DIGEST_JOB, {}, {
+    jobId: DIGEST_REPEAT_ID,
+    repeat: { pattern: DIGEST_CRON },
+    removeOnComplete: { count: 5 },
+    removeOnFail: { count: 10 },
+  });
+}
+
+export function createAbuseSignalsWorker(): Worker<AbuseJobData> {
+  return new Worker<AbuseJobData>(
+    ABUSE_QUEUE,
+    async (job: Job<AbuseJobData>) => {
+      try {
+        if (job.name === SWEEP_JOB) {
+          const result = await runAbuseSweep();
+          recordAbuseSweepRun('success');
+          return result;
+        }
+        if (job.name === DIGEST_JOB) {
+          await runAbuseDigest();
+          return {};
+        }
+        return {};
+      } catch (error) {
+        recordAbuseSweepRun('error');
+        throw error;
+      }
+    },
+    { connection: getBullMQConnection(), concurrency: 1 },
+  );
+}
+
+export async function initializeAbuseSignalsWorker(): Promise<void> {
+  abuseWorker = createAbuseSignalsWorker();
+  attachWorkerObservability(abuseWorker, 'abuseSignalsWorker');
+  await scheduleAbuseSignalsJobs();
+  console.log('[AbuseSignals] Sweep worker initialized');
+}
+
+export async function shutdownAbuseSignalsWorker(): Promise<void> {
+  if (abuseWorker) {
+    await abuseWorker.close();
+    abuseWorker = null;
+  }
+  if (abuseQueue) {
+    await abuseQueue.close();
+    abuseQueue = null;
+  }
+}
+```
+
+- [ ] **Step 5: Wire into index.ts**
+
+Add alongside the userRisk imports (~line 206):
+
+```ts
+import { initializeAbuseSignalsWorker, shutdownAbuseSignalsWorker } from './jobs/abuseSignalsSweep';
+```
+
+Add to the `initializeWorkers()` tuple list (~line 1150):
+
+```ts
+    ['abuseSignalsWorker', initializeAbuseSignalsWorker],
+```
+
+Add to the shutdown list (~line 1365):
+
+```ts
+    shutdownAbuseSignalsWorker,
+```
+
+- [ ] **Step 6: Run the job tests and full API unit suite**
+
+Run: `cd apps/api && npx vitest run src/jobs/abuseSignalsSweep.test.ts`
+Expected: PASS.
+Run: `pnpm test --filter=@breeze/api`
+Expected: PASS (no regressions; watch for the schema-mock trap — any suite stubbing `../../db/schema` may need `partnerAbuseSignals` added).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/abuseSignals/index.ts apps/api/src/jobs/abuseSignalsSweep.ts apps/api/src/jobs/abuseSignalsSweep.test.ts apps/api/src/index.ts
+git commit -m "feat(abuse): hourly abuse-signals sweep + weekly digest job"
+```
+
+---
+
+### Task 11: Hardening fixes (unsuspend email gate, createPartner explicit status)
+
+**Files:**
+- Modify: `apps/api/src/routes/admin/abuse.ts` (unsuspend handler, partner select ~line 384, status decision ~line 400)
+- Modify: `apps/api/src/services/partnerCreate.ts` (make `status` required)
+- Test: the existing test file for `routes/admin/abuse.ts` (co-located; create `abuse.test.ts` with the standard Drizzle-mock scaffolding from `register.test.ts` if none exists)
+
+**Interfaces:**
+- Consumes: nothing new. Changes `CreatePartnerInput.status` from optional to required (Task 2 already passes it explicitly at the only production call site).
+
+- [ ] **Step 1: Write the failing test**
+
+In the abuse route test file:
+
+```ts
+  it('unsuspend falls back to pending when email is unverified, even with payment attached', async () => {
+    // Arrange the partner select to return paymentMethodAttachedAt set, emailVerifiedAt null
+    // (use the file's tx-mock scaffolding), then call POST /partners/:id/unsuspend.
+    // Assert the partners UPDATE ran with status 'pending', not 'active'.
+    expect(capturedPartnerUpdate.status).toBe('pending');
+  });
+```
+
+(Complete the arrange step with the file's mock scaffolding; the assertion above is the contract. If creating the file fresh, copy the `vi.mock('../../db', ...)` block from `register.test.ts` and mock `withSystemDbAccessContext`/`db.transaction` so the transaction callback runs with a stub `tx` whose `update().set()` captures its argument into `capturedPartnerUpdate`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — status is `'active'` (current behavior ignores email verification).
+
+- [ ] **Step 3: Fix the unsuspend gate**
+
+In `apps/api/src/routes/admin/abuse.ts`, add `emailVerifiedAt` to the partner select:
+
+```ts
+          .select({
+            id: partners.id,
+            paymentMethodAttachedAt: partners.paymentMethodAttachedAt,
+            emailVerifiedAt: partners.emailVerifiedAt,
+          })
+```
+
+and change the status decision (comment updated to match):
+
+```ts
+        // Preserve the FULL activation gate (email verification AND payment
+        // method) — unsuspend must not become the one path that activates an
+        // unverified partner. Otherwise route back through pending-activation.
+        const newStatus: 'active' | 'pending' =
+          partner.paymentMethodAttachedAt && partner.emailVerifiedAt ? 'active' : 'pending';
+```
+
+- [ ] **Step 4: Make createPartner status explicit**
+
+In `apps/api/src/services/partnerCreate.ts`, change the input field to required and remove the fallback:
+
+```ts
+  /**
+   * Initial partner status — REQUIRED so no future caller silently mints an
+   * 'active' partner. Hosted signups pass 'pending' (partnerGuard blocks
+   * features until breeze-billing activates post-payment + email verify).
+   */
+  status: PartnerStatus;
+```
+
+and in the insert values: `status: input.status,`
+
+Run `cd apps/api && npx tsc --noEmit` — any caller not passing `status` explicitly now fails the build; fix each by passing the correct explicit value (register.ts already does; tests may need `status: 'pending'` added to fixtures).
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd apps/api && npx vitest run src/routes/admin/abuse.test.ts src/services/partnerCreate.test.ts src/routes/auth/register.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/admin/abuse.ts apps/api/src/services/partnerCreate.ts apps/api/src/routes/admin/abuse.test.ts apps/api/src/services/partnerCreate.test.ts
+git commit -m "fix(abuse): unsuspend re-checks email verification; createPartner requires explicit status"
+```
+
+---
+
+### Task 12: Full verification pass
+
+- [ ] **Step 1: Full API suite + typecheck**
+
+Run: `pnpm test --filter=@breeze/api` and `cd apps/api && npx tsc --noEmit`
+Expected: PASS / no errors.
+
+- [ ] **Step 2: Integration suite (real Postgres on :5433)**
+
+Run the RLS coverage + forge suites per the repo's integration-test mechanics.
+Expected: PASS, including the new `partner_abuse_signals` forge cases.
+
+- [ ] **Step 3: Migration replay**
+
+Run: `cd apps/api && DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" pnpm db:check-drift` twice.
+Expected: exits 0 both times (idempotency).
+
+- [ ] **Step 4: Live smoke (worktree stack)**
+
+Bring up the worktree stack, set `OPS_ALERT_WEBHOOK_URL` to a test webhook, seed a synthetic young partner with ≥5 `DESKTOP-XXXXXXX` devices and force-run the sweep (enqueue `abuse-sweep` once via a one-off script or drop the repeat interval); confirm the alert message arrives and a `partner_abuse_signals` row exists with `delivered_at` set. Then re-run the sweep and confirm no duplicate alert.
+
+- [ ] **Step 5: Commit any fixes, then hand off for PR**
+
+PR 2 ships Tasks 4-12. Use the repo's standard PR + review flow.
+
+---
+
+## Out of scope for this plan (tracked in the spec)
+
+- **Geo PR** (GeoLite2 download job, geography/ASN signals): separate follow-up plan once this lands and capture data accrues.
+- **breeze-billing** Radar early-fraud-warning/dispute forward: separate repo.
+- **Ops tasks**: CrowdSec on droplets, weekly Claude analyst schedule + `internal/` playbook, prod env var rollout (`.env` + compose mapping on droplets), acknowledging the ~11 grandfathered `invariant.active_unverified_email` hits on first sweep.

--- a/docs/superpowers/specs/2026-07-11-signup-abuse-detection-design.md
+++ b/docs/superpowers/specs/2026-07-11-signup-abuse-detection-design.md
@@ -1,0 +1,165 @@
+# Signup Abuse Detection — Design
+
+**Date:** 2026-07-11
+**Status:** Approved design, pre-implementation
+**Owner scope:** hosted-SaaS operators (feature is equally useful to self-hosted multi-tenant deployments)
+
+## Problem
+
+Hosted Breeze accepts self-service partner signups. Abuse of those signups today is detected only by manual operator spot checks. Four threat classes, in priority order:
+
+1. **Malicious RMM use** (top priority): a real, paying account deploying agents to machines the "partner" does not own — the tech-support-scammer pattern. Invisible to payment-fraud screening and to host-level IDS; the evidence lives in application data (enrollment geography, device shapes, remote-session behavior).
+2. **Fraudulent signups**: card testing, fake partners, trial abuse.
+3. **Droplet/host compromise**: intrusion on the hosting VMs themselves.
+4. **Resource abuse**: accounts driving cost or hammering the API.
+
+Response posture (operator decision): **alert-first**. Detections notify the platform operator with evidence; suspension remains a human decision via the existing `POST /admin/partners/:id/suspend-for-abuse` playbook. No auto-suspend in this phase.
+
+## Prior verification (2026-07-10)
+
+The signup gate chain was re-verified before this design was finalized:
+
+- Hosted signups are created `status='pending'`; activation requires **both** `email_verified_at` and `payment_method_attached_at` via a single shared predicate (`services/partnerActivation.ts`), covering both orderings. The billing service independently gates its activation flip on email verification.
+- A `pending` partner can log in but is blocked by `partnerGuard` from orgs, enrollment keys, installer tokens, scripts, and remote sessions; the agent plane (enrollment, agent WS, mTLS, API keys) independently requires the partner to be strictly `active`. No agent can enroll pre-activation. Suspension re-seals the same gates.
+- Production containers were confirmed running with `IS_HOSTED=true` and `NODE_ENV=production`.
+- **Finding:** a deploy-lag window (billing service deployed from a build predating its email-verification gate) allowed a small number of partners to activate with unverified emails between mid-May and mid-June 2026. The window is closed. Affected accounts were reviewed and deliberately grandfathered (see acknowledgment mechanism below). This incident motivates the standing invariant checks in this design.
+
+Known residual gaps, addressed in scope:
+
+- Admin `unsuspend` reinstates on `payment_method_attached_at` alone without re-checking `email_verified_at` — the only activation write that ignores the email gate. **Fix in scope** (fall back to `pending` when email is unverified).
+- `createPartner` defaults omitted `status` to `'active'` for non-MCP callers. Safe today (single caller passes explicitly); **fix in scope** (require explicit status or default hosted-aware).
+- The `IS_HOSTED` boot-refusal validation only runs when `NODE_ENV=production`. Not directly fixed; the consequence (unverified-active partners) is caught by the invariant sweep.
+
+## Architecture overview
+
+Five layers, each independently useful:
+
+1. **Data capture** — persist the IPs and metadata the signals need (ships first; unrecorded signals are unrecoverable).
+2. **Abuse-signals sweep** — an hourly BullMQ job computing deterministic per-partner signals into a new `partner_abuse_signals` table.
+3. **Ops alerting** — a platform-operator notification primitive (Discord webhook / email), immediate alerts + weekly digest.
+4. **Scheduled analyst** — a weekly operator-side Claude run that applies judgment to persisted signals. Reads only; never collects, never acts.
+5. **Host hardening** — CrowdSec on the droplets. Wazuh explicitly deferred (its distinctive value — FIM/compliance — targets the least-likely threat at the highest operational cost).
+
+LLM involvement is confined to layer 4. Layers 1–3 are deterministic SQL + arithmetic.
+
+## Layer 1: Data capture
+
+**New columns (all nullable; existing rows stay null):**
+
+| Table | Column | Written where |
+|---|---|---|
+| `partners` | `signup_ip` (varchar 45) | `register-partner` handler, from trusted client IP |
+| `partners` | `signup_user_agent` (text) | same |
+| `devices` | `enrollment_ip` (varchar 45) | agent enrollment route (IP already computed for rate limiting) |
+| `devices` | `last_public_ip` (varchar 45) | agent WS connection establishment (server-side remote address; **no Go agent changes**) |
+
+**IP enrichment:** MaxMind GeoLite2 (City + ASN), resolved at **sweep time** only — never on hot paths. Databases are downloaded locally by a weekly refresh job using `MAXMIND_LICENSE_KEY`; lookups give country, city, ASN, and org name. Residential-vs-business classification is a best-effort keyword heuristic over ASN org names and is only ever one weighted signal among several.
+
+**Stripe Radar:** `radar.early_fraud_warning.created` and `charge.dispute.created` webhooks belong to the platform Stripe account and therefore land in the **billing service (separate repo)**, which posts them to the same ops webhook (its own env config). Dependency noted; not in this repo's scope.
+
+**Deliberately out of scope this phase:** captcha and disposable-email screening (prevention rather than detection; signup rate limiting already exists; easy independent follow-up).
+
+## Layer 2: Abuse-signals sweep
+
+**Job:** `abuse-signals-sweep`, BullMQ repeatable, hourly. Follows the `userRiskJobs` pattern: `runOutsideDbContext` → `withSystemDbAccessContext`, worker observability attached, no connections held across slow non-DB work. Job IDs use `-`, never `:`.
+
+**Scope per run:** heuristic signals computed for partners created < 90 days ago or with activity since the last sweep; invariant checks run fleet-wide every pass (cheap queries). "Young account" in the signal definitions means partner age < 30 days at full weight, linearly decaying to zero weight at 90 days.
+
+### Signals
+
+**Invariants** (severity `alert`; should never fire):
+
+| Key | Condition |
+|---|---|
+| `invariant.active_unverified_email` | `status='active' AND email_verified_at IS NULL`, excluding acknowledged signals |
+| `invariant.active_no_payment` | `status='active' AND payment_method_attached_at IS NULL`, excluding acknowledged (comped accounts exist) |
+| `invariant.inactive_partner_with_agents` | pending/suspended partner with enrolled devices or live agent connections |
+
+**Malicious-RMM-use heuristics** (weighted, per-partner):
+
+| Key | Signal |
+|---|---|
+| `rmm.geo_spread` | distinct countries across device public IPs on a young account |
+| `rmm.signup_device_mismatch` | signup-IP country differs from dominant device country |
+| `rmm.residential_ratio` | share of devices on eyeball/residential ASNs |
+| `rmm.consumer_devices` | ratio of default hostnames (`DESKTOP-`/`LAPTOP-` pattern) and non-domain-joined Windows machines |
+| `rmm.session_intensity` | remote sessions per device in first weeks; remote session into a device enrolled < 24h earlier weighs heaviest |
+| `rmm.enrollment_velocity` | burst enrollments on young accounts |
+| `rmm.token_spread` | one installer/bootstrap token redeemed from many distinct IPs/countries |
+
+**Fraud / resource** (existing data):
+
+| Key | Signal |
+|---|---|
+| `fraud.failed_login_cluster` | failed-login clusters from audit logs |
+| `resource.enrollment_denied` | enrollment-denied / device-cap-hit counts |
+| `resource.volume_outlier` | script-push and command volume outliers on young accounts |
+
+**Scoring:** transparent weighted sum → `info` (recorded only) / `watch` (weekly digest) / `alert` (immediate notification). Weights and thresholds are constants in one file **with env-var overrides** via a single JSON map, `ABUSE_SIGNAL_OVERRIDES` (e.g. `{"rmm.geo_spread.alert_countries": 5}`), validated at boot with unknown keys warned and ignored, so production values can diverge from the published defaults. Rationale: the repo is public; adversaries can read default thresholds but not the deployed ones.
+
+**Storage:** new table `partner_abuse_signals`:
+
+- `id`, `partner_id` (FK), `signal_key`, `severity`, `score`, `evidence` (jsonb — the actual IPs/hostnames/counts so the operator's decision needs no re-query), `computed_at`, `resolved_at`, `acknowledged_at`, `acknowledged_by`, `delivered_at`.
+- **Acknowledgment replaces code allowlists.** Grandfathered/comped accounts are handled by setting `acknowledged_at`/`acknowledged_by` on the fired signal row — direct SQL in this phase (a platform-admin ack endpoint is a possible follow-up, not in scope). Acknowledged signals are suppressed unless evidence materially changes. No tenant identifiers ever appear in code or config.
+- **RLS: deny-all to app traffic.** This table is *about* partners, not *for* them. RLS enabled + forced with policies passing only for system context (and platform-admin, if the ack endpoint is built). It must NOT use `breeze_has_partner_access`. Registered in the RLS contract test as an intentional special case; integration test proves a partner-scoped token reads zero rows and a cross-tenant forge fails.
+
+**Dedup:** state-based. Notification on first firing or severity escalation only; hourly re-computation updates evidence without re-alerting. `delivered_at` set only on successful send, so failed deliveries retry next sweep.
+
+## Layer 3: Ops alerting
+
+**New `opsAlerts` service** — the platform-operator channel (all existing notification paths are tenant-facing). Env-only config, no infrastructure details in code:
+
+- `OPS_ALERT_WEBHOOK_URL` — Discord-format webhook.
+- `OPS_ALERT_EMAIL` — optional second channel via the existing email service.
+- Both optional: unset → feature logs a warning and no-ops. No new boot-refusal requirements.
+
+**Immediate alerts** (`alert` severity + invariants): one message per partner-signal — partner name + short id + region tag (each regional deployment posts its own, same channel), fired signals + score, inline evidence, pointer to the suspend playbook with partner id pre-filled.
+
+**Weekly digest** (Monday): `watch`-tier signals, week-over-week trends, new-partner count, and an explicit "invariants checked and clean" line — silence must mean *verified nothing*, not *nothing ran*.
+
+**Delivery semantics:** send failure never fails the sweep (log + Sentry + retry next pass). Sweep exports Prometheus counters (signals fired by severity, sweep duration) — a flatlined metric in the existing Grafana stack is the dead-man's switch.
+
+## Layer 4: Scheduled analyst (operator-side, not product code)
+
+Weekly Claude Code scheduled run on the operator's workstation (prod access rides the operator's tailnet; posture-gated SSH may require an interactive re-auth). Playbook document lives in the gitignored `internal/` directory because it references production access paths.
+
+Role boundary: **code decides what is anomalous; the analyst decides what it means.** Each run: pull open watch/alert signals + the week's new partners (read-only SQL), build the holistic picture per flagged partner (name-vs-usage coherence, org/device naming, timing patterns), cross-check payment posture, and deliver per-partner verdicts — *clear / keep watching / suspend candidate with evidence*. Judgment rules encoded in the playbook: distinct-card cardinality beats failure count; out-of-band contact is a signal, not proof; a Radar early-fraud warning is dispositive. The run never mutates anything.
+
+Quarterly deep pass: re-verify activation invariants end-to-end (gate order in code, live container env, unverified-active query), review acknowledged signals, and re-fit signal weights against what real incidents taught.
+
+## Layer 5: Host hardening (ops task, minimal repo footprint)
+
+Droplets already sit behind a cloud firewall (SSH closed to a single allowlisted IP; only the reverse proxy exposed). Remaining edge = public HTTPS.
+
+- **CrowdSec** on both droplets: reverse-proxy log parser + firewall bouncer; community blocklists. Catches scanner floods and credential stuffing at the edge for a few hundred MB of RAM.
+- Hygiene check: unattended security upgrades, auditd.
+- **Wazuh deferred, not rejected** — revisit if FIM/compliance-evidence needs arise; nothing here overlaps with it.
+
+## Testing
+
+- **Unit (Vitest, Drizzle mocks):** each signal computation; scoring thresholds and severity transitions; dedup state machine (fire → escalate → resolve → no re-alert); ops-alert payloads; delivery-failure leaves `delivered_at` null.
+- **Integration (real Postgres):** RLS deny-all on `partner_abuse_signals` (cross-tenant forge → RLS violation; partner token → zero rows; system context → reads) + registration in the RLS coverage contract test; invariant queries against seeded good/bad fixtures; migration idempotency (re-apply is a no-op).
+- **Live validation:** seed a synthetic scattered-devices/instant-remote-session partner in a worktree stack; observe the end-to-end alert before prod deploy.
+
+Migrations follow the standard rules: `YYYY-MM-DD-<slug>.sql`, idempotent, RLS policies in the same migration that creates the table, no inner transactions.
+
+## Rollout
+
+| # | Deliverable | Notes |
+|---|---|---|
+| 1 | Data-capture PR | migrations + write paths; ship first so data accrues |
+| 2 | Sweep PR | signals table, hourly job, invariants + non-geo heuristics (work on existing data), opsAlerts, digest, unsuspend/createPartner hardening fixes |
+| 3 | Geo PR | GeoLite2 refresh job; geography/ASN signals switch on |
+| 4 | Billing-service PR (separate repo) | Radar EFW + dispute → ops webhook |
+| 5 | Ops | CrowdSec on droplets; weekly analyst schedule + `internal/` playbook; env vars added to droplet `.env` **and** compose `environment:` mappings |
+
+New env vars (`OPS_ALERT_WEBHOOK_URL`, `OPS_ALERT_EMAIL`, `MAXMIND_LICENSE_KEY`, threshold overrides) are all optional with logged warnings when unset.
+
+## Decisions log
+
+- Alert-first; no auto-suspend (operator decision, 2026-07-10).
+- Wazuh deferred in favor of CrowdSec; malicious RMM use is invisible at host level.
+- Grandfathered/comped accounts handled via signal acknowledgment in DB, never code allowlists (public repo; no tenant identifiers in git).
+- Signal thresholds env-overridable so deployed values can diverge from published defaults.
+- Everything ships in the public repo; only the analyst playbook (`internal/`) and env values stay private.
+- Captcha/disposable-email screening deferred as independent follow-up.

--- a/docs/superpowers/specs/2026-07-11-signup-abuse-detection-design.md
+++ b/docs/superpowers/specs/2026-07-11-signup-abuse-detection-design.md
@@ -51,7 +51,8 @@ LLM involvement is confined to layer 4. Layers 1–3 are deterministic SQL + ari
 | `partners` | `signup_ip` (varchar 45) | `register-partner` handler, from trusted client IP |
 | `partners` | `signup_user_agent` (text) | same |
 | `devices` | `enrollment_ip` (varchar 45) | agent enrollment route (IP already computed for rate limiting) |
-| `devices` | `last_public_ip` (varchar 45) | agent WS connection establishment (server-side remote address; **no Go agent changes**) |
+
+**Amendment 2026-07-11:** the originally proposed `devices.last_public_ip` is dropped — `devices.last_seen_ip` (varchar 45) already exists, updated on every authenticated agent request with audit-logged transitions. The sweep reads `last_seen_ip` for ongoing device geography. **No Go agent changes** either way.
 
 **IP enrichment:** MaxMind GeoLite2 (City + ASN), resolved at **sweep time** only — never on hot paths. Databases are downloaded locally by a weekly refresh job using `MAXMIND_LICENSE_KEY`; lookups give country, city, ASN, and org name. Residential-vs-business classification is a best-effort keyword heuristic over ASN org names and is only ever one weighted signal among several.
 
@@ -85,7 +86,7 @@ LLM involvement is confined to layer 4. Layers 1–3 are deterministic SQL + ari
 | `rmm.consumer_devices` | ratio of default hostnames (`DESKTOP-`/`LAPTOP-` pattern) and non-domain-joined Windows machines |
 | `rmm.session_intensity` | remote sessions per device in first weeks; remote session into a device enrolled < 24h earlier weighs heaviest |
 | `rmm.enrollment_velocity` | burst enrollments on young accounts |
-| `rmm.token_spread` | one installer/bootstrap token redeemed from many distinct IPs/countries |
+| `rmm.enrollment_ip_spread` | devices enrolled from many distinct IPs relative to fleet size (amended from the original `rmm.token_spread`: bootstrap tokens do not record redeemer IPs; per-device `enrollment_ip` spread measures the same scatter. Upgraded to country-level in the geo PR) |
 
 **Fraud / resource** (existing data):
 

--- a/docs/superpowers/specs/2026-07-11-signup-abuse-detection-design.md
+++ b/docs/superpowers/specs/2026-07-11-signup-abuse-detection-design.md
@@ -106,6 +106,8 @@ LLM involvement is confined to layer 4. Layers 1–3 are deterministic SQL + ari
 
 **Dedup:** state-based. Notification on first firing or severity escalation only; hourly re-computation updates evidence without re-alerting. `delivered_at` set only on successful send, so failed deliveries retry next sweep.
 
+**Scope boundary:** heuristic signals only cover partners that are young (< 90 days old), recently enrolling (device enrolled in the last 2 hours), or currently flagged (have an open signal row, so they stay evaluated to real resolution). Steady-state resource abuse by older accounts with no recent enrollment activity — e.g. a partner past the 90-day window running an established fleet abnormally hard — falls outside the sweep's scope in this phase. That gap is covered by the Prometheus/Grafana stack and the scheduled-analyst layer (Layer 4), not by this hourly job. This is a deliberate boundary, not an oversight; revisit it alongside the geo PR when `rmm.geo_spread`/`rmm.signup_device_mismatch` land and the scope question gets re-examined anyway.
+
 ## Layer 3: Ops alerting
 
 **New `opsAlerts` service** — the platform-operator channel (all existing notification paths are tenant-facing). Env-only config, no infrastructure details in code:


### PR DESCRIPTION
## Summary

Alert-first abuse detection for hosted multi-tenant deployments (spec: `docs/superpowers/specs/2026-07-11-signup-abuse-detection-design.md`, plan: `docs/superpowers/plans/2026-07-11-signup-abuse-detection.md`).

**Data capture** — new nullable attribution columns written on existing hot paths:
- `partners.signup_ip` / `partners.signup_user_agent` (web registrations)
- `devices.enrollment_ip` (both fresh-enroll and re-enroll paths)

**Abuse-signals sweep** — hourly BullMQ job (`abuse-signals`) computing deterministic per-partner signals into a new `partner_abuse_signals` table:
- Activation invariants (fleet-wide, alert on gate drift): active-with-unverified-email, active-without-payment, pending/suspended-with-live-agents
- Malicious-RMM-use heuristics (young/recently-active/flagged partners): consumer-hostname ratio, enrollment velocity, enroll-to-remote-session intensity, enrollment-IP spread
- Fraud/resource: failed-login clusters (both org- and partner-axis attribution), enrollment denials, command/script volume outliers
- Thresholds env-overridable via `ABUSE_SIGNAL_OVERRIDES` (JSON) so deployed values can diverge from published defaults
- State-based dedup: notify on first fire / escalation only; acknowledgment via `acknowledged_at` (no allowlists in code)

**RLS**: `partner_abuse_signals` is system-context-only (deny-all to tenants — partners must never read signals about themselves). Registered in the RLS contract test with a dedicated forge suite proving a partner-scoped context reads zero rows of its own signals.

**Ops alerting** — new platform-operator channel (`OPS_ALERT_WEBHOOK_URL` Discord webhook via SSRF-guarded safeFetch, optional `OPS_ALERT_EMAIL`), immediate alerts with evidence + weekly Monday digest, Prometheus counters (`breeze_abuse_signals_fired_total`, `breeze_abuse_sweep_runs_total`). All new env vars optional — unset means the feature no-ops with a logged warning.

**Hardening** — closes two activation-gate gaps found during design verification:
- Admin unsuspend now re-checks `email_verified_at` (was the only activation write that ignored the email gate)
- `createPartner` requires an explicit `status` (no more silent `'active'` default for future callers)
- Enrollment route: device-cap denials are now audit-logged; resolved-key denials attributed to their org

## Testing

- Full API unit suite green (12k+ tests); typecheck clean
- RLS coverage suite 53/53 including the new deny-all forge cases
- Migrations applied + replayed idempotently on fresh Postgres 16
- Live smoke on a real DB: synthetic scammer-shaped partner fired the expected signals with correct evidence; dedup held across sweeps; invariant fired on email-verification flip; FK cascade cleans signals on partner delete
- Task-by-task review + final whole-branch review (verdict: ready to merge)

## Deploy notes (hosted)

New optional env vars: `OPS_ALERT_WEBHOOK_URL`, `OPS_ALERT_EMAIL`, `OPS_ALERT_LABEL`, `ABUSE_SIGNAL_OVERRIDES` — add to droplet `.env` AND the compose `environment:` block (repo compose files already mapped). First sweep will fire ~11 `invariant.active_unverified_email` alerts for known-grandfathered partners — acknowledge via `acknowledged_at`.

Out of scope (tracked in spec): geo/ASN signals (follow-up PR once GeoLite2 lands), breeze-billing Radar forward, CrowdSec on droplets, weekly analyst schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)