### PR TITLE
feat: extension seam v2 (agent-authenticated extension routes) + generic workspace-index agent module

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/websocket v1.5.3
 	github.com/gosnmp/gosnmp v1.43.2
+	github.com/hirochachacha/go-smb2 v1.1.0
 	github.com/pion/rtcp v1.2.17
 	github.com/pion/webrtc/v4 v4.2.16
 	github.com/shirou/gopsutil/v3 v3.24.5
@@ -67,6 +68,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/geoffgarside/ber v1.1.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/net v0.56.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/text v0.39.0
+	golang.org/x/time v0.15.0
 	google.golang.org/api v0.287.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -118,7 +119,6 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20260519071638-aa98bba5eb94 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260615183401-62b3387ff324 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d // indirect

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.27
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.31
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.105.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/getsentry/sentry-go v0.47.0
 	github.com/go-ole/go-ole v1.2.6
 	github.com/google/gopacket v1.1.19
@@ -67,7 +68,6 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/geoffgarside/ber v1.1.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -111,6 +111,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/geoffgarside/ber v1.1.0 h1:qTmFG4jJbwiSzSXoNJeHcOprVzZ8Ulde2Rrrifu5U9w=
+github.com/geoffgarside/ber v1.1.0/go.mod h1:jVPKeCbj6MvQZhwLYsGwaGI52oUorHoHKNecGT85ZCc=
 github.com/getsentry/sentry-go v0.47.0 h1:AnSMSyrYA5qZCIN/2xpgAAwv63sVULV+vBq37ajouc8=
 github.com/getsentry/sentry-go v0.47.0/go.mod h1:h+b4VHpKnK7aUXB5wc+KDnPgp9ZtfliRD4eV85FbiSA=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
@@ -149,6 +151,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosnmp/gosnmp v1.43.2 h1:F9loz6uMCNtIQj0RNO5wz/mZ+FZt2WyNKJYOvw+Zosw=
 github.com/gosnmp/gosnmp v1.43.2/go.mod h1:smHIwoaqr1M+HTAEd7+mKkPs8lp3Lf/U+htPUql1Q3c=
+github.com/hirochachacha/go-smb2 v1.1.0 h1:b6hs9qKIql9eVXAiN0M2wSFY5xnhbHAQoCwRKbaRTZI=
+github.com/hirochachacha/go-smb2 v1.1.0/go.mod h1:8F1A4d5EZzrGu5R7PU163UcMRDJQl4FtcxjBfsY8TZE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -278,6 +282,7 @@ go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/breeze-rmm/agent/internal/unifi"
 	"github.com/breeze-rmm/agent/internal/userhelper"
 	"github.com/breeze-rmm/agent/internal/websocket"
+	"github.com/breeze-rmm/agent/internal/workspaceindex"
 	"github.com/breeze-rmm/agent/pkg/api"
 	"github.com/spf13/cobra"
 )
@@ -385,14 +386,22 @@ type agentComponents struct {
 	// unifiDone closes after the collector loop goroutine has fully exited.
 	// nil when unifiCancel is nil.
 	unifiDone <-chan struct{}
+
+	// workspaceIndexCancel cancels the server-driven workspace indexing loop.
+	// nil when the local kill switch disables the loop.
+	workspaceIndexCancel context.CancelFunc
+	// workspaceIndexDone closes after crawls and watchers have fully exited.
+	// nil when workspaceIndexCancel is nil.
+	workspaceIndexDone <-chan struct{}
 }
 
 // shutdownAgent gracefully stops all agent components.
 //
 // Every blocking stage is wrapped with a deadline so that a stuck HTTP flush
 // (common during OS shutdown when the network has already gone down) can't
-// pin the process past systemd's TimeoutStopSec. Total worst case is bounded
-// by the sum of per-stage timeouts; the unit file caps the outer wait at 15s.
+// pin the process past its shutdown budget. The workspace-index terminal flush
+// gets a longer local allowance, though the service manager may enforce a
+// shorter outer deadline.
 func shutdownAgent(comps *agentComponents) {
 	if comps == nil {
 		return
@@ -421,6 +430,18 @@ func shutdownAgent(comps *agentComponents) {
 		if comps.unifiDone != nil {
 			runWithTimeout("unifi collector stop", 2*time.Second, func() {
 				<-comps.unifiDone
+			})
+		}
+	}
+
+	// Cancel workspace indexing before core network teardown. A canceled crawl
+	// sends one terminal CompleteRun using a non-canceled context, so allow the
+	// client's 30-second HTTP timeout plus a small scheduling margin.
+	if comps.workspaceIndexCancel != nil {
+		comps.workspaceIndexCancel()
+		if comps.workspaceIndexDone != nil {
+			runWithTimeout("workspace index stop", 35*time.Second, func() {
+				<-comps.workspaceIndexDone
 			})
 		}
 	}
@@ -729,6 +750,25 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 		})
 	}
 
+	var workspaceIndexCancel context.CancelFunc
+	var workspaceIndexDone <-chan struct{}
+	if cfg.WorkspaceIndex.Enabled != nil && !*cfg.WorkspaceIndex.Enabled {
+		log.Debug("workspace indexing disabled by local configuration")
+	} else {
+		workspaceClient := workspaceindex.NewClient(workspaceindex.ClientConfig{
+			ServerURL:    cfg.ServerURL,
+			EndpointBase: cfg.WorkspaceIndex.EndpointBase,
+			AuthToken:    secureToken,
+			HTTPClient:   newUnifiAPIClient(secureToken, tlsCfg),
+			AuthMonitor:  authMon,
+		})
+		var workspaceIndexCtx context.Context
+		workspaceIndexCtx, workspaceIndexCancel = context.WithCancel(context.Background())
+		workspaceIndexDone = workspaceindex.StartLoop(workspaceIndexCtx, workspaceindex.Deps{
+			Client: workspaceClient,
+		})
+	}
+
 	// PAM Track 3: subscribe to Microsoft-Windows-LUA ETW provider for
 	// UAC consent discovery. Windows-only; no-op stub on other platforms
 	// (see etwlua_start_other.go). ctx scoped to the agent process so
@@ -771,15 +811,17 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 	}
 
 	return &agentComponents{
-		hb:               hb,
-		wsClient:         wsClient,
-		secureToken:      secureToken,
-		etwluaCancel:     etwCancel,
-		etwluaDone:       etwluaDone,
-		supervisorCancel: supervisorCancel,
-		supervisorDone:   supervisorDone,
-		unifiCancel:      unifiCancel,
-		unifiDone:        unifiDone,
+		hb:                   hb,
+		wsClient:             wsClient,
+		secureToken:          secureToken,
+		etwluaCancel:         etwCancel,
+		etwluaDone:           etwluaDone,
+		supervisorCancel:     supervisorCancel,
+		supervisorDone:       supervisorDone,
+		unifiCancel:          unifiCancel,
+		unifiDone:            unifiDone,
+		workspaceIndexCancel: workspaceIndexCancel,
+		workspaceIndexDone:   workspaceIndexDone,
 	}, nil
 }
 

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -399,9 +399,8 @@ type agentComponents struct {
 //
 // Every blocking stage is wrapped with a deadline so that a stuck HTTP flush
 // (common during OS shutdown when the network has already gone down) can't
-// pin the process past its shutdown budget. The workspace-index terminal flush
-// gets a longer local allowance, though the service manager may enforce a
-// shorter outer deadline.
+// pin the process past systemd's TimeoutStopSec. Total worst case is bounded
+// by the sum of per-stage timeouts; the unit file caps the outer wait at 15s.
 func shutdownAgent(comps *agentComponents) {
 	if comps == nil {
 		return
@@ -435,12 +434,14 @@ func shutdownAgent(comps *agentComponents) {
 	}
 
 	// Cancel workspace indexing before core network teardown. A canceled crawl
-	// sends one terminal CompleteRun using a non-canceled context, so allow the
-	// client's 30-second HTTP timeout plus a small scheduling margin.
+	// attempts one terminal CompleteRun, but we do NOT wait out its 30s HTTP
+	// timeout — the whole shutdown must fit systemd's 15s TimeoutStopSec, and
+	// a missed terminal flush self-heals server-side (the stale run is marked
+	// abandoned on the next crawl start). 2s matches the sibling stages.
 	if comps.workspaceIndexCancel != nil {
 		comps.workspaceIndexCancel()
 		if comps.workspaceIndexDone != nil {
-			runWithTimeout("workspace index stop", 35*time.Second, func() {
+			runWithTimeout("workspace index stop", 2*time.Second, func() {
 				<-comps.workspaceIndexDone
 			})
 		}

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -156,6 +156,13 @@ type Config struct {
 	// Watchdog configuration for the breeze-watchdog service.
 	Watchdog WatchdogConfig `mapstructure:"watchdog" yaml:"watchdog"`
 
+	// WorkspaceIndex controls the server-driven workspace indexing loop.
+	// Enabled nil defaults to on; explicit false is a hard local kill switch.
+	WorkspaceIndex struct {
+		Enabled      *bool  `mapstructure:"enabled" yaml:"enabled"`
+		EndpointBase string `mapstructure:"endpoint_base" yaml:"endpoint_base"`
+	} `mapstructure:"workspace_index" yaml:"workspace_index"`
+
 	// IsService is a runtime flag set when the agent is running as a system service
 	// (Windows SCM, macOS launchd, Linux systemd). It is not persisted to config.
 	IsService bool `mapstructure:"-"`

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -472,6 +472,16 @@ func TestWatchdogDefaults(t *testing.T) {
 	}
 }
 
+func TestWorkspaceIndexDefaults(t *testing.T) {
+	cfg := Default()
+	if cfg.WorkspaceIndex.Enabled != nil {
+		t.Errorf("Enabled default: want nil (server-driven enabled), got %v", *cfg.WorkspaceIndex.Enabled)
+	}
+	if cfg.WorkspaceIndex.EndpointBase != "" {
+		t.Errorf("EndpointBase default: want empty (client default), got %q", cfg.WorkspaceIndex.EndpointBase)
+	}
+}
+
 // TestIsSecretYAMLKey verifies the drift-proof predicate that decides which
 // config keys belong in secrets.yaml vs agent.yaml. Finding #6.
 func TestIsSecretYAMLKey(t *testing.T) {
@@ -503,6 +513,7 @@ func TestIsSecretYAMLKey(t *testing.T) {
 		}
 	}
 }
+
 
 // TestSaveToStripsBackupS3SecretsFromAgentYAML is the regression test for
 // Finding #6: backup_s3_access_key and backup_s3_secret_key must not appear in
@@ -724,4 +735,3 @@ func TestSaveToAbortsWhenStripFails(t *testing.T) {
 		t.Fatalf("agent.yaml leaked the auth token after a failed strip: %q", data)
 	}
 }
-

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -487,11 +487,11 @@ func TestWorkspaceIndexDefaults(t *testing.T) {
 func TestIsSecretYAMLKey(t *testing.T) {
 	cases := map[string]bool{
 		// Explicit secret keys (named in the switch).
-		"auth_token":         true,
+		"auth_token":          true,
 		"watchdog_auth_token": true,
-		"mtls_cert_pem":      true,
-		"mtls_key_pem":       true,
-		"mtls_cert_expires":  true,
+		"mtls_cert_pem":       true,
+		"mtls_key_pem":        true,
+		"mtls_cert_expires":   true,
 		// Caught by suffix rules (_access_key, _secret_key).
 		"backup_s3_access_key": true,
 		"backup_s3_secret_key": true,
@@ -502,10 +502,10 @@ func TestIsSecretYAMLKey(t *testing.T) {
 		"helper_auth_token": false,
 		// Non-secret keys that happen to contain "key" or "token" substrings
 		// but don't match any suffix rule.
-		"server_url":        false,
-		"agent_id":          false,
-		"backup_s3_bucket":  false,
-		"backup_s3_region":  false,
+		"server_url":       false,
+		"agent_id":         false,
+		"backup_s3_bucket": false,
+		"backup_s3_region": false,
 	}
 	for key, want := range cases {
 		if got := isSecretYAMLKey(key); got != want {
@@ -513,7 +513,6 @@ func TestIsSecretYAMLKey(t *testing.T) {
 		}
 	}
 }
-
 
 // TestSaveToStripsBackupS3SecretsFromAgentYAML is the regression test for
 // Finding #6: backup_s3_access_key and backup_s3_secret_key must not appear in

--- a/agent/internal/workspaceindex/client.go
+++ b/agent/internal/workspaceindex/client.go
@@ -1,0 +1,325 @@
+package workspaceindex
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/authstate"
+	"github.com/breeze-rmm/agent/internal/httputil"
+	"github.com/breeze-rmm/agent/internal/secmem"
+)
+
+const (
+	// DefaultEndpointBase is the default server path for agent workspace-index
+	// operations. ClientConfig.EndpointBase can override it.
+	DefaultEndpointBase = "/api/v1/workspace/agent"
+
+	maxErrorBodyBytes = 64 * 1024
+	requestTimeout    = 30 * time.Second
+	batchRetryCount   = 2
+	batchRetryDelay   = time.Second
+)
+
+var (
+	ErrModuleAbsent    = errors.New("workspace index module absent")
+	ErrRunConflict     = errors.New("workspace index run conflict")
+	ErrBatchTooLarge   = errors.New("workspace index batch too large")
+	ErrAuthUnavailable = errors.New("workspace index request skipped while authentication is unavailable")
+)
+
+// HTTPError describes a non-successful server response. Body is capped at 64
+// KiB and has known credential material redacted.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("workspace index request failed with status %d", e.StatusCode)
+	}
+	return fmt.Sprintf("workspace index request failed with status %d: %s", e.StatusCode, e.Body)
+}
+
+// ClientConfig supplies the workspace-index client dependencies.
+type ClientConfig struct {
+	ServerURL    string
+	EndpointBase string
+	AuthToken    *secmem.SecureString
+	HTTPClient   *http.Client
+	AuthMonitor  *authstate.Monitor
+}
+
+// Client calls the server's agent workspace-index endpoints.
+type Client struct {
+	serverURL    string
+	endpointBase string
+	authToken    *secmem.SecureString
+	httpClient   *http.Client
+	authMonitor  *authstate.Monitor
+}
+
+// NewClient creates a workspace-index API client.
+func NewClient(cfg ClientConfig) *Client {
+	endpointBase := strings.TrimRight(cfg.EndpointBase, "/")
+	if endpointBase == "" {
+		endpointBase = DefaultEndpointBase
+	}
+	if !strings.HasPrefix(endpointBase, "/") {
+		endpointBase = "/" + endpointBase
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	clientCopy := *httpClient
+	clientCopy.Timeout = requestTimeout
+	clientCopy.CheckRedirect = refuseUntrustedRedirect
+
+	return &Client{
+		serverURL:    strings.TrimRight(cfg.ServerURL, "/"),
+		endpointBase: endpointBase,
+		authToken:    cfg.AuthToken,
+		httpClient:   &clientCopy,
+		authMonitor:  cfg.AuthMonitor,
+	}
+}
+
+// FetchConfig returns the current server-driven crawl configuration.
+func (c *Client) FetchConfig(ctx context.Context) (*CrawlConfig, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/crawl-config", nil, false)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if err := c.checkResponse(resp, ErrModuleAbsent, http.StatusNotFound); err != nil {
+		return nil, err
+	}
+
+	var config CrawlConfig
+	if err := json.NewDecoder(resp.Body).Decode(&config); err != nil {
+		return nil, fmt.Errorf("decode crawl config: %w", err)
+	}
+	return &config, nil
+}
+
+// FetchCredential returns the credential for sourceID. The caller owns the
+// returned sensitive value and must call Credential.Zero after use.
+func (c *Client) FetchCredential(ctx context.Context, sourceID string) (*Credential, error) {
+	resp, err := c.do(ctx, http.MethodPost, "/sources/"+url.PathEscape(sourceID)+"/credential", nil, false)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if err := c.checkResponse(resp, nil, 0); err != nil {
+		return nil, err
+	}
+
+	var credential Credential
+	if err := json.NewDecoder(resp.Body).Decode(&credential); err != nil {
+		return nil, fmt.Errorf("decode source credential: %w", err)
+	}
+	return &credential, nil
+}
+
+// StartRun starts a crawl for sourceID.
+func (c *Client) StartRun(ctx context.Context, sourceID string) (*ActiveRun, error) {
+	body, err := json.Marshal(struct {
+		SourceID string `json:"sourceId"`
+	}{SourceID: sourceID})
+	if err != nil {
+		return nil, fmt.Errorf("encode start-run request: %w", err)
+	}
+	resp, err := c.do(ctx, http.MethodPost, "/runs", body, false)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if err := c.checkResponse(resp, ErrRunConflict, http.StatusConflict); err != nil {
+		return nil, err
+	}
+
+	var run ActiveRun
+	if err := json.NewDecoder(resp.Body).Decode(&run); err != nil {
+		return nil, fmt.Errorf("decode start-run response: %w", err)
+	}
+	return &run, nil
+}
+
+// PostBatch uploads a gzip-compressed crawl batch.
+func (c *Client) PostBatch(ctx context.Context, runID string, cursor string, entries []Entry) error {
+	body, err := json.Marshal(struct {
+		Cursor  string  `json:"cursor"`
+		Entries []Entry `json:"entries"`
+	}{Cursor: cursor, Entries: entries})
+	if err != nil {
+		return fmt.Errorf("encode batch request: %w", err)
+	}
+
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	if _, err := zw.Write(body); err != nil {
+		_ = zw.Close()
+		return fmt.Errorf("compress batch request: %w", err)
+	}
+	if err := zw.Close(); err != nil {
+		return fmt.Errorf("finish batch compression: %w", err)
+	}
+
+	resp, err := c.do(ctx, http.MethodPost, "/runs/"+url.PathEscape(runID)+"/batch", compressed.Bytes(), true)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return c.checkResponse(resp, ErrBatchTooLarge, http.StatusRequestEntityTooLarge)
+}
+
+// CompleteRun records a successful or failed crawl completion.
+func (c *Client) CompleteRun(ctx context.Context, runID string, complete bool, stats Stats, errReason string) error {
+	body, err := json.Marshal(struct {
+		Complete bool   `json:"complete"`
+		Stats    Stats  `json:"stats"`
+		Error    string `json:"error,omitempty"`
+	}{Complete: complete, Stats: stats, Error: errReason})
+	if err != nil {
+		return fmt.Errorf("encode complete-run request: %w", err)
+	}
+	resp, err := c.do(ctx, http.MethodPost, "/runs/"+url.PathEscape(runID)+"/complete", body, false)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return c.checkResponse(resp, nil, 0)
+}
+
+// PostEvents uploads runless source upserts and exact-path deletes.
+func (c *Client) PostEvents(ctx context.Context, sourceID string, upserts []Entry, deletes []string) error {
+	body, err := json.Marshal(struct {
+		Upserts []Entry  `json:"upserts"`
+		Deletes []string `json:"deletes"`
+	}{Upserts: upserts, Deletes: deletes})
+	if err != nil {
+		return fmt.Errorf("encode events request: %w", err)
+	}
+	resp, err := c.do(ctx, http.MethodPost, "/sources/"+url.PathEscape(sourceID)+"/events", body, false)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return c.checkResponse(resp, nil, 0)
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body []byte, retryBatch bool) (*http.Response, error) {
+	if c.authMonitor != nil && c.authMonitor.ShouldSkip() {
+		return nil, ErrAuthUnavailable
+	}
+
+	attempts := 1
+	if retryBatch {
+		attempts += batchRetryCount
+	}
+	delay := batchRetryDelay
+	for attempt := 0; attempt < attempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+			if delay < 30*time.Second {
+				delay *= 2
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, c.serverURL+c.endpointBase+path, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("create workspace index request: %w", err)
+		}
+		if token := c.authToken.Reveal(); token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		if body != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		if retryBatch {
+			req.Header.Set("Content-Encoding", "gzip")
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			if attempt+1 < attempts {
+				continue
+			}
+			return nil, fmt.Errorf("send workspace index request: %w", err)
+		}
+
+		if !retryBatch || !isRetryableStatus(resp.StatusCode) || attempt+1 == attempts {
+			return resp, nil
+		}
+		if retryAfter := httputil.ParseRetryAfter(resp.Header, time.Now()); retryAfter > 0 {
+			delay = retryAfter
+		}
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxErrorBodyBytes))
+		resp.Body.Close()
+	}
+	return nil, errors.New("workspace index request exhausted retries")
+}
+
+func (c *Client) checkResponse(resp *http.Response, sentinel error, sentinelStatus int) error {
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		if c.authMonitor != nil {
+			c.authMonitor.RecordSuccess()
+		}
+		return nil
+	}
+	if resp.StatusCode == http.StatusUnauthorized && c.authMonitor != nil {
+		c.authMonitor.RecordAuthFailure()
+	}
+
+	token := c.authToken.Reveal()
+	excerpt, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+	body := strings.TrimSpace(string(excerpt))
+	if token != "" {
+		body = strings.ReplaceAll(body, token, "[REDACTED]")
+	}
+	httpErr := &HTTPError{StatusCode: resp.StatusCode, Body: body}
+	if readErr != nil {
+		httpErr.Body = "unable to read error response"
+	}
+	if sentinel != nil && resp.StatusCode == sentinelStatus {
+		return fmt.Errorf("%w: %w", sentinel, httpErr)
+	}
+	return httpErr
+}
+
+func isRetryableStatus(status int) bool {
+	return status == http.StatusTooManyRequests ||
+		status == http.StatusInternalServerError ||
+		status == http.StatusBadGateway ||
+		status == http.StatusServiceUnavailable ||
+		status == http.StatusGatewayTimeout
+}
+
+func refuseUntrustedRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	previous := via[len(via)-1]
+	if !strings.EqualFold(req.URL.Hostname(), previous.URL.Hostname()) {
+		return fmt.Errorf("refusing redirect from host %s to untrusted host %s during credentialed request", previous.URL.Hostname(), req.URL.Hostname())
+	}
+	if previous.URL.Scheme == "https" && req.URL.Scheme != "https" {
+		return fmt.Errorf("refusing https-to-%s downgrade redirect to %s during credentialed request", req.URL.Scheme, req.URL.Hostname())
+	}
+	return nil
+}

--- a/agent/internal/workspaceindex/client.go
+++ b/agent/internal/workspaceindex/client.go
@@ -26,8 +26,11 @@ const (
 	maxErrorBodyBytes = 64 * 1024
 	requestTimeout    = 30 * time.Second
 	batchRetryCount   = 2
-	batchRetryDelay   = time.Second
 )
+
+// batchRetryDelay is a var (not const) so tests exercising retry exhaustion
+// can shrink it instead of sleeping real seconds.
+var batchRetryDelay = time.Second
 
 var (
 	ErrModuleAbsent    = errors.New("workspace index module absent")

--- a/agent/internal/workspaceindex/client_test.go
+++ b/agent/internal/workspaceindex/client_test.go
@@ -1,0 +1,220 @@
+package workspaceindex
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/secmem"
+)
+
+func newHTTPTestEndpoint(handler http.Handler, hostname string) (string, *http.Client) {
+	return "http://" + hostname, &http.Client{Transport: handlerRoundTripper{handler: handler}}
+}
+
+type handlerRoundTripper struct{ handler http.Handler }
+
+func (rt handlerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	recorder := httptest.NewRecorder()
+	rt.handler.ServeHTTP(recorder, req)
+	return recorder.Result(), nil
+}
+
+func newTestClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+
+	serverURL, httpClient := newHTTPTestEndpoint(handler, "server.test")
+	token := secmem.NewSecureString("agent-secret")
+	t.Cleanup(token.Zero)
+
+	return NewClient(ClientConfig{
+		ServerURL:  serverURL,
+		AuthToken:  token,
+		HTTPClient: httpClient,
+	})
+}
+
+func TestFetchConfigSendsAuthorizationAndDecodesWireShape(t *testing.T) {
+	startedAt := time.Date(2026, time.July, 12, 12, 30, 0, 0, time.UTC)
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/workspace/agent/crawl-config" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer agent-secret" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"enabled":true,
+			"pollIntervalSeconds":300,
+			"limits":{"maxBatchBytes":921600,"maxBatchEntries":2000,"walkOpsPerSecond":200},
+			"sources":[{"id":"source-1","kind":"smb_share","rootPath":"share","cadenceMinutes":720,"excludeGlobs":["tmp/**"],"hasCredential":true,"lastCompleteRunAt":null,"activeRun":{"runId":"run-1","startedAt":"`+startedAt.Format(time.RFC3339)+`","cursor":"dir/file"},"watch":false}]
+		}`)
+	}))
+
+	config, err := client.FetchConfig(context.Background())
+	if err != nil {
+		t.Fatalf("FetchConfig: %v", err)
+	}
+	if !config.Enabled || config.PollIntervalSeconds != 300 || config.Limits.MaxBatchEntries != 2000 {
+		t.Fatalf("unexpected config: %+v", config)
+	}
+	if len(config.Sources) != 1 || config.Sources[0].ActiveRun == nil || config.Sources[0].ActiveRun.RunID != "run-1" {
+		t.Fatalf("unexpected sources: %+v", config.Sources)
+	}
+}
+
+func TestPostBatchGzipRoundTrip(t *testing.T) {
+	mtime := time.Date(2026, time.July, 12, 13, 0, 0, 0, time.UTC)
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/workspace/agent/runs/run-1/batch" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if got := r.Header.Get("Content-Encoding"); got != "gzip" {
+			t.Errorf("Content-Encoding = %q, want gzip", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+
+		zr, err := gzip.NewReader(r.Body)
+		if err != nil {
+			t.Errorf("gzip.NewReader: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		defer zr.Close()
+		var payload struct {
+			Cursor  string  `json:"cursor"`
+			Entries []Entry `json:"entries"`
+		}
+		if err := json.NewDecoder(zr).Decode(&payload); err != nil {
+			t.Errorf("decode batch: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if payload.Cursor != "dir/file.txt" || len(payload.Entries) != 1 || payload.Entries[0].RelPath != "dir/file.txt" {
+			t.Errorf("unexpected payload: %+v", payload)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	err := client.PostBatch(context.Background(), "run-1", "dir/file.txt", []Entry{{
+		RelPath: "dir/file.txt", ParentPath: "dir", Name: "file.txt", Size: 42,
+		Mtime: mtime, Attrs: map[string]any{},
+	}})
+	if err != nil {
+		t.Fatalf("PostBatch: %v", err)
+	}
+}
+
+func TestSentinelStatusMappings(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		call   func(context.Context, *Client) error
+		want   error
+	}{
+		{
+			name:   "module absent",
+			status: http.StatusNotFound,
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.FetchConfig(ctx)
+				return err
+			},
+			want: ErrModuleAbsent,
+		},
+		{
+			name:   "run conflict",
+			status: http.StatusConflict,
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.StartRun(ctx, "source-1")
+				return err
+			},
+			want: ErrRunConflict,
+		},
+		{
+			name:   "batch too large",
+			status: http.StatusRequestEntityTooLarge,
+			call: func(ctx context.Context, client *Client) error {
+				return client.PostBatch(ctx, "run-1", "cursor", nil)
+			},
+			want: ErrBatchTooLarge,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			if err := tt.call(context.Background(), client); !errors.Is(err, tt.want) {
+				t.Fatalf("error = %v, want errors.Is(_, %v)", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedirectToOtherHostIsRefused(t *testing.T) {
+	var attackerHits atomic.Int32
+	attackerURL, _ := newHTTPTestEndpoint(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		attackerHits.Add(1)
+	}), "attacker.test")
+
+	originURL, originClient := newHTTPTestEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attackerURL, http.StatusTemporaryRedirect)
+	}), "origin.test")
+	token := secmem.NewSecureString("redirect-secret")
+	defer token.Zero()
+	client := NewClient(ClientConfig{ServerURL: originURL, AuthToken: token, HTTPClient: originClient})
+
+	_, err := client.FetchConfig(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "untrusted host") {
+		t.Fatalf("FetchConfig error = %v, want untrusted-host redirect error", err)
+	}
+	if got := attackerHits.Load(); got != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", got)
+	}
+	if strings.Contains(err.Error(), "redirect-secret") {
+		t.Fatalf("redirect error leaked bearer token: %v", err)
+	}
+}
+
+func TestCredentialRedactsStringAndJSONRepresentations(t *testing.T) {
+	credential := Credential{Username: "svc-index", Password: "super-secret"}
+	representations := []struct {
+		name string
+		get  func() string
+	}{
+		{name: "String", get: func() string { return fmt.Sprintf("%v", credential) }},
+		{name: "GoString", get: func() string { return fmt.Sprintf("%#v", credential) }},
+		{name: "JSON", get: func() string {
+			data, err := json.Marshal(credential)
+			if err != nil {
+				t.Fatalf("json.Marshal: %v", err)
+			}
+			return string(data)
+		}},
+	}
+
+	for _, tt := range representations {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.get(); strings.Contains(got, credential.Password) {
+				t.Fatalf("representation leaked password: %q", got)
+			}
+		})
+	}
+}

--- a/agent/internal/workspaceindex/client_test.go
+++ b/agent/internal/workspaceindex/client_test.go
@@ -29,6 +29,20 @@ func (rt handlerRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	return recorder.Result(), nil
 }
 
+// hostRoutingTransport dispatches by request hostname so cross-host tests
+// (e.g. redirect refusal) can genuinely observe which host received traffic.
+type hostRoutingTransport struct{ handlers map[string]http.Handler }
+
+func (rt hostRoutingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	handler, ok := rt.handlers[req.URL.Hostname()]
+	if !ok {
+		return nil, fmt.Errorf("no test handler for host %q", req.URL.Hostname())
+	}
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	return recorder.Result(), nil
+}
+
 func newTestClient(t *testing.T, handler http.Handler) *Client {
 	t.Helper()
 
@@ -170,16 +184,24 @@ func TestSentinelStatusMappings(t *testing.T) {
 
 func TestRedirectToOtherHostIsRefused(t *testing.T) {
 	var attackerHits atomic.Int32
-	attackerURL, _ := newHTTPTestEndpoint(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		attackerHits.Add(1)
-	}), "attacker.test")
-
-	originURL, originClient := newHTTPTestEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, attackerURL, http.StatusTemporaryRedirect)
-	}), "origin.test")
+	// One transport serving BOTH hosts, routed by hostname: if the redirect
+	// guard were removed, the follow-up request would genuinely reach the
+	// attacker handler and increment the counter.
+	transport := hostRoutingTransport{handlers: map[string]http.Handler{
+		"attacker.test": http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			attackerHits.Add(1)
+		}),
+		"origin.test": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "http://attacker.test/steal", http.StatusTemporaryRedirect)
+		}),
+	}}
 	token := secmem.NewSecureString("redirect-secret")
 	defer token.Zero()
-	client := NewClient(ClientConfig{ServerURL: originURL, AuthToken: token, HTTPClient: originClient})
+	client := NewClient(ClientConfig{
+		ServerURL:  "http://origin.test",
+		AuthToken:  token,
+		HTTPClient: &http.Client{Transport: transport},
+	})
 
 	_, err := client.FetchConfig(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "untrusted host") {

--- a/agent/internal/workspaceindex/crawl.go
+++ b/agent/internal/workspaceindex/crawl.go
@@ -77,6 +77,8 @@ func runCrawl(ctx context.Context, deps Deps, src SourceConfig, limits ConfigLim
 			cred.Zero()
 			return fail(safeErr)
 		}
+		redactionCred := *cred
+		defer redactionCred.Zero()
 		cred.Zero()
 		if fsys == nil {
 			if closer != nil {
@@ -92,7 +94,8 @@ func runCrawl(ctx context.Context, deps Deps, src SourceConfig, limits ConfigLim
 			ResumeCursor: resumeCursor,
 			Limiter:      limiter,
 		}, emit); walkErr != nil {
-			return fail(fmt.Errorf("walk SMB source: %w", walkErr))
+			safeErr := redactCredentialError(fmt.Errorf("walk SMB source: %w", walkErr), &redactionCred)
+			return fail(safeErr)
 		}
 
 	case "local_profile":

--- a/agent/internal/workspaceindex/crawl.go
+++ b/agent/internal/workspaceindex/crawl.go
@@ -1,0 +1,204 @@
+package workspaceindex
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/time/rate"
+)
+
+type profileCrawlTarget struct {
+	prefix string
+	dir    string
+}
+
+// runCrawl executes one server run from start through terminal completion.
+// An uploader is deliberately single-use: any Add or Drain failure abandons
+// it and fails the run immediately.
+func runCrawl(ctx context.Context, deps Deps, src SourceConfig, limits ConfigLimits) error {
+	deps = deps.withDefaults()
+	if deps.Client == nil {
+		return errors.New("workspace index client is required")
+	}
+
+	run, err := deps.Client.StartRun(ctx, src.ID)
+	if errors.Is(err, ErrRunConflict) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("start crawl run: %w", err)
+	}
+	if run == nil || run.RunID == "" {
+		return errors.New("start crawl run returned no run ID")
+	}
+
+	stats := Stats{}
+	fail := func(cause error) error {
+		stats.Errors++
+		// Reconciliation may cancel the crawl context. Completion is still a
+		// best-effort terminal notification, so retain values but not cancellation.
+		_ = deps.Client.CompleteRun(context.WithoutCancel(ctx), run.RunID, false, stats, cause.Error())
+		return cause
+	}
+
+	uploader := NewUploader(deps.Client, run.RunID, limits)
+	resumeCursor := ""
+	if src.ActiveRun != nil && src.ActiveRun.RunID == run.RunID {
+		resumeCursor = src.ActiveRun.Cursor
+	}
+	limiter := crawlRateLimiter(limits.WalkOpsPerSecond)
+	emit := func(entry Entry) error {
+		if err := uploader.Add(ctx, entry); err != nil {
+			return err
+		}
+		stats.Seen++
+		return nil
+	}
+
+	switch src.Kind {
+	case "smb_share":
+		cred, fetchErr := deps.Client.FetchCredential(ctx, src.ID)
+		if fetchErr != nil {
+			return fail(fmt.Errorf("fetch SMB credential: %w", fetchErr))
+		}
+		if cred == nil {
+			return fail(errors.New("fetch SMB credential returned no credential"))
+		}
+		defer cred.Zero()
+
+		fsys, closer, dialErr := deps.DialSMB(ctx, src.RootPath, cred)
+		if dialErr != nil {
+			safeErr := redactCredentialError(dialErr, cred)
+			cred.Zero()
+			return fail(safeErr)
+		}
+		cred.Zero()
+		if fsys == nil {
+			if closer != nil {
+				_ = closer.Close()
+			}
+			return fail(errors.New("dial SMB returned no filesystem"))
+		}
+		if closer != nil {
+			defer closer.Close()
+		}
+		if _, walkErr := Walk(ctx, fsys, ".", WalkOptions{
+			ExcludeGlobs: src.ExcludeGlobs,
+			ResumeCursor: resumeCursor,
+			Limiter:      limiter,
+		}, emit); walkErr != nil {
+			return fail(fmt.Errorf("walk SMB source: %w", walkErr))
+		}
+
+	case "local_profile":
+		// Each sub-walk operates in its directory-local cursor space. Prefixing
+		// before Add composes those spaces into one globally ordered cursor space:
+		// <username>/<folder>/<sub-walk relPath>.
+		for _, target := range localProfileTargets(deps, src) {
+			localResume, shouldWalk := targetResumeCursor(resumeCursor, target.prefix)
+			if !shouldWalk {
+				continue
+			}
+			_, walkErr := Walk(ctx, NewLocalFS(target.dir), ".", WalkOptions{
+				ExcludeGlobs: src.ExcludeGlobs,
+				ResumeCursor: localResume,
+				Limiter:      limiter,
+			}, func(entry Entry) error {
+				entry.RelPath = path.Join(target.prefix, entry.RelPath)
+				if entry.ParentPath == "" {
+					entry.ParentPath = target.prefix
+				} else {
+					entry.ParentPath = path.Join(target.prefix, entry.ParentPath)
+				}
+				return emit(entry)
+			})
+			if walkErr != nil {
+				return fail(fmt.Errorf("walk local profile %s: %w", target.prefix, walkErr))
+			}
+		}
+
+	default:
+		return fail(fmt.Errorf("unsupported workspace index source kind %q", src.Kind))
+	}
+
+	if err := uploader.Drain(ctx); err != nil {
+		return fail(fmt.Errorf("drain crawl uploader: %w", err))
+	}
+	if err := deps.Client.CompleteRun(ctx, run.RunID, true, stats, ""); err != nil {
+		return fail(fmt.Errorf("complete crawl run: %w", err))
+	}
+	return nil
+}
+
+func crawlRateLimiter(opsPerSecond int) *rate.Limiter {
+	if opsPerSecond <= 0 {
+		return nil
+	}
+	return rate.NewLimiter(rate.Limit(opsPerSecond), opsPerSecond)
+}
+
+func localProfileTargets(deps Deps, src SourceConfig) []profileCrawlTarget {
+	var profiles []ProfileRoot
+	if deps.Enumerate != nil {
+		profiles = deps.Enumerate()
+	} else {
+		profiles = EnumerateProfileRoots(src.RootPath)
+	}
+
+	targets := make([]profileCrawlTarget, 0, len(profiles)*len(standardProfileCrawlDirs))
+	for _, profile := range profiles {
+		for _, dir := range ProfileCrawlDirs(profile) {
+			targets = append(targets, profileCrawlTarget{
+				prefix: path.Join(profile.Username, filepath.Base(dir)),
+				dir:    dir,
+			})
+		}
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		return compareWalkPaths(targets[i].prefix, targets[j].prefix) < 0
+	})
+	return targets
+}
+
+func targetResumeCursor(globalCursor, prefix string) (string, bool) {
+	if globalCursor == "" || globalCursor == prefix {
+		return "", true
+	}
+	if strings.HasPrefix(globalCursor, prefix+"/") {
+		return strings.TrimPrefix(globalCursor, prefix+"/"), true
+	}
+	if compareWalkPaths(prefix, globalCursor) > 0 {
+		return "", true
+	}
+	return "", false
+}
+
+type credentialSafeError struct {
+	message string
+}
+
+func (e *credentialSafeError) Error() string { return e.message }
+
+func redactCredentialError(err error, cred *Credential) error {
+	if err == nil {
+		return nil
+	}
+	message := err.Error()
+	if cred != nil {
+		values := []string{cred.Password, cred.Username}
+		if cred.Domain != nil {
+			values = append(values, *cred.Domain)
+		}
+		for _, value := range values {
+			if value != "" {
+				message = strings.ReplaceAll(message, value, "[REDACTED]")
+			}
+		}
+	}
+	return &credentialSafeError{message: message}
+}

--- a/agent/internal/workspaceindex/crawl_test.go
+++ b/agent/internal/workspaceindex/crawl_test.go
@@ -1,0 +1,264 @@
+package workspaceindex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type crawlCompletion struct {
+	Complete bool   `json:"complete"`
+	Stats    Stats  `json:"stats"`
+	Error    string `json:"error"`
+}
+
+func TestRunCrawlLocalProfileUploadsBatchesAndCompletesWithStats(t *testing.T) {
+	profileDir := filepath.Join(t.TempDir(), "alice")
+	documentsDir := filepath.Join(profileDir, "Documents")
+	if err := os.MkdirAll(filepath.Join(documentsDir, "projects"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(documentsDir, "notes.txt"), []byte("notes"), 0o600); err != nil {
+		t.Fatalf("WriteFile notes: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(documentsDir, "projects", "plan.md"), []byte("plan"), 0o600); err != nil {
+		t.Fatalf("WriteFile plan: %v", err)
+	}
+
+	var requests []string
+	var batches []receivedBatch
+	var completion crawlCompletion
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.Path)
+		switch r.URL.Path {
+		case "/api/v1/workspace/agent/runs":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"runId":"run-happy","cursor":""}`)
+		case "/api/v1/workspace/agent/runs/run-happy/batch":
+			batches = append(batches, decodeReceivedBatch(t, r))
+			w.WriteHeader(http.StatusAccepted)
+		case "/api/v1/workspace/agent/runs/run-happy/complete":
+			if err := json.NewDecoder(r.Body).Decode(&completion); err != nil {
+				t.Errorf("decode completion: %v", err)
+			}
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	deps := Deps{
+		Client: client,
+		Log:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Enumerate: func() []ProfileRoot {
+			return []ProfileRoot{{Username: "alice", Dir: profileDir}}
+		},
+	}
+	err := runCrawl(context.Background(), deps, SourceConfig{
+		ID: "local-1", Kind: "local_profile",
+	}, ConfigLimits{MaxBatchEntries: 2, MaxBatchBytes: 1_000_000, WalkOpsPerSecond: 10_000})
+	if err != nil {
+		t.Fatalf("runCrawl: %v", err)
+	}
+
+	if want := []string{
+		"/api/v1/workspace/agent/runs",
+		"/api/v1/workspace/agent/runs/run-happy/batch",
+		"/api/v1/workspace/agent/runs/run-happy/batch",
+		"/api/v1/workspace/agent/runs/run-happy/complete",
+	}; !reflect.DeepEqual(requests, want) {
+		t.Fatalf("request order = %#v, want %#v", requests, want)
+	}
+	var paths []string
+	for _, batch := range batches {
+		paths = append(paths, entryRelPaths(batch.Entries)...)
+	}
+	wantPaths := []string{
+		"alice/Documents/notes.txt",
+		"alice/Documents/projects",
+		"alice/Documents/projects/plan.md",
+	}
+	if !reflect.DeepEqual(paths, wantPaths) {
+		t.Fatalf("uploaded paths = %#v, want %#v", paths, wantPaths)
+	}
+	if !completion.Complete || completion.Error != "" {
+		t.Fatalf("completion = %+v, want successful completion", completion)
+	}
+	if want := (Stats{Seen: len(wantPaths), Errors: 0}); completion.Stats != want {
+		t.Fatalf("completion stats = %+v, want %+v", completion.Stats, want)
+	}
+}
+
+func TestRunCrawlSMBDialFailureCompletesWithoutBatchOrCredentialLeak(t *testing.T) {
+	const password = "dont-log-this-password"
+	var (
+		batchRequests int
+		completion    crawlCompletion
+		dialedCred    *Credential
+	)
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workspace/agent/runs":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"runId":"run-smb","cursor":""}`)
+		case "/api/v1/workspace/agent/sources/smb-1/credential":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"username":"svc-crawler","password":"`+password+`"}`)
+		case "/api/v1/workspace/agent/runs/run-smb/batch":
+			batchRequests++
+			w.WriteHeader(http.StatusAccepted)
+		case "/api/v1/workspace/agent/runs/run-smb/complete":
+			if err := json.NewDecoder(r.Body).Decode(&completion); err != nil {
+				t.Errorf("decode completion: %v", err)
+			}
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	var logs bytes.Buffer
+	deps := Deps{
+		Client: client,
+		Log:    slog.New(slog.NewTextHandler(&logs, nil)),
+		DialSMB: func(_ context.Context, _ string, cred *Credential) (SourceFS, io.Closer, error) {
+			dialedCred = cred
+			return nil, nil, errors.New("NTLM rejected password " + cred.Password)
+		},
+	}
+	err := runCrawl(context.Background(), deps, SourceConfig{
+		ID: "smb-1", Kind: "smb_share", RootPath: `\\fileserver\workspace`, HasCredential: true,
+	}, ConfigLimits{WalkOpsPerSecond: 10_000})
+	if err == nil {
+		t.Fatal("runCrawl error = nil, want SMB dial failure")
+	}
+	if batchRequests != 0 {
+		t.Fatalf("batch requests = %d, want 0", batchRequests)
+	}
+	if completion.Complete || completion.Error == "" {
+		t.Fatalf("completion = %+v, want failed completion with a reason", completion)
+	}
+	if strings.Contains(completion.Error, password) {
+		t.Fatalf("completion reason leaked password: %q", completion.Error)
+	}
+	if strings.Contains(logs.String(), password) {
+		t.Fatalf("captured slog output leaked password: %q", logs.String())
+	}
+	for cause := err; cause != nil; cause = errors.Unwrap(cause) {
+		if strings.Contains(cause.Error(), password) {
+			t.Fatalf("returned error chain retained password: %q", cause.Error())
+		}
+	}
+	if dialedCred == nil {
+		t.Fatal("DialSMB did not receive a credential")
+	}
+	if dialedCred.Username != "" || dialedCred.Password != "" || dialedCred.Domain != nil {
+		t.Fatalf("credential retained after dial: %#v", dialedCred)
+	}
+}
+
+func TestRunCrawlLocalProfileResumeCursorUsesPrefixedCursorSpace(t *testing.T) {
+	profileDir := filepath.Join(t.TempDir(), "alice")
+	documentsDir := filepath.Join(profileDir, "Documents")
+	downloadsDir := filepath.Join(profileDir, "Downloads")
+	for _, dir := range []string{documentsDir, downloadsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll %s: %v", dir, err)
+		}
+	}
+	for path, contents := range map[string]string{
+		filepath.Join(documentsDir, "before-prefix.txt"): "old",
+		filepath.Join(downloadsDir, "a.txt"):             "at cursor",
+		filepath.Join(downloadsDir, "b.txt"):             "after cursor",
+	} {
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("WriteFile %s: %v", path, err)
+		}
+	}
+
+	var uploaded []string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workspace/agent/runs":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"runId":"run-resume","cursor":"alice/Downloads/a.txt"}`)
+		case "/api/v1/workspace/agent/runs/run-resume/batch":
+			uploaded = append(uploaded, entryRelPaths(decodeReceivedBatch(t, r).Entries)...)
+			w.WriteHeader(http.StatusAccepted)
+		case "/api/v1/workspace/agent/runs/run-resume/complete":
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	deps := Deps{
+		Client: client,
+		Log:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Enumerate: func() []ProfileRoot {
+			return []ProfileRoot{{Username: "alice", Dir: profileDir}}
+		},
+	}
+	src := SourceConfig{
+		ID:   "local-resume",
+		Kind: "local_profile",
+		ActiveRun: &ActiveRun{
+			RunID:  "run-resume",
+			Cursor: "alice/Downloads/a.txt",
+		},
+	}
+	if err := runCrawl(context.Background(), deps, src, ConfigLimits{
+		MaxBatchEntries: 10, MaxBatchBytes: 1_000_000, WalkOpsPerSecond: 10_000,
+	}); err != nil {
+		t.Fatalf("runCrawl: %v", err)
+	}
+
+	want := []string{"alice/Downloads/b.txt"}
+	if !reflect.DeepEqual(uploaded, want) {
+		t.Fatalf("uploaded paths after %q = %#v, want %#v; earlier directory prefixes and entries through the cursor must be skipped", src.ActiveRun.Cursor, uploaded, want)
+	}
+}
+
+func TestRunCrawlZeroesCredentialWhenSMBDialPanics(t *testing.T) {
+	var dialedCred *Credential
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workspace/agent/runs":
+			_, _ = io.WriteString(w, `{"runId":"run-panic","cursor":""}`)
+		case "/api/v1/workspace/agent/sources/smb-panic/credential":
+			_, _ = io.WriteString(w, `{"username":"panic-user","password":"panic-secret"}`)
+		default:
+			w.WriteHeader(http.StatusAccepted)
+		}
+	}))
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("runCrawl did not propagate dial panic")
+		}
+		if dialedCred == nil || dialedCred.Username != "" || dialedCred.Password != "" || dialedCred.Domain != nil {
+			t.Fatalf("credential retained after dial panic: %#v", dialedCred)
+		}
+	}()
+
+	_ = runCrawl(context.Background(), Deps{
+		Client: client,
+		Log:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DialSMB: func(_ context.Context, _ string, cred *Credential) (SourceFS, io.Closer, error) {
+			dialedCred = cred
+			panic("dial panic")
+		},
+	}, SourceConfig{ID: "smb-panic", Kind: "smb_share", RootPath: `\\server\share`}, ConfigLimits{})
+}

--- a/agent/internal/workspaceindex/crawl_test.go
+++ b/agent/internal/workspaceindex/crawl_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -20,6 +21,13 @@ type crawlCompletion struct {
 	Stats    Stats  `json:"stats"`
 	Error    string `json:"error"`
 }
+
+type failingCrawlFS struct {
+	err error
+}
+
+func (f failingCrawlFS) ReadDir(string) ([]fs.DirEntry, error) { return nil, f.err }
+func (f failingCrawlFS) Stat(string) (fs.FileInfo, error)      { return nil, f.err }
 
 func TestRunCrawlLocalProfileUploadsBatchesAndCompletesWithStats(t *testing.T) {
 	profileDir := filepath.Join(t.TempDir(), "alice")
@@ -168,6 +176,73 @@ func TestRunCrawlSMBDialFailureCompletesWithoutBatchOrCredentialLeak(t *testing.
 	}
 }
 
+func TestRunCrawlSMBWalkFailureRedactsCredentialFromCompletionAndReturn(t *testing.T) {
+	const (
+		username = "svc-workspace"
+		password = "walk-secret-password"
+		domain   = "CORP-SECRET"
+	)
+	var (
+		completion crawlCompletion
+		dialedCred *Credential
+	)
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workspace/agent/runs":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"runId":"run-smb-walk","cursor":""}`)
+		case "/api/v1/workspace/agent/sources/smb-walk/credential":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"username":"`+username+`","password":"`+password+`","domain":"`+domain+`"}`)
+		case "/api/v1/workspace/agent/runs/run-smb-walk/complete":
+			if err := json.NewDecoder(r.Body).Decode(&completion); err != nil {
+				t.Errorf("decode completion: %v", err)
+			}
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	walkErr := errors.New("SMB access denied for " + domain + `\` + username + " using " + password)
+	err := runCrawl(context.Background(), Deps{
+		Client: client,
+		Log:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DialSMB: func(_ context.Context, _ string, cred *Credential) (SourceFS, io.Closer, error) {
+			dialedCred = cred
+			return failingCrawlFS{err: walkErr}, nil, nil
+		},
+	}, SourceConfig{
+		ID: "smb-walk", Kind: "smb_share", RootPath: `\\server\share`, HasCredential: true,
+	}, ConfigLimits{WalkOpsPerSecond: 10_000})
+	if err == nil {
+		t.Fatal("runCrawl error = nil, want SMB walk failure")
+	}
+	if completion.Complete || completion.Error == "" {
+		t.Fatalf("completion = %+v, want failed completion with a reason", completion)
+	}
+	for _, surface := range []struct {
+		name  string
+		value string
+	}{
+		{name: "completion reason", value: completion.Error},
+		{name: "returned error", value: err.Error()},
+	} {
+		for _, secret := range []string{username, password, domain} {
+			if strings.Contains(surface.value, secret) {
+				t.Errorf("%s leaked credential value %q: %q", surface.name, secret, surface.value)
+			}
+		}
+	}
+	if dialedCred == nil {
+		t.Fatal("DialSMB did not receive a credential")
+	}
+	if dialedCred.Username != "" || dialedCred.Password != "" || dialedCred.Domain != nil {
+		t.Fatalf("credential retained after successful dial: %#v", dialedCred)
+	}
+}
+
 func TestRunCrawlLocalProfileResumeCursorUsesPrefixedCursorSpace(t *testing.T) {
 	profileDir := filepath.Join(t.TempDir(), "alice")
 	documentsDir := filepath.Join(profileDir, "Documents")
@@ -228,6 +303,121 @@ func TestRunCrawlLocalProfileResumeCursorUsesPrefixedCursorSpace(t *testing.T) {
 	want := []string{"alice/Downloads/b.txt"}
 	if !reflect.DeepEqual(uploaded, want) {
 		t.Fatalf("uploaded paths after %q = %#v, want %#v; earlier directory prefixes and entries through the cursor must be skipped", src.ActiveRun.Cursor, uploaded, want)
+	}
+}
+
+func TestRunCrawlLocalProfileOrdersUsersAndResumesAcrossMultipleRoots(t *testing.T) {
+	profilesBase := t.TempDir()
+	aliceDir := filepath.Join(profilesBase, "alice")
+	bobDir := filepath.Join(profilesBase, "bob")
+	for _, profileDir := range []string{aliceDir, bobDir} {
+		for _, crawlDir := range []string{"Documents", "Downloads"} {
+			if err := os.MkdirAll(filepath.Join(profileDir, crawlDir), 0o755); err != nil {
+				t.Fatalf("MkdirAll %s/%s: %v", profileDir, crawlDir, err)
+			}
+		}
+	}
+
+	files := map[string]string{
+		filepath.Join(aliceDir, "Documents", "01-alice-document.txt"): "alice document one",
+		filepath.Join(aliceDir, "Documents", "02-alice-document.txt"): "alice document two",
+		filepath.Join(aliceDir, "Downloads", "01-alice-download.txt"): "alice download",
+		filepath.Join(bobDir, "Documents", "01-cursor.txt"):           "bob cursor",
+		filepath.Join(bobDir, "Documents", "02-after-cursor.txt"):     "bob after cursor",
+		filepath.Join(bobDir, "Documents", "03-last-document.txt"):    "bob last document",
+		filepath.Join(bobDir, "Downloads", "01-later-folder.txt"):     "bob later folder",
+	}
+	for file, contents := range files {
+		if err := os.WriteFile(file, []byte(contents), 0o600); err != nil {
+			t.Fatalf("WriteFile %s: %v", file, err)
+		}
+	}
+
+	// Return profiles in the opposite order to prove crawl ordering does not
+	// depend on the platform enumerator's result order.
+	enumerate := func() []ProfileRoot {
+		return []ProfileRoot{
+			{Username: "bob", Dir: bobDir},
+			{Username: "alice", Dir: aliceDir},
+		}
+	}
+	limits := ConfigLimits{MaxBatchEntries: 2, MaxBatchBytes: 1_000_000, WalkOpsPerSecond: 10_000}
+
+	run := func(runID, cursor string) []string {
+		t.Helper()
+		var uploaded []string
+		client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/v1/workspace/agent/runs":
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"runId":"`+runID+`","cursor":"`+cursor+`"}`)
+			case "/api/v1/workspace/agent/runs/" + runID + "/batch":
+				uploaded = append(uploaded, entryRelPaths(decodeReceivedBatch(t, r).Entries)...)
+				w.WriteHeader(http.StatusAccepted)
+			case "/api/v1/workspace/agent/runs/" + runID + "/complete":
+				w.WriteHeader(http.StatusAccepted)
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		src := SourceConfig{ID: "local-multi-user", Kind: "local_profile"}
+		if cursor != "" {
+			src.ActiveRun = &ActiveRun{RunID: runID, Cursor: cursor}
+		}
+		if err := runCrawl(context.Background(), Deps{
+			Client:    client,
+			Log:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			Enumerate: enumerate,
+		}, src, limits); err != nil {
+			t.Fatalf("runCrawl(%q, %q): %v", runID, cursor, err)
+		}
+		return uploaded
+	}
+
+	full := run("run-multi-user-full", "")
+	wantFull := []string{
+		"alice/Documents/01-alice-document.txt",
+		"alice/Documents/02-alice-document.txt",
+		"alice/Downloads/01-alice-download.txt",
+		"bob/Documents/01-cursor.txt",
+		"bob/Documents/02-after-cursor.txt",
+		"bob/Documents/03-last-document.txt",
+		"bob/Downloads/01-later-folder.txt",
+	}
+	if !reflect.DeepEqual(full, wantFull) {
+		t.Fatalf("full uploaded paths = %#v, want %#v; all alice roots must precede all bob roots", full, wantFull)
+	}
+	firstBob := -1
+	for i, relPath := range full {
+		if strings.HasPrefix(relPath, "bob/") {
+			firstBob = i
+			break
+		}
+	}
+	if firstBob < 0 {
+		t.Fatalf("full uploaded paths contain no bob entry: %#v", full)
+	}
+	for i, relPath := range full {
+		if strings.HasPrefix(relPath, "alice/") && i >= firstBob {
+			t.Fatalf("alice entry %q at index %d followed first bob entry at index %d: %#v", relPath, i, firstBob, full)
+		}
+	}
+
+	const resumeCursor = "bob/Documents/01-cursor.txt"
+	resumed := run("run-multi-user-resume", resumeCursor)
+	wantResumed := []string{
+		"bob/Documents/02-after-cursor.txt",
+		"bob/Documents/03-last-document.txt",
+		"bob/Downloads/01-later-folder.txt",
+	}
+	if !reflect.DeepEqual(resumed, wantResumed) {
+		t.Fatalf("uploaded paths after %q = %#v, want %#v; resume must continue bob/Documents mid-stream and walk bob's later root", resumeCursor, resumed, wantResumed)
+	}
+	for _, relPath := range resumed {
+		if strings.HasPrefix(relPath, "alice/") {
+			t.Fatalf("resume after %q re-emitted alice path %q: %#v", resumeCursor, relPath, resumed)
+		}
 	}
 }
 

--- a/agent/internal/workspaceindex/fs_local.go
+++ b/agent/internal/workspaceindex/fs_local.go
@@ -1,0 +1,50 @@
+package workspaceindex
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type localFS struct {
+	base string
+}
+
+// NewLocalFS returns a SourceFS rooted at base.
+func NewLocalFS(base string) SourceFS {
+	absBase, err := filepath.Abs(base)
+	if err != nil {
+		absBase = filepath.Clean(base)
+	}
+	return &localFS{base: absBase}
+}
+
+func (l *localFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	fullPath, err := l.resolve(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: err}
+	}
+	return os.ReadDir(fullPath)
+}
+
+func (l *localFS) Stat(name string) (fs.FileInfo, error) {
+	fullPath, err := l.resolve(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "lstat", Path: name, Err: err}
+	}
+	return os.Lstat(fullPath)
+}
+
+func (l *localFS) resolve(name string) (string, error) {
+	if filepath.IsAbs(name) || filepath.VolumeName(name) != "" {
+		return "", fs.ErrInvalid
+	}
+
+	fullPath := filepath.Join(l.base, filepath.Clean(name))
+	rel, err := filepath.Rel(l.base, fullPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fs.ErrInvalid
+	}
+	return fullPath, nil
+}

--- a/agent/internal/workspaceindex/fs_local_test.go
+++ b/agent/internal/workspaceindex/fs_local_test.go
@@ -1,0 +1,139 @@
+package workspaceindex
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLocalFSReadDirAndStat(t *testing.T) {
+	base := t.TempDir()
+	if err := os.Mkdir(filepath.Join(base, "docs"), 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "report.txt"), []byte("report"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	fys := NewLocalFS(base)
+	entries, err := fys.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if got, want := localDirEntryNames(entries), []string{"docs", "report.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ReadDir names = %#v, want %#v", got, want)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantDir bool
+		wantLen int64
+	}{
+		{name: "directory", path: "docs", wantDir: true},
+		{name: "file", path: "report.txt", wantLen: int64(len("report"))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, statErr := fys.Stat(tt.path)
+			if statErr != nil {
+				t.Fatalf("Stat: %v", statErr)
+			}
+			if info.IsDir() != tt.wantDir || (!tt.wantDir && info.Size() != tt.wantLen) {
+				t.Fatalf("Stat(%q) = dir %v size %d, want dir %v size %d", tt.path, info.IsDir(), info.Size(), tt.wantDir, tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestLocalFSSurfacesSymlinkMode(t *testing.T) {
+	base := t.TempDir()
+	if err := os.WriteFile(filepath.Join(base, "target.txt"), []byte("target"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Symlink("target.txt", filepath.Join(base, "link.txt")); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+
+	fys := NewLocalFS(base)
+	entries, err := fys.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var link fs.DirEntry
+	for _, entry := range entries {
+		if entry.Name() == "link.txt" {
+			link = entry
+			break
+		}
+	}
+	if link == nil || link.Type()&fs.ModeSymlink == 0 {
+		t.Fatalf("link entry mode = %v, want symlink", link)
+	}
+
+	info, err := fys.Stat("link.txt")
+	if err != nil {
+		t.Fatalf("Stat symlink: %v", err)
+	}
+	if info.Mode()&fs.ModeSymlink == 0 {
+		t.Fatalf("Stat mode = %v, want symlink", info.Mode())
+	}
+}
+
+func TestLocalFSRejectsPathEscapes(t *testing.T) {
+	fys := NewLocalFS(t.TempDir())
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{name: "ReadDir parent", call: func() error { _, err := fys.ReadDir(".."); return err }},
+		{name: "Stat nested parent", call: func() error { _, err := fys.Stat(filepath.Join("dir", "..", "..", "outside")); return err }},
+		{name: "Stat absolute", call: func() error { _, err := fys.Stat(filepath.Join(string(filepath.Separator), "outside")); return err }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.call(); err == nil {
+				t.Fatal("path escape accepted, want error")
+			}
+		})
+	}
+}
+
+func TestWalkLocalFSIntegrationSkipsSymlink(t *testing.T) {
+	base := t.TempDir()
+	if err := os.Mkdir(filepath.Join(base, "alpha"), 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "alpha", "report.txt"), []byte("report"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "zeta.txt"), []byte("zeta"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Symlink("alpha", filepath.Join(base, "linked-alpha")); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+
+	var got []string
+	_, err := Walk(context.Background(), NewLocalFS(base), ".", WalkOptions{}, func(entry Entry) error {
+		got = append(got, entry.RelPath)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if want := []string{"alpha", "alpha/report.txt", "zeta.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("paths = %#v, want %#v", got, want)
+	}
+}
+
+func localDirEntryNames(entries []fs.DirEntry) []string {
+	names := make([]string, len(entries))
+	for i, entry := range entries {
+		names[i] = entry.Name()
+	}
+	return names
+}

--- a/agent/internal/workspaceindex/fs_smb.go
+++ b/agent/internal/workspaceindex/fs_smb.go
@@ -15,6 +15,36 @@ import (
 	"github.com/hirochachacha/go-smb2"
 )
 
+// Dial seams, overridable in tests so TCP-connect and NTLM-negotiation
+// failure paths (including hostile error strings) are exercisable without a
+// live SMB server. Production values are set here and never mutated at runtime.
+var (
+	smbTCPDial = func(ctx context.Context, address string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "tcp", address)
+	}
+	smbSessionDial = func(ctx context.Context, initiator *smb2.NTLMInitiator, conn net.Conn) (smbMountableSession, error) {
+		s, err := (&smb2.Dialer{Initiator: initiator}).DialContext(ctx, conn)
+		if err != nil {
+			return nil, err
+		}
+		return realSession{s}, nil
+	}
+)
+
+// smbMountableSession is the slice of *smb2.Session DialSMB needs; behind an
+// interface so the auth seam above can return a fake.
+type smbMountableSession interface {
+	smbSession
+	MountWithContext(ctx context.Context, shareName string) (smbShare, error)
+}
+
+type realSession struct{ s *smb2.Session }
+
+func (r realSession) Logoff() error { return r.s.Logoff() }
+func (r realSession) MountWithContext(ctx context.Context, shareName string) (smbShare, error) {
+	return r.s.WithContext(ctx).Mount(shareName)
+}
+
 type smbShare interface {
 	ReadDir(string) ([]os.FileInfo, error)
 	Lstat(string) (os.FileInfo, error)
@@ -162,7 +192,7 @@ func DialSMB(ctx context.Context, unc string, cred *Credential) (SourceFS, io.Cl
 	dialCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	conn, err := (&net.Dialer{}).DialContext(dialCtx, "tcp", net.JoinHostPort(host, "445"))
+	conn, err := smbTCPDial(dialCtx, net.JoinHostPort(host, "445"))
 	if err != nil {
 		credentialCopy.Zero()
 		return nil, nil, redactor.dialFailure("dial", err)
@@ -183,13 +213,13 @@ func DialSMB(ctx context.Context, unc string, cred *Credential) (SourceFS, io.Cl
 		initiator.Domain = ""
 	}()
 
-	session, err := (&smb2.Dialer{Initiator: initiator}).DialContext(dialCtx, conn)
+	session, err := smbSessionDial(dialCtx, initiator, conn)
 	if err != nil {
 		_ = conn.Close()
 		credentialCopy.Zero()
 		return nil, nil, redactor.dialFailure("authenticate", err)
 	}
-	share, err := session.WithContext(dialCtx).Mount(shareName)
+	share, err := session.MountWithContext(dialCtx, shareName)
 	if err != nil {
 		_ = session.Logoff()
 		_ = conn.Close()

--- a/agent/internal/workspaceindex/fs_smb.go
+++ b/agent/internal/workspaceindex/fs_smb.go
@@ -1,0 +1,258 @@
+package workspaceindex
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hirochachacha/go-smb2"
+)
+
+type smbShare interface {
+	ReadDir(string) ([]os.FileInfo, error)
+	Lstat(string) (os.FileInfo, error)
+	Umount() error
+}
+
+type smbSession interface {
+	Logoff() error
+}
+
+type smbFS struct {
+	share      smbShare
+	session    smbSession
+	conn       io.Closer
+	host       string
+	shareName  string
+	prefix     string
+	credential Credential
+	closeOnce  sync.Once
+	closeErr   error
+}
+
+func (s *smbFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	sharePath, err := s.resolve(name)
+	if err != nil {
+		return nil, s.redactError("readdir", name, err)
+	}
+	infos, err := s.share.ReadDir(sharePath)
+	if err != nil {
+		return nil, s.redactError("readdir", sharePath, err)
+	}
+	entries := make([]fs.DirEntry, len(infos))
+	for i, info := range infos {
+		entries[i] = smbDirEntry{info: info}
+	}
+	return entries, nil
+}
+
+func (s *smbFS) Stat(name string) (fs.FileInfo, error) {
+	sharePath, err := s.resolve(name)
+	if err != nil {
+		return nil, s.redactError("lstat", name, err)
+	}
+	info, err := s.share.Lstat(sharePath)
+	if err != nil {
+		return nil, s.redactError("lstat", sharePath, err)
+	}
+	return info, nil
+}
+
+// Close releases the mounted share, SMB session, and TCP connection. It
+// best-effort zeroes only the credential copy retained by this filesystem;
+// callers remain responsible for zeroing their own Credential value.
+func (s *smbFS) Close() error {
+	s.closeOnce.Do(func() {
+		defer s.credential.Zero()
+		var cleanupErrors []error
+		if s.share != nil {
+			cleanupErrors = append(cleanupErrors, s.share.Umount())
+		}
+		if s.session != nil {
+			cleanupErrors = append(cleanupErrors, s.session.Logoff())
+		}
+		if s.conn != nil {
+			cleanupErrors = append(cleanupErrors, s.conn.Close())
+		}
+		s.closeErr = errors.Join(cleanupErrors...)
+		if s.closeErr != nil {
+			s.closeErr = s.redactError("close", "", s.closeErr)
+		}
+	})
+	return s.closeErr
+}
+
+func (s *smbFS) resolve(name string) (string, error) {
+	normalized := strings.ReplaceAll(name, `\`, "/")
+	if strings.HasPrefix(normalized, "/") {
+		return "", &fs.PathError{Op: "resolve", Path: name, Err: fs.ErrInvalid}
+	}
+	var parts []string
+	if s.prefix != "" {
+		parts = append(parts, strings.Split(s.prefix, `\`)...)
+	}
+	if normalized != "" && normalized != "." {
+		for _, part := range strings.Split(normalized, "/") {
+			if part == ".." {
+				return "", &fs.PathError{Op: "resolve", Path: name, Err: fs.ErrInvalid}
+			}
+			if part != "" && part != "." {
+				parts = append(parts, part)
+			}
+		}
+	}
+	return strings.Join(parts, `\`), nil
+}
+
+func (s *smbFS) redactError(operation, path string, err error) error {
+	if err == nil {
+		return nil
+	}
+	location := strings.Trim(strings.Join([]string{s.host, s.shareName, path}, "/"), "/")
+	message := fmt.Sprintf("SMB %s %s: %s", operation, location, err)
+	if s.credential.Password != "" {
+		message = strings.ReplaceAll(message, s.credential.Password, "[REDACTED]")
+	}
+	return &smbOperationError{
+		message: message,
+		err:     err,
+	}
+}
+
+type smbOperationError struct {
+	message string
+	err     error
+}
+
+func (e *smbOperationError) Error() string { return e.message }
+func (e *smbOperationError) Unwrap() error { return e.err }
+
+type smbDirEntry struct {
+	info os.FileInfo
+}
+
+func (e smbDirEntry) Name() string               { return e.info.Name() }
+func (e smbDirEntry) IsDir() bool                { return e.info.IsDir() }
+func (e smbDirEntry) Type() fs.FileMode          { return e.info.Mode().Type() }
+func (e smbDirEntry) Info() (fs.FileInfo, error) { return e.info, nil }
+
+// DialSMB connects to a UNC share using explicit NTLM credentials. The
+// returned filesystem is rooted at the UNC prefix and is read-only by
+// convention; the provisioned SMB account must enforce read-only access.
+// Closing clears the filesystem's retained credential copy; the caller remains
+// responsible for calling Zero on its own Credential value.
+func DialSMB(ctx context.Context, unc string, cred *Credential) (SourceFS, io.Closer, error) {
+	host, shareName, prefix, err := ParseUNC(unc)
+	if err != nil {
+		return nil, nil, err
+	}
+	if cred == nil {
+		return nil, nil, fmt.Errorf("dial SMB %s/%s: credential is required", host, shareName)
+	}
+
+	credentialCopy := cloneCredential(cred)
+	redactor := &smbFS{host: host, shareName: shareName, credential: credentialCopy}
+	dialCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	conn, err := (&net.Dialer{}).DialContext(dialCtx, "tcp", net.JoinHostPort(host, "445"))
+	if err != nil {
+		credentialCopy.Zero()
+		return nil, nil, redactor.dialFailure("dial", err)
+	}
+
+	domain := ""
+	if credentialCopy.Domain != nil {
+		domain = *credentialCopy.Domain
+	}
+	initiator := &smb2.NTLMInitiator{
+		User:     credentialCopy.Username,
+		Password: credentialCopy.Password,
+		Domain:   domain,
+	}
+	defer func() {
+		initiator.User = ""
+		initiator.Password = ""
+		initiator.Domain = ""
+	}()
+
+	session, err := (&smb2.Dialer{Initiator: initiator}).DialContext(dialCtx, conn)
+	if err != nil {
+		_ = conn.Close()
+		credentialCopy.Zero()
+		return nil, nil, redactor.dialFailure("authenticate", err)
+	}
+	share, err := session.WithContext(dialCtx).Mount(shareName)
+	if err != nil {
+		_ = session.Logoff()
+		_ = conn.Close()
+		credentialCopy.Zero()
+		return nil, nil, redactor.dialFailure("mount", err)
+	}
+
+	fys := &smbFS{
+		share:      share,
+		session:    session,
+		conn:       conn,
+		host:       host,
+		shareName:  shareName,
+		prefix:     prefix,
+		credential: credentialCopy,
+	}
+	redactor.credential.Zero()
+	return fys, fys, nil
+}
+
+func (s *smbFS) dialFailure(operation string, err error) error {
+	redacted := s.redactError(operation, "", err)
+	s.credential.Zero()
+	return redacted
+}
+
+func cloneCredential(cred *Credential) Credential {
+	clone := Credential{Username: cred.Username, Password: cred.Password}
+	if cred.Domain != nil {
+		domain := *cred.Domain
+		clone.Domain = &domain
+	}
+	return clone
+}
+
+// ParseUNC splits a UNC path into its host, share, and optional path prefix.
+func ParseUNC(unc string) (host, share, prefix string, err error) {
+	if !strings.HasPrefix(unc, `\\`) {
+		return "", "", "", fmt.Errorf("invalid UNC path: missing leading \\\\")
+	}
+	if strings.Contains(unc, "/") {
+		return "", "", "", fmt.Errorf("invalid UNC path: forward slashes are not allowed")
+	}
+
+	parts := strings.Split(strings.TrimPrefix(unc, `\\`), `\`)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", "", fmt.Errorf("invalid UNC path: host and share are required")
+	}
+	for _, part := range parts {
+		if part == ".." {
+			return "", "", "", fmt.Errorf("invalid UNC path: parent segments are not allowed")
+		}
+	}
+
+	host, share = parts[0], parts[1]
+	prefixParts := parts[2:]
+	for len(prefixParts) > 0 && prefixParts[len(prefixParts)-1] == "" {
+		prefixParts = prefixParts[:len(prefixParts)-1]
+	}
+	for _, part := range prefixParts {
+		if part == "" {
+			return "", "", "", fmt.Errorf("invalid UNC path: empty path segment")
+		}
+	}
+	return host, share, strings.Join(prefixParts, `\`), nil
+}

--- a/agent/internal/workspaceindex/fs_smb_test.go
+++ b/agent/internal/workspaceindex/fs_smb_test.go
@@ -1,0 +1,213 @@
+package workspaceindex
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseUNC(t *testing.T) {
+	tests := []struct {
+		name       string
+		unc        string
+		wantHost   string
+		wantShare  string
+		wantPrefix string
+		wantErr    bool
+	}{
+		{name: "share root", unc: `\\srv\share`, wantHost: "srv", wantShare: "share"},
+		{name: "nested prefix", unc: `\\srv\share\deep\path`, wantHost: "srv", wantShare: "share", wantPrefix: `deep\path`},
+		{name: "trailing separator", unc: `\\srv\share\`, wantHost: "srv", wantShare: "share"},
+		{name: "missing UNC prefix", unc: `srv\share`, wantErr: true},
+		{name: "missing share", unc: `\\srv`, wantErr: true},
+		{name: "parent segment", unc: `\\srv\share\..\x`, wantErr: true},
+		{name: "empty", unc: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, share, prefix, err := ParseUNC(tt.unc)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseUNC(%q) succeeded, want error", tt.unc)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseUNC(%q): %v", tt.unc, err)
+			}
+			if host != tt.wantHost || share != tt.wantShare || prefix != tt.wantPrefix {
+				t.Fatalf("ParseUNC(%q) = (%q, %q, %q), want (%q, %q, %q)", tt.unc, host, share, prefix, tt.wantHost, tt.wantShare, tt.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestDialSMBErrorMentionsHostWithoutPassword(t *testing.T) {
+	const (
+		host     = "192.0.2.1"
+		password = "dial-secret-password"
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	_, closer, err := DialSMB(ctx, `\\`+host+`\share`, &Credential{Username: "reader", Password: password})
+	if closer != nil {
+		_ = closer.Close()
+		t.Fatal("DialSMB returned a closer on error")
+	}
+	if err == nil {
+		t.Fatal("DialSMB succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), host) {
+		t.Fatalf("DialSMB error %q does not mention host %q", err, host)
+	}
+	if strings.Contains(err.Error(), password) {
+		t.Fatalf("DialSMB error %q contains password", err)
+	}
+}
+
+func TestDialSMBAlreadyCancelledReturnsPromptly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	started := time.Now()
+
+	_, closer, err := DialSMB(ctx, `\\192.0.2.1\share`, &Credential{Username: "reader", Password: "secret"})
+	if closer != nil {
+		_ = closer.Close()
+		t.Fatal("DialSMB returned a closer on error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("DialSMB error = %v, want context.Canceled", err)
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("DialSMB with cancelled context took %v, want prompt return", elapsed)
+	}
+}
+
+func TestSMBFSMapsPathsAndUsesLstat(t *testing.T) {
+	file := fakeSMBFileInfo{name: "report.txt", size: 42}
+	directory := fakeSMBFileInfo{name: "docs", mode: fs.ModeDir}
+	share := &fakeSMBShare{entries: []os.FileInfo{directory, file}, statInfo: file}
+	fys := &smbFS{share: share, prefix: `deep\path`}
+
+	entries, err := fys.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if share.readDirPath != `deep\path` {
+		t.Fatalf("ReadDir path = %q, want %q", share.readDirPath, `deep\path`)
+	}
+	if got, want := []string{entries[0].Name(), entries[1].Name()}, []string{"docs", "report.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("entry names = %#v, want %#v", got, want)
+	}
+	if !entries[0].IsDir() || entries[1].Type() != 0 {
+		t.Fatalf("entry types = (%v, %v), want directory then regular file", entries[0].Type(), entries[1].Type())
+	}
+	if info, infoErr := entries[1].Info(); infoErr != nil || info.Name() != "report.txt" {
+		t.Fatalf("entry Info() = (%v, %v), want report.txt", info, infoErr)
+	}
+
+	info, err := fys.Stat("folder/report.txt")
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Name() != "report.txt" || share.lstatPath != `deep\path\folder\report.txt` {
+		t.Fatalf("Stat result/path = (%q, %q), want (%q, %q)", info.Name(), share.lstatPath, "report.txt", `deep\path\folder\report.txt`)
+	}
+}
+
+func TestSMBFSReadErrorDoesNotExposePassword(t *testing.T) {
+	const password = "top-secret-password"
+	fys := &smbFS{
+		share:      &fakeSMBShare{readDirErr: errors.New("read failed using " + password)},
+		credential: Credential{Password: password},
+	}
+
+	_, err := fys.ReadDir(".")
+	if err == nil {
+		t.Fatal("ReadDir succeeded, want error")
+	}
+	if strings.Contains(err.Error(), password) {
+		t.Fatalf("ReadDir error %q contains password", err)
+	}
+}
+
+func TestSMBFSCloseCleansUpAndZeroesRetainedCredential(t *testing.T) {
+	domain := "EXAMPLE"
+	share := &fakeSMBShare{}
+	session := &fakeSMBSession{}
+	conn := &fakeSMBConn{}
+	fys := &smbFS{
+		share:      share,
+		session:    session,
+		conn:       conn,
+		credential: Credential{Username: "reader", Password: "secret", Domain: &domain},
+	}
+
+	if err := fys.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if share.umountCalls != 1 || session.logoffCalls != 1 || conn.closeCalls != 1 {
+		t.Fatalf("cleanup calls = umount %d logoff %d close %d, want all 1", share.umountCalls, session.logoffCalls, conn.closeCalls)
+	}
+	if fys.credential.Username != "" || fys.credential.Password != "" || fys.credential.Domain != nil {
+		t.Fatalf("retained credential after Close = %#v, want zeroed", fys.credential)
+	}
+}
+
+type fakeSMBShare struct {
+	entries     []os.FileInfo
+	statInfo    os.FileInfo
+	readDirErr  error
+	readDirPath string
+	lstatPath   string
+	umountCalls int
+}
+
+func (f *fakeSMBShare) ReadDir(name string) ([]os.FileInfo, error) {
+	f.readDirPath = name
+	return f.entries, f.readDirErr
+}
+
+func (f *fakeSMBShare) Lstat(name string) (os.FileInfo, error) {
+	f.lstatPath = name
+	return f.statInfo, nil
+}
+
+func (f *fakeSMBShare) Umount() error {
+	f.umountCalls++
+	return nil
+}
+
+type fakeSMBSession struct{ logoffCalls int }
+
+func (f *fakeSMBSession) Logoff() error {
+	f.logoffCalls++
+	return nil
+}
+
+type fakeSMBConn struct{ closeCalls int }
+
+func (f *fakeSMBConn) Close() error {
+	f.closeCalls++
+	return nil
+}
+
+type fakeSMBFileInfo struct {
+	name string
+	size int64
+	mode fs.FileMode
+}
+
+func (f fakeSMBFileInfo) Name() string       { return f.name }
+func (f fakeSMBFileInfo) Size() int64        { return f.size }
+func (f fakeSMBFileInfo) Mode() fs.FileMode  { return f.mode }
+func (f fakeSMBFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeSMBFileInfo) IsDir() bool        { return f.mode.IsDir() }
+func (f fakeSMBFileInfo) Sys() any           { return nil }

--- a/agent/internal/workspaceindex/fs_smb_test.go
+++ b/agent/internal/workspaceindex/fs_smb_test.go
@@ -3,12 +3,16 @@ package workspaceindex
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
+	"net"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hirochachacha/go-smb2"
 )
 
 func TestParseUNC(t *testing.T) {
@@ -162,20 +166,24 @@ func TestSMBFSCloseCleansUpAndZeroesRetainedCredential(t *testing.T) {
 }
 
 type fakeSMBShare struct {
-	entries     []os.FileInfo
-	statInfo    os.FileInfo
-	readDirErr  error
-	readDirPath string
-	lstatPath   string
-	umountCalls int
+	entries      []os.FileInfo
+	statInfo     os.FileInfo
+	readDirErr   error
+	readDirPath  string
+	lstatPath    string
+	umountCalls  int
+	readDirCalls int
+	lstatCalls   int
 }
 
 func (f *fakeSMBShare) ReadDir(name string) ([]os.FileInfo, error) {
+	f.readDirCalls++
 	f.readDirPath = name
 	return f.entries, f.readDirErr
 }
 
 func (f *fakeSMBShare) Lstat(name string) (os.FileInfo, error) {
+	f.lstatCalls++
 	f.lstatPath = name
 	return f.statInfo, nil
 }
@@ -211,3 +219,52 @@ func (f fakeSMBFileInfo) Mode() fs.FileMode  { return f.mode }
 func (f fakeSMBFileInfo) ModTime() time.Time { return time.Time{} }
 func (f fakeSMBFileInfo) IsDir() bool        { return f.mode.IsDir() }
 func (f fakeSMBFileInfo) Sys() any           { return nil }
+
+// Auth-failure redaction through the dial seam: even if the negotiation layer
+// returned a hostile error embedding the password, DialSMB must redact it.
+func TestDialSMBAuthFailureRedactsLeakyError(t *testing.T) {
+	const password = "hunter2-ntlm-secret"
+	origTCP, origSession := smbTCPDial, smbSessionDial
+	t.Cleanup(func() { smbTCPDial, smbSessionDial = origTCP, origSession })
+
+	smbTCPDial = func(context.Context, string) (net.Conn, error) {
+		client, server := net.Pipe()
+		t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+		return client, nil
+	}
+	smbSessionDial = func(_ context.Context, initiator *smb2.NTLMInitiator, _ net.Conn) (smbMountableSession, error) {
+		return nil, fmt.Errorf("NTLM negotiation rejected for %s with password %s", initiator.User, initiator.Password)
+	}
+
+	_, _, err := DialSMB(context.Background(), `\\nas01.test\projects`, &Credential{
+		Username: "svc-reader",
+		Password: password,
+	})
+	if err == nil {
+		t.Fatal("DialSMB should fail when session negotiation fails")
+	}
+	if !strings.Contains(err.Error(), "nas01.test") || !strings.Contains(err.Error(), "authenticate") {
+		t.Fatalf("error should carry host + operation context, got: %v", err)
+	}
+	if strings.Contains(err.Error(), password) {
+		t.Fatalf("auth error leaked the password: %v", err)
+	}
+}
+
+// resolve()-level traversal rejection: attacker-shaped names never reach the share.
+func TestSMBFSRejectsTraversalPaths(t *testing.T) {
+	share := &fakeSMBShare{}
+	fys := &smbFS{share: share, host: "nas01", shareName: "projects"}
+	for _, name := range []string{"..", "../x", `..\x`, "a/../b", `a\..\b`, "a/../../b"} {
+		if _, err := fys.ReadDir(name); err == nil {
+			t.Fatalf("ReadDir(%q) should be rejected", name)
+		}
+		if _, err := fys.Stat(name); err == nil {
+			t.Fatalf("Stat(%q) should be rejected", name)
+		}
+	}
+	if share.readDirCalls != 0 || share.lstatCalls != 0 {
+		t.Fatalf("share must never be reached for traversal names (ReadDir=%d, Lstat=%d)",
+			share.readDirCalls, share.lstatCalls)
+	}
+}

--- a/agent/internal/workspaceindex/loop.go
+++ b/agent/internal/workspaceindex/loop.go
@@ -1,0 +1,264 @@
+package workspaceindex
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"math/rand/v2"
+	"reflect"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/logging"
+	"github.com/breeze-rmm/agent/internal/observability"
+)
+
+const moduleAbsentBackoff = 6 * time.Hour
+
+// Deps contains orchestration dependencies and the timing seams used by tests.
+type Deps struct {
+	Client    *Client
+	Log       *slog.Logger
+	Enumerate func() []ProfileRoot
+	DialSMB   func(context.Context, string, *Credential) (SourceFS, io.Closer, error)
+	Now       func() time.Time
+
+	TickInterval  time.Duration
+	WatchDebounce time.Duration
+	WatchDirCap   int
+}
+
+func (d Deps) withDefaults() Deps {
+	if d.Log == nil {
+		d.Log = logging.L("workspaceindex")
+	}
+	if d.DialSMB == nil {
+		d.DialSMB = DialSMB
+	}
+	if d.Now == nil {
+		d.Now = time.Now
+	}
+	if d.TickInterval <= 0 {
+		d.TickInterval = time.Minute
+	}
+	if d.WatchDebounce <= 0 {
+		d.WatchDebounce = 5 * time.Second
+	}
+	if d.WatchDirCap <= 0 {
+		d.WatchDirCap = 4096
+	}
+	return d
+}
+
+type crawlRequest struct {
+	src    SourceConfig
+	limits ConfigLimits
+}
+
+type crawlResult struct {
+	sourceID string
+	err      error
+}
+
+type activeCrawl struct {
+	sourceID string
+	cancel   context.CancelFunc
+}
+
+type watchRegistration struct {
+	src  SourceConfig
+	stop func()
+}
+
+// StartLoop starts the workspace-index scheduler and returns a channel closed
+// after all crawls and watchers have torn down.
+func StartLoop(ctx context.Context, deps Deps) <-chan struct{} {
+	done := make(chan struct{})
+	deps = deps.withDefaults()
+
+	go func() {
+		defer close(done)
+		defer observability.Recoverer("workspaceindex.loop")
+
+		ticker := time.NewTicker(deps.TickInterval)
+		defer ticker.Stop()
+
+		resultCh := make(chan crawlResult, 1)
+		queue := make([]crawlRequest, 0)
+		queued := make(map[string]bool)
+		activeSources := make(map[string]SourceConfig)
+		watchers := make(map[string]watchRegistration)
+		var running *activeCrawl
+		var nextFetch time.Time
+
+		stopWatches := func() {
+			for id, watcher := range watchers {
+				watcher.stop()
+				delete(watchers, id)
+			}
+		}
+		cancelActivity := func() {
+			if running != nil {
+				running.cancel()
+			}
+			stopWatches()
+			queue = queue[:0]
+			clear(queued)
+			clear(activeSources)
+		}
+
+		startNext := func() {
+			if running != nil {
+				return
+			}
+			for len(queue) > 0 {
+				req := queue[0]
+				queue = queue[1:]
+				delete(queued, req.src.ID)
+				if _, exists := activeSources[req.src.ID]; !exists {
+					continue
+				}
+
+				crawlCtx, cancel := context.WithCancel(ctx)
+				running = &activeCrawl{sourceID: req.src.ID, cancel: cancel}
+				go func() {
+					var crawlErr error
+					defer func() { resultCh <- crawlResult{sourceID: req.src.ID, err: crawlErr} }()
+					defer observability.Recoverer("workspaceindex.crawl")
+					crawlErr = runCrawl(crawlCtx, deps, req.src, req.limits)
+				}()
+				return
+			}
+		}
+
+		reconcile := func(config *CrawlConfig, now time.Time) {
+			if !config.Enabled {
+				cancelActivity()
+				return
+			}
+
+			desired := make(map[string]SourceConfig, len(config.Sources))
+			for _, src := range config.Sources {
+				if src.CadenceMinutes > 0 {
+					desired[src.ID] = src
+				}
+			}
+
+			if running != nil {
+				if _, exists := desired[running.sourceID]; !exists {
+					running.cancel()
+				}
+			}
+
+			filtered := queue[:0]
+			for _, req := range queue {
+				if src, exists := desired[req.src.ID]; exists {
+					req.src = src
+					req.limits = config.Limits
+					filtered = append(filtered, req)
+				} else {
+					delete(queued, req.src.ID)
+				}
+			}
+			queue = filtered
+
+			for id, watcher := range watchers {
+				src, exists := desired[id]
+				if !exists || src.Kind != "local_profile" || !src.Watch || !reflect.DeepEqual(src, watcher.src) {
+					watcher.stop()
+					delete(watchers, id)
+				}
+			}
+			for id, src := range desired {
+				if src.Kind == "local_profile" && src.Watch {
+					if _, exists := watchers[id]; !exists {
+						watchers[id] = watchRegistration{src: src, stop: startWatch(ctx, deps, src)}
+					}
+				}
+			}
+
+			activeSources = desired
+			for _, src := range config.Sources {
+				if _, active := desired[src.ID]; !active || !isSourceDue(now, src) {
+					continue
+				}
+				if queued[src.ID] || (running != nil && running.sourceID == src.ID) {
+					continue
+				}
+				queue = append(queue, crawlRequest{src: src, limits: config.Limits})
+				queued[src.ID] = true
+			}
+			startNext()
+		}
+
+		fetch := func() {
+			now := deps.Now()
+			if !nextFetch.IsZero() && now.Before(nextFetch) {
+				return
+			}
+			config, err := deps.Client.FetchConfig(ctx)
+			if err != nil {
+				if errors.Is(err, ErrModuleAbsent) {
+					cancelActivity()
+					nextFetch = now.Add(moduleAbsentBackoff)
+					return
+				}
+				deps.Log.Warn("fetch workspace index config", "err", err)
+				nextFetch = now.Add(deps.TickInterval)
+				return
+			}
+			reconcile(config, now)
+			nextFetch = now.Add(jitterPollInterval(config.PollIntervalSeconds))
+		}
+
+		if deps.Client == nil {
+			deps.Log.Error("workspace index loop requires a client")
+			return
+		}
+		fetch()
+		for {
+			select {
+			case <-ctx.Done():
+				cancelActivity()
+				if running != nil {
+					<-resultCh
+				}
+				return
+			case result := <-resultCh:
+				if running != nil && running.sourceID == result.sourceID {
+					running.cancel()
+					running = nil
+				}
+				if result.err != nil && ctx.Err() == nil {
+					deps.Log.Warn("workspace index crawl failed", "sourceId", result.sourceID, "err", result.err)
+				}
+				startNext()
+			case <-ticker.C:
+				fetch()
+			}
+		}
+	}()
+	return done
+}
+
+func isSourceDue(now time.Time, src SourceConfig) bool {
+	if src.CadenceMinutes <= 0 {
+		return false
+	}
+	if src.LastCompleteRunAt == nil {
+		return true
+	}
+	return now.Sub(*src.LastCompleteRunAt) >= time.Duration(src.CadenceMinutes)*time.Minute
+}
+
+func jitterPollInterval(seconds int) time.Duration {
+	if seconds <= 0 {
+		seconds = 60
+	}
+	base := time.Duration(seconds) * time.Second
+	span := base / 10
+	if span <= 0 {
+		return base
+	}
+	return base - span + time.Duration(rand.Int64N(int64(2*span)+1))
+}

--- a/agent/internal/workspaceindex/loop_test.go
+++ b/agent/internal/workspaceindex/loop_test.go
@@ -1,6 +1,7 @@
 package workspaceindex
 
 import (
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"io"
@@ -248,6 +249,157 @@ func TestStartLoopCancelsCrawlRemovedByConfig(t *testing.T) {
 	waitLoopSignal(t, batchStarted, "crawl batch")
 	waitLoopCondition(t, func() bool { return configFetches.Load() >= 2 }, "configuration reconciliation")
 	waitLoopSignal(t, batchCancelled, "removed crawl cancellation")
+}
+
+func TestStartLoopDisabledStopsCrawlAndWatcherAndDropsSourceState(t *testing.T) {
+	profile := makeLoopTestProfile(t)
+	if err := os.WriteFile(filepath.Join(profile.Dir, "Documents", "second.txt"), []byte("second"), 0o600); err != nil {
+		t.Fatalf("write second crawl entry: %v", err)
+	}
+	var configFetches atomic.Int32
+	var sourceAStarts atomic.Int32
+	var sourceBStarts atomic.Int32
+	var reenabled atomic.Bool
+	batchStarted := make(chan struct{})
+	batchCancelled := make(chan struct{})
+	watchRequestStarted := make(chan struct{})
+	watchRequestCancelled := make(chan struct{})
+	sourceBFirstBatchEntries := make(chan int, 1)
+	var batchStartedOnce sync.Once
+	var batchCancelledOnce sync.Once
+	var watchRequestStartedOnce sync.Once
+	var watchRequestCancelledOnce sync.Once
+	var sourceBFirstBatchOnce sync.Once
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/workspace/agent/crawl-config":
+			fetch := configFetches.Add(1)
+			if fetch == 2 {
+				select {
+				case <-batchStarted:
+				case <-r.Context().Done():
+					return
+				}
+				select {
+				case <-watchRequestStarted:
+				case <-r.Context().Done():
+					return
+				}
+			}
+			config := CrawlConfig{PollIntervalSeconds: 1}
+			switch {
+			case fetch == 1:
+				config.Enabled = true
+				config.Limits = ConfigLimits{MaxBatchEntries: 1, MaxBatchBytes: 1_000_000, WalkOpsPerSecond: 10_000}
+				config.Sources = []SourceConfig{
+					{ID: "source-a", Kind: "local_profile", CadenceMinutes: 60, Watch: true},
+					{ID: "source-b", Kind: "local_profile", CadenceMinutes: 60},
+				}
+			case reenabled.Load():
+				config.Enabled = true
+				config.Limits = ConfigLimits{MaxBatchEntries: 10, MaxBatchBytes: 1_000_000, WalkOpsPerSecond: 10_000}
+				config.Sources = []SourceConfig{{ID: "source-b", Kind: "local_profile", CadenceMinutes: 60}}
+			}
+			writeLoopConfig(t, w, config)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspace/agent/runs":
+			var body struct {
+				SourceID string `json:"sourceId"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode start run: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			switch body.SourceID {
+			case "source-a":
+				sourceAStarts.Add(1)
+				_, _ = io.WriteString(w, `{"runId":"source-a-run","startedAt":"2026-07-12T12:00:00Z","cursor":""}`)
+			case "source-b":
+				sourceBStarts.Add(1)
+				_, _ = io.WriteString(w, `{"runId":"source-b-run","startedAt":"2026-07-12T12:00:00Z","cursor":""}`)
+			default:
+				t.Errorf("unexpected crawl source: %q", body.SourceID)
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspace/agent/runs/source-a-run/batch":
+			batchStartedOnce.Do(func() { close(batchStarted) })
+			<-r.Context().Done()
+			batchCancelledOnce.Do(func() { close(batchCancelled) })
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspace/agent/runs/source-b-run/batch":
+			zr, err := gzip.NewReader(r.Body)
+			if err != nil {
+				t.Errorf("open source B batch: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			defer zr.Close()
+			var batch struct {
+				Entries []Entry `json:"entries"`
+			}
+			if err := json.NewDecoder(zr).Decode(&batch); err != nil {
+				t.Errorf("decode source B batch: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			sourceBFirstBatchOnce.Do(func() { sourceBFirstBatchEntries <- len(batch.Entries) })
+			<-r.Context().Done()
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspace/agent/sources/source-a/events":
+			watchRequestStartedOnce.Do(func() { close(watchRequestStarted) })
+			<-r.Context().Done()
+			watchRequestCancelledOnce.Do(func() { close(watchRequestCancelled) })
+		default:
+			w.WriteHeader(http.StatusAccepted)
+		}
+	}))
+
+	base := time.Date(2026, time.July, 12, 12, 0, 0, 0, time.UTC)
+	var nowCalls atomic.Int64
+	ctx, cancel := context.WithCancel(context.Background())
+	done := StartLoop(ctx, Deps{
+		Client:        client,
+		Log:           loopTestLogger(),
+		Enumerate:     func() []ProfileRoot { return []ProfileRoot{profile} },
+		Now:           func() time.Time { return base.Add(time.Duration(nowCalls.Add(2)) * time.Second) },
+		TickInterval:  time.Millisecond,
+		WatchDebounce: time.Millisecond,
+	})
+	defer func() {
+		cancel()
+		waitLoopSignal(t, done, "loop shutdown")
+	}()
+
+	waitLoopSignal(t, batchStarted, "initial crawl batch")
+	if err := os.WriteFile(filepath.Join(profile.Dir, "Documents", "watch-event.txt"), []byte("event"), 0o600); err != nil {
+		t.Fatalf("write watcher event: %v", err)
+	}
+	waitLoopSignal(t, watchRequestStarted, "watcher event request")
+	waitLoopSignal(t, batchCancelled, "disabled crawl cancellation")
+	waitLoopSignal(t, watchRequestCancelled, "disabled watcher cancellation")
+
+	// A fetch after the disabled reconciliation proves watcher.stop returned;
+	// stop blocks until the real fsnotify watcher goroutine has exited.
+	waitLoopCondition(t, func() bool { return configFetches.Load() >= 5 }, "entry into third post-stop disabled fetch")
+	if got := sourceAStarts.Load(); got != 1 {
+		t.Fatalf("source A crawl starts across disabled ticks = %d, want 1", got)
+	}
+	if got := sourceBStarts.Load(); got != 0 {
+		t.Fatalf("queued source B starts across disabled ticks = %d, want 0", got)
+	}
+
+	reenabled.Store(true)
+	waitLoopCondition(t, func() bool { return sourceBStarts.Load() >= 1 }, "fresh queued-source crawl after re-enabling")
+	if got := sourceBStarts.Load(); got != 1 {
+		t.Fatalf("source B crawl starts after re-enable = %d, want 1", got)
+	}
+	select {
+	case got := <-sourceBFirstBatchEntries:
+		if got <= 1 {
+			t.Fatalf("source B first batch entries = %d, want more than 1 from fresh limits", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for source B first batch")
+	}
 }
 
 func makeLoopTestProfile(t *testing.T) ProfileRoot {

--- a/agent/internal/workspaceindex/loop_test.go
+++ b/agent/internal/workspaceindex/loop_test.go
@@ -1,0 +1,307 @@
+package workspaceindex
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestIsSourceDue(t *testing.T) {
+	now := time.Date(2026, time.July, 12, 12, 0, 0, 0, time.UTC)
+	fortyNineMinutesAgo := now.Add(-49 * time.Minute)
+	fiftyMinutesAgo := now.Add(-50 * time.Minute)
+
+	tests := []struct {
+		name string
+		src  SourceConfig
+		want bool
+	}{
+		{
+			name: "nil last completion is due",
+			src:  SourceConfig{CadenceMinutes: 50},
+			want: true,
+		},
+		{
+			name: "before cadence is not due",
+			src:  SourceConfig{CadenceMinutes: 50, LastCompleteRunAt: &fortyNineMinutesAgo},
+			want: false,
+		},
+		{
+			name: "exact cadence boundary is due",
+			src:  SourceConfig{CadenceMinutes: 50, LastCompleteRunAt: &fiftyMinutesAgo},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSourceDue(now, tt.src); got != tt.want {
+				t.Fatalf("isSourceDue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStartLoopRunsDueSourcesSingleFlightFIFO(t *testing.T) {
+	profile := makeLoopTestProfile(t)
+	var mu sync.Mutex
+	var startOrder []string
+	active := 0
+	maxActive := 0
+	firstBatchStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	completed := make(chan string, 2)
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/workspace/agent/crawl-config":
+			writeLoopConfig(t, w, CrawlConfig{
+				Enabled:             true,
+				PollIntervalSeconds: 3600,
+				Sources: []SourceConfig{
+					{ID: "source-a", Kind: "local_profile", CadenceMinutes: 60},
+					{ID: "source-b", Kind: "local_profile", CadenceMinutes: 60},
+				},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspace/agent/runs":
+			var body struct {
+				SourceID string `json:"sourceId"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode start run: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			startOrder = append(startOrder, body.SourceID)
+			active++
+			if active > maxActive {
+				maxActive = active
+			}
+			mu.Unlock()
+			_, _ = io.WriteString(w, `{"runId":"run-`+body.SourceID+`","startedAt":"2026-07-12T12:00:00Z","cursor":""}`)
+		case r.Method == http.MethodPost && filepath.Base(r.URL.Path) == "batch":
+			if r.URL.Path == "/api/v1/workspace/agent/runs/run-source-a/batch" {
+				select {
+				case <-firstBatchStarted:
+				default:
+					close(firstBatchStarted)
+				}
+				select {
+				case <-releaseFirst:
+				case <-r.Context().Done():
+					return
+				}
+			}
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodPost && filepath.Base(r.URL.Path) == "complete":
+			runID := filepath.Base(filepath.Dir(r.URL.Path))
+			mu.Lock()
+			active--
+			mu.Unlock()
+			completed <- runID
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := StartLoop(ctx, Deps{
+		Client:       client,
+		Log:          loopTestLogger(),
+		Enumerate:    func() []ProfileRoot { return []ProfileRoot{profile} },
+		Now:          func() time.Time { return time.Date(2026, time.July, 12, 12, 0, 0, 0, time.UTC) },
+		TickInterval: time.Millisecond,
+	})
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Error("StartLoop did not stop")
+		}
+	})
+
+	waitLoopSignal(t, firstBatchStarted, "first source batch")
+	time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	if got := append([]string(nil), startOrder...); !reflect.DeepEqual(got, []string{"source-a"}) {
+		mu.Unlock()
+		t.Fatalf("starts while first crawl blocked = %#v, want only source-a", got)
+	}
+	mu.Unlock()
+	close(releaseFirst)
+	waitLoopCompletions(t, completed, 2)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !reflect.DeepEqual(startOrder, []string{"source-a", "source-b"}) {
+		t.Fatalf("start order = %#v, want FIFO", startOrder)
+	}
+	if maxActive != 1 {
+		t.Fatalf("maximum concurrent crawls = %d, want 1", maxActive)
+	}
+}
+
+func TestStartLoopModuleAbsentSleepsForSixHours(t *testing.T) {
+	base := time.Date(2026, time.July, 12, 0, 0, 0, 0, time.UTC)
+	var nowNanos atomic.Int64
+	nowNanos.Store(base.UnixNano())
+	var fetches atomic.Int32
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/workspace/agent/crawl-config" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		fetches.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := StartLoop(ctx, Deps{
+		Client:       client,
+		Log:          loopTestLogger(),
+		Now:          func() time.Time { return time.Unix(0, nowNanos.Load()) },
+		TickInterval: time.Millisecond,
+	})
+	defer func() {
+		cancel()
+		waitLoopSignal(t, done, "loop shutdown")
+	}()
+
+	waitLoopCondition(t, func() bool { return fetches.Load() == 1 }, "initial absent-module fetch")
+	nowNanos.Store(base.Add(6*time.Hour - time.Minute).UnixNano())
+	time.Sleep(20 * time.Millisecond)
+	if got := fetches.Load(); got != 1 {
+		t.Fatalf("fetches before six-hour backoff = %d, want 1", got)
+	}
+
+	nowNanos.Store(base.Add(6*time.Hour + time.Minute).UnixNano())
+	waitLoopCondition(t, func() bool { return fetches.Load() >= 2 }, "fetch after six-hour backoff")
+	if got := fetches.Load(); got != 2 {
+		t.Fatalf("fetches after backoff = %d, want 2", got)
+	}
+}
+
+func TestStartLoopCancelsCrawlRemovedByConfig(t *testing.T) {
+	profile := makeLoopTestProfile(t)
+	var configFetches atomic.Int32
+	batchStarted := make(chan struct{})
+	batchCancelled := make(chan struct{})
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/workspace/agent/crawl-config":
+			fetch := configFetches.Add(1)
+			config := CrawlConfig{Enabled: true, PollIntervalSeconds: 1}
+			if fetch == 1 {
+				config.Sources = []SourceConfig{{ID: "removed-source", Kind: "local_profile", CadenceMinutes: 60}}
+			} else {
+				select {
+				case <-batchStarted:
+				case <-r.Context().Done():
+					return
+				}
+			}
+			writeLoopConfig(t, w, config)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspace/agent/runs":
+			_, _ = io.WriteString(w, `{"runId":"removed-run","startedAt":"2026-07-12T12:00:00Z","cursor":""}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspace/agent/runs/removed-run/batch":
+			close(batchStarted)
+			<-r.Context().Done()
+			close(batchCancelled)
+		default:
+			w.WriteHeader(http.StatusAccepted)
+		}
+	}))
+
+	base := time.Date(2026, time.July, 12, 12, 0, 0, 0, time.UTC)
+	var nowCalls atomic.Int64
+	ctx, cancel := context.WithCancel(context.Background())
+	done := StartLoop(ctx, Deps{
+		Client:    client,
+		Log:       loopTestLogger(),
+		Enumerate: func() []ProfileRoot { return []ProfileRoot{profile} },
+		Now: func() time.Time {
+			return base.Add(time.Duration(nowCalls.Add(1)) * time.Second)
+		},
+		TickInterval: time.Millisecond,
+	})
+	defer func() {
+		cancel()
+		waitLoopSignal(t, done, "loop shutdown")
+	}()
+
+	waitLoopSignal(t, batchStarted, "crawl batch")
+	waitLoopCondition(t, func() bool { return configFetches.Load() >= 2 }, "configuration reconciliation")
+	waitLoopSignal(t, batchCancelled, "removed crawl cancellation")
+}
+
+func makeLoopTestProfile(t *testing.T) ProfileRoot {
+	t.Helper()
+	profileDir := filepath.Join(t.TempDir(), "alice")
+	documents := filepath.Join(profileDir, "Documents")
+	if err := os.MkdirAll(documents, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(documents, "report.txt"), []byte("report"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return ProfileRoot{Username: "alice", Dir: profileDir}
+}
+
+func writeLoopConfig(t *testing.T, w http.ResponseWriter, config CrawlConfig) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(config); err != nil {
+		t.Errorf("encode config: %v", err)
+	}
+}
+
+func loopTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func waitLoopSignal(t *testing.T, signal <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
+func waitLoopCompletions(t *testing.T, completed <-chan string, count int) {
+	t.Helper()
+	for range count {
+		select {
+		case <-completed:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for completion %d of %d", count, count)
+		}
+	}
+}
+
+func waitLoopCondition(t *testing.T, condition func() bool, description string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", description)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/agent/internal/workspaceindex/profiles.go
+++ b/agent/internal/workspaceindex/profiles.go
@@ -1,0 +1,86 @@
+package workspaceindex
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// ProfileRoot identifies a local user's profile directory.
+type ProfileRoot struct {
+	Username string
+	Dir      string
+}
+
+var standardProfileCrawlDirs = []string{"Documents", "Desktop", "Downloads", "Pictures"}
+
+// EnumerateProfileRoots returns the user profile directories under
+// baseOverride, or under the current platform's default profile base when the
+// override is empty. Unreadable and missing bases produce an empty result.
+func EnumerateProfileRoots(baseOverride string) []ProfileRoot {
+	base := baseOverride
+	if base == "" {
+		base = defaultProfileBase
+	}
+	return enumerateProfileRoots(base, profileExclusionsForOS(runtime.GOOS))
+}
+
+func enumerateProfileRoots(base string, exclusions map[string]struct{}) []ProfileRoot {
+	profiles := make([]ProfileRoot, 0)
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return profiles
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || excludedProfileName(entry.Name(), exclusions) {
+			continue
+		}
+		profiles = append(profiles, ProfileRoot{
+			Username: entry.Name(),
+			Dir:      filepath.Join(base, entry.Name()),
+		})
+	}
+	return profiles
+}
+
+func profileExclusionsForOS(goos string) map[string]struct{} {
+	var names []string
+	switch goos {
+	case "windows":
+		names = []string{"Public", "Default", "Default User", "All Users", "WDAGUtilityAccount", "desktop.ini"}
+	case "darwin":
+		names = []string{"Shared", ".localized", "Guest"}
+	}
+
+	exclusions := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		exclusions[name] = struct{}{}
+	}
+	return exclusions
+}
+
+func excludedProfileName(name string, exclusions map[string]struct{}) bool {
+	for excluded := range exclusions {
+		if strings.EqualFold(name, excluded) {
+			return true
+		}
+	}
+	return false
+}
+
+// ProfileCrawlDirs returns the standard, existing directories to crawl for a
+// profile. Local-profile entries use relPath <username>/<folder>/... so callers
+// should prefix paths relative to each returned directory with root.Username
+// and the directory's base name.
+func ProfileCrawlDirs(root ProfileRoot) []string {
+	dirs := make([]string, 0, len(standardProfileCrawlDirs))
+	for _, name := range standardProfileCrawlDirs {
+		dir := filepath.Join(root.Dir, name)
+		info, err := os.Lstat(dir)
+		if err == nil && info.IsDir() {
+			dirs = append(dirs, dir)
+		}
+	}
+	return dirs
+}

--- a/agent/internal/workspaceindex/profiles_darwin.go
+++ b/agent/internal/workspaceindex/profiles_darwin.go
@@ -1,0 +1,5 @@
+//go:build darwin
+
+package workspaceindex
+
+const defaultProfileBase = "/Users"

--- a/agent/internal/workspaceindex/profiles_linux.go
+++ b/agent/internal/workspaceindex/profiles_linux.go
@@ -1,0 +1,5 @@
+//go:build linux
+
+package workspaceindex
+
+const defaultProfileBase = "/home"

--- a/agent/internal/workspaceindex/profiles_test.go
+++ b/agent/internal/workspaceindex/profiles_test.go
@@ -1,0 +1,88 @@
+package workspaceindex
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestEnumerateProfileRootsAppliesPlatformExclusions(t *testing.T) {
+	tests := []struct {
+		name       string
+		exclusions map[string]struct{}
+	}{
+		{name: "windows", exclusions: profileExclusionsForOS("windows")},
+		{name: "darwin", exclusions: profileExclusionsForOS("darwin")},
+		{name: "linux", exclusions: profileExclusionsForOS("linux")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := t.TempDir()
+			for excluded := range tt.exclusions {
+				if err := os.Mkdir(filepath.Join(base, excluded), 0o755); err != nil {
+					t.Fatalf("Mkdir excluded %q: %v", excluded, err)
+				}
+			}
+			for _, username := range []string{"zoe", "alice"} {
+				if err := os.Mkdir(filepath.Join(base, username), 0o755); err != nil {
+					t.Fatalf("Mkdir profile %q: %v", username, err)
+				}
+			}
+			if err := os.WriteFile(filepath.Join(base, "not-a-profile"), nil, 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			got := enumerateProfileRoots(base, tt.exclusions)
+			want := []ProfileRoot{
+				{Username: "alice", Dir: filepath.Join(base, "alice")},
+				{Username: "zoe", Dir: filepath.Join(base, "zoe")},
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("roots = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestEnumerateProfileRootsUsesBaseOverride(t *testing.T) {
+	base := t.TempDir()
+	if err := os.Mkdir(filepath.Join(base, "local-user"), 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	got := EnumerateProfileRoots(base)
+	want := []ProfileRoot{{Username: "local-user", Dir: filepath.Join(base, "local-user")}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("roots = %#v, want %#v", got, want)
+	}
+}
+
+func TestEnumerateProfileRootsEmptyBase(t *testing.T) {
+	if got := EnumerateProfileRoots(t.TempDir()); len(got) != 0 {
+		t.Fatalf("roots = %#v, want empty", got)
+	}
+}
+
+func TestProfileCrawlDirsIncludesOnlyPresentStandardDirectories(t *testing.T) {
+	base := t.TempDir()
+	profileDir := filepath.Join(base, "alice")
+	if err := os.Mkdir(profileDir, 0o755); err != nil {
+		t.Fatalf("Mkdir profile: %v", err)
+	}
+	for _, folder := range []string{"Documents", "Desktop"} {
+		if err := os.Mkdir(filepath.Join(profileDir, folder), 0o755); err != nil {
+			t.Fatalf("Mkdir %s: %v", folder, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(profileDir, "Pictures"), nil, 0o600); err != nil {
+		t.Fatalf("WriteFile Pictures: %v", err)
+	}
+
+	got := ProfileCrawlDirs(ProfileRoot{Username: "alice", Dir: profileDir})
+	want := []string{filepath.Join(profileDir, "Documents"), filepath.Join(profileDir, "Desktop")}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("crawl dirs = %#v, want %#v", got, want)
+	}
+}

--- a/agent/internal/workspaceindex/profiles_windows.go
+++ b/agent/internal/workspaceindex/profiles_windows.go
@@ -1,0 +1,5 @@
+//go:build windows
+
+package workspaceindex
+
+const defaultProfileBase = `C:\Users`

--- a/agent/internal/workspaceindex/types.go
+++ b/agent/internal/workspaceindex/types.go
@@ -1,0 +1,98 @@
+// Package workspaceindex provides server-driven configuration and wire types
+// for indexing files in configured workspaces.
+package workspaceindex
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// CrawlConfig is the server-provided configuration for workspace indexing.
+type CrawlConfig struct {
+	Enabled             bool           `json:"enabled"`
+	PollIntervalSeconds int            `json:"pollIntervalSeconds"`
+	Limits              ConfigLimits   `json:"limits"`
+	Sources             []SourceConfig `json:"sources"`
+}
+
+// ConfigLimits contains server-provided crawl and upload limits.
+type ConfigLimits struct {
+	MaxBatchBytes    int `json:"maxBatchBytes"`
+	MaxBatchEntries  int `json:"maxBatchEntries"`
+	WalkOpsPerSecond int `json:"walkOpsPerSecond"`
+}
+
+// SourceConfig describes one server-configured indexing source.
+type SourceConfig struct {
+	ID                string     `json:"id"`
+	Kind              string     `json:"kind"`
+	RootPath          string     `json:"rootPath"`
+	CadenceMinutes    int        `json:"cadenceMinutes"`
+	ExcludeGlobs      []string   `json:"excludeGlobs"`
+	HasCredential     bool       `json:"hasCredential"`
+	LastCompleteRunAt *time.Time `json:"lastCompleteRunAt"`
+	ActiveRun         *ActiveRun `json:"activeRun"`
+	Watch             bool       `json:"watch"`
+}
+
+// ActiveRun describes a crawl run that can be started or resumed.
+type ActiveRun struct {
+	RunID     string    `json:"runId"`
+	StartedAt time.Time `json:"startedAt"`
+	Cursor    string    `json:"cursor"`
+}
+
+// Entry is the wire representation of an indexed file or directory.
+type Entry struct {
+	RelPath    string         `json:"relPath"`
+	ParentPath string         `json:"parentPath"`
+	Name       string         `json:"name"`
+	IsDir      bool           `json:"isDir"`
+	Size       int64          `json:"size"`
+	Mtime      time.Time      `json:"mtime"`
+	Ctime      *time.Time     `json:"ctime"`
+	Ext        *string        `json:"ext"`
+	Attrs      map[string]any `json:"attrs"`
+}
+
+// Stats summarizes one crawl run.
+type Stats struct {
+	Seen   int `json:"seen"`
+	Errors int `json:"errors"`
+}
+
+// Credential contains a source credential returned by the server. It is
+// sensitive: callers must use it only for the active connection and call Zero
+// as soon as it is no longer needed.
+type Credential struct {
+	Username string  `json:"username"`
+	Password string  `json:"password"`
+	Domain   *string `json:"domain"`
+}
+
+// String returns a redacted representation.
+func (Credential) String() string { return "[REDACTED]" }
+
+// GoString returns a redacted Go-syntax representation.
+func (Credential) GoString() string { return "[REDACTED]" }
+
+// Format redacts the credential for every fmt formatting verb.
+func (Credential) Format(f fmt.State, _ rune) { _, _ = fmt.Fprint(f, "[REDACTED]") }
+
+// MarshalJSON prevents accidental serialization of credential material.
+func (Credential) MarshalJSON() ([]byte, error) { return json.Marshal("[REDACTED]") }
+
+// MarshalText prevents accidental text serialization of credential material.
+func (Credential) MarshalText() ([]byte, error) { return []byte("[REDACTED]"), nil }
+
+// Zero clears the credential fields on the receiving value. This is
+// best-effort because Go strings are immutable and may have been copied.
+func (c *Credential) Zero() {
+	if c == nil {
+		return
+	}
+	c.Username = ""
+	c.Password = ""
+	c.Domain = nil
+}

--- a/agent/internal/workspaceindex/uploader.go
+++ b/agent/internal/workspaceindex/uploader.go
@@ -1,0 +1,99 @@
+package workspaceindex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const (
+	defaultMaxBatchEntries = 2_000
+	defaultMaxBatchBytes   = 900_000
+	entryJSONOverhead      = 1
+)
+
+// Uploader buffers crawl entries and uploads them in bounded batches. It is
+// intended for single-goroutine use by a walker's emit callback.
+type Uploader struct {
+	client     *Client
+	runID      string
+	maxEntries int
+	maxBytes   int
+	buf        []Entry
+	bufBytes   int
+	cursor     string
+}
+
+// NewUploader creates an uploader using server-provided batch limits. Zero
+// limits use conservative defaults.
+func NewUploader(c *Client, runID string, limits ConfigLimits) *Uploader {
+	maxEntries := limits.MaxBatchEntries
+	if maxEntries <= 0 {
+		maxEntries = defaultMaxBatchEntries
+	}
+	maxBytes := limits.MaxBatchBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxBatchBytes
+	}
+
+	return &Uploader{
+		client:     c,
+		runID:      runID,
+		maxEntries: maxEntries,
+		maxBytes:   maxBytes,
+	}
+}
+
+// Add buffers an entry and flushes when either configured batch limit is
+// reached.
+func (u *Uploader) Add(ctx context.Context, entry Entry) error {
+	encoded, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("measure workspace index entry: %w", err)
+	}
+
+	u.buf = append(u.buf, entry)
+	u.bufBytes += len(encoded) + entryJSONOverhead
+	u.cursor = entry.RelPath
+	if len(u.buf) < u.maxEntries && u.bufBytes < u.maxBytes {
+		return nil
+	}
+	return u.flush(ctx)
+}
+
+// Drain uploads any entries still buffered. Draining an empty uploader is a
+// no-op.
+func (u *Uploader) Drain(ctx context.Context) error {
+	return u.flush(ctx)
+}
+
+func (u *Uploader) flush(ctx context.Context) error {
+	if len(u.buf) == 0 {
+		return nil
+	}
+	if err := u.postBatch(ctx, u.buf, u.cursor); err != nil {
+		return err
+	}
+
+	u.buf = u.buf[:0]
+	u.bufBytes = 0
+	u.cursor = ""
+	return nil
+}
+
+func (u *Uploader) postBatch(ctx context.Context, entries []Entry, cursor string) error {
+	err := u.client.PostBatch(ctx, u.runID, cursor, entries)
+	if !errors.Is(err, ErrBatchTooLarge) {
+		return err
+	}
+	if len(entries) == 1 {
+		return err
+	}
+
+	middle := len(entries) / 2
+	if err := u.postBatch(ctx, entries[:middle], entries[middle-1].RelPath); err != nil {
+		return err
+	}
+	return u.postBatch(ctx, entries[middle:], cursor)
+}

--- a/agent/internal/workspaceindex/uploader_test.go
+++ b/agent/internal/workspaceindex/uploader_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 )
 
 type receivedBatch struct {
@@ -196,6 +197,10 @@ func TestUploaderUsesLastEntryAsCursorForEveryBatch(t *testing.T) {
 }
 
 func TestUploaderTerminalServerErrorPropagates(t *testing.T) {
+	origDelay := batchRetryDelay
+	batchRetryDelay = time.Millisecond
+	t.Cleanup(func() { batchRetryDelay = origDelay })
+
 	tests := []struct {
 		name string
 		call func(context.Context, *Uploader) error

--- a/agent/internal/workspaceindex/uploader_test.go
+++ b/agent/internal/workspaceindex/uploader_test.go
@@ -1,0 +1,249 @@
+package workspaceindex
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+type receivedBatch struct {
+	Cursor  string
+	Entries []Entry
+}
+
+func decodeReceivedBatch(t *testing.T, r *http.Request) receivedBatch {
+	t.Helper()
+
+	zr, err := gzip.NewReader(r.Body)
+	if err != nil {
+		t.Fatalf("gzip.NewReader: %v", err)
+	}
+	defer zr.Close()
+
+	var batch receivedBatch
+	if err := json.NewDecoder(zr).Decode(&batch); err != nil {
+		t.Fatalf("decode batch: %v", err)
+	}
+	return batch
+}
+
+func uploaderTestEntry(n int) Entry {
+	path := fmt.Sprintf("dir/file-%02d.txt", n)
+	return Entry{
+		RelPath:    path,
+		ParentPath: "dir",
+		Name:       fmt.Sprintf("file-%02d.txt", n),
+		Attrs:      map[string]any{},
+	}
+}
+
+func TestUploaderFlushesAtExactEntryCap(t *testing.T) {
+	var batches []receivedBatch
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		batches = append(batches, decodeReceivedBatch(t, r))
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	uploader := NewUploader(client, "run-1", ConfigLimits{MaxBatchEntries: 2, MaxBatchBytes: 1_000_000})
+
+	if err := uploader.Add(context.Background(), uploaderTestEntry(1)); err != nil {
+		t.Fatalf("first Add: %v", err)
+	}
+	if len(batches) != 0 {
+		t.Fatalf("requests after first Add = %d, want 0", len(batches))
+	}
+	if err := uploader.Add(context.Background(), uploaderTestEntry(2)); err != nil {
+		t.Fatalf("second Add: %v", err)
+	}
+
+	if len(batches) != 1 {
+		t.Fatalf("requests after exact cap = %d, want 1", len(batches))
+	}
+	if got := entryRelPaths(batches[0].Entries); !reflect.DeepEqual(got, []string{"dir/file-01.txt", "dir/file-02.txt"}) {
+		t.Fatalf("entry paths = %#v", got)
+	}
+}
+
+func TestUploaderFlushesAtApproximateByteCap(t *testing.T) {
+	var batches []receivedBatch
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		batches = append(batches, decodeReceivedBatch(t, r))
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	uploader := NewUploader(client, "run-1", ConfigLimits{MaxBatchEntries: 100, MaxBatchBytes: 200})
+	entry := uploaderTestEntry(1)
+	entry.Attrs = map[string]any{"description": string(make([]byte, 500))}
+
+	if err := uploader.Add(context.Background(), entry); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if len(batches) != 1 {
+		t.Fatalf("requests after byte cap = %d, want 1", len(batches))
+	}
+	if got := entryRelPaths(batches[0].Entries); !reflect.DeepEqual(got, []string{entry.RelPath}) {
+		t.Fatalf("entry paths = %#v", got)
+	}
+}
+
+func TestUploaderDrainFlushesRemainderAndEmptyDrainIsNoOp(t *testing.T) {
+	var batches []receivedBatch
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		batches = append(batches, decodeReceivedBatch(t, r))
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	empty := NewUploader(client, "empty-run", ConfigLimits{})
+	if err := empty.Drain(context.Background()); err != nil {
+		t.Fatalf("empty Drain: %v", err)
+	}
+	if len(batches) != 0 {
+		t.Fatalf("requests after empty Drain = %d, want 0", len(batches))
+	}
+
+	uploader := NewUploader(client, "run-1", ConfigLimits{MaxBatchEntries: 10, MaxBatchBytes: 1_000_000})
+	for i := 1; i <= 2; i++ {
+		if err := uploader.Add(context.Background(), uploaderTestEntry(i)); err != nil {
+			t.Fatalf("Add %d: %v", i, err)
+		}
+	}
+	if err := uploader.Drain(context.Background()); err != nil {
+		t.Fatalf("Drain: %v", err)
+	}
+	if err := uploader.Drain(context.Background()); err != nil {
+		t.Fatalf("second empty Drain: %v", err)
+	}
+
+	if len(batches) != 1 {
+		t.Fatalf("requests after drains = %d, want 1", len(batches))
+	}
+	if got := entryRelPaths(batches[0].Entries); !reflect.DeepEqual(got, []string{"dir/file-01.txt", "dir/file-02.txt"}) {
+		t.Fatalf("entry paths = %#v", got)
+	}
+}
+
+func TestUploaderSplitsTooLargeBatchesAndPreservesOrder(t *testing.T) {
+	var mu sync.Mutex
+	var requestSizes []int
+	var delivered []string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		batch := decodeReceivedBatch(t, r)
+		mu.Lock()
+		defer mu.Unlock()
+		requestSizes = append(requestSizes, len(batch.Entries))
+		if len(batch.Entries) > 2 {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			return
+		}
+		delivered = append(delivered, entryRelPaths(batch.Entries)...)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	uploader := NewUploader(client, "run-1", ConfigLimits{MaxBatchEntries: 5, MaxBatchBytes: 1_000_000})
+
+	for i := 1; i <= 5; i++ {
+		if err := uploader.Add(context.Background(), uploaderTestEntry(i)); err != nil {
+			t.Fatalf("Add %d: %v", i, err)
+		}
+	}
+
+	wantPaths := []string{"dir/file-01.txt", "dir/file-02.txt", "dir/file-03.txt", "dir/file-04.txt", "dir/file-05.txt"}
+	if !reflect.DeepEqual(delivered, wantPaths) {
+		t.Fatalf("delivered paths = %#v, want %#v", delivered, wantPaths)
+	}
+	if want := []int{5, 2, 3, 1, 2}; !reflect.DeepEqual(requestSizes, want) {
+		t.Fatalf("request sizes = %#v, want %#v", requestSizes, want)
+	}
+}
+
+func TestUploaderSingleEntryTooLargeSurfacesError(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+	}))
+	uploader := NewUploader(client, "run-1", ConfigLimits{MaxBatchEntries: 1, MaxBatchBytes: 1_000_000})
+
+	err := uploader.Add(context.Background(), uploaderTestEntry(1))
+	if !errors.Is(err, ErrBatchTooLarge) {
+		t.Fatalf("Add error = %v, want errors.Is(_, ErrBatchTooLarge)", err)
+	}
+}
+
+func TestUploaderUsesLastEntryAsCursorForEveryBatch(t *testing.T) {
+	var cursors []string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		batch := decodeReceivedBatch(t, r)
+		cursors = append(cursors, batch.Cursor)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	uploader := NewUploader(client, "run-1", ConfigLimits{MaxBatchEntries: 2, MaxBatchBytes: 1_000_000})
+
+	for i := 1; i <= 5; i++ {
+		if err := uploader.Add(context.Background(), uploaderTestEntry(i)); err != nil {
+			t.Fatalf("Add %d: %v", i, err)
+		}
+	}
+	if err := uploader.Drain(context.Background()); err != nil {
+		t.Fatalf("Drain: %v", err)
+	}
+
+	want := []string{"dir/file-02.txt", "dir/file-04.txt", "dir/file-05.txt"}
+	if !reflect.DeepEqual(cursors, want) {
+		t.Fatalf("cursors = %#v, want %#v", cursors, want)
+	}
+}
+
+func TestUploaderTerminalServerErrorPropagates(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(context.Context, *Uploader) error
+	}{
+		{
+			name: "Add",
+			call: func(ctx context.Context, uploader *Uploader) error {
+				return uploader.Add(ctx, uploaderTestEntry(1))
+			},
+		},
+		{
+			name: "Drain",
+			call: func(ctx context.Context, uploader *Uploader) error {
+				if err := uploader.Add(ctx, uploaderTestEntry(1)); err != nil {
+					return err
+				}
+				return uploader.Drain(ctx)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requests int
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests++
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			limits := ConfigLimits{MaxBatchEntries: 10, MaxBatchBytes: 1_000_000}
+			if tt.name == "Add" {
+				limits.MaxBatchEntries = 1
+			}
+			err := tt.call(context.Background(), NewUploader(client, "run-1", limits))
+			var httpErr *HTTPError
+			if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusInternalServerError {
+				t.Fatalf("error = %v, want terminal HTTP 500", err)
+			}
+			if requests != 3 {
+				t.Fatalf("requests = %d, want client's 3 total attempts", requests)
+			}
+		})
+	}
+}
+
+func entryRelPaths(entries []Entry) []string {
+	paths := make([]string, len(entries))
+	for i, entry := range entries {
+		paths[i] = entry.RelPath
+	}
+	return paths
+}

--- a/agent/internal/workspaceindex/walker.go
+++ b/agent/internal/workspaceindex/walker.go
@@ -1,0 +1,208 @@
+package workspaceindex
+
+import (
+	"context"
+	"io/fs"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/time/rate"
+)
+
+// SourceFS provides the filesystem operations needed by Walk. Implementations
+// must use Lstat semantics so symlink entries can be identified without being
+// followed.
+type SourceFS interface {
+	ReadDir(path string) ([]fs.DirEntry, error)
+	Stat(path string) (fs.FileInfo, error)
+}
+
+// WalkOptions configures exclusions, cursor resume, and filesystem throttling.
+type WalkOptions struct {
+	ExcludeGlobs []string
+	ResumeCursor string
+	Limiter      *rate.Limiter
+}
+
+var defaultExcludeGlobs = []string{
+	"$RECYCLE.BIN/**",
+	"System Volume Information/**",
+	"**/AppData/**",
+}
+
+// Walk performs a deterministic lexicographic depth-first traversal of root.
+// Directories are emitted before their children, and root itself is not
+// emitted. The returned cursor is the last entry successfully emitted.
+func Walk(
+	ctx context.Context,
+	fsys SourceFS,
+	root string,
+	opts WalkOptions,
+	emit func(Entry) error,
+) (lastCursor string, err error) {
+	excludeGlobs := make([]string, 0, len(defaultExcludeGlobs)+len(opts.ExcludeGlobs))
+	excludeGlobs = append(excludeGlobs, defaultExcludeGlobs...)
+	excludeGlobs = append(excludeGlobs, opts.ExcludeGlobs...)
+
+	var walkDir func(string, string) error
+	walkDir = func(sourcePath, parentRelPath string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := waitForWalkOp(ctx, opts.Limiter); err != nil {
+			return err
+		}
+		children, err := fsys.ReadDir(sourcePath)
+		if err != nil {
+			return err
+		}
+		sort.Slice(children, func(i, j int) bool {
+			return children[i].Name() < children[j].Name()
+		})
+
+		for _, child := range children {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if child.Type()&fs.ModeSymlink != 0 {
+				continue
+			}
+
+			relPath := child.Name()
+			if parentRelPath != "" {
+				relPath = path.Join(parentRelPath, child.Name())
+			}
+			isDir := child.IsDir()
+			if excludedWalkPath(relPath, isDir, excludeGlobs) {
+				continue
+			}
+
+			if compareWalkPaths(relPath, opts.ResumeCursor) > 0 {
+				if err := waitForWalkOp(ctx, opts.Limiter); err != nil {
+					return err
+				}
+				info, err := fsys.Stat(filepath.Join(root, filepath.FromSlash(relPath)))
+				if err != nil {
+					return err
+				}
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				entry := walkEntry(relPath, info, isDir)
+				if err := emit(entry); err != nil {
+					return err
+				}
+				lastCursor = relPath
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+			}
+
+			if isDir && shouldDescendForCursor(relPath, opts.ResumeCursor) {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				if err := walkDir(filepath.Join(root, filepath.FromSlash(relPath)), relPath); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	err = walkDir(filepath.Clean(root), "")
+	return lastCursor, err
+}
+
+func waitForWalkOp(ctx context.Context, limiter *rate.Limiter) error {
+	if limiter == nil {
+		return ctx.Err()
+	}
+	return limiter.Wait(ctx)
+}
+
+func walkEntry(relPath string, info fs.FileInfo, isDir bool) Entry {
+	parentPath := path.Dir(relPath)
+	if parentPath == "." {
+		parentPath = ""
+	}
+	entry := Entry{
+		RelPath:    relPath,
+		ParentPath: parentPath,
+		Name:       path.Base(relPath),
+		IsDir:      isDir,
+		Mtime:      info.ModTime(),
+		Attrs:      map[string]any{},
+	}
+	if isDir {
+		return entry
+	}
+
+	entry.Size = info.Size()
+	ext := path.Ext(entry.Name)
+	if ext != "" && ext != entry.Name {
+		ext = strings.ToLower(strings.TrimPrefix(ext, "."))
+		entry.Ext = &ext
+	}
+	return entry
+}
+
+func shouldDescendForCursor(dirPath, cursor string) bool {
+	return cursor == "" || compareWalkPaths(dirPath, cursor) >= 0 || strings.HasPrefix(cursor, dirPath+"/")
+}
+
+func compareWalkPaths(left, right string) int {
+	leftSegments := strings.Split(left, "/")
+	rightSegments := strings.Split(right, "/")
+	shared := min(len(leftSegments), len(rightSegments))
+	for i := 0; i < shared; i++ {
+		if comparison := strings.Compare(leftSegments[i], rightSegments[i]); comparison != 0 {
+			return comparison
+		}
+	}
+	return len(leftSegments) - len(rightSegments)
+}
+
+func excludedWalkPath(relPath string, isDir bool, globs []string) bool {
+	if isDir {
+		for _, segment := range strings.Split(relPath, "/") {
+			if strings.HasPrefix(segment, ".") {
+				return true
+			}
+		}
+	}
+	for _, pattern := range globs {
+		if matchWalkGlob(pattern, relPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchWalkGlob(pattern, relPath string) bool {
+	pattern = strings.Trim(strings.ReplaceAll(pattern, "\\", "/"), "/")
+	relPath = strings.Trim(relPath, "/")
+	if pattern == "" || relPath == "" {
+		return false
+	}
+	return matchWalkGlobSegments(strings.Split(pattern, "/"), strings.Split(relPath, "/"))
+}
+
+func matchWalkGlobSegments(pattern, value []string) bool {
+	if len(pattern) == 0 {
+		return len(value) == 0
+	}
+	if pattern[0] == "**" {
+		if matchWalkGlobSegments(pattern[1:], value) {
+			return true
+		}
+		return len(value) > 0 && matchWalkGlobSegments(pattern, value[1:])
+	}
+	if len(value) == 0 {
+		return false
+	}
+	matched, err := path.Match(pattern[0], value[0])
+	return err == nil && matched && matchWalkGlobSegments(pattern[1:], value[1:])
+}

--- a/agent/internal/workspaceindex/walker_test.go
+++ b/agent/internal/workspaceindex/walker_test.go
@@ -1,0 +1,365 @@
+package workspaceindex
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+var walkerTestTime = time.Date(2026, time.July, 12, 14, 0, 0, 0, time.UTC)
+
+type fakeWalkNode struct {
+	dir     bool
+	size    int64
+	mode    fs.FileMode
+	modTime time.Time
+}
+
+type fakeWalkFS struct {
+	mu         sync.Mutex
+	nodes      map[string]fakeWalkNode
+	readDirOps int
+	statOps    int
+	onStat     func()
+}
+
+func newFakeWalkFS(root string, nodes map[string]fakeWalkNode) *fakeWalkFS {
+	all := map[string]fakeWalkNode{
+		filepath.Clean(root): {dir: true, mode: fs.ModeDir | 0o755, modTime: walkerTestTime},
+	}
+	for relPath, node := range nodes {
+		if node.modTime.IsZero() {
+			node.modTime = walkerTestTime
+		}
+		if node.dir {
+			node.mode |= fs.ModeDir
+		}
+		all[filepath.Join(root, filepath.FromSlash(relPath))] = node
+	}
+	return &fakeWalkFS{nodes: all}
+}
+
+func (f *fakeWalkFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.readDirOps++
+
+	name = filepath.Clean(name)
+	node, ok := f.nodes[name]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	if !node.dir {
+		return nil, errors.New("not a directory")
+	}
+
+	var entries []fs.DirEntry
+	for childPath, child := range f.nodes {
+		if childPath == name || filepath.Dir(childPath) != name {
+			continue
+		}
+		entries = append(entries, fakeWalkDirEntry{name: filepath.Base(childPath), node: child})
+	}
+	// Intentionally reverse the map-derived order. Walk must sort its own copy.
+	for left, right := 0, len(entries)-1; left < right; left, right = left+1, right-1 {
+		entries[left], entries[right] = entries[right], entries[left]
+	}
+	return entries, nil
+}
+
+func (f *fakeWalkFS) Stat(name string) (fs.FileInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statOps++
+
+	node, ok := f.nodes[filepath.Clean(name)]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	if f.onStat != nil {
+		f.onStat()
+	}
+	return fakeWalkFileInfo{name: filepath.Base(name), node: node}, nil
+}
+
+func (f *fakeWalkFS) opCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.readDirOps + f.statOps
+}
+
+type fakeWalkDirEntry struct {
+	name string
+	node fakeWalkNode
+}
+
+func (e fakeWalkDirEntry) Name() string               { return e.name }
+func (e fakeWalkDirEntry) IsDir() bool                { return e.node.dir }
+func (e fakeWalkDirEntry) Type() fs.FileMode          { return e.node.mode.Type() }
+func (e fakeWalkDirEntry) Info() (fs.FileInfo, error) { return fakeWalkFileInfo(e), nil }
+
+type fakeWalkFileInfo struct {
+	name string
+	node fakeWalkNode
+}
+
+func (i fakeWalkFileInfo) Name() string       { return i.name }
+func (i fakeWalkFileInfo) Size() int64        { return i.node.size }
+func (i fakeWalkFileInfo) Mode() fs.FileMode  { return i.node.mode }
+func (i fakeWalkFileInfo) ModTime() time.Time { return i.node.modTime }
+func (i fakeWalkFileInfo) IsDir() bool        { return i.node.dir }
+func (i fakeWalkFileInfo) Sys() any           { return nil }
+
+func collectWalk(t *testing.T, fsys SourceFS, root string, opts WalkOptions) ([]Entry, string, error) {
+	t.Helper()
+	var entries []Entry
+	lastCursor, err := Walk(context.Background(), fsys, root, opts, func(entry Entry) error {
+		entries = append(entries, entry)
+		return nil
+	})
+	return entries, lastCursor, err
+}
+
+func entryPaths(entries []Entry) []string {
+	paths := make([]string, len(entries))
+	for i, entry := range entries {
+		paths[i] = entry.RelPath
+	}
+	return paths
+}
+
+func TestWalkDeterministicDepthFirstOrderingAndMetadata(t *testing.T) {
+	const root = "root"
+	nodes := map[string]fakeWalkNode{
+		"zeta.txt":           {size: 9},
+		"alpha":              {dir: true, size: 999},
+		"alpha/report.TXT":   {size: 42},
+		"alpha/beta":         {dir: true, size: 999},
+		"alpha/beta/noext":   {size: 7},
+		"alpha/beta/.config": {size: 3},
+		"skip-link":          {mode: fs.ModeSymlink},
+	}
+	wantPaths := []string{
+		"alpha",
+		"alpha/beta",
+		"alpha/beta/.config",
+		"alpha/beta/noext",
+		"alpha/report.TXT",
+		"zeta.txt",
+	}
+
+	var first []Entry
+	for run := 0; run < 2; run++ {
+		entries, lastCursor, err := collectWalk(t, newFakeWalkFS(root, nodes), root, WalkOptions{})
+		if err != nil {
+			t.Fatalf("Walk run %d: %v", run, err)
+		}
+		if got := entryPaths(entries); !reflect.DeepEqual(got, wantPaths) {
+			t.Fatalf("Walk run %d paths = %#v, want %#v", run, got, wantPaths)
+		}
+		if lastCursor != "zeta.txt" {
+			t.Fatalf("Walk run %d cursor = %q, want zeta.txt", run, lastCursor)
+		}
+		if run == 0 {
+			first = entries
+		} else if !reflect.DeepEqual(entries, first) {
+			t.Fatalf("second Walk differs from first:\nfirst:  %#v\nsecond: %#v", first, entries)
+		}
+	}
+
+	for _, entry := range first {
+		if entry.Attrs == nil {
+			t.Fatalf("Attrs is nil for %q", entry.RelPath)
+		}
+	}
+	if got := first[0]; !got.IsDir || got.ParentPath != "" || got.Name != "alpha" || got.Size != 0 || got.Ext != nil {
+		t.Fatalf("root directory entry = %+v", got)
+	}
+	if got := first[1]; !got.IsDir || got.ParentPath != "alpha" || got.Name != "beta" || got.Size != 0 || got.Ext != nil {
+		t.Fatalf("nested directory entry = %+v", got)
+	}
+	if got := first[2]; got.Ext != nil {
+		t.Fatalf("dotfile extension = %q, want nil", *got.Ext)
+	}
+	if got := first[4]; got.Ext == nil || *got.Ext != "txt" || got.Size != 42 || !got.Mtime.Equal(walkerTestTime) {
+		t.Fatalf("file metadata = %+v", got)
+	}
+}
+
+func TestWalkExcludesBuiltInsAndCustomGlobs(t *testing.T) {
+	const root = "root"
+	nodes := map[string]fakeWalkNode{
+		"$RECYCLE.BIN":                        {dir: true},
+		"$RECYCLE.BIN/deleted.txt":            {size: 1},
+		"System Volume Information":           {dir: true},
+		"System Volume Information/state.bin": {size: 1},
+		"Users":                               {dir: true},
+		"Users/me":                            {dir: true},
+		"Users/me/AppData":                    {dir: true},
+		"Users/me/AppData/cache.db":           {size: 1},
+		"Users/me/keep.txt":                   {size: 1},
+		".hidden":                             {dir: true},
+		".hidden/secret.txt":                  {size: 1},
+		"scratch.tmp":                         {size: 1},
+		"logs":                                {dir: true},
+		"logs/2026":                           {dir: true},
+		"logs/2026/private.log":               {size: 1},
+		"logs/2026/public.log":                {size: 1},
+		"keep.md":                             {size: 1},
+	}
+
+	tests := []struct {
+		name         string
+		excludeGlobs []string
+		want         []string
+	}{
+		{
+			name: "built-in defaults",
+			want: []string{
+				"Users", "Users/me", "Users/me/keep.txt", "keep.md", "logs", "logs/2026",
+				"logs/2026/private.log", "logs/2026/public.log", "scratch.tmp",
+			},
+		},
+		{
+			name:         "root and nested custom globs layered over defaults",
+			excludeGlobs: []string{"*.tmp", "logs/**/private.*"},
+			want: []string{
+				"Users", "Users/me", "Users/me/keep.txt", "keep.md", "logs", "logs/2026", "logs/2026/public.log",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entries, _, err := collectWalk(t, newFakeWalkFS(root, nodes), root, WalkOptions{ExcludeGlobs: tt.excludeGlobs})
+			if err != nil {
+				t.Fatalf("Walk: %v", err)
+			}
+			if got := entryPaths(entries); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("paths = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWalkResumeCursorAtEveryEmittedEntry(t *testing.T) {
+	const root = "root"
+	nodes := map[string]fakeWalkNode{
+		"a":            {dir: true},
+		"a/one.txt":    {size: 1},
+		"a/sub":        {dir: true},
+		"a/sub/two.md": {size: 2},
+		"b":            {dir: true},
+		"b/three.log":  {size: 3},
+		"docs":         {dir: true},
+		"docs/child":   {size: 4},
+		"docs.md":      {size: 5},
+		"z.txt":        {size: 4},
+	}
+
+	fullEntries, _, err := collectWalk(t, newFakeWalkFS(root, nodes), root, WalkOptions{})
+	if err != nil {
+		t.Fatalf("full Walk: %v", err)
+	}
+	full := entryPaths(fullEntries)
+
+	for cut := range full {
+		cursor := full[cut]
+		resumedEntries, lastCursor, resumeErr := collectWalk(t, newFakeWalkFS(root, nodes), root, WalkOptions{ResumeCursor: cursor})
+		if resumeErr != nil {
+			t.Fatalf("resume after %q: %v", cursor, resumeErr)
+		}
+		combined := append(append([]string(nil), full[:cut+1]...), entryPaths(resumedEntries)...)
+		if !reflect.DeepEqual(combined, full) {
+			t.Fatalf("resume after %q produced %#v, want %#v", cursor, combined, full)
+		}
+		if cut == len(full)-1 {
+			if lastCursor != "" {
+				t.Fatalf("resume after final cursor returned %q, want empty", lastCursor)
+			}
+		} else if lastCursor != full[len(full)-1] {
+			t.Fatalf("resume after %q returned cursor %q, want %q", cursor, lastCursor, full[len(full)-1])
+		}
+	}
+}
+
+func TestWalkCancellationBetweenEntries(t *testing.T) {
+	const root = "root"
+	fsys := newFakeWalkFS(root, map[string]fakeWalkNode{
+		"a.txt": {size: 1},
+		"b.txt": {size: 1},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	var emitted []string
+
+	lastCursor, err := Walk(ctx, fsys, root, WalkOptions{}, func(entry Entry) error {
+		emitted = append(emitted, entry.RelPath)
+		cancel()
+		return nil
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Walk error = %v, want context.Canceled", err)
+	}
+	if !reflect.DeepEqual(emitted, []string{"a.txt"}) {
+		t.Fatalf("emitted = %#v, want only first entry", emitted)
+	}
+	if lastCursor != "a.txt" {
+		t.Fatalf("last cursor = %q, want a.txt", lastCursor)
+	}
+}
+
+func TestWalkCancellationDuringStatDoesNotEmit(t *testing.T) {
+	const root = "root"
+	fsys := newFakeWalkFS(root, map[string]fakeWalkNode{"a.txt": {size: 1}})
+	ctx, cancel := context.WithCancel(context.Background())
+	fsys.onStat = cancel
+	var emitted []string
+
+	lastCursor, err := Walk(ctx, fsys, root, WalkOptions{}, func(entry Entry) error {
+		emitted = append(emitted, entry.RelPath)
+		return nil
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Walk error = %v, want context.Canceled", err)
+	}
+	if len(emitted) != 0 {
+		t.Fatalf("emitted after cancellation during Stat: %#v", emitted)
+	}
+	if lastCursor != "" {
+		t.Fatalf("last cursor = %q, want empty", lastCursor)
+	}
+}
+
+func TestWalkLimiterWaitsOncePerFilesystemOperation(t *testing.T) {
+	const (
+		root  = "root"
+		burst = 100
+	)
+	fsys := newFakeWalkFS(root, map[string]fakeWalkNode{
+		"dir":          {dir: true},
+		"dir/file.txt": {size: 1},
+		"root.txt":     {size: 2},
+	})
+	limiter := rate.NewLimiter(0, burst)
+
+	entries, _, err := collectWalk(t, fsys, root, WalkOptions{Limiter: limiter})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if got, want := entryPaths(entries), []string{"dir", "dir/file.txt", "root.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("paths = %#v, want %#v", got, want)
+	}
+	ops := fsys.opCount()
+	if got, want := int(limiter.Tokens()), burst-ops; got != want {
+		t.Fatalf("limiter tokens = %d after %d filesystem operations, want %d", got, ops, want)
+	}
+}

--- a/agent/internal/workspaceindex/watch.go
+++ b/agent/internal/workspaceindex/watch.go
@@ -1,0 +1,320 @@
+package workspaceindex
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/observability"
+	"github.com/fsnotify/fsnotify"
+)
+
+var errWatchDirCap = errors.New("workspace index watch directory cap exceeded")
+
+type watchedRoot struct {
+	dir    string
+	prefix string
+}
+
+type pendingWatchEvent struct {
+	name   string
+	root   watchedRoot
+	delete bool
+}
+
+// startWatch watches existing local-profile crawl directories. The returned
+// stop function is idempotent and waits for the watcher goroutine to exit.
+func startWatch(ctx context.Context, deps Deps, src SourceConfig) (stop func()) {
+	deps = deps.withDefaults()
+	if deps.Client == nil || src.Kind != "local_profile" || !src.Watch {
+		return func() {}
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		deps.Log.Warn("create workspace index watcher", "sourceId", src.ID, "err", err)
+		return func() {}
+	}
+
+	roots := make([]watchedRoot, 0)
+	for _, target := range localProfileTargets(deps, src) {
+		roots = append(roots, watchedRoot{dir: filepath.Clean(target.dir), prefix: target.prefix})
+	}
+	sort.Slice(roots, func(i, j int) bool { return roots[i].dir < roots[j].dir })
+	watchGlobs := append([]string(nil), defaultExcludeGlobs...)
+	watchGlobs = append(watchGlobs, src.ExcludeGlobs...)
+
+	dirCount := 0
+	watchedDirs := make(map[string]struct{})
+	for _, root := range roots {
+		if ctx.Err() != nil {
+			_ = watcher.Close()
+			return func() {}
+		}
+		err = addWatchTree(ctx, watcher, root, root.dir, watchGlobs, deps.WatchDirCap, &dirCount, watchedDirs)
+		if err != nil {
+			break
+		}
+	}
+	if err != nil {
+		_ = watcher.Close()
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return func() {}
+		}
+		if errors.Is(err, errWatchDirCap) {
+			deps.Log.Warn("workspace index watch directory cap exceeded; using crawl only", "sourceId", src.ID, "cap", deps.WatchDirCap)
+		} else {
+			deps.Log.Warn("register workspace index watch directories; using crawl only", "sourceId", src.ID, "err", err)
+		}
+		return func() {}
+	}
+	if dirCount == 0 {
+		_ = watcher.Close()
+		return func() {}
+	}
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer observability.Recoverer("workspaceindex.watch")
+		defer watcher.Close()
+
+		pending := make(map[string]pendingWatchEvent)
+		var timer *time.Timer
+		var timerC <-chan time.Time
+
+		resetTimer := func() {
+			if timer == nil {
+				timer = time.NewTimer(deps.WatchDebounce)
+			} else {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(deps.WatchDebounce)
+			}
+			timerC = timer.C
+		}
+		flush := func() {
+			if len(pending) == 0 {
+				return
+			}
+			paths := make([]string, 0, len(pending))
+			for relPath := range pending {
+				paths = append(paths, relPath)
+			}
+			sort.Slice(paths, func(i, j int) bool { return compareWalkPaths(paths[i], paths[j]) < 0 })
+			upserts := make([]Entry, 0, len(paths))
+			deletes := make([]string, 0, len(paths))
+			for _, relPath := range paths {
+				event := pending[relPath]
+				if event.delete {
+					deletes = append(deletes, relPath)
+				} else {
+					info, statErr := os.Lstat(event.name)
+					if statErr != nil {
+						if os.IsNotExist(statErr) {
+							deletes = append(deletes, relPath)
+						}
+						continue
+					}
+					if info.Mode()&os.ModeSymlink != 0 {
+						continue
+					}
+					entry := walkEntry(relPath, info, info.IsDir())
+					if entry.ParentPath == "" {
+						entry.ParentPath = event.root.prefix
+					}
+					upserts = append(upserts, entry)
+				}
+			}
+			clear(pending)
+			if postErr := deps.Client.PostEvents(watchCtx, src.ID, upserts, deletes); postErr != nil && watchCtx.Err() == nil {
+				deps.Log.Warn("post workspace index watch events", "sourceId", src.ID, "err", postErr)
+			}
+		}
+		handleEvent := func(event fsnotify.Event) bool {
+			relPath, root, matched := watchRelPath(event.Name, roots)
+			if !matched {
+				return true
+			}
+			rootRelPath, relErr := filepath.Rel(root.dir, filepath.Clean(event.Name))
+			if relErr != nil {
+				return true
+			}
+			rootRelPath = filepath.ToSlash(rootRelPath)
+			if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+				if watchPathExcluded(rootRelPath, nil, watchGlobs) {
+					return true
+				}
+				pending[relPath] = pendingWatchEvent{delete: true}
+				resetTimer()
+				return true
+			}
+			if event.Op&(fsnotify.Create|fsnotify.Write) == 0 {
+				return true
+			}
+
+			info, statErr := os.Lstat(event.Name)
+			if statErr != nil {
+				if os.IsNotExist(statErr) {
+					if !watchPathExcluded(rootRelPath, nil, watchGlobs) {
+						pending[relPath] = pendingWatchEvent{delete: true}
+						resetTimer()
+					}
+				}
+				return true
+			}
+			if info.Mode()&os.ModeSymlink != 0 {
+				return true
+			}
+			isDir := info.IsDir()
+			if watchPathExcluded(rootRelPath, &isDir, watchGlobs) {
+				return true
+			}
+			if info.IsDir() && event.Op&fsnotify.Create != 0 {
+				if addErr := addWatchTree(watchCtx, watcher, root, event.Name, watchGlobs, deps.WatchDirCap, &dirCount, watchedDirs); addErr != nil {
+					deps.Log.Warn("workspace index watch directory cap or registration failure; using crawl only", "sourceId", src.ID, "cap", deps.WatchDirCap, "err", addErr)
+					return false
+				}
+			}
+			pending[relPath] = pendingWatchEvent{name: event.Name, root: root}
+			resetTimer()
+			return true
+		}
+
+		for {
+			select {
+			case <-watchCtx.Done():
+				if timer != nil {
+					timer.Stop()
+				}
+				return
+			case watchErr, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				deps.Log.Warn("workspace index watcher failed; using crawl only", "sourceId", src.ID, "err", watchErr)
+				return
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				if !handleEvent(event) {
+					return
+				}
+			case <-timerC:
+				drained := false
+			drainEvents:
+				for {
+					select {
+					case event, ok := <-watcher.Events:
+						if !ok {
+							return
+						}
+						drained = true
+						if !handleEvent(event) {
+							return
+						}
+					default:
+						break drainEvents
+					}
+				}
+				if drained {
+					continue
+				}
+				timerC = nil
+				flush()
+			}
+		}
+	}()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			cancel()
+			<-done
+		})
+	}
+}
+
+func watchPathExcluded(relPath string, isDir *bool, globs []string) bool {
+	if isDir != nil {
+		return excludedWalkPath(relPath, *isDir, globs)
+	}
+	return excludedWalkPath(relPath, false, globs) || excludedWalkPath(relPath, true, globs)
+}
+
+func addWatchTree(
+	ctx context.Context,
+	watcher *fsnotify.Watcher,
+	root watchedRoot,
+	start string,
+	globs []string,
+	dirCap int,
+	dirCount *int,
+	watchedDirs map[string]struct{},
+) error {
+	return filepath.WalkDir(start, func(current string, entry fs.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root.dir, current)
+		if err != nil {
+			return err
+		}
+		if rel != "." && excludedWalkPath(filepath.ToSlash(rel), true, globs) {
+			return filepath.SkipDir
+		}
+		current = filepath.Clean(current)
+		if _, exists := watchedDirs[current]; exists {
+			return nil
+		}
+		if *dirCount >= dirCap {
+			return errWatchDirCap
+		}
+		if err := watcher.Add(current); err != nil {
+			return err
+		}
+		watchedDirs[current] = struct{}{}
+		*dirCount++
+		return nil
+	})
+}
+
+func watchRelPath(name string, roots []watchedRoot) (string, watchedRoot, bool) {
+	cleanName := filepath.Clean(name)
+	for _, root := range roots {
+		rel, err := filepath.Rel(root.dir, cleanName)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if rel == "." {
+			return root.prefix, root, true
+		}
+		return path.Join(root.prefix, filepath.ToSlash(rel)), root, true
+	}
+	return "", watchedRoot{}, false
+}

--- a/agent/internal/workspaceindex/watch_test.go
+++ b/agent/internal/workspaceindex/watch_test.go
@@ -1,0 +1,196 @@
+package workspaceindex
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type watchEventsPayload struct {
+	Upserts []Entry  `json:"upserts"`
+	Deletes []string `json:"deletes"`
+}
+
+func TestWatchPathExcludedForUnknownDeleteType(t *testing.T) {
+	globs := append(append([]string(nil), defaultExcludeGlobs...), "ignored/**")
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: ".hidden", want: true},
+		{path: "ignored/child.txt", want: true},
+		{path: "visible.txt", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := watchPathExcluded(tt.path, nil, globs); got != tt.want {
+				t.Fatalf("watchPathExcluded(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStartWatchDebouncesAndCoalescesEventsIntoOnePost(t *testing.T) {
+	const debounce = 250 * time.Millisecond
+	profileDir := filepath.Join(t.TempDir(), "alice")
+	documentsDir := filepath.Join(profileDir, "Documents")
+	if err := os.MkdirAll(documentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	doomedPath := filepath.Join(documentsDir, "doomed.txt")
+	if err := os.WriteFile(doomedPath, []byte("remove me"), 0o600); err != nil {
+		t.Fatalf("seed doomed file: %v", err)
+	}
+
+	payloads := make(chan watchEventsPayload, 4)
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/workspace/agent/sources/source-watch/events" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var payload watchEventsPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		payloads <- payload
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stop := startWatch(ctx, Deps{
+		Client:        client,
+		Log:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Enumerate:     func() []ProfileRoot { return []ProfileRoot{{Username: "alice", Dir: profileDir}} },
+		WatchDebounce: debounce,
+		WatchDirCap:   16,
+	}, SourceConfig{ID: "source-watch", Kind: "local_profile", Watch: true})
+	defer stop()
+
+	keepPath := filepath.Join(documentsDir, "keep.txt")
+	if err := os.WriteFile(keepPath, []byte("first"), 0o600); err != nil {
+		t.Fatalf("create keep file: %v", err)
+	}
+	if err := os.WriteFile(keepPath, []byte("final contents"), 0o600); err != nil {
+		t.Fatalf("rewrite keep file: %v", err)
+	}
+	if err := os.Remove(doomedPath); err != nil {
+		t.Fatalf("remove doomed file: %v", err)
+	}
+
+	var payload watchEventsPayload
+	select {
+	case payload = <-payloads:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for debounced events request")
+	}
+
+	if len(payload.Upserts) != 1 {
+		t.Fatalf("upserts = %+v, want one coalesced entry", payload.Upserts)
+	}
+	upsert := payload.Upserts[0]
+	if upsert.RelPath != "alice/Documents/keep.txt" || upsert.Name != "keep.txt" || upsert.IsDir {
+		t.Fatalf("upsert = %+v, want alice/Documents/keep.txt file", upsert)
+	}
+	if upsert.Size != int64(len("final contents")) {
+		t.Fatalf("upsert size = %d, want %d", upsert.Size, len("final contents"))
+	}
+	if len(payload.Deletes) != 1 || payload.Deletes[0] != "alice/Documents/doomed.txt" {
+		t.Fatalf("deletes = %v, want alice/Documents/doomed.txt", payload.Deletes)
+	}
+
+	select {
+	case extra := <-payloads:
+		t.Fatalf("received second PostEvents payload after coalescing: %+v", extra)
+	case <-time.After(4 * debounce):
+	}
+}
+
+func TestStartWatchDegradesToCrawlOnlyWhenDirectoryCapExceeded(t *testing.T) {
+	profileDir := filepath.Join(t.TempDir(), "alice")
+	documentsDir := filepath.Join(profileDir, "Documents")
+	if err := os.MkdirAll(filepath.Join(documentsDir, "nested"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	var eventPosts atomic.Int32
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspace/agent/sources/source-capped/events" {
+			eventPosts.Add(1)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stop := startWatch(ctx, Deps{
+		Client:        client,
+		Log:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Enumerate:     func() []ProfileRoot { return []ProfileRoot{{Username: "alice", Dir: profileDir}} },
+		WatchDebounce: 25 * time.Millisecond,
+		WatchDirCap:   1,
+	}, SourceConfig{ID: "source-capped", Kind: "local_profile", Watch: true})
+	defer stop()
+
+	if err := os.WriteFile(filepath.Join(documentsDir, "after-cap.txt"), []byte("ignored"), 0o600); err != nil {
+		t.Fatalf("write after cap exceeded: %v", err)
+	}
+	time.Sleep(6 * 25 * time.Millisecond)
+
+	if got := eventPosts.Load(); got != 0 {
+		t.Fatalf("PostEvents calls = %d, want 0 after watcher degraded to crawl-only", got)
+	}
+}
+
+func TestStartWatchExcludedDirectoriesDoNotConsumeCap(t *testing.T) {
+	profileDir := filepath.Join(t.TempDir(), "alice")
+	documentsDir := filepath.Join(profileDir, "Documents")
+	if err := os.MkdirAll(filepath.Join(documentsDir, "ignored", "nested"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	payloads := make(chan watchEventsPayload, 1)
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload watchEventsPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		payloads <- payload
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stop := startWatch(ctx, Deps{
+		Client:        client,
+		Log:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Enumerate:     func() []ProfileRoot { return []ProfileRoot{{Username: "alice", Dir: profileDir}} },
+		WatchDebounce: 50 * time.Millisecond,
+		WatchDirCap:   1,
+	}, SourceConfig{
+		ID: "source-exclusions", Kind: "local_profile", Watch: true,
+		ExcludeGlobs: []string{"ignored/**"},
+	})
+	defer stop()
+
+	if err := os.WriteFile(filepath.Join(documentsDir, "visible.txt"), []byte("visible"), 0o600); err != nil {
+		t.Fatalf("write visible file: %v", err)
+	}
+	select {
+	case payload := <-payloads:
+		if len(payload.Upserts) != 1 || payload.Upserts[0].RelPath != "alice/Documents/visible.txt" {
+			t.Fatalf("payload = %+v, want visible file only", payload)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("excluded directory consumed watch cap and degraded watcher")
+	}
+}

--- a/apps/api/src/extensions/loader.test.ts
+++ b/apps/api/src/extensions/loader.test.ts
@@ -5,15 +5,25 @@ import { join } from 'node:path';
 
 vi.mock('../services/aiTools', () => ({ aiTools: new Map() }));
 vi.mock('../middleware/auth', () => ({ authMiddleware: async (_c: unknown, next: () => Promise<void>) => next() }));
+vi.mock('../middleware/agentAuth', () => ({ agentAuthMiddleware: async (_c: unknown, next: () => Promise<void>) => next() }));
+vi.mock('../services/auditService', () => ({ createAuditLogAsync: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../services/secretCrypto', () => ({
+  encryptSecret: vi.fn((value: string, options: { aad?: string }) => `encrypted:${options.aad}:${value}`),
+  decryptForColumn: vi.fn((_table: string, _column: string, value: string) => value.split(':').at(-1)),
+}));
+vi.mock('../db', () => ({ db: { execute: vi.fn() } }));
+vi.mock('../services/redis', () => ({ getRedis: () => null }));
+vi.mock('../services/clientIp', () => ({ getTrustedClientIp: () => 'extension-loader-test' }));
 
 import { mountExtensions } from './loader';
+import { __resetSkipPrefixesForTests, globalRateLimit } from '../middleware/globalRateLimit';
 
-function scaffoldRuntimeExtension(root: string) {
+function scaffoldRuntimeExtension(root: string, manifestOverrides: Record<string, unknown> = {}) {
   const dir = join(root, 'demo');
   mkdirSync(join(dir, 'src'), { recursive: true });
   writeFileSync(
     join(dir, 'breeze-extension.json'),
-    JSON.stringify({ name: 'demo', routeNamespace: 'demo', entry: 'src/index.ts', tenancy: {} })
+    JSON.stringify({ name: 'demo', routeNamespace: 'demo', entry: 'src/index.ts', tenancy: {}, ...manifestOverrides })
   );
   // A real loadable entry — plain TS, imported under vitest's transform.
   writeFileSync(
@@ -24,8 +34,14 @@ function scaffoldRuntimeExtension(root: string) {
          const app = new Hono();
          const initialAiToolCount = ctx.aiTools.size;
          app.get('/health', (c) => c.json({ ok: true, ext: 'demo', initialAiToolCount }));
+         app.get('/agent/health', (c) => c.json({ ok: true }));
          ctx.mountRoute(app);
          ctx.aiTools.set('demo_tool', { definition: { name: 'demo_tool', description: 'x', input_schema: { type: 'object' } }, tier: 1, handler: async () => 'ok' });
+         const ciphertext = ctx.secrets.encryptForColumn('demo_secrets', 'value', 'secret');
+         const plaintext = ctx.secrets.decryptForColumn('demo_secrets', 'value', ciphertext);
+         if (!ctx.agentAuthMiddleware || !ctx.db || plaintext !== 'secret') throw new Error('missing ctx member');
+         ctx.audit({ actorId: 'user-1', action: 'demo.manual', resourceType: 'demo', result: 'success' });
+         ctx.audit({ actorType: 'agent', actorId: 'agent-1', action: 'demo.agent', resourceType: 'demo', result: 'success' });
        },
      };
      export default ext;`
@@ -60,6 +76,8 @@ describe('mountExtensions', () => {
   let root: string;
   beforeEach(async () => {
     root = mkdtempSync(join(process.cwd(), 'ext-rt-'));
+    __resetSkipPrefixesForTests();
+    vi.clearAllMocks();
     const { aiTools } = await import('../services/aiTools');
     aiTools.clear();
   });
@@ -81,6 +99,32 @@ describe('mountExtensions', () => {
     expect(await res.json()).toEqual({ ok: true, ext: 'demo', initialAiToolCount: 0 });
     const { aiTools } = await import('../services/aiTools');
     expect(aiTools.has('demo_tool')).toBe(true);
+  });
+
+  it('provides seam-v2 context members and registers the agent skip prefix', async () => {
+    scaffoldRuntimeExtension(root, { agentRoutes: true });
+    const app = new Hono();
+    app.use('*', globalRateLimit({ limit: 1, windowSeconds: 60 }));
+
+    await mountExtensions(app, root);
+
+    const { createAuditLogAsync } = await import('../services/auditService');
+    expect(createAuditLogAsync).toHaveBeenCalledWith(expect.objectContaining({
+      actorId: 'user-1',
+      action: 'demo.manual',
+      initiatedBy: 'manual',
+      result: 'success',
+    }));
+    expect(createAuditLogAsync).toHaveBeenCalledWith(expect.objectContaining({
+      actorType: 'agent',
+      actorId: 'agent-1',
+      action: 'demo.agent',
+      initiatedBy: 'agent',
+      result: 'success',
+    }));
+
+    expect((await app.request('/api/v1/demo/agent/health')).status).toBe(200);
+    expect((await app.request('/api/v1/demo/agent/health')).status).toBe(200);
   });
 
   it('loads the dist CJS default export when present', async () => {

--- a/apps/api/src/extensions/loader.ts
+++ b/apps/api/src/extensions/loader.ts
@@ -2,15 +2,26 @@
 // Extension sub-apps mount on the outer app. Middleware added to the `api`
 // instance via api.use('*') does not apply to them, and org-scoped fallback
 // audit cannot attribute extension routes. Extensions MUST apply
-// ctx.authMiddleware and write their own audit entries for mutations.
+// ctx.authMiddleware or ctx.agentAuthMiddleware themselves. Core injects the
+// ALS-bound database, column-bound secrets, and async audit capability.
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { Hono } from 'hono';
-import type { BreezeExtension, ExtensionContext, AiToolLike } from '@breeze/extension-api';
+import type {
+  AiToolLike,
+  BreezeExtension,
+  ExtensionContext,
+  ExtensionDatabase,
+} from '@breeze/extension-api';
 import { discoverExtensions } from './discovery';
 import { aiTools } from '../services/aiTools';
 import { authMiddleware } from '../middleware/auth';
+import { agentAuthMiddleware } from '../middleware/agentAuth';
+import { db } from '../db';
+import { createAuditLogAsync } from '../services/auditService';
+import { decryptForColumn, encryptSecret } from '../services/secretCrypto';
+import { registerGlobalRateLimitSkipPrefix } from '../middleware/globalRateLimit';
 
 async function loadEntry(dir: string, entry: string): Promise<BreezeExtension> {
   const manifestEntry = path.join(dir, entry);
@@ -37,11 +48,26 @@ export async function mountExtensions(app: Hono, root?: string): Promise<void> {
 
   for (const d of discovered) {
     const ext = await loadEntry(d.dir, d.manifest.entry);
+    if (d.manifest.agentRoutes === true) {
+      registerGlobalRateLimitSkipPrefix(`/api/v1/${d.manifest.routeNamespace}/agent/`);
+    }
     const ctx: ExtensionContext = {
       mountRoute: (subApp) => {
         app.route(`/api/v1/${d.manifest.routeNamespace}`, subApp);
       },
       authMiddleware,
+      agentAuthMiddleware,
+      db: db as unknown as ExtensionDatabase,
+      secrets: {
+        encryptForColumn: (table, column, plaintext) =>
+          encryptSecret(plaintext, { aad: `${table}.${column}` }) ?? '',
+        decryptForColumn: (table, column, ciphertext) =>
+          decryptForColumn(table, column, ciphertext) ?? '',
+      },
+      audit: (event) => createAuditLogAsync({
+        ...event,
+        initiatedBy: event.actorType === 'agent' ? 'agent' : 'manual',
+      }),
       aiTools: new Proxy(aiTools as Map<string, AiToolLike>, {
         get(target, prop, receiver) {
           if (prop === 'set') {

--- a/apps/api/src/extensions/tenancyRegistry.test.ts
+++ b/apps/api/src/extensions/tenancyRegistry.test.ts
@@ -13,6 +13,7 @@ vi.mock('./discovery', () => ({
           orgCascadeDeleteTables: ['sample_items', 'memory_blocks'],
           deviceCascadeDeleteTables: ['sample_child', 'sample_parent'],
           deviceOrgDenormalizedTables: ['sample_events'],
+          deviceOrgMoveDeleteTables: ['demo_things'],
         },
       },
     },
@@ -24,6 +25,7 @@ import {
   withExtensionOrgCascade,
   withExtensionDeviceCascade,
   withExtensionDeviceOrgDenormalized,
+  withExtensionDeviceOrgMoveDelete,
   resetExtensionTenancyCacheForTests,
 } from './tenancyRegistry';
 
@@ -57,6 +59,7 @@ describe('tenancyRegistry', () => {
             orgCascadeDeleteTables: ['organizations', 'sample_items', 'organizations'],
             deviceCascadeDeleteTables: ['sample_child', 'sample_parent'],
             deviceOrgDenormalizedTables: ['sample_events'],
+            deviceOrgMoveDeleteTables: ['demo_things'],
           },
         },
       },
@@ -77,6 +80,10 @@ describe('tenancyRegistry', () => {
     expect(withExtensionDeviceOrgDenormalized(['agent_logs'])).toEqual([
       'agent_logs', 'sample_events',
     ]);
+  });
+
+  it('prepends extension device-org-move-delete tables, preserving core order', () => {
+    expect(withExtensionDeviceOrgMoveDelete([])).toEqual(['demo_things']);
   });
 
   it('is a pure pass-through with no extensions', async () => {

--- a/apps/api/src/extensions/tenancyRegistry.ts
+++ b/apps/api/src/extensions/tenancyRegistry.ts
@@ -28,6 +28,11 @@ export function withExtensionDeviceCascade(core: readonly string[]): string[] {
   return [...extra, ...core];
 }
 
+export function withExtensionDeviceOrgMoveDelete(core: readonly string[]): string[] {
+  const extra = getExtensionTenancy().flatMap((t) => t.deviceOrgMoveDeleteTables ?? []);
+  return [...extra, ...core];
+}
+
 export function withExtensionDeviceOrgDenormalized(core: readonly string[]): string[] {
   const extra = getExtensionTenancy().flatMap((t) => t.deviceOrgDenormalizedTables);
   return [...core, ...extra];

--- a/apps/api/src/middleware/globalRateLimit.test.ts
+++ b/apps/api/src/middleware/globalRateLimit.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../services/redis', () => ({
+  getRedis: () => null,
+}));
+
+vi.mock('../services/clientIp', () => ({
+  getTrustedClientIp: vi.fn(() => 'global-rate-limit-test'),
+}));
+
+import {
+  __resetSkipPrefixesForTests,
+  globalRateLimit,
+  registerGlobalRateLimitSkipPrefix,
+} from './globalRateLimit';
+
+beforeEach(() => {
+  __resetSkipPrefixesForTests();
+});
+
+describe('globalRateLimit', () => {
+  it('skips registered extension agent prefixes', async () => {
+    registerGlobalRateLimitSkipPrefix('/api/v1/demo/agent/');
+    const app = new Hono();
+    app.use('*', globalRateLimit({ limit: 1, windowSeconds: 60 }));
+    app.post('/api/v1/demo/agent/batch', (c) => c.json({ ok: true }));
+
+    await app.request('/api/v1/demo/agent/batch', { method: 'POST' });
+    const res = await app.request('/api/v1/demo/agent/batch', { method: 'POST' });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('resets registered prefixes while preserving built-in prefixes', async () => {
+    registerGlobalRateLimitSkipPrefix('/api/v1/demo/agent/');
+    __resetSkipPrefixesForTests();
+
+    const app = new Hono();
+    app.use('*', globalRateLimit({ limit: 1, windowSeconds: 60 }));
+    app.post('/api/v1/demo/agent/batch', (c) => c.json({ ok: true }));
+    app.post('/api/v1/agents/batch', (c) => c.json({ ok: true }));
+
+    await app.request('/api/v1/demo/agent/batch', { method: 'POST' });
+    const limited = await app.request('/api/v1/demo/agent/batch', { method: 'POST' });
+    const builtIn = await app.request('/api/v1/agents/batch', { method: 'POST' });
+
+    expect(limited.status).toBe(429);
+    expect(builtIn.status).toBe(200);
+  });
+});

--- a/apps/api/src/middleware/globalRateLimit.ts
+++ b/apps/api/src/middleware/globalRateLimit.ts
@@ -21,8 +21,19 @@ const SKIP_PATHS = new Set(['/health', '/ready']);
 // so exclude them from the global per-IP limit.  Without this, agent heartbeats
 // and telemetry consume the same IP bucket as the dashboard UI — especially
 // problematic in development where everything originates from localhost.
-const SKIP_PREFIXES = ['/api/v1/agents/', '/api/v1/helper/'];
+const BUILT_IN_SKIP_PREFIXES = ['/api/v1/agents/', '/api/v1/helper/'];
+const skipPrefixes: string[] = [...BUILT_IN_SKIP_PREFIXES];
 const MAX_IN_MEMORY_ENTRIES = 100_000;
+
+export function registerGlobalRateLimitSkipPrefix(prefix: string): void {
+  if (!skipPrefixes.includes(prefix)) {
+    skipPrefixes.push(prefix);
+  }
+}
+
+export function __resetSkipPrefixesForTests(): void {
+  skipPrefixes.splice(0, skipPrefixes.length, ...BUILT_IN_SKIP_PREFIXES);
+}
 
 // ---------------------------------------------------------------------------
 // In-memory fallback rate limiter (used when Redis is unavailable)
@@ -68,7 +79,7 @@ export function globalRateLimit(options?: GlobalRateLimitOptions): MiddlewareHan
     }
 
     // Skip agent routes — they have dedicated per-agent rate limiting
-    if (SKIP_PREFIXES.some(prefix => c.req.path.startsWith(prefix))) {
+    if (skipPrefixes.some(prefix => c.req.path.startsWith(prefix))) {
       return next();
     }
 

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -56,6 +56,7 @@ import { getGlobalEnrollmentSecret } from '../agents/enrollment';
 import {
   withExtensionDeviceCascade,
   withExtensionDeviceOrgDenormalized,
+  withExtensionDeviceOrgMoveDelete,
 } from '../../extensions/tenancyRegistry';
 
 /**
@@ -133,6 +134,12 @@ const CORE_DEVICE_ORG_DENORMALIZED_TABLES = [
 
 export function getDeviceOrgDenormalizedTables(): readonly string[] {
   return withExtensionDeviceOrgDenormalized(CORE_DEVICE_ORG_DENORMALIZED_TABLES);
+}
+
+const CORE_DEVICE_ORG_MOVE_DELETE_TABLES: readonly string[] = [];
+
+export function getDeviceOrgMoveDeleteTables(): readonly string[] {
+  return withExtensionDeviceOrgMoveDelete(CORE_DEVICE_ORG_MOVE_DELETE_TABLES);
 }
 
 /** @deprecated Static core-only snapshot retained for call sites that predate extensions. */

--- a/apps/api/src/routes/devices/moveOrg.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.test.ts
@@ -50,6 +50,12 @@ vi.mock('../../services/deviceLinkGroups', () => ({
   dissolveLinkGroupIfBelowMinimum: vi.fn(async () => false),
 }));
 
+vi.mock('../../extensions/tenancyRegistry', () => ({
+  withExtensionDeviceCascade: (core: readonly string[]) => [...core],
+  withExtensionDeviceOrgDenormalized: (core: readonly string[]) => [...core],
+  withExtensionDeviceOrgMoveDelete: (core: readonly string[]) => ['demo_things', ...core],
+}));
+
 import { db } from '../../db';
 import { getDeviceWithOrgAndSiteCheck } from './helpers';
 import { writeRouteAudit } from '../../services/auditEvents';
@@ -59,6 +65,7 @@ import { moveOrgRoutes } from './moveOrg';
 import {
   CUSTOM_ORG_REWRITE_TABLES,
   getDeviceOrgDenormalizedTables,
+  getDeviceOrgMoveDeleteTables,
   DEVICE_SITE_DENORMALIZED_TABLES,
 } from './core';
 
@@ -224,7 +231,7 @@ describe('POST /devices/:id/move-org', () => {
         ],
         siteRow: { id: TARGET_SITE },
       });
-      const { updatedTables, deviceUpdateSets } = rigTransactionSuccess();
+      const { updatedTables, statements, deviceUpdateSets } = rigTransactionSuccess();
 
       const res = await app.request(`/devices/${DEVICE_ID}/move-org`, {
         method: 'POST',
@@ -268,9 +275,14 @@ describe('POST /devices/:id/move-org', () => {
       // updatedTables a second time for the site_id rewrite.
       expect(updatedTables).toEqual([
         ...getDeviceOrgDenormalizedTables(),
+        ...getDeviceOrgMoveDeleteTables(),
         ...CUSTOM_ORG_REWRITE_TABLES,
         ...DEVICE_SITE_DENORMALIZED_TABLES,
       ]);
+
+      expect(statements).toContain(
+        `DELETE FROM demo_things WHERE device_id = ${DEVICE_ID}`,
+      );
 
       // After the move, the live WS for this agent MUST be closed so the
       // reconnect handshake resolves the new org_id. Otherwise every

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -17,7 +17,11 @@ import {
 } from './helpers';
 import { moveOrgSchema } from './schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
-import { getDeviceOrgDenormalizedTables, DEVICE_SITE_DENORMALIZED_TABLES } from './core';
+import {
+  getDeviceOrgDenormalizedTables,
+  getDeviceOrgMoveDeleteTables,
+  DEVICE_SITE_DENORMALIZED_TABLES,
+} from './core';
 import { dissolveLinkGroupIfBelowMinimum } from '../../services/deviceLinkGroups';
 import { disconnectAgent } from '../agentWs';
 import { captureException } from '../../services/sentry';
@@ -163,6 +167,13 @@ moveOrgRoutes.post(
           await tx.execute(
             sql`UPDATE ${sql.identifier(table)} SET org_id = ${targetOrgId}::uuid WHERE device_id = ${deviceId}::uuid`,
           );
+        }
+
+        // Extension tables that must be DELETED (not re-stamped) on org-move: their rows
+        // FK a source/config row that stays in the old org, so rewriting org_id would
+        // corrupt cross-row consistency. See extension-api tenancy docs.
+        for (const table of getDeviceOrgMoveDeleteTables()) {
+          await tx.execute(sql`DELETE FROM ${sql.identifier(table)} WHERE device_id = ${deviceId}`);
         }
 
         // ticket_alert_links denormalizes org_id for RLS but has no

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -63,7 +63,7 @@ org — rewriting `org_id` on the child row alone would leave it pointing at a
 parent row in a different tenant, corrupting cross-row consistency under RLS.
 Core deletes these rows (via `getDeviceOrgMoveDeleteTables()`, which merges
 core and extension registrations) in the same transaction as the org-move,
-before the denormalized-column rewrite pass. Tables that don't have this FK
+immediately after the denormalized-column rewrite pass. Tables that don't have this FK
 shape and can simply have `org_id` rewritten in place belong in
 `deviceOrgDenormalizedTables` instead.
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -35,6 +35,82 @@ account for this: the builder stage runs a scoped
 `pnpm install --filter './extensions/*' --no-frozen-lockfile` before building
 extensions, so the committed lockfile stays extension-free.
 
+## Seam v2: manifest flags and ExtensionContext
+
+### `agentRoutes` manifest flag
+
+Set `agentRoutes: true` in `breeze-extension.json` when the extension mounts
+routes under `/api/v1/<routeNamespace>/agent/` that are authenticated with
+`ctx.agentAuthMiddleware` (device/agent tokens) rather than user sessions.
+The core loader responds by registering that path prefix as a skip-prefix on
+the global per-IP rate limiter (`registerGlobalRateLimitSkipPrefix`), the
+same treatment core's own `/api/v1/agents/` and `/api/v1/helper/` routes get.
+This is safe because agent-token auth carries its own per-agent/per-org
+limits independent of the global per-IP bucket — device fleets share IPs
+(NAT, proxies) and would otherwise collide with the same limit budget as
+interactive dashboard traffic. Only set this flag for routes actually gated
+by agent-token auth; do not use it to bypass rate limiting on user-facing
+routes.
+
+### `deviceOrgMoveDeleteTables` tenancy list
+
+Register a `device_id`-bearing extension table here when its rows must be
+**deleted**, not org_id-re-stamped, when a device moves to a different
+organization (`PATCH` device org-move flow). Use this instead of
+`deviceOrgDenormalizedTables` when the table's rows FK a source/config row
+(e.g. an extension-owned sources/config table) that stays behind in the old
+org — rewriting `org_id` on the child row alone would leave it pointing at a
+parent row in a different tenant, corrupting cross-row consistency under RLS.
+Core deletes these rows (via `getDeviceOrgMoveDeleteTables()`, which merges
+core and extension registrations) in the same transaction as the org-move,
+before the denormalized-column rewrite pass. Tables that don't have this FK
+shape and can simply have `org_id` rewritten in place belong in
+`deviceOrgDenormalizedTables` instead.
+
+### New `ExtensionContext` members
+
+- **`agentAuthMiddleware`** — Core's agent-token auth middleware. Apply it to
+  any route intended for devices/agents rather than logged-in users; it
+  validates the agent token, sets `c.get('agent')` to an
+  `ExtensionAgentContext` (`deviceId`, `agentId`, `orgId`, `siteId`, `role`),
+  and opens the request's org RLS context accordingly. Routes under this
+  middleware should also be declared via the `agentRoutes` manifest flag (see
+  above) so they're excluded from the global per-IP rate limiter — agent auth
+  enforces its own per-agent/per-org limits instead.
+
+- **`db`** — Core's ALS-bound Drizzle handle (`ExtensionDatabase`), scoped to
+  the ambient request via Node's `AsyncLocalStorage`. It runs *inside* the
+  same request-scoped RLS transaction core uses — the Postgres session GUCs
+  that scope row visibility to the caller's org are already set, so plain
+  queries against extension tables are automatically tenant-isolated as long
+  as the tables carry an `org_id` column with RLS policies (see "Tenant
+  Isolation / RLS" in the root `CLAUDE.md`). `ExtensionDatabase` is a
+  structural type exposing only `execute()`; cast it to your own Drizzle
+  database type to get full query-builder ergonomics:
+  `const db = ctx.db as unknown as PostgresJsDatabase<typeof myExtensionSchema>;`
+  The extension must pin the same `drizzle-orm` version as core to keep the
+  wire format compatible.
+
+- **`secrets`** — Column-bound `encryptForColumn(table, column, plaintext)` /
+  `decryptForColumn(table, column, ciphertext)` helpers backed by core's
+  encryption-at-rest primitives. Use these for any extension-owned secret
+  column (API tokens, credentials, etc.) instead of rolling your own crypto.
+  Important: extension secret columns are **not** entries in core's
+  `encryptedColumnRegistry` (`apps/api/src/services/encryptedColumnRegistry.ts`)
+  — that registry only tracks core tables. Key-rotation tooling built against
+  `encryptedColumnRegistry` will not discover or rotate extension secret
+  columns; an extension that stores encrypted secrets is responsible for its
+  own key-rotation tooling and runbook.
+
+- **`audit`** — `(event: ExtensionAuditEvent) => Promise<void>`. Queues an
+  audit-log entry with fire-and-forget retry semantics (same pipeline core
+  routes use via `createAuditLogAsync`). Call this after any state-changing
+  action so it shows up in the org's audit trail; set `actorType: 'agent'`
+  for actions taken by a device/agent (routes behind `agentAuthMiddleware`)
+  versus `'user'` / `'api_key'` / `'system'` as appropriate. The call does
+  not block on write completion, so don't rely on it for read-your-writes
+  consistency.
+
 ## Trust boundary & lifecycle
 
 - Anything that can write to `extensions/` or set `BREEZE_EXTENSIONS_DIR`
@@ -44,5 +120,10 @@ extensions, so the committed lockfile stays extension-free.
   place. Organization cascade-delete then fails loudly: the transaction rolls
   back with no partial erasure until the extension is restored, or its tables
   are dropped and its `<name>/` migration-ledger rows are deleted.
-- `RESERVED_ROUTE_NAMESPACES` in `@breeze/extension-api` is maintained by hand.
-  When core mounts a new `/api/v1` namespace, add it to that list.
+- `RESERVED_ROUTE_NAMESPACES` in `@breeze/extension-api` is maintained by
+  hand. When core mounts a new `/api/v1` namespace, add it to that list (and
+  to the ground-truth contract array in `packages/extension-api/src/index.test.ts`).
+  Regenerate the inner-mount list with
+  `grep -oE "api\.route\('/[a-z0-9-]+" apps/api/src/index.ts`, then add the
+  outer-app mounts that bypass that router: `oauth`, `settings`, and the
+  shortlink prefix `s`.

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -14,6 +14,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "drizzle-orm": "0.45.2",
     "hono": "^4.12.28",
     "typescript": "^5.7.2",
     "vitest": "^4.1.9"

--- a/packages/extension-api/src/index.test.ts
+++ b/packages/extension-api/src/index.test.ts
@@ -18,6 +18,24 @@ describe('parseExtensionManifest', () => {
     expect(m.name).toBe('sample');
     expect(m.migrationsDir).toBe('migrations'); // default
     expect(m.tenancy.deviceCascadeDeleteTables).toEqual([]); // default
+    expect(m.tenancy.deviceOrgMoveDeleteTables).toBeUndefined(); // optional
+  });
+
+  it('accepts agentRoutes and deviceOrgMoveDeleteTables', () => {
+    const m = parseExtensionManifest({
+      name: 'demo', routeNamespace: 'demo', entry: 'src/index.ts',
+      agentRoutes: true,
+      tenancy: { deviceOrgMoveDeleteTables: ['demo_things'] },
+    });
+    expect(m.agentRoutes).toBe(true);
+    expect(m.tenancy.deviceOrgMoveDeleteTables).toEqual(['demo_things']);
+  });
+
+  it('rejects unprefixed tables in deviceOrgMoveDeleteTables', () => {
+    expect(() => parseExtensionManifest({
+      name: 'demo', routeNamespace: 'demo', entry: 'src/index.ts',
+      tenancy: { deviceOrgMoveDeleteTables: ['other_things'] },
+    })).toThrow(/demo_/);
   });
 
   it('rejects invalid names (uppercase, spaces, leading digit, "plugins")', () => {

--- a/packages/extension-api/src/index.test.ts
+++ b/packages/extension-api/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseExtensionManifest } from './index';
+import { parseExtensionManifest, RESERVED_ROUTE_NAMESPACES } from './index';
 
 describe('parseExtensionManifest', () => {
   const valid = {
@@ -78,5 +78,46 @@ describe('parseExtensionManifest', () => {
         tenancy: { orgCascadeDeleteTables: ['memory_blocks'] },
       })
     ).not.toThrow();
+  });
+});
+
+describe('RESERVED_ROUTE_NAMESPACES', () => {
+  // Hand-maintained contract. Regenerate the inner-mount list with:
+  //   grep -oE "api\.route\('/[a-z0-9-]+" apps/api/src/index.ts
+  // That yields the 111 `/api/v1/*` mounts inside the versioned router. Add
+  // the outer-app mounts that don't go through that router: `oauth`,
+  // `settings` (both mounted directly on the outer Hono app), and the
+  // shortlink prefix `s` (`app.route('/s', publicShortLinkRoutes)`).
+  const CORE_NAMESPACES = [
+    'access-reviews', 'accounting', 'admin', 'agent-versions', 'agent-ws',
+    'agents', 'ai', 'alert-templates', 'alerts', 'analytics', 'api-keys',
+    'audit-baselines', 'audit-logs', 'auth', 'authenticator', 'automations',
+    'backup', 'browser-security', 'c2c', 'catalog', 'changes', 'cis',
+    'client-ai', 'config', 'configuration-policies', 'contracts',
+    'custom-fields', 'deployments', 'desktop-ws', 'dev', 'device-groups',
+    'devices', 'discovery', 'dns-security', 'docs', 'dr', 'enrollment-keys',
+    'events', 'filters', 'google', 'groups', 'helper', 'huntress',
+    'incidents', 'installer', 'integrations', 'internal', 'invoices', 'logs',
+    'm365', 'maintenance', 'mcp', 'me', 'metrics', 'mobile', 'monitoring',
+    'monitors', 'network', 'notifications', 'oauth', 'onedrive', 'orgs',
+    'pam', 'partner', 'partners', 'patch-policies', 'patches', 'pax8',
+    'peripherals', 'permissions', 'playbooks', 'plugins', 'policies',
+    'portal', 'psa', 'quotes', 'reliability', 'remediation-suggestions',
+    'remote', 'reports', 'roles', 's', 's1', 'script-library', 'scripts',
+    'search', 'security', 'sensitive-data', 'settings', 'snmp', 'software',
+    'software-inventory', 'software-policies', 'sso', 'system',
+    'system-tools', 'tags', 'third-party-catalog', 'ticket-categories',
+    'ticket-config', 'tickets', 'time-entries', 'tunnel-http', 'tunnel-ws',
+    'tunnels', 'unifi', 'update-rings', 'user-risk', 'users', 'viewers',
+    'vnc-exchange', 'vnc-viewer', 'vulnerabilities', 'webhooks',
+  ];
+
+  it('has exactly 114 entries in the ground-truth contract', () => {
+    expect(CORE_NAMESPACES).toHaveLength(114);
+  });
+
+  it('reserves every core /api/v1 route namespace', () => {
+    const missing = CORE_NAMESPACES.filter((ns) => !RESERVED_ROUTE_NAMESPACES.has(ns));
+    expect(missing).toEqual([]);
   });
 });

--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -6,11 +6,36 @@ import type { MiddlewareHandler } from 'hono';
 /**
  * Route namespaces already mounted by core (apps/api/src/index.ts, /api/v1/*).
  * An extension may not shadow them. Keep in sync when core adds mounts.
+ *
+ * Regenerate the inner-mount list with:
+ *   grep -oE "api\.route\('/[a-z0-9-]+" apps/api/src/index.ts
+ * then add the outer-app mounts `oauth`, `settings`, and the shortlink
+ * prefix `s`, which are mounted directly on the outer Hono app rather than
+ * through the versioned `/api/v1` router. See src/index.test.ts for the
+ * hand-maintained ground-truth contract this set is checked against.
  */
-const RESERVED_ROUTE_NAMESPACES = new Set([
-  'auth', 'config', 'devices', 'plugins', 'ai', 'mcp', 'oauth', 'settings',
-  'organizations', 'sites', 'alerts', 'scripts', 'automations', 'users',
-  'partners', 'billing', 'tickets', 'reports', 'remote', 'desktop-ws',
+export const RESERVED_ROUTE_NAMESPACES = new Set([
+  'access-reviews', 'accounting', 'admin', 'agent-versions', 'agent-ws',
+  'agents', 'ai', 'alert-templates', 'alerts', 'analytics', 'api-keys',
+  'audit-baselines', 'audit-logs', 'auth', 'authenticator', 'automations',
+  'backup', 'browser-security', 'c2c', 'catalog', 'changes', 'cis',
+  'client-ai', 'config', 'configuration-policies', 'contracts',
+  'custom-fields', 'deployments', 'desktop-ws', 'dev', 'device-groups',
+  'devices', 'discovery', 'dns-security', 'docs', 'dr', 'enrollment-keys',
+  'events', 'filters', 'google', 'groups', 'helper', 'huntress',
+  'incidents', 'installer', 'integrations', 'internal', 'invoices', 'logs',
+  'm365', 'maintenance', 'mcp', 'me', 'metrics', 'mobile', 'monitoring',
+  'monitors', 'network', 'notifications', 'oauth', 'onedrive', 'orgs',
+  'pam', 'partner', 'partners', 'patch-policies', 'patches', 'pax8',
+  'peripherals', 'permissions', 'playbooks', 'plugins', 'policies',
+  'portal', 'psa', 'quotes', 'reliability', 'remediation-suggestions',
+  'remote', 'reports', 'roles', 's', 's1', 'script-library', 'scripts',
+  'search', 'security', 'sensitive-data', 'settings', 'snmp', 'software',
+  'software-inventory', 'software-policies', 'sso', 'system',
+  'system-tools', 'tags', 'third-party-catalog', 'ticket-categories',
+  'ticket-config', 'tickets', 'time-entries', 'tunnel-http', 'tunnel-ws',
+  'tunnels', 'unifi', 'update-rings', 'user-risk', 'users', 'viewers',
+  'vnc-exchange', 'vnc-viewer', 'vulnerabilities', 'webhooks',
 ]);
 
 const NAME_RE = /^[a-z][a-z0-9-]{1,31}$/;

--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -39,6 +39,8 @@ const manifestSchema = z
       }),
     entry: z.string().min(1),
     migrationsDir: z.string().min(1).default('migrations'),
+    // Opts /api/v1/<routeNamespace>/agent/ out of the global per-IP rate
+    // limiter (agent-token auth carries its own per-agent/org limits).
     agentRoutes: z.boolean().optional(),
     tenancy: tenancySchema.optional().default({
       orgCascadeDeleteTables: [],

--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { SQLWrapper } from 'drizzle-orm';
 import type { Hono } from 'hono';
 import type { MiddlewareHandler } from 'hono';
 
@@ -21,6 +22,8 @@ const tenancySchema = z.object({
   deviceCascadeDeleteTables: z.array(z.string()).default([]),
   /** device_id + org_id tables whose org_id is rewritten when a device moves org. */
   deviceOrgDenormalizedTables: z.array(z.string()).default([]),
+  /** device_id tables whose rows are deleted when a device moves org. */
+  deviceOrgMoveDeleteTables: z.array(z.string()).optional(),
 });
 
 const manifestSchema = z
@@ -36,6 +39,7 @@ const manifestSchema = z
       }),
     entry: z.string().min(1),
     migrationsDir: z.string().min(1).default('migrations'),
+    agentRoutes: z.boolean().optional(),
     tenancy: tenancySchema.optional().default({
       orgCascadeDeleteTables: [],
       deviceCascadeDeleteTables: [],
@@ -47,6 +51,7 @@ const manifestSchema = z
       ...m.tenancy.orgCascadeDeleteTables,
       ...m.tenancy.deviceCascadeDeleteTables,
       ...m.tenancy.deviceOrgDenormalizedTables,
+      ...(m.tenancy.deviceOrgMoveDeleteTables ?? []),
     ];
     // memory_blocks is a deliberately shared cross-extension table.
     const SHARED_TABLE_ALLOWLIST = new Set(['memory_blocks']);
@@ -82,12 +87,58 @@ export interface AiToolLike {
   deviceArgs?: readonly string[];
 }
 
+/** Agent identity injected by the core agent authentication middleware. */
+export interface ExtensionAgentContext {
+  deviceId: string;
+  agentId: string;
+  orgId: string;
+  siteId: string | null;
+  role: string;
+}
+
+/** Audit event accepted by the core audit pipeline. */
+export interface ExtensionAuditEvent {
+  orgId?: string | null;
+  actorType?: 'user' | 'api_key' | 'agent' | 'system';
+  actorId: string;
+  action: string;
+  resourceType: string;
+  resourceId?: string;
+  resourceName?: string;
+  details?: Record<string, unknown>;
+  result: 'success' | 'failure' | 'denied';
+  errorMessage?: string;
+}
+
+/** Column-bound encryption helpers injected by core. */
+export interface ExtensionSecrets {
+  encryptForColumn(table: string, column: string, plaintext: string): string;
+  decryptForColumn(table: string, column: string, ciphertext: string): string;
+}
+
+/**
+ * Structural core database handle. Extensions cast this to their own Drizzle type:
+ * `const db = ctx.db as unknown as PostgresJsDatabase;` The extension must pin the
+ * same drizzle-orm version as core.
+ */
+export type ExtensionDatabase = {
+  execute(query: SQLWrapper | string): Promise<unknown>;
+} & Record<string, unknown>;
+
 /** Injected by the core loader — the ONLY channel through which an extension touches Breeze. */
 export interface ExtensionContext {
   /** Mounts subApp at /api/v1/<routeNamespace>. Extension must apply its own auth middleware. */
   mountRoute: (subApp: Hono) => void;
   /** Core auth middleware, injected so the extension need not import @breeze/api. */
   authMiddleware: MiddlewareHandler;
+  /** Core agent auth middleware; sets `c.get('agent')` and opens the org RLS context. */
+  agentAuthMiddleware: MiddlewareHandler;
+  /** Core ALS-bound Drizzle handle; active RLS GUCs apply. */
+  db: ExtensionDatabase;
+  /** Core column-bound encryption helpers. */
+  secrets: ExtensionSecrets;
+  /** Queues an audit event with fire-and-forget retry semantics. */
+  audit: (event: ExtensionAuditEvent) => Promise<void>;
   /** The shared AI tool registry map (keys = tool names; collisions throw in the loader). */
   aiTools: Map<string, AiToolLike>;
   log: (message: string) => void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -933,6 +933,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      drizzle-orm:
+        specifier: 0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(gel@2.2.0)(pg@8.21.0)(postgres@3.4.9)
       hono:
         specifier: ^4.12.28
         version: 4.12.28
@@ -13299,9 +13302,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -933,9 +933,6 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      drizzle-orm:
-        specifier: 0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(gel@2.2.0)(pg@8.21.0)(postgres@3.4.9)
       hono:
         specifier: ^4.12.28
         version: 4.12.28
@@ -13302,7 +13299,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.0': {}
 


### PR DESCRIPTION
## What

Two independent, generic infrastructure pieces:

**Part A — extension seam v2** (`packages/extension-api`, `apps/api/src/extensions/`):
- `ExtensionContext` gains four members wired from core primitives: `agentAuthMiddleware` (device-token auth + org RLS context), `db` (the ALS-bound drizzle handle, so extension queries run inside the ambient request transaction), `secrets` (AAD-bound column encryption via `secretCrypto`), and `audit` (`createAuditLogAsync` wrapper). Extensions previously had no way to authenticate agents, reach the RLS-scoped DB, encrypt columns, or write audit rows without schema-coupling.
- Manifest `agentRoutes: true` opts `/api/v1/<ns>/agent/` out of the global per-IP rate limiter (same rationale as the existing `/api/v1/agents/` skip: NATed fleets share one IP; `agentAuthMiddleware` carries its own per-agent/per-org limits).
- New tenancy list `deviceOrgMoveDeleteTables`: rows deleted (not org_id-re-stamped) on device org-move, for extension tables whose rows FK a config row that stays in the old org. Consumed by `moveOrg` inside the existing transaction.
- `RESERVED_ROUTE_NAMESPACES` refreshed from the stale ~20 entries to the full 114 actual core mounts, with a regenerable contract test.

**Part C — `agent/internal/workspaceindex/`** (new bounded agent module): a generic, server-driven file-index crawler — streaming lexicographic walker with server-held cursor resume, local + SMB (`go-smb2`, explicit read-only credentials fetched transiently per crawl and zeroed) sources, gzip batched uploads with split-on-413, single-flight scheduler with per-source cadence, fsnotify watcher (capped, degrade-to-crawl), full kill-switch layering (server config, per-source, local yaml). Wired into the agent lifecycle following the UniFi collector pattern (own cancel/done, Recoverer on every goroutine, 15s-budget-respecting shutdown).

The module is dormant unless a server answers its (config-overridable) endpoints: config fetch 404s → 6h backoff, zero work. Public installs without a serving extension see one idle poll per 6h.

New deps (exact-pinned): `github.com/hirochachacha/go-smb2 v1.1.0` (+ transitive `geoffgarside/ber`); `golang.org/x/time` and `fsnotify` promoted from indirect.

## Testing

- `packages/extension-api` + `apps/api`: typecheck clean; extensions/, globalRateLimit, moveOrg suites green (60 tests).
- Agent: `go test -race ./...` full suite green; `GOOS=windows` cross-compile green; walker cursor-resume covered by an exhaustive cut-at-every-position test; credential redaction asserted across fmt verbs, JSON, logs, and error chains.
- Boot check: extension discovery/mount verified against a live API instance.
- Lockfile carries no `extensions/*` importers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)