### PR TITLE
feat(auth): MFA policy and assurance (SR2-05,06,07,09,19,20,24)

### DIFF
--- a/apps/api/src/__tests__/integration/mfaAssurance.integration.test.ts
+++ b/apps/api/src/__tests__/integration/mfaAssurance.integration.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Real-Postgres atomicity proof for `invalidateMfaAssuranceAfterFactorChange`
+ * (Task 9 of the MFA policy/assurance PR — SR2-07/SR2-19).
+ *
+ * `mfaAssurance.test.ts` proves the call ordering (mutate → advance epoch →
+ * revoke families → post-commit cleanup) against a MOCKED `db.transaction`.
+ * That proves nothing about whether Postgres itself actually commits the
+ * three writes (factor mutation, `mfa_epoch` bump, refresh-family revoke)
+ * together, or rolls all three back together when `mutate` throws — a mock
+ * can't observe partial-commit behavior because it never talks to a real
+ * transaction. This file drives the real function against real Postgres to
+ * prove both directions of the atomicity invariant.
+ *
+ * The function itself does not open its own RLS access context (see its
+ * docstring — production callers already run inside the request's ambient
+ * `withDbAccessContext`, opened by `authMiddleware`). This test reproduces
+ * that same shape by wrapping the call in `withSystemDbAccessContext`, exactly
+ * as `refreshEpoch.integration.test.ts` wraps `advanceUserEpochs`/
+ * `revokeAllRefreshFamilies` directly.
+ *
+ * Run:
+ *   export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+ *   cd apps/api && pnpm vitest run --config vitest.integration.config.ts \
+ *     src/__tests__/integration/mfaAssurance.integration.test.ts
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { withSystemDbAccessContext } from '../../db';
+import { users, refreshTokenFamilies } from '../../db/schema';
+import { invalidateMfaAssuranceAfterFactorChange } from '../../services/mfaAssurance';
+import { mintRefreshTokenFamily } from '../../services/refreshTokenFamily';
+import { createPartner, createUser } from './db-utils';
+
+async function readUser(userId: string) {
+  const [row] = await getTestDb().select().from(users).where(eq(users.id, userId)).limit(1);
+  if (!row) throw new Error(`user ${userId} not found`);
+  return row;
+}
+
+async function readFamily(familyId: string) {
+  const [row] = await getTestDb()
+    .select()
+    .from(refreshTokenFamilies)
+    .where(eq(refreshTokenFamilies.familyId, familyId))
+    .limit(1);
+  if (!row) throw new Error(`family ${familyId} not found`);
+  return row;
+}
+
+describe('invalidateMfaAssuranceAfterFactorChange — real-PG atomicity (Task 9)', () => {
+  it('commits the factor write + mfa_epoch bump + family revoke together, in one transaction', async () => {
+    const partner = await createPartner();
+    const user = await createUser({ partnerId: partner.id, withMembership: true });
+    const familyId = await mintRefreshTokenFamily(user.id);
+
+    const before = await readUser(user.id);
+    expect(before.mfaEpoch).toBe(1);
+    expect(before.mfaMethod).toBeNull();
+    const familyBefore = await readFamily(familyId);
+    expect(familyBefore.revokedAt).toBeNull();
+
+    const result = await withSystemDbAccessContext(() =>
+      invalidateMfaAssuranceAfterFactorChange(user.id, 'test-commit', async (tx) => {
+        await tx.update(users).set({ mfaMethod: 'sms', updatedAt: new Date() }).where(eq(users.id, user.id));
+      })
+    );
+
+    // Returned mfaEpoch reflects the just-committed value.
+    expect(result.mfaEpoch).toBe(2);
+
+    // All three writes landed together.
+    const after = await readUser(user.id);
+    expect(after.mfaEpoch).toBe(2);
+    expect(after.mfaMethod).toBe('sms');
+    const familyAfter = await readFamily(familyId);
+    expect(familyAfter.revokedAt).not.toBeNull();
+    expect(familyAfter.revokedReason).toBe('test-commit');
+  });
+
+  it('rolls back the factor write AND the epoch bump AND the family revoke when mutate throws (no partial commit)', async () => {
+    const partner = await createPartner();
+    const user = await createUser({ partnerId: partner.id, withMembership: true });
+    const familyId = await mintRefreshTokenFamily(user.id);
+
+    const before = await readUser(user.id);
+    expect(before.mfaEpoch).toBe(1);
+    expect(before.mfaMethod).toBeNull();
+
+    const boom = new Error('factor write failed mid-transaction');
+    await expect(
+      withSystemDbAccessContext(() =>
+        invalidateMfaAssuranceAfterFactorChange(user.id, 'test-rollback', async (tx) => {
+          await tx.update(users).set({ mfaMethod: 'sms', updatedAt: new Date() }).where(eq(users.id, user.id));
+          throw boom;
+        })
+      )
+    ).rejects.toThrow(boom);
+
+    // Nothing committed: the factor field write, the epoch bump, and the
+    // family revoke are all still at their pre-call values.
+    const after = await readUser(user.id);
+    expect(after.mfaEpoch).toBe(1);
+    expect(after.mfaMethod).toBeNull();
+    const familyAfter = await readFamily(familyId);
+    expect(familyAfter.revokedAt).toBeNull();
+  });
+});

--- a/apps/api/src/__tests__/integration/passkeyMfaVerify.integration.test.ts
+++ b/apps/api/src/__tests__/integration/passkeyMfaVerify.integration.test.ts
@@ -91,9 +91,23 @@ describe('POST /auth/mfa/passkey/verify — passkey metadata persists under RLS 
     if (!redis) throw new Error('Redis unavailable in integration environment');
     const tempToken = `test-passkey-mfa-${user.id}`;
     tempTokens.push(tempToken);
+    // SR2-06: the pending record now carries the epoch/status binding
+    // captured at login — parsePendingMfa is strict, so a bare/legacy record
+    // is rejected outright. `createUser` rows default to authEpoch/mfaEpoch=1
+    // and status='active' (see db/schema/users.ts), which this record must
+    // match for the live re-check in the verify handler to succeed.
     await redis.set(
       `mfa:pending:${tempToken}`,
-      JSON.stringify({ userId: user.id, mfaMethod: 'passkey', passkeyAvailable: true }),
+      JSON.stringify({
+        userId: user.id,
+        mfaMethod: 'passkey',
+        passkeyAvailable: true,
+        authEpoch: 1,
+        mfaEpoch: 1,
+        statusExpectation: 'active',
+        allowedMethods: { totp: true, sms: true, passkey: true },
+        expiresAt: Date.now() + 5 * 60 * 1000,
+      }),
       'EX',
       300
     );

--- a/apps/api/src/__tests__/integration/pendingMfaEpoch.integration.test.ts
+++ b/apps/api/src/__tests__/integration/pendingMfaEpoch.integration.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Real-Postgres proof that a pending MFA session is invalidated once
+ * `mfa_epoch` advances underneath it (Task 9 of the MFA policy/assurance PR —
+ * SR2-06).
+ *
+ * `evaluatePendingMfa`/`parsePendingMfa` are covered by mocked unit tests
+ * (helpers.test.ts), which stub the "live" epoch/status entirely. This file
+ * proves the live re-check in `/mfa/verify` actually re-reads the CURRENT
+ * `mfa_epoch` from real Postgres — not a value captured at login time — by
+ * committing a real epoch bump (via `invalidateMfaAssuranceAfterFactorChange`,
+ * the same primitive every factor-change handler uses) between writing the
+ * pending record and presenting it, and asserting the verify call is
+ * rejected and mints no tokens.
+ *
+ * Run:
+ *   export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+ *   cd apps/api && pnpm vitest run --config vitest.integration.config.ts \
+ *     src/__tests__/integration/pendingMfaEpoch.integration.test.ts
+ */
+import './setup';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { users, refreshTokenFamilies } from '../../db/schema';
+import { withSystemDbAccessContext } from '../../db';
+import { invalidateMfaAssuranceAfterFactorChange } from '../../services/mfaAssurance';
+import { createPartner, createUser } from './db-utils';
+import { mfaRoutes } from '../../routes/auth/mfa';
+
+describe('POST /auth/mfa/verify — pending session bound to a stale mfa_epoch is rejected (Task 9, SR2-06)', () => {
+  let app: Hono;
+  const tempTokens: string[] = [];
+
+  beforeEach(() => {
+    app = new Hono();
+    app.route('/auth', mfaRoutes);
+  });
+
+  afterEach(async () => {
+    const { getRedis } = await import('../../services');
+    const redis = getRedis();
+    if (redis && tempTokens.length > 0) {
+      await redis.del(...tempTokens.map((t) => `mfa:pending:${t}`));
+    }
+    tempTokens.length = 0;
+  });
+
+  it('returns 401 "Invalid or expired MFA session" and mints no tokens once mfa_epoch has advanced past the pending record', async () => {
+    const partner = await createPartner();
+    const user = await createUser({ partnerId: partner.id, withMembership: true, mfaEnabled: true });
+
+    const [before] = await getTestDb().select({ mfaEpoch: users.mfaEpoch }).from(users).where(eq(users.id, user.id));
+    const pendingMfaEpoch = before!.mfaEpoch; // N — captured at "login time"
+    expect(pendingMfaEpoch).toBe(1);
+
+    const { getRedis } = await import('../../services');
+    const redis = getRedis();
+    if (!redis) throw new Error('Redis unavailable in integration environment');
+
+    const tempToken = `test-pending-epoch-${user.id}`;
+    tempTokens.push(tempToken);
+    await redis.set(
+      `mfa:pending:${tempToken}`,
+      JSON.stringify({
+        userId: user.id,
+        mfaMethod: 'totp',
+        passkeyAvailable: false,
+        authEpoch: 1,
+        mfaEpoch: pendingMfaEpoch, // bound to N
+        statusExpectation: 'active',
+        allowedMethods: { totp: true, sms: true, passkey: true },
+        expiresAt: Date.now() + 5 * 60 * 1000,
+      }),
+      'EX',
+      300
+    );
+
+    // Advance mfa_epoch to N+1 via a COMMITTED factor-change call — the same
+    // primitive every real factor-add/remove/rotate handler uses, not a raw
+    // test-only UPDATE.
+    const result = await withSystemDbAccessContext(() =>
+      invalidateMfaAssuranceAfterFactorChange(user.id, 'pending-epoch-test', async (tx) => {
+        await tx.update(users).set({ mfaMethod: 'sms', updatedAt: new Date() }).where(eq(users.id, user.id));
+      })
+    );
+    expect(result.mfaEpoch).toBe(pendingMfaEpoch + 1);
+
+    const familiesBefore = await getTestDb()
+      .select()
+      .from(refreshTokenFamilies)
+      .where(eq(refreshTokenFamilies.userId, user.id));
+    expect(familiesBefore).toHaveLength(0); // nothing minted yet
+
+    const res = await app.request('/auth/mfa/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tempToken, code: '123456' }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe('Invalid or expired MFA session');
+
+    // No tokens minted: still zero refresh-token families for this user, and
+    // no Set-Cookie was issued.
+    const familiesAfter = await getTestDb()
+      .select()
+      .from(refreshTokenFamilies)
+      .where(eq(refreshTokenFamilies.userId, user.id));
+    expect(familiesAfter).toHaveLength(0);
+    expect(res.headers.get('set-cookie')).toBeNull();
+
+    // The pending record was consumed by the rejection — a retry with the
+    // same tempToken is rejected outright (no lingering session to hammer).
+    const stillPending = await redis.get(`mfa:pending:${tempToken}`);
+    expect(stillPending).toBeNull();
+  });
+});

--- a/apps/api/src/__tests__/integration/recoveryCode.integration.test.ts
+++ b/apps/api/src/__tests__/integration/recoveryCode.integration.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Real-Postgres concurrency proof for the `/mfa/verify` recovery-code path
+ * (Task 9 of the MFA policy/assurance PR — SR2-09).
+ *
+ * `mfa.ts` removes exactly one matching hash with a RELATIVE jsonb delete
+ * (`mfaRecoveryCodes - inputHash`) guarded by `@> [inputHash]`, instead of a
+ * stale read-modify-write (`SET = <JS array computed from a pre-read
+ * snapshot>`). Mocked unit tests cannot prove the concurrency shape actually
+ * composes under real Postgres — they stub the DB round-trip entirely. This
+ * file drives two genuinely concurrent HTTP requests against real Postgres +
+ * real Redis and proves:
+ *
+ *   (a) identical-code single-winner: two concurrent submissions of the SAME
+ *       valid code race on the `@>` guard — exactly one succeeds, the loser's
+ *       guard fails against the winner's already-committed value (rowCount 0),
+ *       and the persisted array drops by exactly one hash (no double-spend).
+ *   (b) DISTINCT-code no-resurrection (the C1 regression this exists to
+ *       prevent): two concurrent submissions of DIFFERENT valid codes each
+ *       delete their OWN element from the row's latest committed value, so
+ *       BOTH succeed and NEITHER resurrects the other's removed hash. A stale
+ *       read-modify-write would have had both requests compute their `SET`
+ *       value from the SAME pre-race snapshot, so whichever committed second
+ *       would silently restore the first winner's already-spent code.
+ *
+ * Run:
+ *   export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+ *   cd apps/api && pnpm vitest run --config vitest.integration.config.ts \
+ *     src/__tests__/integration/recoveryCode.integration.test.ts
+ */
+import './setup';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { users } from '../../db/schema';
+import { createPartner, createUser } from './db-utils';
+import { hashRecoveryCode } from '../../routes/auth/helpers';
+import { mfaRoutes } from '../../routes/auth/mfa';
+
+const CODE_A = 'AAAA-1111';
+const CODE_B = 'BBBB-2222';
+const CODE_C = 'CCCC-3333';
+
+function pendingRecord(userId: string) {
+  return JSON.stringify({
+    userId,
+    mfaMethod: 'totp',
+    passkeyAvailable: false,
+    authEpoch: 1,
+    mfaEpoch: 1,
+    statusExpectation: 'active',
+    allowedMethods: { totp: true, sms: true, passkey: true },
+    expiresAt: Date.now() + 5 * 60 * 1000,
+  });
+}
+
+async function seedUserWithRecoveryCodes(): Promise<string> {
+  const partner = await createPartner();
+  const user = await createUser({ partnerId: partner.id, withMembership: true, mfaEnabled: true });
+  const hashes = [CODE_A, CODE_B, CODE_C].map(hashRecoveryCode);
+  await getTestDb().update(users).set({ mfaRecoveryCodes: hashes }).where(eq(users.id, user.id));
+  return user.id;
+}
+
+async function readRecoveryCodes(userId: string): Promise<string[]> {
+  const [row] = await getTestDb()
+    .select({ mfaRecoveryCodes: users.mfaRecoveryCodes })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return Array.isArray(row?.mfaRecoveryCodes) ? (row!.mfaRecoveryCodes as string[]) : [];
+}
+
+async function verify(app: Hono, tempToken: string, code: string) {
+  return app.request('/auth/mfa/verify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tempToken, code, method: 'recovery' }),
+  });
+}
+
+describe('POST /auth/mfa/verify (method: recovery) — real-PG single-use concurrency (Task 9, SR2-09)', () => {
+  let app: Hono;
+  const tempTokens: string[] = [];
+
+  beforeEach(() => {
+    app = new Hono();
+    app.route('/auth', mfaRoutes);
+  });
+
+  afterEach(async () => {
+    const { getRedis } = await import('../../services');
+    const redis = getRedis();
+    if (redis && tempTokens.length > 0) {
+      await redis.del(...tempTokens.map((t) => `mfa:pending:${t}`));
+    }
+    tempTokens.length = 0;
+  });
+
+  it('identical-code race: exactly one 200, one 401, persisted array has exactly 2 hashes (no double-spend)', async () => {
+    const userId = await seedUserWithRecoveryCodes();
+    const { getRedis } = await import('../../services');
+    const redis = getRedis();
+    if (!redis) throw new Error('Redis unavailable in integration environment');
+
+    // Two independent pending sessions (as two racing tabs from the same
+    // login would each hold their own tempToken), both bound to the SAME
+    // live epoch/status so neither is rejected by the epoch/status gate.
+    const tokenX = `test-recovery-identical-x-${userId}`;
+    const tokenY = `test-recovery-identical-y-${userId}`;
+    tempTokens.push(tokenX, tokenY);
+    await redis.set(`mfa:pending:${tokenX}`, pendingRecord(userId), 'EX', 300);
+    await redis.set(`mfa:pending:${tokenY}`, pendingRecord(userId), 'EX', 300);
+
+    const [r1, r2] = await Promise.all([verify(app, tokenX, CODE_A), verify(app, tokenY, CODE_A)]);
+
+    const statuses = [r1.status, r2.status].sort((a, b) => a - b);
+    expect(statuses).toEqual([200, 401]);
+
+    const remaining = await readRecoveryCodes(userId);
+    expect(remaining).toHaveLength(2);
+    expect(remaining).not.toContain(hashRecoveryCode(CODE_A));
+    expect(remaining).toEqual(expect.arrayContaining([hashRecoveryCode(CODE_B), hashRecoveryCode(CODE_C)]));
+  });
+
+  it('DISTINCT-code race (C1 regression): both 200, persisted array is exactly [hC] — neither winner resurrects the other\'s removed hash', async () => {
+    const userId = await seedUserWithRecoveryCodes();
+    const { getRedis } = await import('../../services');
+    const redis = getRedis();
+    if (!redis) throw new Error('Redis unavailable in integration environment');
+
+    const tokenX = `test-recovery-distinct-x-${userId}`;
+    const tokenY = `test-recovery-distinct-y-${userId}`;
+    tempTokens.push(tokenX, tokenY);
+    await redis.set(`mfa:pending:${tokenX}`, pendingRecord(userId), 'EX', 300);
+    await redis.set(`mfa:pending:${tokenY}`, pendingRecord(userId), 'EX', 300);
+
+    // Fire concurrently — no await between requests — so the two `UPDATE ...
+    // WHERE mfaRecoveryCodes @> [hash]` statements genuinely race in
+    // Postgres rather than serializing by test-code ordering.
+    const [r1, r2] = await Promise.all([verify(app, tokenX, CODE_A), verify(app, tokenY, CODE_B)]);
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+
+    const remaining = await readRecoveryCodes(userId);
+    // The whole point of the relative jsonb `-` delete: exactly N-2 hashes
+    // remain, and it is precisely the untouched third code — hA is not
+    // resurrected by hB's commit, nor vice versa.
+    expect(remaining).toHaveLength(1);
+    expect(remaining).toEqual([hashRecoveryCode(CODE_C)]);
+    expect(remaining).not.toContain(hashRecoveryCode(CODE_A));
+    expect(remaining).not.toContain(hashRecoveryCode(CODE_B));
+  });
+});

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -487,6 +487,35 @@ describe('authMiddleware', () => {
     expect(vi.mocked(getEffectiveMfaPolicy)).not.toHaveBeenCalled();
   });
 
+  // I6: passkey registration is an enrollment action (passkey is the always-
+  // allowed, phishing-resistant factor). A policy-required-but-unenrolled user
+  // MUST be able to reach /auth/passkeys/register/* — otherwise the broadened
+  // 428 gate locks them out of the one factor the resolver always permits.
+  it('I6: allows an unenrolled user to reach /auth/passkeys/register/options (exempt from the 428 gate)', async () => {
+    const app = new Hono();
+    app.use(authMiddleware);
+    app.post('/api/v1/auth/passkeys/register/options', (c) => c.json({ challenge: 'abc' }));
+
+    vi.mocked(verifyToken).mockResolvedValue({
+      ...basePayload,
+      scope: 'partner',
+      orgId: null
+    });
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectWithLimit([unenrolledUser]) as any)
+      .mockReturnValueOnce(selectWithLimit([{ orgAccess: 'none', orgIds: null }]) as any);
+
+    const res = await app.request('/api/v1/auth/passkeys/register/options', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).not.toBe(428);
+    expect(res.status).toBe(200);
+    expect(vi.mocked(getEffectiveMfaPolicy)).not.toHaveBeenCalled();
+  });
+
   it('permits an enrolled user without consulting the resolver at all', async () => {
     const app = new Hono();
     app.use(authMiddleware);

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -32,6 +32,16 @@ vi.mock('../services/auditEvents', () => ({
   writeAuditEvent: vi.fn()
 }));
 
+// Default: policy never requires MFA. Individual gate tests below override
+// this per-call via mockResolvedValue/mockResolvedValueOnce.
+vi.mock('../services/mfaPolicy', () => ({
+  getEffectiveMfaPolicy: vi.fn(async () => ({
+    required: false,
+    allowedMethods: { totp: true, sms: true, passkey: true },
+    source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: false }
+  }))
+}));
+
 // Default to pass-through; the propagation test below overrides it to
 // return a deny Response the way the real guard does.
 const ipGuardMocks = vi.hoisted(() => ({
@@ -94,6 +104,7 @@ import { isTokenIssuedBeforePasswordChange, isUserTokenRevoked } from '../servic
 import { db, withDbAccessContext } from '../db';
 import { getUserPermissions, hasPermission, canAccessOrg } from '../services/permissions';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
+import { getEffectiveMfaPolicy } from '../services/mfaPolicy';
 
 const basePayload = {
   sub: 'user-123',
@@ -398,21 +409,18 @@ describe('authMiddleware', () => {
 
   // ---- Role-level force_mfa gate (Task 8) ----
   //
-  // Builds a select chain that supports the role-lookup inner-join:
-  //   db.select({...}).from(table).innerJoin(roles, ...).where(...).limit(1)
-  function selectWithJoinLimit(rows: unknown[]) {
-    return {
-      from: vi.fn().mockReturnValue({
-        innerJoin: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue(rows)
-          })
-        })
-      })
-    };
-  }
+  const requirePolicy = {
+    required: true,
+    allowedMethods: { totp: true, sms: true, passkey: true },
+    source: { roleForceMfa: true, settingsRequireMfa: false, killSwitchOff: false }
+  };
+  const noRequirePolicy = {
+    required: false,
+    allowedMethods: { totp: true, sms: true, passkey: true },
+    source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: false }
+  };
 
-  it('returns 428 mfa_enrollment_required when a force_mfa role user has no MFA enabled', async () => {
+  it('returns 428 mfa_enrollment_required when the effective policy requires MFA and the user has none enabled', async () => {
     const app = new Hono();
     app.use(authMiddleware);
     app.get('/test', (c) => c.json({ ok: true }));
@@ -425,10 +433,11 @@ describe('authMiddleware', () => {
     });
 
     vi.mocked(db.select)
-      // 1) user lookup
-      .mockReturnValueOnce(selectWithLimit([unenrolledUser]) as any)
-      // 2) role lookup via partner_users INNER JOIN roles
-      .mockReturnValueOnce(selectWithJoinLimit([{ forceMfa: true }]) as any);
+      // 1) user lookup only — the enrollment gate now delegates the
+      // required/allowed decision entirely to the mocked resolver below,
+      // so no second db.select for a role-join is issued here.
+      .mockReturnValueOnce(selectWithLimit([unenrolledUser]) as any);
+    vi.mocked(getEffectiveMfaPolicy).mockResolvedValue(requirePolicy);
 
     const res = await app.request('/api/v1/partner/me', {
       method: 'POST',
@@ -441,9 +450,15 @@ describe('authMiddleware', () => {
       error: 'mfa_enrollment_required',
       enrollUrl: '/auth/mfa/setup'
     });
+    expect(vi.mocked(getEffectiveMfaPolicy)).toHaveBeenCalledWith({
+      scope: 'partner',
+      userId: unenrolledUser.id,
+      orgId: null,
+      partnerId: basePayload.partnerId
+    });
   });
 
-  it('allows force_mfa role user to reach /auth/mfa/setup-totp while in mfa-required state', async () => {
+  it('allows an unenrolled user to reach /auth/mfa/setup-totp WITHOUT calling the resolver (exempt path checked first)', async () => {
     const app = new Hono();
     app.use(authMiddleware);
     app.post('/api/v1/auth/mfa/setup-totp', (c) => c.json({ secret: 'abc' }));
@@ -457,12 +472,8 @@ describe('authMiddleware', () => {
     vi.mocked(db.select)
       // 1) user lookup
       .mockReturnValueOnce(selectWithLimit([unenrolledUser]) as any)
-      // 2) role lookup — would say "force MFA" but we never reach it
-      //    because the path is exempt before the gate runs role lookup.
-      //    Still — the gate path-checks AFTER doing the role lookup, so
-      //    we still need to return forceMfa here.
-      .mockReturnValueOnce(selectWithJoinLimit([{ forceMfa: true }]) as any)
-      // 3) computeAccessibleOrgIds → partnerUsers (orgAccess only)
+      // 2) exempt path skips the resolver entirely, so the next select is
+      // computeAccessibleOrgIds → partnerUsers (orgAccess only)
       .mockReturnValueOnce(selectWithLimit([{ orgAccess: 'none', orgIds: null }]) as any);
 
     const res = await app.request('/api/v1/auth/mfa/setup-totp', {
@@ -472,9 +483,11 @@ describe('authMiddleware', () => {
 
     expect(res.status).not.toBe(428);
     expect(res.status).toBe(200);
+    // I4: exempt paths must not pay the resolver's extra DB cost.
+    expect(vi.mocked(getEffectiveMfaPolicy)).not.toHaveBeenCalled();
   });
 
-  it('permits force_mfa role user once MFA is enabled (skips role lookup entirely)', async () => {
+  it('permits an enrolled user without consulting the resolver at all', async () => {
     const app = new Hono();
     app.use(authMiddleware);
     app.post('/api/v1/partner/me', (c) => c.json({ ok: true }));
@@ -489,7 +502,8 @@ describe('authMiddleware', () => {
     vi.mocked(db.select)
       // 1) user lookup — mfaEnabled=true (default activeUser)
       .mockReturnValueOnce(selectWithLimit([activeUser]) as any)
-      // 2) Gate is skipped, so the next select is computeAccessibleOrgIds
+      // 2) Gate is skipped (user.mfaEnabled=true), so the next select is
+      // computeAccessibleOrgIds
       .mockReturnValueOnce(selectWithLimit([{ orgAccess: 'none', orgIds: null }]) as any);
 
     const res = await app.request('/api/v1/partner/me', {
@@ -498,9 +512,10 @@ describe('authMiddleware', () => {
     });
 
     expect(res.status).toBe(200);
+    expect(vi.mocked(getEffectiveMfaPolicy)).not.toHaveBeenCalled();
   });
 
-  it('does not gate users whose role does NOT have force_mfa', async () => {
+  it('does not gate an unenrolled user when the effective policy does not require MFA', async () => {
     const app = new Hono();
     app.use(authMiddleware);
     app.post('/api/v1/partner/me', (c) => c.json({ ok: true }));
@@ -513,10 +528,9 @@ describe('authMiddleware', () => {
 
     vi.mocked(db.select)
       .mockReturnValueOnce(selectWithLimit([unenrolledUser]) as any)
-      // forceMfa=false → gate passes
-      .mockReturnValueOnce(selectWithJoinLimit([{ forceMfa: false }]) as any)
       // computeAccessibleOrgIds
       .mockReturnValueOnce(selectWithLimit([{ orgAccess: 'none', orgIds: null }]) as any);
+    vi.mocked(getEffectiveMfaPolicy).mockResolvedValue(noRequirePolicy);
 
     const res = await app.request('/api/v1/partner/me', {
       method: 'POST',
@@ -526,7 +540,7 @@ describe('authMiddleware', () => {
     expect(res.status).toBe(200);
   });
 
-  it('does not gate system-scope users (platform admin uses a user flag, not a role)', async () => {
+  it('does not gate an unenrolled system-scope user (resolver returns required=false for system scope — see mfaPolicy.test.ts)', async () => {
     const app = new Hono();
     app.use(authMiddleware);
     app.post('/api/v1/partner/me', (c) => c.json({ ok: true }));
@@ -539,10 +553,10 @@ describe('authMiddleware', () => {
     });
 
     vi.mocked(db.select)
-      // Just the user lookup — system scope skips force_mfa lookup
-      // (no partner/org membership), and computeAccessibleOrgIds returns
-      // null for system scope without a query.
+      // Just the user lookup — computeAccessibleOrgIds returns null for
+      // system scope without a query.
       .mockReturnValueOnce(selectWithLimit([{ ...unenrolledUser, isPlatformAdmin: true }]) as any);
+    vi.mocked(getEffectiveMfaPolicy).mockResolvedValue(noRequirePolicy);
 
     const res = await app.request('/api/v1/partner/me', {
       method: 'POST',
@@ -550,44 +564,6 @@ describe('authMiddleware', () => {
     });
 
     expect(res.status).toBe(200);
-  });
-
-  // Kill-switch: MFA_FORCE_FOR_PARTNER_ADMIN=false disables the gate
-  // even for users in force_mfa roles, and short-circuits BEFORE the
-  // role lookup so a misconfigured DB can't fail the request either.
-  it('skips the gate entirely when MFA_FORCE_FOR_PARTNER_ADMIN=false', async () => {
-    const prev = process.env.MFA_FORCE_FOR_PARTNER_ADMIN;
-    process.env.MFA_FORCE_FOR_PARTNER_ADMIN = 'false';
-    try {
-      const app = new Hono();
-      app.use(authMiddleware);
-      app.post('/api/v1/partner/me', (c) => c.json({ ok: true }));
-
-      vi.mocked(verifyToken).mockResolvedValue({
-        ...basePayload,
-        scope: 'partner',
-        orgId: null
-      });
-
-      vi.mocked(db.select)
-        // Only the user lookup — the role lookup must be skipped, so we
-        // intentionally do NOT mock selectWithJoinLimit. If the middleware
-        // calls db.select a second time the mock returns undefined and the
-        // test fails with a destructuring error, proving the short-circuit.
-        .mockReturnValueOnce(selectWithLimit([unenrolledUser]) as any)
-        // computeAccessibleOrgIds (last select)
-        .mockReturnValueOnce(selectWithLimit([{ orgAccess: 'none', orgIds: null }]) as any);
-
-      const res = await app.request('/api/v1/partner/me', {
-        method: 'POST',
-        headers: { Authorization: 'Bearer token' }
-      });
-
-      expect(res.status).toBe(200);
-    } finally {
-      if (prev === undefined) delete process.env.MFA_FORCE_FOR_PARTNER_ADMIN;
-      else process.env.MFA_FORCE_FOR_PARTNER_ADMIN = prev;
-    }
   });
 });
 

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -11,7 +11,7 @@ import { ENABLE_2FA } from '../routes/auth/schemas';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
 import { writeAuditEvent } from '../services/auditEvents';
 import { withSentryRequestScope } from '../services/sentry';
-import { mfaForcePartnerAdmin } from '../config/env';
+import { getEffectiveMfaPolicy } from '../services/mfaPolicy';
 import { ipAllowlistGuard } from './ipAllowlistGuard';
 import { isSelfManagedDbContextRoute } from './selfManagedDbContextRoutes';
 
@@ -113,59 +113,6 @@ export function siteAccessCheck(
     if (!siteId) return false;
     return allowedSiteIds.includes(siteId);
   };
-}
-
-/**
- * Resolve whether the user's effective role for the current request has
- * `force_mfa=true`. Returns false for system scope (platform admin is a
- * user flag, not a role) and for any user whose membership row is missing.
- *
- * Runs under system scope because the request's RLS context isn't set yet.
- */
-async function userRoleRequiresMfa(
-  scope: 'system' | 'partner' | 'organization',
-  partnerId: string | null,
-  orgId: string | null,
-  userId: string
-): Promise<boolean> {
-  if (scope === 'system') return false;
-  // Kill-switch: when off, skip the role lookup entirely so an enrollment
-  // outage can be relieved by ops with an env flag (no code deploy).
-  if (!mfaForcePartnerAdmin()) return false;
-
-  return withSystemDbAccessContext(async () => {
-    if (scope === 'organization' && orgId) {
-      const [row] = await db
-        .select({ forceMfa: roles.forceMfa })
-        .from(organizationUsers)
-        .innerJoin(roles, eq(organizationUsers.roleId, roles.id))
-        .where(
-          and(
-            eq(organizationUsers.userId, userId),
-            eq(organizationUsers.orgId, orgId)
-          )
-        )
-        .limit(1);
-      return row?.forceMfa === true;
-    }
-
-    if (scope === 'partner' && partnerId) {
-      const [row] = await db
-        .select({ forceMfa: roles.forceMfa })
-        .from(partnerUsers)
-        .innerJoin(roles, eq(partnerUsers.roleId, roles.id))
-        .where(
-          and(
-            eq(partnerUsers.userId, userId),
-            eq(partnerUsers.partnerId, partnerId)
-          )
-        )
-        .limit(1);
-      return row?.forceMfa === true;
-    }
-
-    return false;
-  });
 }
 
 /**
@@ -475,22 +422,29 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
     throw err;
   }
 
-  // Role-level MFA gate. If the user's role requires MFA and they
-  // haven't enabled it, short-circuit to 428 Precondition Required.
-  // Allow a tight set of routes through (logout, the user's own
-  // profile, MFA setup endpoints) so they can complete enrollment.
-  if (ENABLE_2FA && !user.mfaEnabled) {
-    const requiresMfa = await userRoleRequiresMfa(
-      payload.scope,
-      payload.partnerId,
-      payload.orgId,
-      user.id
-    );
+  // Enrollment gate via the effective-policy resolver. If org/partner
+  // settings (or a force_mfa role, resolved inside getEffectiveMfaPolicy)
+  // require MFA and the user hasn't enrolled, short-circuit to 428
+  // Precondition Required. Allow a tight set of routes through (logout,
+  // the user's own profile, MFA setup endpoints) so they can complete
+  // enrollment.
+  //
+  // Check the exempt path FIRST — the resolver runs an extra
+  // getEffectiveOrgSettings query, and hot polled exempt routes
+  // (/users/me, /auth/mfa/*) must not pay that DB cost on every request
+  // (the US DB has a ~25-connection ceiling).
+  if (ENABLE_2FA && !user.mfaEnabled && !isMfaEnrollmentExemptPath(c.req.path)) {
+    const policy = await getEffectiveMfaPolicy({
+      scope: payload.scope,
+      userId: user.id,
+      orgId: payload.orgId,
+      partnerId: payload.partnerId,
+    });
 
-    if (requiresMfa && !isMfaEnrollmentExemptPath(c.req.path)) {
+    if (policy.required) {
       // Fire-and-forget audit. Lets ops see when forced-enrollment is
       // bouncing users — useful for diagnosing onboarding friction or
-      // a misconfigured role flag.
+      // a misconfigured role flag / org policy.
       writeAuditEvent(c, {
         orgId: payload.orgId ?? null,
         action: 'auth.mfa.enrollment.required',
@@ -500,7 +454,7 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
         actorId: user.id,
         actorEmail: user.email,
         result: 'denied',
-        details: { path: c.req.path, scope: payload.scope }
+        details: { path: c.req.path, scope: payload.scope, source: policy.source }
       });
 
       return c.json(

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -132,6 +132,10 @@ function isMfaEnrollmentExemptPath(path: string): boolean {
   if (rel.startsWith('/auth/mfa/')) return true;
   // Phone verification is part of the MFA setup flow (SMS factor).
   if (rel.startsWith('/auth/phone/')) return true;
+  // Passkey registration is an enrollment action (passkey is the always-allowed,
+  // phishing-resistant factor). Without this, a policy-required-but-unenrolled
+  // user is 428'd on /auth/passkeys/register/* and can never enroll a passkey.
+  if (rel.startsWith('/auth/passkeys/')) return true;
   return false;
 }
 

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -4,7 +4,7 @@ import { verifyToken, TokenPayload } from '../services/jwt';
 import { getUserPermissions, hasPermission, canAccessOrg, canAccessSite, UserPermissions } from '../services/permissions';
 import { isTokenIssuedBeforePasswordChange, isUserTokenRevoked } from '../services/tokenRevocation';
 import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext, type DbAccessScope } from '../db';
-import { users, partnerUsers, organizationUsers, organizations, roles } from '../db/schema';
+import { users, partnerUsers, organizations } from '../db/schema';
 import { and, eq, inArray, isNull, SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import { ENABLE_2FA } from '../routes/auth/schemas';

--- a/apps/api/src/middleware/cfAccessLogin.test.ts
+++ b/apps/api/src/middleware/cfAccessLogin.test.ts
@@ -13,6 +13,10 @@ vi.mock('../config/env', () => ({
   cfAccessTeamDomain: () => envState.teamDomain,
   cfAccessAud: () => envState.audience,
   cfAccessTrustsMfa: () => envState.trustsMfa,
+  // SR2-06: the MFA temp-token branch now resolves the effective MFA policy
+  // (getEffectiveMfaPolicy) to bind allowedMethods onto the pending record —
+  // that service reads this kill-switch flag.
+  mfaForcePartnerAdmin: () => false,
 }));
 
 const verifyState = vi.hoisted(() => ({
@@ -54,7 +58,12 @@ vi.mock('../db', () => {
       thenable.limit = limit;
       return thenable;
     });
-    const from = vi.fn(() => ({ where, limit }));
+    // getEffectiveMfaPolicy's roleForceMfa lookup (real service, unmocked —
+    // resolveCurrentUserTokenContext is stubbed, but the policy resolver
+    // isn't) chains `.from(partnerUsers).innerJoin(roles, ...)` before
+    // `.where().limit()`. `innerJoin` just re-exposes the same where/limit
+    // pair so both the plain and joined query shapes resolve to `rows`.
+    const from = vi.fn(() => ({ where, limit, innerJoin: vi.fn(() => ({ where, limit })) }));
     return { from };
   }
   return {

--- a/apps/api/src/middleware/cfAccessLogin.ts
+++ b/apps/api/src/middleware/cfAccessLogin.ts
@@ -23,6 +23,7 @@ import {
 import { getRedis } from '../services';
 import { createAuditLogAsync } from '../services/auditService';
 import { TenantInactiveError } from '../services/tenantStatus';
+import { getEffectiveMfaPolicy } from '../services/mfaPolicy';
 import { ENABLE_2FA } from '../routes/auth/schemas';
 import {
   auditUserLoginFailure,
@@ -159,10 +160,31 @@ export async function cfAccessLoginMiddleware(c: Context, next: Next): Promise<R
     // totp/sms. The helper fails closed, so a probe error just hides the
     // alternate rather than blocking this CF-Access MFA challenge.
     const passkeyAvailable = await userHasUsablePasskey(user.id);
+    // SR2-06: bind the pending record to the live auth/mfa epochs + status +
+    // effective allowed methods at issuance — same shape/rationale as the
+    // password /login handler (login.ts), so the shared TOTP/SMS/passkey
+    // completion paths (mfa.ts, passkeys.ts) can validate it via
+    // parsePendingMfa/evaluatePendingMfa rather than treating it as a legacy
+    // (rejected) record.
+    const pendingEpochs = await getUserEpochs(user.id);
+    if (!pendingEpochs) throw new Error('user epochs unavailable at MFA temp-token issuance');
+    const pendingPolicy = await getEffectiveMfaPolicy({
+      scope: context.scope, userId: user.id, orgId: context.orgId, partnerId: context.partnerId,
+    });
+    const PENDING_TTL_SECONDS = 300;
     await redis.setex(
       `mfa:pending:${tempToken}`,
-      300,
-      JSON.stringify({ userId: user.id, mfaMethod, passkeyAvailable })
+      PENDING_TTL_SECONDS,
+      JSON.stringify({
+        userId: user.id,
+        mfaMethod,
+        passkeyAvailable,
+        authEpoch: pendingEpochs.authEpoch,
+        mfaEpoch: pendingEpochs.mfaEpoch,
+        statusExpectation: user.status,
+        allowedMethods: pendingPolicy.allowedMethods,
+        expiresAt: Date.now() + PENDING_TTL_SECONDS * 1000,
+      })
     );
     return c.json({
       mfaRequired: true,

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -150,8 +150,21 @@ vi.mock('../services/ipAllowlist', () => ({
   isBlocked: vi.fn(() => false),
 }));
 
-vi.mock('../db', () => ({
-  db: {
+// Task 7: `db.transaction` runs its callback with `db` ITSELF as `tx` — every
+// mutating factor route now folds its write into
+// `invalidateMfaAssuranceAfterFactorChange`'s `mutate(tx)`, and `tx.insert` /
+// `tx.select` / `tx.update` / `tx.delete` need the exact same queue-backed
+// mock behaviour as the top-level `db` calls this suite already asserts
+// against (`dbState.updateSets` etc). The epoch-bump's own
+// `tx.update(users)...returning(...)` shares the same `updateReturningQueue`;
+// most tests don't care about the epoch value, so the fallback below supplies
+// a valid row instead of `[]` (which would make `advanceUserEpochs` throw
+// "user not found"). Tests that need a SPECIFIC returning value (e.g. the
+// rename PATCH route) still take priority by pushing onto the queue first.
+const DEFAULT_EPOCH_ROW = [{ authEpoch: 1, mfaEpoch: 2, emailEpoch: 1, passwordResetEpoch: 1 }];
+
+vi.mock('../db', () => {
+  const dbMock: any = {
     select: vi.fn(() => dbState.makeSelectChain(dbState.selectQueue.shift() ?? [])),
     insert: vi.fn(() => ({
       values: vi.fn(() => ({
@@ -166,7 +179,7 @@ vi.mock('../db', () => ({
         // that also exposes `.returning()` so both shapes work.
         const whereResult: any = Promise.resolve(undefined);
         whereResult.returning = vi.fn(() =>
-          Promise.resolve(dbState.updateReturningQueue.shift() ?? [])
+          Promise.resolve(dbState.updateReturningQueue.shift() ?? DEFAULT_EPOCH_ROW)
         );
         return {
           where: vi.fn(() => whereResult),
@@ -176,10 +189,51 @@ vi.mock('../db', () => ({
     delete: vi.fn(() => ({
       where: vi.fn(() => Promise.resolve(undefined)),
     })),
-  },
-  withSystemDbAccessContext: vi.fn(async <T>(fn: () => Promise<T>) => fn()),
-  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  };
+  dbMock.transaction = vi.fn((fn: (tx: unknown) => Promise<unknown>) => fn(dbMock));
+  return {
+    db: dbMock,
+    withSystemDbAccessContext: vi.fn(async <T>(fn: () => Promise<T>) => fn()),
+    runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  };
+});
+
+// Task 7: keep advanceUserEpochs/revokeAllRefreshFamilies REAL (they just
+// issue `tx.update(...)` against the stubbed transaction above); only
+// runPostCommitCleanup — which fans out to real Redis/permission-cache/OAuth
+// side effects — is mocked.
+vi.mock('../services/authLifecycle', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/authLifecycle')>();
+  return {
+    ...actual,
+    runPostCommitCleanup: vi.fn().mockResolvedValue({
+      redisOk: true,
+      permissionCacheOk: true,
+      oauthOk: true,
+      oauthResult: { grantsRevoked: 0, refreshTokensRevoked: 0, jtisRevoked: 0 },
+    }),
+  };
+});
+
+// Mocked (rather than left real) because the real module pulls in agentWs →
+// configurationPolicy → a much bigger `db/schema` surface than this suite's
+// schema mock provides.
+vi.mock('../services/remoteSessionTeardown', () => ({
+  TEARDOWN_FAILED: -1,
+  terminateUserRemoteSessions: vi.fn().mockResolvedValue(0),
 }));
+
+// Keep the REAL resolver (login.ts already depends on it and this suite's
+// existing login tests exercise it for real), but wrap it in a `vi.fn` so the
+// passkey last-factor-guard tests can override just their own call via
+// `mockResolvedValueOnce` without disturbing login's calls.
+vi.mock('../services/mfaPolicy', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/mfaPolicy')>();
+  return {
+    ...actual,
+    getEffectiveMfaPolicy: vi.fn(actual.getEffectiveMfaPolicy),
+  };
+});
 
 vi.mock('../db/schema', () => ({
   users: {
@@ -253,6 +307,7 @@ vi.mock('../middleware/auth', () => ({
 import { createTokenPair, getRedis, getUserEpochs, rateLimiter, verifyPassword } from '../services';
 import { PasskeyChallengeError } from '../services/passkeys';
 import { withSystemDbAccessContext } from '../db';
+import { getEffectiveMfaPolicy } from '../services/mfaPolicy';
 
 const user = {
   id: 'user-123',
@@ -734,10 +789,17 @@ describe('passkey MFA auth routes', () => {
 
   it('blocks deleting the last MFA factor when MFA is required', async () => {
     vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+    // I3/SR2-05: mfaRequired now comes from getEffectiveMfaPolicy, not the old
+    // inline forceMfa/orgRequiresMfa EXISTS columns.
+    vi.mocked(getEffectiveMfaPolicy).mockResolvedValueOnce({
+      required: true,
+      allowedMethods: { totp: true, sms: true, passkey: true },
+      source: { roleForceMfa: true, settingsRequireMfa: false, killSwitchOff: true },
+    });
     dbState.selectQueue.push(
       [{ passwordHash: '$argon2id$hash' }],
       [{ id: 'credential-1', userId: 'user-123' }],
-      [{ passkeyCount: 1, hasTotp: false, hasSms: false, forceMfa: true }],
+      [{ passkeyCount: 1, hasTotp: false, hasSms: false }],
     );
 
     const res = await app.request('/auth/passkeys/credential-1', {

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -250,7 +250,7 @@ vi.mock('../middleware/auth', () => ({
   requirePermission: vi.fn(() => (_c: any, next: any) => next()),
 }));
 
-import { createTokenPair, getRedis, rateLimiter, verifyPassword } from '../services';
+import { createTokenPair, getRedis, getUserEpochs, rateLimiter, verifyPassword } from '../services';
 import { PasskeyChallengeError } from '../services/passkeys';
 import { withSystemDbAccessContext } from '../db';
 
@@ -263,6 +263,36 @@ const user = {
   mfaEnabled: true,
   mfaMethod: 'passkey',
 };
+
+// SR2-06: the pending MFA record now carries an epoch/status binding.
+// `parsePendingMfa` is STRICT — a record missing any of these fields returns
+// null and is rejected — so every `redisMock.get` fixture in this file must be
+// a full record. Defaults match the default `getUserEpochs` mock
+// ({ authEpoch: 1, mfaEpoch: 1 }) and the `user` fixture's `status: 'active'`
+// so most tests don't need to think about epochs at all; tests that DO care
+// (epoch/status mismatch) pass explicit overrides.
+function pendingMfaJson(overrides: Partial<{
+  userId: string;
+  mfaMethod: string;
+  passkeyAvailable: boolean;
+  authEpoch: number;
+  mfaEpoch: number;
+  statusExpectation: string;
+  allowedMethods: { totp: boolean; sms: boolean; passkey: boolean };
+  expiresAt: number;
+}> = {}): string {
+  return JSON.stringify({
+    userId: 'user-123',
+    mfaMethod: 'totp',
+    passkeyAvailable: false,
+    authEpoch: 1,
+    mfaEpoch: 1,
+    statusExpectation: 'active',
+    allowedMethods: { totp: true, sms: true, passkey: true },
+    expiresAt: Date.now() + 5 * 60 * 1000,
+    ...overrides,
+  });
+}
 
 // Full row shape returned by the passkey INSERT `.returning()`. The
 // register/verify route now passes the inserted row straight to
@@ -509,11 +539,7 @@ describe('passkey MFA auth routes', () => {
   // #2153: the passkey MFA endpoints must accept a pending session whose PRIMARY
   // method is totp/sms as long as the session flags a passkey as available.
   it('returns passkey options for a TOTP-primary pending session flagged passkeyAvailable', async () => {
-    redisMock.get.mockResolvedValueOnce(JSON.stringify({
-      userId: 'user-123',
-      mfaMethod: 'totp',
-      passkeyAvailable: true,
-    }));
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'totp', passkeyAvailable: true }));
     dbState.selectQueue.push([
       {
         id: 'credential-row-1',
@@ -539,11 +565,7 @@ describe('passkey MFA auth routes', () => {
   });
 
   it('verifies a passkey for a TOTP-primary pending session flagged passkeyAvailable', async () => {
-    redisMock.get.mockResolvedValueOnce(JSON.stringify({
-      userId: 'user-123',
-      mfaMethod: 'totp',
-      passkeyAvailable: true,
-    }));
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'totp', passkeyAvailable: true }));
     dbState.selectQueue.push(
       [{ ...user, mfaMethod: 'totp', mfaSecret: 'enc-secret' }],
       [{
@@ -580,11 +602,7 @@ describe('passkey MFA auth routes', () => {
   // half of pendingAllowsPasskey that mints tokens — regressing it to accept
   // any session would be a bypass, so it needs its own explicit test.
   it('rejects /mfa/passkey/verify for a TOTP session with no available passkey', async () => {
-    redisMock.get.mockResolvedValueOnce(JSON.stringify({
-      userId: 'user-123',
-      mfaMethod: 'totp',
-      passkeyAvailable: false,
-    }));
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'totp', passkeyAvailable: false }));
 
     const res = await app.request('/auth/mfa/passkey/verify', {
       method: 'POST',
@@ -602,10 +620,14 @@ describe('passkey MFA auth routes', () => {
     expect(redisMock.del).not.toHaveBeenCalled();
   });
 
-  // #2153 backward-compat: a legacy pre-JSON pending token (bare userId string,
-  // not valid JSON) must be treated as a TOTP session with NO passkey available,
-  // so in-flight sessions during a deploy can't reach the passkey path.
-  it('treats a legacy bare-string pending token as passkey-unavailable', async () => {
+  // SR2-06: parsePendingMfa is STRICT — a legacy pre-rollout pending token
+  // (bare userId string, not valid JSON, no epoch/status binding) now fails
+  // to parse entirely and is rejected with the generic "expired session"
+  // error, rather than falling back to a synthesized TOTP-no-passkey record.
+  // In-flight legacy sessions vanish within the 5-minute TTL; forcing a fresh
+  // login is correct — completing them with no live epoch/status re-check
+  // would be exactly the gap SR2-06 closes.
+  it('rejects a legacy bare-string pending token (pre-SR2-06 format) with a generic 401', async () => {
     redisMock.get.mockResolvedValueOnce('user-123');
 
     const res = await app.request('/auth/mfa/passkey/options', {
@@ -614,16 +636,13 @@ describe('passkey MFA auth routes', () => {
       body: JSON.stringify({ tempToken: 'temp-token' }),
     });
 
-    expect(res.status).toBe(400);
-    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/passkey mfa is not configured/i) });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/invalid or expired/i) });
     expect(passkeyMocks.generatePasskeyAuthenticationOptions).not.toHaveBeenCalled();
   });
 
   it('returns passkey authentication options for a pending passkey MFA login', async () => {
-    redisMock.get.mockResolvedValueOnce(JSON.stringify({
-      userId: 'user-123',
-      mfaMethod: 'passkey',
-    }));
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'passkey' }));
     dbState.selectQueue.push([
       {
         id: 'credential-row-1',
@@ -655,10 +674,7 @@ describe('passkey MFA auth routes', () => {
   });
 
   it('verifies a passkey MFA challenge and mints MFA-satisfied tokens', async () => {
-    redisMock.get.mockResolvedValueOnce(JSON.stringify({
-      userId: 'user-123',
-      mfaMethod: 'passkey',
-    }));
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'passkey' }));
     dbState.selectQueue.push(
       [user],
       [{
@@ -696,10 +712,7 @@ describe('passkey MFA auth routes', () => {
   });
 
   it('rejects a passkey credential that belongs to another user', async () => {
-    redisMock.get.mockResolvedValueOnce(JSON.stringify({
-      userId: 'user-123',
-      mfaMethod: 'passkey',
-    }));
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'passkey' }));
     dbState.selectQueue.push(
       [user],
       [{ id: 'passkey-2', userId: 'user-456', credentialId: 'credential-2' }],
@@ -774,10 +787,7 @@ describe('passkey MFA auth routes', () => {
 
   // (a) Failed assertion must not mint a session.
   it('rejects a passkey MFA challenge that fails WebAuthn verification without minting tokens', async () => {
-    redisMock.get.mockResolvedValueOnce(JSON.stringify({
-      userId: 'user-123',
-      mfaMethod: 'passkey',
-    }));
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'passkey' }));
     dbState.selectQueue.push(
       [user],
       [{
@@ -809,10 +819,7 @@ describe('passkey MFA auth routes', () => {
 
   // (b) A disabled credential owned by the user is still rejected (403).
   it('rejects a disabled passkey credential even when the userId matches', async () => {
-    redisMock.get.mockResolvedValueOnce(JSON.stringify({
-      userId: 'user-123',
-      mfaMethod: 'passkey',
-    }));
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'passkey' }));
     dbState.selectQueue.push(
       [user],
       [{
@@ -840,10 +847,7 @@ describe('passkey MFA auth routes', () => {
 
   // (c) Rate limiter denial → 429, before any DB / credential work.
   it('returns 429 when the MFA rate limiter denies a passkey verify attempt', async () => {
-    redisMock.get.mockResolvedValueOnce(JSON.stringify({
-      userId: 'user-123',
-      mfaMethod: 'passkey',
-    }));
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'passkey' }));
     vi.mocked(rateLimiter).mockResolvedValueOnce({
       allowed: false,
       remaining: 0,
@@ -886,10 +890,7 @@ describe('passkey MFA auth routes', () => {
 
   // (d) A suspended user cannot complete passkey MFA even with a valid assertion.
   it('rejects passkey verify when the user account is no longer active', async () => {
-    redisMock.get.mockResolvedValueOnce(JSON.stringify({
-      userId: 'user-123',
-      mfaMethod: 'passkey',
-    }));
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'passkey' }));
     dbState.selectQueue.push([{ ...user, status: 'suspended' }]);
 
     const res = await app.request('/auth/mfa/passkey/verify', {
@@ -907,12 +908,36 @@ describe('passkey MFA auth routes', () => {
     expect(redisMock.del).not.toHaveBeenCalled();
   });
 
+  // SR2-06: a factor change (mfa_epoch bump) during the 5-minute MFA window
+  // must invalidate the pending passkey session — the epoch captured at login
+  // no longer matches the live user row, so the session is rejected generically
+  // and consumed (single-use) rather than allowed to mint tokens.
+  it('rejects passkey verify when the live mfaEpoch has advanced past the pending record (SR2-06)', async () => {
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'passkey', authEpoch: 1, mfaEpoch: 1 }));
+    dbState.selectQueue.push([user]);
+    vi.mocked(getUserEpochs).mockResolvedValueOnce({ authEpoch: 1, mfaEpoch: 2 });
+
+    const res = await app.request('/auth/mfa/passkey/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tempToken: 'temp-token',
+        credential: { id: 'credential-1', response: {} },
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/invalid or expired/i) });
+    expect(createTokenPair).not.toHaveBeenCalled();
+    expect(passkeyMocks.verifyPasskeyAuthentication).not.toHaveBeenCalled();
+    // Single-use: a rejected (invalidated) session must still be consumed so
+    // it can't be retried.
+    expect(redisMock.del).toHaveBeenCalledWith('mfa:pending:temp-token');
+  });
+
   // (e) /mfa/passkey/options guards.
   it('returns 400 from passkey options when the pending session is not a passkey session', async () => {
-    redisMock.get.mockResolvedValueOnce(JSON.stringify({
-      userId: 'user-123',
-      mfaMethod: 'totp',
-    }));
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'totp', passkeyAvailable: false }));
 
     const res = await app.request('/auth/mfa/passkey/options', {
       method: 'POST',
@@ -926,10 +951,7 @@ describe('passkey MFA auth routes', () => {
   });
 
   it('returns 400 from passkey options when the account has no registered passkeys', async () => {
-    redisMock.get.mockResolvedValueOnce(JSON.stringify({
-      userId: 'user-123',
-      mfaMethod: 'passkey',
-    }));
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'passkey' }));
     dbState.selectQueue.push([]);
 
     const res = await app.request('/auth/mfa/passkey/options', {
@@ -1040,13 +1062,14 @@ describe('passkey MFA auth routes', () => {
 
   // mfa.ts guard: a passkey pending session must be routed to passkey verification.
   it('rejects /mfa/verify (TOTP path) for a pending passkey MFA session', async () => {
-    redisMock.get.mockResolvedValueOnce(JSON.stringify({
-      userId: 'user-123',
-      mfaMethod: 'passkey',
-    }));
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'passkey' }));
     // user lookup inside /mfa/verify happens before the passkey guard returns,
-    // so provide the user row.
-    dbState.selectQueue.push([user]);
+    // so provide the user row. SR2-06 now also hoists a
+    // resolveCurrentUserTokenContext call ahead of the passkey guard (reused
+    // for the method-allowed policy check and the eventual mint), so a
+    // partner-membership row is needed too — otherwise the membership-less
+    // user would hit NoTenantMembershipError before ever reaching the guard.
+    dbState.selectQueue.push([user], [{ partnerId: 'partner-123', roleId: 'role-123' }]);
 
     const res = await app.request('/auth/mfa/verify', {
       method: 'POST',

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -144,6 +144,15 @@ vi.mock('../services/passwordResetEligibility', () => ({
   }),
 }));
 
+// SR2-20: the real './helpers' (used unmocked elsewhere in this suite) calls
+// validateStepUpGrant/consumeStepUpGrant for its existing-factor step-up gate.
+// Mocked here so individual tests control grant validity without touching Redis.
+vi.mock('../services/mfaStepUpGrant', () => ({
+  mintStepUpGrant: vi.fn(),
+  validateStepUpGrant: vi.fn(),
+  consumeStepUpGrant: vi.fn(),
+}));
+
 vi.mock('../services/ipAllowlist', () => ({
   enforceIpAllowlist: vi.fn().mockResolvedValue({ allowed: true }),
   IP_NOT_ALLOWED_BODY: { error: 'IP address is not allowed' },
@@ -296,7 +305,9 @@ vi.mock('../middleware/auth', () => ({
       user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
       orgId: 'org-123',
       partnerId: 'partner-123',
-      token: { mfa: authState.mfaSatisfied },
+      // sid: SR2-20's enforceExistingFactorStepUp binds the grant to the
+      // caller's session id; without it the gate fails closed (503).
+      token: { mfa: authState.mfaSatisfied, sid: 'session-123' },
     });
     return next();
   }),
@@ -308,6 +319,7 @@ import { createTokenPair, getRedis, getUserEpochs, rateLimiter, verifyPassword }
 import { PasskeyChallengeError } from '../services/passkeys';
 import { withSystemDbAccessContext } from '../db';
 import { getEffectiveMfaPolicy } from '../services/mfaPolicy';
+import { validateStepUpGrant, consumeStepUpGrant } from '../services/mfaStepUpGrant';
 
 const user = {
   id: 'user-123',
@@ -465,6 +477,63 @@ describe('passkey MFA auth routes', () => {
         user: expect.objectContaining({ id: 'user-123', email: 'test@example.com' }),
       }),
     );
+  });
+
+  // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
+  // requires a fresh existing-factor step-up grant; a no-factor account's
+  // initial enrollment stays password-only (no grant needed).
+  describe('SR2-20 existing-factor step-up gate on passkey registration', () => {
+    it('rejects register/options on an already-protected account with no grant', async () => {
+      vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+      dbState.selectQueue.push([{ passwordHash: '$argon2id$hash' }]);
+      dbState.selectQueue.push([{ mfaEnabled: true, passkeyCount: 0 }]);
+
+      const res = await app.request('/auth/passkeys/register/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+        body: JSON.stringify({ currentPassword: 'correct-password' }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body).toMatchObject({ error: 'existing_factor_step_up_required' });
+      expect(passkeyMocks.generatePasskeyRegistrationOptions).not.toHaveBeenCalled();
+    });
+
+    it('allows register/options on an already-protected account with a valid grant', async () => {
+      vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+      dbState.selectQueue.push([{ passwordHash: '$argon2id$hash' }]);
+      dbState.selectQueue.push([{ mfaEnabled: true, passkeyCount: 0 }]);
+      dbState.selectQueue.push([]); // listActivePasskeys
+      vi.mocked(validateStepUpGrant).mockResolvedValueOnce(true);
+
+      const res = await app.request('/auth/passkeys/register/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+        body: JSON.stringify({ currentPassword: 'correct-password', stepUpGrantId: 'grant-1' }),
+      });
+
+      expect(res.status).toBe(200);
+      // Non-consuming: register/options validates, register/verify consumes.
+      expect(validateStepUpGrant).toHaveBeenCalledWith('grant-1', expect.objectContaining({ userId: 'user-123' }));
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('allows register/options on a no-factor account with no grant (initial enrollment stays password-only)', async () => {
+      vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+      dbState.selectQueue.push([{ passwordHash: '$argon2id$hash' }]);
+      dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]);
+      dbState.selectQueue.push([]); // listActivePasskeys
+
+      const res = await app.request('/auth/passkeys/register/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+        body: JSON.stringify({ currentPassword: 'correct-password' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(validateStepUpGrant).not.toHaveBeenCalled();
+    });
   });
 
   it('rejects invalid or expired passkey registration challenges', async () => {
@@ -1029,13 +1098,18 @@ describe('passkey MFA auth routes', () => {
 
   // (f) register/verify must NOT clobber an existing TOTP/SMS factor's method.
   it('does not overwrite an existing TOTP factor method when registering a passkey', async () => {
-    // Current MFA select returns an existing TOTP factor.
+    // SR2-20: this account is already MFA-protected (has TOTP), so
+    // register/verify requires a fresh existing-factor step-up grant.
+    // Query order: userIsMfaProtected (gate) first, then the transaction's
+    // own "current MFA" read (hasExistingFactor check) second.
+    dbState.selectQueue.push([{ mfaEnabled: true, passkeyCount: 0 }]);
     dbState.selectQueue.push([{ mfaSecret: 'enc-secret', mfaMethod: 'totp' }]);
+    vi.mocked(consumeStepUpGrant).mockResolvedValueOnce(true);
 
     const res = await app.request('/auth/passkeys/register/verify', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
-      body: JSON.stringify({ credential: { id: 'credential-1', response: {} } }),
+      body: JSON.stringify({ credential: { id: 'credential-1', response: {} }, stepUpGrantId: 'grant-1' }),
     });
 
     expect(res.status).toBe(200);
@@ -1050,7 +1124,25 @@ describe('passkey MFA auth routes', () => {
     expect(userUpdate).not.toHaveProperty('mfaMethod');
   });
 
+  it('rejects registering a passkey on an already-protected account without a step-up grant', async () => {
+    dbState.selectQueue.push([{ mfaEnabled: true, passkeyCount: 0 }]);
+
+    const res = await app.request('/auth/passkeys/register/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ credential: { id: 'credential-1', response: {} } }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toMatchObject({ error: 'existing_factor_step_up_required' });
+    expect(dbState.updateSets).toHaveLength(0);
+  });
+
   it('makes passkey the primary MFA method when the user has no existing factor', async () => {
+    // SR2-20: no-factor account — initial enrollment stays password-only, no
+    // step-up grant required.
+    dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]);
     dbState.selectQueue.push([{ mfaSecret: null, mfaMethod: null }]);
 
     const res = await app.request('/auth/passkeys/register/verify', {

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -279,6 +279,7 @@ import { createAuditLogAsync } from '../services/auditService';
 import { hashRecoveryCode, encryptMfaSecret } from './auth/helpers';
 import { mintStepUpGrant, validateStepUpGrant, consumeStepUpGrant } from '../services/mfaStepUpGrant';
 import { verifyStepUpPasskeyAssertion } from './auth/passkeys';
+import { getTwilioService } from '../services/twilio';
 
 // SR2-08: stub `db.transaction` so advanceUserEpochs/revokeAllRefreshFamilies
 // (kept REAL, see the authLifecycle mock above) run against a fake `tx`
@@ -2747,6 +2748,86 @@ describe('auth routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body).toEqual({ stepUpGrantId: 'grant-totp' });
+    });
+
+    // C1 (exploit-chain half 1 — the SMS factor allowlist): the SMS branch must
+    // prove the account's OWN active SMS factor, not merely that some phone sits
+    // on the row. This is the check that defeats the takeover where an attacker
+    // swapped their own number in via /phone/confirm and then tries to mint a
+    // grant here. A TOTP-protected victim (mfaMethod !== 'sms') must be rejected
+    // 401 WITHOUT Twilio ever being consulted and WITHOUT a grant minted.
+    it('C1: SMS step-up rejects when the active factor is not SMS (swapped-in phone cannot mint a grant)', async () => {
+      const checkVerificationCode = vi.fn().mockResolvedValue({ valid: true });
+      vi.mocked(getTwilioService).mockReturnValue({
+        sendVerificationCode: vi.fn().mockResolvedValue({ success: true }),
+        checkVerificationCode,
+      } as any);
+      // Victim's active factor is TOTP; an attacker-controlled phone was written
+      // to the row and is (per the schema) "verified".
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              { phoneNumber: '+15550000001', mfaEnabled: true, mfaMethod: 'totp', phoneVerified: true }
+            ])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/auth/mfa/step-up', {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ method: 'sms', code: '123456' })
+      });
+
+      expect(res.status).toBe(401);
+      expect(checkVerificationCode).not.toHaveBeenCalled();
+      expect(mintStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('C1: SMS step-up mints a grant only for a genuine active SMS factor', async () => {
+      const checkVerificationCode = vi.fn().mockResolvedValue({ valid: true, serviceError: false });
+      vi.mocked(getTwilioService).mockReturnValue({
+        sendVerificationCode: vi.fn().mockResolvedValue({ success: true }),
+        checkVerificationCode,
+      } as any);
+      vi.mocked(mintStepUpGrant).mockResolvedValueOnce('grant-sms');
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              { phoneNumber: '+15550000009', mfaEnabled: true, mfaMethod: 'sms', phoneVerified: true }
+            ])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/auth/mfa/step-up', {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ method: 'sms', code: '123456' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(checkVerificationCode).toHaveBeenCalledWith('+15550000009', '123456');
+      expect(await res.json()).toEqual({ stepUpGrantId: 'grant-sms' });
+    });
+
+    // I2: /mfa/step-up must be per-user rate-limited like every other MFA
+    // verification endpoint (previously only the 300/60s-per-IP global bound
+    // applied, leaving a 6-digit code brute-forceable to a grant).
+    it('I2: returns 429 without minting a grant when the per-user rate limit is exceeded', async () => {
+      vi.mocked(rateLimiter).mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt: new Date(Date.now() + 60_000) } as any);
+
+      const res = await app.request('/auth/mfa/step-up', {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ method: 'totp', code: '123456' })
+      });
+
+      expect(res.status).toBe(429);
+      expect(mintStepUpGrant).not.toHaveBeenCalled();
+      expect(vi.mocked(rateLimiter).mock.calls.some(([, key]) => String(key) === 'mfa:stepup:user-123')).toBe(true);
     });
   });
 

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -137,6 +137,14 @@ vi.mock('../services/authLifecycle', async (importOriginal) => {
   };
 });
 
+// Task 7: mfaAssurance's post-commit remote-session teardown. Mocked (rather
+// than left real) because the real module pulls in agentWs → configurationPolicy
+// → a much bigger `db/schema` surface than this suite's schema mock provides.
+vi.mock('../services/remoteSessionTeardown', () => ({
+  TEARDOWN_FAILED: -1,
+  terminateUserRemoteSessions: vi.fn().mockResolvedValue(0),
+}));
+
 vi.mock('../db/schema', () => ({
   users: {},
   sessions: {},

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -87,6 +87,27 @@ vi.mock('../services/twilio', () => ({
   }))
 }));
 
+// SR2-20: the real './auth/helpers' (used unmocked elsewhere in this suite)
+// calls validateStepUpGrant/consumeStepUpGrant for its existing-factor
+// step-up gate, and mfa.ts's new POST /mfa/step-up calls mintStepUpGrant.
+// Mocked here so individual tests control grant behaviour without Redis.
+vi.mock('../services/mfaStepUpGrant', () => ({
+  mintStepUpGrant: vi.fn(),
+  validateStepUpGrant: vi.fn(),
+  consumeStepUpGrant: vi.fn(),
+}));
+
+// mfa.ts's POST /mfa/step-up passkey branch calls verifyStepUpPasskeyAssertion
+// (exported from ./auth/passkeys). Keep the REAL module (passkeyRoutes is
+// mounted for real under authRoutes) and only override that one helper.
+vi.mock('./auth/passkeys', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./auth/passkeys')>();
+  return {
+    ...actual,
+    verifyStepUpPasskeyAssertion: vi.fn(),
+  };
+});
+
 vi.mock('../db', () => ({
   db: {
     select: vi.fn(() => ({
@@ -255,7 +276,9 @@ import {
 import { db } from '../db';
 import { runPostCommitCleanup } from '../services/authLifecycle';
 import { createAuditLogAsync } from '../services/auditService';
-import { hashRecoveryCode } from './auth/helpers';
+import { hashRecoveryCode, encryptMfaSecret } from './auth/helpers';
+import { mintStepUpGrant, validateStepUpGrant, consumeStepUpGrant } from '../services/mfaStepUpGrant';
+import { verifyStepUpPasskeyAssertion } from './auth/passkeys';
 
 // SR2-08: stub `db.transaction` so advanceUserEpochs/revokeAllRefreshFamilies
 // (kept REAL, see the authLifecycle mock above) run against a fake `tx`
@@ -1473,6 +1496,74 @@ describe('auth routes', () => {
     });
   });
 
+  // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
+  // requires a fresh existing-factor step-up grant. A no-factor account's
+  // initial enrollment (default db.select mock = []) stays password-only,
+  // which the SR2-24 test above already covers.
+  describe('POST /auth/mfa/verify — setup confirmation requires existing-factor step-up when already protected (SR2-20)', () => {
+    function mockPendingSetup() {
+      const mockRedis = {
+        get: vi.fn().mockResolvedValue(JSON.stringify({
+          secret: 'SETUPSECRET123',
+          recoveryCodes: ['CODE-0001', 'CODE-0002']
+        })),
+        del: vi.fn().mockResolvedValue(1),
+        setex: vi.fn(),
+      };
+      vi.mocked(getRedis).mockReturnValue(mockRedis as any);
+      vi.mocked(consumeMFAToken).mockResolvedValue(true);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined)
+        })
+      } as any);
+    }
+
+    it('rejects with 403 when no step-up grant is presented', async () => {
+      mockPendingSetup();
+      // userIsMfaProtected: account already has an active factor.
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ mfaEnabled: true, passkeyCount: 0 }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/auth/mfa/verify', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: '123456' })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body).toMatchObject({ error: 'existing_factor_step_up_required' });
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('succeeds with a valid (consumed) step-up grant', async () => {
+      mockPendingSetup();
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ mfaEnabled: true, passkeyCount: 0 }])
+          })
+        })
+      } as any);
+      vi.mocked(consumeStepUpGrant).mockResolvedValueOnce(true);
+
+      const res = await app.request('/auth/mfa/verify', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: '123456', stepUpGrantId: 'grant-1' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(consumeStepUpGrant).toHaveBeenCalledWith('grant-1', expect.objectContaining({ userId: 'user-123' }));
+    });
+  });
+
   describe('POST /auth/refresh', () => {
     it('should refresh tokens successfully', async () => {
       vi.mocked(verifyToken).mockResolvedValue({
@@ -2324,6 +2415,97 @@ describe('auth routes', () => {
       expect(verifyMFAToken).not.toHaveBeenCalled();
     });
 
+    // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
+    // requires a fresh existing-factor step-up grant.
+    it('POST /auth/mfa/enable rejects with 403 when already protected and no step-up grant is presented', async () => {
+      vi.mocked(verifyPassword).mockResolvedValue(true);
+      // Password-reprompt select runs first, then userIsMfaProtected's select
+      // (account already protected).
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash' }])
+            })
+          })
+        } as any)
+        .mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ mfaEnabled: true, passkeyCount: 0 }])
+            })
+          })
+        } as any);
+
+      const res = await app.request('/auth/mfa/enable', {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: '123456', currentPassword: 'OldStrongPass123' })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body).toMatchObject({ error: 'existing_factor_step_up_required' });
+      // Never reaches the setup-data lookup / factor write.
+      expect(consumeMFAToken).not.toHaveBeenCalled();
+    });
+
+    it('POST /auth/mfa/enable succeeds with a valid step-up grant when already protected', async () => {
+      const setupRecoveryCodes = ['CODE-0001', 'CODE-0002'];
+      const mockRedis = {
+        get: vi.fn().mockResolvedValue(JSON.stringify({
+          secret: 'MFASECRET123',
+          recoveryCodes: setupRecoveryCodes
+        })),
+        setex: vi.fn(),
+        del: vi.fn().mockResolvedValue(1)
+      };
+      vi.mocked(getRedis).mockReturnValue(mockRedis as any);
+      vi.mocked(consumeMFAToken).mockResolvedValue(true);
+      vi.mocked(verifyPassword).mockResolvedValue(true);
+      vi.mocked(consumeStepUpGrant).mockResolvedValueOnce(true);
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash' }])
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ mfaEnabled: true, passkeyCount: 0 }])
+            })
+          })
+        } as any)
+        .mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as any);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn(() => Object.assign(Promise.resolve(undefined), {
+            returning: vi.fn().mockResolvedValue([{ id: 'user-1' }])
+          }))
+        })
+      } as any);
+
+      const res = await app.request('/auth/mfa/enable', {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: '123456', currentPassword: 'OldStrongPass123', stepUpGrantId: 'grant-1' })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(consumeStepUpGrant).toHaveBeenCalledWith('grant-1', expect.objectContaining({ userId: 'user-123' }));
+    });
+
     it('POST /auth/mfa/enable should reject missing currentPassword (G1)', async () => {
       const res = await app.request('/auth/mfa/enable', {
         method: 'POST',
@@ -2503,6 +2685,68 @@ describe('auth routes', () => {
       });
 
       expect(res.status).toBe(401);
+    });
+  });
+
+  // SR2-20: POST /auth/mfa/step-up proves an EXISTING factor and mints a
+  // short-lived grant. The passkey branch (I2) exists specifically so a
+  // passkey-only user — who has no TOTP/SMS fallback — is never locked out
+  // of adding a second factor.
+  describe('POST /auth/mfa/step-up', () => {
+    it('mints a grant for a passkey-only user via method: passkey (I2)', async () => {
+      vi.mocked(verifyStepUpPasskeyAssertion).mockResolvedValueOnce(true);
+      vi.mocked(mintStepUpGrant).mockResolvedValueOnce('grant-abc');
+
+      const res = await app.request('/auth/mfa/step-up', {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ method: 'passkey', credential: { id: 'credential-1', response: {} } })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ stepUpGrantId: 'grant-abc' });
+      expect(verifyStepUpPasskeyAssertion).toHaveBeenCalledWith('user-123', { id: 'credential-1', response: {} });
+      expect(mintStepUpGrant).toHaveBeenCalledWith(expect.objectContaining({
+        userId: 'user-123',
+        operation: 'add_factor',
+        sid: 'family-123',
+      }));
+    });
+
+    it('returns 401 without minting a grant when the passkey assertion does not verify', async () => {
+      vi.mocked(verifyStepUpPasskeyAssertion).mockResolvedValueOnce(false);
+
+      const res = await app.request('/auth/mfa/step-up', {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ method: 'passkey', credential: { id: 'credential-1', response: {} } })
+      });
+
+      expect(res.status).toBe(401);
+      expect(mintStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('mints a grant for a valid TOTP code', async () => {
+      vi.mocked(consumeMFAToken).mockResolvedValueOnce(true);
+      vi.mocked(mintStepUpGrant).mockResolvedValueOnce('grant-totp');
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ mfaSecret: encryptMfaSecret('PLAINTEXTSECRET') }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/auth/mfa/step-up', {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ method: 'totp', code: '123456' })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ stepUpGrantId: 'grant-totp' });
     });
   });
 

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -16,6 +16,7 @@ vi.mock('../services', () => ({
   verifyToken: vi.fn(),
   generateMFASecret: vi.fn().mockReturnValue('MFASECRET123'),
   verifyMFAToken: vi.fn(),
+  consumeMFAToken: vi.fn(),
   generateOTPAuthURL: vi.fn().mockReturnValue('otpauth://totp/...'),
   generateQRCode: vi.fn().mockResolvedValue('data:image/png;base64,...'),
   generateRecoveryCodes: vi.fn().mockReturnValue(['CODE-0001', 'CODE-0002']),
@@ -210,6 +211,7 @@ import {
   createTokenPair,
   verifyToken,
   verifyMFAToken,
+  consumeMFAToken,
   generateRecoveryCodes,
   invalidateAllUserSessions,
   isUserTokenRevoked,
@@ -225,6 +227,7 @@ import {
   getTrustedClientIp,
   rateLimiter,
   getRedis,
+  getUserEpochs,
   recordAccountFailure,
   clearAccountFailures,
   isAccountLocked
@@ -260,6 +263,23 @@ function stubTx(epochRow: { authEpoch: number; mfaEpoch: number; emailEpoch: num
   }));
   vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn({ update: txUpdate }));
   return capturedUpdates;
+}
+
+// login.ts unconditionally resolves the effective MFA policy (both on the
+// MFA-required early-return branch and the enrollment-check branch below it).
+// For a partner/org scope that reaches the DB, getEffectiveMfaPolicy's
+// roleForceMfa lookup chains `.from(partnerUsers).innerJoin(roles, ...)`
+// before `.where().limit()` — a bare from/where/limit chain (fine for every
+// OTHER select in this suite) doesn't expose `.innerJoin`, so any login test
+// that resolves partner/org scope needs this richer chain instead.
+function selectChainWithPolicyJoin(rows: unknown[]) {
+  const terminal = { where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }) };
+  return {
+    from: vi.fn().mockReturnValue({
+      ...terminal,
+      innerJoin: vi.fn().mockReturnValue(terminal),
+    }),
+  };
 }
 
 describe('auth routes', () => {
@@ -477,26 +497,20 @@ describe('auth routes', () => {
         resetAt: new Date()
       });
       vi.mocked(verifyPassword).mockResolvedValue(true);
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{
-              id: 'user-123',
-              email: 'test@example.com',
-              name: 'Test User',
-              passwordHash: '$argon2id$hash',
-              status: 'active',
-              mfaEnabled: false,
-              // security review #2: a provisioned user has a partner membership.
-              // The blanket mock returns this row for the partnerUsers lookup too,
-              // so resolveCurrentUserTokenContext resolves to partner scope rather
-              // than the (now-rejected) membership-less system default.
-              partnerId: 'partner-1',
-              roleId: 'role-1'
-            }])
-          })
-        })
-      } as any);
+      vi.mocked(db.select).mockReturnValue(selectChainWithPolicyJoin([{
+        id: 'user-123',
+        email: 'test@example.com',
+        name: 'Test User',
+        passwordHash: '$argon2id$hash',
+        status: 'active',
+        mfaEnabled: false,
+        // security review #2: a provisioned user has a partner membership.
+        // The blanket mock returns this row for the partnerUsers lookup too,
+        // so resolveCurrentUserTokenContext resolves to partner scope rather
+        // than the (now-rejected) membership-less system default.
+        partnerId: 'partner-1',
+        roleId: 'role-1'
+      }]) as any);
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({
           where: vi.fn(() => Object.assign(Promise.resolve(undefined), {
@@ -775,23 +789,17 @@ describe('auth routes', () => {
         resetAt: new Date()
       });
       vi.mocked(verifyPassword).mockResolvedValue(true);
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{
-              id: 'user-123',
-              email: 'test@example.com',
-              passwordHash: '$argon2id$hash',
-              status: 'active',
-              mfaEnabled: true,
-              mfaSecret: 'secret123',
-              // security review #2: provisioned user → partner membership.
-              partnerId: 'partner-1',
-              roleId: 'role-1'
-            }])
-          })
-        })
-      } as any);
+      vi.mocked(db.select).mockReturnValue(selectChainWithPolicyJoin([{
+        id: 'user-123',
+        email: 'test@example.com',
+        passwordHash: '$argon2id$hash',
+        status: 'active',
+        mfaEnabled: true,
+        mfaSecret: 'secret123',
+        // security review #2: provisioned user → partner membership.
+        partnerId: 'partner-1',
+        roleId: 'role-1'
+      }]) as any);
 
       const res = await app.request('/auth/login', {
         method: 'POST',
@@ -969,23 +977,17 @@ describe('auth routes', () => {
 
     it('Task 10: clears the failure counter on a successful login', async () => {
       vi.mocked(verifyPassword).mockResolvedValue(true);
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{
-              id: 'user-recover',
-              email: 'recover@x.com',
-              name: 'Recover User',
-              passwordHash: '$argon2id$hash',
-              status: 'active',
-              mfaEnabled: false,
-              // security review #2: provisioned user → partner membership.
-              partnerId: 'partner-1',
-              roleId: 'role-1'
-            }])
-          })
-        })
-      } as any);
+      vi.mocked(db.select).mockReturnValue(selectChainWithPolicyJoin([{
+        id: 'user-recover',
+        email: 'recover@x.com',
+        name: 'Recover User',
+        passwordHash: '$argon2id$hash',
+        status: 'active',
+        mfaEnabled: false,
+        // security review #2: provisioned user → partner membership.
+        partnerId: 'partner-1',
+        roleId: 'role-1'
+      }]) as any);
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({
           where: vi.fn(() => Object.assign(Promise.resolve(undefined), {
@@ -1035,23 +1037,17 @@ describe('auth routes', () => {
       // happen, the per-account failure counter measures *password*
       // attempts and should reset.
       vi.mocked(verifyPassword).mockResolvedValue(true);
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{
-              id: 'user-mfa',
-              email: 'mfa@x.com',
-              passwordHash: '$argon2id$hash',
-              status: 'active',
-              mfaEnabled: true,
-              mfaSecret: 'secret',
-              // security review #2: provisioned user → partner membership.
-              partnerId: 'partner-1',
-              roleId: 'role-1'
-            }])
-          })
-        })
-      } as any);
+      vi.mocked(db.select).mockReturnValue(selectChainWithPolicyJoin([{
+        id: 'user-mfa',
+        email: 'mfa@x.com',
+        passwordHash: '$argon2id$hash',
+        status: 'active',
+        mfaEnabled: true,
+        mfaSecret: 'secret',
+        // security review #2: provisioned user → partner membership.
+        partnerId: 'partner-1',
+        roleId: 'role-1'
+      }]) as any);
 
       const res = await app.request('/auth/login', {
         method: 'POST',
@@ -1157,6 +1153,116 @@ describe('auth routes', () => {
         if (originalNodeEnv !== undefined) process.env.NODE_ENV = originalNodeEnv;
         if (originalE2eMode !== undefined) process.env.E2E_MODE = originalE2eMode;
       }
+    });
+  });
+
+  // SR2-06: the TOTP/SMS completion path (Case 1 of /mfa/verify) must reload
+  // the live user + epochs and reject a pending session whose auth/mfa epoch
+  // no longer matches the live row, rather than minting tokens from a
+  // possibly-stale factor/status. A rejected session is consumed (single-use)
+  // so it can't be retried.
+  describe('POST /auth/mfa/verify — epoch/status-bound pending MFA (SR2-06)', () => {
+    const liveUserRow = {
+      id: 'user-1',
+      email: 'admin@msp.com',
+      name: 'Admin User',
+      status: 'active',
+      mfaEnabled: true,
+      mfaSecret: 'PLAINSECRET123',
+      mfaMethod: 'totp',
+      phoneNumber: null,
+      avatarUrl: null,
+      isPlatformAdmin: false,
+      // Lets resolveCurrentUserTokenContext (real, unmocked helper) resolve a
+      // partner scope instead of the membership-less system default — the
+      // mocked db.select chain below returns this SAME row for every select,
+      // regardless of which columns were requested (mirrors the pattern used
+      // by the "should require MFA when enabled" test above).
+      partnerId: 'partner-1',
+      roleId: 'role-1',
+    };
+
+    function pendingRecord(overrides: Record<string, unknown> = {}) {
+      return JSON.stringify({
+        userId: 'user-1',
+        mfaMethod: 'totp',
+        passkeyAvailable: false,
+        authEpoch: 1,
+        mfaEpoch: 1,
+        statusExpectation: 'active',
+        allowedMethods: { totp: true, sms: true, passkey: true },
+        expiresAt: Date.now() + 5 * 60 * 1000,
+        ...overrides,
+      });
+    }
+
+    let getMock: ReturnType<typeof vi.fn>;
+    let delMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      // getEffectiveMfaPolicy's roleForceMfa lookup chains an .innerJoin(roles,
+      // ...) onto the partnerUsers select before .where().limit() — a plain
+      // from/where/limit chain (sufficient for every other select in this
+      // suite) doesn't expose that method, so build a fully chainable mock
+      // that always resolves to the same live user row regardless of path.
+      const chain: any = {
+        from: vi.fn(() => chain),
+        innerJoin: vi.fn(() => chain),
+        leftJoin: vi.fn(() => chain),
+        where: vi.fn(() => chain),
+        limit: vi.fn(() => Promise.resolve([liveUserRow])),
+      };
+      vi.mocked(db.select).mockReturnValue(chain as any);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      } as any);
+      getMock = vi.fn();
+      delMock = vi.fn();
+      vi.mocked(getRedis).mockReturnValue({ get: getMock, del: delMock, setex: vi.fn() } as any);
+      vi.mocked(getUserEpochs).mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 });
+      vi.mocked(consumeMFAToken).mockResolvedValue(true);
+    });
+
+    async function postMfaVerify(body: { tempToken: string; code: string }) {
+      return app.request('/auth/mfa/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }
+
+    it('rejects with a generic 401 and mints nothing when the live mfaEpoch has advanced past the pending record, consuming the pending key', async () => {
+      getMock.mockResolvedValue(pendingRecord({ mfaEpoch: 1 }));
+      vi.mocked(getUserEpochs).mockResolvedValue({ authEpoch: 1, mfaEpoch: 2 });
+
+      const res = await postMfaVerify({ tempToken: 'temp-token', code: '123456' });
+
+      expect(res.status).toBe(401);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body).toMatchObject({ error: 'Invalid or expired MFA session' });
+      expect(createTokenPair).not.toHaveBeenCalled();
+      expect(consumeMFAToken).not.toHaveBeenCalled();
+      // Single-use: a rejected pending session must be consumed so it can't
+      // be retried.
+      expect(delMock).toHaveBeenCalledWith('mfa:pending:temp-token');
+    });
+
+    it('mints tokens and consumes the pending key when the live epochs match and the code is valid', async () => {
+      getMock.mockResolvedValue(pendingRecord());
+
+      const res = await postMfaVerify({ tempToken: 'temp-token', code: '123456' });
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body).toMatchObject({ mfaRequired: false });
+      expect(consumeMFAToken).toHaveBeenCalledWith('PLAINSECRET123', '123456', 'user-1');
+      expect(createTokenPair).toHaveBeenCalledWith(
+        expect.objectContaining({ sub: 'user-1', mfa: true }),
+        expect.anything(),
+      );
+      expect(delMock).toHaveBeenCalledWith('mfa:pending:temp-token');
     });
   });
 

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -188,6 +188,12 @@ vi.mock('../services/passwordResetEligibility', () => ({
   getPasswordResetEligibilityForUser: vi.fn().mockResolvedValue({ allowed: true, userId: 'user-123', email: 'test@example.com' }),
 }));
 
+// SR2-09: spy on the audit sink so the recovery-code tests can assert no
+// code/hash material ever lands in an audit call.
+vi.mock('../services/auditService', () => ({
+  createAuditLogAsync: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
     c.set('auth', {
@@ -240,6 +246,8 @@ import {
 } from '../services/passwordResetEligibility';
 import { db } from '../db';
 import { runPostCommitCleanup } from '../services/authLifecycle';
+import { createAuditLogAsync } from '../services/auditService';
+import { hashRecoveryCode } from './auth/helpers';
 
 // SR2-08: stub `db.transaction` so advanceUserEpochs/revokeAllRefreshFamilies
 // (kept REAL, see the authLifecycle mock above) run against a fake `tx`
@@ -1263,6 +1271,154 @@ describe('auth routes', () => {
         expect.anything(),
       );
       expect(delMock).toHaveBeenCalledWith('mfa:pending:temp-token');
+    });
+  });
+
+  // SR2-09: recovery-code login. A user locked out of TOTP/SMS can fall back
+  // to a stored recovery code. Removal must be a single-use, concurrency-safe
+  // consume — proven here via the happy path + unknown-code/loser rejection;
+  // the true concurrent-winner proof lives in Task 9 (real Postgres).
+  describe('POST /auth/mfa/verify — recovery-code login (SR2-09)', () => {
+    const recoveryCode = 'ABCD-2345';
+    const recoveryHash = hashRecoveryCode(recoveryCode);
+    const otherHash = hashRecoveryCode('WXYZ-9999');
+
+    const liveUserRow = {
+      id: 'user-1',
+      email: 'admin@msp.com',
+      name: 'Admin User',
+      status: 'active',
+      mfaEnabled: true,
+      mfaSecret: 'PLAINSECRET123',
+      mfaMethod: 'totp',
+      phoneNumber: null,
+      avatarUrl: null,
+      isPlatformAdmin: false,
+      mfaRecoveryCodes: [recoveryHash, otherHash],
+      partnerId: 'partner-1',
+      roleId: 'role-1',
+    };
+
+    function pendingRecord(overrides: Record<string, unknown> = {}) {
+      return JSON.stringify({
+        userId: 'user-1',
+        mfaMethod: 'totp',
+        passkeyAvailable: false,
+        authEpoch: 1,
+        mfaEpoch: 1,
+        statusExpectation: 'active',
+        allowedMethods: { totp: true, sms: true, passkey: true },
+        expiresAt: Date.now() + 5 * 60 * 1000,
+        ...overrides,
+      });
+    }
+
+    let getMock: ReturnType<typeof vi.fn>;
+    let delMock: ReturnType<typeof vi.fn>;
+    let setMock: ReturnType<typeof vi.fn>;
+    let updateWhereMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      const chain: any = {
+        from: vi.fn(() => chain),
+        innerJoin: vi.fn(() => chain),
+        leftJoin: vi.fn(() => chain),
+        where: vi.fn(() => chain),
+        limit: vi.fn(() => Promise.resolve([liveUserRow])),
+      };
+      vi.mocked(db.select).mockReturnValue(chain as any);
+
+      updateWhereMock = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'user-1' }]),
+      });
+      setMock = vi.fn().mockReturnValue({ where: updateWhereMock });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as any);
+
+      getMock = vi.fn();
+      delMock = vi.fn();
+      vi.mocked(getRedis).mockReturnValue({ get: getMock, del: delMock, setex: vi.fn() } as any);
+      vi.mocked(getUserEpochs).mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 });
+    });
+
+    async function postMfaVerify(body: { tempToken: string; code: string; method?: string }) {
+      return app.request('/auth/mfa/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }
+
+    it('mints tokens on a valid recovery code, removing exactly the matching hash via a relative jsonb delete (not a stale full-array SET)', async () => {
+      getMock.mockResolvedValue(pendingRecord());
+
+      const res = await postMfaVerify({ tempToken: 'temp-token', code: recoveryCode, method: 'recovery' });
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body).toMatchObject({ mfaRequired: false });
+
+      // The recovery UPDATE must be the concurrency-safe relative delete —
+      // never a JS-computed "remaining array" SET (that form can resurrect a
+      // sibling code under two concurrent distinct-code removals). It runs
+      // BEFORE the shared mint flow's own "update last login" write, so it
+      // must be the first db.update().set() call.
+      expect(setMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+      const setPayload = setMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect('mfaRecoveryCodes' in setPayload).toBe(true);
+      expect(Array.isArray(setPayload.mfaRecoveryCodes)).toBe(false);
+      const serializedSetPayload = JSON.stringify(setPayload.mfaRecoveryCodes);
+      expect(serializedSetPayload).toContain(recoveryHash);
+      expect(serializedSetPayload).not.toContain(recoveryCode);
+
+      // The removal query is scoped to this exact user + guarded by the
+      // matching-hash containment check (first update().set().where() call).
+      expect(updateWhereMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+
+      expect(createTokenPair).toHaveBeenCalledWith(
+        expect.objectContaining({ sub: 'user-1', mfa: true }),
+        expect.anything(),
+      );
+      // Exactly one pending-record consume on success — the recovery branch
+      // itself never calls redis.del; the shared post-`valid` consume does.
+      expect(delMock).toHaveBeenCalledTimes(1);
+      expect(delMock).toHaveBeenCalledWith('mfa:pending:temp-token');
+    });
+
+    it('rejects an unknown recovery code with 401 and no code/hash material in the audit trail', async () => {
+      getMock.mockResolvedValue(pendingRecord());
+      const unknownCode = 'ZZZZ-0000';
+
+      const res = await postMfaVerify({ tempToken: 'temp-token', code: unknownCode, method: 'recovery' });
+
+      expect(res.status).toBe(401);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body).toMatchObject({ error: 'Invalid MFA code' });
+      expect(createTokenPair).not.toHaveBeenCalled();
+      // Never even attempts the DB removal for a hash that isn't present.
+      expect(setMock).not.toHaveBeenCalled();
+
+      // The failure audit is fire-and-forget (`void auditUserLoginFailure(...)`)
+      // — flush pending microtasks before inspecting the mock.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const auditCalls = vi.mocked(createAuditLogAsync).mock.calls;
+      expect(auditCalls.length).toBeGreaterThan(0);
+      const unknownHash = hashRecoveryCode(unknownCode);
+      for (const [params] of auditCalls) {
+        const serialized = JSON.stringify(params);
+        expect(serialized).not.toContain(unknownCode);
+        expect(serialized).not.toContain(unknownHash);
+      }
+    });
+
+    it('rejects the loser when the DB removal reports zero rows (concurrent winner already consumed this hash)', async () => {
+      getMock.mockResolvedValue(pendingRecord());
+      updateWhereMock.mockReturnValue({ returning: vi.fn().mockResolvedValue([]) });
+
+      const res = await postMfaVerify({ tempToken: 'temp-token', code: recoveryCode, method: 'recovery' });
+
+      expect(res.status).toBe(401);
+      expect(createTokenPair).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -2827,7 +2827,7 @@ describe('auth routes', () => {
 
       expect(res.status).toBe(429);
       expect(mintStepUpGrant).not.toHaveBeenCalled();
-      expect(vi.mocked(rateLimiter).mock.calls.some(([, key]) => String(key) === 'mfa:stepup:user-123')).toBe(true);
+      expect(vi.mocked(rateLimiter).mock.calls.some(([, key]) => String(key) === 'mfa:stepup-rl:user-123')).toBe(true);
     });
   });
 

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1266,6 +1266,49 @@ describe('auth routes', () => {
     });
   });
 
+  // SR2-24: setup-confirm (Case 2 of /mfa/verify, no tempToken) must verify
+  // the code with the CONSUMING verifier so the accepted time step is
+  // recorded and cannot be replayed at login within its validity window.
+  describe('POST /auth/mfa/verify — setup confirmation consumes the TOTP step (SR2-24)', () => {
+    it('confirms setup via consumeMFAToken, not the plain (non-consuming) verifyMFAToken', async () => {
+      const mockRedis = {
+        get: vi.fn().mockResolvedValue(JSON.stringify({
+          secret: 'SETUPSECRET123',
+          recoveryCodes: ['CODE-0001', 'CODE-0002']
+        })),
+        del: vi.fn().mockResolvedValue(1),
+        setex: vi.fn(),
+      };
+      vi.mocked(getRedis).mockReturnValue(mockRedis as any);
+      vi.mocked(consumeMFAToken).mockResolvedValue(true);
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as any);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined)
+        })
+      } as any);
+
+      const res = await app.request('/auth/mfa/verify', {
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer valid-token',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ code: '123456' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(consumeMFAToken).toHaveBeenCalledWith('SETUPSECRET123', '123456', 'user-123');
+      expect(verifyMFAToken).not.toHaveBeenCalled();
+    });
+  });
+
   describe('POST /auth/refresh', () => {
     it('should refresh tokens successfully', async () => {
       vi.mocked(verifyToken).mockResolvedValue({
@@ -2071,7 +2114,7 @@ describe('auth routes', () => {
         del: vi.fn().mockResolvedValue(1)
       };
       vi.mocked(getRedis).mockReturnValue(mockRedis as any);
-      vi.mocked(verifyMFAToken).mockResolvedValue(true);
+      vi.mocked(consumeMFAToken).mockResolvedValue(true);
       vi.mocked(verifyPassword).mockResolvedValue(true);
       // Password-reprompt select runs first, then enable's own select
       vi.mocked(db.select)
@@ -2111,6 +2154,10 @@ describe('auth routes', () => {
       expect(body.success).toBe(true);
       expect(body.recoveryCodes).toEqual(setupRecoveryCodes);
       expect(body.message).toBe('MFA enabled successfully');
+      // SR2-24: /mfa/enable must use the consuming verifier so the accepted
+      // step is recorded and cannot be replayed at login.
+      expect(consumeMFAToken).toHaveBeenCalledWith('MFASECRET123', '123456', 'user-123');
+      expect(verifyMFAToken).not.toHaveBeenCalled();
     });
 
     it('POST /auth/mfa/enable should reject missing currentPassword (G1)', async () => {

--- a/apps/api/src/routes/auth/helpers.test.ts
+++ b/apps/api/src/routes/auth/helpers.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { createHash } from 'crypto';
-import { getAllowedOrigins, hashRecoveryCode, userRequiresSetup } from './helpers';
+import {
+  getAllowedOrigins,
+  hashRecoveryCode,
+  userRequiresSetup,
+  parsePendingMfa,
+  evaluatePendingMfa,
+  type PendingMfaRecord,
+} from './helpers';
 
 describe('getAllowedOrigins (G5 — dev-origin gating)', () => {
   const originalNodeEnv = process.env.NODE_ENV;
@@ -130,5 +137,113 @@ describe('MFA recovery code peppering', () => {
     process.env.JWT_SECRET = 'jwt-key-must-not-be-used';
 
     expect(() => hashRecoveryCode('abcd-1234')).toThrow('MFA_RECOVERY_CODE_PEPPER');
+  });
+});
+
+// SR2-06: the pending MFA record now carries an epoch/status binding so every
+// completion path can detect a factor/status change that happened during the
+// 5-minute MFA window and reject rather than mint stale assurance.
+describe('parsePendingMfa (SR2-06 strict parse)', () => {
+  const fullRecord: PendingMfaRecord = {
+    userId: 'user-1',
+    mfaMethod: 'totp',
+    passkeyAvailable: false,
+    authEpoch: 3,
+    mfaEpoch: 5,
+    statusExpectation: 'active',
+    allowedMethods: { totp: true, sms: false, passkey: true },
+    expiresAt: Date.now() + 300_000,
+  };
+
+  it('round-trips a full JSON record', () => {
+    expect(parsePendingMfa(JSON.stringify(fullRecord))).toEqual(fullRecord);
+  });
+
+  it('returns null for the legacy bare-userId string form', () => {
+    expect(parsePendingMfa('user-1')).toBeNull();
+  });
+
+  it('returns null for JSON missing authEpoch (pre-SR2-06 record)', () => {
+    const { authEpoch, ...rest } = fullRecord;
+    expect(parsePendingMfa(JSON.stringify(rest))).toBeNull();
+  });
+
+  it('returns null for JSON missing mfaEpoch', () => {
+    const { mfaEpoch, ...rest } = fullRecord;
+    expect(parsePendingMfa(JSON.stringify(rest))).toBeNull();
+  });
+
+  it('returns null for JSON missing allowedMethods', () => {
+    const { allowedMethods, ...rest } = fullRecord;
+    expect(parsePendingMfa(JSON.stringify(rest))).toBeNull();
+  });
+
+  it('returns null for an invalid mfaMethod value', () => {
+    expect(parsePendingMfa(JSON.stringify({ ...fullRecord, mfaMethod: 'sms-code' }))).toBeNull();
+  });
+
+  it('returns null for malformed (non-JSON) input', () => {
+    expect(parsePendingMfa('{not json')).toBeNull();
+  });
+
+  it('defaults a missing per-method allowedMethods flag to true (only explicit false disables)', () => {
+    const parsed = parsePendingMfa(JSON.stringify({ ...fullRecord, allowedMethods: {} }));
+    expect(parsed?.allowedMethods).toEqual({ totp: true, sms: true, passkey: true });
+  });
+});
+
+describe('evaluatePendingMfa (SR2-06)', () => {
+  const record: PendingMfaRecord = {
+    userId: 'user-1',
+    mfaMethod: 'totp',
+    passkeyAvailable: false,
+    authEpoch: 3,
+    mfaEpoch: 5,
+    statusExpectation: 'active',
+    allowedMethods: { totp: true, sms: true, passkey: true },
+    expiresAt: Date.now() + 300_000,
+  };
+
+  it('returns ok:true when live epochs and status match the pending record', () => {
+    expect(evaluatePendingMfa(record, { status: 'active', authEpoch: 3, mfaEpoch: 5 })).toEqual({ ok: true });
+  });
+
+  it('returns epoch_mismatch when the live mfaEpoch has advanced past the pending record', () => {
+    expect(evaluatePendingMfa(record, { status: 'active', authEpoch: 3, mfaEpoch: 6 })).toEqual({
+      ok: false,
+      reason: 'epoch_mismatch',
+    });
+  });
+
+  it('returns epoch_mismatch when the live authEpoch has advanced past the pending record', () => {
+    expect(evaluatePendingMfa(record, { status: 'active', authEpoch: 4, mfaEpoch: 5 })).toEqual({
+      ok: false,
+      reason: 'epoch_mismatch',
+    });
+  });
+
+  it('returns status_changed when the live status is no longer active', () => {
+    expect(evaluatePendingMfa(record, { status: 'suspended', authEpoch: 3, mfaEpoch: 5 })).toEqual({
+      ok: false,
+      reason: 'status_changed',
+    });
+  });
+
+  it('returns status_changed when the live status differs from the recorded expectation', () => {
+    const pendingCapturedInactive: PendingMfaRecord = { ...record, statusExpectation: 'invited' };
+    // live.status is forced to 'active' here specifically to isolate the
+    // statusExpectation-mismatch branch from the "not active" branch above.
+    expect(evaluatePendingMfa(pendingCapturedInactive, { status: 'active', authEpoch: 3, mfaEpoch: 5 })).toEqual({
+      ok: false,
+      reason: 'status_changed',
+    });
+  });
+
+  it('returns expired when expiresAt is in the past', () => {
+    const expiredRecord: PendingMfaRecord = { ...record, expiresAt: Date.now() - 1 };
+    expect(evaluatePendingMfa(expiredRecord, { status: 'active', authEpoch: 3, mfaEpoch: 5 })).toEqual({
+      ok: false,
+      reason: 'expired',
+    });
   });
 });

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 import * as dbModule from '../../db';
 import { users, partnerUsers, organizationUsers, organizations, userPasskeys } from '../../db/schema';
 import {
@@ -9,11 +9,14 @@ import {
   getTrustedClientIp,
   getRedis,
   rateLimiter,
-  verifyPassword
+  verifyPassword,
+  getUserEpochs
 } from '../../services';
 import { createAuditLogAsync } from '../../services/auditService';
 import { recordFailedLogin } from '../../services/anomalyMetrics';
 import { consumeMFAToken } from '../../services/mfa';
+import { validateStepUpGrant, consumeStepUpGrant } from '../../services/mfaStepUpGrant';
+import type { AuthContext } from '../../middleware/auth';
 import type { RequestLike } from '../../services/auditEvents';
 import { createHash, randomBytes, timingSafeEqual } from 'crypto';
 import {
@@ -198,6 +201,82 @@ export async function requireFreshMfaStepUp(
     return c.json({ error: 'Invalid credentials' }, 401);
   }
 
+  return null;
+}
+
+// ============================================
+// Existing-factor step-up for factor addition (SR2-20)
+// ============================================
+
+/**
+ * True when the account already has ANY active MFA factor (TOTP, SMS, or a
+ * non-disabled passkey). Drives the SR2-20 gate: initial enrollment (no
+ * factor yet) stays password-only; adding a factor to an ALREADY-PROTECTED
+ * account additionally requires a fresh existing-factor step-up grant.
+ *
+ * Runs under system DB access: several callers (e.g. `/mfa/enable`,
+ * `/passkeys/register/*`) call this from within their own request-scoped
+ * (user-id-scoped) RLS context, where it would still resolve correctly, but
+ * system context keeps this probe uniform regardless of caller context.
+ */
+export async function userIsMfaProtected(userId: string): Promise<boolean> {
+  const [row] = await runWithSystemDbAccess(() =>
+    db
+      .select({
+        mfaEnabled: users.mfaEnabled,
+        passkeyCount: sql<number>`(SELECT COUNT(*)::int FROM user_passkeys WHERE user_id = ${userId} AND disabled_at IS NULL)`,
+      })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+  );
+  return row?.mfaEnabled === true || Number(row?.passkeyCount ?? 0) > 0;
+}
+
+/**
+ * Enforce the SR2-20 existing-factor step-up on a factor-ADDITION endpoint.
+ * No-factor accounts (initial enrollment) pass with password-only (returns
+ * null) — this avoids a chicken-and-egg lockout. Already-protected accounts
+ * must present a fresh grant bound to the live epochs + this session's
+ * `sid`; the binding is re-checked against the LIVE row here (not just at
+ * mint time) so a factor change since the grant was minted (which bumps
+ * `mfa_epoch` + revokes refresh families) invalidates it.
+ *
+ * `opts.consume: false` = non-consuming validate (register/options, which is
+ * followed by a separate /verify that consumes the SAME grant).
+ * `opts.consume: true` = single-use consume (every terminal factor write:
+ * /mfa/enable, setup-confirm, /mfa/sms/enable, /passkeys/register/verify).
+ *
+ * Returns a 403/503 Response to short-circuit the caller, or null to proceed.
+ */
+export async function enforceExistingFactorStepUp(
+  c: Context,
+  auth: AuthContext,
+  grantId: string | undefined,
+  opts: { consume: boolean },
+): Promise<Response | null> {
+  if (!(await userIsMfaProtected(auth.user.id))) return null;
+
+  const epochs = await getUserEpochs(auth.user.id);
+  if (!epochs || !auth.token.sid) {
+    return c.json({ error: 'Service temporarily unavailable' }, 503);
+  }
+
+  const bind = {
+    userId: auth.user.id,
+    operation: 'add_factor' as const,
+    authEpoch: epochs.authEpoch,
+    mfaEpoch: epochs.mfaEpoch,
+    sid: auth.token.sid,
+  };
+
+  const ok = grantId
+    ? (opts.consume ? await consumeStepUpGrant(grantId, bind) : await validateStepUpGrant(grantId, bind))
+    : false;
+
+  if (!ok) {
+    return c.json({ error: 'existing_factor_step_up_required', stepUpUrl: '/auth/mfa/step-up' }, 403);
+  }
   return null;
 }
 

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -439,6 +439,83 @@ export function hashRecoveryCodes(codes: string[]): string[] {
 }
 
 // ============================================
+// Pending MFA session helpers (SR2-06)
+// ============================================
+
+export interface PendingMfaRecord {
+  userId: string;
+  mfaMethod: 'totp' | 'sms' | 'passkey';
+  passkeyAvailable: boolean;
+  authEpoch: number;
+  mfaEpoch: number;
+  statusExpectation: string;
+  allowedMethods: { totp: boolean; sms: boolean; passkey: boolean };
+  expiresAt: number;
+}
+
+/**
+ * Strict parse of a `mfa:pending:<tempToken>` value. Returns null for the
+ * legacy bare-userId form or any record missing the epoch/status binding
+ * (SR2-06): those predate this rollout and must force a fresh login rather than
+ * complete with no live re-check.
+ */
+export function parsePendingMfa(raw: string): PendingMfaRecord | null {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null; // legacy bare-userId string
+  }
+  const method = parsed.mfaMethod;
+  const am = parsed.allowedMethods as Record<string, unknown> | undefined;
+  if (
+    typeof parsed.userId !== 'string' ||
+    (method !== 'totp' && method !== 'sms' && method !== 'passkey') ||
+    typeof parsed.authEpoch !== 'number' ||
+    typeof parsed.mfaEpoch !== 'number' ||
+    typeof parsed.statusExpectation !== 'string' ||
+    typeof parsed.expiresAt !== 'number' ||
+    !am || typeof am !== 'object'
+  ) {
+    return null;
+  }
+  return {
+    userId: parsed.userId,
+    mfaMethod: method,
+    passkeyAvailable: parsed.passkeyAvailable === true,
+    authEpoch: parsed.authEpoch,
+    mfaEpoch: parsed.mfaEpoch,
+    statusExpectation: parsed.statusExpectation,
+    allowedMethods: {
+      totp: am.totp !== false,
+      sms: am.sms !== false,
+      passkey: am.passkey !== false,
+    },
+    expiresAt: parsed.expiresAt,
+  };
+}
+
+/**
+ * Compare a pending record against the live user row. MFA assurance is valid
+ * only for the current MFA config + status (invariants 6/7). Any factor change
+ * bumps mfa_epoch; any account-wide change bumps auth_epoch; a suspend flips
+ * status — all of which must invalidate an in-flight MFA session.
+ */
+export function evaluatePendingMfa(
+  record: PendingMfaRecord,
+  live: { status: string; authEpoch: number; mfaEpoch: number },
+): { ok: true } | { ok: false; reason: 'expired' | 'epoch_mismatch' | 'status_changed' } {
+  if (record.expiresAt <= Date.now()) return { ok: false, reason: 'expired' };
+  if (record.authEpoch !== live.authEpoch || record.mfaEpoch !== live.mfaEpoch) {
+    return { ok: false, reason: 'epoch_mismatch' };
+  }
+  if (live.status !== 'active' || record.statusExpectation !== live.status) {
+    return { ok: false, reason: 'status_changed' };
+  }
+  return { ok: true };
+}
+
+// ============================================
 // Invite token helpers
 // ============================================
 

--- a/apps/api/src/routes/auth/login.test.ts
+++ b/apps/api/src/routes/auth/login.test.ts
@@ -148,6 +148,11 @@ vi.mock('./helpers', () => ({
   ),
   auditLogin: vi.fn(),
   userRequiresSetup: vi.fn(() => false),
+  // #2153: probed at login inside the MFA-required branch to advertise a
+  // passkey as an alternate factor. Not exercised by most tests in this file
+  // (mfaEnabled defaults to false), but must exist as a callable default so
+  // the branch doesn't throw when a test DOES enable MFA.
+  userHasUsablePasskey: vi.fn(async () => false),
 }));
 
 vi.mock('./ssoPolicy', () => ({
@@ -199,6 +204,7 @@ import {
   isTokenIssuedBeforePasswordChange,
   getUserEpochs,
   getRefreshFamily,
+  getRedis,
 } from '../../services';
 import { revokeRefreshFamilyById } from '../../services/authLifecycle';
 import { authMiddleware } from '../../middleware/auth';
@@ -590,6 +596,91 @@ describe('POST /login — MFA enrollment enforcement via effective policy (SR2-0
       expect.objectContaining({ mfa: true }),
       expect.anything()
     );
+  });
+});
+
+// SR2-06: the `mfa:pending:<tempToken>` Redis record must carry the live
+// auth/mfa epochs, account status, and effective allowed methods captured AT
+// LOGIN, so every completion path (mfa.ts TOTP/SMS, passkeys.ts) can detect a
+// factor/status change that happened during the 5-minute MFA window and
+// reject rather than mint stale assurance.
+describe('POST /login — writes epoch/status-bound pending MFA record (SR2-06)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = 'test';
+    process.env.E2E_MODE = 'true';
+    enable2faState.value = true;
+    vi.mocked(enforceIpAllowlist).mockResolvedValue({ decision: 'allow' });
+    vi.mocked(db.select).mockReturnValue(selectChain([{
+      id: 'user-1',
+      email: 'admin@msp.com',
+      name: 'Admin User',
+      passwordHash: 'password-hash',
+      status: 'active',
+      mfaEnabled: true,
+      mfaSecret: 'secret',
+      mfaMethod: 'totp',
+      phoneNumber: null,
+      avatarUrl: null,
+    }]) as any);
+    vi.mocked(db.update).mockReturnValue(updateChain() as any);
+    // A prior describe block ("mints aep/mep/sid") overrides getUserEpochs to
+    // resolve null in one of its tests; clearAllMocks() doesn't reset mock
+    // implementations (only call history), so restore a valid epoch pair here
+    // rather than inheriting that leaked null across files.
+    vi.mocked(getUserEpochs).mockResolvedValue({ authEpoch: 3, mfaEpoch: 5 });
+    vi.mocked(getEffectiveMfaPolicy).mockResolvedValue({
+      required: false,
+      allowedMethods: { totp: true, sms: false, passkey: true },
+      source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: false },
+    });
+  });
+
+  afterEach(() => {
+    enable2faState.value = false;
+  });
+
+  it('writes the live epochs, status, and effective allowed methods onto the pending record', async () => {
+    const setexMock = vi.fn(async (_key: string, _ttlSeconds: number, _value: string) => 'OK');
+    vi.mocked(getRedis).mockReturnValue({ setex: setexMock } as any);
+
+    const res = await postLogin({ email: 'admin@msp.com', password: 'correct-horse' });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.mfaRequired).toBe(true);
+
+    expect(getUserEpochs).toHaveBeenCalledWith('user-1');
+    expect(setexMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^mfa:pending:/),
+      300,
+      expect.any(String),
+    );
+    const written = JSON.parse(setexMock.mock.calls[0]?.[2] as string) as Record<string, unknown>;
+    expect(written).toMatchObject({
+      userId: 'user-1',
+      mfaMethod: 'totp',
+      authEpoch: 3,
+      mfaEpoch: 5,
+      statusExpectation: 'active',
+      allowedMethods: { totp: true, sms: false, passkey: true },
+    });
+    expect(typeof written.expiresAt).toBe('number');
+    expect(written.expiresAt as number).toBeGreaterThan(Date.now());
+  });
+
+  it('fails closed with a generic 401 and mints nothing when the epoch read returns null', async () => {
+    vi.mocked(getUserEpochs).mockResolvedValue(null);
+    const setexMock = vi.fn(async () => 'OK');
+    vi.mocked(getRedis).mockReturnValue({ setex: setexMock } as any);
+
+    const res = await postLogin({ email: 'admin@msp.com', password: 'correct-horse' });
+
+    expect(res.status).toBe(401);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body).toMatchObject({ error: 'Invalid email or password' });
+    expect(setexMock).not.toHaveBeenCalled();
+    expect(createTokenPair).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/auth/login.test.ts
+++ b/apps/api/src/routes/auth/login.test.ts
@@ -1,4 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mutable flag so the "MFA enrollment enforcement" describe block below can
+// flip ENABLE_2FA to true for its tests while every other describe block in
+// this file keeps the file's long-standing ENABLE_2FA=false default. vi.mock
+// factories are hoisted above this, but vi.hoisted() return values are
+// hoisted too (and evaluated first), so the factory closure below can read
+// this box live on every property access — see cfAccessRedirectLogin.test.ts
+// for the same pattern with other mutable mock state.
+const enable2faState = vi.hoisted(() => ({ value: false }));
 
 vi.mock('../../db', () => ({
   db: {
@@ -150,9 +159,22 @@ vi.mock('./schemas', async () => {
   const actual = await vi.importActual<typeof import('./schemas')>('./schemas');
   return {
     ...actual,
-    ENABLE_2FA: false,
+    get ENABLE_2FA() {
+      return enable2faState.value;
+    },
   };
 });
+
+// Default: policy never requires MFA, so the vast majority of tests in this
+// file (written before the resolver existed) don't need to know about it.
+// The enrollment-enforcement describe block below overrides this per test.
+vi.mock('../../services/mfaPolicy', () => ({
+  getEffectiveMfaPolicy: vi.fn(async () => ({
+    required: false,
+    allowedMethods: { totp: true, sms: true, passkey: true },
+    source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: false },
+  })),
+}));
 
 vi.mock('../../services/ipAllowlist', () => ({
   enforceIpAllowlist: vi.fn(),
@@ -184,6 +206,7 @@ import { enforceIpAllowlist } from '../../services/ipAllowlist';
 import { recordFailedLogin } from '../../services/anomalyMetrics';
 import { createAuditLogAsync } from '../../services/auditService';
 import { TenantInactiveError } from '../../services/tenantStatus';
+import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
 import {
   resolveCurrentUserTokenContext,
   NoTenantMembershipError,
@@ -491,6 +514,82 @@ describe('POST /login — mints aep/mep/sid from the live user row', () => {
     const res = await postLogin({ email: 'admin@msp.com', password: 'correct-horse' });
     expect(res.status).toBe(401);
     expect(createTokenPair).not.toHaveBeenCalled();
+  });
+});
+
+// SR2-05 / Task 3: login must never mint vacuous mfa=true for an unenrolled
+// user when the effective policy (org/partner requireMfa OR a force_mfa
+// role, resolved via getEffectiveMfaPolicy) requires MFA. Instead it mints
+// mfa=false and signals mfaEnrollmentRequired so the client routes to
+// /auth/mfa/setup — the middleware's exempt paths admit that flow; every
+// other route then 428s until the user enrolls.
+describe('POST /login — MFA enrollment enforcement via effective policy (SR2-05)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = 'test';
+    process.env.E2E_MODE = 'true';
+    enable2faState.value = true;
+    vi.mocked(enforceIpAllowlist).mockResolvedValue({ decision: 'allow' });
+    vi.mocked(db.select).mockReturnValue(selectChain([{
+      id: 'user-1',
+      email: 'admin@msp.com',
+      name: 'Admin User',
+      passwordHash: 'password-hash',
+      status: 'active',
+      mfaEnabled: false,
+      mfaSecret: null,
+      mfaMethod: null,
+      phoneNumber: null,
+      avatarUrl: null,
+    }]) as any);
+    vi.mocked(db.update).mockReturnValue(updateChain() as any);
+    // A prior describe block ("mints aep/mep/sid") overrides getUserEpochs
+    // to resolve null in one of its tests; clearAllMocks() doesn't reset
+    // mock implementations (only call history), so restore a valid epoch
+    // pair here rather than inheriting that leaked null across files.
+    vi.mocked(getUserEpochs).mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 });
+  });
+
+  afterEach(() => {
+    enable2faState.value = false;
+  });
+
+  it('mints mfa:false and returns mfaEnrollmentRequired:true for an unenrolled user when policy requires MFA', async () => {
+    vi.mocked(getEffectiveMfaPolicy).mockResolvedValue({
+      required: true,
+      allowedMethods: { totp: true, sms: true, passkey: true },
+      source: { roleForceMfa: false, settingsRequireMfa: true, killSwitchOff: false },
+    });
+
+    const res = await postLogin({ email: 'admin@msp.com', password: 'correct-horse' });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.mfaEnrollmentRequired).toBe(true);
+    expect(body.enrollUrl).toBe('/auth/mfa/setup');
+    expect(createTokenPair).toHaveBeenCalledWith(
+      expect.objectContaining({ mfa: false }),
+      expect.anything()
+    );
+  });
+
+  it('mints mfa:true and mfaEnrollmentRequired:false as today when policy does not require MFA', async () => {
+    vi.mocked(getEffectiveMfaPolicy).mockResolvedValue({
+      required: false,
+      allowedMethods: { totp: true, sms: true, passkey: true },
+      source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: false },
+    });
+
+    const res = await postLogin({ email: 'admin@msp.com', password: 'correct-horse' });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.mfaEnrollmentRequired).toBe(false);
+    expect(body.enrollUrl).toBeUndefined();
+    expect(createTokenPair).toHaveBeenCalledWith(
+      expect.objectContaining({ mfa: true }),
+      expect.anything()
+    );
   });
 });
 

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -62,6 +62,7 @@ import { enforceIpAllowlist, IP_NOT_ALLOWED_BODY, isBlocked } from '../../servic
 import { captureException } from '../../services/sentry';
 import { cfAccessLoginMiddleware } from '../../middleware/cfAccessLogin';
 import { dbWriteExpectingRows } from '../../db/dbWriteExpectingRows';
+import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
 
 const { db, withSystemDbAccessContext } = dbModule;
 
@@ -488,9 +489,14 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
   const orgId = context.orgId;
   const scope = context.scope;
 
-  // Create tokens with user's context
-  // MFA is vacuously satisfied when the user hasn't enrolled in MFA
-  const mfaSatisfied = !(ENABLE_2FA && user.mfaEnabled);
+  // Resolve effective policy. A user who reaches here is NOT MFA-enrolled (the
+  // enrolled branch above returns early). If policy requires MFA we must NOT
+  // grant vacuous assurance: mint mfa=false and tell the client to enroll. The
+  // middleware exempt paths (/auth/mfa/*, /users/me) still admit the enrollment
+  // flow; every other route 428s until they enroll.
+  const policy = await getEffectiveMfaPolicy({ scope, userId: user.id, orgId, partnerId });
+  const mfaEnrollmentRequired = ENABLE_2FA && !user.mfaEnabled && policy.required;
+  const mfaSatisfied = !ENABLE_2FA || (!user.mfaEnabled && !policy.required);
 
   // Task 7: mint a fresh refresh-token family for this login. The family id
   // is embedded in the refresh token's `fam` claim and tracked in
@@ -589,7 +595,9 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
     },
     tokens: toPublicTokens(tokens),
     mfaRequired: false,
-    requiresSetup
+    requiresSetup,
+    mfaEnrollmentRequired,
+    enrollUrl: mfaEnrollmentRequired ? '/auth/mfa/setup' : undefined
   });
 });
 

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -445,15 +445,35 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
     // probe error hides the alternate, it never blocks this login.
     const passkeyAvailable = await userHasUsablePasskey(user.id);
 
-    await getRedis()!.setex(`mfa:pending:${tempToken}`, 300, JSON.stringify({
+    // SR2-06: bind the pending record to the live auth/mfa epochs + status +
+    // effective allowed methods at login time, so every completion path
+    // (mfa.ts TOTP/SMS, passkeys.ts) can detect a factor/status change that
+    // happened during the 5-minute MFA window and reject rather than mint
+    // stale assurance.
+    const pendingEpochs = await getUserEpochs(user.id);
+    if (!pendingEpochs) {
+      await floorPromise;
+      return c.json(genericAuthError(), 401);
+    }
+    const pendingPolicy = await getEffectiveMfaPolicy({
+      scope: context.scope, userId: user.id, orgId: context.orgId, partnerId: context.partnerId,
+    });
+    const PENDING_TTL_SECONDS = 300;
+    const pendingRecord = {
       userId: user.id,
       mfaMethod,
       // Server-authoritative: the passkey MFA endpoints gate on this flag, so
       // the client can't self-elevate to the passkey path without an actually
       // registered credential (and /verify still re-checks credential
       // ownership + assertion regardless).
-      passkeyAvailable
-    }));
+      passkeyAvailable,
+      authEpoch: pendingEpochs.authEpoch,
+      mfaEpoch: pendingEpochs.mfaEpoch,
+      statusExpectation: user.status,
+      allowedMethods: pendingPolicy.allowedMethods,
+      expiresAt: Date.now() + PENDING_TTL_SECONDS * 1000,
+    };
+    await getRedis()!.setex(`mfa:pending:${tempToken}`, PENDING_TTL_SECONDS, JSON.stringify(pendingRecord));
 
     // Task 10: the password was verified correctly — clear the per-account
     // failure counter even though MFA still has to succeed. This keeps the

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -49,7 +49,7 @@ import {
   evaluatePendingMfa
 } from './helpers';
 
-const { db, withSystemDbAccessContext } = dbModule;
+const { db, withSystemDbAccessContext, runOutsideDbContext } = dbModule;
 
 // Body schemas that require a password re-prompt. A stolen access token
 // must not be sufficient to install/remove an MFA factor — these
@@ -396,6 +396,13 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
   } catch {
     return c.json({ error: 'Invalid MFA setup data' }, 500);
   }
+  // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
+  // requires a fresh existing-factor proof (no-op for initial enrollment).
+  // Gate BEFORE the consuming verifier (M10) so an unprotected-grant request
+  // 403s without burning the setup time-step — matches /mfa/enable's ordering.
+  const stepUpError = await enforceExistingFactorStepUp(c, auth, c.req.valid('json').stepUpGrantId, { consume: true });
+  if (stepUpError) return stepUpError;
+
   // Consuming verifier: record the accepted time step so it cannot be replayed
   // at login within its ~90s validity window (SR2-24). Fails closed if Redis is
   // down (consumeMFAToken returns false).
@@ -415,28 +422,34 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
     return c.json({ error: 'Invalid MFA code' }, 401);
   }
 
-  // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
-  // requires a fresh existing-factor proof (no-op for initial enrollment).
-  const stepUpError = await enforceExistingFactorStepUp(c, auth, c.req.valid('json').stepUpGrantId, { consume: true });
-  if (stepUpError) return stepUpError;
-
   // SR2-07/SR2-19: fold the factor write into the atomic epoch-bump +
   // refresh-family-revoke transaction, then best-effort post-commit cleanup +
   // remote-session teardown — enabling MFA is a security-relevant factor
   // change and must invalidate any assurance minted before this factor
   // existed.
-  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'mfa-setup-confirm', async (tx) => {
-    await tx
-      .update(users)
-      .set({
-        mfaSecret: encryptMfaSecret(secret),
-        mfaEnabled: true,
-        mfaMethod: 'totp',
-        mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes),
-        updatedAt: new Date()
+  //
+  // I3: unlike every other factor-change caller, this Case-2 path has NO
+  // ambient DB access context — the `await authMiddleware(c, async () => {})`
+  // idiom above tears the RLS context down when its empty `next` returns. So
+  // establish a real system context here; without it the invalidation
+  // transaction runs on the bare pool, forced RLS matches 0 rows, and
+  // advanceUserEpochs throws → hard 500 with the factor never enabled.
+  const result = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'mfa-setup-confirm', async (tx) => {
+        await tx
+          .update(users)
+          .set({
+            mfaSecret: encryptMfaSecret(secret),
+            mfaEnabled: true,
+            mfaMethod: 'totp',
+            mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes),
+            updatedAt: new Date()
+          })
+          .where(eq(users.id, auth.user.id));
       })
-      .where(eq(users.id, auth.user.id));
-  });
+    )
+  );
 
   const setupOrgId = await resolveUserAuditOrgId(auth.user.id);
   writeAuthAudit(c, {
@@ -478,7 +491,7 @@ mfaRoutes.post('/mfa/disable', authMiddleware, zValidator('json', mfaDisableSche
     userId: auth.user.id,
     orgId: auth.orgId ?? null,
     partnerId: auth.partnerId ?? null,
-  });
+  }, { failClosed: true });
   if (disablePolicy.required) {
     return c.json({ error: 'Your organization requires MFA. Contact your admin to change this policy.' }, 403);
   }
@@ -684,15 +697,45 @@ mfaRoutes.post('/mfa/step-up', authMiddleware, zValidator('json', mfaStepUpSchem
   const auth = c.get('auth');
   const body = c.req.valid('json');
 
+  // Rate-limit per user (I2). Every other MFA-verification endpoint throttles
+  // per user; without this the only bound is the 300/60s-per-IP global limit,
+  // leaving a 6-digit TOTP / SMS code brute-forceable to a step-up grant across
+  // a handful of IPs. Fail closed (503) when Redis is unavailable.
+  const redis = getRedis();
+  if (!redis) {
+    return c.json({ error: 'Service temporarily unavailable' }, 503);
+  }
+  const stepUpRate = await rateLimiter(redis, `mfa:stepup:${auth.user.id}`, mfaLimiter.limit, mfaLimiter.windowSeconds);
+  if (!stepUpRate.allowed) {
+    return c.json({ error: 'Too many attempts. Please try again later.' }, 429);
+  }
+
   let ok = false;
   if (body.method === 'totp') {
     const [u] = await db.select({ mfaSecret: users.mfaSecret }).from(users).where(eq(users.id, auth.user.id)).limit(1);
     const secret = u?.mfaSecret ? decryptMfaSecret(u.mfaSecret) : null;
     ok = !!secret && await consumeMFAToken(secret, body.code, auth.user.id);
   } else if (body.method === 'sms') {
-    const [u] = await db.select({ phoneNumber: users.phoneNumber }).from(users).where(eq(users.id, auth.user.id)).limit(1);
+    // Step-up must prove the account's OWN active SMS factor — not merely that
+    // some phone number sits on the row. Allowlist on mfaEnabled + mfaMethod +
+    // phoneVerified (mirrors requireFreshMfaStepUp's TOTP allowlist). Without
+    // this, an attacker who swapped in their own phone via /phone/confirm could
+    // mint a grant here without ever proving the victim's real factor (C1).
+    const [u] = await db
+      .select({
+        phoneNumber: users.phoneNumber,
+        mfaEnabled: users.mfaEnabled,
+        mfaMethod: users.mfaMethod,
+        phoneVerified: users.phoneVerified,
+      })
+      .from(users)
+      .where(eq(users.id, auth.user.id))
+      .limit(1);
+    if (!u?.mfaEnabled || u.mfaMethod !== 'sms' || u.phoneVerified !== true || !u.phoneNumber) {
+      return c.json({ error: 'Invalid credentials' }, 401);
+    }
     const twilio = getTwilioService();
-    if (!twilio || !u?.phoneNumber) return c.json({ error: 'SMS not available' }, 400);
+    if (!twilio) return c.json({ error: 'SMS not available' }, 400);
     const r = await twilio.checkVerificationCode(u.phoneNumber, body.code);
     if (r.serviceError) return c.json({ error: 'SMS verification temporarily unavailable' }, 502);
     ok = r.valid;

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -705,7 +705,10 @@ mfaRoutes.post('/mfa/step-up', authMiddleware, zValidator('json', mfaStepUpSchem
   if (!redis) {
     return c.json({ error: 'Service temporarily unavailable' }, 503);
   }
-  const stepUpRate = await rateLimiter(redis, `mfa:stepup:${auth.user.id}`, mfaLimiter.limit, mfaLimiter.windowSeconds);
+  // Key prefix `mfa:stepup-rl:` is deliberately disjoint from the grant store's
+  // `mfa:stepup:` (mfaStepUpGrant.ts) so the rate-limiter's sorted-set never
+  // shares a namespace with a grant key.
+  const stepUpRate = await rateLimiter(redis, `mfa:stepup-rl:${auth.user.id}`, mfaLimiter.limit, mfaLimiter.windowSeconds);
   if (!stepUpRate.allowed) {
     return c.json({ error: 'Too many attempts. Please try again later.' }, 429);
   }

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -21,10 +21,12 @@ import {
 import { getTwilioService } from '../../services/twilio';
 import { readMobileDeviceId } from '../../services/mobileDeviceBinding';
 import { authMiddleware } from '../../middleware/auth';
-import { ENABLE_2FA, mfaVerifySchema, mfaEnableSchema } from './schemas';
+import { ENABLE_2FA, mfaVerifySchema, mfaEnableSchema, mfaStepUpSchema } from './schemas';
 import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
 import { invalidateMfaAssuranceAfterFactorChange } from '../../services/mfaAssurance';
 import { TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
+import { mintStepUpGrant } from '../../services/mfaStepUpGrant';
+import { verifyStepUpPasskeyAssertion } from './passkeys';
 import {
   getClientIP,
   setRefreshTokenCookie,
@@ -42,6 +44,7 @@ import {
   auditLogin,
   userRequiresSetup,
   requireCurrentPasswordStepUp,
+  enforceExistingFactorStepUp,
   parsePendingMfa,
   evaluatePendingMfa
 } from './helpers';
@@ -56,7 +59,10 @@ const passwordOnlySchema = z.object({
   currentPassword: z.string().min(1).max(256)
 });
 const mfaEnableWithPasswordSchema = mfaEnableSchema.extend({
-  currentPassword: z.string().min(1).max(256)
+  currentPassword: z.string().min(1).max(256),
+  // SR2-20: existing-factor step-up grant required when the account is
+  // already MFA-protected (see enforceExistingFactorStepUp in ./helpers).
+  stepUpGrantId: z.string().optional()
 });
 const mfaDisableSchema = mfaVerifySchema.extend({
   currentPassword: z.string().min(1).max(256)
@@ -409,6 +415,11 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
     return c.json({ error: 'Invalid MFA code' }, 401);
   }
 
+  // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
+  // requires a fresh existing-factor proof (no-op for initial enrollment).
+  const stepUpError = await enforceExistingFactorStepUp(c, auth, c.req.valid('json').stepUpGrantId, { consume: true });
+  if (stepUpError) return stepUpError;
+
   // SR2-07/SR2-19: fold the factor write into the atomic epoch-bump +
   // refresh-family-revoke transaction, then best-effort post-commit cleanup +
   // remote-session teardown — enabling MFA is a security-relevant factor
@@ -572,11 +583,16 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithPa
   }
 
   const auth = c.get('auth');
-  const { code, currentPassword } = c.req.valid('json');
+  const { code, currentPassword, stepUpGrantId } = c.req.valid('json');
 
   // Re-verify password before flipping mfaEnabled=true on the user row.
   const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd');
   if (passwordError) return passwordError;
+
+  // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
+  // requires a fresh existing-factor proof (no-op for initial enrollment).
+  const stepUpError = await enforceExistingFactorStepUp(c, auth, stepUpGrantId, { consume: true });
+  if (stepUpError) return stepUpError;
 
   const redis = getRedis();
 
@@ -650,6 +666,79 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithPa
   });
 
   return c.json({ success: true, recoveryCodes, message: 'MFA enabled successfully' });
+});
+
+// SR2-20: existing-factor step-up. Proves an EXISTING MFA factor (TOTP, SMS,
+// or passkey — a discriminated union on `method` so a passkey-only user is
+// never locked out) and mints a short-lived single-use grant, which the
+// caller then presents as `stepUpGrantId` to a factor-ADDITION endpoint
+// (`/mfa/enable`, setup-confirm, `/mfa/sms/enable`, `/passkeys/register/*`)
+// on an already-protected account. The passkey branch expects the client to
+// have already called `POST /auth/mfa/step-up/options` (passkeys.ts) to get
+// a fresh WebAuthn challenge.
+mfaRoutes.post('/mfa/step-up', authMiddleware, zValidator('json', mfaStepUpSchema), async (c) => {
+  if (!ENABLE_2FA) {
+    return mfaDisabledResponse(c);
+  }
+
+  const auth = c.get('auth');
+  const body = c.req.valid('json');
+
+  let ok = false;
+  if (body.method === 'totp') {
+    const [u] = await db.select({ mfaSecret: users.mfaSecret }).from(users).where(eq(users.id, auth.user.id)).limit(1);
+    const secret = u?.mfaSecret ? decryptMfaSecret(u.mfaSecret) : null;
+    ok = !!secret && await consumeMFAToken(secret, body.code, auth.user.id);
+  } else if (body.method === 'sms') {
+    const [u] = await db.select({ phoneNumber: users.phoneNumber }).from(users).where(eq(users.id, auth.user.id)).limit(1);
+    const twilio = getTwilioService();
+    if (!twilio || !u?.phoneNumber) return c.json({ error: 'SMS not available' }, 400);
+    const r = await twilio.checkVerificationCode(u.phoneNumber, body.code);
+    if (r.serviceError) return c.json({ error: 'SMS verification temporarily unavailable' }, 502);
+    ok = r.valid;
+  } else {
+    // passkey — client must have already called POST /auth/mfa/step-up/options.
+    ok = await verifyStepUpPasskeyAssertion(auth.user.id, body.credential);
+  }
+
+  if (!ok) {
+    writeAuthAudit(c, {
+      orgId: auth.orgId ?? undefined,
+      action: 'auth.mfa.stepup.failed',
+      result: 'failure',
+      reason: 'invalid_factor',
+      userId: auth.user.id,
+      email: auth.user.email,
+      details: { method: body.method }
+    });
+    return c.json({ error: 'Invalid credentials' }, 401);
+  }
+
+  const epochs = await getUserEpochs(auth.user.id);
+  if (!epochs || !auth.token.sid) {
+    return c.json({ error: 'Service temporarily unavailable' }, 503);
+  }
+  const grantId = await mintStepUpGrant({
+    userId: auth.user.id,
+    operation: 'add_factor',
+    authEpoch: epochs.authEpoch,
+    mfaEpoch: epochs.mfaEpoch,
+    sid: auth.token.sid
+  });
+  if (!grantId) {
+    return c.json({ error: 'Service temporarily unavailable' }, 503);
+  }
+
+  writeAuthAudit(c, {
+    orgId: auth.orgId ?? undefined,
+    action: 'auth.mfa.stepup.granted',
+    result: 'success',
+    userId: auth.user.id,
+    email: auth.user.email,
+    details: { method: body.method, operation: 'add_factor' }
+  });
+
+  return c.json({ stepUpGrantId: grantId });
 });
 
 // Generate new MFA recovery codes for the authenticated user

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
-import { eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import * as dbModule from '../../db';
 import { users, organizations } from '../../db/schema';
@@ -30,6 +30,7 @@ import {
   encryptMfaSecret,
   decryptMfaSecret,
   decryptMfaSecretForMigration,
+  hashRecoveryCode,
   hashRecoveryCodes,
   mfaDisabledResponse,
   resolveCurrentUserTokenContext,
@@ -118,7 +119,7 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
     return mfaDisabledResponse(c);
   }
 
-  const { code, tempToken } = c.req.valid('json');
+  const { code, tempToken, method } = c.req.valid('json');
   const redis = getRedis();
 
   if (!redis) {
@@ -213,7 +214,53 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
       return c.json({ error: 'Use passkey verification for this MFA session' }, 400);
     }
 
-    if (effectiveMethod === 'sms') {
+    // Recovery-code login. Independent of the account's primary factor: a user
+    // locked out of their authenticator falls back to a stored recovery code.
+    // Remove exactly one matching hash with a server-side RELATIVE jsonb delete
+    // (`mfaRecoveryCodes - inputHash`) guarded by `@> [inputHash]`. This is the
+    // ONLY correct concurrency shape — it composes under READ COMMITTED:
+    //   - two concurrent DISTINCT valid codes each delete their OWN element from
+    //     the row's committed value (Postgres re-evaluates `-` against the
+    //     latest committed array), so both succeed and NEITHER resurrects the
+    //     other's hash. A stale read-modify-write (SET = a JS array computed
+    //     from a pre-read snapshot) would resurrect the co-winner's hash — never
+    //     do that.
+    //   - two concurrent IDENTICAL codes serialize on the row; the loser's `@>`
+    //     guard fails against the winner's committed value → rowCount 0 → 401.
+    // Single-winner AND no-resurrection are proven against real Postgres (Task 9).
+    if (method === 'recovery') {
+      const inputHash = hashRecoveryCode(code);
+      const stored = Array.isArray(user.mfaRecoveryCodes) ? (user.mfaRecoveryCodes as string[]) : [];
+      if (!stored.includes(inputHash)) {
+        void auditUserLoginFailure(c, {
+          userId: user.id, email: user.email, name: user.name,
+          reason: 'mfa_recovery_code_invalid', details: { method: 'recovery' },
+        });
+        return c.json({ error: 'Invalid MFA code' }, 401);
+      }
+      const removed = await withSystemDbAccessContext(() =>
+        db
+          .update(users)
+          .set({ mfaRecoveryCodes: sql`${users.mfaRecoveryCodes} - ${inputHash}`, updatedAt: new Date() })
+          .where(and(eq(users.id, user.id), sql`${users.mfaRecoveryCodes} @> ${JSON.stringify([inputHash])}::jsonb`))
+          .returning({ id: users.id }),
+      );
+      if (removed.length === 0) {
+        // A concurrent winner already consumed this exact hash — reject the loser.
+        return c.json({ error: 'Invalid MFA code' }, 401);
+      }
+      writeAuthAudit(c, {
+        orgId: undefined,
+        action: 'auth.mfa.recovery_code.used',
+        result: 'success',
+        userId: user.id,
+        email: user.email,
+        // Best-effort count from the PRE-update snapshot only — never read the
+        // post-update array back, and never log the code or its hash.
+        details: { remainingApprox: Math.max(0, stored.length - 1) },
+      });
+      valid = true;
+    } else if (effectiveMethod === 'sms') {
       const phone = user.phoneNumber;
       if (!phone) {
         return c.json({ error: 'No phone number configured for SMS MFA' }, 400);

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -3,7 +3,7 @@ import { zValidator } from '../../lib/validation';
 import { and, eq, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import * as dbModule from '../../db';
-import { users, organizations } from '../../db/schema';
+import { users } from '../../db/schema';
 import {
   createTokenPair,
   generateMFASecret,
@@ -23,6 +23,8 @@ import { readMobileDeviceId } from '../../services/mobileDeviceBinding';
 import { authMiddleware } from '../../middleware/auth';
 import { ENABLE_2FA, mfaVerifySchema, mfaEnableSchema } from './schemas';
 import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
+import { invalidateMfaAssuranceAfterFactorChange } from '../../services/mfaAssurance';
+import { TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
 import {
   getClientIP,
   setRefreshTokenCookie,
@@ -407,16 +409,23 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
     return c.json({ error: 'Invalid MFA code' }, 401);
   }
 
-  await db
-    .update(users)
-    .set({
-      mfaSecret: encryptMfaSecret(secret),
-      mfaEnabled: true,
-      mfaMethod: 'totp',
-      mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes),
-      updatedAt: new Date()
-    })
-    .where(eq(users.id, auth.user.id));
+  // SR2-07/SR2-19: fold the factor write into the atomic epoch-bump +
+  // refresh-family-revoke transaction, then best-effort post-commit cleanup +
+  // remote-session teardown — enabling MFA is a security-relevant factor
+  // change and must invalidate any assurance minted before this factor
+  // existed.
+  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'mfa-setup-confirm', async (tx) => {
+    await tx
+      .update(users)
+      .set({
+        mfaSecret: encryptMfaSecret(secret),
+        mfaEnabled: true,
+        mfaMethod: 'totp',
+        mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes),
+        updatedAt: new Date()
+      })
+      .where(eq(users.id, auth.user.id));
+  });
 
   const setupOrgId = await resolveUserAuditOrgId(auth.user.id);
   writeAuthAudit(c, {
@@ -425,7 +434,7 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
     result: 'success',
     userId: auth.user.id,
     email: auth.user.email,
-    details: { method: 'totp' }
+    details: { method: 'totp', mfaEpoch: result.mfaEpoch, teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED }
   });
 
   await redis.del(`mfa:setup:${auth.user.id}`);
@@ -449,18 +458,18 @@ mfaRoutes.post('/mfa/disable', authMiddleware, zValidator('json', mfaDisableSche
   const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd');
   if (passwordError) return passwordError;
 
-  // Check org policy — if requireMfa is true, block disable
-  if (auth.orgId) {
-    const [org] = await db
-      .select({ settings: organizations.settings })
-      .from(organizations)
-      .where(eq(organizations.id, auth.orgId))
-      .limit(1);
-
-    const orgSettings = org?.settings as { security?: { requireMfa?: boolean } } | null;
-    if (orgSettings?.security?.requireMfa) {
-      return c.json({ error: 'Your organization requires MFA. Contact your admin to change this policy.' }, 403);
-    }
+  // MFA policy blocks self-disable when effective policy (role OR org/partner
+  // requireMfa, partner-inherited) still requires MFA for this user. Uses the
+  // resolver so a partner-set requireMfa — invisible to the old org-only read
+  // — is honored, and partner-scope users are covered (I3, SR2-05).
+  const disablePolicy = await getEffectiveMfaPolicy({
+    scope: auth.scope,
+    userId: auth.user.id,
+    orgId: auth.orgId ?? null,
+    partnerId: auth.partnerId ?? null,
+  });
+  if (disablePolicy.required) {
+    return c.json({ error: 'Your organization requires MFA. Contact your admin to change this policy.' }, 403);
   }
 
   const [user] = await db
@@ -529,18 +538,20 @@ mfaRoutes.post('/mfa/disable', authMiddleware, zValidator('json', mfaDisableSche
     }
   }
 
-  await db
-    .update(users)
-    .set({
-      mfaSecret: null,
-      mfaEnabled: false,
-      mfaMethod: null,
-      mfaRecoveryCodes: null,
-      phoneNumber: null,
-      phoneVerified: false,
-      updatedAt: new Date()
-    })
-    .where(eq(users.id, auth.user.id));
+  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'mfa-disable', async (tx) => {
+    await tx
+      .update(users)
+      .set({
+        mfaSecret: null,
+        mfaEnabled: false,
+        mfaMethod: null,
+        mfaRecoveryCodes: null,
+        phoneNumber: null,
+        phoneVerified: false,
+        updatedAt: new Date()
+      })
+      .where(eq(users.id, auth.user.id));
+  });
 
   writeAuthAudit(c, {
     orgId: auth.orgId ?? undefined,
@@ -548,7 +559,7 @@ mfaRoutes.post('/mfa/disable', authMiddleware, zValidator('json', mfaDisableSche
     result: 'success',
     userId: auth.user.id,
     email: auth.user.email,
-    details: { method: currentMethod }
+    details: { method: currentMethod, mfaEpoch: result.mfaEpoch, teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED }
   });
 
   return c.json({ success: true, message: 'MFA disabled successfully' });
@@ -613,16 +624,18 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithPa
     return c.json({ error: message, message }, 401);
   }
 
-  await db
-    .update(users)
-    .set({
-      mfaSecret: encryptMfaSecret(secret),
-      mfaEnabled: true,
-      mfaMethod: 'totp',
-      mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes),
-      updatedAt: new Date()
-    })
-    .where(eq(users.id, auth.user.id));
+  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'mfa-enable', async (tx) => {
+    await tx
+      .update(users)
+      .set({
+        mfaSecret: encryptMfaSecret(secret),
+        mfaEnabled: true,
+        mfaMethod: 'totp',
+        mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes),
+        updatedAt: new Date()
+      })
+      .where(eq(users.id, auth.user.id));
+  });
 
   await redis.del(`mfa:setup:${auth.user.id}`);
 
@@ -633,7 +646,7 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithPa
     result: 'success',
     userId: auth.user.id,
     email: auth.user.email,
-    details: { method: 'totp' }
+    details: { method: 'totp', mfaEpoch: result.mfaEpoch, teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED }
   });
 
   return c.json({ success: true, recoveryCodes, message: 'MFA enabled successfully' });
@@ -663,13 +676,19 @@ mfaRoutes.post('/mfa/recovery-codes', authMiddleware, zValidator('json', passwor
   }
 
   const recoveryCodes = generateRecoveryCodes();
-  await db
-    .update(users)
-    .set({
-      mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes),
-      updatedAt: new Date()
-    })
-    .where(eq(users.id, auth.user.id));
+  // Rotating recovery codes advances mfa_epoch and signs the user out — per
+  // SR2-19 this is intended: the recovery-code set is part of the MFA config,
+  // and a stale set otherwise remains usable after rotation from a stolen
+  // session.
+  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'mfa-recovery-rotate', async (tx) => {
+    await tx
+      .update(users)
+      .set({
+        mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes),
+        updatedAt: new Date()
+      })
+      .where(eq(users.id, auth.user.id));
+  });
 
   const orgId = await resolveUserAuditOrgId(auth.user.id);
   writeAuthAudit(c, {
@@ -678,7 +697,7 @@ mfaRoutes.post('/mfa/recovery-codes', authMiddleware, zValidator('json', passwor
     result: 'success',
     userId: auth.user.id,
     email: auth.user.email,
-    details: { count: recoveryCodes.length }
+    details: { count: recoveryCodes.length, mfaEpoch: result.mfaEpoch, teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED }
   });
 
   return c.json({ success: true, recoveryCodes, message: 'Recovery codes generated successfully' });

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -7,7 +7,6 @@ import { users, organizations } from '../../db/schema';
 import {
   createTokenPair,
   generateMFASecret,
-  verifyMFAToken,
   consumeMFAToken,
   generateOTPAuthURL,
   generateQRCode,
@@ -342,7 +341,10 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
   } catch {
     return c.json({ error: 'Invalid MFA setup data' }, 500);
   }
-  const valid = await verifyMFAToken(secret, code);
+  // Consuming verifier: record the accepted time step so it cannot be replayed
+  // at login within its ~90s validity window (SR2-24). Fails closed if Redis is
+  // down (consumeMFAToken returns false).
+  const valid = await consumeMFAToken(secret, code, auth.user.id);
 
   if (!valid) {
     const orgId = await resolveUserAuditOrgId(auth.user.id);
@@ -545,7 +547,10 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithPa
     return c.json({ error: message, message }, 500);
   }
 
-  const valid = await verifyMFAToken(secret, code);
+  // Consuming verifier: record the accepted time step so it cannot be replayed
+  // at login within its ~90s validity window (SR2-24). Fails closed if Redis is
+  // down (consumeMFAToken returns false).
+  const valid = await consumeMFAToken(secret, code, auth.user.id);
   if (!valid) {
     const orgId = await resolveUserAuditOrgId(auth.user.id);
     writeAuthAudit(c, {

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -23,6 +23,7 @@ import { getTwilioService } from '../../services/twilio';
 import { readMobileDeviceId } from '../../services/mobileDeviceBinding';
 import { authMiddleware } from '../../middleware/auth';
 import { ENABLE_2FA, mfaVerifySchema, mfaEnableSchema } from './schemas';
+import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
 import {
   getClientIP,
   setRefreshTokenCookie,
@@ -38,7 +39,9 @@ import {
   auditUserLoginFailure,
   auditLogin,
   userRequiresSetup,
-  requireCurrentPasswordStepUp
+  requireCurrentPasswordStepUp,
+  parsePendingMfa,
+  evaluatePendingMfa
 } from './helpers';
 
 const { db, withSystemDbAccessContext } = dbModule;
@@ -130,18 +133,15 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
       return c.json({ error: 'Invalid or expired MFA session' }, 401);
     }
 
-    // Parse pending data — supports both legacy (plain userId string) and new (JSON) format
-    let pendingUserId: string;
-    let pendingMfaMethod: string;
-    try {
-      const parsed = JSON.parse(pendingRaw);
-      pendingUserId = parsed.userId;
-      pendingMfaMethod = parsed.mfaMethod || 'totp';
-    } catch {
-      // Legacy format: plain userId string
-      pendingUserId = pendingRaw;
-      pendingMfaMethod = 'totp';
+    // SR2-06: strict parse — legacy bare-userId / epoch-less records return
+    // null and must force a fresh login rather than complete with no live
+    // re-check of the account's current epoch/status.
+    const pending = parsePendingMfa(pendingRaw);
+    if (!pending) {
+      return c.json({ error: 'Invalid or expired MFA session' }, 401);
     }
+    const pendingUserId = pending.userId;
+    const pendingMfaMethod = pending.mfaMethod;
 
     // Rate limit MFA attempts
     const rateCheck = await rateLimiter(redis, `mfa:${pendingUserId}`, mfaLimiter.limit, mfaLimiter.windowSeconds);
@@ -161,6 +161,48 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
 
     if (!user) {
       return c.json({ error: 'Invalid MFA configuration' }, 400);
+    }
+
+    // SR2-06: re-check the live epoch/status before minting. A factor change
+    // (mfa_epoch), an account-wide security event (auth_epoch), or a suspend
+    // during the 5-minute MFA window must invalidate this in-flight session.
+    const liveEpochs = await getUserEpochs(user.id);
+    const verdict = liveEpochs
+      ? evaluatePendingMfa(pending, { status: user.status, authEpoch: liveEpochs.authEpoch, mfaEpoch: liveEpochs.mfaEpoch })
+      : ({ ok: false, reason: 'epoch_mismatch' } as const);
+    if (!verdict.ok) {
+      // Consume the record so a rejected session can't be retried.
+      await redis.del(`mfa:pending:${tempToken}`);
+      void auditUserLoginFailure(c, {
+        userId: user.id, email: user.email, name: user.name,
+        reason: 'mfa_pending_invalidated',
+        details: { phase: verdict.reason, method: pendingMfaMethod },
+      });
+      return c.json({ error: 'Invalid or expired MFA session' }, 401);
+    }
+
+    // Resolve the user's token context ONCE (reused for the mint below, which
+    // no longer re-resolves it further down).
+    const mfaContext = await resolveCurrentUserTokenContext(user.id);
+
+    // Method must still be allowed by current policy (a factor could have been
+    // disallowed since login). Passkey is handled by its own route; here we gate
+    // totp/sms. Use the real scope/org/partner from the resolved context so
+    // org- and partner-scoped policy resolves correctly.
+    const livePolicy = await getEffectiveMfaPolicy({
+      scope: mfaContext.scope,
+      userId: user.id,
+      orgId: mfaContext.orgId,
+      partnerId: mfaContext.partnerId,
+    });
+    if ((pendingMfaMethod === 'sms' && !livePolicy.allowedMethods.sms) ||
+        (pendingMfaMethod === 'totp' && !livePolicy.allowedMethods.totp)) {
+      await redis.del(`mfa:pending:${tempToken}`);
+      void auditUserLoginFailure(c, {
+        userId: user.id, email: user.email, name: user.name,
+        reason: 'mfa_method_not_allowed', details: { method: pendingMfaMethod },
+      });
+      return c.json({ error: 'This MFA method is no longer permitted. Please sign in again.' }, 401);
     }
 
     // Use the server-stored method only — never allow the client to override
@@ -213,8 +255,8 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
     // Clear temp token
     await redis.del(`mfa:pending:${tempToken}`);
 
-    // Look up user's partner/org context
-    const mfaContext = await resolveCurrentUserTokenContext(user.id);
+    // Partner/org context was already resolved above (mfaContext) — reuse it
+    // rather than re-querying.
     const mfaRoleId = mfaContext.roleId;
     const mfaPartnerId = mfaContext.partnerId;
     const mfaOrgId = mfaContext.orgId;

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -24,6 +24,9 @@ import {
   verifyPasskeyRegistration
 } from '../../services/passkeys';
 import { readMobileDeviceId } from '../../services/mobileDeviceBinding';
+import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
+import { invalidateMfaAssuranceAfterFactorChange } from '../../services/mfaAssurance';
+import { TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
 import { ENABLE_2FA } from './schemas';
 import {
   auditLogin,
@@ -157,46 +160,60 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
   }
 
   const fields = registrationInfoToPasskeyFields(verification, credential);
-  const [inserted] = await db
-    .insert(userPasskeys)
-    .values({
-      userId: auth.user.id,
-      credentialId: fields.credentialId,
-      publicKey: fields.publicKey,
-      counter: fields.counter,
-      deviceType: fields.deviceType,
-      backedUp: fields.backedUp,
-      transports: fields.transports,
-      name: name ?? 'Passkey',
-      aaguid: fields.aaguid,
-      updatedAt: new Date()
-    })
-    .returning();
+
+  // SR2-07/SR2-19: the insert AND the users.mfaEnabled flip are folded into
+  // ONE transaction with the epoch bump + refresh-family revoke — registering
+  // a new passkey is a factor-add and must invalidate assurance minted before
+  // this factor existed. The inserted row is captured via closure so it can
+  // be used in the response after the transaction commits.
+  let inserted: PasskeyRow | undefined;
+  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'passkey-register', async (tx) => {
+    const [row] = await tx
+      .insert(userPasskeys)
+      .values({
+        userId: auth.user.id,
+        credentialId: fields.credentialId,
+        publicKey: fields.publicKey,
+        counter: fields.counter,
+        deviceType: fields.deviceType,
+        backedUp: fields.backedUp,
+        transports: fields.transports,
+        name: name ?? 'Passkey',
+        aaguid: fields.aaguid,
+        updatedAt: new Date()
+      })
+      .returning();
+
+    if (!row) {
+      throw new Error('Passkey insert returned no row');
+    }
+    inserted = row;
+
+    // Enable MFA, but do NOT overwrite an existing TOTP/SMS factor's method.
+    // `mfaMethod` is single-valued and drives login routing (login.ts/mfa.ts);
+    // clobbering it to 'passkey' would strand a user's working authenticator
+    // and risk lockout if they later lose the passkey device. Only make
+    // passkey the primary method when the user has no other factor configured.
+    const [currentMfa] = await tx
+      .select({ mfaSecret: users.mfaSecret, mfaMethod: users.mfaMethod })
+      .from(users)
+      .where(eq(users.id, auth.user.id))
+      .limit(1);
+    const hasExistingFactor = Boolean(currentMfa?.mfaSecret) || currentMfa?.mfaMethod === 'sms';
+
+    await tx
+      .update(users)
+      .set({
+        mfaEnabled: true,
+        ...(hasExistingFactor ? {} : { mfaMethod: 'passkey' }),
+        updatedAt: new Date()
+      })
+      .where(eq(users.id, auth.user.id));
+  });
 
   if (!inserted) {
     throw new Error('Passkey insert returned no row');
   }
-
-  // Enable MFA, but do NOT overwrite an existing TOTP/SMS factor's method.
-  // `mfaMethod` is single-valued and drives login routing (login.ts/mfa.ts);
-  // clobbering it to 'passkey' would strand a user's working authenticator
-  // and risk lockout if they later lose the passkey device. Only make passkey
-  // the primary method when the user has no other factor configured.
-  const [currentMfa] = await db
-    .select({ mfaSecret: users.mfaSecret, mfaMethod: users.mfaMethod })
-    .from(users)
-    .where(eq(users.id, auth.user.id))
-    .limit(1);
-  const hasExistingFactor = Boolean(currentMfa?.mfaSecret) || currentMfa?.mfaMethod === 'sms';
-
-  await db
-    .update(users)
-    .set({
-      mfaEnabled: true,
-      ...(hasExistingFactor ? {} : { mfaMethod: 'passkey' }),
-      updatedAt: new Date()
-    })
-    .where(eq(users.id, auth.user.id));
 
   writeAuthAudit(c, {
     orgId: auth.orgId ?? undefined,
@@ -204,7 +221,12 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
     result: 'success',
     userId: auth.user.id,
     email: auth.user.email,
-    details: { method: 'passkey', credentialId: fields.credentialId }
+    details: {
+      method: 'passkey',
+      credentialId: fields.credentialId,
+      mfaEpoch: result.mfaEpoch,
+      teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED
+    }
   });
 
   return c.json({
@@ -469,29 +491,31 @@ passkeyRoutes.delete('/passkeys/:id', authMiddleware, zValidator('json', deleteP
     return c.json({ error: 'Cannot remove the last MFA factor while your role or organization requires MFA' }, 403);
   }
 
-  await db
-    .delete(userPasskeys)
-    .where(eq(userPasskeys.id, id));
+  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'passkey-delete', async (tx) => {
+    await tx
+      .delete(userPasskeys)
+      .where(eq(userPasskeys.id, id));
 
-  if (remainingFactorCount === 0) {
-    await db
-      .update(users)
-      .set({
-        mfaEnabled: false,
-        mfaMethod: null,
-        updatedAt: new Date()
-      })
-      .where(eq(users.id, auth.user.id));
-  } else if (factorState.currentMfaMethod === 'passkey' && factorState.passkeyCount - 1 === 0) {
-    await db
-      .update(users)
-      .set({
-        mfaEnabled: true,
-        mfaMethod: factorState.hasTotp ? 'totp' : 'sms',
-        updatedAt: new Date()
-      })
-      .where(eq(users.id, auth.user.id));
-  }
+    if (remainingFactorCount === 0) {
+      await tx
+        .update(users)
+        .set({
+          mfaEnabled: false,
+          mfaMethod: null,
+          updatedAt: new Date()
+        })
+        .where(eq(users.id, auth.user.id));
+    } else if (factorState.currentMfaMethod === 'passkey' && factorState.passkeyCount - 1 === 0) {
+      await tx
+        .update(users)
+        .set({
+          mfaEnabled: true,
+          mfaMethod: factorState.hasTotp ? 'totp' : 'sms',
+          updatedAt: new Date()
+        })
+        .where(eq(users.id, auth.user.id));
+    }
+  });
 
   writeAuthAudit(c, {
     orgId: auth.orgId ?? undefined,
@@ -499,7 +523,12 @@ passkeyRoutes.delete('/passkeys/:id', authMiddleware, zValidator('json', deleteP
     result: 'success',
     userId: auth.user.id,
     email: auth.user.email,
-    details: { method: 'passkey', passkeyId: id }
+    details: {
+      method: 'passkey',
+      passkeyId: id,
+      mfaEpoch: result.mfaEpoch,
+      teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED
+    }
   });
 
   return c.json({ success: true });
@@ -536,12 +565,20 @@ async function getMfaFactorState(auth: AuthContext): Promise<{
   currentMfaMethod: 'totp' | 'sms' | 'passkey' | null;
   mfaRequired: boolean;
 }> {
+  // I3/SR2-05: mfaRequired now comes from the resolver so a partner-set
+  // requireMfa (partner-inherited, invisible to the old org-only EXISTS
+  // below) blocks last-factor removal too, matching enrollment/login/disable.
+  const policy = await getEffectiveMfaPolicy({
+    scope: auth.scope,
+    userId: auth.user.id,
+    orgId: auth.orgId ?? null,
+    partnerId: auth.partnerId ?? null,
+  });
+
   // This runs inside the DELETE handler's request (user-scoped) context, where
   // a bare `withSystemDbAccessContext` would be a no-op. Escape the active
-  // context first so the roles / partner_users / organization_users /
-  // organizations reads that decide `mfaRequired` actually run under system
-  // scope — otherwise user-scoped RLS could hide a force_mfa role/org-setting
-  // row, under-count factors, and let the last MFA factor be removed.
+  // context first so the factor-count read is not affected by user-scoped RLS
+  // edge cases.
   const [state] = await runOutsideDbContext(() => withSystemDbAccessContext(async () =>
     db
       .select({
@@ -553,23 +590,7 @@ async function getMfaFactorState(auth: AuthContext): Promise<{
         )`,
         hasTotp: sql<boolean>`${users.mfaSecret} IS NOT NULL`,
         hasSms: sql<boolean>`${users.mfaMethod} = 'sms' AND ${users.phoneVerified} = true`,
-        currentMfaMethod: users.mfaMethod,
-        forceMfa: sql<boolean>`EXISTS (
-          SELECT 1
-          FROM roles r
-          LEFT JOIN partner_users pu ON pu.role_id = r.id
-          LEFT JOIN organization_users ou ON ou.role_id = r.id
-          WHERE (pu.user_id = ${auth.user.id} OR ou.user_id = ${auth.user.id})
-            AND r.force_mfa = true
-        )`,
-        orgRequiresMfa: auth.orgId
-          ? sql<boolean>`EXISTS (
-              SELECT 1
-              FROM organizations o
-              WHERE o.id = ${auth.orgId}
-                AND COALESCE((o.settings->'security'->>'requireMfa')::boolean, false) = true
-            )`
-          : sql<boolean>`false`
+        currentMfaMethod: users.mfaMethod
       })
       .from(users)
       .where(eq(users.id, auth.user.id))
@@ -581,7 +602,7 @@ async function getMfaFactorState(auth: AuthContext): Promise<{
     hasTotp: Boolean(state?.hasTotp),
     hasSms: Boolean(state?.hasSms),
     currentMfaMethod: state?.currentMfaMethod ?? null,
-    mfaRequired: Boolean((state as { forceMfa?: boolean; orgRequiresMfa?: boolean } | undefined)?.forceMfa || (state as { forceMfa?: boolean; orgRequiresMfa?: boolean } | undefined)?.orgRequiresMfa)
+    mfaRequired: policy.required
   };
 }
 

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -31,6 +31,7 @@ import { ENABLE_2FA } from './schemas';
 import {
   auditLogin,
   evaluatePendingMfa,
+  enforceExistingFactorStepUp,
   getClientIP,
   mfaDisabledResponse,
   parsePendingMfa,
@@ -61,11 +62,15 @@ const webAuthnCredentialSchema = z
 const passkeyNameSchema = z.string().trim().min(1).max(255);
 const registerOptionsSchema = z.object({
   currentPassword: z.string().min(1).max(256),
-  name: passkeyNameSchema.optional()
+  name: passkeyNameSchema.optional(),
+  // SR2-20: existing-factor step-up grant required when the account is
+  // already MFA-protected (see enforceExistingFactorStepUp in ./helpers).
+  stepUpGrantId: z.string().optional()
 });
 const registerVerifySchema = z.object({
   credential: webAuthnCredentialSchema,
-  name: passkeyNameSchema.optional()
+  name: passkeyNameSchema.optional(),
+  stepUpGrantId: z.string().optional()
 });
 const passkeyMfaOptionsSchema = z.object({
   tempToken: z.string().min(1)
@@ -111,10 +116,16 @@ passkeyRoutes.post('/passkeys/register/options', authMiddleware, zValidator('jso
   }
 
   const auth = c.get('auth');
-  const { currentPassword } = c.req.valid('json');
+  const { currentPassword, stepUpGrantId } = c.req.valid('json');
 
   const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'passkey:pwd');
   if (passwordError) return passwordError;
+
+  // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
+  // requires a fresh existing-factor proof. Non-consuming here — the SAME
+  // grant is consumed at /passkeys/register/verify below.
+  const stepUpError = await enforceExistingFactorStepUp(c, auth, stepUpGrantId, { consume: false });
+  if (stepUpError) return stepUpError;
 
   const existingPasskeys = await listActivePasskeys(auth.user.id);
   const options = await generatePasskeyRegistrationOptions({
@@ -131,7 +142,7 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
   }
 
   const auth = c.get('auth');
-  const { credential, name } = c.req.valid('json');
+  const { credential, name, stepUpGrantId } = c.req.valid('json');
 
   let verification;
   try {
@@ -160,6 +171,12 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
   }
 
   const fields = registrationInfoToPasskeyFields(verification, credential);
+
+  // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
+  // requires a fresh existing-factor proof. Single-use consume — this is the
+  // terminal factor write.
+  const stepUpError = await enforceExistingFactorStepUp(c, auth, stepUpGrantId, { consume: true });
+  if (stepUpError) return stepUpError;
 
   // SR2-07/SR2-19: the insert AND the users.mfaEnabled flip are folded into
   // ONE transaction with the epoch bump + refresh-family revoke — registering
@@ -234,6 +251,74 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
     passkey: toPublicPasskey(inserted)
   });
 });
+
+// SR2-20: authenticated passkey step-up challenge. Mirrors /mfa/passkey/options
+// (the login-time challenge issuer below), but keyed on the LOGGED-IN user
+// rather than a pre-auth login tempToken — this lets a passkey-only user
+// prove their existing factor to mint a step-up grant (POST /auth/mfa/step-up)
+// without a TOTP/SMS fallback, avoiding a lockout.
+passkeyRoutes.post('/mfa/step-up/options', authMiddleware, async (c) => {
+  if (!ENABLE_2FA) {
+    return mfaDisabledResponse(c);
+  }
+
+  const auth = c.get('auth');
+  const passkeys = await withSystemDbAccessContext(() => listActivePasskeys(auth.user.id));
+  if (passkeys.length === 0) {
+    return c.json({ error: 'No passkeys are registered for this account' }, 400);
+  }
+
+  const options = await generatePasskeyAuthenticationOptions({
+    userId: auth.user.id,
+    passkeys: passkeys.map(toStoredCredential)
+  });
+
+  return c.json({ options });
+});
+
+/**
+ * Verify a WebAuthn assertion as proof of an existing passkey factor for the
+ * SR2-20 step-up flow. Loads the caller-owned passkey, verifies against the
+ * stored authentication challenge (from POST /auth/mfa/step-up/options
+ * above), persists the new signature counter (clone detection), and returns
+ * whether it verified. Reused by mfa.ts's POST /auth/mfa/step-up passkey
+ * branch — keeps all WebAuthn machinery inside this module. Never throws on
+ * a challenge/ownership problem (returns false); other errors propagate.
+ */
+export async function verifyStepUpPasskeyAssertion(userId: string, credential: { id?: string }): Promise<boolean> {
+  const [passkey] = await withSystemDbAccessContext(() =>
+    db
+      .select()
+      .from(userPasskeys)
+      .where(eq(userPasskeys.credentialId, credential?.id ?? ''))
+      .limit(1)
+  );
+  if (!passkey || passkey.userId !== userId || passkey.disabledAt) {
+    return false;
+  }
+
+  let verification;
+  try {
+    verification = await verifyPasskeyAuthentication({
+      userId,
+      response: credential as never,
+      passkey: toStoredCredential(passkey)
+    });
+  } catch (err) {
+    if (err instanceof PasskeyChallengeError) return false;
+    throw err;
+  }
+  if (!verification.verified) return false;
+
+  const updateFields = authenticationInfoToPasskeyUpdateFields(verification);
+  await withSystemDbAccessContext(() =>
+    db
+      .update(userPasskeys)
+      .set({ counter: updateFields.counter, lastUsedAt: updateFields.lastUsedAt, updatedAt: new Date() })
+      .where(eq(userPasskeys.id, passkey.id))
+  );
+  return true;
+}
 
 passkeyRoutes.post('/mfa/passkey/options', zValidator('json', passkeyMfaOptionsSchema), async (c) => {
   if (!ENABLE_2FA) {

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -658,7 +658,7 @@ async function getMfaFactorState(auth: AuthContext): Promise<{
     userId: auth.user.id,
     orgId: auth.orgId ?? null,
     partnerId: auth.partnerId ?? null,
-  });
+  }, { failClosed: true });
 
   // This runs inside the DELETE handler's request (user-scoped) context, where
   // a bare `withSystemDbAccessContext` would be a no-op. Escape the active

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -27,8 +27,11 @@ import { readMobileDeviceId } from '../../services/mobileDeviceBinding';
 import { ENABLE_2FA } from './schemas';
 import {
   auditLogin,
+  evaluatePendingMfa,
   getClientIP,
   mfaDisabledResponse,
+  parsePendingMfa,
+  type PendingMfaRecord,
   requireCurrentPasswordStepUp,
   resolveCurrentUserTokenContext,
   setRefreshTokenCookie,
@@ -75,25 +78,13 @@ const deletePasskeySchema = z.object({
   currentPassword: z.string().min(1).max(256)
 });
 
-type PendingPasskeyMfa = {
-  userId: string;
-  mfaMethod: string;
-  // #2153: true when the account has a registered passkey usable as an
-  // alternate second factor, even if the PRIMARY mfaMethod is totp/sms.
-  // Set server-side at login (login.ts) from a system-scoped user_passkeys
-  // read. Absent on pre-#2153 pending tokens → treated as false (falls back
-  // to the old "primary method is passkey" gate, so in-flight sessions during
-  // a deploy don't regress).
-  passkeyAvailable?: boolean;
-};
-
 // A pending MFA session may use the passkey endpoints when passkey is either
 // the account's primary method OR an available alternate factor. Both /options
 // and /verify still independently re-verify that a matching, non-disabled
 // credential is owned by the user and that the WebAuthn assertion checks out,
 // so this gate only decides whether the passkey path is OFFERED — it never
 // substitutes for credential/assertion verification.
-function pendingAllowsPasskey(pending: PendingPasskeyMfa): boolean {
+function pendingAllowsPasskey(pending: PendingMfaRecord): boolean {
   return pending.mfaMethod === 'passkey' || pending.passkeyAvailable === true;
 }
 
@@ -305,6 +296,18 @@ passkeyRoutes.post('/mfa/passkey/verify', zValidator('json', passkeyMfaVerifySch
     return c.json({ error: 'Invalid or expired MFA session' }, 401);
   }
 
+  // SR2-06: re-check the live epoch/status before minting. A factor change
+  // (mfa_epoch) or account-wide security event (auth_epoch) during the
+  // 5-minute MFA window must invalidate this in-flight session.
+  const liveEpochs = await getUserEpochs(user.id);
+  const verdict = liveEpochs
+    ? evaluatePendingMfa(pending, { status: user.status, authEpoch: liveEpochs.authEpoch, mfaEpoch: liveEpochs.mfaEpoch })
+    : ({ ok: false, reason: 'epoch_mismatch' } as const);
+  if (!verdict.ok) {
+    await redis.del(`mfa:pending:${tempToken}`);
+    return c.json({ error: 'Invalid or expired MFA session' }, 401);
+  }
+
   const [passkey] = await withSystemDbAccessContext(() =>
     db
       .select()
@@ -502,32 +505,12 @@ passkeyRoutes.delete('/passkeys/:id', authMiddleware, zValidator('json', deleteP
   return c.json({ success: true });
 });
 
-async function readPendingPasskeyMfa(tempToken: string): Promise<PendingPasskeyMfa | null> {
+async function readPendingPasskeyMfa(tempToken: string): Promise<PendingMfaRecord | null> {
   const redis = getRedis();
-  if (!redis) {
-    return null;
-  }
-
+  if (!redis) return null;
   const raw = await redis.get(`mfa:pending:${tempToken}`);
-  if (!raw) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as Partial<PendingPasskeyMfa>;
-    if (typeof parsed.userId !== 'string') return null;
-    return {
-      userId: parsed.userId,
-      mfaMethod: parsed.mfaMethod || 'totp',
-      passkeyAvailable: parsed.passkeyAvailable === true
-    };
-  } catch {
-    return {
-      userId: raw,
-      mfaMethod: 'totp',
-      passkeyAvailable: false
-    };
-  }
+  if (!raw) return null;
+  return parsePendingMfa(raw);
 }
 
 async function listActivePasskeys(userId: string): Promise<PasskeyRow[]> {

--- a/apps/api/src/routes/auth/phone.test.ts
+++ b/apps/api/src/routes/auth/phone.test.ts
@@ -1,17 +1,58 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
-vi.mock('../../db', () => ({
-  db: {
+// Task 7: `db.transaction` runs its callback with `db` itself as `tx` — the
+// factor-mutating routes fold their write into
+// `invalidateMfaAssuranceAfterFactorChange`'s `mutate(tx)`, and `tx.update`
+// needs the same mock behaviour as the top-level `db.update` this suite
+// already asserts against. The epoch-bump's own
+// `tx.update(users)...returning(...)` gets a valid row by default so
+// `advanceUserEpochs` doesn't throw "user not found" in tests that don't care
+// about the epoch value.
+vi.mock('../../db', () => {
+  const dbMock: any = {
     select: vi.fn(),
     update: vi.fn(() => ({
-      set: vi.fn(() => ({
-        where: vi.fn(() => Promise.resolve())
-      }))
+      set: vi.fn(() => {
+        const whereResult: any = Promise.resolve();
+        whereResult.returning = vi.fn(() =>
+          Promise.resolve([{ authEpoch: 1, mfaEpoch: 2, emailEpoch: 1, passwordResetEpoch: 1 }])
+        );
+        return {
+          where: vi.fn(() => whereResult)
+        };
+      })
     })),
-  },
-  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
-  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  };
+  dbMock.transaction = vi.fn((fn: (tx: unknown) => Promise<unknown>) => fn(dbMock));
+  return {
+    db: dbMock,
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  };
+});
+
+// Keep advanceUserEpochs/revokeAllRefreshFamilies REAL; only
+// runPostCommitCleanup (Redis/permission-cache/OAuth fan-out) is mocked.
+vi.mock('../../services/authLifecycle', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/authLifecycle')>();
+  return {
+    ...actual,
+    runPostCommitCleanup: vi.fn().mockResolvedValue({
+      redisOk: true,
+      permissionCacheOk: true,
+      oauthOk: true,
+      oauthResult: { grantsRevoked: 0, refreshTokensRevoked: 0, jtisRevoked: 0 },
+    }),
+  };
+});
+
+// Mocked (rather than left real) because the real module pulls in agentWs →
+// configurationPolicy → a much bigger `db/schema` surface than this suite's
+// schema mock provides.
+vi.mock('../../services/remoteSessionTeardown', () => ({
+  TEARDOWN_FAILED: -1,
+  terminateUserRemoteSessions: vi.fn().mockResolvedValue(0),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/auth/phone.test.ts
+++ b/apps/api/src/routes/auth/phone.test.ts
@@ -115,13 +115,17 @@ vi.mock('./helpers', () => ({
   resolveUserAuditOrgId: vi.fn(async () => 'org-1'),
   writeAuthAudit: vi.fn(),
   requireCurrentPasswordStepUp: vi.fn(async () => null),
+  // SR2-20: default = "not already protected" (initial enrollment), matching
+  // this suite's default account state. Individual tests override via
+  // mockResolvedValueOnce to exercise the already-protected gate.
+  enforceExistingFactorStepUp: vi.fn(async () => null),
 }));
 
 import { phoneRoutes } from './phone';
 import { db } from '../../db';
 import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
 import { getTwilioService } from '../../services/twilio';
-import { writeAuthAudit } from './helpers';
+import { writeAuthAudit, enforceExistingFactorStepUp } from './helpers';
 
 function selectChain(rows: unknown[]) {
   return {
@@ -193,6 +197,57 @@ describe('phone routes', () => {
       const body = await res.json();
       expect(body.success).toBe(true);
       expect(db.update).toHaveBeenCalled();
+    });
+
+    // SR2-20: adding SMS as a NEW factor on an ALREADY-PROTECTED account
+    // additionally requires a fresh existing-factor step-up grant.
+    it('rejects with 403 when the account is already protected and no step-up grant is presented', async () => {
+      mockVerifiedUnenrolledUser();
+      vi.mocked(getEffectiveMfaPolicy).mockResolvedValue({
+        required: false,
+        allowedMethods: { totp: true, sms: true, passkey: true },
+        source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: true },
+      });
+      vi.mocked(enforceExistingFactorStepUp).mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'existing_factor_step_up_required', stepUpUrl: '/auth/mfa/step-up' }), {
+          status: 403,
+        }) as any
+      );
+
+      const res = await app.request('/auth/mfa/sms/enable', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ currentPassword: 'correct-password' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('allows enabling SMS MFA on an already-protected account when a valid step-up grant is presented', async () => {
+      mockVerifiedUnenrolledUser();
+      vi.mocked(getEffectiveMfaPolicy).mockResolvedValue({
+        required: false,
+        allowedMethods: { totp: true, sms: true, passkey: true },
+        source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: true },
+      });
+      vi.mocked(enforceExistingFactorStepUp).mockResolvedValueOnce(null);
+
+      const res = await app.request('/auth/mfa/sms/enable', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ currentPassword: 'correct-password', stepUpGrantId: 'grant-1' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(enforceExistingFactorStepUp).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'grant-1',
+        { consume: true }
+      );
     });
   });
 

--- a/apps/api/src/routes/auth/phone.test.ts
+++ b/apps/api/src/routes/auth/phone.test.ts
@@ -328,5 +328,74 @@ describe('phone routes', () => {
         })
       );
     });
+
+    // C1 (exploit-chain half 2 — the /phone/confirm step-up gate). Before this
+    // fix, /phone/confirm swapped the phone behind a PASSWORD ONLY, letting a
+    // stolen-token + phished-password attacker plant their own number (which
+    // then satisfied the SMS step-up). It must now consume an existing-factor
+    // grant for an already-protected account, and block the phone write when
+    // no valid grant is presented.
+    it('C1: rejects a phone swap on an already-protected account when no step-up grant is presented — phone never written', async () => {
+      // Gate denies (no grant on a protected account).
+      vi.mocked(enforceExistingFactorStepUp).mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'existing_factor_step_up_required', stepUpUrl: '/auth/mfa/step-up' }), {
+          status: 403,
+        }) as any
+      );
+      // Twilio would approve if ever reached — proving the block is the gate,
+      // not a bad code.
+      const checkVerificationCode = vi.fn().mockResolvedValue({ valid: true, serviceError: false });
+      vi.mocked(getTwilioService).mockReturnValue({
+        sendVerificationCode: vi.fn(),
+        checkVerificationCode,
+      } as any);
+
+      const res = await app.request('/auth/phone/confirm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          phoneNumber: '+15555550999', // attacker's number
+          code: '123456',
+          currentPassword: 'correct-password',
+        }),
+      });
+
+      expect(res.status).toBe(403);
+      // The gate must run BEFORE the code check and BEFORE any write.
+      expect(checkVerificationCode).not.toHaveBeenCalled();
+      expect(db.update).not.toHaveBeenCalled();
+      expect(db.transaction).not.toHaveBeenCalled();
+      expect(enforceExistingFactorStepUp).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        { consume: true }
+      );
+    });
+
+    it('C1: allows a phone change on an already-protected account when a valid step-up grant is presented', async () => {
+      vi.mocked(enforceExistingFactorStepUp).mockResolvedValueOnce(null);
+      mockCurrentFactorRow({ mfaEnabled: true, mfaMethod: 'sms' });
+      mockValidCode();
+
+      const res = await app.request('/auth/phone/confirm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          phoneNumber: '+15555550100',
+          code: '123456',
+          currentPassword: 'correct-password',
+          stepUpGrantId: 'grant-1',
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(enforceExistingFactorStepUp).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'grant-1',
+        { consume: true }
+      );
+    });
   });
 });

--- a/apps/api/src/routes/auth/phone.test.ts
+++ b/apps/api/src/routes/auth/phone.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => Promise.resolve())
+      }))
+    })),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', () => ({
+  users: {
+    id: 'users.id',
+    phoneNumber: 'users.phoneNumber',
+    phoneVerified: 'users.phoneVerified',
+    mfaEnabled: 'users.mfaEnabled',
+    mfaMethod: 'users.mfaMethod',
+    mfaSecret: 'users.mfaSecret',
+    mfaRecoveryCodes: 'users.mfaRecoveryCodes',
+  },
+  organizations: {
+    id: 'organizations.id',
+    settings: 'organizations.settings',
+  },
+}));
+
+vi.mock('../../services', () => ({
+  generateRecoveryCodes: vi.fn(() => ['CODE-1', 'CODE-2']),
+  rateLimiter: vi.fn(async () => ({ allowed: true, resetAt: new Date(Date.now() + 60_000) })),
+  getRedis: vi.fn(() => ({})),
+  smsPhoneVerifyLimiter: { limit: 5, windowSeconds: 300 },
+  smsPhoneVerifyUserLimiter: { limit: 5, windowSeconds: 300 },
+  smsLoginSendLimiter: { limit: 5, windowSeconds: 300 },
+  smsLoginGlobalLimiter: { limit: 100, windowSeconds: 300 },
+  phoneConfirmLimiter: { limit: 5, windowSeconds: 300 },
+}));
+
+vi.mock('../../services/twilio', () => ({
+  getTwilioService: vi.fn(() => ({
+    sendVerificationCode: vi.fn(),
+    checkVerificationCode: vi.fn(),
+  })),
+}));
+
+// The boundary under test: phone.ts must consult the resolver for the
+// canonical allowedMethods.sms flag rather than reading the dead
+// `security.allowedMfaMethods` key directly off the org row.
+vi.mock('../../services/mfaPolicy', () => ({
+  getEffectiveMfaPolicy: vi.fn(),
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: () => unknown) => {
+    c.set('auth', {
+      scope: 'organization',
+      partnerId: null,
+      orgId: 'org-1',
+      user: { id: 'user-1', email: 'user@example.test', name: 'Sample User' },
+      token: { sid: 'family-1' },
+    });
+    return next();
+  }),
+}));
+
+vi.mock('./helpers', () => ({
+  mfaDisabledResponse: vi.fn((c: any) => c.json({ error: 'Not Found' }, 404)),
+  hashRecoveryCodes: vi.fn((codes: string[]) => codes.map((code) => `hashed-${code}`)),
+  resolveUserAuditOrgId: vi.fn(async () => 'org-1'),
+  writeAuthAudit: vi.fn(),
+  requireCurrentPasswordStepUp: vi.fn(async () => null),
+}));
+
+import { phoneRoutes } from './phone';
+import { db } from '../../db';
+import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
+
+function selectChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+describe('phone routes', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/auth', phoneRoutes);
+  });
+
+  describe('POST /auth/mfa/sms/enable', () => {
+    function mockVerifiedUnenrolledUser() {
+      vi.mocked(db.select).mockReturnValue(
+        selectChain([{ phoneNumber: '+15555550100', phoneVerified: true, mfaEnabled: false }]) as any
+      );
+    }
+
+    it('rejects with 403 when the resolved policy disallows SMS', async () => {
+      mockVerifiedUnenrolledUser();
+      vi.mocked(getEffectiveMfaPolicy).mockResolvedValue({
+        required: false,
+        allowedMethods: { totp: true, sms: false, passkey: true },
+        source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: true },
+      });
+
+      const res = await app.request('/auth/mfa/sms/enable', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ currentPassword: 'correct-password' }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('Your organization does not allow SMS MFA');
+      expect(getEffectiveMfaPolicy).toHaveBeenCalledWith({
+        scope: 'organization',
+        userId: 'user-1',
+        orgId: 'org-1',
+        partnerId: null,
+      });
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('allows enabling SMS MFA when the resolved policy permits it', async () => {
+      mockVerifiedUnenrolledUser();
+      vi.mocked(getEffectiveMfaPolicy).mockResolvedValue({
+        required: false,
+        allowedMethods: { totp: true, sms: true, passkey: true },
+        source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: true },
+      });
+
+      const res = await app.request('/auth/mfa/sms/enable', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ currentPassword: 'correct-password' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(db.update).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/routes/auth/phone.test.ts
+++ b/apps/api/src/routes/auth/phone.test.ts
@@ -120,6 +120,8 @@ vi.mock('./helpers', () => ({
 import { phoneRoutes } from './phone';
 import { db } from '../../db';
 import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
+import { getTwilioService } from '../../services/twilio';
+import { writeAuthAudit } from './helpers';
 
 function selectChain(rows: unknown[]) {
   return {
@@ -191,6 +193,85 @@ describe('phone routes', () => {
       const body = await res.json();
       expect(body.success).toBe(true);
       expect(db.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /auth/phone/confirm', () => {
+    // Task 7 regression guard (SR2-19): invalidation is REPLACEMENT-ONLY.
+    // It must fire when the caller already has an ACTIVE SMS factor
+    // (mfaEnabled && mfaMethod === 'sms'), and must NOT fire during initial
+    // SMS enrollment (no active SMS factor yet) — firing there would sign
+    // the user out mid-enrollment before they ever reach /mfa/sms/enable.
+    function mockCurrentFactorRow(row: { mfaEnabled: boolean; mfaMethod: string | null }) {
+      vi.mocked(db.select).mockReturnValue(selectChain([row]) as any);
+    }
+
+    function mockValidCode() {
+      vi.mocked(getTwilioService).mockReturnValue({
+        sendVerificationCode: vi.fn(),
+        checkVerificationCode: vi.fn().mockResolvedValue({ valid: true, serviceError: false }),
+      } as any);
+    }
+
+    function confirmRequest() {
+      return app.request('/auth/phone/confirm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          phoneNumber: '+15555550100',
+          code: '123456',
+          currentPassword: 'correct-password',
+        }),
+      });
+    }
+
+    it('invalidates MFA assurance when replacing an already-active SMS factor', async () => {
+      mockCurrentFactorRow({ mfaEnabled: true, mfaMethod: 'sms' });
+      mockValidCode();
+
+      const res = await confirmRequest();
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.message).toBe('Phone number verified');
+
+      // Routes through invalidateMfaAssuranceAfterFactorChange, which folds
+      // its write into db.transaction rather than a bare db.update.
+      expect(db.transaction).toHaveBeenCalled();
+
+      expect(writeAuthAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'auth.phone.verify.confirmed',
+          details: expect.objectContaining({ smsFactorReplacement: true }),
+        })
+      );
+    });
+
+    it('does NOT invalidate MFA assurance during initial SMS enrollment (no active SMS factor)', async () => {
+      mockCurrentFactorRow({ mfaEnabled: false, mfaMethod: null });
+      mockValidCode();
+
+      const res = await confirmRequest();
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.message).toBe('Phone number verified');
+
+      // Must NOT route through the invalidation transaction — that would
+      // sign the user out mid-enrollment before /mfa/sms/enable ever runs.
+      expect(db.transaction).not.toHaveBeenCalled();
+      expect(db.update).toHaveBeenCalled();
+
+      expect(writeAuthAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'auth.phone.verify.confirmed',
+          details: expect.not.objectContaining({ smsFactorReplacement: true }),
+        })
+      );
     });
   });
 });

--- a/apps/api/src/routes/auth/phone.ts
+++ b/apps/api/src/routes/auth/phone.ts
@@ -15,6 +15,8 @@ import {
 } from '../../services';
 import { getTwilioService } from '../../services/twilio';
 import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
+import { invalidateMfaAssuranceAfterFactorChange } from '../../services/mfaAssurance';
+import { TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
 import { authMiddleware } from '../../middleware/auth';
 import { ENABLE_2FA, phoneVerifySchema, phoneConfirmSchema, smsSendSchema, smsMfaEnableSchema } from './schemas';
 import {
@@ -147,15 +149,33 @@ phoneRoutes.post('/phone/confirm', authMiddleware, zValidator('json', phoneConfi
     return c.json({ error: 'Invalid verification code' }, 401);
   }
 
-  // Update user with verified phone
-  await db
-    .update(users)
-    .set({
-      phoneNumber,
-      phoneVerified: true,
-      updatedAt: new Date()
-    })
-    .where(eq(users.id, auth.user.id));
+  // Replacement-only invalidation: initial SMS phone verification (before
+  // /mfa/sms/enable has ever run) must NOT sign the user out mid-flow — they
+  // still need to complete enrollment. Only a phone number REPLACEMENT behind
+  // an already-ACTIVE SMS factor is a security-relevant factor change (the
+  // old number could otherwise keep receiving MFA codes for a session that
+  // predates the swap), so only that case invalidates assurance.
+  const [cur] = await db
+    .select({ mfaEnabled: users.mfaEnabled, mfaMethod: users.mfaMethod })
+    .from(users)
+    .where(eq(users.id, auth.user.id))
+    .limit(1);
+  const isSmsFactorReplacement = cur?.mfaEnabled === true && cur.mfaMethod === 'sms';
+
+  let assuranceResult: Awaited<ReturnType<typeof invalidateMfaAssuranceAfterFactorChange>> | null = null;
+  if (isSmsFactorReplacement) {
+    assuranceResult = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'phone-replacement', async (tx) => {
+      await tx
+        .update(users)
+        .set({ phoneNumber, phoneVerified: true, updatedAt: new Date() })
+        .where(eq(users.id, auth.user.id));
+    });
+  } else {
+    await db
+      .update(users)
+      .set({ phoneNumber, phoneVerified: true, updatedAt: new Date() })
+      .where(eq(users.id, auth.user.id));
+  }
 
   writeAuthAudit(c, {
     orgId: orgId ?? undefined,
@@ -163,7 +183,16 @@ phoneRoutes.post('/phone/confirm', authMiddleware, zValidator('json', phoneConfi
     result: 'success',
     userId: auth.user.id,
     email: auth.user.email,
-    details: { phoneLast4: phoneNumber.slice(-4) }
+    details: {
+      phoneLast4: phoneNumber.slice(-4),
+      ...(assuranceResult
+        ? {
+            smsFactorReplacement: true,
+            mfaEpoch: assuranceResult.mfaEpoch,
+            teardownFailed: assuranceResult.remoteSessionsTerminated === TEARDOWN_FAILED
+          }
+        : {})
+    }
   });
 
   return c.json({ success: true, message: 'Phone number verified' });
@@ -221,16 +250,18 @@ phoneRoutes.post('/mfa/sms/enable', authMiddleware, zValidator('json', smsMfaEna
   const recoveryCodes = generateRecoveryCodes();
 
   // Enable SMS MFA
-  await db
-    .update(users)
-    .set({
-      mfaEnabled: true,
-      mfaMethod: 'sms',
-      mfaSecret: null,
-      mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes),
-      updatedAt: new Date()
-    })
-    .where(eq(users.id, auth.user.id));
+  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'sms-mfa-enable', async (tx) => {
+    await tx
+      .update(users)
+      .set({
+        mfaEnabled: true,
+        mfaMethod: 'sms',
+        mfaSecret: null,
+        mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes),
+        updatedAt: new Date()
+      })
+      .where(eq(users.id, auth.user.id));
+  });
 
   const orgId = await resolveUserAuditOrgId(auth.user.id);
   writeAuthAudit(c, {
@@ -239,7 +270,7 @@ phoneRoutes.post('/mfa/sms/enable', authMiddleware, zValidator('json', smsMfaEna
     result: 'success',
     userId: auth.user.id,
     email: auth.user.email,
-    details: { method: 'sms' }
+    details: { method: 'sms', mfaEpoch: result.mfaEpoch, teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED }
   });
 
   return c.json({ success: true, recoveryCodes, message: 'SMS MFA enabled successfully' });

--- a/apps/api/src/routes/auth/phone.ts
+++ b/apps/api/src/routes/auth/phone.ts
@@ -104,10 +104,18 @@ phoneRoutes.post('/phone/confirm', authMiddleware, zValidator('json', phoneConfi
   }
 
   const auth = c.get('auth');
-  const { phoneNumber, code, currentPassword } = c.req.valid('json');
+  const { phoneNumber, code, currentPassword, stepUpGrantId } = c.req.valid('json');
 
   const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd');
   if (passwordError) return passwordError;
+
+  // SR2-20/C1: replacing/verifying the phone on an ALREADY-PROTECTED account is
+  // a factor-affecting change and must additionally prove an existing factor —
+  // otherwise a stolen access token + phished password could swap in the
+  // attacker's number (which then satisfies the SMS step-up). No-op for initial
+  // enrollment (no factor yet → password-only, per enforceExistingFactorStepUp).
+  const stepUpError = await enforceExistingFactorStepUp(c, auth, stepUpGrantId, { consume: true });
+  if (stepUpError) return stepUpError;
 
   const twilio = getTwilioService();
   if (!twilio) {

--- a/apps/api/src/routes/auth/phone.ts
+++ b/apps/api/src/routes/auth/phone.ts
@@ -24,7 +24,8 @@ import {
   hashRecoveryCodes,
   resolveUserAuditOrgId,
   writeAuthAudit,
-  requireCurrentPasswordStepUp
+  requireCurrentPasswordStepUp,
+  enforceExistingFactorStepUp
 } from './helpers';
 
 const { db, withSystemDbAccessContext } = dbModule;
@@ -205,10 +206,15 @@ phoneRoutes.post('/mfa/sms/enable', authMiddleware, zValidator('json', smsMfaEna
   }
 
   const auth = c.get('auth');
-  const { currentPassword } = c.req.valid('json');
+  const { currentPassword, stepUpGrantId } = c.req.valid('json');
 
   const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd');
   if (passwordError) return passwordError;
+
+  // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
+  // requires a fresh existing-factor proof (no-op for initial enrollment).
+  const stepUpError = await enforceExistingFactorStepUp(c, auth, stepUpGrantId, { consume: true });
+  if (stepUpError) return stepUpError;
 
   const [user] = await db
     .select({

--- a/apps/api/src/routes/auth/phone.ts
+++ b/apps/api/src/routes/auth/phone.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import * as dbModule from '../../db';
-import { users, organizations } from '../../db/schema';
+import { users } from '../../db/schema';
 import {
   generateRecoveryCodes,
   rateLimiter,
@@ -14,6 +14,7 @@ import {
   phoneConfirmLimiter
 } from '../../services';
 import { getTwilioService } from '../../services/twilio';
+import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
 import { authMiddleware } from '../../middleware/auth';
 import { ENABLE_2FA, phoneVerifySchema, phoneConfirmSchema, smsSendSchema, smsMfaEnableSchema } from './schemas';
 import {
@@ -202,18 +203,18 @@ phoneRoutes.post('/mfa/sms/enable', authMiddleware, zValidator('json', smsMfaEna
     return c.json({ error: 'MFA is already enabled. Disable it first to switch methods.' }, 400);
   }
 
-  // Check org policy — is SMS allowed?
-  if (auth.orgId) {
-    const [org] = await db
-      .select({ settings: organizations.settings })
-      .from(organizations)
-      .where(eq(organizations.id, auth.orgId))
-      .limit(1);
-
-    const orgSettings = org?.settings as { security?: { allowedMfaMethods?: { sms?: boolean } } } | null;
-    if (orgSettings?.security?.allowedMfaMethods && !orgSettings.security.allowedMfaMethods.sms) {
-      return c.json({ error: 'Your organization does not allow SMS MFA' }, 403);
-    }
+  // Enforce the CANONICAL allowlist through the resolver (partner-inherited).
+  // The old reader consulted `security.allowedMfaMethods`, a spelling that is
+  // written nowhere → the SMS restriction silently no-opped. Passkey is always
+  // allowed; only totp/sms are gated by effective settings.
+  const policy = await getEffectiveMfaPolicy({
+    scope: auth.scope,
+    userId: auth.user.id,
+    orgId: auth.orgId ?? null,
+    partnerId: auth.partnerId ?? null,
+  });
+  if (!policy.allowedMethods.sms) {
+    return c.json({ error: 'Your organization does not allow SMS MFA' }, 403);
   }
 
   // Generate recovery codes

--- a/apps/api/src/routes/auth/schemas.test.ts
+++ b/apps/api/src/routes/auth/schemas.test.ts
@@ -1,4 +1,35 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mfaVerifySchema } from './schemas';
+
+// SR2-09: mfaVerifySchema must accept a 6-digit TOTP/SMS code OR the
+// `XXXX-XXXX` recovery-code form, and the `method` enum must include
+// 'recovery'. The handler (mfa.ts) routes on `method`, not on shape alone.
+describe('mfaVerifySchema (SR2-09 recovery-code login)', () => {
+  it('accepts a 6-digit code with method: totp', () => {
+    const result = mfaVerifySchema.safeParse({ code: '123456', method: 'totp' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an XXXX-XXXX recovery code with method: recovery', () => {
+    const result = mfaVerifySchema.safeParse({ code: 'ABCD-2345', method: 'recovery' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a lowercase recovery code (normalization happens in the handler)', () => {
+    const result = mfaVerifySchema.safeParse({ code: 'abcd-2345', method: 'recovery' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a code that is neither 6 digits nor XXXX-XXXX', () => {
+    const result = mfaVerifySchema.safeParse({ code: 'not-a-code' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a method outside totp/sms/recovery', () => {
+    const result = mfaVerifySchema.safeParse({ code: '123456', method: 'push' });
+    expect(result.success).toBe(false);
+  });
+});
 
 describe('auth feature flag defaults', () => {
   const originalEnableRegistration = process.env.ENABLE_REGISTRATION;

--- a/apps/api/src/routes/auth/schemas.ts
+++ b/apps/api/src/routes/auth/schemas.ts
@@ -42,10 +42,17 @@ export const registerPartnerSchema = z.object({
   })
 });
 
+// TOTP/SMS codes are 6 digits; recovery codes are `XXXX-XXXX` (8 [A-Z0-9]
+// with a hyphen). Accept either shape here; the handler routes on `method`.
+const totpOrSmsCode = /^\d{6}$/;
+const recoveryCode = /^[A-Z0-9]{4}-[A-Z0-9]{4}$/i;
 export const mfaVerifySchema = z.object({
-  code: z.string().length(6),
+  code: z.string().refine(
+    (v) => totpOrSmsCode.test(v.trim()) || recoveryCode.test(v.trim()),
+    { message: 'Invalid code format' },
+  ),
   tempToken: z.string().optional(),
-  method: z.enum(['totp', 'sms']).optional()
+  method: z.enum(['totp', 'sms', 'recovery']).optional(),
 });
 
 export const phoneVerifySchema = z.object({

--- a/apps/api/src/routes/auth/schemas.ts
+++ b/apps/api/src/routes/auth/schemas.ts
@@ -67,7 +67,13 @@ export const phoneVerifySchema = z.object({
 export const phoneConfirmSchema = z.object({
   phoneNumber: z.string().regex(/^\+[1-9]\d{6,14}$/),
   code: z.string().length(6),
-  currentPassword: z.string().min(1).max(256)
+  currentPassword: z.string().min(1).max(256),
+  // SR2-20/C1: an ALREADY-PROTECTED account cannot verify/replace its phone
+  // with a password alone — that would let a stolen-token + phished-password
+  // attacker swap in their own number and then pass the SMS step-up. Required
+  // (via enforceExistingFactorStepUp) only when a factor already exists; initial
+  // enrollment (no factor yet) still passes password-only.
+  stepUpGrantId: z.string().optional()
 });
 
 export const smsMfaEnableSchema = z.object({

--- a/apps/api/src/routes/auth/schemas.ts
+++ b/apps/api/src/routes/auth/schemas.ts
@@ -53,6 +53,10 @@ export const mfaVerifySchema = z.object({
   ),
   tempToken: z.string().optional(),
   method: z.enum(['totp', 'sms', 'recovery']).optional(),
+  // SR2-20: presented on setup-confirm (Case 2 — no tempToken) so an
+  // already-protected account's TOTP-add can satisfy the existing-factor
+  // step-up gate. Ignored on Case 1 (login completion).
+  stepUpGrantId: z.string().optional(),
 });
 
 export const phoneVerifySchema = z.object({
@@ -67,7 +71,10 @@ export const phoneConfirmSchema = z.object({
 });
 
 export const smsMfaEnableSchema = z.object({
-  currentPassword: z.string().min(1).max(256)
+  currentPassword: z.string().min(1).max(256),
+  // SR2-20: existing-factor step-up grant required when the account is
+  // already MFA-protected (see enforceExistingFactorStepUp in ./helpers).
+  stepUpGrantId: z.string().optional()
 });
 
 export const smsSendSchema = z.object({
@@ -91,6 +98,21 @@ export const changePasswordSchema = z.object({
 export const mfaEnableSchema = z.object({
   code: z.string().length(6)
 });
+
+// SR2-20: `POST /auth/mfa/step-up` proof-of-existing-factor request. Accepts
+// ALL factor types (not just the account's primary method) so a passkey-only
+// user is never locked out of adding a second factor. The passkey assertion
+// is shape-checked here only (`.passthrough()`) and cryptographically
+// verified downstream by verifyPasskeyAuthentication (passkeys.ts) — this
+// file deliberately does NOT import passkeys.ts's webAuthnCredentialSchema to
+// avoid a schemas.ts <-> passkeys.ts import cycle.
+const stepUpSixDigit = z.string().refine((v) => /^\d{6}$/.test(v.trim()), { message: 'Invalid code' });
+const stepUpAssertion = z.object({ id: z.string().min(1) }).passthrough();
+export const mfaStepUpSchema = z.discriminatedUnion('method', [
+  z.object({ method: z.literal('totp'), code: stepUpSixDigit }),
+  z.object({ method: z.literal('sms'), code: stepUpSixDigit }),
+  z.object({ method: z.literal('passkey'), credential: stepUpAssertion }),
+]);
 
 export const acceptInviteSchema = z.object({
   token: z.string().min(1),

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -695,6 +695,57 @@ describe('org routes', () => {
       });
     });
 
+    // SR2-05: the system-scoped wholesale settings write is a THIRD write path
+    // (alongside the org-settings write and PATCH /partners/me) that must fold
+    // the legacy `security.allowedMfaMethods` alias into the canonical
+    // `security.allowedMethods` — updatePartnerSchema's `settings: z.any()`
+    // means nothing else strips or canonicalizes the alias key before it hits
+    // the db.update(..).set(...) call.
+    describe('settings.security.allowedMfaMethods alias (system scope)', () => {
+      function mockCurrentPartnerSelect(settings: Record<string, unknown>) {
+        vi.mocked(db.select).mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([])
+              }),
+              limit: vi.fn().mockResolvedValue([{ id: 'partner-1', name: 'P', settings }])
+            })
+          })
+        } as any);
+      }
+
+      function mockUpdateCapture() {
+        let captured: any;
+        vi.mocked(db.update).mockReturnValue({
+          set: vi.fn().mockImplementation((data: any) => {
+            captured = data;
+            return {
+              where: vi.fn().mockReturnValue({
+                returning: vi.fn().mockResolvedValue([{ id: 'partner-1', name: 'P', settings: data.settings }])
+              })
+            };
+          })
+        } as any);
+        return () => captured;
+      }
+
+      it('folds the legacy security.allowedMfaMethods alias into allowedMethods and does not persist the alias', async () => {
+        mockCurrentPartnerSelect({});
+        const getCaptured = mockUpdateCapture();
+
+        const res = await app.request('/orgs/partners/partner-1', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ settings: { security: { allowedMfaMethods: { sms: false } } } })
+        });
+
+        expect(res.status).toBe(200);
+        expect(getCaptured().settings.security.allowedMethods.sms).toBe(false);
+        expect(getCaptured().settings.security.allowedMfaMethods).toBeUndefined();
+      });
+    });
+
     // aiForOfficeEnabled — operator-only entitlement flag.
     // The field must flow through updatePartnerSchema → the db.update(..).set(...)
     // call unchanged. The partner-scope /partners/me route uses a separate

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -1597,6 +1597,44 @@ describe('org routes', () => {
       expect(db.update).toHaveBeenCalled();
     });
 
+    // SR2-05: `security.allowedMfaMethods` is a legacy input alias — it must be
+    // folded into the canonical `security.allowedMethods` before the write and
+    // never persisted as a second key (the dead spelling the SMS-enable reader
+    // used to consult, silently no-opping the restriction).
+    it('folds the legacy security.allowedMfaMethods alias into allowedMethods and does not persist the alias', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      // assertNotLocked('security', ['allowedMethods']) needs an org row (for
+      // partnerId) and a partner row (for its settings) — an empty partner
+      // settings object means nothing is locked.
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue(Promise.resolve([{ partnerId: 'partner-123', settings: {} }]))
+        })
+      } as any);
+
+      let capturedUpdateData: any;
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockImplementation((data: any) => {
+          capturedUpdateData = data;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'org-1', name: 'O' }])
+            })
+          };
+        })
+      } as any);
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { security: { allowedMfaMethods: { sms: false } } } })
+      });
+
+      expect(res.status).toBe(200);
+      expect(capturedUpdateData.settings.security.allowedMethods.sms).toBe(false);
+      expect(capturedUpdateData.settings.security.allowedMfaMethods).toBeUndefined();
+    });
+
     it('should allow system scope updates without partnerId context', async () => {
       setAuthContext({ scope: 'system', partnerId: null });
       vi.mocked(db.update).mockReturnValue({

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -31,6 +31,27 @@ import { registerOrgPortalSettingsRoutes } from './orgPortalSettings';
 import { registerOrgPortalUsersRoutes } from './orgPortalUsers';
 import { registerOrgTicketSettingsRoutes } from './orgTicketSettings';
 
+/**
+ * Fold the legacy `security.allowedMfaMethods` input alias into the canonical
+ * `security.allowedMethods` and drop the alias key so it is never persisted.
+ * Canonical wins on conflict. Mutates and returns the same settings object.
+ */
+function foldAllowedMfaMethodsAlias(settings: unknown): unknown {
+  if (!settings || typeof settings !== 'object') return settings;
+  const s = settings as Record<string, unknown>;
+  const security = s.security;
+  if (!security || typeof security !== 'object') return settings;
+  const sec = security as Record<string, unknown>;
+  if (sec.allowedMfaMethods && typeof sec.allowedMfaMethods === 'object') {
+    sec.allowedMethods = {
+      ...(sec.allowedMfaMethods as Record<string, unknown>),
+      ...((sec.allowedMethods as Record<string, unknown> | undefined) ?? {}),
+    };
+    delete sec.allowedMfaMethods;
+  }
+  return settings;
+}
+
 export const orgRoutes = new Hono();
 const requireOrgRead = requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action);
 const requireOrgWrite = requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action);
@@ -385,6 +406,10 @@ const partnerSettingsSchema = z.object({
     expirationDays: z.number().int().min(0).optional(),
     requireMfa: z.boolean().optional(),
     allowedMethods: z.object({ totp: z.boolean().optional(), sms: z.boolean().optional() }).optional(),
+    // Legacy input alias. Accepted so older clients don't 400, folded into
+    // `allowedMethods` at write time (foldAllowedMfaMethodsAlias) and never
+    // persisted as a second source of truth.
+    allowedMfaMethods: z.object({ totp: z.boolean().optional(), sms: z.boolean().optional() }).optional(),
     sessionTimeout: z.number().int().min(1).optional(),
     maxSessions: z.number().int().min(1).optional(),
     ipAllowlist: z
@@ -617,6 +642,7 @@ orgRoutes.patch(
   // (fail-open). Incoming security fields still override individually, and an
   // explicit `ipAllowlist: []` still clears the list deliberately.
   if (body.settings?.security) {
+    foldAllowedMfaMethodsAlias(body.settings); // canonicalize before deep-merge
     newSettings.security = {
       ...((currentSettings.security as Record<string, unknown> | undefined) ?? {}),
       ...body.settings.security,
@@ -1237,6 +1263,7 @@ const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWrite, re
 
   if (data.settings) {
     const settingsObj = data.settings as Record<string, unknown>;
+    foldAllowedMfaMethodsAlias(data.settings);
 
     // Reject a malformed agent-update maintenance window before any DB work
     // (issue #1963). This is the path getOrgAgentUpdatePolicy reads, so without

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -815,6 +815,15 @@ orgRoutes.patch('/partners/:id', requireScope('system'), requireOrgWrite, requir
   }
 
   if (updates.settings !== undefined) {
+    // Fold the legacy `security.allowedMfaMethods` alias into the canonical
+    // `security.allowedMethods` before anything else touches settings. This
+    // is a wholesale-replace path (updatePartnerSchema uses `settings: z.any()`),
+    // so without this fold a caller sending the alias key here would persist
+    // it verbatim as a second, un-canonicalized key — the resolver only reads
+    // `security.allowedMethods`, so that would silently no-op the MFA-method
+    // change (see foldAllowedMfaMethodsAlias above).
+    updates.settings = foldAllowedMfaMethodsAlias(updates.settings);
+
     // Wholesale settings write: keep an active security.ipAllowlist unless the
     // caller explicitly clears it (see preserveIpAllowlistOnOmit).
     if (updates.settings && typeof updates.settings === 'object' && !Array.isArray(updates.settings)) {

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -314,6 +314,11 @@ orgRoutes.get('/partners', requireScope('system'), requireOrgRead, zValidator('q
 orgRoutes.post('/partners', requireScope('system'), requireOrgWrite, requireMfa(), zValidator('json', createPartnerSchema), async (c) => {
   const auth = c.get('auth');
   const data = c.req.valid('json');
+  // M8: fold the legacy `security.allowedMfaMethods` alias into the canonical
+  // `security.allowedMethods` on CREATE too — the update paths already do, and
+  // without this a create carrying the alias persists a key the resolver ignores
+  // (silent no-op the alias-fold set out to kill).
+  data.settings = foldAllowedMfaMethodsAlias(data.settings);
 
   const clash = await db
     .select({ id: partners.id })
@@ -1164,6 +1169,8 @@ orgRoutes.patch(
 orgRoutes.post('/organizations', requireScope('partner', 'system'), requireOrgWrite, requireMfa(), zValidator('json', createOrganizationSchema), async (c) => {
   const auth = c.get('auth');
   const data = c.req.valid('json');
+  // M8: canonicalize the MFA allowed-methods alias on CREATE (see /partners).
+  data.settings = foldAllowedMfaMethodsAlias(data.settings);
 
   let targetPartnerId: string | null = null;
 

--- a/apps/api/src/services/index.ts
+++ b/apps/api/src/services/index.ts
@@ -19,3 +19,5 @@ export * from './refreshTokenFamily';
 export * from './clientIp';
 export { getUserEpochs } from './authEpochs';
 export { getRefreshFamily } from './refreshTokenFamily';
+export { getEffectiveMfaPolicy } from './mfaPolicy';
+export type { EffectiveMfaPolicy, MfaPolicyInput, MfaAllowedMethods } from './mfaPolicy';

--- a/apps/api/src/services/mfaAssurance.test.ts
+++ b/apps/api/src/services/mfaAssurance.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  dbTransactionMock,
+  advanceUserEpochsMock,
+  revokeAllRefreshFamiliesMock,
+  runPostCommitCleanupMock,
+  terminateUserRemoteSessionsMock,
+} = vi.hoisted(() => ({
+  dbTransactionMock: vi.fn(),
+  advanceUserEpochsMock: vi.fn(),
+  revokeAllRefreshFamiliesMock: vi.fn(),
+  runPostCommitCleanupMock: vi.fn(),
+  terminateUserRemoteSessionsMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    transaction: dbTransactionMock,
+  },
+}));
+
+vi.mock('./authLifecycle', () => ({
+  advanceUserEpochs: advanceUserEpochsMock,
+  revokeAllRefreshFamilies: revokeAllRefreshFamiliesMock,
+  runPostCommitCleanup: runPostCommitCleanupMock,
+}));
+
+vi.mock('./remoteSessionTeardown', () => ({
+  terminateUserRemoteSessions: terminateUserRemoteSessionsMock,
+  TEARDOWN_FAILED: -1,
+}));
+
+import { invalidateMfaAssuranceAfterFactorChange } from './mfaAssurance';
+import { TEARDOWN_FAILED } from './remoteSessionTeardown';
+
+describe('invalidateMfaAssuranceAfterFactorChange', () => {
+  const userId = 'user-123';
+  const fakeTx = { marker: 'tx' } as unknown;
+  const epochRow = { authEpoch: 1, mfaEpoch: 2, emailEpoch: 1, passwordResetEpoch: 1 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbTransactionMock.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => fn(fakeTx));
+    advanceUserEpochsMock.mockResolvedValue(epochRow);
+    revokeAllRefreshFamiliesMock.mockResolvedValue(undefined);
+    runPostCommitCleanupMock.mockResolvedValue({ redisOk: true, permissionCacheOk: true, oauthOk: true });
+    terminateUserRemoteSessionsMock.mockResolvedValue(3);
+  });
+
+  // (a) mutate runs inside the tx before advanceUserEpochs/revokeAllRefreshFamilies.
+  it('runs mutate(tx) inside the transaction before advancing epochs and revoking families, then post-commit cleanup + teardown', async () => {
+    const callOrder: string[] = [];
+    const mutate = vi.fn(async (tx: unknown) => {
+      expect(tx).toBe(fakeTx);
+      callOrder.push('mutate');
+    });
+    advanceUserEpochsMock.mockImplementation(async () => {
+      callOrder.push('advanceUserEpochs');
+      return epochRow;
+    });
+    revokeAllRefreshFamiliesMock.mockImplementation(async () => {
+      callOrder.push('revokeAllRefreshFamilies');
+    });
+    runPostCommitCleanupMock.mockImplementation(async () => {
+      callOrder.push('runPostCommitCleanup');
+      return { redisOk: true, permissionCacheOk: true, oauthOk: true };
+    });
+    terminateUserRemoteSessionsMock.mockImplementation(async () => {
+      callOrder.push('terminateUserRemoteSessions');
+      return 3;
+    });
+
+    const result = await invalidateMfaAssuranceAfterFactorChange(userId, 'test-reason', mutate);
+
+    // (b) post-commit cleanup AND remote-session teardown both run, strictly
+    // after the durable commit (mutate + epoch advance + family revoke).
+    expect(callOrder).toEqual([
+      'mutate',
+      'advanceUserEpochs',
+      'revokeAllRefreshFamilies',
+      'runPostCommitCleanup',
+      'terminateUserRemoteSessions',
+    ]);
+    expect(advanceUserEpochsMock).toHaveBeenCalledWith(fakeTx, userId, { mfa: true });
+    expect(revokeAllRefreshFamiliesMock).toHaveBeenCalledWith(fakeTx, userId, 'test-reason');
+    expect(runPostCommitCleanupMock).toHaveBeenCalledWith(userId);
+    expect(terminateUserRemoteSessionsMock).toHaveBeenCalledWith(userId);
+    expect(result).toEqual({
+      mfaEpoch: epochRow.mfaEpoch,
+      cleanup: { redisOk: true, permissionCacheOk: true, oauthOk: true },
+      remoteSessionsTerminated: 3,
+    });
+  });
+
+  it('works with no mutate provided — still advances the epoch and revokes families', async () => {
+    const result = await invalidateMfaAssuranceAfterFactorChange(userId, 'no-mutate');
+
+    expect(advanceUserEpochsMock).toHaveBeenCalledWith(fakeTx, userId, { mfa: true });
+    expect(revokeAllRefreshFamiliesMock).toHaveBeenCalledWith(fakeTx, userId, 'no-mutate');
+    expect(result.mfaEpoch).toBe(epochRow.mfaEpoch);
+  });
+
+  // (c) TEARDOWN_FAILED must be surfaced, not swallowed and not thrown.
+  it('surfaces TEARDOWN_FAILED (-1) from terminateUserRemoteSessions without throwing or swallowing it', async () => {
+    terminateUserRemoteSessionsMock.mockResolvedValue(TEARDOWN_FAILED);
+
+    const result = await invalidateMfaAssuranceAfterFactorChange(userId, 'teardown-fail');
+
+    expect(result.remoteSessionsTerminated).toBe(TEARDOWN_FAILED);
+    expect(result.remoteSessionsTerminated).toBe(-1);
+    // The durable side of the operation still completed — teardown failure
+    // is a partial OPERATIONAL failure, never a reason to undo the revocation.
+    expect(advanceUserEpochsMock).toHaveBeenCalled();
+    expect(revokeAllRefreshFamiliesMock).toHaveBeenCalled();
+  });
+
+  // (d) A throw inside mutate rejects the whole tx: no epoch bump, no revoke,
+  // and — because db.transaction rejects before ever returning — no
+  // post-commit step runs either. Proves the rollback invariant with mocks;
+  // real-PG atomicity is Task 9.
+  it('rejects the whole operation and skips post-commit steps when mutate throws (transaction rollback)', async () => {
+    const boom = new Error('factor write failed');
+    const mutate = vi.fn(async () => {
+      throw boom;
+    });
+
+    await expect(invalidateMfaAssuranceAfterFactorChange(userId, 'will-fail', mutate)).rejects.toThrow(boom);
+
+    expect(advanceUserEpochsMock).not.toHaveBeenCalled();
+    expect(revokeAllRefreshFamiliesMock).not.toHaveBeenCalled();
+    expect(runPostCommitCleanupMock).not.toHaveBeenCalled();
+    expect(terminateUserRemoteSessionsMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/mfaAssurance.ts
+++ b/apps/api/src/services/mfaAssurance.ts
@@ -1,0 +1,61 @@
+import * as dbModule from '../db';
+import {
+  advanceUserEpochs,
+  revokeAllRefreshFamilies,
+  runPostCommitCleanup,
+  type Tx,
+  type PostCommitCleanupResult,
+} from './authLifecycle';
+import { terminateUserRemoteSessions } from './remoteSessionTeardown';
+
+export interface FactorChangeResult {
+  mfaEpoch: number;
+  cleanup: PostCommitCleanupResult;
+  remoteSessionsTerminated: number;
+}
+
+/**
+ * Invalidate MFA assurance after a factor add/remove/replace/rotate (SR2-07,
+ * SR2-19). No factor-mutating handler today bumps `mfa_epoch`, revokes
+ * refresh families, or terminates remote sessions — a stolen/still-live
+ * access or refresh token, or an open remote-desktop session, survives an
+ * MFA factor change unaffected. This closes that gap as a single reusable
+ * primitive every factor handler folds its own write into.
+ *
+ * Atomic durable effect (invariant 3): `mutate` (the caller's factor write)
+ * + mfa_epoch advance + refresh-family revoke commit together in ONE
+ * transaction or not at all — a throw inside `mutate` rolls back the whole
+ * transaction (no epoch bump, no revoke).
+ *
+ * Post-commit cleanup and remote-session teardown are best-effort and run
+ * AFTER the commit: they can never restore token validity, only extend the
+ * blast radius of the already-durable revocation (Redis/permission-cache/
+ * OAuth cutoff, then live remote-desktop/terminal teardown). Teardown failure
+ * is surfaced to the caller as `remoteSessionsTerminated === TEARDOWN_FAILED`
+ * (-1) rather than swallowed — a partial operational failure here means a
+ * suspended/rogue-factor session could keep a live remote session, and the
+ * caller (route audit) must be able to record that.
+ *
+ * Runs under the caller's ambient (user-scoped) request context: every
+ * caller here is a self-service `authMiddleware`-gated handler writing the
+ * caller's OWN `users` row + OWN `refresh_token_families` rows, which
+ * Shape-6 / user-id-scoped RLS admits without a system-context escape (same
+ * precedent as /change-password). Do NOT wrap this in system context.
+ */
+export async function invalidateMfaAssuranceAfterFactorChange(
+  userId: string,
+  reason: string,
+  mutate?: (tx: Tx) => Promise<void>,
+): Promise<FactorChangeResult> {
+  const epochRow = await dbModule.db.transaction(async (tx: Tx) => {
+    if (mutate) await mutate(tx);
+    const row = await advanceUserEpochs(tx, userId, { mfa: true });
+    await revokeAllRefreshFamilies(tx, userId, reason);
+    return row;
+  });
+
+  const cleanup = await runPostCommitCleanup(userId);
+  const remoteSessionsTerminated = await terminateUserRemoteSessions(userId);
+
+  return { mfaEpoch: epochRow.mfaEpoch, cleanup, remoteSessionsTerminated };
+}

--- a/apps/api/src/services/mfaPolicy.test.ts
+++ b/apps/api/src/services/mfaPolicy.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const roleRows: { forceMfa: boolean }[] = [];
+let effectiveSecurity: Record<string, unknown> | undefined;
+let effectiveThrows = false;
+
+vi.mock('../db', () => {
+  const chain = {
+    from: () => chain,
+    innerJoin: () => chain,
+    where: () => chain,
+    limit: () => Promise.resolve(roleRows),
+    then: (r: (v: unknown[]) => unknown) => r(roleRows),
+  };
+  return {
+    db: { select: () => chain },
+    withSystemDbAccessContext: (fn: () => unknown) => fn(),
+    runOutsideDbContext: (fn: () => unknown) => fn(),
+  };
+});
+
+vi.mock('./effectiveSettings', () => ({
+  getEffectiveOrgSettings: vi.fn(async () => {
+    if (effectiveThrows) throw new Error('boom');
+    return { effective: { security: effectiveSecurity ?? {} }, locked: [] };
+  }),
+}));
+
+// Declare BEFORE the mock factory. The arrow defers the `killSwitch` read to
+// call time, so per-test reassignment is seen (avoids the vitest-hoist TDZ
+// footgun where a factory reading a not-yet-initialized let would throw).
+let killSwitch = true;
+vi.mock('../config/env', () => ({ mfaForcePartnerAdmin: () => killSwitch }));
+
+import { getEffectiveMfaPolicy } from './mfaPolicy';
+
+beforeEach(() => {
+  roleRows.length = 0;
+  effectiveSecurity = undefined;
+  effectiveThrows = false;
+  killSwitch = true;
+});
+
+describe('getEffectiveMfaPolicy', () => {
+  it('system scope: never required, all methods allowed, no joins', async () => {
+    const p = await getEffectiveMfaPolicy({ scope: 'system', userId: 'u1', orgId: null, partnerId: null });
+    expect(p.required).toBe(false);
+    expect(p.allowedMethods).toEqual({ totp: true, sms: true, passkey: true });
+  });
+
+  it('org role force_mfa=true forces required', async () => {
+    roleRows.push({ forceMfa: true });
+    const p = await getEffectiveMfaPolicy({ scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null });
+    expect(p.required).toBe(true);
+    expect(p.source.roleForceMfa).toBe(true);
+  });
+
+  it('org settings requireMfa=true forces required even when role does not', async () => {
+    roleRows.push({ forceMfa: false });
+    effectiveSecurity = { requireMfa: true };
+    const p = await getEffectiveMfaPolicy({ scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null });
+    expect(p.required).toBe(true);
+    expect(p.source.settingsRequireMfa).toBe(true);
+  });
+
+  it('allowedMethods.sms=false disables sms; passkey stays allowed', async () => {
+    roleRows.push({ forceMfa: false });
+    effectiveSecurity = { allowedMethods: { totp: true, sms: false } };
+    const p = await getEffectiveMfaPolicy({ scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null });
+    expect(p.allowedMethods).toEqual({ totp: true, sms: false, passkey: true });
+  });
+
+  it('kill switch off suppresses role-force: role force_mfa=true + no settings requireMfa => not required', async () => {
+    killSwitch = false;
+    roleRows.push({ forceMfa: true });
+    effectiveSecurity = undefined; // no settings requireMfa
+    const p = await getEffectiveMfaPolicy({ scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null });
+    expect(p.required).toBe(false);
+    expect(p.source.killSwitchOff).toBe(true);
+  });
+
+  it('kill switch off does NOT suppress settings: settings requireMfa=true (role false) => still required', async () => {
+    killSwitch = false;
+    roleRows.push({ forceMfa: false });
+    effectiveSecurity = { requireMfa: true };
+    const p = await getEffectiveMfaPolicy({ scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null });
+    expect(p.required).toBe(true);
+    expect(p.source.settingsRequireMfa).toBe(true);
+  });
+
+  it('fails open on settings read error: not required, methods allowed', async () => {
+    roleRows.push({ forceMfa: false });
+    effectiveThrows = true;
+    const p = await getEffectiveMfaPolicy({ scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null });
+    expect(p.required).toBe(false);
+    expect(p.allowedMethods).toEqual({ totp: true, sms: true, passkey: true });
+  });
+});

--- a/apps/api/src/services/mfaPolicy.test.ts
+++ b/apps/api/src/services/mfaPolicy.test.ts
@@ -1,15 +1,35 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const roleRows: { forceMfa: boolean }[] = [];
+const partnerRoleRows: { forceMfa: boolean }[] = [];
+const partnerSettingsRows: { settings: Record<string, unknown> }[] = [];
 let effectiveSecurity: Record<string, unknown> | undefined;
 let effectiveThrows = false;
 
-vi.mock('../db', () => {
+// The resolver issues three distinct select().from(<table>) queries (org role
+// join, partner role join, direct partner-settings read) that must resolve to
+// different fixtures. Route on the actual table object passed to `.from()` —
+// schema tables aren't mocked here, so identity against the real exports is
+// reliable. `partners`/`partnerUsers` are pulled in via an async factory (vi.mock
+// factories run before the top-level `import`s below, so they can't close over
+// a same-file import) — this doesn't affect timing since nothing else awaits
+// module init here.
+vi.mock('../db', async () => {
+  const { partnerUsers } = await import('../db/schema/users');
+  const { partners } = await import('../db/schema/orgs');
+  let lastFrom: unknown;
   const chain = {
-    from: () => chain,
+    from: (tbl: unknown) => {
+      lastFrom = tbl;
+      return chain;
+    },
     innerJoin: () => chain,
     where: () => chain,
-    limit: () => Promise.resolve(roleRows),
+    limit: () => {
+      if (lastFrom === partnerUsers) return Promise.resolve(partnerRoleRows);
+      if (lastFrom === partners) return Promise.resolve(partnerSettingsRows);
+      return Promise.resolve(roleRows);
+    },
     then: (r: (v: unknown[]) => unknown) => r(roleRows),
   };
   return {
@@ -33,12 +53,16 @@ let killSwitch = true;
 vi.mock('../config/env', () => ({ mfaForcePartnerAdmin: () => killSwitch }));
 
 import { getEffectiveMfaPolicy } from './mfaPolicy';
+import { getEffectiveOrgSettings } from './effectiveSettings';
 
 beforeEach(() => {
   roleRows.length = 0;
+  partnerRoleRows.length = 0;
+  partnerSettingsRows.length = 0;
   effectiveSecurity = undefined;
   effectiveThrows = false;
   killSwitch = true;
+  vi.mocked(getEffectiveOrgSettings).mockClear();
 });
 
 describe('getEffectiveMfaPolicy', () => {
@@ -94,5 +118,39 @@ describe('getEffectiveMfaPolicy', () => {
     const p = await getEffectiveMfaPolicy({ scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null });
     expect(p.required).toBe(false);
     expect(p.allowedMethods).toEqual({ totp: true, sms: true, passkey: true });
+  });
+
+  describe('partner scope', () => {
+    it('partner role force_mfa=true forces required (no partner settings requireMfa)', async () => {
+      partnerRoleRows.push({ forceMfa: true });
+      const p = await getEffectiveMfaPolicy({ scope: 'partner', userId: 'u1', orgId: null, partnerId: 'p1' });
+      expect(p.required).toBe(true);
+      expect(p.source.roleForceMfa).toBe(true);
+    });
+
+    it('partner settings security.requireMfa=true forces required via direct partners.settings read (role force=false)', async () => {
+      partnerRoleRows.push({ forceMfa: false });
+      partnerSettingsRows.push({ settings: { security: { requireMfa: true } } });
+      const p = await getEffectiveMfaPolicy({ scope: 'partner', userId: 'u1', orgId: null, partnerId: 'p1' });
+      expect(p.required).toBe(true);
+      expect(p.source.settingsRequireMfa).toBe(true);
+      // Proves the direct partners.settings path ran, not org-inheritance.
+      expect(getEffectiveOrgSettings).not.toHaveBeenCalled();
+    });
+
+    it('partner settings allowedMethods.sms=false disables sms; passkey stays allowed', async () => {
+      partnerRoleRows.push({ forceMfa: false });
+      partnerSettingsRows.push({ settings: { security: { allowedMethods: { sms: false } } } });
+      const p = await getEffectiveMfaPolicy({ scope: 'partner', userId: 'u1', orgId: null, partnerId: 'p1' });
+      expect(p.allowedMethods).toEqual({ totp: true, sms: false, passkey: true });
+    });
+
+    it('kill switch off suppresses partner role-force too: role force_mfa=true + no settings requireMfa => not required', async () => {
+      killSwitch = false;
+      partnerRoleRows.push({ forceMfa: true });
+      const p = await getEffectiveMfaPolicy({ scope: 'partner', userId: 'u1', orgId: null, partnerId: 'p1' });
+      expect(p.required).toBe(false);
+      expect(p.source.killSwitchOff).toBe(true);
+    });
   });
 });

--- a/apps/api/src/services/mfaPolicy.test.ts
+++ b/apps/api/src/services/mfaPolicy.test.ts
@@ -120,6 +120,28 @@ describe('getEffectiveMfaPolicy', () => {
     expect(p.allowedMethods).toEqual({ totp: true, sms: true, passkey: true });
   });
 
+  // I5: control gates (self-disable, last-factor removal) pass { failClosed: true }
+  // so a transient settings-read error cannot relax org/partner-required MFA.
+  it('I5: fails CLOSED (required) on settings read error when opts.failClosed is set', async () => {
+    roleRows.push({ forceMfa: false });
+    effectiveThrows = true;
+    const p = await getEffectiveMfaPolicy(
+      { scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null },
+      { failClosed: true },
+    );
+    expect(p.required).toBe(true);
+  });
+
+  it('I5: failClosed does NOT force required when the settings read SUCCEEDS and requireMfa is false', async () => {
+    roleRows.push({ forceMfa: false });
+    effectiveSecurity = { requireMfa: false };
+    const p = await getEffectiveMfaPolicy(
+      { scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null },
+      { failClosed: true },
+    );
+    expect(p.required).toBe(false);
+  });
+
   describe('partner scope', () => {
     it('partner role force_mfa=true forces required (no partner settings requireMfa)', async () => {
       partnerRoleRows.push({ forceMfa: true });

--- a/apps/api/src/services/mfaPolicy.ts
+++ b/apps/api/src/services/mfaPolicy.ts
@@ -1,0 +1,134 @@
+import { and, eq } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { roles, organizationUsers, partnerUsers } from '../db/schema/users';
+import { partners } from '../db/schema/orgs';
+import { getEffectiveOrgSettings } from './effectiveSettings';
+import { mfaForcePartnerAdmin } from '../config/env';
+import { captureException } from './sentry';
+
+/**
+ * Single source of truth for "does this user need MFA, and which factors may
+ * they use". Combines role `force_mfa` (via the same membership join the
+ * middleware enrollment gate used to make directly) with org/partner
+ * `security.requireMfa`/`security.allowedMethods` resolved THROUGH
+ * getEffectiveOrgSettings so a partner-set policy is inherited by its orgs.
+ *
+ * Strictest-wins: required = roleForce OR settingsRequire. A method is allowed
+ * unless effective settings explicitly disable it. Passkey is always allowed —
+ * it is phishing-resistant, so a tenant may restrict totp/sms but never the
+ * strongest factor.
+ *
+ * Kill switch (MFA_FORCE_FOR_PARTNER_ADMIN=false) suppresses ONLY the
+ * role-driven force (the env flag is named/documented for the partner-admin
+ * role force). Org/partner settings-driven requireMfa is STILL enforced when
+ * the kill switch is off — it does not collapse required to false globally.
+ * `killSwitchOff` in the result therefore means "role-force suppressed".
+ * allowedMethods is unaffected.
+ *
+ * Reads run under a system context (role join + settings touch cross-tenant
+ * tables) via runOutsideDbContext+withSystemDbAccessContext so this is correct
+ * whether the caller is pre-request-context (middleware/login) or inside a
+ * user-scoped request context (factor completion). Settings-read errors fail
+ * OPEN (not required, methods allowed) and emit bounded telemetry
+ * (captureException) — a transient blip must not mass-lock a tenant nor reject
+ * a factor that was allowed at enrollment. Only the SETTINGS read is fail-open;
+ * the role/membership join is deliberately NOT wrapped — it shares the login
+ * path's normal DB dependency, so a role-join failure is an intentional hard
+ * error (failing the request is correct, not the optional-enrichment case the
+ * settings fail-open covers). Do not add a try/catch around the role join.
+ */
+export interface MfaPolicyInput {
+  scope: 'system' | 'partner' | 'organization';
+  userId: string;
+  orgId: string | null;
+  partnerId: string | null;
+}
+export interface MfaAllowedMethods { totp: boolean; sms: boolean; passkey: boolean }
+export interface EffectiveMfaPolicy {
+  required: boolean;
+  allowedMethods: MfaAllowedMethods;
+  source: { roleForceMfa: boolean; settingsRequireMfa: boolean; killSwitchOff: boolean };
+}
+
+interface SecuritySettings {
+  requireMfa?: boolean;
+  allowedMethods?: { totp?: boolean; sms?: boolean };
+}
+
+function methodsFromSettings(security: SecuritySettings | undefined): MfaAllowedMethods {
+  const am = security?.allowedMethods;
+  return {
+    totp: am?.totp !== false,
+    sms: am?.sms !== false,
+    passkey: true, // always allowed — phishing-resistant
+  };
+}
+
+export async function getEffectiveMfaPolicy(input: MfaPolicyInput): Promise<EffectiveMfaPolicy> {
+  const killSwitchOff = !mfaForcePartnerAdmin();
+
+  if (input.scope === 'system') {
+    return {
+      required: false,
+      allowedMethods: { totp: true, sms: true, passkey: true },
+      source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff },
+    };
+  }
+
+  return dbModule.runOutsideDbContext(() =>
+    dbModule.withSystemDbAccessContext(async () => {
+      // --- role force_mfa ---
+      let roleForceMfa = false;
+      if (input.scope === 'organization' && input.orgId) {
+        const [row] = await dbModule.db
+          .select({ forceMfa: roles.forceMfa })
+          .from(organizationUsers)
+          .innerJoin(roles, eq(organizationUsers.roleId, roles.id))
+          .where(and(eq(organizationUsers.userId, input.userId), eq(organizationUsers.orgId, input.orgId)))
+          .limit(1);
+        roleForceMfa = row?.forceMfa === true;
+      } else if (input.scope === 'partner' && input.partnerId) {
+        const [row] = await dbModule.db
+          .select({ forceMfa: roles.forceMfa })
+          .from(partnerUsers)
+          .innerJoin(roles, eq(partnerUsers.roleId, roles.id))
+          .where(and(eq(partnerUsers.userId, input.userId), eq(partnerUsers.partnerId, input.partnerId)))
+          .limit(1);
+        roleForceMfa = row?.forceMfa === true;
+      }
+
+      // --- effective settings (partner-inherited for org scope) ---
+      let security: SecuritySettings | undefined;
+      try {
+        if (input.scope === 'organization' && input.orgId) {
+          const { effective } = await getEffectiveOrgSettings(input.orgId);
+          security = effective.security as SecuritySettings | undefined;
+        } else if (input.scope === 'partner' && input.partnerId) {
+          const [partner] = await dbModule.db
+            .select({ settings: partners.settings })
+            .from(partners)
+            .where(eq(partners.id, input.partnerId))
+            .limit(1);
+          const settings = (partner?.settings ?? {}) as Record<string, unknown>;
+          security = settings.security as SecuritySettings | undefined;
+        }
+      } catch (err) {
+        console.error('[mfa-policy] effective settings read failed — failing open (not required):', err);
+        captureException(err instanceof Error ? err : new Error(String(err)));
+        security = undefined;
+      }
+
+      const settingsRequireMfa = security?.requireMfa === true;
+      // Kill switch suppresses ONLY the role-force component; settings-driven
+      // requireMfa is enforced regardless (overseer hardening decision).
+      const roleForceApplies = roleForceMfa && !killSwitchOff;
+      const required = roleForceApplies || settingsRequireMfa;
+
+      return {
+        required,
+        allowedMethods: methodsFromSettings(security),
+        source: { roleForceMfa, settingsRequireMfa, killSwitchOff },
+      };
+    }),
+  );
+}

--- a/apps/api/src/services/mfaPolicy.ts
+++ b/apps/api/src/services/mfaPolicy.ts
@@ -64,7 +64,20 @@ function methodsFromSettings(security: SecuritySettings | undefined): MfaAllowed
   };
 }
 
-export async function getEffectiveMfaPolicy(input: MfaPolicyInput): Promise<EffectiveMfaPolicy> {
+/**
+ * @param opts.failClosed  Login/enrollment gates FAIL OPEN on a settings-read
+ *   error (a transient blip must never mass-lock a tenant out of signing in).
+ *   CONTROL gates that *relax* protection on a false `required` — self-disable
+ *   (`/mfa/disable`) and last-factor removal (`DELETE /passkeys/:id`) — must
+ *   pass `failClosed: true` so a transient read error cannot let a user strip
+ *   org/partner-required MFA. On a read error under `failClosed`, `required`
+ *   is forced true (the role-force axis is unaffected — its join is outside
+ *   the settings try/catch and already enforces regardless).
+ */
+export async function getEffectiveMfaPolicy(
+  input: MfaPolicyInput,
+  opts?: { failClosed?: boolean },
+): Promise<EffectiveMfaPolicy> {
   const killSwitchOff = !mfaForcePartnerAdmin();
 
   if (input.scope === 'system') {
@@ -99,6 +112,7 @@ export async function getEffectiveMfaPolicy(input: MfaPolicyInput): Promise<Effe
 
       // --- effective settings (partner-inherited for org scope) ---
       let security: SecuritySettings | undefined;
+      let settingsReadFailed = false;
       try {
         if (input.scope === 'organization' && input.orgId) {
           const { effective } = await getEffectiveOrgSettings(input.orgId);
@@ -113,16 +127,22 @@ export async function getEffectiveMfaPolicy(input: MfaPolicyInput): Promise<Effe
           security = settings.security as SecuritySettings | undefined;
         }
       } catch (err) {
-        console.error('[mfa-policy] effective settings read failed — failing open (not required):', err);
+        const disposition = opts?.failClosed ? 'failing closed (required)' : 'failing open (not required)';
+        console.error(`[mfa-policy] effective settings read failed — ${disposition}:`, err);
         captureException(err instanceof Error ? err : new Error(String(err)));
         security = undefined;
+        settingsReadFailed = true;
       }
 
       const settingsRequireMfa = security?.requireMfa === true;
       // Kill switch suppresses ONLY the role-force component; settings-driven
       // requireMfa is enforced regardless (overseer hardening decision).
       const roleForceApplies = roleForceMfa && !killSwitchOff;
-      const required = roleForceApplies || settingsRequireMfa;
+      // Control gates (opts.failClosed) treat an unreadable settings row as
+      // "still required" so a transient blip can't strip org/partner-mandated
+      // MFA; login/enrollment gates leave failClosed unset and fail open.
+      const required =
+        roleForceApplies || settingsRequireMfa || (settingsReadFailed && opts?.failClosed === true);
 
       return {
         required,

--- a/apps/api/src/services/mfaStepUpGrant.test.ts
+++ b/apps/api/src/services/mfaStepUpGrant.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const redisStore = new Map<string, string>();
+const ttls = new Map<string, number>();
+let redisDown = false;
+
+vi.mock('./redis', () => ({
+  getRedis: () => {
+    if (redisDown) return null;
+    return {
+      setex: vi.fn(async (k: string, ttl: number, v: string) => {
+        redisStore.set(k, v);
+        ttls.set(k, ttl);
+        return 'OK';
+      }),
+      get: vi.fn(async (k: string) => redisStore.get(k) ?? null),
+      getdel: vi.fn(async (k: string) => {
+        const v = redisStore.get(k) ?? null;
+        redisStore.delete(k);
+        ttls.delete(k);
+        return v;
+      }),
+    };
+  },
+}));
+
+import { mintStepUpGrant, validateStepUpGrant, consumeStepUpGrant } from './mfaStepUpGrant';
+
+const BIND = {
+  userId: 'user-1',
+  operation: 'add_factor' as const,
+  authEpoch: 1,
+  mfaEpoch: 2,
+  sid: 'family-1',
+};
+
+describe('mfaStepUpGrant', () => {
+  beforeEach(() => {
+    redisStore.clear();
+    ttls.clear();
+    redisDown = false;
+  });
+
+  describe('mintStepUpGrant', () => {
+    it('writes mfa:stepup:<id> with a 300s TTL and returns the id', async () => {
+      const id = await mintStepUpGrant(BIND);
+      expect(id).toBeTruthy();
+      const key = `mfa:stepup:${id}`;
+      expect(redisStore.has(key)).toBe(true);
+      expect(ttls.get(key)).toBe(300);
+      expect(JSON.parse(redisStore.get(key)!)).toEqual(BIND);
+    });
+
+    it('returns null when Redis is down', async () => {
+      redisDown = true;
+      const id = await mintStepUpGrant(BIND);
+      expect(id).toBeNull();
+    });
+  });
+
+  describe('validateStepUpGrant', () => {
+    it('returns true when the id exists and every bind field matches', async () => {
+      const id = await mintStepUpGrant(BIND);
+      const ok = await validateStepUpGrant(id!, BIND);
+      expect(ok).toBe(true);
+      // Non-consuming: the record is still present afterward.
+      expect(redisStore.has(`mfa:stepup:${id}`)).toBe(true);
+    });
+
+    it('returns false when the id does not exist', async () => {
+      const ok = await validateStepUpGrant('nonexistent-id', BIND);
+      expect(ok).toBe(false);
+    });
+
+    it.each([
+      ['userId', { ...BIND, userId: 'other-user' }],
+      ['operation', { ...BIND, operation: 'other_op' as unknown as 'add_factor' }],
+      ['authEpoch', { ...BIND, authEpoch: 999 }],
+      ['mfaEpoch', { ...BIND, mfaEpoch: 999 }],
+      ['sid', { ...BIND, sid: 'other-sid' }],
+    ])('returns false on a %s mismatch', async (_field, mismatchedBind) => {
+      const id = await mintStepUpGrant(BIND);
+      const ok = await validateStepUpGrant(id!, mismatchedBind);
+      expect(ok).toBe(false);
+    });
+
+    it('returns false when Redis is null', async () => {
+      const id = await mintStepUpGrant(BIND);
+      redisDown = true;
+      const ok = await validateStepUpGrant(id!, BIND);
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe('consumeStepUpGrant', () => {
+    it('uses getdel and is single-use: a second consume of the same id returns false', async () => {
+      const id = await mintStepUpGrant(BIND);
+      const first = await consumeStepUpGrant(id!, BIND);
+      expect(first).toBe(true);
+      const second = await consumeStepUpGrant(id!, BIND);
+      expect(second).toBe(false);
+    });
+
+    it('returns false on a bind mismatch (and still consumes the record)', async () => {
+      const id = await mintStepUpGrant(BIND);
+      const ok = await consumeStepUpGrant(id!, { ...BIND, sid: 'other-sid' });
+      expect(ok).toBe(false);
+    });
+
+    it('returns false when Redis is null', async () => {
+      const id = await mintStepUpGrant(BIND);
+      redisDown = true;
+      const ok = await consumeStepUpGrant(id!, BIND);
+      expect(ok).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/services/mfaStepUpGrant.ts
+++ b/apps/api/src/services/mfaStepUpGrant.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from 'crypto';
+import { getRedis } from './redis';
+
+/**
+ * SR2-20: existing-factor step-up grant for adding a NEW MFA factor to an
+ * ALREADY-PROTECTED account. Minted by `POST /auth/mfa/step-up` after the
+ * caller proves an existing factor (TOTP/SMS/passkey), then presented back
+ * to a factor-addition endpoint (`/mfa/enable`, setup-confirm, `/mfa/sms/enable`,
+ * `/passkeys/register/*`) as `stepUpGrantId`.
+ *
+ * Bound to the live `authEpoch`/`mfaEpoch` + the initiating session's `sid` so
+ * a factor change (which bumps `mfa_epoch` + revokes refresh families) or a
+ * session switch invalidates any outstanding grant. Single-use via Redis
+ * `getdel` at the terminal write; non-consuming `validateStepUpGrant` exists
+ * for the intermediate `register/options` step (the SAME grant is consumed
+ * later at `/register/verify`).
+ */
+export interface StepUpGrant {
+  id: string;
+  userId: string;
+  operation: 'add_factor';
+  authEpoch: number;
+  mfaEpoch: number;
+  sid: string;
+}
+
+type GrantBind = Omit<StepUpGrant, 'id'>;
+
+const TTL_SECONDS = 300;
+const key = (id: string) => `mfa:stepup:${id}`;
+
+function bindsMatch(record: GrantBind, bind: GrantBind): boolean {
+  return record.userId === bind.userId
+    && record.operation === bind.operation
+    && record.authEpoch === bind.authEpoch
+    && record.mfaEpoch === bind.mfaEpoch
+    && record.sid === bind.sid;
+}
+
+/** Mint a short-lived single-use step-up grant. Returns null if Redis is down (caller fails closed). */
+export async function mintStepUpGrant(bind: GrantBind): Promise<string | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+  const id = randomUUID();
+  await redis.setex(key(id), TTL_SECONDS, JSON.stringify(bind));
+  return id;
+}
+
+/** Non-consuming check (register/options). Fails closed on Redis down/error/miss/mismatch. */
+export async function validateStepUpGrant(id: string, bind: GrantBind): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  try {
+    const raw = await redis.get(key(id));
+    if (!raw) return false;
+    return bindsMatch(JSON.parse(raw) as GrantBind, bind);
+  } catch {
+    return false;
+  }
+}
+
+/** Single-use consume via getdel (every terminal factor write). Fails closed. */
+export async function consumeStepUpGrant(id: string, bind: GrantBind): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  try {
+    const raw = await redis.getdel(key(id));
+    if (!raw) return false;
+    return bindsMatch(JSON.parse(raw) as GrantBind, bind);
+  } catch {
+    return false;
+  }
+}

--- a/docs/superpowers/plans/2026-07-12-pr2-mfa-policy-assurance.md
+++ b/docs/superpowers/plans/2026-07-12-pr2-mfa-policy-assurance.md
@@ -1,0 +1,1704 @@
+# PR 2 — MFA Policy & Assurance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make MFA *policy* (role `force_mfa` + org/partner `security.requireMfa`/`allowedMethods`, resolved through partner inheritance) and MFA *assurance* (epoch- and status-bound pending records, factor-change global sign-out, working recovery codes, existing-factor step-up) durable and consistent. Close SR2-05, SR2-06, SR2-07, SR2-09, SR2-19, SR2-20, SR2-24.
+
+**Architecture:** Introduce one effective-MFA-policy resolver (`services/mfaPolicy.ts`) consumed by middleware, login, enrollment and factor operations — strictest-wins across role force + effective settings, passkey always allowed. The vacuous `mfa=true` for unenrolled-but-policy-required users is removed (forced-enrollment response instead). Pending MFA records gain `authEpoch/mfaEpoch/statusExpectation/allowedMethods/expiresAt`; every completion path reloads the live user + policy, compares, and consumes atomically before minting. TOTP setup confirmation switches to the consuming verifier. A new `services/mfaAssurance.ts` helper wraps every mutating factor handler in one transaction that advances `mfa_epoch` + revokes all refresh families (via PR 1's `authLifecycle` primitives), then post-commit runs Redis/OAuth cleanup + remote-session teardown — a deliberate global sign-out on any factor change. Recovery-code login is built from scratch (schema relax + atomic single-hash removal). Adding a factor to an already-protected account requires a short-lived single-use step-up grant proving an existing factor.
+
+**Tech Stack:** Hono (TypeScript), Drizzle ORM, PostgreSQL (RLS via `breeze_app`), Redis (ioredis), `otplib` TOTP, `@simplewebauthn/server`, Vitest.
+
+**Stacks on:** `core-auth-1-lifecycle-foundation` (PR #2378). All PR 1 primitives are already merged into this branch: `advanceUserEpochs`, `revokeAllRefreshFamilies`, `revokeRefreshFamilyById`, `runPostCommitCleanup`, `Tx` (`services/authLifecycle.ts`); `getUserEpochs` (`services/authEpochs.ts`, re-exported from `services/index.ts`); epoch columns on `users`; `aep/mep/sid` JWT claims. Do not re-implement them.
+
+## Global Constraints
+
+- **Node 22.20.0.** Prefix every `pnpm`/`node` command with `export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"` (no version manager is installed; the pinned binary lives there).
+- **No migration in PR 2.** The epoch columns (`users.auth_epoch`, `users.mfa_epoch`, …) ship in PR 1; `users.mfa_recovery_codes` (jsonb) already exists. **This PR adds no tables and no columns → no `rls-coverage.integration.test.ts` allowlist changes.** If a task appears to need a new column, STOP — it does not; re-read this constraint.
+- **Epoch enforcement is scoped to `aud=breeze-api` user tokens only** (unchanged from PR 1). Factor operations bump **`mfa_epoch`** only (never `auth_epoch`).
+- **Audit events never contain raw MFA codes, recovery codes, TOTP secrets, WebAuthn assertions, or tokens.** Recovery-code audit records a count/index or `null`, never the code or its hash.
+- **Public auth errors are generic; server-side audit reasons are specific.** A pending-MFA epoch mismatch returns the same `Invalid or expired MFA session` body that an expired token returns; the audit event carries the precise reason.
+- **Security-state DB failure fails the mutation** (no success audit). Redis/cache cleanup failure = bounded telemetry, never restores token validity. Single-use consumption (recovery code, step-up grant, pending record) fails closed on Redis/DB ambiguity.
+- **DB context.** Self-service factor handlers run inside the authenticated request context (user-scoped RLS). Writes to the user's OWN `users` row and OWN `refresh_token_families` pass Shape-6 / user-id-scoped policies, so an ambient `db.transaction` is correct there (same reasoning PR 1 used for `/change-password`). Code that reads cross-tenant rows pre-context or from another user (the policy resolver's role/settings joins) must establish system context; use `runOutsideDbContext(() => withSystemDbAccessContext(...))` so it is correct whether or not a request context is already active.
+- **Commit after each green task.** TDD: write the failing test, observe the reviewed failure, then implement.
+
+## File Structure
+
+- **Create** `apps/api/src/services/mfaPolicy.ts` + `mfaPolicy.test.ts` — effective-policy resolver (Task 1).
+- **Create** `apps/api/src/services/mfaAssurance.ts` + `mfaAssurance.test.ts` — factor-change invalidation helper (Task 7).
+- **Create** `apps/api/src/services/mfaStepUpGrant.ts` + `mfaStepUpGrant.test.ts` — existing-factor step-up grant (Task 8).
+- **Modify** `apps/api/src/middleware/auth.ts` — enrollment gate uses the resolver (Task 3).
+- **Modify** `apps/api/src/routes/auth/login.ts` — forced-enrollment response + epoch/status/method-bound pending record (Tasks 3, 4).
+- **Modify** `apps/api/src/routes/auth/mfa.ts` — pending-MFA validation, recovery branch, consuming setup verifier, factor-change invalidation (Tasks 4, 5, 6, 7).
+- **Modify** `apps/api/src/routes/auth/passkeys.ts` — pending-MFA validation, factor-change invalidation, step-up grant on register (Tasks 4, 7, 8).
+- **Modify** `apps/api/src/routes/auth/phone.ts` — allowedMethods reader via resolver, factor-change invalidation on SMS enable + phone replacement (Tasks 2, 7).
+- **Modify** `apps/api/src/routes/auth/schemas.ts` — `mfaVerifySchema` recovery method (Task 6).
+- **Modify** `apps/api/src/routes/auth/helpers.ts` — `PendingMfaRecord` type + parser/evaluator (Task 4).
+- **Modify** `apps/api/src/routes/orgs.ts` — `allowedMfaMethods` input alias normalization (Task 2).
+- **Modify** `apps/api/src/services/index.ts` — re-export `getEffectiveMfaPolicy` for the mock boundary (Task 1).
+- **Create** `apps/api/src/__tests__/integration/mfaAssurance.integration.test.ts`, `recoveryCode.integration.test.ts`, `pendingMfaEpoch.integration.test.ts` (Task 9).
+
+---
+
+### Task 1: MFA policy resolver service
+
+**Files:**
+- Create: `apps/api/src/services/mfaPolicy.ts`
+- Create: `apps/api/src/services/mfaPolicy.test.ts`
+- Modify: `apps/api/src/services/index.ts` (barrel export)
+
+**Interfaces:**
+- Consumes: `roles.forceMfa` via `organization_users`/`partner_users` join (same shape as `middleware/auth.ts` `userRoleRequiresMfa`); `mfaForcePartnerAdmin()` (`config/env.ts`, env `MFA_FORCE_FOR_PARTNER_ADMIN`, default true); `getEffectiveOrgSettings(orgId)` (`services/effectiveSettings.ts` — returns `{ effective, locked }`, partner-inherited); `partners.settings` (partner-scope path); `runOutsideDbContext`/`withSystemDbAccessContext` (`db/index.ts`).
+- Produces:
+  ```ts
+  export interface MfaPolicyInput {
+    scope: 'system' | 'partner' | 'organization';
+    userId: string;
+    orgId: string | null;
+    partnerId: string | null;
+  }
+  export interface MfaAllowedMethods { totp: boolean; sms: boolean; passkey: boolean }
+  export interface EffectiveMfaPolicy {
+    required: boolean;
+    allowedMethods: MfaAllowedMethods;   // passkey ALWAYS true
+    source: { roleForceMfa: boolean; settingsRequireMfa: boolean; killSwitchOff: boolean };
+  }
+  export async function getEffectiveMfaPolicy(input: MfaPolicyInput): Promise<EffectiveMfaPolicy>;
+  ```
+
+**Design decisions (documented inline in the file's header comment):**
+- **Strictest-wins.** `required = roleForceMfa OR settingsRequireMfa`. A method is `allowed` unless the effective settings explicitly disable it. `passkey` is always allowed — it is phishing-resistant, so an org/partner cannot forbid the strongest factor (only totp/sms can be restricted).
+- **Kill switch gates ONLY the role-force component.** `MFA_FORCE_FOR_PARTNER_ADMIN` is named and documented for the partner-admin *role* force (roles schema comment: "Seeded true for the privileged partner-admin slug"). When `mfaForcePartnerAdmin()` is false, role-driven forcing is suppressed (`roleForceApplies = roleForceMfa && !killSwitchOff`), but org/partner `security.requireMfa` is STILL enforced — so `required = roleForceApplies || settingsRequireMfa`. Overloading this env flag into a global MFA-disable that silently drops org/partner-configured compliance would be a latent foot-gun in a hardening PR, so it is deliberately narrowed. `source.killSwitchOff` is retained (useful for audit) but now means "role-force suppressed", not "everything suppressed". `allowedMethods` is unaffected by the kill switch. (Overseer decision, overriding the earlier "global escape hatch" choice.)
+- **Scope resolution.**
+  - `system` → `required=false`, all methods allowed, no joins (platform admin is governed by `is_platform_admin`, not tenant MFA policy — there is no tenant axis to resolve).
+  - `organization` (has `orgId`) → role join on `organization_users`; settings from `getEffectiveOrgSettings(orgId).effective.security` (partner defaults already merged in).
+  - `partner` (has `partnerId`, no `orgId`) → role join on `partner_users`; settings from the partner's own `partners.settings.security` (no org to inherit through).
+- **Fail-open on settings read errors.** `getEffectiveOrgSettings` throws `HTTPException(404)` for a missing org/partner. Reading effective settings is wrapped in try/catch: on error, `settingsRequireMfa=false` and totp/sms stay allowed (role force still applies). Rationale: a transient settings-read blip must not mass-lock a tenant out of login, and it must not silently reject a factor that was allowed at enrollment. This is a deliberate availability-over-strictness choice for policy resolution only (single-use consumption still fails closed — Tasks 4/6/8).
+- **Runs under system context from every caller.** The role join and settings reads touch cross-tenant tables before the request RLS context is set (middleware/login) or from within a user-scoped context (factor completion). `runOutsideDbContext(() => withSystemDbAccessContext(...))` is correct in both cases.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/services/mfaPolicy.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const roleRows: { forceMfa: boolean }[] = [];
+let effectiveSecurity: Record<string, unknown> | undefined;
+let effectiveThrows = false;
+
+vi.mock('../db', () => {
+  const chain = {
+    from: () => chain,
+    innerJoin: () => chain,
+    where: () => chain,
+    limit: () => Promise.resolve(roleRows),
+    then: (r: (v: unknown[]) => unknown) => r(roleRows),
+  };
+  return {
+    db: { select: () => chain },
+    withSystemDbAccessContext: (fn: () => unknown) => fn(),
+    runOutsideDbContext: (fn: () => unknown) => fn(),
+  };
+});
+
+vi.mock('./effectiveSettings', () => ({
+  getEffectiveOrgSettings: vi.fn(async () => {
+    if (effectiveThrows) throw new Error('boom');
+    return { effective: { security: effectiveSecurity ?? {} }, locked: [] };
+  }),
+}));
+
+// Declare BEFORE the mock factory. The arrow defers the `killSwitch` read to
+// call time, so per-test reassignment is seen (avoids the vitest-hoist TDZ
+// footgun where a factory reading a not-yet-initialized let would throw).
+let killSwitch = true;
+vi.mock('../config/env', () => ({ mfaForcePartnerAdmin: () => killSwitch }));
+
+import { getEffectiveMfaPolicy } from './mfaPolicy';
+
+beforeEach(() => {
+  roleRows.length = 0;
+  effectiveSecurity = undefined;
+  effectiveThrows = false;
+  killSwitch = true;
+});
+
+describe('getEffectiveMfaPolicy', () => {
+  it('system scope: never required, all methods allowed, no joins', async () => {
+    const p = await getEffectiveMfaPolicy({ scope: 'system', userId: 'u1', orgId: null, partnerId: null });
+    expect(p.required).toBe(false);
+    expect(p.allowedMethods).toEqual({ totp: true, sms: true, passkey: true });
+  });
+
+  it('org role force_mfa=true forces required', async () => {
+    roleRows.push({ forceMfa: true });
+    const p = await getEffectiveMfaPolicy({ scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null });
+    expect(p.required).toBe(true);
+    expect(p.source.roleForceMfa).toBe(true);
+  });
+
+  it('org settings requireMfa=true forces required even when role does not', async () => {
+    roleRows.push({ forceMfa: false });
+    effectiveSecurity = { requireMfa: true };
+    const p = await getEffectiveMfaPolicy({ scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null });
+    expect(p.required).toBe(true);
+    expect(p.source.settingsRequireMfa).toBe(true);
+  });
+
+  it('allowedMethods.sms=false disables sms; passkey stays allowed', async () => {
+    roleRows.push({ forceMfa: false });
+    effectiveSecurity = { allowedMethods: { totp: true, sms: false } };
+    const p = await getEffectiveMfaPolicy({ scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null });
+    expect(p.allowedMethods).toEqual({ totp: true, sms: false, passkey: true });
+  });
+
+  it('kill switch off suppresses role-force: role force_mfa=true + no settings requireMfa => not required', async () => {
+    killSwitch = false;
+    roleRows.push({ forceMfa: true });
+    effectiveSecurity = undefined; // no settings requireMfa
+    const p = await getEffectiveMfaPolicy({ scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null });
+    expect(p.required).toBe(false);
+    expect(p.source.killSwitchOff).toBe(true);
+  });
+
+  it('kill switch off does NOT suppress settings: settings requireMfa=true (role false) => still required', async () => {
+    killSwitch = false;
+    roleRows.push({ forceMfa: false });
+    effectiveSecurity = { requireMfa: true };
+    const p = await getEffectiveMfaPolicy({ scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null });
+    expect(p.required).toBe(true);
+    expect(p.source.settingsRequireMfa).toBe(true);
+  });
+
+  it('fails open on settings read error: not required, methods allowed', async () => {
+    roleRows.push({ forceMfa: false });
+    effectiveThrows = true;
+    const p = await getEffectiveMfaPolicy({ scope: 'organization', userId: 'u1', orgId: 'o1', partnerId: null });
+    expect(p.required).toBe(false);
+    expect(p.allowedMethods).toEqual({ totp: true, sms: true, passkey: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/services/mfaPolicy.test.ts
+```
+Expected: FAIL — cannot find module `./mfaPolicy`.
+
+- [ ] **Step 3: Implement**
+
+Create `apps/api/src/services/mfaPolicy.ts`:
+
+```ts
+import { and, eq } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { roles, organizationUsers, partnerUsers } from '../db/schema/users';
+import { partners } from '../db/schema/orgs';
+import { getEffectiveOrgSettings } from './effectiveSettings';
+import { mfaForcePartnerAdmin } from '../config/env';
+import { captureException } from './sentry';
+
+/**
+ * Single source of truth for "does this user need MFA, and which factors may
+ * they use". Combines role `force_mfa` (via the same membership join the
+ * middleware enrollment gate used to make directly) with org/partner
+ * `security.requireMfa`/`security.allowedMethods` resolved THROUGH
+ * getEffectiveOrgSettings so a partner-set policy is inherited by its orgs.
+ *
+ * Strictest-wins: required = roleForce OR settingsRequire. A method is allowed
+ * unless effective settings explicitly disable it. Passkey is always allowed —
+ * it is phishing-resistant, so a tenant may restrict totp/sms but never the
+ * strongest factor.
+ *
+ * Kill switch (MFA_FORCE_FOR_PARTNER_ADMIN=false) suppresses ONLY the
+ * role-driven force (the env flag is named/documented for the partner-admin
+ * role force). Org/partner settings-driven requireMfa is STILL enforced when
+ * the kill switch is off — it does not collapse required to false globally.
+ * `killSwitchOff` in the result therefore means "role-force suppressed".
+ * allowedMethods is unaffected.
+ *
+ * Reads run under a system context (role join + settings touch cross-tenant
+ * tables) via runOutsideDbContext+withSystemDbAccessContext so this is correct
+ * whether the caller is pre-request-context (middleware/login) or inside a
+ * user-scoped request context (factor completion). Settings-read errors fail
+ * OPEN (not required, methods allowed) and emit bounded telemetry
+ * (captureException) — a transient blip must not mass-lock a tenant nor reject
+ * a factor that was allowed at enrollment. Only the SETTINGS read is fail-open;
+ * the role/membership join is deliberately NOT wrapped — it shares the login
+ * path's normal DB dependency, so a role-join failure is an intentional hard
+ * error (failing the request is correct, not the optional-enrichment case the
+ * settings fail-open covers). Do not add a try/catch around the role join.
+ */
+export interface MfaPolicyInput {
+  scope: 'system' | 'partner' | 'organization';
+  userId: string;
+  orgId: string | null;
+  partnerId: string | null;
+}
+export interface MfaAllowedMethods { totp: boolean; sms: boolean; passkey: boolean }
+export interface EffectiveMfaPolicy {
+  required: boolean;
+  allowedMethods: MfaAllowedMethods;
+  source: { roleForceMfa: boolean; settingsRequireMfa: boolean; killSwitchOff: boolean };
+}
+
+interface SecuritySettings {
+  requireMfa?: boolean;
+  allowedMethods?: { totp?: boolean; sms?: boolean };
+}
+
+function methodsFromSettings(security: SecuritySettings | undefined): MfaAllowedMethods {
+  const am = security?.allowedMethods;
+  return {
+    totp: am?.totp !== false,
+    sms: am?.sms !== false,
+    passkey: true, // always allowed — phishing-resistant
+  };
+}
+
+export async function getEffectiveMfaPolicy(input: MfaPolicyInput): Promise<EffectiveMfaPolicy> {
+  const killSwitchOff = !mfaForcePartnerAdmin();
+
+  if (input.scope === 'system') {
+    return {
+      required: false,
+      allowedMethods: { totp: true, sms: true, passkey: true },
+      source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff },
+    };
+  }
+
+  return dbModule.runOutsideDbContext(() =>
+    dbModule.withSystemDbAccessContext(async () => {
+      // --- role force_mfa ---
+      let roleForceMfa = false;
+      if (input.scope === 'organization' && input.orgId) {
+        const [row] = await dbModule.db
+          .select({ forceMfa: roles.forceMfa })
+          .from(organizationUsers)
+          .innerJoin(roles, eq(organizationUsers.roleId, roles.id))
+          .where(and(eq(organizationUsers.userId, input.userId), eq(organizationUsers.orgId, input.orgId)))
+          .limit(1);
+        roleForceMfa = row?.forceMfa === true;
+      } else if (input.scope === 'partner' && input.partnerId) {
+        const [row] = await dbModule.db
+          .select({ forceMfa: roles.forceMfa })
+          .from(partnerUsers)
+          .innerJoin(roles, eq(partnerUsers.roleId, roles.id))
+          .where(and(eq(partnerUsers.userId, input.userId), eq(partnerUsers.partnerId, input.partnerId)))
+          .limit(1);
+        roleForceMfa = row?.forceMfa === true;
+      }
+
+      // --- effective settings (partner-inherited for org scope) ---
+      let security: SecuritySettings | undefined;
+      try {
+        if (input.scope === 'organization' && input.orgId) {
+          const { effective } = await getEffectiveOrgSettings(input.orgId);
+          security = effective.security as SecuritySettings | undefined;
+        } else if (input.scope === 'partner' && input.partnerId) {
+          const [partner] = await dbModule.db
+            .select({ settings: partners.settings })
+            .from(partners)
+            .where(eq(partners.id, input.partnerId))
+            .limit(1);
+          const settings = (partner?.settings ?? {}) as Record<string, unknown>;
+          security = settings.security as SecuritySettings | undefined;
+        }
+      } catch (err) {
+        console.error('[mfa-policy] effective settings read failed — failing open (not required):', err);
+        captureException(err instanceof Error ? err : new Error(String(err)));
+        security = undefined;
+      }
+
+      const settingsRequireMfa = security?.requireMfa === true;
+      // Kill switch suppresses ONLY the role-force component; settings-driven
+      // requireMfa is enforced regardless (overseer hardening decision).
+      const roleForceApplies = roleForceMfa && !killSwitchOff;
+      const required = roleForceApplies || settingsRequireMfa;
+
+      return {
+        required,
+        allowedMethods: methodsFromSettings(security),
+        source: { roleForceMfa, settingsRequireMfa, killSwitchOff },
+      };
+    }),
+  );
+}
+```
+
+> Confirm the exact schema import paths before running: `roles`, `organizationUsers`, `partnerUsers` live in `db/schema/users.ts`; `partners` in `db/schema/orgs.ts`. `mfaForcePartnerAdmin` is exported from `config/env.ts`. If a name differs, match the existing `middleware/auth.ts` imports (it imports `roles`, `organizationUsers`, `partnerUsers`).
+
+- [ ] **Step 4: Barrel export**
+
+In `apps/api/src/services/index.ts`, after the `getRefreshFamily` re-export (`:21`), add:
+
+```ts
+export { getEffectiveMfaPolicy } from './mfaPolicy';
+export type { EffectiveMfaPolicy, MfaPolicyInput, MfaAllowedMethods } from './mfaPolicy';
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/services/mfaPolicy.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/mfaPolicy.ts apps/api/src/services/mfaPolicy.test.ts apps/api/src/services/index.ts
+git commit -m "feat(auth): add effective MFA policy resolver (SR2-05)"
+```
+
+---
+
+### Task 2: Canonicalize `allowedMethods` (fix inert allowlist)
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/phone.ts:205-217` (SMS-enable org-allow reader)
+- Modify: `apps/api/src/routes/orgs.ts:382` (security schema) + `:1266-1280` (org settings write) + `/partners/me` PATCH security deep-merge (`:619-622`)
+- Test: `apps/api/src/routes/auth/phone.test.ts` (create if absent) + `apps/api/src/routes/orgs.test.ts`
+
+**Interfaces:**
+- Consumes: `getEffectiveMfaPolicy` (Task 1).
+- Produces: `/mfa/sms/enable` rejects when `getEffectiveMfaPolicy(...).allowedMethods.sms === false` (reading the CANONICAL `security.allowedMethods`, never the never-written `allowedMfaMethods`). Org/partner settings writers accept `security.allowedMfaMethods` as an input alias and fold it into `security.allowedMethods`, never persisting the alias key.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/api/src/routes/auth/phone.test.ts` (follow the file's existing mock shape; if the file is absent, model it on `auth/login.test.ts`'s harness): a test that mocks `getEffectiveMfaPolicy` to return `allowedMethods.sms=false` and asserts `POST /mfa/sms/enable` returns 403 with `Your organization does not allow SMS MFA`; and a test with `sms=true` that passes the allow-check. Mock the boundary `vi.mock('../../services/mfaPolicy', () => ({ getEffectiveMfaPolicy: vi.fn() }))`.
+
+Add to `apps/api/src/routes/orgs.test.ts`: a settings PATCH that sends `security.allowedMfaMethods={ sms:false }` and asserts the persisted `settings.security.allowedMethods.sms === false` AND `settings.security.allowedMfaMethods` is `undefined` (alias not stored). Follow the file's existing Drizzle-mock capture of the `update().set()` payload.
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/auth/phone.test.ts src/routes/orgs.test.ts -t 'allowed'
+```
+Expected: FAIL — SMS enable reads the never-written `allowedMfaMethods` (always undefined → SMS never blocked); alias is stored verbatim.
+
+- [ ] **Step 3: Implement — phone.ts reader**
+
+In `apps/api/src/routes/auth/phone.ts`, add the import near the top-of-file imports:
+
+```ts
+import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
+```
+
+Replace the org-policy block (`:205-217`, the `if (auth.orgId) { … allowedMfaMethods … }`) with:
+
+```ts
+  // Enforce the CANONICAL allowlist through the resolver (partner-inherited).
+  // The old reader consulted `security.allowedMfaMethods`, a spelling that is
+  // written nowhere → the SMS restriction silently no-opped. Passkey is always
+  // allowed; only totp/sms are gated by effective settings.
+  const policy = await getEffectiveMfaPolicy({
+    scope: auth.scope,
+    userId: auth.user.id,
+    orgId: auth.orgId ?? null,
+    partnerId: auth.partnerId ?? null,
+  });
+  if (!policy.allowedMethods.sms) {
+    return c.json({ error: 'Your organization does not allow SMS MFA' }, 403);
+  }
+```
+
+(`auth.scope`, `auth.orgId`, `auth.partnerId` are on the `AuthContext` set by `authMiddleware`.)
+
+- [ ] **Step 3b: Implement — orgs.ts input alias**
+
+In `apps/api/src/routes/orgs.ts`, add the alias to the security zod object (`:382`, inside `partnerSettingsSchema.security`), right after the `allowedMethods` line (`:387`):
+
+```ts
+    allowedMethods: z.object({ totp: z.boolean().optional(), sms: z.boolean().optional() }).optional(),
+    // Legacy input alias. Accepted so older clients don't 400, folded into
+    // `allowedMethods` at write time (foldAllowedMfaMethodsAlias) and never
+    // persisted as a second source of truth.
+    allowedMfaMethods: z.object({ totp: z.boolean().optional(), sms: z.boolean().optional() }).optional(),
+```
+
+Add a normalizer near the top of `orgs.ts` (after the imports, before the first route):
+
+```ts
+/**
+ * Fold the legacy `security.allowedMfaMethods` input alias into the canonical
+ * `security.allowedMethods` and drop the alias key so it is never persisted.
+ * Canonical wins on conflict. Mutates and returns the same settings object.
+ */
+function foldAllowedMfaMethodsAlias(settings: unknown): unknown {
+  if (!settings || typeof settings !== 'object') return settings;
+  const s = settings as Record<string, unknown>;
+  const security = s.security;
+  if (!security || typeof security !== 'object') return settings;
+  const sec = security as Record<string, unknown>;
+  if (sec.allowedMfaMethods && typeof sec.allowedMfaMethods === 'object') {
+    sec.allowedMethods = {
+      ...(sec.allowedMfaMethods as Record<string, unknown>),
+      ...((sec.allowedMethods as Record<string, unknown> | undefined) ?? {}),
+    };
+    delete sec.allowedMfaMethods;
+  }
+  return settings;
+}
+```
+
+Apply it in the org settings write (`updateOrgHandler`, `:1238`) — immediately after `const settingsObj = data.settings as Record<string, unknown>;`:
+
+```ts
+    foldAllowedMfaMethodsAlias(data.settings);
+```
+
+Apply it in the `/partners/me` PATCH security deep-merge (`:619`) — replace the `if (body.settings?.security) { newSettings.security = { … } }` block's assignment so the alias is folded first:
+
+```ts
+  if (body.settings?.security) {
+    foldAllowedMfaMethodsAlias(body.settings); // canonicalize before deep-merge
+    newSettings.security = {
+      ...((currentSettings.security as Record<string, unknown> | undefined) ?? {}),
+      ...body.settings.security,
+    };
+  }
+```
+
+> Sweep note (CLAUDE.md rule 7): after implementing, `grep -rn "allowedMfaMethods" apps/api/src` — the ONLY remaining reference must be the schema alias + the normalizer. If any other reader survives, it is reading the dead field; route it through the resolver instead.
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/auth/phone.test.ts src/routes/orgs.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/auth/phone.ts apps/api/src/routes/orgs.ts apps/api/src/routes/auth/phone.test.ts apps/api/src/routes/orgs.test.ts
+git commit -m "feat(auth): enforce canonical MFA allowedMethods; accept legacy alias as input (SR2-05)"
+```
+
+---
+
+### Task 3: Enrollment enforcement via the resolver
+
+**Files:**
+- Modify: `apps/api/src/middleware/auth.ts:482-511` (enrollment gate)
+- Modify: `apps/api/src/routes/auth/login.ts:486-533` (mfaSatisfied + forced-enrollment response)
+- Test: `apps/api/src/middleware/auth.test.ts`, `apps/api/src/routes/auth/login.test.ts`
+
+**Interfaces:**
+- Consumes: `getEffectiveMfaPolicy` (Task 1).
+- Produces: middleware enrollment gate uses `getEffectiveMfaPolicy(...).required` (so org/partner `requireMfa` now forces enrollment, not just role force). Login never mints `mfa=true` for an unenrolled user when policy requires MFA; it mints `mfa=false` and returns a `mfaEnrollmentRequired` signal so the client routes to setup (the middleware exempt paths still let them reach `/auth/mfa/*`). Kill-switch + exempt paths preserved (both live inside the resolver / the existing gate).
+
+- [ ] **Step 1: Write the failing tests**
+
+`auth.test.ts`: with `getEffectiveMfaPolicy` mocked to `{ required: true }` and a user with `mfaEnabled=false` hitting a non-exempt path → 428 `mfa_enrollment_required`; with `required=false` → passes through. (Mock `vi.mock('../services/mfaPolicy', …)`; keep the existing `mfaForcePartnerAdmin`/`userRoleRequiresMfa` mocks only if still referenced.)
+
+`login.test.ts`: mock `getEffectiveMfaPolicy` to `{ required: true, allowedMethods:{totp:true,sms:true,passkey:true} }`; a login for an unenrolled user (`mfaEnabled=false`) → 200, response body has `mfaEnrollmentRequired: true`, and the payload passed to the mocked `createTokenPair` has `mfa: false` (assert via `expect(createTokenPair).toHaveBeenCalledWith(expect.objectContaining({ mfa: false }), …)`). With `required: false` → `mfa: true` as today. Mock the boundary `vi.mock('../../services/mfaPolicy', () => ({ getEffectiveMfaPolicy: vi.fn() }))` and `import { getEffectiveMfaPolicy } from '../../services/mfaPolicy'` in the test.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/middleware/auth.test.ts src/routes/auth/login.test.ts -t 'enrollment'
+```
+Expected: FAIL — gate still calls `userRoleRequiresMfa` (org/partner requireMfa ignored); login still mints vacuous `mfa=true`.
+
+- [ ] **Step 3: Implement — middleware gate**
+
+In `apps/api/src/middleware/auth.ts`, add the import (top of file, with the other `../services` imports):
+
+```ts
+import { getEffectiveMfaPolicy } from '../services/mfaPolicy';
+```
+
+Replace the enrollment-gate body (`:482-511`, the `if (ENABLE_2FA && !user.mfaEnabled) { … }`) so `requiresMfa` comes from the resolver. **Check the exempt path FIRST** and only call the resolver for non-exempt paths — the resolver now runs an extra `getEffectiveOrgSettings` query, and hot polled exempt routes (`/users/me`, `/auth/mfa/*`) must not pay that DB cost on every request (the US DB has a ~25-connection ceiling):
+
+```ts
+  if (ENABLE_2FA && !user.mfaEnabled && !isMfaEnrollmentExemptPath(c.req.path)) {
+    const policy = await getEffectiveMfaPolicy({
+      scope: payload.scope,
+      userId: user.id,
+      orgId: payload.orgId,
+      partnerId: payload.partnerId,
+    });
+
+    if (policy.required) {
+      writeAuditEvent(c, {
+        orgId: payload.orgId ?? null,
+        action: 'auth.mfa.enrollment.required',
+        resourceType: 'user',
+        resourceId: user.id,
+        actorType: 'user',
+        actorId: user.id,
+        actorEmail: user.email,
+        result: 'denied',
+        details: { path: c.req.path, scope: payload.scope, source: policy.source },
+      });
+      return c.json({ error: 'mfa_enrollment_required', enrollUrl: '/auth/mfa/setup' }, 428);
+    }
+  }
+```
+
+The now-unused `userRoleRequiresMfa` function (`:125-169`) becomes dead code — **delete it and its call** (grep to confirm no other caller: `grep -rn "userRoleRequiresMfa" apps/api/src`; `getMfaFactorState` in passkeys.ts uses an inline SQL EXISTS, not this function, so it is unaffected).
+
+- [ ] **Step 3b: Implement — login forced-enrollment response**
+
+In `apps/api/src/routes/auth/login.ts`, add the import to the `'../../services/…'` area:
+
+```ts
+import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
+```
+
+Replace the `mfaSatisfied` computation (`:492-493`) and thread the enrollment flag. After `const scope = context.scope;` (`:489`):
+
+```ts
+  // Resolve effective policy. A user who reaches here is NOT MFA-enrolled (the
+  // enrolled branch above returns early). If policy requires MFA we must NOT
+  // grant vacuous assurance: mint mfa=false and tell the client to enroll. The
+  // middleware exempt paths (/auth/mfa/*, /users/me) still admit the enrollment
+  // flow; every other route 428s until they enroll.
+  const policy = await getEffectiveMfaPolicy({ scope, userId: user.id, orgId, partnerId });
+  const mfaEnrollmentRequired = ENABLE_2FA && !user.mfaEnabled && policy.required;
+  const mfaSatisfied = !ENABLE_2FA || (!user.mfaEnabled && !policy.required);
+```
+
+The `createTokenPair({ … mfa: mfaSatisfied … })` call already exists (`:526`); leave `mfa: mfaSatisfied`. Then add `mfaEnrollmentRequired` + `enrollUrl` to the success response body (find the `return c.json({ user: {…}, tokens: … })` for the password-login success and add):
+
+```ts
+      mfaEnrollmentRequired,
+      enrollUrl: mfaEnrollmentRequired ? '/auth/mfa/setup' : undefined,
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/middleware/auth.test.ts src/routes/auth/login.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/middleware/auth.ts apps/api/src/routes/auth/login.ts apps/api/src/middleware/auth.test.ts apps/api/src/routes/auth/login.test.ts
+git commit -m "feat(auth): enforce MFA enrollment via effective policy; no vacuous mfa=true (SR2-05)"
+```
+
+---
+
+### Task 4: Epoch/status-bound pending MFA (SR2-06)
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/helpers.ts` (add `PendingMfaRecord` type + `parsePendingMfa` + `evaluatePendingMfa`)
+- Modify: `apps/api/src/routes/auth/login.ts:447-455` (write the enriched pending record)
+- Modify: `apps/api/src/routes/auth/mfa.ts:127-214` (TOTP/SMS verify — validate before mint)
+- Modify: `apps/api/src/routes/auth/passkeys.ts:505-531` (`readPendingPasskeyMfa`) + `:277-360` (passkey verify — validate before mint)
+- Test: `apps/api/src/routes/auth/helpers.test.ts`, `login.test.ts`, `auth.passkeys.test.ts`, and the main `auth.test.ts` (TOTP verify)
+
+**Interfaces:**
+- Produces (in `helpers.ts`):
+  ```ts
+  export interface PendingMfaRecord {
+    userId: string;
+    mfaMethod: 'totp' | 'sms' | 'passkey';
+    passkeyAvailable: boolean;
+    authEpoch: number;
+    mfaEpoch: number;
+    statusExpectation: string;           // user.status captured at login
+    allowedMethods: { totp: boolean; sms: boolean; passkey: boolean };
+    expiresAt: number;                   // epoch ms
+  }
+  // Strict parser: legacy bare-userId / epoch-less records return null → callers
+  // reject with the generic "Invalid or expired MFA session" (in-flight legacy
+  // records disappear within the 5-min TTL; forcing re-login is correct).
+  export function parsePendingMfa(raw: string): PendingMfaRecord | null;
+  export function evaluatePendingMfa(
+    record: PendingMfaRecord,
+    live: { status: string; authEpoch: number; mfaEpoch: number },
+  ): { ok: true } | { ok: false; reason: 'expired' | 'epoch_mismatch' | 'status_changed' };
+  ```
+- Decision: method-still-allowed is checked separately at the call site against the resolver (`policy.allowedMethods[effectiveMethod]`), because `evaluatePendingMfa` is pure and does not do IO.
+
+- [ ] **Step 1: Write the failing tests**
+
+`helpers.test.ts`: `parsePendingMfa` on a full JSON record round-trips; on a bare userId string returns null; on JSON missing `authEpoch` returns null. `evaluatePendingMfa`: returns `ok:false reason:'epoch_mismatch'` when `record.mfaEpoch !== live.mfaEpoch`; `status_changed` when `live.status!=='active'` or differs from expectation; `expired` when `expiresAt <= Date.now()`; `ok:true` otherwise.
+
+`auth.test.ts` (TOTP verify, Case 1): with a valid pending record but the live user's `mfaEpoch` advanced past `record.mfaEpoch` → 401 generic `Invalid or expired MFA session`, `createTokenPair` NOT called, and the pending key IS deleted (consumed). With matching epochs + valid code → 200.
+
+`auth.passkeys.test.ts`: passkey verify rejects on epoch mismatch the same way.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/auth/helpers.test.ts src/routes/auth.test.ts src/routes/auth.passkeys.test.ts -t 'pending'
+```
+Expected: FAIL — no `parsePendingMfa`/`evaluatePendingMfa`; completion paths do not compare epochs.
+
+- [ ] **Step 3: Implement — helpers**
+
+Add to `apps/api/src/routes/auth/helpers.ts`:
+
+```ts
+export interface PendingMfaRecord {
+  userId: string;
+  mfaMethod: 'totp' | 'sms' | 'passkey';
+  passkeyAvailable: boolean;
+  authEpoch: number;
+  mfaEpoch: number;
+  statusExpectation: string;
+  allowedMethods: { totp: boolean; sms: boolean; passkey: boolean };
+  expiresAt: number;
+}
+
+/**
+ * Strict parse of a `mfa:pending:<tempToken>` value. Returns null for the
+ * legacy bare-userId form or any record missing the epoch/status binding
+ * (SR2-06): those predate this rollout and must force a fresh login rather than
+ * complete with no live re-check.
+ */
+export function parsePendingMfa(raw: string): PendingMfaRecord | null {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null; // legacy bare-userId string
+  }
+  const method = parsed.mfaMethod;
+  const am = parsed.allowedMethods as Record<string, unknown> | undefined;
+  if (
+    typeof parsed.userId !== 'string' ||
+    (method !== 'totp' && method !== 'sms' && method !== 'passkey') ||
+    typeof parsed.authEpoch !== 'number' ||
+    typeof parsed.mfaEpoch !== 'number' ||
+    typeof parsed.statusExpectation !== 'string' ||
+    typeof parsed.expiresAt !== 'number' ||
+    !am || typeof am !== 'object'
+  ) {
+    return null;
+  }
+  return {
+    userId: parsed.userId,
+    mfaMethod: method,
+    passkeyAvailable: parsed.passkeyAvailable === true,
+    authEpoch: parsed.authEpoch,
+    mfaEpoch: parsed.mfaEpoch,
+    statusExpectation: parsed.statusExpectation,
+    allowedMethods: {
+      totp: am.totp !== false,
+      sms: am.sms !== false,
+      passkey: am.passkey !== false,
+    },
+    expiresAt: parsed.expiresAt,
+  };
+}
+
+/**
+ * Compare a pending record against the live user row. MFA assurance is valid
+ * only for the current MFA config + status (invariants 6/7). Any factor change
+ * bumps mfa_epoch; any account-wide change bumps auth_epoch; a suspend flips
+ * status — all of which must invalidate an in-flight MFA session.
+ */
+export function evaluatePendingMfa(
+  record: PendingMfaRecord,
+  live: { status: string; authEpoch: number; mfaEpoch: number },
+): { ok: true } | { ok: false; reason: 'expired' | 'epoch_mismatch' | 'status_changed' } {
+  if (record.expiresAt <= Date.now()) return { ok: false, reason: 'expired' };
+  if (record.authEpoch !== live.authEpoch || record.mfaEpoch !== live.mfaEpoch) {
+    return { ok: false, reason: 'epoch_mismatch' };
+  }
+  if (live.status !== 'active' || record.statusExpectation !== live.status) {
+    return { ok: false, reason: 'status_changed' };
+  }
+  return { ok: true };
+}
+```
+
+- [ ] **Step 3b: Implement — login writes the enriched record**
+
+In `login.ts`, the MFA-required branch (`:432-455`). It already has `context` (`:375`) so `context.scope/orgId/partnerId` are available. Resolve epochs + policy and write the full record. Replace the `getRedis()!.setex('mfa:pending:…', 300, JSON.stringify({ userId, mfaMethod, passkeyAvailable }))` (`:447`) with:
+
+```ts
+    const pendingEpochs = await getUserEpochs(user.id);
+    if (!pendingEpochs) {
+      await floorPromise;
+      return c.json(genericAuthError(), 401);
+    }
+    const pendingPolicy = await getEffectiveMfaPolicy({
+      scope: context.scope, userId: user.id, orgId: context.orgId, partnerId: context.partnerId,
+    });
+    const PENDING_TTL_SECONDS = 300;
+    const pendingRecord = {
+      userId: user.id,
+      mfaMethod,
+      passkeyAvailable,
+      authEpoch: pendingEpochs.authEpoch,
+      mfaEpoch: pendingEpochs.mfaEpoch,
+      statusExpectation: user.status,
+      allowedMethods: pendingPolicy.allowedMethods,
+      expiresAt: Date.now() + PENDING_TTL_SECONDS * 1000,
+    };
+    await getRedis()!.setex(`mfa:pending:${tempToken}`, PENDING_TTL_SECONDS, JSON.stringify(pendingRecord));
+```
+
+(`getEffectiveMfaPolicy` is imported in Task 3; `getUserEpochs` already imported. `user.status` is on the loaded row.)
+
+- [ ] **Step 3c: Implement — TOTP/SMS verify validates before mint**
+
+In `mfa.ts` Case 1 (`:127-214`). Replace the ad-hoc pending parse (`:133-144`) with `parsePendingMfa`, and after loading the live `user` (`:154-160`) + before verifying the code, evaluate epochs/status and method-allowed. Import `parsePendingMfa`, `evaluatePendingMfa` (add to the `'./helpers'` import list) and `getEffectiveMfaPolicy` (from `'../../services/mfaPolicy'`). Note: `auditUserLoginFailure` (used by the snippets below) is ALREADY imported from `'./helpers'` at mfa.ts:38 and already used at :203 — do NOT add a second import (redeclaration error).
+
+Replace `:133-144`:
+
+```ts
+    const pending = parsePendingMfa(pendingRaw);
+    if (!pending) {
+      return c.json({ error: 'Invalid or expired MFA session' }, 401);
+    }
+    const pendingUserId = pending.userId;
+    const pendingMfaMethod = pending.mfaMethod;
+```
+
+After the live `user` load (`:162`) and before `const effectiveMethod = pendingMfaMethod;` (`:167`), add the binding check. HOIST the `resolveCurrentUserTokenContext(user.id)` call (which the mint currently makes at `:217` to build `mfaContext`) to here so it runs ONCE and its scope/orgId/partnerId feed both the policy check and the token mint below. The audit reason is specific; the public error is generic:
+
+```ts
+    const liveEpochs = await getUserEpochs(user.id);
+    const verdict = liveEpochs
+      ? evaluatePendingMfa(pending, { status: user.status, authEpoch: liveEpochs.authEpoch, mfaEpoch: liveEpochs.mfaEpoch })
+      : ({ ok: false, reason: 'epoch_mismatch' } as const);
+    if (!verdict.ok) {
+      // Consume the record so a rejected session can't be retried.
+      await redis.del(`mfa:pending:${tempToken}`);
+      void auditUserLoginFailure(c, {
+        userId: user.id, email: user.email, name: user.name,
+        reason: 'mfa_pending_invalidated',
+        details: { phase: verdict.reason, method: pendingMfaMethod },
+      });
+      return c.json({ error: 'Invalid or expired MFA session' }, 401);
+    }
+
+    // Resolve the user's token context ONCE (reused for the mint below, which
+    // no longer re-resolves it at :217).
+    const mfaContext = await resolveCurrentUserTokenContext(user.id);
+
+    // Method must still be allowed by current policy (a factor could have been
+    // disallowed since login). Passkey is handled by its own route; here we gate
+    // totp/sms. Use the real scope/org/partner from the resolved context so
+    // org- and partner-scoped policy resolves correctly.
+    const livePolicy = await getEffectiveMfaPolicy({
+      scope: mfaContext.scope,
+      userId: user.id,
+      orgId: mfaContext.orgId,
+      partnerId: mfaContext.partnerId,
+    });
+    if ((pendingMfaMethod === 'sms' && !livePolicy.allowedMethods.sms) ||
+        (pendingMfaMethod === 'totp' && !livePolicy.allowedMethods.totp)) {
+      await redis.del(`mfa:pending:${tempToken}`);
+      void auditUserLoginFailure(c, {
+        userId: user.id, email: user.email, name: user.name,
+        reason: 'mfa_method_not_allowed', details: { method: pendingMfaMethod },
+      });
+      return c.json({ error: 'This MFA method is no longer permitted. Please sign in again.' }, 401);
+    }
+```
+
+> Note: because `mfaContext` is now resolved here, DELETE the later `const mfaContext = await resolveCurrentUserTokenContext(user.id);` at `:217` and reuse this hoisted binding for the mint (`mfaRoleId`/`mfaPartnerId`/`mfaOrgId`/`mfaScope` are still derived from `mfaContext` exactly as before). One lookup, no contradiction between this snippet and the mint.
+
+The existing `redis.del` at `:214` (before mint) stays — it is the atomic consume on the success path. Leave the code-verification and mint below unchanged (they already mint epoch-valid tokens from PR 1).
+
+- [ ] **Step 3d: Implement — passkey verify validates before mint**
+
+In `passkeys.ts`, extend `readPendingPasskeyMfa` (`:505-531`) to reuse `parsePendingMfa` so the pending object carries the epoch/status fields, and change `PendingPasskeyMfa` to `PendingMfaRecord`. Simplest: replace the body with:
+
+```ts
+async function readPendingPasskeyMfa(tempToken: string): Promise<PendingMfaRecord | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+  const raw = await redis.get(`mfa:pending:${tempToken}`);
+  if (!raw) return null;
+  return parsePendingMfa(raw);
+}
+```
+
+Import `parsePendingMfa`, `evaluatePendingMfa`, `getUserEpochs` (already imported). In the passkey verify handler (`:277-336`), after the existing `if (user.status !== 'active')` check (`:304`) add the epoch binding (the status check already exists — keep it; add epochs):
+
+```ts
+  const liveEpochs = await getUserEpochs(user.id);
+  const verdict = liveEpochs
+    ? evaluatePendingMfa(pending, { status: user.status, authEpoch: liveEpochs.authEpoch, mfaEpoch: liveEpochs.mfaEpoch })
+    : ({ ok: false, reason: 'epoch_mismatch' } as const);
+  if (!verdict.ok) {
+    await redis.del(`mfa:pending:${tempToken}`);
+    return c.json({ error: 'Invalid or expired MFA session' }, 401);
+  }
+```
+
+Passkey is always an allowed method (Task 1), so no method-allowed gate is needed here. The existing `redis.del` at `:360` remains the success-path consume.
+
+`pendingAllowsPasskey(pending)` (used at `:235`/`:282`) reads `pending.passkeyAvailable` / method — it still works against `PendingMfaRecord` (same fields). Confirm its implementation references only `userId`/`mfaMethod`/`passkeyAvailable`; if it narrows to the old `PendingPasskeyMfa` type name, update the type reference.
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/auth/helpers.test.ts src/routes/auth.test.ts src/routes/auth.passkeys.test.ts src/routes/auth/login.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/auth/helpers.ts apps/api/src/routes/auth/login.ts apps/api/src/routes/auth/mfa.ts apps/api/src/routes/auth/passkeys.ts apps/api/src/routes/auth/helpers.test.ts apps/api/src/routes/auth.test.ts apps/api/src/routes/auth.passkeys.test.ts
+git commit -m "feat(auth): epoch/status-bound pending MFA records (SR2-06)"
+```
+
+---
+
+### Task 5: Consuming TOTP setup verifier (SR2-24)
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/mfa.ts:303` (setup-confirm) and `:506` (/mfa/enable)
+- Test: `apps/api/src/routes/auth.test.ts`
+
+**Interfaces:**
+- Consumes: `consumeMFAToken(secret, code, userId)` (`services/mfa.ts` — already imported into mfa.ts).
+- Produces: setup-confirm and `/mfa/enable` verify the code with the CONSUMING verifier, so the accepted time step is recorded (`mfa:usedstep:<userId>`) and cannot be replayed at login within its validity window.
+
+- [ ] **Step 1: Write the failing test**
+
+`auth.test.ts`: drive setup-confirm with a valid TOTP code → 200; then assert a login `/mfa/verify` with the SAME code (same time step) for that user is rejected (401) because the step was consumed. Since `consumeMFAToken` is Redis-Lua backed, use the file's existing Redis mock and assert `consumeMFAToken` (mocked) is called for setup-confirm — or, if the suite runs real `services/mfa`, assert the second use returns 401. Minimum viable assertion: `expect(consumeMFAToken).toHaveBeenCalledWith(expect.any(String), code, auth.user.id)` for the setup-confirm path (proves the consuming verifier replaced the plain one).
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/auth.test.ts -t 'setup'
+```
+Expected: FAIL — setup-confirm calls the plain `verifyMFAToken` (non-consuming), so replay isn't prevented / the mock isn't called.
+
+- [ ] **Step 3: Implement**
+
+In `mfa.ts` setup-confirm (`:303`), replace:
+
+```ts
+  const valid = await verifyMFAToken(secret, code);
+```
+with:
+```ts
+  // Consuming verifier: record the accepted time step so it cannot be replayed
+  // at login within its ~90s validity window (SR2-24). Fails closed if Redis is
+  // down (consumeMFAToken returns false).
+  const valid = await consumeMFAToken(secret, code, auth.user.id);
+```
+
+Apply the identical replacement in `/mfa/enable` (`:506`, same `const valid = await verifyMFAToken(secret, code);` line → `consumeMFAToken(secret, code, auth.user.id)`).
+
+`verifyMFAToken` is now unused in mfa.ts — remove it from the `'../../services'` import list (`:10`) if no other reference remains (`grep -n verifyMFAToken apps/api/src/routes/auth/mfa.ts`).
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/auth.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/auth/mfa.ts apps/api/src/routes/auth.test.ts
+git commit -m "feat(auth): consume TOTP time step at MFA setup/enable (SR2-24)"
+```
+
+---
+
+### Task 6: Recovery-code login (SR2-09)
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/schemas.ts:45-49` (`mfaVerifySchema`)
+- Modify: `apps/api/src/routes/auth/mfa.ts:126-284` (recovery branch in Case 1)
+- Test: `apps/api/src/routes/auth.test.ts` (unit); concurrency single-winner lives in Task 9 integration.
+
+**Interfaces:**
+- Consumes: `hashRecoveryCode(code)` (`helpers.ts` — sha256 of `pepper + ':' + code.trim().toUpperCase()`); `users.mfaRecoveryCodes` (jsonb array of hex hashes); `parsePendingMfa`/`evaluatePendingMfa` (Task 4).
+- Produces: `mfaVerifySchema.code` accepts a 6-digit TOTP/SMS code OR the `XXXX-XXXX` recovery form; `method` enum gains `'recovery'`. The verify handler grows a recovery branch that hashes the normalized input and atomically removes exactly one matching hash from `mfaRecoveryCodes` (one winner under concurrency), mints only after BOTH the recovery-code removal AND the pending record are consumed, and audits without any code material.
+
+- [ ] **Step 1: Write the failing tests**
+
+`auth.test.ts`: (a) `mfaVerifySchema` accepts `code: 'ABCD-2345'` with `method:'recovery'` and a 6-digit code with `method:'totp'`; (b) a login `/mfa/verify` with `method:'recovery'` and a code whose hash is in the user's `mfaRecoveryCodes` → 200 and the used hash is removed from the persisted array (assert the `update().set()` payload's `mfaRecoveryCodes` no longer contains it); (c) an unknown recovery code → 401 with no code material in any audit call.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/auth/schemas.test.ts src/routes/auth.test.ts -t 'recovery'
+```
+Expected: FAIL — schema rejects the 9-char code / no `recovery` method; handler has no recovery branch.
+
+- [ ] **Step 3: Implement — schema**
+
+In `apps/api/src/routes/auth/schemas.ts`, replace `mfaVerifySchema` (`:45-49`):
+
+```ts
+// TOTP/SMS codes are 6 digits; recovery codes are `XXXX-XXXX` (8 [A-Z0-9]
+// with a hyphen). Accept either shape here; the handler routes on `method`.
+const totpOrSmsCode = /^\d{6}$/;
+const recoveryCode = /^[A-Z0-9]{4}-[A-Z0-9]{4}$/i;
+export const mfaVerifySchema = z.object({
+  code: z.string().refine(
+    (v) => totpOrSmsCode.test(v.trim()) || recoveryCode.test(v.trim()),
+    { message: 'Invalid code format' },
+  ),
+  tempToken: z.string().optional(),
+  method: z.enum(['totp', 'sms', 'recovery']).optional(),
+});
+```
+
+> `mfaDisableSchema = mfaVerifySchema.extend({ currentPassword })` (`mfa.ts:56`) inherits the relaxed `code` — acceptable (disable still verifies a live TOTP/SMS code; a recovery code won't match the TOTP/SMS branch and is rejected there). No change needed to disable.
+
+- [ ] **Step 3b: Implement — recovery branch**
+
+In `mfa.ts` Case 1, after `const effectiveMethod = pendingMfaMethod;` is established and the epoch/status/method checks (Task 4) pass, add a recovery branch that runs when the CLIENT explicitly requests recovery. Read `method` from the validated body (add `method` to the destructure at `:119`: `const { code, tempToken, method } = c.req.valid('json');`).
+
+Insert BEFORE the `if (effectiveMethod === 'sms')` block (`:175`):
+
+```ts
+    // Recovery-code login. Independent of the account's primary factor: a user
+    // locked out of their authenticator falls back to a stored recovery code.
+    // Remove exactly one matching hash with a server-side RELATIVE jsonb delete
+    // (`mfaRecoveryCodes - inputHash`) guarded by `@> [inputHash]`. This is the
+    // ONLY correct concurrency shape — it composes under READ COMMITTED:
+    //   - two concurrent DISTINCT valid codes each delete their OWN element from
+    //     the row's committed value (Postgres re-evaluates `-` against the
+    //     latest committed array), so both succeed and NEITHER resurrects the
+    //     other's hash. A stale read-modify-write (SET = a JS array computed
+    //     from a pre-read snapshot) would resurrect the co-winner's hash — never
+    //     do that.
+    //   - two concurrent IDENTICAL codes serialize on the row; the loser's `@>`
+    //     guard fails against the winner's committed value → rowCount 0 → 401.
+    // Single-winner AND no-resurrection are proven against real Postgres (Task 9).
+    if (method === 'recovery') {
+      const inputHash = hashRecoveryCode(code);
+      const stored = Array.isArray(user.mfaRecoveryCodes) ? (user.mfaRecoveryCodes as string[]) : [];
+      if (!stored.includes(inputHash)) {
+        void auditUserLoginFailure(c, {
+          userId: user.id, email: user.email, name: user.name,
+          reason: 'mfa_recovery_code_invalid', details: { method: 'recovery' },
+        });
+        return c.json({ error: 'Invalid MFA code' }, 401);
+      }
+      const removed = await withSystemDbAccessContext(() =>
+        db
+          .update(users)
+          .set({ mfaRecoveryCodes: sql`${users.mfaRecoveryCodes} - ${inputHash}`, updatedAt: new Date() })
+          .where(and(eq(users.id, user.id), sql`${users.mfaRecoveryCodes} @> ${JSON.stringify([inputHash])}::jsonb`))
+          .returning({ id: users.id }),
+      );
+      if (removed.length === 0) {
+        // A concurrent winner already consumed this exact hash — reject the loser.
+        return c.json({ error: 'Invalid MFA code' }, 401);
+      }
+      writeAuthAudit(c, {
+        orgId: undefined,
+        action: 'auth.mfa.recovery_code.used',
+        result: 'success',
+        userId: user.id,
+        email: user.email,
+        // Best-effort count from the PRE-update snapshot only — never read the
+        // post-update array back, and never log the code or its hash.
+        details: { remainingApprox: Math.max(0, stored.length - 1) },
+      });
+      valid = true;
+    } else if (effectiveMethod === 'sms') {
+      // …existing SMS branch…
+```
+
+> Wiring notes: (1) `valid` is already declared `let valid = false;` at `:169`. The recovery branch removes the code hash + sets `valid = true`; it does NOT call `redis.del`. The single existing `await redis.del(\`mfa:pending:${tempToken}\`)` at `:214` consumes the pending record for ALL branches (recovery included), so there is exactly one pending-record consume and no double-delete. The code below `if (!valid)` (`:202`) and the shared mint (`:216-283`) run unchanged. (2) Import `hashRecoveryCode`, `writeAuthAudit` from `'./helpers'`, and `and`, `sql` from `'drizzle-orm'` (add `and`, `sql` to the existing `import { eq } from 'drizzle-orm'` at `mfa.ts:3`). (3) `user.mfaRecoveryCodes` is selected because Case-1 loads `db.select()` (full row) at `:154-160`.
+
+> M3 — DB context: the recovery UPDATE uses a bare `withSystemDbAccessContext` (no `runOutsideDbContext` wrap) because Case-1 tempToken verification is UNAUTHENTICATED — it runs with NO ambient request DB context, so there is nothing to escape first. (Contrast the self-service factor handlers in Task 7, which run inside a request context and therefore must NOT introduce a system wrap.)
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/auth/schemas.test.ts src/routes/auth.test.ts
+```
+Expected: PASS. (The concurrent single-winner proof is Task 9.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/auth/schemas.ts apps/api/src/routes/auth/mfa.ts apps/api/src/routes/auth/schemas.test.ts apps/api/src/routes/auth.test.ts
+git commit -m "feat(auth): recovery-code login with atomic single-use consumption (SR2-09)"
+```
+
+---
+
+### Task 7: Factor-change invalidation (SR2-07 / SR2-19)
+
+**Files:**
+- Create: `apps/api/src/services/mfaAssurance.ts` + `mfaAssurance.test.ts`
+- Modify: factor handlers in `mfa.ts` (`/mfa/enable`, `/mfa/disable`, `/mfa/recovery-codes`), `phone.ts` (`/mfa/sms/enable`, `/phone/confirm` replacement case), `passkeys.ts` (`/passkeys/register/verify`, `DELETE /passkeys/:id`)
+- Modify (I3): route the `/mfa/disable` requireMfa BLOCK and the passkey last-factor guard (`getMfaFactorState`) through `getEffectiveMfaPolicy` instead of the direct `organizations.settings` read
+- Test: sibling route suites + `mfaAssurance.test.ts`; real-PG atomicity in Task 9.
+
+**Interfaces:**
+- Consumes: `advanceUserEpochs`, `revokeAllRefreshFamilies`, `runPostCommitCleanup`, `Tx` (`services/authLifecycle.ts`); `terminateUserRemoteSessions`, `TEARDOWN_FAILED` (`services/remoteSessionTeardown.ts`); `db`, `db.transaction` (`db/index.ts`).
+- Produces:
+  ```ts
+  export interface FactorChangeResult {
+    mfaEpoch: number;
+    cleanup: import('./authLifecycle').PostCommitCleanupResult;
+    remoteSessionsTerminated: number; // >=0, or TEARDOWN_FAILED (-1) = partial op failure
+  }
+  /**
+   * Invalidate all MFA assurance after a factor change. In ONE transaction:
+   * runs the optional business `mutate(tx)` (the factor write itself, folded in
+   * for atomicity), advances mfa_epoch, and revokes every refresh family. Then
+   * post-commit (best-effort, never restores validity): Redis/permission/OAuth
+   * cleanup + remote-session teardown. Deliberate global sign-out.
+   *
+   * Runs under the caller's ambient (user-scoped) request context: writes touch
+   * the user's OWN users row + OWN refresh_token_families, which Shape-6 /
+   * user-id RLS admits. Do NOT wrap self-service callers in system context.
+   */
+  export async function invalidateMfaAssuranceAfterFactorChange(
+    userId: string,
+    reason: string,
+    mutate?: (tx: Tx) => Promise<void>,
+  ): Promise<FactorChangeResult>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+`mfaAssurance.test.ts` (mock `../db` `transaction`, `./authLifecycle`, `./remoteSessionTeardown`): asserts (a) `mutate` runs inside the tx before `advanceUserEpochs(tx, userId, { mfa: true })` and `revokeAllRefreshFamilies(tx, userId, reason)`; (b) post-commit `runPostCommitCleanup(userId)` AND `terminateUserRemoteSessions(userId)` both run; (c) `remoteSessionsTerminated === TEARDOWN_FAILED` is surfaced (not swallowed, not thrown) when teardown returns `-1`; (d) a throw inside `mutate` rejects and neither post-commit step runs (tx rolled back).
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/services/mfaAssurance.test.ts
+```
+Expected: FAIL — cannot find module `./mfaAssurance`.
+
+- [ ] **Step 3: Implement — service**
+
+Create `apps/api/src/services/mfaAssurance.ts`:
+
+```ts
+import * as dbModule from '../db';
+import {
+  advanceUserEpochs,
+  revokeAllRefreshFamilies,
+  runPostCommitCleanup,
+  type Tx,
+  type PostCommitCleanupResult,
+} from './authLifecycle';
+import { terminateUserRemoteSessions } from './remoteSessionTeardown';
+
+export interface FactorChangeResult {
+  mfaEpoch: number;
+  cleanup: PostCommitCleanupResult;
+  remoteSessionsTerminated: number;
+}
+
+/**
+ * Invalidate MFA assurance after a factor add/remove/replace/rotate (SR2-07,
+ * SR2-19). Atomic durable effect (invariant 3): mutate + mfa_epoch advance +
+ * refresh-family revoke commit together or not at all. Post-commit cleanup and
+ * remote-session teardown are best-effort — teardown failure is surfaced as a
+ * partial operational failure via TEARDOWN_FAILED (-1) but NEVER restores token
+ * validity. Runs under the caller's ambient user-scoped context (self-service).
+ */
+export async function invalidateMfaAssuranceAfterFactorChange(
+  userId: string,
+  reason: string,
+  mutate?: (tx: Tx) => Promise<void>,
+): Promise<FactorChangeResult> {
+  const epochRow = await dbModule.db.transaction(async (tx: Tx) => {
+    if (mutate) await mutate(tx);
+    const row = await advanceUserEpochs(tx, userId, { mfa: true });
+    await revokeAllRefreshFamilies(tx, userId, reason);
+    return row;
+  });
+
+  const cleanup = await runPostCommitCleanup(userId);
+  const remoteSessionsTerminated = await terminateUserRemoteSessions(userId);
+
+  return { mfaEpoch: epochRow.mfaEpoch, cleanup, remoteSessionsTerminated };
+}
+```
+
+- [ ] **Step 3b: Wire into every mutating factor handler**
+
+For each handler, MOVE its existing `db.update(users)…`/insert/delete of the factor into the `mutate(tx)` callback so the factor write and the epoch bump/revoke are one transaction, then use the returned `result` to write a single assurance audit. `reason` ≤ 64 chars. Import `invalidateMfaAssuranceAfterFactorChange` and `TEARDOWN_FAILED` in each route file.
+
+**mfa.ts `/mfa/enable`** (`:522-531`): replace the standalone `await db.update(users).set({ mfaEnabled:true, … })` with:
+```ts
+  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'mfa-enable', async (tx) => {
+    await tx.update(users).set({
+      mfaSecret: encryptMfaSecret(secret), mfaEnabled: true, mfaMethod: 'totp',
+      mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes), updatedAt: new Date(),
+    }).where(eq(users.id, auth.user.id));
+  });
+```
+(add a `details: { mfaEpoch: result.mfaEpoch, teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED }` line to the existing `auth.mfa.setup` success audit).
+
+**mfa.ts setup-confirm** (`:319-328`): same fold (`reason: 'mfa-setup-confirm'`).
+
+**mfa.ts `/mfa/disable`** (`:441-452`): fold the `mfaSecret:null, mfaEnabled:false, …` update into `mutate` (`reason: 'mfa-disable'`).
+
+**mfa.ts `/mfa/recovery-codes`** (`:572-578`): fold the `mfaRecoveryCodes` rotate into `mutate` (`reason: 'mfa-recovery-rotate'`). Note: rotating recovery codes advances `mfa_epoch` and signs the user out — per SR2-19 this is intended (recovery-code set is part of the MFA config).
+
+**phone.ts `/mfa/sms/enable`** (`:223-232`): fold the enable update into `mutate` (`reason: 'sms-mfa-enable'`).
+
+**phone.ts `/phone/confirm`** (`:150-157`): **replacement-only.** Phone verification during initial SMS enrollment must NOT sign the user out (they still need to call `/mfa/sms/enable`). Only invalidate when this is a *replacement* of a phone backing an ACTIVE SMS factor. Load the current `mfaMethod`/`mfaEnabled` first:
+```ts
+  const [cur] = await db.select({ mfaEnabled: users.mfaEnabled, mfaMethod: users.mfaMethod })
+    .from(users).where(eq(users.id, auth.user.id)).limit(1);
+  const isSmsFactorReplacement = cur?.mfaEnabled === true && cur.mfaMethod === 'sms';
+  if (isSmsFactorReplacement) {
+    await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'phone-replacement', async (tx) => {
+      await tx.update(users).set({ phoneNumber, phoneVerified: true, updatedAt: new Date() }).where(eq(users.id, auth.user.id));
+    });
+  } else {
+    await db.update(users).set({ phoneNumber, phoneVerified: true, updatedAt: new Date() }).where(eq(users.id, auth.user.id));
+  }
+```
+
+**passkeys.ts `/passkeys/register/verify`** (`:169-208`): fold BOTH the `user_passkeys` insert AND the `users` mfaEnabled update into `mutate`, capturing the inserted row via a closure variable (`reason: 'passkey-register'`):
+```ts
+  let inserted: typeof userPasskeys.$inferSelect | undefined;
+  await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'passkey-register', async (tx) => {
+    const [row] = await tx.insert(userPasskeys).values({ /* …existing fields… */ }).returning();
+    if (!row) throw new Error('Passkey insert returned no row');
+    inserted = row;
+    const [currentMfa] = await tx.select({ mfaSecret: users.mfaSecret, mfaMethod: users.mfaMethod })
+      .from(users).where(eq(users.id, auth.user.id)).limit(1);
+    const hasExistingFactor = Boolean(currentMfa?.mfaSecret) || currentMfa?.mfaMethod === 'sms';
+    await tx.update(users).set({ mfaEnabled: true, ...(hasExistingFactor ? {} : { mfaMethod: 'passkey' }), updatedAt: new Date() })
+      .where(eq(users.id, auth.user.id));
+  });
+```
+(use `inserted` in the response `toPublicPasskey(inserted)`).
+
+**passkeys.ts `DELETE /passkeys/:id`** (`:469-491`): fold the `delete(userPasskeys)` + the conditional `users` update into `mutate` (`reason: 'passkey-delete'`). Keep the last-factor guard (`:465`) BEFORE the call.
+
+> DB-context note: all seven handlers are `authMiddleware`-gated and act on the CALLER's own rows, so the ambient user-scoped `db.transaction` inside `invalidateMfaAssuranceAfterFactorChange` is correct (Shape-6 / user-id RLS admits self-writes). `terminateUserRemoteSessions` internally does its own `runOutsideDbContext + withSystemDbAccessContext`, so it is safe to call from within the request context.
+
+- [ ] **Step 3c: Route the disable-block + last-factor guard through the resolver (I3, SR2-05 on the factor surface)**
+
+Both `/mfa/disable` and the passkey last-factor guard currently read `organizations.settings.security.requireMfa` DIRECTLY and only for `auth.orgId` — bypassing partner inheritance and ignoring partner-scope users. Switch both to `getEffectiveMfaPolicy(...).required` so a partner-set `requireMfa` correctly blocks disable / last-factor removal. Import `getEffectiveMfaPolicy` from `'../../services/mfaPolicy'` in both files.
+
+**mfa.ts `/mfa/disable`** — replace the org-policy block (`mfa.ts:361-373`, the `if (auth.orgId) { … const orgSettings = org?.settings … requireMfa … }`) with:
+
+```ts
+  // MFA policy blocks self-disable when effective policy (role OR org/partner
+  // requireMfa, partner-inherited) still requires MFA for this user. Uses the
+  // resolver so a partner-set requireMfa — invisible to the old org-only read —
+  // is honored, and partner-scope users are covered.
+  const disablePolicy = await getEffectiveMfaPolicy({
+    scope: auth.scope,
+    userId: auth.user.id,
+    orgId: auth.orgId ?? null,
+    partnerId: auth.partnerId ?? null,
+  });
+  if (disablePolicy.required) {
+    return c.json({ error: 'Your organization requires MFA. Contact your admin to change this policy.' }, 403);
+  }
+```
+
+(Remove the now-unused direct `organizations` import from mfa.ts only if no other reference remains — `grep -n organizations src/routes/auth/mfa.ts`.)
+
+**passkeys.ts last-factor guard (`getMfaFactorState`, `:549-603`)** — keep its factor-count logic (`passkeyCount`/`hasTotp`/`hasSms`) exactly, but replace the `mfaRequired` source. Today it derives `mfaRequired` from the inline `forceMfa` EXISTS + the org-only `orgRequiresMfa` EXISTS. Drop the `orgRequiresMfa` SQL sub-select and compute `mfaRequired` from the resolver instead:
+
+```ts
+  const policy = await getEffectiveMfaPolicy({
+    scope: auth.scope,
+    userId: auth.user.id,
+    orgId: auth.orgId ?? null,
+    partnerId: auth.partnerId ?? null,
+  });
+  // …run the existing system-context factor-count query (passkeyCount/hasTotp/
+  // hasSms/currentMfaMethod) WITHOUT the forceMfa/orgRequiresMfa columns…
+  return {
+    passkeyCount: Number(state?.passkeyCount ?? 0),
+    hasTotp: Boolean(state?.hasTotp),
+    hasSms: Boolean(state?.hasSms),
+    currentMfaMethod: state?.currentMfaMethod ?? null,
+    mfaRequired: policy.required,
+  };
+```
+
+This closes SR2-05 on the factor-operation surface: a partner-set `requireMfa` now blocks both disable and last-factor removal, matching enrollment/login.
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/services/mfaAssurance.test.ts src/routes/auth.test.ts src/routes/auth.passkeys.test.ts src/routes/auth/phone.test.ts
+```
+Expected: PASS. (Route suites: update the mocked `db.transaction`/`authLifecycle`/`remoteSessionTeardown` factories to satisfy the new call — mirror the `auth.test.ts` `stubTx()` + `runPostCommitCleanup` mock convention from PR 1; mock `terminateUserRemoteSessions → 0`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/mfaAssurance.ts apps/api/src/services/mfaAssurance.test.ts apps/api/src/routes/auth/mfa.ts apps/api/src/routes/auth/phone.ts apps/api/src/routes/auth/passkeys.ts apps/api/src/routes/auth.test.ts apps/api/src/routes/auth.passkeys.test.ts apps/api/src/routes/auth/phone.test.ts
+git commit -m "feat(auth): invalidate MFA assurance (epoch+family+remote) on factor change (SR2-07,SR2-19)"
+```
+
+---
+
+### Task 8: Existing-factor step-up for factor addition (SR2-20)
+
+**Files:**
+- Create: `apps/api/src/services/mfaStepUpGrant.ts` + `mfaStepUpGrant.test.ts`
+- Modify: `apps/api/src/routes/auth/mfa.ts` (new `POST /auth/mfa/step-up` mint endpoint incl. passkey-assertion proof; grant gate on `/mfa/enable` + setup-confirm) + `apps/api/src/routes/auth/schemas.ts` (discriminated-union step-up schema + `stepUpGrantId` on factor-add schemas)
+- Modify: `apps/api/src/routes/auth/passkeys.ts` (new authenticated `POST /auth/mfa/step-up/options` challenge issuer; exported `verifyStepUpPasskeyAssertion` helper; `/passkeys/register/options` + `/verify` require the grant when already protected)
+- Modify: `apps/api/src/routes/auth/phone.ts` (`/mfa/sms/enable` grant gate when already protected)
+- Modify: `apps/api/src/routes/auth/helpers.ts` (shared `userIsMfaProtected` + `enforceExistingFactorStepUp` route helper, used by all four factor-addition surfaces)
+- Test: `mfaStepUpGrant.test.ts`, `auth.test.ts`, `auth.passkeys.test.ts`, `phone.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export interface StepUpGrant {
+    id: string;
+    userId: string;
+    operation: 'add_factor';
+    authEpoch: number;
+    mfaEpoch: number;
+    sid: string;            // initiating access-token session id
+  }
+  // Redis key `mfa:stepup:<id>`, TTL 300s.
+  export async function mintStepUpGrant(
+    input: { userId: string; operation: 'add_factor'; authEpoch: number; mfaEpoch: number; sid: string },
+  ): Promise<string | null>;                 // returns grant id, null if Redis down (fail closed at caller)
+  export async function validateStepUpGrant(
+    id: string, bind: Omit<StepUpGrant, 'id'>,
+  ): Promise<boolean>;                        // non-consuming (register/options)
+  export async function consumeStepUpGrant(
+    id: string, bind: Omit<StepUpGrant, 'id'>,
+  ): Promise<boolean>;                        // single-use via getdel (register/verify)
+  ```
+- Decisions:
+  - **SR2-20 is generic to ANY factor addition** (design §"Factor enrollment and changes"). So the grant gates EVERY factor-add surface on an already-protected account, not just passkeys: `/mfa/enable` + setup-confirm (TOTP add/replace), `/mfa/sms/enable` (SMS add), and `/passkeys/register/*` (passkey add). Each keeps its existing `requireCurrentPasswordStepUp` too — password AND a fresh existing-factor proof (design says "additionally").
+  - **Initial enrollment (account has NO factor)** keeps today's behavior: current-password step-up only. No grant required (`enforceExistingFactorStepUp` returns null when `!userIsMfaProtected`). Avoids the chicken-and-egg lockout.
+  - **Adding a factor to an ALREADY-PROTECTED account** additionally requires a fresh existing-factor proof: the client first calls `POST /auth/mfa/step-up` proving an existing factor, which mints a grant; the factor-add endpoint then requires it. `/passkeys/register/options` uses `validateStepUpGrant` (non-consuming — the same grant is consumed at `/verify`); every terminal factor-write (`/verify`, `/mfa/enable`, setup-confirm, `/mfa/sms/enable`) uses `consumeStepUpGrant` (single-use getdel) at the write point.
+  - **Existing-factor proof accepts ALL factor types** so a passkey-ONLY user is not locked out: `POST /auth/mfa/step-up` takes a TOTP code, an SMS code, OR a WebAuthn passkey assertion (discriminated union on `method`). The passkey proof reuses the authentication challenge/verify flow: the client first calls `POST /auth/mfa/step-up/options` (authenticated) to get a challenge, runs a passkey `get()` ceremony, then submits the assertion to `/auth/mfa/step-up` with `method:'passkey'`.
+  - Binding: grant `sid` must equal the caller's `auth.token.sid`; `authEpoch`/`mfaEpoch` are re-validated against the LIVE row at validate/consume (any factor change bumps `mfa_epoch` + revokes families → a stale grant is invalid). Fails closed on Redis ambiguity.
+
+- [ ] **Step 1: Write the failing test**
+
+`mfaStepUpGrant.test.ts` (mock `./redis` `getRedis`): `mintStepUpGrant` writes `mfa:stepup:<id>` with TTL 300 and returns the id; `validateStepUpGrant` returns true only when id exists AND all bind fields match, false on any mismatch; `consumeStepUpGrant` uses `getdel` (single-use) — a second consume of the same id returns false; both return false when `getRedis()` is null.
+
+`auth.passkeys.test.ts`: an already-protected account (mock `userIsMfaProtected → true`) calling `/passkeys/register/options` WITHOUT a valid grant → 403; WITH a valid grant → 200. A no-factor account (`userIsMfaProtected → false`) without a grant still → 200 (password-only path preserved).
+
+`auth.test.ts`: (a) already-protected account calling `/mfa/enable` (and setup-confirm) WITHOUT a grant → 403; WITH a consumed grant → succeeds. (b) `/auth/mfa/step-up` with `method:'passkey'` and a valid assertion for a passkey-only user mints a grant (assert `mintStepUpGrant` called) — proving a passkey-only user is not locked out. `phone.test.ts`: already-protected account calling `/mfa/sms/enable` WITHOUT a grant → 403; WITH a grant → succeeds.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/services/mfaStepUpGrant.test.ts src/routes/auth.passkeys.test.ts -t 'step-up'
+```
+Expected: FAIL — module missing; options/verify enforce no grant.
+
+- [ ] **Step 3: Implement — grant service**
+
+Create `apps/api/src/services/mfaStepUpGrant.ts`:
+
+```ts
+import { randomUUID } from 'crypto';
+import { getRedis } from './redis';
+
+export interface StepUpGrant {
+  id: string;
+  userId: string;
+  operation: 'add_factor';
+  authEpoch: number;
+  mfaEpoch: number;
+  sid: string;
+}
+type GrantBind = Omit<StepUpGrant, 'id'>;
+const TTL_SECONDS = 300;
+const key = (id: string) => `mfa:stepup:${id}`;
+
+function bindsMatch(record: GrantBind, bind: GrantBind): boolean {
+  return record.userId === bind.userId
+    && record.operation === bind.operation
+    && record.authEpoch === bind.authEpoch
+    && record.mfaEpoch === bind.mfaEpoch
+    && record.sid === bind.sid;
+}
+
+/** Mint a short-lived single-use step-up grant. Returns null if Redis is down. */
+export async function mintStepUpGrant(bind: GrantBind): Promise<string | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+  const id = randomUUID();
+  await redis.setex(key(id), TTL_SECONDS, JSON.stringify(bind));
+  return id;
+}
+
+/** Non-consuming check (register/options). Fails closed on Redis error/miss. */
+export async function validateStepUpGrant(id: string, bind: GrantBind): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  try {
+    const raw = await redis.get(key(id));
+    if (!raw) return false;
+    return bindsMatch(JSON.parse(raw) as GrantBind, bind);
+  } catch { return false; }
+}
+
+/** Single-use consume via getdel (register/verify). Fails closed. */
+export async function consumeStepUpGrant(id: string, bind: GrantBind): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  try {
+    const raw = await redis.getdel(key(id));
+    if (!raw) return false;
+    return bindsMatch(JSON.parse(raw) as GrantBind, bind);
+  } catch { return false; }
+}
+```
+
+- [ ] **Step 3b: Implement — mint endpoint**
+
+In `schemas.ts`, add a discriminated union so a passkey-only user can also prove an existing factor. The passkey assertion is shape-checked here (`.passthrough()`) and cryptographically verified downstream by `verifyPasskeyAuthentication`; do NOT import the passkeys route's `webAuthnCredentialSchema` here (that would create a `schemas.ts` ↔ `passkeys.ts` import cycle):
+
+```ts
+const stepUpSixDigit = z.string().refine((v) => /^\d{6}$/.test(v.trim()), { message: 'Invalid code' });
+const stepUpAssertion = z.object({ id: z.string().min(1) }).passthrough(); // full WebAuthn assertion
+export const mfaStepUpSchema = z.discriminatedUnion('method', [
+  z.object({ method: z.literal('totp'), code: stepUpSixDigit }),
+  z.object({ method: z.literal('sms'), code: stepUpSixDigit }),
+  z.object({ method: z.literal('passkey'), credential: stepUpAssertion }),
+]);
+
+// `stepUpGrantId` added to every factor-ADDITION request schema so an
+// already-protected account can present its fresh existing-factor grant.
+// Add this field to: mfaEnableWithPasswordSchema (mfa.ts, /mfa/enable),
+// mfaVerifySchema (setup-confirm Case 2), smsMfaEnableSchema (phone.ts),
+// registerOptionsSchema + registerVerifySchema (passkeys.ts):
+//   stepUpGrantId: z.string().optional(),
+```
+
+In `passkeys.ts`, add the authenticated challenge issuer and export the assertion-verify helper (keeps ALL WebAuthn machinery in the passkeys module — mfa.ts just calls a boolean helper, no route-local imports leak):
+
+```ts
+// Authenticated passkey step-up challenge (mirrors /mfa/passkey/options, but
+// keyed on the logged-in user rather than a login tempToken).
+passkeyRoutes.post('/mfa/step-up/options', authMiddleware, async (c) => {
+  if (!ENABLE_2FA) return mfaDisabledResponse(c);
+  const auth = c.get('auth');
+  const passkeys = await withSystemDbAccessContext(() => listActivePasskeys(auth.user.id));
+  if (passkeys.length === 0) {
+    return c.json({ error: 'No passkeys are registered for this account' }, 400);
+  }
+  const options = await generatePasskeyAuthenticationOptions({
+    userId: auth.user.id,
+    passkeys: passkeys.map(toStoredCredential),
+  });
+  return c.json({ options });
+});
+
+/**
+ * Verify a WebAuthn assertion as proof of an existing passkey factor for the
+ * step-up flow. Loads the caller-owned passkey, verifies against the stored
+ * authentication challenge, persists the new signature counter (clone
+ * detection), and returns whether it verified. Reused by mfa.ts's
+ * /auth/mfa/step-up passkey branch. Returns false (never throws) on a
+ * challenge/ownership problem.
+ */
+export async function verifyStepUpPasskeyAssertion(userId: string, credential: { id?: string }): Promise<boolean> {
+  const [passkey] = await withSystemDbAccessContext(() =>
+    db.select().from(userPasskeys).where(eq(userPasskeys.credentialId, credential?.id ?? '')).limit(1));
+  if (!passkey || passkey.userId !== userId || passkey.disabledAt) return false;
+  let verification;
+  try {
+    verification = await verifyPasskeyAuthentication({ userId, response: credential as never, passkey: toStoredCredential(passkey) });
+  } catch (err) {
+    if (err instanceof PasskeyChallengeError) return false;
+    throw err;
+  }
+  if (!verification.verified) return false;
+  const updateFields = authenticationInfoToPasskeyUpdateFields(verification);
+  await withSystemDbAccessContext(() =>
+    db.update(userPasskeys).set({ counter: updateFields.counter, lastUsedAt: updateFields.lastUsedAt, updatedAt: new Date() }).where(eq(userPasskeys.id, passkey.id)));
+  return true;
+}
+```
+
+In `mfa.ts`, add `POST /auth/mfa/step-up` (authenticated). It verifies the existing factor — `consumeMFAToken` for TOTP, Twilio `checkVerificationCode` for SMS, `verifyStepUpPasskeyAssertion` for passkey — then mints a grant bound to the live epochs + `auth.token.sid`:
+
+```ts
+mfaRoutes.post('/mfa/step-up', authMiddleware, zValidator('json', mfaStepUpSchema), async (c) => {
+  if (!ENABLE_2FA) return mfaDisabledResponse(c);
+  const auth = c.get('auth');
+  const body = c.req.valid('json'); // discriminated union on `method`
+
+  let ok = false;
+  if (body.method === 'totp') {
+    const [u] = await db.select({ mfaSecret: users.mfaSecret }).from(users).where(eq(users.id, auth.user.id)).limit(1);
+    const secret = u?.mfaSecret ? decryptMfaSecret(u.mfaSecret) : null;
+    ok = !!secret && await consumeMFAToken(secret, body.code, auth.user.id);
+  } else if (body.method === 'sms') {
+    const [u] = await db.select({ phoneNumber: users.phoneNumber }).from(users).where(eq(users.id, auth.user.id)).limit(1);
+    const twilio = getTwilioService();
+    if (!twilio || !u?.phoneNumber) return c.json({ error: 'SMS not available' }, 400);
+    const r = await twilio.checkVerificationCode(u.phoneNumber, body.code);
+    if (r.serviceError) return c.json({ error: 'SMS verification temporarily unavailable' }, 502);
+    ok = r.valid;
+  } else {
+    // passkey — client must have called POST /auth/mfa/step-up/options first.
+    ok = await verifyStepUpPasskeyAssertion(auth.user.id, body.credential);
+  }
+  if (!ok) {
+    writeAuthAudit(c, { orgId: auth.orgId ?? undefined, action: 'auth.mfa.stepup.failed', result: 'failure', reason: 'invalid_factor', userId: auth.user.id, email: auth.user.email, details: { method: body.method } });
+    return c.json({ error: 'Invalid credentials' }, 401);
+  }
+
+  const epochs = await getUserEpochs(auth.user.id);
+  if (!epochs || !auth.token.sid) return c.json({ error: 'Service temporarily unavailable' }, 503);
+  const grantId = await mintStepUpGrant({
+    userId: auth.user.id, operation: 'add_factor',
+    authEpoch: epochs.authEpoch, mfaEpoch: epochs.mfaEpoch, sid: auth.token.sid,
+  });
+  if (!grantId) return c.json({ error: 'Service temporarily unavailable' }, 503);
+  writeAuthAudit(c, { orgId: auth.orgId ?? undefined, action: 'auth.mfa.stepup.granted', result: 'success', userId: auth.user.id, email: auth.user.email, details: { method: body.method, operation: 'add_factor' } });
+  return c.json({ stepUpGrantId: grantId });
+});
+```
+
+Import `mintStepUpGrant` from `'../../services/mfaStepUpGrant'`, `mfaStepUpSchema` from `'./schemas'`, `verifyStepUpPasskeyAssertion` from `'./passkeys'`, `getTwilioService` (already imported). (mfa.ts importing from the sibling passkeys route module is fine — passkeys.ts does not import mfa.ts, so no cycle.)
+
+- [ ] **Step 3c: Implement — shared gate helper + passkey register**
+
+Add ONE shared helper to `routes/auth/helpers.ts` so all four factor-add surfaces gate identically (import `getUserEpochs` from `'../../services'`, `validateStepUpGrant`/`consumeStepUpGrant` from `'../../services/mfaStepUpGrant'`, `withSystemDbAccessContext`/`db` as the file already does):
+
+```ts
+/** True when the account already has any MFA factor (TOTP/SMS/passkey). */
+export async function userIsMfaProtected(userId: string): Promise<boolean> {
+  const [row] = await withSystemDbAccessContext(() =>
+    db.select({
+      mfaEnabled: users.mfaEnabled,
+      passkeyCount: sql<number>`(SELECT COUNT(*)::int FROM user_passkeys WHERE user_id = ${userId} AND disabled_at IS NULL)`,
+    }).from(users).where(eq(users.id, userId)).limit(1));
+  return row?.mfaEnabled === true || Number(row?.passkeyCount ?? 0) > 0;
+}
+
+/**
+ * Enforce the SR2-20 existing-factor step-up on a factor-ADDITION endpoint.
+ * No-factor accounts (initial enrollment) pass with password-only (returns
+ * null). Already-protected accounts must present a fresh grant bound to the
+ * live epochs + this session's sid. `consume:false` = validate (register
+ * options); `consume:true` = single-use consume (every terminal factor write).
+ * Returns a 403/503 Response to short-circuit, or null to proceed.
+ */
+export async function enforceExistingFactorStepUp(
+  c: Context, auth: AuthContext, grantId: string | undefined, opts: { consume: boolean },
+): Promise<Response | null> {
+  if (!(await userIsMfaProtected(auth.user.id))) return null;
+  const epochs = await getUserEpochs(auth.user.id);
+  if (!epochs || !auth.token.sid) return c.json({ error: 'Service temporarily unavailable' }, 503);
+  const bind = { userId: auth.user.id, operation: 'add_factor' as const, authEpoch: epochs.authEpoch, mfaEpoch: epochs.mfaEpoch, sid: auth.token.sid };
+  const ok = grantId
+    ? (opts.consume ? await consumeStepUpGrant(grantId, bind) : await validateStepUpGrant(grantId, bind))
+    : false;
+  if (!ok) return c.json({ error: 'existing_factor_step_up_required', stepUpUrl: '/auth/mfa/step-up' }, 403);
+  return null;
+}
+```
+
+In `passkeys.ts`, extend `registerOptionsSchema` + `registerVerifySchema` with `stepUpGrantId: z.string().optional()`. In `/passkeys/register/options` (`:114`, after the password step-up) call the helper with `consume:false`; in `/passkeys/register/verify` (`:134`, before the factor write) call it with `consume:true`:
+
+```ts
+  const stepUpErr = await enforceExistingFactorStepUp(c, auth, c.req.valid('json').stepUpGrantId, { consume: false /* verify: true */ });
+  if (stepUpErr) return stepUpErr;
+```
+
+Import `enforceExistingFactorStepUp` from `'./helpers'`.
+
+- [ ] **Step 3d: Implement — gate the TOTP/SMS factor-addition endpoints (I1)**
+
+Apply the SAME helper (with `consume:true`, since each is a terminal factor write) on the already-protected path of the three non-passkey factor-add endpoints. Add `stepUpGrantId: z.string().optional()` to each endpoint's schema (per Step 3b), keep the existing `requireCurrentPasswordStepUp`, and call the gate immediately BEFORE the factor write / `invalidateMfaAssuranceAfterFactorChange` (Task 7):
+
+- **mfa.ts `/mfa/enable`** (`:467`) — after the password step-up (`:476`):
+  ```ts
+    const stepUpErr = await enforceExistingFactorStepUp(c, auth, c.req.valid('json').stepUpGrantId, { consume: true });
+    if (stepUpErr) return stepUpErr;
+  ```
+- **mfa.ts setup-confirm** (Case 2 of `/mfa/verify`, `:286+`) — same call before the enable write. (`mfaVerifySchema` gains `stepUpGrantId` per Step 3b.)
+- **phone.ts `/mfa/sms/enable`** (`:172`) — after its password step-up (`:180`), same call. Import `enforceExistingFactorStepUp` from `'./helpers'`.
+
+No-factor accounts (`userIsMfaProtected === false`) pass through with password-only, so initial TOTP/SMS enrollment is unchanged. Adding/replacing a factor on a protected account now requires password AND a fresh existing-factor grant on ALL surfaces.
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/services/mfaStepUpGrant.test.ts src/routes/auth.passkeys.test.ts src/routes/auth.test.ts src/routes/auth/phone.test.ts src/routes/auth/helpers.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/mfaStepUpGrant.ts apps/api/src/services/mfaStepUpGrant.test.ts apps/api/src/routes/auth/mfa.ts apps/api/src/routes/auth/schemas.ts apps/api/src/routes/auth/passkeys.ts apps/api/src/routes/auth/phone.ts apps/api/src/routes/auth/helpers.ts apps/api/src/routes/auth.passkeys.test.ts apps/api/src/routes/auth.test.ts apps/api/src/routes/auth/phone.test.ts
+git commit -m "feat(auth): existing-factor step-up grant for adding any factor (SR2-20)"
+```
+
+---
+
+### Task 9: Integration tests + verification gate + open PR
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/mfaAssurance.integration.test.ts`
+- Create: `apps/api/src/__tests__/integration/recoveryCode.integration.test.ts`
+- Create: `apps/api/src/__tests__/integration/pendingMfaEpoch.integration.test.ts`
+
+**Interfaces:**
+- Consumes: everything above; the integration harness (`__tests__/integration/db-utils.ts`) and real Postgres on `:5433`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`mfaAssurance.integration.test.ts`:
+- Seed a user (factor + a refresh family). Call `invalidateMfaAssuranceAfterFactorChange(userId, 'test', mutate)` where `mutate` sets a factor field → assert `mfa_epoch` incremented by 1, the family `revoked_at` set, AND the factor field written — all committed together.
+- Rollback: `mutate` throws → assert `mfa_epoch` UNCHANGED, family NOT revoked, factor field NOT written (atomicity).
+
+`recoveryCode.integration.test.ts`:
+- **Identical-code single-winner:** seed a user with 3 recovery-code hashes + two independent valid pending records (or reuse one per request as the harness allows). Fire TWO concurrent `/mfa/verify method:'recovery'` with the SAME valid code → assert exactly ONE returns 200 and the other 401, and the persisted array has exactly 2 hashes remaining (no double-spend).
+- **Distinct-code no-resurrection (C1 regression):** seed a user with 3 recovery-code hashes [hA, hB, hC]. Fire TWO concurrent `/mfa/verify method:'recovery'` with DIFFERENT valid codes (one hashing to hA, the other to hB), each with its own valid pending record. Assert BOTH return 200 AND the persisted array is exactly `[hC]` (length N-2) — proving the relative jsonb `-` delete composed without either request resurrecting the other's removed hash (which a stale read-modify-write would have caused).
+
+`pendingMfaEpoch.integration.test.ts`:
+- Seed a user + write a pending record with `mfaEpoch=N`. Advance `mfa_epoch` to `N+1` via a committed `invalidateMfaAssuranceAfterFactorChange`. Assert `/mfa/verify` with that pending token returns 401 `Invalid or expired MFA session` and mints no tokens.
+
+Follow existing `*.integration.test.ts` for app-bootstrap + `createSeededTenant`-style seeding from `db-utils.ts`.
+
+- [ ] **Step 2: Run to verify they fail (then pass)**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run --config vitest.integration.config.ts src/__tests__/integration/mfaAssurance.integration.test.ts src/__tests__/integration/recoveryCode.integration.test.ts src/__tests__/integration/pendingMfaEpoch.integration.test.ts
+```
+Expected: with Tasks 1-8 implemented, PASS. Observe at least one assertion fail when a piece is briefly reverted (TDD discipline). Requires the integration Postgres on `:5433` (single-fork; the harness runs `autoMigrate` on it automatically).
+
+- [ ] **Step 3: Commit the integration tests**
+
+```bash
+git add apps/api/src/__tests__/integration/mfaAssurance.integration.test.ts apps/api/src/__tests__/integration/recoveryCode.integration.test.ts apps/api/src/__tests__/integration/pendingMfaEpoch.integration.test.ts
+git commit -m "test(auth): integration coverage for MFA assurance, recovery single-winner, pending epoch"
+```
+
+- [ ] **Step 4: Full verification gate**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm typecheck && pnpm build
+```
+Expected: no type errors; build succeeds (Type Check includes the new test files).
+
+Focused serial unit/route suites (API suite is parallel-flaky — name the exact touched files):
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run \
+  src/services/mfaPolicy.test.ts \
+  src/services/mfaAssurance.test.ts \
+  src/services/mfaStepUpGrant.test.ts \
+  src/routes/auth/helpers.test.ts \
+  src/routes/auth/schemas.test.ts \
+  src/routes/auth/login.test.ts \
+  src/routes/auth/phone.test.ts \
+  src/routes/auth.test.ts \
+  src/routes/auth.passkeys.test.ts \
+  src/routes/orgs.test.ts \
+  src/middleware/auth.test.ts
+```
+Expected: PASS.
+
+Migration drift (no migration added — must still be clean):
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+cd apps/api && pnpm db:check-drift
+```
+Expected: no drift.
+
+RLS + integration:
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run --config vitest.config.rls.ts && \
+  pnpm vitest run --config vitest.integration.config.ts src/__tests__/integration/mfaAssurance.integration.test.ts src/__tests__/integration/recoveryCode.integration.test.ts src/__tests__/integration/pendingMfaEpoch.integration.test.ts
+```
+Expected: PASS. RLS coverage unchanged (no new tables).
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+git push -u origin core-auth-2-mfa-policy
+gh pr create --base core-auth-1-lifecycle-foundation --title "feat(auth): MFA policy and assurance (SR2-05,06,07,09,19,20,24)" --body "$(cat <<'EOF'
+Implements PR 2 of the core-authentication hardening design (docs/superpowers/specs/2026-07-11-core-authentication-hardening-design.md). Stacks on PR #2378 (core-auth-1-lifecycle-foundation).
+
+## What
+- **SR2-05** One effective-MFA-policy resolver (`services/mfaPolicy.ts`): role force_mfa + org/partner requireMfa (through `getEffectiveOrgSettings`, partner-inherited) + canonical `security.allowedMethods`; strictest-wins, passkey always allowed. Middleware enrollment gate + login now use it. `allowedMfaMethods` is accepted only as an input alias, normalized into `allowedMethods`, never stored. The formerly inert SMS allowlist now enforces. The `MFA_FORCE_FOR_PARTNER_ADMIN` kill switch suppresses only role-driven forcing; org/partner `requireMfa` is enforced regardless.
+- **SR2-05** Login no longer mints vacuous `mfa=true` for a policy-required unenrolled user — it returns a forced-enrollment signal (`mfa=false`).
+- **SR2-06** Pending MFA records carry auth/mfa epochs, status expectation, allowed methods, and expiry; every completion path (TOTP/SMS/passkey) reloads the live user + policy, compares, and atomically consumes before minting.
+- **SR2-24** TOTP setup confirmation and `/mfa/enable` use the consuming verifier — the accepted time step cannot be replayed at login.
+- **SR2-09** Recovery-code login: schema accepts `XXXX-XXXX`, one matching hash is atomically removed (single winner under concurrency), tokens minted only after both records consume; audited without code material.
+- **SR2-07 / SR2-19** `services/mfaAssurance.ts` invalidates assurance after every factor add/remove/replace/rotate: one transaction advances `mfa_epoch` + revokes all refresh families, then post-commit runs Redis/OAuth cleanup + remote-session teardown.
+- **SR2-20** Adding ANY factor (TOTP/SMS/passkey) to an already-protected account requires a fresh existing-factor step-up grant (short-lived, single-use, bound to user/operation/epochs/session) in addition to current password. The existing-factor proof accepts a TOTP/SMS code OR a passkey assertion, so a passkey-only user is never locked out. Initial enrollment (no factor) stays password-only. Also routes `/mfa/disable` + the passkey last-factor guard through the resolver so a partner-set requireMfa blocks them.
+
+## Deliberate global sign-out on factor change
+Any factor add/remove/replace/recovery-rotation advances `mfa_epoch` and revokes all refresh families — the acting user (and their other sessions) must re-authenticate with the new configuration. Remote sessions are torn down after commit; teardown failure is reported as partial operational failure but never restores token validity.
+
+## No migration
+Epoch columns ship in PR 1; `mfa_recovery_codes` already exists. No schema change, no RLS allowlist change.
+
+## Reviewer note
+Overseer decision worth confirming: the `MFA_FORCE_FOR_PARTNER_ADMIN` kill switch was deliberately NARROWED to gate only the role-force component (`required = (roleForceMfa && !killSwitchOff) || settingsRequireMfa`). Turning it off no longer disables org/partner-configured `requireMfa` compliance — that was judged a latent foot-gun for a hardening PR. If ops still need a total MFA-enforcement escape hatch, that must be a separate, explicitly-named flag.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+Expected: PR opens against `core-auth-1-lifecycle-foundation`.
+
+---
+
+## Self-Review
+
+**Spec coverage (PR 2 scope):**
+| Finding | Task |
+|---|---|
+| SR2-05 policy resolver (role + org/partner requireMfa via effectiveSettings + allowedMethods) | Task 1 |
+| SR2-05 canonical allowedMethods / alias normalization / SMS enforcement | Task 2 |
+| SR2-05 enrollment enforcement + no vacuous `mfa=true` (exempt-path short-circuit BEFORE resolver) | Task 3 |
+| SR2-05 factor-op surface: disable-block + last-factor guard via resolver (partner-inherited) | Task 7 (Step 3c) |
+| SR2-06 epoch/status/method-bound pending MFA, reload+compare+consume | Task 4 |
+| SR2-24 consuming TOTP setup verifier | Task 5 |
+| SR2-09 recovery-code login, atomic RELATIVE single-use (no distinct-code resurrection) | Task 6 (+ Task 9 identical-code AND distinct-code proofs) |
+| SR2-07 / SR2-19 factor-change epoch bump + family revoke + remote teardown | Task 7 (+ Task 9 atomicity proof) |
+| SR2-20 existing-factor step-up grant for ALL factor additions (TOTP/SMS/passkey), proof accepts all factor types incl. passkey-only | Task 8 |
+| Integration atomicity/concurrency + verification gate + PR | Task 9 |
+
+**Decisions documented inline (no deferral to reader):**
+- No migration (epochs + `mfa_recovery_codes` pre-exist) — stated in Global Constraints and PR body.
+- Kill switch (`MFA_FORCE_FOR_PARTNER_ADMIN`) suppresses ONLY role-driven forcing; org/partner settings `requireMfa` is enforced regardless (`required = (roleForceMfa && !killSwitchOff) || settingsRequireMfa`). Overseer hardening decision overriding the earlier "global escape hatch" (Task 1).
+- Scope resolution: system→none; org→effectiveSettings+org role; partner→partner settings+partner role (Task 1).
+- Settings-read errors fail OPEN for policy AND emit bounded telemetry via `captureException` (imported from `./sentry`, matching authLifecycle.ts); single-use consumption fails CLOSED (Tasks 1, 4, 6, 8).
+- allowedMethods: passkey always true, totp/sms gated by effective settings (Task 1).
+- `/phone/confirm` invalidates only on active-SMS-factor replacement, not initial enrollment (Task 7).
+- Pending-MFA payload + step-up grant TS shapes fixed in the Interfaces blocks (Tasks 4, 8).
+- Audit `action`/`result` strings: `auth.mfa.enrollment.required`/denied (existing), `auth.mfa.recovery_code.used`/success, `auth.mfa.stepup.granted`|`.failed`, `mfa_pending_invalidated`|`mfa_method_not_allowed`|`mfa_recovery_code_invalid` failure reasons — all details carry counts/reasons only, never code material (Tasks 3, 4, 6, 8).
+
+**Placeholder scan:** every code step contains concrete code. Test steps that say "follow the file's existing mock shape" name the exact file + the exact assertions required — mandatory because the Drizzle/Redis mock chain must mirror the specific source chain (breeze-testing rule) and cannot be authored blind. No TBD/TODO.
+
+**Type consistency across tasks:** `EffectiveMfaPolicy`/`MfaPolicyInput`/`MfaAllowedMethods` (Task 1) consumed identically in Tasks 2, 3, 4, 7's callers. `PendingMfaRecord`/`parsePendingMfa`/`evaluatePendingMfa` (Task 4) consumed in Tasks 4's mfa.ts + passkeys.ts. `Tx`/`advanceUserEpochs`/`revokeAllRefreshFamilies`/`runPostCommitCleanup`/`PostCommitCleanupResult` (PR 1) consumed by Task 7's `mfaAssurance.ts`; `terminateUserRemoteSessions`/`TEARDOWN_FAILED` (existing) consumed by Task 7. `FactorChangeResult` (Task 7) is the return type used at all seven factor handlers. `StepUpGrant`/`mintStepUpGrant`/`validateStepUpGrant`/`consumeStepUpGrant` (Task 8) consumed by the mfa.ts mint endpoint and the single `enforceExistingFactorStepUp`/`userIsMfaProtected` helper pair in `helpers.ts`, which ALL four factor-add surfaces call (passkey options `consume:false`; passkey verify + `/mfa/enable` + setup-confirm + `/mfa/sms/enable` `consume:true`) — one binding shape, no divergent copies. `mfaStepUpSchema` is a `z.discriminatedUnion('method', …)` (`totp`/`sms`→`code`, `passkey`→`credential`) consumed by the mint endpoint's `body.method` switch; `verifyStepUpPasskeyAssertion` (exported from the passkeys route, no import cycle) is the passkey branch. `getUserEpochs` (PR 1) returns `{ authEpoch, mfaEpoch }`, consumed as such in Tasks 4, 8. Note: `auditUserLoginFailure` is already imported in mfa.ts (M1 — do not re-import).


### PR DESCRIPTION
Implements PR 2 of the core-authentication hardening design (`docs/superpowers/specs/2026-07-11-core-authentication-hardening-design.md`).

> **Rebased 2026-07-13.** PR 1 (#2378) has been **squash-merged into `main`**, so this branch no longer stacks on it — base is now `main` and the diff is PR 2's own 14 commits only (30 files). Rebased onto current `main` with **zero conflicts**; net diff unchanged.

Closes SR2-05, SR2-06, SR2-07, SR2-09, SR2-19, SR2-20, SR2-24.

## What

- **SR2-05 — one effective MFA-policy resolver** (`services/mfaPolicy.ts`): combines role `force_mfa` + org/partner `security.requireMfa` (resolved through `getEffectiveOrgSettings`, partner-inherited) + canonical `security.allowedMethods`, strictest-wins, passkey always allowed. The middleware enrollment gate and login now use it. `allowedMfaMethods` is accepted only as an input alias, folded into `allowedMethods` at all three settings-write sites, never persisted as a second key — the formerly inert SMS allowlist now actually enforces. Login no longer mints vacuous `mfa=true` for a policy-required unenrolled user; it returns `mfaEnrollmentRequired` with `mfa=false`.
- **SR2-06 — epoch/status-bound pending MFA**: pending records carry auth/mfa epochs, status expectation, allowed methods, and expiry. Every completion path (TOTP/SMS/passkey) reloads the live user + policy, compares epochs/status, enforces method-still-allowed, and atomically consumes the record before minting.
- **SR2-24 — consuming TOTP setup verifier**: setup-confirm and `/mfa/enable` use the consuming verifier, so an accepted setup time-step can't be replayed at login.
- **SR2-09 — recovery-code login**: schema accepts `XXXX-XXXX`; exactly one matching hash is removed with a server-side relative `jsonb -` delete guarded by a containment check, so concurrent submissions have a single winner **and distinct concurrent codes cannot resurrect one another** (proven against real Postgres). Audited without code material.
- **SR2-07 / SR2-19 — factor-change invalidation** (`services/mfaAssurance.ts`): every factor add/remove/replace/recovery-rotation runs one transaction that advances `mfa_epoch` + revokes all refresh families, then post-commit runs Redis/permission/OAuth cleanup + remote-session teardown. Phone re-verify invalidates only on genuine active-SMS-factor replacement (initial enrollment does not sign the user out).
- **SR2-20 — existing-factor step-up**: adding a factor to an already-protected account requires a fresh single-use step-up grant (`services/mfaStepUpGrant.ts`, bound to user/operation/epochs/session), minted via `POST /auth/mfa/step-up` (TOTP, SMS, **or passkey assertion** — so passkey-only users aren't locked out). All factor-addition endpoints consume it; first-enrollment stays password-only.

## Deliberate global sign-out on factor change

Any factor add/remove/replace/recovery-rotation advances `mfa_epoch` and revokes all refresh families — the user's other sessions must re-authenticate with the new configuration. Remote sessions are torn down after the durable commit; teardown failure is reported as partial operational failure (`teardownFailed`) but never restores token validity.

## No migration

Epoch columns ship in PR 1; `mfa_recovery_codes` already exists. No schema change, no RLS-allowlist change.

## Reviewer notes (overseer decisions worth a look)

- **Kill switch narrowed:** `MFA_FORCE_FOR_PARTNER_ADMIN=false` now suppresses only the **role-force** component; org/partner `requireMfa` is enforced regardless. This is a deliberate hardening choice (a partner-admin-named env flag should not silently disable customer-configured MFA compliance). Preserves the flag's original role-force behavior exactly.
- **Settings-read fail-open:** the policy resolver fails open (not-required, methods-allowed, with `captureException`) if the effective-settings read throws, to avoid mass login-lockout on a transient blip. Single-use consumption (pending record, recovery code, step-up grant) still fails closed.

## Verification

- Typecheck + build clean; 393/393 focused auth/middleware/services/orgs unit+route tests.
- Migration drift clean (verified on an isolated DB; shared dev DBs show unrelated cross-worktree ledger contamination).
- RLS 21/22 — the one red is a pre-existing stale "exactly 5 GUCs" assertion in `rls.integration.test.ts` (actual 6), unchanged by this branch.
- New real-Postgres integration tests (5/5): factor-change epoch-bump+family-revoke atomicity **and rollback**; recovery-code identical-code single-winner **and distinct-code no-resurrection**; pending-MFA epoch-mismatch rejection.
- Built via subagent-driven development: per-task adversarial review gate (capable-model reviews on the security-critical tasks) plus a whole-branch merge-readiness review (Ready to merge: Yes, zero Critical/Important).

## Known follow-ups (non-blocking)

- `cfAccessLogin.ts` still mints vacuous `mfa=true` for an unenrolled + policy-required CF-Access user and doesn't surface `mfaEnrollmentRequired` — non-exploitable (the middleware enrollment gate 428s them on the first non-exempt request regardless of the claim). Best folded into PR 3 (SSO/CF hardening).
- Delete the now prod-dead `verifyMFAToken` from `services/mfa.ts` (zero callers, not barrel-exported).
- Minor consistency: `/mfa/enable` consumes the step-up grant before validating the new TOTP code (fails closed; burned-grant is UX friction only) — harmonize with setup-confirm's code-first ordering.
- Add a focused unit test for the step-up helper's 503 fail-closed branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

