### PR TITLE
fix(web): initialize i18n on /register-partner — public signup rendered raw translation keys (#2420)

### DIFF
--- a/apps/web/src/components/auth/PartnerRegisterPage.tsx
+++ b/apps/web/src/components/auth/PartnerRegisterPage.tsx
@@ -4,6 +4,10 @@ import { useAuthStore, apiRegisterPartner } from '../../stores/auth';
 import { useRegistrationGate } from '../../stores/featuresStore';
 import { navigateTo } from '../../lib/navigation';
 import { getSafeNext } from '../../lib/authNext';
+// Initializes the shared i18next singleton. This page's layout has no Sidebar
+// (which is what pulls i18n in elsewhere), so without this every t() call here
+// renders its raw key.
+import '../../lib/i18n';
 
 interface PartnerRegisterPageProps {
   next?: string;


### PR DESCRIPTION
Closes #2420

## What

`/register-partner` — the public, unauthenticated self-service signup page — rendered raw translation keys (`auth.partnerRegister.*`) instead of UI text. The page mounts `<PartnerRegisterPage client:load />` directly (not via `AuthPage.tsx`, which does import `lib/i18n`), and nothing in the island's module graph initialized the shared i18next singleton. `PartnerRegisterForm` calls `useTranslation('auth')` with no English defaults, so the key IS the UI.

This is the exact bug class the #2416 sweep fixed on 47 island entry points — this one was missed.

## Fix

The established #2416 pattern, applied verbatim: the idempotent side-effect `import '../../lib/i18n'` at the island entry point (`PartnerRegisterPage.tsx`), with the same explanatory comment used on `LoginPage`, `ForgotPasswordPage`, `AcceptInvitePage`, and every other sibling auth entry point. The init-ordering/hydration guard from #2416 (`scheduleStoredLocaleAfterHydration` idle-deferral) lives in `lib/i18n` itself, so importing the module gets the full guarded behavior — no new pattern introduced.

## Completeness sweep (as requested in the issue)

Script-walked every `client:*` island mount in `apps/web/src/pages/**/*.astro` + `layouts/*.astro` (174 mounts) through its full relative-import module graph, checking (a) whether the graph translates (`useTranslation` / `i18n.t` / `Trans` / `react-i18next`) and (b) whether it reaches `lib/i18n`:

- **Before this fix:** exactly 1 violation — `pages/register-partner.astro` → `PartnerRegisterPage`.
- **After this fix:** 0 violations. 172/174 mounts reach `lib/i18n`; the only two graphs that don't (`AccountInactiveGuard` and `AdminSessionManager` in `DashboardLayout.astro`) render no translated UI.

No additional pages needed fixing.

## Verification

- `vitest run` — `PartnerRegisterPage.test.tsx`, `PartnerRegisterForm.test.tsx`, `lib/i18n/i18n.test.ts`: 3 files / 22 tests green
- Full `@breeze/web` suite: green (see PR comment)
- `tsc --noEmit` (apps/web): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
