### PR TITLE
fix(api): cap script timeoutSeconds intake at 3600 to match agent executor clamp (#2398)

### DIFF
--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -2457,7 +2457,7 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
                   language: { type: 'string', enum: ['powershell', 'bash', 'python', 'cmd'] },
                   content: { type: 'string', minLength: 1 },
                   parameters: { type: 'object' },
-                  timeoutSeconds: { type: 'integer', minimum: 1, maximum: 86400, default: 300 },
+                  timeoutSeconds: { type: 'integer', minimum: 1, maximum: 3600, default: 300 },
                   runAs: { type: 'string', enum: ['system', 'user', 'elevated'], default: 'system' }
                 },
                 required: ['name', 'osTypes', 'language', 'content']

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -208,6 +208,58 @@ describe('scripts routes', () => {
     expect(body.id).toBe(SCRIPT_ID_1);
   });
 
+  it('should accept timeoutSeconds at the 3600 executor cap on create', async () => {
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: SCRIPT_ID_1,
+          name: 'Long Script',
+          orgId: ORG_ID
+        }])
+      })
+    } as any);
+
+    const res = await app.request('/scripts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({
+        name: 'Long Script',
+        osTypes: ['linux'],
+        language: 'bash',
+        content: 'echo hello',
+        timeoutSeconds: 3600
+      })
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  it('should reject timeoutSeconds above 3600 on create (#2398 — agent clamps at 1h)', async () => {
+    for (const tooLong of [3601, 7200, 86400]) {
+      const res = await app.request('/scripts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({
+          name: 'Too Long',
+          osTypes: ['linux'],
+          language: 'bash',
+          content: 'echo hello',
+          timeoutSeconds: tooLong
+        })
+      });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it('should reject timeoutSeconds above 3600 on update (#2398)', async () => {
+    const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({ timeoutSeconds: 7200 })
+    });
+    expect(res.status).toBe(400);
+  });
+
   it('should update a script and return updated record', async () => {
     vi.mocked(db.select).mockReturnValue({
       from: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -260,6 +260,41 @@ describe('scripts routes', () => {
     expect(res.status).toBe(400);
   });
 
+  it('should accept timeoutSeconds at the 3600 cap on update', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: SCRIPT_ID_1,
+            name: 'Script One',
+            content: 'echo hi',
+            version: 1,
+            isSystem: false,
+            orgId: ORG_ID
+          }])
+        })
+      })
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            id: SCRIPT_ID_1,
+            timeoutSeconds: 3600,
+            version: 2
+          }])
+        })
+      })
+    } as any);
+
+    const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({ timeoutSeconds: 3600 })
+    });
+    expect(res.status).toBe(200);
+  });
+
   it('should update a script and return updated record', async () => {
     vi.mocked(db.select).mockReturnValue({
       from: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -168,7 +168,7 @@ const createScriptSchema = z.object({
   content: z.string().min(1),
   parameters: z.any().optional(),
   // Max 3600: the agent executor clamps script timeouts to 1 hour
-  // (agent/internal/remote/executor/executor.go MaxTimeout) — accepting more
+  // (agent/internal/executor/executor.go MaxTimeout) — accepting more
   // at intake is silent false configurability (#2398).
   timeoutSeconds: z.number().int().min(1).max(3600).default(300),
   runAs: z.enum(['system', 'user', 'elevated']).default('system'),

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -167,7 +167,10 @@ const createScriptSchema = z.object({
   language: z.enum(['powershell', 'bash', 'python', 'cmd']),
   content: z.string().min(1),
   parameters: z.any().optional(),
-  timeoutSeconds: z.number().int().min(1).max(86400).default(300),
+  // Max 3600: the agent executor clamps script timeouts to 1 hour
+  // (agent/internal/remote/executor/executor.go MaxTimeout) — accepting more
+  // at intake is silent false configurability (#2398).
+  timeoutSeconds: z.number().int().min(1).max(3600).default(300),
   runAs: z.enum(['system', 'user', 'elevated']).default('system'),
   isSystem: z.boolean().optional(),
   exitCodeSeverityMapping: exitCodeSeverityMappingSchema.nullable().optional(),
@@ -182,7 +185,7 @@ const updateScriptSchema = z.object({
   language: z.enum(['powershell', 'bash', 'python', 'cmd']).optional(),
   content: z.string().min(1).optional(),
   parameters: z.any().optional(),
-  timeoutSeconds: z.number().int().min(1).max(86400).optional(),
+  timeoutSeconds: z.number().int().min(1).max(3600).optional(),
   runAs: z.enum(['system', 'user', 'elevated']).optional(),
   exitCodeSeverityMapping: exitCodeSeverityMappingSchema.nullable().optional(),
   // Re-scope on edit (issue #1734). Mirrors the create-time "Available to"

--- a/apps/api/src/services/scriptBuilderTools.guard.test.ts
+++ b/apps/api/src/services/scriptBuilderTools.guard.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
 import { TOOL_TIERS } from './aiAgentSdkTools';
 import { TOOL_PERMISSIONS, checkGuardrails } from './aiGuardrails';
-import { SCRIPT_BUILDER_TOOL_TIERS } from './scriptBuilderTools';
+import { applyScriptMetadataInputShape, SCRIPT_BUILDER_TOOL_TIERS } from './scriptBuilderTools';
 import { toolInputSchemas, validateToolInput } from './aiToolSchemas';
 
 /**
@@ -107,5 +108,24 @@ describe('script-builder context tools are fully wired for the session guardrail
         limit: 10,
       }).success,
     ).toBe(true);
+  });
+});
+
+describe('apply_script_metadata timeoutSeconds cap', () => {
+  // The agent executor hard-clamps script timeouts to 3600s
+  // (agent/internal/executor/executor.go MaxTimeout). If this inline cap ever
+  // drifts back up (e.g. to let the builder honor a "2 hour timeout" request),
+  // the builder would propose values the scripts route then rejects with a 400,
+  // breaking the apply flow — see #2398.
+  const schema = z.object(applyScriptMetadataInputShape);
+
+  it('accepts a timeout at the 3600s executor cap', () => {
+    expect(schema.safeParse({ timeoutSeconds: 3600 }).success).toBe(true);
+  });
+
+  it('rejects timeouts above 3600s (#2398)', () => {
+    for (const tooLong of [3601, 7200, 86400]) {
+      expect(schema.safeParse({ timeoutSeconds: tooLong }).success).toBe(false);
+    }
   });
 });

--- a/apps/api/src/services/scriptBuilderTools.ts
+++ b/apps/api/src/services/scriptBuilderTools.ts
@@ -159,6 +159,26 @@ function makeApplyHandler(
 // MCP Server Factory
 // ============================================
 
+// Exported so scriptBuilderTools.guard.test.ts can pin the timeoutSeconds cap
+// to the agent executor's MaxTimeout (3600) — see #2398.
+export const applyScriptMetadataInputShape = {
+  name: z.string().max(255).optional().describe('Script name'),
+  description: z.string().max(2000).optional().describe('Script description'),
+  category: z.enum(['Maintenance', 'Security', 'Monitoring', 'Deployment', 'Backup', 'Network', 'User Management', 'Software', 'Custom']).optional(),
+  osTypes: z.array(z.enum(['windows', 'macos', 'linux'])).optional(),
+  parameters: z.array(z.object({
+    name: z.string(),
+    type: z.enum(['string', 'number', 'boolean', 'select']),
+    defaultValue: z.string().optional(),
+    required: z.boolean().optional(),
+    options: z.string().optional(),
+  })).optional(),
+  runAs: z.enum(['system', 'user', 'elevated']).optional(),
+  // 3600 = agent executor MaxTimeout — higher values are silently clamped
+  // on-device, so don't let the builder propose them (#2398).
+  timeoutSeconds: z.number().int().min(1).max(3600).optional(),
+};
+
 export function createScriptBuilderMcpServer(
   getAuth: () => AuthContext,
   onPreToolUse?: PreToolUseCallback,
@@ -181,23 +201,7 @@ export function createScriptBuilderMcpServer(
     tool(
       'apply_script_metadata',
       'Set script metadata fields in the editor form (name, description, category, OS targets, parameters, etc.). Only include fields you want to change.',
-      {
-        name: z.string().max(255).optional().describe('Script name'),
-        description: z.string().max(2000).optional().describe('Script description'),
-        category: z.enum(['Maintenance', 'Security', 'Monitoring', 'Deployment', 'Backup', 'Network', 'User Management', 'Software', 'Custom']).optional(),
-        osTypes: z.array(z.enum(['windows', 'macos', 'linux'])).optional(),
-        parameters: z.array(z.object({
-          name: z.string(),
-          type: z.enum(['string', 'number', 'boolean', 'select']),
-          defaultValue: z.string().optional(),
-          required: z.boolean().optional(),
-          options: z.string().optional(),
-        })).optional(),
-        runAs: z.enum(['system', 'user', 'elevated']).optional(),
-        // 3600 = agent executor MaxTimeout — higher values are silently clamped
-        // on-device, so don't let the builder propose them (#2398).
-        timeoutSeconds: z.number().int().min(1).max(3600).optional(),
-      },
+      applyScriptMetadataInputShape,
       makeApplyHandler('apply_script_metadata', onPostToolUse)
     ),
 

--- a/apps/api/src/services/scriptBuilderTools.ts
+++ b/apps/api/src/services/scriptBuilderTools.ts
@@ -194,7 +194,9 @@ export function createScriptBuilderMcpServer(
           options: z.string().optional(),
         })).optional(),
         runAs: z.enum(['system', 'user', 'elevated']).optional(),
-        timeoutSeconds: z.number().int().min(1).max(86400).optional(),
+        // 3600 = agent executor MaxTimeout — higher values are silently clamped
+        // on-device, so don't let the builder propose them (#2398).
+        timeoutSeconds: z.number().int().min(1).max(3600).optional(),
       },
       makeApplyHandler('apply_script_metadata', onPostToolUse)
     ),

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -609,7 +609,7 @@ export default function ScriptForm({
         <div className="grid gap-6 md:grid-cols-2">
           <div className="space-y-2">
             <label htmlFor="timeout-seconds" className="text-sm font-medium">{t('scriptForm.fields.timeoutSeconds')}</label>
-            <input id="timeout-seconds" type="number" min={1} max={86400} className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring" {...register('timeoutSeconds')} />
+            <input id="timeout-seconds" type="number" min={1} max={3600} className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring" {...register('timeoutSeconds')} />
             {errors.timeoutSeconds && <p className="text-sm text-destructive">{errors.timeoutSeconds.message}</p>}
             <p className="text-xs text-muted-foreground">{t('scriptForm.execution.timeoutHint')}</p>
           </div>

--- a/apps/web/src/components/scripts/ScriptFormSchema.test.ts
+++ b/apps/web/src/components/scripts/ScriptFormSchema.test.ts
@@ -64,4 +64,18 @@ describe('scriptSchema timeoutSeconds', () => {
       expect(result.success).toBe(false);
     }
   });
+
+  // Deliberate: editing a legacy script saved under the old 86400 cap surfaces
+  // a clear validation error instead of silently clamping — the stored value
+  // was never honored by the agent, so we force a visible correction here
+  // (unlike the AI-builder editorSnapshot, which clamps so session creation
+  // doesn't fail on an unrelated field). See #2398.
+  it('rejects a legacy 86400 value with the 1-hour message on edit', () => {
+    const result = scriptSchema.safeParse({ ...base, timeoutSeconds: 86400 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path[0] === 'timeoutSeconds');
+      expect(issue?.message).toBe('Timeout cannot exceed 1 hour (3600 seconds)');
+    }
+  });
 });

--- a/apps/web/src/components/scripts/ScriptFormSchema.test.ts
+++ b/apps/web/src/components/scripts/ScriptFormSchema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   mappingToRows,
   rowsToMapping,
+  scriptSchema,
   SUPPRESS_SEVERITY,
   type ExitCodeSeverityMapping,
   type ExitCodeSeverityRow,
@@ -40,5 +41,27 @@ describe('rowsToMapping / mappingToRows', () => {
   it('returns an empty array when given no mapping', () => {
     expect(mappingToRows(undefined)).toEqual([]);
     expect(mappingToRows(null)).toEqual([]);
+  });
+});
+
+describe('scriptSchema timeoutSeconds', () => {
+  const base = {
+    name: 'Test Script',
+    category: 'Maintenance',
+    language: 'bash' as const,
+    osTypes: ['linux' as const],
+    content: 'echo test',
+    runAs: 'system' as const,
+  };
+
+  it('accepts a timeout at the 3600s executor cap', () => {
+    expect(scriptSchema.safeParse({ ...base, timeoutSeconds: 3600 }).success).toBe(true);
+  });
+
+  it('rejects timeouts above 3600s (#2398 — agent clamps at 1 hour)', () => {
+    for (const tooLong of [3601, 7200, 86400]) {
+      const result = scriptSchema.safeParse({ ...base, timeoutSeconds: tooLong });
+      expect(result.success).toBe(false);
+    }
   });
 });

--- a/apps/web/src/components/scripts/ScriptFormSchema.ts
+++ b/apps/web/src/components/scripts/ScriptFormSchema.ts
@@ -39,7 +39,9 @@ export const scriptSchema = z.object({
     .number({ error: 'Enter a timeout value' })
     .int('Timeout must be a whole number')
     .min(1, 'Timeout must be at least 1 second')
-    .max(86400, 'Timeout cannot exceed 24 hours'),
+    // 3600 = agent-side executor hard cap; larger values would be silently
+    // clamped to 1 hour on the device (#2398).
+    .max(3600, 'Timeout cannot exceed 1 hour (3600 seconds)'),
   runAs: z.enum(['system', 'user', 'elevated']),
   exitCodeSeverityMapping: z
     .array(exitCodeSeverityRowSchema)

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -928,7 +928,7 @@
       "emptySuffix": "(Python)."
     },
     "execution": {
-      "timeoutHint": "Script is killed after this duration. Default 300s (5 min) is suitable for most tasks.",
+      "timeoutHint": "Script is killed after this duration. Default 300s (5 min) is suitable for most tasks. Maximum 3600s (1 hour).",
       "elevatedHint": "Uses sudo on macOS/Linux, runas on Windows."
     },
     "exitCodeSeverity": {

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -928,7 +928,7 @@
       "emptySuffix": "(Python)."
     },
     "execution": {
-      "timeoutHint": "O script é encerrado após essa duração. O padrão de 300s (5 min) é adequado para a maioria das tarefas.",
+      "timeoutHint": "O script é encerrado após essa duração. O padrão de 300s (5 min) é adequado para a maioria das tarefas. Máximo de 3600s (1 hora).",
       "elevatedHint": "Usa sudo no macOS/Linux, runas no Windows."
     },
     "exitCodeSeverity": {

--- a/packages/shared/src/validators/ai.ts
+++ b/packages/shared/src/validators/ai.ts
@@ -93,7 +93,11 @@ export const scriptBuilderContextSchema = z.object({
       options: z.string().max(1000).optional(),
     })).max(50).optional(),
     runAs: z.enum(['system', 'user', 'elevated']).optional(),
-    timeoutSeconds: z.number().min(1).max(86400).optional(),
+    // The editor snapshot echoes the current form values, which for legacy
+    // scripts may hold timeouts saved under the old 86400 intake cap. Tolerate
+    // those (don't fail session creation on an unrelated field) but clamp to
+    // 3600 — the agent executor's hard MaxTimeout (#2398).
+    timeoutSeconds: z.number().min(1).max(86400).transform((v) => Math.min(v, 3600)).optional(),
   }).optional(),
 });
 

--- a/packages/shared/src/validators/ai_tools.test.ts
+++ b/packages/shared/src/validators/ai_tools.test.ts
@@ -153,6 +153,28 @@ describe('scriptBuilderContextSchema', () => {
     ).toBe(true);
   });
 
+  it('should pass timeoutSeconds through unchanged at or below the 3600 executor cap', () => {
+    const result = scriptBuilderContextSchema.safeParse({
+      editorSnapshot: { timeoutSeconds: 3600 },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.editorSnapshot?.timeoutSeconds).toBe(3600);
+    }
+  });
+
+  it('should clamp legacy timeoutSeconds above 3600 to the executor cap (#2398)', () => {
+    for (const legacy of [3601, 7200, 86400]) {
+      const result = scriptBuilderContextSchema.safeParse({
+        editorSnapshot: { timeoutSeconds: legacy },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.editorSnapshot?.timeoutSeconds).toBe(3600);
+      }
+    }
+  });
+
   it('should reject name over 255 chars in editorSnapshot', () => {
     const result = scriptBuilderContextSchema.safeParse({
       editorSnapshot: { name: 'x'.repeat(256) },


### PR DESCRIPTION
## Summary

The agent executor hard-clamps script timeouts to **3600s (1 hour)** — `MaxTimeout` in `agent/internal/remote/executor/executor.go`, with the user-helper IPC path clamped to match in #2395 — but several intake schemas accepted up to **86400s (24h)**. A tech who set a 4-hour timeout silently got 1-hour behavior with no signal. This PR aligns every script-execution intake site to the executor cap.

## Sites changed (repo-wide `timeoutSeconds` sweep)

| Site | Before | After | Why |
|---|---|---|---|
| `apps/api/src/routes/scripts.ts` create schema | max 86400 | max 3600 | script create intake |
| `apps/api/src/routes/scripts.ts` update schema | max 86400 | max 3600 | script update intake |
| `apps/api/src/services/scriptBuilderTools.ts` `apply_script_metadata` | max 86400 | max 3600 | AI builder must not propose values the agent will silently clamp |
| `packages/shared/src/validators/ai.ts` `scriptBuilderContextSchema.editorSnapshot` | max 86400 | accepts ≤86400, **clamps >3600 → 3600** | see "existing rows" below |
| `apps/api/src/openapi.ts` create-script spec | maximum 86400 | maximum 3600 | docs parity |
| `apps/web/src/components/scripts/ScriptFormSchema.ts` | max 86400 ("24 hours") | max 3600 ("1 hour") | form validation |
| `apps/web/src/components/scripts/ScriptForm.tsx` | input `max={86400}` | `max={3600}` | input constraint |
| `apps/web/src/locales/{en,pt-BR}/scripts.json` `timeoutHint` | no max mentioned | adds "Maximum 3600s (1 hour)" | help text |

## Sites inspected and intentionally left alone

- `packages/shared/src/validators/index.ts:663` — sensitive-data inline settings (max 1800, its own scan path, not the script executor).
- `apps/api/src/routes/sensitiveData.ts:56` (max 1800), `apps/api/src/routes/devices/filesystem.ts:37`, `aiToolSchemas.ts` `analyze_disk_usage`, `aiAgentSdkTools.ts` (max 900) — filesystem/scan timeouts, separate agent paths with their own caps.
- `packages/shared/src/validators/index.ts:191` shared script schema — already capped at 3600 (it was the odd one out that exposed the drift).
- Monitor `pollingInterval`, alert `throttleWindowSeconds`, service-monitoring cooldowns — intervals, not execution timeouts.
- Pass-through readers (`scriptExecution.ts`, `automationRuntime.ts`, `deploymentWorker.ts`, `mobile.ts`, `commandTimeouts.ts`) — read stored values, no intake validation; unchanged so stored legacy values keep working end-to-end (agent clamps anyway).

## Existing DB rows >3600

Schema caps affect new writes only; rows saved under the old 86400 cap may persist larger values.

- **Readers** don't validate on the way out — GET/list/execute paths are unaffected; effective behavior stays 1h via the agent clamp.
- **Update route** — `timeoutSeconds` is optional on PUT; edits that don't touch the field don't re-validate stored values. An edit that *does* submit >3600 now gets a clear 400 / form error instead of silent clamping, which is the point of the issue.
- **AI script-builder sessions** — the `editorSnapshot` echoes current form values, so a hard reject would 400 session creation on legacy scripts over an unrelated field. That schema instead tolerates ≤86400 (the old cap, so it covers all legacy rows) and clamps to 3600.

## Tests

- `apps/api/src/routes/scripts.test.ts` — new: create accepts 3600, rejects 3601/7200/86400; update rejects 7200.
- `packages/shared/src/validators/ai_tools.test.ts` — new: 3600 passes through unchanged; 3601/7200/86400 clamp to 3600.
- `apps/web/src/components/scripts/ScriptFormSchema.test.ts` — new: 3600 valid, 3601/7200/86400 rejected.
- `packages/shared/src/validators/index.test.ts` — already asserted 7200 rejected for the shared schema; unchanged and still green.

Verified: shared suite 45 files / 1073 tests green; API `scripts.test.ts` + both `scriptAi_*` suites + `scriptBuilderTools.guard.test.ts` green; web script form/store suites green; `tsc --noEmit` clean in `apps/api`, `apps/web`, `packages/shared`.

Closes #2398

🤖 Generated with [Claude Code](https://claude.com/claude-code)
