### PR TITLE
fix(agent): bound worker-wedging blockers that retain command payloads (#2387)

### DIFF
--- a/agent/internal/heartbeat/handlers_script.go
+++ b/agent/internal/heartbeat/handlers_script.go
@@ -290,12 +290,18 @@ func (h *Heartbeat) sendCommandToUserHelper(session *sessionbroker.Session, cmd 
 // (executor.DefaultTimeout / executor.MaxTimeout). Without the clamp a huge
 // timeoutSeconds in the command payload parks a worker-pool goroutine (and the
 // command's payload) near-indefinitely on the IPC wait (issue #2387). The +5s
-// grace lets the helper's own timeout fire first so its result wins.
+// grace lets the helper's own timeout fire first so its result wins — this
+// assumes the helper clamps identically (it routes run_script through
+// executor.Execute, which applies the same bounds; its execute_command path
+// does not clamp, so a new payload-timeout command routed here would need its
+// own cap).
 func helperCommandTimeout(timeoutSeconds int) time.Duration {
 	if timeoutSeconds <= 0 {
 		timeoutSeconds = executor.DefaultTimeout
 	}
 	if timeoutSeconds > executor.MaxTimeout {
+		log.Warn("clamping user-helper command timeout to executor maximum",
+			"requestedSeconds", timeoutSeconds, "effectiveSeconds", executor.MaxTimeout)
 		timeoutSeconds = executor.MaxTimeout
 	}
 	return time.Duration(timeoutSeconds)*time.Second + 5*time.Second

--- a/agent/internal/heartbeat/handlers_script.go
+++ b/agent/internal/heartbeat/handlers_script.go
@@ -270,8 +270,7 @@ func (h *Heartbeat) sendCommandToUserHelper(session *sessionbroker.Session, cmd 
 		Payload:   payloadBytes,
 	}
 
-	timeout := time.Duration(timeoutSeconds)*time.Second + 5*time.Second
-	resp, err := session.SendCommand(cmd.ID, ipc.TypeCommand, ipcCmd, timeout)
+	resp, err := session.SendCommand(cmd.ID, ipc.TypeCommand, ipcCmd, helperCommandTimeout(timeoutSeconds))
 	if err != nil {
 		return nil, err
 	}
@@ -284,6 +283,22 @@ func (h *Heartbeat) sendCommandToUserHelper(session *sessionbroker.Session, cmd 
 		return nil, fmt.Errorf("unmarshal user helper result: %w", err)
 	}
 	return &result, nil
+}
+
+// helperCommandTimeout converts a server-supplied timeoutSeconds into the IPC
+// wait deadline, clamped to the same bounds the local script executor applies
+// (executor.DefaultTimeout / executor.MaxTimeout). Without the clamp a huge
+// timeoutSeconds in the command payload parks a worker-pool goroutine (and the
+// command's payload) near-indefinitely on the IPC wait (issue #2387). The +5s
+// grace lets the helper's own timeout fire first so its result wins.
+func helperCommandTimeout(timeoutSeconds int) time.Duration {
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = executor.DefaultTimeout
+	}
+	if timeoutSeconds > executor.MaxTimeout {
+		timeoutSeconds = executor.MaxTimeout
+	}
+	return time.Duration(timeoutSeconds)*time.Second + 5*time.Second
 }
 
 func decodeHelperRunningScripts(result *ipc.IPCCommandResult) ([]string, error) {

--- a/agent/internal/heartbeat/handlers_script_timeout_test.go
+++ b/agent/internal/heartbeat/handlers_script_timeout_test.go
@@ -1,0 +1,39 @@
+package heartbeat
+
+import (
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/executor"
+)
+
+// TestHelperCommandTimeout is part of the issue #2387 hardening: the IPC wait
+// deadline derived from a server-supplied timeoutSeconds must be clamped to
+// the same bounds the local script executor applies, so a huge payload value
+// cannot park a worker-pool goroutine (and its command payload)
+// near-indefinitely on the IPC wait.
+func TestHelperCommandTimeout(t *testing.T) {
+	const grace = 5 * time.Second
+
+	tests := []struct {
+		name           string
+		timeoutSeconds int
+		want           time.Duration
+	}{
+		{"zero falls back to executor default", 0, time.Duration(executor.DefaultTimeout)*time.Second + grace},
+		{"negative falls back to executor default", -30, time.Duration(executor.DefaultTimeout)*time.Second + grace},
+		{"small value passes through", 10, 10*time.Second + grace},
+		{"typical script timeout passes through", 300, 300*time.Second + grace},
+		{"exactly max passes through", executor.MaxTimeout, time.Duration(executor.MaxTimeout)*time.Second + grace},
+		{"above max clamps to executor max", executor.MaxTimeout + 1, time.Duration(executor.MaxTimeout)*time.Second + grace},
+		{"huge server-supplied value clamps to executor max", 86400 * 365, time.Duration(executor.MaxTimeout)*time.Second + grace},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := helperCommandTimeout(tt.timeoutSeconds); got != tt.want {
+				t.Fatalf("helperCommandTimeout(%d) = %s, want %s", tt.timeoutSeconds, got, tt.want)
+			}
+		})
+	}
+}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -222,6 +222,11 @@ type Heartbeat struct {
 	seenCommands   map[string]time.Time
 	seenCommandsMu sync.Mutex
 
+	// commandInFlightWarnAfter overrides the wedged-worker watchdog interval
+	// in executeCommandViaPool; zero means defaultCommandInFlightWarnAfter.
+	// Set before the heartbeat runs (tests only) — never mutated afterwards.
+	commandInFlightWarnAfter time.Duration
+
 	// Guard against concurrent cert renewals from successive heartbeats
 	certRenewing      atomic.Bool
 	tokenRotating     atomic.Bool
@@ -3528,21 +3533,51 @@ func (h *Heartbeat) executeCommandViaPool(cmd Command) tools.CommandResult {
 		}
 	}
 
-	select {
-	case result := <-resultCh:
-		return result
-	case <-h.stopChan:
-		return tools.CommandResult{
-			Status: "failed",
-			Error:  "agent is shutting down",
-		}
-	case <-h.pool.Context().Done():
-		return tools.CommandResult{
-			Status: "failed",
-			Error:  "command execution interrupted during shutdown",
+	// Watchdog: log-only, deliberately NOT a timeout. Some handlers are
+	// long-running by design (run_script up to 1h, software installs, patch
+	// loops), so failing the command here would race legitimate work. The log
+	// flags workers wedged on an unbounded blocking call — each one pins its
+	// decoded command payload (up to maxMessageSize) for the process lifetime
+	// and permanently shrinks the pool (issue #2387).
+	warnAfter := h.commandInFlightWarnAfter
+	if warnAfter <= 0 {
+		warnAfter = defaultCommandInFlightWarnAfter
+	}
+	started := time.Now()
+	watchdog := time.NewTimer(warnAfter)
+	defer watchdog.Stop()
+
+	for {
+		select {
+		case result := <-resultCh:
+			return result
+		case <-watchdog.C:
+			log.Warn("command still in flight after watchdog interval — handler may be wedged and retaining its payload",
+				logging.KeyCommandID, cmd.ID,
+				"type", cmd.Type,
+				"elapsed", time.Since(started).Round(time.Second).String(),
+			)
+			watchdog.Reset(warnAfter)
+		case <-h.stopChan:
+			return tools.CommandResult{
+				Status: "failed",
+				Error:  "agent is shutting down",
+			}
+		case <-h.pool.Context().Done():
+			return tools.CommandResult{
+				Status: "failed",
+				Error:  "command execution interrupted during shutdown",
+			}
 		}
 	}
 }
+
+// defaultCommandInFlightWarnAfter is how long a pool-dispatched command may
+// run before the dispatch loop logs a wedged-worker warning (and again each
+// further interval). Generous on purpose: the longest legitimate handlers
+// (scripts capped at executor.MaxTimeout = 1h, patch installs) must not trip
+// it in normal operation.
+const defaultCommandInFlightWarnAfter = 2 * time.Hour
 
 func isEphemeralCommand(cmdType string) bool {
 	switch cmdType {

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -223,8 +223,9 @@ type Heartbeat struct {
 	seenCommandsMu sync.Mutex
 
 	// commandInFlightWarnAfter overrides the wedged-worker watchdog interval
-	// in executeCommandViaPool; zero means defaultCommandInFlightWarnAfter.
-	// Set before the heartbeat runs (tests only) — never mutated afterwards.
+	// in executeCommandViaPool; non-positive means
+	// defaultCommandInFlightWarnAfter. Set before the heartbeat runs (tests
+	// only) — never mutated afterwards.
 	commandInFlightWarnAfter time.Duration
 
 	// Guard against concurrent cert renewals from successive heartbeats
@@ -3537,8 +3538,9 @@ func (h *Heartbeat) executeCommandViaPool(cmd Command) tools.CommandResult {
 	// long-running by design (run_script up to 1h, software installs, patch
 	// loops), so failing the command here would race legitimate work. The log
 	// flags workers wedged on an unbounded blocking call — each one pins its
-	// decoded command payload (up to maxMessageSize) for the process lifetime
-	// and permanently shrinks the pool (issue #2387).
+	// decoded command payload (up to the 64MB websocket read limit,
+	// maxMessageSize in internal/websocket) for the process lifetime and
+	// permanently shrinks the pool (issue #2387).
 	warnAfter := h.commandInFlightWarnAfter
 	if warnAfter <= 0 {
 		warnAfter = defaultCommandInFlightWarnAfter

--- a/agent/internal/heartbeat/heartbeat_pool_watchdog_test.go
+++ b/agent/internal/heartbeat/heartbeat_pool_watchdog_test.go
@@ -1,0 +1,50 @@
+package heartbeat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+	"github.com/breeze-rmm/agent/internal/workerpool"
+)
+
+// TestExecuteCommandViaPoolWatchdogIsLogOnly verifies the in-flight watchdog
+// added for issue #2387 never fails or abandons a slow command: handlers that
+// are long-running by design (scripts up to 1h, patch installs) must still
+// return their real result even after the watchdog interval has elapsed
+// multiple times.
+//
+// MUST NOT call t.Parallel(): mutates handlerRegistry.
+func TestExecuteCommandViaPoolWatchdogIsLogOnly(t *testing.T) {
+	const slowType = "test_2387_slow_command"
+	handlerRegistry[slowType] = func(h *Heartbeat, cmd Command) tools.CommandResult {
+		time.Sleep(120 * time.Millisecond) // several watchdog intervals
+		return tools.CommandResult{Status: "completed", Stdout: "slow-ok"}
+	}
+	t.Cleanup(func() { delete(handlerRegistry, slowType) })
+
+	h := &Heartbeat{
+		stopChan:                 make(chan struct{}),
+		pool:                     workerpool.New(1, 1),
+		commandInFlightWarnAfter: 20 * time.Millisecond,
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		h.pool.Shutdown(ctx)
+	})
+
+	result := h.executeCommandViaPool(Command{
+		ID:      "watchdog-slow-1",
+		Type:    slowType,
+		Payload: map[string]any{},
+	})
+
+	if result.Status != "completed" {
+		t.Fatalf("watchdog must not fail a slow command: status=%q error=%q", result.Status, result.Error)
+	}
+	if result.Stdout != "slow-ok" {
+		t.Fatalf("expected the handler's real result, got stdout=%q", result.Stdout)
+	}
+}

--- a/agent/internal/remote/tools/terminal.go
+++ b/agent/internal/remote/tools/terminal.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/breeze-rmm/agent/internal/logging"
 	"github.com/breeze-rmm/agent/internal/terminal"
 )
+
+var terminalLog = logging.L("remote-terminal")
 
 // OutputCallback is a function that receives terminal output
 type OutputCallback func(sessionId string, data []byte)
@@ -46,7 +49,8 @@ func StartTerminal(mgr *terminal.Manager, payload map[string]any, outputCallback
 	// Create close handler
 	onClose := func(err error) {
 		if err != nil {
-			fmt.Printf("Terminal session %s closed with error: %v\n", sessionId, err)
+			terminalLog.Warn("terminal session closed with error",
+				"sessionId", sessionId, "error", err.Error())
 		}
 	}
 

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -1678,9 +1678,11 @@ func (b *Broker) removeSessionMapsLocked(session *Session) {
 		delete(b.byIdentity, key)
 	}
 
-	// Track the PID so we can kill it before spawning a replacement.
-	// Don't kill here — the process may still be serving an active desktop session.
-	// Key includes role so SYSTEM and user helper stale PIDs are tracked separately.
+	// Track the PID so it can be killed before spawning a replacement
+	// (Windows only — see trackStaleHelper; elsewhere this is a deliberate
+	// no-op). Don't kill here — the process may still be serving an active
+	// desktop session. Key includes role so SYSTEM and user helper stale
+	// PIDs are tracked separately.
 	if session.PID > 0 {
 		staleKey := session.WinSessionID + "-" + session.HelperRole
 		b.trackStaleHelper(staleKey, session.PID)
@@ -1705,8 +1707,10 @@ func (b *Broker) removeSession(session *Session) {
 // Windows-only: the sole drain path is KillStaleHelpers, whose callers are all
 // Windows-gated (it exists to release DXGI Desktop Duplication locks before
 // respawning a helper). On macOS/Linux nothing ever drains this map, so
-// tracking there grows unbounded for the life of the daemon (issue #2387);
-// macOS stale helpers are torn down via CloseSessionsByDesktopContext instead.
+// tracking there grows unbounded for the life of the daemon (issue #2387).
+// macOS handles helper teardown differently: live sessions are closed at
+// logout via CloseSessionsByDesktopContext, and launchd `kickstart -k` kills
+// any lingering instance on respawn.
 func (b *Broker) trackStaleHelper(winSessionID string, pid int) {
 	if runtime.GOOS != "windows" {
 		return
@@ -1717,6 +1721,10 @@ func (b *Broker) trackStaleHelper(winSessionID string, pid int) {
 // KillStaleHelpers kills any disconnected helper processes for the given
 // Windows session. Call this before spawning a new helper to release DXGI
 // Desktop Duplication locks held by orphaned processes.
+//
+// Windows-only contract: trackStaleHelper only records PIDs on Windows, so on
+// any other platform this is always a no-op against an empty map — do not add
+// non-Windows callers expecting it to find anything.
 func (b *Broker) KillStaleHelpers(winSessionID string) {
 	b.mu.Lock()
 	pids := b.staleHelpers[winSessionID]

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -1701,7 +1701,16 @@ func (b *Broker) removeSession(session *Session) {
 
 // trackStaleHelper records a disconnected helper PID for later cleanup.
 // Called under b.mu lock.
+//
+// Windows-only: the sole drain path is KillStaleHelpers, whose callers are all
+// Windows-gated (it exists to release DXGI Desktop Duplication locks before
+// respawning a helper). On macOS/Linux nothing ever drains this map, so
+// tracking there grows unbounded for the life of the daemon (issue #2387);
+// macOS stale helpers are torn down via CloseSessionsByDesktopContext instead.
 func (b *Broker) trackStaleHelper(winSessionID string, pid int) {
+	if runtime.GOOS != "windows" {
+		return
+	}
 	b.staleHelpers[winSessionID] = append(b.staleHelpers[winSessionID], pid)
 }
 

--- a/agent/internal/sessionbroker/broker_stale_helpers_test.go
+++ b/agent/internal/sessionbroker/broker_stale_helpers_test.go
@@ -1,0 +1,36 @@
+package sessionbroker
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestTrackStaleHelperGatedToWindows is the regression test for the
+// staleHelpers part of issue #2387: the only drain path (KillStaleHelpers) is
+// Windows-only, so tracking on other platforms grows the map unbounded for
+// the life of the daemon.
+func TestTrackStaleHelperGatedToWindows(t *testing.T) {
+	b := &Broker{staleHelpers: make(map[string][]int)}
+
+	b.mu.Lock()
+	b.trackStaleHelper("1-user", 4242)
+	b.trackStaleHelper("1-user", 4243)
+	b.trackStaleHelper("2-system", 4244)
+	b.mu.Unlock()
+
+	if runtime.GOOS == "windows" {
+		if got := len(b.staleHelpers["1-user"]); got != 2 {
+			t.Fatalf("windows: expected 2 tracked PIDs for key 1-user, got %d", got)
+		}
+		if got := len(b.staleHelpers["2-system"]); got != 1 {
+			t.Fatalf("windows: expected 1 tracked PID for key 2-system, got %d", got)
+		}
+		return
+	}
+
+	// Non-Windows: nothing may accumulate — there is no drain path.
+	if got := len(b.staleHelpers); got != 0 {
+		t.Fatalf("non-windows: staleHelpers must stay empty (no drain path exists), got %d keys: %v",
+			got, b.staleHelpers)
+	}
+}

--- a/agent/internal/terminal/session_write_timeout_test.go
+++ b/agent/internal/terminal/session_write_timeout_test.go
@@ -1,0 +1,139 @@
+package terminal
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// wedgedWriteCloser blocks every Write until Close is called — the shape of a
+// PTY whose foreground process stopped reading (e.g. Ctrl-S flow control).
+type wedgedWriteCloser struct {
+	mu       sync.Mutex
+	unblock  chan struct{}
+	closed   bool
+	writes   int
+	released chan struct{} // closed when a blocked Write returns
+}
+
+func newWedgedWriteCloser() *wedgedWriteCloser {
+	return &wedgedWriteCloser{
+		unblock:  make(chan struct{}),
+		released: make(chan struct{}),
+	}
+}
+
+func (w *wedgedWriteCloser) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	w.writes++
+	w.mu.Unlock()
+	<-w.unblock
+	close(w.released)
+	return len(p), nil
+}
+
+func (w *wedgedWriteCloser) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.closed {
+		w.closed = true
+		close(w.unblock)
+	}
+	return nil
+}
+
+// TestSessionWriteTimesOutOnWedgedPTY is the regression test for issue #2387:
+// a PTY/stdin write that never completes must not block write() forever (it
+// used to, while holding s.mu — deadlocking close() and every later terminal
+// command for the session, and pinning a command worker for the process
+// lifetime). The write must fail within the bounded wait and the session must
+// be marked dead.
+func TestSessionWriteTimesOutOnWedgedPTY(t *testing.T) {
+	w := newWedgedWriteCloser()
+	s := &Session{ID: "wedged", stdin: w, writeTimeout: 100 * time.Millisecond}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.write([]byte("x")) }()
+
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("expected write-timeout error, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("write still blocked long after the timeout — worker would be wedged")
+	}
+
+	// The timeout path closes the session asynchronously; close() must both
+	// mark it closed and Close() the writer, which unblocks the wedged write.
+	deadline := time.After(5 * time.Second)
+	for {
+		s.mu.Lock()
+		closed := s.closed
+		s.mu.Unlock()
+		if closed {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("session never marked closed after write timeout")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	select {
+	case <-w.released:
+	case <-time.After(5 * time.Second):
+		t.Fatal("wedged writer goroutine never released after session close")
+	}
+
+	// Later writes must fail fast on the closed session, not queue behind the
+	// wedged writer (the old deadlock).
+	if err := s.write([]byte("y")); err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("expected closed-session error, got %v", err)
+	}
+}
+
+// TestSessionCloseNotBlockedByWedgedWrite verifies close() no longer waits on
+// s.mu behind a blocked write.
+func TestSessionCloseNotBlockedByWedgedWrite(t *testing.T) {
+	w := newWedgedWriteCloser()
+	// Long timeout: close() must win the race, not the bounded wait.
+	s := &Session{ID: "close-race", stdin: w, writeTimeout: 10 * time.Second}
+
+	writeErr := make(chan error, 1)
+	go func() { writeErr <- s.write([]byte("x")) }()
+
+	// Wait until the writer goroutine is actually inside Write.
+	deadline := time.After(2 * time.Second)
+	for {
+		w.mu.Lock()
+		n := w.writes
+		w.mu.Unlock()
+		if n > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("write never started")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- s.close() }()
+
+	select {
+	case <-closeDone:
+		// close() completed while the write was still wedged — no deadlock.
+	case <-time.After(2 * time.Second):
+		t.Fatal("close() blocked behind a wedged write")
+	}
+
+	// Closing the stdin pipe unblocks the wedged write.
+	select {
+	case <-writeErr:
+	case <-time.After(5 * time.Second):
+		t.Fatal("write never returned after close")
+	}
+}

--- a/agent/internal/terminal/terminal.go
+++ b/agent/internal/terminal/terminal.go
@@ -7,12 +7,24 @@ import (
 	"os/exec"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/breeze-rmm/agent/internal/logging"
 	"github.com/breeze-rmm/agent/internal/observability"
 )
 
 var log = logging.L("terminal")
+
+// defaultWriteTimeout bounds each write to the PTY/stdin pipe. A PTY whose
+// foreground process stopped reading (e.g. Ctrl-S flow control) blocks
+// write(2) forever; because write() used to hold s.mu across that call, one
+// wedged write also deadlocked every later terminal command for the session
+// and pinned a command worker plus its payload for the process lifetime
+// (issue #2387). The PTY fd is opened in blocking mode (posix_openpt without
+// O_NONBLOCK on macOS), so SetWriteDeadline is unavailable; a bounded wait on
+// a writer goroutine is used instead. Tests shorten the bound via the
+// Session.writeTimeout field.
+const defaultWriteTimeout = 30 * time.Second
 
 // Session represents an active terminal session
 type Session struct {
@@ -24,7 +36,11 @@ type Session struct {
 	stdin    io.WriteCloser // used on Windows for pipe-based stdin (both ConPTY and legacy pipes)
 	cmd      *exec.Cmd      // process command (Unix/macOS; nil on Windows ConPTY)
 	mu       sync.Mutex
-	closed   bool
+	writeMu  sync.Mutex // serializes PTY/stdin writes; never held with s.mu
+	// writeTimeout bounds each write; zero means defaultWriteTimeout.
+	// Set before the session is used (tests only) — never mutated afterwards.
+	writeTimeout time.Duration
+	closed       bool
 	waitOnce sync.Once // ensures process wait is called exactly once
 	endOnce  sync.Once // ensures terminal close callback runs once
 	onOutput func(data []byte)
@@ -173,12 +189,19 @@ func (m *Manager) removeSessionIfCurrent(id string, target *Session) {
 	delete(m.sessions, id)
 }
 
-// write writes data to the session's PTY or stdin pipe
+// write writes data to the session's PTY or stdin pipe.
+//
+// The blocking write deliberately happens OUTSIDE s.mu: a PTY write can block
+// indefinitely when the foreground process stops draining input, and holding
+// s.mu across it would deadlock close() and every later write for the session.
+// writeMu keeps concurrent writes serialized instead. The write itself runs in
+// a goroutine bounded by writeTimeout; on timeout the session is closed
+// (killing the shell unblocks the wedged write(2)) and an error is returned so
+// the caller's command worker is released.
 func (s *Session) write(data []byte) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if s.closed {
+		s.mu.Unlock()
 		return fmt.Errorf("session is closed")
 	}
 
@@ -189,17 +212,45 @@ func (s *Session) write(data []byte) error {
 	}
 
 	// Prefer stdin pipe (Windows), fall back to PTY fd (Unix/macOS)
-	if s.stdin != nil {
-		_, err := s.stdin.Write(data)
-		return err
+	var w io.Writer
+	switch {
+	case s.stdin != nil:
+		w = s.stdin
+	case s.pty != nil:
+		w = s.pty
 	}
+	s.mu.Unlock()
 
-	if s.pty == nil {
+	if w == nil {
 		return fmt.Errorf("PTY not available")
 	}
 
-	_, err := s.pty.Write(data)
-	return err
+	done := make(chan error, 1)
+	go func() {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+		_, err := w.Write(data)
+		done <- err
+	}()
+
+	timeout := s.writeTimeout
+	if timeout <= 0 {
+		timeout = defaultWriteTimeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		log.Warn("terminal write timed out, closing session",
+			"sessionId", s.ID, "timeout", timeout.String())
+		// Close in a goroutine: close() takes s.mu and waits for the shell
+		// process, and killing the shell is what unblocks the stuck write.
+		go s.close()
+		return fmt.Errorf("terminal write timed out after %s; session %s closed", timeout, s.ID)
+	}
 }
 
 // close closes the terminal session

--- a/agent/internal/terminal/terminal.go
+++ b/agent/internal/terminal/terminal.go
@@ -37,7 +37,7 @@ type Session struct {
 	cmd      *exec.Cmd      // process command (Unix/macOS; nil on Windows ConPTY)
 	mu       sync.Mutex
 	writeMu  sync.Mutex // serializes PTY/stdin writes; never held with s.mu
-	// writeTimeout bounds each write; zero means defaultWriteTimeout.
+	// writeTimeout bounds each write; non-positive means defaultWriteTimeout.
 	// Set before the session is used (tests only) — never mutated afterwards.
 	writeTimeout time.Duration
 	closed       bool
@@ -248,8 +248,17 @@ func (s *Session) write(data []byte) error {
 			"sessionId", s.ID, "timeout", timeout.String())
 		// Close in a goroutine: close() takes s.mu and waits for the shell
 		// process, and killing the shell is what unblocks the stuck write.
-		go s.close()
-		return fmt.Errorf("terminal write timed out after %s; session %s closed", timeout, s.ID)
+		// A close failure here must never be silent — closing the fd is the
+		// mechanism that releases the wedged writer goroutine, so if it fails
+		// that goroutine (and writeMu) stays pinned.
+		go func() {
+			defer observability.Recoverer("terminal.writeTimeoutClose")
+			if err := s.close(); err != nil {
+				log.Error("failed to close session after write timeout — wedged writer may remain pinned",
+					"sessionId", s.ID, "error", err.Error())
+			}
+		}()
+		return fmt.Errorf("terminal write timed out after %s; session %s close initiated", timeout, s.ID)
 	}
 }
 

--- a/agent/internal/tunnel/tunnel.go
+++ b/agent/internal/tunnel/tunnel.go
@@ -18,6 +18,13 @@ const (
 	dialTimeout = 10 * time.Second
 )
 
+// defaultWriteTimeout bounds each Write to the local target. Without it a
+// stalled target (full TCP send buffer, wedged VNC server) blocks the calling
+// worker forever, pinning the command payload that carried the data and
+// permanently shrinking the command worker pool (issue #2387). Tests shorten
+// the bound via the Session.writeTimeout field.
+const defaultWriteTimeout = 30 * time.Second
+
 // DataCallback is called when data is read from the TCP connection.
 type DataCallback func(tunnelID string, data []byte)
 
@@ -31,8 +38,11 @@ type Session struct {
 	TargetPort int
 	TunnelType string // "vnc" or "proxy"
 
-	conn       net.Conn
-	done       chan struct{}
+	conn net.Conn
+	// writeTimeout bounds each Write; zero means defaultWriteTimeout.
+	// Set before the session is used (tests only) — never mutated afterwards.
+	writeTimeout time.Duration
+	done         chan struct{}
 	closeOnce  sync.Once
 	onData     DataCallback
 	onClose    CloseCallback
@@ -87,8 +97,27 @@ func (s *Session) Write(data []byte) error {
 	default:
 	}
 
+	timeout := s.writeTimeout
+	if timeout <= 0 {
+		timeout = defaultWriteTimeout
+	}
+
+	// Bound the write so a stalled target cannot wedge the caller forever.
+	// Deadline errors are permanent on net.Conn (all subsequent writes fail),
+	// so the session is torn down rather than left in a poisoned state.
+	if err := s.conn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
+		return fmt.Errorf("set write deadline for %s:%d: %w", s.TargetHost, s.TargetPort, err)
+	}
 	n, err := s.conn.Write(data)
 	if err != nil {
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			log.Warn("tunnel write timed out, closing session",
+				"tunnelId", s.ID,
+				"target", fmt.Sprintf("%s:%d", s.TargetHost, s.TargetPort),
+				"timeout", timeout.String(),
+			)
+			s.Close()
+		}
 		return fmt.Errorf("write to %s:%d: %w", s.TargetHost, s.TargetPort, err)
 	}
 	s.bytesSent.Add(int64(n))

--- a/agent/internal/tunnel/tunnel.go
+++ b/agent/internal/tunnel/tunnel.go
@@ -39,10 +39,14 @@ type Session struct {
 	TunnelType string // "vnc" or "proxy"
 
 	conn net.Conn
-	// writeTimeout bounds each Write; zero means defaultWriteTimeout.
+	// writeTimeout bounds each Write; non-positive means defaultWriteTimeout.
 	// Set before the session is used (tests only) — never mutated afterwards.
 	writeTimeout time.Duration
-	done         chan struct{}
+	// closeReason records why the session was torn down (e.g. a write
+	// timeout) so readLoop's onClose reports the true cause instead of the
+	// read-side symptom ("use of closed network connection").
+	closeReason atomic.Value // stores error
+	done        chan struct{}
 	closeOnce  sync.Once
 	onData     DataCallback
 	onClose    CloseCallback
@@ -103,22 +107,26 @@ func (s *Session) Write(data []byte) error {
 	}
 
 	// Bound the write so a stalled target cannot wedge the caller forever.
-	// Deadline errors are permanent on net.Conn (all subsequent writes fail),
-	// so the session is torn down rather than left in a poisoned state.
+	// On timeout the session is torn down rather than left running: the
+	// write may have partially flushed, corrupting the VNC/proxy stream
+	// framing, and a target that stalled for the full deadline is presumed
+	// dead.
 	if err := s.conn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
 		return fmt.Errorf("set write deadline for %s:%d: %w", s.TargetHost, s.TargetPort, err)
 	}
 	n, err := s.conn.Write(data)
 	if err != nil {
+		wrapped := fmt.Errorf("write to %s:%d: %w", s.TargetHost, s.TargetPort, err)
 		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 			log.Warn("tunnel write timed out, closing session",
 				"tunnelId", s.ID,
 				"target", fmt.Sprintf("%s:%d", s.TargetHost, s.TargetPort),
 				"timeout", timeout.String(),
 			)
+			s.closeReason.Store(fmt.Errorf("tunnel write timed out after %s: %w", timeout, wrapped))
 			s.Close()
 		}
-		return fmt.Errorf("write to %s:%d: %w", s.TargetHost, s.TargetPort, err)
+		return wrapped
 	}
 	s.bytesSent.Add(int64(n))
 	s.touch()
@@ -161,6 +169,11 @@ func (s *Session) readLoop() {
 
 	defer func() {
 		s.Close()
+		// A recorded close reason (e.g. write timeout) is the true cause;
+		// the read error here is usually just its symptom.
+		if reason, ok := s.closeReason.Load().(error); ok {
+			closeErr = reason
+		}
 		if s.onClose != nil {
 			s.onClose(s.ID, closeErr)
 		}

--- a/agent/internal/tunnel/tunnel_write_test.go
+++ b/agent/internal/tunnel/tunnel_write_test.go
@@ -87,6 +87,13 @@ func TestSessionWriteTimesOutOnStalledTarget(t *testing.T) {
 	default:
 		t.Fatal("session not closed after write timeout")
 	}
+
+	// The recorded close reason must carry the write-timeout cause so
+	// readLoop's onClose reports it (not the read-side symptom).
+	reason, ok := s.closeReason.Load().(error)
+	if !ok || !strings.Contains(reason.Error(), "timed out") {
+		t.Fatalf("expected closeReason to record the write timeout, got %v", reason)
+	}
 	if err := s.Write([]byte("after")); err == nil || !strings.Contains(err.Error(), "closed") {
 		t.Fatalf("expected closed-session error on subsequent write, got %v", err)
 	}

--- a/agent/internal/tunnel/tunnel_write_test.go
+++ b/agent/internal/tunnel/tunnel_write_test.go
@@ -1,0 +1,93 @@
+package tunnel
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newPipeSession(t *testing.T, writeTimeout time.Duration) (*Session, net.Conn) {
+	t.Helper()
+	local, remote := net.Pipe()
+	s := &Session{
+		ID:           "test-tunnel",
+		TargetHost:   "127.0.0.1",
+		TargetPort:   5900,
+		TunnelType:   "vnc",
+		conn:         local,
+		writeTimeout: writeTimeout,
+		done:         make(chan struct{}),
+		createdAt:    time.Now(),
+	}
+	t.Cleanup(func() {
+		s.Close()
+		remote.Close()
+	})
+	return s, remote
+}
+
+func TestSessionWriteSucceedsWithDrainingTarget(t *testing.T) {
+	s, remote := newPipeSession(t, 2*time.Second)
+
+	got := make(chan []byte, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, err := remote.Read(buf)
+		if err != nil {
+			t.Errorf("remote read: %v", err)
+			return
+		}
+		got <- buf[:n]
+	}()
+
+	if err := s.Write([]byte("hello")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	select {
+	case b := <-got:
+		if string(b) != "hello" {
+			t.Fatalf("target received %q, want %q", b, "hello")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("target never received the write")
+	}
+	if s.BytesSent() != 5 {
+		t.Fatalf("BytesSent = %d, want 5", s.BytesSent())
+	}
+}
+
+// TestSessionWriteTimesOutOnStalledTarget is the regression test for issue
+// #2387: a target that never drains must not block Write forever — the write
+// must fail within the deadline and the session must be closed so the calling
+// command worker (and its payload) is released.
+func TestSessionWriteTimesOutOnStalledTarget(t *testing.T) {
+	s, _ := newPipeSession(t, 100*time.Millisecond) // net.Pipe with no reader: Write blocks until deadline
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Write([]byte("stalled")) }()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected timeout error, got nil")
+		}
+		var netErr net.Error
+		if !errors.As(err, &netErr) || !netErr.Timeout() {
+			t.Fatalf("expected net timeout error, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Write still blocked long after the write deadline — worker would be wedged")
+	}
+
+	// The session must be torn down after a write timeout.
+	select {
+	case <-s.done:
+	default:
+		t.Fatal("session not closed after write timeout")
+	}
+	if err := s.Write([]byte("after")); err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("expected closed-session error on subsequent write, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Hardening pass for the ~2.5 GB compressed-heap retention observed on macOS agents (issue #2387). **Refs #2387** — deliberately not `Closes`: root-cause confirmation still needs field heap profiles (the pprof capability tracked in #2389), so the issue stays open.

### Refined retention mechanism

Independent verification found the issue's leading-suspect section partially wrong: `go c.processCommand(cmd)` (`agent/internal/websocket/client.go:353`) is unbounded at the spawn layer, but execution is bounded downstream — `HandleCommand` routes through `executeCommandViaPool` into the worker pool (`agent/internal/workerpool/pool.go`, shipped in 2f88f3417) with `MaxConcurrentCommands=10` / `CommandQueueSize=100` and fast rejection when full.

The real mechanism is the absence of any per-command timeout at the dispatch layer: `executeCommandViaPool` waits on `resultCh` forever, and each in-flight/queued command retains its full decoded payload (`maxMessageSize` = 64 MB, `client.go:28`). Up to ~110 retained payloads is a ~7 GB ceiling; a few dozen wedged workers holding large command payloads is consistent with the observed flat 2.5 GB stuck set. Three concrete indefinite blockers were found that can wedge a worker forever, plus one unbounded map.

### Changes

1. **Tunnel write deadline** (`agent/internal/tunnel/tunnel.go`): `Session.Write` was a bare `conn.Write` with no deadline — a stalled local target (full TCP send buffer, wedged VNC server) blocked the pool worker forever, pinning that command's payload and permanently shrinking the pool. Now each write sets a 30s `SetWriteDeadline`; on timeout the session is closed cleanly and the worker is released.

2. **Bounded terminal write** (`agent/internal/terminal/terminal.go`): `Session.write` performed a PTY/stdin write with no deadline while **holding `s.mu`** — a full PTY buffer (e.g. Ctrl-S'd foreground process) blocked forever AND deadlocked `close()` plus every later terminal command for that session, eating more workers. The PTY fd is opened in blocking mode (`posix_openpt` without `O_NONBLOCK` on macOS), so `SetWriteDeadline` is unavailable; the write now runs on a writer goroutine with a 30s bounded wait (serialized by a new `writeMu`, never held with `s.mu`). On timeout the session is marked dead and torn down, which kills the shell and unblocks the wedged `write(2)`.

3. **Clamp user-helper IPC timeout** (`agent/internal/heartbeat/handlers_script.go`): `sendCommandToUserHelper` used `payload timeoutSeconds + 5s` unclamped — a huge server-supplied `timeoutSeconds` parked a worker near-indefinitely. The local script executor clamps to `MaxTimeout` (3600s, `executor.go:147`); this path didn't. New `helperCommandTimeout` applies the same `DefaultTimeout`/`MaxTimeout` bounds.

4. **`staleHelpers` gated to Windows** (`agent/internal/sessionbroker/broker.go`): the map's only drain path, `KillStaleHelpers`, is Windows-only (both callers Windows-gated; it exists to release DXGI Desktop Duplication locks), so on macOS/Linux the map grew unbounded for the daemon's lifetime. Entries are int PIDs — kilobytes, not the 2.5 GB — but a real leak. Tracking is now skipped off-Windows; macOS stale helpers are already torn down via `CloseSessionsByDesktopContext`.

5. **Log-only in-flight watchdog** (`agent/internal/heartbeat/heartbeat.go`): `executeCommandViaPool` now logs a wedged-worker warning when a command has been in flight for 2h (and every further 2h), citing command id/type/elapsed. Deliberately NOT a timeout — long-running handlers are legitimate (run_script up to 1h, software installs 10–30 min, patch installs loop unbounded), so failing the command would race real work. The log gives field signal for exactly the retention pattern hypothesized in #2387.

### Not changed (noted as follow-up)

`maxMessageSize` (64 MB, `client.go:28`) is ~12x the largest legitimate `file_write` (`maxFileWriteSize` = 4 MB decoded, `fileops.go:18`), but other large-frame paths (terminal output, desktop offer/answer) and the API/server side must agree before shrinking it — left for a follow-up after field profiles confirm the retainer.

### Tests

- `internal/tunnel/tunnel_write_test.go` — stalled-target write times out within the deadline and closes the session (net.Pipe, no reader); draining-target write path unchanged.
- `internal/terminal/session_write_timeout_test.go` — wedged PTY write returns bounded error and marks the session dead; `close()` is no longer deadlocked behind a wedged write (the old `s.mu` hold).
- `internal/heartbeat/handlers_script_timeout_test.go` — table-driven clamp coverage (zero/negative → default, huge → MaxTimeout).
- `internal/heartbeat/heartbeat_pool_watchdog_test.go` — watchdog is log-only: a slow command still returns its real result after multiple watchdog intervals.
- `internal/sessionbroker/broker_stale_helpers_test.go` — `trackStaleHelper` accumulates on Windows only.

### Verification

- `cd agent && go test -race ./...` — full agent suite green.
- `go build ./...` for darwin + `GOOS=windows` + `GOOS=linux` — clean.

Refs #2387
Refs #2389

🤖 Generated with [Claude Code](https://claude.com/claude-code)
