### PR TITLE
test(agent): de-flake script-runner duration assertion (reds Test Agent on unrelated PRs)

### DIFF
--- a/agent/internal/scripts/runner_test.go
+++ b/agent/internal/scripts/runner_test.go
@@ -318,11 +318,32 @@ func TestScriptResultFieldsPopulated(t *testing.T) {
 	if result.Stderr != "err\n" {
 		t.Fatalf("stderr = %q, want %q", result.Stderr, "err\n")
 	}
-	if result.DurationMs <= 0 {
-		t.Fatal("durationMs should be > 0")
+	// DurationMs truncates to whole milliseconds, so a script this short can
+	// legitimately report 0 on a fast runner. Timing is asserted with teeth in
+	// TestScriptResultDurationTracksElapsed instead.
+	if result.DurationMs < 0 {
+		t.Fatalf("durationMs = %d, want >= 0", result.DurationMs)
 	}
 	if result.ErrorMsg != "" {
 		t.Fatalf("errorMsg should be empty for completed scripts, got %q", result.ErrorMsg)
+	}
+}
+
+func TestScriptResultDurationTracksElapsed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping bash test on Windows")
+	}
+
+	r := NewRunner()
+	result := r.Run("bash", "sleep 0.05", 10*time.Second)
+
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, want completed", result.Status)
+	}
+	// Sleeping 50ms must be reflected in the reported duration. The lower bound
+	// is loose enough to absorb sleep(1) rounding down on a coarse timer.
+	if result.DurationMs < 40 {
+		t.Fatalf("durationMs = %d, want >= 40 for a 50ms script", result.DurationMs)
 	}
 }
 


### PR DESCRIPTION
## Problem

`TestScriptResultFieldsPopulated` asserts `result.DurationMs > 0` after running `bash -c 'echo out; echo err >&2; exit 1'`.

`DurationMs` is `time.Since(start).Milliseconds()` (`runner.go:49,90`), which **truncates to whole milliseconds**. That script can complete in under 1ms on a fast CI runner, so `DurationMs` is legitimately `0` and the assertion trips.

This reds **Test Agent on any PR**, regardless of what it touches — it fired on #2455, a 28-file web-only diff, where it cost a real investigation to rule out a regression. Main happened to be green, which makes it look like the PR broke something.

## Fix

The production behavior is correct — a sub-millisecond script really did take ~0ms — so the assertion is what's wrong, not the code.

- `TestScriptResultFieldsPopulated` now asserts `DurationMs >= 0` (the field is populated and sane), with a comment explaining why `> 0` is not a safe bound.
- New `TestScriptResultDurationTracksElapsed` carries the timing coverage with teeth: it sleeps 50ms and requires `DurationMs >= 40` (loose lower bound to absorb coarse-timer rounding).

Net effect: the flake is gone and duration tracking is still genuinely covered — arguably better than before, since the old test only proved the value was non-zero on a script whose duration was meaningless.

## Verification

- Both tests pass **20/20 consecutive runs** under `-race`.
- **Mutation-checked:** zeroing the duration (`* 0` in `runner.go`) makes the new test fail with `durationMs = 0, want >= 40`, then passes again on restore. It is not vacuous.
- `gofmt` clean.