### PR TITLE
fix(web): SSR-safe hash-derived tab state — useHashTab hook + the two #2383 regressions (#2421 Phase 1)

### DIFF
--- a/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
@@ -148,7 +148,7 @@ export default function ConfigPolicyDetailPage({
   // The hash is not available during SSR, so the tab starts at the
   // server-rendered default and adopts the hash post-mount (pre-paint) —
   // reading it in the useState initializer caused a hydration mismatch on
-  // every deep link (#2421).
+  // deep links to a non-default tab (#2421).
   const [activeTab, setActiveTab] = useHashTab<Tab>(VALID_TABS, "overview");
 
   // Reflect the active tab in the URL hash so tabs are deep-linkable and the

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
@@ -27,6 +27,7 @@ import {
 import Breadcrumbs from "../layout/Breadcrumbs";
 import { cn } from "@/lib/utils";
 import { extractApiError } from "@/lib/apiError";
+import { useHashTab } from "@/lib/useHashState";
 import { OverflowTabs } from "../shared/OverflowTabs";
 import { fetchWithAuth } from "../../stores/auth";
 import { useTranslation } from "react-i18next";
@@ -136,12 +137,6 @@ const VALID_TABS: Tab[] = [
   "assignments",
 ];
 
-function tabFromHash(): Tab {
-  if (typeof window === "undefined") return "overview";
-  const hash = window.location.hash.replace(/^#/, "");
-  return (VALID_TABS as string[]).includes(hash) ? (hash as Tab) : "overview";
-}
-
 type ConfigPolicyDetailPageProps = {
   policyId?: string;
 };
@@ -150,20 +145,21 @@ export default function ConfigPolicyDetailPage({
 }: ConfigPolicyDetailPageProps) {
   useTranslation("policies");
   const statusConfig = createStatusConfig();
-  const [activeTab, setActiveTab] = useState<Tab>(tabFromHash);
+  // The hash is not available during SSR, so the tab starts at the
+  // server-rendered default and adopts the hash post-mount (pre-paint) —
+  // reading it in the useState initializer caused a hydration mismatch on
+  // every deep link (#2421).
+  const [activeTab, setActiveTab] = useHashTab<Tab>(VALID_TABS, "overview");
 
   // Reflect the active tab in the URL hash so tabs are deep-linkable and the
   // contextual help button resolves to the right per-feature doc.
-  const selectTab = useCallback((id: Tab) => {
-    if (typeof window !== "undefined") window.location.hash = id;
-    setActiveTab(id);
-  }, []);
-
-  useEffect(() => {
-    const onHashChange = () => setActiveTab(tabFromHash());
-    window.addEventListener("hashchange", onHashChange);
-    return () => window.removeEventListener("hashchange", onHashChange);
-  }, []);
+  const selectTab = useCallback(
+    (id: Tab) => {
+      if (typeof window !== "undefined") window.location.hash = id;
+      setActiveTab(id);
+    },
+    [setActiveTab],
+  );
   const [policy, setPolicy] = useState<PolicyDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();

--- a/apps/web/src/components/software/SoftwarePage.tsx
+++ b/apps/web/src/components/software/SoftwarePage.tsx
@@ -22,8 +22,8 @@ export default function SoftwarePage({
   // The hash is not available during SSR, so the tab starts at the
   // server-rendered default and adopts the hash post-mount (pre-paint) —
   // reading it in the useState initializer caused a hydration mismatch on
-  // every deep link (#2421). The hook also syncs back/forward + external
-  // hash changes.
+  // deep links to a non-default tab (#2421). The hook also syncs back/forward
+  // + external hash changes.
   const [tab, setTab] = useHashTab<Tab>(VALID_TABS, defaultTab);
   const [prefill, setPrefill] = useState<Prefill | null>(null);
 

--- a/apps/web/src/components/software/SoftwarePage.tsx
+++ b/apps/web/src/components/software/SoftwarePage.tsx
@@ -1,18 +1,13 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Package, ShieldCheck } from "lucide-react";
 import SoftwareInventory from "./SoftwareInventory";
 import ComplianceDashboard from "./ComplianceDashboard";
 import { useTranslation } from "react-i18next";
 import { i18n } from "@/lib/i18n";
+import { useHashTab } from "@/lib/useHashState";
 type Tab = "inventory" | "policies";
 
 const VALID_TABS: Tab[] = ["inventory", "policies"];
-
-function getTabFromHash(fallback: Tab): Tab {
-  if (typeof window === "undefined") return fallback;
-  const hash = window.location.hash.replace(/^#/, "");
-  return VALID_TABS.includes(hash as Tab) ? (hash as Tab) : fallback;
-}
 type Prefill = {
   name: string;
   vendor?: string;
@@ -24,7 +19,12 @@ export default function SoftwarePage({
   defaultTab?: Tab;
 }) {
   useTranslation("policies");
-  const [tab, setTab] = useState<Tab>(() => getTabFromHash(defaultTab));
+  // The hash is not available during SSR, so the tab starts at the
+  // server-rendered default and adopts the hash post-mount (pre-paint) —
+  // reading it in the useState initializer caused a hydration mismatch on
+  // every deep link (#2421). The hook also syncs back/forward + external
+  // hash changes.
+  const [tab, setTab] = useHashTab<Tab>(VALID_TABS, defaultTab);
   const [prefill, setPrefill] = useState<Prefill | null>(null);
 
   // Reflect the tab in the URL hash so it's deep-linkable and the contextual
@@ -33,13 +33,6 @@ export default function SoftwarePage({
     if (typeof window !== "undefined") window.location.hash = next;
     setTab(next);
   };
-
-  // Sync with back/forward + external hash changes.
-  useEffect(() => {
-    const onHashChange = () => setTab(getTabFromHash(defaultTab));
-    window.addEventListener("hashchange", onHashChange);
-    return () => window.removeEventListener("hashchange", onHashChange);
-  }, [defaultTab]);
 
   const handleSwitchToPolicies = (data?: Prefill) => {
     setPrefill(data ?? null);

--- a/apps/web/src/lib/useHashState.test.ts
+++ b/apps/web/src/lib/useHashState.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { createElement } from "react";
+import { useHashState, useHashTab } from "./useHashState";
+
+const TABS = ["inventory", "policies"] as const;
+type Tab = (typeof TABS)[number];
+
+/**
+ * Probe that records the value of every render pass, so the tests can assert
+ * what the FIRST render produced (the hydration-relevant render) separately
+ * from the post-effect value. `render()` commits effects synchronously, so
+ * `screen` alone would only ever show the post-effect value.
+ */
+function makeProbe() {
+  const renders: string[] = [];
+  let setTab: (t: Tab) => void = () => {};
+  function Probe({ defaultTab = "inventory" as Tab }: { defaultTab?: Tab }) {
+    const [tab, set] = useHashTab<Tab>(TABS, defaultTab);
+    setTab = set;
+    renders.push(tab);
+    return createElement("div", { "data-testid": "tab" }, tab);
+  }
+  return { Probe, renders, selectTab: (t: Tab) => setTab(t) };
+}
+
+function setHash(hash: string) {
+  window.location.hash = hash;
+}
+
+function fireHashChange(hash: string) {
+  act(() => {
+    setHash(hash);
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+  });
+}
+
+describe("useHashTab", () => {
+  beforeEach(() => {
+    window.location.hash = "";
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("first render uses the SSR-safe default even when a valid hash is present", () => {
+    setHash("#policies");
+    const { Probe, renders } = makeProbe();
+    render(createElement(Probe));
+    // Render #1 must match what the server rendered (the default) — reading
+    // the hash there is exactly the hydration-mismatch bug (#2421).
+    expect(renders[0]).toBe("inventory");
+    // The layout effect then adopts the hash before paint.
+    expect(screen.getByTestId("tab").textContent).toBe("policies");
+  });
+
+  it("stays on the default when the hash is empty", () => {
+    const { Probe, renders } = makeProbe();
+    render(createElement(Probe));
+    expect(renders[0]).toBe("inventory");
+    expect(screen.getByTestId("tab").textContent).toBe("inventory");
+  });
+
+  it("falls back to the default when the hash is not a valid tab", () => {
+    setHash("#not-a-tab");
+    const { Probe } = makeProbe();
+    render(createElement(Probe));
+    expect(screen.getByTestId("tab").textContent).toBe("inventory");
+  });
+
+  it("respects a non-standard default tab", () => {
+    const { Probe } = makeProbe();
+    render(createElement(Probe, { defaultTab: "policies" as Tab }));
+    expect(screen.getByTestId("tab").textContent).toBe("policies");
+  });
+
+  it("follows hashchange events (back/forward, external changes)", () => {
+    const { Probe } = makeProbe();
+    render(createElement(Probe));
+    expect(screen.getByTestId("tab").textContent).toBe("inventory");
+
+    fireHashChange("#policies");
+    expect(screen.getByTestId("tab").textContent).toBe("policies");
+
+    // Navigating back to an empty/unknown hash returns to the default.
+    fireHashChange("#");
+    expect(screen.getByTestId("tab").textContent).toBe("inventory");
+  });
+
+  it("returns a working setter for direct tab selection", () => {
+    const { Probe, selectTab } = makeProbe();
+    render(createElement(Probe));
+    act(() => selectTab("policies"));
+    expect(screen.getByTestId("tab").textContent).toBe("policies");
+  });
+
+  it("removes the hashchange listener on unmount", () => {
+    const { Probe } = makeProbe();
+    const { unmount } = render(createElement(Probe));
+    unmount();
+    // Must not throw (setState on unmounted component would warn/leak).
+    expect(() => fireHashChange("#policies")).not.toThrow();
+  });
+});
+
+describe("useHashState", () => {
+  beforeEach(() => {
+    window.location.hash = "";
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses the custom parser and falls back to the default on undefined", () => {
+    setHash("#page-3");
+    const renders: number[] = [];
+    function Probe() {
+      const [page] = useHashState<number>(1, (hash) => {
+        const m = /^page-(\d+)$/.exec(hash);
+        return m ? Number(m[1]) : undefined;
+      });
+      renders.push(page);
+      return createElement("div", { "data-testid": "page" }, String(page));
+    }
+    render(createElement(Probe));
+    expect(renders[0]).toBe(1); // SSR-safe first render
+    expect(screen.getByTestId("page").textContent).toBe("3");
+
+    fireHashChange("#garbage");
+    expect(screen.getByTestId("page").textContent).toBe("1");
+  });
+});

--- a/apps/web/src/lib/useHashState.test.ts
+++ b/apps/web/src/lib/useHashState.test.ts
@@ -95,12 +95,35 @@ describe("useHashTab", () => {
     expect(screen.getByTestId("tab").textContent).toBe("policies");
   });
 
-  it("removes the hashchange listener on unmount", () => {
-    const { Probe } = makeProbe();
-    const { unmount } = render(createElement(Probe));
-    unmount();
-    // Must not throw (setState on unmounted component would warn/leak).
-    expect(() => fireHashChange("#policies")).not.toThrow();
+  it("honors updated validTabs/default on later hashchanges (latest-ref)", () => {
+    function Probe({
+      tabs,
+      def,
+    }: {
+      tabs: readonly string[];
+      def: string;
+    }) {
+      const [tab] = useHashTab(tabs, def);
+      return createElement("div", { "data-testid": "tab" }, tab);
+    }
+    const { rerender } = render(
+      createElement(Probe, { tabs: ["inventory"], def: "inventory" }),
+    );
+    // Widen the valid set after mount (e.g. tabs derived from feature flags).
+    rerender(
+      createElement(Probe, { tabs: ["inventory", "beta"], def: "inventory" }),
+    );
+    fireHashChange("#beta");
+    // A mount-once closure over the ORIGINAL tabs would fall back to the
+    // default here — the latest-ref must see the widened set.
+    expect(screen.getByTestId("tab").textContent).toBe("beta");
+
+    // The updated default must also be honored on a later invalid hash.
+    rerender(
+      createElement(Probe, { tabs: ["inventory", "beta"], def: "beta" }),
+    );
+    fireHashChange("#garbage");
+    expect(screen.getByTestId("tab").textContent).toBe("beta");
   });
 });
 
@@ -129,5 +152,24 @@ describe("useHashState", () => {
 
     fireHashChange("#garbage");
     expect(screen.getByTestId("page").textContent).toBe("1");
+  });
+
+  it("stops parsing hash changes after unmount (listener removed)", () => {
+    // setState on an unmounted component is a silent no-op in React 18+, so
+    // "doesn't throw" would be vacuous — count parser invocations instead.
+    let parseCalls = 0;
+    function Probe() {
+      const [v] = useHashState<string>("default", (hash) => {
+        parseCalls += 1;
+        return hash === "" ? undefined : hash;
+      });
+      return createElement("div", null, v);
+    }
+    const { unmount } = render(createElement(Probe));
+    const callsWhileMounted = parseCalls;
+    expect(callsWhileMounted).toBeGreaterThan(0); // mount adoption ran
+    unmount();
+    fireHashChange("#after-unmount");
+    expect(parseCalls).toBe(callsWhileMounted);
   });
 });

--- a/apps/web/src/lib/useHashState.ts
+++ b/apps/web/src/lib/useHashState.ts
@@ -4,8 +4,8 @@
  * The URL fragment is never sent to the server, so any state derived from
  * `window.location.hash` inside a `useState` initializer renders differently
  * on the server and on the first client render — React discards the SSR tree
- * with a hydration-mismatch error on every deep link (the #2383 regression
- * class, first fixed for IntegrationsPage in #2416).
+ * with a hydration-mismatch error on every deep link to a non-default tab
+ * (the #2383 regression class, first fixed for IntegrationsPage in #2416).
  *
  * These hooks encode the #2416 fix pattern:
  *   1. State starts from the SSR-safe default, so the first client render

--- a/apps/web/src/lib/useHashState.ts
+++ b/apps/web/src/lib/useHashState.ts
@@ -1,0 +1,84 @@
+/**
+ * SSR-safe URL-hash-derived state (#2421).
+ *
+ * The URL fragment is never sent to the server, so any state derived from
+ * `window.location.hash` inside a `useState` initializer renders differently
+ * on the server and on the first client render — React discards the SSR tree
+ * with a hydration-mismatch error on every deep link (the #2383 regression
+ * class, first fixed for IntegrationsPage in #2416).
+ *
+ * These hooks encode the #2416 fix pattern:
+ *   1. State starts from the SSR-safe default, so the first client render
+ *      matches the server-rendered HTML.
+ *   2. The hash is adopted in a layout effect — post-commit but pre-paint, so
+ *      deep links land on the right tab without a visible flash of the
+ *      default.
+ *   3. The same handler subscribes to `hashchange` for back/forward and
+ *      externally-changed hashes.
+ *
+ * Writing the hash on tab change stays with the caller (CLAUDE.md mandates
+ * `window.location.hash = id` for tab state) — only the READ moves post-mount.
+ */
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+
+// useLayoutEffect warns during SSR (it is a no-op there); useEffect is the
+// server-safe stand-in. On the client we want the layout variant so the hash
+// is adopted before paint.
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+/**
+ * Hash-derived state with a custom parser.
+ *
+ * @param defaultValue SSR-safe default — what the server rendered.
+ * @param parse Maps the raw hash (leading `#` stripped) to a value, or
+ *   `undefined` when the hash doesn't apply (empty/unrecognized), in which
+ *   case the state falls back to `defaultValue`.
+ * @returns `[value, setValue]` — `setValue` is a plain state setter; callers
+ *   keep writing `window.location.hash` themselves on user-driven changes.
+ */
+export function useHashState<T>(
+  defaultValue: T,
+  parse: (hash: string) => T | undefined,
+): [T, Dispatch<SetStateAction<T>>] {
+  const [value, setValue] = useState<T>(defaultValue);
+
+  // Latest-ref so the mount-once effect always sees the current parser and
+  // default without re-subscribing to hashchange on every render (both are
+  // typically inline/derived-from-props at call sites).
+  const latest = useRef({ defaultValue, parse });
+  latest.current = { defaultValue, parse };
+
+  useIsomorphicLayoutEffect(() => {
+    const applyHash = () => {
+      const raw = window.location.hash.replace(/^#/, "");
+      const parsed = latest.current.parse(raw);
+      setValue(parsed === undefined ? latest.current.defaultValue : parsed);
+    };
+    applyHash();
+    window.addEventListener("hashchange", applyHash);
+    return () => window.removeEventListener("hashchange", applyHash);
+  }, []);
+
+  return [value, setValue];
+}
+
+/**
+ * Hash-selected tab: the common case where the hash must be one of a fixed
+ * set of tab ids, anything else falling back to the default tab.
+ */
+export function useHashTab<T extends string>(
+  validTabs: readonly T[],
+  defaultTab: T,
+): [T, Dispatch<SetStateAction<T>>] {
+  return useHashState<T>(defaultTab, (hash) =>
+    (validTabs as readonly string[]).includes(hash) ? (hash as T) : undefined,
+  );
+}


### PR DESCRIPTION
## Summary

**Phase 1 of 2** for the hash-read-in-`useState` hydration-mismatch class (Refs #2421 — issue stays open for the Phase 2 sweep).

Reading `window.location.hash` inside a `useState` initializer of a `client:load` island renders differently on the server (the fragment is never sent) and on the first client render, so React discards the SSR tree with a hydration-mismatch console error and a visible tab flash on every deep link. #2416 fixed this on `IntegrationsPage`; #2383 reintroduced the pattern on two pages.

## Changes

- **New shared hooks** `useHashState` / `useHashTab` (`apps/web/src/lib/useHashState.ts`) encoding exactly the #2416 fix pattern:
  1. State starts from the SSR-safe default, so the first client render matches the server HTML.
  2. The hash is adopted in an isomorphic **layout** effect — post-commit, pre-paint, so deep links land on the right tab with no flash of the default.
  3. The same handler subscribes to `hashchange` for back/forward and external hash changes.
- **Applied to the two live #2383 regressions:**
  - `apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx` (`tabFromHash` as `useState` initializer)
  - `apps/web/src/components/software/SoftwarePage.tsx` (same pattern)

Behavior preserved: hash **writes** on tab change are untouched — callers still set `window.location.hash` per the CLAUDE.md convention. Only the read timing moves post-mount. Deep links (e.g. `/configuration-policies/<id>#backup`) still land on the right tab; invalid/empty hashes still fall back to the default; back/forward still tracks.

**Not in this PR:** the ~20 latent pages listed on #2421 (DevicesPage, OrganizationsPage, DeviceDetails, …) — that mechanical sweep is Phase 2, tracked on the same issue.

## Verification

- New jsdom suite `apps/web/src/lib/useHashState.test.ts` (8 tests): asserts the **first render** uses the default even with a valid hash present (the hydration-relevant render, captured via a render-recording probe), the layout effect then adopts the hash, invalid/empty hash falls back, `hashchange` is followed and unsubscribed on unmount, and the custom-parser variant works.
- `vitest run src/components/configurationPolicies/ConfigPolicyDetailPage.test.tsx` — 9 passed.
- `vitest run src/components/software` — 11 files / 52 tests passed.
- `tsc --noEmit` (apps/web) — clean.

Refs #2421

🤖 Generated with [Claude Code](https://claude.com/claude-code)