### PR TITLE
feat(extensions): verification tripwires for the extension trust boundaries (#2424)

### DIFF
--- a/apps/api/scripts/check-drift.ts
+++ b/apps/api/scripts/check-drift.ts
@@ -97,9 +97,13 @@ async function main() {
         `[check-drift] WARN: ledger row "${row}" belongs to an extension not present on disk`,
       );
     }
-    if (absentExtensionRows.length > 0 && process.env.STRICT_EXTENSION_DRIFT === 'true') {
+    // Strict by default (#2424): an absent-extension ledger row usually means
+    // an extension was removed without cleaning up — its migrations can no
+    // longer be checksum-verified. Set STRICT_EXTENSION_DRIFT=false only for a
+    // deliberate, acknowledged extension removal.
+    if (absentExtensionRows.length > 0 && process.env.STRICT_EXTENSION_DRIFT !== 'false') {
       console.error(
-        '[check-drift] STRICT_EXTENSION_DRIFT=true — failing on absent-extension ledger rows',
+        '[check-drift] failing on absent-extension ledger rows (set STRICT_EXTENSION_DRIFT=false to tolerate a deliberate extension removal)',
       );
       process.exit(1);
     }

--- a/apps/api/src/__tests__/integration/extensionTenancyRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/extensionTenancyRls.integration.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { sql } from 'drizzle-orm';
+import type { ExtensionTenancyDeclaration } from '@breeze/extension-api';
+import { getTestDb } from './setup';
+import { assertExtensionTenancyRls } from '../../extensions/loader';
+
+/**
+ * Real-DB contract test for the extension RLS tripwire (#2424).
+ *
+ * WHY THIS FILE EXISTS: the unit tests in `extensions/loader.test.ts` mock
+ * `db.execute`, so they assert the *verdict logic* but prove nothing about the
+ * catalog query itself. That gap already bit once — the first cut of this
+ * assertion embedded the table list as `= ANY(${tables})`, which drizzle
+ * expands into a TUPLE (`= ANY(($1, $2, ...))`) that Postgres rejects outright.
+ * Every mocked test passed while the real query would have crashed the boot
+ * with a SQL syntax error instead of an RLS verdict — a tripwire that only
+ * ever fired the wrong alarm.
+ *
+ * So this suite runs `assertExtensionTenancyRls` against REAL Postgres, over
+ * fixture tables that reproduce each failure mode. It is the only thing that
+ * can prove the tripwire actually reads the catalog and actually distinguishes
+ * a compliant extension table from a non-compliant one.
+ */
+
+const FIXTURES = [
+  'ext_rls_good',
+  'ext_rls_notforced',
+  'ext_rls_nopolicy',
+  'ext_rls_bare',
+] as const;
+
+async function dropFixtures() {
+  const db = getTestDb();
+  await db.execute(sql.raw(`DROP TABLE IF EXISTS ${FIXTURES.join(', ')} CASCADE`));
+}
+
+beforeAll(async () => {
+  const db = getTestDb();
+  await dropFixtures();
+  // Fully compliant: RLS enabled + forced + a policy.
+  await db.execute(sql.raw(`
+    CREATE TABLE ext_rls_good (id uuid PRIMARY KEY, org_id uuid NOT NULL);
+    ALTER TABLE ext_rls_good ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE ext_rls_good FORCE ROW LEVEL SECURITY;
+    CREATE POLICY ext_rls_good_p ON ext_rls_good FOR ALL USING (true);
+  `));
+  // Enabled but NOT forced — the table owner would bypass RLS.
+  await db.execute(sql.raw(`
+    CREATE TABLE ext_rls_notforced (id uuid PRIMARY KEY, org_id uuid NOT NULL);
+    ALTER TABLE ext_rls_notforced ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY ext_rls_notforced_p ON ext_rls_notforced FOR ALL USING (true);
+  `));
+  // Enabled + forced but zero policies — deny-all, which is a misconfiguration
+  // we still want surfaced loudly rather than silently shipping a dead table.
+  await db.execute(sql.raw(`
+    CREATE TABLE ext_rls_nopolicy (id uuid PRIMARY KEY, org_id uuid NOT NULL);
+    ALTER TABLE ext_rls_nopolicy ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE ext_rls_nopolicy FORCE ROW LEVEL SECURITY;
+  `));
+  // No RLS at all — the case the tripwire exists to catch.
+  await db.execute(sql.raw(`CREATE TABLE ext_rls_bare (id uuid PRIMARY KEY, org_id uuid NOT NULL)`));
+});
+
+afterAll(async () => {
+  await dropFixtures();
+});
+
+function tenancy(
+  overrides: Partial<ExtensionTenancyDeclaration> = {},
+): ExtensionTenancyDeclaration {
+  return {
+    orgCascadeDeleteTables: [],
+    deviceCascadeDeleteTables: [],
+    deviceOrgDenormalizedTables: [],
+    ...overrides,
+  };
+}
+
+describe('assertExtensionTenancyRls (real Postgres)', () => {
+  it('passes for a table with RLS enabled + forced + at least one policy', async () => {
+    await expect(
+      assertExtensionTenancyRls('demo', tenancy({ orgCascadeDeleteTables: ['ext_rls_good'] })),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws when the declared table has no RLS at all', async () => {
+    await expect(
+      assertExtensionTenancyRls('demo', tenancy({ orgCascadeDeleteTables: ['ext_rls_bare'] })),
+    ).rejects.toThrow(/ext_rls_bare.*ROW LEVEL SECURITY enabled/s);
+  });
+
+  it('throws when RLS is enabled but not FORCEd', async () => {
+    await expect(
+      assertExtensionTenancyRls('demo', tenancy({ orgCascadeDeleteTables: ['ext_rls_notforced'] })),
+    ).rejects.toThrow(/FORCE ROW LEVEL SECURITY/);
+  });
+
+  it('throws when the table has RLS but zero policies', async () => {
+    await expect(
+      assertExtensionTenancyRls('demo', tenancy({ orgCascadeDeleteTables: ['ext_rls_nopolicy'] })),
+    ).rejects.toThrow(/no RLS policies/);
+  });
+
+  it('throws when a declared table does not exist in the catalog', async () => {
+    await expect(
+      assertExtensionTenancyRls('demo', tenancy({ orgCascadeDeleteTables: ['ext_rls_never_created'] })),
+    ).rejects.toThrow(/does not exist/);
+  });
+
+  it('reports every non-compliant table across all tenancy arrays in one error', async () => {
+    const err = await assertExtensionTenancyRls(
+      'demo',
+      tenancy({
+        orgCascadeDeleteTables: ['ext_rls_good', 'ext_rls_bare'],
+        deviceCascadeDeleteTables: ['ext_rls_notforced'],
+        deviceOrgDenormalizedTables: ['ext_rls_nopolicy'],
+      }),
+    ).catch((e: Error) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    const msg = (err as Error).message;
+    expect(msg).toContain('ext_rls_bare');
+    expect(msg).toContain('ext_rls_notforced');
+    expect(msg).toContain('ext_rls_nopolicy');
+    // The compliant table must NOT be reported as a problem.
+    expect(msg).not.toContain('ext_rls_good');
+    expect(msg).toContain('refusing to boot');
+  });
+
+  it('is a no-op (no DB round-trip needed) when the manifest declares no tenancy tables', async () => {
+    await expect(assertExtensionTenancyRls('demo', tenancy())).resolves.toBeUndefined();
+  });
+
+  it('verifies real core tables pass the same assertion (proves it reads the live catalog)', async () => {
+    // `devices` is a core tenant table — RLS enabled, forced, with policies.
+    // If the catalog query were broken, this would throw too.
+    await expect(
+      assertExtensionTenancyRls('core-sanity', tenancy({ orgCascadeDeleteTables: ['devices'] })),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/__tests__/integration/extensionTenancyRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/extensionTenancyRls.integration.test.ts
@@ -22,6 +22,21 @@ import { assertExtensionTenancyRls } from '../../extensions/loader';
  * a compliant extension table from a non-compliant one.
  */
 
+/**
+ * NOTE — these fixtures deliberately have NO `org_id` column. Do not add one.
+ *
+ * `rls-coverage.integration.test.ts` auto-discovers org-tenant tables purely by
+ * `column_name = 'org_id'` and then asserts RLS enabled + forced + policies.
+ * It runs against the SAME CI database as this suite. Three of these fixtures
+ * are intentionally RLS-broken, so giving them an `org_id` would make a leaked
+ * fixture (hook timeout, worker crash, cancelled run — anything that skips
+ * `afterAll`) look exactly like a real cross-tenant breach to the repo's
+ * highest-signal alarm, and `cleanupDatabase`'s TRUNCATE hand-list would never
+ * DROP an unknown table, so it would keep failing on unrelated PRs.
+ *
+ * The column buys the test nothing — `assertExtensionTenancyRls` reads only
+ * `pg_class` / `pg_policies` and never inspects columns.
+ */
 const FIXTURES = [
   'ext_rls_good',
   'ext_rls_notforced',
@@ -39,26 +54,26 @@ beforeAll(async () => {
   await dropFixtures();
   // Fully compliant: RLS enabled + forced + a policy.
   await db.execute(sql.raw(`
-    CREATE TABLE ext_rls_good (id uuid PRIMARY KEY, org_id uuid NOT NULL);
+    CREATE TABLE ext_rls_good (id uuid PRIMARY KEY);
     ALTER TABLE ext_rls_good ENABLE ROW LEVEL SECURITY;
     ALTER TABLE ext_rls_good FORCE ROW LEVEL SECURITY;
     CREATE POLICY ext_rls_good_p ON ext_rls_good FOR ALL USING (true);
   `));
   // Enabled but NOT forced — the table owner would bypass RLS.
   await db.execute(sql.raw(`
-    CREATE TABLE ext_rls_notforced (id uuid PRIMARY KEY, org_id uuid NOT NULL);
+    CREATE TABLE ext_rls_notforced (id uuid PRIMARY KEY);
     ALTER TABLE ext_rls_notforced ENABLE ROW LEVEL SECURITY;
     CREATE POLICY ext_rls_notforced_p ON ext_rls_notforced FOR ALL USING (true);
   `));
   // Enabled + forced but zero policies — deny-all, which is a misconfiguration
   // we still want surfaced loudly rather than silently shipping a dead table.
   await db.execute(sql.raw(`
-    CREATE TABLE ext_rls_nopolicy (id uuid PRIMARY KEY, org_id uuid NOT NULL);
+    CREATE TABLE ext_rls_nopolicy (id uuid PRIMARY KEY);
     ALTER TABLE ext_rls_nopolicy ENABLE ROW LEVEL SECURITY;
     ALTER TABLE ext_rls_nopolicy FORCE ROW LEVEL SECURITY;
   `));
   // No RLS at all — the case the tripwire exists to catch.
-  await db.execute(sql.raw(`CREATE TABLE ext_rls_bare (id uuid PRIMARY KEY, org_id uuid NOT NULL)`));
+  await db.execute(sql.raw(`CREATE TABLE ext_rls_bare (id uuid PRIMARY KEY)`));
 });
 
 afterAll(async () => {

--- a/apps/api/src/extensions/discovery.test.ts
+++ b/apps/api/src/extensions/discovery.test.ts
@@ -72,4 +72,18 @@ describe('discoverExtensions', () => {
     scaffold('alpha', { ...MANIFEST, name: 'alpha', routeNamespace: 'alpha', tenancy: {} });
     expect(discoverExtensions(root).map((e) => e.name)).toEqual(['alpha', 'zeta']);
   });
+
+  it('throws when two extensions declare the same routeNamespace', () => {
+    scaffold('alpha', { ...MANIFEST, name: 'alpha', routeNamespace: 'shared', tenancy: {} });
+    scaffold('beta', { ...MANIFEST, name: 'beta', routeNamespace: 'shared', tenancy: {} });
+    expect(() => discoverExtensions(root)).toThrow(/routeNamespace "shared" is declared by both/);
+  });
+
+  it('allows distinct routeNamespaces that differ from the extension name', () => {
+    scaffold('alpha', { ...MANIFEST, name: 'alpha', routeNamespace: 'alpha-routes', tenancy: {} });
+    scaffold('beta', { ...MANIFEST, name: 'beta', routeNamespace: 'beta-routes', tenancy: {} });
+    expect(discoverExtensions(root).map((e) => e.manifest.routeNamespace)).toEqual([
+      'alpha-routes', 'beta-routes',
+    ]);
+  });
 });

--- a/apps/api/src/extensions/discovery.ts
+++ b/apps/api/src/extensions/discovery.ts
@@ -65,5 +65,20 @@ export function discoverExtensions(root: string = resolveExtensionsRoot()): Disc
       migrationsDir: existsSync(migrationsDir) ? migrationsDir : null,
     });
   }
+  // Cross-extension collision tripwire. Directory names guarantee unique
+  // extension names, but two extensions could still declare the same
+  // routeNamespace — the second mount would silently shadow (or interleave
+  // with) the first, including its auth guard. Fail discovery instead.
+  const namespaceOwners = new Map<string, string>();
+  for (const ext of out) {
+    const owner = namespaceOwners.get(ext.manifest.routeNamespace);
+    if (owner) {
+      throw new Error(
+        `[extensions] routeNamespace "${ext.manifest.routeNamespace}" is declared by both "${owner}" and "${ext.name}"`,
+      );
+    }
+    namespaceOwners.set(ext.manifest.routeNamespace, ext.name);
+  }
+
   return out.sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/apps/api/src/extensions/loader.test.ts
+++ b/apps/api/src/extensions/loader.test.ts
@@ -4,8 +4,20 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 vi.mock('../services/aiTools', () => ({ aiTools: new Map() }));
-vi.mock('../middleware/auth', () => ({ authMiddleware: async (_c: unknown, next: () => Promise<void>) => next() }));
-vi.mock('../middleware/agentAuth', () => ({ agentAuthMiddleware: async (_c: unknown, next: () => Promise<void>) => next() }));
+// Auth mocks stamp a response header so tests can observe WHICH guard the
+// loader's default-deny wrapper applied to each route.
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: async (c: { header: (k: string, v: string) => void }, next: () => Promise<void>) => {
+    c.header('x-guard', 'user');
+    return next();
+  },
+}));
+vi.mock('../middleware/agentAuth', () => ({
+  agentAuthMiddleware: async (c: { header: (k: string, v: string) => void }, next: () => Promise<void>) => {
+    c.header('x-guard', 'agent');
+    return next();
+  },
+}));
 vi.mock('../services/auditService', () => ({ createAuditLogAsync: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../services/secretCrypto', () => ({
   encryptSecret: vi.fn((value: string, options: { aad?: string }) => `encrypted:${options.aad}:${value}`),
@@ -18,7 +30,11 @@ vi.mock('../services/clientIp', () => ({ getTrustedClientIp: () => 'extension-lo
 import { mountExtensions } from './loader';
 import { __resetSkipPrefixesForTests, globalRateLimit } from '../middleware/globalRateLimit';
 
-function scaffoldRuntimeExtension(root: string, manifestOverrides: Record<string, unknown> = {}) {
+function scaffoldRuntimeExtension(
+  root: string,
+  manifestOverrides: Record<string, unknown> = {},
+  entrySource?: string,
+) {
   const dir = join(root, 'demo');
   mkdirSync(join(dir, 'src'), { recursive: true });
   writeFileSync(
@@ -28,13 +44,14 @@ function scaffoldRuntimeExtension(root: string, manifestOverrides: Record<string
   // A real loadable entry — plain TS, imported under vitest's transform.
   writeFileSync(
     join(dir, 'src', 'index.ts'),
-    `import { Hono } from 'hono';
+    entrySource ?? `import { Hono } from 'hono';
      const ext = {
        register(ctx) {
          const app = new Hono();
          const initialAiToolCount = ctx.aiTools.size;
          app.get('/health', (c) => c.json({ ok: true, ext: 'demo', initialAiToolCount }));
          app.get('/agent/health', (c) => c.json({ ok: true }));
+         app.get('/pub/thing', (c) => c.json({ ok: true, pub: true }));
          ctx.mountRoute(app);
          ctx.aiTools.set('demo_tool', { definition: { name: 'demo_tool', description: 'x', input_schema: { type: 'object' } }, tier: 1, handler: async () => 'ok' });
          const ciphertext = ctx.secrets.encryptForColumn('demo_secrets', 'value', 'secret');
@@ -175,5 +192,135 @@ describe('mountExtensions', () => {
     aiTools.set('demo_tool', { definition: { name: 'demo_tool' } } as never);
     const app = new Hono();
     await expect(mountExtensions(app, root)).rejects.toThrow(/demo_tool/);
+  });
+
+  describe('default-deny auth guard', () => {
+    it('applies core authMiddleware to non-agent routes and agentAuthMiddleware to /agent/ routes', async () => {
+      scaffoldRuntimeExtension(root);
+      const app = new Hono();
+      await mountExtensions(app, root);
+
+      const userRoute = await app.request('/api/v1/demo/health');
+      expect(userRoute.status).toBe(200);
+      expect(userRoute.headers.get('x-guard')).toBe('user');
+
+      const agentRoute = await app.request('/api/v1/demo/agent/health');
+      expect(agentRoute.status).toBe(200);
+      expect(agentRoute.headers.get('x-guard')).toBe('agent');
+    });
+
+    it('skips core auth only for manifest-declared publicRoutes (exact match)', async () => {
+      scaffoldRuntimeExtension(root, { publicRoutes: ['/health'] });
+      const app = new Hono();
+      await mountExtensions(app, root);
+
+      const publicRoute = await app.request('/api/v1/demo/health');
+      expect(publicRoute.status).toBe(200);
+      expect(publicRoute.headers.get('x-guard')).toBeNull();
+
+      // Everything not listed stays behind core auth.
+      const guarded = await app.request('/api/v1/demo/pub/thing');
+      expect(guarded.headers.get('x-guard')).toBe('user');
+      const agentRoute = await app.request('/api/v1/demo/agent/health');
+      expect(agentRoute.headers.get('x-guard')).toBe('agent');
+    });
+
+    it('supports wildcard publicRoutes prefixes', async () => {
+      scaffoldRuntimeExtension(root, { publicRoutes: ['/pub/*'] });
+      const app = new Hono();
+      await mountExtensions(app, root);
+
+      const pub = await app.request('/api/v1/demo/pub/thing');
+      expect(pub.status).toBe(200);
+      expect(pub.headers.get('x-guard')).toBeNull();
+
+      const guarded = await app.request('/api/v1/demo/health');
+      expect(guarded.headers.get('x-guard')).toBe('user');
+    });
+
+    it('does not register the rate-limit skip prefix when the extension never mounts routes', async () => {
+      scaffoldRuntimeExtension(
+        root,
+        { agentRoutes: true },
+        'const ext = { register(ctx) { /* declares agentRoutes but never calls ctx.mountRoute */ } }; export default ext;',
+      );
+      const app = new Hono();
+      app.use('*', globalRateLimit({ limit: 1, windowSeconds: 60 }));
+      app.get('/api/v1/demo/agent/ping', (c) => c.json({ ok: true }));
+
+      await mountExtensions(app, root);
+
+      // No loader-wrapped /agent/ prefix exists, so the exemption was never
+      // granted — the global limiter still applies to the namespace.
+      expect((await app.request('/api/v1/demo/agent/ping')).status).toBe(200);
+      expect((await app.request('/api/v1/demo/agent/ping')).status).toBe(429);
+    });
+  });
+
+  describe('boot-time extension RLS assertion', () => {
+    const tenancy = { orgCascadeDeleteTables: ['demo_items'] };
+
+    async function mockRlsCatalog(rows: unknown[]) {
+      const { db } = await import('../db');
+      (db.execute as ReturnType<typeof vi.fn>).mockResolvedValue(rows);
+    }
+
+    it('mounts when every declared table has RLS enabled + forced + at least one policy', async () => {
+      scaffoldRuntimeExtension(root, { tenancy });
+      await mockRlsCatalog([
+        { table_name: 'demo_items', rls_enabled: true, rls_forced: true, policy_count: 2 },
+      ]);
+      const app = new Hono();
+      await mountExtensions(app, root);
+      expect((await app.request('/api/v1/demo/health')).status).toBe(200);
+    });
+
+    it('fails the boot when a declared table does not exist', async () => {
+      scaffoldRuntimeExtension(root, { tenancy });
+      await mockRlsCatalog([]);
+      await expect(mountExtensions(new Hono(), root)).rejects.toThrow(/demo_items.*does not exist/);
+    });
+
+    it('fails the boot when RLS is enabled but not forced', async () => {
+      scaffoldRuntimeExtension(root, { tenancy });
+      await mockRlsCatalog([
+        { table_name: 'demo_items', rls_enabled: true, rls_forced: false, policy_count: 1 },
+      ]);
+      await expect(mountExtensions(new Hono(), root)).rejects.toThrow(/FORCE ROW LEVEL SECURITY/);
+    });
+
+    it('fails the boot when a declared table has zero policies', async () => {
+      scaffoldRuntimeExtension(root, { tenancy });
+      await mockRlsCatalog([
+        { table_name: 'demo_items', rls_enabled: true, rls_forced: true, policy_count: 0 },
+      ]);
+      await expect(mountExtensions(new Hono(), root)).rejects.toThrow(/no RLS policies/);
+    });
+
+    it('checks every tenancy array, deduplicated', async () => {
+      scaffoldRuntimeExtension(root, {
+        tenancy: {
+          orgCascadeDeleteTables: ['demo_items'],
+          deviceCascadeDeleteTables: ['demo_items', 'demo_child'],
+          deviceOrgDenormalizedTables: ['demo_events'],
+          deviceOrgMoveDeleteTables: ['demo_moves'],
+        },
+      });
+      await mockRlsCatalog([]);
+      const err = await mountExtensions(new Hono(), root).catch((e: Error) => e);
+      expect(err).toBeInstanceOf(Error);
+      const msg = (err as Error).message;
+      for (const table of ['demo_items', 'demo_child', 'demo_events', 'demo_moves']) {
+        expect(msg).toContain(`"${table}"`);
+      }
+      expect(msg.match(/demo_items/g)).toHaveLength(1); // deduped across arrays
+    });
+
+    it('skips the DB probe entirely when no tenancy tables are declared', async () => {
+      scaffoldRuntimeExtension(root); // tenancy: {}
+      const { db } = await import('../db');
+      await mountExtensions(new Hono(), root);
+      expect(db.execute).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/extensions/loader.test.ts
+++ b/apps/api/src/extensions/loader.test.ts
@@ -7,16 +7,20 @@ vi.mock('../services/aiTools', () => ({ aiTools: new Map() }));
 // Auth mocks stamp a response header so tests can observe WHICH guard the
 // loader's default-deny wrapper applied to each route.
 vi.mock('../middleware/auth', () => ({
-  authMiddleware: async (c: { header: (k: string, v: string) => void }, next: () => Promise<void>) => {
-    c.header('x-guard', 'user');
-    return next();
-  },
+  authMiddleware: vi.fn(
+    async (c: { header: (k: string, v: string) => void }, next: () => Promise<void>) => {
+      c.header('x-guard', 'user');
+      return next();
+    },
+  ),
 }));
 vi.mock('../middleware/agentAuth', () => ({
-  agentAuthMiddleware: async (c: { header: (k: string, v: string) => void }, next: () => Promise<void>) => {
-    c.header('x-guard', 'agent');
-    return next();
-  },
+  agentAuthMiddleware: vi.fn(
+    async (c: { header: (k: string, v: string) => void }, next: () => Promise<void>) => {
+      c.header('x-guard', 'agent');
+      return next();
+    },
+  ),
 }));
 vi.mock('../services/auditService', () => ({ createAuditLogAsync: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../services/secretCrypto', () => ({
@@ -236,6 +240,87 @@ describe('mountExtensions', () => {
 
       const guarded = await app.request('/api/v1/demo/health');
       expect(guarded.headers.get('x-guard')).toBe('user');
+    });
+
+    // The ctx-injected middlewares no-op only when the loader ALREADY ran the
+    // SAME kind of auth. A boolean "loader authed" flag would make a mismatched
+    // middleware silently evaporate — e.g. an extension applying
+    // ctx.agentAuthMiddleware to a non-/agent/ route would get user auth
+    // instead, with c.get('agent') undefined: an auth downgrade.
+    it('runs the extension\'s ctx.agentAuthMiddleware on a non-/agent/ route (loader ran USER auth — kinds differ, must not be skipped)', async () => {
+      scaffoldRuntimeExtension(
+        root,
+        {},
+        `import { Hono } from 'hono';
+         const ext = {
+           register(ctx) {
+             const app = new Hono();
+             // Extension explicitly demands AGENT auth on a path the loader
+             // default-denies with USER auth. Both must run — fail closed.
+             app.use('/telemetry', ctx.agentAuthMiddleware);
+             app.get('/telemetry', (c) => c.json({ ok: true }));
+             ctx.mountRoute(app);
+           },
+         };
+         export default ext;`,
+      );
+      const app = new Hono();
+      await mountExtensions(app, root);
+
+      const res = await app.request('/api/v1/demo/telemetry');
+      expect(res.status).toBe(200);
+      // The loader's user guard ran AND the extension's agent middleware ran —
+      // the header is overwritten by whichever ran last, so 'agent' proves the
+      // extension's middleware was NOT silently skipped.
+      expect(res.headers.get('x-guard')).toBe('agent');
+    });
+
+    it('no-ops a redundant ctx.authMiddleware when the loader already ran the SAME (user) auth', async () => {
+      scaffoldRuntimeExtension(
+        root,
+        {},
+        `import { Hono } from 'hono';
+         const ext = {
+           register(ctx) {
+             const app = new Hono();
+             // Redundant: the loader already applies user auth to this path.
+             app.use('/thing', ctx.authMiddleware);
+             app.get('/thing', (c) => c.json({ ok: true }));
+             ctx.mountRoute(app);
+           },
+         };
+         export default ext;`,
+      );
+      const app = new Hono();
+      await mountExtensions(app, root);
+
+      const { authMiddleware } = await import('../middleware/auth');
+      const res = await app.request('/api/v1/demo/thing');
+      expect(res.status).toBe(200);
+      // Core user auth ran exactly ONCE (the loader's) — the extension's
+      // redundant call was skipped, so the per-IP/per-agent rate counters
+      // inside core auth are not double-incremented.
+      expect(vi.mocked(authMiddleware)).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when an extension calls ctx.mountRoute twice (second sub-app would shadow the first)', async () => {
+      scaffoldRuntimeExtension(
+        root,
+        {},
+        `import { Hono } from 'hono';
+         const ext = {
+           register(ctx) {
+             const a = new Hono();
+             a.get('/health', (c) => c.json({ ok: true }));
+             ctx.mountRoute(a);
+             const b = new Hono();
+             b.get('/health', (c) => c.json({ shadowed: true }));
+             ctx.mountRoute(b);
+           },
+         };
+         export default ext;`,
+      );
+      await expect(mountExtensions(new Hono(), root)).rejects.toThrow(/mountRoute more than once/);
     });
 
     it('does not register the rate-limit skip prefix when the extension never mounts routes', async () => {

--- a/apps/api/src/extensions/loader.ts
+++ b/apps/api/src/extensions/loader.ts
@@ -45,11 +45,22 @@ async function loadEntry(dir: string, entry: string): Promise<BreezeExtension> {
   return ext;
 }
 
-// Context variable marking that the loader guard already authenticated this
-// request, so the ctx-injected middlewares can no-op instead of running the
-// (side-effectful: per-agent/per-IP rate counters) core auth twice when an
-// extension also applies them itself.
-const LOADER_AUTH_APPLIED = 'extensionLoaderAuthApplied';
+// Records WHICH core auth the loader guard already ran for this request, so a
+// ctx-injected middleware can no-op instead of running the (side-effectful:
+// per-agent/per-IP rate counters) core auth twice when an extension redundantly
+// applies the SAME one itself.
+//
+// This stores the KIND, not a boolean, and that distinction is load-bearing.
+// `authMiddleware` and `agentAuthMiddleware` are not interchangeable — they
+// accept disjoint credentials and set disjoint context vars (auth+permissions
+// vs agent). With a boolean, an extension applying `ctx.agentAuthMiddleware` to
+// a route NOT under /agent/ would have it silently evaporate after the loader
+// ran USER auth: the route would fall back to "any authenticated user token"
+// with `c.get('agent')` undefined, downgrading a device-bound ingest route into
+// a cross-tenant primitive. So a MISMATCHED kind must still run — the request
+// then needs both and 401s (fail closed) — and is never silently skipped.
+type LoaderAuthKind = 'user' | 'agent';
+const LOADER_AUTH_KIND = 'extensionLoaderAuthKind';
 
 /**
  * Default-deny auth guard for one extension namespace. Evaluated per request
@@ -76,21 +87,25 @@ export function buildExtensionAuthGuard(
   return async (c, next) => {
     const rel = c.req.path.slice(mountPrefix.length) || '/';
     if (rel === '/agent' || rel.startsWith('/agent/')) {
-      c.set(LOADER_AUTH_APPLIED, true);
+      c.set(LOADER_AUTH_KIND, 'agent');
       return agentAuthMiddleware(c, next);
     }
     if (publicExact.has(rel) || publicPrefixes.some((p) => rel.startsWith(p))) {
       return next();
     }
-    c.set(LOADER_AUTH_APPLIED, true);
+    c.set(LOADER_AUTH_KIND, 'user');
     return authMiddleware(c, next);
   };
 }
 
-/** Wrap a core auth middleware so it no-ops when the loader guard already ran. */
-function skipIfLoaderAuthed(inner: MiddlewareHandler): MiddlewareHandler {
+/**
+ * Wrap a core auth middleware so it no-ops ONLY when the loader guard already
+ * ran the SAME kind of auth for this request. A mismatched kind still runs —
+ * skipping it would silently strip the guarantee the extension asked for.
+ */
+function skipIfLoaderAuthed(inner: MiddlewareHandler, kind: LoaderAuthKind): MiddlewareHandler {
   return (c, next) => {
-    if (c.get(LOADER_AUTH_APPLIED) === true) return next();
+    if (c.get(LOADER_AUTH_KIND) === kind) return next();
     return inner(c, next);
   };
 }
@@ -121,7 +136,20 @@ export async function assertExtensionTenancyRls(
       ...(tenancy.deviceOrgMoveDeleteTables ?? []),
     ]),
   ];
-  if (tables.length === 0) return;
+  if (tables.length === 0) {
+    // This check verifies that DECLARED tables have RLS — it cannot verify that
+    // the extension declared all the tables it created (the policed party still
+    // writes the policy). An extension whose migrations create tenant tables but
+    // whose manifest omits them gets no check at all, so at minimum make the
+    // silence audible. Deriving the table set from the extension's own
+    // migrations and requiring every one to be declared is the real fix.
+    console.warn(
+      `[extensions] "${extensionName}" declares no tenancy tables — no RLS verification performed. `
+        + 'If this extension creates tenant-scoped tables, they MUST be listed in the manifest '
+        + 'tenancy arrays or they ship with no RLS coverage check whatsoever.',
+    );
+    return;
+  }
 
   // Bind the table list as an explicit ARRAY[...] of individually-parameterised
   // text literals. Embedding the JS array directly (`= ANY(${tables})`) makes
@@ -136,7 +164,10 @@ export async function assertExtensionTenancyRls(
              WHERE p.schemaname = 'public' AND p.tablename = c.relname) AS policy_count
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
-    WHERE n.nspname = 'public' AND c.relkind = 'r'
+    -- 'r' = ordinary table, 'p' = partitioned table. Omitting 'p' would report
+    -- a partitioned extension table as "does not exist" and send the operator
+    -- chasing a migration bug that isn't there.
+    WHERE n.nspname = 'public' AND c.relkind IN ('r', 'p')
       AND c.relname::text = ANY(ARRAY[${tableList}]::text[])
   `)) as unknown as RlsCatalogRow[] | { rows?: RlsCatalogRow[] };
   const rows: RlsCatalogRow[] = Array.isArray(result) ? result : (result.rows ?? []);
@@ -151,7 +182,12 @@ export async function assertExtensionTenancyRls(
     }
     if (!row.rls_enabled) problems.push(`"${table}" does not have ROW LEVEL SECURITY enabled`);
     if (!row.rls_forced) problems.push(`"${table}" does not have ROW LEVEL SECURITY forced (ALTER TABLE ... FORCE ROW LEVEL SECURITY)`);
-    if (Number(row.policy_count) === 0) problems.push(`"${table}" has no RLS policies (pg_policies is empty for it)`);
+    // Phrased as `!(n > 0)` rather than `=== 0` so a NaN/null/undefined
+    // policy_count (unexpected row shape, driver change) fails CLOSED like its
+    // two siblings. `Number(undefined) === 0` is false — which would have let a
+    // policy-less table pass silently, in the one function whose whole contract
+    // is to fail loudly.
+    if (!(Number(row.policy_count) > 0)) problems.push(`"${table}" has no RLS policies (pg_policies is empty for it)`);
   }
   if (problems.length > 0) {
     throw new Error(
@@ -174,8 +210,23 @@ export async function mountExtensions(app: Hono, root?: string): Promise<void> {
     const ext = await loadEntry(d.dir, d.manifest.entry);
     await assertExtensionTenancyRls(d.name, d.manifest.tenancy);
     const mountPrefix = `/api/v1/${d.manifest.routeNamespace}`;
+    let mounted = false;
     const ctx: ExtensionContext = {
       mountRoute: (subApp) => {
+        // Each mountRoute call registers its own `use('*', guard)` at the same
+        // prefix, and Hono runs EVERY matching wildcard — so a second call would
+        // run core auth twice per request (double-incrementing the per-agent /
+        // per-IP rate counters, so agents 429 at half the intended rate) while
+        // silently shadowing the first sub-app for any overlapping route. Both
+        // are exactly the quiet misconfiguration these tripwires exist to kill.
+        if (mounted) {
+          throw new Error(
+            `[extensions] "${d.name}" called ctx.mountRoute more than once — `
+              + `a second sub-app at ${mountPrefix} would double-run core auth and `
+              + 'shadow the first. Compose your routes into a single Hono app before mounting.',
+          );
+        }
+        mounted = true;
         const guarded = new Hono();
         guarded.use('*', buildExtensionAuthGuard(mountPrefix, d.manifest));
         guarded.route('/', subApp);
@@ -186,8 +237,8 @@ export async function mountExtensions(app: Hono, root?: string): Promise<void> {
           registerGlobalRateLimitSkipPrefix(`${mountPrefix}/agent/`);
         }
       },
-      authMiddleware: skipIfLoaderAuthed(authMiddleware),
-      agentAuthMiddleware: skipIfLoaderAuthed(agentAuthMiddleware),
+      authMiddleware: skipIfLoaderAuthed(authMiddleware, 'user'),
+      agentAuthMiddleware: skipIfLoaderAuthed(agentAuthMiddleware, 'agent'),
       db: db as unknown as ExtensionDatabase,
       secrets: {
         encryptForColumn: (table, column, plaintext) =>
@@ -216,6 +267,14 @@ export async function mountExtensions(app: Hono, root?: string): Promise<void> {
       log: (message) => console.log(`[extensions:${d.name}] ${message}`),
     };
     await ext.register(ctx);
-    console.log(`[extensions] mounted "${d.name}" at ${mountPrefix}`);
+    // Don't claim a mount that never happened — an extension can register AI
+    // tools / audit hooks without calling mountRoute, and a confident
+    // "mounted at /api/v1/x" line for a namespace serving nothing has sent
+    // people hunting phantom routing bugs.
+    console.log(
+      mounted
+        ? `[extensions] mounted "${d.name}" at ${mountPrefix}`
+        : `[extensions] registered "${d.name}" (no routes mounted — ctx.mountRoute was never called)`,
+    );
   }
 }

--- a/apps/api/src/extensions/loader.ts
+++ b/apps/api/src/extensions/loader.ts
@@ -1,18 +1,25 @@
 //
 // Extension sub-apps mount on the outer app. Middleware added to the `api`
-// instance via api.use('*') does not apply to them, and org-scoped fallback
-// audit cannot attribute extension routes. Extensions MUST apply
-// ctx.authMiddleware or ctx.agentAuthMiddleware themselves. Core injects the
+// instance via api.use('*') does not apply to them, so the loader itself
+// default-denies every mounted extension route: `/agent/*` paths get
+// agentAuthMiddleware, everything else gets authMiddleware, and only
+// manifest-declared `publicRoutes` sub-paths skip auth. The global rate-limit
+// exemption for `/agent/` is granted only for prefixes the loader actually
+// wrapped — manifest trust alone never lifts the limiter. Core injects the
 // ALS-bound database, column-bound secrets, and async audit capability.
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { Hono } from 'hono';
+import { Hono } from 'hono';
+import type { MiddlewareHandler } from 'hono';
+import { sql } from 'drizzle-orm';
 import type {
   AiToolLike,
   BreezeExtension,
   ExtensionContext,
   ExtensionDatabase,
+  ExtensionManifest,
+  ExtensionTenancyDeclaration,
 } from '@breeze/extension-api';
 import { discoverExtensions } from './discovery';
 import { aiTools } from '../services/aiTools';
@@ -38,6 +45,117 @@ async function loadEntry(dir: string, entry: string): Promise<BreezeExtension> {
   return ext;
 }
 
+// Context variable marking that the loader guard already authenticated this
+// request, so the ctx-injected middlewares can no-op instead of running the
+// (side-effectful: per-agent/per-IP rate counters) core auth twice when an
+// extension also applies them itself.
+const LOADER_AUTH_APPLIED = 'extensionLoaderAuthApplied';
+
+/**
+ * Default-deny auth guard for one extension namespace. Evaluated per request
+ * against the sub-path relative to /api/v1/<routeNamespace>:
+ *   1. `/agent` and `/agent/*` → core agentAuthMiddleware (manifest cannot
+ *      opt these public — enforced by the manifest schema too).
+ *   2. manifest.publicRoutes exact/wildcard match → no core auth.
+ *   3. everything else → core authMiddleware.
+ * Exported for tests.
+ */
+export function buildExtensionAuthGuard(
+  mountPrefix: string,
+  manifest: ExtensionManifest,
+): MiddlewareHandler {
+  const publicExact = new Set<string>();
+  const publicPrefixes: string[] = [];
+  for (const route of manifest.publicRoutes ?? []) {
+    if (route.endsWith('/*')) {
+      publicPrefixes.push(route.slice(0, -1)); // keep the trailing '/'
+    } else {
+      publicExact.add(route);
+    }
+  }
+  return async (c, next) => {
+    const rel = c.req.path.slice(mountPrefix.length) || '/';
+    if (rel === '/agent' || rel.startsWith('/agent/')) {
+      c.set(LOADER_AUTH_APPLIED, true);
+      return agentAuthMiddleware(c, next);
+    }
+    if (publicExact.has(rel) || publicPrefixes.some((p) => rel.startsWith(p))) {
+      return next();
+    }
+    c.set(LOADER_AUTH_APPLIED, true);
+    return authMiddleware(c, next);
+  };
+}
+
+/** Wrap a core auth middleware so it no-ops when the loader guard already ran. */
+function skipIfLoaderAuthed(inner: MiddlewareHandler): MiddlewareHandler {
+  return (c, next) => {
+    if (c.get(LOADER_AUTH_APPLIED) === true) return next();
+    return inner(c, next);
+  };
+}
+
+interface RlsCatalogRow {
+  table_name: string;
+  rls_enabled: boolean;
+  rls_forced: boolean;
+  policy_count: number | string;
+}
+
+/**
+ * Boot-time RLS tripwire for extension tables. The core rls-coverage contract
+ * test cannot see tables that ship from a private extension repo, so this is
+ * the only structural check they get: every table an extension declares in its
+ * manifest tenancy arrays must exist with RLS ENABLEd + FORCEd and at least
+ * one policy. Throws (failing the boot loudly) otherwise. Exported for tests.
+ */
+export async function assertExtensionTenancyRls(
+  extensionName: string,
+  tenancy: ExtensionTenancyDeclaration,
+): Promise<void> {
+  const tables = [
+    ...new Set([
+      ...tenancy.orgCascadeDeleteTables,
+      ...tenancy.deviceCascadeDeleteTables,
+      ...tenancy.deviceOrgDenormalizedTables,
+      ...(tenancy.deviceOrgMoveDeleteTables ?? []),
+    ]),
+  ];
+  if (tables.length === 0) return;
+
+  const result = (await db.execute(sql`
+    SELECT c.relname AS table_name,
+           c.relrowsecurity AS rls_enabled,
+           c.relforcerowsecurity AS rls_forced,
+           (SELECT count(*)::int FROM pg_policies p
+             WHERE p.schemaname = 'public' AND p.tablename = c.relname) AS policy_count
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relkind = 'r' AND c.relname = ANY(${tables})
+  `)) as unknown as RlsCatalogRow[] | { rows?: RlsCatalogRow[] };
+  const rows: RlsCatalogRow[] = Array.isArray(result) ? result : (result.rows ?? []);
+  const byName = new Map(rows.map((r) => [r.table_name, r]));
+
+  const problems: string[] = [];
+  for (const table of tables) {
+    const row = byName.get(table);
+    if (!row) {
+      problems.push(`"${table}" is declared in the manifest tenancy but does not exist (did its migration run?)`);
+      continue;
+    }
+    if (!row.rls_enabled) problems.push(`"${table}" does not have ROW LEVEL SECURITY enabled`);
+    if (!row.rls_forced) problems.push(`"${table}" does not have ROW LEVEL SECURITY forced (ALTER TABLE ... FORCE ROW LEVEL SECURITY)`);
+    if (Number(row.policy_count) === 0) problems.push(`"${table}" has no RLS policies (pg_policies is empty for it)`);
+  }
+  if (problems.length > 0) {
+    throw new Error(
+      `[extensions] RLS coverage check failed for extension "${extensionName}" — refusing to boot. `
+        + 'Extension tables are invisible to the core rls-coverage contract test, so this boot-time '
+        + `assertion is their only tripwire:\n  - ${problems.join('\n  - ')}`,
+    );
+  }
+}
+
 export async function mountExtensions(app: Hono, root?: string): Promise<void> {
   if (process.env.BREEZE_EXTENSIONS_ENABLED === 'false') {
     console.log('[extensions] disabled via BREEZE_EXTENSIONS_ENABLED=false');
@@ -48,15 +166,22 @@ export async function mountExtensions(app: Hono, root?: string): Promise<void> {
 
   for (const d of discovered) {
     const ext = await loadEntry(d.dir, d.manifest.entry);
-    if (d.manifest.agentRoutes === true) {
-      registerGlobalRateLimitSkipPrefix(`/api/v1/${d.manifest.routeNamespace}/agent/`);
-    }
+    await assertExtensionTenancyRls(d.name, d.manifest.tenancy);
+    const mountPrefix = `/api/v1/${d.manifest.routeNamespace}`;
     const ctx: ExtensionContext = {
       mountRoute: (subApp) => {
-        app.route(`/api/v1/${d.manifest.routeNamespace}`, subApp);
+        const guarded = new Hono();
+        guarded.use('*', buildExtensionAuthGuard(mountPrefix, d.manifest));
+        guarded.route('/', subApp);
+        app.route(mountPrefix, guarded);
+        // Rate-limit exemption only for a prefix the loader just wrapped with
+        // agentAuthMiddleware — never on manifest trust alone.
+        if (d.manifest.agentRoutes === true) {
+          registerGlobalRateLimitSkipPrefix(`${mountPrefix}/agent/`);
+        }
       },
-      authMiddleware,
-      agentAuthMiddleware,
+      authMiddleware: skipIfLoaderAuthed(authMiddleware),
+      agentAuthMiddleware: skipIfLoaderAuthed(agentAuthMiddleware),
       db: db as unknown as ExtensionDatabase,
       secrets: {
         encryptForColumn: (table, column, plaintext) =>
@@ -85,6 +210,6 @@ export async function mountExtensions(app: Hono, root?: string): Promise<void> {
       log: (message) => console.log(`[extensions:${d.name}] ${message}`),
     };
     await ext.register(ctx);
-    console.log(`[extensions] mounted "${d.name}" at /api/v1/${d.manifest.routeNamespace}`);
+    console.log(`[extensions] mounted "${d.name}" at ${mountPrefix}`);
   }
 }

--- a/apps/api/src/extensions/loader.ts
+++ b/apps/api/src/extensions/loader.ts
@@ -123,15 +123,21 @@ export async function assertExtensionTenancyRls(
   ];
   if (tables.length === 0) return;
 
+  // Bind the table list as an explicit ARRAY[...] of individually-parameterised
+  // text literals. Embedding the JS array directly (`= ANY(${tables})`) makes
+  // drizzle expand it to a TUPLE — `= ANY(($1, $2, ...))` — which Postgres
+  // rejects. `relname` is `name`, not `text`, so it needs the cast to compare.
+  const tableList = sql.join(tables.map((t) => sql`${t}`), sql`, `);
   const result = (await db.execute(sql`
-    SELECT c.relname AS table_name,
+    SELECT c.relname::text AS table_name,
            c.relrowsecurity AS rls_enabled,
            c.relforcerowsecurity AS rls_forced,
            (SELECT count(*)::int FROM pg_policies p
              WHERE p.schemaname = 'public' AND p.tablename = c.relname) AS policy_count
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
-    WHERE n.nspname = 'public' AND c.relkind = 'r' AND c.relname = ANY(${tables})
+    WHERE n.nspname = 'public' AND c.relkind = 'r'
+      AND c.relname::text = ANY(ARRAY[${tableList}]::text[])
   `)) as unknown as RlsCatalogRow[] | { rows?: RlsCatalogRow[] };
   const rows: RlsCatalogRow[] = Array.isArray(result) ? result : (result.rows ?? []);
   const byName = new Map(rows.map((r) => [r.table_name, r]));

--- a/apps/api/src/extensions/tenancyRegistry.test.ts
+++ b/apps/api/src/extensions/tenancyRegistry.test.ts
@@ -86,6 +86,46 @@ describe('tenancyRegistry', () => {
     expect(withExtensionDeviceOrgMoveDelete([])).toEqual(['demo_things']);
   });
 
+  it('dedupes device-cascade tables declared by both an extension and core, keeping the first (extension) position', () => {
+    expect(withExtensionDeviceCascade(['sample_parent', 'backup_jobs'])).toEqual([
+      'sample_child', 'sample_parent', 'backup_jobs',
+    ]);
+  });
+
+  it('dedupes a shared table declared by two extensions in device-cascade lists', () => {
+    const sampleManifest = {
+      name: 'sample', routeNamespace: 'sample', entry: 'src/index.ts',
+      migrationsDir: 'migrations',
+      tenancy: {
+        orgCascadeDeleteTables: [],
+        deviceCascadeDeleteTables: ['memory_blocks', 'sample_child'],
+        deviceOrgDenormalizedTables: [],
+      },
+    };
+    vi.mocked(discoverExtensions).mockReturnValueOnce([
+      { name: 'sample', dir: '/x/sample', migrationsDir: null, manifest: sampleManifest },
+      {
+        name: 'other', dir: '/x/other', migrationsDir: null,
+        manifest: {
+          ...sampleManifest, name: 'other', routeNamespace: 'other',
+          tenancy: { ...sampleManifest.tenancy, deviceCascadeDeleteTables: ['memory_blocks', 'other_child'] },
+        },
+      },
+    ]);
+    expect(withExtensionDeviceCascade(['devices_data'])).toEqual([
+      'memory_blocks', 'sample_child', 'other_child', 'devices_data',
+    ]);
+  });
+
+  it('dedupes device-org-move-delete and device-org-denormalized overlaps with core', () => {
+    expect(withExtensionDeviceOrgMoveDelete(['demo_things', 'core_rows'])).toEqual([
+      'demo_things', 'core_rows',
+    ]);
+    expect(withExtensionDeviceOrgDenormalized(['sample_events', 'agent_logs'])).toEqual([
+      'sample_events', 'agent_logs',
+    ]);
+  });
+
   it('is a pure pass-through with no extensions', async () => {
     vi.mocked(discoverExtensions).mockReturnValueOnce([]);
     resetExtensionTenancyCacheForTests();

--- a/apps/api/src/extensions/tenancyRegistry.test.ts
+++ b/apps/api/src/extensions/tenancyRegistry.test.ts
@@ -86,9 +86,14 @@ describe('tenancyRegistry', () => {
     expect(withExtensionDeviceOrgMoveDelete([])).toEqual(['demo_things']);
   });
 
-  it('dedupes device-cascade tables declared by both an extension and core, keeping the first (extension) position', () => {
-    expect(withExtensionDeviceCascade(['sample_parent', 'backup_jobs'])).toEqual([
-      'sample_child', 'sample_parent', 'backup_jobs',
+  it('dedupes a core/extension overlap WITHOUT hoisting the core table out of its FK-ordered position', () => {
+    // `sample_parent` is declared by both the extension and core, and sits LAST
+    // in core's FK order. A naive Set-dedupe keeps the first occurrence and
+    // would hoist it to the front (['sample_child','sample_parent','backup_jobs']),
+    // letting it be deleted before rows that FK-reference it → 23503. Core's
+    // ordering must win.
+    expect(withExtensionDeviceCascade(['backup_jobs', 'sample_parent'])).toEqual([
+      'sample_child', 'backup_jobs', 'sample_parent',
     ]);
   });
 

--- a/apps/api/src/extensions/tenancyRegistry.ts
+++ b/apps/api/src/extensions/tenancyRegistry.ts
@@ -22,18 +22,22 @@ export function withExtensionOrgCascade(core: readonly string[]): string[] {
   return hasOrganizations ? [...sorted, 'organizations'] : sorted;
 }
 
-/** Extension device-cascade tables run FIRST (extension rows may FK core rows, never vice versa). */
+/**
+ * Extension device-cascade tables run FIRST (extension rows may FK core rows,
+ * never vice versa). Deduped — two extensions may both declare an allowlisted
+ * shared table (e.g. memory_blocks), and a double entry would double-delete.
+ */
 export function withExtensionDeviceCascade(core: readonly string[]): string[] {
   const extra = getExtensionTenancy().flatMap((t) => t.deviceCascadeDeleteTables);
-  return [...extra, ...core];
+  return [...new Set([...extra, ...core])];
 }
 
 export function withExtensionDeviceOrgMoveDelete(core: readonly string[]): string[] {
   const extra = getExtensionTenancy().flatMap((t) => t.deviceOrgMoveDeleteTables ?? []);
-  return [...extra, ...core];
+  return [...new Set([...extra, ...core])];
 }
 
 export function withExtensionDeviceOrgDenormalized(core: readonly string[]): string[] {
   const extra = getExtensionTenancy().flatMap((t) => t.deviceOrgDenormalizedTables);
-  return [...core, ...extra];
+  return [...new Set([...core, ...extra])];
 }

--- a/apps/api/src/extensions/tenancyRegistry.ts
+++ b/apps/api/src/extensions/tenancyRegistry.ts
@@ -23,21 +23,35 @@ export function withExtensionOrgCascade(core: readonly string[]): string[] {
 }
 
 /**
- * Extension device-cascade tables run FIRST (extension rows may FK core rows,
- * never vice versa). Deduped — two extensions may both declare an allowlisted
- * shared table (e.g. memory_blocks), and a double entry would double-delete.
+ * Dedupe extension-declared tables WITHOUT disturbing core's ordering.
+ *
+ * A naive `[...new Set([...extra, ...core])]` keeps the FIRST occurrence, so a
+ * table present in both lists gets silently HOISTED out of its core position to
+ * the front. The core cascade lists are explicitly FK-ordered (children first),
+ * so hoisting can put a parent ahead of rows that reference it — a `23503` mid
+ * transaction. That trades a real invariant for a non-problem: double-deleting
+ * an already-deleted row is a harmless no-op.
+ *
+ * So: drop the extension's entry when core already has the table, and let core
+ * keep its position.
  */
+function dedupeAgainstCore(extra: readonly string[], core: readonly string[]): string[] {
+  const coreSet = new Set(core);
+  return [...new Set(extra)].filter((t) => !coreSet.has(t));
+}
+
+/** Extension device-cascade tables run FIRST (extension rows may FK core rows, never vice versa). */
 export function withExtensionDeviceCascade(core: readonly string[]): string[] {
   const extra = getExtensionTenancy().flatMap((t) => t.deviceCascadeDeleteTables);
-  return [...new Set([...extra, ...core])];
+  return [...dedupeAgainstCore(extra, core), ...core];
 }
 
 export function withExtensionDeviceOrgMoveDelete(core: readonly string[]): string[] {
   const extra = getExtensionTenancy().flatMap((t) => t.deviceOrgMoveDeleteTables ?? []);
-  return [...new Set([...extra, ...core])];
+  return [...dedupeAgainstCore(extra, core), ...core];
 }
 
 export function withExtensionDeviceOrgDenormalized(core: readonly string[]): string[] {
   const extra = getExtensionTenancy().flatMap((t) => t.deviceOrgDenormalizedTables);
-  return [...new Set([...core, ...extra])];
+  return [...core, ...dedupeAgainstCore(extra, core)];
 }

--- a/packages/extension-api/src/index.test.ts
+++ b/packages/extension-api/src/index.test.ts
@@ -64,6 +64,24 @@ describe('parseExtensionManifest', () => {
     }
   });
 
+  it('accepts publicRoutes with exact paths and prefix wildcards', () => {
+    const m = parseExtensionManifest({ ...valid, publicRoutes: ['/health', '/webhooks/*'] });
+    expect(m.publicRoutes).toEqual(['/health', '/webhooks/*']);
+    expect(parseExtensionManifest(valid).publicRoutes).toBeUndefined();
+  });
+
+  it('rejects publicRoutes under /agent/ — they must stay behind agentAuthMiddleware', () => {
+    for (const route of ['/agent', '/agent/hook', '/agent/*']) {
+      expect(() => parseExtensionManifest({ ...valid, publicRoutes: [route] })).toThrow(/agent/i);
+    }
+  });
+
+  it('rejects blanket and malformed publicRoutes', () => {
+    for (const route of ['/', '/*', 'health', 'webhooks/*', '/spaced path']) {
+      expect(() => parseExtensionManifest({ ...valid, publicRoutes: [route] })).toThrow();
+    }
+  });
+
   it('rejects table names not starting with the extension name prefix, except memory_blocks', () => {
     expect(() =>
       parseExtensionManifest({

--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -65,8 +65,29 @@ const manifestSchema = z
     entry: z.string().min(1),
     migrationsDir: z.string().min(1).default('migrations'),
     // Opts /api/v1/<routeNamespace>/agent/ out of the global per-IP rate
-    // limiter (agent-token auth carries its own per-agent/org limits).
+    // limiter (agent-token auth carries its own per-agent/org limits). The
+    // loader grants the exemption only for prefixes it wraps with
+    // agentAuthMiddleware itself — manifest trust alone never lifts the limit.
     agentRoutes: z.boolean().optional(),
+    // Default-deny escape hatch: sub-paths (relative to /api/v1/<routeNamespace>)
+    // served WITHOUT core auth. Exact paths ('/health') or prefix wildcards
+    // ('/webhooks/*'). Everything not listed here gets authMiddleware
+    // (or agentAuthMiddleware under /agent/) applied by the loader.
+    publicRoutes: z
+      .array(
+        z
+          .string()
+          .regex(/^\/[a-zA-Z0-9\-_./]*(\/\*)?$/, {
+            message: 'publicRoutes entries must be absolute sub-paths like "/health" or "/webhooks/*"',
+          })
+          .refine((p) => p !== '/' && p !== '/*', {
+            message: 'publicRoutes may not blanket the whole namespace ("/" or "/*") — default-deny would be meaningless',
+          })
+          .refine((p) => p !== '/agent' && !p.startsWith('/agent/'), {
+            message: 'publicRoutes may not expose /agent/ paths — they must stay behind agentAuthMiddleware (they are exempt from the global rate limiter)',
+          }),
+      )
+      .optional(),
     tenancy: tenancySchema.optional().default({
       orgCascadeDeleteTables: [],
       deviceCascadeDeleteTables: [],
@@ -154,7 +175,14 @@ export type ExtensionDatabase = {
 
 /** Injected by the core loader — the ONLY channel through which an extension touches Breeze. */
 export interface ExtensionContext {
-  /** Mounts subApp at /api/v1/<routeNamespace>. Extension must apply its own auth middleware. */
+  /**
+   * Mounts subApp at /api/v1/<routeNamespace>. The loader default-denies:
+   * `/agent/*` paths get core agentAuthMiddleware, everything else gets core
+   * authMiddleware, unless the sub-path is listed in `manifest.publicRoutes`.
+   * Extensions may still apply `ctx.authMiddleware` / `ctx.agentAuthMiddleware`
+   * themselves (e.g. on public routes) — the injected handlers no-op when the
+   * loader guard already authenticated the request.
+   */
   mountRoute: (subApp: Hono) => void;
   /** Core auth middleware, injected so the extension need not import @breeze/api. */
   authMiddleware: MiddlewareHandler;


### PR DESCRIPTION
## Summary

The extension seam (#2324/#2411) trusted extensions to self-enforce security. Nothing is exploitable today — `extensions/` is empty in this public repo and the real extension lives elsewhere — but each of these trust boundaries activates the moment a production extension ships, and the first three compound. This adds the core-side verification tripwires **before** that happens.

## What changed

**1. Loader-side default-deny auth (`loader.ts`)** — fixes findings 1+2 structurally.
`ctx.mountRoute` no longer hands the sub-app straight to the outer Hono app. The loader wraps it in a guard it owns:

- `/agent` and `/agent/*` → core `agentAuthMiddleware`
- everything else → core `authMiddleware`
- explicit, narrow opt-out via `manifest.publicRoutes` (exact sub-paths `"/health"` or prefix wildcards `"/webhooks/*"`)

A forgotten `subApp.use('*', ...)` can no longer ship a live unauthenticated `/api/v1/<ns>/*`. The manifest schema **refuses** `"/"`, `"/*"` and any `/agent/` path.

`mountRoute` is **single-shot** — Hono runs every matching wildcard, so a second mount at the same prefix would run core auth twice (double-incrementing the per-agent/per-IP rate counters, so agents 429 at half the intended rate) while shadowing the first sub-app. It throws instead.

**2. Rate-limit exemption only for loader-wrapped prefixes.**
`registerGlobalRateLimitSkipPrefix` moved *inside* `mountRoute`. `agentRoutes: true` grants the global per-IP exemption only when the extension actually mounted routes — which the loader has just wrapped in `agentAuthMiddleware`. Manifest trust alone never lifts the limiter.

**3. Boot-time RLS assertion for extension tables (`assertExtensionTenancyRls`).**
Every table an extension declares in a manifest tenancy array is probed against `pg_class.relrowsecurity` / `relforcerowsecurity` / `pg_policies` at load time. Missing table, RLS not enabled, RLS not FORCEd, or zero policies → throws and **fails the boot loudly**, listing every problem.

This is the one class of tenant-scoped table `rls-coverage.integration.test.ts` cannot reach (the tables ship from a private repo), so a boot-time catalog assertion is their only structural tripwire. No RLS contract is weakened — this only adds enforcement.

**4. `STRICT_EXTENSION_DRIFT` default flipped** (`check-drift.ts`). Absent-extension ledger rows now **fail** the drift check unless `STRICT_EXTENSION_DRIFT=false` is set for a deliberate, acknowledged extension removal.

> **Deploy note:** a git worktree does not carry the gitignored `extensions/` dir. Pointing `check-drift` at a DB that was migrated *with* the private extension, from a checkout *without* it, now hard-fails where it previously warned. That is the intended semantic — set `STRICT_EXTENSION_DRIFT=false` for that case.

**5. Cross-extension `routeNamespace` collision check** (`discovery.ts`). Two extensions declaring the same `routeNamespace` would have the second silently shadow/interleave with the first, **auth guard included**. Now throws at discovery.

**6. Device/org cascade lists deduped** (`tenancyRegistry.ts`) — **without reordering core**. A naive `Set` dedupe keeps the first occurrence, which would silently hoist a core table out of its FK-ordered position (→ `23503`). Core's ordering always wins.

## Review

Two independent reviews (`code-reviewer`, `silent-failure-hunter`) ran against this branch. Both caught a **real bug the mocked unit tests could not see**, and both independently flagged one merge-blocker. All findings addressed in `7f395a1dd` + `50f406983`:

- **The RLS tripwire was dead on arrival.** The catalog query used `= ANY(${tables})`; drizzle expands a JS array into a **tuple** (`= ANY(($1,$2))`), which Postgres rejects (`42809`). The assertion would have thrown a SQL syntax error at boot instead of an RLS verdict — a tripwire that only ever fired the wrong alarm. Every unit test passed regardless, because they mock `db.execute`. Fixed to `ARRAY[...]::text[]` and now covered by a **real-DB** test.
- **Auth downgrade via kind-blind skip (blocking).** `skipIfLoaderAuthed` keyed on a boolean "loader already authed", but the two core middlewares are not interchangeable. An extension applying `ctx.agentAuthMiddleware` to a route *not* under `/agent/` had it **silently discarded** after the loader ran user auth — degrading a device-bound route to "any authenticated user token" with `c.get('agent')` undefined. It now records the *kind* and only no-ops on an exact match; a mismatched kind still runs (fail closed).
- `policy_count` was the one assertion of three that failed **open** (`Number(undefined) === 0` is false) — now `!(n > 0)`.
- `relkind` now `IN ('r','p')` — a partitioned table was reported as "does not exist".
- Zero-tenancy extensions now **warn** rather than pass in silence.

## Testing

`extensions/` is empty here, so the unit tests run against **fixture manifests and scaffolded stub extensions**. But the mocked `db.execute` is exactly what hid the SQL bug — so the RLS assertion is additionally covered by a **real-Postgres integration test** (`apps/api/src/__tests__/integration/extensionTenancyRls.integration.test.ts`) over fixture tables reproducing each failure mode, plus a core-`devices` sanity case proving it reads the live catalog. Both new tests were **mutation-tested**: reverting the SQL fix fails 7/8 of the integration suite, and reverting the auth-kind fix fails the downgrade test — neither is vacuous.

The RLS fixtures deliberately carry **no `org_id`** (documented in-file): three are intentionally RLS-broken, and `rls-coverage` auto-discovers org-tenant tables by that exact column against the same CI database — a leaked fixture would otherwise masquerade as a real cross-tenant breach on unrelated PRs.

**Evidence:** extension suites 42 passed; `@breeze/extension-api` 12 passed; real-DB integration 8 passed; cascade consumers (`moveOrg`, `tenantCascade`) 30 passed; `tsc --noEmit` clean.

## Follow-up (not in this PR)

The tripwire verifies that *declared* tables have RLS — it cannot verify that the extension *declared all the tables it created*. An extension whose migrations create a tenant table but whose manifest omits it still gets no check. It now warns, but the real fix is to derive the table set from the extension's own migrations and require every one to be declared. Worth its own issue.

Closes #2424

🤖 Generated with [Claude Code](https://claude.com/claude-code)