### PR TITLE
fix(tickets): ticket-form allowlist edits no longer 400 when an allowlisted org becomes inactive (#2357)

### DIFF
--- a/apps/api/src/__tests__/integration/ticketFormOrgLinksTxnSeam.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketFormOrgLinksTxnSeam.integration.test.ts
@@ -5,18 +5,20 @@
  * withDbAccessContext transaction (C1, uncommitted), then syncs the org
  * allowlist. If syncTicketFormOrgLinks escapes to a FRESH system transaction
  * on another pooled connection (C2), C2's READ COMMITTED snapshot cannot see
- * C1's uncommitted parent, so the non-deferrable FK
- * `ticket_form_org_links.form_id -> ticket_forms(id)` fails with 23503 and the
- * whole request 500s. This suite mirrors that exact route seam: it inserts a
+ * C1's uncommitted parent, so the link policy's WITH CHECK `EXISTS (...
+ * ticket_forms ...)` rejects the row (42501; were the policy absent, the
+ * non-deferrable FK `ticket_form_org_links.form_id -> ticket_forms(id)`
+ * would fail with 23503 at end of statement) and the whole request 500s. This suite mirrors that exact route seam: it inserts a
  * partner-wide parent inside a partner-scoped request context and then — STILL
  * inside that context — calls syncTicketFormOrgLinks with a non-empty
  * allowlist. It must land parent + links together, committed atomically.
  *
- * Only partner-scoped tokens with orgAccess='all' reach this path (POST
- * partner-wide + canManagePartnerWidePolicies gate), so the ambient context is
- * always a partner context whose accessiblePartnerIds covers the owning
- * partner — which is what makes the link WITH CHECK
- * (breeze_has_partner_access on the parent) pass on the ambient connection.
+ * Partner-scoped tokens with orgAccess='all' are what reaches this path in
+ * practice (POST partner-wide + canManagePartnerWidePolicies gate — which
+ * system scope would also clear), so the ambient context is a partner context
+ * whose accessiblePartnerIds covers the owning partner — which is what makes
+ * the link WITH CHECK (breeze_has_partner_access on the parent) pass on the
+ * ambient connection.
  *
  * The org-belongs-to-partner validation read, by contrast, runs under a
  * SYSTEM context (#2357): a request context's accessibleOrgIds only covers
@@ -24,7 +26,8 @@
  * connection made every save of a form that allowlisted a later-suspended/
  * churned/soft-deleted org fail with a false cross-partner 400. This suite
  * also pins the #2357 contract: owned-but-inactive and owned-but-soft-deleted
- * orgs are accepted; unknown and cross-partner ids still 400.
+ * orgs are accepted; cross-partner ids still 400 (unknown-id rejection is
+ * pinned in the unit suite, ticketFormService.test.ts).
  */
 import './setup';
 import { afterEach, describe, expect, it } from 'vitest';

--- a/apps/api/src/__tests__/integration/ticketFormOrgLinksTxnSeam.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketFormOrgLinksTxnSeam.integration.test.ts
@@ -14,11 +14,17 @@
  *
  * Only partner-scoped tokens with orgAccess='all' reach this path (POST
  * partner-wide + canManagePartnerWidePolicies gate), so the ambient context is
- * always a partner context whose accessibleOrgIds covers every org under the
- * partner — which is what makes both the link WITH CHECK
- * (breeze_has_partner_access on the parent) and the org-belongs-to-partner
- * validation read (breeze_has_org_access on organizations) pass on the ambient
- * connection.
+ * always a partner context whose accessiblePartnerIds covers the owning
+ * partner — which is what makes the link WITH CHECK
+ * (breeze_has_partner_access on the parent) pass on the ambient connection.
+ *
+ * The org-belongs-to-partner validation read, by contrast, runs under a
+ * SYSTEM context (#2357): a request context's accessibleOrgIds only covers
+ * active/trial, non-soft-deleted orgs, so validating on the ambient
+ * connection made every save of a form that allowlisted a later-suspended/
+ * churned/soft-deleted org fail with a false cross-partner 400. This suite
+ * also pins the #2357 contract: owned-but-inactive and owned-but-soft-deleted
+ * orgs are accepted; unknown and cross-partner ids still 400.
  */
 import './setup';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -91,6 +97,62 @@ describe('ticket_forms org-links transaction seam (POST with visibleOrgIds)', ()
       db.select().from(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.formId, formId))
     );
     expect(links.map((l) => l.orgId).sort()).toEqual([orgA.id, orgB.id].sort());
+  });
+
+  // #2357 — an org that was validly allowlisted and later became suspended (or
+  // churned/trial-expired) drops out of the caller's accessibleOrgIds
+  // (auth.ts filters status IN ('active','trial')), so the OLD ambient-context
+  // validation read couldn't see it and every subsequent save of the form
+  // 400ed. The ownership check must accept any org of the owning partner
+  // regardless of status.
+  it('accepts an owned org that is SUSPENDED and thus invisible to the caller-shaped request context (#2357)', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const suspendedOrg = await createOrganization({ partnerId: partner.id, status: 'suspended' });
+
+    // Mirror a real token: the suspended org is NOT in accessibleOrgIds.
+    const formId = await withDbAccessContext(partnerContext(partner.id, [orgA.id]), async () => {
+      const [row] = await db
+        .insert(ticketForms)
+        .values({ ...baseForm, partnerId: partner.id, orgId: null })
+        .returning();
+      if (!row) throw new Error('parent insert returned no row');
+      await syncTicketFormOrgLinks(row.id, [orgA.id, suspendedOrg.id], partner.id);
+      return row.id;
+    });
+    created.push(formId);
+
+    const links = await withDbAccessContext(systemContext(), () =>
+      db.select().from(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.formId, formId))
+    );
+    expect(links.map((l) => l.orgId).sort()).toEqual([orgA.id, suspendedOrg.id].sort());
+  });
+
+  // #2357 documented behavior: a SOFT-DELETED (deleted_at set) org of the
+  // owning partner is also accepted — the link row is inert while the org is
+  // deleted, and retaining it means a restored org rejoins the allowlist
+  // instead of silently falling off it on some unrelated form edit. Only
+  // hard-deleted (row gone) and cross-partner ids reject.
+  it('accepts an owned org that is SOFT-DELETED (#2357 — link retained, inert until restore)', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const softDeletedOrg = await createOrganization({ partnerId: partner.id, deletedAt: new Date() });
+
+    const formId = await withDbAccessContext(partnerContext(partner.id, [orgA.id]), async () => {
+      const [row] = await db
+        .insert(ticketForms)
+        .values({ ...baseForm, partnerId: partner.id, orgId: null })
+        .returning();
+      if (!row) throw new Error('parent insert returned no row');
+      await syncTicketFormOrgLinks(row.id, [orgA.id, softDeletedOrg.id], partner.id);
+      return row.id;
+    });
+    created.push(formId);
+
+    const links = await withDbAccessContext(systemContext(), () =>
+      db.select().from(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.formId, formId))
+    );
+    expect(links.map((l) => l.orgId).sort()).toEqual([orgA.id, softDeletedOrg.id].sort());
   });
 
   it('rejects a cross-partner org id and persists NOTHING (rollback contract for the route)', async () => {

--- a/apps/api/src/services/ticketFormService.test.ts
+++ b/apps/api/src/services/ticketFormService.test.ts
@@ -1,17 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { dbSelectMock, insertValuesMock, deleteWhereMock } = vi.hoisted(() => ({
+const { dbSelectMock, insertValuesMock, deleteWhereMock, systemContextMock } = vi.hoisted(() => ({
   dbSelectMock: vi.fn(),
   insertValuesMock: vi.fn(),
-  deleteWhereMock: vi.fn()
+  deleteWhereMock: vi.fn(),
+  systemContextMock: vi.fn()
 }));
 
 vi.mock('../db', () => ({
   runOutsideDbContext: (fn: () => unknown) => fn(),
-  withSystemDbAccessContext: (fn: () => unknown) => fn(),
-  // syncTicketFormOrgLinks runs on the ambient request transaction when one
-  // exists (the FK-seam fix); a truthy context makes it use `db` directly,
-  // which is the mocked query builder these tests assert against.
+  withSystemDbAccessContext: (fn: () => unknown) => {
+    systemContextMock();
+    return fn();
+  },
+  // syncTicketFormOrgLinks runs its WRITE on the ambient request transaction
+  // when one exists (the FK-seam fix); a truthy context makes it use `db`
+  // directly, which is the mocked query builder these tests assert against.
+  // Its org-ownership validation READ always escalates to a system context
+  // (#2357) — systemContextMock counts those escalations.
   getCurrentDbAccessContext: () => ({ scope: 'partner' }),
   db: {
     select: vi.fn(() => ({
@@ -212,6 +218,25 @@ describe('syncTicketFormOrgLinks', () => {
     expect(inserted).toHaveLength(2); // deduped
     expect(inserted.map((r) => r.orgId).sort()).toEqual(['org-a', 'org-b']);
     expect(inserted.every((r) => r.formId === 'form-1')).toBe(true);
+  });
+
+  // #2357 — the ownership validation read must escalate to a system context
+  // (a request context's breeze_has_org_access hides suspended/churned/soft-
+  // deleted orgs, which turned every save of a form allowlisting one into a
+  // false cross-partner 400), while the WRITE stays on the ambient request
+  // transaction (the FK/WITH-CHECK seam). With an ambient context present,
+  // exactly ONE system-context escalation may occur: the validation read.
+  it('non-empty array: validation read escalates to a system context exactly once; the write does not', async () => {
+    dbSelectMock.mockResolvedValueOnce([{ id: 'org-a', partnerId: 'p-1' }]);
+    await syncTicketFormOrgLinks('form-1', ['org-a'], 'p-1');
+    expect(systemContextMock).toHaveBeenCalledTimes(1);
+    expect(deleteWhereMock).toHaveBeenCalledTimes(1);
+    expect(insertValuesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('null orgIds: no validation read, so no system-context escalation at all', async () => {
+    await syncTicketFormOrgLinks('form-1', null, 'p-1');
+    expect(systemContextMock).not.toHaveBeenCalled();
   });
 
   it('throws when an org belongs to a different partner (write aborted before delete/insert)', async () => {

--- a/apps/api/src/services/ticketFormService.ts
+++ b/apps/api/src/services/ticketFormService.ts
@@ -145,57 +145,77 @@ export async function getTicketFormForOrg(
  * because both converge on the same persisted result. Every id in a
  * non-empty array MUST belong to `partnerId`, checked with a single select
  * before any write so a cross-partner id can never sneak in as a link.
+ *
+ * The validation read is an OWNERSHIP check only — `partner_id = partnerId`,
+ * with no org-status filter — and runs under a system context (#2357). A
+ * request context can't do this read: `breeze_has_org_access` only covers
+ * active/trial, non-soft-deleted orgs, so once an allowlisted org became
+ * suspended/churned/soft-deleted, EVERY subsequent save of the form (the web
+ * builder re-sends visibleOrgIds on each save, even a rename) 400ed with a
+ * misleading cross-partner error. Owned-but-inactive and owned-but-soft-
+ * deleted orgs are deliberately accepted: the link row is inert while the org
+ * can't sign in (listTicketFormsForOrg is reached only through org-authorized
+ * callers), and keeping it means a reactivated/restored org rejoins the
+ * allowlist instead of having silently fallen off it. Ids that don't exist or
+ * belong to another partner still 400 — and the system-context read makes
+ * that error finally accurate.
  */
 export async function syncTicketFormOrgLinks(formId: string, orgIds: string[] | null, partnerId: string): Promise<void> {
-  const sync = async () => {
-    if (orgIds === null) {
-      await db.delete(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.formId, formId));
-      return;
+  const dedupedIds = orgIds === null ? null : Array.from(new Set(orgIds));
+
+  // Ownership-only validation read, on its own short-lived system transaction
+  // (runOutsideDbContext exits the ambient store first — never nested inside
+  // the request transaction's connection). It reads committed organizations
+  // rows only, so it does not need to see the request transaction's
+  // uncommitted parent form.
+  if (dedupedIds !== null && dedupedIds.length > 0) {
+    const orgRows = await runOutsideDbContext(() =>
+      withSystemDbAccessContext(() =>
+        db
+          .select({ id: organizations.id, partnerId: organizations.partnerId })
+          .from(organizations)
+          .where(inArray(organizations.id, dedupedIds))
+          .limit(500)
+      )
+    );
+    const partnerIdById = new Map(orgRows.map((r) => [r.id, r.partnerId]));
+    const allBelongToPartner = dedupedIds.every((id) => partnerIdById.get(id) === partnerId);
+    if (!allBelongToPartner) {
+      throw new TicketFormError('visibleOrgIds must reference organizations of the owning partner', 400);
     }
-    const dedupedIds = Array.from(new Set(orgIds));
-    if (dedupedIds.length > 0) {
-      const orgRows = await db
-        .select({ id: organizations.id, partnerId: organizations.partnerId })
-        .from(organizations)
-        .where(inArray(organizations.id, dedupedIds))
-        .limit(500);
-      const partnerIdById = new Map(orgRows.map((r) => [r.id, r.partnerId]));
-      const allBelongToPartner = dedupedIds.every((id) => partnerIdById.get(id) === partnerId);
-      if (!allBelongToPartner) {
-        throw new TicketFormError('visibleOrgIds must reference organizations of the owning partner', 400);
-      }
-    }
-    // Replace semantics: delete-all then bulk insert, in ONE transaction with
-    // the validation read above.
+  }
+
+  // Replace semantics: delete-all then bulk insert.
+  const write = async () => {
     await db.delete(ticketFormOrgLinks).where(eq(ticketFormOrgLinks.formId, formId));
-    if (dedupedIds.length > 0) {
+    if (dedupedIds !== null && dedupedIds.length > 0) {
       await db.insert(ticketFormOrgLinks).values(dedupedIds.map((orgId) => ({ formId, orgId })));
     }
   };
 
-  // The link write MUST share the caller's ambient request transaction when one
-  // exists. On POST /ticket-forms the parent ticket_forms row is inserted
-  // uncommitted on the request transaction (C1); escaping to a FRESH system
-  // transaction on another pooled connection (C2) means C2's READ COMMITTED
-  // snapshot cannot see that parent, so the link policy's WITH CHECK
-  // `EXISTS (... ticket_forms ...)` finds no parent row and the insert is
-  // rejected (42501) — the create 500s (whole-branch review Critical). Running
-  // on the ambient transaction lets the write see the same-transaction parent.
+  // The link WRITE (unlike the validation read above) MUST share the caller's
+  // ambient request transaction when one exists. On POST /ticket-forms the
+  // parent ticket_forms row is inserted uncommitted on the request transaction
+  // (C1); escaping to a FRESH system transaction on another pooled connection
+  // (C2) means C2's READ COMMITTED snapshot cannot see that parent, so the
+  // link policy's WITH CHECK `EXISTS (... ticket_forms ...)` finds no parent
+  // row and the insert is rejected (42501) — the create 500s (whole-branch
+  // review Critical). Running on the ambient transaction lets the write see
+  // the same-transaction parent.
   //
   // Only partner-scoped tokens with orgAccess='all' reach this code path (POST
   // partner-wide + PUT partner-wide, both behind canManagePartnerWidePolicies),
   // so the ambient context is a partner context whose accessiblePartnerIds
-  // covers the owning partner and whose accessibleOrgIds covers every org under
-  // it. That clears BOTH the link WITH CHECK (breeze_has_partner_access on the
-  // parent's partner_id) and the org-belongs-to-partner validation read
-  // (breeze_has_org_access on organizations) — RLS stays fully enforced, it is
-  // simply satisfied by the caller's own partner scope rather than a system
-  // escalation. When there is NO ambient context (defensive; no current caller
-  // reaches here contextless) fall back to a fresh system context.
+  // covers the owning partner — which clears the link WITH CHECK
+  // (breeze_has_partner_access on the parent's partner_id). RLS stays fully
+  // enforced on the write; it is simply satisfied by the caller's own partner
+  // scope rather than a system escalation. When there is NO ambient context
+  // (defensive; no current caller reaches here contextless) fall back to a
+  // fresh system context.
   if (getCurrentDbAccessContext()) {
-    return sync();
+    return write();
   }
-  return runOutsideDbContext(() => withSystemDbAccessContext(sync));
+  return runOutsideDbContext(() => withSystemDbAccessContext(write));
 }
 
 /**

--- a/apps/api/src/services/ticketFormService.ts
+++ b/apps/api/src/services/ticketFormService.ts
@@ -148,8 +148,9 @@ export async function getTicketFormForOrg(
  *
  * The validation read is an OWNERSHIP check only — `partner_id = partnerId`,
  * with no org-status filter — and runs under a system context (#2357). A
- * request context can't do this read: `breeze_has_org_access` only covers
- * active/trial, non-soft-deleted orgs, so once an allowlisted org became
+ * request context can't do this read: `breeze_has_org_access` evaluates the
+ * token's accessible-org set, which auth.ts builds filtered to active/trial,
+ * non-soft-deleted orgs — so once an allowlisted org became
  * suspended/churned/soft-deleted, EVERY subsequent save of the form (the web
  * builder re-sends visibleOrgIds on each save, even a rename) 400ed with a
  * misleading cross-partner error. Owned-but-inactive and owned-but-soft-
@@ -203,9 +204,10 @@ export async function syncTicketFormOrgLinks(formId: string, orgIds: string[] | 
   // review Critical). Running on the ambient transaction lets the write see
   // the same-transaction parent.
   //
-  // Only partner-scoped tokens with orgAccess='all' reach this code path (POST
-  // partner-wide + PUT partner-wide, both behind canManagePartnerWidePolicies),
-  // so the ambient context is a partner context whose accessiblePartnerIds
+  // Partner-scoped tokens with orgAccess='all' are what reaches this code path
+  // in practice (POST partner-wide + PUT partner-wide, both behind
+  // canManagePartnerWidePolicies — which system scope would also clear), so
+  // the ambient context is a partner context whose accessiblePartnerIds
   // covers the owning partner — which clears the link WITH CHECK
   // (breeze_has_partner_access on the parent's partner_id). RLS stays fully
   // enforced on the write; it is simply satisfied by the caller's own partner


### PR DESCRIPTION
Closes #2357

## Problem

`syncTicketFormOrgLinks` revalidates `visibleOrgIds` on every save of a partner-wide form, but the validation read ran on the caller's request DB context. `breeze_has_org_access` only covers `active`/`trial`, non-soft-deleted orgs — so once a validly allowlisted org became suspended, churned, trial-expired, or soft-deleted, **any** subsequent edit of the form (even a rename; the web builder re-sends `visibleOrgIds` on every save) failed with a misleading 400: `visibleOrgIds must reference organizations of the owning partner`. Fail-closed, no tenancy leak — but a partner-wide form became effectively uneditable without manually clearing the allowlist.

## Fix (option 1 from the issue)

- The ownership validation read now runs under a **system context** (`runOutsideDbContext` → `withSystemDbAccessContext`, mirroring the sibling readers in `ticketFormService.ts`; never nested inside the request transaction) and checks **ownership only**: `organizations.partner_id` must equal the owning partner. No status filter.
- **Documented behavior:** owned-but-inactive AND owned-but-soft-deleted orgs are accepted. The link row is inert while the org can't reach the form (`listTicketFormsForOrg` is only reachable through org-authorized callers), and retaining it means a reactivated/restored org rejoins the allowlist instead of silently falling off it on an unrelated form edit. Nonexistent and cross-partner ids still 400 — and with full read visibility the cross-partner error message is now actually accurate.
- The link **write** deliberately stays on the ambient request transaction: its RLS `WITH CHECK` resolves through the (possibly uncommitted) parent form, the seam fixed in e027b3b08. Only the validation read escalates.
- No web changes needed: the builder seeds its draft from the persisted `visibleOrgIds` and checkbox toggles only add/remove the toggled id, so inactive ids are retained and re-sent — with this fix the allowlist survives edits intact.

## Tests

- Unit (`ticketFormService.test.ts`): validation read escalates to a system context exactly once while the write stays ambient; `null` short-circuits with no escalation; existing cross-partner/nonexistent-id 400 cases unchanged.
- Integration (`ticketFormOrgLinksTxnSeam.integration.test.ts`, real Postgres): suspended owned org accepted with a caller-shaped partner context that **cannot** see it; soft-deleted owned org accepted (link retained); cross-partner rejection + rollback contract still green. Both new tests fail on the unfixed service (verified by stashing the fix) and pass with it.

## Verification

- `vitest run src/services/ticketFormService.test.ts` — 21 passed
- `vitest run src/routes/tickets/forms.test.ts` — 35 passed
- `vitest run --config vitest.integration.config.ts src/__tests__/integration/ticketFormOrgLinksTxnSeam.integration.test.ts` — 4 passed (dedicated Postgres)
- `vitest run --config vitest.integration.config.ts src/__tests__/integration/ticketFormsPartnerRls.integration.test.ts` — 10 passed
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)