### PR TITLE
fix(portal): enforce portal_branding.enable_tickets on all portal ticket surfaces (#2345)

### DIFF
--- a/apps/api/src/routes/portal.test.ts
+++ b/apps/api/src/routes/portal.test.ts
@@ -463,6 +463,44 @@ describe('portal routes', () => {
       expect(body.data).toHaveLength(1);
       expect(body.pagination.total).toBe(1);
     });
+
+    // #2345 — enforcement wiring regression guard: drives the REAL portalRoutes
+    // mount (index.ts registration order included), not a re-wired test app. If
+    // the portalTicketsEnabledMiddleware use() in routes/portal/index.ts is ever
+    // removed or reordered, this fails.
+    it('returns 403 PORTAL_TICKETS_DISABLED through the real mount when enable_tickets is false', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(
+          mockSelectLimit([
+            portalUser
+          ]) as any
+        )
+        .mockReturnValueOnce(
+          mockSelectLimit([
+            portalUser
+          ]) as any
+        )
+        // portalTicketsEnabledMiddleware branding lookup — explicit false
+        .mockReturnValueOnce(mockSelectLimit([{ enableTickets: false }]) as any);
+
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined)
+        })
+      } as any);
+
+      const token = await loginUser();
+
+      const res = await app.request('/portal/tickets?page=1&limit=25', {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${token}` }
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('Ticketing is not enabled for this portal');
+      expect(body.code).toBe('PORTAL_TICKETS_DISABLED');
+    });
   });
 
   describe('POST /portal/tickets', () => {

--- a/apps/api/src/routes/portal.test.ts
+++ b/apps/api/src/routes/portal.test.ts
@@ -428,6 +428,8 @@ describe('portal routes', () => {
             portalUser
           ]) as any
         )
+        // #2345 — portalTicketsEnabledMiddleware branding lookup (no row → fail-open, ticketing enabled)
+        .mockReturnValueOnce(mockSelectLimit([]) as any)
         .mockReturnValueOnce(mockSelectWhere([{ count: 1 }]) as any)
         .mockReturnValueOnce(
           mockSelectOrderLimitOffset([
@@ -475,7 +477,9 @@ describe('portal routes', () => {
           mockSelectLimit([
             portalUser
           ]) as any
-        );
+        )
+        // #2345 — portalTicketsEnabledMiddleware branding lookup (no row → fail-open, ticketing enabled)
+        .mockReturnValueOnce(mockSelectLimit([]) as any);
 
       vi.mocked(db.update).mockReturnValueOnce({
         set: vi.fn().mockReturnValue({
@@ -538,6 +542,8 @@ describe('portal routes', () => {
             portalUser
           ]) as any
         )
+        // #2345 — portalTicketsEnabledMiddleware branding lookup (no row → fail-open, ticketing enabled)
+        .mockReturnValueOnce(mockSelectLimit([]) as any)
         .mockReturnValueOnce(
           mockSelectLimit([
             {
@@ -593,6 +599,8 @@ describe('portal routes', () => {
             portalUser
           ]) as any
         )
+        // #2345 — portalTicketsEnabledMiddleware branding lookup (no row → fail-open, ticketing enabled)
+        .mockReturnValueOnce(mockSelectLimit([]) as any)
         .mockReturnValueOnce(mockSelectLimit([]) as any);
 
       vi.mocked(db.update).mockReturnValueOnce({
@@ -625,6 +633,8 @@ describe('portal routes', () => {
             portalUser
           ]) as any
         )
+        // #2345 — portalTicketsEnabledMiddleware branding lookup (no row → fail-open, ticketing enabled)
+        .mockReturnValueOnce(mockSelectLimit([]) as any)
         .mockReturnValueOnce(mockSelectLimit([{ id: 'ticket-1' }]) as any);
 
       vi.mocked(db.update).mockReturnValueOnce({
@@ -674,6 +684,8 @@ describe('portal routes', () => {
             portalUser
           ]) as any
         )
+        // #2345 — portalTicketsEnabledMiddleware branding lookup (no row → fail-open, ticketing enabled)
+        .mockReturnValueOnce(mockSelectLimit([]) as any)
         .mockReturnValueOnce(mockSelectLimit([]) as any);
 
       vi.mocked(db.update).mockReturnValueOnce({

--- a/apps/api/src/routes/portal/index.ts
+++ b/apps/api/src/routes/portal/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { brandingRoutes } from './branding';
 import { authRoutes, portalAuthMiddleware } from './auth';
 import { deviceRoutes } from './devices';
-import { ticketRoutes } from './tickets';
+import { ticketRoutes, portalTicketsEnabledMiddleware } from './tickets';
 import { assetRoutes } from './assets';
 import { profileRoutes } from './profile';
 import { invoiceRoutes as portalInvoiceRoutes } from './invoices';
@@ -17,6 +17,10 @@ portalRoutes.route('/', authRoutes);
 // Protected routes
 portalRoutes.use('/devices/*', portalAuthMiddleware);
 portalRoutes.use('/tickets/*', portalAuthMiddleware);
+// #2345 — org-level enable_tickets gate. MUST come after portalAuthMiddleware
+// (needs portalAuth + the org-scoped DB context) and on the same `/tickets/*`
+// prefix so all ticket surfaces — including GET /tickets/forms — are covered.
+portalRoutes.use('/tickets/*', portalTicketsEnabledMiddleware);
 portalRoutes.use('/assets/*', portalAuthMiddleware);
 portalRoutes.use('/profile/*', portalAuthMiddleware);
 portalRoutes.use('/invoices/*', portalAuthMiddleware);

--- a/apps/api/src/routes/portal/tickets.test.ts
+++ b/apps/api/src/routes/portal/tickets.test.ts
@@ -991,6 +991,9 @@ describe('portalTicketsEnabledMiddleware — enable_tickets gate (#2345)', () =>
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error).toBe('Ticketing is not enabled for this portal');
+    // Machine-readable code — the portal pages key their redirect on this so
+    // other 403s (e.g. "Account is not active") are not misread as "disabled".
+    expect(body.code).toBe('PORTAL_TICKETS_DISABLED');
   });
 
   it('enableTickets=false → 403 on POST /tickets (mutations gated, createTicket never called)', async () => {
@@ -1049,5 +1052,16 @@ describe('portalTicketsEnabledMiddleware — enable_tickets gate (#2345)', () =>
       headers: { Authorization: 'Bearer portal-token' }
     });
     expect(res.status).toBe(200);
+  });
+
+  it('mounted without portalAuth (misordered use()) → explicit 401, not a TypeError 500', async () => {
+    setupBrandingMock([{ enableTickets: false }]);
+    const app = new Hono();
+    // Deliberately NO auth middleware before the gate — simulates a future
+    // index.ts refactor reordering the use() calls.
+    app.use('/tickets/*', portalTicketsEnabledMiddleware);
+    app.route('/', ticketRoutes);
+    const res = await app.request('/tickets');
+    expect(res.status).toBe(401);
   });
 });

--- a/apps/api/src/routes/portal/tickets.test.ts
+++ b/apps/api/src/routes/portal/tickets.test.ts
@@ -81,6 +81,9 @@ vi.mock('../../db/schema', () => ({
   },
   organizations: {
     id: 'id', partnerId: 'partnerId'
+  },
+  portalBranding: {
+    id: 'id', orgId: 'orgId', enableTickets: 'enableTickets'
   }
 }));
 
@@ -103,7 +106,7 @@ vi.mock('./helpers', () => ({
   writePortalAudit: vi.fn()
 }));
 
-import { ticketRoutes } from './tickets';
+import { ticketRoutes, portalTicketsEnabledMiddleware } from './tickets';
 import { validatePortalCookieCsrfRequest, writePortalAudit } from './helpers';
 
 // ── Test app ──────────────────────────────────────────────────────────────────
@@ -921,5 +924,130 @@ describe('portal DELETE /tickets/:id/comments/:commentId', () => {
       headers: portalJsonHeaders,
     });
     expect(res.status).toBe(403);
+  });
+});
+
+// ── portalTicketsEnabledMiddleware — #2345 enable_tickets enforcement ─────────
+//
+// The per-org `portal_branding.enable_tickets` toggle must gate EVERY portal
+// ticket surface. The middleware is registered in routes/portal/index.ts on the
+// same `/tickets/*` prefix as portalAuthMiddleware; this suite wires the app the
+// way index.ts actually mounts it (prefix-scoped middleware + route('/')) so the
+// prefix coverage — including GET /tickets/forms — is asserted structurally.
+describe('portalTicketsEnabledMiddleware — enable_tickets gate (#2345)', () => {
+  function buildGatedApp() {
+    const app = new Hono();
+    app.use('/tickets/*', async (c, next) => {
+      c.set('portalAuth' as never, { user: PORTAL_USER, token: 'tok-1', authMethod: 'bearer' });
+      await next();
+    });
+    app.use('/tickets/*', portalTicketsEnabledMiddleware);
+    app.route('/', ticketRoutes);
+    return app;
+  }
+
+  /**
+   * First db.select call is the middleware's branding lookup
+   * (.from(portalBranding).where(orgId).limit(1)) → returns brandingRows.
+   * Subsequent calls resolve generically so a passing request can complete
+   * (list count/data, forms partnerId lookup, ...).
+   */
+  function setupBrandingMock(brandingRows: object[]) {
+    let callCount = 0;
+    dbSelectMock.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          from: vi.fn(() => ({
+            where: vi.fn(() => ({
+              limit: vi.fn(() => Promise.resolve(brandingRows))
+            }))
+          }))
+        };
+      }
+      // Generic chain: supports .from().where().limit() and the GET /tickets
+      // list shape .from().leftJoin().where().orderBy().limit().offset().
+      const terminal = Promise.resolve([]);
+      const chain: Record<string, unknown> = {};
+      for (const m of ['from', 'leftJoin', 'where', 'orderBy', 'limit']) {
+        chain[m] = vi.fn(() => chain);
+      }
+      chain.offset = vi.fn(() => terminal);
+      (chain as { then: unknown }).then = terminal.then.bind(terminal);
+      return chain;
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enableTickets=false → 403 with a clear message on GET /tickets', async () => {
+    setupBrandingMock([{ enableTickets: false }]);
+    const app = buildGatedApp();
+    const res = await app.request('/tickets', {
+      headers: { Authorization: 'Bearer portal-token' }
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Ticketing is not enabled for this portal');
+  });
+
+  it('enableTickets=false → 403 on POST /tickets (mutations gated, createTicket never called)', async () => {
+    setupBrandingMock([{ enableTickets: false }]);
+    const app = buildGatedApp();
+    const res = await app.request('/tickets', {
+      method: 'POST',
+      headers: portalJsonHeaders,
+      body: JSON.stringify({ subject: 'Printer broken', description: 'It makes a loud clicking noise now', priority: 'normal' })
+    });
+    expect(res.status).toBe(403);
+    expect(createTicketMock).not.toHaveBeenCalled();
+  });
+
+  it('enableTickets=false → 403 on GET /tickets/forms (Phase 2 intake endpoint is covered by the prefix)', async () => {
+    setupBrandingMock([{ enableTickets: false }]);
+    const app = buildGatedApp();
+    const res = await app.request('/tickets/forms', {
+      headers: { Authorization: 'Bearer portal-token' }
+    });
+    expect(res.status).toBe(403);
+    expect(listTicketFormsForOrgMock).not.toHaveBeenCalled();
+  });
+
+  it('enableTickets=false → 403 on GET /tickets/:id and comment mutations', async () => {
+    setupBrandingMock([{ enableTickets: false }]);
+    let app = buildGatedApp();
+    const detail = await app.request(`/tickets/${TICKET_ID}`, {
+      headers: { Authorization: 'Bearer portal-token' }
+    });
+    expect(detail.status).toBe(403);
+
+    setupBrandingMock([{ enableTickets: false }]);
+    app = buildGatedApp();
+    const comment = await app.request(`/tickets/${TICKET_ID}/comments`, {
+      method: 'POST',
+      headers: portalJsonHeaders,
+      body: JSON.stringify({ content: 'hello' })
+    });
+    expect(comment.status).toBe(403);
+  });
+
+  it('enableTickets=true → passes through (200 on GET /tickets)', async () => {
+    setupBrandingMock([{ enableTickets: true }]);
+    const app = buildGatedApp();
+    const res = await app.request('/tickets', {
+      headers: { Authorization: 'Bearer portal-token' }
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('NO branding row → fail-open, ticketing stays enabled (200 on GET /tickets)', async () => {
+    setupBrandingMock([]);
+    const app = buildGatedApp();
+    const res = await app.request('/tickets', {
+      headers: { Authorization: 'Bearer portal-token' }
+    });
+    expect(res.status).toBe(200);
   });
 });

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -39,6 +39,13 @@ export const ticketRoutes = new Hono();
 // class exists but is administratively disabled; 404 would misread as a bug).
 export const portalTicketsEnabledMiddleware: MiddlewareHandler = async (c, next) => {
   const auth = c.get('portalAuth');
+  // Defensive: only meaningful when mounted AFTER portalAuthMiddleware (index.ts
+  // registers it that way). If a refactor ever reorders the use() calls or mounts
+  // this on an unauthenticated prefix, fail closed with an explicit 401 instead
+  // of an opaque TypeError 500.
+  if (!auth) {
+    return c.json({ error: 'Authentication required' }, 401);
+  }
 
   const [row] = await db
     .select({ enableTickets: portalBranding.enableTickets })
@@ -47,7 +54,10 @@ export const portalTicketsEnabledMiddleware: MiddlewareHandler = async (c, next)
     .limit(1);
 
   if (row?.enableTickets === false) {
-    return c.json({ error: 'Ticketing is not enabled for this portal' }, 403);
+    // `code` lets the portal pages distinguish this 403 from other 403s on the
+    // same routes (e.g. portalAuthMiddleware's "Account is not active") and only
+    // redirect for THIS one. Keep in sync with apps/portal/src/pages/tickets/*.
+    return c.json({ error: 'Ticketing is not enabled for this portal', code: 'PORTAL_TICKETS_DISABLED' }, 403);
   }
 
   return next();

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -1,8 +1,9 @@
 import { Hono } from 'hono';
+import type { MiddlewareHandler } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { and, desc, eq, isNull, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
-import { tickets, ticketComments, ticketStatuses, organizations } from '../../db/schema';
+import { tickets, ticketComments, ticketStatuses, organizations, portalBranding } from '../../db/schema';
 import {
   listSchema,
   createTicketSchema,
@@ -23,6 +24,34 @@ import { listTicketFormsForOrg } from '../../services/ticketFormService';
 import { editCommentSchema } from '@breeze/shared';
 
 export const ticketRoutes = new Hono();
+
+// #2345 — per-org portal ticketing kill switch. `portal_branding.enable_tickets`
+// (toggled in the web UI's org portal settings) was stored and surfaced but never
+// enforced. Registered in routes/portal/index.ts on the `/tickets/*` prefix AFTER
+// portalAuthMiddleware, so it covers EVERY portal ticket surface in one place
+// (list/detail/create/comments AND the Phase 2 `/tickets/forms` intake endpoint)
+// and runs inside the session org's RLS context — portal_branding is org-forced,
+// so the session org's row is visible here without a system context.
+//
+// Fail-OPEN on a missing row: the column defaults to true and most orgs have no
+// portal_branding row at all — ticketing must stay enabled for them. Only an
+// explicit `enable_tickets = false` blocks, with a consistent 403 (the resource
+// class exists but is administratively disabled; 404 would misread as a bug).
+export const portalTicketsEnabledMiddleware: MiddlewareHandler = async (c, next) => {
+  const auth = c.get('portalAuth');
+
+  const [row] = await db
+    .select({ enableTickets: portalBranding.enableTickets })
+    .from(portalBranding)
+    .where(eq(portalBranding.orgId, auth.user.orgId))
+    .limit(1);
+
+  if (row?.enableTickets === false) {
+    return c.json({ error: 'Ticketing is not enabled for this portal' }, 403);
+  }
+
+  return next();
+};
 
 // GET /tickets/forms — MUST live under the `/tickets/` prefix: portal auth is
 // applied per-prefix in routes/portal/index.ts (`use('/tickets/*', ...)`), so

--- a/apps/portal/src/layouts/PortalLayout.astro
+++ b/apps/portal/src/layouts/PortalLayout.astro
@@ -2,6 +2,7 @@
 import '../styles/globals.css';
 import { ClientRouter } from 'astro:transitions';
 import { loadPortalBranding } from '../lib/server';
+import { buildPortalNavItems } from '../lib/navItems';
 import { stripBase, withBase } from '../lib/basePath';
 
 interface Props {
@@ -13,14 +14,10 @@ const { title } = Astro.props;
 // active-nav comparison below stays base-agnostic.
 const pathname = stripBase(Astro.url.pathname);
 const branding = await loadPortalBranding(Astro.request);
-const navItems = [
-  { label: 'Devices', href: '/devices' },
-  { label: 'Tickets', href: '/tickets' },
-  { label: 'Quotes', href: '/quotes' },
-  { label: 'Invoices', href: '/invoices' },
-  { label: 'Assets', href: '/assets' },
-  { label: 'Profile', href: '/profile' }
-];
+// #2345 — Tickets is hidden when the org's branding has enableTickets: false.
+// Fail-open when the flag is absent (shared-domain portals get no branding row);
+// the API's 403 gate on /portal/tickets/* is the real enforcement.
+const navItems = buildPortalNavItems(branding);
 
 const isActive = (href: string) => {
   if (href === '/') return pathname === '/';

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -138,6 +138,8 @@ export interface ApiRequestConfig {
 export interface ApiResponse<T> {
   data?: T;
   error?: string;
+  /** Machine-readable error code from the API body (e.g. PORTAL_TICKETS_DISABLED). */
+  code?: string;
   statusCode?: number;
   headers?: Headers;
 }
@@ -192,6 +194,7 @@ export async function apiRequest<T>(
     if (!response.ok) {
       return {
         error: body?.error || 'Request failed',
+        code: typeof body?.code === 'string' ? body.code : undefined,
         statusCode: response.status,
         headers: response.headers
       };
@@ -509,6 +512,7 @@ function mapPaginatedData<T>(
   if (!response.data) {
     return {
       error: response.error,
+      code: response.code,
       statusCode: response.statusCode,
       headers: response.headers
     };
@@ -555,6 +559,7 @@ export const portalApi = {
     if (!response.data) {
       return {
         error: response.error,
+        code: response.code,
         statusCode: response.statusCode,
         headers: response.headers
       };
@@ -577,6 +582,7 @@ export const portalApi = {
     if (!response.data) {
       return {
         error: response.error,
+        code: response.code,
         statusCode: response.statusCode,
         headers: response.headers
       };

--- a/apps/portal/src/lib/navItems.test.ts
+++ b/apps/portal/src/lib/navItems.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { buildPortalNavItems } from './navItems';
+
+describe('buildPortalNavItems — enable_tickets nav gating (#2345)', () => {
+  it('hides the Tickets entry when enableTickets is explicitly false', () => {
+    const items = buildPortalNavItems({ enableTickets: false });
+    expect(items.map((i) => i.href)).not.toContain('/tickets');
+    // Only Tickets is affected — the rest of the nav is untouched.
+    expect(items.map((i) => i.href)).toEqual([
+      '/devices',
+      '/quotes',
+      '/invoices',
+      '/assets',
+      '/profile'
+    ]);
+  });
+
+  it('shows Tickets when enableTickets is true', () => {
+    expect(buildPortalNavItems({ enableTickets: true }).map((i) => i.href)).toContain('/tickets');
+  });
+
+  it('fails OPEN: shows Tickets when the flag is absent (no branding row / default branding)', () => {
+    expect(buildPortalNavItems({}).map((i) => i.href)).toContain('/tickets');
+    expect(
+      buildPortalNavItems({ enableTickets: undefined }).map((i) => i.href)
+    ).toContain('/tickets');
+  });
+});

--- a/apps/portal/src/lib/navItems.ts
+++ b/apps/portal/src/lib/navItems.ts
@@ -1,0 +1,30 @@
+import type { BrandingConfig } from './api';
+
+export interface PortalNavItem {
+  label: string;
+  href: string;
+}
+
+const ALL_NAV_ITEMS: PortalNavItem[] = [
+  { label: 'Devices', href: '/devices' },
+  { label: 'Tickets', href: '/tickets' },
+  { label: 'Quotes', href: '/quotes' },
+  { label: 'Invoices', href: '/invoices' },
+  { label: 'Assets', href: '/assets' },
+  { label: 'Profile', href: '/profile' }
+];
+
+/**
+ * Nav entries for the portal shell, honoring per-org feature toggles from the
+ * branding payload (#2345). Fail-OPEN: a missing branding row / undefined flag
+ * keeps Tickets visible — the API column defaults to true, and the server-side
+ * 403 gate on `/portal/tickets/*` is the real enforcement. Only an explicit
+ * `enableTickets: false` hides the entry.
+ */
+export function buildPortalNavItems(
+  branding: Pick<BrandingConfig, 'enableTickets'>
+): PortalNavItem[] {
+  return ALL_NAV_ITEMS.filter(
+    (item) => item.href !== '/tickets' || branding.enableTickets !== false
+  );
+}

--- a/apps/portal/src/pages/tickets/[id].astro
+++ b/apps/portal/src/pages/tickets/[id].astro
@@ -12,10 +12,11 @@ if (response.statusCode === 401) {
   return Astro.redirect(withBase('/login'));
 }
 
-// #2345 — 403 here means ticketing is disabled for this org
-// (portal_branding.enable_tickets); bounce to the portal home instead of
-// rendering a dead page around the API error.
-if (response.statusCode === 403) {
+// #2345 — the enable_tickets gate 403s with code PORTAL_TICKETS_DISABLED;
+// bounce to the portal home instead of rendering a dead page. Other 403s
+// (e.g. "Account is not active") keep the previous behavior: fall through and
+// render the page with the API error inline.
+if (response.statusCode === 403 && response.code === 'PORTAL_TICKETS_DISABLED') {
   return Astro.redirect(withBase('/devices'));
 }
 ---

--- a/apps/portal/src/pages/tickets/[id].astro
+++ b/apps/portal/src/pages/tickets/[id].astro
@@ -11,6 +11,13 @@ const response = await portalApi.getTicket(id!, buildServerApiConfig(Astro.reque
 if (response.statusCode === 401) {
   return Astro.redirect(withBase('/login'));
 }
+
+// #2345 — 403 here means ticketing is disabled for this org
+// (portal_branding.enable_tickets); bounce to the portal home instead of
+// rendering a dead page around the API error.
+if (response.statusCode === 403) {
+  return Astro.redirect(withBase('/devices'));
+}
 ---
 
 <PortalLayout title="Ticket Details">

--- a/apps/portal/src/pages/tickets/index.astro
+++ b/apps/portal/src/pages/tickets/index.astro
@@ -14,10 +14,11 @@ if (response.statusCode === 401) {
   return Astro.redirect(withBase('/login'));
 }
 
-// #2345 — 403 here means ticketing is disabled for this org
-// (portal_branding.enable_tickets); bounce to the portal home instead of
-// rendering a dead page around the API error.
-if (response.statusCode === 403) {
+// #2345 — the enable_tickets gate 403s with code PORTAL_TICKETS_DISABLED;
+// bounce to the portal home instead of rendering a dead page. Other 403s
+// (e.g. "Account is not active") keep the previous behavior: fall through and
+// render the page with the API error inline.
+if (response.statusCode === 403 && response.code === 'PORTAL_TICKETS_DISABLED') {
   return Astro.redirect(withBase('/devices'));
 }
 ---

--- a/apps/portal/src/pages/tickets/index.astro
+++ b/apps/portal/src/pages/tickets/index.astro
@@ -13,6 +13,13 @@ const response = await portalApi.getTickets(
 if (response.statusCode === 401) {
   return Astro.redirect(withBase('/login'));
 }
+
+// #2345 — 403 here means ticketing is disabled for this org
+// (portal_branding.enable_tickets); bounce to the portal home instead of
+// rendering a dead page around the API error.
+if (response.statusCode === 403) {
+  return Astro.redirect(withBase('/devices'));
+}
 ---
 
 <PortalLayout title="Support Tickets">

--- a/apps/portal/src/pages/tickets/new.astro
+++ b/apps/portal/src/pages/tickets/new.astro
@@ -16,8 +16,17 @@ const formsResponse = await portalApi.getTicketForms(buildServerApiConfig(Astro.
 if (formsResponse.statusCode === 401) {
   return Astro.redirect(withBase('/login'));
 }
-if (formsResponse.statusCode === 403) {
+if (formsResponse.statusCode === 403 && formsResponse.code === 'PORTAL_TICKETS_DISABLED') {
   return Astro.redirect(withBase('/devices'));
+}
+if (formsResponse.error && formsResponse.statusCode !== 403) {
+  // Fail-open is intentional, but never invisible: without this breadcrumb a
+  // probe that fails on every page load (API down, portal→API network fault)
+  // would leave no portal-side trace while the form quietly degrades.
+  console.error('[portal] new-ticket gate probe failed; failing open', {
+    statusCode: formsResponse.statusCode,
+    error: formsResponse.error
+  });
 }
 ---
 

--- a/apps/portal/src/pages/tickets/new.astro
+++ b/apps/portal/src/pages/tickets/new.astro
@@ -1,6 +1,24 @@
 ---
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import NewTicketForm from '../../components/portal/NewTicketForm';
+import { withBase } from '../../lib/basePath';
+import { portalApi } from '../../lib/api';
+import { buildServerApiConfig } from '../../lib/server';
+
+// #2345 — this page has no data fetch of its own, so probe the session org's
+// ticket surface server-side: a 403 from /portal/tickets/forms means ticketing
+// is disabled (portal_branding.enable_tickets) and the page must not render.
+// Session-scoped, so it also covers shared-domain portals where the
+// domain-resolved branding payload carries no flags. Any other outcome
+// (including transient errors) falls through to the form — the API gate on
+// POST /portal/tickets is the real enforcement.
+const formsResponse = await portalApi.getTicketForms(buildServerApiConfig(Astro.request));
+if (formsResponse.statusCode === 401) {
+  return Astro.redirect(withBase('/login'));
+}
+if (formsResponse.statusCode === 403) {
+  return Astro.redirect(withBase('/devices'));
+}
 ---
 
 <PortalLayout title="New Ticket">


### PR DESCRIPTION
## Summary

`portal_branding.enable_tickets` (the per-org "Enable tickets" toggle in the org portal settings editor) was stored and returned but never enforced — an org admin who disabled portal ticketing still got the full portal ticket flow. This enforces it at both layers.

**Server side (the real gate)** — new `portalTicketsEnabledMiddleware` in `apps/api/src/routes/portal/tickets.ts`, registered in `routes/portal/index.ts` on the same `/tickets/*` prefix as `portalAuthMiddleware` (and after it, so it runs inside the session org's RLS context). One guard covers every portal ticket surface: list, detail, create, comment create/edit/delete, **and the Phase 2 `GET /tickets/forms` intake endpoint**. Swept the rest of the portal router — no other route serves ticket data.

- Explicit `enable_tickets = false` → consistent **403** `{"error":"Ticketing is not enabled for this portal"}` (403 over 404: the surface exists but is administratively disabled).
- **Fail-open** on a missing branding row or unset flag — the column defaults to `true` and most orgs have no `portal_branding` row at all, so ticketing stays enabled for them.

**Portal UI** (`apps/portal`) — no dead 403 pages:

- Tickets nav entry hidden when the branding payload has `enableTickets: false` (`buildPortalNavItems`, fail-open when the flag is absent, e.g. shared-domain portals whose domain-resolved branding 404s).
- `/tickets` and `/tickets/[id]` bounce a 403 from their existing session-scoped fetch to `/devices`.
- `/tickets/new` had no server fetch, so it gains a session-scoped probe via `GET /portal/tickets/forms` and redirects on 403 — this covers shared-domain portals where the branding payload carries no flags. Any other outcome falls through to the form; the API gate stays authoritative.

The portal `middleware.ts` was left auth-only on purpose: it has no org/session data without an extra API call per request, and the pages' session-scoped fetches already carry the signal.

## Release notes

**Behavior change:** orgs that previously switched "Enable tickets" off in portal settings believed it worked — it did nothing. After this release the toggle is enforced: portal users of those orgs lose the ticket UI, and the portal ticket API returns 403. Re-enable the toggle in Settings → Portal to restore ticketing. Defaults are unchanged (ticketing stays enabled for orgs that never touched the toggle or have no branding row).

## Tests

- `apps/api/src/routes/portal/tickets.test.ts` — new suite mounts the middleware exactly as `index.ts` does and covers: 403 on GET /tickets, POST /tickets (createTicket never called), GET /tickets/forms (prefix coverage), GET /tickets/:id + comment POST; pass-through on `enableTickets: true`; fail-open on no branding row. 44 passed.
- `apps/api/src/routes/portal.test.ts` — full-mount ticket tests updated for the middleware's branding lookup slot. 27 passed (with `portal.compat.test.ts`).
- `apps/portal/src/lib/navItems.test.ts` — nav hidden on `false`, shown on `true`, fail-open on absent flag. Portal suite 75 passed.
- Typecheck: `tsc --noEmit` clean (api + portal), `astro check` 0 errors.

Closes #2345

🤖 Generated with [Claude Code](https://claude.com/claude-code)