### PR TITLE
fix(security): site-axis fixes for config-policy assignments, audit arrays, invite + Huntress aggregates (SR5-07/17/18/19)

### DIFF
--- a/apps/api/src/__tests__/integration/aiToolsAuditDetailsSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiToolsAuditDetailsSiteScope.integration.test.ts
@@ -181,6 +181,60 @@ describe('query_audit_log — details.deviceId site narrowing (R3b residual)', (
     expect(JSON.stringify(parsed)).not.toContain(outScopeDevice.id);
   });
 
+  it('narrows non-device rows that reference an out-of-scope device via an array-valued details.deviceIds (SR5-17)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const siteAllowed = await createSite({ orgId: org.id });
+    const siteForbidden = await createSite({ orgId: org.id });
+
+    const inScopeA = await seedDevice(org.id, siteAllowed.id);
+    const inScopeB = await seedDevice(org.id, siteAllowed.id);
+    const outScope = await seedDevice(org.id, siteForbidden.id);
+
+    const marker = `sr5-17-arrays-${randomUUID()}`;
+
+    // (a) all-in-scope array → visible
+    await seedAudit(org.id, marker, 'software_deploy_job', randomUUID(), {
+      deviceIds: [inScopeA.id, inScopeB.id],
+      reason: 'all-in-scope-array',
+    });
+    // (b) array containing ONE out-of-scope device → hidden (any forbidden
+    //     element excludes the whole row so no forbidden UUID leaks)
+    await seedAudit(org.id, marker, 'software_deploy_job', randomUUID(), {
+      deviceIds: [inScopeA.id, outScope.id],
+      reason: 'mixed-array',
+    });
+    // (c) array of ONLY out-of-scope devices → hidden
+    await seedAudit(org.id, marker, 'device_link_group', randomUUID(), {
+      deviceIds: [outScope.id],
+      reason: 'forbidden-array',
+    });
+    // (d) empty array → no device reference → visible (no over-exclusion)
+    await seedAudit(org.id, marker, 'software_deploy_job', randomUUID(), {
+      deviceIds: [],
+      reason: 'empty-array',
+    });
+
+    const handler = auditHandler();
+    const auth = makeAuth(org.id, [siteAllowed.id]);
+
+    const raw = await withDbAccessContext(
+      { scope: 'organization', orgId: org.id, accessibleOrgIds: [org.id] },
+      async () => handler({ action: marker, hoursBack: 168, limit: 100 }, auth),
+    );
+    const parsed = JSON.parse(raw);
+    const reasons = (parsed.entries ?? []).map((e: any) => e.details?.reason);
+
+    expect(parsed.error).toBeUndefined();
+    expect(reasons).toContain('all-in-scope-array');
+    expect(reasons).toContain('empty-array');
+    expect(reasons).not.toContain('mixed-array');
+    expect(reasons).not.toContain('forbidden-array');
+    // The out-of-scope device UUID must never leak (not even via the mixed row).
+    expect(JSON.stringify(parsed)).not.toContain(outScope.id);
+    expect(parsed.showing).toBe(2);
+  });
+
   it('does NOT over-exclude device-referencing rows when the caller has no forbidden devices (empty forbidden set)', async () => {
     const partner = await createPartner();
     const org = await createOrganization({ partnerId: partner.id });

--- a/apps/api/src/routes/configurationPolicies/assignments.test.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.test.ts
@@ -8,6 +8,8 @@ const {
   listAssignmentsMock,
   listAssignmentsForTargetMock,
   validateAssignmentTargetMock,
+  authorizeAssignmentTargetMock,
+  getAssignmentMock,
   canManagePartnerWideMock,
 } = vi.hoisted(() => ({
   getConfigPolicyMock: vi.fn(),
@@ -16,6 +18,8 @@ const {
   listAssignmentsMock: vi.fn(),
   listAssignmentsForTargetMock: vi.fn(),
   validateAssignmentTargetMock: vi.fn(),
+  authorizeAssignmentTargetMock: vi.fn(),
+  getAssignmentMock: vi.fn(),
   canManagePartnerWideMock: vi.fn(),
 }));
 
@@ -32,6 +36,8 @@ vi.mock('../../services/configurationPolicy', async (importOriginal) => {
     listAssignments: listAssignmentsMock,
     listAssignmentsForTarget: listAssignmentsForTargetMock,
     validateAssignmentTarget: validateAssignmentTargetMock,
+    authorizeAssignmentTarget: authorizeAssignmentTargetMock,
+    getAssignment: getAssignmentMock,
     canManagePartnerWidePolicies: canManagePartnerWideMock,
   };
 });
@@ -88,6 +94,13 @@ describe('configurationPolicies assignment routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // SR5-07 site sub-axis: default to "allowed" so existing (unrestricted)
+    // cases are unaffected; individual tests override to assert denial. The real
+    // helper is a no-op for callers without allowedSiteIds, so mocking it keeps
+    // these route tests DB-free while still exercising the wiring.
+    authorizeAssignmentTargetMock.mockResolvedValue({ valid: true });
+    // getAssignment backs the DELETE re-check; default to a partner-level row.
+    getAssignmentMock.mockResolvedValue({ id: 'aid', level: 'partner', targetId: PARTNER_ID });
     app = new Hono();
     app.use('*', async (c, next) => {
       c.set('auth', makeAuth());
@@ -432,5 +445,49 @@ describe('configurationPolicies assignment routes', () => {
     });
 
     expect(res.status).toBe(201);
+  });
+
+  // ============================================================
+  // Security: SR5-07 site sub-axis on assignment create/delete
+  // ============================================================
+
+  it('denies a create whose target is outside the caller site access (403) before inserting', async () => {
+    getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Policy 1' });
+    validateAssignmentTargetMock.mockResolvedValue({ valid: true });
+    authorizeAssignmentTargetMock.mockResolvedValue({ valid: false, error: 'Target device is outside your site access' });
+
+    const res = await app.request(`/${POLICY_ID}/assignments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ level: 'device', targetId: DEVICE_ID }),
+    });
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: 'Target device is outside your site access' });
+    expect(assignPolicyMock).not.toHaveBeenCalled();
+  });
+
+  it('denies a delete whose stored target is outside the caller site access (403) before removing', async () => {
+    const AID = '77777777-7777-7777-7777-777777777777';
+    getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Policy 1' });
+    getAssignmentMock.mockResolvedValue({ id: AID, level: 'device', targetId: DEVICE_ID });
+    authorizeAssignmentTargetMock.mockResolvedValue({ valid: false, error: 'Target device is outside your site access' });
+
+    const res = await app.request(`/${POLICY_ID}/assignments/${AID}`, { method: 'DELETE' });
+
+    expect(res.status).toBe(403);
+    expect(getAssignmentMock).toHaveBeenCalledWith(AID, POLICY_ID);
+    expect(unassignPolicyMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the delete target assignment does not exist', async () => {
+    const AID = '88888888-8888-8888-8888-888888888888';
+    getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Policy 1' });
+    getAssignmentMock.mockResolvedValue(null);
+
+    const res = await app.request(`/${POLICY_ID}/assignments/${AID}`, { method: 'DELETE' });
+
+    expect(res.status).toBe(404);
+    expect(unassignPolicyMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/configurationPolicies/assignments.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.ts
@@ -11,9 +11,12 @@ import {
   listAssignments,
   listAssignmentsForTarget,
   validateAssignmentTarget,
+  authorizeAssignmentTarget,
+  getAssignment,
   canManagePartnerWidePolicies,
   PARTNER_WIDE_WRITE_DENIED_MESSAGE,
 } from '../../services/configurationPolicy';
+import type { ConfigAssignmentLevel } from '../../services/configurationPolicy';
 import { invalidateRemoteAccessCache } from '../../services/remoteAccessPolicy';
 import {
   assignPolicySchema,
@@ -98,6 +101,14 @@ assignmentRoutes.post(
       return c.json({ error: targetValidation.error }, 403);
     }
 
+    // Site sub-axis (SR5-07): RLS does not enforce the site allowlist, so a
+    // site-restricted caller must be blocked from assigning to org/partner
+    // targets or to a site/group/device outside their allowed sites.
+    const siteAuth = await authorizeAssignmentTarget(auth, data.level, targetId);
+    if (!siteAuth.valid) {
+      return c.json({ error: siteAuth.error }, 403);
+    }
+
     // assignPolicy returns null (instead of throwing) on a duplicate — see the
     // comment on its onConflictDoNothing insert in configurationPolicy.ts for
     // why the raised-violation catch pattern doesn't work inside this route's
@@ -151,6 +162,20 @@ assignmentRoutes.delete(
     // under the partner. Same blast radius as assigning, so the same gate applies.
     if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
       return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
+    // Site sub-axis (SR5-07): re-check against the stored target so a
+    // site-restricted caller can't remove an assignment that reaches a site,
+    // group, or device outside their allowlist (RLS does not enforce site).
+    const existing = await getAssignment(aid, id);
+    if (!existing) return c.json({ error: 'Assignment not found' }, 404);
+    const siteAuth = await authorizeAssignmentTarget(
+      auth,
+      existing.level as ConfigAssignmentLevel,
+      existing.targetId
+    );
+    if (!siteAuth.valid) {
+      return c.json({ error: siteAuth.error }, 403);
     }
 
     const deleted = await unassignPolicy(aid, id);

--- a/apps/api/src/services/aiToolsAudit.ts
+++ b/apps/api/src/services/aiToolsAudit.ts
@@ -88,9 +88,11 @@ export function registerAuditTools(aiTools: Map<string, AiTool>): void {
       // Both narrowings leave rows with no device reference governed by the org
       // axis only, and are a no-op for unrestricted partner/system callers.
       //
-      // Known residual (documented, not closed here): array-valued `details.deviceIds`
-      // (sparse) and free-text device hostnames in `resourceName` carry no reliable
-      // single device id to key off, so those references are left to the org axis.
+      // Array-valued `details.deviceIds` (software deploy jobs, device-link
+      // groups) IS now closed (SR5-17): a row is excluded if its array shares any
+      // element with the out-of-scope set. Known residual: free-text device
+      // hostnames in `resourceName` carry no reliable device id to key off, so
+      // those references are left to the org axis.
       if (auth.allowedSiteIds && auth.canAccessSite) {
         const orgId = auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
         // One device scan yields both partitions: `allowed` (in-scope, for the
@@ -127,16 +129,29 @@ export function registerAuditTools(aiTools: Map<string, AiTool>): void {
               : ne(auditLogs.resourceType, 'device'),
           );
           // (2) `details`-referenced rows: exclude any row whose
-          // `details.deviceId` / `details.linkedDeviceId` is a known out-of-scope
-          // fleet device. Rows where the key is absent (NULL ->> result) are
-          // untouched — only a positive match against the forbidden set excludes.
+          // `details.deviceId` / `details.linkedDeviceId` (scalar) OR
+          // `details.deviceIds` (array — SR5-17) references a known out-of-scope
+          // fleet device. Rows where the key is absent (NULL ->> result / no
+          // array) are untouched — only a positive match against the forbidden
+          // set excludes. A row that batches devices under `deviceIds` (software
+          // deploy jobs, device-link groups) is dropped entirely if ANY element
+          // is forbidden, so no out-of-site UUID leaks in the returned `details`.
           if (forbiddenDeviceIds.length > 0) {
             const deviceIdRef = sql`${auditLogs.details}->>'deviceId'`;
             const linkedDeviceIdRef = sql`${auditLogs.details}->>'linkedDeviceId'`;
+            // `?|` (jsonb array/text overlap): true when the `deviceIds` array
+            // shares any element with the forbidden set. Guarded so a missing key
+            // or non-array value never excludes. Params are bound individually.
+            const deviceIdsRef = sql`${auditLogs.details}->'deviceIds'`;
+            const forbiddenArray = sql`array[${sql.join(
+              forbiddenDeviceIds.map((id) => sql`${id}`),
+              sql`, `,
+            )}]::text[]`;
             conditions.push(
               and(
                 or(isNull(deviceIdRef), not(inArray(deviceIdRef, forbiddenDeviceIds)))!,
                 or(isNull(linkedDeviceIdRef), not(inArray(linkedDeviceIdRef, forbiddenDeviceIds)))!,
+                sql`(${deviceIdsRef} is null or jsonb_typeof(${deviceIdsRef}) <> 'array' or not (${deviceIdsRef} ?| ${forbiddenArray}))`,
               )!,
             );
           }

--- a/apps/api/src/services/aiToolsConfigPolicy.test.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   assignPolicyMock,
   validateAssignmentTargetMock,
+  authorizeAssignmentTargetMock,
   policyAccessConditionMock,
   canManagePartnerWidePoliciesMock,
   createConfigPolicyMock,
@@ -10,6 +11,9 @@ const {
 } = vi.hoisted(() => ({
   assignPolicyMock: vi.fn(),
   validateAssignmentTargetMock: vi.fn(),
+  // SR5-07 site sub-axis: default allow so existing (unrestricted) cases are
+  // unaffected; site-scope tests override to assert denial.
+  authorizeAssignmentTargetMock: vi.fn(async () => ({ valid: true })),
   policyAccessConditionMock: vi.fn(),
   canManagePartnerWidePoliciesMock: vi.fn(() => true),
   createConfigPolicyMock: vi.fn(),
@@ -65,6 +69,7 @@ vi.mock('./configurationPolicy', () => ({
   listFeatureLinks: vi.fn(),
   listAssignments: vi.fn(),
   validateAssignmentTarget: validateAssignmentTargetMock,
+  authorizeAssignmentTarget: authorizeAssignmentTargetMock,
   canManagePartnerWidePolicies: canManagePartnerWidePoliciesMock,
   policyAccessCondition: policyAccessConditionMock,
   PARTNER_WIDE_WRITE_DENIED_MESSAGE: 'partner-wide write denied',
@@ -128,6 +133,7 @@ describe('configuration policy AI tools', () => {
     vi.clearAllMocks();
     canManagePartnerWidePoliciesMock.mockReturnValue(true);
     policyAccessConditionMock.mockReturnValue(undefined);
+    authorizeAssignmentTargetMock.mockResolvedValue({ valid: true });
   });
 
   it('validates assignment target org before applying a policy', async () => {
@@ -190,6 +196,30 @@ describe('configuration policy AI tools', () => {
       message: `Policy "Policy 1" assigned to device ${DEVICE_ID}`,
       assignmentId: 'assignment-1',
     });
+  });
+
+  it('apply_configuration_policy denies a target outside the caller site access (SR5-07)', async () => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Policy 1' }]),
+        }),
+      }),
+    } as any);
+    validateAssignmentTargetMock.mockResolvedValue({ valid: true });
+    authorizeAssignmentTargetMock.mockResolvedValue({ valid: false, error: 'Target device is outside your site access' });
+
+    const tools = new Map<string, any>();
+    registerConfigPolicyTools(tools);
+
+    const output = await tools.get('apply_configuration_policy')!.handler({
+      configPolicyId: POLICY_ID,
+      level: 'device',
+      targetId: DEVICE_ID,
+    }, makeAuth());
+
+    expect(JSON.parse(output)).toEqual({ error: 'Target device is outside your site access' });
+    expect(assignPolicyMock).not.toHaveBeenCalled();
   });
 
   // assignPolicy's insert (configurationPolicy.ts) uses onConflictDoNothing and
@@ -463,6 +493,31 @@ describe('configuration policy AI tools', () => {
     }, makePartnerAuth());
 
     expect(JSON.parse(output)).toEqual({ error: 'partner-wide write denied' });
+    expect(unassignPolicyMock).not.toHaveBeenCalled();
+  });
+
+  it('remove_configuration_policy_assignment denies removal of a target outside the caller site access (SR5-07)', async () => {
+    // Org-owned policy (policyOrgId non-null) so the partner-wide gate passes;
+    // the site sub-axis then blocks removal of a cross-site device assignment.
+    mockSelectRows([{
+      id: 'assignment-1',
+      configPolicyId: POLICY_ID,
+      policyName: 'Org Policy',
+      policyOrgId: ORG_ID,
+      level: 'device',
+      targetId: DEVICE_ID,
+    }]);
+    canManagePartnerWidePoliciesMock.mockReturnValue(true);
+    authorizeAssignmentTargetMock.mockResolvedValue({ valid: false, error: 'Target device is outside your site access' });
+
+    const tools = new Map<string, any>();
+    registerConfigPolicyTools(tools);
+
+    const output = await tools.get('remove_configuration_policy_assignment')!.handler({
+      assignmentId: 'assignment-1',
+    }, makeAuth());
+
+    expect(JSON.parse(output)).toEqual({ error: 'Target device is outside your site access' });
     expect(unassignPolicyMock).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/services/aiToolsConfigPolicy.test.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.test.ts
@@ -13,7 +13,7 @@ const {
   validateAssignmentTargetMock: vi.fn(),
   // SR5-07 site sub-axis: default allow so existing (unrestricted) cases are
   // unaffected; site-scope tests override to assert denial.
-  authorizeAssignmentTargetMock: vi.fn(async () => ({ valid: true })),
+  authorizeAssignmentTargetMock: vi.fn(async (): Promise<{ valid: boolean; error?: string }> => ({ valid: true })),
   policyAccessConditionMock: vi.fn(),
   canManagePartnerWidePoliciesMock: vi.fn(() => true),
   createConfigPolicyMock: vi.fn(),

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -20,6 +20,7 @@ import {
   listFeatureLinks,
   listAssignments,
   validateAssignmentTarget,
+  authorizeAssignmentTarget,
   canManagePartnerWidePolicies,
   policyAccessCondition,
   PARTNER_WIDE_WRITE_DENIED_MESSAGE,
@@ -273,6 +274,14 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
         return JSON.stringify({ error: targetValidation.error });
       }
 
+      // Site sub-axis (SR5-07): RLS does not enforce the site allowlist, so a
+      // site-restricted caller must be blocked from assigning to org/partner
+      // targets or to a site/group/device outside their allowed sites.
+      const siteAuth = await authorizeAssignmentTarget(auth, input.level as any, targetId);
+      if (!siteAuth.valid) {
+        return JSON.stringify({ error: siteAuth.error });
+      }
+
       // assignPolicy returns null (instead of throwing) on a duplicate — see
       // the comment on its onConflictDoNothing insert in configurationPolicy.ts
       // for why the raised-violation catch pattern doesn't work inside this
@@ -344,6 +353,14 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
       // under the partner. Same blast radius as assigning, so the same gate applies.
       if (assignment.policyOrgId === null && !canManagePartnerWidePolicies(auth)) {
         return JSON.stringify({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+      }
+
+      // Site sub-axis (SR5-07): re-check against the stored target so a
+      // site-restricted caller can't remove an assignment reaching a site,
+      // group, or device outside their allowlist (RLS does not enforce site).
+      const siteAuth = await authorizeAssignmentTarget(auth, assignment.level as any, assignment.targetId);
+      if (!siteAuth.valid) {
+        return JSON.stringify({ error: siteAuth.error });
       }
 
       const deleted = await unassignPolicy(input.assignmentId as string, assignment.configPolicyId);

--- a/apps/api/src/services/aiToolsFleetStatus.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsFleetStatus.siteScope.test.ts
@@ -18,23 +18,29 @@ function handlerFor(name: string): AiTool['handler'] {
   registerFleetStatusTools(reg);
   return reg.get(name)!.handler;
 }
-function makeAuth(allowedSiteIds?: string[]): AuthContext {
+function makeAuth(
+  allowedSiteIds?: string[],
+  overrides: Partial<AuthContext> = {},
+): AuthContext {
   return {
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any, partnerId: 'p1', orgId: null, scope: 'partner',
     accessibleOrgIds: null, orgCondition: () => undefined, canAccessOrg: () => true,
     allowedSiteIds, canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
+    ...overrides,
   };
 }
 
-// invites select first, then device rows (which now include siteId).
-function invitesThenDevices(deviceRows: Array<Record<string, unknown>>) {
+// The invites query is now `.from(...).leftJoin(...).where(...)`; the device
+// query (call 2) is `.from(...).where(...)` and only fires when an enrolled
+// invite has a deviceId.
+function mockSelects(inviteRows: Array<Record<string, unknown>>, deviceRows: Array<Record<string, unknown>> = []) {
   let call = 0;
   mockDb.select.mockImplementation(() => {
     call++;
-    if (call === 1) return { from: () => ({ where: () => Promise.resolve([
-      { id: 'i1', email: 'a@b.c', status: 'enrolled', clickedAt: new Date(), enrolledAt: new Date(), deviceId: 'd1' },
-    ]) }) };
+    if (call === 1) {
+      return { from: () => ({ leftJoin: () => ({ where: () => Promise.resolve(inviteRows) }) }) };
+    }
     return { from: () => ({ where: () => Promise.resolve(deviceRows) }) };
   });
 }
@@ -43,7 +49,12 @@ describe('get_fleet_status — site narrowing of enrolled devices', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('excludes enrolled devices in forbidden sites for a site-restricted caller', async () => {
-    invitesThenDevices([{ id: 'd1', hostname: 'h', osType: 'windows', status: 'online', orgId: 'org-1', siteId: 'site-B' }]);
+    // Invite is on a key in an allowed site so it survives the invite-level
+    // filter, but its enrolled device is in a forbidden site → dropped.
+    mockSelects(
+      [{ id: 'i1', email: 'a@b.c', status: 'enrolled', clickedAt: new Date(), enrolledAt: new Date(), deviceId: 'd1', keySiteId: 'site-A' }],
+      [{ id: 'd1', hostname: 'h', osType: 'windows', status: 'online', orgId: 'org-1', siteId: 'site-B' }],
+    );
     const r = await handlerFor('get_fleet_status')({}, makeAuth(['site-A']));
     const parsed = JSON.parse(r);
     expect(parsed.invite_funnel.devices_online).toBe(0);
@@ -51,9 +62,50 @@ describe('get_fleet_status — site narrowing of enrolled devices', () => {
   });
 
   it('unrestricted caller sees all enrolled devices (no regression)', async () => {
-    invitesThenDevices([{ id: 'd1', hostname: 'h', osType: 'windows', status: 'online', orgId: 'org-1', siteId: 'site-B' }]);
+    mockSelects(
+      [{ id: 'i1', email: 'a@b.c', status: 'enrolled', clickedAt: new Date(), enrolledAt: new Date(), deviceId: 'd1', keySiteId: 'site-B' }],
+      [{ id: 'd1', hostname: 'h', osType: 'windows', status: 'online', orgId: 'org-1', siteId: 'site-B' }],
+    );
     const r = await handlerFor('get_fleet_status')({}, makeAuth(undefined));
     const parsed = JSON.parse(r);
     expect(parsed.invite_funnel.devices_online).toBe(1);
+  });
+});
+
+describe('get_fleet_status — SR5-18 invite-total narrowing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('excludes invite totals/clicks whose enrollment key is outside the caller site allowlist', async () => {
+    mockSelects([
+      { id: 'i1', email: 'in@x.c', status: 'clicked', clickedAt: new Date(), enrolledAt: null, deviceId: null, keySiteId: 'site-A' },
+      { id: 'i2', email: 'out@x.c', status: 'clicked', clickedAt: new Date(), enrolledAt: null, deviceId: null, keySiteId: 'site-B' },
+      { id: 'i3', email: 'orgwide@x.c', status: 'clicked', clickedAt: new Date(), enrolledAt: null, deviceId: null, keySiteId: null },
+    ]);
+    const r = await handlerFor('get_fleet_status')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    // Only the site-A invite is visible; site-B and the org-wide (null-site) key are excluded (fail closed).
+    expect(parsed.invite_funnel.total_invited).toBe(1);
+    expect(parsed.invite_funnel.invites_clicked).toBe(1);
+  });
+
+  it('unrestricted caller sees partner-wide invite totals (no regression)', async () => {
+    mockSelects([
+      { id: 'i1', email: 'in@x.c', status: 'clicked', clickedAt: new Date(), enrolledAt: null, deviceId: null, keySiteId: 'site-A' },
+      { id: 'i2', email: 'out@x.c', status: 'clicked', clickedAt: new Date(), enrolledAt: null, deviceId: null, keySiteId: 'site-B' },
+      { id: 'i3', email: 'orgwide@x.c', status: 'sent', clickedAt: null, enrolledAt: null, deviceId: null, keySiteId: null },
+    ]);
+    const r = await handlerFor('get_fleet_status')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.invite_funnel.total_invited).toBe(3);
+    expect(parsed.invite_funnel.invites_clicked).toBe(2);
+  });
+
+  it('applies the actor org condition to the invite query (org-scoped caller not shown partner-wide totals)', async () => {
+    mockSelects([]);
+    const orgCondition = vi.fn(() => undefined as any);
+    const auth = makeAuth(undefined, { scope: 'organization', orgId: 'org-1', orgCondition });
+    await handlerFor('get_fleet_status')({}, auth);
+    // The invite query narrows by the actor's org axis, not partner-wide only.
+    expect(orgCondition).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/aiToolsFleetStatus.test.ts
+++ b/apps/api/src/services/aiToolsFleetStatus.test.ts
@@ -23,6 +23,14 @@ vi.mock('../db/schema/devices', () => ({
     osType: 'd.os_type',
     status: 'd.status',
     orgId: 'd.org_id',
+    siteId: 'd.site_id',
+  },
+}));
+
+vi.mock('../db/schema/orgs', () => ({
+  enrollmentKeys: {
+    id: 'ek.id',
+    siteId: 'ek.site_id',
   },
 }));
 
@@ -43,6 +51,8 @@ function mockSelectQueue(results: unknown[][]): void {
     const result = queue.shift() ?? [];
     const chain: any = {
       from: vi.fn().mockReturnThis(),
+      // The invites query now joins enrollment_keys for the site sub-axis.
+      leftJoin: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnValue(Promise.resolve(result)),
     };
     return chain as any;

--- a/apps/api/src/services/aiToolsFleetStatus.ts
+++ b/apps/api/src/services/aiToolsFleetStatus.ts
@@ -13,9 +13,10 @@
  * (it's a Tier 1 read tool), so a pre-payment tenant can still see an empty
  * funnel snapshot. Task 6.2 of the MCP bootstrap plan.
  */
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, SQL } from 'drizzle-orm';
 import { db } from '../db';
 import { deploymentInvites } from '../db/schema/deploymentInvites';
+import { enrollmentKeys } from '../db/schema/orgs';
 import { devices } from '../db/schema/devices';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool, AiToolTier } from './aiTools';
@@ -45,7 +46,17 @@ export async function computeInviteFunnel(
   partnerId: string,
   auth?: AuthContext,
 ): Promise<InviteFunnel> {
-  const invites = await db
+  // SR5-18: the invite funnel is partner-keyed, but an org/site-scoped caller
+  // (org token still carries a partnerId) must NOT see partner-wide invite
+  // totals/clicks. Narrow by the actor's org axis, and — for a site-restricted
+  // caller — by the enrollment key's site (invites carry no site of their own;
+  // their enrollment key does). Invites on an org-wide key (site_id NULL) are
+  // fail-closed out for a site-restricted caller.
+  const inviteConditions: SQL[] = [eq(deploymentInvites.partnerId, partnerId)];
+  const inviteOrgCondition = auth?.orgCondition(deploymentInvites.orgId);
+  if (inviteOrgCondition) inviteConditions.push(inviteOrgCondition);
+
+  const rawInvites = await db
     .select({
       id: deploymentInvites.id,
       email: deploymentInvites.invitedEmail,
@@ -53,9 +64,19 @@ export async function computeInviteFunnel(
       clickedAt: deploymentInvites.clickedAt,
       enrolledAt: deploymentInvites.enrolledAt,
       deviceId: deploymentInvites.deviceId,
+      keySiteId: enrollmentKeys.siteId,
     })
     .from(deploymentInvites)
-    .where(eq(deploymentInvites.partnerId, partnerId));
+    .leftJoin(enrollmentKeys, eq(deploymentInvites.enrollmentKeyId, enrollmentKeys.id))
+    .where(and(...inviteConditions));
+
+  // Site sub-axis (app-layer only; RLS does NOT enforce it). Drop invites whose
+  // enrollment key is outside the caller's site allowlist so the top-of-funnel
+  // totals/clicks reflect only site-visible invites. No-op for unrestricted
+  // callers (canAccessSite absent).
+  const invites = auth?.canAccessSite
+    ? rawInvites.filter((i) => auth.canAccessSite!(i.keySiteId))
+    : rawInvites;
 
   const total_invited = invites.length;
   // `clicked` count uses status OR a non-null clickedAt so a row that has

--- a/apps/api/src/services/aiToolsHuntress.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsHuntress.siteScope.test.ts
@@ -88,3 +88,57 @@ describe('get_huntress_incidents — site narrowing (cross-site enumeration)', (
     expect(parsed.incidents).toHaveLength(1);
   });
 });
+
+describe('get_huntress_status — SR5-19 site narrowing of aggregates', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const integration = {
+    id: 'int1', partnerId: 'p1', name: 'Hunt', isActive: true,
+    lastSyncAt: null, lastSyncStatus: null, lastSyncError: null,
+  };
+
+  it('site-restricted caller with zero in-scope devices gets a zeroed summary and never runs the aggregate scans', async () => {
+    let aggregatesRan = false;
+    let call = 0;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      call++;
+      if (call === 1) return chain([integration]); // integrations list
+      if (isDeviceResolverSelect(cols)) {
+        // The org's only Huntress-mapped device is in a forbidden site.
+        return { from: () => ({ where: () => Promise.resolve([{ id: 'd-siteB', siteId: 'site-B' }]) }) };
+      }
+      aggregatesRan = true;
+      return chain([{ count: 0 }]);
+    });
+
+    const r = await handlerFor('get_huntress_status')({}, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+    expect(parsed.scopeNote).toBeDefined();
+    expect(parsed.summary.totalAgents).toBe(0);
+    expect(parsed.summary.openIncidents).toBe(0);
+    expect(parsed.integrations).toEqual([]);
+    // Fail closed: aggregate agent/incident/severity scans must not span all sites.
+    expect(aggregatesRan).toBe(false);
+  });
+
+  it('unrestricted caller runs aggregates normally without a device resolver (no regression)', async () => {
+    let resolverRan = false;
+    let call = 0;
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      call++;
+      if (call === 1) return chain([integration]);
+      if (isDeviceResolverSelect(cols)) {
+        resolverRan = true;
+        return { from: () => ({ where: () => Promise.resolve([]) }) };
+      }
+      if (cols && typeof cols === 'object' && 'count' in (cols as object)) return chain([{ count: 1 }]);
+      return chain([{ totalAgents: 0, mappedAgents: 0, offlineAgents: 0, openIncidents: 0 }]);
+    });
+
+    const r = await handlerFor('get_huntress_status')({}, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+    expect(parsed.scopeNote).toBeUndefined();
+    expect(parsed.integrations).toHaveLength(1);
+    expect(resolverRan).toBe(false);
+  });
+});

--- a/apps/api/src/services/aiToolsHuntress.ts
+++ b/apps/api/src/services/aiToolsHuntress.ts
@@ -104,6 +104,35 @@ export function registerHuntressTools(aiTools: Map<string, AiTool>): void {
         agentScopedConditions.push(eq(huntressAgents.orgId, requestedOrgId));
         incidentScopedConditions.push(eq(huntressIncidents.orgId, requestedOrgId));
       }
+
+      // Site axis (SR5-19; app-layer only, RLS does NOT enforce it). Neither
+      // huntress_agents nor huntress_incidents carries a site_id, so — like the
+      // get_huntress_incidents sibling below — narrow every aggregate (summary +
+      // per-integration agent/incident/severity counts) to the caller's in-scope
+      // device set. A restricted caller with zero in-scope devices short-circuits
+      // to an empty summary (fail closed). Agents/incidents not mapped to a device
+      // (device_id NULL) are excluded for a restricted caller. No-op otherwise.
+      if (auth.allowedSiteIds && auth.canAccessSite) {
+        const queryOrgId = requestedOrgId ?? auth.orgId ?? auth.accessibleOrgIds?.[0] ?? null;
+        const allowed = queryOrgId ? await resolveSiteAllowedDeviceIds(queryOrgId, auth) : [];
+        if (!allowed || allowed.length === 0) {
+          return JSON.stringify({
+            integrations: [],
+            summary: {
+              totalIntegrations: 0,
+              totalAgents: 0,
+              mappedAgents: 0,
+              unmappedAgents: 0,
+              offlineAgents: 0,
+              openIncidents: 0,
+            },
+            pagination: { limit: RESULT_LIMIT, returned: 0, total: 0, truncated: false },
+            scopeNote: SITE_SCOPE_EMPTY_NOTE,
+          });
+        }
+        agentScopedConditions.push(inArray(huntressAgents.deviceId, allowed));
+        incidentScopedConditions.push(inArray(huntressIncidents.deviceId, allowed));
+      }
       const [[integrationCount], [summaryAgentCounts], [summaryIncidentCounts], agentCounts, incidentCounts, severityCounts] = await Promise.all([
         db
           .select({

--- a/apps/api/src/services/configurationPolicy.assignmentSiteScope.test.ts
+++ b/apps/api/src/services/configurationPolicy.assignmentSiteScope.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// authorizeAssignmentTarget (SR5-07) gates whether a SITE-restricted caller may
+// touch a given assignment target. It's a separate concern from
+// validateAssignmentTarget (org/partner ownership). The db is mocked: site/group
+// resolution ends in `.limit(1)`; org/partner denials must short-circuit BEFORE
+// any query runs.
+const { selectMock } = vi.hoisted(() => ({ selectMock: vi.fn() }));
+vi.mock('../db', () => ({
+  db: { select: selectMock },
+}));
+
+import { authorizeAssignmentTarget } from './configurationPolicy';
+import type { AuthContext } from '../middleware/auth';
+
+function mockSelectResolving(rows: unknown[]) {
+  const chain: any = {
+    from: () => chain,
+    innerJoin: () => chain,
+    where: () => chain,
+    limit: () => Promise.resolve(rows),
+  };
+  selectMock.mockReturnValue(chain);
+}
+
+// Site-restricted org-scope caller allowed to see `allowedSiteIds`.
+function restricted(allowedSiteIds: string[]): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
+    accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds,
+    canAccessSite: (s: string | null | undefined) => !!s && allowedSiteIds.includes(s),
+  } as unknown as AuthContext;
+}
+
+// Unrestricted caller (no site allowlist).
+function unrestricted(): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any, partnerId: 'p1', orgId: null, scope: 'partner',
+    accessibleOrgIds: null, orgCondition: () => undefined, canAccessOrg: () => true,
+    allowedSiteIds: undefined, canAccessSite: () => true,
+  } as unknown as AuthContext;
+}
+
+const SITE_A = '44444444-4444-4444-4444-444444444444';
+const SITE_B = '55555555-5555-5555-5555-555555555555';
+const GROUP_ID = '66666666-6666-6666-6666-666666666666';
+const DEVICE_ID = '77777777-7777-7777-7777-777777777777';
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => selectMock.mockReset());
+
+describe('authorizeAssignmentTarget — site sub-axis (SR5-07)', () => {
+  it('is a no-op (allow) for an unrestricted caller, without querying', async () => {
+    const r = await authorizeAssignmentTarget(unrestricted(), 'organization', ORG_ID);
+    expect(r.valid).toBe(true);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('denies an organization-level target for a site-restricted caller (no query)', async () => {
+    const r = await authorizeAssignmentTarget(restricted([SITE_A]), 'organization', ORG_ID);
+    expect(r.valid).toBe(false);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('denies a partner-level target for a site-restricted caller (no query)', async () => {
+    const r = await authorizeAssignmentTarget(restricted([SITE_A]), 'partner', 'p1');
+    expect(r.valid).toBe(false);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('allows a site target inside the caller allowlist', async () => {
+    const r = await authorizeAssignmentTarget(restricted([SITE_A]), 'site', SITE_A);
+    expect(r.valid).toBe(true);
+    // Site membership is decided purely by the allowlist — no DB round-trip.
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('denies a site target outside the caller allowlist', async () => {
+    const r = await authorizeAssignmentTarget(restricted([SITE_A]), 'site', SITE_B);
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.error).toMatch(/outside your site access/i);
+  });
+
+  it('allows a device_group whose site is in the allowlist', async () => {
+    mockSelectResolving([{ siteId: SITE_A }]);
+    const r = await authorizeAssignmentTarget(restricted([SITE_A]), 'device_group', GROUP_ID);
+    expect(r.valid).toBe(true);
+  });
+
+  it('denies a device_group whose site is outside the allowlist', async () => {
+    mockSelectResolving([{ siteId: SITE_B }]);
+    const r = await authorizeAssignmentTarget(restricted([SITE_A]), 'device_group', GROUP_ID);
+    expect(r.valid).toBe(false);
+  });
+
+  it('denies a device_group with no site (org-wide) for a restricted caller (fail closed)', async () => {
+    mockSelectResolving([{ siteId: null }]);
+    const r = await authorizeAssignmentTarget(restricted([SITE_A]), 'device_group', GROUP_ID);
+    expect(r.valid).toBe(false);
+  });
+
+  it('denies an unknown device_group (fail closed)', async () => {
+    mockSelectResolving([]);
+    const r = await authorizeAssignmentTarget(restricted([SITE_A]), 'device_group', GROUP_ID);
+    expect(r.valid).toBe(false);
+  });
+
+  it('allows a device whose site is in the allowlist', async () => {
+    mockSelectResolving([{ siteId: SITE_A }]);
+    const r = await authorizeAssignmentTarget(restricted([SITE_A]), 'device', DEVICE_ID);
+    expect(r.valid).toBe(true);
+  });
+
+  it('denies a device whose site is outside the allowlist', async () => {
+    mockSelectResolving([{ siteId: SITE_B }]);
+    const r = await authorizeAssignmentTarget(restricted([SITE_A]), 'device', DEVICE_ID);
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.error).toMatch(/outside your site access/i);
+  });
+
+  it('denies an unknown device (fail closed)', async () => {
+    mockSelectResolving([]);
+    const r = await authorizeAssignmentTarget(restricted([SITE_A]), 'device', DEVICE_ID);
+    expect(r.valid).toBe(false);
+  });
+});

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -1453,6 +1453,100 @@ export async function validateAssignmentTarget(
   }
 }
 
+/**
+ * Site-axis (SR5-07) authorization for a policy assignment target. This is a
+ * SEPARATE concern from `validateAssignmentTarget`, which only proves the target
+ * belongs to the policy's owning org/partner. `authorizeAssignmentTarget` proves
+ * the CALLER is permitted to touch the target under their site allowlist —
+ * Postgres RLS does NOT enforce the site sub-axis, so it must be checked here.
+ *
+ * No-op (allow) for an unrestricted caller (`allowedSiteIds` undefined). For a
+ * site-restricted caller it fails closed:
+ *  - organization/partner targets are denied outright — a site-scoped tech
+ *    cannot push a policy across a whole org or partner.
+ *  - site targets must be in the caller's site allowlist.
+ *  - device_group / device targets are resolved to their site and checked with
+ *    `canAccessSite` (a group/device with no site, or an unknown id, is denied).
+ *
+ * Callable at assignment time (create) AND re-checked at removal time using the
+ * stored assignment's level/targetId so a later site-restriction change can't be
+ * bypassed by deleting an assignment created earlier.
+ */
+export async function authorizeAssignmentTarget(
+  auth: AuthContext,
+  level: ConfigAssignmentLevel,
+  targetId: string
+): Promise<AssignmentTargetValidation> {
+  // Unrestricted caller (partner/system scope, or org user with no site
+  // restriction) — org/partner ownership is already enforced elsewhere.
+  if (!auth.allowedSiteIds || !auth.canAccessSite) return { valid: true };
+  const canAccessSite = auth.canAccessSite;
+
+  switch (level) {
+    case 'partner':
+    case 'organization':
+      return {
+        valid: false,
+        error: 'Your access is restricted to specific sites — you cannot assign a policy at the organization or partner level.',
+      };
+
+    case 'site':
+      return canAccessSite(targetId)
+        ? { valid: true }
+        : { valid: false, error: 'Target site is outside your site access' };
+
+    case 'device_group': {
+      const [group] = await db
+        .select({ siteId: deviceGroups.siteId })
+        .from(deviceGroups)
+        .where(eq(deviceGroups.id, targetId))
+        .limit(1);
+      // Unknown group, or a group with no single site (org-wide), is denied for a
+      // site-restricted caller (fail closed).
+      return group && canAccessSite(group.siteId)
+        ? { valid: true }
+        : { valid: false, error: 'Target device group is outside your site access' };
+    }
+
+    case 'device': {
+      const [device] = await db
+        .select({ siteId: devices.siteId })
+        .from(devices)
+        .where(eq(devices.id, targetId))
+        .limit(1);
+      return device && canAccessSite(device.siteId)
+        ? { valid: true }
+        : { valid: false, error: 'Target device is outside your site access' };
+    }
+
+    default:
+      return { valid: false, error: 'Unsupported assignment target level' };
+  }
+}
+
+/**
+ * Fetch a single assignment's identity (level + targetId) scoped to its policy.
+ * Used by the REST delete route to re-run the site-axis check against the
+ * stored target before removing the row.
+ */
+export async function getAssignment(assignmentId: string, configPolicyId: string) {
+  const [row] = await db
+    .select({
+      id: configPolicyAssignments.id,
+      level: configPolicyAssignments.level,
+      targetId: configPolicyAssignments.targetId,
+    })
+    .from(configPolicyAssignments)
+    .where(
+      and(
+        eq(configPolicyAssignments.id, assignmentId),
+        eq(configPolicyAssignments.configPolicyId, configPolicyId)
+      )
+    )
+    .limit(1);
+  return row ?? null;
+}
+
 export async function unassignPolicy(assignmentId: string, configPolicyId: string) {
   const [deleted] = await db
     .delete(configPolicyAssignments)


### PR DESCRIPTION
Four site-axis disclosure/authorization fixes across independent AI tools.

**Findings:**
- **SR5-07** config-policy assignments: new shared `authorizeAssignmentTarget(auth, level, targetId)` denies org/partner-level targets for site-restricted callers and validates site/device_group/device targets resolve to an accessible site. Wired into **both** the AI handlers and the REST create/delete routes (the REST route shared the same gap).
- **SR5-17** audit arrays: `query_audit_log` now filters array-valued `details.deviceIds` (was scalar-only), excluding any row referencing an out-of-scope device so forbidden UUIDs can't leak in `details`.
- **SR5-18** fleet-status invites: invite totals/clicks were counted partner-wide; now scoped by the actor's org condition + enrollment-key site.
- **SR5-19** Huntress status: aggregates were org-wide; now narrowed to allowed devices/sites (mirrors the sibling incident path), fail-closed for zero-site callers.

**Verification:** `tsc` clean; new `configurationPolicy.assignmentSiteScope.test.ts` + updated `aiToolsConfigPolicy`/`assignments`/`aiToolsFleetStatus`/`aiToolsHuntress` suites pass; the SR5-17 array filter is proven by `aiToolsAuditDetailsSiteScope.integration.test.ts` against real Postgres with RLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)