### PR TITLE
fix(agent): unifi/workspaceindex follow server-URL promotion + workspaceindex hardening (#2423, #2425)

### DIFF
--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -740,7 +740,10 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 		// zeroed token and spins auth-failure logs (same class as ETW PR #959).
 		unifiCtx, unifiCancel = context.WithCancel(context.Background())
 		unifiDone = unifi.StartCollectorLoop(unifiCtx, unifi.CollectorDeps{
-			APIBaseURL: cfg.ServerURL,
+			// URL provider, not a copied string: after backup-server-URL
+			// promotion (#2323) uploads must follow the promoted primary
+			// instead of POSTing to the dead one forever (#2423).
+			APIBaseURL: hb.ServerURL,
 			AgentID:    cfg.AgentID,
 			HTTP:       newUnifiAPIClient(secureToken, tlsCfg),
 			// Loop failures here are config-fetch / telemetry-upload errors —
@@ -757,7 +760,9 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 		log.Debug("workspace indexing disabled by local configuration")
 	} else {
 		workspaceClient := workspaceindex.NewClient(workspaceindex.ClientConfig{
-			ServerURL:    cfg.ServerURL,
+			// URL provider, not a copied string — see the UniFi collector
+			// wiring above (#2423).
+			ServerURL:    hb.ServerURL,
 			EndpointBase: cfg.WorkspaceIndex.EndpointBase,
 			AuthToken:    secureToken,
 			HTTPClient:   newUnifiAPIClient(secureToken, tlsCfg),
@@ -767,6 +772,8 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 		workspaceIndexCtx, workspaceIndexCancel = context.WithCancel(context.Background())
 		workspaceIndexDone = workspaceindex.StartLoop(workspaceIndexCtx, workspaceindex.Deps{
 			Client: workspaceClient,
+			// Device-audit trace for server-driven indexing activation (#2425).
+			Audit: hb.AuditLog(),
 		})
 	}
 

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -770,11 +770,15 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 		})
 		var workspaceIndexCtx context.Context
 		workspaceIndexCtx, workspaceIndexCancel = context.WithCancel(context.Background())
-		workspaceIndexDone = workspaceindex.StartLoop(workspaceIndexCtx, workspaceindex.Deps{
-			Client: workspaceClient,
-			// Device-audit trace for server-driven indexing activation (#2425).
-			Audit: hb.AuditLog(),
-		})
+		workspaceIndexDeps := workspaceindex.Deps{Client: workspaceClient}
+		// Device-audit trace for server-driven indexing activation (#2425).
+		// Assign only a non-nil logger: a nil *audit.Logger stored in the
+		// AuditLogger interface is a TYPED nil, which passes `!= nil` and would
+		// make the loop's audit guard silently decorative.
+		if auditLog := hb.AuditLog(); auditLog != nil {
+			workspaceIndexDeps.Audit = auditLog
+		}
+		workspaceIndexDone = workspaceindex.StartLoop(workspaceIndexCtx, workspaceIndexDeps)
 	}
 
 	// PAM Track 3: subscribe to Microsoft-Windows-LUA ETW provider for

--- a/agent/internal/audit/audit.go
+++ b/agent/internal/audit/audit.go
@@ -30,19 +30,25 @@ const (
 	EventAgentStop        = "agent_stop"
 	EventLogRotated       = "log_rotated"
 	// EventWorkspaceIndexActivated records that server configuration turned
-	// on filesystem indexing (workspaceindex module) for this device — a
-	// privacy-significant transition that must leave a local, tamper-evident
-	// trace (#2425).
+	// on filesystem indexing (workspaceindex module) for this device, or
+	// widened its scope — a privacy-significant transition that must leave a
+	// local, tamper-evident trace (#2425).
 	EventWorkspaceIndexActivated = "workspace_index_activated"
+	// EventWorkspaceIndexDeactivated closes the bracket opened by
+	// EventWorkspaceIndexActivated. Without it the audit trail can prove
+	// indexing started but never that it stopped, leaving the window
+	// unbounded (#2425).
+	EventWorkspaceIndexDeactivated = "workspace_index_deactivated"
 )
 
 // criticalEvents are event types that require fsync after writing.
 var criticalEvents = map[string]bool{
-	EventPrivilegedOp:            true,
-	EventAgentStart:              true,
-	EventAgentStop:               true,
-	EventConfigChange:            true,
-	EventWorkspaceIndexActivated: true,
+	EventPrivilegedOp:              true,
+	EventAgentStart:                true,
+	EventAgentStop:                 true,
+	EventConfigChange:              true,
+	EventWorkspaceIndexActivated:   true,
+	EventWorkspaceIndexDeactivated: true,
 }
 
 // Entry is a single audit log record.

--- a/agent/internal/audit/audit.go
+++ b/agent/internal/audit/audit.go
@@ -29,14 +29,20 @@ const (
 	EventAgentStart       = "agent_start"
 	EventAgentStop        = "agent_stop"
 	EventLogRotated       = "log_rotated"
+	// EventWorkspaceIndexActivated records that server configuration turned
+	// on filesystem indexing (workspaceindex module) for this device — a
+	// privacy-significant transition that must leave a local, tamper-evident
+	// trace (#2425).
+	EventWorkspaceIndexActivated = "workspace_index_activated"
 )
 
 // criticalEvents are event types that require fsync after writing.
 var criticalEvents = map[string]bool{
-	EventPrivilegedOp: true,
-	EventAgentStart:   true,
-	EventAgentStop:    true,
-	EventConfigChange: true,
+	EventPrivilegedOp:            true,
+	EventAgentStart:              true,
+	EventAgentStop:               true,
+	EventConfigChange:            true,
+	EventWorkspaceIndexActivated: true,
 }
 
 // Entry is a single audit log record.

--- a/agent/internal/heartbeat/backup_failover_test.go
+++ b/agent/internal/heartbeat/backup_failover_test.go
@@ -384,3 +384,33 @@ func TestProbeCommandResultsGoToPromotedURL(t *testing.T) {
 		t.Fatalf("server URL after probe = %q, want %q", got, backupURL)
 	}
 }
+
+// TestPromotionVisibleThroughServerURLProvider pins #2423: agentapp wires
+// hb.ServerURL as the URL provider into the long-lived UniFi telemetry and
+// workspace-index client loops. After backup-server-URL promotion the
+// provider must return the promoted URL, so those loops follow the failover
+// instead of POSTing to the dead primary for the remaining process lifetime.
+func TestPromotionVisibleThroughServerURLProvider(t *testing.T) {
+	const (
+		primaryURL = "https://primary.invalid"
+		backupURL  = "https://backup.invalid"
+	)
+
+	cfg := swapTestConfig(t, primaryURL, backupURL)
+	h := newFailoverTestHeartbeat(cfg, failoverRoundTripper(func(req *http.Request) (*http.Response, error) {
+		return failoverResponse(req, http.StatusOK, `{}`), nil
+	}))
+
+	// The provider is captured ONCE at startup, exactly like agentapp does for
+	// unifi.CollectorDeps.APIBaseURL and workspaceindex.ClientConfig.ServerURL.
+	provider := h.ServerURL
+	if got := provider(); got != primaryURL {
+		t.Fatalf("provider before promotion = %q, want %q", got, primaryURL)
+	}
+
+	h.promoteBackupServerURL(backupURL)
+
+	if got := provider(); got != backupURL {
+		t.Fatalf("provider after promotion = %q, want %q — a copied cfg.ServerURL never observes promotion (#2423)", got, backupURL)
+	}
+}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -2708,6 +2708,15 @@ func (h *Heartbeat) serverURL() string {
 	return h.config.ServerURL
 }
 
+// ServerURL returns the current server base URL, reflecting any
+// backup-server-URL promotion (#2323). Long-lived client loops (UniFi
+// telemetry, workspace indexing) must read the URL through this getter on
+// every request instead of copying cfg.ServerURL once at startup — a copied
+// string keeps pointing at a dead primary after failover (#2423).
+func (h *Heartbeat) ServerURL() string {
+	return h.serverURL()
+}
+
 func (h *Heartbeat) monitoringResultsURL() string {
 	return fmt.Sprintf("%s/api/v1/agents/%s/monitoring-results", h.serverURL(), h.config.AgentID)
 }

--- a/agent/internal/unifi/collector.go
+++ b/agent/internal/unifi/collector.go
@@ -18,7 +18,13 @@ type CollectorConfig struct {
 }
 
 type CollectorDeps struct {
-	APIBaseURL string       // the Breeze server root (cfg.ServerURL), e.g. https://breeze.example.com — NOT including /api/v1
+	// APIBaseURL returns the CURRENT Breeze server root, e.g.
+	// https://breeze.example.com — NOT including /api/v1. It is a provider
+	// (typically heartbeat.ServerURL), not a copied string, so backup-server-URL
+	// promotion after failover (#2323) is visible to every request. A copied
+	// cfg.ServerURL kept uploading to a dead primary for the process lifetime
+	// (#2423).
+	APIBaseURL func() string
 	AgentID    string       // this agent's id; agent telemetry endpoints live under /api/v1/agents/<AgentID>/
 	HTTP       *http.Client // authed transport to the Breeze API (agent token attached)
 	Logf       func(format string, args ...any)
@@ -32,7 +38,7 @@ type CollectorDeps struct {
 // The device is resolved from the agent token server-side; the :id in the path
 // matches the existing agent routes.
 func (d CollectorDeps) agentBase() string {
-	return d.APIBaseURL + "/api/v1/agents/" + d.AgentID
+	return d.APIBaseURL() + "/api/v1/agents/" + d.AgentID
 }
 
 func (d CollectorDeps) logf(format string, args ...any) {

--- a/agent/internal/unifi/collector.go
+++ b/agent/internal/unifi/collector.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/breeze-rmm/agent/internal/observability"
 )
 
 type CollectorConfig struct {
@@ -37,8 +40,20 @@ type CollectorDeps struct {
 // API 404s the request and the collector never leaves status=pending (#2263).
 // The device is resolved from the agent token server-side; the :id in the path
 // matches the existing agent routes.
-func (d CollectorDeps) agentBase() string {
-	return d.APIBaseURL() + "/api/v1/agents/" + d.AgentID
+//
+// An unset or empty-returning APIBaseURL provider is a wiring bug, not a
+// runtime condition: report it as a named error rather than dereferencing a
+// nil func (which would panic the collector goroutine) or silently building a
+// scheme-less relative URL that fails as a cryptic transport error forever.
+func (d CollectorDeps) agentBase() (string, error) {
+	if d.APIBaseURL == nil {
+		return "", errors.New("unifi collector: APIBaseURL provider not set")
+	}
+	baseURL := d.APIBaseURL()
+	if baseURL == "" {
+		return "", errors.New("unifi collector: APIBaseURL provider returned an empty server URL")
+	}
+	return baseURL + "/api/v1/agents/" + d.AgentID, nil
 }
 
 func (d CollectorDeps) logf(format string, args ...any) {
@@ -149,7 +164,11 @@ func RunOnce(ctx context.Context, deps CollectorDeps, cfg CollectorConfig, contr
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, deps.agentBase()+"/unifi-telemetry", bytes.NewReader(body))
+	base, err := deps.agentBase()
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+"/unifi-telemetry", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -174,6 +193,10 @@ func StartCollectorLoop(ctx context.Context, deps CollectorDeps) <-chan struct{}
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
+		// A panic in this loop must not take the whole agent down with it —
+		// the sibling workspaceindex loop has carried this guard since it
+		// shipped; the collector never did.
+		defer observability.Recoverer("unifi.collector")
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 		lastRun := map[string]time.Time{}
@@ -205,7 +228,11 @@ func StartCollectorLoop(ctx context.Context, deps CollectorDeps) <-chan struct{}
 }
 
 func fetchConfigs(ctx context.Context, deps CollectorDeps) ([]CollectorConfig, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, deps.agentBase()+"/unifi-collectors", nil)
+	base, err := deps.agentBase()
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/unifi-collectors", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/internal/unifi/collector_test.go
+++ b/agent/internal/unifi/collector_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -44,7 +45,7 @@ func TestRunOnceUploadsTelemetry(t *testing.T) {
 	defer api.Close()
 
 	cfg := CollectorConfig{CollectorID: "c1", ControllerURL: controller.URL, APIKey: "k"}
-	err := RunOnce(context.Background(), CollectorDeps{APIBaseURL: api.URL, AgentID: "agent-1", HTTP: api.Client()}, cfg, controller.Client())
+	err := RunOnce(context.Background(), CollectorDeps{APIBaseURL: func() string { return api.URL }, AgentID: "agent-1", HTTP: api.Client()}, cfg, controller.Client())
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -93,7 +94,7 @@ func TestRunOnceUploadsSites(t *testing.T) {
 	defer api.Close()
 
 	cfg := CollectorConfig{CollectorID: "c1", ControllerURL: controller.URL, APIKey: "k"}
-	err := RunOnce(context.Background(), CollectorDeps{APIBaseURL: api.URL, AgentID: "agent-1", HTTP: api.Client()}, cfg, controller.Client())
+	err := RunOnce(context.Background(), CollectorDeps{APIBaseURL: func() string { return api.URL }, AgentID: "agent-1", HTTP: api.Client()}, cfg, controller.Client())
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -124,7 +125,7 @@ func TestFetchConfigsHitsAgentScopedPath(t *testing.T) {
 	}))
 	defer api.Close()
 
-	configs, err := fetchConfigs(context.Background(), CollectorDeps{APIBaseURL: api.URL, AgentID: "agent-1", HTTP: api.Client()})
+	configs, err := fetchConfigs(context.Background(), CollectorDeps{APIBaseURL: func() string { return api.URL }, AgentID: "agent-1", HTTP: api.Client()})
 	if err != nil {
 		t.Fatalf("fetchConfigs: %v", err)
 	}
@@ -133,5 +134,53 @@ func TestFetchConfigsHitsAgentScopedPath(t *testing.T) {
 	}
 	if len(configs) != 1 || configs[0].CollectorID != "c1" {
 		t.Fatalf("unexpected configs: %+v", configs)
+	}
+}
+
+// TestFetchConfigsFollowsAPIBaseURLProviderAcrossFailover pins #2423:
+// CollectorDeps.APIBaseURL is a URL provider (heartbeat.ServerURL in
+// production), so after backup-server-URL promotion (#2323) the SAME deps
+// value must send subsequent requests to the promoted URL. A copied
+// cfg.ServerURL string kept POSTing to the dead primary for the process
+// lifetime.
+func TestFetchConfigsFollowsAPIBaseURLProviderAcrossFailover(t *testing.T) {
+	var primaryHits, backupHits atomic.Int32
+	newServer := func(hits *atomic.Int32) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v1/agents/agent-1/unifi-collectors" {
+				w.WriteHeader(404)
+				return
+			}
+			hits.Add(1)
+			_, _ = w.Write([]byte(`{"collectors":[]}`))
+		}))
+	}
+	primary := newServer(&primaryHits)
+	defer primary.Close()
+	backup := newServer(&backupHits)
+	defer backup.Close()
+
+	var serverURL atomic.Value
+	serverURL.Store(primary.URL)
+	deps := CollectorDeps{
+		APIBaseURL: func() string { return serverURL.Load().(string) },
+		AgentID:    "agent-1",
+		HTTP:       &http.Client{},
+	}
+
+	if _, err := fetchConfigs(context.Background(), deps); err != nil {
+		t.Fatalf("fetchConfigs via primary: %v", err)
+	}
+	// Simulate backup-server-URL promotion: the provider now returns the
+	// promoted URL and the same long-lived deps must follow it.
+	serverURL.Store(backup.URL)
+	if _, err := fetchConfigs(context.Background(), deps); err != nil {
+		t.Fatalf("fetchConfigs via promoted backup: %v", err)
+	}
+	if got := primaryHits.Load(); got != 1 {
+		t.Fatalf("primary received %d requests, want 1", got)
+	}
+	if got := backupHits.Load(); got != 1 {
+		t.Fatalf("promoted backup received %d requests, want 1 — deps still pinned to the old primary (#2423)", got)
 	}
 }

--- a/agent/internal/unifi/collector_test.go
+++ b/agent/internal/unifi/collector_test.go
@@ -184,3 +184,27 @@ func TestFetchConfigsFollowsAPIBaseURLProviderAcrossFailover(t *testing.T) {
 		t.Fatalf("promoted backup received %d requests, want 1 — deps still pinned to the old primary (#2423)", got)
 	}
 }
+
+// TestAgentBaseRejectsUnsetOrEmptyProvider pins the wiring-bug contract: an
+// unset APIBaseURL provider must surface as a named error, never a nil-func
+// panic that takes the agent process down from inside the collector goroutine.
+func TestAgentBaseRejectsUnsetOrEmptyProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		deps CollectorDeps
+	}{
+		{name: "nil provider", deps: CollectorDeps{AgentID: "agent-1"}},
+		{name: "provider returns empty", deps: CollectorDeps{AgentID: "agent-1", APIBaseURL: func() string { return "" }}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tt.deps.agentBase(); err == nil {
+				t.Fatal("agentBase() error = nil, want a named wiring error")
+			}
+			// fetchConfigs must propagate it rather than panicking.
+			if _, err := fetchConfigs(context.Background(), tt.deps); err == nil {
+				t.Fatal("fetchConfigs() error = nil, want the wiring error propagated")
+			}
+		})
+	}
+}

--- a/agent/internal/workspaceindex/client.go
+++ b/agent/internal/workspaceindex/client.go
@@ -37,6 +37,9 @@ var (
 	ErrRunConflict     = errors.New("workspace index run conflict")
 	ErrBatchTooLarge   = errors.New("workspace index batch too large")
 	ErrAuthUnavailable = errors.New("workspace index request skipped while authentication is unavailable")
+	// ErrNoServerURL names a wiring bug — the ServerURL provider is unset or
+	// returned empty — so it can't masquerade as a transport failure.
+	ErrNoServerURL = errors.New("workspace index client has no server URL (ServerURL provider unset or empty)")
 )
 
 // HTTPError describes a non-successful server response. Body is capped at 64
@@ -94,6 +97,10 @@ func NewClient(cfg ClientConfig) *Client {
 	clientCopy.Timeout = requestTimeout
 	clientCopy.CheckRedirect = refuseUntrustedRedirect
 
+	// A nil provider is a wiring bug. Keep the client constructible (callers
+	// don't handle an error here) but never let it degrade into a scheme-less
+	// relative URL that fails forever as a cryptic transport error — name the
+	// real cause in every request error instead.
 	serverURL := cfg.ServerURL
 	if serverURL == nil {
 		serverURL = func() string { return "" }
@@ -256,7 +263,22 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte, retry
 
 		// Resolve the server URL per attempt: the provider reflects
 		// backup-server-URL promotion after failover (#2423).
+		//
+		// A promotion mid-crawl re-points an in-flight run's PostBatch/
+		// CompleteRun at the newly promoted server. That is deliberate: the
+		// alternative — pinning the run to a server we already know is dead —
+		// uploads nothing at all. If the promoted server does not share the
+		// primary's database it rejects the stale runID, the crawl fails, and
+		// the loop simply re-runs the source against the live server on the
+		// next cadence. Failing one crawl beats stranding every future one.
 		baseURL := strings.TrimRight(c.serverURL(), "/")
+		if baseURL == "" {
+			// Fail fast and by name. Building the request anyway yields a
+			// scheme-less relative URL whose transport error ("unsupported
+			// protocol scheme") sends the next reader hunting for a DNS/TLS
+			// problem that does not exist, and burns the batch retries doing it.
+			return nil, ErrNoServerURL
+		}
 		req, err := http.NewRequestWithContext(ctx, method, baseURL+c.endpointBase+path, bytes.NewReader(body))
 		if err != nil {
 			return nil, fmt.Errorf("create workspace index request: %w", err)

--- a/agent/internal/workspaceindex/client.go
+++ b/agent/internal/workspaceindex/client.go
@@ -55,7 +55,12 @@ func (e *HTTPError) Error() string {
 
 // ClientConfig supplies the workspace-index client dependencies.
 type ClientConfig struct {
-	ServerURL    string
+	// ServerURL returns the CURRENT server base URL. It is a provider
+	// (typically heartbeat.ServerURL), not a copied string, so backup-server-URL
+	// promotion after failover (#2323) is visible to every request. A copied
+	// cfg.ServerURL kept uploading to a dead primary for the process lifetime
+	// (#2423).
+	ServerURL    func() string
 	EndpointBase string
 	AuthToken    *secmem.SecureString
 	HTTPClient   *http.Client
@@ -64,7 +69,7 @@ type ClientConfig struct {
 
 // Client calls the server's agent workspace-index endpoints.
 type Client struct {
-	serverURL    string
+	serverURL    func() string
 	endpointBase string
 	authToken    *secmem.SecureString
 	httpClient   *http.Client
@@ -89,8 +94,13 @@ func NewClient(cfg ClientConfig) *Client {
 	clientCopy.Timeout = requestTimeout
 	clientCopy.CheckRedirect = refuseUntrustedRedirect
 
+	serverURL := cfg.ServerURL
+	if serverURL == nil {
+		serverURL = func() string { return "" }
+	}
+
 	return &Client{
-		serverURL:    strings.TrimRight(cfg.ServerURL, "/"),
+		serverURL:    serverURL,
 		endpointBase: endpointBase,
 		authToken:    cfg.AuthToken,
 		httpClient:   &clientCopy,
@@ -244,7 +254,10 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte, retry
 			}
 		}
 
-		req, err := http.NewRequestWithContext(ctx, method, c.serverURL+c.endpointBase+path, bytes.NewReader(body))
+		// Resolve the server URL per attempt: the provider reflects
+		// backup-server-URL promotion after failover (#2423).
+		baseURL := strings.TrimRight(c.serverURL(), "/")
+		req, err := http.NewRequestWithContext(ctx, method, baseURL+c.endpointBase+path, bytes.NewReader(body))
 		if err != nil {
 			return nil, fmt.Errorf("create workspace index request: %w", err)
 		}

--- a/agent/internal/workspaceindex/client_test.go
+++ b/agent/internal/workspaceindex/client_test.go
@@ -280,10 +280,56 @@ func TestClientFollowsServerURLProviderAcrossFailover(t *testing.T) {
 	if _, err := client.FetchConfig(context.Background()); err != nil {
 		t.Fatalf("FetchConfig via promoted backup: %v", err)
 	}
+	// Batch upload is the path that actually matters for #2423 (it carries the
+	// crawl payload) and is the one place the base URL is re-resolved per retry
+	// attempt, so assert it follows the promotion too.
+	if err := client.PostBatch(context.Background(), "run-1", "", []Entry{{RelPath: "a"}}); err != nil {
+		t.Fatalf("PostBatch via promoted backup: %v", err)
+	}
 	if got := primaryHits.Load(); got != 1 {
 		t.Fatalf("primary received %d requests, want 1", got)
 	}
-	if got := backupHits.Load(); got != 1 {
-		t.Fatalf("promoted backup received %d requests, want 1 — client still pinned to the old primary (#2423)", got)
+	if got := backupHits.Load(); got != 2 {
+		t.Fatalf("promoted backup received %d requests, want 2 (config + batch) — client still pinned to the old primary (#2423)", got)
+	}
+}
+
+// TestClientFailsFastWithoutServerURL pins that a nil/empty ServerURL provider
+// (a wiring bug) surfaces as ErrNoServerURL immediately, rather than degrading
+// into a scheme-less relative request that fails forever as a cryptic
+// transport error and burns the batch retries.
+func TestClientFailsFastWithoutServerURL(t *testing.T) {
+	var hits atomic.Int32
+	token := secmem.NewSecureString("agent-secret")
+	defer token.Zero()
+	transport := handlerRoundTripper{handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})}
+
+	for _, tt := range []struct {
+		name     string
+		provider func() string
+	}{
+		{name: "nil provider", provider: nil},
+		{name: "provider returns empty", provider: func() string { return "" }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClient(ClientConfig{
+				ServerURL:  tt.provider,
+				AuthToken:  token,
+				HTTPClient: &http.Client{Transport: transport},
+			})
+			if _, err := client.FetchConfig(context.Background()); !errors.Is(err, ErrNoServerURL) {
+				t.Fatalf("FetchConfig error = %v, want ErrNoServerURL", err)
+			}
+			// PostBatch would otherwise burn its retries on the bad URL.
+			if err := client.PostBatch(context.Background(), "run-1", "", []Entry{{RelPath: "a"}}); !errors.Is(err, ErrNoServerURL) {
+				t.Fatalf("PostBatch error = %v, want ErrNoServerURL", err)
+			}
+			if got := hits.Load(); got != 0 {
+				t.Fatalf("transport received %d requests, want 0 (must fail before dispatch)", got)
+			}
+		})
 	}
 }

--- a/agent/internal/workspaceindex/client_test.go
+++ b/agent/internal/workspaceindex/client_test.go
@@ -51,7 +51,7 @@ func newTestClient(t *testing.T, handler http.Handler) *Client {
 	t.Cleanup(token.Zero)
 
 	return NewClient(ClientConfig{
-		ServerURL:  serverURL,
+		ServerURL:  func() string { return serverURL },
 		AuthToken:  token,
 		HTTPClient: httpClient,
 	})
@@ -198,7 +198,7 @@ func TestRedirectToOtherHostIsRefused(t *testing.T) {
 	token := secmem.NewSecureString("redirect-secret")
 	defer token.Zero()
 	client := NewClient(ClientConfig{
-		ServerURL:  "http://origin.test",
+		ServerURL:  func() string { return "http://origin.test" },
 		AuthToken:  token,
 		HTTPClient: &http.Client{Transport: transport},
 	})
@@ -238,5 +238,52 @@ func TestCredentialRedactsStringAndJSONRepresentations(t *testing.T) {
 				t.Fatalf("representation leaked password: %q", got)
 			}
 		})
+	}
+}
+
+// TestClientFollowsServerURLProviderAcrossFailover pins #2423:
+// ClientConfig.ServerURL is a URL provider (heartbeat.ServerURL in
+// production), so after backup-server-URL promotion (#2323) the SAME client
+// must send subsequent requests to the promoted URL. A copied cfg.ServerURL
+// string kept POSTing batch uploads to the dead primary for the process
+// lifetime.
+func TestClientFollowsServerURLProviderAcrossFailover(t *testing.T) {
+	var primaryHits, backupHits atomic.Int32
+	const configBody = `{"enabled":false,"pollIntervalSeconds":60,"limits":{"maxBatchBytes":0,"maxBatchEntries":0,"walkOpsPerSecond":0},"sources":[]}`
+	transport := hostRoutingTransport{handlers: map[string]http.Handler{
+		"primary.test": http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			primaryHits.Add(1)
+			_, _ = io.WriteString(w, configBody)
+		}),
+		"backup.test": http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			backupHits.Add(1)
+			_, _ = io.WriteString(w, configBody)
+		}),
+	}}
+	token := secmem.NewSecureString("agent-secret")
+	defer token.Zero()
+
+	var serverURL atomic.Value
+	serverURL.Store("http://primary.test")
+	client := NewClient(ClientConfig{
+		ServerURL:  func() string { return serverURL.Load().(string) },
+		AuthToken:  token,
+		HTTPClient: &http.Client{Transport: transport},
+	})
+
+	if _, err := client.FetchConfig(context.Background()); err != nil {
+		t.Fatalf("FetchConfig via primary: %v", err)
+	}
+	// Simulate backup-server-URL promotion: the provider now returns the
+	// promoted URL and the same long-lived client must follow it.
+	serverURL.Store("http://backup.test")
+	if _, err := client.FetchConfig(context.Background()); err != nil {
+		t.Fatalf("FetchConfig via promoted backup: %v", err)
+	}
+	if got := primaryHits.Load(); got != 1 {
+		t.Fatalf("primary received %d requests, want 1", got)
+	}
+	if got := backupHits.Load(); got != 1 {
+		t.Fatalf("promoted backup received %d requests, want 1 — client still pinned to the old primary (#2423)", got)
 	}
 }

--- a/agent/internal/workspaceindex/crawl.go
+++ b/agent/internal/workspaceindex/crawl.go
@@ -51,6 +51,20 @@ func runCrawl(ctx context.Context, deps Deps, src SourceConfig, limits ConfigLim
 	if src.ActiveRun != nil && src.ActiveRun.RunID == run.RunID {
 		resumeCursor = src.ActiveRun.Cursor
 	}
+	// Announce a substituted walk rate. Clamping a crawl from "unlimited" to
+	// 200 ops/s is a large, user-visible slowdown; doing it mutely produces
+	// "crawls got slow after the upgrade" reports that are undiagnosable from
+	// shipped logs (#2425).
+	switch ops := limits.WalkOpsPerSecond; {
+	case ops == walkOpsUnlimited:
+		deps.Log.Info("workspace index walk throttling disabled by explicit server sentinel", "sourceId", src.ID)
+	case ops == 0:
+		deps.Log.Info("workspace index walkOpsPerSecond not set by server; using local default ceiling",
+			"sourceId", src.ID, "defaultOpsPerSecond", defaultWalkOpsPerSecond)
+	case ops < 0:
+		deps.Log.Warn("workspace index walkOpsPerSecond from server is invalid; using local default ceiling",
+			"sourceId", src.ID, "received", ops, "defaultOpsPerSecond", defaultWalkOpsPerSecond)
+	}
 	limiter := crawlRateLimiter(limits.WalkOpsPerSecond)
 	emit := func(entry Entry) error {
 		if err := uploader.Add(ctx, entry); err != nil {

--- a/agent/internal/workspaceindex/crawl.go
+++ b/agent/internal/workspaceindex/crawl.go
@@ -138,9 +138,24 @@ func runCrawl(ctx context.Context, deps Deps, src SourceConfig, limits ConfigLim
 	return nil
 }
 
+const (
+	// defaultWalkOpsPerSecond caps filesystem walk operations when the server
+	// config omits walkOpsPerSecond (the Go zero value on a partially
+	// populated crawl-config response) or sends an invalid value. A missing
+	// field must never silently remove IO throttling on a local/SMB walk
+	// (#2425).
+	defaultWalkOpsPerSecond = 200
+	// walkOpsUnlimited is the explicit server sentinel that disables walk
+	// throttling entirely. Only this exact value runs unthrottled.
+	walkOpsUnlimited = -1
+)
+
 func crawlRateLimiter(opsPerSecond int) *rate.Limiter {
-	if opsPerSecond <= 0 {
+	if opsPerSecond == walkOpsUnlimited {
 		return nil
+	}
+	if opsPerSecond <= 0 {
+		opsPerSecond = defaultWalkOpsPerSecond
 	}
 	return rate.NewLimiter(rate.Limit(opsPerSecond), opsPerSecond)
 }

--- a/agent/internal/workspaceindex/crawl_test.go
+++ b/agent/internal/workspaceindex/crawl_test.go
@@ -14,6 +14,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"golang.org/x/time/rate"
 )
 
 type crawlCompletion struct {
@@ -451,4 +453,39 @@ func TestRunCrawlZeroesCredentialWhenSMBDialPanics(t *testing.T) {
 			panic("dial panic")
 		},
 	}, SourceConfig{ID: "smb-panic", Kind: "smb_share", RootPath: `\\server\share`}, ConfigLimits{})
+}
+
+// TestCrawlRateLimiterDefaultsAndSentinel pins #2425: a zero/missing or
+// invalid walkOpsPerSecond in the server config must fall back to a local
+// throttling ceiling, never silently disable IO throttling. Only the explicit
+// sentinel runs unthrottled.
+func TestCrawlRateLimiterDefaultsAndSentinel(t *testing.T) {
+	tests := []struct {
+		name      string
+		ops       int
+		wantNil   bool
+		wantLimit rate.Limit
+	}{
+		{name: "zero value (field omitted) falls back to default ceiling", ops: 0, wantLimit: defaultWalkOpsPerSecond},
+		{name: "invalid negative falls back to default ceiling", ops: -7, wantLimit: defaultWalkOpsPerSecond},
+		{name: "explicit unlimited sentinel disables throttling", ops: walkOpsUnlimited, wantNil: true},
+		{name: "configured positive rate is honored", ops: 350, wantLimit: 350},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limiter := crawlRateLimiter(tt.ops)
+			if tt.wantNil {
+				if limiter != nil {
+					t.Fatalf("crawlRateLimiter(%d) = %v, want nil (unlimited sentinel)", tt.ops, limiter.Limit())
+				}
+				return
+			}
+			if limiter == nil {
+				t.Fatalf("crawlRateLimiter(%d) = nil (unthrottled), want limiter at %v ops/s (#2425)", tt.ops, tt.wantLimit)
+			}
+			if got := limiter.Limit(); got != tt.wantLimit {
+				t.Fatalf("crawlRateLimiter(%d).Limit() = %v, want %v", tt.ops, got, tt.wantLimit)
+			}
+		})
+	}
 }

--- a/agent/internal/workspaceindex/loop.go
+++ b/agent/internal/workspaceindex/loop.go
@@ -9,11 +9,18 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/breeze-rmm/agent/internal/audit"
 	"github.com/breeze-rmm/agent/internal/logging"
 	"github.com/breeze-rmm/agent/internal/observability"
 )
 
 const moduleAbsentBackoff = 6 * time.Hour
+
+// AuditLogger records device-audit events for privacy-significant module
+// transitions. *audit.Logger satisfies it and is nil-receiver safe.
+type AuditLogger interface {
+	Log(eventType string, commandID string, details map[string]any)
+}
 
 // Deps contains orchestration dependencies and the timing seams used by tests.
 type Deps struct {
@@ -22,6 +29,12 @@ type Deps struct {
 	Enumerate func() []ProfileRoot
 	DialSMB   func(context.Context, string, *Credential) (SourceFS, io.Closer, error)
 	Now       func() time.Time
+
+	// Audit, when set, receives a device-audit event each time server
+	// configuration activates filesystem indexing on this device. Enablement
+	// is server-driven (no local opt-in), so activation must at least leave a
+	// prominent local log + tamper-evident audit trace (#2425).
+	Audit AuditLogger
 
 	TickInterval  time.Duration
 	WatchDebounce time.Duration
@@ -90,6 +103,45 @@ func StartLoop(ctx context.Context, deps Deps) <-chan struct{} {
 		watchers := make(map[string]watchRegistration)
 		var running *activeCrawl
 		var nextFetch time.Time
+		// indexingActive tracks the server-driven activation state so the
+		// consent signal (prominent log + device-audit event, #2425) fires on
+		// each off→on transition rather than on every poll.
+		indexingActive := false
+
+		markIndexingInactive := func(reason string) {
+			if indexingActive {
+				deps.Log.Info("workspace indexing deactivated", "reason", reason)
+				indexingActive = false
+			}
+		}
+		markIndexingActive := func(sources map[string]SourceConfig) {
+			if indexingActive {
+				return
+			}
+			indexingActive = true
+			summaries := make([]map[string]any, 0, len(sources))
+			ids := make([]string, 0, len(sources))
+			for _, src := range sources {
+				summaries = append(summaries, map[string]any{
+					"id":             src.ID,
+					"kind":           src.Kind,
+					"rootPath":       src.RootPath,
+					"cadenceMinutes": src.CadenceMinutes,
+					"watch":          src.Watch,
+				})
+				ids = append(ids, src.ID)
+			}
+			// Enablement is a pure server-side flip with no local opt-in, so
+			// activation must be loud: Warn reaches the shipped agent logs and
+			// the audit entry leaves a local tamper-evident trace (#2425).
+			deps.Log.Warn("workspace indexing ACTIVATED by server configuration — filesystem metadata will be enumerated and uploaded",
+				"sourceCount", len(sources), "sourceIds", ids)
+			if deps.Audit != nil {
+				deps.Audit.Log(audit.EventWorkspaceIndexActivated, "", map[string]any{
+					"sources": summaries,
+				})
+			}
+		}
 
 		stopWatches := func() {
 			for id, watcher := range watchers {
@@ -133,6 +185,7 @@ func StartLoop(ctx context.Context, deps Deps) <-chan struct{} {
 
 		reconcile := func(config *CrawlConfig, now time.Time) {
 			if !config.Enabled {
+				markIndexingInactive("disabled by server configuration")
 				cancelActivity()
 				return
 			}
@@ -142,6 +195,11 @@ func StartLoop(ctx context.Context, deps Deps) <-chan struct{} {
 				if src.CadenceMinutes > 0 {
 					desired[src.ID] = src
 				}
+			}
+			if len(desired) > 0 {
+				markIndexingActive(desired)
+			} else {
+				markIndexingInactive("no active sources")
 			}
 
 			if running != nil {
@@ -199,6 +257,7 @@ func StartLoop(ctx context.Context, deps Deps) <-chan struct{} {
 			config, err := deps.Client.FetchConfig(ctx)
 			if err != nil {
 				if errors.Is(err, ErrModuleAbsent) {
+					markIndexingInactive("workspace module absent on server")
 					cancelActivity()
 					nextFetch = now.Add(moduleAbsentBackoff)
 					return

--- a/agent/internal/workspaceindex/loop.go
+++ b/agent/internal/workspaceindex/loop.go
@@ -3,10 +3,14 @@ package workspaceindex
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"math/rand/v2"
 	"reflect"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/audit"
@@ -15,6 +19,29 @@ import (
 )
 
 const moduleAbsentBackoff = 6 * time.Hour
+
+// indexingScopeSignature reduces the announced source set to a comparable
+// string so the consent signal re-fires when the server changes WHAT is
+// indexed, not only when it toggles indexing on. sources must already be
+// ordered deterministically (by source ID).
+//
+// excludeGlobs is part of the signature: DROPPING an exclusion (e.g. removing
+// `Finance/**`) widens what gets enumerated and uploaded just as surely as
+// adding a source, and must re-announce. cadenceMinutes is deliberately NOT
+// part of it — it changes how often the same scope is walked, not its extent.
+func indexingScopeSignature(sources []SourceConfig) string {
+	if len(sources) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(sources))
+	for _, src := range sources {
+		globs := slices.Clone(src.ExcludeGlobs)
+		slices.Sort(globs)
+		parts = append(parts, fmt.Sprintf("%s|%s|%s|%t|%s",
+			src.ID, src.Kind, src.RootPath, src.Watch, strings.Join(globs, ",")))
+	}
+	return strings.Join(parts, ";")
+}
 
 // AuditLogger records device-audit events for privacy-significant module
 // transitions. *audit.Logger satisfies it and is nil-receiver safe.
@@ -103,42 +130,67 @@ func StartLoop(ctx context.Context, deps Deps) <-chan struct{} {
 		watchers := make(map[string]watchRegistration)
 		var running *activeCrawl
 		var nextFetch time.Time
-		// indexingActive tracks the server-driven activation state so the
-		// consent signal (prominent log + device-audit event, #2425) fires on
-		// each off→on transition rather than on every poll.
-		indexingActive := false
+		// auditedScope is the signature of the source set last announced by the
+		// consent signal (prominent log + device-audit event, #2425). Tracking
+		// the SCOPE rather than a mere on/off bool means a server that widens
+		// indexing while it is already active — adding an SMB share, repointing
+		// a rootPath — re-announces instead of riding the first activation's
+		// trace silently. Empty means indexing is not active.
+		auditedScope := ""
 
 		markIndexingInactive := func(reason string) {
-			if indexingActive {
-				deps.Log.Info("workspace indexing deactivated", "reason", reason)
-				indexingActive = false
+			if auditedScope == "" {
+				return
+			}
+			auditedScope = ""
+			// Deactivation is half of the "when was this device indexed?"
+			// question, so it ships (Warn: the log shipper's MinLevel) and
+			// leaves its own audit entry — an activation trace with no
+			// closing bracket cannot bound the indexing window (#2425).
+			deps.Log.Warn("workspace indexing DEACTIVATED", "reason", reason)
+			if deps.Audit != nil {
+				deps.Audit.Log(audit.EventWorkspaceIndexDeactivated, "", map[string]any{
+					"reason": reason,
+				})
 			}
 		}
 		markIndexingActive := func(sources map[string]SourceConfig) {
-			if indexingActive {
+			ordered := make([]SourceConfig, 0, len(sources))
+			for _, id := range slices.Sorted(maps.Keys(sources)) {
+				ordered = append(ordered, sources[id])
+			}
+			scope := indexingScopeSignature(ordered)
+			if scope == auditedScope {
 				return
 			}
-			indexingActive = true
-			summaries := make([]map[string]any, 0, len(sources))
-			ids := make([]string, 0, len(sources))
-			for _, src := range sources {
+			summaries := make([]map[string]any, 0, len(ordered))
+			ids := make([]string, 0, len(ordered))
+			for _, src := range ordered {
 				summaries = append(summaries, map[string]any{
 					"id":             src.ID,
 					"kind":           src.Kind,
 					"rootPath":       src.RootPath,
 					"cadenceMinutes": src.CadenceMinutes,
 					"watch":          src.Watch,
+					"excludeGlobs":   src.ExcludeGlobs,
 				})
 				ids = append(ids, src.ID)
 			}
+			widened := auditedScope != ""
+			auditedScope = scope
+
 			// Enablement is a pure server-side flip with no local opt-in, so
 			// activation must be loud: Warn reaches the shipped agent logs and
 			// the audit entry leaves a local tamper-evident trace (#2425).
-			deps.Log.Warn("workspace indexing ACTIVATED by server configuration — filesystem metadata will be enumerated and uploaded",
-				"sourceCount", len(sources), "sourceIds", ids)
+			message := "workspace indexing ACTIVATED by server configuration — filesystem metadata will be enumerated and uploaded"
+			if widened {
+				message = "workspace indexing SCOPE CHANGED by server configuration — a different set of filesystem locations will be enumerated and uploaded"
+			}
+			deps.Log.Warn(message, "sourceCount", len(sources), "sourceIds", ids)
 			if deps.Audit != nil {
 				deps.Audit.Log(audit.EventWorkspaceIndexActivated, "", map[string]any{
-					"sources": summaries,
+					"sources":     summaries,
+					"scopeChange": widened,
 				})
 			}
 		}

--- a/agent/internal/workspaceindex/loop_test.go
+++ b/agent/internal/workspaceindex/loop_test.go
@@ -522,28 +522,20 @@ func TestStartLoopAuditsActivationTransitions(t *testing.T) {
 		TickInterval: 5 * time.Millisecond,
 	})
 
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		types, _ := audit.snapshot()
-		if len(types) >= 2 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for 2 activation audit events, got %d (%v)", len(types), types)
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	// Expected trail: activated (fetch 1), deactivated (fetch 3), activated
+	// (fetch 4). Fetch 2 repeats the identical scope and must NOT duplicate.
+	waitForAuditEvents(t, audit, 3)
 	cancel()
 	<-done
 
 	types, details := audit.snapshot()
-	if len(types) != 2 {
-		t.Fatalf("audit events = %v, want exactly 2 activation transitions (no per-poll duplicates)", types)
+	wantTypes := []string{
+		"workspace_index_activated",
+		"workspace_index_deactivated",
+		"workspace_index_activated",
 	}
-	for i, eventType := range types {
-		if eventType != "workspace_index_activated" {
-			t.Fatalf("audit event %d type = %q, want workspace_index_activated", i, eventType)
-		}
+	if !reflect.DeepEqual(types, wantTypes) {
+		t.Fatalf("audit events = %v, want %v (transitions only, no per-poll duplicates)", types, wantTypes)
 	}
 	sources, ok := details[0]["sources"].([]map[string]any)
 	if !ok || len(sources) != 1 {
@@ -551,5 +543,93 @@ func TestStartLoopAuditsActivationTransitions(t *testing.T) {
 	}
 	if sources[0]["id"] != "source-docs" || sources[0]["rootPath"] != "/home" || sources[0]["kind"] != "local_profile" {
 		t.Fatalf("source summary = %#v", sources[0])
+	}
+	if details[0]["scopeChange"] != false {
+		t.Fatalf("first activation scopeChange = %v, want false", details[0]["scopeChange"])
+	}
+	if details[1]["reason"] == "" || details[1]["reason"] == nil {
+		t.Fatalf("deactivation details = %#v, want a reason", details[1])
+	}
+}
+
+// TestStartLoopAuditsScopeWideningWhileActive pins the harder half of #2425:
+// the consent trace must also fire when the server WIDENS indexing while it is
+// already active (adds a source / repoints a rootPath). A plain on/off latch
+// would let the new location be enumerated under the first activation's trace,
+// silently — which is the most privacy-significant case.
+func TestStartLoopAuditsScopeWideningWhileActive(t *testing.T) {
+	farFuture := time.Now().Add(100_000 * time.Hour)
+	var reqCount atomic.Int32
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/workspace/agent/crawl-config" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		docs := SourceConfig{
+			ID: "source-docs", Kind: "local_profile", RootPath: "/home",
+			CadenceMinutes: 60, LastCompleteRunAt: &farFuture,
+		}
+		config := CrawlConfig{Enabled: true, PollIntervalSeconds: 1, Sources: []SourceConfig{docs}}
+		// From the 3rd fetch on, the server also indexes an SMB share —
+		// indexing never went inactive, so a boolean latch would say nothing.
+		if reqCount.Add(1) >= 3 {
+			config.Sources = append(config.Sources, SourceConfig{
+				ID: "source-share", Kind: "smb_share", RootPath: `\\fileserver\finance`,
+				CadenceMinutes: 60, LastCompleteRunAt: &farFuture,
+			})
+		}
+		writeLoopConfig(t, w, config)
+	}))
+
+	base := time.Now()
+	var step atomic.Int64
+	audit := &recordingAuditLogger{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := StartLoop(ctx, Deps{
+		Client:       client,
+		Log:          loopTestLogger(),
+		Audit:        audit,
+		Now:          func() time.Time { return base.Add(time.Duration(step.Add(1)) * time.Hour) },
+		TickInterval: 5 * time.Millisecond,
+	})
+
+	waitForAuditEvents(t, audit, 2)
+	cancel()
+	<-done
+
+	types, details := audit.snapshot()
+	if len(types) != 2 || types[0] != "workspace_index_activated" || types[1] != "workspace_index_activated" {
+		t.Fatalf("audit events = %v, want exactly 2 activation events (initial + scope widening)", types)
+	}
+	if details[0]["scopeChange"] != false {
+		t.Fatalf("initial activation scopeChange = %v, want false", details[0]["scopeChange"])
+	}
+	if details[1]["scopeChange"] != true {
+		t.Fatalf("widening event scopeChange = %v, want true", details[1]["scopeChange"])
+	}
+	sources, ok := details[1]["sources"].([]map[string]any)
+	if !ok || len(sources) != 2 {
+		t.Fatalf("widening details = %#v, want two source summaries", details[1])
+	}
+	// Summaries are ordered by source ID: source-docs, source-share.
+	if sources[1]["id"] != "source-share" || sources[1]["rootPath"] != `\\fileserver\finance` {
+		t.Fatalf("newly added source summary = %#v, want the SMB share named", sources[1])
+	}
+}
+
+func waitForAuditEvents(t *testing.T, audit *recordingAuditLogger, count int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		types, _ := audit.snapshot()
+		if len(types) >= count {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d audit events, got %d (%v)", count, len(types), types)
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }

--- a/agent/internal/workspaceindex/loop_test.go
+++ b/agent/internal/workspaceindex/loop_test.go
@@ -457,3 +457,99 @@ func waitLoopCondition(t *testing.T, condition func() bool, description string) 
 		time.Sleep(time.Millisecond)
 	}
 }
+
+type recordingAuditLogger struct {
+	mu      sync.Mutex
+	types   []string
+	details []map[string]any
+}
+
+func (r *recordingAuditLogger) Log(eventType string, _ string, details map[string]any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.types = append(r.types, eventType)
+	r.details = append(r.details, details)
+}
+
+func (r *recordingAuditLogger) snapshot() ([]string, []map[string]any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.types...), append([]map[string]any(nil), r.details...)
+}
+
+// TestStartLoopAuditsActivationTransitions pins #2425: workspace indexing is
+// enabled purely by a server-side config flip, so each off→on transition must
+// emit a device-audit event (and only transitions — not every poll).
+func TestStartLoopAuditsActivationTransitions(t *testing.T) {
+	// Far-future completion keeps every source not-due so no crawl machinery
+	// runs; activation is keyed on enabled sources, not on crawls starting.
+	farFuture := time.Now().Add(100_000 * time.Hour)
+	var reqCount atomic.Int32
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/workspace/agent/crawl-config" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// Fetch 1-2: enabled (one activation event, no duplicate).
+		// Fetch 3: disabled (deactivation). Fetch 4+: enabled again (second event).
+		n := reqCount.Add(1)
+		config := CrawlConfig{Enabled: n != 3, PollIntervalSeconds: 1}
+		if config.Enabled {
+			config.Sources = []SourceConfig{{
+				ID:                "source-docs",
+				Kind:              "local_profile",
+				RootPath:          "/home",
+				CadenceMinutes:    60,
+				LastCompleteRunAt: &farFuture,
+			}}
+		}
+		writeLoopConfig(t, w, config)
+	}))
+
+	// Fake clock: each fetch attempt observes time advanced far past the poll
+	// interval, so every ticker tick performs a real fetch.
+	base := time.Now()
+	var step atomic.Int64
+	audit := &recordingAuditLogger{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := StartLoop(ctx, Deps{
+		Client:       client,
+		Log:          loopTestLogger(),
+		Audit:        audit,
+		Now:          func() time.Time { return base.Add(time.Duration(step.Add(1)) * time.Hour) },
+		TickInterval: 5 * time.Millisecond,
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		types, _ := audit.snapshot()
+		if len(types) >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for 2 activation audit events, got %d (%v)", len(types), types)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	types, details := audit.snapshot()
+	if len(types) != 2 {
+		t.Fatalf("audit events = %v, want exactly 2 activation transitions (no per-poll duplicates)", types)
+	}
+	for i, eventType := range types {
+		if eventType != "workspace_index_activated" {
+			t.Fatalf("audit event %d type = %q, want workspace_index_activated", i, eventType)
+		}
+	}
+	sources, ok := details[0]["sources"].([]map[string]any)
+	if !ok || len(sources) != 1 {
+		t.Fatalf("first activation details = %#v, want one source summary", details[0])
+	}
+	if sources[0]["id"] != "source-docs" || sources[0]["rootPath"] != "/home" || sources[0]["kind"] != "local_profile" {
+		t.Fatalf("source summary = %#v", sources[0])
+	}
+}

--- a/agent/internal/workspaceindex/walker.go
+++ b/agent/internal/workspaceindex/walker.go
@@ -75,7 +75,7 @@ func Walk(
 				relPath = path.Join(parentRelPath, child.Name())
 			}
 			isDir := child.IsDir()
-			if excludedWalkPath(relPath, isDir, excludeGlobs) {
+			if excludedWalkPath(relPath, excludeGlobs) {
 				continue
 			}
 
@@ -165,12 +165,14 @@ func compareWalkPaths(left, right string) int {
 	return len(leftSegments) - len(rightSegments)
 }
 
-func excludedWalkPath(relPath string, isDir bool, globs []string) bool {
-	if isDir {
-		for _, segment := range strings.Split(relPath, "/") {
-			if strings.HasPrefix(segment, ".") {
-				return true
-			}
+// excludedWalkPath reports whether relPath is excluded from indexing. The
+// dot-prefix rule applies to every path segment — files as well as
+// directories. Indexing hidden files (.env, .npmrc, .pgpass directly inside a
+// root) while skipping hidden directories was a privacy hole (#2425).
+func excludedWalkPath(relPath string, globs []string) bool {
+	for _, segment := range strings.Split(relPath, "/") {
+		if strings.HasPrefix(segment, ".") {
+			return true
 		}
 	}
 	for _, pattern := range globs {

--- a/agent/internal/workspaceindex/walker_test.go
+++ b/agent/internal/workspaceindex/walker_test.go
@@ -146,10 +146,11 @@ func TestWalkDeterministicDepthFirstOrderingAndMetadata(t *testing.T) {
 		"alpha/beta/.config": {size: 3},
 		"skip-link":          {mode: fs.ModeSymlink},
 	}
+	// alpha/beta/.config is a hidden FILE: the dot-prefix exclusion applies to
+	// files as well as directories (#2425), so it must not be emitted.
 	wantPaths := []string{
 		"alpha",
 		"alpha/beta",
-		"alpha/beta/.config",
 		"alpha/beta/noext",
 		"alpha/report.TXT",
 		"zeta.txt",
@@ -186,9 +187,9 @@ func TestWalkDeterministicDepthFirstOrderingAndMetadata(t *testing.T) {
 		t.Fatalf("nested directory entry = %+v", got)
 	}
 	if got := first[2]; got.Ext != nil {
-		t.Fatalf("dotfile extension = %q, want nil", *got.Ext)
+		t.Fatalf("extensionless file extension = %q, want nil", *got.Ext)
 	}
-	if got := first[4]; got.Ext == nil || *got.Ext != "txt" || got.Size != 42 || !got.Mtime.Equal(walkerTestTime) {
+	if got := first[3]; got.Ext == nil || *got.Ext != "txt" || got.Size != 42 || !got.Mtime.Equal(walkerTestTime) {
 		t.Fatalf("file metadata = %+v", got)
 	}
 }
@@ -207,6 +208,8 @@ func TestWalkExcludesBuiltInsAndCustomGlobs(t *testing.T) {
 		"Users/me/keep.txt":                   {size: 1},
 		".hidden":                             {dir: true},
 		".hidden/secret.txt":                  {size: 1},
+		".env":                                {size: 1},
+		"Users/me/.npmrc":                     {size: 1},
 		"scratch.tmp":                         {size: 1},
 		"logs":                                {dir: true},
 		"logs/2026":                           {dir: true},

--- a/agent/internal/workspaceindex/watch.go
+++ b/agent/internal/workspaceindex/watch.go
@@ -154,7 +154,7 @@ func startWatch(ctx context.Context, deps Deps, src SourceConfig) (stop func()) 
 			}
 			rootRelPath = filepath.ToSlash(rootRelPath)
 			if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
-				if watchPathExcluded(rootRelPath, nil, watchGlobs) {
+				if excludedWalkPath(rootRelPath, watchGlobs) {
 					return true
 				}
 				pending[relPath] = pendingWatchEvent{delete: true}
@@ -168,7 +168,7 @@ func startWatch(ctx context.Context, deps Deps, src SourceConfig) (stop func()) 
 			info, statErr := os.Lstat(event.Name)
 			if statErr != nil {
 				if os.IsNotExist(statErr) {
-					if !watchPathExcluded(rootRelPath, nil, watchGlobs) {
+					if !excludedWalkPath(rootRelPath, watchGlobs) {
 						pending[relPath] = pendingWatchEvent{delete: true}
 						resetTimer()
 					}
@@ -178,8 +178,7 @@ func startWatch(ctx context.Context, deps Deps, src SourceConfig) (stop func()) 
 			if info.Mode()&os.ModeSymlink != 0 {
 				return true
 			}
-			isDir := info.IsDir()
-			if watchPathExcluded(rootRelPath, &isDir, watchGlobs) {
+			if excludedWalkPath(rootRelPath, watchGlobs) {
 				return true
 			}
 			if info.IsDir() && event.Op&fsnotify.Create != 0 {
@@ -248,13 +247,6 @@ func startWatch(ctx context.Context, deps Deps, src SourceConfig) (stop func()) 
 	}
 }
 
-func watchPathExcluded(relPath string, isDir *bool, globs []string) bool {
-	if isDir != nil {
-		return excludedWalkPath(relPath, *isDir, globs)
-	}
-	return excludedWalkPath(relPath, false, globs) || excludedWalkPath(relPath, true, globs)
-}
-
 func addWatchTree(
 	ctx context.Context,
 	watcher *fsnotify.Watcher,
@@ -285,7 +277,7 @@ func addWatchTree(
 		if err != nil {
 			return err
 		}
-		if rel != "." && excludedWalkPath(filepath.ToSlash(rel), true, globs) {
+		if rel != "." && excludedWalkPath(filepath.ToSlash(rel), globs) {
 			return filepath.SkipDir
 		}
 		current = filepath.Clean(current)

--- a/agent/internal/workspaceindex/watch_test.go
+++ b/agent/internal/workspaceindex/watch_test.go
@@ -7,7 +7,9 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -18,7 +20,7 @@ type watchEventsPayload struct {
 	Deletes []string `json:"deletes"`
 }
 
-func TestWatchPathExcludedForUnknownDeleteType(t *testing.T) {
+func TestExcludedWalkPathHelperCoversHiddenAndGlobbedPaths(t *testing.T) {
 	globs := append(append([]string(nil), defaultExcludeGlobs...), "ignored/**")
 	tests := []struct {
 		path string
@@ -192,5 +194,78 @@ func TestStartWatchExcludedDirectoriesDoNotConsumeCap(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("excluded directory consumed watch cap and degraded watcher")
+	}
+}
+
+// TestStartWatchExcludesHiddenFilesFromUpserts drives the real fsnotify handler
+// to pin the #2425 privacy hole at the exact place it bit: the create/write
+// branch, where isDir is known. The old watch.go called the exclusion helper
+// with isDir=false for a hidden FILE, which skipped the dot-segment check
+// entirely, so .env — matched by none of the default globs — was uploaded via
+// PostEvents. A helper-level unit test cannot catch a re-introduced isDir gate
+// at this call site; only driving the watcher can.
+func TestStartWatchExcludesHiddenFilesFromUpserts(t *testing.T) {
+	const debounce = 250 * time.Millisecond
+	profileDir := filepath.Join(t.TempDir(), "alice")
+	documentsDir := filepath.Join(profileDir, "Documents")
+	if err := os.MkdirAll(documentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	payloads := make(chan watchEventsPayload, 4)
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/workspace/agent/sources/source-watch/events" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var payload watchEventsPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		payloads <- payload
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stop := startWatch(ctx, Deps{
+		Client:        client,
+		Log:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Enumerate:     func() []ProfileRoot { return []ProfileRoot{{Username: "alice", Dir: profileDir}} },
+		WatchDebounce: debounce,
+		WatchDirCap:   16,
+	}, SourceConfig{ID: "source-watch", Kind: "local_profile", Watch: true})
+	defer stop()
+
+	// Credential-bearing dotfiles, none of which any default glob matches.
+	for _, hidden := range []string{".env", ".npmrc", ".pgpass"} {
+		if err := os.WriteFile(filepath.Join(documentsDir, hidden), []byte("SECRET=1"), 0o600); err != nil {
+			t.Fatalf("create %s: %v", hidden, err)
+		}
+	}
+	// A visible file guarantees the watcher really is delivering events — without
+	// it, an exclusion assertion would pass vacuously on a dead watcher.
+	if err := os.WriteFile(filepath.Join(documentsDir, "visible.txt"), []byte("ok"), 0o600); err != nil {
+		t.Fatalf("create visible file: %v", err)
+	}
+
+	var payload watchEventsPayload
+	select {
+	case payload = <-payloads:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for debounced events request")
+	}
+
+	if len(payload.Upserts) != 1 {
+		t.Fatalf("upserts = %+v, want only the visible file (hidden files must not be indexed)", payload.Upserts)
+	}
+	if got := payload.Upserts[0].RelPath; got != "alice/Documents/visible.txt" {
+		t.Fatalf("upsert relPath = %q, want alice/Documents/visible.txt", got)
+	}
+	for _, upsert := range payload.Upserts {
+		if strings.HasPrefix(path.Base(upsert.RelPath), ".") {
+			t.Fatalf("hidden file %q was indexed and uploaded (#2425)", upsert.RelPath)
+		}
 	}
 }

--- a/agent/internal/workspaceindex/watch_test.go
+++ b/agent/internal/workspaceindex/watch_test.go
@@ -30,8 +30,8 @@ func TestWatchPathExcludedForUnknownDeleteType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
-			if got := watchPathExcluded(tt.path, nil, globs); got != tt.want {
-				t.Fatalf("watchPathExcluded(%q) = %v, want %v", tt.path, got, tt.want)
+			if got := excludedWalkPath(tt.path, globs); got != tt.want {
+				t.Fatalf("excludedWalkPath(%q) = %v, want %v", tt.path, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Two related agent fixes from the pre-v0.95.0 review, combined because they overlap in `agent/internal/agentapp/main.go` and `agent/internal/workspaceindex/`.

### Failover URL provider (#2423)

The UniFi telemetry collector (`agentapp/main.go:743`) and the workspace-index client (`:760`) copied `cfg.ServerURL` by value once at startup, so after a backup-server-URL promotion (#2323) they kept POSTing to the dead primary until process restart.

- `heartbeat.ServerURL` — new exported getter over the mutex-guarded `serverURL()`, documented as the mandatory read path for long-lived client loops.
- `unifi.CollectorDeps.APIBaseURL` and `workspaceindex.ClientConfig.ServerURL` are now `func() string` providers, resolved per request; agentapp wires `hb.ServerURL` into both. The type change (rather than a second optional field) makes the copied-string mistake unrepresentable at call sites.
- Promotion visibility pinned by tests in all three packages: `TestPromotionVisibleThroughServerURLProvider` (heartbeat), `TestFetchConfigsFollowsAPIBaseURLProviderAcrossFailover` (unifi), `TestClientFollowsServerURLProviderAcrossFailover` (workspaceindex).

### workspaceindex hardening (#2425, items 1-3)

1. **Rate-limiter zero-value bypass** — `crawlRateLimiter` returned `nil` (unthrottled) on `WalkOpsPerSecond <= 0`, which is also the Go zero value when the server omits the field. It now falls back to a 200 ops/s local ceiling; only the explicit `-1` sentinel disables throttling.
2. **Hidden files indexed** — the dot-prefix exclusion only ran for directories, so `.env`/`.npmrc`/`.pgpass` directly inside a root were indexed and shipped while `.ssh/` was skipped. The rule now applies to every path segment, files included (walker + watch paths; redundant `watchPathExcluded` wrapper removed).
3. **Server-flip enablement signal** — indexing activates purely on a server config flip with no local opt-in. Each off→on transition now emits a prominent `Warn` log (visible to the log shipper) plus a tamper-evident device-audit event (`workspace_index_activated`, registered as a critical/fsync event) with per-source id/kind/rootPath/cadence/watch details. Transitions only — no per-poll duplicates (pinned by `TestStartLoopAuditsActivationTransitions`). I took the issue's "at minimum" option; a local default-off opt-in would be a rollout-breaking product decision and can still be layered on later.

Item 4 of #2425 (API-side tenant scoping of `/api/v1/workspace/agent/*` in the private extension repo) is **out of scope** for this PR and remains open.

## Verification

- `cd agent && go test -race ./internal/workspaceindex/... ./internal/unifi/... ./internal/heartbeat/... ./internal/agentapp/... ./internal/audit/...` — all pass.
- `go build ./...` + `go vet` on touched packages clean; new code is gofmt-clean (pre-existing gofmt drift in three heartbeat test files on main left untouched).

Closes #2423
Refs #2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)