### PR TITLE
fix(api): validate backup exclusion globs against the agent's real matcher (#2473)

### DIFF
--- a/agent/internal/backup/exclude_contract_test.go
+++ b/agent/internal/backup/exclude_contract_test.go
@@ -1,0 +1,114 @@
+package backup
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Cross-language contract test for the backup exclusion-glob dialect (issue #2473).
+//
+// The API validates exclusion globs BEFORE persisting them and shipping them to
+// the fleet. That validator (packages/shared/src/utils/backupExclusionGlob.ts) is
+// a hand-port of THIS package's matcher, because the dialect is Go's stdlib
+// path.Match applied per segment — not doublestar, not minimatch.
+//
+// A port is only safe if it is pinned. Both sides replay the SAME fixture table:
+//
+//	Go (here)  -> the real newExcludeMatcherForOS / matches
+//	TS         -> packages/shared/src/utils/backupExclusionGlob.test.ts
+//
+// If the dialects ever drift apart, one of the two suites goes red. Do NOT "fix"
+// a failure by editing the fixture's expectations — that silently re-opens #2473.
+// If the agent's matcher is intentionally changed, update the fixture AND the TS
+// port together, and expect the TS suite to catch anything you missed.
+
+const contractFixturePath = "../../../packages/shared/src/fixtures/backup-exclusion-contract.json"
+
+type contractFixture struct {
+	Validity []struct {
+		Pattern string  `json:"pattern"`
+		Usable  bool    `json:"usable"`
+		Problem *string `json:"problem"`
+		Note    string  `json:"note"`
+	} `json:"validity"`
+	Matching []struct {
+		Patterns        []string `json:"patterns"`
+		RelPath         string   `json:"relPath"`
+		CaseInsensitive bool     `json:"caseInsensitive"`
+		Expected        bool     `json:"expected"`
+		Note            string   `json:"note"`
+	} `json:"matching"`
+}
+
+func loadContractFixture(t *testing.T) contractFixture {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.FromSlash(contractFixturePath))
+	if err != nil {
+		t.Fatalf("read contract fixture: %v\n"+
+			"This test is the agent half of a cross-language contract; the fixture lives in the shared package.", err)
+	}
+	var fx contractFixture
+	if err := json.Unmarshal(raw, &fx); err != nil {
+		t.Fatalf("parse contract fixture: %v", err)
+	}
+	if len(fx.Validity) == 0 || len(fx.Matching) == 0 {
+		t.Fatalf("contract fixture is empty (validity=%d matching=%d) — a vacuous contract test is worse than none",
+			len(fx.Validity), len(fx.Matching))
+	}
+	return fx
+}
+
+// TestContractValidity pins WHICH PATTERNS THE AGENT WILL ACTUALLY USE.
+//
+// The agent never fails a backup on a bad glob — it logs and skips it. So the
+// observable contract is: does this pattern survive compilation, or is it
+// silently dropped? Compiling a single pattern and checking for a nil matcher is
+// exactly that question, and it is precisely what the API must predict in order
+// to reject a pattern instead of letting it rot in the DB.
+func TestContractValidity(t *testing.T) {
+	fx := loadContractFixture(t)
+
+	for _, tc := range fx.Validity {
+		t.Run(tc.Pattern+" "+tc.Note, func(t *testing.T) {
+			// Case-sensitive compile: case folding cannot change SYNTACTIC validity.
+			m := newExcludeMatcherForOS([]string{tc.Pattern}, false)
+			compiled := m != nil
+
+			if compiled != tc.Usable {
+				verb := "DROPPED"
+				if compiled {
+					verb = "COMPILED"
+				}
+				t.Fatalf("agent %s pattern %q, but the shared contract says usable=%v (%s).\n"+
+					"The API-side validator is derived from this contract — if the agent's behavior "+
+					"changed, update the fixture AND packages/shared/src/utils/backupExclusionGlob.ts together.",
+					verb, tc.Pattern, tc.Usable, tc.Note)
+			}
+		})
+	}
+}
+
+// TestContractMatching pins MATCH SEMANTICS, not just validity.
+//
+// Validity alone would be a weak contract: it would not catch the TS port
+// silently disagreeing about what "**" spans, whether a base-name pattern hits
+// directories, or that '!' is a literal rather than a negation. Those are the
+// cases a generic glob library gets wrong.
+func TestContractMatching(t *testing.T) {
+	fx := loadContractFixture(t)
+
+	for _, tc := range fx.Matching {
+		t.Run(tc.RelPath+" "+tc.Note, func(t *testing.T) {
+			m := newExcludeMatcherForOS(tc.Patterns, tc.CaseInsensitive)
+			// A nil matcher means "exclude nothing" — matches() is nil-safe.
+			got := m.matches(tc.RelPath)
+
+			if got != tc.Expected {
+				t.Fatalf("matcher(patterns=%q, caseInsensitive=%v).matches(%q) = %v, contract expects %v (%s)",
+					tc.Patterns, tc.CaseInsensitive, tc.RelPath, got, tc.Expected, tc.Note)
+			}
+		})
+	}
+}

--- a/agent/internal/backup/exclude_contract_test.go
+++ b/agent/internal/backup/exclude_contract_test.go
@@ -40,6 +40,14 @@ type contractFixture struct {
 		Expected        bool     `json:"expected"`
 		Note            string   `json:"note"`
 	} `json:"matching"`
+	MatcherPortLimitations []struct {
+		Patterns        []string `json:"patterns"`
+		RelPath         string   `json:"relPath"`
+		CaseInsensitive bool     `json:"caseInsensitive"`
+		Go              bool     `json:"go"`
+		TSPort          bool     `json:"tsPort"`
+		Note            string   `json:"note"`
+	} `json:"matcherPortLimitations"`
 }
 
 func loadContractFixture(t *testing.T) contractFixture {
@@ -108,6 +116,48 @@ func TestContractMatching(t *testing.T) {
 			if got != tc.Expected {
 				t.Fatalf("matcher(patterns=%q, caseInsensitive=%v).matches(%q) = %v, contract expects %v (%s)",
 					tc.Patterns, tc.CaseInsensitive, tc.RelPath, got, tc.Expected, tc.Note)
+			}
+		})
+	}
+}
+
+// TestContractMatcherPortLimitations pins the KNOWN, DELIBERATE divergences of
+// the TS matcher port.
+//
+// Go's path.Match advances the name by BYTES in its star loop, and Go's
+// strings.ToLower uses simple (not full Unicode) case mapping. A code-point-based
+// JS port reproduces neither. Rather than pretend the port is exact, the fixture
+// records exactly where it is not.
+//
+// This test asserts the GO side of each documented divergence — i.e. that the
+// agent really does behave the way the note claims. Without it, the "known
+// limitation" note could quietly become wrong and nobody would notice. The TS
+// suite asserts the other half (that the port still diverges as documented), so
+// the boundary cannot silently widen either.
+//
+// Note this is a limitation of the MATCHER only. The API-side validator
+// (describeExclusionPattern) is exhaustively exact against this same Go code.
+func TestContractMatcherPortLimitations(t *testing.T) {
+	fx := loadContractFixture(t)
+
+	if len(fx.MatcherPortLimitations) == 0 {
+		t.Fatal("matcherPortLimitations is empty — if the TS port became exact, remove the block " +
+			"and fold these into matching[]; do not just delete the assertions")
+	}
+
+	for _, tc := range fx.MatcherPortLimitations {
+		t.Run(tc.RelPath+" "+tc.Note, func(t *testing.T) {
+			m := newExcludeMatcherForOS(tc.Patterns, tc.CaseInsensitive)
+			got := m.matches(tc.RelPath)
+
+			if got != tc.Go {
+				t.Fatalf("agent matcher(patterns=%q, ci=%v).matches(%q) = %v, but the fixture documents "+
+					"the agent's behavior as %v (%s).\nThe recorded TS-port limitation is therefore stale.",
+					tc.Patterns, tc.CaseInsensitive, tc.RelPath, got, tc.Go, tc.Note)
+			}
+			if tc.Go == tc.TSPort {
+				t.Fatalf("case %q is listed as a port LIMITATION but records go==tsPort (%v) — "+
+					"if the port now agrees, move this case into matching[]", tc.Note, tc.Go)
 			}
 		})
 	}

--- a/apps/api/src/services/configurationPolicy.backupExcludes.test.ts
+++ b/apps/api/src/services/configurationPolicy.backupExcludes.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+import { addFeatureLink, updateFeatureLink } from './configurationPolicy';
+import { db } from '../db';
+
+/**
+ * Backup exclusion globs, validated at the LAST chokepoint before persistence
+ * (#2473).
+ *
+ * The HTTP routes already validate inlineSettings with backupInlineSettingsSchema.
+ * The AI/MCP `manage_policy_feature_link` tool does NOT — it declares
+ * inlineSettings as `z.record(z.string(), z.unknown())` and hands the blob
+ * straight to addFeatureLink/updateFeatureLink. Both funnel through
+ * decomposeInlineSettings, where the backstop lives.
+ *
+ * These tests drive that real path (not the zod schema in isolation), because
+ * the schema being correct proves nothing about whether the AI path reaches it.
+ */
+
+/** tx.select().from().innerJoin().where().limit() → rows */
+function selectChain(rows: unknown[]) {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.innerJoin = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+/** Row decomposeInlineSettings reads to resolve the policy's ownership axis. */
+const POLICY_ROW = { orgId: 'org-1', partnerId: null, featurePolicyId: null };
+
+/** Row updateFeatureLink reads FIRST, to discover the link's featureType. */
+const EXISTING_BACKUP_LINK = {
+  id: 'link-1',
+  configPolicyId: 'policy-1',
+  featureType: 'backup',
+  featurePolicyId: null,
+  inlineSettings: {},
+};
+
+/**
+ * @param selectResults rows returned by successive tx.select() calls, in order.
+ *   addFeatureLink issues only decompose's ownership query. updateFeatureLink
+ *   issues the existing-link query FIRST, then decompose's — if that sequence is
+ *   not honored, `existing.featureType` is undefined, decompose's switch matches
+ *   nothing, and the test passes vacuously without ever reaching the backstop.
+ * @returns `captured` — values handed to the config_policy_backup_settings
+ *   insert, i.e. what would actually hit the DB.
+ */
+function mockBackupTx(selectResults: unknown[][] = [[POLICY_ROW]]) {
+  const captured: { values?: Record<string, unknown> } = {};
+  let insertCall = 0;
+  let selectCall = 0;
+
+  const tx = {
+    select: vi.fn(() => {
+      const rows = selectResults[selectCall] ?? [POLICY_ROW];
+      selectCall += 1;
+      return selectChain(rows);
+    }),
+    delete: vi.fn(() => ({ where: vi.fn(() => Promise.resolve([])) })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() =>
+            Promise.resolve([{ id: 'link-1', configPolicyId: 'policy-1', featureType: 'backup' }]),
+          ),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((v: Record<string, unknown>) => {
+        insertCall += 1;
+        if (insertCall === 1 && 'inlineSettings' in v) {
+          // The feature-link row itself.
+          return {
+            onConflictDoNothing: vi.fn(() => ({
+              returning: vi.fn(() =>
+                Promise.resolve([
+                  {
+                    id: 'link-1',
+                    configPolicyId: 'policy-1',
+                    featureType: 'backup',
+                    featurePolicyId: null,
+                    inlineSettings: v.inlineSettings,
+                  },
+                ]),
+              ),
+            })),
+          };
+        }
+        // The normalized config_policy_backup_settings row.
+        captured.values = v;
+        return Promise.resolve([]);
+      }),
+    })),
+  };
+
+  // Same tx-mock shape as configurationPolicy.test.ts; the real parameter is a
+  // full Drizzle transaction, which is not worth reconstructing here.
+  // eslint-disable-next-line
+  vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+  return captured;
+}
+
+const VALID_SETTINGS = {
+  backupMode: 'file',
+  paths: ['/data'],
+  targets: { paths: ['/data'], excludes: ['*.tmp', 'node_modules/**'] },
+};
+
+describe('backup exclusion globs — AI/MCP backstop (#2473)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a malformed glob on the AI create path (bypasses the HTTP zod schema)', async () => {
+    mockBackupTx();
+    // Valid in bash/minimatch; the agent's path.Match dialect rejects it, so it
+    // would be silently dropped and exclude nothing.
+    await expect(
+      addFeatureLink('policy-1', 'backup', null, {
+        ...VALID_SETTINGS,
+        targets: { paths: ['/data'], excludes: ['[a-z0-9_-].log'] },
+      }),
+    ).rejects.toThrow(/exclusion pattern/i);
+  });
+
+  it('rejects a malformed glob on the AI update path too', async () => {
+    // Sequence matters: existing-link row first, THEN decompose's ownership row.
+    mockBackupTx([[EXISTING_BACKUP_LINK], [POLICY_ROW]]);
+    await expect(
+      updateFeatureLink('link-1', {
+        inlineSettings: {
+          ...VALID_SETTINGS,
+          targets: { paths: ['/data'], excludes: ['logs/[a-'] },
+        },
+      }),
+    ).rejects.toThrow(/exclusion pattern/i);
+  });
+
+  it('accepts a valid glob on the AI update path (proves the reject above is not vacuous)', async () => {
+    const captured = mockBackupTx([[EXISTING_BACKUP_LINK], [POLICY_ROW]]);
+    await expect(
+      updateFeatureLink('link-1', { inlineSettings: VALID_SETTINGS }),
+    ).resolves.toBeDefined();
+    expect((captured.values?.targets as Record<string, unknown>)?.excludes).toEqual([
+      '*.tmp',
+      'node_modules/**',
+    ]);
+  });
+
+  it('persists the stripped list, not the raw one', async () => {
+    const captured = mockBackupTx();
+    await addFeatureLink('policy-1', 'backup', null, {
+      ...VALID_SETTINGS,
+      targets: { paths: ['/data'], excludes: ['*.tmp', '', '   ', 'node_modules/**'] },
+    });
+    // Blank lines are dropped on the way to the DB — not persisted, not rejected.
+    expect((captured.values?.targets as Record<string, unknown>)?.excludes).toEqual([
+      '*.tmp',
+      'node_modules/**',
+    ]);
+  });
+
+  it('rejects a non-array excludes (a plausible LLM mistake) instead of writing a string into JSONB', async () => {
+    mockBackupTx();
+    await expect(
+      addFeatureLink('policy-1', 'backup', null, {
+        ...VALID_SETTINGS,
+        targets: { paths: ['/data'], excludes: '*.tmp' },
+      }),
+    ).rejects.toThrow(/exclusion pattern/i);
+  });
+
+  it('accepts a valid glob and writes it through', async () => {
+    const captured = mockBackupTx();
+    await addFeatureLink('policy-1', 'backup', null, VALID_SETTINGS);
+    expect((captured.values?.targets as Record<string, unknown>)?.excludes).toEqual([
+      '*.tmp',
+      'node_modules/**',
+    ]);
+  });
+
+  it('does NOT reject a profile-linked link whose targets are legitimately empty', async () => {
+    // Guards the deliberate scoping of the backstop. "What to protect" lives on
+    // the linked backup profile, so targets is empty by design. If someone
+    // "simplifies" the backstop to re-parse the whole blob with
+    // backupInlineSettingsSchema, fileTargetsSchema's paths.min(1) would fire and
+    // break EVERY profile-linked policy save.
+    const captured = mockBackupTx();
+    await expect(
+      addFeatureLink('policy-1', 'backup', null, {
+        schedule: { frequency: 'daily', time: '03:00' },
+        retention: { retentionDays: 30 },
+      }),
+    ).resolves.toBeDefined();
+    expect(captured.values?.targets).toEqual({});
+  });
+});

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -36,6 +36,7 @@ import { and, eq, desc, or, sql, inArray, asc, getTableColumns, SQL } from 'driz
 import { canManagePartnerWidePolicies, PartnerWideWriteDeniedError } from './partnerWideAccess';
 import { z } from 'zod';
 import {
+  backupExcludePatternsSchema,
   eventLogInlineSettingsSchema,
   monitoringInlineSettingsSchema,
   onedriveHelperInlineSettingsSchema,
@@ -670,6 +671,31 @@ async function decomposeInlineSettings(
         }
       }
 
+      // #2473 backstop for file-mode exclusion globs.
+      //
+      // The HTTP routes validate inlineSettings with backupInlineSettingsSchema,
+      // but the AI/MCP `manage_policy_feature_link` tool takes inlineSettings as
+      // an unvalidated `z.record(z.string(), z.unknown())` and hands it straight
+      // to addFeatureLink/updateFeatureLink. Both land here, so this is the last
+      // chokepoint before a malformed glob is persisted and shipped to the
+      // agent (which would silently ignore it and back the files up anyway).
+      //
+      // Scoped deliberately to `excludes`: re-parsing the whole blob with
+      // backupInlineSettingsSchema would reject profile-linked links, whose
+      // targets are legitimately empty because "what to protect" lives on the
+      // linked profile.
+      const rawTargets = (s.targets ?? {}) as Record<string, unknown>;
+      let targets = rawTargets;
+      if (rawTargets.excludes !== undefined) {
+        const parsed = backupExcludePatternsSchema.safeParse(rawTargets.excludes);
+        if (!parsed.success) {
+          const detail = parsed.error.issues.map((i) => i.message).join('; ');
+          throw new Error(`Invalid backup exclusion pattern: ${detail}`);
+        }
+        // Persist the stripped/validated list, not the raw one.
+        targets = { ...rawTargets, excludes: parsed.data };
+      }
+
       await tx.insert(configPolicyBackupSettings).values({
         featureLinkId: linkId,
         orgId: policyRow.orgId,
@@ -678,7 +704,7 @@ async function decomposeInlineSettings(
         retention: (s.retention ?? {}) as Record<string, unknown>,
         paths: (Array.isArray(s.paths) ? s.paths : []) as unknown[],
         backupMode: (s.backupMode ?? 'file') as 'file' | 'hyperv' | 'mssql' | 'system_image',
-        targets: (s.targets ?? {}) as Record<string, unknown>,
+        targets,
         backupProfileId,
         destinationConfigId,
       });

--- a/apps/web/src/components/configurationPolicies/featureTabs/backupTabPresets.test.ts
+++ b/apps/web/src/components/configurationPolicies/featureTabs/backupTabPresets.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { describeExclusionPattern } from '@breeze/shared';
+import { createOsPresets, createExclusionGroups } from './backupTabPresets';
+
+/**
+ * Every exclusion glob this UI ships must be accepted by the API-side validator
+ * added in #2473.
+ *
+ * If a preset or suggestion chip were rejected, EVERY policy save that used it
+ * would fail with a validation error — the over-strict catastrophe the issue
+ * explicitly warns about, triggered by our own defaults.
+ *
+ * This deliberately iterates the REAL preset modules rather than a hand-copied
+ * list. An earlier version of this test copied the patterns by hand and was
+ * already out of sync on day one (it missed `*.swp`), which is exactly the kind
+ * of drift a "kept in sync by hand" comment never prevents.
+ */
+describe('shipped backup exclusion presets are valid in the agent dialect (#2473)', () => {
+  const presetPatterns = createOsPresets().flatMap((p) => p.excludes);
+  const suggestionPatterns = createExclusionGroups().flatMap((g) =>
+    g.items.map((i) => i.pattern),
+  );
+  const shipped = [...new Set([...presetPatterns, ...suggestionPatterns])];
+
+  it('finds patterns to check (guards against the presets being emptied)', () => {
+    expect(presetPatterns.length).toBeGreaterThan(0);
+    expect(suggestionPatterns.length).toBeGreaterThan(0);
+  });
+
+  it.each(shipped)('accepts %s', (pattern) => {
+    const verdict = describeExclusionPattern(pattern);
+    expect(verdict.usable, `${pattern} → ${verdict.message ?? ''}`).toBe(true);
+  });
+});

--- a/packages/shared/src/fixtures/backup-exclusion-contract.json
+++ b/packages/shared/src/fixtures/backup-exclusion-contract.json
@@ -91,6 +91,32 @@
       "note": "normalizes to 'foo/*bar'"
     },
 
+    {
+      "pattern": "\\*",
+      "usable": true,
+      "problem": null,
+      "divergence": "FOOTGUN. In path.Match/minimatch, '\\*' is an ESCAPED LITERAL star. Here the backslash folds to '/', giving '/*', which trims to '*' — a base-name glob matching EVERY file. A tech escaping a star to exclude a file literally named '*' instead excludes the entire backup: it succeeds and protects nothing. Syntactically legal, so we accept it (see the matching[] case).",
+      "note": "normalizes to '*' — excludes everything"
+    },
+    {
+      "pattern": "!important.doc",
+      "usable": true,
+      "problem": null,
+      "divergence": "There is NO negation/un-exclude in this dialect. gitignore users write '!keep.doc' expecting to RE-INCLUDE a file; here it is a literal filename match, so it EXCLUDES a file called '!keep.doc' and does nothing else.",
+      "note": "'!' is literal, not a negation"
+    },
+    { "pattern": "[a]]", "usable": true, "problem": null, "note": "class [a] followed by a literal ']'" },
+    { "pattern": "[^]]", "usable": false, "problem": "syntax", "note": "']' cannot open a negated class" },
+    {
+      "pattern": "[\\]]",
+      "usable": false,
+      "problem": "syntax",
+      "divergence": "Would be an escaped ']' inside a class in path.Match/minimatch. Backslash folds to '/' first, so it splits into the malformed segments '[' and ']]'.",
+      "note": "not an escaped ']'"
+    },
+    { "pattern": "[--0]", "usable": false, "problem": "syntax", "note": "dash as range-lo" },
+    { "pattern": "a**b", "usable": true, "problem": null, "note": "'**' inside a segment is just a star" },
+
     { "pattern": "", "usable": false, "problem": "empty", "note": "blank — agent skips; API strips rather than erroring" },
     { "pattern": "   ", "usable": false, "problem": "empty", "note": "whitespace only" },
     { "pattern": "/", "usable": false, "problem": "empty", "note": "separators only" },
@@ -315,6 +341,106 @@
       "relPath": "srv/var/log/syslog",
       "caseInsensitive": false,
       "expected": true
+    },
+
+    {
+      "divergence": "'\\*' excludes EVERYTHING. The backup then succeeds and protects nothing — the same silent-empty-backup class the profiles schema already guards against for `volumes`.",
+      "patterns": ["\\*"],
+      "relPath": "a/b",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "divergence": "'!' is a LITERAL, so a gitignore-style un-exclude actually excludes the file it names.",
+      "patterns": ["!important.doc"],
+      "relPath": "d/!important.doc",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "divergence": "…and it does NOT re-include (or otherwise affect) the file the author meant.",
+      "patterns": ["!important.doc"],
+      "relPath": "d/important.doc",
+      "caseInsensitive": false,
+      "expected": false
+    },
+    {
+      "note": "'?' does not cross a separator either (the fixture previously only pinned '*')",
+      "patterns": ["a?c"],
+      "relPath": "a/c",
+      "caseInsensitive": false,
+      "expected": false
+    },
+    {
+      "note": "an interior '**' spans ZERO segments",
+      "patterns": ["a/**/b"],
+      "relPath": "a/b",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "divergence": "On Windows the PATTERN is lowercased too, so an uppercase class silently becomes lowercase: '[A-Z]' matches 'a'. It does not on Linux/macOS (next case).",
+      "patterns": ["[A-Z].txt"],
+      "relPath": "d/a.txt",
+      "caseInsensitive": true,
+      "expected": true
+    },
+    {
+      "note": "case-sensitive platforms: '[A-Z]' does not match 'a'",
+      "patterns": ["[A-Z].txt"],
+      "relPath": "d/a.txt",
+      "caseInsensitive": false,
+      "expected": false
+    },
+    {
+      "note": "'?' matches one RUNE, not one UTF-16 code unit — pins the code-point decision (an astral char is a single '?')",
+      "patterns": ["?"],
+      "relPath": "d/😀",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "note": "an astral character class compares whole runes",
+      "patterns": ["[😀-😃]"],
+      "relPath": "d/😀",
+      "caseInsensitive": false,
+      "expected": true
+    }
+  ],
+
+  "$matcherPortLimitations": [
+    "KNOWN, DELIBERATE fidelity boundary of the TS matcher port — NOT of the validator.",
+    "",
+    "`describeExclusionPattern` (the only thing that gates an API save) is exhaustively exact: it was",
+    "differentially fuzzed against the real Go matcher over 177k+ patterns with zero divergences.",
+    "",
+    "`compileExcludeMatcher` is a different story. Go's path.Match advances the NAME by BYTES in its star",
+    "loop, and Go's strings.ToLower uses simple (not full Unicode) case mapping. A code-point-based JS port",
+    "cannot reproduce either without vendoring a UTF-8 byte matcher and Go's case tables. The cases below are",
+    "where the port KNOWINGLY disagrees with the agent. They are asserted by the Go test (proving the agent",
+    "really behaves this way, so this note cannot rot) and asserted-as-divergent by the TS test (so the",
+    "boundary cannot silently widen).",
+    "",
+    "Because of this, compileExcludeMatcher is NOT exported from the package barrel and must not be used to",
+    "show users a 'what would this exclude?' preview — it would lie about CJK/emoji filenames and Turkish 'İ'.",
+    "Making it exact means porting the matcher over UTF-8 bytes; see the PR discussion on #2473."
+  ],
+  "matcherPortLimitations": [
+    {
+      "note": "Go's star loop advances by BYTES, so '?' decodes RuneError one byte at a time at a mid-rune offset: '*??' matches any base name ending in a 3-byte rune. The code-point port says false.",
+      "patterns": ["*??"],
+      "relPath": "d/漢",
+      "caseInsensitive": false,
+      "go": true,
+      "tsPort": false
+    },
+    {
+      "note": "Go strings.ToLower('İ') is 'i' (simple mapping, one rune). JS toLowerCase() applies Unicode SpecialCasing and yields 'i' + U+0307 (two code points), so the lengths no longer line up.",
+      "patterns": ["i"],
+      "relPath": "İ",
+      "caseInsensitive": true,
+      "go": true,
+      "tsPort": false
     }
   ]
 }

--- a/packages/shared/src/fixtures/backup-exclusion-contract.json
+++ b/packages/shared/src/fixtures/backup-exclusion-contract.json
@@ -1,0 +1,320 @@
+{
+  "$comment": [
+    "CONTRACT FIXTURE — backup file-mode exclusion globs (issue #2473).",
+    "",
+    "This table is the single definition of the exclusion-glob dialect. It is replayed against BOTH sides:",
+    "  Go  — agent/internal/backup/exclude_contract_test.go   (the REAL agent matcher, newExcludeMatcherForOS)",
+    "  TS  — packages/shared/src/utils/backupExclusionGlob.test.ts   (the API-side validator/matcher port)",
+    "If the two dialects ever drift apart, both suites go red. Do not edit one side's expectations to make a test pass.",
+    "",
+    "The dialect is Go stdlib path.Match applied PER SEGMENT — NOT doublestar, NOT minimatch, NOT bash.",
+    "Cases tagged \"divergence\" are where a generic glob library would give a different answer; they are the",
+    "reason this could not be a one-line zod refinement.",
+    "",
+    "validity[]  usable=true means the agent compiles and uses the pattern; usable=false means the agent",
+    "            silently DROPS it (logs 'ignoring invalid exclusion pattern'). The API rejects exactly the",
+    "            usable=false/problem=syntax set, and strips the problem=empty set.",
+    "matching[]  expected = does the agent's matcher exclude relPath given patterns?"
+  ],
+
+  "validity": [
+    { "pattern": "*.tmp", "usable": true, "problem": null, "note": "base-name glob" },
+    { "pattern": "Thumbs.db", "usable": true, "problem": null, "note": "literal base name" },
+    { "pattern": "node_modules/**", "usable": true, "problem": null, "note": "path glob with doublestar" },
+    { "pattern": "**/AppData/Local/Temp/**", "usable": true, "problem": null, "note": "leading doublestar" },
+    { "pattern": "[abc].txt", "usable": true, "problem": null, "note": "character class" },
+    { "pattern": "[a-z].txt", "usable": true, "problem": null, "note": "range" },
+    { "pattern": "[^a-z].txt", "usable": true, "problem": null, "note": "negation is '^' in path.Match" },
+    { "pattern": "?", "usable": true, "problem": null, "note": "single-char wildcard" },
+    { "pattern": "***", "usable": true, "problem": null, "note": "collapses to a star; legal" },
+    { "pattern": "abc]", "usable": true, "problem": null, "note": "unmatched ']' is a literal" },
+    { "pattern": "]abc", "usable": true, "problem": null, "note": "leading ']' is a literal" },
+    { "pattern": "[α-ω].txt", "usable": true, "problem": null, "note": "unicode range compares whole runes" },
+
+    {
+      "pattern": "[!a-z].txt",
+      "usable": true,
+      "problem": null,
+      "divergence": "minimatch/bash treat '[!...]' as NEGATION. path.Match treats '!' as a LITERAL class member. Syntactically fine either way, so we MUST accept it — but it means something different. See matching[] for the proof.",
+      "note": "accepted; semantics differ from minimatch"
+    },
+    {
+      "pattern": "[z-a]",
+      "usable": true,
+      "problem": null,
+      "divergence": "Reversed range. path.Match does NOT error on hi<lo; it just never matches. Almost certainly a typo, but the agent accepts it, so an over-strict API would break a save that works today. Deliberately let through.",
+      "note": "accepted; never matches"
+    },
+
+    {
+      "pattern": "[a-z0-9_-].log",
+      "usable": false,
+      "problem": "syntax",
+      "divergence": "HEADLINE CASE. The trailing-dash-means-literal-dash idiom is valid in bash/minimatch/doublestar and is extremely common. Go's path.Match rejects it (getEsc errors on ']' after '-'). Today the agent silently drops this pattern and backs up everything the tech thought was excluded.",
+      "note": "trailing '-' in class"
+    },
+    { "pattern": "[-a].log", "usable": false, "problem": "syntax", "divergence": "leading '-' in class: valid in bash, ErrBadPattern in Go", "note": "leading '-' in class" },
+    { "pattern": "[]]", "usable": false, "problem": "syntax", "divergence": "POSIX/bash allow ']' as the first class member ('[]]' matches ']'). Go rejects it.", "note": "']' first in class" },
+    { "pattern": "[]", "usable": false, "problem": "syntax", "note": "empty class" },
+    { "pattern": "[^]", "usable": false, "problem": "syntax", "note": "empty negated class" },
+    { "pattern": "[", "usable": false, "problem": "syntax", "note": "unclosed class" },
+    { "pattern": "a[bc", "usable": false, "problem": "syntax", "note": "unclosed class" },
+    { "pattern": "logs/[a-", "usable": false, "problem": "syntax", "note": "unclosed class in a path segment" },
+
+    {
+      "pattern": "a[x/y]b",
+      "usable": false,
+      "problem": "syntax",
+      "divergence": "Valid as ONE glob string, but the agent matches slash patterns PER SEGMENT, so this splits into the malformed segments 'a[x' and 'y]b' and is dropped. A whole-string validator would wrongly accept it.",
+      "note": "class split across a '/'"
+    },
+    { "pattern": "a//b", "usable": false, "problem": "syntax", "note": "empty interior segment can never match" },
+
+    {
+      "pattern": "temp\\",
+      "usable": true,
+      "problem": null,
+      "divergence": "A trailing backslash is a TRAILING-ESCAPE syntax error in raw path.Match. But the agent folds '\\'->'/' and trims separators BEFORE matching, so this is just the base-name pattern 'temp'. Validating the raw string with path.Match would wrongly reject it.",
+      "note": "normalizes to 'temp'"
+    },
+    {
+      "pattern": "AppData\\Local\\Temp",
+      "usable": true,
+      "problem": null,
+      "note": "Windows separators are folded to '/' — becomes the path pattern AppData/Local/Temp"
+    },
+    {
+      "pattern": "foo\\*bar",
+      "usable": true,
+      "problem": null,
+      "divergence": "In path.Match/minimatch, '\\*' is an ESCAPED literal star. Here the backslash is folded to '/' first, so this is the two-segment path pattern 'foo/*bar'. Backslash is NEVER an escape in this dialect.",
+      "note": "normalizes to 'foo/*bar'"
+    },
+
+    { "pattern": "", "usable": false, "problem": "empty", "note": "blank — agent skips; API strips rather than erroring" },
+    { "pattern": "   ", "usable": false, "problem": "empty", "note": "whitespace only" },
+    { "pattern": "/", "usable": false, "problem": "empty", "note": "separators only" },
+    { "pattern": "///", "usable": false, "problem": "empty", "note": "separators only" },
+    { "pattern": "\\", "usable": false, "problem": "empty", "note": "folds to '/', trims to empty" },
+    { "pattern": "  *.tmp  ", "usable": true, "problem": null, "note": "surrounding whitespace trimmed" },
+    { "pattern": "/var/log/**", "usable": true, "problem": null, "note": "leading '/' trimmed" }
+  ],
+
+  "matching": [
+    {
+      "note": "base-name pattern matches at any depth, files AND dirs",
+      "patterns": ["*.tmp"],
+      "relPath": "a/b/c/scratch.tmp",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "note": "base-name pattern matches a DIRECTORY named like the glob (walker then skips the subtree)",
+      "patterns": ["*.tmp"],
+      "relPath": "a/cache.tmp",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "note": "base-name pattern does not match a parent segment, only the base name",
+      "patterns": ["*.tmp"],
+      "relPath": "scratch.tmp/keep.txt",
+      "caseInsensitive": false,
+      "expected": false
+    },
+    {
+      "note": "'*' does not cross a separator",
+      "patterns": ["a*c"],
+      "relPath": "a/c",
+      "caseInsensitive": false,
+      "expected": false
+    },
+    {
+      "note": "'?' matches exactly one char",
+      "patterns": ["log?.txt"],
+      "relPath": "logs/log1.txt",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "note": "'?' does not match two chars",
+      "patterns": ["log?.txt"],
+      "relPath": "logs/log12.txt",
+      "caseInsensitive": false,
+      "expected": false
+    },
+
+    {
+      "divergence": "IMPLICIT LEADING '**/'. A bare doublestar/minimatch Match('node_modules/**', 'app/node_modules/react/index.js') is FALSE — the pattern is anchored at the root. The agent prepends '**/' so exclusions are gitignore-style and match at ANY depth. This is the single biggest semantic divergence from a stock glob library.",
+      "patterns": ["node_modules/**"],
+      "relPath": "app/node_modules/react/index.js",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "divergence": "'dir/**' matches the DIRECTORY ITSELF, not just its contents (doublestar historically required 'dir' or 'dir/**' separately). Matters: the walker needs the hit on the dir to skip the whole subtree.",
+      "patterns": ["node_modules/**"],
+      "relPath": "node_modules",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "note": "'dir/**' matches a nested occurrence of the directory itself",
+      "patterns": ["node_modules/**"],
+      "relPath": "app/node_modules",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "note": "leading doublestar spans any number of segments",
+      "patterns": ["**/AppData/Local/Temp/**"],
+      "relPath": "alice/AppData/Local/Temp/x.dat",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "note": "trailing '**' spans ZERO segments — matches the dir itself",
+      "patterns": ["**/AppData/Local/Temp/**"],
+      "relPath": "alice/AppData/Local/Temp",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "note": "path pattern must still match every literal segment",
+      "patterns": ["node_modules/**"],
+      "relPath": "app/node_modules_old/x.js",
+      "caseInsensitive": false,
+      "expected": false
+    },
+    {
+      "note": "multi-segment path pattern, non-matching middle segment",
+      "patterns": ["AppData/Local/Temp/**"],
+      "relPath": "alice/AppData/Roaming/Temp/x.dat",
+      "caseInsensitive": false,
+      "expected": false
+    },
+
+    {
+      "divergence": "'[!ab]' — path.Match reads '!' as a LITERAL class member, so this matches the file literally named '!x'. minimatch would read it as 'NOT a or b' and NOT match '!x'.",
+      "patterns": ["[!ab]x"],
+      "relPath": "dir/!x",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "divergence": "The same pattern under minimatch's negation semantics WOULD match 'cx' (c is not a or b). Under path.Match it does not — 'c' is not one of the literal class members {!, a, b}.",
+      "patterns": ["[!ab]x"],
+      "relPath": "dir/cx",
+      "caseInsensitive": false,
+      "expected": false
+    },
+    {
+      "note": "'^' IS the negation character in path.Match",
+      "patterns": ["[^ab]x"],
+      "relPath": "dir/cx",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "note": "'^' negation excludes the listed members",
+      "patterns": ["[^ab]x"],
+      "relPath": "dir/ax",
+      "caseInsensitive": false,
+      "expected": false
+    },
+    {
+      "divergence": "Reversed range never matches (but is NOT a syntax error — see validity[]).",
+      "patterns": ["[z-a].log"],
+      "relPath": "dir/m.log",
+      "caseInsensitive": false,
+      "expected": false
+    },
+
+    {
+      "divergence": "Backslash is folded to '/', NOT treated as an escape: 'foo\\*bar' behaves as the path pattern 'foo/*bar'.",
+      "patterns": ["foo\\*bar"],
+      "relPath": "x/foo/qbar",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "note": "Windows-style pattern folds to a path pattern and matches at any depth",
+      "patterns": ["AppData\\Local\\Temp"],
+      "relPath": "users/bob/AppData/Local/Temp",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "note": "trailing backslash normalizes to a plain base-name pattern",
+      "patterns": ["temp\\"],
+      "relPath": "a/temp",
+      "caseInsensitive": false,
+      "expected": true
+    },
+
+    {
+      "note": "case-SENSITIVE (linux/macos): pattern case must match",
+      "patterns": ["*.TMP"],
+      "relPath": "a/scratch.tmp",
+      "caseInsensitive": false,
+      "expected": false
+    },
+    {
+      "note": "case-INSENSITIVE (windows): pattern case is folded",
+      "patterns": ["*.TMP"],
+      "relPath": "a/scratch.tmp",
+      "caseInsensitive": true,
+      "expected": true
+    },
+    {
+      "note": "case-INSENSITIVE path pattern",
+      "patterns": ["AppData/Local/Temp/**"],
+      "relPath": "users/bob/appdata/local/temp/x.dat",
+      "caseInsensitive": true,
+      "expected": true
+    },
+
+    {
+      "note": "invalid patterns are DROPPED, not fatal — the valid sibling still applies",
+      "patterns": ["[a-z0-9_-].log", "*.tmp"],
+      "relPath": "a/scratch.tmp",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "note": "…and the dropped pattern excludes nothing (this is the bug #2473 makes visible at the API)",
+      "patterns": ["[a-z0-9_-].log"],
+      "relPath": "a/b.log",
+      "caseInsensitive": false,
+      "expected": false
+    },
+    {
+      "note": "no usable patterns at all -> nil matcher -> nothing excluded",
+      "patterns": ["", "   "],
+      "relPath": "a/b.log",
+      "caseInsensitive": false,
+      "expected": false
+    },
+    {
+      "note": "root itself is never excluded",
+      "patterns": ["**"],
+      "relPath": ".",
+      "caseInsensitive": false,
+      "expected": false
+    },
+    {
+      "note": "bare '**' has no slash, so it is a BASE-NAME glob — and a trailing star matches any base name",
+      "patterns": ["**"],
+      "relPath": "a/b.log",
+      "caseInsensitive": false,
+      "expected": true
+    },
+    {
+      "note": "leading '/' is trimmed, so an absolute-looking pattern still matches at any depth",
+      "patterns": ["/var/log/**"],
+      "relPath": "srv/var/log/syslog",
+      "caseInsensitive": false,
+      "expected": true
+    }
+  ]
+}

--- a/packages/shared/src/utils/backupExclusionGlob.test.ts
+++ b/packages/shared/src/utils/backupExclusionGlob.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  describeExclusionPattern,
+  normalizeExclusionPattern,
+  compileExcludeMatcher,
+  stripEmptyExclusionPatterns,
+  isUsableExclusionPattern,
+  goPathMatch,
+  MAX_EXCLUSION_PATTERN_LENGTH,
+} from './backupExclusionGlob';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The TS half of the cross-language contract (issue #2473).
+//
+// The Go half — agent/internal/backup/exclude_contract_test.go — replays this
+// SAME fixture file against the real agent matcher. Keeping both green is what
+// makes it safe for the API to reject a glob on the agent's behalf.
+//
+// If a case here fails, the port has drifted from the agent. Fix the port, not
+// the fixture.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ValidityCase {
+  pattern: string;
+  usable: boolean;
+  problem: 'empty' | 'syntax' | null;
+  note: string;
+  divergence?: string;
+}
+
+interface MatchingCase {
+  patterns: string[];
+  relPath: string;
+  caseInsensitive: boolean;
+  expected: boolean;
+  note: string;
+  divergence?: string;
+}
+
+const fixture = JSON.parse(
+  readFileSync(join(__dirname, '../fixtures/backup-exclusion-contract.json'), 'utf8'),
+) as { validity: ValidityCase[]; matching: MatchingCase[] };
+
+describe('backup exclusion glob — cross-language contract', () => {
+  it('the fixture is not empty (a vacuous contract test is worse than none)', () => {
+    expect(fixture.validity.length).toBeGreaterThan(20);
+    expect(fixture.matching.length).toBeGreaterThan(20);
+  });
+
+  describe('validity — does the agent compile this pattern, or silently drop it?', () => {
+    it.each(fixture.validity)('$pattern → usable=$usable ($note)', (tc) => {
+      const verdict = describeExclusionPattern(tc.pattern);
+      expect(verdict.usable).toBe(tc.usable);
+      expect(verdict.problem ?? null).toBe(tc.problem);
+      // Every rejection must carry an explanation — a bare "invalid" is what
+      // this issue exists to eliminate.
+      if (!verdict.usable) {
+        expect(verdict.message).toBeTruthy();
+      }
+    });
+  });
+
+  describe('matching — semantics, not just validity', () => {
+    it.each(fixture.matching)('$patterns vs $relPath → $expected ($note)', (tc) => {
+      const matcher = compileExcludeMatcher(tc.patterns, tc.caseInsensitive);
+      // A null matcher is the agent's nil matcher: "exclude nothing".
+      const got = matcher?.matches(tc.relPath) ?? false;
+      expect(got).toBe(tc.expected);
+    });
+  });
+
+  it('covers the dialect divergences that motivated the contract', () => {
+    // Guards against someone quietly deleting the interesting cases and leaving
+    // a contract that only pins the boring ones.
+    const divergences = [...fixture.validity, ...fixture.matching].filter((c) => c.divergence);
+    expect(divergences.length).toBeGreaterThanOrEqual(10);
+  });
+});
+
+describe('normalizeExclusionPattern', () => {
+  it('folds Windows separators BEFORE trimming, so a trailing backslash is not an escape', () => {
+    // Raw path.Match would call "temp\\" a trailing-escape syntax error.
+    expect(normalizeExclusionPattern('temp\\')).toBe('temp');
+    expect(normalizeExclusionPattern('AppData\\Local\\Temp')).toBe('AppData/Local/Temp');
+  });
+
+  it('trims whitespace and leading/trailing separators', () => {
+    expect(normalizeExclusionPattern('  /var/log/  ')).toBe('var/log');
+    expect(normalizeExclusionPattern('///')).toBe('');
+  });
+
+  it('never treats a backslash as an escape character', () => {
+    // The single most likely way a naive port diverges.
+    expect(normalizeExclusionPattern('foo\\*bar')).toBe('foo/*bar');
+  });
+});
+
+describe('describeExclusionPattern — conservative by design', () => {
+  it('accepts patterns that are merely unusual', () => {
+    // Over-strict validation breaks a working policy save. These are all legal
+    // to the agent, so they must be legal to us.
+    for (const p of ['[z-a]', '[!a-z].txt', '***', 'abc]', ']abc', '[α-ω].txt', '?']) {
+      expect(isUsableExclusionPattern(p), `${p} should be accepted`).toBe(true);
+    }
+  });
+
+  it('rejects the trailing-dash character class with an actionable message', () => {
+    // The headline case: valid in bash/minimatch, ErrBadPattern in Go.
+    const v = describeExclusionPattern('[a-z0-9_-].log');
+    expect(v.usable).toBe(false);
+    expect(v.problem).toBe('syntax');
+    expect(v.message).toMatch(/-/);
+    expect(v.message).toMatch(/class/i);
+  });
+
+  it('rejects an unclosed character class with an actionable message', () => {
+    const v = describeExclusionPattern('logs/[a-');
+    expect(v.usable).toBe(false);
+    expect(v.problem).toBe('syntax');
+    expect(v.message).toMatch(/unclosed/i);
+  });
+
+  it('rejects a class split across a separator (per-segment validation)', () => {
+    // Legal as one glob string; malformed once split on '/'. A whole-string
+    // validator would wrongly accept this.
+    expect(describeExclusionPattern('a[x/y]b').usable).toBe(false);
+  });
+
+  it('rejects an empty interior segment', () => {
+    expect(describeExclusionPattern('a//b').problem).toBe('syntax');
+  });
+
+  it('flags blank patterns as empty, not as a syntax error', () => {
+    // The API strips these rather than failing the save.
+    expect(describeExclusionPattern('   ').problem).toBe('empty');
+    expect(describeExclusionPattern('/').problem).toBe('empty');
+  });
+
+  it('enforces a length ceiling (API-only guard; the agent has none)', () => {
+    const long = `${'a'.repeat(MAX_EXCLUSION_PATTERN_LENGTH + 1)}`;
+    const v = describeExclusionPattern(long);
+    expect(v.usable).toBe(false);
+    expect(v.problem).toBe('too_long');
+    // Exactly at the limit is fine.
+    expect(isUsableExclusionPattern('a'.repeat(MAX_EXCLUSION_PATTERN_LENGTH))).toBe(true);
+  });
+});
+
+describe('stripEmptyExclusionPatterns', () => {
+  it('drops blank lines (a textarea artifact) without touching real patterns', () => {
+    expect(stripEmptyExclusionPatterns(['*.tmp', '', '  ', '\\', 'node_modules/**'])).toEqual([
+      '*.tmp',
+      'node_modules/**',
+    ]);
+  });
+
+  it('preserves the original (un-normalized) spelling of kept patterns', () => {
+    // The agent normalizes at compile time; we must not silently rewrite what
+    // the user typed and stored.
+    expect(stripEmptyExclusionPatterns(['  AppData\\Local  '])).toEqual(['  AppData\\Local  ']);
+  });
+});
+
+describe('goPathMatch — the ported Go primitive', () => {
+  it('reports ErrBadPattern independently of the name being matched', () => {
+    // This is the Go 1.16 property the whole validator leans on: it lets us
+    // probe validity with a dummy name.
+    for (const name of ['probe', '', 'a', 'zzz', 'anything.txt']) {
+      expect(goPathMatch('[a-', name).bad, `name=${name}`).toBe(true);
+      expect(goPathMatch('*.tmp', name).bad, `name=${name}`).toBe(false);
+    }
+  });
+
+  it('does not let * cross a separator', () => {
+    expect(goPathMatch('a*c', 'a/c').matched).toBe(false);
+  });
+
+  it('does not reject an inverted range', () => {
+    expect(goPathMatch('[z-a]', 'm')).toEqual({ matched: false, bad: false });
+  });
+});
+
+describe('shipped UI presets and suggestion chips', () => {
+  // If a preset the UI ships were rejected by this validator, EVERY policy save
+  // using that preset would fail — the exact over-strict catastrophe #2473 warns
+  // about. Kept in sync by hand with
+  // apps/web/src/components/configurationPolicies/featureTabs/backupTabPresets.ts.
+  const shipped = [
+    // windows preset
+    '**/AppData/Local/Temp/**',
+    '**/AppData/Local/Microsoft/Windows/INetCache/**',
+    '$RECYCLE.BIN/**',
+    'Thumbs.db',
+    '*.tmp',
+    // macos preset
+    '**/Library/Caches/**',
+    '**/.Trash/**',
+    '.DS_Store',
+    '**/Library/Application Support/MobileSync/Backup/**',
+    // linux preset
+    '**/.cache/**',
+    '**/.local/share/Trash/**',
+    // suggestion chips
+    '*.log',
+    '**/Dropbox/**',
+    '**/OneDrive*/**',
+    'node_modules/**',
+  ];
+
+  it.each(shipped)('accepts shipped pattern %s', (pattern) => {
+    expect(describeExclusionPattern(pattern).usable).toBe(true);
+  });
+
+  it('is a non-trivial list (guards against the array being emptied)', () => {
+    expect(shipped.length).toBeGreaterThanOrEqual(15);
+  });
+});

--- a/packages/shared/src/utils/backupExclusionGlob.test.ts
+++ b/packages/shared/src/utils/backupExclusionGlob.test.ts
@@ -5,7 +5,7 @@ import {
   describeExclusionPattern,
   normalizeExclusionPattern,
   compileExcludeMatcher,
-  stripEmptyExclusionPatterns,
+  sanitizeExclusionPatterns,
   isUsableExclusionPattern,
   goPathMatch,
   MAX_EXCLUSION_PATTERN_LENGTH,
@@ -39,9 +39,22 @@ interface MatchingCase {
   divergence?: string;
 }
 
+interface PortLimitationCase {
+  patterns: string[];
+  relPath: string;
+  caseInsensitive: boolean;
+  go: boolean;
+  tsPort: boolean;
+  note: string;
+}
+
 const fixture = JSON.parse(
   readFileSync(join(__dirname, '../fixtures/backup-exclusion-contract.json'), 'utf8'),
-) as { validity: ValidityCase[]; matching: MatchingCase[] };
+) as {
+  validity: ValidityCase[];
+  matching: MatchingCase[];
+  matcherPortLimitations: PortLimitationCase[];
+};
 
 describe('backup exclusion glob — cross-language contract', () => {
   it('the fixture is not empty (a vacuous contract test is worse than none)', () => {
@@ -68,6 +81,29 @@ describe('backup exclusion glob — cross-language contract', () => {
       // A null matcher is the agent's nil matcher: "exclude nothing".
       const got = matcher?.matches(tc.relPath) ?? false;
       expect(got).toBe(tc.expected);
+    });
+  });
+
+  describe('KNOWN matcher-port limitations (deliberate, documented)', () => {
+    // The TS matcher is code-point based; Go's path.Match advances the name by
+    // BYTES and lowercases with simple (not full Unicode) mapping. These cases
+    // pin exactly where the port disagrees, so the boundary cannot silently
+    // widen — and so nobody mistakes the matcher for exact.
+    //
+    // The Go suite asserts the other half (that the agent really behaves this
+    // way). If the port is ever made byte-faithful, these move into matching[].
+    //
+    // This is a limitation of the MATCHER only. describeExclusionPattern — the
+    // validator that actually gates an API save — is exhaustively exact.
+    it.each(fixture.matcherPortLimitations)('$relPath — $note', (tc) => {
+      const matcher = compileExcludeMatcher(tc.patterns, tc.caseInsensitive);
+      const got = matcher?.matches(tc.relPath) ?? false;
+      expect(got).toBe(tc.tsPort);
+      expect(tc.tsPort).not.toBe(tc.go); // must genuinely still be a divergence
+    });
+
+    it('is not empty (if the port became exact, fold these into matching[])', () => {
+      expect(fixture.matcherPortLimitations.length).toBeGreaterThan(0);
     });
   });
 
@@ -148,18 +184,18 @@ describe('describeExclusionPattern — conservative by design', () => {
   });
 });
 
-describe('stripEmptyExclusionPatterns', () => {
+describe('sanitizeExclusionPatterns', () => {
   it('drops blank lines (a textarea artifact) without touching real patterns', () => {
-    expect(stripEmptyExclusionPatterns(['*.tmp', '', '  ', '\\', 'node_modules/**'])).toEqual([
+    expect(sanitizeExclusionPatterns(['*.tmp', '', '  ', '\\', 'node_modules/**'])).toEqual([
       '*.tmp',
       'node_modules/**',
     ]);
   });
 
-  it('preserves the original (un-normalized) spelling of kept patterns', () => {
-    // The agent normalizes at compile time; we must not silently rewrite what
-    // the user typed and stored.
-    expect(stripEmptyExclusionPatterns(['  AppData\\Local  '])).toEqual(['  AppData\\Local  ']);
+  it('trims, but does NOT otherwise rewrite what the user typed', () => {
+    // Trimming is lossless (the agent trims too). Folding '\\' to '/' would not
+    // be: it would visibly change the pattern on round-trip.
+    expect(sanitizeExclusionPatterns(['  AppData\\Local  '])).toEqual(['AppData\\Local']);
   });
 });
 
@@ -179,41 +215,5 @@ describe('goPathMatch — the ported Go primitive', () => {
 
   it('does not reject an inverted range', () => {
     expect(goPathMatch('[z-a]', 'm')).toEqual({ matched: false, bad: false });
-  });
-});
-
-describe('shipped UI presets and suggestion chips', () => {
-  // If a preset the UI ships were rejected by this validator, EVERY policy save
-  // using that preset would fail — the exact over-strict catastrophe #2473 warns
-  // about. Kept in sync by hand with
-  // apps/web/src/components/configurationPolicies/featureTabs/backupTabPresets.ts.
-  const shipped = [
-    // windows preset
-    '**/AppData/Local/Temp/**',
-    '**/AppData/Local/Microsoft/Windows/INetCache/**',
-    '$RECYCLE.BIN/**',
-    'Thumbs.db',
-    '*.tmp',
-    // macos preset
-    '**/Library/Caches/**',
-    '**/.Trash/**',
-    '.DS_Store',
-    '**/Library/Application Support/MobileSync/Backup/**',
-    // linux preset
-    '**/.cache/**',
-    '**/.local/share/Trash/**',
-    // suggestion chips
-    '*.log',
-    '**/Dropbox/**',
-    '**/OneDrive*/**',
-    'node_modules/**',
-  ];
-
-  it.each(shipped)('accepts shipped pattern %s', (pattern) => {
-    expect(describeExclusionPattern(pattern).usable).toBe(true);
-  });
-
-  it('is a non-trivial list (guards against the array being emptied)', () => {
-    expect(shipped.length).toBeGreaterThanOrEqual(15);
   });
 });

--- a/packages/shared/src/utils/backupExclusionGlob.ts
+++ b/packages/shared/src/utils/backupExclusionGlob.ts
@@ -389,20 +389,42 @@ export function isUsableExclusionPattern(raw: string): boolean {
 }
 
 /**
- * Drop the patterns the agent would drop anyway (blank lines from a textarea).
+ * Clean a pattern list for storage: trim each entry, then drop the ones that
+ * normalize away to nothing (blank lines from a textarea).
  *
- * The API strips these instead of rejecting them: a blank pattern excludes
- * nothing, so rejecting it would fail a save over an artifact of how the UI
- * splits input — the exact over-strict failure this feature must avoid.
+ * Blanks are STRIPPED rather than rejected: a blank pattern excludes nothing, so
+ * failing a save over an artifact of how the UI splits input would be the exact
+ * over-strict regression this feature must avoid.
+ *
+ * Trimming only — deliberately NOT full normalization. The agent trims anyway,
+ * so this is semantically lossless, whereas folding `\` to `/` would visibly
+ * rewrite what the user typed (`AppData\Local` would round-trip as
+ * `AppData/Local`).
  */
-export function stripEmptyExclusionPatterns(patterns: string[]): string[] {
-  return patterns.filter((p) => normalizeExclusionPattern(p) !== '');
+export function sanitizeExclusionPatterns(patterns: string[]): string[] {
+  return patterns
+    .map((p) => p.trim())
+    .filter((p) => normalizeExclusionPattern(p) !== '');
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// The matcher itself. Not used for validation — this exists so the contract
-// fixtures can assert MATCH SEMANTICS (not just validity) against real Go, and
-// so the UI can eventually preview "what would this exclude?".
+// The matcher itself. NOT on the validation path, and NOT exported from the
+// package barrel. It exists so the contract fixtures can assert MATCH SEMANTICS
+// (not just validity) against real Go — which is what pins `**` spans, base-name
+// behavior, and the `!`-is-literal rule.
+//
+// ⚠️ KNOWN FIDELITY BOUNDARY — do not build a "what would this exclude?" preview
+// on this. Go's path.Match advances the NAME by bytes in its star loop (so `*??`
+// matches a 3-byte rune), and Go's strings.ToLower uses simple rather than full
+// Unicode case mapping (so `İ` folds to one rune, not two). This code-point port
+// reproduces neither, and knowingly disagrees with the agent on CJK/emoji
+// filenames and Turkish `İ`. Those divergences are enumerated and asserted in
+// `matcherPortLimitations` (backup-exclusion-contract.json) so they cannot widen
+// unnoticed. Making it exact means porting over UTF-8 bytes + Go's case tables.
+//
+// The VALIDATOR above (`describeExclusionPattern`) has no such caveat: it was
+// differentially fuzzed against the real Go matcher over 177k+ patterns with
+// zero divergences, and it is the only thing that gates an API save.
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface ExcludeMatcher {

--- a/packages/shared/src/utils/backupExclusionGlob.ts
+++ b/packages/shared/src/utils/backupExclusionGlob.ts
@@ -1,0 +1,502 @@
+/**
+ * Backup file-mode exclusion-glob dialect — the TS side of a two-sided contract.
+ *
+ * The Go agent decides what a backup exclusion pattern means
+ * (`agent/internal/backup/exclude.go`). This module mirrors that decision so the
+ * API can reject a pattern the agent would silently drop, BEFORE it is persisted
+ * and shipped to the fleet.
+ *
+ * ## The dialect is NOT `doublestar`
+ *
+ * Despite the `**` support, the agent does not use the `bmatcuk/doublestar`
+ * library. It hand-rolls a segment walker over Go's **stdlib `path.Match`**, so
+ * the real grammar is `path.Match`'s — which differs from `doublestar`,
+ * `minimatch`, and bash in ways that matter (see BACKUP_EXCLUSION_CONTRACT
+ * fixtures). Validating with `minimatch` would be wrong in both directions.
+ *
+ * Two rules follow from the agent's normalization order, and a naive port gets
+ * both wrong:
+ *
+ *  1. **Backslash is never an escape.** `path.Match` treats `\` as an escape
+ *     character, but the agent rewrites every `\` to `/` *before* matching
+ *     (so Windows-style `AppData\Local` works). By the time `path.Match` sees a
+ *     pattern there are no backslashes left. `foo\*bar` is a two-segment path
+ *     pattern, not an escaped star.
+ *  2. **Slash patterns are validated per segment, not as a whole string.** The
+ *     agent splits on `/` and calls `path.Match` on each segment, so `a[x/y]b`
+ *     — a legal glob as one string — splits into the malformed segments `a[x`
+ *     and `y]b` and is rejected.
+ *
+ * ## Conservative by construction
+ *
+ * `describeExclusionPattern` reports a pattern invalid **only** when the agent's
+ * own matcher would refuse to compile it. Reversed ranges (`[z-a]`), `[!...]`
+ * (literal `!` in `path.Match`, not a negation), and other merely-unusual
+ * patterns are reported valid, because the agent accepts them. Over-strict
+ * validation would break a working policy save; that is the worse failure.
+ *
+ * Anything exported here is pinned by `backup-exclusion-contract.json`, which is
+ * replayed against the REAL agent matcher in
+ * `agent/internal/backup/exclude_contract_test.go`. If the two dialects ever
+ * drift apart, that Go test and `backupExclusionGlob.test.ts` both go red.
+ */
+
+/** Longest pattern we accept. Guards the O(segments) matcher from silly input. */
+export const MAX_EXCLUSION_PATTERN_LENGTH = 512;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Faithful port of Go's stdlib `path.Match` (go/src/path/match.go).
+//
+// Ported literally, including the Go 1.16 fix that makes ErrBadPattern
+// independent of the name being matched (the trailing "validate the remainder of
+// the pattern" loop). That independence is what lets the agent — and us — probe
+// validity with a fixed dummy name.
+//
+// Operates on code points (Array.from) because Go's getEsc decodes runes: the
+// range `[α-ω]` must compare whole runes, not UTF-16 code units.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ErrBadPattern sentinel. `bad` means "syntax error", not "did not match". */
+interface MatchResult {
+  matched: boolean;
+  bad: boolean;
+}
+
+interface ChunkResult {
+  rest: string[];
+  ok: boolean;
+  bad: boolean;
+}
+
+interface EscResult {
+  r: string;
+  nchunk: string[];
+  bad: boolean;
+}
+
+const BAD_ESC: EscResult = { r: '', nchunk: [], bad: true };
+const BAD_CHUNK: ChunkResult = { rest: [], ok: false, bad: true };
+
+function codePoints(s: string): string[] {
+  return Array.from(s);
+}
+
+function ord(c: string): number {
+  return c.codePointAt(0) ?? -1;
+}
+
+/** Go: getEsc — reads one (possibly escaped) rune of a character class. */
+function getEsc(chunk: string[]): EscResult {
+  if (chunk.length === 0 || chunk[0] === '-' || chunk[0] === ']') {
+    return BAD_ESC;
+  }
+  let rest = chunk;
+  if (rest[0] === '\\') {
+    rest = rest.slice(1);
+    if (rest.length === 0) return BAD_ESC;
+  }
+  const r = rest[0]!; // guarded: rest is non-empty here
+  const nchunk = rest.slice(1);
+  // Go errors when the class has no room left for its closing ']'.
+  if (nchunk.length === 0) return BAD_ESC;
+  return { r, nchunk, bad: false };
+}
+
+/** Go: scanChunk — splits off the leading '*'s and the next literal chunk. */
+function scanChunk(pattern: string[]): { star: boolean; chunk: string[]; rest: string[] } {
+  let p = pattern;
+  let star = false;
+  while (p.length > 0 && p[0] === '*') {
+    p = p.slice(1);
+    star = true;
+  }
+  let inrange = false;
+  let i = 0;
+  for (i = 0; i < p.length; i++) {
+    const ch = p[i];
+    if (ch === '\\') {
+      if (i + 1 < p.length) i++;
+    } else if (ch === '[') {
+      inrange = true;
+    } else if (ch === ']') {
+      inrange = false;
+    } else if (ch === '*') {
+      if (!inrange) break;
+    }
+  }
+  return { star, chunk: p.slice(0, i), rest: p.slice(i) };
+}
+
+/** Go: matchChunk — matches a star-free chunk, still parsing after a mismatch. */
+function matchChunk(chunkIn: string[], sIn: string[]): ChunkResult {
+  let chunk = chunkIn;
+  let s = sIn;
+  // Go: "After the match fails, the loop continues on processing chunk,
+  // checking that the pattern is well-formed but no longer reading s."
+  let failed = false;
+
+  while (chunk.length > 0) {
+    if (!failed && s.length === 0) failed = true;
+
+    if (chunk[0] === '[') {
+      let r = '';
+      if (!failed) {
+        // !failed implies s is non-empty (the guard at the top of the loop).
+        r = s[0]!;
+        s = s.slice(1);
+      }
+      chunk = chunk.slice(1);
+      let negated = false;
+      if (chunk.length > 0 && chunk[0] === '^') {
+        negated = true;
+        chunk = chunk.slice(1);
+      }
+      let match = false;
+      let nrange = 0;
+      for (;;) {
+        if (chunk.length > 0 && chunk[0] === ']' && nrange > 0) {
+          chunk = chunk.slice(1);
+          break;
+        }
+        const lo = getEsc(chunk);
+        if (lo.bad) return BAD_CHUNK;
+        chunk = lo.nchunk;
+        let hi = lo.r;
+        // getEsc guarantees a non-empty remainder, so chunk[0] is safe here.
+        if (chunk[0] === '-') {
+          const h = getEsc(chunk.slice(1));
+          if (h.bad) return BAD_CHUNK;
+          hi = h.r;
+          chunk = h.nchunk;
+        }
+        // NOTE: Go does NOT reject an inverted range (`[z-a]`); it simply never
+        // matches. We must not reject it either.
+        if (!failed && ord(lo.r) <= ord(r) && ord(r) <= ord(hi)) match = true;
+        nrange++;
+      }
+      if (match === negated) failed = true;
+      continue;
+    }
+
+    if (chunk[0] === '?') {
+      if (!failed) {
+        if (s[0] === '/') failed = true;
+        else s = s.slice(1);
+      }
+      chunk = chunk.slice(1);
+      continue;
+    }
+
+    if (chunk[0] === '\\') {
+      chunk = chunk.slice(1);
+      if (chunk.length === 0) return BAD_CHUNK;
+      // Go falls through to the literal case.
+    }
+
+    if (!failed) {
+      if (chunk[0] !== s[0]) failed = true;
+      else s = s.slice(1);
+    }
+    chunk = chunk.slice(1);
+  }
+
+  if (failed) return { rest: [], ok: false, bad: false };
+  return { rest: s, ok: true, bad: false };
+}
+
+/**
+ * Go `path.Match`. `bad: true` is Go's ErrBadPattern.
+ *
+ * Exported for the contract test — application code should use
+ * `describeExclusionPattern` / `compileExcludeMatcher`.
+ */
+export function goPathMatch(pattern: string, name: string): MatchResult {
+  let pat = codePoints(pattern);
+  let nm = codePoints(name);
+
+  while (pat.length > 0) {
+    const { star, chunk, rest } = scanChunk(pat);
+    pat = rest;
+
+    if (star && chunk.length === 0) {
+      // Trailing '*' matches the rest of the name unless it contains a '/'.
+      return { matched: !nm.includes('/'), bad: false };
+    }
+
+    const mc = matchChunk(chunk, nm);
+    if (mc.bad) return { matched: false, bad: true };
+    if (mc.ok && (mc.rest.length === 0 || pat.length > 0)) {
+      nm = mc.rest;
+      continue;
+    }
+
+    if (star) {
+      let advanced = false;
+      for (let i = 0; i < nm.length && nm[i] !== '/'; i++) {
+        const m2 = matchChunk(chunk, nm.slice(i + 1));
+        if (m2.bad) return { matched: false, bad: true };
+        if (m2.ok) {
+          if (pat.length === 0 && m2.rest.length > 0) continue;
+          nm = m2.rest;
+          advanced = true;
+          break;
+        }
+      }
+      if (advanced) continue;
+    }
+
+    // Go 1.16+: before returning "no match", still prove the remainder parses.
+    // This is what makes ErrBadPattern name-independent.
+    while (pat.length > 0) {
+      const sc = scanChunk(pat);
+      pat = sc.rest;
+      const m3 = matchChunk(sc.chunk, []);
+      if (m3.bad) return { matched: false, bad: true };
+    }
+    return { matched: false, bad: false };
+  }
+
+  return { matched: nm.length === 0, bad: false };
+}
+
+/** Is `segment` a syntactically legal single-segment `path.Match` glob? */
+function isValidGlobSegment(segment: string): boolean {
+  // ErrBadPattern is name-independent (Go 1.16+), so a fixed probe is
+  // exhaustive — the same trick the agent uses.
+  return !goPathMatch(segment, 'probe').bad;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Port of the agent's excludeMatcher (agent/internal/backup/exclude.go)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The agent's pattern normalization, exactly: trim whitespace, fold Windows
+ * separators to '/', then strip leading/trailing '/'.
+ *
+ * Order matters. Folding before trimming '/' is why a trailing backslash
+ * (`temp\`) is a harmless trailing separator rather than Go's "trailing escape"
+ * syntax error.
+ */
+export function normalizeExclusionPattern(raw: string): string {
+  const folded = raw.trim().replaceAll('\\', '/');
+  // Strip leading and trailing '/' (Go: strings.Trim(p, "/")).
+  return folded.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+/** Why the agent would not use a pattern. */
+export type ExclusionPatternProblem =
+  | 'empty' // normalizes away to nothing — agent skips it silently
+  | 'too_long' // API-only guard; the agent has no length limit
+  | 'syntax'; // agent logs "ignoring invalid exclusion pattern" and drops it
+
+export interface ExclusionPatternVerdict {
+  /** Normalized form the agent would actually compile. */
+  normalized: string;
+  /** True when the agent would compile and use this pattern. */
+  usable: boolean;
+  problem?: ExclusionPatternProblem;
+  /** Human-facing explanation. Only set when `usable` is false. */
+  message?: string;
+}
+
+/**
+ * Decide whether the agent would compile this pattern, or silently drop it.
+ *
+ * This is the single source of truth for API-boundary validation. It is
+ * deliberately permissive: it only reports `syntax` for patterns the agent's own
+ * `path.Match` call rejects.
+ */
+export function describeExclusionPattern(raw: string): ExclusionPatternVerdict {
+  const normalized = normalizeExclusionPattern(raw);
+
+  if (normalized === '') {
+    return {
+      normalized,
+      usable: false,
+      problem: 'empty',
+      message: 'Pattern is empty.',
+    };
+  }
+
+  if (normalized.length > MAX_EXCLUSION_PATTERN_LENGTH) {
+    return {
+      normalized,
+      usable: false,
+      problem: 'too_long',
+      message: `Pattern is longer than ${MAX_EXCLUSION_PATTERN_LENGTH} characters.`,
+    };
+  }
+
+  // Slash patterns are validated per segment — mirroring the agent, which
+  // matches them per segment. `a[x/y]b` is a legal one-string glob but splits
+  // into the malformed segments `a[x` and `y]b`.
+  const segments = normalized.includes('/') ? normalized.split('/') : [normalized];
+
+  for (const segment of segments) {
+    if (segment === '**') continue; // doublestar spans segments; not a glob itself
+    if (segment === '') {
+      // Interior empty segment from `a//b`. Cannot ever match a real path
+      // segment, so the agent rejects the whole pattern.
+      return {
+        normalized,
+        usable: false,
+        problem: 'syntax',
+        message: 'Pattern contains an empty path segment (e.g. "a//b").',
+      };
+    }
+    if (!isValidGlobSegment(segment)) {
+      return {
+        normalized,
+        usable: false,
+        problem: 'syntax',
+        message: describeSegmentSyntaxError(segment),
+      };
+    }
+  }
+
+  return { normalized, usable: true };
+}
+
+/**
+ * Best-effort explanation of WHY a segment failed to parse.
+ *
+ * Purely cosmetic — the accept/reject decision above is made by the ported
+ * matcher, never by these heuristics. The goal is that a tech pasting
+ * `[a-z0-9_-].log` gets told about the trailing dash instead of "syntax error".
+ */
+function describeSegmentSyntaxError(segment: string): string {
+  const quoted = `"${segment}"`;
+
+  // Unclosed '[' is by far the most common mistake.
+  if (segment.includes('[') && !segment.includes(']')) {
+    return `Unclosed character class in ${quoted} — add a closing "]" or escape the "[".`;
+  }
+  if (/\[\^?\]/.test(segment)) {
+    return `Empty character class in ${quoted} — a "[...]" class must list at least one character.`;
+  }
+  // The classic: bash/minimatch allow a leading or trailing '-' to mean a
+  // literal dash. Go's path.Match does not.
+  if (/\[\^?-/.test(segment) || /-\]/.test(segment)) {
+    return `Character class in ${quoted} has a leading or trailing "-". This backup matcher does not allow a literal dash there — move it into the middle of the class or drop it (e.g. "[a-z0-9_]").`;
+  }
+  return `Invalid glob syntax in ${quoted}.`;
+}
+
+/** Convenience predicate used by the zod refinements. */
+export function isUsableExclusionPattern(raw: string): boolean {
+  return describeExclusionPattern(raw).usable;
+}
+
+/**
+ * Drop the patterns the agent would drop anyway (blank lines from a textarea).
+ *
+ * The API strips these instead of rejecting them: a blank pattern excludes
+ * nothing, so rejecting it would fail a save over an artifact of how the UI
+ * splits input — the exact over-strict failure this feature must avoid.
+ */
+export function stripEmptyExclusionPatterns(patterns: string[]): string[] {
+  return patterns.filter((p) => normalizeExclusionPattern(p) !== '');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The matcher itself. Not used for validation — this exists so the contract
+// fixtures can assert MATCH SEMANTICS (not just validity) against real Go, and
+// so the UI can eventually preview "what would this exclude?".
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ExcludeMatcher {
+  matches(relPath: string): boolean;
+}
+
+/**
+ * Go: path.Base. Differs from "last element of split" on a trailing slash —
+ * path.Base("a/") is "a", not "". Mirrored so the two matchers cannot drift.
+ */
+function goPathBase(p: string): string {
+  if (p === '') return '.';
+  let s = p.replace(/\/+$/, '');
+  if (s === '') return '/';
+  const i = s.lastIndexOf('/');
+  if (i >= 0) s = s.slice(i + 1);
+  return s === '' ? '/' : s;
+}
+
+/** Go: matchSegments — '**' spans zero or more path segments. */
+function matchSegments(pattern: string[], segs: string[]): boolean {
+  let pat = pattern;
+  let rest = segs;
+  while (pat.length > 0) {
+    if (pat[0] === '**') {
+      while (pat.length > 0 && pat[0] === '**') pat = pat.slice(1);
+      if (pat.length === 0) return true; // trailing '**' matches everything
+      for (let i = 0; i <= rest.length; i++) {
+        if (matchSegments(pat, rest.slice(i))) return true;
+      }
+      return false;
+    }
+    if (rest.length === 0) return false;
+    const m = goPathMatch(pat[0]!, rest[0]!); // both guarded non-empty above
+    if (m.bad || !m.matched) return false;
+    pat = pat.slice(1);
+    rest = rest.slice(1);
+  }
+  return rest.length === 0;
+}
+
+/**
+ * Compile exclusion patterns the way the agent does.
+ *
+ * Returns `null` when no usable pattern remains — the agent's nil matcher,
+ * meaning "exclude nothing". Invalid patterns are DROPPED here, not thrown, to
+ * mirror the agent (which logs and continues rather than failing the backup).
+ *
+ * @param caseInsensitive Agent passes `runtime.GOOS == "windows"`.
+ */
+export function compileExcludeMatcher(
+  patterns: string[],
+  caseInsensitive: boolean,
+): ExcludeMatcher | null {
+  const baseName: string[] = [];
+  const relPath: string[][] = [];
+
+  for (const raw of patterns) {
+    let p = normalizeExclusionPattern(raw);
+    if (p === '') continue;
+    if (caseInsensitive) p = p.toLowerCase();
+
+    if (p.includes('/')) {
+      const segs = p.split('/');
+      if (!segs.every((s) => s === '**' || (s !== '' && isValidGlobSegment(s)))) {
+        continue; // agent logs + skips
+      }
+      // Implicit leading '**/' — patterns match at any depth (gitignore-style).
+      relPath.push(['**', ...segs]);
+    } else {
+      if (!isValidGlobSegment(p)) continue;
+      baseName.push(p);
+    }
+  }
+
+  if (baseName.length === 0 && relPath.length === 0) return null;
+
+  return {
+    matches(relPathIn: string): boolean {
+      if (relPathIn === '' || relPathIn === '.') return false;
+      let rel = relPathIn.replaceAll('\\', '/');
+      if (caseInsensitive) rel = rel.toLowerCase();
+
+      const segs = rel.split('/');
+      const base = goPathBase(rel);
+      for (const p of baseName) {
+        if (goPathMatch(p, base).matched) return true;
+      }
+
+      if (relPath.length === 0) return false;
+      for (const patSegs of relPath) {
+        if (matchSegments(patSegs, segs)) return true;
+      }
+      return false;
+    },
+  };
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -9,4 +9,18 @@ export * from './depositMath';
 export * from './csvExport';
 export * from './reportSchedule';
 export * from './s3Region';
-export * from './backupExclusionGlob';
+// Deliberately NOT `export *`. `compileExcludeMatcher` is a code-point port of
+// the agent's matcher and knowingly diverges from Go on mid-rune byte offsets
+// and Unicode special-casing (see matcherPortLimitations in
+// backup-exclusion-contract.json), so it must not become a public API that
+// someone builds a "what would this exclude?" preview on. The VALIDATOR is
+// exact and is what callers should use.
+export {
+  describeExclusionPattern,
+  isUsableExclusionPattern,
+  sanitizeExclusionPatterns,
+  normalizeExclusionPattern,
+  MAX_EXCLUSION_PATTERN_LENGTH,
+  type ExclusionPatternVerdict,
+  type ExclusionPatternProblem,
+} from './backupExclusionGlob';

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -9,3 +9,4 @@ export * from './depositMath';
 export * from './csvExport';
 export * from './reportSchedule';
 export * from './s3Region';
+export * from './backupExclusionGlob';

--- a/packages/shared/src/validators/backupTargets.test.ts
+++ b/packages/shared/src/validators/backupTargets.test.ts
@@ -318,3 +318,87 @@ describe('updateBackupProfileSchema', () => {
     expect(result.success).toBe(false);
   });
 });
+
+// ── Exclusion-glob validation at the API boundary (#2473) ───────────────────
+//
+// The dialect itself is pinned by the cross-language contract in
+// utils/backupExclusionGlob.test.ts (+ the Go half). These tests only assert
+// the WIRING: that both entry points reject what the agent would drop, strip
+// blank lines, and leave the optional/[] distinction intact.
+
+describe('backup exclusion glob validation (#2473)', () => {
+  describe('fileTargetsSchema.excludes', () => {
+    it('accepts the OS-preset patterns shipped by the UI', () => {
+      const result = fileTargetsSchema.safeParse({
+        paths: ['/data'],
+        excludes: ['*.tmp', 'Thumbs.db', 'node_modules/**', '**/AppData/Local/Temp/**'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a glob the agent would silently ignore', () => {
+      // Valid in bash/minimatch; ErrBadPattern in the agent's path.Match dialect.
+      const result = fileTargetsSchema.safeParse({
+        paths: ['/data'],
+        excludes: ['[a-z0-9_-].log'],
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0]?.path).toEqual(['excludes', 0]);
+      expect(result.error?.issues[0]?.message).toMatch(/silently exclude nothing/);
+    });
+
+    it('points at the offending index, not the whole array', () => {
+      const result = fileTargetsSchema.safeParse({
+        paths: ['/data'],
+        excludes: ['*.tmp', 'node_modules/**', 'logs/[a-'],
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0]?.path).toEqual(['excludes', 2]);
+    });
+
+    it('strips blank entries instead of failing the save', () => {
+      // A textarea split on newlines produces these. Rejecting them would be an
+      // over-strict regression that breaks a working configuration.
+      const result = fileTargetsSchema.safeParse({
+        paths: ['/data'],
+        excludes: ['*.tmp', '', '   ', 'node_modules/**'],
+      });
+      expect(result.success).toBe(true);
+      expect(result.data?.excludes).toEqual(['*.tmp', 'node_modules/**']);
+    });
+
+    it('accepts merely-unusual patterns the agent accepts', () => {
+      // Over-strict validation is the worse failure mode: these all compile in
+      // the agent, so blocking them would break a save that works today.
+      const result = fileTargetsSchema.safeParse({
+        paths: ['/data'],
+        excludes: ['[z-a]', '[!a-z].txt', 'AppData\\Local\\Temp', 'temp\\'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('keeps omitted distinct from empty', () => {
+      // undefined = fall back to agent-local excludes; [] = no exclusions.
+      expect(fileTargetsSchema.safeParse({ paths: ['/d'] }).data?.excludes).toBeUndefined();
+      expect(fileTargetsSchema.safeParse({ paths: ['/d'], excludes: [] }).data?.excludes).toEqual([]);
+    });
+  });
+
+  describe('backupProfileSelectionsSchema.file.excludes', () => {
+    it('rejects a malformed glob on a profile', () => {
+      const result = backupProfileSelectionsSchema.safeParse({
+        file: { enabled: true, paths: ['C:\\Users'], excludes: ['a[x/y]b'] },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0]?.path).toEqual(['file', 'excludes', 0]);
+    });
+
+    it('strips blank entries on a profile too', () => {
+      const result = backupProfileSelectionsSchema.safeParse({
+        file: { enabled: true, paths: ['C:\\Users'], excludes: ['*.tmp', ''] },
+      });
+      expect(result.success).toBe(true);
+      expect(result.data?.file?.excludes).toEqual(['*.tmp']);
+    });
+  });
+});

--- a/packages/shared/src/validators/backupTargets.test.ts
+++ b/packages/shared/src/validators/backupTargets.test.ts
@@ -402,3 +402,89 @@ describe('backup exclusion glob validation (#2473)', () => {
     });
   });
 });
+
+// Regressions caught in review of #2473.
+describe('backup exclusion glob — review regressions', () => {
+  it('reports the index in the USER-SUPPLIED array, not the blank-stripped one', () => {
+    // Blanks are stripped by a transform. If validation ran after the strip, the
+    // bad pattern below (raw index 2) would be reported at index 0, and a UI
+    // mapping the issue back to a textarea row would highlight the wrong line.
+    const result = fileTargetsSchema.safeParse({
+      paths: ['/data'],
+      excludes: ['', '  ', '[a-z0-9_-].log', '*.tmp'],
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['excludes', 2]);
+  });
+
+  it('does not claim the agent would ignore an over-length pattern', () => {
+    // The length cap is an API-side guard; the agent has no length limit. Saying
+    // "the agent would ignore this" would be false.
+    const result = fileTargetsSchema.safeParse({
+      paths: ['/data'],
+      excludes: ['a'.repeat(600)],
+    });
+    expect(result.success).toBe(false);
+    const msg = result.error?.issues[0]?.message ?? '';
+    expect(msg).toMatch(/longer than/i);
+    expect(msg).not.toMatch(/silently exclude nothing/);
+  });
+
+  it('does not impose a new count cap on legacy inline-settings excludes', () => {
+    // This field has always been uncapped. Adding a cap would fail the save for
+    // an existing policy that exceeds it — the over-strict regression #2473 warns
+    // about. (Profiles keep the .max(64) they shipped with in #2417.)
+    const many = Array.from({ length: 200 }, (_, i) => `*.tmp${i}`);
+    expect(fileTargetsSchema.safeParse({ paths: ['/d'], excludes: many }).success).toBe(true);
+    expect(
+      backupProfileSelectionsSchema.safeParse({
+        file: { enabled: true, paths: ['C:\\Users'], excludes: many },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('trims stored profile patterns (preserving the pre-#2473 .trim() behavior)', () => {
+    const result = backupProfileSelectionsSchema.safeParse({
+      file: { enabled: true, paths: ['C:\\Users'], excludes: ['  *.tmp  '] },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.file?.excludes).toEqual(['*.tmp']);
+  });
+});
+
+describe('legacy configurations carrying a dead glob (#2473)', () => {
+  // A policy saved BEFORE this change can hold a malformed glob — that population
+  // is precisely what the issue says exists, because techs typed these and the
+  // agent silently dropped them.
+  //
+  // Such a policy now FAILS to save on the next edit, even if the tech only
+  // touched the schedule (BackupTab re-submits the whole inlineSettings blob).
+  // That is intentional: the pattern was already excluding nothing, and the
+  // alternative is to keep pretending it works. This test exists so the behavior
+  // is a recorded decision rather than a production surprise — and so the error
+  // is legible enough for the tech to fix.
+  it('fails the save, pointing at the exact offending pattern', () => {
+    const legacy = {
+      backupMode: 'file',
+      paths: ['/data'],
+      schedule: { frequency: 'daily', time: '03:00' },
+      targets: { paths: ['/data'], excludes: ['*.tmp', '[a-z0-9_-].log'] },
+    };
+    const result = backupInlineSettingsSchema.safeParse(legacy);
+    expect(result.success).toBe(false);
+    // Must point at the row, not the whole blob, so a UI can highlight it.
+    expect(result.error?.issues[0]?.path).toEqual(['targets', 'excludes', 1]);
+    // Must be actionable: name the real problem, not "invalid pattern".
+    expect(result.error?.issues[0]?.message).toMatch(/dash/i);
+  });
+
+  it('a legacy policy whose globs are all valid still saves untouched', () => {
+    const legacy = {
+      backupMode: 'file',
+      paths: ['/data'],
+      schedule: { frequency: 'daily', time: '03:00' },
+      targets: { paths: ['/data'], excludes: ['*.tmp', 'node_modules/**'] },
+    };
+    expect(backupInlineSettingsSchema.safeParse(legacy).success).toBe(true);
+  });
+});

--- a/packages/shared/src/validators/backupTargets.ts
+++ b/packages/shared/src/validators/backupTargets.ts
@@ -1,8 +1,54 @@
 import { z } from 'zod';
+import {
+  describeExclusionPattern,
+  stripEmptyExclusionPatterns,
+} from '../utils/backupExclusionGlob';
+
+/** Same ceiling the profiles schema already applied to paths/excludes. */
+const MAX_EXCLUDE_PATTERNS = 64;
+
+/**
+ * File-mode exclusion globs, validated against the Go agent's dialect (#2473).
+ *
+ * Before this, a malformed glob was accepted, persisted, and shipped to the
+ * fleet, where the agent logged "ignoring invalid exclusion pattern" and backed
+ * up everything the tech believed was excluded — with no feedback to whoever
+ * typed it.
+ *
+ * Two deliberate design choices, both aimed at NOT breaking working saves:
+ *
+ *  - **Blank entries are stripped, not rejected.** A textarea split on newlines
+ *    yields empty strings; failing the save over one would be an over-strict
+ *    regression. The agent skips them too.
+ *  - **Only definite syntax errors are rejected** — the ones the agent's own
+ *    matcher refuses to compile. Merely unusual patterns (`[z-a]`, `[!a-z]`)
+ *    are accepted, because the agent accepts them.
+ *
+ * The dialect is pinned by a cross-language contract fixture replayed against
+ * the real agent matcher — see packages/shared/src/utils/backupExclusionGlob.ts.
+ */
+export const backupExcludePatternsSchema = z
+  .array(z.string())
+  .max(MAX_EXCLUDE_PATTERNS)
+  .transform(stripEmptyExclusionPatterns)
+  .superRefine((patterns, ctx) => {
+    patterns.forEach((pattern, index) => {
+      const verdict = describeExclusionPattern(pattern);
+      if (verdict.usable) return;
+      ctx.addIssue({
+        code: 'custom',
+        path: [index],
+        message: `${verdict.message} The backup agent would ignore this pattern, so it would silently exclude nothing.`,
+      });
+    });
+  });
 
 export const fileTargetsSchema = z.object({
   paths: z.array(z.string()).min(1),
-  excludes: z.array(z.string()).optional(),
+  // Stays OPTIONAL on purpose: omitted means "fall back to the agent's local
+  // excludes", whereas an explicit [] means "no exclusions this run". Do not
+  // collapse the two with a .default([]) — see backupWorker.resolveBackupTargets.
+  excludes: backupExcludePatternsSchema.optional(),
 });
 
 export const hypervTargetsSchema = z.object({
@@ -136,7 +182,9 @@ export const backupProfileSelectionsSchema = z
       .object({
         enabled: z.boolean().default(false),
         paths: z.array(z.string().trim().min(1)).max(64).default([]),
-        excludes: z.array(z.string().trim().min(1)).max(64).default([]),
+        // Was z.array(z.string().trim().min(1)) — which rejected a blank line
+        // outright. Blank entries are now stripped instead (see schema doc).
+        excludes: backupExcludePatternsSchema.default([]),
         // Reserved for drive-letter/volume selection once the agent reports
         // volume inventory (spec phase 3). Rejected until then (see
         // superRefine): job creation cannot expand volumes into paths yet,

--- a/packages/shared/src/validators/backupTargets.ts
+++ b/packages/shared/src/validators/backupTargets.ts
@@ -1,11 +1,37 @@
 import { z } from 'zod';
 import {
   describeExclusionPattern,
-  stripEmptyExclusionPatterns,
+  sanitizeExclusionPatterns,
 } from '../utils/backupExclusionGlob';
 
-/** Same ceiling the profiles schema already applied to paths/excludes. */
-const MAX_EXCLUDE_PATTERNS = 64;
+/**
+ * Only appended for a genuine SYNTAX error. A pattern rejected for length is one
+ * the agent would happily compile — telling the user "the agent would ignore
+ * this" would be a lie (the length cap is an API-side guard, nothing more).
+ */
+const AGENT_WOULD_IGNORE =
+  ' The backup agent would ignore this pattern, so it would silently exclude nothing.';
+
+/**
+ * Per-pattern validation. Runs on the RAW array, BEFORE blanks are stripped, so
+ * `path: [index]` still points at the row the user actually typed — a UI mapping
+ * an issue back to a textarea line would otherwise highlight the wrong one once
+ * a blank line precedes the offender.
+ */
+function refineExcludePatterns(patterns: string[], ctx: z.RefinementCtx) {
+  patterns.forEach((pattern, index) => {
+    const verdict = describeExclusionPattern(pattern);
+    if (verdict.usable) return;
+    // Blanks are stripped by the transform below, not rejected.
+    if (verdict.problem === 'empty') return;
+    const suffix = verdict.problem === 'syntax' ? AGENT_WOULD_IGNORE : '';
+    ctx.addIssue({
+      code: 'custom',
+      path: [index],
+      message: `${verdict.message}${suffix}`,
+    });
+  });
+}
 
 /**
  * File-mode exclusion globs, validated against the Go agent's dialect (#2473).
@@ -29,19 +55,21 @@ const MAX_EXCLUDE_PATTERNS = 64;
  */
 export const backupExcludePatternsSchema = z
   .array(z.string())
-  .max(MAX_EXCLUDE_PATTERNS)
-  .transform(stripEmptyExclusionPatterns)
-  .superRefine((patterns, ctx) => {
-    patterns.forEach((pattern, index) => {
-      const verdict = describeExclusionPattern(pattern);
-      if (verdict.usable) return;
-      ctx.addIssue({
-        code: 'custom',
-        path: [index],
-        message: `${verdict.message} The backup agent would ignore this pattern, so it would silently exclude nothing.`,
-      });
-    });
-  });
+  .superRefine(refineExcludePatterns)
+  .transform(sanitizeExclusionPatterns);
+
+/**
+ * Profiles variant. Keeps the `.max(64)` cap that shipped with the profiles
+ * schema in #2417 — deliberately NOT added to `backupExcludePatternsSchema`,
+ * because the legacy inline-settings `excludes` has always been uncapped and
+ * introducing a cap here would fail a save for an existing policy that exceeds
+ * it. That is the over-strict regression this feature exists to avoid.
+ */
+const backupProfileExcludePatternsSchema = z
+  .array(z.string())
+  .max(64)
+  .superRefine(refineExcludePatterns)
+  .transform(sanitizeExclusionPatterns);
 
 export const fileTargetsSchema = z.object({
   paths: z.array(z.string()).min(1),
@@ -184,7 +212,8 @@ export const backupProfileSelectionsSchema = z
         paths: z.array(z.string().trim().min(1)).max(64).default([]),
         // Was z.array(z.string().trim().min(1)) — which rejected a blank line
         // outright. Blank entries are now stripped instead (see schema doc).
-        excludes: backupExcludePatternsSchema.default([]),
+        // Trimming is preserved by sanitizeExclusionPatterns.
+        excludes: backupProfileExcludePatternsSchema.default([]),
         // Reserved for drive-letter/volume selection once the agent reports
         // volume inventory (spec phase 3). Rejected until then (see
         // superRefine): job creation cannot expand volumes into paths yet,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -814,6 +814,7 @@ export * from './clientAiDlp';
 // ============================================
 
 export {
+  backupExcludePatternsSchema,
   fileTargetsSchema,
   hypervTargetsSchema,
   mssqlTargetsSchema,


### PR DESCRIPTION
## The bug

Backup file-mode exclusion globs are accepted, persisted, and shipped to the agent with **no validation**. A malformed glob isn't an error on the agent either — it logs `ignoring invalid exclusion pattern` and skips it. So the files a tech believed were excluded get backed up anyway, and nobody is ever told.

## The dialect is not `doublestar`

The issue (and I) assumed the agent used `bmatcuk/doublestar`. **It doesn't** — there is no doublestar dependency in `agent/go.mod`. `agent/internal/backup/exclude.go` hand-rolls a segment walker over Go's **stdlib `path.Match`**, so the real grammar is `path.Match`'s, applied **per segment**.

That changes everything, because two properties fall out of the agent's normalization order that a naive port gets wrong:

1. **Backslash is never an escape.** `path.Match` treats `\` as an escape character — but the agent rewrites every `\` to `/` *before* matching (so `AppData\Local` works). By the time `path.Match` sees a pattern there are no backslashes left. Validating the raw string with `path.Match` would reject `temp\` as a "trailing escape" — a pattern that works fine today.
2. **Slash patterns are validated per segment.** `a[x/y]b` is a legal glob as one string, but splits into the malformed segments `a[x` and `y]b`. A whole-string validator would wrongly accept it.

Validating with `minimatch` would have been wrong in **both** directions.

## Approach: pin the contract first, validate second

`packages/shared/src/fixtures/backup-exclusion-contract.json` — a fixture table of validity + `{pattern, path, expectedMatch}` triples, replayed against **both** sides:

| side | file | runs against |
|---|---|---|
| Go | `agent/internal/backup/exclude_contract_test.go` | the **real** agent matcher (`newExcludeMatcherForOS`) |
| TS | `packages/shared/src/utils/backupExclusionGlob.test.ts` | the API-side port |

The validity half asserts the behavior that actually matters — *does the agent compile this pattern, or silently drop it?* — by compiling a single pattern and checking for a nil matcher. That is exactly the question the API must answer.

I hand-authored the expectations from documented intent and let real Go arbitrate. It disagreed with me on one case (a bare `**`) and Go was right — the contract doing its job on its first run.

## Divergences found

**Caught by the validator** (agent rejects → API now rejects):

| pattern | why it's a trap |
|---|---|
| `[a-z0-9_-].log` | **Headline case.** The trailing-dash-means-literal-dash idiom is valid in bash/minimatch/doublestar and is *extremely* common. Go's `path.Match` rejects it. Today this silently excludes nothing. |
| `[-a].log`, `[]]`, `[^]]`, `[--0]` | leading/trailing dash and `]`-first classes: all valid in bash, `ErrBadPattern` in Go |
| `a[x/y]b` | legal as one glob string; malformed once split on `/` |
| `[\]]` | would be an escaped `]` elsewhere; the backslash folds to `/` first |
| `a//b`, `[`, `a[bc`, `[]`, `[^]` | empty segment / unclosed / empty class |

**Deliberately let through** (agent accepts → API accepts, because over-strict is the worse error):

| pattern | why |
|---|---|
| `[z-a]` | Reversed range. Go does **not** error on `hi < lo` — it just never matches. Almost certainly a typo, but the agent accepts it, and rejecting it would break a save that "works" today. |
| `[!a-z]` | `path.Match` reads `!` as a **literal** class member, not a negation (`^` is the negation char). |
| `!important.doc` | **There is no negation in this dialect.** A gitignore user writing `!keep.doc` to *re-include* a file instead **excludes** the file named `!keep.doc`. Syntactically fine, so accepted — but pinned in the fixture because it's a live footgun. |
| `\*` | **The nastiest one.** An escaped literal star everywhere else; here the backslash folds to `/`, giving `/*` → trims to `*` — a base-name glob matching **every file**. The backup then succeeds and protects nothing. Legal syntax, so accepted. |
| `temp\`, `foo\*bar`, `***`, `abc]`, `[α-ω]` | all legal to `path.Match` |

**Semantic divergences pinned in the fixture** (not validation, but they'd bite any future port): the agent prepends an implicit `**/` so exclusions are gitignore-style and match at **any depth** — stock `doublestar.Match("node_modules/**", "app/node_modules/x")` is `false`, the agent's is `true`. `dir/**` matches the **directory itself** (that's what lets the walker skip the subtree). And on Windows the *pattern* is lowercased too, so `[A-Z]` silently becomes `[a-z]`.

## Honest limitation: the validator is exact, the matcher is not

Both reviewers differential-fuzzed my TS port against the real Go matcher. Results, stated plainly:

- **`describeExclusionPattern` — the validator, the only thing that gates a save — is exact.** 177k+ exhaustively enumerated patterns, plus 40k random cases I ran myself: **zero divergences** from real Go, and **zero cases where it is stricter than the agent**.
- **`compileExcludeMatcher` — the matcher — is NOT exact.** Go's `path.Match` advances the name by **bytes** in its star loop (so `*??` matches a 3-byte rune), and Go's `strings.ToLower` uses simple rather than full Unicode case mapping (so `İ` folds to one rune, not two). A code-point-based JS port reproduces neither without vendoring a UTF-8 byte matcher and Go's case tables.

Rather than ship an approximation quietly, those divergences are enumerated in a `matcherPortLimitations` block, **asserted on the Go side** (so the note can't rot) and **asserted-as-divergent on the TS side** (so the boundary can't silently widen). The matcher is **not exported from the package barrel** — it must not become a "what would this exclude?" preview, because it would lie about CJK/emoji filenames and Turkish `İ`. Making it exact means porting over UTF-8 bytes; happy to do that as a follow-up if a preview UI is wanted.

## Not breaking working saves

This is the failure mode the issue explicitly warns about, so:

- **Only definite syntax errors are rejected** — the ones the agent's own matcher refuses to compile. Never "patterns I think are unusual".
- **Blank entries are stripped, not rejected.** A textarea split on newlines yields empty strings; failing a save over one would be an over-strict regression.
- **No new count cap.** An earlier revision added `.max(64)` to the previously-uncapped legacy `excludes` — caught in review and removed. (Profiles keep the `.max(64)` they shipped with in #2417.)
- **Every shipped preset and suggestion chip is asserted accepted**, in a test that iterates the **real** preset modules (`apps/web/.../backupTabPresets.test.ts`) rather than a hand-copied list — the hand-copied version was already missing `*.swp` on day one.
- `excludes` stays **optional** — omitted (fall back to agent-local excludes) is still distinct from `[]` (no exclusions).
- Errors carry `path: ['targets','excludes',N]` pointing at the **user-supplied** index (validated before blanks are stripped), so a UI can highlight the offending row.

## Also closes an AI/MCP hole

`manage_policy_feature_link` takes `inlineSettings` as an unvalidated `z.record(z.string(), z.unknown())` and hands it straight to `addFeatureLink`/`updateFeatureLink` — the route schema never sees it. Both funnel through `decomposeInlineSettings`, so the globs are validated there as a backstop, covered by `configurationPolicy.backupExcludes.test.ts` driving the real create **and** update paths. The backstop is scoped to `excludes` on purpose: re-parsing the whole blob would reject profile-linked links, whose targets are legitimately empty — there's a test locking that in.

Covered write paths: config-policy feature links (POST/PATCH), backup profiles (POST/PATCH), the AI/MCP profile tools, and now the AI/MCP feature-link tools.

## ⚠️ Decide before merging: existing policies with a dead glob

A policy saved **before** this change can hold a malformed glob — and per the issue, that population plausibly exists, because techs typed these and the agent silently dropped them.

Such a policy now **fails to save on the next edit**, even if the tech only touched the schedule (`BackupTab` re-submits the whole blob). That is intentional — the pattern was already excluding nothing — and the error names the exact problem:

> Character class in `"[a-z0-9_-].log"` has a leading or trailing `-` … The backup agent would ignore this pattern, so it would silently exclude nothing.

But it's a behavior change against live data. Worth doing before merge: size the population with a `SELECT` over `config_policy_backup_settings.targets->'excludes'` (and `backup_profiles.selections`) run through `describeExclusionPattern`. If it's non-zero, this belongs in the release notes. There's a `describe('legacy configurations carrying a dead glob')` block recording the decision either way.

## Verification

- `go test -race ./internal/backup/` — **ok**, 82 contract subtests against the real matcher
- `packages/shared` — **1202 passed** (47 files)
- `apps/api` affected suites single-fork — **305 passed** (25 files)
- `apps/web` preset test — **17 passed** (iterates the real presets)
- `tsc --noEmit` clean in `packages/shared`, `apps/api`, `apps/web`; `eslint` clean
- Independent differential fuzz vs real Go: **0 validator divergences**, **0 over-strict rejections**

Closes #2473

🤖 Generated with [Claude Code](https://claude.com/claude-code)