### PR TITLE
fix(security): bound Google mobile-wipe target + site-scope AI monitor probing (SR5-02/08)

### DIFF
--- a/apps/api/src/jobs/monitorWorker.test.ts
+++ b/apps/api/src/jobs/monitorWorker.test.ts
@@ -146,7 +146,58 @@ function selectWhereOrderLimitResolved(rows: unknown[]) {
   };
 }
 
-const { recordMonitorCheckResult, processScheduler } = await import('./monitorWorker');
+const { recordMonitorCheckResult, processScheduler, selectExecutionAgentForMonitor } = await import('./monitorWorker');
+
+describe('selectExecutionAgentForMonitor (SR5-08 site-bound fallback)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('picks an online agent in the monitor site when one exists', async () => {
+    vi.mocked(db.select)
+      // asset → siteId
+      .mockReturnValueOnce(selectLimitResolved([{ siteId: 'site-1' }]) as any)
+      // site agent lookup → online agent in site-1
+      .mockReturnValueOnce(selectLimitResolved([{ agentId: 'agent-site-1' }]) as any);
+
+    const agentId = await selectExecutionAgentForMonitor({ orgId: 'org-1', assetId: 'asset-1' });
+    expect(agentId).toBe('agent-site-1');
+  });
+
+  it('does NOT fall back to an arbitrary org agent when a site-bound monitor has no online site agent', async () => {
+    vi.mocked(db.select)
+      // asset → siteId (site-1)
+      .mockReturnValueOnce(selectLimitResolved([{ siteId: 'site-1' }]) as any)
+      // no online agent in site-1
+      .mockReturnValueOnce(selectLimitResolved([]) as any);
+
+    const agentId = await selectExecutionAgentForMonitor({ orgId: 'org-1', assetId: 'asset-1' });
+    // Fail closed rather than cross the site boundary.
+    expect(agentId).toBeNull();
+    // Only the asset + site-agent lookups ran — no org-wide fallback query.
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows an org-wide agent for an unbound (assetless) monitor — behavior preserved', async () => {
+    vi.mocked(db.select)
+      // org-wide online agent lookup
+      .mockReturnValueOnce(selectLimitResolved([{ agentId: 'agent-any' }]) as any);
+
+    const agentId = await selectExecutionAgentForMonitor({ orgId: 'org-1', assetId: null });
+    expect(agentId).toBe('agent-any');
+    // No asset lookup for an assetless monitor; only the org-wide query runs.
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats an asset with a null site as unbound (org-wide allowed)', async () => {
+    vi.mocked(db.select)
+      // asset → siteId null
+      .mockReturnValueOnce(selectLimitResolved([{ siteId: null }]) as any)
+      // org-wide online agent lookup
+      .mockReturnValueOnce(selectLimitResolved([{ agentId: 'agent-any' }]) as any);
+
+    const agentId = await selectExecutionAgentForMonitor({ orgId: 'org-1', assetId: 'asset-1' });
+    expect(agentId).toBe('agent-any');
+  });
+});
 
 describe('processScheduler (#1105 connection-hold)', () => {
   beforeEach(() => {

--- a/apps/api/src/jobs/monitorWorker.ts
+++ b/apps/api/src/jobs/monitorWorker.ts
@@ -181,7 +181,7 @@ function parseNumericThreshold(threshold: string | null | undefined): number | n
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-async function selectExecutionAgentForMonitor(
+export async function selectExecutionAgentForMonitor(
   monitor: {
     orgId: string;
     assetId: string | null;
@@ -199,6 +199,10 @@ async function selectExecutionAgentForMonitor(
   }
 
   if (assetSiteId) {
+    // Site-bound monitor: the executing agent MUST live in the monitor's site.
+    // If no online agent is available there, return null rather than crossing
+    // the site boundary to an arbitrary org agent (SR5-08) — that would direct
+    // a root-level agent in another site to probe this target.
     const [siteAgent] = await db
       .select({ agentId: devices.agentId })
       .from(devices)
@@ -209,11 +213,13 @@ async function selectExecutionAgentForMonitor(
       ))
       .limit(1);
 
-    if (siteAgent?.agentId) {
-      return siteAgent.agentId;
-    }
+    return siteAgent?.agentId ?? null;
   }
 
+  // Unbound monitor (no site scope): org-wide selection is legitimate. Monitors
+  // created by site-restricted callers are now required to be site-bound
+  // (aiToolsMonitoring create gate), so this path is reached only for monitors
+  // an unrestricted caller intentionally left assetless.
   const [onlineAgent] = await db
     .select({ agentId: devices.agentId })
     .from(devices)

--- a/apps/api/src/services/aiToolsGoogle.test.ts
+++ b/apps/api/src/services/aiToolsGoogle.test.ts
@@ -40,6 +40,7 @@ import {
   googleShareCalendarHandler,
   googleOffboardUserHandler,
   googleWipeMobileDeviceHandler,
+  canonicalizeUserEmail,
   googleSecurityDriftHandler,
   googleEmailReportHandler,
   computeSecurityDrift,
@@ -407,7 +408,11 @@ describe('calendar sharing', () => {
 describe('offboard workflow', () => {
   function mockDir(overrides: Record<string, any> = {}) {
     return {
-      users: { signOut: vi.fn().mockResolvedValue({}), update: vi.fn().mockResolvedValue({}) },
+      users: {
+        get: vi.fn().mockResolvedValue({ data: { primaryEmail: 'leaver@x.com' } }),
+        signOut: vi.fn().mockResolvedValue({}),
+        update: vi.fn().mockResolvedValue({}),
+      },
       tokens: {
         list: vi.fn().mockResolvedValue({ data: { items: [{ clientId: 'app-1' }, { clientId: 'app-2' }] } }),
         delete: vi.fn().mockResolvedValue({}),
@@ -415,7 +420,7 @@ describe('offboard workflow', () => {
       groups: { list: vi.fn().mockResolvedValue({ data: { groups: [{ id: 'grp-1' }] } }) },
       members: { delete: vi.fn().mockResolvedValue({}) },
       mobiledevices: {
-        list: vi.fn().mockResolvedValue({ data: { mobiledevices: [{ resourceId: 'dev-1' }] } }),
+        list: vi.fn().mockResolvedValue({ data: { mobiledevices: [{ resourceId: 'dev-1', email: ['leaver@x.com'] }] } }),
         action: vi.fn().mockResolvedValue({}),
       },
       ...overrides,
@@ -508,7 +513,11 @@ describe('stolen-device full wipe', () => {
   it('issues a FULL remote wipe and says it erases the whole device', async () => {
     const action = vi.fn().mockResolvedValue({});
     (client.getDirectoryClient as any).mockReturnValue({
-      mobiledevices: { list: vi.fn().mockResolvedValue({ data: { mobiledevices: [{ resourceId: 'dev-1' }] } }), action },
+      users: { get: vi.fn().mockResolvedValue({ data: { primaryEmail: 'u@x.com' } }) },
+      mobiledevices: {
+        list: vi.fn().mockResolvedValue({ data: { mobiledevices: [{ resourceId: 'dev-1', email: ['u@x.com'] }] } }),
+        action,
+      },
     });
     const out = await googleWipeMobileDeviceHandler({ userEmail: 'u@x.com', reason: 'phone stolen' }, auth, SESSION);
     expect(action).toHaveBeenCalledWith(
@@ -516,14 +525,103 @@ describe('stolen-device full wipe', () => {
     );
     expect(out).toContain('FULL factory reset');
     expect(out).toContain('entire device');
+    // Execution record is bound to the resolved user + concrete device IDs.
+    expect(out).toContain('dev-1');
+    expect(out).toContain('u@x.com');
   });
 
   it('reports when no devices are enrolled', async () => {
     (client.getDirectoryClient as any).mockReturnValue({
+      users: { get: vi.fn().mockResolvedValue({ data: { primaryEmail: 'u@x.com' } }) },
       mobiledevices: { list: vi.fn().mockResolvedValue({ data: { mobiledevices: [] } }), action: vi.fn() },
     });
     const out = await googleWipeMobileDeviceHandler({ userEmail: 'u@x.com', reason: 'stolen' }, auth, SESSION);
     expect(out).toContain('nothing to wipe');
+  });
+
+  // ── SR5-02 hardening: target-expansion guard ────────────────────────────────
+  it('rejects a wildcard userEmail before touching Google', async () => {
+    const usersGet = vi.fn();
+    const list = vi.fn();
+    const action = vi.fn();
+    (client.getDirectoryClient as any).mockReturnValue({
+      users: { get: usersGet },
+      mobiledevices: { list, action },
+    });
+    const out = await googleWipeMobileDeviceHandler({ userEmail: 'a*', reason: 'stolen' }, auth, SESSION);
+    expect(out).toContain('invalid_user_email');
+    // No identity resolution and no wipe are attempted for a non-canonical value.
+    expect(usersGet).not.toHaveBeenCalled();
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('rejects a query-operator userEmail (email: OR expansion)', async () => {
+    const action = vi.fn();
+    (client.getDirectoryClient as any).mockReturnValue({
+      users: { get: vi.fn() },
+      mobiledevices: { list: vi.fn(), action },
+    });
+    const out = await googleWipeMobileDeviceHandler(
+      { userEmail: 'a@x.com OR email:b@x.com', reason: 'stolen' },
+      auth,
+      SESSION,
+    );
+    expect(out).toContain('invalid_user_email');
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('only wipes devices whose account EXACTLY matches the resolved user', async () => {
+    const action = vi.fn().mockResolvedValue({});
+    // The server query is only a prefilter; it returns an extra device that
+    // belongs to a different user (prefix collision). It must be dropped.
+    (client.getDirectoryClient as any).mockReturnValue({
+      users: { get: vi.fn().mockResolvedValue({ data: { primaryEmail: 'ann@x.com' } }) },
+      mobiledevices: {
+        list: vi.fn().mockResolvedValue({
+          data: {
+            mobiledevices: [
+              { resourceId: 'ann-phone', email: ['ann@x.com'] },
+              { resourceId: 'annette-phone', email: ['annette@x.com'] },
+              { resourceId: 'no-email' },
+            ],
+          },
+        }),
+        action,
+      },
+    });
+    const out = await googleWipeMobileDeviceHandler({ userEmail: 'Ann@x.com', reason: 'stolen' }, auth, SESSION);
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(action).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceId: 'ann-phone', requestBody: { action: 'admin_remote_wipe' } }),
+    );
+    expect(action).not.toHaveBeenCalledWith(expect.objectContaining({ resourceId: 'annette-phone' }));
+    expect(out).toContain('ann-phone');
+  });
+
+  it('refuses when the user cannot be resolved (zero identities → 404)', async () => {
+    const action = vi.fn();
+    (client.getDirectoryClient as any).mockReturnValue({
+      users: { get: vi.fn().mockRejectedValue({ code: 404, message: 'Resource Not Found' }) },
+      mobiledevices: { list: vi.fn(), action },
+    });
+    const out = await googleWipeMobileDeviceHandler({ userEmail: 'ghost@x.com', reason: 'stolen' }, auth, SESSION);
+    // Surfaces an error and never issues a wipe.
+    expect(out).toContain('error');
+    expect(action).not.toHaveBeenCalled();
+  });
+});
+
+describe('canonicalizeUserEmail', () => {
+  it('accepts a plain address and lowercases it', () => {
+    expect(canonicalizeUserEmail('User@Example.com')).toBe('user@example.com');
+  });
+  it('rejects wildcards, operators, and embedded whitespace', () => {
+    for (const bad of ['a*', 'a b@x.com', 'a@x.com OR b@y.com', 'email:a@x.com', '', 'nope', 'a@x', '<a@x.com>', 'a@x.com,b@y.com']) {
+      expect(canonicalizeUserEmail(bad)).toBeNull();
+    }
+  });
+  it('trims surrounding whitespace but keeps a single bare address', () => {
+    expect(canonicalizeUserEmail('  a@x.com  ')).toBe('a@x.com');
   });
 });
 

--- a/apps/api/src/services/aiToolsGoogle.ts
+++ b/apps/api/src/services/aiToolsGoogle.ts
@@ -82,7 +82,7 @@ type DirectoryClient = ReturnType<typeof getDirectoryClient>;
  */
 export function canonicalizeUserEmail(raw: string): string | null {
   const email = raw.trim();
-  // Single addr-spec only: local@domain.tld, RFC-ish, no query operators.
+  // Single addr-spec only (user@example.com form), RFC-ish, no query operators.
   const STRICT_EMAIL = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
   if (!STRICT_EMAIL.test(email)) return null;
   // No embedded whitespace or wildcard survived the regex, but be explicit.

--- a/apps/api/src/services/aiToolsGoogle.ts
+++ b/apps/api/src/services/aiToolsGoogle.ts
@@ -71,25 +71,98 @@ type CalendarRole = (typeof CALENDAR_ROLES)[number];
 type DirectoryClient = ReturnType<typeof getDirectoryClient>;
 
 /**
- * Issue a mobile-device action to every device enrolled to a user.
+ * Canonicalize a user-supplied email to a single, strict addr-spec.
+ *
+ * Returns the lowercased address, or null if the input is not a bare, single
+ * email. This deliberately rejects the Google Directory query metacharacters
+ * (`*`, `:`, whitespace, quotes, parentheses, angle brackets, commas) that would
+ * otherwise turn `email:${x}` into a prefix / OR search matching MORE than one
+ * user — the SR5-02 wipe target-expansion vector. A value like `a*` or
+ * `a@x.com OR b@y.com` fails this test and is refused before any wipe.
+ */
+export function canonicalizeUserEmail(raw: string): string | null {
+  const email = raw.trim();
+  // Single addr-spec only: local@domain.tld, RFC-ish, no query operators.
+  const STRICT_EMAIL = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
+  if (!STRICT_EMAIL.test(email)) return null;
+  // No embedded whitespace or wildcard survived the regex, but be explicit.
+  if (/[\s*]/.test(email)) return null;
+  return email.toLowerCase();
+}
+
+type ResolvedWipeTarget =
+  | { ok: true; user: string; deviceIds: string[] }
+  | { ok: false; code: string; message: string };
+
+/**
+ * Resolve the EXACT set of mobile devices to wipe for one user.
+ *
+ * Hardening (SR5-02): rather than trusting the raw `email:${x}` server query to
+ * scope the target set, we (1) canonicalize the input to a single address,
+ * (2) resolve the exact identity via `users.get` (one user or fail — zero/404 is
+ * refused, and an exact key can never resolve multiple), then (3) locally
+ * EXACT-match each returned device's account emails to the resolved
+ * `primaryEmail`, dropping any device that does not carry that exact account.
+ * The server query is only a prefilter; the local exact-match is the real gate.
+ */
+async function resolveWipeTarget(dir: DirectoryClient, rawEmail: string): Promise<ResolvedWipeTarget> {
+  const canonical = canonicalizeUserEmail(rawEmail);
+  if (!canonical) {
+    return {
+      ok: false,
+      code: 'invalid_user_email',
+      message:
+        'userEmail must be a single canonical email address (no wildcards, query operators, or whitespace).',
+    };
+  }
+
+  // Resolve the exact identity first. `users.get` by key returns exactly one
+  // user or 404 — this rejects both zero (no such user) and any expansion.
+  let primaryEmail: string;
+  try {
+    const res = await dir.users.get({ userKey: canonical });
+    const pe = res.data.primaryEmail;
+    if (!pe) {
+      return { ok: false, code: 'user_not_resolved', message: `Could not resolve a single user for ${canonical}.` };
+    }
+    primaryEmail = pe.toLowerCase();
+  } catch (err) {
+    const norm = normalizeGoogleError(err);
+    return { ok: false, code: norm.code, message: norm.message };
+  }
+
+  const list = await dir.mobiledevices.list({ customerId: 'my_customer', query: `email:${primaryEmail}` });
+  const deviceIds: string[] = [];
+  for (const d of list.data.mobiledevices ?? []) {
+    if (!d.resourceId) continue;
+    // EXACT-match: only wipe a device that actually carries the resolved
+    // user's account. Drops prefix / fuzzy matches the server may return.
+    const accounts = (d.email ?? []).map((e) => (e ?? '').toLowerCase());
+    if (!accounts.includes(primaryEmail)) continue;
+    deviceIds.push(d.resourceId);
+  }
+  return { ok: true, user: primaryEmail, deviceIds };
+}
+
+/**
+ * Issue a mobile-device action to a pre-resolved, bounded set of device IDs.
  *   - admin_account_wipe: remove ONLY the managed corporate account + its data
  *     (mail/Drive) from the device. Safe for BYOD; the personal device is intact.
  *   - admin_remote_wipe: full factory reset of the entire device. STOLEN-DEVICE
  *     use only — never part of offboarding.
+ * The caller resolves `deviceIds` via `resolveWipeTarget` so the acted-on set is
+ * bound to one exact user, not whatever a raw query happened to return.
  */
 async function wipeMobileDevices(
   dir: DirectoryClient,
-  userEmail: string,
+  deviceIds: string[],
   action: 'admin_account_wipe' | 'admin_remote_wipe',
 ): Promise<number> {
-  const list = await dir.mobiledevices.list({ customerId: 'my_customer', query: `email:${userEmail}` });
-  const devices = list.data.mobiledevices ?? [];
   let n = 0;
-  for (const d of devices) {
-    if (!d.resourceId) continue;
+  for (const resourceId of deviceIds) {
     await dir.mobiledevices.action({
       customerId: 'my_customer',
-      resourceId: d.resourceId,
+      resourceId,
       requestBody: { action },
     });
     n++;
@@ -878,8 +951,14 @@ export async function googleOffboardUserHandler(
   // 4. SELECTIVE mobile account-wipe (BYOD: corporate data only).
   if (accountWipeMobile) {
     steps.push(await runStep('mobile_account_wipe', async () => {
-      const n = await wipeMobileDevices(dir, email, 'admin_account_wipe');
-      return n === 0 ? 'no mobile devices enrolled' : `account-wiped ${n} device(s) (corporate data only)`;
+      const resolved = await resolveWipeTarget(dir, email);
+      // Fail the step (not swallow) if the target can't be resolved to one
+      // exact user — the offboard then reports incomplete rather than green.
+      if (!resolved.ok) throw new Error(`${resolved.code}: ${resolved.message}`);
+      const n = await wipeMobileDevices(dir, resolved.deviceIds, 'admin_account_wipe');
+      return n === 0
+        ? `no mobile devices enrolled for ${resolved.user}`
+        : `account-wiped ${n} device(s) for ${resolved.user} (corporate data only) [${resolved.deviceIds.join(', ')}]`;
     }));
   }
 
@@ -930,9 +1009,13 @@ export async function googleWipeMobileDeviceHandler(
 
   try {
     const dir = getDirectoryClient(ctx.keyJson, ctx.conn.adminEmail);
-    const n = await wipeMobileDevices(dir, email, 'admin_remote_wipe');
-    if (n === 0) return `No mobile devices are enrolled for ${email}; nothing to wipe.`;
-    return `Issued a FULL factory reset to ${n} device(s) for ${email} (stolen-device remote wipe). This erases the entire device, not just corporate data.`;
+    const resolved = await resolveWipeTarget(dir, email);
+    if (!resolved.ok) return errorString(resolved.code, resolved.message);
+    const n = await wipeMobileDevices(dir, resolved.deviceIds, 'admin_remote_wipe');
+    if (n === 0) return `No mobile devices are enrolled for ${resolved.user}; nothing to wipe.`;
+    // Execution record is bound to the resolved canonical user + the concrete
+    // device IDs, so the audited action is a known, bounded set (SR5-02).
+    return `Issued a FULL factory reset to ${n} device(s) for ${resolved.user} (stolen-device remote wipe) [${resolved.deviceIds.join(', ')}]. This erases the entire device, not just corporate data.`;
   } catch (err) {
     return googleError(err);
   }

--- a/apps/api/src/services/aiToolsMonitoring.test.ts
+++ b/apps/api/src/services/aiToolsMonitoring.test.ts
@@ -287,6 +287,73 @@ describe('manage_monitors — site-axis enforcement', () => {
     });
   });
 
+  // ─── create action (SR5-08) ──────────────────────────────────────────────
+
+  describe('action: create', () => {
+    // db.insert().values().returning() → [monitor]
+    function insertReturning(monitor: Record<string, unknown>) {
+      return {
+        values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([monitor]) }),
+      } as any;
+    }
+    // db.select().from().where().limit() → [{ id }] (asset org-ownership check).
+    function assetOwnerLookup(found: boolean) {
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(found ? [{ id: ASSET_ALLOWED }] : []) }),
+        }),
+      } as any;
+    }
+
+    const CREATE = {
+      action: 'create',
+      name: 'db-probe',
+      monitorType: 'tcp_port',
+      target: '10.0.0.5:5432',
+    };
+
+    it('denies a site-restricted caller creating an UNBOUND monitor (fail-closed)', async () => {
+      const out = JSON.parse(await handle({ ...CREATE }, makeSiteRestrictedAuth()));
+      expect(out.error).toMatch(/site-restricted/i);
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    });
+
+    it('denies a site-restricted caller binding an asset in a forbidden site', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(assetOwnerLookup(true))   // org-ownership check passes
+        .mockReturnValueOnce(assetLookup('site-2'));    // asset resolves to denied site
+      const out = JSON.parse(await handle({ ...CREATE, assetId: ASSET_ALLOWED }, makeSiteRestrictedAuth()));
+      expect(out.error).toMatch(/site-restricted/i);
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    });
+
+    it('rejects a cross-org assetId (fail-closed)', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(assetOwnerLookup(false)); // asset not in caller org
+      const out = JSON.parse(await handle({ ...CREATE, assetId: ASSET_DENIED }, makeSiteRestrictedAuth()));
+      expect(out.error).toMatch(/asset not found or access denied/i);
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    });
+
+    it('allows a site-restricted caller binding an asset in an allowed site', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(assetOwnerLookup(true))   // org-ownership check passes
+        .mockReturnValueOnce(assetLookup('site-1'));    // asset resolves to allowed site
+      vi.mocked(db.insert).mockReturnValue(insertReturning({ id: 'new-mon', name: 'db-probe' }));
+      const out = JSON.parse(await handle({ ...CREATE, assetId: ASSET_ALLOWED }, makeSiteRestrictedAuth()));
+      expect(out.success).toBe(true);
+      expect(vi.mocked(db.insert)).toHaveBeenCalledOnce();
+    });
+
+    it('allows an unrestricted caller to create an assetless monitor (behavior preserved)', async () => {
+      vi.mocked(db.insert).mockReturnValue(insertReturning({ id: 'new-mon', name: 'db-probe' }));
+      const out = JSON.parse(await handle({ ...CREATE }, makeUnrestrictedAuth()));
+      expect(out.success).toBe(true);
+      // No asset lookups for an unrestricted, unbound create.
+      expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+      expect(vi.mocked(db.insert)).toHaveBeenCalledOnce();
+    });
+  });
+
   // ─── unrestricted caller invariant ───────────────────────────────────────
 
   describe('unrestricted caller bypass', () => {

--- a/apps/api/src/services/aiToolsMonitoring.ts
+++ b/apps/api/src/services/aiToolsMonitoring.ts
@@ -155,6 +155,7 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
         properties: {
           action: { type: 'string', enum: ['get', 'create', 'update', 'delete'], description: 'The action to perform' },
           monitorId: { type: 'string', description: 'Monitor UUID (required for get/update/delete)' },
+          assetId: { type: 'string', description: 'Discovered-asset UUID to bind the monitor to (sets its site scope). Required for site-restricted users on create.' },
           name: { type: 'string', description: 'Monitor name (for create/update)' },
           monitorType: { type: 'string', description: 'Monitor type: icmp_ping, tcp_port, http_check, dns_check (for create)' },
           target: { type: 'string', description: 'Target host/URL (for create/update)' },
@@ -242,8 +243,35 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
         if (!input.monitorType) return JSON.stringify({ error: 'monitorType is required' });
         if (!input.target) return JSON.stringify({ error: 'target is required' });
 
+        const assetId = typeof input.assetId === 'string' && input.assetId ? input.assetId : null;
+
+        // Validate the asset binding belongs to the caller's org (fail closed
+        // on a cross-org assetId) before it can set the monitor's site scope.
+        if (assetId) {
+          const [asset] = await db
+            .select({ id: discoveredAssets.id })
+            .from(discoveredAssets)
+            .where(and(eq(discoveredAssets.id, assetId), eq(discoveredAssets.orgId, orgId)))
+            .limit(1);
+          if (!asset) return JSON.stringify({ error: 'Asset not found or access denied' });
+        }
+
+        // Site-axis gate on create (SR5-08): a site-restricted caller MUST bind
+        // the monitor to an asset in a site they can access. Fail closed if
+        // unbound — an assetless monitor has no site, and the worker would then
+        // pick an arbitrary org agent to probe an arbitrary target across sites.
+        // Unrestricted callers pass regardless (assertMonitorSiteAccess short-
+        // circuits when auth.canAccessSite is undefined).
+        if (!(await assertMonitorSiteAccess({ id: 'new', assetId, orgId }))) {
+          return JSON.stringify({
+            error:
+              'Site-restricted users must bind the monitor to an asset in an accessible site (provide assetId).',
+          });
+        }
+
         const [monitor] = await db.insert(networkMonitors).values({
           orgId,
+          assetId,
           name: input.name as string,
           monitorType: input.monitorType as 'icmp_ping' | 'tcp_port' | 'http_check' | 'dns_check',
           target: input.target as string,


### PR DESCRIPTION
Two hardening fixes (below the confidence bar of the review but real gaps).

**Findings:**
- **SR5-02** Google mobile-wipe: the wipe query was built from a raw `email:${userEmail}` string and acted on every returned device, so a wildcard/operator value could expand the target set. Now `userEmail` is canonicalized to a strict single address (wildcards/operators rejected), the exact user is resolved, each returned device is exact-matched to that user's normalized email, and the execution/audit record is bound to the resolved user + concrete device IDs/count.
- **SR5-08** assetless monitor probing: monitor `create` skipped the site gate that get/update/delete enforce, and the worker fell back to any online org device — letting a site-restricted caller originate recurring probes via a sibling-site agent. Create now requires a site-accessible asset binding for restricted callers; the worker fallback for a site-bound monitor no longer crosses the site boundary.

**Verification:** `tsc` clean; `aiToolsGoogle.test.ts` (54) / `aiToolsMonitoring.test.ts` (16) / `monitorWorker.test.ts` (8) pass, including canonicalization-reject and exact-match cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)