### PR TITLE
feat(agent): worker-pool wedge observability — heartbeat gauges + short ephemeral watchdog tier (#2400)

### DIFF
--- a/agent/internal/collectors/runtime_stats.go
+++ b/agent/internal/collectors/runtime_stats.go
@@ -12,6 +12,14 @@ type RuntimeStats struct {
 	SysBytes          uint64 `json:"sysBytes"`
 	NumGC             uint32 `json:"numGc"`
 	Goroutines        int    `json:"goroutines"`
+
+	// Worker-pool wedge gauges (issue #2400). Filled in by the heartbeat —
+	// not by CollectRuntimeStats, which has no view of the pool.
+	// CommandsInFlight is how many pool-dispatched commands are currently
+	// executing; CommandsOverdue is how many of those have been running
+	// longer than their in-flight watchdog tier (wedged-worker suspects).
+	CommandsInFlight int `json:"commandsInFlight"`
+	CommandsOverdue  int `json:"commandsOverdue"`
 }
 
 // CollectRuntimeStats reads the Go runtime's memory statistics for this

--- a/agent/internal/collectors/runtime_stats_test.go
+++ b/agent/internal/collectors/runtime_stats_test.go
@@ -46,6 +46,7 @@ func TestRuntimeStatsJSONShape(t *testing.T) {
 	for _, key := range []string{
 		"heapAllocBytes", "heapInuseBytes", "heapReleasedBytes",
 		"sysBytes", "numGc", "goroutines",
+		"commandsInFlight", "commandsOverdue",
 	} {
 		if _, ok := m[key]; !ok {
 			t.Errorf("expected JSON key %q missing", key)

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -2931,9 +2931,7 @@ func (h *Heartbeat) sendHeartbeat() {
 
 	// Agent's own runtime memory gauges (#2389), plus worker-pool wedge
 	// gauges (#2400) so in-flight/overdue commands are visible fleet-wide.
-	payload.AgentRuntime = collectors.CollectRuntimeStats()
-	payload.AgentRuntime.CommandsInFlight, payload.AgentRuntime.CommandsOverdue =
-		h.inFlightCommandStats(time.Now())
+	payload.AgentRuntime = h.collectAgentRuntime(time.Now())
 
 	// OneDrive helper state (Phase 2). Nil until a config has been applied on a
 	// Windows box — omitempty then drops the field entirely.
@@ -3562,7 +3560,7 @@ func (h *Heartbeat) sendHelperTokenUpdate(newToken string) {
 }
 
 func (h *Heartbeat) processCommand(cmd Command) {
-	result := h.executeCommand(cmd)
+	result := h.runTrackedCommand(cmd)
 
 	if result.Status == "duplicate" {
 		return
@@ -3651,7 +3649,7 @@ func (h *Heartbeat) executeCommandViaPool(cmd Command) tools.CommandResult {
 
 	resultCh := make(chan tools.CommandResult, 1)
 	if !h.pool.Submit(func() {
-		resultCh <- h.executeCommand(cmd)
+		resultCh <- h.runTrackedCommand(cmd)
 	}) {
 		return tools.CommandResult{
 			Status: "failed",
@@ -3670,8 +3668,6 @@ func (h *Heartbeat) executeCommandViaPool(cmd Command) tools.CommandResult {
 	// get a much shorter tier (issue #2400) — still log-only.
 	warnAfter := h.commandWarnAfter(cmd.Type)
 	started := time.Now()
-	inFlightKey := h.trackInFlight(started, warnAfter)
-	defer h.untrackInFlight(inFlightKey)
 	watchdog := time.NewTimer(warnAfter)
 	defer watchdog.Stop()
 
@@ -3740,6 +3736,19 @@ type inFlightCommand struct {
 	warnAfter time.Duration
 }
 
+// runTrackedCommand executes cmd on the calling goroutine (a pool worker),
+// recording it in the in-flight wedge gauges for exactly the duration of its
+// execution. Both command-delivery channels go through here — the WebSocket
+// dispatch loop (executeCommandViaPool) and the heartbeat-response poll path
+// (processCommand) — so the gauges see every pool worker a command occupies,
+// and tracking starts when a worker picks the command up, not when it is
+// queued behind a backlog.
+func (h *Heartbeat) runTrackedCommand(cmd Command) tools.CommandResult {
+	key := h.trackInFlight(time.Now(), h.commandWarnAfter(cmd.Type))
+	defer h.untrackInFlight(key)
+	return h.executeCommand(cmd)
+}
+
 // trackInFlight records a command dispatch and returns the key to pass to
 // untrackInFlight when the dispatch loop exits.
 func (h *Heartbeat) trackInFlight(started time.Time, warnAfter time.Duration) uint64 {
@@ -3757,6 +3766,17 @@ func (h *Heartbeat) untrackInFlight(key uint64) {
 	h.inFlightMu.Lock()
 	defer h.inFlightMu.Unlock()
 	delete(h.inFlightCommands, key)
+}
+
+// collectAgentRuntime builds the heartbeat's agentRuntime gauge object: the
+// Go runtime memory stats (#2389) plus the worker-pool wedge gauges (#2400).
+// Extracted from sendHeartbeat so the gauge wiring itself is testable — if
+// this stops being called with live tracker data, the gauges silently report
+// a permanently-plausible 0/0.
+func (h *Heartbeat) collectAgentRuntime(now time.Time) *collectors.RuntimeStats {
+	rt := collectors.CollectRuntimeStats()
+	rt.CommandsInFlight, rt.CommandsOverdue = h.inFlightCommandStats(now)
+	return rt
 }
 
 // inFlightCommandStats returns how many pool-dispatched commands are

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -227,10 +227,25 @@ type Heartbeat struct {
 	seenCommandsMu sync.Mutex
 
 	// commandInFlightWarnAfter overrides the wedged-worker watchdog interval
-	// in executeCommandViaPool; non-positive means
+	// in executeCommandViaPool for non-ephemeral commands; non-positive means
 	// defaultCommandInFlightWarnAfter. Set before the heartbeat runs (tests
 	// only) — never mutated afterwards.
 	commandInFlightWarnAfter time.Duration
+
+	// ephemeralCommandInFlightWarnAfter is the same override for the short
+	// watchdog tier applied to ephemeral commands (isEphemeralCommand:
+	// terminal/tunnel/desktop data, which should complete in milliseconds);
+	// non-positive means defaultEphemeralCommandInFlightWarnAfter. Tests only.
+	ephemeralCommandInFlightWarnAfter time.Duration
+
+	// inFlightCommands tracks every command currently executing on the worker
+	// pool (keyed by a per-dispatch sequence number so duplicate command IDs
+	// can't clobber each other), with its start time and watchdog tier. Read
+	// by inFlightCommandStats to put wedged-worker gauges on the heartbeat
+	// (issue #2400).
+	inFlightMu       sync.Mutex
+	inFlightCommands map[uint64]inFlightCommand
+	inFlightSeq      atomic.Uint64
 
 	// Guard against concurrent cert renewals from successive heartbeats
 	certRenewing      atomic.Bool
@@ -2914,8 +2929,11 @@ func (h *Heartbeat) sendHeartbeat() {
 	// it or when the query failed — omitempty then drops the field.
 	payload.Battery = h.hardwareCol.CollectBattery()
 
-	// Agent's own runtime memory gauges (#2389).
+	// Agent's own runtime memory gauges (#2389), plus worker-pool wedge
+	// gauges (#2400) so in-flight/overdue commands are visible fleet-wide.
 	payload.AgentRuntime = collectors.CollectRuntimeStats()
+	payload.AgentRuntime.CommandsInFlight, payload.AgentRuntime.CommandsOverdue =
+		h.inFlightCommandStats(time.Now())
 
 	// OneDrive helper state (Phase 2). Nil until a config has been applied on a
 	// Windows box — omitempty then drops the field entirely.
@@ -3647,12 +3665,13 @@ func (h *Heartbeat) executeCommandViaPool(cmd Command) tools.CommandResult {
 	// flags workers wedged on an unbounded blocking call — each one pins its
 	// decoded command payload (up to the 64MB websocket read limit,
 	// maxMessageSize in internal/websocket) for the process lifetime and
-	// permanently shrinks the pool (issue #2387).
-	warnAfter := h.commandInFlightWarnAfter
-	if warnAfter <= 0 {
-		warnAfter = defaultCommandInFlightWarnAfter
-	}
+	// permanently shrinks the pool (issue #2387). Ephemeral commands
+	// (terminal/tunnel/desktop data) should complete in milliseconds, so they
+	// get a much shorter tier (issue #2400) — still log-only.
+	warnAfter := h.commandWarnAfter(cmd.Type)
 	started := time.Now()
+	inFlightKey := h.trackInFlight(started, warnAfter)
+	defer h.untrackInFlight(inFlightKey)
 	watchdog := time.NewTimer(warnAfter)
 	defer watchdog.Stop()
 
@@ -3665,6 +3684,7 @@ func (h *Heartbeat) executeCommandViaPool(cmd Command) tools.CommandResult {
 				logging.KeyCommandID, cmd.ID,
 				"type", cmd.Type,
 				"elapsed", time.Since(started).Round(time.Second).String(),
+				"warnAfter", warnAfter.String(),
 			)
 			watchdog.Reset(warnAfter)
 		case <-h.stopChan:
@@ -3687,6 +3707,73 @@ func (h *Heartbeat) executeCommandViaPool(cmd Command) tools.CommandResult {
 // (scripts capped at executor.MaxTimeout = 1h, patch installs) must not trip
 // it in normal operation.
 const defaultCommandInFlightWarnAfter = 2 * time.Hour
+
+// defaultEphemeralCommandInFlightWarnAfter is the short watchdog tier for
+// ephemeral commands (isEphemeralCommand: terminal_data, tunnel_data, desktop
+// input, ...). Those handlers hand off to an interactive session and should
+// return in milliseconds, so one stuck for a minute is a wedged interactive
+// path — worth flagging long before the 2h tier would (issue #2400). Log-only,
+// exactly like the default tier: it never fails or kills the command.
+const defaultEphemeralCommandInFlightWarnAfter = 60 * time.Second
+
+// commandWarnAfter returns the in-flight watchdog tier for a command type:
+// the short ephemeral tier for interactive-session data commands, the
+// generous default for everything else. Test overrides on the Heartbeat take
+// precedence within their tier.
+func (h *Heartbeat) commandWarnAfter(cmdType string) time.Duration {
+	if isEphemeralCommand(cmdType) {
+		if h.ephemeralCommandInFlightWarnAfter > 0 {
+			return h.ephemeralCommandInFlightWarnAfter
+		}
+		return defaultEphemeralCommandInFlightWarnAfter
+	}
+	if h.commandInFlightWarnAfter > 0 {
+		return h.commandInFlightWarnAfter
+	}
+	return defaultCommandInFlightWarnAfter
+}
+
+// inFlightCommand is one pool-dispatched command currently executing, as
+// tracked for the heartbeat wedge gauges (issue #2400).
+type inFlightCommand struct {
+	started   time.Time
+	warnAfter time.Duration
+}
+
+// trackInFlight records a command dispatch and returns the key to pass to
+// untrackInFlight when the dispatch loop exits.
+func (h *Heartbeat) trackInFlight(started time.Time, warnAfter time.Duration) uint64 {
+	key := h.inFlightSeq.Add(1)
+	h.inFlightMu.Lock()
+	defer h.inFlightMu.Unlock()
+	if h.inFlightCommands == nil {
+		h.inFlightCommands = make(map[uint64]inFlightCommand)
+	}
+	h.inFlightCommands[key] = inFlightCommand{started: started, warnAfter: warnAfter}
+	return key
+}
+
+func (h *Heartbeat) untrackInFlight(key uint64) {
+	h.inFlightMu.Lock()
+	defer h.inFlightMu.Unlock()
+	delete(h.inFlightCommands, key)
+}
+
+// inFlightCommandStats returns how many pool-dispatched commands are
+// currently executing and how many of those are overdue — running longer
+// than their watchdog tier. Reported on every heartbeat via the agentRuntime
+// gauges so wedged workers are visible fleet-wide (issue #2400).
+func (h *Heartbeat) inFlightCommandStats(now time.Time) (inFlight, overdue int) {
+	h.inFlightMu.Lock()
+	defer h.inFlightMu.Unlock()
+	inFlight = len(h.inFlightCommands)
+	for _, c := range h.inFlightCommands {
+		if now.Sub(c.started) > c.warnAfter {
+			overdue++
+		}
+	}
+	return inFlight, overdue
+}
 
 func isEphemeralCommand(cmdType string) bool {
 	switch cmdType {

--- a/agent/internal/heartbeat/heartbeat_inflight_stats_test.go
+++ b/agent/internal/heartbeat/heartbeat_inflight_stats_test.go
@@ -206,6 +206,154 @@ func TestEphemeralShortTierIsLogOnly(t *testing.T) {
 	}
 }
 
+// TestRunTrackedCommandTracksExecution verifies the shared tracking helper
+// used by BOTH delivery channels — the WebSocket dispatch loop
+// (executeCommandViaPool) and the heartbeat-response poll path
+// (processCommand) — registers the command for exactly the duration of its
+// execution. This is what keeps HTTP-poll-delivered commands (the degraded-WS
+// devices most likely to wedge) visible in the gauges.
+//
+// MUST NOT call t.Parallel(): mutates handlerRegistry.
+func TestRunTrackedCommandTracksExecution(t *testing.T) {
+	const blockType = "test_2400_tracked_direct"
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(unblock)
+
+	handlerRegistry[blockType] = func(h *Heartbeat, cmd Command) tools.CommandResult {
+		<-release
+		return tools.CommandResult{Status: "completed", Stdout: "tracked-ok"}
+	}
+	t.Cleanup(func() { delete(handlerRegistry, blockType) })
+
+	h := &Heartbeat{}
+	done := make(chan tools.CommandResult, 1)
+	go func() {
+		done <- h.runTrackedCommand(Command{
+			ID:      "tracked-direct-1",
+			Type:    blockType,
+			Payload: map[string]any{},
+		})
+	}()
+
+	waitForInFlight(t, h, 1)
+	unblock()
+	result := <-done
+	if result.Status != "completed" || result.Stdout != "tracked-ok" {
+		t.Fatalf("unexpected result: status=%q stdout=%q error=%q", result.Status, result.Stdout, result.Error)
+	}
+	waitForInFlight(t, h, 0)
+}
+
+// TestConcurrentDuplicateIDCommandsBothCounted guards the per-dispatch
+// sequence key: two commands with the SAME command ID executing concurrently
+// (legitimately possible — start_desktop/stop_desktop are exempt from
+// command-ID dedup, see executeCommand #434) must each hold their own gauge
+// entry, and completing one must not evict the other. If the tracker key were
+// ever "simplified" to cmd.ID, the survivor would go invisible — exactly the
+// wedged command the gauge exists to surface.
+//
+// MUST NOT call t.Parallel(): mutates handlerRegistry.
+func TestConcurrentDuplicateIDCommandsBothCounted(t *testing.T) {
+	firstRelease := make(chan struct{})
+	secondRelease := make(chan struct{})
+	var firstOnce, secondOnce sync.Once
+	unblockFirst := func() { firstOnce.Do(func() { close(firstRelease) }) }
+	unblockSecond := func() { secondOnce.Do(func() { close(secondRelease) }) }
+	t.Cleanup(unblockFirst)
+	t.Cleanup(unblockSecond)
+
+	invocation := make(chan int, 2)
+	var calls int
+	var callsMu sync.Mutex
+	orig, hadOrig := handlerRegistry[tools.CmdStartDesktop]
+	handlerRegistry[tools.CmdStartDesktop] = func(h *Heartbeat, cmd Command) tools.CommandResult {
+		callsMu.Lock()
+		calls++
+		n := calls
+		callsMu.Unlock()
+		invocation <- n
+		if n == 1 {
+			<-firstRelease
+		} else {
+			<-secondRelease
+		}
+		return tools.CommandResult{Status: "completed"}
+	}
+	t.Cleanup(func() {
+		if hadOrig {
+			handlerRegistry[tools.CmdStartDesktop] = orig
+		} else {
+			delete(handlerRegistry, tools.CmdStartDesktop)
+		}
+	})
+
+	h := &Heartbeat{
+		stopChan: make(chan struct{}),
+		pool:     workerpool.New(2, 2),
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		h.pool.Shutdown(ctx)
+	})
+
+	sameID := "duplicate-id-2400"
+	done := make(chan tools.CommandResult, 2)
+	for range 2 {
+		go func() {
+			done <- h.executeCommandViaPool(Command{
+				ID:      sameID,
+				Type:    tools.CmdStartDesktop,
+				Payload: map[string]any{},
+			})
+		}()
+	}
+
+	// Both handlers running concurrently under the same command ID.
+	<-invocation
+	<-invocation
+	waitForInFlight(t, h, 2)
+
+	// Completing the first must leave the second tracked.
+	unblockFirst()
+	<-done
+	waitForInFlight(t, h, 1)
+
+	unblockSecond()
+	<-done
+	waitForInFlight(t, h, 0)
+}
+
+// TestCollectAgentRuntimeCarriesWedgeGauges pins the sendHeartbeat wiring:
+// the agentRuntime payload object must carry live tracker values. If
+// collectAgentRuntime stopped consulting the tracker, the gauges would report
+// a permanently-plausible 0/0 with every other test still green.
+func TestCollectAgentRuntimeCarriesWedgeGauges(t *testing.T) {
+	t.Parallel()
+
+	h := &Heartbeat{}
+	now := time.Now()
+	h.trackInFlight(now.Add(-2*time.Minute), defaultEphemeralCommandInFlightWarnAfter) // overdue
+	h.trackInFlight(now.Add(-time.Minute), defaultCommandInFlightWarnAfter)            // in flight, not overdue
+
+	rt := h.collectAgentRuntime(now)
+	if rt == nil {
+		t.Fatal("collectAgentRuntime returned nil")
+	}
+	if rt.CommandsInFlight != 2 {
+		t.Errorf("CommandsInFlight = %d, want 2", rt.CommandsInFlight)
+	}
+	if rt.CommandsOverdue != 1 {
+		t.Errorf("CommandsOverdue = %d, want 1", rt.CommandsOverdue)
+	}
+	// And the memory gauges still ride along.
+	if rt.SysBytes == 0 || rt.Goroutines < 1 {
+		t.Errorf("memory gauges missing: sysBytes=%d goroutines=%d", rt.SysBytes, rt.Goroutines)
+	}
+}
+
 // waitForInFlight polls the in-flight gauge until it reports want, failing
 // the test after a generous deadline.
 func waitForInFlight(t *testing.T, h *Heartbeat, want int) {

--- a/agent/internal/heartbeat/heartbeat_inflight_stats_test.go
+++ b/agent/internal/heartbeat/heartbeat_inflight_stats_test.go
@@ -1,0 +1,224 @@
+package heartbeat
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+	"github.com/breeze-rmm/agent/internal/workerpool"
+)
+
+// Tests for the worker-pool wedge gauges (issue #2400): the in-flight command
+// tracker behind the heartbeat's agentRuntime.commandsInFlight /
+// commandsOverdue fields, and the two-tier in-flight watchdog interval.
+
+// TestCommandWarnAfterTierSelection verifies the two watchdog tiers:
+// ephemeral commands (terminal/tunnel/desktop data) get the short tier,
+// everything else the generous default, and each tier's test override applies
+// only within its own tier.
+func TestCommandWarnAfterTierSelection(t *testing.T) {
+	t.Parallel()
+
+	h := &Heartbeat{}
+	if got := h.commandWarnAfter(tools.CmdTerminalData); got != defaultEphemeralCommandInFlightWarnAfter {
+		t.Errorf("ephemeral default tier = %v, want %v", got, defaultEphemeralCommandInFlightWarnAfter)
+	}
+	if got := h.commandWarnAfter(tools.CmdTunnelData); got != defaultEphemeralCommandInFlightWarnAfter {
+		t.Errorf("tunnel_data tier = %v, want %v", got, defaultEphemeralCommandInFlightWarnAfter)
+	}
+	if got := h.commandWarnAfter(tools.CmdDesktopInput); got != defaultEphemeralCommandInFlightWarnAfter {
+		t.Errorf("desktop input tier = %v, want %v", got, defaultEphemeralCommandInFlightWarnAfter)
+	}
+	if got := h.commandWarnAfter("run_script"); got != defaultCommandInFlightWarnAfter {
+		t.Errorf("non-ephemeral default tier = %v, want %v", got, defaultCommandInFlightWarnAfter)
+	}
+
+	// Overrides apply within their own tier only.
+	hOverride := &Heartbeat{
+		commandInFlightWarnAfter:          time.Minute,
+		ephemeralCommandInFlightWarnAfter: time.Second,
+	}
+	if got := hOverride.commandWarnAfter(tools.CmdTerminalData); got != time.Second {
+		t.Errorf("ephemeral override tier = %v, want %v", got, time.Second)
+	}
+	if got := hOverride.commandWarnAfter("run_script"); got != time.Minute {
+		t.Errorf("non-ephemeral override tier = %v, want %v", got, time.Minute)
+	}
+
+	// The non-ephemeral override must NOT leak into the ephemeral tier.
+	hPartial := &Heartbeat{commandInFlightWarnAfter: 5 * time.Hour}
+	if got := hPartial.commandWarnAfter(tools.CmdTerminalData); got != defaultEphemeralCommandInFlightWarnAfter {
+		t.Errorf("ephemeral tier with only non-ephemeral override set = %v, want %v",
+			got, defaultEphemeralCommandInFlightWarnAfter)
+	}
+}
+
+// TestInFlightCommandStatsOverdueTiers drives the overdue computation with an
+// injected `now` (no sleeping): a command crosses into overdue exactly when
+// its own tier's interval elapses, so an ephemeral command wedged for minutes
+// counts as overdue while a long-running script under the 2h tier does not.
+func TestInFlightCommandStatsOverdueTiers(t *testing.T) {
+	t.Parallel()
+
+	h := &Heartbeat{}
+	now := time.Now()
+
+	// One ephemeral-tier command started 90s ago (past its 60s tier), one
+	// standard-tier command started 10min ago (well inside its 2h tier).
+	h.trackInFlight(now.Add(-90*time.Second), defaultEphemeralCommandInFlightWarnAfter)
+	h.trackInFlight(now.Add(-10*time.Minute), defaultCommandInFlightWarnAfter)
+
+	inFlight, overdue := h.inFlightCommandStats(now)
+	if inFlight != 2 || overdue != 1 {
+		t.Fatalf("mixed tiers: inFlight=%d overdue=%d, want 2/1", inFlight, overdue)
+	}
+
+	// Three hours later both have crossed their tiers.
+	inFlight, overdue = h.inFlightCommandStats(now.Add(3 * time.Hour))
+	if inFlight != 2 || overdue != 2 {
+		t.Fatalf("after 3h: inFlight=%d overdue=%d, want 2/2", inFlight, overdue)
+	}
+
+	// A command still inside its tier is in flight but not overdue.
+	hFresh := &Heartbeat{}
+	hFresh.trackInFlight(now.Add(-30*time.Second), defaultEphemeralCommandInFlightWarnAfter)
+	inFlight, overdue = hFresh.inFlightCommandStats(now)
+	if inFlight != 1 || overdue != 0 {
+		t.Fatalf("inside tier: inFlight=%d overdue=%d, want 1/0", inFlight, overdue)
+	}
+
+	// Untracking removes the entry from both gauges.
+	hGone := &Heartbeat{}
+	key := hGone.trackInFlight(now.Add(-3*time.Hour), defaultCommandInFlightWarnAfter)
+	hGone.untrackInFlight(key)
+	inFlight, overdue = hGone.inFlightCommandStats(now)
+	if inFlight != 0 || overdue != 0 {
+		t.Fatalf("after untrack: inFlight=%d overdue=%d, want 0/0", inFlight, overdue)
+	}
+}
+
+// TestInFlightGaugeReflectsPoolState verifies executeCommandViaPool registers
+// a command in the in-flight gauge for exactly the duration of its execution:
+// 1 while the handler is blocked, back to 0 once the result is returned.
+//
+// MUST NOT call t.Parallel(): mutates handlerRegistry.
+func TestInFlightGaugeReflectsPoolState(t *testing.T) {
+	const blockType = "test_2400_blocking_command"
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(unblock)
+
+	handlerRegistry[blockType] = func(h *Heartbeat, cmd Command) tools.CommandResult {
+		<-release
+		return tools.CommandResult{Status: "completed", Stdout: "blocked-ok"}
+	}
+	t.Cleanup(func() { delete(handlerRegistry, blockType) })
+
+	h := &Heartbeat{
+		stopChan: make(chan struct{}),
+		pool:     workerpool.New(1, 1),
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		h.pool.Shutdown(ctx)
+	})
+
+	done := make(chan tools.CommandResult, 1)
+	go func() {
+		done <- h.executeCommandViaPool(Command{
+			ID:      "inflight-gauge-1",
+			Type:    blockType,
+			Payload: map[string]any{},
+		})
+	}()
+
+	// The command must show up in the gauge while its handler is blocked.
+	waitForInFlight(t, h, 1)
+
+	// It is not overdue yet — the default (non-ephemeral) tier is hours away.
+	if _, overdue := h.inFlightCommandStats(time.Now()); overdue != 0 {
+		t.Fatalf("fresh command counted as overdue: %d", overdue)
+	}
+	// But the same snapshot taken far in the future crosses the tier.
+	if _, overdue := h.inFlightCommandStats(time.Now().Add(defaultCommandInFlightWarnAfter + time.Minute)); overdue != 1 {
+		t.Fatal("command past its tier not counted as overdue")
+	}
+
+	unblock()
+	result := <-done
+	if result.Status != "completed" || result.Stdout != "blocked-ok" {
+		t.Fatalf("unexpected result: status=%q stdout=%q error=%q", result.Status, result.Stdout, result.Error)
+	}
+
+	// Once the dispatch loop returns, the gauge must drop back to zero.
+	waitForInFlight(t, h, 0)
+}
+
+// TestEphemeralShortTierIsLogOnly verifies the short ephemeral tier behaves
+// exactly like the 2h tier: it warns but never fails or abandons the command,
+// even after the interval elapses several times.
+//
+// MUST NOT call t.Parallel(): mutates handlerRegistry.
+func TestEphemeralShortTierIsLogOnly(t *testing.T) {
+	if !isEphemeralCommand(tools.CmdTerminalData) {
+		t.Fatalf("precondition: %s must be ephemeral", tools.CmdTerminalData)
+	}
+
+	orig, hadOrig := handlerRegistry[tools.CmdTerminalData]
+	handlerRegistry[tools.CmdTerminalData] = func(h *Heartbeat, cmd Command) tools.CommandResult {
+		time.Sleep(120 * time.Millisecond) // several short-tier intervals
+		return tools.CommandResult{Status: "completed", Stdout: "slow-ephemeral-ok"}
+	}
+	t.Cleanup(func() {
+		if hadOrig {
+			handlerRegistry[tools.CmdTerminalData] = orig
+		} else {
+			delete(handlerRegistry, tools.CmdTerminalData)
+		}
+	})
+
+	h := &Heartbeat{
+		stopChan:                          make(chan struct{}),
+		pool:                              workerpool.New(1, 1),
+		ephemeralCommandInFlightWarnAfter: 20 * time.Millisecond,
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		h.pool.Shutdown(ctx)
+	})
+
+	result := h.executeCommandViaPool(Command{
+		ID:      "ephemeral-watchdog-1",
+		Type:    tools.CmdTerminalData,
+		Payload: map[string]any{},
+	})
+
+	if result.Status != "completed" {
+		t.Fatalf("short tier must not fail a slow ephemeral command: status=%q error=%q", result.Status, result.Error)
+	}
+	if result.Stdout != "slow-ephemeral-ok" {
+		t.Fatalf("expected the handler's real result, got stdout=%q", result.Stdout)
+	}
+}
+
+// waitForInFlight polls the in-flight gauge until it reports want, failing
+// the test after a generous deadline.
+func waitForInFlight(t *testing.T, h *Heartbeat, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		inFlight, _ := h.inFlightCommandStats(time.Now())
+		if inFlight == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("in-flight gauge never reached %d (last: %d)", want, inFlight)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}

--- a/apps/api/src/routes/agents/schemas.heartbeatTolerance.test.ts
+++ b/apps/api/src/routes/agents/schemas.heartbeatTolerance.test.ts
@@ -453,4 +453,38 @@ describe('heartbeatSchema — agentRuntime gauges (#2389)', () => {
     if (!result.success) return;
     expect(result.data.agentRuntime).toBeUndefined();
   });
+
+  // Worker-pool wedge gauges (#2400) ride the same agentRuntime object.
+  it('parses agentRuntime with wedge gauges (commandsInFlight/commandsOverdue)', () => {
+    const result = heartbeatSchema.safeParse({
+      ...minimal,
+      agentRuntime: { ...validRuntime, commandsInFlight: 3, commandsOverdue: 1 },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.agentRuntime?.commandsInFlight).toBe(3);
+    expect(result.data.agentRuntime?.commandsOverdue).toBe(1);
+  });
+
+  it('agentRuntime without wedge gauges (pre-#2400 agent) still parses whole', () => {
+    const result = heartbeatSchema.safeParse({ ...minimal, agentRuntime: validRuntime });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.agentRuntime).toBeDefined();
+    expect(result.data.agentRuntime?.commandsInFlight).toBeUndefined();
+    expect(result.data.agentRuntime?.commandsOverdue).toBeUndefined();
+  });
+
+  it('drops only the bad wedge gauge, keeping the rest of agentRuntime', () => {
+    const result = heartbeatSchema.safeParse({
+      ...minimal,
+      agentRuntime: { ...validRuntime, commandsInFlight: -2, commandsOverdue: 1 },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.agentRuntime).toBeDefined();
+    expect(result.data.agentRuntime?.commandsInFlight).toBeUndefined();
+    expect(result.data.agentRuntime?.commandsOverdue).toBe(1);
+    expect(result.data.agentRuntime?.goroutines).toBe(validRuntime.goroutines);
+  });
 });

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -209,6 +209,12 @@ export const heartbeatSchema = z.object({
     sysBytes: uint64Counter,
     numGc: z.number().int().min(0),
     goroutines: z.number().int().min(0),
+    // Worker-pool wedge gauges (#2400): commands currently executing on the
+    // pool and how many are overdue past their in-flight watchdog tier.
+    // Per-field optional + .catch so agents predating #2400 (which omit
+    // them) don't lose the whole agentRuntime object.
+    commandsInFlight: z.number().int().min(0).optional().catch(undefined),
+    commandsOverdue: z.number().int().min(0).optional().catch(undefined),
   }).optional().catch(undefined),
   role: z.enum(['agent', 'watchdog']).optional(),
   watchdogState: z.string().optional().catch(undefined),


### PR DESCRIPTION
Closes #2400

Two follow-ups from the #2387 worker-pool wedge investigation, unblocked by PR #2394 (agentRuntime heartbeat gauges) and PR #2395 (log-only in-flight watchdog).

## 1. Wedged/in-flight command count on the heartbeat

- `executeCommandViaPool` now registers every pool-dispatched command in an in-flight tracker (start time + its watchdog tier, keyed by a per-dispatch sequence number so duplicate command IDs can't clobber each other) and deregisters when the dispatch loop exits.
- The heartbeat reports two new gauges on the `agentRuntime` payload object from #2394: `commandsInFlight` (commands currently executing on the pool) and `commandsOverdue` (commands running longer than their watchdog tier — wedged-worker suspects). They land in `device_metrics.custom_metrics` through the existing #2394 persistence path, so no migration and no `heartbeat.ts` change.
- API `heartbeatSchema`: the new fields are per-field `.optional().catch(undefined)` inside the existing tolerant `agentRuntime` object, so pre-#2400 agents (which omit them) keep their whole `agentRuntime` object and a bad value drops only that field.

## 2. Short watchdog tier for ephemeral commands

- `isEphemeralCommand` types (terminal_data / tunnel_data / desktop input, which should complete in milliseconds) now get a **60s log-only** watchdog tier; everything else keeps the 2h default from #2395.
- Still strictly log-only — the watchdog never fails, kills, or abandons a command. The warn line now also includes the tier (`warnAfter`) so 60s-tier and 2h-tier warnings are distinguishable in shipped logs.

## Tests

- `agent/internal/heartbeat/heartbeat_inflight_stats_test.go`: injected-`now` overdue computation crossing each tier, live-pool gauge registration/deregistration around a blocked handler, tier selection (incl. override isolation between tiers), and log-only behavior of the short tier against the real `terminal_data` registry entry.
- `runtime_stats_test.go`: JSON wire-shape contract extended with the two new keys.
- `schemas.heartbeatTolerance.test.ts`: gauges parse, pre-#2400 agentRuntime still parses whole, bad gauge drops only itself.

## Verification

- `cd agent && go test -race ./internal/heartbeat/... ./internal/collectors/... ./internal/workerpool/...` — all ok
- `GOOS=windows/darwin/linux go build ./...` — all ok
- `vitest run schemas.heartbeatTolerance.test.ts` (34 passed) + `heartbeat.test.ts` (78 passed); `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)