### PR TITLE
fix(agent): reduce WS read limit 64MB → 16MB and align API send-side caps (#2399)

### DIFF
--- a/agent/internal/remote/tools/fileops.go
+++ b/agent/internal/remote/tools/fileops.go
@@ -14,8 +14,16 @@ import (
 
 const (
 	// maxFileReadSize is the maximum file size for reading (1MB)
-	maxFileReadSize      = 1024 * 1024
-	maxFileWriteSize     = 4 * 1024 * 1024
+	maxFileReadSize = 1024 * 1024
+	// MaxFileWriteSize is the maximum decoded size a file_write command may
+	// carry (~5.46MB base64-encoded on the wire). Exported because the
+	// websocket read limit (websocket.maxMessageSize) is derived from it —
+	// bumping this constant forces reconsideration of that limit via
+	// TestMaxMessageSizeCoversLargestLegitimateFrame. The API-side upload
+	// schema (apps/api/src/routes/systemTools/schemas.ts fileUploadBodySchema)
+	// mirrors this cap; larger transfers use the chunked HTTP file-transfer
+	// endpoints instead.
+	MaxFileWriteSize     = 4 * 1024 * 1024
 	defaultFileListLimit = 1000
 	maxFileListLimit     = 5000
 	maxTrashListItems    = 500
@@ -345,8 +353,8 @@ func WriteFile(payload map[string]any) CommandResult {
 	// Decode content based on encoding
 	var data []byte
 	if encoding == "base64" {
-		if len(content) > base64.StdEncoding.EncodedLen(maxFileWriteSize) {
-			return NewErrorResult(fmt.Errorf("file write payload too large (max %d bytes decoded)", maxFileWriteSize), time.Since(start).Milliseconds())
+		if len(content) > base64.StdEncoding.EncodedLen(MaxFileWriteSize) {
+			return NewErrorResult(fmt.Errorf("file write payload too large (max %d bytes decoded)", MaxFileWriteSize), time.Since(start).Milliseconds())
 		}
 		var err error
 		data, err = base64.StdEncoding.DecodeString(content)
@@ -356,8 +364,8 @@ func WriteFile(payload map[string]any) CommandResult {
 	} else {
 		data = []byte(content)
 	}
-	if len(data) > maxFileWriteSize {
-		return NewErrorResult(fmt.Errorf("file write payload too large: %d bytes (max %d bytes)", len(data), maxFileWriteSize), time.Since(start).Milliseconds())
+	if len(data) > MaxFileWriteSize {
+		return NewErrorResult(fmt.Errorf("file write payload too large: %d bytes (max %d bytes)", len(data), MaxFileWriteSize), time.Since(start).Milliseconds())
 	}
 
 	// Write file

--- a/agent/internal/remote/tools/fileops_test.go
+++ b/agent/internal/remote/tools/fileops_test.go
@@ -270,7 +270,7 @@ func TestWriteFileRejectsOversizedTextPayload(t *testing.T) {
 
 	result := WriteFile(map[string]any{
 		"path":    target,
-		"content": strings.Repeat("x", maxFileWriteSize+1),
+		"content": strings.Repeat("x", MaxFileWriteSize+1),
 	})
 
 	if result.Status != "failed" {
@@ -284,7 +284,7 @@ func TestWriteFileRejectsOversizedTextPayload(t *testing.T) {
 func TestWriteFileRejectsOversizedBase64Payload(t *testing.T) {
 	tmpDir := t.TempDir()
 	target := filepath.Join(tmpDir, "too-large.bin")
-	data := make([]byte, maxFileWriteSize+1)
+	data := make([]byte, MaxFileWriteSize+1)
 
 	result := WriteFile(map[string]any{
 		"path":     target,

--- a/agent/internal/websocket/client.go
+++ b/agent/internal/websocket/client.go
@@ -22,10 +22,21 @@ import (
 var log = logging.L("websocket")
 
 const (
-	writeWait      = 10 * time.Second
-	pongWait       = 60 * time.Second
-	pingPeriod     = (pongWait * 9) / 10
-	maxMessageSize = 64 * 1024 * 1024 // 64MB — file_write commands carry base64 content
+	writeWait  = 10 * time.Second
+	pongWait   = 60 * time.Second
+	pingPeriod = (pongWait * 9) / 10
+	// maxMessageSize bounds inbound WS frames via conn.SetReadLimit. Exceeding
+	// it is NOT a graceful rejection: gorilla returns ErrReadLimit and closes
+	// the connection, forcing a reconnect — so keep generous headroom over the
+	// largest legitimate frame. Audited 2026-07 (issue #2399): the largest
+	// legit server→agent frame is a file_write command at ~5.6MB (4MB decoded
+	// cap, tools.MaxFileWriteSize, base64-encoded + JSON envelope); the
+	// "connected" welcome frame's pending-command batch is budgeted
+	// server-side to 6MB of payloads. Everything else (http_request ~1.37MB,
+	// tunnel_data ~1.33MB, scripts 1MB, terminal input 256KB, desktop SDP
+	// 64KB) is far smaller. 16MB ≈ 2.8x the largest legit frame; the
+	// relationship is pinned by TestMaxMessageSizeCoversLargestLegitimateFrame.
+	maxMessageSize = 16 * 1024 * 1024
 	initialBackoff = 1 * time.Second
 	maxBackoff     = 60 * time.Second
 	backoffFactor  = 2.0

--- a/agent/internal/websocket/client_connect_test.go
+++ b/agent/internal/websocket/client_connect_test.go
@@ -395,8 +395,8 @@ func TestConstants(t *testing.T) {
 	if pingPeriod >= pongWait {
 		t.Fatalf("pingPeriod (%v) must be less than pongWait (%v)", pingPeriod, pongWait)
 	}
-	if maxMessageSize != 64*1024*1024 {
-		t.Fatalf("maxMessageSize = %d, want %d", maxMessageSize, 64*1024*1024)
+	if maxMessageSize != 16*1024*1024 {
+		t.Fatalf("maxMessageSize = %d, want %d", maxMessageSize, 16*1024*1024)
 	}
 	if initialBackoff != 1*time.Second {
 		t.Fatalf("initialBackoff = %v, want 1s", initialBackoff)

--- a/agent/internal/websocket/limits_test.go
+++ b/agent/internal/websocket/limits_test.go
@@ -1,0 +1,37 @@
+package websocket
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+)
+
+// TestMaxMessageSizeCoversLargestLegitimateFrame pins the relationship between
+// the WS read limit and the largest legitimate server→agent frame: a
+// file_write command carrying base64 content up to tools.MaxFileWriteSize
+// decoded. Exceeding SetReadLimit is not a graceful rejection — gorilla
+// returns ErrReadLimit and closes the connection — so the read limit must
+// keep generous (>= 2x) headroom over the largest legit frame. If a future
+// change bumps MaxFileWriteSize, this test fails on purpose: re-audit the
+// frame sizes (issue #2399) and resize maxMessageSize deliberately, and keep
+// the API-side caps in sync (fileUploadBodySchema in
+// apps/api/src/routes/systemTools/schemas.ts and the pending-command payload
+// budget in apps/api/src/routes/agentWs.ts).
+func TestMaxMessageSizeCoversLargestLegitimateFrame(t *testing.T) {
+	encodedFileWrite := base64.StdEncoding.EncodedLen(tools.MaxFileWriteSize)
+
+	if maxMessageSize < 2*encodedFileWrite {
+		t.Fatalf(
+			"maxMessageSize (%d) must be at least 2x the largest legitimate frame (file_write, %d bytes base64-encoded of MaxFileWriteSize=%d decoded); re-audit issue #2399 before changing either constant",
+			maxMessageSize, encodedFileWrite, tools.MaxFileWriteSize,
+		)
+	}
+
+	// Sanity ceiling: the read limit exists to bound worst-case memory
+	// retention of queued command payloads (issue #2399); it should never
+	// silently creep back toward the old 64MB.
+	if maxMessageSize > 32*1024*1024 {
+		t.Fatalf("maxMessageSize (%d) exceeds 32MB — the read limit bounds worst-case queued-command memory; justify and re-audit before raising it", maxMessageSize)
+	}
+}

--- a/agent/internal/websocket/limits_test.go
+++ b/agent/internal/websocket/limits_test.go
@@ -19,6 +19,13 @@ import (
 // apps/api/src/routes/systemTools/schemas.ts and the pending-command payload
 // budget in apps/api/src/routes/agentWs.ts).
 func TestMaxMessageSizeCoversLargestLegitimateFrame(t *testing.T) {
+	// Numeric pin mirroring the API-side pin (schemas.test.ts): the 4MB cap is
+	// a cross-language contract — the API validates uploads against it and the
+	// WS pending-batch budget assumes it. Changing it in Go alone must fail here.
+	if tools.MaxFileWriteSize != 4*1024*1024 {
+		t.Fatalf("MaxFileWriteSize = %d, want %d; it is mirrored by AGENT_MAX_FILE_WRITE_BYTES in apps/api/src/routes/systemTools/schemas.ts — change both sides together", tools.MaxFileWriteSize, 4*1024*1024)
+	}
+
 	encodedFileWrite := base64.StdEncoding.EncodedLen(tools.MaxFileWriteSize)
 
 	if maxMessageSize < 2*encodedFileWrite {

--- a/apps/api/src/middleware/bodyLimit.test.ts
+++ b/apps/api/src/middleware/bodyLimit.test.ts
@@ -33,10 +33,12 @@ describe('bodyLimitForPath', () => {
     });
   });
 
-  it('carves out file-browser uploads at 50MB', () => {
+  // Sized from the agent's 4MB file_write cap (~5.6MB base64 + JSON envelope);
+  // the agent's WS read limit is derived from the same cap (issue #2399).
+  it('carves out file-browser uploads at 8MB', () => {
     expect(bodyLimitForPath('/api/v1/system-tools/devices/dev-1/files/upload')).toEqual({
-      maxSize: 50 * MB,
-      error: 'File too large (max ~37MB)',
+      maxSize: 8 * MB,
+      error: 'File too large (max 4MB); use file transfer for larger files',
     });
   });
 

--- a/apps/api/src/middleware/bodyLimit.ts
+++ b/apps/api/src/middleware/bodyLimit.ts
@@ -19,9 +19,11 @@ export function bodyLimitForPath(path: string): { maxSize: number; error: string
   if (path.match(/^\/api\/v1\/remote\/transfers\/[^/]+\/chunks$/)) {
     return { maxSize: 50 * 1024 * 1024, error: 'Chunk too large (max 50MB)' };
   }
-  // File browser uploads send base64-encoded content in JSON body (~33% overhead).
+  // File browser uploads send base64-encoded content in JSON body (~33%
+  // overhead). The agent caps file_write at 4MB decoded (~5.6MB base64, see
+  // fileUploadBodySchema); 8MB covers that plus JSON envelope/escaping.
   if (path.match(/^\/api\/v1\/system-tools\/devices\/[^/]+\/files\/upload$/)) {
-    return { maxSize: 50 * 1024 * 1024, error: 'File too large (max ~37MB)' };
+    return { maxSize: 8 * 1024 * 1024, error: 'File too large (max 4MB); use file transfer for larger files' };
   }
   // Software package (installer) uploads are multipart and capped at 500MB by the
   // route's own MAX_UPLOAD_SIZE check; give the body limit headroom over that so the

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -156,6 +156,12 @@ vi.mock('../services/tenantStatus', () => ({
   isAgentTenantActive: vi.fn(async () => true),
 }));
 
+vi.mock('../services/commandDispatch', () => ({
+  claimPendingCommandForDelivery: vi.fn(),
+  releaseClaimedCommandDelivery: vi.fn(),
+  claimPendingCommandsForDevice: vi.fn(async () => []),
+}));
+
 import { db } from '../db';
 import { devices } from '../db/schema';
 import {
@@ -166,7 +172,10 @@ import {
   isAgentConnected,
   __resetCrossTenantDropsForTest,
   AGENT_WS_CAPABILITIES,
+  claimWsPendingCommandsBudgeted,
+  WS_PENDING_COMMAND_PAYLOAD_BUDGET_BYTES,
 } from './agentWs';
+import { claimPendingCommandsForDevice } from '../services/commandDispatch';
 import { writeAuditEvent } from '../services/auditEvents';
 import { isAgentTenantActive } from '../services/tenantStatus';
 import { enqueueDiscoveryResults } from '../jobs/discoveryWorker';
@@ -1453,5 +1462,30 @@ describe('Findings #8 / #5 — WS command-result audit + secret redaction', () =
     const stored = setSpy.mock.calls[0]![0] as { result: { stdout: string } };
     expect(stored.result.stdout).toContain('[PRIVATE_KEY_REDACTED]');
     expect(stored.result.stdout).not.toContain('BEGIN RSA PRIVATE KEY');
+  });
+});
+
+// Regression for #2399: the agent WS delivers a claimed pending-command batch
+// in a single frame that must stay under the agent's 16MB read limit —
+// exceeding it kills the connection (gorilla ErrReadLimit). These tests pin
+// that the WS claim path is always budgeted; reverting it to a bare
+// claimPendingCommandsForDevice(deviceId, 10) would silently reintroduce the
+// oversized-frame hazard.
+describe('claimWsPendingCommandsBudgeted (#2399)', () => {
+  it('claims with the serialized-payload budget set', async () => {
+    await claimWsPendingCommandsBudgeted('dev-1');
+
+    expect(claimPendingCommandsForDevice).toHaveBeenCalledWith('dev-1', 10, 'agent', {
+      maxTotalPayloadBytes: WS_PENDING_COMMAND_PAYLOAD_BUDGET_BYTES,
+    });
+  });
+
+  it('keeps the budget comfortably under the agent 16MB read limit', () => {
+    const agentReadLimit = 16 * 1024 * 1024; // agent/internal/websocket/client.go maxMessageSize
+    expect(WS_PENDING_COMMAND_PAYLOAD_BUDGET_BYTES).toBe(6 * 1024 * 1024);
+    // Budget + a full extra file_write payload (first-command-always rule)
+    // + generous envelope allowance must still fit under the read limit.
+    const maxSingleFileWriteChars = Math.ceil((4 * 1024 * 1024) / 3) * 4;
+    expect(WS_PENDING_COMMAND_PAYLOAD_BUDGET_BYTES + maxSingleFileWriteChars + 1024 * 1024).toBeLessThan(agentReadLimit);
   });
 });

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1617,8 +1617,26 @@ async function processCommandResult(
  * 16MB and the largest single command payload is a file_write at ~5.6MB
  * (base64 of the 4MB agent cap, see fileUploadBodySchema); 6MB of payloads
  * plus JSON envelope keeps the worst-case frame comfortably under the limit.
+ * Exported for the regression test pinning this value against the agent's
+ * read limit (issue #2399).
  */
-const WS_PENDING_COMMAND_PAYLOAD_BUDGET_BYTES = 6 * 1024 * 1024;
+export const WS_PENDING_COMMAND_PAYLOAD_BUDGET_BYTES = 6 * 1024 * 1024;
+
+/**
+ * Claim pending commands for delivery over the agent WebSocket. Unlike the
+ * HTTP heartbeat claim paths, the WS batch is serialized into a SINGLE frame
+ * (`connected` welcome / `heartbeat_ack`) that must stay under the agent's
+ * 16MB read limit — exceeding it kills the connection instead of rejecting
+ * the frame (agent/internal/websocket/client.go, issue #2399) — so the claim
+ * is always budgeted. Over-budget commands stay pending and are picked up by
+ * a later heartbeat/claim cycle. Exported so a unit test can pin that the WS
+ * path never claims unbudgeted.
+ */
+export function claimWsPendingCommandsBudgeted(deviceId: string) {
+  return claimPendingCommandsForDevice(deviceId, 10, 'agent', {
+    maxTotalPayloadBytes: WS_PENDING_COMMAND_PAYLOAD_BUDGET_BYTES,
+  });
+}
 
 /**
  * Get pending commands for an agent
@@ -1653,15 +1671,7 @@ async function getPendingCommands(agentId: string): Promise<AgentCommand[]> {
       return [];
     }
 
-    // The claimed batch is delivered to the agent in a single WS frame
-    // (`connected` welcome / `heartbeat_ack`), which must stay under the
-    // agent's 16MB read limit — exceeding it kills the connection instead of
-    // rejecting the frame (agent/internal/websocket/client.go, issue #2399).
-    // Budget the batch's cumulative payload size; commands over budget stay
-    // pending and are picked up by a later heartbeat/claim cycle.
-    const commands = await claimPendingCommandsForDevice(device.id, 10, 'agent', {
-      maxTotalPayloadBytes: WS_PENDING_COMMAND_PAYLOAD_BUDGET_BYTES,
-    });
+    const commands = await claimWsPendingCommandsBudgeted(device.id);
 
     // Decrypt sensitive command payloads (e.g. FileVault rotation credentials)
     // just-in-time. WS-connected agents receive pending commands through this

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1678,7 +1678,10 @@ async function getPendingCommands(agentId: string): Promise<AgentCommand[]> {
     // path, so without the decrypt an encryption_rotate_key command would reach
     // the agent as ciphertext and fail. A command whose payload can't be
     // decrypted is dropped (not delivered as ciphertext) rather than failing
-    // the whole batch.
+    // the whole batch. Ordering note (#2399): the claim's payload budget was
+    // measured on the stored (encrypted) payload BEFORE this decrypt;
+    // ciphertext is >= plaintext size so the budget only over-counts — keep
+    // decryption after the claim so that stays true.
     return decryptCommandsForDelivery(
       commands.map(cmd => ({
         id: cmd.id,

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1612,6 +1612,15 @@ async function processCommandResult(
 }
 
 /**
+ * Cumulative serialized-payload budget for a pending-command batch delivered
+ * over the agent WebSocket in a single frame. The agent's WS read limit is
+ * 16MB and the largest single command payload is a file_write at ~5.6MB
+ * (base64 of the 4MB agent cap, see fileUploadBodySchema); 6MB of payloads
+ * plus JSON envelope keeps the worst-case frame comfortably under the limit.
+ */
+const WS_PENDING_COMMAND_PAYLOAD_BUDGET_BYTES = 6 * 1024 * 1024;
+
+/**
  * Get pending commands for an agent
  */
 async function getPendingCommands(agentId: string): Promise<AgentCommand[]> {
@@ -1644,7 +1653,15 @@ async function getPendingCommands(agentId: string): Promise<AgentCommand[]> {
       return [];
     }
 
-    const commands = await claimPendingCommandsForDevice(device.id, 10);
+    // The claimed batch is delivered to the agent in a single WS frame
+    // (`connected` welcome / `heartbeat_ack`), which must stay under the
+    // agent's 16MB read limit — exceeding it kills the connection instead of
+    // rejecting the frame (agent/internal/websocket/client.go, issue #2399).
+    // Budget the batch's cumulative payload size; commands over budget stay
+    // pending and are picked up by a later heartbeat/claim cycle.
+    const commands = await claimPendingCommandsForDevice(device.id, 10, 'agent', {
+      maxTotalPayloadBytes: WS_PENDING_COMMAND_PAYLOAD_BUDGET_BYTES,
+    });
 
     // Decrypt sensitive command payloads (e.g. FileVault rotation credentials)
     // just-in-time. WS-connected agents receive pending commands through this

--- a/apps/api/src/routes/systemTools/schemas.test.ts
+++ b/apps/api/src/routes/systemTools/schemas.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AGENT_MAX_FILE_WRITE_BASE64_CHARS,
+  AGENT_MAX_FILE_WRITE_BYTES,
+  fileUploadBodySchema,
+} from './schemas';
+
+// Regression for #2399: the file-browser upload schema must never accept
+// content the agent's file_write handler would reject (4MB decoded cap,
+// agent/internal/remote/tools/fileops.go MaxFileWriteSize). The agent's WS
+// read limit (16MB) is derived from this cap, and an oversized frame kills
+// the agent's WebSocket connection instead of being gracefully rejected —
+// so the API must enforce the bound before dispatch.
+describe('fileUploadBodySchema size caps (#2399)', () => {
+  it('matches Go base64.StdEncoding.EncodedLen(4MB)', () => {
+    // EncodedLen(n) = ceil(n/3)*4 (StdEncoding, padded)
+    expect(AGENT_MAX_FILE_WRITE_BASE64_CHARS).toBe(
+      Math.ceil(AGENT_MAX_FILE_WRITE_BYTES / 3) * 4,
+    );
+    expect(AGENT_MAX_FILE_WRITE_BYTES).toBe(4 * 1024 * 1024);
+  });
+
+  it('accepts base64 content up to the encoded 4MB cap', () => {
+    const result = fileUploadBodySchema.safeParse({
+      path: '/tmp/file.bin',
+      content: 'A'.repeat(AGENT_MAX_FILE_WRITE_BASE64_CHARS),
+      encoding: 'base64',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects base64 content over the encoded 4MB cap', () => {
+    const result = fileUploadBodySchema.safeParse({
+      path: '/tmp/file.bin',
+      content: 'A'.repeat(AGENT_MAX_FILE_WRITE_BASE64_CHARS + 1),
+      encoding: 'base64',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts text content up to 4MB of UTF-8 bytes', () => {
+    const result = fileUploadBodySchema.safeParse({
+      path: '/tmp/file.txt',
+      content: 'x'.repeat(AGENT_MAX_FILE_WRITE_BYTES),
+      encoding: 'text',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects text content over 4MB of UTF-8 bytes', () => {
+    const result = fileUploadBodySchema.safeParse({
+      path: '/tmp/file.txt',
+      content: 'x'.repeat(AGENT_MAX_FILE_WRITE_BYTES + 1),
+      encoding: 'text',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('measures text content in UTF-8 bytes, not string length (multi-byte)', () => {
+    // 'é' is 1 UTF-16 code unit but 2 UTF-8 bytes: 2.5M chars = 5MB > 4MB.
+    const result = fileUploadBodySchema.safeParse({
+      path: '/tmp/file.txt',
+      content: 'é'.repeat(2_500_000),
+      encoding: 'text',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('applies the text-encoding byte check when encoding is omitted (defaults to text)', () => {
+    const result = fileUploadBodySchema.safeParse({
+      path: '/tmp/file.txt',
+      content: 'é'.repeat(2_500_000),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/routes/systemTools/schemas.ts
+++ b/apps/api/src/routes/systemTools/schemas.ts
@@ -130,8 +130,36 @@ export const fileTrashPurgeBodySchema = z.object({
   trashIds: z.array(trashIdString).optional(),
 });
 
-export const fileUploadBodySchema = z.object({
-  path: filePathString,
-  content: z.string().min(0).max(50_000_000),
-  encoding: z.enum(['base64', 'text']).optional().default('text'),
-});
+// The agent rejects file_write payloads over 4MB decoded
+// (agent/internal/remote/tools/fileops.go MaxFileWriteSize), and its WebSocket
+// read limit is sized from that cap (agent/internal/websocket/client.go
+// maxMessageSize, issue #2399) — an oversized frame is not gracefully
+// rejected, it kills the agent's WS connection. Enforce the same bound here so
+// the API never emits a file_write frame the agent cannot accept. Larger
+// transfers go through the chunked file-transfer endpoints instead.
+export const AGENT_MAX_FILE_WRITE_BYTES = 4 * 1024 * 1024;
+// Mirrors Go's base64.StdEncoding.EncodedLen(n): ceil(n/3)*4, padding included.
+export const AGENT_MAX_FILE_WRITE_BASE64_CHARS =
+  Math.ceil(AGENT_MAX_FILE_WRITE_BYTES / 3) * 4;
+
+export const fileUploadBodySchema = z
+  .object({
+    path: filePathString,
+    content: z.string().min(0).max(AGENT_MAX_FILE_WRITE_BASE64_CHARS),
+    encoding: z.enum(['base64', 'text']).optional().default('text'),
+  })
+  .superRefine((body, ctx) => {
+    // The .max() above bounds base64 exactly; text content is measured in
+    // UTF-8 bytes (what the agent writes to disk), which can exceed the char
+    // count for multi-byte content.
+    const tooLarge =
+      body.encoding === 'text' &&
+      Buffer.byteLength(body.content, 'utf8') > AGENT_MAX_FILE_WRITE_BYTES;
+    if (tooLarge) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['content'],
+        message: `File too large (max ${AGENT_MAX_FILE_WRITE_BYTES / (1024 * 1024)}MB); use file transfer for larger files`,
+      });
+    }
+  });

--- a/apps/api/src/routes/systemTools/schemas.ts
+++ b/apps/api/src/routes/systemTools/schemas.ts
@@ -145,7 +145,15 @@ export const AGENT_MAX_FILE_WRITE_BASE64_CHARS =
 export const fileUploadBodySchema = z
   .object({
     path: filePathString,
-    content: z.string().min(0).max(AGENT_MAX_FILE_WRITE_BASE64_CHARS),
+    // Custom message: the char count references the invisible base64 blob,
+    // not the user's file — surface the actionable limit instead (the
+    // FileManager UI always uploads base64 and renders this message verbatim).
+    content: z
+      .string()
+      .min(0)
+      .max(AGENT_MAX_FILE_WRITE_BASE64_CHARS, {
+        message: 'File too large (max 4MB); use file transfer for larger files',
+      }),
     encoding: z.enum(['base64', 'text']).optional().default('text'),
   })
   .superRefine((body, ctx) => {

--- a/apps/api/src/services/aiToolsFilesystem.fileWriteCap.test.ts
+++ b/apps/api/src/services/aiToolsFilesystem.fileWriteCap.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('./commandQueue', () => ({
+  executeCommand: vi.fn(async () => ({ status: 'completed', stdout: '{}' })),
+  CommandTypes: new Proxy({}, { get: (_t, prop) => String(prop) }),
+}));
+
+vi.mock('./filesystemAnalysis', () => ({
+  buildCleanupPreview: vi.fn(),
+  getLatestFilesystemSnapshot: vi.fn(),
+  parseFilesystemAnalysisStdout: vi.fn(),
+  saveFilesystemSnapshot: vi.fn(),
+  safeCleanupCategories: [],
+}));
+
+import { db } from '../db';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+import { executeCommand } from './commandQueue';
+import { registerFilesystemTools } from './aiToolsFilesystem';
+import { AGENT_MAX_FILE_WRITE_BYTES } from '../routes/systemTools/schemas';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+
+function createQueryChain(rows: any[] = []) {
+  const chain: any = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.then = (resolve: (value: any[]) => unknown, reject?: (error: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject);
+  return chain;
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    token: {} as any,
+    partnerId: null,
+    orgId: ORG_ID,
+    scope: 'organization',
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    orgCondition: vi.fn(() => undefined),
+  } as any;
+}
+
+function getFileOperationsTool(): AiTool {
+  const aiTools = new Map<string, AiTool>();
+  registerFilesystemTools(aiTools);
+  const tool = aiTools.get('file_operations');
+  if (!tool) throw new Error('file_operations tool not registered');
+  return tool;
+}
+
+// Regression for #2399: the file_operations AI tool is a file_write producer
+// that bypasses fileUploadBodySchema. Without this cap it could dispatch a
+// single-frame file_write exceeding the agent's 16MB WS read limit, which
+// kills the agent's connection (gorilla ErrReadLimit) instead of returning an
+// error. The tool must reject oversized content BEFORE executeCommand.
+describe('file_operations write size cap (#2399)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockImplementation(
+      () =>
+        createQueryChain([
+          { id: DEVICE_ID, orgId: ORG_ID, siteId: null, hostname: 'host-1', status: 'online' },
+        ]) as any,
+    );
+  });
+
+  it('rejects write content over the agent 4MB cap without dispatching', async () => {
+    const tool = getFileOperationsTool();
+    const result = JSON.parse(
+      await tool.handler(
+        {
+          deviceId: DEVICE_ID,
+          action: 'write',
+          path: '/tmp/big.txt',
+          content: 'x'.repeat(AGENT_MAX_FILE_WRITE_BYTES + 1),
+        },
+        makeAuth(),
+      ),
+    );
+
+    expect(result.error).toContain('too large');
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('measures UTF-8 bytes, not string length', async () => {
+    const tool = getFileOperationsTool();
+    // 'é' is 1 UTF-16 code unit but 2 UTF-8 bytes: 2.5M chars = 5MB > 4MB.
+    const result = JSON.parse(
+      await tool.handler(
+        { deviceId: DEVICE_ID, action: 'write', path: '/tmp/big.txt', content: 'é'.repeat(2_500_000) },
+        makeAuth(),
+      ),
+    );
+
+    expect(result.error).toContain('too large');
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('dispatches writes at or under the cap', async () => {
+    const tool = getFileOperationsTool();
+    await tool.handler(
+      {
+        deviceId: DEVICE_ID,
+        action: 'write',
+        path: '/tmp/ok.txt',
+        content: 'x'.repeat(AGENT_MAX_FILE_WRITE_BYTES),
+      },
+      makeAuth(),
+    );
+
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(executeCommand).mock.calls[0]?.[1]).toBe('file_write');
+  });
+
+  it('does not apply the cap to non-write actions', async () => {
+    const tool = getFileOperationsTool();
+    await tool.handler(
+      { deviceId: DEVICE_ID, action: 'read', path: '/tmp/file.txt' },
+      makeAuth(),
+    );
+
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(executeCommand).mock.calls[0]?.[1]).toBe('file_read');
+  });
+});

--- a/apps/api/src/services/aiToolsFilesystem.ts
+++ b/apps/api/src/services/aiToolsFilesystem.ts
@@ -14,6 +14,7 @@ import { devices, deviceFilesystemCleanupRuns } from '../db/schema';
 import { eq, and, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
+import { AGENT_MAX_FILE_WRITE_BYTES } from '../routes/systemTools/schemas';
 import {
   buildCleanupPreview,
   getLatestFilesystemSnapshot,
@@ -93,6 +94,20 @@ export function registerFilesystemTools(aiTools: Map<string, AiTool>): void {
 
       const fileCommandType = actionMap[input.action as string];
       if (!fileCommandType) return JSON.stringify({ error: `Unknown action: ${input.action}` });
+
+      // The agent rejects file_write payloads over 4MB decoded, and its WS
+      // read limit (16MB) is sized from that cap — an oversized frame kills
+      // the agent's connection instead of being rejected (issue #2399).
+      // Reject before dispatch, mirroring fileUploadBodySchema; this tool
+      // sends plain text, so measure UTF-8 bytes (what the agent writes).
+      if (fileCommandType === 'file_write') {
+        const contentBytes = Buffer.byteLength((input.content as string) ?? '', 'utf8');
+        if (contentBytes > AGENT_MAX_FILE_WRITE_BYTES) {
+          return JSON.stringify({
+            error: `File content too large (${contentBytes} bytes; max ${AGENT_MAX_FILE_WRITE_BYTES}). Use the file transfer feature for larger files.`,
+          });
+        }
+      }
 
       const result = await executeCommand(deviceId, fileCommandType, {
         path: input.path,

--- a/apps/api/src/services/commandDispatch.test.ts
+++ b/apps/api/src/services/commandDispatch.test.ts
@@ -88,6 +88,86 @@ describe('command dispatch helpers', () => {
     expect(claimed[0]?.id).toBe('cmd-1');
   });
 
+  // Regression for #2399: the agent WS path delivers the claimed batch in a
+  // single frame that must stay under the agent's 16MB read limit (exceeding
+  // it kills the connection), so the claim loop honors a cumulative payload
+  // budget — over-budget commands stay pending for a later delivery cycle.
+  it('stops claiming once the payload budget is exhausted, leaving the rest pending', async () => {
+    const bigPayload = { content: 'x'.repeat(1000) };
+    const pending = [
+      { id: 'cmd-1', deviceId: 'dev-1', status: 'pending', payload: bigPayload, createdAt: new Date('2026-03-31T00:00:00Z') },
+      { id: 'cmd-2', deviceId: 'dev-1', status: 'pending', payload: bigPayload, createdAt: new Date('2026-03-31T00:00:01Z') },
+      { id: 'cmd-3', deviceId: 'dev-1', status: 'pending', payload: bigPayload, createdAt: new Date('2026-03-31T00:00:02Z') },
+    ];
+    const returning = vi.fn().mockImplementation(async () => [pending[returning.mock.calls.length - 1]]);
+
+    const tx = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                for: vi.fn().mockResolvedValue(pending),
+              }),
+            }),
+          }),
+        }),
+      }),
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning,
+          }),
+        }),
+      }),
+    };
+
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    // Each payload serializes to a bit over 1000 bytes; a 2500-byte budget
+    // fits two commands but not three.
+    const claimed = await claimPendingCommandsForDevice('dev-1', 10, 'agent', {
+      maxTotalPayloadBytes: 2500,
+    });
+
+    expect(claimed.map((c: any) => c.id)).toEqual(['cmd-1', 'cmd-2']);
+    expect(returning).toHaveBeenCalledTimes(2);
+  });
+
+  it('always claims the first command even when it alone exceeds the payload budget', async () => {
+    const huge = { id: 'cmd-1', deviceId: 'dev-1', status: 'pending', payload: { content: 'x'.repeat(5000) }, createdAt: new Date('2026-03-31T00:00:00Z') };
+    const returning = vi.fn().mockResolvedValue([huge]);
+
+    const tx = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                for: vi.fn().mockResolvedValue([huge]),
+              }),
+            }),
+          }),
+        }),
+      }),
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning,
+          }),
+        }),
+      }),
+    };
+
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const claimed = await claimPendingCommandsForDevice('dev-1', 10, 'agent', {
+      maxTotalPayloadBytes: 100,
+    });
+
+    expect(claimed.map((c: any) => c.id)).toEqual(['cmd-1']);
+  });
+
   it('releases a claimed command back to pending state', async () => {
     const where = vi.fn().mockResolvedValue(undefined);
     vi.mocked(db.update).mockReturnValue({

--- a/apps/api/src/services/commandDispatch.ts
+++ b/apps/api/src/services/commandDispatch.ts
@@ -49,6 +49,20 @@ export async function claimPendingCommandsForDevice(
   deviceId: string,
   limit: number = 10,
   targetRole: 'agent' | 'watchdog' = 'agent',
+  options: {
+    /**
+     * Stop claiming once the cumulative serialized payload size of already
+     * claimed commands plus the next candidate would exceed this budget
+     * (the first command is always claimed). Used by the agent WebSocket
+     * path, where the whole batch is delivered in a single frame that must
+     * stay under the agent's WS read limit (16MB — exceeding it kills the
+     * connection, agent/internal/websocket/client.go, issue #2399).
+     * Commands left unclaimed stay pending and are delivered by a later
+     * heartbeat/claim cycle. HTTP delivery paths have no frame limit and
+     * omit this.
+     */
+    maxTotalPayloadBytes?: number;
+  } = {},
 ): Promise<DeviceCommandRow[]> {
   return db.transaction(async (tx) => {
     const pendingCommands = await tx
@@ -66,7 +80,21 @@ export async function claimPendingCommandsForDevice(
       .for('update', { skipLocked: true });
 
     const claimed: DeviceCommandRow[] = [];
+    let claimedPayloadBytes = 0;
     for (const command of pendingCommands) {
+      if (options.maxTotalPayloadBytes !== undefined) {
+        const payloadBytes = Buffer.byteLength(
+          JSON.stringify(command.payload ?? {}),
+          'utf8',
+        );
+        if (
+          claimed.length > 0 &&
+          claimedPayloadBytes + payloadBytes > options.maxTotalPayloadBytes
+        ) {
+          break;
+        }
+        claimedPayloadBytes += payloadBytes;
+      }
       const executedAt = new Date();
       const rows = await tx
         .update(deviceCommands)

--- a/apps/api/src/services/commandDispatch.ts
+++ b/apps/api/src/services/commandDispatch.ts
@@ -93,6 +93,16 @@ export async function claimPendingCommandsForDevice(
         ) {
           break;
         }
+        if (payloadBytes > options.maxTotalPayloadBytes) {
+          // First-command-always rule: a single over-budget payload is still
+          // claimed (otherwise it would block the queue forever), but if it
+          // exceeds the agent's WS read limit the frame will kill the agent's
+          // connection with no server-side signal (ErrReadLimit is agent-side
+          // only) — leave a greppable trail for that mystery reconnect.
+          console.warn(
+            `[commandDispatch] claiming single command over the WS payload budget: id=${command.id} type=${command.type} payloadBytes=${payloadBytes} budget=${options.maxTotalPayloadBytes}`,
+          );
+        }
         claimedPayloadBytes += payloadBytes;
       }
       const executedAt = new Date();


### PR DESCRIPTION
Closes #2399

## Summary

The agent's WebSocket read limit (`conn.SetReadLimit`) was **64MB**, justified by a comment saying file_write carries base64 content — but the agent's actual file_write cap is **4MB decoded** (~5.6MB encoded). Because queued commands retain their full decoded payloads until a pool worker frees up (#2387 / #2395), the frame ceiling directly bounds worst-case memory retention (~110 in-flight/queued × frame size). This PR audits every server→agent frame type, reduces the limit to **16MB** (~2.8x the largest legitimate frame), and fixes the API send side so it can never emit a frame the agent's new limit would kill.

**Important gorilla semantics:** exceeding `SetReadLimit` is *not* a graceful rejection — gorilla returns `ErrReadLimit` and closes the connection, forcing a reconnect. That is why the headroom is generous and why the API send-side caps are part of this PR, not optional.

## Frame audit (the justification for 16MB)

| Frame / command type | Largest field | Max realistic size | Where capped |
|---|---|---|---|
| `file_write` (upload route) | `content` (base64) | **~5.6MB** (4MB decoded) | agent: `fileops.go` `MaxFileWriteSize` (post-read); API: `fileUploadBodySchema` — **tightened in this PR** (was 50M chars) |
| `file_write` (`file_operations` AI tool) | `content` (text) | **4MB** UTF-8 bytes | was **uncapped** (found in PR review) — **capped in this PR** before dispatch, sharing `AGENT_MAX_FILE_WRITE_BYTES` |
| `connected` welcome | `pendingCommands` batch (up to 10 claimed commands in ONE frame) | **≤ ~6MB payloads** after this PR (was uncapped — 10 × 50MB theoretical) | `agentWs.ts` `WS_PENDING_COMMAND_PAYLOAD_BUDGET_BYTES`, enforced in `claimPendingCommandsForDevice` — **added in this PR** |
| `http_request` (tunnel HTTP proxy) | `bodyB64` | ~1.37MB | API global 1MB bodyLimit (agent-side decode uncapped; the 16MiB `httpProxyMaxBody` caps only the fetched response) |
| `tunnel_data` | `data` (base64) | ~1.33MB (1MB decoded) | `handlers_tunnel.go` |
| `run_script` | `content` (plain text) | 1MB (+JSON escaping, realistically <1.4MB) | executor `MaxScriptSize` (`shell.go`); API create route under global 1MB bodyLimit |
| `terminal_data` | `data` | 256KB | `terminal.go` `maxTerminalWriteBytes` |
| `start_desktop` | `offer` (SDP) + iceServers | ≤64KB | API `webrtcOfferSchema` `.max(65536)`; no trickle-ICE inbound commands |
| `desktop_input` / `desktop_config` | validated event fields | <4KB | `handlers_desktop.go` validation |
| `registry_set` | `data` value | ~1MB | API global bodyLimit |
| `software_install`, `dev_update` | `downloadUrl` — URLs only, binary fetched over HTTPS | <4KB | structurally small |
| `file_transfer` | paths/transferId only — bytes move over chunked HTTP endpoints | <4KB | structurally small |
| backup/bmr/hyperv/mssql/vss forwards, policy syncs, patch id lists, incident response, misc | config JSON / id lists | <256KB | API global 1MB bodyLimit |
| `ping` / `ack` / `error` | — | <1KB | fixed shape |

Notes: inbound frames are all TEXT/JSON — binary frames (0x02 desktop JPEG, 0x03 tunnel) flow agent→server only. Heartbeat is HTTP POST for the Go agent, so config blobs/trust keysets do not ride this WS. Largest legit single frame: **file_write ~5.6MB**; largest legit batch frame after this PR: **~6MB + envelope**. 16MB ≈ 2.8x headroom.

## Changes

**Agent**
- `websocket/client.go`: `maxMessageSize` 64MB → **16MB**, with the derivation and the ErrReadLimit hazard documented at the constant.
- `remote/tools/fileops.go`: exported `MaxFileWriteSize` (doc comment cross-references the WS limit and API schema).
- New `websocket/limits_test.go`: pins `maxMessageSize >= 2 × base64.EncodedLen(tools.MaxFileWriteSize)` (a future file-cap bump fails the test and forces a re-audit) plus a 32MB sanity ceiling. Updated the existing constant pin in `client_connect_test.go`.

**API (send side must agree with the new bound)**
- `systemTools/schemas.ts`: `fileUploadBodySchema.content` capped at the agent's real limit — base64 ≤ `EncodedLen(4MB)` chars, text ≤ 4MB UTF-8 bytes (was `max(50_000_000)`; anything >4MB decoded already failed at the agent after full transit, so no functionality is lost — it now fails fast with a clear 400).
- `middleware/bodyLimit.ts`: upload-route carve-out 50MB → 8MB.
- `services/commandDispatch.ts`: `claimPendingCommandsForDevice` gains an optional cumulative payload budget (first command always claimed; over-budget commands stay `pending` and are delivered by a later heartbeat/claim cycle — FIFO order preserved).
- `routes/agentWs.ts`: the WS pending-command claim (feeds both the `connected` welcome and the `heartbeat_ack` branch) passes a 6MB budget.

## Deliberately deferred (follow-ups, will file)

- **Go agent silently drops `pendingCommands` from the `connected` frame** (`handleConnectedMessage` parses only `capabilities`) while the server marks them `sent` — commands claimed into the welcome frame are lost until timeout. Pre-existing bug, orthogonal to the read limit; the HTTP heartbeat is the working delivery path.
- Rejecting oversized `file_write` content at agent dispatch time (before queueing) — less valuable now that the API can't send >5.6MB content and the frame limit bounds retention; noted in #2399 as optional.
- Legacy `device_commands` rows created before this PR with >6MB payloads would still be claimed alone (first-command-always rule) and could exceed 16MB on delivery; the connection would drop once, the command is already marked `sent`, and no reconnect loop occurs.

## Verification

- `cd agent && go test -race ./internal/websocket/... ./internal/remote/tools/... ./internal/heartbeat/...` — all pass.
- `GOOS=windows|linux|darwin go build ./...` — all pass; `gofmt` / `go vet` clean on touched packages.
- `vitest run` on `commandDispatch.test.ts`, `systemTools/schemas.test.ts`, `bodyLimit.test.ts`, `agents.test.ts`, `agents/commands.test.ts`, `agents/heartbeat.test.ts`, `commandQueue.test.ts` — 148 tests pass.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)