### PR TITLE
fix(web): honor partner session timeout in All Organizations mode (#2347)

### DIFF
--- a/apps/web/src/components/auth/AdminSessionManager.test.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.test.tsx
@@ -146,3 +146,91 @@ describe('AdminSessionManager idle timeout source', () => {
     expect(apiLogoutMock).not.toHaveBeenCalled();
   });
 });
+
+describe('AdminSessionManager All Organizations mode (#2347)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    useAuthStoreMock.mockImplementation((selector: any) => selector({ isAuthenticated: true }));
+    // All Organizations intentionally persists `currentOrgId` as null.
+    useOrgStoreMock.mockImplementation((selector: any) => selector({ currentOrgId: null }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('loads the partner-level session timeout instead of the 60-minute default when no org is selected', async () => {
+    // Partner configured a 1440-minute (24h) timeout; the idle manager must honor
+    // it even though no organization is selected for viewing.
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ settings: { security: { sessionTimeout: 1440 } } })
+    );
+
+    render(<AdminSessionManager />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // It reads the authenticated user's partner record, never an org URL.
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/orgs/partners/me');
+    expect(fetchWithAuthMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('/effective-settings')
+    );
+
+    // A background heartbeat crossing the 60-minute frontend fallback must NOT
+    // log out while the configured partner timeout (1440 min) is far longer —
+    // this is the exact #2347 regression.
+    await act(async () => {
+      vi.advanceTimersByTime(61 * 60_000);
+      await Promise.resolve();
+    });
+    expect(apiLogoutMock).not.toHaveBeenCalled();
+  });
+
+  it('still logs out once the configured partner timeout elapses in All Organizations mode', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ settings: { security: { sessionTimeout: 2 } } })
+    );
+
+    render(<AdminSessionManager />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Just under 2 minutes — no logout yet.
+    await act(async () => {
+      vi.advanceTimersByTime(90_000);
+      await Promise.resolve();
+    });
+    expect(apiLogoutMock).not.toHaveBeenCalled();
+
+    // Cross the 2-minute threshold — the heartbeat must log out.
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+    expect(apiLogoutMock).toHaveBeenCalledTimes(1);
+    expect(navigateToMock).toHaveBeenCalledWith('/login', { replace: true });
+  });
+
+  it('keeps the default timeout when the partner record cannot be loaded', async () => {
+    // e.g. a non-partner scope gets 403 — never silently zero the timer.
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({}, false, 403));
+
+    render(<AdminSessionManager />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(5 * 60_000);
+      await Promise.resolve();
+    });
+    expect(apiLogoutMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/auth/AdminSessionManager.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.tsx
@@ -64,44 +64,68 @@ export default function AdminSessionManager() {
   }, [isAuthenticated]);
 
   useEffect(() => {
-    if (!isAuthenticated || !currentOrgId) {
+    if (!isAuthenticated) {
       setIdleTimeoutMs(DEFAULT_IDLE_TIMEOUT_MS);
       return;
     }
 
     let cancelled = false;
 
-    const loadOrgSessionTimeout = async () => {
+    const applyConfiguredTimeout = (configuredMinutes: number) => {
+      if (!cancelled && Number.isFinite(configuredMinutes) && configuredMinutes > 0) {
+        setIdleTimeoutMs(Math.max(1, configuredMinutes) * 60 * 1000);
+      }
+    };
+
+    const loadSessionTimeout = async () => {
       try {
-        // Use effective settings so a partner-level `security.sessionTimeout`
-        // default is honored by the idle-logout runtime, matching what the
-        // settings UI shows as effective/locked. Reading the raw org record
-        // missed partner defaults the org hadn't overridden locally (#2147).
-        const response = await fetchWithAuth(
-          `/orgs/organizations/${currentOrgId}/effective-settings`
-        );
+        if (currentOrgId) {
+          // Org selected: use that org's effective settings so a partner-level
+          // `security.sessionTimeout` default is honored by the idle-logout
+          // runtime, matching what the settings UI shows as effective/locked.
+          // Reading the raw org record missed partner defaults the org hadn't
+          // overridden locally (#2147).
+          const response = await fetchWithAuth(
+            `/orgs/organizations/${currentOrgId}/effective-settings`
+          );
+          if (!response.ok) {
+            // Surface the failure: this is the path that enforces a possibly
+            // partner-locked idle timeout, so a silent fall-back to the frontend
+            // default must at least be diagnosable (matches OrgSettingsPage).
+            console.warn(
+              '[AdminSessionManager] Failed to load effective session timeout:',
+              response.status
+            );
+            return;
+          }
+          const data = await response.json();
+          applyConfiguredTimeout(Number(data?.effective?.security?.sessionTimeout));
+          return;
+        }
+
+        // All Organizations mode intentionally sets `currentOrgId` to `null`.
+        // The idle timeout is a property of the authenticated user's partner,
+        // not of whichever org is selected for viewing data, so fall back to the
+        // partner-level security policy. Without this the timer silently reset to
+        // the 60-minute frontend default whenever no org was selected, logging a
+        // partner admin out early despite a longer configured timeout (#2347).
+        const response = await fetchWithAuth('/orgs/partners/me');
         if (!response.ok) {
-          // Surface the failure: this is the path that enforces a possibly
-          // partner-locked idle timeout, so a silent fall-back to the frontend
-          // default must at least be diagnosable (matches OrgSettingsPage).
           console.warn(
-            '[AdminSessionManager] Failed to load effective session timeout:',
+            '[AdminSessionManager] Failed to load partner session timeout:',
             response.status
           );
           return;
         }
         const data = await response.json();
-        const configuredMinutes = Number(data?.effective?.security?.sessionTimeout);
-        if (!cancelled && Number.isFinite(configuredMinutes) && configuredMinutes > 0) {
-          setIdleTimeoutMs(Math.max(1, configuredMinutes) * 60 * 1000);
-        }
+        applyConfiguredTimeout(Number(data?.settings?.security?.sessionTimeout));
       } catch (err) {
-        // Keep current timeout fallback when effective settings cannot be loaded.
-        console.warn('[AdminSessionManager] Error loading effective session timeout:', err);
+        // Keep current timeout fallback when session settings cannot be loaded.
+        console.warn('[AdminSessionManager] Error loading session timeout:', err);
       }
     };
 
-    void loadOrgSessionTimeout();
+    void loadSessionTimeout();
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
Fixes #2347.

## Problem
`AdminSessionManager` reset the idle timeout to the hardcoded 60-minute frontend default whenever no organization was selected. "All Organizations" intentionally persists `currentOrgId` as `null`, so a partner admin who configured a longer session timeout (e.g. 1440 min) was still logged out after ~60 minutes while viewing All Organizations — including from a throttled background tab. This is the gap left by #2171 (fixed #2147 for the org-selected path, which still requires a non-null `currentOrgId`).

## Fix
The idle timeout is a property of the authenticated user's partner, not of whichever org is selected for viewing data. When `currentOrgId` is `null`, load the partner-level policy via `GET /orgs/partners/me` and use `settings.security.sessionTimeout` — the same source the partner settings UI (`PartnerSettingsPage`) reads. Falls back to the frontend default only when the partner record can't be loaded (e.g. a non-partner scope returning 403), never silently zeroing the timer. The org-selected path (`/orgs/organizations/:id/effective-settings`) is unchanged.

## Tests
New `AdminSessionManager All Organizations mode (#2347)` suite:
- Loads the partner-level timeout (1440 min) instead of the 60-min default; a background heartbeat crossing 60 minutes does **not** log out (the exact regression).
- Logout still fires once the configured partner timeout elapses.
- A failed partner fetch keeps the default rather than zeroing the timer.

## Local verification
- `apps/web` vitest `AdminSessionManager.test.tsx`: **7/7 pass** (4 existing + 3 new) on node 22.20.0 (CI `.nvmrc`).
- eslint clean on both changed files.
- `astro check`: adds **zero** new type errors vs the `origin/main` baseline (verified by stash-diff).
