### PR TITLE
fix(web): gate row-menu Run Script on decommissioned (not offline) (#2426)

### DIFF
--- a/apps/web/src/components/devices/DeviceActions.test.tsx
+++ b/apps/web/src/components/devices/DeviceActions.test.tsx
@@ -97,7 +97,12 @@ describe('DeviceActions — offline gating (issue #2013)', () => {
       expect(power).toHaveAttribute('title', 'Device is offline');
     });
 
-    it('keeps Run Script and Remote Tools disabled with the offline tooltip (existing behavior)', () => {
+    // Remote Tools is a live session — disabled-when-offline is CORRECT.
+    // Run Script is a queued command and would be delivered on reconnect, so
+    // disabling it here is stricter than the API requires (#2426). That gate is
+    // deliberately deferred to a maintainer decision (PR #2457), not endorsed;
+    // this test pins the status quo so a change to it is a conscious one.
+    it('keeps Run Script and Remote Tools disabled with the offline tooltip (status quo — Run Script gate is stricter than the API, see #2426)', () => {
       render(<DeviceActions device={offlineDevice} />);
 
       const runScript = button(/run script/i);
@@ -118,11 +123,20 @@ describe('DeviceActions — offline gating (issue #2013)', () => {
     });
   });
 
-  // Intermediate statuses (maintenance/updating/quarantined/decommissioned/pending)
-  // are NOT online, so the agent can't service a live session or command. Before
-  // #2078 the action bar gated on `=== 'offline'`, leaving these buttons enabled
-  // and firing requests the API rejects with "Device is not online". They must
-  // now be disabled — with a status-accurate tooltip, not the wrong "offline" copy.
+  // Intermediate statuses (maintenance/updating/quarantined/decommissioned/pending).
+  // Before #2078 the action bar gated on `=== 'offline'`, so these buttons stayed
+  // enabled AND showed the wrong "Device is offline" copy. They are now disabled
+  // with a status-accurate tooltip, which is what these tests pin.
+  //
+  // CORRECTION (#2426): an earlier version of this comment claimed the agent
+  // "can't service a live session or command" in these states and that the API
+  // "rejects [them] with 'Device is not online'". That is true of LIVE SESSIONS
+  // (Connect Desktop, Remote Terminal, Remote Tools) only. QUEUED COMMANDS
+  // (Run Script, Reboot, Shutdown, Refresh) are inserted as pending
+  // `device_commands` and claimed on the agent's next poll — the API refuses
+  // them only for `decommissioned`. So for the queued commands these gates are
+  // stricter than the API requires; the tests below pin existing behaviour, they
+  // do not certify it as correct. See the category note in DeviceActions.tsx.
   describe('intermediate (non-online, non-offline) statuses — issue #2078', () => {
     it('disables session/command buttons for a device in maintenance mode', () => {
       render(<DeviceActions device={maintenanceDevice} />);

--- a/apps/web/src/components/devices/DeviceActions.tsx
+++ b/apps/web/src/components/devices/DeviceActions.tsx
@@ -33,24 +33,31 @@ import "../../lib/i18n";
 //   "Device is not online" comes ONLY from these routes (`terminalWs`,
 //   `desktopWs`, `tunnelWs`, `tunnels`, `bootMetrics`, `remote/sessions`).
 //
-//   QUEUED COMMAND — Run Script, Reboot, Shutdown, Refresh. These insert a
-//   `device_commands` row with `status:'pending'` (no TTL) and the agent claims
-//   it on its NEXT poll/heartbeat. The API gates them on `decommissioned` ONLY:
-//   `routes/devices/commands.ts` (:89, :157, :268, :437) and
-//   `services/scriptExecution.ts:118`, which filters `status !== 'decommissioned'`
-//   and returns `status:'queued'`. `routes/scripts.ts` has NO status gate at all.
-//   So a script queued against an offline device IS delivered — it runs when the
-//   machine comes back. That is a feature, not a doomed request.
+//   QUEUED COMMAND — Run Script, Reboot, Reboot to Safe Mode, Shutdown,
+//   Refresh. These insert a `device_commands` row with `status:'pending'` (no
+//   TTL) and the agent claims it on its NEXT poll/heartbeat. The only status
+//   the API refuses is `decommissioned`: `routes/devices/commands.ts` (:89,
+//   :157, :268, :437), and for scripts the shared `executeScriptOnDevices`
+//   service (`services/scriptExecution.ts:118`) — which drops decommissioned
+//   devices from the target set and returns `status:'queued'` for the rest.
+//   (The gate lives in that service, not in `routes/scripts.ts`.) So a script
+//   queued against an offline device IS delivered — it runs when the machine
+//   comes back. That is a feature, not a doomed request.
 //
 // Consequence: gating a queued command on `!== 'online'` does not prevent a
 // doomed request, it REMOVES working functionality. The only status that can
 // never service a queued command is `decommissioned` (agent-less by definition).
 //
-// The `!online` gates still applied to Run Script / Power / Refresh BELOW are
-// therefore stricter than the API requires. They are left in place pending a
-// maintainer decision (see PR #2457) rather than changed silently — but do not
-// copy them to new surfaces, and do not "fix" a missing gate by adding one.
-// Wake (Wake-on-LAN) targets offline devices by design and is never gated.
+// The `!online` gates BELOW on the queued commands — run-script (:261, :418),
+// refresh (:296, :520), reboot (:306, :474), reboot_safe_mode (:326, :484),
+// shutdown (:494), and the Power dropdown trigger (:459) — are therefore
+// stricter than the API requires. They are left in place pending a maintainer
+// decision (PR #2457) rather than changed silently. The `!online` gates on
+// Connect Desktop and Remote Tools are correct — those are live sessions.
+// Do not copy the queued-command gates to new surfaces, and do not "fix" a
+// missing gate by adding one; gate queued commands on `decommissioned`
+// (see DeviceList.tsx). Wake (Wake-on-LAN) targets offline devices by design
+// and is never gated.
 function isDeviceOnline(device: Device): boolean {
   return device.status === "online";
 }
@@ -188,8 +195,10 @@ export default function DeviceActions({
   const [modalType, setModalType] = useState<ModalType>("none");
   const [loading, setLoading] = useState(false);
 
-  // Session/command buttons are unavailable unless the agent is online. Wake
-  // (Wake-on-LAN) is intentionally exempt and gated on `=== 'offline'`.
+  // NOTE: `online` gates BOTH live-session buttons (correctly) and queued
+  // commands (more strictly than the API requires) — see the category note at
+  // the top of this file. It is not evidence that a queued command needs an
+  // online agent. Wake (Wake-on-LAN) is exempt and gated on `=== 'offline'`.
   const online = isDeviceOnline(device);
   const offlineTitle = online ? undefined : unavailableTitle(device.status, t);
 

--- a/apps/web/src/components/devices/DeviceActions.tsx
+++ b/apps/web/src/components/devices/DeviceActions.tsx
@@ -22,14 +22,35 @@ import { ConfirmDialog } from "../shared/ConfirmDialog";
 import { useTranslation } from "react-i18next";
 import "../../lib/i18n";
 
-// Live sessions and agent commands (Connect Desktop, Run Script, Remote Tools,
-// Power, Reboot, Refresh, …) require an actively-connected agent — i.e.
-// status === 'online'. Every other status (offline, maintenance,
-// decommissioned, quarantined, updating, pending) means the agent can't service
-// the request, so the API rejects it with "Device is not online". Gate on
-// `!== 'online'` (matching DeviceList.tsx) rather than `=== 'offline'` so
-// intermediate states don't fire doomed requests (#2078). Wake (Wake-on-LAN) is
-// the deliberate exception — it targets offline devices and stays reachable.
+// CORRECTION (#2426): an earlier version of this comment claimed that Run
+// Script / Power / Reboot / Refresh "require an actively-connected agent" and
+// that "the API rejects it with 'Device is not online'". **That was wrong**,
+// and it propagated into two PRs before anyone checked it against the API.
+// Two genuinely different categories live on this page:
+//
+//   LIVE SESSION — Connect Desktop, Remote Terminal, Remote Tools. These hand
+//   off a socket, so they really do need `status === 'online'`. The string
+//   "Device is not online" comes ONLY from these routes (`terminalWs`,
+//   `desktopWs`, `tunnelWs`, `tunnels`, `bootMetrics`, `remote/sessions`).
+//
+//   QUEUED COMMAND — Run Script, Reboot, Shutdown, Refresh. These insert a
+//   `device_commands` row with `status:'pending'` (no TTL) and the agent claims
+//   it on its NEXT poll/heartbeat. The API gates them on `decommissioned` ONLY:
+//   `routes/devices/commands.ts` (:89, :157, :268, :437) and
+//   `services/scriptExecution.ts:118`, which filters `status !== 'decommissioned'`
+//   and returns `status:'queued'`. `routes/scripts.ts` has NO status gate at all.
+//   So a script queued against an offline device IS delivered — it runs when the
+//   machine comes back. That is a feature, not a doomed request.
+//
+// Consequence: gating a queued command on `!== 'online'` does not prevent a
+// doomed request, it REMOVES working functionality. The only status that can
+// never service a queued command is `decommissioned` (agent-less by definition).
+//
+// The `!online` gates still applied to Run Script / Power / Refresh BELOW are
+// therefore stricter than the API requires. They are left in place pending a
+// maintainer decision (see PR #2457) rather than changed silently — but do not
+// copy them to new surfaces, and do not "fix" a missing gate by adding one.
+// Wake (Wake-on-LAN) targets offline devices by design and is never gated.
 function isDeviceOnline(device: Device): boolean {
   return device.status === "online";
 }

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -1060,7 +1060,7 @@ describe('DeviceList — vm_host guest nesting (#2308)', () => {
   });
 });
 
-describe('DeviceList — row-menu agent commands gated on device status (#2426)', () => {
+describe('DeviceList — row-menu action gating (#2426)', () => {
   beforeEach(() => {
     window.localStorage?.clear();
   });
@@ -1069,56 +1069,93 @@ describe('DeviceList — row-menu agent commands gated on device status (#2426)'
     fireEvent.click(screen.getByRole('button', { name: 'Device actions' }));
   };
 
-  it('disables Run Script (and siblings) for an offline device with a status tooltip', () => {
-    const onAction = vi.fn();
-    const device: Device = { ...baseDevice, status: 'offline' };
-    render(<DeviceList devices={[device]} onAction={onAction} />);
-    openRowMenu();
+  const runScriptBtn = () => screen.getByRole('button', { name: /run script/i });
 
-    const runScript = screen.getByRole('button', { name: /run script/i });
-    expect(runScript).toBeDisabled();
-    expect(runScript).toHaveAttribute('title', 'Device is offline');
-    fireEvent.click(runScript);
-    expect(onAction).not.toHaveBeenCalled();
-
-    // The sibling agent commands carry the same gate AND the same tooltip —
-    // they were already disabled, so assert the title too or a dropped
-    // tooltip would go unnoticed.
-    for (const name of [/remote terminal/i, /^reboot$/i]) {
-      const sibling = screen.getByRole('button', { name });
-      expect(sibling).toBeDisabled();
-      expect(sibling).toHaveAttribute('title', 'Device is offline');
-    }
-
-    // Wake (Wake-on-LAN) is the deliberate exception: it exists precisely to
-    // target an offline device, so it must stay enabled. Guards against a
-    // future "gate every row-menu action on !== online" sweep silently killing
-    // the one action that is only useful when the device is offline.
-    expect(screen.getByRole('button', { name: /^wake$/i })).toBeEnabled();
-  });
-
-  it('disables Run Script for a decommissioned device with a decommissioned tooltip', () => {
+  // The headline bug: a decommissioned device is agent-less and can NEVER claim
+  // a queued command. It is the one status the API genuinely rejects
+  // (commands.ts, scriptExecution.ts:118). #2315's "show decommissioned" toggle
+  // made these rows trivially reachable from the list.
+  it('disables Run Script for a decommissioned device, with a tooltip saying why', () => {
     const onAction = vi.fn();
     const device: Device = { ...baseDevice, status: 'decommissioned' };
     render(<DeviceList devices={[device]} onAction={onAction} includeDecommissioned />);
     openRowMenu();
 
-    const runScript = screen.getByRole('button', { name: /run script/i });
-    expect(runScript).toBeDisabled();
-    expect(runScript).toHaveAttribute('title', 'Device is decommissioned');
-    fireEvent.click(runScript);
+    expect(runScriptBtn()).toBeDisabled();
+    expect(runScriptBtn()).toHaveAttribute('title', 'Device is decommissioned');
+    fireEvent.click(runScriptBtn());
     expect(onAction).not.toHaveBeenCalled();
   });
 
-  it('keeps Run Script enabled (no tooltip) for an online device and emits the action', () => {
+  // REGRESSION GUARD. Run Script is a QUEUED command: the API inserts a pending
+  // device_commands row and the agent claims it on its next poll, so running a
+  // script against an offline machine works — it executes on reconnect. An
+  // earlier cut of this fix gated Run Script on `!== "online"` (copying the
+  // live-session siblings, on the strength of a code comment that turned out to
+  // be false) and would have silently REMOVED that capability. This test fails
+  // if anyone re-introduces that gate.
+  it('keeps Run Script ENABLED for an offline device — the command queues and runs on reconnect', () => {
+    const onAction = vi.fn();
+    const device: Device = { ...baseDevice, status: 'offline' };
+    render(<DeviceList devices={[device]} onAction={onAction} />);
+    openRowMenu();
+
+    expect(runScriptBtn()).toBeEnabled();
+    expect(runScriptBtn()).not.toHaveAttribute('title');
+    fireEvent.click(runScriptBtn());
+    expect(onAction).toHaveBeenCalledWith('run-script', device);
+  });
+
+  // Same argument for the other non-online, non-decommissioned states: the agent
+  // may be unreachable right now, but the command is still deliverable later.
+  it.each(['maintenance', 'quarantined', 'updating', 'pending'] as const)(
+    'keeps Run Script enabled for a %s device (queued command, not a live session)',
+    (status) => {
+      const onAction = vi.fn();
+      const device: Device = { ...baseDevice, status };
+      render(<DeviceList devices={[device]} onAction={onAction} />);
+      openRowMenu();
+
+      expect(runScriptBtn()).toBeEnabled();
+      fireEvent.click(runScriptBtn());
+      expect(onAction).toHaveBeenCalledWith('run-script', device);
+    },
+  );
+
+  it('emits run-script for an online device', () => {
     const onAction = vi.fn();
     render(<DeviceList devices={[baseDevice]} onAction={onAction} />);
     openRowMenu();
 
-    const runScript = screen.getByRole('button', { name: /run script/i });
-    expect(runScript).toBeEnabled();
-    expect(runScript).not.toHaveAttribute('title');
-    fireEvent.click(runScript);
+    expect(runScriptBtn()).toBeEnabled();
+    fireEvent.click(runScriptBtn());
     expect(onAction).toHaveBeenCalledWith('run-script', baseDevice);
+  });
+
+  // Remote Terminal really IS a live session (terminalWs rejects anything but
+  // online), so its `!== "online"` gate is correct. Reboot's identical gate is
+  // arguably too strict — it's a queued command — but that's pre-existing
+  // behaviour left for a maintainer call, so pin it as-is rather than leave it
+  // untested either way.
+  it('keeps the live-session gate on Remote Terminal (and the status-quo gate on Reboot) for an offline device', () => {
+    const device: Device = { ...baseDevice, status: 'offline' };
+    render(<DeviceList devices={[device]} />);
+    openRowMenu();
+
+    for (const name of [/remote terminal/i, /^reboot$/i]) {
+      const btn = screen.getByRole('button', { name });
+      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute('title', 'Device is offline');
+    }
+  });
+
+  // Wake (Wake-on-LAN) is the deliberate exception — it exists precisely to
+  // target an offline device. Guards against a future "gate every row-menu
+  // action" sweep killing the one action that's only useful when offline.
+  it('leaves Wake enabled on an offline device', () => {
+    render(<DeviceList devices={[{ ...baseDevice, status: 'offline' }]} />);
+    openRowMenu();
+
+    expect(screen.getByRole('button', { name: /^wake$/i })).toBeEnabled();
   });
 });

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -1081,8 +1081,20 @@ describe('DeviceList — row-menu agent commands gated on device status (#2426)'
     fireEvent.click(runScript);
     expect(onAction).not.toHaveBeenCalled();
 
-    expect(screen.getByRole('button', { name: /remote terminal/i })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /^reboot$/i })).toBeDisabled();
+    // The sibling agent commands carry the same gate AND the same tooltip —
+    // they were already disabled, so assert the title too or a dropped
+    // tooltip would go unnoticed.
+    for (const name of [/remote terminal/i, /^reboot$/i]) {
+      const sibling = screen.getByRole('button', { name });
+      expect(sibling).toBeDisabled();
+      expect(sibling).toHaveAttribute('title', 'Device is offline');
+    }
+
+    // Wake (Wake-on-LAN) is the deliberate exception: it exists precisely to
+    // target an offline device, so it must stay enabled. Guards against a
+    // future "gate every row-menu action on !== online" sweep silently killing
+    // the one action that is only useful when the device is offline.
+    expect(screen.getByRole('button', { name: /^wake$/i })).toBeEnabled();
   });
 
   it('disables Run Script for a decommissioned device with a decommissioned tooltip', () => {

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -1059,3 +1059,54 @@ describe('DeviceList — vm_host guest nesting (#2308)', () => {
     expect(screen.getByLabelText('Select vm-db')).toBeInTheDocument();
   });
 });
+
+describe('DeviceList — row-menu agent commands gated on device status (#2426)', () => {
+  beforeEach(() => {
+    window.localStorage?.clear();
+  });
+
+  const openRowMenu = () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Device actions' }));
+  };
+
+  it('disables Run Script (and siblings) for an offline device with a status tooltip', () => {
+    const onAction = vi.fn();
+    const device: Device = { ...baseDevice, status: 'offline' };
+    render(<DeviceList devices={[device]} onAction={onAction} />);
+    openRowMenu();
+
+    const runScript = screen.getByRole('button', { name: /run script/i });
+    expect(runScript).toBeDisabled();
+    expect(runScript).toHaveAttribute('title', 'Device is offline');
+    fireEvent.click(runScript);
+    expect(onAction).not.toHaveBeenCalled();
+
+    expect(screen.getByRole('button', { name: /remote terminal/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^reboot$/i })).toBeDisabled();
+  });
+
+  it('disables Run Script for a decommissioned device with a decommissioned tooltip', () => {
+    const onAction = vi.fn();
+    const device: Device = { ...baseDevice, status: 'decommissioned' };
+    render(<DeviceList devices={[device]} onAction={onAction} includeDecommissioned />);
+    openRowMenu();
+
+    const runScript = screen.getByRole('button', { name: /run script/i });
+    expect(runScript).toBeDisabled();
+    expect(runScript).toHaveAttribute('title', 'Device is decommissioned');
+    fireEvent.click(runScript);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('keeps Run Script enabled (no tooltip) for an online device and emits the action', () => {
+    const onAction = vi.fn();
+    render(<DeviceList devices={[baseDevice]} onAction={onAction} />);
+    openRowMenu();
+
+    const runScript = screen.getByRole('button', { name: /run script/i });
+    expect(runScript).toBeEnabled();
+    expect(runScript).not.toHaveAttribute('title');
+    fireEvent.click(runScript);
+    expect(onAction).toHaveBeenCalledWith('run-script', baseDevice);
+  });
+});

--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import DeviceList, { type Device } from './DeviceList';
@@ -1134,28 +1134,48 @@ describe('DeviceList — row-menu action gating (#2426)', () => {
 
   // Remote Terminal really IS a live session (terminalWs rejects anything but
   // online), so its `!== "online"` gate is correct. Reboot's identical gate is
-  // arguably too strict — it's a queued command — but that's pre-existing
-  // behaviour left for a maintainer call, so pin it as-is rather than leave it
-  // untested either way.
-  it('keeps the live-session gate on Remote Terminal (and the status-quo gate on Reboot) for an offline device', () => {
-    const device: Device = { ...baseDevice, status: 'offline' };
-    render(<DeviceList devices={[device]} />);
-    openRowMenu();
+  // stricter than the API requires — it's a queued command — but that's
+  // pre-existing behaviour left for a maintainer call, so pin it as-is rather
+  // than leave it untested either way.
+  //
+  // The per-status tooltip map is exercised across ALL six non-online statuses:
+  // it's new code mapping each to a distinct string, so a transposed entry
+  // (quarantined → "Device is updating") would otherwise ship silently.
+  it.each([
+    ['offline', 'Device is offline'],
+    ['maintenance', 'Device is in maintenance mode'],
+    ['decommissioned', 'Device is decommissioned'],
+    ['quarantined', 'Device is quarantined'],
+    ['updating', 'Device is updating'],
+    ['pending', 'Device is pending enrollment'],
+  ] as const)(
+    'disables Remote Terminal and Reboot for a %s device with the status-accurate tooltip',
+    (status, expectedTitle) => {
+      render(
+        <DeviceList devices={[{ ...baseDevice, status }]} includeDecommissioned />,
+      );
+      openRowMenu();
 
-    for (const name of [/remote terminal/i, /^reboot$/i]) {
-      const btn = screen.getByRole('button', { name });
-      expect(btn).toBeDisabled();
-      expect(btn).toHaveAttribute('title', 'Device is offline');
-    }
-  });
+      for (const name of [/remote terminal/i, /^reboot$/i]) {
+        const btn = screen.getByRole('button', { name });
+        expect(btn).toBeDisabled();
+        expect(btn).toHaveAttribute('title', expectedTitle);
+      }
+    },
+  );
 
   // Wake (Wake-on-LAN) is the deliberate exception — it exists precisely to
   // target an offline device. Guards against a future "gate every row-menu
   // action" sweep killing the one action that's only useful when offline.
-  it('leaves Wake enabled on an offline device', () => {
+  it('leaves Wake enabled on an offline device, and renders it only when offline', () => {
     render(<DeviceList devices={[{ ...baseDevice, status: 'offline' }]} />);
     openRowMenu();
-
     expect(screen.getByRole('button', { name: /^wake$/i })).toBeEnabled();
+
+    // Wake is offline-only by design — it must not appear on an online row.
+    cleanup();
+    render(<DeviceList devices={[baseDevice]} />);
+    openRowMenu();
+    expect(screen.queryByRole('button', { name: /^wake$/i })).toBeNull();
   });
 });

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -301,10 +301,24 @@ const statusFullLabelKeys: Record<DeviceStatus, string> = {
   pending: "deviceList.statuses.full.pending",
 };
 
-// Agent commands (Remote Terminal, Run Script, Reboot) require an
-// actively-connected agent — the API rejects them for any non-online status
-// with "Device is not online" (#2078), so there is no offline queuing to
-// preserve. Tooltip keys mirror unavailableTitle in DeviceActions.tsx (#2426).
+// Row-menu action gating (#2426). The two categories are NOT the same, and
+// conflating them is exactly the bug this fixes:
+//
+//   LIVE SESSION (Remote Terminal, Connect Desktop, Remote Tools) — needs an
+//   actively-connected agent to hand off a socket. `terminalWs`/`desktopWs`/
+//   `tunnelWs` reject anything but `online` with "Device is not online".
+//   → gate on `status !== 'online'`.
+//
+//   QUEUED COMMAND (Run Script, Reboot, Power, Refresh) — inserted as a
+//   `device_commands` row with `status:'pending'` and claimed on the agent's
+//   NEXT poll/heartbeat. The API gates these on `decommissioned` ONLY
+//   (`routes/devices/commands.ts`, `services/scriptExecution.ts:118`, which
+//   filters `status !== 'decommissioned'` and returns `status:'queued'`).
+//   Running a script against an OFFLINE device is a working, intentional
+//   feature: it executes on reconnect. Gating these on `!== 'online'` would
+//   REMOVE that capability.
+//   → gate on `status === 'decommissioned'` (an agent-less machine that can
+//     never claim the command — the one status the API genuinely rejects).
 const commandUnavailableTitleKeys: Record<
   Exclude<DeviceStatus, "online">,
   string
@@ -319,13 +333,28 @@ const commandUnavailableTitleKeys: Record<
 
 type DeviceTranslation = ReturnType<typeof useTranslation<"devices">>["t"];
 
-function commandUnavailableTitle(
+// Tooltip for a live-session action disabled because the agent isn't connected.
+function liveSessionUnavailableTitle(
   status: DeviceStatus,
   t: DeviceTranslation,
 ): string | undefined {
   return status === "online"
     ? undefined
     : t(/* i18n-dynamic */ commandUnavailableTitleKeys[status]);
+}
+
+// A queued command can only be refused outright for a decommissioned device.
+function isCommandQueueable(status: DeviceStatus): boolean {
+  return status !== "decommissioned";
+}
+
+function queuedCommandUnavailableTitle(
+  status: DeviceStatus,
+  t: DeviceTranslation,
+): string | undefined {
+  return isCommandQueueable(status)
+    ? undefined
+    : t("deviceActions.unavailable.decommissioned");
 }
 
 // Cap visible tag chips per row; the rest collapse into a +N chip, with the
@@ -2251,10 +2280,11 @@ export default function DeviceList({
                                   }}
                                   className="z-50 w-48 rounded-md border bg-card shadow-lg"
                                 >
+                                  {/* Live session — needs a connected agent. */}
                                   <button
                                     type="button"
                                     disabled={device.status !== "online"}
-                                    title={commandUnavailableTitle(
+                                    title={liveSessionUnavailableTitle(
                                       device.status,
                                       t,
                                     )}
@@ -2267,10 +2297,13 @@ export default function DeviceList({
                                     <Terminal className="h-4 w-4" />
                                     {t("deviceList.remoteTerminal")}{" "}
                                   </button>
+                                  {/* Queued command — an offline device runs it
+                                      on reconnect, so only a decommissioned
+                                      (agent-less) device is refused. */}
                                   <button
                                     type="button"
-                                    disabled={device.status !== "online"}
-                                    title={commandUnavailableTitle(
+                                    disabled={!isCommandQueueable(device.status)}
+                                    title={queuedCommandUnavailableTitle(
                                       device.status,
                                       t,
                                     )}
@@ -2283,10 +2316,16 @@ export default function DeviceList({
                                     <FileCode className="h-4 w-4" />
                                     {t("deviceList.runScript")}{" "}
                                   </button>
+                                  {/* Reboot is ALSO a queued command, so this
+                                      `!== "online"` gate is arguably too strict
+                                      by the same argument. Left as-is
+                                      deliberately — pre-existing behaviour, and
+                                      loosening it is a maintainer call (see PR
+                                      #2457 discussion). */}
                                   <button
                                     type="button"
                                     disabled={device.status !== "online"}
-                                    title={commandUnavailableTitle(
+                                    title={liveSessionUnavailableTitle(
                                       device.status,
                                       t,
                                     )}

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -301,6 +301,33 @@ const statusFullLabelKeys: Record<DeviceStatus, string> = {
   pending: "deviceList.statuses.full.pending",
 };
 
+// Agent commands (Remote Terminal, Run Script, Reboot) require an
+// actively-connected agent — the API rejects them for any non-online status
+// with "Device is not online" (#2078), so there is no offline queuing to
+// preserve. Tooltip keys mirror unavailableTitle in DeviceActions.tsx (#2426).
+const commandUnavailableTitleKeys: Record<
+  Exclude<DeviceStatus, "online">,
+  string
+> = {
+  offline: "deviceActions.unavailable.offline",
+  maintenance: "deviceActions.unavailable.maintenance",
+  decommissioned: "deviceActions.unavailable.decommissioned",
+  quarantined: "deviceActions.unavailable.quarantined",
+  updating: "deviceActions.unavailable.updating",
+  pending: "deviceActions.unavailable.pending",
+};
+
+type DeviceTranslation = ReturnType<typeof useTranslation<"devices">>["t"];
+
+function commandUnavailableTitle(
+  status: DeviceStatus,
+  t: DeviceTranslation,
+): string | undefined {
+  return status === "online"
+    ? undefined
+    : t(/* i18n-dynamic */ commandUnavailableTitleKeys[status]);
+}
+
 // Cap visible tag chips per row; the rest collapse into a +N chip, with the
 // full comma-joined list on the cell's title attribute (same overflow trick
 // as the status pill). Keeps row height and column width bounded.
@@ -2227,6 +2254,10 @@ export default function DeviceList({
                                   <button
                                     type="button"
                                     disabled={device.status !== "online"}
+                                    title={commandUnavailableTitle(
+                                      device.status,
+                                      t,
+                                    )}
                                     onClick={() => {
                                       onAction?.("terminal", device);
                                       setRowMenuOpenId(null);
@@ -2238,11 +2269,16 @@ export default function DeviceList({
                                   </button>
                                   <button
                                     type="button"
+                                    disabled={device.status !== "online"}
+                                    title={commandUnavailableTitle(
+                                      device.status,
+                                      t,
+                                    )}
                                     onClick={() => {
                                       onAction?.("run-script", device);
                                       setRowMenuOpenId(null);
                                     }}
-                                    className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted"
+                                    className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
                                   >
                                     <FileCode className="h-4 w-4" />
                                     {t("deviceList.runScript")}{" "}
@@ -2250,6 +2286,10 @@ export default function DeviceList({
                                   <button
                                     type="button"
                                     disabled={device.status !== "online"}
+                                    title={commandUnavailableTitle(
+                                      device.status,
+                                      t,
+                                    )}
                                     onClick={() => {
                                       onAction?.("reboot", device);
                                       setRowMenuOpenId(null);

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -301,28 +301,31 @@ const statusFullLabelKeys: Record<DeviceStatus, string> = {
   pending: "deviceList.statuses.full.pending",
 };
 
-// Row-menu action gating (#2426). The two categories are NOT the same, and
-// conflating them is exactly the bug this fixes:
+// Row-menu action gating (#2426). Two categories, and conflating them is the
+// bug this fixes. In THIS menu the members are:
 //
-//   LIVE SESSION (Remote Terminal, Connect Desktop, Remote Tools) — needs an
-//   actively-connected agent to hand off a socket. `terminalWs`/`desktopWs`/
-//   `tunnelWs` reject anything but `online` with "Device is not online".
+//   LIVE SESSION — Remote Terminal. Hands off a socket, so it needs an
+//   actively-connected agent. `terminalWs` (and its desktop/tunnel siblings)
+//   reject anything but `online` with "Device is not online".
 //   → gate on `status !== 'online'`.
 //
-//   QUEUED COMMAND (Run Script, Reboot, Power, Refresh) — inserted as a
-//   `device_commands` row with `status:'pending'` and claimed on the agent's
-//   NEXT poll/heartbeat. The API gates these on `decommissioned` ONLY
-//   (`routes/devices/commands.ts`, `services/scriptExecution.ts:118`, which
-//   filters `status !== 'decommissioned'` and returns `status:'queued'`).
-//   Running a script against an OFFLINE device is a working, intentional
-//   feature: it executes on reconnect. Gating these on `!== 'online'` would
-//   REMOVE that capability.
+//   QUEUED COMMAND — Run Script, Reboot. Inserted as a `device_commands` row
+//   with `status:'pending'` (no TTL) and claimed on the agent's NEXT
+//   poll/heartbeat. The only status the API refuses is `decommissioned`:
+//   `routes/devices/commands.ts` (:89, :157, :268, :437) and the shared
+//   `executeScriptOnDevices` service (`services/scriptExecution.ts:118`, which
+//   drops `status === 'decommissioned'` devices from the target set and returns
+//   `status:'queued'` for the rest). Running a script against an OFFLINE device
+//   is a working, intentional feature: it executes on reconnect. Gating a
+//   queued command on `!== 'online'` does not prevent a doomed request, it
+//   REMOVES that capability.
 //   → gate on `status === 'decommissioned'` (an agent-less machine that can
-//     never claim the command — the one status the API genuinely rejects).
-const commandUnavailableTitleKeys: Record<
-  Exclude<DeviceStatus, "online">,
-  string
-> = {
+//     never claim the command).
+//
+// Reboot is a queued command but still carries the `!== 'online'` gate below —
+// pre-existing behaviour, deliberately not loosened here. See the note in
+// DeviceActions.tsx and PR #2457.
+const notOnlineTitleKeys: Record<Exclude<DeviceStatus, "online">, string> = {
   offline: "deviceActions.unavailable.offline",
   maintenance: "deviceActions.unavailable.maintenance",
   decommissioned: "deviceActions.unavailable.decommissioned",
@@ -333,28 +336,29 @@ const commandUnavailableTitleKeys: Record<
 
 type DeviceTranslation = ReturnType<typeof useTranslation<"devices">>["t"];
 
-// Tooltip for a live-session action disabled because the agent isn't connected.
-function liveSessionUnavailableTitle(
+// Status-accurate tooltip for anything gated on `!== 'online'`. Says only why
+// the device isn't online — it does NOT assert which category the action is.
+function notOnlineTitle(
   status: DeviceStatus,
   t: DeviceTranslation,
 ): string | undefined {
   return status === "online"
     ? undefined
-    : t(/* i18n-dynamic */ commandUnavailableTitleKeys[status]);
+    : t(/* i18n-dynamic */ notOnlineTitleKeys[status]);
 }
 
-// A queued command can only be refused outright for a decommissioned device.
+// A queued command is refused only for a decommissioned device.
 function isCommandQueueable(status: DeviceStatus): boolean {
   return status !== "decommissioned";
 }
 
-function queuedCommandUnavailableTitle(
+function notQueueableTitle(
   status: DeviceStatus,
   t: DeviceTranslation,
 ): string | undefined {
   return isCommandQueueable(status)
     ? undefined
-    : t("deviceActions.unavailable.decommissioned");
+    : t(/* i18n-dynamic */ notOnlineTitleKeys.decommissioned);
 }
 
 // Cap visible tag chips per row; the rest collapse into a +N chip, with the
@@ -2284,7 +2288,7 @@ export default function DeviceList({
                                   <button
                                     type="button"
                                     disabled={device.status !== "online"}
-                                    title={liveSessionUnavailableTitle(
+                                    title={notOnlineTitle(
                                       device.status,
                                       t,
                                     )}
@@ -2303,7 +2307,7 @@ export default function DeviceList({
                                   <button
                                     type="button"
                                     disabled={!isCommandQueueable(device.status)}
-                                    title={queuedCommandUnavailableTitle(
+                                    title={notQueueableTitle(
                                       device.status,
                                       t,
                                     )}
@@ -2317,15 +2321,14 @@ export default function DeviceList({
                                     {t("deviceList.runScript")}{" "}
                                   </button>
                                   {/* Reboot is ALSO a queued command, so this
-                                      `!== "online"` gate is arguably too strict
-                                      by the same argument. Left as-is
-                                      deliberately — pre-existing behaviour, and
-                                      loosening it is a maintainer call (see PR
-                                      #2457 discussion). */}
+                                      `!== "online"` gate is stricter than the
+                                      API requires. Left as-is deliberately —
+                                      pre-existing behaviour, and loosening it
+                                      is a maintainer call (PR #2457). */}
                                   <button
                                     type="button"
                                     disabled={device.status !== "online"}
-                                    title={liveSessionUnavailableTitle(
+                                    title={notOnlineTitle(
                                       device.status,
                                       t,
                                     )}


### PR DESCRIPTION
> **Correction — the first cut of this PR was built on a false premise and has been rewritten.** It gated Run Script on `status !== 'online'`. That would have **removed working functionality**. Details in "The false premise" below; the fix now gates on `decommissioned`. Reviewers who saw the earlier version: the semantics have changed.

## Problem

The device-list row dropdown's **Run Script** item had no device-status guard at all. #2315's "N decommissioned hidden — show" toggle made decommissioned devices trivially reachable from the list, so scripts could be queued against **agent-less machines that can never run them**.

## The false premise (why v1 of this PR was wrong)

The comment at `DeviceActions.tsx:24-32` claimed that Run Script / Power / Reboot "require an actively-connected agent… so the API rejects it with *Device is not online*". I took it at face value and mirrored the `!== 'online'` gate from the sibling items. **The API does no such thing:**

| Claim | Reality |
|---|---|
| API rejects Run Script when not online | `routes/devices/commands.ts` rejects **only `decommissioned`** — `:89`, `:157`, `:268`, `:437`. No online/offline branch on the queued-command path. |
| Scripts need a live agent | `services/scriptExecution.ts:118` filters `status !== 'decommissioned'` and returns `status:'queued'`. `routes/scripts.ts` has **zero** device-status gating. |
| Commands die if the device is offline | They insert as `status:'pending'` with **no TTL** and are claimed on the agent's next poll/heartbeat. |
| `"Device is not online"` proves the gate | That string originates **only** from live-session routes — `terminalWs`, `desktopWs`, `tunnelWs`, `tunnels`, `bootMetrics`, `remote/sessions`. None of them is Run Script or Reboot. |

**Running a script against an offline device works today — it executes on reconnect.** That's a feature, not a doomed request. The comment over-generalised from Connect Desktop / Remote Terminal (which really *are* live sessions) to every action on the page.

## Fix

Two categories, gated differently:

- **Live session** (Remote Terminal) — hands off a socket, genuinely needs `online`. Gate unchanged: `!== 'online'`.
- **Queued command** (Run Script) — deliverable later. Gate is now **`=== 'decommissioned'`** only: the one status that can never claim a command, and the one the API actually rejects. Offline / maintenance / quarantined / updating / pending stay **enabled** and queue as designed.

Tooltip retained on the disabled state ("Device is decommissioned"), reusing existing `deviceActions.unavailable.*` keys — already translated in `en` and `pt-BR`, no new strings.

**Root cause also fixed:** the wrong comment in `DeviceActions.tsx` is rewritten to state plainly which actions are live-session (need `online`) and which are queued commands (need only *not decommissioned*), with the API file:line refs. It had already propagated this error into two PRs; leaving it would have produced a third.

## For the maintainer to decide (not changed here)

**The existing `!== 'online'` gates on Reboot / Power / Shutdown / Refresh are over-restrictive by exactly the same argument** — they're all queued commands that would be delivered on reconnect. That applies to the row-menu Reboot *and* the `DeviceActions` action-bar (Reboot, Power, Refresh, and the details-page Run Script itself).

I have **deliberately not touched them.** They are pre-existing behaviour, loosening them is a product call (do you *want* "reboot on next check-in" to be a one-click action?), and silently widening the blast radius of a bug-fix PR is how the original error spread. Both the code and this PR flag it. Note the consequence if you decline: the list's Run Script will allow offline queuing while the details page's Run Script still blocks it — a real inconsistency, resolvable either way, but yours to choose.

## Tests

`DeviceList.test.tsx` — pins the corrected semantics:
- decommissioned → Run Script disabled, tooltip "Device is decommissioned", no action emitted.
- **offline → Run Script ENABLED and emits `run-script`** (explicit regression guard against re-introducing the `!== 'online'` gate).
- maintenance / quarantined / updating / pending → enabled and emit (table-driven).
- Remote Terminal + Reboot keep their gate and tooltip on an offline row (status quo pinned, not left untested).
- Wake stays enabled on an offline row — it exists *to* target offline devices; guards a future "gate everything" sweep.

**Verification:** 112 tests green across `DeviceList`, `DeviceList.ptBR`, `DeviceList.unified`, `DeviceList.vpn`, `DeviceActions`, and the i18n literal-key gate. `npx tsc --noEmit` clean. **Mutation-checked:** putting the `!== 'online'` gate back turns 5 of the new tests red — the guard actually bites.

Closes #2426

🤖 Generated with [Claude Code](https://claude.com/claude-code)