### PR TITLE
fix(agent): resolve breeze-backup helper as breeze-backup.exe on Windows

### DIFF
--- a/agent/internal/sessionbroker/backup.go
+++ b/agent/internal/sessionbroker/backup.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
@@ -19,6 +20,19 @@ const (
 
 // backupHelperScopes defines allowed IPC scopes for the backup helper.
 var backupHelperScopes = []string{"backup"}
+
+// backupBinaryName returns the on-disk filename of the breeze-backup helper as
+// installed alongside the agent. Unlike the Windows-only breeze-user-helper,
+// the backup helper is built for every supported OS (see agent/Makefile), so
+// the executable suffix must be applied conditionally: breeze-backup.exe on
+// Windows, breeze-backup elsewhere. Taking goos as a parameter keeps this
+// testable on every platform the agent builds on.
+func backupBinaryName(goos string) string {
+	if goos == "windows" {
+		return "breeze-backup.exe"
+	}
+	return "breeze-backup"
+}
 
 // backupHelper tracks the backup helper process and session.
 type backupHelper struct {
@@ -77,7 +91,7 @@ func (b *Broker) spawnBackupHelper(binaryPath string) (*Session, error) {
 			return nil, fmt.Errorf("failed to find self path: %w", err)
 		}
 		dir := filepath.Dir(self)
-		path = filepath.Join(dir, "breeze-backup")
+		path = filepath.Join(dir, backupBinaryName(runtime.GOOS))
 	}
 
 	if _, err := os.Stat(path); err != nil {

--- a/agent/internal/sessionbroker/backup_test.go
+++ b/agent/internal/sessionbroker/backup_test.go
@@ -71,6 +71,29 @@ func TestHelperRoleBackupConstant(t *testing.T) {
 	}
 }
 
+// TestBackupBinaryName pins the platform-suffix contract for the breeze-backup
+// helper. The helper is built for every supported OS (see agent/Makefile), and
+// is installed as breeze-backup.exe on Windows but breeze-backup elsewhere. The
+// original bug resolved the sibling fallback as "breeze-backup" on every OS, so
+// on Windows os.Stat could never find the installed breeze-backup.exe and every
+// backup run failed with "backup binary not found". No non-Windows CI run could
+// have caught it, hence this GOOS-parameterized test.
+func TestBackupBinaryName(t *testing.T) {
+	tests := []struct {
+		goos string
+		want string
+	}{
+		{"windows", "breeze-backup.exe"},
+		{"linux", "breeze-backup"},
+		{"darwin", "breeze-backup"},
+	}
+	for _, tt := range tests {
+		if got := backupBinaryName(tt.goos); got != tt.want {
+			t.Errorf("backupBinaryName(%q) = %q, want %q", tt.goos, got, tt.want)
+		}
+	}
+}
+
 func TestGetOrSpawnBackupHelper_ExistingSession(t *testing.T) {
 	b := &Broker{
 		sessions:     make(map[string]*Session),


### PR DESCRIPTION
## Problem

Windows agents fail **every** backup run with:

```
backup helper unavailable: backup binary not found at C:\Program Files\Breeze\breeze-backup:
GetFileAttributesEx C:\Program Files\Breeze\breeze-backup: The system cannot find the file specified.
```

Reported by a user (GenieUK) whose S3 test was green and whose `breeze-backup.exe` was confirmed present in the Breeze folder.

## Root cause

The backup helper is a separate binary the agent spawns. When no explicit `backup_binary_path` is configured — which is **every** enrolled agent, since enrollment never populates that field — the broker resolves the helper as a sibling of the agent using the bare name:

```go
path = filepath.Join(dir, "breeze-backup")   // agent/internal/sessionbroker/backup.go
```

On Windows the installer ships the file as `breeze-backup.exe` (`breeze.wxs`), so `os.Stat(".../breeze-backup")` never finds it. Build and deploy were always correct — only the runtime lookup used the wrong name. The Windows-only sibling `breeze-user-helper.exe` resolver already carries the suffix; the backup helper (which ships on all OSes) just never got the conditional `.exe`. No non-Windows CI run could catch this.

The green S3 test is consistent with this: the credential check never reaches the helper-spawn step, so it passes while the backup dies at binary resolution. One root cause, not two.

## Fix

Add a testable `backupBinaryName(goos)` helper (mirroring the `userhelper_path.go` convention) that appends `.exe` only on Windows, and use it in the fallback resolution.

## Verification

- `go test ./internal/sessionbroker/` — all backup tests pass, including new `TestBackupBinaryName` (windows → `breeze-backup.exe`, linux/darwin → `breeze-backup`)
- `GOOS=windows GOARCH=amd64 go build ./internal/sessionbroker/` — succeeds
- `go vet ./internal/sessionbroker/` — clean

Cannot be driven end-to-end on non-Windows CI (it's Windows-only runtime behavior); the GOOS-parameterized unit test plus the Windows cross-compile are the strongest available proof. A build off this branch on a Windows endpoint would confirm live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)