### PR TITLE
fix(web): polish batch — error/empty states, mutation-guard coverage, confirmation, 403 handling (#2429)

### DIFF
--- a/apps/web/src/components/auth/AdminSessionManager.test.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.test.tsx
@@ -359,6 +359,42 @@ describe('AdminSessionManager scope switching (#2348 / #2429)', () => {
     expect(navigateToMock).toHaveBeenCalledWith('/login', { replace: true });
   });
 
+  it('does not RELAX a strict budget to the 60-minute default when the next lookup fails', async () => {
+    // Resetting to DEFAULT on scope change must not become a loophole: an org
+    // mandating a 5-minute idle timeout whose follow-up settings fetch blips
+    // would otherwise silently get a 60-minute window — a 12x loosening of a
+    // compliance control. The failure fallback clamps to the shortest budget we
+    // have evidence for.
+    setScope(ORG_ID);
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ effective: { security: { sessionTimeout: 5 } }, locked: [] })
+    );
+
+    const { rerender } = render(<AdminSessionManager />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Switch scope; the new lookup fails outright.
+    setScope('org-other');
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({}, false, 500));
+
+    rerender(<AdminSessionManager />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // 5 minutes of idle must still log out — NOT be stretched to 60.
+    await act(async () => {
+      vi.advanceTimersByTime(6 * 60_000);
+      await Promise.resolve();
+    });
+
+    expect(apiLogoutMock).toHaveBeenCalledTimes(1);
+  });
+
   it('applies the newly selected org budget after switching All Organizations → org', async () => {
     // Partner scope allows 24h.
     setScope(null);

--- a/apps/web/src/components/auth/AdminSessionManager.test.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.test.tsx
@@ -234,3 +234,145 @@ describe('AdminSessionManager All Organizations mode (#2347)', () => {
     expect(apiLogoutMock).not.toHaveBeenCalled();
   });
 });
+
+describe('AdminSessionManager scope switching (#2348 / #2429)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    useAuthStoreMock.mockImplementation((selector: any) => selector({ isAuthenticated: true }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Point the mocked org store at a scope; the next render observes it. */
+  const setScope = (currentOrgId: string | null) => {
+    useOrgStoreMock.mockImplementation((selector: any) => selector({ currentOrgId }));
+  };
+
+  it('refetches from the partner endpoint when switching org → All Organizations', async () => {
+    setScope(ORG_ID);
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ effective: { security: { sessionTimeout: 30 } }, locked: [] })
+    );
+
+    const { rerender } = render(<AdminSessionManager />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(
+      `/orgs/organizations/${ORG_ID}/effective-settings`
+    );
+
+    // Switch to All Organizations. The scope lives in the org store, so the
+    // component only sees it on the next render — this is the rerender() the
+    // suite previously never exercised.
+    setScope(null);
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ settings: { security: { sessionTimeout: 1440 } } })
+    );
+
+    rerender(<AdminSessionManager />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/orgs/partners/me');
+  });
+
+  it('does not enforce the previous org budget while the new scope is still loading', async () => {
+    // Org scope has an aggressive 2-minute timeout.
+    setScope(ORG_ID);
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ effective: { security: { sessionTimeout: 2 } }, locked: [] })
+    );
+
+    const { rerender } = render(<AdminSessionManager />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Switch to All Organizations, where the partner allows 24h — but hold the
+    // partner response open so we sit inside the async refetch window.
+    setScope(null);
+    let releasePartnerFetch!: (value: Response) => void;
+    fetchWithAuthMock.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        releasePartnerFetch = resolve;
+      })
+    );
+
+    rerender(<AdminSessionManager />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Mid-switch the new budget is unknown. The stale 2-minute ORG budget must
+    // NOT be applied to the partner scope — that would log a partner admin out
+    // moments after switching. This is the #2429 stale-value bug.
+    await act(async () => {
+      vi.advanceTimersByTime(5 * 60_000);
+      await Promise.resolve();
+    });
+    expect(apiLogoutMock).not.toHaveBeenCalled();
+
+    // Now let the partner settings land (1440 min) and confirm the session
+    // still stands well past the old org budget.
+    await act(async () => {
+      releasePartnerFetch(
+        makeJsonResponse({ settings: { security: { sessionTimeout: 1440 } } })
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(30 * 60_000);
+      await Promise.resolve();
+    });
+    expect(apiLogoutMock).not.toHaveBeenCalled();
+  });
+
+  it('applies the newly selected org budget after switching All Organizations → org', async () => {
+    // Partner scope allows 24h.
+    setScope(null);
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ settings: { security: { sessionTimeout: 1440 } } })
+    );
+
+    const { rerender } = render(<AdminSessionManager />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Switch into an org that locks the timeout down to 2 minutes.
+    setScope(ORG_ID);
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        effective: { security: { sessionTimeout: 2 } },
+        locked: ['security.sessionTimeout']
+      })
+    );
+
+    rerender(<AdminSessionManager />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The org's stricter 2-minute budget now governs — the 1440 carried over
+    // from the partner scope must not keep the session alive.
+    await act(async () => {
+      vi.advanceTimersByTime(3 * 60_000);
+      await Promise.resolve();
+    });
+
+    expect(apiLogoutMock).toHaveBeenCalledTimes(1);
+    expect(navigateToMock).toHaveBeenCalledWith('/login', { replace: true });
+  });
+});

--- a/apps/web/src/components/auth/AdminSessionManager.test.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.test.tsx
@@ -337,6 +337,28 @@ describe('AdminSessionManager scope switching (#2348 / #2429)', () => {
     expect(apiLogoutMock).not.toHaveBeenCalled();
   });
 
+  it('still idle-logs-out on the default budget when the settings fetch never settles', async () => {
+    // Guard against the tempting-but-wrong fix for the stale-budget bug: gating
+    // idle logout on "the new scope's budget has resolved" means a settings
+    // request that hangs forever silently disables session expiry altogether.
+    // Enforcement must always fall back to the frontend default, never park.
+    setScope(ORG_ID);
+    fetchWithAuthMock.mockReturnValue(new Promise<Response>(() => {})); // never settles
+
+    render(<AdminSessionManager />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(61 * 60_000); // past the 60-minute default
+      await Promise.resolve();
+    });
+
+    expect(apiLogoutMock).toHaveBeenCalledTimes(1);
+    expect(navigateToMock).toHaveBeenCalledWith('/login', { replace: true });
+  });
+
   it('applies the newly selected org budget after switching All Organizations → org', async () => {
     // Partner scope allows 24h.
     setScope(null);

--- a/apps/web/src/components/auth/AdminSessionManager.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.tsx
@@ -34,6 +34,9 @@ export default function AdminSessionManager() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const currentOrgId = useOrgStore((state) => state.currentOrgId);
   const [idleTimeoutMs, setIdleTimeoutMs] = useState(DEFAULT_IDLE_TIMEOUT_MS);
+  // Last budget we actually READ from the server, for any scope. Used only as a
+  // clamp when a later lookup fails — see settleTimeout.
+  const lastKnownBudgetMsRef = useRef<number | null>(null);
   const lastActivityAtRef = useRef<number>(Date.now());
   const lastRefreshAtRef = useRef<number>(0);
   const refreshInFlightRef = useRef(false);
@@ -87,14 +90,29 @@ export default function AdminSessionManager() {
 
     /**
      * Apply the timeout for this scope. `configuredMinutes` is null when the
-     * lookup failed, which leaves the frontend default in force — never the
-     * previous scope's value.
+     * lookup failed.
+     *
+     * On failure we do NOT simply leave the frontend default in force: that
+     * would RELAX a stricter policy (an org mandating a 5-minute idle timeout
+     * whose settings fetch blips would silently get a 60-minute window — a 12x
+     * loosening of a compliance control). Instead we clamp to the shortest
+     * budget we have any evidence for. Erring shorter logs a user out early at
+     * worst; erring longer leaves an unattended session open. (#2429)
      */
     const settleTimeout = (configuredMinutes: number | null) => {
       if (cancelled) return;
       if (configuredMinutes !== null && Number.isFinite(configuredMinutes) && configuredMinutes > 0) {
-        setIdleTimeoutMs(Math.max(1, configuredMinutes) * 60 * 1000);
+        const ms = Math.max(1, configuredMinutes) * 60 * 1000;
+        lastKnownBudgetMsRef.current = ms;
+        setIdleTimeoutMs(ms);
+        return;
       }
+      const lastKnown = lastKnownBudgetMsRef.current;
+      setIdleTimeoutMs(
+        lastKnown === null
+          ? DEFAULT_IDLE_TIMEOUT_MS
+          : Math.min(DEFAULT_IDLE_TIMEOUT_MS, lastKnown),
+      );
     };
 
     const loadSessionTimeout = async () => {

--- a/apps/web/src/components/auth/AdminSessionManager.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.tsx
@@ -34,6 +34,12 @@ export default function AdminSessionManager() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const currentOrgId = useOrgStore((state) => state.currentOrgId);
   const [idleTimeoutMs, setIdleTimeoutMs] = useState(DEFAULT_IDLE_TIMEOUT_MS);
+  // False while the effective timeout for the CURRENT scope is still in flight.
+  // Scope switches (All Orgs ↔ org) refetch asynchronously, and until that lands
+  // `idleTimeoutMs` still holds the PREVIOUS scope's budget — enforcing it would
+  // let a 5-minute org timeout idle-log-out a partner admin who just switched to
+  // All Orgs. The heartbeat therefore skips idle logout until this resolves.
+  const [idleTimeoutResolved, setIdleTimeoutResolved] = useState(false);
   const lastActivityAtRef = useRef<number>(Date.now());
   const lastRefreshAtRef = useRef<number>(0);
   const refreshInFlightRef = useRef(false);
@@ -66,15 +72,31 @@ export default function AdminSessionManager() {
   useEffect(() => {
     if (!isAuthenticated) {
       setIdleTimeoutMs(DEFAULT_IDLE_TIMEOUT_MS);
+      setIdleTimeoutResolved(false);
       return;
     }
 
     let cancelled = false;
 
-    const applyConfiguredTimeout = (configuredMinutes: number) => {
-      if (!cancelled && Number.isFinite(configuredMinutes) && configuredMinutes > 0) {
+    // The scope just changed (or we just mounted), so whatever is in state
+    // belongs to the previous scope. Park enforcement and drop back to the
+    // frontend default until the new scope's budget lands, so a stale — possibly
+    // much shorter — budget can never be applied to the new scope (#2429).
+    setIdleTimeoutResolved(false);
+    setIdleTimeoutMs(DEFAULT_IDLE_TIMEOUT_MS);
+
+    /**
+     * Settle the timeout for this scope. `configuredMinutes` is null when the
+     * lookup failed, which keeps the frontend default. EVERY path must call
+     * this: leaving `idleTimeoutResolved` false would park idle logout forever
+     * and turn a failed settings fetch into a session that never times out.
+     */
+    const settleTimeout = (configuredMinutes: number | null) => {
+      if (cancelled) return;
+      if (configuredMinutes !== null && Number.isFinite(configuredMinutes) && configuredMinutes > 0) {
         setIdleTimeoutMs(Math.max(1, configuredMinutes) * 60 * 1000);
       }
+      setIdleTimeoutResolved(true);
     };
 
     const loadSessionTimeout = async () => {
@@ -96,10 +118,11 @@ export default function AdminSessionManager() {
               '[AdminSessionManager] Failed to load effective session timeout:',
               response.status
             );
+            settleTimeout(null);
             return;
           }
           const data = await response.json();
-          applyConfiguredTimeout(Number(data?.effective?.security?.sessionTimeout));
+          settleTimeout(Number(data?.effective?.security?.sessionTimeout));
           return;
         }
 
@@ -115,13 +138,16 @@ export default function AdminSessionManager() {
             '[AdminSessionManager] Failed to load partner session timeout:',
             response.status
           );
+          settleTimeout(null);
           return;
         }
         const data = await response.json();
-        applyConfiguredTimeout(Number(data?.settings?.security?.sessionTimeout));
+        settleTimeout(Number(data?.settings?.security?.sessionTimeout));
       } catch (err) {
-        // Keep current timeout fallback when session settings cannot be loaded.
+        // Fall back to the frontend default — NOT to the previous scope's
+        // budget, which is what `idleTimeoutMs` would otherwise still hold.
         console.warn('[AdminSessionManager] Error loading session timeout:', err);
+        settleTimeout(null);
       }
     };
 
@@ -143,7 +169,9 @@ export default function AdminSessionManager() {
       const now = Date.now();
       const idleMs = now - lastActivityAtRef.current;
 
-      if (idleMs >= idleTimeoutMs) {
+      // Never idle-log-out against a budget we haven't confirmed for the current
+      // scope — mid-switch that value belongs to the scope we just left (#2429).
+      if (idleTimeoutResolved && idleMs >= idleTimeoutMs) {
         idleLogoutInFlightRef.current = true;
         await apiLogout();
         if (!cancelled) {
@@ -184,7 +212,7 @@ export default function AdminSessionManager() {
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [isAuthenticated, idleTimeoutMs]);
+  }, [isAuthenticated, idleTimeoutMs, idleTimeoutResolved]);
 
   return null;
 }

--- a/apps/web/src/components/auth/AdminSessionManager.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.tsx
@@ -34,12 +34,6 @@ export default function AdminSessionManager() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const currentOrgId = useOrgStore((state) => state.currentOrgId);
   const [idleTimeoutMs, setIdleTimeoutMs] = useState(DEFAULT_IDLE_TIMEOUT_MS);
-  // False while the effective timeout for the CURRENT scope is still in flight.
-  // Scope switches (All Orgs ↔ org) refetch asynchronously, and until that lands
-  // `idleTimeoutMs` still holds the PREVIOUS scope's budget — enforcing it would
-  // let a 5-minute org timeout idle-log-out a partner admin who just switched to
-  // All Orgs. The heartbeat therefore skips idle logout until this resolves.
-  const [idleTimeoutResolved, setIdleTimeoutResolved] = useState(false);
   const lastActivityAtRef = useRef<number>(Date.now());
   const lastRefreshAtRef = useRef<number>(0);
   const refreshInFlightRef = useRef(false);
@@ -72,31 +66,35 @@ export default function AdminSessionManager() {
   useEffect(() => {
     if (!isAuthenticated) {
       setIdleTimeoutMs(DEFAULT_IDLE_TIMEOUT_MS);
-      setIdleTimeoutResolved(false);
       return;
     }
 
     let cancelled = false;
 
-    // The scope just changed (or we just mounted), so whatever is in state
-    // belongs to the previous scope. Park enforcement and drop back to the
-    // frontend default until the new scope's budget lands, so a stale — possibly
-    // much shorter — budget can never be applied to the new scope (#2429).
-    setIdleTimeoutResolved(false);
+    // The scope just changed (or we just mounted), so whatever budget is in
+    // state belongs to the PREVIOUS scope. Drop back to the frontend default
+    // until the new scope's budget lands — otherwise a 5-minute org budget
+    // stays armed against a partner admin who just switched to All Orgs and
+    // logs them out moments later (#2429).
+    //
+    // Deliberately a reset-to-default and NOT a "park enforcement until this
+    // resolves" flag: a settings fetch that never settles (hung connection)
+    // would then disable idle logout for the whole session. Always enforcing
+    // *some* budget fails safe. The default is only ever in force for the
+    // duration of the refetch, and a scope switch is itself user activity, so
+    // the idle clock is at ~0 across that window anyway.
     setIdleTimeoutMs(DEFAULT_IDLE_TIMEOUT_MS);
 
     /**
-     * Settle the timeout for this scope. `configuredMinutes` is null when the
-     * lookup failed, which keeps the frontend default. EVERY path must call
-     * this: leaving `idleTimeoutResolved` false would park idle logout forever
-     * and turn a failed settings fetch into a session that never times out.
+     * Apply the timeout for this scope. `configuredMinutes` is null when the
+     * lookup failed, which leaves the frontend default in force — never the
+     * previous scope's value.
      */
     const settleTimeout = (configuredMinutes: number | null) => {
       if (cancelled) return;
       if (configuredMinutes !== null && Number.isFinite(configuredMinutes) && configuredMinutes > 0) {
         setIdleTimeoutMs(Math.max(1, configuredMinutes) * 60 * 1000);
       }
-      setIdleTimeoutResolved(true);
     };
 
     const loadSessionTimeout = async () => {
@@ -169,9 +167,7 @@ export default function AdminSessionManager() {
       const now = Date.now();
       const idleMs = now - lastActivityAtRef.current;
 
-      // Never idle-log-out against a budget we haven't confirmed for the current
-      // scope — mid-switch that value belongs to the scope we just left (#2429).
-      if (idleTimeoutResolved && idleMs >= idleTimeoutMs) {
+      if (idleMs >= idleTimeoutMs) {
         idleLogoutInFlightRef.current = true;
         await apiLogout();
         if (!cancelled) {
@@ -212,7 +208,7 @@ export default function AdminSessionManager() {
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [isAuthenticated, idleTimeoutMs, idleTimeoutResolved]);
+  }, [isAuthenticated, idleTimeoutMs]);
 
   return null;
 }

--- a/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.test.tsx
@@ -724,4 +724,34 @@ describe('BackupTab', () => {
     // The create form must not auto-open over a load failure.
     expect(screen.queryByText(/Editing storage configuration/i)).toBeNull();
   });
+
+  it('destination 403: shows a permissions panel with NO retry, not the load-error banner (#2429)', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = (init as RequestInit | undefined)?.method ?? 'GET';
+      if (url === '/backup/configs' && method === 'GET') {
+        return makeJsonResponse({ error: 'forbidden' }, false, 403);
+      }
+      if (url === '/backup/profiles' && method === 'GET') {
+        return makeJsonResponse({ data: [] });
+      }
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(
+      <BackupTab
+        policyId="policy-1"
+        existingLink={undefined}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    // A 403 is terminal for this user: the retryable banner (and its Retry
+    // button, which could only 403 again) must not be what they see.
+    expect(await screen.findByTestId('backup-destinations-denied')).toBeTruthy();
+    expect(screen.queryByTestId('backup-destinations-load-error')).toBeNull();
+    // Still never the create-first-destination form.
+    expect(screen.queryByText(/Editing storage configuration/i)).toBeNull();
+  });
 });

--- a/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.tsx
@@ -33,6 +33,7 @@ import { fetchWithAuth } from "../../../stores/auth";
 import { extractApiError } from "@/lib/apiError";
 import { useTranslation } from "react-i18next";
 import { i18n } from "@/lib/i18n";
+import AccessDenied from "../../shared/AccessDenied";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 type ScheduleFrequency = "daily" | "weekly" | "monthly";
@@ -544,7 +545,13 @@ export default function BackupTab({
   const [configsLoaded, setConfigsLoaded] = useState(false);
   // ...and a FAILED fetch is neither. Without this, a transient 500 renders the
   // "create your first destination" form over an org that already has some.
-  const [configsFailed, setConfigsFailed] = useState(false);
+  //
+  // 'denied' (403) is split out from 'other': a permission denial is terminal
+  // for this user, so it gets a permissions panel and NO Retry — a retry could
+  // only 403 again. (#2429)
+  const [configsError, setConfigsError] = useState<"none" | "denied" | "other">(
+    "none",
+  );
   const [selectedConfigId, setSelectedConfigId] = useState<string>(() => {
     if (storedDestinationId) return storedDestinationId;
     // Legacy custom links stored the destination in featurePolicyId; profile
@@ -593,8 +600,15 @@ export default function BackupTab({
   const fetchConfigs = useCallback(async () => {
     if (!meta.fetchUrl) return;
     setConfigsLoading(true);
+    setConfigsError("none");
     try {
       const response = await fetchWithAuth(meta.fetchUrl);
+      // Terminal for this user — not something a Retry can clear. Kept out of
+      // the throw path so the status is not flattened into a message. (#2429)
+      if (response.status === 403) {
+        setConfigsError("denied");
+        return;
+      }
       if (!response.ok) {
         throw new Error(`Failed to load backup destinations (${response.status})`);
       }
@@ -606,13 +620,12 @@ export default function BackupTab({
             ? payload
             : [],
       );
-      setConfigsFailed(false);
       setConfigsLoaded(true);
     } catch (err) {
       // Never fall through to the empty state: the destination list is what the
       // whole tab keys off, and an empty one auto-opens the create form.
       console.error("Failed to load backup destinations", err);
-      setConfigsFailed(true);
+      setConfigsError("other");
     } finally {
       setConfigsLoading(false);
     }
@@ -1870,7 +1883,12 @@ export default function BackupTab({
                 "policies:configurationPolicies.featureTabs.backupTab.partnerDestinationNote",
               )}
             </div>
-          ) : configsFailed ? (
+          ) : configsError === "denied" ? (
+            // A permission denial is not a transient failure. Same "don't show
+            // the picker over a load we couldn't complete" rule as below, but
+            // with no Retry — it could only 403 again. (#2429)
+            <AccessDenied testId="backup-destinations-denied" />
+          ) : configsError === "other" ? (
             // Never show the destination picker (or its "create your first
             // destination" empty state) over a failed load — the org may well
             // have destinations we just couldn't fetch.

--- a/apps/web/src/components/devices/DeviceLinkedProfilesTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceLinkedProfilesTab.test.tsx
@@ -99,7 +99,7 @@ describe('DeviceLinkedProfilesTab', () => {
     expect(JSON.parse((patchCall[1] as RequestInit).body as string)).toEqual({ removeDeviceIds: ['dev-1'] });
   });
 
-  it('remove-link DELETEs the group and reloads the panel', async () => {
+  describe('remove-link confirmation (#2429)', () => {
     const groupPayload = {
       group: { id: 'g1', name: null },
       members: [
@@ -107,20 +107,44 @@ describe('DeviceLinkedProfilesTab', () => {
         { deviceId: 'dev-2', hostname: 'b', displayName: null, osType: 'linux', osVersion: '22', agentVersion: '1', status: 'offline', lastSeenAt: null },
       ],
     };
-    fetchWithAuthMock
-      .mockResolvedValueOnce(jsonResponse(groupPayload)) // initial load
-      .mockResolvedValueOnce(jsonResponse({ success: true })) // DELETE
-      .mockResolvedValueOnce(jsonResponse({ group: null, members: [] })); // reload
 
-    render(<DeviceLinkedProfilesTab deviceId="dev-1" />);
-    await waitFor(() => expect(screen.getByTestId('linked-profiles-tab')).toBeInTheDocument());
+    it('does NOT dissolve the group on the first click — it asks first', async () => {
+      fetchWithAuthMock.mockResolvedValue(jsonResponse(groupPayload));
 
-    fireEvent.click(screen.getByTestId('linked-profiles-dissolve'));
+      render(<DeviceLinkedProfilesTab deviceId="dev-1" />);
+      await waitFor(() => expect(screen.getByTestId('linked-profiles-tab')).toBeInTheDocument());
+      expect(fetchWithAuthMock).toHaveBeenCalledTimes(1); // initial load only
 
-    await waitFor(() => expect(screen.getByTestId('linked-profiles-empty')).toBeInTheDocument());
-    const deleteCall = fetchWithAuthMock.mock.calls[1]!;
-    expect(deleteCall[0]).toBe('/devices/link-groups/g1');
-    expect(deleteCall[1]).toMatchObject({ method: 'DELETE' });
+      fireEvent.click(screen.getByTestId('linked-profiles-dissolve'));
+
+      // The confirm step is up and nothing has been destroyed yet.
+      await waitFor(() =>
+        expect(screen.getByTestId('linked-profiles-dissolve-confirm')).toBeInTheDocument(),
+      );
+      expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+      expect(fetchWithAuthMock).not.toHaveBeenCalledWith(
+        '/devices/link-groups/g1',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+
+    it('DELETEs the group and reloads the panel once confirmed', async () => {
+      fetchWithAuthMock
+        .mockResolvedValueOnce(jsonResponse(groupPayload)) // initial load
+        .mockResolvedValueOnce(jsonResponse({ success: true })) // DELETE
+        .mockResolvedValueOnce(jsonResponse({ group: null, members: [] })); // reload
+
+      render(<DeviceLinkedProfilesTab deviceId="dev-1" />);
+      await waitFor(() => expect(screen.getByTestId('linked-profiles-tab')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('linked-profiles-dissolve'));
+      fireEvent.click(await screen.findByTestId('linked-profiles-dissolve-confirm'));
+
+      await waitFor(() => expect(screen.getByTestId('linked-profiles-empty')).toBeInTheDocument());
+      const deleteCall = fetchWithAuthMock.mock.calls[1]!;
+      expect(deleteCall[0]).toBe('/devices/link-groups/g1');
+      expect(deleteCall[1]).toMatchObject({ method: 'DELETE' });
+    });
   });
 
   describe('vm_host groups (#2308)', () => {

--- a/apps/web/src/components/devices/DeviceLinkedProfilesTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceLinkedProfilesTab.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import DeviceLinkedProfilesTab from './DeviceLinkedProfilesTab';
 import { fetchWithAuth } from '../../stores/auth';
+import { runAction, handleActionError } from '../../lib/runAction';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
@@ -17,6 +18,7 @@ vi.mock('../../lib/runAction', () => ({
 }));
 
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const runActionMock = vi.mocked(runAction);
 
 const jsonResponse = (payload: unknown, ok = true): Response =>
   ({ ok, status: ok ? 200 : 500, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
@@ -126,6 +128,29 @@ describe('DeviceLinkedProfilesTab', () => {
         '/devices/link-groups/g1',
         expect.objectContaining({ method: 'DELETE' }),
       );
+    });
+
+    it('closes the dialog on a FAILED dissolve so the error toast is not hidden behind it', async () => {
+      // The Toast island and the Dialog portal are both z-50 and the portal is
+      // appended later, so a modal left open paints over the only failure signal
+      // runAction gives the user. Leaving it open turns a failed destructive
+      // action into a silent no-op.
+      fetchWithAuthMock.mockResolvedValueOnce(jsonResponse(groupPayload)); // initial load
+      runActionMock.mockRejectedValueOnce(new Error('boom')); // DELETE fails
+
+      render(<DeviceLinkedProfilesTab deviceId="dev-1" />);
+      await waitFor(() => expect(screen.getByTestId('linked-profiles-tab')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('linked-profiles-dissolve'));
+      fireEvent.click(await screen.findByTestId('linked-profiles-dissolve-confirm'));
+
+      // Dialog is gone (toast is visible), the failure was handled, and the
+      // group was NOT optimistically removed from the UI.
+      await waitFor(() =>
+        expect(screen.queryByTestId('linked-profiles-dissolve-confirm')).not.toBeInTheDocument(),
+      );
+      expect(handleActionError).toHaveBeenCalled();
+      expect(screen.getByTestId('linked-profiles-tab')).toBeInTheDocument();
     });
 
     it('DELETEs the group and reloads the panel once confirmed', async () => {

--- a/apps/web/src/components/devices/DeviceLinkedProfilesTab.tsx
+++ b/apps/web/src/components/devices/DeviceLinkedProfilesTab.tsx
@@ -127,12 +127,17 @@ export default function DeviceLinkedProfilesTab({
         errorFallback: "Could not remove the link",
         successMessage: "Link removed",
       });
-      setConfirmDissolve(false);
       await load();
     } catch (err) {
       handleActionError(err, "Could not remove the link");
     } finally {
       setBusy(false);
+      // Close on FAILURE as well as success. runAction surfaces the failure as a
+      // toast, but the Toast island and the Dialog portal both sit at z-50 and
+      // the portal is appended later in the DOM — leaving the modal open would
+      // paint its backdrop straight over the only error signal the user gets,
+      // turning a failed dissolve into a silent no-op (#2429).
+      setConfirmDissolve(false);
     }
   };
 

--- a/apps/web/src/components/devices/DeviceLinkedProfilesTab.tsx
+++ b/apps/web/src/components/devices/DeviceLinkedProfilesTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Link2, Link2Off, Circle } from "lucide-react";
 import { fetchWithAuth } from "../../stores/auth";
 import { runAction, handleActionError } from "../../lib/runAction";
+import { ConfirmDialog } from "../shared/ConfirmDialog";
 import { useTranslation } from "react-i18next";
 import "../../lib/i18n";
 
@@ -50,6 +51,9 @@ export default function DeviceLinkedProfilesTab({
     "none",
   );
   const [busy, setBusy] = useState(false);
+  // Dissolving the group is destructive and irreversible from this panel, so it
+  // gets the same confirm step as every other destructive device flow (#2429).
+  const [confirmDissolve, setConfirmDissolve] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -123,6 +127,7 @@ export default function DeviceLinkedProfilesTab({
         errorFallback: "Could not remove the link",
         successMessage: "Link removed",
       });
+      setConfirmDissolve(false);
       await load();
     } catch (err) {
       handleActionError(err, "Could not remove the link");
@@ -233,7 +238,7 @@ export default function DeviceLinkedProfilesTab({
           <button
             type="button"
             disabled={busy}
-            onClick={() => void dissolveGroup()}
+            onClick={() => setConfirmDissolve(true)}
             data-testid="linked-profiles-dissolve"
             className="inline-flex items-center gap-1.5 rounded-md border border-destructive/40 px-3 py-1.5 text-sm text-destructive hover:bg-destructive/10 disabled:opacity-50"
           >
@@ -241,6 +246,24 @@ export default function DeviceLinkedProfilesTab({
           </button>
         </div>
       </div>
+
+      {confirmDissolve && (
+        <ConfirmDialog
+          open
+          onClose={() => {
+            if (!busy) setConfirmDissolve(false);
+          }}
+          onConfirm={() => void dissolveGroup()}
+          title={t("deviceLinkedProfilesTab.confirmDissolve.title")}
+          message={t("deviceLinkedProfilesTab.confirmDissolve.message", {
+            count: members.length,
+          })}
+          confirmLabel={t("deviceLinkedProfilesTab.confirmDissolve.confirm")}
+          variant="destructive"
+          confirmTestId="linked-profiles-dissolve-confirm"
+          isLoading={busy}
+        />
+      )}
 
       <div className="overflow-hidden rounded-lg border">
         <table className="w-full text-sm">

--- a/apps/web/src/components/security/ScoreDetailPage.tsx
+++ b/apps/web/src/components/security/ScoreDetailPage.tsx
@@ -9,6 +9,8 @@ import {
   widthPercentClass,
 } from "@/lib/utils";
 import { fetchWithAuth } from "@/stores/auth";
+import { errorKindOf, throwIfNotOk, type LoadErrorKind } from "@/lib/httpError";
+import AccessDenied from "../shared/AccessDenied";
 import SecurityPageHeader from "./SecurityPageHeader";
 import SecurityStatCard from "./SecurityStatCard";
 type ScoreComponent = {
@@ -38,9 +40,11 @@ export default function ScoreDetailPage() {
   const [data, setData] = useState<ScoreBreakdown | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  const [errorKind, setErrorKind] = useState<LoadErrorKind>("none");
   const abortRef = useRef<AbortController | null>(null);
   const fetchData = useCallback(async () => {
     setError(undefined);
+    setErrorKind("none");
     setLoading(true);
     abortRef.current?.abort();
     const controller = new AbortController();
@@ -49,7 +53,9 @@ export default function ScoreDetailPage() {
       const res = await fetchWithAuth("/security/score-breakdown", {
         signal: controller.signal,
       });
-      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      // HttpError (not a bare Error) so a 403 survives the throw and the render
+      // can tell "you may not see this" from "this broke, try again" (#2429).
+      throwIfNotOk(res);
       const json = await res.json();
       if (!json.data)
         throw new Error(t("securityScoreDetailPage.invalidResponseFromServer"));
@@ -57,7 +63,9 @@ export default function ScoreDetailPage() {
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
       console.error("[ScoreDetailPage] fetch error:", err);
-      setError(friendlyFetchError(err));
+      const kind = errorKindOf(err);
+      setErrorKind(kind);
+      if (kind === "other") setError(friendlyFetchError(err));
     } finally {
       setLoading(false);
     }
@@ -76,6 +84,20 @@ export default function ScoreDetailPage() {
         <div className="flex items-center justify-center py-20">
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>
+      </div>
+    );
+  }
+  // A 403 is terminal for this user — the permission gate will deny a retry too,
+  // so show the access-denied panel (no Retry button) instead of the transient
+  // failure banner below (#2429).
+  if (errorKind === "denied") {
+    return (
+      <div className="space-y-6">
+        <SecurityPageHeader
+          title={t("securityScoreDetailPage.securityScore")}
+          subtitle={t("securityScoreDetailPage.scoreBreakdownByCategory")}
+        />
+        <AccessDenied testId="security-score-detail-denied" />
       </div>
     );
   }

--- a/apps/web/src/components/security/SecurityDashboard.test.tsx
+++ b/apps/web/src/components/security/SecurityDashboard.test.tsx
@@ -212,6 +212,24 @@ describe('SecurityDashboard', () => {
           "Security data couldn't be loaded. Check your connection and retry."
         )
       ).toBeNull();
+      // The page-level Refresh is withheld too — it could only 403 again.
+      expect(screen.queryByRole('button', { name: /refresh/i })).toBeNull();
+    });
+
+    it('renders NO dashboard body behind the denied panel — never fabricated zeros', async () => {
+      route(forbidden(), forbidden());
+      render(<SecurityDashboard />);
+
+      await screen.findByTestId('security-dashboard-denied');
+
+      // A denied user must not be told, authoritatively, that they have zero
+      // vulnerabilities and zero AV coverage. `isEmptyTenant` cannot save us
+      // here (it requires overview !== null, and a 403 leaves it null), so the
+      // denied branch has to terminate the render.
+      expect(screen.queryByText('Security Score')).toBeNull();
+      expect(screen.queryByText(/open items/)).toBeNull();
+      expect(screen.queryByText(/devices tracked/)).toBeNull();
+      expect(screen.queryByText('No devices reporting yet')).toBeNull();
     });
 
     it('explains the denial without a Retry when only one axis is forbidden', async () => {
@@ -228,7 +246,7 @@ describe('SecurityDashboard', () => {
       expect(screen.getByText('62')).toBeInTheDocument();
     });
 
-    it('still offers Retry when a transient failure accompanies the denial', async () => {
+    it('still offers Retry when a transient failure accompanies the denial — and says so', async () => {
       route(new Error('network'), forbidden());
       render(<SecurityDashboard />);
 
@@ -237,6 +255,34 @@ describe('SecurityDashboard', () => {
         await screen.findByTestId('security-dashboard-retry')
       ).toBeInTheDocument();
       expect(screen.queryByTestId('security-dashboard-denied')).toBeNull();
+
+      // The copy must match the affordance: a Retry sitting under a pure
+      // "you lack permission" message reads as unmotivated.
+      expect(
+        screen.getByText(
+          "Some security data couldn't be loaded. Values shown may be incomplete."
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('treats a malformed 200 body as a retryable failure, not an empty tenant', async () => {
+      // A truncated/HTML (proxy error page) body used to JSON.parse-fail, get
+      // swallowed into null, normalize to all-zeros, and render as a confident
+      // "No devices reporting yet" — a clean bill of health for a broken load.
+      const garbage = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => '<html>502 Bad Gateway</html>'
+      } as Response;
+      route(garbage, garbage);
+      render(<SecurityDashboard />);
+
+      expect(
+        await screen.findByTestId('security-dashboard-load-error')
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('security-dashboard-retry')).toBeInTheDocument();
+      expect(screen.queryByText('No devices reporting yet')).toBeNull();
     });
 
     it('keeps the plain retryable banner for a non-403 failure', async () => {

--- a/apps/web/src/components/security/SecurityDashboard.test.tsx
+++ b/apps/web/src/components/security/SecurityDashboard.test.tsx
@@ -166,4 +166,90 @@ describe('SecurityDashboard', () => {
     expect(screen.queryByText('High risk')).toBeNull();
     expect(screen.queryByText('Security Score')).toBeNull();
   });
+
+  describe('403 is a permissions state, not a retryable error (#2429)', () => {
+    /** A permission denial: resolves (not rejects) with a non-ok 403 Response. */
+    const forbidden = () =>
+      ({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        text: async () => ''
+      }) as Response;
+
+    /** Route each security endpoint to a Response, or reject for a transport error. */
+    function route(
+      overview: unknown | Error | Response,
+      threats: unknown | Error | Response
+    ) {
+      const settle = (v: unknown | Error | Response) => {
+        if (v instanceof Error) return Promise.reject(v);
+        if (v && typeof v === 'object' && 'ok' in (v as Response)) {
+          return Promise.resolve(v as Response);
+        }
+        return Promise.resolve(ok(v));
+      };
+      fetchWithAuth.mockImplementation((url: string) => {
+        if (url === '/security/dashboard') return settle(overview);
+        if (url === '/security/threats') return settle(threats);
+        return Promise.resolve(ok({}));
+      });
+    }
+
+    it('shows an access-denied panel with no Retry when both loads are forbidden', async () => {
+      route(forbidden(), forbidden());
+      render(<SecurityDashboard />);
+
+      expect(
+        await screen.findByTestId('security-dashboard-denied')
+      ).toBeInTheDocument();
+
+      // The bug: a 403 got the generic "couldn't be loaded — Retry" banner, and
+      // that Retry could only ever 403 again.
+      expect(screen.queryByTestId('security-dashboard-retry')).toBeNull();
+      expect(
+        screen.queryByText(
+          "Security data couldn't be loaded. Check your connection and retry."
+        )
+      ).toBeNull();
+    });
+
+    it('explains the denial without a Retry when only one axis is forbidden', async () => {
+      route(overviewPayload, forbidden());
+      render(<SecurityDashboard />);
+
+      expect(
+        await screen.findByText(
+          "Some security data isn't visible to you. Ask an administrator if you need access."
+        )
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId('security-dashboard-retry')).toBeNull();
+      // The readable axis still renders.
+      expect(screen.getByText('62')).toBeInTheDocument();
+    });
+
+    it('still offers Retry when a transient failure accompanies the denial', async () => {
+      route(new Error('network'), forbidden());
+      render(<SecurityDashboard />);
+
+      // One axis is genuinely retryable, so the button stays — it can fix that one.
+      expect(
+        await screen.findByTestId('security-dashboard-retry')
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId('security-dashboard-denied')).toBeNull();
+    });
+
+    it('keeps the plain retryable banner for a non-403 failure', async () => {
+      route(new Error('network'), new Error('network'));
+      render(<SecurityDashboard />);
+
+      expect(
+        await screen.findByText(
+          "Security data couldn't be loaded. Check your connection and retry."
+        )
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('security-dashboard-retry')).toBeInTheDocument();
+      expect(screen.queryByTestId('security-dashboard-denied')).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/components/security/SecurityDashboard.tsx
+++ b/apps/web/src/components/security/SecurityDashboard.tsx
@@ -486,8 +486,14 @@ const fetchJson = async (url: string) => {
   if (!text) return null;
   try {
     return JSON.parse(text);
-  } catch {
-    return null;
+  } catch (err) {
+    // Do NOT swallow this into `null`. A null payload normalizes to a fully
+    // zeroed overview, which the caller records as a SUCCESS and `isEmptyTenant`
+    // then renders as a confident "No devices reporting yet" — i.e. a truncated
+    // or HTML (proxy/error-page) body would be shown to the user as a clean bill
+    // of health. Surface it as a retryable failure instead. (#2429)
+    console.error(`[SecurityDashboard] invalid JSON from ${url}:`, err);
+    throw new Error(`Invalid JSON response from ${url}`);
   }
 };
 interface SecurityDashboardProps {
@@ -630,20 +636,23 @@ export default function SecurityDashboard({
     },
   ];
   const adminDevices = ovData.adminAudit.devices.slice(0, 3);
-  return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-        <div>
-          <h1 className="text-xl font-semibold">
-            {t("securitySecurityDashboard.security")}
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            {t(
-              "securitySecurityDashboard.trackProtectionCoverageVulnerabilitiesAndPolicyCompliance",
-            )}
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-3">
+
+  const pageHeader = (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div>
+        <h1 className="text-xl font-semibold">
+          {t("securitySecurityDashboard.security")}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {t(
+            "securitySecurityDashboard.trackProtectionCoverageVulnerabilitiesAndPolicyCompliance",
+          )}
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Refresh is an error-recovery affordance here; on a fully-denied
+            dashboard it could only 403 again, so it is withheld. */}
+        {!bothDenied && (
           <button
             type="button"
             onClick={fetchSecurityData}
@@ -657,34 +666,56 @@ export default function SecurityDashboard({
             )}
             {t("securitySecurityDashboard.refresh")}
           </button>
-          {lastUpdated && (
-            <span className="text-xs text-muted-foreground">
-              {t("securitySecurityDashboard.updated", {
-                time: formatTime(lastUpdated, { timeZone: timezone }),
-              })}
-            </span>
-          )}
-        </div>
+        )}
+        {lastUpdated && !bothDenied && (
+          <span className="text-xs text-muted-foreground">
+            {t("securitySecurityDashboard.updated", {
+              time: formatTime(lastUpdated, { timeZone: timezone }),
+            })}
+          </span>
+        )}
       </div>
+    </div>
+  );
 
-      {bothDenied ? (
-        // Nothing on this dashboard is readable by this user. A retry would
-        // 403 again, so offer an explanation instead of a dead button.
+  // Nothing on this dashboard is readable by this user. Terminate the render
+  // here: falling through would paint the normal body from `defaultOverview` /
+  // `defaultVulnerabilities` and tell someone who is not allowed to see the data
+  // that they have 0 critical vulnerabilities and 0% AV coverage — exactly the
+  // fabricated-zeros hazard `isEmptyTenant` exists to prevent (it can't help
+  // here: it requires `overview !== null`, and a 403 leaves it null). (#2429)
+  if (bothDenied) {
+    return (
+      <div className="space-y-6">
+        {pageHeader}
         <AccessDenied
           testId="security-dashboard-denied"
           message={t("securitySecurityDashboard.accessDeniedMessage")}
         />
-      ) : (
-        anyLoadFailed && (
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {pageHeader}
+
+      {anyLoadFailed && (
           <div
             className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-center"
             data-testid="security-dashboard-load-error"
             role="alert"
           >
             <p className="text-sm text-destructive">
-              {anyDenied
+              {/* Copy must match the affordance below it. The "everything is
+                  broken, check your connection" line is reserved for a purely
+                  transient total failure — a mixed denied+transient load is
+                  partial, and blaming the user's connection for a permission
+                  denial would be wrong. With nothing retryable, say so plainly
+                  and render no Retry. */}
+              {!anyTransient
                 ? t("securitySecurityDashboard.someSecurityDataPermissionDenied")
-                : bothFailed
+                : bothFailed && !anyDenied
                   ? t("securitySecurityDashboard.securityDataCouldNotBeLoaded")
                   : t(
                       "securitySecurityDashboard.someSecurityDataCouldNotBeLoaded",
@@ -702,7 +733,6 @@ export default function SecurityDashboard({
               </button>
             )}
           </div>
-        )
       )}
 
       {ENABLE_EDR_INTEGRATIONS && <EdrSummaryPanel />}

--- a/apps/web/src/components/security/SecurityDashboard.tsx
+++ b/apps/web/src/components/security/SecurityDashboard.tsx
@@ -26,6 +26,8 @@ import {
 } from "recharts";
 import { cn, formatNumber, widthPercentClass } from "@/lib/utils";
 import { fetchWithAuth } from "@/stores/auth";
+import { errorKindOf, throwIfNotOk, type LoadErrorKind } from "@/lib/httpError";
+import AccessDenied from "../shared/AccessDenied";
 import { ENABLE_EDR_INTEGRATIONS } from "../../lib/featureFlags";
 import EdrSummaryPanel from "./EdrSummaryPanel";
 type Priority = "critical" | "high" | "medium" | "low";
@@ -477,9 +479,9 @@ const normalizeVulnerabilities = (raw: unknown): VulnerabilitySummary => {
 };
 const fetchJson = async (url: string) => {
   const response = await fetchWithAuth(url);
-  if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`);
-  }
+  // HttpError (not bare Error) so a 403 survives the throw and the caller can
+  // tell "you may not see this" from "this broke, try again" (#2429).
+  throwIfNotOk(response);
   const text = await response.text();
   if (!text) return null;
   try {
@@ -499,14 +501,21 @@ export default function SecurityDashboard({
   const [vulnerabilities, setVulnerabilities] =
     useState<VulnerabilitySummary | null>(null);
   const [loading, setLoading] = useState(true);
-  const [loadFailures, setLoadFailures] = useState({
-    overview: false,
-    vulnerabilities: false,
+  // Per-axis load outcome. Was a pair of booleans, which collapsed a 403 into
+  // the same "failed" bit as a 500 and offered a Retry that could never
+  // succeed (#2429).
+  const [loadFailures, setLoadFailures] = useState<{
+    overview: LoadErrorKind;
+    vulnerabilities: LoadErrorKind;
+  }>({
+    overview: "none",
+    vulnerabilities: "none",
   });
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const fetchSecurityData = useCallback(async () => {
     setLoading(true);
-    const failures = { overview: false, vulnerabilities: false };
+    const failures: { overview: LoadErrorKind; vulnerabilities: LoadErrorKind } =
+      { overview: "none", vulnerabilities: "none" };
     await Promise.all([
       (async () => {
         try {
@@ -515,7 +524,7 @@ export default function SecurityDashboard({
         } catch (err) {
           // Keep any previously loaded data on refresh failure rather than
           // clobbering the dashboard with fabricated zeros.
-          failures.overview = true;
+          failures.overview = errorKindOf(err);
         }
       })(),
       (async () => {
@@ -523,7 +532,7 @@ export default function SecurityDashboard({
           const vulnerabilityData = await fetchJson("/security/threats");
           setVulnerabilities(normalizeVulnerabilities(vulnerabilityData));
         } catch (err) {
-          failures.vulnerabilities = true;
+          failures.vulnerabilities = errorKindOf(err);
         }
       })(),
     ]);
@@ -570,7 +579,22 @@ export default function SecurityDashboard({
     [ovData.recommendations],
   );
   const isInitialLoading = loading && !lastUpdated;
-  const anyLoadFailed = loadFailures.overview || loadFailures.vulnerabilities;
+  // NB: these are LoadErrorKind strings now, so they must be compared against
+  // 'none' — a bare truthiness check would treat "none" as a failure.
+  const anyLoadFailed =
+    loadFailures.overview !== "none" || loadFailures.vulnerabilities !== "none";
+  const bothDenied =
+    loadFailures.overview === "denied" &&
+    loadFailures.vulnerabilities === "denied";
+  const anyDenied =
+    loadFailures.overview === "denied" ||
+    loadFailures.vulnerabilities === "denied";
+  // Retry is only offered when something retryable actually failed. A 403 is
+  // terminal for this user, so a Retry beside it would loop forever.
+  const anyTransient =
+    loadFailures.overview === "other" || loadFailures.vulnerabilities === "other";
+  const bothFailed =
+    loadFailures.overview !== "none" && loadFailures.vulnerabilities !== "none";
   // A tenant with no devices reporting gets a real empty state, never a
   // fabricated 0/100 "High risk" screen.
   const isEmptyTenant =
@@ -643,22 +667,42 @@ export default function SecurityDashboard({
         </div>
       </div>
 
-      {anyLoadFailed && (
-        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-center">
-          <p className="text-sm text-destructive">
-            {loadFailures.overview && loadFailures.vulnerabilities
-              ? t("securitySecurityDashboard.securityDataCouldNotBeLoaded")
-              : t("securitySecurityDashboard.someSecurityDataCouldNotBeLoaded")}
-          </p>
-          <button
-            type="button"
-            onClick={fetchSecurityData}
-            className="mt-2 inline-flex items-center gap-1 text-sm text-primary hover:underline"
+      {bothDenied ? (
+        // Nothing on this dashboard is readable by this user. A retry would
+        // 403 again, so offer an explanation instead of a dead button.
+        <AccessDenied
+          testId="security-dashboard-denied"
+          message={t("securitySecurityDashboard.accessDeniedMessage")}
+        />
+      ) : (
+        anyLoadFailed && (
+          <div
+            className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-center"
+            data-testid="security-dashboard-load-error"
+            role="alert"
           >
-            <RefreshCw className="h-3 w-3" />
-            {t("securitySecurityDashboard.retry")}
-          </button>
-        </div>
+            <p className="text-sm text-destructive">
+              {anyDenied
+                ? t("securitySecurityDashboard.someSecurityDataPermissionDenied")
+                : bothFailed
+                  ? t("securitySecurityDashboard.securityDataCouldNotBeLoaded")
+                  : t(
+                      "securitySecurityDashboard.someSecurityDataCouldNotBeLoaded",
+                    )}
+            </p>
+            {anyTransient && (
+              <button
+                type="button"
+                onClick={fetchSecurityData}
+                data-testid="security-dashboard-retry"
+                className="mt-2 inline-flex items-center gap-1 text-sm text-primary hover:underline"
+              >
+                <RefreshCw className="h-3 w-3" />
+                {t("securitySecurityDashboard.retry")}
+              </button>
+            )}
+          </div>
+        )
       )}
 
       {ENABLE_EDR_INTEGRATIONS && <EdrSummaryPanel />}

--- a/apps/web/src/components/security/TrendsPage.tsx
+++ b/apps/web/src/components/security/TrendsPage.tsx
@@ -14,6 +14,8 @@ import {
 import { Loader2, TrendingDown, TrendingUp } from "lucide-react";
 import { cn, friendlyFetchError } from "@/lib/utils";
 import { fetchWithAuth } from "@/stores/auth";
+import { errorKindOf, throwIfNotOk, type LoadErrorKind } from "@/lib/httpError";
+import AccessDenied from "../shared/AccessDenied";
 import SecurityPageHeader from "./SecurityPageHeader";
 import SecurityStatCard from "./SecurityStatCard";
 type TrendSummary = {
@@ -53,6 +55,7 @@ export default function TrendsPage() {
   const [data, setData] = useState<TrendsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  const [errorKind, setErrorKind] = useState<LoadErrorKind>("none");
   const [period, setPeriod] = useState<Period>("30d");
   const [visibleLines, setVisibleLines] = useState<Set<string>>(
     new Set(["overall", "antivirus", "firewall", "encryption"]),
@@ -70,6 +73,7 @@ export default function TrendsPage() {
   };
   const fetchData = useCallback(async () => {
     setError(undefined);
+    setErrorKind("none");
     setLoading(true);
     abortRef.current?.abort();
     const controller = new AbortController();
@@ -78,7 +82,9 @@ export default function TrendsPage() {
       const res = await fetchWithAuth(`/security/trends?period=${period}`, {
         signal: controller.signal,
       });
-      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      // HttpError (not a bare Error) so a 403 survives the throw and the render
+      // can tell "you may not see this" from "this broke, try again" (#2429).
+      throwIfNotOk(res);
       const json = await res.json();
       if (!json.data)
         throw new Error(t("securityTrendsPage.invalidResponseFromServer"));
@@ -86,7 +92,9 @@ export default function TrendsPage() {
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
       console.error("[TrendsPage] fetch error:", err);
-      setError(friendlyFetchError(err));
+      const kind = errorKindOf(err);
+      setErrorKind(kind);
+      if (kind === "other") setError(friendlyFetchError(err));
     } finally {
       setLoading(false);
     }
@@ -116,6 +124,20 @@ export default function TrendsPage() {
         <div className="flex items-center justify-center py-20">
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>
+      </div>
+    );
+  }
+  // A 403 is terminal for this user — the permission gate will deny a retry too,
+  // so show the access-denied panel (no Retry button) instead of the transient
+  // failure banner below (#2429).
+  if (errorKind === "denied") {
+    return (
+      <div className="space-y-6">
+        <SecurityPageHeader
+          title={t("securityTrendsPage.securityTrends")}
+          subtitle={t("securityTrendsPage.scoreMovementOverTime")}
+        />
+        <AccessDenied testId="security-trends-denied" />
       </div>
     );
   }

--- a/apps/web/src/components/security/UserRiskPage.tsx
+++ b/apps/web/src/components/security/UserRiskPage.tsx
@@ -170,6 +170,11 @@ export default function UserRiskPage() {
       setEvaluation(evaluationJson?.data ?? null);
       setSelected((current) => current ?? rows[0] ?? null);
     } catch (err) {
+      // Log on BOTH paths. A 'denied' render swallows the error object (the
+      // AccessDenied panel supplies its own copy), so without this a 403 caused
+      // by a bug — a bad orgId in the query, a mis-scoped token — would leave no
+      // artifact anywhere to debug from. (#2429)
+      console.error("[UserRiskPage] failed to load user risk scores:", err);
       const kind = errorKindOf(err);
       setErrorKind(kind);
       // 'denied' renders AccessDenied, which supplies its own copy.
@@ -228,6 +233,9 @@ export default function UserRiskPage() {
         if (active) setDetail(json?.data ?? null);
       })
       .catch((err) => {
+        // Logged unconditionally — see the note in loadScores: the 'denied'
+        // branch discards the error object, so this is the only artifact.
+        console.error("[UserRiskPage] failed to load user risk detail:", err);
         if (active) {
           setDetail(null);
           const kind = errorKindOf(err);

--- a/apps/web/src/components/security/UserRiskPage.tsx
+++ b/apps/web/src/components/security/UserRiskPage.tsx
@@ -11,6 +11,12 @@ import {
   XCircle,
 } from "lucide-react";
 import { runAction, handleActionError } from "../../lib/runAction";
+import {
+  errorKindOf,
+  HttpError,
+  type LoadErrorKind,
+} from "../../lib/httpError";
+import AccessDenied from "../shared/AccessDenied";
 import { fetchWithAuth } from "../../stores/auth";
 import { useMlFeatureFlags } from "../../hooks/useMlFeatureFlags";
 import { formatDateTime } from "@/lib/dateTimeFormat";
@@ -116,7 +122,9 @@ export default function UserRiskPage() {
   const [loading, setLoading] = useState(true);
   const [detailLoading, setDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorKind, setErrorKind] = useState<LoadErrorKind>("none");
   const [detailError, setDetailError] = useState<string | null>(null);
+  const [detailErrorKind, setDetailErrorKind] = useState<LoadErrorKind>("none");
   const [detailReloadKey, setDetailReloadKey] = useState(0);
   const [labeling, setLabeling] = useState<
     "true_positive" | "false_positive" | null
@@ -129,17 +137,30 @@ export default function UserRiskPage() {
     }
     setLoading(true);
     setError(null);
+    setErrorKind("none");
     try {
       const [scoresResponse, evaluationResponse] = await Promise.all([
         fetchWithAuth("/user-risk/scores?limit=25&minScore=50"),
         fetchWithAuth("/user-risk/evaluation?days=30"),
       ]);
-      if (!scoresResponse.ok)
+      // A 403 must survive the throw as an HttpError so the render can show a
+      // permissions message instead of a Retry that can never succeed (#2429).
+      // Every other status keeps its existing user-facing copy.
+      if (!scoresResponse.ok) {
+        if (scoresResponse.status === 403)
+          throw new HttpError(scoresResponse.status, scoresResponse.statusText);
         throw new Error(t("securityUserRiskPage.failedToLoadUserRiskScores"));
-      if (!evaluationResponse.ok)
+      }
+      if (!evaluationResponse.ok) {
+        if (evaluationResponse.status === 403)
+          throw new HttpError(
+            evaluationResponse.status,
+            evaluationResponse.statusText,
+          );
         throw new Error(
           t("securityUserRiskPage.failedToLoadUserRiskEvaluation"),
         );
+      }
       const scoresJson = await scoresResponse.json();
       const evaluationJson = await evaluationResponse.json();
       const rows = Array.isArray(scoresJson?.data)
@@ -149,11 +170,15 @@ export default function UserRiskPage() {
       setEvaluation(evaluationJson?.data ?? null);
       setSelected((current) => current ?? rows[0] ?? null);
     } catch (err) {
-      setError(
-        err instanceof Error
-          ? err.message
-          : t("securityUserRiskPage.failedToLoadUserRisk"),
-      );
+      const kind = errorKindOf(err);
+      setErrorKind(kind);
+      // 'denied' renders AccessDenied, which supplies its own copy.
+      if (kind === "other")
+        setError(
+          err instanceof Error
+            ? err.message
+            : t("securityUserRiskPage.failedToLoadUserRisk"),
+        );
     } finally {
       setLoading(false);
     }
@@ -166,6 +191,7 @@ export default function UserRiskPage() {
       setSelected(null);
       setDetail(null);
       setError(null);
+      setErrorKind("none");
       setLoading(false);
       return;
     }
@@ -175,31 +201,44 @@ export default function UserRiskPage() {
     if (userRiskDisabled) {
       setDetail(null);
       setDetailError(null);
+      setDetailErrorKind("none");
       return;
     }
     if (!selected) {
       setDetail(null);
       setDetailError(null);
+      setDetailErrorKind("none");
       return;
     }
     let active = true;
     setDetailLoading(true);
     setDetailError(null);
+    setDetailErrorKind("none");
     fetchWithAuth(`/user-risk/users/${selected.userId}?orgId=${selected.orgId}`)
       .then(async (response) => {
-        if (!response.ok)
+        if (!response.ok) {
+          // A 403 must survive the throw as an HttpError so the render can show
+          // a permissions message instead of a Retry that can never succeed
+          // (#2429). Every other status keeps its existing copy.
+          if (response.status === 403)
+            throw new HttpError(response.status, response.statusText);
           throw new Error(t("securityUserRiskPage.failedToLoadUserRiskDetail"));
+        }
         const json = await response.json();
         if (active) setDetail(json?.data ?? null);
       })
       .catch((err) => {
         if (active) {
           setDetail(null);
-          setDetailError(
-            err instanceof Error
-              ? err.message
-              : t("securityUserRiskPage.failedToLoadUserRiskDetail"),
-          );
+          const kind = errorKindOf(err);
+          setDetailErrorKind(kind);
+          // 'denied' renders AccessDenied, which supplies its own copy.
+          if (kind === "other")
+            setDetailError(
+              err instanceof Error
+                ? err.message
+                : t("securityUserRiskPage.failedToLoadUserRiskDetail"),
+            );
         }
       })
       .finally(() => {
@@ -288,6 +327,12 @@ export default function UserRiskPage() {
         </section>
       </div>
     );
+  }
+  // A 403 is terminal for this user — the permission gate will deny a retry too,
+  // so show the access-denied panel (no Retry button) instead of the transient
+  // failure banner below (#2429).
+  if (errorKind === "denied") {
+    return <AccessDenied testId="user-risk-denied" />;
   }
   if (error) {
     return (
@@ -421,7 +466,11 @@ export default function UserRiskPage() {
                 </span>
               </div>
 
-              {detailError && (
+              {/* A 403 on the detail fetch is terminal — reloading it would 403
+                  again, so no Retry is offered on that path (#2429). */}
+              {detailErrorKind === "denied" ? (
+                <AccessDenied testId="user-risk-detail-denied" />
+              ) : detailError ? (
                 <div
                   className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
                   data-testid="user-risk-detail-error"
@@ -439,7 +488,7 @@ export default function UserRiskPage() {
                     {t("securityUserRiskPage.retry")}
                   </button>
                 </div>
-              )}
+              ) : null}
 
               <div className="flex flex-wrap gap-2">
                 <button

--- a/apps/web/src/components/settings/TicketFormsCard.tsx
+++ b/apps/web/src/components/settings/TicketFormsCard.tsx
@@ -389,18 +389,22 @@ export default function TicketFormsCard() {
       base.visibleOrgIds = d.limitOrgs ? d.visibleOrgIds : null;
     }
 
-    // CREATE also sends the immutable ownership axis; UPDATE (schema is
-    // .partial()) sends only the mutable base.
-    const request = isCreate
-      ? () => {
-          const body: Record<string, unknown> = { ...base, ownerScope: d.ownerScope };
-          if (d.ownerScope === 'organization') body.orgId = d.orgId;
-          return fetchWithAuth('/ticket-forms', { method: 'POST', body: JSON.stringify(body) });
-        }
-      : () => fetchWithAuth(`/ticket-forms/${editing.id}`, { method: 'PUT', body: JSON.stringify(base) });
     try {
       await runAction({
-        request,
+        // CREATE also sends the immutable ownership axis; UPDATE (schema is
+        // .partial()) sends only the mutable base.
+        //
+        // Kept inline rather than hoisted to a `const request`: the
+        // no-silent-mutations guard is a *lexical* AST check, so a thunk
+        // defined outside the runAction(...) call reads as an unwrapped
+        // mutation even though it is passed straight in (#2429).
+        request: isCreate
+          ? () => {
+              const body: Record<string, unknown> = { ...base, ownerScope: d.ownerScope };
+              if (d.ownerScope === 'organization') body.orgId = d.orgId;
+              return fetchWithAuth('/ticket-forms', { method: 'POST', body: JSON.stringify(body) });
+            }
+          : () => fetchWithAuth(`/ticket-forms/${editing.id}`, { method: 'PUT', body: JSON.stringify(base) }),
         successMessage: t('ticketFormsCard.formSaved'),
         errorFallback: t('ticketFormsCard.saveFailed'),
         onUnauthorized: UNAUTHORIZED

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -92,6 +92,11 @@ const TARGET_GLOBS = [
   'src/components/devices/DeviceEdrPanel.tsx',
   'src/components/security/S1ThreatList.tsx',
   'src/components/security/HuntressIncidentList.tsx',
+  // Ticket intake/creation: both already route every mutation through
+  // runAction, but were never guarded, so a future bare mutation would have
+  // shipped with zero CI signal while sibling ticket files stayed covered (#2429).
+  'src/components/settings/TicketFormsCard.tsx',
+  'src/components/tickets/CreateTicketPage.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -283,7 +288,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(64);
+    expect(absoluteFiles.length).toBe(66);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/httpError.ts
+++ b/apps/web/src/lib/httpError.ts
@@ -1,0 +1,43 @@
+/**
+ * A fetch failure that still carries its HTTP status.
+ *
+ * Loaders that did `throw new Error(\`${res.status} ${res.statusText}\`)` lost the
+ * status into a string the moment they threw, so a 403 was indistinguishable
+ * from a 500 and got the same "couldn't be loaded — Retry" banner. Retry can
+ * never clear a 403 (the server-side permission gate will deny it again), so the
+ * status has to survive the throw for the UI to branch on it. (#2429)
+ *
+ * The message is kept in the historical `"<status> <statusText>"` shape so the
+ * existing `friendlyFetchError()` string-sniff in `lib/utils.ts` keeps working
+ * for callers that have not been migrated to `errorKindOf()`.
+ */
+export class HttpError extends Error {
+  readonly status: number;
+
+  constructor(status: number, statusText = '') {
+    super(`${status} ${statusText}`.trim());
+    this.name = 'HttpError';
+    this.status = status;
+  }
+}
+
+/**
+ * How a load failure should be surfaced.
+ * - `none`   — no failure.
+ * - `denied` — 403. Terminal for this user: show a permissions message, NO retry.
+ * - `other`  — transient/unknown. Retry is meaningful.
+ */
+export type LoadErrorKind = 'none' | 'denied' | 'other';
+
+/** Classify a thrown loader error. Anything without a 403 status is retryable. */
+export function errorKindOf(err: unknown): Exclude<LoadErrorKind, 'none'> {
+  return err instanceof HttpError && err.status === 403 ? 'denied' : 'other';
+}
+
+/** Throw an `HttpError` if the response is not ok. Returns the response otherwise. */
+export function throwIfNotOk(response: Response): Response {
+  if (!response.ok) {
+    throw new HttpError(response.status, response.statusText);
+  }
+  return response;
+}

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -900,6 +900,11 @@
     "profiles": "profiles",
     "unlinkThisDevice": "Unlink this device",
     "removeLink": "Remove link",
+    "confirmDissolve": {
+      "title": "Remove this link?",
+      "message": "This ungroups all {{count}} linked devices. Each stays a fully managed endpoint with its own inventory and history — only the grouping is removed. You can re-link them later from the device list.",
+      "confirm": "Remove link"
+    },
     "profile": "Profile",
     "os": "OS",
     "status": "Status",

--- a/apps/web/src/locales/en/security.json
+++ b/apps/web/src/locales/en/security.json
@@ -483,6 +483,8 @@
     "securityScore": "Security Score",
     "securityScoreTrend": "Security Score Trend",
     "someSecurityDataCouldNotBeLoaded": "Some security data couldn't be loaded. Values shown may be incomplete.",
+    "accessDeniedMessage": "You don't have permission to view security data for this organization.",
+    "someSecurityDataPermissionDenied": "Some security data isn't visible to you. Ask an administrator if you need access.",
     "strong": "Strong",
     "trackProtectionCoverageVulnerabilitiesAndPolicyCompliance": "Track protection coverage, vulnerabilities, and policy compliance.",
     "trendInsights": "Trend insights",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -900,6 +900,11 @@
     "profiles": "perfis",
     "unlinkThisDevice": "Desvincular este dispositivo",
     "removeLink": "Remover vínculo",
+    "confirmDissolve": {
+      "title": "Remover este vínculo?",
+      "message": "Isso desagrupa todos os {{count}} dispositivos vinculados. Cada um continua sendo um endpoint totalmente gerenciado, com inventário e histórico próprios — apenas o agrupamento é removido. Você pode vinculá-los novamente mais tarde na lista de dispositivos.",
+      "confirm": "Remover vínculo"
+    },
     "profile": "Perfil",
     "os": "OS",
     "status": "Status",

--- a/apps/web/src/locales/pt-BR/security.json
+++ b/apps/web/src/locales/pt-BR/security.json
@@ -483,6 +483,8 @@
     "securityScore": "Pontuação de segurança",
     "securityScoreTrend": "Tendência da pontuação de segurança",
     "someSecurityDataCouldNotBeLoaded": "Não foi possível carregar parte dos dados de segurança. Os valores exibidos podem estar incompletos.",
+    "accessDeniedMessage": "Você não tem permissão para ver os dados de segurança desta organização.",
+    "someSecurityDataPermissionDenied": "Alguns dados de segurança não estão visíveis para você. Fale com um administrador se precisar de acesso.",
     "strong": "Forte",
     "trackProtectionCoverageVulnerabilitiesAndPolicyCompliance": "Acompanhe cobertura de proteção, vulnerabilidades e conformidade com políticas.",
     "trendInsights": "Insights de tendência",


### PR DESCRIPTION
Closes #2429

Five verified low-severity web findings from the pre-v0.95.0 review, batched.

> [!NOTE]
> **Rebased onto `main`** after #2455 was squash-merged. Now targets `main` directly, carries only its own 3 commits, and CI runs for real. The earlier "stacked on #2455" caveat no longer applies.

## What changed

**1 — BackupTab: a 403 was rendered as a retryable load failure**
Scope note: while this PR was in review, a **separate merged PR fixed the core of item 1 on `main`** (a `configsFailed` flag that stops the "create your first destination" form auto-opening over a failed GET). That fix is kept as-is. What remains here is the piece it doesn't cover: a **403** still got the retryable error banner with a Retry button that could only 403 again. It now routes to the shared `AccessDenied` panel. My duplicate implementation (a `configsError` tri-state in `BackupDestinationSection`) was dropped during the rebase in favour of main's.

**2 — `no-silent-mutations` guard coverage gap**
Added `TicketFormsCard.tsx` + `CreateTicketPage.tsx` to the guarded set (`64` → `66`; the count constant is updated in the same commit — it has red-ed `main` before when it drifted).

Adding them surfaced a **live gap**, not a hypothetical one: `TicketFormsCard`'s mutation thunk was hoisted to a `const request = …` and passed into `runAction({ request })`. The guard is a *lexical* AST walk, so it cannot see through that — the call read as an unwrapped mutation. Rather than paper over it with a misleading `// runaction-exempt:` marker, the thunk is inlined into the `runAction(...)` call. Identical behavior; now genuinely guarded.

**3 — `AdminSessionManager` scope switch (untested + stale budget)**
No test exercised the All-Orgs↔org switch (no `rerender()`), and there was a real bug behind it: on scope change, `idleTimeoutMs` still held the **previous scope's** value for the duration of the async settings refetch. A 5-minute org budget could therefore idle-log-out a partner admin moments after they switched to All Orgs.

It now resets to the frontend default on scope change, and the failure fallback **clamps to the shortest budget we have evidence for** — deliberately *not* a "park enforcement until it resolves" flag, which would let a non-settling fetch disable session expiry entirely, and deliberately not a plain reset-to-default, which would *relax* a stricter org policy on a blip. Erring shorter logs a user out early; erring longer leaves an unattended session open. Four `rerender()`-based tests added.

**4 — `dissolveGroup()` had no confirmation**
It fired immediately on click, unlike every other destructive device flow. Routed through the shared `ConfirmDialog` (the dominant pattern — 3 device files use it vs. 1 stray `window.confirm`) with a `destructive` variant. The dialog closes in `finally`, **including on failure** — `Dialog` portals at `z-50` and would otherwise paint its backdrop straight over the non-portaled Toast island, hiding the only error signal the user gets.

**5 — Security dashboard rendered a 403 as a retryable network error**
Loaders threw `new Error(\`${status} ${statusText}\`)`, collapsing the status into a string — and `UserRiskPage` discarded it entirely. Users got a "couldn't be loaded — **Retry**" banner whose Retry could only ever 403 again.

Added `lib/httpError.ts` (`HttpError` / `errorKindOf` / `throwIfNotOk`) so the status survives the throw, and branched 403 onto the **existing shared `AccessDenied` component** — whose docblock already says precisely this ("a 403 is not a transient failure, so offering a retry button is misleading"). It was used by 6 other pages and by **zero** of the 20 security components. Applied to `SecurityDashboard`, `ScoreDetailPage`, `TrendsPage`, `UserRiskPage`.

Review also caught that a fully-403'd dashboard rendered **fabricated zeros** ("0 critical vulnerabilities", "0% AV coverage") *underneath* the denied panel, and that a malformed 200 body was being swallowed into `null` → normalized to all-zeros → shown as a confident "No devices reporting yet". Both fixed.

Non-403 failures keep their existing copy and Retry byte-for-byte.

## i18n
New keys added to **both** `en` and `pt-BR`. The 403 branches deliberately reuse the already-translated `common:shared.accessDenied.*` copy rather than minting untranslated strings. All `t()` calls are literal-key.

## Not in this PR
The issue's **comment** adds a 6th item — validating glob syntax in `packages/shared/src/validators/backupTargets.ts`. That one is not web polish: it has to match the Go agent's doublestar dialect (`agent/internal/backup/exclude.go`), and a mis-validation would reject legitimate patterns and block policy saves. It belongs with the #2435 backup-excludes work. **`Closes #2429` will auto-close this issue — if you want that item tracked, split it into its own issue before merging.**

The ~11 remaining `security/*` pages that still pair a 403 with a dead Retry are **#2472** (PR #2482).

## Verification
- Full web suite: **438 files / 3497 tests** green on the rebased branch.
- `tsc --noEmit` clean; `astro check` → 0 errors, 0 warnings.
- The stale-idle-budget and fail-open-clamp tests were each confirmed to **fail** against the unfixed code (not vacuous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)