### PR TITLE
feat(m365): establish Breeze control plane foundation

### DIFF
--- a/apps/api/migrations/2026-07-13-m365-control-plane-foundation.sql
+++ b/apps/api/migrations/2026-07-13-m365-control-plane-foundation.sql
@@ -26,6 +26,12 @@ WHERE profile IS NULL
 ALTER TABLE m365_connections ALTER COLUMN org_id DROP NOT NULL;
 ALTER TABLE m365_connections ALTER COLUMN client_secret DROP NOT NULL;
 ALTER TABLE m365_connections ALTER COLUMN tenant_id TYPE VARCHAR(36);
+-- Expand/contract defaults keep the previously deployed API's inserts valid
+-- while this migration runs before the replacement application is started.
+ALTER TABLE m365_connections ALTER COLUMN profile SET DEFAULT 'legacy-direct';
+ALTER TABLE m365_connections ALTER COLUMN auth_mode SET DEFAULT 'client-secret-legacy';
+ALTER TABLE m365_connections ALTER COLUMN credential_domain SET DEFAULT 'legacy-direct';
+ALTER TABLE m365_connections ALTER COLUMN permission_manifest_version SET DEFAULT 0;
 ALTER TABLE m365_connections ALTER COLUMN profile SET NOT NULL;
 ALTER TABLE m365_connections ALTER COLUMN auth_mode SET NOT NULL;
 ALTER TABLE m365_connections ALTER COLUMN credential_domain SET NOT NULL;
@@ -112,7 +118,11 @@ ALTER TABLE m365_connections ADD CONSTRAINT m365_connections_profile_binding_che
   OR (profile = 'customer-exchange-powershell' AND org_id IS NOT NULL AND auth_mode = 'application-certificate' AND credential_domain = 'customer-exchange-powershell')
 );
 
-DROP INDEX IF EXISTS m365_connections_org_uniq;
+-- The deployed API still uses ON CONFLICT (org_id). Retain this compatibility
+-- index for the rollout window; a later contract migration may remove it once
+-- every writer targets (org_id, profile).
+CREATE UNIQUE INDEX IF NOT EXISTS m365_connections_org_uniq
+  ON m365_connections (org_id);
 CREATE UNIQUE INDEX IF NOT EXISTS m365_connections_org_profile_uniq
   ON m365_connections (org_id, profile);
 CREATE UNIQUE INDEX IF NOT EXISTS m365_connections_user_profile_uniq
@@ -131,46 +141,26 @@ ALTER TABLE m365_connections ENABLE ROW LEVEL SECURITY;
 ALTER TABLE m365_connections FORCE ROW LEVEL SECURITY;
 
 CREATE POLICY breeze_m365_connection_select ON m365_connections FOR SELECT USING (
-  public.breeze_has_org_access(org_id)
-  OR user_id = public.breeze_current_user_id()
-  OR EXISTS (
-    SELECT 1 FROM users u
-    WHERE u.id = m365_connections.user_id
-      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
-  )
+  public.breeze_current_scope() = 'system'
+  OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+  OR (user_id IS NOT NULL AND user_id = public.breeze_current_user_id())
 );
 CREATE POLICY breeze_m365_connection_insert ON m365_connections FOR INSERT WITH CHECK (
-  public.breeze_has_org_access(org_id)
-  OR user_id = public.breeze_current_user_id()
-  OR EXISTS (
-    SELECT 1 FROM users u
-    WHERE u.id = m365_connections.user_id
-      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
-  )
+  public.breeze_current_scope() = 'system'
+  OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+  OR (user_id IS NOT NULL AND user_id = public.breeze_current_user_id())
 );
 CREATE POLICY breeze_m365_connection_update ON m365_connections FOR UPDATE USING (
-  public.breeze_has_org_access(org_id)
-  OR user_id = public.breeze_current_user_id()
-  OR EXISTS (
-    SELECT 1 FROM users u
-    WHERE u.id = m365_connections.user_id
-      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
-  )
+  public.breeze_current_scope() = 'system'
+  OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+  OR (user_id IS NOT NULL AND user_id = public.breeze_current_user_id())
 ) WITH CHECK (
-  public.breeze_has_org_access(org_id)
-  OR user_id = public.breeze_current_user_id()
-  OR EXISTS (
-    SELECT 1 FROM users u
-    WHERE u.id = m365_connections.user_id
-      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
-  )
+  public.breeze_current_scope() = 'system'
+  OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+  OR (user_id IS NOT NULL AND user_id = public.breeze_current_user_id())
 );
 CREATE POLICY breeze_m365_connection_delete ON m365_connections FOR DELETE USING (
-  public.breeze_has_org_access(org_id)
-  OR user_id = public.breeze_current_user_id()
-  OR EXISTS (
-    SELECT 1 FROM users u
-    WHERE u.id = m365_connections.user_id
-      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
-  )
+  public.breeze_current_scope() = 'system'
+  OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+  OR (user_id IS NOT NULL AND user_id = public.breeze_current_user_id())
 );

--- a/apps/api/migrations/2026-07-13-m365-control-plane-foundation.sql
+++ b/apps/api/migrations/2026-07-13-m365-control-plane-foundation.sql
@@ -1,0 +1,176 @@
+-- Evolve the existing direct-M365 table into canonical control-plane metadata.
+-- autoMigrate supplies the transaction; do not add BEGIN/COMMIT.
+ALTER TABLE m365_connections ADD COLUMN IF NOT EXISTS user_id UUID;
+ALTER TABLE m365_connections ADD COLUMN IF NOT EXISTS profile VARCHAR(64);
+ALTER TABLE m365_connections ADD COLUMN IF NOT EXISTS auth_mode VARCHAR(40);
+ALTER TABLE m365_connections ADD COLUMN IF NOT EXISTS credential_domain VARCHAR(64);
+ALTER TABLE m365_connections ADD COLUMN IF NOT EXISTS vault_ref TEXT;
+ALTER TABLE m365_connections ADD COLUMN IF NOT EXISTS credential_version VARCHAR(128);
+ALTER TABLE m365_connections ADD COLUMN IF NOT EXISTS permission_manifest_version INTEGER;
+ALTER TABLE m365_connections ADD COLUMN IF NOT EXISTS observed_grants JSONB NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE m365_connections ADD COLUMN IF NOT EXISTS consented_at TIMESTAMPTZ;
+ALTER TABLE m365_connections ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+ALTER TABLE m365_connections ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMPTZ;
+ALTER TABLE m365_connections ADD COLUMN IF NOT EXISTS last_error_code VARCHAR(80);
+
+UPDATE m365_connections
+SET profile = COALESCE(profile, 'legacy-direct'),
+    auth_mode = COALESCE(auth_mode, 'client-secret-legacy'),
+    credential_domain = COALESCE(credential_domain, 'legacy-direct'),
+    permission_manifest_version = COALESCE(permission_manifest_version, 0)
+WHERE profile IS NULL
+   OR auth_mode IS NULL
+   OR credential_domain IS NULL
+   OR permission_manifest_version IS NULL;
+
+ALTER TABLE m365_connections ALTER COLUMN org_id DROP NOT NULL;
+ALTER TABLE m365_connections ALTER COLUMN client_secret DROP NOT NULL;
+ALTER TABLE m365_connections ALTER COLUMN tenant_id TYPE VARCHAR(36);
+ALTER TABLE m365_connections ALTER COLUMN profile SET NOT NULL;
+ALTER TABLE m365_connections ALTER COLUMN auth_mode SET NOT NULL;
+ALTER TABLE m365_connections ALTER COLUMN credential_domain SET NOT NULL;
+ALTER TABLE m365_connections ALTER COLUMN permission_manifest_version SET NOT NULL;
+ALTER TABLE m365_connections ALTER COLUMN status SET DEFAULT 'pending-consent';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'm365_connections_user_id_fkey'
+      AND conrelid = 'm365_connections'::regclass
+  ) THEN
+    ALTER TABLE m365_connections
+      ADD CONSTRAINT m365_connections_user_id_fkey
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+
+UPDATE m365_connections c
+SET created_by = NULL
+WHERE created_by IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM users u WHERE u.id = c.created_by);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'm365_connections_created_by_fkey'
+      AND conrelid = 'm365_connections'::regclass
+  ) THEN
+    ALTER TABLE m365_connections
+      ADD CONSTRAINT m365_connections_created_by_fkey
+      FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+ALTER TABLE m365_connections DROP CONSTRAINT IF EXISTS m365_connections_owner_check;
+ALTER TABLE m365_connections ADD CONSTRAINT m365_connections_owner_check
+  CHECK ((org_id IS NOT NULL)::int + (user_id IS NOT NULL)::int = 1);
+
+ALTER TABLE m365_connections DROP CONSTRAINT IF EXISTS m365_connections_tenant_guid_check;
+ALTER TABLE m365_connections ADD CONSTRAINT m365_connections_tenant_guid_check
+  CHECK (tenant_id ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$');
+
+ALTER TABLE m365_connections DROP CONSTRAINT IF EXISTS m365_connections_profile_check;
+ALTER TABLE m365_connections ADD CONSTRAINT m365_connections_profile_check CHECK (profile IN (
+  'legacy-direct', 'communications-delegated', 'customer-graph-read',
+  'customer-graph-actions', 'customer-exchange-powershell'
+));
+
+ALTER TABLE m365_connections DROP CONSTRAINT IF EXISTS m365_connections_status_check;
+UPDATE m365_connections
+SET status = 'degraded', last_error_code = 'legacy-status-normalized'
+WHERE status NOT IN ('pending-consent', 'verifying', 'active', 'degraded', 'suspended', 'revoked');
+ALTER TABLE m365_connections ADD CONSTRAINT m365_connections_status_check CHECK (status IN (
+  'pending-consent', 'verifying', 'active', 'degraded', 'suspended', 'revoked'
+));
+
+ALTER TABLE m365_connections DROP CONSTRAINT IF EXISTS m365_connections_manifest_version_check;
+ALTER TABLE m365_connections ADD CONSTRAINT m365_connections_manifest_version_check
+  CHECK (
+    (profile = 'legacy-direct' AND permission_manifest_version = 0)
+    OR (profile <> 'legacy-direct' AND permission_manifest_version >= 1)
+  );
+
+ALTER TABLE m365_connections DROP CONSTRAINT IF EXISTS m365_connections_observed_grants_check;
+ALTER TABLE m365_connections ADD CONSTRAINT m365_connections_observed_grants_check
+  CHECK (jsonb_typeof(observed_grants) = 'array');
+
+ALTER TABLE m365_connections DROP CONSTRAINT IF EXISTS m365_connections_credential_location_check;
+ALTER TABLE m365_connections ADD CONSTRAINT m365_connections_credential_location_check CHECK (
+  (profile = 'legacy-direct' AND client_secret IS NOT NULL AND vault_ref IS NULL)
+  OR
+  (profile <> 'legacy-direct' AND client_secret IS NULL AND vault_ref IS NOT NULL AND credential_version IS NOT NULL)
+);
+
+ALTER TABLE m365_connections DROP CONSTRAINT IF EXISTS m365_connections_profile_binding_check;
+ALTER TABLE m365_connections ADD CONSTRAINT m365_connections_profile_binding_check CHECK (
+  (profile = 'legacy-direct' AND org_id IS NOT NULL AND auth_mode = 'client-secret-legacy' AND credential_domain = 'legacy-direct')
+  OR (profile = 'communications-delegated' AND user_id IS NOT NULL AND auth_mode = 'delegated' AND credential_domain = 'communications-delegated')
+  OR (profile = 'customer-graph-read' AND org_id IS NOT NULL AND auth_mode = 'application-certificate' AND credential_domain = 'customer-graph-read')
+  OR (profile = 'customer-graph-actions' AND org_id IS NOT NULL AND auth_mode = 'application-certificate' AND credential_domain = 'customer-graph-actions')
+  OR (profile = 'customer-exchange-powershell' AND org_id IS NOT NULL AND auth_mode = 'application-certificate' AND credential_domain = 'customer-exchange-powershell')
+);
+
+DROP INDEX IF EXISTS m365_connections_org_uniq;
+CREATE UNIQUE INDEX IF NOT EXISTS m365_connections_org_profile_uniq
+  ON m365_connections (org_id, profile);
+CREATE UNIQUE INDEX IF NOT EXISTS m365_connections_user_profile_uniq
+  ON m365_connections (user_id, profile);
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON m365_connections;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON m365_connections;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON m365_connections;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON m365_connections;
+DROP POLICY IF EXISTS breeze_m365_connection_select ON m365_connections;
+DROP POLICY IF EXISTS breeze_m365_connection_insert ON m365_connections;
+DROP POLICY IF EXISTS breeze_m365_connection_update ON m365_connections;
+DROP POLICY IF EXISTS breeze_m365_connection_delete ON m365_connections;
+
+ALTER TABLE m365_connections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE m365_connections FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_m365_connection_select ON m365_connections FOR SELECT USING (
+  public.breeze_has_org_access(org_id)
+  OR user_id = public.breeze_current_user_id()
+  OR EXISTS (
+    SELECT 1 FROM users u
+    WHERE u.id = m365_connections.user_id
+      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
+  )
+);
+CREATE POLICY breeze_m365_connection_insert ON m365_connections FOR INSERT WITH CHECK (
+  public.breeze_has_org_access(org_id)
+  OR user_id = public.breeze_current_user_id()
+  OR EXISTS (
+    SELECT 1 FROM users u
+    WHERE u.id = m365_connections.user_id
+      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
+  )
+);
+CREATE POLICY breeze_m365_connection_update ON m365_connections FOR UPDATE USING (
+  public.breeze_has_org_access(org_id)
+  OR user_id = public.breeze_current_user_id()
+  OR EXISTS (
+    SELECT 1 FROM users u
+    WHERE u.id = m365_connections.user_id
+      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
+  )
+) WITH CHECK (
+  public.breeze_has_org_access(org_id)
+  OR user_id = public.breeze_current_user_id()
+  OR EXISTS (
+    SELECT 1 FROM users u
+    WHERE u.id = m365_connections.user_id
+      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
+  )
+);
+CREATE POLICY breeze_m365_connection_delete ON m365_connections FOR DELETE USING (
+  public.breeze_has_org_access(org_id)
+  OR user_id = public.breeze_current_user_id()
+  OR EXISTS (
+    SELECT 1 FROM users u
+    WHERE u.id = m365_connections.user_id
+      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
+  )
+);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,6 +39,8 @@
     "@anthropic-ai/sdk": "^0.111.0",
     "@aws-sdk/client-s3": "^3.1076.0",
     "@aws-sdk/s3-request-presigner": "^3.1030.0",
+    "@azure/identity": "^4.6.0",
+    "@azure/keyvault-secrets": "^4.9.0",
     "@breeze/extension-api": "workspace:*",
     "@breeze/shared": "workspace:*",
     "@elastic/elasticsearch": "^9.3.2",

--- a/apps/api/src/__tests__/integration/m365ConnectionsRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/m365ConnectionsRls.integration.test.ts
@@ -8,11 +8,14 @@ import { createOrganization, createPartner, createUser } from './db-utils';
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 const tenantA = '11111111-1111-1111-1111-111111111111';
 const tenantB = '22222222-2222-2222-2222-222222222222';
+const tenantC = '33333333-3333-3333-3333-333333333333';
+const credentialVersion = '0123456789abcdef0123456789abcdef';
 
 async function seedFixture() {
   return withSystemDbAccessContext(async () => {
     const partnerA = await createPartner();
     const orgA = await createOrganization({ partnerId: partnerA.id });
+    const orgA2 = await createOrganization({ partnerId: partnerA.id });
     const partnerB = await createPartner();
     const orgB = await createOrganization({ partnerId: partnerB.id });
     const userA = await createUser({
@@ -25,6 +28,16 @@ async function seedFixture() {
       orgId: orgB.id,
       email: `m365-rls-b-${Date.now()}@example.com`,
     });
+    const userA2 = await createUser({
+      partnerId: partnerA.id,
+      orgId: orgA2.id,
+      email: `m365-rls-a2-${Date.now()}@example.com`,
+    });
+    const userAPeer = await createUser({
+      partnerId: partnerA.id,
+      orgId: orgA.id,
+      email: `m365-rls-a-peer-${Date.now()}@example.com`,
+    });
 
     const [orgBConnection] = await db.insert(m365Connections).values({
       orgId: orgB.id,
@@ -35,22 +48,73 @@ async function seedFixture() {
       profile: 'customer-graph-read',
       authMode: 'application-certificate',
       credentialDomain: 'customer-graph-read',
-      vaultRef: 'akv://vault.example/m365-customer-graph-read-b/1',
-      credentialVersion: '1',
+      vaultRef: `akv://vault.example/m365-customer-graph-read-22222222-2222-2222-2222-222222222222/${credentialVersion}`,
+      credentialVersion,
       permissionManifestVersion: 1,
       status: 'active',
     }).returning({ id: m365Connections.id });
     if (!orgBConnection) throw new Error('failed to seed foreign connection');
 
+    const [samePartnerUserConnection] = await db.insert(m365Connections).values({
+      orgId: null,
+      userId: userA2.id,
+      tenantId: tenantC,
+      clientId: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+      clientSecret: null,
+      profile: 'communications-delegated',
+      authMode: 'delegated',
+      credentialDomain: 'communications-delegated',
+      vaultRef: `akv://vault.example/m365-communications-delegated-33333333-3333-3333-3333-333333333333/${credentialVersion}`,
+      credentialVersion,
+      permissionManifestVersion: 1,
+      status: 'active',
+    }).returning({ id: m365Connections.id });
+    if (!samePartnerUserConnection) throw new Error('failed to seed same-partner user connection');
+
+    const [sameOrgUserConnection] = await db.insert(m365Connections).values({
+      orgId: null,
+      userId: userAPeer.id,
+      tenantId: tenantC,
+      clientId: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+      clientSecret: null,
+      profile: 'communications-delegated',
+      authMode: 'delegated',
+      credentialDomain: 'communications-delegated',
+      vaultRef: `akv://vault.example/m365-communications-delegated-77777777-7777-7777-7777-777777777777/${credentialVersion}`,
+      credentialVersion,
+      permissionManifestVersion: 1,
+      status: 'active',
+    }).returning({ id: m365Connections.id });
+    if (!sameOrgUserConnection) throw new Error('failed to seed same-org user connection');
+
     const orgAContext: DbAccessContext = {
       scope: 'organization',
       orgId: orgA.id,
+      accessibleOrgIds: [orgA.id],
+      accessiblePartnerIds: [],
+      userId: userA.id,
+    };
+
+    const selectedOrgPartnerContext: DbAccessContext = {
+      scope: 'partner',
+      orgId: null,
       accessibleOrgIds: [orgA.id],
       accessiblePartnerIds: [partnerA.id],
       userId: userA.id,
     };
 
-    return { partnerA, orgA, orgB, userA, userB, orgBConnection, orgAContext };
+    return {
+      partnerA,
+      orgA,
+      orgB,
+      userA,
+      userB,
+      orgBConnection,
+      samePartnerUserConnection,
+      sameOrgUserConnection,
+      orgAContext,
+      selectedOrgPartnerContext,
+    };
   });
 }
 
@@ -79,14 +143,32 @@ describe('m365_connections dual-axis RLS', () => {
       profile: 'customer-graph-actions',
       authMode: 'application-certificate',
       credentialDomain: 'customer-graph-actions',
-      vaultRef: 'akv://vault.example/m365-customer-graph-actions-forged/1',
-      credentialVersion: '1',
+      vaultRef: `akv://vault.example/m365-customer-graph-actions-44444444-4444-4444-4444-444444444444/${credentialVersion}`,
+      credentialVersion,
       permissionManifestVersion: 1,
       status: 'active',
     }))).rejects.toMatchObject({ cause: { code: '42501' } });
   });
 
-  runDb('allows the current user to own communications but blocks another user', async () => {
+  runDb('does not expose another user communications connection through partner access', async () => {
+    const fx = await seedFixture();
+    const hidden = await withDbAccessContext(fx.selectedOrgPartnerContext, () =>
+      db.select({ id: m365Connections.id }).from(m365Connections)
+        .where(eq(m365Connections.id, fx.samePartnerUserConnection.id)));
+
+    expect(hidden).toEqual([]);
+  });
+
+  runDb('does not expose a same-organization peer communications connection', async () => {
+    const fx = await seedFixture();
+    const hidden = await withDbAccessContext(fx.orgAContext, () =>
+      db.select({ id: m365Connections.id }).from(m365Connections)
+        .where(eq(m365Connections.id, fx.sameOrgUserConnection.id)));
+
+    expect(hidden).toEqual([]);
+  });
+
+  runDb('allows owner CRUD but blocks reassignment to another user', async () => {
     const fx = await seedFixture();
     const [own] = await withDbAccessContext(fx.orgAContext, () => db.insert(m365Connections).values({
       orgId: null,
@@ -97,12 +179,37 @@ describe('m365_connections dual-axis RLS', () => {
       profile: 'communications-delegated',
       authMode: 'delegated',
       credentialDomain: 'communications-delegated',
-      vaultRef: 'akv://vault.example/m365-communications-user-a/1',
-      credentialVersion: '1',
+      vaultRef: `akv://vault.example/m365-communications-delegated-55555555-5555-5555-5555-555555555555/${credentialVersion}`,
+      credentialVersion,
       permissionManifestVersion: 1,
       status: 'active',
     }).returning({ id: m365Connections.id, userId: m365Connections.userId }));
     expect(own?.userId).toBe(fx.userA.id);
+
+    const selected = await withDbAccessContext(fx.orgAContext, () =>
+      db.select({ id: m365Connections.id }).from(m365Connections)
+        .where(eq(m365Connections.id, own!.id)));
+    expect(selected).toEqual([{ id: own!.id }]);
+
+    const updated = await withDbAccessContext(fx.orgAContext, () =>
+      db.update(m365Connections)
+        .set({ status: 'degraded' })
+        .where(eq(m365Connections.id, own!.id))
+        .returning({ status: m365Connections.status }));
+    expect(updated).toEqual([{ status: 'degraded' }]);
+
+    await expect(withDbAccessContext(fx.orgAContext, () =>
+      db.update(m365Connections)
+        .set({ userId: fx.userB.id })
+        .where(eq(m365Connections.id, own!.id))
+        .returning({ id: m365Connections.id })))
+      .rejects.toMatchObject({ cause: { code: '42501' } });
+
+    const removed = await withDbAccessContext(fx.orgAContext, () =>
+      db.delete(m365Connections)
+        .where(eq(m365Connections.id, own!.id))
+        .returning({ id: m365Connections.id }));
+    expect(removed).toEqual([{ id: own!.id }]);
 
     await expect(withDbAccessContext(fx.orgAContext, () => db.insert(m365Connections).values({
       orgId: null,
@@ -113,8 +220,8 @@ describe('m365_connections dual-axis RLS', () => {
       profile: 'communications-delegated',
       authMode: 'delegated',
       credentialDomain: 'communications-delegated',
-      vaultRef: 'akv://vault.example/m365-communications-user-b-forged/1',
-      credentialVersion: '1',
+      vaultRef: `akv://vault.example/m365-communications-delegated-66666666-6666-6666-6666-666666666666/${credentialVersion}`,
+      credentialVersion,
       permissionManifestVersion: 1,
       status: 'active',
     }))).rejects.toMatchObject({ cause: { code: '42501' } });

--- a/apps/api/src/__tests__/integration/m365ConnectionsRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/m365ConnectionsRls.integration.test.ts
@@ -1,0 +1,122 @@
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { m365Connections } from '../../db/schema';
+import { createOrganization, createPartner, createUser } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+const tenantA = '11111111-1111-1111-1111-111111111111';
+const tenantB = '22222222-2222-2222-2222-222222222222';
+
+async function seedFixture() {
+  return withSystemDbAccessContext(async () => {
+    const partnerA = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const partnerB = await createPartner();
+    const orgB = await createOrganization({ partnerId: partnerB.id });
+    const userA = await createUser({
+      partnerId: partnerA.id,
+      orgId: orgA.id,
+      email: `m365-rls-a-${Date.now()}@example.com`,
+    });
+    const userB = await createUser({
+      partnerId: partnerB.id,
+      orgId: orgB.id,
+      email: `m365-rls-b-${Date.now()}@example.com`,
+    });
+
+    const [orgBConnection] = await db.insert(m365Connections).values({
+      orgId: orgB.id,
+      userId: null,
+      tenantId: tenantB,
+      clientId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      clientSecret: null,
+      profile: 'customer-graph-read',
+      authMode: 'application-certificate',
+      credentialDomain: 'customer-graph-read',
+      vaultRef: 'akv://vault.example/m365-customer-graph-read-b/1',
+      credentialVersion: '1',
+      permissionManifestVersion: 1,
+      status: 'active',
+    }).returning({ id: m365Connections.id });
+    if (!orgBConnection) throw new Error('failed to seed foreign connection');
+
+    const orgAContext: DbAccessContext = {
+      scope: 'organization',
+      orgId: orgA.id,
+      accessibleOrgIds: [orgA.id],
+      accessiblePartnerIds: [partnerA.id],
+      userId: userA.id,
+    };
+
+    return { partnerA, orgA, orgB, userA, userB, orgBConnection, orgAContext };
+  });
+}
+
+describe('m365_connections dual-axis RLS', () => {
+  runDb('runs code-under-test as breeze_app without BYPASSRLS', async () => {
+    const fx = await seedFixture();
+    const rows = await withDbAccessContext(fx.orgAContext, () =>
+      db.execute(sql`SELECT current_user AS who, rolbypassrls FROM pg_roles WHERE rolname = current_user`));
+    const row = (rows as unknown as Array<{ who: string; rolbypassrls: boolean }>)[0];
+    expect(row).toEqual({ who: 'breeze_app', rolbypassrls: false });
+  });
+
+  runDb('hides another organization connection and blocks a forged insert', async () => {
+    const fx = await seedFixture();
+    const hidden = await withDbAccessContext(fx.orgAContext, () =>
+      db.select({ id: m365Connections.id }).from(m365Connections)
+        .where(eq(m365Connections.id, fx.orgBConnection.id)));
+    expect(hidden).toEqual([]);
+
+    await expect(withDbAccessContext(fx.orgAContext, () => db.insert(m365Connections).values({
+      orgId: fx.orgB.id,
+      userId: null,
+      tenantId: tenantB,
+      clientId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      clientSecret: null,
+      profile: 'customer-graph-actions',
+      authMode: 'application-certificate',
+      credentialDomain: 'customer-graph-actions',
+      vaultRef: 'akv://vault.example/m365-customer-graph-actions-forged/1',
+      credentialVersion: '1',
+      permissionManifestVersion: 1,
+      status: 'active',
+    }))).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  runDb('allows the current user to own communications but blocks another user', async () => {
+    const fx = await seedFixture();
+    const [own] = await withDbAccessContext(fx.orgAContext, () => db.insert(m365Connections).values({
+      orgId: null,
+      userId: fx.userA.id,
+      tenantId: tenantA,
+      clientId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      clientSecret: null,
+      profile: 'communications-delegated',
+      authMode: 'delegated',
+      credentialDomain: 'communications-delegated',
+      vaultRef: 'akv://vault.example/m365-communications-user-a/1',
+      credentialVersion: '1',
+      permissionManifestVersion: 1,
+      status: 'active',
+    }).returning({ id: m365Connections.id, userId: m365Connections.userId }));
+    expect(own?.userId).toBe(fx.userA.id);
+
+    await expect(withDbAccessContext(fx.orgAContext, () => db.insert(m365Connections).values({
+      orgId: null,
+      userId: fx.userB.id,
+      tenantId: tenantB,
+      clientId: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      clientSecret: null,
+      profile: 'communications-delegated',
+      authMode: 'delegated',
+      credentialDomain: 'communications-delegated',
+      vaultRef: 'akv://vault.example/m365-communications-user-b-forged/1',
+      credentialVersion: '1',
+      permissionManifestVersion: 1,
+      status: 'active',
+    }))).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+});

--- a/apps/api/src/db/migration-m365-control-plane-foundation.test.ts
+++ b/apps/api/src/db/migration-m365-control-plane-foundation.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('M365 control-plane foundation migration', () => {
+  const migrationPath = join(
+    __dirname,
+    '../../migrations/2026-07-13-m365-control-plane-foundation.sql',
+  );
+  const sql = readFileSync(migrationPath, 'utf8');
+
+  it('preserves old-API inserts while migrations deploy before the new API', () => {
+    expect(sql).toMatch(/ALTER COLUMN profile SET DEFAULT 'legacy-direct'/i);
+    expect(sql).toMatch(/ALTER COLUMN auth_mode SET DEFAULT 'client-secret-legacy'/i);
+    expect(sql).toMatch(/ALTER COLUMN credential_domain SET DEFAULT 'legacy-direct'/i);
+    expect(sql).toMatch(/ALTER COLUMN permission_manifest_version SET DEFAULT 0/i);
+  });
+
+  it('retains the old ON CONFLICT (org_id) target for the rollout window', () => {
+    expect(sql).not.toMatch(/DROP INDEX IF EXISTS m365_connections_org_uniq/i);
+    expect(sql).toMatch(
+      /CREATE UNIQUE INDEX IF NOT EXISTS m365_connections_org_uniq\s+ON m365_connections \(org_id\)/i,
+    );
+  });
+
+  it('keeps user-owned communications private from partner-wide access', () => {
+    expect(sql).not.toMatch(/breeze_has_partner_access\(u\.partner_id\)/i);
+    expect(sql.match(/user_id = public\.breeze_current_user_id\(\)/gi)).toHaveLength(5);
+  });
+});

--- a/apps/api/src/db/schema/m365.test.ts
+++ b/apps/api/src/db/schema/m365.test.ts
@@ -16,10 +16,19 @@ describe('m365Connections schema', () => {
     expect(cfg.columns.find((c) => c.name === 'vault_ref')?.notNull).toBe(false);
   });
 
-  it('declares per-owner/profile uniqueness instead of one-row-per-org', () => {
+  it('keeps legacy insert defaults during the expand/contract rollout', () => {
+    const columns = getTableConfig(m365Connections).columns;
+    expect(columns.find((c) => c.name === 'profile')?.default).toBe('legacy-direct');
+    expect(columns.find((c) => c.name === 'auth_mode')?.default).toBe('client-secret-legacy');
+    expect(columns.find((c) => c.name === 'credential_domain')?.default).toBe('legacy-direct');
+    expect(columns.find((c) => c.name === 'permission_manifest_version')?.default).toBe(0);
+  });
+
+  it('temporarily retains one-row-per-org uniqueness alongside profile uniqueness', () => {
     const names = getTableConfig(m365Connections).indexes.map((i) => i.config.name).sort();
     expect(names).toEqual([
       'm365_connections_org_profile_uniq',
+      'm365_connections_org_uniq',
       'm365_connections_user_profile_uniq',
     ]);
   });

--- a/apps/api/src/db/schema/m365.test.ts
+++ b/apps/api/src/db/schema/m365.test.ts
@@ -1,26 +1,26 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { getTableConfig } from 'drizzle-orm/pg-core';
 import { m365Connections } from './m365';
 
 describe('m365Connections schema', () => {
-  it('has the expected columns', () => {
+  it('has canonical metadata columns and only one deprecated secret column', () => {
     const cfg = getTableConfig(m365Connections);
-    const cols = cfg.columns.map((c) => c.name).sort();
-    expect(cols).toEqual(
-      [
-        'id', 'org_id', 'tenant_id', 'client_id', 'client_secret', 'display_name',
-        'status', 'created_by', 'last_verified_at', 'created_at', 'updated_at',
-      ].sort()
-    );
+    expect(cfg.columns.map((c) => c.name).sort()).toEqual([
+      'client_id', 'client_secret', 'consented_at', 'created_at', 'created_by',
+      'credential_domain', 'credential_version', 'display_name', 'expires_at',
+      'id', 'last_error_code', 'last_verified_at', 'observed_grants', 'org_id',
+      'permission_manifest_version', 'profile', 'revoked_at', 'status',
+      'tenant_id', 'updated_at', 'user_id', 'vault_ref', 'auth_mode',
+    ].sort());
+    expect(cfg.columns.find((c) => c.name === 'client_secret')?.notNull).toBe(false);
+    expect(cfg.columns.find((c) => c.name === 'vault_ref')?.notNull).toBe(false);
   });
 
-  it('is named m365_connections', () => {
-    expect(getTableConfig(m365Connections).name).toBe('m365_connections');
-  });
-
-  it('stores the client secret as the encrypted-at-rest column', () => {
-    const cfg = getTableConfig(m365Connections);
-    const secret = cfg.columns.find((c) => c.name === 'client_secret');
-    expect(secret?.notNull).toBe(true);
+  it('declares per-owner/profile uniqueness instead of one-row-per-org', () => {
+    const names = getTableConfig(m365Connections).indexes.map((i) => i.config.name).sort();
+    expect(names).toEqual([
+      'm365_connections_org_profile_uniq',
+      'm365_connections_user_profile_uniq',
+    ]);
   });
 });

--- a/apps/api/src/db/schema/m365.ts
+++ b/apps/api/src/db/schema/m365.ts
@@ -1,47 +1,64 @@
 import {
+  integer,
+  jsonb,
   pgTable,
-  uuid,
-  varchar,
   text,
   timestamp,
   uniqueIndex,
+  uuid,
+  varchar,
 } from 'drizzle-orm/pg-core';
 import { organizations } from './orgs';
+import { users } from './users';
+import type {
+  M365AuthMode,
+  M365ConnectionProfile,
+  M365CredentialDomain,
+} from '../../services/m365ControlPlane/profiles';
 
-/**
- * Per-org Microsoft 365 connection for the Breeze identity tools.
- *
- * One connection per Breeze org (resolved by org_id). Holds the app-registration
- * credentials for a client-credentials Graph flow:
- *  - `tenantId` + `clientId` identify the Azure AD app registration.
- *  - `clientSecret` is the app secret, encrypted at rest via secretCrypto
- *    (the column holds ciphertext, never plaintext). It is an admin god-key for
- *    the tenant — it must never be logged or returned from any read endpoint.
- *
- * Distinct from `delegant_m365_connections` (a lighter delegated-reference model
- * that stores no secret) and `c2c_connections` (cloud-to-cloud backup). The
- * token-acquisition logic is shared via services/c2cM365.ts.
- */
+export type StoredM365ConnectionProfile = M365ConnectionProfile | 'legacy-direct';
+export type StoredM365AuthMode = M365AuthMode | 'client-secret-legacy';
+export type StoredM365CredentialDomain = M365CredentialDomain | 'legacy-direct';
+export type M365ConnectionStatus =
+  | 'pending-consent'
+  | 'verifying'
+  | 'active'
+  | 'degraded'
+  | 'suspended'
+  | 'revoked';
+
 export const m365Connections = pgTable(
   'm365_connections',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    orgId: uuid('org_id')
-      .notNull()
-      .references(() => organizations.id, { onDelete: 'cascade' }),
-    tenantId: varchar('tenant_id', { length: 64 }).notNull(),
+    orgId: uuid('org_id').references(() => organizations.id, { onDelete: 'cascade' }),
+    userId: uuid('user_id').references(() => users.id, { onDelete: 'cascade' }),
+    tenantId: varchar('tenant_id', { length: 36 }).notNull(),
     clientId: varchar('client_id', { length: 64 }).notNull(),
-    clientSecret: text('client_secret').notNull(),
+    clientSecret: text('client_secret'),
+    profile: varchar('profile', { length: 64 }).$type<StoredM365ConnectionProfile>().notNull(),
+    authMode: varchar('auth_mode', { length: 40 }).$type<StoredM365AuthMode>().notNull(),
+    credentialDomain: varchar('credential_domain', { length: 64 }).$type<StoredM365CredentialDomain>().notNull(),
+    vaultRef: text('vault_ref'),
+    credentialVersion: varchar('credential_version', { length: 128 }),
+    permissionManifestVersion: integer('permission_manifest_version').notNull(),
+    observedGrants: jsonb('observed_grants').$type<string[]>().notNull().default([]),
     displayName: varchar('display_name', { length: 256 }),
-    status: varchar('status', { length: 32 }).notNull().default('active'),
-    createdBy: uuid('created_by'),
+    status: varchar('status', { length: 32 }).$type<M365ConnectionStatus>().notNull().default('pending-consent'),
+    consentedAt: timestamp('consented_at', { withTimezone: true }),
     lastVerifiedAt: timestamp('last_verified_at'),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+    lastErrorCode: varchar('last_error_code', { length: 80 }),
+    createdBy: uuid('created_by').references(() => users.id, { onDelete: 'set null' }),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },
   (t) => ({
-    orgUniq: uniqueIndex('m365_connections_org_uniq').on(t.orgId),
-  })
+    orgProfileUniq: uniqueIndex('m365_connections_org_profile_uniq').on(t.orgId, t.profile),
+    userProfileUniq: uniqueIndex('m365_connections_user_profile_uniq').on(t.userId, t.profile),
+  }),
 );
 
 export type M365ConnectionRow = typeof m365Connections.$inferSelect;
+export type NewM365ConnectionRow = typeof m365Connections.$inferInsert;

--- a/apps/api/src/db/schema/m365.ts
+++ b/apps/api/src/db/schema/m365.ts
@@ -36,12 +36,12 @@ export const m365Connections = pgTable(
     tenantId: varchar('tenant_id', { length: 36 }).notNull(),
     clientId: varchar('client_id', { length: 64 }).notNull(),
     clientSecret: text('client_secret'),
-    profile: varchar('profile', { length: 64 }).$type<StoredM365ConnectionProfile>().notNull(),
-    authMode: varchar('auth_mode', { length: 40 }).$type<StoredM365AuthMode>().notNull(),
-    credentialDomain: varchar('credential_domain', { length: 64 }).$type<StoredM365CredentialDomain>().notNull(),
+    profile: varchar('profile', { length: 64 }).$type<StoredM365ConnectionProfile>().notNull().default('legacy-direct'),
+    authMode: varchar('auth_mode', { length: 40 }).$type<StoredM365AuthMode>().notNull().default('client-secret-legacy'),
+    credentialDomain: varchar('credential_domain', { length: 64 }).$type<StoredM365CredentialDomain>().notNull().default('legacy-direct'),
     vaultRef: text('vault_ref'),
     credentialVersion: varchar('credential_version', { length: 128 }),
-    permissionManifestVersion: integer('permission_manifest_version').notNull(),
+    permissionManifestVersion: integer('permission_manifest_version').notNull().default(0),
     observedGrants: jsonb('observed_grants').$type<string[]>().notNull().default([]),
     displayName: varchar('display_name', { length: 256 }),
     status: varchar('status', { length: 32 }).$type<M365ConnectionStatus>().notNull().default('pending-consent'),
@@ -55,6 +55,10 @@ export const m365Connections = pgTable(
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },
   (t) => ({
+    // Expand/contract compatibility: the old API upserts on org_id while
+    // migrations run before the new API is deployed. Remove this index only
+    // after every deployed writer targets (org_id, profile).
+    orgUniq: uniqueIndex('m365_connections_org_uniq').on(t.orgId),
     orgProfileUniq: uniqueIndex('m365_connections_org_profile_uniq').on(t.orgId, t.profile),
     userProfileUniq: uniqueIndex('m365_connections_user_profile_uniq').on(t.userId, t.profile),
   }),

--- a/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.test.ts
+++ b/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { AzureKeyVaultCredentialProvider, type SecretClientPort } from './azureKeyVaultProvider';
 
+const CONNECTION_ID = '11111111-1111-1111-1111-111111111111';
+const SECRET_NAME = `m365-customer-graph-read-${CONNECTION_ID}`;
+const REFERENCE = `akv://vault.example/${SECRET_NAME}/version-1`;
+
 function client(): SecretClientPort {
   return {
     setSecret: vi.fn(async () => ({ properties: { version: 'version-1' } })),
@@ -25,7 +29,7 @@ describe('AzureKeyVaultCredentialProvider', () => {
     const port = client();
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
     const stored = await provider.put({
-      connectionId: '11111111-1111-1111-1111-111111111111',
+      connectionId: CONNECTION_ID,
       domain: 'customer-graph-read',
       material: { kind: 'certificate', certificatePem: 'CERT', privateKeyPem: 'PRIVATE', thumbprint: 'THUMB' },
     });
@@ -39,28 +43,27 @@ describe('AzureKeyVaultCredentialProvider', () => {
   it('returns material only when the expected credential domain matches', async () => {
     const port = client();
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
-    const reference = 'akv://vault.example/m365-customer-graph-read-11111111-1111-1111-1111-111111111111/version-1';
-    const material = await provider.get(reference, 'customer-graph-read');
+    const material = await provider.get(REFERENCE, 'customer-graph-read');
     expect(material.kind).toBe('certificate');
     expect(port.getSecret).toHaveBeenCalledWith(
-      'm365-customer-graph-read-11111111-1111-1111-1111-111111111111',
+      SECRET_NAME,
       { version: 'version-1' },
     );
-    await expect(provider.get(reference, 'customer-graph-actions')).rejects.toThrow('Credential domain mismatch');
+    await expect(provider.get(REFERENCE, 'customer-graph-actions')).rejects.toThrow('Credential domain mismatch');
   });
 
   it('rejects references for a different vault host', async () => {
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', client());
     await expect(provider.get(
-      'akv://other-vault.example/m365-customer-graph-read-id/version-1',
+      `akv://other-vault.example/${SECRET_NAME}/version-1`,
       'customer-graph-read',
     )).rejects.toThrow('Credential reference vault mismatch');
   });
 
   it.each([
-    'https://vault.example/m365-customer-graph-read-id/version-1',
-    'akv://vault.example/m365-customer-graph-read-id',
-    'akv://vault.example/m365-customer-graph-read-id/version-1/extra',
+    `https://vault.example/${SECRET_NAME}/version-1`,
+    `akv://vault.example/${SECRET_NAME}`,
+    `akv://vault.example/${SECRET_NAME}/version-1/extra`,
   ])('rejects malformed credential reference %s', async (reference) => {
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', client());
     await expect(provider.get(reference, 'customer-graph-read')).rejects.toThrow(
@@ -79,7 +82,7 @@ describe('AzureKeyVaultCredentialProvider', () => {
     }));
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
     await expect(provider.get(
-      'akv://vault.example/m365-customer-graph-read-id/version-1',
+      REFERENCE,
       'customer-graph-read',
     )).rejects.toThrow('Credential secret has an unsupported envelope');
   });
@@ -88,7 +91,7 @@ describe('AzureKeyVaultCredentialProvider', () => {
     const port = client();
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
     await expect(provider.put({
-      connectionId: '11111111-1111-1111-1111-111111111111',
+      connectionId: CONNECTION_ID,
       domain: 'customer-graph-read',
       material: { kind: 'delegated-refresh-token', refreshToken: 'REFRESH' },
     })).rejects.toThrow('Credential material does not match credential domain');
@@ -99,7 +102,7 @@ describe('AzureKeyVaultCredentialProvider', () => {
     const port = client();
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
     await expect(provider.put({
-      connectionId: '11111111-1111-1111-1111-111111111111',
+      connectionId: CONNECTION_ID,
       domain: 'customer-graph-read',
       material: {
         kind: 'certificate',
@@ -128,7 +131,7 @@ describe('AzureKeyVaultCredentialProvider', () => {
     }));
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
     await expect(provider.get(
-      'akv://vault.example/m365-communications-delegated-id/version-1',
+      `akv://vault.example/m365-communications-delegated-${CONNECTION_ID}/version-1`,
       'communications-delegated',
     )).rejects.toThrow('Credential material does not match credential domain');
   });
@@ -150,7 +153,7 @@ describe('AzureKeyVaultCredentialProvider', () => {
     }));
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
     await expect(provider.get(
-      'akv://vault.example/m365-customer-graph-read-id/version-1',
+      REFERENCE,
       'customer-graph-read',
     )).rejects.toThrow('Credential secret has an unsupported envelope');
   });
@@ -161,10 +164,165 @@ describe('AzureKeyVaultCredentialProvider', () => {
     port.beginDeleteSecret = vi.fn(async () => ({ pollUntilDone }));
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
     await provider.delete(
-      'akv://vault.example/m365-customer-graph-read-id/version-1',
+      REFERENCE,
       'customer-graph-read',
     );
-    expect(port.beginDeleteSecret).toHaveBeenCalledWith('m365-customer-graph-read-id');
+    expect(port.beginDeleteSecret).toHaveBeenCalledWith(SECRET_NAME);
     expect(pollUntilDone).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a runtime-invalid put domain before credential material reaches the client', async () => {
+    const port = client();
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+
+    await expect(provider.put({
+      connectionId: CONNECTION_ID,
+      domain: 'unrecognized' as never,
+      material: { kind: 'certificate', certificatePem: 'CERT', privateKeyPem: 'PRIVATE', thumbprint: 'THUMB' },
+    })).rejects.toThrow('Unsupported M365 credential domain');
+    expect(port.setSecret).not.toHaveBeenCalled();
+  });
+
+  it('rejects a runtime-invalid expected get domain before accessing the client', async () => {
+    const port = client();
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+
+    await expect(provider.get(REFERENCE, 'unrecognized' as never)).rejects.toThrow(
+      'Unsupported M365 credential domain',
+    );
+    expect(port.getSecret).not.toHaveBeenCalled();
+  });
+
+  it('rejects a runtime-invalid expected delete domain before accessing the client', async () => {
+    const port = client();
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+
+    await expect(provider.delete(REFERENCE, 'unrecognized' as never)).rejects.toThrow(
+      'Unsupported M365 credential domain',
+    );
+    expect(port.beginDeleteSecret).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    `akv://vault.example/m365-customer-graph-read-arbitrary/version-1`,
+    `akv://vault.example/${SECRET_NAME}/anything`,
+    `akv://vault.example/m365-customer-graph-read-extra-${CONNECTION_ID}/version-1`,
+  ])('rejects noncanonical delete reference %s before deleting any secret versions', async (reference) => {
+    const port = client();
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+
+    await expect(provider.delete(reference, 'customer-graph-read')).rejects.toThrow(
+      'Invalid Azure Key Vault credential reference',
+    );
+    expect(port.beginDeleteSecret).not.toHaveBeenCalled();
+  });
+
+  it('accepts an Azure-generated 32-hex-character secret version', async () => {
+    const port = client();
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+    const version = '0123456789abcdef0123456789abcdef';
+
+    await provider.get(`akv://vault.example/${SECRET_NAME}/${version}`, 'customer-graph-read');
+
+    expect(port.getSecret).toHaveBeenCalledWith(SECRET_NAME, { version });
+  });
+
+  it('does not emit a provider reference for a noncanonical returned version', async () => {
+    const port = client();
+    port.setSecret = vi.fn(async () => ({ properties: { version: 'anything' } }));
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+
+    await expect(provider.put({
+      connectionId: CONNECTION_ID,
+      domain: 'customer-graph-read',
+      material: { kind: 'certificate', certificatePem: 'CERT', privateKeyPem: 'PRIVATE', thumbprint: 'THUMB' },
+    })).rejects.toThrow('Azure Key Vault did not return a valid secret version');
+  });
+
+  it('replaces a credential write failure with a fixed secret-free error', async () => {
+    const port = client();
+    const sentinel = 'SENTINEL-PRIVATE-KEY-WRITE';
+    port.setSecret = vi.fn(async (_name, envelope) => {
+      throw Object.assign(new Error(`sdk write failure: ${envelope}`), {
+        request: { body: envelope },
+        response: { body: sentinel },
+      });
+    });
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+
+    const failure = await provider.put({
+      connectionId: CONNECTION_ID,
+      domain: 'customer-graph-read',
+      material: { kind: 'certificate', certificatePem: 'CERT', privateKeyPem: sentinel, thumbprint: 'THUMB' },
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toBe('Azure Key Vault credential write failed');
+    expect(failure).not.toHaveProperty('cause');
+    expect(failure).not.toHaveProperty('request');
+    expect(failure).not.toHaveProperty('response');
+    expect(failure).not.toHaveProperty('envelope');
+    expect(String(failure)).not.toContain(sentinel);
+    expect(String(failure)).not.toContain(REFERENCE);
+  });
+
+  it('replaces a credential read failure with a fixed secret-free error', async () => {
+    const port = client();
+    const sentinel = 'SENTINEL-REFRESH-TOKEN-READ';
+    port.getSecret = vi.fn(async () => {
+      throw Object.assign(new Error(`sdk read failure: ${sentinel} ${REFERENCE}`), {
+        request: { reference: REFERENCE },
+        response: { body: sentinel },
+      });
+    });
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+
+    const failure = await provider.get(REFERENCE, 'customer-graph-read').catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toBe('Azure Key Vault credential read failed');
+    expect(failure).not.toHaveProperty('cause');
+    expect(failure).not.toHaveProperty('request');
+    expect(failure).not.toHaveProperty('response');
+    expect(failure).not.toHaveProperty('envelope');
+    expect(String(failure)).not.toContain(sentinel);
+    expect(String(failure)).not.toContain(REFERENCE);
+  });
+
+  it.each(['begin', 'poll'] as const)(
+    'replaces a credential delete %s failure with a fixed secret-free error',
+    async (failureStage) => {
+      const port = client();
+      const sentinel = `SENTINEL-DELETE-${failureStage}`;
+      const sdkError = Object.assign(new Error(`sdk delete failure: ${sentinel} ${REFERENCE}`), {
+        request: { reference: REFERENCE },
+        response: { body: sentinel },
+      });
+      port.beginDeleteSecret = failureStage === 'begin'
+        ? vi.fn(async () => { throw sdkError; })
+        : vi.fn(async () => ({ pollUntilDone: vi.fn(async () => { throw sdkError; }) }));
+      const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+
+      const failure = await provider.delete(REFERENCE, 'customer-graph-read').catch((error: unknown) => error);
+
+      expect(failure).toBeInstanceOf(Error);
+      expect((failure as Error).message).toBe('Azure Key Vault credential delete failed');
+      expect(failure).not.toHaveProperty('cause');
+      expect(failure).not.toHaveProperty('request');
+      expect(failure).not.toHaveProperty('response');
+      expect(failure).not.toHaveProperty('envelope');
+      expect(String(failure)).not.toContain(sentinel);
+      expect(String(failure)).not.toContain(REFERENCE);
+    },
+  );
+
+  it('deletes the whole named secret only after validating a canonical pinned reference', async () => {
+    const port = client();
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+
+    await provider.delete(REFERENCE, 'customer-graph-read');
+
+    // Azure beginDeleteSecret is name-scoped: deleting the name deletes all versions.
+    expect(port.beginDeleteSecret).toHaveBeenCalledWith(SECRET_NAME);
   });
 });

--- a/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.test.ts
+++ b/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.test.ts
@@ -3,11 +3,12 @@ import { AzureKeyVaultCredentialProvider, type SecretClientPort } from './azureK
 
 const CONNECTION_ID = '11111111-1111-1111-1111-111111111111';
 const SECRET_NAME = `m365-customer-graph-read-${CONNECTION_ID}`;
-const REFERENCE = `akv://vault.example/${SECRET_NAME}/version-1`;
+const SECRET_VERSION = '0123456789abcdef0123456789abcdef';
+const REFERENCE = `akv://vault.example/${SECRET_NAME}/${SECRET_VERSION}`;
 
 function client(): SecretClientPort {
   return {
-    setSecret: vi.fn(async () => ({ properties: { version: 'version-1' } })),
+    setSecret: vi.fn(async () => ({ properties: { version: SECRET_VERSION } })),
     getSecret: vi.fn(async () => ({
       value: JSON.stringify({
         schemaVersion: 1,
@@ -34,8 +35,8 @@ describe('AzureKeyVaultCredentialProvider', () => {
       material: { kind: 'certificate', certificatePem: 'CERT', privateKeyPem: 'PRIVATE', thumbprint: 'THUMB' },
     });
     expect(stored).toEqual({
-      reference: 'akv://vault.example/m365-customer-graph-read-11111111-1111-1111-1111-111111111111/version-1',
-      version: 'version-1',
+      reference: REFERENCE,
+      version: SECRET_VERSION,
     });
     expect(JSON.stringify(stored)).not.toContain('PRIVATE');
   });
@@ -47,7 +48,7 @@ describe('AzureKeyVaultCredentialProvider', () => {
     expect(material.kind).toBe('certificate');
     expect(port.getSecret).toHaveBeenCalledWith(
       SECRET_NAME,
-      { version: 'version-1' },
+      { version: SECRET_VERSION },
     );
     await expect(provider.get(REFERENCE, 'customer-graph-actions')).rejects.toThrow('Credential domain mismatch');
   });
@@ -55,15 +56,15 @@ describe('AzureKeyVaultCredentialProvider', () => {
   it('rejects references for a different vault host', async () => {
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', client());
     await expect(provider.get(
-      `akv://other-vault.example/${SECRET_NAME}/version-1`,
+      `akv://other-vault.example/${SECRET_NAME}/${SECRET_VERSION}`,
       'customer-graph-read',
     )).rejects.toThrow('Credential reference vault mismatch');
   });
 
   it.each([
-    `https://vault.example/${SECRET_NAME}/version-1`,
+    `https://vault.example/${SECRET_NAME}/${SECRET_VERSION}`,
     `akv://vault.example/${SECRET_NAME}`,
-    `akv://vault.example/${SECRET_NAME}/version-1/extra`,
+    `akv://vault.example/${SECRET_NAME}/${SECRET_VERSION}/extra`,
   ])('rejects malformed credential reference %s', async (reference) => {
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', client());
     await expect(provider.get(reference, 'customer-graph-read')).rejects.toThrow(
@@ -131,7 +132,7 @@ describe('AzureKeyVaultCredentialProvider', () => {
     }));
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
     await expect(provider.get(
-      `akv://vault.example/m365-communications-delegated-${CONNECTION_ID}/version-1`,
+      `akv://vault.example/m365-communications-delegated-${CONNECTION_ID}/${SECRET_VERSION}`,
       'communications-delegated',
     )).rejects.toThrow('Credential material does not match credential domain');
   });
@@ -204,9 +205,9 @@ describe('AzureKeyVaultCredentialProvider', () => {
   });
 
   it.each([
-    `akv://vault.example/m365-customer-graph-read-arbitrary/version-1`,
+    `akv://vault.example/m365-customer-graph-read-arbitrary/${SECRET_VERSION}`,
     `akv://vault.example/${SECRET_NAME}/anything`,
-    `akv://vault.example/m365-customer-graph-read-extra-${CONNECTION_ID}/version-1`,
+    `akv://vault.example/m365-customer-graph-read-extra-${CONNECTION_ID}/${SECRET_VERSION}`,
   ])('rejects noncanonical delete reference %s before deleting any secret versions', async (reference) => {
     const port = client();
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
@@ -220,11 +221,20 @@ describe('AzureKeyVaultCredentialProvider', () => {
   it('accepts an Azure-generated 32-hex-character secret version', async () => {
     const port = client();
     const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
-    const version = '0123456789abcdef0123456789abcdef';
 
-    await provider.get(`akv://vault.example/${SECRET_NAME}/${version}`, 'customer-graph-read');
+    await provider.get(REFERENCE, 'customer-graph-read');
 
-    expect(port.getSecret).toHaveBeenCalledWith(SECRET_NAME, { version });
+    expect(port.getSecret).toHaveBeenCalledWith(SECRET_NAME, { version: SECRET_VERSION });
+  });
+
+  it('rejects the former test-only version literal before accessing Key Vault', async () => {
+    const port = client();
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+    await expect(provider.get(
+      `akv://vault.example/${SECRET_NAME}/version-1`,
+      'customer-graph-read',
+    )).rejects.toThrow('Invalid Azure Key Vault credential reference');
+    expect(port.getSecret).not.toHaveBeenCalled();
   });
 
   it('does not emit a provider reference for a noncanonical returned version', async () => {

--- a/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.test.ts
+++ b/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.test.ts
@@ -21,7 +21,6 @@ function client(): SecretClientPort {
         },
       }),
     })),
-    beginDeleteSecret: vi.fn(async () => ({ pollUntilDone: vi.fn(async () => undefined) })),
   };
 }
 
@@ -159,17 +158,9 @@ describe('AzureKeyVaultCredentialProvider', () => {
     )).rejects.toThrow('Credential secret has an unsupported envelope');
   });
 
-  it('waits for Key Vault deletion to complete', async () => {
-    const port = client();
-    const pollUntilDone = vi.fn(async () => undefined);
-    port.beginDeleteSecret = vi.fn(async () => ({ pollUntilDone }));
-    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
-    await provider.delete(
-      REFERENCE,
-      'customer-graph-read',
-    );
-    expect(port.beginDeleteSecret).toHaveBeenCalledWith(SECRET_NAME);
-    expect(pollUntilDone).toHaveBeenCalledOnce();
+  it('does not expose name-wide deletion without a DB-backed lifecycle workflow', () => {
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', client());
+    expect(provider).not.toHaveProperty('delete');
   });
 
   it('rejects a runtime-invalid put domain before credential material reaches the client', async () => {
@@ -192,30 +183,6 @@ describe('AzureKeyVaultCredentialProvider', () => {
       'Unsupported M365 credential domain',
     );
     expect(port.getSecret).not.toHaveBeenCalled();
-  });
-
-  it('rejects a runtime-invalid expected delete domain before accessing the client', async () => {
-    const port = client();
-    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
-
-    await expect(provider.delete(REFERENCE, 'unrecognized' as never)).rejects.toThrow(
-      'Unsupported M365 credential domain',
-    );
-    expect(port.beginDeleteSecret).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    `akv://vault.example/m365-customer-graph-read-arbitrary/${SECRET_VERSION}`,
-    `akv://vault.example/${SECRET_NAME}/anything`,
-    `akv://vault.example/m365-customer-graph-read-extra-${CONNECTION_ID}/${SECRET_VERSION}`,
-  ])('rejects noncanonical delete reference %s before deleting any secret versions', async (reference) => {
-    const port = client();
-    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
-
-    await expect(provider.delete(reference, 'customer-graph-read')).rejects.toThrow(
-      'Invalid Azure Key Vault credential reference',
-    );
-    expect(port.beginDeleteSecret).not.toHaveBeenCalled();
   });
 
   it('accepts an Azure-generated 32-hex-character secret version', async () => {
@@ -299,40 +266,4 @@ describe('AzureKeyVaultCredentialProvider', () => {
     expect(String(failure)).not.toContain(REFERENCE);
   });
 
-  it.each(['begin', 'poll'] as const)(
-    'replaces a credential delete %s failure with a fixed secret-free error',
-    async (failureStage) => {
-      const port = client();
-      const sentinel = `SENTINEL-DELETE-${failureStage}`;
-      const sdkError = Object.assign(new Error(`sdk delete failure: ${sentinel} ${REFERENCE}`), {
-        request: { reference: REFERENCE },
-        response: { body: sentinel },
-      });
-      port.beginDeleteSecret = failureStage === 'begin'
-        ? vi.fn(async () => { throw sdkError; })
-        : vi.fn(async () => ({ pollUntilDone: vi.fn(async () => { throw sdkError; }) }));
-      const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
-
-      const failure = await provider.delete(REFERENCE, 'customer-graph-read').catch((error: unknown) => error);
-
-      expect(failure).toBeInstanceOf(Error);
-      expect((failure as Error).message).toBe('Azure Key Vault credential delete failed');
-      expect(failure).not.toHaveProperty('cause');
-      expect(failure).not.toHaveProperty('request');
-      expect(failure).not.toHaveProperty('response');
-      expect(failure).not.toHaveProperty('envelope');
-      expect(String(failure)).not.toContain(sentinel);
-      expect(String(failure)).not.toContain(REFERENCE);
-    },
-  );
-
-  it('deletes the whole named secret only after validating a canonical pinned reference', async () => {
-    const port = client();
-    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
-
-    await provider.delete(REFERENCE, 'customer-graph-read');
-
-    // Azure beginDeleteSecret is name-scoped: deleting the name deletes all versions.
-    expect(port.beginDeleteSecret).toHaveBeenCalledWith(SECRET_NAME);
-  });
 });

--- a/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.test.ts
+++ b/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AzureKeyVaultCredentialProvider, type SecretClientPort } from './azureKeyVaultProvider';
+
+function client(): SecretClientPort {
+  return {
+    setSecret: vi.fn(async () => ({ properties: { version: 'version-1' } })),
+    getSecret: vi.fn(async () => ({
+      value: JSON.stringify({
+        schemaVersion: 1,
+        domain: 'customer-graph-read',
+        material: {
+          kind: 'certificate',
+          certificatePem: 'CERT',
+          privateKeyPem: 'PRIVATE',
+          thumbprint: 'THUMB',
+        },
+      }),
+    })),
+    beginDeleteSecret: vi.fn(async () => ({ pollUntilDone: vi.fn(async () => undefined) })),
+  };
+}
+
+describe('AzureKeyVaultCredentialProvider', () => {
+  it('returns a versioned reference without returning the stored material', async () => {
+    const port = client();
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+    const stored = await provider.put({
+      connectionId: '11111111-1111-1111-1111-111111111111',
+      domain: 'customer-graph-read',
+      material: { kind: 'certificate', certificatePem: 'CERT', privateKeyPem: 'PRIVATE', thumbprint: 'THUMB' },
+    });
+    expect(stored).toEqual({
+      reference: 'akv://vault.example/m365-customer-graph-read-11111111-1111-1111-1111-111111111111/version-1',
+      version: 'version-1',
+    });
+    expect(JSON.stringify(stored)).not.toContain('PRIVATE');
+  });
+
+  it('returns material only when the expected credential domain matches', async () => {
+    const port = client();
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+    const reference = 'akv://vault.example/m365-customer-graph-read-11111111-1111-1111-1111-111111111111/version-1';
+    const material = await provider.get(reference, 'customer-graph-read');
+    expect(material.kind).toBe('certificate');
+    expect(port.getSecret).toHaveBeenCalledWith(
+      'm365-customer-graph-read-11111111-1111-1111-1111-111111111111',
+      { version: 'version-1' },
+    );
+    await expect(provider.get(reference, 'customer-graph-actions')).rejects.toThrow('Credential domain mismatch');
+  });
+
+  it('rejects references for a different vault host', async () => {
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', client());
+    await expect(provider.get(
+      'akv://other-vault.example/m365-customer-graph-read-id/version-1',
+      'customer-graph-read',
+    )).rejects.toThrow('Credential reference vault mismatch');
+  });
+
+  it.each([
+    'https://vault.example/m365-customer-graph-read-id/version-1',
+    'akv://vault.example/m365-customer-graph-read-id',
+    'akv://vault.example/m365-customer-graph-read-id/version-1/extra',
+  ])('rejects malformed credential reference %s', async (reference) => {
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', client());
+    await expect(provider.get(reference, 'customer-graph-read')).rejects.toThrow(
+      'Invalid Azure Key Vault credential reference',
+    );
+  });
+
+  it('rejects a malformed credential envelope', async () => {
+    const port = client();
+    port.getSecret = vi.fn(async () => ({
+      value: JSON.stringify({
+        schemaVersion: 1,
+        domain: 'customer-graph-read',
+        material: { kind: 'unknown-secret-kind', value: 'SECRET' },
+      }),
+    }));
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+    await expect(provider.get(
+      'akv://vault.example/m365-customer-graph-read-id/version-1',
+      'customer-graph-read',
+    )).rejects.toThrow('Credential secret has an unsupported envelope');
+  });
+
+  it('rejects a refresh token in a certificate credential domain', async () => {
+    const port = client();
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+    await expect(provider.put({
+      connectionId: '11111111-1111-1111-1111-111111111111',
+      domain: 'customer-graph-read',
+      material: { kind: 'delegated-refresh-token', refreshToken: 'REFRESH' },
+    })).rejects.toThrow('Credential material does not match credential domain');
+    expect(port.setSecret).not.toHaveBeenCalled();
+  });
+
+  it('rejects mixed credential material before storing it', async () => {
+    const port = client();
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+    await expect(provider.put({
+      connectionId: '11111111-1111-1111-1111-111111111111',
+      domain: 'customer-graph-read',
+      material: {
+        kind: 'certificate',
+        certificatePem: 'CERT',
+        privateKeyPem: 'PRIVATE',
+        thumbprint: 'THUMB',
+        refreshToken: 'REFRESH',
+      } as never,
+    })).rejects.toThrow('Credential material does not match credential domain');
+    expect(port.setSecret).not.toHaveBeenCalled();
+  });
+
+  it('rejects a certificate returned for the delegated credential domain', async () => {
+    const port = client();
+    port.getSecret = vi.fn(async () => ({
+      value: JSON.stringify({
+        schemaVersion: 1,
+        domain: 'communications-delegated',
+        material: {
+          kind: 'certificate',
+          certificatePem: 'CERT',
+          privateKeyPem: 'PRIVATE',
+          thumbprint: 'THUMB',
+        },
+      }),
+    }));
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+    await expect(provider.get(
+      'akv://vault.example/m365-communications-delegated-id/version-1',
+      'communications-delegated',
+    )).rejects.toThrow('Credential material does not match credential domain');
+  });
+
+  it('rejects an envelope that mixes material from separate credential domains', async () => {
+    const port = client();
+    port.getSecret = vi.fn(async () => ({
+      value: JSON.stringify({
+        schemaVersion: 1,
+        domain: 'customer-graph-read',
+        material: {
+          kind: 'certificate',
+          certificatePem: 'CERT',
+          privateKeyPem: 'PRIVATE',
+          thumbprint: 'THUMB',
+          refreshToken: 'REFRESH',
+        },
+      }),
+    }));
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+    await expect(provider.get(
+      'akv://vault.example/m365-customer-graph-read-id/version-1',
+      'customer-graph-read',
+    )).rejects.toThrow('Credential secret has an unsupported envelope');
+  });
+
+  it('waits for Key Vault deletion to complete', async () => {
+    const port = client();
+    const pollUntilDone = vi.fn(async () => undefined);
+    port.beginDeleteSecret = vi.fn(async () => ({ pollUntilDone }));
+    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+    await provider.delete(
+      'akv://vault.example/m365-customer-graph-read-id/version-1',
+      'customer-graph-read',
+    );
+    expect(port.beginDeleteSecret).toHaveBeenCalledWith('m365-customer-graph-read-id');
+    expect(pollUntilDone).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.ts
+++ b/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.ts
@@ -21,10 +21,34 @@ export interface SecretClientPort {
 interface ParsedReference {
   host: string;
   name: string;
+  domain: M365CredentialDomain;
   version: string;
 }
 
 const CONNECTION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// Azure-generated secret versions are 32 hexadecimal characters. `version-1`
+// remains valid for the provider port contract used by the foundation plan.
+// This is syntax validation for a pinned reference, not an authorization check.
+const KEY_VAULT_VERSION_RE = /^(?:[0-9a-f]{32}|version-1)$/i;
+
+function isCredentialDomain(value: unknown): value is M365CredentialDomain {
+  return typeof value === 'string'
+    && M365_CREDENTIAL_DOMAINS.includes(value as M365CredentialDomain);
+}
+
+function assertCredentialDomain(value: unknown): asserts value is M365CredentialDomain {
+  if (!isCredentialDomain(value)) throw new Error('Unsupported M365 credential domain');
+}
+
+function parseCredentialName(name: string): M365CredentialDomain | undefined {
+  for (const domain of M365_CREDENTIAL_DOMAINS) {
+    const prefix = `m365-${domain}-`;
+    if (name.startsWith(prefix) && CONNECTION_ID_RE.test(name.slice(prefix.length))) {
+      return domain;
+    }
+  }
+  return undefined;
+}
 
 function hasExactKeys(value: object, expected: readonly string[]): boolean {
   const keys = Object.keys(value);
@@ -55,7 +79,10 @@ function materialMatchesDomain(
 function parseReference(reference: string): ParsedReference {
   try {
     const url = new URL(reference);
-    const [name, version, extra] = url.pathname.split('/').filter(Boolean);
+    const pathSegments = url.pathname.split('/');
+    const name = pathSegments[1];
+    const version = pathSegments[2];
+    const domain = name ? parseCredentialName(name) : undefined;
     if (
       url.protocol !== 'akv:'
       || !url.hostname
@@ -63,13 +90,16 @@ function parseReference(reference: string): ParsedReference {
       || url.password
       || url.search
       || url.hash
+      || pathSegments.length !== 3
       || !name
       || !version
-      || extra
+      || !domain
+      || !KEY_VAULT_VERSION_RE.test(version)
+      || reference !== `akv://${url.host}/${name}/${version}`
     ) {
       throw new Error('invalid');
     }
-    return { host: url.host, name, version };
+    return { host: url.host, name, domain, version };
   } catch {
     throw new Error('Invalid Azure Key Vault credential reference');
   }
@@ -130,26 +160,40 @@ export class AzureKeyVaultCredentialProvider implements CredentialProvider {
     domain: M365CredentialDomain;
     material: M365CredentialMaterial;
   }): Promise<StoredCredentialReference> {
+    assertCredentialDomain(input.domain);
     if (!CONNECTION_ID_RE.test(input.connectionId)) throw new Error('Connection id must be a UUID');
     if (!materialMatchesDomain(input.domain, input.material)) {
       throw new Error('Credential material does not match credential domain');
     }
     const name = `m365-${input.domain}-${input.connectionId}`;
     const envelope: CredentialEnvelope = { schemaVersion: 1, domain: input.domain, material: input.material };
-    const stored = await this.client.setSecret(name, JSON.stringify(envelope), {
-      contentType: 'application/vnd.breeze.m365-credential+json',
-      tags: { domain: input.domain, connectionId: input.connectionId },
-    });
+    let stored: Awaited<ReturnType<SecretClientPort['setSecret']>>;
+    try {
+      stored = await this.client.setSecret(name, JSON.stringify(envelope), {
+        contentType: 'application/vnd.breeze.m365-credential+json',
+        tags: { domain: input.domain, connectionId: input.connectionId },
+      });
+    } catch {
+      throw new Error('Azure Key Vault credential write failed');
+    }
     const version = stored.properties.version;
-    if (!version) throw new Error('Azure Key Vault did not return a secret version');
+    if (!version || !KEY_VAULT_VERSION_RE.test(version)) {
+      throw new Error('Azure Key Vault did not return a valid secret version');
+    }
     return { reference: `akv://${this.vaultHost}/${name}/${version}`, version };
   }
 
   async get(reference: string, expectedDomain: M365CredentialDomain): Promise<M365CredentialMaterial> {
+    assertCredentialDomain(expectedDomain);
     const parsed = parseReference(reference);
     if (parsed.host !== this.vaultHost) throw new Error('Credential reference vault mismatch');
-    if (!parsed.name.startsWith(`m365-${expectedDomain}-`)) throw new Error('Credential domain mismatch');
-    const secret = await this.client.getSecret(parsed.name, { version: parsed.version });
+    if (parsed.domain !== expectedDomain) throw new Error('Credential domain mismatch');
+    let secret: Awaited<ReturnType<SecretClientPort['getSecret']>>;
+    try {
+      secret = await this.client.getSecret(parsed.name, { version: parsed.version });
+    } catch {
+      throw new Error('Azure Key Vault credential read failed');
+    }
     const envelope = parseEnvelope(secret.value);
     if (envelope.domain !== expectedDomain) throw new Error('Credential domain mismatch');
     if (!materialMatchesDomain(expectedDomain, envelope.material)) {
@@ -159,10 +203,18 @@ export class AzureKeyVaultCredentialProvider implements CredentialProvider {
   }
 
   async delete(reference: string, expectedDomain: M365CredentialDomain): Promise<void> {
+    assertCredentialDomain(expectedDomain);
     const parsed = parseReference(reference);
     if (parsed.host !== this.vaultHost) throw new Error('Credential reference vault mismatch');
-    if (!parsed.name.startsWith(`m365-${expectedDomain}-`)) throw new Error('Credential domain mismatch');
-    const poller = await this.client.beginDeleteSecret(parsed.name);
-    await poller.pollUntilDone();
+    if (parsed.domain !== expectedDomain) throw new Error('Credential domain mismatch');
+    try {
+      // Azure deletion is name-scoped and intentionally deletes the named secret
+      // with all of its versions. Canonical host/domain/name/version validation
+      // above must succeed before beginning that all-version operation.
+      const poller = await this.client.beginDeleteSecret(parsed.name);
+      await poller.pollUntilDone();
+    } catch {
+      throw new Error('Azure Key Vault credential delete failed');
+    }
   }
 }

--- a/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.ts
+++ b/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.ts
@@ -15,7 +15,6 @@ interface CredentialEnvelope {
 export interface SecretClientPort {
   setSecret(name: string, value: string, options?: unknown): Promise<{ properties: { version?: string } }>;
   getSecret(name: string, options?: { version?: string }): Promise<{ value?: string }>;
-  beginDeleteSecret(name: string): Promise<{ pollUntilDone(): Promise<unknown> }>;
 }
 
 interface ParsedReference {
@@ -197,21 +196,5 @@ export class AzureKeyVaultCredentialProvider implements CredentialProvider {
       throw new Error('Credential material does not match credential domain');
     }
     return envelope.material;
-  }
-
-  async delete(reference: string, expectedDomain: M365CredentialDomain): Promise<void> {
-    assertCredentialDomain(expectedDomain);
-    const parsed = parseReference(reference);
-    if (parsed.host !== this.vaultHost) throw new Error('Credential reference vault mismatch');
-    if (parsed.domain !== expectedDomain) throw new Error('Credential domain mismatch');
-    try {
-      // Azure deletion is name-scoped and intentionally deletes the named secret
-      // with all of its versions. Canonical host/domain/name/version validation
-      // above must succeed before beginning that all-version operation.
-      const poller = await this.client.beginDeleteSecret(parsed.name);
-      await poller.pollUntilDone();
-    } catch {
-      throw new Error('Azure Key Vault credential delete failed');
-    }
   }
 }

--- a/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.ts
+++ b/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.ts
@@ -1,0 +1,168 @@
+import { DefaultAzureCredential } from '@azure/identity';
+import { SecretClient } from '@azure/keyvault-secrets';
+import {
+  M365_CREDENTIAL_DOMAINS,
+  type M365CredentialDomain,
+} from '../../../services/m365ControlPlane/profiles';
+import type { CredentialProvider, M365CredentialMaterial, StoredCredentialReference } from './types';
+
+interface CredentialEnvelope {
+  schemaVersion: 1;
+  domain: M365CredentialDomain;
+  material: M365CredentialMaterial;
+}
+
+export interface SecretClientPort {
+  setSecret(name: string, value: string, options?: unknown): Promise<{ properties: { version?: string } }>;
+  getSecret(name: string, options?: { version?: string }): Promise<{ value?: string }>;
+  beginDeleteSecret(name: string): Promise<{ pollUntilDone(): Promise<unknown> }>;
+}
+
+interface ParsedReference {
+  host: string;
+  name: string;
+  version: string;
+}
+
+const CONNECTION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function hasExactKeys(value: object, expected: readonly string[]): boolean {
+  const keys = Object.keys(value);
+  return keys.length === expected.length && keys.every((key) => expected.includes(key));
+}
+
+function materialMatchesDomain(
+  domain: M365CredentialDomain,
+  material: M365CredentialMaterial,
+): boolean {
+  if (typeof material !== 'object' || material === null) return false;
+  if (domain === 'communications-delegated') {
+    return hasExactKeys(material, ['kind', 'refreshToken'])
+      && material.kind === 'delegated-refresh-token'
+      && typeof material.refreshToken === 'string'
+      && material.refreshToken.length > 0;
+  }
+  return hasExactKeys(material, ['kind', 'certificatePem', 'privateKeyPem', 'thumbprint'])
+    && material.kind === 'certificate'
+    && typeof material.certificatePem === 'string'
+    && material.certificatePem.length > 0
+    && typeof material.privateKeyPem === 'string'
+    && material.privateKeyPem.length > 0
+    && typeof material.thumbprint === 'string'
+    && material.thumbprint.length > 0;
+}
+
+function parseReference(reference: string): ParsedReference {
+  try {
+    const url = new URL(reference);
+    const [name, version, extra] = url.pathname.split('/').filter(Boolean);
+    if (
+      url.protocol !== 'akv:'
+      || !url.hostname
+      || url.username
+      || url.password
+      || url.search
+      || url.hash
+      || !name
+      || !version
+      || extra
+    ) {
+      throw new Error('invalid');
+    }
+    return { host: url.host, name, version };
+  } catch {
+    throw new Error('Invalid Azure Key Vault credential reference');
+  }
+}
+
+function parseEnvelope(value: string | undefined): CredentialEnvelope {
+  if (!value) throw new Error('Credential secret has no value');
+
+  try {
+    const parsed = JSON.parse(value) as Partial<CredentialEnvelope>;
+    const domainValid = M365_CREDENTIAL_DOMAINS.includes(parsed.domain as M365CredentialDomain);
+    const material = parsed.material;
+    const delegatedValid = typeof material === 'object'
+      && material !== null
+      && hasExactKeys(material, ['kind', 'refreshToken'])
+      && material.kind === 'delegated-refresh-token'
+      && typeof material.refreshToken === 'string'
+      && material.refreshToken.length > 0;
+    const certificateValid = typeof material === 'object'
+      && material !== null
+      && hasExactKeys(material, ['kind', 'certificatePem', 'privateKeyPem', 'thumbprint'])
+      && material.kind === 'certificate'
+      && typeof material.certificatePem === 'string'
+      && material.certificatePem.length > 0
+      && typeof material.privateKeyPem === 'string'
+      && material.privateKeyPem.length > 0
+      && typeof material.thumbprint === 'string'
+      && material.thumbprint.length > 0;
+    if (parsed.schemaVersion !== 1 || !domainValid || (!delegatedValid && !certificateValid)) {
+      throw new Error('invalid');
+    }
+    return parsed as CredentialEnvelope;
+  } catch {
+    throw new Error('Credential secret has an unsupported envelope');
+  }
+}
+
+export class AzureKeyVaultCredentialProvider implements CredentialProvider {
+  private readonly vaultHost: string;
+
+  constructor(vaultUrl: string, private readonly client: SecretClientPort) {
+    const parsed = new URL(vaultUrl);
+    if (parsed.protocol !== 'https:' || !parsed.hostname) throw new Error('Azure Key Vault URL must use HTTPS');
+    this.vaultHost = parsed.host;
+  }
+
+  static fromEnvironment(): AzureKeyVaultCredentialProvider {
+    const vaultUrl = process.env.M365_AZURE_KEY_VAULT_URL;
+    if (!vaultUrl) throw new Error('M365_AZURE_KEY_VAULT_URL is required');
+    return new AzureKeyVaultCredentialProvider(
+      vaultUrl,
+      new SecretClient(vaultUrl, new DefaultAzureCredential()) as unknown as SecretClientPort,
+    );
+  }
+
+  async put(input: {
+    connectionId: string;
+    domain: M365CredentialDomain;
+    material: M365CredentialMaterial;
+  }): Promise<StoredCredentialReference> {
+    if (!CONNECTION_ID_RE.test(input.connectionId)) throw new Error('Connection id must be a UUID');
+    if (!materialMatchesDomain(input.domain, input.material)) {
+      throw new Error('Credential material does not match credential domain');
+    }
+    const name = `m365-${input.domain}-${input.connectionId}`;
+    const envelope: CredentialEnvelope = { schemaVersion: 1, domain: input.domain, material: input.material };
+    const stored = await this.client.setSecret(name, JSON.stringify(envelope), {
+      contentType: 'application/vnd.breeze.m365-credential+json',
+      tags: { domain: input.domain, connectionId: input.connectionId },
+    });
+    const version = stored.properties.version;
+    if (!version) throw new Error('Azure Key Vault did not return a secret version');
+    return { reference: `akv://${this.vaultHost}/${name}/${version}`, version };
+  }
+
+  async get(reference: string, expectedDomain: M365CredentialDomain): Promise<M365CredentialMaterial> {
+    const parsed = parseReference(reference);
+    if (parsed.host !== this.vaultHost) throw new Error('Credential reference vault mismatch');
+    if (!parsed.name.startsWith(`m365-${expectedDomain}-`)) throw new Error('Credential domain mismatch');
+    const secret = await this.client.getSecret(parsed.name, { version: parsed.version });
+    const envelope = parseEnvelope(secret.value);
+    if (envelope.domain !== expectedDomain) throw new Error('Credential domain mismatch');
+    if (!materialMatchesDomain(expectedDomain, envelope.material)) {
+      throw new Error('Credential material does not match credential domain');
+    }
+    return envelope.material;
+  }
+
+  async delete(reference: string, expectedDomain: M365CredentialDomain): Promise<void> {
+    const parsed = parseReference(reference);
+    if (parsed.host !== this.vaultHost) throw new Error('Credential reference vault mismatch');
+    if (!parsed.name.startsWith(`m365-${expectedDomain}-`)) throw new Error('Credential domain mismatch');
+    const poller = await this.client.beginDeleteSecret(parsed.name);
+    await poller.pollUntilDone();
+  }
+}

--- a/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.ts
+++ b/apps/api/src/executors/m365/credentials/azureKeyVaultProvider.ts
@@ -26,10 +26,7 @@ interface ParsedReference {
 }
 
 const CONNECTION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-// Azure-generated secret versions are 32 hexadecimal characters. `version-1`
-// remains valid for the provider port contract used by the foundation plan.
-// This is syntax validation for a pinned reference, not an authorization check.
-const KEY_VAULT_VERSION_RE = /^(?:[0-9a-f]{32}|version-1)$/i;
+const KEY_VAULT_VERSION_RE = /^[0-9a-f]{32}$/i;
 
 function isCredentialDomain(value: unknown): value is M365CredentialDomain {
   return typeof value === 'string'

--- a/apps/api/src/executors/m365/credentials/types.ts
+++ b/apps/api/src/executors/m365/credentials/types.ts
@@ -16,5 +16,4 @@ export interface CredentialProvider {
     material: M365CredentialMaterial;
   }): Promise<StoredCredentialReference>;
   get(reference: string, expectedDomain: M365CredentialDomain): Promise<M365CredentialMaterial>;
-  delete(reference: string, expectedDomain: M365CredentialDomain): Promise<void>;
 }

--- a/apps/api/src/executors/m365/credentials/types.ts
+++ b/apps/api/src/executors/m365/credentials/types.ts
@@ -1,0 +1,20 @@
+import type { M365CredentialDomain } from '../../../services/m365ControlPlane/profiles';
+
+export type M365CredentialMaterial =
+  | { kind: 'delegated-refresh-token'; refreshToken: string }
+  | { kind: 'certificate'; certificatePem: string; privateKeyPem: string; thumbprint: string };
+
+export interface StoredCredentialReference {
+  reference: string;
+  version: string;
+}
+
+export interface CredentialProvider {
+  put(input: {
+    connectionId: string;
+    domain: M365CredentialDomain;
+    material: M365CredentialMaterial;
+  }): Promise<StoredCredentialReference>;
+  get(reference: string, expectedDomain: M365CredentialDomain): Promise<M365CredentialMaterial>;
+  delete(reference: string, expectedDomain: M365CredentialDomain): Promise<void>;
+}

--- a/apps/api/src/routes/clientAi/adminOrgs.test.ts
+++ b/apps/api/src/routes/clientAi/adminOrgs.test.ts
@@ -28,6 +28,10 @@ vi.mock('../../config/env', () => ({
 }));
 
 vi.mock('../../db', () => ({ db: { select: dbSelectMock } }));
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return { ...actual, eq: vi.fn(actual.eq) };
+});
 
 import {
   clientAiAdminOrgRoutes,
@@ -37,6 +41,8 @@ import {
   currentMonthKey,
 } from './adminOrgs';
 import { authMiddleware } from '../../middleware/auth';
+import { eq } from 'drizzle-orm';
+import { m365Connections } from '../../db/schema/m365';
 
 const ORG_ID = '0c0c0c0c-1111-4222-8333-444455556666';
 const OTHER_ORG_ID = '9d9d9d9d-1111-4222-8333-444455556666';
@@ -160,6 +166,13 @@ describe('GET /client-ai/admin/orgs', () => {
     });
     const res = await buildApp().request('/client-ai/admin/orgs', { headers: AUTHED });
     expect((await res.json()).data[0].suggestedEntraTenantId).toBe(TID);
+  });
+
+  it('uses only legacy-direct rows for the transitional M365 tenant suggestion', async () => {
+    setupOrgListDb();
+    const res = await buildApp().request('/client-ai/admin/orgs', { headers: AUTHED });
+    expect(res.status).toBe(200);
+    expect(eq).toHaveBeenCalledWith(m365Connections.profile, 'legacy-direct');
   });
 });
 

--- a/apps/api/src/routes/clientAi/adminOrgs.ts
+++ b/apps/api/src/routes/clientAi/adminOrgs.ts
@@ -118,7 +118,8 @@ clientAiAdminOrgRoutes.get('/orgs', requireOrgsRead, async (c) => {
 
   const m365 = await db
     .select({ orgId: m365Connections.orgId, tenantId: m365Connections.tenantId })
-    .from(m365Connections);
+    .from(m365Connections)
+    .where(eq(m365Connections.profile, 'legacy-direct'));
 
   const delegant = await db
     .select({
@@ -149,7 +150,7 @@ clientAiAdminOrgRoutes.get('/orgs', requireOrgsRead, async (c) => {
     }
   }
   for (const row of m365) {
-    if (ENTRA_TENANT_GUID_REGEX.test(row.tenantId)) {
+    if (row.orgId && ENTRA_TENANT_GUID_REGEX.test(row.tenantId)) {
       suggestedByOrg.set(row.orgId, row.tenantId.toLowerCase());
     }
   }

--- a/apps/api/src/routes/m365.test.ts
+++ b/apps/api/src/routes/m365.test.ts
@@ -5,6 +5,7 @@ import { Hono } from 'hono';
 let selectRows: unknown[] = [];
 let insertRows: unknown[] = [];
 let deleteRows: unknown[] = [];
+let insertedValues: unknown;
 let tokenResult: { accessToken: string; expiresIn: number };
 let graphResult: { ok: boolean; orgDisplayName?: string; error?: string };
 let tokenThrows = false;
@@ -24,7 +25,13 @@ vi.mock('../middleware/auth', () => ({
   requirePermission: vi.fn(() => (_c: any, next: any) => next()),
   requireMfa: vi.fn(() => (_c: any, next: any) => next()),
 }));
-vi.mock('../db/schema/m365', () => ({ m365Connections: { orgId: 'org_id' } }));
+vi.mock('../db/schema/m365', () => ({
+  m365Connections: {
+    orgId: 'org_id',
+    profile: 'profile',
+    status: 'status',
+  },
+}));
 vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
 vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
 vi.mock('../services/secretCrypto', () => ({ encryptSecret: vi.fn(() => 'ENCRYPTED-SECRET') }));
@@ -40,7 +47,12 @@ vi.mock('../services/c2cM365', () => ({
 vi.mock('../db', () => ({
   db: {
     select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn(async () => selectRows) })) })) })),
-    insert: vi.fn(() => ({ values: vi.fn(() => ({ onConflictDoUpdate: vi.fn(() => ({ returning: vi.fn(async () => insertRows) })) })) })),
+    insert: vi.fn(() => ({
+      values: vi.fn((values: unknown) => {
+        insertedValues = values;
+        return { onConflictDoUpdate: vi.fn(() => ({ returning: vi.fn(async () => insertRows) })) };
+      }),
+    })),
     delete: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(async () => deleteRows) })) })),
   },
 }));
@@ -60,6 +72,8 @@ function app() {
 const storedRow = {
   id: 'conn-1', orgId: 'org-1', tenantId: '11111111-1111-1111-1111-111111111111', clientId: 'client-1',
   clientSecret: 'ENCRYPTED-SECRET', displayName: 'Contoso', status: 'active',
+  profile: 'legacy-direct', authMode: 'client-secret-legacy', credentialDomain: 'legacy-direct',
+  vaultRef: null, permissionManifestVersion: 0, observedGrants: [],
   lastVerifiedAt: new Date('2026-06-01T00:00:00Z'), createdAt: new Date('2026-06-01T00:00:00Z'),
   updatedAt: new Date('2026-06-01T00:00:00Z'),
 };
@@ -70,6 +84,7 @@ beforeEach(() => {
   tokenResult = { accessToken: 'tok', expiresIn: 3600 };
   graphResult = { ok: true, orgDisplayName: 'Contoso' };
   tokenThrows = false;
+  insertedValues = undefined;
 });
 
 describe('m365 connection routes', () => {
@@ -105,6 +120,20 @@ describe('m365 connection routes', () => {
     expect(body.connected).toBe(true);
     expect(JSON.stringify(body)).not.toContain('super-secret');
     expect(JSON.stringify(body)).not.toContain('ENCRYPTED-SECRET');
+    expect(insertedValues).toMatchObject({
+      profile: 'legacy-direct',
+      authMode: 'client-secret-legacy',
+      credentialDomain: 'legacy-direct',
+      permissionManifestVersion: 0,
+      vaultRef: null,
+    });
+  });
+
+  it('does not attempt Graph auth when a legacy row has no encrypted secret', async () => {
+    selectRows = [{ ...storedRow, clientSecret: null }];
+    const res = await app().request('/m365/connection');
+    expect(res.status).toBe(200);
+    expect((await res.json()).connected).toBe(true);
   });
 
   it('POST /connection returns 400 with a hint when Graph verification fails', async () => {

--- a/apps/api/src/routes/m365.ts
+++ b/apps/api/src/routes/m365.ts
@@ -12,7 +12,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { db } from '../db';
 import { m365Connections } from '../db/schema/m365';
 import { authMiddleware, requireMfa, requirePermission } from '../middleware/auth';
@@ -28,6 +28,9 @@ export const m365Routes = new Hono();
 
 const requireOrgsRead = requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action);
 const requireOrgsWrite = requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action);
+
+const legacyDirectForOrg = (orgId: string) =>
+  and(eq(m365Connections.orgId, orgId), eq(m365Connections.profile, 'legacy-direct'));
 
 // Every endpoint requires an authenticated session (populates c.get('auth') for
 // the requirePermission / requireMfa guards below). Without this the guards see
@@ -69,7 +72,7 @@ m365Routes.get('/connection', requireOrgsRead, async (c) => {
   const [row] = await db
     .select()
     .from(m365Connections)
-    .where(eq(m365Connections.orgId, orgId))
+    .where(legacyDirectForOrg(orgId))
     .limit(1);
 
   if (!row) return c.json({ connected: false });
@@ -145,6 +148,13 @@ m365Routes.post(
         tenantId: payload.tenantId,
         clientId: payload.clientId,
         clientSecret: encryptedSecret,
+        profile: 'legacy-direct',
+        authMode: 'client-secret-legacy',
+        credentialDomain: 'legacy-direct',
+        vaultRef: null,
+        credentialVersion: null,
+        permissionManifestVersion: 0,
+        observedGrants: [],
         displayName,
         status: 'active',
         createdBy: auth.user?.id ?? null,
@@ -153,7 +163,7 @@ m365Routes.post(
         updatedAt: now,
       })
       .onConflictDoUpdate({
-        target: m365Connections.orgId,
+        target: [m365Connections.orgId, m365Connections.profile],
         set: {
           tenantId: payload.tenantId,
           clientId: payload.clientId,
@@ -192,7 +202,7 @@ m365Routes.delete('/connection', requireOrgsWrite, requireMfa(), async (c) => {
 
   const [row] = await db
     .delete(m365Connections)
-    .where(eq(m365Connections.orgId, orgId))
+    .where(legacyDirectForOrg(orgId))
     .returning();
 
   if (row) {

--- a/apps/api/src/services/m365ControlPlane/profiles.test.ts
+++ b/apps/api/src/services/m365ControlPlane/profiles.test.ts
@@ -5,15 +5,69 @@ import {
   getM365PermissionProfile,
 } from './profiles';
 
+const PROFILE_CONTRACTS = [
+  {
+    id: 'communications-delegated',
+    version: 1,
+    ownerAxis: 'user',
+    authMode: 'delegated',
+    credentialDomain: 'communications-delegated',
+    executor: 'communications',
+    grantClass: 'delegated',
+  },
+  {
+    id: 'customer-graph-read',
+    version: 1,
+    ownerAxis: 'organization',
+    authMode: 'application-certificate',
+    credentialDomain: 'customer-graph-read',
+    executor: 'graph-read',
+    grantClass: 'application',
+  },
+  {
+    id: 'customer-graph-actions',
+    version: 1,
+    ownerAxis: 'organization',
+    authMode: 'application-certificate',
+    credentialDomain: 'customer-graph-actions',
+    executor: 'graph-actions',
+    grantClass: 'application',
+  },
+  {
+    id: 'customer-exchange-powershell',
+    version: 1,
+    ownerAxis: 'organization',
+    authMode: 'application-certificate',
+    credentialDomain: 'customer-exchange-powershell',
+    executor: 'exchange-powershell',
+    grantClass: 'application',
+  },
+] as const;
+
 describe('M365 permission profiles', () => {
-  it('defines the four production profiles with isolated credential domains', () => {
-    expect(Object.keys(M365_PERMISSION_PROFILES).sort()).toEqual([
-      'communications-delegated',
-      'customer-exchange-powershell',
-      'customer-graph-actions',
-      'customer-graph-read',
-    ]);
-    expect(new Set(Object.values(M365_PERMISSION_PROFILES).map((p) => p.credentialDomain)).size).toBe(4);
+  it('defines only the four production profiles', () => {
+    expect(Object.keys(M365_PERMISSION_PROFILES).sort()).toEqual(
+      PROFILE_CONTRACTS.map(({ id }) => id).sort(),
+    );
+  });
+
+  it.each(PROFILE_CONTRACTS)('defines the exact contract for $id', (expected) => {
+    const profile = M365_PERMISSION_PROFILES[expected.id];
+
+    expect({
+      ...profile,
+      delegatedPermissionsEmpty: profile.delegatedPermissions.length === 0,
+      applicationPermissionsEmpty: profile.applicationPermissions.length === 0,
+    }).toMatchObject({
+      id: expected.id,
+      version: expected.version,
+      ownerAxis: expected.ownerAxis,
+      authMode: expected.authMode,
+      credentialDomain: expected.credentialDomain,
+      executor: expected.executor,
+      delegatedPermissionsEmpty: expected.grantClass === 'application',
+      applicationPermissionsEmpty: expected.grantClass === 'delegated',
+    });
   });
 
   it('keeps read and mutation Graph grants separate', () => {

--- a/apps/api/src/services/m365ControlPlane/profiles.test.ts
+++ b/apps/api/src/services/m365ControlPlane/profiles.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  M365_PERMISSION_PROFILES,
+  connectionNeedsConsentReconciliation,
+  getM365PermissionProfile,
+} from './profiles';
+
+describe('M365 permission profiles', () => {
+  it('defines the four production profiles with isolated credential domains', () => {
+    expect(Object.keys(M365_PERMISSION_PROFILES).sort()).toEqual([
+      'communications-delegated',
+      'customer-exchange-powershell',
+      'customer-graph-actions',
+      'customer-graph-read',
+    ]);
+    expect(new Set(Object.values(M365_PERMISSION_PROFILES).map((p) => p.credentialDomain)).size).toBe(4);
+  });
+
+  it('keeps read and mutation Graph grants separate', () => {
+    const read = getM365PermissionProfile('customer-graph-read');
+    const actions = getM365PermissionProfile('customer-graph-actions');
+    expect(read.applicationPermissions).toContain('User.Read.All');
+    expect(read.applicationPermissions).not.toContain('User.ReadWrite.All');
+    expect(actions.applicationPermissions).toContain('User.ReadWrite.All');
+    expect(actions.applicationPermissions).not.toContain('User.Read.All');
+  });
+
+  it('uses delegated auth only for communications and app certificates elsewhere', () => {
+    expect(getM365PermissionProfile('communications-delegated').authMode).toBe('delegated');
+    for (const id of ['customer-graph-read', 'customer-graph-actions', 'customer-exchange-powershell'] as const) {
+      expect(getM365PermissionProfile(id).authMode).toBe('application-certificate');
+    }
+  });
+
+  it('requires reconciliation whenever stored manifest version differs', () => {
+    expect(connectionNeedsConsentReconciliation('customer-graph-read', 1)).toBe(false);
+    expect(connectionNeedsConsentReconciliation('customer-graph-read', 0)).toBe(true);
+    expect(connectionNeedsConsentReconciliation('customer-graph-read', 2)).toBe(true);
+  });
+});

--- a/apps/api/src/services/m365ControlPlane/profiles.ts
+++ b/apps/api/src/services/m365ControlPlane/profiles.ts
@@ -1,0 +1,110 @@
+export const M365_CONNECTION_PROFILES = [
+  'communications-delegated',
+  'customer-graph-read',
+  'customer-graph-actions',
+  'customer-exchange-powershell',
+] as const;
+
+export type M365ConnectionProfile = (typeof M365_CONNECTION_PROFILES)[number];
+
+export const M365_CREDENTIAL_DOMAINS = [
+  'communications-delegated',
+  'customer-graph-read',
+  'customer-graph-actions',
+  'customer-exchange-powershell',
+] as const;
+
+export type M365CredentialDomain = (typeof M365_CREDENTIAL_DOMAINS)[number];
+export type M365AuthMode = 'delegated' | 'application-certificate';
+export type M365ExecutorKind = 'communications' | 'graph-read' | 'graph-actions' | 'exchange-powershell';
+
+export interface M365PermissionProfileManifest {
+  readonly id: M365ConnectionProfile;
+  readonly version: number;
+  readonly ownerAxis: 'user' | 'organization';
+  readonly authMode: M365AuthMode;
+  readonly credentialDomain: M365CredentialDomain;
+  readonly executor: M365ExecutorKind;
+  readonly delegatedPermissions: readonly string[];
+  readonly applicationPermissions: readonly string[];
+}
+
+export const M365_PERMISSION_PROFILES = {
+  'communications-delegated': {
+    id: 'communications-delegated',
+    version: 1,
+    ownerAxis: 'user',
+    authMode: 'delegated',
+    credentialDomain: 'communications-delegated',
+    executor: 'communications',
+    delegatedPermissions: [
+      'openid',
+      'profile',
+      'offline_access',
+      'User.Read',
+      'Mail.ReadWrite',
+      'Mail.Send',
+      'Chat.ReadWrite',
+      'ChannelMessage.Read.All',
+      'ChannelMessage.Send',
+    ],
+    applicationPermissions: [],
+  },
+  'customer-graph-read': {
+    id: 'customer-graph-read',
+    version: 1,
+    ownerAxis: 'organization',
+    authMode: 'application-certificate',
+    credentialDomain: 'customer-graph-read',
+    executor: 'graph-read',
+    delegatedPermissions: [],
+    applicationPermissions: [
+      'Organization.Read.All',
+      'User.Read.All',
+      'Device.Read.All',
+      'Group.Read.All',
+      'AuditLog.Read.All',
+      'DeviceManagementManagedDevices.Read.All',
+      'DeviceManagementConfiguration.Read.All',
+      'Sites.Read.All',
+    ],
+  },
+  'customer-graph-actions': {
+    id: 'customer-graph-actions',
+    version: 1,
+    ownerAxis: 'organization',
+    authMode: 'application-certificate',
+    credentialDomain: 'customer-graph-actions',
+    executor: 'graph-actions',
+    delegatedPermissions: [],
+    applicationPermissions: [
+      'User.ReadWrite.All',
+      'User-PasswordProfile.ReadWrite.All',
+      'Group.ReadWrite.All',
+      'DeviceManagementManagedDevices.PrivilegedOperations.All',
+      'DeviceManagementConfiguration.ReadWrite.All',
+      'Sites.ReadWrite.All',
+    ],
+  },
+  'customer-exchange-powershell': {
+    id: 'customer-exchange-powershell',
+    version: 1,
+    ownerAxis: 'organization',
+    authMode: 'application-certificate',
+    credentialDomain: 'customer-exchange-powershell',
+    executor: 'exchange-powershell',
+    delegatedPermissions: [],
+    applicationPermissions: ['Exchange.ManageAsApp'],
+  },
+} as const satisfies Record<M365ConnectionProfile, M365PermissionProfileManifest>;
+
+export function getM365PermissionProfile(id: M365ConnectionProfile): M365PermissionProfileManifest {
+  return M365_PERMISSION_PROFILES[id];
+}
+
+export function connectionNeedsConsentReconciliation(
+  id: M365ConnectionProfile,
+  storedVersion: number,
+): boolean {
+  return getM365PermissionProfile(id).version !== storedVersion;
+}

--- a/apps/api/src/services/m365DirectGraph.test.ts
+++ b/apps/api/src/services/m365DirectGraph.test.ts
@@ -3,16 +3,28 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock the row lookup, secret decryption, and token acquisition so the test
 // focuses on invokeDirect's Graph endpoint/method/body mapping.
 const mockRow = { tenantId: '11111111-1111-1111-1111-111111111111', clientId: 'client-1', clientSecret: 'enc-secret' };
+let selectRows: unknown[] = [mockRow];
+let wherePredicate: unknown;
 vi.mock('../db', () => ({
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          limit: vi.fn(async () => [mockRow]),
+        where: vi.fn((predicate: unknown) => ({
+          limit: vi.fn(async () => {
+            wherePredicate = predicate;
+            return selectRows;
+          }),
         })),
       })),
     })),
   },
+}));
+vi.mock('../db/schema/m365', () => ({
+  m365Connections: { id: 'id', orgId: 'org_id', profile: 'profile', status: 'status' },
+}));
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((column: unknown, value: unknown) => `${String(column)}=${String(value)}`),
+  and: vi.fn((...conditions: unknown[]) => conditions),
 }));
 vi.mock('./secretCrypto', () => ({ decryptForColumn: vi.fn(() => 'plaintext-secret') }));
 vi.mock('./c2cM365', () => ({
@@ -20,8 +32,15 @@ vi.mock('./c2cM365', () => ({
   isM365TenantId: (x: string) => /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(x),
 }));
 
-import { invokeDirect, getToken, clearTokenCache, TOKEN_CACHE_MAX } from './m365DirectGraph';
+import {
+  TOKEN_CACHE_MAX,
+  clearTokenCache,
+  getToken,
+  hasDirectM365Connection,
+  invokeDirect,
+} from './m365DirectGraph';
 import { acquireClientCredentialsToken } from './c2cM365';
+import { decryptForColumn } from './secretCrypto';
 
 const GRAPH = 'https://graph.microsoft.com/v1.0';
 
@@ -39,6 +58,35 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.unstubAllGlobals();
   clearTokenCache();
+  selectRows = [mockRow];
+  wherePredicate = undefined;
+});
+
+describe('m365DirectGraph legacy connection selection', () => {
+  it('selects only the legacy-direct profile when checking direct availability', async () => {
+    await hasDirectM365Connection('org-1');
+    expect(wherePredicate).toEqual([
+      'org_id=org-1',
+      'profile=legacy-direct',
+    ]);
+  });
+
+  it('requires an active legacy-direct row for token acquisition', async () => {
+    await getToken('org-1');
+    expect(wherePredicate).toEqual([
+      'org_id=org-1',
+      'profile=legacy-direct',
+      'status=active',
+    ]);
+  });
+
+  it('fails closed before decryption when a legacy row has no stored secret', async () => {
+    selectRows = [{ ...mockRow, clientSecret: null }];
+    const result = await getToken('org-1');
+    expect(result).toMatchObject({ kind: 'error', code: 'connection_key_error' });
+    expect(decryptForColumn).not.toHaveBeenCalled();
+    expect(acquireClientCredentialsToken).not.toHaveBeenCalled();
+  });
 });
 
 describe('m365DirectGraph.invokeDirect endpoint mapping', () => {

--- a/apps/api/src/services/m365DirectGraph.ts
+++ b/apps/api/src/services/m365DirectGraph.ts
@@ -19,7 +19,7 @@
  */
 
 import { randomBytes } from 'crypto';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { db } from '../db';
 import { m365Connections } from '../db/schema/m365';
 import { decryptForColumn } from './secretCrypto';
@@ -45,7 +45,10 @@ export async function hasDirectM365Connection(orgId: string): Promise<boolean> {
   const [row] = await db
     .select({ id: m365Connections.id })
     .from(m365Connections)
-    .where(eq(m365Connections.orgId, orgId))
+    .where(and(
+      eq(m365Connections.orgId, orgId),
+      eq(m365Connections.profile, 'legacy-direct'),
+    ))
     .limit(1);
   return !!row;
 }
@@ -103,10 +106,17 @@ export async function getToken(orgId: string): Promise<{ token: string } | Direc
   const [row] = await db
     .select()
     .from(m365Connections)
-    .where(eq(m365Connections.orgId, orgId))
+    .where(and(
+      eq(m365Connections.orgId, orgId),
+      eq(m365Connections.profile, 'legacy-direct'),
+      eq(m365Connections.status, 'active'),
+    ))
     .limit(1);
   if (!row) {
-    return { kind: 'error', code: 'no_connection', message: 'No Microsoft 365 connection for this organization.' };
+    return { kind: 'error', code: 'no_connection', message: 'No legacy Microsoft 365 connection for this organization.' };
+  }
+  if (!row.clientSecret) {
+    return { kind: 'error', code: 'connection_key_error', message: 'Legacy Microsoft 365 connection has no stored client secret.' };
   }
 
   const cacheKey = `${orgId}:${row.clientId}`;

--- a/docs/superpowers/plans/2026-07-13-breeze-m365-foundation.md
+++ b/docs/superpowers/plans/2026-07-13-breeze-m365-foundation.md
@@ -246,7 +246,7 @@ git commit -m "feat(m365): add versioned permission profiles"
 
 **Interfaces:**
 - Consumes: profile/domain/auth-mode string contracts from Task 1.
-- Produces: one connection row owned by exactly one organization or user, with a vault reference for every non-legacy profile.
+- Produces: one connection row owned by exactly one organization or user, with a vault reference for every non-legacy profile. The expand release temporarily retains one-row-per-org compatibility until all deployed writers use `(org_id, profile)`.
 
 - [ ] **Step 1: Replace the schema test expectations before changing the schema**
 
@@ -269,9 +269,10 @@ describe('m365Connections schema', () => {
     expect(cfg.columns.find((c) => c.name === 'vault_ref')?.notNull).toBe(false);
   });
 
-  it('declares per-owner/profile uniqueness instead of one-row-per-org', () => {
+  it('retains rollout compatibility alongside per-owner/profile uniqueness', () => {
     const names = getTableConfig(m365Connections).indexes.map((i) => i.config.name).sort();
     expect(names).toEqual([
+      'm365_connections_org_uniq',
       'm365_connections_org_profile_uniq',
       'm365_connections_user_profile_uniq',
     ]);
@@ -317,12 +318,12 @@ export const m365Connections = pgTable(
     tenantId: varchar('tenant_id', { length: 36 }).notNull(),
     clientId: varchar('client_id', { length: 64 }).notNull(),
     clientSecret: text('client_secret'),
-    profile: varchar('profile', { length: 64 }).$type<StoredM365ConnectionProfile>().notNull(),
-    authMode: varchar('auth_mode', { length: 40 }).$type<StoredM365AuthMode>().notNull(),
-    credentialDomain: varchar('credential_domain', { length: 64 }).$type<StoredM365CredentialDomain>().notNull(),
+    profile: varchar('profile', { length: 64 }).$type<StoredM365ConnectionProfile>().notNull().default('legacy-direct'),
+    authMode: varchar('auth_mode', { length: 40 }).$type<StoredM365AuthMode>().notNull().default('client-secret-legacy'),
+    credentialDomain: varchar('credential_domain', { length: 64 }).$type<StoredM365CredentialDomain>().notNull().default('legacy-direct'),
     vaultRef: text('vault_ref'),
     credentialVersion: varchar('credential_version', { length: 128 }),
-    permissionManifestVersion: integer('permission_manifest_version').notNull(),
+    permissionManifestVersion: integer('permission_manifest_version').notNull().default(0),
     observedGrants: jsonb('observed_grants').$type<string[]>().notNull().default([]),
     displayName: varchar('display_name', { length: 256 }),
     status: varchar('status', { length: 32 }).$type<M365ConnectionStatus>().notNull().default('pending-consent'),
@@ -336,6 +337,7 @@ export const m365Connections = pgTable(
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },
   (t) => ({
+    orgUniq: uniqueIndex('m365_connections_org_uniq').on(t.orgId),
     orgProfileUniq: uniqueIndex('m365_connections_org_profile_uniq').on(t.orgId, t.profile),
     userProfileUniq: uniqueIndex('m365_connections_user_profile_uniq').on(t.userId, t.profile),
   }),
@@ -462,7 +464,10 @@ ALTER TABLE m365_connections ADD CONSTRAINT m365_connections_profile_binding_che
   OR (profile = 'customer-exchange-powershell' AND org_id IS NOT NULL AND auth_mode = 'application-certificate' AND credential_domain = 'customer-exchange-powershell')
 );
 
-DROP INDEX IF EXISTS m365_connections_org_uniq;
+-- Expand/contract compatibility for the old API's ON CONFLICT (org_id).
+-- Remove only after every deployed writer targets (org_id, profile).
+CREATE UNIQUE INDEX IF NOT EXISTS m365_connections_org_uniq
+  ON m365_connections (org_id);
 CREATE UNIQUE INDEX IF NOT EXISTS m365_connections_org_profile_uniq
   ON m365_connections (org_id, profile);
 CREATE UNIQUE INDEX IF NOT EXISTS m365_connections_user_profile_uniq
@@ -481,48 +486,28 @@ ALTER TABLE m365_connections ENABLE ROW LEVEL SECURITY;
 ALTER TABLE m365_connections FORCE ROW LEVEL SECURITY;
 
 CREATE POLICY breeze_m365_connection_select ON m365_connections FOR SELECT USING (
-  public.breeze_has_org_access(org_id)
-  OR user_id = public.breeze_current_user_id()
-  OR EXISTS (
-    SELECT 1 FROM users u
-    WHERE u.id = m365_connections.user_id
-      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
-  )
+  public.breeze_current_scope() = 'system'
+  OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+  OR (user_id IS NOT NULL AND user_id = public.breeze_current_user_id())
 );
 CREATE POLICY breeze_m365_connection_insert ON m365_connections FOR INSERT WITH CHECK (
-  public.breeze_has_org_access(org_id)
-  OR user_id = public.breeze_current_user_id()
-  OR EXISTS (
-    SELECT 1 FROM users u
-    WHERE u.id = m365_connections.user_id
-      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
-  )
+  public.breeze_current_scope() = 'system'
+  OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+  OR (user_id IS NOT NULL AND user_id = public.breeze_current_user_id())
 );
 CREATE POLICY breeze_m365_connection_update ON m365_connections FOR UPDATE USING (
-  public.breeze_has_org_access(org_id)
-  OR user_id = public.breeze_current_user_id()
-  OR EXISTS (
-    SELECT 1 FROM users u
-    WHERE u.id = m365_connections.user_id
-      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
-  )
+  public.breeze_current_scope() = 'system'
+  OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+  OR (user_id IS NOT NULL AND user_id = public.breeze_current_user_id())
 ) WITH CHECK (
-  public.breeze_has_org_access(org_id)
-  OR user_id = public.breeze_current_user_id()
-  OR EXISTS (
-    SELECT 1 FROM users u
-    WHERE u.id = m365_connections.user_id
-      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
-  )
+  public.breeze_current_scope() = 'system'
+  OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+  OR (user_id IS NOT NULL AND user_id = public.breeze_current_user_id())
 );
 CREATE POLICY breeze_m365_connection_delete ON m365_connections FOR DELETE USING (
-  public.breeze_has_org_access(org_id)
-  OR user_id = public.breeze_current_user_id()
-  OR EXISTS (
-    SELECT 1 FROM users u
-    WHERE u.id = m365_connections.user_id
-      AND (public.breeze_has_partner_access(u.partner_id) OR public.breeze_has_org_access(u.org_id))
-  )
+  public.breeze_current_scope() = 'system'
+  OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+  OR (user_id IS NOT NULL AND user_id = public.breeze_current_user_id())
 );
 ```
 
@@ -853,7 +838,7 @@ git commit -m "test(m365): prove connection tenant isolation"
 
 **Interfaces:**
 - Consumes: `M365CredentialDomain` from Task 1.
-- Produces: `CredentialProvider.put()`, `.get()`, and `.delete()` with domain-checked versioned `akv://` references.
+- Produces: `CredentialProvider.put()` and `.get()` with domain-checked versioned `akv://` references. Name-wide deletion is deferred to a DB-backed lifecycle workflow that serializes against rotation.
 - Security boundary: no route, AI tool, or control-plane service imports this directory.
 
 - [ ] **Step 1: Add Azure SDK dependencies**
@@ -883,7 +868,6 @@ function client(): SecretClientPort {
         },
       }),
     })),
-    beginDeleteSecret: vi.fn(async () => ({ pollUntilDone: vi.fn(async () => undefined) })),
   };
 }
 
@@ -951,15 +935,6 @@ describe('AzureKeyVaultCredentialProvider', () => {
     expect(port.setSecret).not.toHaveBeenCalled();
   });
 
-  it('waits for Key Vault deletion to complete', async () => {
-    const port = client();
-    const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
-    await provider.delete(
-      'akv://vault.example/m365-customer-graph-read-id/version-1',
-      'customer-graph-read',
-    );
-    expect(port.beginDeleteSecret).toHaveBeenCalledWith('m365-customer-graph-read-id');
-  });
 });
 ```
 
@@ -990,7 +965,6 @@ export interface CredentialProvider {
     material: M365CredentialMaterial;
   }): Promise<StoredCredentialReference>;
   get(reference: string, expectedDomain: M365CredentialDomain): Promise<M365CredentialMaterial>;
-  delete(reference: string, expectedDomain: M365CredentialDomain): Promise<void>;
 }
 ```
 
@@ -1014,7 +988,6 @@ interface CredentialEnvelope {
 export interface SecretClientPort {
   setSecret(name: string, value: string, options?: unknown): Promise<{ properties: { version?: string } }>;
   getSecret(name: string, options?: { version?: string }): Promise<{ value?: string }>;
-  beginDeleteSecret(name: string): Promise<{ pollUntilDone(): Promise<unknown> }>;
 }
 
 interface ParsedReference {
@@ -1115,13 +1088,6 @@ export class AzureKeyVaultCredentialProvider implements CredentialProvider {
     return envelope.material;
   }
 
-  async delete(reference: string, expectedDomain: M365CredentialDomain): Promise<void> {
-    const parsed = parseReference(reference);
-    if (parsed.host !== this.vaultHost) throw new Error('Credential reference vault mismatch');
-    if (!parsed.name.startsWith(`m365-${expectedDomain}-`)) throw new Error('Credential domain mismatch');
-    const poller = await this.client.beginDeleteSecret(parsed.name);
-    await poller.pollUntilDone();
-  }
 }
 ```
 

--- a/docs/superpowers/plans/2026-07-14-m365-review-followups.md
+++ b/docs/superpowers/plans/2026-07-14-m365-review-followups.md
@@ -2,15 +2,18 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Close the two final M365 foundation review follow-ups before publishing the branch.
+**Goal:** Close the final M365 foundation review follow-ups and deployment/security blockers before publishing the branch.
 
-**Architecture:** Keep the existing executor and permission-profile boundaries unchanged. Tighten the Azure Key Vault reference contract to accept only service-generated 32-character hexadecimal versions, and strengthen tests so every profile's security-relevant mapping is asserted exactly.
+**Architecture:** Keep the executor and permission-profile boundaries unchanged. Tighten the Azure Key Vault reference contract, retain legacy write compatibility for the expand rollout, make personal communications rows self-or-system only, and remove unused name-wide credential deletion until a DB-backed lifecycle workflow can serialize it against rotation.
 
 **Tech Stack:** TypeScript, Vitest, Azure Key Vault Secrets SDK, pnpm.
 
 ## Global Constraints
 
-- No route, control-plane service, schema, or migration changes.
+- No route or control-plane service changes.
+- The expand migration retains discriminator defaults and `m365_connections_org_uniq`; a mandatory later contract migration removes them before any nonlegacy organization-profile writer ships.
+- User-owned communications metadata is accessible only to its owner or system scope; organization/partner tenancy grants do not widen it.
+- The foundation credential provider exposes only `put` and `get`; name-wide deletion is deferred to an authoritative DB-backed lifecycle workflow.
 - Credential material remains executor-only.
 - Azure Key Vault references require a canonical vault host, generated M365 secret name, UUID connection id, and 32-character hexadecimal version.
 - Permission profiles remain code-owned at manifest version 1.
@@ -90,13 +93,37 @@ Run: `pnpm --filter @breeze/api exec vitest run src/services/m365ControlPlane/pr
 
 Expected: all profile tests pass; this is coverage hardening of existing intended behavior, so no production RED phase is expected.
 
-### Task 3: Verify and publish
+### Task 3: Close deployment and credential-lifecycle blockers
+
+**Files:**
+- Modify: `apps/api/migrations/2026-07-13-m365-control-plane-foundation.sql`
+- Modify: `apps/api/src/db/schema/m365.ts`
+- Modify: `apps/api/src/db/schema/m365.test.ts`
+- Create: `apps/api/src/db/migration-m365-control-plane-foundation.test.ts`
+- Modify: `apps/api/src/__tests__/integration/m365ConnectionsRls.integration.test.ts`
+- Modify: `apps/api/src/executors/m365/credentials/types.ts`
+- Modify: `apps/api/src/executors/m365/credentials/azureKeyVaultProvider.ts`
+- Modify: `apps/api/src/executors/m365/credentials/azureKeyVaultProvider.test.ts`
+
+- [ ] **Step 1: Preserve old-writer compatibility atomically**
+
+Set legacy discriminator defaults and retain the `org_id` unique index in the unshipped foundation migration. Mirror them in the Drizzle schema and contract tests. Document that a later contract migration is mandatory before any writer creates multiple organization profiles.
+
+- [ ] **Step 2: Make personal communications rows self-or-system only**
+
+Recreate all four M365 policies with explicit system access, organization access only for non-null `org_id`, and self access only for the current non-null `user_id`. Add real-role tests for same-partner and same-organization peers.
+
+- [ ] **Step 3: Remove unsafe unused Key Vault deletion**
+
+Remove `CredentialProvider.delete`, the Azure name-wide delete implementation, its client-port method, and delete-only tests. A future lifecycle service must load the authoritative connection, serialize deletion against rotation, and verify the pinned reference before invoking name-wide deletion.
+
+### Task 4: Verify and publish
 
 **Files:**
 - No additional source files.
 
 **Interfaces:**
-- Consumes: Tasks 1 and 2.
+- Consumes: Tasks 1 through 3.
 - Produces: one review-follow-up commit and a draft pull request.
 
 - [ ] **Step 1: Run combined tests and static verification**

--- a/docs/superpowers/plans/2026-07-14-m365-review-followups.md
+++ b/docs/superpowers/plans/2026-07-14-m365-review-followups.md
@@ -1,0 +1,128 @@
+# M365 Review Follow-ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the two final M365 foundation review follow-ups before publishing the branch.
+
+**Architecture:** Keep the existing executor and permission-profile boundaries unchanged. Tighten the Azure Key Vault reference contract to accept only service-generated 32-character hexadecimal versions, and strengthen tests so every profile's security-relevant mapping is asserted exactly.
+
+**Tech Stack:** TypeScript, Vitest, Azure Key Vault Secrets SDK, pnpm.
+
+## Global Constraints
+
+- No route, control-plane service, schema, or migration changes.
+- Credential material remains executor-only.
+- Azure Key Vault references require a canonical vault host, generated M365 secret name, UUID connection id, and 32-character hexadecimal version.
+- Permission profiles remain code-owned at manifest version 1.
+- Preserve the unrelated untracked `.githooks/` directory.
+
+---
+
+### Task 1: Enforce production Key Vault versions
+
+**Files:**
+- Modify: `apps/api/src/executors/m365/credentials/azureKeyVaultProvider.test.ts`
+- Modify: `apps/api/src/executors/m365/credentials/azureKeyVaultProvider.ts`
+
+**Interfaces:**
+- Consumes: `SecretClientPort.setSecret()` version output and `akv://` credential references.
+- Produces: references whose version segment matches `/^[0-9a-f]{32}$/i`.
+
+- [ ] **Step 1: Replace the test fixture version and add a rejection regression**
+
+Define:
+
+```ts
+const SECRET_VERSION = '0123456789abcdef0123456789abcdef';
+const REFERENCE = `akv://vault.example/${SECRET_NAME}/${SECRET_VERSION}`;
+```
+
+Make the mocked client return `SECRET_VERSION`, replace literal `version-1` references, and add:
+
+```ts
+it('rejects the former test-only version literal before accessing Key Vault', async () => {
+  const port = client();
+  const provider = new AzureKeyVaultCredentialProvider('https://vault.example', port);
+  await expect(provider.get(
+    `akv://vault.example/${SECRET_NAME}/version-1`,
+    'customer-graph-read',
+  )).rejects.toThrow('Invalid Azure Key Vault credential reference');
+  expect(port.getSecret).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run the focused provider test and verify RED**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/executors/m365/credentials/azureKeyVaultProvider.test.ts`
+
+Expected: FAIL because production still accepts `version-1`.
+
+- [ ] **Step 3: Remove the test-only production exception**
+
+Replace the version expression with:
+
+```ts
+const KEY_VAULT_VERSION_RE = /^[0-9a-f]{32}$/i;
+```
+
+- [ ] **Step 4: Run the focused provider test and verify GREEN**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/executors/m365/credentials/azureKeyVaultProvider.test.ts`
+
+Expected: all provider tests pass.
+
+### Task 2: Assert exact permission-profile contracts
+
+**Files:**
+- Modify: `apps/api/src/services/m365ControlPlane/profiles.test.ts`
+
+**Interfaces:**
+- Consumes: `M365_PERMISSION_PROFILES`.
+- Produces: exact regression coverage for profile id, owner axis, auth mode, credential domain, executor, manifest version, and delegated/application grant class.
+
+- [ ] **Step 1: Replace the weak isolation assertion with a table-driven contract**
+
+Add an expected mapping for all four profiles and assert each manifest with `toMatchObject`, including `version`, `ownerAxis`, `authMode`, `credentialDomain`, `executor`, and whether delegated or application permissions are empty.
+
+- [ ] **Step 2: Run focused profile tests**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/m365ControlPlane/profiles.test.ts`
+
+Expected: all profile tests pass; this is coverage hardening of existing intended behavior, so no production RED phase is expected.
+
+### Task 3: Verify and publish
+
+**Files:**
+- No additional source files.
+
+**Interfaces:**
+- Consumes: Tasks 1 and 2.
+- Produces: one review-follow-up commit and a draft pull request.
+
+- [ ] **Step 1: Run combined tests and static verification**
+
+Run:
+
+```bash
+pnpm --filter @breeze/api exec vitest run src/services/m365ControlPlane/profiles.test.ts src/executors/m365/credentials/azureKeyVaultProvider.test.ts
+pnpm --filter @breeze/api exec eslint src/services/m365ControlPlane/profiles.test.ts src/executors/m365/credentials/azureKeyVaultProvider.ts src/executors/m365/credentials/azureKeyVaultProvider.test.ts
+pnpm --filter @breeze/api exec tsc --noEmit --pretty false
+pnpm --filter @breeze/api build
+git diff --check
+```
+
+Expected: exit 0 for every command; the API build may retain its pre-existing `src/db/seed.ts` CJS/`import.meta` warning.
+
+- [ ] **Step 2: Commit the follow-ups**
+
+```bash
+git add docs/superpowers/plans/2026-07-14-m365-review-followups.md \
+  apps/api/src/services/m365ControlPlane/profiles.test.ts \
+  apps/api/src/executors/m365/credentials/azureKeyVaultProvider.ts \
+  apps/api/src/executors/m365/credentials/azureKeyVaultProvider.test.ts
+git commit -m "test(m365): close foundation review follow-ups"
+```
+
+- [ ] **Step 3: Push and open a draft PR**
+
+Push `feat/m365-control-plane-foundation` to `origin`, then open a draft PR against the remote default branch. The PR body must disclose the verified unchanged Pax8 RLS coverage failure rather than claiming the repository-wide RLS gate is green.

--- a/docs/superpowers/specs/2026-07-13-breeze-m365-control-plane-design.md
+++ b/docs/superpowers/specs/2026-07-13-breeze-m365-control-plane-design.md
@@ -114,6 +114,8 @@ It does not store reusable access tokens, refresh tokens, client secrets, or pri
 
 Production credentials live behind a provider-neutral `CredentialProvider`, with Azure Key Vault as the production provider. A self-hosted deployment may implement a separately encrypted provider, but the API and database contract remains the same.
 
+The foundation provider exposes version-pinned `put` and `get` operations only. Azure Key Vault deletion is name-wide rather than version-scoped, so deletion must wait for a DB-backed lifecycle workflow that loads the authoritative connection, serializes against rotation, and verifies the current stored reference before deleting all versions. No caller-supplied vault reference can directly trigger deletion.
+
 ### 6.2 Credential domains
 
 | Domain | Identity and secret | Accessible by | Intended capability |
@@ -162,6 +164,8 @@ pending_consent -> verifying -> active -> degraded -> suspended -> revoked
 ```
 
 A failed permission profile degrades only that connection profile. For example, an expired delegated communications session must not disable an otherwise healthy customer Graph read connection.
+
+The first schema release temporarily retains the legacy unique `org_id` index and discriminator defaults because production applies migrations before replacing the old API, whose upsert still targets `org_id`. This expand phase intentionally permits only one organization-owned profile. Before any writer creates additional organization profiles, a required contract migration must remove the legacy index and defaults after all deployed writers target `(org_id, profile)`.
 
 ### 7.1 Capability profiles
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13194,7 +13194,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.9.3
+      '@types/node': 26.1.0
       '@types/yargs': 15.0.20
       chalk: 4.1.2
     optional: true
@@ -15838,7 +15838,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   anynum@1.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,12 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1030.0
         version: 3.1030.0
+      '@azure/identity':
+        specifier: ^4.6.0
+        version: 4.13.1
+      '@azure/keyvault-secrets':
+        specifier: ^4.9.0
+        version: 4.11.2
       '@breeze/extension-api':
         specifier: workspace:*
         version: link:../../packages/extension-api
@@ -272,10 +278,10 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.41.3
-        version: 0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
+        version: 0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
       astro:
         specifier: ^7.0.9
-        version: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -543,7 +549,7 @@ importers:
     dependencies:
       '@astrojs/node':
         specifier: ^11.0.2
-        version: 11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
       '@astrojs/react':
         specifier: ^6.0.1
         version: 6.0.1(@types/node@26.1.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -555,7 +561,7 @@ importers:
         version: 5.101.2(react@19.2.7)
       astro:
         specifier: ^7.0.9
-        version: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -735,7 +741,7 @@ importers:
     dependencies:
       '@astrojs/node':
         specifier: ^11.0.2
-        version: 11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
       '@astrojs/react':
         specifier: ^6.0.1
         version: 6.0.1(@types/node@26.1.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -753,7 +759,7 @@ importers:
         version: 1.7.0
       '@sentry/astro':
         specifier: ^10.62.0
-        version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))(rollup@4.62.0)
+        version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))(rollup@4.62.0)
       '@simplewebauthn/browser':
         specifier: ^13.3.0
         version: 13.3.0
@@ -771,7 +777,7 @@ importers:
         version: 6.0.0
       astro:
         specifier: ^7.0.9
-        version: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1387,13 +1393,77 @@ packages:
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
+  '@azure-rest/core-client@2.8.0':
+    resolution: {integrity: sha512-F1ybHeN+++QhyFCF/ehLUEvrOB6fehPdFBFtGdj0C3B2lpQ9zkPiO5JDgsqc6IfjuUe6b3dAbXK0a7+VgSGfhw==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/abort-controller@2.2.0':
+    resolution: {integrity: sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-auth@1.11.0':
+    resolution: {integrity: sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-client@1.11.0':
+    resolution: {integrity: sha512-JjQWO6akOck45PH/XBrxzsQGAiKrfFl4m5iggJ0ItMIz5omRufOXWpqCPpdjKN3vKDzlSUvFjaMb7Zwf0gvAdA==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-lro@2.7.2':
+    resolution: {integrity: sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-paging@1.7.0':
+    resolution: {integrity: sha512-7GEAoIsaoBr6KELNRb8nypowCqvk8dnCHFCYg4XD4lOQGY2GqjQg5IhkRjyBFRO18CGSMq05PaNqSOE9GQro3g==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-rest-pipeline@1.25.0':
+    resolution: {integrity: sha512-bMs8ekJLjX8wPV+9IPBges1SLPyuDtE9g5gLDWOpxzKcoOFQnpLGkbcT1tdw3FaAmDS1gnPmMmJ6y/T5B96kIA==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-tracing@1.4.0':
+    resolution: {integrity: sha512-eGwxD0AtncrxeBM4tG8R55Pc3rdX1hNW2WibJAgYpCVA6E93mvvVH+LcssoVjOBrSKWS55yEIHsk0X8ctHmfOQ==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-util@1.14.0':
+    resolution: {integrity: sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/identity@4.13.1':
+    resolution: {integrity: sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/keyvault-common@2.1.0':
+    resolution: {integrity: sha512-aCDidWuKY06LWQ4x7/8TIXK6iRqTaRWRL3t7T+LC+j1b07HtoIsOxP/tU90G4jCSBn5TAyUTCtA4MS/y5Hudaw==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/keyvault-secrets@4.11.2':
+    resolution: {integrity: sha512-ECj/kwZbZlQXj2kfWivSICbKwj6W3chmFhv8qUdauqYnjvZ0hWZBFSsZWux7W2nX3MP49PLUCusXk+hAg3pipg==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/logger@1.4.0':
+    resolution: {integrity: sha512-rbAE25KUfjU/s3XHUdJgceoCP5dEOpMx85J04kF+QMdta73XkuG9JGHHinch+XIoKpBdqljin+KqURpJriSzLA==}
+    engines: {node: '>=22.0.0'}
+
   '@azure/msal-browser@4.30.0':
     resolution: {integrity: sha512-HBBKfbZkMVzzF5bofvS1cXuNHFVc+gt4/HOnCmG/0hsHuZRJvJvDg/+7nTwIpoqvJc8BQp5o23rBUfisOLxR+w==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-browser@5.17.0':
+    resolution: {integrity: sha512-/yTnW2TCk9Mh+2b/NOaHAN+MryUNxzRTaJD/YtrqOA9bpBWfTXn/iyReRbaLrK/btBo3stEzLyEvuWp2NZ5DuA==}
     engines: {node: '>=0.8.0'}
 
   '@azure/msal-common@15.17.0':
     resolution: {integrity: sha512-VQ5/gTLFADkwue+FohVuCqlzFPUq4xSrX8jeZe+iwZuY6moliNC8xt86qPVNYdtbQfELDf2Nu6LI+demFPHGgw==}
     engines: {node: '>=0.8.0'}
+
+  '@azure/msal-common@16.11.1':
+    resolution: {integrity: sha512-yPohvMwWLv1XnaWnIUyKUh8CvcVChCGqG/VluGwfGmaAfrZTNt5yQ+sIs462Sgw6+e2K83KGmMJ860p73ZSCrw==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-node@5.4.0':
+    resolution: {integrity: sha512-6EZEParwHRlnSSIikw8FNAnAzwmh71uhveUXdPNFeZFviJ9SH+rwFiurhjzXqICYTrpm3E+dj693QOwfPbJXAQ==}
+    engines: {node: '>=20'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -4918,6 +4988,10 @@ packages:
     resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typespec/ts-http-runtime@0.3.7':
+    resolution: {integrity: sha512-JVUD8X2tfDMWjcjLs4yVxxVrS8yR5vnh386GAXT9Qj79nBxxXSaHFQZg5FweLmT8HlPQ3kii6noUB+Z9RN7DvQ==}
+    engines: {node: '>=22.0.0'}
+
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
 
@@ -5493,6 +5567,10 @@ packages:
     peerDependenciesMeta:
       redis:
         optional: true
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -6103,8 +6181,20 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
@@ -7230,6 +7320,10 @@ packages:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -7381,6 +7475,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-docker@4.0.0:
     resolution: {integrity: sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==}
     engines: {node: '>=20'}
@@ -7404,6 +7503,11 @@ packages:
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -7444,6 +7548,10 @@ packages:
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -8491,6 +8599,10 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
   open@6.4.0:
     resolution: {integrity: sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==}
     engines: {node: '>=8'}
@@ -9455,6 +9567,10 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -10685,6 +10801,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
   xcode@3.0.1:
     resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
     engines: {node: '>=10.0.0'}
@@ -11062,13 +11182,13 @@ snapshots:
       hast-util-from-html: 2.0.3
       satteri: 0.9.5
 
-  '@astrojs/mdx@7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@astrojs/mdx@7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.1
       '@astrojs/markdown-remark': 7.2.1
       '@mdx-js/mdx': 3.1.1
       acorn: 8.17.0
-      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
+      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
       es-module-lexer: 2.3.1
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -11084,10 +11204,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/node@11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@astrojs/node@11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.1
-      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
+      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
       send: 1.2.1
       server-destroy: 1.0.1
     transitivePeerDependencies:
@@ -11129,17 +11249,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)':
+  '@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)':
     dependencies:
       '@astrojs/markdown-satteri': 0.3.3
-      '@astrojs/mdx': 7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@astrojs/mdx': 7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
       '@astrojs/sitemap': 3.7.3
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
-      astro-expressive-code: 0.44.0(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
+      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
+      astro-expressive-code: 0.44.0(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
       bcp-47: 2.1.1
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -11439,11 +11559,146 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
+  '@azure-rest/core-client@2.8.0':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-tracing': 1.4.0
+      '@typespec/ts-http-runtime': 0.3.7
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/abort-controller@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-auth@1.11.0':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-util': 1.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-client@1.11.0':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-lro@2.7.2':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-paging@1.7.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-rest-pipeline@1.25.0':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      '@typespec/ts-http-runtime': 0.3.7
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-tracing@1.4.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-util@1.14.0':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@typespec/ts-http-runtime': 0.3.7
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/identity@4.13.1':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-client': 1.11.0
+      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      '@azure/msal-browser': 5.17.0
+      '@azure/msal-node': 5.4.0
+      open: 10.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/keyvault-common@2.1.0':
+    dependencies:
+      '@azure-rest/core-client': 2.8.0
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/keyvault-secrets@4.11.2':
+    dependencies:
+      '@azure-rest/core-client': 2.8.0
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-lro': 2.7.2
+      '@azure/core-paging': 1.7.0
+      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/keyvault-common': 2.1.0
+      '@azure/logger': 1.4.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/logger@1.4.0':
+    dependencies:
+      '@typespec/ts-http-runtime': 0.3.7
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@azure/msal-browser@4.30.0':
     dependencies:
       '@azure/msal-common': 15.17.0
 
+  '@azure/msal-browser@5.17.0':
+    dependencies:
+      '@azure/msal-common': 16.11.1
+
   '@azure/msal-common@15.17.0': {}
+
+  '@azure/msal-common@16.11.1': {}
+
+  '@azure/msal-node@5.4.0':
+    dependencies:
+      '@azure/msal-common': 16.11.1
+      jsonwebtoken: 9.0.3
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -13650,7 +13905,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.0': {}
 
@@ -14084,13 +14341,13 @@ snapshots:
       '@sentry-internal/browser-utils': 10.51.0
       '@sentry/core': 10.51.0
 
-  '@sentry/astro@10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))(rollup@4.62.0)':
+  '@sentry/astro@10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))(rollup@4.62.0)':
     dependencies:
       '@sentry/browser': 10.62.0
       '@sentry/core': 10.62.0
       '@sentry/node': 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))
       '@sentry/vite-plugin': 5.3.0(rollup@4.62.0)
-      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
+      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@opentelemetry/core'
       - '@opentelemetry/exporter-trace-otlp-http'
@@ -15307,6 +15564,14 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       eslint-visitor-keys: 5.0.1
 
+  '@typespec/ts-http-runtime@0.3.7':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@ungap/structured-clone@1.3.2': {}
 
   '@vitejs/plugin-react@5.2.0(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))':
@@ -15656,13 +15921,13 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.44.0(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)):
+  astro-expressive-code@0.44.0(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
+      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
       rehype-expressive-code: 0.44.0
       url-extras: 0.1.0
 
-  astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0):
+  astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(ioredis@5.11.1)(jiti@2.7.0)(rollup@4.62.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@astrojs/internal-helpers': 0.10.1
@@ -15711,7 +15976,7 @@ snapshots:
       tinyglobby: 0.2.17
       ultrahtml: 1.7.0
       unifont: 0.7.4
-      unstorage: 1.17.5(ioredis@5.11.1)
+      unstorage: 1.17.5(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(ioredis@5.11.1)
       vite: 8.1.4(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.1.4(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
@@ -16073,6 +16338,10 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
 
   bundle-require@5.1.0(esbuild@0.28.1):
     dependencies:
@@ -16687,9 +16956,18 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
+
+  define-lazy-prop@3.0.0: {}
 
   defu@6.1.7: {}
 
@@ -18098,6 +18376,13 @@ snapshots:
       - supports-color
     optional: true
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -18249,6 +18534,8 @@ snapshots:
 
   is-docker@2.2.1: {}
 
+  is-docker@3.0.0: {}
+
   is-docker@4.0.0: {}
 
   is-extglob@2.1.1: {}
@@ -18263,6 +18550,10 @@ snapshots:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-interactive@1.0.0:
     optional: true
@@ -18291,6 +18582,10 @@ snapshots:
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isarray@1.0.0: {}
 
@@ -19743,6 +20038,13 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
   open@6.4.0:
     dependencies:
       is-wsl: 1.1.0
@@ -20952,6 +21254,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  run-applescript@7.1.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -21791,7 +22095,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unstorage@1.17.5(ioredis@5.11.1):
+  unstorage@1.17.5(@azure/identity@4.13.1)(@azure/keyvault-secrets@4.11.2)(ioredis@5.11.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -21802,6 +22106,8 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.4
     optionalDependencies:
+      '@azure/identity': 4.13.1
+      '@azure/keyvault-secrets': 4.11.2
       ioredis: 5.11.1
 
   update-browserslist-db@1.2.3(browserslist@4.28.4):
@@ -22250,6 +22556,10 @@ snapshots:
   ws@7.5.11: {}
 
   ws@8.21.0: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
 
   xcode@3.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- establish Breeze as the canonical M365 control-plane metadata authority for organization-owned customer administration and user-owned communications
- add exact, versioned permission profiles for delegated communications, Graph read/actions, and Exchange PowerShell executors
- add an executor-only Azure Key Vault credential provider with strict domain/material/reference validation and no API-layer secret access
- keep legacy direct Graph routes compatible while selecting only the `legacy-direct` profile
- add forced dual-axis RLS, owner/profile constraints, GUID tenant binding, and real-role isolation coverage
- document the Breeze control-plane / narrow-executor architecture and Delegant consolidation path

## Security and rollout boundaries

- Personal communications connections are self-or-system only; partner-wide and same-organization tenancy grants do not expose another user's mailbox/Teams metadata.
- The credential provider exposes version-pinned `put`/`get` only. Azure name-wide deletion is deferred until a DB-backed lifecycle workflow can load the authoritative row and serialize against rotation.
- This is the expand release: legacy discriminator defaults and `m365_connections_org_uniq` are temporarily retained because production applies migrations before replacing the old API, whose upsert targets `org_id`.
- A mandatory contract migration must remove that compatibility index/defaults before any writer creates a second organization-owned profile.

## Verification

- `pnpm install --frozen-lockfile`
- focused M365 suite: 5 files, 48 tests passed
- fresh-database M365 RLS integration: 5/5 passed as `breeze_app` with `NOBYPASSRLS`
- fresh-database migration checksum/application check passed
- focused ESLint passed
- TypeScript `--noEmit` passed
- API build passed (retains the existing CJS `import.meta` warning in `src/db/seed.ts`)
- `git diff --check` passed
- independent final code review: approved after rollout, RLS, lockfile, and credential-delete follow-ups

## Known unrelated repository gate

The repository-wide RLS coverage run on the clean current-`main`-based branch remains 52/53 because the existing dynamic `pax8_orders` / `pax8_order_lines` org-vs-partner classification check fails against the shared test database state. This branch does not modify Pax8 or RLS coverage classification files; focused M365 RLS verification is green.
