### PR TITLE
feat(tickets): intake forms Phase 2 — portal card-grid intake + org-subset allowlist

### DIFF
--- a/apps/api/migrations/2026-07-11-ticket-form-org-links.sql
+++ b/apps/api/migrations/2026-07-11-ticket-form-org-links.sql
@@ -1,0 +1,64 @@
+-- Org allowlist for partner-wide ticket_forms (spec §5, epic #2135 follow-on;
+-- plan: docs/superpowers/plans/2026-07-11-ticket-intake-forms-phase2.md).
+--
+-- Semantics: no link rows for a form = visible to every org under the owning
+-- partner; rows present = allowlist (only the linked orgs see the form).
+-- Only meaningful for partner-wide ticket_forms rows (org_id IS NULL,
+-- partner_id set) — org-owned forms never have links.
+--
+-- This is an FK-child of the dual-axis ticket_forms parent. RLS reaches
+-- tenancy by joining through ticket_forms (system OR org-access OR
+-- partner-access on the PARENT row), mirroring how
+-- 2026-07-01-maintenance-windows-partner-ownership.sql re-issued the
+-- maintenance_occurrences FK-child policy with the dual-axis parent
+-- predicate. A plain breeze_has_org_access(ticket_form_org_links.org_id)
+-- policy would be WRONG here: this table's own org_id column is the
+-- ALLOWLISTED org (arbitrary data), not the tenancy axis — the row must be
+-- visible to whoever can see the owning ticket_forms row (its org OR its
+-- partner), not merely to the one org named in the link.
+--
+-- Idempotent: CREATE IF NOT EXISTS / CREATE INDEX IF NOT EXISTS, DROP POLICY
+-- IF EXISTS then CREATE. No inner BEGIN/COMMIT (autoMigrate wraps each file
+-- in a transaction). Never edit this file after it ships — fix forward.
+
+CREATE TABLE IF NOT EXISTS ticket_form_org_links (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  form_id uuid NOT NULL REFERENCES ticket_forms(id) ON DELETE CASCADE,
+  org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  created_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ticket_form_org_links_form_org_uq
+  ON ticket_form_org_links(form_id, org_id);
+CREATE INDEX IF NOT EXISTS ticket_form_org_links_form_id_idx ON ticket_form_org_links(form_id);
+CREATE INDEX IF NOT EXISTS ticket_form_org_links_org_id_idx ON ticket_form_org_links(org_id);
+
+-- RLS: FK-child join through the dual-axis ticket_forms parent predicate.
+ALTER TABLE ticket_form_org_links ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ticket_form_org_links FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS ticket_form_org_links_isolation ON ticket_form_org_links;
+CREATE POLICY ticket_form_org_links_isolation
+  ON ticket_form_org_links
+  USING (
+    EXISTS (
+      SELECT 1 FROM ticket_forms tf
+      WHERE tf.id = ticket_form_org_links.form_id
+        AND (
+          public.breeze_current_scope() = 'system'
+          OR (tf.org_id IS NOT NULL AND public.breeze_has_org_access(tf.org_id))
+          OR (tf.partner_id IS NOT NULL AND public.breeze_has_partner_access(tf.partner_id))
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM ticket_forms tf
+      WHERE tf.id = ticket_form_org_links.form_id
+        AND (
+          public.breeze_current_scope() = 'system'
+          OR (tf.org_id IS NOT NULL AND public.breeze_has_org_access(tf.org_id))
+          OR (tf.partner_id IS NOT NULL AND public.breeze_has_partner_access(tf.partner_id))
+        )
+    )
+  );

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -110,6 +110,16 @@ const ORG_AXIS_POLICY_EXCLUDED_TABLES: ReadonlySet<string> = new Set<string>([
   // org_id is for routing + cascade only. Functional cross-partner/cross-org
   // forge proof: customerEmailDomainsRls.integration.test.ts.
   'customer_email_domains',
+  // ticket_form_org_links (2026-07-11): FK-child of the dual-axis ticket_forms
+  // parent (Shape 5-adjacent, registered in PARENT_FK_JOIN_POLICY_TABLES
+  // below). Its own org_id column is the ALLOWLISTED org, not the tenancy
+  // axis — the loose `LIKE '%breeze_has_org_access%'` substring match in the
+  // generic org-tenant test would otherwise spuriously "pass" this table
+  // because the FK-join policy text does call breeze_has_org_access(tf.org_id)
+  // (the PARENT's column), just not on this table's own org_id. Excluding it
+  // here keeps that generic check honest; PARENT_FK_JOIN_POLICY_TABLES is the
+  // real assertion for this table's policy shape.
+  'ticket_form_org_links',
 ]);
 
 // Tables whose own `id` column is the tenant identifier (no `org_id`).
@@ -401,6 +411,12 @@ const PARENT_FK_JOIN_POLICY_TABLES: ReadonlyMap<string, readonly string[]> = new
   // never allowlisted, so the contract test couldn't see it. Register it so a
   // future regression that drops/weakens the policy is caught.
   ['psa_ticket_mappings', ['psa_connections']],
+  // ticket_form_org_links (2026-07-11): org allowlist for partner-wide
+  // ticket_forms. Its policy joins through ticket_forms and OR's in the
+  // parent's dual-axis predicate (org OR partner OR system) — a plain
+  // breeze_has_org_access(parent.org_id) join would be WRONG because the
+  // parent's org_id is NULL for the partner-wide forms this table scopes.
+  ['ticket_form_org_links', ['ticket_forms']],
 ]);
 
 // Tables scoped to the calling user via breeze_current_user_id().

--- a/apps/api/src/__tests__/integration/ticketFormOrgLinksTxnSeam.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketFormOrgLinksTxnSeam.integration.test.ts
@@ -1,0 +1,133 @@
+/**
+ * ticket_forms org-links transaction seam (Critical — Phase 2 whole-branch review).
+ *
+ * POST /ticket-forms creates the parent ticket_forms row on the request's
+ * withDbAccessContext transaction (C1, uncommitted), then syncs the org
+ * allowlist. If syncTicketFormOrgLinks escapes to a FRESH system transaction
+ * on another pooled connection (C2), C2's READ COMMITTED snapshot cannot see
+ * C1's uncommitted parent, so the non-deferrable FK
+ * `ticket_form_org_links.form_id -> ticket_forms(id)` fails with 23503 and the
+ * whole request 500s. This suite mirrors that exact route seam: it inserts a
+ * partner-wide parent inside a partner-scoped request context and then — STILL
+ * inside that context — calls syncTicketFormOrgLinks with a non-empty
+ * allowlist. It must land parent + links together, committed atomically.
+ *
+ * Only partner-scoped tokens with orgAccess='all' reach this path (POST
+ * partner-wide + canManagePartnerWidePolicies gate), so the ambient context is
+ * always a partner context whose accessibleOrgIds covers every org under the
+ * partner — which is what makes both the link WITH CHECK
+ * (breeze_has_partner_access on the parent) and the org-belongs-to-partner
+ * validation read (breeze_has_org_access on organizations) pass on the ambient
+ * connection.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { ticketForms, ticketFormOrgLinks } from '../../db/schema';
+import { syncTicketFormOrgLinks, TicketFormError } from '../../services/ticketFormService';
+import { createOrganization, createPartner } from './db-utils';
+
+const created: string[] = [];
+
+function systemContext(): DbAccessContext {
+  return { scope: 'system', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: null, userId: null };
+}
+
+// Mirrors an orgAccess='all' partner token: accessibleOrgIds covers every org
+// under the partner (buildDbAccessContext / computeAccessibleOrgIds), which is
+// the only shape that clears canManagePartnerWidePolicies and thus the only one
+// that reaches syncTicketFormOrgLinks.
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+    currentPartnerId: partnerId
+  };
+}
+
+const baseForm = { name: 'Onboarding', fields: [], defaultTags: [] };
+
+afterEach(async () => {
+  if (created.length === 0) return;
+  await withDbAccessContext(systemContext(), async () => {
+    for (const id of created) {
+      await db.delete(ticketForms).where(eq(ticketForms.id, id));
+    }
+  });
+  created.length = 0;
+});
+
+describe('ticket_forms org-links transaction seam (POST with visibleOrgIds)', () => {
+  it('creates parent + links on the SAME request transaction (no cross-connection FK 23503)', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+
+    // The whole seam runs inside ONE partner-scoped request transaction, exactly
+    // like the POST route: insert the partner-wide parent (uncommitted here),
+    // then sync the org allowlist against that not-yet-committed parent.
+    const formId = await withDbAccessContext(partnerContext(partner.id, [orgA.id, orgB.id]), async () => {
+      const [row] = await db
+        .insert(ticketForms)
+        .values({ ...baseForm, partnerId: partner.id, orgId: null })
+        .returning();
+      if (!row) throw new Error('parent insert returned no row');
+      await syncTicketFormOrgLinks(row.id, [orgA.id, orgB.id], partner.id);
+      return row.id;
+    });
+    created.push(formId);
+
+    // Committed together: both the parent and its two link rows are visible now.
+    const [form] = await withDbAccessContext(systemContext(), () =>
+      db.select().from(ticketForms).where(eq(ticketForms.id, formId))
+    );
+    expect(form).toBeTruthy();
+
+    const links = await withDbAccessContext(systemContext(), () =>
+      db.select().from(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.formId, formId))
+    );
+    expect(links.map((l) => l.orgId).sort()).toEqual([orgA.id, orgB.id].sort());
+  });
+
+  it('rejects a cross-partner org id and persists NOTHING (rollback contract for the route)', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const otherPartner = await createPartner();
+    const foreignOrg = await createOrganization({ partnerId: otherPartner.id });
+
+    // Same request-transaction seam, but one visibleOrgId belongs to a DIFFERENT
+    // partner. The org-belongs-to-partner validation read must reject it with a
+    // TicketFormError (400) BEFORE any link write, and — because the route wraps
+    // this in try/catch and deletes the parent on failure — nothing must persist.
+    await expect(
+      withDbAccessContext(partnerContext(partner.id, [orgA.id]), async () => {
+        const [row] = await db
+          .insert(ticketForms)
+          .values({ ...baseForm, partnerId: partner.id, orgId: null })
+          .returning();
+        if (!row) throw new Error('parent insert returned no row');
+        try {
+          await syncTicketFormOrgLinks(row.id, [orgA.id, foreignOrg.id], partner.id);
+        } catch (err) {
+          // Emulate the route's rollback-on-sync-failure.
+          await db.delete(ticketForms).where(eq(ticketForms.id, row.id));
+          throw err;
+        }
+      })
+    ).rejects.toBeInstanceOf(TicketFormError);
+
+    // No form and no links survived the rolled-back request.
+    const forms = await withDbAccessContext(systemContext(), () =>
+      db.select().from(ticketForms).where(eq(ticketForms.partnerId, partner.id))
+    );
+    expect(forms).toEqual([]);
+    const links = await withDbAccessContext(systemContext(), () =>
+      db.select().from(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.orgId, foreignOrg.id))
+    );
+    expect(links).toEqual([]);
+  });
+});

--- a/apps/api/src/__tests__/integration/ticketFormsPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketFormsPartnerRls.integration.test.ts
@@ -202,4 +202,96 @@ describe('ticket_forms partner RLS', () => {
       )
     ).rejects.toMatchObject({ cause: { code: '23505' } });
   });
+
+  // Deferred from Task 1's review: the two existing link-write assertions only
+  // prove the DENY side (cross-partner forge → 42501). This proves the ALLOW
+  // side of the same WITH CHECK clause — the owning partner's own context can
+  // actually insert a link on its own form, exercising the
+  // breeze_has_partner_access(tf.partner_id) branch positively, not just its
+  // negation.
+  it('the owning partner context can insert a link on its own partner-wide form', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const [form] = await withDbAccessContext(systemContext(), () =>
+      db.insert(ticketForms).values({ ...baseForm, partnerId: partner.id, orgId: null }).returning()
+    );
+    if (!form) throw new Error('insert returned no row');
+    created.push(form.id);
+
+    const [link] = await withDbAccessContext(partnerContext(partner.id, [org.id]), () =>
+      db.insert(ticketFormOrgLinks).values({ formId: form.id, orgId: org.id }).returning()
+    );
+    expect(link).toMatchObject({ formId: form.id, orgId: org.id });
+  });
+
+  describe('allowlist resolution (Task 2: listTicketFormsForOrg)', () => {
+    it('allowlist: partner-wide form with links is visible ONLY to linked orgs; an unlinked partner-wide form stays visible to all', async () => {
+      const partner = await createPartner();
+      const orgA = await createOrganization({ partnerId: partner.id });
+      const orgB = await createOrganization({ partnerId: partner.id });
+
+      const [formP] = await withDbAccessContext(systemContext(), () =>
+        db.insert(ticketForms).values({ ...baseForm, name: 'P — allowlisted', partnerId: partner.id, orgId: null }).returning()
+      );
+      const [formQ] = await withDbAccessContext(systemContext(), () =>
+        db.insert(ticketForms).values({ ...baseForm, name: 'Q — unlinked', partnerId: partner.id, orgId: null }).returning()
+      );
+      if (!formP || !formQ) throw new Error('insert returned no row');
+      created.push(formP.id, formQ.id);
+
+      await withDbAccessContext(systemContext(), () =>
+        db.insert(ticketFormOrgLinks).values({ formId: formP.id, orgId: orgA.id }).returning()
+      );
+
+      const forOrgA = await listTicketFormsForOrg({ id: orgA.id, partnerId: partner.id });
+      expect(forOrgA.map((f) => f.name).sort()).toEqual(['P — allowlisted', 'Q — unlinked']);
+
+      const forOrgB = await listTicketFormsForOrg({ id: orgB.id, partnerId: partner.id });
+      expect(forOrgB.map((f) => f.name)).toEqual(['Q — unlinked']);
+    });
+
+    it('portalOnly filters out showInPortal=false rows', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+
+      const rows = await withDbAccessContext(systemContext(), () =>
+        db
+          .insert(ticketForms)
+          .values([
+            { ...baseForm, name: 'Visible in portal', orgId: org.id, partnerId: null, showInPortal: true },
+            { ...baseForm, name: 'Internal only', orgId: org.id, partnerId: null, showInPortal: false }
+          ])
+          .returning()
+      );
+      created.push(...rows.map((r) => r.id));
+
+      const all = await listTicketFormsForOrg({ id: org.id, partnerId: partner.id });
+      expect(all.map((f) => f.name).sort()).toEqual(['Internal only', 'Visible in portal']);
+
+      const portalOnly = await listTicketFormsForOrg({ id: org.id, partnerId: partner.id }, { portalOnly: true });
+      expect(portalOnly.map((f) => f.name)).toEqual(['Visible in portal']);
+    });
+
+    it('orders by sortOrder then name — exact order, no .sort() masking', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+
+      const rows = await withDbAccessContext(systemContext(), () =>
+        db
+          .insert(ticketForms)
+          .values([
+            { ...baseForm, name: 'Zebra', orgId: org.id, partnerId: null, sortOrder: 1 },
+            { ...baseForm, name: 'Alpha', orgId: org.id, partnerId: null, sortOrder: 1 },
+            { ...baseForm, name: 'Middle', orgId: org.id, partnerId: null, sortOrder: 2 }
+          ])
+          .returning()
+      );
+      created.push(...rows.map((r) => r.id));
+
+      const forOrg = await listTicketFormsForOrg({ id: org.id, partnerId: partner.id });
+      // sortOrder 1 group ordered by name (Alpha before Zebra), then sortOrder 2.
+      expect(forOrg.map((f) => f.name)).toEqual(['Alpha', 'Zebra', 'Middle']);
+    });
+  });
 });

--- a/apps/api/src/__tests__/integration/ticketFormsPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketFormsPartnerRls.integration.test.ts
@@ -29,7 +29,7 @@ import './setup';
 import { afterEach, describe, expect, it } from 'vitest';
 import { eq } from 'drizzle-orm';
 import { db, withDbAccessContext, type DbAccessContext } from '../../db';
-import { ticketForms } from '../../db/schema';
+import { ticketForms, ticketFormOrgLinks } from '../../db/schema';
 import { listTicketFormsForOrg } from '../../services/ticketFormService';
 import { createOrganization, createPartner } from './db-utils';
 
@@ -141,5 +141,65 @@ describe('ticket_forms partner RLS', () => {
 
     const forOtherOrg = await listTicketFormsForOrg({ id: otherOrg.id, partnerId: otherPartner.id });
     expect(forOtherOrg.map((f) => f.name)).toEqual(['Other partner']);
+  });
+
+  it('org link rows are invisible cross-partner and writable only by the owning partner (42501)', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const orgA2 = await createOrganization({ partnerId: partnerA.id });
+
+    const [form] = await withDbAccessContext(systemContext(), () =>
+      db.insert(ticketForms).values({ ...baseForm, partnerId: partnerA.id, orgId: null }).returning()
+    );
+    if (!form) throw new Error('insert returned no row');
+    created.push(form.id);
+
+    const [link] = await withDbAccessContext(systemContext(), () =>
+      db.insert(ticketFormOrgLinks).values({ formId: form.id, orgId: orgA.id }).returning()
+    );
+    if (!link) throw new Error('insert returned no row');
+
+    // Partner B cannot see partner A's link row (parent-join predicate denies).
+    const visibleToPartnerB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db.select().from(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.id, link.id))
+    );
+    expect(visibleToPartnerB).toEqual([]);
+
+    // Partner B forging a link onto partner A's (invisible) form is rejected
+    // at the DB layer — a distinct org so this doesn't collide with the
+    // unique constraint instead of RLS.
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db.insert(ticketFormOrgLinks).values({ formId: form.id, orgId: orgA2.id }).returning()
+      )
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+
+    // The owning partner CAN see + would be permitted to write its own link row.
+    const visibleToPartnerA = await withDbAccessContext(partnerContext(partnerA.id, [orgA.id, orgA2.id]), () =>
+      db.select().from(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.id, link.id))
+    );
+    expect(visibleToPartnerA).toEqual([link]);
+  });
+
+  it('link unique constraint rejects duplicates (23505)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const [form] = await withDbAccessContext(systemContext(), () =>
+      db.insert(ticketForms).values({ ...baseForm, partnerId: partner.id, orgId: null }).returning()
+    );
+    if (!form) throw new Error('insert returned no row');
+    created.push(form.id);
+
+    await withDbAccessContext(systemContext(), () =>
+      db.insert(ticketFormOrgLinks).values({ formId: form.id, orgId: org.id }).returning()
+    );
+
+    await expect(
+      withDbAccessContext(systemContext(), () =>
+        db.insert(ticketFormOrgLinks).values({ formId: form.id, orgId: org.id }).returning()
+      )
+    ).rejects.toMatchObject({ cause: { code: '23505' } });
   });
 });

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -85,6 +85,7 @@ export * from './tickets';
 export * from './ticketConfig';
 export * from './ticketResponseTemplates';
 export * from './ticketForms';
+export * from './ticketFormOrgLinks';
 export * from './ticketMailbox';
 export * from './catalog';
 export * from './timeTracking';

--- a/apps/api/src/db/schema/ticketFormOrgLinks.ts
+++ b/apps/api/src/db/schema/ticketFormOrgLinks.ts
@@ -1,0 +1,33 @@
+import { index, pgTable, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { organizations } from './orgs';
+import { ticketForms } from './ticketForms';
+
+/**
+ * Org allowlist for partner-wide ticket_forms (spec §5, epic #2135 follow-on).
+ * No link rows for a form = visible to every org under the owning partner;
+ * rows present = allowlist (only the linked orgs see the form). Only
+ * meaningful for partner-wide forms (ticket_forms.org_id IS NULL); org-owned
+ * forms never have links.
+ *
+ * FK-child of the dual-axis `ticket_forms` parent. This table's own `org_id`
+ * column is the ALLOWLISTED org (arbitrary data), NOT the tenancy axis — RLS
+ * reaches tenancy by joining through `ticket_forms` (system OR org-access OR
+ * partner-access on the PARENT row), mirroring how
+ * 2026-07-01-maintenance-windows-partner-ownership.sql re-issued the
+ * maintenance_occurrences FK-child policy. See
+ * 2026-07-11-ticket-form-org-links.sql for the policy definition.
+ */
+export const ticketFormOrgLinks = pgTable(
+  'ticket_form_org_links',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    formId: uuid('form_id').notNull().references(() => ticketForms.id, { onDelete: 'cascade' }),
+    orgId: uuid('org_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+    createdAt: timestamp('created_at').defaultNow().notNull()
+  },
+  (t) => [
+    uniqueIndex('ticket_form_org_links_form_org_uq').on(t.formId, t.orgId),
+    index('ticket_form_org_links_form_id_idx').on(t.formId),
+    index('ticket_form_org_links_org_id_idx').on(t.orgId)
+  ]
+);

--- a/apps/api/src/routes/portal/schemas.ts
+++ b/apps/api/src/routes/portal/schemas.ts
@@ -121,11 +121,34 @@ export const listSchema = z.object({
 
 export const ticketPrioritySchema = z.enum(['low', 'normal', 'high', 'urgent']);
 
-export const createTicketSchema = z.object({
-  subject: z.string().min(1).max(255),
-  description: z.string().min(1),
-  priority: ticketPrioritySchema.optional().default('normal')
-});
+// Phase 2 (ticket intake forms): subject/description become optional when a
+// formId is supplied — createTicket composes them from the form (title
+// template + rendered responses). Portal keeps its OWN schema (does not
+// import the shared createTicketSchema) per the Phase 2 plan's global
+// constraints. `priority.default('normal')` is intentionally kept even though
+// a form may carry its own defaultPriority: the portal UI has no per-form
+// priority prefill yet, so the portal's explicit 'normal' wins over the
+// form's default in Phase 2 — acceptable per the design brief; revisit if/when
+// the portal form UI grows a priority prefill.
+export const createTicketSchema = z
+  .object({
+    subject: z.string().min(1).max(255).optional(),
+    description: z.string().min(1).optional(),
+    priority: ticketPrioritySchema.optional().default('normal'),
+    formId: z.string().guid().optional(),
+    formResponses: z.record(z.string(), z.unknown()).optional()
+  })
+  .superRefine((v, ctx) => {
+    if (!v.formId && (!v.subject || !v.subject.trim())) {
+      ctx.addIssue({ code: 'custom', path: ['subject'], message: 'subject is required unless a formId is provided' });
+    }
+    if (!v.formId && (!v.description || !v.description.trim())) {
+      ctx.addIssue({ code: 'custom', path: ['description'], message: 'description is required unless a formId is provided' });
+    }
+    if (v.formResponses && !v.formId) {
+      ctx.addIssue({ code: 'custom', path: ['formResponses'], message: 'formResponses requires formId' });
+    }
+  });
 
 export const ticketParamSchema = z.object({
   id: z.string().guid()

--- a/apps/api/src/routes/portal/tickets.test.ts
+++ b/apps/api/src/routes/portal/tickets.test.ts
@@ -57,7 +57,7 @@ vi.mock('../../db', () => ({
     select: dbSelectMock,
     insert: vi.fn(() => ({ values: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) })) }))
   },
-  // GET /ticket-forms resolves the session org's partnerId under a system
+  // GET /tickets/forms resolves the session org's partnerId under a system
   // context (mirrors routes/portal/quotes.ts:70) — pass-through no-ops here,
   // same convention as routes/portal/quotes.test.ts.
   runOutsideDbContext: <T,>(fn: () => T): T => fn(),
@@ -363,7 +363,7 @@ describe('portal ticket soft-delete exclusion', () => {
   });
 });
 
-// ── GET /ticket-forms — Task 4: portal forms read ────────────────────────────
+// ── GET /tickets/forms — Task 4: portal forms read ───────────────────────────
 
 const FORM_ROW = {
   id: 'f-1',
@@ -384,7 +384,7 @@ const FORM_ROW = {
   updatedAt: new Date()
 };
 
-describe('GET /ticket-forms', () => {
+describe('GET /tickets/forms', () => {
   let app: ReturnType<typeof buildApp>;
 
   beforeEach(() => {
@@ -403,7 +403,7 @@ describe('GET /ticket-forms', () => {
   it('resolves the session org + partnerId and calls listTicketFormsForOrg with portalOnly: true', async () => {
     listTicketFormsForOrgMock.mockResolvedValue([FORM_ROW]);
 
-    const res = await app.request('/ticket-forms', {
+    const res = await app.request('/tickets/forms', {
       headers: { Authorization: 'Bearer portal-token' }
     });
 
@@ -417,7 +417,7 @@ describe('GET /ticket-forms', () => {
   it('returns ONLY the slim keys (id, name, description, categoryId, fields, defaultPriority) — no titleTemplate or other columns', async () => {
     listTicketFormsForOrgMock.mockResolvedValue([FORM_ROW]);
 
-    const res = await app.request('/ticket-forms', {
+    const res = await app.request('/tickets/forms', {
       headers: { Authorization: 'Bearer portal-token' }
     });
 
@@ -441,13 +441,78 @@ describe('GET /ticket-forms', () => {
   it('returns { data: [] } when the service returns no forms', async () => {
     listTicketFormsForOrgMock.mockResolvedValue([]);
 
-    const res = await app.request('/ticket-forms', {
+    const res = await app.request('/tickets/forms', {
       headers: { Authorization: 'Bearer portal-token' }
     });
 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({ data: [] });
+  });
+});
+
+// ── GET /tickets/forms — mount-wiring regression (auth-prefix coverage) ───────
+//
+// routes/portal/index.ts protects the ticket router with
+// `portalRoutes.use('/tickets/*', portalAuthMiddleware)` — a `/tickets/*`
+// prefix, NOT a blanket `use('*')` like buildApp() above. A forms route
+// registered outside that prefix (the original `/ticket-forms` path) ships
+// with NO auth in production and 500s on the missing portalAuth context.
+// This suite wires the app the way index.ts ACTUALLY mounts it (same
+// use-prefix + route('/') calls, with a portalAuthMiddleware stand-in that
+// 401s without a session) so the auth-prefix coverage of the forms route is
+// asserted structurally, not assumed.
+describe('GET /tickets/forms — index.ts mount wiring', () => {
+  function buildMountedApp() {
+    const app = new Hono();
+    // Verbatim shape of routes/portal/index.ts: prefix-scoped auth middleware,
+    // then the router mounted at '/'. The stub mirrors portalAuthMiddleware's
+    // contract: 401 without a session credential, portalAuth set otherwise.
+    app.use('/tickets/*', async (c, next) => {
+      if (!c.req.header('Authorization')) {
+        return c.json({ error: 'Authentication required' }, 401);
+      }
+      c.set('portalAuth' as never, { user: PORTAL_USER, token: 'tok-1', authMethod: 'bearer' });
+      await next();
+    });
+    app.route('/', ticketRoutes);
+    return app;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbSelectMock.mockImplementation(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([{ partnerId: 'p-1' }]))
+        }))
+      }))
+    }));
+  });
+
+  it('WITHOUT a session: 401 — proves the /tickets/* auth prefix covers the forms route', async () => {
+    const app = buildMountedApp();
+    const res = await app.request('/tickets/forms');
+    expect(res.status).toBe(401);
+    expect(listTicketFormsForOrgMock).not.toHaveBeenCalled();
+  });
+
+  it('WITH a session: 200 slim payload — proves /tickets/forms is not swallowed by the /tickets/:id matcher', async () => {
+    listTicketFormsForOrgMock.mockResolvedValue([FORM_ROW]);
+    const app = buildMountedApp();
+    const res = await app.request('/tickets/forms', {
+      headers: { Authorization: 'Bearer portal-token' }
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { data: Record<string, unknown>[] };
+    expect(body.data[0]).toEqual({
+      id: FORM_ROW.id,
+      name: FORM_ROW.name,
+      description: FORM_ROW.description,
+      categoryId: FORM_ROW.categoryId,
+      fields: FORM_ROW.fields,
+      defaultPriority: FORM_ROW.defaultPriority
+    });
   });
 });
 

--- a/apps/api/src/routes/portal/tickets.test.ts
+++ b/apps/api/src/routes/portal/tickets.test.ts
@@ -56,7 +56,12 @@ vi.mock('../../db', () => ({
   db: {
     select: dbSelectMock,
     insert: vi.fn(() => ({ values: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) })) }))
-  }
+  },
+  // GET /ticket-forms resolves the session org's partnerId under a system
+  // context (mirrors routes/portal/quotes.ts:70) — pass-through no-ops here,
+  // same convention as routes/portal/quotes.test.ts.
+  runOutsideDbContext: <T,>(fn: () => T): T => fn(),
+  withSystemDbAccessContext: <T,>(fn: () => Promise<T>): Promise<T> => fn()
 }));
 
 vi.mock('../../db/schema', () => ({
@@ -73,7 +78,20 @@ vi.mock('../../db/schema', () => ({
   },
   ticketStatuses: {
     id: 'id', name: 'name', color: 'color'
+  },
+  organizations: {
+    id: 'id', partnerId: 'partnerId'
   }
+}));
+
+// ── ticketFormService mock ────────────────────────────────────────────────────
+
+const { listTicketFormsForOrgMock } = vi.hoisted(() => ({
+  listTicketFormsForOrgMock: vi.fn()
+}));
+
+vi.mock('../../services/ticketFormService', () => ({
+  listTicketFormsForOrg: listTicketFormsForOrgMock
 }));
 
 vi.mock('./helpers', () => ({
@@ -345,6 +363,94 @@ describe('portal ticket soft-delete exclusion', () => {
   });
 });
 
+// ── GET /ticket-forms — Task 4: portal forms read ────────────────────────────
+
+const FORM_ROW = {
+  id: 'f-1',
+  name: 'Printer Issue',
+  description: 'Report a printer problem',
+  categoryId: 'cat-1',
+  fields: [{ key: 'model', label: 'Printer model', type: 'text', required: true }],
+  defaultPriority: 'high',
+  // Fields that must NOT leak into the slim portal payload:
+  titleTemplate: '{{model}} is broken',
+  orgId: null,
+  partnerId: 'p-1',
+  isActive: true,
+  showInPortal: true,
+  sortOrder: 1,
+  version: 1,
+  createdAt: new Date(),
+  updatedAt: new Date()
+};
+
+describe('GET /ticket-forms', () => {
+  let app: ReturnType<typeof buildApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    // Org partnerId lookup: db.select({partnerId}).from(organizations).where(...).limit(1)
+    dbSelectMock.mockImplementation(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([{ partnerId: 'p-1' }]))
+        }))
+      }))
+    }));
+  });
+
+  it('resolves the session org + partnerId and calls listTicketFormsForOrg with portalOnly: true', async () => {
+    listTicketFormsForOrgMock.mockResolvedValue([FORM_ROW]);
+
+    const res = await app.request('/ticket-forms', {
+      headers: { Authorization: 'Bearer portal-token' }
+    });
+
+    expect(res.status).toBe(200);
+    expect(listTicketFormsForOrgMock).toHaveBeenCalledWith(
+      { id: PORTAL_USER.orgId, partnerId: 'p-1' },
+      { portalOnly: true }
+    );
+  });
+
+  it('returns ONLY the slim keys (id, name, description, categoryId, fields, defaultPriority) — no titleTemplate or other columns', async () => {
+    listTicketFormsForOrgMock.mockResolvedValue([FORM_ROW]);
+
+    const res = await app.request('/ticket-forms', {
+      headers: { Authorization: 'Bearer portal-token' }
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { data: Record<string, unknown>[] };
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]).toEqual({
+      id: FORM_ROW.id,
+      name: FORM_ROW.name,
+      description: FORM_ROW.description,
+      categoryId: FORM_ROW.categoryId,
+      fields: FORM_ROW.fields,
+      defaultPriority: FORM_ROW.defaultPriority
+    });
+    expect(body.data[0]).not.toHaveProperty('titleTemplate');
+    expect(body.data[0]).not.toHaveProperty('orgId');
+    expect(body.data[0]).not.toHaveProperty('partnerId');
+    expect(body.data[0]).not.toHaveProperty('showInPortal');
+  });
+
+  it('returns { data: [] } when the service returns no forms', async () => {
+    listTicketFormsForOrgMock.mockResolvedValue([]);
+
+    const res = await app.request('/ticket-forms', {
+      headers: { Authorization: 'Bearer portal-token' }
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ data: [] });
+  });
+});
+
 // ── POST /tickets — B1 fix: delegates to createTicket ────────────────────────
 
 const CREATED_AT = new Date('2026-01-15T10:00:00Z');
@@ -441,6 +547,83 @@ describe('POST /tickets — delegates to createTicket', () => {
     expect(res.status).toBe(404);
     const body = await res.json() as { error: string };
     expect(body.error).toMatch(/organization not found/i);
+  });
+
+  // ── Task 4: form-aware create ──────────────────────────────────────────────
+
+  it('passes formId and formResponses through to createTicket', async () => {
+    const FORM_ID = '3f2f1d8e-1111-4222-8333-444455556677';
+    const res = await app.request('/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ formId: FORM_ID, formResponses: { model: 'HP LaserJet' } })
+    });
+
+    expect(res.status).toBe(201);
+    expect(createTicketMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        formId: FORM_ID,
+        formResponses: { model: 'HP LaserJet' },
+        source: 'portal'
+      }),
+      expect.objectContaining({ userId: PORTAL_USER.id })
+    );
+  });
+
+  it('rejects formResponses without formId with a 400 (schema-level, before createTicket is called)', async () => {
+    const res = await app.request('/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ formResponses: { model: 'HP LaserJet' } })
+    });
+
+    expect(res.status).toBe(400);
+    expect(createTicketMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts a form-only submission with no subject/description', async () => {
+    const FORM_ID = '3f2f1d8e-1111-4222-8333-444455556677';
+    const res = await app.request('/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ formId: FORM_ID, formResponses: { model: 'HP LaserJet' } })
+    });
+
+    expect(res.status).toBe(201);
+    expect(createTicketMock).toHaveBeenCalledWith(
+      expect.objectContaining({ formId: FORM_ID, subject: undefined, description: undefined }),
+      expect.anything()
+    );
+  });
+
+  it('accepts a legacy submission (subject + description, no form) unchanged', async () => {
+    const res = await app.request('/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ subject: 'Printer not working', description: 'It clicks' })
+    });
+
+    expect(res.status).toBe(201);
+    expect(createTicketMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Printer not working',
+        description: 'It clicks',
+        formId: undefined,
+        formResponses: undefined
+      }),
+      expect.anything()
+    );
+  });
+
+  it('rejects a blank subject with no formId with a 400', async () => {
+    const res = await app.request('/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ subject: '   ', description: 'It clicks' })
+    });
+
+    expect(res.status).toBe(400);
+    expect(createTicketMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -24,14 +24,20 @@ import { editCommentSchema } from '@breeze/shared';
 
 export const ticketRoutes = new Hono();
 
-// GET /ticket-forms — literal path, registered first so it can never be
-// shadowed by a `/tickets/:id`-style param route mounted later in this file
-// (same mount-order convention as Phase 1). Portal runs under an org-scoped
-// RLS context where partner-wide ticket_forms rows are invisible (#1105
-// pattern), so the org's partnerId is resolved under a system context first —
-// mirrors routes/portal/quotes.ts:70 exactly. Slim payload only: no
-// titleTemplate (the server composes subjects, never the portal client).
-ticketRoutes.get('/ticket-forms', async (c) => {
+// GET /tickets/forms — MUST live under the `/tickets/` prefix: portal auth is
+// applied per-prefix in routes/portal/index.ts (`use('/tickets/*', ...)`), so
+// a sibling path like `/ticket-forms` would ship with NO auth at all (the
+// prefix matcher does not cover it). MOUNT ORDER: this literal route is
+// registered BEFORE `GET /tickets/:id` below — Hono matches in registration
+// order, so registering it later would let the :id matcher swallow `forms`
+// (and 400 on the guid param). Same mount-order convention as Phase 1's
+// staff ticket router.
+// Portal runs under an org-scoped RLS context where partner-wide
+// ticket_forms rows are invisible (#1105 pattern), so the org's partnerId is
+// resolved under a system context first — mirrors routes/portal/quotes.ts:70
+// exactly. Slim payload only: no titleTemplate (the server composes
+// subjects, never the portal client).
+ticketRoutes.get('/tickets/forms', async (c) => {
   const auth = c.get('portalAuth');
 
   const [org] = await runOutsideDbContext(() =>

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -49,7 +49,15 @@ ticketRoutes.get('/tickets/forms', async (c) => {
         .limit(1)
     )
   );
-  if (!org) return c.json({ data: [] });
+  if (!org) {
+    // Should never happen: portalAuth already resolved this org for the
+    // session, so a miss here means the org row vanished mid-request (or a
+    // deeper data-integrity bug). Degrade to an empty form list rather than
+    // 500ing the New Ticket page, but leave a breadcrumb — this is not a
+    // normal "no forms configured" case.
+    console.error('[portal] ticket-forms: session org not found', { orgId: auth.user.orgId });
+    return c.json({ data: [] });
+  }
 
   const forms = await listTicketFormsForOrg({ id: auth.user.orgId, partnerId: org.partnerId }, { portalOnly: true });
   const data = forms.map((f) => ({

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -1,8 +1,8 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { and, desc, eq, isNull, sql } from 'drizzle-orm';
-import { db } from '../../db';
-import { tickets, ticketComments, ticketStatuses } from '../../db/schema';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import { tickets, ticketComments, ticketStatuses, organizations } from '../../db/schema';
 import {
   listSchema,
   createTicketSchema,
@@ -19,9 +19,43 @@ import {
   writePortalAudit,
 } from './helpers';
 import { createTicket, TicketServiceError, portalCommentMutable, editTicketComment, deleteTicketComment } from '../../services/ticketService';
+import { listTicketFormsForOrg } from '../../services/ticketFormService';
 import { editCommentSchema } from '@breeze/shared';
 
 export const ticketRoutes = new Hono();
+
+// GET /ticket-forms — literal path, registered first so it can never be
+// shadowed by a `/tickets/:id`-style param route mounted later in this file
+// (same mount-order convention as Phase 1). Portal runs under an org-scoped
+// RLS context where partner-wide ticket_forms rows are invisible (#1105
+// pattern), so the org's partnerId is resolved under a system context first —
+// mirrors routes/portal/quotes.ts:70 exactly. Slim payload only: no
+// titleTemplate (the server composes subjects, never the portal client).
+ticketRoutes.get('/ticket-forms', async (c) => {
+  const auth = c.get('portalAuth');
+
+  const [org] = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db
+        .select({ partnerId: organizations.partnerId })
+        .from(organizations)
+        .where(eq(organizations.id, auth.user.orgId))
+        .limit(1)
+    )
+  );
+  if (!org) return c.json({ data: [] });
+
+  const forms = await listTicketFormsForOrg({ id: auth.user.orgId, partnerId: org.partnerId }, { portalOnly: true });
+  const data = forms.map((f) => ({
+    id: f.id,
+    name: f.name,
+    description: f.description,
+    categoryId: f.categoryId,
+    fields: f.fields,
+    defaultPriority: f.defaultPriority,
+  }));
+  return c.json({ data });
+});
 
 ticketRoutes.get('/tickets', zValidator('query', listSchema), async (c) => {
   const auth = c.get('portalAuth');
@@ -102,6 +136,8 @@ ticketRoutes.post('/tickets', zValidator('json', createTicketSchema), async (c) 
         subject: payload.subject,
         description: payload.description,
         priority: payload.priority,
+        formId: payload.formId,
+        formResponses: payload.formResponses,
         source: 'portal',
         submittedBy: auth.user.id,
         submitterEmail: auth.user.email,

--- a/apps/api/src/routes/tickets/forms.test.ts
+++ b/apps/api/src/routes/tickets/forms.test.ts
@@ -1,7 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
-const { authRef, dbRowsMock, insertReturningMock, insertValuesMock, updateReturningMock, updateSetMock, deleteWhereMock, listForOrgMock, writeRouteAuditMock, selectWhereArgs } = vi.hoisted(() => ({
+const {
+  authRef,
+  dbRowsMock,
+  insertReturningMock,
+  insertValuesMock,
+  updateReturningMock,
+  updateSetMock,
+  deleteWhereMock,
+  listForOrgMock,
+  syncOrgLinksMock,
+  getOrgLinkMapMock,
+  writeRouteAuditMock,
+  selectWhereArgs
+} = vi.hoisted(() => ({
   /** Every db.select()...where(...) arg, so tests can assert fetch conditions. */
   selectWhereArgs: [] as unknown[],
   /** Captures db.insert().values(arg) so tests can assert the persisted owner axis. */
@@ -25,11 +38,23 @@ const { authRef, dbRowsMock, insertReturningMock, insertValuesMock, updateReturn
   updateSetMock: vi.fn(),
   deleteWhereMock: vi.fn(),
   listForOrgMock: vi.fn(),
+  syncOrgLinksMock: vi.fn(),
+  getOrgLinkMapMock: vi.fn(),
   writeRouteAuditMock: vi.fn()
 }));
 
 vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: writeRouteAuditMock }));
-vi.mock('../../services/ticketFormService', () => ({ listTicketFormsForOrg: listForOrgMock }));
+vi.mock('../../services/ticketFormService', async () => {
+  // Keep the real TicketFormError class (forms.ts does `instanceof` checks
+  // against it) while mocking the two functions under test.
+  const actual = await vi.importActual<typeof import('../../services/ticketFormService')>('../../services/ticketFormService');
+  return {
+    ...actual,
+    listTicketFormsForOrg: listForOrgMock,
+    syncTicketFormOrgLinks: syncOrgLinksMock,
+    getTicketFormOrgLinkMap: getOrgLinkMapMock
+  };
+});
 vi.mock('../../services/ticketService', async () => {
   const actual = await vi.importActual<typeof import('../../services/ticketService')>('../../services/ticketService');
   return { ...actual, assertCategoryInPartner: vi.fn().mockResolvedValue({ id: 'cat-1', partnerId: 'p-1' }) };
@@ -75,6 +100,7 @@ import { sql, type SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import { ticketFormRoutes } from './forms';
 import { assertCategoryInPartner, TicketServiceError } from '../../services/ticketService';
+import { TicketFormError } from '../../services/ticketFormService';
 
 /** Render a captured Drizzle condition to a SQL string for shape assertions. */
 function renderSql(condition: unknown): string {
@@ -97,6 +123,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   selectWhereArgs.length = 0;
   authRef.current = { ...authRef.current, scope: 'partner', partnerId: 'p-1', partnerOrgAccess: 'all', orgId: null, orgCondition: () => undefined, canAccessOrg: () => true };
+  syncOrgLinksMock.mockResolvedValue(undefined);
+  getOrgLinkMapMock.mockResolvedValue(new Map());
 });
 
 describe('POST /ticket-forms', () => {
@@ -214,6 +242,90 @@ describe('POST /ticket-forms', () => {
       body: JSON.stringify({ name: 'x', orgId: ORG_ID, fields: [{ key: 'BAD KEY', label: 'x', type: 'text', required: false }] })
     });
     expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /ticket-forms — visibleOrgIds', () => {
+  const ORG_A = '11112222-3333-4444-8555-666677778888';
+  const ORG_B = '22223333-4444-4555-8666-777788889999';
+
+  it('creates a partner-wide form and syncs links with the token-derived partner + the array as-is', async () => {
+    insertReturningMock.mockResolvedValue([{ id: 'f-2', orgId: null, partnerId: 'p-1', ...validBody }]);
+    const res = await makeApp().request('/ticket-forms', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...validBody, ownerScope: 'partner', visibleOrgIds: [ORG_A, ORG_B] })
+    });
+    expect(res.status).toBe(201);
+    expect(syncOrgLinksMock).toHaveBeenCalledWith('f-2', [ORG_A, ORG_B], 'p-1');
+    const body = await res.json();
+    expect(body.data.visibleOrgIds).toEqual([ORG_A, ORG_B]);
+  });
+
+  it('normalizes an empty visibleOrgIds array to null before syncing', async () => {
+    insertReturningMock.mockResolvedValue([{ id: 'f-2', orgId: null, partnerId: 'p-1', ...validBody }]);
+    const res = await makeApp().request('/ticket-forms', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...validBody, ownerScope: 'partner', visibleOrgIds: [] })
+    });
+    expect(res.status).toBe(201);
+    expect(syncOrgLinksMock).toHaveBeenCalledWith('f-2', null, 'p-1');
+    const body = await res.json();
+    expect(body.data.visibleOrgIds).toBeNull();
+  });
+
+  it('partner-wide create with no visibleOrgIds still syncs (no-op) with null and reports null', async () => {
+    insertReturningMock.mockResolvedValue([{ id: 'f-2', orgId: null, partnerId: 'p-1', ...validBody }]);
+    const res = await makeApp().request('/ticket-forms', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...validBody, ownerScope: 'partner' })
+    });
+    expect(res.status).toBe(201);
+    expect(syncOrgLinksMock).toHaveBeenCalledWith('f-2', null, 'p-1');
+    const body = await res.json();
+    expect(body.data.visibleOrgIds).toBeNull();
+  });
+
+  it('400s an org-owned create that supplies visibleOrgIds, before any insert or sync', async () => {
+    const res = await makeApp().request('/ticket-forms', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...validBody, ownerScope: 'organization', orgId: ORG_A, visibleOrgIds: [ORG_B] })
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('visibleOrgIds is only valid on partner-wide forms');
+    expect(insertValuesMock).not.toHaveBeenCalled();
+    expect(syncOrgLinksMock).not.toHaveBeenCalled();
+  });
+
+  it('400s a default-ownerScope (org-owned) create that supplies visibleOrgIds', async () => {
+    const res = await makeApp().request('/ticket-forms', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...validBody, orgId: ORG_A, visibleOrgIds: [ORG_B] })
+    });
+    expect(res.status).toBe(400);
+    expect(insertValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('rolls back (deletes) the just-created form when the sync rejects, and surfaces its 400', async () => {
+    insertReturningMock.mockResolvedValue([{ id: 'f-2', orgId: null, partnerId: 'p-1', ...validBody }]);
+    syncOrgLinksMock.mockRejectedValueOnce(
+      new TicketFormError('visibleOrgIds must reference organizations of the owning partner', 400)
+    );
+    const res = await makeApp().request('/ticket-forms', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...validBody, ownerScope: 'partner', visibleOrgIds: [ORG_A] })
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('visibleOrgIds must reference organizations of the owning partner');
+    // The form row inserted above must be deleted — no orphaned half-created form.
+    expect(deleteWhereMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -380,5 +492,130 @@ describe('PUT/DELETE app-layer tenant scoping on the row fetch', () => {
     const rendered = renderSql(selectWhereArgs[0]);
     expect(rendered).toContain('org_scope_marker');
     expect(rendered).toContain('and');
+  });
+});
+
+describe('PUT /ticket-forms/:id — visibleOrgIds', () => {
+  const FORM_ID = '9a8b7c6d-1111-4222-8333-444455556666';
+  const ORG_A = '11112222-3333-4444-8555-666677778888';
+  const ORG_B = '22223333-4444-4555-8666-777788889999';
+
+  function partnerWideRow() {
+    dbRowsMock.mockResolvedValue([{ id: FORM_ID, orgId: null, partnerId: 'p-1', version: 1, fields: [], name: 'Onboarding' }]);
+  }
+
+  it('undefined (key omitted): links untouched — sync never called', async () => {
+    partnerWideRow();
+    updateReturningMock.mockResolvedValue([{ id: FORM_ID, orgId: null, partnerId: 'p-1', version: 1, fields: [], name: 'renamed' }]);
+    const res = await makeApp().request(`/ticket-forms/${FORM_ID}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'renamed' })
+    });
+    expect(res.status).toBe(200);
+    expect(syncOrgLinksMock).not.toHaveBeenCalled();
+    const setArg = updateSetMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect('visibleOrgIds' in setArg).toBe(false);
+    expect('version' in setArg).toBe(false);
+  });
+
+  it('null: clears the allowlist via sync, does not bump version, and never reaches .set()', async () => {
+    partnerWideRow();
+    updateReturningMock.mockResolvedValue([{ id: FORM_ID, orgId: null, partnerId: 'p-1', version: 1, fields: [], name: 'Onboarding' }]);
+    const res = await makeApp().request(`/ticket-forms/${FORM_ID}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ visibleOrgIds: null })
+    });
+    expect(res.status).toBe(200);
+    expect(syncOrgLinksMock).toHaveBeenCalledWith(FORM_ID, null, 'p-1');
+    const setArg = updateSetMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect('visibleOrgIds' in setArg).toBe(false);
+    expect('version' in setArg).toBe(false);
+  });
+
+  it('[] (empty array): normalized to null before syncing, same as explicit null', async () => {
+    partnerWideRow();
+    updateReturningMock.mockResolvedValue([{ id: FORM_ID, orgId: null, partnerId: 'p-1', version: 1, fields: [], name: 'Onboarding' }]);
+    const res = await makeApp().request(`/ticket-forms/${FORM_ID}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ visibleOrgIds: [] })
+    });
+    expect(res.status).toBe(200);
+    expect(syncOrgLinksMock).toHaveBeenCalledWith(FORM_ID, null, 'p-1');
+  });
+
+  it('non-empty array: replaces the allowlist via sync with the array as-is, .set() never sees the key', async () => {
+    partnerWideRow();
+    updateReturningMock.mockResolvedValue([{ id: FORM_ID, orgId: null, partnerId: 'p-1', version: 1, fields: [], name: 'Onboarding' }]);
+    const res = await makeApp().request(`/ticket-forms/${FORM_ID}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ visibleOrgIds: [ORG_A, ORG_B] })
+    });
+    expect(res.status).toBe(200);
+    expect(syncOrgLinksMock).toHaveBeenCalledWith(FORM_ID, [ORG_A, ORG_B], 'p-1');
+    const setArg = updateSetMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect('visibleOrgIds' in setArg).toBe(false);
+  });
+
+  it('400s an update of an org-owned row that supplies visibleOrgIds, before any sync or column update', async () => {
+    dbRowsMock.mockResolvedValue([{ id: FORM_ID, orgId: ORG_A, partnerId: null, version: 1, fields: [], name: 'Onboarding' }]);
+    const res = await makeApp().request(`/ticket-forms/${FORM_ID}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ visibleOrgIds: [ORG_B] })
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('visibleOrgIds is only valid on partner-wide forms');
+    expect(syncOrgLinksMock).not.toHaveBeenCalled();
+    expect(updateReturningMock).not.toHaveBeenCalled();
+  });
+
+  it('sync failure aborts before the column update runs (form left completely unmodified) and surfaces the 400', async () => {
+    partnerWideRow();
+    syncOrgLinksMock.mockRejectedValueOnce(
+      new TicketFormError('visibleOrgIds must reference organizations of the owning partner', 400)
+    );
+    const res = await makeApp().request(`/ticket-forms/${FORM_ID}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'renamed', visibleOrgIds: [ORG_A] })
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('visibleOrgIds must reference organizations of the owning partner');
+    expect(updateSetMock).not.toHaveBeenCalled();
+    expect(updateReturningMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /ticket-forms — management list', () => {
+  it('carries visibleOrgIds from getTicketFormOrgLinkMap (present when links exist, null otherwise)', async () => {
+    dbRowsMock.mockResolvedValue([
+      { id: 'f-1', orgId: null, partnerId: 'p-1', name: 'All-orgs form' },
+      { id: 'f-2', orgId: null, partnerId: 'p-1', name: 'Limited form' }
+    ]);
+    getOrgLinkMapMock.mockResolvedValue(new Map([['f-2', ['org-a', 'org-b']]]));
+    const res = await makeApp().request('/ticket-forms');
+    expect(res.status).toBe(200);
+    expect(getOrgLinkMapMock).toHaveBeenCalledWith(['f-1', 'f-2']);
+    const body = await res.json();
+    expect(body.data.find((f: { id: string }) => f.id === 'f-1').visibleOrgIds).toBeNull();
+    expect(body.data.find((f: { id: string }) => f.id === 'f-2').visibleOrgIds).toEqual(['org-a', 'org-b']);
+  });
+});
+
+describe('GET /ticket-forms/available — does not carry visibleOrgIds', () => {
+  it('does not call getTicketFormOrgLinkMap; the picker payload is unmodified from the service result', async () => {
+    dbRowsMock.mockResolvedValue([{ id: ORG_ID, partnerId: 'p-1' }]); // org lookup
+    listForOrgMock.mockResolvedValue([{ id: 'f-1', name: 'Onboarding' }]);
+    const res = await makeApp().request(`/ticket-forms/available?orgId=${ORG_ID}`);
+    expect(res.status).toBe(200);
+    expect(getOrgLinkMapMock).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.data).toEqual([{ id: 'f-1', name: 'Onboarding' }]);
   });
 });

--- a/apps/api/src/routes/tickets/forms.ts
+++ b/apps/api/src/routes/tickets/forms.ts
@@ -217,7 +217,16 @@ ticketFormRoutes.post(
       } catch (err) {
         // A failed sync (e.g. cross-partner org id) must not leave an
         // orphaned half-created form behind — delete it and surface the 400.
-        await db.delete(ticketForms).where(eq(ticketForms.id, row.id));
+        // The rollback itself must not be allowed to throw and mask the
+        // original TicketFormError with an unrelated 500.
+        try {
+          await db.delete(ticketForms).where(eq(ticketForms.id, row.id));
+        } catch (rollbackErr) {
+          console.warn('[ticket-forms] rollback delete failed after syncTicketFormOrgLinks error', {
+            formId: row.id,
+            rollbackErr
+          });
+        }
         return handleServiceError(c, err);
       }
     }
@@ -288,8 +297,10 @@ ticketFormRoutes.put(
 
     // version identifies which field schema stored responses were validated
     // against and which template composed the subject, so it only bumps when
-    // fields/titleTemplate change; presentation-only fields (isActive/sortOrder/
-    // visibleOrgIds) don't bump.
+    // fields/titleTemplate change; presentation-only fields (isActive/sortOrder)
+    // don't bump. visibleOrgIds is NOT presentation-only — it drives the
+    // allowlist sync above — it's simply not a ticket_forms column, so it
+    // can't participate in the version bump either way.
     const bumpVersion = payload.fields !== undefined || payload.titleTemplate !== undefined;
     const [updated] = await db
       .update(ticketForms)

--- a/apps/api/src/routes/tickets/forms.ts
+++ b/apps/api/src/routes/tickets/forms.ts
@@ -9,8 +9,26 @@ import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthC
 import { writeRouteAudit } from '../../services/auditEvents';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../services/partnerWideAccess';
 import { PERMISSIONS } from '../../services/permissions';
-import { listTicketFormsForOrg } from '../../services/ticketFormService';
+import {
+  getTicketFormOrgLinkMap,
+  listTicketFormsForOrg,
+  syncTicketFormOrgLinks,
+  TicketFormError
+} from '../../services/ticketFormService';
 import { assertCategoryInPartner, TicketServiceError } from '../../services/ticketService';
+
+const VISIBLE_ORG_IDS_SCOPE_ERROR = 'visibleOrgIds is only valid on partner-wide forms';
+
+/**
+ * The persisted allowlist state is exactly two values (spec ruling, Task 2/3
+ * review): null/absent = visible to every org under the partner, or a
+ * non-empty array = the allowlist. An empty array is meaningless — "no link
+ * rows" already means visible-to-all — so routes normalize it to null before
+ * ever reaching syncTicketFormOrgLinks.
+ */
+function normalizeVisibleOrgIds(v: string[] | null | undefined): string[] | null {
+  return v && v.length > 0 ? v : null;
+}
 
 export const ticketFormRoutes = new Hono();
 
@@ -32,7 +50,7 @@ const idParamSchema = z.object({ id: z.string().guid() });
 // duplicate the mapping locally instead. (ticketPartsRoutes has its own copy too,
 // mapping a different error type, TimeEntryServiceError.)
 function handleServiceError(c: { json: (b: unknown, s: number) => Response }, err: unknown): Response {
-  if (err instanceof TicketServiceError) {
+  if (err instanceof TicketServiceError || err instanceof TicketFormError) {
     return c.json({ error: err.message }, err.status);
   }
   throw err;
@@ -89,7 +107,10 @@ ticketFormRoutes.get('/ticket-forms', authMiddleware, scopes, requireTicketRead,
     .from(ticketForms)
     .where(ticketFormAccessCondition(auth))
     .orderBy(asc(ticketForms.sortOrder), asc(ticketForms.name));
-  return c.json({ data: rows });
+  // Management list only (NOT /available — pickers don't need the allowlist).
+  const linkMap = await getTicketFormOrgLinkMap(rows.map((r) => r.id));
+  const data = rows.map((r) => ({ ...r, visibleOrgIds: linkMap.get(r.id) ?? null }));
+  return c.json({ data });
 });
 
 ticketFormRoutes.get(
@@ -126,6 +147,12 @@ ticketFormRoutes.post(
   async (c) => {
     const auth = c.get('auth');
     const payload = c.req.valid('json');
+
+    // Fail fast, before any DB work: visibleOrgIds is only meaningful on a
+    // partner-wide form (org-owned forms have no partner allowlist axis).
+    if (payload.visibleOrgIds !== undefined && payload.ownerScope !== 'partner') {
+      return c.json({ error: VISIBLE_ORG_IDS_SCOPE_ERROR }, 400);
+    }
 
     // Ownership axis (Partner-Wide First, epic #2135, mirrors software
     // policies #2126). The partner is ALWAYS derived from the caller's own
@@ -181,6 +208,20 @@ ticketFormRoutes.post(
       .returning();
     if (!row) return c.json({ error: 'Failed to create ticket form' }, 500);
 
+    // Org-owned forms have no allowlist axis and were already rejected above
+    // if visibleOrgIds was supplied; only partner-wide creates sync links.
+    const normalizedVisibleOrgIds = normalizeVisibleOrgIds(payload.visibleOrgIds);
+    if (payload.ownerScope === 'partner') {
+      try {
+        await syncTicketFormOrgLinks(row.id, normalizedVisibleOrgIds, auth.partnerId!);
+      } catch (err) {
+        // A failed sync (e.g. cross-partner org id) must not leave an
+        // orphaned half-created form behind — delete it and surface the 400.
+        await db.delete(ticketForms).where(eq(ticketForms.id, row.id));
+        return handleServiceError(c, err);
+      }
+    }
+
     writeRouteAudit(c, {
       orgId: row.orgId,
       action: 'ticket_form.create',
@@ -190,7 +231,7 @@ ticketFormRoutes.post(
       details: { formId: row.id, name: row.name, partnerWide: row.orgId === null }
     });
 
-    return c.json({ data: row }, 201);
+    return c.json({ data: { ...row, visibleOrgIds: normalizedVisibleOrgIds } }, 201);
   }
 );
 
@@ -214,6 +255,12 @@ ticketFormRoutes.put(
       return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
+    // visibleOrgIds is only meaningful on a partner-wide row (org-owned forms
+    // have no partner allowlist axis).
+    if (payload.visibleOrgIds !== undefined && row.orgId !== null) {
+      return c.json({ error: VISIBLE_ORG_IDS_SCOPE_ERROR }, 400);
+    }
+
     if (payload.categoryId) {
       const effectivePartnerId = await resolveEffectivePartnerId({ orgId: row.orgId, partnerId: row.partnerId });
       try {
@@ -223,15 +270,31 @@ ticketFormRoutes.put(
       }
     }
 
+    // undefined = links untouched; null/[] = clear (normalized); non-empty
+    // array = replace. Run BEFORE the column update so a rejected sync (e.g.
+    // cross-partner org id) leaves the form row completely unmodified.
+    if (payload.visibleOrgIds !== undefined) {
+      const normalized = normalizeVisibleOrgIds(payload.visibleOrgIds);
+      try {
+        await syncTicketFormOrgLinks(id, normalized, row.partnerId!);
+      } catch (err) {
+        return handleServiceError(c, err);
+      }
+    }
+
+    // visibleOrgIds is not a ticket_forms column — strip it explicitly rather
+    // than relying on drizzle to drop unknown keys from the .set() spread.
+    const { visibleOrgIds, ...columns } = payload;
+
     // version identifies which field schema stored responses were validated
     // against and which template composed the subject, so it only bumps when
-    // fields/titleTemplate change; presentation-only fields (isActive/sortOrder)
-    // don't bump.
+    // fields/titleTemplate change; presentation-only fields (isActive/sortOrder/
+    // visibleOrgIds) don't bump.
     const bumpVersion = payload.fields !== undefined || payload.titleTemplate !== undefined;
     const [updated] = await db
       .update(ticketForms)
       .set({
-        ...payload,
+        ...columns,
         ...(bumpVersion ? { version: row.version + 1 } : {}),
         updatedAt: new Date()
       })

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -293,6 +293,14 @@ const CORE_ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'sso_verified_domains',
   'storage_encryption_keys',
   'ticket_alert_links',
+  // ticket_form_org_links (spec 2026-07-11): org allowlist for partner-wide
+  // ticket_forms. Own org_id column is a direct FK to organizations (ON
+  // DELETE CASCADE already clears rows on org delete; listed here anyway per
+  // the cascade contract test's requirement that every org_id-columned table
+  // be enumerated for auditability). localeCompare sorts this BEFORE
+  // 'ticket_forms' (underscore < 's'), not after — verified against the
+  // alphabetization contract test in tenantCascade.integration.test.ts.
+  'ticket_form_org_links',
   // ticket_forms (spec 2026-07-10): dual-axis (org_id XOR partner_id) —
   // partner-wide forms are cleared via cascadeDeletePartner's dynamic
   // partner_id sweep (information_schema-driven), not a static list; this

--- a/apps/api/src/services/ticketFormService.test.ts
+++ b/apps/api/src/services/ticketFormService.test.ts
@@ -9,6 +9,10 @@ const { dbSelectMock, insertValuesMock, deleteWhereMock } = vi.hoisted(() => ({
 vi.mock('../db', () => ({
   runOutsideDbContext: (fn: () => unknown) => fn(),
   withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  // syncTicketFormOrgLinks runs on the ambient request transaction when one
+  // exists (the FK-seam fix); a truthy context makes it use `db` directly,
+  // which is the mocked query builder these tests assert against.
+  getCurrentDbAccessContext: () => ({ scope: 'partner' }),
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({

--- a/apps/api/src/services/ticketFormService.test.ts
+++ b/apps/api/src/services/ticketFormService.test.ts
@@ -119,21 +119,25 @@ describe('getTicketFormForOrg', () => {
     expect(dbSelectMock).toHaveBeenCalledTimes(1);
   });
 
+  // isOrgAllowedForPartnerWideForm now issues ONE query with two EXISTS
+  // probes (anyLinks / linkForOrg) instead of fetching up to 500 link rows
+  // and doing the membership check in JS — see ticketFormService.ts. The
+  // second dbSelectMock resolution below stands in for that probe's row.
   it('resolves when partner-wide form has no link rows (allowlist not in effect)', async () => {
     dbSelectMock.mockResolvedValueOnce([form]); // form select
-    dbSelectMock.mockResolvedValueOnce([]); // links select — no rows
+    dbSelectMock.mockResolvedValueOnce([{ anyLinks: false, linkForOrg: false }]); // probe: no links
     await expect(getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' })).resolves.toMatchObject({ id: 'form-1' });
   });
 
   it('resolves when partner-wide form has link rows that include this org', async () => {
     dbSelectMock.mockResolvedValueOnce([form]);
-    dbSelectMock.mockResolvedValueOnce([{ orgId: 'org-2' }, { orgId: 'org-1' }]);
+    dbSelectMock.mockResolvedValueOnce([{ anyLinks: true, linkForOrg: true }]); // probe: links exist, org included
     await expect(getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' })).resolves.toMatchObject({ id: 'form-1' });
   });
 
   it('400 (tenant-miss message, deliberately indistinguishable) when partner-wide form has link rows that EXCLUDE this org', async () => {
     dbSelectMock.mockResolvedValueOnce([form]);
-    dbSelectMock.mockResolvedValueOnce([{ orgId: 'org-OTHER' }]);
+    dbSelectMock.mockResolvedValueOnce([{ anyLinks: true, linkForOrg: false }]); // probe: links exist, org excluded
     const err = await getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' }).catch((e) => e);
     expect(err).toBeInstanceOf(TicketFormError);
     expect(err.status).toBe(400);
@@ -142,7 +146,7 @@ describe('getTicketFormForOrg', () => {
 
   it('400 when inactive (isActive is checked after the allowlist passes)', async () => {
     dbSelectMock.mockResolvedValueOnce([{ ...(form as object), isActive: false }]);
-    dbSelectMock.mockResolvedValueOnce([]); // no links — allowlist passes
+    dbSelectMock.mockResolvedValueOnce([{ anyLinks: false, linkForOrg: false }]); // no links — allowlist passes
     await expect(getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' })).rejects.toMatchObject({ status: 400 });
   });
 
@@ -182,7 +186,10 @@ describe('syncTicketFormOrgLinks', () => {
     expect(insertValuesMock).not.toHaveBeenCalled();
   });
 
-  it('empty array is a valid "allowlist nobody" state: deletes all, skips org validation and insert', async () => {
+  // Not a distinct "allowlist nobody" state (routes normalize [] -> null
+  // before calling this) — an empty array converges on the exact same
+  // zero-row result as null, since both delete all links and insert nothing.
+  it('empty array converges on the same zero-row result as null: deletes all, skips org validation and insert', async () => {
     await syncTicketFormOrgLinks('form-1', [], 'p-1');
     expect(deleteWhereMock).toHaveBeenCalledTimes(1);
     expect(dbSelectMock).not.toHaveBeenCalled();

--- a/apps/api/src/services/ticketFormService.test.ts
+++ b/apps/api/src/services/ticketFormService.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { dbSelectMock } = vi.hoisted(() => ({ dbSelectMock: vi.fn() }));
+const { dbSelectMock, insertValuesMock, deleteWhereMock } = vi.hoisted(() => ({
+  dbSelectMock: vi.fn(),
+  insertValuesMock: vi.fn(),
+  deleteWhereMock: vi.fn()
+}));
 
 vi.mock('../db', () => ({
   runOutsideDbContext: (fn: () => unknown) => fn(),
@@ -13,11 +17,29 @@ vi.mock('../db', () => ({
           orderBy: vi.fn(() => dbSelectMock())
         }))
       }))
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((v: unknown) => {
+        insertValuesMock(v);
+        return Promise.resolve();
+      })
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn((...args: unknown[]) => {
+        deleteWhereMock(...args);
+        return Promise.resolve();
+      })
     }))
   }
 }));
 
-import { applyIntakeForm, getTicketFormForOrg, TicketFormError } from './ticketFormService';
+import {
+  applyIntakeForm,
+  getTicketFormForOrg,
+  getTicketFormOrgLinkMap,
+  syncTicketFormOrgLinks,
+  TicketFormError
+} from './ticketFormService';
 
 const form = {
   id: 'form-1',
@@ -78,19 +100,146 @@ describe('getTicketFormForOrg', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('404 when missing', async () => {
-    dbSelectMock.mockResolvedValue([]);
+    dbSelectMock.mockResolvedValueOnce([]);
     await expect(getTicketFormForOrg('nope', { id: 'org-1', partnerId: 'p-1' })).rejects.toMatchObject({ status: 404 });
   });
 
-  it('400 when the form belongs to another tenant', async () => {
-    dbSelectMock.mockResolvedValue([{ ...(form as object), partnerId: 'p-OTHER' }]);
+  it('400 when the form belongs to another tenant (org-owned-elsewhere AND partner-wide-elsewhere both fail)', async () => {
+    dbSelectMock.mockResolvedValueOnce([{ ...(form as object), partnerId: 'p-OTHER' }]);
+    await expect(getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' })).rejects.toMatchObject({ status: 400 });
+    // Only the single form select ran — a tenant mismatch never reaches the
+    // allowlist check.
+    expect(dbSelectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('org-owned forms skip the allowlist check entirely (single select)', async () => {
+    const orgOwned = { ...(form as object), orgId: 'org-1', partnerId: null };
+    dbSelectMock.mockResolvedValueOnce([orgOwned]);
+    await expect(getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' })).resolves.toMatchObject({ id: 'form-1' });
+    expect(dbSelectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves when partner-wide form has no link rows (allowlist not in effect)', async () => {
+    dbSelectMock.mockResolvedValueOnce([form]); // form select
+    dbSelectMock.mockResolvedValueOnce([]); // links select — no rows
+    await expect(getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' })).resolves.toMatchObject({ id: 'form-1' });
+  });
+
+  it('resolves when partner-wide form has link rows that include this org', async () => {
+    dbSelectMock.mockResolvedValueOnce([form]);
+    dbSelectMock.mockResolvedValueOnce([{ orgId: 'org-2' }, { orgId: 'org-1' }]);
+    await expect(getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' })).resolves.toMatchObject({ id: 'form-1' });
+  });
+
+  it('400 (tenant-miss message, deliberately indistinguishable) when partner-wide form has link rows that EXCLUDE this org', async () => {
+    dbSelectMock.mockResolvedValueOnce([form]);
+    dbSelectMock.mockResolvedValueOnce([{ orgId: 'org-OTHER' }]);
+    const err = await getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' }).catch((e) => e);
+    expect(err).toBeInstanceOf(TicketFormError);
+    expect(err.status).toBe(400);
+    expect(err.message).toBe('Ticket form is not available for this organization');
+  });
+
+  it('400 when inactive (isActive is checked after the allowlist passes)', async () => {
+    dbSelectMock.mockResolvedValueOnce([{ ...(form as object), isActive: false }]);
+    dbSelectMock.mockResolvedValueOnce([]); // no links — allowlist passes
     await expect(getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' })).rejects.toMatchObject({ status: 400 });
   });
 
-  it('400 when inactive; resolves when partner-wide matches the org partner', async () => {
-    dbSelectMock.mockResolvedValue([{ ...(form as object), isActive: false }]);
-    await expect(getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' })).rejects.toMatchObject({ status: 400 });
-    dbSelectMock.mockResolvedValue([form]);
+  it('requirePortalVisible: 400 when showInPortal is false', async () => {
+    const orgOwned = { ...(form as object), orgId: 'org-1', partnerId: null, showInPortal: false };
+    dbSelectMock.mockResolvedValueOnce([orgOwned]);
+    const err = await getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' }, { requirePortalVisible: true }).catch(
+      (e) => e
+    );
+    expect(err).toBeInstanceOf(TicketFormError);
+    expect(err.status).toBe(400);
+    expect(err.message).toBe('Ticket form is not available in the portal');
+  });
+
+  it('requirePortalVisible: resolves when showInPortal is true', async () => {
+    const orgOwned = { ...(form as object), orgId: 'org-1', partnerId: null, showInPortal: true };
+    dbSelectMock.mockResolvedValueOnce([orgOwned]);
+    await expect(
+      getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' }, { requirePortalVisible: true })
+    ).resolves.toMatchObject({ id: 'form-1' });
+  });
+
+  it('requirePortalVisible absent: does not enforce portal visibility even when showInPortal is false', async () => {
+    const orgOwned = { ...(form as object), orgId: 'org-1', partnerId: null, showInPortal: false };
+    dbSelectMock.mockResolvedValueOnce([orgOwned]);
     await expect(getTicketFormForOrg('form-1', { id: 'org-1', partnerId: 'p-1' })).resolves.toMatchObject({ id: 'form-1' });
+  });
+});
+
+describe('syncTicketFormOrgLinks', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('null orgIds deletes all links and never validates orgs or inserts', async () => {
+    await syncTicketFormOrgLinks('form-1', null, 'p-1');
+    expect(deleteWhereMock).toHaveBeenCalledTimes(1);
+    expect(dbSelectMock).not.toHaveBeenCalled();
+    expect(insertValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('empty array is a valid "allowlist nobody" state: deletes all, skips org validation and insert', async () => {
+    await syncTicketFormOrgLinks('form-1', [], 'p-1');
+    expect(deleteWhereMock).toHaveBeenCalledTimes(1);
+    expect(dbSelectMock).not.toHaveBeenCalled();
+    expect(insertValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('non-empty array: validates every org belongs to partnerId, dedupes, then replaces (delete + insert)', async () => {
+    dbSelectMock.mockResolvedValueOnce([
+      { id: 'org-a', partnerId: 'p-1' },
+      { id: 'org-b', partnerId: 'p-1' }
+    ]);
+    await syncTicketFormOrgLinks('form-1', ['org-a', 'org-b', 'org-a'], 'p-1');
+    expect(deleteWhereMock).toHaveBeenCalledTimes(1);
+    expect(insertValuesMock).toHaveBeenCalledTimes(1);
+    const inserted = insertValuesMock.mock.calls[0]![0] as Array<{ formId: string; orgId: string }>;
+    expect(inserted).toHaveLength(2); // deduped
+    expect(inserted.map((r) => r.orgId).sort()).toEqual(['org-a', 'org-b']);
+    expect(inserted.every((r) => r.formId === 'form-1')).toBe(true);
+  });
+
+  it('throws when an org belongs to a different partner (write aborted before delete/insert)', async () => {
+    dbSelectMock.mockResolvedValueOnce([{ id: 'org-a', partnerId: 'p-OTHER' }]);
+    const err = await syncTicketFormOrgLinks('form-1', ['org-a'], 'p-1').catch((e) => e);
+    expect(err).toBeInstanceOf(TicketFormError);
+    expect(err.status).toBe(400);
+    expect(err.message).toBe('visibleOrgIds must reference organizations of the owning partner');
+    expect(deleteWhereMock).not.toHaveBeenCalled();
+    expect(insertValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('throws when an org id does not exist at all', async () => {
+    dbSelectMock.mockResolvedValueOnce([]); // org-a not found
+    const err = await syncTicketFormOrgLinks('form-1', ['org-a'], 'p-1').catch((e) => e);
+    expect(err).toBeInstanceOf(TicketFormError);
+    expect(err.status).toBe(400);
+    expect(deleteWhereMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('getTicketFormOrgLinkMap', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns an empty map without querying when formIds is empty', async () => {
+    const map = await getTicketFormOrgLinkMap([]);
+    expect(map.size).toBe(0);
+    expect(dbSelectMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a map keyed only by forms that have link rows', async () => {
+    dbSelectMock.mockResolvedValueOnce([
+      { formId: 'f1', orgId: 'o1' },
+      { formId: 'f1', orgId: 'o2' },
+      { formId: 'f2', orgId: 'o3' }
+    ]);
+    const map = await getTicketFormOrgLinkMap(['f1', 'f2', 'f3']);
+    expect(map.get('f1')).toEqual(['o1', 'o2']);
+    expect(map.get('f2')).toEqual(['o3']);
+    expect(map.has('f3')).toBe(false);
   });
 });

--- a/apps/api/src/services/ticketFormService.ts
+++ b/apps/api/src/services/ticketFormService.ts
@@ -75,15 +75,27 @@ export async function listTicketFormsForOrg(org: OrgRef, opts?: { portalOnly?: b
  * under the partner may use it; rows present = only the linked orgs may.
  * Reads under a system context. Callers must only invoke this once the form
  * is already confirmed partner-wide AND owned by this org's own partner.
+ *
+ * Two EXISTS probes (any-links / link-for-this-org) in one query — mirrors
+ * the NOT EXISTS/EXISTS shape in listTicketFormsForOrg's WHERE — rather than
+ * fetching up to 500 link rows and doing the membership check in JS.
  */
 async function isOrgAllowedForPartnerWideForm(formId: string, orgId: string): Promise<boolean> {
-  const links = await runOutsideDbContext(() =>
+  const rows = await runOutsideDbContext(() =>
     withSystemDbAccessContext(() =>
-      db.select({ orgId: ticketFormOrgLinks.orgId }).from(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.formId, formId)).limit(500)
+      db
+        .select({
+          anyLinks: sql<boolean>`EXISTS (SELECT 1 FROM ${ticketFormOrgLinks} WHERE ${ticketFormOrgLinks.formId} = ${ticketForms.id})`,
+          linkForOrg: sql<boolean>`EXISTS (SELECT 1 FROM ${ticketFormOrgLinks} WHERE ${ticketFormOrgLinks.formId} = ${ticketForms.id} AND ${ticketFormOrgLinks.orgId} = ${orgId})`
+        })
+        .from(ticketForms)
+        .where(eq(ticketForms.id, formId))
+        .limit(1)
     )
   );
-  if (links.length === 0) return true; // no rows = allowlist not in effect
-  return links.some((l) => l.orgId === orgId);
+  const row = rows[0];
+  if (!row || !row.anyLinks) return true; // no rows (or form vanished) = allowlist not in effect
+  return row.linkForOrg;
 }
 
 /**
@@ -125,11 +137,14 @@ export async function getTicketFormForOrg(
  * Replace the org allowlist for a form (system-context write; intended for
  * partner-wide forms only — callers gate visibleOrgIds to ownerScope
  * 'partner' before reaching here). `null` clears the allowlist entirely
- * (form reverts to visible-to-all-the-partner's-orgs); an array (including
- * empty) replaces the link rows wholesale — an empty array is a valid
- * "allowlist nobody" state, not an error. Every id in a non-empty array MUST
- * belong to `partnerId`, checked with a single select before any write so a
- * cross-partner id can never sneak in as a link.
+ * (form reverts to visible-to-all-the-partner's-orgs). An array replaces the
+ * link rows wholesale; an EMPTY array produces the exact same zero-row state
+ * as `null` — there is no distinct "allowlist nobody" state, since "no link
+ * rows" already means visible-to-all (spec ruling). Callers (routes) should
+ * normalize `[] -> null` before calling, but this function tolerates either
+ * because both converge on the same persisted result. Every id in a
+ * non-empty array MUST belong to `partnerId`, checked with a single select
+ * before any write so a cross-partner id can never sneak in as a link.
  */
 export async function syncTicketFormOrgLinks(formId: string, orgIds: string[] | null, partnerId: string): Promise<void> {
   return runOutsideDbContext(() =>
@@ -164,8 +179,10 @@ export async function syncTicketFormOrgLinks(formId: string, orgIds: string[] | 
 /**
  * Link map for management-list responses: `Map<formId, orgId[]>` containing
  * ONLY the forms that have link rows (a form with no entry means "no
- * allowlist" / visible to all the partner's orgs — callers must not confuse
- * a missing key with an empty-allowlist array, which is a distinct state).
+ * allowlist" / visible to all the partner's orgs). The map can never hold an
+ * empty array — a form only gets a key when at least one link row exists —
+ * so there is no distinct "empty allowlist" state to guard against; a
+ * missing key IS the all-orgs state.
  */
 export async function getTicketFormOrgLinkMap(formIds: string[]): Promise<Map<string, string[]>> {
   if (formIds.length === 0) return new Map();

--- a/apps/api/src/services/ticketFormService.ts
+++ b/apps/api/src/services/ticketFormService.ts
@@ -6,7 +6,7 @@ import {
   type TicketFormField,
   type TicketPriority
 } from '@breeze/shared';
-import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { db, getCurrentDbAccessContext, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { organizations, ticketFormOrgLinks, ticketForms } from '../db/schema';
 
 export type TicketFormRow = typeof ticketForms.$inferSelect;
@@ -147,33 +147,55 @@ export async function getTicketFormForOrg(
  * before any write so a cross-partner id can never sneak in as a link.
  */
 export async function syncTicketFormOrgLinks(formId: string, orgIds: string[] | null, partnerId: string): Promise<void> {
-  return runOutsideDbContext(() =>
-    withSystemDbAccessContext(async () => {
-      if (orgIds === null) {
-        await db.delete(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.formId, formId));
-        return;
-      }
-      const dedupedIds = Array.from(new Set(orgIds));
-      if (dedupedIds.length > 0) {
-        const orgRows = await db
-          .select({ id: organizations.id, partnerId: organizations.partnerId })
-          .from(organizations)
-          .where(inArray(organizations.id, dedupedIds))
-          .limit(500);
-        const partnerIdById = new Map(orgRows.map((r) => [r.id, r.partnerId]));
-        const allBelongToPartner = dedupedIds.every((id) => partnerIdById.get(id) === partnerId);
-        if (!allBelongToPartner) {
-          throw new TicketFormError('visibleOrgIds must reference organizations of the owning partner', 400);
-        }
-      }
-      // Replace semantics: delete-all then bulk insert, inside the same
-      // system-context transaction as the validation read above.
+  const sync = async () => {
+    if (orgIds === null) {
       await db.delete(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.formId, formId));
-      if (dedupedIds.length > 0) {
-        await db.insert(ticketFormOrgLinks).values(dedupedIds.map((orgId) => ({ formId, orgId })));
+      return;
+    }
+    const dedupedIds = Array.from(new Set(orgIds));
+    if (dedupedIds.length > 0) {
+      const orgRows = await db
+        .select({ id: organizations.id, partnerId: organizations.partnerId })
+        .from(organizations)
+        .where(inArray(organizations.id, dedupedIds))
+        .limit(500);
+      const partnerIdById = new Map(orgRows.map((r) => [r.id, r.partnerId]));
+      const allBelongToPartner = dedupedIds.every((id) => partnerIdById.get(id) === partnerId);
+      if (!allBelongToPartner) {
+        throw new TicketFormError('visibleOrgIds must reference organizations of the owning partner', 400);
       }
-    })
-  );
+    }
+    // Replace semantics: delete-all then bulk insert, in ONE transaction with
+    // the validation read above.
+    await db.delete(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.formId, formId));
+    if (dedupedIds.length > 0) {
+      await db.insert(ticketFormOrgLinks).values(dedupedIds.map((orgId) => ({ formId, orgId })));
+    }
+  };
+
+  // The link write MUST share the caller's ambient request transaction when one
+  // exists. On POST /ticket-forms the parent ticket_forms row is inserted
+  // uncommitted on the request transaction (C1); escaping to a FRESH system
+  // transaction on another pooled connection (C2) means C2's READ COMMITTED
+  // snapshot cannot see that parent, so the link policy's WITH CHECK
+  // `EXISTS (... ticket_forms ...)` finds no parent row and the insert is
+  // rejected (42501) — the create 500s (whole-branch review Critical). Running
+  // on the ambient transaction lets the write see the same-transaction parent.
+  //
+  // Only partner-scoped tokens with orgAccess='all' reach this code path (POST
+  // partner-wide + PUT partner-wide, both behind canManagePartnerWidePolicies),
+  // so the ambient context is a partner context whose accessiblePartnerIds
+  // covers the owning partner and whose accessibleOrgIds covers every org under
+  // it. That clears BOTH the link WITH CHECK (breeze_has_partner_access on the
+  // parent's partner_id) and the org-belongs-to-partner validation read
+  // (breeze_has_org_access on organizations) — RLS stays fully enforced, it is
+  // simply satisfied by the caller's own partner scope rather than a system
+  // escalation. When there is NO ambient context (defensive; no current caller
+  // reaches here contextless) fall back to a fresh system context.
+  if (getCurrentDbAccessContext()) {
+    return sync();
+  }
+  return runOutsideDbContext(() => withSystemDbAccessContext(sync));
 }
 
 /**

--- a/apps/api/src/services/ticketFormService.ts
+++ b/apps/api/src/services/ticketFormService.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray, sql } from 'drizzle-orm';
 import {
   buildResponseValidator,
   renderFormResponses,
@@ -7,7 +7,7 @@ import {
   type TicketPriority
 } from '@breeze/shared';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { ticketForms } from '../db/schema';
+import { organizations, ticketFormOrgLinks, ticketForms } from '../db/schema';
 
 export type TicketFormRow = typeof ticketForms.$inferSelect;
 
@@ -33,10 +33,12 @@ interface OrgRef {
 
 /**
  * Forms visible to an org: org-owned rows plus the org's partner's
- * partner-wide rows. Partner-owned rows are INVISIBLE to org-scoped RLS
- * contexts (heartbeat/#1105 pattern), so this reads under a system context
- * and filters explicitly. Callers MUST have already authorized the org
- * (route: auth.canAccessOrg).
+ * partner-wide rows THAT pass the org allowlist (spec §5): no
+ * ticket_form_org_links rows for a form = visible to every org under the
+ * partner; rows present = only the linked orgs see it. Partner-owned rows
+ * are INVISIBLE to org-scoped RLS contexts (heartbeat/#1105 pattern), so
+ * this reads under a system context and filters explicitly. Callers MUST
+ * have already authorized the org (route: auth.canAccessOrg).
  */
 export async function listTicketFormsForOrg(org: OrgRef, opts?: { portalOnly?: boolean }): Promise<TicketFormRow[]> {
   return runOutsideDbContext(() =>
@@ -48,7 +50,19 @@ export async function listTicketFormsForOrg(org: OrgRef, opts?: { portalOnly?: b
           and(
             eq(ticketForms.isActive, true),
             opts?.portalOnly ? eq(ticketForms.showInPortal, true) : undefined,
-            sql`(${ticketForms.orgId} = ${org.id} OR (${ticketForms.orgId} IS NULL AND ${ticketForms.partnerId} = ${org.partnerId}))`
+            sql`(
+              ${ticketForms.orgId} = ${org.id}
+              OR (
+                ${ticketForms.orgId} IS NULL AND ${ticketForms.partnerId} = ${org.partnerId}
+                AND (
+                  NOT EXISTS (SELECT 1 FROM ${ticketFormOrgLinks} WHERE ${ticketFormOrgLinks.formId} = ${ticketForms.id})
+                  OR EXISTS (
+                    SELECT 1 FROM ${ticketFormOrgLinks}
+                    WHERE ${ticketFormOrgLinks.formId} = ${ticketForms.id} AND ${ticketFormOrgLinks.orgId} = ${org.id}
+                  )
+                )
+              )
+            )`
           )
         )
         .orderBy(asc(ticketForms.sortOrder), asc(ticketForms.name))
@@ -57,12 +71,33 @@ export async function listTicketFormsForOrg(org: OrgRef, opts?: { portalOnly?: b
 }
 
 /**
- * Load a form and verify it is usable for the given org (tenant + active).
- * The caller MUST have already authorized the org (createTicket resolves it
- * from the ticket's target org before calling here) — this reads under a system
- * context so it does not re-check tenancy at the RLS layer.
+ * Allowlist check for a single partner-wide form: no link rows = every org
+ * under the partner may use it; rows present = only the linked orgs may.
+ * Reads under a system context. Callers must only invoke this once the form
+ * is already confirmed partner-wide AND owned by this org's own partner.
  */
-export async function getTicketFormForOrg(formId: string, org: OrgRef): Promise<TicketFormRow> {
+async function isOrgAllowedForPartnerWideForm(formId: string, orgId: string): Promise<boolean> {
+  const links = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db.select({ orgId: ticketFormOrgLinks.orgId }).from(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.formId, formId)).limit(500)
+    )
+  );
+  if (links.length === 0) return true; // no rows = allowlist not in effect
+  return links.some((l) => l.orgId === orgId);
+}
+
+/**
+ * Load a form and verify it is usable for the given org (tenant + allowlist +
+ * active [+ portal, when requested]). The caller MUST have already
+ * authorized the org (createTicket resolves it from the ticket's target org
+ * before calling here) — this reads under a system context so it does not
+ * re-check tenancy at the RLS layer.
+ */
+export async function getTicketFormForOrg(
+  formId: string,
+  org: OrgRef,
+  opts?: { requirePortalVisible?: boolean }
+): Promise<TicketFormRow> {
   const rows = await runOutsideDbContext(() =>
     withSystemDbAccessContext(() => db.select().from(ticketForms).where(eq(ticketForms.id, formId)).limit(1))
   );
@@ -73,8 +108,83 @@ export async function getTicketFormForOrg(formId: string, org: OrgRef): Promise<
   if (!ownedByOrg && !partnerWide) {
     throw new TicketFormError('Ticket form is not available for this organization', 400);
   }
+  // Same message as the tenant-miss above, deliberately indistinguishable: an
+  // allowlist miss must not let a caller (e.g. a portal user probing formIds)
+  // learn the form exists but simply excludes their org.
+  if (partnerWide && !(await isOrgAllowedForPartnerWideForm(form.id, org.id))) {
+    throw new TicketFormError('Ticket form is not available for this organization', 400);
+  }
   if (!form.isActive) throw new TicketFormError('Ticket form is inactive', 400);
+  if (opts?.requirePortalVisible && !form.showInPortal) {
+    throw new TicketFormError('Ticket form is not available in the portal', 400);
+  }
   return form;
+}
+
+/**
+ * Replace the org allowlist for a form (system-context write; intended for
+ * partner-wide forms only — callers gate visibleOrgIds to ownerScope
+ * 'partner' before reaching here). `null` clears the allowlist entirely
+ * (form reverts to visible-to-all-the-partner's-orgs); an array (including
+ * empty) replaces the link rows wholesale — an empty array is a valid
+ * "allowlist nobody" state, not an error. Every id in a non-empty array MUST
+ * belong to `partnerId`, checked with a single select before any write so a
+ * cross-partner id can never sneak in as a link.
+ */
+export async function syncTicketFormOrgLinks(formId: string, orgIds: string[] | null, partnerId: string): Promise<void> {
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      if (orgIds === null) {
+        await db.delete(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.formId, formId));
+        return;
+      }
+      const dedupedIds = Array.from(new Set(orgIds));
+      if (dedupedIds.length > 0) {
+        const orgRows = await db
+          .select({ id: organizations.id, partnerId: organizations.partnerId })
+          .from(organizations)
+          .where(inArray(organizations.id, dedupedIds))
+          .limit(500);
+        const partnerIdById = new Map(orgRows.map((r) => [r.id, r.partnerId]));
+        const allBelongToPartner = dedupedIds.every((id) => partnerIdById.get(id) === partnerId);
+        if (!allBelongToPartner) {
+          throw new TicketFormError('visibleOrgIds must reference organizations of the owning partner', 400);
+        }
+      }
+      // Replace semantics: delete-all then bulk insert, inside the same
+      // system-context transaction as the validation read above.
+      await db.delete(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.formId, formId));
+      if (dedupedIds.length > 0) {
+        await db.insert(ticketFormOrgLinks).values(dedupedIds.map((orgId) => ({ formId, orgId })));
+      }
+    })
+  );
+}
+
+/**
+ * Link map for management-list responses: `Map<formId, orgId[]>` containing
+ * ONLY the forms that have link rows (a form with no entry means "no
+ * allowlist" / visible to all the partner's orgs — callers must not confuse
+ * a missing key with an empty-allowlist array, which is a distinct state).
+ */
+export async function getTicketFormOrgLinkMap(formIds: string[]): Promise<Map<string, string[]>> {
+  if (formIds.length === 0) return new Map();
+  const rows = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db
+        .select({ formId: ticketFormOrgLinks.formId, orgId: ticketFormOrgLinks.orgId })
+        .from(ticketFormOrgLinks)
+        .where(inArray(ticketFormOrgLinks.formId, formIds))
+        .limit(10_000)
+    )
+  );
+  const map = new Map<string, string[]>();
+  for (const row of rows) {
+    const list = map.get(row.formId);
+    if (list) list.push(row.orgId);
+    else map.set(row.formId, [row.orgId]);
+  }
+  return map;
 }
 
 export interface AppliedIntakeForm {

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -515,7 +515,11 @@ describe('createTicket — intake form (formId)', () => {
       actor
     );
 
-    expect(formMocks.getTicketFormForOrg).toHaveBeenCalledWith('form-1', { id: 'o-1', partnerId: 'p-1' });
+    expect(formMocks.getTicketFormForOrg).toHaveBeenCalledWith(
+      'form-1',
+      { id: 'o-1', partnerId: 'p-1' },
+      { requirePortalVisible: false }
+    );
     expect(formMocks.applyIntakeForm).toHaveBeenCalledWith(
       { id: 'form-1', name: 'Intake', version: 1 },
       { affected_user: 'jdoe' }
@@ -601,6 +605,57 @@ describe('createTicket — intake form (formId)', () => {
     expect(err.status).toBe(400);
     expect(err.message).toMatch(/not available for this organization/i);
     expect(valuesMock).not.toHaveBeenCalled();
+  });
+
+  it('portal source passes requirePortalVisible:true; a showInPortal-guard rejection maps to TicketServiceError 400 and writes nothing', async () => {
+    dbMocks.selectResult.mockResolvedValue([{ id: 'o-1', partnerId: 'p-1' }]);
+    const { TicketFormError } = await vi.importActual<typeof import('./ticketFormService')>('./ticketFormService');
+    formMocks.getTicketFormForOrg.mockRejectedValue(new TicketFormError('Ticket form is not available in the portal', 400));
+
+    const err = await createTicket(
+      {
+        orgId: 'o-1',
+        source: 'portal',
+        submittedBy: 'user-1',
+        submitterEmail: 'client@client.example',
+        formId: 'form-internal',
+        formResponses: {}
+      },
+      actor
+    ).catch((e) => e);
+
+    expect(formMocks.getTicketFormForOrg).toHaveBeenCalledWith(
+      'form-internal',
+      { id: 'o-1', partnerId: 'p-1' },
+      { requirePortalVisible: true }
+    );
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(400);
+    expect(err.message).toMatch(/not available in the portal/i);
+    expect(valuesMock).not.toHaveBeenCalled();
+  });
+
+  it('non-portal source (e.g. manual/api/alert) does not require portal visibility', async () => {
+    dbMocks.selectResult.mockResolvedValue([{ id: 'o-1', partnerId: 'p-1' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 't-form-4', orgId: 'o-1', internalNumber: 'T-2026-0042', status: 'new' }]);
+    formMocks.getTicketFormForOrg.mockResolvedValue({ id: 'form-1', name: 'Intake', version: 1 });
+    formMocks.applyIntakeForm.mockReturnValue({
+      responses: {},
+      subjectFromForm: 'Form subject',
+      descriptionBlock: 'form block',
+      categoryId: null,
+      defaultPriority: null,
+      defaultTags: [],
+      intakeSnapshot: { intakeForm: { formId: 'form-1', formName: 'Intake', formVersion: 1, responses: {} } }
+    });
+
+    await createTicket({ orgId: 'o-1', source: 'api', formId: 'form-1', formResponses: {} }, actor);
+
+    expect(formMocks.getTicketFormForOrg).toHaveBeenCalledWith(
+      'form-1',
+      { id: 'o-1', partnerId: 'p-1' },
+      { requirePortalVisible: false }
+    );
   });
 });
 

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -270,7 +270,11 @@ export async function createTicket(input: CreateTicketInput, actor: TicketActor)
   let intake: ReturnType<typeof applyIntakeForm> | null = null;
   if (input.formId) {
     try {
-      const form = await getTicketFormForOrg(input.formId, { id: org.id, partnerId: org.partnerId });
+      const form = await getTicketFormForOrg(
+        input.formId,
+        { id: org.id, partnerId: org.partnerId },
+        { requirePortalVisible: input.source === 'portal' }
+      );
       intake = applyIntakeForm(form, input.formResponses ?? {});
     } catch (err) {
       if (err instanceof TicketFormError) throw new TicketServiceError(err.message, err.status);

--- a/apps/portal/Dockerfile
+++ b/apps/portal/Dockerfile
@@ -14,9 +14,14 @@ WORKDIR /app
 FROM base AS deps
 WORKDIR /app
 
-# Copy workspace configuration + portal manifest (portal has no workspace deps)
+# Copy workspace configuration + portal manifest. The portal depends on
+# packages/shared SOURCE at build time (runtime @breeze/shared imports, e.g. the
+# ticket intake-form validators, resolved via the tsconfig path alias), so the
+# shared manifest must be present for lockfile workspace resolution here and the
+# shared source must be copied into the builder stage below — mirrors apps/web/Dockerfile.
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY apps/portal/package.json ./apps/portal/
+COPY packages/shared/package.json ./packages/shared/
 
 # Install all dependencies
 RUN pnpm install --frozen-lockfile --prefer-offline
@@ -36,12 +41,15 @@ ENV NODE_ENV=${NODE_ENV}
 ENV PORTAL_BASE_PATH=${PORTAL_BASE_PATH}
 ENV PUBLIC_API_URL=${PUBLIC_API_URL}
 
-# Copy dependencies from deps stage
+# Copy dependencies from deps stage (packages/ carries packages/shared/node_modules
+# so @breeze/shared's own deps — e.g. zod — resolve during the build)
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/portal/node_modules ./apps/portal/node_modules
+COPY --from=deps /app/packages ./packages
 
-# Copy source code
+# Copy source code (packages/ = @breeze/shared source, imported at runtime by the portal)
 COPY apps/portal ./apps/portal
+COPY packages ./packages
 COPY tsconfig.json ./
 
 # Build the Astro application

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -30,8 +30,11 @@
     "@astrojs/check": "^0.9.9",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/vite": "^4.3.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.1.1",
     "tailwindcss": "^4.3.1",
     "typescript": "^5.7.2",
     "vitest": "^4.1.10"

--- a/apps/portal/src/components/portal/NewTicketForm.test.tsx
+++ b/apps/portal/src/components/portal/NewTicketForm.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import type { PortalTicketForm } from '@/lib/api';
+
+// Mock the API client + navigation so the component fetches from stubs and never
+// touches window navigation.
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('@/lib/api', () => ({
+  portalApi: {
+    getTicketForms: vi.fn(),
+    createTicket: vi.fn()
+  }
+}));
+
+import { portalApi } from '@/lib/api';
+import { NewTicketForm } from './NewTicketForm';
+
+const getTicketForms = portalApi.getTicketForms as ReturnType<typeof vi.fn>;
+const createTicket = portalApi.createTicket as ReturnType<typeof vi.fn>;
+
+const FORM: PortalTicketForm = {
+  id: 'form-1',
+  name: 'Printer Problem',
+  description: 'Report a printer issue',
+  categoryId: null,
+  defaultPriority: 'high',
+  fields: [
+    { key: 'model', label: 'Model', type: 'text', required: true },
+    { key: 'qty', label: 'Quantity', type: 'number', required: false }
+  ]
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createTicket.mockResolvedValue({ data: { id: 'ticket-99' } });
+});
+
+afterEach(() => cleanup());
+
+describe('NewTicketForm (portal) — intake form grid', () => {
+  it('renders the card grid from the fetched forms plus a "Something else" card', async () => {
+    getTicketForms.mockResolvedValue({ data: [FORM] });
+    render(<NewTicketForm />);
+
+    expect(await screen.findByTestId('portal-ticket-form-card-form-1')).toBeTruthy();
+    expect(screen.getByTestId('portal-ticket-form-card-blank')).toBeTruthy();
+  });
+
+  it('the blank card falls through to the legacy subject/description form', async () => {
+    getTicketForms.mockResolvedValue({ data: [FORM] });
+    render(<NewTicketForm />);
+
+    fireEvent.click(await screen.findByTestId('portal-ticket-form-card-blank'));
+
+    // Legacy free-text inputs are present; intake fields are not.
+    expect(screen.getByLabelText('Title')).toBeTruthy();
+    expect(screen.queryByTestId('ticket-form-field-model')).toBeNull();
+  });
+
+  it('selecting a form card renders its intake fields', async () => {
+    getTicketForms.mockResolvedValue({ data: [FORM] });
+    render(<NewTicketForm />);
+
+    fireEvent.click(await screen.findByTestId('portal-ticket-form-card-form-1'));
+
+    expect(screen.getByTestId('ticket-form-field-model')).toBeTruthy();
+    expect(screen.getByTestId('ticket-form-field-qty')).toBeTruthy();
+  });
+
+  it('blocks submit with an inline error when a required field is empty — no API call', async () => {
+    getTicketForms.mockResolvedValue({ data: [FORM] });
+    render(<NewTicketForm />);
+
+    fireEvent.click(await screen.findByTestId('portal-ticket-form-card-form-1'));
+    fireEvent.click(screen.getByTestId('portal-ticket-form-submit'));
+
+    const err = await screen.findByTestId('ticket-form-field-error-model');
+    expect(err.textContent).toBe('This field is required');
+    expect(createTicket).not.toHaveBeenCalled();
+  });
+
+  it('posts formId + coerced responses (no subject) on a valid submit', async () => {
+    getTicketForms.mockResolvedValue({ data: [FORM] });
+    render(<NewTicketForm />);
+
+    fireEvent.click(await screen.findByTestId('portal-ticket-form-card-form-1'));
+    fireEvent.change(screen.getByTestId('ticket-form-field-model'), { target: { value: 'HP LaserJet' } });
+    fireEvent.change(screen.getByTestId('ticket-form-field-qty'), { target: { value: '3' } });
+    fireEvent.click(screen.getByTestId('portal-ticket-form-submit'));
+
+    await waitFor(() => expect(createTicket).toHaveBeenCalledTimes(1));
+    const payload = createTicket.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      formId: 'form-1',
+      formResponses: { model: 'HP LaserJet', qty: 3 }, // '3' coerced to a number
+      priority: 'high' // prefilled from defaultPriority
+    });
+    expect(payload).not.toHaveProperty('subject');
+  });
+
+  it('degrades to the legacy form (with a console.warn) when the forms fetch fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    getTicketForms.mockResolvedValue({ error: 'Network error' });
+    render(<NewTicketForm />);
+
+    // Legacy form is shown; no grid.
+    expect(await screen.findByLabelText('Title')).toBeTruthy();
+    expect(screen.queryByTestId('portal-ticket-form-card-blank')).toBeNull();
+    await waitFor(() => expect(warn).toHaveBeenCalled());
+    warn.mockRestore();
+  });
+});

--- a/apps/portal/src/components/portal/NewTicketForm.tsx
+++ b/apps/portal/src/components/portal/NewTicketForm.tsx
@@ -1,12 +1,14 @@
 import { withBase } from '@/lib/basePath';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Loader2, AlertCircle, ArrowLeft } from 'lucide-react';
-import { portalApi } from '@/lib/api';
+import { Loader2, AlertCircle, ArrowLeft, FileText, MessageSquarePlus } from 'lucide-react';
+import { buildResponseValidator, coerceFormResponses } from '@breeze/shared';
+import { portalApi, type PortalTicketForm, type TicketPriority } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { navigateTo } from '@/lib/navigation';
+import TicketFormFields from './TicketFormFields';
 
 const ticketSchema = z.object({
   subject: z.string().min(5, 'Title must be at least 5 characters'),
@@ -16,9 +18,27 @@ const ticketSchema = z.object({
 
 type TicketFormData = z.infer<typeof ticketSchema>;
 
+const inputCls = cn(
+  'mt-1 block w-full rounded-md border bg-background px-3 py-2 text-sm shadow-xs',
+  'focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary'
+);
+
 export function NewTicketForm() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Intake forms (Phase 2). Purely additive: a fetch failure silently degrades to
+  // the legacy free-text form (no grid, no toast — just a console breadcrumb).
+  const [forms, setForms] = useState<PortalTicketForm[]>([]);
+  const [selectedForm, setSelectedForm] = useState<PortalTicketForm | null>(null);
+  // True once the user picks "Something else" from the grid → legacy free-text form.
+  const [showLegacy, setShowLegacy] = useState(false);
+
+  // Controlled state for the intake-form path.
+  const [formValues, setFormValues] = useState<Record<string, unknown>>({});
+  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+  const [formDescription, setFormDescription] = useState('');
+  const [formPriority, setFormPriority] = useState<TicketPriority>('normal');
 
   const {
     register,
@@ -31,6 +51,25 @@ export function NewTicketForm() {
     }
   });
 
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const result = await portalApi.getTicketForms();
+      if (cancelled) return;
+      if (result.data) {
+        setForms(result.data);
+      } else {
+        // Forms are additive — degrade to the legacy free-text form, but leave a
+        // breadcrumb so a broken picker isn't invisible in the console.
+        console.warn('[portal/new-ticket] forms fetch failed', result.error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Legacy free-text path — unchanged behaviour from before intake forms.
   const onSubmit = async (data: TicketFormData) => {
     setIsLoading(true);
     setError(null);
@@ -46,11 +85,83 @@ export function NewTicketForm() {
     setIsLoading(false);
   };
 
+  const selectForm = (form: PortalTicketForm) => {
+    setSelectedForm(form);
+    setShowLegacy(false);
+    setError(null);
+    setFormErrors({});
+    setFormDescription('');
+    setFormPriority(form.defaultPriority ?? 'normal');
+    const defaults: Record<string, unknown> = {};
+    for (const f of form.fields) if (f.defaultValue !== undefined) defaults[f.key] = f.defaultValue;
+    setFormValues(defaults);
+  };
+
+  // Back affordance → return to the card grid and clear all intake-form state.
+  const backToGrid = () => {
+    setSelectedForm(null);
+    setShowLegacy(false);
+    setFormValues({});
+    setFormErrors({});
+    setFormDescription('');
+    setError(null);
+  };
+
+  const submitForm = async () => {
+    if (!selectedForm) return;
+
+    // Validate client-side for inline errors before POSTing. The API re-validates
+    // authoritatively — this is a UX fast-path, not the gate.
+    const coerced = coerceFormResponses(selectedForm.fields, formValues);
+    const parsed = buildResponseValidator(selectedForm.fields).safeParse(coerced);
+    if (!parsed.success) {
+      const errs: Record<string, string> = {};
+      for (const issue of parsed.error.issues) {
+        const key = String(issue.path[0] ?? '');
+        // 'invalid_type: received undefined' on a missing required field reads badly — normalize.
+        if (key && !errs[key]) {
+          errs[key] =
+            issue.code === 'invalid_type' && coerced[key] === undefined
+              ? 'This field is required'
+              : issue.message;
+        }
+      }
+      // Guard against a silent no-op: if no issue mapped to a field key, surface a
+      // generic form-level error so validation failure is never invisible.
+      if (Object.keys(errs).length === 0) {
+        errs.__form = 'Some responses are invalid. Please review the form and try again.';
+      }
+      setFormErrors(errs);
+      return;
+    }
+
+    setFormErrors({});
+    setIsLoading(true);
+    setError(null);
+
+    const result = await portalApi.createTicket({
+      formId: selectedForm.id,
+      formResponses: parsed.data as Record<string, unknown>,
+      description: formDescription.trim() || undefined,
+      priority: formPriority
+    });
+
+    if (result.data) {
+      await navigateTo(`/tickets/${result.data.id}`);
+    } else {
+      setError(result.error || 'Failed to create ticket');
+    }
+
+    setIsLoading(false);
+  };
+
+  const showGrid = forms.length > 0 && !selectedForm && !showLegacy;
+
   return (
     <div className="mx-auto max-w-2xl">
       <div className="mb-6">
         <a
-          href={withBase("/tickets")}
+          href={withBase('/tickets')}
           className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
         >
           <ArrowLeft className="h-4 w-4" />
@@ -59,121 +170,260 @@ export function NewTicketForm() {
       </div>
 
       <div className="rounded-lg border bg-card p-6">
-        <h2 className="text-lg font-semibold">Create New Ticket</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Describe your issue and we'll get back to you as soon as possible.
-        </p>
-
-        <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-6">
-          {error && (
-            <div className="flex items-center gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-              <AlertCircle className="h-4 w-4" />
-              {error}
-            </div>
-          )}
-
-          <div>
-            <label
-              htmlFor="subject"
-              className="block text-sm font-medium text-foreground"
-            >
-              Title
-            </label>
-            <input
-              id="subject"
-              type="text"
-              placeholder="Brief summary of your issue"
-              {...register('subject')}
-              className={cn(
-                'mt-1 block w-full rounded-md border bg-background px-3 py-2 text-sm shadow-xs',
-                'focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary',
-                errors.subject && 'border-destructive'
-              )}
-            />
-            {errors.subject && (
-              <p className="mt-1 text-sm text-destructive">
-                {errors.subject.message}
-              </p>
-            )}
-          </div>
-
-          <div>
-            <label
-              htmlFor="priority"
-              className="block text-sm font-medium text-foreground"
-            >
-              Priority
-            </label>
-            <select
-              id="priority"
-              {...register('priority')}
-              className={cn(
-                'mt-1 block w-full rounded-md border bg-background px-3 py-2 text-sm shadow-xs',
-                'focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary'
-              )}
-            >
-              <option value="low">Low</option>
-              <option value="normal">Normal</option>
-              <option value="high">High</option>
-              <option value="urgent">Urgent</option>
-            </select>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Select the urgency level of your issue
+        {showGrid ? (
+          <>
+            <h2 className="text-lg font-semibold">Create New Ticket</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Choose what you need help with to get started.
             </p>
-          </div>
-
-          <div>
-            <label
-              htmlFor="description"
-              className="block text-sm font-medium text-foreground"
-            >
-              Description
-            </label>
-            <textarea
-              id="description"
-              rows={6}
-              placeholder="Please provide detailed information about your issue..."
-              {...register('description')}
-              className={cn(
-                'mt-1 block w-full rounded-md border bg-background px-3 py-2 text-sm shadow-xs',
-                'focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary',
-                errors.description && 'border-destructive'
-              )}
-            />
-            {errors.description && (
-              <p className="mt-1 text-sm text-destructive">
-                {errors.description.message}
-              </p>
+            <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {forms.map((form) => (
+                <button
+                  key={form.id}
+                  type="button"
+                  onClick={() => selectForm(form)}
+                  data-testid={`portal-ticket-form-card-${form.id}`}
+                  className={cn(
+                    'flex flex-col items-start gap-1 rounded-lg border bg-background p-4 text-left',
+                    'hover:border-primary hover:bg-muted focus:outline-hidden focus:ring-2 focus:ring-primary'
+                  )}
+                >
+                  <span className="flex items-center gap-2 text-sm font-medium text-foreground">
+                    <FileText className="h-4 w-4 text-muted-foreground" />
+                    {form.name}
+                  </span>
+                  {form.description && (
+                    <span className="text-xs text-muted-foreground">{form.description}</span>
+                  )}
+                </button>
+              ))}
+              <button
+                type="button"
+                onClick={() => setShowLegacy(true)}
+                data-testid="portal-ticket-form-card-blank"
+                className={cn(
+                  'flex flex-col items-start gap-1 rounded-lg border border-dashed bg-background p-4 text-left',
+                  'hover:border-primary hover:bg-muted focus:outline-hidden focus:ring-2 focus:ring-primary'
+                )}
+              >
+                <span className="flex items-center gap-2 text-sm font-medium text-foreground">
+                  <MessageSquarePlus className="h-4 w-4 text-muted-foreground" />
+                  Something else
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  Describe your issue in your own words.
+                </span>
+              </button>
+            </div>
+          </>
+        ) : selectedForm ? (
+          <>
+            {forms.length > 0 && (
+              <button
+                type="button"
+                onClick={backToGrid}
+                data-testid="portal-ticket-form-back"
+                className="mb-4 inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back to options
+              </button>
             )}
-          </div>
+            <h2 className="text-lg font-semibold">{selectedForm.name}</h2>
+            {selectedForm.description && (
+              <p className="mt-1 text-sm text-muted-foreground">{selectedForm.description}</p>
+            )}
 
-          <div className="flex justify-end gap-3">
-            <a
-              href={withBase("/tickets")}
-              className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                void submitForm();
+              }}
+              className="mt-6 space-y-6"
             >
-              Cancel
-            </a>
-            <button
-              type="submit"
-              disabled={isLoading}
-              className={cn(
-                'flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground',
-                'hover:bg-primary/90 focus:outline-hidden focus:ring-2 focus:ring-primary focus:ring-offset-2',
-                'disabled:cursor-not-allowed disabled:opacity-50'
+              {error && (
+                <div className="flex items-center gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  {error}
+                </div>
               )}
-            >
-              {isLoading ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Creating...
-                </>
-              ) : (
-                'Create Ticket'
+              {formErrors.__form && (
+                <p className="text-sm text-destructive" data-testid="portal-ticket-form-error">
+                  {formErrors.__form}
+                </p>
               )}
-            </button>
-          </div>
-        </form>
+
+              <TicketFormFields
+                fields={selectedForm.fields}
+                values={formValues}
+                errors={formErrors}
+                onChange={(key, value) => setFormValues((v) => ({ ...v, [key]: value }))}
+              />
+
+              <div>
+                <label htmlFor="form-description" className="block text-sm font-medium text-foreground">
+                  Additional details <span className="text-muted-foreground">(optional)</span>
+                </label>
+                <textarea
+                  id="form-description"
+                  rows={4}
+                  placeholder="Anything else we should know?"
+                  value={formDescription}
+                  onChange={(e) => setFormDescription(e.target.value)}
+                  data-testid="portal-ticket-form-description"
+                  className={inputCls}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="form-priority" className="block text-sm font-medium text-foreground">
+                  Priority
+                </label>
+                <select
+                  id="form-priority"
+                  value={formPriority}
+                  onChange={(e) => setFormPriority(e.target.value as TicketPriority)}
+                  data-testid="portal-ticket-form-priority"
+                  className={inputCls}
+                >
+                  <option value="low">Low</option>
+                  <option value="normal">Normal</option>
+                  <option value="high">High</option>
+                  <option value="urgent">Urgent</option>
+                </select>
+              </div>
+
+              <div className="flex justify-end gap-3">
+                <a
+                  href={withBase('/tickets')}
+                  className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+                >
+                  Cancel
+                </a>
+                <button
+                  type="submit"
+                  disabled={isLoading}
+                  data-testid="portal-ticket-form-submit"
+                  className={cn(
+                    'flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground',
+                    'hover:bg-primary/90 focus:outline-hidden focus:ring-2 focus:ring-primary focus:ring-offset-2',
+                    'disabled:cursor-not-allowed disabled:opacity-50'
+                  )}
+                >
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Creating...
+                    </>
+                  ) : (
+                    'Submit Ticket'
+                  )}
+                </button>
+              </div>
+            </form>
+          </>
+        ) : (
+          <>
+            {forms.length > 0 && (
+              <button
+                type="button"
+                onClick={backToGrid}
+                data-testid="portal-ticket-form-back"
+                className="mb-4 inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back to options
+              </button>
+            )}
+            <h2 className="text-lg font-semibold">Create New Ticket</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Describe your issue and we'll get back to you as soon as possible.
+            </p>
+
+            <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-6">
+              {error && (
+                <div className="flex items-center gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  {error}
+                </div>
+              )}
+
+              <div>
+                <label htmlFor="subject" className="block text-sm font-medium text-foreground">
+                  Title
+                </label>
+                <input
+                  id="subject"
+                  type="text"
+                  placeholder="Brief summary of your issue"
+                  {...register('subject')}
+                  className={cn(inputCls, errors.subject && 'border-destructive')}
+                />
+                {errors.subject && (
+                  <p className="mt-1 text-sm text-destructive">{errors.subject.message}</p>
+                )}
+              </div>
+
+              <div>
+                <label htmlFor="priority" className="block text-sm font-medium text-foreground">
+                  Priority
+                </label>
+                <select id="priority" {...register('priority')} className={inputCls}>
+                  <option value="low">Low</option>
+                  <option value="normal">Normal</option>
+                  <option value="high">High</option>
+                  <option value="urgent">Urgent</option>
+                </select>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Select the urgency level of your issue
+                </p>
+              </div>
+
+              <div>
+                <label htmlFor="description" className="block text-sm font-medium text-foreground">
+                  Description
+                </label>
+                <textarea
+                  id="description"
+                  rows={6}
+                  placeholder="Please provide detailed information about your issue..."
+                  {...register('description')}
+                  className={cn(inputCls, errors.description && 'border-destructive')}
+                />
+                {errors.description && (
+                  <p className="mt-1 text-sm text-destructive">{errors.description.message}</p>
+                )}
+              </div>
+
+              <div className="flex justify-end gap-3">
+                <a
+                  href={withBase('/tickets')}
+                  className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+                >
+                  Cancel
+                </a>
+                <button
+                  type="submit"
+                  disabled={isLoading}
+                  className={cn(
+                    'flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground',
+                    'hover:bg-primary/90 focus:outline-hidden focus:ring-2 focus:ring-primary focus:ring-offset-2',
+                    'disabled:cursor-not-allowed disabled:opacity-50'
+                  )}
+                >
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Creating...
+                    </>
+                  ) : (
+                    'Create Ticket'
+                  )}
+                </button>
+              </div>
+            </form>
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/portal/src/components/portal/TicketFormFields.test.tsx
+++ b/apps/portal/src/components/portal/TicketFormFields.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import type { TicketFormField } from '@breeze/shared';
+import TicketFormFields from './TicketFormFields';
+
+afterEach(() => cleanup());
+
+// One field of every supported type, exercising the full renderer surface.
+const fields: TicketFormField[] = [
+  { key: 'summary', label: 'Summary', type: 'text', required: true },
+  { key: 'details', label: 'Details', type: 'textarea', required: false },
+  { key: 'category', label: 'Category', type: 'select', required: true, options: ['A', 'B'] },
+  { key: 'agree', label: 'I agree', type: 'checkbox', required: true },
+  { key: 'when', label: 'When', type: 'date', required: false },
+  { key: 'count', label: 'Count', type: 'number', required: false }
+];
+
+describe('TicketFormFields (portal)', () => {
+  it('renders an input for every field type with its testid', () => {
+    render(<TicketFormFields fields={fields} values={{}} errors={{}} onChange={() => {}} />);
+    for (const f of fields) {
+      expect(screen.getByTestId(`ticket-form-field-${f.key}`)).toBeTruthy();
+    }
+  });
+
+  it('renders the per-field error line when an error is present', () => {
+    render(
+      <TicketFormFields
+        fields={fields}
+        values={{}}
+        errors={{ summary: 'This field is required' }}
+        onChange={() => {}}
+      />
+    );
+    const errLine = screen.getByTestId('ticket-form-field-error-summary');
+    expect(errLine.textContent).toBe('This field is required');
+    // No error line for fields without an error.
+    expect(screen.queryByTestId('ticket-form-field-error-details')).toBeNull();
+  });
+
+  it('emits onChange with the field key and value for text and checkbox', () => {
+    const onChange = vi.fn();
+    render(<TicketFormFields fields={fields} values={{}} errors={{}} onChange={onChange} />);
+    fireEvent.change(screen.getByTestId('ticket-form-field-summary'), { target: { value: 'hi' } });
+    expect(onChange).toHaveBeenCalledWith('summary', 'hi');
+    fireEvent.click(screen.getByTestId('ticket-form-field-agree'));
+    expect(onChange).toHaveBeenCalledWith('agree', true);
+  });
+});

--- a/apps/portal/src/components/portal/TicketFormFields.tsx
+++ b/apps/portal/src/components/portal/TicketFormFields.tsx
@@ -1,0 +1,100 @@
+import type { TicketFormField } from '@breeze/shared';
+
+// Deliberate duplicate of apps/web/src/components/tickets/TicketFormFields.tsx
+// (the portal cannot share web React components — no runtime package spans
+// api/web/portal; only pure `@breeze/shared` Zod logic is shared). Keep in sync
+// with that source file. Convention documented at
+// apps/web/src/components/billing/invoiceTypes.ts:5.
+
+interface Props {
+  fields: TicketFormField[];
+  values: Record<string, unknown>;
+  errors: Record<string, string>;
+  onChange: (key: string, value: unknown) => void;
+}
+
+// Controlled, stateless renderer for a ticket form's fields. Styling mirrors the
+// portal's NewTicketForm inputs so intake fields match the rest of the portal.
+const inputCls =
+  'mt-1 block w-full rounded-md border bg-background px-3 py-2 text-sm shadow-xs focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary';
+
+export default function TicketFormFields({ fields, values, errors, onChange }: Props) {
+  return (
+    <div className="space-y-4">
+      {fields.map((f) => {
+        const err = errors[f.key];
+        const common = {
+          id: `tf-${f.key}`,
+          'data-testid': `ticket-form-field-${f.key}`
+        } as const;
+        return (
+          <div key={f.key}>
+            {f.type === 'checkbox' ? (
+              <label htmlFor={`tf-${f.key}`} className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <input
+                  {...common}
+                  type="checkbox"
+                  className="h-4 w-4 rounded border"
+                  checked={values[f.key] === true}
+                  onChange={(e) => onChange(f.key, e.target.checked)}
+                />
+                <span>
+                  {f.label}
+                  {f.required && <span className="text-destructive"> *</span>}
+                </span>
+              </label>
+            ) : (
+              <>
+                <label htmlFor={`tf-${f.key}`} className="block text-sm font-medium text-foreground">
+                  {f.label}
+                  {f.required && <span className="text-destructive"> *</span>}
+                </label>
+                {f.type === 'textarea' && (
+                  <textarea
+                    {...common}
+                    className={inputCls}
+                    rows={3}
+                    placeholder={f.placeholder}
+                    value={(values[f.key] as string) ?? ''}
+                    onChange={(e) => onChange(f.key, e.target.value)}
+                  />
+                )}
+                {(f.type === 'text' || f.type === 'date' || f.type === 'number') && (
+                  <input
+                    {...common}
+                    className={inputCls}
+                    type={f.type === 'text' ? 'text' : f.type}
+                    placeholder={f.placeholder}
+                    value={(values[f.key] as string | number) ?? ''}
+                    onChange={(e) => onChange(f.key, e.target.value)}
+                  />
+                )}
+                {f.type === 'select' && (
+                  <select
+                    {...common}
+                    className={inputCls}
+                    value={(values[f.key] as string) ?? ''}
+                    onChange={(e) => onChange(f.key, e.target.value)}
+                  >
+                    <option value="">Select…</option>
+                    {(f.options ?? []).map((o) => (
+                      <option key={o} value={o}>
+                        {o}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </>
+            )}
+            {f.helpText && <p className="mt-1 text-xs text-muted-foreground">{f.helpText}</p>}
+            {err && (
+              <p className="mt-1 text-xs text-destructive" data-testid={`ticket-form-field-error-${f.key}`}>
+                {err}
+              </p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/portal/src/components/portal/index.ts
+++ b/apps/portal/src/components/portal/index.ts
@@ -12,6 +12,7 @@ export { ResetPasswordForm } from './ResetPasswordForm';
 export { DeviceList } from './DeviceList';
 export { TicketList } from './TicketList';
 export { NewTicketForm } from './NewTicketForm';
+export { default as TicketFormFields } from './TicketFormFields';
 export { TicketDetails } from './TicketDetails';
 export { AssetList } from './AssetList';
 export { ProfileSettings } from './ProfileSettings';

--- a/apps/portal/src/lib/api.test.ts
+++ b/apps/portal/src/lib/api.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { buildPortalApiUrl } from './api';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { buildPortalApiUrl, portalApi } from './api';
 
 // Regression guard for the same-origin client API base (the deploy relies on it):
 // with PUBLIC_API_URL unset, the browser must issue RELATIVE /api/v1 requests so
@@ -32,5 +32,29 @@ describe('buildPortalApiUrl (client, PUBLIC_API_URL unset)', () => {
 
   it('passes absolute URLs through untouched', () => {
     expect(buildPortalApiUrl('https://files.example/x.pdf')).toBe('https://files.example/x.pdf');
+  });
+});
+
+// Pin the literal request path of the intake-forms read. A typo here would be
+// invisible forever: NewTicketForm silently degrades to the legacy form on any
+// fetch failure, so a 404'ing path would never surface in the UI.
+describe('portalApi.getTicketForms request path', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('GETs /portal/tickets/forms (under the /tickets auth prefix, NOT /ticket-forms)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await portalApi.getTicketForms();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain('/portal/tickets/forms');
+    expect(url).not.toContain('/portal/ticket-forms');
+    expect(result.data).toEqual([]);
   });
 });

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -7,7 +7,7 @@ import { navigateTo } from './navigation';
 // Invoice-domain enum SSOT lives in @breeze/shared (billing-enums.ts). Imported
 // into local scope for the InvoiceSummary/InvoiceDetail types below and re-exported
 // (type-only, erased at build) so '@/lib/api' consumers are unaffected.
-import type { InvoiceStatus } from '@breeze/shared';
+import type { InvoiceStatus, TicketFormField } from '@breeze/shared';
 
 // Client API base. Empty (the default) → same-origin **relative** requests
 // (`/api/v1/...`), which the reverse proxy routes to the API under `/api/*`. This
@@ -292,6 +292,30 @@ export interface TicketDetails extends TicketSummary {
   comments: TicketComment[];
 }
 
+// Slim portal-visible intake form (Phase 2). Mirrors the `GET /portal/tickets/forms`
+// payload — no titleTemplate (the server composes the subject) and no showInPortal
+// (the route already filtered to portal-visible forms).
+export interface PortalTicketForm {
+  id: string;
+  name: string;
+  description: string | null;
+  categoryId: string | null;
+  fields: TicketFormField[];
+  defaultPriority: TicketPriority | null;
+}
+
+// createTicket accepts EITHER the legacy free-text payload OR an intake-form
+// payload. On the form path the subject/description are composed server-side, so
+// no `subject` key is sent (an optional free-text `description` may still ride along).
+export type CreateTicketInput =
+  | { subject: string; description: string; priority: TicketPriority }
+  | {
+      formId: string;
+      formResponses: Record<string, unknown>;
+      description?: string;
+      priority: TicketPriority;
+    };
+
 export interface Asset {
   id: string;
   hostname: string;
@@ -543,8 +567,30 @@ export const portalApi = {
     };
   },
 
+  // Portal-visible intake forms for the session org (allowlist + showInPortal
+  // resolved server-side). Returns [] on any failure so callers can silently
+  // degrade to the legacy free-text form.
+  getTicketForms: async (
+    config: ApiRequestConfig = {}
+  ): Promise<ApiResponse<PortalTicketForm[]>> => {
+    const response = await apiGet<{ data: PortalTicketForm[] }>('/portal/tickets/forms', config);
+    if (!response.data) {
+      return {
+        error: response.error,
+        statusCode: response.statusCode,
+        headers: response.headers
+      };
+    }
+
+    return {
+      data: response.data.data,
+      statusCode: response.statusCode,
+      headers: response.headers
+    };
+  },
+
   createTicket: async (
-    data: { subject: string; description: string; priority: TicketPriority },
+    data: CreateTicketInput,
     config: ApiRequestConfig = {}
   ): Promise<ApiResponse<TicketSummary & { description: string }>> => {
     const response = await apiPost<{ ticket: TicketSummary & { description: string } }>(

--- a/apps/portal/vitest.config.ts
+++ b/apps/portal/vitest.config.ts
@@ -1,8 +1,23 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Mirrors the `@/*` and `@breeze/shared` paths in apps/portal/tsconfig.json so
+      // vitest can resolve app + workspace imports without a build step. Required for
+      // any component test whose module graph reaches `@/lib/*` or `@breeze/shared`
+      // (e.g. the ticket-intake renderer). Mirrors apps/web/vitest.config.ts.
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '@breeze/shared': fileURLToPath(
+        new URL('../../packages/shared/src/index.ts', import.meta.url)
+      )
+    }
+  },
   test: {
     globals: true,
+    // Node by default (most portal suites are pure lib logic). Component test files
+    // opt into jsdom per-file via a `// @vitest-environment jsdom` header comment.
     environment: 'node',
     include: ['src/**/*.test.{ts,tsx}'],
     passWithNoTests: true

--- a/apps/web/src/components/settings/TicketFormsCard.test.tsx
+++ b/apps/web/src/components/settings/TicketFormsCard.test.tsx
@@ -211,6 +211,122 @@ describe('TicketFormsCard', () => {
     expect(fetchMock.mock.calls.some(([u, i]) => String(u) === '/ticket-forms' && (i as RequestInit)?.method === 'POST')).toBe(false);
   });
 
+  it('creates a partner-wide form with an org allowlist → POST body visibleOrgIds: [a, b]', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/ticket-forms' && (!init || !init.method)) return makeJsonResponse({ data: [FORM] });
+      if (url === '/ticket-forms' && init?.method === 'POST')
+        return makeJsonResponse({ data: { ...FORM, id: 'f-2' } });
+      if (url === '/orgs/organizations?limit=100')
+        return makeJsonResponse({ data: [{ id: 'org-a', name: 'Org A' }, { id: 'org-b', name: 'Org B' }] });
+      if (url === '/ticket-categories') return makeJsonResponse({ data: [] });
+      return makeJsonResponse({ error: 'unexpected' }, false, 404);
+    });
+    render(<TicketFormsCard />);
+    await screen.findByTestId('ticket-form-row-f-1');
+    fireEvent.click(screen.getByTestId('ticket-form-create'));
+    fireEvent.change(screen.getByTestId('ticket-form-name'), { target: { value: 'Limited' } });
+    fireEvent.click(screen.getByTestId('ticket-form-owner-partner'));
+    fireEvent.click(screen.getByTestId('ticket-form-limit-orgs'));
+    fireEvent.click(screen.getByTestId('ticket-form-visible-org-org-a'));
+    fireEvent.click(screen.getByTestId('ticket-form-visible-org-org-b'));
+    fireEvent.click(screen.getByTestId('ticket-form-save'));
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(([u, i]) => String(u) === '/ticket-forms' && (i as RequestInit)?.method === 'POST');
+      expect(post).toBeTruthy();
+      const body = JSON.parse(String((post![1] as RequestInit).body));
+      expect(body.ownerScope).toBe('partner');
+      expect(body.visibleOrgIds).toEqual(['org-a', 'org-b']);
+    });
+  });
+
+  it('blocks save with an inline issue when limit-orgs is checked but zero orgs selected', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/ticket-forms' && (!init || !init.method)) return makeJsonResponse({ data: [FORM] });
+      if (url === '/orgs/organizations?limit=100') return makeJsonResponse({ data: [{ id: 'org-a', name: 'Org A' }] });
+      if (url === '/ticket-categories') return makeJsonResponse({ data: [] });
+      return makeJsonResponse({ error: 'unexpected' }, false, 404);
+    });
+    render(<TicketFormsCard />);
+    await screen.findByTestId('ticket-form-row-f-1');
+    fireEvent.click(screen.getByTestId('ticket-form-create'));
+    fireEvent.change(screen.getByTestId('ticket-form-name'), { target: { value: 'Empty allowlist' } });
+    fireEvent.click(screen.getByTestId('ticket-form-limit-orgs'));
+    fireEvent.click(screen.getByTestId('ticket-form-save'));
+    expect(await screen.findByTestId('ticket-form-issues')).toBeTruthy();
+    expect(screen.getByTestId('ticket-form-issues').textContent).toContain('Select at least one organization');
+    expect(fetchMock.mock.calls.some(([u, i]) => String(u) === '/ticket-forms' && (i as RequestInit)?.method === 'POST')).toBe(false);
+  });
+
+  it('hydrates the allowlist from a limited partner-wide row and clears it via unchecking → PUT visibleOrgIds: null', async () => {
+    const limitedForm = { ...FORM, visibleOrgIds: ['org-a'] };
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/ticket-forms' && (!init || !init.method)) return makeJsonResponse({ data: [limitedForm] });
+      if (url === '/ticket-forms/f-1' && init?.method === 'PUT') return makeJsonResponse({ data: FORM });
+      if (url === '/orgs/organizations?limit=100')
+        return makeJsonResponse({ data: [{ id: 'org-a', name: 'Org A' }, { id: 'org-b', name: 'Org B' }] });
+      if (url === '/ticket-categories') return makeJsonResponse({ data: [] });
+      return makeJsonResponse({ error: 'unexpected' }, false, 404);
+    });
+    render(<TicketFormsCard />);
+    await screen.findByTestId('ticket-form-row-f-1');
+    fireEvent.click(screen.getByTestId('ticket-form-edit-f-1'));
+    // Hydration: checkbox pre-checked, org-a pre-selected.
+    expect((screen.getByTestId('ticket-form-limit-orgs') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByTestId('ticket-form-visible-org-org-a') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByTestId('ticket-form-visible-org-org-b') as HTMLInputElement).checked).toBe(false);
+    // Uncheck the limit → save clears the allowlist.
+    fireEvent.click(screen.getByTestId('ticket-form-limit-orgs'));
+    fireEvent.click(screen.getByTestId('ticket-form-save'));
+    await waitFor(() => {
+      const put = fetchMock.mock.calls.find(([u, i]) => String(u) === '/ticket-forms/f-1' && (i as RequestInit)?.method === 'PUT');
+      expect(put).toBeTruthy();
+      const body = JSON.parse(String((put![1] as RequestInit).body));
+      expect(body.visibleOrgIds).toBeNull();
+    });
+  });
+
+  it('renders an N-orgs count badge for a limited partner-wide row', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/ticket-forms' && (!init || !init.method))
+        return makeJsonResponse({ data: [{ ...FORM, visibleOrgIds: ['org-a', 'org-b'] }] });
+      if (url === '/orgs/organizations?limit=100') return makeJsonResponse({ data: [] });
+      if (url === '/ticket-categories') return makeJsonResponse({ data: [] });
+      return makeJsonResponse({ error: 'unexpected' }, false, 404);
+    });
+    render(<TicketFormsCard />);
+    await screen.findByTestId('ticket-form-row-f-1');
+    expect(screen.getByTestId('ticket-form-org-count-f-1').textContent).toContain('2 orgs');
+    expect(screen.queryByTestId('ticket-form-all-orgs-f-1')).toBeNull();
+  });
+
+  it('never shows the allowlist control for an org-owned form, and PUT omits visibleOrgIds', async () => {
+    const orgForm = { ...FORM, orgId: 'org-a', partnerId: null, visibleOrgIds: null };
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/ticket-forms' && (!init || !init.method)) return makeJsonResponse({ data: [orgForm] });
+      if (url === '/ticket-forms/f-1' && init?.method === 'PUT') return makeJsonResponse({ data: orgForm });
+      if (url === '/orgs/organizations?limit=100') return makeJsonResponse({ data: [{ id: 'org-a', name: 'Org A' }] });
+      if (url === '/ticket-categories') return makeJsonResponse({ data: [] });
+      return makeJsonResponse({ error: 'unexpected' }, false, 404);
+    });
+    render(<TicketFormsCard />);
+    await screen.findByTestId('ticket-form-row-f-1');
+    fireEvent.click(screen.getByTestId('ticket-form-edit-f-1'));
+    expect(screen.queryByTestId('ticket-form-limit-orgs')).toBeNull();
+    fireEvent.change(screen.getByTestId('ticket-form-name'), { target: { value: 'Org form v2' } });
+    fireEvent.click(screen.getByTestId('ticket-form-save'));
+    await waitFor(() => {
+      const put = fetchMock.mock.calls.find(([u, i]) => String(u) === '/ticket-forms/f-1' && (i as RequestInit)?.method === 'PUT');
+      expect(put).toBeTruthy();
+      const body = JSON.parse(String((put![1] as RequestInit).body));
+      expect(body).not.toHaveProperty('visibleOrgIds');
+    });
+  });
+
   it('two-step delete: first click arms, second click fires DELETE', async () => {
     fetchMock.mockImplementation(async (input, init) => {
       const url = String(input);

--- a/apps/web/src/components/settings/TicketFormsCard.tsx
+++ b/apps/web/src/components/settings/TicketFormsCard.tsx
@@ -496,6 +496,11 @@ export default function TicketFormsCard() {
                         ))}
                       </select>
                     )}
+                    {/* This testid is reused below in the partner-wide Visibility
+                        fieldset (same string, both instances). That's unambiguous
+                        for tests to target: ownerScope is XOR, so only one of the
+                        two owner-scope sections ever renders at a time — never
+                        both `ticket-form-orgs-error` nodes simultaneously. */}
                     {draft.ownerScope === 'organization' && orgsLoadFailed && (
                       <p className="text-xs text-destructive" data-testid="ticket-form-orgs-error">
                         Organizations failed to load, so an org-scoped form can't be created yet.{' '}

--- a/apps/web/src/components/settings/TicketFormsCard.tsx
+++ b/apps/web/src/components/settings/TicketFormsCard.tsx
@@ -23,6 +23,9 @@ interface TicketForm {
   titleTemplate: string | null;
   descriptionIntro: string | null;
   defaultPriority: string | null;
+  // Partner-wide allowlist: null (or absent) = visible to all the partner's orgs;
+  // a non-empty array = only those orgs. Never `[]` (server normalizes empty → null).
+  visibleOrgIds?: string[] | null;
   showInPortal: boolean;
   isActive: boolean;
   sortOrder: number;
@@ -57,6 +60,10 @@ interface FormDraft {
   categoryId: string;
   ownerScope: 'partner' | 'organization';
   orgId: string;
+  // Partner-wide allowlist editor state. `limitOrgs` unchecked → save `null` (all
+  // orgs); checked → `visibleOrgIds` (min 1, enforced client-side — never send `[]`).
+  limitOrgs: boolean;
+  visibleOrgIds: string[];
   fields: DraftField[];
   titleTemplate: string;
   descriptionIntro: string;
@@ -138,6 +145,8 @@ function draftFromForm(form: TicketForm): FormDraft {
     // Ownership is immutable on edit; seed something valid but the fieldset is hidden.
     ownerScope: form.orgId === null ? 'partner' : 'organization',
     orgId: form.orgId ?? '',
+    limitOrgs: form.visibleOrgIds != null,
+    visibleOrgIds: form.visibleOrgIds ?? [],
     fields: form.fields.map((f) => ({
       label: f.label,
       type: f.type,
@@ -163,6 +172,8 @@ function emptyDraft(): FormDraft {
     categoryId: '',
     ownerScope: 'partner',
     orgId: '',
+    limitOrgs: false,
+    visibleOrgIds: [],
     fields: [],
     titleTemplate: '',
     descriptionIntro: '',
@@ -273,6 +284,16 @@ export default function TicketFormsCard() {
       [next[i], next[j]] = [next[j], next[i]];
       return { ...e, draft: { ...e.draft, fields: next } };
     });
+  // Toggle an org in the partner-wide allowlist; preserves click order so the
+  // saved array matches selection order.
+  const toggleVisibleOrg = (id: string) =>
+    setEditing((e) => {
+      if (!e) return e;
+      const next = e.draft.visibleOrgIds.includes(id)
+        ? e.draft.visibleOrgIds.filter((x) => x !== id)
+        : [...e.draft.visibleOrgIds, id];
+      return { ...e, draft: { ...e.draft, visibleOrgIds: next } };
+    });
 
   // Derived keys + built fields for the current draft (drives read-only key labels + preview).
   const draft = editing?.draft;
@@ -291,6 +312,11 @@ export default function TicketFormsCard() {
     const orgScopeBlockedByLoad = orgScopeNeedsOrg && orgsLoadFailed;
     if (orgScopeNeedsOrg && !orgsLoadFailed) {
       localIssues.push('Select an organization for an organization-scoped form.');
+    }
+    // Allowlist is only meaningful on partner-wide forms. Checked-but-empty is
+    // unrepresentable: force a choice rather than silently sending null/[].
+    if (d.ownerScope === 'partner' && d.limitOrgs && d.visibleOrgIds.length === 0) {
+      localIssues.push('Select at least one organization or uncheck "Limit to specific organizations".');
     }
     const built = buildFields(d.fields);
     const parsed = ticketFormFieldsSchema.safeParse(built);
@@ -348,6 +374,13 @@ export default function TicketFormsCard() {
     setOptional('titleTemplate', d.titleTemplate);
     setOptional('descriptionIntro', d.descriptionIntro);
     setOptional('defaultPriority', d.defaultPriority);
+
+    // Allowlist only on partner-wide forms (both create and edit; for edit,
+    // ownerScope is derived from orgId === null). Unchecked → null (all orgs);
+    // checked → the selected ids. Org-owned forms never carry the key (API 400s).
+    if (d.ownerScope === 'partner') {
+      base.visibleOrgIds = d.limitOrgs ? d.visibleOrgIds : null;
+    }
 
     // CREATE also sends the immutable ownership axis; UPDATE (schema is
     // .partial()) sends only the mutable base.
@@ -476,6 +509,53 @@ export default function TicketFormsCard() {
                         </button>
                       </p>
                     )}
+                  </fieldset>
+                )}
+
+                {/* Org allowlist — partner-wide forms only (create with partner
+                    scope, or editing a partner-wide row where orgId === null). */}
+                {draft.ownerScope === 'partner' && (
+                  <fieldset className="space-y-2 rounded-md border p-3" data-testid="ticket-form-visibility">
+                    <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">Visibility</legend>
+                    <label className="flex items-center gap-2 text-sm">
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border"
+                        checked={draft.limitOrgs}
+                        onChange={(e) => patchDraft({ limitOrgs: e.target.checked })}
+                        data-testid="ticket-form-limit-orgs"
+                      />
+                      Limit to specific organizations
+                    </label>
+                    {draft.limitOrgs &&
+                      (orgsLoadFailed ? (
+                        <p className="text-xs text-destructive" data-testid="ticket-form-orgs-error">
+                          Organizations failed to load, so the allowlist can't be edited yet.{' '}
+                          <button
+                            type="button"
+                            onClick={() => void load()}
+                            className="underline hover:text-foreground"
+                            data-testid="ticket-form-orgs-retry"
+                          >
+                            Retry
+                          </button>
+                        </p>
+                      ) : (
+                        <div className="space-y-1" data-testid="ticket-form-visible-orgs">
+                          {orgs.map((o) => (
+                            <label key={o.id} className="flex items-center gap-2 text-sm">
+                              <input
+                                type="checkbox"
+                                className="h-4 w-4 rounded border"
+                                checked={draft.visibleOrgIds.includes(o.id)}
+                                onChange={() => toggleVisibleOrg(o.id)}
+                                data-testid={`ticket-form-visible-org-${o.id}`}
+                              />
+                              {o.name}
+                            </label>
+                          ))}
+                        </div>
+                      ))}
                   </fieldset>
                 )}
 
@@ -805,16 +885,26 @@ export default function TicketFormsCard() {
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2 text-sm font-medium">
                     <span>{form.name}</span>
-                    {form.orgId === null && (
-                      <span
-                        className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
-                        title="Partner-wide form — available to every organization"
-                        data-testid={`ticket-form-all-orgs-${form.id}`}
-                      >
-                        <Globe className="h-3 w-3" />
-                        All orgs
-                      </span>
-                    )}
+                    {form.orgId === null &&
+                      (form.visibleOrgIds == null ? (
+                        <span
+                          className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                          title="Partner-wide form — available to every organization"
+                          data-testid={`ticket-form-all-orgs-${form.id}`}
+                        >
+                          <Globe className="h-3 w-3" />
+                          All orgs
+                        </span>
+                      ) : (
+                        <span
+                          className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                          title="Partner-wide form limited to specific organizations"
+                          data-testid={`ticket-form-org-count-${form.id}`}
+                        >
+                          <Globe className="h-3 w-3" />
+                          {form.visibleOrgIds.length} org{form.visibleOrgIds.length === 1 ? '' : 's'}
+                        </span>
+                      ))}
                     {form.showInPortal && (
                       <span className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">Portal</span>
                     )}

--- a/docs/superpowers/plans/2026-07-11-ticket-intake-forms-phase2.md
+++ b/docs/superpowers/plans/2026-07-11-ticket-intake-forms-phase2.md
@@ -1,0 +1,209 @@
+# Ticket Intake Forms Phase 2 (Portal Intake + Org Allowlist) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** End users submit uniform tickets through intake forms in the client portal (card grid on New Ticket), and partner-wide forms can be limited to a subset of orgs via an allowlist join table.
+
+**Architecture:** Phase 1 (merged, `2b7c10ed3`) built the dual-axis `ticket_forms` table, shared Zod validators, `ticketFormService` (system-context reads), and `createTicket` intake handling. Phase 2 adds: `ticket_form_org_links` (FK-child allowlist; no rows = all orgs), allowlist-aware resolution in `ticketFormService`, a `showInPortal` enforcement guard on portal-sourced creates, a portal read route + extended portal create schema, an org multi-select in the web builder, and a portal-native form renderer + card grid. The portal deliberately duplicates React components (no runtime sharing with apps/web — repo convention); only the pure Zod logic from `@breeze/shared` is imported.
+
+**Tech Stack:** Hono, Drizzle, hand-written SQL migration, Zod 4, React 19 (portal: react-hook-form), Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-10-ticket-intake-forms-design.md` §4.3 (portal card grid) + §5 Phase 2 (org allowlist). Phase 1 plan (patterns/reference): `docs/superpowers/plans/2026-07-10-ticket-intake-forms.md`.
+
+## Global Constraints
+
+- Zod 4: `.guid()` not `.uuid()`. NEVER derive an update schema via `.partial()` over `.default()`-carrying fields (repo-wide hardened bug class — `ticket_forms` uses the base/extend pattern in `packages/shared/src/validators/ticketForms.ts`; extend that base, don't fork it).
+- Migration `apps/api/migrations/2026-07-11-ticket-form-org-links.sql`: idempotent, NO inner `BEGIN;`, RLS in the same file. Never edit shipped migrations (incl. `2026-07-10-ticket-forms.sql`).
+- `ticket_form_org_links` registrations (same PR): `PARENT_FK_JOIN_POLICY_TABLES` gets `['ticket_form_org_links', ['ticket_forms']]` (`rls-coverage.integration.test.ts:~359`; precedent `maintenance_occurrences`); `ORG_CASCADE_DELETE_ORDER` in `apps/api/src/services/tenantCascade.ts` (alphabetical; it has an `org_id` column); partner side is covered by the dynamic `information_schema` sweep (documented in that file) — no static partner list exists.
+- The FK-child RLS policy must join through the DUAL-AXIS parent predicate (system OR org-access OR partner-access on the `ticket_forms` row), mirroring how `2026-07-01-maintenance-windows-partner-ownership.sql` re-issued `maintenance_occurrences` policies. A plain `breeze_has_org_access(parent.org_id)` join is WRONG here — the parent's org_id is NULL for partner-wide forms.
+- Allowlist semantics (spec §5): **no link rows = visible to all the partner's orgs; rows present = allowlist.** Applies to BOTH `listTicketFormsForOrg` and the `getTicketFormForOrg` usability guard. `visibleOrgIds` is only valid on partner-wide forms (org-owned → 400).
+- Portal routes run under an org-scoped RLS context (`routes/portal/auth.ts` wraps requests); partner-owned rows are invisible there. New portal reads use `runOutsideDbContext(() => withSystemDbAccessContext(...))` — copy the in-router precedent at `apps/api/src/routes/portal/quotes.ts:70`.
+- Portal-sourced creates must enforce `showInPortal` (Phase 1 gap: `getTicketFormForOrg` doesn't check it, so a portal user replaying an internal form's UUID would succeed today-after-portal-wiring).
+- The portal CANNOT import React components from apps/web or carry them in packages/shared (plain TS/Zod only — verified, and `apps/web/src/components/billing/invoiceTypes.ts:5` documents the deliberate-duplication convention). The portal gets its own `TicketFormFields.tsx`; only `buildResponseValidator`/`coerceFormResponses`/`TicketFormField` come from `@breeze/shared`.
+- Portal POST /tickets keeps its OWN schema (`apps/api/src/routes/portal/schemas.ts`) — extend it there; do not switch it to the shared `createTicketSchema`.
+- `formResponses` without `formId` must be rejected (mirror the shared-schema superRefine added post-Phase-1).
+- Web mutations via `runAction`; `data-testid` on every interactive element. Portal components follow portal conventions (react-hook-form + inline error strings — see `NewTicketForm.tsx`), NOT apps/web's runAction (portal has no runAction).
+- Deferred PR-review debt this plan must pay: integration assertions for `portalOnly` filtering AND `sortOrder,name` ordering of `listTicketFormsForOrg` (previously dead code / unasserted).
+- Do not run `*.integration.test.ts` against the shared :5433 Postgres — use a throwaway container (recipe proven in Phase 1; see `2026-07-10` plan Task 3 environment guidance).
+- Placeholder emails in docs/tests: never real domains — use `*.example` (customer-PII CI guard).
+- Work on branch `feat/ticket-forms-portal-phase2`.
+
+---
+
+### Task 1: `ticket_form_org_links` — migration, schema, registrations, RLS tests
+
+**Files:**
+- Create: `apps/api/migrations/2026-07-11-ticket-form-org-links.sql`
+- Create: `apps/api/src/db/schema/ticketFormOrgLinks.ts` (+ barrel line in `apps/api/src/db/schema/index.ts`)
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` (PARENT_FK_JOIN_POLICY_TABLES)
+- Modify: `apps/api/src/services/tenantCascade.ts` (ORG_CASCADE_DELETE_ORDER, alphabetical: between `'ticket_categories'`-adjacent entries — exact spot: after `'ticket_forms'`, before `'ticket_parts'`)
+- Modify: `apps/api/src/__tests__/integration/ticketFormsPartnerRls.integration.test.ts` (allowlist cases)
+
+**Interfaces:**
+- Produces: `ticketFormOrgLinks` Drizzle table `{ id uuid pk, formId uuid NOT NULL → ticket_forms ON DELETE CASCADE, orgId uuid NOT NULL → organizations ON DELETE CASCADE, createdAt }`, unique index on `(form_id, org_id)`.
+
+- [ ] **Step 1: Migration** — `CREATE TABLE IF NOT EXISTS ticket_form_org_links` with the columns above, `CREATE UNIQUE INDEX IF NOT EXISTS ticket_form_org_links_form_org_uq ON ticket_form_org_links(form_id, org_id)`, plus `ticket_form_org_links_form_id_idx` and `_org_id_idx`. RLS: ENABLE + FORCE, `DROP POLICY IF EXISTS ticket_form_org_links_isolation` then CREATE with USING/WITH CHECK both:
+
+```sql
+EXISTS (
+  SELECT 1 FROM ticket_forms tf
+  WHERE tf.id = ticket_form_org_links.form_id
+    AND (
+      public.breeze_current_scope() = 'system'
+      OR (tf.org_id IS NOT NULL AND public.breeze_has_org_access(tf.org_id))
+      OR (tf.partner_id IS NOT NULL AND public.breeze_has_partner_access(tf.partner_id))
+    )
+)
+```
+
+- [ ] **Step 2: Drizzle schema** — mirror `apps/api/src/db/schema/ticketForms.ts` idioms (imports from `./orgs`, timestamp defaults); `uniqueIndex` for the pair. Barrel export. Run `pnpm db:check-drift` against a local/throwaway DB.
+- [ ] **Step 3: Registrations** — `['ticket_form_org_links', ['ticket_forms']]` in `PARENT_FK_JOIN_POLICY_TABLES`; `'ticket_form_org_links'` in `ORG_CASCADE_DELETE_ORDER` (alphabetical). Comment each with one line referencing the dual-axis parent.
+- [ ] **Step 4: RLS integration tests (extend the Phase 1 suite, TDD against throwaway DB)** — new cases in `ticketFormsPartnerRls.integration.test.ts`:
+
+```ts
+it('org link rows are invisible cross-partner and writable only by the owning partner (42501)', ...)
+// partner A creates partner-wide form + link to its org; partner B context: select → [], forge insert link on A's form → 42501
+it('link unique constraint rejects duplicates (23505)', ...)
+```
+
+- [ ] **Step 5: Run** rls-coverage + tenantCascade + the extended suite on a throwaway Postgres (Phase 1 recipe). All green (new allowlist-resolution cases land in Task 2's step).
+- [ ] **Step 6: Commit** `feat(api): ticket_form_org_links allowlist table — schema, migration, FK-child RLS`
+
+---
+
+### Task 2: Shared `visibleOrgIds` + allowlist/portal-visibility logic in `ticketFormService`
+
+**Files:**
+- Modify: `packages/shared/src/validators/ticketForms.ts` + `.test.ts`
+- Modify: `apps/api/src/services/ticketFormService.ts` + `.test.ts`
+- Modify: `apps/api/src/services/ticketService.ts` (portal-source guard) + `.test.ts`
+- Modify: `apps/api/src/__tests__/integration/ticketFormsPartnerRls.integration.test.ts` (fan-out + portalOnly + ordering assertions)
+
+**Interfaces (produced):**
+- Shared: `createTicketFormSchema`/`updateTicketFormSchema` gain `visibleOrgIds: z.array(z.string().guid()).max(500).nullable().optional()` — added to the DEFAULT-FREE BASE schema (null/absent = all orgs). Semantics comment required.
+- Service: `listTicketFormsForOrg(org, opts?)` — partner-wide branch additionally requires `(no links OR link for org.id)`; implement with SQL `NOT EXISTS`/`EXISTS` subqueries on `ticket_form_org_links`. Ordering unchanged (`sortOrder, name`).
+- Service: `getTicketFormForOrg(formId, org, opts?: { requirePortalVisible?: boolean })` — partner-wide rows additionally pass the allowlist check (400 `'Ticket form is not available for this organization'` on miss); `requirePortalVisible && !form.showInPortal` → 400 `'Ticket form is not available in the portal'`.
+- Service: `syncTicketFormOrgLinks(formId: string, orgIds: string[] | null, partnerId: string): Promise<void>` — system-context; validates every org belongs to `partnerId` (read orgs, compare partner ids; throw `TicketFormError(400, 'visibleOrgIds must reference organizations of the owning partner')`); `null` → delete all rows; array → delete + insert (replace semantics). Also `getTicketFormOrgLinkMap(formIds: string[]): Promise<Map<string, string[]>>` for list responses.
+- `createTicket` (`ticketService.ts`): pass `{ requirePortalVisible: input.source === 'portal' }` to `getTicketFormForOrg`.
+
+- [ ] **Step 1 (TDD):** shared tests — visibleOrgIds accepted (array/null/absent) on create+update, rejected >500, guid-validated; base/extend construction untouched (update parse of `{name}` still yields only `{name}`).
+- [ ] **Step 2 (TDD):** ticketFormService unit tests (mocked db, Phase 1 conventions) — `getTicketFormForOrg` 400 on `requirePortalVisible` + `showInPortal:false`; org-owned forms skip allowlist; `syncTicketFormOrgLinks` throws on cross-partner org.
+- [ ] **Step 3 (TDD):** ticketService test — portal-source create with internal-only form mock → `TicketServiceError` 400, no insert; non-portal source unaffected.
+- [ ] **Step 4: Integration (the real proof + PR-review debt):** extend the fan-out test file:
+
+```ts
+it('allowlist: partner-wide form with links visible ONLY to linked orgs', ...)
+// form P linked to orgA: listTicketFormsForOrg(orgA) includes it; (orgB of same partner) excludes it; unlinked partner-wide form Q visible to both
+it('portalOnly filters showInPortal=false rows', ...)
+it('ordering: sortOrder then name', ...) // create 3 forms with sortOrder 2/1/1 and names, assert exact order — no .sort() masking
+```
+
+- [ ] **Step 5:** Run shared + api unit suites, tsc, integration suite on throwaway DB. Commit `feat(api): allowlist + portal-visibility resolution for ticket forms`
+
+---
+
+### Task 3: Staff routes — `visibleOrgIds` round-trip
+
+**Files:**
+- Modify: `apps/api/src/routes/tickets/forms.ts` + `forms.test.ts`
+
+**Interfaces:**
+- POST: `visibleOrgIds` only when `ownerScope === 'partner'` (else 400 `'visibleOrgIds is only valid on partner-wide forms'`); after insert, `syncTicketFormOrgLinks(row.id, payload.visibleOrgIds ?? null, auth.partnerId)`.
+- PUT: only when row is partner-wide (else 400); `visibleOrgIds === undefined` → links untouched; `null` → clear; array → replace. Does NOT bump `version` (visibility isn't part of the response contract).
+- GET list + available: responses gain `visibleOrgIds: string[] | null` via `getTicketFormOrgLinkMap` (null when no rows). `available` needs no change to its filtering (service handles it) — but add the field for symmetry only on the management list, NOT on `available` (pickers don't need it).
+- Strip `visibleOrgIds` from the `.set()` spread on PUT (it's not a column): `const { visibleOrgIds, ...columns } = payload;`.
+
+- [ ] **Step 1 (TDD):** route tests — create partner-wide with visibleOrgIds calls sync with token partner; create org-owned with visibleOrgIds → 400; PUT undefined/null/array semantics (sync called correctly, set() never receives the key); management list carries the field.
+- [ ] **Step 2:** implement; run forms suite + tsc. Commit `feat(api): visibleOrgIds round-trip on /ticket-forms`
+
+---
+
+### Task 4: Portal API — forms read + form-aware create
+
+**Files:**
+- Modify: `apps/api/src/routes/portal/tickets.ts` + `tickets.test.ts`
+- Modify: `apps/api/src/routes/portal/schemas.ts`
+
+**Interfaces:**
+- `GET /ticket-forms` (portal router, same mount as portal ticket routes; auth from `portalAuth`): resolve `{ id: user.orgId, partnerId }` — read the org's partnerId the same way `routes/portal/quotes.ts` resolves partner context (system-context read, `runOutsideDbContext(() => withSystemDbAccessContext(...))`); return `{ data: forms.map(slim) }` where slim = `{ id, name, description, categoryId, fields, defaultPriority }` from `listTicketFormsForOrg(org, { portalOnly: true })`. No titleTemplate (server composes subjects).
+- Portal `createTicketSchema` (`schemas.ts`) becomes:
+
+```ts
+export const createTicketSchema = z
+  .object({
+    subject: z.string().min(1).max(255).optional(),
+    description: z.string().min(1).optional(),
+    priority: ticketPrioritySchema.optional().default('normal'),
+    formId: z.string().guid().optional(),
+    formResponses: z.record(z.string(), z.unknown()).optional()
+  })
+  .superRefine((v, ctx) => {
+    if (!v.formId && (!v.subject || !v.subject.trim())) {
+      ctx.addIssue({ code: 'custom', path: ['subject'], message: 'subject is required unless a formId is provided' });
+    }
+    if (!v.formId && (!v.description || !v.description.trim())) {
+      ctx.addIssue({ code: 'custom', path: ['description'], message: 'description is required unless a formId is provided' });
+    }
+    if (v.formResponses && !v.formId) {
+      ctx.addIssue({ code: 'custom', path: ['formResponses'], message: 'formResponses requires formId' });
+    }
+  });
+```
+
+(Keeping `priority.default('normal')` here is fine: the portal UI has no per-form priority prefill; forms' `defaultPriority` losing to the portal's explicit `'normal'` is acceptable Phase 2 behavior — note it in the PR body. If the executor disagrees, the alternative is dropping the default and letting the service chain resolve — either is acceptable, but then update the handler's typing accordingly and say so in the report.)
+- POST handler passes `formId`/`formResponses` through to `createTicket` (which already validates, composes, and — from Task 2 — enforces `showInPortal` + allowlist for `source: 'portal'`).
+
+- [ ] **Step 1 (TDD):** portal route tests (mock `ticketService`/`ticketFormService` per `portal/tickets.test.ts` conventions) — GET returns slim forms for the session org; POST passes formId/formResponses; POST with formResponses-sans-formId → 400; POST form-only (no subject/description) accepted by schema.
+- [ ] **Step 2:** implement; run portal route tests + tsc. Commit `feat(api): portal ticket-forms read + form-aware portal ticket create`
+
+---
+
+### Task 5: Web builder — org allowlist multi-select
+
+**Files:**
+- Modify: `apps/web/src/components/settings/TicketFormsCard.tsx` + `.test.tsx`
+
+**Interfaces:**
+- Editor (partner-wide scope only, both create and edit): checkbox "Limit to specific organizations" (`ticket-form-limit-orgs`); when checked, a multi-select of the partner's orgs (`ticket-form-visible-orgs`, reuse the orgs list already fetched). Unchecked → `visibleOrgIds: null` on save; checked → selected ids (min 1 — inline issue otherwise).
+- List rows: partner-wide forms show `All orgs` badge when `visibleOrgIds` is null, else `N orgs` (`ticket-form-org-count-<id>`).
+- Edit hydration: seed the control from the row's `visibleOrgIds`.
+
+- [ ] **Step 1 (TDD):** tests — create partner-wide with 2 orgs selected → POST body `visibleOrgIds: [a, b]`; unchecking sends `null` on edit; badge renders `2 orgs`; checked-with-zero-selection blocks save with inline issue.
+- [ ] **Step 2:** implement (existing editor patterns; all mutations already runAction). Run TicketFormsCard tests + full web suite. Commit `feat(web): org allowlist selector on partner-wide intake forms`
+
+---
+
+### Task 6: Portal UI — form renderer + card grid
+
+**Files:**
+- Create: `apps/portal/src/components/portal/TicketFormFields.tsx` (portal-native duplicate — header comment MUST note "Deliberate duplicate of apps/web/src/components/tickets/TicketFormFields.tsx (portal cannot share web React components); keep in sync", matching the `invoiceTypes.ts:5` convention)
+- Create: `apps/portal/src/components/portal/TicketFormFields.test.tsx`
+- Modify: `apps/portal/src/components/portal/NewTicketForm.tsx` + create `NewTicketForm.test.tsx` (if none exists)
+- Modify: `apps/portal/src/components/portal/index.ts` (barrel)
+- Modify: `apps/portal/src/lib/api.ts` (`getTicketForms()` → `GET /portal/ticket-forms` — confirm the exact portal API mount prefix by reading how `createTicket` builds its path in that file)
+- Possibly modify: `apps/portal/package.json` (devDeps)
+
+**Interfaces:**
+- `TicketFormFields` props identical to the web version: `{ fields, values, errors, onChange }`, testids `ticket-form-field-<key>` / `ticket-form-field-error-<key>`; styling per portal conventions (copy input classes from `NewTicketForm.tsx`).
+- `NewTicketForm` flow: on mount also fetch forms (silent-degrade with `console.warn` breadcrumb). If forms exist → card grid first (`portal-ticket-form-card-<id>`, name + description), plus a "Something else" card (`portal-ticket-form-card-blank`) falling through to today's subject/description/priority form. Selecting a form renders `TicketFormFields` (+ optional extra-details textarea mapped to `description`), validates via `coerceFormResponses` + `buildResponseValidator` from `@breeze/shared` (missing-required → "This field is required"), submits `{ formId, formResponses, description? , priority }` — no subject. Back link returns to the grid and clears state.
+- Test environment: portal vitest is `environment: 'node'` — add `// @vitest-environment jsdom` per component test file. Check `apps/portal/package.json` devDeps for `@testing-library/react` + `jsdom`; if absent, add the same versions apps/web uses (workspace-consistent; `pnpm install` after). This is the one lockfile-touching step — isolate it in its own commit if added.
+
+- [ ] **Step 1:** deps check/add (own commit if needed: `chore(portal): component-test tooling`)
+- [ ] **Step 2 (TDD):** renderer test — all six field types render with testids; error line renders.
+- [ ] **Step 3 (TDD):** NewTicketForm tests — grid renders from mocked `portalApi.getTicketForms`; blank card → legacy form; form card → fields; invalid required blocks submit with inline error and no API call; valid submit posts formId+coerced responses without subject; forms-fetch failure degrades to legacy form.
+- [ ] **Step 4:** implement; run portal tests (`pnpm --filter @breeze/portal test` — confirm the actual package name in apps/portal/package.json) + `astro check` if portal CI runs it (check `.github/workflows/ci.yml` for the portal job's commands and run those). Commit `feat(portal): intake-form card grid on New Ticket`
+
+---
+
+### Task 7: Verification gate + sweep
+
+- [ ] **Step 1:** Sweep `ticket_form_org_links|visibleOrgIds|getTicketForms` repo-wide — every reader/writer goes through the service/routes above; no bare org filtering.
+- [ ] **Step 2:** Full suites: shared, api (compare failures to known-flake list only), web, portal; tsc api; `pnpm db:check-drift`; integration trio + extended allowlist/ordering cases on a throwaway DB (unprivileged `breeze_app`, prove non-vacuous per Phase 1 recipe).
+- [ ] **Step 3:** Manual live check (optional but preferred): worktree-stack up, create a partner-wide form limited to one org, verify portal of that org shows the card and a sibling org's portal doesn't, submit a ticket, confirm rendered description + `custom_fields.intakeForm`.
+- [ ] **Step 4:** Commit any sweep fixes; PR body: allowlist semantics (no rows = all orgs), the new `showInPortal` enforcement on portal creates (Phase 1 gap closed), portal priority-default note (Task 4), lockfile change if Task 6 added devDeps, and a `Refs` note that `portalBranding.enableTickets` remains un-enforced (tracked as a separate issue).
+
+## Self-Review Notes
+
+- Spec coverage: §4.3 card grid → Tasks 4+6; §5 allowlist → Tasks 1-3+5; portal RLS caveat → Tasks 2/4 (system-context reads); PR-review debt (portalOnly/ordering assertions) → Task 2 Step 4.
+- Deliberate scope exclusions: `portalBranding.enableTickets` enforcement (pre-existing silent-toggle gap — separate issue, since enforcing it changes behavior for orgs that toggled it off believing it worked); AI phase (Phase 3); e2e portal specs (no portal Playwright scaffolding exists — net-new rig, separate effort).
+- Verify-at-execution points: portal package name for test filter (Task 6), portal API mount prefix (Task 6 api.ts), portal CI commands (Task 6 Step 4), exact `PARENT_FK_JOIN_POLICY_TABLES` entry format (Task 1 Step 3 — read neighbors first).

--- a/packages/shared/src/validators/ticketForms.test.ts
+++ b/packages/shared/src/validators/ticketForms.test.ts
@@ -106,6 +106,47 @@ describe('createTicketFormSchema / updateTicketFormSchema', () => {
       expect('orgId' in r.data).toBe(false);
     }
   });
+
+  describe('visibleOrgIds (Phase 2 allowlist)', () => {
+    const orgA = '3f2f1d8e-1111-4222-8333-444455556666';
+    const orgB = '3f2f1d8e-2222-4222-8333-444455556666';
+
+    it('create accepts an array of guids, null, or absence', () => {
+      expect(createTicketFormSchema.safeParse({ name: 'n', fields, visibleOrgIds: [orgA, orgB] }).success).toBe(true);
+      expect(createTicketFormSchema.safeParse({ name: 'n', fields, visibleOrgIds: null }).success).toBe(true);
+      const r = createTicketFormSchema.safeParse({ name: 'n', fields });
+      expect(r.success).toBe(true);
+      if (r.success) expect('visibleOrgIds' in r.data).toBe(false);
+    });
+
+    it('update accepts an array of guids, null, or absence', () => {
+      expect(updateTicketFormSchema.safeParse({ visibleOrgIds: [orgA] }).success).toBe(true);
+      expect(updateTicketFormSchema.safeParse({ visibleOrgIds: null }).success).toBe(true);
+      const r = updateTicketFormSchema.parse({ name: 'x' });
+      expect('visibleOrgIds' in r).toBe(false);
+    });
+
+    it('rejects non-guid entries', () => {
+      expect(createTicketFormSchema.safeParse({ name: 'n', fields, visibleOrgIds: ['not-a-guid'] }).success).toBe(false);
+      expect(updateTicketFormSchema.safeParse({ visibleOrgIds: ['not-a-guid'] }).success).toBe(false);
+    });
+
+    it('rejects more than 500 entries', () => {
+      const many = Array.from({ length: 501 }, (_, i) => `3f2f1d8e-0000-4222-8333-${String(i).padStart(12, '0')}`);
+      expect(createTicketFormSchema.safeParse({ name: 'n', fields, visibleOrgIds: many }).success).toBe(false);
+      expect(updateTicketFormSchema.safeParse({ visibleOrgIds: many }).success).toBe(false);
+    });
+
+    it('accepts exactly 500 entries', () => {
+      const exactly500 = Array.from({ length: 500 }, (_, i) => `3f2f1d8e-0000-4222-8333-${String(i).padStart(12, '0')}`);
+      expect(createTicketFormSchema.safeParse({ name: 'n', fields, visibleOrgIds: exactly500 }).success).toBe(true);
+    });
+
+    it('does not disturb base/extend construction: a partial update of only { name } still yields only { name }', () => {
+      const r = updateTicketFormSchema.parse({ name: 'x' });
+      expect(Object.keys(r)).toEqual(['name']);
+    });
+  });
 });
 
 describe('buildResponseValidator', () => {

--- a/packages/shared/src/validators/ticketForms.ts
+++ b/packages/shared/src/validators/ticketForms.ts
@@ -69,7 +69,11 @@ const ticketFormBaseSchema = z.object({
   defaultTags: z.array(z.string().min(1).max(100)).max(20),
   showInPortal: z.boolean(),
   isActive: z.boolean(),
-  sortOrder: z.number().int().min(0).max(10_000)
+  sortOrder: z.number().int().min(0).max(10_000),
+  // Org allowlist (Phase 2, epic #2135 follow-on): null/absent = visible to
+  // all the partner's orgs; array = allowlist. Only meaningful on
+  // partner-wide forms — routes reject it on org-owned forms.
+  visibleOrgIds: z.array(z.string().guid()).max(500).nullable().optional()
 });
 
 export const createTicketFormSchema = ticketFormBaseSchema.extend({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,12 +580,21 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.2
         version: 4.3.2(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
@@ -1361,10 +1370,6 @@ packages:
     resolution: {integrity: sha512-VQ5/gTLFADkwue+FohVuCqlzFPUq4xSrX8jeZe+iwZuY6moliNC8xt86qPVNYdtbQfELDf2Nu6LI+demFPHGgw==}
     engines: {node: '>=0.8.0'}
 
-  '@babel/code-frame@7.28.6':
-    resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
@@ -1450,10 +1455,6 @@ packages:
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -1737,10 +1738,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': '>=7.29.6 <8.0.0'
-
-  '@babel/runtime@7.28.6':
-    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
@@ -11030,12 +11027,6 @@ snapshots:
 
   '@azure/msal-common@15.17.0': {}
 
-  '@babel/code-frame@7.28.6':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -11172,8 +11163,6 @@ snapshots:
       - supports-color
 
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -11496,8 +11485,6 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/runtime@7.28.6': {}
 
   '@babel/runtime@7.29.7': {}
 
@@ -13200,7 +13187,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.0': {}
 
@@ -14286,8 +14275,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.28.6
-      '@babel/runtime': 7.28.6
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16


### PR DESCRIPTION
Phase 2 of ticket intake forms (spec `docs/superpowers/specs/2026-07-10-ticket-intake-forms-design.md`, plan `docs/superpowers/plans/2026-07-11-ticket-intake-forms-phase2.md`; Phase 1 was #2339). Built subagent-driven with per-task independent reviews, a verification gate, and a final whole-branch review.

## What's new

**Org-subset allowlist for partner-wide forms**
- New `ticket_form_org_links` table (FK-child dual-axis RLS through the parent `ticket_forms` predicate; registered in `PARENT_FK_JOIN_POLICY_TABLES` + cascade order).
- `visibleOrgIds` round-trips on `POST/PUT /ticket-forms` (partner-wide forms only; partner id always from the caller's token). Link sync runs on the request transaction (a late-caught seam: a separate system-context transaction couldn't see the uncommitted parent on create — covered by a new real-DB seam test).
- Web builder: "Limit to specific organizations" multi-select + `N orgs` badge on partner-wide forms.

**Portal intake**
- `GET /api/v1/portal/tickets/forms` (under the portal auth prefix) returns a slim payload of portal-visible forms via a system-context read (org-scoped portal RLS can't see partner-wide rows).
- New Ticket page becomes a card grid (form cards + "General request" blank card) with a shared field renderer; responses land as rendered markdown in the description + snapshot in `custom_fields.intakeForm`, same as web.
- Portal Dockerfile now copies `packages/shared` (the new runtime import; production image build was proven broken without it and proven fixed with `docker build --target builder`).

## Semantics & behavior notes
- **Allowlist:** no `ticket_form_org_links` rows = form visible to **all** partner orgs. "Allowlist nobody" is unrepresentable: routes normalize `[]` to null and the UI requires ≥1 org when limiting.
- **`showInPortal` is now enforced** on portal ticket creation (`requirePortalVisible` when `source === 'portal'`) — closes a Phase 1 gap where the flag was display-only. Tenant-miss and visibility-miss return the same 400 (no existence oracle between them).
- **Portal priority default:** the portal create schema keeps `.default('normal')` (portal users never pick priority), unlike the web schema where the default was removed in Phase 1.
- **Lockfile:** portal gains `@testing-library/*` + jsdom devDeps for the new component tests.
- Refs #2345 (`portalBranding.enableTickets` remains un-enforced — pre-existing, deliberately out of scope).
- Refs #2357 (follow-up found in final review: editing a partner-wide form 400s if a previously allowlisted org has since been suspended/deleted; fail-closed, workaround exists).

## Verification
- Full suites green (shared 1065, api 12,233, web 3,274, portal 72; only known parallel-load flakes, all pass isolated); api tsc clean; `db:check-drift` clean.
- Throwaway-DB integration as unprivileged `breeze_app`: `ticketFormsPartnerRls` 10/10 (cross-partner forge 42501, XOR 23514, allowlist split, portal-visibility, ordering, owning-partner link insert), rls-coverage contract 50/50, new transaction-seam suite 2/2. Non-vacuousness proven by deliberately flipping a forge assertion (fails with 42501) and reverting.
- Repo-wide consumer sweep: every `ticket_form_org_links`/`visibleOrgIds` reader/writer goes through the service/route layer; no hidden second readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)