### PR TITLE
fix(security): agent→API trust-boundary hardening (10 findings)

### DIFF
--- a/agent/cmd/breeze-watchdog/main.go
+++ b/agent/cmd/breeze-watchdog/main.go
@@ -520,7 +520,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 
 				// Send initial failover heartbeat.
 				stats := currentRestartStats(recovery, cfg.Watchdog.MaxRestartsPer24h)
-				resp, err := failoverClient.SendHeartbeat(version, wd.State(), journal.Recent(10), stats)
+				resp, err := failoverClient.SendHeartbeat(version, wd.State(), stats)
 				if err != nil {
 					failoverFailures++
 					lastDiskServerURL = noteFailoverHeartbeatFailure(failoverClient, journal, lastDiskServerURL, failoverFailures)
@@ -629,7 +629,7 @@ func handleFailoverPoll(
 ) {
 	// Send failover heartbeat.
 	stats := currentRestartStats(recovery, maxPer24h)
-	resp, err := fc.SendHeartbeat(version, wd.State(), journal.Recent(10), stats)
+	resp, err := fc.SendHeartbeat(version, wd.State(), stats)
 	if err != nil {
 		*failoverFailures = *failoverFailures + 1
 		*lastDiskServerURL = noteFailoverHeartbeatFailure(fc, journal, *lastDiskServerURL, *failoverFailures)
@@ -790,18 +790,34 @@ func handleFailoverCommand(
 			resultStatus = "failed"
 			errMsg = err.Error()
 		} else {
-			resultStatus = "completed"
-			result = map[string]any{
+			res := map[string]any{
 				"journal_entries": len(entries),
 				"state":           wd.State(),
 				"history":         wd.StateHistory(),
 			}
-			// Ship full journal entries.
-			if shipErr := fc.ShipLogs(entries); shipErr != nil {
+			// Ship full journal entries to the diagnostic-log endpoint. Only
+			// report "completed" if they actually reached the API — otherwise
+			// operators would see a false success for empty diagnostics.
+			shipped, shipErr := fc.ShipLogs(entries)
+			res["shipped_logs"] = shipped
+			if shipErr != nil {
 				journal.Log(watchdog.LevelWarn, "failover.ship_logs_failed", map[string]any{
-					"error": shipErr.Error(),
+					"error":   shipErr.Error(),
+					"shipped": shipped,
+					"total":   len(entries),
 				})
+				res["ship_error"] = shipErr.Error()
+				// partial flag records that some batches landed; the API's
+				// command-result status enum only accepts completed/failed/
+				// timeout, so any ship failure maps to "failed" while the
+				// payload carries the shipped/total detail.
+				res["partial"] = shipped > 0
+				resultStatus = "failed"
+				errMsg = shipErr.Error()
+			} else {
+				resultStatus = "completed"
 			}
+			result = res
 		}
 
 	case "update_agent":

--- a/agent/cmd/breeze-watchdog/main_test.go
+++ b/agent/cmd/breeze-watchdog/main_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/watchdog"
+)
+
+// collectDiagnosticsHarness spins up a fake API that routes /logs and
+// /commands/.../result, drives handleFailoverCommand with a collect_diagnostics
+// command against a journal pre-seeded with `entryCount` on-disk entries, and
+// returns the submitted command-result body. The logsStatus callback decides
+// the HTTP status for each /logs POST (1-indexed call number) so a test can
+// stage a mixed 201/500 (partial) or all-201 (full success) ship outcome.
+func collectDiagnosticsHarness(t *testing.T, entryCount int, logsStatus func(call int) int) map[string]any {
+	t.Helper()
+
+	journal, err := watchdog.NewJournal(t.TempDir(), 10, 3)
+	if err != nil {
+		t.Fatalf("new journal: %v", err)
+	}
+	defer journal.Close()
+	for i := 0; i < entryCount; i++ {
+		journal.Log(watchdog.LevelInfo, "seed.entry", map[string]any{"i": i})
+	}
+
+	var logsCalls int
+	var resultBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/result"):
+			raw, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(raw, &resultBody); err != nil {
+				t.Errorf("decode result body: %v", err)
+			}
+			w.WriteHeader(http.StatusOK)
+		case strings.HasSuffix(r.URL.Path, "/logs"):
+			logsCalls++
+			w.WriteHeader(logsStatus(logsCalls))
+			w.Write([]byte(`{}`)) //nolint:errcheck
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	fc := watchdog.NewFailoverClient(srv.URL, "agent-1", "tok", nil)
+	wd := watchdog.NewWatchdog(watchdog.Config{})
+	cfg := &config.Config{AgentID: "agent-1", ServerURL: srv.URL}
+	tokens := &tokenHolder{}
+	recovery := watchdog.NewRecoveryManager(3, 0)
+
+	cmd := watchdog.FailoverCommand{ID: "cmd-diag", Type: "collect_diagnostics"}
+	handleFailoverCommand(fc, cmd, wd, journal, cfg, tokens, recovery)
+
+	if resultBody == nil {
+		t.Fatal("no command result was submitted")
+	}
+	return resultBody
+}
+
+// nestedResult extracts the "result" object submitted alongside the status.
+func nestedResult(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+	res, ok := body["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("result field missing/not an object: %#v", body["result"])
+	}
+	return res
+}
+
+// TestCollectDiagnosticsPartialShipFailsWithPartialFlag drives collect_diagnostics
+// with >200 seeded entries so ShipLogs splits into two batches; the first lands
+// (201) and the second fails (500). The submitted result must report
+// status=failed, partial=true, and shipped_logs=200 (only the first batch) — the
+// headline of finding #7: an operator sees a truthful partial, not a false
+// "completed" for diagnostics that only half-reached the API.
+func TestCollectDiagnosticsPartialShipFailsWithPartialFlag(t *testing.T) {
+	// 250 seeded + the "failover.command" entry handleFailoverCommand itself
+	// logs = 251 entries → batches of 200 + 51. First 201, rest 500.
+	body := collectDiagnosticsHarness(t, 250, func(call int) int {
+		if call == 1 {
+			return http.StatusCreated
+		}
+		return http.StatusInternalServerError
+	})
+
+	if got, _ := body["status"].(string); got != "failed" {
+		t.Errorf("status = %v, want failed", body["status"])
+	}
+	res := nestedResult(t, body)
+	if got := res["partial"]; got != true {
+		t.Errorf("result.partial = %v, want true", got)
+	}
+	if got := res["shipped_logs"]; got != float64(200) {
+		t.Errorf("result.shipped_logs = %v, want 200 (first batch only)", got)
+	}
+	if _, ok := res["ship_error"]; !ok {
+		t.Errorf("result.ship_error missing, want the ship failure detail")
+	}
+}
+
+// TestCollectDiagnosticsFullShipCompletes drives collect_diagnostics when every
+// /logs batch lands (201). The result must report status=completed, carry a
+// positive shipped_logs count, and NOT flag a partial.
+func TestCollectDiagnosticsFullShipCompletes(t *testing.T) {
+	body := collectDiagnosticsHarness(t, 250, func(int) int { return http.StatusCreated })
+
+	if got, _ := body["status"].(string); got != "completed" {
+		t.Errorf("status = %v, want completed", body["status"])
+	}
+	res := nestedResult(t, body)
+	shipped, _ := res["shipped_logs"].(float64)
+	if shipped <= 0 {
+		t.Errorf("result.shipped_logs = %v, want > 0", res["shipped_logs"])
+	}
+	if got, ok := res["partial"]; ok && got == true {
+		t.Errorf("result.partial = true on full success, want absent/false")
+	}
+}

--- a/agent/internal/executor/security.go
+++ b/agent/internal/executor/security.go
@@ -201,8 +201,14 @@ func SanitizeOutput(output string) string {
 		{regexp.MustCompile(`(?i)(api[_-]?key|apikey|token|secret|password|passwd|pwd)\s*[=:]\s*['"]?[a-zA-Z0-9_\-]{8,}['"]?`), "$1=[REDACTED]"},
 		// AWS keys
 		{regexp.MustCompile(`(?i)AKIA[0-9A-Z]{16}`), "[AWS_KEY_REDACTED]"},
-		// Private keys
-		{regexp.MustCompile(`-----BEGIN [A-Z]+ PRIVATE KEY-----`), "[PRIVATE_KEY_REDACTED]"},
+		// Private keys — remove the ENTIRE PEM block (header + base64 body + footer),
+		// not just the header line, or the key stays fully reconstructable. The
+		// algorithm token is optional so PKCS#8 `-----BEGIN PRIVATE KEY-----`
+		// is covered alongside RSA/EC/DSA/OPENSSH/ENCRYPTED forms. `(?s)` lets `.`
+		// match newlines; the non-greedy `.*?` stops at the first END marker so two
+		// separate keys are each redacted individually. (RE2 has no backreferences,
+		// so the header/footer algorithm tokens are matched independently.)
+		{regexp.MustCompile(`(?s)-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----.*?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY-----`), "[PRIVATE_KEY_REDACTED]"},
 		// Connection strings
 		{regexp.MustCompile(`(?i)(mongodb|mysql|postgresql|redis|amqp)://[^\s]+`), "$1://[CONNECTION_STRING_REDACTED]"},
 		// Bearer tokens

--- a/agent/internal/executor/security.go
+++ b/agent/internal/executor/security.go
@@ -209,6 +209,16 @@ func SanitizeOutput(output string) string {
 		// separate keys are each redacted individually. (RE2 has no backreferences,
 		// so the header/footer algorithm tokens are matched independently.)
 		{regexp.MustCompile(`(?s)-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----.*?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY-----`), "[PRIVATE_KEY_REDACTED]"},
+		// Truncated private key fallback — a key cut off between header and footer
+		// (output caps, killed process) has a BEGIN line and a full base64 body but
+		// no END marker, so the complete-block rule above matches nothing and the
+		// body leaks verbatim. This rule strips a lone BEGIN header plus any
+		// immediately-following base64/whitespace body. It MUST run AFTER the
+		// complete-block rule: that pass replaces whole keys (END marker included)
+		// with the marker text first, so this fallback finds no remaining BEGIN
+		// header for a complete key and can only catch genuinely truncated ones.
+		// RE2 is linear (no catastrophic backtracking), so the greedy `*` is safe.
+		{regexp.MustCompile(`-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----[A-Za-z0-9+/=\s]*`), "[PRIVATE_KEY_REDACTED]"},
 		// Connection strings
 		{regexp.MustCompile(`(?i)(mongodb|mysql|postgresql|redis|amqp)://[^\s]+`), "$1://[CONNECTION_STRING_REDACTED]"},
 		// Bearer tokens

--- a/agent/internal/executor/security_test.go
+++ b/agent/internal/executor/security_test.go
@@ -14,6 +14,10 @@ func TestSanitizeOutput_PrivateKeyRedaction(t *testing.T) {
 	openssh := "-----BEGIN OPENSSH PRIVATE KEY-----\n" + testKeyBody + "\n-----END OPENSSH PRIVATE KEY-----"
 	ec := "-----BEGIN EC PRIVATE KEY-----\n" + testKeyBody + "\n-----END EC PRIVATE KEY-----"
 	encrypted := "-----BEGIN ENCRYPTED PRIVATE KEY-----\n" + testKeyBody + "\n-----END ENCRYPTED PRIVATE KEY-----"
+	// A key truncated between header and footer: BEGIN + full base64 body but no
+	// END marker (output caps, killed process). The complete-block rule can't
+	// match it, so the fallback header+body rule must catch it.
+	truncated := "-----BEGIN PRIVATE KEY-----\n" + testKeyBody + "\nAnOtHeRlInE0987654321"
 
 	tests := []struct {
 		name  string
@@ -63,6 +67,16 @@ func TestSanitizeOutput_PrivateKeyRedaction(t *testing.T) {
 			wantAbsent:         []string{testKeyBody, "-----END RSA PRIVATE KEY-----", "-----END OPENSSH PRIVATE KEY-----"},
 			wantPresent:        []string{"middle text"},
 			wantRedactionCount: 2,
+		},
+		{
+			// A truncated key is cut off at the end of output, so the greedy
+			// fallback body match extends to end-of-string. Text BEFORE the BEGIN
+			// header is untouched; there is no trailing text to preserve.
+			name:               "truncated key (no END marker) still redacted",
+			input:              "before the key\n" + truncated,
+			wantAbsent:         []string{testKeyBody, "-----BEGIN PRIVATE KEY-----", "AnOtHeRlInE0987654321"},
+			wantPresent:        []string{"before the key"},
+			wantRedactionCount: 1,
 		},
 		{
 			name:               "non-key text passthrough",

--- a/agent/internal/executor/security_test.go
+++ b/agent/internal/executor/security_test.go
@@ -1,0 +1,94 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+)
+
+// A representative base64 body line that must never survive redaction.
+const testKeyBody = "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDb1234567890abcd"
+
+func TestSanitizeOutput_PrivateKeyRedaction(t *testing.T) {
+	pkcs8 := "-----BEGIN PRIVATE KEY-----\n" + testKeyBody + "\nAnOtHeRlInE0987654321\n-----END PRIVATE KEY-----"
+	rsa := "-----BEGIN RSA PRIVATE KEY-----\n" + testKeyBody + "\n-----END RSA PRIVATE KEY-----"
+	openssh := "-----BEGIN OPENSSH PRIVATE KEY-----\n" + testKeyBody + "\n-----END OPENSSH PRIVATE KEY-----"
+	ec := "-----BEGIN EC PRIVATE KEY-----\n" + testKeyBody + "\n-----END EC PRIVATE KEY-----"
+	encrypted := "-----BEGIN ENCRYPTED PRIVATE KEY-----\n" + testKeyBody + "\n-----END ENCRYPTED PRIVATE KEY-----"
+
+	tests := []struct {
+		name  string
+		input string
+		// wantAbsent are substrings that must NOT appear in the sanitized output
+		// (base64 body, footer markers, header markers).
+		wantAbsent []string
+		// wantPresent are substrings that MUST survive (surrounding non-key text).
+		wantPresent []string
+		// wantRedactionCount is how many [PRIVATE_KEY_REDACTED] markers to expect.
+		wantRedactionCount int
+	}{
+		{
+			name:               "PKCS#8 block fully redacted",
+			input:              "before\n" + pkcs8 + "\nafter",
+			wantAbsent:         []string{testKeyBody, "-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----", "AnOtHeRlInE0987654321"},
+			wantPresent:        []string{"before", "after"},
+			wantRedactionCount: 1,
+		},
+		{
+			name:               "RSA block body and END marker gone",
+			input:              rsa,
+			wantAbsent:         []string{testKeyBody, "-----BEGIN RSA PRIVATE KEY-----", "-----END RSA PRIVATE KEY-----"},
+			wantRedactionCount: 1,
+		},
+		{
+			name:               "OPENSSH block fully redacted",
+			input:              openssh,
+			wantAbsent:         []string{testKeyBody, "OPENSSH PRIVATE KEY"},
+			wantRedactionCount: 1,
+		},
+		{
+			name:               "EC block fully redacted",
+			input:              ec,
+			wantAbsent:         []string{testKeyBody, "EC PRIVATE KEY"},
+			wantRedactionCount: 1,
+		},
+		{
+			name:               "ENCRYPTED block fully redacted",
+			input:              encrypted,
+			wantAbsent:         []string{testKeyBody, "ENCRYPTED PRIVATE KEY"},
+			wantRedactionCount: 1,
+		},
+		{
+			name:               "two keys both redacted",
+			input:              rsa + "\nmiddle text\n" + openssh,
+			wantAbsent:         []string{testKeyBody, "-----END RSA PRIVATE KEY-----", "-----END OPENSSH PRIVATE KEY-----"},
+			wantPresent:        []string{"middle text"},
+			wantRedactionCount: 2,
+		},
+		{
+			name:               "non-key text passthrough",
+			input:              "just a normal script output with no secrets",
+			wantPresent:        []string{"just a normal script output with no secrets"},
+			wantRedactionCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeOutput(tt.input)
+
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("sanitized output still contains %q; key not fully redacted.\ngot: %q", absent, got)
+				}
+			}
+			for _, present := range tt.wantPresent {
+				if !strings.Contains(got, present) {
+					t.Errorf("sanitized output missing expected text %q.\ngot: %q", present, got)
+				}
+			}
+			if n := strings.Count(got, "[PRIVATE_KEY_REDACTED]"); n != tt.wantRedactionCount {
+				t.Errorf("expected %d [PRIVATE_KEY_REDACTED] markers, got %d.\noutput: %q", tt.wantRedactionCount, n, got)
+			}
+		})
+	}
+}

--- a/agent/internal/watchdog/failover.go
+++ b/agent/internal/watchdog/failover.go
@@ -98,15 +98,19 @@ func (c *FailoverClient) setHeaders(req *http.Request) {
 
 // SendHeartbeat POSTs a watchdog heartbeat to the API and returns the parsed
 // response. The request body includes role, watchdogState, agentVersion,
-// journalExcerpt, mainAgentRestartCount24h, mainAgentLastRestartAt,
-// flapDetected, and timestamp fields.
-func (c *FailoverClient) SendHeartbeat(watchdogVersion, currentState string, journalEntries []JournalEntry, restartStats RestartStats) (*HeartbeatResponse, error) {
+// mainAgentRestartCount24h, mainAgentLastRestartAt, flapDetected, and
+// timestamp fields.
+//
+// The heartbeat intentionally does NOT send a journalExcerpt: the API
+// heartbeat schema (apps/api/src/routes/agents/schemas.ts) has no such field
+// and silently strips it, so shipping it was dead wire data. Diagnostic
+// journal entries reach the server via ShipLogs / the /logs endpoint instead.
+func (c *FailoverClient) SendHeartbeat(watchdogVersion, currentState string, restartStats RestartStats) (*HeartbeatResponse, error) {
 	body := map[string]any{
 		"role":                     "watchdog",
 		"watchdogState":            currentState,
 		"status":                   "ok",
 		"agentVersion":             watchdogVersion,
-		"journalExcerpt":           journalEntries,
 		"timestamp":                time.Now().UTC().Format(time.RFC3339),
 		"mainAgentRestartCount24h": restartStats.Count24h,
 		"flapDetected":             restartStats.FlapDetected,
@@ -209,14 +213,135 @@ func (c *FailoverClient) SubmitCommandResult(commandID, status string, result an
 	return nil
 }
 
-// ShipLogs POSTs a batch of journal entries to the agent logs endpoint.
-func (c *FailoverClient) ShipLogs(entries []JournalEntry) error {
-	data, err := json.Marshal(entries)
+// apiLogEntry mirrors the API's agent diagnostic-log ingest contract
+// (apps/api/src/routes/agents/logs.ts, agentLogEntrySchema). The endpoint
+// requires an OBJECT `{ logs: [...] }` whose entries carry timestamp/level/
+// component/message(+optional fields) — NOT the watchdog's raw JournalEntry
+// shape ({time, level, event, data}). We translate here so the watchdog
+// speaks the API's existing contract rather than loosening the API.
+type apiLogEntry struct {
+	Timestamp string         `json:"timestamp"`
+	Level     string         `json:"level"`
+	Component string         `json:"component"`
+	Message   string         `json:"message"`
+	Fields    map[string]any `json:"fields,omitempty"`
+}
+
+// apiLogBatch is the request body wrapper the /logs endpoint requires.
+type apiLogBatch struct {
+	Logs []apiLogEntry `json:"logs"`
+}
+
+const (
+	// shipLogsMaxBatchEntries matches the API's z.array(...).max(200) cap.
+	shipLogsMaxBatchEntries = 200
+	// shipLogsMaxBatchBytes keeps each POST comfortably under the API's 256KB
+	// bodyLimit (the watchdog posts uncompressed), leaving headroom for JSON
+	// framing overhead.
+	shipLogsMaxBatchBytes = 240 * 1024
+	// shipLogsMaxMessageLen matches the API's message .max(10000). Trim rather
+	// than let one long line 400 the whole batch.
+	shipLogsMaxMessageLen = 10000
+	// shipLogsMaxFieldsBytes matches the API's fields 32KB refine. Drop
+	// oversized data rather than reject the batch.
+	shipLogsMaxFieldsBytes = 32000
+)
+
+// normalizeLogLevel maps a journal level onto the API's accepted enum
+// (debug/info/warn/error). Watchdog levels (info/warn/error) already fall
+// within it; anything unexpected degrades to "info" so a stray level can't
+// reject the batch.
+func normalizeLogLevel(level string) string {
+	switch level {
+	case "debug", "info", "warn", "error":
+		return level
+	default:
+		return LevelInfo
+	}
+}
+
+// journalEntryToAPI translates a watchdog JournalEntry into the API's log
+// entry shape (time→timestamp RFC3339, event→message, fixed component, data→
+// fields), enforcing the endpoint's per-field size limits.
+func journalEntryToAPI(entry JournalEntry) apiLogEntry {
+	message := entry.Event
+	if len(message) > shipLogsMaxMessageLen {
+		message = message[:shipLogsMaxMessageLen]
+	}
+	out := apiLogEntry{
+		Timestamp: entry.Time.UTC().Format(time.RFC3339),
+		Level:     normalizeLogLevel(entry.Level),
+		Component: "watchdog",
+		Message:   message,
+	}
+	if len(entry.Data) > 0 {
+		if b, err := json.Marshal(entry.Data); err == nil && len(b) <= shipLogsMaxFieldsBytes {
+			out.Fields = entry.Data
+		}
+	}
+	return out
+}
+
+// ShipLogs translates watchdog journal entries into the API's diagnostic-log
+// ingest contract and POSTs them in batches (respecting the API's 200-entry
+// cap and 256KB body limit). It returns the number of entries successfully
+// shipped and, if any batch failed, the first error encountered. Callers use
+// the shipped count to distinguish a total failure (0 shipped) from a partial
+// one (some shipped) so the command result isn't falsely reported "completed".
+func (c *FailoverClient) ShipLogs(entries []JournalEntry) (int, error) {
+	if len(entries) == 0 {
+		return 0, nil
+	}
+
+	url := fmt.Sprintf("%s/api/v1/agents/%s/logs", c.BaseURL(), c.agentID)
+
+	shipped := 0
+	var firstErr error
+
+	batch := make([]apiLogEntry, 0, shipLogsMaxBatchEntries)
+	batchBytes := 0
+
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		if err := c.postLogBatch(url, batch); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+		} else {
+			shipped += len(batch)
+		}
+		batch = batch[:0]
+		batchBytes = 0
+	}
+
+	for _, entry := range entries {
+		apiEntry := journalEntryToAPI(entry)
+		// Approximate the serialized size (+1 for the joining comma) so a batch
+		// never crosses the API body limit mid-flight.
+		entryBytes := shipLogsMaxMessageLen // conservative fallback
+		if b, err := json.Marshal(apiEntry); err == nil {
+			entryBytes = len(b) + 1
+		}
+		if len(batch) > 0 && (len(batch) >= shipLogsMaxBatchEntries || batchBytes+entryBytes > shipLogsMaxBatchBytes) {
+			flush()
+		}
+		batch = append(batch, apiEntry)
+		batchBytes += entryBytes
+	}
+	flush()
+
+	return shipped, firstErr
+}
+
+// postLogBatch POSTs a single translated batch to the /logs endpoint.
+func (c *FailoverClient) postLogBatch(url string, batch []apiLogEntry) error {
+	data, err := json.Marshal(apiLogBatch{Logs: batch})
 	if err != nil {
 		return fmt.Errorf("failover: marshal logs: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/api/v1/agents/%s/logs", c.BaseURL(), c.agentID)
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("failover: build logs request: %w", err)
@@ -230,7 +355,9 @@ func (c *FailoverClient) ShipLogs(entries []JournalEntry) error {
 	defer resp.Body.Close()
 
 	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
+	// Accept any 2xx: the /logs endpoint returns 200 (empty batch), 201 (all
+	// inserted), or 207 (partial insert) — all mean the batch was received.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("failover: ship logs returned %d: %s", resp.StatusCode, string(respBody))
 	}
 	return nil

--- a/agent/internal/watchdog/failover.go
+++ b/agent/internal/watchdog/failover.go
@@ -355,8 +355,9 @@ func (c *FailoverClient) postLogBatch(url string, batch []apiLogEntry) error {
 	defer resp.Body.Close()
 
 	respBody, _ := io.ReadAll(resp.Body)
-	// Accept any 2xx: the /logs endpoint returns 200 (empty batch), 201 (all
-	// inserted), or 207 (partial insert) — all mean the batch was received.
+	// Accept any 2xx: the /logs endpoint returns 201 (all inserted) or 207
+	// (partial insert) — both mean the batch was received. (ShipLogs never
+	// POSTs an empty batch; it early-returns on zero entries.)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("failover: ship logs returned %d: %s", resp.StatusCode, string(respBody))
 	}

--- a/agent/internal/watchdog/failover_test.go
+++ b/agent/internal/watchdog/failover_test.go
@@ -302,6 +302,151 @@ func TestShipLogsBatchesOverCap(t *testing.T) {
 	}
 }
 
+// TestJournalEntryToAPITranslation asserts the JournalEntry→apiLogEntry field
+// mapping directly (not just end-to-end through ShipLogs): event→message,
+// time→RFC3339 timestamp (in UTC), data→fields, fixed component="watchdog",
+// and normalizeLogLevel folding an unknown level to "info".
+func TestJournalEntryToAPITranslation(t *testing.T) {
+	t.Parallel()
+
+	// A non-UTC zone proves the translation normalizes to UTC.
+	loc := time.FixedZone("UTC+2", 2*60*60)
+	entryTime := time.Date(2026, 5, 1, 14, 30, 0, 0, loc)
+
+	entry := JournalEntry{
+		Time:  entryTime,
+		Level: "verbose", // unknown level → must fold to "info"
+		Event: "agent.crash",
+		Data:  map[string]any{"pid": 42},
+	}
+
+	got := journalEntryToAPI(entry)
+
+	if got.Component != "watchdog" {
+		t.Errorf("component = %q, want watchdog", got.Component)
+	}
+	if got.Message != "agent.crash" {
+		t.Errorf("message = %q, want agent.crash (from event)", got.Message)
+	}
+	if want := entryTime.UTC().Format(time.RFC3339); got.Timestamp != want {
+		t.Errorf("timestamp = %q, want %q (RFC3339 UTC)", got.Timestamp, want)
+	}
+	if got.Level != LevelInfo {
+		t.Errorf("level = %q, want %q (unknown level folds to info)", got.Level, LevelInfo)
+	}
+	if got.Fields == nil {
+		t.Fatal("fields = nil, want data carried into fields")
+	}
+	if got.Fields["pid"] != 42 {
+		t.Errorf("fields[pid] = %v, want 42", got.Fields["pid"])
+	}
+
+	// Every known level passes through unchanged.
+	for _, lvl := range []string{"debug", LevelInfo, LevelWarn, LevelError} {
+		if got := normalizeLogLevel(lvl); got != lvl {
+			t.Errorf("normalizeLogLevel(%q) = %q, want unchanged", lvl, got)
+		}
+	}
+}
+
+// TestJournalEntryToAPILimits covers the two size-guard branches: an oversized
+// fields object (>32KB) is dropped rather than shipped, and an over-length
+// message (>10000 chars) is truncated rather than allowed to 400 the batch.
+func TestJournalEntryToAPILimits(t *testing.T) {
+	t.Parallel()
+
+	t.Run("oversized fields dropped", func(t *testing.T) {
+		t.Parallel()
+		// Marshals to >shipLogsMaxFieldsBytes (32000), so fields must be dropped.
+		entry := JournalEntry{
+			Time:  time.Now(),
+			Level: LevelInfo,
+			Event: "big.data",
+			Data:  map[string]any{"blob": strings.Repeat("x", shipLogsMaxFieldsBytes+1000)},
+		}
+		got := journalEntryToAPI(entry)
+		if got.Fields != nil {
+			t.Errorf("fields = %v, want nil (oversized data dropped)", got.Fields)
+		}
+	})
+
+	t.Run("message truncated", func(t *testing.T) {
+		t.Parallel()
+		entry := JournalEntry{
+			Time:  time.Now(),
+			Level: LevelInfo,
+			Event: strings.Repeat("a", shipLogsMaxMessageLen+500),
+		}
+		got := journalEntryToAPI(entry)
+		if len(got.Message) != shipLogsMaxMessageLen {
+			t.Errorf("message len = %d, want %d (truncated)", len(got.Message), shipLogsMaxMessageLen)
+		}
+	})
+}
+
+// TestShipLogsSplitsOnByteCap verifies the BYTE cap (not the 200-entry count
+// cap) forces a batch split: a handful of near-maximal entries (~40KB each)
+// exceed shipLogsMaxBatchBytes long before the count cap, so ShipLogs must
+// emit multiple POSTs — each body under the API's 256KB bodyLimit (no 413).
+func TestShipLogsSplitsOnByteCap(t *testing.T) {
+	t.Parallel()
+
+	const apiBodyLimit = 256 * 1024
+
+	var batchSizes []int
+	var bodyBytes []int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		bodyBytes = append(bodyBytes, len(raw))
+		var body apiLogBatch
+		if err := json.Unmarshal(raw, &body); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		batchSizes = append(batchSizes, len(body.Logs))
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{}`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	// Each entry maxes message (10000) + fields (~31KB) ≈ 40KB translated, so a
+	// few entries blow past the 240KB byte cap while staying well under the
+	// 200-entry count cap.
+	const n = 14
+	entries := make([]JournalEntry, n)
+	for i := range entries {
+		entries[i] = JournalEntry{
+			Time:  time.Now().UTC(),
+			Level: LevelInfo,
+			Event: strings.Repeat("m", shipLogsMaxMessageLen),
+			Data:  map[string]any{"blob": strings.Repeat("d", shipLogsMaxFieldsBytes-100)},
+		}
+	}
+
+	client := NewFailoverClient(srv.URL, "device-logs", "tok", nil)
+	shipped, err := client.ShipLogs(entries)
+	if err != nil {
+		t.Fatalf("ShipLogs: %v", err)
+	}
+	if shipped != n {
+		t.Errorf("shipped = %d, want %d", shipped, n)
+	}
+	if len(batchSizes) < 2 {
+		t.Fatalf("got %d batch(es), want >=2 (byte cap must force a split)", len(batchSizes))
+	}
+	for i, size := range batchSizes {
+		// Prove the split was byte-driven, not count-driven.
+		if size >= shipLogsMaxBatchEntries {
+			t.Errorf("batch[%d] size = %d hit the count cap; split was not byte-driven", i, size)
+		}
+	}
+	for i, b := range bodyBytes {
+		if b > apiBodyLimit {
+			t.Errorf("batch[%d] body = %d bytes exceeds API bodyLimit %d (would 413)", i, b, apiBodyLimit)
+		}
+	}
+}
+
 // TestShipLogsPartialFailure verifies that when a later batch fails, ShipLogs
 // returns the count of entries from the batches that succeeded plus an error,
 // so the caller can report a partial (not falsely "completed") result.

--- a/agent/internal/watchdog/failover_test.go
+++ b/agent/internal/watchdog/failover_test.go
@@ -38,11 +38,7 @@ func TestFailoverHeartbeat(t *testing.T) {
 
 	client := NewFailoverClient(srv.URL, "device-abc", "tok-test", nil)
 
-	entries := []JournalEntry{
-		{Time: time.Now(), Level: LevelInfo, Event: "startup"},
-	}
-
-	resp, err := client.SendHeartbeat("0.1.0", StateFailover, entries, RestartStats{})
+	resp, err := client.SendHeartbeat("0.1.0", StateFailover, RestartStats{})
 	if err != nil {
 		t.Fatalf("SendHeartbeat returned error: %v", err)
 	}
@@ -152,8 +148,12 @@ func TestSendHeartbeatIncludesRestartStats(t *testing.T) {
 		LastRestartAt: time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC),
 		FlapDetected:  false,
 	}
-	if _, err := fc.SendHeartbeat("0.65.20", "RECOVERING", nil, stats); err != nil {
+	if _, err := fc.SendHeartbeat("0.65.20", "RECOVERING", stats); err != nil {
 		t.Fatalf("SendHeartbeat: %v", err)
+	}
+
+	if _, ok := captured["journalExcerpt"]; ok {
+		t.Errorf("heartbeat body should not include journalExcerpt (dead wire data), got %v", captured["journalExcerpt"])
 	}
 
 	if got := captured["mainAgentRestartCount24h"]; got != float64(4) {
@@ -164,5 +164,173 @@ func TestSendHeartbeatIncludesRestartStats(t *testing.T) {
 	}
 	if got := captured["flapDetected"]; got != false {
 		t.Errorf("flapDetected: want false, got %v", got)
+	}
+}
+
+// TestShipLogsMarshalsAPIContract verifies ShipLogs POSTs the API's required
+// `{ logs: [...] }` wrapper with the watchdog JournalEntry fields translated to
+// the endpoint's schema (time→timestamp, event→message, fixed component,
+// data→fields), and that non-200 2xx codes (201/207) count as success.
+func TestShipLogsMarshalsAPIContract(t *testing.T) {
+	t.Parallel()
+
+	fixedTime := time.Date(2026, 5, 1, 12, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		statusCode  int
+		entries     []JournalEntry
+		wantShipped int
+		wantErr     bool
+	}{
+		{
+			name:       "201 created is success",
+			statusCode: http.StatusCreated,
+			entries: []JournalEntry{
+				{Time: fixedTime, Level: LevelWarn, Event: "agent.crash", Data: map[string]any{"pid": 42}},
+			},
+			wantShipped: 1,
+		},
+		{
+			name:        "207 partial insert is success",
+			statusCode:  http.StatusMultiStatus,
+			entries:     []JournalEntry{{Time: fixedTime, Level: LevelInfo, Event: "startup"}},
+			wantShipped: 1,
+		},
+		{
+			name:        "200 ok is success",
+			statusCode:  http.StatusOK,
+			entries:     []JournalEntry{{Time: fixedTime, Level: LevelError, Event: "boom"}},
+			wantShipped: 1,
+		},
+		{
+			name:        "500 is failure with zero shipped",
+			statusCode:  http.StatusInternalServerError,
+			entries:     []JournalEntry{{Time: fixedTime, Level: LevelInfo, Event: "startup"}},
+			wantShipped: 0,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var body apiLogBatch
+			var decodeErr error
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				decodeErr = json.NewDecoder(r.Body).Decode(&body)
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(`{}`)) //nolint:errcheck
+			}))
+			defer srv.Close()
+
+			client := NewFailoverClient(srv.URL, "device-logs", "tok", nil)
+			shipped, err := client.ShipLogs(tt.entries)
+
+			if decodeErr != nil {
+				t.Fatalf("server failed to decode { logs: [...] } wrapper: %v", decodeErr)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ShipLogs err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if shipped != tt.wantShipped {
+				t.Errorf("shipped = %d, want %d", shipped, tt.wantShipped)
+			}
+
+			if len(body.Logs) != len(tt.entries) {
+				t.Fatalf("server received %d logs, want %d", len(body.Logs), len(tt.entries))
+			}
+			for i, got := range body.Logs {
+				src := tt.entries[i]
+				if got.Component != "watchdog" {
+					t.Errorf("logs[%d].component = %q, want watchdog", i, got.Component)
+				}
+				if got.Message != src.Event {
+					t.Errorf("logs[%d].message = %q, want %q (event)", i, got.Message, src.Event)
+				}
+				if got.Timestamp != src.Time.UTC().Format(time.RFC3339) {
+					t.Errorf("logs[%d].timestamp = %q, want %q", i, got.Timestamp, src.Time.UTC().Format(time.RFC3339))
+				}
+				if got.Level != src.Level {
+					t.Errorf("logs[%d].level = %q, want %q", i, got.Level, src.Level)
+				}
+			}
+		})
+	}
+}
+
+// TestShipLogsBatchesOverCap verifies ShipLogs splits >200 entries into multiple
+// POSTs, each honoring the API's 200-entry cap, and sums the shipped count.
+func TestShipLogsBatchesOverCap(t *testing.T) {
+	t.Parallel()
+
+	var batchSizes []int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body apiLogBatch
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		batchSizes = append(batchSizes, len(body.Logs))
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{}`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	entries := make([]JournalEntry, 450)
+	for i := range entries {
+		entries[i] = JournalEntry{Time: time.Now().UTC(), Level: LevelInfo, Event: "e"}
+	}
+
+	client := NewFailoverClient(srv.URL, "device-logs", "tok", nil)
+	shipped, err := client.ShipLogs(entries)
+	if err != nil {
+		t.Fatalf("ShipLogs: %v", err)
+	}
+	if shipped != 450 {
+		t.Errorf("shipped = %d, want 450", shipped)
+	}
+	if len(batchSizes) != 3 {
+		t.Fatalf("got %d batches, want 3 (200+200+50)", len(batchSizes))
+	}
+	for i, n := range batchSizes {
+		if n > shipLogsMaxBatchEntries {
+			t.Errorf("batch[%d] size = %d exceeds cap %d", i, n, shipLogsMaxBatchEntries)
+		}
+	}
+}
+
+// TestShipLogsPartialFailure verifies that when a later batch fails, ShipLogs
+// returns the count of entries from the batches that succeeded plus an error,
+// so the caller can report a partial (not falsely "completed") result.
+func TestShipLogsPartialFailure(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusCreated)
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		w.Write([]byte(`{}`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	entries := make([]JournalEntry, 250) // forces 2 batches (200 + 50)
+	for i := range entries {
+		entries[i] = JournalEntry{Time: time.Now().UTC(), Level: LevelInfo, Event: "e"}
+	}
+
+	client := NewFailoverClient(srv.URL, "device-logs", "tok", nil)
+	shipped, err := client.ShipLogs(entries)
+	if err == nil {
+		t.Fatal("expected error from failed second batch, got nil")
+	}
+	if shipped != 200 {
+		t.Errorf("shipped = %d, want 200 (only first batch succeeded)", shipped)
 	}
 }

--- a/agent/internal/watchdog/integration_test.go
+++ b/agent/internal/watchdog/integration_test.go
@@ -244,7 +244,7 @@ func Test_FailoverHeartbeatIncludesNewFields(t *testing.T) {
 		FlapDetected:  h.recovery.Count24h() >= h.maxPer24h,
 	}
 	fc := NewFailoverClient(server.URL, "agent-test", "tok", nil)
-	if _, err := fc.SendHeartbeat("v-test", h.wd.State(), nil, stats); err != nil {
+	if _, err := fc.SendHeartbeat("v-test", h.wd.State(), stats); err != nil {
 		t.Fatalf("SendHeartbeat: %v", err)
 	}
 	if got := captured["mainAgentRestartCount24h"]; got != float64(5) {

--- a/apps/api/src/__tests__/devices.endpoints.test.ts
+++ b/apps/api/src/__tests__/devices.endpoints.test.ts
@@ -10,6 +10,7 @@ vi.mock('../services/commandQueue', () => ({
 }));
 
 vi.mock('../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeAuditEvent: vi.fn(),
   writeRouteAudit: vi.fn()
 }));

--- a/apps/api/src/__tests__/integration/softwareCatalogDelete.integration.test.ts
+++ b/apps/api/src/__tests__/integration/softwareCatalogDelete.integration.test.ts
@@ -48,6 +48,7 @@ vi.mock('../../middleware/auth', async (importOriginal) => {
 });
 
 vi.mock('../../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeRouteAudit: vi.fn(),
   writeAuditEvent: vi.fn(),
 }));

--- a/apps/api/src/__tests__/multi-tenant-isolation.test.ts
+++ b/apps/api/src/__tests__/multi-tenant-isolation.test.ts
@@ -86,6 +86,7 @@ vi.mock('../middleware/auth', () => ({
 // ─── Mock side-effect services ────────────────────────────────────────────────
 
 vi.mock('../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeRouteAudit: vi.fn(),
   writeAuditEvent: vi.fn(),
 }));

--- a/apps/api/src/middleware/agentAuth.ts
+++ b/apps/api/src/middleware/agentAuth.ts
@@ -24,8 +24,12 @@ export interface AgentAuthContext {
    * Used by rotate-token to compare-and-swap the rotation against the exact
    * hash that authenticated, so a superseded/racing token cannot mint durable
    * credentials. Never log or return this value.
+   *
+   * Optional at the type level so existing callers that build a partial agent
+   * context (tests, non-rotation routes) still typecheck; the real middleware
+   * ALWAYS populates it, and rotate-token fails closed if it is ever absent.
    */
-  authTokenHash: string;
+  authTokenHash?: string;
 }
 
 export type AgentCredentialRole = 'agent' | 'watchdog';

--- a/apps/api/src/middleware/agentAuth.ts
+++ b/apps/api/src/middleware/agentAuth.ts
@@ -16,6 +16,16 @@ export interface AgentAuthContext {
   orgId: string;
   siteId: string;
   role: AgentCredentialRole;
+  /**
+   * SHA-256 hex of the bearer token that actually authenticated this request —
+   * i.e. the CURRENT-token hash the middleware matched (rotation-required
+   * previous-token callers are still surfaced via `agentTokenRotationRequired`,
+   * but must be rejected before any credential mint; see token.ts rotate-token).
+   * Used by rotate-token to compare-and-swap the rotation against the exact
+   * hash that authenticated, so a superseded/racing token cannot mint durable
+   * credentials. Never log or return this value.
+   */
+  authTokenHash: string;
 }
 
 export type AgentCredentialRole = 'agent' | 'watchdog';
@@ -418,6 +428,11 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
     orgId: device.orgId,
     siteId: device.siteId,
     role: match.role,
+    // The exact hash that authenticated this request (current token). For a
+    // rotation-required previous-token match this is still the previous-token
+    // hash, but rotate-token rejects those before reaching any CAS, so callers
+    // that mint credentials only ever see the current-token hash here.
+    authTokenHash: tokenHash,
   });
 
   // #1105 — high-frequency, high-concurrency routes that self-manage their DB

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -149,6 +149,7 @@ vi.mock('../services/auditService', () => ({
 vi.mock('../services/auditEvents', () => ({
   ANONYMOUS_ACTOR_ID: '00000000-0000-0000-0000-000000000000',
   writeAuditEvent: vi.fn(),
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
 }));
 
 vi.mock('../services/tenantStatus', () => ({

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -161,9 +161,12 @@ import {
   createAgentWsHandlers,
   createAgentWsRoutes,
   validateAgentToken,
+  disconnectAgent,
+  isAgentConnected,
   __resetCrossTenantDropsForTest,
   AGENT_WS_CAPABILITIES,
 } from './agentWs';
+import { writeAuditEvent } from '../services/auditEvents';
 import { isAgentTenantActive } from '../services/tenantStatus';
 import { enqueueDiscoveryResults } from '../jobs/discoveryWorker';
 import { enqueueSnmpPollResults } from '../jobs/snmpWorker';
@@ -1222,5 +1225,232 @@ describe('agent websocket command results', () => {
     const app = createAgentWsRoutes(((_handler: unknown) => async (_c: any) => new Response('ws', { status: 101 })) as any);
     const res = await app.request('/agent-overlimit/ws');
     expect(res.status).toBe(429);
+  });
+});
+
+// Finding #4 — one authorized socket per agent. A second socket must close the
+// first, and disconnectAgent/revocation must always act on the authoritative
+// (newest) socket so no orphan survives.
+describe('Finding #4 — one-socket-per-agent invariant', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('closes the previous socket when a second socket opens for the same agent', async () => {
+    const preValidatedAgent = { deviceId: 'device-dup', orgId: 'org-dup' };
+    vi.mocked(db.update).mockReturnValue(updateResult() as any);
+    // Empty device select: onOpen registers the socket without reaching the
+    // (unmocked) command-claim path.
+    vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
+
+    const handlers = createAgentWsHandlers('agent-dup', preValidatedAgent);
+    const ws1 = wsMock();
+    const ws2 = wsMock();
+
+    await handlers.onOpen({}, ws1 as any);
+    await handlers.onOpen({}, ws2 as any);
+
+    expect(ws1.close).toHaveBeenCalledWith(4002, 'Superseded by newer connection');
+    expect(ws2.close).not.toHaveBeenCalled();
+    expect(isAgentConnected('agent-dup')).toBe(true);
+  });
+
+  it('disconnectAgent closes the current authoritative socket', async () => {
+    const preValidatedAgent = { deviceId: 'device-auth', orgId: 'org-auth' };
+    vi.mocked(db.update).mockReturnValue(updateResult() as any);
+    vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
+
+    const handlers = createAgentWsHandlers('agent-auth', preValidatedAgent);
+    const ws = wsMock();
+    await handlers.onOpen({}, ws as any);
+
+    const outcome = disconnectAgent('agent-auth', 4041, 'Device decommissioned');
+
+    expect(outcome).toBe('closed');
+    expect(ws.close).toHaveBeenCalledWith(4041, 'Device decommissioned');
+  });
+
+  it('an orphaned socket cannot outlive its replacement — onClose of the orphan never evicts the live socket', async () => {
+    const preValidatedAgent = { deviceId: 'device-orphan', orgId: 'org-orphan' };
+    vi.mocked(db.update).mockReturnValue(updateResult() as any);
+    vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
+
+    const handlers = createAgentWsHandlers('agent-orphan', preValidatedAgent);
+    const ws1 = wsMock();
+    const ws2 = wsMock();
+
+    await handlers.onOpen({}, ws1 as any); // ws1 authoritative
+    await handlers.onOpen({}, ws2 as any); // ws2 supersedes; ws1 closed as orphan
+
+    // The orphan's late onClose must NOT evict ws2 from the connection map or
+    // clobber its ping state (both guarded by connection identity).
+    await handlers.onClose({}, ws1 as any);
+
+    expect(isAgentConnected('agent-orphan')).toBe(true);
+    disconnectAgent('agent-orphan');
+    expect(ws2.close).toHaveBeenCalled();
+  });
+});
+
+// Finding #3 — established sockets must stop acting once containment changes.
+describe('Finding #3 — lifecycle recheck on sensitive operations', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('severs the socket on a command result when the device was quarantined after connect', async () => {
+    const preValidatedAgent = { deviceId: 'device-q', orgId: 'org-q' };
+    vi.mocked(db.update).mockReturnValue(updateResult([{ id: 'cmd-1' }]) as any);
+    vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any); // onOpen: register only
+
+    const handlers = createAgentWsHandlers('agent-q', preValidatedAgent);
+    const ws = wsMock();
+    await handlers.onOpen({}, ws as any);
+    vi.mocked(ws.close).mockClear();
+    vi.mocked(db.update).mockClear();
+
+    // command lookup returns a live row, then the lifecycle recheck sees the
+    // device is now quarantined.
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectOwnedCommandResult([
+        { id: 'cmd-1', type: 'run_script', payload: {}, deviceId: 'device-q' },
+      ]) as any)
+      .mockReturnValueOnce(selectAgentDevice([{ status: 'quarantined', agentTokenSuspendedAt: null }]) as any);
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: '77777777-7777-4777-8777-777777777777',
+        status: 'completed',
+        stdout: 'ok',
+      }),
+    } as any, ws as any);
+
+    expect(ws.close).toHaveBeenCalledWith(4001, 'Device no longer authorized');
+    // Aborted before persisting: the command row is never terminally updated.
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('severs the socket on a heartbeat command-claim when the token was suspended after connect', async () => {
+    const preValidatedAgent = { deviceId: 'device-s', orgId: 'org-s' };
+    vi.mocked(db.update).mockReturnValue(updateResult() as any);
+    vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any); // onOpen: register only
+
+    const handlers = createAgentWsHandlers('agent-s', preValidatedAgent);
+    const ws = wsMock();
+    await handlers.onOpen({}, ws as any);
+    vi.mocked(ws.close).mockClear();
+
+    // The claim path re-checks the same device row it fetches: a suspended
+    // token (org/partner tenant suspension denormalizes here) severs the socket.
+    vi.mocked(db.select).mockReturnValue(
+      selectAgentDevice([{ id: 'device-s', status: 'online', agentTokenSuspendedAt: new Date() }]) as any
+    );
+
+    await handlers.onMessage({
+      data: JSON.stringify({ type: 'heartbeat', timestamp: 123 }),
+    } as any, ws as any);
+
+    expect(ws.close).toHaveBeenCalledWith(4001, 'Device no longer authorized');
+  });
+});
+
+// Finding #8 — WS command results emit the same append-only audit as REST.
+// Finding #5 — WS result stdout/stderr are redacted before persistence.
+describe('Findings #8 / #5 — WS command-result audit + secret redaction', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('emits agent.command.result.submit exactly once after a real terminal transition', async () => {
+    const preValidatedAgent = { deviceId: 'device-a', orgId: 'org-a' };
+    vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([
+      { id: 'cmd-1', type: 'run_script', payload: {}, deviceId: 'device-a' },
+    ]) as any);
+    vi.mocked(db.update).mockReturnValue(updateResult([{ id: 'cmd-1' }]) as any);
+
+    const handlers = createAgentWsHandlers('agent-a', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: '88888888-8888-4888-8888-888888888888',
+        status: 'completed',
+        exitCode: 0,
+        stdout: 'done',
+      }),
+    } as any, ws as any);
+
+    expect(writeAuditEvent).toHaveBeenCalledTimes(1);
+    const auditEvent = vi.mocked(writeAuditEvent).mock.calls[0]![1];
+    expect(auditEvent).toMatchObject({
+      action: 'agent.command.result.submit',
+      actorType: 'agent',
+      actorId: 'agent-a',
+      orgId: 'org-a',
+      resourceType: 'device_command',
+      resourceId: '88888888-8888-4888-8888-888888888888',
+      result: 'success',
+      details: { commandType: 'run_script', status: 'completed', exitCode: 0 },
+    });
+  });
+
+  it('does NOT audit when the compare-and-set no-ops (duplicate/late result)', async () => {
+    const preValidatedAgent = { deviceId: 'device-a', orgId: 'org-a' };
+    vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([
+      { id: 'cmd-1', type: 'run_script', payload: {}, deviceId: 'device-a' },
+    ]) as any);
+    // returning [] — the row was already terminal, so no transition occurred.
+    vi.mocked(db.update).mockReturnValue(updateResult([]) as any);
+
+    const handlers = createAgentWsHandlers('agent-a', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: '88888888-8888-4888-8888-888888888888',
+        status: 'completed',
+        exitCode: 0,
+        stdout: 'done',
+      }),
+    } as any, ws as any);
+
+    expect(writeAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it('redacts a PEM private key from stdout before it is persisted', async () => {
+    const preValidatedAgent = { deviceId: 'device-r', orgId: 'org-r' };
+    vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([
+      { id: 'cmd-1', type: 'run_script', payload: {}, deviceId: 'device-r' },
+    ]) as any);
+
+    // Capture the persisted result payload from the terminal UPDATE .set(...).
+    const setSpy = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'cmd-1' }]) }),
+    });
+    vi.mocked(db.update).mockReturnValue({ set: setSpy } as any);
+
+    const pem =
+      '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKe0m0h\n-----END RSA PRIVATE KEY-----';
+
+    const handlers = createAgentWsHandlers('agent-r', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: '99999999-9999-4999-8999-999999999999',
+        status: 'completed',
+        exitCode: 0,
+        stdout: `key follows:\n${pem}\nend`,
+      }),
+    } as any, ws as any);
+
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    const stored = setSpy.mock.calls[0]![0] as { result: { stdout: string } };
+    expect(stored.result.stdout).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(stored.result.stdout).not.toContain('BEGIN RSA PRIVATE KEY');
   });
 });

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -30,7 +30,7 @@ import { matchRoleScopedAgentTokenHash, suspendAgentToken, type AgentCredentialR
 import { AGENT_TOKEN_SUSPEND_REASON } from '../services/agentTokenSuspension';
 import { isAgentTenantActive } from '../services/tenantStatus';
 import { createAuditLogAsync } from '../services/auditService';
-import { ANONYMOUS_ACTOR_ID, writeAuditEvent } from '../services/auditEvents';
+import { ANONYMOUS_ACTOR_ID, writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
 import { redactSecretsFromOutput } from '../services/secretRedaction';
 import { detectResultValidationFamily, validateCriticalCommandResult, DR_COMMAND_TYPES } from '../services/agentCommandResultValidation';
 import { updateRestoreJobByCommandId, updateRestoreJobFromResult } from '../services/restoreResultPersistence';
@@ -764,12 +764,12 @@ type AgentTokenValidation =
   | { ok: true; ctx: AgentDbContext }
   | { ok: false; reason: 'unauthorized' | 're_enrollment_required' };
 
-// Finding #8: WS command-result ingest has no Hono request context, but
-// writeAuditEvent only reads `x-forwarded-for` / `user-agent` off it for
-// ip/userAgent enrichment. A minimal header-less RequestLike lets the WS path
-// emit the same append-only audit as the REST path (client IP is simply absent
-// on the persistent socket, which is expected).
-const WS_AUDIT_REQUEST = { req: { header: () => undefined } };
+// Finding #8: WS command-result ingest has no Hono request context. The
+// header-less shim returns undefined for all client-IP/user-agent headers, so
+// client IP is simply absent on the WS audit path (expected on a persistent
+// socket). This lets the WS path emit the same append-only audit as the REST
+// path via the canonical snapshot-backed RequestLike helper.
+const WS_AUDIT_REQUEST = requestLikeFromSnapshot({});
 
 /**
  * Finding #3 (defense-in-depth): re-verify a live agent's device lifecycle

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -30,7 +30,8 @@ import { matchRoleScopedAgentTokenHash, suspendAgentToken, type AgentCredentialR
 import { AGENT_TOKEN_SUSPEND_REASON } from '../services/agentTokenSuspension';
 import { isAgentTenantActive } from '../services/tenantStatus';
 import { createAuditLogAsync } from '../services/auditService';
-import { ANONYMOUS_ACTOR_ID } from '../services/auditEvents';
+import { ANONYMOUS_ACTOR_ID, writeAuditEvent } from '../services/auditEvents';
+import { redactSecretsFromOutput } from '../services/secretRedaction';
 import { detectResultValidationFamily, validateCriticalCommandResult, DR_COMMAND_TYPES } from '../services/agentCommandResultValidation';
 import { updateRestoreJobByCommandId, updateRestoreJobFromResult } from '../services/restoreResultPersistence';
 import { captureException } from '../services/sentry';
@@ -493,6 +494,11 @@ const activeConnections = new Map<string, WSContext>();
 interface AgentPingState {
   pingInterval: ReturnType<typeof setInterval>;
   lastPongAt: number;
+  // Finding #4: the socket this ping state belongs to. onClose/onError use it to
+  // delete ONLY their own ping state — a superseded orphan closing must never
+  // clobber the live (newer) socket's ping state, mirroring the
+  // `activeConnections.get(agentId) === ws` guard on the connection map.
+  ws: WSContext;
 }
 const agentPingStates = new Map<string, AgentPingState>();
 const AGENT_PING_INTERVAL_MS = 30_000;
@@ -600,11 +606,18 @@ function commandResultToStdout(result: AgentCommandResult): string | undefined {
 }
 
 function buildStoredCommandResult(result: AgentCommandResult, stdout: string | undefined) {
+  // Finding #5 (WS leg): strip full PEM private-key blocks from agent output
+  // BEFORE it is persisted into device_commands.result and later shown to
+  // scripts:read users. Mirrors the REST ingest path
+  // (routes/agents/commands.ts). Pre-update agents don't redact
+  // server-side-visible output, so we redact here as defense-in-depth.
+  // Preserve null/undefined (don't coerce to '') to keep the stored shape
+  // stable; exitCode/status/durationMs are untouched.
   return {
     status: result.status,
     exitCode: result.exitCode,
-    stdout,
-    stderr: result.stderr,
+    stdout: stdout != null ? redactSecretsFromOutput(stdout) : stdout,
+    stderr: result.stderr != null ? redactSecretsFromOutput(result.stderr) : result.stderr,
     durationMs: result.durationMs,
     error: result.error,
   };
@@ -750,6 +763,48 @@ type AgentDbContext = {
 type AgentTokenValidation =
   | { ok: true; ctx: AgentDbContext }
   | { ok: false; reason: 'unauthorized' | 're_enrollment_required' };
+
+// Finding #8: WS command-result ingest has no Hono request context, but
+// writeAuditEvent only reads `x-forwarded-for` / `user-agent` off it for
+// ip/userAgent enrichment. A minimal header-less RequestLike lets the WS path
+// emit the same append-only audit as the REST path (client IP is simply absent
+// on the persistent socket, which is expected).
+const WS_AUDIT_REQUEST = { req: { header: () => undefined } };
+
+/**
+ * Finding #3 (defense-in-depth): re-verify a live agent's device lifecycle
+ * state with ONE lightweight indexed SELECT, so a socket that outlived a
+ * containment change (decommission, quarantine, or org/partner/token
+ * suspension) stops acting on the next sensitive operation.
+ *
+ * Fail-OPEN on a transient DB error or a missing row: the pre-upgrade auth gate
+ * already proved the device existed, and the authoritative containment paths
+ * (credential suspension + disconnectAgent) still fail closed on the next
+ * (re)connect. Failing closed here would let a DB blip mass-drop the fleet. We
+ * only sever on a POSITIVE containment signal (terminal status / suspend
+ * timestamp). System DB context because `devices` is RLS-guarded and this can
+ * run outside a tenant context.
+ */
+async function isAgentDeviceStillAuthorized(agentId: string): Promise<boolean> {
+  try {
+    const [row] = await runOutsideDbContext(() =>
+      withSystemDbAccessContext(() =>
+        db
+          .select({ status: devices.status, agentTokenSuspendedAt: devices.agentTokenSuspendedAt })
+          .from(devices)
+          .where(eq(devices.agentId, agentId))
+          .limit(1)
+      )
+    );
+    if (!row) return true; // fail-open: existence already validated pre-upgrade
+    if (row.status === 'decommissioned' || row.status === 'quarantined') return false;
+    if (row.agentTokenSuspendedAt) return false;
+    return true;
+  } catch (err) {
+    console.error(`[AgentWs] lifecycle recheck query failed for ${agentId}; failing open:`, err);
+    return true;
+  }
+}
 
 /**
  * Validate agent token by hashing it and comparing against the stored hash.
@@ -1356,7 +1411,8 @@ export async function processOrphanedCommandResult(
 async function processCommandResult(
   agentId: string,
   result: z.infer<typeof commandResultSchema>,
-  deviceId?: string
+  deviceId?: string,
+  orgId?: string
 ): Promise<void> {
   try {
     // Resolve any in-process promise awaiting this command id (e.g. http_request
@@ -1439,6 +1495,22 @@ async function processCommandResult(
       return;
     }
 
+    // Finding #3 (defense-in-depth): before terminally updating a device-bound
+    // command row + firing downstream handlers, re-verify the device wasn't
+    // decommissioned/quarantined or its token suspended (org/partner tenant
+    // suspension denormalizes onto devices.agentTokenSuspendedAt) after this
+    // long-lived socket was established. Cost: one extra indexed row read per
+    // device-bound (UUID) command result — acceptable, and NOT run on the
+    // high-frequency pong/heartbeat/terminal-output frames. If contained, sever
+    // the authoritative socket and abort without persisting the result.
+    if (!(await isAgentDeviceStillAuthorized(agentId))) {
+      console.warn(
+        `[AgentWs] Aborting command result ${result.commandId} for ${agentId}: device contained (decommissioned/quarantined/suspended). Severing socket.`
+      );
+      disconnectAgent(agentId, 4001, 'Device no longer authorized');
+      return;
+    }
+
     const {
       normalizedResult,
       stdout,
@@ -1469,6 +1541,28 @@ async function processCommandResult(
       console.warn(`[AgentWs] Ignoring stale or already-processed command result ${result.commandId} for agent ${agentId}`);
       return;
     }
+
+    // Finding #8: emit the append-only audit event for a WS-ingested command
+    // result, matching the REST path (routes/agents/commands.ts). Placed
+    // immediately after the compare-and-set above so it fires EXACTLY ONCE and
+    // ONLY when the row actually transitioned to a terminal state — a
+    // duplicate/late result no-ops the UPDATE and returns above, never audited.
+    // Emitted before the validationError early-return because a
+    // validation-rejected result still transitioned the row to 'failed'.
+    writeAuditEvent(WS_AUDIT_REQUEST, {
+      orgId: orgId ?? null,
+      actorType: 'agent',
+      actorId: agentId,
+      action: 'agent.command.result.submit',
+      resourceType: 'device_command',
+      resourceId: result.commandId,
+      details: {
+        commandType: command.type,
+        status: normalizedResult.status,
+        exitCode: normalizedResult.exitCode ?? null,
+      },
+      result: normalizedResult.status === 'completed' ? 'success' : 'failure',
+    });
 
     if (validationError) {
       console.warn(`[AgentWs] ${validationError} — command ${result.commandId} rejected for agent ${agentId}`);
@@ -1523,12 +1617,30 @@ async function processCommandResult(
 async function getPendingCommands(agentId: string): Promise<AgentCommand[]> {
   try {
     const [device] = await db
-      .select({ id: devices.id })
+      .select({ id: devices.id, status: devices.status, agentTokenSuspendedAt: devices.agentTokenSuspendedAt })
       .from(devices)
       .where(eq(devices.agentId, agentId))
       .limit(1);
 
     if (!device) {
+      return [];
+    }
+
+    // Finding #3 (defense-in-depth): the claim path is a sensitive operation on
+    // a long-lived socket. Re-verify containment on the SAME row we already
+    // fetched (zero extra queries) before claiming/decrypting pending commands.
+    // If the device was decommissioned/quarantined or its token suspended
+    // (org/partner tenant suspension denormalizes onto agentTokenSuspendedAt)
+    // after this socket was established, sever it and claim nothing.
+    if (
+      device.status === 'decommissioned' ||
+      device.status === 'quarantined' ||
+      device.agentTokenSuspendedAt
+    ) {
+      console.warn(
+        `[AgentWs] Refusing command claim for ${agentId}: device contained (decommissioned/quarantined/suspended). Severing socket.`
+      );
+      disconnectAgent(agentId, 4001, 'Device no longer authorized');
       return [];
     }
 
@@ -1583,6 +1695,22 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
 
   return {
     onOpen: async (_event: unknown, ws: WSContext) => {
+      // Finding #4: enforce the one-socket-per-agent invariant. A second socket
+      // for the same agentId would otherwise overwrite the map entry WITHOUT
+      // closing the previous socket, leaving an orphaned-but-authorized socket
+      // whose onMessage handler + captured authorization keep working while
+      // revocation/disconnect (which only act on the mapped socket) miss it.
+      // Close the previous socket before replacing it so `activeConnections`
+      // stays authoritative and disconnectAgent can never miss a live socket.
+      const previousWs = activeConnections.get(agentId);
+      if (previousWs && previousWs !== ws) {
+        try {
+          previousWs.close(4002, 'Superseded by newer connection');
+        } catch {
+          // Best-effort: the orphan may already be torn down.
+        }
+      }
+
       // Clean up any existing ping state from a previous connection
       const existingPingState = agentPingStates.get(agentId);
       if (existingPingState) {
@@ -1659,7 +1787,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
           agentPingStates.delete(agentId);
         }
       }, AGENT_PING_INTERVAL_MS);
-      agentPingStates.set(agentId, { pingInterval, lastPongAt: now });
+      agentPingStates.set(agentId, { pingInterval, lastPongAt: now, ws });
     },
 
     onMessage: async (event: MessageEvent, ws: WSContext) => {
@@ -2055,7 +2183,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
         switch (parsed.data.type) {
           case 'command_result':
             await runWithAgentDbAccess(async () =>
-              processCommandResult(agentId, parsed.data as z.infer<typeof commandResultSchema>, authenticatedAgent.deviceId)
+              processCommandResult(agentId, parsed.data as z.infer<typeof commandResultSchema>, authenticatedAgent.deviceId, authenticatedAgent.orgId)
             );
             ws.send(JSON.stringify({
               type: 'ack',
@@ -2142,9 +2270,12 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
     },
 
 onClose: async (_event: unknown, ws: WSContext) => {
-      // Clean up ping interval
+      // Clean up ping interval — but ONLY this ws's own ping state (Finding #4).
+      // A superseded orphan closing must not clear the live (newer) socket's
+      // ping state, so gate the delete on connection identity, mirroring the
+      // `activeConnections.get(agentId) === ws` guard below.
       const pingState = agentPingStates.get(agentId);
-      if (pingState) {
+      if (pingState && pingState.ws === ws) {
         clearInterval(pingState.pingInterval);
         agentPingStates.delete(agentId);
       }
@@ -2206,9 +2337,10 @@ onClose: async (_event: unknown, ws: WSContext) => {
 
     onError: (event: unknown, ws: WSContext) => {
       console.error(`WebSocket error for agent ${agentId}:`, event);
-      // Clean up ping interval
+      // Clean up ping interval — ONLY this ws's own ping state (Finding #4), so a
+      // superseded orphan erroring out can't clobber the live socket's state.
       const pingState = agentPingStates.get(agentId);
-      if (pingState) {
+      if (pingState && pingState.ws === ws) {
         clearInterval(pingState.pingInterval);
         agentPingStates.delete(agentId);
       }
@@ -2582,6 +2714,11 @@ export type AgentWsDisconnectResult = 'closed' | 'close-failed' | 'not-connected
  * Callers that record the outcome (audit trails) must not collapse
  * 'close-failed' into success: a throwing close() plausibly leaves the
  * channel live, which is exactly what e.g. a decommission needs to know.
+ *
+ * Finding #4: `activeConnections` holds at most ONE socket per agent (onOpen
+ * closes any prior socket before replacing it), so closing
+ * `activeConnections.get(agentId)` is authoritative — revocation can never miss
+ * a live-but-orphaned socket.
  */
 export function disconnectAgent(agentId: string, code: number = 4040, reason: string = 'orgId changed, reconnect required'): AgentWsDisconnectResult {
   const ws = activeConnections.get(agentId);

--- a/apps/api/src/routes/agents.test.ts
+++ b/apps/api/src/routes/agents.test.ts
@@ -22,6 +22,7 @@ vi.mock('../services/rate-limit', () => ({
   })),
 }));
 vi.mock('../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeAuditEvent: vi.fn()
 }));
 // Enrollment now gates on tenant status; default to an active tenant so these

--- a/apps/api/src/routes/agents/commands.test.ts
+++ b/apps/api/src/routes/agents/commands.test.ts
@@ -37,6 +37,11 @@ vi.mock('../../db/schema', () => ({
     id: 'devices.id',
     agentId: 'devices.agent_id',
   },
+  deploymentResults: {
+    deploymentId: 'deployment_results.deployment_id',
+    deviceId: 'deployment_results.device_id',
+    status: 'deployment_results.status',
+  },
 }));
 
 vi.mock('../../services/restoreResultPersistence', () => ({
@@ -174,6 +179,110 @@ describe('agent commands routes', () => {
         },
       ],
     });
+  });
+
+  // A complete, well-formed PEM private-key block (header + base64 body +
+  // footer). The base64 body must survive verbatim if redaction fails, so we
+  // assert the body marker is gone after ingest.
+  const PRIVATE_KEY_BLOCK = [
+    '-----BEGIN PRIVATE KEY-----',
+    'MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDexampleAAAA1234',
+    'BODYb64lineTwoZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ567890',
+    '-----END PRIVATE KEY-----',
+  ].join('\n');
+
+  it('redacts private-key blocks from stdout, stderr, AND error before persisting the command result', async () => {
+    selectMock.mockReturnValueOnce(
+      chainMock([
+        {
+          id: commandId,
+          deviceId: 'device-1',
+          type: 'run_script',
+          status: 'sent',
+          targetRole: 'agent',
+        },
+      ])
+    );
+    const updateChain = chainMock([{ id: 'cmd-1' }]);
+    updateMock.mockReturnValueOnce(updateChain);
+
+    const res = await app.request(`/agents/${agentId}/commands/${commandId}/result`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        commandId,
+        status: 'completed',
+        exitCode: 0,
+        stdout: `stdout-pre ${PRIVATE_KEY_BLOCK} stdout-post`,
+        stderr: `stderr-pre ${PRIVATE_KEY_BLOCK} stderr-post`,
+        error: `error-pre ${PRIVATE_KEY_BLOCK} error-post`,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+
+    // Assert on exactly what is handed to db.update(...).set(...).
+    const stored = updateChain.set.mock.calls[0][0];
+    expect(stored.result.stdout).toBe('stdout-pre [PRIVATE_KEY_REDACTED] stdout-post');
+    expect(stored.result.stderr).toBe('stderr-pre [PRIVATE_KEY_REDACTED] stderr-post');
+    expect(stored.result.error).toBe('error-pre [PRIVATE_KEY_REDACTED] error-post');
+
+    // No fragment of the key (header, footer, or base64 body) survives anywhere
+    // in the persisted result object.
+    const serialized = JSON.stringify(stored.result);
+    expect(serialized).not.toContain('BEGIN PRIVATE KEY');
+    expect(serialized).not.toContain('END PRIVATE KEY');
+    expect(serialized).not.toContain('MIIEvQ');
+    expect(serialized).not.toContain('BODYb64lineTwo');
+  });
+
+  it('redacts private-key blocks from the software-install deployment result path', async () => {
+    // sw-install commandId embeds deployment + device UUIDs; the device UUID
+    // must equal the authenticated agent's deviceId for the update to fire.
+    const deploymentUuid = '11111111-1111-4111-8111-111111111111';
+    const deviceUuid = '33333333-3333-4333-8333-333333333333';
+    const swCommandId = `sw-install-${deploymentUuid}-${deviceUuid}`;
+
+    const swApp = new Hono();
+    swApp.use('*', async (c, next) => {
+      c.set('agent', {
+        deviceId: deviceUuid,
+        agentId: 'agent-1',
+        orgId: 'org-1',
+        siteId: 'site-1',
+        role: 'agent',
+      });
+      await next();
+    });
+    swApp.route('/agents', commandsRoutes);
+
+    const updateChain = chainMock([]);
+    updateMock.mockReturnValueOnce(updateChain);
+
+    const res = await swApp.request(`/agents/${agentId}/commands/${swCommandId}/result`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        commandId: swCommandId,
+        status: 'completed',
+        exitCode: 0,
+        stdout: `install-log ${PRIVATE_KEY_BLOCK} done`,
+        error: `install-error ${PRIVATE_KEY_BLOCK} boom`,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+
+    // deployment_results is never queried via selectMock on this path.
+    expect(selectMock).not.toHaveBeenCalled();
+    const stored = updateChain.set.mock.calls[0][0];
+    expect(stored.output).toBe('install-log [PRIVATE_KEY_REDACTED] done');
+    expect(stored.errorMessage).toBe('install-error [PRIVATE_KEY_REDACTED] boom');
+
+    const serialized = JSON.stringify(stored);
+    expect(serialized).not.toContain('BEGIN PRIVATE KEY');
+    expect(serialized).not.toContain('MIIEvQ');
+    expect(serialized).not.toContain('BODYb64lineTwo');
   });
 
   it('rejects normal agent results for watchdog-targeted commands', async () => {

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -50,7 +50,7 @@ function buildStoredCommandResult(data: z.infer<typeof commandResultSchema>, std
     stdout: stdout != null ? redactSecretsFromOutput(stdout) : stdout,
     stderr: data.stderr != null ? redactSecretsFromOutput(data.stderr) : data.stderr,
     durationMs: data.durationMs,
-    error: data.error,
+    error: data.error != null ? redactSecretsFromOutput(data.error) : data.error,
   };
 }
 

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -29,6 +29,7 @@ import { applyVaultSyncCommandResult } from '../../services/vaultSyncPersistence
 import { processBackupVerificationResult } from '../backup/verificationService';
 import { updateRestoreJobByCommandId } from '../../services/restoreResultPersistence';
 import { detectResultValidationFamily, validateCriticalCommandResult, DR_COMMAND_TYPES } from '../../services/agentCommandResultValidation';
+import { redactSecretsFromOutput } from '../../services/secretRedaction';
 
 export const commandsRoutes = new Hono();
 const ACCEPTED_COMMAND_RESULT_STATUSES = ['pending', 'sent'] as const;
@@ -39,11 +40,15 @@ function commandResultToStdout(data: z.infer<typeof commandResultSchema>): strin
 }
 
 function buildStoredCommandResult(data: z.infer<typeof commandResultSchema>, stdout: string | undefined) {
+  // Defense-in-depth: strip full PEM private-key blocks from agent output
+  // before it is persisted and later shown to scripts:read users. Pre-update
+  // agents don't redact server-side-visible output, so we redact here.
+  // Preserve null/undefined (don't coerce to '') to keep the stored shape stable.
   return {
     status: data.status,
     exitCode: data.exitCode,
-    stdout,
-    stderr: data.stderr,
+    stdout: stdout != null ? redactSecretsFromOutput(stdout) : stdout,
+    stderr: data.stderr != null ? redactSecretsFromOutput(data.stderr) : data.stderr,
     durationMs: data.durationMs,
     error: data.error,
   };
@@ -181,8 +186,15 @@ commandsRoutes.post(
               startedAt,
               completedAt,
               exitCode: data.exitCode ?? null,
-              output: data.stdout ?? null,
-              errorMessage: data.error ?? data.stderr ?? null,
+              // Defense-in-depth: redact PEM private-key blocks from persisted
+              // software-install output/errors (mirrors buildStoredCommandResult).
+              output: data.stdout != null ? redactSecretsFromOutput(data.stdout) : null,
+              errorMessage:
+                data.error != null
+                  ? redactSecretsFromOutput(data.error)
+                  : data.stderr != null
+                    ? redactSecretsFromOutput(data.stderr)
+                    : null,
             })
             .where(and(
               eq(deploymentResults.deploymentId, deploymentIdFromCmd),

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -188,6 +188,19 @@ function selectChainResolving(value: unknown) {
   };
 }
 
+// A `where(...)` result for the db.update chain that is BOTH awaitable (the
+// watchdog-branch update and any caller that ignores the result) AND carries a
+// `.returning()` method (the guarded main-branch update reads back whether a
+// row actually changed — finding #10 state-transition audit). `returningRows`
+// defaults to one row so the guarded write reads as "took effect"; pass `[]` to
+// model a terminal-status device whose guarded update matched 0 rows.
+function whereResultWithReturning(returningRows: unknown[] = [{ id: 'device-1' }]) {
+  const result: Promise<undefined> & { returning?: ReturnType<typeof vi.fn> } =
+    Promise.resolve(undefined);
+  result.returning = vi.fn().mockResolvedValue(returningRows);
+  return result;
+}
+
 function buildApp(): Hono {
   const app = new Hono();
   app.use('*', async (c, next) => {
@@ -269,7 +282,7 @@ describe('POST /agents/:id/heartbeat — manifestTrustKeys delivery (#639)', () 
     // db.update for devices → no return needed
     updateMock.mockReturnValue({
       set: vi.fn(() => ({
-        where: vi.fn().mockResolvedValue(undefined),
+        where: vi.fn(() => whereResultWithReturning()),
       })),
     });
 
@@ -423,7 +436,7 @@ describe('POST /agents/:id/heartbeat — main-agent-silent asymmetry detector (#
       ]),
     );
 
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     updateMock.mockReturnValue({ set: setSpy });
 
     selectMock.mockReturnValue(selectChainResolving([])); // agentVersions etc
@@ -469,7 +482,7 @@ describe('POST /agents/:id/heartbeat — main-agent-silent asymmetry detector (#
         },
       ]),
     );
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     updateMock.mockReturnValue({ set: setSpy });
     selectMock.mockReturnValue(selectChainResolving([]));
 
@@ -499,7 +512,7 @@ describe('POST /agents/:id/heartbeat — main-agent-silent asymmetry detector (#
         },
       ]),
     );
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     updateMock.mockReturnValue({ set: setSpy });
     selectMock.mockReturnValue(selectChainResolving([]));
 
@@ -533,7 +546,7 @@ describe('POST /agents/:id/heartbeat — main-agent-silent asymmetry detector (#
         },
       ]),
     );
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     updateMock.mockReturnValue({ set: setSpy });
     insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
     selectMock.mockReturnValue(selectChainResolving([]));
@@ -565,7 +578,7 @@ describe('POST /agents/:id/heartbeat — main-agent-silent asymmetry detector (#
         },
       ]),
     );
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     updateMock.mockReturnValue({ set: setSpy });
     insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
     selectMock.mockReturnValue(selectChainResolving([]));
@@ -621,7 +634,7 @@ describe('POST /agents/:id/heartbeat — watchdog restart-stats logging (#799)',
     // db.update for devices (watchdog status update) → no return needed.
     updateMock.mockReturnValue({
       set: vi.fn(() => ({
-        where: vi.fn().mockResolvedValue(undefined),
+        where: vi.fn(() => whereResultWithReturning()),
       })),
     });
 
@@ -732,7 +745,7 @@ describe('POST /agents/:id/heartbeat — watchdog-branch agent recovery upgradeT
     getActiveTrustKeysetMock.mockReset();
     getActiveTrustKeysetMock.mockResolvedValue([]);
     updateMock.mockReturnValue({
-      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+      set: vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) })),
     });
   });
 
@@ -918,7 +931,7 @@ describe('POST /agents/:id/heartbeat — controlled fleet rollout (promotion gat
     getActiveTrustKeysetMock.mockReset();
     getActiveTrustKeysetMock.mockResolvedValue([]);
     updateMock.mockReturnValue({
-      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+      set: vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) })),
     });
     insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
   });
@@ -1037,7 +1050,7 @@ describe('pendingReboot persistence', () => {
   }
 
   it('persists pendingReboot=true from the main-agent heartbeat', async () => {
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     setupMocks(setSpy);
 
     const resp = await buildApp().request('/agents/device-1/heartbeat', {
@@ -1052,7 +1065,7 @@ describe('pendingReboot persistence', () => {
   });
 
   it('clears pendingReboot when the field is absent (old agents / post-reboot)', async () => {
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     setupMocks(setSpy);
 
     // minimalHeartbeatBody has no pendingReboot key — simulates old agents and
@@ -1069,7 +1082,7 @@ describe('pendingReboot persistence', () => {
   });
 
   it('watchdog heartbeats never touch pendingReboot', async () => {
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     // Watchdog device lookup needs lastSeenAt for the silence-detector.
     vi.clearAllMocks();
     getActiveTrustKeysetMock.mockResolvedValue([]);
@@ -1130,7 +1143,7 @@ describe('batteryStatus persistence', () => {
   }
 
   it('persists a battery snapshot, stamping reportedAt and keeping only sent fields', async () => {
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     setupMocks(setSpy);
 
     const resp = await buildApp().request('/agents/device-1/heartbeat', {
@@ -1158,7 +1171,7 @@ describe('batteryStatus persistence', () => {
   });
 
   it('persists a charging snapshot with timeToFullMinutes', async () => {
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     setupMocks(setSpy);
 
     const resp = await buildApp().request('/agents/device-1/heartbeat', {
@@ -1178,7 +1191,7 @@ describe('batteryStatus persistence', () => {
   });
 
   it('records a no-battery desktop as { present: false }', async () => {
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     setupMocks(setSpy);
 
     const resp = await buildApp().request('/agents/device-1/heartbeat', {
@@ -1196,7 +1209,7 @@ describe('batteryStatus persistence', () => {
   });
 
   it('leaves batteryStatus untouched when the agent omits battery (old agent)', async () => {
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     setupMocks(setSpy);
 
     const resp = await buildApp().request('/agents/device-1/heartbeat', {
@@ -1243,7 +1256,7 @@ describe('POST /agents/:id/heartbeat — uacInterceptionEnabled delivery', () =>
     // db.update for devices → no return needed
     updateMock.mockReturnValue({
       set: vi.fn(() => ({
-        where: vi.fn().mockResolvedValue(undefined),
+        where: vi.fn(() => whereResultWithReturning()),
       })),
     });
 
@@ -1389,7 +1402,7 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
     getActiveTrustKeysetMock.mockReset();
     getActiveTrustKeysetMock.mockResolvedValue([]);
     updateMock.mockReturnValue({
-      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+      set: vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) })),
     });
     insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
   });
@@ -1549,7 +1562,7 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
     getActiveTrustKeysetMock.mockReset();
     getActiveTrustKeysetMock.mockResolvedValue([]);
     updateMock.mockReturnValue({
-      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+      set: vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) })),
     });
     insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
   });
@@ -1713,7 +1726,7 @@ describe('POST /agents/:id/heartbeat — watchdogVersion telemetry (#1802)', () 
   }
 
   it('persists the watchdogVersion the main agent reports to the device row', async () => {
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     arrange(setSpy);
 
     const resp = await post({ agentVersion: '0.66.0', watchdogVersion: '0.66.0' });
@@ -1724,7 +1737,7 @@ describe('POST /agents/:id/heartbeat — watchdogVersion telemetry (#1802)', () 
   });
 
   it('leaves the stored watchdogVersion untouched when an old agent omits it', async () => {
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     arrange(setSpy);
 
     const resp = await post({ agentVersion: '0.66.0' });
@@ -1736,7 +1749,7 @@ describe('POST /agents/:id/heartbeat — watchdogVersion telemetry (#1802)', () 
 
   it('uses the reported version (not the stale column) to suppress redundant re-sends', async () => {
     const { compareAgentVersions, getOrgAgentUpdateConfig } = await import('./helpers');
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     arrange(setSpy);
     vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({ settings: { policy: 'auto', maintenanceWindow: null }, pins: { agent: null, watchdog: null } });
     vi.mocked(compareAgentVersions).mockImplementation(realishCompare);
@@ -1752,7 +1765,7 @@ describe('POST /agents/:id/heartbeat — watchdogVersion telemetry (#1802)', () 
 
   it('still upgrades when the reported watchdogVersion is genuinely behind latest', async () => {
     const { compareAgentVersions, getOrgAgentUpdateConfig } = await import('./helpers');
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     arrange(setSpy);
     vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({ settings: { policy: 'auto', maintenanceWindow: null }, pins: { agent: null, watchdog: null } });
     vi.mocked(compareAgentVersions).mockImplementation(realishCompare);
@@ -1786,7 +1799,7 @@ describe('POST /agents/:id/heartbeat — active server URL telemetry (#2288)', (
     updateMock.mockReturnValue({
       set: vi.fn((values: Record<string, unknown>) => {
         capturedDeviceUpdate = values;
-        return { where: vi.fn().mockResolvedValue(undefined) };
+        return { where: vi.fn(() => whereResultWithReturning()) };
       }),
     });
     insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
@@ -1853,7 +1866,7 @@ describe('POST /agents/:id/heartbeat — virtualization attribute (#1387)', () =
         },
       ]),
     );
-    const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    const setSpy = vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) }));
     updateMock.mockReturnValue({ set: setSpy });
     insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
     selectMock.mockReturnValue(selectChainResolving([]));
@@ -1944,7 +1957,7 @@ describe('POST /agents/:id/heartbeat — version-pin threading (#2124)', () => {
     getActiveTrustKeysetMock.mockResolvedValue([]);
     selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
-    updateMock.mockReturnValue({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) });
+    updateMock.mockReturnValue({ set: vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) })) });
     insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
   }
 
@@ -2038,7 +2051,9 @@ describe('POST /agents/:id/heartbeat — terminal-status guard (#2230)', () => {
         },
       ]),
     );
-    const whereSpy = vi.fn().mockResolvedValue(undefined);
+    // Guarded write matches 0 rows (device is terminal-status) → `.returning()`
+    // yields an empty array, which must suppress the state-transition audit.
+    const whereSpy = vi.fn(() => whereResultWithReturning([]));
     const setSpy = vi.fn(() => ({ where: whereSpy }));
     updateMock.mockReturnValue({ set: setSpy });
     insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
@@ -2057,5 +2072,201 @@ describe('POST /agents/:id/heartbeat — terminal-status guard (#2230)', () => {
     expect(whereSpy.mock.calls[0]?.[0]).toEqual(
       and(eq(devices.id, 'device-1'), notInArray(devices.status, ['decommissioned', 'quarantined'])),
     );
+
+    // Finding #10: a guard-rejected (0-row) write must NOT record a phantom
+    // state transition.
+    const { writeAuditEvent } = await import('../../services/auditEvents');
+    expect(vi.mocked(writeAuditEvent)).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'agent.heartbeat.state_change' }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
+// Finding #10 — durable audit of security-relevant heartbeat state changes.
+// The main-agent heartbeat mutates several security-relevant device fields
+// (status, hostname, agentServerUrl, tcc/desktop access, main-agent-silent
+// recovery) but previously left no persisted trail. These tests assert one
+// content-minimal `agent.heartbeat.state_change` audit fires ONLY on a genuine
+// transition, and NOT on a steady-state beat.
+// ---------------------------------------------------------------------
+describe('POST /agents/:id/heartbeat — state-change audit (finding #10)', () => {
+  // Steady-state baseline the handler will diff against. status already online,
+  // hostname/agentServerUrl/tcc/desktop already match what a steady beat sends.
+  const baselineDevice = {
+    id: 'device-1',
+    orgId: 'org-1',
+    siteId: 'site-1',
+    hostname: 'host-1',
+    osType: 'linux',
+    osVersion: 'Ubuntu 22.04',
+    osBuild: null,
+    architecture: 'amd64',
+    agentVersion: '0.65.10',
+    deviceRole: 'server',
+    deviceRoleSource: 'auto',
+    agentTokenHash: 'hash',
+    tokenIssuedAt: new Date(),
+    status: 'online',
+    agentServerUrl: 'https://cp.example.com',
+    tccPermissions: { screenRecording: 'granted' },
+    desktopAccess: { level: 'full' },
+    mainAgentSilentSince: null,
+  };
+
+  function arrange(deviceOverrides: Record<string, unknown> = {}) {
+    vi.clearAllMocks();
+    getActiveTrustKeysetMock.mockResolvedValue([]);
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([{ ...baselineDevice, ...deviceOverrides }]),
+    );
+    updateMock.mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning([{ id: 'device-1' }])) })),
+    });
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+    selectMock.mockReturnValue(selectChainResolving([]));
+  }
+
+  async function beat(body: Record<string, unknown>) {
+    return buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  async function auditCalls() {
+    const { writeAuditEvent } = await import('../../services/auditEvents');
+    return vi
+      .mocked(writeAuditEvent)
+      .mock.calls.filter((c) => (c[1] as { action?: string })?.action === 'agent.heartbeat.state_change');
+  }
+
+  it('offline→online emits exactly one state_change audit carrying before/after status', async () => {
+    arrange({ status: 'offline' });
+
+    const resp = await beat({
+      ...minimalHeartbeatBody,
+      hostname: 'host-1', // unchanged
+      serverUrl: 'https://cp.example.com', // unchanged
+      tccPermissions: { screenRecording: 'granted' }, // unchanged
+      desktopAccess: { level: 'full' }, // unchanged
+    });
+    expect(resp.status).toBe(200);
+
+    const calls = await auditCalls();
+    expect(calls).toHaveLength(1);
+    const details = (calls[0][1] as { details: { changes: any[] } }).details;
+    expect(details.changes).toEqual([{ field: 'status', before: 'offline', after: 'online' }]);
+    // Actor/resource shape mirrors the co-located threshold-scan audit.
+    expect(calls[0][1]).toMatchObject({
+      orgId: 'org-1',
+      actorType: 'agent',
+      actorId: 'agent-1',
+      resourceType: 'device',
+      resourceId: 'device-1',
+    });
+  });
+
+  it('hostname change emits a state_change audit with before/after', async () => {
+    arrange(); // status already online, hostname host-1
+    const resp = await beat({ ...minimalHeartbeatBody, hostname: 'renamed-host' });
+    expect(resp.status).toBe(200);
+
+    const calls = await auditCalls();
+    expect(calls).toHaveLength(1);
+    const changes = (calls[0][1] as { details: { changes: any[] } }).details.changes;
+    expect(changes).toContainEqual({ field: 'hostname', before: 'host-1', after: 'renamed-host' });
+  });
+
+  it('agentServerUrl change emits a state_change audit with before/after', async () => {
+    arrange();
+    const resp = await beat({ ...minimalHeartbeatBody, serverUrl: 'https://new-cp.example.com' });
+    expect(resp.status).toBe(200);
+
+    const changes = (await auditCalls())[0]?.[1] as { details: { changes: any[] } };
+    expect(changes.details.changes).toContainEqual({
+      field: 'agentServerUrl',
+      before: 'https://cp.example.com',
+      after: 'https://new-cp.example.com',
+    });
+  });
+
+  it('tccPermissions change emits a state_change audit', async () => {
+    arrange();
+    const resp = await beat({
+      ...minimalHeartbeatBody,
+      tccPermissions: { screenRecording: 'denied' },
+    });
+    expect(resp.status).toBe(200);
+
+    const changes = ((await auditCalls())[0]?.[1] as { details: { changes: any[] } }).details.changes;
+    expect(changes).toContainEqual({
+      field: 'tccPermissions',
+      before: { screenRecording: 'granted' },
+      after: { screenRecording: 'denied' },
+    });
+  });
+
+  it('desktopAccess change emits a state_change audit', async () => {
+    arrange();
+    const resp = await beat({
+      ...minimalHeartbeatBody,
+      desktopAccess: { level: 'restricted' },
+    });
+    expect(resp.status).toBe(200);
+
+    const changes = ((await auditCalls())[0]?.[1] as { details: { changes: any[] } }).details.changes;
+    expect(changes).toContainEqual({
+      field: 'desktopAccess',
+      before: { level: 'full' },
+      after: { level: 'restricted' },
+    });
+  });
+
+  it('main-agent recovery (mainAgentSilentSince non-null→null) emits a mainAgentSilent transition', async () => {
+    arrange({ mainAgentSilentSince: new Date(Date.now() - 5 * 60 * 1000) });
+    const resp = await beat({
+      ...minimalHeartbeatBody,
+      hostname: 'host-1',
+      serverUrl: 'https://cp.example.com',
+      tccPermissions: { screenRecording: 'granted' },
+      desktopAccess: { level: 'full' },
+    });
+    expect(resp.status).toBe(200);
+
+    const changes = ((await auditCalls())[0]?.[1] as { details: { changes: any[] } }).details.changes;
+    expect(changes).toContainEqual({ field: 'mainAgentSilent', before: true, after: false });
+  });
+
+  it('steady-state heartbeat (nothing security-relevant changed) emits NO audit', async () => {
+    arrange(); // baseline already online with matching fields
+    const resp = await beat({
+      ...minimalHeartbeatBody,
+      // Re-report identical values — must not be treated as changes.
+      hostname: 'host-1',
+      serverUrl: 'https://cp.example.com',
+      tccPermissions: { screenRecording: 'granted' },
+      desktopAccess: { level: 'full' },
+    });
+    expect(resp.status).toBe(200);
+
+    expect(await auditCalls()).toHaveLength(0);
+  });
+
+  it('batches multiple simultaneous changes into a single audit event', async () => {
+    arrange({ status: 'offline' });
+    const resp = await beat({
+      ...minimalHeartbeatBody,
+      hostname: 'renamed-host',
+      serverUrl: 'https://new-cp.example.com',
+    });
+    expect(resp.status).toBe(200);
+
+    const calls = await auditCalls();
+    expect(calls).toHaveLength(1); // ONE event, not three
+    const fields = (calls[0][1] as { details: { changes: any[] } }).details.changes.map((c) => c.field);
+    expect(fields).toEqual(expect.arrayContaining(['status', 'hostname', 'agentServerUrl']));
   });
 });

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -2069,7 +2069,7 @@ describe('POST /agents/:id/heartbeat — terminal-status guard (#2230)', () => {
     // The first devices update is the deviceUpdates write.
     const firstSet = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
     expect(firstSet.status).toBe('online');
-    expect(whereSpy.mock.calls[0]?.[0]).toEqual(
+    expect((whereSpy.mock.calls as any[])[0]?.[0]).toEqual(
       and(eq(devices.id, 'device-1'), notInArray(devices.status, ['decommissioned', 'quarantined'])),
     );
 
@@ -2157,13 +2157,13 @@ describe('POST /agents/:id/heartbeat — state-change audit (finding #10)', () =
 
     const calls = await auditCalls();
     expect(calls).toHaveLength(1);
-    const details = (calls[0][1] as { details: { changes: any[] } }).details;
+    const details = (calls[0]![1] as unknown as { details: { changes: any[] } }).details;
     expect(details.changes).toEqual([{ field: 'status', before: 'offline', after: 'online' }]);
     // Actor/resource shape mirrors the co-located threshold-scan audit.
-    expect(calls[0][1]).toMatchObject({
+    expect(calls[0]![1]).toMatchObject({
       orgId: 'org-1',
       actorType: 'agent',
-      actorId: 'agent-1',
+      actorId: 'device-1', // = the :id path param (agentId), mirroring the threshold-scan audit
       resourceType: 'device',
       resourceId: 'device-1',
     });
@@ -2176,7 +2176,7 @@ describe('POST /agents/:id/heartbeat — state-change audit (finding #10)', () =
 
     const calls = await auditCalls();
     expect(calls).toHaveLength(1);
-    const changes = (calls[0][1] as { details: { changes: any[] } }).details.changes;
+    const changes = (calls[0]![1] as unknown as { details: { changes: any[] } }).details.changes;
     expect(changes).toContainEqual({ field: 'hostname', before: 'host-1', after: 'renamed-host' });
   });
 
@@ -2185,7 +2185,7 @@ describe('POST /agents/:id/heartbeat — state-change audit (finding #10)', () =
     const resp = await beat({ ...minimalHeartbeatBody, serverUrl: 'https://new-cp.example.com' });
     expect(resp.status).toBe(200);
 
-    const changes = (await auditCalls())[0]?.[1] as { details: { changes: any[] } };
+    const changes = (await auditCalls())[0]?.[1] as unknown as { details: { changes: any[] } };
     expect(changes.details.changes).toContainEqual({
       field: 'agentServerUrl',
       before: 'https://cp.example.com',
@@ -2201,7 +2201,7 @@ describe('POST /agents/:id/heartbeat — state-change audit (finding #10)', () =
     });
     expect(resp.status).toBe(200);
 
-    const changes = ((await auditCalls())[0]?.[1] as { details: { changes: any[] } }).details.changes;
+    const changes = ((await auditCalls())[0]?.[1] as unknown as { details: { changes: any[] } }).details.changes;
     expect(changes).toContainEqual({
       field: 'tccPermissions',
       before: { screenRecording: 'granted' },
@@ -2217,7 +2217,7 @@ describe('POST /agents/:id/heartbeat — state-change audit (finding #10)', () =
     });
     expect(resp.status).toBe(200);
 
-    const changes = ((await auditCalls())[0]?.[1] as { details: { changes: any[] } }).details.changes;
+    const changes = ((await auditCalls())[0]?.[1] as unknown as { details: { changes: any[] } }).details.changes;
     expect(changes).toContainEqual({
       field: 'desktopAccess',
       before: { level: 'full' },
@@ -2236,7 +2236,7 @@ describe('POST /agents/:id/heartbeat — state-change audit (finding #10)', () =
     });
     expect(resp.status).toBe(200);
 
-    const changes = ((await auditCalls())[0]?.[1] as { details: { changes: any[] } }).details.changes;
+    const changes = ((await auditCalls())[0]?.[1] as unknown as { details: { changes: any[] } }).details.changes;
     expect(changes).toContainEqual({ field: 'mainAgentSilent', before: true, after: false });
   });
 
@@ -2266,7 +2266,7 @@ describe('POST /agents/:id/heartbeat — state-change audit (finding #10)', () =
 
     const calls = await auditCalls();
     expect(calls).toHaveLength(1); // ONE event, not three
-    const fields = (calls[0][1] as { details: { changes: any[] } }).details.changes.map((c) => c.field);
+    const fields = (calls[0]![1] as unknown as { details: { changes: any[] } }).details.changes.map((c) => c.field);
     expect(fields).toEqual(expect.arrayContaining(['status', 'hostname', 'agentServerUrl']));
   });
 });

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -547,6 +547,14 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     // mainAgentSilentSince null↔non-null transition. The main-agent branch only
     // ever CLEARS it (recovery); the watchdog branch owns the SET side. Audit
     // only the actual flip, reported as a boolean `mainAgentSilent`.
+    //
+    // NB: in practice this only ever records the CLEAR (silent→recovered) side.
+    // The SET side (main agent going silent) happens in the watchdog branch,
+    // which RETURNS EARLY above — before this audit block — so it never reaches
+    // here. That transition is intentionally NOT in audit_logs: it is durably
+    // covered by `publishEvent('device.main_agent_silent')` + an agent_logs row
+    // written in the watchdog branch. So the absence of a SET-side state_change
+    // audit is deliberate, not a coverage gap.
     if ('mainAgentSilentSince' in deviceUpdates) {
       const wasSet = (device.mainAgentSilentSince ?? null) !== null;
       const nowSet = (deviceUpdates.mainAgentSilentSince ?? null) !== null;

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -490,13 +490,83 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
   // a decommission landing mid-request (between the auth fetch and this
   // write) would be silently flipped back to 'online' (#2230). Mirrors
   // TERMINAL_DEVICE_STATUSES in routes/agentWs.ts.
-  await db
+  //
+  // `.returning` reports whether the guarded write actually took effect: a
+  // terminal-status device matches 0 rows, so `updatedRows` is empty and the
+  // state-transition audit below is skipped (finding #10 — never audit a write
+  // that the guard rejected).
+  const updatedRows = await db
     .update(devices)
     .set(deviceUpdates)
     .where(and(
       eq(devices.id, device.id),
       notInArray(devices.status, ['decommissioned', 'quarantined'])
-    ));
+    ))
+    .returning({ id: devices.id });
+
+  // Durable audit of security-relevant device state transitions (finding #10).
+  // The heartbeat mutates several security-relevant fields but previously left
+  // no persisted trail — only transient Redis pub/sub. This is a high-volume
+  // endpoint, so we emit at most ONE `agent.heartbeat.state_change` event per
+  // beat, carrying only fields that GENUINELY changed. Routine/noisy fields
+  // (lastSeenAt, metrics, uptime, agentVersion, pendingReboot, lastUser) are
+  // deliberately excluded so a steady-state heartbeat produces NO audit. Gated
+  // on `updatedRows.length` so a guard-rejected (terminal-status) write never
+  // records a phantom transition.
+  if (updatedRows.length > 0) {
+    const changes: Array<{ field: string; before: unknown; after: unknown }> = [];
+
+    // offline→online (status is always written as 'online' here; audit only the
+    // transition FROM a non-online value).
+    if (device.status !== 'online') {
+      changes.push({ field: 'status', before: device.status ?? null, after: 'online' });
+    }
+    // hostname — deviceUpdates.hostname is set only when it differs (see above),
+    // so its presence already means a genuine change.
+    if (deviceUpdates.hostname !== undefined) {
+      changes.push({ field: 'hostname', before: device.hostname ?? null, after: deviceUpdates.hostname });
+    }
+    // agentServerUrl / tccPermissions / desktopAccess are written unconditionally
+    // when reported, so compare against the pre-update snapshot to avoid auditing
+    // an unchanged re-report.
+    if (deviceUpdates.agentServerUrl !== undefined && deviceUpdates.agentServerUrl !== device.agentServerUrl) {
+      changes.push({ field: 'agentServerUrl', before: device.agentServerUrl ?? null, after: deviceUpdates.agentServerUrl });
+    }
+    if (
+      deviceUpdates.tccPermissions !== undefined &&
+      JSON.stringify(deviceUpdates.tccPermissions) !== JSON.stringify(device.tccPermissions ?? null)
+    ) {
+      changes.push({ field: 'tccPermissions', before: device.tccPermissions ?? null, after: deviceUpdates.tccPermissions });
+    }
+    if (
+      deviceUpdates.desktopAccess !== undefined &&
+      JSON.stringify(deviceUpdates.desktopAccess) !== JSON.stringify(device.desktopAccess ?? null)
+    ) {
+      changes.push({ field: 'desktopAccess', before: device.desktopAccess ?? null, after: deviceUpdates.desktopAccess });
+    }
+    // mainAgentSilentSince null↔non-null transition. The main-agent branch only
+    // ever CLEARS it (recovery); the watchdog branch owns the SET side. Audit
+    // only the actual flip, reported as a boolean `mainAgentSilent`.
+    if ('mainAgentSilentSince' in deviceUpdates) {
+      const wasSet = (device.mainAgentSilentSince ?? null) !== null;
+      const nowSet = (deviceUpdates.mainAgentSilentSince ?? null) !== null;
+      if (wasSet !== nowSet) {
+        changes.push({ field: 'mainAgentSilent', before: wasSet, after: nowSet });
+      }
+    }
+
+    if (changes.length > 0) {
+      writeAuditEvent(c, {
+        orgId: device.orgId,
+        actorType: 'agent',
+        actorId: agentId,
+        action: 'agent.heartbeat.state_change',
+        resourceType: 'device',
+        resourceId: device.id,
+        details: { changes },
+      });
+    }
+  }
 
   // Publish event when agent version changes (for real-time UI updates)
   if (data.agentVersion && data.agentVersion !== device.agentVersion) {

--- a/apps/api/src/routes/agents/logs.test.ts
+++ b/apps/api/src/routes/agents/logs.test.ts
@@ -37,7 +37,12 @@ vi.mock('../../db/schema', () => ({
   },
 }));
 
+vi.mock('../../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+}));
+
 import { db } from '../../db';
+import { writeAuditEvent } from '../../services/auditEvents';
 import { logsRoutes } from './logs';
 
 // ---------------------------------------------------------------------------
@@ -194,6 +199,39 @@ describe('agent logs routes', () => {
           },
         }),
       ]);
+    });
+  });
+
+  describe('POST /agents/:id/logs — ingest audit (Finding #9)', () => {
+    it('writes a content-free agent.logs.submit audit event on ingest', async () => {
+      mockDeviceLookup(true);
+      mockInsertSuccess();
+
+      const logs = Array.from({ length: 3 }, () =>
+        makeLogEntry({ message: 'secret token=abc123' })
+      );
+      const res = await app.request(`/agents/${AGENT_ID}/logs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ logs }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(writeAuditEvent).toHaveBeenCalledTimes(1);
+      const [, event] = vi.mocked(writeAuditEvent).mock.calls[0];
+      expect(event).toMatchObject({
+        orgId: ORG_ID,
+        actorType: 'agent',
+        actorId: AGENT_ID,
+        action: 'agent.logs.submit',
+        resourceType: 'device',
+        resourceId: DEVICE_ID,
+        details: { submittedCount: 3, insertedCount: 3 },
+      });
+      // Content-free: no log message contents leak into the audit details.
+      expect(JSON.stringify(event.details)).not.toContain('token=');
+      // partialFailure omitted on a fully-successful insert.
+      expect(event.details).not.toHaveProperty('partialFailure');
     });
   });
 });

--- a/apps/api/src/routes/agents/logs.test.ts
+++ b/apps/api/src/routes/agents/logs.test.ts
@@ -218,7 +218,7 @@ describe('agent logs routes', () => {
 
       expect(res.status).toBe(201);
       expect(writeAuditEvent).toHaveBeenCalledTimes(1);
-      const [, event] = vi.mocked(writeAuditEvent).mock.calls[0];
+      const [, event] = vi.mocked(writeAuditEvent).mock.calls[0]!;
       expect(event).toMatchObject({
         orgId: ORG_ID,
         actorType: 'agent',

--- a/apps/api/src/routes/agents/logs.test.ts
+++ b/apps/api/src/routes/agents/logs.test.ts
@@ -71,6 +71,25 @@ function mockInsertSuccess() {
   return values;
 }
 
+// The route inserts in batches of 100. This lets the FIRST batch land and the
+// SECOND batch throw, so we exercise the partial-insert path (some rows in,
+// some lost) while the swallowed error still leaves an ingest-audit trail.
+function mockInsertPartial() {
+  const values = vi
+    .fn()
+    .mockResolvedValueOnce(undefined) // first 100-row batch succeeds
+    .mockRejectedValueOnce(new Error('insert failed for batch 2'));
+  vi.mocked(db.insert).mockReturnValue({ values } as any);
+  return values;
+}
+
+// Every batch insert throws → inserted stays 0.
+function mockInsertFailure() {
+  const values = vi.fn().mockRejectedValue(new Error('insert failed'));
+  vi.mocked(db.insert).mockReturnValue({ values } as any);
+  return values;
+}
+
 function makeLogEntry(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     timestamp: '2026-05-01T00:00:00.000Z',
@@ -232,6 +251,77 @@ describe('agent logs routes', () => {
       expect(JSON.stringify(event.details)).not.toContain('token=');
       // partialFailure omitted on a fully-successful insert.
       expect(event.details).not.toHaveProperty('partialFailure');
+    });
+
+    it('still writes the ingest audit with partialFailure when some rows fail to insert', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockDeviceLookup(true);
+      mockInsertPartial();
+
+      // 150 entries → two batches (100 + 50). The 100-row batch lands, the
+      // 50-row batch throws, so 100 are inserted and 50 are lost.
+      const logs = Array.from({ length: 150 }, () =>
+        makeLogEntry({ message: 'secret token=abc123' })
+      );
+      const res = await app.request(`/agents/${AGENT_ID}/logs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ logs }),
+      });
+
+      // Partial success → 207 with the inserted/total split.
+      expect(res.status).toBe(207);
+      expect(await res.json()).toEqual({ received: 100, total: 150, partial: true });
+
+      // The ingest audit STILL fires on partial failure, carrying the reduced
+      // insertedCount and the partialFailure shortfall.
+      expect(writeAuditEvent).toHaveBeenCalledTimes(1);
+      const [, event] = vi.mocked(writeAuditEvent).mock.calls[0]!;
+      expect(event).toMatchObject({
+        orgId: ORG_ID,
+        actorType: 'agent',
+        actorId: AGENT_ID,
+        action: 'agent.logs.submit',
+        resourceType: 'device',
+        resourceId: DEVICE_ID,
+        details: { submittedCount: 150, insertedCount: 100, partialFailure: 50 },
+      });
+      // Content-free even on the failure path.
+      expect(JSON.stringify(event.details)).not.toContain('token=');
+
+      consoleError.mockRestore();
+    });
+
+    it('writes the ingest audit and returns 500 when every insert fails (inserted === 0)', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockDeviceLookup(true);
+      mockInsertFailure();
+
+      const logs = Array.from({ length: 3 }, () =>
+        makeLogEntry({ message: 'secret token=abc123' })
+      );
+      const res = await app.request(`/agents/${AGENT_ID}/logs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ logs }),
+      });
+
+      // Total failure → 500, no rows accepted.
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: 'Failed to insert logs', received: 0 });
+
+      // The audit fires BEFORE the 500 return, so the arrival of the batch is
+      // still recorded even though nothing persisted.
+      expect(writeAuditEvent).toHaveBeenCalledTimes(1);
+      const [, event] = vi.mocked(writeAuditEvent).mock.calls[0]!;
+      expect(event).toMatchObject({
+        action: 'agent.logs.submit',
+        resourceId: DEVICE_ID,
+        details: { submittedCount: 3, insertedCount: 0, partialFailure: 3 },
+      });
+      expect(JSON.stringify(event.details)).not.toContain('token=');
+
+      consoleError.mockRestore();
     });
   });
 });

--- a/apps/api/src/routes/agents/logs.ts
+++ b/apps/api/src/routes/agents/logs.ts
@@ -6,6 +6,7 @@ import { gunzipSync } from 'node:zlib';
 import { db } from '../../db';
 import { devices, agentLogs } from '../../db/schema';
 import { redactLogFields, redactLogMessage } from '../../services/logRedaction';
+import { writeAuditEvent } from '../../services/auditEvents';
 
 export const logsRoutes = new Hono();
 
@@ -115,6 +116,26 @@ logsRoutes.post(
   } catch (err) {
     console.error(`[AgentLogs] Error batch inserting logs for device ${device.id}:`, err);
   }
+
+  // Content-free ingest audit (counts only, NO log message contents) so the
+  // arrival of diagnostic evidence is itself auditable — mirrors the sibling
+  // eventlogs.ts `agent.eventlogs.submit` event. Fires on success and partial/
+  // total failure alike, so a swallowed insert error still leaves a trail.
+  const agent = c.get('agent') as { orgId?: string; agentId?: string } | undefined;
+  const partialFailure = rows.length - inserted;
+  writeAuditEvent(c, {
+    orgId: agent?.orgId ?? device.orgId,
+    actorType: 'agent',
+    actorId: agent?.agentId ?? agentId,
+    action: 'agent.logs.submit',
+    resourceType: 'device',
+    resourceId: device.id,
+    details: {
+      submittedCount: data.logs.length,
+      insertedCount: inserted,
+      ...(partialFailure > 0 ? { partialFailure } : {}),
+    },
+  });
 
   if (inserted === 0 && rows.length > 0) {
     return c.json({ error: 'Failed to insert logs', received: 0 }, 500);

--- a/apps/api/src/routes/agents/mtls.test.ts
+++ b/apps/api/src/routes/agents/mtls.test.ts
@@ -48,8 +48,25 @@ vi.mock('../../middleware/auth', () => ({
   }),
 }));
 
+const { matchTokenMock } = vi.hoisted(() => ({
+  // Default: current-token match (no rotation required). Individual tests
+  // override to { tokenRotationRequired: true } to exercise the previous-token
+  // rejection on /renew-cert.
+  matchTokenMock: vi.fn(() => ({ tokenRotationRequired: false })),
+}));
 vi.mock('../../middleware/agentAuth', () => ({
-  matchAgentTokenHash: vi.fn(() => ({ mode: 'primary' })),
+  matchAgentTokenHash: matchTokenMock,
+}));
+
+// mtls.ts imports disconnectAgent from routes/agentWs to sever the agent
+// command channel on the quarantine path (Finding #3). Mock it so importing
+// mtls.ts doesn't pull the heavy agentWs → terminalWs chain, and so we can
+// assert the wiring fires.
+const { disconnectAgentMock } = vi.hoisted(() => ({
+  disconnectAgentMock: vi.fn(() => 'closed'),
+}));
+vi.mock('../agentWs', () => ({
+  disconnectAgent: disconnectAgentMock,
 }));
 
 const { tenantActiveMock } = vi.hoisted(() => ({
@@ -205,9 +222,34 @@ function mockDeviceLookup(row: Record<string, unknown> | null) {
   } as any);
 }
 
-function mockDbUpdateOk() {
+// The renew-cert writes use `.where(...).returning({ id })` and require exactly
+// one row; the org-settings PATCH writes just `await ...where(...)`. So the
+// where() result must be BOTH awaitable (thenable → undefined) AND expose a
+// `.returning()` that resolves to one device row. `rowCount` lets a test force
+// a 0-row write to exercise the fail-closed path.
+function mockDbUpdateOk(rowCount = 1) {
+  const rows = Array.from({ length: rowCount }, () => ({ id: DEVICE_ID }));
   dbUpdateMock.mockReturnValue({
-    set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue(rows),
+        then: (resolve: (v: unknown) => unknown) => resolve(undefined),
+      }),
+    }),
+  } as any);
+}
+
+// Queue an organizations.settings row for readOrgMtlsPolicyOrNull (the fail-
+// closed org mTLS policy read on /renew-cert). Pass null to simulate a missing
+// org row (drives the fail-closed 500). Must be queued AFTER the device lookup
+// since both go through dbSelectMock.mockReturnValueOnce in call order.
+function mockOrgSettingsLookup(settings: Record<string, unknown> | null = {}) {
+  dbSelectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(settings === null ? [] : [{ settings }]),
+      }),
+    }),
   } as any);
 }
 
@@ -245,6 +287,7 @@ describe('POST /renew-cert — E4 per-device cooldown', () => {
 
     // First request — success
     mockDeviceLookup(deviceRow);
+    mockOrgSettingsLookup(); // org policy row present (auto_reissue default)
     const first = await buildApp().request('/agents/renew-cert', {
       method: 'POST',
       headers: { Authorization: `Bearer ${TOKEN}` },
@@ -328,6 +371,7 @@ describe('POST /renew-cert — tenant-status gate (F4)', () => {
       serialNumber: 'sn-1',
     });
     mockDeviceLookup(activeDeviceRow);
+    mockOrgSettingsLookup(); // org policy row present
 
     const res = await buildApp().request('/agents/renew-cert', {
       method: 'POST',
@@ -349,11 +393,11 @@ describe('remote-session teardown wiring on quarantine / deny', () => {
     mockDbUpdateOk();
   });
 
-  it('POST /renew-cert quarantine branch tears down live remote sessions', async () => {
-    // Expired cert + org expiredCertPolicy 'quarantine' (the getOrgMtlsSettings
-    // mock default) drives the renew handler into the quarantine branch, which
-    // must cut any in-flight desktop/terminal session to the now-isolated
-    // device. Dropping that call silently leaves live control running.
+  it('POST /renew-cert quarantine branch tears down live remote sessions AND severs the agent WS', async () => {
+    // Expired cert + org expiredCertPolicy 'quarantine' drives the renew handler
+    // into the quarantine branch, which must cut any in-flight desktop/terminal
+    // session AND sever the agent command WebSocket to the now-isolated device.
+    // Dropping either call silently leaves live control / command draining.
     const deviceRow = {
       id: DEVICE_ID,
       orgId: ORG_ID,
@@ -370,6 +414,7 @@ describe('remote-session teardown wiring on quarantine / deny', () => {
     };
 
     mockDeviceLookup(deviceRow);
+    mockOrgSettingsLookup({ mtls: { expiredCertPolicy: 'quarantine' } });
     const res = await buildApp().request('/agents/renew-cert', {
       method: 'POST',
       headers: { Authorization: `Bearer ${TOKEN}` },
@@ -382,6 +427,8 @@ describe('remote-session teardown wiring on quarantine / deny', () => {
     expect(issueCertMock).not.toHaveBeenCalled();
     // Wiring under test: live remote control to the quarantined device is cut.
     expect(terminateDeviceRemoteSessions).toHaveBeenCalledWith(DEVICE_ID);
+    // Finding #3: the agent command WebSocket is also severed (code 4041).
+    expect(disconnectAgentMock).toHaveBeenCalledWith(AGENT_ID, 4041, expect.any(String));
   });
 
   it('POST /:id/deny tears down live remote sessions for the denied device', async () => {
@@ -404,6 +451,97 @@ describe('remote-session teardown wiring on quarantine / deny', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ success: true });
     expect(terminateDeviceRemoteSessions).toHaveBeenCalledWith(DEVICE_ID);
+  });
+});
+
+describe('POST /renew-cert — cert-issuing fail-closed guards', () => {
+  const baseDeviceRow = {
+    id: DEVICE_ID,
+    orgId: ORG_ID,
+    agentId: AGENT_ID,
+    hostname: 'host-1',
+    status: 'online',
+    agentTokenHash: TOKEN_HASH,
+    previousTokenHash: null,
+    previousTokenExpiresAt: null,
+    agentTokenSuspendedAt: null,
+    // Non-expired cert → the handler takes the issue path (not quarantine).
+    mtlsCertExpiresAt: new Date(Date.now() + 30 * 24 * 3600 * 1000),
+    mtlsCertCfId: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisState.clear();
+    issueCertMock.mockReset();
+    revokeCertMock.mockReset();
+    tenantActiveMock.mockResolvedValue(true);
+    matchTokenMock.mockReturnValue({ tokenRotationRequired: false });
+    mockDbUpdateOk();
+  });
+
+  it('Finding #2: rejects a PREVIOUS (superseded) token caller with 401 and issues no cert', async () => {
+    // The caller authenticated via the previous/rotated token — accepted for
+    // idempotent agent traffic, but NOT for minting new cert material. A stolen
+    // superseded token must not obtain a fresh certificate + private key.
+    matchTokenMock.mockReturnValueOnce({ tokenRotationRequired: true });
+    mockDeviceLookup(baseDeviceRow);
+
+    const res = await buildApp().request('/agents/renew-cert', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/rotate/i);
+    // No cert material is minted for a superseded token.
+    expect(issueCertMock).not.toHaveBeenCalled();
+  });
+
+  it('Finding #1: fails closed (500) and returns NO cert material when the metadata write affects 0 rows', async () => {
+    // A 0-row cert-metadata write under FORCE RLS would otherwise "succeed"
+    // silently, leaking an UNTRACKED cert (no serial/expiry/cfId recorded → not
+    // revocable later). The handler must deny AND revoke the just-issued cert.
+    issueCertMock.mockResolvedValue({
+      id: 'cf-cert-untracked',
+      certificate: 'CERT',
+      privateKey: 'KEY',
+      expiresOn: new Date(Date.now() + 30 * 24 * 3600 * 1000).toISOString(),
+      issuedOn: new Date().toISOString(),
+      serialNumber: 'sn-untracked',
+    });
+    mockDeviceLookup(baseDeviceRow);
+    mockOrgSettingsLookup(); // auto_reissue default → issue path
+    mockDbUpdateOk(0); // metadata write matches 0 rows
+
+    const res = await buildApp().request('/agents/renew-cert', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    // Crucially, no certificate/privateKey is handed back on the fail-closed path.
+    expect(body.mtls).toBeUndefined();
+    expect(body.error).toMatch(/failed/i);
+    // The untracked cert is revoked so it can't be used.
+    expect(revokeCertMock).toHaveBeenCalledWith('cf-cert-untracked');
+  });
+
+  it('Finding #1: fails closed (500) when the org policy row is missing (no auto_reissue fallback)', async () => {
+    // A missing org row must NOT silently downgrade to auto_reissue and issue a
+    // cert against an org whose policy we can't resolve.
+    mockDeviceLookup(baseDeviceRow);
+    mockOrgSettingsLookup(null); // org row absent
+
+    const res = await buildApp().request('/agents/renew-cert', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+
+    expect(res.status).toBe(500);
+    expect(issueCertMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/agents/mtls.ts
+++ b/apps/api/src/routes/agents/mtls.ts
@@ -13,7 +13,8 @@ import { matchAgentTokenHash } from '../../middleware/agentAuth';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { CloudflareMtlsService } from '../../services/cloudflareMtls';
 import { orgMtlsSettingsSchema, orgHelperSettingsSchema, orgLogForwardingSettingsSchema } from '@breeze/shared';
-import { getOrgMtlsSettings, getOrgHelperSettings, issueMtlsCertForDevice, isObject } from './helpers';
+import { getOrgHelperSettings, issueMtlsCertForDevice, isObject } from './helpers';
+import { disconnectAgent } from '../agentWs';
 import { getRedis } from '../../services/redis';
 import { rateLimiter } from '../../services/rate-limit';
 import { encryptSecret } from '../../services/secretCrypto';
@@ -93,6 +94,47 @@ function resolveSecretForStorage(incoming: unknown, existing: unknown): string |
   return encryptSecret(trimmed) ?? undefined;
 }
 
+type OrgMtlsPolicy = { certLifetimeDays: number; expiredCertPolicy: 'auto_reissue' | 'quarantine' };
+
+/**
+ * Read the org's mTLS policy for the /renew-cert agent path.
+ *
+ * SECURITY (fail-closed): this route hand-rolls bearer auth and skips
+ * agentAuthMiddleware (see AGENT_AUTH_SKIP_ID_SEGMENTS), so it carries NO
+ * ambient request DB context. Under FORCE RLS the bare `breeze_app` pool would
+ * return 0 rows for a contextless read — silently collapsing an org configured
+ * `quarantine` into the `auto_reissue` default and handing a fresh cert+key to
+ * a possibly-compromised agent. We therefore read INSIDE
+ * `withSystemDbAccessContext` (mirroring the device lookup above) so RLS
+ * returns the real row and the true policy is honored.
+ *
+ * Returns `null` when the org row is genuinely absent. Callers MUST treat null
+ * as the most-restrictive path (error / deny) — never fall back to
+ * `auto_reissue` on a missing row. (An org that simply has no mTLS settings
+ * still yields a row and its real default policy; only a truly missing org row
+ * returns null.) The parse mirrors helpers.ts `getOrgMtlsSettings`, inlined
+ * here so we can distinguish "no org row" from "org with default settings",
+ * which that helper cannot.
+ */
+async function readOrgMtlsPolicyOrNull(orgId: string): Promise<OrgMtlsPolicy | null> {
+  return withSystemDbAccessContext(async () => {
+    const [org] = await db
+      .select({ settings: organizations.settings })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+    if (!org) return null;
+    const settings = isObject(org.settings) ? org.settings : {};
+    const mtls = isObject(settings.mtls) ? settings.mtls : {};
+    const certLifetimeDays =
+      typeof mtls.certLifetimeDays === 'number' && mtls.certLifetimeDays >= 1 && mtls.certLifetimeDays <= 365
+        ? Math.round(mtls.certLifetimeDays)
+        : 90;
+    const expiredCertPolicy = mtls.expiredCertPolicy === 'quarantine' ? 'quarantine' : 'auto_reissue';
+    return { certLifetimeDays, expiredCertPolicy };
+  });
+}
+
 // ============================================
 // mTLS Certificate Renewal
 // ============================================
@@ -142,6 +184,32 @@ mtlsRoutes.post('/renew-cert', async (c) => {
 
   if (!device || !match) {
     return c.json({ error: 'Invalid agent credentials' }, 401);
+  }
+
+  // FINDING #2 (fail-closed): only the CURRENT token may mint new cert material.
+  // `matchAgentTokenHash` accepts the PREVIOUS (superseded) token within its
+  // rotation grace window — that's correct for idempotent agent traffic
+  // (heartbeats/results) but NOT for this cert-issuing route: a stolen,
+  // already-rotated token must not be able to obtain a fresh certificate +
+  // private key. When the previous hash matched, `match.tokenRotationRequired`
+  // is true; reject here (ONLY on this route — the general agent auth path
+  // keeps accepting the previous token for grace). The message tells a
+  // legitimate agent to finish rotating before renewing.
+  if (match.tokenRotationRequired) {
+    writeAuditEvent(c, {
+      orgId: device.orgId,
+      actorType: 'agent',
+      actorId: device.agentId,
+      action: 'agent.mtls.renew.denied',
+      resourceType: 'device',
+      resourceId: device.id,
+      result: 'denied',
+      details: { reason: 'previous_token_rejected' },
+    });
+    return c.json(
+      { error: 'Rotate to the current agent token before renewing the certificate' },
+      401
+    );
   }
 
   // Task 18: auto-suspended tokens fail closed at every auth gate. The
@@ -246,20 +314,53 @@ mtlsRoutes.post('/renew-cert', async (c) => {
     return c.json({ error: 'mTLS not configured' }, 400);
   }
 
-  const mtlsSettings = await getOrgMtlsSettings(device.orgId);
+  // FINDING #1 (fail-closed): read the org mTLS policy INSIDE a system DB
+  // context. A contextless read here returns 0 rows under FORCE RLS, which
+  // would silently downgrade a `quarantine` org to the `auto_reissue` default.
+  // A genuinely missing org row (null) is treated as an error — never
+  // auto_reissue — so we deny rather than issue a cert against an org we can't
+  // resolve a policy for.
+  const mtlsSettings = await readOrgMtlsPolicyOrNull(device.orgId);
+  if (!mtlsSettings) {
+    console.error('[agents] mTLS renew: org policy row not found, failing closed:', device.orgId);
+    writeAuditEvent(c, {
+      orgId: device.orgId,
+      actorType: 'agent',
+      actorId: device.agentId,
+      action: 'agent.mtls.renew.denied',
+      resourceType: 'device',
+      resourceId: device.id,
+      result: 'denied',
+      details: { reason: 'org_policy_unavailable' },
+    });
+    return c.json({ error: 'Certificate renewal unavailable' }, 500);
+  }
 
   const certExpired = device.mtlsCertExpiresAt && device.mtlsCertExpiresAt.getTime() < Date.now();
 
   if (certExpired && mtlsSettings.expiredCertPolicy === 'quarantine') {
-    await db
-      .update(devices)
-      .set({
-        status: 'quarantined',
-        quarantinedAt: new Date(),
-        quarantinedReason: 'mtls_cert_expired',
-        updatedAt: new Date(),
-      })
-      .where(eq(devices.id, device.id));
+    // FINDING #1: the quarantine write must run in a system DB context and
+    // actually affect a row. A contextless / 0-row write under FORCE RLS would
+    // "succeed" while leaving the device un-quarantined. Require exactly 1 row;
+    // if none, fail closed (500) rather than tearing down / returning as if the
+    // device were isolated.
+    const quarantined = await withSystemDbAccessContext(async () =>
+      db
+        .update(devices)
+        .set({
+          status: 'quarantined',
+          quarantinedAt: new Date(),
+          quarantinedReason: 'mtls_cert_expired',
+          updatedAt: new Date(),
+        })
+        .where(eq(devices.id, device.id))
+        .returning({ id: devices.id })
+    );
+
+    if (quarantined.length !== 1) {
+      console.error('[agents] mTLS quarantine write affected 0 rows, failing closed:', device.id);
+      return c.json({ error: 'Certificate renewal failed' }, 500);
+    }
 
     // Cut any live remote-control session to this device. Flipping `status`
     // alone is only checked at connect time, so an in-flight desktop/terminal
@@ -268,6 +369,13 @@ mtlsRoutes.post('/renew-cert', async (c) => {
     // inside the service) is recorded in the audit trail below so there's a
     // forensic record that live control may have persisted.
     const teardownResult = await terminateDeviceRemoteSessions(device.id);
+
+    // FINDING #3: also sever the agent command WebSocket. terminateDeviceRemoteSessions
+    // only cuts remote-desktop/terminal sessions; the agent's own command channel
+    // would keep draining decrypted commands after quarantine. In-process only
+    // (cross-replica broadcast is handled by the agentWs owner). Mirrors the
+    // decommission caller in devices/core.ts (code 4041).
+    const agentWsDisconnect = disconnectAgent(device.agentId, 4041, 'Device quarantined: mTLS cert expired');
 
     writeAuditEvent(c, {
       orgId: device.orgId,
@@ -279,6 +387,7 @@ mtlsRoutes.post('/renew-cert', async (c) => {
       details: {
         reason: 'mtls_cert_expired',
         remoteSessionTeardown: teardownResult === TEARDOWN_FAILED ? 'failed' : 'ok',
+        agentWsDisconnect,
       },
     });
 
@@ -305,30 +414,63 @@ mtlsRoutes.post('/renew-cert', async (c) => {
     return c.json({ error: message }, 500);
   }
 
+  // FINDING #1 (atomicity / fail-closed): do NOT return certificate material
+  // until its metadata has provably persisted. The write runs in a system DB
+  // context and must affect exactly 1 row; a contextless / 0-row write under
+  // FORCE RLS would otherwise "succeed" silently, leaving us handing out an
+  // UNTRACKED cert (no serial/expiry/cfId recorded → cannot be revoked or
+  // reasoned about later). If persistence fails or affects 0 rows, revoke the
+  // just-issued cert (best-effort) and deny the renewal. Better to deny than to
+  // leak an untracked cert.
+  let persisted: { id: string }[];
   try {
-    await db
-      .update(devices)
-      .set({
-        mtlsCertSerialNumber: cert.serialNumber,
-        mtlsCertExpiresAt: new Date(cert.expiresOn),
-        mtlsCertIssuedAt: new Date(cert.issuedOn),
-        mtlsCertCfId: cert.id,
-        updatedAt: new Date(),
-      })
-      .where(eq(devices.id, device.id));
+    persisted = await withSystemDbAccessContext(async () =>
+      db
+        .update(devices)
+        .set({
+          mtlsCertSerialNumber: cert.serialNumber,
+          mtlsCertExpiresAt: new Date(cert.expiresOn),
+          mtlsCertIssuedAt: new Date(cert.issuedOn),
+          mtlsCertCfId: cert.id,
+          updatedAt: new Date(),
+        })
+        .where(eq(devices.id, device.id))
+        .returning({ id: devices.id })
+    );
+  } catch (dbErr) {
+    console.error('[agents] failed to persist renewed mTLS cert metadata to DB:', String(dbErr));
+    persisted = [];
+  }
 
+  if (persisted.length !== 1) {
+    console.error('[agents] mTLS cert metadata write affected 0 rows, revoking untracked cert and failing closed:', device.id);
+    try {
+      await cfService.revokeCertificate(cert.id);
+    } catch (revokeErr) {
+      console.error('[agents] failed to revoke untracked mTLS cert after metadata write failure:', String(revokeErr));
+    }
     writeAuditEvent(c, {
       orgId: device.orgId,
       actorType: 'agent',
       actorId: device.agentId,
-      action: 'agent.mtls.renewed',
+      action: 'agent.mtls.renew.denied',
       resourceType: 'device',
       resourceId: device.id,
-      details: { serialNumber: cert.serialNumber },
+      result: 'denied',
+      details: { reason: 'cert_metadata_persist_failed', serialNumber: cert.serialNumber },
     });
-  } catch (dbErr) {
-    console.error('[agents] failed to persist renewed mTLS cert metadata to DB:', String(dbErr));
+    return c.json({ error: 'Certificate renewal failed' }, 500);
   }
+
+  writeAuditEvent(c, {
+    orgId: device.orgId,
+    actorType: 'agent',
+    actorId: device.agentId,
+    action: 'agent.mtls.renewed',
+    resourceType: 'device',
+    resourceId: device.id,
+    details: { serialNumber: cert.serialNumber },
+  });
 
   // E4: record successful renewal in the long-term cooldown window.
   if (redis) {

--- a/apps/api/src/routes/agents/reliability.test.ts
+++ b/apps/api/src/routes/agents/reliability.test.ts
@@ -65,6 +65,7 @@ vi.mock('../../services/reliabilityScoring', () => ({
 }));
 
 vi.mock('../../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeAuditEvent: vi.fn(),
 }));
 

--- a/apps/api/src/routes/agents/token.test.ts
+++ b/apps/api/src/routes/agents/token.test.ts
@@ -42,12 +42,23 @@ vi.mock('./helpers', () => ({
   generateApiKey: vi.fn(() => 'brz_rotated_token'),
 }));
 
+// Capture the drizzle condition builders so we can assert the rotate-token
+// UPDATE is compare-and-swapped against the authenticating token hash.
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ __and: args })),
+  eq: vi.fn((col: unknown, val: unknown) => ({ __eq: [col, val] })),
+}));
+
+import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { generateApiKey } from './helpers';
 import { tokenRoutes } from './token';
 
-function buildApp(): Hono {
+// Default hash the mocked middleware reports as the current-token hash.
+const CURRENT_AGENT_TOKEN_HASH = 'current-agent-token-hash';
+
+function buildApp(opts?: { rotationRequired?: boolean; authTokenHash?: string }): Hono {
   const app = new Hono();
   app.use('/agents/*', async (c, next) => {
     c.set('agent', {
@@ -56,7 +67,9 @@ function buildApp(): Hono {
       agentId: 'agent-123',
       siteId: 'site-1',
       role: 'agent',
+      authTokenHash: opts?.authTokenHash ?? CURRENT_AGENT_TOKEN_HASH,
     });
+    c.set('agentTokenRotationRequired', opts?.rotationRequired ?? false);
     await next();
   });
   app.route('/agents', tokenRoutes);
@@ -88,7 +101,9 @@ describe('agent token rotation route', () => {
 
     vi.mocked(db.update).mockReturnValue({
       set: vi.fn(() => ({
-        where: vi.fn().mockResolvedValue(undefined),
+        where: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue([{ id: 'device-1' }]),
+        })),
       })),
     } as any);
   });
@@ -103,9 +118,10 @@ describe('agent token rotation route', () => {
       .mockReturnValueOnce('brz_rotated_watchdog_token')
       .mockReturnValueOnce('brz_rotated_helper_token');
 
-    const set = vi.fn(() => ({
-      where: vi.fn().mockResolvedValue(undefined),
+    const where = vi.fn(() => ({
+      returning: vi.fn().mockResolvedValue([{ id: 'device-1' }]),
     }));
+    const set = vi.fn(() => ({ where }));
     vi.mocked(db.update).mockReturnValue({ set } as any);
 
     const response = await buildApp().request('/agents/agent-123/rotate-token', {
@@ -120,9 +136,15 @@ describe('agent token rotation route', () => {
       rotatedAt: '2026-03-31T18:45:00.000Z',
     });
 
+    // The UPDATE is compare-and-swapped against the hash that authenticated
+    // this request — devices.agentTokenHash = <authenticating current hash>.
+    expect(eq).toHaveBeenCalledWith('agentTokenHash', CURRENT_AGENT_TOKEN_HASH);
+    expect(where).toHaveBeenCalledTimes(1);
+
     expect(generateApiKey).toHaveBeenCalledTimes(3);
     expect(set).toHaveBeenCalledWith({
-      previousTokenHash: 'old-token-hash',
+      // previousTokenHash snapshots the authenticating (current-at-rotation) hash.
+      previousTokenHash: CURRENT_AGENT_TOKEN_HASH,
       previousTokenExpiresAt: new Date('2026-03-31T18:50:00.000Z'),
       agentTokenHash: createHash('sha256').update('brz_rotated_agent_token').digest('hex'),
       tokenIssuedAt: new Date('2026-03-31T18:45:00.000Z'),
@@ -178,7 +200,9 @@ describe('agent token rotation route', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.mocked(db.update).mockReturnValue({
       set: vi.fn(() => ({
-        where: vi.fn().mockRejectedValue(new Error('db unavailable')),
+        where: vi.fn(() => ({
+          returning: vi.fn().mockRejectedValue(new Error('db unavailable')),
+        })),
       })),
     } as any);
 
@@ -191,5 +215,58 @@ describe('agent token rotation route', () => {
     expect(writeAuditEvent).not.toHaveBeenCalled();
 
     consoleError.mockRestore();
+  });
+
+  it('rejects a superseded (previous-token) caller and mints no tokens', async () => {
+    // agentAuthMiddleware matched the PREVIOUS token during the grace window
+    // and set agentTokenRotationRequired=true. A stolen superseded token must
+    // not be able to renew itself into durable credentials.
+    const response = await buildApp({ rotationRequired: true }).request(
+      '/agents/agent-123/rotate-token',
+      { method: 'POST' }
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Rotate using the current token; superseded tokens cannot rotate',
+    });
+
+    // No credential mint, no DB read/write, no audit — rejected before any work.
+    expect(generateApiKey).not.toHaveBeenCalled();
+    expect(db.select).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+    expect(writeAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 409 and mints no tokens when the compare-and-swap matches zero rows', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Someone else rotated first (or the authenticating hash no longer matches
+    // the stored current hash): the CAS UPDATE touches zero rows.
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue([]),
+        })),
+      })),
+    } as any);
+
+    const response = await buildApp().request('/agents/agent-123/rotate-token', {
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body).toEqual({
+      error: 'Token rotation conflict; re-authenticate with the current token',
+    });
+
+    // The freshly-minted plaintext tokens were never persisted, so they must
+    // not be returned to the caller.
+    expect(body.authToken).toBeUndefined();
+    expect(body.watchdogAuthToken).toBeUndefined();
+    expect(body.helperAuthToken).toBeUndefined();
+    expect(writeAuditEvent).not.toHaveBeenCalled();
+
+    consoleWarn.mockRestore();
   });
 });

--- a/apps/api/src/routes/agents/token.test.ts
+++ b/apps/api/src/routes/agents/token.test.ts
@@ -58,7 +58,15 @@ import { tokenRoutes } from './token';
 // Default hash the mocked middleware reports as the current-token hash.
 const CURRENT_AGENT_TOKEN_HASH = 'current-agent-token-hash';
 
-function buildApp(opts?: { rotationRequired?: boolean; authTokenHash?: string }): Hono {
+function buildApp(opts?: {
+  rotationRequired?: boolean;
+  authTokenHash?: string;
+  // Force the middleware to set an agent context with NO authTokenHash, so the
+  // fail-closed `if (!authTokenHash) return 401` guard becomes reachable. The
+  // default `?? CURRENT_AGENT_TOKEN_HASH` fallback would otherwise always
+  // supply a truthy hash and mask that branch.
+  omitAuthTokenHash?: boolean;
+}): Hono {
   const app = new Hono();
   app.use('/agents/*', async (c, next) => {
     c.set('agent', {
@@ -67,7 +75,9 @@ function buildApp(opts?: { rotationRequired?: boolean; authTokenHash?: string })
       agentId: 'agent-123',
       siteId: 'site-1',
       role: 'agent',
-      authTokenHash: opts?.authTokenHash ?? CURRENT_AGENT_TOKEN_HASH,
+      authTokenHash: opts?.omitAuthTokenHash
+        ? undefined
+        : (opts?.authTokenHash ?? CURRENT_AGENT_TOKEN_HASH),
     });
     c.set('agentTokenRotationRequired', opts?.rotationRequired ?? false);
     await next();
@@ -232,6 +242,27 @@ describe('agent token rotation route', () => {
     });
 
     // No credential mint, no DB read/write, no audit — rejected before any work.
+    expect(generateApiKey).not.toHaveBeenCalled();
+    expect(db.select).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+    expect(writeAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 and mints nothing when the authenticating token hash is absent', async () => {
+    // Fail-closed guard: without the middleware-supplied authTokenHash the
+    // compare-and-swap has nothing to bind to, so rotation must be refused
+    // BEFORE any credential mint, DB read/write, or audit — never run an
+    // UPDATE that isn't bound to the caller's token.
+    const response = await buildApp({ omitAuthTokenHash: true }).request(
+      '/agents/agent-123/rotate-token',
+      { method: 'POST' }
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Missing authenticated token binding',
+    });
+
     expect(generateApiKey).not.toHaveBeenCalled();
     expect(db.select).not.toHaveBeenCalled();
     expect(db.update).not.toHaveBeenCalled();

--- a/apps/api/src/routes/agents/token.ts
+++ b/apps/api/src/routes/agents/token.ts
@@ -30,6 +30,14 @@ tokenRoutes.post('/:id/rotate-token', async (c) => {
     );
   }
 
+  // The authenticating-token hash is required for the compare-and-swap below.
+  // The real agentAuthMiddleware always sets it; fail closed if it is ever
+  // absent rather than running an UPDATE that isn't bound to the caller's token.
+  const authTokenHash = agent.authTokenHash;
+  if (!authTokenHash) {
+    return c.json({ error: 'Missing authenticated token binding' }, 401);
+  }
+
   const [device] = await db
     .select({
       id: devices.id,
@@ -77,7 +85,7 @@ tokenRoutes.post('/:id/rotate-token', async (c) => {
     rotatedRows = await db
       .update(devices)
       .set({
-        previousTokenHash: agent.authTokenHash,
+        previousTokenHash: authTokenHash,
         previousTokenExpiresAt,
         agentTokenHash,
         tokenIssuedAt: rotatedAt,
@@ -94,7 +102,7 @@ tokenRoutes.post('/:id/rotate-token', async (c) => {
       .where(
         and(
           eq(devices.id, device.id),
-          eq(devices.agentTokenHash, agent.authTokenHash)
+          eq(devices.agentTokenHash, authTokenHash)
         )
       )
       .returning({ id: devices.id });

--- a/apps/api/src/routes/agents/token.ts
+++ b/apps/api/src/routes/agents/token.ts
@@ -17,6 +17,19 @@ tokenRoutes.post('/:id/rotate-token', async (c) => {
     return c.json({ error: 'Agent credential role mismatch' }, 403);
   }
 
+  // PART A — superseded (previous-token) credentials must not renew themselves.
+  // agentAuthMiddleware still lets a previous-token match through during the
+  // ~5-min grace window (flagged for the agent to re-provision), but a stolen
+  // superseded token must never be able to mint durable new agent/watchdog/
+  // helper credentials and demote the legitimate current token. Rotation must
+  // be driven by the CURRENT token only.
+  if (c.get('agentTokenRotationRequired')) {
+    return c.json(
+      { error: 'Rotate using the current token; superseded tokens cannot rotate' },
+      401
+    );
+  }
+
   const [device] = await db
     .select({
       id: devices.id,
@@ -53,11 +66,18 @@ tokenRoutes.post('/:id/rotate-token', async (c) => {
   // lgtm[js/insufficient-password-hash]
   const helperTokenHash = createHash('sha256').update(helperAuthToken).digest('hex');
 
+  // PART B — bind the rotation atomically to the hash that actually
+  // authenticated this request. The UPDATE is a compare-and-swap on the
+  // CURRENT agent-token hash (the value the middleware matched), so a race
+  // (someone else rotated first) or any hash mismatch touches zero rows and
+  // mints nothing. previousTokenHash becomes the authenticating hash — the
+  // token that was current at rotation time.
+  let rotatedRows: { id: string }[];
   try {
-    await db
+    rotatedRows = await db
       .update(devices)
       .set({
-        previousTokenHash: device.agentTokenHash,
+        previousTokenHash: agent.authTokenHash,
         previousTokenExpiresAt,
         agentTokenHash,
         tokenIssuedAt: rotatedAt,
@@ -71,7 +91,13 @@ tokenRoutes.post('/:id/rotate-token', async (c) => {
         helperTokenIssuedAt: rotatedAt,
         updatedAt: rotatedAt,
       })
-      .where(eq(devices.id, device.id));
+      .where(
+        and(
+          eq(devices.id, device.id),
+          eq(devices.agentTokenHash, agent.authTokenHash)
+        )
+      )
+      .returning({ id: devices.id });
   } catch (error) {
     console.error('[agents] token rotation DB update failed:', {
       agentId,
@@ -79,6 +105,17 @@ tokenRoutes.post('/:id/rotate-token', async (c) => {
       error,
     });
     return c.json({ error: 'Failed to rotate agent token' }, 500);
+  }
+
+  // Zero rows => the current-token hash moved out from under us (concurrent
+  // rotation / stale token). Do NOT return any freshly-minted plaintext tokens;
+  // they were never persisted because the CAS matched nothing.
+  if (rotatedRows.length !== 1) {
+    console.warn('[agents] token rotation compare-and-swap matched no rows:', {
+      agentId,
+      deviceId: device.id,
+    });
+    return c.json({ error: 'Token rotation conflict; re-authenticate with the current token' }, 409);
   }
 
   try {

--- a/apps/api/src/routes/backup/jobs.test.ts
+++ b/apps/api/src/routes/backup/jobs.test.ts
@@ -92,6 +92,7 @@ vi.mock('../../middleware/auth', () => ({
 }));
 
 vi.mock('../../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeRouteAudit: vi.fn(),
 }));
 

--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -13,6 +13,7 @@ vi.mock('../services/remoteSessionTeardown', () => ({
 }));
 
 vi.mock('../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeAuditEvent: vi.fn(),
   writeRouteAudit: vi.fn()
 }));

--- a/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
+++ b/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
@@ -77,6 +77,7 @@ vi.mock('../../services/enrollmentKeySecurity', () => ({
 }));
 
 vi.mock('../../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeRouteAudit: vi.fn()
 }));
 

--- a/apps/api/src/routes/discovery.manualEdge.test.ts
+++ b/apps/api/src/routes/discovery.manualEdge.test.ts
@@ -7,6 +7,7 @@ import { discoveredAssets, topologyManualNodes, networkTopology } from '../db/sc
 vi.mock('../services', () => ({}));
 
 vi.mock('../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeAuditEvent: vi.fn(),
   writeRouteAudit: vi.fn(),
 }));

--- a/apps/api/src/routes/discovery.manualNode.test.ts
+++ b/apps/api/src/routes/discovery.manualNode.test.ts
@@ -7,6 +7,7 @@ import { sites, topologyManualNodes, networkTopology, topologyLayout } from '../
 vi.mock('../services', () => ({}));
 
 vi.mock('../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeAuditEvent: vi.fn(),
   writeRouteAudit: vi.fn(),
 }));

--- a/apps/api/src/routes/discovery.test.ts
+++ b/apps/api/src/routes/discovery.test.ts
@@ -11,6 +11,7 @@ import { networkTopology, topologyLayout, discoveredAssets, sites } from '../db/
 vi.mock('../services', () => ({}));
 
 vi.mock('../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeAuditEvent: vi.fn(),
   writeRouteAudit: vi.fn()
 }));

--- a/apps/api/src/routes/discovery.topologyRead.test.ts
+++ b/apps/api/src/routes/discovery.topologyRead.test.ts
@@ -7,6 +7,7 @@ import { networkTopology, topologyManualNodes } from '../db/schema';
 vi.mock('../services', () => ({}));
 
 vi.mock('../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeAuditEvent: vi.fn(),
   writeRouteAudit: vi.fn(),
 }));

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -14,6 +14,7 @@ const EXECUTION_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
 vi.mock('../services', () => ({}));
 
 vi.mock('../services/auditEvents', () => ({
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeRouteAudit: vi.fn()
 }));
 

--- a/apps/api/src/services/secretRedaction.test.ts
+++ b/apps/api/src/services/secretRedaction.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { redactSecretsFromOutput } from './secretRedaction';
+
+// A representative base64 body line that must never survive redaction.
+const KEY_BODY = 'MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDb1234567890abcd';
+
+const REDACTED = '[PRIVATE_KEY_REDACTED]';
+
+function pemBlock(label: string): string {
+  const header = `-----BEGIN ${label}-----`;
+  const footer = `-----END ${label}-----`;
+  return `${header}\n${KEY_BODY}\nAnOtHeRlInE0987654321\n${footer}`;
+}
+
+describe('redactSecretsFromOutput', () => {
+  it('returns empty string for null/undefined', () => {
+    expect(redactSecretsFromOutput(null)).toBe('');
+    expect(redactSecretsFromOutput(undefined)).toBe('');
+  });
+
+  it('redacts a PKCS#8 private key block (optional algorithm token)', () => {
+    const input = `before\n${pemBlock('PRIVATE KEY')}\nafter`;
+    const out = redactSecretsFromOutput(input);
+    expect(out).not.toContain(KEY_BODY);
+    expect(out).not.toContain('-----BEGIN PRIVATE KEY-----');
+    expect(out).not.toContain('-----END PRIVATE KEY-----');
+    expect(out).toContain('before');
+    expect(out).toContain('after');
+    expect(out).toContain(REDACTED);
+  });
+
+  it('redacts an RSA private key block including body and END marker', () => {
+    const out = redactSecretsFromOutput(pemBlock('RSA PRIVATE KEY'));
+    expect(out).not.toContain(KEY_BODY);
+    expect(out).not.toContain('RSA PRIVATE KEY');
+    expect(out).toBe(REDACTED);
+  });
+
+  it('redacts an OPENSSH private key block', () => {
+    const out = redactSecretsFromOutput(pemBlock('OPENSSH PRIVATE KEY'));
+    expect(out).not.toContain(KEY_BODY);
+    expect(out).not.toContain('OPENSSH PRIVATE KEY');
+    expect(out).toBe(REDACTED);
+  });
+
+  it('redacts an ENCRYPTED private key block', () => {
+    const out = redactSecretsFromOutput(pemBlock('ENCRYPTED PRIVATE KEY'));
+    expect(out).not.toContain(KEY_BODY);
+    expect(out).not.toContain('ENCRYPTED PRIVATE KEY');
+    expect(out).toBe(REDACTED);
+  });
+
+  it('redacts two keys in one string individually', () => {
+    const input = `${pemBlock('RSA PRIVATE KEY')}\nmiddle text\n${pemBlock('OPENSSH PRIVATE KEY')}`;
+    const out = redactSecretsFromOutput(input);
+    expect(out).not.toContain(KEY_BODY);
+    expect(out).not.toContain('-----END RSA PRIVATE KEY-----');
+    expect(out).not.toContain('-----END OPENSSH PRIVATE KEY-----');
+    expect(out).toContain('middle text');
+    // Non-greedy match: each key is its own redaction marker.
+    expect(out.match(/\[PRIVATE_KEY_REDACTED\]/g)).toHaveLength(2);
+  });
+
+  it('passes through non-key text unchanged', () => {
+    const input = 'just a normal script output with no secrets';
+    expect(redactSecretsFromOutput(input)).toBe(input);
+  });
+});

--- a/apps/api/src/services/secretRedaction.test.ts
+++ b/apps/api/src/services/secretRedaction.test.ts
@@ -63,23 +63,26 @@ describe('redactSecretsFromOutput', () => {
 
   // --- ReDoS: pathological input must complete quickly, not hang the loop. ---
   it('handles pathological BEGIN-only input in bounded time', () => {
-    // 100k BEGIN markers (~2.7 MB) with NO END marker. Under the old unbounded
+    // 30k BEGIN markers (~0.8 MB) with NO END marker. Under the old unbounded
     // `[\s\S]*?` PEM regex each BEGIN scanned to end-of-string, so this
     // backtracked ~O(n²) and would run for many minutes, blocking the event
     // loop. With the 16 KiB-bounded gap each match attempt is bounded → linear
-    // (measured ~2.8 s here vs. effectively non-terminating before).
-    const input = '-----BEGIN PRIVATE KEY-----'.repeat(100_000);
+    // (~1 s idle vs. effectively non-terminating before).
+    const input = '-----BEGIN PRIVATE KEY-----'.repeat(30_000);
     const start = Date.now();
     const out = redactSecretsFromOutput(input);
     const elapsed = Date.now() - start;
     expect(typeof out).toBe('string');
-    // Generous ceiling: the pathological case previously would not return at
-    // all. Linear behavior finishes in well under this bound.
-    expect(elapsed).toBeLessThan(5_000);
+    // Deliberately loose ceiling: this only needs to separate linear behavior
+    // (seconds, even on a loaded shared CI runner or under parallel local
+    // forks) from the old ReDoS behavior (minutes / never returns, which the
+    // 30 s test timeout catches). A tight bound flaked on CI (6.7 s at 100k
+    // markers) and under local parallel runs.
+    expect(elapsed).toBeLessThan(20_000);
     // The lone headers are stripped by the truncated-key fallback.
     expect(out).not.toContain('-----BEGIN PRIVATE KEY-----');
     expect(out).toContain(REDACTED);
-  });
+  }, 30_000);
 
   // --- Truncated key: header + body but no END must still be fully redacted. ---
   it('redacts a truncated private key (BEGIN + body, no END marker)', () => {

--- a/apps/api/src/services/secretRedaction.test.ts
+++ b/apps/api/src/services/secretRedaction.test.ts
@@ -13,11 +13,6 @@ function pemBlock(label: string): string {
 }
 
 describe('redactSecretsFromOutput', () => {
-  it('returns empty string for null/undefined', () => {
-    expect(redactSecretsFromOutput(null)).toBe('');
-    expect(redactSecretsFromOutput(undefined)).toBe('');
-  });
-
   it('redacts a PKCS#8 private key block (optional algorithm token)', () => {
     const input = `before\n${pemBlock('PRIVATE KEY')}\nafter`;
     const out = redactSecretsFromOutput(input);
@@ -64,5 +59,69 @@ describe('redactSecretsFromOutput', () => {
   it('passes through non-key text unchanged', () => {
     const input = 'just a normal script output with no secrets';
     expect(redactSecretsFromOutput(input)).toBe(input);
+  });
+
+  // --- ReDoS: pathological input must complete quickly, not hang the loop. ---
+  it('handles pathological BEGIN-only input in bounded time', () => {
+    // 100k BEGIN markers (~2.7 MB) with NO END marker. Under the old unbounded
+    // `[\s\S]*?` PEM regex each BEGIN scanned to end-of-string, so this
+    // backtracked ~O(n²) and would run for many minutes, blocking the event
+    // loop. With the 16 KiB-bounded gap each match attempt is bounded → linear
+    // (measured ~2.8 s here vs. effectively non-terminating before).
+    const input = '-----BEGIN PRIVATE KEY-----'.repeat(100_000);
+    const start = Date.now();
+    const out = redactSecretsFromOutput(input);
+    const elapsed = Date.now() - start;
+    expect(typeof out).toBe('string');
+    // Generous ceiling: the pathological case previously would not return at
+    // all. Linear behavior finishes in well under this bound.
+    expect(elapsed).toBeLessThan(5_000);
+    // The lone headers are stripped by the truncated-key fallback.
+    expect(out).not.toContain('-----BEGIN PRIVATE KEY-----');
+    expect(out).toContain(REDACTED);
+  });
+
+  // --- Truncated key: header + body but no END must still be fully redacted. ---
+  it('redacts a truncated private key (BEGIN + body, no END marker)', () => {
+    const input = `logs before\n-----BEGIN RSA PRIVATE KEY-----\n${KEY_BODY}\nAnOtHeRlInE0987654321`;
+    const out = redactSecretsFromOutput(input);
+    expect(out).not.toContain(KEY_BODY);
+    expect(out).not.toContain('-----BEGIN RSA PRIVATE KEY-----');
+    expect(out).toContain('logs before');
+    expect(out).toContain(REDACTED);
+  });
+
+  // --- Ported patterns from the agent's SanitizeOutput. ---
+  it('redacts AWS access key IDs', () => {
+    const out = redactSecretsFromOutput('key is AKIAIOSFODNN7EXAMPLE here');
+    expect(out).not.toContain('AKIAIOSFODNN7EXAMPLE');
+    expect(out).toContain('[AWS_KEY_REDACTED]');
+  });
+
+  it('redacts bearer tokens', () => {
+    const out = redactSecretsFromOutput('Authorization: Bearer abc123.def-456_XYZ');
+    expect(out).not.toContain('abc123.def-456_XYZ');
+    expect(out).toContain('Bearer [TOKEN_REDACTED]');
+  });
+
+  it('redacts password= / token= / secret= style pairs', () => {
+    const out = redactSecretsFromOutput('DB_PASSWORD=SuperSecret123 and token: abcd1234efgh');
+    expect(out).not.toContain('SuperSecret123');
+    expect(out).not.toContain('abcd1234efgh');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts connection strings', () => {
+    const out = redactSecretsFromOutput('conn postgresql://user:pass@host:5432/db extra');
+    expect(out).not.toContain('user:pass@host');
+    expect(out).toContain('postgresql://[CONNECTION_STRING_REDACTED]');
+  });
+
+  it('redacts JWTs', () => {
+    const jwt =
+      'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+    const out = redactSecretsFromOutput(`JWT ${jwt} done`);
+    expect(out).not.toContain(jwt);
+    expect(out).toContain('[JWT_REDACTED]');
   });
 });

--- a/apps/api/src/services/secretRedaction.ts
+++ b/apps/api/src/services/secretRedaction.ts
@@ -1,0 +1,37 @@
+/**
+ * Server-side secret redaction for agent-reported command output.
+ *
+ * This mirrors the agent-side `SanitizeOutput` private-key rule
+ * (`agent/internal/executor/security.go`) and exists as a defense-in-depth
+ * layer: agent-side redaction only protects output produced by agents that
+ * have already updated, so we ALSO strip private keys here at ingest time so
+ * that pre-update agents (which persist stdout/stderr verbatim) can never
+ * store a reconstructable private key that `scripts:read` users could view.
+ *
+ * The regex removes the ENTIRE PEM block (header + base64 body + footer),
+ * not just the header line. The algorithm token is optional so PKCS#8
+ * `-----BEGIN PRIVATE KEY-----` is covered alongside the
+ * RSA/EC/DSA/OPENSSH/ENCRYPTED forms. The `s` (dotAll) flag lets `.` match
+ * newlines; the non-greedy `*?` stops at the first END marker so two separate
+ * keys in one string are each redacted individually rather than as one span.
+ *
+ * Kept dependency-free and backed by a single precompiled RegExp so it is
+ * cheap to run on every persisted result.
+ */
+const PRIVATE_KEY_BLOCK =
+  /-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/g;
+
+const PRIVATE_KEY_REPLACEMENT = '[PRIVATE_KEY_REDACTED]';
+
+/**
+ * Redacts full PEM private-key blocks from agent output before persistence.
+ *
+ * Returns '' for null/undefined so callers can safely persist the result
+ * without extra null handling.
+ */
+export function redactSecretsFromOutput(text: string | null | undefined): string {
+  if (text === null || text === undefined) {
+    return '';
+  }
+  return text.replace(PRIVATE_KEY_BLOCK, PRIVATE_KEY_REPLACEMENT);
+}

--- a/apps/api/src/services/secretRedaction.ts
+++ b/apps/api/src/services/secretRedaction.ts
@@ -1,37 +1,90 @@
 /**
  * Server-side secret redaction for agent-reported command output.
  *
- * This mirrors the agent-side `SanitizeOutput` private-key rule
+ * This mirrors the agent-side `SanitizeOutput` redaction rules
  * (`agent/internal/executor/security.go`) and exists as a defense-in-depth
  * layer: agent-side redaction only protects output produced by agents that
- * have already updated, so we ALSO strip private keys here at ingest time so
- * that pre-update agents (which persist stdout/stderr verbatim) can never
- * store a reconstructable private key that `scripts:read` users could view.
+ * have already updated, so we ALSO strip secrets here at ingest time so that
+ * pre-update agents (which persist stdout/stderr verbatim) can never store a
+ * reconstructable private key, cloud credential, or bearer token that
+ * `scripts:read` users could later view.
  *
- * The regex removes the ENTIRE PEM block (header + base64 body + footer),
- * not just the header line. The algorithm token is optional so PKCS#8
- * `-----BEGIN PRIVATE KEY-----` is covered alongside the
- * RSA/EC/DSA/OPENSSH/ENCRYPTED forms. The `s` (dotAll) flag lets `.` match
- * newlines; the non-greedy `*?` stops at the first END marker so two separate
- * keys in one string are each redacted individually rather than as one span.
+ * Every pattern is ReDoS-safe: there are no nested quantifiers and any
+ * open-ended span is either a single character class (`[^\s]+`, `[A-Za-z...]*`)
+ * or a length-bounded `[\s\S]{0,N}?` gap, so each match attempt is linear in
+ * the input length even on adversarial, attacker-controlled stdout.
  *
- * Kept dependency-free and backed by a single precompiled RegExp so it is
- * cheap to run on every persisted result.
+ * Private-key handling is a two-pass strategy (order matters):
+ *   1. COMPLETE_PRIVATE_KEY_BLOCK removes a full PEM block (header + body +
+ *      footer). The BEGIN/END gap is bounded to 16 KiB via `[\s\S]{0,16384}?`
+ *      — a PEM private-key body is well under 8 KiB even for RSA-4096, so this
+ *      is safe headroom while keeping the match bounded (the old unbounded
+ *      `[\s\S]*?` backtracked ~O(n²) on many BEGIN markers with no END, which
+ *      blocked the event loop). The optional algorithm token covers PKCS#8
+ *      `-----BEGIN PRIVATE KEY-----` alongside RSA/EC/DSA/OPENSSH/ENCRYPTED.
+ *   2. TRUNCATED_PRIVATE_KEY strips a lone BEGIN header plus any immediately
+ *      following base64/whitespace body when the END marker is missing (output
+ *      truncated by the size cap or a killed process). It runs AFTER pass 1 so
+ *      complete `-----END-----` markers are already consumed. The trailing span
+ *      is a single greedy character class (linear, no nested quantifiers).
+ *
+ * `[\s\S]` (not `.` with a dotAll flag) is what actually matches newlines here;
+ * only the `g` flag is set. Kept dependency-free and backed by precompiled
+ * RegExps so it is cheap to run on every persisted result.
  */
-const PRIVATE_KEY_BLOCK =
-  /-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/g;
 
 const PRIVATE_KEY_REPLACEMENT = '[PRIVATE_KEY_REDACTED]';
 
+// Pass 1: complete PEM block, BEGIN→END gap bounded to 16 KiB (ReDoS-safe).
+const COMPLETE_PRIVATE_KEY_BLOCK =
+  /-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----[\s\S]{0,16384}?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/g;
+
+// Pass 2: truncated key (BEGIN header + base64 body, END missing). Single
+// greedy char-class span = linear, no nested quantifiers.
+const TRUNCATED_PRIVATE_KEY =
+  /-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----[A-Za-z0-9+/=\s]*/g;
+
 /**
- * Redacts full PEM private-key blocks from agent output before persistence.
- *
- * Returns '' for null/undefined so callers can safely persist the result
- * without extra null handling.
+ * Ordered redaction rules mirrored from `SanitizeOutput` in
+ * `agent/internal/executor/security.go`. Applied sequentially in this order so
+ * server-side behavior matches what up-to-date agents already do to their own
+ * output — no new false-positive surface beyond what the fleet already redacts.
  */
-export function redactSecretsFromOutput(text: string | null | undefined): string {
-  if (text === null || text === undefined) {
-    return '';
+const REDACTIONS: ReadonlyArray<{ pattern: RegExp; replacement: string }> = [
+  // api_key/apikey/token/secret/password/passwd/pwd = <value> pairs.
+  {
+    pattern:
+      /(api[_-]?key|apikey|token|secret|password|passwd|pwd)\s*[=:]\s*['"]?[a-zA-Z0-9_-]{8,}['"]?/gi,
+    replacement: '$1=[REDACTED]',
+  },
+  // AWS access key IDs.
+  { pattern: /AKIA[0-9A-Z]{16}/gi, replacement: '[AWS_KEY_REDACTED]' },
+  // Private keys — complete block first, then truncated fallback.
+  { pattern: COMPLETE_PRIVATE_KEY_BLOCK, replacement: PRIVATE_KEY_REPLACEMENT },
+  { pattern: TRUNCATED_PRIVATE_KEY, replacement: PRIVATE_KEY_REPLACEMENT },
+  // Connection strings (mongodb/mysql/postgresql/redis/amqp URIs).
+  {
+    pattern: /(mongodb|mysql|postgresql|redis|amqp):\/\/[^\s]+/gi,
+    replacement: '$1://[CONNECTION_STRING_REDACTED]',
+  },
+  // Bearer tokens.
+  { pattern: /bearer\s+[a-zA-Z0-9_\-.]+/gi, replacement: 'Bearer [TOKEN_REDACTED]' },
+  // JWTs (header.payload.signature).
+  {
+    pattern: /eyJ[a-zA-Z0-9_-]*\.eyJ[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]*/g,
+    replacement: '[JWT_REDACTED]',
+  },
+];
+
+/**
+ * Redacts private-key blocks and other well-known secrets (AWS keys, bearer
+ * tokens, JWTs, connection strings, `secret=`-style pairs) from agent output
+ * before persistence, mirroring the agent's own `SanitizeOutput`.
+ */
+export function redactSecretsFromOutput(text: string): string {
+  let result = text;
+  for (const { pattern, replacement } of REDACTIONS) {
+    result = result.replace(pattern, replacement);
   }
-  return text.replace(PRIVATE_KEY_BLOCK, PRIVATE_KEY_REPLACEMENT);
+  return result;
 }

--- a/apps/api/src/services/tenantLifecycle.test.ts
+++ b/apps/api/src/services/tenantLifecycle.test.ts
@@ -11,6 +11,7 @@ vi.mock('../db/schema', () => ({
   devices: {
     id: 'devices.id',
     orgId: 'devices.orgId',
+    agentId: 'devices.agentId',
     agentTokenSuspendedAt: 'devices.agentTokenSuspendedAt',
     agentTokenSuspendedReason: 'devices.agentTokenSuspendedReason',
   },
@@ -29,11 +30,21 @@ vi.mock('./permissions', () => ({ clearPermissionCache: vi.fn(async () => undefi
 vi.mock('./tokenRevocation', () => ({ revokeAllUserTokens: vi.fn(async () => undefined) }));
 vi.mock('./tenantStatus', () => ({ invalidateAgentTenantCache: vi.fn(async () => undefined) }));
 
+// Finding #3(b): severAgentCredentialsForOrgIds dynamically imports agentWs to
+// sever live sockets. Default: no connected agents, so the disconnect branch is
+// skipped and the existing revoke/restore tests' db.select ordering is
+// untouched. Individual tests override getConnectedAgentIds to exercise it.
+vi.mock('../routes/agentWs', () => ({
+  disconnectAgent: vi.fn(),
+  getConnectedAgentIds: vi.fn(() => [] as string[]),
+}));
+
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args) => ({ and: args })),
   eq: vi.fn((l, r) => ({ eq: [l, r] })),
   inArray: vi.fn((c, vals) => ({ inArray: [c, vals] })),
   isNull: vi.fn((c) => ({ isNull: c })),
+  isNotNull: vi.fn((c) => ({ isNotNull: c })),
   gt: vi.fn((l, r) => ({ gt: [l, r] })),
   or: vi.fn((...args) => ({ or: args })),
   sql: vi.fn(),
@@ -42,6 +53,7 @@ vi.mock('drizzle-orm', () => ({
 import { db } from '../db';
 import { apiKeys, devices, enrollmentKeys } from '../db/schema';
 import { invalidateAgentTenantCache } from './tenantStatus';
+import { disconnectAgent, getConnectedAgentIds } from '../routes/agentWs';
 import {
   revokeOrganizationTenantAccess,
   revokePartnerTenantAccess,
@@ -120,6 +132,30 @@ describe('tenantLifecycle — agent fleet severance', () => {
     expect(invalidateAgentTenantCache).toHaveBeenCalledWith(['org-1']);
     expect(result.agentTokensSuspended).toBe(2);
     expect(result.enrollmentKeysInvalidated).toBe(1);
+  });
+
+  it('severs live agent WS sockets for connected devices in a suspended org (Finding #3b)', async () => {
+    queueSelect([{ userId: 'u1' }]); // organizationUsers
+    queueSelect([{ agentId: 'agent-live' }, { agentId: 'agent-offline' }]); // devices in org
+    // Only one of the two devices has a live socket right now.
+    vi.mocked(getConnectedAgentIds).mockReturnValueOnce(['agent-live']);
+
+    await revokeOrganizationTenantAccess('org-1');
+
+    // The connected agent's socket is force-closed immediately (containment is
+    // not deferred to its next auth gate); the offline device is left alone.
+    expect(disconnectAgent).toHaveBeenCalledTimes(1);
+    expect(disconnectAgent).toHaveBeenCalledWith('agent-live', 4001, 'Tenant suspended');
+  });
+
+  it('does not query devices or disconnect when no agents are connected', async () => {
+    queueSelect([{ userId: 'u1' }]); // organizationUsers
+    // getConnectedAgentIds defaults to [] — the disconnect branch is skipped
+    // entirely (no device SELECT is issued).
+    const result = await revokeOrganizationTenantAccess('org-1');
+
+    expect(disconnectAgent).not.toHaveBeenCalled();
+    expect(result.agentTokensSuspended).toBe(2);
   });
 
   it('revokePartnerTenantAccess severs agents across every org under the partner', async () => {

--- a/apps/api/src/services/tenantLifecycle.ts
+++ b/apps/api/src/services/tenantLifecycle.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, inArray, isNull, or } from 'drizzle-orm';
+import { and, eq, gt, inArray, isNotNull, isNull, or } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { apiKeys, devices, enrollmentKeys, organizationUsers, organizations, partnerUsers } from '../db/schema';
 import { revokeAllOrgOauthArtifacts, revokeAllPartnerOauthArtifacts } from '../oauth/grantRevocation';
@@ -73,6 +73,36 @@ async function severAgentCredentialsForOrgIds(
       )
     )
     .returning({ id: enrollmentKeys.id });
+
+  // Finding #3(b): suspending the token + invalidating the cache only fails the
+  // NEXT auth gate — an already-established agent WS keeps its captured
+  // authorization until it happens to reconnect. Sever live sockets for devices
+  // in the affected orgs so containment is immediate, not eventual.
+  //
+  // agentWs is imported dynamically (not statically): `routes/agentWs` pulls in
+  // a large graph of services, and a static service→route edge here risks an
+  // import cycle. Dynamic import at call time is the established de-cycling
+  // pattern in this repo (agentWs itself dynamically imports its result
+  // handlers). Best-effort: socket teardown must NEVER fail the credential
+  // revocation, which is the load-bearing containment step.
+  try {
+    const { disconnectAgent, getConnectedAgentIds } = await import('../routes/agentWs');
+    const connected = getConnectedAgentIds();
+    if (connected.length > 0) {
+      const connectedSet = new Set(connected);
+      const deviceRows = await db
+        .select({ agentId: devices.agentId })
+        .from(devices)
+        .where(and(inArray(devices.orgId, orgIds), isNotNull(devices.agentId)));
+      for (const row of deviceRows) {
+        if (row.agentId && connectedSet.has(row.agentId)) {
+          disconnectAgent(row.agentId, 4001, 'Tenant suspended');
+        }
+      }
+    }
+  } catch (err) {
+    console.error('[tenantLifecycle] Failed to sever live agent sockets after credential cutoff:', err);
+  }
 
   return {
     agentTokensSuspended: suspended.length,

--- a/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.test.tsx
@@ -94,8 +94,10 @@ describe('AutomationTab — deploy_software action', () => {
       expect(fetchMock).toHaveBeenCalledWith('/software/catalog?limit=100'),
     );
 
-    // Open the picker dropdown and select an entry.
-    fireEvent.click(screen.getByText('Select software...'));
+    // Open the picker dropdown and select an entry. findByText: the picker
+    // shows "Loading..." until the catalog fetch resolves — the waitFor above
+    // only proves the fetch was CALLED, not that the state update flushed.
+    fireEvent.click(await screen.findByText('Select software...'));
     fireEvent.click(await screen.findByText('Google Chrome'));
 
     // Persist and assert the emitted action shape.

--- a/apps/web/src/components/devices/DeviceCompare.tsx
+++ b/apps/web/src/components/devices/DeviceCompare.tsx
@@ -23,6 +23,7 @@ import {
   formatDateTime as formatUserDateTime,
   formatTime as formatUserTime,
 } from "@/lib/dateTimeFormat";
+import { escapeCsvCell } from "@/lib/csvExport";
 import type { Device, DeviceStatus, OSType } from "./DeviceList";
 import { useTranslation } from "react-i18next";
 import "../../lib/i18n";
@@ -580,13 +581,6 @@ function getPatchStatus(patches: PatchItem[], patchName: string): PatchStatus {
   return match?.status ?? "unknown";
 }
 
-function escapeCsv(value: string): string {
-  if (value.includes(",") || value.includes("\n") || value.includes('"')) {
-    return `"${value.replace(/"/g, '""')}"`;
-  }
-  return value;
-}
-
 function escapeHtml(value: string): string {
   return value
     .replace(/&/g, "&amp;")
@@ -1071,8 +1065,10 @@ export default function DeviceCompare({ timezone }: DeviceCompareProps = {}) {
       ]);
     });
 
+    // Neutralize spreadsheet-formula injection from agent-supplied fields
+    // (hostname/cpuModel/software/patch/config values) before quoting.
     const csv = rows
-      .map((row) => row.map((value) => escapeCsv(value ?? "")).join(","))
+      .map((row) => row.map((value) => escapeCsvCell(value ?? "")).join(","))
       .join("\n");
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
     const url = URL.createObjectURL(blob);

--- a/apps/web/src/components/pam/PamAuditTab.test.tsx
+++ b/apps/web/src/components/pam/PamAuditTab.test.tsx
@@ -188,12 +188,28 @@ describe('buildAuditCsv', () => {
     expect(lines[1]).toContain('Allow run_script');
   });
 
-  it('emits empty provenance cells when null', () => {
-    const csv = buildAuditCsv([decided]);
+  it('emits empty (quoted) provenance cells when null', () => {
+    // Use a comma-free reason so a naive split lines up with the header.
+    const csv = buildAuditCsv([{ ...decided, reason: 'Restart spooler' }]);
     const header = csv.split('\n')[0].split(',');
     const row = csv.split('\n')[1].split(',');
     for (const col of ['decisionSource', 'matchedPolicyName', 'pamRuleName']) {
-      expect(row[header.indexOf(col)]).toBe('');
+      // Cells are RFC-4180 quoted by the shared serializer, so empty renders as "".
+      expect(row[header.indexOf(col)]).toBe('""');
     }
+  });
+
+  it('neutralizes spreadsheet-formula injection in agent-supplied fields', () => {
+    const malicious: ElevationRequest = {
+      ...decided,
+      deviceHostname: '=cmd()|/C calc',
+      subjectUsername: '+HYPERLINK("http://evil","click")',
+      reason: '@SUM(1+1)',
+    };
+    const line = buildAuditCsv([malicious]).split('\n')[1];
+    // Leading formula chars are prefixed with a single quote inside the quoted cell.
+    expect(line).toContain('"\'=cmd()|/C calc"');
+    expect(line).toContain('"\'+HYPERLINK(');
+    expect(line).toContain('"\'@SUM(1+1)"');
   });
 });

--- a/apps/web/src/components/pam/PamAuditTab.tsx
+++ b/apps/web/src/components/pam/PamAuditTab.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { formatDateTime } from '@/lib/dateTimeFormat';
+import { escapeCsvCell } from '@/lib/csvExport';
 import {
   type ElevationFlowType,
   type ElevationRequest,
@@ -33,9 +34,9 @@ const FLOW_OPTIONS: Array<ElevationFlowType | ''> = ['', 'uac_intercept', 'tech_
 /** Hard cap on rows fetched for CSV export (10 pages of 100). */
 const EXPORT_MAX_ROWS = 1000;
 
+/** Neutralize spreadsheet-formula injection then RFC-4180-quote an audit cell. */
 function csvEscape(value: unknown): string {
-  const s = value === null || value === undefined ? '' : String(value);
-  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  return escapeCsvCell(value === null || value === undefined ? '' : String(value));
 }
 
 export function buildAuditCsv(rows: ElevationRequest[]): string {

--- a/apps/web/src/components/remote/EventViewer.tsx
+++ b/apps/web/src/components/remote/EventViewer.tsx
@@ -23,6 +23,7 @@ import { cn } from '@/lib/utils';
 import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
+import { toCsv } from '@/lib/csvExport';
 
 // Platform type
 export type Platform = 'windows' | 'macos' | 'linux';
@@ -200,10 +201,12 @@ function exportToCsv(events: EventLogEntry[], filename: string): void {
     e.source,
     String(e.eventId),
     e.category || '',
-    '"' + e.message.replace(/"/g, '""') + '"'
+    e.message
   ]);
-  
-  const csvContent = [headers.join(','), ...rows.map(r => r.join(','))].join('\n');
+
+  // Neutralize spreadsheet-formula injection from agent-supplied fields
+  // (source/category/message) before quoting.
+  const csvContent = toCsv(headers, rows);
   const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
   const link = document.createElement('a');
   link.href = URL.createObjectURL(blob);

--- a/apps/web/src/components/remote/SessionHistoryPage.test.tsx
+++ b/apps/web/src/components/remote/SessionHistoryPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RemoteSession } from './SessionHistory';
 
@@ -21,14 +21,30 @@ const sessionState = vi.hoisted(() => ({
 }));
 
 vi.mock('./SessionHistory', () => ({
-  default: ({ onViewDetails }: { onViewDetails?: (session: RemoteSession) => void }) => (
-    <button
-      type="button"
-      onClick={() => onViewDetails?.({ ...sessionState.session, recordingUrl: sessionState.recordingUrl })}
-    >
-      Open details
-    </button>
+  // Stub the child so tests can drive the page's own callbacks directly: an
+  // "Open details" button (recording-URL safe-href tests) and an "Export"
+  // button that fires the page's real handleExport (CSV export test).
+  default: ({
+    onViewDetails,
+    onExport,
+  }: {
+    onViewDetails?: (session: RemoteSession) => void;
+    onExport?: () => void;
+  }) => (
+    <div>
+      <button
+        type="button"
+        onClick={() => onViewDetails?.({ ...sessionState.session, recordingUrl: sessionState.recordingUrl })}
+      >
+        Open details
+      </button>
+      <button type="button" onClick={() => onExport?.()}>
+        Export
+      </button>
+    </div>
   ),
+  // Identity so the raw API session shape flows straight into handleExport's
+  // CSV row builder.
   normalizeRemoteSession: vi.fn((value: RemoteSession) => value),
 }));
 
@@ -41,6 +57,17 @@ vi.mock('@/lib/navigation', () => ({
 }));
 
 import SessionHistoryPage from './SessionHistoryPage';
+import { fetchWithAuth } from '@/stores/auth';
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function makeJsonResponse(payload: unknown, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
 
 describe('SessionHistoryPage', () => {
   beforeEach(() => {
@@ -66,5 +93,75 @@ describe('SessionHistoryPage', () => {
       'href',
       `${window.location.origin}/recording.mp4`,
     );
+  });
+});
+
+// Regression guard: the CSV export was changed from genuinely-broken hand-rolled
+// quoting (no quote-doubling, no formula neutralization) to the shared
+// `toCsv(...)`. Prove an attacker-influenced session field (deviceHostname /
+// userName are agent-reported) is BOTH formula-neutralized (leading ') and
+// RFC-4180 quoted in the exported blob.
+describe('SessionHistoryPage CSV export', () => {
+  let capturedBlob: Blob | null;
+
+  beforeEach(() => {
+    capturedBlob = null;
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn((blob: Blob) => {
+        capturedBlob = blob;
+        return 'blob:mock';
+      }),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it('neutralizes and RFC-4180-quotes formula injection from agent-supplied fields', async () => {
+    // One page with total=1 so handleExport's pagination loop terminates after
+    // a single fetch. normalizeRemoteSession is the identity stub, so these raw
+    // fields flow straight into the CSV row builder.
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        data: [
+          {
+            id: 'sess-1',
+            deviceId: 'dev-1',
+            deviceHostname: '=cmd()|/C calc', // formula-injection payload
+            deviceOsType: 'windows',
+            userId: 'user-1',
+            userName: 'evil "quote"', // embedded double-quote → must be doubled
+            userEmail: 'evil@example.com',
+            type: 'terminal',
+            status: 'disconnected',
+            startedAt: '2026-06-01T00:00:00.000Z',
+            endedAt: '2026-06-01T00:05:00.000Z',
+            durationSeconds: 300,
+            bytesTransferred: 2048,
+            createdAt: '2026-06-01T00:00:00.000Z',
+          },
+        ],
+        pagination: { total: 1 },
+      }),
+    );
+
+    render(<SessionHistoryPage />);
+
+    fireEvent.click(screen.getByText('Export'));
+
+    await waitFor(() => {
+      expect(capturedBlob).not.toBeNull();
+    });
+
+    const csv = await capturedBlob!.text();
+
+    // Formula char neutralized with a leading single quote AND the cell is quoted.
+    expect(csv).toContain('"\'=cmd()|/C calc"');
+    // Embedded double-quote doubled inside the quoted cell.
+    expect(csv).toContain('"evil ""quote"""');
+    // Header row still present.
+    expect(csv.split('\n')[0]).toContain('Device');
   });
 });

--- a/apps/web/src/components/remote/SessionHistoryPage.tsx
+++ b/apps/web/src/components/remote/SessionHistoryPage.tsx
@@ -8,6 +8,7 @@ import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { formatNumber } from '@/lib/i18n/format';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
+import { toCsv } from '@/lib/csvExport';
 
 type SessionHistoryPageProps = {
   limit?: number;
@@ -66,10 +67,9 @@ export default function SessionHistoryPage({ limit }: SessionHistoryPageProps) {
         s.bytesTransferred || ''
       ]);
 
-      const csvContent = [
-        csvHeaders.join(','),
-        ...rows.map((row: (string | number)[]) => row.map(cell => `"${cell}"`).join(','))
-      ].join('\n');
+      // Neutralize spreadsheet-formula injection from agent-supplied fields
+      // (deviceHostname/userName) before quoting.
+      const csvContent = toCsv(csvHeaders, rows);
 
       // Download CSV
       const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });

--- a/apps/web/src/components/software/SoftwareInventoryView.test.tsx
+++ b/apps/web/src/components/software/SoftwareInventoryView.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SoftwareInventoryView from './SoftwareInventoryView';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+function makeJsonResponse(payload: unknown, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+describe('SoftwareInventoryView CSV export', () => {
+  let capturedBlob: Blob | null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedBlob = null;
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn((blob: Blob) => {
+        capturedBlob = blob;
+        return 'blob:mock';
+      }),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it('neutralizes spreadsheet-formula injection in agent-supplied fields', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        data: [
+          {
+            id: 'inv-1',
+            device: 'WS-ALPHA',
+            software: '=cmd()|/C calc',
+            version: '1.0',
+            vendor: '+HYPERLINK("http://evil","click")',
+            installDate: '2026-06-01T00:00:00.000Z',
+            managed: true,
+          },
+        ],
+      }),
+    );
+
+    render(<SoftwareInventoryView />);
+
+    // Wait for the malicious inventory row to load.
+    await waitFor(() => {
+      expect(screen.getByText('=cmd()|/C calc')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Export CSV'));
+
+    await waitFor(() => {
+      expect(capturedBlob).not.toBeNull();
+    });
+
+    const csv = await capturedBlob!.text();
+    // Leading formula chars are prefixed with a single quote inside the quoted cell.
+    expect(csv).toContain('"\'=cmd()|/C calc"');
+    expect(csv).toContain('"\'+HYPERLINK(');
+    // Header row is still present and safe.
+    expect(csv.split('\n')[0]).toContain('Device');
+  });
+});

--- a/apps/web/src/components/software/SoftwareInventoryView.tsx
+++ b/apps/web/src/components/software/SoftwareInventoryView.tsx
@@ -5,6 +5,8 @@ import { fetchWithAuth } from "../../stores/auth";
 import { ConfirmDialog } from "../shared/ConfirmDialog";
 import { useTranslation } from "react-i18next";
 import { i18n } from "@/lib/i18n";
+import { toCsv } from "@/lib/csvExport";
+
 type InventoryItem = {
   id: string;
   device: string;
@@ -190,7 +192,9 @@ export default function SoftwareInventoryView({
       item.installDate,
       item.managed ? "Yes" : "No",
     ]);
-    const csvContent = [header, ...rows].map((row) => row.join(",")).join("\n");
+    // Neutralize spreadsheet-formula injection from agent-supplied fields
+    // (software/version/vendor) before quoting.
+    const csvContent = toCsv(header, rows);
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");


### PR DESCRIPTION
Hardens the agent→API trust boundary against a **compromised enrolled agent**, from a focused security review. 10 findings (5 HIGH, 5 MEDIUM) were independently verified, then fixed and re-verified.

## Findings & fixes

**HIGH**
- **#1 renew-cert quarantine bypass** — the route read org mTLS policy and wrote device state *after* its DB context closed, so under forced RLS as the unprivileged role those reads/writes silently returned 0 rows and a `quarantine` policy fell back to `auto_reissue`. Now reads policy + all device writes inside `withSystemDbAccessContext`, fails closed on a missing org row or any 0-row write, and only returns cert material after metadata persists (else revokes the issued cert).
- **#2 previous-token self-renewal** — a superseded token (5-min grace) could mint durable new agent/watchdog/helper credentials. Now rejected (401) on both rotate-token and renew-cert; rotate-token UPDATE is a compare-and-swap bound to the authenticating token hash (409, mints nothing, on a losing race).
- **#3 established WS bypass containment** — quarantine and tenant suspension/deletion didn't sever a live agent socket. Now they do; plus a lightweight per-message lifecycle recheck on the command-claim and command-result paths.
- **#4 duplicate WS orphan** — a second socket replaced the tracked one without closing the first, leaving an orphan revocation couldn't reach. Now single-socket-per-agent (superseded socket closed on connect) with connection-identity-guarded ping state.
- **#5 private-key redaction** — the agent regex missed PKCS#8 and left the key body intact. Now removes whole PEM blocks (PKCS#8 + RSA/EC/DSA/OPENSSH/ENCRYPTED), plus a server-side redaction layer at result ingest for pre-update agents.

**MEDIUM**
- **#6** CSV formula-injection — 5 web exporters now neutralize agent-controlled cells via the shared helper.
- **#7** watchdog diagnostics never reached the API (wrong wire shape / status / false "completed"); now speaks the log contract and reports failure honestly.
- **#8** WS command-result completions weren't audited (REST path was); now emit `agent.command.result.submit` once per real transition.
- **#9** `logs.ts` ingest had no audit event; added a content-free one.
- **#10** heartbeat overwrote security-relevant state with no history; now emits `agent.heartbeat.state_change` on genuine transitions only.

## PR-review follow-up (same branch)
A multi-agent review verified the auth cluster clean (no bypass/RLS/silent-mint) and caught issues in the redaction layer, all fixed here: a **ReDoS** in the new server-side redactor (bounded → linear), an unredacted `error` field, truncated-key passthrough, and redaction parity (ported the agent's AWS-key/bearer/JWT/connection-string/secret-pair patterns server-side).

## Verification
- `apps/api` typecheck clean; **171** unit tests pass
- `apps/web` **15** tests pass
- Go build + `-race` (executor / watchdog / breeze-watchdog) pass

## Pre-merge follow-ups (not done here)
1. **Real-Postgres integration test for renew-cert (#1).** The fix's premise — a contextless read returns 0 rows under forced RLS, a system-context read returns the real row — is proven only via mocks. Should be closed with one integration test against real Postgres per the repo's RLS-contract discipline.
2. **Cross-replica socket severance.** `disconnectAgent` is in-process only, so a live socket on another API replica isn't severed immediately on quarantine/tenant-suspension (mitigated by the per-message recheck; matches the existing decommission convention). Fine if prod is single-API-replica per region — worth confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)