### PR TITLE
feat(api): expose capture_pprof as MCP tool capture_agent_pprof (#2401)

### DIFF
--- a/apps/api/src/middleware/bodyLimit.test.ts
+++ b/apps/api/src/middleware/bodyLimit.test.ts
@@ -33,6 +33,22 @@ describe('bodyLimitForPath', () => {
     });
   });
 
+  // Regression for #2401: agent command results on the heartbeat/REST
+  // fallback leg can legitimately carry multi-MB stdout (capture_pprof
+  // profiles, big script output). commandResultSchema caps stdout/stderr at
+  // 5MB each; the body limit must not 413 a schema-valid result.
+  it('carves out agent command-result submissions at 12MB', () => {
+    expect(
+      bodyLimitForPath('/api/v1/agents/agent-1/commands/11111111-1111-4111-8111-111111111111/result'),
+    ).toEqual({
+      maxSize: 12 * MB,
+      error: 'Command result too large (max 12MB)',
+    });
+    // Sibling agent routes keep the default.
+    expect(bodyLimitForPath('/api/v1/agents/agent-1/commands').maxSize).toBe(1 * MB);
+    expect(bodyLimitForPath('/api/v1/agents/agent-1/heartbeat').maxSize).toBe(1 * MB);
+  });
+
   // Sized from the agent's 4MB file_write cap (~5.6MB base64 + JSON envelope);
   // the agent's WS read limit is derived from the same cap (issue #2399).
   it('carves out file-browser uploads at 8MB', () => {

--- a/apps/api/src/middleware/bodyLimit.ts
+++ b/apps/api/src/middleware/bodyLimit.ts
@@ -31,5 +31,15 @@ export function bodyLimitForPath(path: string): { maxSize: number; error: string
   if (path.match(/^\/api\/v1\/software\/catalog\/[^/]+\/versions\/upload$/)) {
     return { maxSize: 512 * 1024 * 1024, error: 'Package too large (max 500MB)' };
   }
+  // Agent command results submitted via the heartbeat/REST fallback leg (used
+  // when the WS path is unavailable). commandResultSchema already caps stdout
+  // and stderr at 5MB each; without this carve-out a large-but-valid result
+  // (e.g. a ~2.8MB capture_pprof profile payload, or big script output) is
+  // 413-rejected before the schema runs, the row never completes, and the
+  // caller sees a misleading generic timeout (#2401). 12MB covers both capped
+  // fields plus JSON escaping/envelope. Agent-authenticated route.
+  if (path.match(/^\/api\/v1\/agents\/[^/]+\/commands\/[^/]+\/result$/)) {
+    return { maxSize: 12 * 1024 * 1024, error: 'Command result too large (max 12MB)' };
+  }
   return { maxSize: 1024 * 1024, error: 'Request body too large' };
 }

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -497,6 +497,52 @@ describe('agent websocket command results', () => {
     expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
   });
 
+  it('stores capture_pprof stdout byte-for-byte on the WS leg (secret redaction would corrupt the base64 profiles, #2401)', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectOwnedCommandResult([
+        {
+          id: 'cmd-pprof',
+          type: 'capture_pprof',
+          payload: { profile: 'heap' },
+          deviceId: 'device-123'
+        }
+      ]) as any);
+
+    const updateChain = updateResult([{ id: 'cmd-pprof' }]);
+    vi.mocked(db.update).mockReturnValue(updateChain as any);
+
+    // Contains substrings the redaction patterns fire on (case-insensitive
+    // AKIA + 16 alnum; token=...); must be persisted unmodified.
+    const pprofStdout = JSON.stringify({
+      capturedAt: '2026-07-12T10:00:00Z',
+      heapProfileBase64: `QUJDakiAABCDEF1234567890abToken=abcdefgh12345678REVG${'Zm9v'.repeat(100)}`,
+      heapProfileBytes: 4096,
+    });
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: '22222222-2222-4222-8222-222222222222',
+        status: 'completed',
+        exitCode: 0,
+        stdout: pprofStdout,
+        stderr: 'password=supersecret123'
+      })
+    } as any, ws as any);
+
+    expect(db.update).toHaveBeenCalledTimes(1);
+    const stored = updateChain.set.mock.calls[0]![0] as { result: { stdout: string; stderr: string } };
+    expect(stored.result.stdout).toBe(pprofStdout);
+    // stderr is NOT exempt.
+    expect(stored.result.stderr).toContain('[REDACTED]');
+    expect(stored.result.stderr).not.toContain('supersecret123');
+  });
+
   it('rejects watchdog-targeted command results on the agent websocket', async () => {
     const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
 

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -32,6 +32,7 @@ import { isAgentTenantActive } from '../services/tenantStatus';
 import { createAuditLogAsync } from '../services/auditService';
 import { ANONYMOUS_ACTOR_ID, writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
 import { redactSecretsFromOutput } from '../services/secretRedaction';
+import { isRawStdoutArtifactCommand } from '../services/commandAudit';
 import { detectResultValidationFamily, validateCriticalCommandResult, DR_COMMAND_TYPES } from '../services/agentCommandResultValidation';
 import { updateRestoreJobByCommandId, updateRestoreJobFromResult } from '../services/restoreResultPersistence';
 import { captureException } from '../services/sentry';
@@ -605,7 +606,11 @@ function commandResultToStdout(result: AgentCommandResult): string | undefined {
     (result.result !== undefined ? JSON.stringify(result.result) : undefined);
 }
 
-function buildStoredCommandResult(result: AgentCommandResult, stdout: string | undefined) {
+function buildStoredCommandResult(
+  commandType: string,
+  result: AgentCommandResult,
+  stdout: string | undefined,
+) {
   // Finding #5 (WS leg): strip full PEM private-key blocks from agent output
   // BEFORE it is persisted into device_commands.result and later shown to
   // scripts:read users. Mirrors the REST ingest path
@@ -613,10 +618,15 @@ function buildStoredCommandResult(result: AgentCommandResult, stdout: string | u
   // server-side-visible output, so we redact here as defense-in-depth.
   // Preserve null/undefined (don't coerce to '') to keep the stored shape
   // stable; exitCode/status/durationMs are untouched.
+  //
+  // Exception: artifact-bearing stdout (capture_pprof base64 profiles) must be
+  // stored byte-for-byte -- the redaction patterns statistically fire inside
+  // megabytes of random base64 and would silently corrupt the artifact (#2401).
+  const skipStdoutRedaction = isRawStdoutArtifactCommand(commandType);
   return {
     status: result.status,
     exitCode: result.exitCode,
-    stdout: stdout != null ? redactSecretsFromOutput(stdout) : stdout,
+    stdout: stdout != null && !skipStdoutRedaction ? redactSecretsFromOutput(stdout) : stdout,
     stderr: result.stderr != null ? redactSecretsFromOutput(result.stderr) : result.stderr,
     durationMs: result.durationMs,
     error: result.error,
@@ -1524,7 +1534,7 @@ async function processCommandResult(
         .set({
             status: normalizedResult.status === 'completed' ? 'completed' : 'failed',
             completedAt: new Date(),
-            result: buildStoredCommandResult(normalizedResult, stdout)
+            result: buildStoredCommandResult(command.type, normalizedResult, stdout)
         })
         .where(
           and(

--- a/apps/api/src/routes/agents/commands.test.ts
+++ b/apps/api/src/routes/agents/commands.test.ts
@@ -236,6 +236,52 @@ describe('agent commands routes', () => {
     expect(serialized).not.toContain('BODYb64lineTwo');
   });
 
+  it('stores capture_pprof stdout byte-for-byte (secret redaction would corrupt the base64 profiles, #2401)', async () => {
+    selectMock.mockReturnValueOnce(
+      chainMock([
+        {
+          id: commandId,
+          deviceId: 'device-1',
+          type: 'capture_pprof',
+          status: 'sent',
+          targetRole: 'agent',
+        },
+      ])
+    );
+    const updateChain = chainMock([{ id: 'cmd-1' }]);
+    updateMock.mockReturnValueOnce(updateChain);
+
+    // Base64 profile payload containing substrings the redaction patterns
+    // fire on (case-insensitive AKIA + 16 alnum; token=...). In random
+    // base64 these occur by chance roughly once per ~MB — redaction would
+    // silently corrupt the gzip protobuf.
+    const pprofStdout = JSON.stringify({
+      capturedAt: '2026-07-12T10:00:00Z',
+      heapProfileBase64: `QUJDakiAABCDEF1234567890abToken=abcdefgh12345678REVG${'Zm9v'.repeat(100)}`,
+      heapProfileBytes: 4096,
+    });
+
+    const res = await app.request(`/agents/${agentId}/commands/${commandId}/result`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        commandId,
+        status: 'completed',
+        exitCode: 0,
+        stdout: pprofStdout,
+        stderr: `stderr-pre ${PRIVATE_KEY_BLOCK} stderr-post`,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+
+    const stored = updateChain.set.mock.calls[0][0];
+    // stdout is the artifact channel — byte-for-byte.
+    expect(stored.result.stdout).toBe(pprofStdout);
+    // stderr is NOT exempt.
+    expect(stored.result.stderr).toBe('stderr-pre [PRIVATE_KEY_REDACTED] stderr-post');
+  });
+
   it('redacts private-key blocks from the software-install deployment result path', async () => {
     // sw-install commandId embeds deployment + device UUIDs; the device UUID
     // must equal the authenticated agent's deviceId for the update to fire.

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -30,6 +30,7 @@ import { processBackupVerificationResult } from '../backup/verificationService';
 import { updateRestoreJobByCommandId } from '../../services/restoreResultPersistence';
 import { detectResultValidationFamily, validateCriticalCommandResult, DR_COMMAND_TYPES } from '../../services/agentCommandResultValidation';
 import { redactSecretsFromOutput } from '../../services/secretRedaction';
+import { isRawStdoutArtifactCommand } from '../../services/commandAudit';
 
 export const commandsRoutes = new Hono();
 const ACCEPTED_COMMAND_RESULT_STATUSES = ['pending', 'sent'] as const;
@@ -39,15 +40,24 @@ function commandResultToStdout(data: z.infer<typeof commandResultSchema>): strin
     (data.result !== undefined ? JSON.stringify(data.result) : undefined);
 }
 
-function buildStoredCommandResult(data: z.infer<typeof commandResultSchema>, stdout: string | undefined) {
+function buildStoredCommandResult(
+  commandType: string,
+  data: z.infer<typeof commandResultSchema>,
+  stdout: string | undefined,
+) {
   // Defense-in-depth: strip full PEM private-key blocks from agent output
   // before it is persisted and later shown to scripts:read users. Pre-update
   // agents don't redact server-side-visible output, so we redact here.
   // Preserve null/undefined (don't coerce to '') to keep the stored shape stable.
+  //
+  // Exception: artifact-bearing stdout (capture_pprof base64 profiles) must be
+  // stored byte-for-byte -- the redaction patterns statistically fire inside
+  // megabytes of random base64 and would silently corrupt the artifact (#2401).
+  const skipStdoutRedaction = isRawStdoutArtifactCommand(commandType);
   return {
     status: data.status,
     exitCode: data.exitCode,
-    stdout: stdout != null ? redactSecretsFromOutput(stdout) : stdout,
+    stdout: stdout != null && !skipStdoutRedaction ? redactSecretsFromOutput(stdout) : stdout,
     stderr: data.stderr != null ? redactSecretsFromOutput(data.stderr) : data.stderr,
     durationMs: data.durationMs,
     error: data.error != null ? redactSecretsFromOutput(data.error) : data.error,
@@ -250,7 +260,7 @@ commandsRoutes.post(
         .set({
           status: normalizedData.status === 'completed' ? 'completed' : 'failed',
           completedAt: new Date(),
-          result: buildStoredCommandResult(normalizedData, stdout),
+          result: buildStoredCommandResult(command.type, normalizedData, stdout),
           // Credentials ride the payload for some commands (e.g. FileVault
           // rotation); blank them once the command is terminal.
           ...(hasSensitivePayload(command.type) ? { payload: null } : {}),

--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -971,6 +971,44 @@ describe('device commands routes', () => {
       expect(JSON.stringify(body.data)).not.toContain('hunter2');
       expect(JSON.stringify(body.data)).not.toContain('abc123');
     });
+
+    it('passes through raw stdout for capture_pprof so profiles are retrievable (#2401)', async () => {
+      const pprofStdout = JSON.stringify({
+        capturedAt: '2026-07-12T10:00:00Z',
+        heapProfileBase64: 'aGVhcC1wcm9maWxlLWJ5dGVz',
+        heapProfileBytes: 2048,
+      });
+
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a',
+        orgId: 'org-123',
+        hostname: 'host-a',
+        status: 'online'
+      } as never);
+
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'cmd-pprof',
+              deviceId: 'device-a',
+              type: 'capture_pprof',
+              status: 'completed',
+              payload: { profile: 'heap' },
+              result: { status: 'completed', stdout: pprofStdout }
+            }])
+          })
+        })
+      } as never);
+
+      const res = await app.request('/devices/device-a/commands/cmd-pprof', {
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.result.stdout).toBe(pprofStdout);
+    });
   });
 
   describe('GET /devices/:id/commands', () => {

--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -1012,6 +1012,59 @@ describe('device commands routes', () => {
   });
 
   describe('GET /devices/:id/commands', () => {
+    it('keeps capture_pprof stdout redacted in the LIST endpoint (no raw pass-through)', async () => {
+      // The raw stdout pass-through is deliberately scoped to the
+      // single-command GET; history pages must never balloon by megabytes of
+      // base64 per capture_pprof row (#2401).
+      const pprofStdout = JSON.stringify({
+        heapProfileBase64: 'aGVhcC1wcm9maWxlLWJ5dGVz',
+        heapProfileBytes: 2048,
+      });
+
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a',
+        orgId: 'org-123',
+        hostname: 'host-a',
+        status: 'online'
+      } as never);
+
+      vi.mocked(db.select)
+        // count query
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 1 }])
+          })
+        } as never)
+        // page query
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockResolvedValue([{
+                    id: 'cmd-pprof',
+                    deviceId: 'device-a',
+                    type: 'capture_pprof',
+                    status: 'completed',
+                    payload: { profile: 'heap' },
+                    result: { status: 'completed', stdout: pprofStdout }
+                  }])
+                })
+              })
+            })
+          })
+        } as never);
+
+      const res = await app.request('/devices/device-a/commands', {
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data[0].result.stdout).toContain('stdout omitted');
+      expect(JSON.stringify(body)).not.toContain('aGVhcC1wcm9maWxlLWJ5dGVz');
+    });
+
     it('denies command history when the device is outside the caller site restriction', async () => {
       vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
         id: 'device-a',

--- a/apps/api/src/routes/devices/commands.ts
+++ b/apps/api/src/routes/devices/commands.ts
@@ -553,6 +553,8 @@ commandsRoutes.get(
       return c.json({ error: 'Command not found' }, 404);
     }
 
-    return c.json({ data: sanitizeCommandForHistory(command) });
+    // allowRawStdout only takes effect for artifact-bearing command types
+    // (capture_pprof profiles); everything else stays redacted (#2401).
+    return c.json({ data: sanitizeCommandForHistory(command, { allowRawStdout: true }) });
   }
 );

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -132,6 +132,7 @@ export const TOOL_TIERS = {
   // Agent log tools
   search_agent_logs: 1,
   set_agent_log_level: 2,
+  capture_agent_pprof: 2,
   // Event log tools
   search_logs: 1,
   get_log_trends: 1,
@@ -1516,6 +1517,16 @@ export function createBreezeMcpServer(
         durationMinutes: z.number().int().min(1).max(1440).optional(),
       },
       makeHandler('set_agent_log_level', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'capture_agent_pprof',
+      "Capture Go runtime pprof profiles (heap and/or goroutine) from a device's Breeze agent process for memory/goroutine-leak diagnostics. Returns profile metadata only; the raw profiles are stored on the command result for download.",
+      {
+        deviceId: uuid,
+        profile: z.enum(['heap', 'goroutine', 'all']).optional(),
+      },
+      makeHandler('capture_agent_pprof', getAuth, onPreToolUse, onPostToolUse)
     ),
 
     // Event log tools

--- a/apps/api/src/services/aiAgentSystemPrompt.ts
+++ b/apps/api/src/services/aiAgentSystemPrompt.ts
@@ -94,7 +94,7 @@ Policy inheritance flows top-down; lower levels override higher with priority or
 - **Services & Processes**: manage_services, manage_processes, manage_startup_items, manage_scheduled_tasks
 - **Files & Disk**: file_operations, analyze_disk_usage, disk_cleanup, registry_operations
 - **Remote Access**: take_screenshot, analyze_screen, computer_control
-- **Logs**: search_logs, get_log_trends, detect_log_correlations, search_agent_logs, set_agent_log_level, query_audit_log, query_change_log
+- **Logs**: search_logs, get_log_trends, detect_log_correlations, search_agent_logs, set_agent_log_level, capture_agent_pprof, query_audit_log, query_change_log
 - **Backup**: query_backups, get_backup_status, browse_snapshots, trigger_backup, restore_snapshot, restore_as_vm, instant_boot_vm, get_vm_restore_estimate, query_mssql_instances, get_mssql_backup_status, trigger_mssql_backup, restore_mssql_database, verify_mssql_backup, query_hyperv_vms, get_hyperv_vm_details, manage_hyperv_vm, trigger_hyperv_backup, restore_hyperv_vm, manage_hyperv_checkpoints, query_vaults, get_vault_status, trigger_vault_sync, configure_vault, query_c2c_connections, query_c2c_jobs, search_c2c_items, trigger_c2c_sync, restore_c2c_items, query_backup_sla, get_sla_breaches, get_sla_compliance_report, configure_backup_sla, query_dr_plans, get_dr_plan_details, get_dr_execution_status, execute_dr_plan, manage_dr_plan, manage_backup_configs
 - **Network**: network_discovery, configure_network_baseline, get_network_changes
 - **Groups**: manage_groups (list/get/create/update/delete/add_devices/remove_devices)

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -332,6 +332,7 @@ export const TOOL_PERMISSIONS: Record<string, { resource: string; action: string
   // Agent log tools
   search_agent_logs: { resource: 'devices', action: 'read' },
   set_agent_log_level: { resource: 'devices', action: 'execute' },
+  capture_agent_pprof: { resource: 'devices', action: 'execute' },
   // Event log tools
   search_logs: { resource: 'devices', action: 'read' },
   get_log_trends: { resource: 'devices', action: 'read' },
@@ -576,6 +577,7 @@ const TOOL_RATE_LIMITS: Record<string, { limit: number; windowSeconds: number }>
   detect_log_correlations: { limit: 10, windowSeconds: 300 },
   // Agent log tools
   set_agent_log_level: { limit: 5, windowSeconds: 600 },
+  capture_agent_pprof: { limit: 3, windowSeconds: 600 },
   // Configuration policy tools
   get_configuration_policy: { limit: 30, windowSeconds: 300 },
   manage_configuration_policy: { limit: 20, windowSeconds: 300 },
@@ -946,6 +948,11 @@ function buildApprovalDescription(
       parts.push(`Set log level to ${input.level}`);
       if (input.deviceId) parts.push(`on device ${(input.deviceId as string).slice(0, 8)}...`);
       if (input.durationMinutes) parts.push(`for ${input.durationMinutes} minutes`);
+      break;
+
+    case 'capture_agent_pprof':
+      parts.push(`Capture agent ${(input.profile as string) ?? 'all'} pprof profile(s)`);
+      if (input.deviceId) parts.push(`on device ${(input.deviceId as string).slice(0, 8)}...`);
       break;
 
     case 'apply_configuration_policy':

--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -1029,6 +1029,11 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
     durationMinutes: z.number().int().min(1).max(1440).optional(),
   }),
 
+  capture_agent_pprof: z.object({
+    deviceId: uuid,
+    profile: z.enum(['heap', 'goroutine', 'all']).optional(),
+  }),
+
   // Event log tools
   search_logs: z.object({
     query: z.string().max(500).optional(),

--- a/apps/api/src/services/aiToolsAgentLogs.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.siteScope.test.ts
@@ -10,7 +10,12 @@ vi.mock('./commandQueue', () => ({
   queueCommandForExecution: vi.fn(async () => ({ command: { id: 'c1', status: 'sent' } })),
   executeCommand: vi.fn(async () => ({
     status: 'completed',
-    stdout: JSON.stringify({ capturedAt: '2026-07-12T10:00:00Z', runtime: { goroutines: 1 } }),
+    stdout: JSON.stringify({
+      capturedAt: '2026-07-12T10:00:00Z',
+      runtime: { goroutines: 1 },
+      goroutineProfileBase64: 'Zm9v',
+      goroutineProfileBytes: 3,
+    }),
     commandId: 'c2',
   })),
 }));

--- a/apps/api/src/services/aiToolsAgentLogs.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.siteScope.test.ts
@@ -8,6 +8,11 @@ vi.mock('../db', () => ({
 }));
 vi.mock('./commandQueue', () => ({
   queueCommandForExecution: vi.fn(async () => ({ command: { id: 'c1', status: 'sent' } })),
+  executeCommand: vi.fn(async () => ({
+    status: 'completed',
+    stdout: JSON.stringify({ capturedAt: '2026-07-12T10:00:00Z', runtime: { goroutines: 1 } }),
+    commandId: 'c2',
+  })),
 }));
 vi.mock('./logRedaction', () => ({ redactAgentLogRow: (r: any) => ({ message: r.message, fields: r.fields }) }));
 
@@ -43,6 +48,22 @@ describe('set_agent_log_level — site scoping (per-device write)', () => {
   it('unrestricted caller is unaffected', async () => {
     mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', siteId: 'site-Z' }]) }) }) });
     const r = await handlerFor('set_agent_log_level')({ deviceId: 'd1', level: 'debug' }, makeAuth(undefined));
+    expect(r).not.toContain('access denied');
+  });
+});
+
+describe('capture_agent_pprof — site scoping (per-device write)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('denies a device in a forbidden site', async () => {
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', siteId: 'site-B' }]) }) }) });
+    const r = await handlerFor('capture_agent_pprof')({ deviceId: 'd1' }, makeAuth(['site-A']));
+    expect(r).toContain('access denied');
+  });
+
+  it('unrestricted caller is unaffected', async () => {
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'd1', siteId: 'site-Z' }]) }) }) });
+    const r = await handlerFor('capture_agent_pprof')({ deviceId: 'd1' }, makeAuth(undefined));
     expect(r).not.toContain('access denied');
   });
 });

--- a/apps/api/src/services/aiToolsAgentLogs.test.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.test.ts
@@ -12,11 +12,12 @@ vi.mock('../db', () => ({
 
 vi.mock('./commandQueue', () => ({
   queueCommandForExecution: vi.fn(),
+  executeCommand: vi.fn(),
 }));
 
 import { registerAgentLogTools } from './aiToolsAgentLogs';
 import { db } from '../db';
-import { queueCommandForExecution } from './commandQueue';
+import { queueCommandForExecution, executeCommand } from './commandQueue';
 import type { AiTool } from './aiTools';
 import type { AuthContext } from '../middleware/auth';
 
@@ -48,9 +49,10 @@ describe('aiToolsAgentLogs', () => {
     registerAgentLogTools(tools);
   });
 
-  it('should register search_agent_logs and set_agent_log_level', () => {
+  it('should register search_agent_logs, set_agent_log_level and capture_agent_pprof', () => {
     expect(tools.has('search_agent_logs')).toBe(true);
     expect(tools.has('set_agent_log_level')).toBe(true);
+    expect(tools.has('capture_agent_pprof')).toBe(true);
   });
 
   it('search_agent_logs should be tier 1', () => {
@@ -61,6 +63,12 @@ describe('aiToolsAgentLogs', () => {
   it('set_agent_log_level should be tier 2', () => {
     const tool = tools.get('set_agent_log_level')!;
     expect(tool.tier).toBe(2);
+  });
+
+  it('capture_agent_pprof should be tier 2 with deviceId device arg', () => {
+    const tool = tools.get('capture_agent_pprof')!;
+    expect(tool.tier).toBe(2);
+    expect(tool.deviceArgs).toEqual(['deviceId']);
   });
 
   describe('search_agent_logs', () => {
@@ -257,6 +265,162 @@ describe('aiToolsAgentLogs', () => {
         { level: 'info', durationMinutes: 60 },
         { userId: 'user-1' },
       );
+    });
+  });
+
+  describe('capture_agent_pprof', () => {
+    const capturedStdout = JSON.stringify({
+      capturedAt: '2026-07-12T10:00:00Z',
+      runtime: { heapAllocBytes: 1024, goroutines: 42 },
+      heapProfileBase64: 'aGVhcC1wcm9maWxlLWJ5dGVz',
+      heapProfileBytes: 2048,
+      goroutineProfileBase64: 'Z29yb3V0aW5lLXByb2ZpbGUtYnl0ZXM=',
+      goroutineProfileBytes: 512,
+    });
+
+    it('should return error without org context', async () => {
+      const tool = tools.get('capture_agent_pprof')!;
+      const result = await tool.handler({ deviceId: 'dev-1' }, { user: { id: 'u1' } } as any);
+      const parsed = JSON.parse(result);
+      expect(parsed.error).toContain('No organization context');
+    });
+
+    it('should return error without deviceId', async () => {
+      const tool = tools.get('capture_agent_pprof')!;
+      const result = await tool.handler({}, makeAuth('org-1'));
+      const parsed = JSON.parse(result);
+      expect(parsed.error).toContain('deviceId is required');
+      expect(executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('should reject an unknown profile without dispatching a command', async () => {
+      const tool = tools.get('capture_agent_pprof')!;
+      const result = await tool.handler(
+        { deviceId: 'dev-1', profile: 'cpu' },
+        makeAuth('org-1'),
+      );
+      const parsed = JSON.parse(result);
+      expect(parsed.error).toContain('Invalid profile "cpu"');
+      expect(executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('should execute the capture_pprof command type and default profile to all', async () => {
+      mockDeviceSelect('dev-1');
+      vi.mocked(executeCommand).mockResolvedValue({
+        status: 'completed',
+        stdout: capturedStdout,
+        commandId: 'cmd-pprof-1',
+      } as any);
+
+      const tool = tools.get('capture_agent_pprof')!;
+      const result = await tool.handler({ deviceId: 'dev-1' }, makeAuth('org-1'));
+
+      expect(executeCommand).toHaveBeenCalledWith(
+        'dev-1',
+        'capture_pprof',
+        { profile: 'all' },
+        { userId: 'user-1', timeoutMs: 30000 },
+      );
+
+      const parsed = JSON.parse(result);
+      expect(parsed.status).toBe('completed');
+      expect(parsed.commandId).toBe('cmd-pprof-1');
+      expect(parsed.capturedAt).toBe('2026-07-12T10:00:00Z');
+      expect(parsed.runtime).toEqual({ heapAllocBytes: 1024, goroutines: 42 });
+      expect(parsed.profiles).toEqual({
+        heap: { sizeBytes: 2048 },
+        goroutine: { sizeBytes: 512 },
+      });
+    });
+
+    it('should pass an explicit profile through to the agent command', async () => {
+      mockDeviceSelect('dev-1');
+      vi.mocked(executeCommand).mockResolvedValue({
+        status: 'completed',
+        stdout: JSON.stringify({
+          capturedAt: '2026-07-12T10:00:00Z',
+          runtime: { goroutines: 7 },
+          goroutineProfileBase64: 'Zm9v',
+          goroutineProfileBytes: 3,
+        }),
+        commandId: 'cmd-pprof-2',
+      } as any);
+
+      const tool = tools.get('capture_agent_pprof')!;
+      const result = await tool.handler(
+        { deviceId: 'dev-1', profile: 'goroutine' },
+        makeAuth('org-1'),
+      );
+
+      expect(executeCommand).toHaveBeenCalledWith(
+        'dev-1',
+        'capture_pprof',
+        { profile: 'goroutine' },
+        { userId: 'user-1', timeoutMs: 30000 },
+      );
+      const parsed = JSON.parse(result);
+      expect(parsed.profiles).toEqual({ goroutine: { sizeBytes: 3 } });
+    });
+
+    it('must NOT inline base64 profile data into the tool output', async () => {
+      mockDeviceSelect('dev-1');
+      vi.mocked(executeCommand).mockResolvedValue({
+        status: 'completed',
+        stdout: capturedStdout,
+        commandId: 'cmd-pprof-3',
+      } as any);
+
+      const tool = tools.get('capture_agent_pprof')!;
+      const result = await tool.handler({ deviceId: 'dev-1' }, makeAuth('org-1'));
+
+      expect(result).not.toContain('aGVhcC1wcm9maWxlLWJ5dGVz');
+      expect(result).not.toContain('Z29yb3V0aW5lLXByb2ZpbGUtYnl0ZXM=');
+      // But it must tell the caller where to get the artifact.
+      const parsed = JSON.parse(result);
+      expect(parsed.retrieval).toContain('/devices/dev-1/commands/cmd-pprof-3');
+    });
+
+    it('should return error when device is not in the org', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as any);
+
+      const tool = tools.get('capture_agent_pprof')!;
+      const result = await tool.handler({ deviceId: 'dev-other' }, makeAuth('org-1'));
+      const parsed = JSON.parse(result);
+      expect(parsed.error).toContain('Device not found or access denied');
+      expect(executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('should surface command failure', async () => {
+      mockDeviceSelect('dev-1');
+      vi.mocked(executeCommand).mockResolvedValue({
+        status: 'failed',
+        error: 'Device is offline, cannot execute command',
+      } as any);
+
+      const tool = tools.get('capture_agent_pprof')!;
+      const result = await tool.handler({ deviceId: 'dev-1' }, makeAuth('org-1'));
+      const parsed = JSON.parse(result);
+      expect(parsed.error).toBe('Device is offline, cannot execute command');
+    });
+
+    it('should handle unparseable agent output', async () => {
+      mockDeviceSelect('dev-1');
+      vi.mocked(executeCommand).mockResolvedValue({
+        status: 'completed',
+        stdout: 'not-json',
+        commandId: 'cmd-pprof-4',
+      } as any);
+
+      const tool = tools.get('capture_agent_pprof')!;
+      const result = await tool.handler({ deviceId: 'dev-1' }, makeAuth('org-1'));
+      const parsed = JSON.parse(result);
+      expect(parsed.error).toContain('Failed to parse profile capture response');
     });
   });
 });

--- a/apps/api/src/services/aiToolsAgentLogs.test.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.test.ts
@@ -409,7 +409,7 @@ describe('aiToolsAgentLogs', () => {
       expect(parsed.error).toBe('Device is offline, cannot execute command');
     });
 
-    it('should handle unparseable agent output', async () => {
+    it('should handle unparseable agent output and still return the commandId', async () => {
       mockDeviceSelect('dev-1');
       vi.mocked(executeCommand).mockResolvedValue({
         status: 'completed',
@@ -421,6 +421,25 @@ describe('aiToolsAgentLogs', () => {
       const result = await tool.handler({ deviceId: 'dev-1' }, makeAuth('org-1'));
       const parsed = JSON.parse(result);
       expect(parsed.error).toContain('Failed to parse profile capture response');
+      expect(parsed.commandId).toBe('cmd-pprof-4');
+    });
+
+    it('should NOT report success when a completed result carries no profile data', async () => {
+      mockDeviceSelect('dev-1');
+      vi.mocked(executeCommand).mockResolvedValue({
+        status: 'completed',
+        // Valid JSON but no heapProfileBytes/goroutineProfileBytes fields
+        // (agent/API contract drift or stdout lost in transit).
+        stdout: JSON.stringify({ capturedAt: '2026-07-12T10:00:00Z' }),
+        commandId: 'cmd-pprof-5',
+      } as any);
+
+      const tool = tools.get('capture_agent_pprof')!;
+      const result = await tool.handler({ deviceId: 'dev-1' }, makeAuth('org-1'));
+      const parsed = JSON.parse(result);
+      expect(parsed.status).toBeUndefined();
+      expect(parsed.error).toContain('no profile data');
+      expect(parsed.commandId).toBe('cmd-pprof-5');
     });
   });
 });

--- a/apps/api/src/services/aiToolsAgentLogs.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.ts
@@ -303,7 +303,12 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
         });
 
         if (result.status !== 'completed') {
-          return JSON.stringify({ error: result.error || 'Profile capture failed' });
+          return JSON.stringify({
+            error: result.error || 'Profile capture failed',
+            // Present when the command row was created before failing —
+            // lets the operator inspect the stored result/stderr.
+            commandId: result.commandId ?? null,
+          });
         }
 
         // The agent returns the profiles base64-encoded in stdout (up to
@@ -313,8 +318,14 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
         try {
           captured = JSON.parse(result.stdout ?? '{}');
         } catch (parseErr) {
-          console.error('[ai:capture_agent_pprof] Failed to parse capture result', parseErr);
-          return JSON.stringify({ error: 'Failed to parse profile capture response' });
+          console.error(
+            `[ai:capture_agent_pprof] Failed to parse capture result (deviceId=${deviceId}, commandId=${result.commandId ?? 'unknown'})`,
+            parseErr,
+          );
+          return JSON.stringify({
+            error: 'Failed to parse profile capture response',
+            commandId: result.commandId ?? null,
+          });
         }
 
         const profiles: Record<string, { sizeBytes: number }> = {};
@@ -323,6 +334,19 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
         }
         if (typeof captured.goroutineProfileBytes === 'number') {
           profiles.goroutine = { sizeBytes: captured.goroutineProfileBytes };
+        }
+
+        // A completed command whose stdout carries no profile fields means
+        // the agent/API contract drifted (or stdout was lost in transit).
+        // Don't dress that up as success.
+        if (Object.keys(profiles).length === 0) {
+          console.error(
+            `[ai:capture_agent_pprof] Completed capture returned no profile data (deviceId=${deviceId}, commandId=${result.commandId ?? 'unknown'})`,
+          );
+          return JSON.stringify({
+            error: 'Profile capture completed but returned no profile data (agent/API version mismatch?)',
+            commandId: result.commandId ?? null,
+          });
         }
 
         return JSON.stringify({

--- a/apps/api/src/services/aiToolsAgentLogs.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.ts
@@ -4,6 +4,7 @@
  * Tools for searching agent diagnostic logs and controlling log levels.
  * - search_agent_logs (Tier 1): Query logs across fleet with filters
  * - set_agent_log_level (Tier 2): Temporarily adjust agent log verbosity
+ * - capture_agent_pprof (Tier 2): On-demand Go runtime profiles from the agent
  */
 
 import { db } from '../db';
@@ -229,6 +230,117 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
         const message = err instanceof Error ? err.message : 'Internal error';
         console.error('[ai:set_agent_log_level]', message, err);
         return JSON.stringify({ error: `Failed to set log level: ${message}` });
+      }
+    },
+  });
+
+  // ============================================
+  // 3. capture_agent_pprof — On-demand runtime profiles (#2401)
+  // ============================================
+
+  registerTool({
+    tier: 2 as AiToolTier,
+    deviceArgs: ['deviceId'],
+    definition: {
+      name: 'capture_agent_pprof',
+      description:
+        "Capture Go runtime pprof profiles (heap and/or goroutine) from a device's Breeze agent process, for diagnosing agent memory growth or goroutine leaks. Returns profile metadata only (byte sizes, capture time, runtime gauges including goroutine count) — the raw profiles are stored on the command result and can be downloaded from the device command API for analysis with `go tool pprof`. Requires approval.",
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          deviceId: {
+            type: 'string',
+            description: 'The device UUID whose agent to profile',
+          },
+          profile: {
+            type: 'string',
+            enum: ['heap', 'goroutine', 'all'],
+            description: 'Which profile(s) to capture (default: all)',
+          },
+        },
+        required: ['deviceId'],
+      },
+    },
+    handler: async (input: Record<string, unknown>, auth: AuthContext) => {
+      try {
+        const orgId = getOrgId(auth);
+        if (!orgId) {
+          return JSON.stringify({ error: 'No organization context available' });
+        }
+
+        const deviceId = input.deviceId as string;
+        if (!deviceId) {
+          return JSON.stringify({ error: 'deviceId is required' });
+        }
+
+        const profile = (input.profile as string | undefined) ?? 'all';
+        if (!['heap', 'goroutine', 'all'].includes(profile)) {
+          return JSON.stringify({
+            error: `Invalid profile "${profile}": must be heap, goroutine, or all`,
+          });
+        }
+
+        // Verify device belongs to the caller's organization
+        const [device] = await db
+          .select({ id: devices.id, siteId: devices.siteId })
+          .from(devices)
+          .where(and(eq(devices.id, deviceId), eq(devices.orgId, orgId)))
+          .limit(1);
+
+        if (!device) {
+          return JSON.stringify({ error: 'Device not found or access denied' });
+        }
+        // Site axis (app-layer only; RLS does NOT enforce it).
+        if (deviceSiteDenied(auth, device.siteId)) {
+          return JSON.stringify({ error: 'Device not found or access denied' });
+        }
+
+        const { executeCommand } = await import('./commandQueue');
+
+        const result = await executeCommand(deviceId, 'capture_pprof', { profile }, {
+          userId: auth.user.id,
+          timeoutMs: 30000,
+        });
+
+        if (result.status !== 'completed') {
+          return JSON.stringify({ error: result.error || 'Profile capture failed' });
+        }
+
+        // The agent returns the profiles base64-encoded in stdout (up to
+        // ~2.7 MB for "all"). NEVER inline them into the AI transcript —
+        // return metadata and point at the persisted command result instead.
+        let captured: Record<string, unknown>;
+        try {
+          captured = JSON.parse(result.stdout ?? '{}');
+        } catch (parseErr) {
+          console.error('[ai:capture_agent_pprof] Failed to parse capture result', parseErr);
+          return JSON.stringify({ error: 'Failed to parse profile capture response' });
+        }
+
+        const profiles: Record<string, { sizeBytes: number }> = {};
+        if (typeof captured.heapProfileBytes === 'number') {
+          profiles.heap = { sizeBytes: captured.heapProfileBytes };
+        }
+        if (typeof captured.goroutineProfileBytes === 'number') {
+          profiles.goroutine = { sizeBytes: captured.goroutineProfileBytes };
+        }
+
+        return JSON.stringify({
+          status: 'completed',
+          commandId: result.commandId ?? null,
+          capturedAt: captured.capturedAt ?? null,
+          // Runtime gauges at capture time (heapAllocBytes, heapInuseBytes,
+          // sysBytes, numGc, goroutines) for correlating with the profiles.
+          runtime: captured.runtime ?? null,
+          profiles,
+          retrieval: result.commandId
+            ? `Raw profiles are base64-encoded gzip protobuf (the format \`go tool pprof\` consumes), stored on the command result. Fetch GET /devices/${deviceId}/commands/${result.commandId} and decode the heapProfileBase64 / goroutineProfileBase64 fields from the result stdout JSON. Do NOT re-fetch them into this conversation.`
+            : 'Profiles captured but the command id was unavailable; look up the latest capture_pprof command for this device in the command history.',
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Internal error';
+        console.error('[ai:capture_agent_pprof]', message, err);
+        return JSON.stringify({ error: `Profile capture failed: ${message}` });
       }
     },
   });

--- a/apps/api/src/services/commandAudit.test.ts
+++ b/apps/api/src/services/commandAudit.test.ts
@@ -72,4 +72,55 @@ describe('commandAudit', () => {
       stderr: '[REDACTED]: stderr omitted from command history',
     });
   });
+
+  describe('capture_pprof raw stdout pass-through (#2401)', () => {
+    const pprofStdout = JSON.stringify({
+      capturedAt: '2026-07-12T10:00:00Z',
+      heapProfileBase64: 'aGVhcC1wcm9maWxlLWJ5dGVz',
+      heapProfileBytes: 2048,
+    });
+
+    it('keeps capture_pprof stdout when allowRawStdout is set (single-command GET)', () => {
+      const command = sanitizeCommandForHistory(
+        {
+          id: 'cmd-4',
+          type: 'capture_pprof',
+          payload: { profile: 'heap' },
+          result: { status: 'completed', stdout: pprofStdout, stderr: 'noise' },
+        },
+        { allowRawStdout: true },
+      );
+
+      expect((command.result as { stdout: string }).stdout).toBe(pprofStdout);
+      // stderr is never passed through, even for allowlisted types.
+      expect((command.result as { stderr: string }).stderr).toContain('stderr omitted');
+    });
+
+    it('still redacts capture_pprof stdout without the opt-in (list endpoints)', () => {
+      const command = sanitizeCommandForHistory({
+        id: 'cmd-5',
+        type: 'capture_pprof',
+        payload: { profile: 'heap' },
+        result: { status: 'completed', stdout: pprofStdout },
+      });
+
+      expect((command.result as { stdout: string }).stdout).toContain('stdout omitted');
+      expect(JSON.stringify(command)).not.toContain('aGVhcC1wcm9maWxlLWJ5dGVz');
+    });
+
+    it('never passes through stdout for non-allowlisted command types, even with the opt-in', () => {
+      const command = sanitizeCommandForHistory(
+        {
+          id: 'cmd-6',
+          type: 'script',
+          payload: { content: 'echo secret' },
+          result: { status: 'completed', stdout: 'token=abc123' },
+        },
+        { allowRawStdout: true },
+      );
+
+      expect((command.result as { stdout: string }).stdout).toContain('stdout omitted');
+      expect(JSON.stringify(command)).not.toContain('abc123');
+    });
+  });
 });

--- a/apps/api/src/services/commandAudit.test.ts
+++ b/apps/api/src/services/commandAudit.test.ts
@@ -80,6 +80,33 @@ describe('commandAudit', () => {
       heapProfileBytes: 2048,
     });
 
+    it('passes multi-KB stdout through byte-for-byte, bypassing the 4096-char truncation and secret patterns', () => {
+      // Real pprof stdout is megabytes of base64. The sanitizer's default
+      // pass truncates strings at 4096 chars and rewrites secret-shaped
+      // substrings — either would silently corrupt the profile. This pins
+      // that the raw override wins: exact equality on a >4096-char payload
+      // containing a secret-shaped substring.
+      const bigBase64 = 'QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo='.repeat(300); // ~10,800 chars
+      const withSecretShape = JSON.stringify({
+        capturedAt: '2026-07-12T10:00:00Z',
+        heapProfileBase64: `${bigBase64}token=abcdefgh12345678${bigBase64}`,
+        heapProfileBytes: 999999,
+      });
+      expect(withSecretShape.length).toBeGreaterThan(4096);
+
+      const command = sanitizeCommandForHistory(
+        {
+          id: 'cmd-big',
+          type: 'capture_pprof',
+          payload: { profile: 'heap' },
+          result: { status: 'completed', stdout: withSecretShape },
+        },
+        { allowRawStdout: true },
+      );
+
+      expect((command.result as { stdout: string }).stdout).toBe(withSecretShape);
+    });
+
     it('keeps capture_pprof stdout when allowRawStdout is set (single-command GET)', () => {
       const command = sanitizeCommandForHistory(
         {

--- a/apps/api/src/services/commandAudit.ts
+++ b/apps/api/src/services/commandAudit.ts
@@ -66,21 +66,50 @@ export function commandAuditDetails(
   };
 }
 
-export function sanitizeCommandResultForHistory(result: CommandResult | null | undefined): unknown {
+/**
+ * Command types whose result stdout is a machine artifact with no tenant or
+ * secret content, and whose only delivery channel IS the stored command
+ * result. `capture_pprof` stdout is JSON carrying base64 gzip-protobuf Go
+ * runtime profiles of the agent's own process (heap allocation sites /
+ * goroutine stacks of our binary) — nothing user-generated to leak, and
+ * redacting it would make the profiles unretrievable (#2401).
+ */
+const RAW_STDOUT_COMMAND_TYPES = new Set(['capture_pprof']);
+
+export function sanitizeCommandResultForHistory(
+  result: CommandResult | null | undefined,
+  opts: { keepRawStdout?: boolean } = {},
+): unknown {
   if (!isRecord(result)) return result ?? null;
   const sanitized = sanitizeAuditPayload(result, { maxStringLength: 4096 });
 
   return {
     ...(isRecord(sanitized) ? sanitized : {}),
-    stdout: typeof result.stdout === 'string' ? `${REDACTED}: stdout omitted from command history` : result.stdout,
+    stdout:
+      typeof result.stdout === 'string'
+        ? opts.keepRawStdout
+          ? result.stdout
+          : `${REDACTED}: stdout omitted from command history`
+        : result.stdout,
     stderr: typeof result.stderr === 'string' ? `${REDACTED}: stderr omitted from command history` : result.stderr,
   };
 }
 
-export function sanitizeCommandForHistory<T extends { type: string; payload?: unknown; result?: unknown }>(command: T): T {
+export function sanitizeCommandForHistory<T extends { type: string; payload?: unknown; result?: unknown }>(
+  command: T,
+  opts: {
+    /**
+     * Opt-in stdout pass-through, honored only for RAW_STDOUT_COMMAND_TYPES.
+     * Only the single-command GET sets this — list endpoints stay redacted so
+     * pages of history never balloon by megabytes of base64 per profile row.
+     */
+    allowRawStdout?: boolean;
+  } = {},
+): T {
+  const keepRawStdout = opts.allowRawStdout === true && RAW_STDOUT_COMMAND_TYPES.has(command.type);
   return {
     ...command,
     payload: sanitizeCommandPayloadForAudit(command.type, command.payload as CommandPayload | null | undefined),
-    result: sanitizeCommandResultForHistory(command.result as CommandResult | null | undefined),
+    result: sanitizeCommandResultForHistory(command.result as CommandResult | null | undefined, { keepRawStdout }),
   } as T;
 }

--- a/apps/api/src/services/commandAudit.ts
+++ b/apps/api/src/services/commandAudit.ts
@@ -73,8 +73,24 @@ export function commandAuditDetails(
  * runtime profiles of the agent's own process (heap allocation sites /
  * goroutine stacks of our binary) — nothing user-generated to leak, and
  * redacting it would make the profiles unretrievable (#2401).
+ *
+ * String literal (not CommandTypes.CAPTURE_PPROF) on purpose: commandQueue.ts
+ * imports this module, so a value import back into commandQueue would create
+ * a runtime import cycle.
  */
 const RAW_STDOUT_COMMAND_TYPES = new Set(['capture_pprof']);
+
+/**
+ * True when a command type's stdout is an opaque machine artifact that must
+ * be stored byte-for-byte. Both result-ingest legs (agent WS + REST) use this
+ * to skip `redactSecretsFromOutput` on stdout: the secret patterns
+ * (case-insensitive AKIA + 16 alnum, etc.) statistically fire inside
+ * megabytes of random base64 and would silently corrupt the profile bytes.
+ * stderr/error redaction is never skipped.
+ */
+export function isRawStdoutArtifactCommand(type: string): boolean {
+  return RAW_STDOUT_COMMAND_TYPES.has(type);
+}
 
 export function sanitizeCommandResultForHistory(
   result: CommandResult | null | undefined,

--- a/apps/api/src/services/commandQueue.test.ts
+++ b/apps/api/src/services/commandQueue.test.ts
@@ -385,6 +385,56 @@ describe('command queue service', () => {
     expect(result).toEqual({ ...completed.result, commandId: completed.id });
   });
 
+  // Behavioral pin for AUDITED_COMMANDS membership: capture_pprof is a
+  // privileged diagnostic, so dispatching it must write an audit_logs row.
+  // AUDITED_COMMANDS is module-private, so removal of the entry would be
+  // invisible without this test (#2401).
+  it('writes an audit log when executing capture_pprof', async () => {
+    const device = { id: 'dev-2', status: 'online', orgId: 'org-1', hostname: 'host-a', agentId: null };
+    const queued = { id: 'cmd-pprof' };
+    const completed = {
+      id: 'cmd-pprof',
+      status: 'completed',
+      result: { status: 'completed', stdout: '{}' }
+    };
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([device])
+          })
+        })
+      } as any)
+      .mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([completed])
+          })
+        })
+      } as any);
+
+    const auditValues = vi.fn().mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) });
+    vi.mocked(db.insert)
+      .mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([queued])
+        })
+      } as any)
+      .mockReturnValueOnce({ values: auditValues } as any);
+
+    const result = await executeCommand('dev-2', CommandTypes.CAPTURE_PPROF, { profile: 'all' }, { userId: 'user-1' });
+
+    expect(result.status).toBe('completed');
+    expect(auditValues).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'agent.command.capture_pprof',
+      actorId: 'user-1',
+      resourceType: 'device',
+      resourceId: 'dev-2',
+      orgId: 'org-1',
+    }));
+  });
+
   it('should return pending commands for a device', async () => {
     const commands = [{ id: 'cmd-5' }, { id: 'cmd-6' }];
     vi.mocked(db.select).mockReturnValue({

--- a/apps/api/src/services/commandQueue.test.ts
+++ b/apps/api/src/services/commandQueue.test.ts
@@ -380,7 +380,9 @@ describe('command queue service', () => {
 
     const result = await executeCommand('dev-2', 'list_services');
 
-    expect(result).toEqual(completed.result);
+    // executeCommand attaches the device_commands row id so callers can
+    // reference the persisted result (#2401).
+    expect(result).toEqual({ ...completed.result, commandId: completed.id });
   });
 
   it('should return pending commands for a device', async () => {

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -206,9 +206,10 @@ export interface CommandResult {
   data?: unknown;
   /**
    * The device_commands row id, attached by executeCommand once a command row
-   * exists. Lets callers point at the persisted result (e.g. the AI pprof tool
-   * references GET /devices/:id/commands/:commandId instead of inlining the
-   * artifact). Absent on failures that occur before the row is created.
+   * exists (success or failure). Lets callers point at the persisted result
+   * (e.g. the AI pprof tool references GET /devices/:id/commands/:commandId
+   * instead of inlining the artifact). Absent only on failures that occur
+   * before the row is created (device missing/offline, insert failure).
    */
   commandId?: string;
 }
@@ -853,7 +854,9 @@ export async function executeCommand(
           // may still pick the command up via the heartbeat path before the
           // timeout fires, in which case the user gets a real result.
           if (INTERACTIVE_COMMAND_TYPES.has(type)) {
-            return { status: 'failed' as const, error: DEVICE_UNREACHABLE_ERROR };
+            // Row already exists at this point — attach its id so the
+            // "commandId present ⇔ row exists" contract holds on this path too.
+            return { status: 'failed' as const, error: DEVICE_UNREACHABLE_ERROR, commandId: command.id };
           }
         }
       }

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -204,6 +204,13 @@ export interface CommandResult {
   error?: string;
   durationMs?: number;
   data?: unknown;
+  /**
+   * The device_commands row id, attached by executeCommand once a command row
+   * exists. Lets callers point at the persisted result (e.g. the AI pprof tool
+   * references GET /devices/:id/commands/:commandId instead of inlining the
+   * artifact). Absent on failures that occur before the row is created.
+   */
+  commandId?: string;
 }
 
 export interface QueuedCommand {
@@ -278,6 +285,9 @@ const AUDITED_COMMANDS: Set<string> = new Set([
   CommandTypes.QUARANTINE_FILE,
   CommandTypes.TAKE_SCREENSHOT,
   CommandTypes.COMPUTER_ACTION,
+  // Runtime diagnostics — profiling the agent process is a privileged
+  // diagnostic action; keep a durable audit trail of who triggered it (#2401).
+  CommandTypes.CAPTURE_PPROF,
   CommandTypes.MANAGE_STARTUP_ITEM,
   CommandTypes.APPLY_AUDIT_POLICY_BASELINE,
   // Peripheral control — pushes full active policy set to agent
@@ -852,10 +862,11 @@ export async function executeCommand(
     // Poll for result
     const result = await waitForCommandResult(command.id, timeoutMs);
 
-    return result.result ?? {
+    const finalResult = result.result ?? {
       status: 'failed' as const,
       error: 'Command did not complete',
     };
+    return { ...finalResult, commandId: command.id };
   });
 }
 

--- a/apps/web/src/components/ai-risk/tierConfig.ts
+++ b/apps/web/src/components/ai-risk/tierConfig.ts
@@ -150,6 +150,7 @@ export const TIER_DEFINITIONS: TierDefinition[] = [
       // Logs & Audit
       { name: 'detect_log_correlations', description: 'Log correlation detection', category: 'Logs & Audit' },
       { name: 'set_agent_log_level', description: 'Set agent log level', category: 'Logs & Audit' },
+      { name: 'capture_agent_pprof', description: 'Capture agent pprof profiles', category: 'Logs & Audit' },
       // Configuration Policies
       { name: 'apply_configuration_policy', description: 'Assign config policy', category: 'Configuration Policies' },
       { name: 'remove_configuration_policy_assignment', description: 'Remove config assignment', category: 'Configuration Policies' },
@@ -274,6 +275,7 @@ export const RATE_LIMIT_CONFIGS: RateLimitConfig[] = [
   { toolName: 'get_log_trends', limit: 20, windowSeconds: 300, tier: 1, permission: 'devices.read', category: 'Logs & Audit' },
   { toolName: 'detect_log_correlations', limit: 10, windowSeconds: 300, tier: 2, permission: 'devices.read', category: 'Logs & Audit' },
   { toolName: 'set_agent_log_level', limit: 5, windowSeconds: 600, tier: 2, permission: 'devices.execute', category: 'Logs & Audit' },
+  { toolName: 'capture_agent_pprof', limit: 3, windowSeconds: 600, tier: 2, permission: 'devices.execute', category: 'Logs & Audit' },
   // Configuration Policies
   { toolName: 'get_configuration_policy', limit: 30, windowSeconds: 300, tier: 1, permission: 'policies.read', category: 'Configuration Policies' },
   { toolName: 'manage_configuration_policy', limit: 20, windowSeconds: 300, tier: 1, permission: 'policies.write', category: 'Configuration Policies' },
@@ -360,6 +362,7 @@ export const RBAC_MAPPINGS: Record<string, string | Record<string, string>> = {
   detect_log_correlations: 'devices.read',
   search_agent_logs: 'devices.read',
   set_agent_log_level: 'devices.execute',
+  capture_agent_pprof: 'devices.execute',
   // Screenshots
   take_screenshot: 'devices.execute',
   analyze_screen: 'devices.execute',


### PR DESCRIPTION
## Summary

PR #2394 added the `capture_pprof` agent command (on-demand heap/goroutine profiles, base64 in the command result, 1 MiB raw cap per profile) but deliberately deferred AI exposure. This registers **`capture_agent_pprof`** as an approval-gated MCP/AI tool following the `set_agent_log_level` pattern — at **every** registration site in one PR, since partial registration across the gate's multiple maps is a known silent-drift trap.

### Registration sites (all mirrored from `set_agent_log_level`)

| Site | Change |
|---|---|
| `services/aiToolsAgentLogs.ts` | Tool implementation — Tier 2, `deviceArgs: ['deviceId']`, org check + site-scope check, dispatches `capture_pprof` via `executeCommand` (30 s wait) |
| `services/aiAgentSdkTools.ts` | `TOOL_TIERS: 2` + SDK `tool()` registration (`deviceId` uuid, `profile: heap\|goroutine\|all` optional) |
| `services/aiGuardrails.ts` | `TOOL_PERMISSIONS` → `devices.execute`; `RATE_LIMITS` → 3 / 10 min; `buildApprovalDescription` case |
| `services/aiToolSchemas.ts` | Zod input schema |
| `services/aiAgentSystemPrompt.ts` | Logs tool list |
| `web ai-risk/tierConfig.ts` (×3) | Tier-2 tool list, rate-limit table, permission map |

Tier 2 means the chat path requires human approval (`aiAgentSdk` gates all tier ≥ 2 calls through the approval flow) and the MCP path requires write-capable tokens. The `aiToolsRegistryParity` test enforces schema + permission presence with **no** new legacy-gap entries.

### Artifact delivery — no megabytes of base64 in the transcript

The agent returns profiles base64-encoded in the command-result stdout (up to ~2.7 MB for `all`). No existing AI tool convention fits (`take_screenshot` inlines base64 because the chat UI renders images; there is no file/artifact download convention in the AI tool layer), so per the issue the tool returns a **truncation-safe summary**: per-profile byte sizes, capture timestamp, and the runtime gauges snapshot (heap bytes, GC count, **goroutine count**), plus a `retrieval` pointer to `GET /devices/:id/commands/:commandId`.

### Supporting changes — making the artifact actually retrievable (incl. PR-review findings)

The retrieval pointer would have been a lie without three fixes, two of which were caught by PR review:

1. **History redaction (planned):** `sanitizeCommandResultForHistory` unconditionally redacts stdout from command history — which also meant #2394's profiles were unretrievable by humans at all. Added a narrow allowlist (`RAW_STDOUT_COMMAND_TYPES = {'capture_pprof'}`) honored **only** by the single-command GET; list endpoints stay redacted so history pages never balloon. pprof profiles are allocation sites / goroutine stacks of our own agent binary — no tenant or user-generated content. Non-allowlisted types remain redacted even with the opt-in flag (pinned by tests in both directions, including a >4096-char payload proving the truncation/secret-pattern bypass).
2. **Ingest redaction (review finding, critical):** both result-ingest legs (agent WS + heartbeat REST) ran `redactSecretsFromOutput` on stdout before persisting. The case-insensitive `AKIA[0-9A-Z]{16}` pattern statistically fires inside megabytes of random base64 (~1/MB), silently corrupting the gzip-protobuf profiles while every layer reports success. Artifact-bearing stdout is now stored byte-for-byte on both legs (`isRawStdoutArtifactCommand`); stderr/error redaction is unchanged. Pinned by ingest tests on both legs using redaction-triggering substrings.
3. **Body limit (review finding, high):** the heartbeat/REST result route sat under the global 1 MB body limit, so a schema-valid multi-MB result (pprof `all` ≈ 2.8 MB; `commandResultSchema` allows 5 MB stdout) was 413-rejected on the WS-fallback leg and surfaced as a misleading generic timeout. Added a 12 MB carve-out for `/api/v1/agents/:id/commands/:commandId/result`.

Also from review: a completed capture whose stdout carries no profile fields now returns an error instead of a success payload with empty `profiles`; parse-failure/command-failure paths include `commandId` (and log device/command context); `executeCommand` attaches `commandId` to its returned `CommandResult` on all post-insert paths; `capture_pprof` added to `AUDITED_COMMANDS` (behaviorally pinned).

## Testing

- `pnpm exec vitest run` on the 10 affected suites (`aiToolsAgentLogs` + siteScope, `commandAudit`, `aiToolsRegistryParity`, `commandQueue`, `devices/commands`, `aiGuardrails`, `agents/commands`, `agentWs`, `bodyLimit`) — **256 passed**.
- Adjacent registries: `aiAgentSdk.test.ts`, `clientAiTools.registry.test.ts`, `helperToolFilter.test.ts` — 88 passed.
- `npx tsc --noEmit` clean in `apps/api` **and** `apps/web`.

Closes #2401
Refs #2389, #2394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)