### PR TITLE
fix(oauth): PR #2377 follow-ups — grant revoked_at durability, accurate 503, single RBAC fetch

### DIFF
--- a/apps/api/src/oauth/grantRevocation.test.ts
+++ b/apps/api/src/oauth/grantRevocation.test.ts
@@ -56,7 +56,7 @@ describe('revokeAllUserOauthArtifacts', () => {
     // with no active refresh row).
     mockSelectRows([{ id: 'grant-A' }, { id: 'grant-B' }, { id: 'grant-C' }]);
 
-    mockUpdateChain();
+    const { set } = mockUpdateChain();
 
     const result = await revokeAllUserOauthArtifacts(userId);
 
@@ -72,6 +72,13 @@ describe('revokeAllUserOauthArtifacts', () => {
     expect(grantCalls.sort()).toEqual(['grant-A', 'grant-B', 'grant-C']);
 
     expect(updateMock).toHaveBeenCalledWith(oauthRefreshTokens);
+    // Durability: revoked_at is also stamped on the grant rows themselves so
+    // revocation survives Redis-marker expiry (parity with revocationService).
+    expect(updateMock).toHaveBeenCalledWith(oauthGrants);
+    expect(set).toHaveBeenCalledWith({
+      revokedAt: expect.any(Date),
+      revokedReason: 'tenant-lifecycle:user',
+    });
     expect(result).toEqual({ grantsRevoked: 3, refreshTokensRevoked: 3, jtisRevoked: 3 });
   });
 
@@ -79,13 +86,25 @@ describe('revokeAllUserOauthArtifacts', () => {
     const userId = '22222222-2222-2222-2222-222222222222';
     mockSelectRows([]); // no refresh tokens
     mockSelectRows([{ id: 'grant-X' }]);
+    mockUpdateChain();
 
     const result = await revokeAllUserOauthArtifacts(userId);
 
     expect(revokeJtiMock).not.toHaveBeenCalled();
     expect(revokeGrantMock).toHaveBeenCalledWith('grant-X', expect.any(Number));
+    expect(updateMock).toHaveBeenCalledWith(oauthGrants);
     expect(result.grantsRevoked).toBe(1);
     expect(result.refreshTokensRevoked).toBe(0);
+  });
+
+  it('does not stamp grant rows when no grants are discovered', async () => {
+    mockSelectRows([]); // no refresh tokens
+    mockSelectRows([]); // no grants
+    mockUpdateChain();
+
+    await revokeAllUserOauthArtifacts('88888888-8888-8888-8888-888888888888');
+
+    expect(updateMock).not.toHaveBeenCalled();
   });
 
   it('queries the correct tables', async () => {
@@ -115,12 +134,16 @@ describe('revokeAllUserOauthArtifacts', () => {
       { id: 'rt-partner', expiresAt: new Date(Date.now() + 60_000) },
     ]);
     mockSelectRows([{ id: 'grant-partner' }]);
-    mockUpdateChain();
+    const { set } = mockUpdateChain();
 
     const result = await revokeAllPartnerOauthArtifacts('66666666-6666-6666-8666-666666666666');
 
     expect(revokeJtiMock).toHaveBeenCalledWith('rt-partner', expect.any(Number));
     expect(revokeGrantMock).toHaveBeenCalledWith('grant-partner', expect.any(Number));
+    expect(set).toHaveBeenCalledWith({
+      revokedAt: expect.any(Date),
+      revokedReason: 'tenant-lifecycle:partner',
+    });
     expect(result.refreshTokensRevoked).toBe(1);
   });
 
@@ -149,12 +172,16 @@ describe('revokeAllUserOauthArtifacts', () => {
     await expect(revokeAllUserOauthArtifacts(userId)).rejects.toThrow(/redis down/);
   });
 
-  it('propagates revokeGrant cache failures', async () => {
+  it('propagates revokeGrant cache failures and does not stamp grant rows (fail closed)', async () => {
     const userId = '55555555-5555-5555-5555-555555555555';
     mockSelectRows([]);
     mockSelectRows([{ id: 'grant-X' }]);
+    mockUpdateChain();
     revokeGrantMock.mockRejectedValueOnce(new Error('redis down'));
 
     await expect(revokeAllUserOauthArtifacts(userId)).rejects.toThrow(/redis down/);
+    // A stamped-but-unmarked grant would look revoked in the DB while its
+    // in-flight access JWTs kept working — the stamp must not happen.
+    expect(updateMock).not.toHaveBeenCalledWith(oauthGrants);
   });
 });

--- a/apps/api/src/oauth/grantRevocation.ts
+++ b/apps/api/src/oauth/grantRevocation.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { oauthGrants, oauthRefreshTokens } from '../db/schema';
 import { revokeGrant, revokeJti } from './revocationCache';
@@ -67,11 +67,12 @@ async function revokeOauthArtifactsByColumn(
 
   // Grant discovery is authoritative from oauth_grants — never from refresh
   // payload grantIds. This is what makes code-only grants (no refresh row)
-  // still get a revocation marker.
+  // still get a revocation marker. Already-revoked grants are skipped so a
+  // repeat call is a no-op (matches revocationService.ts).
   const grants = await db
     .select({ id: oauthGrants.id })
     .from(oauthGrants)
-    .where(eq(grantColumn, value));
+    .where(and(eq(grantColumn, value), isNull(oauthGrants.revokedAt)));
 
   for (const grant of grants) {
     if (seenGrants.has(grant.id)) continue;
@@ -87,6 +88,16 @@ async function revokeOauthArtifactsByColumn(
       });
       throw err;
     }
+  }
+
+  // Stamp revoked_at AFTER every marker write succeeded (fail closed, same
+  // ordering as revocationService.ts): a stamped-but-unmarked grant would look
+  // revoked in the DB while its in-flight access JWTs kept working.
+  if (seenGrants.size > 0) {
+    await db
+      .update(oauthGrants)
+      .set({ revokedAt: now, revokedReason: `tenant-lifecycle:${target}` })
+      .where(inArray(oauthGrants.id, [...seenGrants]));
   }
 
   return {
@@ -112,7 +123,9 @@ function inExplicitSystemContext<T>(fn: () => Promise<T>): Promise<T> {
  *      in-flight access JWT.
  *   3. Write a grant-level marker for every Grant row discovered from the
  *      authoritative oauth_grants table, so code-only grants (auth-code access
- *      tokens with no refresh row) are also rejected.
+ *      tokens with no refresh row) are also rejected. Once every marker is
+ *      written, stamp `revoked_at` on those grant rows so revocation survives
+ *      marker expiry / Redis loss (durability parity with revocationService).
  *
  * We intentionally do NOT delete the oauth_grants / oauth_refresh_tokens rows:
  * keeping them simplifies audit trail and matches what `connectedApps.ts`

--- a/apps/api/src/routes/connectedApps.ts
+++ b/apps/api/src/routes/connectedApps.ts
@@ -69,10 +69,11 @@ if (MCP_OAUTH_ENABLED) {
     // authoritative from oauth_grants (partner scope), so code-only grants —
     // auth-code access tokens minted without a refresh token — are revoked
     // too (MCP-OAUTH-07). The service writes Redis markers BEFORE any DB
-    // mutation and throws on marker failure; we surface that as a 503 so the
-    // user sees a hard error rather than a hidden-but-partially-revoked app.
-    // Only this partner's join row is removed; other partners on the same
-    // shared client keep working.
+    // mutation and throws on ANY failure (marker write or the later DB
+    // stamping); we surface both as a 503 so the user sees a hard error
+    // rather than a hidden-but-partially-revoked app. Only this partner's
+    // join row is removed; other partners on the same shared client keep
+    // working.
     try {
       await revokeClientFamilies(clientId, { kind: 'partner', partnerId });
     } catch (err) {
@@ -82,7 +83,7 @@ if (MCP_OAUTH_ENABLED) {
         err,
         context: { clientId, partnerId },
       });
-      throw new HTTPException(503, { message: 'revocation cache unavailable' });
+      throw new HTTPException(503, { message: 'revocation failed — the app may still have access; please retry' });
     }
 
     return c.body(null, 204);

--- a/apps/api/src/services/aiGuardrails.test.ts
+++ b/apps/api/src/services/aiGuardrails.test.ts
@@ -52,7 +52,7 @@ vi.mock('./redis', () => ({
   getRedis: vi.fn(),
 }));
 
-import { checkGuardrails, checkToolPermission, checkPermissionRequirement } from './aiGuardrails';
+import { checkGuardrails, checkToolPermission, checkPermissionRequirement, checkPermissionRequirements } from './aiGuardrails';
 import { getUserPermissions, hasPermission } from './permissions';
 
 // ─── Tier escalation for fleet tools ────────────────────────────────────
@@ -356,6 +356,55 @@ describe('checkToolPermission — backup restore tools', () => {
     const result = await checkToolPermission('restore_mssql_database', {}, auth);
 
     expect(result).toBeNull();
+  });
+
+  it('resolves getUserPermissions once even when extra permissions are required', async () => {
+    vi.mocked(getUserPermissions).mockClear();
+    vi.mocked(getUserPermissions).mockResolvedValue({ roleId: 'operator' } as any);
+    vi.mocked(hasPermission).mockReturnValue(true);
+
+    // restore_snapshot has a base permission plus TOOL_EXTRA_PERMISSIONS —
+    // all requirements must be checked against a single role resolution.
+    const result = await checkToolPermission('restore_snapshot', {}, auth);
+
+    expect(result).toBeNull();
+    expect(getUserPermissions).toHaveBeenCalledTimes(1);
+    expect(hasPermission).toHaveBeenCalledWith(expect.anything(), 'devices', 'execute');
+    expect(hasPermission).toHaveBeenCalledWith(expect.anything(), 'backup', 'read');
+  });
+});
+
+describe('checkPermissionRequirements — batch variant', () => {
+  const auth = {
+    user: { id: 'user-1' },
+    token: { roleId: 'operator', scope: 'organization' },
+    orgId: 'org-1',
+    partnerId: null,
+  } as any;
+
+  beforeEach(() => {
+    vi.mocked(hasPermission).mockReset();
+    vi.mocked(getUserPermissions).mockReset();
+  });
+
+  it('returns null for an empty requirement list without resolving permissions', async () => {
+    const result = await checkPermissionRequirements(auth, []);
+    expect(result).toBeNull();
+    expect(getUserPermissions).not.toHaveBeenCalled();
+  });
+
+  it('returns the first denial in requirement order', async () => {
+    vi.mocked(getUserPermissions).mockResolvedValue({ roleId: 'operator' } as any);
+    vi.mocked(hasPermission).mockImplementation((_perms, resource) => resource !== 'backup');
+
+    const result = await checkPermissionRequirements(auth, [
+      { resource: 'devices', action: 'execute' },
+      { resource: 'backup', action: 'read' },
+      { resource: 'alerts', action: 'read' },
+    ]);
+
+    expect(result).toBe('Insufficient permissions: requires backup.read');
+    expect(getUserPermissions).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -743,9 +743,25 @@ export async function checkPermissionRequirement(
   auth: AuthContext,
   requirement: { resource: string; action: string }
 ): Promise<string | null> {
+  return checkPermissionRequirements(auth, [requirement]);
+}
+
+/**
+ * Batch variant: resolves the user's permissions ONCE and checks every
+ * requirement against that single resolution, returning the first denial.
+ * Use this when a caller has several requirements for the same auth context
+ * (e.g. a tool's base permission plus TOOL_EXTRA_PERMISSIONS) — calling the
+ * single-requirement form in a loop re-fetches getUserPermissions each time.
+ */
+export async function checkPermissionRequirements(
+  auth: AuthContext,
+  requirements: Array<{ resource: string; action: string }>
+): Promise<string | null> {
+  if (requirements.length === 0) return null;
   if (!auth.token) {
+    const described = requirements.map((r) => `${r.resource}.${r.action}`).join(', ');
     console.warn(
-      `[aiGuardrails] checkPermissionRequirement called without auth.token for ${requirement.resource}.${requirement.action}`
+      `[aiGuardrails] checkPermissionRequirements called without auth.token for ${described}`
     );
     return null;
   }
@@ -760,8 +776,10 @@ export async function checkPermissionRequirement(
     return 'Insufficient permissions: no role assigned';
   }
 
-  if (!hasPermission(userPerms, requirement.resource, requirement.action)) {
-    return `Insufficient permissions: requires ${requirement.resource}.${requirement.action}`;
+  for (const requirement of requirements) {
+    if (!hasPermission(userPerms, requirement.resource, requirement.action)) {
+      return `Insufficient permissions: requires ${requirement.resource}.${requirement.action}`;
+    }
   }
 
   return null;
@@ -811,15 +829,13 @@ export async function checkToolPermission(
     return `Missing required "action" argument for tool "${toolName}"`;
   }
 
-  const denial = await checkPermissionRequirement(auth, required);
-  if (denial) return denial;
-
-  for (const extraPermission of TOOL_EXTRA_PERMISSIONS[toolName] ?? []) {
-    const extraDenial = await checkPermissionRequirement(auth, extraPermission);
-    if (extraDenial) return extraDenial;
-  }
-
-  return null;
+  // One getUserPermissions resolution covers the base requirement and every
+  // extra permission; denials keep the same first-failure ordering as the
+  // old per-requirement loop.
+  return checkPermissionRequirements(auth, [
+    required,
+    ...(TOOL_EXTRA_PERMISSIONS[toolName] ?? []),
+  ]);
 }
 
 /**


### PR DESCRIPTION
Closes the three non-blocking follow-ups deferred from #2377 (whole-branch review triage).

## Changes

**1. `grantRevocation.ts` — durability parity with `revocationService.ts`**
The tenant-lifecycle helpers (`revokeAllUser/Partner/OrgOauthArtifacts`) wrote Redis grant markers but never stamped `oauth_grants.revoked_at`, so that revocation path depended solely on marker TTL surviving Redis loss. They now stamp `revoked_at` + `revoked_reason` (`tenant-lifecycle:<user|partner|org>`) **after** every marker write succeeds — same fail-closed ordering as `revocationService.ts` (a stamped-but-unmarked grant would look revoked in the DB while in-flight access JWTs kept working). Grant discovery now filters `revoked_at IS NULL`, so repeat calls are no-ops.

**2. `connectedApps.ts` — accurate 503 message**
`revokeClientFamilies` throws on marker-write failure *or* the later DB stamping, but the DELETE handler always reported "revocation cache unavailable". The message is now failure-mode-neutral: `revocation failed — the app may still have access; please retry`. (The two 503s in `routes/oauth.ts` genuinely are cache-only and keep their message.)

**3. `aiGuardrails.ts` — single `getUserPermissions` fetch per tool call**
New `checkPermissionRequirements(auth, requirements[])` resolves the user's permissions once and checks all requirements against it (first-denial ordering preserved). `checkToolPermission` passes `[base, ...TOOL_EXTRA_PERMISSIONS]` in one call instead of fetching per permission; `checkPermissionRequirement` delegates to the batch variant, so `resources/read` (MCP-OAUTH-03) is unchanged.

## Tests

- `grantRevocation.test.ts`: asserts the grant stamp (`revokedAt` + per-target `revokedReason`), the no-grants no-op, and that a marker failure prevents the stamp (fail closed).
- `aiGuardrails.test.ts`: asserts one `getUserPermissions` resolution for a tool with extra permissions, empty-list short-circuit, and first-denial ordering in the batch variant.
- All three affected suites + the three caller suites (abuse, authLifecycle, tenantLifecycle) green: 168/168. API `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)