### PR TITLE
feat(ai): org/site MCP tools — list_organizations + manage_organizations (#2366)

### DIFF
--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -160,6 +160,9 @@ export const TOOL_TIERS = {
   query_monitors: 1,
   manage_monitors: 1,           // Action-level escalation in guardrails
   get_service_monitoring_status: 1,
+  // Org lifecycle tools (issue #2366) — new-customer intake (org → site → quote)
+  list_organizations: 1,
+  manage_organizations: 2,      // create_org/update_org/create_site escalate to 3 in guardrails
   // M365 helpdesk tools (Delegant-backed)
   m365_lookup_user: 1,
   m365_recent_signins: 1,
@@ -1750,6 +1753,32 @@ export function createBreezeMcpServer(
         limit: z.number().int().min(1).max(500).optional(),
       },
       makeHandler('get_service_monitoring_status', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    // Org lifecycle tools (issue #2366) — new-customer intake (org → site → quote)
+
+    tool(
+      'list_organizations',
+      'List/search the organizations the caller can access (name substring match), each with id, name, slug, status, and its sites (id + name). Use this to resolve the orgId and siteId that other tools require. Partner-scoped callers see all their orgs; organization-scoped callers see only their own. Read-only.',
+      {
+        search: z.string().max(255).optional(),
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+      makeHandler('list_organizations', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'manage_organizations',
+      'Create and manage organizations and sites (new-customer intake). Actions: create_org (name required; creates the org under the caller\'s partner with a default "Main Office" site — partner scope only), update_org (name/status patch), create_site (orgId + name + optional address), add_contact (not yet supported — returns guidance). create_org, update_org, and create_site require approval.',
+      {
+        action: z.enum(['create_org', 'update_org', 'create_site', 'add_contact']),
+        orgId: uuid.optional(),
+        name: z.string().max(255).optional(),
+        status: z.enum(['active', 'suspended', 'trial', 'churned']).optional(),
+        address: z.record(z.string(), z.unknown()).optional(),
+        email: z.string().email().max(255).optional(),
+      },
+      makeHandler('manage_organizations', getAuth, onPreToolUse, onPostToolUse)
     ),
 
     // Action Plan tool (for action_plan and hybrid_plan modes)

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -99,6 +99,9 @@ const TIER3_ACTIONS: Record<string, string[]> = {
   manage_invoices: ['issue', 'void', 'record_payment', 'void_payment'],
   manage_contracts: ['activate', 'pause', 'resume', 'cancel'],
   manage_quotes: ['send'],
+  // Org lifecycle (issue #2366) — tenant-shape mutations require approval.
+  // add_contact stays at the tool's base tier (it returns guidance only).
+  manage_organizations: ['create_org', 'update_org', 'create_site'],
 };
 
 // RBAC permission map: tool → { resource, action } (or action-based overrides)
@@ -201,6 +204,13 @@ export const TOOL_PERMISSIONS: Record<string, { resource: string; action: string
     send: { resource: 'quotes', action: 'send' },
     decline: { resource: 'quotes', action: 'write' },
     create_pay_link: { resource: 'quotes', action: 'write' },
+  },
+  list_organizations: { resource: 'organizations', action: 'read' },
+  manage_organizations: {
+    create_org: { resource: 'organizations', action: 'write' },
+    update_org: { resource: 'organizations', action: 'write' },
+    create_site: { resource: 'sites', action: 'write' },
+    add_contact: { resource: 'organizations', action: 'write' },
   },
   manage_services: { resource: 'devices', action: 'execute' },
   manage_processes: {
@@ -988,6 +998,13 @@ function buildApprovalDescription(
       parts.push(`Registry ${action}: ${input.keyPath}`);
       if (input.valueName) parts.push(`\\${input.valueName}`);
       if (input.deviceId) parts.push(`on device ${(input.deviceId as string).slice(0, 8)}...`);
+      break;
+
+    case 'manage_organizations':
+      if (action === 'create_org') parts.push(`Create organization "${input.name}" (with a default Main Office site)`);
+      else if (action === 'update_org') parts.push(`Update organization ${(input.orgId as string)?.slice(0, 8)}...${input.status ? ` (status → ${input.status})` : ''}`);
+      else if (action === 'create_site') parts.push(`Create site "${input.name}" in organization ${(input.orgId as string)?.slice(0, 8) ?? '(own org)'}...`);
+      else parts.push(`Organizations: ${action}`);
       break;
 
     case 'manage_monitors':

--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -295,6 +295,20 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
     quoteId: uuid,
   }),
 
+  list_organizations: z.object({
+    search: z.string().max(255).optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+  }),
+
+  manage_organizations: z.object({
+    action: z.enum(['create_org', 'update_org', 'create_site', 'add_contact']),
+    orgId: uuid.optional(),
+    name: z.string().min(1).max(255).optional(),
+    status: z.enum(['active', 'suspended', 'trial', 'churned']).optional(),
+    address: z.record(z.string(), z.unknown()).optional(),
+    email: z.string().email().max(255).optional(),
+  }),
+
   manage_quotes: z.object({
     action: z.enum([
       'create_draft',

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -61,6 +61,7 @@ import { registerCatalogTools } from './aiToolsCatalog';
 import { registerBillingTools } from './aiToolsBilling';
 import { registerContractTools } from './aiToolsContracts';
 import { registerQuoteTools } from './aiToolsQuotes';
+import { registerOrgTools } from './aiToolsOrgs';
 import { registerPamTools } from './aiToolsPam';
 // M365 helpdesk tools are session-aware (handler signature includes a sessionId)
 // so they are NOT registered in the `aiTools` execution registry — they run via
@@ -238,6 +239,7 @@ registerCatalogTools(aiTools);
 registerBillingTools(aiTools);
 registerContractTools(aiTools);
 registerQuoteTools(aiTools);
+registerOrgTools(aiTools);
 registerIncidentTools(aiTools);
 registerPerformanceTools(aiTools);
 registerUserRiskTools(aiTools);

--- a/apps/api/src/services/aiToolsOrgs.test.ts
+++ b/apps/api/src/services/aiToolsOrgs.test.ts
@@ -1,0 +1,493 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('./auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+  requestLikeFromSnapshot: vi.fn(() => ({})),
+}));
+vi.mock('./tenantLifecycle', () => ({
+  revokeOrganizationTenantAccess: vi.fn(async () => undefined),
+  restoreOrganizationTenantAccess: vi.fn(async () => undefined),
+}));
+
+import { and, eq, ilike, inArray, isNull } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { organizations, sites } from '../db/schema';
+import { writeAuditEvent } from './auditEvents';
+import {
+  revokeOrganizationTenantAccess,
+  restoreOrganizationTenantAccess,
+} from './tenantLifecycle';
+import { registerOrgTools, slugifyOrgName, generateUniqueOrgSlug } from './aiToolsOrgs';
+import type { AiTool } from './aiTools';
+import type { AuthContext } from '../middleware/auth';
+import { validateToolInput } from './aiToolSchemas';
+
+const mockDb = db as unknown as {
+  select: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+};
+
+const ORG_1 = '11111111-1111-4111-8111-111111111111';
+const ORG_2 = '22222222-2222-4222-8222-222222222222';
+const OTHER_ORG = '99999999-9999-4999-8999-999999999999';
+const SITE_1 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const SITE_2 = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const PARTNER_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+// ── DB chain mocks ───────────────────────────────────────────────────────────
+// Select chains in this file are awaited at three different depths:
+//   orgs list  → from().where().orderBy().limit()
+//   sites list → from().where().orderBy()          (no limit)
+//   slug read  → from().where()                    (awaited directly)
+// One thenable chain object covers all three; results are consumed FIFO.
+const selectQueue: unknown[][] = [];
+const insertQueue: unknown[][] = [];
+const updateQueue: unknown[][] = [];
+const whereSpy = vi.fn();
+const insertValuesSpy = vi.fn();
+const updateSetSpy = vi.fn();
+
+function makeSelectChain() {
+  let consumed: unknown[] | null = null;
+  const rows = () => {
+    if (consumed === null) consumed = selectQueue.shift() ?? [];
+    return consumed;
+  };
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn((cond: unknown) => {
+    whereSpy(cond);
+    return chain;
+  });
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows()));
+  chain.then = (res: (v: unknown) => unknown, rej: (e: unknown) => unknown) =>
+    Promise.resolve(rows()).then(res, rej);
+  return chain;
+}
+
+function primeDb() {
+  mockDb.select.mockImplementation(() => makeSelectChain());
+  mockDb.insert.mockImplementation((table: unknown) => ({
+    values: (v: unknown) => {
+      insertValuesSpy(table, v);
+      return { returning: () => Promise.resolve(insertQueue.shift() ?? []) };
+    },
+  }));
+  mockDb.update.mockImplementation(() => ({
+    set: (u: unknown) => {
+      updateSetSpy(u);
+      return {
+        where: (cond: unknown) => {
+          whereSpy(cond);
+          return { returning: () => Promise.resolve(updateQueue.shift() ?? []) };
+        },
+      };
+    },
+  }));
+}
+
+// ── Auth fixtures ────────────────────────────────────────────────────────────
+function partnerAuth(overrides: Partial<AuthContext> = {}): AuthContext {
+  const accessible = [ORG_1, ORG_2];
+  return {
+    user: { id: 'de305d54-75b4-431b-adb2-eb6b9e546014', email: 'tech@msp.example', name: 'Tech', isPlatformAdmin: false },
+    token: {} as never,
+    partnerId: PARTNER_ID,
+    orgId: null,
+    scope: 'partner',
+    accessibleOrgIds: accessible,
+    orgCondition: vi.fn(() => undefined),
+    canAccessOrg: (id: string) => accessible.includes(id),
+    ...overrides,
+  } as unknown as AuthContext;
+}
+
+function orgAuth(overrides: Partial<AuthContext> = {}): AuthContext {
+  return {
+    user: { id: 'de305d54-75b4-431b-adb2-eb6b9e546015', email: 'user@customer.example', name: 'User', isPlatformAdmin: false },
+    token: {} as never,
+    partnerId: PARTNER_ID,
+    orgId: ORG_1,
+    scope: 'organization',
+    accessibleOrgIds: [ORG_1],
+    orgCondition: vi.fn(() => undefined),
+    canAccessOrg: (id: string) => id === ORG_1,
+    ...overrides,
+  } as unknown as AuthContext;
+}
+
+function getTools(): { list: AiTool; manage: AiTool } {
+  const reg = new Map<string, AiTool>();
+  registerOrgTools(reg);
+  const list = reg.get('list_organizations');
+  const manage = reg.get('manage_organizations');
+  if (!list || !manage) throw new Error('org tools not registered');
+  return { list, manage };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectQueue.length = 0;
+  insertQueue.length = 0;
+  updateQueue.length = 0;
+  primeDb();
+});
+
+// ── Registration ─────────────────────────────────────────────────────────────
+
+describe('org tools registration', () => {
+  it('registers list_organizations at tier 1 and manage_organizations at tier 2 with no device args', () => {
+    const { list, manage } = getTools();
+    expect(list.tier).toBe(1);
+    expect(manage.tier).toBe(2);
+    expect(list.deviceArgs).toEqual([]);
+    expect(manage.deviceArgs).toEqual([]);
+  });
+
+  it('validates inputs through the shared Zod schema map', () => {
+    expect(validateToolInput('manage_organizations', { action: 'create_org', name: 'Acme Dental' }).success).toBe(true);
+    expect(validateToolInput('manage_organizations', { action: 'drop_all_orgs' }).success).toBe(false);
+    expect(validateToolInput('manage_organizations', { action: 'update_org', orgId: 'not-a-uuid' }).success).toBe(false);
+    expect(validateToolInput('list_organizations', { search: 'acme', limit: 10 }).success).toBe(true);
+    expect(validateToolInput('list_organizations', { limit: 0 }).success).toBe(false);
+  });
+});
+
+// ── list_organizations ───────────────────────────────────────────────────────
+
+describe('list_organizations', () => {
+  it('partner scope lists all accessible orgs with their sites grouped', async () => {
+    selectQueue.push([
+      { id: ORG_1, name: 'Acme Dental', slug: 'acme-dental', status: 'active' },
+      { id: ORG_2, name: 'Beta Corp', slug: 'beta-corp', status: 'trial' },
+    ]);
+    selectQueue.push([
+      { id: SITE_1, name: 'Main Office', orgId: ORG_1 },
+      { id: SITE_2, name: 'Warehouse', orgId: ORG_2 },
+    ]);
+
+    const out = JSON.parse(await getTools().list.handler({}, partnerAuth()));
+    expect(out.showing).toBe(2);
+    expect(out.organizations).toHaveLength(2);
+    expect(out.organizations[0]).toEqual({
+      id: ORG_1, name: 'Acme Dental', slug: 'acme-dental', status: 'active',
+      sites: [{ id: SITE_1, name: 'Main Office' }],
+    });
+    expect(out.organizations[1].sites).toEqual([{ id: SITE_2, name: 'Warehouse' }]);
+
+    // The org query is narrowed to the caller's accessible orgs.
+    expect(whereSpy.mock.calls[0]![0]).toEqual(
+      and(isNull(organizations.deletedAt), inArray(organizations.id, [ORG_1, ORG_2]))
+    );
+  });
+
+  it('applies the name-substring search filter', async () => {
+    selectQueue.push([{ id: ORG_1, name: 'Acme Dental', slug: 'acme-dental', status: 'active' }]);
+    selectQueue.push([]);
+
+    await getTools().list.handler({ search: 'acme' }, partnerAuth());
+    expect(whereSpy.mock.calls[0]![0]).toEqual(
+      and(
+        isNull(organizations.deletedAt),
+        ilike(organizations.name, '%acme%'),
+        inArray(organizations.id, [ORG_1, ORG_2])
+      )
+    );
+  });
+
+  it('org scope sees only its own org', async () => {
+    selectQueue.push([{ id: ORG_1, name: 'Acme Dental', slug: 'acme-dental', status: 'active' }]);
+    selectQueue.push([{ id: SITE_1, name: 'Main Office', orgId: ORG_1 }]);
+
+    const out = JSON.parse(await getTools().list.handler({}, orgAuth()));
+    expect(out.organizations).toHaveLength(1);
+    expect(out.organizations[0].id).toBe(ORG_1);
+    // The org query is pinned to the caller's own org id.
+    expect(whereSpy.mock.calls[0]![0]).toEqual(
+      and(isNull(organizations.deletedAt), eq(organizations.id, ORG_1))
+    );
+  });
+
+  it('org scope with no orgId returns empty without querying', async () => {
+    const out = JSON.parse(await getTools().list.handler({}, orgAuth({ orgId: null })));
+    expect(out).toEqual({ organizations: [], showing: 0 });
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('partner scope with no accessible orgs returns empty without querying', async () => {
+    const out = JSON.parse(
+      await getTools().list.handler({}, partnerAuth({ accessibleOrgIds: [], canAccessOrg: () => false }))
+    );
+    expect(out).toEqual({ organizations: [], showing: 0 });
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('site-restricted caller with an empty site allowlist gets orgs with no sites (single query)', async () => {
+    selectQueue.push([{ id: ORG_1, name: 'Acme Dental', slug: 'acme-dental', status: 'active' }]);
+
+    const out = JSON.parse(
+      await getTools().list.handler({}, orgAuth({ allowedSiteIds: [] }))
+    );
+    expect(out.organizations[0].sites).toEqual([]);
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('site-restricted caller only sees allowed sites', async () => {
+    selectQueue.push([{ id: ORG_1, name: 'Acme Dental', slug: 'acme-dental', status: 'active' }]);
+    selectQueue.push([{ id: SITE_1, name: 'Main Office', orgId: ORG_1 }]);
+
+    await getTools().list.handler({}, orgAuth({ allowedSiteIds: [SITE_1] }));
+    expect(whereSpy.mock.calls[1]![0]).toEqual(
+      and(inArray(sites.orgId, [ORG_1]), inArray(sites.id, [SITE_1]))
+    );
+  });
+});
+
+// ── manage_organizations: create_org ─────────────────────────────────────────
+
+describe('manage_organizations create_org', () => {
+  it('rejects an organization-scoped caller with a clean authorization error', async () => {
+    const out = JSON.parse(
+      await getTools().manage.handler({ action: 'create_org', name: 'Sneaky Org' }, orgAuth())
+    );
+    expect(out.code).toBe('PARTNER_SCOPE_REQUIRED');
+    expect(out.error).toMatch(/partner-scoped/i);
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('rejects a partner-scoped caller with no partnerId', async () => {
+    const out = JSON.parse(
+      await getTools().manage.handler(
+        { action: 'create_org', name: 'Orphan Org' },
+        partnerAuth({ partnerId: null })
+      )
+    );
+    expect(out.code).toBe('PARTNER_SCOPE_REQUIRED');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('creates the org under the caller partner with a default Main Office site (system db context)', async () => {
+    selectQueue.push([{ slug: 'existing-org' }]); // slug-uniqueness read
+    insertQueue.push([{ id: ORG_1, name: 'Acme Dental', slug: 'acme-dental', status: 'active' }]);
+    insertQueue.push([{ id: SITE_1, name: 'Main Office' }]);
+
+    const out = JSON.parse(
+      await getTools().manage.handler({ action: 'create_org', name: 'Acme Dental' }, partnerAuth())
+    );
+
+    expect(out.organization).toEqual({ id: ORG_1, name: 'Acme Dental', slug: 'acme-dental', status: 'active' });
+    expect(out.defaultSite).toEqual({ id: SITE_1, name: 'Main Office' });
+
+    // Org insert pinned to the CALLER's partner, slug derived from the name.
+    expect(insertValuesSpy).toHaveBeenNthCalledWith(1, organizations, {
+      partnerId: PARTNER_ID,
+      name: 'Acme Dental',
+      slug: 'acme-dental',
+      type: 'customer',
+      status: 'active',
+    });
+    // Default site insert for the new org.
+    expect(insertValuesSpy).toHaveBeenNthCalledWith(2, sites, {
+      orgId: ORG_1,
+      name: 'Main Office',
+      timezone: 'UTC',
+    });
+    // Tenant creation escapes the request RLS context.
+    expect(runOutsideDbContext).toHaveBeenCalled();
+    expect(withSystemDbAccessContext).toHaveBeenCalled();
+    // Audit events for both created resources.
+    expect(writeAuditEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('suffixes the slug when the base is already taken', async () => {
+    selectQueue.push([{ slug: 'acme-dental' }, { slug: 'acme-dental-2' }]);
+    insertQueue.push([{ id: ORG_1, name: 'Acme Dental', slug: 'acme-dental-3', status: 'active' }]);
+    insertQueue.push([{ id: SITE_1, name: 'Main Office' }]);
+
+    await getTools().manage.handler({ action: 'create_org', name: 'Acme Dental' }, partnerAuth());
+    expect(insertValuesSpy.mock.calls[0]![1]).toMatchObject({ slug: 'acme-dental-3' });
+  });
+
+  it('rejects a blank name', async () => {
+    const out = JSON.parse(
+      await getTools().manage.handler({ action: 'create_org', name: '   ' }, partnerAuth())
+    );
+    expect(out.error).toMatch(/name is required/i);
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+});
+
+// ── manage_organizations: update_org ─────────────────────────────────────────
+
+describe('manage_organizations update_org', () => {
+  it('rejects an organization-scoped caller', async () => {
+    const out = JSON.parse(
+      await getTools().manage.handler(
+        { action: 'update_org', orgId: ORG_1, name: 'Renamed' },
+        orgAuth()
+      )
+    );
+    expect(out.code).toBe('PARTNER_SCOPE_REQUIRED');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('denies a partner caller updating an org outside its accessible set', async () => {
+    const out = JSON.parse(
+      await getTools().manage.handler(
+        { action: 'update_org', orgId: OTHER_ORG, name: 'Hijack' },
+        partnerAuth()
+      )
+    );
+    expect(out.error).toMatch(/not found or access denied/i);
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('patches name and returns the safe projection', async () => {
+    updateQueue.push([{ id: ORG_1, name: 'Renamed', slug: 'acme-dental', status: 'active' }]);
+    const out = JSON.parse(
+      await getTools().manage.handler({ action: 'update_org', orgId: ORG_1, name: 'Renamed' }, partnerAuth())
+    );
+    expect(out.organization.name).toBe('Renamed');
+    expect(updateSetSpy.mock.calls[0]![0]).toMatchObject({ name: 'Renamed' });
+    expect(revokeOrganizationTenantAccess).not.toHaveBeenCalled();
+    expect(restoreOrganizationTenantAccess).not.toHaveBeenCalled();
+  });
+
+  it('suspending an org severs tenant access; reactivating restores it', async () => {
+    updateQueue.push([{ id: ORG_1, name: 'Acme', slug: 'acme', status: 'suspended' }]);
+    await getTools().manage.handler({ action: 'update_org', orgId: ORG_1, status: 'suspended' }, partnerAuth());
+    expect(revokeOrganizationTenantAccess).toHaveBeenCalledWith(ORG_1);
+
+    updateQueue.push([{ id: ORG_1, name: 'Acme', slug: 'acme', status: 'active' }]);
+    await getTools().manage.handler({ action: 'update_org', orgId: ORG_1, status: 'active' }, partnerAuth());
+    expect(restoreOrganizationTenantAccess).toHaveBeenCalledWith(ORG_1);
+  });
+
+  it('rejects an invalid status and an empty patch', async () => {
+    const bad = JSON.parse(
+      await getTools().manage.handler({ action: 'update_org', orgId: ORG_1, status: 'deleted' }, partnerAuth())
+    );
+    expect(bad.error).toMatch(/status must be one of/i);
+
+    const empty = JSON.parse(
+      await getTools().manage.handler({ action: 'update_org', orgId: ORG_1 }, partnerAuth())
+    );
+    expect(empty.error).toMatch(/no updates provided/i);
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('returns not-found when the update matches no row (deleted org / RLS deny)', async () => {
+    updateQueue.push([]);
+    const out = JSON.parse(
+      await getTools().manage.handler({ action: 'update_org', orgId: ORG_1, name: 'Ghost' }, partnerAuth())
+    );
+    expect(out.error).toMatch(/not found or access denied/i);
+  });
+});
+
+// ── manage_organizations: create_site ────────────────────────────────────────
+
+describe('manage_organizations create_site', () => {
+  it('creates a site in an accessible org (partner scope) with optional address', async () => {
+    insertQueue.push([{ id: SITE_2, name: 'Warehouse', orgId: ORG_2 }]);
+    const address = { addressLine1: '1 Dock St', city: 'Springfield' };
+    const out = JSON.parse(
+      await getTools().manage.handler(
+        { action: 'create_site', orgId: ORG_2, name: 'Warehouse', address },
+        partnerAuth()
+      )
+    );
+    expect(out.site).toEqual({ id: SITE_2, name: 'Warehouse', orgId: ORG_2 });
+    expect(insertValuesSpy).toHaveBeenCalledWith(sites, {
+      orgId: ORG_2,
+      name: 'Warehouse',
+      address,
+    });
+  });
+
+  it('denies a partner caller targeting an org outside its accessible set', async () => {
+    const out = JSON.parse(
+      await getTools().manage.handler(
+        { action: 'create_site', orgId: OTHER_ORG, name: 'Rogue Site' },
+        partnerAuth()
+      )
+    );
+    expect(out.error).toMatch(/access denied/i);
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('org scope may create a site in its OWN org only', async () => {
+    insertQueue.push([{ id: SITE_1, name: 'Branch', orgId: ORG_1 }]);
+    const ok = JSON.parse(
+      await getTools().manage.handler({ action: 'create_site', name: 'Branch' }, orgAuth())
+    );
+    expect(ok.site.orgId).toBe(ORG_1);
+    expect(insertValuesSpy.mock.calls[0]![1]).toMatchObject({ orgId: ORG_1 });
+
+    const denied = JSON.parse(
+      await getTools().manage.handler(
+        { action: 'create_site', orgId: ORG_2, name: 'Cross-org site' },
+        orgAuth()
+      )
+    );
+    expect(denied.error).toMatch(/cannot access another organization/i);
+  });
+
+  it('surfaces a 0-row insert (RLS deny) as an error instead of silent success', async () => {
+    insertQueue.push([]);
+    const out = JSON.parse(
+      await getTools().manage.handler({ action: 'create_site', orgId: ORG_1, name: 'Phantom' }, partnerAuth())
+    );
+    expect(out.error).toMatch(/failed to create site/i);
+  });
+
+  it('requires a name', async () => {
+    const out = JSON.parse(
+      await getTools().manage.handler({ action: 'create_site', orgId: ORG_1 }, partnerAuth())
+    );
+    expect(out.error).toMatch(/name is required/i);
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+});
+
+// ── manage_organizations: add_contact ────────────────────────────────────────
+
+describe('manage_organizations add_contact', () => {
+  it('returns a structured not-supported note without touching the database', async () => {
+    const out = JSON.parse(
+      await getTools().manage.handler(
+        { action: 'add_contact', orgId: ORG_1, name: 'Pat', email: 'pat@customer.example' },
+        partnerAuth()
+      )
+    );
+    expect(out.status).toBe('not_supported');
+    expect(out.code).toBe('CONTACT_ENTITY_UNDEFINED');
+    expect(out.note).toMatch(/product decision/i);
+    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+});
+
+// ── slug helpers ─────────────────────────────────────────────────────────────
+
+describe('slug helpers', () => {
+  it('slugifies names like the accounting importer', () => {
+    expect(slugifyOrgName('Acme Dental, LLC.')).toBe('acme-dental-llc');
+    expect(slugifyOrgName('---')).toBe('org');
+    expect(slugifyOrgName('Ünïcode & Co')).toBe('n-code-co');
+  });
+
+  it('appends numeric suffixes for taken slugs', () => {
+    const taken = new Set(['acme', 'acme-2']);
+    expect(generateUniqueOrgSlug('acme', taken)).toBe('acme-3');
+    expect(generateUniqueOrgSlug('fresh', taken)).toBe('fresh');
+  });
+});

--- a/apps/api/src/services/aiToolsOrgs.ts
+++ b/apps/api/src/services/aiToolsOrgs.ts
@@ -1,0 +1,502 @@
+/**
+ * AI Organization/Site Tools (issue #2366)
+ *
+ * Fills the MCP org-lifecycle gap so the new-customer intake workflow
+ * (org → site → quote) is possible without touching the web UI:
+ *  - `list_organizations` — read-only name-substring lookup of the caller's
+ *    accessible orgs, each with its sites. This is how the model resolves the
+ *    orgId/siteId that `manage_quotes.create_draft` and
+ *    `manage_contracts.create_draft` require.
+ *  - `manage_organizations` — write multiplexer: create_org / update_org /
+ *    create_site (all approval-gated Tier 3 via TIER3_ACTIONS in
+ *    aiGuardrails), plus add_contact which returns a structured
+ *    "needs product decision" note (Breeze has no first-class org-contact
+ *    entity — see the handler).
+ *
+ * Tenancy is enforced AT THE TOOL LAYER (the route site/org-scope scanner
+ * cannot see this parallel path):
+ *  - Cross-org listing narrows to `auth.accessibleOrgIds` for partner scope
+ *    and pins org scope to `auth.orgId` with the same safe projection the
+ *    GET /orgs/organizations route uses (no settings/ssoConfig/billing leak).
+ *  - `create_org` is a PARTNER-scope operation: an organization-scoped caller
+ *    gets a clean PARTNER_SCOPE_REQUIRED error. The insert mirrors the
+ *    POST /orgs/organizations route + quickbooksCustomerImport service:
+ *    tenant creation must escape the request RLS context
+ *    (runOutsideDbContext → withSystemDbAccessContext) because the new org id
+ *    cannot be in the caller's accessible set yet. Like the QB customer import
+ *    and partnerCreate, a default "Main Office" site is created in the same
+ *    transaction so the new org is immediately quotable (quotes need siteId).
+ *  - `update_org` mirrors the PATCH /orgs/organizations/:id invariants,
+ *    including severing/restoring agent tenant access on status transitions.
+ *  - `create_site` allows org-scoped callers for their OWN org only (same as
+ *    POST /orgs/sites) via the resolveWritableToolOrgId rules.
+ */
+
+import { and, eq, ilike, inArray, isNull, type SQL } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { organizations, sites } from '../db/schema';
+import { escapeLike } from '../utils/sql';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool, AiToolTier } from './aiTools';
+import { writeAuditEvent, requestLikeFromSnapshot } from './auditEvents';
+import {
+  restoreOrganizationTenantAccess,
+  revokeOrganizationTenantAccess,
+} from './tenantLifecycle';
+
+// Mirrors the org PATCH route's status set (schema orgStatusEnum). Kept as a
+// literal array (not orgStatusEnum.enumValues) so schema mocks in tests don't
+// break the zod/tool definitions.
+const ORG_STATUSES = ['active', 'suspended', 'trial', 'churned'] as const;
+type OrgStatus = (typeof ORG_STATUSES)[number];
+
+// Local copy of the slug helpers from services/accounting/quickbooksCustomerImport.ts
+// (duplicated rather than imported so this file doesn't drag the accounting
+// provider stack into every consumer; keep the two in sync).
+export function slugifyOrgName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 90)
+    .replace(/-+$/, '');
+  return slug || 'org';
+}
+
+export function generateUniqueOrgSlug(base: string, taken: Set<string>): string {
+  if (!taken.has(base)) return base;
+  for (let n = 2; ; n++) {
+    const candidate = `${base}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+// Local copy of the shared hub helper (same rules as resolveWritableToolOrgId
+// in services/aiTools.ts, duplicated like aiToolsBrowser/aiToolsCompliance do
+// so tests don't need to load the whole tool hub).
+function resolveWritableOrgId(
+  auth: AuthContext,
+  inputOrgId?: string
+): { orgId?: string; error?: string } {
+  if (auth.scope === 'organization') {
+    if (!auth.orgId) return { error: 'Organization context required' };
+    if (inputOrgId && inputOrgId !== auth.orgId) {
+      return { error: 'Cannot access another organization' };
+    }
+    return { orgId: auth.orgId };
+  }
+
+  if (inputOrgId) {
+    if (!auth.canAccessOrg(inputOrgId)) {
+      return { error: 'Access denied to this organization' };
+    }
+    return { orgId: inputOrgId };
+  }
+
+  if (auth.orgId) {
+    return { orgId: auth.orgId };
+  }
+
+  if (Array.isArray(auth.accessibleOrgIds) && auth.accessibleOrgIds.length === 1) {
+    return { orgId: auth.accessibleOrgIds[0] };
+  }
+
+  return { error: 'orgId is required for this operation' };
+}
+
+function jsonError(message: string, code?: string): string {
+  return JSON.stringify(code ? { error: message, code } : { error: message });
+}
+
+/** Best-effort audit write — never blocks the tool result (deleteTenant pattern). */
+function auditOrgToolEvent(
+  auth: AuthContext,
+  entry: {
+    orgId: string | null;
+    action: string;
+    resourceType: string;
+    resourceId?: string;
+    resourceName?: string;
+    details?: Record<string, unknown>;
+  }
+): void {
+  try {
+    writeAuditEvent(requestLikeFromSnapshot({}), {
+      orgId: entry.orgId,
+      actorId: auth.user.id,
+      actorEmail: auth.user.email,
+      action: entry.action,
+      resourceType: entry.resourceType,
+      resourceId: entry.resourceId,
+      resourceName: entry.resourceName,
+      result: 'success',
+      details: { ...entry.details, tool_name: 'manage_organizations' },
+    });
+  } catch (err) {
+    console.error('[manage_organizations] audit write failed', err);
+  }
+}
+
+const SAFE_ORG_PROJECTION = {
+  id: organizations.id,
+  name: organizations.name,
+  slug: organizations.slug,
+  status: organizations.status,
+};
+
+async function handleListOrganizations(
+  input: Record<string, unknown>,
+  auth: AuthContext
+): Promise<string> {
+  const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
+  const search = typeof input.search === 'string' ? input.search.trim() : '';
+  const searchCondition = search
+    ? ilike(organizations.name, `%${escapeLike(search)}%`)
+    : undefined;
+
+  const conditions: SQL[] = [isNull(organizations.deletedAt)];
+  if (searchCondition) conditions.push(searchCondition);
+
+  if (auth.scope === 'organization') {
+    // Org-scoped callers see ONLY their own org.
+    if (!auth.orgId) return JSON.stringify({ organizations: [], showing: 0 });
+    conditions.push(eq(organizations.id, auth.orgId));
+  } else if (auth.scope === 'partner') {
+    const orgIds = auth.accessibleOrgIds ?? [];
+    if (orgIds.length === 0) return JSON.stringify({ organizations: [], showing: 0 });
+    conditions.push(inArray(organizations.id, orgIds));
+  }
+  // system scope: no extra org filter (mirrors GET /orgs/organizations).
+
+  // Safe projection for every scope — an unprojected select would leak
+  // settings/ssoConfig/billingContact into the model context.
+  const orgs = await db
+    .select(SAFE_ORG_PROJECTION)
+    .from(organizations)
+    .where(and(...conditions))
+    .orderBy(organizations.name)
+    .limit(limit);
+
+  // Attach each org's sites (id + name — enough to feed manage_quotes'
+  // siteId). Site-restricted callers only see their allowed sites, mirroring
+  // the GET /orgs/sites confinement.
+  const sitesByOrg = new Map<string, Array<{ id: string; name: string }>>();
+  const orgIdsOnPage = orgs.map((o) => o.id);
+  // Site-restricted caller with an empty allowlist sees no sites at all —
+  // skip the query entirely rather than emit an empty IN ().
+  const siteListDenied = auth.allowedSiteIds !== undefined && auth.allowedSiteIds.length === 0;
+  if (orgIdsOnPage.length > 0 && !siteListDenied) {
+    const siteConditions: SQL[] = [inArray(sites.orgId, orgIdsOnPage)];
+    if (auth.allowedSiteIds && auth.allowedSiteIds.length > 0) {
+      siteConditions.push(inArray(sites.id, auth.allowedSiteIds));
+    }
+    const siteRows = await db
+      .select({ id: sites.id, name: sites.name, orgId: sites.orgId })
+      .from(sites)
+      .where(and(...siteConditions))
+      .orderBy(sites.name);
+    for (const row of siteRows) {
+      const list = sitesByOrg.get(row.orgId) ?? [];
+      list.push({ id: row.id, name: row.name });
+      sitesByOrg.set(row.orgId, list);
+    }
+  }
+
+  const data = orgs.map((org) => ({
+    ...org,
+    sites: sitesByOrg.get(org.id) ?? [],
+  }));
+
+  return JSON.stringify({ organizations: data, showing: data.length });
+}
+
+async function handleCreateOrg(
+  input: Record<string, unknown>,
+  auth: AuthContext
+): Promise<string> {
+  // Org creation is a PARTNER-scope operation: an org-scoped token must get a
+  // clean authorization error (never a cross-tenant write).
+  if (auth.scope !== 'partner' || !auth.partnerId) {
+    return jsonError(
+      'Creating organizations requires a partner-scoped session. Organization-scoped callers cannot create organizations.',
+      'PARTNER_SCOPE_REQUIRED'
+    );
+  }
+  const partnerId = auth.partnerId;
+
+  const name = typeof input.name === 'string' ? input.name.trim() : '';
+  if (!name) return jsonError('name is required for create_org');
+
+  // Tenant creation must escape the request RLS context: the new org id cannot
+  // be in the caller's accessible set yet (same rationale + pattern as
+  // POST /orgs/organizations and quickbooksCustomerImport). Partner authority
+  // was checked above. The slug read, org insert, and default-site insert share
+  // one system-context transaction.
+  const created = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const existing = await db
+        .select({ slug: organizations.slug })
+        .from(organizations)
+        .where(eq(organizations.partnerId, partnerId));
+      const taken = new Set(existing.map((row) => row.slug));
+      const slug = generateUniqueOrgSlug(slugifyOrgName(name), taken);
+
+      const [org] = await db
+        .insert(organizations)
+        .values({
+          partnerId,
+          name: name.slice(0, 255),
+          slug,
+          type: 'customer' as const,
+          status: 'active' as const,
+        })
+        .returning({
+          id: organizations.id,
+          name: organizations.name,
+          slug: organizations.slug,
+          status: organizations.status,
+        });
+      if (!org) throw new Error('Organization insert returned no row');
+
+      // Default site, same invariant as partnerCreate + the QB customer
+      // import — a brand-new org must be immediately usable for quoting
+      // (quotes require a siteId).
+      const [site] = await db
+        .insert(sites)
+        .values({ orgId: org.id, name: 'Main Office', timezone: 'UTC' })
+        .returning({ id: sites.id, name: sites.name });
+      if (!site) throw new Error('Default site insert returned no row');
+
+      return { org, site };
+    })
+  );
+
+  auditOrgToolEvent(auth, {
+    orgId: created.org.id,
+    action: 'organization.create',
+    resourceType: 'organization',
+    resourceId: created.org.id,
+    resourceName: created.org.name,
+    details: { partnerId, defaultSiteId: created.site.id },
+  });
+  auditOrgToolEvent(auth, {
+    orgId: created.org.id,
+    action: 'site.create',
+    resourceType: 'site',
+    resourceId: created.site.id,
+    resourceName: created.site.name,
+  });
+
+  return JSON.stringify({
+    organization: created.org,
+    defaultSite: created.site,
+    note: 'A default "Main Office" site was created with the organization; use create_site to add more locations.',
+  });
+}
+
+async function handleUpdateOrg(
+  input: Record<string, unknown>,
+  auth: AuthContext
+): Promise<string> {
+  // Mirrors PATCH /orgs/organizations/:id — partner/system scope only.
+  if (auth.scope === 'organization') {
+    return jsonError(
+      'Updating organizations requires a partner-scoped session.',
+      'PARTNER_SCOPE_REQUIRED'
+    );
+  }
+  const orgId = typeof input.orgId === 'string' ? input.orgId : '';
+  if (!orgId) return jsonError('orgId is required for update_org');
+  if (auth.scope === 'partner' && !auth.canAccessOrg(orgId)) {
+    return jsonError('Organization not found or access denied');
+  }
+
+  const name = typeof input.name === 'string' ? input.name.trim() : undefined;
+  const status = typeof input.status === 'string' ? input.status : undefined;
+  if (name === '') return jsonError('name cannot be empty');
+  if (status !== undefined && !ORG_STATUSES.includes(status as OrgStatus)) {
+    return jsonError(`status must be one of: ${ORG_STATUSES.join(', ')}`);
+  }
+  if (name === undefined && status === undefined) {
+    return jsonError('No updates provided — pass name and/or status');
+  }
+
+  const updates: Record<string, unknown> = { updatedAt: new Date() };
+  if (name !== undefined) updates.name = name.slice(0, 255);
+  if (status !== undefined) updates.status = status;
+
+  const [org] = await db
+    .update(organizations)
+    .set(updates)
+    .where(and(eq(organizations.id, orgId), isNull(organizations.deletedAt)))
+    .returning({
+      id: organizations.id,
+      name: organizations.name,
+      slug: organizations.slug,
+      status: organizations.status,
+    });
+  if (!org) return jsonError('Organization not found or access denied');
+
+  // Status-transition invariants from the org PATCH route: suspending/churning
+  // severs agent tenant access; re-activating restores it.
+  if (status !== undefined && status !== 'active' && status !== 'trial') {
+    await revokeOrganizationTenantAccess(org.id);
+  } else if (status === 'active' || status === 'trial') {
+    await restoreOrganizationTenantAccess(org.id);
+  }
+
+  auditOrgToolEvent(auth, {
+    orgId: org.id,
+    action: 'organization.update',
+    resourceType: 'organization',
+    resourceId: org.id,
+    resourceName: org.name,
+    details: {
+      changedFields: [
+        ...(name !== undefined ? ['name'] : []),
+        ...(status !== undefined ? ['status'] : []),
+      ],
+    },
+  });
+
+  return JSON.stringify({ organization: org });
+}
+
+async function handleCreateSite(
+  input: Record<string, unknown>,
+  auth: AuthContext
+): Promise<string> {
+  const resolved = resolveWritableOrgId(
+    auth,
+    typeof input.orgId === 'string' ? input.orgId : undefined
+  );
+  if (resolved.error || !resolved.orgId) {
+    return jsonError(resolved.error ?? 'orgId is required for create_site');
+  }
+
+  const name = typeof input.name === 'string' ? input.name.trim() : '';
+  if (!name) return jsonError('name is required for create_site');
+
+  const address =
+    input.address && typeof input.address === 'object' && !Array.isArray(input.address)
+      ? (input.address as Record<string, unknown>)
+      : undefined;
+
+  // Insert under the request context — RLS on `sites` (org axis) is the
+  // defense-in-depth backstop behind the resolveWritableOrgId check above.
+  const [site] = await db
+    .insert(sites)
+    .values({
+      orgId: resolved.orgId,
+      name: name.slice(0, 255),
+      address,
+    })
+    .returning({ id: sites.id, name: sites.name, orgId: sites.orgId });
+  // A 0-row insert means the RLS policy rejected it even though the app-layer
+  // check passed — surface it instead of returning success with no site.
+  if (!site) return jsonError('Failed to create site');
+
+  auditOrgToolEvent(auth, {
+    orgId: site.orgId,
+    action: 'site.create',
+    resourceType: 'site',
+    resourceId: site.id,
+    resourceName: site.name,
+  });
+
+  return JSON.stringify({ site });
+}
+
+function handleAddContact(): string {
+  // Breeze has no first-class organization-contact entity: `sites.contact` and
+  // `organizations.billingContact` are JSONB blobs, and portal users
+  // (orgPortalUsers) carry user-invite semantics we must not trigger from an
+  // AI tool. Surfacing a structured note (instead of inventing an invite flow)
+  // is deliberate — see issue #2366.
+  return JSON.stringify({
+    status: 'not_supported',
+    code: 'CONTACT_ENTITY_UNDEFINED',
+    note:
+      'Breeze has no standalone org-contact record yet, so add_contact needs a product decision before it can write anything. ' +
+      'Available today: a site contact can be set on the site record (web UI Settings → Organizations → site), and the billing ' +
+      'contact lives on the organization record. Portal users are invite-based and are not created by this tool.',
+  });
+}
+
+export function registerOrgTools(aiTools: Map<string, AiTool>): void {
+  aiTools.set('list_organizations', {
+    tier: 1 as AiToolTier,
+    deviceArgs: [],
+    definition: {
+      name: 'list_organizations',
+      description:
+        'List/search the organizations the caller can access (name substring match), each with id, name, slug, status, and ' +
+        'its sites (id + name). Use this to resolve the orgId and siteId that manage_quotes, manage_contracts, and ' +
+        'manage_invoices require. Partner-scoped callers see all their orgs; organization-scoped callers see only their own. ' +
+        'Read-only.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          search: { type: 'string', description: 'Case-insensitive name substring filter' },
+          limit: { type: 'number', description: 'Max results (default 25, max 100)' },
+        },
+        required: [],
+      },
+    },
+    handler: async (input, auth) => {
+      try {
+        return await handleListOrganizations(input, auth);
+      } catch (err) {
+        console.error('[list_organizations]', err);
+        return jsonError('Operation failed. Check server logs for details.');
+      }
+    },
+  });
+
+  aiTools.set('manage_organizations', {
+    tier: 2 as AiToolTier,
+    deviceArgs: [],
+    definition: {
+      name: 'manage_organizations',
+      description:
+        'Create and manage organizations and sites (new-customer intake). Actions: create_org (name required; creates the ' +
+        'org under the caller\'s partner WITH a default "Main Office" site — partner scope only), update_org (name/status ' +
+        'patch; suspending or churning an org severs its agents), create_site (orgId + name + optional address object), ' +
+        'add_contact (not yet supported — returns guidance). create_org, update_org, and create_site require approval.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          action: {
+            type: 'string',
+            enum: ['create_org', 'update_org', 'create_site', 'add_contact'],
+          },
+          orgId: { type: 'string', description: 'Organization UUID (update_org, create_site, add_contact)' },
+          name: { type: 'string', description: 'Org name (create_org/update_org) or site name (create_site)' },
+          status: { type: 'string', enum: [...ORG_STATUSES], description: 'New org status (update_org)' },
+          address: { type: 'object', description: 'Site address object (create_site), e.g. {addressLine1, city, state, postalCode, country}' },
+          email: { type: 'string', description: 'Contact email (add_contact — currently unsupported)' },
+        },
+        required: ['action'],
+      },
+    },
+    handler: async (input, auth) => {
+      try {
+        switch (input.action) {
+          case 'create_org':
+            return await handleCreateOrg(input, auth);
+          case 'update_org':
+            return await handleUpdateOrg(input, auth);
+          case 'create_site':
+            return await handleCreateSite(input, auth);
+          case 'add_contact':
+            return handleAddContact();
+          default:
+            return jsonError(`Unknown action: ${String(input.action)}`);
+        }
+      } catch (err) {
+        console.error('[manage_organizations]', input.action, err);
+        return jsonError('Operation failed. Check server logs for details.');
+      }
+    },
+  });
+}

--- a/apps/api/src/services/aiToolsReliability.test.ts
+++ b/apps/api/src/services/aiToolsReliability.test.ts
@@ -33,6 +33,11 @@ vi.mock('../db/schema', () => new Proxy({
     // Return empty object for any un-mocked table/export
     return {};
   },
+  // vitest validates named imports with `in` before calling get — without a
+  // has trap, any schema export not listed above fails the whole suite load.
+  has() {
+    return true;
+  },
 }));
 
 vi.mock('./aiToolSchemas', () => ({


### PR DESCRIPTION
## Summary

Fills the MCP org-lifecycle gap from #2366: across ~170 tools there was no way to look up **or** create an organization/site, which stranded the billing tools (`manage_quotes.create_draft` / `manage_contracts.create_draft` need `orgId` + `siteId`) for the front-door MSP workflow: org → site → contact → quote.

New domain file `apps/api/src/services/aiToolsOrgs.ts` (hub/per-domain pattern), registered in every sibling list: aiTools hub, `toolInputSchemas`, `TOOL_PERMISSIONS` + `TIER3_ACTIONS` + approval descriptions (aiGuardrails), and `TOOL_TIERS` + SDK `tool()` definitions (aiAgentSdkTools) — so the in-app chat path matches the MCP path. The MCP server picks both tools up automatically from the aiTools registry.

### `list_organizations` (tier 1, read-only)

- Name-substring search over the caller's accessible orgs; returns `id, name, slug, status` (safe projection — no `settings`/`ssoConfig`/`billingContact` leak into model context) plus each org's sites (`id`, `name`) to feed `manage_quotes`' `siteId`.
- **Partner scope** sees its `accessibleOrgIds`; **org scope** is pinned to its own org; **site-restricted** callers only see their allowed sites — all mirroring `GET /orgs/organizations` + `GET /orgs/sites` confinement.

### `manage_organizations` (tier 2 base; `create_org`/`update_org`/`create_site` escalate to tier-3 approval via `TIER3_ACTIONS`)

- **create_org** — PARTNER-scope only: an org-scoped token gets a clean `PARTNER_SCOPE_REQUIRED` error, never a cross-tenant write. Mirrors `POST /orgs/organizations` + the QuickBooks customer-import invariants: tenant creation escapes the request RLS context (`runOutsideDbContext` → `withSystemDbAccessContext` — the new org id can't be in the caller's accessible set yet), unique slug generation, and a default **"Main Office" site created in the same transaction** so the new org is immediately quotable. Audit events for both resources.
- **update_org** — name/status patch mirroring `PATCH /orgs/organizations/:id`, including severing agent tenant access on suspend/churn and restoring it on reactivate (`tenantLifecycle`).
- **create_site** — `orgId` + `name` + optional `address`, same `resolveWritableToolOrgId` rules as `POST /orgs/sites` (org-scoped callers: own org only). A 0-row insert (RLS deny) surfaces as an error instead of silent success.
- **add_contact** — returns a structured `not_supported` note (`CONTACT_ENTITY_UNDEFINED`). **Product decision needed:** Breeze has no first-class org-contact entity — `sites.contact` and `organizations.billingContact` are JSONB blobs, and portal users carry user-invite semantics an AI tool must not trigger. Per the issue, org + site are implemented and contacts return guidance rather than an invented invite flow.

## Tenancy / authz

- Org creation and cross-org listing are partner-scope operations; org-scoped tokens see only themselves in `list_organizations` and are cleanly rejected by `create_org`/`update_org`.
- No new tables, no migrations — `organizations` is an id-keyed tenant table (shape 2) and `sites` is org-axis, both already RLS-covered. RLS remains the defense-in-depth backstop behind the app-layer checks (the tool layer runs under the caller's DB access context on both the MCP and SDK paths).

## Ops note

Tier-3 actions (`create_org`/`update_org`/`create_site`) are additionally gated in production by `MCP_EXECUTE_TOOL_ALLOWLIST` — add `manage_organizations` to that env var on the droplets when this ships, same as the other approval-gated manage_* tools.

## Testing

- `aiToolsOrgs.test.ts` (28 tests): partner token lists all its orgs with sites grouped; org token sees only itself; org token `create_org` rejected (`PARTNER_SCOPE_REQUIRED`, no insert); `create_org` happy path (partner-pinned insert, slug uniqueness, default site, system db context, audit); `update_org` scope/status/sever-restore; `create_site` happy path + cross-org denials + 0-row RLS surfacing; `add_contact` structured note; slug helpers.
- Contract/parity suites green: `aiToolsRegistryParity`, `aiTools.deviceAccessSiteScope.contract`, `aiTools.deviceArgsCoverage.contract`, `scriptBuilderTools.guard` (100 tests, 5 files).
- `aiGuardrails.test.ts`, `aiToolSchemas.security.test.ts`, `aiAgentSdk.test.ts`, `mcpServer.test.ts` green.
- `tsc --noEmit` clean (includes test files).
- Pre-existing/environmental: `mcpServer.effectiveTier.test.ts` fails identically on a clean `origin/main` checkout in this environment (needs live infra) — unrelated to this change.

Closes #2366

🤖 Generated with [Claude Code](https://claude.com/claude-code)
