### PR TITLE
fix(web): gate bulk Run Script/Reboot on decommissioned, not offline (#2465)

### DIFF
--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -1,8 +1,12 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import DeviceList, { type Device } from './DeviceList';
 import { COLUMN_IDS } from './columnVisibility';
+import {
+  DECOMMISSION_BLOCKED_BULK_ACTIONS,
+  INTENTIONALLY_UNGATED_BULK_ACTIONS,
+} from './bulkActionGating';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
@@ -1177,5 +1181,92 @@ describe('DeviceList — row-menu action gating (#2426)', () => {
     render(<DeviceList devices={[baseDevice]} />);
     openRowMenu();
     expect(screen.queryByRole('button', { name: /^wake$/i })).toBeNull();
+  });
+});
+
+// #2465 CONTRACT: the bulk-action status gate lives in DevicesPage, but the
+// action strings it gates are emitted from HERE. Nothing else binds the two, so
+// a gate that names an action DeviceList no longer emits — or misses one it
+// newly does — degrades silently: DECOMMISSIONED devices quietly start receiving
+// commands the API refuses outright, and every behavioural test stays green,
+// because a gate's only failure mode is doing nothing.
+//
+// (Offline devices receiving queued commands is the INTENDED behaviour, not the
+// regression — they run on reconnect. That distinction is the whole of #2465.)
+//
+// This test enumerates the REAL bulk bar and forces every action it emits into
+// exactly one of the two policy sets. Add a bulk button without classifying it
+// and this fails, with the offending string named.
+describe('DeviceList — bulk actions are all classified by the status gate (#2465)', () => {
+  // Two online devices: the link-* items only render at selectedIds.size >= 2,
+  // so a 1-device selection would hide them from the enumeration.
+  const bulkDevices = (): Device[] => [
+    { ...baseDevice, id: '71111111-1111-1111-1111-111111111111', hostname: 'bulk-a' },
+    { ...baseDevice, id: '72222222-2222-2222-2222-222222222222', hostname: 'bulk-b' },
+  ];
+
+  const openBulkMenu = () => {
+    fireEvent.click(screen.getByLabelText('Select all devices on this page'));
+    fireEvent.click(screen.getByRole('button', { name: /bulk actions/i }));
+    return screen.getByTestId('bulk-actions-menu');
+  };
+
+  /**
+   * Clicking an item closes the menu and clears the selection, so each button is
+   * driven from a fresh render and identified by index within the live menu.
+   */
+  function emittedBulkActions(): string[] {
+    const probe = render(<DeviceList devices={bulkDevices()} onBulkAction={vi.fn()} />);
+    const buttonCount = within(openBulkMenu()).getAllByRole('button').length;
+    probe.unmount();
+    expect(buttonCount).toBeGreaterThan(0); // menu must actually render items
+
+    const emitted: string[] = [];
+    for (let i = 0; i < buttonCount; i++) {
+      const onBulkAction = vi.fn();
+      const view = render(<DeviceList devices={bulkDevices()} onBulkAction={onBulkAction} />);
+      const buttons = within(openBulkMenu()).getAllByRole('button');
+      fireEvent.click(buttons[i]!);
+      expect(onBulkAction).toHaveBeenCalledTimes(1);
+      emitted.push(onBulkAction.mock.calls[0]![0] as string);
+      view.unmount();
+    }
+    return emitted;
+  }
+
+  it('classifies every emitted bulk action as either decommission-gated or explicitly exempt', () => {
+    const emitted = emittedBulkActions();
+
+    const unclassified = emitted.filter(
+      action =>
+        !DECOMMISSION_BLOCKED_BULK_ACTIONS.has(action) && !INTENTIONALLY_UNGATED_BULK_ACTIONS.has(action),
+    );
+    expect(
+      unclassified,
+      `Unclassified bulk action(s): ${unclassified.join(', ')}. Add each to DECOMMISSION_BLOCKED_BULK_ACTIONS `
+        + '(it sends an agent command, which the API refuses for decommissioned devices) or to '
+        + 'INTENTIONALLY_UNGATED_BULK_ACTIONS (with a reason) in bulkActionGating.ts.',
+    ).toEqual([]);
+
+    // Sanity: the enumeration actually saw the two actions #2465 is about, so a
+    // silently-empty menu can't make this test vacuously pass.
+    expect(emitted).toContain('reboot');
+    expect(emitted).toContain('run-script');
+  });
+
+  it('keeps wake on the ungated side of the contract', () => {
+    // The exemption that most looks like an oversight to a future reader:
+    // Wake targets devices that are not running, by design. Pinned here at the
+    // policy level, and behaviourally in DevicesPage.test.tsx.
+    expect(emittedBulkActions()).toContain('wake');
+    expect(INTENTIONALLY_UNGATED_BULK_ACTIONS.has('wake')).toBe(true);
+    expect(DECOMMISSION_BLOCKED_BULK_ACTIONS.has('wake')).toBe(false);
+  });
+
+  it('never classifies an action as both gated and exempt', () => {
+    const both = [...DECOMMISSION_BLOCKED_BULK_ACTIONS].filter(a =>
+      INTENTIONALLY_UNGATED_BULK_ACTIONS.has(a),
+    );
+    expect(both).toEqual([]);
   });
 });

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -32,6 +32,12 @@ import type {
   VpnPresence,
 } from "@breeze/shared";
 import ConnectDesktopButton from "../remote/ConnectDesktopButton";
+// Single source of truth for "can this device still accept a queued command?".
+// Hoisted out of this file (#2465): the bulk bar in DevicesPage needs the SAME
+// rule, and re-deriving it per surface is exactly how the false "must be online"
+// premise got copied three times (DeviceActions -> row menu -> bulk bar). The
+// verified API contract lives next to it — read that before changing this.
+import { isCommandQueueable } from "./bulkActionGating";
 import { widthPercentClass, formatUptime } from "@/lib/utils";
 import { formatLastSeen } from "@/lib/formatTime";
 import { formatNumber } from "@/lib/i18n/format";
@@ -345,11 +351,6 @@ function notOnlineTitle(
   return status === "online"
     ? undefined
     : t(/* i18n-dynamic */ notOnlineTitleKeys[status]);
-}
-
-// A queued command is refused only for a decommissioned device.
-function isCommandQueueable(status: DeviceStatus): boolean {
-  return status !== "decommissioned";
 }
 
 function notQueueableTitle(
@@ -1984,7 +1985,10 @@ export default function DeviceList({
               <MoreHorizontal className="h-4 w-4" />
             </button>
             {bulkMenuOpen && (
-              <div className="absolute left-0 top-full z-10 mt-1 w-48 rounded-md border bg-card shadow-lg">
+              <div
+                data-testid="bulk-actions-menu"
+                className="absolute left-0 top-full z-10 mt-1 w-48 rounded-md border bg-card shadow-lg"
+              >
                 <button
                   type="button"
                   onClick={() => handleBulkAction("reboot")}

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -140,7 +140,7 @@ vi.mock('./DeviceList', () => ({
       data-display-names={devices.map(d => d.displayName ?? '').join(',')}
       data-watchdog-versions={devices.map(d => d.watchdogVersion ?? '').join(',')}
     >
-      {['maintenance-on', 'maintenance-off', 'decommission', 'reboot', 'run-script', 'link-vm-host'].map(action => (
+      {['maintenance-on', 'maintenance-off', 'decommission', 'reboot', 'run-script', 'link-vm-host', 'wake'].map(action => (
         <button
           key={action}
           type="button"
@@ -893,5 +893,369 @@ describe('DevicesPage — vm_host bulk link chain (#2308)', () => {
     });
     // Modal stays open — the user can pick again or cancel.
     expect(screen.getByTestId('vm-host-modal')).toBeInTheDocument();
+  });
+});
+
+// #2465: bulk "Reboot Selected" / "Run Script" had no device-status gate, so a
+// selection containing DECOMMISSIONED devices fired agent commands the API
+// refuses outright ("Cannot send commands to a decommissioned device").
+//
+// The gate is `decommissioned`, NOT `!== 'online'`. That distinction is the
+// whole point of this suite and is easy to "fix" back into a bug: agent commands
+// are QUEUED (status 'pending', no TTL) and claimed on the device's next
+// check-in, so an OFFLINE device really does reboot when it comes back. Filtering
+// to online-only would silently discard commands the backend would have honoured.
+// The API rejects exactly one status, and these tests pin that boundary.
+describe('DevicesPage — bulk agent commands gated on decommissioned only (#2465)', () => {
+  // A status filter that INCLUDES decommissioned is what puts retired rows back
+  // in reach of a select-all (they're hidden by default, #2251) — that's how
+  // they land in a mixed batch in the first place.
+  async function renderMixedFleet(ids: string[] = [DEV_1, DEV_2, DEV_3]) {
+    const { decodeFilterFromHash } = await import('./filterUrl');
+    vi.mocked(decodeFilterFromHash).mockReturnValue({
+      operator: 'AND',
+      conditions: [{ field: 'status', operator: 'in', value: ['online', 'offline', 'decommissioned'] }],
+    } as never);
+    vi.mocked(fetchWithAuth).mockImplementation(async (url: string) => {
+      if (url.startsWith('/filters/preview')) {
+        return jsonResponse({
+          data: { totalCount: ids.length, deviceIds: ids, evaluatedAt: new Date().toISOString() },
+        });
+      }
+      return jsonResponse({ data: [] });
+    });
+    render(<DevicesPage />);
+    const list = await screen.findByTestId('device-list');
+    await waitFor(() => expect(list.getAttribute('data-device-count')).toBe(String(ids.length)));
+    return list;
+  }
+
+  // online + offline + decommissioned: the only selection that exercises both
+  // sides of the boundary at once.
+  function boundaryFleet() {
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [
+        rawDevice(DEV_1, 'host-alpha'),
+        { ...rawDevice(DEV_2, 'host-beta'), status: 'offline' },
+        { ...rawDevice(DEV_3, 'host-gamma'), status: 'decommissioned' },
+      ],
+    } as never);
+  }
+
+  it('skips ONLY the decommissioned device and still reboots the offline one', async () => {
+    const { sendBulkCommand } = await import('../../services/deviceActions');
+    vi.mocked(sendBulkCommand).mockResolvedValue({ commands: [{}, {}], failed: [], skipped: [] } as never);
+
+    boundaryFleet();
+    await renderMixedFleet();
+    fireEvent.click(screen.getByTestId('bulk-reboot'));
+
+    expect(await screen.findByTestId('confirm-decommissioned-skip')).toBeTruthy();
+    expect(vi.mocked(sendBulkCommand)).not.toHaveBeenCalled();
+    // Assert the WHOLE sentence, not just the prefix. The tail carries {{eligible}}
+    // — the count of machines about to reboot. Wire that to skippedCount by mistake
+    // and the dialog says "Continue with the remaining 1 device(s)?" while rebooting
+    // 2; a prefix-only match would never notice.
+    expect(
+      screen.getByText(
+        /1 of 3 selected devices are decommissioned and will be skipped.*Continue with the remaining 2 device\(s\)\?/i,
+      ),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('confirm-decommissioned-skip'));
+
+    await waitFor(() => expect(vi.mocked(sendBulkCommand)).toHaveBeenCalledTimes(1));
+    const [deviceIds, action] = vi.mocked(sendBulkCommand).mock.calls[0];
+    expect(action).toBe('reboot');
+    // THE load-bearing assertion. The offline device (DEV_2) MUST be targeted:
+    // its command queues and runs on reconnect. A regression to an online-only
+    // filter drops it here and this is the test that catches it.
+    expect([...(deviceIds as string[])].sort()).toEqual([DEV_1, DEV_2].sort());
+    expect(deviceIds).not.toContain(DEV_3);
+  });
+
+  it('does NOT confirm or filter when the selection is merely online + offline', async () => {
+    const { sendBulkCommand } = await import('../../services/deviceActions');
+    vi.mocked(sendBulkCommand).mockResolvedValue({ commands: [{}, {}], failed: [], skipped: [] } as never);
+
+    // No decommissioned rows → nothing the API would refuse → no gate at all.
+    // An offline device is a perfectly good reboot target.
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [
+        rawDevice(DEV_1, 'host-alpha'),
+        { ...rawDevice(DEV_2, 'host-beta'), status: 'offline' },
+      ],
+    } as never);
+    await renderMixedFleet([DEV_1, DEV_2]);
+
+    fireEvent.click(screen.getByTestId('bulk-reboot'));
+
+    await waitFor(() => expect(vi.mocked(sendBulkCommand)).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTestId('confirm-decommissioned-skip')).toBeNull();
+    expect([...(vi.mocked(sendBulkCommand).mock.calls[0][0] as string[])].sort()).toEqual(
+      [DEV_1, DEV_2].sort(),
+    );
+  });
+
+  it('sends nothing when the user cancels the decommissioned-skip confirm', async () => {
+    const { sendBulkCommand } = await import('../../services/deviceActions');
+
+    boundaryFleet();
+    await renderMixedFleet();
+    fireEvent.click(screen.getByTestId('bulk-reboot'));
+    await screen.findByTestId('confirm-decommissioned-skip');
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    await waitFor(() => expect(screen.queryByTestId('confirm-decommissioned-skip')).toBeNull());
+    expect(vi.mocked(sendBulkCommand)).not.toHaveBeenCalled();
+  });
+
+  it('refuses outright when EVERY selected device is decommissioned', async () => {
+    const { sendBulkCommand } = await import('../../services/deviceActions');
+    const { showToast } = await import('../shared/Toast');
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [
+        { ...rawDevice(DEV_1, 'host-alpha'), status: 'decommissioned' },
+        { ...rawDevice(DEV_2, 'host-beta'), status: 'decommissioned' },
+      ],
+    } as never);
+    await renderMixedFleet([DEV_1, DEV_2]);
+
+    fireEvent.click(screen.getByTestId('bulk-reboot'));
+
+    await waitFor(() => {
+      const messages = vi.mocked(showToast).mock.calls.map(c => c[0].message ?? '');
+      expect(messages.some(m => /all 2 selected device\(s\) are decommissioned/i.test(m))).toBe(true);
+    });
+    expect(screen.queryByTestId('confirm-decommissioned-skip')).toBeNull();
+    expect(vi.mocked(sendBulkCommand)).not.toHaveBeenCalled();
+  });
+
+  it('narrows bulk Run Script past the decommissioned device, keeping the offline one', async () => {
+    const { executeScript } = await import('../../services/deviceActions');
+    vi.mocked(executeScript).mockResolvedValue({
+      batchId: 'batch-1',
+      scriptId: 'script-1',
+      devicesTargeted: 2,
+      executions: [],
+      status: 'queued',
+    } as never);
+
+    boundaryFleet();
+    await renderMixedFleet();
+    fireEvent.click(screen.getByTestId('bulk-run-script'));
+
+    // Skip is disclosed BEFORE the user invests in choosing a script.
+    fireEvent.click(await screen.findByTestId('confirm-decommissioned-skip'));
+    fireEvent.click(await screen.findByTestId('pick-script'));
+    fireEvent.click(await screen.findByTestId('confirm-fleet-action'));
+
+    await waitFor(() => expect(vi.mocked(executeScript)).toHaveBeenCalledTimes(1));
+    const [, deviceIds] = vi.mocked(executeScript).mock.calls[0];
+    // Offline device still gets the script — it runs on reconnect.
+    expect([...(deviceIds as string[])].sort()).toEqual([DEV_1, DEV_2].sort());
+  });
+
+  // Every non-decommissioned status is queueable, so ALL of them must survive the
+  // gate. This is the class a future "tighten it up" change would quietly break:
+  // maintenance/updating/quarantined/pending look un-runnable, but the API takes
+  // their commands and the agent claims them on its next check-in. Mirrors the
+  // row-menu cases in DeviceList.test.tsx.
+  it.each(['maintenance', 'updating', 'quarantined', 'pending'])(
+    'keeps a %s device in the batch — its command queues like any other',
+    async (status) => {
+      const { sendBulkCommand } = await import('../../services/deviceActions');
+      vi.mocked(sendBulkCommand).mockResolvedValue({ commands: [{}, {}], failed: [], skipped: [] } as never);
+
+      vi.mocked(fetchAllDevices).mockResolvedValue({
+        data: [
+          rawDevice(DEV_1, 'host-alpha'),
+          { ...rawDevice(DEV_2, 'host-beta'), status },
+        ],
+      } as never);
+      await renderMixedFleet([DEV_1, DEV_2]);
+
+      fireEvent.click(screen.getByTestId('bulk-reboot'));
+
+      // No confirm — nothing here is decommissioned, so nothing is being skipped.
+      await waitFor(() => expect(vi.mocked(sendBulkCommand)).toHaveBeenCalledTimes(1));
+      expect(screen.queryByTestId('confirm-decommissioned-skip')).toBeNull();
+      expect([...(vi.mocked(sendBulkCommand).mock.calls[0][0] as string[])].sort()).toEqual(
+        [DEV_1, DEV_2].sort(),
+      );
+    },
+  );
+
+  it('leaves bulk Wake UNGATED — it exists precisely to reach devices that are not running', async () => {
+    const { sendBulkWakeCommand } = await import('../../services/deviceActions');
+    vi.mocked(sendBulkWakeCommand).mockResolvedValue({ sent: [], failed: [] } as never);
+
+    boundaryFleet();
+    await renderMixedFleet();
+    fireEvent.click(screen.getByTestId('bulk-wake'));
+
+    await waitFor(() => expect(vi.mocked(sendBulkWakeCommand)).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTestId('confirm-decommissioned-skip')).toBeNull();
+    expect([...(vi.mocked(sendBulkWakeCommand).mock.calls[0][0] as string[])].sort()).toEqual(
+      [DEV_1, DEV_2, DEV_3].sort(),
+    );
+  });
+
+  it('sends exactly one bulk command when the confirm button is double-clicked', async () => {
+    const { sendBulkCommand } = await import('../../services/deviceActions');
+    vi.mocked(sendBulkCommand).mockResolvedValue({ commands: [{}], failed: [], skipped: [] } as never);
+
+    boundaryFleet();
+    await renderMixedFleet();
+    fireEvent.click(screen.getByTestId('bulk-reboot'));
+    const confirm = await screen.findByTestId('confirm-decommissioned-skip');
+
+    // An impatient double-click on a bulk REBOOT must not reboot the fleet twice.
+    //
+    // What this actually fences: converting the dialog to a stay-mounted +
+    // spinner pattern (leaning on ConfirmDialog's `disabled`, or on the
+    // actionInProgress guard — which reads a stale `false` closure and cannot
+    // help) lets the second click through and fires sendBulkCommand twice.
+    // It does NOT discriminate the set-state-before-dispatch ORDER: under React
+    // 18 both updates flush together at the end of the handler, so swapping them
+    // would still pass. The unmount is the guard; the ordering is not load-bearing.
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+
+    await waitFor(() => expect(vi.mocked(sendBulkCommand)).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(sendBulkCommand)).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The #1322 network-row filter and the #2465 decommissioned gate run back-to-back
+// over the same selection and had never been exercised TOGETHER. Ordering is
+// load-bearing: a network row's id is a discovered_assets.id, not a devices.id,
+// and network rows carry status 'online' — so the decommissioned gate would
+// happily wave one through into sendBulkCommand if the network filter stopped
+// running first.
+describe('DevicesPage — network filter + decommissioned gate compose (#1322 × #2465)', () => {
+  const NET_1 = '44444444-4444-4444-4444-444444444444';
+
+  async function renderFleet(count: string) {
+    const { decodeFilterFromHash } = await import('./filterUrl');
+    vi.mocked(decodeFilterFromHash).mockReturnValue({
+      operator: 'AND',
+      conditions: [{ field: 'status', operator: 'in', value: ['online', 'offline', 'decommissioned'] }],
+    } as never);
+    vi.mocked(fetchWithAuth).mockImplementation(async (url: string) => {
+      if (url.startsWith('/filters/preview')) {
+        return jsonResponse({
+          data: {
+            totalCount: 3,
+            deviceIds: [DEV_1, DEV_2, DEV_3],
+            evaluatedAt: new Date().toISOString(),
+          },
+        });
+      }
+      return jsonResponse({ data: [] });
+    });
+    vi.mocked(fetchAllNetworkDevices).mockResolvedValue({
+      data: [{
+        id: NET_1,
+        deviceClass: 'network',
+        assetType: 'printer',
+        hostname: 'Lobby Printer',
+        status: 'online', // network assets are always 'online' — and agent-less
+        lastSeenAt: new Date().toISOString(),
+        orgId: 'org-1',
+        siteId: 'site-1',
+        tags: [],
+      }],
+      total: 1,
+      pagesWalked: 1,
+    } as never);
+    render(<DevicesPage />);
+    const list = await screen.findByTestId('device-list');
+    await waitFor(() => expect(list.getAttribute('data-device-count')).toBe(count));
+  }
+
+  it('drops the network row AND the decommissioned agent, keeping online + offline', async () => {
+    const { sendBulkCommand } = await import('../../services/deviceActions');
+    const { showToast } = await import('../shared/Toast');
+    vi.mocked(sendBulkCommand).mockResolvedValue({ commands: [{}, {}], failed: [], skipped: [] } as never);
+
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [
+        rawDevice(DEV_1, 'host-alpha'),
+        { ...rawDevice(DEV_2, 'host-beta'), status: 'offline' },
+        { ...rawDevice(DEV_3, 'host-gamma'), status: 'decommissioned' },
+      ],
+    } as never);
+    await renderFleet('4'); // 3 agents + 1 network row
+
+    fireEvent.click(screen.getByTestId('bulk-reboot'));
+
+    // Each drop is disclosed through its own channel: the network row via the
+    // #1322 toast, the decommissioned agent via the #2465 confirm.
+    const messages = vi.mocked(showToast).mock.calls.map(c => c[0].message ?? '');
+    expect(messages.some(m => /network device.*skipped/i.test(m))).toBe(true);
+    expect(await screen.findByTestId('confirm-decommissioned-skip')).toBeTruthy();
+    // Denominator is the AGENT selection (3), not the raw 4 — the network row is
+    // already accounted for by its own toast.
+    expect(screen.getByText(/1 of 3 selected devices are decommissioned/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('confirm-decommissioned-skip'));
+
+    await waitFor(() => expect(vi.mocked(sendBulkCommand)).toHaveBeenCalledTimes(1));
+    const [deviceIds] = vi.mocked(sendBulkCommand).mock.calls[0];
+    expect([...(deviceIds as string[])].sort()).toEqual([DEV_1, DEV_2].sort());
+    expect(deviceIds).not.toContain(NET_1); // a printer must never be rebooted
+  });
+});
+
+// The exemptions in INTENTIONALLY_UNGATED_BULK_ACTIONS are load-bearing: an
+// all-offline fleet is the PRIMARY use case for decommission (retiring dead
+// machines) and for maintenance flags. A future "these touch devices too, gate
+// them" sweep would break exactly this.
+describe('DevicesPage — ungated bulk actions still work on an all-offline fleet (#2465)', () => {
+  beforeEach(() => {
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [
+        { ...rawDevice(DEV_1, 'host-alpha'), status: 'offline' },
+        { ...rawDevice(DEV_2, 'host-beta'), status: 'offline' },
+      ],
+    } as never);
+  });
+
+  async function renderOfflineFleet() {
+    const { decodeFilterFromHash } = await import('./filterUrl');
+    vi.mocked(decodeFilterFromHash).mockReturnValue(null);
+    render(<DevicesPage />);
+    const list = await screen.findByTestId('device-list');
+    await waitFor(() => expect(list.getAttribute('data-device-count')).toBe('2'));
+  }
+
+  it('decommissions every offline device — no gate, no confirm', async () => {
+    const { bulkDecommissionDevices } = await import('../../services/deviceActions');
+    vi.mocked(bulkDecommissionDevices).mockResolvedValue({ decommissioned: 2, failed: [] } as never);
+
+    await renderOfflineFleet();
+    fireEvent.click(screen.getByTestId('bulk-decommission'));
+
+    await waitFor(() => expect(vi.mocked(bulkDecommissionDevices)).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTestId('confirm-decommissioned-skip')).toBeNull();
+    expect([...(vi.mocked(bulkDecommissionDevices).mock.calls[0][0] as string[])].sort()).toEqual(
+      [DEV_1, DEV_2].sort(),
+    );
+  });
+
+  it('flags every offline device into maintenance — no gate, no confirm', async () => {
+    const { toggleMaintenanceMode } = await import('../../services/deviceActions');
+    vi.mocked(toggleMaintenanceMode).mockResolvedValue({ success: true, device: {} } as never);
+
+    await renderOfflineFleet();
+    fireEvent.click(screen.getByTestId('bulk-maintenance-on'));
+
+    await waitFor(() => expect(vi.mocked(toggleMaintenanceMode)).toHaveBeenCalledTimes(2));
+    expect(screen.queryByTestId('confirm-decommissioned-skip')).toBeNull();
+    expect(vi.mocked(toggleMaintenanceMode).mock.calls.map(c => c[0]).sort()).toEqual(
+      [DEV_1, DEV_2].sort(),
+    );
   });
 });

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -39,6 +39,7 @@ import { ENABLE_NETWORK_DEVICES_IN_LIST } from '@/lib/featureFlags';
 import ProgressBar from '../shared/ProgressBar';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { scopeConfirmMessage } from '@/lib/scopeConfirmMessage';
+import { DECOMMISSION_BLOCKED_BULK_ACTIONS, isCommandQueueable } from './bulkActionGating';
 // Initializes the shared i18next singleton. Islands hydrate independently, so
 // an island that hydrates before whichever other island happens to pull i18n in
 // would otherwise render raw keys (and mismatch the SSR markup).
@@ -115,6 +116,14 @@ export default function DevicesPage() {
   const [scriptTargetDevices, setScriptTargetDevices] = useState<Device[]>([]);
   type PendingScriptRun = { script: Script; runAs: ScriptRunAsSelection; parameters?: Record<string, unknown>; devices: Device[] };
   const [pendingScriptRun, setPendingScriptRun] = useState<PendingScriptRun | null>(null);
+  // #2465: a bulk agent command whose selection included decommissioned devices
+  // (the one status the API refuses). `devices` is the eligible subset the action
+  // will actually run on — offline devices stay IN, since their command queues
+  // and runs on reconnect. The dialog reports what is being dropped so the user
+  // confirms the reduced target set rather than having part of their selection
+  // silently discarded.
+  type PendingDecommissionedSkip = { action: string; devices: Device[]; skippedCount: number; totalCount: number };
+  const [pendingDecommissionedSkip, setPendingDecommissionedSkip] = useState<PendingDecommissionedSkip | null>(null);
   const [settingsDevice, setSettingsDevice] = useState<Device | null>(null);
   // v2 chip bar seeds its filter from the URL hash so a filtered view is
   // shareable; the legacy DeviceFilterBar owns its own state and ignores it.
@@ -832,6 +841,50 @@ export default function DevicesPage() {
       });
     }
 
+    // Decommissioned gate (#2465). Agent commands are QUEUED, not delivered
+    // live: the API refuses exactly one status — `decommissioned` — and any
+    // other device (offline included) has its command stored `pending` and run
+    // on its next check-in. So gate on `decommissioned` ONLY. Filtering to
+    // `status === 'online'` here would look like the obvious fix and would in
+    // fact discard commands the backend would have honoured — see the verified
+    // API contract in bulkActionGating.ts before "tightening" this.
+    //
+    // Decommissioned rows are hidden by default, but a status filter that
+    // includes them (or the #2251 "show" hint) puts them back in reach of a
+    // select-all, which is how they land in a mixed batch.
+    if (DECOMMISSION_BLOCKED_BULK_ACTIONS.has(action)) {
+      const eligibleDevices = selectedDevices.filter(d => isCommandQueueable(d.status));
+      const skippedDecommissionedCount = selectedDevices.length - eligibleDevices.length;
+
+      if (eligibleDevices.length === 0) {
+        showToast({
+          type: 'error',
+          message: t('devicesPage.toasts.bulkAllDecommissioned', { total: selectedDevices.length }),
+        });
+        return;
+      }
+      if (skippedDecommissionedCount > 0) {
+        setPendingDecommissionedSkip({
+          action,
+          devices: eligibleDevices,
+          skippedCount: skippedDecommissionedCount,
+          totalCount: selectedDevices.length,
+        });
+        return;
+      }
+    }
+
+    await runBulkAction(action, selectedDevices);
+  };
+
+  // Executes a bulk action against an already-vetted device set (network rows
+  // dropped, decommissioned targets filtered + confirmed). Offline devices are
+  // deliberately still IN this set — their command queues and runs on reconnect.
+  // Entered either directly from handleBulkAction (nothing to skip) or from the
+  // decommissioned-skip confirm.
+  const runBulkAction = async (action: string, selectedDevices: Device[]) => {
+    if (actionInProgress || selectedDevices.length === 0) return;
+
     const deviceIds = selectedDevices.map(d => d.id);
     const deviceCount = selectedDevices.length;
 
@@ -1265,6 +1318,39 @@ export default function DevicesPage() {
           />
         );
       })()}
+
+      {/* Decommissioned-skip confirm (#2465): the selection contained retired,
+          agent-less devices, which the API refuses. Name the count being dropped
+          and make the user own the reduced batch. Offline devices are NOT
+          dropped — their command queues and runs when they reconnect. */}
+      {pendingDecommissionedSkip && (
+        <ConfirmDialog
+          open={true}
+          onClose={() => setPendingDecommissionedSkip(null)}
+          // Confirming UNMOUNTS this dialog, which is what makes a double-click
+          // safe — a second click has no button to hit. No isLoading/spinner
+          // here on purpose: that would mean keeping the dialog mounted, and
+          // then neither guard holds — ConfirmDialog's `disabled` and
+          // runBulkAction's `actionInProgress` both read a closure captured at
+          // render, still `false` on the second click, so the fleet reboots
+          // twice. (The set-state/dispatch ORDER below is not what saves us:
+          // React batches both. The unmount is.) DevicesPage.test.tsx pins it.
+          onConfirm={() => {
+            const p = pendingDecommissionedSkip;
+            setPendingDecommissionedSkip(null);
+            void runBulkAction(p.action, p.devices);
+          }}
+          title={t('devicesPage.confirmDecommissionedSkip.title')}
+          variant="warning"
+          confirmLabel={t('common:actions.confirm')}
+          confirmTestId="confirm-decommissioned-skip"
+          message={t('devicesPage.confirmDecommissionedSkip.message', {
+            skipped: pendingDecommissionedSkip.skippedCount,
+            total: pendingDecommissionedSkip.totalCount,
+            eligible: pendingDecommissionedSkip.devices.length,
+          })}
+        />
+      )}
 
       {settingsDevice && (
         <DeviceSettingsModal

--- a/apps/web/src/components/devices/bulkActionGating.ts
+++ b/apps/web/src/components/devices/bulkActionGating.ts
@@ -1,0 +1,105 @@
+/**
+ * Device-status gating policy for the DeviceList bulk-action bar (#2465).
+ *
+ * ## What the API actually rejects (verified, #2465)
+ *
+ * The obvious gate here — "skip devices that aren't online" — is WRONG, and the
+ * mistake has now been made in three places in this codebase. Agent commands are
+ * QUEUED, not delivered live:
+ *
+ *   - `POST /devices/bulk/commands` and `POST /devices/:id/commands` reject
+ *     exactly one status: `decommissioned`. There is no online/offline branch.
+ *   - `POST /scripts/:id/execute` has no device-status gating at all.
+ *   - Commands insert as `status: 'pending'` with NO TTL and are claimed by
+ *     `claimPendingCommandsForDevice` on the agent's next poll/heartbeat.
+ *
+ * So rebooting an OFFLINE device works — it reboots when it comes back. Filtering
+ * offline devices out of the batch would DISCARD commands the backend would have
+ * honoured: a capability regression, not a bugfix.
+ *
+ * `"Device is not online"` (#2078) is a real error, but it comes only from
+ * LIVE-SESSION endpoints — terminalWs, desktopWs, tunnelWs, tunnels,
+ * remote/sessions, bootMetrics. The bulk bar offers none of them. That error got
+ * generalised from live sessions to queued commands as the gate was copied out of
+ * DeviceActions.tsx into the row menu (#2426) and was about to be copied here.
+ *
+ * Hence: gate on `decommissioned` — the one status the backend truly refuses, and
+ * the one the original complaint was actually about ("scripts queued against
+ * devices that can never run them", i.e. retired, agent-less machines).
+ *
+ * ## Why this lives in its own module
+ *
+ * So the contract test in DeviceList.test.tsx can bind these sets to the action
+ * strings the bulk bar ACTUALLY emits. Without that binding the gate has a silent
+ * failure mode: add or rename a bulk action and it simply isn't gated, while every
+ * existing test stays green — because a gate's only failure mode is doing nothing.
+ */
+
+/**
+ * Can this device still accept a QUEUED agent command?
+ *
+ * The single source of truth for that question — used by the DeviceList row menu
+ * AND the bulk bar. Keeping one named predicate is the point: the false "must be
+ * online" premise spread precisely because the check was re-derived by hand in
+ * each new surface (DeviceActions → row menu → bulk bar).
+ *
+ * Takes a plain `string` rather than `DeviceStatus` so this module imports
+ * nothing — DeviceList imports it, not the other way round, so there is no cycle.
+ */
+export function isCommandQueueable(status: string): boolean {
+  return status !== 'decommissioned';
+}
+
+/**
+ * Bulk actions that dispatch an agent command, which the API refuses for a
+ * DECOMMISSIONED device (it has no agent, and never will again). Every other
+ * status — `offline` included — is queued and runs on reconnect, so those devices
+ * deliberately stay in the batch.
+ *
+ * `shutdown` / `lock` / `reboot_safe_mode` have no bulk button today, but
+ * runBulkAction's switch already routes them through sendBulkCommand, so they are
+ * classified up front: wiring a button later must not silently skip the gate.
+ */
+export const DECOMMISSION_BLOCKED_BULK_ACTIONS: ReadonlySet<string> = new Set([
+  'reboot',
+  'reboot_safe_mode',
+  'shutdown',
+  'lock',
+  'run-script',
+]);
+
+/**
+ * Bulk actions deliberately NOT gated on device status. Every one is a considered
+ * exemption, not an oversight — the contract test forces any NEW bulk action into
+ * one set or the other, so a future "gate everything that touches a device" sweep
+ * can't quietly break them.
+ *
+ *   wake            — NOT gated here, on two separate grounds. Keep them apart:
+ *                     (a) it must never be gated on `online` — it exists precisely
+ *                         to reach a device that is NOT running. That's the trap a
+ *                         "gate everything" sweep falls into; pinned by test.
+ *                     (b) it is not gated on `decommissioned` either — see the NOTE
+ *                         below. That one is a deferral, not a principle.
+ *   maintenance-*   — a DB flag, not an agent command. (Also see the NOTE.)
+ *   decommission    — retiring dead machines IS the use case.
+ *   deploy-software — navigates to /software; sends no command from here.
+ *   link-*          — DB-only topology linkage; no agent involved.
+ *
+ * NOTE (follow-up, deliberately out of scope): the API *also* refuses
+ * `decommissioned` for bulk wake (`commands.ts:89`) and for maintenance
+ * (`commands.ts:382`). So a decommissioned device in either of those batches is
+ * still a doomed target today. It degrades gracefully — the API returns a
+ * per-device `DECOMMISSIONED` failure and the UI surfaces a partial-failure toast,
+ * rather than the silent no-op #2465 was about — so extending the skip treatment to
+ * them is a real but separate behaviour change from what #2465 asked for. Flagged in
+ * the PR for the maintainer rather than smuggled in here.
+ */
+export const INTENTIONALLY_UNGATED_BULK_ACTIONS: ReadonlySet<string> = new Set([
+  'wake',
+  'maintenance-on',
+  'maintenance-off',
+  'decommission',
+  'deploy-software',
+  'link-multiboot',
+  'link-vm-host',
+]);

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -1665,6 +1665,10 @@
       "shutdown": "Shutdown"
     },
     "addDevice": "Add Device",
+    "confirmDecommissionedSkip": {
+      "message": "{{skipped}} of {{total}} selected devices are decommissioned and will be skipped — they no longer have an agent. Continue with the remaining {{eligible}} device(s)? Any that are offline will run this when they next check in.",
+      "title": "Some selected devices are decommissioned"
+    },
     "confirmRunAction": "Run {{script}}",
     "confirmScriptRun": "Confirm script run",
     "emptyDescription": "Get started by adding your first device. The installer and enrollment key are generated automatically.",
@@ -1687,6 +1691,7 @@
       "agentOnlyAction": "This action applies to agent devices only. Network devices have no agent and were skipped.",
       "alreadyPendingTail": "Already Pending Tail",
       "bulkActionFailed": "Bulk Action Failed",
+      "bulkAllDecommissioned": "All {{total}} selected device(s) are decommissioned — they no longer have an agent to run this.",
       "bulkCommandPartialFailed": "Bulk Command Partial Failed",
       "bulkCommandSent": "Bulk Command Sent",
       "bulkDecommissionFailed": "Bulk Decommission Failed",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -1665,6 +1665,10 @@
       "shutdown": "Desligar"
     },
     "addDevice": "Adicionar dispositivo",
+    "confirmDecommissionedSkip": {
+      "message": "{{skipped}} de {{total}} dispositivos selecionados estão desativados e serão ignorados — eles não têm mais um agente. Continuar com os {{eligible}} dispositivo(s) restantes? Os que estiverem offline executarão esta ação na próxima vez que se conectarem.",
+      "title": "Alguns dispositivos selecionados estão desativados"
+    },
     "confirmRunAction": "Executar {{script}}",
     "confirmScriptRun": "Confirmar execução do script",
     "emptyDescription": "Comece adicionando seu primeiro dispositivo. O instalador e a chave de registro são gerados automaticamente.",
@@ -1687,6 +1691,7 @@
       "agentOnlyAction": "Esta ação se aplica somente a dispositivos com agente. Os dispositivos de rede não têm agente e foram ignorados.",
       "alreadyPendingTail": "Já estava pendente",
       "bulkActionFailed": "Falha na ação em massa",
+      "bulkAllDecommissioned": "Todos os {{total}} dispositivos selecionados estão desativados — eles não têm mais um agente para executar esta ação.",
       "bulkCommandPartialFailed": "Falha parcial no comando em massa",
       "bulkCommandSent": "Comando em massa enviado",
       "bulkDecommissionFailed": "Falha ao desativar dispositivos em massa",


### PR DESCRIPTION
## Problem

Bulk **Reboot Selected** and **Run Script** had no device-status gate. A selection containing **decommissioned** devices fired agent commands the API refuses outright (`"Cannot send commands to a decommissioned device"`) — retired, agent-less machines that can never run them.

## The issue's premise was false, and this PR corrects it

#2465 asked for a gate on `!== 'online'`, on the premise that the API rejects offline devices with *"Device is not online"* (#2078). **That premise does not hold for `reboot` or `run-script`** — the same correction #2457 made for the row menu:

| Claim | What the code does |
|---|---|
| API rejects non-online targets | `routes/devices/commands.ts` refuses exactly one status: **`decommissioned`** (`:89`, `:157`, `:268`, `:437`). No online/offline branch. |
| `run-script` rejected when offline | `routes/scripts.ts` has **zero** device-status gating on execute. |
| "doomed on arrival" | Commands insert as `status:'pending'` with **no TTL**, claimed by `claimPendingCommandsForDevice` on the agent's next poll/heartbeat. |
| `"Device is not online"` | Only from **live-session** endpoints — `terminalWs`, `desktopWs`, `tunnelWs`, `tunnels`, `remote/sessions`, `bootMetrics`. **The bulk bar offers none of them.** |

**Bulk-rebooting an OFFLINE device works today — it reboots when it comes back.** Filtering to the online subset (what the issue specified) would have **discarded commands the backend honours**: a capability regression wearing a bugfix's clothes.

## Fix

Gate on **`decommissioned` only**:

- **Offline devices stay in the batch** — their command queues and runs on reconnect. The confirm copy says so.
- Selection contains decommissioned devices → warn with the count (*"1 of 3 selected devices are decommissioned and will be skipped — they no longer have an agent"*) and proceed on the rest. **The warn-then-proceed interaction from the issue's option 2 was right; only the predicate was wrong.**
- All decommissioned → error toast, nothing sent.
- No decommissioned devices → **no confirm, no filtering** — zero friction on the common case.
- **Wake stays ungated.**

| Action | Gated on `decommissioned`? | Why |
|---|---|---|
| `reboot`, `reboot_safe_mode`, `shutdown`, `lock`, `run-script` | **yes** | agent command; API refuses decommissioned |
| **`wake`** | **no — deliberate** | exists to reach a device that isn't running |
| `maintenance-on/off`, `decommission` | no | DB flag / retiring dead machines *is* the use case |
| `deploy-software`, `link-*` | no | navigation / DB-only linkage |

## One source of truth for the predicate

The false premise spread **because the rule was re-derived by hand in each new surface** — `DeviceActions.tsx` → row menu (#2426) → and it was about to land here. So #2457's `isCommandQueueable` is hoisted out of `DeviceList.tsx` into `bulkActionGating.ts`, next to the verified API contract, and **imported by both the row menu and the bulk bar**.

There is now exactly one line to get wrong, and both surfaces are bound to it: **flipping it to `=== 'online'` reddens 13 tests across both files** (5 row-menu + 8 bulk).

## Contract test (the structural gap)

Nothing bound the gated-action set to the action strings `DeviceList` actually emits — so adding or renaming a bulk action would silently leave it ungated while every test stayed green, **because a gate's only failure mode is doing nothing.** The contract test enumerates the *real* bulk menu and forces every emitted action into `DECOMMISSION_BLOCKED_BULK_ACTIONS` or `INTENTIONALLY_UNGATED_BULK_ACTIONS`. Verified: it fails and names the offender when one is left unclassified.

## Tests

Pinned in **both** directions, since the tempting "fix" is to regress this:
- mixed online+offline+decommissioned → skips only the decommissioned one; **the offline device is still rebooted** (load-bearing)
- merely online+offline → **no confirm, no filtering**, all targeted
- `maintenance` / `updating` / `quarantined` / `pending` → each **stays in** the batch (all queueable)
- all-decommissioned → error toast, nothing sent
- bulk Run Script → decommissioned skipped, offline kept
- **bulk Wake ungated**; cancel → nothing sent; double-click → exactly one dispatch
- **#1322 × #2465 compose** — network rows carry `status:'online'` and are agent-less, so ordering is load-bearing; a printer must never be rebooted
- ungated exemptions (decommission / maintenance) still work on an **all-offline** fleet

**Verification:** `apps/web` devices + i18n suites → **45 files / 514 tests passed**; `npx tsc --noEmit` clean. CI now runs for real (this targets `main`).

## i18n

`devicesPage.confirmDecommissionedSkip.{title,message}` + `devicesPage.toasts.bulkAllDecommissioned`, in **both** `en` and `pt-BR`. No dynamic `t()` calls. Confirm label reuses `common:actions.confirm`. `localeParity` (keys **and** interpolation tokens) + `keyUsage` gates pass.

## Notes for the maintainer

- **Row-menu Reboot is still `!== 'online'`** (`DeviceList.tsx:2313` uses `isCommandQueueable`, but the Reboot button keeps the stricter gate) — which by this PR's own contract is too strict, since reboot is a queued command. **So the bulk bar will now reboot an offline device that the row `⋯` menu greys out.** That inconsistency **pre-dates both PRs** (bulk reboot was previously *ungated* and already reached offline devices), and #2426/#2457 deliberately left it as a maintainer call, so I did **not** change it. Loosening it is a 2-line change — the predicate already exists.
- **Follow-up (not smuggled in):** the API *also* refuses `decommissioned` for bulk **wake** (`commands.ts:89`) and **maintenance** (`commands.ts:382`). Both degrade gracefully to a per-device failure toast rather than the silent no-op #2465 was about, so extending the skip treatment is a separate behaviour change.
- **Mock drift:** `DevicesPage.test.tsx`'s stubbed `DeviceList` hardcodes its bulk-action list. The contract test binds *sets ↔ real buttons*, but nothing binds *mock ↔ buttons* — add a bulk button and it gets classified but receives no behavioural coverage. Touch both files.

Rebased onto `main` now that #2457 has squash-merged; the diff is this PR's bulk-bar work only.

Closes #2465

🤖 Generated with [Claude Code](https://claude.com/claude-code)