### PR TITLE
fix(api): enforce effective request database role (SR1-02)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,14 +12,17 @@ POSTGRES_PASSWORD=breeze_secure_password_change_me
 POSTGRES_DB=breeze
 POSTGRES_PORT=5432
 
-# Full database connection URL (used by API)
+# Administrator/system URL. Required for migrations and role setup; request
+# handlers do not use this connection in production.
 DATABASE_URL=postgresql://breeze:breeze_secure_password_change_me@localhost:5432/breeze
-# Unprivileged application DB role. Created automatically at startup by autoMigrate.
-# Uses the same POSTGRES_PASSWORD as the admin user in dev. Rotate in prod.
+# Exact unprivileged request-pool URL. Production startup probes this connection
+# and refuses SUPERUSER or BYPASSRLS roles. Uses the same POSTGRES_PASSWORD as
+# the admin user in this local example; use distinct strong credentials in prod.
 DATABASE_URL_APP=postgresql://breeze_app:breeze_secure_password_change_me@localhost:5432/breeze
-# Optional: override the breeze_app password. If set, ensureAppRole uses this
-# value; otherwise it falls back to POSTGRES_PASSWORD. The password in
-# DATABASE_URL_APP above must match whichever one is effective.
+# Optional: override the breeze_app password. Without DATABASE_URL_APP, Breeze
+# derives a breeze_app URL from DATABASE_URL using this value, then
+# POSTGRES_PASSWORD as fallback. AUTO_MIGRATE=false skips migrations only; the
+# effective production request role is still verified at startup.
 # BREEZE_APP_DB_PASSWORD=
 
 # --------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -15,9 +15,11 @@ POSTGRES_PORT=5432
 # Administrator/system URL. Required for migrations and role setup; request
 # handlers do not use this connection in production.
 DATABASE_URL=postgresql://breeze:breeze_secure_password_change_me@localhost:5432/breeze
-# Exact unprivileged request-pool URL. Production startup probes this connection
-# and refuses SUPERUSER or BYPASSRLS roles. Uses the same POSTGRES_PASSWORD as
-# the admin user in this local example; use distinct strong credentials in prod.
+# Exact unprivileged request-pool URL for direct API deployments and production
+# deploy Compose. The standard root docker-compose.yml derives this URL inside
+# the API container instead. When supplied explicitly, its password must match
+# BREEZE_APP_DB_PASSWORD when set, or POSTGRES_PASSWORD otherwise. Production
+# startup probes this connection and refuses SUPERUSER or BYPASSRLS roles.
 DATABASE_URL_APP=postgresql://breeze_app:breeze_secure_password_change_me@localhost:5432/breeze
 # Optional: override the breeze_app password. Without DATABASE_URL_APP, Breeze
 # derives a breeze_app URL from DATABASE_URL using this value, then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1037,6 +1037,19 @@ jobs:
           DB_CONTEXTLESS_WRITE_STRICT: 'true'
         run: pnpm --filter=@breeze/api test:integration
 
+      # Dedicated exact-role enforcement runner. The general integration config
+      # excludes it because this suite manages a temporary BYPASSRLS role and
+      # must not inherit the shared TRUNCATE hooks. The preceding suite has
+      # already applied migrations and ensured the breeze_app login exists.
+      - name: Run request database role enforcement tests
+        env:
+          DATABASE_URL: postgresql://breeze_test:breeze_test@localhost:5433/breeze_test
+          DATABASE_URL_APP: postgresql://breeze_app:breeze_test@localhost:5433/breeze_test
+          BREEZE_APP_DB_PASSWORD: breeze_test
+          POSTGRES_PASSWORD: breeze_test
+          NODE_ENV: test
+        run: pnpm --filter=@breeze/api test:request-db-role
+
       # The rls-coverage contract test inspects pg_catalog to verify every
       # tenant-scoped table has policies covering SELECT/INSERT/UPDATE/DELETE
       # via the right access helper. Runs against the same test DB AFTER

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,6 +29,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:integration:watch": "vitest --config vitest.integration.config.ts",
     "test:rls-coverage": "vitest run --config vitest.config.rls-coverage.ts",
+    "test:request-db-role": "vitest run --config vitest.config.request-db-role.ts",
     "test:site-scope-coverage": "vitest run --config vitest.config.site-scope-coverage.ts",
     "test:run": "vitest run"
   },

--- a/apps/api/src/__tests__/integration/setup.ts
+++ b/apps/api/src/__tests__/integration/setup.ts
@@ -23,6 +23,7 @@ import postgres, { type Sql } from 'postgres';
 import Redis, { type RedisOptions } from 'ioredis';
 import * as schema from '../../db/schema';
 import { autoMigrate } from '../../db/autoMigrate';
+import { assertTestDatabaseUrlSafe } from '../../testUtils/integrationDatabaseSafety';
 
 // Load test environment variables
 const DATABASE_URL = process.env.DATABASE_URL || 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
@@ -33,81 +34,11 @@ const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6380';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret-must-be-at-least-32-characters-long';
 process.env.NODE_ENV = 'test';
 
-// Safety guard: cleanupDatabase() runs TRUNCATE CASCADE on core tenant tables
-// (users, partners, organizations, sites, devices, sessions, ...) on beforeEach.
-// Running integration tests against a non-test database will wipe real data —
-// this has happened before. Multiple defenses, all of which must pass before
-// any postgres pool is opened OR any TRUNCATE runs:
-//
-//   1. Database name must be in the allowlist (default: 'breeze_test', plus
-//      anything ending in '_test' so per-feature test DBs work).
-//   2. Hostname must be local (localhost / 127.0.0.1 / breeze-postgres-test).
-//   3. Port must NOT be the default dev port (5432) — test stack uses 5433.
-//   4. Either NODE_ENV=test or BREEZE_TEST_DB_URL is explicitly set to the
-//      same URL as DATABASE_URL (operator opt-in), to make it impossible to
-//      accidentally wipe a dev DB by sourcing the wrong .env.
-//
-// The previous BREEZE_ALLOW_NON_TEST_DB=1 escape hatch has been removed: it
-// existed for "diagnostic runs that don't call cleanupDatabase", but no
-// in-tree caller actually uses that path, and the hatch made the wipe
-// possible with a single env flip.
-const ALLOWED_TEST_DB_NAME_RE = /^breeze_test(_[a-z0-9]+)?$/;
-const FORBIDDEN_PORTS = new Set(['5432']); // default dev/prod postgres port
-const ALLOWED_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'breeze-postgres-test', 'postgres-test']);
-
-function parseDbUrl(connectionUrl: string): { dbName: string; host: string; port: string } | null {
-  try {
-    const u = new URL(connectionUrl);
-    return {
-      dbName: u.pathname.replace(/^\//, ''),
-      host: u.hostname,
-      port: u.port || '5432',
-    };
-  } catch {
-    return null;
-  }
-}
-
-function assertTestDatabase(connectionUrl: string, operation: string): void {
-  const parsed = parseDbUrl(connectionUrl);
-  if (!parsed) {
-    throw new Error(`Integration test ${operation} refused: could not parse connection URL "${connectionUrl}"`);
-  }
-  const { dbName, host, port } = parsed;
-  const failures: string[] = [];
-
-  if (!ALLOWED_TEST_DB_NAME_RE.test(dbName)) {
-    failures.push(`database name "${dbName}" must match /^breeze_test(_[a-z0-9]+)?$/`);
-  }
-  if (FORBIDDEN_PORTS.has(port)) {
-    failures.push(`port "${port}" is the default dev/prod postgres port (test stack uses 5433)`);
-  }
-  if (!ALLOWED_HOSTS.has(host)) {
-    failures.push(`host "${host}" is not in the local-test allowlist (${Array.from(ALLOWED_HOSTS).join(', ')})`);
-  }
-
-  // Operator opt-in: even if everything above passes, require either NODE_ENV=test
-  // OR BREEZE_TEST_DB_URL pointing at this same URL. This makes it impossible
-  // to wipe a dev DB by accidentally exporting the wrong DATABASE_URL.
-  const nodeEnvOk = process.env.NODE_ENV === 'test';
-  const explicitOptIn = process.env.BREEZE_TEST_DB_URL === connectionUrl;
-  if (!nodeEnvOk && !explicitOptIn) {
-    failures.push(
-      `neither NODE_ENV=test nor BREEZE_TEST_DB_URL=${connectionUrl} is set (operator opt-in required)`
-    );
-  }
-
-  if (failures.length > 0) {
-    throw new Error(
-      `Integration test ${operation} refused — DATABASE_URL "${connectionUrl}" failed safety checks:\n` +
-      failures.map((f) => `  - ${f}`).join('\n') +
-      `\n\nIntegration tests run TRUNCATE CASCADE on core tables on beforeEach — running against ` +
-      `a non-test DB will wipe real data. To run locally:\n` +
-      `  1. Start test containers: docker compose -f docker-compose.test.yml up -d\n` +
-      `  2. Run: pnpm test:integration (which sets DATABASE_URL to the test stack)\n`
-    );
-  }
-}
+// Shared safety guard: cleanupDatabase() runs TRUNCATE CASCADE on core tenant
+// tables. It requires a parseable breeze_test(_*) database on a local allowlisted
+// host, a non-default port, and explicit test-mode/operator opt-in before any
+// postgres pool is opened or destructive SQL is run. The dedicated request-role
+// runner uses this same helper so its role DDL cannot drift outside this boundary.
 
 export type TestDatabase = PostgresJsDatabase<typeof schema>;
 
@@ -164,12 +95,12 @@ export function getTestRedis() {
 export async function setupIntegrationTests() {
   // Fail loud if DATABASE_URL points at anything other than a known test DB.
   // This runs before any connection so no client is even opened on a prod/dev DB.
-  assertTestDatabase(DATABASE_URL, 'setup');
+  assertTestDatabaseUrlSafe(DATABASE_URL, 'setup');
   // Same guard for DATABASE_URL_APP: code-under-test connects through the app
   // pool (see `apps/api/src/db/index.ts`), so a misconfigured DATABASE_URL_APP
   // would let `breeze_app` writes land in a dev/prod DB even if DATABASE_URL is
   // correct. Guard both so there is no way to half-configure.
-  assertTestDatabase(DATABASE_URL_APP, 'setup (DATABASE_URL_APP)');
+  assertTestDatabaseUrlSafe(DATABASE_URL_APP, 'setup (DATABASE_URL_APP)');
 
   // Create database connection. This client connects as the superuser
   // (breeze_test) so test helpers can seed and truncate without tripping
@@ -269,7 +200,7 @@ export async function cleanupDatabase() {
   // Defense-in-depth: the same guard fires in setupIntegrationTests, but assert
   // again here in case a future caller invokes cleanupDatabase outside the
   // normal beforeAll path. Wiping a prod/dev DB must require deliberate opt-in.
-  assertTestDatabase(DATABASE_URL, 'cleanupDatabase');
+  assertTestDatabaseUrlSafe(DATABASE_URL, 'cleanupDatabase');
 
   // ml_feedback_events is append-only production data. Clean it explicitly
   // through the retention/erasure bypass GUC instead of relying on an implicit

--- a/apps/api/src/__tests__/integration/setup.ts
+++ b/apps/api/src/__tests__/integration/setup.ts
@@ -95,19 +95,24 @@ export function getTestRedis() {
 export async function setupIntegrationTests() {
   // Fail loud if DATABASE_URL points at anything other than a known test DB.
   // This runs before any connection so no client is even opened on a prod/dev DB.
-  assertTestDatabaseUrlSafe(DATABASE_URL, 'setup');
+  const safeDatabaseUrl = assertTestDatabaseUrlSafe(DATABASE_URL, 'setup');
   // Same guard for DATABASE_URL_APP: code-under-test connects through the app
   // pool (see `apps/api/src/db/index.ts`), so a misconfigured DATABASE_URL_APP
   // would let `breeze_app` writes land in a dev/prod DB even if DATABASE_URL is
   // correct. Guard both so there is no way to half-configure.
-  assertTestDatabaseUrlSafe(DATABASE_URL_APP, 'setup (DATABASE_URL_APP)');
+  const safeAppDatabaseUrl = assertTestDatabaseUrlSafe(
+    DATABASE_URL_APP,
+    'setup (DATABASE_URL_APP)',
+  );
+  process.env.DATABASE_URL = safeDatabaseUrl;
+  process.env.DATABASE_URL_APP = safeAppDatabaseUrl;
 
   // Create database connection. This client connects as the superuser
   // (breeze_test) so test helpers can seed and truncate without tripping
   // RLS. Code-under-test that imports `db` from `apps/api/src/db` goes
   // through a separate pool that connects as `breeze_app` — that's the
   // pool where RLS is actually enforced.
-  testClient = postgres(DATABASE_URL, {
+  testClient = postgres(safeDatabaseUrl, {
     max: 10,
     idle_timeout: 20,
     connect_timeout: 10,
@@ -124,7 +129,7 @@ export async function setupIntegrationTests() {
   // forced RLS is enforced, but bypasses the contextless-write proxy guard
   // (#1379 A1 / #1828) so a deliberate contextless write reaches the DB layer
   // and surfaces the real RLS rejection instead of the guard's throw.
-  appClient = postgres(DATABASE_URL_APP, {
+  appClient = postgres(safeAppDatabaseUrl, {
     max: 5,
     idle_timeout: 20,
     connect_timeout: 10,

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -341,7 +341,9 @@ const envSchema = z
         (v) => !v || v.startsWith('postgres://') || v.startsWith('postgresql://'),
         { message: 'DATABASE_URL_APP must be a valid postgres:// or postgresql:// URL' },
       )
-      .describe('Optional unprivileged application DB connection. If unset, falls back to DATABASE_URL.'),
+      .describe(
+        'Explicit unprivileged request DB connection. If unset, Breeze derives the breeze_app URL using BREEZE_APP_DB_PASSWORD or POSTGRES_PASSWORD; production refuses direct DATABASE_URL fallback.',
+      ),
 
     BREEZE_APP_DB_PASSWORD: z
       .string()

--- a/apps/api/src/db/autoMigrate.test.ts
+++ b/apps/api/src/db/autoMigrate.test.ts
@@ -4,7 +4,6 @@ import {
   hashSql,
   hasNoTransactionDirective,
   splitSqlStatements,
-  deriveAppConnectionString,
   CHECKSUM_RECONCILIATIONS,
   planMigrations,
   partitionLedgerRows,
@@ -69,76 +68,6 @@ describe('autoMigrate', () => {
       `;
       const expected = createHash('sha256').update(sql).digest('hex');
       expect(hashSql(sql)).toBe(expected);
-    });
-  });
-
-  describe('deriveAppConnectionString', () => {
-    it('swaps user and password on a basic URL', () => {
-      const result = deriveAppConnectionString(
-        'postgresql://breeze:secret@db:5432/breeze',
-        'breeze_app',
-        'app_secret',
-      );
-      expect(result).toBe('postgresql://breeze_app:app_secret@db:5432/breeze');
-    });
-
-    it('preserves query params like sslmode', () => {
-      const result = deriveAppConnectionString(
-        'postgresql://breeze:secret@db:5432/breeze?sslmode=require',
-        'breeze_app',
-        'app_secret',
-      );
-      expect(result).toBe('postgresql://breeze_app:app_secret@db:5432/breeze?sslmode=require');
-    });
-
-    it('preserves host and port', () => {
-      const result = deriveAppConnectionString(
-        'postgresql://admin:x@pg.internal.example.com:6432/production',
-        'breeze_app',
-        'pw',
-      );
-      expect(result).toBe('postgresql://breeze_app:pw@pg.internal.example.com:6432/production');
-    });
-
-    it('URL-encodes special characters in the password', () => {
-      const result = deriveAppConnectionString(
-        'postgresql://breeze:x@db:5432/breeze',
-        'breeze_app',
-        'p@ss/word:with spaces',
-      );
-      // The URL class percent-encodes @ / : and space in password position.
-      expect(result).toContain('breeze_app:');
-      // parsed.password returns the raw percent-encoded form; decoding it
-      // should round-trip to the original (that's what postgres-js does
-      // when it parses the connection string).
-      const parsed = new URL(result!);
-      expect(decodeURIComponent(parsed.password)).toBe('p@ss/word:with spaces');
-      expect(parsed.username).toBe('breeze_app');
-    });
-
-    it('returns null when password is undefined', () => {
-      expect(
-        deriveAppConnectionString('postgresql://breeze:x@db:5432/breeze', 'breeze_app', undefined),
-      ).toBeNull();
-    });
-
-    it('returns null when password is empty string', () => {
-      expect(
-        deriveAppConnectionString('postgresql://breeze:x@db:5432/breeze', 'breeze_app', ''),
-      ).toBeNull();
-    });
-
-    it('returns null when admin URL is unparseable', () => {
-      expect(deriveAppConnectionString('not a url', 'breeze_app', 'pw')).toBeNull();
-    });
-
-    it('works with postgres:// scheme as well as postgresql://', () => {
-      const result = deriveAppConnectionString(
-        'postgres://breeze:secret@db:5432/breeze',
-        'breeze_app',
-        'app_secret',
-      );
-      expect(result).toBe('postgres://breeze_app:app_secret@db:5432/breeze');
     });
   });
 

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -245,30 +245,6 @@ export function splitSqlStatements(content: string): string[] {
 }
 
 /**
- * Build a connection string for the unprivileged `breeze_app` role by taking
- * an admin DATABASE_URL and swapping in the app user+password. Returns null
- * if no password is available or the admin URL can't be parsed — callers
- * should treat null as "cannot auto-configure, require DATABASE_URL_APP".
- *
- * Exported for unit testing.
- */
-export function deriveAppConnectionString(
-  adminUrl: string,
-  appUser: string,
-  appPassword: string | undefined,
-): string | null {
-  if (!appPassword) return null;
-  try {
-    const url = new URL(adminUrl);
-    url.username = appUser;
-    url.password = appPassword;
-    return url.toString();
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Determine the database state based on whether key tables exist.
  *
  * - `fresh`  — no `users` table → run every migration from scratch
@@ -566,54 +542,6 @@ export async function autoMigrate(): Promise<void> {
     // ── 7b. Re-run ensureAppRole so any tables created in step 7 receive
     //        the standard privilege grants. Idempotent.
     await ensureAppRole();
-
-    // Resolve the app connection string. Preference order:
-    //   1. DATABASE_URL_APP (explicit, operator-provided)
-    //   2. Derived from DATABASE_URL by swapping user → breeze_app and
-    //      password → BREEZE_APP_DB_PASSWORD / POSTGRES_PASSWORD
-    //   3. DATABASE_URL itself — but the probe below will then hard-fail
-    //      because that's the superuser connection
-    const explicitAppUrl = process.env.DATABASE_URL_APP;
-    const derivedAppUrl = explicitAppUrl
-      ? null
-      : deriveAppConnectionString(
-          connectionString,
-          'breeze_app',
-          process.env.BREEZE_APP_DB_PASSWORD || process.env.POSTGRES_PASSWORD,
-        );
-    if (!explicitAppUrl && derivedAppUrl) {
-      console.log(
-        '[auto-migrate] DATABASE_URL_APP not set — derived unprivileged app connection from DATABASE_URL',
-      );
-    }
-    const appConnString = explicitAppUrl || derivedAppUrl || connectionString;
-
-    const appClient = postgres(appConnString, { max: 1 });
-    try {
-      const rows = await appClient`
-        SELECT current_user AS "user", rolsuper, rolbypassrls
-        FROM pg_roles
-        WHERE rolname = current_user
-      `;
-      const me = rows[0];
-      if (!me) {
-        throw new Error(
-          'App DB role verification returned no row for current_user — cannot confirm RLS enforcement. Refusing to start.',
-        );
-      }
-      console.log(
-        `[auto-migrate] App DB user: ${me.user} (super=${me.rolsuper}, bypassrls=${me.rolbypassrls})`,
-      );
-      if (me.rolbypassrls || me.rolsuper) {
-        throw new Error(
-          `App DB user "${me.user}" has BYPASSRLS or SUPERUSER — RLS policies would not be enforced. `
-            + 'Refusing to start. Either set DATABASE_URL_APP to a non-superuser connection string, '
-            + 'or set BREEZE_APP_DB_PASSWORD / POSTGRES_PASSWORD so the app URL can be derived automatically.',
-        );
-      }
-    } finally {
-      await appClient.end();
-    }
 
     // ── 8. Auto-seed if no users exist ───────────────────────────────────
     const userCheck = await client`SELECT id FROM users LIMIT 1`;

--- a/apps/api/src/db/databaseStartup.test.ts
+++ b/apps/api/src/db/databaseStartup.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { initializeDatabaseForStartup } from './databaseStartup';
+
+describe('initializeDatabaseForStartup', () => {
+  it('verifies the production request role when AUTO_MIGRATE=false', async () => {
+    const migrate = vi.fn();
+    const verifyRequestRole = vi.fn().mockRejectedValue(new Error('unsafe request role'));
+
+    await expect(
+      initializeDatabaseForStartup({
+        autoMigrateEnabled: false,
+        production: true,
+        migrate,
+        verifyRequestRole,
+      }),
+    ).rejects.toThrow('unsafe request role');
+
+    expect(migrate).not.toHaveBeenCalled();
+    expect(verifyRequestRole).toHaveBeenCalledOnce();
+  });
+
+  it('runs migrations before verifying the production request role', async () => {
+    const calls: string[] = [];
+    const migrate = vi.fn(async () => {
+      calls.push('migrate');
+    });
+    const verifyRequestRole = vi.fn(async () => {
+      calls.push('verify');
+      return {
+        currentUser: 'breeze_app',
+        isSuperuser: false,
+        bypassesRls: false,
+      };
+    });
+
+    await initializeDatabaseForStartup({
+      autoMigrateEnabled: true,
+      production: true,
+      migrate,
+      verifyRequestRole,
+    });
+
+    expect(calls).toEqual(['migrate', 'verify']);
+  });
+
+  it('runs enabled migrations without probing the request role outside production', async () => {
+    const migrate = vi.fn();
+    const verifyRequestRole = vi.fn();
+
+    await initializeDatabaseForStartup({
+      autoMigrateEnabled: true,
+      production: false,
+      migrate,
+      verifyRequestRole,
+    });
+
+    expect(migrate).toHaveBeenCalledOnce();
+    expect(verifyRequestRole).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when migrations are disabled outside production', async () => {
+    const migrate = vi.fn();
+    const verifyRequestRole = vi.fn();
+
+    await initializeDatabaseForStartup({
+      autoMigrateEnabled: false,
+      production: false,
+      migrate,
+      verifyRequestRole,
+    });
+
+    expect(migrate).not.toHaveBeenCalled();
+    expect(verifyRequestRole).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/db/databaseStartup.ts
+++ b/apps/api/src/db/databaseStartup.ts
@@ -1,0 +1,34 @@
+import type { RequestDatabaseRole } from './index';
+
+export interface DatabaseStartupOptions {
+  autoMigrateEnabled: boolean;
+  production: boolean;
+  migrate?: () => Promise<void>;
+  verifyRequestRole?: () => Promise<RequestDatabaseRole>;
+}
+
+/**
+ * Runs database startup work in its security-sensitive order: migrations may
+ * create/configure the request role, then production verifies the exact pool
+ * that will serve requests. Disabling migrations never disables verification.
+ */
+export async function initializeDatabaseForStartup(
+  options: DatabaseStartupOptions,
+): Promise<void> {
+  const migrate = options.migrate ?? (async () => {
+    const { autoMigrate } = await import('./autoMigrate');
+    await autoMigrate();
+  });
+  const verifyRequestRole = options.verifyRequestRole ?? (async () => {
+    const { assertRequestDatabaseRoleSafe } = await import('./index');
+    return assertRequestDatabaseRoleSafe();
+  });
+
+  if (options.autoMigrateEnabled) {
+    await migrate();
+  }
+
+  if (options.production) {
+    await verifyRequestRole();
+  }
+}

--- a/apps/api/src/db/ensureAppRole.ts
+++ b/apps/api/src/db/ensureAppRole.ts
@@ -41,9 +41,9 @@ export async function ensureAppRole(): Promise<void> {
     //    "ERROR: permission denied to alter role / Only roles with the
     //    SUPERUSER attribute may change the SUPERUSER attribute."
     //    The role was created with the right attributes on first run;
-    //    there is nothing to reconcile on subsequent runs. The probe in
-    //    autoMigrate already verifies rolsuper=false / rolbypassrls=false
-    //    and hard-fails startup if either has drifted.
+    //    there is nothing to reconcile on subsequent runs. Production startup
+    //    enforcement probes the effective request pool role and hard-fails if
+    //    rolsuper or rolbypassrls has drifted (see databaseStartup.ts).
     await client.unsafe(`
       DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'breeze_app') THEN

--- a/apps/api/src/db/ensureAppRole.ts
+++ b/apps/api/src/db/ensureAppRole.ts
@@ -1,4 +1,5 @@
 import postgres from 'postgres';
+import { getAppDatabasePassword } from './requestDatabaseConfig';
 
 /**
  * Ensures a non-superuser, non-BYPASSRLS role `breeze_app` exists and has the
@@ -17,8 +18,7 @@ export async function ensureAppRole(): Promise<void> {
 
   // The password the breeze_app role should be (re)set to. In dev we fall back
   // to POSTGRES_PASSWORD so the same password works for both admin and app.
-  const password =
-    process.env.BREEZE_APP_DB_PASSWORD || process.env.POSTGRES_PASSWORD || '';
+  const password = getAppDatabasePassword() || '';
 
   if (!password) {
     console.warn(

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -37,6 +37,59 @@ const client = postgres(requestDatabaseConfig.url, {
   max_lifetime: 60 * 30,
   connect_timeout: 10,
 });
+
+export interface RequestDatabaseRole {
+  currentUser: string;
+  isSuperuser: boolean;
+  bypassesRls: boolean;
+}
+
+const REQUEST_DATABASE_ROLE_REMEDIATION =
+  'Set DATABASE_URL_APP to a NOSUPERUSER NOBYPASSRLS role, or configure ' +
+  'BREEZE_APP_DB_PASSWORD/POSTGRES_PASSWORD so Breeze can derive the breeze_app URL.';
+
+/**
+ * Reads the effective role from the exact module-scope postgres.js client that
+ * backs `db`. This must not use a separate probe connection: startup is proving
+ * the identity and RLS capabilities of the pool that will serve requests.
+ */
+export async function getRequestDatabaseRole(): Promise<RequestDatabaseRole> {
+  const rows = await client`
+    SELECT current_user AS "currentUser",
+           rolsuper AS "isSuperuser",
+           rolbypassrls AS "bypassesRls"
+    FROM pg_roles
+    WHERE rolname = current_user
+  `;
+  const role = rows[0] as RequestDatabaseRole | undefined;
+
+  if (!role) {
+    throw new Error(
+      '[database] Could not verify the effective request database role: ' +
+        `pg_roles returned no row for current_user. ${REQUEST_DATABASE_ROLE_REMEDIATION}`,
+    );
+  }
+
+  return role;
+}
+
+export async function assertRequestDatabaseRoleSafe(): Promise<RequestDatabaseRole> {
+  const role = await getRequestDatabaseRole();
+  const unsafeCapabilities: string[] = [];
+  if (role.isSuperuser) unsafeCapabilities.push('SUPERUSER');
+  if (role.bypassesRls) unsafeCapabilities.push('BYPASSRLS');
+
+  if (unsafeCapabilities.length > 0) {
+    throw new Error(
+      `[database] Unsafe effective request database role "${role.currentUser}": ` +
+        `${unsafeCapabilities.join(' and ')}. Request handlers require a ` +
+        `NOSUPERUSER NOBYPASSRLS role. ${REQUEST_DATABASE_ROLE_REMEDIATION}`,
+    );
+  }
+
+  return role;
+}
+
 const baseDb = drizzle(client, { schema });
 const dbContextStorage = new AsyncLocalStorage<typeof baseDb>();
 // Parallel store holding the DbAccessContext METADATA (scope + allowlists) for

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -9,16 +9,13 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from './schema';
 import { captureMessage } from '../services/sentry';
-import { resolveRequestDatabaseConfig } from './requestDatabaseConfig';
+import {
+  logRequestDatabaseConfigSource,
+  resolveRequestDatabaseConfig,
+} from './requestDatabaseConfig';
 
 const requestDatabaseConfig = resolveRequestDatabaseConfig();
-const requestDatabaseLog =
-  `[database] Request pool configuration source: ${requestDatabaseConfig.source}`;
-if (requestDatabaseConfig.source === 'development-fallback') {
-  console.warn(requestDatabaseLog);
-} else {
-  console.log(requestDatabaseLog);
-}
+logRequestDatabaseConfigSource(requestDatabaseConfig);
 
 // Pool sizing: postgres-js defaults to max=10, which causes cascading 504s
 // under heartbeat storms (e.g. a 1000-agent fleet reconnecting at once).

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -9,15 +9,16 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from './schema';
 import { captureMessage } from '../services/sentry';
+import { resolveRequestDatabaseConfig } from './requestDatabaseConfig';
 
-// Prefer DATABASE_URL_APP (the unprivileged breeze_app role) so RLS policies
-// are actually enforced. Fall back to DATABASE_URL for backward compatibility
-// with existing deployments; autoMigrate will warn loudly if that connection
-// has BYPASSRLS/SUPERUSER.
-const connectionString =
-  process.env.DATABASE_URL_APP
-  || process.env.DATABASE_URL
-  || 'postgresql://breeze:breeze@localhost:5432/breeze';
+const requestDatabaseConfig = resolveRequestDatabaseConfig();
+const requestDatabaseLog =
+  `[database] Request pool configuration source: ${requestDatabaseConfig.source}`;
+if (requestDatabaseConfig.source === 'development-fallback') {
+  console.warn(requestDatabaseLog);
+} else {
+  console.log(requestDatabaseLog);
+}
 
 // Pool sizing: postgres-js defaults to max=10, which causes cascading 504s
 // under heartbeat storms (e.g. a 1000-agent fleet reconnecting at once).
@@ -30,7 +31,7 @@ function getDbPoolMax(): number {
   return raw;
 }
 
-const client = postgres(connectionString, {
+const client = postgres(requestDatabaseConfig.url, {
   max: getDbPoolMax(),
   idle_timeout: 20,
   max_lifetime: 60 * 30,

--- a/apps/api/src/db/requestDatabaseCompose.test.ts
+++ b/apps/api/src/db/requestDatabaseCompose.test.ts
@@ -1,0 +1,73 @@
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPOSITORY_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../..',
+);
+const IMAGE_DIGEST = `example.invalid/breeze@sha256:${'0'.repeat(64)}`;
+
+function renderApiEnvironment(appPassword: string): Record<string, string> {
+  const rendered = execFileSync(
+    'docker',
+    [
+      'compose',
+      '--project-directory',
+      REPOSITORY_ROOT,
+      '-f',
+      path.join(REPOSITORY_ROOT, 'docker-compose.yml'),
+      'config',
+      '--format',
+      'json',
+    ],
+    {
+      cwd: REPOSITORY_ROOT,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        AGENT_ENROLLMENT_SECRET: 'compose-agent-enrollment-secret',
+        APP_ENCRYPTION_KEY: 'compose-app-encryption-key',
+        BREEZE_API_IMAGE_REF: IMAGE_DIGEST,
+        BREEZE_APP_DB_PASSWORD: appPassword,
+        BREEZE_BINARIES_IMAGE_REF: IMAGE_DIGEST,
+        BREEZE_DOMAIN: 'breeze.example.test',
+        BREEZE_PORTAL_IMAGE_REF: IMAGE_DIGEST,
+        BREEZE_VERSION: 'test-version',
+        BREEZE_WEB_IMAGE_REF: IMAGE_DIGEST,
+        CADDY_IMAGE_REF: IMAGE_DIGEST,
+        COTURN_IMAGE_REF: IMAGE_DIGEST,
+        ENROLLMENT_KEY_PEPPER: 'compose-enrollment-key-pepper',
+        JWT_SECRET: 'compose-jwt-secret',
+        MFA_ENCRYPTION_KEY: 'compose-mfa-encryption-key',
+        MFA_RECOVERY_CODE_PEPPER: 'compose-mfa-recovery-code-pepper',
+        POSTGRES_IMAGE_REF: IMAGE_DIGEST,
+        POSTGRES_PASSWORD: 'compose-postgres-password',
+        REDIS_IMAGE_REF: IMAGE_DIGEST,
+        TURN_SECRET: 'compose-turn-secret',
+      },
+    },
+  );
+  const config = JSON.parse(rendered) as {
+    services: { api: { environment: Record<string, string> } };
+  };
+  return config.services.api.environment;
+}
+
+describe('standard Compose request database configuration', () => {
+  it('derives the request URL from POSTGRES_PASSWORD by default', () => {
+    const environment = renderApiEnvironment('');
+
+    expect(Object.hasOwn(environment, 'DATABASE_URL_APP')).toBe(false);
+    expect(environment.POSTGRES_PASSWORD === 'compose-postgres-password').toBe(true);
+  });
+
+  it('derives the request URL from BREEZE_APP_DB_PASSWORD when overridden', () => {
+    const environment = renderApiEnvironment('compose-app-role-password');
+
+    expect(Object.hasOwn(environment, 'DATABASE_URL_APP')).toBe(false);
+    expect(environment.BREEZE_APP_DB_PASSWORD === 'compose-app-role-password').toBe(true);
+    expect(environment.POSTGRES_PASSWORD === 'compose-postgres-password').toBe(true);
+  });
+});

--- a/apps/api/src/db/requestDatabaseConfig.test.ts
+++ b/apps/api/src/db/requestDatabaseConfig.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveAppConnectionString,
+  resolveRequestDatabaseConfig,
+} from './requestDatabaseConfig';
+
+describe('requestDatabaseConfig', () => {
+  describe('deriveAppConnectionString', () => {
+    it('derives the breeze_app URL from the admin URL and app password', () => {
+      expect(
+        deriveAppConnectionString(
+          'postgresql://admin:admin-secret@db:5432/breeze',
+          'request-secret',
+        ),
+      ).toBe('postgresql://breeze_app:request-secret@db:5432/breeze');
+    });
+
+    it('preserves query parameters, host, port, database, and scheme', () => {
+      expect(
+        deriveAppConnectionString(
+          'postgres://admin:admin-secret@request-db:6432/production?sslmode=require',
+          'request-secret',
+        ),
+      ).toBe(
+        'postgres://breeze_app:request-secret@request-db:6432/production?sslmode=require',
+      );
+    });
+
+    it('URL-encodes special characters in the password', () => {
+      const result = deriveAppConnectionString(
+        'postgresql://admin:admin-secret@db:5432/breeze',
+        'p@ss/word:with spaces',
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = new URL(result!);
+      expect(parsed.username).toBe('breeze_app');
+      expect(decodeURIComponent(parsed.password)).toBe('p@ss/word:with spaces');
+    });
+
+    it('returns null without a password', () => {
+      expect(
+        deriveAppConnectionString('postgresql://admin:admin-secret@db:5432/breeze', undefined),
+      ).toBeNull();
+      expect(
+        deriveAppConnectionString('postgresql://admin:admin-secret@db:5432/breeze', ''),
+      ).toBeNull();
+    });
+
+    it('returns null for a malformed admin URL', () => {
+      expect(deriveAppConnectionString('not a url', 'request-secret')).toBeNull();
+    });
+  });
+
+  describe('resolveRequestDatabaseConfig', () => {
+    it('derives the request URL using BREEZE_APP_DB_PASSWORD', () => {
+      expect(
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL: 'postgresql://admin:admin-secret@db:5432/breeze',
+          BREEZE_APP_DB_PASSWORD: 'request-secret',
+        }).url,
+      ).toBe('postgresql://breeze_app:request-secret@db:5432/breeze');
+    });
+
+    it('prefers an explicit request URL', () => {
+      expect(
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL: 'postgresql://admin:admin-secret@db:5432/breeze',
+          DATABASE_URL_APP:
+            'postgresql://explicit:explicit-secret@request-db:6432/breeze?sslmode=require',
+          BREEZE_APP_DB_PASSWORD: 'ignored',
+        }),
+      ).toEqual({
+        url: 'postgresql://explicit:explicit-secret@request-db:6432/breeze?sslmode=require',
+        source: 'explicit',
+      });
+    });
+
+    it('derives the request URL using POSTGRES_PASSWORD', () => {
+      expect(
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL: 'postgresql://admin:admin-secret@db:5432/breeze',
+          POSTGRES_PASSWORD: 'postgres-secret',
+        }),
+      ).toEqual({
+        url: 'postgresql://breeze_app:postgres-secret@db:5432/breeze',
+        source: 'derived',
+      });
+    });
+
+    it('refuses a production request pool without an unprivileged URL or password', () => {
+      expect(() =>
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL: 'postgresql://admin:admin-secret@db:5432/breeze',
+        }),
+      ).toThrow(/DATABASE_URL_APP.*BREEZE_APP_DB_PASSWORD.*POSTGRES_PASSWORD/);
+    });
+
+    it('refuses a production request pool when DATABASE_URL is malformed', () => {
+      expect(() =>
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL: 'not a url',
+          BREEZE_APP_DB_PASSWORD: 'request-secret',
+        }),
+      ).toThrow(/DATABASE_URL_APP.*BREEZE_APP_DB_PASSWORD.*POSTGRES_PASSWORD/);
+    });
+
+    it('returns the warned non-production compatibility fallback', () => {
+      expect(
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'development',
+          DATABASE_URL: 'postgresql://admin:admin-secret@db:5432/breeze',
+        }),
+      ).toEqual({
+        url: 'postgresql://admin:admin-secret@db:5432/breeze',
+        source: 'development-fallback',
+      });
+    });
+  });
+});

--- a/apps/api/src/db/requestDatabaseConfig.test.ts
+++ b/apps/api/src/db/requestDatabaseConfig.test.ts
@@ -135,6 +135,31 @@ describe('requestDatabaseConfig', () => {
       }
     });
 
+    it.each([
+      'postgresql://request-user:request-password@db-one%2Cdb-two/breeze',
+      'postgresql://request-user:request-password@db-one%2cdb-two%3A6432/breeze',
+    ])('rejects an explicit encoded multi-host request URL without leaking credentials: %s', (url) => {
+      expect(() =>
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL_APP: url,
+        }),
+      ).toThrow(/DATABASE_URL_APP.*single database\/HA endpoint/i);
+
+      try {
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL_APP: url,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message).not.toContain('request-user');
+        expect(message).not.toContain('request-password');
+        expect(message).not.toContain('db-one');
+        expect(message).not.toContain('db-two');
+      }
+    });
+
     it('derives the request URL using POSTGRES_PASSWORD', () => {
       expect(
         resolveRequestDatabaseConfig({
@@ -173,6 +198,34 @@ describe('requestDatabaseConfig', () => {
           BREEZE_APP_DB_PASSWORD: 'request-secret',
         }),
       ).toThrow(/single database\/HA endpoint/i);
+
+      try {
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL: url,
+          BREEZE_APP_DB_PASSWORD: 'request-secret',
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message).not.toContain('admin');
+        expect(message).not.toContain('admin-secret');
+        expect(message).not.toContain('request-secret');
+        expect(message).not.toContain('db-one');
+        expect(message).not.toContain('db-two');
+      }
+    });
+
+    it.each([
+      'postgresql://admin:admin-secret@db-one%2Cdb-two/breeze',
+      'postgresql://admin:admin-secret@db-one%2cdb-two:5432/breeze',
+    ])('rejects a derived encoded multi-host request URL without leaking credentials: %s', (url) => {
+      expect(() =>
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL: url,
+          BREEZE_APP_DB_PASSWORD: 'request-secret',
+        }),
+      ).toThrow(/DATABASE_URL.*single database\/HA endpoint/i);
 
       try {
         resolveRequestDatabaseConfig({

--- a/apps/api/src/db/requestDatabaseConfig.test.ts
+++ b/apps/api/src/db/requestDatabaseConfig.test.ts
@@ -30,13 +30,13 @@ describe('requestDatabaseConfig', () => {
     it('URL-encodes special characters in the password', () => {
       const result = deriveAppConnectionString(
         'postgresql://admin:admin-secret@db:5432/breeze',
-        'p@ss/word:with spaces',
+        'p@ss/word:with % spaces',
       );
 
       expect(result).not.toBeNull();
       const parsed = new URL(result!);
       expect(parsed.username).toBe('breeze_app');
-      expect(decodeURIComponent(parsed.password)).toBe('p@ss/word:with spaces');
+      expect(decodeURIComponent(parsed.password)).toBe('p@ss/word:with % spaces');
     });
 
     it('returns null without a password', () => {
@@ -75,6 +75,19 @@ describe('requestDatabaseConfig', () => {
         }),
       ).toEqual({
         url: 'postgresql://explicit:explicit-secret@request-db:6432/breeze?sslmode=require',
+        source: 'explicit',
+      });
+    });
+
+    it('returns the canonical explicit single-endpoint URL with query parameters', () => {
+      expect(
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL_APP:
+            'POSTGRESQL://request-user:request-password@localhost:55432/breeze?sslmode=require',
+        }),
+      ).toEqual({
+        url: 'postgresql://request-user:request-password@localhost:55432/breeze?sslmode=require',
         source: 'explicit',
       });
     });
@@ -157,6 +170,44 @@ describe('requestDatabaseConfig', () => {
         expect(message).not.toContain('request-password');
         expect(message).not.toContain('db-one');
         expect(message).not.toContain('db-two');
+      }
+    });
+
+    it.each([
+      [
+        'an encoded-comma authority before a second raw at-sign',
+        'postgresql://request-user:request-password@primary%2Cunsafe%2Cignored@safe/breeze',
+      ],
+      [
+        'a literal extra raw at-sign in the authority',
+        'postgresql://request-user:request-password@unsafe@safe/breeze',
+      ],
+      [
+        'a fragment containing encoded host material',
+        'postgresql://request-user:request-password@safe:5432/breeze#primary%2Cunsafe%2Cignored',
+      ],
+    ])('rejects explicit parser-differential payloads without leaking input: %s', (_case, url) => {
+      let caught: unknown;
+      try {
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL_APP: url,
+        });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      const message = caught instanceof Error ? caught.message : String(caught);
+      expect(message).toMatch(/DATABASE_URL_APP.*single database\/HA endpoint/i);
+      for (const secret of [
+        'request-user',
+        'request-password',
+        'primary',
+        'unsafe',
+        'safe',
+      ]) {
+        expect(message).not.toContain(secret);
       }
     });
 
@@ -243,6 +294,38 @@ describe('requestDatabaseConfig', () => {
       }
     });
 
+    it.each([
+      'postgresql://admin-user:admin-password@primary%2Cunsafe%2Cignored@safe/breeze',
+      'postgresql://admin-user:admin-password@unsafe@safe/breeze',
+      'postgresql://admin-user:admin-password@safe:5432/breeze#primary%2Cunsafe%2Cignored',
+    ])('rejects a derived parser differential without leaking input: %s', (url) => {
+      let caught: unknown;
+
+      try {
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL: url,
+          BREEZE_APP_DB_PASSWORD: 'request-password',
+        });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      const message = caught instanceof Error ? caught.message : String(caught);
+      expect(message).toMatch(/DATABASE_URL.*single database\/HA endpoint/i);
+      for (const secret of [
+        'admin-user',
+        'admin-password',
+        'request-password',
+        'primary',
+        'unsafe',
+        'safe',
+      ]) {
+        expect(message).not.toContain(secret);
+      }
+    });
+
     it('refuses a production request pool without an unprivileged URL or password', () => {
       expect(() =>
         resolveRequestDatabaseConfig({
@@ -259,7 +342,7 @@ describe('requestDatabaseConfig', () => {
           DATABASE_URL: 'not a url',
           BREEZE_APP_DB_PASSWORD: 'request-secret',
         }),
-      ).toThrow(/DATABASE_URL_APP.*BREEZE_APP_DB_PASSWORD.*POSTGRES_PASSWORD/);
+      ).toThrow(/DATABASE_URL.*valid PostgreSQL URL.*single database\/HA endpoint/i);
     });
 
     it('returns the warned non-production compatibility fallback', () => {
@@ -273,6 +356,35 @@ describe('requestDatabaseConfig', () => {
         source: 'development-fallback',
       });
     });
+
+    it.each(['development', 'test'])(
+      'rejects a malformed %s fallback URL with a fixed redacted error',
+      (nodeEnv) => {
+        const username = 'fallback-user';
+        const password = 'fallback-password';
+        const host = 'fallback-host';
+        let caught: unknown;
+
+        try {
+          resolveRequestDatabaseConfig({
+            NODE_ENV: nodeEnv,
+            DATABASE_URL:
+              `postgresql://${username}:${password}@${host}:not-a-port/breeze`,
+          });
+        } catch (error) {
+          caught = error;
+        }
+
+        expect(caught).toBeInstanceOf(Error);
+        const message = caught instanceof Error ? caught.message : String(caught);
+        expect(message).toBe(
+          '[database] DATABASE_URL is invalid. Configure a valid PostgreSQL URL for a single database/HA endpoint.',
+        );
+        expect(message).not.toContain(username);
+        expect(message).not.toContain(password);
+        expect(message).not.toContain(host);
+      },
+    );
   });
 
   describe('logRequestDatabaseConfigSource', () => {

--- a/apps/api/src/db/requestDatabaseConfig.test.ts
+++ b/apps/api/src/db/requestDatabaseConfig.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   deriveAppConnectionString,
+  logRequestDatabaseConfigSource,
   resolveRequestDatabaseConfig,
 } from './requestDatabaseConfig';
 
@@ -78,6 +79,62 @@ describe('requestDatabaseConfig', () => {
       });
     });
 
+    it('rejects a malformed explicit request URL without leaking credentials', () => {
+      const username = 'request-url-user';
+      const password = 'request-url-password';
+
+      expect(() =>
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL_APP:
+            `postgresql://${username}:${password}@request-db:not-a-port/breeze`,
+        }),
+      ).toThrowError(
+        expect.objectContaining({
+          message: expect.not.stringContaining(username),
+        }),
+      );
+
+      try {
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL_APP:
+            `postgresql://${username}:${password}@request-db:not-a-port/breeze`,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message).toMatch(/DATABASE_URL_APP.*valid.*single database\/HA endpoint/i);
+        expect(message).not.toContain(username);
+        expect(message).not.toContain(password);
+        expect(message).not.toContain('request-db:not-a-port');
+      }
+    });
+
+    it.each([
+      'postgresql://request-user:request-password@db-one,db-two/breeze',
+      'postgresql://request-user:request-password@db-one:5432,db-two:5432/breeze',
+    ])('rejects an explicit multi-host request URL without leaking credentials: %s', (url) => {
+      expect(() =>
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL_APP: url,
+        }),
+      ).toThrow(/DATABASE_URL_APP.*single database\/HA endpoint/i);
+
+      try {
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL_APP: url,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message).not.toContain('request-user');
+        expect(message).not.toContain('request-password');
+        expect(message).not.toContain('db-one');
+        expect(message).not.toContain('db-two');
+      }
+    });
+
     it('derives the request URL using POSTGRES_PASSWORD', () => {
       expect(
         resolveRequestDatabaseConfig({
@@ -89,6 +146,48 @@ describe('requestDatabaseConfig', () => {
         url: 'postgresql://breeze_app:postgres-secret@db:5432/breeze',
         source: 'derived',
       });
+    });
+
+    it('prefers BREEZE_APP_DB_PASSWORD when both app password sources are present', () => {
+      expect(
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL: 'postgresql://admin:admin-secret@db:5432/breeze',
+          BREEZE_APP_DB_PASSWORD: 'app-specific-secret',
+          POSTGRES_PASSWORD: 'shared-postgres-secret',
+        }),
+      ).toEqual({
+        url: 'postgresql://breeze_app:app-specific-secret@db:5432/breeze',
+        source: 'derived',
+      });
+    });
+
+    it.each([
+      'postgresql://admin:admin-secret@db-one,db-two/breeze',
+      'postgresql://admin:admin-secret@db-one:5432,db-two:5432/breeze',
+    ])('rejects a derived multi-host request URL without leaking credentials: %s', (url) => {
+      expect(() =>
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL: url,
+          BREEZE_APP_DB_PASSWORD: 'request-secret',
+        }),
+      ).toThrow(/single database\/HA endpoint/i);
+
+      try {
+        resolveRequestDatabaseConfig({
+          NODE_ENV: 'production',
+          DATABASE_URL: url,
+          BREEZE_APP_DB_PASSWORD: 'request-secret',
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message).not.toContain('admin');
+        expect(message).not.toContain('admin-secret');
+        expect(message).not.toContain('request-secret');
+        expect(message).not.toContain('db-one');
+        expect(message).not.toContain('db-two');
+      }
     });
 
     it('refuses a production request pool without an unprivileged URL or password', () => {
@@ -120,6 +219,27 @@ describe('requestDatabaseConfig', () => {
         url: 'postgresql://admin:admin-secret@db:5432/breeze',
         source: 'development-fallback',
       });
+    });
+  });
+
+  describe('logRequestDatabaseConfigSource', () => {
+    it('warns for the non-production fallback using only its source label', () => {
+      const logger = { log: vi.fn(), warn: vi.fn() };
+      const url = 'postgresql://fallback-user:fallback-password@fallback-db:5432/breeze';
+
+      logRequestDatabaseConfigSource(
+        { url, source: 'development-fallback' },
+        logger,
+      );
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[database] Request pool configuration source: development-fallback',
+      );
+      expect(logger.log).not.toHaveBeenCalled();
+      const logged = JSON.stringify(logger.warn.mock.calls);
+      expect(logged).not.toContain(url);
+      expect(logged).not.toContain('fallback-user');
+      expect(logged).not.toContain('fallback-password');
     });
   });
 });

--- a/apps/api/src/db/requestDatabaseConfig.test.ts
+++ b/apps/api/src/db/requestDatabaseConfig.test.ts
@@ -1,11 +1,32 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   deriveAppConnectionString,
+  getAppDatabasePassword,
   logRequestDatabaseConfigSource,
   resolveRequestDatabaseConfig,
 } from './requestDatabaseConfig';
 
 describe('requestDatabaseConfig', () => {
+  describe('getAppDatabasePassword', () => {
+    it('preserves leading and trailing whitespace in the selected secret', () => {
+      expect(
+        getAppDatabasePassword({
+          BREEZE_APP_DB_PASSWORD: ' request secret ',
+          POSTGRES_PASSWORD: 'fallback',
+        }),
+      ).toBe(' request secret ');
+    });
+
+    it('treats an all-whitespace app password as the selected secret', () => {
+      expect(
+        getAppDatabasePassword({
+          BREEZE_APP_DB_PASSWORD: '   ',
+          POSTGRES_PASSWORD: 'fallback',
+        }),
+      ).toBe('   ');
+    });
+  });
+
   describe('deriveAppConnectionString', () => {
     it('derives the breeze_app URL from the admin URL and app password', () => {
       expect(
@@ -236,6 +257,30 @@ describe('requestDatabaseConfig', () => {
         url: 'postgresql://breeze_app:app-specific-secret@db:5432/breeze',
         source: 'derived',
       });
+    });
+
+    it('preserves whitespace bytes when deriving the request password', () => {
+      const config = resolveRequestDatabaseConfig({
+        NODE_ENV: 'production',
+        DATABASE_URL: 'postgresql://admin:admin-secret@db:5432/breeze',
+        BREEZE_APP_DB_PASSWORD: ' request secret ',
+        POSTGRES_PASSWORD: 'fallback',
+      });
+
+      expect(decodeURIComponent(new URL(config.url).password)).toBe(
+        ' request secret ',
+      );
+    });
+
+    it('does not replace an all-whitespace app password with POSTGRES_PASSWORD', () => {
+      const config = resolveRequestDatabaseConfig({
+        NODE_ENV: 'production',
+        DATABASE_URL: 'postgresql://admin:admin-secret@db:5432/breeze',
+        BREEZE_APP_DB_PASSWORD: '   ',
+        POSTGRES_PASSWORD: 'fallback',
+      });
+
+      expect(decodeURIComponent(new URL(config.url).password)).toBe('   ');
     });
 
     it.each([

--- a/apps/api/src/db/requestDatabaseConfig.ts
+++ b/apps/api/src/db/requestDatabaseConfig.ts
@@ -12,8 +12,23 @@ export interface RequestDatabaseConfig {
 
 type RequestDatabaseConfigLogger = Pick<Console, 'log' | 'warn'>;
 
+interface AppDatabasePasswordEnv {
+  BREEZE_APP_DB_PASSWORD?: string;
+  POSTGRES_PASSWORD?: string;
+}
+
 const SINGLE_ENDPOINT_GUIDANCE =
   'Configure a valid PostgreSQL URL for a single database/HA endpoint.';
+
+/**
+ * Select the password bytes used both to configure and connect as breeze_app.
+ * Database passwords are opaque secrets, so whitespace must not be normalized.
+ */
+export function getAppDatabasePassword(
+  env: AppDatabasePasswordEnv = process.env,
+): string | undefined {
+  return env.BREEZE_APP_DB_PASSWORD || env.POSTGRES_PASSWORD || undefined;
+}
 
 function canonicalizeRequestDatabaseUrl(
   connectionUrl: string,
@@ -67,8 +82,7 @@ export function resolveRequestDatabaseConfig(
   const rawAdminUrl =
     env.DATABASE_URL?.trim() || 'postgresql://breeze:breeze@localhost:5432/breeze';
   const adminUrl = canonicalizeRequestDatabaseUrl(rawAdminUrl, 'DATABASE_URL');
-  const password =
-    env.BREEZE_APP_DB_PASSWORD?.trim() || env.POSTGRES_PASSWORD?.trim();
+  const password = getAppDatabasePassword(env);
   const derived = deriveAppConnectionString(adminUrl, password);
   if (derived) return { url: derived, source: 'derived' };
 

--- a/apps/api/src/db/requestDatabaseConfig.ts
+++ b/apps/api/src/db/requestDatabaseConfig.ts
@@ -1,3 +1,5 @@
+import { canonicalizeSingleEndpointPostgresUrl } from '../lib/postgresConnectionUrl';
+
 export type RequestDatabaseConfigSource =
   | 'explicit'
   | 'derived'
@@ -13,36 +15,14 @@ type RequestDatabaseConfigLogger = Pick<Console, 'log' | 'warn'>;
 const SINGLE_ENDPOINT_GUIDANCE =
   'Configure a valid PostgreSQL URL for a single database/HA endpoint.';
 
-function connectionHostSegment(connectionUrl: string): string | null {
-  const authority = connectionUrl.match(/^[a-z][a-z0-9+.-]*:\/\/([^/?#]*)/iu)?.[1];
-  if (authority === undefined) return null;
-  return authority.slice(authority.lastIndexOf('@') + 1);
-}
-
-function usesMultipleHosts(connectionUrl: string): boolean {
-  return /,|%2c/iu.test(connectionHostSegment(connectionUrl) ?? '');
-}
-
-function parseSingleEndpointUrl(connectionUrl: string, source: string): URL {
-  const error = new Error(`[database] ${source} is invalid. ${SINGLE_ENDPOINT_GUIDANCE}`);
-
-  if (usesMultipleHosts(connectionUrl)) throw error;
-
-  try {
-    const parsed = new URL(connectionUrl);
-    if (
-      (parsed.protocol !== 'postgres:' && parsed.protocol !== 'postgresql:')
-      || !parsed.hostname
-      || parsed.hostname.includes(',')
-    ) {
-      throw error;
-    }
-    return parsed;
-  } catch {
-    // URL parser errors can expose the parser's credential-bearing `.input`.
-    // Always replace them with the fixed, actionable message above.
-    throw error;
-  }
+function canonicalizeRequestDatabaseUrl(
+  connectionUrl: string,
+  source: 'DATABASE_URL' | 'DATABASE_URL_APP',
+): string {
+  return canonicalizeSingleEndpointPostgresUrl(
+    connectionUrl,
+    `[database] ${source} is invalid. ${SINGLE_ENDPOINT_GUIDANCE}`,
+  );
 }
 
 export function logRequestDatabaseConfigSource(
@@ -64,10 +44,10 @@ export function deriveAppConnectionString(
   if (!appPassword) return null;
 
   try {
-    const url = parseSingleEndpointUrl(adminUrl, 'DATABASE_URL');
+    const url = new URL(canonicalizeRequestDatabaseUrl(adminUrl, 'DATABASE_URL'));
     url.username = 'breeze_app';
-    url.password = appPassword;
-    return url.toString();
+    url.password = encodeURIComponent(appPassword);
+    return canonicalizeRequestDatabaseUrl(url.toString(), 'DATABASE_URL');
   } catch {
     return null;
   }
@@ -78,19 +58,17 @@ export function resolveRequestDatabaseConfig(
 ): RequestDatabaseConfig {
   const explicit = env.DATABASE_URL_APP?.trim();
   if (explicit) {
-    parseSingleEndpointUrl(explicit, 'DATABASE_URL_APP');
-    return { url: explicit, source: 'explicit' };
+    return {
+      url: canonicalizeRequestDatabaseUrl(explicit, 'DATABASE_URL_APP'),
+      source: 'explicit',
+    };
   }
 
-  const adminUrl =
+  const rawAdminUrl =
     env.DATABASE_URL?.trim() || 'postgresql://breeze:breeze@localhost:5432/breeze';
+  const adminUrl = canonicalizeRequestDatabaseUrl(rawAdminUrl, 'DATABASE_URL');
   const password =
     env.BREEZE_APP_DB_PASSWORD?.trim() || env.POSTGRES_PASSWORD?.trim();
-  if (password && usesMultipleHosts(adminUrl)) {
-    throw new Error(
-      `[database] Cannot derive the request database URL from DATABASE_URL. ${SINGLE_ENDPOINT_GUIDANCE}`,
-    );
-  }
   const derived = deriveAppConnectionString(adminUrl, password);
   if (derived) return { url: derived, source: 'derived' };
 

--- a/apps/api/src/db/requestDatabaseConfig.ts
+++ b/apps/api/src/db/requestDatabaseConfig.ts
@@ -1,0 +1,47 @@
+export type RequestDatabaseConfigSource =
+  | 'explicit'
+  | 'derived'
+  | 'development-fallback';
+
+export interface RequestDatabaseConfig {
+  url: string;
+  source: RequestDatabaseConfigSource;
+}
+
+export function deriveAppConnectionString(
+  adminUrl: string,
+  appPassword: string | undefined,
+): string | null {
+  if (!appPassword) return null;
+
+  try {
+    const url = new URL(adminUrl);
+    url.username = 'breeze_app';
+    url.password = appPassword;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function resolveRequestDatabaseConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): RequestDatabaseConfig {
+  const explicit = env.DATABASE_URL_APP?.trim();
+  if (explicit) return { url: explicit, source: 'explicit' };
+
+  const adminUrl =
+    env.DATABASE_URL?.trim() || 'postgresql://breeze:breeze@localhost:5432/breeze';
+  const password =
+    env.BREEZE_APP_DB_PASSWORD?.trim() || env.POSTGRES_PASSWORD?.trim();
+  const derived = deriveAppConnectionString(adminUrl, password);
+  if (derived) return { url: derived, source: 'derived' };
+
+  if (env.NODE_ENV === 'production') {
+    throw new Error(
+      '[database] Cannot configure the unprivileged request pool. Set DATABASE_URL_APP to a NOSUPERUSER/NOBYPASSRLS role, or set BREEZE_APP_DB_PASSWORD/POSTGRES_PASSWORD so Breeze can derive the breeze_app URL from DATABASE_URL. Refusing to use DATABASE_URL for request handlers.',
+    );
+  }
+
+  return { url: adminUrl, source: 'development-fallback' };
+}

--- a/apps/api/src/db/requestDatabaseConfig.ts
+++ b/apps/api/src/db/requestDatabaseConfig.ts
@@ -8,6 +8,55 @@ export interface RequestDatabaseConfig {
   source: RequestDatabaseConfigSource;
 }
 
+type RequestDatabaseConfigLogger = Pick<Console, 'log' | 'warn'>;
+
+const SINGLE_ENDPOINT_GUIDANCE =
+  'Configure a valid PostgreSQL URL for a single database/HA endpoint.';
+
+function connectionHostSegment(connectionUrl: string): string | null {
+  const authority = connectionUrl.match(/^[a-z][a-z0-9+.-]*:\/\/([^/?#]*)/iu)?.[1];
+  if (authority === undefined) return null;
+  return authority.slice(authority.lastIndexOf('@') + 1);
+}
+
+function usesMultipleHosts(connectionUrl: string): boolean {
+  return connectionHostSegment(connectionUrl)?.includes(',') ?? false;
+}
+
+function parseSingleEndpointUrl(connectionUrl: string, source: string): URL {
+  const error = new Error(`[database] ${source} is invalid. ${SINGLE_ENDPOINT_GUIDANCE}`);
+
+  if (usesMultipleHosts(connectionUrl)) throw error;
+
+  try {
+    const parsed = new URL(connectionUrl);
+    if (
+      (parsed.protocol !== 'postgres:' && parsed.protocol !== 'postgresql:')
+      || !parsed.hostname
+      || parsed.hostname.includes(',')
+    ) {
+      throw error;
+    }
+    return parsed;
+  } catch {
+    // URL parser errors can expose the parser's credential-bearing `.input`.
+    // Always replace them with the fixed, actionable message above.
+    throw error;
+  }
+}
+
+export function logRequestDatabaseConfigSource(
+  config: RequestDatabaseConfig,
+  logger: RequestDatabaseConfigLogger = console,
+): void {
+  const message = `[database] Request pool configuration source: ${config.source}`;
+  if (config.source === 'development-fallback') {
+    logger.warn(message);
+    return;
+  }
+  logger.log(message);
+}
+
 export function deriveAppConnectionString(
   adminUrl: string,
   appPassword: string | undefined,
@@ -15,7 +64,7 @@ export function deriveAppConnectionString(
   if (!appPassword) return null;
 
   try {
-    const url = new URL(adminUrl);
+    const url = parseSingleEndpointUrl(adminUrl, 'DATABASE_URL');
     url.username = 'breeze_app';
     url.password = appPassword;
     return url.toString();
@@ -28,12 +77,20 @@ export function resolveRequestDatabaseConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): RequestDatabaseConfig {
   const explicit = env.DATABASE_URL_APP?.trim();
-  if (explicit) return { url: explicit, source: 'explicit' };
+  if (explicit) {
+    parseSingleEndpointUrl(explicit, 'DATABASE_URL_APP');
+    return { url: explicit, source: 'explicit' };
+  }
 
   const adminUrl =
     env.DATABASE_URL?.trim() || 'postgresql://breeze:breeze@localhost:5432/breeze';
   const password =
     env.BREEZE_APP_DB_PASSWORD?.trim() || env.POSTGRES_PASSWORD?.trim();
+  if (password && usesMultipleHosts(adminUrl)) {
+    throw new Error(
+      `[database] Cannot derive the request database URL from DATABASE_URL. ${SINGLE_ENDPOINT_GUIDANCE}`,
+    );
+  }
   const derived = deriveAppConnectionString(adminUrl, password);
   if (derived) return { url: derived, source: 'derived' };
 

--- a/apps/api/src/db/requestDatabaseConfig.ts
+++ b/apps/api/src/db/requestDatabaseConfig.ts
@@ -20,7 +20,7 @@ function connectionHostSegment(connectionUrl: string): string | null {
 }
 
 function usesMultipleHosts(connectionUrl: string): boolean {
-  return connectionHostSegment(connectionUrl)?.includes(',') ?? false;
+  return /,|%2c/iu.test(connectionHostSegment(connectionUrl) ?? '');
 }
 
 function parseSingleEndpointUrl(connectionUrl: string, source: string): URL {

--- a/apps/api/src/db/requestDatabaseRole.integration.test.ts
+++ b/apps/api/src/db/requestDatabaseRole.integration.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import postgres, { type Sql } from 'postgres';
+
+const ADMIN_DATABASE_URL = process.env.DATABASE_URL;
+const APP_DATABASE_URL = process.env.DATABASE_URL_APP;
+const BYPASS_ROLE = 'breeze_request_bypassrls_test';
+const BYPASS_PASSWORD = 'breeze_request_bypassrls_test_password';
+
+if (!ADMIN_DATABASE_URL || !APP_DATABASE_URL) {
+  throw new Error(
+    'request database role tests require DATABASE_URL (admin) and DATABASE_URL_APP (breeze_app)',
+  );
+}
+
+let adminClient: Sql;
+let closeRequestPool: (() => Promise<void>) | undefined;
+
+async function loadFreshRequestPool(connectionUrl: string) {
+  if (closeRequestPool) {
+    await closeRequestPool();
+    closeRequestPool = undefined;
+  }
+
+  vi.resetModules();
+  process.env.DATABASE_URL_APP = connectionUrl;
+  process.env.NODE_ENV = 'test';
+  const database = await import('./index');
+  closeRequestPool = database.closeDb;
+  return database;
+}
+
+describe('request database role startup enforcement', () => {
+  beforeAll(async () => {
+    adminClient = postgres(ADMIN_DATABASE_URL, { max: 1 });
+    await adminClient.unsafe(`DROP ROLE IF EXISTS ${BYPASS_ROLE}`);
+    await adminClient.unsafe(
+      `CREATE ROLE ${BYPASS_ROLE} LOGIN PASSWORD '${BYPASS_PASSWORD}' NOSUPERUSER BYPASSRLS`,
+    );
+  });
+
+  afterEach(async () => {
+    await closeRequestPool?.();
+    closeRequestPool = undefined;
+    vi.resetModules();
+    process.env.DATABASE_URL = ADMIN_DATABASE_URL;
+    process.env.DATABASE_URL_APP = APP_DATABASE_URL;
+    process.env.NODE_ENV = 'test';
+    delete process.env.AUTO_MIGRATE;
+  });
+
+  afterAll(async () => {
+    await adminClient.unsafe(`DROP ROLE IF EXISTS ${BYPASS_ROLE}`);
+    await adminClient.end();
+  });
+
+  it('reports the exact breeze_app request-pool role', async () => {
+    const { getRequestDatabaseRole } = await loadFreshRequestPool(APP_DATABASE_URL);
+
+    await expect(getRequestDatabaseRole()).resolves.toEqual({
+      currentUser: 'breeze_app',
+      isSuperuser: false,
+      bypassesRls: false,
+    });
+  });
+
+  it('rejects a SUPERUSER request pool', async () => {
+    const { assertRequestDatabaseRoleSafe } = await loadFreshRequestPool(ADMIN_DATABASE_URL);
+
+    await expect(assertRequestDatabaseRoleSafe()).rejects.toThrow(/SUPERUSER/);
+  });
+
+  it('rejects a BYPASSRLS request pool', async () => {
+    const bypassUrl = new URL(ADMIN_DATABASE_URL);
+    bypassUrl.username = BYPASS_ROLE;
+    bypassUrl.password = BYPASS_PASSWORD;
+    const { assertRequestDatabaseRoleSafe } = await loadFreshRequestPool(bypassUrl.toString());
+
+    await expect(assertRequestDatabaseRoleSafe()).rejects.toThrow(/BYPASSRLS/);
+  });
+
+  it('rejects unsafe production startup when AUTO_MIGRATE=false without invoking migrations', async () => {
+    vi.resetModules();
+    process.env.DATABASE_URL = ADMIN_DATABASE_URL;
+    process.env.DATABASE_URL_APP = ADMIN_DATABASE_URL;
+    process.env.NODE_ENV = 'production';
+    process.env.AUTO_MIGRATE = 'false';
+
+    const database = await import('./index');
+    closeRequestPool = database.closeDb;
+    const { initializeDatabaseForStartup } = await import('./databaseStartup');
+    const migrate = vi.fn();
+
+    await expect(
+      initializeDatabaseForStartup({
+        autoMigrateEnabled: process.env.AUTO_MIGRATE !== 'false',
+        production: process.env.NODE_ENV === 'production',
+        migrate,
+      }),
+    ).rejects.toThrow(/SUPERUSER/);
+    expect(migrate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/db/requestDatabaseRole.integration.test.ts
+++ b/apps/api/src/db/requestDatabaseRole.integration.test.ts
@@ -2,12 +2,12 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest
 import postgres, { type Sql } from 'postgres';
 import { assertTestDatabaseUrlSafe } from '../testUtils/integrationDatabaseSafety';
 
-const ADMIN_DATABASE_URL = process.env.DATABASE_URL;
-const APP_DATABASE_URL = process.env.DATABASE_URL_APP;
+const rawAdminDatabaseUrl = process.env.DATABASE_URL;
+const rawAppDatabaseUrl = process.env.DATABASE_URL_APP;
 const BYPASS_ROLE = 'breeze_request_bypassrls_test';
 const BYPASS_PASSWORD = 'breeze_request_bypassrls_test_password';
 
-if (!ADMIN_DATABASE_URL || !APP_DATABASE_URL) {
+if (!rawAdminDatabaseUrl || !rawAppDatabaseUrl) {
   throw new Error(
     'request database role tests require DATABASE_URL (admin) and DATABASE_URL_APP (breeze_app)',
   );
@@ -17,8 +17,14 @@ if (!ADMIN_DATABASE_URL || !APP_DATABASE_URL) {
 // construct the admin client or execute DROP/CREATE ROLE. Both URLs must stay
 // inside the same explicit local-test safety boundary as the shared integration
 // runner despite this suite not importing its hook-heavy setup module.
-assertTestDatabaseUrlSafe(ADMIN_DATABASE_URL, 'request database role admin setup');
-assertTestDatabaseUrlSafe(APP_DATABASE_URL, 'request database role app setup');
+const ADMIN_DATABASE_URL = assertTestDatabaseUrlSafe(
+  rawAdminDatabaseUrl,
+  'request database role admin setup',
+);
+const APP_DATABASE_URL = assertTestDatabaseUrlSafe(
+  rawAppDatabaseUrl,
+  'request database role app setup',
+);
 
 let adminClient: Sql;
 let closeRequestPool: (() => Promise<void>) | undefined;
@@ -81,7 +87,11 @@ describe('request database role startup enforcement', () => {
     const bypassUrl = new URL(ADMIN_DATABASE_URL);
     bypassUrl.username = BYPASS_ROLE;
     bypassUrl.password = BYPASS_PASSWORD;
-    const { assertRequestDatabaseRoleSafe } = await loadFreshRequestPool(bypassUrl.toString());
+    const safeBypassUrl = assertTestDatabaseUrlSafe(
+      bypassUrl.toString(),
+      'request database role bypass setup',
+    );
+    const { assertRequestDatabaseRoleSafe } = await loadFreshRequestPool(safeBypassUrl);
 
     await expect(assertRequestDatabaseRoleSafe()).rejects.toThrow(/BYPASSRLS/);
   });

--- a/apps/api/src/db/requestDatabaseRole.integration.test.ts
+++ b/apps/api/src/db/requestDatabaseRole.integration.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import postgres, { type Sql } from 'postgres';
+import { assertTestDatabaseUrlSafe } from '../testUtils/integrationDatabaseSafety';
 
 const ADMIN_DATABASE_URL = process.env.DATABASE_URL;
 const APP_DATABASE_URL = process.env.DATABASE_URL_APP;
@@ -11,6 +12,13 @@ if (!ADMIN_DATABASE_URL || !APP_DATABASE_URL) {
     'request database role tests require DATABASE_URL (admin) and DATABASE_URL_APP (breeze_app)',
   );
 }
+
+// These assertions intentionally run at module evaluation, before beforeAll can
+// construct the admin client or execute DROP/CREATE ROLE. Both URLs must stay
+// inside the same explicit local-test safety boundary as the shared integration
+// runner despite this suite not importing its hook-heavy setup module.
+assertTestDatabaseUrlSafe(ADMIN_DATABASE_URL, 'request database role admin setup');
+assertTestDatabaseUrlSafe(APP_DATABASE_URL, 'request database role app setup');
 
 let adminClient: Sql;
 let closeRequestPool: (() => Promise<void>) | undefined;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -266,7 +266,7 @@ import { writeAuditEvent } from './services/auditEvents';
 import { drainAuditRetryQueue } from './services/auditService';
 import { createCorsOriginResolver } from './services/corsOrigins';
 import { validateConfig } from './config/validate';
-import { autoMigrate } from './db/autoMigrate';
+import { initializeDatabaseForStartup } from './db/databaseStartup';
 import { mountExtensions } from './extensions/loader';
 import { syncBinaries } from './services/binarySync';
 import * as dbModule from './db';
@@ -1508,19 +1508,13 @@ async function bootstrap(): Promise<void> {
   // Validate configuration before anything else — fail fast on missing/insecure secrets.
   // The validated config is stored as a singleton; retrieve later via getConfig().
   const config = validateConfig();
+  await initializeDatabaseForStartup({
+    autoMigrateEnabled: process.env.AUTO_MIGRATE !== 'false',
+    production: config.NODE_ENV === 'production',
+  });
   console.log(`[config] Validated: NODE_ENV=${config.NODE_ENV}, port=${config.API_PORT}`);
   if ((process.env.AGENT_BACKUP_SERVER_URL ?? '').trim()) {
     console.log(`[config] AGENT_BACKUP_SERVER_URL active: ${process.env.AGENT_BACKUP_SERVER_URL!.trim()}`);
-  }
-
-  // Auto-migrate schema and seed on first boot (set AUTO_MIGRATE=false to
-  // disable). Runs BEFORE runStartupChecks because ensureAppRole() — called
-  // from autoMigrate — is what creates the unprivileged breeze_app role that
-  // DATABASE_URL_APP points at. On a fresh database the role doesn't exist
-  // until this runs, and the connectivity check (which uses the proxied
-  // `db`) would fail first.
-  if (process.env.AUTO_MIGRATE !== 'false') {
-    await autoMigrate();
   }
 
   await mountExtensions(app);

--- a/apps/api/src/lib/postgresConnectionUrl.test.ts
+++ b/apps/api/src/lib/postgresConnectionUrl.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalizeSingleEndpointPostgresUrl } from './postgresConnectionUrl';
+
+const GENERIC_ERROR = 'The PostgreSQL connection URL is invalid.';
+
+describe('canonicalizeSingleEndpointPostgresUrl', () => {
+  it('canonicalizes one endpoint while preserving encoded credentials, path, and query', () => {
+    expect(
+      canonicalizeSingleEndpointPostgresUrl(
+        'POSTGRESQL://db-user:p%40ss@localhost:55432/breeze%20test?application_name=breeze%20api&sslmode=require',
+        GENERIC_ERROR,
+      ),
+    ).toBe(
+      'postgresql://db-user:p%40ss@localhost:55432/breeze%20test?application_name=breeze%20api&sslmode=require',
+    );
+  });
+
+  it.each([
+    'mysql://db-user:db-password@localhost:55432/breeze',
+    'postgresql:///breeze',
+    'postgresql://db-user:db-password@localhost:55432/breeze#',
+    'postgresql://db-user:db-password@localhost:55432/breeze#primary%2Cunsafe',
+    'postgresql://db-user:db-password@primary@localhost:55432/breeze',
+    'postgresql://db-user:db-password@primary,unsafe/breeze',
+    'postgresql://db-user:db-password@primary%2Cunsafe/breeze',
+    'postgresql://db-user:db-password@primary%252Cunsafe/breeze',
+    'postgresql://db-user:db-password@primary%ZZunsafe/breeze',
+    'postgresql://db%ZZuser:db-password@localhost:55432/breeze',
+    'postgresql://db-user:db%ZZpassword@localhost:55432/breeze',
+  ])('rejects unsafe or malformed input with only the generic message: %s', (url) => {
+    expect(() =>
+      canonicalizeSingleEndpointPostgresUrl(url, GENERIC_ERROR),
+    ).toThrowError(GENERIC_ERROR);
+
+    try {
+      canonicalizeSingleEndpointPostgresUrl(url, GENERIC_ERROR);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toBe(GENERIC_ERROR);
+      for (const inputPart of [
+        'db-user',
+        'db-password',
+        'localhost',
+        'primary',
+        'unsafe',
+        'primary%ZZunsafe',
+      ]) {
+        expect(message).not.toContain(inputPart);
+      }
+    }
+  });
+});

--- a/apps/api/src/lib/postgresConnectionUrl.ts
+++ b/apps/api/src/lib/postgresConnectionUrl.ts
@@ -1,0 +1,37 @@
+export function canonicalizeSingleEndpointPostgresUrl(
+  connectionUrl: string,
+  errorMessage: string,
+): string {
+  try {
+    if (connectionUrl.includes('#')) throw new Error();
+
+    const authority = connectionUrl.match(
+      /^[a-z][a-z0-9+.-]*:\/\/([^/?#]*)/iu,
+    )?.[1];
+    if (authority === undefined) throw new Error();
+
+    const rawAtDelimiterCount = authority.match(/@/gu)?.length ?? 0;
+    if (rawAtDelimiterCount > 1) throw new Error();
+
+    const hostSegment = authority.slice(authority.indexOf('@') + 1);
+    if (/,|%2c/iu.test(hostSegment)) throw new Error();
+
+    const decodedHostSegment = decodeURIComponent(hostSegment);
+    if (/,|%2c/iu.test(decodedHostSegment)) throw new Error();
+
+    const parsed = new URL(connectionUrl);
+    if (
+      (parsed.protocol !== 'postgres:' && parsed.protocol !== 'postgresql:')
+      || !parsed.hostname
+    ) {
+      throw new Error();
+    }
+
+    decodeURIComponent(parsed.username);
+    decodeURIComponent(parsed.password);
+
+    return parsed.toString();
+  } catch {
+    throw new Error(errorMessage);
+  }
+}

--- a/apps/api/src/testUtils/integrationDatabaseSafety.test.ts
+++ b/apps/api/src/testUtils/integrationDatabaseSafety.test.ts
@@ -6,9 +6,21 @@ const SAFE_URL =
 
 describe('assertTestDatabaseUrlSafe', () => {
   it('accepts an explicitly test-mode local database on a non-default port', () => {
-    expect(() =>
+    expect(
       assertTestDatabaseUrlSafe(SAFE_URL, 'setup', { nodeEnv: 'test' }),
-    ).not.toThrow();
+    ).toBe(SAFE_URL);
+  });
+
+  it('returns a canonical local URL while preserving query parameters', () => {
+    expect(
+      assertTestDatabaseUrlSafe(
+        'POSTGRESQL://breeze_test:breeze_test@localhost:55432/breeze_test?sslmode=require',
+        'setup',
+        { nodeEnv: 'test' },
+      ),
+    ).toBe(
+      'postgresql://breeze_test:breeze_test@localhost:55432/breeze_test?sslmode=require',
+    );
   });
 
   it('accepts an exact BREEZE_TEST_DB_URL opt-in outside test mode', () => {
@@ -76,5 +88,44 @@ describe('assertTestDatabaseUrlSafe', () => {
     expect(message).not.toContain(connectionUrl);
     expect(message).not.toContain(username);
     expect(message).not.toContain(password);
+  });
+
+  it.each([
+    [
+      'an encoded-comma host before a second raw at-sign',
+      'postgresql://guard-user:guard-password@primary%2Cunsafe%2Cignored@127.0.0.1:55432/breeze_test',
+    ],
+    [
+      'a fragment containing encoded host material',
+      'postgresql://guard-user:guard-password@127.0.0.1:55432/breeze_test#primary%2Cunsafe%2Cignored',
+    ],
+  ])('rejects local-looking parser differentials before client or DDL work: %s', (_case, url) => {
+    const clientAndDdlPath = vi.fn();
+    let caught: unknown;
+
+    try {
+      const canonicalUrl = assertTestDatabaseUrlSafe(
+        url,
+        'request database role setup',
+        { nodeEnv: 'test' },
+      );
+      clientAndDdlPath(canonicalUrl);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(clientAndDdlPath).not.toHaveBeenCalled();
+    const message = caught instanceof Error ? caught.message : String(caught);
+    expect(message).toMatch(/Integration test request database role setup refused/i);
+    for (const secret of [
+      'guard-user',
+      'guard-password',
+      'primary',
+      'unsafe',
+      '127.0.0.1',
+    ]) {
+      expect(message).not.toContain(secret);
+    }
   });
 });

--- a/apps/api/src/testUtils/integrationDatabaseSafety.test.ts
+++ b/apps/api/src/testUtils/integrationDatabaseSafety.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { assertTestDatabaseUrlSafe } from './integrationDatabaseSafety';
+
+const SAFE_URL =
+  'postgresql://breeze_test:breeze_test@127.0.0.1:55432/breeze_test';
+
+describe('assertTestDatabaseUrlSafe', () => {
+  it('accepts an explicitly test-mode local database on a non-default port', () => {
+    expect(() =>
+      assertTestDatabaseUrlSafe(SAFE_URL, 'setup', { nodeEnv: 'test' }),
+    ).not.toThrow();
+  });
+
+  it('accepts an exact BREEZE_TEST_DB_URL opt-in outside test mode', () => {
+    expect(() =>
+      assertTestDatabaseUrlSafe(SAFE_URL, 'setup', {
+        nodeEnv: 'development',
+        breezeTestDbUrl: SAFE_URL,
+      }),
+    ).not.toThrow();
+  });
+
+  it.each([
+    ['an unparseable URL', 'not a database url'],
+    [
+      'a production-like database name',
+      'postgresql://production-user:production-password@127.0.0.1:55432/breeze',
+    ],
+    [
+      'a remote host',
+      'postgresql://production-user:production-password@production-db.example.com:55432/breeze_test',
+    ],
+    [
+      'the default PostgreSQL port',
+      'postgresql://production-user:production-password@127.0.0.1:5432/breeze_test',
+    ],
+  ])('refuses %s before the client or DDL path', (_description, connectionUrl) => {
+    const clientAndDdlPath = vi.fn();
+
+    expect(() => {
+      assertTestDatabaseUrlSafe(connectionUrl, 'request database role setup', {
+        nodeEnv: 'test',
+      });
+      clientAndDdlPath();
+    }).toThrow(/Integration test request database role setup refused/i);
+
+    expect(clientAndDdlPath).not.toHaveBeenCalled();
+  });
+
+  it('requires NODE_ENV=test or an exact explicit URL opt-in', () => {
+    expect(() =>
+      assertTestDatabaseUrlSafe(SAFE_URL, 'setup', {
+        nodeEnv: 'development',
+        breezeTestDbUrl:
+          'postgresql://breeze_test:breeze_test@127.0.0.1:55432/breeze_test_other',
+      }),
+    ).toThrow(/operator opt-in/i);
+  });
+
+  it('does not include credentials or the supplied URL in refusal errors', () => {
+    const username = 'production-user';
+    const password = 'production-password';
+    const connectionUrl =
+      `postgresql://${username}:${password}@production-db.example.com:5432/production`;
+
+    let caught: unknown;
+    try {
+      assertTestDatabaseUrlSafe(connectionUrl, 'setup', { nodeEnv: 'test' });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const message = caught instanceof Error ? caught.message : String(caught);
+    expect(message).toMatch(/Integration test setup refused/i);
+    expect(message).not.toContain(connectionUrl);
+    expect(message).not.toContain(username);
+    expect(message).not.toContain(password);
+  });
+});

--- a/apps/api/src/testUtils/integrationDatabaseSafety.ts
+++ b/apps/api/src/testUtils/integrationDatabaseSafety.ts
@@ -1,0 +1,65 @@
+export interface TestDatabaseSafetyEnvironment {
+  nodeEnv?: string;
+  breezeTestDbUrl?: string;
+}
+
+const ALLOWED_TEST_DB_NAME_RE = /^breeze_test(_[a-z0-9]+)?$/u;
+const ALLOWED_TEST_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '[::1]',
+  'breeze-postgres-test',
+  'postgres-test',
+]);
+const FORBIDDEN_TEST_PORTS = new Set(['5432']);
+
+export function assertTestDatabaseUrlSafe(
+  connectionUrl: string,
+  operation: string,
+  environment: TestDatabaseSafetyEnvironment = {
+    nodeEnv: process.env.NODE_ENV,
+    breezeTestDbUrl: process.env.BREEZE_TEST_DB_URL,
+  },
+): void {
+  const failures: string[] = [];
+  let parsed: URL | undefined;
+
+  try {
+    parsed = new URL(connectionUrl);
+  } catch {
+    failures.push('connection URL is not parseable');
+  }
+
+  if (parsed) {
+    if (parsed.protocol !== 'postgres:' && parsed.protocol !== 'postgresql:') {
+      failures.push('connection URL must use postgres:// or postgresql://');
+    }
+
+    const databaseName = parsed.pathname.replace(/^\//u, '');
+    if (!ALLOWED_TEST_DB_NAME_RE.test(databaseName)) {
+      failures.push('database name must match /^breeze_test(_[a-z0-9]+)?$/');
+    }
+    if (!ALLOWED_TEST_HOSTS.has(parsed.hostname)) {
+      failures.push('host is not in the local-test allowlist');
+    }
+    if (FORBIDDEN_TEST_PORTS.has(parsed.port || '5432')) {
+      failures.push('port is the default development/production PostgreSQL port');
+    }
+  }
+
+  if (
+    environment.nodeEnv !== 'test'
+    && environment.breezeTestDbUrl !== connectionUrl
+  ) {
+    failures.push(
+      'operator opt-in requires NODE_ENV=test or BREEZE_TEST_DB_URL to exactly match the connection URL',
+    );
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Integration test ${operation} refused — database target failed safety checks:\n`
+      + failures.map((failure) => `  - ${failure}`).join('\n'),
+    );
+  }
+}

--- a/apps/api/src/testUtils/integrationDatabaseSafety.ts
+++ b/apps/api/src/testUtils/integrationDatabaseSafety.ts
@@ -1,3 +1,5 @@
+import { canonicalizeSingleEndpointPostgresUrl } from '../lib/postgresConnectionUrl';
+
 export interface TestDatabaseSafetyEnvironment {
   nodeEnv?: string;
   breezeTestDbUrl?: string;
@@ -20,21 +22,22 @@ export function assertTestDatabaseUrlSafe(
     nodeEnv: process.env.NODE_ENV,
     breezeTestDbUrl: process.env.BREEZE_TEST_DB_URL,
   },
-): void {
+): string {
   const failures: string[] = [];
+  let canonicalUrl: string | undefined;
   let parsed: URL | undefined;
 
   try {
-    parsed = new URL(connectionUrl);
+    canonicalUrl = canonicalizeSingleEndpointPostgresUrl(
+      connectionUrl,
+      'Integration database connection URL is invalid.',
+    );
+    parsed = new URL(canonicalUrl);
   } catch {
-    failures.push('connection URL is not parseable');
+    failures.push('connection URL is not a valid single-endpoint PostgreSQL URL');
   }
 
   if (parsed) {
-    if (parsed.protocol !== 'postgres:' && parsed.protocol !== 'postgresql:') {
-      failures.push('connection URL must use postgres:// or postgresql://');
-    }
-
     const databaseName = parsed.pathname.replace(/^\//u, '');
     if (!ALLOWED_TEST_DB_NAME_RE.test(databaseName)) {
       failures.push('database name must match /^breeze_test(_[a-z0-9]+)?$/');
@@ -62,4 +65,6 @@ export function assertTestDatabaseUrlSafe(
       + failures.map((failure) => `  - ${failure}`).join('\n'),
     );
   }
+
+  return canonicalUrl!;
 }

--- a/apps/api/vitest.config.request-db-role.ts
+++ b/apps/api/vitest.config.request-db-role.ts
@@ -9,7 +9,11 @@ export default defineConfig({
     // and must never inherit the core-table TRUNCATE hooks.
     sequence: { concurrent: false },
     fileParallelism: false,
-    testTimeout: 30000,
-    hookTimeout: 30000,
+    // Cold transformation of db/index.ts can exceed 30s on CI. A timeout leaves
+    // that dynamic import running while afterEach mutates DATABASE_URL_APP for
+    // the next test, producing cross-test role contamination instead of a clean
+    // timeout. Keep the sequential suite above that observed cold-start ceiling.
+    testTimeout: 60000,
+    hookTimeout: 60000,
   },
 });

--- a/apps/api/vitest.config.request-db-role.ts
+++ b/apps/api/vitest.config.request-db-role.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/db/requestDatabaseRole.integration.test.ts'],
+    // No shared integration setup: this suite only manages a temporary role
+    // and must never inherit the core-table TRUNCATE hooks.
+    sequence: { concurrent: false },
+    fileParallelism: false,
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
     include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
     exclude: [
       'src/__tests__/integration/**',
+      // Real-PostgreSQL exact request-pool role checks have a dedicated runner.
+      'src/db/requestDatabaseRole.integration.test.ts',
       // Real-driver integration test for the inbound email pipeline. It needs the
       // integration setup (real postgres pool + autoMigrate seed) and is run by
       // vitest.integration.config.ts — not the unit runner, which has no DB.

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -63,6 +63,9 @@ export default defineConfig({
       'src/services/warrantyAlertEvaluator.integration.test.ts',
     ],
     exclude: [
+      // Uses fresh request-pool modules and manages its own temporary role;
+      // never attach the shared integration TRUNCATE hooks.
+      'src/db/requestDatabaseRole.integration.test.ts',
       // rls.integration.test.ts is a mocked unit test in integration's
       // clothing — it stubs the postgres/drizzle layer at the module
       // level and cannot coexist with setup.ts opening a real postgres

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -59,10 +59,12 @@ TRUSTED_PROXY_CIDRS=172.30.0.11/32
 IP_ALLOWLIST_ENFORCEMENT_MODE=enforce
 
 # ── Database (Managed Postgres) ─────────────────────────────────────
-DATABASE_URL=postgresql://user:password@host:port/dbname?sslmode=require
-# Unprivileged app role (RLS enforced). Set ONE of these:
+DATABASE_URL=postgresql://admin_user:password@host:port/dbname?sslmode=require
+# DATABASE_URL remains required for migrations/system setup. Request handlers
+# use an exact unprivileged NOSUPERUSER NOBYPASSRLS pool, verified at startup.
+# Set ONE of these (AUTO_MIGRATE=false does not skip request-role verification):
 BREEZE_APP_DB_PASSWORD=
-# DATABASE_URL_APP=postgresql://app_user:password@host:port/dbname?sslmode=require
+# DATABASE_URL_APP=postgresql://breeze_app:password@host:port/dbname?sslmode=require
 
 # ── Redis ───────────────────────────────────────────────────────────
 # REQUIRED in production. Empty values are rejected by the redis container,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,11 +69,8 @@ services:
       NODE_ENV: production
       API_PORT: 3001
       DATABASE_URL: postgresql://${POSTGRES_USER:-breeze}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-breeze}
-      # Unprivileged app role connection — RLS policies are enforced against this user.
-      # Falls back to DATABASE_URL (superuser) if unset — but RLS will be bypassed in that case.
-      DATABASE_URL_APP: postgresql://breeze_app:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-breeze}
-      # ensureAppRole reads one of these from the api container env to CREATE/ALTER the
-      # breeze_app role on first boot. Without one of these, DATABASE_URL_APP fails auth.
+      # The request pool derives its breeze_app URL from DATABASE_URL and the same
+      # effective password ensureAppRole uses to CREATE/ALTER that unprivileged role.
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
       BREEZE_APP_DB_PASSWORD: ${BREEZE_APP_DB_PASSWORD:-}
       REDIS_HOST: redis

--- a/docs/runbooks/request-database-role.md
+++ b/docs/runbooks/request-database-role.md
@@ -1,0 +1,60 @@
+# Request database role
+
+Breeze uses two PostgreSQL connection roles in production:
+
+- `DATABASE_URL` is the administrator/system connection required for migrations,
+  role setup, and other system initialization.
+- The request pool is the unprivileged connection used by API request contexts.
+  PostgreSQL row-level security depends on this role being both `NOSUPERUSER`
+  and `NOBYPASSRLS`.
+
+At startup, Breeze queries `current_user`, `rolsuper`, and `rolbypassrls` through
+the exact module-scope request pool that backs the exported API database client.
+Production startup fails if that effective role is a `SUPERUSER`, has
+`BYPASSRLS`, or cannot be identified.
+
+## Supported production configuration
+
+| Configuration | Request pool result |
+|---|---|
+| `DATABASE_URL_APP` set | Used exactly as supplied; startup probes that pool |
+| No `DATABASE_URL_APP`, `BREEZE_APP_DB_PASSWORD` set | Derive `breeze_app` URL from `DATABASE_URL` |
+| No `DATABASE_URL_APP`, only `POSTGRES_PASSWORD` set | Derive `breeze_app` URL from `DATABASE_URL` |
+| Neither explicit URL nor app password available | Production startup refuses to use `DATABASE_URL` |
+
+`DATABASE_URL` remains required even when `DATABASE_URL_APP` is set because
+migrations and system setup use the administrator connection. `AUTO_MIGRATE=false`
+skips migrations only; it does not skip the production request-role assertion.
+
+For a separately managed PostgreSQL service, create or configure the request role
+with equivalent attributes to:
+
+```sql
+ALTER ROLE breeze_app LOGIN NOSUPERUSER NOBYPASSRLS;
+```
+
+Use a unique, strong request-role password. Set either a complete
+`DATABASE_URL_APP`, or set `BREEZE_APP_DB_PASSWORD` so Breeze derives a
+`breeze_app` URL using the host, port, database, and query parameters from
+`DATABASE_URL`. `POSTGRES_PASSWORD` is also accepted as the derivation password
+for the standard self-hosted setup.
+
+## Verify the effective role
+
+Connect using the same request URL supplied to Breeze. Avoid putting a password
+directly in shell history; use a protected service file, a password manager, or
+an ephemeral `PGPASSWORD` value appropriate for your environment.
+
+```sh
+psql "$DATABASE_URL_APP" -c 'SELECT current_user;'
+psql "$DATABASE_URL_APP" -c \
+  'SELECT rolname, rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user;'
+```
+
+The expected result identifies the intended request role and reports `f` for
+both `rolsuper` and `rolbypassrls`. Either flag being `t` is fatal to Breeze API
+startup because that capability can bypass forced tenant RLS protections.
+
+When the URL is derived instead of supplied explicitly, construct the equivalent
+`breeze_app` connection for the check without logging its password. Confirm its
+host, port, database, and TLS parameters match `DATABASE_URL`.

--- a/docs/superpowers/plans/2026-07-11-wave-2-effective-request-database-role.md
+++ b/docs/superpowers/plans/2026-07-11-wave-2-effective-request-database-role.md
@@ -1,0 +1,300 @@
+# Wave 2 Effective Request Database Role Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure production request handlers always use one canonically resolved, unprivileged PostgreSQL pool and refuse startup when that exact pool can bypass RLS.
+
+**Architecture:** Move request-connection resolution out of migration code into a small pure module that runs before the exported request pool is constructed. `DATABASE_URL` remains the system/migration URL; `DATABASE_URL_APP` wins when explicitly supplied; otherwise a password-only configuration derives a `breeze_app` URL from `DATABASE_URL`. A production startup initializer runs migrations only when enabled, then probes the exact request client regardless of `AUTO_MIGRATE` and rejects `SUPERUSER` or `BYPASSRLS` roles.
+
+**Tech Stack:** TypeScript, postgres-js, Drizzle ORM, Vitest, PostgreSQL 16 on OrbStack, pnpm 10.33.4.
+
+## Global Constraints
+
+- Implement Wave 2 / SR1-02 only.
+- Do not include or duplicate PR #2356 Microsoft 365 mailbox changes.
+- `DATABASE_URL` remains the migration/system connection.
+- `DATABASE_URL_APP`, when supplied, remains the explicit request connection.
+- Resolve the canonical unprivileged request URL before constructing the exported request pool.
+- Password-only configuration derives the request URL by replacing the `DATABASE_URL` credentials with `breeze_app` plus `BREEZE_APP_DB_PASSWORD`, falling back to `POSTGRES_PASSWORD` only for the password value.
+- Production must fail closed with an actionable configuration error when no explicit or derivable request URL exists; it must not silently fall back to `DATABASE_URL`.
+- Production startup must probe the exact postgres-js client used by request handlers and reject roles with `rolsuper=true` or `rolbypassrls=true`.
+- The production role probe runs whether `AUTO_MIGRATE` is enabled or set to `false`.
+- Existing non-production behavior may retain an explicitly warned compatibility fallback so unit tests and local tooling that never connect can continue importing the DB module.
+- Use OrbStack PostgreSQL for real-driver tests and keep the existing RLS coverage contract green.
+- The referenced `docs/superpowers/specs/2026-07-11-security-review-remediation-design.md` was absent from the dirty checkout, fetched `origin/main` at `0f05c1faa274f9c49b96ef57b829d9dbf2989477`, and all local Breeze worktrees; the user request and SR1-02 finding are the controlling requirements.
+
+---
+
+### Task 1: Canonical request database URL resolution
+
+**Files:**
+- Create: `apps/api/src/db/requestDatabaseConfig.ts`
+- Create: `apps/api/src/db/requestDatabaseConfig.test.ts`
+- Modify: `apps/api/src/db/index.ts:13-39`
+- Modify: `apps/api/src/db/autoMigrate.ts:247-269,570-615`
+- Modify: `apps/api/src/db/autoMigrate.test.ts:1-140`
+
+**Interfaces:**
+- Produces: `deriveAppConnectionString(adminUrl: string, appPassword: string | undefined): string | null`.
+- Produces: `resolveRequestDatabaseConfig(env?: NodeJS.ProcessEnv): { url: string; source: 'explicit' | 'derived' | 'development-fallback' }`.
+- Consumes: `DATABASE_URL`, `DATABASE_URL_APP`, `BREEZE_APP_DB_PASSWORD`, `POSTGRES_PASSWORD`, and `NODE_ENV`.
+- The returned `url` is consumed once by `db/index.ts` before its module-scope postgres-js request client is constructed.
+
+- [ ] **Step 1: Write failing resolver tests**
+
+Add focused tests that assert the following exact behaviors:
+
+```ts
+expect(resolveRequestDatabaseConfig({
+  NODE_ENV: 'production',
+  DATABASE_URL: 'postgresql://admin:admin-secret@db:5432/breeze',
+  BREEZE_APP_DB_PASSWORD: 'request-secret',
+}).url).toBe('postgresql://breeze_app:request-secret@db:5432/breeze');
+
+expect(resolveRequestDatabaseConfig({
+  NODE_ENV: 'production',
+  DATABASE_URL: 'postgresql://admin:admin-secret@db:5432/breeze',
+  DATABASE_URL_APP: 'postgresql://explicit:explicit-secret@request-db:6432/breeze?sslmode=require',
+  BREEZE_APP_DB_PASSWORD: 'ignored',
+})).toEqual({
+  url: 'postgresql://explicit:explicit-secret@request-db:6432/breeze?sslmode=require',
+  source: 'explicit',
+});
+
+expect(() => resolveRequestDatabaseConfig({
+  NODE_ENV: 'production',
+  DATABASE_URL: 'postgresql://admin:admin-secret@db:5432/breeze',
+})).toThrow(/DATABASE_URL_APP.*BREEZE_APP_DB_PASSWORD.*POSTGRES_PASSWORD/);
+```
+
+Also cover `POSTGRES_PASSWORD`, special-character password encoding, malformed `DATABASE_URL`, and the warned non-production compatibility fallback.
+
+- [ ] **Step 2: Run the resolver tests and verify RED**
+
+Run:
+
+```bash
+corepack pnpm -F @breeze/api exec vitest run src/db/requestDatabaseConfig.test.ts
+```
+
+Expected: FAIL because `requestDatabaseConfig.ts` and its exports do not exist.
+
+- [ ] **Step 3: Implement the minimal resolver**
+
+Implement a pure module with the following decision order:
+
+```ts
+const explicit = env.DATABASE_URL_APP?.trim();
+if (explicit) return { url: explicit, source: 'explicit' };
+
+const adminUrl = env.DATABASE_URL?.trim()
+  || 'postgresql://breeze:breeze@localhost:5432/breeze';
+const password = env.BREEZE_APP_DB_PASSWORD?.trim()
+  || env.POSTGRES_PASSWORD?.trim();
+const derived = deriveAppConnectionString(adminUrl, password);
+if (derived) return { url: derived, source: 'derived' };
+
+if (env.NODE_ENV === 'production') {
+  throw new Error(
+    '[database] Cannot configure the unprivileged request pool. Set DATABASE_URL_APP to a NOSUPERUSER/NOBYPASSRLS role, or set BREEZE_APP_DB_PASSWORD/POSTGRES_PASSWORD so Breeze can derive the breeze_app URL from DATABASE_URL. Refusing to use DATABASE_URL for request handlers.',
+  );
+}
+
+return { url: adminUrl, source: 'development-fallback' };
+```
+
+Use the resolver result before `postgres(...)` in `db/index.ts`. Log only the source, never a URL or password; emit a warning for `development-fallback`. Remove the duplicate derivation helper and separate app-role probe from `autoMigrate.ts`, and move its resolver tests into the new test file. Keep `autoMigrate()` on `DATABASE_URL` and retain both `ensureAppRole()` calls.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+corepack pnpm -F @breeze/api exec vitest run src/db/requestDatabaseConfig.test.ts src/db/autoMigrate.test.ts
+```
+
+Expected: PASS with the resolver cases and existing migration-helper suite green.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add apps/api/src/db/requestDatabaseConfig.ts apps/api/src/db/requestDatabaseConfig.test.ts apps/api/src/db/index.ts apps/api/src/db/autoMigrate.ts apps/api/src/db/autoMigrate.test.ts
+git commit -m "fix(api): resolve unprivileged request database URL"
+```
+
+---
+
+### Task 2: Exact request-pool startup enforcement, PostgreSQL regression coverage, and operator docs
+
+**Files:**
+- Create: `apps/api/src/db/databaseStartup.ts`
+- Create: `apps/api/src/db/databaseStartup.test.ts`
+- Create: `apps/api/src/db/requestDatabaseRole.integration.test.ts`
+- Create: `apps/api/vitest.config.request-db-role.ts`
+- Create: `docs/runbooks/request-database-role.md`
+- Modify: `apps/api/src/db/index.ts`
+- Modify: `apps/api/src/index.ts:1500-1530`
+- Modify: `apps/api/package.json`
+- Modify: `apps/api/vitest.config.ts`
+- Modify: `apps/api/vitest.integration.config.ts`
+- Modify: `.env.example:8-24`
+- Modify: `deploy/.env.example:60-66`
+
+**Interfaces:**
+- Consumes: the module-scope postgres-js `client` in `apps/api/src/db/index.ts`—the same client backing exported `db` and every request context.
+- Produces: `getRequestDatabaseRole(): Promise<{ currentUser: string; isSuperuser: boolean; bypassesRls: boolean }>`.
+- Produces: `assertRequestDatabaseRoleSafe(): Promise<RequestDatabaseRole>`; throws an actionable error when no role row is returned, `isSuperuser`, or `bypassesRls` is true.
+- Produces: `initializeDatabaseForStartup(options)`; conditionally runs migrations, then always runs the exact-pool role assertion in production.
+
+- [ ] **Step 1: Write failing startup-order unit tests**
+
+Use injected `migrate` and `verifyRequestRole` spies so the tests cover orchestration without importing the full API:
+
+```ts
+it('verifies the production request role when AUTO_MIGRATE=false', async () => {
+  const migrate = vi.fn();
+  const verifyRequestRole = vi.fn().mockRejectedValue(new Error('unsafe request role'));
+
+  await expect(initializeDatabaseForStartup({
+    autoMigrateEnabled: false,
+    production: true,
+    migrate,
+    verifyRequestRole,
+  })).rejects.toThrow('unsafe request role');
+
+  expect(migrate).not.toHaveBeenCalled();
+  expect(verifyRequestRole).toHaveBeenCalledOnce();
+});
+```
+
+Also cover migrate-before-verify when enabled and no production role probe in non-production.
+
+- [ ] **Step 2: Write failing real-PostgreSQL role tests**
+
+Run these through a dedicated Vitest config without the shared integration truncation setup. Against the isolated OrbStack PostgreSQL 16 database:
+
+```ts
+const role = await getRequestDatabaseRole();
+expect(role).toEqual({
+  currentUser: 'breeze_app',
+  isSuperuser: false,
+  bypassesRls: false,
+});
+```
+
+Create a temporary login role with `BYPASSRLS`, load a fresh request-pool module for each connection URL, and assert:
+
+```ts
+await expect(assertRequestDatabaseRoleSafe()).rejects.toThrow(/SUPERUSER/);
+await expect(assertRequestDatabaseRoleSafe()).rejects.toThrow(/BYPASSRLS/);
+```
+
+Finally set `NODE_ENV=production`, `AUTO_MIGRATE=false`, and point the canonical request pool at the admin URL; call `initializeDatabaseForStartup` with the real assertion and verify startup rejects without invoking migrations.
+
+- [ ] **Step 3: Run both new suites and verify RED**
+
+Run:
+
+```bash
+corepack pnpm -F @breeze/api exec vitest run src/db/databaseStartup.test.ts
+DATABASE_URL='postgresql://breeze_test:breeze_test@127.0.0.1:55432/breeze_test' \
+DATABASE_URL_APP='postgresql://breeze_app:breeze_test@127.0.0.1:55432/breeze_test' \
+corepack pnpm -F @breeze/api test:request-db-role
+```
+
+Expected: FAIL because the startup initializer, exact-pool role exports, config, and script do not exist.
+
+- [ ] **Step 4: Implement exact-pool enforcement and wire startup**
+
+In `db/index.ts`, query the already-created module-scope `client`:
+
+```sql
+SELECT current_user AS "currentUser",
+       rolsuper AS "isSuperuser",
+       rolbypassrls AS "bypassesRls"
+FROM pg_roles
+WHERE rolname = current_user
+```
+
+Reject missing rows and unsafe flags with an error that names the effective role and tells operators to set `DATABASE_URL_APP` to a `NOSUPERUSER NOBYPASSRLS` role or configure `BREEZE_APP_DB_PASSWORD`/`POSTGRES_PASSWORD` for derivation. Do not open a second probe client.
+
+Wire `initializeDatabaseForStartup` immediately after `validateConfig()` in `bootstrap()`:
+
+```ts
+await initializeDatabaseForStartup({
+  autoMigrateEnabled: process.env.AUTO_MIGRATE !== 'false',
+  production: config.NODE_ENV === 'production',
+});
+```
+
+The default dependencies call `autoMigrate` and `assertRequestDatabaseRoleSafe`. This ordering ensures role setup can happen during migrations but role verification is never inside the `AUTO_MIGRATE` branch.
+
+- [ ] **Step 5: Add operator documentation**
+
+Document the supported production matrix:
+
+| Configuration | Request pool result |
+|---|---|
+| `DATABASE_URL_APP` set | Used exactly as supplied; startup probes that pool |
+| No `DATABASE_URL_APP`, `BREEZE_APP_DB_PASSWORD` set | Derive `breeze_app` URL from `DATABASE_URL` |
+| No `DATABASE_URL_APP`, only `POSTGRES_PASSWORD` set | Derive `breeze_app` URL from `DATABASE_URL` |
+| Neither explicit URL nor app password available | Production startup refuses to use `DATABASE_URL` |
+
+State that `DATABASE_URL` is still required for migrations/system setup, `AUTO_MIGRATE=false` skips migrations only, and a `SUPERUSER`/`BYPASSRLS` effective request role is fatal. Include safe `psql` verification commands for `current_user`, `rolsuper`, and `rolbypassrls` without real infrastructure values.
+
+- [ ] **Step 6: Run focused and PostgreSQL-backed tests and verify GREEN**
+
+Run:
+
+```bash
+corepack pnpm -F @breeze/api exec vitest run \
+  src/db/requestDatabaseConfig.test.ts \
+  src/db/databaseStartup.test.ts \
+  src/db/autoMigrate.test.ts \
+  src/config/validate.test.ts
+
+DATABASE_URL='postgresql://breeze_test:breeze_test@127.0.0.1:55432/breeze_test' \
+DATABASE_URL_APP='postgresql://breeze_app:breeze_test@127.0.0.1:55432/breeze_test' \
+corepack pnpm -F @breeze/api test:request-db-role
+
+DATABASE_URL='postgresql://breeze_test:breeze_test@127.0.0.1:55432/breeze_test' \
+DATABASE_URL_APP='postgresql://breeze_app:breeze_test@127.0.0.1:55432/breeze_test' \
+corepack pnpm -F @breeze/api test:rls-coverage
+```
+
+Expected: all focused tests, all role tests, and all 53 RLS coverage tests pass.
+
+- [ ] **Step 7: Run repository verification**
+
+Run:
+
+```bash
+DATABASE_URL='postgresql://breeze_test:breeze_test@127.0.0.1:55432/breeze_test' \
+corepack pnpm -F @breeze/api db:check-drift
+corepack pnpm -F @breeze/api exec tsc --noEmit
+corepack pnpm -F @breeze/api build
+corepack pnpm -F @breeze/api lint
+git diff --check origin/main...HEAD
+```
+
+Expected: drift check, typecheck, build, lint, and whitespace validation all exit 0.
+
+- [ ] **Step 8: Commit Task 2**
+
+```bash
+git add apps/api/src/db/databaseStartup.ts apps/api/src/db/databaseStartup.test.ts \
+  apps/api/src/db/requestDatabaseRole.integration.test.ts apps/api/src/db/index.ts \
+  apps/api/src/index.ts apps/api/vitest.config.request-db-role.ts \
+  apps/api/vitest.config.ts apps/api/vitest.integration.config.ts apps/api/package.json \
+  .env.example deploy/.env.example docs/runbooks/request-database-role.md
+git commit -m "fix(api): enforce effective request database role"
+```
+
+---
+
+### Final review and publication gate
+
+- [ ] Generate a whole-branch review package from the merge base and request an independent security review focused on SR1-02, exact-pool identity, startup ordering, secret handling, and Wave 2-only scope.
+- [ ] Fix every Critical or Important review finding, re-run the covering tests, and request re-review.
+- [ ] Re-run the complete verification commands with fresh output.
+- [ ] Push `fix/security-review-request-db-role` and open a draft pull request against `main`; do not merge it.


### PR DESCRIPTION
## Summary

- resolve and canonicalize the unprivileged request database URL before constructing the exported request pool
- derive the `breeze_app` URL from password-only configuration while preserving explicit `DATABASE_URL_APP` and migration-only `DATABASE_URL` semantics
- probe the exact production request pool on every startup, including `AUTO_MIGRATE=false`, and reject SUPERUSER or BYPASSRLS roles
- harden single-endpoint URL parsing, compose configuration, integration-test safety, CI coverage, and operator guidance

Wave 2 / SR1-02 only. This PR intentionally contains no Microsoft 365 mailbox changes from Wave 1 / PR #2356.

## Verification

- focused API tests: 243 passed
- effective request-role PostgreSQL integration: 4 passed
- RLS coverage: 53 passed
- migration drift: all 391 files match
- API typecheck, build, and lint: passed
- `git diff --check`: passed
- final whole-branch security review: no findings

The API build retains the pre-existing `src/db/seed.ts` CommonJS `import.meta` warning.