### PR TITLE
fix(api): redact agent-supplied error/output strings on every persistence surface (#2434)

### DIFF
--- a/apps/api/src/jobs/monitorWorker.test.ts
+++ b/apps/api/src/jobs/monitorWorker.test.ts
@@ -345,4 +345,60 @@ describe('recordMonitorCheckResult', () => {
     expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
     expect(vi.mocked(setCooldown)).not.toHaveBeenCalled();
   });
+
+  it('redacts secrets from agent-supplied error and details before persistence (#2434)', async () => {
+    const pem =
+      '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKe0m0h\n-----END RSA PRIVATE KEY-----';
+
+    const txInsertValues = vi.fn().mockResolvedValue(undefined);
+    const txUpdateSet = vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    });
+    vi.mocked(db.transaction).mockImplementation(async (callback: any) => callback({
+      insert: vi.fn().mockReturnValue({ values: txInsertValues }),
+      update: vi.fn().mockReturnValue({ set: txUpdateSet }),
+    }));
+
+    vi.mocked(db.select)
+      // monitor lookup after the transaction
+      .mockReturnValueOnce(selectLimitResolved([{
+        id: 'monitor-1',
+        orgId: 'org-1',
+        assetId: null,
+        name: 'Edge Ping',
+        target: '8.8.8.8',
+        monitorType: 'icmp_ping',
+        consecutiveFailures: 1
+      }]) as any)
+      // no active alert rules — nothing further to evaluate
+      .mockReturnValueOnce(selectWhereResolved([]) as any);
+
+    await recordMonitorCheckResult('monitor-1', {
+      monitorId: 'monitor-1',
+      status: 'offline',
+      responseMs: 0,
+      error: `probe failed, key follows:\n${pem}`,
+      details: {
+        monitorId: 'monitor-1',
+        status: 'offline',
+        error: `probe failed, key follows:\n${pem}`,
+        nested: { hint: `still leaking:\n${pem}` },
+      },
+    });
+
+    // network_monitor_results row: error + every string inside details redacted.
+    const inserted = txInsertValues.mock.calls[0]![0] as {
+      error: string;
+      details: { error: string; nested: { hint: string } };
+    };
+    expect(inserted.error).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(inserted.details.error).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(inserted.details.nested.hint).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(JSON.stringify(inserted)).not.toContain('BEGIN RSA PRIVATE KEY');
+
+    // network_monitors state: lastError redacted too.
+    const stateSet = txUpdateSet.mock.calls[0]![0] as { lastError: string };
+    expect(stateSet.lastError).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(stateSet.lastError).not.toContain('BEGIN RSA PRIVATE KEY');
+  });
 });

--- a/apps/api/src/jobs/monitorWorker.ts
+++ b/apps/api/src/jobs/monitorWorker.ts
@@ -24,6 +24,7 @@ import {
   withQueueMeta,
 } from './queueSchemas';
 import { attachWorkerObservability } from './workerObservability';
+import { redactOptionalSecretText, redactSecretsDeep } from '../services/secretRedaction';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -399,6 +400,20 @@ export async function recordMonitorCheckResult(
   monitorId: string,
   result: MonitorCheckResult
 ): Promise<void> {
+  // #2434 chokepoint: monitor check results arrive from agents (the WS
+  // Redis-down direct path AND the BullMQ process-check-result path both
+  // funnel here). The free-text `error` and the raw `details` blob are
+  // persisted to network_monitor_results / network_monitors.lastError /
+  // alert details and surfaced in the web UI — redact secrets once at entry
+  // so every write below (results insert, monitor state, alert evaluation)
+  // is covered.
+  result = {
+    ...result,
+    error: redactOptionalSecretText(result.error),
+    details: result.details != null
+      ? redactSecretsDeep(result.details) as Record<string, unknown>
+      : result.details,
+  };
   const now = new Date();
 
   // Use a transaction to keep results table and monitor state in sync

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -1669,6 +1669,41 @@ describe('#2434 — secret redaction on non-device_commands persistence surfaces
     expect(stored.errorMessage).not.toContain('BEGIN RSA PRIVATE KEY');
   });
 
+  it('hands per-type handlers a redacted result — pins the processCommandResult chokepoint', async () => {
+    // Regression guard for the chokepoint itself. Several downstream handlers
+    // (CIS failure branch, software-remediation audit) persist agent error text
+    // that ONLY this call redacts on the WS leg. Without this test, deleting the
+    // chokepoint leaves every other suite green while raw key material lands in
+    // cis_baseline_results. `backup_verify` is the probe: its handler is mocked,
+    // so we can assert exactly what the dispatch handed it.
+    const preValidatedAgent = { deviceId: 'device-ck', orgId: 'org-ck' };
+    vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([
+      { id: 'cmd-ck', type: 'backup_verify', payload: {}, deviceId: 'device-ck' },
+    ]) as any);
+    vi.mocked(db.update).mockReturnValue(updateResult([{ id: 'cmd-ck' }]) as any);
+
+    const handlers = createAgentWsHandlers('agent-ck', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: '99999999-9999-4999-8999-999999999999',
+        status: 'failed',
+        exitCode: 1,
+        error: `verify failed, key follows:\n${pem2434}`,
+        stderr: `stderr, key follows:\n${pem2434}`,
+      }),
+    } as any, ws as any);
+
+    expect(processBackupVerificationResult).toHaveBeenCalledTimes(1);
+    const handed = vi.mocked(processBackupVerificationResult).mock.calls[0]![1] as {
+      error?: string;
+    };
+    expect(handed.error).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(JSON.stringify(handed)).not.toContain('BEGIN RSA PRIVATE KEY');
+  });
+
   it('redacts remote_sessions.errorMessage on a failed desk-start result (fast path)', async () => {
     const preValidatedAgent = { deviceId: 'device-rs', orgId: 'org-rs' };
     const sessionSetSpy = vi.fn().mockReturnValue({

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -1590,3 +1590,109 @@ describe('WS frames never claim pending commands (#2407)', () => {
     expect(ack!.commands).toEqual([]);
   });
 });
+
+// #2434 — agent-supplied error/output strings persisted OUTSIDE device_commands
+// must be redacted too (script_executions, tunnel_sessions, remote_sessions).
+describe('#2434 — secret redaction on non-device_commands persistence surfaces', () => {
+  const pem2434 =
+    '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKe0m0h\n-----END RSA PRIVATE KEY-----';
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('redacts stdout/stderr/errorMessage persisted to script_executions', async () => {
+    const preValidatedAgent = { deviceId: 'device-se', orgId: 'org-se' };
+    vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([
+      { id: 'cmd-se', type: 'script', payload: { executionId: 'exec-1' }, deviceId: 'device-se' },
+    ]) as any);
+
+    // 1st update: device_commands terminal transition. 2nd: script_executions.
+    const scriptSetSpy = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'exec-1', scriptId: 'script-1' }]),
+      }),
+    });
+    vi.mocked(db.update)
+      .mockReturnValueOnce(updateResult([{ id: 'cmd-se' }]) as any)
+      .mockReturnValueOnce({ set: scriptSetSpy } as any);
+
+    const handlers = createAgentWsHandlers('agent-se', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: '99999999-9999-4999-8999-999999999999',
+        status: 'failed',
+        exitCode: 1,
+        stdout: `out with key:\n${pem2434}`,
+        stderr: `err with key:\n${pem2434}`,
+        error: `boom with key:\n${pem2434}`,
+      }),
+    } as any, ws as any);
+
+    expect(scriptSetSpy).toHaveBeenCalledTimes(1);
+    const stored = scriptSetSpy.mock.calls[0]![0] as {
+      stdout: string; stderr: string; errorMessage: string;
+    };
+    for (const field of ['stdout', 'stderr', 'errorMessage'] as const) {
+      expect(stored[field]).toContain('[PRIVATE_KEY_REDACTED]');
+      expect(stored[field]).not.toContain('BEGIN RSA PRIVATE KEY');
+    }
+  });
+
+  it('redacts tunnel_sessions.errorMessage on a failed tun-open result (orphaned-path chokepoint)', async () => {
+    const preValidatedAgent = { deviceId: 'device-tn', orgId: 'org-tn' };
+    const tunnelSetSpy = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'tunnel1', deviceId: 'device-tn' }]),
+      }),
+    });
+    vi.mocked(db.update).mockReturnValue({ set: tunnelSetSpy } as any);
+
+    const handlers = createAgentWsHandlers('agent-tn', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: 'tun-open-tunnel1',
+        status: 'failed',
+        error: `tunnel bind failed, key follows:\n${pem2434}`,
+      }),
+    } as any, ws as any);
+
+    expect(tunnelSetSpy).toHaveBeenCalledTimes(1);
+    const stored = tunnelSetSpy.mock.calls[0]![0] as { errorMessage: string };
+    expect(stored.errorMessage).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(stored.errorMessage).not.toContain('BEGIN RSA PRIVATE KEY');
+  });
+
+  it('redacts remote_sessions.errorMessage on a failed desk-start result (fast path)', async () => {
+    const preValidatedAgent = { deviceId: 'device-rs', orgId: 'org-rs' };
+    const sessionSetSpy = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'sess1' }]),
+      }),
+    });
+    vi.mocked(db.update).mockReturnValue({ set: sessionSetSpy } as any);
+
+    const handlers = createAgentWsHandlers('agent-rs', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: 'desk-start-sess1',
+        status: 'failed',
+        error: `capture init failed, key follows: ${pem2434}`,
+      }),
+    } as any, ws as any);
+
+    expect(sessionSetSpy).toHaveBeenCalledTimes(1);
+    const stored = sessionSetSpy.mock.calls[0]![0] as { errorMessage: string };
+    expect(stored.errorMessage).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(stored.errorMessage).not.toContain('BEGIN RSA PRIVATE KEY');
+  });
+});

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -29,7 +29,7 @@ import { AGENT_TOKEN_SUSPEND_REASON } from '../services/agentTokenSuspension';
 import { isAgentTenantActive } from '../services/tenantStatus';
 import { createAuditLogAsync } from '../services/auditService';
 import { ANONYMOUS_ACTOR_ID, writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
-import { redactSecretsFromOutput } from '../services/secretRedaction';
+import { redactSecretsFromOutput, redactOptionalSecretText, redactAgentResultErrorFields } from '../services/secretRedaction';
 import { isRawStdoutArtifactCommand } from '../services/commandAudit';
 import { detectResultValidationFamily, validateCriticalCommandResult, DR_COMMAND_TYPES } from '../services/agentCommandResultValidation';
 import { updateRestoreJobByCommandId, updateRestoreJobFromResult } from '../services/restoreResultPersistence';
@@ -398,9 +398,12 @@ async function handleScriptResult({ agentId, command, result, resolvedDeviceId, 
           status: scriptStatus,
           completedAt: new Date(),
           exitCode: result.exitCode ?? null,
-          stdout: stdout ?? null,
-          stderr: result.stderr ?? null,
-          errorMessage: result.error ?? null,
+          // #2434: script output/errors surface to scripts:read users in the
+          // web UI — redact secrets before persistence (idempotent when the
+          // ingest chokepoint already redacted error/stderr).
+          stdout: stdout != null ? redactSecretsFromOutput(stdout) : null,
+          stderr: redactOptionalSecretText(result.stderr) ?? null,
+          errorMessage: redactOptionalSecretText(result.error) ?? null,
         })
         .where(and(
           eq(scriptExecutions.id, executionId),
@@ -945,6 +948,14 @@ export async function processOrphanedCommandResult(
   authenticatedDeviceId: string,
   result: z.infer<typeof commandResultSchema>
 ): Promise<void> {
+  // #2434 chokepoint: redact agent-supplied error/stderr ONCE at ingest so
+  // every persistence branch below (discovery job errors, tunnel session
+  // errorMessage, backup job errorLog, restore metadata, vault sync state)
+  // stores redacted text. stdout is left raw — structured-JSON consumers
+  // (vault sync resolution) parse it; its persisted forms are redacted at
+  // their write sites.
+  result = redactAgentResultErrorFields(result);
+
   // Check if this is an SNMP poll result
   const snmpData = result.result as {
     deviceId?: string;
@@ -1423,6 +1434,14 @@ async function processCommandResult(
   orgId?: string
 ): Promise<void> {
   try {
+    // #2434 chokepoint — FIRST statement, so "any agent result that enters this
+    // function is redacted" is a true invariant for every exit path below
+    // (in-process awaiter, orphaned-result branch, device_commands write, and
+    // the per-type handler dispatch). Mirrors processOrphanedCommandResult,
+    // which redacts at its own top. Idempotent, so downstream re-redaction of
+    // the same text is harmless.
+    result = redactAgentResultErrorFields(result);
+
     // Resolve any in-process promise awaiting this command id (e.g. http_request
     // sent via sendCommandToAgentAwaitResult). No-op for all other result types.
     // When consumed, the result has no device_commands row and needs no further
@@ -1519,6 +1538,11 @@ async function processCommandResult(
       return;
     }
 
+    // `result` was already redacted at the top of this function (#2434), and
+    // normalizeCriticalResultIfNeeded only ever REPLACES `error` with a
+    // server-generated rejection reason — so normalizedResult.error/stderr are
+    // redacted by construction and feed both the device_commands write and the
+    // per-type handler dispatch below.
     const {
       normalizedResult,
       stdout,
@@ -2082,11 +2106,16 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
               expectedSessionId && (!resultSessionId || resultSessionId === expectedSessionId)
                 ? expectedSessionId
                 : null;
-            const errorMsg = typeof failResult.error === 'string'
-              ? failResult.error.slice(0, 1024)
-              : fastError
-                ? fastError.slice(0, 1024)
-                : 'Desktop capture failed on agent';
+            // #2434: agent-supplied failure text is persisted to
+            // remote_sessions.errorMessage and shown to viewers — redact
+            // secrets first (fast path bypasses the command-result chokepoint).
+            const errorMsg = redactSecretsFromOutput(
+              typeof failResult.error === 'string'
+                ? failResult.error.slice(0, 1024)
+                : fastError
+                  ? fastError.slice(0, 1024)
+                  : 'Desktop capture failed on agent'
+            );
             if (sessionId) {
               try {
                 await runWithAgentDbAccess(async () => {

--- a/apps/api/src/routes/agents/commands.test.ts
+++ b/apps/api/src/routes/agents/commands.test.ts
@@ -356,4 +356,40 @@ describe('agent commands routes', () => {
     expect(res.status).toBe(403);
     expect(updateMock).not.toHaveBeenCalled();
   });
+
+  it('hands per-type post-processing handlers redacted error/stderr (#2434 chokepoint)', async () => {
+    const { processBackupVerificationResult } = await import('../backup/verificationService');
+    selectMock.mockReturnValueOnce(
+      chainMock([
+        {
+          id: commandId,
+          deviceId: 'device-1',
+          type: 'backup_verify',
+          status: 'sent',
+          targetRole: 'agent',
+        },
+      ])
+    );
+    updateMock.mockReturnValueOnce(chainMock([{ id: 'cmd-1' }]));
+
+    const res = await app.request(`/agents/${agentId}/commands/${commandId}/result`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        commandId,
+        status: 'failed',
+        exitCode: 1,
+        error: `verify failed ${PRIVATE_KEY_BLOCK} end`,
+        stderr: `stderr ${PRIVATE_KEY_BLOCK} end`,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(processBackupVerificationResult).toHaveBeenCalledTimes(1);
+    const handlerArg = vi.mocked(processBackupVerificationResult).mock.calls[0]![1] as {
+      error?: string;
+    };
+    expect(handlerArg.error).toBe('verify failed [PRIVATE_KEY_REDACTED] end');
+    expect(JSON.stringify(handlerArg)).not.toContain('BEGIN PRIVATE KEY');
+  });
 });

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -30,7 +30,7 @@ import { applyVaultSyncCommandResult } from '../../services/vaultSyncPersistence
 import { processBackupVerificationResult } from '../backup/verificationService';
 import { updateRestoreJobByCommandId } from '../../services/restoreResultPersistence';
 import { detectResultValidationFamily, validateCriticalCommandResult, DR_COMMAND_TYPES } from '../../services/agentCommandResultValidation';
-import { redactSecretsFromOutput } from '../../services/secretRedaction';
+import { redactSecretsFromOutput, redactAgentResultErrorFields } from '../../services/secretRedaction';
 import { isRawStdoutArtifactCommand } from '../../services/commandAudit';
 
 export const commandsRoutes = new Hono();
@@ -249,10 +249,18 @@ commandsRoutes.post(
     }
 
     const {
-      normalizedData,
+      normalizedData: rawNormalizedData,
       stdout,
       validationError,
     } = normalizeCriticalResultIfNeeded(command.type, commandId, data);
+
+    // #2434 chokepoint (REST twin of agentWs.processCommandResult): redact
+    // agent-supplied error/stderr ONCE before the device_commands write and
+    // the per-type post-processing handlers (security, CIS, sensitive-data,
+    // backup verification, restore, vault sync) so every persisted surface
+    // receives redacted text. stdout stays raw here (structured-JSON parsers
+    // + capture_pprof artifacts); persisted stdout is redacted per-site.
+    const normalizedData = redactAgentResultErrorFields(rawNormalizedData);
 
     const updated = await runOutsideDbContext(async () => {
       const query = db

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -78,6 +78,18 @@ vi.mock('../../db/schema', () => ({
     version: 'agent_versions.version',
     createdAt: 'agent_versions.created_at',
   },
+  // Resolved via a dynamic import inside PUT /:id/monitoring-results.
+  serviceProcessCheckResults: {
+    orgId: 'service_process_check_results.org_id',
+    deviceId: 'service_process_check_results.device_id',
+    details: 'service_process_check_results.details',
+  },
+}));
+
+// Same route dynamically imports getRedis; null disables the failure-counter
+// branch so the test focuses on what is persisted.
+vi.mock('../../services/redis', () => ({
+  getRedis: vi.fn(() => null),
 }));
 
 // Heartbeat schema is large — bypass it by stubbing the validator to make
@@ -2539,5 +2551,61 @@ describe('POST /agents/:id/heartbeat — undecryptable claimed commands are rele
       { id: 'cmd-good', type: 'run_script', payload: { scriptId: 'script-1' } },
     ]);
     expect(releaseClaimedCommandDeliveryMock).not.toHaveBeenCalled();
+  });
+});
+
+// #2434 — the service/process monitoring ingest persists an agent-supplied
+// free-form `details` blob straight into a jsonb column that the monitoring UI
+// renders. It is a separate REST ingest from the command-result path, so the
+// command-result chokepoint never sees it.
+describe('PUT /:id/monitoring-results — secret redaction (#2434)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redacts secrets from agent-supplied check details before persistence', async () => {
+    const pem =
+      '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKe0m0h\n-----END RSA PRIVATE KEY-----';
+
+    // device lookup by agentId
+    selectMock.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([
+            { id: 'device-1', orgId: 'org-1', siteId: 'site-1' },
+          ]),
+        }),
+      }),
+    });
+
+    const values = vi.fn().mockResolvedValue(undefined);
+    insertMock.mockReturnValue({ values });
+
+    const res = await buildApp().request('/agents/agent-1/monitoring-results', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        results: [{
+          watchType: 'service',
+          name: 'sshd',
+          status: 'error',
+          details: {
+            lastError: `service failed to start:\n${pem}`,
+            nested: { hint: `config holds:\n${pem}` },
+          },
+        }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(values).toHaveBeenCalledTimes(1);
+
+    const inserted = values.mock.calls[0]![0] as Array<{ details: Record<string, any> }>;
+    expect(inserted[0]!.details.lastError).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(inserted[0]!.details.nested.hint).toContain('[PRIVATE_KEY_REDACTED]');
+
+    const serialized = JSON.stringify(inserted);
+    expect(serialized).not.toContain('BEGIN RSA PRIVATE KEY');
+    expect(serialized).not.toContain('MIIBOgIBAAJBAKe0m0h');
   });
 });

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -40,6 +40,7 @@ import { captureException } from '../../services/sentry';
 import { resolveRemoteAccessForDevice } from '../../services/remoteAccessPolicy';
 import { getActiveTrustKeyset, type ManifestTrustKey } from '../../services/manifestSigning';
 import { decryptClaimedCommandsForDelivery } from '../../services/commandDelivery';
+import { redactSecretsDeep } from '../../services/secretRedaction';
 
 /**
  * #1121 — pure collapse detector for the watchdogState tolerance gap.
@@ -1078,7 +1079,9 @@ heartbeatRoutes.put('/:id/monitoring-results', bodyLimit({ maxSize: 1024 * 1024,
     cpuPercent: typeof r.cpuPercent === 'number' ? r.cpuPercent : null,
     memoryMb: typeof r.memoryMb === 'number' ? r.memoryMb : null,
     pid: typeof r.pid === 'number' ? r.pid : null,
-    details: (r.details && typeof r.details === 'object') ? r.details : null,
+    // #2434: details is an agent-supplied free-form blob surfaced in the
+    // service-monitoring UI — redact secret-shaped strings before persistence.
+    details: (r.details && typeof r.details === 'object') ? redactSecretsDeep(r.details) : null,
     autoRestartAttempted: r.autoRestartAttempted === true,
     autoRestartSucceeded: typeof r.autoRestartSucceeded === 'boolean' ? r.autoRestartSucceeded : null,
   }));

--- a/apps/api/src/routes/agents/helpers.redaction.test.ts
+++ b/apps/api/src/routes/agents/helpers.redaction.test.ts
@@ -174,8 +174,50 @@ describe('#2434 — handleCisCommandResult redacts stdout-derived CIS state', ()
     );
 
     expect(insertValuesMock).toHaveBeenCalledTimes(1);
-    const inserted = insertValuesMock.mock.calls[0]![0] as { findings: unknown };
+    const inserted = insertValuesMock.mock.calls[0]![0] as {
+      findings: unknown;
+      checkedAt: unknown;
+    };
     expectRedacted(inserted.findings);
+
+    // Regression: redaction must not flatten the Date. `db.insert` is mocked
+    // here, so Drizzle's timestamp mapper never runs — without this assertion a
+    // `checkedAt` of `{}` sails through the test and only explodes in prod,
+    // where the throw is swallowed and successful CIS scans stop persisting.
+    expect(inserted.checkedAt).toBeInstanceOf(Date);
+  });
+
+  it('redacts error/stderr on the FAILURE branch (no reliance on the ingest chokepoint)', async () => {
+    // baseline → device org → idempotency probe → previous result
+    selectQueue.push(
+      [{ id: BASELINE_ID, orgId: ORG_ID, name: 'CIS L1' }],
+      [{ orgId: ORG_ID }],
+      [],
+      [],
+    );
+
+    // A failed collector run: the finding's `message` and the summary are built
+    // straight from the agent's error/stderr. This handler must self-redact —
+    // if it only worked because a caller two modules away redacted first, then
+    // deleting that call would silently leak a raw key into
+    // cis_baseline_results with a fully green test suite.
+    await handleCisCommandResult(
+      makeCommand('cis_benchmark', { baselineId: BASELINE_ID }),
+      makeResult({
+        status: 'failed',
+        exitCode: 1,
+        error: `collector died: ${PEM}`,
+        stderr: `stderr: ${PEM}`,
+      }),
+    );
+
+    expect(insertValuesMock).toHaveBeenCalledTimes(1);
+    const inserted = insertValuesMock.mock.calls[0]![0] as {
+      findings: unknown;
+      summary: unknown;
+    };
+    expectRedacted(inserted.findings);
+    expectRedacted(inserted.summary);
   });
 
   it('redacts remediation details/beforeState/afterState/rollbackHint parsed from raw stdout', async () => {

--- a/apps/api/src/routes/agents/helpers.redaction.test.ts
+++ b/apps/api/src/routes/agents/helpers.redaction.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { z } from 'zod';
+import type { commandResultSchema } from './schemas';
+
+/**
+ * #2434 — agent-supplied strings persisted OUTSIDE device_commands must be
+ * redacted before they hit the DB.
+ *
+ * These handlers are the ones that persist values parsed out of RAW `stdout`.
+ * stdout is deliberately NOT redacted by the ingest chokepoint (structured-JSON
+ * consumers parse it, and capture_pprof artifacts must stay byte-for-byte), so
+ * each of these write sites has to redact for itself. This suite proves they do.
+ */
+
+const { dbMock, insertValuesMock, updateSetMock, selectQueue } = vi.hoisted(() => {
+  // Each db.select() call shifts one queued row-set, mirroring the handlers'
+  // fixed lookup order.
+  const selectQueue: unknown[][] = [];
+  const shift = () => selectQueue.shift() ?? [];
+
+  const insertValuesMock = vi.fn();
+  const updateSetMock = vi.fn().mockReturnValue({
+    where: vi.fn().mockResolvedValue(undefined),
+  });
+
+  const dbMock = {
+    select: vi.fn(() => {
+      const rows = shift();
+      const terminal = Object.assign(Promise.resolve(rows), {
+        limit: vi.fn().mockResolvedValue(rows),
+        orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+      });
+      return { from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue(terminal) }) };
+    }),
+    insert: vi.fn(() => ({
+      values: vi.fn((vals: unknown) => {
+        insertValuesMock(vals);
+        const returning = vi.fn().mockResolvedValue([
+          { id: 'result-1', score: 10, failedChecks: 0, checkedAt: new Date() },
+        ]);
+        return Object.assign(Promise.resolve(undefined), {
+          returning,
+          onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+          onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
+        });
+      }),
+    })),
+    update: vi.fn(() => ({ set: updateSetMock })),
+  };
+
+  return { dbMock, insertValuesMock, updateSetMock, selectQueue };
+});
+
+vi.mock('../../db', () => ({
+  db: dbMock,
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', () => new Proxy({}, {
+  get: (_t, prop: string) => (prop === 'then' ? undefined : { $inferSelect: {}, name: prop }),
+  has: () => true,
+}));
+
+vi.mock('../../services/redis', () => ({ getRedis: vi.fn(() => null) }));
+vi.mock('../../services/eventBus', () => ({
+  publishEvent: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../jobs/softwareComplianceWorker', () => ({
+  scheduleSoftwareComplianceCheck: vi.fn(),
+}));
+vi.mock('../../services/softwarePolicyService', () => ({
+  recordSoftwarePolicyAudit: vi.fn(),
+}));
+vi.mock('../../services/commandQueue', () => ({ queueCommandForExecution: vi.fn() }));
+vi.mock('../../services/filesystemAnalysis', () => ({
+  getFilesystemScanState: vi.fn(),
+  mergeFilesystemAnalysisPayload: vi.fn(),
+  parseFilesystemAnalysisStdout: vi.fn(),
+  readCheckpointPendingDirectories: vi.fn(),
+  readHotDirectories: vi.fn(),
+  saveFilesystemSnapshot: vi.fn(),
+  upsertFilesystemScanState: vi.fn(),
+}));
+vi.mock('../../services/cloudflareMtls', () => ({ CloudflareMtlsService: vi.fn() }));
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../metrics', () => ({ recordSoftwareRemediationDecision: vi.fn() }));
+
+import {
+  handleCisCommandResult,
+  handleSecurityCommandResult,
+  handleSensitiveDataCommandResult,
+} from './helpers';
+
+const DEVICE_ID = '00000000-0000-4000-8000-000000000001';
+const ORG_ID = '00000000-0000-4000-8000-000000000002';
+const BASELINE_ID = '00000000-0000-4000-8000-000000000003';
+const COMMAND_ID = '00000000-0000-4000-8000-000000000004';
+const SCAN_ID = '00000000-0000-4000-8000-000000000005';
+const ACTION_ID = '00000000-0000-4000-8000-000000000006';
+
+const PEM =
+  '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKe0m0h\n-----END RSA PRIVATE KEY-----';
+
+function makeCommand(type: string, payload: Record<string, unknown>) {
+  return {
+    id: COMMAND_ID,
+    deviceId: DEVICE_ID,
+    type,
+    payload,
+    status: 'completed',
+    result: null,
+  } as any;
+}
+
+function makeResult(
+  overrides: Partial<z.infer<typeof commandResultSchema>> = {},
+): z.infer<typeof commandResultSchema> {
+  return {
+    commandId: COMMAND_ID,
+    status: 'completed',
+    exitCode: 0,
+    ...overrides,
+  } as z.infer<typeof commandResultSchema>;
+}
+
+/** Asserts no fragment of the PEM survived anywhere in the persisted value. */
+function expectRedacted(value: unknown) {
+  const serialized = JSON.stringify(value);
+  expect(serialized).toContain('[PRIVATE_KEY_REDACTED]');
+  expect(serialized).not.toContain('BEGIN RSA PRIVATE KEY');
+  expect(serialized).not.toContain('MIIBOgIBAAJBAKe0m0h');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectQueue.length = 0;
+});
+
+describe('#2434 — handleCisCommandResult redacts stdout-derived CIS state', () => {
+  it('redacts secrets in baseline findings parsed from raw stdout', async () => {
+    // baseline → device org → idempotency probe → previous result
+    selectQueue.push(
+      [{ id: BASELINE_ID, orgId: ORG_ID, name: 'CIS L1' }],
+      [{ orgId: ORG_ID }],
+      [],
+      [],
+    );
+
+    // The collector's own JSON, carrying a secret in a finding's evidence —
+    // exactly the shape a failing check produces when it quotes the offending
+    // config value.
+    const stdout = JSON.stringify({
+      checkedAt: '2026-07-13T00:00:00Z',
+      totalChecks: 1,
+      passedChecks: 0,
+      failedChecks: 1,
+      score: 0,
+      findings: [{
+        checkId: '1.1.1',
+        title: 'Ensure key material is not stored on disk',
+        severity: 'high',
+        status: 'fail',
+        message: `found key material: ${PEM}`,
+        evidence: `C:\\keys\\id_rsa contains:\n${PEM}`,
+        remediation: 'Remove the key',
+      }],
+    });
+
+    await handleCisCommandResult(
+      makeCommand('cis_benchmark', { baselineId: BASELINE_ID }),
+      makeResult({ stdout }),
+    );
+
+    expect(insertValuesMock).toHaveBeenCalledTimes(1);
+    const inserted = insertValuesMock.mock.calls[0]![0] as { findings: unknown };
+    expectRedacted(inserted.findings);
+  });
+
+  it('redacts remediation details/beforeState/afterState/rollbackHint parsed from raw stdout', async () => {
+    // action lookup for apply_cis_remediation
+    selectQueue.push([
+      {
+        id: ACTION_ID,
+        orgId: ORG_ID,
+        deviceId: DEVICE_ID,
+        details: {},
+        beforeState: null,
+        afterState: null,
+        rollbackHint: null,
+      },
+    ]);
+
+    // beforeState/afterState are the ACTUAL config values the remediation
+    // touched — a registry value holding a service-account credential lands
+    // here verbatim unless redacted.
+    const stdout = JSON.stringify({
+      details: { note: `applied with key ${PEM}` },
+      beforeState: { 'HKLM\\Svc\\Password': `${PEM}` },
+      afterState: { 'HKLM\\Svc\\Password': 'password=NewSecretValue123' },
+      rollbackHint: `restore with ${PEM}`,
+    });
+
+    await handleCisCommandResult(
+      makeCommand('apply_cis_remediation', { actionId: ACTION_ID }),
+      makeResult({ stdout }),
+    );
+
+    expect(updateSetMock).toHaveBeenCalledTimes(1);
+    const stored = updateSetMock.mock.calls[0]![0] as Record<string, unknown>;
+    expectRedacted(stored.details);
+    expectRedacted(stored.beforeState);
+    expectRedacted(stored.rollbackHint);
+    // afterState carried a `password=` pair rather than a PEM.
+    expect(JSON.stringify(stored.afterState)).not.toContain('NewSecretValue123');
+  });
+});
+
+describe('#2434 — handleSecurityCommandResult redacts the raw threat blob', () => {
+  it('redacts secrets in security_threats.details', async () => {
+    // device org lookup, then the security-scan record lookup
+    selectQueue.push([{ orgId: ORG_ID }], []);
+
+    // AV threat records routinely embed the offending command line / script.
+    const stdout = JSON.stringify({
+      threats: [{
+        name: 'Suspicious.Script',
+        type: 'script',
+        severity: 'high',
+        path: 'C:\\tmp\\evil.ps1',
+        commandLine: `powershell -c "$k='${PEM}'"`,
+      }],
+      threatsFound: 1,
+    });
+
+    await handleSecurityCommandResult(
+      makeCommand('security_scan', {}),
+      makeResult({ stdout }),
+    );
+
+    // Threat rows are inserted with details = the raw threat object.
+    const threatInsert = insertValuesMock.mock.calls
+      .map((call) => call[0])
+      .find((vals) => Array.isArray(vals) && vals.some((v: any) => v?.details));
+    expect(threatInsert).toBeDefined();
+    expectRedacted(threatInsert);
+  });
+});
+
+describe('#2434 — handleSensitiveDataCommandResult redacts the agent summary', () => {
+  it('redacts secrets in sensitive_data_scans.summary.agentSummary', async () => {
+    selectQueue.push([
+      { id: SCAN_ID, orgId: ORG_ID, deviceId: DEVICE_ID, summary: {} },
+    ]);
+
+    const stdout = JSON.stringify({
+      scanId: SCAN_ID,
+      summary: { note: `scanner dump: ${PEM}` },
+      findings: [],
+    });
+
+    await handleSensitiveDataCommandResult(
+      makeCommand('sensitive_data_scan', { scanId: SCAN_ID }),
+      makeResult({ stdout }),
+    );
+
+    expect(updateSetMock).toHaveBeenCalled();
+    const stored = updateSetMock.mock.calls[0]![0] as { summary: { agentSummary: unknown } };
+    expectRedacted(stored.summary.agentSummary);
+  });
+});

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -57,6 +57,7 @@ import { recordSoftwarePolicyAudit } from '../../services/softwarePolicyService'
 import { resolvePatchConfigForDevice } from '../../services/featureConfigResolver';
 import { resolveUserGroupMembershipCached } from '../../services/onedriveGraph';
 import { captureException } from '../../services/sentry';
+import { redactSecretsDeep, redactOptionalSecretText } from '../../services/secretRedaction';
 import { CloudflareMtlsService } from '../../services/cloudflareMtls';
 import { isAllowedPolicyConfigProbe } from './policyProbeSafety';
 import { PAM_DEFAULTS, parsePamSettings, type PamSettings } from './pamSettings';
@@ -651,7 +652,11 @@ export async function handleSecurityCommandResult(
           filePath: asString(threat.path) ?? asString(threat.filePath) ?? null,
           processName: asString(threat.processName) ?? null,
           detectedAt: completedAt,
-          details: threat
+          // #2434: `threat` is the raw agent/AV threat object parsed out of
+          // stdout (stdout is deliberately NOT redacted at the ingest
+          // chokepoint). AV records routinely embed the offending command line
+          // or script fragment, so redact every string in the blob.
+          details: redactSecretsDeep(threat)
         });
       }
 
@@ -827,7 +832,8 @@ export async function handleSensitiveDataCommandResult(
           ...existingSummary,
           commandId: command.id,
           commandStatus: resultData.status,
-          agentSummary: scanSummary,
+          // #2434: agent-supplied summary blob parsed from raw stdout.
+          agentSummary: redactSecretsDeep(scanSummary),
           findingsCount: dedupedFindings.length,
           findings: {
             total: dedupedFindings.length,
@@ -1210,7 +1216,16 @@ export async function handleCisCommandResult(
       .orderBy(desc(cisBaselineResults.checkedAt))
       .limit(1);
 
-    let parsed = parseCisCollectorOutput(resultData.stdout);
+    // #2434: the success path parses findings out of RAW stdout (stdout is not
+    // redacted at the ingest chokepoint), and each finding carries free-text
+    // `message` / `evidence` / `remediation` produced by the collector — a
+    // failing check's evidence can quote the very config value (connection
+    // string, service-account password) that made it fail. Redact the whole
+    // parsed blob before it reaches cis_baseline_results. The failure branch
+    // below builds its finding from error/stderr, already redacted upstream.
+    let parsed = redactSecretsDeep(
+      parseCisCollectorOutput(resultData.stdout)
+    ) as ReturnType<typeof parseCisCollectorOutput>;
     if (resultData.status !== 'completed') {
       parsed = {
         checkedAt: new Date(),
@@ -1379,15 +1394,21 @@ export async function handleCisCommandResult(
     completedAt: new Date().toISOString(),
   };
 
+  // #2434: resultDetails / beforeState / afterState / rollbackHint are all
+  // derived from RAW stdout (unredacted at the chokepoint). before/afterState
+  // hold the ACTUAL values of the registry keys or config the remediation
+  // changed — a service-account password living in a registry value would be
+  // persisted verbatim and rendered in the CIS UI. Redaction is idempotent, so
+  // the already-redacted error/stderr in updatedDetails pass through unharmed.
   await db
     .update(cisRemediationActions)
     .set({
       status: completed ? 'completed' : 'failed',
       executedAt: new Date(),
-      details: updatedDetails,
-      beforeState: beforeStateFromResult ?? action.beforeState ?? null,
-      afterState: afterStateFromResult ?? action.afterState ?? null,
-      rollbackHint: rollbackHint ?? null,
+      details: redactSecretsDeep(updatedDetails) as Record<string, unknown>,
+      beforeState: redactSecretsDeep(beforeStateFromResult ?? action.beforeState ?? null) as Record<string, unknown> | null,
+      afterState: redactSecretsDeep(afterStateFromResult ?? action.afterState ?? null) as Record<string, unknown> | null,
+      rollbackHint: redactOptionalSecretText(rollbackHint ?? null),
     })
     .where(eq(cisRemediationActions.id, action.id));
 

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -1068,7 +1068,11 @@ export async function handleSoftwareRemediationCommandResult(
       commandId: command.id,
       softwareName,
       softwareVersion: softwareVersion ?? null,
-      message: resultData.error ?? resultData.stderr ?? 'Uninstall command failed',
+      // #2434: self-redact rather than depend on the ingest chokepoint two
+      // modules away (idempotent — already-redacted text passes through).
+      message: redactOptionalSecretText(resultData.error)
+        ?? redactOptionalSecretText(resultData.stderr)
+        ?? 'Uninstall command failed',
       status: resultData.status,
       exitCode: resultData.exitCode ?? null,
       failedAt: new Date().toISOString(),
@@ -1097,7 +1101,8 @@ export async function handleSoftwareRemediationCommandResult(
         softwareVersion: softwareVersion ?? null,
         commandStatus: resultData.status,
         exitCode: resultData.exitCode ?? null,
-        error: resultData.error ?? null,
+        // #2434: self-redact (see above) — this lands in audit_logs.details.
+        error: redactOptionalSecretText(resultData.error) ?? null,
       },
     }).catch((err) => {
       console.error('[agents/helpers] Audit write failed for remediation_command_failed:', err);
@@ -1220,13 +1225,29 @@ export async function handleCisCommandResult(
     // redacted at the ingest chokepoint), and each finding carries free-text
     // `message` / `evidence` / `remediation` produced by the collector — a
     // failing check's evidence can quote the very config value (connection
-    // string, service-account password) that made it fail. Redact the whole
-    // parsed blob before it reaches cis_baseline_results. The failure branch
-    // below builds its finding from error/stderr, already redacted upstream.
-    let parsed = redactSecretsDeep(
-      parseCisCollectorOutput(resultData.stdout)
-    ) as ReturnType<typeof parseCisCollectorOutput>;
+    // string, service-account password) that made it fail.
+    //
+    // Redact only the JSON-safe sub-parts. Do NOT hand the whole object to
+    // redactSecretsDeep: `checkedAt` is a Date, and a generic object walk
+    // would rebuild it as `{}` (Object.entries(new Date()) === []), which
+    // makes Drizzle's timestamp mapper throw on insert — a throw the caller
+    // swallows, so successful scans would silently stop persisting while
+    // failed ones (which rebuild checkedAt below) kept working.
+    const collected = parseCisCollectorOutput(resultData.stdout);
+    let parsed: ReturnType<typeof parseCisCollectorOutput> = {
+      ...collected,
+      findings: redactSecretsDeep(collected.findings) as typeof collected.findings,
+      rawSummary: redactSecretsDeep(collected.rawSummary) as typeof collected.rawSummary,
+    };
     if (resultData.status !== 'completed') {
+      // #2434: error/stderr arrive already-redacted from the ingest chokepoint,
+      // but redact again here rather than depending on a caller two modules
+      // away — this handler is reachable from both ingest legs and the
+      // failure branch writes agent text straight into a user-visible finding.
+      // Every sibling persistence service (backup/restore/vault) self-redacts
+      // for the same reason; redaction is idempotent, so this is free.
+      const failureError = redactOptionalSecretText(resultData.error);
+      const failureStderr = redactOptionalSecretText(resultData.stderr);
       parsed = {
         checkedAt: new Date(),
         findings: [{
@@ -1234,7 +1255,7 @@ export async function handleCisCommandResult(
           title: 'CIS collector execution',
           severity: 'high',
           status: 'fail',
-          message: resultData.error ?? resultData.stderr ?? 'CIS collector execution failed',
+          message: failureError ?? failureStderr ?? 'CIS collector execution failed',
           evidence: null,
           remediation: null,
         }],
@@ -1243,8 +1264,8 @@ export async function handleCisCommandResult(
         failedChecks: 1,
         score: 0,
         rawSummary: {
-          error: resultData.error ?? null,
-          stderr: resultData.stderr ?? null,
+          error: failureError ?? null,
+          stderr: failureStderr ?? null,
           status: resultData.status,
         },
       };

--- a/apps/api/src/routes/agents/unifiTelemetry.test.ts
+++ b/apps/api/src/routes/agents/unifiTelemetry.test.ts
@@ -102,4 +102,28 @@ describe('agent unifi telemetry routes', () => {
     expect(res.status).toBe(403);
     expect(collectorSvc.listCollectorsForDevice).not.toHaveBeenCalled();
   });
+
+
+  it('redacts secrets from the agent-supplied poll error before enqueue (#2434)', async () => {
+    const pem =
+      '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKe0m0h\n-----END RSA PRIVATE KEY-----';
+    const body = {
+      collectorId: 'c1',
+      polledAt: '2026-06-29T00:00:00Z',
+      firmwareOk: false,
+      devices: [],
+      clients: [],
+      error: `controller rejected the poll, key follows:\n${pem}`,
+    };
+    const res = await appWithRole('agent').request(`/agents/${AGENT_ID}/unifi-telemetry`, {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body),
+    });
+
+    expect(res.status).toBe(202);
+    // lastPollError is rendered in the collectors UI — a controller error can
+    // embed the controller API key, so it must never be enqueued verbatim.
+    const enqueued = (worker.enqueueUnifiTelemetry as any).mock.calls[0][0] as { error: string };
+    expect(enqueued.error).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(enqueued.error).not.toContain('BEGIN RSA PRIVATE KEY');
+  });
 });

--- a/apps/api/src/routes/agents/unifiTelemetry.ts
+++ b/apps/api/src/routes/agents/unifiTelemetry.ts
@@ -5,6 +5,7 @@ import { requireAgentRole } from '../../middleware/requireAgentRole';
 import { db, withSystemDbAccessContext } from '../../db';
 import { listCollectorsForDevice } from '../../services/unifi/unifiCollectorService';
 import { enqueueUnifiTelemetry } from '../../jobs/unifiTelemetryWorker';
+import { redactOptionalSecretText } from '../../services/secretRedaction';
 
 /**
  * UniFi Phase 2a agent-side telemetry endpoints. Mounted under `/agents`, so the
@@ -79,6 +80,15 @@ unifiTelemetryRoutes.post('/:id/unifi-telemetry', zValidator('json', telemetrySc
   const payload = c.req.valid('json');
   // Stamp the token-resolved deviceId server-side (never trust a client value);
   // the worker enforces it matches the collector's owner before any write.
-  await enqueueUnifiTelemetry({ ...payload, deviceId: agent.deviceId });
+  //
+  // #2434: `error` is the UniFi controller's own failure text, persisted to
+  // unifi_collectors.lastPollError and rendered in the collectors UI — a
+  // controller HTTP error can embed the controller API key / bearer token, so
+  // redact at this trust boundary before it is enqueued.
+  await enqueueUnifiTelemetry({
+    ...payload,
+    error: redactOptionalSecretText(payload.error),
+    deviceId: agent.deviceId,
+  });
   return c.json({ accepted: true }, 202);
 });

--- a/apps/api/src/services/backupResultPersistence.test.ts
+++ b/apps/api/src/services/backupResultPersistence.test.ts
@@ -398,4 +398,48 @@ describe('backup result persistence', () => {
       immutableUntil: expect.any(Date),
     }));
   });
+
+  it('redacts secrets from the agent-supplied error before persisting errorLog (#2434)', async () => {
+    const pem =
+      '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKe0m0h\n-----END RSA PRIVATE KEY-----';
+    const updateChain = chainMock([{ id: 'job-1', configId: null, backupType: 'file' }]);
+    vi.mocked(db.update).mockReturnValue(updateChain as any);
+
+    await applyBackupCommandResultToJob({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      resultStatus: 'failed',
+      result: {
+        error: `backup failed, key follows:\n${pem}`,
+      },
+    });
+
+    const setArg = updateChain.set.mock.calls[0][0] as { errorLog: string };
+    expect(setArg.errorLog).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(setArg.errorLog).not.toContain('BEGIN RSA PRIVATE KEY');
+  });
+
+  it('redacts secrets from the agent-supplied warning persisted to errorLog on success (#2434)', async () => {
+    const pem =
+      '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKe0m0h\n-----END RSA PRIVATE KEY-----';
+    const updateChain = chainMock([{ id: 'job-1', configId: null, backupType: 'file' }]);
+    vi.mocked(db.update).mockReturnValue(updateChain as any);
+
+    await applyBackupCommandResultToJob({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      resultStatus: 'completed',
+      result: {
+        filesBackedUp: 4,
+        warning: `partial backup, key follows:\n${pem}`,
+      },
+    });
+
+    const setArg = updateChain.set.mock.calls[0][0] as { errorLog: string };
+    expect(setArg.errorLog).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(setArg.errorLog).not.toContain('BEGIN RSA PRIVATE KEY');
+  });
 });
+

--- a/apps/api/src/services/backupResultPersistence.ts
+++ b/apps/api/src/services/backupResultPersistence.ts
@@ -20,6 +20,7 @@ import {
   checkBackupProviderCapabilities,
 } from './backupSnapshotStorage';
 import { resolveBackupProtectionForDevice } from './featureConfigResolver';
+import { redactSecretsFromOutput } from './secretRedaction';
 
 export const IN_FLIGHT_BACKUP_JOB_STATUSES = ['pending', 'running'] as const;
 type SnapshotImmutabilityEnforcement = 'application' | 'provider';
@@ -420,11 +421,13 @@ export async function applyBackupCommandResultToJob(params: {
     updateData.totalSize = result.bytesBackedUp ?? null;
     updateData.backupType = result.backupType ?? null;
     if (result.warning) {
-      updateData.errorLog = result.warning;
+      // #2434: warning/error are agent-supplied free text surfaced in the
+      // backup UI — redact secrets before persisting to errorLog.
+      updateData.errorLog = redactSecretsFromOutput(result.warning);
     }
   } else {
     updateData.status = 'failed';
-    updateData.errorLog = result.error ?? result.warning ?? 'Unknown error';
+    updateData.errorLog = redactSecretsFromOutput(result.error ?? result.warning ?? 'Unknown error');
     if (result.backupType) {
       updateData.backupType = result.backupType;
     }

--- a/apps/api/src/services/restoreResultPersistence.test.ts
+++ b/apps/api/src/services/restoreResultPersistence.test.ts
@@ -96,6 +96,44 @@ describe('restore result persistence', () => {
     });
   });
 
+  it('redacts secrets from agent-supplied error/stderr/warnings before persistence (#2434)', () => {
+    const pem =
+      '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKe0m0h\n-----END RSA PRIVATE KEY-----';
+
+    const metadata = buildRestoreResultMetadata(
+      'backup_restore',
+      {
+        status: 'failed',
+        stderr: `restore stderr, key follows:\n${pem}`,
+        error: `restore failed, key follows:\n${pem}`,
+      },
+      {
+        status: 'failed',
+        warnings: [`warning with key:\n${pem}`, 'plain warning'],
+      }
+    );
+
+    for (const value of [metadata.error, metadata.stderr, (metadata.warnings as string[])[0]]) {
+      expect(value).toContain('[PRIVATE_KEY_REDACTED]');
+      expect(value).not.toContain('BEGIN RSA PRIVATE KEY');
+    }
+    expect((metadata.warnings as string[])[1]).toBe('plain warning');
+  });
+
+  it('redacts the agent-supplied structured error too (#2434)', () => {
+    const pem =
+      '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKe0m0h\n-----END RSA PRIVATE KEY-----';
+
+    const metadata = buildRestoreResultMetadata(
+      'backup_restore',
+      { status: 'failed' },
+      { status: 'failed', error: `structured error, key follows:\n${pem}` }
+    );
+
+    expect(metadata.error).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(metadata.error).not.toContain('BEGIN RSA PRIVATE KEY');
+  });
+
   it('updates mutable restore jobs with the persisted restore summary', async () => {
     const returning = vi.fn().mockResolvedValue([{ id: 'restore-1' }]);
     const where = vi.fn().mockReturnValue({ returning });

--- a/apps/api/src/services/restoreResultPersistence.ts
+++ b/apps/api/src/services/restoreResultPersistence.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray } from 'drizzle-orm';
 import { db } from '../db';
 import { restoreJobs } from '../db/schema';
+import { redactSecretsFromOutput } from './secretRedaction';
 
 export type RestoreCommandResultLike = {
   status: 'completed' | 'failed' | 'timeout';
@@ -77,6 +78,21 @@ export function buildRestoreResultMetadata(
   }
   if (result.durationMs !== undefined && metadata.durationMs === undefined) {
     metadata.durationMs = result.durationMs;
+  }
+
+  // #2434: error/stderr/warnings are agent-supplied free text persisted into
+  // restore_jobs.targetConfig.result and surfaced in the restore UI — redact
+  // secrets before persistence (whichever source populated them above).
+  if (typeof metadata.error === 'string') {
+    metadata.error = redactSecretsFromOutput(metadata.error);
+  }
+  if (typeof metadata.stderr === 'string') {
+    metadata.stderr = redactSecretsFromOutput(metadata.stderr);
+  }
+  if (Array.isArray(metadata.warnings)) {
+    metadata.warnings = metadata.warnings.map((warning) =>
+      typeof warning === 'string' ? redactSecretsFromOutput(warning) : warning
+    );
   }
 
   return metadata;

--- a/apps/api/src/services/secretRedaction.test.ts
+++ b/apps/api/src/services/secretRedaction.test.ts
@@ -218,6 +218,24 @@ describe('redactSecretsDeep (#2434)', () => {
     expect(serialized).not.toContain('MIIBOgIBAAJBAKe0m0h');
   });
 
+  it('passes a Date through BY REFERENCE — a generic walk would flatten it to {}', () => {
+    // Object.entries(new Date()) === [], so an unguarded walk rebuilds a Date as
+    // {} and it loses toISOString(). Drizzle's timestamp mapper then throws on
+    // insert, the caller's try/catch swallows it, and the row silently never
+    // persists (this shipped as a real bug in the first cut of this PR: it took
+    // out the CIS *success* path while failed scans kept writing).
+    const checkedAt = new Date('2026-07-13T00:00:00Z');
+    const out = redactSecretsDeep({
+      checkedAt,
+      findings: [{ message: `key: ${pem}` }],
+    }) as { checkedAt: unknown; findings: unknown };
+
+    expect(out.checkedAt).toBeInstanceOf(Date);
+    expect((out.checkedAt as Date).toISOString()).toBe('2026-07-13T00:00:00.000Z');
+    // ...while still redacting the strings alongside it.
+    expect(JSON.stringify(out.findings)).toContain('[PRIVATE_KEY_REDACTED]');
+  });
+
   it('does not hang or leak on a cyclic structure', () => {
     const cyclic: Record<string, unknown> = { note: `key: ${pem}` };
     cyclic.self = cyclic;

--- a/apps/api/src/services/secretRedaction.test.ts
+++ b/apps/api/src/services/secretRedaction.test.ts
@@ -203,4 +203,26 @@ describe('redactSecretsDeep (#2434)', () => {
     expect(redactSecretsDeep(7)).toBe(7);
     expect(redactSecretsDeep(undefined)).toBeUndefined();
   });
+
+  it('FAILS CLOSED past the recursion bound — an over-nested secret cannot escape', () => {
+    // A hostile agent nests the key deeper than the recursion bound to dodge
+    // redaction. If the bound returned the subtree as-is, this would persist
+    // the PEM verbatim. 64 levels is double MAX_DEEP_REDACTION_DEPTH.
+    let nested: Record<string, unknown> = { key: pem };
+    for (let i = 0; i < 64; i++) nested = { deeper: nested };
+
+    const out = redactSecretsDeep(nested);
+    const serialized = JSON.stringify(out);
+    expect(serialized).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(serialized).not.toContain('BEGIN RSA PRIVATE KEY');
+    expect(serialized).not.toContain('MIIBOgIBAAJBAKe0m0h');
+  });
+
+  it('does not hang or leak on a cyclic structure', () => {
+    const cyclic: Record<string, unknown> = { note: `key: ${pem}` };
+    cyclic.self = cyclic;
+
+    const serialized = JSON.stringify(redactSecretsDeep(cyclic));
+    expect(serialized).not.toContain('BEGIN RSA PRIVATE KEY');
+  });
 });

--- a/apps/api/src/services/secretRedaction.test.ts
+++ b/apps/api/src/services/secretRedaction.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { redactSecretsFromOutput } from './secretRedaction';
+import {
+  redactSecretsFromOutput,
+  redactOptionalSecretText,
+  redactAgentResultErrorFields,
+  redactSecretsDeep,
+} from './secretRedaction';
 
 // A representative base64 body line that must never survive redaction.
 const KEY_BODY = 'MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDb1234567890abcd';
@@ -126,5 +131,76 @@ describe('redactSecretsFromOutput', () => {
     const out = redactSecretsFromOutput(`JWT ${jwt} done`);
     expect(out).not.toContain(jwt);
     expect(out).toContain('[JWT_REDACTED]');
+  });
+});
+
+describe('redactOptionalSecretText (#2434)', () => {
+  it('preserves null and undefined', () => {
+    expect(redactOptionalSecretText(null)).toBeNull();
+    expect(redactOptionalSecretText(undefined)).toBeUndefined();
+  });
+
+  it('redacts a non-null value', () => {
+    const out = redactOptionalSecretText('password=SuperSecret123');
+    expect(out).not.toContain('SuperSecret123');
+  });
+});
+
+describe('redactAgentResultErrorFields (#2434 chokepoint)', () => {
+  const pem =
+    '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKe0m0h\n-----END RSA PRIVATE KEY-----';
+
+  it('redacts error and stderr but leaves stdout and structured result untouched', () => {
+    const result = {
+      status: 'failed',
+      stdout: `stdout keeps raw: ${pem}`,
+      stderr: `stderr: ${pem}`,
+      error: `error: ${pem}`,
+      result: { key: pem },
+    };
+    const out = redactAgentResultErrorFields(result);
+    expect(out.error).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(out.stderr).toContain('[PRIVATE_KEY_REDACTED]');
+    // stdout is deliberately untouched here (structured-JSON consumers +
+    // capture_pprof artifacts) — its persisted forms are redacted per-site.
+    expect(out.stdout).toContain('BEGIN RSA PRIVATE KEY');
+    expect(out.result).toBe(result.result);
+    expect(out.status).toBe('failed');
+  });
+
+  it('returns the same object when there is nothing to redact', () => {
+    const result: { status: 'completed'; error?: string; stderr?: string } = {
+      status: 'completed',
+    };
+    expect(redactAgentResultErrorFields(result)).toBe(result);
+  });
+});
+
+describe('redactSecretsDeep (#2434)', () => {
+  const pem =
+    '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKe0m0h\n-----END RSA PRIVATE KEY-----';
+
+  it('redacts strings nested in objects and arrays', () => {
+    const out = redactSecretsDeep({
+      error: `top: ${pem}`,
+      list: [`item: ${pem}`, 42, null],
+      nested: { deeper: { hint: `deep: ${pem}` } },
+      count: 3,
+      flag: true,
+    }) as Record<string, unknown>;
+
+    expect(JSON.stringify(out)).not.toContain('BEGIN RSA PRIVATE KEY');
+    expect(out.error).toContain('[PRIVATE_KEY_REDACTED]');
+    expect((out.list as unknown[])[0]).toContain('[PRIVATE_KEY_REDACTED]');
+    expect((out.list as unknown[])[1]).toBe(42);
+    expect(((out.nested as any).deeper.hint)).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(out.count).toBe(3);
+    expect(out.flag).toBe(true);
+  });
+
+  it('passes through scalars and nullish values', () => {
+    expect(redactSecretsDeep(null)).toBeNull();
+    expect(redactSecretsDeep(7)).toBe(7);
+    expect(redactSecretsDeep(undefined)).toBeUndefined();
   });
 });

--- a/apps/api/src/services/secretRedaction.ts
+++ b/apps/api/src/services/secretRedaction.ts
@@ -150,6 +150,23 @@ export function redactSecretsDeep(value: unknown, depth = 0): unknown {
   if (typeof value === 'string') return redactSecretsFromOutput(value);
   if (value == null || typeof value !== 'object') return value;
 
+  // Non-plain objects must pass through BY REFERENCE. `Object.entries(new Date())`
+  // is `[]`, so walking a Date would rebuild it as `{}` — it loses toISOString(),
+  // Drizzle's timestamp mapper throws on insert, the caller's try/catch swallows
+  // it, and the row silently never persists. Same for the other carriers that can
+  // ride a result blob. None of these can hold a secret in a string field we'd
+  // otherwise reach, so passing them through costs no coverage.
+  if (
+    value instanceof Date ||
+    value instanceof RegExp ||
+    Buffer.isBuffer(value) ||
+    ArrayBuffer.isView(value) ||
+    value instanceof Map ||
+    value instanceof Set
+  ) {
+    return value;
+  }
+
   if (depth >= MAX_DEEP_REDACTION_DEPTH) {
     try {
       return JSON.parse(redactSecretsFromOutput(JSON.stringify(value)));

--- a/apps/api/src/services/secretRedaction.ts
+++ b/apps/api/src/services/secretRedaction.ts
@@ -123,19 +123,42 @@ export function redactAgentResultErrorFields<
   } as T;
 }
 
-const MAX_DEEP_REDACTION_DEPTH = 8;
+/**
+ * Recursion bound for {@link redactSecretsDeep}. Generous: agent `details` /
+ * `findings` blobs are a handful of levels deep in practice, and the payloads
+ * are already size-capped upstream (1 MB command-result cap, body limits on the
+ * REST ingests), so this only ever trips on pathological input.
+ */
+const MAX_DEEP_REDACTION_DEPTH = 32;
 
 /**
  * Recursively redacts every string value inside an agent-supplied JSON blob
  * before it is persisted to a jsonb column (e.g. network monitor result
- * `details`, service/process check `details`). Depth-bounded; non-string
- * scalars and keys are left untouched. Cycles are cut by the depth bound.
+ * `details`, service/process check `details`, CIS findings). Non-string scalars
+ * and object KEYS are left untouched — only values are rewritten, so parsers
+ * that key off field names keep working.
+ *
+ * The depth bound FAILS CLOSED. Returning an over-deep subtree as-is would hand
+ * an attacker a trivial bypass: nest the secret one level below the bound and it
+ * is persisted verbatim. Instead, at the bound we serialize the remaining
+ * subtree, run the flat redactor over that text, and reparse — so no raw string
+ * can survive at any depth, while the structure is preserved. (JSON.stringify
+ * also throws on a cycle, which the catch turns into a fully-redacted string
+ * rather than a hang.)
  */
 export function redactSecretsDeep(value: unknown, depth = 0): unknown {
   if (typeof value === 'string') return redactSecretsFromOutput(value);
-  if (value == null || typeof value !== 'object' || depth >= MAX_DEEP_REDACTION_DEPTH) {
-    return value;
+  if (value == null || typeof value !== 'object') return value;
+
+  if (depth >= MAX_DEEP_REDACTION_DEPTH) {
+    try {
+      return JSON.parse(redactSecretsFromOutput(JSON.stringify(value)));
+    } catch {
+      // Cyclic or non-serializable: drop the subtree rather than persist it raw.
+      return '[REDACTED_UNSERIALIZABLE]';
+    }
   }
+
   if (Array.isArray(value)) {
     return value.map((item) => redactSecretsDeep(item, depth + 1));
   }

--- a/apps/api/src/services/secretRedaction.ts
+++ b/apps/api/src/services/secretRedaction.ts
@@ -88,3 +88,60 @@ export function redactSecretsFromOutput(text: string): string {
   }
   return result;
 }
+
+/**
+ * Null/undefined-preserving variant of {@link redactSecretsFromOutput} for
+ * optional free-text columns (errorMessage, errorLog, lastError, ...): the
+ * stored shape must stay `null`/`undefined` when the agent sent nothing.
+ */
+export function redactOptionalSecretText<T extends string | null | undefined>(
+  text: T
+): T {
+  return (text != null ? redactSecretsFromOutput(text) : text) as T;
+}
+
+/**
+ * Shared chokepoint (#2434) for agent command-result ingest: returns the
+ * result with its free-text `error` and `stderr` fields redacted so EVERY
+ * downstream persistence surface (script_executions, backup/restore jobs,
+ * vault sync state, CIS results, tunnel/remote sessions, discovery jobs, ...)
+ * receives already-redacted text and new per-type handlers cannot forget to
+ * redact. `stdout` is intentionally NOT touched here: several handlers parse
+ * stdout as structured JSON, and artifact-bearing stdout (capture_pprof) must
+ * stay byte-for-byte — stdout redaction stays at the persistence sites that
+ * store it (buildStoredCommandResult / handleScriptResult), keyed by command
+ * type. Redaction is idempotent, so double-redaction downstream is harmless.
+ */
+export function redactAgentResultErrorFields<
+  T extends { error?: string | null; stderr?: string | null }
+>(result: T): T {
+  if (result.error == null && result.stderr == null) return result;
+  return {
+    ...result,
+    error: redactOptionalSecretText(result.error),
+    stderr: redactOptionalSecretText(result.stderr),
+  } as T;
+}
+
+const MAX_DEEP_REDACTION_DEPTH = 8;
+
+/**
+ * Recursively redacts every string value inside an agent-supplied JSON blob
+ * before it is persisted to a jsonb column (e.g. network monitor result
+ * `details`, service/process check `details`). Depth-bounded; non-string
+ * scalars and keys are left untouched. Cycles are cut by the depth bound.
+ */
+export function redactSecretsDeep(value: unknown, depth = 0): unknown {
+  if (typeof value === 'string') return redactSecretsFromOutput(value);
+  if (value == null || typeof value !== 'object' || depth >= MAX_DEEP_REDACTION_DEPTH) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSecretsDeep(item, depth + 1));
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = redactSecretsDeep(entry, depth + 1);
+  }
+  return out;
+}

--- a/apps/api/src/services/vaultSyncPersistence.test.ts
+++ b/apps/api/src/services/vaultSyncPersistence.test.ts
@@ -131,4 +131,29 @@ describe('applyVaultSyncCommandResult', () => {
     expect(updateMock).toHaveBeenCalled();
     expect(insertMock).not.toHaveBeenCalled();
   });
+
+  it('redacts secrets from agent-supplied error text before persisting lastSyncError (#2434)', async () => {
+    selectMock.mockReturnValueOnce(chainMock([{ id: VAULT_ID, orgId: ORG_ID }]));
+
+    const pem =
+      '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKe0m0h\n-----END RSA PRIVATE KEY-----';
+
+    await applyVaultSyncCommandResult({
+      deviceId: DEVICE_ID,
+      command: {
+        payload: {
+          vaultId: VAULT_ID,
+          snapshotId: 'snap-ext-003',
+        },
+      },
+      resultStatus: 'failed',
+      error: `sync failed, key follows:\n${pem}`,
+    });
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    const setArg = (updateMock.mock.results[0]!.value as { set: ReturnType<typeof vi.fn> })
+      .set.mock.calls[0]![0] as { lastSyncError: string };
+    expect(setArg.lastSyncError).toContain('[PRIVATE_KEY_REDACTED]');
+    expect(setArg.lastSyncError).not.toContain('BEGIN RSA PRIVATE KEY');
+  });
 });

--- a/apps/api/src/services/vaultSyncPersistence.ts
+++ b/apps/api/src/services/vaultSyncPersistence.ts
@@ -3,6 +3,7 @@ import { and, desc, eq, gte } from 'drizzle-orm';
 import { db } from '../db';
 import { backupSnapshots, localVaults, vaultSnapshotInventory } from '../db/schema';
 import { vaultSyncStructuredResultSchema } from './agentCommandResultValidation';
+import { redactSecretsFromOutput } from './secretRedaction';
 
 type VaultSyncCommandLike = {
   payload?: unknown;
@@ -169,13 +170,17 @@ export async function applyVaultSyncCommandResult(input: ApplyVaultSyncCommandRe
 
   const completedAt = new Date();
   const status = input.resultStatus === 'completed' ? 'completed' : 'failed';
+  // #2434: every fallback here is agent-supplied free text (including raw
+  // stdout) surfaced in the vault UI — redact secrets before persistence.
   const lastSyncError = status === 'completed'
     ? null
-    : (typeof structured.error === 'string' ? structured.error : undefined) ??
-      input.error ??
-      input.stderr ??
-      input.stdout ??
-      'Vault sync failed';
+    : redactSecretsFromOutput(
+        (typeof structured.error === 'string' ? structured.error : undefined) ??
+        input.error ??
+        input.stderr ??
+        input.stdout ??
+        'Vault sync failed'
+      );
 
   await db
     .update(localVaults)


### PR DESCRIPTION
## Summary

PR #2432 redacted the agent-supplied `error` string on the WS command-result path — but only where it lands in `device_commands.result`. The review of that PR flagged that the **per-type handlers persist the same agent-supplied text into other tables unredacted**. This is the full sweep.

Trust boundary (same as #2359 / #2419): a compromised or merely buggy agent can put key material, tokens, or connection strings into an `error`/`stderr`/`output` string. These columns are rendered in the web UI to non-admin roles, so anything agent-sourced must be redacted **before** it is persisted.

## Approach — a chokepoint, not N call-site patches

The issue asked for a shared chokepoint so future handlers can't miss it. Three helpers in `services/secretRedaction.ts`:

| Helper | Purpose |
|---|---|
| `redactAgentResultErrorFields(result)` | Redacts `error` + `stderr` on a command result. Called **once, as the first statement** of each ingest leg. |
| `redactSecretsDeep(value)` | Recursively redacts every string in an agent-supplied jsonb blob (depth-bounded). |
| `redactOptionalSecretText(text)` | Null/undefined-preserving variant, for optional free-text columns. |

The chokepoint fires at the entry of **both** command-result ingest legs — `agentWs.processCommandResult`, `agentWs.processOrphanedCommandResult`, and the REST twin `agents/commands.ts` — so every per-type handler downstream receives an already-redacted result object. Redaction is idempotent, so a handler that also redacts locally is harmless.

**`stdout` is deliberately NOT redacted at the chokepoint.** Several handlers parse stdout as structured JSON, and artifact-bearing stdout (`capture_pprof` base64 profiles) must be stored byte-for-byte or the redaction patterns statistically corrupt it (#2401). Instead, every site that persists *stdout-derived free text* redacts for itself — enumerated below.

## Full enumeration of agent-supplied-string persistence surfaces

Every place an agent-supplied string reaches the DB, with a disposition. This table is the point of the issue — silent truncation of the sweep is the failure mode it exists to prevent.

### Covered by the chokepoint (error / stderr)

| Surface | Column(s) | How |
|---|---|---|
| `agentWs.ts` command result | `device_commands.result.{stdout,stderr,error}` | pre-existing `buildStoredCommandResult` + #2432 |
| `agentWs.ts` `handleScriptResult` | `script_executions.{stdout,stderr,errorMessage}` | **fixed** — was the issue's headline case (`agentWs.ts:403`) |
| `handleBackupVerificationResult` → `verificationScheduled.ts` | `backup_verifications.details.reason` | chokepoint |
| `handleVmRestoreResult` / orphan restore → `restoreResultPersistence.ts` | `restore_jobs.targetConfig.result.{error,stderr,warnings}` | chokepoint + **site fix** (warnings) |
| `handleProviderBackedBackupResult` / orphan backup job → `backupResultPersistence.ts` | `backup_jobs.errorLog` | chokepoint + **site fix** (`warning` branch) |
| `handleVaultSyncResult` / `vault-auto-sync-*` → `vaultSyncPersistence.ts` | `local_vaults.lastSyncError` | **site fix** — its fallback chain ends in **raw stdout** |
| orphan discovery-job branch | `discovery_jobs.errors.message` | chokepoint |
| `tun-open-*` / `tun-closed-*` | `tunnel_sessions.errorMessage` | chokepoint |
| `handleCisResult` | `cis_baseline_results.summary.rawSummary.{error,stderr}`, `cis_remediation_actions.details.{error,stderr}` | chokepoint |
| `handleSoftwareRemediationCommandResult` (REST) | `software_compliance_status.remediationErrors[].message`, software-policy audit `details.error` | chokepoint |
| REST `agents/commands.ts` | `device_commands.result`, `deployment_results.{output,errorMessage}` | pre-existing + chokepoint |

### Fixed at the write site (not reachable by the error/stderr chokepoint)

| Surface | Column(s) | Why it needed its own fix |
|---|---|---|
| `monitorWorker.recordMonitorCheckResult` | `network_monitor_results.{error,details}`, `network_monitors.lastError`, `alerts.context.error` | Sourced from `result.result`, not `error`/`stderr`. Both legs (WS-direct + BullMQ) funnel through this one function — redacted at its entry. |
| `heartbeat.ts` monitoring-results | `service_process_check_results.details` | Separate REST ingest; free-form agent blob → `redactSecretsDeep`. |
| `agentWs.ts` desk-start failure (fast path) | `remote_sessions.errorMessage` | The `term-`/`desk-` fast path bypasses the command-result chokepoint entirely. |
| `unifiTelemetry.ts` ingest | `unifi_collectors.lastPollError` | **Real leak found during the sweep** — a UniFi controller HTTP error can embed the controller API key, and it is rendered in the collectors UI. |
| `helpers.ts` `handleCisCommandResult` | `cis_baseline_results.findings` | Findings are parsed from **raw stdout**; each carries free-text `message`/`evidence`/`remediation` — a failing check quotes the config value that made it fail. |
| `helpers.ts` `handleCisCommandResult` | `cis_remediation_actions.{details,beforeState,afterState,rollbackHint}` | `beforeState`/`afterState` are the **actual values** of the registry keys the remediation changed — a service-account password in a registry value was persisted verbatim. |
| `helpers.ts` `handleSecurityCommandResult` | `security_threats.details` | The raw AV threat object from stdout; threat records routinely embed the offending command line / script. |
| `helpers.ts` `handleSensitiveDataCommandResult` | `sensitive_data_scans.summary.agentSummary` | Arbitrary agent summary object parsed from stdout. |

### Transitively covered (read the already-redacted `device_commands.result` back out)

`patchJobExecutor` (`patch_job_results.{output,errorMessage}`), `deploymentWorker` (`deployment_results.*`), `systemTools/*` (`audit_logs.errorMessage`), `backup/hyperv.ts` + `backup/mssql.ts` (`backup_jobs.errorLog`). These all consume `executeCommand` / `pollForCommandResult`, which return the **DB row** — already redacted at write. No change needed; verified by reading each call path.

### Not applicable

| Surface | Reason |
|---|---|
| `drResultHandler.ts` → `dr_executions.results` | Only `deviceId`/`commandId`/`commandType`/`status`/`completedAt` — no free text. |
| `handleDiscoveryResult`, `handleSnmpPollResult` | Structured inventory / numeric metrics; the `errors.message` strings are server-generated. |
| `staleCommandReaper`, `backupWorker.markJobFailed`, `tunnelWs`, `desktopWs` | Server-generated constants, not agent-sourced. |
| `resolvePendingAgentCommand` (in-process `http_request` awaiter) | Response-only, never persisted. Now redacted anyway, since the chokepoint moved to the first statement of `processCommandResult` — making "any agent result entering this function is redacted" a true invariant for **both** entry points. |
| `elevation_requests.reason`, helper `aiMessages` | Human-typed, not command output. |
| Inventory / state / change-log (`inventory.ts`, `state.ts`, `changes.ts`, `peripherals.ts`, `connections.ts`, …) | Structured inventory (names, paths, versions, registry probe values), not the error/output free-text class. Redacting would corrupt exact-match semantics (e.g. registry value comparison). |

### Deliberately out of scope — one judgement call worth flagging

**`device_event_logs.message` / `.details` (`eventlogs.ts:136`)** is agent-supplied, unredacted, and genuinely *can* carry secrets (PowerShell script-block logging, event 4104, embeds script text). I did **not** redact it here, for two reasons: it is verbatim OS event-log text that operators diff against the host's own Event Viewer (redacting mutates a forensic record), and log-forwarding re-ships the **unredacted** `event.message` to the org's SIEM anyway — so redacting only the DB copy would create a confusing split-brain. This deserves its own issue and a deliberate decision, not a silent fold-in here. Happy to file it.

## Tests

One per persisted surface — 24 new assertions across 7 files:

- `secretRedaction.test.ts` — the three new helpers (null-preservation, stdout left raw, deep/nested/array redaction, depth bound).
- `agentWs.test.ts` — `script_executions`, `tunnel_sessions.errorMessage`, `remote_sessions.errorMessage` (fast path).
- `agents/commands.test.ts` — proves the per-type handlers **receive** the redacted object (REST leg).
- `helpers.redaction.test.ts` (new) — CIS findings, CIS remediation before/after state, `security_threats.details`, sensitive-data agent summary.
- `vaultSyncPersistence` / `backupResultPersistence` / `restoreResultPersistence` / `monitorWorker` / `unifiTelemetry` — one each.

**Verification:** 217 tests green across the 12 affected files (`vitest run`, single command); `tsc --noEmit` clean.

Closes #2434

🤖 Generated with [Claude Code](https://claude.com/claude-code)
