### PR TITLE
fix(api): redact secrets from WS command-result error field before persistence (#2419)

### DIFF
--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -1498,7 +1498,7 @@ describe('Findings #8 / #5 — WS command-result audit + secret redaction', () =
     expect(writeAuditEvent).not.toHaveBeenCalled();
   });
 
-  it('redacts a PEM private key from stdout before it is persisted', async () => {
+  it('redacts a PEM private key from stdout, stderr, AND error before persistence (#2419)', async () => {
     const preValidatedAgent = { deviceId: 'device-r', orgId: 'org-r' };
     vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([
       { id: 'cmd-1', type: 'run_script', payload: {}, deviceId: 'device-r' },
@@ -1520,16 +1520,22 @@ describe('Findings #8 / #5 — WS command-result audit + secret redaction', () =
       data: JSON.stringify({
         type: 'command_result',
         commandId: '99999999-9999-4999-8999-999999999999',
-        status: 'completed',
-        exitCode: 0,
+        status: 'failed',
+        exitCode: 1,
         stdout: `key follows:\n${pem}\nend`,
+        stderr: `warning, leaked key:\n${pem}`,
+        error: `command failed while handling key:\n${pem}`,
       }),
     } as any, ws as any);
 
     expect(setSpy).toHaveBeenCalledTimes(1);
-    const stored = setSpy.mock.calls[0]![0] as { result: { stdout: string } };
-    expect(stored.result.stdout).toContain('[PRIVATE_KEY_REDACTED]');
-    expect(stored.result.stdout).not.toContain('BEGIN RSA PRIVATE KEY');
+    const stored = setSpy.mock.calls[0]![0] as {
+      result: { stdout: string; stderr: string; error: string };
+    };
+    for (const field of ['stdout', 'stderr', 'error'] as const) {
+      expect(stored.result[field]).toContain('[PRIVATE_KEY_REDACTED]');
+      expect(stored.result[field]).not.toContain('BEGIN RSA PRIVATE KEY');
+    }
   });
 });
 

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -627,7 +627,7 @@ function buildStoredCommandResult(
     stdout: stdout != null && !skipStdoutRedaction ? redactSecretsFromOutput(stdout) : stdout,
     stderr: result.stderr != null ? redactSecretsFromOutput(result.stderr) : result.stderr,
     durationMs: result.durationMs,
-    error: result.error,
+    error: result.error != null ? redactSecretsFromOutput(result.error) : result.error,
   };
 }
 


### PR DESCRIPTION
## Summary

The agent WS command-result persistence path (`buildStoredCommandResult` in `apps/api/src/routes/agentWs.ts`) stored `error: result.error` verbatim, while its REST twin (`apps/api/src/routes/agents/commands.ts`) applies `redactSecretsFromOutput` to `error` when non-null. `stdout`/`stderr` were already redacted on both legs (verified — the two functions store the same six fields; `error` was the only divergence). This closes the parity gap in the #2359 redaction layer: a secret in a WS-delivered result `error` field was persisted into `device_commands.result` unredacted and later visible to `scripts:read` users.

## Changes

- `apps/api/src/routes/agentWs.ts` — apply `redactSecretsFromOutput` to `error` when non-null, mirroring the REST path.
- `apps/api/src/routes/agentWs.test.ts` — extended the existing WS redaction test to assert PEM-key redaction on `stdout`, `stderr`, AND `error` in the persisted result.

## Verification

- Test confirmed red without the fix (persisted `error` contained the raw PEM), green with it.
- `pnpm exec vitest run src/routes/agentWs.test.ts` — 48 passed.
- `npx tsc --noEmit` (apps/api) — clean.

Closes #2419

🤖 Generated with [Claude Code](https://claude.com/claude-code)