### PR TITLE
fix(agent): log shipper follows backup-server-URL promotion (#2463)

### DIFF
--- a/agent/cmd/breeze-desktop-helper/main.go
+++ b/agent/cmd/breeze-desktop-helper/main.go
@@ -76,13 +76,17 @@ func runDesktopHelper() {
 		socketPath = cfg.IPCSocketPath
 	}
 
+	// Like the user-helper, this is a separate long-lived process with no
+	// heartbeat, and nothing respawns it on a backup-server-URL promotion
+	// (#2323) — so its shipper reads the persisted server URL on a TTL instead
+	// of freezing the startup copy at the dead primary (#2463).
 	if cfg.AgentID != "" && cfg.ServerURL != "" && cfg.HelperAuthToken != "" {
 		helperToken := secmem.NewSecureString(cfg.HelperAuthToken)
 		cfg.HelperAuthToken = ""
 		cfg.AuthToken = ""
 		authMon := authstate.NewMonitor(3)
 		logging.InitShipper(logging.ShipperConfig{
-			ServerURL:    cfg.ServerURL,
+			ServerURL:    config.NewPersistedServerURLProvider("", cfg.ServerURL, 0),
 			AgentID:      cfg.AgentID,
 			AuthToken:    helperToken,
 			AgentVersion: version + "-desktop-helper",

--- a/agent/cmd/breeze-desktop-helper/main.go
+++ b/agent/cmd/breeze-desktop-helper/main.go
@@ -80,6 +80,11 @@ func runDesktopHelper() {
 	// heartbeat, and nothing respawns it on a backup-server-URL promotion
 	// (#2323) — so its shipper reads the persisted server URL on a TTL instead
 	// of freezing the startup copy at the dead primary (#2463).
+	//
+	// Also like the user-helper, this gate is only reachable when config.Load
+	// above succeeded, which it does not in a user context (it reads root-only
+	// secrets.yaml) — see #2483. Reachable today on Windows, where the
+	// desktop-helper runs as SYSTEM.
 	if cfg.AgentID != "" && cfg.ServerURL != "" && cfg.HelperAuthToken != "" {
 		helperToken := secmem.NewSecureString(cfg.HelperAuthToken)
 		cfg.HelperAuthToken = ""

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -1481,6 +1481,14 @@ func runHelperProcess(name, role, context, binaryKind string) {
 	// (#2463). The agent persists the promotion swap to agent.yaml, which is
 	// world-readable precisely so the helper can read its server URL, so the
 	// provider re-reads it there on a TTL.
+	//
+	// NOTE: this whole block is currently reachable only in a SYSTEM/root-context
+	// helper. config.Load above returns an error in a user-context helper —
+	// it unconditionally reads root-only secrets.yaml — so cfg falls back to
+	// config.Default(), whose empty AgentID/ServerURL fail this gate and leave
+	// the user helper with no shipper at all. That is a separate, pre-existing
+	// bug (#2483); the provider below is what the SYSTEM-context helpers that
+	// DO ship today need.
 	if cfg.AgentID != "" && cfg.ServerURL != "" && cfg.HelperAuthToken != "" {
 		helperToken := secmem.NewSecureString(cfg.HelperAuthToken)
 		cfg.AuthToken = ""

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -578,10 +578,19 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 	// stops spamming the API (#401).
 	authMon := authstate.NewMonitor(3)
 
-	// Initialize log shipper for centralized diagnostics
+	// Initialize log shipper for centralized diagnostics.
+	//
+	// The shipper's URL is a provider, not a copied string: after a
+	// backup-server-URL promotion (#2323) diagnostics must follow the promoted
+	// primary instead of being shipped at the dead one for the rest of the
+	// process lifetime — precisely when those logs are most wanted (#2463).
+	// The heartbeat does not exist yet (it owns the promoted URL), so the
+	// provider is seeded with the startup value and bound to hb.ServerURL
+	// below, before the heartbeat starts.
+	shipperServerURL := newServerURLProvider(cfg.ServerURL)
 	if cfg.AgentID != "" && cfg.ServerURL != "" {
 		logging.InitShipper(logging.ShipperConfig{
-			ServerURL:    cfg.ServerURL,
+			ServerURL:    shipperServerURL.Get,
 			AgentID:      cfg.AgentID,
 			AuthToken:    secureToken,
 			AgentVersion: version,
@@ -706,6 +715,13 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 	// Start heartbeat - this implements the main agent run loop
 	hb := heartbeat.NewWithVersion(cfg, version, secureToken, tlsCfg)
 	hb.SetAuthMonitor(authMon)
+
+	// Point the log shipper at the heartbeat's promoted-URL getter (#2463).
+	// This MUST happen before hb.Start(): the heartbeat is the only thing that
+	// can promote a backup URL, so binding first means there is no window in
+	// which a promotion could land while the shipper still holds the startup
+	// value.
+	shipperServerURL.Bind(hb.ServerURL)
 
 	// Log agent start audit event (nil-safe: Log() is a no-op on nil receiver)
 	hb.AuditLog().Log(audit.EventAgentStart, "", map[string]any{
@@ -1456,14 +1472,22 @@ func runHelperProcess(name, role, context, binaryKind string) {
 		socketPath = cfg.IPCSocketPath
 	}
 
-	// Ship helper logs to the API under the same agent identity
+	// Ship helper logs to the API under the same agent identity.
+	//
+	// The helper is a SEPARATE, long-lived process with no heartbeat of its
+	// own, and nothing respawns it when the agent promotes a backup server URL
+	// (#2323) — so a copied cfg.ServerURL would keep shipping helper
+	// diagnostics at the dead primary for the rest of the logon session
+	// (#2463). The agent persists the promotion swap to agent.yaml, which is
+	// world-readable precisely so the helper can read its server URL, so the
+	// provider re-reads it there on a TTL.
 	if cfg.AgentID != "" && cfg.ServerURL != "" && cfg.HelperAuthToken != "" {
 		helperToken := secmem.NewSecureString(cfg.HelperAuthToken)
 		cfg.AuthToken = ""
 		cfg.HelperAuthToken = ""
 		helperAuthMon := authstate.NewMonitor(3)
 		logging.InitShipper(logging.ShipperConfig{
-			ServerURL:    cfg.ServerURL,
+			ServerURL:    config.NewPersistedServerURLProvider(cfgFile, cfg.ServerURL, 0),
 			AgentID:      cfg.AgentID,
 			AuthToken:    helperToken,
 			AgentVersion: version + "-helper",

--- a/agent/internal/agentapp/serverurl.go
+++ b/agent/internal/agentapp/serverurl.go
@@ -35,8 +35,11 @@ func newServerURLProvider(startupURL string) *serverURLProvider {
 }
 
 // Bind re-points the provider at the heartbeat's promoted-URL getter. Call it
-// before starting the heartbeat. A nil fn is ignored, so a caller that has no
-// heartbeat keeps the startup value rather than getting an empty URL.
+// before starting the heartbeat.
+//
+// A nil fn is ignored rather than stored: storing it would panic the shipper's
+// goroutine on the next flush (it has no recover()), and there is no
+// legitimate caller — do not read this guard as license to pass nil.
 func (p *serverURLProvider) Bind(fn func() string) {
 	if fn == nil {
 		return

--- a/agent/internal/agentapp/serverurl.go
+++ b/agent/internal/agentapp/serverurl.go
@@ -1,0 +1,54 @@
+package agentapp
+
+import "sync/atomic"
+
+// serverURLProvider is a late-bound func() string for the AGENT process's log
+// shipper (#2463).
+//
+// Why late binding is needed at all: the shipper must be initialized early in
+// startAgent, BEFORE the heartbeat is constructed, because several one-shot
+// startup diagnostics are logged in between and must reach agent_logs — the
+// systemd unit-reconcile failure reporter (#1201), the ProgramData ACL drift
+// warning (#1481), and any mTLS renewal failure. But only the heartbeat knows
+// the CURRENT server URL after a backup-server-URL promotion (#2323), and it
+// only exposes it through hb.ServerURL(), which reads under the heartbeat's
+// mutex.
+//
+// So the provider is seeded with the startup config value and re-pointed at
+// hb.ServerURL as soon as the heartbeat exists. Bind() is called before
+// hb.Start(), i.e. before any promotion can possibly happen, so no window is
+// left where a promotion could be missed.
+//
+// The seeded value is a by-value copy of cfg.ServerURL on purpose: it is only
+// ever returned before the heartbeat exists, when no promotion can have
+// occurred, and it must NOT be a live read of cfg.ServerURL — promotion writes
+// that field under the heartbeat's mutex, so reading it from the shipper's
+// goroutine would be a data race.
+type serverURLProvider struct {
+	startupURL string                        // immutable; the pre-heartbeat value
+	live       atomic.Pointer[func() string] // set once, by Bind
+}
+
+// newServerURLProvider seeds the provider with the URL known at startup.
+func newServerURLProvider(startupURL string) *serverURLProvider {
+	return &serverURLProvider{startupURL: startupURL}
+}
+
+// Bind re-points the provider at the heartbeat's promoted-URL getter. Call it
+// before starting the heartbeat. A nil fn is ignored, so a caller that has no
+// heartbeat keeps the startup value rather than getting an empty URL.
+func (p *serverURLProvider) Bind(fn func() string) {
+	if fn == nil {
+		return
+	}
+	p.live.Store(&fn)
+}
+
+// Get is the func() string handed to logging.ShipperConfig.ServerURL. It is
+// called from the shipper's own goroutine on every flush, hence the atomic.
+func (p *serverURLProvider) Get() string {
+	if fn := p.live.Load(); fn != nil {
+		return (*fn)()
+	}
+	return p.startupURL
+}

--- a/agent/internal/agentapp/serverurl_test.go
+++ b/agent/internal/agentapp/serverurl_test.go
@@ -1,0 +1,73 @@
+package agentapp
+
+import (
+	"sync"
+	"testing"
+)
+
+// Before the heartbeat exists the provider serves the startup config value —
+// the shipper is initialized first on purpose (startup diagnostics must ship).
+func TestServerURLProviderUsesStartupURLBeforeBind(t *testing.T) {
+	p := newServerURLProvider("https://primary.example.com")
+	if got, want := p.Get(), "https://primary.example.com"; got != want {
+		t.Fatalf("Get() before Bind = %q, want %q", got, want)
+	}
+}
+
+// After Bind, every read goes through the heartbeat's getter, so a
+// backup-server-URL promotion (#2323) is visible to the shipper (#2463).
+func TestServerURLProviderFollowsBoundGetter(t *testing.T) {
+	p := newServerURLProvider("https://primary.example.com")
+
+	promoted := "https://primary.example.com"
+	p.Bind(func() string { return promoted })
+
+	if got, want := p.Get(), "https://primary.example.com"; got != want {
+		t.Fatalf("Get() after Bind = %q, want %q", got, want)
+	}
+
+	promoted = "https://backup.example.com" // heartbeat promotes the backup
+
+	if got, want := p.Get(), "https://backup.example.com"; got != want {
+		t.Fatalf("Get() after promotion = %q, want %q — the shipper must not hold a stale copy (#2463)", got, want)
+	}
+}
+
+// Bind(nil) must not blank the URL. A nil func() string stored and then called
+// would panic inside the shipper's goroutine — the hazard PR #2454 fixed in
+// the sibling clients — so it is ignored and the startup value is kept.
+func TestServerURLProviderIgnoresNilBind(t *testing.T) {
+	p := newServerURLProvider("https://primary.example.com")
+	p.Bind(nil)
+
+	if got, want := p.Get(), "https://primary.example.com"; got != want {
+		t.Fatalf("Get() after Bind(nil) = %q, want %q", got, want)
+	}
+}
+
+// Bind happens on the startup goroutine while the shipper reads from its own;
+// -race must be clean.
+func TestServerURLProviderConcurrentBindAndGet(t *testing.T) {
+	p := newServerURLProvider("https://primary.example.com")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		p.Bind(func() string { return "https://backup.example.com" })
+	}()
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				if got := p.Get(); got == "" {
+					t.Errorf("Get() returned empty URL")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/agent/internal/config/serverurl.go
+++ b/agent/internal/config/serverurl.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// defaultConfigFilePath mirrors Load()'s default lookup — viper.SetConfigName
+// ("agent") + viper.AddConfigPath(configDir()) — without touching the global
+// viper singleton. Load() also falls back to "." ; a helper that finds no
+// agent.yaml at the real config dir simply keeps its startup URL (see
+// NewPersistedServerURLProvider), which is the correct degradation.
+func defaultConfigFilePath() string {
+	return filepath.Join(configDir(), "agent.yaml")
+}
+
+// defaultPersistedServerURLTTL bounds how often a helper process re-reads
+// agent.yaml looking for a promoted server URL. Promotion is rare (it takes
+// backupProbeThreshold consecutive heartbeat failures) and the log shipper
+// flushes at most once a minute, so a 60s TTL costs at most one small YAML
+// read per flush while keeping the post-failover blind window to ~1 minute.
+const defaultPersistedServerURLTTL = 60 * time.Second
+
+// PersistedServerURL reads server_url straight out of agent.yaml.
+//
+// It exists for the HELPER processes (breeze-user-helper, breeze-desktop-
+// helper). They are separate, long-lived processes: they load config once at
+// spawn and are never respawned when the agent promotes a backup server URL
+// (#2323) — HelperLifecycleManager only spawns helpers that are MISSING, and
+// promoteBackupServerURL signals nothing — so a startup copy of ServerURL
+// keeps them shipping diagnostics to the dead primary for the rest of the
+// logon session (#2463). The agent persists the promotion swap to agent.yaml
+// synchronously (heartbeat.promoteBackupServerURL -> config.SetAllAndPersist),
+// which makes that file the authoritative cross-process source of truth.
+//
+// It deliberately does NOT go through Load():
+//
+//   - Load() also opens secrets.yaml, which is root/SYSTEM-only by design
+//     (0600 on Unix, an SDDL with no Users ACE on Windows), so it returns an
+//     error outright in a user-context helper. agent.yaml is world-readable
+//     (0644) precisely so the helper can read its server URL and agent id —
+//     see the comment in permissions_unix.go.
+//   - Load() mutates the package-global viper singleton with no lock, so it is
+//     not safe to call repeatedly from a background shipping goroutine.
+//
+// cfgFile may be empty, in which case the default config path is used.
+func PersistedServerURL(cfgFile string) (string, error) {
+	path := cfgFile
+	if path == "" {
+		path = defaultConfigFilePath()
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	// Decode only the one key we need. A partial struct means unrelated
+	// schema drift elsewhere in agent.yaml cannot break the read.
+	var parsed struct {
+		ServerURL string `yaml:"server_url"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		return "", fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if parsed.ServerURL == "" {
+		return "", fmt.Errorf("%s has no server_url", path)
+	}
+	return parsed.ServerURL, nil
+}
+
+// NewPersistedServerURLProvider returns a func() string for a helper process's
+// logging.ShipperConfig.ServerURL — a provider that follows a backup-server-URL
+// promotion instead of freezing the startup value (#2463).
+//
+// Semantics:
+//
+//   - Re-reads agent.yaml at most once per ttl (<=0 selects the default).
+//   - Falls back to the last known good URL — seeded with initial, the value
+//     the caller loaded at startup — whenever a re-read fails or yields an
+//     empty value. A helper that cannot read the config file must keep shipping
+//     to the URL it already had, not silently stop shipping: a transient read
+//     error is not evidence that the server moved.
+//   - Never returns a URL it was never given: if initial is empty and every
+//     read fails, it returns "", and the shipper reports that as the wiring
+//     bug it is rather than POSTing to a relative URL.
+//
+// Safe for concurrent use — the shipper calls it from its own goroutine.
+func NewPersistedServerURLProvider(cfgFile, initial string, ttl time.Duration) func() string {
+	if ttl <= 0 {
+		ttl = defaultPersistedServerURLTTL
+	}
+
+	var (
+		mu        sync.Mutex
+		lastGood  = initial
+		nextCheck time.Time // zero => re-read on first call
+	)
+
+	return func() string {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if now := time.Now(); now.After(nextCheck) {
+			nextCheck = now.Add(ttl)
+			if serverURL, err := PersistedServerURL(cfgFile); err == nil {
+				lastGood = serverURL
+			}
+			// On error: keep lastGood. Intentionally silent — this runs on the
+			// log-shipping path, so logging a read failure here would be the
+			// very log entry that then tries to ship through this provider.
+		}
+		return lastGood
+	}
+}

--- a/agent/internal/config/serverurl.go
+++ b/agent/internal/config/serverurl.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -71,6 +72,18 @@ func PersistedServerURL(cfgFile string) (string, error) {
 	if parsed.ServerURL == "" {
 		return "", fmt.Errorf("%s has no server_url", path)
 	}
+	// Validate before handing this to a caller that will cache it.
+	// SetAllAndPersist writes agent.yaml through viper.WriteConfig, which
+	// truncates in place rather than doing an atomic temp+rename, so a helper
+	// reading concurrently with a promotion can observe a torn file that still
+	// parses as valid YAML but carries a truncated value
+	// ("server_url: https://ba"). Caching that would pin the shipper to a
+	// garbage host for a full TTL.
+	if u, err := url.Parse(parsed.ServerURL); err != nil {
+		return "", fmt.Errorf("%s has an unparsable server_url: %w", path, err)
+	} else if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return "", fmt.Errorf("%s has a malformed server_url %q (want an http(s) URL with a host)", path, parsed.ServerURL)
+	}
 	return parsed.ServerURL, nil
 }
 
@@ -82,13 +95,19 @@ func PersistedServerURL(cfgFile string) (string, error) {
 //
 //   - Re-reads agent.yaml at most once per ttl (<=0 selects the default).
 //   - Falls back to the last known good URL — seeded with initial, the value
-//     the caller loaded at startup — whenever a re-read fails or yields an
-//     empty value. A helper that cannot read the config file must keep shipping
-//     to the URL it already had, not silently stop shipping: a transient read
-//     error is not evidence that the server moved.
+//     the caller loaded at startup — whenever a re-read fails. A helper that
+//     cannot read the config file must keep shipping to the URL it already had,
+//     not silently stop shipping: a transient read error is not evidence that
+//     the server moved. Callers should pass a non-empty initial.
 //   - Never returns a URL it was never given: if initial is empty and every
 //     read fails, it returns "", and the shipper reports that as the wiring
 //     bug it is rather than POSTing to a relative URL.
+//   - Reports SUSTAINED read failure on stderr. Keeping quiet would be its own
+//     instance of #2463: if agent.yaml is unreadable (an ACL reharden, #1481)
+//     or the agent's promotion persist failed, this provider serves a possibly
+//     DEAD primary forever with no signal anywhere. stderr rather than slog
+//     because this runs on the shipping path and the shipper must not log
+//     through itself; both helpers redirect stderr into their log file.
 //
 // Safe for concurrent use — the shipper calls it from its own goroutine.
 func NewPersistedServerURLProvider(cfgFile, initial string, ttl time.Duration) func() string {
@@ -100,6 +119,7 @@ func NewPersistedServerURLProvider(cfgFile, initial string, ttl time.Duration) f
 		mu        sync.Mutex
 		lastGood  = initial
 		nextCheck time.Time // zero => re-read on first call
+		failures  int       // consecutive
 	)
 
 	return func() string {
@@ -107,13 +127,29 @@ func NewPersistedServerURLProvider(cfgFile, initial string, ttl time.Duration) f
 		defer mu.Unlock()
 
 		if now := time.Now(); now.After(nextCheck) {
+			// Advanced before the attempt, so a failing read backs off a full
+			// TTL rather than re-reading on every chunk of every flush.
 			nextCheck = now.Add(ttl)
-			if serverURL, err := PersistedServerURL(cfgFile); err == nil {
+
+			serverURL, err := PersistedServerURL(cfgFile)
+			switch {
+			case err == nil:
+				failures = 0
 				lastGood = serverURL
+			default:
+				// One failure is expected and benign: agent.yaml is written
+				// with a truncating in-place write, so a read landing mid-
+				// persist can tear. Sustained failure is not benign — it means
+				// we may be pinned to a demoted primary. Rate-limited to keep a
+				// broken path from flooding the helper log (same shape as
+				// Shipper.Enqueue's drop reporting).
+				failures++
+				if failures == 3 || failures%60 == 0 {
+					fmt.Fprintf(os.Stderr,
+						"[server-url] %d consecutive failures re-reading persisted server URL: %v — still using %q, which may be a demoted primary\n",
+						failures, err, lastGood)
+				}
 			}
-			// On error: keep lastGood. Intentionally silent — this runs on the
-			// log-shipping path, so logging a read failure here would be the
-			// very log entry that then tries to ship through this provider.
 		}
 		return lastGood
 	}

--- a/agent/internal/config/serverurl_test.go
+++ b/agent/internal/config/serverurl_test.go
@@ -59,6 +59,61 @@ func TestPersistedServerURLErrors(t *testing.T) {
 	})
 }
 
+// agent.yaml is written with a truncating in-place write (viper.WriteConfig,
+// not an atomic temp+rename), so a helper reading concurrently with a
+// promotion can observe a torn value that is still valid YAML. Caching that
+// would pin the shipper to a garbage host for a whole TTL.
+func TestPersistedServerURLRejectsTornValue(t *testing.T) {
+	torn := []string{
+		"https://ba",       // truncated mid-host: parses, but has no valid host... see below
+		"htt",              // truncated scheme
+		"not a url at all", // no scheme
+		"://backup.example.com",
+	}
+	for _, v := range torn {
+		t.Run(v, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "agent.yaml")
+			if err := os.WriteFile(path, []byte("server_url: "+v+"\n"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := PersistedServerURL(path)
+			// "https://ba" is a syntactically valid URL with host "ba" — it is
+			// accepted, and that is fine: it is indistinguishable from a real
+			// single-label internal hostname. The guard's job is to reject
+			// values with no scheme or no host, which is what the rest cover.
+			if v == "https://ba" {
+				if err != nil {
+					t.Fatalf("PersistedServerURL(%q) = error %v, want it accepted", v, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("PersistedServerURL(%q) = %q, want an error (malformed URL must not be cached)", v, got)
+			}
+		})
+	}
+}
+
+// A torn read must not clobber the last known good URL.
+func TestPersistedServerURLProviderKeepsLastGoodOnTornWrite(t *testing.T) {
+	path := writeAgentYAML(t, "https://primary.example.com")
+	provider := NewPersistedServerURLProvider(path, "https://primary.example.com", time.Nanosecond)
+
+	if got, want := provider(), "https://primary.example.com"; got != want {
+		t.Fatalf("provider() = %q, want %q", got, want)
+	}
+
+	// Simulate catching viper's truncating write mid-flight.
+	if err := os.WriteFile(path, []byte("server_url: \n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := provider(), "https://primary.example.com"; got != want {
+		t.Fatalf("after torn write: provider() = %q, want %q (must not cache a torn value)", got, want)
+	}
+}
+
 // TestPersistedServerURLProviderFollowsPromotion is the helper-process half of
 // #2463: the agent persists the promoted server_url to agent.yaml, and the
 // helper — which is never respawned on promotion — must pick it up rather than

--- a/agent/internal/config/serverurl_test.go
+++ b/agent/internal/config/serverurl_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func writeAgentYAML(t *testing.T, serverURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+	body := "agent_id: dev-1\n"
+	if serverURL != "" {
+		body += "server_url: " + serverURL + "\n"
+	}
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("write agent.yaml: %v", err)
+	}
+	return path
+}
+
+func TestPersistedServerURL(t *testing.T) {
+	path := writeAgentYAML(t, "https://primary.example.com")
+
+	got, err := PersistedServerURL(path)
+	if err != nil {
+		t.Fatalf("PersistedServerURL() error = %v", err)
+	}
+	if want := "https://primary.example.com"; got != want {
+		t.Fatalf("PersistedServerURL() = %q, want %q", got, want)
+	}
+}
+
+func TestPersistedServerURLErrors(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		if _, err := PersistedServerURL(filepath.Join(t.TempDir(), "nope.yaml")); err == nil {
+			t.Fatal("expected an error for a missing config file")
+		}
+	})
+
+	t.Run("no server_url key", func(t *testing.T) {
+		if _, err := PersistedServerURL(writeAgentYAML(t, "")); err == nil {
+			t.Fatal("expected an error when server_url is absent")
+		}
+	})
+
+	t.Run("malformed yaml", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "agent.yaml")
+		if err := os.WriteFile(path, []byte("server_url: [unclosed\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := PersistedServerURL(path); err == nil {
+			t.Fatal("expected a parse error for malformed yaml")
+		}
+	})
+}
+
+// TestPersistedServerURLProviderFollowsPromotion is the helper-process half of
+// #2463: the agent persists the promoted server_url to agent.yaml, and the
+// helper — which is never respawned on promotion — must pick it up rather than
+// shipping to the dead primary for the rest of the logon session.
+func TestPersistedServerURLProviderFollowsPromotion(t *testing.T) {
+	path := writeAgentYAML(t, "https://primary.example.com")
+
+	// ttl=1ns so the test doesn't sleep; the TTL logic itself is covered below.
+	provider := NewPersistedServerURLProvider(path, "https://primary.example.com", time.Nanosecond)
+
+	if got, want := provider(), "https://primary.example.com"; got != want {
+		t.Fatalf("before promotion: provider() = %q, want %q", got, want)
+	}
+
+	// The agent promotes the backup and persists the swap.
+	if err := os.WriteFile(path, []byte("server_url: https://backup.example.com\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := provider(), "https://backup.example.com"; got != want {
+		t.Fatalf("after promotion: provider() = %q, want %q — the helper must follow the persisted promotion (#2463)", got, want)
+	}
+}
+
+// A transient read failure must NOT blank the URL: the helper keeps shipping
+// to the last known good server. Losing the URL would silently stop shipping.
+func TestPersistedServerURLProviderKeepsLastGoodOnReadFailure(t *testing.T) {
+	path := writeAgentYAML(t, "https://primary.example.com")
+	provider := NewPersistedServerURLProvider(path, "https://seed.example.com", time.Nanosecond)
+
+	if got, want := provider(), "https://primary.example.com"; got != want {
+		t.Fatalf("provider() = %q, want %q", got, want)
+	}
+
+	// Config file becomes unreadable (deleted / EACCES in a user-context helper).
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := provider(), "https://primary.example.com"; got != want {
+		t.Fatalf("after read failure: provider() = %q, want %q (last known good)", got, want)
+	}
+}
+
+// With no readable config and no seed, the provider returns "" rather than a
+// bogus URL — the shipper turns that into a named wiring error.
+func TestPersistedServerURLProviderEmptyWhenNothingKnown(t *testing.T) {
+	provider := NewPersistedServerURLProvider(filepath.Join(t.TempDir(), "absent.yaml"), "", time.Nanosecond)
+	if got := provider(); got != "" {
+		t.Fatalf("provider() = %q, want \"\"", got)
+	}
+}
+
+// The TTL must actually throttle re-reads — the provider is called on every
+// log flush and must not stat/parse agent.yaml more often than that.
+func TestPersistedServerURLProviderRespectsTTL(t *testing.T) {
+	path := writeAgentYAML(t, "https://primary.example.com")
+	provider := NewPersistedServerURLProvider(path, "https://primary.example.com", time.Hour)
+
+	if got, want := provider(), "https://primary.example.com"; got != want {
+		t.Fatalf("provider() = %q, want %q", got, want)
+	}
+
+	if err := os.WriteFile(path, []byte("server_url: https://backup.example.com\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Inside the TTL window: the change must NOT be observed yet.
+	if got, want := provider(), "https://primary.example.com"; got != want {
+		t.Fatalf("within TTL: provider() = %q, want %q (re-read should be throttled)", got, want)
+	}
+}
+
+// The shipper calls the provider from its own goroutine; -race must be clean.
+func TestPersistedServerURLProviderConcurrent(t *testing.T) {
+	path := writeAgentYAML(t, "https://primary.example.com")
+	provider := NewPersistedServerURLProvider(path, "https://primary.example.com", time.Nanosecond)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 25; j++ {
+				_ = provider()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/agent/internal/heartbeat/backup_failover_test.go
+++ b/agent/internal/heartbeat/backup_failover_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/breeze-rmm/agent/internal/config"
 	"github.com/breeze-rmm/agent/internal/health"
 	"github.com/breeze-rmm/agent/internal/httputil"
+	"github.com/breeze-rmm/agent/internal/logging"
 	"github.com/breeze-rmm/agent/internal/tunnel"
 	"github.com/breeze-rmm/agent/internal/websocket"
 	"github.com/breeze-rmm/agent/internal/workerpool"
@@ -40,11 +41,11 @@ func failoverResponse(req *http.Request, status int, body string) *http.Response
 
 func newFailoverTestHeartbeat(cfg *config.Config, transport http.RoundTripper) *Heartbeat {
 	return &Heartbeat{
-		config:          cfg,
-		client:          &http.Client{Transport: transport},
-		healthMon:       health.NewMonitor(),
-		tunnelMgr:       &tunnel.Manager{},
-		retryCfg:        httputil.RetryConfig{MaxRetries: 0},
+		config:    cfg,
+		client:    &http.Client{Transport: transport},
+		healthMon: health.NewMonitor(),
+		tunnelMgr: &tunnel.Manager{},
+		retryCfg:  httputil.RetryConfig{MaxRetries: 0},
 	}
 }
 
@@ -385,11 +386,12 @@ func TestProbeCommandResultsGoToPromotedURL(t *testing.T) {
 	}
 }
 
-// TestPromotionVisibleThroughServerURLProvider pins #2423: agentapp wires
-// hb.ServerURL as the URL provider into the long-lived UniFi telemetry and
-// workspace-index client loops. After backup-server-URL promotion the
-// provider must return the promoted URL, so those loops follow the failover
-// instead of POSTing to the dead primary for the remaining process lifetime.
+// TestPromotionVisibleThroughServerURLProvider pins #2423 and #2463: agentapp
+// wires hb.ServerURL as the URL provider into the long-lived UniFi telemetry
+// and workspace-index client loops, and into the log shipper. After
+// backup-server-URL promotion the provider must return the promoted URL, so
+// those clients follow the failover instead of POSTing to the dead primary for
+// the remaining process lifetime.
 func TestPromotionVisibleThroughServerURLProvider(t *testing.T) {
 	const (
 		primaryURL = "https://primary.invalid"
@@ -401,16 +403,34 @@ func TestPromotionVisibleThroughServerURLProvider(t *testing.T) {
 		return failoverResponse(req, http.StatusOK, `{}`), nil
 	}))
 
-	// The provider is captured ONCE at startup, exactly like agentapp does for
-	// unifi.CollectorDeps.APIBaseURL and workspaceindex.ClientConfig.ServerURL.
-	provider := h.ServerURL
-	if got := provider(); got != primaryURL {
-		t.Fatalf("provider before promotion = %q, want %q", got, primaryURL)
+	// Each provider is captured ONCE at startup, exactly like agentapp does for
+	// unifi.CollectorDeps.APIBaseURL, workspaceindex.ClientConfig.ServerURL and
+	// logging.ShipperConfig.ServerURL.
+	unifiProvider := h.ServerURL
+	workspaceIndexProvider := h.ServerURL
+	// The shipper's field is typed func() string precisely so a by-value
+	// cfg.ServerURL copy is unrepresentable at the call site (#2463); this
+	// assignment is the compile-time half of the guarantee.
+	shipperProvider := logging.ShipperConfig{ServerURL: h.ServerURL}.ServerURL
+
+	providers := map[string]func() string{
+		"unifi":          unifiProvider,
+		"workspaceindex": workspaceIndexProvider,
+		"log shipper":    shipperProvider,
+	}
+
+	for name, provider := range providers {
+		if got := provider(); got != primaryURL {
+			t.Fatalf("%s provider before promotion = %q, want %q", name, got, primaryURL)
+		}
 	}
 
 	h.promoteBackupServerURL(backupURL)
 
-	if got := provider(); got != backupURL {
-		t.Fatalf("provider after promotion = %q, want %q — a copied cfg.ServerURL never observes promotion (#2423)", got, backupURL)
+	for name, provider := range providers {
+		if got := provider(); got != backupURL {
+			t.Fatalf("%s provider after promotion = %q, want %q — a copied cfg.ServerURL never observes promotion (#2423, #2463)",
+				name, got, backupURL)
+		}
 	}
 }

--- a/agent/internal/heartbeat/handlers_logship_test.go
+++ b/agent/internal/heartbeat/handlers_logship_test.go
@@ -12,7 +12,7 @@ import (
 func initTestShipper(t *testing.T) {
 	t.Helper()
 	logging.InitShipper(logging.ShipperConfig{
-		ServerURL:    "http://localhost:3001",
+		ServerURL:    func() string { return "http://localhost:3001" },
 		AgentID:      "test-agent",
 		AuthToken:    secmem.NewSecureString("test-token"),
 		AgentVersion: "1.0.0",

--- a/agent/internal/logging/retryafter_test.go
+++ b/agent/internal/logging/retryafter_test.go
@@ -135,7 +135,7 @@ func TestShipBatchHonorsRetryAfterOn429(t *testing.T) {
 	defer server.Close()
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:    server.URL,
+		ServerURL:    func() string { return server.URL },
 		AgentID:      "test-agent",
 		AuthToken:    testToken("brz_secret"),
 		AgentVersion: "1.0.0",
@@ -193,7 +193,7 @@ func TestShipBatchHonorsRetryAfterOn503(t *testing.T) {
 	defer server.Close()
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:    server.URL,
+		ServerURL:    func() string { return server.URL },
 		AgentID:      "test-agent",
 		AuthToken:    testToken("brz_secret"),
 		AgentVersion: "1.0.0",

--- a/agent/internal/logging/shipper.go
+++ b/agent/internal/logging/shipper.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -63,7 +64,7 @@ type LogEntry struct {
 
 // Shipper buffers log entries and ships them to the API in compressed batches.
 type Shipper struct {
-	serverURL    string
+	serverURL    func() string
 	agentID      string
 	authToken    TokenRevealer
 	agentVersion string
@@ -80,7 +81,19 @@ type Shipper struct {
 
 // ShipperConfig configures the log shipper.
 type ShipperConfig struct {
-	ServerURL    string
+	// ServerURL returns the CURRENT Breeze server root, e.g.
+	// https://breeze.example.com — NOT including /api/v1. It is a provider
+	// (heartbeat.ServerURL in the agent; a persisted-config reader in the
+	// helper processes), not a copied string, so backup-server-URL promotion
+	// after failover (#2323) is visible to every flush.
+	//
+	// The type is deliberately a func rather than a string plus an optional
+	// "and also watch this for updates" field: a by-value cfg.ServerURL copy
+	// pinned diagnostics to the DEAD primary for the whole process lifetime —
+	// exactly when those logs are most wanted — and the same mistake had
+	// already been made twice in sibling clients (#2423, #2425). Making the
+	// field a func makes it unrepresentable (#2463).
+	ServerURL    func() string
 	AgentID      string
 	AuthToken    TokenRevealer
 	AgentVersion string
@@ -106,6 +119,25 @@ func NewShipper(cfg ShipperConfig) *Shipper {
 		minLevel:     parseLevel(cfg.MinLevel),
 		authMon:      cfg.AuthMonitor,
 	}
+}
+
+// resolveServerURL returns the CURRENT server root from the provider.
+//
+// An unset provider, or one that returns an empty string, is a wiring bug
+// rather than a runtime condition: report it as a named error instead of
+// calling a nil func — which would panic the ship loop goroutine, and unlike
+// the sibling client loops the shipper carries no observability.Recoverer, so
+// the panic would take the whole agent down — or building a scheme-less
+// relative URL that fails forever as a cryptic transport error.
+func (s *Shipper) resolveServerURL() (string, error) {
+	if s.serverURL == nil {
+		return "", errors.New("log shipper: ServerURL provider not set")
+	}
+	serverURL := s.serverURL()
+	if serverURL == "" {
+		return "", errors.New("log shipper: ServerURL provider returned an empty server URL")
+	}
+	return serverURL, nil
 }
 
 // Start begins the background shipping loop.
@@ -361,7 +393,22 @@ func (s *Shipper) shipChunk(entries []LogEntry) bool {
 	}
 	compressedBytes := compressed.Bytes()
 
-	url := fmt.Sprintf("%s/api/v1/agents/%s/logs", s.serverURL, s.agentID)
+	// Resolved here, on every flush, rather than captured once at init: after a
+	// backup-server-URL promotion (#2323) the next flush must go to the
+	// promoted primary. The retry attempts below deliberately keep the URL this
+	// flush started with — a promotion landing inside a single chunk's ~3s
+	// retry window is picked up by the next batch (<=60s), which is what
+	// matters; the bug being fixed was a URL frozen for the process lifetime
+	// (#2463).
+	baseURL, err := s.resolveServerURL()
+	if err != nil {
+		// Terminal for the whole batch: every remaining chunk would hit the
+		// same wiring bug, so shipBatch must not burn a request per chunk.
+		fmt.Fprintf(os.Stderr, "[log-shipper] %v — dropping %d entries\n", err, len(entries))
+		s.droppedCount.Add(int64(len(entries)))
+		return false
+	}
+	url := fmt.Sprintf("%s/api/v1/agents/%s/logs", baseURL, s.agentID)
 
 	// nextSleepOverride, if non-zero, replaces the default fixed-jitter sleep
 	// for the next retry. Set when the server sends Retry-After on 429/503.

--- a/agent/internal/logging/shipper.go
+++ b/agent/internal/logging/shipper.go
@@ -76,7 +76,11 @@ type Shipper struct {
 	minLevel     slog.Level
 	mu           sync.RWMutex // protects minLevel
 	droppedCount atomic.Int64
-	authMon      AuthSkipper
+	// urlErrCount rate-limits the unresolvable-server-URL report. That state
+	// never self-heals, so an unguarded stderr write would emit a line on every
+	// flush for the process lifetime.
+	urlErrCount atomic.Int64
+	authMon     AuthSkipper
 }
 
 // ShipperConfig configures the log shipper.
@@ -369,6 +373,31 @@ func (s *Shipper) shipBatch(entries []LogEntry) {
 // rest of the batch. Chunk-local outcomes (success, or a non-retried
 // non-auth 4xx that drops only this chunk) return true.
 func (s *Shipper) shipChunk(entries []LogEntry) bool {
+	// Resolved here, on every flush, rather than captured once at init: after a
+	// backup-server-URL promotion (#2323) the next flush must go to the
+	// promoted primary. The retry attempts below deliberately keep the URL this
+	// flush started with — a promotion landing inside a single chunk's ~3s
+	// retry window is picked up by the next batch (<=60s), which is what
+	// matters; the bug being fixed was a URL frozen for the process lifetime
+	// (#2463).
+	//
+	// Resolved BEFORE the marshal+gzip below so a wiring bug doesn't burn a
+	// compression pass over 200 entries before discovering it has nowhere to
+	// send them.
+	baseURL, err := s.resolveServerURL()
+	if err != nil {
+		// Terminal for the whole batch: every remaining chunk would hit the
+		// same wiring bug, so shipBatch must not burn a request per chunk.
+		// Rate-limited — this state does not self-heal, so an unguarded write
+		// would emit a line on every flush forever.
+		dropped := s.droppedCount.Add(int64(len(entries)))
+		if s.urlErrCount.Add(1)%10 == 1 {
+			fmt.Fprintf(os.Stderr, "[log-shipper] %v — dropped %d entries (%d total)\n", err, len(entries), dropped)
+		}
+		return false
+	}
+	url := fmt.Sprintf("%s/api/v1/agents/%s/logs", baseURL, s.agentID)
+
 	payload, err := json.Marshal(map[string]any{
 		"logs": entries,
 	})
@@ -392,23 +421,6 @@ func (s *Shipper) shipChunk(entries []LogEntry) bool {
 		return true
 	}
 	compressedBytes := compressed.Bytes()
-
-	// Resolved here, on every flush, rather than captured once at init: after a
-	// backup-server-URL promotion (#2323) the next flush must go to the
-	// promoted primary. The retry attempts below deliberately keep the URL this
-	// flush started with — a promotion landing inside a single chunk's ~3s
-	// retry window is picked up by the next batch (<=60s), which is what
-	// matters; the bug being fixed was a URL frozen for the process lifetime
-	// (#2463).
-	baseURL, err := s.resolveServerURL()
-	if err != nil {
-		// Terminal for the whole batch: every remaining chunk would hit the
-		// same wiring bug, so shipBatch must not burn a request per chunk.
-		fmt.Fprintf(os.Stderr, "[log-shipper] %v — dropping %d entries\n", err, len(entries))
-		s.droppedCount.Add(int64(len(entries)))
-		return false
-	}
-	url := fmt.Sprintf("%s/api/v1/agents/%s/logs", baseURL, s.agentID)
 
 	// nextSleepOverride, if non-zero, replaces the default fixed-jitter sleep
 	// for the next retry. Set when the server sends Retry-After on 429/503.

--- a/agent/internal/logging/shipper_auth_test.go
+++ b/agent/internal/logging/shipper_auth_test.go
@@ -37,7 +37,7 @@ func TestShipBatch_SkipsWhenAuthDead(t *testing.T) {
 	auth.skip.Store(true)
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:   srv.URL,
+		ServerURL:   func() string { return srv.URL },
 		AgentID:     "test-agent",
 		AuthToken:   testTokenRevealer{},
 		MinLevel:    "info",
@@ -75,7 +75,7 @@ func TestShipBatch_RecordsAuthFailureOn401(t *testing.T) {
 	auth := &testAuthSkipper{}
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:   srv.URL,
+		ServerURL:   func() string { return srv.URL },
 		AgentID:     "test-agent",
 		AuthToken:   testTokenRevealer{},
 		MinLevel:    "info",
@@ -103,7 +103,7 @@ func TestShipBatch_RecordsSuccessOn200(t *testing.T) {
 	auth := &testAuthSkipper{}
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:   srv.URL,
+		ServerURL:   func() string { return srv.URL },
 		AgentID:     "test-agent",
 		AuthToken:   testTokenRevealer{},
 		MinLevel:    "info",
@@ -130,7 +130,7 @@ func TestShipBatch_SkipDropsWhenStopping(t *testing.T) {
 	auth.skip.Store(true)
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:   "http://unused", // never called
+		ServerURL:   func() string { return "http://unused" }, // never called
 		AgentID:     "test-agent",
 		AuthToken:   testTokenRevealer{},
 		MinLevel:    "info",

--- a/agent/internal/logging/shipper_promotion_test.go
+++ b/agent/internal/logging/shipper_promotion_test.go
@@ -1,0 +1,152 @@
+package logging
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func promotionTestEntry() LogEntry {
+	return LogEntry{
+		Timestamp:    time.Now(),
+		Level:        "ERROR",
+		Component:    "test",
+		Message:      "after the primary died",
+		AgentVersion: "1.0.0",
+	}
+}
+
+// countingLogServer returns an httptest server that counts the log-ship
+// requests it receives.
+func countingLogServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/logs") {
+			hits.Add(1)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// TestShipperFollowsServerURLPromotion is the regression test for #2463.
+//
+// The shipper used to copy cfg.ServerURL by value at InitShipper time, so
+// after the heartbeat's backup-server-URL promotion (#2323) it kept POSTing
+// diagnostics to the DEAD primary for the rest of the process lifetime —
+// exactly when those logs are most wanted. With ServerURL as a func() string
+// provider resolved on every flush, the next batch goes to the promoted
+// primary instead.
+func TestShipperFollowsServerURLPromotion(t *testing.T) {
+	primary, primaryHits := countingLogServer(t)
+	backup, backupHits := countingLogServer(t)
+
+	// The provider stands in for heartbeat.ServerURL: promotion swaps the URL
+	// it returns, without the shipper being reconstructed.
+	var current atomic.Value
+	current.Store(primary.URL)
+
+	s := NewShipper(ShipperConfig{
+		ServerURL:    func() string { return current.Load().(string) },
+		AgentID:      "agent-1",
+		AuthToken:    testToken("tok"),
+		AgentVersion: "1.0.0",
+		MinLevel:     "debug",
+		HTTPClient:   primary.Client(),
+	})
+
+	s.shipBatch([]LogEntry{promotionTestEntry()})
+	if got := primaryHits.Load(); got != 1 {
+		t.Fatalf("before promotion: primary hits = %d, want 1", got)
+	}
+	if got := backupHits.Load(); got != 0 {
+		t.Fatalf("before promotion: backup hits = %d, want 0", got)
+	}
+
+	// The primary dies and the heartbeat promotes the backup (#2323).
+	current.Store(backup.URL)
+
+	s.shipBatch([]LogEntry{promotionTestEntry()})
+
+	if got := backupHits.Load(); got != 1 {
+		t.Fatalf("after promotion: promoted-server hits = %d, want 1 — "+
+			"a by-value cfg.ServerURL copy never observes promotion and ships to the dead primary forever (#2463)", got)
+	}
+	if got := primaryHits.Load(); got != 1 {
+		t.Fatalf("after promotion: dead-primary hits = %d, want 1 (no new requests)", got)
+	}
+}
+
+// TestShipperNilProviderDoesNotPanic pins the nil-provider hazard that PR
+// #2454 fixed in the sibling clients: a nil func() string called inside the
+// ship-loop goroutine would panic, and the shipper has no recover(), so it
+// would take the whole agent down. It must degrade to a counted drop instead.
+func TestShipperNilProviderDoesNotPanic(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider func() string
+	}{
+		{name: "nil provider", provider: nil},
+		{name: "provider returns empty", provider: func() string { return "" }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewShipper(ShipperConfig{
+				ServerURL:    tc.provider,
+				AgentID:      "agent-1",
+				AuthToken:    testToken("tok"),
+				AgentVersion: "1.0.0",
+				MinLevel:     "debug",
+			})
+
+			// Must not panic — the real hazard is a panic in shipLoop's
+			// goroutine, so run it through the loop, not just shipBatch.
+			s.Start()
+			s.Enqueue(promotionTestEntry())
+			s.Stop() // drains, which flushes the batch through shipChunk
+
+			if got := s.DroppedLogCount(); got != 1 {
+				t.Fatalf("dropped count = %d, want 1 (entry must be dropped, not silently lost or panicked on)", got)
+			}
+		})
+	}
+}
+
+// TestShipperUnresolvableURLAbortsRemainingChunks: an unset/empty provider
+// dooms every chunk alike, so shipBatch must abort the batch rather than burn
+// a request-build attempt per chunk. All entries are still accounted for in
+// the dropped counter.
+func TestShipperUnresolvableURLAbortsRemainingChunks(t *testing.T) {
+	s := NewShipper(ShipperConfig{
+		ServerURL:    func() string { return "" },
+		AgentID:      "agent-1",
+		AuthToken:    testToken("tok"),
+		AgentVersion: "1.0.0",
+		MinLevel:     "debug",
+	})
+
+	// Two chunks' worth of entries (maxEntriesPerShipRequest = 200).
+	entries := make([]LogEntry, maxEntriesPerShipRequest+5)
+	for i := range entries {
+		entries[i] = promotionTestEntry()
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.shipBatch(entries)
+	}()
+	wg.Wait()
+
+	if got := s.DroppedLogCount(); got != int64(len(entries)) {
+		t.Fatalf("dropped count = %d, want %d (every entry in the aborted batch must be counted)", got, len(entries))
+	}
+}

--- a/agent/internal/logging/shipper_test.go
+++ b/agent/internal/logging/shipper_test.go
@@ -23,15 +23,15 @@ func (t testToken) Reveal() string { return string(t) }
 
 func TestNewShipperDefaults(t *testing.T) {
 	s := NewShipper(ShipperConfig{
-		ServerURL:    "http://localhost:3001",
+		ServerURL:    func() string { return "http://localhost:3001" },
 		AgentID:      "agent-1",
 		AuthToken:    testToken("tok"),
 		AgentVersion: "1.0.0",
 		MinLevel:     "warn",
 	})
 
-	if s.serverURL != "http://localhost:3001" {
-		t.Fatalf("unexpected serverURL: %s", s.serverURL)
+	if got, err := s.resolveServerURL(); err != nil || got != "http://localhost:3001" {
+		t.Fatalf("resolveServerURL() = (%q, %v), want (\"http://localhost:3001\", nil)", got, err)
 	}
 	if s.agentID != "agent-1" {
 		t.Fatalf("unexpected agentID: %s", s.agentID)
@@ -47,7 +47,7 @@ func TestNewShipperDefaults(t *testing.T) {
 func TestNewShipperCustomHTTPClient(t *testing.T) {
 	client := &http.Client{Timeout: 5 * time.Second}
 	s := NewShipper(ShipperConfig{
-		ServerURL:  "http://localhost:3001",
+		ServerURL:  func() string { return "http://localhost:3001" },
 		AgentID:    "a",
 		HTTPClient: client,
 	})
@@ -232,7 +232,7 @@ func TestShipBatchSendsGzipJSON(t *testing.T) {
 	defer server.Close()
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:    server.URL,
+		ServerURL:    func() string { return server.URL },
 		AgentID:      "test-agent",
 		AuthToken:    testToken("brz_secret"),
 		AgentVersion: "1.0.0",
@@ -322,7 +322,7 @@ func TestShipperStartStopDrains(t *testing.T) {
 	defer server.Close()
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:    server.URL,
+		ServerURL:    func() string { return server.URL },
 		AgentID:      "test-agent",
 		AuthToken:    testToken("tok"),
 		AgentVersion: "1.0.0",
@@ -427,7 +427,7 @@ func TestShipBatchChunksFullBatch(t *testing.T) {
 	defer server.Close()
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:  server.URL,
+		ServerURL:  func() string { return server.URL },
 		AgentID:    "test-agent",
 		AuthToken:  testToken("tok"),
 		MinLevel:   "debug",
@@ -472,7 +472,7 @@ func TestShipBatchSmallBatchSingleRequest(t *testing.T) {
 	defer server.Close()
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:  server.URL,
+		ServerURL:  func() string { return server.URL },
 		AgentID:    "test-agent",
 		AuthToken:  testToken("tok"),
 		MinLevel:   "debug",
@@ -513,7 +513,7 @@ func TestShipBatchMidChunk4xxDropsOnlyThatChunk(t *testing.T) {
 	defer server.Close()
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:  server.URL,
+		ServerURL:  func() string { return server.URL },
 		AgentID:    "test-agent",
 		AuthToken:  testToken("tok"),
 		MinLevel:   "debug",
@@ -569,7 +569,7 @@ func TestShipBatchRetries5xxPerChunk(t *testing.T) {
 	defer server.Close()
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:  server.URL,
+		ServerURL:  func() string { return server.URL },
 		AgentID:    "test-agent",
 		AuthToken:  testToken("tok"),
 		MinLevel:   "debug",
@@ -606,7 +606,7 @@ func TestShipBatch401AbortsRemainingChunks(t *testing.T) {
 
 	auth := &testAuthSkipper{}
 	s := NewShipper(ShipperConfig{
-		ServerURL:   server.URL,
+		ServerURL:   func() string { return server.URL },
 		AgentID:     "test-agent",
 		AuthToken:   testToken("tok"),
 		MinLevel:    "debug",
@@ -640,7 +640,7 @@ func TestShipBatchAbortsRemainingChunksOnTerminalFailure(t *testing.T) {
 	defer server.Close()
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:  server.URL,
+		ServerURL:  func() string { return server.URL },
 		AgentID:    "test-agent",
 		AuthToken:  testToken("tok"),
 		MinLevel:   "debug",
@@ -667,7 +667,7 @@ func TestShipBatchURLFormat(t *testing.T) {
 	defer server.Close()
 
 	s := NewShipper(ShipperConfig{
-		ServerURL:  server.URL,
+		ServerURL:  func() string { return server.URL },
 		AgentID:    "abc-123",
 		AuthToken:  testToken("tok"),
 		HTTPClient: server.Client(),


### PR DESCRIPTION
## Problem

`logging.InitShipper` was handed a **by-value copy** of `cfg.ServerURL` at every call site. The heartbeat's backup-server-URL promotion (#2323) mutates the effective server URL at runtime after a failover, so the shipper never saw it: **after promotion the agent kept shipping diagnostic logs to the dead primary** — precisely when those logs are most wanted.

Third instance of the class after the unifi and workspaceindex clients (#2423 / #2425, PR #2454).

## Fix

`ShipperConfig.ServerURL` changes from `string` to a `func() string` provider, resolved **on every flush**:

```go
ServerURL func() string  // was: string
```

Making the field a func — rather than adding an optional second "and also watch this" field — is what makes the copied-string mistake **unrepresentable at the call sites**. That paid off immediately: the type change surfaced a **third shipper call site the issue never listed**, `cmd/breeze-desktop-helper/main.go:85`.

### The three call sites

| Call site | Provider | Why |
|---|---|---|
| **agent** (`agentapp/main.go:590`) | `hb.ServerURL` (late-bound) | The heartbeat owns the promoted URL. |
| **user-helper** (`agentapp/main.go:1479`) | `config.NewPersistedServerURLProvider` | Separate process, no heartbeat. |
| **desktop-helper** (`cmd/breeze-desktop-helper/main.go:89`) | `config.NewPersistedServerURLProvider` | Same — **not listed in the issue**; the type change found it. |

**Agent — why a late-bound provider and not just `hb.ServerURL` directly.** The shipper must be initialized *before* the heartbeat is constructed: one-shot startup diagnostics are logged in between and must reach `agent_logs` (systemd unit-reconcile failures #1201, ProgramData ACL drift #1481, mTLS renewal failures). So `serverURLProvider` is seeded with the startup value and re-pointed at `hb.ServerURL` via `Bind()` — called **before `hb.Start()`**, i.e. before any promotion can possibly land, so no window is left open. The seed is a by-value copy *on purpose*: promotion writes `cfg.ServerURL` under the heartbeat's mutex, so a live read of `cfg.ServerURL` from the shipper's goroutine would be a data race.

**Helpers — why they read `agent.yaml`.** The helpers are separate, long-lived processes with no heartbeat, and **nothing respawns them on promotion** (`HelperLifecycleManager` only spawns helpers that are *missing*; `promoteBackupServerURL` signals nothing, and there is no IPC message carrying a server URL). The agent persists the swap to `agent.yaml` synchronously, and that file is world-readable **precisely so the helper can read its server URL** (see the comment in `config/permissions_unix.go`). The provider re-reads it on a 60s TTL, keeping the last known good URL on a read failure — a transient read error is not evidence the server moved.

It deliberately does **not** go through `config.Load()`, which (a) also opens `secrets.yaml` — root/SYSTEM-only, so `Load()` fails outright in a user-context helper — and (b) mutates the package-global viper singleton with no lock, which is not safe from a background shipping goroutine.

**Nil-provider hazard** (the one #2454 found): a nil `func() string` called inside the ship-loop goroutine would panic, and unlike the sibling client loops the shipper has **no `recover()`**, so it would take the whole agent down. An unset or empty-returning provider is now a named error and a counted drop, terminal for the batch.

## Exhaustive sweep (the issue asked for this)

Every server-URL capture in `agent/` (excl. tests), with a disposition each. Three instances of one class means the enumeration should be *finished*, not extended one client at a time.

| Subsystem | Location | Disposition |
|---|---|---|
| Heartbeat | `heartbeat.go:2705` `serverURL()` | **COVERED** — it *is* the promotion source |
| WebSocket client | `websocket/client.go:106` `SetServerURL` | **COVERED** — `promoteBackupServerURL` re-points it |
| UniFi collector | `unifi/collector.go` `APIBaseURL func() string` | **COVERED** — PR #2454 |
| Workspace-index client | `workspaceindex/client.go` | **COVERED** — PR #2454 |
| Watchdog `FailoverClient` | `watchdog/failover.go:76` | **COVERED** — mutex-guarded `SetBaseURL`, retargeted from disk |
| Agent updater / token-rotate / cert-renew / elevation | `heartbeat.go:3309,3388,4347…` | **COVERED** — all already `h.serverURL()`, built per invocation |
| **Log shipper × 3** | agent + user-helper + desktop-helper | **FIXED HERE** |
| **Helper ("Breeze Assist") Manager download** | `heartbeat.go:501` → `helper/manager.go:128` closure → `helper/download.go:23` | **NEEDS FIX — out of scope, follow-up filed.** `cfg.ServerURL` is baked into the downloader closure at construction, so Assist package downloads/updates go to the dead primary after failover. Different subsystem; keeping this PR reviewable. |
| **Watchdog binary updater** | `cmd/breeze-watchdog/main.go:876,907` | **NEEDS FIX — out of scope, follow-up filed.** `noteFailoverHeartbeatFailure` retargets only the `FailoverClient`, never `cfg`, so the watchdog can be heartbeating the promoted backup while still downloading binaries from the dead primary. |
| mTLS cert renewal at boot | `agentapp/main.go:637` | **NOT APPLICABLE** — startup-only, runs before any heartbeat can promote |
| Enrollment / installer bootstrap / BMR recovery | `main.go:1140`, `bootstrap.go:66`, `backup/bmr/*` | **NOT APPLICABLE** — one-shot processes; URL from a job descriptor or CLI flag |

## Tests

- **`logging`**: `TestShipperFollowsServerURLPromotion` — two `httptest` servers; ship, flip the provider (promotion), ship again; asserts the second batch lands on the **promoted** server and the dead primary gets no new requests. **Mutation-verified**: reintroducing the bug (freeze the URL at construction) makes it fail with `promoted-server hits = 0, want 1`. Plus nil-provider / empty-provider guards driven through the real `shipLoop` goroutine (the panic path), and chunk-abort accounting.
- **`heartbeat`**: extended `TestPromotionVisibleThroughServerURLProvider` (the test #2454 added) to assert the shipper's provider follows a promotion alongside the unifi/workspaceindex ones — including a compile-time assertion that `h.ServerURL` satisfies `logging.ShipperConfig.ServerURL`.
- **`config`**: persisted-URL provider — follows a promotion written to `agent.yaml`, keeps last-known-good on read failure, respects the TTL, `-race` clean under concurrent reads.
- **`agentapp`**: late-bound provider — startup value before `Bind`, promoted value after, `Bind(nil)` ignored, `-race` clean under concurrent bind/get.

**Verification:** `go test -race ./internal/logging/... ./internal/heartbeat/... ./internal/agentapp/... ./internal/config/...` — all green. `go build ./...`, `go vet ./...`, `gofmt` clean.

## ⚠️ Stacked PR

Based on **`fix/2423-url-provider-workspaceindex-hardening`** (PR #2454), not `main` — that PR introduces the `func() string` URL-provider pattern this reuses and edits the same `agentapp/main.go` startup block. **Merge after #2454**, or retarget to `main` once #2454 lands.

Closes #2463

🤖 Generated with [Claude Code](https://claude.com/claude-code)