### PR TITLE
docs: recognize Breeze sponsors and contributors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: LanternOps

--- a/.github/scripts/update-community-readme.mjs
+++ b/.github/scripts/update-community-readme.mjs
@@ -1,0 +1,45 @@
+export function escapeHtml(value) {
+  return String(value).replace(/[&<>"']/g, (character) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[character]);
+}
+
+export function isBot(account) {
+  return account.type === 'Bot' || account.login.endsWith('[bot]');
+}
+
+export function renderGallery(accounts, emptyMarkdown) {
+  if (accounts.length === 0) {
+    return emptyMarkdown;
+  }
+
+  return accounts.map((account) => {
+    const displayName = account.name || account.login;
+    const avatarUrl = new URL(account.avatarUrl);
+    avatarUrl.searchParams.set('s', '128');
+
+    return '<a href="' + escapeHtml(account.url) + '">'
+      + '<img src="' + escapeHtml(avatarUrl.toString()) + '"'
+      + ' width="64" height="64"'
+      + ' alt="' + escapeHtml(displayName) + '"'
+      + ' title="' + escapeHtml(displayName + ' (@' + account.login + ')') + '" />'
+      + '</a>';
+  }).join('\n');
+}
+
+export function replaceMarkedBlock(markdown, name, content) {
+  const start = '<!-- ' + name + ':start -->';
+  const end = '<!-- ' + name + ':end -->';
+  if (markdown.split(start).length !== 2
+      || markdown.split(end).length !== 2
+      || markdown.indexOf(start) > markdown.indexOf(end)) {
+    throw new Error('README must contain exactly one ordered ' + name + ' marker pair');
+  }
+  return markdown.slice(0, markdown.indexOf(start))
+    + start + '\n' + content + '\n' + end
+    + markdown.slice(markdown.indexOf(end) + end.length);
+}

--- a/.github/scripts/update-community-readme.mjs
+++ b/.github/scripts/update-community-readme.mjs
@@ -1,3 +1,36 @@
+import { readFile, rename, rm, writeFile } from 'node:fs/promises';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const githubHeaders = (token) => ({
+  Authorization: `Bearer ${token}`,
+  Accept: 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+});
+
+const sponsorsQuery = `
+  query PublicSponsors($login: String!, $cursor: String) {
+    organization(login: $login) {
+      sponsorshipsAsMaintainer(
+        first: 100
+        after: $cursor
+        activeOnly: true
+        includePrivate: false
+      ) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          sponsorEntity {
+            ... on User { login name avatarUrl url }
+            ... on Organization { login name avatarUrl url }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const defaultReadmePath = fileURLToPath(new URL('../../README.md', import.meta.url));
+
 export function escapeHtml(value) {
   return String(value).replace(/[&<>"']/g, (character) => ({
     '&': '&amp;',
@@ -42,4 +75,181 @@ export function replaceMarkedBlock(markdown, name, content) {
   return markdown.slice(0, markdown.indexOf(start))
     + start + '\n' + content + '\n' + end
     + markdown.slice(markdown.indexOf(end) + end.length);
+}
+
+export async function fetchSponsors(fetchImpl, token) {
+  const sponsorsByLogin = new Map();
+  let cursor = null;
+
+  do {
+    const response = await fetchImpl('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        ...githubHeaders(token),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: sponsorsQuery,
+        variables: { login: 'LanternOps', cursor },
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub GraphQL request failed (${response.status})`);
+    }
+
+    const payload = await response.json();
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+      throw new Error(`GitHub GraphQL errors: ${payload.errors
+        .map((error) => error.message || String(error))
+        .join('; ')}`);
+    }
+
+    const organization = payload?.data?.organization;
+    if (!organization) {
+      throw new Error('GitHub GraphQL response is missing the LanternOps organization');
+    }
+    const connection = organization.sponsorshipsAsMaintainer;
+    if (!connection
+        || !Array.isArray(connection.nodes)
+        || typeof connection.pageInfo?.hasNextPage !== 'boolean'
+        || (connection.pageInfo.endCursor !== null
+          && typeof connection.pageInfo.endCursor !== 'string')) {
+      throw new Error('GitHub GraphQL response contains a malformed sponsorship connection');
+    }
+    if (connection.pageInfo.hasNextPage && !connection.pageInfo.endCursor) {
+      throw new Error('GitHub GraphQL response contains a malformed sponsorship connection');
+    }
+
+    for (const node of connection.nodes) {
+      const sponsor = node?.sponsorEntity;
+      if (sponsor == null) {
+        continue;
+      }
+      if (typeof sponsor.login !== 'string'
+          || (sponsor.name !== null && sponsor.name !== undefined
+            && typeof sponsor.name !== 'string')
+          || typeof sponsor.avatarUrl !== 'string'
+          || typeof sponsor.url !== 'string') {
+        throw new Error('GitHub GraphQL response contains a malformed sponsor');
+      }
+      const key = sponsor.login.toLowerCase();
+      if (!sponsorsByLogin.has(key)) {
+        sponsorsByLogin.set(key, sponsor);
+      }
+    }
+
+    cursor = connection.pageInfo.hasNextPage
+      ? connection.pageInfo.endCursor
+      : null;
+  } while (cursor !== null);
+
+  return [...sponsorsByLogin.values()].sort((left, right) => (
+    left.login.localeCompare(right.login, 'en', { sensitivity: 'base' })
+  ));
+}
+
+export async function fetchContributors(fetchImpl, token) {
+  const contributors = [];
+  let page = 1;
+  let entries;
+
+  do {
+    const url = 'https://api.github.com/repos/LanternOps/breeze/contributors'
+      + `?anon=0&per_page=100&page=${page}`;
+    const response = await fetchImpl(url, {
+      method: 'GET',
+      headers: githubHeaders(token),
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub contributors request failed (${response.status})`);
+    }
+
+    entries = await response.json();
+    if (!Array.isArray(entries)) {
+      throw new Error('GitHub contributors response must be an array');
+    }
+
+    for (const entry of entries) {
+      if (typeof entry?.login !== 'string'
+          || typeof entry.avatar_url !== 'string'
+          || typeof entry.html_url !== 'string'
+          || typeof entry.type !== 'string') {
+        throw new Error('GitHub contributors response contains a malformed account');
+      }
+      const contributor = {
+        login: entry.login,
+        avatarUrl: entry.avatar_url,
+        url: entry.html_url,
+        type: entry.type,
+      };
+      if (!isBot(contributor)) {
+        contributors.push(contributor);
+      }
+    }
+    page += 1;
+  } while (entries.length === 100);
+
+  return contributors;
+}
+
+export function buildReadme(source, sponsors, contributors) {
+  const withSponsors = replaceMarkedBlock(
+    source,
+    'sponsors',
+    renderGallery(
+      sponsors,
+      '_No public sponsors yet. [Become the first sponsor →](https://github.com/sponsors/LanternOps)_',
+    ),
+  );
+  return replaceMarkedBlock(
+    withSponsors,
+    'contributors',
+    renderGallery(contributors, '_No contributors are available yet._'),
+  );
+}
+
+export async function updateReadme({
+  fetchImpl = globalThis.fetch,
+  token,
+  readmePath = defaultReadmePath,
+  fsImpl = { readFile, writeFile, rename, rm },
+} = {}) {
+  if (!token) {
+    throw new Error('GITHUB_TOKEN is required');
+  }
+
+  const [source, sponsors, contributors] = await Promise.all([
+    fsImpl.readFile(readmePath, 'utf8'),
+    fetchSponsors(fetchImpl, token),
+    fetchContributors(fetchImpl, token),
+  ]);
+  const updated = buildReadme(source, sponsors, contributors);
+  if (updated === source) {
+    return { changed: false };
+  }
+
+  const temporaryPath = `${readmePath}.${process.pid}.tmp`;
+  try {
+    await fsImpl.writeFile(temporaryPath, updated, 'utf8');
+    await fsImpl.rename(temporaryPath, readmePath);
+  } catch (error) {
+    try {
+      await fsImpl.rm(temporaryPath, { force: true });
+    } catch {
+      // Preserve the original update error.
+    }
+    throw error;
+  }
+
+  return { changed: true };
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const result = await updateReadme({ token: process.env.GITHUB_TOKEN });
+    console.log(result.changed ? 'README.md changed' : 'README.md unchanged');
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
 }

--- a/.github/scripts/update-community-readme.mjs
+++ b/.github/scripts/update-community-readme.mjs
@@ -30,6 +30,20 @@ const sponsorsQuery = `
 `;
 
 const defaultReadmePath = fileURLToPath(new URL('../../README.md', import.meta.url));
+const githubRequestTimeoutMs = 30_000;
+
+function parseHttpsUrl(value, label) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${label} must be a valid HTTPS URL`);
+  }
+  if (url.protocol !== 'https:') {
+    throw new Error(`${label} must be a valid HTTPS URL`);
+  }
+  return url;
+}
 
 export function escapeHtml(value) {
   return String(value).replace(/[&<>"']/g, (character) => ({
@@ -52,7 +66,8 @@ export function renderGallery(accounts, emptyMarkdown) {
 
   return accounts.map((account) => {
     const displayName = account.name || account.login;
-    const avatarUrl = new URL(account.avatarUrl);
+    parseHttpsUrl(account.url, 'Profile URL');
+    const avatarUrl = parseHttpsUrl(account.avatarUrl, 'Avatar URL');
     avatarUrl.searchParams.set('s', '128');
 
     return '<a href="' + escapeHtml(account.url) + '">'
@@ -79,6 +94,7 @@ export function replaceMarkedBlock(markdown, name, content) {
 
 export async function fetchSponsors(fetchImpl, token) {
   const sponsorsByLogin = new Map();
+  const seenCursors = new Set();
   let cursor = null;
 
   do {
@@ -92,6 +108,7 @@ export async function fetchSponsors(fetchImpl, token) {
         query: sponsorsQuery,
         variables: { login: 'LanternOps', cursor },
       }),
+      signal: AbortSignal.timeout(githubRequestTimeoutMs),
     });
     if (!response.ok) {
       throw new Error(`GitHub GraphQL request failed (${response.status})`);
@@ -119,6 +136,10 @@ export async function fetchSponsors(fetchImpl, token) {
     if (connection.pageInfo.hasNextPage && !connection.pageInfo.endCursor) {
       throw new Error('GitHub GraphQL response contains a malformed sponsorship connection');
     }
+    if (connection.pageInfo.hasNextPage
+        && seenCursors.has(connection.pageInfo.endCursor)) {
+      throw new Error('GitHub GraphQL response contains a repeated pagination cursor');
+    }
 
     for (const node of connection.nodes) {
       const sponsor = node?.sponsorEntity;
@@ -138,9 +159,12 @@ export async function fetchSponsors(fetchImpl, token) {
       }
     }
 
-    cursor = connection.pageInfo.hasNextPage
-      ? connection.pageInfo.endCursor
-      : null;
+    if (connection.pageInfo.hasNextPage) {
+      seenCursors.add(connection.pageInfo.endCursor);
+      cursor = connection.pageInfo.endCursor;
+    } else {
+      cursor = null;
+    }
   } while (cursor !== null);
 
   return [...sponsorsByLogin.values()].sort((left, right) => (
@@ -159,6 +183,7 @@ export async function fetchContributors(fetchImpl, token) {
     const response = await fetchImpl(url, {
       method: 'GET',
       headers: githubHeaders(token),
+      signal: AbortSignal.timeout(githubRequestTimeoutMs),
     });
     if (!response.ok) {
       throw new Error(`GitHub contributors request failed (${response.status})`);

--- a/.github/scripts/update-community-readme.test.mjs
+++ b/.github/scripts/update-community-readme.test.mjs
@@ -88,6 +88,27 @@ test('renders the supplied empty state when the account list is empty', () => {
   assert.equal(renderGallery([], '_Be the first sponsor._'), '_Be the first sponsor._');
 });
 
+test('rejects profile and avatar URLs that are invalid or not HTTPS', () => {
+  const account = {
+    login: 'ada',
+    avatarUrl: 'https://avatars.githubusercontent.com/u/1',
+    url: 'https://github.com/ada',
+  };
+
+  for (const [field, value] of [
+    ['avatarUrl', 'http://avatars.githubusercontent.com/u/1'],
+    ['avatarUrl', 'not a URL'],
+    ['url', 'http://github.com/ada'],
+    ['url', 'not a URL'],
+  ]) {
+    assert.throws(
+      () => renderGallery([{ ...account, [field]: value }], 'empty'),
+      /valid HTTPS URL/,
+      `${field}=${value}`,
+    );
+  }
+});
+
 test('replaces exactly one marker pair', () => {
   const source = 'before\n<!-- sponsors:start -->\nold\n<!-- sponsors:end -->\nafter\n';
   assert.equal(
@@ -220,6 +241,8 @@ test('fetches all active public sponsors, removes nulls and duplicates, and sort
     assert.equal(headers.get('Accept'), 'application/vnd.github+json');
     assert.equal(headers.get('Content-Type'), 'application/json');
     assert.equal(headers.get('X-GitHub-Api-Version'), '2022-11-28');
+    assert.ok(request.init.signal instanceof AbortSignal);
+    assert.equal(request.init.signal.aborted, false);
 
     const body = JSON.parse(request.init.body);
     assert.equal(body.variables.login, 'LanternOps');
@@ -228,6 +251,31 @@ test('fetches all active public sponsors, removes nulls and duplicates, and sort
     assert.match(body.query, /includePrivate:\s*false/);
     assert.doesNotMatch(body.query, /privacyLevel|amount|tier/i);
   }
+});
+
+test('rejects a repeated sponsor pagination cursor', async () => {
+  let requestCount = 0;
+
+  await assert.rejects(
+    fetchSponsors(async () => {
+      requestCount += 1;
+      if (requestCount > 2) {
+        throw new Error('unexpected third request');
+      }
+      return jsonResponse({
+        data: {
+          organization: {
+            sponsorshipsAsMaintainer: {
+              pageInfo: { hasNextPage: true, endCursor: 'same-cursor' },
+              nodes: [],
+            },
+          },
+        },
+      });
+    }, 'secret-token'),
+    /repeated.*cursor/i,
+  );
+  assert.equal(requestCount, 2);
 });
 
 test('rejects failed and malformed sponsor API responses', async (t) => {
@@ -326,6 +374,8 @@ test('fetches contributor pages through the final short page and filters bots', 
     assert.equal(headers.get('Authorization'), 'Bearer secret-token');
     assert.equal(headers.get('Accept'), 'application/vnd.github+json');
     assert.equal(headers.get('X-GitHub-Api-Version'), '2022-11-28');
+    assert.ok(init.signal instanceof AbortSignal);
+    assert.equal(init.signal.aborted, false);
   }
   assert.equal(contributors.length, 99);
   assert.deepEqual(contributors.slice(0, 2), [
@@ -517,16 +567,35 @@ test('repository README contains exactly one ordered community marker pair', asy
   }
 });
 
-test('repository workflow updates the README on schedule or by dispatch', async () => {
+test('repository workflows gate and safely update the community README', async () => {
   const workflow = await readFile(
     new URL('../workflows/update-community-readme.yml', import.meta.url),
     'utf8',
   );
+  const ciWorkflow = await readFile(new URL('../workflows/ci.yml', import.meta.url), 'utf8');
+  const packageJson = JSON.parse(
+    await readFile(new URL('../../package.json', import.meta.url), 'utf8'),
+  );
 
+  assert.equal(
+    packageJson.scripts['test:community-readme'],
+    'node --test .github/scripts/update-community-readme.test.mjs',
+  );
+  assert.match(ciWorkflow, /run: pnpm test:community-readme/);
   assert.match(workflow, /^\s*schedule:\s*$/m);
   assert.match(workflow, /^\s*- cron: ['"]17 5 \* \* \*['"]\s*$/m);
   assert.match(workflow, /^\s*workflow_dispatch:\s*$/m);
   assert.match(workflow, /^permissions:\n  contents: write$/m);
-  assert.match(workflow, /node \.github\/scripts\/update-community-readme\.mjs/);
+  assert.match(workflow, /^concurrency:\n  group: update-community-readme\n  cancel-in-progress: false$/m);
+  assert.match(workflow, /^    timeout-minutes: 10$/m);
+  const testCommand = 'node --test .github/scripts/update-community-readme.test.mjs';
+  const updateCommand = 'node .github/scripts/update-community-readme.mjs';
+  assert.ok(workflow.includes(testCommand));
+  assert.ok(workflow.indexOf(testCommand) < workflow.indexOf(updateCommand));
   assert.doesNotMatch(workflow, /^\s*pull_request:\s*$/m);
+  assert.doesNotMatch(workflow, /^\s*push:\s*$/m);
+  assert.match(workflow, /git diff --quiet -- README\.md/);
+  assert.match(workflow, /git add README\.md/);
+  assert.match(workflow, /git commit --only .* -- README\.md/);
+  assert.doesNotMatch(workflow, /git add (?:--all|-A|\.)/);
 });

--- a/.github/scripts/update-community-readme.test.mjs
+++ b/.github/scripts/update-community-readme.test.mjs
@@ -2,11 +2,53 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  buildReadme,
   escapeHtml,
+  fetchContributors,
+  fetchSponsors,
   isBot,
   renderGallery,
   replaceMarkedBlock,
+  updateReadme,
 } from './update-community-readme.mjs';
+
+const readmeSource = `before
+<!-- sponsors:start -->
+old sponsors
+<!-- sponsors:end -->
+middle
+<!-- contributors:start -->
+old contributors
+<!-- contributors:end -->
+after
+`;
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function emptySponsorResponse() {
+  return jsonResponse({
+    data: {
+      organization: {
+        sponsorshipsAsMaintainer: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [],
+        },
+      },
+    },
+  });
+}
+
+function successfulFetch(url) {
+  if (url === 'https://api.github.com/graphql') {
+    return emptySponsorResponse();
+  }
+  return jsonResponse([]);
+}
 
 test('escapes HTML-sensitive characters', () => {
   assert.equal(
@@ -79,4 +121,380 @@ test('rejects duplicated or reversed marker pairs', () => {
     ),
     /exactly one/,
   );
+});
+
+test('fetches all active public sponsors, removes nulls and duplicates, and sorts by login', async () => {
+  const requests = [];
+  const pages = [
+    {
+      data: {
+        organization: {
+          sponsorshipsAsMaintainer: {
+            pageInfo: { hasNextPage: true, endCursor: 'page-2' },
+            nodes: [
+              {
+                sponsorEntity: {
+                  login: 'Zed',
+                  name: 'Zed Industries',
+                  avatarUrl: 'https://avatars.githubusercontent.com/u/3',
+                  url: 'https://github.com/Zed',
+                },
+              },
+              null,
+              { sponsorEntity: null },
+              {
+                sponsorEntity: {
+                  login: 'ada',
+                  name: 'Ada',
+                  avatarUrl: 'https://avatars.githubusercontent.com/u/1',
+                  url: 'https://github.com/ada',
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      data: {
+        organization: {
+          sponsorshipsAsMaintainer: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                sponsorEntity: {
+                  login: 'ADA',
+                  name: 'Duplicate Ada',
+                  avatarUrl: 'https://avatars.githubusercontent.com/u/11',
+                  url: 'https://github.com/ADA',
+                },
+              },
+              {
+                sponsorEntity: {
+                  login: 'bob',
+                  name: null,
+                  avatarUrl: 'https://avatars.githubusercontent.com/u/2',
+                  url: 'https://github.com/bob',
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  ];
+
+  const sponsors = await fetchSponsors(async (url, init) => {
+    requests.push({ url, init });
+    return jsonResponse(pages[requests.length - 1]);
+  }, 'secret-token');
+
+  assert.deepEqual(sponsors, [
+    {
+      login: 'ada',
+      name: 'Ada',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/1',
+      url: 'https://github.com/ada',
+    },
+    {
+      login: 'bob',
+      name: null,
+      avatarUrl: 'https://avatars.githubusercontent.com/u/2',
+      url: 'https://github.com/bob',
+    },
+    {
+      login: 'Zed',
+      name: 'Zed Industries',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/3',
+      url: 'https://github.com/Zed',
+    },
+  ]);
+  assert.equal(requests.length, 2);
+
+  for (const [index, request] of requests.entries()) {
+    assert.equal(request.url, 'https://api.github.com/graphql');
+    assert.equal(request.init.method, 'POST');
+    const headers = new Headers(request.init.headers);
+    assert.equal(headers.get('Authorization'), 'Bearer secret-token');
+    assert.equal(headers.get('Accept'), 'application/vnd.github+json');
+    assert.equal(headers.get('Content-Type'), 'application/json');
+    assert.equal(headers.get('X-GitHub-Api-Version'), '2022-11-28');
+
+    const body = JSON.parse(request.init.body);
+    assert.equal(body.variables.login, 'LanternOps');
+    assert.equal(body.variables.cursor, index === 0 ? null : 'page-2');
+    assert.match(body.query, /activeOnly:\s*true/);
+    assert.match(body.query, /includePrivate:\s*false/);
+    assert.doesNotMatch(body.query, /privacyLevel|amount|tier/i);
+  }
+});
+
+test('rejects failed and malformed sponsor API responses', async (t) => {
+  const cases = [
+    {
+      name: 'non-2xx response',
+      response: new Response('server error', { status: 500 }),
+      error: /GraphQL request failed.*500/,
+    },
+    {
+      name: 'GraphQL errors',
+      response: jsonResponse({ errors: [{ message: 'forbidden' }] }),
+      error: /GraphQL.*forbidden/,
+    },
+    {
+      name: 'missing organization',
+      response: jsonResponse({ data: { organization: null } }),
+      error: /organization/,
+    },
+    {
+      name: 'malformed connection',
+      response: jsonResponse({
+        data: {
+          organization: {
+            sponsorshipsAsMaintainer: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: null,
+            },
+          },
+        },
+      }),
+      error: /connection/,
+    },
+  ];
+
+  for (const fixture of cases) {
+    await t.test(fixture.name, async () => {
+      await assert.rejects(
+        fetchSponsors(async () => fixture.response, 'secret-token'),
+        fixture.error,
+      );
+    });
+  }
+});
+
+test('fetches contributor pages through the final short page and filters bots', async () => {
+  const firstPage = Array.from({ length: 100 }, (_, index) => ({
+    login: `person-${index}`,
+    avatar_url: `https://avatars.githubusercontent.com/u/${index}`,
+    html_url: `https://github.com/person-${index}`,
+    type: 'User',
+  }));
+  firstPage[1] = {
+    login: 'release-service',
+    avatar_url: 'https://avatars.githubusercontent.com/u/1001',
+    html_url: 'https://github.com/apps/release-service',
+    type: 'Bot',
+  };
+  firstPage[2] = {
+    login: 'dependabot[bot]',
+    avatar_url: 'https://avatars.githubusercontent.com/u/1002',
+    html_url: 'https://github.com/dependabot',
+    type: 'User',
+  };
+  const secondPage = [
+    {
+      login: 'final-person',
+      avatar_url: 'https://avatars.githubusercontent.com/u/2000',
+      html_url: 'https://github.com/final-person',
+      type: 'User',
+    },
+    {
+      login: 'final-bot[bot]',
+      avatar_url: 'https://avatars.githubusercontent.com/u/2001',
+      html_url: 'https://github.com/final-bot',
+      type: 'User',
+    },
+  ];
+  const requests = [];
+
+  const contributors = await fetchContributors(async (url, init) => {
+    requests.push({ url, init });
+    return jsonResponse(requests.length === 1 ? firstPage : secondPage);
+  }, 'secret-token');
+
+  assert.deepEqual(
+    requests.map(({ url }) => url),
+    [
+      'https://api.github.com/repos/LanternOps/breeze/contributors?anon=0&per_page=100&page=1',
+      'https://api.github.com/repos/LanternOps/breeze/contributors?anon=0&per_page=100&page=2',
+    ],
+  );
+  for (const { init } of requests) {
+    const headers = new Headers(init.headers);
+    assert.equal(init.method, 'GET');
+    assert.equal(headers.get('Authorization'), 'Bearer secret-token');
+    assert.equal(headers.get('Accept'), 'application/vnd.github+json');
+    assert.equal(headers.get('X-GitHub-Api-Version'), '2022-11-28');
+  }
+  assert.equal(contributors.length, 99);
+  assert.deepEqual(contributors.slice(0, 2), [
+    {
+      login: 'person-0',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/0',
+      url: 'https://github.com/person-0',
+      type: 'User',
+    },
+    {
+      login: 'person-3',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/3',
+      url: 'https://github.com/person-3',
+      type: 'User',
+    },
+  ]);
+  assert.equal(contributors.at(-1).login, 'final-person');
+});
+
+test('builds both README galleries in memory with stable empty states', () => {
+  const result = buildReadme(readmeSource, [], []);
+  assert.equal(
+    result,
+    `before
+<!-- sponsors:start -->
+_No public sponsors yet. [Become the first sponsor →](https://github.com/sponsors/LanternOps)_
+<!-- sponsors:end -->
+middle
+<!-- contributors:start -->
+_No contributors are available yet._
+<!-- contributors:end -->
+after
+`,
+  );
+});
+
+test('does not write when an API request fails', async () => {
+  let writeCalls = 0;
+  const fsImpl = {
+    readFile: async () => readmeSource,
+    writeFile: async () => { writeCalls += 1; },
+    rename: async () => { writeCalls += 1; },
+    rm: async () => { writeCalls += 1; },
+  };
+
+  await assert.rejects(
+    updateReadme({
+      fetchImpl: async (url) => (url === 'https://api.github.com/graphql'
+        ? new Response('failed', { status: 503 })
+        : jsonResponse([])),
+      token: 'secret-token',
+      readmePath: '/repo/README.md',
+      fsImpl,
+    }),
+    /503/,
+  );
+  assert.equal(writeCalls, 0);
+});
+
+test('does not write when README markers are malformed', async () => {
+  let writeCalls = 0;
+  const fsImpl = {
+    readFile: async () => '<!-- sponsors:start -->\nold\n<!-- sponsors:end -->\n',
+    writeFile: async () => { writeCalls += 1; },
+    rename: async () => { writeCalls += 1; },
+    rm: async () => { writeCalls += 1; },
+  };
+
+  await assert.rejects(
+    updateReadme({
+      fetchImpl: successfulFetch,
+      token: 'secret-token',
+      readmePath: '/repo/README.md',
+      fsImpl,
+    }),
+    /contributors marker pair/,
+  );
+  assert.equal(writeCalls, 0);
+});
+
+test('atomically replaces a changed README and makes the second update a no-op', async () => {
+  let source = readmeSource;
+  let temporary;
+  const operations = [];
+  const readmePath = '/repo/README.md';
+  const expectedTemporaryPath = `${readmePath}.${process.pid}.tmp`;
+  const fsImpl = {
+    readFile: async (path, encoding) => {
+      assert.equal(path, readmePath);
+      assert.equal(encoding, 'utf8');
+      return source;
+    },
+    writeFile: async (path, content, encoding) => {
+      assert.equal(path, expectedTemporaryPath);
+      assert.equal(encoding, 'utf8');
+      operations.push(['write', path]);
+      temporary = content;
+    },
+    rename: async (from, to) => {
+      assert.equal(from, expectedTemporaryPath);
+      assert.equal(to, readmePath);
+      operations.push(['rename', from, to]);
+      source = temporary;
+      temporary = undefined;
+    },
+    rm: async (path, options) => {
+      assert.equal(path, expectedTemporaryPath);
+      assert.deepEqual(options, { force: true });
+      operations.push(['rm', path]);
+      temporary = undefined;
+    },
+  };
+
+  assert.deepEqual(
+    await updateReadme({
+      fetchImpl: successfulFetch,
+      token: 'secret-token',
+      readmePath,
+      fsImpl,
+    }),
+    { changed: true },
+  );
+  assert.deepEqual(
+    await updateReadme({
+      fetchImpl: successfulFetch,
+      token: 'secret-token',
+      readmePath,
+      fsImpl,
+    }),
+    { changed: false },
+  );
+  assert.deepEqual(operations, [
+    ['write', expectedTemporaryPath],
+    ['rename', expectedTemporaryPath, readmePath],
+  ]);
+});
+
+test('removes the temporary sibling when atomic replacement fails', async () => {
+  const readmePath = '/repo/README.md';
+  const expectedTemporaryPath = `${readmePath}.${process.pid}.tmp`;
+  let temporary;
+  const operations = [];
+  const fsImpl = {
+    readFile: async () => readmeSource,
+    writeFile: async (path, content) => {
+      assert.equal(path, expectedTemporaryPath);
+      operations.push('write');
+      temporary = content;
+    },
+    rename: async () => {
+      operations.push('rename');
+      throw new Error('rename failed');
+    },
+    rm: async (path, options) => {
+      assert.equal(path, expectedTemporaryPath);
+      assert.deepEqual(options, { force: true });
+      operations.push('rm');
+      temporary = undefined;
+    },
+  };
+
+  await assert.rejects(
+    updateReadme({
+      fetchImpl: successfulFetch,
+      token: 'secret-token',
+      readmePath,
+      fsImpl,
+    }),
+    /rename failed/,
+  );
+  assert.deepEqual(operations, ['write', 'rename', 'rm']);
+  assert.equal(temporary, undefined);
 });

--- a/.github/scripts/update-community-readme.test.mjs
+++ b/.github/scripts/update-community-readme.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
 import {
@@ -497,4 +498,35 @@ test('removes the temporary sibling when atomic replacement fails', async () => 
   );
   assert.deepEqual(operations, ['write', 'rename', 'rm']);
   assert.equal(temporary, undefined);
+});
+
+test('repository funding points GitHub Sponsors at LanternOps', async () => {
+  const funding = await readFile(new URL('../FUNDING.yml', import.meta.url), 'utf8');
+  assert.equal(funding, 'github: LanternOps\n');
+});
+
+test('repository README contains exactly one ordered community marker pair', async () => {
+  const readme = await readFile(new URL('../../README.md', import.meta.url), 'utf8');
+
+  for (const name of ['sponsors', 'contributors']) {
+    const start = `<!-- ${name}:start -->`;
+    const end = `<!-- ${name}:end -->`;
+    assert.equal(readme.split(start).length - 1, 1, `${name} start marker count`);
+    assert.equal(readme.split(end).length - 1, 1, `${name} end marker count`);
+    assert.ok(readme.indexOf(start) < readme.indexOf(end), `${name} markers are ordered`);
+  }
+});
+
+test('repository workflow updates the README on schedule or by dispatch', async () => {
+  const workflow = await readFile(
+    new URL('../workflows/update-community-readme.yml', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(workflow, /^\s*schedule:\s*$/m);
+  assert.match(workflow, /^\s*- cron: ['"]17 5 \* \* \*['"]\s*$/m);
+  assert.match(workflow, /^\s*workflow_dispatch:\s*$/m);
+  assert.match(workflow, /^permissions:\n  contents: write$/m);
+  assert.match(workflow, /node \.github\/scripts\/update-community-readme\.mjs/);
+  assert.doesNotMatch(workflow, /^\s*pull_request:\s*$/m);
 });

--- a/.github/scripts/update-community-readme.test.mjs
+++ b/.github/scripts/update-community-readme.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  escapeHtml,
+  isBot,
+  renderGallery,
+  replaceMarkedBlock,
+} from './update-community-readme.mjs';
+
+test('escapes HTML-sensitive characters', () => {
+  assert.equal(
+    escapeHtml(`Breeze & <fast> \"remote\" 'management'`),
+    'Breeze &amp; &lt;fast&gt; &quot;remote&quot; &#39;management&#39;',
+  );
+});
+
+test('identifies GitHub bot account types and login suffixes', () => {
+  assert.equal(isBot({ login: 'release-service', type: 'Bot' }), true);
+  assert.equal(isBot({ login: 'dependabot[bot]', type: 'User' }), true);
+  assert.equal(isBot({ login: 'octocat', type: 'User' }), false);
+});
+
+test('renders linked, escaped, fixed-size accessible avatars', () => {
+  assert.equal(
+    renderGallery([
+      {
+        login: 'ada',
+        name: `Ada <Lovelace> & \"Friends\"`,
+        avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+        url: 'https://github.com/ada?tab=overview&from=gallery',
+      },
+      {
+        login: `grace'o`,
+        avatarUrl: 'https://avatars.githubusercontent.com/u/2',
+        url: 'https://github.com/grace-o',
+      },
+    ], 'No community members yet.'),
+    '<a href="https://github.com/ada?tab=overview&amp;from=gallery"><img src="https://avatars.githubusercontent.com/u/1?v=4&amp;s=128" width="64" height="64" alt="Ada &lt;Lovelace&gt; &amp; &quot;Friends&quot;" title="Ada &lt;Lovelace&gt; &amp; &quot;Friends&quot; (@ada)" /></a>\n'
+      + '<a href="https://github.com/grace-o"><img src="https://avatars.githubusercontent.com/u/2?s=128" width="64" height="64" alt="grace&#39;o" title="grace&#39;o (@grace&#39;o)" /></a>',
+  );
+});
+
+test('renders the supplied empty state when the account list is empty', () => {
+  assert.equal(renderGallery([], '_Be the first sponsor._'), '_Be the first sponsor._');
+});
+
+test('replaces exactly one marker pair', () => {
+  const source = 'before\n<!-- sponsors:start -->\nold\n<!-- sponsors:end -->\nafter\n';
+  assert.equal(
+    replaceMarkedBlock(source, 'sponsors', 'new'),
+    'before\n<!-- sponsors:start -->\nnew\n<!-- sponsors:end -->\nafter\n',
+  );
+  assert.throws(() => replaceMarkedBlock('missing', 'sponsors', 'new'), /exactly one/);
+});
+
+test('rejects duplicated or reversed marker pairs', () => {
+  assert.throws(
+    () => replaceMarkedBlock(
+      '<!-- sponsors:start -->\nfirst\n<!-- sponsors:start -->\nsecond\n<!-- sponsors:end -->',
+      'sponsors',
+      'new',
+    ),
+    /exactly one/,
+  );
+  assert.throws(
+    () => replaceMarkedBlock(
+      '<!-- sponsors:start -->\nfirst\n<!-- sponsors:end -->\nsecond\n<!-- sponsors:end -->',
+      'sponsors',
+      'new',
+    ),
+    /exactly one/,
+  );
+  assert.throws(
+    () => replaceMarkedBlock(
+      '<!-- sponsors:end -->\nold\n<!-- sponsors:start -->',
+      'sponsors',
+      'new',
+    ),
+    /exactly one/,
+  );
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
 
+      - name: Test community README automation
+        run: pnpm test:community-readme
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/update-community-readme.yml
+++ b/.github/workflows/update-community-readme.yml
@@ -8,10 +8,15 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: update-community-readme
+  cancel-in-progress: false
+
 jobs:
   update-community-readme:
     name: Refresh sponsors and contributors
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -22,6 +27,9 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+
+      - name: Test community README automation
+        run: node --test .github/scripts/update-community-readme.test.mjs
 
       - name: Update community README
         env:

--- a/.github/workflows/update-community-readme.yml
+++ b/.github/workflows/update-community-readme.yml
@@ -1,0 +1,42 @@
+name: Update community README
+
+on:
+  schedule:
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-community-readme:
+    name: Refresh sponsors and contributors
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Update community README
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node .github/scripts/update-community-readme.mjs
+
+      - name: Commit and push README changes
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "README.md is already current"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit --only -m "docs: refresh sponsors and contributors [skip ci]" -- README.md
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -388,6 +388,18 @@ For detailed architecture documentation, see [docs/architecture.md](docs/archite
 
 ---
 
+## Support Breeze
+
+Breeze is free and open source. If it helps your team, you can support ongoing development by [sponsoring LanternOps on GitHub](https://github.com/sponsors/LanternOps).
+
+### Sponsors
+
+<!-- sponsors:start -->
+_No public sponsors yet. [Become the first sponsor →](https://github.com/sponsors/LanternOps)_
+<!-- sponsors:end -->
+
+---
+
 ## Contributing
 
 Breeze is built by MSPs, for MSPs. Contributions are welcome.
@@ -421,6 +433,18 @@ make build  # outputs to agent/bin/
 - **Agent testing** — Run the agent on Windows/Linux and report what works and what doesn't.
 - **Playbooks** — Share your remediation workflows so others can use them.
 - **Documentation** — Help us make the docs better.
+
+### Contributors
+
+Thank you to everyone who has contributed to Breeze.
+
+<!-- contributors:start -->
+<a href="https://github.com/ToddHebebrand"><img src="https://avatars.githubusercontent.com/u/8375744?v=4&amp;s=128" width="64" height="64" alt="ToddHebebrand" title="ToddHebebrand (@ToddHebebrand)" /></a>
+<a href="https://github.com/bdunncompany"><img src="https://avatars.githubusercontent.com/u/17571793?v=4&amp;s=128" width="64" height="64" alt="bdunncompany" title="bdunncompany (@bdunncompany)" /></a>
+<a href="https://github.com/ramphex"><img src="https://avatars.githubusercontent.com/u/43665314?v=4&amp;s=128" width="64" height="64" alt="ramphex" title="ramphex (@ramphex)" /></a>
+<a href="https://github.com/Emilien-Etadam"><img src="https://avatars.githubusercontent.com/u/56485277?v=4&amp;s=128" width="64" height="64" alt="Emilien-Etadam" title="Emilien-Etadam (@Emilien-Etadam)" /></a>
+<a href="https://github.com/CookieSource"><img src="https://avatars.githubusercontent.com/u/36531905?v=4&amp;s=128" width="64" height="64" alt="CookieSource" title="CookieSource (@CookieSource)" /></a>
+<!-- contributors:end -->
 
 ### Community
 

--- a/docs/superpowers/plans/2026-07-14-readme-sponsors-contributors.md
+++ b/docs/superpowers/plans/2026-07-14-readme-sponsors-contributors.md
@@ -212,4 +212,3 @@ Expected: checks pass and no device-change-history or .githooks files appear.
     gh pr create --base main --head docs/readme-sponsors-contributors --title "docs: recognize Breeze sponsors and contributors" --body-file /tmp/breeze-community-pr.md
 
 The PR body must summarize funding, automatic public recognition, privacy, workflow triggers, tests, and the expected sponsor empty state while GitHub reviews the listing.
-

--- a/docs/superpowers/plans/2026-07-14-readme-sponsors-contributors.md
+++ b/docs/superpowers/plans/2026-07-14-readme-sponsors-contributors.md
@@ -1,0 +1,215 @@
+# README Sponsors and Contributors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Add automatically refreshed public sponsor and human contributor galleries to the Breeze README, plus GitHub's native Sponsor button.
+
+**Architecture:** A dependency-free Node.js module owns rendering, GitHub API pagination, validation, and atomic README replacement. A scheduled/manual GitHub Actions workflow supplies the repository token, runs the module, and commits only a changed README. Stable HTML comments isolate generated content from hand-written copy.
+
+**Tech Stack:** Node.js 22 ESM, built-in fetch, node:test, GitHub GraphQL and REST APIs, GitHub Actions, Markdown/HTML.
+
+## Global Constraints
+
+- Display active public sponsors only; never query or render private sponsors, amounts, or tiers.
+- Filter GitHub bot accounts from contributors.
+- Use no runtime npm dependencies or third-party sponsor widgets/actions.
+- Build both galleries in memory and leave README.md untouched on any failure.
+- Run automation only on a daily schedule and manual dispatch with contents: write.
+- Implement on a clean docs/readme-sponsors-contributors branch.
+
+## File Map
+
+- Create .github/FUNDING.yml for GitHub's Sponsor button.
+- Create .github/scripts/update-community-readme.mjs for rendering, API access, and atomic updates.
+- Create .github/scripts/update-community-readme.test.mjs for Node tests.
+- Create .github/workflows/update-community-readme.yml for refreshes.
+- Modify README.md with support copy and generated block markers.
+
+---
+
+### Task 1: Rendering and marker safety
+
+**Files:**
+- Create: .github/scripts/update-community-readme.mjs
+- Create: .github/scripts/update-community-readme.test.mjs
+
+**Interfaces:**
+- Produces escapeHtml(value), isBot(account), renderGallery(accounts, emptyMarkdown), and replaceMarkedBlock(markdown, name, content).
+- CommunityAccount fields are login, optional name, avatarUrl, url, and optional type.
+
+- [ ] **Step 1: Write failing helper tests**
+
+Use node:test and node:assert/strict. Assert HTML escaping, Bot type and [bot] suffix handling, fixed 64px accessible avatars, empty-state output, and rejection of missing, duplicate, or reversed markers.
+
+    test('replaces exactly one marker pair', () => {
+      const source = 'before\n<!-- sponsors:start -->\nold\n<!-- sponsors:end -->\nafter\n';
+      assert.equal(
+        replaceMarkedBlock(source, 'sponsors', 'new'),
+        'before\n<!-- sponsors:start -->\nnew\n<!-- sponsors:end -->\nafter\n',
+      );
+      assert.throws(() => replaceMarkedBlock('missing', 'sponsors', 'new'), /exactly one/);
+    });
+
+- [ ] **Step 2: Verify the test fails**
+
+Run: node --test .github/scripts/update-community-readme.test.mjs
+
+Expected: ERR_MODULE_NOT_FOUND.
+
+- [ ] **Step 3: Implement pure helpers**
+
+escapeHtml must replace ampersand, angle brackets, both quote types. isBot must accept GitHub type Bot or a login ending [bot]. renderGallery must add s=128 to avatar URLs and render linked images with width, height, title, and alt attributes. replaceMarkedBlock must require exactly one ordered start/end pair and preserve everything outside it.
+
+    export function replaceMarkedBlock(markdown, name, content) {
+      const start = '<!-- ' + name + ':start -->';
+      const end = '<!-- ' + name + ':end -->';
+      if (markdown.split(start).length !== 2
+          || markdown.split(end).length !== 2
+          || markdown.indexOf(start) > markdown.indexOf(end)) {
+        throw new Error('README must contain exactly one ordered ' + name + ' marker pair');
+      }
+      return markdown.slice(0, markdown.indexOf(start))
+        + start + '\n' + content + '\n' + end
+        + markdown.slice(markdown.indexOf(end) + end.length);
+    }
+
+- [ ] **Step 4: Run and commit**
+
+Run: node --test .github/scripts/update-community-readme.test.mjs
+
+Expected: helper tests PASS.
+
+    git add .github/scripts/update-community-readme.mjs .github/scripts/update-community-readme.test.mjs
+    git commit -m "test(docs): define community gallery rendering"
+
+---
+
+### Task 2: GitHub clients and atomic update
+
+**Files:**
+- Modify: .github/scripts/update-community-readme.mjs
+- Modify: .github/scripts/update-community-readme.test.mjs
+
+**Interfaces:**
+- Produces fetchSponsors(fetchImpl, token), fetchContributors(fetchImpl, token), buildReadme(source, sponsors, contributors), and updateReadme(options).
+
+- [ ] **Step 1: Add failing API tests**
+
+Inject fetchImpl fixtures using Node's Response. Cover two-page sponsor results, includePrivate: false, activeOnly: true, null removal, case-insensitive de-duplication, alphabetical ordering, contributor pages of 100 plus a final short page, bot filtering, API failure without a write, malformed markers without a write, and a no-op second update.
+
+- [ ] **Step 2: Verify missing exports fail**
+
+Run: node --test .github/scripts/update-community-readme.test.mjs
+
+Expected: FAIL for missing API/updater exports.
+
+- [ ] **Step 3: Implement the sponsor client**
+
+Use this GraphQL connection:
+
+    organization(login: $login) {
+      sponsorshipsAsMaintainer(
+        first: 100,
+        after: $cursor,
+        activeOnly: true,
+        includePrivate: false
+      ) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          sponsorEntity {
+            ... on User { login name avatarUrl url }
+            ... on Organization { login name avatarUrl url }
+          }
+        }
+      }
+    }
+
+Send Authorization: Bearer, Accept: application/vnd.github+json, and X-GitHub-Api-Version: 2022-11-28. Reject non-2xx responses, GraphQL errors, missing organizations, and malformed connections. Never request privacyLevel, amounts, or tiers.
+
+- [ ] **Step 4: Implement contributors and atomic writes**
+
+Request GET /repos/LanternOps/breeze/contributors?anon=0&per_page=100&page=N until a page has fewer than 100 entries. Map avatar_url and html_url, preserve API order, and filter bots.
+
+Read the original README and fetch both lists before rendering. Replace sponsors then contributors in memory. When changed, write a process-specific temporary sibling and rename it over README.md; remove the temp file after errors. The CLI reads GITHUB_TOKEN, logs changed/unchanged, and exits nonzero on failure.
+
+- [ ] **Step 5: Run and commit**
+
+Run: node --test .github/scripts/update-community-readme.test.mjs
+
+Expected: all helper, API, privacy, pagination, and atomic-write tests PASS.
+
+    git add .github/scripts/update-community-readme.mjs .github/scripts/update-community-readme.test.mjs
+    git commit -m "feat(docs): automate sponsor and contributor galleries"
+
+---
+
+### Task 3: Funding, README, and workflow
+
+**Files:**
+- Create: .github/FUNDING.yml
+- Create: .github/workflows/update-community-readme.yml
+- Modify: README.md
+- Modify: .github/scripts/update-community-readme.test.mjs
+
+- [ ] **Step 1: Add a failing repository contract test**
+
+Assert funding equals github: LanternOps plus a newline; each README block has exactly one start/end marker; and the workflow contains schedule, workflow_dispatch, contents: write, and the updater command but no pull_request trigger.
+
+- [ ] **Step 2: Add funding and README content**
+
+FUNDING.yml:
+
+    github: LanternOps
+
+Before Contributing, add Support Breeze copy explaining that Breeze is free/open source and linking to https://github.com/sponsors/LanternOps. Add a Sponsors subsection with these markers and empty state:
+
+    <!-- sponsors:start -->
+    _No public sponsors yet. [Become the first sponsor →](https://github.com/sponsors/LanternOps)_
+    <!-- sponsors:end -->
+
+After Ways to Contribute, add a Contributors subsection thanking contributors and these markers:
+
+    <!-- contributors:start -->
+    _No contributors are available yet._
+    <!-- contributors:end -->
+
+- [ ] **Step 3: Add the workflow**
+
+Schedule at 17 5 * * * and allow workflow_dispatch. Grant only contents: write. Use actions/checkout@v7 and actions/setup-node@v6 with Node 22. Pass GITHUB_TOKEN from \${{ github.token }}. Run the repository script. If README differs, commit only README as github-actions[bot] with message docs: refresh sponsors and contributors [skip ci], then push HEAD:main.
+
+- [ ] **Step 4: Populate and verify**
+
+    GITHUB_TOKEN="$(gh auth token)" node .github/scripts/update-community-readme.mjs
+    node --test .github/scripts/update-community-readme.test.mjs
+    actionlint .github/workflows/update-community-readme.yml
+    ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0), aliases: true)' .github/FUNDING.yml
+    git diff --check
+
+Expected: sponsor empty state remains during GitHub review; contributors populate; tests and validators pass.
+
+- [ ] **Step 5: Commit**
+
+    git add .github/FUNDING.yml .github/workflows/update-community-readme.yml .github/scripts/update-community-readme.test.mjs README.md
+    git commit -m "docs: recognize Breeze sponsors and contributors"
+
+---
+
+### Task 4: Final verification and PR
+
+- [ ] **Step 1: Run final checks**
+
+    node --test .github/scripts/update-community-readme.test.mjs
+    actionlint .github/workflows/update-community-readme.yml
+    git diff --check
+    git status --short
+    git diff --stat origin/main...HEAD
+
+Expected: checks pass and no device-change-history or .githooks files appear.
+
+- [ ] **Step 2: Push and open the PR**
+
+    git push -u origin docs/readme-sponsors-contributors
+    gh pr create --base main --head docs/readme-sponsors-contributors --title "docs: recognize Breeze sponsors and contributors" --body-file /tmp/breeze-community-pr.md
+
+The PR body must summarize funding, automatic public recognition, privacy, workflow triggers, tests, and the expected sponsor empty state while GitHub reviews the listing.
+

--- a/docs/superpowers/specs/2026-07-14-readme-sponsors-contributors-design.md
+++ b/docs/superpowers/specs/2026-07-14-readme-sponsors-contributors-design.md
@@ -1,0 +1,100 @@
+# README Sponsors and Contributors Design
+
+## Goal
+
+Recognize the people and organizations supporting Breeze while keeping the README professional, current, and low-maintenance. GitHub Sponsors remains a voluntary way to support open-source development and is visually separate from Breeze's hosted commercial offering.
+
+## Scope
+
+This change will:
+
+- Enable GitHub's native Sponsor button for the `LanternOps` organization.
+- Add a concise sponsorship call-to-action and a public sponsor gallery to `README.md`.
+- Add an automatically maintained contributor gallery to `README.md`.
+- Add a repository-owned updater script and GitHub Actions workflow.
+
+It will not change product pricing, hosted subscriptions, sponsor tiers, application UI, or access to product features.
+
+## README Presentation
+
+Add a `Support Breeze` section near the existing `Contributing` section. Its copy will explain that Breeze is free and open source and invite self-hosters and community members to support continued development through GitHub Sponsors.
+
+The section will include a `Sponsors` gallery containing linked GitHub avatars for active public sponsors. Until the LanternOps Sponsors listing is approved and receives a public sponsor, the gallery will show a restrained invitation to become the first sponsor.
+
+Add a `Contributors` subsection within `Contributing`, after `Ways to Contribute`. It will contain linked GitHub avatars for repository contributors. Automated accounts will not be displayed.
+
+Both galleries will use HTML comments as stable replacement boundaries:
+
+```html
+<!-- sponsors:start -->
+<!-- sponsors:end -->
+
+<!-- contributors:start -->
+<!-- contributors:end -->
+```
+
+Generated avatars will include useful alternative text, fixed dimensions, and links to the corresponding GitHub profile. Sponsor ordering will be alphabetical so the README does not imply sponsorship value or disclose tiers. Contributors will retain GitHub's contribution-count ordering.
+
+The top-of-page navigation will not gain an additional sponsorship link. The native GitHub Sponsor button and the dedicated README section provide discoverability without making sponsorship part of the primary product pitch.
+
+## Native GitHub Funding Link
+
+Create `.github/FUNDING.yml` containing:
+
+```yaml
+github: LanternOps
+```
+
+GitHub will use this file to display its native Sponsor button once the LanternOps Sponsors listing is public.
+
+## Automation
+
+Create a dependency-free Node.js script under `.github/scripts/` that:
+
+1. Queries GitHub's GraphQL API for active sponsorships received by `LanternOps`, requesting public sponsorships only.
+2. Queries GitHub's REST API for all contributors to `LanternOps/breeze`, following pagination.
+3. Removes bot accounts from the contributor result.
+4. Validates and escapes all rendered profile data.
+5. Generates both README gallery blocks in memory.
+6. Replaces the marked regions only after every API request and validation step succeeds.
+7. Writes `README.md` only when its contents have changed.
+
+The script will use the workflow-provided GitHub token. It will not query private sponsorships, sponsorship amounts, tiers, or payment information.
+
+Create a GitHub Actions workflow that:
+
+- Runs on a daily schedule and through `workflow_dispatch`.
+- Uses only `contents: write` permission.
+- Does not run on pull requests or process untrusted repository content.
+- Runs the repository-owned updater script.
+- Commits and pushes only when the README changed.
+- Uses the existing `github-actions[bot]` commit identity pattern already present in the repository.
+
+The generated commit message will identify the update as documentation automation and skip redundant CI when supported.
+
+## Failure Handling
+
+API, authentication, pagination, validation, or marker errors will fail the workflow before `README.md` is written. The existing README will remain intact. Missing or duplicated marker pairs are treated as errors rather than causing broad text replacement.
+
+If the default workflow token cannot read the public organization sponsorship connection after the Sponsors listing becomes active, the workflow will report a clear authentication error. A dedicated read-only secret can then be added as a follow-up; the initial design does not introduce a long-lived personal token unnecessarily.
+
+An empty API result is valid. It renders the sponsor invitation or an empty contributor message rather than failing.
+
+## Verification
+
+Verification will cover:
+
+- Script fixture tests for public sponsors, empty sponsors, contributors, bot filtering, pagination, escaping, and malformed/missing markers.
+- A dry run against the current README using mocked GitHub API responses.
+- YAML parsing for `.github/FUNDING.yml` and the workflow.
+- A final diff check confirming only the intended README regions are changed.
+
+Because the LanternOps Sponsors listing is currently under review, live sponsor population cannot be verified until GitHub makes the listing public. The empty-state output and API behavior will be verified now.
+
+## Success Criteria
+
+- The repository exposes GitHub's native Sponsor button when the listing becomes public.
+- The README clearly distinguishes voluntary sponsorship from hosted Breeze subscriptions.
+- Active public sponsors appear automatically; private sponsors and financial details never appear.
+- New human contributors appear automatically and bots do not.
+- Routine syncs require no maintainer action and do not create commits when nothing changed.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "turbo run build",
     "lint": "turbo run lint",
     "test": "turbo run test",
+    "test:community-readme": "node --test .github/scripts/update-community-readme.test.mjs",
     "db:migrate": "turbo run db:migrate --filter=@breeze/api",
     "db:check-drift": "turbo run db:check-drift --filter=@breeze/api",
     "db:seed": "turbo run db:seed --filter=@breeze/api",


### PR DESCRIPTION
## Summary

- add GitHub's native Sponsor button for `LanternOps` and a clear Support/Sponsors section in the README
- automatically render active public sponsors and non-bot contributors with a daily/manual GitHub Actions workflow
- use a dependency-free, marker-safe, atomic README updater with focused regression coverage wired into blocking CI

## Privacy and safety

- requests active sponsorships with `includePrivate: false`
- never requests or renders sponsor amounts, tiers, or privacy fields
- validates HTTPS profile/avatar URLs, filters bots, applies request/job timeouts, and commits only `README.md`

## Verification

- `node --test .github/scripts/update-community-readme.test.mjs` — 23 passed
- `pnpm test:community-readme` — 23 passed
- updater syntax check, workflow lint, YAML parse, and `git diff --check` passed
- authenticated live updater run returned `README.md unchanged`
- full `pnpm test` is not reported green because the unchanged repository baseline currently has unrelated API test failures; the new focused suite is blocking in CI

The LanternOps GitHub Sponsors listing is still under review, so the sponsor block intentionally shows its stable empty state. It will populate automatically once GitHub exposes public sponsors.
