### PR TITLE
fix(ai): catalog MCP tools — strip raw distributor blob + internal IDs, SKU/part-number search (#2365)

### DIFF
--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -321,6 +321,7 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
   search_catalog: z.object({
     search: z.string().optional(),
     itemType: z.enum(['hardware', 'software', 'service']).optional(),
+    isBundle: z.boolean().optional(),
     limit: z.number().int().min(1).max(100).optional(),
   }),
 

--- a/apps/api/src/services/aiToolsCatalog.test.ts
+++ b/apps/api/src/services/aiToolsCatalog.test.ts
@@ -280,6 +280,30 @@ describe('aiToolsCatalog: get_catalog_item', () => {
     expect(parsed.item.attributes.distributor.msrp).toBe(150);
   });
 
+  it('redacts revenueAllocation from bundle components for org-scoped callers', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeChain([{ id: ITEM_ID, isBundle: true, attributes: {} }], {}) as any)
+      .mockReturnValueOnce(
+        makeChain(
+          [{ id: 'comp-row', componentItemId: 'c1', quantity: '2', showOnInvoice: false, revenueAllocation: '60.00' }],
+          {}
+        ) as any
+      );
+
+    const orgAuth = {
+      user: { id: 'u1' },
+      partnerId: PARTNER_ID,
+      scope: 'organization',
+      orgId: 'org-1',
+      accessibleOrgIds: ['org-1'],
+    } as any;
+    const out = await tools().get('get_catalog_item')!.handler({ catalogItemId: ITEM_ID }, orgAuth);
+    const parsed = JSON.parse(out);
+    expect(parsed.components).toEqual([
+      { id: 'comp-row', componentItemId: 'c1', quantity: '2', showOnInvoice: false },
+    ]);
+  });
+
   it('handles items with no distributor attributes (empty attributes object)', async () => {
     const row = { id: ITEM_ID, partnerId: PARTNER_ID, createdBy: null, isBundle: false, attributes: {} };
     vi.mocked(db.select).mockReturnValueOnce(makeChain([row], {}) as any);

--- a/apps/api/src/services/aiToolsCatalog.test.ts
+++ b/apps/api/src/services/aiToolsCatalog.test.ts
@@ -247,6 +247,51 @@ describe('aiToolsCatalog: get_catalog_item', () => {
     expect(parsed.item.markupPercent).toBe('20.00');
   });
 
+  it('drops unknown/future top-level columns and unknown distributor sub-fields by construction (allowlist)', async () => {
+    const row = {
+      id: ITEM_ID,
+      partnerId: PARTNER_ID,
+      createdBy: 'user-uuid',
+      name: 'SPL Dock',
+      isBundle: false,
+      unitPrice: '120.00',
+      // A column a future migration might add — must NOT reach MCP output because
+      // the output is an allowlist, not a blocklist of known-sensitive names.
+      supplierAccountId: 'acct-should-not-leak',
+      internalNotes: 'confidential margin strategy',
+      attributes: {
+        category: 'docks',
+        distributor: {
+          synnexSku: '14703953',
+          cost: 100,
+          msrp: 150,
+          raw: { verbatim: true },
+          // A future distributor sub-field an importer might store — must be dropped.
+          dealerCost: 42,
+          supplierToken: 'secret-token',
+        },
+      },
+    };
+    vi.mocked(db.select).mockReturnValueOnce(makeChain([row], {}) as any);
+
+    const out = await tools().get('get_catalog_item')!.handler({ catalogItemId: ITEM_ID }, partnerAuth());
+    const parsed = JSON.parse(out);
+
+    // Unknown top-level columns are dropped even for partner (full-access) scope.
+    expect(parsed.item).not.toHaveProperty('supplierAccountId');
+    expect(parsed.item).not.toHaveProperty('internalNotes');
+    // Known allowlisted fields still present.
+    expect(parsed.item.name).toBe('SPL Dock');
+    expect(parsed.item.unitPrice).toBe('120.00');
+    // Unknown distributor sub-fields (and the raw blob) are dropped; normalized survive.
+    expect(parsed.item.attributes.distributor).not.toHaveProperty('raw');
+    expect(parsed.item.attributes.distributor).not.toHaveProperty('dealerCost');
+    expect(parsed.item.attributes.distributor).not.toHaveProperty('supplierToken');
+    expect(parsed.item.attributes.distributor).toMatchObject({ synnexSku: '14703953', cost: 100, msrp: 150 });
+    // Non-distributor attribute keys still pass through.
+    expect(parsed.item.attributes.category).toBe('docks');
+  });
+
   it('redacts costBasis/markupPercent/distributor.cost for org-scoped callers (defense-in-depth)', async () => {
     const row = {
       id: ITEM_ID,

--- a/apps/api/src/services/aiToolsCatalog.test.ts
+++ b/apps/api/src/services/aiToolsCatalog.test.ts
@@ -9,6 +9,8 @@ vi.mock('drizzle-orm', () => ({
   eq: (a: unknown, b: unknown) => ({ _op: 'eq', a, b }),
   ilike: (a: unknown, b: unknown) => ({ _op: 'ilike', a, b }),
   asc: (a: unknown) => ({ _op: 'asc', a }),
+  or: (...args: unknown[]) => ({ _op: 'or', args }),
+  sql: (strings: TemplateStringsArray, ...vals: unknown[]) => ({ _op: 'sql', strings: [...strings], vals }),
 }));
 
 vi.mock('../db', () => ({
@@ -25,6 +27,7 @@ vi.mock('../db/schema', () => ({
     isBundle: 'ci.is_bundle',
     isActive: 'ci.is_active',
     partnerId: 'ci.partner_id',
+    attributes: 'ci.attributes',
   },
   catalogItemOrgPricing: { id: 'cop.id' },
   catalogBundleComponents: {
@@ -117,8 +120,47 @@ describe('aiToolsCatalog: search_catalog', () => {
 
     const conds = flattenConditions(capture.where);
     expect(conds).toContainEqual({ _op: 'eq', a: 'ci.item_type', b: 'hardware' });
-    // search term is escaped (% and _ become \% and \_) and wrapped in %...%
-    expect(conds).toContainEqual({ _op: 'ilike', a: 'ci.name', b: '%50\\%\\_off%' });
+    // The search condition is an OR across name / sku / distributor part numbers;
+    // the term is escaped (% and _ become \% and \_) and wrapped in %...%
+    const orToken = conds.find((c) => c._op === 'or');
+    expect(orToken).toBeDefined();
+    expect(orToken.args).toContainEqual({ _op: 'ilike', a: 'ci.name', b: '%50\\%\\_off%' });
+  });
+
+  it('search matches sku and distributor part-number attributes (mfgPartNo / synnexSku)', async () => {
+    const capture: WhereCapture = {};
+    vi.mocked(db.select).mockReturnValue(makeChain([], capture) as any);
+
+    await tools().get('search_catalog')!.handler({ search: '14703953' }, partnerAuth());
+
+    const orToken = flattenConditions(capture.where).find((c) => c._op === 'or');
+    expect(orToken).toBeDefined();
+    // name + item SKU columns
+    expect(orToken.args).toContainEqual({ _op: 'ilike', a: 'ci.name', b: '%14703953%' });
+    expect(orToken.args).toContainEqual({ _op: 'ilike', a: 'ci.sku', b: '%14703953%' });
+    // jsonb fragments on attributes.distributor.mfgPartNo / .synnexSku
+    const sqlFragments = orToken.args.filter((a: any) => a._op === 'sql');
+    expect(sqlFragments).toHaveLength(2);
+    const fragmentText = sqlFragments.map((f: any) => f.strings.join('?')).join(' | ');
+    expect(fragmentText).toContain("'distributor' ->> 'mfgPartNo'");
+    expect(fragmentText).toContain("'distributor' ->> 'synnexSku'");
+    for (const f of sqlFragments) {
+      expect(f.vals).toContainEqual('%14703953%');
+    }
+  });
+
+  it('applies the isBundle filter for both true and false (but not when omitted)', async () => {
+    for (const isBundle of [true, false]) {
+      const capture: WhereCapture = {};
+      vi.mocked(db.select).mockReturnValue(makeChain([], capture) as any);
+      await tools().get('search_catalog')!.handler({ isBundle }, partnerAuth());
+      expect(flattenConditions(capture.where)).toContainEqual({ _op: 'eq', a: 'ci.is_bundle', b: isBundle });
+    }
+    // omitted → no isBundle condition
+    const capture: WhereCapture = {};
+    vi.mocked(db.select).mockReturnValue(makeChain([], capture) as any);
+    await tools().get('search_catalog')!.handler({}, partnerAuth());
+    expect(flattenConditions(capture.where).some((c) => c.a === 'ci.is_bundle')).toBe(false);
   });
 });
 
@@ -151,6 +193,102 @@ describe('aiToolsCatalog: get_catalog_item', () => {
     expect(parsed.components).toBeUndefined();
     // Only the item lookup ran — the components query is gated on isBundle.
     expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('strips internal IDs and attributes.distributor.raw, keeping normalized distributor fields', async () => {
+    const row = {
+      id: ITEM_ID,
+      partnerId: PARTNER_ID,
+      createdBy: 'user-uuid',
+      name: 'SPL Dock',
+      isBundle: false,
+      costBasis: '100.00',
+      markupPercent: '20.00',
+      unitPrice: '120.00',
+      attributes: {
+        category: 'docks',
+        distributor: {
+          source: 'td_synnex_ec_express',
+          synnexSku: '14703953',
+          mfgPartNo: 'SPL-DOCK-1',
+          status: 'Active',
+          cost: 100,
+          msrp: 150,
+          warehouses: [{ code: 'A1', available: 3 }],
+          importedAt: '2026-07-01T00:00:00.000Z',
+          raw: { hugeVerbatimProviderPayload: true, price: 100, msrp: 150 },
+        },
+      },
+    };
+    vi.mocked(db.select).mockReturnValueOnce(makeChain([row], {}) as any);
+
+    const out = await tools().get('get_catalog_item')!.handler({ catalogItemId: ITEM_ID }, partnerAuth());
+    const parsed = JSON.parse(out);
+
+    // Internal IDs are redacted server-side (MCP instructions say never reveal them).
+    expect(parsed.item).not.toHaveProperty('partnerId');
+    expect(parsed.item).not.toHaveProperty('createdBy');
+    // The verbatim import blob is stripped…
+    expect(parsed.item.attributes.distributor).not.toHaveProperty('raw');
+    // …but the normalized distributor fields survive.
+    expect(parsed.item.attributes.distributor).toMatchObject({
+      synnexSku: '14703953',
+      mfgPartNo: 'SPL-DOCK-1',
+      status: 'Active',
+      cost: 100,
+      msrp: 150,
+      importedAt: '2026-07-01T00:00:00.000Z',
+    });
+    expect(parsed.item.attributes.distributor.warehouses).toEqual([{ code: 'A1', available: 3 }]);
+    // Non-distributor attributes are untouched.
+    expect(parsed.item.attributes.category).toBe('docks');
+    // Partner scope keeps cost/margin fields.
+    expect(parsed.item.costBasis).toBe('100.00');
+    expect(parsed.item.markupPercent).toBe('20.00');
+  });
+
+  it('redacts costBasis/markupPercent/distributor.cost for org-scoped callers (defense-in-depth)', async () => {
+    const row = {
+      id: ITEM_ID,
+      partnerId: PARTNER_ID,
+      createdBy: 'user-uuid',
+      name: 'SPL Dock',
+      isBundle: false,
+      costBasis: '100.00',
+      markupPercent: '20.00',
+      unitPrice: '120.00',
+      attributes: { distributor: { synnexSku: '14703953', cost: 100, msrp: 150, raw: {} } },
+    };
+    vi.mocked(db.select).mockReturnValueOnce(makeChain([row], {}) as any);
+
+    const orgAuth = {
+      user: { id: 'u1' },
+      partnerId: PARTNER_ID, // org tokens DO carry the owning org's partnerId
+      scope: 'organization',
+      orgId: 'org-1',
+      accessibleOrgIds: ['org-1'],
+    } as any;
+    const out = await tools().get('get_catalog_item')!.handler({ catalogItemId: ITEM_ID }, orgAuth);
+    const parsed = JSON.parse(out);
+
+    expect(parsed.item).not.toHaveProperty('costBasis');
+    expect(parsed.item).not.toHaveProperty('markupPercent');
+    expect(parsed.item.attributes.distributor).not.toHaveProperty('cost');
+    expect(parsed.item.attributes.distributor).not.toHaveProperty('raw');
+    // Sell-side fields remain visible.
+    expect(parsed.item.unitPrice).toBe('120.00');
+    expect(parsed.item.attributes.distributor.msrp).toBe(150);
+  });
+
+  it('handles items with no distributor attributes (empty attributes object)', async () => {
+    const row = { id: ITEM_ID, partnerId: PARTNER_ID, createdBy: null, isBundle: false, attributes: {} };
+    vi.mocked(db.select).mockReturnValueOnce(makeChain([row], {}) as any);
+
+    const out = await tools().get('get_catalog_item')!.handler({ catalogItemId: ITEM_ID }, partnerAuth());
+    const parsed = JSON.parse(out);
+    expect(parsed.item.attributes).toEqual({});
+    expect(parsed.item).not.toHaveProperty('partnerId');
+    expect(parsed.item).not.toHaveProperty('createdBy');
   });
 
   it('returns components for a bundle item (second select scoped to the bundle + partner)', async () => {

--- a/apps/api/src/services/aiToolsCatalog.ts
+++ b/apps/api/src/services/aiToolsCatalog.ts
@@ -11,7 +11,7 @@
  * is additionally filtered to `isActive` rows.
  */
 
-import { and, asc, eq, ilike } from 'drizzle-orm';
+import { and, asc, eq, ilike, or, sql } from 'drizzle-orm';
 import type {
   BundleComponentInput,
   CreateCatalogItemInput,
@@ -49,6 +49,60 @@ function serviceErrorToJson(err: unknown): string | null {
   return null;
 }
 
+type CatalogItemRow = typeof catalogItems.$inferSelect;
+
+/**
+ * Shape a catalog row for AI/MCP output.
+ *
+ * - Drops internal IDs (`partnerId`, `createdBy`): the MCP server instructions
+ *   tell the model never to reveal internal IDs — redaction belongs server-side,
+ *   not in model discipline.
+ * - Strips `attributes.distributor.raw`, the verbatim provider payload kept for
+ *   import traceability. It is a near-duplicate of the normalized distributor
+ *   fields (cost/msrp/warehouses/…), blows the MCP output depth limiter
+ *   ("[truncated: max depth reached]" noise), and roughly doubles tokens. The
+ *   normalized fields (cost, msrp, warehouses, mfgPartNo, synnexSku, status,
+ *   importedAt, …) are kept.
+ * - Redacts cost/margin fields (`costBasis`, `markupPercent`,
+ *   `attributes.distributor.cost`) for org-scoped callers. Note the catalog is
+ *   partner-axis (RLS shape 3) and org-scoped tokens carry the owning org's
+ *   partnerId (so they pass the partnerId gate) but get an RLS context without
+ *   partner access, so the partner-scoped SELECT returns 0 rows today —
+ *   effectively partner-only. This redaction is defense-in-depth so a future
+ *   system-context execution path can never leak distributor cost / margin to a
+ *   customer (org) token.
+ */
+function sanitizeCatalogItemForAi(item: CatalogItemRow, auth: AuthContext): Record<string, unknown> {
+  const { partnerId: _partnerId, createdBy: _createdBy, ...rest } = item;
+  const out: Record<string, unknown> = { ...rest };
+
+  const attrs = item.attributes;
+  if (attrs && typeof attrs === 'object' && !Array.isArray(attrs)) {
+    const attrsCopy: Record<string, unknown> = { ...(attrs as Record<string, unknown>) };
+    const dist = attrsCopy.distributor;
+    if (dist && typeof dist === 'object' && !Array.isArray(dist)) {
+      const { raw: _raw, ...distRest } = dist as Record<string, unknown>;
+      attrsCopy.distributor = distRest;
+    }
+    out.attributes = attrsCopy;
+  }
+
+  if (auth.scope === 'organization') {
+    delete out.costBasis;
+    delete out.markupPercent;
+    const outAttrs = out.attributes;
+    if (outAttrs && typeof outAttrs === 'object' && !Array.isArray(outAttrs)) {
+      const dist = (outAttrs as Record<string, unknown>).distributor;
+      if (dist && typeof dist === 'object' && !Array.isArray(dist)) {
+        const { cost: _cost, ...distRest } = dist as Record<string, unknown>;
+        (outAttrs as Record<string, unknown>).distributor = distRest;
+      }
+    }
+  }
+
+  return out;
+}
+
 export function registerCatalogTools(aiTools: Map<string, AiTool>): void {
   aiTools.set('search_catalog', {
     tier: 2 as AiToolTier,
@@ -56,15 +110,22 @@ export function registerCatalogTools(aiTools: Map<string, AiTool>): void {
     definition: {
       name: 'search_catalog',
       description:
-        'Search the partner product catalog (hardware, software, services, and bundles) by name or type. Read-only.',
+        'Search the partner product catalog (hardware, software, services, and bundles). The search term matches item name, SKU, and distributor part numbers (manufacturer part number / SYNNEX SKU). Optional filters: item type, bundle flag. Read-only.',
       input_schema: {
         type: 'object' as const,
         properties: {
-          search: { type: 'string', description: 'Name substring to match' },
+          search: {
+            type: 'string',
+            description: 'Substring to match against item name, SKU, or distributor part number (mfgPartNo / synnexSku)'
+          },
           itemType: {
             type: 'string',
             enum: ['hardware', 'software', 'service'],
             description: 'Filter by item type'
+          },
+          isBundle: {
+            type: 'boolean',
+            description: 'Filter to bundles only (true) or non-bundles only (false)'
           },
           limit: { type: 'number', description: 'Max results (default 25, max 100)' }
         },
@@ -82,8 +143,21 @@ export function registerCatalogTools(aiTools: Map<string, AiTool>): void {
           eq(catalogItems.itemType, input.itemType as 'hardware' | 'software' | 'service')
         );
       }
+      if (typeof input.isBundle === 'boolean') {
+        conditions.push(eq(catalogItems.isBundle, input.isBundle));
+      }
       if (input.search) {
-        conditions.push(ilike(catalogItems.name, `%${escapeLikePattern(String(input.search))}%`));
+        const pattern = `%${escapeLikePattern(String(input.search))}%`;
+        // Match name, the item's own SKU, and the normalized distributor part
+        // numbers stored on imported items (attributes.distributor.mfgPartNo /
+        // .synnexSku) — "find the item for SKU 14703953" is a natural quoting ask.
+        const searchCondition = or(
+          ilike(catalogItems.name, pattern),
+          ilike(catalogItems.sku, pattern),
+          sql`${catalogItems.attributes} -> 'distributor' ->> 'mfgPartNo' ILIKE ${pattern}`,
+          sql`${catalogItems.attributes} -> 'distributor' ->> 'synnexSku' ILIKE ${pattern}`
+        );
+        if (searchCondition) conditions.push(searchCondition);
       }
       const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
       const rows = await db
@@ -137,8 +211,9 @@ export function registerCatalogTools(aiTools: Map<string, AiTool>): void {
       if (!item) {
         return JSON.stringify({ error: 'Catalog item not found' });
       }
+      const sanitized = sanitizeCatalogItemForAi(item, auth);
       if (!item.isBundle) {
-        return JSON.stringify({ item });
+        return JSON.stringify({ item: sanitized });
       }
       const components = await db
         .select({
@@ -155,7 +230,7 @@ export function registerCatalogTools(aiTools: Map<string, AiTool>): void {
             eq(catalogBundleComponents.partnerId, partnerId)
           )
         );
-      return JSON.stringify({ item, components });
+      return JSON.stringify({ item: sanitized, components });
     }
   });
 

--- a/apps/api/src/services/aiToolsCatalog.ts
+++ b/apps/api/src/services/aiToolsCatalog.ts
@@ -52,50 +52,97 @@ function serviceErrorToJson(err: unknown): string | null {
 type CatalogItemRow = typeof catalogItems.$inferSelect;
 
 /**
- * Shape a catalog row for AI/MCP output.
+ * Top-level catalog columns exposed to AI/MCP output. This is an ALLOWLIST, not
+ * a blocklist: internal IDs (`partnerId`, `createdBy`) and any future column
+ * added to `catalog_items` are dropped by construction — never leaked by
+ * forgetting to strip them. `costBasis`/`markupPercent` are further redacted for
+ * org-scoped callers (see AI_ITEM_ORG_REDACTED_FIELDS).
+ */
+const AI_ITEM_FIELDS = [
+  'id',
+  'name',
+  'itemType',
+  'sku',
+  'description',
+  'billingType',
+  'billingFrequency',
+  'commitmentTermMonths',
+  'unitPrice',
+  'costBasis',
+  'markupPercent',
+  'unitOfMeasure',
+  'taxable',
+  'taxCategory',
+  'isBundle',
+  'isActive',
+  'createdAt',
+  'updatedAt',
+] as const satisfies readonly (keyof CatalogItemRow)[];
+
+/**
+ * Normalized distributor sub-fields kept from `attributes.distributor`. Also an
+ * allowlist: the verbatim `raw` provider payload — and any future/unknown
+ * distributor sub-field an importer might add — are dropped by construction.
+ * `cost` is additionally redacted for org-scoped callers.
+ */
+const AI_DISTRIBUTOR_FIELDS = [
+  'cost',
+  'msrp',
+  'warehouses',
+  'mfgPartNo',
+  'synnexSku',
+  'status',
+  'importedAt',
+] as const;
+
+/** Top-level cost/margin fields hidden from org-scoped (customer) callers. */
+const AI_ITEM_ORG_REDACTED_FIELDS = ['costBasis', 'markupPercent'] as const;
+
+function pickAllowed(src: Record<string, unknown>, keys: readonly string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of keys) {
+    if (key in src) out[key] = src[key];
+  }
+  return out;
+}
+
+/**
+ * Shape a catalog row for AI/MCP output using explicit allowlists.
  *
- * - Drops internal IDs (`partnerId`, `createdBy`): the MCP server instructions
- *   tell the model never to reveal internal IDs — redaction belongs server-side,
- *   not in model discipline.
- * - Strips `attributes.distributor.raw`, the verbatim provider payload kept for
- *   import traceability. It is a near-duplicate of the normalized distributor
- *   fields (cost/msrp/warehouses/…), blows the MCP output depth limiter
- *   ("[truncated: max depth reached]" noise), and roughly doubles tokens. The
- *   normalized fields (cost, msrp, warehouses, mfgPartNo, synnexSku, status,
- *   importedAt, …) are kept.
- * - Redacts cost/margin fields (`costBasis`, `markupPercent`,
- *   `attributes.distributor.cost`) for org-scoped callers. Note the catalog is
- *   partner-axis (RLS shape 3) and org-scoped tokens carry the owning org's
- *   partnerId (so they pass the partnerId gate) but get an RLS context without
- *   partner access, so the partner-scoped SELECT returns 0 rows today —
- *   effectively partner-only. This redaction is defense-in-depth so a future
- *   system-context execution path can never leak distributor cost / margin to a
- *   customer (org) token.
+ * - Top-level fields are projected via AI_ITEM_FIELDS, so internal IDs and any
+ *   future column can never leak by omission (the reason this replaced the prior
+ *   blocklist that named individual fields to strip).
+ * - `attributes` is free-form jsonb: partner-authored keys pass through, but the
+ *   `distributor` sub-object is rebuilt from AI_DISTRIBUTOR_FIELDS so the raw
+ *   import blob and any future distributor sub-field are dropped.
+ * - Cost/margin fields (`costBasis`, `markupPercent`, `distributor.cost`) are
+ *   redacted for org-scoped callers. The catalog is partner-axis (RLS shape 3)
+ *   and org-scoped tokens carry the owning org's partnerId (so they pass the
+ *   partnerId gate) but get an RLS context without partner access, so the
+ *   partner-scoped SELECT returns 0 rows today — effectively partner-only. This
+ *   redaction is defense-in-depth so a future system-context execution path can
+ *   never leak distributor cost / margin to a customer (org) token.
  */
 function sanitizeCatalogItemForAi(item: CatalogItemRow, auth: AuthContext): Record<string, unknown> {
-  const { partnerId: _partnerId, createdBy: _createdBy, ...rest } = item;
-  const out: Record<string, unknown> = { ...rest };
+  const out = pickAllowed(item as unknown as Record<string, unknown>, AI_ITEM_FIELDS);
 
   const attrs = item.attributes;
   if (attrs && typeof attrs === 'object' && !Array.isArray(attrs)) {
     const attrsCopy: Record<string, unknown> = { ...(attrs as Record<string, unknown>) };
     const dist = attrsCopy.distributor;
     if (dist && typeof dist === 'object' && !Array.isArray(dist)) {
-      const { raw: _raw, ...distRest } = dist as Record<string, unknown>;
-      attrsCopy.distributor = distRest;
+      attrsCopy.distributor = pickAllowed(dist as Record<string, unknown>, AI_DISTRIBUTOR_FIELDS);
     }
     out.attributes = attrsCopy;
   }
 
   if (auth.scope === 'organization') {
-    delete out.costBasis;
-    delete out.markupPercent;
+    for (const field of AI_ITEM_ORG_REDACTED_FIELDS) delete out[field];
     const outAttrs = out.attributes;
     if (outAttrs && typeof outAttrs === 'object' && !Array.isArray(outAttrs)) {
       const dist = (outAttrs as Record<string, unknown>).distributor;
       if (dist && typeof dist === 'object' && !Array.isArray(dist)) {
-        const { cost: _cost, ...distRest } = dist as Record<string, unknown>;
-        (outAttrs as Record<string, unknown>).distributor = distRest;
+        delete (dist as Record<string, unknown>).cost;
       }
     }
   }

--- a/apps/api/src/services/aiToolsCatalog.ts
+++ b/apps/api/src/services/aiToolsCatalog.ts
@@ -230,7 +230,13 @@ export function registerCatalogTools(aiTools: Map<string, AiTool>): void {
             eq(catalogBundleComponents.partnerId, partnerId)
           )
         );
-      return JSON.stringify({ item: sanitized, components });
+      // Same org-scope defense-in-depth as the item's cost fields:
+      // revenueAllocation is the partner's internal revenue split.
+      const sanitizedComponents =
+        auth.scope === 'organization'
+          ? components.map(({ revenueAllocation: _ra, ...rest }) => rest)
+          : components;
+      return JSON.stringify({ item: sanitized, components: sanitizedComponents });
     }
   });
 


### PR DESCRIPTION
## Summary

Polish for the catalog MCP tools (`get_catalog_item` / `search_catalog`) in `apps/api/src/services/aiToolsCatalog.ts`, from dogfooding a quoting workflow.

**`get_catalog_item`**
- Strips `attributes.distributor.raw` — the verbatim provider payload kept for import traceability. It near-duplicates the normalized distributor fields, blows the MCP output depth limiter (`"[truncated: max depth reached]"` noise), and roughly doubles response tokens. The normalized fields (`cost`, `msrp`, `warehouses`, `mfgPartNo`, `synnexSku`, `status`, `importedAt`, …) are kept. (The Digital Bridge importer already strips `raw` at import time; the EC Express importer stores it — this fixes the output side regardless of source.)
- Redacts internal IDs (`partnerId`, `createdBy`) server-side. The MCP server instructions tell the model never to reveal internal IDs; redaction now doesn't depend on model discipline.

**`search_catalog`**
- The search term now matches item **name OR `sku` OR the normalized distributor part numbers** (`attributes.distributor.mfgPartNo` / `.synnexSku`, via jsonb `->>` ILIKE — no schema change). "Find the item for SKU 14703953" now works.
- New **`isBundle` boolean filter** (also added to the zod input schema in `aiToolSchemas.ts`).
- Tool description updated to advertise both.

## Org-scope reachability (traced per the issue's ask)

- Both tools are tier 2, guardrail resource `catalog: read` — there is **no partner-scope gate** on the tool itself.
- Org-scoped MCP keys **do** reach the handler: `buildAuthFromApiKey` resolves `partnerId` from the owning org's partner (see `routes/mcpServer.ts`), so the handler's `if (!partnerId)` check passes.
- However `catalog_items` is **partner-axis RLS (shape 3)**, and org-key requests get a DB context with empty `accessiblePartnerIds`, so the partner-scoped SELECT returns 0 rows today → org tokens get "Catalog item not found". Effectively partner-only in practice.
- **Defense-in-depth anyway:** `get_catalog_item` now redacts `costBasis`, `markupPercent`, and `attributes.distributor.cost` when `auth.scope === 'organization'`, so a future system-context execution path (the heartbeat-probe-config class of change) can never leak distributor cost / margin to a customer token. Sell-side fields (`unitPrice`, `msrp`) stay visible.

## Tests

- `aiToolsCatalog.test.ts`: raw blob stripped + normalized fields kept; `partnerId`/`createdBy` absent; org-scope cost redaction; empty-attributes edge; SKU + mfgPartNo/synnexSku search tokens; `isBundle` filter true/false/omitted (12 tests).
- Site-scope contract test (`aiTools.deviceAccessSiteScope.contract.test.ts`) green — no registration/deviceArgs changes.

Closes #2365

🤖 Generated with [Claude Code](https://claude.com/claude-code)
