### PR TITLE
fix(api): release undecryptable claimed commands back to pending on heartbeat delivery (#2414)

### DIFF
--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -24,7 +24,8 @@ import { captureException } from '../../services/sentry';
 import { processCollectedAuditPolicyCommandResult } from '../../services/auditBaselineService';
 import { CommandTypes, queueCommandForExecution } from '../../services/commandQueue';
 import { claimPendingCommandsForDevice } from '../../services/commandDispatch';
-import { decryptCommandsForDelivery, hasSensitivePayload } from '../../services/sensitiveCommandPayload';
+import { decryptClaimedCommandsForDelivery } from '../../services/commandDelivery';
+import { hasSensitivePayload } from '../../services/sensitiveCommandPayload';
 import { applyVaultSyncCommandResult } from '../../services/vaultSyncPersistence';
 import { processBackupVerificationResult } from '../backup/verificationService';
 import { updateRestoreJobByCommandId } from '../../services/restoreResultPersistence';
@@ -139,12 +140,11 @@ commandsRoutes.get('/:id/commands', async (c) => {
     )
   );
 
+  // #2414 — decrypt just-in-time; a command whose payload fails decryption is
+  // released back to `pending` (not stranded as `sent`) while its siblings
+  // still deliver.
   return c.json({
-    commands: decryptCommandsForDelivery(commands.map(cmd => ({
-      id: cmd.id,
-      type: cmd.type,
-      payload: cmd.payload,
-    }))),
+    commands: await decryptClaimedCommandsForDelivery(commands),
   });
 });
 

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -136,8 +136,17 @@ vi.mock('../../services/deviceIpHistory', () => ({
   processDeviceIPHistoryUpdate: vi.fn(),
 }));
 
+const claimPendingCommandsForDeviceMock = vi.fn(async (): Promise<unknown[]> => []);
+const releaseClaimedCommandDeliveryMock = vi.fn(async () => undefined);
+
+// Only claim/release are mocked; the batch decrypt-and-release helper
+// (services/commandDelivery, #2414) runs for real so the heartbeat tests below
+// exercise the actual release-on-decrypt-failure behavior.
 vi.mock('../../services/commandDispatch', () => ({
-  claimPendingCommandsForDevice: vi.fn(async () => []),
+  claimPendingCommandsForDevice: (...args: unknown[]) =>
+    claimPendingCommandsForDeviceMock(...(args as [])),
+  releaseClaimedCommandDelivery: (...args: unknown[]) =>
+    releaseClaimedCommandDeliveryMock(...(args as [])),
 }));
 
 vi.mock('../../services/eventBus', () => ({
@@ -2396,5 +2405,139 @@ describe('POST /agents/:id/heartbeat — agentRuntime gauges (#2389)', () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+});
+
+describe('POST /agents/:id/heartbeat — undecryptable claimed commands are released, siblings deliver (#2414)', () => {
+  const claimedAt = new Date('2026-07-13T00:00:00Z');
+  const goodCommand = {
+    id: 'cmd-good',
+    type: 'run_script',
+    payload: { scriptId: 'script-1' },
+    executedAt: claimedAt,
+  };
+  // A well-formed-looking but undecryptable sensitive payload (e.g. after an
+  // APP_ENCRYPTION_KEY rotation) — the real services/commandDelivery +
+  // sensitiveCommandPayload modules run here, so decryption genuinely fails.
+  const undecryptableCommand = {
+    id: 'cmd-bad',
+    type: 'encryption_rotate_key',
+    payload: { password: 'enc:v3:deadbeef:not-real-ciphertext' },
+    executedAt: claimedAt,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getActiveTrustKeysetMock.mockResolvedValue([]);
+    updateMock.mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) })),
+    });
+    insertMock.mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  it('agent path: releases the undecryptable command back to pending and still delivers its sibling', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          siteId: 'site-1',
+          hostname: 'host-1',
+          osType: 'linux',
+          architecture: 'amd64',
+          agentVersion: '0.65.10',
+          agentTokenHash: 'hash',
+          tokenIssuedAt: new Date(),
+        },
+      ]),
+    );
+    selectMock.mockReturnValue(selectChainResolving([]));
+    claimPendingCommandsForDeviceMock.mockResolvedValueOnce([goodCommand, undecryptableCommand]);
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { commands: Array<{ id: string }> };
+    // The decryptable sibling still delivers; the undecryptable one is dropped
+    // from the response...
+    expect(body.commands.map((cmd) => cmd.id)).toEqual(['cmd-good']);
+    // ...and released back to pending (NOT stranded as 'sent' awaiting a
+    // misattributed agent-timeout reap).
+    expect(releaseClaimedCommandDeliveryMock).toHaveBeenCalledWith('cmd-bad', claimedAt);
+    const { captureException } = await import('../../services/sentry');
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('commandId=cmd-bad'),
+      }),
+    );
+  });
+
+  it('watchdog path: releases the undecryptable command back to pending and still delivers its sibling', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          hostname: 'host-1',
+          osType: 'linux',
+          architecture: 'amd64',
+          lastSeenAt: new Date(),
+          mainAgentSilentSince: null,
+        },
+      ]),
+    );
+    selectMock.mockReturnValue(selectChainResolving([]));
+    claimPendingCommandsForDeviceMock.mockResolvedValueOnce([goodCommand, undecryptableCommand]);
+
+    const resp = await buildWatchdogApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ agentVersion: '0.65.15', role: 'watchdog', watchdogState: 'MONITORING' }),
+    });
+
+    expect(resp.status).toBe(200);
+    expect(claimPendingCommandsForDeviceMock).toHaveBeenCalledWith('device-1', 10, 'watchdog');
+    const body = (await resp.json()) as { commands: Array<{ id: string }> };
+    expect(body.commands.map((cmd) => cmd.id)).toEqual(['cmd-good']);
+    expect(releaseClaimedCommandDeliveryMock).toHaveBeenCalledWith('cmd-bad', claimedAt);
+  });
+
+  it('agent path: normal delivery is untouched — every claimed command decrypts, nothing is released', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          siteId: 'site-1',
+          hostname: 'host-1',
+          osType: 'linux',
+          architecture: 'amd64',
+          agentVersion: '0.65.10',
+          agentTokenHash: 'hash',
+          tokenIssuedAt: new Date(),
+        },
+      ]),
+    );
+    selectMock.mockReturnValue(selectChainResolving([]));
+    claimPendingCommandsForDeviceMock.mockResolvedValueOnce([goodCommand]);
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { commands: Array<{ id: string; type: string; payload: unknown }> };
+    expect(body.commands).toEqual([
+      { id: 'cmd-good', type: 'run_script', payload: { scriptId: 'script-1' } },
+    ]);
+    expect(releaseClaimedCommandDeliveryMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -39,7 +39,7 @@ import type { AgentAuthContext } from '../../middleware/agentAuth';
 import { captureException } from '../../services/sentry';
 import { resolveRemoteAccessForDevice } from '../../services/remoteAccessPolicy';
 import { getActiveTrustKeyset, type ManifestTrustKey } from '../../services/manifestSigning';
-import { decryptCommandsForDelivery } from '../../services/sensitiveCommandPayload';
+import { decryptClaimedCommandsForDelivery } from '../../services/commandDelivery';
 
 /**
  * #1121 — pure collapse detector for the watchdogState tolerance gap.
@@ -361,12 +361,11 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       }
     }
 
+    // #2414 — decrypt just-in-time; a command whose payload fails decryption is
+    // released back to `pending` (not stranded as `sent`) while its siblings
+    // still deliver.
     return c.json({
-      commands: decryptCommandsForDelivery(watchdogCommands.map(cmd => ({
-        id: cmd.id,
-        type: cmd.type,
-        payload: cmd.payload,
-      }))),
+      commands: await decryptClaimedCommandsForDelivery(watchdogCommands),
       watchdogUpgradeTo,
       upgradeTo: agentUpgradeTo,
     });
@@ -947,6 +946,11 @@ if (latestHelper) {
     console.error('[heartbeat] Failed to resolve remote access policy:', err);
   }
 
+  // #2414 — decrypt just-in-time; a command whose payload fails decryption is
+  // released back to `pending` (not stranded as `sent`) while its siblings
+  // still deliver.
+  const deliverableCommands = await decryptClaimedCommandsForDelivery(commands);
+
   // Main-branch response payload — built inside the org context, but the
   // manifest-trust-keyset and policy probe config are fetched AFTER this
   // context closes (see below).
@@ -954,11 +958,7 @@ if (latestHelper) {
     deviceOrgId: device.orgId,
     deviceId: device.id,
     mainResponse: {
-      commands: decryptCommandsForDelivery(commands.map(cmd => ({
-        id: cmd.id,
-        type: cmd.type,
-        payload: cmd.payload
-      }))),
+      commands: deliverableCommands,
       configUpdate: mergedConfigUpdate,
       upgradeTo,
       helperUpgradeTo: helperUpgradeTo ?? undefined,

--- a/apps/api/src/services/commandDelivery.test.ts
+++ b/apps/api/src/services/commandDelivery.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+process.env.APP_ENCRYPTION_KEY = process.env.APP_ENCRYPTION_KEY || 'test-app-encryption-key-for-vitest';
+
+const releaseClaimedCommandDeliveryMock = vi.fn(async () => undefined);
+vi.mock('./commandDispatch', () => ({
+  releaseClaimedCommandDelivery: (...args: unknown[]) =>
+    releaseClaimedCommandDeliveryMock(...(args as [])),
+}));
+
+const captureExceptionMock = vi.fn();
+vi.mock('./sentry', () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...(args as [])),
+}));
+
+import { decryptClaimedCommandsForDelivery } from './commandDelivery';
+import { encryptSensitivePayloadFields } from './sensitiveCommandPayload';
+
+const claimedAt = new Date('2026-07-13T00:00:00Z');
+
+// A well-formed-looking but undecryptable sensitive payload (e.g. after an
+// APP_ENCRYPTION_KEY rotation).
+const undecryptable = {
+  id: 'cmd-bad',
+  type: 'encryption_rotate_key',
+  payload: { password: 'enc:v3:deadbeef:not-real-ciphertext' },
+  executedAt: claimedAt,
+};
+
+describe('decryptClaimedCommandsForDelivery (#2414)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('releases a command that fails decryption back to pending while its siblings still deliver', async () => {
+    const goodEncrypted = encryptSensitivePayloadFields('encryption_rotate_key', { password: 'pw' });
+    const claimed = [
+      { id: 'cmd-plain', type: 'run_script', payload: { scriptId: 's-1' }, executedAt: claimedAt },
+      { id: 'cmd-good', type: 'encryption_rotate_key', payload: goodEncrypted, executedAt: claimedAt },
+      undecryptable,
+    ];
+
+    const delivered = await decryptClaimedCommandsForDelivery(claimed);
+
+    expect(delivered.map((cmd) => cmd.id)).toEqual(['cmd-plain', 'cmd-good']);
+    expect((delivered[1]?.payload as Record<string, unknown> | undefined)?.password).toBe('pw');
+    // The undecryptable command must go back to pending — not strand as sent.
+    expect(releaseClaimedCommandDeliveryMock).toHaveBeenCalledTimes(1);
+    expect(releaseClaimedCommandDeliveryMock).toHaveBeenCalledWith('cmd-bad', claimedAt);
+    // Loud: the decrypt failure is reported to Sentry with commandId/type context.
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('commandId=cmd-bad'),
+      }),
+    );
+  });
+
+  it('does not touch the release path when every command decrypts', async () => {
+    const delivered = await decryptClaimedCommandsForDelivery([
+      { id: 'cmd-1', type: 'run_script', payload: { scriptId: 's-1' }, executedAt: claimedAt },
+    ]);
+
+    expect(delivered.map((cmd) => cmd.id)).toEqual(['cmd-1']);
+    expect(releaseClaimedCommandDeliveryMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('still returns the deliverable siblings (and captures) when the release itself fails', async () => {
+    releaseClaimedCommandDeliveryMock.mockRejectedValueOnce(new Error('db down'));
+
+    const delivered = await decryptClaimedCommandsForDelivery([
+      { id: 'cmd-plain', type: 'run_script', payload: {}, executedAt: claimedAt },
+      undecryptable,
+    ]);
+
+    expect(delivered.map((cmd) => cmd.id)).toEqual(['cmd-plain']);
+    // Two captures: the decrypt failure (chokepoint) + the failed release.
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('release of undeliverable claimed command failed (commandId=cmd-bad'),
+      }),
+    );
+  });
+
+  it('captures instead of releasing when a failed row is missing its claim timestamp', async () => {
+    const delivered = await decryptClaimedCommandsForDelivery([
+      { ...undecryptable, executedAt: null },
+    ]);
+
+    expect(delivered).toEqual([]);
+    expect(releaseClaimedCommandDeliveryMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('cannot release'),
+      }),
+    );
+  });
+
+  it('returns an empty array for an empty batch', async () => {
+    await expect(decryptClaimedCommandsForDelivery([])).resolves.toEqual([]);
+    expect(releaseClaimedCommandDeliveryMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/commandDelivery.ts
+++ b/apps/api/src/services/commandDelivery.ts
@@ -1,0 +1,77 @@
+import { releaseClaimedCommandDelivery } from './commandDispatch';
+import {
+  decryptCommandsForDelivery,
+  type DeliverableCommand,
+} from './sensitiveCommandPayload';
+import { captureException } from './sentry';
+
+/**
+ * The subset of a just-claimed `device_commands` row that batch delivery needs.
+ * `executedAt` is the claim timestamp `claimPendingCommandsForDevice` wrote when
+ * it flipped the row to `sent` — `releaseClaimedCommandDelivery` keys on it so a
+ * release can never clobber a newer claim.
+ */
+export type ClaimedCommand = {
+  id: string;
+  type: string;
+  payload: unknown;
+  executedAt: Date | null;
+};
+
+/**
+ * Decrypt a batch of JUST-CLAIMED commands for delivery, releasing any that
+ * fail decryption back to `pending` (issue #2414).
+ *
+ * `claimPendingCommandsForDevice` flips rows to `sent` before the payloads are
+ * decrypted. `decryptCommandsForDelivery` then silently drops any command whose
+ * sensitive payload can't be decrypted (rotated/corrupted APP_ENCRYPTION_KEY,
+ * AAD mismatch) — without a release, such a command strands as `sent` with zero
+ * delivery attempts until the stale reaper misattributes it to an agent
+ * timeout. This helper diffs input vs output by id and releases every dropped
+ * command so the failure stays recoverable (and, once the command ages out
+ * while `pending`, the reaper reports "agent never received the command"
+ * rather than "no response from agent"). The decrypt failure itself is
+ * reported to Sentry by `decryptCommandForDelivery`; this only adds a capture
+ * when the RELEASE fails, since that re-strands the command.
+ *
+ * Successfully decrypted siblings in the same batch are always returned — one
+ * bad payload never sinks the batch (and a release failure never throws out of
+ * the delivery path).
+ */
+export async function decryptClaimedCommandsForDelivery(
+  claimed: ClaimedCommand[],
+): Promise<DeliverableCommand[]> {
+  const delivered = decryptCommandsForDelivery(
+    claimed.map((cmd) => ({ id: cmd.id, type: cmd.type, payload: cmd.payload })),
+  );
+  if (delivered.length === claimed.length) {
+    return delivered;
+  }
+
+  const deliveredIds = new Set(delivered.map((cmd) => cmd.id));
+  for (const cmd of claimed) {
+    if (deliveredIds.has(cmd.id)) continue;
+    try {
+      if (!cmd.executedAt) {
+        // Claimed rows always carry the claim timestamp; without it the
+        // conditional release cannot run safely. Surface loudly instead of
+        // silently stranding the command as `sent`.
+        throw new Error('claimed command row has no executedAt — cannot release');
+      }
+      await releaseClaimedCommandDelivery(cmd.id, cmd.executedAt);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        '[commandDelivery] failed to release undeliverable claimed command back to pending; it will strand as sent until the stale reaper times it out',
+        { commandId: cmd.id, type: cmd.type, error: message },
+      );
+      captureException(
+        new Error(
+          `[commandDelivery] release of undeliverable claimed command failed (commandId=${cmd.id}, type=${cmd.type}): ${message}`,
+        ),
+      );
+    }
+  }
+
+  return delivered;
+}

--- a/apps/api/src/services/commandDispatch.ts
+++ b/apps/api/src/services/commandDispatch.ts
@@ -27,6 +27,19 @@ export async function claimPendingCommandForDelivery(
   return rows.length > 0 ? { id: commandId, executedAt } : null;
 }
 
+/**
+ * Put a claimed-but-undelivered command back to `pending`. Keyed on
+ * `(id, status='sent', executedAt=<claim ts>)` so a stale release can never
+ * clobber a newer claim or resurrect a terminal command (0-row no-op is the
+ * correct outcome in both cases).
+ *
+ * Context note: `withSystemDbAccessContext` does NOT escalate when a request
+ * context is already active — on the heartbeat paths (#2414) this UPDATE runs
+ * inside the caller's org-scoped transaction. That is safe solely because
+ * `device_commands` is intentionally RLS-free; if it ever gains a system-only
+ * write policy, this release would become a silent 0-row no-op on the hottest
+ * delivery path.
+ */
 export async function releaseClaimedCommandDelivery(
   commandId: string,
   executedAt: Date,

--- a/apps/api/src/services/sensitiveCommandPayload.ts
+++ b/apps/api/src/services/sensitiveCommandPayload.ts
@@ -1,4 +1,5 @@
 import { decryptSecret, encryptSecret } from './secretCrypto';
+import { captureException } from './sentry';
 
 // device_commands is intentionally system-scoped (no RLS) and its payload
 // column is plaintext JSONB. Commands whose payload carries credentials are
@@ -57,17 +58,31 @@ export type DeliverableCommand = { id: string; type: string; payload: unknown };
  * decrypted, or `null` if decryption throws (a rotated/corrupted
  * `APP_ENCRYPTION_KEY`, an AAD mismatch, or corrupt ciphertext). Callers MUST
  * drop a `null` rather than deliver it: a single un-decryptable command must
- * never fail the whole batch or heartbeat response. For non-sensitive command
- * types this is a pure passthrough that cannot throw. Never logs ciphertext or
- * key material — only the command id/type.
+ * never fail the whole batch or heartbeat response. Callers that CLAIMED the
+ * command before decrypting must also release it back to `pending` (see
+ * `decryptClaimedCommandsForDelivery` in services/commandDelivery.ts, #2414) —
+ * otherwise it strands as `sent` and the eventual reaper timeout misattributes
+ * a server-side decrypt failure to agent unreachability. For non-sensitive
+ * command types this is a pure passthrough that cannot throw. Never logs
+ * ciphertext or key material — only the command id/type.
+ *
+ * A decrypt failure is reported to Sentry here (the single chokepoint every
+ * delivery path funnels through) so a mass decrypt-failure event — e.g. a
+ * rotated APP_ENCRYPTION_KEY — is distinguishable from agent flakiness.
  */
 export function decryptCommandForDelivery(cmd: DeliverableCommand): DeliverableCommand | null {
   try {
     return { id: cmd.id, type: cmd.type, payload: decryptSensitivePayloadFields(cmd.type, cmd.payload) };
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     console.error(
       '[sensitiveCommandPayload] failed to decrypt command payload for delivery; dropping this command only',
-      { commandId: cmd.id, type: cmd.type, error: err instanceof Error ? err.message : String(err) },
+      { commandId: cmd.id, type: cmd.type, error: message },
+    );
+    captureException(
+      new Error(
+        `[sensitiveCommandPayload] command payload decrypt failed (commandId=${cmd.id}, type=${cmd.type}): ${message}`,
+      ),
     );
     return null;
   }


### PR DESCRIPTION
## Summary

The HTTP heartbeat claim paths (`claimPendingCommandsForDevice` → rows flipped to `sent`) piped batches through `decryptCommandsForDelivery`, which silently filters out any command whose sensitive payload fails to decrypt. Nothing released the filtered commands, so they stranded as `status='sent'` with zero delivery attempts until `staleCommandReaper` misattributed the server-side decrypt failure (rotated/corrupted `APP_ENCRYPTION_KEY`, AAD mismatch) to *"Server-side timeout: no response from agent"*. Since PR #2412 made the heartbeat claim the sole batch-delivery route, this was the only remaining asymmetry with the sound `executeCommand` direct-push path (which already releases on decrypt failure).

## Changes

- **New `apps/api/src/services/commandDelivery.ts`** — `decryptClaimedCommandsForDelivery` diffs the just-claimed batch against the decrypt output by command id and calls `releaseClaimedCommandDelivery` for anything filtered out, so the command goes back to `pending` instead of stranding as `sent`. Deliverable siblings in the same batch always still ship; a release failure is captured to Sentry (with commandId/type) and never throws out of the delivery path.
- **`routes/agents/heartbeat.ts`** — both response assemblies (agent main branch and watchdog branch) now go through the new helper.
- **`routes/agents/commands.ts`** — the `GET /:id/commands` poll route had the identical claim-then-silently-filter gap; wired through the same helper.
- **`services/sensitiveCommandPayload.ts`** — the decrypt-failure filter path now reports to Sentry with commandId/type context (was `console.error` only). This is the single chokepoint all delivery paths funnel through, so a mass decrypt-failure event post key-rotation is now distinguishable from agent flakiness.

## Termination safety

A permanently undecryptable command now loops claim → release each heartbeat, but the reaper's `pending` expiry keys off `createdAt` (not the reset `executedAt`), so it still reaches a terminal `failed` state after the per-type timeout — with the more accurate *"Command expired: agent never received the command"* message plus Sentry events pinning the real cause.

## Verification

- New `services/commandDelivery.test.ts` (5 tests): undecryptable command released back to pending with the claim timestamp while siblings deliver; no release when all decrypt; release-failure capture; missing-`executedAt` guard; empty batch.
- New route-level tests in `heartbeat.test.ts` (3 tests) running the REAL `commandDelivery` + `sensitiveCommandPayload` modules with only claim/release mocked: agent path and watchdog path each release the undecryptable command and deliver the sibling; normal all-decryptable delivery is byte-identical with zero releases (no regression to the sole batch-delivery route).
- Affected suites single-fork: `commandDelivery`, `sensitiveCommandPayload`, `commandDispatch`, `heartbeat`, `commands`, `agents`, `agentWs`, `commandQueue`, `commandQueueTransitions` — 206 tests, all green. `tsc --noEmit` clean.

Closes #2414

🤖 Generated with [Claude Code](https://claude.com/claude-code)