### PR TITLE
fix(security): owner-bind AI session read/approval + redact transcript secrets (SR5-09/10/16)

### DIFF
--- a/apps/api/migrations/2026-07-11-ai-sessions-read-all-permission.sql
+++ b/apps/api/migrations/2026-07-11-ai-sessions-read-all-permission.sql
@@ -1,0 +1,32 @@
+-- SR5-09: introduce ai_sessions:read_all and grant it to the global Org Admin
+-- system role. This gates the cross-user AI session audit dashboard
+-- (GET /admin/sessions) behind a dedicated capability instead of
+-- organizations:read, which was too broad (any org-read holder could enumerate
+-- every user's AI sessions). Partner Admin keeps access via its *:* grant.
+--
+-- Operates ONLY on the global Org Admin system role row (partner_id IS NULL,
+-- is_system = TRUE). Per-partner cloned Partner Admin rows carry *:* and keep
+-- everything; custom roles are untouched. Idempotent.
+
+-- 1. Ensure the permission catalog row exists exactly once (permissions has no
+--    unique(resource,action), so guard with WHERE NOT EXISTS).
+INSERT INTO permissions (resource, action, description)
+SELECT 'ai_sessions', 'read_all', 'View all users'' AI session history (admin audit dashboard)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM permissions WHERE resource = 'ai_sessions' AND action = 'read_all'
+);
+
+-- 2. Grant it to the global Org Admin system role.
+DO $$
+DECLARE n integer;
+BEGIN
+  INSERT INTO role_permissions (role_id, permission_id)
+  SELECT r.id, p.id
+  FROM roles r
+  CROSS JOIN (SELECT id FROM permissions WHERE resource = 'ai_sessions' AND action = 'read_all' LIMIT 1) p
+  WHERE r.partner_id IS NULL AND r.scope = 'organization'
+    AND r.name = 'Org Admin' AND r.is_system = TRUE
+  ON CONFLICT (role_id, permission_id) DO NOTHING;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RAISE WARNING 'ai-sessions-read-all: granted ai_sessions:read_all to % Org Admin role(s)', n;
+END $$;

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -192,6 +192,10 @@ export const DEFAULT_PERMISSIONS = [
   { resource: 'vulnerabilities', action: 'accept_risk',
     description: 'Waive (accept risk) and reopen vulnerability findings' },
 
+  // AI session audit (SR5-09)
+  { resource: 'ai_sessions', action: 'read_all',
+    description: "View all users' AI session history (admin audit dashboard)" },
+
   // Admin
   { resource: '*', action: '*', description: 'Full administrative access' }
 ];
@@ -273,7 +277,8 @@ export const SYSTEM_ROLES = [
       'topology:read', 'topology:write',
       'remote:access',
       'audit:read',
-      'vulnerabilities:accept_risk'
+      'vulnerabilities:accept_risk',
+      'ai_sessions:read_all'
     ]
   },
   {

--- a/apps/api/src/routes/ai-flagging.test.ts
+++ b/apps/api/src/routes/ai-flagging.test.ts
@@ -153,7 +153,12 @@ describe('AI flagging routes', () => {
     const body = await res.json();
     expect(body.success).toBe(true);
 
-    expect(getSession).toHaveBeenCalledWith(SESSION_ID, expect.any(Object));
+    // Flagging is a moderation action → org-scoped lookup (SR5-09 opt-out).
+    expect(getSession).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.any(Object),
+      expect.objectContaining({ allowAnyOwnerInOrg: true }),
+    );
     expect(mockSet).toHaveBeenCalledWith(
       expect.objectContaining({
         flaggedBy: 'user-1',

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -122,6 +122,14 @@ function generateSessionTitle(content: string): string {
 export const aiRoutes = new Hono();
 const requireAiRead = requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action);
 const requireAiWrite = requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action);
+// SR5-09: reading OTHER users' AI sessions (the admin audit dashboard) is a
+// dedicated, higher-trust capability — NOT organizations:read, which every
+// technician/viewer holds and which for ordinary AI routes only ever returns the
+// caller's OWN sessions. Gated on ai_sessions:read_all (Org Admin + Partner Admin).
+const requireAiSessionsReadAll = requirePermission(
+  PERMISSIONS.AI_SESSIONS_READ_ALL.resource,
+  PERMISSIONS.AI_SESSIONS_READ_ALL.action,
+);
 const requireTicketsWrite = requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action);
 
 aiRoutes.use('*', authMiddleware);
@@ -301,7 +309,9 @@ aiRoutes.post(
     const auth = c.get('auth');
     const sessionId = c.req.param('id')!;
 
-    const session = await getSession(sessionId, auth);
+    // Flagging is a moderation action (paired with the admin-only unflag below),
+    // not an owner-only read — keep its existing org-scoped behavior.
+    const session = await getSession(sessionId, auth, { allowAnyOwnerInOrg: true });
     if (!session) {
       return c.json({ error: 'Session not found' }, 404);
     }
@@ -338,7 +348,9 @@ aiRoutes.delete(
     const auth = c.get('auth');
     const sessionId = c.req.param('id')!;
 
-    const session = await getSession(sessionId, auth);
+    // Admin-only unflag (requireScope partner/system): moderators clear another
+    // user's flag, so this is deliberately org-scoped, not owner-bound.
+    const session = await getSession(sessionId, auth, { allowAnyOwnerInOrg: true });
     if (!session) {
       return c.json({ error: 'Session not found' }, 404);
     }
@@ -1017,11 +1029,15 @@ aiRoutes.put(
   }
 );
 
-// GET /admin/sessions - Get session history for admin dashboard
+// GET /admin/sessions - Get session history for admin dashboard.
+// SR5-09: enumerates other users' sessions (id, userId, title, cost, flags), so
+// it requires ai_sessions:read_all — a stricter gate than the ordinary AI reads.
+// The returned rows are already a projected metadata DTO (getSessionHistory):
+// no systemPrompt, contextSnapshot, sdkSessionId, or raw tool input/output.
 aiRoutes.get(
   '/admin/sessions',
   requireScope('organization', 'partner', 'system'),
-  requireAiRead,
+  requireAiSessionsReadAll,
   async (c) => {
     const auth = c.get('auth');
     const orgId = c.req.query('orgId') || auth.orgId;

--- a/apps/api/src/routes/ai_admin_sessions_permission.test.ts
+++ b/apps/api/src/routes/ai_admin_sessions_permission.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// SR5-09(b): GET /admin/sessions enumerates OTHER users' AI sessions and must be
+// gated on the dedicated ai_sessions:read_all capability — NOT organizations:read
+// (which every technician/viewer holds). This suite uses an ENFORCING
+// requirePermission mock so the gate is actually exercised end-to-end.
+
+type Perm = { resource: string; action: string };
+let currentAuth: any;
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn() },
+}));
+
+vi.mock('../db/schema', () => ({
+  aiSessions: {},
+  aiMessages: {},
+  aiToolExecutions: {},
+  auditLogs: {},
+  aiActionPlans: {},
+  organizations: {},
+  devices: {},
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', currentAuth);
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn((resource: string, action: string) => async (c: any, next: any) => {
+    const perms: Perm[] = c.get('auth')?.permissions ?? [];
+    const ok = perms.some(
+      (p) => (p.resource === resource || p.resource === '*') && (p.action === action || p.action === '*'),
+    );
+    if (!ok) return c.json({ error: 'Forbidden' }, 403);
+    return next();
+  }),
+}));
+
+vi.mock('../services/aiAgent', () => ({
+  createSession: vi.fn(),
+  getSession: vi.fn(),
+  listSessions: vi.fn(),
+  closeSession: vi.fn(),
+  getSessionMessages: vi.fn(),
+  handleApproval: vi.fn(),
+  searchSessions: vi.fn(),
+  listM365Connections: vi.fn(),
+  resolveDefaultModel: vi.fn(() => 'model'),
+}));
+
+vi.mock('../services/aiCostTracker', () => ({
+  getSessionHistory: vi.fn().mockResolvedValue([]),
+  getUsageSummary: vi.fn(),
+  updateBudget: vi.fn(),
+  recordUsage: vi.fn(),
+}));
+
+vi.mock('../services/streamingSessionManager', () => ({
+  streamingSessionManager: { get: vi.fn(), remove: vi.fn(), interrupt: vi.fn() },
+}));
+
+vi.mock('../services/aiAgentSdk', () => ({
+  runPreFlightChecks: vi.fn(),
+  abortActivePlan: vi.fn(),
+}));
+
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../services/effectiveSettings', () => ({ assertNotLocked: vi.fn() }));
+
+import { aiRoutes } from './ai';
+import { getSessionHistory } from '../services/aiCostTracker';
+
+const ORG_ID = 'org-111';
+
+function authWith(permissions: Perm[]) {
+  return {
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    scope: 'organization',
+    partnerId: null,
+    orgId: ORG_ID,
+    accessibleOrgIds: [ORG_ID],
+    permissions,
+    orgCondition: () => undefined,
+    canAccessOrg: (id: string) => id === ORG_ID,
+  };
+}
+
+describe('GET /ai/admin/sessions permission gate (SR5-09)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSessionHistory).mockResolvedValue([]);
+    app = new Hono();
+    app.route('/ai', aiRoutes);
+  });
+
+  it('denies a caller holding only organizations:read (the old, too-broad gate)', async () => {
+    currentAuth = authWith([{ resource: 'organizations', action: 'read' }]);
+
+    const res = await app.request(`/ai/admin/sessions?orgId=${ORG_ID}`, {
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(getSessionHistory).not.toHaveBeenCalled();
+  });
+
+  it('allows a caller holding ai_sessions:read_all', async () => {
+    currentAuth = authWith([{ resource: 'ai_sessions', action: 'read_all' }]);
+
+    const res = await app.request(`/ai/admin/sessions?orgId=${ORG_ID}`, {
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(getSessionHistory).toHaveBeenCalled();
+  });
+
+  it('allows a wildcard (*:*) admin such as Partner Admin', async () => {
+    currentAuth = authWith([{ resource: '*', action: '*' }]);
+
+    const res = await app.request(`/ai/admin/sessions?orgId=${ORG_ID}`, {
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/src/routes/permissionsCatalog.ts
+++ b/apps/api/src/routes/permissionsCatalog.ts
@@ -30,7 +30,8 @@ const RESOURCE_LABELS: Record<string, string> = {
   contracts: 'Contracts',
   sso: 'Single Sign-On',
   topology: 'Network Topology',
-  vulnerabilities: 'Vulnerabilities'
+  vulnerabilities: 'Vulnerabilities',
+  ai_sessions: 'AI Sessions'
 };
 
 const ACTION_LABELS: Record<string, string> = {
@@ -45,7 +46,8 @@ const ACTION_LABELS: Record<string, string> = {
   manage: 'Manage',
   send: 'Send',
   admin: 'Administer',
-  accept_risk: 'Accept Risk'
+  accept_risk: 'Accept Risk',
+  read_all: 'Read All'
 };
 
 // GET /permissions/catalog - Returns the authoritative list of assignable

--- a/apps/api/src/services/aiAgent.authz.test.ts
+++ b/apps/api/src/services/aiAgent.authz.test.ts
@@ -65,7 +65,7 @@ function stubSelectOnce(rows: unknown[]) {
 }
 
 function ownerCondFrom(whereSpy: ReturnType<typeof vi.fn>): Cond | undefined {
-  const arg = whereSpy.mock.calls[0][0] as Cond;
+  const arg = whereSpy.mock.calls[0]![0] as Cond;
   return arg.conds?.find((c) => c.op === 'eq' && c.col === 'aiSessions.userId');
 }
 

--- a/apps/api/src/services/aiAgent.authz.test.ts
+++ b/apps/api/src/services/aiAgent.authz.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Drive getSession / getSessionMessages / handleApproval through the real service
+// logic without a live DB. We mock drizzle's `eq`/`and` to capture the WHERE
+// predicates so we can assert the SR5-09 owner-binding, and drive JS-level
+// branches (SR5-10 owner assertion in handleApproval) via mocked query results.
+
+const selectMock = vi.fn();
+const updateMock = vi.fn();
+
+vi.mock('../db', () => ({
+  db: {
+    select: (...a: unknown[]) => selectMock(...a),
+    update: (...a: unknown[]) => updateMock(...a),
+  },
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+
+vi.mock('../db/schema', () => ({
+  aiSessions: {
+    id: 'aiSessions.id',
+    orgId: 'aiSessions.orgId',
+    userId: 'aiSessions.userId',
+    status: 'aiSessions.status',
+    lastActivityAt: 'aiSessions.lastActivityAt',
+    createdAt: 'aiSessions.createdAt',
+  },
+  aiMessages: { sessionId: 'aiMessages.sessionId', createdAt: 'aiMessages.createdAt' },
+  aiToolExecutions: {
+    id: 'aiToolExecutions.id',
+    status: 'aiToolExecutions.status',
+    sessionId: 'aiToolExecutions.sessionId',
+  },
+  delegantM365Connections: {},
+  devices: {},
+}));
+
+// Capture-friendly drizzle predicate builders.
+vi.mock('drizzle-orm', () => ({
+  eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
+  and: (...conds: unknown[]) => ({ op: 'and', conds }),
+  desc: (col: unknown) => ({ op: 'desc', col }),
+  sql: Object.assign((..._a: unknown[]) => ({ op: 'sql' }), {}),
+}));
+
+vi.mock('./aiAgentSystemPrompt', () => ({ AI_SYSTEM_PROMPT_BASE: 'base' }));
+vi.mock('./brainDeviceContext', () => ({ getActiveDeviceContext: vi.fn() }));
+vi.mock('./aiInputSanitizer', () => ({ sanitizePageContext: (x: unknown) => x }));
+
+import { getSession, getSessionMessages, handleApproval } from './aiAgent';
+
+type Cond = { op: string; col?: unknown; val?: unknown; conds?: Cond[] };
+
+const auth = (userId: string): any => ({
+  user: { id: userId },
+  orgId: 'org-1',
+  orgCondition: () => undefined, // no org filter in these unit tests
+});
+
+/** Mock a single `select().from().where().limit()` chain returning `rows`; returns the where spy. */
+function stubSelectOnce(rows: unknown[]) {
+  const whereSpy = vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) });
+  selectMock.mockReturnValueOnce({ from: vi.fn().mockReturnValue({ where: whereSpy }) });
+  return whereSpy;
+}
+
+function ownerCondFrom(whereSpy: ReturnType<typeof vi.fn>): Cond | undefined {
+  const arg = whereSpy.mock.calls[0][0] as Cond;
+  return arg.conds?.find((c) => c.op === 'eq' && c.col === 'aiSessions.userId');
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('getSession owner-binding (SR5-09)', () => {
+  it('binds the query to the caller as owner by default', async () => {
+    const whereSpy = stubSelectOnce([{ id: 's1', orgId: 'org-1', userId: 'user-1' }]);
+
+    await getSession('s1', auth('user-1'));
+
+    const ownerCond = ownerCondFrom(whereSpy);
+    expect(ownerCond).toBeDefined();
+    expect(ownerCond?.val).toBe('user-1');
+  });
+
+  it('omits the owner predicate only when allowAnyOwnerInOrg is set (admin/internal)', async () => {
+    const whereSpy = stubSelectOnce([{ id: 's1', orgId: 'org-1', userId: 'someone-else' }]);
+
+    await getSession('s1', auth('admin-1'), { allowAnyOwnerInOrg: true });
+
+    expect(ownerCondFrom(whereSpy)).toBeUndefined();
+  });
+});
+
+describe('getSessionMessages (SR5-09)', () => {
+  it('returns null for a non-owner (owner-scoped lookup finds nothing) and never reads messages', async () => {
+    stubSelectOnce([]); // getSession: owner predicate filters the row out
+
+    const result = await getSessionMessages('s1', auth('peer-user'));
+
+    expect(result).toBeNull();
+    // messages query must NOT run once the session lookup fails
+    expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns session + messages for the owner', async () => {
+    stubSelectOnce([{ id: 's1', orgId: 'org-1', userId: 'user-1' }]); // getSession
+    // messages: select().from().where().orderBy()
+    selectMock.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockResolvedValue([{ id: 'm1', content: 'hi' }]),
+        }),
+      }),
+    });
+
+    const result = await getSessionMessages('s1', auth('user-1'));
+
+    expect(result?.session.id).toBe('s1');
+    expect(result?.messages).toHaveLength(1);
+  });
+});
+
+describe('handleApproval owner-binding (SR5-10)', () => {
+  function stubExecutionThenSession(execution: unknown, session: unknown) {
+    stubSelectOnce([execution]); // execution lookup
+    stubSelectOnce([session]); // getSession internal (org-scoped)
+  }
+
+  it('rejects approval by a non-owner and does not mutate the execution', async () => {
+    stubExecutionThenSession(
+      { id: 'exec-1', status: 'pending', sessionId: 's1' },
+      { id: 's1', orgId: 'org-1', userId: 'victim' },
+    );
+    const setSpy = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    updateMock.mockReturnValue({ set: setSpy });
+
+    const ok = await handleApproval('exec-1', true, auth('attacker'), 's1');
+
+    expect(ok).toBe(false);
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('allows the session owner to approve and records approvedBy', async () => {
+    stubExecutionThenSession(
+      { id: 'exec-1', status: 'pending', sessionId: 's1' },
+      { id: 's1', orgId: 'org-1', userId: 'victim' },
+    );
+    const setSpy = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    updateMock.mockReturnValue({ set: setSpy });
+
+    const ok = await handleApproval('exec-1', true, auth('victim'), 's1');
+
+    expect(ok).toBe(true);
+    expect(setSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'approved', approvedBy: 'victim' }),
+    );
+  });
+});

--- a/apps/api/src/services/aiAgent.ts
+++ b/apps/api/src/services/aiAgent.ts
@@ -159,10 +159,33 @@ export async function createSession(
   return { id: session.id, orgId, delegantM365ConnectionId };
 }
 
-export async function getSession(sessionId: string, auth: AuthContext) {
+/**
+ * Load a single session for the caller.
+ *
+ * OWNER-BOUND by default (SR5-09): the row must belong to `auth.user.id`, not
+ * merely to an org the caller can reach. The session transcript (systemPrompt,
+ * contextSnapshot, sdkSessionId, raw message content) is private to the user who
+ * created it; an org peer with organizations:read must NOT be able to load
+ * another user's session via `GET /sessions/:id`, its messages, or any
+ * owner-driven mutation route (title/close/interrupt/pause/approve/plan/ticket).
+ * The org condition is still applied underneath as defense-in-depth.
+ *
+ * `allowAnyOwnerInOrg: true` relaxes the owner check to an org-only lookup. It is
+ * ONLY for genuine admin/moderation routes (unflag) and internal callers that
+ * re-assert authorization themselves (`handleApproval`, which independently
+ * asserts owner for SR5-10). Never pass it from an ordinary user-facing route.
+ */
+export async function getSession(
+  sessionId: string,
+  auth: AuthContext,
+  options: { allowAnyOwnerInOrg?: boolean } = {},
+) {
   const conditions = [eq(aiSessions.id, sessionId)];
   const orgCondition = auth.orgCondition(aiSessions.orgId);
   if (orgCondition) conditions.push(orgCondition);
+  if (!options.allowAnyOwnerInOrg) {
+    conditions.push(eq(aiSessions.userId, auth.user.id));
+  }
 
   const [session] = await db
     .select()
@@ -367,9 +390,29 @@ export async function handleApproval(
     return false;
   }
 
-  // Verify the session belongs to the user's org
-  const session = await getSession(execution.sessionId, auth);
+  // Internal org-scoped lookup (owner is asserted explicitly below, so this must
+  // NOT owner-bind — otherwise a valid owner-check couldn't read session.userId).
+  const session = await getSession(execution.sessionId, auth, { allowAnyOwnerInOrg: true });
   if (!session) return false;
+
+  // SR5-10 (SECURITY-CRITICAL): the approver MUST be the session owner. Approving
+  // resumes the paused tool under the ORIGINAL (queuing user's) session
+  // authorization; letting an org peer approve would execute a privileged action
+  // the victim queued, laundering it through the victim's grants/MFA/site scope.
+  // Owner-only is the minimal correct rule (a designated-approver model would
+  // have to independently re-satisfy the pending action's constraints).
+  if (session.userId !== auth.user.id) {
+    console.warn(
+      '[AI] Cross-user approval denied:',
+      JSON.stringify({
+        executionId,
+        sessionId: execution.sessionId,
+        sessionOwnerId: session.userId,
+        actorId: auth.user.id,
+      }),
+    );
+    return false;
+  }
 
   await db
     .update(aiToolExecutions)

--- a/apps/api/src/services/aiToolOutput.test.ts
+++ b/apps/api/src/services/aiToolOutput.test.ts
@@ -1,5 +1,59 @@
 import { describe, expect, it } from 'vitest';
-import { compactToolResultForChat } from './aiToolOutput';
+import { compactToolResultForChat, redactSensitiveToolInput } from './aiToolOutput';
+
+// SR5-16: tool_input is persisted UNCONDITIONALLY to the transcript (even for
+// denied calls). Sensitive keys must be masked at that chokepoint.
+describe('redactSensitiveToolInput', () => {
+  const REDACTED = '[REDACTED]';
+
+  it('masks known-sensitive keys (accessKey/secretKey/password/token/apiKey/clientSecret/privateKey/connectionString)', () => {
+    const out = redactSensitiveToolInput({
+      accessKey: 'AKIAIOSFODNN7EXAMPLE',
+      secretKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      password: 'hunter2',
+      token: 'ghp_abcdefghijklmnopqrstuvwxyz0123456789',
+      apiKey: 'sk-ant-super-secret',
+      clientSecret: 'cs-value',
+      privateKey: '-----BEGIN PRIVATE KEY-----',
+      connectionString: 'Server=db;Password=p;',
+    });
+
+    for (const key of Object.keys(out)) {
+      expect(out[key]).toBe(REDACTED);
+    }
+  });
+
+  it('masks sensitive keys nested inside providerConfig (manage_backup_configs shape)', () => {
+    const out = redactSensitiveToolInput({
+      provider: 's3',
+      providerConfig: {
+        region: 'us-east-1',
+        bucket: 'backups',
+        accessKey: 'AKIA...',
+        secretKey: 'super-secret',
+      },
+    });
+
+    const cfg = out.providerConfig as Record<string, unknown>;
+    // Non-sensitive fields survive so the transcript stays useful.
+    expect(cfg.region).toBe('us-east-1');
+    expect(cfg.bucket).toBe('backups');
+    // Secrets are masked.
+    expect(cfg.accessKey).toBe(REDACTED);
+    expect(cfg.secretKey).toBe(REDACTED);
+    expect(out.provider).toBe('s3');
+  });
+
+  it('leaves inputs with no sensitive keys untouched', () => {
+    const input = { deviceId: 'dev-1', command: 'restart', count: 3, enabled: true };
+    expect(redactSensitiveToolInput(input)).toEqual(input);
+  });
+
+  it('scrubs inline secret assignments embedded in string values', () => {
+    const out = redactSensitiveToolInput({ note: 'use password=hunter2 to connect' });
+    expect(out.note).not.toContain('hunter2');
+  });
+});
 
 describe('compactToolResultForChat', () => {
   it('returns compact JSON preview for oversized non-JSON output', () => {

--- a/apps/api/src/services/aiToolOutput.ts
+++ b/apps/api/src/services/aiToolOutput.ts
@@ -60,6 +60,27 @@ export function redactAiToolOutputText(value: string): string {
   );
 }
 
+/**
+ * Deep-redact known-sensitive keys from a tool-call INPUT before it is persisted
+ * to `ai_messages.tool_input` (SR5-16).
+ *
+ * Tool schemas invite plaintext secrets — e.g. `manage_backup_configs`
+ * `providerConfig.accessKey` / `secretKey` — and the streaming manager persists
+ * `block.input` UNCONDITIONALLY, even for a call the user later denies. That put
+ * cleartext credentials in the transcript, readable by anyone who could load the
+ * session. This is the single chokepoint that keeps them out: it runs
+ * `redactLogFields` (the shared deep key-based redactor — masks values for keys
+ * matching password/token/secret/*key/clientSecret/connectionString/… and also
+ * scrubs inline `key=value` secrets in string leaves) over EVERY tool's input as
+ * defense-in-depth, rather than relying on per-tool allow/deny lists.
+ */
+export function redactSensitiveToolInput(
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  const redacted = redactLogFields(input);
+  return isRecord(redacted) ? redacted : {};
+}
+
 function clampInteger(value: unknown, defaultValue: number, min: number, max: number): number {
   const num = Number(value);
   if (!Number.isFinite(num)) return defaultValue;

--- a/apps/api/src/services/logRedaction.ts
+++ b/apps/api/src/services/logRedaction.ts
@@ -1,6 +1,6 @@
 const REDACTED = '[REDACTED]';
 
-const SECRET_KEY_PATTERN = /password|passwd|pwd|token|secret|api.*key|access.*key|private.*key|client.*secret|authorization|cookie|session|credential|community|authpassphrase|privacypassphrase/i;
+const SECRET_KEY_PATTERN = /password|passwd|pwd|token|secret|api.*key|access.*key|private.*key|client.*secret|authorization|cookie|session|credential|community|authpassphrase|privacypassphrase|connection.?string|conn.?string|sas.?token|shared.?key/i;
 
 const SECRET_ASSIGNMENT_PATTERNS: RegExp[] = [
   /\b(authorization\s*:\s*bearer\s+)[^\s,;]+/gi,

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -27,7 +27,7 @@ import { createBreezeMcpServer, BREEZE_MCP_TOOL_NAMES } from './aiAgentSdkTools'
 import { createSessionPreToolUse, createSessionPostToolUse } from './aiAgentSdk';
 import type { RequestLike } from './auditEvents';
 import { getTrustedClientIpOrUndefined } from './clientIp';
-import { redactAiToolOutputText } from './aiToolOutput';
+import { redactAiToolOutputText, redactSensitiveToolInput } from './aiToolOutput';
 import { isRecognizedSelfHostSignal } from '../config/env';
 
 const SESSION_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2h idle eviction (aligned with pre-flight check)
@@ -684,7 +684,15 @@ export class StreamingSessionManager {
                     sessionId: session.breezeSessionId,
                     role: 'assistant',
                     content: assistantContent || null,
-                    contentBlocks: message.message.content as unknown as Record<string, unknown>[],
+                    // SR5-16: the assistant content blocks embed each tool_use's
+                    // raw `input`, so redact those here too — otherwise the same
+                    // plaintext secret persisted below in `tool_input` would still
+                    // land here in cleartext.
+                    contentBlocks: message.message.content.map((b) =>
+                      b.type === 'tool_use'
+                        ? { ...b, input: redactSensitiveToolInput(b.input as Record<string, unknown>) }
+                        : b,
+                    ) as unknown as Record<string, unknown>[],
                     inputTokens: message.message.usage?.input_tokens ?? 0,
                     outputTokens: message.message.usage?.output_tokens ?? 0,
                   })
@@ -708,7 +716,11 @@ export class StreamingSessionManager {
                         sessionId: session.breezeSessionId,
                         role: 'tool_use',
                         toolName: bareName,
-                        toolInput: block.input as Record<string, unknown>,
+                        // SR5-16: mask known-sensitive keys (accessKey, secretKey,
+                        // password, token, apiKey, clientSecret, privateKey,
+                        // connectionString, …) before persisting. Unconditional —
+                        // this runs even for tool calls the user later denies.
+                        toolInput: redactSensitiveToolInput(block.input as Record<string, unknown>),
                         toolUseId: block.id,
                       })
                   );

--- a/packages/shared/src/constants/permissions.ts
+++ b/packages/shared/src/constants/permissions.ts
@@ -113,6 +113,12 @@ export const PERMISSION_GRANTS = {
   // cannot unilaterally waive a critical/KEV finding.
   VULN_RISK_ACCEPT: { resource: 'vulnerabilities', action: 'accept_risk' },
 
+  // AI session audit (SR5-09) — read OTHER users' AI session history via the
+  // admin dashboard. A dedicated, higher-trust capability: ordinary AI reads use
+  // organizations:read and only ever return the caller's OWN sessions, so the
+  // cross-user admin/audit surface must NOT be gated on organizations:read.
+  AI_SESSIONS_READ_ALL: { resource: 'ai_sessions', action: 'read_all' },
+
   // Admin
   ADMIN_ALL: { resource: '*', action: '*' },
 } as const;


### PR DESCRIPTION
Three fixes to the AI session/approval/transcript paths.

**Findings:**
- **SR5-09** cross-user transcript read: `getSession` is now owner-bound by default (`userId === caller`), with an explicit `allowAnyOwnerInOrg` opt-out for audited internal callers. The admin session-list route moves off `organizations.read` to a new `ai_sessions:read_all` permission (registered in shared constants + seed + a migration), and returns a projected metadata DTO.
- **SR5-10** cross-user approval: tool-call and plan approval now assert the approver is the session owner before mutating/resuming (previously any org peer with write+MFA could approve another user's pending Tier-3 action, which then executed under the victim's authorization).
- **SR5-16** secret persistence: sensitive keys (accessKey/secretKey/password/token/connectionString/…) are redacted from `tool_input` and embedded content-block inputs at the persistence chokepoint — unconditionally, so denied tool calls are covered too.

**Product decision to confirm:** Partner Technician/Viewer roles (which hold `organizations.read`) lose access to the cross-user AI audit dashboard under the tightened permission — intended, but may need a role-grant / nav decision.

**Verification:** `tsc` clean; new `aiAgent.authz.test.ts` / `ai_admin_sessions_permission.test.ts` / `aiToolOutput.test.ts` + existing `aiAgentSdk`/`streamingSessionManager.security`/`ai-flagging`/`seed` suites pass; migration-ordering test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)