### PR TITLE
fix(backup): storage-config UX — require/derive S3 region, edit UI, friendly path validation

### DIFF
--- a/apps/api/src/routes/backup/configs.test.ts
+++ b/apps/api/src/routes/backup/configs.test.ts
@@ -18,6 +18,7 @@ const insertMock = vi.fn(() => chainMock([]));
 const updateMock = vi.fn(() => chainMock([]));
 const checkBackupProviderCapabilitiesMock = vi.fn();
 const s3SendMock = vi.fn();
+const s3ClientCtorMock = vi.fn();
 
 vi.mock('../../db', () => ({
   db: {
@@ -66,6 +67,9 @@ vi.mock('../../middleware/auth', () => ({
 
 vi.mock('@aws-sdk/client-s3', () => ({
   S3Client: class S3Client {
+    constructor(config: unknown) {
+      s3ClientCtorMock(config);
+    }
     send = s3SendMock;
   },
   PutObjectCommand: class PutObjectCommand {
@@ -110,6 +114,7 @@ describe('backup config routes', () => {
     updateMock.mockReset();
     checkBackupProviderCapabilitiesMock.mockReset();
     s3SendMock.mockReset();
+    s3ClientCtorMock.mockReset();
     selectMock.mockImplementation(() => chainMock([]));
     insertMock.mockImplementation(() => chainMock([]));
     updateMock.mockImplementation(() => chainMock([]));
@@ -349,14 +354,14 @@ describe('backup config routes', () => {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
       body: JSON.stringify({
-        details: { bucket: 'archive' },
+        details: { bucket: 'archive', region: 'us-east-1' },
       }),
     });
 
     expect(res.status).toBe(200);
     const updateSet = updateMock.mock.results[0]?.value?.set;
     expect(updateSet).toHaveBeenCalledWith(expect.objectContaining({
-      providerConfig: { bucket: 'archive', accessKey: 'key', secretKey: 'secret' },
+      providerConfig: { bucket: 'archive', region: 'us-east-1', accessKey: 'key', secretKey: 'secret' },
       providerCapabilities: null,
       providerCapabilitiesCheckedAt: null,
     }));
@@ -393,6 +398,7 @@ describe('backup config routes', () => {
       body: JSON.stringify({
         details: {
           bucket: 'archive',
+          region: 'us-east-1',
           secretKey: { redacted: true, hasSecret: true, masked: '********' },
           credentials: {
             token: '********',
@@ -406,6 +412,7 @@ describe('backup config routes', () => {
     expect(updateSet).toHaveBeenCalledWith(expect.objectContaining({
       providerConfig: {
         bucket: 'archive',
+        region: 'us-east-1',
         secretKey: 'existing-secret-key',
         credentials: {
           token: 'existing-nested-token',
@@ -416,5 +423,106 @@ describe('backup config routes', () => {
     const body = await res.json();
     expect(JSON.stringify(body)).not.toContain('existing-secret-key');
     expect(JSON.stringify(body)).not.toContain('existing-nested-token');
+  });
+
+  it('rejects S3 config creation without a region or region-bearing endpoint', async () => {
+    const res = await app.request('/backup/configs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({
+        name: 'MinIO backups',
+        provider: 's3',
+        details: {
+          bucket: 'backups',
+          region: '',
+          accessKey: 'key',
+          secretKey: 'secret',
+          endpoint: 'minio.internal.example.com',
+        },
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('derives and persists the region from an S3-compatible endpoint on create', async () => {
+    insertMock.mockReturnValueOnce(chainMock([makeConfig({
+      providerConfig: {
+        bucket: 'backups',
+        region: 'us-west-004',
+        accessKey: 'key',
+        secretKey: 'secret',
+        endpoint: 's3.us-west-004.backblazeb2.com',
+      },
+    })]));
+
+    const res = await app.request('/backup/configs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({
+        name: 'B2 backups',
+        provider: 's3',
+        details: {
+          bucket: 'backups',
+          region: '',
+          accessKey: 'key',
+          secretKey: 'secret',
+          endpoint: 's3.us-west-004.backblazeb2.com',
+        },
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const insertValues = insertMock.mock.results[0]?.value?.values;
+    expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({
+      providerConfig: expect.objectContaining({ region: 'us-west-004' }),
+    }));
+  });
+
+  it('rejects S3 config updates that drop the region without a derivable endpoint', async () => {
+    selectMock.mockReturnValueOnce(chainMock([makeConfig()]));
+
+    const res = await app.request(`/backup/configs/${CONFIG_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({
+        details: { bucket: 'archive', region: '', accessKey: 'key', secretKey: 'secret' },
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('region');
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('derives the probe region from the endpoint when a stored region is empty', async () => {
+    selectMock.mockReturnValueOnce(chainMock([makeConfig({
+      providerConfig: {
+        bucket: 'backups',
+        region: '',
+        accessKey: 'key',
+        secretKey: 'secret',
+        endpoint: 's3.us-west-004.backblazeb2.com',
+      },
+    })]));
+    updateMock.mockReturnValueOnce(chainMock([makeConfig()]));
+    s3SendMock.mockResolvedValue({});
+    checkBackupProviderCapabilitiesMock.mockResolvedValue({
+      objectLock: { supported: true, error: null },
+    });
+
+    const res = await app.request(`/backup/configs/${CONFIG_ID}/test`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('success');
+    expect(s3ClientCtorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ region: 'us-west-004' }),
+    );
   });
 });

--- a/apps/api/src/routes/backup/configs.ts
+++ b/apps/api/src/routes/backup/configs.ts
@@ -16,8 +16,9 @@ import {
 } from '../../services/backupEncryption';
 import { checkBackupProviderCapabilities, type ProviderCapabilityStatus } from '../../services/backupSnapshotStorage';
 import { PERMISSIONS } from '../../services/permissions';
+import { deriveS3RegionFromEndpoint } from '@breeze/shared';
 import { resolveScopedOrgId } from './helpers';
-import { configSchema, configUpdateSchema } from './schemas';
+import { configSchema, configUpdateSchema, validateS3Details } from './schemas';
 
 export const configsRoutes = new Hono();
 
@@ -146,7 +147,7 @@ async function probeLocalConfig(details: Record<string, unknown>): Promise<void>
 
 async function probeS3Config(details: Record<string, unknown>): Promise<void> {
   const bucket = typeof details.bucket === 'string' ? details.bucket : '';
-  const region = typeof details.region === 'string' ? details.region : 'us-east-1';
+  const storedRegion = typeof details.region === 'string' ? details.region.trim() : '';
   const accessKeyId = typeof details.accessKey === 'string' ? details.accessKey : '';
   const secretAccessKey = typeof details.secretKey === 'string' ? details.secretKey : '';
   const endpoint = typeof details.endpoint === 'string' ? details.endpoint : undefined;
@@ -154,6 +155,14 @@ async function probeS3Config(details: Record<string, unknown>): Promise<void> {
 
   if (!bucket.trim() || !accessKeyId.trim() || !secretAccessKey.trim()) {
     throw new Error('S3 bucket and credentials are required');
+  }
+
+  // Configs saved before region validation existed can carry '' — derive
+  // from the endpoint (required for B2 etc., where the signing region must
+  // match) and only fall back to us-east-1 for endpoint-less AWS configs.
+  const region = storedRegion || deriveS3RegionFromEndpoint(endpoint) || (endpoint ? '' : 'us-east-1');
+  if (!region) {
+    throw new Error('S3 region is not configured — edit the storage configuration and set the region for this endpoint');
   }
 
   const client = new S3Client({
@@ -208,12 +217,19 @@ configsRoutes.post(
     }
 
     const payload = c.req.valid('json');
+    const details: Record<string, unknown> = { ...(payload.details ?? {}) };
+    if (payload.provider === 's3') {
+      // Schema already rejected unresolvable configs; persist the resolved
+      // region so endpoint-derived regions are explicit in storage.
+      const { region } = validateS3Details(details);
+      if (region) details.region = region;
+    }
     const encryption = payload.encryption ?? false;
     try {
       assertBackupStorageEncryptionSupported({
         encryption,
         provider: payload.provider,
-        providerConfig: payload.details ?? {},
+        providerConfig: details,
       });
     } catch (error) {
       return c.json({ error: error instanceof Error ? error.message : 'Backup encryption is not supported for this config' }, 400);
@@ -227,7 +243,7 @@ configsRoutes.post(
         name: payload.name,
         type: 'file',
         provider: payload.provider,
-        providerConfig: payload.details ?? {},
+        providerConfig: details,
         providerCapabilities: null,
         providerCapabilitiesCheckedAt: null,
         encryption,
@@ -309,6 +325,13 @@ configsRoutes.patch(
       const nextProviderConfig = payload.details !== undefined
         ? preserveSecretFields(payload.details, current.providerConfig)
         : current.providerConfig;
+      if (payload.details !== undefined && current.provider === 's3' && isRecord(nextProviderConfig)) {
+        const { error, region } = validateS3Details(nextProviderConfig);
+        if (error) {
+          return c.json({ error }, 400);
+        }
+        if (region) nextProviderConfig.region = region;
+      }
       const nextEncryption = payload.encryption ?? current.encryption;
 
       try {

--- a/apps/api/src/routes/backup/schemas.ts
+++ b/apps/api/src/routes/backup/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { deriveS3RegionFromEndpoint } from '@breeze/shared';
 import {
   backupRetentionSchema as sharedBackupRetentionSchema,
   backupRetentionUpdateSchema as sharedBackupRetentionUpdateSchema,
@@ -14,6 +15,34 @@ const queryBoolean = z.preprocess((value) => {
   return value;
 }, z.boolean());
 
+/**
+ * Validates s3-provider details and reports missing bucket/region.
+ * Region may be omitted when it can be derived from the endpoint
+ * (e.g. s3.us-west-004.backblazeb2.com) — S3-compatible providers like
+ * Backblaze B2 reject requests signed with a mismatched region, so a
+ * blanket default is never safe. Returns the resolved region so callers
+ * can persist it.
+ */
+export function validateS3Details(details: Record<string, unknown>): {
+  error: string | null;
+  region: string | null;
+} {
+  const bucket = typeof details.bucket === 'string' ? details.bucket.trim() : '';
+  if (!bucket) {
+    return { error: 'S3 bucket is required', region: null };
+  }
+  const explicitRegion = typeof details.region === 'string' ? details.region.trim() : '';
+  const endpoint = typeof details.endpoint === 'string' ? details.endpoint : undefined;
+  const region = explicitRegion || deriveS3RegionFromEndpoint(endpoint);
+  if (!region) {
+    return {
+      error: 'S3 region is required (set it explicitly or use an endpoint that includes it, e.g. s3.us-west-004.backblazeb2.com)',
+      region: null,
+    };
+  }
+  return { error: null, region };
+}
+
 export const configSchema = z.object({
   name: z.string().min(1),
   provider: z.enum(['s3', 'local']),
@@ -23,6 +52,12 @@ export const configSchema = z.object({
     (val) => JSON.stringify(val).length <= 65536,
     { message: 'Object too large (max 64KB)' }
   ).optional()
+}).superRefine((data, ctx) => {
+  if (data.provider !== 's3') return;
+  const { error } = validateS3Details(data.details ?? {});
+  if (error) {
+    ctx.addIssue({ code: 'custom', message: error, path: ['details'] });
+  }
 });
 
 export const configUpdateSchema = z.object({

--- a/apps/api/src/services/backupSnapshotStorage.ts
+++ b/apps/api/src/services/backupSnapshotStorage.ts
@@ -6,6 +6,7 @@ import {
   ListObjectsV2Command,
   PutObjectRetentionCommand,
 } from '@aws-sdk/client-s3';
+import { deriveS3RegionFromEndpoint } from '@breeze/shared';
 import { buildS3Client } from './recoveryMediaService';
 import { asRecord, getStringValue } from './recoveryBootstrap';
 
@@ -34,7 +35,9 @@ export type ProviderCapabilityStatus = {
 
 function buildS3StorageClient(providerConfig: Record<string, unknown>) {
   const bucket = getStringValue(providerConfig, 'bucket') || getStringValue(providerConfig, 'bucketName');
-  const region = getStringValue(providerConfig, 'region');
+  const region =
+    getStringValue(providerConfig, 'region')?.trim() ||
+    deriveS3RegionFromEndpoint(getStringValue(providerConfig, 'endpoint'));
   if (!bucket || !region) {
     throw new Error('S3 backup storage is misconfigured');
   }

--- a/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.test.tsx
@@ -52,7 +52,7 @@ const baseLink = {
   featurePolicyId: 'config-1',
   inlineSettings: {
     backupMode: 'file',
-    targets: { paths: [], excludes: [] },
+    targets: { paths: ['C:/Data'], excludes: [] },
     schedule: {
       frequency: 'daily',
       time: '03:00',
@@ -67,7 +67,7 @@ const baseLink = {
       keepYearly: 3,
       weeklyDay: 0,
     },
-    paths: [],
+    paths: ['C:/Data'],
   },
 };
 
@@ -192,5 +192,195 @@ describe('BackupTab', () => {
         }),
       }),
     );
+  });
+
+  it('blocks file-mode save with no backup paths and shows a friendly error', async () => {
+    render(
+      <BackupTab
+        policyId="policy-1"
+        existingLink={{
+          ...baseLink,
+          inlineSettings: {
+            ...baseLink.inlineSettings,
+            targets: { paths: [], excludes: [] },
+            paths: [],
+          },
+        }}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    await screen.findByText('Primary S3 (Amazon S3)');
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+
+    expect(await screen.findByText(/Add at least one backup path/i)).toBeTruthy();
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it('flushes a typed-but-not-added backup path on save', async () => {
+    render(
+      <BackupTab
+        policyId="policy-1"
+        existingLink={{
+          ...baseLink,
+          inlineSettings: {
+            ...baseLink.inlineSettings,
+            targets: { paths: [], excludes: [] },
+            paths: [],
+          },
+        }}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    await screen.findByText('Primary S3 (Amazon S3)');
+    const pathInput = screen.getByPlaceholderText(/C:\\Users/i);
+    fireEvent.change(pathInput, { target: { value: '/Users' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect(saveMock).toHaveBeenCalledWith(
+      'link-1',
+      expect.objectContaining({
+        inlineSettings: expect.objectContaining({
+          paths: ['/Users'],
+          targets: expect.objectContaining({ paths: ['/Users'] }),
+        }),
+      }),
+    );
+  });
+
+  it('edits an existing storage config via PATCH with masked secrets preserved', async () => {
+    const configWithRedactedSecrets = {
+      ...baseConfig,
+      details: {
+        bucket: 'backups',
+        region: '',
+        endpoint: 's3.us-west-004.backblazeb2.com',
+        accessKey: { redacted: true, hasSecret: true, masked: '********' },
+        secretKey: { redacted: true, hasSecret: true, masked: '********' },
+      },
+    };
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = (init as RequestInit | undefined)?.method ?? 'GET';
+      if (url === '/backup/configs' && method === 'GET') {
+        return makeJsonResponse({ data: [configWithRedactedSecrets] });
+      }
+      if (url === '/backup/configs/config-1' && method === 'PATCH') {
+        return makeJsonResponse({
+          ...configWithRedactedSecrets,
+          details: { ...configWithRedactedSecrets.details, region: 'us-west-004' },
+        });
+      }
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(
+      <BackupTab
+        policyId="policy-1"
+        existingLink={baseLink}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    await screen.findByText('Primary S3 (Amazon S3)');
+    fireEvent.click(screen.getByRole('button', { name: /^Edit$/i }));
+    expect(await screen.findByText(/Editing storage configuration/i)).toBeTruthy();
+
+    const regionInput = screen.getByPlaceholderText(/us-east-1/i);
+    fireEvent.change(regionInput, { target: { value: 'us-west-004' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/backup/configs/config-1',
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
+    const patchCall = fetchMock.mock.calls.find(
+      ([url, init]) => String(url) === '/backup/configs/config-1' && (init as RequestInit)?.method === 'PATCH',
+    );
+    const patchBody = JSON.parse(String((patchCall?.[1] as RequestInit).body));
+    expect(patchBody.details).toMatchObject({
+      bucket: 'backups',
+      region: 'us-west-004',
+      endpoint: 's3.us-west-004.backblazeb2.com',
+      accessKey: '********',
+      secretKey: '********',
+    });
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+  });
+
+  it('blocks s3 create when region is empty and not derivable from the endpoint', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = (init as RequestInit | undefined)?.method ?? 'GET';
+      if (url === '/backup/configs' && method === 'GET') {
+        return makeJsonResponse({ data: [] });
+      }
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(
+      <BackupTab
+        policyId="policy-1"
+        existingLink={undefined}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    // With no configs the tab drops into create mode automatically
+    const nameInput = await screen.findByPlaceholderText(/Production S3 Backups/i);
+    fireEvent.change(nameInput, { target: { value: 'My B2' } });
+    fireEvent.change(screen.getByPlaceholderText(/my-backup-bucket/i), {
+      target: { value: 'bucket' },
+    });
+    // Satisfy the backup-path requirement so the region check is what fires
+    fireEvent.change(screen.getByPlaceholderText(/C:\\Users/i), {
+      target: { value: '/data' },
+    });
+    const regionInput = screen.getByPlaceholderText(/us-east-1/i);
+    fireEvent.change(regionInput, { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+
+    expect(await screen.findByText(/S3 region is required/i)).toBeTruthy();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/backup/configs',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('auto-fills the region from an S3-compatible endpoint', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = (init as RequestInit | undefined)?.method ?? 'GET';
+      if (url === '/backup/configs' && method === 'GET') {
+        return makeJsonResponse({ data: [] });
+      }
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(
+      <BackupTab
+        policyId="policy-1"
+        existingLink={undefined}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    await screen.findByPlaceholderText(/Production S3 Backups/i);
+    const endpointInput = screen.getByPlaceholderText(/backblazeb2/i);
+    fireEvent.change(endpointInput, {
+      target: { value: 's3.us-west-004.backblazeb2.com' },
+    });
+
+    const regionInput = screen.getByPlaceholderText(/us-east-1/i) as HTMLInputElement;
+    expect(regionInput.value).toBe('us-west-004');
   });
 });

--- a/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.tsx
@@ -830,7 +830,7 @@ export default function BackupTab({
     setS3Region(region);
     setS3RegionTouched(Boolean(region.trim()));
     setS3Endpoint(typeof details.endpoint === "string" ? details.endpoint : "");
-    if (typeof details.prefix === "string") update("s3Prefix", details.prefix);
+    update("s3Prefix", typeof details.prefix === "string" ? details.prefix : "");
     setS3AccessKey(hasStoredSecret(details.accessKey) ? MASKED_SECRET : "");
     setS3SecretKey(hasStoredSecret(details.secretKey) ? MASKED_SECRET : "");
     setLocalPath(

--- a/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import {
   HardDrive,
   Loader2,
+  Pencil,
   Plus,
   Trash2,
   CheckCircle2,
@@ -12,6 +13,7 @@ import {
   Clock,
   Shield,
 } from "lucide-react";
+import { deriveS3RegionFromEndpoint } from "@breeze/shared";
 import type { FeatureTabProps } from "./types";
 import { FEATURE_META } from "./types";
 import { useFeatureLink } from "./useFeatureLink";
@@ -101,6 +103,16 @@ type BackupInlineSettingsPayload = {
   targets: Record<string, unknown>;
 };
 // ── Constants ──────────────────────────────────────────────────────────────────
+// Matches the API's redaction sentinel: sending it back on PATCH keeps the stored secret.
+const MASKED_SECRET = "********";
+function hasStoredSecret(value: unknown): boolean {
+  if (typeof value === "string") return value.length > 0;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    return record.redacted === true && record.hasSecret !== false;
+  }
+  return false;
+}
 const scheduleDefaults: BackupScheduleSettings = {
   scheduleFrequency: "daily",
   scheduleTime: "03:00",
@@ -370,14 +382,21 @@ function PathList({
   onRemove,
   placeholder,
   label,
+  pendingValue,
+  onPendingChange,
 }: {
   items: string[];
   onAdd: (value: string) => void;
   onRemove: (value: string) => void;
   placeholder: string;
   label: string;
+  /** Optional controlled pending input so the parent can flush a typed-but-not-added value on save. */
+  pendingValue?: string;
+  onPendingChange?: (value: string) => void;
 }) {
-  const [input, setInput] = useState("");
+  const [localInput, setLocalInput] = useState("");
+  const input = pendingValue ?? localInput;
+  const setInput = onPendingChange ?? setLocalInput;
   const handleAdd = () => {
     const trimmed = input.trim();
     if (!trimmed || items.includes(trimmed)) return;
@@ -614,12 +633,14 @@ export default function BackupTab({
   const [selectedConfigId, setSelectedConfigId] = useState<string>(
     () => effectiveLink?.featurePolicyId ?? "",
   );
-  const [mode, setMode] = useState<"select" | "create">("select");
-  // New config fields
+  const [mode, setMode] = useState<"select" | "create" | "edit">("select");
+  // New / edited config fields
+  const [editingConfigId, setEditingConfigId] = useState<string | null>(null);
   const [newConfigName, setNewConfigName] = useState("");
   const [newProvider, setNewProvider] = useState<BackupProvider>("s3");
   const [s3Bucket, setS3Bucket] = useState("");
   const [s3Region, setS3Region] = useState("us-east-1");
+  const [s3RegionTouched, setS3RegionTouched] = useState(false);
   const [s3AccessKey, setS3AccessKey] = useState("");
   const [s3SecretKey, setS3SecretKey] = useState("");
   const [s3Endpoint, setS3Endpoint] = useState("");
@@ -627,6 +648,8 @@ export default function BackupTab({
   const [configSaving, setConfigSaving] = useState(false);
   const [configError, setConfigError] = useState<string>();
   const [testMessage, setTestMessage] = useState<string>();
+  // Typed-but-not-added backup path, flushed on save (controlled PathList input)
+  const [pendingPath, setPendingPath] = useState("");
   // Connection test
   const [testStatus, setTestStatus] = useState<
     "idle" | "testing" | "success" | "failed"
@@ -747,21 +770,22 @@ export default function BackupTab({
     }
   };
   // ── Create config via API ──────────────────────────────────────────────────
+  const buildProviderDetails = (): Record<string, unknown> =>
+    newProvider === "s3"
+      ? {
+          bucket: s3Bucket,
+          region: s3Region.trim(),
+          accessKey: s3AccessKey,
+          secretKey: s3SecretKey,
+          ...(s3Endpoint ? { endpoint: s3Endpoint } : {}),
+          ...(settings.s3Prefix ? { prefix: settings.s3Prefix } : {}),
+        }
+      : { path: localPath };
   const createConfig = async (): Promise<string | null> => {
     setConfigError(undefined);
     setConfigSaving(true);
     try {
-      const details: Record<string, unknown> =
-        newProvider === "s3"
-          ? {
-              bucket: s3Bucket,
-              region: s3Region,
-              accessKey: s3AccessKey,
-              secretKey: s3SecretKey,
-              ...(s3Endpoint ? { endpoint: s3Endpoint } : {}),
-              ...(settings.s3Prefix ? { prefix: settings.s3Prefix } : {}),
-            }
-          : { path: localPath };
+      const details = buildProviderDetails();
       const response = await fetchWithAuth("/backup/configs", {
         method: "POST",
         body: JSON.stringify({
@@ -795,14 +819,92 @@ export default function BackupTab({
       setConfigSaving(false);
     }
   };
+  // ── Edit existing config ───────────────────────────────────────────────────
+  const beginEditConfig = (config: BackupConfig) => {
+    const details = config.details ?? {};
+    setEditingConfigId(config.id);
+    setNewConfigName(config.name);
+    setNewProvider(config.provider === "local" ? "local" : "s3");
+    setS3Bucket(typeof details.bucket === "string" ? details.bucket : "");
+    const region = typeof details.region === "string" ? details.region : "";
+    setS3Region(region);
+    setS3RegionTouched(Boolean(region.trim()));
+    setS3Endpoint(typeof details.endpoint === "string" ? details.endpoint : "");
+    if (typeof details.prefix === "string") update("s3Prefix", details.prefix);
+    setS3AccessKey(hasStoredSecret(details.accessKey) ? MASKED_SECRET : "");
+    setS3SecretKey(hasStoredSecret(details.secretKey) ? MASKED_SECRET : "");
+    setLocalPath(
+      typeof details.path === "string" ? details.path : "/var/backups/breeze",
+    );
+    setConfigError(undefined);
+    setMode("edit");
+  };
+  const updateConfig = async (): Promise<string | null> => {
+    if (!editingConfigId) return null;
+    setConfigError(undefined);
+    setConfigSaving(true);
+    try {
+      const response = await fetchWithAuth(
+        `/backup/configs/${editingConfigId}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            name: newConfigName,
+            details: buildProviderDetails(),
+          }),
+        },
+      );
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(
+          extractApiError(
+            data,
+            i18n.t(
+              "policies:configurationPolicies.featureTabs.backupTab.failedToUpdateBackupConfig",
+            ),
+          ),
+        );
+      }
+      const updated = await response.json();
+      const cfg = updated.data ?? updated;
+      setConfigs((prev) => prev.map((c) => (c.id === cfg.id ? cfg : c)));
+      setSelectedConfigId(cfg.id);
+      setEditingConfigId(null);
+      setMode("select");
+      return cfg.id;
+    } catch (err) {
+      setConfigError(err instanceof Error ? err.message : "An error occurred");
+      return null;
+    } finally {
+      setConfigSaving(false);
+    }
+  };
   // ── Save feature link ──────────────────────────────────────────────────────
   const handleSave = async (options?: {
     downgradeInvalidProvider?: boolean;
   }) => {
     clearError();
     setConfigError(undefined);
+    // File mode: commit a typed-but-not-added path, then require at least one.
+    let pathsForSave = settings.paths;
+    if (backupMode === "file") {
+      const pending = pendingPath.trim();
+      if (pending && !pathsForSave.includes(pending)) {
+        pathsForSave = [...pathsForSave, pending];
+        update("paths", pathsForSave);
+        setPendingPath("");
+      }
+      if (pathsForSave.length === 0) {
+        setConfigError(
+          i18n.t(
+            "policies:configurationPolicies.featureTabs.backupTab.addAtLeastOneBackupPath",
+          ),
+        );
+        return;
+      }
+    }
     let configId = selectedConfigId;
-    if (mode === "create") {
+    if (mode === "create" || mode === "edit") {
       if (!newConfigName.trim()) {
         setConfigError(
           i18n.t(
@@ -819,6 +921,18 @@ export default function BackupTab({
         );
         return;
       }
+      if (
+        newProvider === "s3" &&
+        !s3Region.trim() &&
+        !deriveS3RegionFromEndpoint(s3Endpoint)
+      ) {
+        setConfigError(
+          i18n.t(
+            "policies:configurationPolicies.featureTabs.backupTab.s3RegionIsRequired",
+          ),
+        );
+        return;
+      }
       if (newProvider === "local" && !localPath.trim()) {
         setConfigError(
           i18n.t(
@@ -827,9 +941,9 @@ export default function BackupTab({
         );
         return;
       }
-      const created = await createConfig();
-      if (!created) return;
-      configId = created;
+      const savedId = mode === "create" ? await createConfig() : await updateConfig();
+      if (!savedId) return;
+      configId = savedId;
     }
     if (!configId) {
       setConfigError(
@@ -851,10 +965,14 @@ export default function BackupTab({
       );
       return;
     }
+    const baseSettings = { ...settings, paths: pathsForSave };
     const settingsToSave =
       providerModeInvalid && options?.downgradeInvalidProvider
-        ? { ...settings, immutabilityMode: "application" as ImmutabilityMode }
-        : settings;
+        ? {
+            ...baseSettings,
+            immutabilityMode: "application" as ImmutabilityMode,
+          }
+        : baseSettings;
     const result = await save(existingLink?.id ?? null, {
       featureType: "backup",
       featurePolicyId: configId,
@@ -1166,12 +1284,19 @@ export default function BackupTab({
           {configs.length > 0 && (
             <button
               type="button"
-              onClick={() =>
-                setMode(mode === "create" ? "select" : "create")
-              }
+              onClick={() => {
+                if (mode === "select") {
+                  setMode("create");
+                } else {
+                  setEditingConfigId(null);
+                  setMode("select");
+                }
+              }}
               className="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
             >
-              {mode === "create" ? (
+              {mode === "edit" ? (
+                i18n.t("common:actions.cancel")
+              ) : mode === "create" ? (
                 i18n.t(
                   "policies:configurationPolicies.featureTabs.backupTab.useExistingConfig",
                 )
@@ -1332,10 +1457,22 @@ export default function BackupTab({
                             </span>
                           </span>
                         </div>
-                        <p className="text-xs text-muted-foreground">
-                          {capabilitySummary(selectedConfig)}
-                        </p>
+                        {capabilitySummary(selectedConfig) !== testMessage && (
+                          <p className="text-xs text-muted-foreground">
+                            {capabilitySummary(selectedConfig)}
+                          </p>
+                        )}
                       </div>
+                      <div className="flex items-center gap-2">
+                      {/* Edit config button */}
+                      <button
+                        type="button"
+                        onClick={() => beginEditConfig(selectedConfig)}
+                        className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition hover:bg-muted"
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                        {i18n.t("common:actions.edit")}
+                      </button>
                       {/* Test connection button */}
                       <button
                         type="button"
@@ -1371,6 +1508,7 @@ export default function BackupTab({
                                   "policies:configurationPolicies.featureTabs.backupTab.test",
                                 )}
                       </button>
+                      </div>
                     </div>
                     {testMessage && (
                       <div
@@ -1389,8 +1527,15 @@ export default function BackupTab({
             )}
           </div>
         ) : (
-          /* ── Create new config ────────────────────────────────────────── */
+          /* ── Create / edit config ─────────────────────────────────────── */
           <div className="mt-2 space-y-4 rounded-md border bg-muted/10 p-4">
+            {mode === "edit" && (
+              <p className="text-xs font-medium text-primary">
+                {i18n.t(
+                  "policies:configurationPolicies.featureTabs.backupTab.editingStorageConfiguration",
+                )}
+              </p>
+            )}
             <div>
               <label className="text-xs font-medium text-muted-foreground">
                 {i18n.t(
@@ -1407,6 +1552,8 @@ export default function BackupTab({
               />
             </div>
 
+            {/* Provider is immutable once created — hide the picker while editing */}
+            {mode !== "edit" && (
             <div>
               <label className="text-xs font-medium text-muted-foreground">
                 {i18n.t(
@@ -1449,6 +1596,7 @@ export default function BackupTab({
                 })}
               </div>
             </div>
+            )}
 
             {newProvider === "s3" && (
               <div className="space-y-3">
@@ -1476,7 +1624,10 @@ export default function BackupTab({
                     </label>
                     <input
                       value={s3Region}
-                      onChange={(e) => setS3Region(e.target.value)}
+                      onChange={(e) => {
+                        setS3Region(e.target.value);
+                        setS3RegionTouched(true);
+                      }}
                       placeholder={i18n.t(
                         "policies:configurationPolicies.featureTabs.backupTab.usEast1",
                       )}
@@ -1519,6 +1670,13 @@ export default function BackupTab({
                     />
                   </div>
                 </div>
+                {mode === "edit" && (
+                  <p className="chart-legend-xs text-muted-foreground">
+                    {i18n.t(
+                      "policies:configurationPolicies.featureTabs.backupTab.secretsUnchangedHint",
+                    )}
+                  </p>
+                )}
                 <div className="grid gap-3 sm:grid-cols-2">
                   <div>
                     <label className="text-xs text-muted-foreground">
@@ -1558,7 +1716,16 @@ export default function BackupTab({
                     </label>
                     <input
                       value={s3Endpoint}
-                      onChange={(e) => setS3Endpoint(e.target.value)}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setS3Endpoint(value);
+                        // Providers like Backblaze B2 encode the signing region
+                        // in the endpoint — fill it in unless the user set one.
+                        const derived = deriveS3RegionFromEndpoint(value);
+                        if (derived && (!s3RegionTouched || !s3Region.trim())) {
+                          setS3Region(derived);
+                        }
+                      }}
                       placeholder={i18n.t(
                         "policies:configurationPolicies.featureTabs.backupTab.httpsS3UsWest002Backblazeb2Com",
                       )}
@@ -1626,6 +1793,8 @@ export default function BackupTab({
                     settings.paths.filter((p) => p !== v),
                   )
                 }
+                pendingValue={pendingPath}
+                onPendingChange={setPendingPath}
                 placeholder={i18n.t(
                   "policies:configurationPolicies.featureTabs.backupTab.cUsersOrHomeOrEtc",
                 )}

--- a/apps/web/src/locales/en/policies.json
+++ b/apps/web/src/locales/en/policies.json
@@ -509,7 +509,12 @@
         "immutableDays": "immutableDays",
         "backupWindowStart": "backupWindowStart",
         "backupWindowEnd": "backupWindowEnd",
-        "retentionSummary": "{{days}}d, {{versions}} versions"
+        "retentionSummary": "{{days}}d, {{versions}} versions",
+        "addAtLeastOneBackupPath": "Add at least one backup path before saving",
+        "s3RegionIsRequired": "S3 region is required — enter it or use an endpoint that includes it (e.g. s3.us-west-004.backblazeb2.com)",
+        "failedToUpdateBackupConfig": "Failed to update backup config",
+        "editingStorageConfiguration": "Editing storage configuration",
+        "secretsUnchangedHint": "Leave the masked credentials unchanged to keep the saved keys."
       },
       "complianceTab": {
         "requiredSoftware": "Required Software",

--- a/apps/web/src/locales/pt-BR/policies.json
+++ b/apps/web/src/locales/pt-BR/policies.json
@@ -509,7 +509,12 @@
         "immutableDays": "immutableDays",
         "backupWindowStart": "backupWindowStart",
         "backupWindowEnd": "backupWindowEnd",
-        "retentionSummary": "{{days}}d, {{versions}} versões"
+        "retentionSummary": "{{days}}d, {{versions}} versões",
+        "addAtLeastOneBackupPath": "Adicione pelo menos um caminho de backup antes de salvar",
+        "s3RegionIsRequired": "A região do S3 é obrigatória — informe-a ou use um endpoint que a inclua (ex.: s3.us-west-004.backblazeb2.com)",
+        "failedToUpdateBackupConfig": "Falha ao atualizar a configuração de backup",
+        "editingStorageConfiguration": "Editando configuração de armazenamento",
+        "secretsUnchangedHint": "Mantenha as credenciais mascaradas para preservar as chaves salvas."
       },
       "complianceTab": {
         "requiredSoftware": "Software obrigatório",

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './quoteMath';
 export * from './depositMath';
 export * from './csvExport';
 export * from './reportSchedule';
+export * from './s3Region';

--- a/packages/shared/src/utils/s3Region.test.ts
+++ b/packages/shared/src/utils/s3Region.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { deriveS3RegionFromEndpoint } from './s3Region';
+
+describe('deriveS3RegionFromEndpoint', () => {
+  it('derives Backblaze B2 regions', () => {
+    expect(deriveS3RegionFromEndpoint('s3.us-west-004.backblazeb2.com')).toBe('us-west-004');
+    expect(deriveS3RegionFromEndpoint('https://s3.eu-central-003.backblazeb2.com')).toBe('eu-central-003');
+  });
+
+  it('derives AWS regions from regional endpoints', () => {
+    expect(deriveS3RegionFromEndpoint('s3.us-west-2.amazonaws.com')).toBe('us-west-2');
+    expect(deriveS3RegionFromEndpoint('s3-eu-west-1.amazonaws.com')).toBe('eu-west-1');
+    expect(deriveS3RegionFromEndpoint('s3.dualstack.us-east-1.amazonaws.com')).toBe('us-east-1');
+  });
+
+  it('derives Wasabi and DigitalOcean Spaces regions', () => {
+    expect(deriveS3RegionFromEndpoint('s3.eu-central-1.wasabisys.com')).toBe('eu-central-1');
+    expect(deriveS3RegionFromEndpoint('nyc3.digitaloceanspaces.com')).toBe('nyc3');
+  });
+
+  it('tolerates schemes, ports, paths, and casing', () => {
+    expect(deriveS3RegionFromEndpoint('https://s3.us-west-004.backblazeb2.com/')).toBe('us-west-004');
+    expect(deriveS3RegionFromEndpoint('https://S3.US-WEST-004.BACKBLAZEB2.COM:443/bucket')).toBe('us-west-004');
+    expect(deriveS3RegionFromEndpoint('  s3.us-west-004.backblazeb2.com  ')).toBe('us-west-004');
+  });
+
+  it('returns null when no region is encoded', () => {
+    expect(deriveS3RegionFromEndpoint('s3.amazonaws.com')).toBeNull();
+    expect(deriveS3RegionFromEndpoint('minio.internal.example.com')).toBeNull();
+    expect(deriveS3RegionFromEndpoint('')).toBeNull();
+    expect(deriveS3RegionFromEndpoint(null)).toBeNull();
+    expect(deriveS3RegionFromEndpoint(undefined)).toBeNull();
+    expect(deriveS3RegionFromEndpoint('http://')).toBeNull();
+  });
+});

--- a/packages/shared/src/utils/s3Region.ts
+++ b/packages/shared/src/utils/s3Region.ts
@@ -1,0 +1,50 @@
+/**
+ * Derive an S3 signing region from an S3-compatible endpoint hostname.
+ *
+ * Several S3-compatible providers embed the region in the endpoint host
+ * (and some, like Backblaze B2, reject requests signed with a mismatched
+ * region), so when a user supplies an endpoint but no region we can — and
+ * should — derive it instead of falling back to a generic default.
+ */
+const ENDPOINT_REGION_PATTERNS: RegExp[] = [
+  // AWS dualstack: s3.dualstack.us-east-1.amazonaws.com
+  /^s3\.dualstack\.([a-z0-9-]+)\.amazonaws\.com$/,
+  // AWS: s3.us-west-2.amazonaws.com / legacy s3-us-west-2.amazonaws.com
+  /^s3[.-]([a-z0-9-]+)\.amazonaws\.com$/,
+  // Backblaze B2: s3.us-west-004.backblazeb2.com
+  /^s3\.([a-z0-9-]+)\.backblazeb2\.com$/,
+  // Wasabi: s3.eu-central-1.wasabisys.com
+  /^s3\.([a-z0-9-]+)\.wasabisys\.com$/,
+  // DigitalOcean Spaces: nyc3.digitaloceanspaces.com
+  /^([a-z0-9]+)\.digitaloceanspaces\.com$/,
+];
+
+/**
+ * Returns the region embedded in an S3-compatible endpoint, or null when the
+ * endpoint is absent, unparseable, or from a provider whose endpoints do not
+ * encode a region (e.g. MinIO on a custom domain).
+ */
+export function deriveS3RegionFromEndpoint(
+  endpoint: string | null | undefined,
+): string | null {
+  const raw = endpoint?.trim();
+  if (!raw) return null;
+
+  let hostname: string;
+  try {
+    hostname = new URL(raw.includes('://') ? raw : `https://${raw}`).hostname;
+  } catch {
+    return null;
+  }
+
+  const host = hostname.toLowerCase();
+  for (const pattern of ENDPOINT_REGION_PATTERNS) {
+    const match = host.match(pattern);
+    // AWS's regionless legacy endpoint (s3.amazonaws.com) never matches, but
+    // guard against captures that are obviously not regions.
+    if (match?.[1] && match[1] !== 's3') {
+      return match[1];
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Backup testing on the config-policy **Backup** tab surfaced two blockers; this PR fixes them plus two adjacent defects.

### 1. Raw Zod error on save with no committed backup paths
A path typed into the Backup Paths input but never committed via **Add** was silently dropped, so Save posted `targets.paths: []` and the API's 400 rendered as `Invalid backup settings: targets: Too small: expected array to have >=1 items`.

- Save now flushes a typed-but-not-added path automatically (PathList's pending input is lifted/controlled for the paths list).
- File-mode saves with zero paths fail fast client-side with **"Add at least one backup path before saving"**.

### 2. S3 region unvalidated → persistent "Region is missing" failure with no edit path
`configSchema.details` was untyped (`z.record(z.any())`), so clearing the region field (correct instinct for Backblaze, where `us-east-1` is wrong) stored `region: ""`. The connection test then threw the AWS SDK's bare `Region is missing`, which got persisted into `providerCapabilities` as a permanent Failed state — and there was no edit UI anywhere to fix it.

- **New shared util** `deriveS3RegionFromEndpoint` (Backblaze B2, AWS regional/dualstack/legacy, Wasabi, DigitalOcean Spaces). B2 rejects requests signed with a mismatched region, so deriving — not defaulting — is the correct behavior.
- **Create/PATCH now validate** s3 details: non-empty bucket + region (explicit or endpoint-derived). The resolved region is persisted.
- **Connection test + capability probes derive the region for legacy rows** saved with an empty region — existing broken configs self-heal on Test without editing.
- **Web form**: region required client-side, and the endpoint field auto-fills the region (unless manually overridden).

### 3. No edit UI for storage configs
Added an **Edit** button on the config summary card, reusing the create form (provider immutable, so the picker is hidden) wired to the existing `PATCH /backup/configs/:id`. Masked credentials (`********`) round-trip through the route's secret-preservation merge, so keys don't need re-entering; a hint says so. PATCH already resets persisted capabilities on details change, so a fixed config re-tests cleanly.

### 4. Duplicate error display
The persisted capability summary and the test banner showed the same message twice; the plain-text summary is now suppressed when identical to the banner.

## Tests
- `packages/shared`: new `s3Region.test.ts` (5 cases); full suite 1076 passed.
- `apps/api`: 4 new cases (create rejects underivable missing region; create persists derived region; PATCH rejects dropping region; test route derives probe region for legacy `region:""` rows). Two existing PATCH tests updated — they previously sent partial details that silently dropped the region, which is exactly the bug class now rejected. Backup route suite: 152 passed.
- `apps/web`: 5 new BackupTab cases (friendly empty-paths error; pending-path flush; edit-via-PATCH with masked secrets; region required on create; endpoint→region auto-fill). Suite + no-silent-mutations guard pass.
- Typecheck clean on shared/api/web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)