### PR TITLE
fix(security): re-tier AI filesystem read/list as privileged + agent path containment (SR5-01)

### DIFF
--- a/agent/internal/remote/tools/fileops.go
+++ b/agent/internal/remote/tools/fileops.go
@@ -72,6 +72,112 @@ func isDeniedSystemPath(cleanPath string) bool {
 	return false
 }
 
+// sensitiveReadPatterns are lowercased, forward-slash-normalized path fragments
+// for credential/secret stores that must never be exfiltrated via a file read or
+// directory list. This is a defense-in-depth deny-list (SR5-01): the primary
+// gate is the API re-tiering that forces devices.execute + Tier-3 approval, but
+// the agent runs as root/LocalSystem and must not blindly trust the path it is
+// handed. Matched at a path-component boundary (see matchesPathFragment) so e.g.
+// ".../config/system" does not spuriously match ".../config/systemprofile".
+var sensitiveReadPatterns = []string{
+	// Unix / Linux credential + secret stores
+	"/etc/shadow",
+	"/etc/gshadow",
+	"/etc/sudoers",
+	"/etc/sudoers.d",
+	"/etc/ssl/private",
+	// macOS shadow-equivalent
+	"/private/etc/master.passwd",
+	"/etc/master.passwd",
+	// Windows registry credential hives
+	"/windows/system32/config/sam",
+	"/windows/system32/config/security",
+	"/windows/system32/config/system",
+	"/windows/ntds/ntds.dit",
+}
+
+// sensitiveReadBasenames are lowercased filenames that are credential stores
+// regardless of directory (browser password databases, etc.).
+var sensitiveReadBasenames = map[string]bool{
+	"login data":     true, // Chrome / Edge / Brave / Chromium
+	"key4.db":        true, // Firefox NSS key DB
+	"logins.json":    true, // Firefox saved logins
+	"signons.sqlite": true, // legacy Firefox logins
+	"cookies.sqlite": true, // Firefox cookies (session theft)
+}
+
+// matchesPathFragment reports whether frag occurs in norm at a path-component
+// boundary: as an exact match, a trailing component, or an interior directory.
+func matchesPathFragment(norm, frag string) bool {
+	return norm == frag ||
+		strings.HasSuffix(norm, frag) ||
+		strings.Contains(norm, frag+"/")
+}
+
+// isSensitiveReadPath reports whether reading/listing the given path would expose
+// a well-known secret store. The comparison is OS-agnostic (backslashes are
+// normalized to forward slashes and case is folded), so a Windows target checked
+// on a Unix host still matches.
+func isSensitiveReadPath(p string) bool {
+	// Normalize backslashes explicitly: filepath.ToSlash is a no-op on Unix, but
+	// the agent may be asked to read a Windows path (or a Windows path may reach
+	// a Unix test host), so fold both separators unconditionally.
+	norm := strings.ToLower(strings.ReplaceAll(p, "\\", "/"))
+
+	for _, frag := range sensitiveReadPatterns {
+		if matchesPathFragment(norm, frag) {
+			return true
+		}
+	}
+
+	base := norm
+	if i := strings.LastIndex(norm, "/"); i >= 0 {
+		base = norm[i+1:]
+	}
+	if sensitiveReadBasenames[base] {
+		return true
+	}
+
+	// SSH private keys: any file under a .ssh directory whose name looks like a
+	// private key (id_*, identity) and is not the public half (*.pub).
+	if strings.Contains(norm, "/.ssh/") {
+		if base == "identity" || base == "authorized_keys" {
+			return true
+		}
+		if strings.HasPrefix(base, "id_") && !strings.HasSuffix(base, ".pub") {
+			return true
+		}
+	}
+
+	// macOS keychains
+	if strings.Contains(norm, "/library/keychains/") ||
+		strings.HasSuffix(base, ".keychain") ||
+		strings.HasSuffix(base, ".keychain-db") {
+		return true
+	}
+
+	return false
+}
+
+// enforceReadContainment blocks reads/lists of obviously-sensitive credential
+// stores. Symlinks are resolved first (filepath.EvalSymlinks) so a symlink whose
+// own name is innocuous cannot be used to escape the deny-list. Both the literal
+// path and the resolved path are checked.
+func enforceReadContainment(cleanPath string) error {
+	if isSensitiveReadPath(cleanPath) {
+		return fmt.Errorf("read denied on sensitive path: %s", cleanPath)
+	}
+	// EvalSymlinks requires the target to exist; if it can't be resolved the
+	// literal check above already ran, and the subsequent os.Stat/Open will
+	// surface any not-exist error.
+	if resolved, err := filepath.EvalSymlinks(cleanPath); err == nil && resolved != cleanPath {
+		if isSensitiveReadPath(resolved) {
+			return fmt.Errorf("read denied on sensitive path (via symlink): %s", cleanPath)
+		}
+	}
+	return nil
+}
+
 // ListDrives enumerates available drives/mount points.
 func ListDrives(_ map[string]any) CommandResult {
 	return listDrivesOS(time.Now())
@@ -93,6 +199,11 @@ func ListFiles(payload map[string]any) CommandResult {
 
 	// Normalize path separators
 	cleanPath := filepath.Clean(path)
+
+	// Defense-in-depth: never enumerate a credential store directory (SR5-01).
+	if err := enforceReadContainment(cleanPath); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
 
 	limit := GetPayloadInt(payload, "limit", defaultFileListLimit)
 	if limit < 1 {
@@ -164,6 +275,11 @@ func ReadFile(payload map[string]any) CommandResult {
 
 	// Normalize path separators
 	cleanPath := filepath.Clean(path)
+
+	// Defense-in-depth: never read a credential store, even symlinked (SR5-01).
+	if err := enforceReadContainment(cleanPath); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
 
 	// Check file info first
 	info, err := os.Stat(cleanPath)

--- a/agent/internal/remote/tools/fileops_containment_test.go
+++ b/agent/internal/remote/tools/fileops_containment_test.go
@@ -1,0 +1,189 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestIsSensitiveReadPath exercises the OS-agnostic deny-list matching for
+// credential/secret stores (SR5-01 defense-in-depth). Windows-style paths are
+// checked on any host because matching normalizes separators and case.
+func TestIsSensitiveReadPath(t *testing.T) {
+	cases := []struct {
+		name      string
+		path      string
+		sensitive bool
+	}{
+		// Unix secrets
+		{"etc shadow", "/etc/shadow", true},
+		{"etc shadow backup exact", "/etc/gshadow", true},
+		{"etc sudoers", "/etc/sudoers", true},
+		{"etc sudoers.d entry", "/etc/sudoers.d/90-breeze", true},
+		{"etc ssl private key", "/etc/ssl/private/server.key", true},
+		{"macos master.passwd", "/private/etc/master.passwd", true},
+		// SSH private keys
+		{"user ssh id_rsa", "/home/alice/.ssh/id_rsa", true},
+		{"user ssh id_ed25519", "/home/alice/.ssh/id_ed25519", true},
+		{"root ssh identity", "/root/.ssh/identity", true},
+		{"ssh authorized_keys", "/home/alice/.ssh/authorized_keys", true},
+		// Windows registry hives (checked on any OS)
+		{"windows SAM hive", `C:\Windows\System32\config\SAM`, true},
+		{"windows SECURITY hive", `C:\Windows\System32\config\SECURITY`, true},
+		{"windows SYSTEM hive", `C:\Windows\System32\config\SYSTEM`, true},
+		{"windows NTDS", `C:\Windows\NTDS\ntds.dit`, true},
+		// Browser credential stores (basename match)
+		{"chrome login data", `C:\Users\bob\AppData\Local\Google\Chrome\User Data\Default\Login Data`, true},
+		{"firefox logins", "/home/alice/.mozilla/firefox/abc.default/logins.json", true},
+		{"firefox key4", "/home/alice/.mozilla/firefox/abc.default/key4.db", true},
+		// macOS keychain
+		{"login keychain", "/Users/alice/Library/Keychains/login.keychain-db", true},
+
+		// Benign paths that MUST still be readable
+		{"public ssh key", "/home/alice/.ssh/id_rsa.pub", false},
+		{"config systemprofile not hive", `C:\Windows\System32\config\systemprofile\NTUSER.DAT`, false},
+		{"regular home file", "/home/alice/notes.txt", false},
+		{"regular etc file", "/etc/hosts", false},
+		{"tmp log", "/tmp/breeze.log", false},
+		{"program files exe", `C:\Program Files\App\app.exe`, false},
+		{"user document", `C:\Users\bob\Documents\report.docx`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSensitiveReadPath(tc.path); got != tc.sensitive {
+				t.Fatalf("isSensitiveReadPath(%q) = %v, want %v", tc.path, got, tc.sensitive)
+			}
+		})
+	}
+}
+
+// TestEnforceReadContainmentSymlinkEscape proves that a symlink whose own name
+// is innocuous cannot be used to read a sensitive target: EvalSymlinks resolves
+// the link before the deny-list check.
+func TestEnforceReadContainmentSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is unreliable without privilege on Windows CI")
+	}
+
+	dir := t.TempDir()
+
+	// Build a fake sensitive target: <tmp>/etc/shadow (matches the deny-list at
+	// a component boundary via HasSuffix "/etc/shadow").
+	etcDir := filepath.Join(dir, "etc")
+	if err := os.MkdirAll(etcDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	shadow := filepath.Join(etcDir, "shadow")
+	if err := os.WriteFile(shadow, []byte("root:$6$secret"), 0o600); err != nil {
+		t.Fatalf("write shadow: %v", err)
+	}
+
+	// Innocuous-looking symlink pointing at the sensitive target.
+	link := filepath.Join(dir, "innocent.txt")
+	if err := os.Symlink(shadow, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := enforceReadContainment(filepath.Clean(link)); err == nil {
+		t.Fatal("expected symlink to sensitive target to be denied, got nil")
+	} else if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink-specific denial, got: %v", err)
+	}
+
+	// A symlink to a benign file must still be readable.
+	benign := filepath.Join(dir, "data.txt")
+	if err := os.WriteFile(benign, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write benign: %v", err)
+	}
+	benignLink := filepath.Join(dir, "shortcut.txt")
+	if err := os.Symlink(benign, benignLink); err != nil {
+		t.Fatalf("symlink benign: %v", err)
+	}
+	if err := enforceReadContainment(filepath.Clean(benignLink)); err != nil {
+		t.Fatalf("benign symlink should be allowed, got: %v", err)
+	}
+}
+
+// TestReadFileDeniesSensitivePath verifies the containment is wired into the
+// ReadFile entry point (not just the helper), including the symlink path.
+func TestReadFileDeniesSensitivePath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is unreliable without privilege on Windows CI")
+	}
+
+	dir := t.TempDir()
+	etcDir := filepath.Join(dir, "etc")
+	if err := os.MkdirAll(etcDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	shadow := filepath.Join(etcDir, "shadow")
+	if err := os.WriteFile(shadow, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Direct read of the sensitive target is denied.
+	res := ReadFile(map[string]any{"path": shadow})
+	if res.Status == "completed" {
+		t.Fatal("expected direct read of sensitive path to fail")
+	}
+	if !strings.Contains(res.Error, "sensitive path") {
+		t.Fatalf("expected sensitive-path error, got: %q", res.Error)
+	}
+
+	// Symlink-laundered read is denied too.
+	link := filepath.Join(dir, "notes.txt")
+	if err := os.Symlink(shadow, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	res = ReadFile(map[string]any{"path": link})
+	if res.Status == "completed" {
+		t.Fatal("expected symlinked read of sensitive path to fail")
+	}
+	if !strings.Contains(res.Error, "sensitive path") {
+		t.Fatalf("expected sensitive-path error for symlink, got: %q", res.Error)
+	}
+
+	// A normal file still reads fine.
+	normal := filepath.Join(dir, "readme.txt")
+	if err := os.WriteFile(normal, []byte("hello world"), 0o644); err != nil {
+		t.Fatalf("write normal: %v", err)
+	}
+	res = ReadFile(map[string]any{"path": normal})
+	if res.Status != "completed" {
+		t.Fatalf("expected normal read to succeed, got error: %q", res.Error)
+	}
+}
+
+// TestListFilesDeniesSensitiveDir ensures directory enumeration of a credential
+// store is blocked.
+func TestListFilesDeniesSensitiveDir(t *testing.T) {
+	dir := t.TempDir()
+	sslPriv := filepath.Join(dir, "etc", "ssl", "private")
+	if err := os.MkdirAll(sslPriv, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sslPriv, "server.key"), []byte("key"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	res := ListFiles(map[string]any{"path": sslPriv})
+	if res.Status == "completed" {
+		t.Fatal("expected listing of /etc/ssl/private to be denied")
+	}
+	if !strings.Contains(res.Error, "sensitive path") {
+		t.Fatalf("expected sensitive-path error, got: %q", res.Error)
+	}
+
+	// A normal directory lists fine.
+	normalDir := filepath.Join(dir, "docs")
+	if err := os.MkdirAll(normalDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	res = ListFiles(map[string]any{"path": normalDir})
+	if res.Status != "completed" {
+		t.Fatalf("expected normal dir listing to succeed, got: %q", res.Error)
+	}
+}

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -1145,7 +1145,7 @@ export function createBreezeMcpServer(
 
     tool(
       'file_operations',
-      'Perform file operations on a device. Read/list are safe; write/delete require approval.',
+      'Perform file operations on a device. All actions (read, list, write, delete, mkdir, rename) require approval because the agent reads/writes as root/LocalSystem.',
       {
         deviceId: uuid,
         action: z.enum(['list', 'read', 'write', 'delete', 'mkdir', 'rename']),

--- a/apps/api/src/services/aiGuardrails.test.ts
+++ b/apps/api/src/services/aiGuardrails.test.ts
@@ -22,6 +22,8 @@ vi.mock('./aiTools', () => ({
       // Non-fleet tools for baseline tests
       query_devices: 1,
       query_change_log: 1,
+      // file_operations base tier 1; guardrails escalate every action to Tier 3 (SR5-01)
+      file_operations: 1,
       execute_command: 3,
       run_backup_verification: 2,
       // Ticketing tools
@@ -465,5 +467,79 @@ describe('checkToolPermission — action-multiplexed tools require action arg', 
     const result = await checkToolPermission('query_devices', {}, auth);
 
     expect(result).toBeNull();
+  });
+});
+
+// ─── SR5-01: filesystem read/list are privileged (execute + Tier 3) ─────
+
+describe('checkGuardrails — file_operations read/list escalate to Tier 3 (SR5-01)', () => {
+  it('read and list require interactive approval, not auto-execute', () => {
+    for (const action of ['read', 'list']) {
+      const result = checkGuardrails('file_operations', { action, path: '/etc/shadow' });
+      expect(result.tier).toBe(3);
+      expect(result.allowed).toBe(true);
+      expect(result.requiresApproval).toBe(true);
+    }
+  });
+
+  it('write/delete/mkdir/rename remain Tier 3', () => {
+    for (const action of ['write', 'delete', 'mkdir', 'rename']) {
+      const result = checkGuardrails('file_operations', { action, path: '/tmp/x' });
+      expect(result.tier).toBe(3);
+      expect(result.requiresApproval).toBe(true);
+    }
+  });
+});
+
+describe('checkToolPermission — file_operations requires devices.execute (SR5-01)', () => {
+  const auth = {
+    user: { id: 'user-1' },
+    token: { roleId: 'viewer', scope: 'organization' },
+    orgId: 'org-1',
+    partnerId: null,
+  } as any;
+
+  beforeEach(() => {
+    vi.mocked(hasPermission).mockClear();
+    vi.mocked(getUserPermissions).mockClear();
+  });
+
+  it('read is denied for a devices.read-only role (no longer maps to devices.read)', async () => {
+    vi.mocked(getUserPermissions).mockResolvedValue({ roleId: 'viewer' } as any);
+    // Role has devices.read but NOT devices.execute.
+    vi.mocked(hasPermission).mockImplementation((_perms, resource, action) =>
+      resource === 'devices' && action === 'read'
+    );
+
+    const result = await checkToolPermission('file_operations', { action: 'read', path: '/etc/shadow' }, auth);
+
+    expect(result).toBe('Insufficient permissions: requires devices.execute');
+    expect(hasPermission).toHaveBeenCalledWith(expect.anything(), 'devices', 'execute');
+    // Must NOT have been satisfied by devices.read.
+    expect(hasPermission).not.toHaveBeenCalledWith(expect.anything(), 'devices', 'read');
+  });
+
+  it('list is likewise gated on devices.execute', async () => {
+    vi.mocked(getUserPermissions).mockResolvedValue({ roleId: 'viewer' } as any);
+    vi.mocked(hasPermission).mockImplementation((_perms, resource, action) =>
+      resource === 'devices' && action === 'read'
+    );
+
+    const result = await checkToolPermission('file_operations', { action: 'list', path: '/root' }, auth);
+
+    expect(result).toBe('Insufficient permissions: requires devices.execute');
+    expect(hasPermission).toHaveBeenCalledWith(expect.anything(), 'devices', 'execute');
+  });
+
+  it('read is allowed when the role holds devices.execute', async () => {
+    vi.mocked(getUserPermissions).mockResolvedValue({ roleId: 'operator' } as any);
+    vi.mocked(hasPermission).mockImplementation((_perms, resource, action) =>
+      resource === 'devices' && action === 'execute'
+    );
+
+    const result = await checkToolPermission('file_operations', { action: 'read', path: '/etc/hosts' }, auth);
+
+    expect(result).toBeNull();
+    expect(hasPermission).toHaveBeenCalledWith(expect.anything(), 'devices', 'execute');
   });
 });

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -70,7 +70,11 @@ const TIER1_ACTIONS: Record<string, string[]> = {
 
 // Mutations that require approval (Tier 3) even if the tool is registered as Tier 1
 const TIER3_ACTIONS: Record<string, string[]> = {
-  file_operations: ['write', 'delete', 'mkdir', 'rename'],
+  // SR5-01: filesystem READ/LIST are privileged. The endpoint agent runs as
+  // root/LocalSystem and does not restrict reads to an approved root, so an
+  // unapproved read can exfiltrate any file (/etc/shadow, SAM hive, SSH keys).
+  // Require interactive approval (Tier 3) for read/list, same as the mutations.
+  file_operations: ['read', 'list', 'write', 'delete', 'mkdir', 'rename'],
   manage_services: ['start', 'stop', 'restart'],
   security_scan: ['quarantine', 'remove', 'restore'],
   disk_cleanup: ['execute'],
@@ -215,8 +219,10 @@ export const TOOL_PERMISSIONS: Record<string, { resource: string; action: string
     execute: { resource: 'devices', action: 'execute' },
   },
   file_operations: {
-    list: { resource: 'devices', action: 'read' },
-    read: { resource: 'devices', action: 'read' },
+    // SR5-01: read/list require devices.execute (not devices.read). Reading an
+    // arbitrary file off a root/LocalSystem agent is a privileged operation.
+    list: { resource: 'devices', action: 'execute' },
+    read: { resource: 'devices', action: 'execute' },
     write: { resource: 'devices', action: 'execute' },
     delete: { resource: 'devices', action: 'execute' },
     mkdir: { resource: 'devices', action: 'execute' },

--- a/apps/api/src/services/aiToolsFilesystem.ts
+++ b/apps/api/src/services/aiToolsFilesystem.ts
@@ -2,7 +2,9 @@
  * AI Filesystem Tools
  *
  * Tools for file operations and disk usage analysis.
- * - file_operations (Tier 1 read/list, Tier 3 write/delete): Perform file operations on a device
+ * - file_operations (all actions Tier 3): Perform file operations on a device.
+ *   Reads run as root/LocalSystem on the endpoint, so read/list are privileged
+ *   (require devices.execute + approval), same as write/delete (SR5-01).
  * - analyze_disk_usage (Tier 1): Analyze filesystem usage for a device
  * - disk_cleanup (Tier 1 preview, Tier 3 execute): Preview or execute disk cleanup
  */
@@ -52,15 +54,15 @@ export function registerFilesystemTools(aiTools: Map<string, AiTool>): void {
   }
 
   // ============================================
-  // file_operations - Tier 1 (read/list), Tier 3 (write/delete)
+  // file_operations - all actions Tier 3 (SR5-01)
   // ============================================
 
   registerTool({
-    tier: 1 as AiToolTier, // Runtime tier check for write/delete in guardrails
+    tier: 1 as AiToolTier, // Base tier; guardrails escalate every action to Tier 3 via TIER3_ACTIONS
     deviceArgs: ['deviceId'],
     definition: {
       name: 'file_operations',
-      description: 'Perform file operations on a device. List and read are safe; write, delete, mkdir, and rename require approval.',
+      description: 'Perform file operations on a device. All actions (list, read, write, delete, mkdir, rename) require approval because the agent reads/writes as root/LocalSystem.',
       input_schema: {
         type: 'object' as const,
         properties: {


### PR DESCRIPTION
Reclassifies AI filesystem **read**/**list** as privileged. Previously `file_operations.read` mapped to `devices.read` and ran at Tier 1 (auto-execute, no approval), letting a `devices.read`-only user exfiltrate arbitrary files from any online device in their org via the endpoint agent (which runs as root/LocalSystem).

**Finding:** SR5-01.

**Approach (two layers):**
1. **API re-tiering (primary):** `file_operations.read`/`list` now require `devices.execute` and are added to `TIER3_ACTIONS`, so they demand execute permission + interactive approval like write/delete. Traced through `checkGuardrails`/`checkToolPermission`/the SDK approval gate to confirm enforcement.
2. **Agent path containment (defense-in-depth, Go):** symlink-safe deny-list (`filepath.EvalSymlinks` before the check) blocking obvious credential stores (`/etc/shadow`, SSH private keys, Windows SAM/SECURITY/SYSTEM hives, browser credential DBs, keychains) for read/list.

**Flagged product decision:** `file_operations` remains in Helper's standard surface but read/list flip from auto-execute to approval-gated. Fully removing read from Helper would require splitting the multiplexed tool — left as a follow-up.

**Verification:** `tsc` clean; `aiGuardrails.test.ts` (97) proves read/list → tier 3 + execute-required; Go `fileops_containment_test.go` passes under `-race` (deny-list matrix + symlink-escape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)