### PR TITLE
fix(agent): chunk log shipper flushes to the API's 200-entry request cap (#2397)

### DIFF
--- a/agent/internal/logging/shipper.go
+++ b/agent/internal/logging/shipper.go
@@ -201,11 +201,12 @@ const (
 // shipBatch ships a flushed batch, splitting it into chunks of at most
 // maxEntriesPerShipRequest entries per HTTP request — the API rejects any
 // larger request wholesale (#2397). Each chunk succeeds or fails
-// independently: a 4xx on one chunk drops only that chunk's entries and
-// later chunks still ship. A terminal transport failure (network error, or
-// 429/5xx after exhausting retries) aborts the remaining chunks instead —
-// the server is unreachable or unhealthy, and each further chunk would burn
-// another full retry cycle for the same outcome, blocking the ship loop.
+// independently: a non-auth 4xx on one chunk drops only that chunk's entries
+// and later chunks still ship. A terminal failure — network error or 429/5xx
+// after exhausting retries (server unreachable/unhealthy), or a 401 (token
+// dead for every chunk alike) — aborts the remaining chunks instead, since
+// each further chunk would burn another doomed request or retry cycle for
+// the same outcome, blocking the ship loop.
 func (s *Shipper) shipBatch(entries []LogEntry) {
 	if s.authMon != nil && s.authMon.ShouldSkip() {
 		// Auth-dead: don't drop entries on the ticker path — re-buffer
@@ -241,7 +242,7 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 		end := min(start+maxEntriesPerShipRequest, len(entries))
 		if !s.shipChunk(entries[start:end]) {
 			if remaining := len(entries) - end; remaining > 0 {
-				fmt.Fprintf(os.Stderr, "[log-shipper] dropping %d entries in remaining chunks after transport failure\n", remaining)
+				fmt.Fprintf(os.Stderr, "[log-shipper] dropping %d entries in remaining chunks after terminal failure\n", remaining)
 				s.droppedCount.Add(int64(remaining))
 			}
 			return
@@ -251,10 +252,11 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 
 // shipChunk sends one HTTP request carrying at most maxEntriesPerShipRequest
 // entries, with per-chunk retry for network errors and 429/5xx responses.
-// It returns false when the transport is terminally unhealthy (network error
-// or retryable status after exhausting retries) so the caller can stop
-// burning retry cycles on the batch's remaining chunks; chunk-local outcomes
-// (success, or a non-retried 4xx that drops only this chunk) return true.
+// It returns false on terminal failures that would doom every remaining
+// chunk alike — network error or retryable status after exhausting retries,
+// or a 401 (dead token) — so the caller can stop burning requests on the
+// rest of the batch. Chunk-local outcomes (success, or a non-retried
+// non-auth 4xx that drops only this chunk) return true.
 func (s *Shipper) shipChunk(entries []LogEntry) bool {
 	payload, err := json.Marshal(map[string]any{
 		"logs": entries,
@@ -359,18 +361,29 @@ func (s *Shipper) shipChunk(entries []LogEntry) bool {
 		}
 
 		if resp.StatusCode >= 400 {
-			// Client error (4xx): do not retry. Chunk-local — the rejection
-			// is about this request's contents, so only this chunk's entries
-			// are dropped and the batch's remaining chunks still ship.
+			// Client error (4xx): do not retry this chunk.
 			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 			resp.Body.Close()
 			cancel()
-			if resp.StatusCode == http.StatusUnauthorized && s.authMon != nil {
-				s.authMon.RecordAuthFailure()
-			}
 			fmt.Fprintf(os.Stderr, "[log-shipper] server returned %d for %d entries: %s\n",
 				resp.StatusCode, len(entries), string(body))
 			s.droppedCount.Add(int64(len(entries)))
+			if resp.StatusCode == http.StatusUnauthorized {
+				// Auth is request-independent: the token won't get healthier
+				// between chunks, so shipping the batch's remaining chunks
+				// would just burn one doomed request — and one extra
+				// RecordAuthFailure — per chunk, skewing the auth monitor's
+				// skip threshold (tuned for one failure per flush, the
+				// pre-chunking behavior). Terminal: record once, abort batch.
+				if s.authMon != nil {
+					s.authMon.RecordAuthFailure()
+				}
+				return false
+			}
+			// Other 4xxs are chunk-local — the rejection is about this
+			// request's contents (e.g. a validation failure) — so only this
+			// chunk's entries are dropped and the batch's remaining chunks
+			// still ship (#2397).
 			return true
 		}
 

--- a/agent/internal/logging/shipper.go
+++ b/agent/internal/logging/shipper.go
@@ -37,6 +37,18 @@ const (
 	defaultBufferSize    = 500
 )
 
+// maxEntriesPerShipRequest mirrors the API log endpoint's per-request cap:
+// apps/api/src/routes/agents/logs.ts validates `logs: z.array(...).max(200)`
+// and 400s the entire request when exceeded — and 4xx responses are never
+// retried, so an oversized request loses every entry in it (#2397). The
+// shipper accumulates up to defaultMaxBatchSize (500) entries per flush, so
+// each flush is split into chunks of at most this many entries per HTTP
+// request. Go and TypeScript can't share a constant; this comment is the
+// sync mechanism — this value must stay <= the API-side cap (never raise it
+// in lockstep with a server bump: self-hosted API versions vary, so the
+// agent must conform to the oldest supported cap).
+const maxEntriesPerShipRequest = 200
+
 // LogEntry represents a single log entry to be shipped remotely.
 type LogEntry struct {
 	Timestamp    time.Time      `json:"timestamp"`
@@ -186,6 +198,14 @@ const (
 	shipRetryBackoff = 1 * time.Second
 )
 
+// shipBatch ships a flushed batch, splitting it into chunks of at most
+// maxEntriesPerShipRequest entries per HTTP request — the API rejects any
+// larger request wholesale (#2397). Each chunk succeeds or fails
+// independently: a 4xx on one chunk drops only that chunk's entries and
+// later chunks still ship. A terminal transport failure (network error, or
+// 429/5xx after exhausting retries) aborts the remaining chunks instead —
+// the server is unreachable or unhealthy, and each further chunk would burn
+// another full retry cycle for the same outcome, blocking the ship loop.
 func (s *Shipper) shipBatch(entries []LogEntry) {
 	if s.authMon != nil && s.authMon.ShouldSkip() {
 		// Auth-dead: don't drop entries on the ticker path — re-buffer
@@ -217,13 +237,32 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 		return
 	}
 
+	for start := 0; start < len(entries); start += maxEntriesPerShipRequest {
+		end := min(start+maxEntriesPerShipRequest, len(entries))
+		if !s.shipChunk(entries[start:end]) {
+			if remaining := len(entries) - end; remaining > 0 {
+				fmt.Fprintf(os.Stderr, "[log-shipper] dropping %d entries in remaining chunks after transport failure\n", remaining)
+				s.droppedCount.Add(int64(remaining))
+			}
+			return
+		}
+	}
+}
+
+// shipChunk sends one HTTP request carrying at most maxEntriesPerShipRequest
+// entries, with per-chunk retry for network errors and 429/5xx responses.
+// It returns false when the transport is terminally unhealthy (network error
+// or retryable status after exhausting retries) so the caller can stop
+// burning retry cycles on the batch's remaining chunks; chunk-local outcomes
+// (success, or a non-retried 4xx that drops only this chunk) return true.
+func (s *Shipper) shipChunk(entries []LogEntry) bool {
 	payload, err := json.Marshal(map[string]any{
 		"logs": entries,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[log-shipper] marshal error: %v\n", err)
 		s.droppedCount.Add(int64(len(entries)))
-		return
+		return true
 	}
 
 	// Compress payload with gzip
@@ -232,12 +271,12 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 	if _, err := gw.Write(payload); err != nil {
 		fmt.Fprintf(os.Stderr, "[log-shipper] gzip write error: %v\n", err)
 		s.droppedCount.Add(int64(len(entries)))
-		return
+		return true
 	}
 	if err := gw.Close(); err != nil {
 		fmt.Fprintf(os.Stderr, "[log-shipper] gzip close error: %v\n", err)
 		s.droppedCount.Add(int64(len(entries)))
-		return
+		return true
 	}
 	compressedBytes := compressed.Bytes()
 
@@ -264,7 +303,7 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 			cancel()
 			fmt.Fprintf(os.Stderr, "[log-shipper] request build error: %v\n", err)
 			s.droppedCount.Add(int64(len(entries)))
-			return
+			return true
 		}
 
 		req.Header.Set("Authorization", "Bearer "+s.authToken.Reveal())
@@ -281,7 +320,7 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 			}
 			fmt.Fprintf(os.Stderr, "[log-shipper] HTTP error (giving up after %d attempts): %v\n", shipRetryCount+1, err)
 			s.droppedCount.Add(int64(len(entries)))
-			return
+			return false
 		}
 
 		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
@@ -300,7 +339,7 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 			fmt.Fprintf(os.Stderr, "[log-shipper] server returned %d (giving up after %d attempts): %s\n",
 				resp.StatusCode, shipRetryCount+1, string(body))
 			s.droppedCount.Add(int64(len(entries)))
-			return
+			return false
 		}
 
 		if resp.StatusCode >= 500 {
@@ -316,11 +355,13 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 			fmt.Fprintf(os.Stderr, "[log-shipper] server returned %d (giving up after %d attempts): %s\n",
 				resp.StatusCode, shipRetryCount+1, string(body))
 			s.droppedCount.Add(int64(len(entries)))
-			return
+			return false
 		}
 
 		if resp.StatusCode >= 400 {
-			// Client error (4xx): do not retry
+			// Client error (4xx): do not retry. Chunk-local — the rejection
+			// is about this request's contents, so only this chunk's entries
+			// are dropped and the batch's remaining chunks still ship.
 			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 			resp.Body.Close()
 			cancel()
@@ -330,7 +371,7 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 			fmt.Fprintf(os.Stderr, "[log-shipper] server returned %d for %d entries: %s\n",
 				resp.StatusCode, len(entries), string(body))
 			s.droppedCount.Add(int64(len(entries)))
-			return
+			return true
 		}
 
 		// Success
@@ -340,8 +381,9 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 		if s.authMon != nil {
 			s.authMon.RecordSuccess()
 		}
-		return
+		return true
 	}
+	return true // unreachable: the loop always returns on its final attempt
 }
 
 // DroppedLogCount returns the current count of dropped log entries without

--- a/agent/internal/logging/shipper_test.go
+++ b/agent/internal/logging/shipper_test.go
@@ -270,23 +270,28 @@ func TestShipperStartStopDrains(t *testing.T) {
 }
 
 // decodeShippedLogs decompresses one shipped request body and returns its
-// log entries.
+// log entries. It uses t.Errorf (not Fatalf) because it runs inside httptest
+// handler goroutines, where FailNow/Goexit is undefined behavior; on decode
+// failure it returns nil and the caller's count assertions fail loudly.
 func decodeShippedLogs(t *testing.T, body []byte) []LogEntry {
 	t.Helper()
 	gr, err := gzip.NewReader(bytes.NewReader(body))
 	if err != nil {
-		t.Fatalf("gzip reader: %v", err)
+		t.Errorf("gzip reader: %v", err)
+		return nil
 	}
 	defer gr.Close()
 	decompressed, err := io.ReadAll(gr)
 	if err != nil {
-		t.Fatalf("decompress: %v", err)
+		t.Errorf("decompress: %v", err)
+		return nil
 	}
 	var payload struct {
 		Logs []LogEntry `json:"logs"`
 	}
 	if err := json.Unmarshal(decompressed, &payload); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+		t.Errorf("unmarshal: %v", err)
+		return nil
 	}
 	return payload.Logs
 }
@@ -498,6 +503,42 @@ func TestShipBatchRetries5xxPerChunk(t *testing.T) {
 	}
 	if got := s.DroppedLogCount(); got != 0 {
 		t.Fatalf("expected 0 dropped entries, got %d", got)
+	}
+}
+
+// TestShipBatch401AbortsRemainingChunks verifies a 401 is treated as
+// terminal for the whole batch: the token is dead for every chunk alike, so
+// only one request is made, RecordAuthFailure fires exactly once per flush
+// (the pre-chunking behavior the auth monitor's skip threshold was tuned
+// for), and the remaining chunks are dropped with count.
+func TestShipBatch401AbortsRemainingChunks(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	auth := &testAuthSkipper{}
+	s := NewShipper(ShipperConfig{
+		ServerURL:   server.URL,
+		AgentID:     "test-agent",
+		AuthToken:   testToken("tok"),
+		MinLevel:    "debug",
+		HTTPClient:  server.Client(),
+		AuthMonitor: auth,
+	})
+
+	s.shipBatch(makeEntries(500))
+
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 request (401 is terminal, not retried), got %d", got)
+	}
+	if got := auth.failures.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 RecordAuthFailure per flush, got %d", got)
+	}
+	if got := s.DroppedLogCount(); got != 500 {
+		t.Fatalf("expected all 500 entries dropped (200 rejected + 300 aborted), got %d", got)
 	}
 }
 

--- a/agent/internal/logging/shipper_test.go
+++ b/agent/internal/logging/shipper_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -264,6 +266,268 @@ func TestShipperStartStopDrains(t *testing.T) {
 
 	if count != 5 {
 		t.Fatalf("expected 5 drained entries, got %d", count)
+	}
+}
+
+// decodeShippedLogs decompresses one shipped request body and returns its
+// log entries.
+func decodeShippedLogs(t *testing.T, body []byte) []LogEntry {
+	t.Helper()
+	gr, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer gr.Close()
+	decompressed, err := io.ReadAll(gr)
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	var payload struct {
+		Logs []LogEntry `json:"logs"`
+	}
+	if err := json.Unmarshal(decompressed, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return payload.Logs
+}
+
+// makeEntries builds n entries with sequential messages "entry-0".."entry-n-1"
+// so tests can verify which entries survived chunked shipping.
+func makeEntries(n int) []LogEntry {
+	entries := make([]LogEntry, n)
+	for i := range entries {
+		entries[i] = LogEntry{
+			Timestamp: time.Now(),
+			Level:     "INFO",
+			Component: "test",
+			Message:   fmt.Sprintf("entry-%d", i),
+		}
+	}
+	return entries
+}
+
+// TestMaxEntriesPerShipRequestMatchesAPICap pins the agent-side chunk size to
+// the API's per-request cap (apps/api/src/routes/agents/logs.ts,
+// z.array(...).max(200)). If this fails, someone changed one side without
+// re-checking the other — see the comment on maxEntriesPerShipRequest.
+func TestMaxEntriesPerShipRequestMatchesAPICap(t *testing.T) {
+	if maxEntriesPerShipRequest != 200 {
+		t.Fatalf("maxEntriesPerShipRequest = %d, want 200 (the API rejects requests with more than 200 entries; #2397)", maxEntriesPerShipRequest)
+	}
+	if maxEntriesPerShipRequest > defaultMaxBatchSize {
+		t.Fatalf("chunk size %d exceeds batch size %d — chunking would be dead code", maxEntriesPerShipRequest, defaultMaxBatchSize)
+	}
+}
+
+// TestShipBatchChunksFullBatch verifies a full 500-entry flush is split into
+// three requests of 200/200/100 entries — a single 500-entry request would be
+// rejected wholesale by the API's 200-entry cap (#2397).
+func TestShipBatchChunksFullBatch(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		chunks [][]LogEntry
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		chunks = append(chunks, decodeShippedLogs(t, body))
+		mu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	s := NewShipper(ShipperConfig{
+		ServerURL:  server.URL,
+		AgentID:    "test-agent",
+		AuthToken:  testToken("tok"),
+		MinLevel:   "debug",
+		HTTPClient: server.Client(),
+	})
+
+	s.shipBatch(makeEntries(defaultMaxBatchSize))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 requests for a %d-entry batch, got %d", defaultMaxBatchSize, len(chunks))
+	}
+	for i, want := range []int{200, 200, 100} {
+		if got := len(chunks[i]); got != want {
+			t.Fatalf("chunk %d: expected %d entries, got %d", i, want, got)
+		}
+	}
+	// Entries must arrive in order with none lost or duplicated.
+	idx := 0
+	for _, chunk := range chunks {
+		for _, e := range chunk {
+			if want := fmt.Sprintf("entry-%d", idx); e.Message != want {
+				t.Fatalf("entry %d: expected message %q, got %q", idx, want, e.Message)
+			}
+			idx++
+		}
+	}
+	if got := s.DroppedLogCount(); got != 0 {
+		t.Fatalf("expected 0 dropped entries, got %d", got)
+	}
+}
+
+// TestShipBatchSmallBatchSingleRequest verifies batches at or under the cap
+// still go out as one request.
+func TestShipBatchSmallBatchSingleRequest(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	s := NewShipper(ShipperConfig{
+		ServerURL:  server.URL,
+		AgentID:    "test-agent",
+		AuthToken:  testToken("tok"),
+		MinLevel:   "debug",
+		HTTPClient: server.Client(),
+	})
+
+	s.shipBatch(makeEntries(maxEntriesPerShipRequest))
+
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 request for a %d-entry batch, got %d", maxEntriesPerShipRequest, got)
+	}
+}
+
+// TestShipBatchMidChunk4xxDropsOnlyThatChunk verifies a 400 on the second
+// chunk drops only that chunk's 200 entries — chunks 1 and 3 still ship
+// (previously a 4xx burned the whole 500-entry batch, #2397).
+func TestShipBatchMidChunk4xxDropsOnlyThatChunk(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		received []LogEntry
+		requests int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		requests++
+		reject := requests == 2
+		if !reject {
+			received = append(received, decodeShippedLogs(t, body)...)
+		}
+		mu.Unlock()
+		if reject {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	s := NewShipper(ShipperConfig{
+		ServerURL:  server.URL,
+		AgentID:    "test-agent",
+		AuthToken:  testToken("tok"),
+		MinLevel:   "debug",
+		HTTPClient: server.Client(),
+	})
+
+	s.shipBatch(makeEntries(500))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 3 {
+		t.Fatalf("expected 3 requests (4xx is not retried), got %d", requests)
+	}
+	if len(received) != 300 {
+		t.Fatalf("expected 300 delivered entries (chunks 1 and 3), got %d", len(received))
+	}
+	// Chunk 3 (entries 400..499) must have shipped despite chunk 2's 400.
+	if got, want := received[200].Message, "entry-400"; got != want {
+		t.Fatalf("first entry after the rejected chunk: expected %q, got %q", want, got)
+	}
+	if got, want := received[299].Message, "entry-499"; got != want {
+		t.Fatalf("last delivered entry: expected %q, got %q", want, got)
+	}
+	if got := s.DroppedLogCount(); got != 200 {
+		t.Fatalf("expected exactly the rejected chunk's 200 entries dropped, got %d", got)
+	}
+}
+
+// TestShipBatchRetries5xxPerChunk verifies the 5xx retry loop applies to each
+// chunk independently: a transient 500 on the second chunk is retried and the
+// full batch is eventually delivered.
+func TestShipBatchRetries5xxPerChunk(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		received []LogEntry
+		requests int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		requests++
+		fail := requests == 2 // first attempt of chunk 2
+		if !fail {
+			received = append(received, decodeShippedLogs(t, body)...)
+		}
+		mu.Unlock()
+		if fail {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	s := NewShipper(ShipperConfig{
+		ServerURL:  server.URL,
+		AgentID:    "test-agent",
+		AuthToken:  testToken("tok"),
+		MinLevel:   "debug",
+		HTTPClient: server.Client(),
+	})
+
+	s.shipBatch(makeEntries(500))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 4 {
+		t.Fatalf("expected 4 requests (3 chunks + 1 retry of chunk 2), got %d", requests)
+	}
+	if len(received) != 500 {
+		t.Fatalf("expected all 500 entries delivered after retry, got %d", len(received))
+	}
+	if got := s.DroppedLogCount(); got != 0 {
+		t.Fatalf("expected 0 dropped entries, got %d", got)
+	}
+}
+
+// TestShipBatchAbortsRemainingChunksOnTerminalFailure verifies that when a
+// chunk exhausts its retries against a dead server, the batch's remaining
+// chunks are dropped (with count) instead of each burning another full retry
+// cycle while the ship loop is blocked.
+func TestShipBatchAbortsRemainingChunksOnTerminalFailure(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	s := NewShipper(ShipperConfig{
+		ServerURL:  server.URL,
+		AgentID:    "test-agent",
+		AuthToken:  testToken("tok"),
+		MinLevel:   "debug",
+		HTTPClient: server.Client(),
+	})
+
+	s.shipBatch(makeEntries(500))
+
+	if got, want := requests.Load(), int64(shipRetryCount+1); got != want {
+		t.Fatalf("expected %d requests (only chunk 1's retry cycle), got %d", want, got)
+	}
+	if got := s.DroppedLogCount(); got != 500 {
+		t.Fatalf("expected all 500 entries dropped (200 exhausted + 300 aborted), got %d", got)
 	}
 }
 


### PR DESCRIPTION
Closes #2397

## Problem

The agent log shipper accumulates up to 500 entries per flush (`defaultMaxBatchSize`) but shipped them all in one HTTP request. The API's logs endpoint caps `logs` at 200 entries per request (`apps/api/src/routes/agents/logs.ts`, `z.array(...).max(200)`) and 400s the whole request when exceeded — and the shipper never retries 4xx. A full batch was therefore guaranteed lost wholesale, precisely under bursty logging when logs matter most. Same burn-the-batch class as #2386.

## Fix (agent-side only)

- New named constant `maxEntriesPerShipRequest = 200` in `agent/internal/logging/shipper.go`, with a comment pointing at the API-side cap (Go and TS can't share code — the comment is the sync mechanism, and the value must stay <= the oldest supported API cap since self-hosted versions vary).
- `shipBatch` now splits each flush into <=200-entry chunks; the 500-entry accumulation buffer is unchanged.
- New `shipChunk` carries one HTTP request with the existing retry loop:
  - **Non-auth 4xx** — chunk-local: drops only that chunk's entries; the batch's remaining chunks still ship.
  - **429/5xx/network errors** — retried per chunk (`shipRetryCount`, Retry-After honored as before).
  - **Terminal failures abort the batch's remaining chunks** with a counted drop: network error or 429/5xx after exhausting retries (server unreachable — each further chunk would burn another full retry cycle while blocking the ship loop), and **401** (token dead for every chunk alike; also keeps `RecordAuthFailure` at one per flush, matching the pre-chunking rate the auth monitor's skip threshold was tuned for). Net drop count in these cases matches the old single-request behavior.
- Server cap untouched.

## Tests (`agent/internal/logging/shipper_test.go`)

- 500-entry flush produces exactly 3 requests of 200/200/100, in order, none lost or duplicated.
- <=200-entry batch still goes out as a single request.
- A 400 on chunk 2 drops only that chunk (300 entries delivered, `DroppedLogCount == 200`, chunk 3 verified shipped).
- A transient 500 on chunk 2 is retried per-chunk; all 500 entries delivered.
- Dead server: only chunk 1's retry cycle runs (3 requests), remaining chunks abort with counted drops.
- 401: exactly 1 request, exactly 1 `RecordAuthFailure`, all 500 dropped with count.
- Pin test asserting `maxEntriesPerShipRequest == 200` against the API contract.

## Verification

- `cd agent && go test -race ./internal/logging/...` — ok (7.5s)
- `gofmt -l` clean, `go vet` clean, `go build ./...` ok

## Note for the merger

Open PR #2392 (#2386) also touches `shipper.go` (adds `capFields` in `Enqueue`). This change is confined to the flush/ship path, so overlap is minimal, but whichever merges second may need a trivial rebase. This PR is based on `origin/main`, not on #2392's branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)