### PR TITLE
fix(security): site-scope backup/DR restore source snapshots (SR5-11/12/13)

### DIFF
--- a/apps/api/src/services/aiToolsBackup.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsBackup.siteScope.test.ts
@@ -121,3 +121,73 @@ describe('query_backups list_jobs — site narrowing (device-keyed jobs)', () =>
     expect(parsed.showing).toBe(1);
   });
 });
+
+describe('restore_snapshot — cross-site snapshot authorization (source device site)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const snapshotRow = {
+    id: 's1', orgId: 'org-1', providerSnapshotId: 'provider-xyz', deviceId: 'src-dev',
+    metadata: {}, size: 1024, hardwareProfile: {},
+  };
+
+  // Return the queued selects in order.
+  function seqSelect(results: Array<unknown[]>) {
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      const rows = results[call++] ?? [];
+      return { from: () => ({ where: () => ({ limit: () => Promise.resolve(rows) }) }) };
+    });
+  }
+
+  it('denies a Site-A target + Site-B snapshot (cross-site restore) and does not insert', async () => {
+    seqSelect([
+      [{ id: 'd1', siteId: 'site-A' }], // target device (allowed)
+      [snapshotRow],                    // snapshot row (source deviceId = src-dev)
+      [{ siteId: 'site-B' }],           // snapshot source device → forbidden site
+    ]);
+    const result = await handlerFor('restore_snapshot')({ snapshotId: 's1', deviceId: 'd1' }, makeAuth(['site-A']));
+    expect(result).toContain('access denied');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('allows a same-site restore (Site-A target + Site-A snapshot) and inserts a restore job', async () => {
+    seqSelect([
+      [{ id: 'd1', siteId: 'site-A' }],   // target device (allowed)
+      [snapshotRow],                      // snapshot row
+      [{ siteId: 'site-A' }],             // snapshot source device → same site, allowed
+      [{ id: 'd1', status: 'online' }],   // target device online check
+    ]);
+    const now = new Date();
+    const rj = {
+      id: 'rj', deviceId: 'd1', snapshotId: 's1', restoreType: 'full', selectedPaths: [],
+      status: 'pending', targetPath: null, targetConfig: null, createdAt: now, startedAt: null,
+      completedAt: null, updatedAt: now, restoredSize: null, restoredFiles: null, commandId: null,
+    };
+    (db as any).insert = vi.fn(() => ({ values: () => ({ returning: () => Promise.resolve([rj]) }) }));
+    (db as any).update = vi.fn(() => ({ set: () => ({ where: () => ({ returning: () => Promise.resolve([{ ...rj, status: 'running', commandId: 'c1' }]) }) }) }));
+    const result = await handlerFor('restore_snapshot')({ snapshotId: 's1', deviceId: 'd1' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    expect((db as any).insert).toHaveBeenCalled();
+  });
+
+  it('unrestricted caller restores without a source-device query (no regression)', async () => {
+    // Unrestricted: loader skips the source-device gate. Selects: target, snapshot, target-online.
+    seqSelect([
+      [{ id: 'd1', siteId: 'site-Z' }], // target device
+      [snapshotRow],                    // snapshot row
+      [{ id: 'd1', status: 'online' }], // target device online check
+    ]);
+    const now = new Date();
+    const rj = {
+      id: 'rj', deviceId: 'd1', snapshotId: 's1', restoreType: 'full', selectedPaths: [],
+      status: 'pending', targetPath: null, targetConfig: null, createdAt: now, startedAt: null,
+      completedAt: null, updatedAt: now, restoredSize: null, restoredFiles: null, commandId: null,
+    };
+    (db as any).insert = vi.fn(() => ({ values: () => ({ returning: () => Promise.resolve([rj]) }) }));
+    (db as any).update = vi.fn(() => ({ set: () => ({ where: () => ({ returning: () => Promise.resolve([{ ...rj, status: 'running', commandId: 'c1' }]) }) }) }));
+    const result = await handlerFor('restore_snapshot')({ snapshotId: 's1', deviceId: 'd1' }, makeAuth(undefined));
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/apps/api/src/services/aiToolsBackup.ts
+++ b/apps/api/src/services/aiToolsBackup.ts
@@ -25,6 +25,7 @@ import { CommandTypes, queueCommandForExecution } from './commandQueue';
 import { createManualBackupJobIfIdle } from './backupJobCreation';
 import { enqueueBackupDispatch } from '../jobs/backupEnqueue';
 import { deviceSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { loadSnapshotWithSiteAccess } from './aiToolsBackupShared';
 import { inArray } from 'drizzle-orm';
 
 type BackupHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
@@ -601,18 +602,12 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
       if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
       if (deviceSiteDenied(auth, device.siteId)) return JSON.stringify({ error: 'Device not found or access denied' });
 
-      // Verify snapshot exists and belongs to org (via orgId on snapshots table)
-      const snapshotConditions: SQL[] = [eq(backupSnapshots.id, snapshotId)];
-      const sc = orgWhere(auth, backupSnapshots.orgId);
-      if (sc) snapshotConditions.push(sc);
-      const [snapshot] = await db.select({
-        id: backupSnapshots.id,
-        snapshotId: backupSnapshots.snapshotId,
-        deviceId: backupSnapshots.deviceId,
-      }).from(backupSnapshots)
-        .where(and(...snapshotConditions))
-        .limit(1);
-      if (!snapshot) return JSON.stringify({ error: 'Snapshot not found or access denied' });
+      // Verify the snapshot under the caller's org AND site scope: the source
+      // snapshot's device must be within the caller's site scope, not just the
+      // restore target (shared provider namespace → cross-site restore else).
+      const snapshotResult = await loadSnapshotWithSiteAccess(auth, snapshotId);
+      if ('error' in snapshotResult) return JSON.stringify({ error: snapshotResult.error });
+      const snapshot = snapshotResult.snapshot;
 
       // Determine restore type based on selectedPaths
       const selectedPaths = Array.isArray(input.selectedPaths) ? input.selectedPaths as string[] : undefined;
@@ -668,7 +663,7 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
           CommandTypes.BACKUP_RESTORE,
           {
             restoreJobId: restoreJob.id,
-            snapshotId: snapshot.snapshotId,
+            snapshotId: snapshot.providerSnapshotId,
             targetPath: restoreJob.targetPath ?? '',
             selectedPaths: restoreType === 'selective' ? (selectedPaths ?? []) : [],
           },
@@ -705,9 +700,9 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
           commandId: command.id,
           status: updatedRestoreJob?.status ?? restoreJob.status,
           restoreType,
-          snapshotId: snapshot.snapshotId,
+          snapshotId: snapshot.providerSnapshotId,
           deviceId,
-          message: `Restore job created (${restoreType} restore from snapshot ${snapshot.snapshotId})`,
+          message: `Restore job created (${restoreType} restore from snapshot ${snapshot.providerSnapshotId})`,
         });
       } catch (err) {
         const error = err instanceof Error ? err.message : 'Failed to dispatch restore command to agent';

--- a/apps/api/src/services/aiToolsBackupShared.test.ts
+++ b/apps/api/src/services/aiToolsBackupShared.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: { select: vi.fn() },
+}));
+
+import { db } from '../db';
+import { loadSnapshotWithSiteAccess } from './aiToolsBackupShared';
+import type { AuthContext } from '../middleware/auth';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    allowedSiteIds,
+    canAccessSite: (siteId) => (!allowedSiteIds ? true : !!siteId && allowedSiteIds.includes(siteId)),
+  } as AuthContext;
+}
+
+const snapshotRow = {
+  id: 's1',
+  orgId: 'org-1',
+  providerSnapshotId: 'provider-xyz',
+  deviceId: 'src-dev',
+  metadata: { backupKind: 'hyperv_export' },
+  size: 1024,
+  hardwareProfile: {},
+};
+
+// call 1 = snapshot select; call 2 (restricted only) = source device select { siteId }
+function mockSnapshotThenSourceDevice(snapshot: Record<string, unknown> | undefined, sourceSiteId?: string | null) {
+  let call = 0;
+  mockDb.select.mockImplementation(() => {
+    call++;
+    if (call === 1) {
+      return { from: () => ({ where: () => ({ limit: () => Promise.resolve(snapshot ? [snapshot] : []) }) }) };
+    }
+    return { from: () => ({ where: () => ({ limit: () => Promise.resolve(sourceSiteId === undefined ? [] : [{ siteId: sourceSiteId }]) }) }) };
+  });
+}
+
+describe('loadSnapshotWithSiteAccess', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('denies a cross-site snapshot for a site-restricted caller (source in a forbidden site)', async () => {
+    mockSnapshotThenSourceDevice(snapshotRow, 'site-B');
+    const result = await loadSnapshotWithSiteAccess(makeAuth(['site-A']), 's1');
+    expect('error' in result).toBe(true);
+    if ('error' in result) expect(result.error).toContain('access denied');
+  });
+
+  it('allows a same-site snapshot for a site-restricted caller', async () => {
+    mockSnapshotThenSourceDevice(snapshotRow, 'site-A');
+    const result = await loadSnapshotWithSiteAccess(makeAuth(['site-A']), 's1');
+    expect('snapshot' in result).toBe(true);
+    if ('snapshot' in result) expect(result.snapshot.providerSnapshotId).toBe('provider-xyz');
+  });
+
+  it('fails closed when a restricted caller loads a snapshot whose source device is unknown/removed', async () => {
+    // snapshot has a deviceId but the device row no longer exists → source query returns []
+    mockSnapshotThenSourceDevice(snapshotRow, undefined);
+    const result = await loadSnapshotWithSiteAccess(makeAuth(['site-A']), 's1');
+    expect('error' in result).toBe(true);
+  });
+
+  it('allows any snapshot for an unrestricted caller WITHOUT a source-device query (no regression)', async () => {
+    let calls = 0;
+    mockDb.select.mockImplementation(() => {
+      calls++;
+      return { from: () => ({ where: () => ({ limit: () => Promise.resolve([snapshotRow]) }) }) };
+    });
+    const result = await loadSnapshotWithSiteAccess(makeAuth(undefined), 's1');
+    expect('snapshot' in result).toBe(true);
+    expect(calls).toBe(1); // only the snapshot select — no site gating for unrestricted callers
+  });
+
+  it('returns access denied for a missing/out-of-org snapshot', async () => {
+    mockSnapshotThenSourceDevice(undefined);
+    const result = await loadSnapshotWithSiteAccess(makeAuth(['site-A']), 'missing');
+    expect('error' in result).toBe(true);
+  });
+});

--- a/apps/api/src/services/aiToolsBackupShared.ts
+++ b/apps/api/src/services/aiToolsBackupShared.ts
@@ -1,0 +1,94 @@
+/**
+ * AI Backup/DR tools — shared site-aware snapshot loader.
+ *
+ * Restore/DR tools authorize their TARGET device against the caller's site
+ * scope (`deviceSiteDenied`), but historically loaded the SOURCE snapshot by
+ * org only. Because Postgres RLS enforces the org axis but NOT the site axis,
+ * a site-restricted caller who legitimately owns a Site-A target could load a
+ * Site-B snapshot (shared provider namespace) and restore it onto their target.
+ *
+ * `loadSnapshotWithSiteAccess` closes that gap: it loads a snapshot under the
+ * caller's org scope AND resolves the snapshot's SOURCE device
+ * (`backupSnapshots.deviceId` → `devices.siteId`), then applies the SAME
+ * `deviceSiteDenied` gate used for restore targets. A site-restricted caller
+ * therefore cannot load a snapshot whose source device lives in a site they
+ * cannot reach — so both the source snapshot and the target device must be
+ * within the caller's site scope for a restore to proceed.
+ *
+ * No-op for unrestricted callers (`auth.canAccessSite` undefined): identical
+ * behaviour, no extra device query, no regression.
+ */
+
+import { and, eq, SQL } from 'drizzle-orm';
+import { db } from '../db';
+import { backupSnapshots, devices } from '../db/schema';
+import type { AuthContext } from '../middleware/auth';
+import { deviceSiteDenied } from './aiToolsSiteScope';
+
+export type SiteScopedSnapshot = {
+  id: string;
+  orgId: string;
+  /** Provider-side snapshot identifier (backup_snapshots.snapshot_id). */
+  providerSnapshotId: string;
+  /** Source device the snapshot was captured from. */
+  deviceId: string;
+  metadata: unknown;
+  size: number | null;
+  hardwareProfile: unknown;
+};
+
+const SNAPSHOT_DENIED = 'Snapshot not found or access denied';
+
+/**
+ * Load a backup snapshot by id under the caller's org + site scope.
+ *
+ * Returns `{ error }` (a single collapsed message so callers cannot distinguish
+ * "not found" from "denied") when the snapshot is missing, out of org scope, or
+ * — for a site-restricted caller — its source device is in an inaccessible
+ * site. Fails closed: a snapshot whose source device is unknown/removed is
+ * denied for a restricted caller. Returns `{ snapshot }` otherwise.
+ */
+export async function loadSnapshotWithSiteAccess(
+  auth: AuthContext,
+  snapshotId: string,
+): Promise<{ error: string } | { snapshot: SiteScopedSnapshot }> {
+  const conditions: SQL[] = [eq(backupSnapshots.id, snapshotId)];
+  const oc = auth.orgCondition(backupSnapshots.orgId);
+  if (oc) conditions.push(oc);
+
+  const [row] = await db
+    .select({
+      id: backupSnapshots.id,
+      orgId: backupSnapshots.orgId,
+      providerSnapshotId: backupSnapshots.snapshotId,
+      deviceId: backupSnapshots.deviceId,
+      metadata: backupSnapshots.metadata,
+      size: backupSnapshots.size,
+      hardwareProfile: backupSnapshots.hardwareProfile,
+    })
+    .from(backupSnapshots)
+    .where(and(...conditions))
+    .limit(1);
+
+  if (!row) return { error: SNAPSHOT_DENIED };
+
+  // Site axis (app-layer only; RLS does NOT enforce it). Resolve the snapshot's
+  // SOURCE device site and gate it exactly like a restore target. Gated on
+  // `allowedSiteIds` (the restriction marker) so unrestricted callers incur no
+  // extra query — `canAccessSite` is always present, allow-all when unrestricted.
+  if (auth.allowedSiteIds && auth.canAccessSite) {
+    const [sourceDevice] = row.deviceId
+      ? await db
+          .select({ siteId: devices.siteId })
+          .from(devices)
+          .where(eq(devices.id, row.deviceId))
+          .limit(1)
+      : [];
+    // Unknown/removed source device → siteId undefined → denied (fail closed).
+    if (deviceSiteDenied(auth, sourceDevice?.siteId ?? null)) {
+      return { error: SNAPSHOT_DENIED };
+    }
+  }
+
+  return { snapshot: row };
+}

--- a/apps/api/src/services/aiToolsBackupVm.ts
+++ b/apps/api/src/services/aiToolsBackupVm.ts
@@ -16,6 +16,7 @@ import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { CommandTypes, queueCommandForExecution } from './commandQueue';
 import { deviceSiteDenied, deviceIdSiteDenied } from './aiToolsSiteScope';
+import { loadSnapshotWithSiteAccess } from './aiToolsBackupShared';
 
 type BackupHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -105,19 +106,12 @@ export function registerBackupVmTools(aiTools: Map<string, AiTool>): void {
         return JSON.stringify({ error: 'Only Hyper-V VM restore is currently supported' });
       }
 
-      const snapshotConditions: SQL[] = [eq(backupSnapshots.id, snapshotId)];
-      const sc = orgWhere(auth, backupSnapshots.orgId);
-      if (sc) snapshotConditions.push(sc);
-      const [snapshot] = await db
-        .select({
-          id: backupSnapshots.id,
-          orgId: backupSnapshots.orgId,
-          snapshotId: backupSnapshots.snapshotId,
-        })
-        .from(backupSnapshots)
-        .where(and(...snapshotConditions))
-        .limit(1);
-      if (!snapshot) return JSON.stringify({ error: 'Snapshot not found or access denied' });
+      // Load the snapshot under org AND site scope (source device site gated),
+      // so a site-restricted caller cannot restore a cross-site snapshot onto a
+      // target they legitimately own.
+      const snapshotResult = await loadSnapshotWithSiteAccess(auth, snapshotId);
+      if ('error' in snapshotResult) return JSON.stringify({ error: snapshotResult.error });
+      const snapshot = snapshotResult.snapshot;
 
       const deviceConditions: SQL[] = [eq(devices.id, targetDeviceId)];
       const dc = orgWhere(auth, devices.orgId);
@@ -161,7 +155,7 @@ export function registerBackupVmTools(aiTools: Map<string, AiTool>): void {
         CommandTypes.VM_RESTORE_FROM_BACKUP,
         {
           restoreJobId: restoreJob?.id,
-          snapshotId: snapshot.snapshotId,
+          snapshotId: snapshot.providerSnapshotId,
           vmName,
           memoryMb: vmSpecs.memoryMb,
           cpuCount: vmSpecs.cpuCount,
@@ -239,19 +233,12 @@ export function registerBackupVmTools(aiTools: Map<string, AiTool>): void {
         return JSON.stringify({ error: 'snapshotId, targetDeviceId, and vmName are required' });
       }
 
-      const snapshotConditions: SQL[] = [eq(backupSnapshots.id, snapshotId)];
-      const sc = orgWhere(auth, backupSnapshots.orgId);
-      if (sc) snapshotConditions.push(sc);
-      const [snapshot] = await db
-        .select({
-          id: backupSnapshots.id,
-          orgId: backupSnapshots.orgId,
-          snapshotId: backupSnapshots.snapshotId,
-        })
-        .from(backupSnapshots)
-        .where(and(...snapshotConditions))
-        .limit(1);
-      if (!snapshot) return JSON.stringify({ error: 'Snapshot not found or access denied' });
+      // Load the snapshot under org AND site scope (source device site gated),
+      // so a site-restricted caller cannot instant-boot a cross-site snapshot
+      // onto a target they legitimately own.
+      const snapshotResult = await loadSnapshotWithSiteAccess(auth, snapshotId);
+      if ('error' in snapshotResult) return JSON.stringify({ error: snapshotResult.error });
+      const snapshot = snapshotResult.snapshot;
 
       const deviceConditions: SQL[] = [eq(devices.id, targetDeviceId)];
       const dc = orgWhere(auth, devices.orgId);
@@ -294,7 +281,7 @@ export function registerBackupVmTools(aiTools: Map<string, AiTool>): void {
         CommandTypes.VM_INSTANT_BOOT,
         {
           restoreJobId: restoreJob?.id,
-          snapshotId: snapshot.snapshotId,
+          snapshotId: snapshot.providerSnapshotId,
           vmName,
           memoryMb: vmSpecs.memoryMb,
           cpuCount: vmSpecs.cpuCount,

--- a/apps/api/src/services/aiToolsDR.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsDR.siteScope.test.ts
@@ -71,7 +71,7 @@ describe('execute_dr_plan — cross-site device authorization', () => {
     const parsed = JSON.parse(result);
     expect(parsed.success).toBe(true);
     expect(mockEnqueue).toHaveBeenCalledTimes(1);
-    expect(mockEnqueue.mock.calls[0][0].authorizedDeviceIds).toEqual(['dev-A']);
+    expect(mockEnqueue.mock.calls[0]![0].authorizedDeviceIds).toEqual(['dev-A']);
   });
 
   it('unrestricted caller executes with no authorization pin (authorizedDeviceIds null)', async () => {
@@ -83,7 +83,7 @@ describe('execute_dr_plan — cross-site device authorization', () => {
     const result = await handlerFor('execute_dr_plan')({ planId: 'p1', executionType: 'failover' }, makeAuth(undefined));
     const parsed = JSON.parse(result);
     expect(parsed.success).toBe(true);
-    expect(mockEnqueue.mock.calls[0][0].authorizedDeviceIds).toBeNull();
+    expect(mockEnqueue.mock.calls[0]![0].authorizedDeviceIds).toBeNull();
   });
 });
 

--- a/apps/api/src/services/aiToolsDR.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsDR.siteScope.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('./drExecutionService', () => ({
+  createDrExecutionAndEnqueue: vi.fn(async () => ({ id: 'exec-1', status: 'pending' })),
+}));
+
+import { db } from '../db';
+import { createDrExecutionAndEnqueue } from './drExecutionService';
+import { registerDRTools } from './aiToolsDR';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+const mockEnqueue = createDrExecutionAndEnqueue as unknown as ReturnType<typeof vi.fn>;
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerDRTools(reg);
+  return reg.get(name)!.handler;
+}
+
+function makeAuth(allowedSiteIds?: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds, canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+  } as AuthContext;
+}
+
+// Thenable that resolves to `rows` and supports any query-builder chaining shape.
+function chain(rows: unknown[]): any {
+  const p: any = Promise.resolve(rows);
+  for (const m of ['from', 'where', 'limit', 'orderBy', 'leftJoin', 'innerJoin', 'groupBy']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+function seqSelect(results: Array<unknown[]>) {
+  let call = 0;
+  mockDb.select.mockImplementation(() => chain(results[call++] ?? []));
+}
+
+const PLAN = { id: 'p1', orgId: 'org-1', name: 'Plan 1', status: 'active' };
+
+describe('execute_dr_plan — cross-site device authorization', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('denies execution when any group device is outside the caller\'s site scope', async () => {
+    seqSelect([
+      [PLAN],                                            // loadPlanWithAccess
+      [{ id: 'g1', name: 'G1', sequence: 0, devices: ['dev-A', 'dev-B'], restoreConfig: {}, estimatedDurationMinutes: null }], // groups
+      [{ id: 'dev-A', siteId: 'site-A' }, { id: 'dev-B', siteId: 'site-B' }], // resolveSiteDevicePartition (org devices)
+    ]);
+    const result = await handlerFor('execute_dr_plan')({ planId: 'p1', executionType: 'failover' }, makeAuth(['site-A']));
+    expect(result).toContain('outside your site access');
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('allows execution when all group devices are in scope, pinning the authorized set', async () => {
+    seqSelect([
+      [PLAN],
+      [{ id: 'g1', name: 'G1', sequence: 0, devices: ['dev-A'], restoreConfig: {}, estimatedDurationMinutes: null }],
+      [{ id: 'dev-A', siteId: 'site-A' }, { id: 'dev-B', siteId: 'site-B' }],
+    ]);
+    const result = await handlerFor('execute_dr_plan')({ planId: 'p1', executionType: 'failover' }, makeAuth(['site-A']));
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    expect(mockEnqueue.mock.calls[0][0].authorizedDeviceIds).toEqual(['dev-A']);
+  });
+
+  it('unrestricted caller executes with no authorization pin (authorizedDeviceIds null)', async () => {
+    seqSelect([
+      [PLAN],
+      [{ id: 'g1', name: 'G1', sequence: 0, devices: ['dev-A', 'dev-B'], restoreConfig: {}, estimatedDurationMinutes: null }],
+      // no partition select — resolveSiteDevicePartition short-circuits for unrestricted callers
+    ]);
+    const result = await handlerFor('execute_dr_plan')({ planId: 'p1', executionType: 'failover' }, makeAuth(undefined));
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    expect(mockEnqueue.mock.calls[0][0].authorizedDeviceIds).toBeNull();
+  });
+});
+
+describe('query_dr_plans — hides fully out-of-scope plans', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('hides a plan whose devices are all outside the caller\'s site scope', async () => {
+    seqSelect([
+      [{ id: 'p1', name: 'P1', groupCount: 1 }, { id: 'p2', name: 'P2', groupCount: 1 }], // plans
+      [{ id: 'dev-A', siteId: 'site-A' }, { id: 'dev-B', siteId: 'site-B' }],             // partition
+      [{ planId: 'p1', devices: ['dev-A'] }, { planId: 'p2', devices: ['dev-B'] }],       // groups per plan
+    ]);
+    const result = await handlerFor('query_dr_plans')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(result);
+    expect(parsed.showing).toBe(1);
+    expect(parsed.plans.map((p: any) => p.id)).toEqual(['p1']);
+  });
+
+  it('unrestricted caller sees all plans (no regression)', async () => {
+    seqSelect([
+      [{ id: 'p1', name: 'P1', groupCount: 1 }, { id: 'p2', name: 'P2', groupCount: 1 }],
+    ]);
+    const result = await handlerFor('query_dr_plans')({}, makeAuth(undefined));
+    const parsed = JSON.parse(result);
+    expect(parsed.showing).toBe(2);
+  });
+});

--- a/apps/api/src/services/aiToolsDR.ts
+++ b/apps/api/src/services/aiToolsDR.ts
@@ -8,10 +8,11 @@
 
 import { db } from '../db';
 import { drExecutions, drPlanGroups, drPlans } from '../db/schema';
-import { eq, and, asc, desc, sql, SQL } from 'drizzle-orm';
+import { eq, and, asc, desc, inArray, sql, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { createDrExecutionAndEnqueue } from './drExecutionService';
+import { resolveSiteDevicePartition } from './aiToolsSiteScope';
 
 type DRHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -56,6 +57,19 @@ async function loadPlanWithAccess(planId: string, auth: AuthContext) {
     .limit(1);
 
   return plan ?? null;
+}
+
+/** Collect the distinct in-plan device IDs across a set of DR plan groups. */
+function collectGroupDeviceIds(groups: Array<{ devices: unknown }>): string[] {
+  const ids = new Set<string>();
+  for (const group of groups) {
+    if (Array.isArray(group.devices)) {
+      for (const deviceId of group.devices) {
+        if (typeof deviceId === 'string') ids.add(deviceId);
+      }
+    }
+  }
+  return [...ids];
 }
 
 // ============================================
@@ -124,6 +138,38 @@ export function registerDRTools(aiTools: Map<string, AiTool>): void {
         )
         .orderBy(desc(drPlans.createdAt))
         .limit(limit);
+
+      // Site axis (app-layer only; RLS enforces org, NOT site). Hide plans that
+      // are ENTIRELY outside a site-restricted caller's scope so they cannot
+      // enumerate foreign plans/devices. No-op for unrestricted callers.
+      const orgId = getOrgId(auth);
+      const partition = orgId ? await resolveSiteDevicePartition(orgId, auth) : null;
+      if (partition && rows.length > 0) {
+        const allowed = new Set(partition.allowed);
+        const planIds = rows.map((row) => row.id);
+        const groupRows = await db
+          .select({ planId: drPlanGroups.planId, devices: drPlanGroups.devices })
+          .from(drPlanGroups)
+          .where(inArray(drPlanGroups.planId, planIds));
+        const deviceIdsByPlan = new Map<string, string[]>();
+        for (const group of groupRows) {
+          const list = deviceIdsByPlan.get(group.planId) ?? [];
+          if (Array.isArray(group.devices)) {
+            for (const deviceId of group.devices) {
+              if (typeof deviceId === 'string') list.push(deviceId);
+            }
+          }
+          deviceIdsByPlan.set(group.planId, list);
+        }
+        const visible = rows.filter((row) => {
+          const ids = deviceIdsByPlan.get(row.id) ?? [];
+          // A plan with no assigned devices carries nothing site-sensitive.
+          if (ids.length === 0) return true;
+          // Otherwise require at least one device in an accessible site.
+          return ids.some((id) => allowed.has(id));
+        });
+        return JSON.stringify({ plans: visible, showing: visible.length });
+      }
 
       return JSON.stringify({ plans: rows, showing: rows.length });
     }),
@@ -297,11 +343,31 @@ export function registerDRTools(aiTools: Map<string, AiTool>): void {
         .where(and(...groupConditions))
         .orderBy(asc(drPlanGroups.sequence));
 
+      // Site axis (app-layer only; RLS enforces org, NOT site). This Tier-3 tool
+      // has no deviceArgs — the devices live in the group JSON arrays, so the
+      // central per-device site gate never sees them. A site-restricted caller
+      // may execute a plan only if EVERY device across all its groups is within
+      // their site scope; deny otherwise. The authorized set is then pinned onto
+      // the execution so the (system-context) worker refuses to dispatch to any
+      // out-of-scope device even if the plan's groups are later edited.
+      const planDeviceIds = collectGroupDeviceIds(groups);
+      let authorizedDeviceIds: string[] | null = null;
+      const partition = await resolveSiteDevicePartition(plan.orgId, auth);
+      if (partition) {
+        const allowed = new Set(partition.allowed);
+        const outOfScope = planDeviceIds.filter((id) => !allowed.has(id));
+        if (outOfScope.length > 0) {
+          return JSON.stringify({ error: 'DR plan includes devices outside your site access' });
+        }
+        authorizedDeviceIds = planDeviceIds;
+      }
+
       const execution = await createDrExecutionAndEnqueue({
         planId: plan.id,
         orgId: plan.orgId,
         executionType: executionType as 'rehearsal' | 'failover' | 'failback',
         initiatedBy: auth.user?.id ?? null,
+        authorizedDeviceIds,
       });
       if (!execution) return JSON.stringify({ error: 'Failed to create DR execution record' });
 

--- a/apps/api/src/services/aiToolsHyperv.ts
+++ b/apps/api/src/services/aiToolsHyperv.ts
@@ -7,13 +7,14 @@
  */
 
 import { db } from '../db';
-import { backupJobs, backupSnapshots, devices, hypervVms } from '../db/schema';
+import { backupJobs, devices, hypervVms } from '../db/schema';
 import { eq, and, desc, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { CommandTypes, queueCommandForExecution } from './commandQueue';
 import { resolveBackupConfigForDevice } from './featureConfigResolver';
 import { deviceSiteDenied, deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { loadSnapshotWithSiteAccess } from './aiToolsBackupShared';
 
 function getOrgId(auth: AuthContext): string | null {
   return auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
@@ -392,19 +393,12 @@ export function registerHypervTools(aiTools: Map<string, AiTool>): void {
       if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
       if (deviceSiteDenied(auth, device.siteId)) return JSON.stringify({ error: 'Device not found or access denied' });
 
-      const snapshotConditions: SQL[] = [eq(backupSnapshots.id, snapshotId)];
-      const sc = orgWhere(auth, backupSnapshots.orgId);
-      if (sc) snapshotConditions.push(sc);
-      const [snapshot] = await db
-        .select({
-          id: backupSnapshots.id,
-          providerSnapshotId: backupSnapshots.snapshotId,
-          metadata: backupSnapshots.metadata,
-        })
-        .from(backupSnapshots)
-        .where(and(...snapshotConditions))
-        .limit(1);
-      if (!snapshot) return JSON.stringify({ error: 'Snapshot not found or access denied' });
+      // Load the snapshot under org AND site scope (source device site gated),
+      // so a site-restricted caller cannot import a cross-site snapshot onto a
+      // Hyper-V host they legitimately own.
+      const snapshotResult = await loadSnapshotWithSiteAccess(auth, snapshotId);
+      if ('error' in snapshotResult) return JSON.stringify({ error: snapshotResult.error });
+      const snapshot = snapshotResult.snapshot;
       const metadata =
         snapshot.metadata && typeof snapshot.metadata === 'object' && !Array.isArray(snapshot.metadata)
           ? snapshot.metadata as Record<string, unknown>

--- a/apps/api/src/services/aiToolsMssql.ts
+++ b/apps/api/src/services/aiToolsMssql.ts
@@ -21,6 +21,7 @@ import type { AiTool } from './aiTools';
 import { CommandTypes, queueCommandForExecution } from './commandQueue';
 import { resolveBackupConfigForDevice } from './featureConfigResolver';
 import { deviceSiteDenied, deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { loadSnapshotWithSiteAccess } from './aiToolsBackupShared';
 
 function getOrgId(auth: AuthContext): string | null {
   return auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
@@ -396,19 +397,12 @@ export function registerMssqlTools(aiTools: Map<string, AiTool>): void {
       if (!device) return JSON.stringify({ error: 'Device not found or access denied' });
       if (deviceSiteDenied(auth, device.siteId)) return JSON.stringify({ error: 'Device not found or access denied' });
 
-      const snapshotConditions: SQL[] = [eq(backupSnapshots.id, snapshotId)];
-      const sc = orgWhere(auth, backupSnapshots.orgId);
-      if (sc) snapshotConditions.push(sc);
-      const [snapshot] = await db
-        .select({
-          id: backupSnapshots.id,
-          providerSnapshotId: backupSnapshots.snapshotId,
-          metadata: backupSnapshots.metadata,
-        })
-        .from(backupSnapshots)
-        .where(and(...snapshotConditions))
-        .limit(1);
-      if (!snapshot) return JSON.stringify({ error: 'Snapshot not found or access denied' });
+      // Load the snapshot under the caller's org AND site scope: the source
+      // snapshot must be within the caller's site scope, not just the target
+      // device (shared provider namespace → cross-site restore otherwise).
+      const snapshotResult = await loadSnapshotWithSiteAccess(auth, snapshotId);
+      if ('error' in snapshotResult) return JSON.stringify({ error: snapshotResult.error });
+      const snapshot = snapshotResult.snapshot;
 
       const metadata =
         snapshot.metadata && typeof snapshot.metadata === 'object' && !Array.isArray(snapshot.metadata)

--- a/apps/api/src/services/drExecutionService.ts
+++ b/apps/api/src/services/drExecutionService.ts
@@ -72,7 +72,22 @@ export type DrExecutionResults = {
   groupResults: GroupResult[];
   activeGroupId?: string | null;
   haltReason?: string | null;
+  /**
+   * Site-scope authorization snapshot captured at enqueue time. `null` means the
+   * initiating caller was NOT site-restricted (dispatch to any device in the
+   * plan's groups). A `string[]` is the exact set of device IDs the caller was
+   * authorized to reach — the worker (system DB context, no auth) MUST refuse to
+   * dispatch to any device outside this set even if the plan's groups are later
+   * edited to add out-of-scope devices. See `dispatchGroup`.
+   */
+  authorizedDeviceIds?: string[] | null;
 };
+
+/** Normalize a persisted `authorizedDeviceIds` value → string[] | null (legacy/undefined → null = unrestricted). */
+function normalizeAuthorizedDeviceIds(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.filter((entry): entry is string => typeof entry === 'string');
+}
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -256,9 +271,17 @@ export async function createDrExecutionAndEnqueue(input: {
   orgId: string;
   executionType: 'rehearsal' | 'failover' | 'failback';
   initiatedBy?: string | null;
+  /**
+   * Site-scope authorization snapshot from the initiating caller. `null` (or
+   * omitted) = unrestricted caller; a `string[]` pins the exact devices the
+   * worker is allowed to dispatch to (see `DrExecutionResults.authorizedDeviceIds`).
+   */
+  authorizedDeviceIds?: string[] | null;
 }): Promise<DrExecutionRecord | null> {
   const groups = await loadDrPlanGroups(input.planId, input.orgId);
   const now = new Date();
+  const initialResults = buildInitialResults(groups, now);
+  initialResults.authorizedDeviceIds = input.authorizedDeviceIds ?? null;
   const [execution] = await db
     .insert(drExecutions)
     .values({
@@ -268,7 +291,7 @@ export async function createDrExecutionAndEnqueue(input: {
       status: 'pending',
       startedAt: now,
       initiatedBy: input.initiatedBy ?? null,
-      results: buildInitialResults(groups, now),
+      results: initialResults,
       createdAt: now,
     })
     .returning();
@@ -344,8 +367,25 @@ async function dispatchGroup(
       .map((entry) => entry.deviceId),
   );
 
+  // Site-scope authorization snapshot the initiating caller was granted at
+  // enqueue time. `null` = unrestricted. The worker runs in a system DB context
+  // (no auth), so this is the ONLY defense against dispatching to an out-of-site
+  // device that was added to the plan's groups after authorization.
+  const authorizedDeviceIds = currentResults.authorizedDeviceIds ?? null;
+
   for (const deviceId of deviceIds) {
     if (alreadyQueued.has(deviceId)) {
+      continue;
+    }
+
+    if (authorizedDeviceIds && !authorizedDeviceIds.includes(deviceId)) {
+      nextResults.failedDispatches.push({
+        groupId: group.id,
+        groupName: group.name,
+        deviceId,
+        commandType,
+        error: 'Device is outside the initiating caller\'s site authorization',
+      });
       continue;
     }
 
@@ -434,6 +474,9 @@ export async function reconcileDrExecution(executionId: string): Promise<DrExecu
     plannedGroups: normalizePlannedGroups(groups),
     queuedCommands: normalizeQueuedCommands(currentResultsRecord.queuedCommands),
     failedDispatches: normalizeFailedDispatches(currentResultsRecord.failedDispatches),
+    // Carry the caller's site-scope authorization forward across reconciles so
+    // the worker keeps honoring it on every dispatch.
+    authorizedDeviceIds: normalizeAuthorizedDeviceIds(currentResultsRecord.authorizedDeviceIds),
   };
 
   const commandIds = results.queuedCommands.map((entry) => entry.commandId);


### PR DESCRIPTION
Closes a cross-site composition gap in the Tier-3 restore/DR tools: they site-checked the **target** device but loaded the **source** snapshot (or DR plan devices) by org only, so a caller owning a legitimate target could restore a sibling-site snapshot onto it (shared provider namespace) or execute a DR plan spanning sibling-site devices.

**Findings:** SR5-11 (MSSQL restore), SR5-12 (backup/VM/Hyper-V restore), SR5-13 (DR plan execute + read).

**Approach:** new shared `loadSnapshotWithSiteAccess` resolves the snapshot's source device (`snapshot.deviceId → siteId`) and applies the same site gate as the target; used by all restore handlers. DR execute resolves every group's device array against the caller's sites before enqueue, persists an authorization snapshot, and the worker re-checks it before each dispatch (the worker runs in a system DB context, so the persisted pin is the enforcement point). Read tools hide fully-out-of-scope plans. Unrestricted callers incur no extra queries / no behavior change.

**Note:** reachable via the MCP tool path (not the in-app SDK). The parallel non-AI REST restore routes may warrant a similar source-snapshot audit (out of scope here).

**Verification:** `tsc` clean; new `aiToolsBackupShared.test.ts` / `aiToolsBackup.siteScope.test.ts` / `aiToolsDR.siteScope.test.ts` + existing backup/DR suites (93) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)