### PR TITLE
fix(security): site-scope invoice/quote AI actors + services (SR5-14/15)

### DIFF
--- a/apps/api/src/routes/invoices/invoices.ts
+++ b/apps/api/src/routes/invoices/invoices.ts
@@ -37,7 +37,10 @@ const dueDateSchema = z.object({
 
 export function invoiceActorFrom(c: { get: (k: string) => unknown }): InvoiceActor {
   const auth = c.get('auth') as AuthContext;
-  return { userId: auth.user.id, partnerId: auth.partnerId ?? null, accessibleOrgIds: auth.accessibleOrgIds };
+  // These routes require partner/system scope, where allowedSiteIds is undefined
+  // (unrestricted) — threading it is a no-op today but keeps the actor honest if an
+  // org/site-scoped token is ever admitted here.
+  return { userId: auth.user.id, partnerId: auth.partnerId ?? null, accessibleOrgIds: auth.accessibleOrgIds, allowedSiteIds: auth.allowedSiteIds };
 }
 export function handleServiceError(c: { json: (b: unknown, s: number) => Response }, err: unknown): Response {
   if (err instanceof InvoiceServiceError) return c.json({ error: err.message, code: err.code }, err.status);

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -31,7 +31,10 @@ const blockParam = z.object({ id: z.string().guid(), blockId: z.string().guid() 
 
 export function quoteActorFrom(c: { get: (k: string) => unknown }): QuoteActor {
   const auth = c.get('auth') as AuthContext;
-  return { userId: auth.user.id, partnerId: auth.partnerId ?? null, accessibleOrgIds: auth.accessibleOrgIds };
+  // These routes require partner/system scope, where allowedSiteIds is undefined
+  // (unrestricted) — threading it is a no-op today but keeps the actor honest if an
+  // org/site-scoped token is ever admitted here.
+  return { userId: auth.user.id, partnerId: auth.partnerId ?? null, accessibleOrgIds: auth.accessibleOrgIds, allowedSiteIds: auth.allowedSiteIds };
 }
 export function handleServiceError(c: { json: (b: unknown, s: number) => Response }, err: unknown): Response {
   if (err instanceof QuoteServiceError) return c.json({ error: err.message, code: err.code }, err.status);

--- a/apps/api/src/services/aiToolsBilling.ts
+++ b/apps/api/src/services/aiToolsBilling.ts
@@ -53,7 +53,11 @@ function actorFromAuth(auth: AuthContext): InvoiceActor {
   return {
     userId: auth.user.id,
     partnerId: auth.partnerId ?? null,
-    accessibleOrgIds: auth.accessibleOrgIds
+    accessibleOrgIds: auth.accessibleOrgIds,
+    // Thread the caller's site-axis restriction so a site-limited AI session can't
+    // read/mutate out-of-site invoices. undefined (partner/system, all-sites org
+    // users) stays unrestricted, preserving prior behavior.
+    allowedSiteIds: auth.allowedSiteIds
   };
 }
 

--- a/apps/api/src/services/aiToolsQuotes.ts
+++ b/apps/api/src/services/aiToolsQuotes.ts
@@ -46,7 +46,11 @@ function actorFromAuth(auth: AuthContext): QuoteActor {
   return {
     userId: auth.user.id,
     partnerId: auth.partnerId ?? null,
-    accessibleOrgIds: auth.accessibleOrgIds
+    accessibleOrgIds: auth.accessibleOrgIds,
+    // Thread the caller's site-axis restriction so a site-limited AI session can't
+    // read/mutate out-of-site quotes. undefined (partner/system, all-sites org
+    // users) stays unrestricted, preserving prior behavior.
+    allowedSiteIds: auth.allowedSiteIds
   };
 }
 

--- a/apps/api/src/services/invoiceCheckout.test.ts
+++ b/apps/api/src/services/invoiceCheckout.test.ts
@@ -40,10 +40,17 @@ vi.mock('./partnerStripe', async (importOriginal) => {
   };
 });
 
-// requireOrgAccess only — the rest of invoiceService is irrelevant here and
-// pulls in unrelated schema imports, so keep the mock minimal (no-op by default).
-const { requireOrgAccessMock } = vi.hoisted(() => ({ requireOrgAccessMock: vi.fn() }));
-vi.mock('./invoiceService', () => ({ requireOrgAccess: requireOrgAccessMock }));
+// requireOrgAccess/requireSiteAccess only — the rest of invoiceService is
+// irrelevant here and pulls in unrelated schema imports, so keep the mock minimal
+// (both no-op by default; site enforcement is exercised in the siteScope suites).
+const { requireOrgAccessMock, requireSiteAccessMock } = vi.hoisted(() => ({
+  requireOrgAccessMock: vi.fn(),
+  requireSiteAccessMock: vi.fn(),
+}));
+vi.mock('./invoiceService', () => ({
+  requireOrgAccess: requireOrgAccessMock,
+  requireSiteAccess: requireSiteAccessMock,
+}));
 
 import { createInvoicePayLink } from './invoiceCheckout';
 

--- a/apps/api/src/services/invoiceCheckout.ts
+++ b/apps/api/src/services/invoiceCheckout.ts
@@ -5,7 +5,7 @@ import { invoices, invoiceStripePayments } from '../db/schema';
 import { getPartnerStripeClient, PartnerStripeError } from './partnerStripe';
 import { toMinorUnits } from './stripeMoney';
 import { InvoiceServiceError, type InvoiceActor } from './invoiceTypes';
-import { requireOrgAccess } from './invoiceService';
+import { requireOrgAccess, requireSiteAccess } from './invoiceService';
 
 // Statuses whose balance can be collected online. Mirrors the customer-portal
 // PAYABLE set (routes/portal/invoices.ts) — drafts/paid/void are excluded.
@@ -37,6 +37,9 @@ export async function createInvoicePayLink(invoiceId: string, actor: InvoiceActo
   );
   if (!inv) throw new InvoiceServiceError('Invoice not found', 404, 'INVOICE_NOT_FOUND');
   requireOrgAccess(actor, inv.orgId);
+  // Site-axis guard: a site-restricted caller must not mint a pay link for an
+  // out-of-site invoice. No-op for unrestricted (partner/system/portal) actors.
+  requireSiteAccess(actor, inv.siteId);
   if (!PAYABLE.has(inv.status)) throw new InvoiceServiceError('Invoice is not payable', 409, 'NOT_PAYABLE');
 
   // Deposit-first: charge the deposit remaining while unmet, else the full

--- a/apps/api/src/services/invoiceService.siteScope.test.ts
+++ b/apps/api/src/services/invoiceService.siteScope.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Site-axis (sub-org) authorization guard for invoiceService (SR5-14). Mirrors the
+// controllable Drizzle-chain mock in invoiceService.test.ts: every builder method
+// returns the same chain; a query resolves when awaited, yielding the next queued
+// result. These tests lock the site-scope branch of the org/site guards — the
+// SQL-level list filtering is additionally proven against real Postgres in the
+// integration suite.
+const results: unknown[][] = [];
+function queueResult(rows: unknown[]) { results.push(rows); }
+
+vi.mock('../db', () => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {};
+    const methods = ['select', 'from', 'where', 'limit', 'orderBy', 'insert', 'values', 'returning', 'update', 'set', 'delete', 'for', 'innerJoin', 'execute'];
+    for (const m of methods) chain[m] = vi.fn(() => chain);
+    (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) => {
+      const rows = results.shift() ?? [];
+      return Promise.resolve(rows).then(resolve);
+    };
+    return chain;
+  };
+  const db = makeChain();
+  return {
+    db,
+    runOutsideDbContext: (fn: () => unknown) => fn(),
+    withSystemDbAccessContext: (fn: () => unknown) => fn()
+  };
+});
+
+vi.mock('./catalogService', () => ({ resolvePrice: vi.fn(), computeBundleEconomics: vi.fn() }));
+vi.mock('./invoiceEvents', () => ({ emitInvoiceEvent: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./stripeConnectService', () => ({ getConnection: vi.fn().mockResolvedValue(null) }));
+
+import * as svc from './invoiceService';
+import { db } from '../db';
+
+// A site-restricted org actor (allowedSiteIds present) that can reach org1 and only siteA.
+const restricted = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'], allowedSiteIds: ['siteA'] };
+// An unrestricted actor (allowedSiteIds undefined) — partner/system scope or all-sites org user.
+const unrestricted = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
+
+describe('invoiceService site-axis guard', () => {
+  beforeEach(() => { results.length = 0; vi.clearAllMocks(); });
+
+  it('getInvoice denies a site-restricted actor an out-of-site invoice (SITE_DENIED 403)', async () => {
+    queueResult([{ id: 'i1', status: 'sent', orgId: 'org1', partnerId: 'p1', siteId: 'siteB' }]);
+    await expect(svc.getInvoice('i1', restricted)).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+  });
+
+  it('getInvoice denies a site-restricted actor a null-site (org-level) invoice (SITE_DENIED 403)', async () => {
+    // Null-site semantics: a restricted caller can never see an org-level invoice,
+    // matching auth.ts siteAccessCheck which denies a restricted caller a null site.
+    queueResult([{ id: 'i1', status: 'sent', orgId: 'org1', partnerId: 'p1', siteId: null }]);
+    await expect(svc.getInvoice('i1', restricted)).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+  });
+
+  it('getInvoice allows a site-restricted actor an in-site invoice', async () => {
+    queueResult([{ id: 'i1', status: 'sent', orgId: 'org1', partnerId: 'p1', siteId: 'siteA' }]); // getOwnedInvoiceOr404
+    queueResult([]); // lines
+    const result = await svc.getInvoice('i1', restricted);
+    expect(result.invoice.id).toBe('i1');
+  });
+
+  it('getInvoice is unaffected for an unrestricted actor (out-of-site & null-site both visible)', async () => {
+    queueResult([{ id: 'i1', status: 'sent', orgId: 'org1', partnerId: 'p1', siteId: 'siteB' }]);
+    queueResult([]); // lines
+    const result = await svc.getInvoice('i1', unrestricted);
+    expect(result.invoice.id).toBe('i1');
+  });
+
+  it('updateInvoice denies editing an out-of-site draft (SITE_DENIED 403)', async () => {
+    queueResult([{ id: 'i1', status: 'draft', orgId: 'org1', partnerId: 'p1', siteId: 'siteB' }]);
+    await expect(svc.updateInvoice('i1', { notes: 'x' }, restricted)).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+  });
+
+  it('updateInvoice denies MOVING an in-site draft to an out-of-site siteId (SITE_DENIED 403)', async () => {
+    // Existing site (siteA) is accessible, but the requested move target (siteB) is not.
+    queueResult([{ id: 'i1', status: 'draft', orgId: 'org1', partnerId: 'p1', siteId: 'siteA' }]);
+    await expect(svc.updateInvoice('i1', { siteId: 'siteB' }, restricted)).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+  });
+
+  it('createManualInvoice rejects an out-of-site siteId (SITE_DENIED 403)', async () => {
+    await expect(
+      svc.createManualInvoice({ orgId: 'org1', siteId: 'siteB' }, restricted)
+    ).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+  });
+
+  it('createManualInvoice rejects a null-site invoice for a restricted actor (SITE_DENIED 403)', async () => {
+    await expect(
+      svc.createManualInvoice({ orgId: 'org1' }, restricted)
+    ).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+  });
+
+  it('recordPayment denies a payment on an out-of-site invoice (SITE_DENIED 403)', async () => {
+    queueResult([{ id: 'i1', status: 'sent', orgId: 'org1', partnerId: 'p1', siteId: 'siteB', balance: '50.00' }]);
+    await expect(
+      svc.recordPayment('i1', { amount: 10, method: 'check', receivedAt: '2026-06-14' }, restricted)
+    ).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+  });
+
+  it('listInvoices adds a site filter for a restricted actor (where receives a defined condition)', async () => {
+    queueResult([]); // final rows
+    await svc.listInvoices({ limit: 25 }, restricted);
+    const whereMock = (db as unknown as { where: { mock: { calls: unknown[][] } } }).where;
+    // With no orgId/status/cursor, the ONLY condition is the site restriction, so a
+    // defined argument proves the filter was applied.
+    expect(whereMock.mock.calls.at(-1)![0]).toBeDefined();
+  });
+
+  it('listInvoices adds NO site filter for an unrestricted actor (where receives undefined)', async () => {
+    queueResult([]); // final rows
+    await svc.listInvoices({ limit: 25 }, unrestricted);
+    const whereMock = (db as unknown as { where: { mock: { calls: unknown[][] } } }).where;
+    expect(whereMock.mock.calls.at(-1)![0]).toBeUndefined();
+  });
+});

--- a/apps/api/src/services/invoiceService.ts
+++ b/apps/api/src/services/invoiceService.ts
@@ -30,6 +30,27 @@ export function requireOrgAccess(actor: InvoiceActor, orgId: string): void {
   }
 }
 
+/**
+ * Site-axis guard mirroring `siteAccessCheck` (middleware/auth.ts). An actor
+ * with no `allowedSiteIds` (undefined) is unrestricted — this is a no-op, so
+ * partner/system callers and all-sites org users are unaffected. A site-restricted
+ * actor may only touch a siteId in its allowlist; a null/undefined siteId (an
+ * org-level invoice with no site) is DENIED, exactly as the auth closure denies a
+ * restricted caller for a null site.
+ */
+export function requireSiteAccess(actor: InvoiceActor, siteId: string | null | undefined): void {
+  if (!actor.allowedSiteIds) return; // unrestricted (partner/system, or all-sites org user)
+  if (!siteId || !actor.allowedSiteIds.includes(siteId)) {
+    throw new InvoiceServiceError('Site access denied', 403, 'SITE_DENIED');
+  }
+}
+
+/** Org + site guard for a loaded invoice row (the common case). */
+export function requireInvoiceAccess(actor: InvoiceActor, inv: { orgId: string; siteId: string | null }): void {
+  requireOrgAccess(actor, inv.orgId);
+  requireSiteAccess(actor, inv.siteId);
+}
+
 async function getOwnedInvoiceOr404(id: string) {
   const rows = await db.select().from(invoices).where(eq(invoices.id, id)).limit(1);
   if (!rows[0]) throw new InvoiceServiceError('Invoice not found', 404, 'INVOICE_NOT_FOUND');
@@ -43,6 +64,7 @@ function assertDraft(inv: { status: string }): void {
 export async function createManualInvoice(input: { orgId: string; siteId?: string; notes?: string; termsAndConditions?: string }, actor: InvoiceActor) {
   const partnerId = requirePartner(actor);
   requireOrgAccess(actor, input.orgId);
+  requireSiteAccess(actor, input.siteId ?? null);
   const rows = await db.insert(invoices).values({
     partnerId, orgId: input.orgId, siteId: input.siteId ?? null, status: 'draft',
     notes: input.notes ?? null, termsAndConditions: input.termsAndConditions ?? null, createdBy: actor.userId
@@ -91,7 +113,7 @@ async function insertLineAndRecompute(
 }
 
 export async function addManualLine(invoiceId: string, input: ManualLineInput, actor: InvoiceActor) {
-  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireOrgAccess(actor, inv.orgId);
+  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireInvoiceAccess(actor, inv);
   const lineTotal = computeLineTotal(String(input.quantity), String(input.unitPrice));
   return insertLineAndRecompute(invoiceId, inv.orgId, {
     sourceType: 'manual', sourceId: null, catalogItemId: null, parentLineId: null, ticketId: null,
@@ -102,7 +124,7 @@ export async function addManualLine(invoiceId: string, input: ManualLineInput, a
 }
 
 export async function addCatalogLine(invoiceId: string, catalogItemId: string, quantity: number, actor: InvoiceActor) {
-  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireOrgAccess(actor, inv.orgId);
+  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireInvoiceAccess(actor, inv);
   const resolved = await resolvePrice(catalogItemId, inv.orgId, { userId: actor.userId, partnerId: actor.partnerId, accessibleOrgIds: actor.accessibleOrgIds });
   const [item] = await db.select({ name: catalogItems.name, description: catalogItems.description, isBundle: catalogItems.isBundle }).from(catalogItems).where(eq(catalogItems.id, catalogItemId)).limit(1);
   if (item?.isBundle) throw new InvoiceServiceError('Use addBundleLine for bundles', 400, 'INVALID_STATE');
@@ -116,7 +138,7 @@ export async function addCatalogLine(invoiceId: string, catalogItemId: string, q
 }
 
 export async function addBundleLine(invoiceId: string, bundleId: string, quantity: number, actor: InvoiceActor) {
-  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireOrgAccess(actor, inv.orgId);
+  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireInvoiceAccess(actor, inv);
   const catalogActor = { userId: actor.userId, partnerId: actor.partnerId, accessibleOrgIds: actor.accessibleOrgIds };
   const econ = await computeBundleEconomics(bundleId, inv.orgId, catalogActor); // throws NOT_A_BUNDLE etc.
   const [bundle] = await db.select({ name: catalogItems.name, description: catalogItems.description }).from(catalogItems).where(eq(catalogItems.id, bundleId)).limit(1);
@@ -173,7 +195,7 @@ export async function addContractLine(
   },
   actor: InvoiceActor
 ) {
-  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireOrgAccess(actor, inv.orgId);
+  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireInvoiceAccess(actor, inv);
 
   // Quantity is always engine-supplied (e.g. device count) — normalize but do not override.
   const quantity = String(input.quantity);
@@ -211,7 +233,7 @@ export async function addContractLine(
 }
 
 export async function updateLine(invoiceId: string, lineId: string, patch: { name?: string | null; description?: string | null; quantity?: number; unitPrice?: number; taxable?: boolean; customerVisible?: boolean }, actor: InvoiceActor) {
-  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireOrgAccess(actor, inv.orgId);
+  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireInvoiceAccess(actor, inv);
   const [existing] = await db.select().from(invoiceLines).where(and(eq(invoiceLines.id, lineId), eq(invoiceLines.invoiceId, invoiceId))).limit(1);
   if (!existing) throw new InvoiceServiceError('Line not found', 404, 'LINE_NOT_FOUND');
   const quantity = patch.quantity != null ? String(patch.quantity) : existing.quantity;
@@ -227,7 +249,7 @@ export async function updateLine(invoiceId: string, lineId: string, patch: { nam
 }
 
 export async function removeLine(invoiceId: string, lineId: string, actor: InvoiceActor) {
-  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireOrgAccess(actor, inv.orgId);
+  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireInvoiceAccess(actor, inv);
   // cascade FK removes bundle children when a parent is deleted
   await db.delete(invoiceLines).where(and(eq(invoiceLines.id, lineId), eq(invoiceLines.invoiceId, invoiceId)));
   await recomputeInvoiceTotals(invoiceId);
@@ -235,7 +257,7 @@ export async function removeLine(invoiceId: string, lineId: string, actor: Invoi
 }
 
 export async function deleteDraftInvoice(invoiceId: string, actor: InvoiceActor) {
-  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireOrgAccess(actor, inv.orgId);
+  const inv = await getOwnedInvoiceOr404(invoiceId); assertDraft(inv); requireInvoiceAccess(actor, inv);
   await db.delete(invoices).where(eq(invoices.id, invoiceId)); // lines cascade
 }
 
@@ -249,7 +271,10 @@ export async function updateInvoice(
 ) {
   const inv = await getOwnedInvoiceOr404(invoiceId);
   assertDraft(inv);
-  requireOrgAccess(actor, inv.orgId);
+  requireInvoiceAccess(actor, inv);
+  // A site-restricted caller may not move the invoice to a site it can't access
+  // (nor clear it to null, which a restricted caller can never see).
+  if (patch.siteId !== undefined) requireSiteAccess(actor, patch.siteId);
   const set: Record<string, unknown> = { updatedAt: new Date() };
   if (patch.notes !== undefined) set.notes = patch.notes;
   if (patch.siteId !== undefined) set.siteId = patch.siteId;     // null clears it
@@ -267,7 +292,7 @@ export async function updateInvoice(
  */
 export async function updateIssuedDueDate(invoiceId: string, dueDate: string, actor: InvoiceActor) {
   const inv = await getOwnedInvoiceOr404(invoiceId);
-  requireOrgAccess(actor, inv.orgId);
+  requireInvoiceAccess(actor, inv);
   if (!['sent', 'partially_paid', 'overdue'].includes(inv.status)) {
     throw new InvoiceServiceError('Due date can only be changed on an open issued invoice', 409, 'INVALID_STATE');
   }
@@ -279,7 +304,7 @@ export async function updateIssuedDueDate(invoiceId: string, dueDate: string, ac
 }
 
 export async function getInvoice(invoiceId: string, actor: InvoiceActor) {
-  const inv = await getOwnedInvoiceOr404(invoiceId); requireOrgAccess(actor, inv.orgId);
+  const inv = await getOwnedInvoiceOr404(invoiceId); requireInvoiceAccess(actor, inv);
   const lines = await db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, invoiceId)).orderBy(invoiceLines.sortOrder);
   // Whether this invoice's partner can collect online (gates the "Send payment
   // link" UI). Partner-axis read under a partner/system request scope, so the
@@ -301,6 +326,10 @@ export async function listInvoices(query: { orgId?: string; status?: string; lim
   const conds = [] as Array<ReturnType<typeof eq>>;
   if (query.orgId) { requireOrgAccess(actor, query.orgId); conds.push(eq(invoices.orgId, query.orgId)); }
   if (query.status) conds.push(eq(invoices.status, query.status as never));
+  // Site-restricted callers only see invoices assigned to a site in their allowlist.
+  // `siteId IN (...)` is false for NULL, so null-site (org-level) invoices are
+  // excluded — consistent with requireSiteAccess denying a restricted caller a null site.
+  if (actor.allowedSiteIds) conds.push(inArray(invoices.siteId, actor.allowedSiteIds) as ReturnType<typeof eq>);
   // Deterministic keyset: order by (createdAt, id) desc. The cursor is the last
   // row's id; resolve its createdAt and filter (createdAt, id) < (cursorCreatedAt, cursorId).
   if (query.cursor) {
@@ -430,6 +459,7 @@ async function materializeLines(invoiceId: string, orgId: string, specs: DraftLi
 export async function assembleDraftFromOrg(input: { orgId: string; siteId?: string; from: string; to: string }, actor: InvoiceActor) {
   const partnerId = requirePartner(actor);
   requireOrgAccess(actor, input.orgId);
+  requireSiteAccess(actor, input.siteId ?? null);
   const from = new Date(input.from + 'T00:00:00Z');
   const to = new Date(input.to + 'T23:59:59Z');
   const specs = [...(await gatherOrgTimeEntries(input.orgId, from, to)), ...(await gatherOrgParts(input.orgId, from, to))];
@@ -445,6 +475,9 @@ export async function assembleDraftFromTicket(ticketId: string, actor: InvoiceAc
   const [tk] = await db.select({ orgId: tickets.orgId }).from(tickets).where(eq(tickets.id, ticketId)).limit(1);
   if (!tk) throw new InvoiceServiceError('Ticket not found', 404, 'INVOICE_NOT_FOUND');
   requireOrgAccess(actor, tk.orgId);
+  // This path produces an org-level (null-site) invoice; a site-restricted caller
+  // can never see such a row, so deny it up front rather than orphan an invoice.
+  requireSiteAccess(actor, null);
   const specs = await gatherTicketBillables(ticketId);
   if (specs.length === 0) throw new InvoiceServiceError('Nothing billable on this ticket', 409, 'NOTHING_TO_INVOICE');
   const [inv] = await db.insert(invoices).values({ partnerId, orgId: tk.orgId, status: 'draft', createdBy: actor.userId }).returning();
@@ -460,7 +493,7 @@ export async function assembleDraftFromTicket(ticketId: string, actor: InvoiceAc
 export async function issueInvoice(invoiceId: string, actor: InvoiceActor) {
   const inv = await getOwnedInvoiceOr404(invoiceId);
   assertDraft(inv);
-  requireOrgAccess(actor, inv.orgId);
+  requireInvoiceAccess(actor, inv);
 
   // Gather source rows referenced by lines, for the double-bill guard + flip.
   const lines = await db.select({ id: invoiceLines.id, sourceType: invoiceLines.sourceType, sourceId: invoiceLines.sourceId, customerVisible: invoiceLines.customerVisible }).from(invoiceLines).where(eq(invoiceLines.invoiceId, invoiceId));
@@ -570,7 +603,7 @@ export async function recomputeInvoiceStatus(invoiceId: string): Promise<void> {
 
 export async function recordPayment(invoiceId: string, input: RecordPaymentInput, actor: InvoiceActor) {
   const inv = await getOwnedInvoiceOr404(invoiceId);
-  requireOrgAccess(actor, inv.orgId);
+  requireInvoiceAccess(actor, inv);
   if (inv.status === 'draft') throw new InvoiceServiceError('Cannot record payment on a draft', 409, 'INVALID_STATE');
   if (inv.status === 'void') throw new InvoiceServiceError('Cannot record payment on a void invoice', 409, 'INVALID_STATE');
   // Exact integer-cents comparison — robust against float representation error.
@@ -606,7 +639,11 @@ export async function recordPayment(invoiceId: string, input: RecordPaymentInput
 export async function voidPayment(paymentId: string, actor: InvoiceActor) {
   const [pay] = await db.select().from(invoicePayments).where(eq(invoicePayments.id, paymentId)).limit(1);
   if (!pay) throw new InvoiceServiceError('Payment not found', 404, 'PAYMENT_NOT_FOUND');
-  requireOrgAccess(actor, pay.orgId);
+  // The payment row carries orgId but not siteId; load the parent invoice so the
+  // site-axis guard runs against the invoice's site (a site-restricted caller must
+  // not void a payment on an out-of-site invoice).
+  const parentInv = await getOwnedInvoiceOr404(pay.invoiceId);
+  requireInvoiceAccess(actor, parentInv);
   // Capture the destroyed row's financial details BEFORE the delete so the voided
   // payment survives in the durable audit chain even after the row is gone.
   const audit = {
@@ -627,7 +664,7 @@ export async function voidPayment(paymentId: string, actor: InvoiceActor) {
 
 export async function listPayments(invoiceId: string, actor: InvoiceActor) {
   const inv = await getOwnedInvoiceOr404(invoiceId);
-  requireOrgAccess(actor, inv.orgId);
+  requireInvoiceAccess(actor, inv);
   const rows = await db.select().from(invoicePayments).where(eq(invoicePayments.invoiceId, invoiceId)).orderBy(invoicePayments.receivedAt);
   // Tag each payment's origin so the UI can badge online (Stripe) payments and
   // hide manual-void on them (Stripe payments are refunded through Stripe, not
@@ -646,7 +683,7 @@ export async function listPayments(invoiceId: string, actor: InvoiceActor) {
 
 export async function voidInvoice(invoiceId: string, reason: string, opts: { reissue?: boolean }, actor: InvoiceActor) {
   const inv = await getOwnedInvoiceOr404(invoiceId);
-  requireOrgAccess(actor, inv.orgId);
+  requireInvoiceAccess(actor, inv);
   if (inv.status === 'draft') throw new InvoiceServiceError('Delete drafts instead of voiding', 409, 'INVALID_STATE');
   if (inv.status === 'void') throw new InvoiceServiceError('Already void', 409, 'INVALID_STATE');
 

--- a/apps/api/src/services/invoiceTypes.ts
+++ b/apps/api/src/services/invoiceTypes.ts
@@ -12,11 +12,22 @@ export interface InvoiceActor {
   userId: string | null;
   partnerId: string | null;
   accessibleOrgIds: string[] | null;
+  /**
+   * Site-axis allowlist (sub-org restriction), mirroring `AuthContext.allowedSiteIds`
+   * and enforced with the same `siteAccessCheck` semantics (middleware/auth.ts).
+   * `undefined` = unrestricted (partner/system scope, or an org user with no site
+   * restriction) — behaves exactly as before this field existed. When set to an
+   * array the actor is site-restricted: it may only touch invoices whose `siteId`
+   * is in the list, and a null-site invoice is DENIED (matching the auth closure,
+   * which denies a restricted caller for a null/undefined siteId).
+   */
+  allowedSiteIds?: string[];
 }
 
 export type InvoiceServiceErrorCode =
   | 'PARTNER_UNRESOLVABLE'
   | 'ORG_DENIED'
+  | 'SITE_DENIED'
   | 'INVOICE_NOT_FOUND'
   | 'NOT_A_DRAFT'
   | 'NOTHING_TO_INVOICE'

--- a/apps/api/src/services/quotePay.ts
+++ b/apps/api/src/services/quotePay.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm';
 import { db } from '../db';
 import { quotes } from '../db/schema/quotes';
 import { QuoteServiceError } from './quoteTypes';
+import { assertQuoteAccess } from './quoteService';
 import { createInvoicePayLink } from './invoiceCheckout';
 import type { InvoiceActor } from './invoiceTypes';
 
@@ -23,9 +24,15 @@ import type { InvoiceActor } from './invoiceTypes';
  */
 export async function createQuotePayLink(quoteId: string, actor: InvoiceActor): Promise<{ url: string }> {
   const [q] = await db
-    .select({ status: quotes.status, convertedInvoiceId: quotes.convertedInvoiceId })
+    .select({ status: quotes.status, convertedInvoiceId: quotes.convertedInvoiceId, orgId: quotes.orgId, siteId: quotes.siteId })
     .from(quotes).where(eq(quotes.id, quoteId)).limit(1);
   if (!q) throw new QuoteServiceError('Quote not found', 404, 'QUOTE_NOT_FOUND');
+  // Enforce org + site on the QUOTE itself. createInvoicePayLink enforces org on the
+  // converted invoice downstream, but the site axis was previously bypassable here —
+  // a site-restricted caller could mint a pay link for an out-of-site quote. The
+  // InvoiceActor is structurally a QuoteActor (same fields), so this reuses the one
+  // canonical quote guard.
+  assertQuoteAccess(actor, q);
   if (q.status !== 'converted' || !q.convertedInvoiceId) {
     throw new QuoteServiceError('Quote must be accepted before it can be paid', 409, 'NOT_CONVERTED');
   }

--- a/apps/api/src/services/quoteService.siteScope.test.ts
+++ b/apps/api/src/services/quoteService.siteScope.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Site-axis (sub-org) authorization guard for quoteService (SR5-15). Same
+// controllable Drizzle-chain mock as quoteService.test.ts. These tests lock the
+// site-scope branch of assertQuoteAccess/assertSite; the SQL-level list filtering
+// is additionally proven against real Postgres in the integration suite.
+const results: unknown[][] = [];
+function queueResult(rows: unknown[]) { results.push(rows); }
+
+vi.mock('../db', () => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {};
+    const methods = ['select', 'from', 'where', 'limit', 'orderBy', 'insert', 'values', 'returning', 'update', 'set', 'delete', 'for', 'innerJoin', 'leftJoin', 'execute', 'transaction'];
+    for (const m of methods) chain[m] = vi.fn(() => chain);
+    (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) => {
+      const rows = results.shift() ?? [];
+      return Promise.resolve(rows).then(resolve);
+    };
+    return chain;
+  };
+  const db = makeChain();
+  return {
+    db,
+    runOutsideDbContext: (fn: () => unknown) => fn(),
+    withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  };
+});
+
+import * as svc from './quoteService';
+import { db } from '../db';
+
+// A site-restricted org actor (allowedSiteIds present) that can reach org1 and only siteA.
+const restricted = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'], allowedSiteIds: ['siteA'] };
+// An unrestricted actor (allowedSiteIds undefined) — partner/system scope or all-sites org user.
+const unrestricted = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
+
+describe('quoteService site-axis guard', () => {
+  beforeEach(() => { results.length = 0; vi.clearAllMocks(); });
+
+  it('getQuote denies a site-restricted actor an out-of-site quote (SITE_DENIED 403)', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', siteId: 'siteB' }]);
+    await expect(svc.getQuote('q1', restricted)).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+  });
+
+  it('getQuote denies a site-restricted actor a null-site (org-level) quote (SITE_DENIED 403)', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', siteId: null }]);
+    await expect(svc.getQuote('q1', restricted)).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+  });
+
+  it('getQuote is unaffected for an unrestricted actor (null-site quote visible)', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', siteId: null, taxRate: null, depositType: 'none', depositPercent: null }]); // quote row
+    queueResult([]); // blocks
+    queueResult([]); // lines
+    const { quote } = await svc.getQuote('q1', unrestricted);
+    expect(quote.id).toBe('q1');
+  });
+
+  it('updateQuote denies editing an out-of-site draft (SITE_DENIED 403)', async () => {
+    // loadDraft's assertQuoteAccess rejects the out-of-site quote before any write.
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', siteId: 'siteB' }]);
+    await expect(svc.updateQuote('q1', { title: 'x' }, restricted)).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+  });
+
+  it('updateQuote denies MOVING an in-site draft to an out-of-site siteId (SITE_DENIED 403)', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', siteId: 'siteA' }]);
+    await expect(svc.updateQuote('q1', { siteId: 'siteB' }, restricted)).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+  });
+
+  it('createQuote rejects an out-of-site siteId (SITE_DENIED 403)', async () => {
+    await expect(
+      svc.createQuote({ orgId: 'org1', siteId: 'siteB', currencyCode: 'USD' } as never, restricted)
+    ).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+  });
+
+  it('createQuote rejects a null-site quote for a restricted actor (SITE_DENIED 403)', async () => {
+    await expect(
+      svc.createQuote({ orgId: 'org1', currencyCode: 'USD' } as never, restricted)
+    ).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+  });
+
+  it('listQuotes adds a site filter for a restricted actor (where receives a defined condition)', async () => {
+    queueResult([]); // rows
+    await svc.listQuotes({ limit: 25 } as never, restricted);
+    const whereMock = (db as unknown as { where: { mock: { calls: unknown[][] } } }).where;
+    expect(whereMock.mock.calls.at(-1)![0]).toBeDefined();
+  });
+
+  it('listQuotes adds NO site filter for an unrestricted actor (where receives undefined)', async () => {
+    queueResult([]); // rows
+    await svc.listQuotes({ limit: 25 } as never, unrestricted);
+    const whereMock = (db as unknown as { where: { mock: { calls: unknown[][] } } }).where;
+    expect(whereMock.mock.calls.at(-1)![0]).toBeUndefined();
+  });
+});

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, lt, or, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, lt, or, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { quotes, quoteLines, quoteBlocks, quoteImages } from '../db/schema/quotes';
 import { invoices } from '../db/schema/invoices';
@@ -40,6 +40,32 @@ function assertOrg(actor: QuoteActor, orgId: string): void {
   if (actor.accessibleOrgIds !== null && !actor.accessibleOrgIds.includes(orgId)) {
     throw new QuoteServiceError('Organization access denied', 403, 'ORG_DENIED');
   }
+}
+
+/**
+ * Site-axis guard mirroring `siteAccessCheck` (middleware/auth.ts). An actor with
+ * no `allowedSiteIds` (undefined) is unrestricted — a no-op, so partner/system
+ * callers and all-sites org users are unaffected. A site-restricted actor may only
+ * touch a siteId in its allowlist; a null/undefined siteId (an org-level quote) is
+ * DENIED, exactly as the auth closure denies a restricted caller for a null site.
+ */
+function assertSite(actor: QuoteActor, siteId: string | null | undefined): void {
+  if (!actor.allowedSiteIds) return; // unrestricted
+  if (!siteId || !actor.allowedSiteIds.includes(siteId)) {
+    throw new QuoteServiceError('Site access denied', 403, 'SITE_DENIED');
+  }
+}
+
+/**
+ * Org + site guard for a loaded quote row. The single authorization chokepoint for
+ * every quote path (CRUD via loadDraft, getQuote, and the pay-link path in
+ * quotePay). Exported so quotePay can enforce the same site restriction that was
+ * previously bypassable (org is enforced downstream in createInvoicePayLink; site
+ * was not enforced anywhere on the quote).
+ */
+export function assertQuoteAccess(actor: QuoteActor, quote: { orgId: string; siteId: string | null }): void {
+  assertOrg(actor, quote.orgId);
+  assertSite(actor, quote.siteId);
 }
 
 /**
@@ -85,7 +111,7 @@ async function recomputeAndPersist(quoteId: string): Promise<void> {
 async function loadDraft(quoteId: string, actor: QuoteActor) {
   const [q] = await db.select().from(quotes).where(eq(quotes.id, quoteId)).limit(1);
   if (!q) throw new QuoteServiceError('Quote not found', 404, 'QUOTE_NOT_FOUND');
-  assertOrg(actor, q.orgId);
+  assertQuoteAccess(actor, q);
   if (q.status !== 'draft') throw new QuoteServiceError('Quote is not a draft', 409, 'NOT_A_DRAFT');
   return q;
 }
@@ -138,6 +164,7 @@ async function resolveQuoteTaxRate(orgId: string, partnerId: string): Promise<st
 export async function createQuote(input: CreateQuoteInput, actor: QuoteActor) {
   const partnerId = resolvePartner(actor);
   assertOrg(actor, input.orgId);
+  assertSite(actor, input.siteId ?? null);
   const taxRate = await resolveQuoteTaxRate(input.orgId, partnerId);
   // Number at creation (not at send): techs reference the number while drafting
   // and in the list. A deleted draft leaves a counter gap, which the numbering
@@ -166,7 +193,7 @@ export async function createQuote(input: CreateQuoteInput, actor: QuoteActor) {
 export async function getQuote(id: string, actor: QuoteActor) {
   const [q] = await db.select().from(quotes).where(eq(quotes.id, id)).limit(1);
   if (!q) throw new QuoteServiceError('Quote not found', 404, 'QUOTE_NOT_FOUND');
-  assertOrg(actor, q.orgId);
+  assertQuoteAccess(actor, q);
   const blocks = await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, id)).orderBy(quoteBlocks.sortOrder);
   const lines = await db.select().from(quoteLines).where(eq(quoteLines.quoteId, id)).orderBy(quoteLines.sortOrder);
   // dueOnAcceptanceTotal is a derived (non-persisted) figure: the amount accept
@@ -194,6 +221,10 @@ export async function listQuotes(query: ListQuotesQuery, actor: QuoteActor) {
   const conds = [] as Array<ReturnType<typeof eq>>;
   if (query.orgId) { assertOrg(actor, query.orgId); conds.push(eq(quotes.orgId, query.orgId)); }
   if (query.status) conds.push(eq(quotes.status, query.status as never));
+  // Site-restricted callers only see quotes assigned to a site in their allowlist.
+  // `siteId IN (...)` is false for NULL, so null-site (org-level) quotes are
+  // excluded — consistent with assertSite denying a restricted caller a null site.
+  if (actor.allowedSiteIds) conds.push(inArray(quotes.siteId, actor.allowedSiteIds) as ReturnType<typeof eq>);
   // Deterministic keyset: order by (createdAt, id) desc; cursor is the last row's id.
   if (query.cursor) {
     const [c] = await db.select({ createdAt: quotes.createdAt }).from(quotes).where(eq(quotes.id, query.cursor)).limit(1);
@@ -223,6 +254,9 @@ export async function listQuotes(query: ListQuotesQuery, actor: QuoteActor) {
  *  explicitly cleared with null. A tax-rate change triggers a totals recompute. */
 export async function updateQuote(id: string, input: UpdateQuoteInput, actor: QuoteActor) {
   const q = await loadDraft(id, actor);
+  // A site-restricted caller may not move the quote to a site it can't access
+  // (nor clear it to null, which a restricted caller can never see).
+  if (input.siteId !== undefined) assertSite(actor, input.siteId);
   const set: Record<string, unknown> = { updatedAt: new Date() };
   if (input.siteId !== undefined) set.siteId = input.siteId;
   if (input.title !== undefined) set.title = input.title === null ? null : input.title.trim() || null;

--- a/apps/api/src/services/quoteTypes.ts
+++ b/apps/api/src/services/quoteTypes.ts
@@ -10,11 +10,22 @@ export interface QuoteActor {
   userId: string | null;
   partnerId: string | null;
   accessibleOrgIds: string[] | null;
+  /**
+   * Site-axis allowlist (sub-org restriction), mirroring `AuthContext.allowedSiteIds`
+   * and enforced with the same `siteAccessCheck` semantics (middleware/auth.ts).
+   * `undefined` = unrestricted (partner/system scope, or an org user with no site
+   * restriction) — behaves exactly as before this field existed. When set to an
+   * array the actor is site-restricted: it may only touch quotes whose `siteId`
+   * is in the list, and a null-site quote is DENIED (matching the auth closure,
+   * which denies a restricted caller for a null/undefined siteId).
+   */
+  allowedSiteIds?: string[];
 }
 
 export type QuoteServiceErrorCode =
   | 'PARTNER_UNRESOLVABLE'
   | 'ORG_DENIED'
+  | 'SITE_DENIED'
   | 'QUOTE_NOT_FOUND'
   | 'NOT_A_DRAFT'
   | 'LINE_NOT_FOUND'


### PR DESCRIPTION
Threads the caller's site scope into the shared `InvoiceActor`/`QuoteActor` and enforces it in the invoice/quote service authorization helpers. The AI actor builders previously dropped site scope and the services authorized by org only, though invoices/quotes carry `siteId` — so a site-restricted caller could read/mutate sibling-site records.

**Findings:** SR5-14 (invoices), SR5-15 (quotes).

**Approach:** added an optional `allowedSiteIds` to both actor types (existing constructors compile unchanged; the four auth-carrying builders now pass it). New `requireSiteAccess`/`requireInvoiceAccess` and `assertQuoteAccess` gate every get/list/create/update/payment/pay-link path; create/update validate the target `siteId`; list queries filter by allowed sites.

**Product decision to confirm:** null-site (org-level) invoices/quotes are **denied** to site-restricted callers (mirrors the canonical `siteAccessCheck`). One-line change if org-wide visibility is preferred. REST routes are `partner`/`system`-scoped so their behavior is unchanged today.

**Verification:** `tsc` clean; new `invoiceService.siteScope.test.ts` / `quoteService.siteScope.test.ts` (20) + existing invoice/quote route + service suites (98) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)