### PR TITLE
fix(api): count kev_epss drops and escalate a feed that never reports a total (#2470)

### DIFF
--- a/apps/api/src/jobs/vulnerabilityJobs.ts
+++ b/apps/api/src/jobs/vulnerabilityJobs.ts
@@ -327,6 +327,7 @@ async function fetchNvdRecords(params: {
   let skippedCount = 0;
   let entryCount = 0;
   let startIndex = 0;
+  let pagesFetched = 0;
 
   // STICKY total. A page that comes back reshaped/cached/rate-limited (no usable
   // meta) must never be able to LOWER what we already know the feed contains.
@@ -348,6 +349,7 @@ async function fetchNvdRecords(params: {
       lastModEndDate: params.lastModEndDate,
       startIndex,
     });
+    pagesFetched += 1;
     const {
       records: pageRecords,
       skippedCount: pageSkippedCount,
@@ -384,8 +386,9 @@ async function fetchNvdRecords(params: {
     startIndex += resultsPerPage;
 
     // No total was EVER reported: we cannot know whether more pages exist, so
-    // stop after what we have rather than paging blind. Not a truncation — it's
-    // unknowable, and the old code behaved the same way.
+    // stop after what we have rather than paging blind (an unbounded blind pager
+    // would re-ingest or spin). Stopping here is right — reporting it as a clean
+    // success is not, so the post-loop guard escalates it (#2470).
     if (knownTotal === null) break;
     if (startIndex >= knownTotal) break;
 
@@ -422,6 +425,34 @@ async function fetchNvdRecords(params: {
       totalResults: truncation.knownTotal,
       reason: truncation.reason,
       ingestedEntries: entryCount,
+    });
+  } else if (knownTotal === null) {
+    // "No total reported" is its OWN escalation condition (#2470), not an implicit
+    // success. Every guard above is predicated on a known total, so a feed that
+    // never reports one leaves them with nothing to pin: the pager stops after page
+    // one and the truncation escalation — written for exactly this class of silent
+    // loss — self-suppresses. The run then writes last_sync_status='ok' over a
+    // fraction of the window.
+    //
+    // Mutually exclusive with the branch above by construction: `truncation` is only
+    // ever set when knownTotal !== null, so a run escalates at most once.
+    //
+    // Cannot false-positive on a healthy feed: NVD always reports totalResults —
+    // an empty window comes back as `totalResults: 0`, which pins knownTotal=0 and
+    // exits through the normal path. Reaching here means the response was reshaped,
+    // truncated, or an error body served with a 200.
+    const message =
+      '[VulnerabilityJobs/nvd] NVD pagination terminated without the feed EVER reporting '
+      + `totalResults (ingested ${entryCount} entr(ies) over ${pagesFetched} page(s)) — `
+      + 'completeness cannot be verified and later pages may never have been requested; '
+      + 'treating as a probable silent truncation';
+    console.error(message);
+    captureMessage(message, 'warning', {
+      startIndex,
+      totalResults: null,
+      reason: 'no_total_reported',
+      ingestedEntries: entryCount,
+      pagesFetched,
     });
   }
 
@@ -1209,9 +1240,15 @@ export async function initializeVulnerabilityJobs(): Promise<void> {
           ? `, ${summary.skipped} CVE entr(ies) skipped (malformed or missing id)`
           : '';
         if (source === 'kev_epss') {
+          // kev_epss drops entries for a malformed/missing id OR an unusable EPSS
+          // score, so it gets its own phrasing rather than the CVE-id-only one (#2470).
+          const exploitSkippedSummary = summary.skipped
+            ? `, ${summary.skipped} feed entr(ies) skipped (malformed id or unusable score)`
+            : '';
           console.log(
             `[VulnerabilityJobs] ${job.name} (${source}) completed: `
             + `${summary.kev ?? 0} KEV update(s), ${summary.epss ?? 0} EPSS update(s)`
+            + exploitSkippedSummary
           );
           return;
         }

--- a/apps/api/src/jobs/vulnerabilityJobsNvd.integration.test.ts
+++ b/apps/api/src/jobs/vulnerabilityJobsNvd.integration.test.ts
@@ -220,6 +220,63 @@ describe('syncNvd', () => {
       expect(message).toContain('ingested 2 entries but feed reported 10');
     });
 
+    // #2470: every guard above is predicated on a KNOWN total. A feed that never
+    // reports one leaves them nothing to pin — the pager stops after page one and
+    // the truncation escalation, written for exactly this loss, self-suppresses.
+    runDb('escalates when the feed NEVER reports a total (truncates to page one)', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { fetchNvdPage } = await import('../services/nvdClient');
+
+      vi.mocked(fetchNvdPage).mockClear();
+      // A full page of results, but no totalResults anywhere. There may be 50 more
+      // pages behind it; the old code returned page one and reported 'ok'.
+      vi.mocked(fetchNvdPage).mockResolvedValueOnce(
+        page(['CVE-2024-11111', 'CVE-2024-22222'], { resultsPerPage: 2 }),
+      );
+
+      const result = await syncNvd();
+
+      expect(error).toHaveBeenCalledTimes(1);
+      const message = error.mock.calls[0]?.[0] as string;
+      expect(message).toContain('without the feed EVER reporting totalResults');
+      expect(message).toContain('ingested 2 entr(ies) over 1 page(s)');
+
+      // It still stops after page one — paging blind is not the fix; escalating is.
+      expect(vi.mocked(fetchNvdPage)).toHaveBeenCalledTimes(1);
+      expect(result.vulns).toBe(2);
+    });
+
+    runDb('escalates a reshaped first page (no entries, no total) rather than reporting a clean run', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { fetchNvdPage } = await import('../services/nvdClient');
+
+      vi.mocked(fetchNvdPage).mockClear();
+      // A 200 carrying an error body / reshaped payload. A healthy empty window
+      // still reports `totalResults: 0`, so this is never a false positive.
+      vi.mocked(fetchNvdPage).mockResolvedValueOnce({});
+
+      const result = await syncNvd();
+
+      expect(error).toHaveBeenCalledTimes(1);
+      expect(error.mock.calls[0]?.[0]).toContain('without the feed EVER reporting totalResults');
+      expect(result.vulns).toBe(0);
+    });
+
+    runDb('does NOT escalate a healthy empty window (totalResults: 0)', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { fetchNvdPage } = await import('../services/nvdClient');
+
+      vi.mocked(fetchNvdPage).mockClear();
+      vi.mocked(fetchNvdPage).mockResolvedValueOnce(page([], { totalResults: 0, resultsPerPage: 0 }));
+
+      await syncNvd();
+
+      expect(error).not.toHaveBeenCalled();
+    });
+
     runDb('keeps paging when a page omits meta, instead of silently ending the run', async () => {
       vi.spyOn(console, 'warn').mockImplementation(() => {});
       const error = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/apps/api/src/services/cveId.test.ts
+++ b/apps/api/src/services/cveId.test.ts
@@ -124,6 +124,7 @@ describe('warnHighSkipRatio', () => {
       entryCount: 100,
       ratio: 0.2,
       trigger: 'ratio',
+      droppedWhat: 'malformed-CVE',
     });
   });
 
@@ -141,6 +142,7 @@ describe('warnHighSkipRatio', () => {
       entryCount: 1_000_000,
       ratio: 0.005,
       trigger: 'absolute_floor',
+      droppedWhat: 'malformed-CVE',
     });
   });
 
@@ -175,6 +177,29 @@ describe('warnHighSkipRatio', () => {
       entryCount: 45,
       ratio: 40 / 45,
       trigger: 'gross_loss',
+      droppedWhat: 'malformed-CVE',
+    });
+  });
+
+  // #2470: kev_epss also drops entries for an unusable SCORE, not just a malformed
+  // id. Sentry is the loudest channel, so the default wording must be overridable —
+  // "malformed-CVE" would point an operator at the CVE-id regex during a score-field
+  // regression.
+  it('names what was dropped when the caller overrides the default', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnHighSkipRatio('ExploitFeeds/epss', 200, 400, 'malformed-id/unusable-score');
+
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0]?.[0]).toContain('High malformed-id/unusable-score skip count');
+    expect(captureMessage).toHaveBeenCalledWith(expect.any(String), 'warning', {
+      tag: 'ExploitFeeds/epss',
+      skippedCount: 200,
+      entryCount: 400,
+      ratio: 0.5,
+      // 200/400 on a 400-entry feed trips the RATIO check first (evaluated before
+      // the absolute floor), even though 200 also clears the floor.
+      trigger: 'ratio',
+      droppedWhat: 'malformed-id/unusable-score',
     });
   });
 

--- a/apps/api/src/services/cveId.ts
+++ b/apps/api/src/services/cveId.ts
@@ -97,7 +97,18 @@ export const GROSS_LOSS_MIN_SKIPS = 5;
  * feed is huge); or the run lost at least GROSS_LOSS_RATIO of a small feed.
  * No-op when nothing was skipped.
  */
-export function warnHighSkipRatio(tag: string, skippedCount: number, entryCount: number): void {
+export function warnHighSkipRatio(
+  tag: string,
+  skippedCount: number,
+  entryCount: number,
+  /**
+   * What was dropped. Defaults to the malformed-CVE-id case every caller had when
+   * this was written. `kev_epss` also drops entries for an unusable SCORE (#2470),
+   * and Sentry is the loudest channel — naming a score-field regression
+   * "malformed-CVE" would send an operator to debug the CVE-id regex.
+   */
+  droppedWhat = 'malformed-CVE'
+): void {
   if (skippedCount <= 0 || entryCount <= 0) return;
 
   const ratio = skippedCount / entryCount;
@@ -108,11 +119,11 @@ export function warnHighSkipRatio(tag: string, skippedCount: number, entryCount:
 
   const trigger = ratioTrips ? 'ratio' : floorTrips ? 'absolute_floor' : 'gross_loss';
   const message =
-    `[${tag}] High malformed-CVE skip count: ${skippedCount} of ${entryCount} `
+    `[${tag}] High ${droppedWhat} skip count: ${skippedCount} of ${entryCount} `
     + `CVE entries (${(ratio * 100).toFixed(1)}%) were skipped this sync — `
     + 'probable upstream feed quality regression';
   console.error(message);
-  captureMessage(message, 'warning', { tag, skippedCount, entryCount, ratio, trigger });
+  captureMessage(message, 'warning', { tag, skippedCount, entryCount, ratio, trigger, droppedWhat });
 }
 
 /**

--- a/apps/api/src/services/exploitFeeds.integration.test.ts
+++ b/apps/api/src/services/exploitFeeds.integration.test.ts
@@ -51,6 +51,8 @@ function epssFeed(
   return {
     scores: new Map(scores),
     skippedCveIds: new Set<string>(),
+    unusableScoreSamples: [],
+    unusableScoreCount: 0,
     skippedCount: 0,
     entryCount: scores.length,
     ...overrides,
@@ -223,6 +225,34 @@ describe('enrichExploitSignals', () => {
 
       expect(error).not.toHaveBeenCalled();
       expect((await readSource())?.skippedCount).toBe(2);
+    });
+
+    // Review finding: EPSS now throws on a zero-valid-id feed, and it already threw on
+    // a non-200. KEV (exploited in the wild) is the higher-severity signal, so a
+    // FIRST.org break must not discard KEV data we already have in hand.
+    runDb('applies KEV flags even when the EPSS fetch fails, and still marks the source error', async () => {
+      await seedVulnerability('CVE-2024-0519');
+
+      await expect(
+        enrichExploitSignals({
+          fetchKevCveIds: async () => kevFeed(['CVE-2024-0519']),
+          fetchEpssScores: async () => {
+            throw new Error('EPSS feed unreachable');
+          },
+        })
+      ).rejects.toThrow('EPSS feed unreachable');
+
+      const [row] = await withSystemDbAccessContext(() =>
+        db
+          .select({ knownExploited: vulnerabilities.knownExploited })
+          .from(vulnerabilities)
+          .where(eq(vulnerabilities.cveId, 'CVE-2024-0519'))
+          .limit(1)
+      );
+      // KEV enrichment landed...
+      expect(row?.knownExploited).toBe(true);
+      // ...and the run is still honestly reported as a failure, not a clean sync.
+      expect((await readSource())?.status).toBe('error');
     });
 
     runDb('a failed run leaves the last successful skip count intact', async () => {

--- a/apps/api/src/services/exploitFeeds.integration.test.ts
+++ b/apps/api/src/services/exploitFeeds.integration.test.ts
@@ -178,7 +178,10 @@ describe('enrichExploitSignals', () => {
       expect(error).toHaveBeenCalledTimes(1);
       const message = error.mock.calls[0]?.[0] as string;
       expect(message).toContain('[ExploitFeeds/epss]');
-      expect(message).toContain('High malformed-CVE skip count: 200 of 400');
+      // NOT "malformed-CVE": the EPSS numerator includes unusable-score drops, and
+      // Sentry is the loudest channel — that wording would send an operator to debug
+      // the CVE-id regex during a score-field regression.
+      expect(message).toContain('High malformed-id/unusable-score skip count: 200 of 400');
 
       // Still persisted, still 'ok' — the escalation is the signal, not a status flip.
       expect((await readSource())?.skippedCount).toBe(200);

--- a/apps/api/src/services/exploitFeeds.integration.test.ts
+++ b/apps/api/src/services/exploitFeeds.integration.test.ts
@@ -37,6 +37,7 @@ async function seedVulnerability(cveId: string): Promise<void> {
 function kevFeed(cveIds: string[], overrides: Partial<KevParseResult> = {}): KevParseResult {
   return {
     cveIds: new Set(cveIds),
+    skippedCveIds: new Set<string>(),
     skippedCount: 0,
     entryCount: cveIds.length,
     ...overrides,
@@ -174,11 +175,38 @@ describe('enrichExploitSignals', () => {
 
       expect(error).toHaveBeenCalledTimes(1);
       const message = error.mock.calls[0]?.[0] as string;
-      expect(message).toContain('[ExploitFeeds/kev_epss]');
-      expect(message).toContain('High malformed-CVE skip count: 200 of 401');
+      expect(message).toContain('[ExploitFeeds/epss]');
+      expect(message).toContain('High malformed-CVE skip count: 200 of 400');
 
       // Still persisted, still 'ok' — the escalation is the signal, not a status flip.
       expect((await readSource())?.skippedCount).toBe(200);
+    });
+
+    // Review finding: pooling KEV (~1.3k entries) with EPSS (fetched for the whole
+    // ~250k catalog) into one denominator makes KEV ~0.5% of it, so a real KEV
+    // regression computes to a fraction of a percent and trips none of the three
+    // triggers. The ratio must be evaluated PER FEED.
+    runDb('escalates a KEV-only regression that a pooled denominator would suppress', async () => {
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await seedVulnerability('CVE-2024-0519');
+
+      await enrichExploitSignals({
+        // 60 of 1,300 KEV entries dropped = 4.6% of that feed, 4x the 1% threshold.
+        fetchKevCveIds: async () =>
+          kevFeed(['CVE-2024-0519'], { skippedCount: 60, entryCount: 1300 }),
+        // A healthy, much larger EPSS feed. Pooled, the KEV loss would be
+        // 60/251,300 = 0.02% — under the ratio, the absolute floor AND gross loss.
+        fetchEpssScores: async () =>
+          epssFeed([['CVE-2024-0519', 0.5]], { skippedCount: 0, entryCount: 250_000 }),
+      });
+
+      expect(error).toHaveBeenCalledTimes(1);
+      const message = error.mock.calls[0]?.[0] as string;
+      expect(message).toContain('[ExploitFeeds/kev]');
+      expect(message).toContain('60 of 1300');
+
+      expect((await readSource())?.skippedCount).toBe(60);
     });
 
     runDb('does not escalate a handful of skips on a large feed', async () => {

--- a/apps/api/src/services/exploitFeeds.integration.test.ts
+++ b/apps/api/src/services/exploitFeeds.integration.test.ts
@@ -1,10 +1,11 @@
 import '../__tests__/integration/setup';
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { eq } from 'drizzle-orm';
 
 import { db, withSystemDbAccessContext } from '../db';
 import { vulnerabilities, vulnerabilitySources } from '../db/schema';
+import type { EpssParseResult, KevParseResult } from './exploitFeeds';
 import { enrichExploitSignals } from './exploitFeeds';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
@@ -14,6 +15,10 @@ beforeEach(async () => {
     await db.delete(vulnerabilities);
     await db.delete(vulnerabilitySources);
   });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 async function seedVulnerability(cveId: string): Promise<void> {
@@ -29,16 +34,51 @@ async function seedVulnerability(cveId: string): Promise<void> {
   });
 }
 
+function kevFeed(cveIds: string[], overrides: Partial<KevParseResult> = {}): KevParseResult {
+  return {
+    cveIds: new Set(cveIds),
+    skippedCount: 0,
+    entryCount: cveIds.length,
+    ...overrides,
+  };
+}
+
+function epssFeed(
+  scores: Array<[string, number]>,
+  overrides: Partial<EpssParseResult> = {}
+): EpssParseResult {
+  return {
+    scores: new Map(scores),
+    skippedCveIds: new Set<string>(),
+    skippedCount: 0,
+    entryCount: scores.length,
+    ...overrides,
+  };
+}
+
+async function readSource() {
+  const [row] = await withSystemDbAccessContext(() =>
+    db
+      .select({
+        status: vulnerabilitySources.lastSyncStatus,
+        skippedCount: vulnerabilitySources.lastSyncSkippedCount,
+      })
+      .from(vulnerabilitySources)
+      .where(eq(vulnerabilitySources.source, 'kev_epss'))
+  );
+  return row;
+}
+
 describe('enrichExploitSignals', () => {
   runDb('marks KEV CVEs and stores EPSS scores for catalog vulnerabilities', async () => {
     await seedVulnerability('CVE-2024-0519');
 
-    const fetchKevCveIds = vi.fn(async () => new Set(['CVE-2024-0519']));
-    const fetchEpssScores = vi.fn(async () => new Map([['CVE-2024-0519', 0.5]]));
+    const fetchKevCveIds = vi.fn(async () => kevFeed(['CVE-2024-0519']));
+    const fetchEpssScores = vi.fn(async () => epssFeed([['CVE-2024-0519', 0.5]]));
 
     const result = await enrichExploitSignals({ fetchKevCveIds, fetchEpssScores });
 
-    expect(result).toEqual({ kev: 1, epss: 1 });
+    expect(result).toEqual({ kev: 1, epss: 1, skipped: 0 });
     expect(fetchKevCveIds).toHaveBeenCalledOnce();
     expect(fetchEpssScores).toHaveBeenCalledWith(['CVE-2024-0519']);
 
@@ -55,5 +95,131 @@ describe('enrichExploitSignals', () => {
 
     expect(row?.knownExploited).toBe(true);
     expect(Number(row?.epssScore)).toBeCloseTo(0.5);
+  });
+
+  // #2470: the kev_epss source could never record anything but NULL, so a feed
+  // shipping garbage was indistinguishable from a healthy one — and from a source
+  // that had simply never run.
+  describe('skip counts (#2470)', () => {
+    runDb('a clean run persists an explicit 0 (NULL would mean never recorded)', async () => {
+      await seedVulnerability('CVE-2024-0519');
+
+      await enrichExploitSignals({
+        fetchKevCveIds: async () => kevFeed(['CVE-2024-0519']),
+        fetchEpssScores: async () => epssFeed([['CVE-2024-0519', 0.5]]),
+      });
+
+      const source = await readSource();
+      expect(source?.status).toBe('ok');
+      expect(source?.skippedCount).toBe(0);
+    });
+
+    runDb('persists the parse-boundary skips from BOTH feeds alongside a healthy status', async () => {
+      await seedVulnerability('CVE-2024-0519');
+
+      const result = await enrichExploitSignals({
+        // 3 KEV entries dropped for a missing id, 4 EPSS entries for an unusable score.
+        fetchKevCveIds: async () =>
+          kevFeed(['CVE-2024-0519'], { skippedCount: 3, entryCount: 4 }),
+        fetchEpssScores: async () =>
+          epssFeed([['CVE-2024-0519', 0.5]], { skippedCount: 4, entryCount: 5 }),
+      });
+
+      expect(result.skipped).toBe(7);
+
+      const source = await readSource();
+      // The whole point: 'ok' AND a nonzero count, together. A green status is
+      // otherwise read as proof the catalog is complete.
+      expect(source?.status).toBe('ok');
+      expect(source?.skippedCount).toBe(7);
+    });
+
+    runDb('unions the re-check skips with the parse-boundary skips', async () => {
+      await seedVulnerability('CVE-2024-0519');
+
+      const result = await enrichExploitSignals({
+        fetchKevCveIds: async () => kevFeed(['CVE-2024-0519']),
+        // Two scores that clear the parse boundary but cannot be applied: one for a
+        // CVE absent from the catalog, one that is not finite. Both are entries we
+        // fetched and silently discarded.
+        fetchEpssScores: async () =>
+          epssFeed(
+            [
+              ['CVE-2024-0519', 0.5],
+              ['CVE-2099-99999', 0.7],
+              ['CVE-2024-22222', Number.NaN],
+            ],
+            { skippedCount: 1, entryCount: 4 }
+          ),
+      });
+
+      // 1 parse-boundary skip + 2 re-check skips.
+      expect(result.skipped).toBe(3);
+      expect(result.epss).toBe(1);
+      expect((await readSource())?.skippedCount).toBe(3);
+    });
+
+    runDb('escalates a high skip ratio through warnHighSkipRatio', async () => {
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await seedVulnerability('CVE-2024-0519');
+
+      await enrichExploitSignals({
+        fetchKevCveIds: async () => kevFeed(['CVE-2024-0519'], { skippedCount: 0, entryCount: 1 }),
+        // 200 dropped entries of 400 — trips the absolute floor (>=100) and the
+        // gross-loss trigger.
+        fetchEpssScores: async () =>
+          epssFeed([['CVE-2024-0519', 0.5]], { skippedCount: 200, entryCount: 400 }),
+      });
+
+      expect(error).toHaveBeenCalledTimes(1);
+      const message = error.mock.calls[0]?.[0] as string;
+      expect(message).toContain('[ExploitFeeds/kev_epss]');
+      expect(message).toContain('High malformed-CVE skip count: 200 of 401');
+
+      // Still persisted, still 'ok' — the escalation is the signal, not a status flip.
+      expect((await readSource())?.skippedCount).toBe(200);
+    });
+
+    runDb('does not escalate a handful of skips on a large feed', async () => {
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await seedVulnerability('CVE-2024-0519');
+
+      await enrichExploitSignals({
+        fetchKevCveIds: async () => kevFeed(['CVE-2024-0519'], { skippedCount: 0, entryCount: 1 }),
+        // 2 of 1000 = 0.2%: under the ratio threshold, the absolute floor and gross loss.
+        fetchEpssScores: async () =>
+          epssFeed([['CVE-2024-0519', 0.5]], { skippedCount: 2, entryCount: 1000 }),
+      });
+
+      expect(error).not.toHaveBeenCalled();
+      expect((await readSource())?.skippedCount).toBe(2);
+    });
+
+    runDb('a failed run leaves the last successful skip count intact', async () => {
+      await seedVulnerability('CVE-2024-0519');
+
+      await enrichExploitSignals({
+        fetchKevCveIds: async () => kevFeed(['CVE-2024-0519'], { skippedCount: 5, entryCount: 6 }),
+        fetchEpssScores: async () => epssFeed([['CVE-2024-0519', 0.5]]),
+      });
+      expect((await readSource())?.skippedCount).toBe(5);
+
+      await expect(
+        enrichExploitSignals({
+          fetchKevCveIds: async () => {
+            throw new Error('KEV feed unreachable');
+          },
+          fetchEpssScores: async () => epssFeed([]),
+        })
+      ).rejects.toThrow('KEV feed unreachable');
+
+      const source = await readSource();
+      // The count pairs with last_successful_sync_at, so the error path must not
+      // overwrite it with a partial number.
+      expect(source?.status).toBe('error');
+      expect(source?.skippedCount).toBe(5);
+    });
   });
 });

--- a/apps/api/src/services/exploitFeeds.test.ts
+++ b/apps/api/src/services/exploitFeeds.test.ts
@@ -92,6 +92,20 @@ describe('fetchKevCveIds (#2470)', () => {
     await expect(fetchKevCveIds()).rejects.toThrow(/zero valid CVE ids/);
   });
 
+  // Review finding: a ROOT-key rename is the likeliest format change and it lands in
+  // assertSomeValidCveIds' `entryCount === 0` exemption — zero entries means zero
+  // skips, so every guard no-ops and the source records a clean sync while the whole
+  // KEV catalog stops applying. KEV is a full snapshot, never legitimately empty.
+  it.each([
+    ['root key renamed', { data: [{ cveID: 'CVE-2024-0519' }] }],
+    ['error body served with 200', {}],
+    ['explicitly empty', { vulnerabilities: [] }],
+  ])('throws when the feed yields no entries at all (%s)', async (_label, payload) => {
+    mockFetchJson([payload]);
+
+    await expect(fetchKevCveIds()).rejects.toThrow(/never empty/);
+  });
+
   it('records an explicit 0 on a clean feed (NULL would mean never recorded)', async () => {
     mockFetchJson([{ vulnerabilities: [{ cveID: 'CVE-2024-0519' }] }]);
 
@@ -132,15 +146,32 @@ describe('fetchEpssScores (#2470)', () => {
     expect(result.scores).toEqual(new Map([['CVE-2024-0519', 0.5]]));
     expect(result.skippedCount).toBe(3);
     expect(result.entryCount).toBe(4);
-    // The id-less entry cannot be sampled, but is still counted above.
-    expect(result.skippedCveIds).toEqual(new Set(['CVE-2024-22222', 'CVE-2024-33333']));
+    // Score-drops are NOT filed as malformed ids — these ids are perfectly valid.
+    // Reporting them as id problems would send an operator to debug the CVE-id
+    // regex during a score-field regression.
+    expect(result.skippedCveIds).toEqual(new Set());
+    expect(result.unusableScoreCount).toBe(2);
+    expect(result.unusableScoreSamples).toEqual([
+      'CVE-2024-22222="not-a-number"',
+      'CVE-2024-33333=undefined',
+    ]);
+  });
+
+  it('files a MALFORMED id as an id-drop, not a score-drop', async () => {
+    mockFetchJson([{ data: [{ cve: 'cve-2024-1234', epss: '0.5' }, { cve: 'CVE-2024-0519', epss: '0.5' }] }]);
+
+    const result = await fetchEpssScores(['CVE-2024-0519']);
+
+    expect(result.skippedCveIds).toEqual(new Set(['cve-2024-1234']));
+    expect(result.unusableScoreCount).toBe(0);
+    expect(result.skippedCount).toBe(1);
   });
 
   // The #2427 review's central lesson: upstream garbage is typically ONE repeated
   // literal, so a distinct-id count (`Set.size`) reports a 2,000-record drop as
   // `skipped=1` and trips no escalation — reproducing the very bug the counting
   // exists to catch. The count must be of dropped ENTRIES.
-  it('counts dropped ENTRIES, not distinct ids (a repeated bogus id counts once per entry)', async () => {
+  it('counts dropped ENTRIES, not distinct ids (a repeated bad score counts once per entry)', async () => {
     mockFetchJson([
       {
         data: [
@@ -152,9 +183,28 @@ describe('fetchEpssScores (#2470)', () => {
 
     const result = await fetchEpssScores(['CVE-2024-0519']);
 
+    // A Set.size-based count would have reported 1 here — the #2427 review's blind spot.
     expect(result.skippedCount).toBe(2000);
+    expect(result.unusableScoreCount).toBe(2000);
     expect(result.entryCount).toBe(2001);
-    // A Set.size-based count would have reported 1 here.
+    // Only 10 raw values are sampled for the log line; the COUNT is not derived from it.
+    expect(result.unusableScoreSamples).toHaveLength(10);
+  });
+
+  it('counts dropped ENTRIES for a repeated MALFORMED id too', async () => {
+    mockFetchJson([
+      {
+        data: [
+          ...Array.from({ length: 2000 }, () => ({ cve: 'cve-2024-99999', epss: '0.5' })),
+          { cve: 'CVE-2024-0519', epss: '0.5' },
+        ],
+      },
+    ]);
+
+    const result = await fetchEpssScores(['CVE-2024-0519']);
+
+    expect(result.skippedCount).toBe(2000);
+    // The distinct-id set is for the log SAMPLE only — never the count.
     expect(result.skippedCveIds.size).toBe(1);
   });
 
@@ -202,7 +252,12 @@ describe('fetchEpssScores (#2470)', () => {
 
     expect(result.scores.has('CVE-2024-0519')).toBe(false);
     expect(result.skippedCount).toBe(1);
-    expect(result.skippedCveIds).toEqual(new Set(['CVE-2024-0519']));
+    // A score problem, not an id problem — the id is valid and must not be reported
+    // as malformed.
+    expect(result.skippedCveIds).toEqual(new Set());
+    expect(result.unusableScoreCount).toBe(1);
+    // The healthy sibling entry still scores.
+    expect(result.scores.get('CVE-2024-11111')).toBe(0.5);
   });
 
   it('accepts a numeric 0 and 1 (the valid ends of the probability range)', async () => {
@@ -214,8 +269,23 @@ describe('fetchEpssScores (#2470)', () => {
     expect(result.skippedCount).toBe(0);
   });
 
-  it('throws when the feed returns entries but not one usable score', async () => {
+  // The assert is about IDS. A returned-but-unscored entry has a perfectly good id,
+  // and a small all-recent catalog can legitimately come back entirely unscored
+  // (reserved/very-new CVEs have no EPSS score) — throwing there would mark a healthy
+  // source 'error'. A total score loss is still LOUD (100% skip ratio trips the
+  // gross-loss trigger) and parseEpssScore keeps the corrupt values out of the catalog.
+  it('does NOT throw when every entry is unscored — that is a score loss, not an id failure', async () => {
     mockFetchJson([{ data: Array.from({ length: 100 }, () => ({ cve: 'CVE-2024-0519', epss: null })) }]);
+
+    const result = await fetchEpssScores(['CVE-2024-0519']);
+
+    expect(result.scores.size).toBe(0);
+    expect(result.skippedCount).toBe(100);
+    expect(result.unusableScoreCount).toBe(100);
+  });
+
+  it('DOES throw when the feed returns entries but zero valid ids (an id-format change)', async () => {
+    mockFetchJson([{ data: Array.from({ length: 100 }, () => ({ cve: 'cve-2024-1234', epss: '0.5' })) }]);
 
     await expect(fetchEpssScores(['CVE-2024-0519'])).rejects.toThrow(/zero valid CVE ids/);
   });

--- a/apps/api/src/services/exploitFeeds.test.ts
+++ b/apps/api/src/services/exploitFeeds.test.ts
@@ -56,6 +56,42 @@ describe('fetchKevCveIds (#2470)', () => {
     expect(result.entryCount).toBe(5);
   });
 
+  // Review finding: without an id-SHAPE guard, an upstream format change yields a
+  // non-empty string for every entry — skippedCount stays 0, the junk falls out at
+  // the catalog intersection (explicitly "not a skip"), and the source records a
+  // CLEAN sync while the whole KEV catalog fails to apply. Worse than the NULL.
+  it('counts entries dropped for a MALFORMED id, not just a missing one', async () => {
+    mockFetchJson([
+      {
+        vulnerabilities: [
+          { cveID: 'CVE-2024-0519' },
+          { cveID: 'cve-2024-1234' }, // lowercase
+          { cveID: 'CVE-2023-38039 mariner - do not use this one' }, // annotated
+          { cveID: 'KEV-2024-0001' }, // reshaped scheme
+        ],
+      },
+    ]);
+
+    const result = await fetchKevCveIds();
+
+    expect(result.cveIds).toEqual(new Set(['CVE-2024-0519']));
+    expect(result.skippedCount).toBe(3);
+    expect(result.entryCount).toBe(4);
+    expect(result.skippedCveIds.size).toBe(3);
+  });
+
+  // The codebase's own contract (cveId.ts assertSomeValidCveIds): a feed with
+  // entries but zero valid ids is a format change — refuse to mark it successful.
+  it('throws when the feed has entries but zero valid ids (CISA renames the id field)', async () => {
+    mockFetchJson([
+      {
+        vulnerabilities: Array.from({ length: 1300 }, () => ({ cve_id: 'CVE-2024-0519' })),
+      },
+    ]);
+
+    await expect(fetchKevCveIds()).rejects.toThrow(/zero valid CVE ids/);
+  });
+
   it('records an explicit 0 on a clean feed (NULL would mean never recorded)', async () => {
     mockFetchJson([{ vulnerabilities: [{ cveID: 'CVE-2024-0519' }] }]);
 
@@ -144,5 +180,43 @@ describe('fetchEpssScores (#2470)', () => {
 
     expect(result.skippedCount).toBe(0);
     expect(result.entryCount).toBe(1);
+  });
+
+  // Review finding: `Number(null)`, `Number('')`, `Number(false)` and `Number([])`
+  // are all 0 — and 0 is FINITE, so a bare Number.isFinite guard accepts them. A
+  // feed shipping `"epss": null` would overwrite every score with 0.0 while
+  // counting zero skips: a full-catalog EPSS wipe reported as a clean sync.
+  // `"epss": true` would coerce to a 1.0 exploit probability fleet-wide.
+  it.each([
+    ['null', null],
+    ['empty string', ''],
+    ['false', false],
+    ['true', true],
+    ['empty array', []],
+    ['out of range (>1)', '7'],
+    ['negative', '-0.5'],
+  ])('does not coerce %s into a score — counts it as a skip', async (_label, epss) => {
+    mockFetchJson([{ data: [{ cve: 'CVE-2024-0519', epss }, { cve: 'CVE-2024-11111', epss: '0.5' }] }]);
+
+    const result = await fetchEpssScores(['CVE-2024-0519', 'CVE-2024-11111']);
+
+    expect(result.scores.has('CVE-2024-0519')).toBe(false);
+    expect(result.skippedCount).toBe(1);
+    expect(result.skippedCveIds).toEqual(new Set(['CVE-2024-0519']));
+  });
+
+  it('accepts a numeric 0 and 1 (the valid ends of the probability range)', async () => {
+    mockFetchJson([{ data: [{ cve: 'CVE-2024-0519', epss: 0 }, { cve: 'CVE-2024-11111', epss: 1 }] }]);
+
+    const result = await fetchEpssScores(['CVE-2024-0519', 'CVE-2024-11111']);
+
+    expect(result.scores).toEqual(new Map([['CVE-2024-0519', 0], ['CVE-2024-11111', 1]]));
+    expect(result.skippedCount).toBe(0);
+  });
+
+  it('throws when the feed returns entries but not one usable score', async () => {
+    mockFetchJson([{ data: Array.from({ length: 100 }, () => ({ cve: 'CVE-2024-0519', epss: null })) }]);
+
+    await expect(fetchEpssScores(['CVE-2024-0519'])).rejects.toThrow(/zero valid CVE ids/);
   });
 });

--- a/apps/api/src/services/exploitFeeds.test.ts
+++ b/apps/api/src/services/exploitFeeds.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The parse boundaries under test never touch the DB, but importing the module
+// pulls `../db` in — stub it so this stays a pure unit test.
+vi.mock('../db', () => ({
+  db: {},
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+
+vi.mock('../db/schema', () => ({
+  vulnerabilities: { cveId: 'vulnerabilities.cveId' },
+  vulnerabilitySources: { source: 'vulnerabilitySources.source' },
+}));
+
+import { fetchEpssScores, fetchKevCveIds } from './exploitFeeds';
+
+function mockFetchJson(payloads: unknown[]): void {
+  const fetchMock = vi.fn();
+  for (const payload of payloads) {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => payload });
+  }
+  vi.stubGlobal('fetch', fetchMock);
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// #2470: both feeds behind the `kev_epss` source used to drop malformed entries
+// with a bare `continue` and count nothing, so `last_sync_skipped_count` stayed
+// NULL — indistinguishable from "never recorded". A feed that starts shipping
+// garbage looked identical to a healthy one.
+describe('fetchKevCveIds (#2470)', () => {
+  it('counts entries dropped for a missing/blank id', async () => {
+    mockFetchJson([
+      {
+        vulnerabilities: [
+          { cveID: 'CVE-2024-0519' },
+          { cveID: '   ' }, // blank
+          { cveID: 12345 }, // not a string
+          {}, // absent
+          { cveID: 'CVE-2024-11111' },
+        ],
+      },
+    ]);
+
+    const result = await fetchKevCveIds();
+
+    expect(result.cveIds).toEqual(new Set(['CVE-2024-0519', 'CVE-2024-11111']));
+    expect(result.skippedCount).toBe(3);
+    expect(result.entryCount).toBe(5);
+  });
+
+  it('records an explicit 0 on a clean feed (NULL would mean never recorded)', async () => {
+    mockFetchJson([{ vulnerabilities: [{ cveID: 'CVE-2024-0519' }] }]);
+
+    const result = await fetchKevCveIds();
+
+    expect(result.skippedCount).toBe(0);
+    expect(result.entryCount).toBe(1);
+  });
+
+  it('does NOT count a well-formed id that is simply absent from our catalog', async () => {
+    // The catalog intersection happens in enrichExploitSignals and is expected
+    // behaviour (KEV lists CVEs most catalogs do not carry) — counting it as a
+    // data-quality skip would escalate on every healthy run.
+    mockFetchJson([{ vulnerabilities: [{ cveID: 'CVE-1999-0001' }, { cveID: 'CVE-1999-0002' }] }]);
+
+    const result = await fetchKevCveIds();
+
+    expect(result.skippedCount).toBe(0);
+    expect(result.cveIds.size).toBe(2);
+  });
+});
+
+describe('fetchEpssScores (#2470)', () => {
+  it('counts entries dropped for a non-string id and for an unusable score', async () => {
+    mockFetchJson([
+      {
+        data: [
+          { cve: 'CVE-2024-0519', epss: '0.5' },
+          { cve: 42, epss: '0.1' }, // no usable id
+          { cve: 'CVE-2024-22222', epss: 'not-a-number' }, // unusable score
+          { cve: 'CVE-2024-33333' }, // score absent
+        ],
+      },
+    ]);
+
+    const result = await fetchEpssScores(['CVE-2024-0519']);
+
+    expect(result.scores).toEqual(new Map([['CVE-2024-0519', 0.5]]));
+    expect(result.skippedCount).toBe(3);
+    expect(result.entryCount).toBe(4);
+    // The id-less entry cannot be sampled, but is still counted above.
+    expect(result.skippedCveIds).toEqual(new Set(['CVE-2024-22222', 'CVE-2024-33333']));
+  });
+
+  // The #2427 review's central lesson: upstream garbage is typically ONE repeated
+  // literal, so a distinct-id count (`Set.size`) reports a 2,000-record drop as
+  // `skipped=1` and trips no escalation — reproducing the very bug the counting
+  // exists to catch. The count must be of dropped ENTRIES.
+  it('counts dropped ENTRIES, not distinct ids (a repeated bogus id counts once per entry)', async () => {
+    mockFetchJson([
+      {
+        data: [
+          ...Array.from({ length: 2000 }, () => ({ cve: 'CVE-2024-99999', epss: 'garbage' })),
+          { cve: 'CVE-2024-0519', epss: '0.5' },
+        ],
+      },
+    ]);
+
+    const result = await fetchEpssScores(['CVE-2024-0519']);
+
+    expect(result.skippedCount).toBe(2000);
+    expect(result.entryCount).toBe(2001);
+    // A Set.size-based count would have reported 1 here.
+    expect(result.skippedCveIds.size).toBe(1);
+  });
+
+  it('accumulates skips and entries across paged chunks', async () => {
+    // EPSS_BATCH_SIZE is 100, so 150 ids fan out to two requests.
+    const requested = Array.from({ length: 150 }, (_, i) => `CVE-2024-${String(i).padStart(5, '0')}`);
+    mockFetchJson([
+      { data: [{ cve: requested[0], epss: '0.5' }, { cve: 'CVE-2024-88888', epss: 'bad' }] },
+      { data: [{ cve: 'CVE-2024-77777', epss: 'bad' }] },
+    ]);
+
+    const result = await fetchEpssScores(requested);
+
+    expect(result.skippedCount).toBe(2);
+    expect(result.entryCount).toBe(3);
+    expect(result.scores.size).toBe(1);
+  });
+
+  it('records an explicit 0 on a clean feed', async () => {
+    mockFetchJson([{ data: [{ cve: 'CVE-2024-0519', epss: '0.5' }] }]);
+
+    const result = await fetchEpssScores(['CVE-2024-0519']);
+
+    expect(result.skippedCount).toBe(0);
+    expect(result.entryCount).toBe(1);
+  });
+});

--- a/apps/api/src/services/exploitFeeds.ts
+++ b/apps/api/src/services/exploitFeeds.ts
@@ -39,16 +39,24 @@ export interface KevParseResult {
 export interface EpssParseResult {
   scores: Map<string, number>;
   /**
-   * Distinct ids whose score was unusable — for the log sample ONLY. Entries
-   * with no id at all never reach this set; they are still counted in
-   * `skippedCount`.
+   * Distinct MALFORMED ids — for the log sample ONLY. Kept strictly to genuinely
+   * malformed ids so the reporters that consume it stay truthful: an entry whose
+   * id is fine but whose SCORE is unusable belongs in `unusableScoreSamples`, not
+   * here. Filing score-drops as id-drops tells an operator to go debug the CVE-id
+   * regex during a score-field regression.
    */
   skippedCveIds: ReadonlySet<string>;
-  /** Dropped ENTRIES, counting occurrences — never distinct ids. */
+  /** Sample of `cveId=rawScore` pairs dropped for an unusable score — the datum that names the regression. */
+  unusableScoreSamples: readonly string[];
+  /** Entries dropped for an unusable score, counting occurrences. */
+  unusableScoreCount: number;
+  /** Dropped ENTRIES (id OR score), counting occurrences — never distinct ids. */
   skippedCount: number;
   /** Upstream entries considered (kept + skipped). */
   entryCount: number;
 }
+
+const MAX_SCORE_SAMPLES = 10;
 
 export interface ExploitFeedDependencies {
   fetchKevCveIds?: () => Promise<KevParseResult>;
@@ -83,6 +91,23 @@ export async function fetchKevCveIds(): Promise<KevParseResult> {
   const cveIds = new Set<string>();
   const malformedCveIds = new Set<string>();
   let skippedCount = 0;
+
+  // A ROOT-KEY rename is the likeliest KEV format change, and it lands in
+  // assertSomeValidCveIds' `entryCount === 0` exemption: zero entries means zero
+  // skips, so every guard below no-ops and the source records a CLEAN sync while
+  // the entire ~1,300-CVE actively-exploited catalog stops applying and
+  // `known_exploited` goes stale fleet-wide.
+  //
+  // Unlike an NVD time WINDOW (which is legitimately empty on a quiet day), the KEV
+  // feed is a full SNAPSHOT — it has never been empty and cannot legitimately be —
+  // so this cannot false-positive. Also catches an error body served with a 200.
+  if (items.length === 0) {
+    throw new Error(
+      '[ExploitFeeds/kev] CISA KEV feed returned no vulnerability entries — KEV is a full '
+      + 'snapshot and is never empty; probable upstream format change (root key rename) or an '
+      + 'error body served with 200; refusing to mark the sync successful'
+    );
+  }
 
   for (const item of items) {
     const cveId = typeof item.cveID === 'string' ? item.cveID.trim() : '';
@@ -151,9 +176,11 @@ function parseEpssScore(raw: unknown): number | null {
 export async function fetchEpssScores(cveIds: string[]): Promise<EpssParseResult> {
   const scores = new Map<string, number>();
   const skippedCveIds = new Set<string>();
+  const unusableScoreSamples: string[] = [];
+  let unusableScoreCount = 0;
   let skippedCount = 0;
   let entryCount = 0;
-  let validCount = 0;
+  let validIdCount = 0;
   const uniqueCveIds = [...new Set(cveIds.map((cve) => cve.trim()).filter(Boolean))];
 
   for (const cveChunk of chunk(uniqueCveIds, EPSS_BATCH_SIZE)) {
@@ -181,33 +208,43 @@ export async function fetchEpssScores(cveIds: string[]): Promise<EpssParseResult
         continue;
       }
 
+      // The id is GOOD from here on — a drop below is a score problem, and must
+      // never be filed as a malformed id (see EpssParseResult.skippedCveIds).
+      validIdCount += 1;
+
       const epss = parseEpssScore(item.epss);
       if (epss === null) {
         // An id we asked about came back with an unusable score: the CVE silently
-        // keeps its stale/absent EPSS score. Count it (#2470).
-        skippedCveIds.add(cveId);
+        // keeps its stale/absent EPSS score. Count it (#2470), and sample the RAW
+        // value — `null` vs `""` vs `true` vs `1.5` is the one datum that names the
+        // upstream regression.
+        if (unusableScoreSamples.length < MAX_SCORE_SAMPLES) {
+          unusableScoreSamples.push(`${cveId}=${JSON.stringify(item.epss) ?? String(item.epss)}`);
+        }
+        unusableScoreCount += 1;
         skippedCount += 1;
         continue;
       }
 
-      validCount += 1;
       scores.set(cveId, epss);
     }
   }
 
-  // A feed that returned entries but not one usable score is a probable upstream
-  // format change, not the occasional-garbage case the skip path exists for —
-  // refuse to mark the sync successful (the contract cveId.ts already sets for
-  // NVD/MSRC/SOFA). Aggregate across chunks on purpose: an individual chunk can
-  // legitimately return zero scored entries (reserved/very-new CVEs have none).
+  // Assert on ID validity ONLY. assertSomeValidCveIds is about CVE ids — its message
+  // says "zero valid CVE ids" — so counting an unscored-but-well-identified entry as
+  // invalid would both lie and misfire: a small, all-recent catalog can legitimately
+  // come back entirely unscored (reserved/very-new CVEs have no EPSS score), and that
+  // must not mark the source 'error'. A total SCORE loss is still loud — it is a 100%
+  // skip ratio, which trips warnHighSkipRatio's gross-loss trigger, and parseEpssScore
+  // has already ensured nothing corrupt reaches the catalog.
   assertSomeValidCveIds({
     tag: 'ExploitFeeds/epss',
     entryCount,
-    validCount,
+    validCount: validIdCount,
     malformedIds: skippedCveIds,
   });
 
-  return { scores, skippedCveIds, skippedCount, entryCount };
+  return { scores, skippedCveIds, unusableScoreSamples, unusableScoreCount, skippedCount, entryCount };
 }
 
 async function loadCatalogCveIds(): Promise<string[]> {
@@ -280,19 +317,29 @@ export async function enrichExploitSignals(
   deps: ExploitFeedDependencies = {}
 ): Promise<{ kev: number; epss: number; skipped: number }> {
   try {
-    const catalogCveIds = await loadCatalogCveIds();
+    // Normalize once: the EPSS request and response are both trimmed, so a catalog
+    // row with stray whitespace would otherwise be requested trimmed, returned
+    // trimmed, then fail this set and be counted as a re-check drop on every run.
+    const catalogCveIds = (await loadCatalogCveIds()).map((cveId) => cveId.trim());
     const catalogCveSet = new Set(catalogCveIds);
     const fetchKev = deps.fetchKevCveIds ?? fetchKevCveIds;
     const fetchEpss = deps.fetchEpssScores ?? fetchEpssScores;
 
     const kevFeed = await fetchKev();
     const kevCveIds = [...kevFeed.cveIds].filter((cveId) => catalogCveSet.has(cveId));
-    const epssFeed = await fetchEpss(catalogCveIds);
 
-    warnMalformedCveIds('ExploitFeeds/epss', epssFeed.skippedCveIds);
-
-    return await withSystemDbAccessContext(async () => {
-      let kev = 0;
+    // Apply KEV BEFORE fetching EPSS, in its own db context. KEV (exploited in the
+    // wild) is the higher-severity signal, and a FIRST.org outage/reshape — which
+    // throws, both on a non-200 and now on a zero-valid-id feed — must not stall it.
+    // Ordering it first means an EPSS failure still leaves KEV flags applied and the
+    // source marked 'error' (an honest partial), rather than discarding healthy KEV
+    // data we already have in hand.
+    //
+    // Two separate contexts on purpose: EPSS fans out to one HTTP request per 100
+    // catalog CVEs, and holding a db context across that would pin a pool connection
+    // for the whole sweep.
+    const kev = await withSystemDbAccessContext(async () => {
+      let applied = 0;
       for (const cveChunk of chunk(kevCveIds, DB_UPDATE_BATCH_SIZE)) {
         // Benign empty-chunk guard, NOT a dropped entry — nothing to count.
         if (cveChunk.length === 0) continue;
@@ -302,9 +349,26 @@ export async function enrichExploitSignals(
           .set({ knownExploited: true })
           .where(inArray(vulnerabilities.cveId, cveChunk))
           .returning({ id: vulnerabilities.id });
-        kev += updated.length;
+        applied += updated.length;
       }
+      return applied;
+    });
 
+    const epssFeed = await fetchEpss(catalogCveIds);
+
+    warnMalformedCveIds('ExploitFeeds/epss', epssFeed.skippedCveIds);
+    if (epssFeed.unusableScoreCount > 0) {
+      // Reported separately from malformed ids: these ids are FINE. Naming them as
+      // malformed would send an operator to debug the CVE-id regex during what is
+      // actually a score-field regression.
+      console.warn(
+        `[ExploitFeeds/epss] Dropped ${epssFeed.unusableScoreCount} entr(ies) with an unusable `
+        + `EPSS score (sample: ${epssFeed.unusableScoreSamples.join(', ')}) — `
+        + 'probable upstream score-field regression'
+      );
+    }
+
+    return await withSystemDbAccessContext(async () => {
       let epss = 0;
       let recheckSkippedCount = 0;
       for (const [cveId, score] of epssFeed.scores.entries()) {

--- a/apps/api/src/services/exploitFeeds.ts
+++ b/apps/api/src/services/exploitFeeds.ts
@@ -2,7 +2,12 @@ import { eq, inArray } from 'drizzle-orm';
 
 import { db, withSystemDbAccessContext } from '../db';
 import { vulnerabilities, vulnerabilitySources } from '../db/schema';
-import { warnHighSkipRatio, warnMalformedCveIds } from './cveId';
+import {
+  assertSomeValidCveIds,
+  isValidCveId,
+  warnHighSkipRatio,
+  warnMalformedCveIds,
+} from './cveId';
 
 const KEV_URL = 'https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json';
 const EPSS_URL = 'https://api.first.org/data/v1/epss';
@@ -17,6 +22,8 @@ const DB_UPDATE_BATCH_SIZE = 1000;
  */
 export interface KevParseResult {
   cveIds: Set<string>;
+  /** Distinct malformed ids dropped — for the log sample ONLY, never the count. */
+  skippedCveIds: ReadonlySet<string>;
   /**
    * Dropped ENTRIES, counting occurrences — never distinct ids (#2427 review).
    * A distinct-id count renders a mass drop of one repeated literal as `1` and
@@ -74,22 +81,71 @@ export async function fetchKevCveIds(): Promise<KevParseResult> {
   const root = await fetchJson(KEV_URL) as { vulnerabilities?: Array<{ cveID?: unknown }> };
   const items = root.vulnerabilities ?? [];
   const cveIds = new Set<string>();
+  const malformedCveIds = new Set<string>();
   let skippedCount = 0;
 
   for (const item of items) {
     const cveId = typeof item.cveID === 'string' ? item.cveID.trim() : '';
     if (!cveId) {
       // A KEV entry with a missing/blank id is a silently dropped exploited-CVE
-      // record — count it (#2470). NOTE: a well-formed KEV id that simply isn't
-      // in our catalog is NOT a skip; that intersection is the caller's job and
-      // dropping it is the expected behaviour, not a data-quality signal.
+      // record — count it (#2470).
       skippedCount += 1;
       continue;
     }
+
+    // Validate the id SHAPE, like every sibling parser (parseNvd/parseCvrf/
+    // parseSofa) does. Without this, an upstream id-format change (lowercase,
+    // an added prefix/suffix, an annotation like the Mariner literal in
+    // cveId.ts) yields a non-empty string for every entry: skippedCount stays 0,
+    // the junk ids fall out at the catalog intersection below, and the source
+    // records a CLEAN sync while the whole KEV catalog silently fails to apply.
+    // That is strictly worse than the NULL this counting replaced.
+    //
+    // NOTE the distinction: a WELL-FORMED KEV id that simply isn't in our catalog
+    // is NOT a skip — KEV lists CVEs most catalogs don't carry, so that
+    // intersection is expected behaviour, not a data-quality signal. Only a
+    // malformed id counts.
+    if (!isValidCveId(cveId)) {
+      malformedCveIds.add(cveId);
+      skippedCount += 1;
+      continue;
+    }
+
     cveIds.add(cveId);
   }
 
-  return { cveIds, skippedCount, entryCount: items.length };
+  assertSomeValidCveIds({
+    tag: 'ExploitFeeds/kev',
+    entryCount: items.length,
+    validCount: cveIds.size,
+    malformedIds: malformedCveIds,
+  });
+  warnMalformedCveIds('ExploitFeeds/kev', malformedCveIds);
+
+  return { cveIds, skippedCveIds: malformedCveIds, skippedCount, entryCount: items.length };
+}
+
+/**
+ * Parse an EPSS probability WITHOUT `Number()`'s coercion footguns.
+ *
+ * `Number(null)`, `Number('')`, `Number(false)` and `Number([])` are all `0` —
+ * and `0` is finite, so a bare `Number.isFinite` guard ACCEPTS them. A FIRST.org
+ * regression shipping `"epss": null` would therefore overwrite every CVE's score
+ * with 0.0 (a 0.94 becomes 0.0, feeding risk scoring) while counting ZERO skips
+ * and reporting a clean sync — the very failure class #2470 exists to close, in
+ * the lines meant to close it. `"epss": true` is worse: a 1.0 exploit probability
+ * fleet-wide.
+ *
+ * Only a real number or a non-empty numeric string is a score. EPSS is a
+ * probability, so anything outside [0,1] is corrupt regardless of type.
+ */
+function parseEpssScore(raw: unknown): number | null {
+  const value = typeof raw === 'number'
+    ? raw
+    : typeof raw === 'string' && raw.trim() !== '' ? Number(raw) : Number.NaN;
+
+  if (!Number.isFinite(value) || value < 0 || value > 1) return null;
+  return value;
 }
 
 export async function fetchEpssScores(cveIds: string[]): Promise<EpssParseResult> {
@@ -97,6 +153,7 @@ export async function fetchEpssScores(cveIds: string[]): Promise<EpssParseResult
   const skippedCveIds = new Set<string>();
   let skippedCount = 0;
   let entryCount = 0;
+  let validCount = 0;
   const uniqueCveIds = [...new Set(cveIds.map((cve) => cve.trim()).filter(Boolean))];
 
   for (const cveChunk of chunk(uniqueCveIds, EPSS_BATCH_SIZE)) {
@@ -117,18 +174,38 @@ export async function fetchEpssScores(cveIds: string[]): Promise<EpssParseResult
         continue;
       }
 
-      const epss = Number(item.epss);
-      if (!Number.isFinite(epss)) {
-        // An id we asked about came back with an unparseable score: the CVE
-        // silently keeps a stale/absent EPSS score. Count it (#2470).
+      // Same id-shape guard as the KEV parse and the sibling feed parsers.
+      if (!isValidCveId(cveId)) {
         skippedCveIds.add(cveId);
         skippedCount += 1;
         continue;
       }
 
+      const epss = parseEpssScore(item.epss);
+      if (epss === null) {
+        // An id we asked about came back with an unusable score: the CVE silently
+        // keeps its stale/absent EPSS score. Count it (#2470).
+        skippedCveIds.add(cveId);
+        skippedCount += 1;
+        continue;
+      }
+
+      validCount += 1;
       scores.set(cveId, epss);
     }
   }
+
+  // A feed that returned entries but not one usable score is a probable upstream
+  // format change, not the occasional-garbage case the skip path exists for —
+  // refuse to mark the sync successful (the contract cveId.ts already sets for
+  // NVD/MSRC/SOFA). Aggregate across chunks on purpose: an individual chunk can
+  // legitimately return zero scored entries (reserved/very-new CVEs have none).
+  assertSomeValidCveIds({
+    tag: 'ExploitFeeds/epss',
+    entryCount,
+    validCount,
+    malformedIds: skippedCveIds,
+  });
 
   return { scores, skippedCveIds, skippedCount, entryCount };
 }
@@ -249,10 +326,22 @@ export async function enrichExploitSignals(
         epss += updated.length;
       }
 
-      const skipped = kevFeed.skippedCount + epssFeed.skippedCount + recheckSkippedCount;
-      const entryCount = kevFeed.entryCount + epssFeed.entryCount;
-      warnHighSkipRatio('ExploitFeeds/kev_epss', skipped, entryCount);
+      // Escalate PER FEED, never on a pooled denominator. KEV ships ~1.3k entries
+      // while EPSS is fetched for the whole catalog (~250k), so summing them makes
+      // KEV ~0.5% of the denominator: a 60-entry KEV regression (4.6% of that feed,
+      // 4x over the ratio threshold) computes to 0.02% pooled and trips none of the
+      // three triggers. Pooling would reintroduce exactly the gap warnHighSkipRatio's
+      // three triggers were designed to eliminate.
+      warnHighSkipRatio('ExploitFeeds/kev', kevFeed.skippedCount, kevFeed.entryCount);
+      warnHighSkipRatio(
+        'ExploitFeeds/epss',
+        epssFeed.skippedCount + recheckSkippedCount,
+        epssFeed.entryCount
+      );
 
+      // The PERSISTED count is the union: last_sync_skipped_count is per-SOURCE,
+      // and `kev_epss` is one source.
+      const skipped = kevFeed.skippedCount + epssFeed.skippedCount + recheckSkippedCount;
       await upsertExploitSourceSuccess(new Date(), skipped);
       return { kev, epss, skipped };
     });

--- a/apps/api/src/services/exploitFeeds.ts
+++ b/apps/api/src/services/exploitFeeds.ts
@@ -2,15 +2,50 @@ import { eq, inArray } from 'drizzle-orm';
 
 import { db, withSystemDbAccessContext } from '../db';
 import { vulnerabilities, vulnerabilitySources } from '../db/schema';
+import { warnHighSkipRatio, warnMalformedCveIds } from './cveId';
 
 const KEV_URL = 'https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json';
 const EPSS_URL = 'https://api.first.org/data/v1/epss';
 const EPSS_BATCH_SIZE = 100;
 const DB_UPDATE_BATCH_SIZE = 1000;
 
+/**
+ * Parse-boundary result for the CISA KEV catalog (#2470), mirroring the
+ * `{ records, skippedCveIds, skippedCount, entryCount }` shape #2427 introduced
+ * for parseNvd/parseCvrf/parseSofa: the drops have to survive the call, or the
+ * `kev_epss` source can never record anything but NULL.
+ */
+export interface KevParseResult {
+  cveIds: Set<string>;
+  /**
+   * Dropped ENTRIES, counting occurrences — never distinct ids (#2427 review).
+   * A distinct-id count renders a mass drop of one repeated literal as `1` and
+   * trips no escalation, which is the exact blind spot this counting exists to
+   * close.
+   */
+  skippedCount: number;
+  /** Upstream entries considered (kept + skipped) — the honest ratio denominator. */
+  entryCount: number;
+}
+
+/** Parse-boundary result for the FIRST.org EPSS feed (#2470). */
+export interface EpssParseResult {
+  scores: Map<string, number>;
+  /**
+   * Distinct ids whose score was unusable — for the log sample ONLY. Entries
+   * with no id at all never reach this set; they are still counted in
+   * `skippedCount`.
+   */
+  skippedCveIds: ReadonlySet<string>;
+  /** Dropped ENTRIES, counting occurrences — never distinct ids. */
+  skippedCount: number;
+  /** Upstream entries considered (kept + skipped). */
+  entryCount: number;
+}
+
 export interface ExploitFeedDependencies {
-  fetchKevCveIds?: () => Promise<Set<string>>;
-  fetchEpssScores?: (cveIds: string[]) => Promise<Map<string, number>>;
+  fetchKevCveIds?: () => Promise<KevParseResult>;
+  fetchEpssScores?: (cveIds: string[]) => Promise<EpssParseResult>;
 }
 
 function chunk<T>(values: T[], size: number): T[][] {
@@ -35,21 +70,33 @@ async function fetchJson(url: string): Promise<unknown> {
   return response.json();
 }
 
-export async function fetchKevCveIds(): Promise<Set<string>> {
+export async function fetchKevCveIds(): Promise<KevParseResult> {
   const root = await fetchJson(KEV_URL) as { vulnerabilities?: Array<{ cveID?: unknown }> };
-  const cves = new Set<string>();
+  const items = root.vulnerabilities ?? [];
+  const cveIds = new Set<string>();
+  let skippedCount = 0;
 
-  for (const item of root.vulnerabilities ?? []) {
-    if (typeof item.cveID === 'string' && item.cveID.trim()) {
-      cves.add(item.cveID.trim());
+  for (const item of items) {
+    const cveId = typeof item.cveID === 'string' ? item.cveID.trim() : '';
+    if (!cveId) {
+      // A KEV entry with a missing/blank id is a silently dropped exploited-CVE
+      // record — count it (#2470). NOTE: a well-formed KEV id that simply isn't
+      // in our catalog is NOT a skip; that intersection is the caller's job and
+      // dropping it is the expected behaviour, not a data-quality signal.
+      skippedCount += 1;
+      continue;
     }
+    cveIds.add(cveId);
   }
 
-  return cves;
+  return { cveIds, skippedCount, entryCount: items.length };
 }
 
-export async function fetchEpssScores(cveIds: string[]): Promise<Map<string, number>> {
+export async function fetchEpssScores(cveIds: string[]): Promise<EpssParseResult> {
   const scores = new Map<string, number>();
+  const skippedCveIds = new Set<string>();
+  let skippedCount = 0;
+  let entryCount = 0;
   const uniqueCveIds = [...new Set(cveIds.map((cve) => cve.trim()).filter(Boolean))];
 
   for (const cveChunk of chunk(uniqueCveIds, EPSS_BATCH_SIZE)) {
@@ -59,17 +106,31 @@ export async function fetchEpssScores(cveIds: string[]): Promise<Map<string, num
       data?: Array<{ cve?: unknown; epss?: unknown }>;
     };
 
-    for (const item of root.data ?? []) {
-      if (typeof item.cve !== 'string') continue;
+    const items = root.data ?? [];
+    entryCount += items.length;
+
+    for (const item of items) {
+      const cveId = typeof item.cve === 'string' ? item.cve.trim() : '';
+      if (!cveId) {
+        // No usable id — countable, but there is nothing to put in the sample.
+        skippedCount += 1;
+        continue;
+      }
 
       const epss = Number(item.epss);
-      if (Number.isFinite(epss)) {
-        scores.set(item.cve, epss);
+      if (!Number.isFinite(epss)) {
+        // An id we asked about came back with an unparseable score: the CVE
+        // silently keeps a stale/absent EPSS score. Count it (#2470).
+        skippedCveIds.add(cveId);
+        skippedCount += 1;
+        continue;
       }
+
+      scores.set(cveId, epss);
     }
   }
 
-  return scores;
+  return { scores, skippedCveIds, skippedCount, entryCount };
 }
 
 async function loadCatalogCveIds(): Promise<string[]> {
@@ -82,13 +143,14 @@ async function loadCatalogCveIds(): Promise<string[]> {
   return rows.map((row) => row.cveId);
 }
 
-async function upsertExploitSourceSuccess(now: Date): Promise<void> {
+async function upsertExploitSourceSuccess(now: Date, skippedCount: number): Promise<void> {
   const updated = await db
     .update(vulnerabilitySources)
     .set({
       lastSuccessfulSyncAt: now,
       lastSyncStatus: 'ok',
       lastSyncError: null,
+      lastSyncSkippedCount: skippedCount,
       cursor: now.toISOString(),
       updatedAt: now,
     })
@@ -102,11 +164,15 @@ async function upsertExploitSourceSuccess(now: Date): Promise<void> {
     lastSuccessfulSyncAt: now,
     lastSyncStatus: 'ok',
     lastSyncError: null,
+    lastSyncSkippedCount: skippedCount,
     cursor: now.toISOString(),
     updatedAt: now,
   });
 }
 
+// Error path deliberately leaves `lastSyncSkippedCount` untouched (#2427): the
+// count must always pair with `lastSuccessfulSyncAt`, so a failed run keeps the
+// last successful run's number rather than overwriting it with a partial one.
 async function upsertExploitSourceError(message: string): Promise<void> {
   const now = new Date();
   const updated = await db
@@ -135,20 +201,23 @@ function errorMessage(error: unknown): string {
 
 export async function enrichExploitSignals(
   deps: ExploitFeedDependencies = {}
-): Promise<{ kev: number; epss: number }> {
+): Promise<{ kev: number; epss: number; skipped: number }> {
   try {
     const catalogCveIds = await loadCatalogCveIds();
     const catalogCveSet = new Set(catalogCveIds);
     const fetchKev = deps.fetchKevCveIds ?? fetchKevCveIds;
     const fetchEpss = deps.fetchEpssScores ?? fetchEpssScores;
 
-    const kevCatalogCveIds = await fetchKev();
-    const kevCveIds = [...kevCatalogCveIds].filter((cveId) => catalogCveSet.has(cveId));
-    const epssScores = await fetchEpss(catalogCveIds);
+    const kevFeed = await fetchKev();
+    const kevCveIds = [...kevFeed.cveIds].filter((cveId) => catalogCveSet.has(cveId));
+    const epssFeed = await fetchEpss(catalogCveIds);
+
+    warnMalformedCveIds('ExploitFeeds/epss', epssFeed.skippedCveIds);
 
     return await withSystemDbAccessContext(async () => {
       let kev = 0;
       for (const cveChunk of chunk(kevCveIds, DB_UPDATE_BATCH_SIZE)) {
+        // Benign empty-chunk guard, NOT a dropped entry — nothing to count.
         if (cveChunk.length === 0) continue;
 
         const updated = await db
@@ -160,8 +229,17 @@ export async function enrichExploitSignals(
       }
 
       let epss = 0;
-      for (const [cveId, score] of epssScores.entries()) {
-        if (!catalogCveSet.has(cveId) || !Number.isFinite(score)) continue;
+      let recheckSkippedCount = 0;
+      for (const [cveId, score] of epssFeed.scores.entries()) {
+        // Defense-in-depth re-check. A score that cleared the parse boundary but
+        // still can't be applied is a silently discarded entry, so it joins the
+        // count (#2470) — the same union of parse-boundary and re-check skips the
+        // NVD/MSRC/SOFA syncs do. These entries were already counted in
+        // `entryCount` at the parse boundary, so the denominator is unaffected.
+        if (!catalogCveSet.has(cveId) || !Number.isFinite(score)) {
+          recheckSkippedCount += 1;
+          continue;
+        }
 
         const updated = await db
           .update(vulnerabilities)
@@ -171,8 +249,12 @@ export async function enrichExploitSignals(
         epss += updated.length;
       }
 
-      await upsertExploitSourceSuccess(new Date());
-      return { kev, epss };
+      const skipped = kevFeed.skippedCount + epssFeed.skippedCount + recheckSkippedCount;
+      const entryCount = kevFeed.entryCount + epssFeed.entryCount;
+      warnHighSkipRatio('ExploitFeeds/kev_epss', skipped, entryCount);
+
+      await upsertExploitSourceSuccess(new Date(), skipped);
+      return { kev, epss, skipped };
     });
   } catch (error) {
     try {

--- a/apps/api/src/services/exploitFeeds.ts
+++ b/apps/api/src/services/exploitFeeds.ts
@@ -354,6 +354,17 @@ export async function enrichExploitSignals(
       return applied;
     });
 
+    // Escalate KEV here, NOT after the EPSS fetch: a KEV regression that coincides
+    // with an EPSS outage would otherwise never reach Sentry, because the EPSS fetch
+    // throws first.
+    //
+    // PER FEED, never on a pooled denominator. KEV ships ~1.3k entries while EPSS is
+    // fetched for the whole catalog (~250k), so summing them makes KEV ~0.5% of the
+    // denominator: a 60-entry KEV regression (4.6% of that feed, 4x over the ratio
+    // threshold) computes to 0.02% pooled and trips none of the three triggers —
+    // reintroducing exactly the gap warnHighSkipRatio's three triggers exist to close.
+    warnHighSkipRatio('ExploitFeeds/kev', kevFeed.skippedCount, kevFeed.entryCount);
+
     const epssFeed = await fetchEpss(catalogCveIds);
 
     warnMalformedCveIds('ExploitFeeds/epss', epssFeed.skippedCveIds);
@@ -390,17 +401,15 @@ export async function enrichExploitSignals(
         epss += updated.length;
       }
 
-      // Escalate PER FEED, never on a pooled denominator. KEV ships ~1.3k entries
-      // while EPSS is fetched for the whole catalog (~250k), so summing them makes
-      // KEV ~0.5% of the denominator: a 60-entry KEV regression (4.6% of that feed,
-      // 4x over the ratio threshold) computes to 0.02% pooled and trips none of the
-      // three triggers. Pooling would reintroduce exactly the gap warnHighSkipRatio's
-      // three triggers were designed to eliminate.
-      warnHighSkipRatio('ExploitFeeds/kev', kevFeed.skippedCount, kevFeed.entryCount);
+      // EPSS drops entries for a malformed id OR an unusable score, so it must not be
+      // escalated as a "malformed-CVE" problem — Sentry is the loudest channel, and
+      // that wording would point an operator at the CVE-id regex during a score-field
+      // regression. (KEV is escalated above, before the EPSS fetch can throw.)
       warnHighSkipRatio(
         'ExploitFeeds/epss',
         epssFeed.skippedCount + recheckSkippedCount,
-        epssFeed.entryCount
+        epssFeed.entryCount,
+        'malformed-id/unusable-score'
       );
 
       // The PERSISTED count is the union: last_sync_skipped_count is per-SOURCE,


### PR DESCRIPTION
> **Stacked on #2460** (`feat/2427-vuln-sync-skip-counts`), which builds the skip-count infrastructure this PR reuses — the `{records, skippedCveIds, skippedCount, entryCount}` parse-boundary shape, the `last_sync_skipped_count` column + migration, `warnHighSkipRatio`, and `GET /vulnerabilities/sync/status`. **Merge after #2460, or retarget to `main` once it lands.** Basing on `main` would have rebuilt all of it.

## Problem

Two silent-truncation gaps deliberately left out of #2460's scope. Same failure class #2427 was filed to kill: **the feed quietly delivers less than it should, and the sync still reports `ok`.**

1. **`kev_epss` dropped entries uncounted** — bare `continue`, counting nothing, so `vulnerability_sources.last_sync_skipped_count` stayed **`NULL`** for this source: indistinguishable from "never recorded".
2. **A feed that never reports `totalResults` truncates to page one** — every pager guard #2460 added is predicated on a *known* total, so a feed that never reports one leaves them nothing to pin. The pager stops after page one and the sticky-total escalation, written for exactly this loss, **self-suppresses**.

## Change

**`kev_epss` skip counts.** Both feeds behind the source now return the `{ skippedCount, entryCount }` parse-boundary shape, mirroring `parseNvd`/`parseCvrf`/`parseSofa`. `enrichExploitSignals` unions them with its **re-check** drops, persists on the **success path only**, and escalates through `warnHighSkipRatio`. Counts dropped **ENTRIES, never distinct ids** — #2460's review found a `Set.size` count reports a 2,000-record Mariner drop as `skipped=1`; a test pins this at 2,000 repeats. A KEV id merely *absent from our catalog* is **not** a skip (expected intersection). `:152` (`cveChunk.length === 0`) is a benign empty-chunk guard, left uncounted.

**No-total escalation.** The NVD pager treats "no total reported" as its own escalation condition (`reason: 'no_total_reported'`), mutually exclusive with the truncation branch by construction. It still **stops** after page one — paging blind would re-ingest or spin; escalating is the fix. **Cannot false-positive:** a healthy NVD empty window reports `totalResults: 0`, which pins `knownTotal=0` and exits normally.

## What three review rounds changed (the interesting part)

Review found that my first cut **reproduced the bug class it was closing** — the same trap #2427's own review fell into. Fixed:

- **`Number(item.epss)` coerced `null`/`""`/`false`/`[]` → `0`** (finite! so the `isFinite` guard *accepted* them) and `true` → `1`. A feed shipping `"epss": null` would have overwritten **every CVE's score with 0.0** at `skipped=0`, `status='ok'` — a full-catalog EPSS wipe reported as a clean sync. `parseEpssScore()` now takes only a real number or a non-empty numeric string, range-checked `[0,1]`.
- **The KEV parse accepted any non-empty string as a CVE id** — the only parser in the subsystem without an `isValidCveId` shape guard. An upstream id-format change yields a non-empty string per entry, so `skippedCount` stayed 0 while the junk fell out at the catalog intersection. Both boundaries now validate id shape.
- **A KEV *root-key* rename** (the likeliest format change) landed in `assertSomeValidCveIds`' `entryCount === 0` exemption: zero entries ⇒ zero skips ⇒ every guard no-ops ⇒ clean sync while the entire ~1,300-CVE actively-exploited catalog stops applying. KEV is a full **snapshot** (never legitimately empty, unlike an NVD time *window*), so an empty-feed throw **cannot false-positive**. Now throws.
- **Neither feed called `assertSomeValidCveIds`**, so the codebase's own contract ("refuse to mark the sync successful") didn't apply to the source I touched. Both now assert — on **id** validity only, since a small all-recent catalog can legitimately come back entirely unscored. A total score loss is still loud via the gross-loss trigger.
- **Unusable *scores* were filed as malformed *ids***, so both reporters described a score-field regression as an id problem — sending an operator to debug the CVE-id regex. Score drops are now tracked and reported separately, **with a sample of the raw value** (`null` vs `""` vs `true` vs `1.5`), which is the datum that names the regression. `warnHighSkipRatio` takes an additive `droppedWhat` so Sentry (the loudest channel) says `malformed-id/unusable-score`, not `malformed-CVE`.
- **`warnHighSkipRatio` pooled KEV (~1.3k entries) with EPSS (~250k, fetched for the whole catalog)** into one denominator, diluting KEV ~200x: a 60-entry KEV regression (4.6% of that feed) tripped **none** of the three triggers. Now evaluated **per feed**; the *persisted* count stays the union (the column is per-source). KEV escalates *before* the EPSS fetch, so an EPSS outage can't suppress it.
- **KEV updates now land before the EPSS fetch**, in their own db context, so an EPSS break no longer discards healthy known-exploited data. The source is still marked `error` — an honest partial, not a clean sync. (Two contexts on purpose: EPSS fans out one HTTP request per 100 catalog CVEs; holding a db context across that sweep would pin a pool connection.)

## Verification

- **Unit, 119/119** across `cveId`/`nvdClient`/`msrcClient`/`sofaClient`/`vulnerabilities` routes + new `services/exploitFeeds.test.ts` (24): both parse boundaries, the entries-not-distinct-ids invariant on **both** the id and score paths, every `Number()` coercion footgun (`null`/`""`/`false`/`true`/`[]`/out-of-range), the empty-KEV and zero-valid-id throws, and the "all-unscored does NOT throw" case.
- **Integration (real Postgres :5433), 29/29:** clean run persists an explicit `0`; a lossy run persists a nonzero count **alongside `status='ok'`**; re-check skips union with parse-boundary skips; a KEV-only regression escalates that a pooled denominator would have suppressed; an EPSS failure still lands KEV flags **and** marks the source `error`; a failed run leaves the last successful count intact. NVD adds: escalates when the feed never reports a total (and still fetches only one page), escalates a reshaped `{}` first page, and does **not** escalate a healthy `totalResults: 0` window.
- `tsc --noEmit` clean. No migration or schema change — the column ships in #2460.

## Deliberately NOT done (flagged, your call)

- **A truncated/degraded sync still writes `last_sync_status='ok'`.** Review pushed to make it throw. Declined: the issue explicitly sanctions "emit a distinct warning"; #2460 already made this call for NVD truncation; and throwing would stall the cursor indefinitely on a flaky upstream. A distinct `status='truncated'`/`'degraded'` state is a **schema + UI decision** that belongs to you, not a stacked bugfix. Happy to file it.
- **The 1% / 100 / 50% thresholds** the issue flags as unvalidated. Sanity-checking them against real feed volumes is a data question; moving them here would silently alter #2460's behavior in the same diff.

Closes #2470

🤖 Generated with [Claude Code](https://claude.com/claude-code)