### PR TITLE
feat(sso): OIDC hardening — default-role ceiling, provider generation gate, session binding, verified-email requirement, SSRF-safe discovery (SR2-10..14)

### DIFF
--- a/apps/api/migrations/2026-07-16-sso-session-binding-and-provider-version.sql
+++ b/apps/api/migrations/2026-07-16-sso-session-binding-and-provider-version.sql
@@ -1,0 +1,97 @@
+-- PR 3 (SR2-11): SSO provider config generations + pending-session binding.
+--
+-- 1. sso_providers.config_version — monotonic generation, bumped by every
+--    config change AND every status change. A pending SSO session snapshots it;
+--    the callback rejects a drift, so a provider reconfigured or disabled during
+--    the <=10-minute state TTL cannot complete a login or an account link.
+--    No RLS change needed: sso_providers already carries the dual-axis ALL
+--    policy sso_providers_org_isolation (2026-07-03), which covers all columns.
+--
+-- 1b. sso_providers.default_role_configured_by (SR2-10) -- the admin who LAST SET
+--    default_role_id. This is the principal the callback re-validates the
+--    delegated role against just before JIT provisioning. created_by is the wrong
+--    principal: it names the ORIGINAL creator while config-time validation checks
+--    the CURRENT caller, and no route ever rewrites it -- so an offboarded creator
+--    would make JIT fail permanently with no repair path (the provider cannot be
+--    recreated without orphaning every user_sso_identities row, since
+--    (provider_id, external_id) is the identity key).
+--
+-- 2. sso_sessions binding columns. NULLABLE by construction: a LOGIN session has
+--    no initiating user, so the three initiating_* columns are only ever set by
+--    POST /sso/link/start. provider_version is nullable only so this migration
+--    needs no backfill; the callback treats NULL as a REJECT (fail closed) --
+--    defaulting pre-deploy rows to 1 would bless exactly the unbound sessions
+--    this change exists to invalidate. Worst case is one <=10-minute window of
+--    in-flight SSO round-trips at deploy time.
+--
+-- 3. sso_sessions RLS. The table had NONE (created in 0001-baseline.sql:5828,
+--    never given a policy). It is a pre-auth CSRF/PKCE transaction store with no
+--    tenant column, written and consumed only by unauthenticated (/sso/callback,
+--    /sso/login/*) or system-context (/sso/link/start) code. Classification:
+--    system-scope-only -- ENABLE + FORCE RLS with one ALL-command policy keyed on
+--    breeze.scope = 'system'. Same shape as partner_abuse_signals (2026-07-13)
+--    and software_product_resolutions. Registered in INTENTIONAL_UNSCOPED in
+--    rls-coverage.integration.test.ts.
+
+ALTER TABLE sso_providers
+  ADD COLUMN IF NOT EXISTS config_version INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE sso_providers
+  ADD COLUMN IF NOT EXISTS default_role_configured_by UUID REFERENCES users(id);
+
+ALTER TABLE sso_sessions
+  ADD COLUMN IF NOT EXISTS provider_version INTEGER;
+
+ALTER TABLE sso_sessions
+  ADD COLUMN IF NOT EXISTS initiating_auth_epoch INTEGER;
+
+ALTER TABLE sso_sessions
+  ADD COLUMN IF NOT EXISTS initiating_mfa_epoch INTEGER;
+
+ALTER TABLE sso_sessions
+  ADD COLUMN IF NOT EXISTS initiating_session_id UUID;
+
+COMMENT ON COLUMN sso_providers.config_version IS
+  'Monotonic config generation. Bumped on every provider config change and status change. Pending sso_sessions snapshot it; the callback rejects a mismatch (SR2-11).';
+COMMENT ON COLUMN sso_providers.default_role_configured_by IS
+  'The admin who last SET default_role_id. The SSO callback re-validates the delegated role against THIS user''s live permission ceiling before JIT provisioning (SR2-10). Re-saving the default role as a current admin is the repair path when the previous configurer is offboarded.';
+COMMENT ON COLUMN sso_sessions.provider_version IS
+  'sso_providers.config_version snapshot at session creation. NULL = pre-deploy row; the callback rejects it (fail closed).';
+COMMENT ON COLUMN sso_sessions.initiating_session_id IS
+  'Link mode only: refresh_token_families.family_id (the initiating access token''s `sid`). The link callback requires that family to still be live.';
+
+-- Purge any session rows that predate the binding columns. They are all <=10
+-- minutes from expiry and cannot satisfy the new callback checks anyway; purging
+-- them makes the invalidation explicit (and auditable) instead of surfacing as a
+-- burst of session_expired redirects. Report the count -- silently discarding
+-- rows destroys the forensic trail.
+DO $$
+DECLARE
+  n INTEGER;
+BEGIN
+  DELETE FROM sso_sessions WHERE provider_version IS NULL;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'purged % in-flight sso_sessions rows with no provider_version binding (SR2-11 rollout)', n;
+  END IF;
+END $$;
+
+ALTER TABLE sso_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sso_sessions FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'sso_sessions'
+      AND policyname = 'sso_sessions_system_only'
+  ) THEN
+    EXECUTE $POLICY$
+      CREATE POLICY sso_sessions_system_only
+        ON sso_sessions
+        USING (current_setting('breeze.scope', true) = 'system')
+        WITH CHECK (current_setting('breeze.scope', true) = 'system')
+    $POLICY$;
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-07-17-sso-default-role-configured-by-on-delete.sql
+++ b/apps/api/migrations/2026-07-17-sso-default-role-configured-by-on-delete.sql
@@ -1,0 +1,42 @@
+-- PR3 review M3 — sso_providers.default_role_configured_by FK: ON DELETE SET NULL.
+--
+-- 2026-07-16 added the column with a bare `REFERENCES users(id)` (NO ACTION).
+-- Two reasons to make it SET NULL, both strictly safer:
+--
+--   1. FAIL CLOSED. default_role_configured_by names the admin whose LIVE
+--      permission ceiling the SSO callback re-checks the delegated default role
+--      against just before JIT-provisioning a user (SR2-10). If that account is
+--      ever hard-deleted, NO ACTION would block the delete (FK 23503) while
+--      SET NULL leaves the provider with an unresolvable principal — and
+--      revalidateSsoDefaultRole refuses JIT on a NULL configurer
+--      (`default_role_configurer_unknown`). A vanished configurer must revoke
+--      the standing delegation, not preserve it; the repair path is for a
+--      current admin to re-save the default role, which re-stamps the column.
+--
+--   2. No new FK-block class. User deletion is membership-only today
+--      (DELETE /users/:id removes organization_users), so this is latent —
+--      but a future hard-delete would otherwise be blocked by this edge.
+--
+-- Forward-only fix (the 2026-07-16 migration is shipped and must not be edited).
+-- Idempotent: DROP CONSTRAINT IF EXISTS (both the Postgres default name and the
+-- drizzle-style name, so it converges regardless of how the edge was created)
+-- then re-add. Re-applying is a no-op.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'sso_providers'
+      AND column_name = 'default_role_configured_by'
+  ) THEN
+    ALTER TABLE sso_providers
+      DROP CONSTRAINT IF EXISTS sso_providers_default_role_configured_by_fkey;
+    ALTER TABLE sso_providers
+      DROP CONSTRAINT IF EXISTS sso_providers_default_role_configured_by_users_id_fk;
+    ALTER TABLE sso_providers
+      ADD CONSTRAINT sso_providers_default_role_configured_by_fkey
+      FOREIGN KEY (default_role_configured_by)
+      REFERENCES users(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -77,6 +77,7 @@ const INTENTIONAL_UNSCOPED: ReadonlySet<string> = new Set<string>([
   'third_party_package_catalog', // System-wide curated catalog of third-party packages; writes gated by platform-admin role at the route layer.
   'third_party_release_tests', // System-wide release test results; references catalog (unscoped) and is platform-admin-only at the route layer.
   'partner_abuse_signals', // Operator abuse signals ABOUT partners. Forced RLS, system-only policy — partners must never see their own risk signals.
+  'sso_sessions', // Pre-auth SSO CSRF/PKCE transaction store (state/nonce/code_verifier + link binding). No tenant column; written/consumed only by unauthenticated callback + system-context routes. Forced RLS, system-only policy → only system context.
 ]);
 
 // Tables with org_id metadata that are intentionally not generic org-tenant
@@ -605,6 +606,69 @@ describe('RLS coverage contract', () => {
     expect(`${authCodes?.qual}\n${authCodes?.with_check}`).toContain('user_id = breeze_current_user_id()');
     expect(`${grants?.qual}\n${grants?.with_check}`).toContain('account_id = breeze_current_user_id()');
     expect(`${refreshTokens?.qual}\n${refreshTokens?.with_check}`).toContain('user_id = breeze_current_user_id()');
+  });
+
+  it('sso_sessions is forced-RLS and reachable only from system scope', async () => {
+    const [cls] = (await db.execute(sql`
+      SELECT c.relrowsecurity AS rls_on, c.relforcerowsecurity AS force_on
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relname = 'sso_sessions';
+    `)) as unknown as Array<{ rls_on: boolean; force_on: boolean }>;
+
+    expect(cls?.rls_on).toBe(true);
+    expect(cls?.force_on).toBe(true);
+
+    const policies = (await db.execute(sql`
+      SELECT policyname, cmd, COALESCE(qual, '') AS qual, COALESCE(with_check, '') AS with_check
+      FROM pg_policies
+      WHERE schemaname = 'public' AND tablename = 'sso_sessions'
+      ORDER BY policyname;
+    `)) as unknown as Array<{ policyname: string; cmd: string; qual: string; with_check: string }>;
+
+    // Exactly one ALL-command system-only policy. sso_sessions is a pre-auth
+    // CSRF/PKCE transaction store with no tenant column — no tenant axis may
+    // read or write it, only withSystemDbAccessContext.
+    expect(policies).toHaveLength(1);
+    expect(policies[0]?.policyname).toBe('sso_sessions_system_only');
+    expect(policies[0]?.cmd).toBe('ALL');
+    const predicate = `${policies[0]?.qual}\n${policies[0]?.with_check}`;
+    expect(predicate).toContain("current_setting('breeze.scope'");
+    expect(predicate).not.toContain('breeze_has_org_access');
+    expect(predicate).not.toContain('breeze_has_partner_access');
+  });
+
+  it('sso_sessions carries the provider-version and link-binding columns', async () => {
+    const cols = (await db.execute(sql`
+      SELECT column_name, is_nullable, data_type
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'sso_sessions'
+        AND column_name IN ('provider_version', 'initiating_auth_epoch', 'initiating_mfa_epoch', 'initiating_session_id')
+      ORDER BY column_name;
+    `)) as unknown as Array<{ column_name: string; is_nullable: string; data_type: string }>;
+
+    expect(cols.map((c) => c.column_name)).toEqual([
+      'initiating_auth_epoch', 'initiating_mfa_epoch', 'initiating_session_id', 'provider_version',
+    ]);
+    // All nullable: login sessions have no initiating user; provider_version is
+    // NULL only for pre-deploy in-flight rows (which the callback rejects).
+    for (const c of cols) expect(c.is_nullable).toBe('YES');
+
+    const [pv] = (await db.execute(sql`
+      SELECT is_nullable, column_default
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'sso_providers' AND column_name = 'config_version';
+    `)) as unknown as Array<{ is_nullable: string; column_default: string }>;
+    expect(pv?.is_nullable).toBe('NO');
+    expect(pv?.column_default).toContain('1');
+
+    const [drcb] = (await db.execute(sql`
+      SELECT is_nullable, data_type
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'sso_providers' AND column_name = 'default_role_configured_by';
+    `)) as unknown as Array<{ is_nullable: string; data_type: string }>;
+    expect(drcb?.is_nullable).toBe('YES');
+    expect(drcb?.data_type).toBe('uuid');
   });
 
   it('every tenant-scoped public table has FORCE ROW LEVEL SECURITY enabled', async () => {

--- a/apps/api/src/__tests__/integration/ssoHardening.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoHardening.integration.test.ts
@@ -49,10 +49,15 @@ vi.mock('../../services/sso', async (importOriginal) => {
     exchangeCodeForTokens: vi.fn(),
     getUserInfo: vi.fn(),
     verifyIdTokenSignature: vi.fn(),
+    // I1/I2: the provider-write routes' outbound discovery call. Stubbed so the
+    // suite never touches the network — the stub also records the ambient DB
+    // context at call time, which is what proves the #1105 conn-hold is gone.
+    discoverOIDCConfig: vi.fn(),
   };
 });
 
-import { exchangeCodeForTokens, getUserInfo, verifyIdTokenSignature } from '../../services/sso';
+import { exchangeCodeForTokens, getUserInfo, verifyIdTokenSignature, discoverOIDCConfig } from '../../services/sso';
+import { getCurrentDbAccessContext } from '../../db';
 import { ssoRoutes } from '../../routes/sso';
 
 const ISSUER = 'https://idp.example.test';
@@ -625,5 +630,164 @@ describe('SSO hardening — real-DB (SR2-10 … SR2-12)', () => {
       // still only the one identity from the successful staff link
       expect(await identityCountFor(provider.id)).toBe(1);
     }
+  });
+
+  // ── I1 + I2: PATCH /providers/:id issuer re-discovery ──────────────────────
+  //
+  // I1 (#1105 class): discovery is a 10s-bounded fetch of a TENANT-CONTROLLED
+  // host. Held inside authMiddleware's request transaction it pins a pooled
+  // breeze_app connection idle-in-transaction for the duration — 25 concurrent
+  // PATCHes against an unrate-limited route stall the whole API for every
+  // tenant. The route is now in SELF_MANAGED_DB_CONTEXT_ROUTES, so the
+  // middleware opens NO ambient transaction and the handler wraps each DB op in
+  // its own short withDbAccessContext block.
+  //
+  // I2: a rejected re-discovery used to NULL all four endpoint columns, bump
+  // configVersion (killing every in-flight session) and return 200 — silently
+  // taking the org's SSO offline behind a success toast. It now 400s and writes
+  // nothing.
+  //
+  // Real DB, real authMiddleware, real RLS pool. Only the outbound fetch is
+  // stubbed; the stub records the ambient DB context at call time.
+  describe('#9 PATCH provider issuer re-discovery (I1 conn-hold + I2 silent-failure)', () => {
+    async function seedSsoAdminToken(partnerId: string, orgId: string) {
+      const role = await createRole({ scope: 'organization', orgId });
+      await grantRolePermissions(role.id, [{ resource: 'sso', action: 'admin' }]);
+      const admin = await seedPasswordlessUser({ partnerId, orgId, email: `ssoadmin-${randomUUID()}@${EMAIL_DOMAIN}` });
+      await assignUserToOrganization(admin.id, orgId, role.id);
+      clearPermissionCache();
+      return createAccessToken({
+        sub: admin.id,
+        email: admin.email,
+        roleId: role.id,
+        orgId,
+        partnerId: null,
+        scope: 'organization',
+        mfa: true,
+        aep: 1,
+        mep: 1,
+        sid: randomUUID(),
+      });
+    }
+
+    /** Mount under the REAL API prefix so authMiddleware's self-managed-route match applies. */
+    function apiApp() {
+      const a = new Hono();
+      a.route('/api/v1/sso', ssoRoutes);
+      return a;
+    }
+
+    function patchIssuer(a: Hono, providerId: string, token: string, issuer: string, prefix = '/api/v1/sso') {
+      return a.request(`${prefix}/providers/${providerId}`, {
+        method: 'PATCH',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ issuer }),
+      });
+    }
+
+    function providerRow(id: string) {
+      return getTestDb()
+        .select({
+          issuer: ssoProviders.issuer,
+          authorizationUrl: ssoProviders.authorizationUrl,
+          tokenUrl: ssoProviders.tokenUrl,
+          userInfoUrl: ssoProviders.userInfoUrl,
+          jwksUrl: ssoProviders.jwksUrl,
+          configVersion: ssoProviders.configVersion,
+        })
+        .from(ssoProviders)
+        .where(eq(ssoProviders.id, id))
+        .then((rows) => rows[0]!);
+    }
+
+    it('succeeds with NO ambient DB transaction held across the discovery call, and re-writes all four endpoints', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const provider = await seedOrgProvider(org.id);
+      const token = await seedSsoAdminToken(partner.id, org.id);
+
+      // The whole I1 assertion: what the ambient DB context is AT THE MOMENT the
+      // outbound fetch would run. Before the SELF_MANAGED_DB_CONTEXT_ROUTES entry
+      // this was the request's held transaction (safeFetch's
+      // assertOutsideHeldDbContext tripwire fired here, warn-only).
+      let contextDuringDiscovery: unknown = 'not-called';
+      const newIssuer = 'https://new-idp.example.test';
+      vi.mocked(discoverOIDCConfig).mockReset().mockImplementation(async () => {
+        contextDuringDiscovery = getCurrentDbAccessContext();
+        return {
+          issuer: newIssuer,
+          authorization_endpoint: `${newIssuer}/authorize`,
+          token_endpoint: `${newIssuer}/token`,
+          userinfo_endpoint: `${newIssuer}/userinfo`,
+          jwks_uri: `${newIssuer}/jwks`,
+        } as any;
+      });
+
+      const res = await patchIssuer(apiApp(), provider.id, token, newIssuer);
+      expect(res.status).toBe(200);
+      expect(contextDuringDiscovery).toBeUndefined();
+
+      // …and the DB work still happened, under the caller's own RLS context.
+      const after = await providerRow(provider.id);
+      expect(after.issuer).toBe(newIssuer);
+      expect(after.authorizationUrl).toBe(`${newIssuer}/authorize`);
+      expect(after.tokenUrl).toBe(`${newIssuer}/token`);
+      expect(after.userInfoUrl).toBe(`${newIssuer}/userinfo`);
+      expect(after.jwksUrl).toBe(`${newIssuer}/jwks`);
+      expect(after.configVersion).toBe(provider.configVersion + 1);
+    });
+
+    it('control: the SAME handler mounted off the /api/v1 prefix DOES hold a transaction (proves the assertion above is not vacuous)', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const provider = await seedOrgProvider(org.id);
+      const token = await seedSsoAdminToken(partner.id, org.id);
+
+      let contextDuringDiscovery: unknown = 'not-called';
+      const newIssuer = 'https://control-idp.example.test';
+      vi.mocked(discoverOIDCConfig).mockReset().mockImplementation(async () => {
+        contextDuringDiscovery = getCurrentDbAccessContext();
+        return {
+          issuer: newIssuer,
+          authorization_endpoint: `${newIssuer}/authorize`,
+          token_endpoint: `${newIssuer}/token`,
+          userinfo_endpoint: `${newIssuer}/userinfo`,
+          jwks_uri: `${newIssuer}/jwks`,
+        } as any;
+      });
+
+      // Mounted at bare '/sso' → isSelfManagedDbContextRoute does not match →
+      // authMiddleware opens the ambient request transaction, exactly as it did
+      // for the /api/v1 path before this fix.
+      const bare = new Hono();
+      bare.route('/sso', ssoRoutes);
+      const res = await patchIssuer(bare, provider.id, token, newIssuer, '/sso');
+      expect(res.status).toBe(200);
+      expect(contextDuringDiscovery).toMatchObject({ scope: 'organization', orgId: org.id });
+    });
+
+    it('rejected re-discovery → 400, and the provider row is COMPLETELY unchanged (no endpoint NULLing, no configVersion bump)', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const provider = await seedOrgProvider(org.id);
+      const token = await seedSsoAdminToken(partner.id, org.id);
+      const before = await providerRow(provider.id);
+
+      vi.mocked(discoverOIDCConfig).mockReset().mockRejectedValue(
+        new Error('OIDC discovery failed: 404'),
+      );
+
+      // The scenario from the review: an admin fixing a typo in a WORKING
+      // provider's issuer typos it again. Old behavior: 200 OK + org-wide SSO
+      // outage. New: nothing moves.
+      const res = await patchIssuer(apiApp(), provider.id, token, 'https://typo-idp.example.test');
+      expect(res.status).toBe(400);
+      const body = await res.json() as { code?: string; error?: string };
+      expect(body.code).toBe('oidc_discovery_failed');
+      expect(body.error).toContain('OIDC discovery failed: 404');
+
+      const after = await providerRow(provider.id);
+      expect(after).toEqual(before);
+    });
   });
 });

--- a/apps/api/src/__tests__/integration/ssoHardening.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoHardening.integration.test.ts
@@ -1,0 +1,629 @@
+/**
+ * Real-DB coverage for the PR 3 SSO hardening layers (SR2-10 … SR2-12), driven
+ * through the REAL ssoRoutes against the genuine breeze_app RLS-enforced pool.
+ * Only the IdP network calls are stubbed (exchangeCodeForTokens / getUserInfo /
+ * verifyIdTokenSignature); every gate (provider-generation, link-binding, the
+ * domain-ownership gate, and the JIT default-role permission ceiling) runs
+ * against real rows. These prove properties the wholesale-mocked unit suites
+ * structurally cannot: the JIT ceiling reads real role_permissions under RLS,
+ * and the MSP-topology partner-admin configurer (no organization_users row) is
+ * resolved on BOTH axes.
+ *
+ * Mock shape (mandatory): spread importOriginal so readEmailVerifiedClaim /
+ * assertSafeOidcEndpoint / generateState survive — a full factory would strip
+ * them and break the runtime gates.
+ */
+import './setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { createHmac, randomUUID } from 'crypto';
+import { and, eq } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import {
+  ssoProviders,
+  ssoSessions,
+  ssoVerifiedDomains,
+  userSsoIdentities,
+  users,
+  refreshTokenFamilies,
+} from '../../db/schema';
+import {
+  createPartner,
+  createOrganization,
+  createRole,
+  assignUserToOrganization,
+  assignUserToPartner,
+  grantRolePermissions,
+} from './db-utils';
+import { encryptSecret } from '../../services/secretCrypto';
+import { createAccessToken } from '../../services/jwt';
+import { clearPermissionCache } from '../../services/permissions';
+
+process.env.APP_ENCRYPTION_KEY =
+  process.env.APP_ENCRYPTION_KEY || 'integration-test-app-encryption-key-32-bytes!';
+
+vi.mock('../../services/sso', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/sso')>();
+  return {
+    ...actual,
+    exchangeCodeForTokens: vi.fn(),
+    getUserInfo: vi.fn(),
+    verifyIdTokenSignature: vi.fn(),
+  };
+});
+
+import { exchangeCodeForTokens, getUserInfo, verifyIdTokenSignature } from '../../services/sso';
+import { ssoRoutes } from '../../routes/sso';
+
+const ISSUER = 'https://idp.example.test';
+const EMAIL_DOMAIN = 'corp.example';
+
+// ── seed helpers ─────────────────────────────────────────────────────────────
+
+async function seedOrgProvider(
+  orgId: string,
+  opts: {
+    status?: 'active' | 'inactive' | 'testing';
+    autoProvision?: boolean;
+    defaultRoleId?: string | null;
+    defaultRoleConfiguredBy?: string | null;
+    createdBy?: string | null;
+  } = {},
+) {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(ssoProviders)
+    .values({
+      orgId,
+      partnerId: null,
+      name: `Org IdP ${randomUUID()}`,
+      type: 'oidc',
+      status: opts.status ?? 'active',
+      issuer: ISSUER,
+      clientId: 'test-client-id',
+      clientSecret: encryptSecret('test-client-secret'),
+      authorizationUrl: `${ISSUER}/authorize`,
+      tokenUrl: `${ISSUER}/token`,
+      userInfoUrl: `${ISSUER}/userinfo`,
+      jwksUrl: `${ISSUER}/jwks`,
+      autoProvision: opts.autoProvision ?? false,
+      defaultRoleId: opts.defaultRoleId ?? null,
+      defaultRoleConfiguredBy: opts.defaultRoleConfiguredBy ?? null,
+      createdBy: opts.createdBy ?? null,
+    })
+    .returning();
+  if (!row) throw new Error('failed to seed org provider');
+  return row;
+}
+
+async function seedPartnerProvider(partnerId: string) {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(ssoProviders)
+    .values({
+      orgId: null,
+      partnerId,
+      name: `Partner IdP ${randomUUID()}`,
+      type: 'oidc',
+      status: 'active',
+      issuer: ISSUER,
+      clientId: 'test-client-id',
+      clientSecret: encryptSecret('test-client-secret'),
+      authorizationUrl: `${ISSUER}/authorize`,
+      tokenUrl: `${ISSUER}/token`,
+      userInfoUrl: `${ISSUER}/userinfo`,
+      jwksUrl: `${ISSUER}/jwks`,
+      autoProvision: false,
+    })
+    .returning();
+  if (!row) throw new Error('failed to seed partner provider');
+  return row;
+}
+
+async function seedPasswordlessUser(opts: { partnerId: string; orgId?: string | null; email: string; status?: 'active' | 'disabled' }) {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(users)
+    .values({
+      partnerId: opts.partnerId,
+      orgId: opts.orgId ?? null,
+      email: opts.email.toLowerCase(),
+      name: 'Test User',
+      passwordHash: null,
+      status: opts.status ?? 'active',
+    })
+    .returning();
+  if (!row) throw new Error('failed to seed user');
+  return row;
+}
+
+async function seedVerifiedDomain(orgId: string, domain: string) {
+  const db = getTestDb();
+  await db.insert(ssoVerifiedDomains).values({
+    orgId,
+    domain: domain.toLowerCase(),
+    verificationToken: `tok-${randomUUID()}`,
+    verifiedAt: new Date(),
+  });
+}
+
+function buildTestSsoStateCookie(state: string): string {
+  const secret = process.env.APP_ENCRYPTION_KEY!;
+  const value = createHmac('sha256', secret).update(`sso-login-state:${state}`).digest('hex');
+  return `breeze_sso_state=${encodeURIComponent(value)}`;
+}
+
+/** Seed a login-mode session directly and return its state + matching cookie. */
+async function seedLoginSession(providerId: string, providerVersion: number) {
+  const db = getTestDb();
+  const state = `login-${randomUUID()}`;
+  const nonce = `nonce-${randomUUID()}`;
+  await db.insert(ssoSessions).values({
+    providerId,
+    state,
+    nonce,
+    providerVersion,
+    redirectUrl: '/',
+    linkUserId: null,
+    expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+  });
+  return { state, nonce, cookie: buildTestSsoStateCookie(state) };
+}
+
+async function seedLinkSession(
+  providerId: string,
+  providerVersion: number,
+  binding: { linkUserId: string; authEpoch: number; mfaEpoch: number; sessionId: string },
+) {
+  const db = getTestDb();
+  const state = `link-${randomUUID()}`;
+  const nonce = `nonce-${randomUUID()}`;
+  await db.insert(ssoSessions).values({
+    providerId,
+    state,
+    nonce,
+    providerVersion,
+    redirectUrl: '/settings/profile',
+    linkUserId: binding.linkUserId,
+    initiatingAuthEpoch: binding.authEpoch,
+    initiatingMfaEpoch: binding.mfaEpoch,
+    initiatingSessionId: binding.sessionId,
+    expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+  });
+  return { state, nonce, cookie: buildTestSsoStateCookie(state) };
+}
+
+function idClaims(sub: string, email: string, nonce: string, emailVerified?: boolean) {
+  const claims: Record<string, unknown> = {
+    iss: ISSUER,
+    sub,
+    aud: 'test-client-id',
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    iat: Math.floor(Date.now() / 1000),
+    nonce,
+    email,
+  };
+  if (emailVerified !== undefined) claims.email_verified = emailVerified;
+  return claims as any;
+}
+
+function setCallbackMocks(sub: string, email: string, nonce: string, emailVerified?: boolean) {
+  vi.mocked(verifyIdTokenSignature).mockResolvedValue(idClaims(sub, email, nonce, emailVerified));
+  vi.mocked(getUserInfo).mockResolvedValue({ sub, email, name: 'Test User' } as any);
+}
+
+async function callback(app: Hono, state: string, cookie: string) {
+  return app.request(`/sso/callback?code=idp-auth-code&state=${state}`, { headers: { cookie } });
+}
+
+async function familyCountFor(userId: string): Promise<number> {
+  const rows = await getTestDb().select({ id: refreshTokenFamilies.familyId }).from(refreshTokenFamilies).where(eq(refreshTokenFamilies.userId, userId));
+  return rows.length;
+}
+
+async function identityCountFor(providerId: string): Promise<number> {
+  const rows = await getTestDb().select({ id: userSsoIdentities.id }).from(userSsoIdentities).where(eq(userSsoIdentities.providerId, providerId));
+  return rows.length;
+}
+
+async function userExistsByEmail(email: string): Promise<boolean> {
+  const rows = await getTestDb().select({ id: users.id }).from(users).where(eq(users.email, email.toLowerCase())).limit(1);
+  return rows.length > 0;
+}
+
+// ── suite ────────────────────────────────────────────────────────────────────
+
+describe('SSO hardening — real-DB (SR2-10 … SR2-12)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = new Hono();
+    app.route('/sso', ssoRoutes);
+    vi.mocked(exchangeCodeForTokens).mockReset().mockResolvedValue({
+      access_token: 'idp-access-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      refresh_token: 'idp-refresh-token',
+      id_token: 'header.payload.signature',
+    } as any);
+    clearPermissionCache();
+  });
+
+  afterEach(() => {
+    vi.mocked(getUserInfo).mockReset();
+    vi.mocked(verifyIdTokenSignature).mockReset();
+  });
+
+  it('#1 provider disabled mid-flow → callback rejects (sso_provider_inactive), no refresh family minted', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const role = await createRole({ scope: 'organization', orgId: org.id });
+    const user = await seedPasswordlessUser({ partnerId: partner.id, orgId: org.id, email: `u1-${randomUUID()}@${EMAIL_DOMAIN}` });
+    await assignUserToOrganization(user.id, org.id, role.id);
+    const provider = await seedOrgProvider(org.id, { status: 'active' });
+    // Link the user by (provider, sub) so a proceeding callback WOULD mint.
+    const sub = `sub-${randomUUID()}`;
+    await getTestDb().insert(userSsoIdentities).values({ userId: user.id, providerId: provider.id, externalId: sub, email: user.email });
+
+    const { state, nonce, cookie } = await seedLoginSession(provider.id, provider.configVersion);
+
+    // Disable + bump generation.
+    await getTestDb().update(ssoProviders).set({ status: 'inactive', configVersion: provider.configVersion + 1 }).where(eq(ssoProviders.id, provider.id));
+
+    setCallbackMocks(sub, user.email, nonce, true);
+    const res = await callback(app, state, cookie);
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('/login?error=sso_provider_inactive');
+    expect(await familyCountFor(user.id)).toBe(0);
+  });
+
+  it('#2 config change → version bump rejects the pending session (sso_config_changed) and burns it', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const role = await createRole({ scope: 'organization', orgId: org.id });
+    const user = await seedPasswordlessUser({ partnerId: partner.id, orgId: org.id, email: `u2-${randomUUID()}@${EMAIL_DOMAIN}` });
+    await assignUserToOrganization(user.id, org.id, role.id);
+    const provider = await seedOrgProvider(org.id, { status: 'active' });
+    const sub = `sub-${randomUUID()}`;
+    await getTestDb().insert(userSsoIdentities).values({ userId: user.id, providerId: provider.id, externalId: sub, email: user.email });
+
+    const { state, nonce, cookie } = await seedLoginSession(provider.id, provider.configVersion);
+
+    // Config change, still active: version drifts.
+    await getTestDb().update(ssoProviders).set({ configVersion: provider.configVersion + 1 }).where(eq(ssoProviders.id, provider.id));
+
+    setCallbackMocks(sub, user.email, nonce, true);
+    const res = await callback(app, state, cookie);
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('/login?error=sso_config_changed');
+
+    // The session was atomically claimed (deleted) up-front — not retryable.
+    const rows = await getTestDb().select({ id: ssoSessions.id }).from(ssoSessions).where(eq(ssoSessions.state, state));
+    expect(rows).toEqual([]);
+  });
+
+  it('#3 logout (revoked initiating family) invalidates a pending link → session_invalid, no identity', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const role = await createRole({ scope: 'organization', orgId: org.id });
+    const user = await seedPasswordlessUser({ partnerId: partner.id, orgId: org.id, email: `u3-${randomUUID()}@${EMAIL_DOMAIN}` });
+    await assignUserToOrganization(user.id, org.id, role.id);
+    const provider = await seedOrgProvider(org.id, { status: 'active' });
+
+    const familyId = randomUUID();
+    await getTestDb().insert(refreshTokenFamilies).values({
+      familyId,
+      userId: user.id,
+      absoluteExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    });
+
+    const { state, nonce, cookie } = await seedLinkSession(provider.id, provider.configVersion, {
+      linkUserId: user.id,
+      authEpoch: 1,
+      mfaEpoch: 1,
+      sessionId: familyId,
+    });
+
+    // Logout revokes the initiating family durably.
+    await getTestDb().update(refreshTokenFamilies).set({ revokedAt: new Date() }).where(eq(refreshTokenFamilies.familyId, familyId));
+
+    setCallbackMocks(`sub-${randomUUID()}`, user.email, nonce, true);
+    const res = await callback(app, state, cookie);
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('/settings/profile?ssoLinkError=session_invalid');
+    expect(await identityCountFor(provider.id)).toBe(0);
+  });
+
+  it('#3b auth_epoch bump (password reset / suspension / global revocation) invalidates a pending link', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const role = await createRole({ scope: 'organization', orgId: org.id });
+    const user = await seedPasswordlessUser({ partnerId: partner.id, orgId: org.id, email: `u3b-${randomUUID()}@${EMAIL_DOMAIN}` });
+    await assignUserToOrganization(user.id, org.id, role.id);
+    const provider = await seedOrgProvider(org.id, { status: 'active' });
+
+    const familyId = randomUUID();
+    await getTestDb().insert(refreshTokenFamilies).values({
+      familyId,
+      userId: user.id,
+      absoluteExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    });
+
+    const { state, nonce, cookie } = await seedLinkSession(provider.id, provider.configVersion, {
+      linkUserId: user.id,
+      authEpoch: 1,
+      mfaEpoch: 1,
+      sessionId: familyId,
+    });
+
+    // Any auth_epoch bump strands the snapshotted epoch.
+    await getTestDb().update(users).set({ authEpoch: 2 }).where(eq(users.id, user.id));
+
+    setCallbackMocks(`sub-${randomUUID()}`, user.email, nonce, true);
+    const res = await callback(app, state, cookie);
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('/settings/profile?ssoLinkError=session_invalid');
+    expect(await identityCountFor(provider.id)).toBe(0);
+  });
+
+  it('#4 domain-ownership gate on auto-link: absent email_verified rejects until the org proves the domain', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const role = await createRole({ scope: 'organization', orgId: org.id });
+    const alice = await seedPasswordlessUser({ partnerId: partner.id, orgId: org.id, email: `alice-${randomUUID()}@${EMAIL_DOMAIN}` });
+    await assignUserToOrganization(alice.id, org.id, role.id);
+    const provider = await seedOrgProvider(org.id, { status: 'active' });
+    const sub = `sub-${randomUUID()}`;
+
+    // Phase 1: no verified domain, id_token OMITS email_verified → absent → reject.
+    {
+      const { state, nonce, cookie } = await seedLoginSession(provider.id, provider.configVersion);
+      setCallbackMocks(sub, alice.email, nonce, undefined);
+      const res = await callback(app, state, cookie);
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('/login?error=sso_email_unverified');
+      expect(await identityCountFor(provider.id)).toBe(0);
+    }
+
+    // Phase 2: prove the domain → the same absent-claim auto-link now succeeds.
+    await seedVerifiedDomain(org.id, EMAIL_DOMAIN);
+    {
+      const { state, nonce, cookie } = await seedLoginSession(provider.id, provider.configVersion);
+      setCallbackMocks(sub, alice.email, nonce, undefined);
+      const res = await callback(app, state, cookie);
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('#ssoCode=');
+      expect(await identityCountFor(provider.id)).toBe(1);
+    }
+  });
+
+  it('#5 JIT default-role ceiling fires against real role_permissions and clears once the configurer is granted the permission', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    // Configurer admin: holds devices:read, LACKS devices:write.
+    const adminRole = await createRole({ scope: 'organization', orgId: org.id });
+    await grantRolePermissions(adminRole.id, [{ resource: 'devices', action: 'read' }]);
+    const admin = await seedPasswordlessUser({ partnerId: partner.id, orgId: org.id, email: `admin5-${randomUUID()}@${EMAIL_DOMAIN}` });
+    await assignUserToOrganization(admin.id, org.id, adminRole.id);
+
+    // Delegated default role holds devices:write (a real assignable permission
+    // the configurer does NOT hold).
+    const elevatedRole = await createRole({ scope: 'organization', orgId: org.id });
+    await grantRolePermissions(elevatedRole.id, [{ resource: 'devices', action: 'write' }]);
+
+    await seedVerifiedDomain(org.id, EMAIL_DOMAIN);
+    const provider = await seedOrgProvider(org.id, {
+      status: 'active',
+      autoProvision: true,
+      defaultRoleId: elevatedRole.id,
+      defaultRoleConfiguredBy: admin.id,
+    });
+
+    const newEmail = `newhire5-${randomUUID()}@${EMAIL_DOMAIN}`;
+
+    // Phase 1: ceiling exceeded → refuse, no user minted.
+    {
+      const { state, nonce, cookie } = await seedLoginSession(provider.id, provider.configVersion);
+      setCallbackMocks(`sub-${randomUUID()}`, newEmail, nonce, true);
+      const res = await callback(app, state, cookie);
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('/login?error=invalid_provider_configuration');
+      expect(await userExistsByEmail(newEmail)).toBe(false);
+    }
+
+    // Phase 2: grant the configurer the permission → now within ceiling.
+    await grantRolePermissions(adminRole.id, [{ resource: 'devices', action: 'write' }]);
+    clearPermissionCache();
+    {
+      const { state, nonce, cookie } = await seedLoginSession(provider.id, provider.configVersion);
+      setCallbackMocks(`sub-${randomUUID()}`, newEmail, nonce, true);
+      const res = await callback(app, state, cookie);
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('#ssoCode=');
+      expect(await userExistsByEmail(newEmail)).toBe(true);
+    }
+  });
+
+  it('#6 (C2) a PARTNER ADMIN with NO org membership can configure a working org-axis JIT provider (both-axis resolution)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    // Partner admin: partner_users row + orgAccess=all, NO organization_users row.
+    const partnerRole = await createRole({ scope: 'partner', partnerId: partner.id });
+    await grantRolePermissions(partnerRole.id, [{ resource: 'devices', action: 'write' }]);
+    const partnerAdmin = await seedPasswordlessUser({ partnerId: partner.id, orgId: null, email: `padmin6-${randomUUID()}@${EMAIL_DOMAIN}` });
+    await assignUserToPartner(partnerAdmin.id, partner.id, partnerRole.id, 'all');
+
+    // Org default role holds a permission WITHIN the partner admin's ceiling.
+    const orgDefaultRole = await createRole({ scope: 'organization', orgId: org.id });
+    await grantRolePermissions(orgDefaultRole.id, [{ resource: 'devices', action: 'write' }]);
+
+    await seedVerifiedDomain(org.id, EMAIL_DOMAIN);
+    const provider = await seedOrgProvider(org.id, {
+      status: 'active',
+      autoProvision: true,
+      defaultRoleId: orgDefaultRole.id,
+      defaultRoleConfiguredBy: partnerAdmin.id,
+    });
+
+    const newEmail = `newhire6-${randomUUID()}@${EMAIL_DOMAIN}`;
+    const { state, nonce, cookie } = await seedLoginSession(provider.id, provider.configVersion);
+    setCallbackMocks(`sub-${randomUUID()}`, newEmail, nonce, true);
+    const res = await callback(app, state, cookie);
+    expect(res.status).toBe(302);
+    // If getUserPermissions had been called with only { orgId }, the partner
+    // admin would resolve to null and this would be invalid_provider_configuration.
+    expect(res.headers.get('location')).toContain('#ssoCode=');
+    expect(await userExistsByEmail(newEmail)).toBe(true);
+  });
+
+  it('#7 repair path: an offboarded configurer bricks JIT; re-saving the default role as a current admin restores it', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const orgDefaultRole = await createRole({ scope: 'organization', orgId: org.id });
+    await grantRolePermissions(orgDefaultRole.id, [{ resource: 'devices', action: 'write' }]);
+
+    // Configurer since suspended (status='disabled').
+    const suspendedRole = await createRole({ scope: 'organization', orgId: org.id });
+    await grantRolePermissions(suspendedRole.id, [{ resource: 'devices', action: 'write' }]);
+    const suspended = await seedPasswordlessUser({ partnerId: partner.id, orgId: org.id, email: `susp7-${randomUUID()}@${EMAIL_DOMAIN}`, status: 'disabled' });
+    await assignUserToOrganization(suspended.id, org.id, suspendedRole.id);
+
+    await seedVerifiedDomain(org.id, EMAIL_DOMAIN);
+    const provider = await seedOrgProvider(org.id, {
+      status: 'active',
+      autoProvision: true,
+      defaultRoleId: orgDefaultRole.id,
+      defaultRoleConfiguredBy: suspended.id,
+    });
+
+    const newEmail = `newhire7-${randomUUID()}@${EMAIL_DOMAIN}`;
+
+    // Phase 1: suspended configurer → refuse.
+    {
+      const { state, nonce, cookie } = await seedLoginSession(provider.id, provider.configVersion);
+      setCallbackMocks(`sub-${randomUUID()}`, newEmail, nonce, true);
+      const res = await callback(app, state, cookie);
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('/login?error=invalid_provider_configuration');
+      expect(await userExistsByEmail(newEmail)).toBe(false);
+    }
+
+    // Phase 2: a current, adequately-permissioned admin re-saves the default role
+    // through the real PATCH route → re-stamps default_role_configured_by.
+    const freshRole = await createRole({ scope: 'organization', orgId: org.id });
+    await grantRolePermissions(freshRole.id, [
+      { resource: 'devices', action: 'write' },
+      { resource: 'sso', action: 'admin' },
+    ]);
+    const freshAdmin = await seedPasswordlessUser({ partnerId: partner.id, orgId: org.id, email: `fresh7-${randomUUID()}@${EMAIL_DOMAIN}` });
+    await assignUserToOrganization(freshAdmin.id, org.id, freshRole.id);
+    const freshToken = await createAccessToken({
+      sub: freshAdmin.id,
+      email: freshAdmin.email,
+      roleId: freshRole.id,
+      orgId: org.id,
+      partnerId: null,
+      scope: 'organization',
+      mfa: true,
+      aep: 1,
+      mep: 1,
+      sid: randomUUID(),
+    });
+    clearPermissionCache();
+
+    const patchRes = await app.request(`/sso/providers/${provider.id}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${freshToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ defaultRoleId: orgDefaultRole.id }),
+    });
+    expect(patchRes.status).toBe(200);
+
+    const [restamped] = await getTestDb().select({ configuredBy: ssoProviders.defaultRoleConfiguredBy, v: ssoProviders.configVersion }).from(ssoProviders).where(eq(ssoProviders.id, provider.id));
+    expect(restamped?.configuredBy).toBe(freshAdmin.id);
+
+    // Phase 3: re-drive with the CURRENT config version → provisioned.
+    clearPermissionCache();
+    {
+      const { state, nonce, cookie } = await seedLoginSession(provider.id, restamped!.v);
+      setCallbackMocks(`sub-${randomUUID()}`, newEmail, nonce, true);
+      const res = await callback(app, state, cookie);
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('#ssoCode=');
+      expect(await userExistsByEmail(newEmail)).toBe(true);
+    }
+  });
+
+  it('#8 unknown configurer (default_role_configured_by AND created_by both NULL) FAILS CLOSED — no user provisioned', async () => {
+    // Corrected behavior (Task 3 removed the wildcard back door): the legacy shape
+    // does NOT proceed with a "ceiling-skipped" audit. With no resolvable
+    // principal there is no ceiling, so JIT is REFUSED. Repair = re-save the
+    // default role as a current adequately-permissioned admin.
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    // Structurally valid org-scoped default role (so we exercise the JIT
+    // fail-closed gate, not the earlier pre-check).
+    const orgDefaultRole = await createRole({ scope: 'organization', orgId: org.id });
+    await grantRolePermissions(orgDefaultRole.id, [{ resource: 'devices', action: 'read' }]);
+
+    await seedVerifiedDomain(org.id, EMAIL_DOMAIN);
+    const provider = await seedOrgProvider(org.id, {
+      status: 'active',
+      autoProvision: true,
+      defaultRoleId: orgDefaultRole.id,
+      defaultRoleConfiguredBy: null,
+      createdBy: null,
+    });
+
+    const newEmail = `newhire8-${randomUUID()}@${EMAIL_DOMAIN}`;
+    const { state, nonce, cookie } = await seedLoginSession(provider.id, provider.configVersion);
+    setCallbackMocks(`sub-${randomUUID()}`, newEmail, nonce, true);
+    const res = await callback(app, state, cookie);
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('/login?error=invalid_provider_configuration');
+    expect(await userExistsByEmail(newEmail)).toBe(false);
+  });
+
+  it('C: partner-axis link binds a partner-staff user (orgId NULL) and rejects one that has gained an orgId', async () => {
+    const partner = await createPartner();
+    const partnerRole = await createRole({ scope: 'partner', partnerId: partner.id });
+
+    // Staff user: partner_users row, users.orgId NULL → binds successfully.
+    const staff = await seedPasswordlessUser({ partnerId: partner.id, orgId: null, email: `staff-c-${randomUUID()}@${EMAIL_DOMAIN}` });
+    await assignUserToPartner(staff.id, partner.id, partnerRole.id, 'all');
+    const provider = await seedPartnerProvider(partner.id);
+
+    const familyId = randomUUID();
+    await getTestDb().insert(refreshTokenFamilies).values({ familyId, userId: staff.id, absoluteExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000) });
+
+    {
+      const { state, nonce, cookie } = await seedLinkSession(provider.id, provider.configVersion, { linkUserId: staff.id, authEpoch: 1, mfaEpoch: 1, sessionId: familyId });
+      setCallbackMocks(`sub-c-${randomUUID()}`, staff.email, nonce, true);
+      const res = await callback(app, state, cookie);
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('/settings/profile?ssoLinked=1');
+      expect(await identityCountFor(provider.id)).toBe(1);
+    }
+
+    // Staff user violates the partner-staff invariant by gaining an orgId →
+    // link_axis_membership_lost → session_invalid, no new identity.
+    const org = await createOrganization({ partnerId: partner.id });
+    const violator = await seedPasswordlessUser({ partnerId: partner.id, orgId: org.id, email: `violator-c-${randomUUID()}@${EMAIL_DOMAIN}` });
+    await assignUserToPartner(violator.id, partner.id, partnerRole.id, 'all');
+    const violatorFamily = randomUUID();
+    await getTestDb().insert(refreshTokenFamilies).values({ familyId: violatorFamily, userId: violator.id, absoluteExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000) });
+
+    {
+      const { state, nonce, cookie } = await seedLinkSession(provider.id, provider.configVersion, { linkUserId: violator.id, authEpoch: 1, mfaEpoch: 1, sessionId: violatorFamily });
+      setCallbackMocks(`sub-c2-${randomUUID()}`, violator.email, nonce, true);
+      const res = await callback(app, state, cookie);
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('/settings/profile?ssoLinkError=session_invalid');
+      // still only the one identity from the successful staff link
+      expect(await identityCountFor(provider.id)).toBe(1);
+    }
+  });
+});

--- a/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
@@ -35,9 +35,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 import { decodeJwt } from 'jose';
 import { and, eq } from 'drizzle-orm';
-import { createHmac } from 'crypto';
+import { createHmac, randomUUID } from 'crypto';
 import { getTestDb } from './setup';
-import { ssoProviders, ssoSessions, userSsoIdentities, users } from '../../db/schema';
+import { ssoProviders, ssoSessions, userSsoIdentities, users, refreshTokenFamilies } from '../../db/schema';
 import {
   createPartner,
   createOrganization,
@@ -401,6 +401,15 @@ describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', ()
 
     // (b) Authenticated POST /sso/link/start/:providerId as V (mfa:true in
     // the test token, since requireMfa() gates the link-start route).
+    // PR 3's SR2-11b link binding stores the initiating token's `sid` on the
+    // link session and requires that refresh family to still be LIVE at the
+    // callback. Mint one so /link/start's snapshot binds to a real family.
+    const vFamilyId = randomUUID();
+    await db.insert(refreshTokenFamilies).values({
+      familyId: vFamilyId,
+      userId: passwordUser.id,
+      absoluteExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    });
     const vToken = await createAccessToken({
       sub: passwordUser.id,
       email: passwordUser.email,
@@ -411,9 +420,11 @@ describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', ()
       mfa: true,
       // Epoch claims (core-auth PR 1): authMiddleware rejects access tokens
       // missing aep/mep/sid or stale vs users.auth_epoch/mfa_epoch (DB default 1).
+      // sid must be the LIVE family id, not a placeholder, so the SR2-11b link
+      // binding can resolve it back to a refresh_token_family.
       aep: 1,
       mep: 1,
-      sid: 'it-session',
+      sid: vFamilyId,
     });
 
     const linkStartRes = await app.request(`/sso/link/start/${provider.id}`, {
@@ -538,6 +549,9 @@ describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', ()
       codeVerifier: null,
       redirectUrl: '/',
       linkUserId: null,
+      // Task 4's generation gate rejects a callback whose session provider_version
+      // doesn't match the provider's config_version (NULL → provider_version_missing).
+      providerVersion: orgProvider.configVersion,
       expiresAt: new Date(Date.now() + 10 * 60 * 1000),
     });
 

--- a/apps/api/src/__tests__/integration/ssoSessionsRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoSessionsRls.integration.test.ts
@@ -1,0 +1,397 @@
+/**
+ * sso_sessions RLS — system-scope-only enforcement (SR2-11, Task 1).
+ *
+ * Migration under test: 2026-07-16-sso-session-binding-and-provider-version.sql.
+ *
+ * sso_sessions is a pre-auth CSRF/PKCE transaction store with NO tenant column.
+ * Task 1 gave it ENABLE + FORCE ROW LEVEL SECURITY plus ONE ALL-command policy
+ * keyed on `breeze.scope = 'system'` (`sso_sessions_system_only`). This suite
+ * proves the policy is real against the genuine `breeze_app` RLS-enforced pool
+ * (the rls-coverage contract test only asserts the policy EXISTS; it does not
+ * exercise it), and — critically — that enabling it did NOT brick provider
+ * deletion (C1), which depends on the two authenticated bare-`db` writers moving
+ * into system context.
+ *
+ * SQLSTATE discipline (memory: rls-forge-test-memoized-fixture-vacuous): every
+ * negative control asserts the SPECIFIC Postgres error code (42501 for an INSERT
+ * WITH CHECK deny) or a concrete 0-row / row-survives property — never a bare
+ * `.rejects.toThrow()`.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'crypto';
+import { eq, sql } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, runOutsideDbContext, type DbAccessContext } from '../../db';
+import { getTestDb } from './setup';
+import { ssoProviders, ssoSessions, userSsoIdentities, users } from '../../db/schema';
+import {
+  createOrganization,
+  createPartner,
+  createRole,
+  assignUserToOrganization,
+  grantRolePermissions,
+} from './db-utils';
+import { encryptSecret } from '../../services/secretCrypto';
+import { createAccessToken } from '../../services/jwt';
+import { Hono } from 'hono';
+import { ssoRoutes } from '../../routes/sso';
+
+// The link-start route needs this to sign the state cookie; harmless here but
+// keeps parity with the other SSO integration suites.
+process.env.APP_ENCRYPTION_KEY =
+  process.env.APP_ENCRYPTION_KEY || 'integration-test-app-encryption-key-32-bytes!';
+
+const ISSUER = 'https://idp.example.test';
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+/** Seed an org-axis provider directly (superuser bypasses RLS for seeding). */
+async function seedOrgProvider(orgId: string) {
+  const testDb = getTestDb();
+  const [row] = await testDb
+    .insert(ssoProviders)
+    .values({
+      orgId,
+      partnerId: null,
+      name: `RLS IdP ${randomUUID()}`,
+      type: 'oidc',
+      status: 'active',
+      issuer: ISSUER,
+      clientId: 'test-client-id',
+      clientSecret: encryptSecret('test-client-secret'),
+      authorizationUrl: `${ISSUER}/authorize`,
+      tokenUrl: `${ISSUER}/token`,
+      userInfoUrl: `${ISSUER}/userinfo`,
+      jwksUrl: `${ISSUER}/jwks`,
+      autoProvision: false,
+    })
+    .returning();
+  if (!row) throw new Error('failed to seed provider');
+  return row;
+}
+
+const trackedProviders: string[] = [];
+afterEach(async () => {
+  if (trackedProviders.length === 0) return;
+  const testDb = getTestDb();
+  for (const id of trackedProviders) {
+    await testDb.delete(ssoSessions).where(eq(ssoSessions.providerId, id));
+    await testDb.delete(userSsoIdentities).where(eq(userSsoIdentities.providerId, id));
+    await testDb.delete(ssoProviders).where(eq(ssoProviders.id, id));
+  }
+  trackedProviders.length = 0;
+});
+
+describe('sso_sessions RLS — system-scope-only (2026-07-16 migration)', () => {
+  it('a row inserted under system scope is INVISIBLE to an org-scoped SELECT (0 rows, not an error)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const provider = await seedOrgProvider(org.id);
+    trackedProviders.push(provider.id);
+
+    const state = `rls-select-${randomUUID()}`;
+    await withSystemDbAccessContext(async () =>
+      db.insert(ssoSessions).values({
+        providerId: provider.id,
+        state,
+        nonce: `nonce-${randomUUID()}`,
+        expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+      }),
+    );
+
+    // Under an org-scoped context breeze_app cannot satisfy USING(scope='system'):
+    // the row is filtered out, so the SELECT returns 0 rows (no error).
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db.select({ id: ssoSessions.id }).from(ssoSessions).where(eq(ssoSessions.state, state)),
+    );
+    expect(visibleToOrg).toEqual([]);
+
+    // The row genuinely exists (superuser bypasses RLS).
+    const [systemView] = await getTestDb()
+      .select({ id: ssoSessions.id })
+      .from(ssoSessions)
+      .where(eq(ssoSessions.state, state))
+      .limit(1);
+    expect(systemView).toBeDefined();
+  });
+
+  it('an org-scoped INSERT is denied with SQLSTATE 42501 (WITH CHECK)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const provider = await seedOrgProvider(org.id);
+    trackedProviders.push(provider.id);
+
+    await expect(
+      withDbAccessContext(orgContext(org.id), () =>
+        db.insert(ssoSessions).values({
+          providerId: provider.id,
+          state: `rls-forge-${randomUUID()}`,
+          nonce: `nonce-${randomUUID()}`,
+          expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+        }),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('an org-scoped DELETE is a no-op: 0 rows affected and the row survives (cannot burn another scope\'s pending state)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const provider = await seedOrgProvider(org.id);
+    trackedProviders.push(provider.id);
+
+    const state = `rls-delete-${randomUUID()}`;
+    await withSystemDbAccessContext(async () =>
+      db.insert(ssoSessions).values({
+        providerId: provider.id,
+        state,
+        nonce: `nonce-${randomUUID()}`,
+        expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+      }),
+    );
+
+    const deleted = await withDbAccessContext(orgContext(org.id), () =>
+      db.delete(ssoSessions).where(eq(ssoSessions.state, state)).returning({ id: ssoSessions.id }),
+    );
+    expect(deleted).toEqual([]);
+
+    // Still present under system scope — the delete never touched it.
+    const survivor = await withSystemDbAccessContext(async () =>
+      db.select({ id: ssoSessions.id }).from(ssoSessions).where(eq(ssoSessions.state, state)).limit(1),
+    );
+    expect(survivor).toHaveLength(1);
+  });
+
+  it('system scope can INSERT, SELECT and DELETE the row', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const provider = await seedOrgProvider(org.id);
+    trackedProviders.push(provider.id);
+
+    const state = `rls-system-${randomUUID()}`;
+    await withSystemDbAccessContext(async () =>
+      db.insert(ssoSessions).values({
+        providerId: provider.id,
+        state,
+        nonce: `nonce-${randomUUID()}`,
+        expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+      }),
+    );
+
+    const selected = await withSystemDbAccessContext(async () =>
+      db.select({ id: ssoSessions.id }).from(ssoSessions).where(eq(ssoSessions.state, state)).limit(1),
+    );
+    expect(selected).toHaveLength(1);
+
+    const deleted = await withSystemDbAccessContext(async () =>
+      db.delete(ssoSessions).where(eq(ssoSessions.state, state)).returning({ id: ssoSessions.id }),
+    );
+    expect(deleted).toHaveLength(1);
+  });
+
+  // ── C1: DELETE /providers/:id survives BOTH RLS blockers ──────────────────
+  // sso_sessions (system-only) + user_sso_identities (USER_ID_SCOPED) would each
+  // silently 0-row from an admin's tenant context, and neither FK cascades — so
+  // before Task 1's system-context wrap the provider delete would die with FK
+  // 23503. These prove the wrap works, and — carry-list proof A — that the three
+  // deletes share ONE transaction.
+
+  async function orgAdminToken(orgId: string, partnerId: string) {
+    // An org admin holding sso:admin, MFA-satisfied (requireMfa gates the route).
+    const role = await createRole({ scope: 'organization', orgId });
+    await grantRolePermissions(role.id, [{ resource: 'sso', action: 'admin' }]);
+    const testDb = getTestDb();
+    const [admin] = await testDb
+      .insert(users)
+      .values({
+        partnerId,
+        orgId,
+        email: `sso-admin-${randomUUID()}@corp.example`,
+        name: 'SSO Admin',
+        passwordHash: null,
+        status: 'active',
+      })
+      .returning();
+    if (!admin) throw new Error('failed to seed admin');
+    await assignUserToOrganization(admin.id, orgId, role.id);
+    const token = await createAccessToken({
+      sub: admin.id,
+      email: admin.email,
+      roleId: role.id,
+      orgId,
+      partnerId: null,
+      scope: 'organization',
+      mfa: true,
+      aep: 1,
+      mep: 1,
+      sid: randomUUID(),
+    });
+    return { admin, token };
+  }
+
+  it('C1: DELETE /providers/:id returns 200 and removes the provider, its pending session, AND another user\'s identity link', async () => {
+    const app = new Hono();
+    app.route('/sso', ssoRoutes);
+
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const provider = await seedOrgProvider(org.id);
+    trackedProviders.push(provider.id);
+    const { token } = await orgAdminToken(org.id, partner.id);
+
+    const testDb = getTestDb();
+    // (a) a pending session for the provider
+    await testDb.insert(ssoSessions).values({
+      providerId: provider.id,
+      state: `c1-${randomUUID()}`,
+      nonce: `nonce-${randomUUID()}`,
+      providerVersion: provider.configVersion,
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+    });
+    // (b) an identity link belonging to a DIFFERENT user than the deleting admin
+    const [otherUser] = await testDb
+      .insert(users)
+      .values({
+        partnerId: partner.id,
+        orgId: org.id,
+        email: `other-${randomUUID()}@corp.example`,
+        name: 'Other User',
+        passwordHash: null,
+        status: 'active',
+      })
+      .returning();
+    await testDb.insert(userSsoIdentities).values({
+      userId: otherUser!.id,
+      providerId: provider.id,
+      externalId: `ext-${randomUUID()}`,
+      email: otherUser!.email,
+    });
+
+    const res = await app.request(`/sso/providers/${provider.id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+
+    const providerRows = await testDb.select({ id: ssoProviders.id }).from(ssoProviders).where(eq(ssoProviders.id, provider.id));
+    const sessionRows = await testDb.select({ id: ssoSessions.id }).from(ssoSessions).where(eq(ssoSessions.providerId, provider.id));
+    const identityRows = await testDb.select({ id: userSsoIdentities.id }).from(userSsoIdentities).where(eq(userSsoIdentities.providerId, provider.id));
+    expect(providerRows).toEqual([]);
+    expect(sessionRows).toEqual([]);
+    expect(identityRows).toEqual([]);
+  });
+
+  it('C1/404: DELETE on a non-existent provider id performs ZERO deletes (guard-before-delete ordering)', async () => {
+    const app = new Hono();
+    app.route('/sso', ssoRoutes);
+
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const provider = await seedOrgProvider(org.id);
+    trackedProviders.push(provider.id);
+    const { token } = await orgAdminToken(org.id, partner.id);
+
+    const testDb = getTestDb();
+    await testDb.insert(ssoSessions).values({
+      providerId: provider.id,
+      state: `c1-404-${randomUUID()}`,
+      nonce: `nonce-${randomUUID()}`,
+      providerVersion: provider.configVersion,
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+    });
+
+    const res = await app.request(`/sso/providers/${randomUUID()}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(404);
+
+    // The real provider's session is untouched — the 404 returns before the
+    // system-context cleanup block runs.
+    const sessionRows = await testDb.select({ id: ssoSessions.id }).from(ssoSessions).where(eq(ssoSessions.providerId, provider.id));
+    expect(sessionRows).toHaveLength(1);
+  });
+
+  it('A: atomicity — if the provider DELETE fails mid-transaction, the identity/session deletes roll back', async () => {
+    // Carry-list proof A. The only FK children of sso_providers are the two the
+    // route itself deletes (sso_sessions, user_sso_identities), so there is no
+    // natural un-cleaned child to block the provider delete. We CONSTRUCT one: a
+    // throwaway table with an ON DELETE NO ACTION FK to sso_providers. With a row
+    // in it, the provider delete throws FK 23503 INSIDE the single
+    // withSystemDbAccessContext transaction, which rolls back the already-issued
+    // session + identity deletes. We assert the other user's identity SURVIVES.
+    const app = new Hono();
+    app.route('/sso', ssoRoutes);
+
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const provider = await seedOrgProvider(org.id);
+    trackedProviders.push(provider.id);
+    const { token } = await orgAdminToken(org.id, partner.id);
+
+    const testDb = getTestDb();
+    const blockerTable = `_t8_fk_blocker_${randomUUID().replace(/-/g, '')}`;
+    try {
+      // NO ACTION (default) → the parent delete fails while a child exists.
+      await testDb.execute(
+        sql.raw(
+          `CREATE TABLE ${blockerTable} (id uuid primary key default gen_random_uuid(), provider_id uuid REFERENCES sso_providers(id))`,
+        ),
+      );
+
+      const [otherUser] = await testDb
+        .insert(users)
+        .values({
+          partnerId: partner.id,
+          orgId: org.id,
+          email: `atomic-${randomUUID()}@corp.example`,
+          name: 'Atomic User',
+          passwordHash: null,
+          status: 'active',
+        })
+        .returning();
+      await testDb.insert(userSsoIdentities).values({
+        userId: otherUser!.id,
+        providerId: provider.id,
+        externalId: `ext-atomic-${randomUUID()}`,
+        email: otherUser!.email,
+      });
+      await testDb.insert(ssoSessions).values({
+        providerId: provider.id,
+        state: `atomic-${randomUUID()}`,
+        nonce: `nonce-${randomUUID()}`,
+        providerVersion: provider.configVersion,
+        expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+      });
+
+      // The blocker row makes the provider delete fail 23503.
+      await testDb.execute(sql.raw(`INSERT INTO ${blockerTable} (provider_id) VALUES ('${provider.id}')`));
+
+      const res = await app.request(`/sso/providers/${provider.id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      // The uncaught FK error surfaces as a 500 from the route.
+      expect(res.status).toBe(500);
+
+      // ROLLBACK PROPERTY: the identity + session deletes that ran earlier in the
+      // same transaction were rolled back — the rows survive.
+      const identityRows = await testDb.select({ id: userSsoIdentities.id }).from(userSsoIdentities).where(eq(userSsoIdentities.providerId, provider.id));
+      const sessionRows = await testDb.select({ id: ssoSessions.id }).from(ssoSessions).where(eq(ssoSessions.providerId, provider.id));
+      const providerRows = await testDb.select({ id: ssoProviders.id }).from(ssoProviders).where(eq(ssoProviders.id, provider.id));
+      expect(identityRows).toHaveLength(1);
+      expect(sessionRows).toHaveLength(1);
+      expect(providerRows).toHaveLength(1);
+    } finally {
+      await testDb.execute(sql.raw(`DROP TABLE IF EXISTS ${blockerTable}`));
+    }
+  });
+});

--- a/apps/api/src/db/schema/sso.ts
+++ b/apps/api/src/db/schema/sso.ts
@@ -68,7 +68,12 @@ export const ssoProviders = pgTable('sso_providers', {
   // when the previous configurer is offboarded. NOT createdBy: that names the
   // original creator (who may never have touched defaultRoleId), and no route
   // ever rewrites it.
-  defaultRoleConfiguredBy: uuid('default_role_configured_by').references(() => users.id),
+  //
+  // ON DELETE SET NULL (2026-07-17): a hard-deleted configurer must REVOKE the
+  // standing delegation, not preserve it. NULL here makes JIT fail closed
+  // (`default_role_configurer_unknown` in revalidateSsoDefaultRole); the repair
+  // is a current admin re-saving the default role, which re-stamps this column.
+  defaultRoleConfiguredBy: uuid('default_role_configured_by').references(() => users.id, { onDelete: 'set null' }),
 
   // Metadata
   createdBy: uuid('created_by').references(() => users.id),

--- a/apps/api/src/db/schema/sso.ts
+++ b/apps/api/src/db/schema/sso.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, uniqueIndex } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, uniqueIndex, integer } from 'drizzle-orm/pg-core';
 import { organizations, partners } from './orgs';
 import { users } from './users';
 
@@ -55,6 +55,21 @@ export const ssoProviders = pgTable('sso_providers', {
   // Breeze MFA-gated routes via their IdP). Off by default — fail-safe.
   trustsIdpMfa: boolean('trusts_idp_mfa').notNull().default(false),
 
+  // Monotonic config generation (SR2-11). Bumped by PATCH /providers/:id and by
+  // POST /providers/:id/status. Pending sso_sessions snapshot this value; the
+  // callback rejects a session whose snapshot no longer matches, so a provider
+  // reconfigured or disabled mid-flow cannot complete a login or a link.
+  configVersion: integer('config_version').notNull().default(1),
+
+  // SR2-10: the admin who LAST SET defaultRoleId — the principal whose LIVE
+  // permission ceiling the callback re-checks the delegated role against just
+  // before JIT provisioning. Stamped by POST /providers and by every PATCH that
+  // sets defaultRoleId, so "re-save the default role" is a first-class repair
+  // when the previous configurer is offboarded. NOT createdBy: that names the
+  // original creator (who may never have touched defaultRoleId), and no route
+  // ever rewrites it.
+  defaultRoleConfiguredBy: uuid('default_role_configured_by').references(() => users.id),
+
   // Metadata
   createdBy: uuid('created_by').references(() => users.id),
   createdAt: timestamp('created_at').defaultNow().notNull(),
@@ -104,6 +119,23 @@ export const ssoSessions = pgTable('sso_sessions', {
   // deleted by the callback) must not block a hard user delete — sso_sessions
   // has no partner_id/org_id, so the tenant-cascade sweep never reaches it.
   linkUserId: uuid('link_user_id').references(() => users.id, { onDelete: 'cascade' }),
+
+  // SR2-11 pending-transaction binding.
+  //
+  // providerVersion: sso_providers.config_version at creation. NULL only for
+  // rows written before this column existed — the callback REJECTS those.
+  providerVersion: integer('provider_version'),
+
+  // The three initiating_* columns are LINK-MODE ONLY (set by
+  // POST /sso/link/start alongside linkUserId). A login session has no
+  // initiating user, so they stay NULL there — which is why they are nullable.
+  // The link callback requires all three to be present AND to still match live
+  // state, which is what makes logout / password reset / MFA reset / suspension
+  // / global revocation invalidate a pending link.
+  initiatingAuthEpoch: integer('initiating_auth_epoch'),
+  initiatingMfaEpoch: integer('initiating_mfa_epoch'),
+  // = refresh_token_families.family_id == the initiating access token's `sid`.
+  initiatingSessionId: uuid('initiating_session_id'),
 
   expiresAt: timestamp('expires_at').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull()

--- a/apps/api/src/middleware/selfManagedDbContextRoutes.test.ts
+++ b/apps/api/src/middleware/selfManagedDbContextRoutes.test.ts
@@ -27,6 +27,15 @@ describe('isSelfManagedDbContextRoute', () => {
     ['POST', '/api/v1/catalog/distributors/pax8/import'],
     ['POST', '/api/v1/catalog/distributors/pax8/import/'],
     ['post', '/api/v1/catalog/distributors/pax8/import'], // method is case-insensitive
+    // PR3 — the three SSO provider routes that run OIDC discovery against a
+    // tenant-controlled issuer (10s timeout) inside the handler.
+    ['POST', '/api/v1/sso/providers'],
+    ['POST', '/api/v1/sso/providers/'],
+    ['PATCH', '/api/v1/sso/providers/abc-123'],
+    ['PATCH', '/api/v1/sso/providers/abc-123/'],
+    ['patch', '/api/v1/sso/providers/abc-123'], // method is case-insensitive
+    ['POST', '/api/v1/sso/providers/abc-123/test'],
+    ['POST', '/api/v1/sso/providers/abc-123/test/'],
   ];
 
   const NO_MATCH: ReadonlyArray<[string, string, string]> = [
@@ -58,6 +67,17 @@ describe('isSelfManagedDbContextRoute', () => {
     ['GET', '/api/v1/catalog/distributors/pax8/pricing', 'pricing is DB-only'],
     ['POST', '/api/v1/catalog/distributors/pax8/import/extra', 'extra segment must not match'],
     ['GET', '/api/v1/catalog/distributors/pax8/import', 'import is POST-only'],
+    // PR3 — every OTHER sso route does only DB work and MUST keep the ambient
+    // RLS transaction. A wrong match here silently drops tenant scoping.
+    ['GET', '/api/v1/sso/providers', 'list is DB-only'],
+    ['GET', '/api/v1/sso/providers/abc-123', 'detail read is DB-only'],
+    ['DELETE', '/api/v1/sso/providers/abc-123', 'delete is DB-only (system-context cascade)'],
+    ['POST', '/api/v1/sso/providers/abc-123/status', 'status flip is DB-only'],
+    ['PATCH', '/api/v1/sso/providers/abc-123/test', 'no such route; PATCH only opts out on the bare provider path'],
+    ['GET', '/api/v1/sso/providers/abc-123/test', 'test is POST-only'],
+    ['POST', '/api/v1/sso/providers/abc-123/test/extra', 'extra segment must not match'],
+    ['POST', '/api/v1/sso/domains', 'domain routes are DB-only'],
+    ['POST', '/api/v1/sso/link/start/abc-123', 'link start is DB-only'],
   ];
 
   it.each(MATCH)('opts out: %s %s', (method, path) => {

--- a/apps/api/src/middleware/selfManagedDbContextRoutes.ts
+++ b/apps/api/src/middleware/selfManagedDbContextRoutes.ts
@@ -52,6 +52,19 @@ const SELF_MANAGED_DB_CONTEXT_ROUTES: readonly SelfManagedRoute[] = [
   // 30s readyTimeout). testSftpConnection wraps each DB op in its own short
   // withDbAccessContext, so the socket is never held across an open transaction.
   { method: 'POST', pattern: /^\/api\/v1\/catalog\/distributors\/td-synnex-sftp\/test\/?$/ },
+  // PR3 (SSO/OIDC) — the three provider routes that run OIDC discovery
+  // (`discoverOIDCConfig` → `safeFetch`, up to OIDC_FETCH_TIMEOUT_MS = 10s
+  // against a TENANT-CONTROLLED issuer host). Held inside the request
+  // transaction, a tenant admin pointing `issuer` at a blackholed host pins a
+  // pooled connection idle-in-transaction for 10s per call, on unrate-limited
+  // routes, against a 25-connection prod pool — tenant-triggerable pool
+  // starvation for every tenant (#1105 class). The handlers wrap each DB op in
+  // its own short `withDbAccessContext(dbAccessContextFromAuth(auth), …)` block
+  // (see `withProviderDbContext` in routes/sso.ts) and run discovery between
+  // them, holding no connection across the network call.
+  { method: 'POST', pattern: /^\/api\/v1\/sso\/providers\/?$/ },
+  { method: 'PATCH', pattern: /^\/api\/v1\/sso\/providers\/[^/]+\/?$/ },
+  { method: 'POST', pattern: /^\/api\/v1\/sso\/providers\/[^/]+\/test\/?$/ },
 ];
 
 /**

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -45,6 +45,24 @@ vi.mock('../services/sso', () => ({
   idpAssertedMfa: (claims: { amr?: unknown }) => Array.isArray(claims?.amr) && claims.amr.includes('mfa'),
   mapUserAttributes: vi.fn(),
   discoverOIDCConfig: vi.fn(),
+  // SR2-14: getOIDCConfig (defined in the route file, NOT mocked) now calls this
+  // to re-validate persisted endpoints at runtime. Faithful mirror of the real
+  // implementation (missing / non-HTTPS / internal-literal → throw) so the
+  // runtime-revalidation tests bite while safe https endpoints stay no-ops.
+  assertSafeOidcEndpoint: (label: string, urlStr: string | null | undefined, allowPrivateNetwork = false) => {
+    if (!urlStr) throw new Error(`OIDC endpoint missing: ${label}`);
+    let u: URL;
+    try { u = new URL(urlStr); } catch { throw new Error(`OIDC endpoint rejected: ${label}`); }
+    const isHttps = u.protocol === 'https:';
+    const isHttp = u.protocol === 'http:';
+    if (!isHttps && !(allowPrivateNetwork && isHttp)) throw new Error(`OIDC endpoint rejected (must be HTTPS): ${label}`);
+    const host = u.hostname.replace(/^\[|\]$/g, '');
+    if (host === 'localhost') throw new Error(`OIDC endpoint rejected (internal): ${label}`);
+    const literalIp = /^[0-9.]+$/.test(host) || host.includes(':');
+    if (literalIp && /^(127\.|10\.|192\.168\.|169\.254\.|0\.|172\.(1[6-9]|2\d|3[01])\.|::1|::$|fc|fd|fe80)/i.test(host)) {
+      throw new Error(`OIDC endpoint rejected (internal): ${label}`);
+    }
+  },
   PROVIDER_PRESETS: {
     okta: {
       scopes: 'openid profile email',
@@ -1583,6 +1601,23 @@ describe('sso routes', () => {
       expect(createTokenPair).toHaveBeenCalledWith(expect.objectContaining({ sub: USER_UUID }), expect.any(Object));
     });
 
+    // SR2-14: the callback re-reads the provider and builds its OIDC config via
+    // getOIDCConfig, which now re-validates the persisted endpoints. A stale/
+    // attacker tokenUrl (e.g. left by a PATCH issuer change) must abort the flow
+    // via the existing catch-all redirect BEFORE the code is exchanged — the
+    // decrypted client_secret never leaves the process.
+    it('re-validates persisted endpoints at runtime: an unsafe tokenUrl redirects without a token exchange', async () => {
+      primeCallback();
+      vi.mocked(db.select).mockReturnValueOnce(
+        sel([{ ...PROVIDER_ROW[0], tokenUrl: 'http://evil.example.com/token' }])
+      );
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('/login?error=sso_error');
+      expect(exchangeCodeForTokens).not.toHaveBeenCalled();
+    });
+
     it('refuses to JIT-link an SSO assertion to an existing PASSWORD account (1B)', async () => {
       primeCallback();
       vi.mocked(db.select)
@@ -2534,6 +2569,22 @@ describe('sso routes', () => {
         providerVersion: ACTIVE_OIDC_PROVIDER_ROW.configVersion
       }));
       expect(res.headers.get('set-cookie') ?? '').toContain('breeze_sso_state=');
+    });
+
+    // SR2-14: an endpoint that was persisted (or left stale by a PATCH issuer
+    // change) pointing at a non-HTTPS/internal host must yield a clean 400, not
+    // an unhandled 500 from getOIDCConfig throwing out of the handler.
+    it('returns 400 for a provider with an unsafe persisted endpoint (not 500)', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(
+        providerSelectChain([
+          { ...ACTIVE_OIDC_PROVIDER_ROW, orgId: ORG_UUID, partnerId: null, tokenUrl: 'http://evil.example.com/token' }
+        ]) as any
+      );
+
+      const res = await app.request(`/sso/login/${ORG_UUID}`);
+
+      expect(res.status).toBe(400);
+      expect(db.insert).not.toHaveBeenCalled();
     });
 
     it('429s on the per-(IP, org) bucket without touching the DB', async () => {

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -747,6 +747,79 @@ describe('sso routes', () => {
     // context, not the caller's tenant-scoped context.
     expect(runOutsideDbContext).toHaveBeenCalled();
     expect(withSystemDbAccessContext).toHaveBeenCalled();
+    // Atomicity: all three deletes must be issued from inside ONE
+    // withSystemDbAccessContext invocation, not the cleanup pair in one call
+    // and the provider delete in a second (which would put the provider
+    // delete back in the request transaction on a different connection).
+    //
+    // NOTE: withSystemDbAccessContext is called a SECOND time on this happy
+    // path too — but that second call is the unrelated writeRouteAudit ->
+    // createAuditLogAsync fire-and-forget audit-log write (see
+    // services/auditService.ts), not a second provider-cleanup wrap. So a
+    // bare `toHaveBeenCalledTimes(1)` assertion would be wrong here; instead
+    // assert that all three delete() calls landed inside the FIRST
+    // withSystemDbAccessContext invocation, before any subsequent one fired.
+    // The mock harness can prove this grouping via invocation order, but it
+    // cannot observe connection/transaction boundaries directly — that
+    // cross-connection guarantee is left to the Task 8 integration suite
+    // against a real Postgres.
+    const deleteCallOrders = vi.mocked(db.delete).mock.invocationCallOrder;
+    const systemCtxCallOrders = vi.mocked(withSystemDbAccessContext).mock.invocationCallOrder;
+    const secondSystemCtxCallOrder = systemCtxCallOrders[1];
+    expect(deleteCallOrders).toHaveLength(3);
+    if (secondSystemCtxCallOrder !== undefined) {
+      expect(deleteCallOrders.every((order) => order < secondSystemCtxCallOrder)).toBe(true);
+    }
+  });
+
+  // Atomicity regression guard (SR2-11): the provider delete must live in the
+  // SAME withSystemDbAccessContext call as the sso_sessions/user_sso_identities
+  // cleanup. Before this fix, the provider delete ran separately in the
+  // caller's request transaction — so a concurrent-delete 404 here (or a
+  // thrown error) would roll back the request transaction while the cleanup
+  // deletes, already committed on a different connection, stayed gone
+  // forever. This proves the 404 path is reached via the single wrapped call
+  // and that no second withSystemDbAccessContext invocation was made to
+  // salvage/duplicate the provider delete. Unlike the happy-path test above,
+  // `toHaveBeenCalledTimes(1)` IS a valid assertion here: the 404 branch
+  // returns before writeRouteAudit (and its own unrelated
+  // withSystemDbAccessContext call) is ever reached.
+  it('returns 404 without a second system-context call when the provider delete finds no row (concurrent-delete race)', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID, orgId: ORG_UUID }])
+        })
+      })
+    } as any);
+
+    // sso_sessions and user_sso_identities cleanup succeed, but by the time
+    // the provider delete runs (still inside the same system-context call),
+    // a concurrent request has already removed the row — .returning() comes
+    // back empty.
+    vi.mocked(db.delete)
+      .mockReturnValueOnce({ where: vi.fn().mockResolvedValue(undefined) } as any)
+      .mockReturnValueOnce({ where: vi.fn().mockResolvedValue(undefined) } as any)
+      .mockReturnValueOnce({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([])
+        })
+      } as any);
+
+    const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Provider not found');
+
+    // All three deletes were still attempted inside the one wrapped call —
+    // the handler doesn't short-circuit the cleanup deletes early, and it
+    // doesn't retry/fall back into a second system-context invocation.
+    expect(db.delete).toHaveBeenCalledTimes(3);
+    expect(withSystemDbAccessContext).toHaveBeenCalledTimes(1);
   });
 
   it('rejects testing non-OIDC providers', async () => {

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -59,6 +59,13 @@ vi.mock('../services', () => ({
   mintRefreshTokenFamily: vi.fn().mockResolvedValue('sso-family-id-mock'),
   bindRefreshJtiToFamily: vi.fn().mockResolvedValue(undefined),
   getUserEpochs: vi.fn().mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 }),
+  // SR2-11b: /sso/link/start binds the pending link to the initiating refresh
+  // family; the link callback re-checks it is still live (not revoked/expired)
+  // as part of validateLinkBinding. Default: a healthy, far-future family.
+  getRefreshFamily: vi.fn().mockResolvedValue({
+    revokedAt: null,
+    absoluteExpiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+  }),
   // Partner-axis login rate limiting (#2183 spec §5) — default allowed so
   // existing tests exercising the route body are unaffected; the dedicated
   // 429 test overrides this per-call.
@@ -257,7 +264,10 @@ vi.mock('../middleware/auth', () => ({
       partnerId: null,
       accessibleOrgIds: ['00000000-0000-4000-8000-000000000010'],
       canAccessOrg: () => true,
-      user: { id: '00000000-0000-4000-8000-000000000020', email: 'test@example.com' }
+      user: { id: '00000000-0000-4000-8000-000000000020', email: 'test@example.com' },
+      // SR2-11b: /sso/link/start binds the pending session to the initiating
+      // refresh family. Without this key every link test throws on auth.token.sid.
+      token: { sid: '00000000-0000-4000-8000-0000000000fa' },
     });
     return next();
   }),
@@ -286,7 +296,7 @@ vi.mock('../middleware/auth', () => ({
 }));
 
 import { db, runOutsideDbContext, withSystemDbAccessContext, getCurrentDbAccessContext } from '../db';
-import { createTokenPair, rateLimiter } from '../services';
+import { createTokenPair, rateLimiter, getUserEpochs, getRefreshFamily } from '../services';
 import { authMiddleware } from '../middleware/auth';
 import {
   discoverOIDCConfig,
@@ -317,6 +327,7 @@ describe('sso routes', () => {
     accessibleOrgIds: string[] | null;
     canAccessOrg: (orgId: string) => boolean;
     partnerOrgAccess: 'all' | 'selected' | 'none' | null;
+    token: Record<string, unknown>;
   }> = {}) => {
     vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
       c.set('auth', {
@@ -326,7 +337,11 @@ describe('sso routes', () => {
         accessibleOrgIds: 'accessibleOrgIds' in overrides ? overrides.accessibleOrgIds : [ORG_UUID],
         canAccessOrg: overrides.canAccessOrg ?? (() => true),
         partnerOrgAccess: 'partnerOrgAccess' in overrides ? overrides.partnerOrgAccess : null,
-        user: { id: USER_UUID, email: 'test@example.com' }
+        user: { id: USER_UUID, email: 'test@example.com' },
+        // SR2-11b: /sso/link/start binds the pending session to the initiating
+        // refresh family — defaults to a populated sid; tests that need to
+        // exercise the missing-sid 503 path override `token`.
+        token: 'token' in overrides ? overrides.token : { sid: '00000000-0000-4000-8000-0000000000fa' }
       });
       return next();
     });
@@ -2685,7 +2700,10 @@ describe('sso routes', () => {
       expect(body.data).toEqual([{ id: 'pp-1', name: 'MSP IdP', type: 'oidc', linked: false }]);
     });
 
-    it('POST /sso/link/start/:providerId returns authUrl, sets state cookie, and stamps linkUserId', async () => {
+    // SR2-11b: /link/start snapshots {authEpoch, mfaEpoch, sid} at creation
+    // (default auth mock: getUserEpochs → {authEpoch:1, mfaEpoch:1}, token.sid
+    // → INITIATING_SID) so the callback can re-check them against live state.
+    it('POST /sso/link/start/:providerId returns authUrl, sets state cookie, and stamps linkUserId + SR2-11b binding', async () => {
       vi.mocked(db.select).mockReturnValueOnce(sel([ORG_PROVIDER]));
       const insertValues = vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) }));
       vi.mocked(db.insert).mockReturnValueOnce({ values: insertValues } as any);
@@ -2700,7 +2718,13 @@ describe('sso routes', () => {
       expect(body.authUrl).toMatch(/^https:\/\/idp\.example\.com\/auth/);
       const setCookie = res.headers.get('set-cookie') ?? '';
       expect(setCookie).toContain('breeze_sso_state');
-      expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ linkUserId: USER_UUID }));
+      expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({
+        linkUserId: USER_UUID,
+        providerVersion: ORG_PROVIDER.configVersion,
+        initiatingAuthEpoch: 1,
+        initiatingMfaEpoch: 1,
+        initiatingSessionId: INITIATING_SID,
+      }));
     });
 
     it('POST /sso/link/start 401s an unauthenticated caller', async () => {
@@ -2738,23 +2762,86 @@ describe('sso routes', () => {
       expect(partnerRes.status).toBe(403);
     });
 
+    it('POST /sso/link/start returns 503 when epochs are unavailable (no session written)', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(sel([ORG_PROVIDER]));
+      vi.mocked(getUserEpochs).mockResolvedValueOnce(null);
+
+      const res = await app.request(`/sso/link/start/${PROVIDER_UUID}`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(503);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('POST /sso/link/start returns 503 when the token has no sid (no session written)', async () => {
+      setAuthContext({ token: {} });
+      vi.mocked(db.select).mockReturnValueOnce(sel([ORG_PROVIDER]));
+
+      const res = await app.request(`/sso/link/start/${PROVIDER_UUID}`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(503);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
     // ── Callback link-mode branch ──────────────────────────────────────────
-    const primeLinkCallback = (linkUserId: string) => {
+    // SR2-11b: validateLinkBinding re-checks the pending link against LIVE
+    // state before it can attach an external identity. It issues, in order:
+    // a `users` select (the linking user), then — only if status/epochs/family
+    // all still check out — ONE axis-membership select (organization_users on
+    // the org axis). That membership select lands BEFORE the route's existing
+    // (provider, sub) userSsoIdentities select. Every link test funnels
+    // through this one helper so that ordering/shift lives in exactly one
+    // place instead of being hand-copied into every test.
+    const INITIATING_SID = '00000000-0000-4000-8000-0000000000fa';
+    const ACTIVE_LINKING_USER = {
+      id: USER_UUID, email: 'tech@example.com', name: 'Tech', status: 'active', orgId: null
+    };
+    const primeLinkCallback = (opts: {
+      linkUserId: string;
+      provider?: Record<string, unknown>;
+      // undefined = default healthy user; null = simulate "user gone" (no row).
+      linkingUser?: Record<string, unknown> | null;
+      // undefined = default live membership row; [] = membership lost.
+      membership?: unknown[];
+      sessionOverrides?: Record<string, unknown>;
+    }) => {
+      const {
+        linkUserId,
+        provider = ORG_PROVIDER,
+        linkingUser = ACTIVE_LINKING_USER,
+        membership = [{ userId: linkUserId }],
+        sessionOverrides = {},
+      } = opts;
+
       vi.mocked(exchangeCodeForTokens).mockResolvedValue({ access_token: 'a', refresh_token: 'r', expires_in: 3600, id_token: 'h.p.s' } as any);
       vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'tech@example.com', name: 'Tech' } as any);
       vi.mocked(mapUserAttributes).mockReturnValue({ email: 'tech@example.com', name: 'Tech' } as any);
       vi.mocked(db.delete).mockReturnValueOnce({
-        where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sso-session-link', providerId: PROVIDER_UUID, state: 'state', nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/settings/profile', linkUserId, providerVersion: 1 }]) })
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            id: 'sso-session-link', providerId: PROVIDER_UUID, state: 'state', nonce: 'nonce',
+            codeVerifier: 'verifier', redirectUrl: '/settings/profile', linkUserId, providerVersion: 1,
+            initiatingAuthEpoch: 1, initiatingMfaEpoch: 1, initiatingSessionId: INITIATING_SID,
+            ...sessionOverrides,
+          }])
+        })
       } as any);
+
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([provider]))                                // provider by id
+        .mockReturnValueOnce(sel(linkingUser ? [linkingUser] : []))          // validateLinkBinding: users
+        .mockReturnValueOnce(sel(membership));                               // validateLinkBinding: axis membership
     };
     const doCallback = () => app.request('/sso/callback?code=oidc-code&state=state', { method: 'GET', headers: { cookie: ssoStateCookieHeader('state') } });
 
     it('callback link mode creates the identity for the SESSION user after verification', async () => {
-      primeLinkCallback(USER_UUID);
-      vi.mocked(db.select)
-        .mockReturnValueOnce(sel([ORG_PROVIDER]))                                        // provider by id
-        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'tech@example.com', name: 'Tech' }])) // linking user
-        .mockReturnValueOnce(sel([]));                                                    // (provider, sub) not in use
+      primeLinkCallback({ linkUserId: USER_UUID });
+      vi.mocked(db.select).mockReturnValueOnce(sel([])); // (provider, sub) not in use
       const insertValues = vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) }));
       vi.mocked(db.insert).mockReturnValueOnce({ values: insertValues } as any);
 
@@ -2768,10 +2855,10 @@ describe('sso routes', () => {
     });
 
     it('callback link mode rejects an email mismatch (no insert)', async () => {
-      primeLinkCallback(USER_UUID);
-      vi.mocked(db.select)
-        .mockReturnValueOnce(sel([ORG_PROVIDER]))
-        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'someone-else@corp.com', name: 'Other' }]));
+      primeLinkCallback({
+        linkUserId: USER_UUID,
+        linkingUser: { id: USER_UUID, email: 'someone-else@corp.com', name: 'Other', status: 'active', orgId: null },
+      });
 
       const res = await doCallback();
       expect(res.status).toBe(302);
@@ -2781,17 +2868,67 @@ describe('sso routes', () => {
     });
 
     it('callback link mode rejects a (provider, sub) already linked to another user (no insert)', async () => {
-      primeLinkCallback(USER_UUID);
-      vi.mocked(db.select)
-        .mockReturnValueOnce(sel([ORG_PROVIDER]))
-        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'tech@example.com', name: 'Tech' }]))
-        .mockReturnValueOnce(sel([{ id: 'identity-x', userId: '00000000-0000-4000-8000-0000000000aa' }]));
+      primeLinkCallback({ linkUserId: USER_UUID });
+      vi.mocked(db.select).mockReturnValueOnce(sel([{ id: 'identity-x', userId: '00000000-0000-4000-8000-0000000000aa' }]));
 
       const res = await doCallback();
       expect(res.status).toBe(302);
       expect(res.headers.get('location')).toContain('ssoLinkError=identity_in_use');
       expect(db.insert).not.toHaveBeenCalled();
       expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    // ── SR2-11b: live re-check of the /link/start binding ──────────────────
+    it('callback rejects a revoked initiating refresh family (session_invalid, no insert)', async () => {
+      vi.mocked(getRefreshFamily).mockResolvedValueOnce({
+        revokedAt: new Date(), absoluteExpiresAt: new Date(Date.now() + 1e9)
+      });
+      primeLinkCallback({ linkUserId: USER_UUID });
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/settings/profile?ssoLinkError=session_invalid');
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('callback rejects an auth-epoch bump since /link/start (session_invalid, no insert)', async () => {
+      vi.mocked(getUserEpochs).mockResolvedValueOnce({ authEpoch: 2, mfaEpoch: 1 });
+      primeLinkCallback({ linkUserId: USER_UUID });
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/settings/profile?ssoLinkError=session_invalid');
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('callback rejects a suspended linking user (session_invalid, no insert)', async () => {
+      primeLinkCallback({
+        linkUserId: USER_UUID,
+        linkingUser: { ...ACTIVE_LINKING_USER, status: 'suspended' },
+      });
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/settings/profile?ssoLinkError=session_invalid');
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('callback rejects a NULL binding column — pre-deploy row (session_invalid, no insert)', async () => {
+      primeLinkCallback({ linkUserId: USER_UUID, sessionOverrides: { initiatingSessionId: null } });
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/settings/profile?ssoLinkError=session_invalid');
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('callback rejects lost org-axis membership since /link/start (session_invalid, no insert)', async () => {
+      primeLinkCallback({ linkUserId: USER_UUID, membership: [] });
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/settings/profile?ssoLinkError=session_invalid');
+      expect(db.insert).not.toHaveBeenCalled();
     });
   });
 
@@ -2877,14 +3014,22 @@ describe('sso routes', () => {
       vi.mocked(exchangeCodeForTokens).mockResolvedValue({ access_token: 'a', refresh_token: 'r', expires_in: 3600, id_token: 'h.p.s' } as any);
       vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'tech@example.com', name: 'Tech' } as any);
       vi.mocked(mapUserAttributes).mockReturnValue({ email: 'tech@example.com', name: 'Tech' } as any);
-      claimSession({ providerVersion: 2, linkUserId: USER_UUID });
+      // SR2-11b: LINK-mode callback now re-checks the /link/start binding
+      // (validateLinkBinding), so the claimed session needs a live binding and
+      // the select queue gains the axis-membership select it issues.
+      claimSession({
+        providerVersion: 2, linkUserId: USER_UUID,
+        initiatingAuthEpoch: 1, initiatingMfaEpoch: 1,
+        initiatingSessionId: '00000000-0000-4000-8000-0000000000fa',
+      });
       vi.mocked(db.select)
         .mockReturnValueOnce(sel([{
           ...GEN_PROVIDER, status: 'testing', configVersion: 2,
           issuer: 'https://issuer.example.com', clientId: 'client-id', clientSecret: 'client-secret',
           jwksUrl: 'https://issuer.example.com/jwks'
         }])) // provider by id
-        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'tech@example.com', name: 'Tech' }])) // linking user
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'tech@example.com', name: 'Tech', status: 'active', orgId: null }])) // validateLinkBinding: users
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }])) // validateLinkBinding: axis membership
         .mockReturnValueOnce(sel([])); // (provider, sub) not in use
       const insertValues = vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) }));
       vi.mocked(db.insert).mockReturnValueOnce({ values: insertValues } as any);

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -121,7 +121,14 @@ vi.mock('../db/schema', () => ({
     authorizationUrl: 'authorizationUrl',
     tokenUrl: 'tokenUrl',
     userInfoUrl: 'userInfoUrl',
-    jwksUrl: 'jwksUrl'
+    jwksUrl: 'jwksUrl',
+    // SR2-11 (config generation) + SR2-10 (default-role delegation) columns —
+    // kept in the mock so any eq()/set() reference on them resolves to a real
+    // key instead of `undefined`.
+    configVersion: 'configVersion',
+    createdBy: 'createdBy',
+    defaultRoleId: 'defaultRoleId',
+    defaultRoleConfiguredBy: 'defaultRoleConfiguredBy'
   },
   ssoSessions: {
     id: 'id',
@@ -1034,7 +1041,8 @@ describe('sso routes', () => {
           state: 'state',
           nonce: 'nonce',
           codeVerifier: 'verifier',
-          redirectUrl: '/dashboard'
+          redirectUrl: '/dashboard',
+          providerVersion: 1
         }])
       })
     } as any);
@@ -1047,6 +1055,8 @@ describe('sso routes', () => {
               id: PROVIDER_UUID,
               orgId: ORG_UUID,
               type: 'oidc',
+              status: 'active',
+              configVersion: 1,
               issuer: 'https://issuer.example.com',
               authorizationUrl: 'https://issuer.example.com/auth',
               tokenUrl: 'https://issuer.example.com/token',
@@ -1172,7 +1182,8 @@ describe('sso routes', () => {
           state: 'state',
           nonce: 'nonce',
           codeVerifier: 'verifier',
-          redirectUrl: '/'
+          redirectUrl: '/',
+          providerVersion: 1
         }])
       })
     } as any);
@@ -1185,6 +1196,8 @@ describe('sso routes', () => {
               id: PROVIDER_UUID,
               orgId: ORG_UUID,
               type: 'oidc',
+              status: 'active',
+              configVersion: 1,
               issuer: 'https://issuer.example.com',
               authorizationUrl: 'https://issuer.example.com/auth',
               tokenUrl: 'https://issuer.example.com/token',
@@ -1289,7 +1302,8 @@ describe('sso routes', () => {
                 state: 'state',
                 nonce: 'nonce',
                 codeVerifier: 'verifier',
-                redirectUrl: '/dashboard'
+                redirectUrl: '/dashboard',
+                providerVersion: 1
               }]
             : [])
         })
@@ -1303,6 +1317,8 @@ describe('sso routes', () => {
                 id: PROVIDER_UUID,
                 orgId: ORG_UUID,
                 type: 'oidc',
+                status: 'active',
+                configVersion: 1,
                 issuer: 'https://issuer.example.com',
                 authorizationUrl: 'https://issuer.example.com/auth',
                 tokenUrl: 'https://issuer.example.com/token',
@@ -1502,7 +1518,7 @@ describe('sso routes', () => {
       from: vi.fn().mockReturnValue({ innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }) }) })
     } as any);
     const PROVIDER_ROW = [{
-      id: PROVIDER_UUID, orgId: ORG_UUID, type: 'oidc',
+      id: PROVIDER_UUID, orgId: ORG_UUID, type: 'oidc', status: 'active', configVersion: 1,
       issuer: 'https://issuer.example.com', authorizationUrl: 'https://issuer.example.com/auth',
       tokenUrl: 'https://issuer.example.com/token', userInfoUrl: 'https://issuer.example.com/userinfo',
       jwksUrl: 'https://issuer.example.com/jwks', clientId: 'client-id', clientSecret: 'client-secret',
@@ -1514,7 +1530,7 @@ describe('sso routes', () => {
       vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'test@example.com', name: 'Test User' } as any);
       vi.mocked(mapUserAttributes).mockReturnValue({ email: 'test@example.com', name: 'Test User' } as any);
       vi.mocked(db.delete).mockReturnValueOnce({
-        where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sso-session-z', providerId: PROVIDER_UUID, state: 'state', nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/dashboard' }]) })
+        where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sso-session-z', providerId: PROVIDER_UUID, state: 'state', nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/dashboard', providerVersion: 1 }]) })
       } as any);
     };
     const doCallback = () => app.request('/sso/callback?code=oidc-code&state=state', { method: 'GET', headers: { cookie: ssoStateCookieHeader('state') } });
@@ -2160,6 +2176,7 @@ describe('sso routes', () => {
     partnerId: PARTNER_UUID as string | null,
     type: 'oidc',
     status: 'active',
+    configVersion: 4,
     issuer: 'https://issuer.example.com',
     authorizationUrl: 'https://issuer.example.com/auth',
     tokenUrl: 'https://issuer.example.com/token',
@@ -2196,7 +2213,9 @@ describe('sso routes', () => {
       expect(res.headers.get('location')).toBe('https://idp.example.com/auth');
       expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({
         providerId: PROVIDER_UUID,
-        redirectUrl: '/dashboard'
+        redirectUrl: '/dashboard',
+        // SR2-11: the session snapshots the provider's LIVE generation.
+        providerVersion: ACTIVE_OIDC_PROVIDER_ROW.configVersion
       }));
       const setCookie = res.headers.get('set-cookie') ?? '';
       expect(setCookie).toContain('breeze_sso_state=');
@@ -2263,7 +2282,9 @@ describe('sso routes', () => {
       expect(res.headers.get('location')).toBe('https://idp.example.com/auth');
       expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({
         providerId: PROVIDER_UUID,
-        redirectUrl: '/dashboard'
+        redirectUrl: '/dashboard',
+        // SR2-11: the session snapshots the provider's LIVE generation.
+        providerVersion: ACTIVE_OIDC_PROVIDER_ROW.configVersion
       }));
       expect(res.headers.get('set-cookie') ?? '').toContain('breeze_sso_state=');
     });
@@ -2317,6 +2338,8 @@ describe('sso routes', () => {
       orgId: null,
       partnerId: PARTNER_UUID,
       type: 'oidc',
+      status: 'active',
+      configVersion: 1,
       issuer: 'https://issuer.example.com',
       authorizationUrl: 'https://issuer.example.com/auth',
       tokenUrl: 'https://issuer.example.com/token',
@@ -2350,7 +2373,7 @@ describe('sso routes', () => {
       vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'tech@msp.example', name: 'Tech' } as any);
       vi.mocked(mapUserAttributes).mockReturnValue({ email: 'tech@msp.example', name: 'Tech' } as any);
       vi.mocked(db.delete).mockReturnValueOnce({
-        where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sso-session-p', providerId: PROVIDER_UUID, state: 'state', nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/dashboard' }]) })
+        where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sso-session-p', providerId: PROVIDER_UUID, state: 'state', nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/dashboard', providerVersion: 1 }]) })
       } as any);
     };
     const doCallback = () => app.request('/sso/callback?code=oidc-code&state=state', { method: 'GET', headers: { cookie: ssoStateCookieHeader('state') } });
@@ -2617,7 +2640,7 @@ describe('sso routes', () => {
     } as any);
 
     const ORG_PROVIDER = {
-      id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null, status: 'active', type: 'oidc',
+      id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null, status: 'active', configVersion: 1, type: 'oidc',
       name: 'Okta', issuer: 'https://issuer.example.com',
       authorizationUrl: 'https://issuer.example.com/auth', tokenUrl: 'https://issuer.example.com/token',
       userInfoUrl: 'https://issuer.example.com/userinfo', jwksUrl: 'https://issuer.example.com/jwks',
@@ -2721,7 +2744,7 @@ describe('sso routes', () => {
       vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'tech@example.com', name: 'Tech' } as any);
       vi.mocked(mapUserAttributes).mockReturnValue({ email: 'tech@example.com', name: 'Tech' } as any);
       vi.mocked(db.delete).mockReturnValueOnce({
-        where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sso-session-link', providerId: PROVIDER_UUID, state: 'state', nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/settings/profile', linkUserId }]) })
+        where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sso-session-link', providerId: PROVIDER_UUID, state: 'state', nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/settings/profile', linkUserId, providerVersion: 1 }]) })
       } as any);
     };
     const doCallback = () => app.request('/sso/callback?code=oidc-code&state=state', { method: 'GET', headers: { cookie: ssoStateCookieHeader('state') } });
@@ -2769,6 +2792,154 @@ describe('sso routes', () => {
       expect(res.headers.get('location')).toContain('ssoLinkError=identity_in_use');
       expect(db.insert).not.toHaveBeenCalled();
       expect(createTokenPair).not.toHaveBeenCalled();
+    });
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // SR2-11: provider config generation + status/version gate in the callback.
+  //
+  // The vulnerability: nothing bumped a generation on config/status writes,
+  // nothing snapshotted it at session creation, and the callback never
+  // re-checked provider.status or any version — so a provider disabled (or
+  // reconfigured) during the <=10-minute state TTL still completed a full
+  // login or link.
+  // ══════════════════════════════════════════════════════════════════════════
+  describe('SSO provider generation gate (SR2-11)', () => {
+    const sel = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }) })
+    } as any);
+    const doCallback = () => app.request('/sso/callback?code=oidc-code&state=state', { method: 'GET', headers: { cookie: ssoStateCookieHeader('state') } });
+    // Minimal org-axis provider shape: enough to pass the org-XOR-partner
+    // guard and reach the generation gate, which runs BEFORE anything that
+    // would need type/issuer/clientId (getOIDCConfig, default-role lookup).
+    const GEN_PROVIDER = { id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null, type: 'oidc', defaultRoleId: null };
+    const claimSession = (overrides: Record<string, unknown>) => {
+      vi.mocked(db.delete).mockReturnValueOnce({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            id: 'sso-session-gen', providerId: PROVIDER_UUID, state: 'state', nonce: 'nonce',
+            codeVerifier: 'verifier', redirectUrl: '/dashboard', linkUserId: null,
+            ...overrides
+          }])
+        })
+      } as any);
+    };
+
+    it('rejects a provider disabled mid-flow (login mode)', async () => {
+      claimSession({ providerVersion: 3 });
+      vi.mocked(db.select).mockReturnValueOnce(sel([{ ...GEN_PROVIDER, status: 'inactive', configVersion: 3 }]));
+
+      const res = await doCallback();
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/login?error=sso_provider_inactive');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    it('rejects a config change mid-flow (login mode)', async () => {
+      claimSession({ providerVersion: 3 });
+      vi.mocked(db.select).mockReturnValueOnce(sel([{ ...GEN_PROVIDER, status: 'active', configVersion: 4 }]));
+
+      const res = await doCallback();
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/login?error=sso_config_changed');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    it('rejects a NULL providerVersion (pre-deploy row) — fail closed, never a pass', async () => {
+      claimSession({ providerVersion: null });
+      vi.mocked(db.select).mockReturnValueOnce(sel([{ ...GEN_PROVIDER, status: 'active', configVersion: 1 }]));
+
+      const res = await doCallback();
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/login?error=sso_config_changed');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    it('rejects an inactive provider in LINK mode', async () => {
+      claimSession({ providerVersion: 2, linkUserId: USER_UUID });
+      vi.mocked(db.select).mockReturnValueOnce(sel([{ ...GEN_PROVIDER, status: 'inactive', configVersion: 2 }]));
+
+      const res = await doCallback();
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/settings/profile?ssoLinkError=provider_inactive');
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    // Mirrors link-start's OWN gate (status !== 'inactive'): a `testing`
+    // provider must still be linkable, or the link round-trip it started
+    // itself would be impossible to complete — hardening, not a new bug.
+    it('ACCEPTS a testing provider in LINK mode (mirrors link-start’s own gate)', async () => {
+      vi.mocked(exchangeCodeForTokens).mockResolvedValue({ access_token: 'a', refresh_token: 'r', expires_in: 3600, id_token: 'h.p.s' } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'tech@example.com', name: 'Tech' } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'tech@example.com', name: 'Tech' } as any);
+      claimSession({ providerVersion: 2, linkUserId: USER_UUID });
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([{
+          ...GEN_PROVIDER, status: 'testing', configVersion: 2,
+          issuer: 'https://issuer.example.com', clientId: 'client-id', clientSecret: 'client-secret',
+          jwksUrl: 'https://issuer.example.com/jwks'
+        }])) // provider by id
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'tech@example.com', name: 'Tech' }])) // linking user
+        .mockReturnValueOnce(sel([])); // (provider, sub) not in use
+      const insertValues = vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) }));
+      vi.mocked(db.insert).mockReturnValueOnce({ values: insertValues } as any);
+
+      const res = await doCallback();
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/settings/profile?ssoLinked=1');
+      expect(insertValues).toHaveBeenCalled();
+    });
+
+    it('PATCH /providers/:id bumps config_version in the same UPDATE as the change', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(sel([{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null }]));
+      const setSpy = vi.fn((_values: Record<string, unknown>) => ({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null, name: 'Okta Updated' }])
+        })
+      }));
+      vi.mocked(db.update).mockReturnValueOnce({ set: setSpy } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Okta Updated' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(setSpy).toHaveBeenCalledTimes(1);
+      const setPayload = setSpy.mock.calls[0]![0] as Record<string, unknown>;
+      expect(Object.keys(setPayload)).toContain('configVersion');
+      // A SQL expression object, not a literal number — the bump happens in
+      // Postgres against the live value, never a value computed in-process.
+      expect(typeof setPayload.configVersion).not.toBe('number');
+    });
+
+    it('POST /providers/:id/status bumps config_version on every status transition', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(sel([{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null }]));
+      const setSpy = vi.fn((_values: Record<string, unknown>) => ({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null, name: 'Okta', status: 'inactive' }])
+        })
+      }));
+      vi.mocked(db.update).mockReturnValueOnce({ set: setSpy } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}/status`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'inactive' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(setSpy).toHaveBeenCalledTimes(1);
+      const setPayload = setSpy.mock.calls[0]![0] as Record<string, unknown>;
+      expect(Object.keys(setPayload)).toContain('configVersion');
+      expect(typeof setPayload.configVersion).not.toBe('number');
     });
   });
 
@@ -3062,6 +3233,8 @@ describe('sso routes', () => {
       partnerId: null,
       name: 'Okta',
       type: 'oidc',
+      status: 'active',
+      configVersion: 1,
       issuer: 'https://issuer.example.com',
       authorizationUrl: 'https://issuer.example.com/auth',
       tokenUrl: 'https://issuer.example.com/token',
@@ -3102,7 +3275,7 @@ describe('sso routes', () => {
         where: vi.fn().mockReturnValue({
           returning: vi.fn().mockResolvedValue([{
             id: 'sso-session-jit', providerId: PROVIDER_UUID, state: 'state',
-            nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/'
+            nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/', providerVersion: 1
           }])
         })
       } as any);

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -33,7 +33,14 @@ vi.mock('../services/sso', () => ({
   decodeIdToken: vi.fn(),
   verifyIdTokenClaims: vi.fn(),
   verifyIdTokenSignature: vi.fn(),
-  assertEmailVerified: vi.fn(),
+  // SR2-12: real logic (not a stub) so the callback tests actually exercise the
+  // claim reader across id_token / userinfo bodies.
+  readEmailVerifiedClaim: (source: Record<string, unknown> | null | undefined) => {
+    const ev = source?.email_verified;
+    if (ev === true || ev === 'true') return 'true';
+    if (ev === false || ev === 'false') return 'false';
+    return 'absent';
+  },
   // Real logic (not a stub) so the IdP-MFA tests exercise the amr check.
   idpAssertedMfa: (claims: { amr?: unknown }) => Array.isArray(claims?.amr) && claims.amr.includes('mfa'),
   mapUserAttributes: vi.fn(),
@@ -246,6 +253,9 @@ vi.mock('../services/ssoDomainVerification', () => ({
   recordNameFor: vi.fn((domain: string) => `_breeze-verify.${domain}`),
   recordValueFor: vi.fn((token: string) => `breeze-domain-verify=${token}`),
   isSsoProvisioningBlocked: vi.fn().mockResolvedValue(false),
+  // NEW (SR2-12): the hard absent-claim gate. Default true so existing tests,
+  // which assert on isSsoProvisioningBlocked, are unaffected.
+  isDomainVerifiedForOrg: vi.fn().mockResolvedValue(true),
 }));
 
 // Partial-mock auth/helpers: keep the real cookie helpers the callback uses,
@@ -305,7 +315,7 @@ import {
   mapUserAttributes,
   verifyIdTokenSignature,
 } from '../services/sso';
-import { createPendingDomain, verifyDomain, isSsoProvisioningBlocked } from '../services/ssoDomainVerification';
+import { createPendingDomain, verifyDomain, isSsoProvisioningBlocked, isDomainVerifiedForOrg } from '../services/ssoDomainVerification';
 import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
 import { getUserPermissions } from '../services/permissions';
 import { writeRouteAudit } from '../services/auditEvents';
@@ -385,6 +395,13 @@ describe('sso routes', () => {
       remaining: 9,
       resetAt: new Date(Date.now() + 60_000)
     } as any);
+    // SR2-12: these ssoDomainVerification mocks are set with persistent
+    // implementations (mockResolvedValue) by individual tests, and clearAllMocks
+    // does NOT reset implementations — so restore their factory defaults here so
+    // a prior test's override (e.g. isSsoProvisioningBlocked=true, or the SR2-12
+    // absent-claim gate's isDomainVerifiedForOrg=false) cannot bleed forward.
+    vi.mocked(isSsoProvisioningBlocked).mockReset().mockResolvedValue(false);
+    vi.mocked(isDomainVerifiedForOrg).mockReset().mockResolvedValue(true);
     delete process.env.SSO_EXCHANGE_RETURN_REFRESH_TOKEN;
     process.env.APP_ENCRYPTION_KEY = SSO_STATE_COOKIE_SECRET;
     permissionGate.deny = false;
@@ -1571,6 +1588,7 @@ describe('sso routes', () => {
       vi.mocked(db.select)
         .mockReturnValueOnce(sel(PROVIDER_ROW))
         .mockReturnValueOnce(sel([])) // no (provider, sub) link yet
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }])) // SR2-12: org-members subquery for emailCondition clamp (constructed before byEmail)
         .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'test@example.com', name: 'Pw', passwordHash: '$argon2id$hash' }]))
         .mockReturnValueOnce(sel([])); // no other-provider link (still denied — has a password)
 
@@ -1585,6 +1603,7 @@ describe('sso routes', () => {
       vi.mocked(db.select)
         .mockReturnValueOnce(sel(PROVIDER_ROW))
         .mockReturnValueOnce(sel([])) // no link for THIS provider
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }])) // SR2-12: org-members subquery for emailCondition clamp
         .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'test@example.com', name: 'SsoOnly', passwordHash: null }]))
         .mockReturnValueOnce(sel([{ id: 'other-provider-link' }])); // linked to another provider
 
@@ -1599,6 +1618,7 @@ describe('sso routes', () => {
       vi.mocked(db.select)
         .mockReturnValueOnce(sel(PROVIDER_ROW))
         .mockReturnValueOnce(sel([])) // no link yet
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }])) // SR2-12: org-members subquery for emailCondition clamp
         .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'test@example.com', name: 'SsoOnly', passwordHash: null }]))
         .mockReturnValueOnce(sel([])) // no other-provider link → safe to link
         .mockReturnValueOnce(selJoin([{ orgId: ORG_UUID, roleId: 'role-1', roleName: 'Member', roleScope: 'organization' }]))
@@ -1689,6 +1709,218 @@ describe('sso routes', () => {
       // but the gate block is inside `if (!user)` which is false here — so
       // the callback must NOT have redirected to sso_domain_unverified.
       expect(res.headers.get('location') ?? '').not.toContain('sso_domain_unverified');
+    });
+  });
+
+  describe('SSO verified identity claims (SR2-12)', () => {
+    const sel = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }) })
+    } as any);
+    const selJoin = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({ innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }) }) })
+    } as any);
+    const ORG_PROVIDER = {
+      id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null, type: 'oidc', status: 'active', configVersion: 1,
+      issuer: 'https://issuer.example.com', authorizationUrl: 'https://issuer.example.com/auth',
+      tokenUrl: 'https://issuer.example.com/token', userInfoUrl: 'https://issuer.example.com/userinfo',
+      jwksUrl: 'https://issuer.example.com/jwks', clientId: 'client-id', clientSecret: 'client-secret',
+      scopes: 'openid profile email', attributeMapping: { email: 'email', name: 'name' },
+      autoProvision: false, allowedDomains: null, defaultRoleId: null, trustsIdpMfa: false
+    };
+    const PARTNER_PROVIDER = {
+      ...ORG_PROVIDER, orgId: null, partnerId: PARTNER_UUID,
+    };
+    // Prime the session-claim delete + userinfo/exchange. Callers set
+    // verifyIdTokenSignature / getUserInfo / mapUserAttributes for the case.
+    const primeSession = () => {
+      vi.mocked(exchangeCodeForTokens).mockResolvedValue({ access_token: 'a', refresh_token: 'r', expires_in: 3600, id_token: 'h.p.s' } as any);
+      vi.mocked(db.delete).mockReturnValueOnce({
+        where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sso-session-v', providerId: PROVIDER_UUID, state: 'state', nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/dashboard', providerVersion: 1 }]) })
+      } as any);
+    };
+    const doCallback = () => app.request('/sso/callback?code=oidc-code&state=state', { method: 'GET', headers: { cookie: ssoStateCookieHeader('state') } });
+
+    // 1. id_token email_verified:false → reject before identity resolution.
+    it('rejects an id_token asserting email_verified:false', async () => {
+      primeSession();
+      vi.mocked(verifyIdTokenSignature).mockResolvedValue({ sub: 'external-user-1', nonce: 'nonce', email: 'test@corp.example', email_verified: false } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'test@corp.example', name: 'T' } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'test@corp.example', name: 'T' } as any);
+      vi.mocked(db.select).mockReturnValueOnce(sel([ORG_PROVIDER]));
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=sso_email_unverified');
+      expect(createTokenPair).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    // 2. id_token omits email; userinfo carries email_verified:false → reject.
+    //    This is the path that was NEVER read before SR2-12.
+    it('rejects when the id_token omits email and userinfo asserts email_verified:false', async () => {
+      primeSession();
+      vi.mocked(verifyIdTokenSignature).mockResolvedValue({ sub: 's1', nonce: 'nonce' } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: 's1', email: 'x@corp.example', email_verified: false, name: 'X' } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'x@corp.example', name: 'X' } as any);
+      vi.mocked(db.select).mockReturnValueOnce(sel([ORG_PROVIDER]));
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=sso_email_unverified');
+      expect(createTokenPair).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    // 3. Absent claim + org axis + domain NOT verified + no existing link → reject.
+    it('rejects an absent claim on the org axis when the domain is not verified', async () => {
+      primeSession();
+      vi.mocked(verifyIdTokenSignature).mockResolvedValue({ sub: 'external-user-1', nonce: 'nonce' } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'test@corp.example', name: 'T' } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'test@corp.example', name: 'T' } as any);
+      vi.mocked(isDomainVerifiedForOrg).mockResolvedValueOnce(false);
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([ORG_PROVIDER]))
+        .mockReturnValueOnce(sel([])); // no (provider, sub) link → user null → domain gate
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=sso_email_unverified');
+      expect(createTokenPair).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    // 4. Absent claim + org axis + domain VERIFIED → proceeds to the auto-link path.
+    it('allows an absent claim on the org axis when Breeze has proven the domain', async () => {
+      primeSession();
+      vi.mocked(verifyIdTokenSignature).mockResolvedValue({ sub: 'external-user-1', nonce: 'nonce' } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'test@corp.example', name: 'T' } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'test@corp.example', name: 'T' } as any);
+      // isDomainVerifiedForOrg defaults to true (mock factory).
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([ORG_PROVIDER]))
+        .mockReturnValueOnce(sel([]))                              // no (provider, sub) link
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }]))        // org-members subquery (emailCondition clamp)
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'test@corp.example', name: 'SsoOnly', passwordHash: null }])) // byEmail
+        .mockReturnValueOnce(sel([]))                             // no other-provider link → safe to link
+        .mockReturnValueOnce(selJoin([{ orgId: ORG_UUID, roleId: 'role-1', roleName: 'Member', roleScope: 'organization' }]))
+        .mockReturnValueOnce(sel([]));                            // existingIdentity none → insert
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toMatch(/ssoCode=/);
+      expect(createTokenPair).toHaveBeenCalled();
+    });
+
+    // 5. Absent claim + PARTNER axis → tolerated (documented gap): reaches the
+    //    partner identity resolution and, with no user, invite_required — NOT
+    //    sso_email_unverified.
+    it('tolerates an absent claim on the partner axis (documented gap)', async () => {
+      primeSession();
+      vi.mocked(verifyIdTokenSignature).mockResolvedValue({ sub: 'external-user-1', nonce: 'nonce' } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'tech@msp.example', name: 'Tech' } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'tech@msp.example', name: 'Tech' } as any);
+      // Even if the org-domain machinery would say "no", the partner axis must
+      // never consult it — prove it by forcing false.
+      vi.mocked(isDomainVerifiedForOrg).mockResolvedValue(false);
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([PARTNER_PROVIDER]))
+        .mockReturnValueOnce(sel([]))                              // no (provider, sub) link
+        .mockReturnValueOnce(sel([]));                            // partner-axis byEmail (no members subquery) → none
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=invite_required');
+      expect(res.headers.get('location') ?? '').not.toContain('sso_email_unverified');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    // 6. Absent claim + already-linked (provider, sub) identity → allowed. The
+    //    email-driven gates never run, so enabling enforcement can't lock out an
+    //    existing SSO user (even with the domain unverified).
+    it('exempts an already-linked identity from the absent-claim gate', async () => {
+      primeSession();
+      vi.mocked(verifyIdTokenSignature).mockResolvedValue({ sub: 'external-user-1', nonce: 'nonce' } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'test@corp.example', name: 'T' } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'test@corp.example', name: 'T' } as any);
+      vi.mocked(isDomainVerifiedForOrg).mockResolvedValue(false); // would reject if consulted
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([ORG_PROVIDER]))
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }]))        // (provider, sub) link → user resolved
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'test@corp.example', name: 'Linked' }]))
+        .mockReturnValueOnce(selJoin([{ orgId: ORG_UUID, roleId: 'role-1', roleName: 'Member', roleScope: 'organization' }]))
+        .mockReturnValueOnce(sel([{ id: 'identity-1' }]));
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toMatch(/ssoCode=/);
+      expect(res.headers.get('location') ?? '').not.toContain('sso_email_unverified');
+      expect(createTokenPair).toHaveBeenCalled();
+    });
+
+    // 7. Org clamp on the auto-link email match. A by-email user who is NOT a
+    //    member of the provider's org is blocked one gate deeper (no_org_access)
+    //    and never mints — the membership subquery is exactly that population.
+    it('does not mint when the by-email user is not a member of the provider org', async () => {
+      primeSession();
+      vi.mocked(verifyIdTokenSignature).mockResolvedValue({ sub: 'external-user-1', nonce: 'nonce' } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'test@corp.example', name: 'T' } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'test@corp.example', name: 'T' } as any);
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([ORG_PROVIDER]))
+        .mockReturnValueOnce(sel([]))                              // no (provider, sub) link
+        .mockReturnValueOnce(sel([]))                             // org-members subquery → empty (not a member)
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'test@corp.example', name: 'Outsider', passwordHash: null }])) // byEmail
+        .mockReturnValueOnce(sel([]))                             // no other-provider link → user = byEmail
+        .mockReturnValueOnce(selJoin([]));                        // NO org membership → no_org_access
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=no_org_access');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    // 8. Mapped-email laundering (I3). attributeMapping.email='preferred_username'
+    //    names a DIFFERENT address than userinfo.email, which is what
+    //    email_verified:true attests — so the claim must NOT count. With no
+    //    verified domain, the absent-claim gate rejects.
+    it('does not let a true claim launder a mapped address it does not attest', async () => {
+      primeSession();
+      vi.mocked(verifyIdTokenSignature).mockResolvedValue({ sub: 'external-user-1', nonce: 'nonce' } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'real@corp.example', email_verified: true, preferred_username: 'spoof@corp.example', name: 'X' } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'spoof@corp.example', name: 'X' } as any);
+      vi.mocked(isDomainVerifiedForOrg).mockResolvedValueOnce(false);
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([{ ...ORG_PROVIDER, attributeMapping: { email: 'preferred_username', name: 'name' } }]))
+        .mockReturnValueOnce(sel([])); // no link → user null → domain gate
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=sso_email_unverified');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    // 8 (mirror). Same setup, but the org HAS the domain verified → the domain
+    //    gate carries the legitimate case forward (proving it is the domain
+    //    proof, not the laundered claim, that admits it).
+    it('admits the mapped-address case when the org has proven the domain', async () => {
+      primeSession();
+      vi.mocked(verifyIdTokenSignature).mockResolvedValue({ sub: 'external-user-1', nonce: 'nonce' } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'real@corp.example', email_verified: true, preferred_username: 'spoof@corp.example', name: 'X' } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'spoof@corp.example', name: 'X' } as any);
+      // isDomainVerifiedForOrg defaults to true → domain proof carries it.
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([{ ...ORG_PROVIDER, attributeMapping: { email: 'preferred_username', name: 'name' } }]))
+        .mockReturnValueOnce(sel([]))                              // no link
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }]))        // org-members subquery
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'spoof@corp.example', name: 'SsoOnly', passwordHash: null }])) // byEmail
+        .mockReturnValueOnce(sel([]))                             // no other-provider link
+        .mockReturnValueOnce(selJoin([{ orgId: ORG_UUID, roleId: 'role-1', roleName: 'Member', roleScope: 'organization' }]))
+        .mockReturnValueOnce(sel([]));                            // existingIdentity none
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toMatch(/ssoCode=/);
+      expect(createTokenPair).toHaveBeenCalled();
     });
   });
 
@@ -3429,6 +3661,7 @@ describe('sso routes', () => {
         .mockReturnValueOnce(selLimit([provider]))              // 1. provider
         .mockReturnValueOnce(selLimit([ORG_ROLE_ROW]))          // 2. pre-JIT axis check (getProviderAxisRole)
         .mockReturnValueOnce(selLimit([]))                      // 3. (provider, sub) → unlinked
+        .mockReturnValueOnce(selLimit([]))                      // 3b. SR2-12: org-members subquery for the emailCondition clamp (constructed just before the by-email select)
         .mockReturnValueOnce(selLimit([]));                     // 4. users by email → none
       for (const t of tail) vi.mocked(db.select).mockReturnValueOnce(t);
     };

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -788,6 +788,168 @@ describe('sso routes', () => {
     });
   });
 
+  // ── I2: OIDC discovery failure must FAIL LOUDLY, never persist ────────────
+  //
+  // Both write routes used to catch a rejected discovery, console.warn, and then
+  // return success: POST persisted a provider with all four endpoint columns NULL
+  // and returned 201; PATCH NULLed the four endpoints of a WORKING provider,
+  // bumped configVersion (killing every in-flight session), and returned 200 with
+  // the updated row. Nothing in the response said discovery had failed, so a typo
+  // in an issuer took a tenant's SSO offline behind a success toast — the exact
+  // silent-mutation class the repo's runAction convention exists to prevent.
+  // Both now 400 and persist NOTHING.
+  describe('OIDC discovery failure on provider writes (I2)', () => {
+    const existingProviderRow = {
+      id: PROVIDER_UUID,
+      orgId: ORG_UUID,
+      partnerId: null,
+      issuer: 'https://old-issuer.example.com',
+      type: 'oidc',
+    };
+
+    const selectExisting = () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([existingProviderRow])
+          })
+        })
+      } as any);
+    };
+
+    it('POST → 400 and creates NOTHING when discovery is rejected', async () => {
+      vi.mocked(discoverOIDCConfig).mockRejectedValue(
+        new Error('OIDC discovery blocked: no DNS records for typo.example.com')
+      );
+
+      const res = await app.request('/sso/providers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Okta',
+          type: 'oidc',
+          issuer: 'https://typo.example.com',
+          clientId: 'client-id',
+          clientSecret: 'client-secret'
+        })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.code).toBe('oidc_discovery_failed');
+      // The operator gets the real reason, not a generic failure.
+      expect(body.error).toContain('no DNS records for typo.example.com');
+      // The whole point: no half-broken provider row (endpoints NULL, unusable,
+      // unrepairable — discovery is the only writer of those four columns).
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('PATCH → re-discovers and re-writes all four endpoints when the issuer changes', async () => {
+      selectExisting();
+      vi.mocked(discoverOIDCConfig).mockResolvedValue({
+        issuer: 'https://new-issuer.example.com',
+        authorization_endpoint: 'https://new-issuer.example.com/auth',
+        token_endpoint: 'https://new-issuer.example.com/token',
+        userinfo_endpoint: 'https://new-issuer.example.com/userinfo',
+        jwks_uri: 'https://new-issuer.example.com/jwks'
+      } as any);
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID, name: 'Okta', orgId: ORG_UUID }])
+        })
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ issuer: 'https://new-issuer.example.com' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(discoverOIDCConfig).toHaveBeenCalledWith('https://new-issuer.example.com', {
+        allowPrivateNetwork: false
+      });
+      expect(setMock).toHaveBeenCalledWith(expect.objectContaining({
+        issuer: 'https://new-issuer.example.com',
+        authorizationUrl: 'https://new-issuer.example.com/auth',
+        tokenUrl: 'https://new-issuer.example.com/token',
+        userInfoUrl: 'https://new-issuer.example.com/userinfo',
+        jwksUrl: 'https://new-issuer.example.com/jwks',
+      }));
+    });
+
+    it('PATCH → 400, and NOTHING is written, when re-discovery of a changed issuer fails', async () => {
+      selectExisting();
+      vi.mocked(discoverOIDCConfig).mockRejectedValue(new Error('OIDC discovery failed: 404'));
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        // The scenario: an admin fixing a typo in a working Entra issuer typos it
+        // again (missing the `.0`). Old behavior: 200 + SSO offline for the org.
+        body: JSON.stringify({ issuer: 'https://login.microsoftonline.com/tenant/v2' })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.code).toBe('oidc_discovery_failed');
+      expect(body.error).toContain('OIDC discovery failed: 404');
+      expect(body.error).toContain('No changes were saved');
+      // No endpoint NULLing, no issuer repoint, and — critically — no
+      // configVersion bump, which would have killed every in-flight session.
+      expect(db.update).not.toHaveBeenCalled();
+      expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        action: 'sso.provider.update.rejected',
+        details: expect.objectContaining({ reason: 'oidc_discovery_failed' }),
+      }));
+    });
+
+    it('PATCH → does NOT re-discover when the issuer is unchanged', async () => {
+      selectExisting();
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID, name: 'Renamed', orgId: ORG_UUID }])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed', issuer: existingProviderRow.issuer })
+      });
+
+      expect(res.status).toBe(200);
+      expect(discoverOIDCConfig).not.toHaveBeenCalled();
+    });
+
+    // SR2-10 invariant that was asserted only in a comment: an unrelated edit
+    // (rename, secret rotation) must never clobber default_role_configured_by to
+    // null — that would brick JIT with `default_role_configurer_unknown`.
+    it('PATCH without defaultRoleId leaves defaultRoleConfiguredBy untouched', async () => {
+      selectExisting();
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID, name: 'Renamed', orgId: ORG_UUID }])
+        })
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed' })
+      });
+
+      expect(res.status).toBe(200);
+      const updates = setMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(updates).not.toHaveProperty('defaultRoleConfiguredBy');
+    });
+  });
+
   it('deletes a provider and related records', async () => {
     vi.mocked(db.select).mockReturnValue({
       from: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -115,7 +115,24 @@ vi.mock('../db/schema', () => ({
     userInfoUrl: 'userInfoUrl',
     jwksUrl: 'jwksUrl'
   },
-  ssoSessions: {},
+  ssoSessions: {
+    id: 'id',
+    providerId: 'providerId',
+    state: 'state',
+    nonce: 'nonce',
+    codeVerifier: 'codeVerifier',
+    redirectUrl: 'redirectUrl',
+    linkUserId: 'linkUserId',
+    // SR2-11 binding columns (2026-07-16 migration): kept in the mock so any
+    // eq()/insert reference on them resolves to a real key instead of
+    // `undefined` (an empty-object mock silently breaks assertions on these).
+    providerVersion: 'providerVersion',
+    initiatingAuthEpoch: 'initiatingAuthEpoch',
+    initiatingMfaEpoch: 'initiatingMfaEpoch',
+    initiatingSessionId: 'initiatingSessionId',
+    expiresAt: 'expiresAt',
+    createdAt: 'createdAt',
+  },
   ssoVerifiedDomains: {
     id: 'id',
     orgId: 'orgId',
@@ -207,7 +224,7 @@ vi.mock('../middleware/auth', () => ({
   })
 }));
 
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { createTokenPair, rateLimiter } from '../services';
 import { authMiddleware } from '../middleware/auth';
 import {
@@ -683,6 +700,53 @@ describe('sso routes', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.success).toBe(true);
+  });
+
+  // Regression guard (SR2-11): sso_sessions is now system-scope-only under
+  // FORCE RLS, with no ON DELETE CASCADE from sso_providers. Before the
+  // cleanup deletes were wrapped in withSystemDbAccessContext, the first
+  // delete (sso_sessions) would 0-row from the admin's tenant-scoped
+  // context whenever a pending session existed, and the sso_providers
+  // delete three lines later would then die with FK violation 23503 — i.e.
+  // provider deletion would fail within 10 minutes of any login attempt.
+  // This asserts the happy path still returns 200 with all three deletes
+  // issued and system context invoked around the cleanup.
+  it('deletes a provider with a pending session present (FK-violation regression guard)', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID, orgId: ORG_UUID }])
+        })
+      })
+    } as any);
+
+    // First delete call = ssoSessions — simulate a pending session row
+    // existing (matched by the providerId filter) that must be cleared
+    // before the FK-checked ssoProviders delete below can succeed.
+    vi.mocked(db.delete)
+      .mockReturnValueOnce({ where: vi.fn().mockResolvedValue([{ id: 'pending-session-id' }]) } as any)
+      .mockReturnValueOnce({ where: vi.fn().mockResolvedValue(undefined) } as any)
+      .mockReturnValueOnce({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID }])
+        })
+      } as any);
+
+    const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // All three deletes fired (sso_sessions, user_sso_identities, sso_providers)...
+    expect(db.delete).toHaveBeenCalledTimes(3);
+    // ...and the sso_sessions/user_sso_identities cleanup ran through system
+    // context, not the caller's tenant-scoped context.
+    expect(runOutsideDbContext).toHaveBeenCalled();
+    expect(withSystemDbAccessContext).toHaveBeenCalled();
   });
 
   it('rejects testing non-OIDC providers', async () => {

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -94,7 +94,15 @@ vi.mock('../db', () => ({
     }))
   },
   runOutsideDbContext: vi.fn((fn: () => any) => fn()),
-  withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn())
+  withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn()),
+  // SR2-10 Fix 2: revalidateSsoDefaultRole asserts the ambient context is
+  // 'system' before doing anything else. withSystemDbAccessContext above is a
+  // dumb passthrough (it does not actually track ambient state the way the
+  // real AsyncLocalStorage-backed implementation does), so this mock is what
+  // stands in for "the wrap really ran" — default it to 'system' so every
+  // existing test (which relies on the wrap being effective) stays green. The
+  // dedicated Fix 2 test below overrides this to prove the guard bites.
+  getCurrentDbAccessContext: vi.fn(() => ({ scope: 'system' as const }))
 }));
 
 vi.mock('../db/schema', () => ({
@@ -270,7 +278,7 @@ vi.mock('../middleware/auth', () => ({
   })
 }));
 
-import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext, getCurrentDbAccessContext } from '../db';
 import { createTokenPair, rateLimiter } from '../services';
 import { authMiddleware } from '../middleware/auth';
 import {
@@ -2826,9 +2834,12 @@ describe('sso routes', () => {
       orgId: null
     };
     // The trap (binding decision A): a SYSTEM role carrying the `*:*` wildcard.
-    // checkRoleStructure() returns null (= "assignable") for exactly this row —
-    // so a structural fallback would JIT-provision every SSO user at FULL
-    // WILDCARD. Only a real permission ceiling against a real principal stops it.
+    // A caller-independent structural check would return null (= "assignable")
+    // for exactly this row — so a structural fallback would JIT-provision every
+    // SSO user at FULL WILDCARD. Only a real permission ceiling against a real
+    // principal stops it. (This same row also matches Fix 1's config-time gap:
+    // `isSystem: true` with `orgId: null` is exactly what getProviderAxisRole
+    // must refuse that the old getScopedRole call would have accepted.)
     const SYSTEM_WILDCARD_ROLE_ROW = {
       id: ROLE_UUID,
       scope: 'organization',
@@ -2854,7 +2865,7 @@ describe('sso routes', () => {
     it('POST /providers (org axis) rejects a defaultRoleId above the caller ceiling', async () => {
       permissionsByUser[USER_UUID] = { permissions: [{ resource: 'devices', action: 'read' }] };
       vi.mocked(db.select)
-        .mockReturnValueOnce(selLimit([ORG_ROLE_ROW]))               // getScopedRole
+        .mockReturnValueOnce(selLimit([ORG_ROLE_ROW]))               // getProviderAxisRole
         .mockReturnValueOnce(selLimit([{ parentRoleId: null }]))     // effective perms: role row
         .mockReturnValueOnce(selJoin([{ resource: 'users', action: 'write' }])); // role's perms
 
@@ -2872,7 +2883,32 @@ describe('sso routes', () => {
 
     it('POST /providers (org axis) rejects an unknown defaultRoleId', async () => {
       permissionsByUser[USER_UUID] = { permissions: [{ resource: '*', action: '*' }] };
-      vi.mocked(db.select).mockReturnValueOnce(selLimit([])); // getScopedRole → null
+      vi.mocked(db.select).mockReturnValueOnce(selLimit([])); // getProviderAxisRole → null
+
+      const res = await app.request('/sso/providers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: createBody({ ownerScope: 'organization' })
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).error)
+        .toBe('defaultRoleId must be an organization-scoped role belonging to this organization');
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    // SR2-10 Fix 1: config time must reject a defaultRoleId the JIT resolver
+    // could NEVER resolve — a built-in system role, whose org_id/partner_id are
+    // always NULL. The caller holds `*:*` (would sail through the ceiling), so
+    // this proves the axis check runs BEFORE/INDEPENDENT of the ceiling, not as
+    // a side effect of it. Before Fix 1, `getScopedRole`'s isSystem shortcut
+    // would have accepted this row and 201'd — the exact drift the reviewer
+    // caught: a provider saved with this defaultRoleId would then die at
+    // `invalid_provider_configuration` on every future SSO sign-in, because the
+    // JIT resolver applies strict axis equality and a system role never matches.
+    it('POST /providers (org axis) rejects a SYSTEM role not scoped to this org (config/JIT drift gap)', async () => {
+      permissionsByUser[USER_UUID] = { permissions: [{ resource: '*', action: '*' }] };
+      vi.mocked(db.select).mockReturnValueOnce(selLimit([SYSTEM_WILDCARD_ROLE_ROW]));
 
       const res = await app.request('/sso/providers', {
         method: 'POST',
@@ -3073,7 +3109,7 @@ describe('sso routes', () => {
 
       vi.mocked(db.select)
         .mockReturnValueOnce(selLimit([provider]))              // 1. provider
-        .mockReturnValueOnce(selLimit([{ id: ROLE_UUID }]))     // 2. legacy axis/scope check
+        .mockReturnValueOnce(selLimit([ORG_ROLE_ROW]))          // 2. pre-JIT axis check (getProviderAxisRole)
         .mockReturnValueOnce(selLimit([]))                      // 3. (provider, sub) → unlinked
         .mockReturnValueOnce(selLimit([]));                     // 4. users by email → none
       for (const t of tail) vi.mocked(db.select).mockReturnValueOnce(t);
@@ -3088,7 +3124,7 @@ describe('sso routes', () => {
       permissionsByUser[CONFIGURER_UUID] = { permissions: [{ resource: 'devices', action: 'read' }] };
       primeJitCallback(
         jitProvider(),
-        selLimit([ORG_ROLE_ROW]),                                  // 5. getScopedRole (live)
+        selLimit([ORG_ROLE_ROW]),                                  // 5. getProviderAxisRole (live)
         selLimit([{ id: CONFIGURER_UUID, status: 'active' }]),     // 6. configurer live status
         selLimit([{ partnerId: PARTNER_UUID }]),                   // 7. org's owning partner
         selLimit([{ parentRoleId: null }]),                        // 8. role's effective perms
@@ -3128,8 +3164,9 @@ describe('sso routes', () => {
     });
 
     // Binding decision (A): the unknowable-configurer fallback FAILS CLOSED.
-    // A structural check (checkRoleStructure) returns null for a SYSTEM wildcard
-    // role — using it here would JIT every user at full wildcard.
+    // A caller-independent structural check would return null (= assignable)
+    // for a SYSTEM wildcard role — using it here would JIT every user at full
+    // wildcard.
     it('refuses JIT when NO configurer can be resolved (fails closed, never structural)', async () => {
       primeJitCallback(
         jitProvider({ defaultRoleConfiguredBy: null, createdBy: null }),
@@ -3147,21 +3184,24 @@ describe('sso routes', () => {
       }));
     });
 
-    // THE WILDCARD TRAP (binding decision A). The provider's default role is the
-    // built-in SYSTEM super-admin role (`*:*`). checkRoleStructure() would say
-    // "assignable". The real ceiling must refuse it because the configuring org
-    // admin does not hold `*:*`.
-    it('refuses to JIT-provision at the SYSTEM WILDCARD role when the configurer does not hold the wildcard', async () => {
+    // THE WILDCARD TRAP (binding decision A), SR2-10 Fix 1 revision. The
+    // provider's default role is the built-in SYSTEM super-admin role (`*:*`).
+    // A caller-independent structural check would say "assignable" — the real
+    // defense is that `getProviderAxisRole` (used here too, not just at config
+    // time) has no `isSystem` escape hatch at all, so a role whose `orgId` is
+    // NULL (every seeded system role) can never resolve on the provider's org
+    // axis. Before Fix 1 this was refused one step later, by the permission
+    // ceiling specifically because the configurer didn't hold `*:*` — which
+    // meant a configurer who DID hold `*:*` (a genuine platform super-admin)
+    // could have slipped a system role through. The axis check now refuses it
+    // unconditionally, regardless of the configurer's own permissions.
+    it('refuses to JIT-provision at the SYSTEM WILDCARD role — it can never resolve on the provider axis', async () => {
       permissionsByUser[CONFIGURER_UUID] = {
-        permissions: [{ resource: 'users', action: 'write' }, { resource: 'sso', action: 'admin' }]
+        permissions: [{ resource: '*', action: '*' }] // even a configurer WITH the wildcard is refused
       };
       primeJitCallback(
         jitProvider(),
-        selLimit([SYSTEM_WILDCARD_ROLE_ROW]),
-        selLimit([{ id: CONFIGURER_UUID, status: 'active' }]),
-        selLimit([{ partnerId: PARTNER_UUID }]),
-        selLimit([{ parentRoleId: null }]),
-        selJoin([{ resource: '*', action: '*' }])   // the built-in super-admin grant
+        selLimit([SYSTEM_WILDCARD_ROLE_ROW])
       );
 
       const res = await doJitCallback();
@@ -3172,7 +3212,7 @@ describe('sso routes', () => {
       expect(createTokenPair).not.toHaveBeenCalled();
       expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
         result: 'denied',
-        details: expect.objectContaining({ reason: 'default_role_exceeds_configurer_permissions' })
+        details: expect.objectContaining({ reason: 'default_role_not_on_provider_axis' })
       }));
     });
 
@@ -3187,12 +3227,15 @@ describe('sso routes', () => {
 
       primeJitCallback(
         jitProvider(),
-        selLimit([ORG_ROLE_ROW]),                              // 5. getScopedRole
+        selLimit([ORG_ROLE_ROW]),                              // 5. getProviderAxisRole
         selLimit([{ id: CONFIGURER_UUID, status: 'active' }]), // 6. configurer status
         selLimit([{ partnerId: PARTNER_UUID }]),               // 7. org's owning partner (partner axis!)
         selLimit([{ parentRoleId: null }]),                    // 8. effective perms: role row
         selJoin([{ resource: 'users', action: 'write' }]),     // 9. in-ceiling
-        selLimit([{ partnerId: PARTNER_UUID }]),               // 10. provisioning: org partner
+        // SR2-10 Fix 4: no separate "provisioning: org partner" select here —
+        // the provisioning block now reuses the org's partnerId that #7 (the
+        // ceiling's own resolution above) already fetched, instead of
+        // re-querying `organizations` for the identical row.
         selJoinLimit([{ orgId: ORG_UUID, roleId: ROLE_UUID, roleName: 'Support', roleScope: 'organization' }]), // membership
         selLimit([])                                           // existing identity → none
       );
@@ -3244,7 +3287,7 @@ describe('sso routes', () => {
       permissionsByUser[CONFIGURER_UUID] = { permissions: [{ resource: '*', action: '*' }] };
       primeJitCallback(
         jitProvider(),
-        selLimit([])   // getScopedRole → role deleted / re-scoped
+        selLimit([])   // getProviderAxisRole → role deleted / re-scoped
       );
 
       const res = await doJitCallback();
@@ -3256,6 +3299,60 @@ describe('sso routes', () => {
         result: 'denied',
         details: expect.objectContaining({ reason: 'default_role_not_on_provider_axis' })
       }));
+    });
+
+    // SR2-10 Fix 2. `revalidateSsoDefaultRole` MUST run inside
+    // withSystemDbAccessContext — outside it, `role_permissions` (FORCE RLS)
+    // 0-rows and `applyCeiling` treats "no permissions" as "assignable",
+    // fail-OPEN for ANY role (not just a system one — `getProviderAxisRole`'s
+    // own axis check independently blocks system roles regardless of DB
+    // context, so this scenario is built around an ORDINARY org-scoped custom
+    // role to isolate the ceiling's own fail-open mode specifically). The mock
+    // queues a role that DOES resolve (ORG_ROLE_ROW) but an EMPTY
+    // role_permissions join (position 9) — exactly what force-RLS returns with
+    // no context — and a configurer who holds none of the role's (real, but
+    // invisible-to-this-read) permissions, plus full provisioning mocks. If the
+    // invariant is missing, this data is shaped to let JIT actually provision
+    // the user (proving fail-open, not just "some other reason it fails
+    // closed"); manually inverting the guard and re-running this test (see the
+    // fix report) showed exactly that — `db.insert` WAS called.
+    //
+    // `getCurrentDbAccessContext` stands in for "did withSystemDbAccessContext
+    // actually take effect" (the db mock makes the real wrap a pass-through,
+    // so it can't detect a dropped wrap itself). Every other test in this file
+    // defaults it to 'system'; this test alone overrides it to prove the throw
+    // fires before any of the fail-open-shaped data below is ever touched.
+    it('throws (fails closed) if revalidateSsoDefaultRole ever runs outside a system DB context', async () => {
+      permissionsByUser[CONFIGURER_UUID] = { permissions: [{ resource: 'devices', action: 'read' }] };
+      vi.mocked(getCurrentDbAccessContext).mockReturnValueOnce({ scope: 'organization' } as any);
+      primeJitCallback(
+        jitProvider(),
+        selLimit([ORG_ROLE_ROW]),                              // 5. getProviderAxisRole
+        selLimit([{ id: CONFIGURER_UUID, status: 'active' }]), // 6. configurer status
+        selLimit([{ partnerId: PARTNER_UUID }]),                // 7. org's owning partner
+        selLimit([{ parentRoleId: null }]),                     // 8. effective perms: role row
+        selJoin([]),                                            // 9. role_permissions — 0-rows w/o system ctx
+        selJoinLimit([{ orgId: ORG_UUID, roleId: ROLE_UUID, roleName: 'Support', roleScope: 'organization' }]), // membership
+        selLimit([])                                            // existing identity → none
+      );
+      const usersInsertValues = vi.fn(() => ({
+        returning: vi.fn().mockResolvedValue([{
+          id: NEW_USER_UUID, email: 'new@example.com', name: 'New User', orgId: ORG_UUID, partnerId: PARTNER_UUID
+        }])
+      }));
+      const orgUsersInsertValues = vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) }));
+      vi.mocked(db.insert)
+        .mockReturnValueOnce({ values: usersInsertValues } as any)
+        .mockReturnValueOnce({ values: orgUsersInsertValues } as any);
+
+      const res = await doJitCallback();
+
+      // Caught by the callback's top-level catch (same as any other
+      // unexpected error) and redirected — NOT silently provisioned, even
+      // though every downstream mock was primed to let provisioning succeed.
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('/login?error=sso_error');
+      expect(db.insert).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -151,7 +151,10 @@ vi.mock('../db/schema', () => ({
     id: 'id',
     email: 'email',
     orgId: 'orgId',
-    partnerId: 'partnerId'
+    partnerId: 'partnerId',
+    // SR2-10: the JIT ceiling re-check reads the configurer's live status —
+    // a disabled/offboarded configurer must not keep delegating a role.
+    status: 'status'
   },
   organizationUsers: {
     orgId: 'orgId',
@@ -163,13 +166,56 @@ vi.mock('../db/schema', () => ({
     partnerId: 'partnerId',
     roleId: 'roleId'
   },
+  // SR2-10: the callback resolves the provider org's owning partner so the
+  // configurer's permissions resolve on the PARTNER axis too (an MSP partner
+  // admin has no organization_users row). Previously absent from this mock —
+  // the JIT provisioning path was never exercised by a unit test.
+  organizations: {
+    id: 'id',
+    partnerId: 'partnerId'
+  },
   roles: {
     id: 'id',
     name: 'name',
     scope: 'scope',
     orgId: 'orgId',
-    partnerId: 'partnerId'
+    partnerId: 'partnerId',
+    isSystem: 'isSystem',
+    description: 'description',
+    parentRoleId: 'parentRoleId'
+  },
+  // Consumed by the REAL services/roleAssignment (deliberately not mocked in
+  // this suite — see the SR2-10 describe block).
+  permissions: {
+    id: 'id',
+    resource: 'resource',
+    action: 'action'
+  },
+  rolePermissions: {
+    roleId: 'roleId',
+    permissionId: 'permissionId'
   }
+}));
+
+// SR2-10: keep PERMISSIONS (read at module scope by the route's
+// requirePermission guard) REAL; only getUserPermissions is driven per-test.
+// It is the resolver for BOTH the config-time caller ceiling and the JIT
+// configurer ceiling.
+const { permissionsByUser } = vi.hoisted(() => ({
+  permissionsByUser: {} as Record<string, { permissions: Array<{ resource: string; action: string }> } | null>,
+}));
+
+vi.mock('../services/permissions', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../services/permissions')>()),
+  getUserPermissions: vi.fn(async (userId: string) => permissionsByUser[userId] ?? null),
+}));
+
+// Spy on the audit sink so SR2-10 denials can be asserted by action/reason.
+// Also removes writeRouteAudit's fire-and-forget audit-log db.insert from the
+// mock queues, which keeps the callback select/insert ordering deterministic.
+vi.mock('../services/auditEvents', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../services/auditEvents')>()),
+  writeRouteAudit: vi.fn(),
 }));
 
 vi.mock('../services/ssoDomainVerification', () => ({
@@ -236,6 +282,8 @@ import {
 } from '../services/sso';
 import { createPendingDomain, verifyDomain, isSsoProvisioningBlocked } from '../services/ssoDomainVerification';
 import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
+import { getUserPermissions } from '../services/permissions';
+import { writeRouteAudit } from '../services/auditEvents';
 import { auditLogin } from './auth/helpers';
 
 const PROVIDER_UUID = '00000000-0000-4000-8000-000000000001';
@@ -311,6 +359,7 @@ describe('sso routes', () => {
     process.env.APP_ENCRYPTION_KEY = SSO_STATE_COOKIE_SECRET;
     permissionGate.deny = false;
     mfaGate.deny = false;
+    for (const key of Object.keys(permissionsByUser)) delete permissionsByUser[key];
     // security review #2: the callback now requires a signature-verified id_token
     // (jwksUrl + id_token mandatory; the unsigned decode path was removed).
     // Default the verifier to "passes" with minimal claims so flows that don't
@@ -2712,6 +2761,501 @@ describe('sso routes', () => {
       expect(res.headers.get('location')).toContain('ssoLinkError=identity_in_use');
       expect(db.insert).not.toHaveBeenCalled();
       expect(createTokenPair).not.toHaveBeenCalled();
+    });
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // SR2-10: SSO default-role delegation ceiling
+  //
+  // The vulnerability: an SSO provider's defaultRoleId was applied to every
+  // JIT-provisioned user with NO permission ceiling — nobody checked that the
+  // admin who configured it was entitled to grant that role. The org axis (the
+  // ONLY axis that JIT-provisions) validated nothing at all.
+  //
+  // NOTE: services/roleAssignment is deliberately NOT mocked in this suite.
+  // The ceiling is the security control under test; stubbing it would make
+  // every assertion below vacuous (we would only be testing our own stub). The
+  // real validator runs against the db mock, so the queues here include its
+  // selects.
+  // ══════════════════════════════════════════════════════════════════════════
+  describe('SSO default-role delegation ceiling (SR2-10)', () => {
+    const ROLE_UUID = '00000000-0000-4000-8000-000000000040';
+    const CONFIGURER_UUID = '00000000-0000-4000-8000-000000000050';
+    const CREATOR_UUID = '00000000-0000-4000-8000-000000000051';
+    const NEW_USER_UUID = '00000000-0000-4000-8000-000000000052';
+
+    // select().from().where().limit()
+    const selLimit = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) })
+      })
+    }) as any;
+    // select().from().innerJoin().where()  — getEffectiveRolePermissions (no limit)
+    const selJoin = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(rows) })
+      })
+    }) as any;
+    // select().from().innerJoin().where().limit() — org membership resolution
+    const selJoinLimit = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) })
+        })
+      })
+    }) as any;
+
+    const ORG_ROLE_ROW = {
+      id: ROLE_UUID,
+      scope: 'organization',
+      name: 'Support',
+      description: null,
+      isSystem: false,
+      parentRoleId: null,
+      partnerId: null,
+      orgId: ORG_UUID
+    };
+    const PARTNER_ROLE_ROW = {
+      id: ROLE_UUID,
+      scope: 'partner',
+      name: 'Partner Tech',
+      description: null,
+      isSystem: false,
+      parentRoleId: null,
+      partnerId: PARTNER_UUID,
+      orgId: null
+    };
+    // The trap (binding decision A): a SYSTEM role carrying the `*:*` wildcard.
+    // checkRoleStructure() returns null (= "assignable") for exactly this row —
+    // so a structural fallback would JIT-provision every SSO user at FULL
+    // WILDCARD. Only a real permission ceiling against a real principal stops it.
+    const SYSTEM_WILDCARD_ROLE_ROW = {
+      id: ROLE_UUID,
+      scope: 'organization',
+      name: 'Super Admin',
+      description: null,
+      isSystem: true,
+      parentRoleId: null,
+      partnerId: null,
+      orgId: null
+    };
+
+    const createBody = (extra: Record<string, unknown> = {}) => JSON.stringify({
+      name: 'Okta',
+      type: 'oidc',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      defaultRoleId: ROLE_UUID,
+      ...extra
+    });
+
+    // ─── Config time ────────────────────────────────────────────────────────
+
+    it('POST /providers (org axis) rejects a defaultRoleId above the caller ceiling', async () => {
+      permissionsByUser[USER_UUID] = { permissions: [{ resource: 'devices', action: 'read' }] };
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selLimit([ORG_ROLE_ROW]))               // getScopedRole
+        .mockReturnValueOnce(selLimit([{ parentRoleId: null }]))     // effective perms: role row
+        .mockReturnValueOnce(selJoin([{ resource: 'users', action: 'write' }])); // role's perms
+
+      const res = await app.request('/sso/providers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: createBody({ ownerScope: 'organization' })
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).error)
+        .toBe('Cannot assign a role with permission not held by caller: users:write');
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('POST /providers (org axis) rejects an unknown defaultRoleId', async () => {
+      permissionsByUser[USER_UUID] = { permissions: [{ resource: '*', action: '*' }] };
+      vi.mocked(db.select).mockReturnValueOnce(selLimit([])); // getScopedRole → null
+
+      const res = await app.request('/sso/providers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: createBody({ ownerScope: 'organization' })
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).error)
+        .toBe('defaultRoleId must be an organization-scoped role belonging to this organization');
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('POST /providers (org axis) accepts an in-ceiling defaultRoleId and stamps defaultRoleConfiguredBy', async () => {
+      permissionsByUser[USER_UUID] = { permissions: [{ resource: 'users', action: 'write' }] };
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selLimit([ORG_ROLE_ROW]))
+        .mockReturnValueOnce(selLimit([{ parentRoleId: null }]))
+        .mockReturnValueOnce(selJoin([{ resource: 'users', action: 'write' }]));
+
+      const insertValues = vi.fn(() => ({
+        returning: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null, name: 'Okta', type: 'oidc', status: 'inactive' }])
+      }));
+      vi.mocked(db.insert).mockReturnValueOnce({ values: insertValues } as any);
+
+      const res = await app.request('/sso/providers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: createBody({ ownerScope: 'organization' })
+      });
+
+      expect(res.status).toBe(201);
+      expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({
+        defaultRoleId: ROLE_UUID,
+        defaultRoleConfiguredBy: USER_UUID
+      }));
+    });
+
+    it('POST /providers does NOT stamp defaultRoleConfiguredBy when no role is delegated', async () => {
+      const insertValues = vi.fn(() => ({
+        returning: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null, name: 'Okta', type: 'oidc', status: 'inactive' }])
+      }));
+      vi.mocked(db.insert).mockReturnValueOnce({ values: insertValues } as any);
+
+      const res = await app.request('/sso/providers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Okta', type: 'oidc', ownerScope: 'organization' })
+      });
+
+      expect(res.status).toBe(201);
+      expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ defaultRoleConfiguredBy: null }));
+    });
+
+    it('POST /providers (PARTNER axis) rejects a defaultRoleId above the partner admin ceiling', async () => {
+      setAuthContext({
+        scope: 'partner', orgId: null, partnerId: PARTNER_UUID,
+        accessibleOrgIds: [], partnerOrgAccess: 'all'
+      });
+      // Partner admin holds devices:read only — they may not delegate users:write.
+      permissionsByUser[USER_UUID] = { permissions: [{ resource: 'devices', action: 'read' }] };
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selLimit([PARTNER_ROLE_ROW]))
+        .mockReturnValueOnce(selLimit([{ parentRoleId: null }]))
+        .mockReturnValueOnce(selJoin([{ resource: 'users', action: 'write' }]));
+
+      const res = await app.request('/sso/providers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: createBody({ ownerScope: 'partner' })
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).error)
+        .toBe('Cannot assign a role with permission not held by caller: users:write');
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('PATCH /providers/:id rejects an out-of-ceiling defaultRoleId (no update)', async () => {
+      permissionsByUser[USER_UUID] = { permissions: [{ resource: 'devices', action: 'read' }] };
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selLimit([{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null }])) // existing
+        .mockReturnValueOnce(selLimit([ORG_ROLE_ROW]))
+        .mockReturnValueOnce(selLimit([{ parentRoleId: null }]))
+        .mockReturnValueOnce(selJoin([{ resource: 'users', action: 'write' }]));
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ defaultRoleId: ROLE_UUID })
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).error)
+        .toBe('Cannot assign a role with permission not held by caller: users:write');
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('PATCH /providers/:id re-stamps defaultRoleConfiguredBy when the default role is set', async () => {
+      permissionsByUser[USER_UUID] = { permissions: [{ resource: 'users', action: 'write' }] };
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selLimit([{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null }]))
+        .mockReturnValueOnce(selLimit([ORG_ROLE_ROW]))
+        .mockReturnValueOnce(selLimit([{ parentRoleId: null }]))
+        .mockReturnValueOnce(selJoin([{ resource: 'users', action: 'write' }]));
+
+      const updateSet = vi.fn(() => ({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null, name: 'Okta' }])
+        })
+      }));
+      vi.mocked(db.update).mockReturnValueOnce({ set: updateSet } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ defaultRoleId: ROLE_UUID })
+      });
+
+      expect(res.status).toBe(200);
+      expect(updateSet).toHaveBeenCalledWith(expect.objectContaining({ defaultRoleConfiguredBy: USER_UUID }));
+    });
+
+    it('PATCH /providers/:id without defaultRoleId does NOT touch defaultRoleConfiguredBy', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selLimit([{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null }]));
+
+      const updateSet = vi.fn((_values: Record<string, unknown>) => ({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null, name: 'Renamed' }])
+        })
+      }));
+      vi.mocked(db.update).mockReturnValueOnce({ set: updateSet } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(updateSet).toHaveBeenCalledTimes(1);
+      expect(Object.keys(updateSet.mock.calls[0]![0])).not.toContain('defaultRoleConfiguredBy');
+    });
+
+    // ─── JIT time ───────────────────────────────────────────────────────────
+
+    const jitProvider = (overrides: Record<string, unknown> = {}) => ({
+      id: PROVIDER_UUID,
+      orgId: ORG_UUID,
+      partnerId: null,
+      name: 'Okta',
+      type: 'oidc',
+      issuer: 'https://issuer.example.com',
+      authorizationUrl: 'https://issuer.example.com/auth',
+      tokenUrl: 'https://issuer.example.com/token',
+      userInfoUrl: 'https://issuer.example.com/userinfo',
+      jwksUrl: 'https://issuer.example.com/jwks',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      scopes: 'openid profile email',
+      attributeMapping: { email: 'email', name: 'name' },
+      autoProvision: true,
+      allowedDomains: null,
+      trustsIdpMfa: false,
+      defaultRoleId: ROLE_UUID,
+      defaultRoleConfiguredBy: CONFIGURER_UUID,
+      createdBy: CREATOR_UUID,
+      ...overrides
+    });
+
+    // Primes the IdP round-trip + the callback's pre-JIT selects for a BRAND NEW
+    // (unlinked, unknown-email) org-axis user. Leaves the db.select queue
+    // positioned at the SR2-10 re-validation selects.
+    const primeJitCallback = (provider: Record<string, unknown>, ...tail: any[]) => {
+      // vi.clearAllMocks() clears CALLS but not implementations, and an earlier
+      // suite pins this to `true` — pin it back or every JIT test dies at the
+      // domain gate before reaching the ceiling under test.
+      vi.mocked(isSsoProvisioningBlocked).mockResolvedValue(false);
+      vi.mocked(exchangeCodeForTokens).mockResolvedValue({
+        access_token: 'idp-access-token', refresh_token: 'idp-refresh-token',
+        expires_in: 3600, id_token: 'header.payload.sig'
+      } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({
+        sub: 'external-user-1', email: 'new@example.com', name: 'New User'
+      } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'new@example.com', name: 'New User' } as any);
+      vi.mocked(verifyIdTokenSignature).mockResolvedValue({ sub: 'external-user-1', nonce: 'nonce' } as any);
+
+      vi.mocked(db.delete).mockReturnValueOnce({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            id: 'sso-session-jit', providerId: PROVIDER_UUID, state: 'state',
+            nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/'
+          }])
+        })
+      } as any);
+
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selLimit([provider]))              // 1. provider
+        .mockReturnValueOnce(selLimit([{ id: ROLE_UUID }]))     // 2. legacy axis/scope check
+        .mockReturnValueOnce(selLimit([]))                      // 3. (provider, sub) → unlinked
+        .mockReturnValueOnce(selLimit([]));                     // 4. users by email → none
+      for (const t of tail) vi.mocked(db.select).mockReturnValueOnce(t);
+    };
+
+    const doJitCallback = () => app.request('/sso/callback?code=oidc-code&state=state', {
+      headers: { cookie: ssoStateCookieHeader('state') }
+    });
+
+    it('refuses JIT when the configurer has since been stripped of the delegated permission', async () => {
+      // Legal at config time; the configurer has since been demoted to devices:read.
+      permissionsByUser[CONFIGURER_UUID] = { permissions: [{ resource: 'devices', action: 'read' }] };
+      primeJitCallback(
+        jitProvider(),
+        selLimit([ORG_ROLE_ROW]),                                  // 5. getScopedRole (live)
+        selLimit([{ id: CONFIGURER_UUID, status: 'active' }]),     // 6. configurer live status
+        selLimit([{ partnerId: PARTNER_UUID }]),                   // 7. org's owning partner
+        selLimit([{ parentRoleId: null }]),                        // 8. role's effective perms
+        selJoin([{ resource: 'users', action: 'write' }])          // 9. → users:write
+      );
+
+      const res = await doJitCallback();
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/login?error=invalid_provider_configuration');
+      expect(db.insert).not.toHaveBeenCalled(); // no users row, no organization_users row
+      expect(createTokenPair).not.toHaveBeenCalled();
+      expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        action: 'sso.callback.rejected',
+        result: 'denied',
+        details: expect.objectContaining({ reason: 'default_role_exceeds_configurer_permissions' })
+      }));
+    });
+
+    it('refuses JIT when the configurer account has been deactivated', async () => {
+      permissionsByUser[CONFIGURER_UUID] = { permissions: [{ resource: '*', action: '*' }] };
+      primeJitCallback(
+        jitProvider(),
+        selLimit([ORG_ROLE_ROW]),
+        selLimit([{ id: CONFIGURER_UUID, status: 'disabled' }]) // offboarded
+      );
+
+      const res = await doJitCallback();
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/login?error=invalid_provider_configuration');
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        result: 'denied',
+        details: expect.objectContaining({ reason: 'default_role_configurer_inactive' })
+      }));
+    });
+
+    // Binding decision (A): the unknowable-configurer fallback FAILS CLOSED.
+    // A structural check (checkRoleStructure) returns null for a SYSTEM wildcard
+    // role — using it here would JIT every user at full wildcard.
+    it('refuses JIT when NO configurer can be resolved (fails closed, never structural)', async () => {
+      primeJitCallback(
+        jitProvider({ defaultRoleConfiguredBy: null, createdBy: null }),
+        selLimit([ORG_ROLE_ROW])
+      );
+
+      const res = await doJitCallback();
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/login?error=invalid_provider_configuration');
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        result: 'denied',
+        details: expect.objectContaining({ reason: 'default_role_configurer_unknown' })
+      }));
+    });
+
+    // THE WILDCARD TRAP (binding decision A). The provider's default role is the
+    // built-in SYSTEM super-admin role (`*:*`). checkRoleStructure() would say
+    // "assignable". The real ceiling must refuse it because the configuring org
+    // admin does not hold `*:*`.
+    it('refuses to JIT-provision at the SYSTEM WILDCARD role when the configurer does not hold the wildcard', async () => {
+      permissionsByUser[CONFIGURER_UUID] = {
+        permissions: [{ resource: 'users', action: 'write' }, { resource: 'sso', action: 'admin' }]
+      };
+      primeJitCallback(
+        jitProvider(),
+        selLimit([SYSTEM_WILDCARD_ROLE_ROW]),
+        selLimit([{ id: CONFIGURER_UUID, status: 'active' }]),
+        selLimit([{ partnerId: PARTNER_UUID }]),
+        selLimit([{ parentRoleId: null }]),
+        selJoin([{ resource: '*', action: '*' }])   // the built-in super-admin grant
+      );
+
+      const res = await doJitCallback();
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/login?error=invalid_provider_configuration');
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(createTokenPair).not.toHaveBeenCalled();
+      expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        result: 'denied',
+        details: expect.objectContaining({ reason: 'default_role_exceeds_configurer_permissions' })
+      }));
+    });
+
+    // Binding decision (B): an MSP partner admin has NO organization_users row in
+    // the customer org. Resolving the configurer on the org axis ALONE would
+    // return null permissions → every JIT sign-in on their provider would fail
+    // forever. Both axes must be supplied.
+    it('JIT-provisions successfully when the configurer is a PARTNER admin with no organization_users row', async () => {
+      // Keyed by (userId) in the mock; the route must pass BOTH orgId and the
+      // org owning partnerId, or getUserPermissions could never resolve them.
+      permissionsByUser[CONFIGURER_UUID] = { permissions: [{ resource: 'users', action: 'write' }] };
+
+      primeJitCallback(
+        jitProvider(),
+        selLimit([ORG_ROLE_ROW]),                              // 5. getScopedRole
+        selLimit([{ id: CONFIGURER_UUID, status: 'active' }]), // 6. configurer status
+        selLimit([{ partnerId: PARTNER_UUID }]),               // 7. org's owning partner (partner axis!)
+        selLimit([{ parentRoleId: null }]),                    // 8. effective perms: role row
+        selJoin([{ resource: 'users', action: 'write' }]),     // 9. in-ceiling
+        selLimit([{ partnerId: PARTNER_UUID }]),               // 10. provisioning: org partner
+        selJoinLimit([{ orgId: ORG_UUID, roleId: ROLE_UUID, roleName: 'Support', roleScope: 'organization' }]), // membership
+        selLimit([])                                           // existing identity → none
+      );
+
+      const usersInsertValues = vi.fn(() => ({
+        returning: vi.fn().mockResolvedValue([{
+          id: NEW_USER_UUID, email: 'new@example.com', name: 'New User', orgId: ORG_UUID, partnerId: PARTNER_UUID
+        }])
+      }));
+      const orgUsersInsertValues = vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) }));
+      vi.mocked(db.insert)
+        .mockReturnValueOnce({ values: usersInsertValues } as any)
+        .mockReturnValueOnce({ values: orgUsersInsertValues } as any);
+
+      const res = await doJitCallback();
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('ssoCode=');
+      expect(usersInsertValues).toHaveBeenCalledWith(expect.objectContaining({ email: 'new@example.com' }));
+      expect(orgUsersInsertValues).toHaveBeenCalledWith(expect.objectContaining({
+        orgId: ORG_UUID, userId: NEW_USER_UUID, roleId: ROLE_UUID
+      }));
+      // The configurer's permissions were resolved on BOTH axes.
+      expect(getUserPermissions).toHaveBeenCalledWith(CONFIGURER_UUID, {
+        orgId: ORG_UUID, partnerId: PARTNER_UUID
+      });
+    });
+
+    it('falls back to created_by when default_role_configured_by is NULL (legacy rows)', async () => {
+      permissionsByUser[CREATOR_UUID] = { permissions: [{ resource: 'devices', action: 'read' }] };
+      primeJitCallback(
+        jitProvider({ defaultRoleConfiguredBy: null }),         // createdBy: CREATOR_UUID
+        selLimit([ORG_ROLE_ROW]),
+        selLimit([{ id: CREATOR_UUID, status: 'active' }]),
+        selLimit([{ partnerId: PARTNER_UUID }]),
+        selLimit([{ parentRoleId: null }]),
+        selJoin([{ resource: 'users', action: 'write' }])       // above the creator's ceiling
+      );
+
+      const res = await doJitCallback();
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/login?error=invalid_provider_configuration');
+      expect(getUserPermissions).toHaveBeenCalledWith(CREATOR_UUID, { orgId: ORG_UUID, partnerId: PARTNER_UUID });
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('refuses JIT when the delegated role no longer exists on the provider axis', async () => {
+      permissionsByUser[CONFIGURER_UUID] = { permissions: [{ resource: '*', action: '*' }] };
+      primeJitCallback(
+        jitProvider(),
+        selLimit([])   // getScopedRole → role deleted / re-scoped
+      );
+
+      const res = await doJitCallback();
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/login?error=invalid_provider_configuration');
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        result: 'denied',
+        details: expect.objectContaining({ reason: 'default_role_not_on_provider_axis' })
+      }));
     });
   });
 });

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -127,6 +127,11 @@ vi.mock('../db', () => ({
   },
   runOutsideDbContext: vi.fn((fn: () => any) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn()),
+  // I1: the three discovery routes are in SELF_MANAGED_DB_CONTEXT_ROUTES, so they
+  // open their own short request-scoped contexts around each db op (the outbound
+  // OIDC fetch runs between them, holding no connection). Pass-through here — the
+  // real behavior is exercised by the middleware predicate test + integration.
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => any) => fn()),
   // SR2-10 Fix 2: revalidateSsoDefaultRole asserts the ambient context is
   // 'system' before doing anything else. withSystemDbAccessContext above is a
   // dumb passthrough (it does not actually track ambient state the way the
@@ -320,7 +325,17 @@ vi.mock('../middleware/auth', () => ({
       return c.json({ error: 'MFA required' }, 403);
     }
     return next();
-  })
+  }),
+  // I1: routes/sso rebuilds the request's RLS context from `auth` for its own
+  // short DB blocks (the provider routes opt out of the ambient request tx).
+  dbAccessContextFromAuth: vi.fn((auth: any) => ({
+    scope: auth.scope,
+    orgId: auth.orgId ?? null,
+    accessibleOrgIds: auth.accessibleOrgIds ?? null,
+    accessiblePartnerIds: auth.partnerId ? [auth.partnerId] : [],
+    userId: auth.user?.id ?? null,
+    currentPartnerId: auth.partnerId ?? null,
+  }))
 }));
 
 import { db, runOutsideDbContext, withSystemDbAccessContext, getCurrentDbAccessContext } from '../db';

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { eq, and, gt, ne, isNull, inArray, sql } from 'drizzle-orm';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { nanoid } from 'nanoid';
-import { db, runOutsideDbContext, withSystemDbAccessContext, getCurrentDbAccessContext } from '../db';
+import { db, runOutsideDbContext, withDbAccessContext, withSystemDbAccessContext, getCurrentDbAccessContext } from '../db';
 import {
   ssoProviders,
   ssoSessions,
@@ -17,7 +17,7 @@ import {
   roles
 } from '../db/schema';
 import { createPendingDomain, verifyDomain, recordNameFor, recordValueFor, isSsoProvisioningBlocked, isDomainVerifiedForOrg } from '../services/ssoDomainVerification';
-import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
+import { authMiddleware, dbAccessContextFromAuth, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import {
   generateState,
   generateNonce,
@@ -179,10 +179,78 @@ const createProviderSchema = z.object({
   trustsIdpMfa: z.boolean().optional()
 });
 
-const updateProviderSchema = createProviderSchema.omit({ orgId: true, ownerScope: true }).partial();
+// `preset` is NOT a column on sso_providers — it is a create-time convenience
+// that POST /providers expands into scopes + attributeMapping. PATCH spreads
+// `...body` straight into db.update().set(), so leaving `preset` in the update
+// schema means `PATCH { preset: 'okta' }` reaches Drizzle's mapUpdateSet with a
+// key that has no column and throws at runtime. PATCH never applied a preset
+// anyway — omit it. (Same class as the ownerScope omit above.)
+const updateProviderSchema = createProviderSchema
+  .omit({ orgId: true, ownerScope: true, preset: true })
+  .partial();
 const tokenExchangeSchema = z.object({
   code: z.string().min(1)
 });
+
+/**
+ * Run one short DB access context in the CALLER's exact tenant scope.
+ *
+ * The three provider routes that perform OIDC discovery (POST /providers,
+ * PATCH /providers/:id, POST /providers/:id/test) are registered in
+ * SELF_MANAGED_DB_CONTEXT_ROUTES, so `authMiddleware` does NOT open the ambient
+ * request transaction for them: `discoverOIDCConfig` → `safeFetch` is a
+ * 10-second-timeout call to a TENANT-CONTROLLED issuer host, and holding a
+ * pooled `breeze_app` connection idle-in-transaction across it is
+ * tenant-triggerable pool starvation (#1105 class — 25 connections in prod, and
+ * these routes have no rate limit). `safeFetch`'s `assertOutsideHeldDbContext`
+ * tripwire exists precisely to catch this.
+ *
+ * `runOutsideDbContext` alone does NOT fix it — it only swaps the ALS `db`
+ * reference; the middleware's outer `baseDb.transaction` stays held. The route
+ * must not open that transaction at all, which is what the allowlist buys.
+ *
+ * Consequence: these handlers run with NO ambient context, so EVERY db op needs
+ * an explicit short context or it hits the bare pool (RLS-denied → silent 0-row
+ * read / contextless-write guard). `dbAccessContextFromAuth` rebuilds the exact
+ * context authMiddleware would have opened, so RLS is byte-identical to every
+ * other route; the discovery call happens BETWEEN these blocks, holding nothing.
+ * The `runOutsideDbContext` wrap is a defensive no-op here (there is no ambient
+ * context to exit) that keeps this correct if the route is ever removed from the
+ * allowlist. Pattern: services/accounting/quickbooksCustomerImport.ts.
+ */
+function withProviderDbContext<T>(auth: AuthContext, fn: () => Promise<T>): Promise<T> {
+  return runOutsideDbContext(() => withDbAccessContext(dbAccessContextFromAuth(auth), fn));
+}
+
+/**
+ * Operator-facing reason a discovery attempt failed. discoverOIDCConfig already
+ * shapes these for human eyes ("OIDC discovery blocked: no DNS records for …",
+ * "OIDC discovery failed: 404", "OIDC discovery returned an endpoint that is not
+ * HTTPS …"), and POST /providers/:id/test has always relayed them verbatim to
+ * the UI — the caller supplied the issuer, so this leaks nothing they don't know.
+ */
+function discoveryErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * The mailbox domain of an address, or null when it has none.
+ *
+ * `email.split('@')[1]` is UNSOUND for a multi-`@` address: for
+ * `victim@corp.example@evil.com` it yields `corp.example` — a domain the org may
+ * well have DNS-verified — while the real mailbox domain is `evil.com`. Both the
+ * allowedDomains gate and the SR2-12 absent-claim domain proof key off this, so
+ * take the LAST `@` (RFC 5321: only the final one separates local-part from
+ * domain) and treat "no domain at all" as null, which every caller must fail
+ * closed on.
+ */
+function emailDomainOf(email: string): string | null {
+  const at = email.lastIndexOf('@');
+  if (at <= 0 || at === email.length - 1) {
+    return null;
+  }
+  return email.slice(at + 1).toLowerCase();
+}
 
 // ============================================
 // Helper Functions
@@ -428,16 +496,22 @@ async function validateProviderDefaultRole(
  * rather than open — but it would brick every SSO login, so the wrap is
  * mandatory, not cosmetic.
  *
- * INVARIANT (SR2-10 Fix 2): the line above is a doc comment, not an
+ * INVARIANT (SR2-10 Fix 2): the paragraph above is a doc comment, not an
  * enforcement mechanism — a future refactor could drop the wrap and no unit
  * test would catch it (the db mock makes `withSystemDbAccessContext` a
- * pass-through, so a missing wrap is invisible there). `role_permissions` is
- * FORCE-RLS: a read OUTSIDE a system context 0-rows under `breeze_app`, and
- * `applyCeiling` (services/roleAssignment) treats an empty effective-
- * permission set as "no permissions to exceed" → assignable. So a silently
- * dropped wrap doesn't error, it fails OPEN — greenlighting ANY role. Assert
- * the ambient context is really `'system'` at entry and throw otherwise, so
- * the failure is loud and immediate instead of a silent privilege escalation.
+ * pass-through, so a missing wrap is invisible there). What a dropped wrap
+ * actually does today: `getProviderAxisRole` runs FIRST, `roles` is FORCE-RLS,
+ * so it 0-rows under `breeze_app` with no system context and we return
+ * `default_role_not_on_provider_axis` — i.e. it currently fails CLOSED, and it
+ * bricks EVERY SSO sign-in on the provider rather than escalating privilege.
+ * That is a lucky ordering, not a guarantee: the ceiling itself is the
+ * fail-open shape (`applyCeiling` in services/roleAssignment treats an empty
+ * effective-permission set as "no permissions to exceed" → assignable), so if
+ * the role read is ever reordered, cached, or moved behind a system-context
+ * helper, an un-wrapped `role_permissions` read would 0-row and greenlight ANY
+ * role. Assert the ambient context is really `'system'` at entry and throw
+ * otherwise, so neither failure (the brick or the escalation) can arrive
+ * silently.
  */
 async function revalidateSsoDefaultRole(params: {
   roleId: string;
@@ -876,9 +950,9 @@ ssoRoutes.post(
     // SR2-10: existence + scope + tenant (as before) AND the permission-subset
     // ceiling against the configuring admin.
     if (body.defaultRoleId) {
-      const roleError = await validateProviderDefaultRole(
-        c, auth, body.defaultRoleId, { scope: 'partner', partnerId: auth.partnerId },
-      );
+      const roleError = await withProviderDbContext(auth, () => validateProviderDefaultRole(
+        c, auth, body.defaultRoleId!, { scope: 'partner', partnerId: auth.partnerId! },
+      ));
       if (roleError) {
         return c.json({ error: roleError }, 400);
       }
@@ -893,9 +967,9 @@ ssoRoutes.post(
     // JIT-provisions, so an org admin could delegate a role broader than their
     // own authority to every future SSO sign-in.
     if (body.defaultRoleId) {
-      const roleError = await validateProviderDefaultRole(
-        c, auth, body.defaultRoleId, { scope: 'organization', orgId: orgResult.orgId },
-      );
+      const roleError = await withProviderDbContext(auth, () => validateProviderDefaultRole(
+        c, auth, body.defaultRoleId!, { scope: 'organization', orgId: orgResult.orgId },
+      ));
       if (roleError) {
         return c.json({ error: roleError }, 400);
       }
@@ -915,7 +989,9 @@ ssoRoutes.post(
     }
   }
 
-  // If issuer provided, try to discover endpoints
+  // If issuer provided, discover endpoints. NOTE: this outbound call runs with
+  // NO ambient DB context (see withProviderDbContext) — do not add a db op to
+  // this block or move it inside one.
   if (body.issuer && body.type === 'oidc') {
     try {
       // Self-hosted deployments (IS_HOSTED affirmatively false) may point at an
@@ -929,14 +1005,26 @@ ssoRoutes.post(
       config.jwksUrl = discovery.jwks_uri;
     } catch (error) {
       // Discovery failed OR returned endpoints that failed SSRF/HTTPS validation
-      // (SR2-14). Either way we persist NO endpoints — an unusable provider is
-      // strictly better than one pointing at an attacker-controlled endpoint.
+      // (SR2-14). FAIL LOUDLY — do not create the provider.
+      //
+      // This used to console.warn and then persist the row with all four
+      // endpoint columns NULL, returning 201. That provider can never complete a
+      // login (getOIDCConfig's runtime assertSafeOidcEndpoint throws on the
+      // NULLs / on the `${issuer}/authorize` fallbacks) and there is no API field
+      // to repair the endpoints — they are only ever written by discovery. So a
+      // 201 announced success for a provider that was dead on arrival, with the
+      // reason available nowhere but the API logs. Refusing the write is both
+      // honest and strictly safer: nothing is persisted, nothing to clean up.
       console.warn('OIDC discovery failed or was rejected:', error);
       captureException(error instanceof Error ? error : new Error(String(error)));
+      return c.json({
+        error: `OIDC discovery failed for issuer "${body.issuer}": ${discoveryErrorMessage(error)}`,
+        code: 'oidc_discovery_failed',
+      }, 400);
     }
   }
 
-  const [provider] = await db
+  const [provider] = await withProviderDbContext(auth, () => db
     .insert(ssoProviders)
     .values({
       ...ownerColumns,
@@ -963,7 +1051,7 @@ ssoRoutes.post(
       createdBy: auth.user.id,
       status: 'inactive'
     })
-    .returning();
+    .returning());
 
   if (!provider) {
     return c.json({ error: 'Failed to create provider' }, 500);
@@ -997,17 +1085,20 @@ ssoRoutes.patch(
   const { id: providerId } = c.req.valid('param');
   const body = c.req.valid('json');
 
-  const [existing] = await db
-    .select({
-      id: ssoProviders.id,
-      orgId: ssoProviders.orgId,
-      partnerId: ssoProviders.partnerId,
-      issuer: ssoProviders.issuer,
-      type: ssoProviders.type
-    })
-    .from(ssoProviders)
-    .where(eq(ssoProviders.id, providerId))
-    .limit(1);
+  const existing = await withProviderDbContext(auth, async () => {
+    const [row] = await db
+      .select({
+        id: ssoProviders.id,
+        orgId: ssoProviders.orgId,
+        partnerId: ssoProviders.partnerId,
+        issuer: ssoProviders.issuer,
+        type: ssoProviders.type
+      })
+      .from(ssoProviders)
+      .where(eq(ssoProviders.id, providerId))
+      .limit(1);
+    return row;
+  });
 
   if (!existing) {
     return c.json({ error: 'Provider not found' }, 404);
@@ -1025,17 +1116,32 @@ ssoRoutes.patch(
     if (!scopeContext) {
       return c.json({ error: 'Provider has no owning organization or partner' }, 400);
     }
-    const roleError = await validateProviderDefaultRole(c, auth, body.defaultRoleId, scopeContext);
+    const roleError = await withProviderDbContext(auth, () =>
+      validateProviderDefaultRole(c, auth, body.defaultRoleId!, scopeContext));
     if (roleError) {
       return c.json({ error: roleError }, 400);
     }
   }
 
   // SR2-14: repointing the issuer WITHOUT re-discovery leaves tokenUrl/jwksUrl
-  // aimed at the OLD IdP (or, with a crafted discovery doc, an attacker's).
-  // Re-discover; if that fails or is rejected, CLEAR the endpoints (fail closed)
-  // rather than keep stale ones. The provider is unusable until it is fixed —
-  // which is the correct outcome for a half-repointed IdP.
+  // aimed at the OLD IdP (or, with a crafted discovery doc, an attacker's). So
+  // an issuer change REQUIRES a successful re-discovery.
+  //
+  // This block used to swallow the failure, NULL all four endpoint columns, bump
+  // configVersion (killing every in-flight session) and return 200 with the
+  // updated row. An admin fixing a typo in a WORKING provider's issuer — and
+  // typo'ing it again — would take the org's SSO offline, see a success toast,
+  // and get no signal anywhere as to why nobody can sign in. The endpoints are
+  // only ever written by discovery, so there was no API path back either.
+  //
+  // Fail LOUDLY instead: 400, and persist NOTHING. The old (working) endpoints,
+  // the old issuer and the old configVersion all survive untouched, so a failed
+  // re-discovery is a no-op rather than an outage. Fail-closed is preserved —
+  // the endpoints never end up pointing at an IdP the issuer no longer names,
+  // because the issuer never changes without them.
+  //
+  // NOTE: the discovery call below runs with NO ambient DB context (see
+  // withProviderDbContext) — do not add a db op to this block.
   const issuerChanged = body.issuer !== undefined && body.issuer !== existing.issuer;
   const rediscovered: Partial<typeof ssoProviders.$inferInsert> = {};
   if (issuerChanged && (body.type ?? existing.type) === 'oidc') {
@@ -1050,17 +1156,30 @@ ssoRoutes.patch(
     } catch (error) {
       console.warn(`[sso] re-discovery failed for provider ${providerId} after issuer change:`, error);
       captureException(error instanceof Error ? error : new Error(String(error)));
-      rediscovered.authorizationUrl = null;
-      rediscovered.tokenUrl = null;
-      rediscovered.userInfoUrl = null;
-      rediscovered.jwksUrl = null;
+      writeRouteAudit(c, {
+        orgId: existing.orgId,
+        action: 'sso.provider.update.rejected',
+        resourceType: 'sso_provider',
+        resourceId: existing.id,
+        details: {
+          reason: 'oidc_discovery_failed',
+          attemptedIssuer: body.issuer,
+          partnerId: existing.partnerId,
+        }
+      });
+      return c.json({
+        error: `OIDC discovery failed for issuer "${body.issuer}": ${discoveryErrorMessage(error)}. `
+          + 'No changes were saved — the provider still uses its previous issuer and endpoints.',
+        code: 'oidc_discovery_failed',
+      }, 400);
     }
   }
 
   const updates: Partial<typeof ssoProviders.$inferInsert> = {
     ...body,
-    // SR2-14 (Task 7): must come AFTER ...body so re-discovered endpoints (or
-    // the fail-closed nulls) override any stale endpoint columns in the body.
+    // SR2-14 (Task 7): must come AFTER ...body. `body` cannot carry endpoint
+    // columns (they are not in createProviderSchema), so this is belt-and-braces
+    // against a future schema addition, not a live override.
     ...rediscovered,
     updatedAt: new Date(),
     // SR2-10: re-stamp the JIT principal whenever the delegation is (re-)set.
@@ -1081,11 +1200,11 @@ ssoRoutes.patch(
     updates.clientSecret = encryptSecret(body.clientSecret);
   }
 
-  const [updated] = await db
+  const [updated] = await withProviderDbContext(auth, () => db
     .update(ssoProviders)
     .set(updates)
     .where(eq(ssoProviders.id, providerId))
-    .returning();
+    .returning());
 
   if (!updated) {
     return c.json({ error: 'Provider not found' }, 404);
@@ -1251,11 +1370,17 @@ ssoRoutes.post(
   const auth = c.get('auth') as AuthContext;
   const { id: providerId } = c.req.valid('param');
 
-  const [provider] = await db
-    .select()
-    .from(ssoProviders)
-    .where(eq(ssoProviders.id, providerId))
-    .limit(1);
+  // Short, explicit DB context — this route is in SELF_MANAGED_DB_CONTEXT_ROUTES
+  // (the discovery call below is tenant-controlled and 10s-bounded), so there is
+  // no ambient request transaction to read under.
+  const provider = await withProviderDbContext(auth, async () => {
+    const [row] = await db
+      .select()
+      .from(ssoProviders)
+      .where(eq(ssoProviders.id, providerId))
+      .limit(1);
+    return row;
+  });
 
   if (!provider) {
     return c.json({ error: 'Provider not found' }, 404);
@@ -1274,7 +1399,8 @@ ssoRoutes.post(
   }
 
   try {
-    // Test discovery
+    // Test discovery. Runs with NO ambient DB context (see above) — the only DB
+    // work left in this handler is writeRouteAudit, which opens its own.
     if (provider.issuer) {
       // Self-hosted deployments (IS_HOSTED affirmatively false) may point at an
       // internal IdP on an RFC1918 address; hosted SaaS stays strict.
@@ -2144,11 +2270,13 @@ ssoRoutes.get('/callback', async (c) => {
         : c.redirect('/login?error=sso_email_unverified');
     }
 
-    // Check allowed domains
+    // Check allowed domains. An address whose mailbox domain cannot be parsed is
+    // REJECTED, not waved through: the old `if (emailDomain && …)` skipped the
+    // whole gate for such an address, which is exactly backwards for an allowlist.
     if (provider.allowedDomains) {
       const domains = provider.allowedDomains.split(',').map(d => d.trim().toLowerCase());
-      const emailDomain = attrs.email.split('@')[1]?.toLowerCase();
-      if (emailDomain && !domains.includes(emailDomain)) {
+      const emailDomain = emailDomainOf(attrs.email);
+      if (!emailDomain || !domains.includes(emailDomain)) {
         clearStateCookie();
         return c.redirect('/login?error=domain_not_allowed');
       }
@@ -2281,7 +2409,7 @@ ssoRoutes.get('/callback', async (c) => {
     // restricted to the partner's own staff pool (partnerId + orgId IS NULL)
     // below, so it doesn't consult verified org domains.
     if (!user && provider.orgId) {
-      const assertedEmailDomain = attrs.email.split('@')[1]?.toLowerCase() ?? null;
+      const assertedEmailDomain = emailDomainOf(attrs.email);
 
       // SR2-12: an ABSENT `email_verified` claim is acceptable ONLY when Breeze
       // itself has proven the domain (DNS TXT, sso_verified_domains). This is
@@ -2334,6 +2462,23 @@ ssoRoutes.get('/callback', async (c) => {
         console.warn(
           `[sso/callback] domain verification blocked link/provision: org=${provider.orgId} provider=${provider.id} emailDomain=${assertedEmailDomain ?? 'none'}`
         );
+        // Same structured audit event as every sibling callback rejection
+        // (SR2-11 / SR2-12) — a console line is not an audit trail.
+        writeRouteAudit(c, {
+          orgId: provider.orgId,
+          action: 'sso.callback.rejected',
+          resourceType: 'sso_provider',
+          resourceId: provider.id,
+          resourceName: provider.name,
+          result: 'denied',
+          details: {
+            mode: callbackMode,
+            phase: 'domain_verification',
+            reason: 'sso_domain_unverified',
+            emailDomain: assertedEmailDomain,
+            partnerId: provider.partnerId,
+          },
+        });
         clearStateCookie();
         return c.redirect('/login?error=sso_domain_unverified');
       }

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { eq, and, gt, ne, isNull } from 'drizzle-orm';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { nanoid } from 'nanoid';
-import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext, getCurrentDbAccessContext } from '../db';
 import {
   ssoProviders,
   ssoSessions,
@@ -41,7 +41,7 @@ import { captureException } from '../services/sentry';
 import { decryptForColumn, encryptSecret } from '../services/secretCrypto';
 import { PERMISSIONS, getUserPermissions } from '../services/permissions';
 import {
-  getScopedRole,
+  getProviderAxisRole,
   validateAssignableRole,
   checkRolePermissionCeiling,
   type ScopeContext,
@@ -334,11 +334,13 @@ function buildSsoCallbackUri(): string {
 //      have been months ago, and that admin may since have been demoted or
 //      offboarded.
 //
-// FAIL CLOSED. `checkRoleStructure` is deliberately NOT used as a fallback
-// ceiling anywhere in this file: it returns null (= assignable) for a SYSTEM
-// role carrying `*:*`, so a provider whose default role is the built-in
-// super-admin role would JIT every user at FULL WILDCARD — the exact
-// vulnerability this code exists to close. If a ceiling cannot be established
+// FAIL CLOSED. A caller-independent STRUCTURAL check is deliberately NOT used
+// as a fallback ceiling anywhere in this file (an earlier `checkRoleStructure`
+// helper that did exactly this — return null/"assignable" for a SYSTEM role
+// carrying `*:*` — was deleted (SR2-10 Fix 3) once it had no remaining
+// caller): a provider whose default role is the built-in super-admin role
+// would JIT every user at FULL WILDCARD — the exact vulnerability this code
+// exists to close. If a ceiling cannot be established
 // against a real principal's live permissions, the role is NOT assignable and
 // JIT provisioning is refused.
 
@@ -366,6 +368,18 @@ function providerScopeContext(p: { orgId: string | null; partnerId: string | nul
  * a caller who reaches this route body provably HAS a resolved permission set
  * (requirePermission 403s "No permissions found" otherwise), so there is no
  * principal here for whom a structural-only check would be the only option.
+ *
+ * ROLE RESOLUTION: uses `getProviderAxisRole` (services/roleAssignment), the
+ * SAME strict resolver the JIT re-validation below and the pre-JIT axis check
+ * in the callback use — never `getScopedRole`. `getScopedRole` waves through
+ * ANY `isSystem` role regardless of its org/partner columns (correct for
+ * routes/users.ts's ordinary role assignment, where that's the point of
+ * `isSystem`); seeded system roles carry `org_id`/`partner_id` = NULL
+ * (db/seed.ts), so a role admitted here via that escape hatch could NEVER be
+ * resolved by the JIT axis-equality check — every future SSO sign-in on the
+ * provider would 201 at config time and then die forever at
+ * `invalid_provider_configuration`. Tightening this to `getProviderAxisRole`
+ * closes that gap; it does not loosen anything JIT-side.
  */
 async function validateProviderDefaultRole(
   c: any,
@@ -373,7 +387,7 @@ async function validateProviderDefaultRole(
   defaultRoleId: string,
   scopeContext: ScopeContext,
 ): Promise<string | null> {
-  const role = await getScopedRole(defaultRoleId, scopeContext);
+  const role = await getProviderAxisRole(defaultRoleId, scopeContext);
   if (!role) {
     return scopeContext.scope === 'partner'
       ? 'defaultRoleId must be a partner-scoped role belonging to your partner'
@@ -411,13 +425,41 @@ async function validateProviderDefaultRole(
  * means "role not found" / "configurer has no permissions", i.e. it fails closed
  * rather than open — but it would brick every SSO login, so the wrap is
  * mandatory, not cosmetic.
+ *
+ * INVARIANT (SR2-10 Fix 2): the line above is a doc comment, not an
+ * enforcement mechanism — a future refactor could drop the wrap and no unit
+ * test would catch it (the db mock makes `withSystemDbAccessContext` a
+ * pass-through, so a missing wrap is invisible there). `role_permissions` is
+ * FORCE-RLS: a read OUTSIDE a system context 0-rows under `breeze_app`, and
+ * `applyCeiling` (services/roleAssignment) treats an empty effective-
+ * permission set as "no permissions to exceed" → assignable. So a silently
+ * dropped wrap doesn't error, it fails OPEN — greenlighting ANY role. Assert
+ * the ambient context is really `'system'` at entry and throw otherwise, so
+ * the failure is loud and immediate instead of a silent privilege escalation.
  */
 async function revalidateSsoDefaultRole(params: {
   roleId: string;
   scopeContext: ScopeContext;
   configuredByUserId: string | null;
-}): Promise<{ ok: true; roleId: string } | { ok: false; reason: string }> {
-  const role = await getScopedRole(params.roleId, params.scopeContext);
+}): Promise<
+  | { ok: true; roleId: string; orgPartnerId: string | null }
+  | { ok: false; reason: string }
+> {
+  const ambientContext = getCurrentDbAccessContext();
+  if (ambientContext?.scope !== 'system') {
+    throw new Error(
+      'revalidateSsoDefaultRole must run inside withSystemDbAccessContext — the '
+      + 'permission-subset ceiling reads role_permissions (FORCE RLS); outside a '
+      + 'system context it 0-rows and the ceiling fails OPEN instead of refusing.'
+    );
+  }
+
+  // SR2-10 Fix 1: getProviderAxisRole, not getScopedRole — the strict resolver
+  // shared with config time (validateProviderDefaultRole above) and the
+  // pre-JIT axis check in the callback. See getProviderAxisRole's docstring
+  // (services/roleAssignment) for why getScopedRole's isSystem escape hatch
+  // must never be used on this path.
+  const role = await getProviderAxisRole(params.roleId, params.scopeContext);
   if (!role) {
     return { ok: false, reason: 'default_role_not_on_provider_axis' };
   }
@@ -443,6 +485,10 @@ async function revalidateSsoDefaultRole(params: {
 
   let orgId: string | undefined;
   let partnerId: string | undefined;
+  // Also handed back to the caller as `orgPartnerId` (Fix 4) so the
+  // provisioning block ~40 lines below doesn't re-run the identical
+  // `organizations` select for the same org id.
+  let orgPartnerId: string | null = null;
   if (params.scopeContext.scope === 'organization') {
     orgId = params.scopeContext.orgId;
     const [org] = await db
@@ -451,6 +497,7 @@ async function revalidateSsoDefaultRole(params: {
       .where(eq(organizations.id, orgId))
       .limit(1);
     partnerId = org?.partnerId ?? undefined;
+    orgPartnerId = org?.partnerId ?? null;
   } else {
     partnerId = params.scopeContext.partnerId;
   }
@@ -463,7 +510,7 @@ async function revalidateSsoDefaultRole(params: {
   const ceilingError = await checkRolePermissionCeiling(configurerPermissions, role);
   return ceilingError
     ? { ok: false, reason: 'default_role_exceeds_configurer_permissions' }
-    : { ok: true, roleId: role.id };
+    : { ok: true, roleId: role.id, orgPartnerId };
 }
 
 function getOIDCConfig(provider: typeof ssoProviders.$inferSelect): OIDCConfig {
@@ -1674,22 +1721,18 @@ ssoRoutes.get('/callback', async (c) => {
   // this is config validation ONLY — v1 never APPLIES a default role at login
   // (identity-first, membership-required), so a defaultRoleId can never grant
   // access to a membershipless user.
+  //
+  // SR2-10 Fix 1: uses `getProviderAxisRole` (services/roleAssignment) — the
+  // SAME strict resolver `validateProviderDefaultRole` (config time) and
+  // `revalidateSsoDefaultRole` (below) use, via the shared `providerScopeContext`
+  // axis helper. Keeping this one call site means config time, this pre-check,
+  // and the JIT ceiling can never resolve a defaultRoleId differently again.
   let validatedDefaultRoleId: string | null = null;
   if (provider.defaultRoleId) {
-    const roleCondition = provider.partnerId
-      ? and(
-          eq(roles.id, provider.defaultRoleId),
-          eq(roles.scope, 'partner'),
-          eq(roles.partnerId, provider.partnerId)
-        )
-      : and(
-          eq(roles.id, provider.defaultRoleId),
-          eq(roles.scope, 'organization'),
-          eq(roles.orgId, provider.orgId!)
-        );
-    const [defaultRole] = await withSystemDbAccessContext(async () =>
-      db.select({ id: roles.id }).from(roles).where(roleCondition).limit(1)
-    );
+    const defaultRoleScope = providerScopeContext(provider);
+    const defaultRole = defaultRoleScope
+      ? await withSystemDbAccessContext(() => getProviderAxisRole(provider.defaultRoleId!, defaultRoleScope))
+      : null;
 
     if (!defaultRole) {
       clearStateCookie();
@@ -2008,20 +2051,19 @@ ssoRoutes.get('/callback', async (c) => {
       // SSO-provisioned users are customer-org members: partner_id is
       // inherited from the provider's org's owning partner, org_id is
       // the provider's org.
-      const newUser = await withSystemDbAccessContext(async () => {
-        const [providerOrg] = await db
-          .select({ partnerId: organizations.partnerId })
-          .from(organizations)
-          .where(eq(organizations.id, provisionOrgId))
-          .limit(1);
-        if (!providerOrg) {
-          return null;
-        }
-
+      //
+      // SR2-10 Fix 4: `provisionOrgPartnerId` is the SAME `organizations.partnerId`
+      // for this SAME provisionOrgId that revalidateSsoDefaultRole already fetched
+      // a few lines up — reused here instead of round-tripping the identical select
+      // again. `null` there means the org row didn't exist at that read (the
+      // NOT NULL `organizations.partner_id` column guarantees a real row is never
+      // null), so it fails closed exactly like the old re-query's `!providerOrg` did.
+      const provisionOrgPartnerId: string | null = jitRole.orgPartnerId;
+      const newUser = provisionOrgPartnerId === null ? null : await withSystemDbAccessContext(async () => {
         const [created] = await db
           .insert(users)
           .values({
-            partnerId: providerOrg.partnerId,
+            partnerId: provisionOrgPartnerId,
             orgId: provisionOrgId,
             email: attrs.email.toLowerCase(),
             name: attrs.name,

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -39,7 +39,13 @@ import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from 
 import { getTrustedClientIp } from '../services/clientIp';
 import { captureException } from '../services/sentry';
 import { decryptForColumn, encryptSecret } from '../services/secretCrypto';
-import { PERMISSIONS } from '../services/permissions';
+import { PERMISSIONS, getUserPermissions } from '../services/permissions';
+import {
+  getScopedRole,
+  validateAssignableRole,
+  checkRolePermissionCeiling,
+  type ScopeContext,
+} from '../services/roleAssignment';
 import { selfHostAllowsPrivateNetwork } from '../config/env';
 import { envFlag } from '../utils/envFlag';
 import { setRefreshTokenCookie, getCookieValue, auditLogin } from './auth/helpers';
@@ -308,6 +314,158 @@ function buildSsoCallbackUri(): string {
   return `${getCanonicalPublicBaseUrl()}/api/v1/sso/callback`;
 }
 
+// ============================================
+// SR2-10 — SSO default-role delegation ceiling
+// ============================================
+//
+// An SSO provider's `defaultRoleId` is a STANDING DELEGATION: every future
+// JIT-provisioned user gets that role. Before this, nobody checked that the
+// admin who configured it was entitled to grant it — so an admin who could edit
+// an SSO provider could mint users more privileged than themselves. The same
+// permission-subset ceiling the user-invite path enforces (routes/users.ts, via
+// services/roleAssignment) now applies HERE, twice:
+//
+//   1. CONFIG TIME  — against the LIVE, authenticated caller (both axes: their
+//      permission set is whatever authMiddleware/requirePermission resolved for
+//      their real membership, org OR partner).
+//   2. JIT TIME     — against the LIVE permissions of the admin who last SET the
+//      role (`default_role_configured_by`, falling back to `created_by`). A
+//      delegation must not outlive its configurer's authority: config time may
+//      have been months ago, and that admin may since have been demoted or
+//      offboarded.
+//
+// FAIL CLOSED. `checkRoleStructure` is deliberately NOT used as a fallback
+// ceiling anywhere in this file: it returns null (= assignable) for a SYSTEM
+// role carrying `*:*`, so a provider whose default role is the built-in
+// super-admin role would JIT every user at FULL WILDCARD — the exact
+// vulnerability this code exists to close. If a ceiling cannot be established
+// against a real principal's live permissions, the role is NOT assignable and
+// JIT provisioning is refused.
+
+/**
+ * The ScopeContext a provider's defaultRoleId must satisfy — the PROVIDER's own
+ * axis, never the caller's. (a) These routes admit system scope, for which
+ * getScopeContext(auth) throws 403; (b) the role must belong to the tenant the
+ * provider provisions INTO, which is the provider's axis by definition.
+ */
+function providerScopeContext(p: { orgId: string | null; partnerId: string | null }): ScopeContext | null {
+  if (p.partnerId) return { scope: 'partner', partnerId: p.partnerId };
+  if (p.orgId) return { scope: 'organization', orgId: p.orgId };
+  return null;
+}
+
+/**
+ * CONFIG-TIME gate, shared by POST /providers and PATCH /providers/:id.
+ * Returns an error message (caller returns 400) or null.
+ *
+ * The ceiling principal is the authenticated caller. `validateAssignableRole`
+ * resolves them from `c.get('permissions')` — the set requirePermission already
+ * resolved on whichever axis they actually hold (org_users OR partner_users), so
+ * an MSP partner admin with no organization_users row is measured against their
+ * real partner permissions, not a null set. Every scope goes through the ceiling:
+ * a caller who reaches this route body provably HAS a resolved permission set
+ * (requirePermission 403s "No permissions found" otherwise), so there is no
+ * principal here for whom a structural-only check would be the only option.
+ */
+async function validateProviderDefaultRole(
+  c: any,
+  auth: AuthContext,
+  defaultRoleId: string,
+  scopeContext: ScopeContext,
+): Promise<string | null> {
+  const role = await getScopedRole(defaultRoleId, scopeContext);
+  if (!role) {
+    return scopeContext.scope === 'partner'
+      ? 'defaultRoleId must be a partner-scoped role belonging to your partner'
+      : 'defaultRoleId must be an organization-scoped role belonging to this organization';
+  }
+  return validateAssignableRole(c, auth, role);
+}
+
+/**
+ * JIT-TIME gate. Runs immediately before the SSO callback provisions a NEW user
+ * with the provider's defaultRoleId. Re-checks, against LIVE state:
+ *   (a) the role still exists on the provider's axis;
+ *   (b) the configurer is still a real, ACTIVE account; and
+ *   (c) the role's effective permissions are still within that configurer's
+ *       live permission ceiling.
+ *
+ * PRINCIPAL PRECEDENCE: `default_role_configured_by` (stamped by every write
+ * that SETS defaultRoleId) → `created_by` (rows predating that column) → FAIL
+ * CLOSED. Neither resolving is NOT a licence to fall back to a structural check
+ * (see the wildcard trap above); the sign-in is refused and the repair is to
+ * re-save the default role as a current admin, which re-stamps the column.
+ *
+ * BOTH AXES are handed to getUserPermissions. Passing only { orgId } would run
+ * only resolveOrgAxis (services/permissions.ts), which needs an
+ * organization_users row — and an MSP PARTNER ADMIN configuring SSO for a
+ * customer org has none (they act via partner_users + orgAccess). That would
+ * return null → fail closed → every JIT sign-in on that provider would fail
+ * forever, on the most normal MSP topology there is. Supplying the provider
+ * org's owning partner as well lets getUserPermissions' own org→partner
+ * fall-through resolve them correctly.
+ *
+ * DB CONTEXT: MUST be called inside withSystemDbAccessContext. /sso/callback is
+ * unauthenticated — it has no request context at all, so a bare read here is
+ * denied by forced RLS and silently returns 0 rows. On this path a 0-row read
+ * means "role not found" / "configurer has no permissions", i.e. it fails closed
+ * rather than open — but it would brick every SSO login, so the wrap is
+ * mandatory, not cosmetic.
+ */
+async function revalidateSsoDefaultRole(params: {
+  roleId: string;
+  scopeContext: ScopeContext;
+  configuredByUserId: string | null;
+}): Promise<{ ok: true; roleId: string } | { ok: false; reason: string }> {
+  const role = await getScopedRole(params.roleId, params.scopeContext);
+  if (!role) {
+    return { ok: false, reason: 'default_role_not_on_provider_axis' };
+  }
+
+  // No resolvable principal → no ceiling → refuse. (Never a structural check.)
+  if (!params.configuredByUserId) {
+    return { ok: false, reason: 'default_role_configurer_unknown' };
+  }
+
+  const [configurer] = await db
+    .select({ id: users.id, status: users.status })
+    .from(users)
+    .where(eq(users.id, params.configuredByUserId))
+    .limit(1);
+
+  // Deleted or deactivated configurer: their authority is gone, so the standing
+  // delegation goes with it. getUserPermissions does NOT look at users.status,
+  // so without this an offboarded-but-still-role-bearing admin would keep
+  // minting privileged users indefinitely.
+  if (!configurer || configurer.status !== 'active') {
+    return { ok: false, reason: 'default_role_configurer_inactive' };
+  }
+
+  let orgId: string | undefined;
+  let partnerId: string | undefined;
+  if (params.scopeContext.scope === 'organization') {
+    orgId = params.scopeContext.orgId;
+    const [org] = await db
+      .select({ partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+    partnerId = org?.partnerId ?? undefined;
+  } else {
+    partnerId = params.scopeContext.partnerId;
+  }
+
+  const configurerPermissions = await getUserPermissions(configurer.id, { orgId, partnerId });
+  if (!configurerPermissions) {
+    return { ok: false, reason: 'default_role_configurer_no_permissions' };
+  }
+
+  const ceilingError = await checkRolePermissionCeiling(configurerPermissions, role);
+  return ceilingError
+    ? { ok: false, reason: 'default_role_exceeds_configurer_permissions' }
+    : { ok: true, roleId: role.id };
+}
+
 function getOIDCConfig(provider: typeof ssoProviders.$inferSelect): OIDCConfig {
   const decryptedClientSecret = decryptForColumn('sso_providers', 'client_secret', provider.clientSecret);
 
@@ -509,18 +667,14 @@ ssoRoutes.post(
     if (!canManagePartnerWidePolicies(auth)) {
       return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
+    // SR2-10: existence + scope + tenant (as before) AND the permission-subset
+    // ceiling against the configuring admin.
     if (body.defaultRoleId) {
-      const [role] = await db
-        .select({ id: roles.id })
-        .from(roles)
-        .where(and(
-          eq(roles.id, body.defaultRoleId),
-          eq(roles.scope, 'partner'),
-          eq(roles.partnerId, auth.partnerId)
-        ))
-        .limit(1);
-      if (!role) {
-        return c.json({ error: 'defaultRoleId must be a partner-scoped role belonging to your partner' }, 400);
+      const roleError = await validateProviderDefaultRole(
+        c, auth, body.defaultRoleId, { scope: 'partner', partnerId: auth.partnerId },
+      );
+      if (roleError) {
+        return c.json({ error: roleError }, 400);
       }
     }
     ownerColumns = { orgId: null, partnerId: auth.partnerId };
@@ -528,6 +682,17 @@ ssoRoutes.post(
     const orgResult = resolveOrgIdForProviderRoute(auth, body.orgId);
     if ('error' in orgResult) {
       return c.json({ error: orgResult.error }, orgResult.status);
+    }
+    // SR2-10: the org axis validated NOTHING here — and it is the ONLY axis that
+    // JIT-provisions, so an org admin could delegate a role broader than their
+    // own authority to every future SSO sign-in.
+    if (body.defaultRoleId) {
+      const roleError = await validateProviderDefaultRole(
+        c, auth, body.defaultRoleId, { scope: 'organization', orgId: orgResult.orgId },
+      );
+      if (roleError) {
+        return c.json({ error: roleError }, 400);
+      }
     }
     ownerColumns = { orgId: orgResult.orgId, partnerId: null };
   }
@@ -579,6 +744,10 @@ ssoRoutes.post(
       jwksUrl: config.jwksUrl,
       autoProvision: body.autoProvision ?? true,
       defaultRoleId: body.defaultRoleId,
+      // SR2-10: the admin whose LIVE permission ceiling the callback re-checks
+      // this delegation against before JIT. Stamped only when a role is actually
+      // delegated. Never client-settable (not in createProviderSchema).
+      defaultRoleConfiguredBy: body.defaultRoleId ? auth.user.id : null,
       allowedDomains: body.allowedDomains,
       enforceSSO: body.enforceSSO ?? false,
       trustsIdpMfa: body.trustsIdpMfa ?? false,
@@ -633,24 +802,31 @@ ssoRoutes.patch(
     return c.json({ error: 'Access denied' }, 403);
   }
 
-  if (existing.partnerId && body.defaultRoleId) {
-    const [role] = await db
-      .select({ id: roles.id })
-      .from(roles)
-      .where(and(
-        eq(roles.id, body.defaultRoleId),
-        eq(roles.scope, 'partner'),
-        eq(roles.partnerId, existing.partnerId)
-      ))
-      .limit(1);
-    if (!role) {
-      return c.json({ error: 'defaultRoleId must be a partner-scoped role belonging to your partner' }, 400);
+  // SR2-10: axis-aware. This was partner-only (`existing.partnerId && ...`), so
+  // a PATCH could set ANY defaultRoleId on an org-axis provider — the axis that
+  // actually JIT-provisions — with no existence, tenant, or ceiling check.
+  if (body.defaultRoleId) {
+    const scopeContext = providerScopeContext(existing);
+    if (!scopeContext) {
+      return c.json({ error: 'Provider has no owning organization or partner' }, 400);
+    }
+    const roleError = await validateProviderDefaultRole(c, auth, body.defaultRoleId, scopeContext);
+    if (roleError) {
+      return c.json({ error: roleError }, 400);
     }
   }
 
   const updates: Partial<typeof ssoProviders.$inferInsert> = {
     ...body,
-    updatedAt: new Date()
+    updatedAt: new Date(),
+    // SR2-10: re-stamp the JIT principal whenever the delegation is (re-)set.
+    // This is the repair path when the previous configurer offboards: re-saving
+    // the default role as a current admin re-points the ceiling at a live
+    // account. Untouched by a PATCH that doesn't carry defaultRoleId, so an
+    // unrelated edit (rename, secret rotation) can never clobber it to null.
+    ...(body.defaultRoleId !== undefined
+      ? { defaultRoleConfiguredBy: body.defaultRoleId ? auth.user.id : null }
+      : {}),
   };
 
   if (body.clientSecret !== undefined) {
@@ -1777,6 +1953,49 @@ ssoRoutes.get('/callback', async (c) => {
       if (!validatedDefaultRoleId) {
         clearStateCookie();
         return c.redirect('/login?error=default_role_required');
+      }
+
+      // SR2-10: re-validate the standing delegation against LIVE state at the
+      // moment of provisioning. The config-time ceiling ran when the provider was
+      // saved — possibly months ago, by an admin who has since been demoted or
+      // offboarded. Fails CLOSED: no resolvable configurer ⇒ no ceiling ⇒ no
+      // provisioning (a structural check would wave a SYSTEM wildcard role
+      // straight through — see revalidateSsoDefaultRole).
+      //
+      // System DB context: the callback is unauthenticated and has no request
+      // context, so these reads would otherwise be denied by forced RLS.
+      const jitScope = providerScopeContext(provider);
+      const jitRole = jitScope
+        ? await withSystemDbAccessContext(() =>
+            revalidateSsoDefaultRole({
+              roleId: validatedDefaultRoleId!,
+              scopeContext: jitScope,
+              // The admin who last SET the delegated role; fall back to the
+              // original creator for rows predating that column.
+              configuredByUserId: provider.defaultRoleConfiguredBy ?? provider.createdBy ?? null,
+            }),
+          )
+        : ({ ok: false, reason: 'provider_axis_missing' } as const);
+
+      if (!jitRole.ok) {
+        writeRouteAudit(c, {
+          orgId: provider.orgId,
+          action: 'sso.callback.rejected',
+          resourceType: 'sso_provider',
+          resourceId: provider.id,
+          resourceName: provider.name,
+          result: 'denied',
+          details: {
+            mode: 'login',
+            phase: 'jit_default_role',
+            reason: jitRole.reason,
+            roleId: validatedDefaultRoleId,
+            partnerId: provider.partnerId,
+            remediation: 're-save the provider defaultRoleId as a current admin entitled to grant it',
+          },
+        });
+        clearStateCookie();
+        return c.redirect('/login?error=invalid_provider_configuration');
       }
 
       // Reachable on the ORG axis ONLY — the partner axis returned

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -33,7 +33,7 @@ import {
   PROVIDER_PRESETS,
   type OIDCConfig
 } from '../services/sso';
-import { createTokenPair, createSession, mintRefreshTokenFamily, bindRefreshJtiToFamily, getUserEpochs, rateLimiter, getRedis } from '../services';
+import { createTokenPair, createSession, mintRefreshTokenFamily, bindRefreshJtiToFamily, getUserEpochs, getRefreshFamily, rateLimiter, getRedis } from '../services';
 import { writeRouteAudit } from '../services/auditEvents';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
 import { getTrustedClientIp } from '../services/clientIp';
@@ -553,6 +553,103 @@ function checkProviderGeneration(
     return { ok: false, reason: 'provider_version_mismatch' };
   }
   return { ok: true };
+}
+
+type LinkRejectReason =
+  | 'link_binding_missing'
+  | 'link_user_gone'
+  | 'link_user_inactive'
+  | 'link_epochs_unavailable'
+  | 'link_auth_epoch_mismatch'
+  | 'link_mfa_epoch_mismatch'
+  | 'link_family_missing'
+  | 'link_family_revoked'
+  | 'link_family_expired'
+  | 'link_axis_membership_lost';
+
+/**
+ * SR2-11b: re-check a pending LINK session against LIVE state before it is
+ * allowed to bind an external identity to a Breeze account.
+ *
+ * The session snapshotted {authEpoch, mfaEpoch, sid} at /link/start. Any of the
+ * following since then must kill it:
+ *   - the user was suspended/deleted            -> status / user_gone
+ *   - password reset, email change, membership
+ *     change, platform-privilege change         -> auth_epoch bump
+ *   - any MFA factor change                     -> mfa_epoch bump
+ *   - logout, or a global session revocation    -> the bound refresh family is
+ *                                                  revoked (or gone/expired)
+ *   - removal from the provider's org/partner   -> axis membership lost
+ *
+ * A pre-deploy row (any binding column NULL) is a REJECT, not a pass.
+ *
+ * MUST be called inside withSystemDbAccessContext (/sso/callback is
+ * unauthenticated; getRefreshFamily establishes its own system context).
+ */
+async function validateLinkBinding(
+  session: typeof ssoSessions.$inferSelect,
+  provider: typeof ssoProviders.$inferSelect,
+): Promise<{ ok: true; user: typeof users.$inferSelect } | { ok: false; reason: LinkRejectReason }> {
+  if (
+    session.initiatingAuthEpoch == null ||
+    session.initiatingMfaEpoch == null ||
+    session.initiatingSessionId == null
+  ) {
+    return { ok: false, reason: 'link_binding_missing' };
+  }
+
+  const [linkingUser] = await db
+    .select()
+    .from(users)
+    .where(eq(users.id, session.linkUserId!))
+    .limit(1);
+  if (!linkingUser) return { ok: false, reason: 'link_user_gone' };
+  if (linkingUser.status !== 'active') return { ok: false, reason: 'link_user_inactive' };
+
+  const liveEpochs = await getUserEpochs(linkingUser.id);
+  if (!liveEpochs) return { ok: false, reason: 'link_epochs_unavailable' };
+  if (liveEpochs.authEpoch !== session.initiatingAuthEpoch) {
+    return { ok: false, reason: 'link_auth_epoch_mismatch' };
+  }
+  if (liveEpochs.mfaEpoch !== session.initiatingMfaEpoch) {
+    return { ok: false, reason: 'link_mfa_epoch_mismatch' };
+  }
+
+  const family = await getRefreshFamily(session.initiatingSessionId);
+  if (!family) return { ok: false, reason: 'link_family_missing' };
+  if (family.revokedAt) return { ok: false, reason: 'link_family_revoked' };
+  if (family.absoluteExpiresAt.getTime() <= Date.now()) {
+    return { ok: false, reason: 'link_family_expired' };
+  }
+
+  // Axis membership must STILL be held (the /link/start pool check is a
+  // snapshot, not a guarantee).
+  if (provider.orgId) {
+    const [membership] = await db
+      .select({ userId: organizationUsers.userId })
+      .from(organizationUsers)
+      .where(and(
+        eq(organizationUsers.userId, linkingUser.id),
+        eq(organizationUsers.orgId, provider.orgId),
+      ))
+      .limit(1);
+    if (!membership) return { ok: false, reason: 'link_axis_membership_lost' };
+  } else if (provider.partnerId) {
+    if (linkingUser.orgId != null) return { ok: false, reason: 'link_axis_membership_lost' };
+    const [membership] = await db
+      .select({ userId: partnerUsers.userId })
+      .from(partnerUsers)
+      .where(and(
+        eq(partnerUsers.userId, linkingUser.id),
+        eq(partnerUsers.partnerId, provider.partnerId),
+      ))
+      .limit(1);
+    if (!membership) return { ok: false, reason: 'link_axis_membership_lost' };
+  } else {
+    return { ok: false, reason: 'link_axis_membership_lost' };
+  }
+
+  return { ok: true, user: linkingUser };
 }
 
 function getOIDCConfig(provider: typeof ssoProviders.$inferSelect): OIDCConfig {
@@ -1416,6 +1513,21 @@ ssoRoutes.post(
     const state = generateState();
     const nonce = generateNonce();
 
+    // SR2-11b: bind the pending link to the CURRENT security generation of the
+    // initiating session. Mirrors PR 2's enforceExistingFactorStepUp
+    // (routes/auth/helpers.ts:252-281): capture {authEpoch, mfaEpoch, sid} at
+    // mint, re-check against the LIVE row at consume. This is what makes a
+    // logout / password reset / MFA reset / suspension / global revocation
+    // between start and callback invalidate the pending link.
+    //
+    // Fail closed: without epochs or a sid there is nothing to bind to, so we
+    // refuse to create the session rather than create an unbindable one.
+    const initiatorEpochs = await getUserEpochs(auth.user.id);
+    const initiatingSid = auth.token?.sid;
+    if (!initiatorEpochs || !initiatingSid) {
+      return c.json({ error: 'Service temporarily unavailable' }, 503);
+    }
+
     // sso_sessions is system-scope-only under RLS (2026-07-16 migration): this
     // insert ran on the bare pool and only worked because the table had no
     // policies. The row is a pre-auth transaction record, not tenant data — it
@@ -1433,6 +1545,9 @@ ssoRoutes.post(
           linkUserId: auth.user.id,
           // SR2-11: snapshot the generation this session was created under.
           providerVersion: provider.configVersion,
+          initiatingAuthEpoch: initiatorEpochs.authEpoch,
+          initiatingMfaEpoch: initiatorEpochs.mfaEpoch,
+          initiatingSessionId: initiatingSid,
           expiresAt: new Date(Date.now() + 10 * 60 * 1000)
         })
       )
@@ -1932,12 +2047,12 @@ ssoRoutes.get('/callback', async (c) => {
     // NEVER creates users, and NEVER touches login's identity resolution.
     if (session.linkUserId) {
       const outcome = await withSystemDbAccessContext(async () => {
-        const [linkingUser] = await db
-          .select()
-          .from(users)
-          .where(eq(users.id, session.linkUserId!))
-          .limit(1);
-        if (!linkingUser) return { error: 'user_gone' as const };
+        // SR2-11b: live re-check of the binding captured at /link/start.
+        const binding = await validateLinkBinding(session, provider);
+        if (!binding.ok) {
+          return { error: 'session_invalid' as const, auditReason: binding.reason };
+        }
+        const linkingUser = binding.user;
 
         // The verified assertion must be for the SAME person: the asserted
         // email must equal the linking user's email. Without this a user could
@@ -1980,6 +2095,24 @@ ssoRoutes.get('/callback', async (c) => {
 
       clearStateCookie();
       if ('error' in outcome) {
+        writeRouteAudit(c, {
+          orgId: provider.orgId,
+          action: 'sso.identity.link_rejected',
+          resourceType: 'sso_provider',
+          resourceId: provider.id,
+          resourceName: provider.name,
+          result: 'denied',
+          details: {
+            // The PUBLIC code is deliberately coarse (session_invalid). The
+            // precise reason lives here only — distinguishing "suspended" from
+            // "session revoked" from "removed from org" in the URL would leak
+            // account state to whoever holds the browser.
+            reason: (outcome as { auditReason?: string }).auditReason ?? outcome.error,
+            publicCode: outcome.error,
+            partnerId: provider.partnerId,
+            userId: session.linkUserId,
+          },
+        });
         return c.redirect(`/settings/profile?ssoLinkError=${outcome.error}`);
       }
       writeRouteAudit(c, {

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -712,17 +712,33 @@ ssoRoutes.delete(
   // tenant-scoped context, BOTH of these silently delete 0 rows — and neither FK
   // cascades, so the sso_providers delete below then dies with FK violation
   // 23503. Provider cleanup is a legitimate system operation: run it as one.
-  await runOutsideDbContext(() =>
+  //
+  // All three deletes — sessions, identities, and the provider row itself —
+  // must run inside this SAME system-context invocation (not just the same
+  // request handler). This route's handler already runs inside one request
+  // transaction (see middleware/auth.ts), but that transaction lives on a
+  // different pooled connection than a nested withSystemDbAccessContext call.
+  // If the provider delete were left outside this wrap (in the request
+  // transaction) while the cleanup deletes ran here, a rollback of the
+  // request transaction (e.g. the `!deleted` 404 below, a deadlock, or a
+  // statement timeout) would leave the already-committed cleanup deletes
+  // unrecoverable while the provider row survived — orphaning every user's
+  // SSO identity link for a provider that never actually got deleted. Doing
+  // the provider delete here also means it no longer gets RLS as a second
+  // line of defense — that's acceptable because the row's visibility AND the
+  // caller's authority over it were already proven under RLS above (the
+  // select + canWriteProviderRow check).
+  const deleted = await runOutsideDbContext(() =>
     withSystemDbAccessContext(async () => {
       await db.delete(ssoSessions).where(eq(ssoSessions.providerId, providerId));
       await db.delete(userSsoIdentities).where(eq(userSsoIdentities.providerId, providerId));
+      const [row] = await db
+        .delete(ssoProviders)
+        .where(eq(ssoProviders.id, providerId))
+        .returning();
+      return row;
     })
   );
-
-  const [deleted] = await db
-    .delete(ssoProviders)
-    .where(eq(ssoProviders.id, providerId))
-    .returning();
 
   if (!deleted) {
     return c.json({ error: 'Provider not found' }, 404);

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -30,6 +30,7 @@ import {
   idpAssertedMfa,
   mapUserAttributes,
   discoverOIDCConfig,
+  assertSafeOidcEndpoint,
   PROVIDER_PRESETS,
   type OIDCConfig,
   type EmailVerifiedClaim
@@ -660,7 +661,10 @@ function getOIDCConfig(provider: typeof ssoProviders.$inferSelect): OIDCConfig {
     throw new Error('Provider is not fully configured');
   }
 
-  return {
+  // Resolved ONCE here, from deployment config — never from a request value.
+  const allowPrivateNetwork = selfHostAllowsPrivateNetwork();
+
+  const config: OIDCConfig = {
     issuer: provider.issuer,
     clientId: provider.clientId,
     clientSecret: decryptedClientSecret,
@@ -668,8 +672,23 @@ function getOIDCConfig(provider: typeof ssoProviders.$inferSelect): OIDCConfig {
     tokenUrl: provider.tokenUrl || `${provider.issuer}/oauth/token`,
     userInfoUrl: provider.userInfoUrl || `${provider.issuer}/userinfo`,
     jwksUrl: provider.jwksUrl || undefined,
-    scopes: provider.scopes || 'openid profile email'
+    scopes: provider.scopes || 'openid profile email',
+    allowPrivateNetwork
   };
+
+  // SR2-14: RE-VALIDATE persisted endpoints at runtime. They were trusted
+  // blindly: discovery wrote them verbatim, and PATCH can change `issuer`
+  // WITHOUT re-running discovery, so tokenUrl/jwksUrl could still point at the
+  // previous (or an attacker's) IdP. The `${issuer}/…` string-concat fallbacks
+  // above are validated by the same gate.
+  assertSafeOidcEndpoint('authorization_endpoint', config.authorizationUrl, allowPrivateNetwork);
+  assertSafeOidcEndpoint('token_endpoint', config.tokenUrl, allowPrivateNetwork);
+  assertSafeOidcEndpoint('userinfo_endpoint', config.userInfoUrl, allowPrivateNetwork);
+  if (config.jwksUrl) {
+    assertSafeOidcEndpoint('jwks_uri', config.jwksUrl, allowPrivateNetwork);
+  }
+
+  return config;
 }
 
 function getClientIP(c: any): string {
@@ -909,8 +928,11 @@ ssoRoutes.post(
       config.userInfoUrl = discovery.userinfo_endpoint;
       config.jwksUrl = discovery.jwks_uri;
     } catch (error) {
-      // Discovery failed, user will need to provide URLs manually
-      console.warn('OIDC discovery failed:', error);
+      // Discovery failed OR returned endpoints that failed SSRF/HTTPS validation
+      // (SR2-14). Either way we persist NO endpoints — an unusable provider is
+      // strictly better than one pointing at an attacker-controlled endpoint.
+      console.warn('OIDC discovery failed or was rejected:', error);
+      captureException(error instanceof Error ? error : new Error(String(error)));
     }
   }
 
@@ -976,7 +998,13 @@ ssoRoutes.patch(
   const body = c.req.valid('json');
 
   const [existing] = await db
-    .select({ id: ssoProviders.id, orgId: ssoProviders.orgId, partnerId: ssoProviders.partnerId })
+    .select({
+      id: ssoProviders.id,
+      orgId: ssoProviders.orgId,
+      partnerId: ssoProviders.partnerId,
+      issuer: ssoProviders.issuer,
+      type: ssoProviders.type
+    })
     .from(ssoProviders)
     .where(eq(ssoProviders.id, providerId))
     .limit(1);
@@ -1003,8 +1031,37 @@ ssoRoutes.patch(
     }
   }
 
+  // SR2-14: repointing the issuer WITHOUT re-discovery leaves tokenUrl/jwksUrl
+  // aimed at the OLD IdP (or, with a crafted discovery doc, an attacker's).
+  // Re-discover; if that fails or is rejected, CLEAR the endpoints (fail closed)
+  // rather than keep stale ones. The provider is unusable until it is fixed —
+  // which is the correct outcome for a half-repointed IdP.
+  const issuerChanged = body.issuer !== undefined && body.issuer !== existing.issuer;
+  const rediscovered: Partial<typeof ssoProviders.$inferInsert> = {};
+  if (issuerChanged && (body.type ?? existing.type) === 'oidc') {
+    try {
+      const discovery = await discoverOIDCConfig(body.issuer!, {
+        allowPrivateNetwork: selfHostAllowsPrivateNetwork()
+      });
+      rediscovered.authorizationUrl = discovery.authorization_endpoint;
+      rediscovered.tokenUrl = discovery.token_endpoint;
+      rediscovered.userInfoUrl = discovery.userinfo_endpoint;
+      rediscovered.jwksUrl = discovery.jwks_uri;
+    } catch (error) {
+      console.warn(`[sso] re-discovery failed for provider ${providerId} after issuer change:`, error);
+      captureException(error instanceof Error ? error : new Error(String(error)));
+      rediscovered.authorizationUrl = null;
+      rediscovered.tokenUrl = null;
+      rediscovered.userInfoUrl = null;
+      rediscovered.jwksUrl = null;
+    }
+  }
+
   const updates: Partial<typeof ssoProviders.$inferInsert> = {
     ...body,
+    // SR2-14 (Task 7): must come AFTER ...body so re-discovered endpoints (or
+    // the fail-closed nulls) override any stale endpoint columns in the body.
+    ...rediscovered,
     updatedAt: new Date(),
     // SR2-10: re-stamp the JIT principal whenever the delegation is (re-)set.
     // This is the repair path when the previous configurer offboards: re-saving
@@ -1509,7 +1566,13 @@ ssoRoutes.post(
       return c.json({ error: 'Only OIDC linking is currently supported' }, 400);
     }
 
-    const config = getOIDCConfig(provider);
+    let config: OIDCConfig;
+    try {
+      config = getOIDCConfig(provider);
+    } catch (err) {
+      console.warn(`[sso] provider ${provider.id} has an invalid configuration:`, err);
+      return c.json({ error: 'SSO provider configuration is invalid' }, 400);
+    }
     const pkce = generatePKCEChallenge();
     const state = generateState();
     const nonce = generateNonce();
@@ -1664,7 +1727,13 @@ ssoRoutes.get('/login/partner/:partnerId', zValidator('param', partnerIdParamSch
     return c.json({ error: 'Only OIDC login is currently supported' }, 400);
   }
 
-  const config = getOIDCConfig(provider);
+  let config: OIDCConfig;
+  try {
+    config = getOIDCConfig(provider);
+  } catch (err) {
+    console.warn(`[sso] provider ${provider.id} has an invalid configuration:`, err);
+    return c.json({ error: 'SSO provider configuration is invalid' }, 400);
+  }
   const pkce = generatePKCEChallenge();
   const state = generateState();
   const nonce = generateNonce();
@@ -1758,7 +1827,13 @@ ssoRoutes.get('/login/:orgId', zValidator('param', orgIdParamSchema), async (c) 
     return c.json({ error: 'Only OIDC login is currently supported' }, 400);
   }
 
-  const config = getOIDCConfig(provider);
+  let config: OIDCConfig;
+  try {
+    config = getOIDCConfig(provider);
+  } catch (err) {
+    console.warn(`[sso] provider ${provider.id} has an invalid configuration:`, err);
+    return c.json({ error: 'SSO provider configuration is invalid' }, 400);
+  }
 
   // Generate PKCE challenge
   const pkce = generatePKCEChallenge();

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { eq, and, gt, ne, isNull } from 'drizzle-orm';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { nanoid } from 'nanoid';
-import { db, withSystemDbAccessContext } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import {
   ssoProviders,
   ssoSessions,
@@ -707,9 +707,17 @@ ssoRoutes.delete(
     return c.json({ error: 'Access denied' }, 403);
   }
 
-  // Delete related records first
-  await db.delete(ssoSessions).where(eq(ssoSessions.providerId, providerId));
-  await db.delete(userSsoIdentities).where(eq(userSsoIdentities.providerId, providerId));
+  // sso_sessions is system-scope-only and user_sso_identities is user-id-scoped
+  // (breeze_current_user_id()) under RLS. On the bare pool, from an admin's
+  // tenant-scoped context, BOTH of these silently delete 0 rows — and neither FK
+  // cascades, so the sso_providers delete below then dies with FK violation
+  // 23503. Provider cleanup is a legitimate system operation: run it as one.
+  await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      await db.delete(ssoSessions).where(eq(ssoSessions.providerId, providerId));
+      await db.delete(userSsoIdentities).where(eq(userSsoIdentities.providerId, providerId));
+    })
+  );
 
   const [deleted] = await db
     .delete(ssoProviders)
@@ -1116,15 +1124,25 @@ ssoRoutes.post(
     const state = generateState();
     const nonce = generateNonce();
 
-    await db.insert(ssoSessions).values({
-      providerId: provider.id,
-      state,
-      nonce,
-      codeVerifier: pkce.codeVerifier,
-      redirectUrl: '/settings/profile',
-      linkUserId: auth.user.id,
-      expiresAt: new Date(Date.now() + 10 * 60 * 1000)
-    });
+    // sso_sessions is system-scope-only under RLS (2026-07-16 migration): this
+    // insert ran on the bare pool and only worked because the table had no
+    // policies. The row is a pre-auth transaction record, not tenant data — it
+    // is consumed by the unauthenticated callback, which also runs in system
+    // context. runOutsideDbContext first: we are inside the authenticated
+    // request's org/partner-scoped context here.
+    await runOutsideDbContext(() =>
+      withSystemDbAccessContext(async () =>
+        db.insert(ssoSessions).values({
+          providerId: provider.id,
+          state,
+          nonce,
+          codeVerifier: pkce.codeVerifier,
+          redirectUrl: '/settings/profile',
+          linkUserId: auth.user.id,
+          expiresAt: new Date(Date.now() + 10 * 60 * 1000)
+        })
+      )
+    );
 
     const authUrl = buildAuthorizationUrl({
       config,

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -16,7 +16,7 @@ import {
   partnerUsers,
   roles
 } from '../db/schema';
-import { createPendingDomain, verifyDomain, recordNameFor, recordValueFor, isSsoProvisioningBlocked } from '../services/ssoDomainVerification';
+import { createPendingDomain, verifyDomain, recordNameFor, recordValueFor, isSsoProvisioningBlocked, isDomainVerifiedForOrg } from '../services/ssoDomainVerification';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import {
   generateState,
@@ -26,12 +26,13 @@ import {
   exchangeCodeForTokens,
   getUserInfo,
   verifyIdTokenSignature,
-  assertEmailVerified,
+  readEmailVerifiedClaim,
   idpAssertedMfa,
   mapUserAttributes,
   discoverOIDCConfig,
   PROVIDER_PRESETS,
-  type OIDCConfig
+  type OIDCConfig,
+  type EmailVerifiedClaim
 } from '../services/sso';
 import { createTokenPair, createSession, mintRefreshTokenFamily, bindRefreshJtiToFamily, getUserEpochs, getRefreshFamily, rateLimiter, getRedis } from '../services';
 import { writeRouteAudit } from '../services/auditEvents';
@@ -1986,9 +1987,6 @@ ssoRoutes.get('/callback', async (c) => {
       return c.redirect('/login?error=sso_provider_unverified');
     }
     const idClaims = await verifyIdTokenSignature(tokens.id_token, config, session.nonce);
-    if (idClaims.email) {
-      assertEmailVerified(idClaims);
-    }
 
     // Get user info (display attributes). Bind it to the signed token: per OIDC
     // Core §5.3.2 the userinfo `sub` MUST equal the id_token `sub`; otherwise
@@ -2014,6 +2012,61 @@ ssoRoutes.get('/callback', async (c) => {
     // still bound to the verified subject via the `sub` check above.)
     if (idClaims.email) {
       attrs.email = String(idClaims.email).toLowerCase();
+    }
+
+    // ── SR2-12: verified identity claims ─────────────────────────────────────
+    // The `email_verified` decision must ride the SAME source that supplied the
+    // final email. Previously it was read ONLY from the id_token and ONLY when
+    // the id_token carried an email — so an IdP that omits `email` from the
+    // id_token had its userinfo email accepted with the userinfo
+    // `email_verified` NEVER read (OIDCUserInfo.email_verified had zero
+    // readers). That unverified email then drove the domain check, the
+    // auto-link, and JIT.
+    // …and it must be bound to the address we ACTUALLY use. On the userinfo path
+    // `attrs.email` comes from mapUserAttributes(userInfo, mapping) with an
+    // ADMIN-SET mapping key — which may be `upn` / `preferred_username` / … —
+    // while userinfo's `email_verified` attests userinfo.`email`. Trusting the
+    // claim across that gap would let attributeMapping.email='preferred_username'
+    // launder an unattested address behind email_verified:true. So on the
+    // userinfo path the claim only counts when it demonstrably describes the same
+    // address; otherwise it is 'absent' and falls into the domain-ownership gate.
+    const usingIdTokenEmail = Boolean(idClaims.email);
+    const userInfoRecord = userInfo as unknown as Record<string, unknown>;
+    const userInfoEmail =
+      typeof userInfoRecord.email === 'string' ? userInfoRecord.email.toLowerCase() : null;
+    const mappedKeyIsEmail = (mapping?.email ?? 'email') === 'email';
+    const claimDescribesMappedEmail =
+      mappedKeyIsEmail || (userInfoEmail !== null && userInfoEmail === attrs.email.toLowerCase());
+
+    const emailVerifiedClaim: EmailVerifiedClaim = usingIdTokenEmail
+      ? readEmailVerifiedClaim(idClaims as unknown as Record<string, unknown>)
+      : claimDescribesMappedEmail
+        ? readEmailVerifiedClaim(userInfoRecord)
+        : 'absent';
+
+    // Explicit false is ALWAYS fatal, on both axes, on every path (including an
+    // already-linked identity): the IdP is affirmatively telling us the mailbox
+    // is not proven.
+    if (emailVerifiedClaim === 'false') {
+      writeRouteAudit(c, {
+        orgId: provider.orgId,
+        action: 'sso.callback.rejected',
+        resourceType: 'sso_provider',
+        resourceId: provider.id,
+        resourceName: provider.name,
+        result: 'denied',
+        details: {
+          mode: callbackMode,
+          phase: 'email_verification',
+          reason: 'email_verified_false',
+          claimSource: idClaims.email ? 'id_token' : 'userinfo',
+          partnerId: provider.partnerId,
+        },
+      });
+      clearStateCookie();
+      return callbackMode === 'link'
+        ? c.redirect('/settings/profile?ssoLinkError=email_unverified')
+        : c.redirect('/login?error=sso_email_unverified');
     }
 
     // Check allowed domains
@@ -2154,6 +2207,51 @@ ssoRoutes.get('/callback', async (c) => {
     // below, so it doesn't consult verified org domains.
     if (!user && provider.orgId) {
       const assertedEmailDomain = attrs.email.split('@')[1]?.toLowerCase() ?? null;
+
+      // SR2-12: an ABSENT `email_verified` claim is acceptable ONLY when Breeze
+      // itself has proven the domain (DNS TXT, sso_verified_domains). This is
+      // the "documented and enforced equivalent guarantee" the design requires:
+      // we stop taking the IdP's silence on faith and substitute our own proof.
+      //
+      // Reached only when the identity is being resolved BY EMAIL (auto-link) or
+      // provisioned fresh (JIT) — an already-linked (provider, sub) identity is
+      // deliberately exempt, so enabling this never locks out an existing user.
+      //
+      // ORG AXIS ONLY. sso_verified_domains.org_id is NOT NULL: there is no
+      // partner-axis domain machinery, so applying this to the partner axis
+      // would reject EVERY partner-axis Entra login (Entra omits the claim). The
+      // partner axis is materially lower-risk — no JIT at all, and its email
+      // match already clamps to (same partner, orgId IS NULL, passwordless, no
+      // conflicting provider link). KNOWN GAP; follow-up is to make
+      // sso_verified_domains dual-axis (PARTNER-WIDE FIRST) and then gate here.
+      if (emailVerifiedClaim === 'absent') {
+        const domainProven = assertedEmailDomain
+          ? await withSystemDbAccessContext(() =>
+              isDomainVerifiedForOrg(provider.orgId!, assertedEmailDomain),
+            )
+          : false;
+        if (!domainProven) {
+          writeRouteAudit(c, {
+            orgId: provider.orgId,
+            action: 'sso.callback.rejected',
+            resourceType: 'sso_provider',
+            resourceId: provider.id,
+            resourceName: provider.name,
+            result: 'denied',
+            details: {
+              mode: callbackMode,
+              phase: 'email_verification',
+              reason: 'email_verified_absent_domain_unverified',
+              claimSource: idClaims.email ? 'id_token' : 'userinfo',
+              emailDomain: assertedEmailDomain,
+              partnerId: provider.partnerId,
+            },
+          });
+          clearStateCookie();
+          return c.redirect('/login?error=sso_email_unverified');
+        }
+      }
+
       const domainBlocked = await withSystemDbAccessContext(() =>
         isSsoProvisioningBlocked(provider.orgId!, assertedEmailDomain)
       );
@@ -2177,13 +2275,32 @@ ssoRoutes.get('/callback', async (c) => {
       // (partnerId match AND orgId IS NULL). This is what guarantees an
       // org-bound user (orgId set) can NEVER be resolved through a partner
       // provider — the row is filtered out at the DB layer, never matched.
+      // Org-axis clamp (SR2-12 / defense in depth). The org branch previously
+      // matched `eq(users.email, …)` GLOBALLY — any user in any tenant. Login
+      // was still blocked one gate deeper (the org-axis mint requires an
+      // organization_users row for provider.orgId, else no_org_access), so this
+      // was NOT exploitable — it is debt, and it is closed here.
+      //
+      // Clamp on MEMBERSHIP, not on users.org_id: a legitimate multi-org user's
+      // users.org_id may name a different org while they hold a valid membership
+      // in the provider's org, and a naive column clamp would lock them out.
+      // This subquery is exactly the population the mint gate would accept.
       const emailCondition = provider.partnerId
         ? and(
             eq(users.email, attrs.email.toLowerCase()),
             eq(users.partnerId, provider.partnerId),
             isNull(users.orgId)
           )
-        : eq(users.email, attrs.email.toLowerCase());
+        : and(
+            eq(users.email, attrs.email.toLowerCase()),
+            inArray(
+              users.id,
+              db
+                .select({ userId: organizationUsers.userId })
+                .from(organizationUsers)
+                .where(eq(organizationUsers.orgId, provider.orgId!))
+            )
+          );
       const [byEmail] = await withSystemDbAccessContext(async () =>
         db.select().from(users).where(emailCondition).limit(1)
       );

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
-import { eq, and, gt, ne, isNull } from 'drizzle-orm';
+import { eq, and, gt, ne, isNull, inArray, sql } from 'drizzle-orm';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { nanoid } from 'nanoid';
 import { db, runOutsideDbContext, withSystemDbAccessContext, getCurrentDbAccessContext } from '../db';
@@ -513,6 +513,48 @@ async function revalidateSsoDefaultRole(params: {
     : { ok: true, roleId: role.id, orgPartnerId };
 }
 
+type SsoCallbackMode = 'login' | 'link';
+
+/**
+ * SR2-11: a pending SSO transaction is valid only against the provider
+ * GENERATION it was created under, and only while the provider is still usable
+ * for its own mode.
+ *
+ * Status per mode mirrors each mode's INIT gate: /login/* requires
+ * status='active', /link/start requires status!=='inactive' (a `testing`
+ * provider may be linked). Neither was checked at the callback before this
+ * change — a provider disabled inside the <=10-minute state TTL still completed
+ * a full login or link.
+ *
+ * A NULL providerVersion (a row written before the column existed) is a REJECT,
+ * not a pass: those are exactly the unbound sessions this change invalidates.
+ *
+ * PURE function over already-fetched rows — adds NO db access. Called from the
+ * callback right after the org-XOR-partner axis guard and before any
+ * default-role work, so a stale/disabled transaction never reaches JIT logic.
+ */
+function checkProviderGeneration(
+  provider: typeof ssoProviders.$inferSelect,
+  session: typeof ssoSessions.$inferSelect,
+  mode: SsoCallbackMode,
+):
+  | { ok: true }
+  | { ok: false; reason: 'provider_inactive' | 'provider_not_usable' | 'provider_version_missing' | 'provider_version_mismatch' } {
+  if (provider.status === 'inactive') {
+    return { ok: false, reason: 'provider_inactive' };
+  }
+  if (mode === 'login' && provider.status !== 'active') {
+    return { ok: false, reason: 'provider_not_usable' };
+  }
+  if (session.providerVersion == null) {
+    return { ok: false, reason: 'provider_version_missing' };
+  }
+  if (session.providerVersion !== provider.configVersion) {
+    return { ok: false, reason: 'provider_version_mismatch' };
+  }
+  return { ok: true };
+}
+
 function getOIDCConfig(provider: typeof ssoProviders.$inferSelect): OIDCConfig {
   const decryptedClientSecret = decryptForColumn('sso_providers', 'client_secret', provider.clientSecret);
 
@@ -874,6 +916,10 @@ ssoRoutes.patch(
     ...(body.defaultRoleId !== undefined
       ? { defaultRoleConfiguredBy: body.defaultRoleId ? auth.user.id : null }
       : {}),
+    // SR2-11: any config change starts a new generation. Every pending
+    // sso_session snapshotted the OLD version and is now dead at the callback.
+    // Bumped in the same UPDATE as the change, so the two can never diverge.
+    configVersion: sql`${ssoProviders.configVersion} + 1` as unknown as number,
   };
 
   if (body.clientSecret !== undefined) {
@@ -1010,7 +1056,14 @@ ssoRoutes.post(
 
   const [updated] = await db
     .update(ssoProviders)
-    .set({ status, updatedAt: new Date() })
+    .set({
+      status,
+      updatedAt: new Date(),
+      // SR2-11: a status change is a config change. Disabling a provider must
+      // kill its outstanding sessions, and re-enabling must not resurrect them
+      // (two writes, two bumps).
+      configVersion: sql`${ssoProviders.configVersion} + 1` as unknown as number,
+    })
     .where(eq(ssoProviders.id, providerId))
     .returning();
 
@@ -1378,6 +1431,8 @@ ssoRoutes.post(
           codeVerifier: pkce.codeVerifier,
           redirectUrl: '/settings/profile',
           linkUserId: auth.user.id,
+          // SR2-11: snapshot the generation this session was created under.
+          providerVersion: provider.configVersion,
           expiresAt: new Date(Date.now() + 10 * 60 * 1000)
         })
       )
@@ -1506,6 +1561,8 @@ ssoRoutes.get('/login/partner/:partnerId', zValidator('param', partnerIdParamSch
       nonce,
       codeVerifier: pkce.codeVerifier,
       redirectUrl,
+      // SR2-11: snapshot the generation this session was created under.
+      providerVersion: provider.configVersion,
       expiresAt
     })
   );
@@ -1601,6 +1658,8 @@ ssoRoutes.get('/login/:orgId', zValidator('param', orgIdParamSchema), async (c) 
       nonce,
       codeVerifier: pkce.codeVerifier,
       redirectUrl,
+      // SR2-11: snapshot the generation this session was created under.
+      providerVersion: provider.configVersion,
       expiresAt
     })
   );
@@ -1713,6 +1772,45 @@ ssoRoutes.get('/callback', async (c) => {
   if (!providerOrgId && !provider.partnerId) {
     clearStateCookie();
     return c.redirect('/login?error=provider_not_found');
+  }
+
+  // SR2-11: reject a transaction whose provider is no longer usable for THIS
+  // mode, or whose snapshot no longer matches the provider's live generation.
+  // Runs BEFORE any default-role/ceiling work below — a stale or disabled
+  // transaction must never reach JIT logic at all.
+  const callbackMode: SsoCallbackMode = session.linkUserId ? 'link' : 'login';
+
+  const generation = checkProviderGeneration(provider, session, callbackMode);
+  if (!generation.ok) {
+    writeRouteAudit(c, {
+      orgId: provider.orgId,
+      action: 'sso.callback.rejected',
+      resourceType: 'sso_provider',
+      resourceId: provider.id,
+      resourceName: provider.name,
+      result: 'denied',
+      details: {
+        mode: callbackMode,
+        phase: 'provider_generation',
+        reason: generation.reason,
+        partnerId: provider.partnerId,
+        sessionVersion: session.providerVersion,
+        providerVersion: provider.configVersion,
+      },
+    });
+    clearStateCookie();
+    if (callbackMode === 'link') {
+      return c.redirect(
+        generation.reason === 'provider_inactive' || generation.reason === 'provider_not_usable'
+          ? '/settings/profile?ssoLinkError=provider_inactive'
+          : '/settings/profile?ssoLinkError=config_changed',
+      );
+    }
+    return c.redirect(
+      generation.reason === 'provider_inactive' || generation.reason === 'provider_not_usable'
+        ? '/login?error=sso_provider_inactive'
+        : '/login?error=sso_config_changed',
+    );
   }
 
   // Default-role validation is axis-aware: partner-axis providers require a

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -7,7 +7,7 @@ import { and, eq, or } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { nanoid } from 'nanoid';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { users, partnerUsers, organizationUsers, roles, organizations, partners, permissions, rolePermissions } from '../db/schema';
+import { users, partnerUsers, organizationUsers, roles, organizations, partners } from '../db/schema';
 import { authMiddleware, hasSatisfiedMfa, requireMfa, requirePermission } from '../middleware/auth';
 import {
   MAX_AVATAR_SIZE_BYTES,
@@ -21,11 +21,14 @@ import {
 import {
   clearPermissionCache,
   getUserPermissions,
-  hasPermission,
-  isAssignablePermission,
-  PERMISSIONS,
-  type UserPermissions
+  PERMISSIONS
 } from '../services/permissions';
+import {
+  getScopeContext,
+  getScopedRole,
+  validateAssignableRole,
+  type ScopeContext,
+} from '../services/roleAssignment';
 import { createAuditLogAsync } from '../services/auditService';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 import { getEmailService } from '../services/email';
@@ -122,142 +125,6 @@ const updateUserSchema = z.object({
 const assignRoleSchema = z.object({
   roleId: z.string().guid()
 });
-
-type ScopeContext =
-  | { scope: 'partner'; partnerId: string }
-  | { scope: 'organization'; orgId: string };
-
-function getScopeContext(auth: { scope: string; partnerId: string | null; orgId: string | null }): ScopeContext {
-  if (auth.scope === 'partner' && auth.partnerId) {
-    return { scope: 'partner', partnerId: auth.partnerId };
-  }
-
-  if (auth.scope === 'organization' && auth.orgId) {
-    return { scope: 'organization', orgId: auth.orgId };
-  }
-
-  throw new HTTPException(403, { message: 'Partner or organization context required' });
-}
-
-async function getScopedRole(roleId: string, scopeContext: ScopeContext) {
-  const [role] = await db
-    .select({
-      id: roles.id,
-      scope: roles.scope,
-      name: roles.name,
-      description: roles.description,
-      isSystem: roles.isSystem,
-      parentRoleId: roles.parentRoleId,
-      partnerId: roles.partnerId,
-      orgId: roles.orgId
-    })
-    .from(roles)
-    .where(eq(roles.id, roleId))
-    .limit(1);
-
-  if (!role || role.scope !== scopeContext.scope) {
-    return null;
-  }
-
-  if (role.isSystem) {
-    return role;
-  }
-
-  if (scopeContext.scope === 'partner' && role.partnerId === scopeContext.partnerId) {
-    return role;
-  }
-
-  if (scopeContext.scope === 'organization' && role.orgId === scopeContext.orgId) {
-    return role;
-  }
-
-  return null;
-}
-
-async function getEffectiveRolePermissions(
-  roleId: string,
-  visited: Set<string> = new Set()
-): Promise<Array<{ resource: string; action: string }>> {
-  if (visited.has(roleId)) return [];
-  visited.add(roleId);
-
-  const [role] = await db
-    .select({ parentRoleId: roles.parentRoleId })
-    .from(roles)
-    .where(eq(roles.id, roleId))
-    .limit(1);
-
-  const directPermissions = await db
-    .select({
-      resource: permissions.resource,
-      action: permissions.action
-    })
-    .from(rolePermissions)
-    .innerJoin(permissions, eq(rolePermissions.permissionId, permissions.id))
-    .where(eq(rolePermissions.roleId, roleId));
-
-  if (!role?.parentRoleId) {
-    return directPermissions;
-  }
-
-  const inheritedPermissions = await getEffectiveRolePermissions(role.parentRoleId, visited);
-  const result = new Map<string, { resource: string; action: string }>();
-  for (const permission of [...directPermissions, ...inheritedPermissions]) {
-    result.set(`${permission.resource}:${permission.action}`, permission);
-  }
-  return [...result.values()];
-}
-
-async function getCallerPermissions(
-  c: any,
-  auth: { user: { id: string }; partnerId: string | null; orgId: string | null }
-): Promise<UserPermissions | null> {
-  const existing = c.get('permissions') as UserPermissions | undefined;
-  if (existing) return existing;
-
-  return getUserPermissions(auth.user.id, {
-    partnerId: auth.partnerId || undefined,
-    orgId: auth.orgId || undefined
-  });
-}
-
-async function validateAssignableRole(
-  c: any,
-  auth: { user: { id: string }; partnerId: string | null; orgId: string | null },
-  role: { id: string; isSystem: boolean }
-): Promise<string | null> {
-  const rolePermissionsForAssignment = await getEffectiveRolePermissions(role.id);
-  if (rolePermissionsForAssignment.length === 0) {
-    return null;
-  }
-
-  const callerPermissions = await getCallerPermissions(c, auth);
-  if (!callerPermissions) {
-    return 'No permissions found';
-  }
-
-  for (const permission of rolePermissionsForAssignment) {
-    if (permission.resource === '*' || permission.action === '*') {
-      if (!role.isSystem) {
-        return 'Custom roles with wildcard permissions cannot be assigned';
-      }
-      if (!hasPermission(callerPermissions, permission.resource, permission.action)) {
-        return 'Cannot assign a role broader than caller permissions';
-      }
-      continue;
-    }
-
-    if (!isAssignablePermission(permission)) {
-      return `Role contains unknown permission: ${permission.resource}:${permission.action}`;
-    }
-
-    if (!hasPermission(callerPermissions, permission.resource, permission.action)) {
-      return `Cannot assign a role with permission not held by caller: ${permission.resource}:${permission.action}`;
-    }
-  }
-
-  return null;
-}
 
 async function getScopedUser(userId: string, scopeContext: ScopeContext) {
   if (scopeContext.scope === 'partner') {

--- a/apps/api/src/services/roleAssignment.test.ts
+++ b/apps/api/src/services/roleAssignment.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Row queues consumed in the exact order the service issues its selects.
+const roleRowQueue: unknown[][] = [];
+const permRowQueue: Array<Array<{ resource: string; action: string }>> = [];
+
+vi.mock('../db', () => {
+  const selectChain = (queue: unknown[][]) => ({
+    from: () => ({
+      where: () => ({ limit: () => Promise.resolve(queue.shift() ?? []) }),
+      innerJoin: () => ({ where: () => Promise.resolve(queue.shift() ?? []) }),
+    }),
+  });
+  return {
+    db: {
+      select: (fields?: Record<string, unknown>) => {
+        // The permissions join selects { resource, action }; everything else is a role row.
+        const isPermSelect = !!fields && 'resource' in fields && 'action' in fields;
+        return selectChain(isPermSelect ? (permRowQueue as unknown[][]) : roleRowQueue);
+      },
+    },
+  };
+});
+
+const callerPerms = { permissions: [] as Array<{ resource: string; action: string }> };
+vi.mock('./permissions', () => ({
+  getUserPermissions: vi.fn(async () => callerPerms),
+  hasPermission: vi.fn((perms: typeof callerPerms, resource: string, action: string) =>
+    perms.permissions.some(
+      (p) => (p.resource === resource || p.resource === '*') && (p.action === action || p.action === '*'),
+    ),
+  ),
+  isAssignablePermission: vi.fn((p: { resource: string }) => p.resource !== 'unknown'),
+  PERMISSIONS: {},
+}));
+
+import {
+  getScopeContext,
+  checkRoleStructure,
+  checkRolePermissionCeiling,
+  validateAssignableRole,
+} from './roleAssignment';
+import { getUserPermissions } from './permissions';
+
+beforeEach(() => {
+  roleRowQueue.length = 0;
+  permRowQueue.length = 0;
+  callerPerms.permissions = [];
+});
+
+describe('getScopeContext', () => {
+  it('returns partner context for a partner-scope auth', () => {
+    expect(getScopeContext({ scope: 'partner', partnerId: 'p1', orgId: null })).toEqual({ scope: 'partner', partnerId: 'p1' });
+  });
+  it('returns organization context for an org-scope auth', () => {
+    expect(getScopeContext({ scope: 'organization', partnerId: null, orgId: 'o1' })).toEqual({ scope: 'organization', orgId: 'o1' });
+  });
+  it('throws 403 for system scope (no tenant axis)', () => {
+    expect(() => getScopeContext({ scope: 'system', partnerId: null, orgId: null })).toThrow();
+  });
+});
+
+describe('checkRolePermissionCeiling', () => {
+  it('allows a role whose permissions are a subset of the caller permissions', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: 'devices', action: 'read' }]);
+    callerPerms.permissions = [{ resource: 'devices', action: 'read' }];
+    expect(await checkRolePermissionCeiling(callerPerms as never, { id: 'r1', isSystem: false })).toBeNull();
+  });
+
+  it('rejects a role with a permission the caller does not hold', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: 'users', action: 'write' }]);
+    callerPerms.permissions = [{ resource: 'devices', action: 'read' }];
+    expect(await checkRolePermissionCeiling(callerPerms as never, { id: 'r1', isSystem: false }))
+      .toBe('Cannot assign a role with permission not held by caller: users:write');
+  });
+
+  it('rejects a CUSTOM role carrying a wildcard permission', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: '*', action: '*' }]);
+    callerPerms.permissions = [{ resource: '*', action: '*' }];
+    expect(await checkRolePermissionCeiling(callerPerms as never, { id: 'r1', isSystem: false }))
+      .toBe('Custom roles with wildcard permissions cannot be assigned');
+  });
+
+  it('rejects an unknown permission', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: 'unknown', action: 'read' }]);
+    callerPerms.permissions = [{ resource: 'unknown', action: 'read' }];
+    expect(await checkRolePermissionCeiling(callerPerms as never, { id: 'r1', isSystem: false }))
+      .toBe('Role contains unknown permission: unknown:read');
+  });
+
+  it('returns "No permissions found" when the caller has none', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: 'devices', action: 'read' }]);
+    expect(await checkRolePermissionCeiling(null, { id: 'r1', isSystem: false })).toBe('No permissions found');
+  });
+
+  it('allows a role with zero effective permissions regardless of caller', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([]);
+    expect(await checkRolePermissionCeiling(null, { id: 'r1', isSystem: false })).toBeNull();
+  });
+});
+
+describe('checkRoleStructure', () => {
+  it('rejects wildcard on a custom role without consulting any caller', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: '*', action: '*' }]);
+    expect(await checkRoleStructure({ id: 'r1', isSystem: false }))
+      .toBe('Custom roles with wildcard permissions cannot be assigned');
+  });
+
+  it('allows a wildcard on a SYSTEM role', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: '*', action: '*' }]);
+    expect(await checkRoleStructure({ id: 'r1', isSystem: true })).toBeNull();
+  });
+
+  it('rejects an unknown permission', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: 'unknown', action: 'read' }]);
+    expect(await checkRoleStructure({ id: 'r1', isSystem: false }))
+      .toBe('Role contains unknown permission: unknown:read');
+  });
+});
+
+describe('validateAssignableRole', () => {
+  it('resolves the caller permissions from the Hono context when present', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: 'devices', action: 'read' }]);
+    const ctxPerms = { permissions: [{ resource: 'devices', action: 'read' }] };
+    const c = { get: (k: string) => (k === 'permissions' ? ctxPerms : undefined) };
+    expect(await validateAssignableRole(c, { user: { id: 'u1' }, scope: 'partner', partnerId: 'p1', orgId: null }, { id: 'r1', isSystem: false }))
+      .toBeNull();
+  });
+
+  // I7: order is load-bearing — a permission-less role must NOT trigger a
+  // getUserPermissions resolution (which on the system-scope path opens a fresh
+  // system transaction, permissions.ts:135). The original short-circuited first.
+  it('does NOT resolve caller permissions for a role with zero effective permissions', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([]); // no effective permissions
+    const c = { get: () => undefined };
+    expect(await validateAssignableRole(c, { user: { id: 'u1' }, scope: 'partner', partnerId: 'p1', orgId: null }, { id: 'r1', isSystem: false }))
+      .toBeNull();
+    expect(getUserPermissions).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/roleAssignment.test.ts
+++ b/apps/api/src/services/roleAssignment.test.ts
@@ -13,11 +13,11 @@ vi.mock('../db', () => {
   });
   return {
     db: {
-      select: (fields?: Record<string, unknown>) => {
+      select: vi.fn((fields?: Record<string, unknown>) => {
         // The permissions join selects { resource, action }; everything else is a role row.
         const isPermSelect = !!fields && 'resource' in fields && 'action' in fields;
         return selectChain(isPermSelect ? (permRowQueue as unknown[][]) : roleRowQueue);
-      },
+      }),
     },
   };
 });
@@ -36,16 +36,19 @@ vi.mock('./permissions', () => ({
 
 import {
   getScopeContext,
+  getScopedRole,
   checkRoleStructure,
   checkRolePermissionCeiling,
   validateAssignableRole,
 } from './roleAssignment';
 import { getUserPermissions } from './permissions';
+import { db } from '../db';
 
 beforeEach(() => {
   roleRowQueue.length = 0;
   permRowQueue.length = 0;
   callerPerms.permissions = [];
+  vi.mocked(db.select).mockClear();
 });
 
 describe('getScopeContext', () => {
@@ -103,6 +106,18 @@ describe('checkRolePermissionCeiling', () => {
     permRowQueue.push([]);
     expect(await checkRolePermissionCeiling(null, { id: 'r1', isSystem: false })).toBeNull();
   });
+
+  // Finding 4(a): a SYSTEM role carrying a wildcard is allowed the wildcard
+  // itself, but the caller must actually HOLD that wildcard permission — this
+  // is distinct from the "Custom roles with wildcard..." branch above, which
+  // fires for non-system roles regardless of what the caller holds.
+  it('rejects a SYSTEM role carrying a wildcard when the caller lacks the wildcard', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: '*', action: '*' }]);
+    callerPerms.permissions = [{ resource: 'devices', action: 'read' }]; // no wildcard
+    expect(await checkRolePermissionCeiling(callerPerms as never, { id: 'r1', isSystem: true }))
+      .toBe('Cannot assign a role broader than caller permissions');
+  });
 });
 
 describe('checkRoleStructure', () => {
@@ -147,5 +162,53 @@ describe('validateAssignableRole', () => {
     expect(await validateAssignableRole(c, { user: { id: 'u1' }, scope: 'partner', partnerId: 'p1', orgId: null }, { id: 'r1', isSystem: false }))
       .toBeNull();
     expect(getUserPermissions).not.toHaveBeenCalled();
+  });
+
+  // Finding 3: this is the entire reason checkRolePermissionCeiling's private
+  // applyCeiling sharing exists — validateAssignableRole must walk the role's
+  // effective permissions EXACTLY ONCE (1 role-row select + 1 permissions-join
+  // select), never twice. A regression back to the old exported 3-arg
+  // override, or dropping the sharing entirely, changes this count.
+  it('issues exactly two db.select calls (single walk of getEffectiveRolePermissions)', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: 'devices', action: 'read' }]);
+    callerPerms.permissions = [{ resource: 'devices', action: 'read' }];
+    const c = { get: () => undefined };
+    await validateAssignableRole(c, { user: { id: 'u1' }, scope: 'partner', partnerId: 'p1', orgId: null }, { id: 'r1', isSystem: false });
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getScopedRole (tenant isolation)', () => {
+  const baseRole = {
+    id: 'r1',
+    name: 'Operator',
+    description: null,
+    parentRoleId: null,
+  };
+
+  it('rejects a role from a different scope axis entirely (cross-scope)', async () => {
+    roleRowQueue.push([{ ...baseRole, scope: 'organization', isSystem: false, partnerId: null, orgId: 'o-other' }]);
+    expect(await getScopedRole('r1', { scope: 'partner', partnerId: 'p1' })).toBeNull();
+  });
+
+  it('rejects a partner-scoped role owned by a DIFFERENT partner (cross-partner)', async () => {
+    roleRowQueue.push([{ ...baseRole, scope: 'partner', isSystem: false, partnerId: 'p-other', orgId: null }]);
+    expect(await getScopedRole('r1', { scope: 'partner', partnerId: 'p1' })).toBeNull();
+  });
+
+  it('rejects an org-scoped role owned by a DIFFERENT org (cross-org)', async () => {
+    roleRowQueue.push([{ ...baseRole, scope: 'organization', isSystem: false, partnerId: null, orgId: 'o-other' }]);
+    expect(await getScopedRole('r1', { scope: 'organization', orgId: 'o1' })).toBeNull();
+  });
+
+  it('allows a partner-scoped role owned by the SAME partner', async () => {
+    roleRowQueue.push([{ ...baseRole, scope: 'partner', isSystem: false, partnerId: 'p1', orgId: null }]);
+    expect(await getScopedRole('r1', { scope: 'partner', partnerId: 'p1' })).not.toBeNull();
+  });
+
+  it('allows a SYSTEM role whose scope axis matches, regardless of ownership columns', async () => {
+    roleRowQueue.push([{ ...baseRole, scope: 'partner', isSystem: true, partnerId: null, orgId: null }]);
+    expect(await getScopedRole('r1', { scope: 'partner', partnerId: 'p1' })).not.toBeNull();
   });
 });

--- a/apps/api/src/services/roleAssignment.test.ts
+++ b/apps/api/src/services/roleAssignment.test.ts
@@ -37,7 +37,7 @@ vi.mock('./permissions', () => ({
 import {
   getScopeContext,
   getScopedRole,
-  checkRoleStructure,
+  getProviderAxisRole,
   checkRolePermissionCeiling,
   validateAssignableRole,
 } from './roleAssignment';
@@ -120,28 +120,6 @@ describe('checkRolePermissionCeiling', () => {
   });
 });
 
-describe('checkRoleStructure', () => {
-  it('rejects wildcard on a custom role without consulting any caller', async () => {
-    roleRowQueue.push([{ parentRoleId: null }]);
-    permRowQueue.push([{ resource: '*', action: '*' }]);
-    expect(await checkRoleStructure({ id: 'r1', isSystem: false }))
-      .toBe('Custom roles with wildcard permissions cannot be assigned');
-  });
-
-  it('allows a wildcard on a SYSTEM role', async () => {
-    roleRowQueue.push([{ parentRoleId: null }]);
-    permRowQueue.push([{ resource: '*', action: '*' }]);
-    expect(await checkRoleStructure({ id: 'r1', isSystem: true })).toBeNull();
-  });
-
-  it('rejects an unknown permission', async () => {
-    roleRowQueue.push([{ parentRoleId: null }]);
-    permRowQueue.push([{ resource: 'unknown', action: 'read' }]);
-    expect(await checkRoleStructure({ id: 'r1', isSystem: false }))
-      .toBe('Role contains unknown permission: unknown:read');
-  });
-});
-
 describe('validateAssignableRole', () => {
   it('resolves the caller permissions from the Hono context when present', async () => {
     roleRowQueue.push([{ parentRoleId: null }]);
@@ -210,5 +188,58 @@ describe('getScopedRole (tenant isolation)', () => {
   it('allows a SYSTEM role whose scope axis matches, regardless of ownership columns', async () => {
     roleRowQueue.push([{ ...baseRole, scope: 'partner', isSystem: true, partnerId: null, orgId: null }]);
     expect(await getScopedRole('r1', { scope: 'partner', partnerId: 'p1' })).not.toBeNull();
+  });
+});
+
+// SR2-10 Fix 1: getProviderAxisRole is getScopedRole's query MINUS the
+// `isSystem` escape hatch. Same fixtures as above, run through the stricter
+// resolver, to pin the ONE behavioral difference that matters: a system role
+// that getScopedRole would wave through is refused here.
+describe('getProviderAxisRole (SR2-10 Fix 1 — strict, no isSystem escape hatch)', () => {
+  const baseRole = {
+    id: 'r1',
+    name: 'Operator',
+    description: null,
+    parentRoleId: null,
+  };
+
+  it('rejects a role from a different scope axis entirely (cross-scope)', async () => {
+    roleRowQueue.push([{ ...baseRole, scope: 'organization', isSystem: false, partnerId: null, orgId: 'o-other' }]);
+    expect(await getProviderAxisRole('r1', { scope: 'partner', partnerId: 'p1' })).toBeNull();
+  });
+
+  it('rejects a partner-scoped role owned by a DIFFERENT partner (cross-partner)', async () => {
+    roleRowQueue.push([{ ...baseRole, scope: 'partner', isSystem: false, partnerId: 'p-other', orgId: null }]);
+    expect(await getProviderAxisRole('r1', { scope: 'partner', partnerId: 'p1' })).toBeNull();
+  });
+
+  it('rejects an org-scoped role owned by a DIFFERENT org (cross-org)', async () => {
+    roleRowQueue.push([{ ...baseRole, scope: 'organization', isSystem: false, partnerId: null, orgId: 'o-other' }]);
+    expect(await getProviderAxisRole('r1', { scope: 'organization', orgId: 'o1' })).toBeNull();
+  });
+
+  it('allows a partner-scoped role owned by the SAME partner', async () => {
+    roleRowQueue.push([{ ...baseRole, scope: 'partner', isSystem: false, partnerId: 'p1', orgId: null }]);
+    expect(await getProviderAxisRole('r1', { scope: 'partner', partnerId: 'p1' })).not.toBeNull();
+  });
+
+  it('allows an org-scoped role owned by the SAME org', async () => {
+    roleRowQueue.push([{ ...baseRole, scope: 'organization', isSystem: false, partnerId: null, orgId: 'o1' }]);
+    expect(await getProviderAxisRole('r1', { scope: 'organization', orgId: 'o1' })).not.toBeNull();
+  });
+
+  // THE gap this fix closes. getScopedRole (above) allows exactly this row via
+  // its isSystem shortcut; getScopedRole is what SSO config-time used to call.
+  // A seeded system role's org_id/partner_id are always NULL, so JIT's
+  // axis-equality resolver could never re-resolve it — config-time 201'd a
+  // defaultRoleId that would then brick every SSO sign-in on that provider.
+  it('rejects a SYSTEM role whose scope axis matches but ownership columns do not (the config/JIT drift gap)', async () => {
+    roleRowQueue.push([{ ...baseRole, scope: 'partner', isSystem: true, partnerId: null, orgId: null }]);
+    expect(await getProviderAxisRole('r1', { scope: 'partner', partnerId: 'p1' })).toBeNull();
+  });
+
+  it('rejects the ORG-axis equivalent of the same trap', async () => {
+    roleRowQueue.push([{ ...baseRole, scope: 'organization', isSystem: true, partnerId: null, orgId: null }]);
+    expect(await getProviderAxisRole('r1', { scope: 'organization', orgId: 'o1' })).toBeNull();
   });
 });

--- a/apps/api/src/services/roleAssignment.ts
+++ b/apps/api/src/services/roleAssignment.ts
@@ -97,6 +97,61 @@ export async function getScopedRole(roleId: string, scopeContext: ScopeContext):
   return null;
 }
 
+/**
+ * SR2-10 Fix 1: the STRICT role resolver shared by SSO config-time
+ * (`routes/sso.ts` `validateProviderDefaultRole`) and SSO JIT-time
+ * (`routes/sso.ts` callback pre-check and `revalidateSsoDefaultRole`).
+ * Deliberately the SAME query as `getScopedRole` above, MINUS its
+ * `if (role.isSystem) return role;` escape hatch: the role must carry a real,
+ * exact `roles.orgId` / `roles.partnerId` equal to the provider's own axis. A
+ * built-in system role always has `org_id` AND `partner_id` NULL (seed.ts), so
+ * it can never satisfy this — which is intentional: SSO JIT-provisioning
+ * inserts the id straight into `organization_users.role_id` for the
+ * PROVIDER'S org, and a role that isn't actually scoped to that org has no
+ * business being a standing SSO delegation, `isSystem` or not.
+ *
+ * `getScopedRole`'s permissiveness IS correct for its own caller
+ * (`routes/users.ts`'s ordinary role-assignment flow, where "isSystem" means
+ * "usable in any tenant") and must not be tightened — that would silently
+ * break ordinary user/role administration. SSO uses this function instead, at
+ * every site that resolves a provider's `defaultRoleId`, so config time and
+ * JIT time can never disagree about which roles are resolvable again.
+ *
+ * The org/partner-equality check is done here in application code (not left
+ * to the SQL `WHERE`) for the same defense-in-depth reason `getScopedRole`
+ * does it this way: correctness doesn't depend on trusting a query string.
+ */
+export async function getProviderAxisRole(roleId: string, scopeContext: ScopeContext): Promise<AssignableRoleRow | null> {
+  const [role] = await db
+    .select({
+      id: roles.id,
+      scope: roles.scope,
+      name: roles.name,
+      description: roles.description,
+      isSystem: roles.isSystem,
+      parentRoleId: roles.parentRoleId,
+      partnerId: roles.partnerId,
+      orgId: roles.orgId
+    })
+    .from(roles)
+    .where(eq(roles.id, roleId))
+    .limit(1);
+
+  if (!role || role.scope !== scopeContext.scope) {
+    return null;
+  }
+
+  if (scopeContext.scope === 'partner' && role.partnerId === scopeContext.partnerId) {
+    return role as AssignableRoleRow;
+  }
+
+  if (scopeContext.scope === 'organization' && role.orgId === scopeContext.orgId) {
+    return role as AssignableRoleRow;
+  }
+
+  return null;
+}
+
 export async function getEffectiveRolePermissions(
   roleId: string,
   visited: Set<string> = new Set()
@@ -142,35 +197,6 @@ export async function getCallerPermissions(
     partnerId: auth.partnerId || undefined,
     orgId: auth.orgId || undefined
   });
-}
-
-/**
- * Caller-INDEPENDENT structural checks: a custom role may not carry wildcard
- * permissions, and every permission must be a known one. This is the subset of
- * the ceiling check that can still be applied when no caller identity is
- * available (SSO JIT against a provider with no resolvable configurer).
- */
-export async function checkRoleStructure(
-  role: Pick<AssignableRoleRow, 'id' | 'isSystem'>
-): Promise<string | null> {
-  const rolePermissionsForAssignment = await getEffectiveRolePermissions(role.id);
-  if (rolePermissionsForAssignment.length === 0) {
-    return null;
-  }
-
-  for (const permission of rolePermissionsForAssignment) {
-    if (permission.resource === '*' || permission.action === '*') {
-      if (!role.isSystem) {
-        return 'Custom roles with wildcard permissions cannot be assigned';
-      }
-      continue;
-    }
-    if (!isAssignablePermission(permission)) {
-      return `Role contains unknown permission: ${permission.resource}:${permission.action}`;
-    }
-  }
-
-  return null;
 }
 
 /**

--- a/apps/api/src/services/roleAssignment.ts
+++ b/apps/api/src/services/roleAssignment.ts
@@ -17,7 +17,10 @@ import {
  * routes/sso.ts both consume this module.
  *
  * Every returned message string is byte-identical to the pre-extraction
- * behavior — routes/users.test.ts asserts on them.
+ * behavior. routes/users.test.ts only asserts on the resulting HTTP status
+ * (403) and that db.update was never called for the rejected assignment — it
+ * does not pin any message string. The actual byte-identity safety net is
+ * roleAssignment.test.ts, which asserts on the returned strings directly.
  *
  * DB CONTEXT: these functions use the ambient `db`. routes/users.ts calls them
  * inside the authenticated request's RLS context (correct). A caller with NO
@@ -171,26 +174,20 @@ export async function checkRoleStructure(
 }
 
 /**
- * Full ceiling check against an ALREADY-RESOLVED caller permission set. Returns
- * an error message string, or null when the role is assignable.
- *
- * `precomputedRolePermissions` lets a caller that has already walked the
- * role's effective permissions (validateAssignableRole's short-circuit check
- * does exactly that) pass the result straight through instead of paying for a
- * second recursive role walk. This is the "thread the resolved array in as an
- * optional 3rd arg" escape hatch — required, not cosmetic: without it,
- * validateAssignableRole issues one extra pair of db.select calls per
- * invocation, which desyncs the exact call-count the existing
- * routes/users.test.ts mock queues assume (a mocked test asserting a specific
- * sequence of `db.select` return values), turning an expected 403 into a 500.
+ * Ceiling check body, shared by `checkRolePermissionCeiling` and
+ * `validateAssignableRole`. Kept module-private (not exported) so nothing
+ * outside this file can substitute a `rolePermissions` array that doesn't
+ * match what the role actually carries — see `checkRolePermissionCeiling`'s
+ * docstring for why that matters. `rolePermissions` is always the real,
+ * freshly (or singly) resolved effective-permissions array for `role`, never
+ * caller-supplied.
  */
-export async function checkRolePermissionCeiling(
+async function applyCeiling(
   callerPermissions: UserPermissions | null,
   role: Pick<AssignableRoleRow, 'id' | 'isSystem'>,
-  precomputedRolePermissions?: Array<{ resource: string; action: string }>
+  rolePermissions: Array<{ resource: string; action: string }>
 ): Promise<string | null> {
-  const rolePermissionsForAssignment = precomputedRolePermissions ?? await getEffectiveRolePermissions(role.id);
-  if (rolePermissionsForAssignment.length === 0) {
+  if (rolePermissions.length === 0) {
     return null;
   }
 
@@ -198,7 +195,7 @@ export async function checkRolePermissionCeiling(
     return 'No permissions found';
   }
 
-  for (const permission of rolePermissionsForAssignment) {
+  for (const permission of rolePermissions) {
     if (permission.resource === '*' || permission.action === '*') {
       if (!role.isSystem) {
         return 'Custom roles with wildcard permissions cannot be assigned';
@@ -222,6 +219,27 @@ export async function checkRolePermissionCeiling(
 }
 
 /**
+ * Full ceiling check against an ALREADY-RESOLVED caller permission set. Walks
+ * the role's effective permissions itself — there is deliberately no
+ * caller-supplied override for that walk. (An earlier revision took an
+ * optional `precomputedRolePermissions` 3rd arg; it was removed because it let
+ * a caller short-circuit the ceiling with an unvalidated array — e.g. an empty
+ * array would report ANY role, including a wildcard system role, as
+ * assignable without ever reading its real permissions, and it did so before
+ * the null-caller guard even ran. `validateAssignableRole` still gets the
+ * single-walk sharing it needs for the I7 short-circuit and to keep the
+ * db.select call count/ordering routes/users.test.ts's mock queues assume —
+ * it does so via the private `applyCeiling` helper below, not through this
+ * exported function's signature.)
+ */
+export async function checkRolePermissionCeiling(
+  callerPermissions: UserPermissions | null,
+  role: Pick<AssignableRoleRow, 'id' | 'isSystem'>
+): Promise<string | null> {
+  return applyCeiling(callerPermissions, role, await getEffectiveRolePermissions(role.id));
+}
+
+/**
  * Behavior-preserving façade retained for routes/users.ts.
  *
  * ORDER IS LOAD-BEARING. The original resolved the ROLE's effective permissions
@@ -242,5 +260,5 @@ export async function validateAssignableRole(
     return null; // no caller resolution — matches the original's side effects exactly
   }
   const callerPermissions = await getCallerPermissions(c, auth);
-  return checkRolePermissionCeiling(callerPermissions, role, rolePermissionsForAssignment);
+  return applyCeiling(callerPermissions, role, rolePermissionsForAssignment);
 }

--- a/apps/api/src/services/roleAssignment.ts
+++ b/apps/api/src/services/roleAssignment.ts
@@ -1,0 +1,246 @@
+import { eq } from 'drizzle-orm';
+import { HTTPException } from 'hono/http-exception';
+import { db } from '../db';
+import { roles, permissions, rolePermissions } from '../db/schema';
+import {
+  getUserPermissions,
+  hasPermission,
+  isAssignablePermission,
+  type UserPermissions,
+} from './permissions';
+
+/**
+ * Canonical assignable-role validation. Lifted VERBATIM out of routes/users.ts
+ * (where it was module-private) so SSO default-role configuration and JIT
+ * provisioning enforce the SAME permission-subset ceiling as ordinary user
+ * administration (SR2-10). Do not fork a second copy: routes/users.ts and
+ * routes/sso.ts both consume this module.
+ *
+ * Every returned message string is byte-identical to the pre-extraction
+ * behavior — routes/users.test.ts asserts on them.
+ *
+ * DB CONTEXT: these functions use the ambient `db`. routes/users.ts calls them
+ * inside the authenticated request's RLS context (correct). A caller with NO
+ * request context — the unauthenticated /sso/callback — must wrap the call in
+ * withSystemDbAccessContext itself.
+ */
+
+export type ScopeContext =
+  | { scope: 'partner'; partnerId: string }
+  | { scope: 'organization'; orgId: string };
+
+export interface AuthLike {
+  user: { id: string };
+  scope: string;
+  partnerId: string | null;
+  orgId: string | null;
+}
+
+export interface AssignableRoleRow {
+  id: string;
+  scope: string;
+  name: string;
+  description: string | null;
+  isSystem: boolean;
+  parentRoleId: string | null;
+  partnerId: string | null;
+  orgId: string | null;
+}
+
+export function getScopeContext(auth: { scope: string; partnerId: string | null; orgId: string | null }): ScopeContext {
+  if (auth.scope === 'partner' && auth.partnerId) {
+    return { scope: 'partner', partnerId: auth.partnerId };
+  }
+
+  if (auth.scope === 'organization' && auth.orgId) {
+    return { scope: 'organization', orgId: auth.orgId };
+  }
+
+  throw new HTTPException(403, { message: 'Partner or organization context required' });
+}
+
+export async function getScopedRole(roleId: string, scopeContext: ScopeContext): Promise<AssignableRoleRow | null> {
+  const [role] = await db
+    .select({
+      id: roles.id,
+      scope: roles.scope,
+      name: roles.name,
+      description: roles.description,
+      isSystem: roles.isSystem,
+      parentRoleId: roles.parentRoleId,
+      partnerId: roles.partnerId,
+      orgId: roles.orgId
+    })
+    .from(roles)
+    .where(eq(roles.id, roleId))
+    .limit(1);
+
+  if (!role || role.scope !== scopeContext.scope) {
+    return null;
+  }
+
+  if (role.isSystem) {
+    return role as AssignableRoleRow;
+  }
+
+  if (scopeContext.scope === 'partner' && role.partnerId === scopeContext.partnerId) {
+    return role as AssignableRoleRow;
+  }
+
+  if (scopeContext.scope === 'organization' && role.orgId === scopeContext.orgId) {
+    return role as AssignableRoleRow;
+  }
+
+  return null;
+}
+
+export async function getEffectiveRolePermissions(
+  roleId: string,
+  visited: Set<string> = new Set()
+): Promise<Array<{ resource: string; action: string }>> {
+  if (visited.has(roleId)) return [];
+  visited.add(roleId);
+
+  const [role] = await db
+    .select({ parentRoleId: roles.parentRoleId })
+    .from(roles)
+    .where(eq(roles.id, roleId))
+    .limit(1);
+
+  const directPermissions = await db
+    .select({
+      resource: permissions.resource,
+      action: permissions.action
+    })
+    .from(rolePermissions)
+    .innerJoin(permissions, eq(rolePermissions.permissionId, permissions.id))
+    .where(eq(rolePermissions.roleId, roleId));
+
+  if (!role?.parentRoleId) {
+    return directPermissions;
+  }
+
+  const inheritedPermissions = await getEffectiveRolePermissions(role.parentRoleId, visited);
+  const result = new Map<string, { resource: string; action: string }>();
+  for (const permission of [...directPermissions, ...inheritedPermissions]) {
+    result.set(`${permission.resource}:${permission.action}`, permission);
+  }
+  return [...result.values()];
+}
+
+export async function getCallerPermissions(
+  c: any,
+  auth: AuthLike
+): Promise<UserPermissions | null> {
+  const existing = c?.get?.('permissions') as UserPermissions | undefined;
+  if (existing) return existing;
+
+  return getUserPermissions(auth.user.id, {
+    partnerId: auth.partnerId || undefined,
+    orgId: auth.orgId || undefined
+  });
+}
+
+/**
+ * Caller-INDEPENDENT structural checks: a custom role may not carry wildcard
+ * permissions, and every permission must be a known one. This is the subset of
+ * the ceiling check that can still be applied when no caller identity is
+ * available (SSO JIT against a provider with no resolvable configurer).
+ */
+export async function checkRoleStructure(
+  role: Pick<AssignableRoleRow, 'id' | 'isSystem'>
+): Promise<string | null> {
+  const rolePermissionsForAssignment = await getEffectiveRolePermissions(role.id);
+  if (rolePermissionsForAssignment.length === 0) {
+    return null;
+  }
+
+  for (const permission of rolePermissionsForAssignment) {
+    if (permission.resource === '*' || permission.action === '*') {
+      if (!role.isSystem) {
+        return 'Custom roles with wildcard permissions cannot be assigned';
+      }
+      continue;
+    }
+    if (!isAssignablePermission(permission)) {
+      return `Role contains unknown permission: ${permission.resource}:${permission.action}`;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Full ceiling check against an ALREADY-RESOLVED caller permission set. Returns
+ * an error message string, or null when the role is assignable.
+ *
+ * `precomputedRolePermissions` lets a caller that has already walked the
+ * role's effective permissions (validateAssignableRole's short-circuit check
+ * does exactly that) pass the result straight through instead of paying for a
+ * second recursive role walk. This is the "thread the resolved array in as an
+ * optional 3rd arg" escape hatch — required, not cosmetic: without it,
+ * validateAssignableRole issues one extra pair of db.select calls per
+ * invocation, which desyncs the exact call-count the existing
+ * routes/users.test.ts mock queues assume (a mocked test asserting a specific
+ * sequence of `db.select` return values), turning an expected 403 into a 500.
+ */
+export async function checkRolePermissionCeiling(
+  callerPermissions: UserPermissions | null,
+  role: Pick<AssignableRoleRow, 'id' | 'isSystem'>,
+  precomputedRolePermissions?: Array<{ resource: string; action: string }>
+): Promise<string | null> {
+  const rolePermissionsForAssignment = precomputedRolePermissions ?? await getEffectiveRolePermissions(role.id);
+  if (rolePermissionsForAssignment.length === 0) {
+    return null;
+  }
+
+  if (!callerPermissions) {
+    return 'No permissions found';
+  }
+
+  for (const permission of rolePermissionsForAssignment) {
+    if (permission.resource === '*' || permission.action === '*') {
+      if (!role.isSystem) {
+        return 'Custom roles with wildcard permissions cannot be assigned';
+      }
+      if (!hasPermission(callerPermissions, permission.resource, permission.action)) {
+        return 'Cannot assign a role broader than caller permissions';
+      }
+      continue;
+    }
+
+    if (!isAssignablePermission(permission)) {
+      return `Role contains unknown permission: ${permission.resource}:${permission.action}`;
+    }
+
+    if (!hasPermission(callerPermissions, permission.resource, permission.action)) {
+      return `Cannot assign a role with permission not held by caller: ${permission.resource}:${permission.action}`;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Behavior-preserving façade retained for routes/users.ts.
+ *
+ * ORDER IS LOAD-BEARING. The original resolved the ROLE's effective permissions
+ * first and early-returned null on an empty set, only THEN touching
+ * getCallerPermissions. Calling getCallerPermissions unconditionally would make
+ * a permission-less role trigger a getUserPermissions resolution that never ran
+ * before — which on the system-scope path opens a fresh system transaction
+ * (services/permissions.ts:135). So: short-circuit FIRST, resolve the caller
+ * SECOND.
+ */
+export async function validateAssignableRole(
+  c: any,
+  auth: AuthLike,
+  role: Pick<AssignableRoleRow, 'id' | 'isSystem'>
+): Promise<string | null> {
+  const rolePermissionsForAssignment = await getEffectiveRolePermissions(role.id);
+  if (rolePermissionsForAssignment.length === 0) {
+    return null; // no caller resolution — matches the original's side effects exactly
+  }
+  const callerPermissions = await getCallerPermissions(c, auth);
+  return checkRolePermissionCeiling(callerPermissions, role, rolePermissionsForAssignment);
+}

--- a/apps/api/src/services/sso.test.ts
+++ b/apps/api/src/services/sso.test.ts
@@ -4,6 +4,7 @@ import {
   verifyIdTokenClaims,
   verifyIdTokenSignature,
   assertEmailVerified,
+  readEmailVerifiedClaim,
   idpAssertedMfa,
   discoverOIDCConfig,
   isInternalUrl,
@@ -194,6 +195,26 @@ describe('sso service', () => {
     // server-to-server userinfo call, not the id_token email, anyway.
     it('passes when email_verified is absent (does not lock out Azure AD)', () => {
       expect(() => assertEmailVerified({})).not.toThrow();
+    });
+  });
+
+  describe('readEmailVerifiedClaim (SR2-12)', () => {
+    it.each([
+      [{ email_verified: true }, 'true'],
+      [{ email_verified: 'true' }, 'true'],
+      [{ email_verified: false }, 'false'],
+      [{ email_verified: 'false' }, 'false'],
+      [{}, 'absent'],
+      [{ email_verified: null }, 'absent'],
+      [{ email_verified: 'maybe' }, 'absent'],
+      [{ email_verified: 1 }, 'absent'],
+    ])('%o -> %s', (source, expected) => {
+      expect(readEmailVerifiedClaim(source as Record<string, unknown>)).toBe(expected);
+    });
+
+    it('returns absent for null/undefined', () => {
+      expect(readEmailVerifiedClaim(null)).toBe('absent');
+      expect(readEmailVerifiedClaim(undefined)).toBe('absent');
     });
   });
 

--- a/apps/api/src/services/sso.test.ts
+++ b/apps/api/src/services/sso.test.ts
@@ -8,11 +8,39 @@ import {
   idpAssertedMfa,
   discoverOIDCConfig,
   isInternalUrl,
+  assertSafeOidcEndpoint,
+  validateDiscoveredEndpoints,
+  exchangeCodeForTokens,
+  _resetIdTokenJwksCacheForTests,
+  OIDC_FETCH_TIMEOUT_MS,
   type OIDCConfig,
+  type OIDCDiscoveryDocument,
   PROVIDER_PRESETS,
   SAML_PROVIDER_PRESETS,
   ALL_SSO_PRESETS
 } from './sso';
+import { createRemoteJWKSet, customFetch } from 'jose';
+import { safeFetch, SsrfBlockedError } from './urlSafety';
+import { assertOutsideHeldDbContext } from '../db';
+
+// SR2-13/14: mock the outbound-HTTP + jose transport so the SSRF-safe wiring
+// can be asserted without a network. `safeFetch` DEFAULTS to the real
+// implementation (so the direct SSRF-rejection + #1105 tripwire tests exercise
+// the genuine guard); per-test `...Once` overrides stub it where a controlled
+// response body is needed. `createRemoteJWKSet` is captured so the injected
+// `customFetch` can be inspected. `../db` is mocked only for the tripwire.
+vi.mock('./urlSafety', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./urlSafety')>();
+  return {
+    ...actual,
+    safeFetch: vi.fn((...args: Parameters<typeof actual.safeFetch>) => actual.safeFetch(...args)),
+  };
+});
+vi.mock('jose', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('jose')>();
+  return { ...actual, createRemoteJWKSet: vi.fn(() => async () => ({})) };
+});
+vi.mock('../db', () => ({ assertOutsideHeldDbContext: vi.fn() }));
 
 describe('idpAssertedMfa (security review #2 H-1)', () => {
   it('is true only when amr contains the RFC 8176 "mfa" reference', () => {
@@ -420,5 +448,151 @@ describe('sso service', () => {
         expect(isInternalUrl('https://[::ffff:169.254.169.254]', true)).toBe(true); // mapped metadata
       });
     });
+  });
+});
+
+describe('SSRF-safe OIDC transport (SR2-13/14)', () => {
+  const baseConfig: OIDCConfig = {
+    issuer: 'https://issuer.example.com',
+    clientId: 'client-123',
+    clientSecret: 'secret-456',
+    authorizationUrl: 'https://issuer.example.com/auth',
+    tokenUrl: 'https://issuer.example.com/token',
+    userInfoUrl: 'https://issuer.example.com/userinfo',
+    scopes: 'openid profile email'
+  };
+
+  const publicDiscoveryDoc: OIDCDiscoveryDocument = {
+    issuer: 'https://issuer.example.com',
+    authorization_endpoint: 'https://issuer.example.com/auth',
+    token_endpoint: 'https://issuer.example.com/token',
+    userinfo_endpoint: 'https://issuer.example.com/userinfo',
+    jwks_uri: 'https://issuer.example.com/jwks'
+  };
+
+  function jsonResponse(body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' }
+    });
+  }
+
+  // A structurally-valid compact JWS so jose parses the header, accepts the alg,
+  // and reaches the (injected) key resolver — the point at which customFetch
+  // fires. The signature is bogus; these tests never assert a successful verify.
+  function rs256Token(): string {
+    const header = Buffer.from(JSON.stringify({ alg: 'RS256', kid: 'x' })).toString('base64url');
+    const payload = Buffer.from(
+      JSON.stringify({ iss: baseConfig.issuer, aud: baseConfig.clientId })
+    ).toString('base64url');
+    return `${header}.${payload}.AAAA`;
+  }
+
+  beforeEach(() => {
+    _resetIdTokenJwksCacheForTests();
+    vi.mocked(safeFetch).mockClear();
+    vi.mocked(createRemoteJWKSet).mockClear();
+    vi.mocked(assertOutsideHeldDbContext).mockClear();
+  });
+
+  // 1
+  it('assertSafeOidcEndpoint enforces HTTPS + public routability', () => {
+    expect(() => assertSafeOidcEndpoint('token_endpoint', 'https://idp.example.com/jwks')).not.toThrow();
+    expect(() => assertSafeOidcEndpoint('token_endpoint', undefined)).toThrow(/missing/);
+    expect(() => assertSafeOidcEndpoint('token_endpoint', 'http://idp.example.com/jwks')).toThrow(/rejected/);
+    expect(() => assertSafeOidcEndpoint('token_endpoint', 'http://169.254.169.254/x')).toThrow(/rejected/);
+    expect(() => assertSafeOidcEndpoint('token_endpoint', 'https://127.0.0.1/jwks')).toThrow(/rejected/);
+    expect(() => assertSafeOidcEndpoint('token_endpoint', 'https://localhost/jwks')).toThrow(/rejected/);
+    // Self-host escape hatch: http + RFC1918 permitted; metadata still blocked.
+    expect(() => assertSafeOidcEndpoint('token_endpoint', 'http://10.0.0.5/jwks', true)).not.toThrow();
+    expect(() => assertSafeOidcEndpoint('token_endpoint', 'http://169.254.169.254/x', true)).toThrow(/rejected/);
+  });
+
+  // 2
+  it('validateDiscoveredEndpoints rejects a cleartext token_endpoint and an internal jwks_uri', () => {
+    expect(() => validateDiscoveredEndpoints(publicDiscoveryDoc)).not.toThrow();
+    expect(() =>
+      validateDiscoveredEndpoints({ ...publicDiscoveryDoc, token_endpoint: 'http://issuer.example.com/token' })
+    ).toThrow(/token_endpoint/);
+    expect(() =>
+      validateDiscoveredEndpoints({ ...publicDiscoveryDoc, jwks_uri: 'https://10.0.0.5/jwks' })
+    ).toThrow(/jwks_uri/);
+  });
+
+  // 3
+  it('discoverOIDCConfig rejects a document with an internal jwks_uri (and does not return it)', async () => {
+    vi.mocked(safeFetch).mockResolvedValueOnce(
+      jsonResponse({ ...publicDiscoveryDoc, jwks_uri: 'http://10.0.0.5/jwks' })
+    );
+    await expect(discoverOIDCConfig('https://issuer.example.com')).rejects.toThrow(/jwks_uri/);
+  });
+
+  // 4 — load-bearing: safeFetch is injected into jose, and the injected fn
+  // rejects a private-IP URL (proving jose's internal refresh path is guarded).
+  it('injects safeFetch into jose via customFetch, and the injected fn blocks a private IP', async () => {
+    const config: OIDCConfig = { ...baseConfig, jwksUrl: 'https://idp.example.com/jwks' };
+    // jwtVerify will fail on the stub key; we only need createRemoteJWKSet to run.
+    await verifyIdTokenSignature('a.b.c', config, 'nonce').catch(() => {});
+
+    const opts = vi.mocked(createRemoteJWKSet).mock.calls[0]![1] as Record<PropertyKey, unknown>;
+    expect(typeof opts[customFetch]).toBe('function');
+
+    const fetchImpl = opts[customFetch] as (u: string, o: Record<string, unknown>) => Promise<Response>;
+    await expect(fetchImpl('http://169.254.169.254/jwks', {})).rejects.toThrow(SsrfBlockedError);
+  });
+
+  // 5
+  it('verifyIdTokenSignature rejects an internal jwksUrl before constructing a key set', async () => {
+    const config: OIDCConfig = { ...baseConfig, jwksUrl: 'http://127.0.0.1/jwks' };
+    await expect(verifyIdTokenSignature(rs256Token(), config, 'nonce')).rejects.toThrow();
+    expect(createRemoteJWKSet).not.toHaveBeenCalled();
+  });
+
+  // 6
+  it('exchangeCodeForTokens refuses a plain-http tokenUrl and never dispatches the secret', async () => {
+    const config: OIDCConfig = { ...baseConfig, tokenUrl: 'http://evil.example.com/token' };
+    await expect(
+      exchangeCodeForTokens({ config, code: 'code', redirectUri: 'https://app.example.com/cb' })
+    ).rejects.toThrow(/token_endpoint/);
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  // 7
+  it('passes OIDC_FETCH_TIMEOUT_MS to token + discovery fetches', async () => {
+    vi.mocked(safeFetch).mockResolvedValueOnce(jsonResponse({ access_token: 'a', token_type: 'Bearer' }));
+    await exchangeCodeForTokens({ config: baseConfig, code: 'code', redirectUri: 'https://app.example.com/cb' });
+    expect(vi.mocked(safeFetch).mock.calls[0]![1]).toMatchObject({ timeoutMs: OIDC_FETCH_TIMEOUT_MS });
+
+    vi.mocked(safeFetch).mockClear();
+    vi.mocked(safeFetch).mockResolvedValueOnce(jsonResponse(publicDiscoveryDoc));
+    await discoverOIDCConfig('https://issuer.example.com');
+    expect(vi.mocked(safeFetch).mock.calls[0]![1]).toMatchObject({ timeoutMs: OIDC_FETCH_TIMEOUT_MS });
+  });
+
+  // 10 (M4) — the #1105 tripwire is load-bearing: JWKS now flows through
+  // safeFetch, which throws in a held DB context. Pin that calling
+  // verifyIdTokenSignature inside a held context trips it, so nobody moves the
+  // callback's call site into a withSystemDbAccessContext block.
+  it('trips the #1105 tripwire when verifyIdTokenSignature runs inside a held DB context', async () => {
+    vi.mocked(assertOutsideHeldDbContext).mockImplementationOnce((op: string) => {
+      throw new Error(`${op} ran inside a held withDbAccessContext transaction (#1105)`);
+    });
+    // Make jose's key resolver actually drive the injected transport, exactly as
+    // it does on a real kid-miss / cache-expiry refresh.
+    vi.mocked(createRemoteJWKSet).mockImplementationOnce(
+      (url: URL, opts: any) =>
+        (async () => {
+          await opts[customFetch](url.toString(), {
+            headers: new Headers(),
+            method: 'GET',
+            redirect: 'manual',
+            signal: new AbortController().signal
+          });
+          return {};
+        }) as any
+    );
+
+    const config: OIDCConfig = { ...baseConfig, jwksUrl: 'https://idp.example.com/jwks' };
+    await expect(verifyIdTokenSignature(rs256Token(), config, 'nonce')).rejects.toThrow(/safeFetch/);
   });
 });

--- a/apps/api/src/services/sso.ts
+++ b/apps/api/src/services/sso.ts
@@ -1,5 +1,5 @@
 import { randomBytes, createHash } from 'crypto';
-import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { createRemoteJWKSet, jwtVerify, customFetch } from 'jose';
 import { safeFetch, SsrfBlockedError, isPrivateIp, isAlwaysBlockedIp } from './urlSafety';
 
 // ============================================
@@ -15,6 +15,13 @@ export interface OIDCConfig {
   userInfoUrl: string;
   jwksUrl?: string;
   scopes: string;
+  /**
+   * Self-host escape hatch for an internal IdP on an RFC1918 address / plain
+   * HTTP. Resolved ONCE by getOIDCConfig from selfHostAllowsPrivateNetwork() —
+   * never from a request-supplied value. Loopback/link-local/metadata stay
+   * blocked either way (safeFetch's isAlwaysBlockedIp).
+   */
+  allowPrivateNetwork?: boolean;
 }
 
 export interface OIDCTokenResponse {
@@ -117,6 +124,12 @@ export interface TokenExchangeParams {
 export async function exchangeCodeForTokens(params: TokenExchangeParams): Promise<OIDCTokenResponse> {
   const { config, code, redirectUri, codeVerifier } = params;
 
+  // SR2-14: this request carries the DECRYPTED client_secret. A malicious or
+  // compromised discovery document could point token_endpoint at a plain-HTTP
+  // public host and exfiltrate it in cleartext. Refuse before the body is built.
+  const allowPrivateNetwork = config.allowPrivateNetwork ?? false;
+  assertSafeOidcEndpoint('token_endpoint', config.tokenUrl, allowPrivateNetwork);
+
   const body = new URLSearchParams();
   body.set('grant_type', 'authorization_code');
   body.set('client_id', config.clientId);
@@ -134,7 +147,10 @@ export async function exchangeCodeForTokens(params: TokenExchangeParams): Promis
       'Content-Type': 'application/x-www-form-urlencoded',
       'Accept': 'application/json'
     },
-    body: body.toString()
+    body: body.toString(),
+    timeoutMs: OIDC_FETCH_TIMEOUT_MS,
+    maxBytes: OIDC_MAX_RESPONSE_BYTES,
+    allowPrivateNetwork
   });
 
   if (!response.ok) {
@@ -150,12 +166,18 @@ export async function exchangeCodeForTokens(params: TokenExchangeParams): Promis
 // ============================================
 
 export async function getUserInfo(config: OIDCConfig, accessToken: string): Promise<OIDCUserInfo> {
+  const allowPrivateNetwork = config.allowPrivateNetwork ?? false;
+  assertSafeOidcEndpoint('userinfo_endpoint', config.userInfoUrl, allowPrivateNetwork);
+
   const response = await safeFetch(config.userInfoUrl, {
     method: 'GET',
     headers: {
       'Authorization': `Bearer ${accessToken}`,
       'Accept': 'application/json'
-    }
+    },
+    timeoutMs: OIDC_FETCH_TIMEOUT_MS,
+    maxBytes: OIDC_MAX_RESPONSE_BYTES,
+    allowPrivateNetwork
   });
 
   if (!response.ok) {
@@ -171,6 +193,11 @@ export async function getUserInfo(config: OIDCConfig, accessToken: string): Prom
 // ============================================
 
 export async function refreshAccessToken(config: OIDCConfig, refreshToken: string): Promise<OIDCTokenResponse> {
+  // Same client_secret cleartext concern as exchangeCodeForTokens (SR2-14).
+  // Dead code today, but guard it so it can never become a live hole.
+  const allowPrivateNetwork = config.allowPrivateNetwork ?? false;
+  assertSafeOidcEndpoint('token_endpoint', config.tokenUrl, allowPrivateNetwork);
+
   const body = new URLSearchParams();
   body.set('grant_type', 'refresh_token');
   body.set('client_id', config.clientId);
@@ -183,7 +210,10 @@ export async function refreshAccessToken(config: OIDCConfig, refreshToken: strin
       'Content-Type': 'application/x-www-form-urlencoded',
       'Accept': 'application/json'
     },
-    body: body.toString()
+    body: body.toString(),
+    timeoutMs: OIDC_FETCH_TIMEOUT_MS,
+    maxBytes: OIDC_MAX_RESPONSE_BYTES,
+    allowPrivateNetwork
   });
 
   if (!response.ok) {
@@ -264,18 +294,51 @@ export function verifyIdTokenClaims(claims: IDTokenClaims, config: OIDCConfig, n
 // ID Token Signature Verification (JWKS)
 // ============================================
 
-// Cache one remote JWKS set per jwks_uri. jose refreshes on `kid` miss and
-// caches keys internally, so this avoids re-fetching the JWKS on every login.
+// Cache one remote JWKS set per (policy, jwks_uri). jose refreshes on `kid`
+// miss and on cacheMaxAge expiry, so this avoids re-fetching on every login.
+//
+// BOUNDED (SR2-13): the key is tenant-influenced (an admin picks the issuer),
+// so an unbounded Map was a slow memory-growth vector. 500 entries is far
+// beyond any realistic provider count; the oldest is evicted first (Map
+// preserves insertion order).
+const MAX_JWKS_CACHE_ENTRIES = 500;
 const idTokenJwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
 
-function getIdTokenJwks(jwksUri: string): ReturnType<typeof createRemoteJWKSet> {
-  let jwks = idTokenJwksCache.get(jwksUri);
+function getIdTokenJwks(
+  jwksUri: string,
+  allowPrivateNetwork: boolean,
+): ReturnType<typeof createRemoteJWKSet> {
+  // The policy flag is part of the key: a self-host-permissive JWKS set must
+  // never be served to a strict caller.
+  const cacheKey = `${allowPrivateNetwork ? 'priv' : 'pub'}|${jwksUri}`;
+  let jwks = idTokenJwksCache.get(cacheKey);
   if (!jwks) {
     jwks = createRemoteJWKSet(new URL(jwksUri), {
       cacheMaxAge: 10 * 60 * 1000, // 10 minutes
       cooldownDuration: 30 * 1000,
+      // SR2-13: inject the SSRF-safe transport into jose itself. A URL check at
+      // construct time would NOT be enough — jose re-fetches the JWKS on its own
+      // whenever a `kid` misses or cacheMaxAge expires, using its GLOBAL fetch
+      // (undici): no scheme check, no private-IP check, no DNS pinning. Routing
+      // those refreshes through safeFetch is the only way to satisfy the design's
+      // "caching must not bypass transport validation on refresh".
+      //
+      // safeFetch(urlStr, init) is signature-compatible with jose's
+      // FetchImplementation: (url: string, options) => Promise<Response>.
+      [customFetch]: (url: string, options: Record<string, unknown>) =>
+        safeFetch(url, {
+          ...(options as object),
+          timeoutMs: OIDC_JWKS_TIMEOUT_MS,
+          maxBytes: OIDC_MAX_RESPONSE_BYTES, // unauthenticated route: cap the body
+          allowPrivateNetwork,
+        }),
     });
-    idTokenJwksCache.set(jwksUri, jwks);
+
+    if (idTokenJwksCache.size >= MAX_JWKS_CACHE_ENTRIES) {
+      const oldest = idTokenJwksCache.keys().next().value;
+      if (oldest !== undefined) idTokenJwksCache.delete(oldest);
+    }
+    idTokenJwksCache.set(cacheKey, jwks);
   }
   return jwks;
 }
@@ -304,7 +367,13 @@ export async function verifyIdTokenSignature(
     throw new Error('Cannot verify ID token signature: provider has no JWKS URL configured');
   }
 
-  const jwks = getIdTokenJwks(config.jwksUrl);
+  const allowPrivateNetwork = config.allowPrivateNetwork ?? false;
+  // Reject the URL before jose ever constructs a key set for it (SR2-13). The
+  // customFetch injection below covers every actual request, including jose's
+  // internal refreshes; this is the cheap up-front rejection.
+  assertSafeOidcEndpoint('jwks_uri', config.jwksUrl, allowPrivateNetwork);
+
+  const jwks = getIdTokenJwks(config.jwksUrl, allowPrivateNetwork);
 
   let payload: IDTokenClaims;
   try {
@@ -422,6 +491,56 @@ export function isInternalUrl(urlStr: string, allowPrivateNetwork = false): bool
   return allowPrivateNetwork ? isAlwaysBlockedIp(hostname) : isPrivateIp(hostname);
 }
 
+/** Wall-clock cap for provider-controlled OIDC fetches. None was set before (SR2-14). */
+export const OIDC_FETCH_TIMEOUT_MS = 10_000;
+/** JWKS cap — matches jose's own default so a healthy IdP sees no change. */
+export const OIDC_JWKS_TIMEOUT_MS = 5_000;
+/**
+ * Body ceiling for every OIDC document (discovery, token, userinfo, JWKS). All
+ * four are small; 1 MiB is orders of magnitude of headroom. safeFetch had NO
+ * size cap, and /sso/callback is UNAUTHENTICATED — so a compromised IdP
+ * returning a multi-GB JWKS would have been an unauthenticated memory-
+ * exhaustion vector the moment JWKS started flowing through safeFetch (SR2-13).
+ */
+export const OIDC_MAX_RESPONSE_BYTES = 1 * 1024 * 1024;
+
+/**
+ * One policy gate for every endpoint we will either PERSIST from a discovery
+ * document or USE at runtime (SR2-14). Enforces HTTPS (http only in self-host
+ * mode) and rejects loopback/link-local/private/metadata targets, delegating
+ * the IP predicates to urlSafety via isInternalUrl. This is the check that
+ * stops a malicious discovery document from making Breeze POST the DECRYPTED
+ * client_secret in cleartext.
+ */
+export function assertSafeOidcEndpoint(
+  label: string,
+  urlStr: string | null | undefined,
+  allowPrivateNetwork = false,
+): void {
+  if (!urlStr) {
+    throw new Error(`OIDC endpoint missing: ${label}`);
+  }
+  if (isInternalUrl(urlStr, allowPrivateNetwork)) {
+    throw new Error(`OIDC endpoint rejected (must be HTTPS and publicly routable): ${label}`);
+  }
+}
+
+/**
+ * Validate every endpoint a discovery document would cause us to persist,
+ * BEFORE it is persisted. Discovery output was written verbatim with zero
+ * validation — no scheme check, no private-IP check. Throws on the first bad
+ * one.
+ */
+export function validateDiscoveredEndpoints(
+  doc: OIDCDiscoveryDocument,
+  allowPrivateNetwork = false,
+): void {
+  assertSafeOidcEndpoint('authorization_endpoint', doc.authorization_endpoint, allowPrivateNetwork);
+  assertSafeOidcEndpoint('token_endpoint', doc.token_endpoint, allowPrivateNetwork);
+  assertSafeOidcEndpoint('userinfo_endpoint', doc.userinfo_endpoint, allowPrivateNetwork);
+  assertSafeOidcEndpoint('jwks_uri', doc.jwks_uri, allowPrivateNetwork);
+}
+
 export interface DiscoverOIDCConfigOptions {
   /**
    * Self-hosted opt-in for an internal IdP (Authentik/Keycloak) whose issuer
@@ -449,7 +568,9 @@ export async function discoverOIDCConfig(
     response = await safeFetch(wellKnownUrl, {
       method: 'GET',
       headers: { 'Accept': 'application/json' },
-      allowPrivateNetwork
+      allowPrivateNetwork,
+      timeoutMs: OIDC_FETCH_TIMEOUT_MS,
+      maxBytes: OIDC_MAX_RESPONSE_BYTES
     });
   } catch (err) {
     if (err instanceof SsrfBlockedError) {
@@ -468,7 +589,11 @@ export async function discoverOIDCConfig(
     throw new Error(`OIDC discovery failed: ${response.status}`);
   }
 
-  return response.json() as Promise<OIDCDiscoveryDocument>;
+  const doc = (await response.json()) as OIDCDiscoveryDocument;
+  // SR2-14: validate BEFORE the caller persists these. Discovery output was
+  // written to sso_providers verbatim with zero validation.
+  validateDiscoveredEndpoints(doc, allowPrivateNetwork);
+  return doc;
 }
 
 // ============================================

--- a/apps/api/src/services/sso.ts
+++ b/apps/api/src/services/sso.ts
@@ -329,19 +329,31 @@ export async function verifyIdTokenSignature(
 }
 
 /**
- * Reject an id_token whose email is EXPLICITLY marked unverified before it is
- * trusted for user provisioning or account linking. `email_verified` may arrive
- * as a boolean or string.
+ * The three possible states of an OIDC `email_verified` claim, read from EITHER
+ * an id_token claim set OR a userinfo body. `email_verified` may legitimately
+ * arrive as a boolean or as a string (SR2-12).
  *
- * Only an explicit false/"false" blocks: many IdPs (notably Azure AD / Entra)
- * omit `email_verified` entirely even for verified mailboxes, so treating an
- * ABSENT claim as unverified would lock those tenants out. Identity ultimately
- * flows from the server-to-server userinfo call, not the id_token email, so an
- * absent claim is acceptable here.
+ * 'absent' covers missing, null, and any non-boolean junk value — an IdP that
+ * says something we cannot interpret has not asserted verification.
+ */
+export type EmailVerifiedClaim = 'true' | 'false' | 'absent';
+
+export function readEmailVerifiedClaim(
+  source: Record<string, unknown> | null | undefined,
+): EmailVerifiedClaim {
+  const ev = source?.email_verified;
+  if (ev === true || ev === 'true') return 'true';
+  if (ev === false || ev === 'false') return 'false';
+  return 'absent';
+}
+
+/**
+ * @deprecated Superseded by readEmailVerifiedClaim + the callback's axis-aware
+ * gate (SR2-12). Kept because it is the documented "explicit false only"
+ * behavior and is still unit-tested; the SSO callback no longer calls it.
  */
 export function assertEmailVerified(claims: Pick<IDTokenClaims, 'email_verified'>): void {
-  const ev = (claims as { email_verified?: unknown }).email_verified;
-  if (ev === false || ev === 'false') {
+  if (readEmailVerifiedClaim(claims as Record<string, unknown>) === 'false') {
     throw new Error('ID token email is explicitly not verified (email_verified === false)');
   }
 }

--- a/apps/api/src/services/urlSafety.test.ts
+++ b/apps/api/src/services/urlSafety.test.ts
@@ -9,6 +9,7 @@ import {
   isRfc1918OrUla,
   isAlwaysBlockedIp,
   SsrfBlockedError,
+  ResponseTooLargeError,
   __setLookupForTests
 } from './urlSafety';
 
@@ -327,6 +328,81 @@ describe('safeFetch — SSRF policy', () => {
     expect(pinnedAddress).toBe('8.8.8.8');
     expect(pinnedFamily).toBe(4);
     requestSpy.mockRestore();
+  });
+});
+
+describe('safeFetch — maxBytes body cap (SR2-13)', () => {
+  afterEach(() => {
+    __setLookupForTests(null);
+    vi.restoreAllMocks();
+  });
+
+  // Public IP so safeFetch's SSRF gate passes and we reach the (spied) request.
+  function primeLookupPublic(): void {
+    __setLookupForTests(async () => [{ address: '8.8.8.8', family: 4 }]);
+  }
+
+  // Spy http.request with a fake req/res that emits the supplied chunks then
+  // 'end'. Returns the fake req so a test can assert `.destroy()` fired on
+  // overrun. Chunks are emitted synchronously AFTER safeFetch's response
+  // callback has attached its `data`/`end` listeners.
+  function spyRequestEmitting(chunks: Buffer[]): { req: any } {
+    const handle: { req: any } = { req: undefined };
+    vi.spyOn(http, 'request').mockImplementation((_options: any, callback?: any) => {
+      const req = new EventEmitter() as any;
+      req.write = vi.fn();
+      req.destroy = vi.fn();
+      req.setTimeout = vi.fn();
+      req.end = vi.fn(() => {
+        const res = new EventEmitter() as any;
+        res.statusCode = 200;
+        res.statusMessage = 'OK';
+        res.headers = { 'content-type': 'application/json' };
+        callback?.(res);
+        for (const chunk of chunks) res.emit('data', chunk);
+        res.emit('end');
+      });
+      handle.req = req;
+      return req;
+    });
+    return handle;
+  }
+
+  it('destroys the socket and rejects with ResponseTooLargeError on overrun', async () => {
+    primeLookupPublic();
+    // 2048 > 1024, then a LATE chunk after the overrun to prove the guard
+    // does not double-reject or keep buffering after destroy.
+    const handle = spyRequestEmitting([Buffer.alloc(2048, 0x61), Buffer.alloc(4096, 0x62)]);
+
+    await expect(safeFetch('http://big.example.test/jwks', { maxBytes: 1024 })).rejects.toBeInstanceOf(
+      ResponseTooLargeError
+    );
+    expect(handle.req.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('carries the ceiling on the error', async () => {
+    primeLookupPublic();
+    spyRequestEmitting([Buffer.alloc(5000, 0x61)]);
+    await expect(safeFetch('http://big.example.test/jwks', { maxBytes: 1024 })).rejects.toMatchObject({
+      maxBytes: 1024
+    });
+  });
+
+  it('resolves normally when the body is under maxBytes', async () => {
+    primeLookupPublic();
+    spyRequestEmitting([Buffer.from('{"ok":true}')]);
+    const res = await safeFetch('http://small.example.test/jwks', { maxBytes: 1024 });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
+  it('is unbounded when maxBytes is unset (no behavior change for existing callers)', async () => {
+    primeLookupPublic();
+    spyRequestEmitting([Buffer.alloc(1_000_000, 0x63)]);
+    const res = await safeFetch('http://huge.example.test/x');
+    expect(res.status).toBe(200);
+    const body = await res.arrayBuffer();
+    expect(body.byteLength).toBe(1_000_000);
   });
 });
 

--- a/apps/api/src/services/urlSafety.ts
+++ b/apps/api/src/services/urlSafety.ts
@@ -32,6 +32,14 @@ export class SsrfBlockedError extends Error {
   }
 }
 
+/** The response body exceeded the caller's `maxBytes` ceiling. The socket is destroyed. */
+export class ResponseTooLargeError extends Error {
+  constructor(public readonly maxBytes: number) {
+    super(`response body exceeded maxBytes (${maxBytes})`);
+    this.name = 'ResponseTooLargeError';
+  }
+}
+
 // IPv4 ranges that must never be dialed from the server.
 // Ordered roughly by how commonly they appear.
 const PRIVATE_V4_MATCHERS: Array<(octets: number[]) => boolean> = [
@@ -195,6 +203,17 @@ export interface SafeFetchInit extends Omit<RequestInit, 'signal'> {
    * even when this is true. Leave unset for strict (hosted-SaaS) behavior.
    */
   allowPrivateNetwork?: boolean;
+  /**
+   * Hard ceiling on the response body in bytes. On overrun the socket is
+   * destroyed and ResponseTooLargeError is thrown — the partial body is never
+   * buffered further. Unset = unbounded (legacy behavior for existing callers).
+   *
+   * safeFetch previously had NO size cap: it buffered whatever the remote sent.
+   * That is an unauthenticated memory-exhaustion vector wherever a remote host
+   * is attacker-influenced and the calling route is public — e.g. the SSO
+   * callback's JWKS fetch (SR2-13).
+   */
+  maxBytes?: number;
 }
 
 /**
@@ -358,8 +377,25 @@ export async function safeFetch(urlStr: string, init: SafeFetchInit = {}): Promi
       // Follow no redirects by default — caller gets the raw response and can
       // re-invoke safeFetch if they want to trust the Location header.
       const chunks: Buffer[] = [];
-      res.on('data', (c: Buffer) => chunks.push(c));
+      let received = 0;
+      let aborted = false;
+      const maxBytes = init.maxBytes;
+      res.on('data', (c: Buffer) => {
+        if (aborted) return;
+        received += c.length;
+        if (maxBytes !== undefined && received > maxBytes) {
+          // Overrun: stop buffering, tear down the socket, and reject exactly
+          // once. `aborted` guards against a late 'data'/'end' after destroy
+          // re-entering resolve/reject (the Promise is already settled).
+          aborted = true;
+          req.destroy();
+          reject(new ResponseTooLargeError(maxBytes));
+          return;
+        }
+        chunks.push(c);
+      });
       res.on('end', () => {
+        if (aborted) return;
         const bodyBytes = Buffer.concat(chunks);
         const responseHeaders = new Headers();
         for (const [k, v] of Object.entries(res.headers)) {

--- a/apps/web/src/components/settings/ConnectSsoCard.test.tsx
+++ b/apps/web/src/components/settings/ConnectSsoCard.test.tsx
@@ -106,13 +106,43 @@ describe('ConnectSsoCard (#2183)', () => {
     expect(await screen.findByText(/already linked to a different Breeze user/i)).toBeInTheDocument();
   });
 
-  it('shows an error banner for ?ssoLinkError=user_gone', async () => {
-    setLocation('?ssoLinkError=user_gone');
+  // SR2-11: user_gone was folded into session_invalid (removing an account-state
+  // oracle), so the callback can no longer emit it.
+  it('shows an error banner for ?ssoLinkError=session_invalid', async () => {
+    setLocation('?ssoLinkError=session_invalid');
     fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ data: [] }));
 
     render(<ConnectSsoCard />);
 
-    expect(await screen.findByText(/could not be found/i)).toBeInTheDocument();
+    expect(await screen.findByText(/session changed/i)).toBeInTheDocument();
+  });
+
+  it('shows an error banner for ?ssoLinkError=provider_inactive', async () => {
+    setLocation('?ssoLinkError=provider_inactive');
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+    render(<ConnectSsoCard />);
+
+    expect(await screen.findByText(/no longer active/i)).toBeInTheDocument();
+  });
+
+  it('shows an error banner for ?ssoLinkError=config_changed', async () => {
+    setLocation('?ssoLinkError=config_changed');
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+    render(<ConnectSsoCard />);
+
+    expect(await screen.findByText(/configuration changed/i)).toBeInTheDocument();
+  });
+
+  // SR2-12: the IdP did not positively verify the asserted address.
+  it('shows an error banner for ?ssoLinkError=email_unverified', async () => {
+    setLocation('?ssoLinkError=email_unverified');
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+    render(<ConnectSsoCard />);
+
+    expect(await screen.findByText(/did not confirm/i)).toBeInTheDocument();
   });
 
   it('renders an inline error line (not null) when the options fetch returns a server error', async () => {

--- a/apps/web/src/components/settings/ConnectSsoCard.tsx
+++ b/apps/web/src/components/settings/ConnectSsoCard.tsx
@@ -11,7 +11,15 @@ type LinkOption = { id: string; name: string; type: string; linked: boolean };
 const LINK_ERROR_KEYS: Record<string, string> = {
   email_mismatch: 'connectSsoCard.emailMismatch',
   identity_in_use: 'connectSsoCard.identityInUse',
-  user_gone: 'connectSsoCard.userGone'
+  // SR2-11: the pending link was invalidated by a live security-state change
+  // (sign-out, password reset, MFA change, suspension, lost membership). The
+  // server deliberately does NOT say which — that would be an account-state
+  // oracle — so the copy asks the user to sign in and retry.
+  session_invalid: 'connectSsoCard.sessionInvalid',
+  provider_inactive: 'connectSsoCard.providerInactive',
+  config_changed: 'connectSsoCard.configChanged',
+  // SR2-12: the IdP did not positively verify the asserted address.
+  email_unverified: 'connectSsoCard.emailUnverified'
 };
 
 export default function ConnectSsoCard() {

--- a/apps/web/src/components/settings/SsoProviderForm.test.tsx
+++ b/apps/web/src/components/settings/SsoProviderForm.test.tsx
@@ -7,6 +7,15 @@ const ROLES: Role[] = [
   { id: 'partner-role', name: 'Partner Technician', scope: 'partner' },
 ];
 
+// SR2-10 Fix 1: a built-in system role can never be resolved by SSO JIT
+// provisioning (its org_id/partner_id are always NULL), so config time now
+// 400s it — the dropdown must not offer it in the first place.
+const ROLES_WITH_SYSTEM: Role[] = [
+  ...ROLES,
+  { id: 'system-org-role', name: 'Built-in Org Admin', scope: 'organization', isSystem: true },
+  { id: 'system-partner-role', name: 'Built-in Partner Admin', scope: 'partner', isSystem: true },
+];
+
 describe('SsoProviderForm ownership selector', () => {
   it('shows the ownership selector on create for partner-scope users', () => {
     render(<SsoProviderForm showOwnerScope roles={ROLES} />);
@@ -61,5 +70,22 @@ describe('SsoProviderForm ownership selector', () => {
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalled());
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ ownerScope: 'organization' }));
+  });
+
+  // SR2-10 Fix 1: the API now 400s a defaultRoleId that isn't scoped to the
+  // provider's own org/partner — a built-in system role never is (its
+  // org_id/partner_id are always NULL). Filtering it out of the dropdown means
+  // an admin literally cannot select a role guaranteed to fail.
+  it('excludes isSystem roles from the org default-role dropdown', () => {
+    render(<SsoProviderForm showOwnerScope roles={ROLES_WITH_SYSTEM} />);
+    expect(screen.getByRole('option', { name: 'Org Technician' })).toBeTruthy();
+    expect(screen.queryByRole('option', { name: 'Built-in Org Admin' })).toBeNull();
+  });
+
+  it('excludes isSystem roles from the partner default-role dropdown', () => {
+    render(<SsoProviderForm showOwnerScope roles={ROLES_WITH_SYSTEM} />);
+    fireEvent.click(screen.getByTestId('sso-provider-owner-partner'));
+    expect(screen.getByRole('option', { name: 'Partner Technician' })).toBeTruthy();
+    expect(screen.queryByRole('option', { name: 'Built-in Partner Admin' })).toBeNull();
   });
 });

--- a/apps/web/src/components/settings/SsoProviderForm.tsx
+++ b/apps/web/src/components/settings/SsoProviderForm.tsx
@@ -53,6 +53,15 @@ export type Role = {
   // Present on roles fetched from /roles. Used to filter the default-role
   // dropdown by the selected ownership scope (partner vs organization).
   scope?: 'partner' | 'organization';
+  // Present on roles fetched from /roles. A built-in system role's org_id /
+  // partner_id are always NULL, so it can never be resolved by the SSO JIT
+  // provisioning path's strict axis-equality check (SR2-10 Fix 1) even though
+  // it's a perfectly valid role for ordinary user invites — the API's
+  // config-time validator now 400s a defaultRoleId for exactly this reason.
+  // Filtered out of the dropdown below so an admin can't pick a role
+  // guaranteed to fail, which would otherwise silently brick every future SSO
+  // sign-in on the provider.
+  isSystem?: boolean;
 };
 
 type SsoProviderFormProps = {
@@ -136,9 +145,17 @@ export default function SsoProviderForm({
   // scope: partner-wide providers auto-provision into PARTNER roles, org
   // providers into ORG roles. Roles carry `scope`; when it's absent (older
   // payloads) fall back to showing them under the organization scope.
+  //
+  // Also excludes `isSystem` roles (SR2-10 Fix 1): a built-in system role's
+  // org_id/partner_id are always NULL, so the JIT provisioning path can never
+  // resolve one, and the API now 400s a defaultRoleId that isn't scoped to the
+  // provider's own org/partner. Offering it here would let an admin pick a
+  // role guaranteed to fail.
   const visibleRoles = useMemo(() => {
-    if (ownerScope === 'partner') return roles.filter(r => r.scope === 'partner');
-    return roles.filter(r => r.scope !== 'partner');
+    const scoped = ownerScope === 'partner'
+      ? roles.filter(r => r.scope === 'partner')
+      : roles.filter(r => r.scope !== 'partner');
+    return scoped.filter(r => !r.isSystem);
   }, [roles, ownerScope]);
 
   // Apply preset configuration when preset changes

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1542,7 +1542,10 @@
     "connect": "Verbinden",
     "emailMismatch": "Dieses Identitätsanbieterkonto verwendet eine andere E-Mail-Adresse als Ihr Breeze-Konto. Melden Sie sich mit der E-Mail-Adresse Ihres Breeze-Kontos bei Ihrem Anbieter an und versuchen Sie es erneut.",
     "identityInUse": "Dieses Identitätsanbieterkonto ist bereits mit einem anderen Breeze-Benutzer verknüpft.",
-    "userGone": "Ihr Konto konnte nicht gefunden werden. Bitte melden Sie sich erneut an."
+    "sessionInvalid": "Ihre Sitzung hat sich geändert, bevor die Verknüpfung abgeschlossen werden konnte. Bitte melden Sie sich erneut an und versuchen Sie es noch einmal.",
+    "providerInactive": "Dieser Single-Sign-On-Anbieter ist nicht mehr aktiv. Wenden Sie sich an Ihren Administrator.",
+    "configChanged": "Die Single-Sign-On-Konfiguration wurde geändert, während Sie sich verbunden haben. Bitte versuchen Sie es erneut.",
+    "emailUnverified": "Ihr Identitätsanbieter hat nicht bestätigt, dass Ihre E-Mail-Adresse verifiziert ist. Wenden Sie sich an Ihren Administrator."
   },
   "connectedAppsList": {
     "loadingConnectedApps": "Verbundene Apps werden geladen…",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1542,7 +1542,10 @@
     "connect": "Connect",
     "emailMismatch": "That identity provider account uses a different email than your Breeze account. Sign in to your provider with the email on your Breeze account and try again.",
     "identityInUse": "That identity provider account is already linked to a different Breeze user.",
-    "userGone": "Your account could not be found. Please sign in again."
+    "sessionInvalid": "Your session changed before linking could finish. Please sign in again and retry.",
+    "providerInactive": "That single sign-on provider is no longer active. Contact your administrator.",
+    "configChanged": "The single sign-on configuration changed while you were connecting. Please try again.",
+    "emailUnverified": "Your identity provider did not confirm that your email address is verified. Contact your administrator."
   },
   "connectedAppsList": {
     "loadingConnectedApps": "Loading connected apps…",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1542,7 +1542,10 @@
     "connect": "Conectar",
     "emailMismatch": "Esa cuenta del proveedor de identidad utiliza un correo electrónico diferente al de su cuenta Breeze. Inicie sesión en su proveedor con el correo electrónico de su cuenta Breeze y vuelva a intentarlo.",
     "identityInUse": "Esa cuenta del proveedor de identidad ya está vinculada a un usuario Breeze diferente.",
-    "userGone": "No se pudo encontrar su cuenta. Inicie sesión de nuevo."
+    "sessionInvalid": "Su sesión cambió antes de que se pudiera completar la vinculación. Inicie sesión de nuevo y vuelva a intentarlo.",
+    "providerInactive": "Ese proveedor de inicio de sesión único ya no está activo. Comuníquese con su administrador.",
+    "configChanged": "La configuración del inicio de sesión único cambió mientras se conectaba. Vuelva a intentarlo.",
+    "emailUnverified": "Su proveedor de identidad no confirmó que su correo electrónico esté verificado. Comuníquese con su administrador."
   },
   "connectedAppsList": {
     "loadingConnectedApps": "Cargando aplicaciones conectadas…",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1542,7 +1542,10 @@
     "connect": "Connecter",
     "emailMismatch": "Ce compte fournisseur d’identité utilise une adresse e-mail différente de votre compte Breeze. Connectez-vous à votre fournisseur avec l’adresse e-mail sur votre compte Breeze et réessayez.",
     "identityInUse": "Ce compte de fournisseur d’identité est déjà lié à un autre utilisateur Breeze.",
-    "userGone": "Votre compte n’a pas été retrouvé. Veuillez vous reconnecter."
+    "sessionInvalid": "Votre session a changé avant que la liaison puisse aboutir. Veuillez vous reconnecter et réessayer.",
+    "providerInactive": "Ce fournisseur de connexion unique n’est plus actif. Contactez votre administrateur.",
+    "configChanged": "La configuration de la connexion unique a été modifiée pendant l’opération. Veuillez réessayer.",
+    "emailUnverified": "Votre fournisseur d’identité n’a pas confirmé que votre adresse e-mail est vérifiée. Contactez votre administrateur."
   },
   "connectedAppsList": {
     "loadingConnectedApps": "Chargement des applications connectées...",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1542,7 +1542,10 @@
     "connect": "Conectar",
     "emailMismatch": "Essa conta do provedor de identidade usa um e-mail diferente da sua conta Breeze. Faça login no seu provedor com o e-mail da sua conta Breeze e tente novamente.",
     "identityInUse": "Essa conta do provedor de identidade já está vinculada a um usuário diferente do Breeze.",
-    "userGone": "Sua conta não foi encontrada. Faça login novamente."
+    "sessionInvalid": "Sua sessão foi alterada antes que a vinculação pudesse ser concluída. Faça login novamente e tente de novo.",
+    "providerInactive": "Esse provedor de logon único não está mais ativo. Entre em contato com o administrador.",
+    "configChanged": "A configuração de logon único mudou enquanto você se conectava. Tente novamente.",
+    "emailUnverified": "Seu provedor de identidade não confirmou que seu endereço de e-mail foi verificado. Entre em contato com o administrador."
   },
   "connectedAppsList": {
     "loadingConnectedApps": "Carregando aplicativos conectados…",

--- a/docs/superpowers/plans/2026-07-12-pr3-sso-oidc-hardening.md
+++ b/docs/superpowers/plans/2026-07-12-pr3-sso-oidc-hardening.md
@@ -1,0 +1,2940 @@
+# PR 3 — SSO / OIDC Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close SR2-10 … SR2-14. Make the SSO default role obey the same permission-subset ceiling as ordinary user administration; give SSO providers a monotonic config version and make pending SSO sessions bound to it *and* (for link sessions) to the initiating user's live security generation; require a positively-verified email before an assertion may drive account resolution; and route every provider-controlled outbound fetch — **including jose's internal JWKS refresh** — through the existing SSRF-safe transport, with discovery-derived endpoints validated before persistence and re-validated at runtime.
+
+**Architecture:** The SSO stack is *already* substantially hardened (PKCE S256, nonce, HMAC browser-binding cookie, atomic single-use state consume, mandatory id_token signature verification with an asymmetric-only alg allowlist, userinfo↔id_token `sub` binding, passwordless-only auto-link, DNS-TXT verified-domain machinery, and an SSRF-safe `safeFetch`). **Do not rebuild any of those.** PR 3 adds five surgical layers on top:
+
+1. `services/roleAssignment.ts` — the canonical assignable-role validator, extracted verbatim out of `routes/users.ts` (where it is module-private) so `routes/sso.ts` can consume the *same* code instead of forking a weaker copy.
+2. `sso_providers.config_version` — bumped on every config change *and* every status change. Pending `sso_sessions` snapshot it; the callback rejects a version drift or a non-active provider.
+3. `sso_sessions` link-binding columns (`initiating_auth_epoch`, `initiating_mfa_epoch`, `initiating_session_id`) + **RLS (ENABLE + FORCE, system-scope-only policy)**. The link callback re-checks the binding against live state, so logout / password reset / suspension / global revocation invalidate a pending link.
+4. A single verified-email decision point that reads `email_verified` from *whichever* claim source supplied the final email (id_token **or** userinfo — userinfo's copy is never read today) and requires org-domain ownership when the claim is absent.
+5. `safeFetch` injected into jose via the `customFetch` symbol, plus `assertSafeOidcEndpoint` applied to discovery output before persistence and to persisted endpoints at runtime.
+
+**Tech Stack:** Hono (TypeScript), Drizzle ORM, PostgreSQL (RLS via `breeze_app`), `jose` 6.2.3, Vitest.
+
+**Stacks on:** `core-auth-2-mfa-policy` (PR #2385) → `core-auth-1-lifecycle-foundation` (PR #2378). Branch: **`core-auth-3-sso-oidc`**. PR 1 + PR 2 primitives are already on this branch — **do not re-implement them**:
+- `getUserEpochs(userId, executor?) : Promise<{ authEpoch: number; mfaEpoch: number } | null>` — `services/authEpochs.ts:15`, re-exported from `services/index.ts:20`.
+- `getRefreshFamily(familyId) : Promise<{ revokedAt: Date | null; absoluteExpiresAt: Date } | null>` — `services/refreshTokenFamily.ts:72`, re-exported from `services/index.ts:21` (system-scoped internally).
+- `auth.token.sid` — `TokenPayload.sid?` (`services/jwt.ts:210`), reachable as `auth.token` on `AuthContext` (`middleware/auth.ts:25`). Never read in `sso.ts` today.
+- `enforceExistingFactorStepUp` (`routes/auth/helpers.ts:252-281`) — **the canonical bind-and-recheck shape.** Task 5 mirrors it (capture `{authEpoch, mfaEpoch, sid}` at mint; re-check against the live row at consume; 503 when `!epochs || !auth.token.sid`).
+
+---
+
+## Global Constraints
+
+- **Node 22.20.0.** Prefix every `pnpm`/`node` command with `export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"` (no version manager is installed; the pinned binary lives there).
+- **Migration IS required in this PR** (unlike PR 2). Hand-written idempotent SQL in `apps/api/migrations/`, filename `YYYY-MM-DD-<slug>.sql` that sorts **after** `2026-07-15-auth-epochs-and-family-expiry.sql` (PR 1's migration — currently the last file). **No inner `BEGIN;`/`COMMIT;`** (`autoMigrate` wraps each file in `client.begin(...)`). `IF NOT EXISTS` / `DO $$ … END $$` everywhere; re-applying must be a pure no-op. Never edit a shipped migration.
+- **New/changed RLS ships in the same migration and registers in `rls-coverage.integration.test.ts` in the same PR.** `sso_sessions` gains ENABLE + FORCE RLS with a **system-scope-only** policy. Adding a *column* to `sso_providers` needs **no** policy change — the existing dual-axis `sso_providers_org_isolation` policy (`migrations/2026-07-03-sso-partner-axis-login-branding.sql:67-92`) already covers all columns.
+- **Reuse, do not rebuild.** `safeFetch` / `SsrfBlockedError` / `isPrivateIp` / `isAlwaysBlockedIp` (`services/urlSafety.ts:208`, `:23`, `:118`) and `checkSsrfSafe` (`services/ssrfGuard.ts:111`) already exist. **Do not author a third SSRF utility.** `validateAssignableRole` is extracted, not copied.
+- **Public auth errors are generic; server-side audit reasons are specific.** Callback rejections redirect to the existing `/login?error=<code>` (login mode) or `/settings/profile?ssoLinkError=<code>` (link mode) convention. **Audit `details` NEVER contain `state`, `code_verifier`, `code`, an `id_token`/`access_token`/`refresh_token`, or a decrypted `client_secret`** — only ids, reason codes, and version integers.
+- **Fail closed.** A missing binding column, an unresolvable epoch, an unresolvable refresh family, or an unvalidatable endpoint rejects the transaction. Security-state DB failure fails the mutation with no success audit.
+- **DB context.** `/sso/callback` and `/sso/login/*` are unauthenticated — every DB touch there runs inside `withSystemDbAccessContext`. **There are TWO authenticated bare-`db` writes to `sso_sessions` today, and both only work because the table has no RLS:**
+  1. `POST /sso/link/start` — the session INSERT (`routes/sso.ts:1098-1106`).
+  2. `DELETE /providers/:id` — `await db.delete(ssoSessions).where(eq(ssoSessions.providerId, providerId))` (`routes/sso.ts:690`), followed by `db.delete(userSsoIdentities)` (`:691`).
+
+  Task 1 enables FORCE RLS with a system-only policy, so **Task 1 must wrap BOTH** or it ships two regressions. The second is the nastier one: the FK `sso_sessions_provider_id_sso_providers_id_fk` (`0001-baseline.sql:14888`) has **no `ON DELETE CASCADE`**, so a silently-0-rowing session delete makes the subsequent `db.delete(ssoProviders)` raise FK violation **23503 → 500** whenever a pending session exists — i.e. any provider deletion within 10 minutes of a login attempt. The bare pool is forbidden in request code.
+- **Sequencing.** Task 1 adds `provider_version` (and purges unbound rows); **Task 4** adds the writers that populate it. Between those two commits every newly created session has `provider_version = NULL`, and once Task 4's gate lands those sessions are dead on arrival. Harmless inside a single PR — but **do NOT cherry-pick Task 1 alone onto a droplet.**
+- **Test-harness landmines in `routes/sso.test.ts` (2446 lines) — read before touching `sso.ts`:**
+  - `vi.mock('../services')` (`:49-67`) is a **full factory with no `importOriginal`**. **Any new import from `'../services'` into `sso.ts` must be added to that factory or the ENTIRE suite fails at import.** Task 5 adds `getRefreshFamily`.
+  - `vi.mock('../services/sso')` (`:22-47`) is likewise a **full factory** (`idpAssertedMfa` is the one real impl). Task 6 adds `readEmailVerifiedClaim` → **must be added to that factory** (use the real one-liner, not a stub, so the tests exercise it).
+  - `services/roleAssignment.ts` (Task 2) is a **new module path** — `vi.mock('../services')` does NOT cover it. Task 3 must add a dedicated `vi.mock('../services/roleAssignment', …)`.
+  - `vi.mock('../db/schema')` (`:100-156`) has **`ssoSessions: {}` — empty**. Any test asserting on a new `ssoSessions` column must add the key.
+  - `vi.mock('../middleware/auth')` (`:174-208`) sets a fake `auth` with `user: { id, email }` and **no `token` key**. Task 5 reads `auth.token.sid` → **every link test throws** unless the mock gains `token: { sid: '…' }`.
+  - `beforeEach` (`:255-308`) hard-`mockReset()`s each db verb; per-test priming uses `mockReturnValueOnce` **queues in the exact order the route issues selects**. **Adding a select to the callback shifts every downstream queue in every primed test.** Tasks 4, 5, 6 add selects — expect to re-order `primeLinkCallback` (`:2391-2398`) and the login-callback primers, and budget for it.
+- **API suite is parallel-flaky** → run focused, named files. `tsc` is OOM-prone project-wide.
+- **Commit after each green task.** TDD: write the failing test, observe the reviewed failure, then implement.
+- **Do NOT open the PR.** Task 8 ends at a green verification gate; the controller opens the PR after a whole-branch review.
+
+## File Structure
+
+- **Create** `apps/api/migrations/2026-07-16-sso-session-binding-and-provider-version.sql` (Task 1)
+- **Create** `apps/api/src/services/roleAssignment.ts` + `roleAssignment.test.ts` (Task 2)
+- **Create** `apps/api/src/__tests__/integration/ssoHardening.integration.test.ts` (Task 8)
+- **Create** `apps/api/src/__tests__/integration/ssoSessionsRls.integration.test.ts` (Task 8)
+- **Modify** `apps/api/src/db/schema/sso.ts` — `ssoProviders.configVersion`; `ssoSessions.providerVersion` / `.initiatingAuthEpoch` / `.initiatingMfaEpoch` / `.initiatingSessionId` (Task 1)
+- **Modify** `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — register `sso_sessions` (Task 1)
+- **Modify** `apps/api/src/routes/users.ts` — delete the private helpers, import from `services/roleAssignment` (Task 2)
+- **Modify** `apps/api/src/routes/sso.ts` — role validation both axes + JIT re-validation (Task 3); version bump + status/version gate (Task 4); link binding capture + re-check (Task 5); verified-email gate + org clamp (Task 6); endpoint re-validation in `getOIDCConfig` (Task 7)
+- **Modify** `apps/api/src/services/sso.ts` — `readEmailVerifiedClaim` (Task 6); `customFetch` injection, `assertSafeOidcEndpoint`, `validateDiscoveredEndpoints`, `timeoutMs`/`maxBytes`, `OIDCConfig.allowPrivateNetwork` (Task 7)
+- **Modify** `apps/api/src/services/urlSafety.ts` + `urlSafety.test.ts` — `SafeFetchInit.maxBytes` + `ResponseTooLargeError` bounded body read (Task 7)
+- **Modify** `apps/web/src/components/settings/ConnectSsoCard.tsx` + `ConnectSsoCard.test.tsx` + `connectSsoCard.*` i18n keys — web arm for the new `ssoLinkError` codes (Task 6)
+- **Modify** `apps/api/src/routes/sso.test.ts` — mock-factory extensions + new tests (Tasks 3-7)
+- **Modify** `apps/api/src/services/sso.test.ts` — `readEmailVerifiedClaim`, endpoint validation, JWKS `customFetch` (Tasks 6, 7)
+- **Modify** `apps/api/src/routes/users.test.ts` — unchanged assertions must stay green (Task 2)
+
+---
+
+### Task 1: Migration + schema + `sso_sessions` RLS
+
+**Files:**
+- Create: `apps/api/migrations/2026-07-16-sso-session-binding-and-provider-version.sql`
+- Modify: `apps/api/src/db/schema/sso.ts:11-62` (`ssoProviders`), `:92-110` (`ssoSessions`)
+- Modify: `apps/api/src/routes/sso.ts:1098-1106` (link-start insert → system context) **and `:690-691`** (`DELETE /providers/:id` cleanup deletes → system context)
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts:68-80` (`INTENTIONAL_UNSCOPED`) + a new bespoke `it(...)`
+- Test: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` (real DB), `apps/api/src/routes/sso.test.ts` (link-start still 200; **provider delete still 200 with a pending session present**)
+
+**Interfaces:**
+- Produces (Drizzle, consumed by Tasks 3 + 4 + 5):
+  ```ts
+  // ssoProviders
+  configVersion: integer('config_version').notNull().default(1)          // number
+  defaultRoleConfiguredBy: uuid('default_role_configured_by'),           // string | null — the admin who last SET defaultRoleId (Task 3's JIT principal)
+  // ssoSessions
+  providerVersion:     integer('provider_version'),                   // number | null
+  initiatingAuthEpoch: integer('initiating_auth_epoch'),              // number | null
+  initiatingMfaEpoch:  integer('initiating_mfa_epoch'),               // number | null
+  initiatingSessionId: uuid('initiating_session_id'),                 // string | null (= refresh_token_families.family_id, the JWT `sid`)
+  ```
+
+**Decisions (documented here, not deferred):**
+- **Filename:** `2026-07-16-sso-session-binding-and-provider-version.sql`. The last shipped migration is `2026-07-15-auth-epochs-and-family-expiry.sql` (PR 1); `2026-07-16-*` sorts after it under `localeCompare`. No `-a-`/`-b-` infix is needed (single file, no same-day sibling).
+- **`config_version` is `NOT NULL DEFAULT 1`.** Every existing provider starts at generation 1. Monotonic `+1` on any config or status change (Task 4).
+- **`default_role_configured_by UUID NULL` is added here, used by Task 3.** The JIT permission ceiling needs a *principal* to compare the delegated role against. `created_by` is the wrong one: it names the **original creator**, while config-time validation checks the **current caller** — so Admin B (broad permissions) could save a `defaultRoleId` that Admin A (the narrow creator) cannot support, and the provider would save cleanly but fail JIT forever, silently. Worse, **no API route rewrites `created_by`**, so once the creator offboards the provider is unrepairable — and it cannot simply be recreated, because `(provider_id, external_id)` is the identity key for every `user_sso_identities` row. A dedicated column stamped by **every write that sets `defaultRoleId`** (POST and PATCH alike) collapses the principal mismatch AND gives admins a first-class repair: re-save the default role as a current admin.
+- **The four `sso_sessions` columns are NULLABLE.** Login sessions never set the three `initiating_*` columns (there is no initiating user), so `NOT NULL` is impossible. `provider_version` is nullable **only** so the migration doesn't have to backfill in-flight rows.
+- **How the callback distinguishes login from link mode:** unchanged — `session.linkUserId != null` ⇒ link mode (`routes/sso.ts:1561`). The three `initiating_*` columns are read **only** in that branch.
+- **Fail-closed on NULL, not default-to-1.** A session row whose `provider_version` is NULL (i.e. created by the pre-deploy code, still inside its ≤10-min TTL) is **rejected** by the callback (Task 4), and a link session missing any `initiating_*` column is **rejected** (Task 5). Backfilling them to `1` would silently bless exactly the un-bound sessions this PR exists to invalidate. The blast radius is bounded: at most one 10-minute window of in-flight SSO round-trips at deploy time, and PR 1 already forces a global sign-out on this branch.
+- **RLS classification for `sso_sessions`: system-scope-only.** It has no `org_id`/`partner_id` and never will — it is a short-lived pre-auth CSRF/PKCE transaction store written and consumed exclusively by unauthenticated (`/sso/login/*`, `/sso/callback`) or system-context (`/sso/link/start`, after this task) code paths. There is no tenant reader. That is exactly the `partner_abuse_signals` / `software_product_resolutions` shape: `ENABLE` + `FORCE ROW LEVEL SECURITY` with one ALL-command policy `USING/WITH CHECK (current_setting('breeze.scope', true) = 'system')`. It therefore registers in **`INTENTIONAL_UNSCOPED`** (the documentation list for system-scoped tables), **not** in any of the six tenant-shape allowlists — none of which it satisfies. It does **not** go in `EXEMPT_TABLES`: that set only exists to silence the `org_id`-column auto-discovery query, and `sso_sessions` has no `org_id`, so auto-discovery never surfaces it. Because neither list actually *asserts* anything about it, this task also adds a **bespoke `it(...)`** to the contract file that asserts `relrowsecurity`, `relforcerowsecurity`, and the system-only predicate — so the classification is enforced, not merely annotated.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts`, add this test inside the top-level `describe('RLS coverage contract', …)` block (place it next to the other bespoke policy tests, e.g. after the `'OAuth token-row policies do not grant generic org-axis access'` test at `:528`):
+
+```ts
+  it('sso_sessions is forced-RLS and reachable only from system scope', async () => {
+    const [cls] = (await db.execute(sql`
+      SELECT c.relrowsecurity AS rls_on, c.relforcerowsecurity AS force_on
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relname = 'sso_sessions';
+    `)) as unknown as Array<{ rls_on: boolean; force_on: boolean }>;
+
+    expect(cls?.rls_on).toBe(true);
+    expect(cls?.force_on).toBe(true);
+
+    const policies = (await db.execute(sql`
+      SELECT policyname, cmd, COALESCE(qual, '') AS qual, COALESCE(with_check, '') AS with_check
+      FROM pg_policies
+      WHERE schemaname = 'public' AND tablename = 'sso_sessions'
+      ORDER BY policyname;
+    `)) as unknown as Array<{ policyname: string; cmd: string; qual: string; with_check: string }>;
+
+    // Exactly one ALL-command system-only policy. sso_sessions is a pre-auth
+    // CSRF/PKCE transaction store with no tenant column — no tenant axis may
+    // read or write it, only withSystemDbAccessContext.
+    expect(policies).toHaveLength(1);
+    expect(policies[0]?.policyname).toBe('sso_sessions_system_only');
+    expect(policies[0]?.cmd).toBe('ALL');
+    const predicate = `${policies[0]?.qual}\n${policies[0]?.with_check}`;
+    expect(predicate).toContain("current_setting('breeze.scope'");
+    expect(predicate).not.toContain('breeze_has_org_access');
+    expect(predicate).not.toContain('breeze_has_partner_access');
+  });
+
+  it('sso_sessions carries the provider-version and link-binding columns', async () => {
+    const cols = (await db.execute(sql`
+      SELECT column_name, is_nullable, data_type
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'sso_sessions'
+        AND column_name IN ('provider_version', 'initiating_auth_epoch', 'initiating_mfa_epoch', 'initiating_session_id')
+      ORDER BY column_name;
+    `)) as unknown as Array<{ column_name: string; is_nullable: string; data_type: string }>;
+
+    expect(cols.map((c) => c.column_name)).toEqual([
+      'initiating_auth_epoch', 'initiating_mfa_epoch', 'initiating_session_id', 'provider_version',
+    ]);
+    // All nullable: login sessions have no initiating user; provider_version is
+    // NULL only for pre-deploy in-flight rows (which the callback rejects).
+    for (const c of cols) expect(c.is_nullable).toBe('YES');
+
+    const [pv] = (await db.execute(sql`
+      SELECT is_nullable, column_default
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'sso_providers' AND column_name = 'config_version';
+    `)) as unknown as Array<{ is_nullable: string; column_default: string }>;
+    expect(pv?.is_nullable).toBe('NO');
+    expect(pv?.column_default).toContain('1');
+
+    const [drcb] = (await db.execute(sql`
+      SELECT is_nullable, data_type
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'sso_providers' AND column_name = 'default_role_configured_by';
+    `)) as unknown as Array<{ is_nullable: string; data_type: string }>;
+    expect(drcb?.is_nullable).toBe('YES');
+    expect(drcb?.data_type).toBe('uuid');
+  });
+```
+
+Also add `sso_sessions` to `INTENTIONAL_UNSCOPED` (`:68-80`), after the `partner_abuse_signals` entry:
+
+```ts
+  'sso_sessions', // Pre-auth SSO CSRF/PKCE transaction store (state/nonce/code_verifier + link binding). No tenant column; written/consumed only by unauthenticated callback + system-context routes. Forced RLS, system-only policy → only system context.
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run --config vitest.integration.config.ts src/__tests__/integration/rls-coverage.integration.test.ts -t 'sso_sessions'
+```
+Expected: **FAIL** — `rls_on` is `false` (the table has zero policies and RLS was never enabled), and the four columns do not exist.
+
+- [ ] **Step 3: Implement — the migration**
+
+Create `apps/api/migrations/2026-07-16-sso-session-binding-and-provider-version.sql`:
+
+```sql
+-- PR 3 (SR2-11): SSO provider config generations + pending-session binding.
+--
+-- 1. sso_providers.config_version — monotonic generation, bumped by every
+--    config change AND every status change. A pending SSO session snapshots it;
+--    the callback rejects a drift, so a provider reconfigured or disabled during
+--    the <=10-minute state TTL cannot complete a login or an account link.
+--    No RLS change needed: sso_providers already carries the dual-axis ALL
+--    policy sso_providers_org_isolation (2026-07-03), which covers all columns.
+--
+-- 1b. sso_providers.default_role_configured_by (SR2-10) -- the admin who LAST SET
+--    default_role_id. This is the principal the callback re-validates the
+--    delegated role against just before JIT provisioning. created_by is the wrong
+--    principal: it names the ORIGINAL creator while config-time validation checks
+--    the CURRENT caller, and no route ever rewrites it -- so an offboarded creator
+--    would make JIT fail permanently with no repair path (the provider cannot be
+--    recreated without orphaning every user_sso_identities row, since
+--    (provider_id, external_id) is the identity key).
+--
+-- 2. sso_sessions binding columns. NULLABLE by construction: a LOGIN session has
+--    no initiating user, so the three initiating_* columns are only ever set by
+--    POST /sso/link/start. provider_version is nullable only so this migration
+--    needs no backfill; the callback treats NULL as a REJECT (fail closed) --
+--    defaulting pre-deploy rows to 1 would bless exactly the unbound sessions
+--    this change exists to invalidate. Worst case is one <=10-minute window of
+--    in-flight SSO round-trips at deploy time.
+--
+-- 3. sso_sessions RLS. The table had NONE (created in 0001-baseline.sql:5828,
+--    never given a policy). It is a pre-auth CSRF/PKCE transaction store with no
+--    tenant column, written and consumed only by unauthenticated (/sso/callback,
+--    /sso/login/*) or system-context (/sso/link/start) code. Classification:
+--    system-scope-only -- ENABLE + FORCE RLS with one ALL-command policy keyed on
+--    breeze.scope = 'system'. Same shape as partner_abuse_signals (2026-07-13)
+--    and software_product_resolutions. Registered in INTENTIONAL_UNSCOPED in
+--    rls-coverage.integration.test.ts.
+
+ALTER TABLE sso_providers
+  ADD COLUMN IF NOT EXISTS config_version INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE sso_providers
+  ADD COLUMN IF NOT EXISTS default_role_configured_by UUID REFERENCES users(id);
+
+ALTER TABLE sso_sessions
+  ADD COLUMN IF NOT EXISTS provider_version INTEGER;
+
+ALTER TABLE sso_sessions
+  ADD COLUMN IF NOT EXISTS initiating_auth_epoch INTEGER;
+
+ALTER TABLE sso_sessions
+  ADD COLUMN IF NOT EXISTS initiating_mfa_epoch INTEGER;
+
+ALTER TABLE sso_sessions
+  ADD COLUMN IF NOT EXISTS initiating_session_id UUID;
+
+COMMENT ON COLUMN sso_providers.config_version IS
+  'Monotonic config generation. Bumped on every provider config change and status change. Pending sso_sessions snapshot it; the callback rejects a mismatch (SR2-11).';
+COMMENT ON COLUMN sso_providers.default_role_configured_by IS
+  'The admin who last SET default_role_id. The SSO callback re-validates the delegated role against THIS user''s live permission ceiling before JIT provisioning (SR2-10). Re-saving the default role as a current admin is the repair path when the previous configurer is offboarded.';
+COMMENT ON COLUMN sso_sessions.provider_version IS
+  'sso_providers.config_version snapshot at session creation. NULL = pre-deploy row; the callback rejects it (fail closed).';
+COMMENT ON COLUMN sso_sessions.initiating_session_id IS
+  'Link mode only: refresh_token_families.family_id (the initiating access token''s `sid`). The link callback requires that family to still be live.';
+
+-- Purge any session rows that predate the binding columns. They are all <=10
+-- minutes from expiry and cannot satisfy the new callback checks anyway; purging
+-- them makes the invalidation explicit (and auditable) instead of surfacing as a
+-- burst of session_expired redirects. Report the count -- silently discarding
+-- rows destroys the forensic trail.
+DO $$
+DECLARE
+  n INTEGER;
+BEGIN
+  DELETE FROM sso_sessions WHERE provider_version IS NULL;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'purged % in-flight sso_sessions rows with no provider_version binding (SR2-11 rollout)', n;
+  END IF;
+END $$;
+
+ALTER TABLE sso_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sso_sessions FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'sso_sessions'
+      AND policyname = 'sso_sessions_system_only'
+  ) THEN
+    EXECUTE $POLICY$
+      CREATE POLICY sso_sessions_system_only
+        ON sso_sessions
+        USING (current_setting('breeze.scope', true) = 'system')
+        WITH CHECK (current_setting('breeze.scope', true) = 'system')
+    $POLICY$;
+  END IF;
+END $$;
+```
+
+- [ ] **Step 4: Implement — the Drizzle schema**
+
+In `apps/api/src/db/schema/sso.ts`, add `integer` to the `drizzle-orm/pg-core` import on line 1:
+
+```ts
+import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, uniqueIndex, integer } from 'drizzle-orm/pg-core';
+```
+
+In `ssoProviders` (`:11-62`), add immediately after `trustsIdpMfa` (`:56`), before the `// Metadata` block:
+
+```ts
+  // Monotonic config generation (SR2-11). Bumped by PATCH /providers/:id and by
+  // POST /providers/:id/status. Pending sso_sessions snapshot this value; the
+  // callback rejects a session whose snapshot no longer matches, so a provider
+  // reconfigured or disabled mid-flow cannot complete a login or a link.
+  configVersion: integer('config_version').notNull().default(1),
+
+  // SR2-10: the admin who LAST SET defaultRoleId — the principal whose LIVE
+  // permission ceiling the callback re-checks the delegated role against just
+  // before JIT provisioning. Stamped by POST /providers and by every PATCH that
+  // sets defaultRoleId, so "re-save the default role" is a first-class repair
+  // when the previous configurer is offboarded. NOT createdBy: that names the
+  // original creator (who may never have touched defaultRoleId), and no route
+  // ever rewrites it.
+  defaultRoleConfiguredBy: uuid('default_role_configured_by').references(() => users.id),
+```
+
+In `ssoSessions` (`:92-110`), add immediately after `linkUserId` (`:106`), before `expiresAt`:
+
+```ts
+  // SR2-11 pending-transaction binding.
+  //
+  // providerVersion: sso_providers.config_version at creation. NULL only for
+  // rows written before this column existed — the callback REJECTS those.
+  providerVersion: integer('provider_version'),
+
+  // The three initiating_* columns are LINK-MODE ONLY (set by
+  // POST /sso/link/start alongside linkUserId). A login session has no
+  // initiating user, so they stay NULL there — which is why they are nullable.
+  // The link callback requires all three to be present AND to still match live
+  // state, which is what makes logout / password reset / MFA reset / suspension
+  // / global revocation invalidate a pending link.
+  initiatingAuthEpoch: integer('initiating_auth_epoch'),
+  initiatingMfaEpoch: integer('initiating_mfa_epoch'),
+  // = refresh_token_families.family_id == the initiating access token's `sid`.
+  initiatingSessionId: uuid('initiating_session_id'),
+```
+
+- [ ] **Step 5: Implement — BOTH authenticated bare-`db` writes to `sso_sessions` must use system context**
+
+`sso_sessions` now has FORCED RLS with a system-only policy. There are **two** authenticated routes writing it on the bare pool today, and both break.
+
+**5a — `POST /sso/link/start` (INSERT).** The bare-`db` insert at `routes/sso.ts:1098-1106` would raise `new row violates row-level security policy` from the caller's org/partner-scoped request context. Wrap it. Replace:
+
+```ts
+    await db.insert(ssoSessions).values({
+      providerId: provider.id,
+      state,
+      nonce,
+      codeVerifier: pkce.codeVerifier,
+      redirectUrl: '/settings/profile',
+      linkUserId: auth.user.id,
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000)
+    });
+```
+
+with:
+
+```ts
+    // sso_sessions is system-scope-only under RLS (2026-07-16 migration): this
+    // insert ran on the bare pool and only worked because the table had no
+    // policies. The row is a pre-auth transaction record, not tenant data — it
+    // is consumed by the unauthenticated callback, which also runs in system
+    // context. runOutsideDbContext first: we are inside the authenticated
+    // request's org/partner-scoped context here.
+    await runOutsideDbContext(() =>
+      withSystemDbAccessContext(async () =>
+        db.insert(ssoSessions).values({
+          providerId: provider.id,
+          state,
+          nonce,
+          codeVerifier: pkce.codeVerifier,
+          redirectUrl: '/settings/profile',
+          linkUserId: auth.user.id,
+          expiresAt: new Date(Date.now() + 10 * 60 * 1000)
+        })
+      )
+    );
+```
+
+**5b — `DELETE /providers/:id` (the cleanup DELETEs).** This is the sharper regression. `routes/sso.ts:690-691`:
+
+```ts
+  // Delete related records first
+  await db.delete(ssoSessions).where(eq(ssoSessions.providerId, providerId));
+  await db.delete(userSsoIdentities).where(eq(userSsoIdentities.providerId, providerId));
+```
+
+Under the new policy the first DELETE matches **0 rows silently** from the admin's tenant-scoped context. The FK `sso_sessions_provider_id_sso_providers_id_fk` (`0001-baseline.sql:14888`) has **no `ON DELETE CASCADE`**, so the `db.delete(ssoProviders)` three lines later then raises FK violation **23503 → 500** — meaning *provider deletion fails outright whenever a pending session exists*, i.e. within 10 minutes of any login attempt.
+
+`user_sso_identities` is `USER_ID_SCOPED` under RLS (`breeze_current_user_id()`, registered at `rls-coverage.integration.test.ts:420`), so the second DELETE plausibly already 0-rows for **other users'** identities today — same FK-violation hazard, pre-existing. **Do not assume either way**: Task 8 adds a real-DB assertion that proves provider deletion succeeds with (a) a pending session and (b) another user's linked identity present. Wrap both now; the Task 8 assertion is what confirms it.
+
+Replace those two lines with:
+
+```ts
+  // sso_sessions is system-scope-only and user_sso_identities is user-id-scoped
+  // (breeze_current_user_id()) under RLS. On the bare pool, from an admin's
+  // tenant-scoped context, BOTH of these silently delete 0 rows — and neither FK
+  // cascades, so the sso_providers delete below then dies with FK violation
+  // 23503. Provider cleanup is a legitimate system operation: run it as one.
+  await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      await db.delete(ssoSessions).where(eq(ssoSessions.providerId, providerId));
+      await db.delete(userSsoIdentities).where(eq(userSsoIdentities.providerId, providerId));
+    })
+  );
+```
+
+(Authorization is unchanged: `canWriteProviderRow(auth, existing)` at `:685-687` already gated this route. The system context is scoped to the cleanup writes only — it does not widen who may call the route.)
+
+Extend the `../db` import on `routes/sso.ts:7`:
+
+```ts
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+```
+
+(`vi.mock('../db')` in `routes/sso.test.ts:69-98` already stubs `runOutsideDbContext` as a pass-through, so no test-mock change is needed here.)
+
+**Unit test (add to `routes/sso.test.ts`):** `DELETE /providers/:id` returns 200 and issues all three deletes (`ssoSessions`, `userSsoIdentities`, `ssoProviders`) — prime the mocked `db.delete()` chains and assert `db.delete` was called three times and the final `.returning()` resolved a row. This is the regression guard for the FK-violation path.
+
+- [ ] **Step 6: Run to verify it passes**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run --config vitest.integration.config.ts src/__tests__/integration/rls-coverage.integration.test.ts
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+cd apps/api && pnpm db:check-drift
+cd apps/api && pnpm vitest run src/routes/sso.test.ts
+```
+Expected: RLS contract PASS (incl. the two new tests); **no drift**; `sso.test.ts` still green (link-start unchanged externally).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/migrations/2026-07-16-sso-session-binding-and-provider-version.sql apps/api/src/db/schema/sso.ts apps/api/src/routes/sso.ts apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+git commit -m "feat(sso): provider config_version + session binding columns + sso_sessions RLS (SR2-11)"
+```
+
+---
+
+### Task 2: Extract the canonical assignable-role validator (pure refactor)
+
+**Files:**
+- Create: `apps/api/src/services/roleAssignment.ts`
+- Create: `apps/api/src/services/roleAssignment.test.ts`
+- Modify: `apps/api/src/routes/users.ts:125-259` (delete the private helpers) + `:1123-1130` + `:1658-1665` (call sites) + imports (`:1-30`)
+- Test: `apps/api/src/routes/users.test.ts` (**must stay green with zero edits** — that is this task's acceptance criterion)
+
+**Interfaces:**
+- Consumes: `db` (`../db`); `roles`, `permissions`, `rolePermissions` (`../db/schema`); `getUserPermissions`, `hasPermission`, `isAssignablePermission`, `type UserPermissions` (`./permissions`); `HTTPException` (`hono/http-exception`).
+- Produces:
+  ```ts
+  export type ScopeContext =
+    | { scope: 'partner'; partnerId: string }
+    | { scope: 'organization'; orgId: string };
+
+  export interface AuthLike {
+    user: { id: string };
+    scope: string;   // REQUIRED — validateProviderDefaultRole (Task 3) branches on `auth.scope === 'system'`; an optional field would silently read `undefined` on a malformed auth object and fall through to the ceiling path.
+    partnerId: string | null;
+    orgId: string | null;
+  }
+
+  export interface AssignableRoleRow {
+    id: string;
+    scope: string;
+    name: string;
+    description: string | null;
+    isSystem: boolean;
+    parentRoleId: string | null;
+    partnerId: string | null;
+    orgId: string | null;
+  }
+
+  export function getScopeContext(auth: { scope: string; partnerId: string | null; orgId: string | null }): ScopeContext; // throws HTTPException(403)
+  export function getScopedRole(roleId: string, scopeContext: ScopeContext): Promise<AssignableRoleRow | null>;
+  export function getEffectiveRolePermissions(roleId: string, visited?: Set<string>): Promise<Array<{ resource: string; action: string }>>;
+  export function getCallerPermissions(c: any, auth: AuthLike): Promise<UserPermissions | null>;
+
+  /** Structural-only checks: custom roles may not carry wildcard perms; every perm must be known. Caller-independent. */
+  export function checkRoleStructure(role: Pick<AssignableRoleRow, 'id' | 'isSystem'>): Promise<string | null>;
+
+  /** Full ceiling check against an already-resolved permission set. Returns an error message, or null when assignable. */
+  export function checkRolePermissionCeiling(
+    callerPermissions: UserPermissions | null,
+    role: Pick<AssignableRoleRow, 'id' | 'isSystem'>,
+  ): Promise<string | null>;
+
+  /** The behavior-preserving façade `routes/users.ts` keeps calling. */
+  export function validateAssignableRole(
+    c: any,
+    auth: AuthLike,
+    role: Pick<AssignableRoleRow, 'id' | 'isSystem'>,
+  ): Promise<string | null>;
+  ```
+
+**Decisions:**
+- **Zero behavior change — including side-effect ORDER.** Every returned message string is byte-identical to today's (`routes/users.test.ts` asserts on them). The split exists only so the SSO callback (Task 3), which has no HTTP caller, can reach the ceiling logic with a permission set it resolved itself. **Critically, the original (`routes/users.ts:228-236`) resolves the ROLE's effective permissions first and early-returns `null` on an empty set, and only THEN calls `getCallerPermissions`.** A naive façade (`getCallerPermissions(…)` then `checkRolePermissionCeiling(…)`) would invert that: a permission-less role would now trigger a `getUserPermissions` resolution that previously never ran — and on the SSO/system-scope path that can open a *fresh system transaction* (`services/permissions.ts:135`, `runOutsideDbContext(() => withSystemDbAccessContext(…))`). So `validateAssignableRole` **must short-circuit on the empty effective-permission set BEFORE resolving the caller** (see the implementation below).
+- **`checkRoleStructure` is new but not new logic** — it is the subset of `checkRolePermissionCeiling` that does not consult the caller (wildcard-on-custom-role, unknown-permission). Task 3's JIT re-validation falls back to it when the provider's configuring admin is unknowable.
+- **Bare `db`, no context wrapper.** Identical to today: `users.ts` calls run inside the authenticated request's RLS context. Callers that are *not* in a request context (the SSO callback) must wrap the call themselves in `withSystemDbAccessContext` — Task 3 does.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/services/roleAssignment.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Row queues consumed in the exact order the service issues its selects.
+const roleRowQueue: unknown[][] = [];
+const permRowQueue: Array<Array<{ resource: string; action: string }>> = [];
+
+vi.mock('../db', () => {
+  const selectChain = (queue: unknown[][]) => ({
+    from: () => ({
+      where: () => ({ limit: () => Promise.resolve(queue.shift() ?? []) }),
+      innerJoin: () => ({ where: () => Promise.resolve(queue.shift() ?? []) }),
+    }),
+  });
+  return {
+    db: {
+      select: (fields?: Record<string, unknown>) => {
+        // The permissions join selects { resource, action }; everything else is a role row.
+        const isPermSelect = !!fields && 'resource' in fields && 'action' in fields;
+        return selectChain(isPermSelect ? (permRowQueue as unknown[][]) : roleRowQueue);
+      },
+    },
+  };
+});
+
+const callerPerms = { permissions: [] as Array<{ resource: string; action: string }> };
+vi.mock('./permissions', () => ({
+  getUserPermissions: vi.fn(async () => callerPerms),
+  hasPermission: vi.fn((perms: typeof callerPerms, resource: string, action: string) =>
+    perms.permissions.some(
+      (p) => (p.resource === resource || p.resource === '*') && (p.action === action || p.action === '*'),
+    ),
+  ),
+  isAssignablePermission: vi.fn((p: { resource: string }) => p.resource !== 'unknown'),
+  PERMISSIONS: {},
+}));
+
+import {
+  getScopeContext,
+  checkRoleStructure,
+  checkRolePermissionCeiling,
+  validateAssignableRole,
+} from './roleAssignment';
+
+beforeEach(() => {
+  roleRowQueue.length = 0;
+  permRowQueue.length = 0;
+  callerPerms.permissions = [];
+});
+
+describe('getScopeContext', () => {
+  it('returns partner context for a partner-scope auth', () => {
+    expect(getScopeContext({ scope: 'partner', partnerId: 'p1', orgId: null })).toEqual({ scope: 'partner', partnerId: 'p1' });
+  });
+  it('returns organization context for an org-scope auth', () => {
+    expect(getScopeContext({ scope: 'organization', partnerId: null, orgId: 'o1' })).toEqual({ scope: 'organization', orgId: 'o1' });
+  });
+  it('throws 403 for system scope (no tenant axis)', () => {
+    expect(() => getScopeContext({ scope: 'system', partnerId: null, orgId: null })).toThrow();
+  });
+});
+
+describe('checkRolePermissionCeiling', () => {
+  it('allows a role whose permissions are a subset of the caller permissions', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: 'devices', action: 'read' }]);
+    callerPerms.permissions = [{ resource: 'devices', action: 'read' }];
+    expect(await checkRolePermissionCeiling(callerPerms as never, { id: 'r1', isSystem: false })).toBeNull();
+  });
+
+  it('rejects a role with a permission the caller does not hold', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: 'users', action: 'write' }]);
+    callerPerms.permissions = [{ resource: 'devices', action: 'read' }];
+    expect(await checkRolePermissionCeiling(callerPerms as never, { id: 'r1', isSystem: false }))
+      .toBe('Cannot assign a role with permission not held by caller: users:write');
+  });
+
+  it('rejects a CUSTOM role carrying a wildcard permission', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: '*', action: '*' }]);
+    callerPerms.permissions = [{ resource: '*', action: '*' }];
+    expect(await checkRolePermissionCeiling(callerPerms as never, { id: 'r1', isSystem: false }))
+      .toBe('Custom roles with wildcard permissions cannot be assigned');
+  });
+
+  it('rejects an unknown permission', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: 'unknown', action: 'read' }]);
+    callerPerms.permissions = [{ resource: 'unknown', action: 'read' }];
+    expect(await checkRolePermissionCeiling(callerPerms as never, { id: 'r1', isSystem: false }))
+      .toBe('Role contains unknown permission: unknown:read');
+  });
+
+  it('returns "No permissions found" when the caller has none', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: 'devices', action: 'read' }]);
+    expect(await checkRolePermissionCeiling(null, { id: 'r1', isSystem: false })).toBe('No permissions found');
+  });
+
+  it('allows a role with zero effective permissions regardless of caller', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([]);
+    expect(await checkRolePermissionCeiling(null, { id: 'r1', isSystem: false })).toBeNull();
+  });
+});
+
+describe('checkRoleStructure', () => {
+  it('rejects wildcard on a custom role without consulting any caller', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: '*', action: '*' }]);
+    expect(await checkRoleStructure({ id: 'r1', isSystem: false }))
+      .toBe('Custom roles with wildcard permissions cannot be assigned');
+  });
+
+  it('allows a wildcard on a SYSTEM role', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: '*', action: '*' }]);
+    expect(await checkRoleStructure({ id: 'r1', isSystem: true })).toBeNull();
+  });
+
+  it('rejects an unknown permission', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: 'unknown', action: 'read' }]);
+    expect(await checkRoleStructure({ id: 'r1', isSystem: false }))
+      .toBe('Role contains unknown permission: unknown:read');
+  });
+});
+
+describe('validateAssignableRole', () => {
+  it('resolves the caller permissions from the Hono context when present', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([{ resource: 'devices', action: 'read' }]);
+    const ctxPerms = { permissions: [{ resource: 'devices', action: 'read' }] };
+    const c = { get: (k: string) => (k === 'permissions' ? ctxPerms : undefined) };
+    expect(await validateAssignableRole(c, { user: { id: 'u1' }, scope: 'partner', partnerId: 'p1', orgId: null }, { id: 'r1', isSystem: false }))
+      .toBeNull();
+  });
+
+  // I7: order is load-bearing — a permission-less role must NOT trigger a
+  // getUserPermissions resolution (which on the system-scope path opens a fresh
+  // system transaction, permissions.ts:135). The original short-circuited first.
+  it('does NOT resolve caller permissions for a role with zero effective permissions', async () => {
+    roleRowQueue.push([{ parentRoleId: null }]);
+    permRowQueue.push([]); // no effective permissions
+    const c = { get: () => undefined };
+    expect(await validateAssignableRole(c, { user: { id: 'u1' }, scope: 'partner', partnerId: 'p1', orgId: null }, { id: 'r1', isSystem: false }))
+      .toBeNull();
+    expect(getUserPermissions).not.toHaveBeenCalled();
+  });
+});
+```
+
+(Import `getUserPermissions` in the test file — `import { getUserPermissions } from './permissions';` — so the `not.toHaveBeenCalled()` assertion binds to the mocked fn.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/services/roleAssignment.test.ts
+```
+Expected: **FAIL** — cannot find module `./roleAssignment`.
+
+- [ ] **Step 3: Implement — create the service**
+
+Create `apps/api/src/services/roleAssignment.ts`:
+
+```ts
+import { eq } from 'drizzle-orm';
+import { HTTPException } from 'hono/http-exception';
+import { db } from '../db';
+import { roles, permissions, rolePermissions } from '../db/schema';
+import {
+  getUserPermissions,
+  hasPermission,
+  isAssignablePermission,
+  type UserPermissions,
+} from './permissions';
+
+/**
+ * Canonical assignable-role validation. Lifted VERBATIM out of routes/users.ts
+ * (where it was module-private) so SSO default-role configuration and JIT
+ * provisioning enforce the SAME permission-subset ceiling as ordinary user
+ * administration (SR2-10). Do not fork a second copy: routes/users.ts and
+ * routes/sso.ts both consume this module.
+ *
+ * Every returned message string is byte-identical to the pre-extraction
+ * behavior — routes/users.test.ts asserts on them.
+ *
+ * DB CONTEXT: these functions use the ambient `db`. routes/users.ts calls them
+ * inside the authenticated request's RLS context (correct). A caller with NO
+ * request context — the unauthenticated /sso/callback — must wrap the call in
+ * withSystemDbAccessContext itself.
+ */
+
+export type ScopeContext =
+  | { scope: 'partner'; partnerId: string }
+  | { scope: 'organization'; orgId: string };
+
+export interface AuthLike {
+  user: { id: string };
+  scope?: string;
+  partnerId: string | null;
+  orgId: string | null;
+}
+
+export interface AssignableRoleRow {
+  id: string;
+  scope: string;
+  name: string;
+  description: string | null;
+  isSystem: boolean;
+  parentRoleId: string | null;
+  partnerId: string | null;
+  orgId: string | null;
+}
+
+export function getScopeContext(auth: { scope: string; partnerId: string | null; orgId: string | null }): ScopeContext {
+  if (auth.scope === 'partner' && auth.partnerId) {
+    return { scope: 'partner', partnerId: auth.partnerId };
+  }
+
+  if (auth.scope === 'organization' && auth.orgId) {
+    return { scope: 'organization', orgId: auth.orgId };
+  }
+
+  throw new HTTPException(403, { message: 'Partner or organization context required' });
+}
+
+export async function getScopedRole(roleId: string, scopeContext: ScopeContext): Promise<AssignableRoleRow | null> {
+  const [role] = await db
+    .select({
+      id: roles.id,
+      scope: roles.scope,
+      name: roles.name,
+      description: roles.description,
+      isSystem: roles.isSystem,
+      parentRoleId: roles.parentRoleId,
+      partnerId: roles.partnerId,
+      orgId: roles.orgId
+    })
+    .from(roles)
+    .where(eq(roles.id, roleId))
+    .limit(1);
+
+  if (!role || role.scope !== scopeContext.scope) {
+    return null;
+  }
+
+  if (role.isSystem) {
+    return role as AssignableRoleRow;
+  }
+
+  if (scopeContext.scope === 'partner' && role.partnerId === scopeContext.partnerId) {
+    return role as AssignableRoleRow;
+  }
+
+  if (scopeContext.scope === 'organization' && role.orgId === scopeContext.orgId) {
+    return role as AssignableRoleRow;
+  }
+
+  return null;
+}
+
+export async function getEffectiveRolePermissions(
+  roleId: string,
+  visited: Set<string> = new Set()
+): Promise<Array<{ resource: string; action: string }>> {
+  if (visited.has(roleId)) return [];
+  visited.add(roleId);
+
+  const [role] = await db
+    .select({ parentRoleId: roles.parentRoleId })
+    .from(roles)
+    .where(eq(roles.id, roleId))
+    .limit(1);
+
+  const directPermissions = await db
+    .select({
+      resource: permissions.resource,
+      action: permissions.action
+    })
+    .from(rolePermissions)
+    .innerJoin(permissions, eq(rolePermissions.permissionId, permissions.id))
+    .where(eq(rolePermissions.roleId, roleId));
+
+  if (!role?.parentRoleId) {
+    return directPermissions;
+  }
+
+  const inheritedPermissions = await getEffectiveRolePermissions(role.parentRoleId, visited);
+  const result = new Map<string, { resource: string; action: string }>();
+  for (const permission of [...directPermissions, ...inheritedPermissions]) {
+    result.set(`${permission.resource}:${permission.action}`, permission);
+  }
+  return [...result.values()];
+}
+
+export async function getCallerPermissions(
+  c: any,
+  auth: AuthLike
+): Promise<UserPermissions | null> {
+  const existing = c?.get?.('permissions') as UserPermissions | undefined;
+  if (existing) return existing;
+
+  return getUserPermissions(auth.user.id, {
+    partnerId: auth.partnerId || undefined,
+    orgId: auth.orgId || undefined
+  });
+}
+
+/**
+ * Caller-INDEPENDENT structural checks: a custom role may not carry wildcard
+ * permissions, and every permission must be a known one. This is the subset of
+ * the ceiling check that can still be applied when no caller identity is
+ * available (SSO JIT against a provider with no resolvable configurer).
+ */
+export async function checkRoleStructure(
+  role: Pick<AssignableRoleRow, 'id' | 'isSystem'>
+): Promise<string | null> {
+  const rolePermissionsForAssignment = await getEffectiveRolePermissions(role.id);
+  if (rolePermissionsForAssignment.length === 0) {
+    return null;
+  }
+
+  for (const permission of rolePermissionsForAssignment) {
+    if (permission.resource === '*' || permission.action === '*') {
+      if (!role.isSystem) {
+        return 'Custom roles with wildcard permissions cannot be assigned';
+      }
+      continue;
+    }
+    if (!isAssignablePermission(permission)) {
+      return `Role contains unknown permission: ${permission.resource}:${permission.action}`;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Full ceiling check against an ALREADY-RESOLVED caller permission set. Returns
+ * an error message string, or null when the role is assignable.
+ */
+export async function checkRolePermissionCeiling(
+  callerPermissions: UserPermissions | null,
+  role: Pick<AssignableRoleRow, 'id' | 'isSystem'>
+): Promise<string | null> {
+  const rolePermissionsForAssignment = await getEffectiveRolePermissions(role.id);
+  if (rolePermissionsForAssignment.length === 0) {
+    return null;
+  }
+
+  if (!callerPermissions) {
+    return 'No permissions found';
+  }
+
+  for (const permission of rolePermissionsForAssignment) {
+    if (permission.resource === '*' || permission.action === '*') {
+      if (!role.isSystem) {
+        return 'Custom roles with wildcard permissions cannot be assigned';
+      }
+      if (!hasPermission(callerPermissions, permission.resource, permission.action)) {
+        return 'Cannot assign a role broader than caller permissions';
+      }
+      continue;
+    }
+
+    if (!isAssignablePermission(permission)) {
+      return `Role contains unknown permission: ${permission.resource}:${permission.action}`;
+    }
+
+    if (!hasPermission(callerPermissions, permission.resource, permission.action)) {
+      return `Cannot assign a role with permission not held by caller: ${permission.resource}:${permission.action}`;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Behavior-preserving façade retained for routes/users.ts.
+ *
+ * ORDER IS LOAD-BEARING. The original resolved the ROLE's effective permissions
+ * first and early-returned null on an empty set, only THEN touching
+ * getCallerPermissions. Calling getCallerPermissions unconditionally would make
+ * a permission-less role trigger a getUserPermissions resolution that never ran
+ * before — which on the system-scope path opens a fresh system transaction
+ * (services/permissions.ts:135). So: short-circuit FIRST, resolve the caller
+ * SECOND.
+ */
+export async function validateAssignableRole(
+  c: any,
+  auth: AuthLike,
+  role: Pick<AssignableRoleRow, 'id' | 'isSystem'>
+): Promise<string | null> {
+  const rolePermissionsForAssignment = await getEffectiveRolePermissions(role.id);
+  if (rolePermissionsForAssignment.length === 0) {
+    return null; // no caller resolution — matches the original's side effects exactly
+  }
+  const callerPermissions = await getCallerPermissions(c, auth);
+  return checkRolePermissionCeiling(callerPermissions, role);
+}
+```
+
+> `checkRolePermissionCeiling` re-resolves the effective permissions itself (it is also called directly by Task 3 with a pre-resolved permission set). That is one extra recursive role walk on the `users.ts` path versus today — acceptable, and strictly cheaper than the alternative (an inverted side-effect order that opens a system transaction). If a reviewer objects to the double walk, thread the resolved array in as an optional 3rd arg; do **not** "fix" it by reordering.
+>
+> Also preserve the order *inside* `checkRolePermissionCeiling`: empty-set short-circuit BEFORE the `!callerPermissions` → `'No permissions found'` check. Inverting that changes the return value for permission-less roles and will red `users.test.ts`.
+
+- [ ] **Step 4: Implement — rewire `routes/users.ts`**
+
+In `apps/api/src/routes/users.ts`:
+
+1. **Delete** `type ScopeContext` (`:125-127`), `getScopeContext` (`:129-139`), `getScopedRole` (`:141-174`), `getEffectiveRolePermissions` (`:176-208`), `getCallerPermissions` (`:210-221`), and `validateAssignableRole` (`:223-259`).
+2. Add the import next to the other `../services/*` imports:
+   ```ts
+   import {
+     getScopeContext,
+     getScopedRole,
+     validateAssignableRole,
+     type ScopeContext,
+   } from '../services/roleAssignment';
+   ```
+3. Leave both call sites (`:1123-1130` user invite, `:1658-1665` role assignment) **completely untouched** — the imported names and signatures are identical.
+4. Run `grep -n "permissions\|rolePermissions\|isAssignablePermission\|hasPermission\|HTTPException" apps/api/src/routes/users.ts` and prune any import that is now unused (`isAssignablePermission` and the `permissions`/`rolePermissions` schema tables are the likely orphans; `hasPermission`, `HTTPException` and `getUserPermissions` may still be used elsewhere in the file — **check, do not assume**). `pnpm typecheck` (Step 5) is the authority: `noUnusedLocals` will flag them if they are dead.
+
+- [ ] **Step 5: Run to verify it passes**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/services/roleAssignment.test.ts src/routes/users.test.ts && pnpm typecheck
+```
+Expected: **PASS**, with `users.test.ts` green **without a single edit to it**. If `users.test.ts` needed edits, the refactor was not behavior-preserving — revert and re-do.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/roleAssignment.ts apps/api/src/services/roleAssignment.test.ts apps/api/src/routes/users.ts
+git commit -m "refactor(auth): extract canonical assignable-role validator into services/roleAssignment (SR2-10 prep)"
+```
+
+---
+
+### Task 3: SR2-10 — SSO role delegation on both axes + JIT re-validation
+
+**Files:**
+- Modify: `apps/api/src/routes/sso.ts` — POST `/providers` (`:471-585`, partner branch `:484-512`, org branch `:505-511`), PATCH `/providers/:id` (`:586-660`, role block `:615-628`), callback default-role block (`:1440-1469`), JIT block (`:1716-1778`)
+- Test: `apps/api/src/routes/sso.test.ts`
+
+**Interfaces:**
+- Consumes (Task 2): `getScopedRole`, `validateAssignableRole`, `checkRoleStructure`, `checkRolePermissionCeiling`, `type ScopeContext`, `type AssignableRoleRow` from `'../services/roleAssignment'`; `getUserPermissions` from `'../services/permissions'` (already imported? — `sso.ts:41` imports `PERMISSIONS` from there; extend that import).
+- Produces (used only inside `sso.ts`):
+  ```ts
+  /** Resolve the ScopeContext for a provider's OWN axis (never the caller's). */
+  function providerScopeContext(p: { orgId: string | null; partnerId: string | null }): ScopeContext | null;
+
+  /**
+   * Re-validate a provider's defaultRoleId immediately before JIT provisioning.
+   * Runs inside withSystemDbAccessContext (the callback has no request context).
+   */
+  async function revalidateSsoDefaultRole(params: {
+    roleId: string;
+    scopeContext: ScopeContext;
+    configuredByUserId: string | null;
+  }): Promise<{ ok: true; roleId: string } | { ok: false; reason: string }>;
+  ```
+
+**Decisions (documented here — reviewer should challenge the third):**
+- **Config-time validation runs on BOTH axes.** Today the partner axis checks existence + scope + tenant (`sso.ts:484-512`, `:615-628`) and **the org axis — the only axis that does JIT — checks nothing at all**; `defaultRoleId` flows straight into the INSERT (`:560`) and the `...body` UPDATE (`:630-643`). Both axes now go through `getScopedRole` (existence + scope + tenant, same guarantees as before on the partner axis) **plus** `validateAssignableRole` (permission-subset vs the configuring admin, wildcard-on-custom rejection, unknown-permission rejection).
+- **The ScopeContext comes from the PROVIDER's axis, never `getScopeContext(auth)`.** These routes admit `requireScope('organization', 'partner', 'system')`, and `getScopeContext` throws 403 for `system`. Using the provider's own axis is also simply more correct: the role must belong to the tenant the provider provisions into.
+- **System-scope callers skip the permission-subset ceiling, but still get `checkRoleStructure`.** A platform admin has no `orgId`/`partnerId`, so `getUserPermissions(userId, {})` cannot resolve a meaningful tenant permission set — running the ceiling check would spuriously reject with `'No permissions found'`. A platform admin is by definition above every tenant ceiling. They still cannot attach a custom wildcard role or a role with unknown permissions.
+- **JIT re-validation ceiling = `sso_providers.default_role_configured_by` (Task 1's new column), resolved LIVE, falling back to `created_by`, then to structural-only.** The design says validation runs "again immediately before JIT provisioning", but the callback has no caller — so the ceiling that must still hold is the *configurer's*: an SSO default role may not outlive the authority of the admin who configured it (the same principle SR2-15 applies to API keys). **`created_by` alone is the wrong principal** — see Task 1's decisions: it names the original creator while config-time validates the current caller (so Admin B could save a role Admin A cannot support → the provider saves but fails JIT forever, silently), and no route rewrites it (so an offboarded creator bricks the provider, which cannot be recreated without orphaning every `user_sso_identities` row). `default_role_configured_by` is stamped by **every write that sets `defaultRoleId`** (POST + PATCH, Step 3 below), which both collapses the principal mismatch and makes "re-save the default role as a current admin" the repair.
+- **Resolve the configurer's permissions on BOTH axes, not one.** `getUserPermissions(userId, { orgId })` runs only `resolveOrgAxis` (`services/permissions.ts:187-193`), which requires an `organization_users` row. **An MSP partner admin configuring SSO for a customer org has no such row** — they act through `partner_users` + `orgAccess`, and `POST /providers` explicitly admits partner scope. Passing only `{ orgId }` would return `null` → ceiling check → `default_role_exceeds_configurer_permissions` → **every JIT sign-in on that provider fails, forever**, on the most normal MSP topology there is. (This is invisible at config time, which uses `getCallerPermissions` → `c.get('permissions')` — the already-resolved partner set.) So the JIT path passes **`{ orgId: provider.orgId, partnerId: <organizations.partnerId for that org> }`** — one extra select in system context — and lets `getUserPermissions`'s own org→partner fall-through (`permissions.ts:187-193`) do the work. Task 8 carries the integration proof (a provider created by a partner admin with **no** org membership must JIT successfully).
+- **Both `default_role_configured_by` AND `created_by` NULL (legacy/seeded rows) → structural-only re-validation, not a hard fail.** Hard-failing would break JIT for every pre-API provider row on upgrade, for zero attacker-relevant gain (the role still must be scope-correct, tenant-correct, non-wildcard, and known-permission). **This is the one path where the permission ceiling is NOT applied, so it is LOUDLY AUDITED** — a real `writeRouteAudit` event (`action: 'sso.callback.jit_ceiling_skipped'`), not a `console.warn`. The repair is a one-click re-save of the default role, which stamps `default_role_configured_by`. Reviewer: challenge this if you prefer the hard fail.
+- **Rejection surface:** config time → `400 { error: <the validator's message> }` (identical style to today's `defaultRoleId must be a partner-scoped role…`). JIT time → the existing `/login?error=invalid_provider_configuration` redirect, plus a specific audit reason.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `apps/api/src/routes/sso.test.ts`, first extend the mock surface (this is a prerequisite for the tests to even import):
+
+```ts
+// NEW — services/roleAssignment.ts is a distinct module path; vi.mock('../services')
+// does NOT cover it.
+const { roleAssignmentGate } = vi.hoisted(() => ({
+  roleAssignmentGate: {
+    scopedRole: null as { id: string; isSystem: boolean; scope: string; orgId: string | null; partnerId: string | null } | null,
+    assignError: null as string | null,
+    structureError: null as string | null,
+    ceilingError: null as string | null,
+  },
+}));
+
+vi.mock('../services/roleAssignment', () => ({
+  getScopedRole: vi.fn(async () => roleAssignmentGate.scopedRole),
+  validateAssignableRole: vi.fn(async () => roleAssignmentGate.assignError),
+  checkRoleStructure: vi.fn(async () => roleAssignmentGate.structureError),
+  checkRolePermissionCeiling: vi.fn(async () => roleAssignmentGate.ceilingError),
+}));
+```
+
+Reset it in `beforeEach` (`:255-308`):
+
+```ts
+  roleAssignmentGate.scopedRole = { id: 'role-1', isSystem: false, scope: 'organization', orgId: '00000000-0000-4000-8000-000000000010', partnerId: null };
+  roleAssignmentGate.assignError = null;
+  roleAssignmentGate.structureError = null;
+  roleAssignmentGate.ceilingError = null;
+```
+
+Then add a `describe('SSO default-role delegation (SR2-10)', …)` with:
+
+1. **`POST /providers` (org axis) rejects a defaultRoleId above the caller's ceiling** — set `roleAssignmentGate.assignError = 'Cannot assign a role with permission not held by caller: users:write'`; POST a provider with `ownerScope:'organization'` + `defaultRoleId`; expect **400** with that exact message (400, not 403 — it matches the existing `defaultRoleId must be a partner-scoped role…` rejection style on this route and Step 3's implementation), and assert `db.insert` was **never** called.
+2. **`POST /providers` (org axis) rejects an unknown `defaultRoleId`** — `roleAssignmentGate.scopedRole = null` → expect 400 `defaultRoleId must be an organization-scoped role belonging to this organization`.
+3. **`POST /providers` (org axis) accepts an in-ceiling role** — gate returns a role and `assignError = null` → 201.
+4. **`PATCH /providers/:id` (org axis) rejects an out-of-ceiling defaultRoleId** — same shape; assert `db.update` never called.
+5. **Callback JIT re-validates** — prime a callback for a new (unlinked, unknown-email) org-axis user with `autoProvision:true` and a `defaultRoleId`; set `roleAssignmentGate.ceilingError = 'Cannot assign a role broader than caller permissions'` → expect a redirect to `/login?error=invalid_provider_configuration` and assert **no `users` insert** happened.
+6. **`POST` / `PATCH` stamp `defaultRoleConfiguredBy`** — capture the `db.insert().values()` payload from a `POST /providers` carrying a `defaultRoleId` and assert `defaultRoleConfiguredBy === auth.user.id`; capture the `db.update().set()` payload from a `PATCH` carrying a `defaultRoleId` and assert the same. Also assert a `PATCH` **without** `defaultRoleId` does **not** include the key (it must not be clobbered to null by an unrelated edit).
+7. **Unknown configurer → JIT proceeds but emits the ceiling-skipped audit** — provider row with `defaultRoleConfiguredBy: null` and `createdBy: null`, `structureError = null` → the user IS provisioned, and `writeRouteAudit` was called with `action: 'sso.callback.jit_ceiling_skipped'`. (Mock/spy `writeRouteAudit` via `vi.mock('../services/auditEvents')` if the suite does not already; check first — `sso.ts:36` imports it.)
+
+**Two more mock prerequisites:**
+- `revalidateSsoDefaultRole` calls `getUserPermissions` (`../services/permissions`), which `sso.ts` does not currently import. Extend the existing `import { PERMISSIONS } from '../services/permissions'` (`sso.ts:41`) rather than adding a second import line, and **mock the module in the test while KEEPING `PERMISSIONS` real** (the route's `requirePermission(PERMISSIONS.SSO_ADMIN.resource, …)` guard reads it at module scope):
+  ```ts
+  vi.mock('../services/permissions', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../services/permissions')>()),
+    getUserPermissions: vi.fn(async () => ({ permissions: [{ resource: '*', action: '*' }] })),
+  }));
+  ```
+- **`db.select()` QUEUE SHIFT (org-axis JIT only):** `revalidateSsoDefaultRole` issues **one extra `db.select`** (the `organizations.partnerId` lookup) — but *only* when a configurer resolves, and it lives inside the function, which the tests above mock wholesale. So with `vi.mock('../services/roleAssignment')` in place, the callback queues are **unchanged**. The moment an implementer un-mocks it (don't), the queues shift. POST/PATCH queues are likewise unchanged because the mocked `getScopedRole` never touches `db`. **Verify by running the whole file, not just `-t`.**
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/sso.test.ts -t 'SR2-10'
+```
+Expected: **FAIL** — the org axis validates nothing (the provider is created with an arbitrary `defaultRoleId`), and the callback's JIT applies `validatedDefaultRoleId` with no permission check.
+
+- [ ] **Step 3: Implement — config-time validation on both axes**
+
+In `apps/api/src/routes/sso.ts`, add the import (next to the `partnerWideAccess` import at `:38`):
+
+```ts
+import {
+  getScopedRole,
+  validateAssignableRole,
+  checkRoleStructure,
+  checkRolePermissionCeiling,
+  type ScopeContext,
+} from '../services/roleAssignment';
+import { getUserPermissions } from '../services/permissions'; // extend the existing `PERMISSIONS` import on :41 instead of adding a second line
+```
+
+Add these two helpers near `getOIDCConfig` (after `buildSsoCallbackUri`, ~`:288`):
+
+```ts
+/**
+ * The ScopeContext a provider's defaultRoleId must satisfy — the PROVIDER's own
+ * axis, never the caller's. These routes admit system scope, for which
+ * getScopeContext(auth) throws; and the role must belong to the tenant the
+ * provider provisions into, which is the provider's axis by definition.
+ */
+function providerScopeContext(p: { orgId: string | null; partnerId: string | null }): ScopeContext | null {
+  if (p.partnerId) return { scope: 'partner', partnerId: p.partnerId };
+  if (p.orgId) return { scope: 'organization', orgId: p.orgId };
+  return null;
+}
+
+/**
+ * SR2-10 config-time gate, shared by POST /providers and PATCH /providers/:id.
+ * Returns an error message (caller returns 400) or null.
+ *
+ * Both axes go through the SAME canonical validator routes/users.ts uses. The
+ * org axis validated NOTHING before this change — and it is the only axis that
+ * JIT-provisions, so an org admin could delegate a role broader than their own
+ * authority to every future SSO sign-in.
+ *
+ * A system-scope (platform-admin) caller skips the permission-subset ceiling:
+ * they have no orgId/partnerId, so getUserPermissions cannot resolve a tenant
+ * permission set, and a platform admin is above every tenant ceiling anyway.
+ * They still cannot attach a custom wildcard role or an unknown permission.
+ */
+async function validateProviderDefaultRole(
+  c: any,
+  auth: AuthContext,
+  defaultRoleId: string,
+  scopeContext: ScopeContext,
+): Promise<string | null> {
+  const role = await getScopedRole(defaultRoleId, scopeContext);
+  if (!role) {
+    return scopeContext.scope === 'partner'
+      ? 'defaultRoleId must be a partner-scoped role belonging to your partner'
+      : 'defaultRoleId must be an organization-scoped role belonging to this organization';
+  }
+  if (auth.scope === 'system') {
+    return checkRoleStructure(role);
+  }
+  return validateAssignableRole(c, auth, role);
+}
+```
+
+**POST `/providers`** — in the partner branch (`:484-512`), **replace** the ad-hoc role select with:
+
+```ts
+    if (body.defaultRoleId) {
+      const roleError = await validateProviderDefaultRole(
+        c, auth, body.defaultRoleId, { scope: 'partner', partnerId: auth.partnerId },
+      );
+      if (roleError) {
+        return c.json({ error: roleError }, 400);
+      }
+    }
+```
+
+In the org branch, immediately after `ownerColumns = { orgId: orgResult.orgId, partnerId: null };` (`:511`), **add** (this validation does not exist today):
+
+```ts
+    if (body.defaultRoleId) {
+      const roleError = await validateProviderDefaultRole(
+        c, auth, body.defaultRoleId, { scope: 'organization', orgId: orgResult.orgId },
+      );
+      if (roleError) {
+        return c.json({ error: roleError }, 400);
+      }
+    }
+```
+
+**PATCH `/providers/:id`** — replace the partner-only role block (`:615-628`) with an axis-aware one. Note `existing` is selected with `{ id, orgId, partnerId }` (`:601-605`), which is everything `providerScopeContext` needs:
+
+```ts
+  if (body.defaultRoleId) {
+    const scopeContext = providerScopeContext(existing);
+    if (!scopeContext) {
+      return c.json({ error: 'Provider has no owning organization or partner' }, 400);
+    }
+    const roleError = await validateProviderDefaultRole(c, auth, body.defaultRoleId, scopeContext);
+    if (roleError) {
+      return c.json({ error: roleError }, 400);
+    }
+  }
+```
+
+**Stamp the JIT principal on every write that sets `defaultRoleId`** (SR2-10, Task 1's `default_role_configured_by`). In **POST `/providers`**, add to the `.values({ … })` (`:552-568`):
+
+```ts
+      defaultRoleId: body.defaultRoleId,
+      // The admin whose LIVE permission ceiling the callback re-checks this role
+      // against before JIT. Stamped only when a role is actually delegated.
+      defaultRoleConfiguredBy: body.defaultRoleId ? auth.user.id : null,
+```
+
+In **PATCH `/providers/:id`**, fold it into `updates` (which also gains `configVersion` in Task 4):
+
+```ts
+  const updates: Partial<typeof ssoProviders.$inferInsert> = {
+    ...body,
+    updatedAt: new Date(),
+    // Re-stamp the JIT principal whenever the delegated role is (re-)set. This is
+    // the repair path when the previous configurer offboards: re-saving the
+    // default role as a current admin re-points the ceiling at a live account.
+    ...(body.defaultRoleId ? { defaultRoleConfiguredBy: auth.user.id } : {}),
+  };
+```
+
+> `updateProviderSchema` is `createProviderSchema.omit({ orgId: true, ownerScope: true }).partial()`, so `defaultRoleId` is already an accepted PATCH field — no schema change. `defaultRoleConfiguredBy` is **not** in either schema and must never be client-settable.
+
+- [ ] **Step 4: Implement — JIT re-validation in the callback**
+
+Add `revalidateSsoDefaultRole` next to the helpers above:
+
+```ts
+/**
+ * SR2-10 JIT gate. Runs immediately before an SSO callback provisions a NEW
+ * user with the provider's defaultRoleId. Re-checks (a) the role still exists on
+ * the provider's axis, and (b) the role's effective permissions are still within
+ * the LIVE permission ceiling of the admin who configured the delegation — an
+ * SSO default role must not outlive its configurer's authority.
+ *
+ * PRINCIPAL: default_role_configured_by (stamped by every write that SETS
+ * defaultRoleId), falling back to created_by for rows that predate that column,
+ * then to STRUCTURAL-only re-validation when neither resolves.
+ *
+ * BOTH AXES are passed to getUserPermissions. Passing only { orgId } for an
+ * org-axis provider would run only resolveOrgAxis (permissions.ts:187-193),
+ * which needs an organization_users row — and an MSP PARTNER ADMIN configuring
+ * SSO for a customer org has none (they act via partner_users + orgAccess). That
+ * would return null -> ceiling failure -> every JIT sign-in on that provider
+ * fails forever, on the most normal MSP topology. Supplying both lets
+ * getUserPermissions' own org->partner fall-through resolve them correctly.
+ *
+ * `skippedCeiling` is returned (not swallowed) so the caller can emit a LOUD
+ * audit: this is the one path where the permission ceiling is not applied.
+ *
+ * MUST be called inside withSystemDbAccessContext — /sso/callback has no request
+ * context, so a bare read here silently returns 0 rows under RLS.
+ */
+async function revalidateSsoDefaultRole(params: {
+  roleId: string;
+  scopeContext: ScopeContext;
+  configuredByUserId: string | null;
+}): Promise<
+  | { ok: true; roleId: string; skippedCeiling: boolean }
+  | { ok: false; reason: string }
+> {
+  const role = await getScopedRole(params.roleId, params.scopeContext);
+  if (!role) {
+    return { ok: false, reason: 'default_role_not_on_provider_axis' };
+  }
+
+  if (!params.configuredByUserId) {
+    const structureError = await checkRoleStructure(role);
+    return structureError
+      ? { ok: false, reason: 'default_role_structure_invalid' }
+      : { ok: true, roleId: role.id, skippedCeiling: true };
+  }
+
+  // Resolve the tenant axes to hand getUserPermissions. For an ORG-axis provider
+  // we also supply the org's owning partner, so a partner admin with no
+  // organization_users row still resolves through the partner axis.
+  let orgId: string | undefined;
+  let partnerId: string | undefined;
+  if (params.scopeContext.scope === 'organization') {
+    orgId = params.scopeContext.orgId;
+    const [org] = await db
+      .select({ partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+    partnerId = org?.partnerId ?? undefined;
+  } else {
+    partnerId = params.scopeContext.partnerId;
+  }
+
+  const configurerPermissions = await getUserPermissions(params.configuredByUserId, { orgId, partnerId });
+  const ceilingError = await checkRolePermissionCeiling(configurerPermissions, role);
+  return ceilingError
+    ? { ok: false, reason: 'default_role_exceeds_configurer_permissions' }
+    : { ok: true, roleId: role.id, skippedCeiling: false };
+}
+```
+
+(`organizations` is already imported into `routes/sso.ts` at `:8-18`.)
+
+In the callback's JIT block (`:1716-1778`), **immediately after** the `if (!validatedDefaultRoleId) { … default_role_required }` guard and **before** `const provisionOrgId = provider.orgId!;`, insert:
+
+```ts
+      // SR2-10: re-validate the delegated role against LIVE state at the moment
+      // of provisioning — the config-time check ran when the provider was saved,
+      // possibly months ago and by an admin who has since been demoted.
+      const jitScope = providerScopeContext(provider);
+      const jitRole = jitScope
+        ? await withSystemDbAccessContext(() =>
+            revalidateSsoDefaultRole({
+              roleId: validatedDefaultRoleId!,
+              scopeContext: jitScope,
+              // The admin who last SET the delegated role; fall back to the
+              // original creator for rows predating that column.
+              configuredByUserId: provider.defaultRoleConfiguredBy ?? provider.createdBy ?? null,
+            }),
+          )
+        : ({ ok: false, reason: 'provider_axis_missing' } as const);
+
+      if (!jitRole.ok) {
+        writeRouteAudit(c, {
+          orgId: provider.orgId,
+          action: 'sso.callback.rejected',
+          resourceType: 'sso_provider',
+          resourceId: provider.id,
+          resourceName: provider.name,
+          result: 'denied',
+          details: { mode: 'login', phase: 'jit_default_role', reason: jitRole.reason, partnerId: provider.partnerId },
+        });
+        clearStateCookie();
+        return c.redirect('/login?error=invalid_provider_configuration');
+      }
+
+      if (jitRole.skippedCeiling) {
+        // The ONE path where the permission ceiling is not applied (no resolvable
+        // configurer — a legacy row). It must be loudly auditable, not a
+        // console.warn: this is a real, if bounded, delegation gap, and the
+        // repair (re-save the default role as a current admin, which stamps
+        // default_role_configured_by) is only discoverable if it is visible.
+        writeRouteAudit(c, {
+          orgId: provider.orgId,
+          action: 'sso.callback.jit_ceiling_skipped',
+          resourceType: 'sso_provider',
+          resourceId: provider.id,
+          resourceName: provider.name,
+          result: 'success',
+          details: {
+            reason: 'default_role_configurer_unknown',
+            providerId: provider.id,
+            roleId: validatedDefaultRoleId,
+            partnerId: provider.partnerId,
+            remediation: 're-save defaultRoleId as a current admin',
+          },
+        });
+      }
+```
+
+(The existing `validatedDefaultRoleId` from `:1440-1469` remains the value inserted into `organization_users` — `jitRole.roleId` is the same id; keep using `validatedDefaultRoleId` so the downstream insert is untouched.)
+
+- [ ] **Step 5: Run to verify they pass**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/sso.test.ts src/routes/users.test.ts
+```
+Expected: **PASS** (full file, not just `-t` — the mock-queue ordering must still hold for every pre-existing test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/sso.ts apps/api/src/routes/sso.test.ts
+git commit -m "feat(sso): permission-subset ceiling on defaultRoleId at config time (both axes) and at JIT (SR2-10)"
+```
+
+---
+
+### Task 4: SR2-11a — provider config version + status/version gate in the callback
+
+**Files:**
+- Modify: `apps/api/src/routes/sso.ts` — PATCH `/providers/:id` (`:630-643`), POST `/providers/:id/status` (`:742-747`), the three session-create sites (`:1098-1106` link, `:1224-1233` partner login, `:1319-1328` org login), callback provider re-read (`:1416-1427`)
+- Test: `apps/api/src/routes/sso.test.ts`
+
+**Interfaces:**
+- Consumes (Task 1): `ssoProviders.configVersion` (`number`), `ssoSessions.providerVersion` (`number | null`), `session.linkUserId` (`string | null`).
+- Produces (used by Task 5 + Task 8):
+  ```ts
+  type SsoCallbackMode = 'login' | 'link';
+  /** Provider must be usable for THIS mode, and the session's snapshot must still match. */
+  function checkProviderGeneration(
+    provider: typeof ssoProviders.$inferSelect,
+    session: typeof ssoSessions.$inferSelect,
+    mode: SsoCallbackMode,
+  ): { ok: true } | { ok: false; reason: 'provider_inactive' | 'provider_not_usable' | 'provider_version_missing' | 'provider_version_mismatch' };
+  ```
+
+**Decisions:**
+- **What bumps the version:** `PATCH /providers/:id` (any field) and `POST /providers/:id/status` (any status transition). Both bump by exactly `+1` in the same `UPDATE` that writes the change — so a config write and its generation bump can never diverge. `POST /providers` starts at the column default `1`. `DELETE` needs no bump (the provider row is gone; the callback's `provider_not_found` redirect already covers it). `POST /providers/:id/test` performs no write → no bump.
+- **Status required at the callback, per mode.** Login-init requires `status='active'` (`:1294-1297`, `:1202-1205`); link-start requires `status !== 'inactive'` (`:1071`, so a `testing` provider may start a link). The callback mirrors **each mode's own init gate**: login mode requires `status === 'active'`; link mode requires `status !== 'inactive'`. Anything stricter would make a `testing` provider's link round-trip impossible to complete — a bug, not a hardening. Today **neither** is checked, so a provider disabled during the ≤10-min window still completes a full login or link.
+- **Version mismatch is a hard reject in BOTH modes**, including `provider_version IS NULL` (pre-deploy rows — see Task 1). This is what makes "provider disablement/configuration changes … invalidate outstanding sessions" true rather than aspirational: even if an admin flips `inactive → active` again inside the window, the two status writes have bumped the version twice and every session minted before them is dead.
+- **Public error codes** (login mode, `/login?error=…`): `sso_provider_inactive`, `sso_config_changed`. Link mode (`/settings/profile?ssoLinkError=…`): `provider_inactive`, `config_changed`. Distinguishable but stateless — no ids, no versions in the URL.
+- **Audit:** `action: 'sso.callback.rejected'`, `result: 'denied'`, `details: { mode, phase: 'provider_generation', reason, providerId, expectedVersion, sessionVersion }`. Version integers are safe to record (they are not secrets). **No `state`, no `code`, no token material.**
+
+- [ ] **Step 1: Write the failing tests**
+
+In `routes/sso.test.ts`, extend the `vi.mock('../db/schema')` `ssoSessions` stub (`:100-156`, currently `ssoSessions: {}`):
+
+```ts
+  ssoSessions: {
+    id: 'id',
+    providerId: 'providerId',
+    state: 'state',
+    nonce: 'nonce',
+    codeVerifier: 'codeVerifier',
+    redirectUrl: 'redirectUrl',
+    linkUserId: 'linkUserId',
+    providerVersion: 'providerVersion',
+    initiatingAuthEpoch: 'initiatingAuthEpoch',
+    initiatingMfaEpoch: 'initiatingMfaEpoch',
+    initiatingSessionId: 'initiatingSessionId',
+    expiresAt: 'expiresAt',
+    createdAt: 'createdAt',
+  },
+```
+
+and add `configVersion: 'configVersion'`, `createdBy: 'createdBy'`, `defaultRoleId: 'defaultRoleId'`, and `defaultRoleConfiguredBy: 'defaultRoleConfiguredBy'` to the `ssoProviders` stub.
+
+Add `describe('SSO provider generation gate (SR2-11)', …)`:
+
+1. **Callback rejects a provider disabled mid-flow (login mode)** — prime the session claim to return `{ …, linkUserId: null, providerVersion: 3 }` and the provider re-read to return `{ …, status: 'inactive', configVersion: 3 }` → expect `302` to `/login?error=sso_provider_inactive`, and assert `createTokenPair` was **not** called.
+2. **Callback rejects a config change mid-flow (login mode)** — session `providerVersion: 3`, provider `status: 'active', configVersion: 4` → `302` to `/login?error=sso_config_changed`; no token mint.
+3. **Callback rejects a NULL `providerVersion` (pre-deploy row)** — session `providerVersion: null`, provider `configVersion: 1` → `302` to `/login?error=sso_config_changed`.
+4. **Callback rejects an inactive provider in LINK mode** — session `{ linkUserId: '…', providerVersion: 2 }`, provider `{ status: 'inactive', configVersion: 2 }` → `302` to `/settings/profile?ssoLinkError=provider_inactive`; assert no `userSsoIdentities` insert.
+5. **Callback ACCEPTS a `testing` provider in LINK mode** (mirrors link-start's own gate) — provider `{ status: 'testing', configVersion: 2 }`, session `providerVersion: 2` → proceeds to the link branch.
+6. **`PATCH /providers/:id` bumps `config_version`** — capture the object passed to the mocked `db.update().set()` and assert it carries a `configVersion` key whose value is an SQL expression (not a literal). Simplest robust assertion: `expect(Object.keys(setPayload)).toContain('configVersion')`.
+7. **`POST /providers/:id/status` bumps `config_version`** — same assertion on the status route's `set()` payload.
+8. **Login init stores the snapshot** — capture the `db.insert(ssoSessions).values()` payload from `GET /login/:orgId` and assert `providerVersion === provider.configVersion`.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/sso.test.ts -t 'SR2-11'
+```
+Expected: **FAIL** — the callback never reads `provider.status` or any version; the writers set no `configVersion`; the session inserts carry no `providerVersion`.
+
+- [ ] **Step 3: Implement — bump the version on every config/status write**
+
+In `routes/sso.ts`, extend the `drizzle-orm` import (`:4`):
+
+```ts
+import { eq, and, gt, ne, isNull, inArray, sql } from 'drizzle-orm';
+```
+(`inArray` is used by Task 6; add it now to avoid two edits to the same line.)
+
+**PATCH `/providers/:id`** — in the `updates` object (`:630-633`, which Task 3 already extended with the `defaultRoleConfiguredBy` stamp):
+
+```ts
+  const updates: Partial<typeof ssoProviders.$inferInsert> = {
+    ...body,
+    updatedAt: new Date(),
+    ...(body.defaultRoleId ? { defaultRoleConfiguredBy: auth.user.id } : {}),   // Task 3
+    // SR2-11: any config change starts a new generation. Every pending
+    // sso_session snapshotted the OLD version and is now dead at the callback.
+    // Bumped in the same UPDATE as the change, so the two can never diverge.
+    configVersion: sql`${ssoProviders.configVersion} + 1` as unknown as number,
+  };
+```
+
+> Tasks 3, 4 and 7 each add a key to this ONE object. The final form (after Task 7 adds `...rediscovered`) is the canonical one — see Task 7 Step 4.
+
+**POST `/providers/:id/status`** — in the `.set(...)` (`:745`):
+
+```ts
+    .set({
+      status,
+      updatedAt: new Date(),
+      // SR2-11: a status change is a config change. Disabling a provider must
+      // kill its outstanding sessions, and re-enabling must not resurrect them
+      // (two writes, two bumps).
+      configVersion: sql`${ssoProviders.configVersion} + 1` as unknown as number,
+    })
+```
+
+- [ ] **Step 4: Implement — snapshot the version at session creation**
+
+All three `db.insert(ssoSessions).values({ … })` sites gain `providerVersion: provider.configVersion`:
+- link start (`:1098-1106`, now wrapped by Task 1),
+- partner login init (`:1224-1233`),
+- org login init (`:1319-1328`).
+
+```ts
+      providerVersion: provider.configVersion,
+```
+
+(All three already have the full `provider` row in scope from a `select()` with no field list.)
+
+- [ ] **Step 5: Implement — the callback gate**
+
+Add the checker next to `revalidateSsoDefaultRole`:
+
+```ts
+type SsoCallbackMode = 'login' | 'link';
+
+/**
+ * SR2-11: a pending SSO transaction is valid only against the provider
+ * GENERATION it was created under, and only while the provider is still usable
+ * for its own mode.
+ *
+ * Status per mode mirrors each mode's INIT gate: /login/* requires
+ * status='active', /link/start requires status!=='inactive' (a `testing`
+ * provider may be linked). Neither was checked at the callback before this
+ * change — a provider disabled inside the <=10-minute state TTL still completed
+ * a full login or link.
+ *
+ * A NULL providerVersion (a row written before the column existed) is a REJECT,
+ * not a pass: those are exactly the unbound sessions this change invalidates.
+ */
+function checkProviderGeneration(
+  provider: typeof ssoProviders.$inferSelect,
+  session: typeof ssoSessions.$inferSelect,
+  mode: SsoCallbackMode,
+):
+  | { ok: true }
+  | { ok: false; reason: 'provider_inactive' | 'provider_not_usable' | 'provider_version_missing' | 'provider_version_mismatch' } {
+  if (provider.status === 'inactive') {
+    return { ok: false, reason: 'provider_inactive' };
+  }
+  if (mode === 'login' && provider.status !== 'active') {
+    return { ok: false, reason: 'provider_not_usable' };
+  }
+  if (session.providerVersion == null) {
+    return { ok: false, reason: 'provider_version_missing' };
+  }
+  if (session.providerVersion !== provider.configVersion) {
+    return { ok: false, reason: 'provider_version_mismatch' };
+  }
+  return { ok: true };
+}
+```
+
+In the callback, **immediately after** the org-XOR-partner guard (`:1436-1440`, the `if (!providerOrgId && !provider.partnerId)` block) and **before** the default-role block (`:1447`), insert:
+
+```ts
+  const callbackMode: SsoCallbackMode = session.linkUserId ? 'link' : 'login';
+
+  const generation = checkProviderGeneration(provider, session, callbackMode);
+  if (!generation.ok) {
+    writeRouteAudit(c, {
+      orgId: provider.orgId,
+      action: 'sso.callback.rejected',
+      resourceType: 'sso_provider',
+      resourceId: provider.id,
+      resourceName: provider.name,
+      result: 'denied',
+      details: {
+        mode: callbackMode,
+        phase: 'provider_generation',
+        reason: generation.reason,
+        partnerId: provider.partnerId,
+        sessionVersion: session.providerVersion,
+        providerVersion: provider.configVersion,
+      },
+    });
+    clearStateCookie();
+    if (callbackMode === 'link') {
+      return c.redirect(
+        generation.reason === 'provider_inactive' || generation.reason === 'provider_not_usable'
+          ? '/settings/profile?ssoLinkError=provider_inactive'
+          : '/settings/profile?ssoLinkError=config_changed',
+      );
+    }
+    return c.redirect(
+      generation.reason === 'provider_inactive' || generation.reason === 'provider_not_usable'
+        ? '/login?error=sso_provider_inactive'
+        : '/login?error=sso_config_changed',
+    );
+  }
+```
+
+- [ ] **Step 6: Run to verify they pass**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/sso.test.ts
+```
+Expected: **PASS** (whole file — the new callback block adds **no** `db.select`, so the existing `mockReturnValueOnce` queues are unaffected; if a pre-existing test reds, it is because its primed provider row lacks `configVersion`/its session row lacks `providerVersion` — add them to the fixture, do not weaken the gate).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/routes/sso.ts apps/api/src/routes/sso.test.ts
+git commit -m "feat(sso): bump provider config_version on every config/status change; callback rejects inactive provider or stale generation (SR2-11)"
+```
+
+---
+
+### Task 5: SR2-11b — link sessions bound to the initiating session
+
+**Files:**
+- Modify: `apps/api/src/routes/sso.ts` — `POST /sso/link/start` (`:1056-1133`), link-callback branch (`:1555-1622`)
+- Test: `apps/api/src/routes/sso.test.ts` (`describe('Connect SSO link flow (#2183)')` `:2281-2445`, `primeLinkCallback` `:2391-2398`)
+
+**Interfaces:**
+- Consumes: `getUserEpochs` (already imported from `'../services'` at `sso.ts:35`); **`getRefreshFamily`** — NEW import from `'../services'` (**must be added to `vi.mock('../services')` at `sso.test.ts:49-67`**); `auth.token.sid` (**`vi.mock('../middleware/auth')` at `:174-208` must gain a `token` key**); `organizationUsers`, `partnerUsers` (already imported at `sso.ts:8-18`).
+- Produces (used only inside `sso.ts`):
+  ```ts
+  type LinkRejectReason =
+    | 'link_binding_missing'
+    | 'link_user_gone'
+    | 'link_user_inactive'
+    | 'link_epochs_unavailable'
+    | 'link_auth_epoch_mismatch'
+    | 'link_mfa_epoch_mismatch'
+    | 'link_family_missing'
+    | 'link_family_revoked'
+    | 'link_family_expired'
+    | 'link_axis_membership_lost';
+
+  /** Re-check a pending link session against LIVE state. Call inside withSystemDbAccessContext. */
+  async function validateLinkBinding(
+    session: typeof ssoSessions.$inferSelect,
+    provider: typeof ssoProviders.$inferSelect,
+  ): Promise<{ ok: true; user: typeof users.$inferSelect } | { ok: false; reason: LinkRejectReason }>;
+  ```
+
+**Decisions:**
+- **Capture shape mirrors PR 2's `enforceExistingFactorStepUp`** (`routes/auth/helpers.ts:252-281`): `{ authEpoch, mfaEpoch, sid }`, resolved from `getUserEpochs(auth.user.id)` + `auth.token.sid`. If **either** is unavailable → **503** `{ error: 'Service temporarily unavailable' }` and **no session row is written**. Same fail-closed contract, same 503, so the two bind-and-recheck surfaces cannot drift.
+- **`mfaEpoch` is captured and re-checked** even though the design text names only auth epoch. `/sso/link/start` is already behind `requireMfa()`; an MFA-factor change (which PR 2 makes bump `mfa_epoch` and revoke every family) must therefore invalidate a pending link. Cheap, strictly stronger, and it makes the check symmetric with the pending-MFA record. (Note the family-revocation check would *also* catch this — `mfa_epoch` re-check is defense in depth.)
+- **The refresh family is the logout hook.** `getRefreshFamily(sid)` returns `{ revokedAt, absoluteExpiresAt }`; a logout durably revokes exactly that family (PR 1). So checking `revokedAt == null && absoluteExpiresAt > now` is precisely what makes "logout invalidates link transactions through their bound refresh family" true. A **missing** family row (`null`) is a reject, not a pass.
+- **Axis membership is re-asserted**, not assumed from the session: org-axis provider → a live `organization_users(userId, provider.orgId)` row; partner-axis provider → a live `partner_users(userId, provider.partnerId)` row **and** `users.orgId IS NULL` (the same staff invariant the mint gate asserts). A user removed from the org between start and callback cannot complete the link.
+- **One generic public error for all of these: `/settings/profile?ssoLinkError=session_invalid`.** The specific `LinkRejectReason` goes only to the audit. Rationale: these codes are rendered in the UI, and distinguishing "your account was suspended" from "your session was revoked" from "you lost org membership" leaks account state to whoever holds the browser. The pre-existing `user_gone` / `email_mismatch` / `identity_in_use` codes are unchanged.
+- **Audit:** `action: 'sso.identity.link_rejected'`, `result: 'denied'`, `details: { reason, providerId, partnerId, userId }`. No `state`, no tokens.
+
+- [ ] **Step 1: Write the failing tests**
+
+First, the mock prerequisites in `routes/sso.test.ts` — **without these the whole suite throws**:
+
+```ts
+// vi.mock('../services') factory (:49-67) — ADD:
+  getRefreshFamily: vi.fn().mockResolvedValue({
+    revokedAt: null,
+    absoluteExpiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+  }),
+
+// vi.mock('../middleware/auth') factory (:174-208) — the fake auth context ADDS `token`:
+    c.set('auth', {
+      scope: 'organization',
+      orgId: '00000000-0000-4000-8000-000000000010',
+      partnerId: null,
+      accessibleOrgIds: ['00000000-0000-4000-8000-000000000010'],
+      canAccessOrg: () => true,
+      user: { id: '00000000-0000-4000-8000-000000000020', email: 'test@example.com' },
+      // SR2-11b: /sso/link/start binds the pending session to the initiating
+      // refresh family. Without this key every link test throws on auth.token.sid.
+      token: { sid: '00000000-0000-4000-8000-0000000000fa' },
+    });
+```
+
+Then, in `describe('Connect SSO link flow (#2183)')`, add tests:
+
+1. **`/link/start` stores the binding** — capture the `db.insert(ssoSessions).values()` payload and assert `initiatingAuthEpoch === 1`, `initiatingMfaEpoch === 1` (the `getUserEpochs` mock returns `{authEpoch:1,mfaEpoch:1}`), `initiatingSessionId === '00000000-0000-4000-8000-0000000000fa'`, `providerVersion === provider.configVersion`.
+2. **`/link/start` returns 503 when epochs are unavailable** — `vi.mocked(getUserEpochs).mockResolvedValueOnce(null)` → 503 and `db.insert` **never** called.
+3. **`/link/start` returns 503 when the token has no `sid`** — override the auth mock's `token` to `{}` for one test → 503, no insert.
+4. **Link callback rejects a revoked initiating family** — `vi.mocked(getRefreshFamily).mockResolvedValueOnce({ revokedAt: new Date(), absoluteExpiresAt: new Date(Date.now()+1e9) })` → `302` to `/settings/profile?ssoLinkError=session_invalid`; assert no `userSsoIdentities` insert.
+5. **Link callback rejects an auth-epoch bump** — session `initiatingAuthEpoch: 1`, `getUserEpochs` → `{ authEpoch: 2, mfaEpoch: 1 }` → `session_invalid`, no insert.
+6. **Link callback rejects a suspended user** — the primed `users` row has `status: 'suspended'` → `session_invalid`, no insert.
+7. **Link callback rejects a NULL binding (pre-deploy row)** — session has `linkUserId` set but `initiatingSessionId: null` → `session_invalid`, no insert.
+8. **Link callback rejects lost org membership** — prime the `organization_users` membership select to return `[]` → `session_invalid`, no insert.
+9. **Happy path still links** — all live checks pass → `302` to `/settings/profile?ssoLinked=1` and the `userSsoIdentities` insert fires.
+
+> **`primeLinkCallback` (`:2391-2398`) must be rewritten.** `validateLinkBinding` adds **one new select** (the axis-membership row) *after* the existing `users` select and *before* the `userSsoIdentities` select. Every `mockReturnValueOnce` queue in the link tests shifts by one. Update the helper once and let all the link tests consume it.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/sso.test.ts -t 'link'
+```
+Expected: **FAIL** — `/link/start` writes no binding columns; the link callback checks none of them.
+
+- [ ] **Step 3: Implement — capture the binding at `/link/start`**
+
+Extend the `'../services'` import (`sso.ts:35`):
+
+```ts
+import { createTokenPair, createSession, mintRefreshTokenFamily, bindRefreshJtiToFamily, getUserEpochs, getRefreshFamily, rateLimiter, getRedis } from '../services';
+```
+
+In `POST /sso/link/start/:providerId`, **immediately before** the session insert (the block Task 1 wrapped), add:
+
+```ts
+    // SR2-11b: bind the pending link to the CURRENT security generation of the
+    // initiating session. Mirrors PR 2's enforceExistingFactorStepUp
+    // (routes/auth/helpers.ts:252-281): capture {authEpoch, mfaEpoch, sid} at
+    // mint, re-check against the LIVE row at consume. This is what makes a
+    // logout / password reset / MFA reset / suspension / global revocation
+    // between start and callback invalidate the pending link.
+    //
+    // Fail closed: without epochs or a sid there is nothing to bind to, so we
+    // refuse to create the session rather than create an unbindable one.
+    const initiatorEpochs = await getUserEpochs(auth.user.id);
+    const initiatingSid = auth.token?.sid;
+    if (!initiatorEpochs || !initiatingSid) {
+      return c.json({ error: 'Service temporarily unavailable' }, 503);
+    }
+```
+
+and extend the insert's `.values({ … })` with:
+
+```ts
+          providerVersion: provider.configVersion,          // Task 4
+          initiatingAuthEpoch: initiatorEpochs.authEpoch,
+          initiatingMfaEpoch: initiatorEpochs.mfaEpoch,
+          initiatingSessionId: initiatingSid,
+```
+
+- [ ] **Step 4: Implement — re-check the binding at the link callback**
+
+Add the validator next to `checkProviderGeneration`:
+
+```ts
+type LinkRejectReason =
+  | 'link_binding_missing'
+  | 'link_user_gone'
+  | 'link_user_inactive'
+  | 'link_epochs_unavailable'
+  | 'link_auth_epoch_mismatch'
+  | 'link_mfa_epoch_mismatch'
+  | 'link_family_missing'
+  | 'link_family_revoked'
+  | 'link_family_expired'
+  | 'link_axis_membership_lost';
+
+/**
+ * SR2-11b: re-check a pending LINK session against LIVE state before it is
+ * allowed to bind an external identity to a Breeze account.
+ *
+ * The session snapshotted {authEpoch, mfaEpoch, sid} at /link/start. Any of the
+ * following since then must kill it:
+ *   - the user was suspended/deleted            -> status / user_gone
+ *   - password reset, email change, membership
+ *     change, platform-privilege change         -> auth_epoch bump
+ *   - any MFA factor change                     -> mfa_epoch bump
+ *   - logout, or a global session revocation    -> the bound refresh family is
+ *                                                  revoked (or gone/expired)
+ *   - removal from the provider's org/partner   -> axis membership lost
+ *
+ * A pre-deploy row (any binding column NULL) is a REJECT, not a pass.
+ *
+ * MUST be called inside withSystemDbAccessContext (/sso/callback is
+ * unauthenticated; getRefreshFamily establishes its own system context).
+ */
+async function validateLinkBinding(
+  session: typeof ssoSessions.$inferSelect,
+  provider: typeof ssoProviders.$inferSelect,
+): Promise<{ ok: true; user: typeof users.$inferSelect } | { ok: false; reason: LinkRejectReason }> {
+  if (
+    session.initiatingAuthEpoch == null ||
+    session.initiatingMfaEpoch == null ||
+    session.initiatingSessionId == null
+  ) {
+    return { ok: false, reason: 'link_binding_missing' };
+  }
+
+  const [linkingUser] = await db
+    .select()
+    .from(users)
+    .where(eq(users.id, session.linkUserId!))
+    .limit(1);
+  if (!linkingUser) return { ok: false, reason: 'link_user_gone' };
+  if (linkingUser.status !== 'active') return { ok: false, reason: 'link_user_inactive' };
+
+  const liveEpochs = await getUserEpochs(linkingUser.id);
+  if (!liveEpochs) return { ok: false, reason: 'link_epochs_unavailable' };
+  if (liveEpochs.authEpoch !== session.initiatingAuthEpoch) {
+    return { ok: false, reason: 'link_auth_epoch_mismatch' };
+  }
+  if (liveEpochs.mfaEpoch !== session.initiatingMfaEpoch) {
+    return { ok: false, reason: 'link_mfa_epoch_mismatch' };
+  }
+
+  const family = await getRefreshFamily(session.initiatingSessionId);
+  if (!family) return { ok: false, reason: 'link_family_missing' };
+  if (family.revokedAt) return { ok: false, reason: 'link_family_revoked' };
+  if (family.absoluteExpiresAt.getTime() <= Date.now()) {
+    return { ok: false, reason: 'link_family_expired' };
+  }
+
+  // Axis membership must STILL be held (the /link/start pool check is a
+  // snapshot, not a guarantee).
+  if (provider.orgId) {
+    const [membership] = await db
+      .select({ userId: organizationUsers.userId })
+      .from(organizationUsers)
+      .where(and(
+        eq(organizationUsers.userId, linkingUser.id),
+        eq(organizationUsers.orgId, provider.orgId),
+      ))
+      .limit(1);
+    if (!membership) return { ok: false, reason: 'link_axis_membership_lost' };
+  } else if (provider.partnerId) {
+    if (linkingUser.orgId != null) return { ok: false, reason: 'link_axis_membership_lost' };
+    const [membership] = await db
+      .select({ userId: partnerUsers.userId })
+      .from(partnerUsers)
+      .where(and(
+        eq(partnerUsers.userId, linkingUser.id),
+        eq(partnerUsers.partnerId, provider.partnerId),
+      ))
+      .limit(1);
+    if (!membership) return { ok: false, reason: 'link_axis_membership_lost' };
+  } else {
+    return { ok: false, reason: 'link_axis_membership_lost' };
+  }
+
+  return { ok: true, user: linkingUser };
+}
+```
+
+Rewrite the head of the link branch (`sso.ts:1561-1573`). **Replace**:
+
+```ts
+    if (session.linkUserId) {
+      const outcome = await withSystemDbAccessContext(async () => {
+        const [linkingUser] = await db
+          .select()
+          .from(users)
+          .where(eq(users.id, session.linkUserId!))
+          .limit(1);
+        if (!linkingUser) return { error: 'user_gone' as const };
+```
+
+**with**:
+
+```ts
+    if (session.linkUserId) {
+      const outcome = await withSystemDbAccessContext(async () => {
+        // SR2-11b: live re-check of the binding captured at /link/start.
+        const binding = await validateLinkBinding(session, provider);
+        if (!binding.ok) {
+          return { error: 'session_invalid' as const, auditReason: binding.reason };
+        }
+        const linkingUser = binding.user;
+```
+
+and change the failure handler (`:1608-1611`) from:
+
+```ts
+      clearStateCookie();
+      if ('error' in outcome) {
+        return c.redirect(`/settings/profile?ssoLinkError=${outcome.error}`);
+      }
+```
+
+to:
+
+```ts
+      clearStateCookie();
+      if ('error' in outcome) {
+        writeRouteAudit(c, {
+          orgId: provider.orgId,
+          action: 'sso.identity.link_rejected',
+          resourceType: 'sso_provider',
+          resourceId: provider.id,
+          resourceName: provider.name,
+          result: 'denied',
+          details: {
+            // The PUBLIC code is deliberately coarse (session_invalid). The
+            // precise reason lives here only — distinguishing "suspended" from
+            // "session revoked" from "removed from org" in the URL would leak
+            // account state to whoever holds the browser.
+            reason: (outcome as { auditReason?: string }).auditReason ?? outcome.error,
+            publicCode: outcome.error,
+            partnerId: provider.partnerId,
+            userId: session.linkUserId,
+          },
+        });
+        return c.redirect(`/settings/profile?ssoLinkError=${outcome.error}`);
+      }
+```
+
+The rest of the link branch (email match → `email_mismatch`; `(provider, sub)` conflict → `identity_in_use`; the `userSsoIdentities` insert) is unchanged and continues to use `linkingUser`.
+
+> **The `user_gone` public code disappears from the link surface** (folded into `session_invalid`). That is intentional — it was an account-state oracle. The web UI **does** switch on `ssoLinkError` (`apps/web/src/components/settings/ConnectSsoCard.tsx:11-15`, tests at `ConnectSsoCard.test.tsx:91-110`), so an unmapped code renders a useless generic banner. **Task 6 Step 5 carries the web arm for every new code introduced by Tasks 4, 5 and 6** — do not ship this task expecting the UI to cope.
+
+- [ ] **Step 5: Run to verify they pass**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/routes/sso.test.ts
+```
+Expected: **PASS** (whole file).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/sso.ts apps/api/src/routes/sso.test.ts
+git commit -m "feat(sso): bind pending link sessions to the initiating session; re-check epochs/family/status/membership at callback (SR2-11)"
+```
+
+---
+
+### Task 6: SR2-12 — verified identity claims (+ org clamp on auto-link)
+
+**Files:**
+- Modify: `apps/api/src/services/sso.ts:331-347` (`assertEmailVerified` neighborhood) — add `readEmailVerifiedClaim`
+- Modify: `apps/api/src/routes/sso.ts:1497-1535` (email-verification + attribute mapping), `:1650-1662` (domain gate), `:1664-1705` (auto-link + `emailCondition`)
+- Modify: `apps/web/src/components/settings/ConnectSsoCard.tsx:11-15` (`LINK_ERROR_KEYS`) + the `connectSsoCard.*` i18n locale files (incl. `pt-BR`) — **the web arm for ALL new link-error codes from Tasks 4, 5 and 6** (Step 5)
+- Test: `apps/api/src/services/sso.test.ts`, `apps/api/src/routes/sso.test.ts`, `apps/web/src/components/settings/ConnectSsoCard.test.tsx`
+
+**Interfaces:**
+- Produces (`services/sso.ts`, consumed by `routes/sso.ts` **and by the `vi.mock('../services/sso')` factory**):
+  ```ts
+  export type EmailVerifiedClaim = 'true' | 'false' | 'absent';
+  /**
+   * Read `email_verified` from an id_token claim set OR a userinfo body.
+   * true/'true' -> 'true'; false/'false' -> 'false'; anything else (missing,
+   * null, non-boolean junk) -> 'absent'.
+   */
+  export function readEmailVerifiedClaim(source: Record<string, unknown> | null | undefined): EmailVerifiedClaim;
+  ```
+- Consumes: `isDomainVerifiedForOrg(orgId, rawDomain): Promise<boolean>` (`services/ssoDomainVerification.ts:99`) — **add to the `routes/sso.ts` import from `'../services/ssoDomainVerification'` at `:19`**; `isSsoProvisioningBlocked` (already imported); `inArray` (drizzle — added in Task 4); `organizationUsers` (already imported).
+
+> ⚠️ **READ FIRST — `db.select()` QUEUE SHIFT.** Step 4(d) builds `emailCondition` with an `inArray(users.id, db.select({…})…)` subquery. `db.select()` is **invoked at condition-construction time**, and `routes/sso.test.ts`'s hand-rolled mock hands out a queued chain **per `db.select()` call**. So **every existing org-axis callback test that reaches the by-email branch shifts by one queue slot.** Before writing any new test, re-prime the affected `mockReturnValueOnce` queues in the existing login-callback primers (insert one extra chain returning `[]` or the member row, positioned where the subquery is constructed — i.e. *before* the by-email `users` select resolves). Do not chase this as a phantom failure in "unrelated" tests; it is this change.
+
+**Decisions (Overseer Decisions 1-4, implemented exactly):**
+- **The claim is read from whichever source supplied the FINAL email.** Today `assertEmailVerified` is called only `if (idClaims.email)` (`routes/sso.ts:1502-1504`), and **userinfo's `email_verified` is never read anywhere** (`OIDCUserInfo.email_verified` is declared at `services/sso.ts:32` with zero readers). So when the id_token omits `email`, the callback silently falls through to an *unverified* userinfo email that then drives the domain check, the auto-link, and JIT. Fixed: pick the claim source at the same moment the email is picked.
+- **The attestation must be bound to the MAPPED email — the last laundering path.** On the userinfo path the final address is `attrs.email = mapUserAttributes(userInfo, mapping)` (`services/sso.ts:482-521`), and `mapping.email` is **admin-set jsonb** that may name `upn`, `preferred_username`, or any other key. But `email_verified` in a userinfo body attests userinfo.**`email`** — a *different* address. So `attributeMapping.email = 'preferred_username'` + `email_verified: true` would launder a completely unattested address behind a true verification claim. **Fix:** on the userinfo path, treat the claim as **`'absent'`** unless the mapping key is literally `'email'` **or** the mapped value equals `userInfo.email`. Absent then falls into the domain-ownership gate, which is exactly the right outcome. (The id_token path is unaffected: `attrs.email` is overwritten from `idClaims.email` there, so the claim and the address come from the same object.)
+- **`false` → ALWAYS reject** (both axes, all paths, including already-linked users). Unchanged in spirit from today, but now it also fires on the userinfo path.
+- **`true` → allow.**
+- **`absent` → allow ONLY if the asserted email's domain is a VERIFIED domain for the provider's org** (`isDomainVerifiedForOrg`), else reject. This is the design's "documented and enforced equivalent guarantee" — Breeze itself proves the domain via DNS TXT instead of trusting an IdP that declines to say.
+- **ORG AXIS ONLY, and this is a known gap.** `sso_verified_domains.org_id` is `NOT NULL` — **there is no partner-axis domain machinery at all**, so applying the absent-claim gate to the partner axis would reject *every* partner-axis Entra login (Entra omits `email_verified`). The partner axis keeps today's absent-claim tolerance. It is materially lower-risk: it has **no JIT** (`routes/sso.ts:1707-1714` → `invite_required`), and its auto-link already clamps hard to `(users.partnerId = provider.partnerId AND users.orgId IS NULL AND passwordless AND no conflicting provider link)` — i.e. an already-provisioned staff member of the very partner that configured the IdP. **Documented follow-up (NOT PR 3 scope):** extend `sso_verified_domains` to dual-axis per the PARTNER-WIDE FIRST principle, then apply the same gate on the partner axis. State this in the PR body as a known gap.
+- **Placement of the absent-claim gate:** inside the `!user && provider.orgId` block, alongside the existing `isSsoProvisioningBlocked` call — i.e. exactly where email (rather than the `(provider, sub)` link) drives resolution. Already-linked identities stay exempt, which preserves today's guarantee that turning domain enforcement on never locks out an existing SSO user. The **explicit-`false`** gate, by contrast, sits at the top (before identity resolution) and applies to everyone.
+- **Auto-link is gated on domain ownership** (Overseer Decision 2). Note this is *already* structurally true — `isSsoProvisioningBlocked` runs at `:1650` **before** the by-email branch, so it covers auto-link and JIT alike — but it is **opt-in** (it no-ops unless the org already has ≥1 verified domain or `SSO_DOMAIN_VERIFICATION_STRICT=true`). The new absent-claim gate is **not** opt-in: an absent claim requires a verified domain, full stop. Together, an org-axis auto-link now requires *either* a positively verified email *or* a Breeze-proven domain.
+- **Org clamp on the auto-link email match** (Overseer Decision 4). `emailCondition`'s org branch is `eq(users.email, …)` — matching **any** user globally. Cross-tenant login is already blocked one gate deeper (the org-axis mint requires an `organization_users` row for `provider.orgId`, else `no_org_access`), so **this was not exploitable** — it is defense-in-depth debt. The clamp is **membership-bounded**, not `eq(users.orgId, provider.orgId)`: a legitimate multi-org user's `users.orgId` may point at a different org while they hold a valid membership in the provider's org, and a naive column clamp would break them. Use `inArray(users.id, <org members subquery>)` — exactly the population the mint gate would accept.
+- **Public error code:** `/login?error=sso_email_unverified` for both the explicit-`false` and the absent-without-verified-domain cases (indistinguishable publicly). The audit reason distinguishes `email_verified_false` from `email_verified_absent_domain_unverified`. The existing `sso_domain_unverified` code stays for the `isSsoProvisioningBlocked` path.
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/api/src/services/sso.test.ts` — add:
+
+```ts
+describe('readEmailVerifiedClaim (SR2-12)', () => {
+  it.each([
+    [{ email_verified: true }, 'true'],
+    [{ email_verified: 'true' }, 'true'],
+    [{ email_verified: false }, 'false'],
+    [{ email_verified: 'false' }, 'false'],
+    [{}, 'absent'],
+    [{ email_verified: null }, 'absent'],
+    [{ email_verified: 'maybe' }, 'absent'],
+    [{ email_verified: 1 }, 'absent'],
+  ])('%o -> %s', (source, expected) => {
+    expect(readEmailVerifiedClaim(source as Record<string, unknown>)).toBe(expected);
+  });
+
+  it('returns absent for null/undefined', () => {
+    expect(readEmailVerifiedClaim(null)).toBe('absent');
+    expect(readEmailVerifiedClaim(undefined)).toBe('absent');
+  });
+});
+```
+
+`apps/api/src/routes/sso.test.ts` — add `describe('SSO verified identity claims (SR2-12)', …)`:
+
+1. **id_token `email_verified: false` → reject** — `302` to `/login?error=sso_email_unverified`; no token mint, no user insert.
+2. **id_token omits `email`; userinfo carries `email_verified: false` → reject** (this is the never-read path) — same redirect. Prime `verifyIdTokenSignature` → `{ sub: 's1', nonce: 'nonce' }` (no `email`) and `getUserInfo` → `{ sub: 's1', email: 'x@corp.example', email_verified: false }`.
+3. **Absent claim + org axis + domain NOT verified + no existing link → reject** — mock `isDomainVerifiedForOrg` → `false` → `/login?error=sso_email_unverified`; assert **no** `users` insert.
+4. **Absent claim + org axis + domain VERIFIED → proceeds** — `isDomainVerifiedForOrg` → `true` → reaches the auto-link/JIT path.
+5. **Absent claim + PARTNER axis → tolerated** (documented gap) — a partner-axis callback with an absent claim reaches the partner identity resolution (and, with no user, the `invite_required` redirect) rather than `sso_email_unverified`.
+6. **Absent claim + already-linked user (org axis) → allowed** — the `(provider, sub)` link resolves the user, so the email-driven gates never run.
+7. **Org clamp on auto-link** — prime the by-email select and assert the WHERE it receives is membership-bounded. Cheapest robust assertion given the hand-rolled Drizzle mock: assert that when the by-email select returns a user who is **not** in the provider's org, the callback does not mint (`createTokenPair` not called). Prime the `organizationUsers` membership subquery mock to return `[]`.
+
+8. **Mapped-email laundering is blocked (I3)** — `attributeMapping: { email: 'preferred_username', name: 'name' }`; userinfo `{ sub:'s1', email:'real@corp.example', email_verified: true, preferred_username: 'spoof@corp.example' }`; id_token omits `email`; the org has **no** verified domain → **reject** `/login?error=sso_email_unverified`. The `email_verified: true` attests `real@…`, not the mapped `spoof@…`, so it must not count. Add the mirror case: same setup but the org **has** `corp.example` verified → proceeds (the domain gate is what carries it, which is correct).
+
+**`services/ssoDomainVerification` is ALREADY MOCKED — `routes/sso.test.ts:158`.** Do **not** add a second `vi.mock` for that path: a duplicate clobbers the first and reds the existing domain-gate tests, which use `vi.mocked(isSsoProvisioningBlocked)` (`:1297`, `:1314`). **Extend the existing factory** with the one new export:
+
+```ts
+vi.mock('../services/ssoDomainVerification', () => ({
+  createPendingDomain: vi.fn(),
+  verifyDomain: vi.fn(),
+  recordNameFor: vi.fn((domain: string) => `_breeze-verify.${domain}`),
+  recordValueFor: vi.fn((token: string) => `breeze-domain-verify=${token}`),
+  isSsoProvisioningBlocked: vi.fn().mockResolvedValue(false),
+  // NEW (SR2-12): the hard absent-claim gate. Default true so existing tests,
+  // which assert on isSsoProvisioningBlocked, are unaffected.
+  isDomainVerifiedForOrg: vi.fn().mockResolvedValue(true),
+}));
+```
+Per-test overrides use `vi.mocked(isDomainVerifiedForOrg).mockResolvedValueOnce(false)` — matching how the file already drives `isSsoProvisioningBlocked`.
+
+And add `readEmailVerifiedClaim` to the `vi.mock('../services/sso')` factory (`:22-47`) — **use the real implementation, not a stub**, so these tests actually exercise the claim reader:
+
+```ts
+  readEmailVerifiedClaim: (source: Record<string, unknown> | null | undefined) => {
+    const ev = source?.email_verified;
+    if (ev === true || ev === 'true') return 'true';
+    if (ev === false || ev === 'false') return 'false';
+    return 'absent';
+  },
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/services/sso.test.ts src/routes/sso.test.ts -t 'SR2-12'
+```
+Expected: **FAIL** — `readEmailVerifiedClaim` does not exist; the userinfo `email_verified: false` case sails through; an absent claim is unconditionally tolerated; the org auto-link matches globally.
+
+- [ ] **Step 3: Implement — the claim reader**
+
+In `apps/api/src/services/sso.ts`, **replace** the `assertEmailVerified` block (`:331-347`) with:
+
+```ts
+/**
+ * The three possible states of an OIDC `email_verified` claim, read from EITHER
+ * an id_token claim set OR a userinfo body. `email_verified` may legitimately
+ * arrive as a boolean or as a string (SR2-12).
+ *
+ * 'absent' covers missing, null, and any non-boolean junk value — an IdP that
+ * says something we cannot interpret has not asserted verification.
+ */
+export type EmailVerifiedClaim = 'true' | 'false' | 'absent';
+
+export function readEmailVerifiedClaim(
+  source: Record<string, unknown> | null | undefined,
+): EmailVerifiedClaim {
+  const ev = source?.email_verified;
+  if (ev === true || ev === 'true') return 'true';
+  if (ev === false || ev === 'false') return 'false';
+  return 'absent';
+}
+
+/**
+ * @deprecated Superseded by readEmailVerifiedClaim + the callback's axis-aware
+ * gate (SR2-12). Kept because it is the documented "explicit false only"
+ * behavior and is still unit-tested; the SSO callback no longer calls it.
+ */
+export function assertEmailVerified(claims: Pick<IDTokenClaims, 'email_verified'>): void {
+  if (readEmailVerifiedClaim(claims as Record<string, unknown>) === 'false') {
+    throw new Error('ID token email is explicitly not verified (email_verified === false)');
+  }
+}
+```
+
+- [ ] **Step 4: Implement — the callback gates**
+
+In `apps/api/src/routes/sso.ts`:
+
+Update the `'../services/sso'` import (`:20-34`): drop `assertEmailVerified`, add `readEmailVerifiedClaim` **and `type EmailVerifiedClaim`**. Update the `'../services/ssoDomainVerification'` import (`:19`) to add `isDomainVerifiedForOrg`. (`mapping` is already in scope at `:1523`: `const mapping = (provider.attributeMapping as any) || { email: 'email', name: 'name' };`.)
+
+**(a) Delete** the current gate (`:1502-1504`):
+```ts
+    const idClaims = await verifyIdTokenSignature(tokens.id_token, config, session.nonce);
+    if (idClaims.email) {
+      assertEmailVerified(idClaims);
+    }
+```
+→ becomes just:
+```ts
+    const idClaims = await verifyIdTokenSignature(tokens.id_token, config, session.nonce);
+```
+
+**(b)** After the `attrs.email` finalization block (`:1528-1535`, the `if (idClaims.email) { attrs.email = …lowerCase(); }`), insert the source-aware gate:
+
+```ts
+    // ── SR2-12: verified identity claims ─────────────────────────────────────
+    // The `email_verified` decision must ride the SAME source that supplied the
+    // final email. Previously it was read ONLY from the id_token and ONLY when
+    // the id_token carried an email — so an IdP that omits `email` from the
+    // id_token had its userinfo email accepted with the userinfo
+    // `email_verified` NEVER read (OIDCUserInfo.email_verified had zero
+    // readers). That unverified email then drove the domain check, the
+    // auto-link, and JIT.
+    // …and it must be bound to the address we ACTUALLY use. On the userinfo path
+    // `attrs.email` comes from mapUserAttributes(userInfo, mapping) with an
+    // ADMIN-SET mapping key — which may be `upn` / `preferred_username` / … —
+    // while userinfo's `email_verified` attests userinfo.`email`. Trusting the
+    // claim across that gap would let attributeMapping.email='preferred_username'
+    // launder an unattested address behind email_verified:true. So on the
+    // userinfo path the claim only counts when it demonstrably describes the same
+    // address; otherwise it is 'absent' and falls into the domain-ownership gate.
+    const usingIdTokenEmail = Boolean(idClaims.email);
+    const userInfoRecord = userInfo as unknown as Record<string, unknown>;
+    const userInfoEmail =
+      typeof userInfoRecord.email === 'string' ? userInfoRecord.email.toLowerCase() : null;
+    const mappedKeyIsEmail = (mapping?.email ?? 'email') === 'email';
+    const claimDescribesMappedEmail =
+      mappedKeyIsEmail || (userInfoEmail !== null && userInfoEmail === attrs.email.toLowerCase());
+
+    const emailVerifiedClaim: EmailVerifiedClaim = usingIdTokenEmail
+      ? readEmailVerifiedClaim(idClaims as unknown as Record<string, unknown>)
+      : claimDescribesMappedEmail
+        ? readEmailVerifiedClaim(userInfoRecord)
+        : 'absent';
+
+    // Explicit false is ALWAYS fatal, on both axes, on every path (including an
+    // already-linked identity): the IdP is affirmatively telling us the mailbox
+    // is not proven.
+    if (emailVerifiedClaim === 'false') {
+      writeRouteAudit(c, {
+        orgId: provider.orgId,
+        action: 'sso.callback.rejected',
+        resourceType: 'sso_provider',
+        resourceId: provider.id,
+        resourceName: provider.name,
+        result: 'denied',
+        details: {
+          mode: callbackMode,
+          phase: 'email_verification',
+          reason: 'email_verified_false',
+          claimSource: idClaims.email ? 'id_token' : 'userinfo',
+          partnerId: provider.partnerId,
+        },
+      });
+      clearStateCookie();
+      return callbackMode === 'link'
+        ? c.redirect('/settings/profile?ssoLinkError=email_unverified')
+        : c.redirect('/login?error=sso_email_unverified');
+    }
+```
+
+**(c)** In the `if (!user && provider.orgId)` domain block (`:1650-1662`), **prepend** the absent-claim gate (keep the existing `isSsoProvisioningBlocked` check that follows it):
+
+```ts
+    if (!user && provider.orgId) {
+      const assertedEmailDomain = attrs.email.split('@')[1]?.toLowerCase() ?? null;
+
+      // SR2-12: an ABSENT `email_verified` claim is acceptable ONLY when Breeze
+      // itself has proven the domain (DNS TXT, sso_verified_domains). This is
+      // the "documented and enforced equivalent guarantee" the design requires:
+      // we stop taking the IdP's silence on faith and substitute our own proof.
+      //
+      // Reached only when the identity is being resolved BY EMAIL (auto-link) or
+      // provisioned fresh (JIT) — an already-linked (provider, sub) identity is
+      // deliberately exempt, so enabling this never locks out an existing user.
+      //
+      // ORG AXIS ONLY. sso_verified_domains.org_id is NOT NULL: there is no
+      // partner-axis domain machinery, so applying this to the partner axis
+      // would reject EVERY partner-axis Entra login (Entra omits the claim). The
+      // partner axis is materially lower-risk — no JIT at all, and its email
+      // match already clamps to (same partner, orgId IS NULL, passwordless, no
+      // conflicting provider link). KNOWN GAP; follow-up is to make
+      // sso_verified_domains dual-axis (PARTNER-WIDE FIRST) and then gate here.
+      if (emailVerifiedClaim === 'absent') {
+        const domainProven = assertedEmailDomain
+          ? await withSystemDbAccessContext(() =>
+              isDomainVerifiedForOrg(provider.orgId!, assertedEmailDomain),
+            )
+          : false;
+        if (!domainProven) {
+          writeRouteAudit(c, {
+            orgId: provider.orgId,
+            action: 'sso.callback.rejected',
+            resourceType: 'sso_provider',
+            resourceId: provider.id,
+            resourceName: provider.name,
+            result: 'denied',
+            details: {
+              mode: callbackMode,
+              phase: 'email_verification',
+              reason: 'email_verified_absent_domain_unverified',
+              claimSource: idClaims.email ? 'id_token' : 'userinfo',
+              emailDomain: assertedEmailDomain,
+              partnerId: provider.partnerId,
+            },
+          });
+          clearStateCookie();
+          return c.redirect('/login?error=sso_email_unverified');
+        }
+      }
+
+      const domainBlocked = await withSystemDbAccessContext(() =>
+        isSsoProvisioningBlocked(provider.orgId!, assertedEmailDomain)
+      );
+      if (domainBlocked) {
+        console.warn(
+          `[sso/callback] domain verification blocked link/provision: org=${provider.orgId} provider=${provider.id} emailDomain=${assertedEmailDomain ?? 'none'}`
+        );
+        clearStateCookie();
+        return c.redirect('/login?error=sso_domain_unverified');
+      }
+    }
+```
+
+**(d)** The org clamp on `emailCondition` (`:1677-1684`). Replace:
+
+```ts
+      const emailCondition = provider.partnerId
+        ? and(
+            eq(users.email, attrs.email.toLowerCase()),
+            eq(users.partnerId, provider.partnerId),
+            isNull(users.orgId)
+          )
+        : eq(users.email, attrs.email.toLowerCase());
+```
+
+with:
+
+```ts
+      // Org-axis clamp (SR2-12 / defense in depth). The org branch previously
+      // matched `eq(users.email, …)` GLOBALLY — any user in any tenant. Login
+      // was still blocked one gate deeper (the org-axis mint requires an
+      // organization_users row for provider.orgId, else no_org_access), so this
+      // was NOT exploitable — it is debt, and it is closed here.
+      //
+      // Clamp on MEMBERSHIP, not on users.org_id: a legitimate multi-org user's
+      // users.org_id may name a different org while they hold a valid membership
+      // in the provider's org, and a naive column clamp would lock them out.
+      // This subquery is exactly the population the mint gate would accept.
+      const emailCondition = provider.partnerId
+        ? and(
+            eq(users.email, attrs.email.toLowerCase()),
+            eq(users.partnerId, provider.partnerId),
+            isNull(users.orgId)
+          )
+        : and(
+            eq(users.email, attrs.email.toLowerCase()),
+            inArray(
+              users.id,
+              db
+                .select({ userId: organizationUsers.userId })
+                .from(organizationUsers)
+                .where(eq(organizationUsers.orgId, provider.orgId!))
+            )
+          );
+```
+
+- [ ] **Step 5: Implement — the WEB arm for the new link-error codes (I6)**
+
+Tasks 4, 5 and 6 introduce four new `ssoLinkError` codes and retire one. The web card that renders them is **`apps/web/src/components/settings/ConnectSsoCard.tsx:11-15`**:
+
+```ts
+const LINK_ERROR_KEYS: Record<string, string> = {
+  email_mismatch: 'connectSsoCard.emailMismatch',
+  identity_in_use: 'connectSsoCard.identityInUse',
+  user_gone: 'connectSsoCard.userGone'
+};
+```
+
+Anything not in that map falls back to the generic `connectSsoCard.couldNotConnectSingleSignOn`, so the new codes would render as an unhelpful catch-all. Replace the map with:
+
+```ts
+const LINK_ERROR_KEYS: Record<string, string> = {
+  email_mismatch: 'connectSsoCard.emailMismatch',
+  identity_in_use: 'connectSsoCard.identityInUse',
+  // SR2-11: the pending link was invalidated by a live security-state change
+  // (sign-out, password reset, MFA change, suspension, lost membership). The
+  // server deliberately does NOT say which — that would be an account-state
+  // oracle — so the copy asks the user to sign in and retry.
+  session_invalid: 'connectSsoCard.sessionInvalid',
+  provider_inactive: 'connectSsoCard.providerInactive',
+  config_changed: 'connectSsoCard.configChanged',
+  // SR2-12: the IdP did not positively verify the asserted address.
+  email_unverified: 'connectSsoCard.emailUnverified'
+};
+```
+
+**Remove the `user_gone` arm** — Task 5 folds that code into `session_invalid` (it was an account-state oracle), so it can no longer be emitted. Delete the now-dead `connectSsoCard.userGone` i18n key **only if** nothing else references it (`grep -rn "connectSsoCard.userGone" apps/web/src`), and add the four new keys to every locale file that carries `connectSsoCard.*` (**including `pt-BR`** — the console is internationalized).
+
+Update `apps/web/src/components/settings/ConnectSsoCard.test.tsx`: the existing `?ssoLinkError=user_gone` test (`:109-110`) must be **repointed to `session_invalid`**, and add cases for `provider_inactive`, `config_changed`, and `email_unverified` (mirroring the `email_mismatch` test at `:91-99`).
+
+- [ ] **Step 6: Run to verify they pass**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/services/sso.test.ts src/routes/sso.test.ts
+cd ../.. && pnpm test --filter=@breeze/web -- ConnectSsoCard
+```
+Expected: **PASS** (whole files, API and web).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/sso.ts apps/api/src/services/sso.test.ts apps/api/src/routes/sso.ts apps/api/src/routes/sso.test.ts apps/web/src/components/settings/ConnectSsoCard.tsx apps/web/src/components/settings/ConnectSsoCard.test.tsx apps/web/src/i18n
+git commit -m "feat(sso): require a positively verified email (id_token OR userinfo, bound to the mapped address); org-domain proof when the claim is absent; clamp org auto-link to members; surface new link-error codes in the web card (SR2-12)"
+```
+
+---
+
+### Task 7: SR2-13 / SR2-14 — SSRF-safe JWKS + endpoint validation
+
+**Files:**
+- Modify: `apps/api/src/services/urlSafety.ts` — `SafeFetchInit.maxBytes` + a bounded body read (`:355-381`)
+- Modify: `apps/api/src/services/urlSafety.test.ts` — `maxBytes` overrun test
+- Modify: `apps/api/src/services/sso.ts:1-3` (imports), `:9-18` (`OIDCConfig`), `:117-146` (`exchangeCodeForTokens`), `:152-168` (`getUserInfo`), `:174-196` (`refreshAccessToken`), `:266-330` (JWKS cache + `verifyIdTokenSignature`), `:424-460` (`discoverOIDCConfig`)
+- Modify: `apps/api/src/routes/sso.ts:290-307` (`getOIDCConfig`) + the five `getOIDCConfig` call sites + POST `/providers` discovery (`:527-542`) + PATCH `/providers/:id` issuer change
+- Test: `apps/api/src/services/sso.test.ts`, `apps/api/src/routes/sso.test.ts`
+
+**Interfaces:**
+- Consumes: `safeFetch(urlStr, init)` where `init: { timeoutMs?, signal?, allowPrivateNetwork?, …RequestInit }` (`services/urlSafety.ts:208`) — **already imported** into `services/sso.ts:3`; `isInternalUrl` (`services/sso.ts:385`); `customFetch` (jose 6.2.3 — `export declare const customFetch: unique symbol`, `dist/types/jwks/remote.d.ts:100`; `RemoteJWKSetOptions[customFetch]?: FetchImplementation` at `:189`, where `FetchImplementation = (url: string, options: {…}) => Promise<Response>`); `selfHostAllowsPrivateNetwork()` (`config/env.ts`, already imported into `routes/sso.ts:42`).
+- Produces (`services/urlSafety.ts`) — **new, shared with every existing caller**:
+  ```ts
+  export interface SafeFetchInit extends Omit<RequestInit, 'signal'> {
+    timeoutMs?: number;
+    signal?: AbortSignal;
+    allowPrivateNetwork?: boolean;
+    /** Hard ceiling on the response body. Overrun destroys the socket and throws. Unset = unbounded (legacy). */
+    maxBytes?: number;
+  }
+  export class ResponseTooLargeError extends Error {}   // NEW
+  ```
+- Produces (`services/sso.ts`):
+  ```ts
+  export const OIDC_FETCH_TIMEOUT_MS: number;      // 10_000
+  export const OIDC_JWKS_TIMEOUT_MS: number;       // 5_000
+  export const OIDC_MAX_RESPONSE_BYTES: number;    // 1 * 1024 * 1024
+
+  export interface OIDCConfig {
+    // …existing fields…
+    /** Self-host escape hatch, resolved ONCE by getOIDCConfig from selfHostAllowsPrivateNetwork(). Never request-supplied. */
+    allowPrivateNetwork?: boolean;
+  }
+
+  /** Throws when `urlStr` is absent, non-HTTPS (unless self-host http), or points at a blocked address. */
+  export function assertSafeOidcEndpoint(label: string, urlStr: string | null | undefined, allowPrivateNetwork?: boolean): void;
+
+  /** Validates every endpoint a discovery document would cause us to persist. Throws on the first bad one. */
+  export function validateDiscoveredEndpoints(doc: OIDCDiscoveryDocument, allowPrivateNetwork?: boolean): void;
+
+  /** Test-only: clear the JWKS cache. (already exists as _resetIdTokenJwksCacheForTests) */
+  export function _resetIdTokenJwksCacheForTests(): void;
+  ```
+
+**Decisions:**
+- **A construct-time URL check on `jwksUrl` is NOT sufficient — say it out loud.** `createRemoteJWKSet` is built once per URL and cached in a module-level `Map` (`services/sso.ts:269`); jose then **re-fetches on its own** whenever a `kid` misses or `cacheMaxAge` (10 min) expires, using jose's **global `fetch`** (undici). Validating only inside `getIdTokenJwks` would leave every one of those refetches unguarded: no scheme check, no private-IP check, no DNS pinning. The design's "JWKS caching must not bypass transport validation on refresh" can only be satisfied by **injecting the transport**. jose 6.2.3 exposes exactly that hook (`customFetch`), and `safeFetch(urlStr, init)` is signature-compatible with `FetchImplementation`.
+- **`allowPrivateNetwork` rides on `OIDCConfig`.** `getOIDCConfig` (which already builds the config from the provider row) resolves it **once** from `selfHostAllowsPrivateNetwork()` — never from anything request-supplied — and `exchangeCodeForTokens` / `getUserInfo` / `verifyIdTokenSignature` read `config.allowPrivateNetwork ?? false`. This keeps one policy value threaded through every provider-controlled fetch without adding a parameter to five signatures.
+- **The JWKS cache key includes the policy flag** (`${allowPrivateNetwork ? 'priv' : 'pub'}|${jwksUri}`) so a self-host-permissive entry can never be served to a strict caller. The cache is also **bounded** (500 entries, oldest evicted) — it was an unbounded `Map` keyed by a tenant-influenced URL.
+- **Discovery output is validated BEFORE it is persisted.** `discoverOIDCConfig` now calls `validateDiscoveredEndpoints` on the parsed document and throws if any of `authorization_endpoint` / `token_endpoint` / `userinfo_endpoint` / `jwks_uri` is missing, non-HTTPS, or SSRF-unsafe. POST `/providers` already catches discovery failure and creates the provider with NULL endpoints (`:538-541`) — that behavior is retained, so the failure mode is "provider is unusable until fixed", never "provider persists an attacker-controlled endpoint".
+- **`tokenUrl` HTTPS is enforced** (SR2-14's sharpest edge: a malicious discovery document could make Breeze POST the **decrypted `client_secret`** in cleartext to a public HTTP host). `assertSafeOidcEndpoint` requires HTTPS via `isInternalUrl`, which only permits `http:` when `allowPrivateNetwork` is on (self-host, internal IdP).
+- **Persisted endpoints are re-validated at RUNTIME** in `getOIDCConfig` — they are trusted blindly today, and `PATCH /providers/:id` can change `issuer` without re-running discovery, leaving `tokenUrl`/`jwksUrl` pointed at the old (or an attacker's) IdP. `getOIDCConfig` throws on a bad endpoint; the callback's existing `try/catch` turns that into a redirect, and the four non-callback call sites get an explicit `try/catch` → `400`.
+- **`PATCH /providers/:id` re-runs discovery when `issuer` changes**, and on discovery failure **clears** the four endpoint columns rather than leaving stale ones pointing at the previous IdP. Fail closed: an admin who repoints the issuer gets a provider that must be re-discovered, not one that silently keeps talking to the old IdP.
+- **Timeouts.** None of the four SSO `safeFetch` calls passes `timeoutMs` today. Discovery / token / userinfo get `OIDC_FETCH_TIMEOUT_MS = 10_000`; JWKS gets `OIDC_JWKS_TIMEOUT_MS = 5_000` (matching jose's own default so behavior is unchanged for a healthy IdP).
+- **`safeFetch` gets a `maxBytes` bounded read — it has NO size cap today.** Verified: `services/urlSafety.ts:355-381` buffers the entire body (`res.on('data', c => chunks.push(c))` → `Buffer.concat(chunks)`) with no content-length check and no byte ceiling. `/sso/callback` is **unauthenticated**, so the moment JWKS routes through `safeFetch` (this task), a malicious or compromised IdP returning a multi-GB JWKS body becomes an **unauthenticated memory-exhaustion vector**. Adding `maxBytes?: number` to `SafeFetchInit` — accumulate, `req.destroy()` and throw on overrun — is ~10 lines in the one shared utility and immediately benefits **every** existing caller (webhooks, Pax8, SentinelOne, TD SYNNEX, DNS…). All four OIDC documents are small; give them `OIDC_MAX_RESPONSE_BYTES = 1 MiB`.
+- **A port allowlist is explicitly OUT OF SCOPE.** There is none anywhere in the codebase today. Adding one would risk breaking legitimate IdPs served on nonstandard ports (self-hosted Keycloak/Authentik routinely are), and it is not the sharp risk here — the sharp risks are scheme (cleartext secret), destination IP (SSRF), and body size (memory exhaustion), all of which *are* closed. Say so plainly in the PR body rather than implying full coverage.
+- **Do NOT build a third SSRF utility.** Everything here composes `safeFetch` (`urlSafety.ts`) and `isInternalUrl` (which already delegates its IP predicates to `urlSafety`). The `maxBytes` option **extends** `safeFetch`; it does not fork it.
+- **The `#1105` tripwire is now load-bearing for SSO.** `safeFetch` calls `assertOutsideHeldDbContext('safeFetch')` (`urlSafety.ts:218`), which **throws** in CI/strict. Today's JWKS fetch uses jose's global fetch and is exempt from that guard; **after this task it is not.** `verifyIdTokenSignature` is called at `routes/sso.ts:1501`, outside any held DB context — so it is safe *today*, but that is now an invariant, not an accident. Step 1 adds a test that pins it (M4), so nobody later moves the call inside a `withSystemDbAccessContext` block and turns every SSO login into a 500.
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/api/src/services/sso.test.ts` — add `describe('SSRF-safe OIDC transport (SR2-13/14)', …)`:
+
+1. **`assertSafeOidcEndpoint` rejects `http://` in strict mode** and **accepts it when `allowPrivateNetwork`**; rejects `http://169.254.169.254/…`, `https://127.0.0.1/jwks`, `https://localhost/jwks`, and a missing URL; accepts `https://idp.example.com/jwks`.
+2. **`validateDiscoveredEndpoints` throws when `token_endpoint` is `http://`** (the client-secret-in-cleartext case) and when `jwks_uri` points at a private IP; passes a fully-HTTPS public document.
+3. **`discoverOIDCConfig` rejects a discovery document with an internal `jwks_uri`** — mock `safeFetch` (via `vi.mock('./urlSafety')`, spreading `importOriginal` so `SsrfBlockedError`/`isPrivateIp`/`isAlwaysBlockedIp` stay real) to return a JSON body whose `jwks_uri` is `http://10.0.0.5/jwks` → expect a throw, and expect the function **not** to return the document.
+4. **`getIdTokenJwks` injects `safeFetch` into jose** — the load-bearing test. Assert on the options object passed to `createRemoteJWKSet` by mocking `jose`:
+   ```ts
+   vi.mock('jose', async (importOriginal) => {
+     const actual = await importOriginal<typeof import('jose')>();
+     return { ...actual, createRemoteJWKSet: vi.fn(() => async () => ({})) };
+   });
+   ```
+   Then call `verifyIdTokenSignature` with a config carrying `jwksUrl` and assert:
+   ```ts
+   const opts = vi.mocked(createRemoteJWKSet).mock.calls[0]![1] as Record<PropertyKey, unknown>;
+   expect(typeof opts[customFetch]).toBe('function');
+   ```
+   and — the real point — **invoke that function** with a private-IP URL and assert it rejects with `SsrfBlockedError`, proving jose's internal refresh path is guarded:
+   ```ts
+   const fetchImpl = opts[customFetch] as (u: string, o: Record<string, unknown>) => Promise<Response>;
+   await expect(fetchImpl('http://169.254.169.254/jwks', {})).rejects.toThrow(SsrfBlockedError);
+   ```
+   Call `_resetIdTokenJwksCacheForTests()` in `beforeEach`.
+5. **`verifyIdTokenSignature` rejects an internal `jwksUrl` before any fetch** — config with `jwksUrl: 'http://127.0.0.1/jwks'` → throws; `createRemoteJWKSet` **not** called.
+6. **`exchangeCodeForTokens` refuses a plain-`http` `tokenUrl`** in strict mode → throws, and the mocked `safeFetch` is **never** called (the secret never leaves the process).
+7. **Timeouts are passed** — assert the mocked `safeFetch` received `timeoutMs: 10_000` for discovery/token/userinfo.
+
+`apps/api/src/routes/sso.test.ts` — add:
+
+8. **`getOIDCConfig` re-validates persisted endpoints at runtime** — prime the callback's provider re-read with `tokenUrl: 'http://evil.example.com/token'` → the callback redirects to `/login?error=sso_failed` (the existing catch-all in the outer `try/catch`) and `exchangeCodeForTokens` is **never** called.
+9. **`GET /login/:orgId` returns 400 for a provider with an unsafe persisted endpoint** (not an unhandled 500).
+10. **M4 — the `#1105` tripwire is pinned.** `verifyIdTokenSignature` now runs inside `safeFetch`, which calls `assertOutsideHeldDbContext('safeFetch')` (throws in strict/CI). Assert that calling `verifyIdTokenSignature` **inside a held DB context** trips the tripwire, so nobody later moves the callback's call site (`routes/sso.ts:1501`, currently outside any context — safe) into a `withSystemDbAccessContext` block and turns every SSO login into a 500. In `services/sso.test.ts`, wrap the call in whatever the codebase's held-context test harness is (grep `assertOutsideHeldDbContext` for the existing pattern) and `await expect(...).rejects.toThrow(/safeFetch/)`.
+
+`apps/api/src/services/urlSafety.test.ts` — add:
+
+11. **`maxBytes` overrun destroys the socket and throws** — serve a body larger than `maxBytes` from the test HTTP server the suite already uses → `await expect(safeFetch(url, { maxBytes: 1024 })).rejects.toThrow(ResponseTooLargeError)`.
+12. **A body under `maxBytes` still resolves normally**, and **`maxBytes` unset is unbounded** (no behavior change for existing callers).
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/services/sso.test.ts src/services/urlSafety.test.ts src/routes/sso.test.ts -t 'SR2-1'
+cd apps/api && pnpm vitest run src/services/urlSafety.test.ts -t 'maxBytes'
+```
+Expected: **FAIL** — `maxBytes`/`ResponseTooLargeError` do not exist (the body read is unbounded); `assertSafeOidcEndpoint`/`validateDiscoveredEndpoints` do not exist; `createRemoteJWKSet` is called with **no** `customFetch`; `exchangeCodeForTokens` happily POSTs to `http://`.
+
+- [ ] **Step 3: Implement — bounded body read in `services/urlSafety.ts`**
+
+Add the error class next to `SsrfBlockedError` (`:23`):
+
+```ts
+/** The response body exceeded the caller's `maxBytes` ceiling. The socket is destroyed. */
+export class ResponseTooLargeError extends Error {
+  constructor(public readonly maxBytes: number) {
+    super(`response body exceeded maxBytes (${maxBytes})`);
+    this.name = 'ResponseTooLargeError';
+  }
+}
+```
+
+Add the option to `SafeFetchInit` (`:190-197`):
+
+```ts
+  /**
+   * Hard ceiling on the response body in bytes. On overrun the socket is
+   * destroyed and ResponseTooLargeError is thrown — the partial body is never
+   * buffered further. Unset = unbounded (legacy behavior for existing callers).
+   *
+   * safeFetch previously had NO size cap: it buffered whatever the remote sent.
+   * That is an unauthenticated memory-exhaustion vector wherever a remote host
+   * is attacker-influenced and the calling route is public — e.g. the SSO
+   * callback's JWKS fetch.
+   */
+  maxBytes?: number;
+```
+
+Replace the body accumulation (`:360-363`):
+
+```ts
+      const chunks: Buffer[] = [];
+      let received = 0;
+      const maxBytes = init.maxBytes;
+      res.on('data', (chunk: Buffer) => {
+        received += chunk.length;
+        if (maxBytes !== undefined && received > maxBytes) {
+          req.destroy();
+          reject(new ResponseTooLargeError(maxBytes));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      res.on('end', () => {
+        const bodyBytes = Buffer.concat(chunks);
+        // …unchanged Response construction below…
+```
+
+(`req` is the `http(s).request` handle already in scope at that point — confirm the identifier name before writing; the surrounding block already calls `res.on('error', reject)`.)
+
+- [ ] **Step 3b: Implement — `services/sso.ts`**
+
+Imports (`:1-3`):
+
+```ts
+import { randomBytes, createHash } from 'crypto';
+import { createRemoteJWKSet, jwtVerify, customFetch } from 'jose';
+import { safeFetch, SsrfBlockedError, isPrivateIp, isAlwaysBlockedIp } from './urlSafety';
+```
+
+Add to `OIDCConfig` (`:9-18`):
+
+```ts
+export interface OIDCConfig {
+  issuer: string;
+  clientId: string;
+  clientSecret: string;
+  authorizationUrl: string;
+  tokenUrl: string;
+  userInfoUrl: string;
+  jwksUrl?: string;
+  scopes: string;
+  /**
+   * Self-host escape hatch for an internal IdP on an RFC1918 address / plain
+   * HTTP. Resolved ONCE by getOIDCConfig from selfHostAllowsPrivateNetwork() —
+   * never from a request-supplied value. Loopback/link-local/metadata stay
+   * blocked either way (safeFetch's isAlwaysBlockedIp).
+   */
+  allowPrivateNetwork?: boolean;
+}
+```
+
+Add the shared endpoint policy (place it directly after `isInternalUrl`, ~`:411`):
+
+```ts
+/** Wall-clock cap for provider-controlled OIDC fetches. None was set before (SR2-14). */
+export const OIDC_FETCH_TIMEOUT_MS = 10_000;
+/** JWKS cap — matches jose's own default so a healthy IdP sees no change. */
+export const OIDC_JWKS_TIMEOUT_MS = 5_000;
+/**
+ * Body ceiling for every OIDC document (discovery, token, userinfo, JWKS). All
+ * four are small; 1 MiB is orders of magnitude of headroom. safeFetch had NO size
+ * cap, and /sso/callback is UNAUTHENTICATED — so a compromised IdP returning a
+ * multi-GB JWKS would have been an unauthenticated memory-exhaustion vector the
+ * moment JWKS started flowing through safeFetch (SR2-13).
+ */
+export const OIDC_MAX_RESPONSE_BYTES = 1 * 1024 * 1024;
+
+/**
+ * One policy gate for every endpoint we will either PERSIST from a discovery
+ * document or USE at runtime (SR2-14). Enforces HTTPS (http only in self-host
+ * mode) and rejects loopback/link-local/private/metadata targets, delegating the
+ * IP predicates to urlSafety. This is the check that stops a malicious discovery
+ * document from making Breeze POST the DECRYPTED client_secret in cleartext.
+ */
+export function assertSafeOidcEndpoint(
+  label: string,
+  urlStr: string | null | undefined,
+  allowPrivateNetwork = false,
+): void {
+  if (!urlStr) {
+    throw new Error(`OIDC endpoint missing: ${label}`);
+  }
+  if (isInternalUrl(urlStr, allowPrivateNetwork)) {
+    throw new Error(`OIDC endpoint rejected (must be HTTPS and publicly routable): ${label}`);
+  }
+}
+
+/**
+ * Validate every endpoint a discovery document would cause us to persist,
+ * BEFORE it is persisted. Discovery output was written verbatim with zero
+ * validation (routes/sso.ts:527-542) — no scheme check, no private-IP check.
+ */
+export function validateDiscoveredEndpoints(
+  doc: OIDCDiscoveryDocument,
+  allowPrivateNetwork = false,
+): void {
+  assertSafeOidcEndpoint('authorization_endpoint', doc.authorization_endpoint, allowPrivateNetwork);
+  assertSafeOidcEndpoint('token_endpoint', doc.token_endpoint, allowPrivateNetwork);
+  assertSafeOidcEndpoint('userinfo_endpoint', doc.userinfo_endpoint, allowPrivateNetwork);
+  assertSafeOidcEndpoint('jwks_uri', doc.jwks_uri, allowPrivateNetwork);
+}
+```
+
+Replace the JWKS cache + `getIdTokenJwks` (`:266-281`):
+
+```ts
+// Cache one remote JWKS set per (policy, jwks_uri). jose refreshes on `kid` miss
+// and on cacheMaxAge expiry, so this avoids re-fetching on every login.
+//
+// BOUNDED (SR2-13): the key is tenant-influenced (an admin picks the issuer), so
+// an unbounded Map was a slow memory-growth vector. 500 entries is far beyond any
+// realistic provider count; the oldest is evicted first (Map preserves insertion
+// order).
+const MAX_JWKS_CACHE_ENTRIES = 500;
+const idTokenJwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+
+function getIdTokenJwks(
+  jwksUri: string,
+  allowPrivateNetwork: boolean,
+): ReturnType<typeof createRemoteJWKSet> {
+  // The policy flag is part of the key: a self-host-permissive JWKS set must
+  // never be served to a strict caller.
+  const cacheKey = `${allowPrivateNetwork ? 'priv' : 'pub'}|${jwksUri}`;
+  let jwks = idTokenJwksCache.get(cacheKey);
+  if (!jwks) {
+    jwks = createRemoteJWKSet(new URL(jwksUri), {
+      cacheMaxAge: 10 * 60 * 1000, // 10 minutes
+      cooldownDuration: 30 * 1000,
+      // SR2-13: inject the SSRF-safe transport into jose itself. A URL check at
+      // construct time would NOT be enough — jose re-fetches the JWKS on its own
+      // whenever a `kid` misses or cacheMaxAge expires, using its GLOBAL fetch
+      // (undici): no scheme check, no private-IP check, no DNS pinning. Routing
+      // those refreshes through safeFetch is the only way to satisfy the design's
+      // "caching must not bypass transport validation on refresh".
+      //
+      // safeFetch(urlStr, init) is signature-compatible with jose's
+      // FetchImplementation: (url: string, options) => Promise<Response>.
+      [customFetch]: (url: string, options: Record<string, unknown>) =>
+        safeFetch(url, {
+          ...(options as object),
+          timeoutMs: OIDC_JWKS_TIMEOUT_MS,
+          maxBytes: OIDC_MAX_RESPONSE_BYTES, // unauthenticated route: cap the body
+          allowPrivateNetwork,
+        }),
+    });
+
+    if (idTokenJwksCache.size >= MAX_JWKS_CACHE_ENTRIES) {
+      const oldest = idTokenJwksCache.keys().next().value;
+      if (oldest !== undefined) idTokenJwksCache.delete(oldest);
+    }
+    idTokenJwksCache.set(cacheKey, jwks);
+  }
+  return jwks;
+}
+```
+
+In `verifyIdTokenSignature` (`:298-329`), replace the head:
+
+```ts
+export async function verifyIdTokenSignature(
+  idToken: string,
+  config: OIDCConfig,
+  nonce: string
+): Promise<IDTokenClaims> {
+  if (!config.jwksUrl) {
+    throw new Error('Cannot verify ID token signature: provider has no JWKS URL configured');
+  }
+
+  const allowPrivateNetwork = config.allowPrivateNetwork ?? false;
+  // Reject the URL before jose ever constructs a key set for it (SR2-13). The
+  // customFetch injection below covers every actual request, including jose's
+  // internal refreshes; this is the cheap up-front rejection.
+  assertSafeOidcEndpoint('jwks_uri', config.jwksUrl, allowPrivateNetwork);
+
+  const jwks = getIdTokenJwks(config.jwksUrl, allowPrivateNetwork);
+  // …unchanged jwtVerify + nonce check below…
+```
+
+In `exchangeCodeForTokens` (`:117-146`), before building the body:
+
+```ts
+export async function exchangeCodeForTokens(params: TokenExchangeParams): Promise<OIDCTokenResponse> {
+  const { config, code, redirectUri, codeVerifier } = params;
+
+  // SR2-14: this request carries the DECRYPTED client_secret. A malicious or
+  // compromised discovery document could point token_endpoint at a plain-HTTP
+  // public host and exfiltrate it in cleartext. Refuse before the body is built.
+  const allowPrivateNetwork = config.allowPrivateNetwork ?? false;
+  assertSafeOidcEndpoint('token_endpoint', config.tokenUrl, allowPrivateNetwork);
+  // …existing body construction…
+```
+and the fetch:
+```ts
+  const response = await safeFetch(config.tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'Accept': 'application/json' },
+    body: body.toString(),
+    timeoutMs: OIDC_FETCH_TIMEOUT_MS,
+    maxBytes: OIDC_MAX_RESPONSE_BYTES,
+    allowPrivateNetwork,
+  });
+```
+
+Apply the same additions (`assertSafeOidcEndpoint` + `timeoutMs` + `maxBytes` + `allowPrivateNetwork`) to `getUserInfo` (`:152-168`, label `'userinfo_endpoint'`, `config.userInfoUrl`) and `refreshAccessToken` (`:174-196`, label `'token_endpoint'`, `config.tokenUrl` — dead code today but must not become a live hole later).
+
+In `discoverOIDCConfig` (`:424-460`), replace the return:
+
+```ts
+  if (!response.ok) {
+    throw new Error(`OIDC discovery failed: ${response.status}`);
+  }
+
+  const doc = (await response.json()) as OIDCDiscoveryDocument;
+  // SR2-14: validate BEFORE the caller persists these. Discovery output was
+  // written to sso_providers verbatim with zero validation.
+  validateDiscoveredEndpoints(doc, allowPrivateNetwork);
+  return doc;
+```
+and add `timeoutMs: OIDC_FETCH_TIMEOUT_MS, maxBytes: OIDC_MAX_RESPONSE_BYTES` to its `safeFetch` init.
+
+- [ ] **Step 4: Implement — `routes/sso.ts`**
+
+Extend the `'../services/sso'` import to add `assertSafeOidcEndpoint`.
+
+Replace `getOIDCConfig` (`:290-307`):
+
+```ts
+function getOIDCConfig(provider: typeof ssoProviders.$inferSelect): OIDCConfig {
+  const decryptedClientSecret = decryptForColumn('sso_providers', 'client_secret', provider.clientSecret);
+
+  if (!provider.clientId || !decryptedClientSecret || !provider.issuer) {
+    throw new Error('Provider is not fully configured');
+  }
+
+  // Resolved ONCE here, from deployment config — never from a request value.
+  const allowPrivateNetwork = selfHostAllowsPrivateNetwork();
+
+  const config: OIDCConfig = {
+    issuer: provider.issuer,
+    clientId: provider.clientId,
+    clientSecret: decryptedClientSecret,
+    authorizationUrl: provider.authorizationUrl || `${provider.issuer}/authorize`,
+    tokenUrl: provider.tokenUrl || `${provider.issuer}/oauth/token`,
+    userInfoUrl: provider.userInfoUrl || `${provider.issuer}/userinfo`,
+    jwksUrl: provider.jwksUrl || undefined,
+    scopes: provider.scopes || 'openid profile email',
+    allowPrivateNetwork
+  };
+
+  // SR2-14: RE-VALIDATE persisted endpoints at runtime. They were trusted
+  // blindly: discovery wrote them verbatim, and PATCH can change `issuer`
+  // WITHOUT re-running discovery, so tokenUrl/jwksUrl could still point at the
+  // previous (or an attacker's) IdP. The `${issuer}/…` string-concat fallbacks
+  // above are validated by the same gate.
+  assertSafeOidcEndpoint('authorization_endpoint', config.authorizationUrl, allowPrivateNetwork);
+  assertSafeOidcEndpoint('token_endpoint', config.tokenUrl, allowPrivateNetwork);
+  assertSafeOidcEndpoint('userinfo_endpoint', config.userInfoUrl, allowPrivateNetwork);
+  if (config.jwksUrl) {
+    assertSafeOidcEndpoint('jwks_uri', config.jwksUrl, allowPrivateNetwork);
+  }
+
+  return config;
+}
+```
+
+`getOIDCConfig` now throws for an unsafe persisted endpoint. The **callback** call site (`~:1470`) is already inside the big `try { … } catch` → it becomes the existing `sso_failed` redirect. The other four call sites are **not** in a try block and would surface as an unhandled 500. Wrap each:
+
+- `POST /sso/link/start/:providerId` (`~:1090`)
+- `GET /sso/login/partner/:partnerId` (`~:1219`)
+- `GET /sso/login/:orgId` (`~:1317`)
+- `POST /providers/:id/test` (`~:2105` — confirm the exact line with `grep -n "getOIDCConfig(" apps/api/src/routes/sso.ts`)
+
+```ts
+  let config: OIDCConfig;
+  try {
+    config = getOIDCConfig(provider);
+  } catch (err) {
+    console.warn(`[sso] provider ${provider.id} has an invalid configuration:`, err);
+    return c.json({ error: 'SSO provider configuration is invalid' }, 400);
+  }
+```
+(The `/test` route already relays a message to the UI — return its message verbatim there, matching its existing shape.)
+
+**POST `/providers`** — the discovery block (`:527-542`) needs no change *in shape*: `discoverOIDCConfig` now throws on an unsafe document, the existing `catch` logs and leaves the endpoint columns NULL, and the provider is created unusable-until-fixed. Upgrade the log so the failure is observable:
+
+```ts
+    } catch (error) {
+      // Discovery failed OR returned endpoints that failed SSRF/HTTPS validation
+      // (SR2-14). Either way we persist NO endpoints — an unusable provider is
+      // strictly better than one pointing at an attacker-controlled endpoint.
+      console.warn('OIDC discovery failed or was rejected:', error);
+      captureException(error instanceof Error ? error : new Error(String(error)));
+    }
+```
+(`captureException` is already imported at `sso.ts:39`.)
+
+**PATCH `/providers/:id`** — re-run discovery when `issuer` changes. Insert immediately before the `updates` object is built (`:630`). This requires selecting `issuer` and `type` on the `existing` read (`:601-605`) — extend that select's field list:
+
+```ts
+  // SR2-14: repointing the issuer WITHOUT re-discovery leaves tokenUrl/jwksUrl
+  // aimed at the OLD IdP (or, with a crafted discovery doc, an attacker's).
+  // Re-discover; if that fails or is rejected, CLEAR the endpoints (fail closed)
+  // rather than keep stale ones. The provider is unusable until it is fixed —
+  // which is the correct outcome for a half-repointed IdP.
+  const issuerChanged = body.issuer !== undefined && body.issuer !== existing.issuer;
+  const rediscovered: Partial<typeof ssoProviders.$inferInsert> = {};
+  if (issuerChanged && (body.type ?? existing.type) === 'oidc') {
+    try {
+      const discovery = await discoverOIDCConfig(body.issuer!, {
+        allowPrivateNetwork: selfHostAllowsPrivateNetwork()
+      });
+      rediscovered.authorizationUrl = discovery.authorization_endpoint;
+      rediscovered.tokenUrl = discovery.token_endpoint;
+      rediscovered.userInfoUrl = discovery.userinfo_endpoint;
+      rediscovered.jwksUrl = discovery.jwks_uri;
+    } catch (error) {
+      console.warn(`[sso] re-discovery failed for provider ${providerId} after issuer change:`, error);
+      captureException(error instanceof Error ? error : new Error(String(error)));
+      rediscovered.authorizationUrl = null;
+      rediscovered.tokenUrl = null;
+      rediscovered.userInfoUrl = null;
+      rediscovered.jwksUrl = null;
+    }
+  }
+```
+and fold it into `updates`. **This is the CANONICAL final form of that object** (Task 3 added the stamp, Task 4 the version bump, Task 7 the re-discovery):
+
+```ts
+  const updates: Partial<typeof ssoProviders.$inferInsert> = {
+    ...body,
+    ...rediscovered,                                                            // Task 7 (must come AFTER ...body so it overrides stale endpoints)
+    updatedAt: new Date(),
+    ...(body.defaultRoleId ? { defaultRoleConfiguredBy: auth.user.id } : {}),   // Task 3
+    configVersion: sql`${ssoProviders.configVersion} + 1` as unknown as number, // Task 4
+  };
+```
+
+- [ ] **Step 5: Run to verify they pass**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/services/urlSafety.test.ts src/services/sso.test.ts src/routes/sso.test.ts
+```
+Expected: **PASS** (whole files). `urlSafety.test.ts` must be fully green — `maxBytes` is unset for every existing caller, so their behavior is unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/urlSafety.ts apps/api/src/services/urlSafety.test.ts apps/api/src/services/sso.ts apps/api/src/services/sso.test.ts apps/api/src/routes/sso.ts apps/api/src/routes/sso.test.ts
+git commit -m "feat(sso): SSRF-safe JWKS via jose customFetch; bounded safeFetch body reads; validate discovery output before persisting and persisted endpoints at runtime; enforce HTTPS on tokenUrl; add timeouts (SR2-13, SR2-14)"
+```
+
+---
+
+### Task 8: Integration tests + verification gate
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/ssoHardening.integration.test.ts`
+- Create: `apps/api/src/__tests__/integration/ssoSessionsRls.integration.test.ts`
+
+**Interfaces:**
+- Consumes: everything above; the integration harness (`__tests__/integration/db-utils.ts`) and real Postgres on **:5433**. Model the app bootstrap + provider/user seeding on **`apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts`** (850+ lines): it mounts the REAL `ssoRoutes` against the RLS-enforced pool and mocks **only** `exchangeCodeForTokens` / `getUserInfo` / `verifyIdTokenSignature` via `vi.mock('../../services/sso', async (importOriginal) => ({ ...(await importOriginal()), … }))`, and sets `APP_ENCRYPTION_KEY` at module top (required by the state-cookie HMAC). **Reuse that spread-importOriginal shape** — a full factory would strip `readEmailVerifiedClaim` / `assertSafeOidcEndpoint`.
+- Model the RLS forge on `ssoProvidersPartnerRls` / `ssoVerifiedDomainsRls`. **Beware the memoized-fixture trap:** if the forge helper is memoized across tests it can vacuously pass — assert the *specific* Postgres error code, not merely "it threw".
+
+- [ ] **Step 1: Write `ssoSessionsRls.integration.test.ts`**
+
+Prove the Task-1 policy is real, not decorative:
+
+1. **Cross-scope SELECT is denied.** Insert an `sso_sessions` row under `withSystemDbAccessContext`. Then, under an **org-scoped** DB context (`withDbAccessContext` for a seeded org), `SELECT * FROM sso_sessions WHERE state = …` → **0 rows** (FORCE RLS + system-only policy ⇒ the row is invisible, not an error).
+2. **Cross-scope INSERT is denied with `42501`.** Under an org-scoped context, forge `INSERT INTO sso_sessions (provider_id, state, nonce, expires_at) VALUES (…)` → must fail with **`new row violates row-level security policy`** (SQLSTATE `42501`). Assert on the code/message, not just `.rejects.toThrow()`.
+3. **Cross-scope DELETE is a no-op.** Under an org-scoped context, `DELETE FROM sso_sessions WHERE state = …` → 0 rows affected, and the row still exists when re-read under system context (this is the property that stops a tenant from burning another tenant's pending state).
+4. **System context can do all three.**
+5. **C1 — `DELETE /providers/:id` fully succeeds with both blockers present.** This is the proof that Task 1's RLS did not brick provider deletion. Seed an org-axis provider; then create **(a)** a pending `sso_sessions` row for it (unexpired) and **(b)** a `user_sso_identities` row belonging to a **different** user than the deleting admin. Call the real `DELETE /providers/:id` route as an authorized org admin → **200**, and assert in system context that the provider row, the session row, **and the other user's identity row** are all gone. If this fails with FK violation **23503** or leaves rows behind, the corresponding delete is still 0-rowing under RLS — wrap it in system context (Task 1 Step 5b already wraps both; this test is what confirms it, since `user_sso_identities` is `USER_ID_SCOPED` (`breeze_current_user_id()`) and may have been silently 0-rowing for other users' rows **even before this PR**).
+
+- [ ] **Step 2: Write `ssoHardening.integration.test.ts`**
+
+Five real-Postgres proofs, one per hardening layer:
+
+1. **Provider disabled mid-flow → callback rejects.** Seed an active org-axis OIDC provider + a user linked by `(provider, sub)`. Drive `GET /sso/login/:orgId` to create a real `sso_sessions` row (capture `state` + the `Set-Cookie`). Then `UPDATE sso_providers SET status='inactive', config_version = config_version + 1`. Then `GET /sso/callback?code=…&state=…` with the cookie → **302 to `/login?error=sso_provider_inactive`**, and assert **no** new `refresh_token_families` row was minted for the user.
+2. **Config change → version bump invalidates a pending session.** Same setup, but instead `PATCH /providers/:id` (through the real route, as an authorized admin — or `UPDATE sso_providers SET config_version = config_version + 1` if the route auth fixture is heavy) leaving `status='active'`. Callback → **302 to `/login?error=sso_config_changed`**. Also assert the `sso_sessions` row is **gone** (the atomic claim burned it) — a rejected session must not be retryable.
+3. **Logout invalidates a pending link.** Seed a user with a live `refresh_token_families` row (`family_id = F`, `revoked_at IS NULL`). Insert a link `sso_sessions` row bound to `{ linkUserId: u, initiatingAuthEpoch: e.auth, initiatingMfaEpoch: e.mfa, initiatingSessionId: F, providerVersion: p.config_version }`. Then `UPDATE refresh_token_families SET revoked_at = now() WHERE family_id = F` (what logout does durably). Drive the callback → **302 to `/settings/profile?ssoLinkError=session_invalid`**, and assert **no `user_sso_identities` row** was created. Repeat the same assertion for an `auth_epoch` bump (`UPDATE users SET auth_epoch = auth_epoch + 1`) — this is the password-reset / suspension / global-revocation path.
+4. **Domain-ownership gate on auto-link.** Seed an org-axis provider, a **passwordless** user in the org with email `alice@corp.example` and **no** `(provider, sub)` link, and **no** verified domain for the org. Drive a callback whose id_token omits `email_verified` and whose email is `alice@corp.example` → **302 to `/login?error=sso_email_unverified`**, and assert **no `user_sso_identities` row**. Then insert a verified `sso_verified_domains` row for `corp.example` and re-drive → the auto-link **succeeds** (a `user_sso_identities` row appears) — proving the gate is the domain, not a blanket refusal.
+5. **JIT default-role ceiling (SR2-10) fires against real permission rows.** Seed an org-axis provider with `auto_provision=true`, `default_role_configured_by = adminUser`, and a `default_role_id` pointing at an org role that holds a permission the admin does **not** hold. Drive a callback for a brand-new email (with a verified domain so Test 4's gate passes) → **302 to `/login?error=invalid_provider_configuration`** and **no new `users` row**. Then grant the admin that permission and re-drive → the user **is** provisioned.
+6. **C2 — a PARTNER ADMIN with NO org membership can configure a working org-axis provider.** This is the case Test 5 cannot catch (it seeds an org member) and that the Task-3 unit tests cannot catch (they mock `roleAssignment` wholesale). Seed a partner, an org under it, and a **partner admin** who has a `partner_users` row (with `orgAccess`) and **NO `organization_users` row**. Create an org-axis provider with `default_role_configured_by = thatPartnerAdmin` and a `default_role_id` whose permissions are **within** their ceiling. Drive a JIT callback for a brand-new email → **the user IS provisioned** (302 to the success path, a new `users` + `organization_users` row). If this reds with `/login?error=invalid_provider_configuration`, `getUserPermissions` was called with only `{ orgId }` and returned `null` — the single-axis bug. This is the **normal MSP topology**, so this test is the regression guard for "every JIT sign-in fails forever".
+7. **`default_role_configured_by` repair path (SR2-10 / C3).** Seed a provider whose `default_role_configured_by` names a user who has since been **suspended / stripped of the permission**. Drive a JIT callback → rejected. Then `PATCH /providers/:id` re-setting the same `defaultRoleId` as a **current, adequately-permissioned admin** → assert the column is re-stamped, and re-drive the callback → the user **is** provisioned. (This proves the offboarded-configurer deadlock is repairable without recreating the provider, which would orphan every `user_sso_identities` row.)
+8. **Unknown configurer → JIT proceeds, ceiling-skipped audit is written (I1).** Seed a provider with `default_role_configured_by = NULL` **and** `created_by = NULL` (the legacy shape) and a structurally-valid `default_role_id`. Drive a JIT callback → the user **is** provisioned, **and** an `audit_logs` row exists with `action = 'sso.callback.jit_ceiling_skipped'`. This is the one path where the permission ceiling is not applied; if it is not auditable, it is not acceptable.
+
+- [ ] **Step 2b: Update `ssoPartnerLogin.integration.test.ts` fixtures (M2)**
+
+This pre-existing real-DB SSO suite is the most likely casualty of Tasks 4-7 and **this plan explicitly authorizes editing it**:
+- Its seeded `sso_providers` rows need `config_version` (the column default handles it — confirm the seed helper doesn't `INSERT` an explicit column list that omits it in a way that breaks).
+- Its seeded/driven `sso_sessions` rows need **`provider_version` matching the provider's `config_version`**, or Task 4's gate rejects every one of its callbacks with `sso_config_changed`.
+- If any of its providers are seeded with a `status` other than `'active'`, the login-mode gate now rejects them.
+- Its `vi.mock('../../services/sso', …)` must keep the `importOriginal` spread (a full factory would strip `readEmailVerifiedClaim` / `assertSafeOidcEndpoint`).
+
+Make these edits **as part of this task** and run the suite; do not treat its failures as flakes.
+
+- [ ] **Step 3: Run the integration suites**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/ssoSessionsRls.integration.test.ts \
+  src/__tests__/integration/ssoHardening.integration.test.ts \
+  src/__tests__/integration/ssoPartnerLogin.integration.test.ts
+```
+Expected: **PASS**. Requires the integration Postgres on **:5433** (single-fork; the harness runs `autoMigrate` on it, which applies the new `2026-07-16-*` migration). `ssoPartnerLogin.integration.test.ts` is included deliberately — it is the pre-existing real-DB SSO suite and is the most likely thing Tasks 4-7 broke (its seeded providers now need `config_version`, and its sessions need `provider_version`).
+
+**TDD discipline:** briefly revert one production line (e.g. the `checkProviderGeneration` call) and observe the corresponding test fail for the reviewed reason before restoring it.
+
+- [ ] **Step 4: Commit the integration tests**
+
+```bash
+git add apps/api/src/__tests__/integration/ssoSessionsRls.integration.test.ts apps/api/src/__tests__/integration/ssoHardening.integration.test.ts apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
+git commit -m "test(sso): real-DB coverage for provider generation, link binding, domain gate, JIT ceiling, sso_sessions RLS"
+```
+
+- [ ] **Step 5: Full verification gate**
+
+Typecheck + build (Type Check includes test files):
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm typecheck && pnpm build
+```
+Expected: no type errors; build succeeds. (`tsc` is OOM-prone project-wide — if it dies, re-run; do not "fix" it by loosening types.)
+
+Focused serial unit/route suites — **every file this PR touched, named explicitly** (the API suite is parallel-flaky):
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run \
+  src/services/roleAssignment.test.ts \
+  src/services/urlSafety.test.ts \
+  src/services/sso.test.ts \
+  src/routes/sso.test.ts \
+  src/routes/users.test.ts \
+  src/routes/auth/ssoPolicy.test.ts \
+  src/services/ssoDomainVerification.test.ts
+```
+Expected: **PASS**.
+
+Web (Task 6 Step 5 touched `ConnectSsoCard`):
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+pnpm test --filter=@breeze/web -- ConnectSsoCard
+```
+Expected: **PASS** — including the repointed `session_invalid` case and the three new arms.
+
+Migration drift (a migration **was** added — this must still be clean):
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+cd apps/api && pnpm db:check-drift
+```
+Expected: **no drift** (the Drizzle schema in `db/schema/sso.ts` matches `2026-07-16-sso-session-binding-and-provider-version.sql` exactly). Drift here almost always means a column type or nullability mismatch — fix the *schema*, never by editing the shipped migration.
+
+Migration ordering regression test + RLS suite + integration:
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+cd apps/api && pnpm vitest run src/db/autoMigrate.test.ts && \
+  pnpm vitest run --config vitest.config.rls.ts && \
+  pnpm vitest run --config vitest.integration.config.ts \
+    src/__tests__/integration/rls-coverage.integration.test.ts \
+    src/__tests__/integration/ssoSessionsRls.integration.test.ts \
+    src/__tests__/integration/ssoHardening.integration.test.ts \
+    src/__tests__/integration/ssoPartnerLogin.integration.test.ts \
+    src/__tests__/integration/ssoProvidersPartnerRls.integration.test.ts \
+    src/__tests__/integration/tenantCascadeSso.integration.test.ts
+```
+Expected: **PASS**. `tenantCascadeSso` is included because Task 1 adds a FK-free `initiating_session_id` column — confirm the cascade sweep is unaffected.
+
+Idempotency check (re-applying the migration must be a no-op):
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+docker exec -i breeze-postgres psql -U breeze -d breeze -f - < apps/api/migrations/2026-07-16-sso-session-binding-and-provider-version.sql
+```
+Expected: no errors, no duplicate-object failures (the DELETE reports 0 rows the second time).
+
+- [ ] **Step 6: STOP — do not open the PR**
+
+The controller opens the PR after a whole-branch review. Push the branch and report:
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+git push -u origin core-auth-3-sso-oidc
+```
+
+Report to the controller: the gate output, plus these items, **all of which must appear in the PR body**:
+
+**Known gaps (deliberate, documented):**
+1. **Partner-axis domain verification does not exist** — `sso_verified_domains.org_id` is `NOT NULL`, so SR2-12's absent-claim gate is **org-axis only**; the partner axis keeps today's absent-claim tolerance. Follow-up: make `sso_verified_domains` dual-axis (PARTNER-WIDE FIRST).
+2. **No resolvable configurer ⇒ structural-only JIT re-validation** (legacy rows with both `default_role_configured_by` and `created_by` NULL). Loudly audited (`sso.callback.jit_ceiling_skipped`); repair = re-save the default role as a current admin.
+3. **No port allowlist** (SR2-14). Explicitly out of scope — it would risk breaking legitimate self-hosted IdPs on nonstandard ports, and the sharp risks (scheme, destination IP, body size) are all closed. **Do not let the PR body imply full SR2-14 coverage.**
+
+**Operational notes:**
+4. The migration **purges in-flight `sso_sessions`** — a ≤10-minute window of interrupted SSO round-trips at deploy (and PR 1 already forces a global sign-out on this branch).
+5. **`DELETE /providers/:id` was silently broken-in-waiting**: enabling RLS on `sso_sessions` would have made its cleanup delete 0-row and the FK-uncascaded provider delete then 500. Fixed here and proved with a real-DB test — call it out so reviewers know why that route changed.
+6. **`safeFetch` gained a `maxBytes` bounded read** — a shared-utility change that touches every outbound-fetch caller in the repo (opt-in; unset = unchanged). Flag it for a wider look than the SSO diff.
+
+---
+
+## Self-Review
+
+**Spec coverage (PR 3 scope, SR2-10 … SR2-14):**
+
+| Finding | Design-doc requirement | Task |
+|---|---|---|
+| **SR2-10** | "SSO provider default-role configuration uses the same assignable-role and permission-subset validation as normal user administration." | Task 2 (extract the canonical validator) + Task 3 (apply at config time on **both** axes — the org axis validated nothing) |
+| **SR2-10** | "Validation runs when configuration is saved **and again immediately before JIT provisioning**." | Task 3 (`revalidateSsoDefaultRole` against the configurer's live ceiling) |
+| **SR2-10** | "JIT remains limited to the provider's own partner/organization axis." | Already true (`provisionOrgId = provider.orgId!`) — asserted, not rebuilt |
+| **SR2-11** | "SSO providers gain a monotonic configuration version. Pending SSO sessions store provider ID/version." | Task 1 (schema) + Task 4 (bump + snapshot) |
+| **SR2-11** | "Callback … rejects **inactive providers**, version mismatch…" | Task 4 (`checkProviderGeneration`; status was **never** checked before) |
+| **SR2-11** | "Account-link sessions additionally store initiating user ID, auth epoch, and `session_id`." | Task 1 (schema) + Task 5 (capture at `/link/start`) |
+| **SR2-11** | "Callback … rejects … auth-epoch mismatch, a revoked/expired initiating refresh family, tenant mismatch, or expired/consumed state." | Task 5 (`validateLinkBinding`) |
+| **SR2-11** | "Logout invalidates link transactions through their bound refresh family; password reset, email change, status change, and global session revocation invalidate them through auth-epoch or family mismatch." | Task 5 + Task 8 proof #3 |
+| **SR2-12** | "Explicit `email_verified=false` is always rejected." | Task 6 (now also on the **userinfo** path, which had zero readers) |
+| **SR2-12** | "Missing verification is rejected unless an explicit provider adapter documents and enforces an equivalent guarantee." | Task 6 (absent ⇒ org-domain ownership proof via `isDomainVerifiedForOrg`) — **org axis only; partner axis is a documented gap** |
+| **SR2-12** | "Auto-linking remains passwordless-only and subject to verified-domain ownership." | Task 6 (passwordless-only already true; domain gate now covers auto-link, plus the missing org clamp) |
+| **SR2-13** | "Discovery and JWKS retrieval share one SSRF-safe transport… JWKS caching must not bypass transport validation on refresh." | Task 7 (`safeFetch` injected into jose via `customFetch` — construct-time-only would miss jose's refresh-on-`kid`-miss) |
+| **SR2-14** | "Persisted endpoints are revalidated at runtime." | Task 7 (`getOIDCConfig` gate) |
+| **SR2-14** | DNS + connection-time IP validation; loopback/link-local/private/metadata denial; redirect limits | **Already provided by `safeFetch`** (resolves once and *pins* the validated IP; follows **no** redirects; blocks every non-public range incl. IPv4-mapped IPv6). Asserted, not rebuilt. |
+| **SR2-14** | HTTPS enforcement | **NEW (Task 7)** — `assertSafeOidcEndpoint` on `tokenUrl` / `userInfoUrl` / `jwksUrl` / `authorizationUrl`, applied pre-persist, at runtime, and pre-fetch |
+| **SR2-14** | Time limits | **NEW (Task 7)** — none of the four SSO `safeFetch` calls passed `timeoutMs` before |
+| **SR2-14** | **Response-size limits** | **NEW (Task 7) — `safeFetch` had NO size cap.** It buffered the whole body (`urlSafety.ts:355-381`). Task 7 adds `maxBytes` to `SafeFetchInit` (bounded read → `req.destroy()` + `ResponseTooLargeError`) and gives the OIDC calls 1 MiB. Without this, routing JWKS through `safeFetch` would have turned the **unauthenticated** `/sso/callback` into a memory-exhaustion vector. |
+| **SR2-14** | **Allowed ports** | ❌ **NOT IMPLEMENTED — explicitly out of scope.** No port allowlist exists anywhere in the codebase, and adding one risks breaking legitimate self-hosted IdPs on nonstandard ports. The sharp risks (scheme → cleartext secret; destination IP → SSRF; body size → OOM) are all closed. **Must be stated plainly in the PR body — do not imply full coverage.** |
+| Contract | "Any new Postgres table/column … declares an RLS tenancy shape and registers in the rls-coverage allowlists in the same PR." | Task 1 (`sso_sessions` → ENABLE + FORCE + system-only policy, `INTENTIONAL_UNSCOPED` + a bespoke enforcing test) |
+| Regression | Enabling RLS on `sso_sessions` must not break the two authenticated bare-`db` writers | Task 1 Step 5a/5b (link-start INSERT + `DELETE /providers/:id` cleanup DELETEs) + Task 8 real-DB proof #5 |
+| Regression | New public link-error codes must render in the UI | Task 6 Step 5 (`ConnectSsoCard` `LINK_ERROR_KEYS` + i18n + tests) |
+| Verification | Node 22 build/typecheck, focused serial Vitest (API **and web**), migration drift, real-DB RLS/integration | Task 8 |
+
+**Decisions documented inline (nothing deferred to the reader):**
+- **Migration filename** `2026-07-16-sso-session-binding-and-provider-version.sql` — sorts after `2026-07-15-auth-epochs-and-family-expiry.sql`; no `-a-`/`-b-` infix needed (Task 1).
+- **Column names/types/nullability:** `sso_providers.config_version INTEGER NOT NULL DEFAULT 1`; `sso_sessions.provider_version / initiating_auth_epoch / initiating_mfa_epoch INTEGER NULL`, `initiating_session_id UUID NULL` (= `refresh_token_families.family_id` = the JWT `sid`). All four nullable **because login sessions have no initiating user** (Task 1).
+- **Login vs link mode** is `session.linkUserId != null` (unchanged); the `initiating_*` columns are read only in the link branch (Task 1/5).
+- **NULL ⇒ reject, not default-to-1** — backfilling would bless exactly the unbound sessions this PR invalidates. The migration purges them and reports the count (Task 1).
+- **`sso_sessions` RLS list:** `INTENTIONAL_UNSCOPED` (system-scope-only shape, alongside `partner_abuse_signals` / `software_product_resolutions`), **not** `EXEMPT_TABLES` (which only silences `org_id` auto-discovery, and `sso_sessions` has no `org_id`) and not any of the six tenant shapes (it satisfies none). Because neither list *asserts* anything, a bespoke enforcing `it(...)` is added to the contract file (Task 1).
+- **BOTH authenticated bare-`db` writers to `sso_sessions` move to `withSystemDbAccessContext`** — `/sso/link/start`'s INSERT **and `DELETE /providers/:id`'s cleanup DELETEs (`sso.ts:690-691`)**. The second is the dangerous one: the FK has no cascade, so a silently-0-rowing session delete makes provider deletion die with FK violation 23503. `user_sso_identities` (USER_ID_SCOPED) is wrapped alongside it, with a real-DB assertion in Task 8 rather than an assumption (Task 1 Step 5, Task 8 proof #5).
+- **`sso_providers.default_role_configured_by` is the JIT principal**, not `created_by` — `created_by` names the original creator (≠ the config-time caller) and is never rewritten, so an offboarded creator would brick JIT with no repair short of recreating the provider (which orphans every `user_sso_identities` row, since `(provider_id, external_id)` is the identity key). Stamped by every write that sets `defaultRoleId`; falls back to `created_by`, then to structural-only (Tasks 1, 3).
+- **The JIT configurer's permissions are resolved on BOTH axes** (`{ orgId, partnerId: <org's owning partner> }`). Single-axis `{ orgId }` runs only `resolveOrgAxis` (`permissions.ts:187-193`), which needs an `organization_users` row — which an **MSP partner admin has not got**. That would fail JIT forever on the normal MSP topology (Task 3; integration proof = Task 8 #6).
+- **The unknown-configurer fallback is LOUDLY AUDITED** (`sso.callback.jit_ceiling_skipped`, a real `writeRouteAudit`, not a `console.warn`) — it is the one path where the permission ceiling is not applied (Task 3; proof = Task 8 #8).
+- **The email_verified attestation is bound to the MAPPED address.** On the userinfo path, `attributeMapping.email` is admin-set jsonb and may name `upn`/`preferred_username`, while userinfo's `email_verified` attests userinfo.`email` — a different address. The claim counts only when the mapping key is literally `email` or the mapped value equals `userInfo.email`; otherwise it is `'absent'` and falls into the domain-ownership gate (Task 6).
+- **`safeFetch` gains a `maxBytes` bounded read** (shared utility, benefits every caller); a **port allowlist is explicitly out of scope** (Task 7).
+- **`validateAssignableRole`'s side-effect ORDER is preserved** — empty effective-permission set short-circuits BEFORE the caller is resolved, or a permission-less role would newly open a system transaction (`permissions.ts:135`) it never used to (Task 2).
+- **`AuthLike.scope` is REQUIRED**, not optional — `validateProviderDefaultRole` branches on `auth.scope === 'system'` and must not silently read `undefined` (Task 2).
+- **Web arm shipped in-PR** for the four new / one retired `ssoLinkError` codes; `user_gone` is removed as an account-state oracle (Task 6 Step 5).
+- **Do NOT cherry-pick Task 1 alone to a droplet** — Task 4 supplies the `provider_version` writers (Global Constraints).
+- **Callback status policy per mode:** login requires `active`; link requires `!== 'inactive'` — each mirrors its own init gate, so a `testing` provider can still complete a link it was allowed to start (Task 4).
+- **JIT ceiling = the provider's configuring admin (`created_by`), live.** `created_by IS NULL` ⇒ structural-only re-validation + warning, not a hard fail (would break every legacy provider). **Reviewer: challenge this.** (Task 3)
+- **System-scope callers skip the ceiling, keep the structural check** — a platform admin has no tenant permission set to compare against (Task 3).
+- **Org clamp is membership-bounded (`inArray` over `organization_users`), not `eq(users.orgId, …)`** — a column clamp would break legitimate multi-org users (Task 6).
+- **Absent-claim domain gate is ORG AXIS ONLY.** `sso_verified_domains.org_id` is `NOT NULL`; there is no partner-axis domain machinery, and gating the partner axis would reject every partner-axis Entra login. Partner axis has no JIT and already clamps hard. **Known gap; follow-up = make `sso_verified_domains` dual-axis (PARTNER-WIDE FIRST).** Must appear in the PR body (Task 6).
+- **A construct-time JWKS URL check is insufficient** — jose refetches internally on `kid` miss / cache expiry through its global fetch. `customFetch` injection is the only sufficient fix (Task 7).
+- **Audit `action`/`result` strings:** `sso.callback.rejected` (`result: 'denied'`, `details: { mode, phase, reason, partnerId, sessionVersion, providerVersion, claimSource, emailDomain }`) and `sso.identity.link_rejected` (`result: 'denied'`, `details: { reason, publicCode, partnerId, userId }`). Existing `sso.identity.link_started` / `sso.identity.linked` / `sso.provider.create` / `.update` / `.status.update` are unchanged. **Reason codes:** `provider_inactive`, `provider_not_usable`, `provider_version_missing`, `provider_version_mismatch`, `link_binding_missing`, `link_user_gone`, `link_user_inactive`, `link_epochs_unavailable`, `link_auth_epoch_mismatch`, `link_mfa_epoch_mismatch`, `link_family_missing`, `link_family_revoked`, `link_family_expired`, `link_axis_membership_lost`, `email_verified_false`, `email_verified_absent_domain_unverified`, `default_role_not_on_provider_axis`, `default_role_structure_invalid`, `default_role_exceeds_configurer_permissions`, `provider_axis_missing`. **None contains `state`, `code`, `code_verifier`, an id/access/refresh token, or a client secret** — only ids, reason strings, email *domains*, and version integers (Tasks 3-6).
+- **Public redirect codes** (generic but distinguishable, following the existing convention): login → `sso_provider_inactive`, `sso_config_changed`, `sso_email_unverified`, plus the existing `invalid_provider_configuration`, `sso_domain_unverified`, `sso_link_required`, `invite_required`, `session_expired`, `sso_failed`. Link → `provider_inactive`, `config_changed`, `session_invalid`, `email_unverified`, plus the existing `email_mismatch`, `identity_in_use`. **`user_gone` is retired from the link surface** (folded into `session_invalid`) because it was an account-state oracle (Tasks 4-6).
+
+**Placeholder scan:** every implementation step contains real, complete code. **No open choices remain** — Task 3's config-time rejection is pinned to **400** (matching the route's existing `defaultRoleId must be a…` style); the earlier "403 (or 400 — pick one)" is gone. The test steps that say "model on `<file>`" (Task 8's integration bootstrap; the `sso.test.ts` mock-queue re-ordering in Tasks 3/5/6) name the exact file, the exact helper (`primeLinkCallback`, `ssoStateCookieHeader`), and the exact assertions required — mandatory, because the hand-rolled Drizzle `mockReturnValueOnce` queues mirror the specific order of selects the route issues and cannot be authored blind. Two steps say "confirm the identifier before writing" (`req` in `urlSafety.ts`'s response handler; the `/providers/:id/test` `getOIDCConfig` line number) — these are deliberate one-line greps against real code, not deferred decisions. No TBD, no TODO, no "add error handling", no "similar to Task N".
+
+**Mock-queue shift inventory (the #1 source of phantom failures in `routes/sso.test.ts`):**
+| Task | Adds a `db.select()`? | Effect on existing queues |
+|---|---|---|
+| 3 | Yes — inside `revalidateSsoDefaultRole` (`organizations.partnerId`) | **None**, because the tests mock `../services/roleAssignment` wholesale |
+| 4 | No | None |
+| 5 | Yes — axis-membership row in `validateLinkBinding` | **Shifts every link test by one.** `primeLinkCallback` (`:2391-2398`) must be rewritten once |
+| 6 | Yes — the `inArray` subquery is a `db.select()` **at condition-construction time** | **Shifts every org-axis callback test that reaches the by-email branch by one.** Re-prime before writing new tests |
+| 7 | No | None |
+
+**Cross-task type consistency:**
+- `ScopeContext` / `AssignableRoleRow` / `AuthLike` (Task 2) are consumed identically by `routes/users.ts` (Task 2), `validateProviderDefaultRole` + `revalidateSsoDefaultRole` (Task 3). `validateAssignableRole(c, auth, role) : Promise<string | null>` keeps its exact pre-extraction signature and message strings, which is why `users.test.ts` must pass **unedited**.
+- `checkRoleStructure` / `checkRolePermissionCeiling` (Task 2) are the caller-independent halves used by Task 3's JIT path and by the system-scope config path. `AuthLike.scope` is **required** (`string`), so Task 3's `auth.scope === 'system'` branch is type-checked, not accidentally `undefined`.
+- `revalidateSsoDefaultRole` (Task 3) returns `{ ok: true; roleId: string; skippedCeiling: boolean } | { ok: false; reason: string }` — the `skippedCeiling` flag is what drives the `sso.callback.jit_ceiling_skipped` audit at the single call site. It reads `provider.defaultRoleConfiguredBy ?? provider.createdBy ?? null` (Task 1's column, then the legacy fallback) and passes **both** `{ orgId, partnerId }` to `getUserPermissions`.
+- `ssoProviders.configVersion: number` (Task 1) is read by `checkProviderGeneration` (Task 4) and written by the two bump sites (Task 4); `ssoSessions.providerVersion: number | null` is written at all three session-create sites (Task 4) and read by `checkProviderGeneration`. `ssoProviders.defaultRoleConfiguredBy: string | null` (Task 1) is written by POST + PATCH (Task 3) and read by the JIT gate (Task 3). **Tasks 3, 4 and 7 each add a key to the SAME PATCH `updates` object — Task 7 Step 4 shows its canonical final form; do not let three partial snippets drift into three different objects.**
+- `ssoSessions.initiatingAuthEpoch / initiatingMfaEpoch: number | null` and `initiatingSessionId: string | null` (Task 1) are written **only** by `/sso/link/start` (Task 5) and read **only** by `validateLinkBinding` (Task 5). `getUserEpochs` returns `{ authEpoch: number; mfaEpoch: number } | null`; `getRefreshFamily` returns `{ revokedAt: Date | null; absoluteExpiresAt: Date } | null` — both consumed exactly as PR 1 declares them, both fail-closed on `null`.
+- `SsoCallbackMode` (Task 4) is computed once (`session.linkUserId ? 'link' : 'login'`) and consumed by Task 4's generation gate **and** Task 6's email-verification gate — one variable, no divergent re-derivation.
+- `EmailVerifiedClaim = 'true' | 'false' | 'absent'` + `readEmailVerifiedClaim` (Task 6) are produced in `services/sso.ts`, consumed in `routes/sso.ts` (as an explicitly-typed `const emailVerifiedClaim: EmailVerifiedClaim`), **and re-declared in the `vi.mock('../services/sso')` factory** — keep the three in sync or the route tests silently test a stub. `isDomainVerifiedForOrg` is added to the **existing** `vi.mock('../services/ssoDomainVerification')` factory (`routes/sso.test.ts:158`), never a second `vi.mock` for the same path (a duplicate clobbers the first and reds the existing domain-gate tests at `:1297`/`:1314`).
+- `SafeFetchInit.maxBytes?: number` + `ResponseTooLargeError` (Task 7, `services/urlSafety.ts`) are additive: unset ⇒ unbounded ⇒ **zero behavior change for every existing caller** (webhooks, Pax8, SentinelOne, TD SYNNEX, DNS). Only the four OIDC calls opt in, at `OIDC_MAX_RESPONSE_BYTES`.
+- `OIDCConfig.allowPrivateNetwork?: boolean` (Task 7) is set **once** by `getOIDCConfig` from `selfHostAllowsPrivateNetwork()` and read by `exchangeCodeForTokens`, `getUserInfo`, `refreshAccessToken`, and `verifyIdTokenSignature` → `getIdTokenJwks` (where it is also part of the cache key). It is never request-supplied. `assertSafeOidcEndpoint(label, url, allowPrivateNetwork)` is the single policy gate used by `validateDiscoveredEndpoints` (pre-persist), `getOIDCConfig` (runtime), and each transport function (pre-fetch) — one predicate, three call layers, no forked SSRF logic.
+- **`#1105` invariant (M4):** `verifyIdTokenSignature` now transitively calls `safeFetch` → `assertOutsideHeldDbContext('safeFetch')`, which **throws**. Its call site (`routes/sso.ts:1501`) is outside any held DB context today; Task 7's test pins that so a future refactor cannot move it inside `withSystemDbAccessContext` and 500 every SSO login.


### PR DESCRIPTION
PR 3 of the six-PR core-authentication-hardening epic (#2489). Hardens the SSO/OIDC subsystem: **SR2-10 through SR2-14**.

PRs 1 (#2378) and 2 (#2385) are already merged; this is rebased directly onto `main`.

## What this fixes

| Item | Before | After |
|---|---|---|
| **SR2-10** | An org admin could set an SSO provider's default role to *any* role, including ones granting more than the admin holds. Every JIT-provisioned user got it. | The default role is checked against the **configurer's** permission ceiling, at config time **and again at JIT time** (the configurer may since have been demoted or offboarded). Fails closed. |
| **SR2-11a** | A provider disabled or reconfigured mid-flow still completed a full login/link inside the ≤10-min state TTL. | Every config/status write bumps `config_version`; the callback rejects a stale (or NULL) `provider_version`, or a provider not usable for that mode. |
| **SR2-11b** | A pending SSO *link* survived logout, password change, and MFA reset of the initiating session. | Link sessions are bound to the initiating session (auth epoch, MFA epoch, refresh-token family) and re-checked at the callback. |
| **SR2-12** | An IdP asserting `email_verified: false` — or omitting it — could still JIT-provision or auto-link by email. Account-takeover by unverified email. | `false` → **always** rejected. **Absent** → allowed only if the asserted email's domain is a DNS-TXT-verified domain for the provider's org. Auto-link clamped to actual org members. |
| **SR2-13/14** | JWKS/discovery fetches were unbounded, untimed, and not SSRF-checked — including jose's *internal* re-fetch on kid-miss. | SSRF-safe fetch injected into jose via `customFetch`; bounded bodies; timeouts; discovered endpoints validated before persisting **and** re-validated at runtime; HTTPS enforced on `token_url`. |

Also fixed along the way:
- `DELETE /providers/:id` performed three deletes non-atomically — a failure mid-way orphaned identity links. Now one transaction.
- **Live 500:** the web provider edit form posts `preset`, which `updateProviderSchema` accepted but has no DB column — Drizzle dereferenced an undefined column. Editing any SSO provider 500'd.
- **Silent mutation failure:** a failed OIDC discovery on `PATCH /providers/:id` NULLed all four endpoint columns, bumped `config_version` (killing in-flight sessions), returned **200 OK**, and took the org's SSO offline with no signal. Now 400s and persists nothing.
- **DB connection starvation (#1105 class):** OIDC discovery ran *inside* the held request transaction. A tenant-controlled `issuer` × 10s timeout × unrate-limited PATCH against a 25-connection prod pool was tenant-triggerable. Discovery now runs outside any held transaction (`SELF_MANAGED_DB_CONTEXT_ROUTES`).

## ⚠️ Deploy: run this pre-flight query FIRST

Runtime endpoint re-validation will reject any provider whose **persisted** endpoints aren't HTTPS + publicly routable. Any row returned = **that tenant's SSO goes down the moment this deploys.**

```sql
SELECT p.id, p.org_id, p.partner_id, p.name, p.status, p.issuer,
       p.authorization_url, p.token_url, p.userinfo_url, p.jwks_url
FROM sso_providers p
WHERE p.type = 'oidc'
  AND p.status <> 'inactive'          -- drop this line to also list dormant providers
  AND (
        p.authorization_url IS NULL OR p.token_url IS NULL
     OR p.userinfo_url IS NULL OR p.jwks_url IS NULL
     OR p.authorization_url !~* '^https://' OR p.token_url !~* '^https://'
     OR p.userinfo_url !~* '^https://' OR p.jwks_url !~* '^https://'
     OR concat_ws(' ', p.authorization_url, p.token_url, p.userinfo_url, p.jwks_url)
        ~* '://\[?(localhost|127\.|10\.|192\.168\.|169\.254\.|0\.|172\.(1[6-9]|2[0-9]|3[01])\.|::1|f[cd])'
  )
ORDER BY p.status, p.org_id;
```

0 rows ⇒ safe. Remediation for any hit is a PATCH of the issuer through the (now loud) provider route, which re-discovers HTTPS endpoints.

**Other operational notes:**
- The migration **purges in-flight `sso_sessions`** (they predate the binding columns and are unverifiable). Anyone mid-login at deploy retries; no data loss.
- A legacy provider with a `default_role_id` but no `created_by` **stops JIT-provisioning** until an adequately-permissioned admin re-saves the default role. Fails closed by design.
- An IdP that puts `email` in the id_token but `email_verified` only in userinfo now needs a DNS-verified org domain.
- `safeFetch` (`services/urlSafety.ts`) is a **shared** utility and gained `maxBytes`. Unset = unbounded = byte-identical prior behavior for existing callers — verified, but worth a second pair of eyes.

## Known gaps (deliberate, not oversights)

1. **Partner-axis domain verification does not exist** — `sso_verified_domains.org_id` is `NOT NULL`, so the absent-`email_verified` domain gate is **org-axis only**; the partner axis keeps the old tolerance. Follow-up: make it dual-axis (partner-wide first).
2. **Unknown configurer fails closed** — JIT is refused rather than falling back to a structural check. An earlier draft had a `jit_ceiling_skipped` fallback; it was a wildcard back door and was removed deliberately. There is no such audit code.
3. **No port allowlist** on OIDC endpoints — explicitly out of scope for SR2-14. This is not full SR2-14 coverage.

## Follow-ups (not in this PR)

- Caller's permission ceiling doesn't walk `parent_role_id` while the target role does. Pre-existing and fail-closed, but SR2-10 puts it on the login path.
- `POST`/`PATCH /providers` remain unrate-limited while making a tenant-controlled outbound call. Connection-hold is gone; a port-scan-by-timing surface remains (admin-only, `sso:admin` + MFA).
- The web edit form also posts `defaultRoleId: ''` / `issuer: ''`, which `.guid()`/`.url()` reject with a 400 — pre-existing on `main`, sibling of the `preset` bug.
- The three PR-2 follow-ups earmarked "fold into PR 3" (cfAccessLogin `mfa=true` parity, delete dead `verifyMFAToken`, `/mfa/enable` grant-consume ordering) are **not** in this PR — it stayed SSO-scoped. They carry forward to PR 4.
- **`vitest.config.rls.ts` is not wired into CI at all** — no script invokes it, and the blocking integration job excludes `rls.integration.test.ts` by name. Our tenant-isolation contract suite only runs when a human runs it. Consequently `rls.integration.test.ts` has a **stale assertion red on `main`** ("exactly five session variables" — `breeze.current_partner_id` made it six back in #1357). Not caused by this stack; needs its own fix on `main`.

## i18n

`main` added `de-DE`, `es-419`, and `fr-FR` (#2451) after this branch was cut. The four new SSO link-error keys are backfilled into all five locales, and the now-dead `userGone` key is removed everywhere (`user_gone` was folded into `session_invalid` so the callback stops leaking an account-state oracle). `localeParity` passes.

## Testing

- Full API unit suite: **978 files / 12,483 tests, 0 failures.**
- New real-DB integration coverage: `ssoHardening.integration.test.ts`, `ssoSessionsRls.integration.test.ts` (+ `ssoPartnerLogin` fixtures) — **32 passing.**
- `sso_sessions` gains RLS (enabled + **forced**, system-only policy), registered in the RLS coverage contract.
- **Adversarial guard-bite: all five protections were verified to actually bite.** Each was individually neutered and the tests went red — dropping the `sso_sessions` policy, the generation gate, the epoch/family checks, the domain gate, and the JIT ceiling (that last one mints an over-privileged user when removed). None of these tests are vacuous.
- Migration idempotency verified (clean re-apply no-op); `db:check-drift` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
