### PR TITLE
fix(web): hash-in-useState hydration sweep — 23 components to useHashState + AST guard test (#2421 Phase 2)

### DIFF
--- a/apps/web/src/components/auditBaselines/AuditBaselinesPage.tsx
+++ b/apps/web/src/components/auditBaselines/AuditBaselinesPage.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
 import { BarChart3, ListChecks, ShieldCheck } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useHashTab } from '@/lib/useHashState';
 import ComplianceDashboard from './ComplianceDashboard';
 import BaselineList from './BaselineList';
 import BaselineApplyTab from './BaselineApplyTab';
@@ -15,24 +15,12 @@ const tabs = [
 
 type TabId = (typeof tabs)[number]['id'];
 
+const TAB_IDS = tabs.map((tab) => tab.id);
+
 export default function AuditBaselinesPage() {
   const { t } = useTranslation('security');
-  const [activeTab, setActiveTab] = useState<TabId>(() => {
-    if (typeof window !== 'undefined') {
-      const hash = window.location.hash.replace('#', '') as TabId;
-      if (tabs.some((t) => t.id === hash)) return hash;
-    }
-    return 'dashboard';
-  });
-
-  useEffect(() => {
-    const onHashChange = () => {
-      const hash = window.location.hash.replace('#', '') as TabId;
-      if (tabs.some((t) => t.id === hash)) setActiveTab(hash);
-    };
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, []);
+  // SSR-safe hash tab (#2421): starts at the default, adopts the hash post-mount.
+  const [activeTab, setActiveTab] = useHashTab<TabId>(TAB_IDS, 'dashboard');
 
   const handleTabChange = (id: TabId) => {
     setActiveTab(id);

--- a/apps/web/src/components/auth/AuthPage.tsx
+++ b/apps/web/src/components/auth/AuthPage.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import LoginPage from './LoginPage';
 import PartnerRegisterPage from './PartnerRegisterPage';
 import { useRegistrationGate } from '../../stores/featuresStore';
+import { useHashState } from '@/lib/useHashState';
 // Initializes the shared i18next singleton. This page's layout has no Sidebar
 // (which is what pulls i18n in elsewhere), so without this every t() call here
 // renders its raw key.
@@ -14,14 +14,11 @@ interface AuthPageProps {
 
 type Tab = 'signin' | 'signup';
 
-function getInitialTab(): Tab {
-  if (typeof window === 'undefined') return 'signin';
-  return window.location.hash === '#signup' ? 'signup' : 'signin';
-}
-
 export default function AuthPage({ next }: AuthPageProps) {
   const { t } = useTranslation('auth');
-  const [tab, setTab] = useState<Tab>(getInitialTab);
+  // SSR-safe hash tab (#2421): starts at signin, adopts the hash post-mount.
+  // Any hash other than #signup (including #signin) falls back to signin.
+  const [tab, setTab] = useHashState<Tab>('signin', (h) => (h === 'signup' ? 'signup' : undefined));
 
   // Runtime registration gate (#1308 / #1979). The server enforces
   // ENABLE_REGISTRATION on /auth/register-partner; mirror it client-side so the
@@ -29,14 +26,6 @@ export default function AuthPage({ next }: AuthPageProps) {
   // disabled. The gate is read from runtime /config, the same source of truth
   // PartnerRegisterPage and LoginForm consult — not a build-time PUBLIC_ flag.
   const { enabled: registrationEnabled, loaded: gateLoaded } = useRegistrationGate();
-
-  useEffect(() => {
-    const onHashChange = () => {
-      setTab(window.location.hash === '#signup' ? 'signup' : 'signin');
-    };
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, []);
 
   const handleTabChange = (newTab: Tab) => {
     window.location.hash = newTab;

--- a/apps/web/src/components/backup/BackupDashboard.tsx
+++ b/apps/web/src/components/backup/BackupDashboard.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CheckCircle2, Database, HardDrive, ShieldAlert } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useHashState } from '@/lib/useHashState';
 import { fetchWithAuth } from '../../stores/auth';
 import BackupOverviewContent from './BackupOverviewContent';
 import BackupVerificationOverview from './BackupVerificationOverview';
@@ -63,11 +64,8 @@ function TabFallback() {
 
 export default function BackupDashboard() {
   const { t } = useTranslation('backup');
-  const [activeTab, setActiveTab] = useState<BackupTab>(() => {
-    if (typeof window === 'undefined') return 'overview';
-    const hash = window.location.hash.replace('#', '');
-    return isValidTab(hash) ? hash : 'overview';
-  });
+  // SSR-safe hash tab (#2421): starts at the default, adopts the hash post-mount.
+  const [activeTab, setActiveTab] = useHashState<BackupTab>('overview', (h) => (isValidTab(h) ? h : undefined));
   const [stats, setStats] = useState<BackupStat[]>([]);
   const [recentJobs, setRecentJobs] = useState<BackupJob[]>([]);
   const [overdueDevices, setOverdueDevices] = useState<OverdueDevice[]>([]);
@@ -176,15 +174,6 @@ export default function BackupDashboard() {
   useEffect(() => {
     fetchOverview();
   }, [fetchOverview]);
-
-  useEffect(() => {
-    const onHashChange = () => {
-      const hash = window.location.hash.replace('#', '');
-      setActiveTab(isValidTab(hash) ? hash : 'overview');
-    };
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, []);
 
   const handleRunAllClick = useCallback(async () => {
     try {

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -209,6 +209,57 @@ describe('InvoicesPage', () => {
     expect(screen.getByTestId('invoices-filters-clear')).toBeInTheDocument();
   });
 
+  // #2421: useHashState starts at the SSR-safe default and adopts the hash
+  // post-mount, so a deep-linked load fires TWO list requests — the unfiltered
+  // seed and the filtered one. Without loadInvoices' fetchSeq guard, a slow seed
+  // response landing last repaints the grid with ALL invoices while the Status
+  // control still reads "overdue" — the wrong list under a filtered header.
+  it('deep-linked filter wins when the unfiltered seed response resolves last', async () => {
+    let releaseSeed!: () => void;
+    const seedGate = new Promise<void>((resolve) => { releaseSeed = resolve; });
+
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });
+      if (input.startsWith('/invoices')) {
+        // The seed request carries no status param — hold it open, and have it
+        // return the FULL list so a stale win would be unmistakable.
+        if (!input.includes('status=')) {
+          await seedGate;
+          return json({ data: INVOICES });
+        }
+        return json({ data: INVOICES.filter((i) => i.status === 'overdue') });
+      }
+      return json({}, false, 404);
+    });
+
+    window.location.hash = '#status=overdue';
+    render(<InvoicesPage />);
+
+    // The filtered response lands first and paints only the overdue invoice.
+    await screen.findByTestId('invoices-row-inv-1');
+    expect(screen.queryByTestId('invoices-row-inv-2')).not.toBeInTheDocument();
+
+    // Now let the stale seed response resolve — it must be dropped.
+    releaseSeed();
+    await waitFor(() => expect(screen.getByTestId('invoices-table')).toBeInTheDocument());
+    expect(screen.queryByTestId('invoices-row-inv-2')).not.toBeInTheDocument();
+    expect(screen.getByTestId('invoices-row-inv-1')).toBeInTheDocument();
+    // ...and the late response must not strand the page in a loading state.
+    expect(screen.getByTestId('invoices-filter-status')).toHaveValue('overdue');
+  });
+
+  // The `(h) => (h ? readFilters(h) : undefined)` parse is what keeps the
+  // EMPTY_FILTERS *reference* on the no-hash path. A bare `readFilters` returns
+  // a fresh object, whose new identity retriggers the load effect on every mount.
+  it('fetches the list exactly once when there is no hash', async () => {
+    wireDefault();
+    render(<InvoicesPage />);
+    await waitFor(() => expect(screen.getByTestId('invoices-table')).toBeInTheDocument());
+
+    const listCalls = fetchMock.mock.calls.filter(([input]) => String(input).startsWith('/invoices'));
+    expect(listCalls).toHaveLength(1);
+  });
+
   it('shows a Clear control once a filter is active and resets all filters', async () => {
     wireDefault();
     render(<InvoicesPage />);

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -241,10 +241,12 @@ describe('InvoicesPage', () => {
 
     // Now let the stale seed response resolve — it must be dropped.
     releaseSeed();
+    // The table (not a spinner) is still rendered — the late response neither
+    // repaints the rows nor strands the page in a loading state...
     await waitFor(() => expect(screen.getByTestId('invoices-table')).toBeInTheDocument());
     expect(screen.queryByTestId('invoices-row-inv-2')).not.toBeInTheDocument();
     expect(screen.getByTestId('invoices-row-inv-1')).toBeInTheDocument();
-    // ...and the late response must not strand the page in a loading state.
+    // ...and the list still agrees with the filter control.
     expect(screen.getByTestId('invoices-filter-status')).toHaveValue('overdue');
   });
 

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '../../lib/i18n';
 import { fetchWithAuth } from '../../stores/auth';
@@ -96,9 +96,13 @@ export function InvoicesPage() {
   // so it renders the access-denied state rather than the retryable error.
   const [forbidden, setForbidden] = useState(false);
   // SSR-safe hash adoption + hashchange subscription live in the hook (#2421).
-  const [filters, setFilters] = useHashState<Filters>(EMPTY_FILTERS, readFilters);
+  // An empty hash parses to undefined (not a fresh EMPTY_FILTERS object) so the
+  // no-deep-link case keeps the default reference and never refetches.
+  const [filters, setFilters] = useHashState<Filters>(EMPTY_FILTERS, (h) => (h ? readFilters(h) : undefined));
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<Sort | null>(null);
+  // Monotonic id of the newest in-flight list request (see loadInvoices).
+  const fetchSeq = useRef(0);
 
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [bulkBusy, setBulkBusy] = useState(false);
@@ -131,6 +135,11 @@ export function InvoicesPage() {
   }, [t]);
 
   const loadInvoices = useCallback(async (f: Filters) => {
+    // Latest-request-wins. A deep-linked load (`/invoices#status=paid`) fires
+    // this twice — once with the SSR-safe default filters, then again once
+    // useHashState adopts the hash (#2421) — and the unfiltered query can
+    // resolve last, painting the wrong list. Drop every response but the newest.
+    const seq = ++fetchSeq.current;
     try {
       setLoading(true);
       setError(undefined);
@@ -142,15 +151,18 @@ export function InvoicesPage() {
       if (f.to) params.set('to', f.to);
       const qs = params.toString();
       const res = await fetchWithAuth(`/invoices${qs ? `?${qs}` : ''}`);
+      if (seq !== fetchSeq.current) return;
       if (res.status === 401) return UNAUTHORIZED();
       if (res.status === 403) { setForbidden(true); return; }
       if (!res.ok) throw new Error(t('invoicesPage.errors.loadInvoices'));
       const body = (await res.json()) as { data: InvoiceSummary[] };
+      if (seq !== fetchSeq.current) return;
       setInvoices(body.data ?? []);
     } catch (err) {
+      if (seq !== fetchSeq.current) return;
       setError(err instanceof Error ? err.message : t('invoicesPage.errors.loadInvoices'));
     } finally {
-      setLoading(false);
+      if (seq === fetchSeq.current) setLoading(false);
     }
   }, [t]);
 

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -4,6 +4,7 @@ import '../../lib/i18n';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError, ActionError } from '../../lib/runAction';
+import { useHashState } from '@/lib/useHashState';
 import { usePermissions } from '../../lib/permissions';
 import { Dialog } from '../shared/Dialog';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
@@ -49,9 +50,9 @@ interface Filters {
 }
 const EMPTY_FILTERS: Filters = { orgId: '', status: '', from: '', to: '' };
 
-function readFilters(): Filters {
-  if (typeof window === 'undefined') return EMPTY_FILTERS;
-  const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+// Pure: takes the raw hash (leading `#` already stripped by useHashState, #2421).
+function readFilters(hash: string): Filters {
+  const params = new URLSearchParams(hash);
   const status = params.get('status') ?? '';
   return {
     orgId: params.get('orgId') ?? '',
@@ -94,7 +95,8 @@ export function InvoicesPage() {
   // A 403 from the invoices route is a permission denial, not a load failure,
   // so it renders the access-denied state rather than the retryable error.
   const [forbidden, setForbidden] = useState(false);
-  const [filters, setFilters] = useState<Filters>(() => readFilters());
+  // SSR-safe hash adoption + hashchange subscription live in the hook (#2421).
+  const [filters, setFilters] = useHashState<Filters>(EMPTY_FILTERS, readFilters);
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<Sort | null>(null);
 
@@ -154,13 +156,6 @@ export function InvoicesPage() {
 
   useEffect(() => { void loadOrgs(); }, [loadOrgs]);
   useEffect(() => { void loadInvoices(filters); }, [loadInvoices, filters]);
-
-  // React to back/forward hash changes.
-  useEffect(() => {
-    const onHash = () => setFilters(readFilters());
-    window.addEventListener('hashchange', onHash);
-    return () => window.removeEventListener('hashchange', onHash);
-  }, []);
 
   // Clear bulk selection whenever the server-side filters or client-side search
   // change so stale invisible rows are never acted on.

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '../../../lib/i18n';
 import { fetchWithAuth } from '../../../stores/auth';
@@ -100,9 +100,13 @@ export function QuotesPage() {
   // renders the access-denied state rather than the retryable error.
   const [forbidden, setForbidden] = useState(false);
   // SSR-safe hash adoption + hashchange subscription live in the hook (#2421).
-  const [filters, setFilters] = useHashState<Filters>(EMPTY_FILTERS, readFilters);
+  // An empty hash parses to undefined (not a fresh EMPTY_FILTERS object) so the
+  // no-deep-link case keeps the default reference and never refetches.
+  const [filters, setFilters] = useHashState<Filters>(EMPTY_FILTERS, (h) => (h ? readFilters(h) : undefined));
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<Sort | null>(null);
+  // Monotonic id of the newest in-flight list request (see loadQuotes).
+  const fetchSeq = useRef(0);
 
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [sendOpen, setSendOpen] = useState(false);
@@ -130,20 +134,28 @@ export function QuotesPage() {
   }, [t]);
 
   const loadQuotes = useCallback(async (f: Filters) => {
+    // Latest-request-wins. A deep-linked load (`/quotes#status=sent`) fires this
+    // twice — once with the SSR-safe default filters, then again once
+    // useHashState adopts the hash (#2421) — and the unfiltered query can
+    // resolve last, painting the wrong list. Drop every response but the newest.
+    const seq = ++fetchSeq.current;
     try {
       setLoading(true);
       setError(undefined);
       setForbidden(false);
       const res = await listQuotes({ orgId: f.orgId || undefined, status: f.status || undefined });
+      if (seq !== fetchSeq.current) return;
       if (res.status === 401) return UNAUTHORIZED();
       if (res.status === 403) { setForbidden(true); return; }
       if (!res.ok) throw new Error(t('quotes.page.errors.loadQuotes'));
       const body = (await res.json()) as { data: Quote[] };
+      if (seq !== fetchSeq.current) return;
       setQuotes(body.data ?? []);
     } catch (err) {
+      if (seq !== fetchSeq.current) return;
       setError(err instanceof Error ? err.message : t('quotes.page.errors.loadQuotes'));
     } finally {
-      setLoading(false);
+      if (seq === fetchSeq.current) setLoading(false);
     }
   }, [t]);
 

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -4,6 +4,7 @@ import '../../../lib/i18n';
 import { fetchWithAuth } from '../../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError, ActionError } from '../../../lib/runAction';
+import { useHashState } from '@/lib/useHashState';
 import { usePermissions } from '../../../lib/permissions';
 import { Dialog } from '../../shared/Dialog';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
@@ -47,9 +48,9 @@ interface Filters {
 }
 const EMPTY_FILTERS: Filters = { orgId: '', status: '' };
 
-function readFilters(): Filters {
-  if (typeof window === 'undefined') return EMPTY_FILTERS;
-  const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+// Pure: takes the raw hash (leading `#` already stripped by useHashState, #2421).
+function readFilters(hash: string): Filters {
+  const params = new URLSearchParams(hash);
   const status = params.get('status') ?? '';
   return {
     orgId: params.get('orgId') ?? '',
@@ -98,7 +99,8 @@ export function QuotesPage() {
   // A 403 from the quotes route is a permission denial, not a load failure, so it
   // renders the access-denied state rather than the retryable error.
   const [forbidden, setForbidden] = useState(false);
-  const [filters, setFilters] = useState<Filters>(() => readFilters());
+  // SSR-safe hash adoption + hashchange subscription live in the hook (#2421).
+  const [filters, setFilters] = useHashState<Filters>(EMPTY_FILTERS, readFilters);
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<Sort | null>(null);
 
@@ -147,13 +149,6 @@ export function QuotesPage() {
 
   useEffect(() => { void loadOrgs(); }, [loadOrgs]);
   useEffect(() => { void loadQuotes(filters); }, [loadQuotes, filters]);
-
-  // React to back/forward hash changes.
-  useEffect(() => {
-    const onHash = () => setFilters(readFilters());
-    window.addEventListener('hashchange', onHash);
-    return () => window.removeEventListener('hashchange', onHash);
-  }, []);
 
   // Clear bulk selection whenever the server-side filters or client-side search
   // change so stale invisible rows are never acted on.

--- a/apps/web/src/components/clientAi/AiForOfficePage.test.tsx
+++ b/apps/web/src/components/clientAi/AiForOfficePage.test.tsx
@@ -69,9 +69,8 @@ describe('AiForOfficePage', () => {
   });
 
   it('getStateFromHash falls back to orgs for junk hashes', () => {
-    window.location.hash = '#nonsense';
-    expect(getStateFromHash()).toEqual({ tab: 'orgs' });
-    window.location.hash = '#policy/';
-    expect(getStateFromHash()).toEqual({ tab: 'orgs' });
+    // #2421: the parser is pure — it takes the already-#-stripped hash string.
+    expect(getStateFromHash('nonsense')).toEqual({ tab: 'orgs' });
+    expect(getStateFromHash('policy/')).toEqual({ tab: 'orgs' });
   });
 });

--- a/apps/web/src/components/clientAi/AiForOfficePage.tsx
+++ b/apps/web/src/components/clientAi/AiForOfficePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useHashState } from "@/lib/useHashState";
 import OrgsTab from "./OrgsTab";
 import PolicyEditor from "./PolicyEditor";
 import SessionsTab from "./SessionsTab";
@@ -19,9 +19,9 @@ type SimpleTab = (typeof SIMPLE_TABS)[number];
 
 export type TabState = { tab: SimpleTab } | { tab: "policy"; orgId: string };
 
-export function getStateFromHash(): TabState {
-  if (typeof window === "undefined") return { tab: "orgs" };
-  const hash = window.location.hash.replace("#", "");
+// Pure parser (leading `#` already stripped by useHashState) so it is
+// SSR-safe — the hash is adopted post-mount by the hook (#2421).
+export function getStateFromHash(hash: string): TabState {
   if (hash.startsWith("policy/")) {
     const orgId = hash.slice("policy/".length);
     if (orgId) return { tab: "policy", orgId };
@@ -33,13 +33,10 @@ export function getStateFromHash(): TabState {
 
 export default function AiForOfficePage() {
   const { t } = useTranslation("ai");
-  const [state, setState] = useState<TabState>(getStateFromHash);
-
-  useEffect(() => {
-    const onHashChange = () => setState(getStateFromHash());
-    window.addEventListener("hashchange", onHashChange);
-    return () => window.removeEventListener("hashchange", onHashChange);
-  }, []);
+  const [state, setState] = useHashState<TabState>(
+    { tab: "orgs" },
+    getStateFromHash,
+  );
 
   const switchTab = (tab: SimpleTab) => {
     window.location.hash = tab;

--- a/apps/web/src/components/contracts/ContractWorkspace.tsx
+++ b/apps/web/src/components/contracts/ContractWorkspace.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { navigateTo } from '@/lib/navigation';
+import { useHashState } from '@/lib/useHashState';
 import '@/lib/i18n';
 import ContractEditor from './ContractEditor';
 import ContractDetail from './ContractDetail';
@@ -19,18 +20,19 @@ interface Props {
   contractId?: string;
 }
 
-/** Read a deep-linked org for the create form (e.g. `/contracts/new#orgId=…`). */
-function readPresetOrgId(): string | undefined {
-  if (typeof window === 'undefined') return undefined;
-  const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
-  return params.get('orgId') ?? undefined;
-}
-
 export default function ContractWorkspace({ contractId }: Props) {
   const { t } = useTranslation('billing');
   const isNew = contractId === 'new';
   const { can } = usePermissions();
   const canWrite = can('contracts', 'write');
+
+  // Deep-linked org for the create form (e.g. `/contracts/new#orgId=…`), adopted
+  // post-mount to avoid SSR hydration mismatches (#2421). Only meaningful when
+  // `isNew`; harmless otherwise.
+  const [presetOrgId] = useHashState<string | undefined>(
+    undefined,
+    (h) => new URLSearchParams(h).get('orgId') ?? undefined,
+  );
 
   const [detail, setDetail] = useState<ContractDetailData | null>(null);
   const [loading, setLoading] = useState(!isNew);
@@ -67,7 +69,7 @@ export default function ContractWorkspace({ contractId }: Props) {
           <a href="/contracts" className="text-xs text-muted-foreground hover:underline">{t('contracts.contractWorkspace.backToContracts')}</a>
           <h1 className="text-xl font-semibold" data-testid="contract-workspace-title">{t('contracts.contractWorkspace.newContract')}</h1>
         </div>
-        <ContractEditor presetOrgId={readPresetOrgId()} />
+        <ContractEditor presetOrgId={presetOrgId} />
       </div>
     );
   }

--- a/apps/web/src/components/contracts/ContractWorkspace.tsx
+++ b/apps/web/src/components/contracts/ContractWorkspace.tsx
@@ -69,7 +69,12 @@ export default function ContractWorkspace({ contractId }: Props) {
           <a href="/contracts" className="text-xs text-muted-foreground hover:underline">{t('contracts.contractWorkspace.backToContracts')}</a>
           <h1 className="text-xl font-semibold" data-testid="contract-workspace-title">{t('contracts.contractWorkspace.newContract')}</h1>
         </div>
-        <ContractEditor presetOrgId={presetOrgId} />
+        {/* ContractEditor seeds its org select from presetOrgId in a useState
+            initializer, so it must remount when the hash-derived value arrives
+            post-mount (#2421) — otherwise the deep-linked org (the "New
+            contract" CTA on the org Contracts tab) is silently dropped and the
+            picker comes up empty. */}
+        <ContractEditor key={presetOrgId ?? 'new'} presetOrgId={presetOrgId} />
       </div>
     );
   }

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BULK_ID_LIMIT } from '@breeze/shared';
 import { fetchWithAuth } from '../../stores/auth';
@@ -96,12 +96,16 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
   // SSR-safe hash adoption + hashchange subscription live in the hook (#2421).
   // When locked to an org (embedded in a hash-routed tab) the host owns the
   // hash, so parse yields undefined and the locked default always wins.
+  // An empty hash parses to undefined (not a fresh EMPTY_FILTERS object) so the
+  // no-deep-link case keeps the default reference and never refetches.
   const [filters, setFilters] = useHashState<Filters>(
     lockedOrgId ? { ...EMPTY_FILTERS, orgId: lockedOrgId } : EMPTY_FILTERS,
-    (h) => (lockedOrgId ? undefined : readFilters(h)),
+    (h) => (lockedOrgId || !h ? undefined : readFilters(h)),
   );
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<Sort | null>(null);
+  // Monotonic id of the newest in-flight list request (see loadContracts).
+  const fetchSeq = useRef(0);
   const [cancelOpen, setCancelOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [bulkBusy, setBulkBusy] = useState(false);
@@ -121,21 +125,29 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
   }, [t]);
 
   const loadContracts = useCallback(async (f: Filters) => {
+    // Latest-request-wins. A deep-linked load (`/contracts#status=active`) fires
+    // this twice — once with the SSR-safe default filters, then again once
+    // useHashState adopts the hash (#2421) — and the unfiltered query can
+    // resolve last, painting the wrong list. Drop every response but the newest.
+    const seq = ++fetchSeq.current;
     try {
       setLoading(true);
       setError(undefined);
       setForbidden(false);
       const res = await listContracts({ orgId: f.orgId || undefined, status: f.status || undefined });
+      if (seq !== fetchSeq.current) return;
       if (res.status === 401) return UNAUTHORIZED();
       if (res.status === 403) { setForbidden(true); return; }
       if (!res.ok) throw new Error(t('contracts.contractsList.errors.loadContracts'));
       const body = (await res.json().catch(() => null)) as { data: ContractSummary[] } | null;
+      if (seq !== fetchSeq.current) return;
       if (!body) throw new Error(t('contracts.contractsList.errors.loadContracts'));
       setContracts(body.data ?? []);
     } catch (err) {
+      if (seq !== fetchSeq.current) return;
       setError(err instanceof Error ? err.message : t('contracts.contractsList.errors.loadContracts'));
     } finally {
-      setLoading(false);
+      if (seq === fetchSeq.current) setLoading(false);
     }
   }, [t]);
 

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -5,6 +5,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import '@/lib/i18n';
 import { runAction, handleActionError } from '../../lib/runAction';
+import { useHashState } from '@/lib/useHashState';
 import {
   listContracts,
   monthlyValue,
@@ -46,9 +47,9 @@ interface Filters {
 }
 const EMPTY_FILTERS: Filters = { orgId: '', status: '' };
 
-function readFilters(): Filters {
-  if (typeof window === 'undefined') return EMPTY_FILTERS;
-  const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+// Pure: takes the raw hash (leading `#` already stripped by useHashState, #2421).
+function readFilters(hash: string): Filters {
+  const params = new URLSearchParams(hash);
   const status = params.get('status') ?? '';
   return {
     orgId: params.get('orgId') ?? '',
@@ -92,8 +93,12 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
   // A 403 from the contracts route is a permission denial, not a load failure, so
   // it renders the access-denied state rather than the retryable error.
   const [forbidden, setForbidden] = useState(false);
-  const [filters, setFilters] = useState<Filters>(() =>
-    lockedOrgId ? { ...EMPTY_FILTERS, orgId: lockedOrgId } : readFilters(),
+  // SSR-safe hash adoption + hashchange subscription live in the hook (#2421).
+  // When locked to an org (embedded in a hash-routed tab) the host owns the
+  // hash, so parse yields undefined and the locked default always wins.
+  const [filters, setFilters] = useHashState<Filters>(
+    lockedOrgId ? { ...EMPTY_FILTERS, orgId: lockedOrgId } : EMPTY_FILTERS,
+    (h) => (lockedOrgId ? undefined : readFilters(h)),
   );
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<Sort | null>(null);
@@ -136,15 +141,6 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
 
   useEffect(() => { void loadOrgs(); }, [loadOrgs]);
   useEffect(() => { void loadContracts(filters); }, [loadContracts, filters]);
-
-  // React to back/forward hash changes — only when standalone. When locked to an
-  // org (embedded in a hash-routed tab), the host owns the hash; ignore it.
-  useEffect(() => {
-    if (lockedOrgId) return;
-    const onHash = () => setFilters(readFilters());
-    window.addEventListener('hashchange', onHash);
-    return () => window.removeEventListener('hashchange', onHash);
-  }, [lockedOrgId]);
 
   // Clear bulk selection whenever the server-side filters or client-side search
   // change so stale, now-invisible rows are never acted on.

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { useHashState } from "@/lib/useHashState";
 import {
   Monitor,
   Cpu,
@@ -176,16 +177,15 @@ const VALID_TABS: Tab[] = [
   "tickets",
 ];
 
-function getTabFromHash(): Tab {
-  if (typeof window === "undefined") return "overview";
-  const hash = window.location.hash.replace("#", "").split("/")[0] ?? "";
-  if (VALID_TABS.includes(hash as Tab)) return hash as Tab;
-  return "overview";
+// Pure hash parsers (leading `#` already stripped by useHashState) so they are
+// SSR-safe — the hash is adopted post-mount by the hook (#2421).
+function tabFromHash(hash: string): Tab | undefined {
+  const seg = hash.split("/")[0] ?? "";
+  return VALID_TABS.includes(seg as Tab) ? (seg as Tab) : undefined;
 }
 
-function getAnomalyIdFromHash(): string | undefined {
-  if (typeof window === "undefined") return undefined;
-  const [tab, anomalyId] = window.location.hash.replace("#", "").split("/");
+function anomalyIdFromHash(hash: string): string | undefined {
+  const [tab, anomalyId] = hash.split("/");
   return tab === "anomalies" && anomalyId ? anomalyId : undefined;
 }
 
@@ -196,10 +196,10 @@ export default function DeviceDetails({
   onAction,
 }: DeviceDetailsProps) {
   const { t } = useTranslation("devices");
-  const [activeTab, setActiveTab] = useState<Tab>(getTabFromHash);
-  const [focusedAnomalyId, setFocusedAnomalyId] = useState<string | undefined>(
-    getAnomalyIdFromHash,
-  );
+  const [activeTab, setActiveTab] = useHashState<Tab>("overview", tabFromHash);
+  const [focusedAnomalyId, setFocusedAnomalyId] = useHashState<
+    string | undefined
+  >(undefined, anomalyIdFromHash);
   // Whether the Overview Activity rail is collapsed to its thin vertical bar.
   // Starts collapsed so the page paints at full width during the async load and
   // never flashes a rail that then vanishes (the v0.85.0 stretch bug). Once the
@@ -227,15 +227,6 @@ export default function DeviceDetails({
     activityUserToggled.current = false;
     setActivityCollapsed(true);
   }, [device.id]);
-
-  useEffect(() => {
-    const onHashChange = () => {
-      setActiveTab(getTabFromHash());
-      setFocusedAnomalyId(getAnomalyIdFromHash());
-    };
-    window.addEventListener("hashchange", onHashChange);
-    return () => window.removeEventListener("hashchange", onHashChange);
-  }, []);
 
   const switchTab = (tab: Tab) => {
     window.location.hash = tab;

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -31,6 +31,7 @@ import { fetchAllDevices, fetchAllNetworkDevices } from '../../lib/devicesFetch'
 import { useOrgStore } from '../../stores/orgStore';
 import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, sendBulkWakeCommand, summarizeBulkWakeFailures, summarizeBulkCommandFailures, watchWakeOutcome, WakeCommandError, wakeFriendlyErrorMessage, linkDevicesMultiboot, linkDevicesVmHost } from '../../services/deviceActions';
 import { navigateTo } from '@/lib/navigation';
+import { useHashState } from '@/lib/useHashState';
 import { getErrorMessage, getErrorTitle, isAccessDenied } from '@/lib/errorMessages';
 import AccessDenied from '../shared/AccessDenied';
 import { asRecord, toPercent } from '@/lib/deviceUtils';
@@ -104,10 +105,9 @@ export default function DevicesPage() {
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [actionInProgress, setActionInProgress] = useState(false);
   const [bulkProgress, setBulkProgress] = useState<{ current: number; total: number; label: string } | null>(null);
-  const [showAddDevice, setShowAddDevice] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    return window.location.hash === '#add-device';
-  });
+  // The three hash-seeded states below adopt the hash post-mount via
+  // useHashState so the first client render matches the SSR markup (#2421).
+  const [showAddDevice, setShowAddDevice] = useHashState<boolean>(false, (h) => (h === 'add-device' ? true : undefined));
   const [scriptPickerOpen, setScriptPickerOpen] = useState(false);
   // vm_host link creation (#2308): the bulk action opens a host-picker modal
   // over the selected devices; null = closed.
@@ -118,18 +118,12 @@ export default function DevicesPage() {
   const [settingsDevice, setSettingsDevice] = useState<Device | null>(null);
   // v2 chip bar seeds its filter from the URL hash so a filtered view is
   // shareable; the legacy DeviceFilterBar owns its own state and ignores it.
-  const [advancedFilter, setAdvancedFilter] = useState<FilterConditionGroup | null>(() => {
-    if (typeof window === 'undefined') return null;
-    return decodeFilterFromHash(window.location.hash);
-  });
+  const [advancedFilter, setAdvancedFilter] = useHashState<FilterConditionGroup | null>(null, (h) => decodeFilterFromHash(h) ?? undefined);
   // [ All | Agent | Network ] class segment (#1424). Seeded from the hash so a
   // chosen class is shareable; a pure client-side narrowing of the merged list.
   // Only meaningful when the network arm is enabled (otherwise the list is
   // agent-only and the segment is hidden).
-  const [deviceClassFilter, setDeviceClassFilter] = useState<DeviceClassFilter>(() => {
-    if (typeof window === 'undefined') return 'all';
-    return readDeviceClassFromHash(window.location.hash);
-  });
+  const [deviceClassFilter, setDeviceClassFilter] = useHashState<DeviceClassFilter>('all', (h) => readDeviceClassFromHash(h));
   const handleDeviceClassChange = useCallback((next: DeviceClassFilter) => {
     setDeviceClassFilter(next);
     writeDeviceClassToHash(next);

--- a/apps/web/src/components/devices/NetworkDeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/NetworkDeviceDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useHashState } from '@/lib/useHashState';
 import { ArrowLeft, Globe, ExternalLink, Wifi, WifiOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { fetchWithAuth } from '../../stores/auth';
@@ -60,13 +61,6 @@ function formatTimestamp(value?: string | null): string {
 const VALID_TABS = ['overview', 'monitoring'] as const;
 type Tab = (typeof VALID_TABS)[number];
 
-function getTabFromHash(): Tab {
-  if (typeof window === 'undefined') return 'overview';
-  const hash = window.location.hash.replace('#', '').split('/')[0] ?? '';
-  if ((VALID_TABS as readonly string[]).includes(hash)) return hash as Tab;
-  return 'overview';
-}
-
 function Section({
   title,
   children,
@@ -99,15 +93,12 @@ export default function NetworkDeviceDetailPage({ assetId }: NetworkDeviceDetail
   const [extras, setExtras] = useState<AssetDetailExtras>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
-  const [activeTab, setActiveTab] = useState<Tab>(getTabFromHash);
-
-  // Keep the active tab in sync with the URL hash so the view is shareable and
-  // the browser back/forward buttons move between tabs (mirrors DeviceDetails).
-  useEffect(() => {
-    const onHashChange = () => setActiveTab(getTabFromHash());
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, []);
+  // Hash-derived tab adopted post-mount to avoid an SSR hydration mismatch
+  // (#2421); the hook also syncs back/forward via hashchange.
+  const [activeTab, setActiveTab] = useHashState<Tab>('overview', (h) => {
+    const seg = h.split('/')[0] ?? '';
+    return (VALID_TABS as readonly string[]).includes(seg) ? (seg as Tab) : undefined;
+  });
 
   const switchTab = (tab: Tab) => {
     window.location.hash = tab;

--- a/apps/web/src/components/dnsSecurity/DnsSecurityPage.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityPage.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
+import { useHashTab } from '@/lib/useHashState';
 import { Network, Plug, ListChecks, ScrollText } from 'lucide-react';
 import DnsSecurityIntegrationsTab from './DnsSecurityIntegrationsTab';
 import DnsSecurityPoliciesTab from './DnsSecurityPoliciesTab';
@@ -11,28 +12,17 @@ type Tab = 'overview' | 'integrations' | 'policies' | 'events';
 
 const VALID_TABS: readonly Tab[] = ['overview', 'integrations', 'policies', 'events'];
 
-function readTabFromHash(): Tab {
-  if (typeof window === 'undefined') return 'overview';
-  const hash = window.location.hash.replace('#', '');
-  return (VALID_TABS as readonly string[]).includes(hash) ? (hash as Tab) : 'overview';
-}
-
 export default function DnsSecurityPage() {
   const { t } = useTranslation('security');
-  const [activeTab, setActiveTab] = useState<Tab>(readTabFromHash);
+  // SSR-safe hash tab (#2421): starts at the default, adopts the hash post-mount.
+  const [activeTab, setActiveTab] = useHashTab<Tab>(VALID_TABS, 'overview');
 
   // Reflect tab into URL hash per the CLAUDE.md "URL State in Components"
   // rule — matches DeviceDetails.tsx / OrganizationsPage.tsx.
   const switchTab = useCallback((tab: Tab) => {
     window.location.hash = tab;
     setActiveTab(tab);
-  }, []);
-
-  useEffect(() => {
-    const onHashChange = () => setActiveTab(readTabFromHash());
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, []);
+  }, [setActiveTab]);
 
   return (
     <div className="space-y-6">

--- a/apps/web/src/components/dr/DRDashboard.tsx
+++ b/apps/web/src/components/dr/DRDashboard.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatDateTime } from '@/lib/dateTimeFormat';
+import { useHashState } from '@/lib/useHashState';
 import { Dialog } from '../shared/Dialog';
 import { fetchWithAuth } from '../../stores/auth';
 import DRExecutionView from './DRExecutionView';
@@ -81,10 +82,8 @@ function statusBadge(status: string) {
 
 export default function DRDashboard() {
   const { t } = useTranslation('backup');
-  const [activeTab, setActiveTab] = useState<DRTab>(() => {
-    if (typeof window === 'undefined') return 'plans';
-    return window.location.hash.replace('#', '') === 'executions' ? 'executions' : 'plans';
-  });
+  // SSR-safe hash tab (#2421): starts at the default, adopts the hash post-mount.
+  const [activeTab, setActiveTab] = useHashState<DRTab>('plans', (h) => (h === 'executions' ? 'executions' : undefined));
   const [plans, setPlans] = useState<DRPlan[]>([]);
   const [executions, setExecutions] = useState<DRExecution[]>([]);
   const [groupCounts, setGroupCounts] = useState<Record<string, number>>({});
@@ -148,15 +147,6 @@ export default function DRDashboard() {
   useEffect(() => {
     void refreshAll();
   }, [refreshAll]);
-
-  useEffect(() => {
-    const onHashChange = () => {
-      const nextHash = window.location.hash.replace('#', '');
-      setActiveTab(nextHash === 'executions' ? 'executions' : 'plans');
-    };
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, []);
 
   const hasRunningExecution = useMemo(
     () => executions.some((execution) => ['pending', 'running'].includes(execution.status)),

--- a/apps/web/src/components/monitoring/MonitoringPage.tsx
+++ b/apps/web/src/components/monitoring/MonitoringPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useHashTab } from '@/lib/useHashState';
 import MonitoringAssetsDashboard from './MonitoringAssetsDashboard';
 import NetworkMonitorList from '../monitors/NetworkMonitorList';
 import SNMPTemplateList from '../snmp/SNMPTemplateList';
@@ -12,28 +13,13 @@ import '../../lib/i18n';
 const MONITORING_TABS = ['assets', 'checks', 'templates'] as const;
 type MonitoringTab = (typeof MONITORING_TABS)[number];
 
-function getTabFromHash(): MonitoringTab {
-  if (typeof window === 'undefined') return 'assets';
-  const hash = window.location.hash.replace('#', '');
-  if (hash && (MONITORING_TABS as readonly string[]).includes(hash)) {
-    return hash as MonitoringTab;
-  }
-  return 'assets';
-}
-
 export default function MonitoringPage() {
   const { t } = useTranslation('common');
-  const [activeTab, setActiveTab] = useState<MonitoringTab>(getTabFromHash);
+  // SSR-safe hash tab (#2421): starts at the default, adopts the hash post-mount.
+  const [activeTab, setActiveTab] = useHashTab<MonitoringTab>(MONITORING_TABS, 'assets');
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | undefined>(undefined);
   const [templateRefreshToken, setTemplateRefreshToken] = useState(0);
   const [initialAssetId, setInitialAssetId] = useState<string | null>(null);
-
-  // Sync active tab when the hash changes (e.g. back/forward navigation).
-  useEffect(() => {
-    const onHashChange = () => setActiveTab(getTabFromHash());
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -57,7 +43,7 @@ export default function MonitoringPage() {
   const navigateToTab = useCallback((tab: MonitoringTab) => {
     if (typeof window !== 'undefined') window.location.hash = tab;
     setActiveTab(tab);
-  }, []);
+  }, [setActiveTab]);
 
   return (
     <div className="space-y-6">

--- a/apps/web/src/components/pam/PamPage.tsx
+++ b/apps/web/src/components/pam/PamPage.tsx
@@ -1,5 +1,6 @@
 import '@/lib/i18n';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useHashTab } from '@/lib/useHashState';
 import { Activity, Inbox, ListChecks, ScrollText, ShieldCheck } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useEventStream } from '../../hooks/useEventStream';
@@ -22,15 +23,10 @@ const ELEVATION_EVENTS = [
   'elevation.revoked',
 ];
 
-function readTabFromHash(): Tab {
-  if (typeof window === 'undefined') return 'overview';
-  const hash = window.location.hash.replace('#', '');
-  return (VALID_TABS as readonly string[]).includes(hash) ? (hash as Tab) : 'overview';
-}
-
 export default function PamPage() {
   const { t } = useTranslation('security');
-  const [activeTab, setActiveTab] = useState<Tab>(readTabFromHash);
+  // SSR-safe hash tab (#2421): starts at the default, adopts the hash post-mount.
+  const [activeTab, setActiveTab] = useHashTab<Tab>(VALID_TABS, 'overview');
   // Bumped on every elevation.* event (debounced); tabs refetch when it changes.
   const [liveTick, setLiveTick] = useState(0);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -38,13 +34,7 @@ export default function PamPage() {
   const switchTab = useCallback((tab: Tab) => {
     window.location.hash = tab;
     setActiveTab(tab);
-  }, []);
-
-  useEffect(() => {
-    const onHashChange = () => setActiveTab(readTabFromHash());
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, []);
+  }, [setActiveTab]);
 
   const { connected, subscribe, unsubscribe } = useEventStream({
     onEvent: (event) => {

--- a/apps/web/src/components/patches/PatchesPage.tsx
+++ b/apps/web/src/components/patches/PatchesPage.tsx
@@ -65,12 +65,10 @@ export default function PatchesPage() {
   const canManageRings = scope === 'partner' || scope === 'system';
   const RING_SCOPE_HINT = t('patchesPage.ringScopeHint');
 
-  // Seed from the hash, applying the org-scope guard: an org user landing on
-  // #rings (e.g. a bookmark) falls back to compliance so the rings body is never
-  // rendered without navigation access.
-  const [activeTab, setActiveTabState] = useState<TabKey>(() =>
-    resolveTab(getTabFromHash(), canManageRings)
-  );
+  // Start from the SSR-safe default; the hash (with the org-scope guard) is
+  // applied post-mount by the sync effect below, avoiding an SSR hydration
+  // mismatch (#2421).
+  const [activeTab, setActiveTabState] = useState<TabKey>('compliance');
   const setActiveTab = useCallback((tab: TabKey) => {
     setActiveTabState(tab);
     setTabInHash(tab);

--- a/apps/web/src/components/security/EdrPage.tsx
+++ b/apps/web/src/components/security/EdrPage.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import "@/lib/i18n";
-import { useEffect, useState } from "react";
+import { useHashState } from "@/lib/useHashState";
 import { ShieldAlert, Activity } from "lucide-react";
 import S1ThreatList from "./S1ThreatList";
 import HuntressIncidentList from "./HuntressIncidentList";
@@ -21,19 +21,12 @@ const TABS: {
     testid: "edr-tab-huntress",
   },
 ];
-function tabFromHash(): EdrTab {
-  if (typeof window === "undefined") return "sentinelone";
-  const h = window.location.hash.replace(/^#/, "");
-  return h === "huntress" ? "huntress" : "sentinelone";
-}
 export default function EdrPage() {
   const { t } = useTranslation("security");
-  const [activeTab, setActiveTab] = useState<EdrTab>(tabFromHash);
-  useEffect(() => {
-    const onHash = () => setActiveTab(tabFromHash());
-    window.addEventListener("hashchange", onHash);
-    return () => window.removeEventListener("hashchange", onHash);
-  }, []);
+  // SSR-safe hash tab (#2421): starts at the default, adopts the hash post-mount.
+  const [activeTab, setActiveTab] = useHashState<EdrTab>("sentinelone", (h) =>
+    h === "huntress" ? "huntress" : undefined,
+  );
   const switchTab = (t: EdrTab) => {
     window.location.hash = t;
     setActiveTab(t);

--- a/apps/web/src/components/security/VulnerabilitiesPage.tsx
+++ b/apps/web/src/components/security/VulnerabilitiesPage.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import "@/lib/i18n";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useHashState } from "@/lib/useHashState";
 import {
   AlertTriangle,
   Loader2,
@@ -71,13 +72,11 @@ export default function VulnerabilitiesPage() {
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   // Deep-linkable severity filter (#severity=critical), see dashboard severity rows.
-  const [severity, setSeverity] = useState(() => {
-    if (typeof window === "undefined") return "";
-    const match = window.location.hash.match(
-      /severity=(critical|high|medium|low)/,
-    );
-    return match ? match[1] : "";
-  });
+  // Adopted post-mount to avoid an SSR hydration mismatch (#2421).
+  const [severity, setSeverity] = useHashState<string>(
+    "",
+    (h) => h.match(/severity=(critical|high|medium|low)/)?.[1],
+  );
   const [status, setStatus] = useState("");
   const [category, setCategory] = useState("");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());

--- a/apps/web/src/components/security/VulnerabilitiesPage.tsx
+++ b/apps/web/src/components/security/VulnerabilitiesPage.tsx
@@ -115,7 +115,12 @@ export default function VulnerabilitiesPage() {
         console.error("[VulnerabilitiesPage] fetch error:", err);
         setError(friendlyFetchError(err));
       } finally {
-        setLoading(false);
+        // An aborted request must NOT drop the spinner — a superseding request
+        // is still in flight. On a `#severity=` deep link the hook's post-mount
+        // adoption (#2421) aborts the seed fetch, and clearing `loading` here
+        // would paint the settled "No vulnerabilities found" empty state (rows
+        // are still []) for the whole duration of the real request.
+        if (!controller.signal.aborted) setLoading(false);
       }
     },
     [debouncedSearch, severity, status, category],

--- a/apps/web/src/components/sensitiveData/SensitiveDataPage.tsx
+++ b/apps/web/src/components/sensitiveData/SensitiveDataPage.tsx
@@ -1,5 +1,5 @@
 import '@/lib/i18n';
-import { useState, useEffect } from 'react';
+import { useHashState } from '@/lib/useHashState';
 import { ScanSearch } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import DashboardTab from './DashboardTab';
@@ -16,22 +16,12 @@ const TABS: { id: Tab; label: string }[] = [
   { id: 'policies', label: 'Policies' },
 ];
 
-function getTabFromHash(): Tab {
-  if (typeof window === 'undefined') return 'dashboard';
-  const hash = window.location.hash.replace('#', '');
-  if (TABS.some((t) => t.id === hash)) return hash as Tab;
-  return 'dashboard';
-}
-
 export default function SensitiveDataPage() {
   const { t } = useTranslation('security');
-  const [activeTab, setActiveTab] = useState<Tab>(getTabFromHash);
-
-  useEffect(() => {
-    const onHashChange = () => setActiveTab(getTabFromHash());
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, []);
+  // SSR-safe hash tab (#2421): starts at the default, adopts the hash post-mount.
+  const [activeTab, setActiveTab] = useHashState<Tab>('dashboard', (h) =>
+    TABS.some((tab) => tab.id === h) ? (h as Tab) : undefined
+  );
 
   const switchTab = (tab: Tab) => {
     window.location.hash = tab;

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef, type DragEvent } from 'react';
+import { useHashState } from '@/lib/useHashState';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
 import type { Organization } from './OrganizationList';
@@ -44,10 +45,9 @@ export default function OrganizationsPage() {
   const [error, setError] = useState<string>();
   const [modalMode, setModalMode] = useState<ModalMode>('closed');
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
-  const [initialOrgId] = useState(() => {
-    if (typeof window === 'undefined') return null;
-    return window.location.hash.replace('#', '') || null;
-  });
+  // Deep-linked org id adopted post-mount (#2421); later hash writes are
+  // harmless because the consumer effect only fires while nothing is selected.
+  const [initialOrgId] = useHashState<string | null>(null, (h) => h || undefined);
   const [submitting, setSubmitting] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [draggedOrgId, setDraggedOrgId] = useState<string | null>(null);

--- a/apps/web/src/components/settings/SiteDetailPage.tsx
+++ b/apps/web/src/components/settings/SiteDetailPage.tsx
@@ -13,6 +13,7 @@ import {
   CheckCircle2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useHashTab } from '@/lib/useHashState';
 import Breadcrumbs from '../layout/Breadcrumbs';
 import { fetchWithAuth } from '../../stores/auth';
 import { formatTime as formatUserTime } from '@/lib/dateTimeFormat';
@@ -86,13 +87,6 @@ const tabs = [
 
 const VALID_TABS: TabKey[] = tabs.map(t => t.id);
 
-function getTabFromHash(): TabKey {
-  if (typeof window === 'undefined') return 'details';
-  const hash = window.location.hash.replace('#', '');
-  if (VALID_TABS.includes(hash as TabKey)) return hash as TabKey;
-  return 'details';
-}
-
 const timezoneOptions = [
   'UTC',
   'America/Los_Angeles',
@@ -121,13 +115,8 @@ const formatTime = (date: Date) =>
 
 export default function SiteDetailPage({ siteId }: { siteId: string }) {
   const { t } = useTranslation('settings');
-  const [activeTab, setActiveTab] = useState<TabKey>(getTabFromHash);
-
-  useEffect(() => {
-    const onHashChange = () => setActiveTab(getTabFromHash());
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, []);
+  // SSR-safe hash tab (#2421): starts at the default, adopts the hash post-mount.
+  const [activeTab, setActiveTab] = useHashTab<TabKey>(VALID_TABS, 'details');
 
   const switchTab = (tab: TabKey) => {
     window.location.hash = tab;

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -340,7 +340,13 @@ describe('TicketsPage', () => {
 
       await screen.findByTestId('ticket-row-tk-risk');
 
-      expect(ticketFetchUrls().at(0)).toContain('sort=oldest');
+      // SSR-safe hash adoption (#2421): the first render uses the 'triage'
+      // default, then useHashState adopts the hash pre-paint and the list
+      // effect refetches with sort=oldest (fetchSeq drops the stale response).
+      // Assert on the fetch that wins, not the seed fetch.
+      await waitFor(() => {
+        expect(ticketFetchUrls().at(-1)).toContain('sort=oldest');
+      });
       expect(screen.getByTestId('ticket-sort')).toHaveValue('oldest');
       await waitFor(() => {
         expect(screen.getByTestId('ticket-row-tk-risk')).toHaveAttribute('aria-selected', 'true');

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -7,6 +7,7 @@ import { fetchWithAuth, useAuthStore } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
+import { useHashState } from '@/lib/useHashState';
 import { getJwtClaims, loginPathWithNext } from '../../lib/authScope';
 import TicketQueueList from './TicketQueueList';
 import TicketArchivedList from './TicketArchivedList';
@@ -119,11 +120,11 @@ function tabQuery(tab: Exclude<Tab, 'review' | 'archived'>): string {
 // The bare segment is the selected ticket key (internal number or id); the
 // `sort=` segment carries the queue sort. Both are optional, and the default
 // sort ('triage') is omitted so plain `#T-2026-0001` hashes keep working.
-function parseHash(): { selection: string | null; sort: TicketSort } {
-  if (typeof window === 'undefined') return { selection: null, sort: 'triage' };
+// Pure: takes the raw hash (leading `#` already stripped by useHashState, #2421).
+function parseHash(hash: string): { selection: string | null; sort: TicketSort } {
   let selection: string | null = null;
   let sort: TicketSort = 'triage';
-  for (const part of window.location.hash.replace('#', '').split('&')) {
+  for (const part of hash.split('&')) {
     if (!part) continue;
     if (part.startsWith('sort=')) {
       const value = part.slice('sort='.length);
@@ -163,8 +164,10 @@ export default function TicketsPage() {
   const [stats, setStats] = useState<{ open: number; unassigned: number; mine: number; breached: number; atRisk?: number } | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
-  const [selectedNumber, setSelectedNumber] = useState<string | null>(() => parseHash().selection);
-  const [sort, setSort] = useState<TicketSort>(() => parseHash().sort);
+  // SSR-safe hash adoption + hashchange subscription live in the hook (#2421).
+  // parse → undefined falls back to the null default, preserving "no selection".
+  const [selectedNumber, setSelectedNumber] = useHashState<string | null>(null, (h) => parseHash(h).selection ?? undefined);
+  const [sort, setSort] = useHashState<TicketSort>('triage', (h) => parseHash(h).sort);
   const [search, setSearch] = useState('');
   // Debounced twin of `search` — only this drives the list fetch, so typing
   // doesn't fire a 100-row query per keystroke (the input itself stays instant).
@@ -355,16 +358,6 @@ export default function TicketsPage() {
     setBulkAssignee('');
     setBulkStatus('');
   }, [search, orgFilter, priorityFilter, categoryFilter, assigneeFilter]);
-
-  useEffect(() => {
-    const onHash = () => {
-      const parsed = parseHash();
-      setSelectedNumber(parsed.selection);
-      setSort(parsed.sort);
-    };
-    window.addEventListener('hashchange', onHash);
-    return () => window.removeEventListener('hashchange', onHash);
-  }, []);
 
   // Single writer for the hash so selection and sort never clobber each other.
   const writeHash = useCallback((selection: string | null, sortValue: TicketSort) => {

--- a/apps/web/src/components/time/TimesheetPage.tsx
+++ b/apps/web/src/components/time/TimesheetPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError, handleActionError } from '../../lib/runAction';
@@ -122,6 +122,8 @@ export default function TimesheetPage() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editForm, setEditForm] = useState<EditForm>({ description: '', isBillable: true, hourlyRate: '' });
   const [loading, setLoading] = useState(true);
+  // Monotonic id of the newest in-flight timesheet request (see loadSheet).
+  const fetchSeq = useRef(0);
   const [loadError, setLoadError] = useState(false);
   const friendly = useCallback((code: string): string | undefined => {
     const key = FRIENDLY[code];
@@ -139,14 +141,23 @@ export default function TimesheetPage() {
     })();
   }, []);
 
-  // Load timesheet when week or tech changes
+  // Load timesheet when week or tech changes.
+  //
+  // Latest-request-wins. A deep-linked load (`/time#week=…&tech=…`) fires this
+  // twice — once with the SSR-safe defaults (current Monday, own sheet), then
+  // again once useHashState adopts the hash (#2421). The `weekStart !== loadWeek`
+  // check below only compares a response against its OWN request, so both pass;
+  // without a sequence guard the seed response could land last and paint the
+  // current week's own hours under a header naming another week and tech.
   const loadSheet = useCallback(async (loadWeek: string, loadTech: string | null) => {
+    const seq = ++fetchSeq.current;
     setLoading(true);
     setLoadError(false);
     try {
       const params = new URLSearchParams({ weekStart: loadWeek });
       if (loadTech) params.set('userId', loadTech);
       const res = await fetchWithAuth(`/time-entries/timesheet?${params.toString()}`);
+      if (seq !== fetchSeq.current) return;
       if (!res.ok) {
         if (res.status === 403 && loadTech) {
           // No admin access to another tech's sheet — fall back to own
@@ -160,13 +171,15 @@ export default function TimesheetPage() {
         return;
       }
       const body = await res.json().catch(() => null) as { data?: TsSheet } | null;
+      if (seq !== fetchSeq.current) return;
       if (body?.data?.weekStart && body.data.weekStart !== loadWeek) return; // stale response from rapid navigation
       setSheet(body?.data ?? null);
       setSelected(new Set()); // clear selection on new load
     } catch {
+      if (seq !== fetchSeq.current) return;
       setLoadError(true);
     } finally {
-      setLoading(false);
+      if (seq === fetchSeq.current) setLoading(false);
     }
   }, []);
 

--- a/apps/web/src/components/time/TimesheetPage.tsx
+++ b/apps/web/src/components/time/TimesheetPage.tsx
@@ -5,6 +5,7 @@ import { runAction, ActionError, handleActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
 import { formatMinutes } from '../../lib/timeFormat';
 import { onTimerChanged } from '../../lib/timerActions';
+import { useHashState } from '@/lib/useHashState';
 // Initializes the shared i18next singleton. Islands hydrate independently, so
 // an island that hydrates before whichever other island happens to pull i18n in
 // would otherwise render raw keys (and mismatch the SSR markup).
@@ -72,11 +73,11 @@ function shiftWeek(weekStart: string, delta: number): string {
   return base.toISOString().slice(0, 10);
 }
 
-function parseHash(): { week: string; tech: string | null } {
-  if (typeof window === 'undefined') return { week: mondayUtc(new Date()), tech: null };
+// Pure: takes the raw hash (leading `#` already stripped by useHashState, #2421).
+function parseHash(hash: string): { week: string; tech: string | null } {
   let week: string | null = null;
   let tech: string | null = null;
-  for (const part of window.location.hash.replace('#', '').split('&')) {
+  for (const part of hash.split('&')) {
     if (!part) continue;
     if (part.startsWith('week=')) {
       const v = part.slice('week='.length);
@@ -110,9 +111,10 @@ const FRIENDLY: Record<string, string> = {
 
 export default function TimesheetPage() {
   const { t } = useTranslation('common');
-  const initial = parseHash();
-  const [week, setWeek] = useState<string>(initial.week);
-  const [tech, setTech] = useState<string | null>(initial.tech);
+  // SSR-safe hash adoption lives in the hook (#2421). parseHash's week already
+  // falls back to the current Monday; tech → undefined keeps the null default.
+  const [week, setWeek] = useHashState<string>(mondayUtc(new Date()), (h) => parseHash(h).week);
+  const [tech, setTech] = useHashState<string | null>(null, (h) => parseHash(h).tech ?? undefined);
   const [sheet, setSheet] = useState<TsSheet | null>(null);
   const [users, setUsers] = useState<User[]>([]);
   const [adminDenied, setAdminDenied] = useState(false);

--- a/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type KeyboardEvent } from 'react';
+import { useHashState } from '@/lib/useHashState';
 import { AlertTriangle, Clock, ShieldAlert, Wrench } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -44,16 +45,15 @@ function filtersMatchPreset(filters: VulnFleetFilters, preset: VulnFleetFilters)
 const STAT_BUTTON =
   'block h-full w-full rounded-lg text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background';
 
-function getTabFromHash(): Tab {
-  if (typeof window === 'undefined') return 'software';
-  const hash = window.location.hash.replace('#', '').split('/')[0] ?? '';
-  if (VALID_TABS.includes(hash as Tab)) return hash as Tab;
-  return 'software';
+// Pure hash parsers (leading `#` already stripped by useHashState) so they are
+// SSR-safe — the hash is adopted post-mount by the hook (#2421).
+function tabFromHash(hash: string): Tab | undefined {
+  const seg = hash.split('/')[0] ?? '';
+  return VALID_TABS.includes(seg as Tab) ? (seg as Tab) : undefined;
 }
 
-function getSelectionFromHash(): string | undefined {
-  if (typeof window === 'undefined') return undefined;
-  const [tab, ...rest] = window.location.hash.replace('#', '').split('/');
+function selectionFromHash(hash: string): string | undefined {
+  const [tab, ...rest] = hash.split('/');
   if (!VALID_TABS.includes(tab as Tab) || rest.length === 0) return undefined;
   // groupKey segments may themselves contain encoded slashes — rejoin.
   const raw = rest.join('/');
@@ -66,21 +66,12 @@ function getSelectionFromHash(): string | undefined {
 
 export function VulnerabilityFleetPage() {
   const { t } = useTranslation('vulnerabilities');
-  const [activeTab, setActiveTab] = useState<Tab>(getTabFromHash);
-  const [selection, setSelection] = useState<string | undefined>(getSelectionFromHash);
+  const [activeTab, setActiveTab] = useHashState<Tab>('software', tabFromHash);
+  const [selection, setSelection] = useHashState<string | undefined>(undefined, selectionFromHash);
   const [filters, setFilters] = useState<VulnFleetFilters>(DEFAULT_FILTERS);
   const [stats, setStats] = useState<FleetVulnStats | null>(null);
   const [statsError, setStatsError] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
-
-  useEffect(() => {
-    const onHashChange = () => {
-      setActiveTab(getTabFromHash());
-      setSelection(getSelectionFromHash());
-    };
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, []);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/lib/__tests__/no-hash-in-usestate.test.ts
+++ b/apps/web/src/lib/__tests__/no-hash-in-usestate.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Guard (#2421): no component may read `window.location.hash` inside a
+ * `useState` initializer.
+ *
+ * The URL fragment is never sent to the server, so hash-derived initial state
+ * renders differently on the server and on the first client render — React
+ * discards the SSR tree with a hydration-mismatch error on every deep link
+ * (the #2383/#2416 regression class). The sanctioned pattern is
+ * `useHashState` / `useHashTab` from `src/lib/useHashState.ts`, which starts
+ * from the SSR-safe default and adopts the hash in a pre-paint effect.
+ *
+ * This is an AST check (TypeScript compiler API), modeled on
+ * `no-silent-mutations.test.ts`. Two rules, both call-local:
+ *   1. The `useState` argument subtree itself contains a `location.hash` read.
+ *   2. The argument references a SAME-FILE function whose body reads
+ *      `location.hash` (the common `useState(getTabFromHash)` form).
+ * Cross-file helpers are out of reach of rule 2, but every such helper call
+ * observed so far passes `window.location.hash` at the call site — which rule
+ * 1 catches.
+ *
+ * Legitimate exceptions (none known today) must carry an explicit
+ * `// hash-usestate-exempt: <reason>` marker on the enclosing statement.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join, dirname, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = resolve(__dirname, '../..'); // apps/web/src
+
+const LOCATION_HASH_RE = /\blocation\s*\.\s*hash\b/;
+
+type Violation = { line: number; snippet: string };
+
+function calleeName(expr: ts.Expression): string | null {
+  if (ts.isIdentifier(expr)) return expr.text;
+  if (ts.isPropertyAccessExpression(expr)) return expr.name.text; // React.useState
+  return null;
+}
+
+/** Names of functions declared in this file whose body reads location.hash. */
+function collectHashReadingHelpers(sf: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isFunctionDeclaration(node) && node.name && node.body) {
+      if (LOCATION_HASH_RE.test(node.body.getText(sf))) names.add(node.name.text);
+    } else if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer))
+    ) {
+      if (LOCATION_HASH_RE.test(node.initializer.getText(sf))) names.add(node.name.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return names;
+}
+
+function referencesAny(node: ts.Node, names: Set<string>): boolean {
+  if (names.size === 0) return false;
+  let found = false;
+  const visit = (n: ts.Node): void => {
+    if (found) return;
+    if (ts.isIdentifier(n) && names.has(n.text)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(node);
+  return found;
+}
+
+function enclosingStatementStart(node: ts.Node): number {
+  let cur: ts.Node = node;
+  while (
+    cur.parent &&
+    !ts.isBlock(cur.parent) &&
+    !ts.isSourceFile(cur.parent) &&
+    !ts.isModuleBlock(cur.parent) &&
+    !ts.isCaseClause(cur.parent) &&
+    !ts.isDefaultClause(cur.parent)
+  ) {
+    cur = cur.parent;
+  }
+  return cur.getFullStart();
+}
+
+function isExempt(src: string, node: ts.Node): boolean {
+  const from = enclosingStatementStart(node);
+  const window = src.slice(from, node.getStart());
+  return /hash-usestate-exempt/i.test(window);
+}
+
+export function findViolations(src: string, label = 'sample.tsx'): Violation[] {
+  const sf = ts.createSourceFile(label, src, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const hashHelpers = collectHashReadingHelpers(sf);
+  const violations: Violation[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && calleeName(node.expression) === 'useState') {
+      const arg = node.arguments[0];
+      if (arg) {
+        const direct = LOCATION_HASH_RE.test(arg.getText(sf));
+        // A bare same-file-helper reference (`useState(getTabFromHash)`) or a
+        // wrapped call (`useState(() => getTabFromHash())`) is just as unsafe.
+        const viaHelper = !direct && referencesAny(arg, hashHelpers);
+        if ((direct || viaHelper) && !isExempt(src, node)) {
+          const { line } = sf.getLineAndCharacterOfPosition(node.getStart());
+          violations.push({
+            line: line + 1,
+            snippet: node.getText(sf).replace(/\s+/g, ' ').slice(0, 120),
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return violations;
+}
+
+/** All non-test .ts/.tsx sources under apps/web/src. */
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue;
+      out.push(...listSourceFiles(full));
+      continue;
+    }
+    if (!/\.(ts|tsx)$/.test(entry)) continue;
+    if (/\.(test|spec)\.(ts|tsx)$/.test(entry)) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+// ─── Self-check: the analyzer itself has teeth ──────────────────────────────
+describe('guard self-checks (AST analyzer)', () => {
+  it('flags an inline lazy initializer reading location.hash', () => {
+    const src = `const [open] = useState(() => window.location.hash === '#add-device');`;
+    expect(findViolations(src)).toHaveLength(1);
+  });
+
+  it('flags a direct (non-lazy) initializer expression reading location.hash', () => {
+    const src = `const [tab] = useState(window.location.hash.replace('#', ''));`;
+    expect(findViolations(src)).toHaveLength(1);
+  });
+
+  it('flags a bare same-file helper reference (useState(getTabFromHash))', () => {
+    const src = `
+      function getTabFromHash() { return window.location.hash.replace('#', ''); }
+      const [tab] = useState(getTabFromHash);
+    `;
+    expect(findViolations(src)).toHaveLength(1);
+  });
+
+  it('flags a wrapped same-file helper call (useState(() => helper(...)))', () => {
+    const src = `
+      const readTab = () => window.location.hash.slice(1);
+      const [tab] = useState(() => resolve(readTab(), true));
+    `;
+    expect(findViolations(src)).toHaveLength(1);
+  });
+
+  it('does NOT flag a plain default initializer', () => {
+    expect(findViolations(`const [tab] = useState('overview');`)).toHaveLength(0);
+    expect(findViolations(`const [tab] = useState<string | null>(null);`)).toHaveLength(0);
+  });
+
+  it('does NOT flag a pure helper that takes the hash as a parameter', () => {
+    const src = `
+      function parseTab(hash: string) { return hash || 'overview'; }
+      const [tab] = useState(() => parseTab('overview'));
+    `;
+    expect(findViolations(src)).toHaveLength(0);
+  });
+
+  it('does NOT flag hash reads outside useState initializers (effects, handlers)', () => {
+    const src = `
+      const [tab, setTab] = useState('overview');
+      useEffect(() => { setTab(window.location.hash.slice(1)); }, []);
+      const onClick = () => { window.location.hash = 'x'; };
+    `;
+    expect(findViolations(src)).toHaveLength(0);
+  });
+
+  it('honours an explicit hash-usestate-exempt marker', () => {
+    const src = `
+      // hash-usestate-exempt: rendered client-only via client:only
+      const [tab] = useState(() => window.location.hash.slice(1));
+    `;
+    expect(findViolations(src)).toHaveLength(0);
+  });
+});
+
+// ─── Main guard ─────────────────────────────────────────────────────────────
+describe('no location.hash reads in useState initializers (apps/web/src)', () => {
+  const files = listSourceFiles(SRC_ROOT);
+
+  it('finds a plausible number of source files to scan (glob is not broken)', () => {
+    expect(files.length).toBeGreaterThan(200);
+  });
+
+  it('every hash-derived initial state goes through useHashState/useHashTab', () => {
+    const all: string[] = [];
+    for (const file of files) {
+      const src = readFileSync(file, 'utf8');
+      // Fast path: skip files that never mention both tokens.
+      if (!src.includes('useState') || !LOCATION_HASH_RE.test(src)) continue;
+      const rel = file.startsWith(SRC_ROOT) ? 'src' + file.slice(SRC_ROOT.length).split(sep).join('/') : file;
+      for (const v of findViolations(src, rel)) {
+        all.push(`  ${rel} L${v.line}: ${v.snippet}`);
+      }
+    }
+    expect(
+      all,
+      all.length
+        ? `location.hash read inside a useState initializer (SSR hydration mismatch, #2421):\n` +
+            all.join('\n') +
+            `\nUse useHashState/useHashTab from src/lib/useHashState.ts instead, or add ` +
+            `"// hash-usestate-exempt: <reason>" for a genuinely client-only component.`
+        : undefined
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/__tests__/no-hash-in-usestate.test.ts
+++ b/apps/web/src/lib/__tests__/no-hash-in-usestate.test.ts
@@ -40,8 +40,15 @@ function calleeName(expr: ts.Expression): string | null {
   return null;
 }
 
-/** Names of functions declared in this file whose body reads location.hash. */
-function collectHashReadingHelpers(sf: ts.SourceFile): Set<string> {
+/**
+ * Names declared in this file that carry a `location.hash` read — both
+ * hash-reading *functions* (`function getTabFromHash() {…}`, `const readTab =
+ * () => …`) and plain *values* computed from the hash (`const initial =
+ * window.location.hash.slice(1)`). The latter matters because `const initial =
+ * …hash…; useState(initial)` is the most natural thing to write once the guard
+ * reds a PR, and it reintroduces exactly the same hydration bug.
+ */
+function collectHashReadingNames(sf: ts.SourceFile): Set<string> {
   const names = new Set<string>();
   const visit = (node: ts.Node): void => {
     if (ts.isFunctionDeclaration(node) && node.name && node.body) {
@@ -50,9 +57,10 @@ function collectHashReadingHelpers(sf: ts.SourceFile): Set<string> {
       ts.isVariableDeclaration(node) &&
       ts.isIdentifier(node.name) &&
       node.initializer &&
-      (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer))
+      LOCATION_HASH_RE.test(node.initializer.getText(sf))
     ) {
-      if (LOCATION_HASH_RE.test(node.initializer.getText(sf))) names.add(node.name.text);
+      // Covers both function-valued and plain-value initializers.
+      names.add(node.name.text);
     }
     ts.forEachChild(node, visit);
   };
@@ -96,25 +104,38 @@ function isExempt(src: string, node: ts.Node): boolean {
   return /hash-usestate-exempt/i.test(window);
 }
 
+// `useReducer(reducer, initialArg, init)` has the same lazy-init hazard as
+// useState, so both are checked. The initial value is the last argument.
+const INIT_HOOKS = new Set(['useState', 'useReducer']);
+
 export function findViolations(src: string, label = 'sample.tsx'): Violation[] {
   const sf = ts.createSourceFile(label, src, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
-  const hashHelpers = collectHashReadingHelpers(sf);
+  const hashNames = collectHashReadingNames(sf);
   const violations: Violation[] = [];
 
   const visit = (node: ts.Node): void => {
-    if (ts.isCallExpression(node) && calleeName(node.expression) === 'useState') {
-      const arg = node.arguments[0];
-      if (arg) {
+    if (ts.isCallExpression(node)) {
+      const callee = calleeName(node.expression);
+      if (!callee || !INIT_HOOKS.has(callee)) {
+        ts.forEachChild(node, visit);
+        return;
+      }
+      // useState(initial) / useReducer(reducer, initialArg, init?) — the state
+      // seed is everything after the reducer for useReducer, the sole arg for useState.
+      const seedArgs =
+        callee === 'useReducer' ? node.arguments.slice(1) : node.arguments.slice(0, 1);
+      for (const arg of seedArgs) {
         const direct = LOCATION_HASH_RE.test(arg.getText(sf));
-        // A bare same-file-helper reference (`useState(getTabFromHash)`) or a
-        // wrapped call (`useState(() => getTabFromHash())`) is just as unsafe.
-        const viaHelper = !direct && referencesAny(arg, hashHelpers);
-        if ((direct || viaHelper) && !isExempt(src, node)) {
+        // A bare same-file reference (`useState(getTabFromHash)`, `useState(initial)`)
+        // or a wrapped call (`useState(() => getTabFromHash())`) is just as unsafe.
+        const viaName = !direct && referencesAny(arg, hashNames);
+        if ((direct || viaName) && !isExempt(src, node)) {
           const { line } = sf.getLineAndCharacterOfPosition(node.getStart());
           violations.push({
             line: line + 1,
             snippet: node.getText(sf).replace(/\s+/g, ' ').slice(0, 120),
           });
+          break;
         }
       }
     }
@@ -169,6 +190,19 @@ describe('guard self-checks (AST analyzer)', () => {
     expect(findViolations(src)).toHaveLength(1);
   });
 
+  it('flags a hash read hoisted into a local const (the natural way to dodge the guard)', () => {
+    const src = `
+      const initial = window.location.hash.slice(1);
+      const [tab] = useState(initial);
+    `;
+    expect(findViolations(src)).toHaveLength(1);
+  });
+
+  it('flags a lazy useReducer init reading location.hash', () => {
+    const src = `const [s, d] = useReducer(reducer, null, () => window.location.hash.slice(1));`;
+    expect(findViolations(src)).toHaveLength(1);
+  });
+
   it('does NOT flag a plain default initializer', () => {
     expect(findViolations(`const [tab] = useState('overview');`)).toHaveLength(0);
     expect(findViolations(`const [tab] = useState<string | null>(null);`)).toHaveLength(0);
@@ -206,6 +240,17 @@ describe('no location.hash reads in useState initializers (apps/web/src)', () =>
 
   it('finds a plausible number of source files to scan (glob is not broken)', () => {
     expect(files.length).toBeGreaterThan(200);
+  });
+
+  // The escape hatch is a free-form comment, so — unlike the runAction guard's
+  // reviewed allowlist module — nothing would otherwise stop someone silencing a
+  // real violation with CI still green. Pin the count at zero: adding the first
+  // legitimate exemption must be a deliberate, reviewed bump of this number.
+  it('nobody has silenced a violation with hash-usestate-exempt (expected: 0)', () => {
+    const exempted = files.filter((file) =>
+      /hash-usestate-exempt/i.test(readFileSync(file, 'utf8')),
+    );
+    expect(exempted).toEqual([]);
   });
 
   it('every hash-derived initial state goes through useHashState/useHashTab', () => {


### PR DESCRIPTION
## Summary

Phase 2 of #2421 (Phase 1 = #2433, which introduced the shared `useHashState`/`useHashTab` hooks and fixed the two live #2383 regressions). This PR sweeps the latent pages that still read `window.location.hash` inside a `useState` initializer — or bare in the render path — which makes React discard the SSR tree with a hydration-mismatch error on every deep link.

Closes #2421

## What changed

**23 components converted** to the shared hooks (state starts at the SSR-safe default; the hash is adopted in a pre-paint layout effect and tracked on `hashchange`):

- Simple tab pages → `useHashTab` / single-value `useHashState`: AuditBaselinesPage, AuthPage, BackupDashboard, DRDashboard, DnsSecurityPage, EdrPage, MonitoringPage, PamPage, SensitiveDataPage, SiteDetailPage
- Compound-hash pages (tab/sub-segment, object state): DeviceDetails (tab + focused anomaly), NetworkDeviceDetailPage, VulnerabilityFleetPage (tab + selection), AiForOfficePage (`policy/<orgId>`), VulnerabilitiesPage (`severity=` filter), OrganizationsPage (deep-linked org id)
- Param-style hash pages: TicketsPage (selection + sort), TimesheetPage (week + tech), InvoicesPage / QuotesPage / ContractsList (filters; ContractsList keeps its `lockedOrgId` embedded-mode semantics), ContractWorkspace (render-path `#orgId=` read), DevicesPage (add-device flag + v2 filter + device-class segment)
- PatchesPage: special case — keeps its scope-guarded `resolveTab` sync effect (org users deep-linking `#rings` still get downgraded and the stale hash cleared); only the initializer's hash read is removed.

**Mechanics:** hash-parse helpers became pure `(hash: string)` functions; now-redundant manual `hashchange` effects were deleted (the hook subscribes itself); every hash **write** (`window.location.hash = …`, `history.replaceState`, `writeHashFilters`, …) is untouched, so each page's hash schema and deep-link format are preserved exactly.

**Guard test** (`apps/web/src/lib/__tests__/no-hash-in-usestate.test.ts`): AST-based (TypeScript compiler API, modeled on `no-silent-mutations.test.ts`). Fails when any `useState` initializer under `apps/web/src` reads `location.hash` directly **or** via a same-file helper (`useState(getTabFromHash)`), with 8 self-checks proving the analyzer has teeth and a `// hash-usestate-exempt: <reason>` escape hatch. It flagged all 20+ pre-sweep offenders and passes clean after.

**Test adjustment:** TicketsPage's combined-hash deep-link test now asserts on the winning fetch rather than the seed fetch — the first render intentionally uses the SSR-safe default before the hook adopts the hash pre-paint (the page's `fetchSeq` already drops the stale response).

## Not converted (already SSR-safe, left alone)

DiscoveryPage, OrgSettingsPage, PartnerSettingsPage, TicketingSettingsTabs, InvoiceWorkspace, QuoteWorkspace (default-seeded + post-mount sync), and non-initializer hash uses (helpStore, authScope, AuthOverlay, M365MailboxCard, QuickbooksIntegration, listChrome).

## Verification

- New guard test + `useHashState.test.ts`: 19 passed
- 23 affected component test files (AuthPage, BackupDashboard, DRDashboard, EdrPage, VulnerabilitiesPage, PamPage, MonitoringPage, PatchesPage, SiteDetailPage, OrganizationsPage.firstSite, AiForOfficePage, NetworkDeviceDetailPage, TicketsPage, TimesheetPage, InvoicesPage ×2, QuotesPage ×2, ContractsList ×2, DevicesPage, VulnerabilityFleetPage, no-silent-mutations): all green
- `tsc --noEmit -p apps/web`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)