### PR TITLE
fix(backup): apply file-mode exclusion patterns end-to-end (#2418)

### DIFF
--- a/agent/cmd/breeze-backup/exec_backup.go
+++ b/agent/cmd/breeze-backup/exec_backup.go
@@ -66,6 +66,24 @@ func applyCommandStorageEncryption(provider providers.BackupProvider, payload js
 	return nil
 }
 
+// parseBackupRunExcludes extracts file-exclusion glob patterns from a
+// backup_run command payload (#2418). Returns nil when the payload omits the
+// field so locally-configured excludes still apply; a server that sends an
+// explicit empty list disables exclusions for the run. Unknown payload fields
+// are ignored (encoding/json), so older servers and newer agents interoperate.
+func parseBackupRunExcludes(payload json.RawMessage) ([]string, error) {
+	if len(payload) == 0 {
+		return nil, nil
+	}
+	var p struct {
+		Excludes []string `json:"excludes"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return nil, fmt.Errorf("invalid backup payload: %w", err)
+	}
+	return p.Excludes, nil
+}
+
 func resolveRestoreProvider(mgr *backup.BackupManager, vaultState *vaultManagerRef) providers.BackupProvider {
 	if mgr == nil {
 		return nil

--- a/agent/cmd/breeze-backup/exec_backup_test.go
+++ b/agent/cmd/breeze-backup/exec_backup_test.go
@@ -249,3 +249,64 @@ func TestExecBMRRecoverUsesTokenDrivenRunner(t *testing.T) {
 		t.Fatalf("runner cfg = %+v", cfg)
 	}
 }
+
+func TestParseBackupRunExcludes(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    []string // nil = fall back to config excludes
+		wantErr bool
+	}{
+		{
+			name:    "empty payload returns nil (config fallback)",
+			payload: "",
+			want:    nil,
+		},
+		{
+			name:    "missing excludes field returns nil (old-server compat)",
+			payload: `{"paths":["/data"],"jobId":"j1"}`,
+			want:    nil,
+		},
+		{
+			name:    "explicit empty list disables exclusions (non-nil empty)",
+			payload: `{"paths":["/data"],"excludes":[]}`,
+			want:    []string{},
+		},
+		{
+			name:    "populated excludes decoded alongside other payload fields",
+			payload: `{"jobId":"j1","paths":["C:\\Users"],"excludes":["*.tmp","node_modules/**"],"storageEncryption":{"required":false,"mode":"disabled"}}`,
+			want:    []string{"*.tmp", "node_modules/**"},
+		},
+		{
+			name:    "malformed payload returns error",
+			payload: `{"excludes":`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBackupRunExcludes(json.RawMessage(tt.payload))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if (got == nil) != (tt.want == nil) {
+				t.Fatalf("nil-ness mismatch: got %#v, want %#v (nil vs empty is the compat contract)", got, tt.want)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("excludes[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/agent/cmd/breeze-backup/main.go
+++ b/agent/cmd/breeze-backup/main.go
@@ -447,7 +447,11 @@ func executeCommand(req backupipc.BackupCommandRequest, mgr *backup.BackupManage
 		if err := applyCommandStorageEncryption(mgr.GetProvider(), req.Payload); err != nil {
 			return fail(err.Error())
 		}
-		result := marshalResult(mgr.RunBackup())
+		excludes, err := parseBackupRunExcludes(req.Payload)
+		if err != nil {
+			return fail(err.Error())
+		}
+		result := marshalResult(mgr.RunBackupWithExcludes(excludes))
 		// Auto-sync to vault after successful backup (async — don't block command response)
 		if result.Success {
 			go autoSyncToVault(result.Stdout, vaultState, conn)

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -33,6 +33,7 @@ var errBackupStopped = errors.New("backup stopped")
 type BackupConfig struct {
 	Provider           providers.BackupProvider
 	Paths              []string
+	Excludes           []string // Glob exclusion patterns for file-mode backups (see excludeMatcher)
 	Schedule           time.Duration
 	Retention          int
 	VSSEnabled         bool   // Windows only: create VSS shadow copy before backup
@@ -158,8 +159,21 @@ func (m *BackupManager) Stop() bool {
 	return true
 }
 
-// RunBackup triggers an immediate backup run.
+// RunBackup triggers an immediate backup run using the configured exclusion
+// patterns.
 func (m *BackupManager) RunBackup() (*BackupJob, error) {
+	return m.RunBackupWithExcludes(nil)
+}
+
+// RunBackupWithExcludes triggers an immediate backup run. A non-nil excludes
+// slice overrides the configured exclusion patterns for this run only (an
+// empty non-nil slice disables exclusions); nil falls back to the config
+// excludes. Server-dispatched backup_run commands pass their policy excludes
+// here (#2418).
+func (m *BackupManager) RunBackupWithExcludes(excludes []string) (*BackupJob, error) {
+	if excludes == nil {
+		excludes = m.config.Excludes
+	}
 	if m.config.Provider == nil {
 		return nil, errors.New("backup provider is required")
 	}
@@ -266,7 +280,7 @@ func (m *BackupManager) RunBackup() (*BackupJob, error) {
 		return stopBackupRun()
 	}
 	cutoff := m.lastSnapshotTime
-	files, scanErr := m.collectBackupFilesFromPaths(ctx, backupPaths, cutoff)
+	files, scanErr := m.collectBackupFilesFromPaths(ctx, backupPaths, cutoff, newExcludeMatcher(excludes))
 	if scanErr != nil {
 		if errors.Is(scanErr, errBackupStopped) {
 			return stopBackupRun()
@@ -355,10 +369,10 @@ type backupFile struct {
 }
 
 func (m *BackupManager) collectBackupFiles(cutoff time.Time) ([]backupFile, error) {
-	return m.collectBackupFilesFromPaths(context.Background(), m.config.Paths, cutoff)
+	return m.collectBackupFilesFromPaths(context.Background(), m.config.Paths, cutoff, newExcludeMatcher(m.config.Excludes))
 }
 
-func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths []string, cutoff time.Time) ([]backupFile, error) {
+func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths []string, cutoff time.Time, excl *excludeMatcher) ([]backupFile, error) {
 	var files []backupFile
 	var errs []error
 	seen := make(map[string]struct{})
@@ -384,6 +398,9 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				continue
 			}
 			relPath := filepath.Base(cleanRoot)
+			if excl.matches(relPath) {
+				continue
+			}
 			snapshotPath := filepath.ToSlash(filepath.Join(rootLabel, relPath))
 			if _, exists := seen[snapshotPath]; exists {
 				log.Printf("[backup] duplicate backup path skipped: %s", snapshotPath)
@@ -408,6 +425,14 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				return nil
 			}
 			if entry.IsDir() {
+				// An excluded directory is skipped entirely (fs.SkipDir), not
+				// just its immediate files (#2418).
+				if excl != nil && path != cleanRoot {
+					relPath, relErr := filepath.Rel(cleanRoot, path)
+					if relErr == nil && excl.matches(filepath.ToSlash(relPath)) {
+						return fs.SkipDir
+					}
+				}
 				return nil
 			}
 			if entry.Type()&os.ModeSymlink != 0 {
@@ -424,6 +449,9 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 			relPath, err := filepath.Rel(cleanRoot, path)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to resolve relative path for %s: %w", path, err))
+				return nil
+			}
+			if excl.matches(filepath.ToSlash(relPath)) {
 				return nil
 			}
 			snapshotPath := filepath.ToSlash(filepath.Join(rootLabel, relPath))

--- a/agent/internal/backup/exclude.go
+++ b/agent/internal/backup/exclude.go
@@ -50,16 +50,24 @@ func newExcludeMatcherForOS(patterns []string, caseInsensitive bool) *excludeMat
 			p = strings.ToLower(p)
 		}
 		// Validate glob syntax up front so a bad pattern is reported once per
-		// run instead of erroring on every visited file.
-		if _, err := path.Match(strings.ReplaceAll(p, "**", "*"), "probe"); err != nil {
-			log.Printf("[backup] ignoring invalid exclusion pattern %q: %v", raw, err)
-			continue
-		}
+		// run instead of silently never matching. Validation must mirror the
+		// runtime exactly: slash patterns are matched per segment, so they
+		// are validated per segment too (e.g. "a[x/y]b" is a valid glob as a
+		// full string but splits into malformed segments).
 		if strings.Contains(p, "/") {
+			segs := strings.Split(p, "/")
+			if !validGlobSegments(segs) {
+				log.Printf("[backup] ignoring invalid exclusion pattern %q", raw)
+				continue
+			}
 			// Implicit leading "**/" so patterns match at any depth
 			// (consecutive "**" segments are collapsed by matchSegments).
-			m.relPath = append(m.relPath, append([]string{"**"}, strings.Split(p, "/")...))
+			m.relPath = append(m.relPath, append([]string{"**"}, segs...))
 		} else {
+			if _, err := path.Match(p, "probe"); err != nil {
+				log.Printf("[backup] ignoring invalid exclusion pattern %q: %v", raw, err)
+				continue
+			}
 			m.baseName = append(m.baseName, p)
 		}
 	}
@@ -100,9 +108,31 @@ func (m *excludeMatcher) matches(relPath string) bool {
 	return false
 }
 
+// validGlobSegments reports whether every non-doublestar segment is a valid
+// single-segment glob. path.Match's ErrBadPattern is independent of the name
+// being matched (Go 1.16+), so probing with a fixed name is exhaustive.
+// Empty segments (from "a//b") are rejected: they could never match a real
+// path segment and indicate a malformed pattern.
+func validGlobSegments(segs []string) bool {
+	for _, s := range segs {
+		if s == "**" {
+			continue
+		}
+		if s == "" {
+			return false
+		}
+		if _, err := path.Match(s, "probe"); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
 // matchSegments matches glob pattern segments against path segments, where a
 // "**" pattern segment spans zero or more path segments. Non-doublestar
-// segments use path.Match single-segment glob semantics.
+// segments use path.Match single-segment glob semantics (errors from a
+// malformed segment are treated as non-match; construction-time validation
+// makes that branch defensively unreachable).
 func matchSegments(pattern, segs []string) bool {
 	for len(pattern) > 0 {
 		if pattern[0] == "**" {

--- a/agent/internal/backup/exclude.go
+++ b/agent/internal/backup/exclude.go
@@ -1,0 +1,133 @@
+package backup
+
+import (
+	"log"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// excludeMatcher applies user-configured exclusion patterns to paths visited
+// during a file-mode backup walk. Patterns come from the config-policy Backup
+// tab (see apps/web/.../backupTabPresets.ts) and use forward-slash glob
+// syntax with doublestar support:
+//
+//   - "*.tmp", "Thumbs.db"                — no slash: matched against the base
+//     name of every file AND directory visited.
+//   - "node_modules/**", "$RECYCLE.BIN/**" — slash: matched against the
+//     root-relative path, where "**" spans zero or more path segments.
+//     Patterns match at any depth (gitignore-style implicit leading "**/"),
+//     so "node_modules/**" excludes every node_modules directory, not just
+//     one at the backup root. A pattern that matches a directory excludes
+//     the whole subtree (the walker returns fs.SkipDir).
+//
+// Matching is case-insensitive on Windows (case-insensitive filesystems) and
+// case-sensitive elsewhere. Invalid glob patterns are logged and skipped
+// rather than failing the backup.
+type excludeMatcher struct {
+	baseName        []string   // patterns without "/" — base-name globs
+	relPath         [][]string // patterns with "/" — pre-split path segments
+	caseInsensitive bool
+}
+
+// newExcludeMatcher compiles exclusion patterns. Returns nil when no usable
+// patterns remain (callers treat a nil matcher as "exclude nothing").
+func newExcludeMatcher(patterns []string) *excludeMatcher {
+	return newExcludeMatcherForOS(patterns, runtime.GOOS == "windows")
+}
+
+func newExcludeMatcherForOS(patterns []string, caseInsensitive bool) *excludeMatcher {
+	m := &excludeMatcher{caseInsensitive: caseInsensitive}
+	for _, raw := range patterns {
+		// Normalize Windows-style separators so "AppData\Local" works; after
+		// this, backslash escape sequences no longer exist in patterns.
+		p := strings.ReplaceAll(strings.TrimSpace(raw), "\\", "/")
+		p = strings.Trim(p, "/")
+		if p == "" {
+			continue
+		}
+		if caseInsensitive {
+			p = strings.ToLower(p)
+		}
+		// Validate glob syntax up front so a bad pattern is reported once per
+		// run instead of erroring on every visited file.
+		if _, err := path.Match(strings.ReplaceAll(p, "**", "*"), "probe"); err != nil {
+			log.Printf("[backup] ignoring invalid exclusion pattern %q: %v", raw, err)
+			continue
+		}
+		if strings.Contains(p, "/") {
+			// Implicit leading "**/" so patterns match at any depth
+			// (consecutive "**" segments are collapsed by matchSegments).
+			m.relPath = append(m.relPath, append([]string{"**"}, strings.Split(p, "/")...))
+		} else {
+			m.baseName = append(m.baseName, p)
+		}
+	}
+	if len(m.baseName) == 0 && len(m.relPath) == 0 {
+		return nil
+	}
+	return m
+}
+
+// matches reports whether the entry at relPath (root-relative, slash-separated)
+// is excluded. Works for files and directories alike; the walker decides
+// whether a hit means "skip file" or "skip subtree".
+func (m *excludeMatcher) matches(relPath string) bool {
+	if m == nil || relPath == "" || relPath == "." {
+		return false
+	}
+	rel := strings.ReplaceAll(relPath, "\\", "/")
+	if m.caseInsensitive {
+		rel = strings.ToLower(rel)
+	}
+
+	base := path.Base(rel)
+	for _, p := range m.baseName {
+		if ok, _ := path.Match(p, base); ok {
+			return true
+		}
+	}
+
+	if len(m.relPath) == 0 {
+		return false
+	}
+	segs := strings.Split(rel, "/")
+	for _, patSegs := range m.relPath {
+		if matchSegments(patSegs, segs) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchSegments matches glob pattern segments against path segments, where a
+// "**" pattern segment spans zero or more path segments. Non-doublestar
+// segments use path.Match single-segment glob semantics.
+func matchSegments(pattern, segs []string) bool {
+	for len(pattern) > 0 {
+		if pattern[0] == "**" {
+			// Collapse consecutive "**" and try every possible span.
+			for len(pattern) > 0 && pattern[0] == "**" {
+				pattern = pattern[1:]
+			}
+			if len(pattern) == 0 {
+				return true // trailing ** matches everything (including nothing)
+			}
+			for i := 0; i <= len(segs); i++ {
+				if matchSegments(pattern, segs[i:]) {
+					return true
+				}
+			}
+			return false
+		}
+		if len(segs) == 0 {
+			return false
+		}
+		if ok, err := path.Match(pattern[0], segs[0]); err != nil || !ok {
+			return false
+		}
+		pattern = pattern[1:]
+		segs = segs[1:]
+	}
+	return len(segs) == 0
+}

--- a/agent/internal/backup/exclude_test.go
+++ b/agent/internal/backup/exclude_test.go
@@ -44,6 +44,9 @@ func TestExcludeMatcher(t *testing.T) {
 		{name: "no patterns passes everything through", patterns: nil, relPath: "anything.tmp", want: false},
 		{name: "invalid pattern is dropped not fatal", patterns: []string{"[unclosed"}, relPath: "file.txt", want: false},
 		{name: "invalid pattern does not disable valid ones", patterns: []string{"[unclosed", "*.tmp"}, relPath: "file.tmp", want: true},
+		{name: "bracket class containing slash is dropped at compile", patterns: []string{"a[x/y]b"}, relPath: "a[x/y]b/file.txt", want: false},
+		{name: "bracket-slash pattern does not disable valid ones", patterns: []string{"a[x/y]b", "*.tmp"}, relPath: "file.tmp", want: true},
+		{name: "empty interior segment is invalid", patterns: []string{"a//b"}, relPath: "a/b", want: false},
 		{name: "empty and whitespace patterns ignored", patterns: []string{"", "  "}, relPath: "file.txt", want: false},
 	}
 
@@ -67,6 +70,9 @@ func TestExcludeMatcher_NilSafe(t *testing.T) {
 	}
 	if newExcludeMatcherForOS([]string{"", "[bad"}, false) != nil {
 		t.Error("only-unusable patterns should compile to a nil matcher")
+	}
+	if newExcludeMatcherForOS([]string{"a[x/y]b", "a//b"}, false) != nil {
+		t.Error("per-segment-invalid slash patterns should compile to a nil matcher")
 	}
 }
 
@@ -178,6 +184,33 @@ func TestCollectBackupFiles_Excludes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// A base-name glob matches directories too: a dir whose NAME matches the
+// pattern is pruned as a whole subtree, even though the files inside it would
+// not match the glob themselves. Pins the documented "files AND directories"
+// base-name semantics end-to-end so a future file-only "fix" fails loudly.
+func TestCollectBackupFiles_BaseNameGlobExcludesDirectorySubtree(t *testing.T) {
+	root := t.TempDir()
+	tmpDir := pathpkg.Join(root, "cache.tmp")
+	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", tmpDir, err)
+	}
+	createTempFile(t, root, "keep.txt", "keep")
+	createTempFile(t, tmpDir, "data.txt", "inside excluded dir")
+
+	mgr := NewBackupManager(BackupConfig{
+		Paths:    []string{root},
+		Excludes: []string{"*.tmp"},
+	})
+
+	files, err := mgr.collectBackupFiles(time.Time{})
+	if err != nil {
+		t.Fatalf("collectBackupFiles failed: %v", err)
+	}
+	if len(files) != 1 || files[0].snapshotPath != "path_0/keep.txt" {
+		t.Fatalf("expected only path_0/keep.txt (cache.tmp/ subtree pruned), got %+v", files)
 	}
 }
 

--- a/agent/internal/backup/exclude_test.go
+++ b/agent/internal/backup/exclude_test.go
@@ -1,0 +1,224 @@
+package backup
+
+import (
+	"os"
+	pathpkg "path/filepath"
+	"testing"
+	"time"
+)
+
+func TestExcludeMatcher(t *testing.T) {
+	tests := []struct {
+		name            string
+		patterns        []string
+		relPath         string
+		caseInsensitive bool
+		want            bool
+	}{
+		// Base-name globs (no slash)
+		{name: "tmp glob matches file", patterns: []string{"*.tmp"}, relPath: "docs/report.tmp", want: true},
+		{name: "tmp glob spares other files", patterns: []string{"*.tmp"}, relPath: "docs/report.txt", want: false},
+		{name: "bare name matches directory base", patterns: []string{"node_modules"}, relPath: "app/node_modules", want: true},
+		{name: "exact file name at root", patterns: []string{"Thumbs.db"}, relPath: "Thumbs.db", want: true},
+		{name: "exact file name nested", patterns: []string{".DS_Store"}, relPath: "a/b/.DS_Store", want: true},
+		{name: "base-name glob does not match path segments mid-path", patterns: []string{"*.tmp"}, relPath: "cache.tmp/data.txt", want: false},
+
+		// Path-relative doublestar globs
+		{name: "dir doublestar matches dir itself", patterns: []string{"node_modules/**"}, relPath: "node_modules", want: true},
+		{name: "dir doublestar matches nested dir", patterns: []string{"node_modules/**"}, relPath: "app/node_modules", want: true},
+		{name: "dir doublestar matches contents", patterns: []string{"node_modules/**"}, relPath: "app/node_modules/react/index.js", want: true},
+		{name: "leading doublestar nested glob matches deep", patterns: []string{"**/AppData/Local/Temp/**"}, relPath: "alice/AppData/Local/Temp/x.dat", want: true},
+		{name: "leading doublestar matches the dir itself", patterns: []string{"**/AppData/Local/Temp/**"}, relPath: "alice/AppData/Local/Temp", want: true},
+		{name: "nested glob requires all middle segments", patterns: []string{"**/AppData/Local/Temp/**"}, relPath: "alice/AppData/Local", want: false},
+		{name: "dollar sign is literal", patterns: []string{"$RECYCLE.BIN/**"}, relPath: "$RECYCLE.BIN/S-1-5/file", want: true},
+		{name: "star in path pattern", patterns: []string{"**/OneDrive*/**"}, relPath: "bob/OneDrive - Contoso/doc.docx", want: true},
+		{name: "path pattern spares unrelated path", patterns: []string{"node_modules/**"}, relPath: "src/index.ts", want: false},
+
+		// Normalization
+		{name: "backslash pattern normalized", patterns: []string{"AppData\\Local\\Temp/**"}, relPath: "AppData/Local/Temp/x", want: true},
+		{name: "backslash relPath normalized", patterns: []string{"node_modules/**"}, relPath: "app\\node_modules\\x.js", want: true},
+		{name: "case-insensitive on windows", patterns: []string{"thumbs.db"}, relPath: "pics/Thumbs.DB", caseInsensitive: true, want: true},
+		{name: "case-sensitive elsewhere", patterns: []string{"thumbs.db"}, relPath: "pics/Thumbs.DB", want: false},
+
+		// No excludes / invalid patterns
+		{name: "no patterns passes everything through", patterns: nil, relPath: "anything.tmp", want: false},
+		{name: "invalid pattern is dropped not fatal", patterns: []string{"[unclosed"}, relPath: "file.txt", want: false},
+		{name: "invalid pattern does not disable valid ones", patterns: []string{"[unclosed", "*.tmp"}, relPath: "file.tmp", want: true},
+		{name: "empty and whitespace patterns ignored", patterns: []string{"", "  "}, relPath: "file.txt", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newExcludeMatcherForOS(tt.patterns, tt.caseInsensitive)
+			if got := m.matches(tt.relPath); got != tt.want {
+				t.Errorf("matches(%q) with patterns %v = %v, want %v", tt.relPath, tt.patterns, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExcludeMatcher_NilSafe(t *testing.T) {
+	var m *excludeMatcher
+	if m.matches("anything") {
+		t.Error("nil matcher must match nothing")
+	}
+	if newExcludeMatcherForOS(nil, false) != nil {
+		t.Error("no patterns should compile to a nil matcher")
+	}
+	if newExcludeMatcherForOS([]string{"", "[bad"}, false) != nil {
+		t.Error("only-unusable patterns should compile to a nil matcher")
+	}
+}
+
+// TestCollectBackupFiles_Excludes drives the real walker over a temp tree and
+// checks glob exclusions end-to-end (#2418).
+func TestCollectBackupFiles_Excludes(t *testing.T) {
+	newTree := func(t *testing.T) string {
+		t.Helper()
+		root := t.TempDir()
+		mkdir := func(parts ...string) string {
+			p := pathpkg.Join(append([]string{root}, parts...)...)
+			if err := os.MkdirAll(p, 0755); err != nil {
+				t.Fatalf("mkdir %s: %v", p, err)
+			}
+			return p
+		}
+		mkdir("src")
+		mkdir("src", "node_modules", "react")
+		mkdir("cache")
+		createTempFile(t, root, "keep.txt", "keep")
+		createTempFile(t, root, "junk.tmp", "junk")
+		createTempFile(t, pathpkg.Join(root, "src"), "app.ts", "code")
+		createTempFile(t, pathpkg.Join(root, "src", "node_modules"), "pkg.json", "{}")
+		createTempFile(t, pathpkg.Join(root, "src", "node_modules", "react"), "index.js", "js")
+		createTempFile(t, pathpkg.Join(root, "cache"), "blob.bin", "bin")
+		return root
+	}
+
+	tests := []struct {
+		name     string
+		excludes []string
+		want     []string // expected snapshot paths (path_0-relative, sorted)
+	}{
+		{
+			name:     "no excludes passthrough",
+			excludes: nil,
+			want: []string{
+				"path_0/cache/blob.bin",
+				"path_0/junk.tmp",
+				"path_0/keep.txt",
+				"path_0/src/app.ts",
+				"path_0/src/node_modules/pkg.json",
+				"path_0/src/node_modules/react/index.js",
+			},
+		},
+		{
+			name:     "tmp glob excludes matching files only",
+			excludes: []string{"*.tmp"},
+			want: []string{
+				"path_0/cache/blob.bin",
+				"path_0/keep.txt",
+				"path_0/src/app.ts",
+				"path_0/src/node_modules/pkg.json",
+				"path_0/src/node_modules/react/index.js",
+			},
+		},
+		{
+			name:     "directory name exclusion skips whole subtree",
+			excludes: []string{"node_modules"},
+			want: []string{
+				"path_0/cache/blob.bin",
+				"path_0/junk.tmp",
+				"path_0/keep.txt",
+				"path_0/src/app.ts",
+			},
+		},
+		{
+			name:     "nested doublestar glob skips subtree at any depth",
+			excludes: []string{"**/node_modules/**"},
+			want: []string{
+				"path_0/cache/blob.bin",
+				"path_0/junk.tmp",
+				"path_0/keep.txt",
+				"path_0/src/app.ts",
+			},
+		},
+		{
+			name:     "combined patterns",
+			excludes: []string{"*.tmp", "node_modules/**", "cache/**"},
+			want: []string{
+				"path_0/keep.txt",
+				"path_0/src/app.ts",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := newTree(t)
+			mgr := NewBackupManager(BackupConfig{
+				Paths:    []string{root},
+				Excludes: tt.excludes,
+			})
+
+			files, err := mgr.collectBackupFiles(time.Time{})
+			if err != nil {
+				t.Fatalf("collectBackupFiles failed: %v", err)
+			}
+			var got []string
+			for _, f := range files {
+				got = append(got, f.snapshotPath)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d files %v, want %d files %v", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("file[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// Per-run excludes passed by the backup_run command override config excludes.
+func TestCollectBackupFilesFromPaths_PerRunExcludesOverrideConfig(t *testing.T) {
+	root := t.TempDir()
+	createTempFile(t, root, "a.tmp", "a")
+	createTempFile(t, root, "b.log", "b")
+
+	mgr := NewBackupManager(BackupConfig{
+		Paths:    []string{root},
+		Excludes: []string{"*.log"}, // config says exclude logs
+	})
+
+	// Per-run override: exclude *.tmp instead (as backup_run payload would).
+	files, err := mgr.collectBackupFilesFromPaths(
+		t.Context(), []string{root}, time.Time{}, newExcludeMatcher([]string{"*.tmp"}),
+	)
+	if err != nil {
+		t.Fatalf("collectBackupFilesFromPaths failed: %v", err)
+	}
+	if len(files) != 1 || files[0].snapshotPath != "path_0/b.log" {
+		t.Fatalf("expected only path_0/b.log, got %+v", files)
+	}
+}
+
+// A single-file backup root is also subject to base-name exclusion.
+func TestCollectBackupFiles_SingleFileRootExcluded(t *testing.T) {
+	root := t.TempDir()
+	file := createTempFile(t, root, "solo.tmp", "solo")
+
+	mgr := NewBackupManager(BackupConfig{
+		Paths:    []string{file},
+		Excludes: []string{"*.tmp"},
+	})
+
+	files, err := mgr.collectBackupFiles(time.Time{})
+	if err != nil {
+		t.Fatalf("collectBackupFiles failed: %v", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected excluded single-file root to yield 0 files, got %+v", files)
+	}
+}

--- a/apps/api/src/jobs/backupWorker.test.ts
+++ b/apps/api/src/jobs/backupWorker.test.ts
@@ -36,7 +36,30 @@ describe('resolveBackupTargets', () => {
       'device-id'
     );
     expect(result).toEqual([
-      { commandType: 'backup_run', payload: { paths: ['/data', '/etc'] } },
+      {
+        commandType: 'backup_run',
+        payload: { paths: ['/data', '/etc'], excludes: [] },
+      },
+    ]);
+  });
+
+  it('forwards exclusion patterns for file mode (#2418)', async () => {
+    const result = await resolveBackupTargets(
+      'file',
+      {
+        paths: ['C:\\Users'],
+        excludes: ['*.tmp', 'node_modules/**', '**/AppData/Local/Temp/**'],
+      },
+      'device-id'
+    );
+    expect(result).toEqual([
+      {
+        commandType: 'backup_run',
+        payload: {
+          paths: ['C:\\Users'],
+          excludes: ['*.tmp', 'node_modules/**', '**/AppData/Local/Temp/**'],
+        },
+      },
     ]);
   });
 
@@ -250,10 +273,10 @@ describe('resolveBackupTargets', () => {
     expect(result).toEqual([]);
   });
 
-  it('returns empty paths array for file mode when paths not provided', async () => {
+  it('returns empty paths/excludes arrays for file mode when not provided', async () => {
     const result = await resolveBackupTargets('file', {}, 'device-id');
     expect(result).toEqual([
-      { commandType: 'backup_run', payload: { paths: [] } },
+      { commandType: 'backup_run', payload: { paths: [], excludes: [] } },
     ]);
   });
 });

--- a/apps/api/src/jobs/backupWorker.test.ts
+++ b/apps/api/src/jobs/backupWorker.test.ts
@@ -29,7 +29,9 @@ describe('resolveBackupTargets', () => {
     mockDb.limit.mockResolvedValue([]);
   });
 
-  it('returns file targets unchanged', async () => {
+  it('returns file targets unchanged, omitting excludes when not configured', async () => {
+    // No excludes key at all — the agent treats a missing field as "fall back
+    // to locally-configured excludes", so the worker must not invent one.
     const result = await resolveBackupTargets(
       'file',
       { paths: ['/data', '/etc'] },
@@ -38,8 +40,21 @@ describe('resolveBackupTargets', () => {
     expect(result).toEqual([
       {
         commandType: 'backup_run',
-        payload: { paths: ['/data', '/etc'], excludes: [] },
+        payload: { paths: ['/data', '/etc'] },
       },
+    ]);
+    expect(result[0]!.payload).not.toHaveProperty('excludes');
+  });
+
+  it('forwards an explicit empty excludes list for file mode', async () => {
+    // Explicit [] means "no exclusions for this run" on the agent side.
+    const result = await resolveBackupTargets(
+      'file',
+      { paths: ['/data'], excludes: [] },
+      'device-id'
+    );
+    expect(result).toEqual([
+      { commandType: 'backup_run', payload: { paths: ['/data'], excludes: [] } },
     ]);
   });
 
@@ -273,10 +288,10 @@ describe('resolveBackupTargets', () => {
     expect(result).toEqual([]);
   });
 
-  it('returns empty paths/excludes arrays for file mode when not provided', async () => {
+  it('returns empty paths and no excludes field for file mode when not provided', async () => {
     const result = await resolveBackupTargets('file', {}, 'device-id');
     expect(result).toEqual([
-      { commandType: 'backup_run', payload: { paths: [], excludes: [] } },
+      { commandType: 'backup_run', payload: { paths: [] } },
     ]);
   });
 });

--- a/apps/api/src/jobs/backupWorker.ts
+++ b/apps/api/src/jobs/backupWorker.ts
@@ -271,12 +271,14 @@ export async function resolveBackupTargets(
   switch (backupMode) {
     case 'file': {
       const t = targets as { paths?: string[]; excludes?: string[] };
-      return [
-        {
-          commandType: 'backup_run',
-          payload: { paths: t.paths ?? [], excludes: t.excludes ?? [] },
-        },
-      ];
+      // Preserve the omitted-vs-empty distinction the agent relies on: a
+      // missing excludes field means "fall back to locally-configured
+      // excludes", an explicit [] means "no exclusions for this run".
+      const payload: Record<string, unknown> = { paths: t.paths ?? [] };
+      if (t.excludes !== undefined) {
+        payload.excludes = t.excludes;
+      }
+      return [{ commandType: 'backup_run', payload }];
     }
 
     case 'system_image':

--- a/apps/api/src/jobs/backupWorker.ts
+++ b/apps/api/src/jobs/backupWorker.ts
@@ -270,8 +270,13 @@ export async function resolveBackupTargets(
 ): Promise<BackupTarget[]> {
   switch (backupMode) {
     case 'file': {
-      const t = targets as { paths?: string[] };
-      return [{ commandType: 'backup_run', payload: { paths: t.paths ?? [] } }];
+      const t = targets as { paths?: string[]; excludes?: string[] };
+      return [
+        {
+          commandType: 'backup_run',
+          payload: { paths: t.paths ?? [], excludes: t.excludes ?? [] },
+        },
+      ];
     }
 
     case 'system_image':


### PR DESCRIPTION
Closes #2418

## Problem

The redesigned config-policy Backup tab (#2415) saves exclusion patterns for file-mode destinations (`targets.excludes`), but they were silently discarded before reaching the agent:

- `resolveBackupTargets` (`apps/api/src/jobs/backupWorker.ts`) forwarded only `paths` for `case 'file'`.
- The agent's `BackupConfig` had no excludes field and `collectBackupFilesFromPaths` did a plain `filepath.WalkDir` with no filtering.

A tech configuring "back up `C:\Users` but exclude `node_modules`" got a success toast and a backup of everything.

## Fix

**Worker** — `case 'file'` now forwards `excludes: t.excludes ?? []` in the `backup_run` payload, reusing the exact field name the UI and `fileTargetsSchema` (`packages/shared/src/validators/backupTargets.ts`) already persist — no second shape invented.

**Agent** — new `excludeMatcher` (`agent/internal/backup/exclude.go`):
- No-slash patterns (`*.tmp`, `Thumbs.db`, `node_modules`) match the base name of every file and directory visited.
- Slash patterns (`node_modules/**`, `$RECYCLE.BIN/**`, `**/AppData/Local/Temp/**`) match the root-relative path with `**` spanning zero or more segments, at any depth (gitignore-style implicit leading `**/` — this is what the UI's suggested chips like `node_modules/**` intend).
- A matched **directory is skipped entirely via `fs.SkipDir`**, not just its files.
- Case-insensitive on Windows, case-sensitive elsewhere; invalid glob patterns are logged and skipped, never fail the backup.

`BackupConfig` gains `Excludes []string`; `RunBackupWithExcludes(excludes)` lets the `backup_run` command override per run (`nil` = fall back to config, explicit `[]` = disable). The breeze-backup helper decodes `excludes` from the command payload and passes it through.

**Pattern semantics vs VM/SQL modes:** hyperv/mssql `excludeVms`/`excludeDatabases` are exact-name set filters applied server-side at target resolution; file-mode excludes are path globs that can only be applied where the filesystem is visible, i.e. in the agent walker. Both keep the same "targets.exclude* field on the policy" shape.

## Backwards compatibility

- **Old agent + new server:** the extra `excludes` payload field is ignored — heartbeat `Command.Payload` is `map[string]any` and the helper decodes payloads via `encoding/json` into selected-field structs, which ignores unknown JSON fields. Behavior identical to today (no exclusions applied).
- **New agent + old server:** payload has no `excludes` → `parseBackupRunExcludes` returns `nil` → falls back to (empty) config excludes → passthrough.

## Tests

- `apps/api/src/jobs/backupWorker.test.ts` — file mode forwards exclusion patterns; empty defaults for both `paths` and `excludes` (12 passed).
- `agent/internal/backup/exclude_test.go` — table-driven matcher tests (base-name globs, doublestar path globs, `$`/`*` literals, backslash normalization, Windows case-insensitivity, invalid/empty patterns) plus real-walker tests over a temp tree: `*.tmp` glob, directory-name exclusion (`node_modules`), nested doublestar (`**/node_modules/**`), combined patterns, per-run override of config excludes, excluded single-file root, and no-excludes passthrough.
- `cd agent && go test -race ./internal/backup/... ./cmd/breeze-backup/...` — all green; `go vet` + `gofmt` clean; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)