### PR TITLE
Security: MCP org API-key site-scope fails closed on null creator perms (SR2-15)

### DIFF
--- a/apps/api/src/routes/mcpServer.bearer.test.ts
+++ b/apps/api/src/routes/mcpServer.bearer.test.ts
@@ -39,15 +39,25 @@ vi.mock('../db', () => {
   // `.where(...)` needs to be both awaitable (for queries that don't call
   // .limit — e.g. resolvePartnerAccessibleOrgIds' org enumeration) AND
   // provide a `.limit(...)` continuation (for the membership lookup).
-  const rows = [{ partnerId: 'partner-1', orgAccess: 'all', orgIds: null, id: 'org-1' }];
+  //
+  // `roleId` is REQUIRED on the membership row: getUserPermissions returns null
+  // for a row without a usable role, and buildAuthFromApiKey now fails CLOSED on
+  // null perms (SR2-15). This row models a legitimate creator who HAS a role but
+  // NO site restriction (siteIds null → allowedSiteIds undefined → all sites),
+  // which is exactly the "unrestricted creator" these tests assert.
+  const rows = [{ partnerId: 'partner-1', orgAccess: 'all', orgIds: null, id: 'org-1', roleId: 'role-1', siteIds: null }];
   const makeWhere = () => {
     const thenable = Promise.resolve(rows) as Promise<typeof rows> & { limit: (n: number) => Promise<typeof rows> };
     thenable.limit = async () => rows;
     return thenable;
   };
+  // buildPerms resolves role→permissions via `.innerJoin(...).where(...)`, so the
+  // chain must offer innerJoin (returning a `.where` continuation) alongside the
+  // direct `.where` used by the membership/org-enumeration selects.
+  const makeFrom = () => ({ where: makeWhere, innerJoin: () => ({ where: makeWhere }) });
   return {
     db: {
-      select: () => ({ from: () => ({ where: makeWhere }) }),
+      select: () => ({ from: makeFrom }),
     },
     hasDbAccessContext: vi.fn(() => true),
     getCurrentDbAccessContext: vi.fn(() => undefined),

--- a/apps/api/src/routes/mcpServer.creatorPermsNull.test.ts
+++ b/apps/api/src/routes/mcpServer.creatorPermsNull.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { z as zod } from 'zod';
+
+// SR2-15 (core-auth-hardening) regression: an org-scoped MCP API key inherits
+// its creator's site-axis restriction via getUserPermissions(...).allowedSiteIds.
+//
+// THE FAIL-OPEN this suite pins closed: when the creator has been stripped of the
+// membership the key derives from — they're still `status='active'`, so PR 1's
+// creator-status gate passes — getUserPermissions returns **null**. The old code
+// read `creatorPerms?.allowedSiteIds`, so null collapsed to `undefined`, and
+// siteAccessCheck(undefined) means "full access to EVERY site in the org". A key
+// whose creator has NO authority got unrestricted org+site access.
+//
+// Fix: buildAuthFromApiKey returns null on null perms → buildCheckedAuthFromApiKey
+// denies with 403 (fail CLOSED). A legitimate full-access admin (non-null perms,
+// allowedSiteIds undefined) and a site-restricted creator (explicit list) are
+// unaffected.
+
+const mocks = vi.hoisted(() => ({
+  getActiveOrgTenant: vi.fn(async (_orgId: string): Promise<{ orgId: string; partnerId: string } | null> => ({
+    orgId: 'org-1',
+    partnerId: 'partner-1',
+  })),
+  // Default: a legitimate FULL-ACCESS org admin (non-null, allowedSiteIds
+  // undefined). Individual tests override with mockResolvedValueOnce.
+  getUserPermissions: vi.fn(async (_userId: string, _ctx: { partnerId?: string; orgId?: string }) => ({
+    permissions: [],
+    partnerId: null,
+    orgId: 'org-1',
+    roleId: 'role-1',
+    scope: 'organization' as const,
+    allowedSiteIds: undefined as string[] | undefined,
+  })),
+  // Capturing stub: 3rd arg is the full AuthContext handed to the RBAC gate, so
+  // we can inspect allowedSiteIds / canAccessSite. Returns null = allow.
+  checkToolPermission: vi.fn(async (
+    _toolName: string,
+    _input: unknown,
+    _auth: { allowedSiteIds?: string[]; canAccessSite: (s: string | null | undefined) => boolean },
+  ) => null),
+  executeTool: vi.fn(async () => JSON.stringify({ ok: true })),
+}));
+
+vi.mock('../services/tenantStatus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/tenantStatus')>();
+  return { ...actual, getActiveOrgTenant: mocks.getActiveOrgTenant };
+});
+
+vi.mock('../services/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/permissions')>();
+  return { ...actual, getUserPermissions: mocks.getUserPermissions };
+});
+
+vi.mock('../services/aiGuardrails', () => ({
+  checkGuardrails: () => ({ allowed: true, tier: 1 }),
+  checkToolPermission: mocks.checkToolPermission,
+  checkToolRateLimit: async () => null,
+}));
+
+vi.mock('../services/aiTools', () => ({
+  getToolDefinitions: () => [
+    { name: 'list_devices', description: 'list', inputSchema: zod.object({}).passthrough() },
+  ],
+  executeTool: mocks.executeTool,
+  getToolTier: () => 1,
+}));
+
+vi.mock('../db', () => ({
+  db: {},
+  withDbAccessContext: vi.fn((_ctx: any, fn: any) => fn()),
+  withSystemDbAccessContext: vi.fn((fn: any) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => any) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: {}, alerts: {}, scripts: {}, automations: {},
+  organizations: { id: 'organizations.id', partnerId: 'organizations.partnerId' },
+  partners: { id: 'partners.id', billingEmail: 'partners.billingEmail' },
+  partnerUsers: {}, apiKeys: {},
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+  requestLikeFromSnapshot: vi.fn(),
+}));
+vi.mock('../services/redis', () => ({ getRedis: () => null }));
+vi.mock('../services/rate-limit', () => ({
+  rateLimiter: vi.fn(async () => ({ allowed: true, resetAt: new Date(Date.now() + 60000) })),
+}));
+vi.mock('../middleware/bearerTokenAuth', () => ({
+  bearerTokenAuthMiddleware: async () => { throw new Error('should not be called without a Bearer header'); },
+  resolvePartnerAccessibleOrgIds: async () => [],
+}));
+vi.mock('./mcpExecutionOrg', () => ({
+  resolveMcpExecutionOrgId: () => 'org-1',
+  resolveMcpExecutionContext: async () => ({ orgId: 'org-1' }),
+  McpExecutionOrgError: class McpExecutionOrgError extends Error {},
+}));
+vi.mock('../services/mcpToolExecutionLedger', () => ({
+  beginMcpToolExecutionLedger: async () => ({ id: 'ledger-1' }),
+  completeMcpToolExecutionLedger: async () => undefined,
+}));
+
+function mockApiKey() {
+  vi.doMock('../middleware/apiKeyAuth', () => ({
+    apiKeyAuthMiddleware: async (c: any, next: any) => {
+      c.set('apiKey', {
+        id: 'key-1',
+        orgId: 'org-1',
+        partnerId: null,
+        name: 'test',
+        keyPrefix: 'brz_test',
+        scopes: ['ai:read'],
+        rateLimit: 1000,
+        createdBy: 'creator-user',
+      });
+      c.set('apiKeyOrgId', 'org-1');
+      await next();
+    },
+    requireApiKeyScope: () => async (_c: any, next: any) => next(),
+  }));
+}
+
+async function callListDevices() {
+  mockApiKey();
+  const mod = await import('./mcpServer');
+  return mod.mcpServerRoutes.request('/message', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'X-API-Key': 'brz_test' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'list_devices', arguments: {} },
+    }),
+  });
+}
+
+describe('MCP org-scoped key: creator perms fail closed on null (SR2-15)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.getActiveOrgTenant.mockClear();
+    mocks.getUserPermissions.mockClear();
+    mocks.checkToolPermission.mockClear();
+    mocks.executeTool.mockClear();
+    delete process.env.IS_HOSTED;
+  });
+
+  afterEach(() => {
+    vi.doUnmock('../middleware/apiKeyAuth');
+  });
+
+  it('DENIES the request (403) when getUserPermissions returns null (creator stripped of membership)', async () => {
+    // Creator is still active (PR 1 gate passes) but has NO org role and NO
+    // partner role → getUserPermissions returns null.
+    mocks.getUserPermissions.mockResolvedValueOnce(null as any);
+
+    const res = await callListDevices();
+
+    expect(res.status).toBe(403);
+    // The tool never dispatched — auth was rejected before RBAC/execution.
+    expect(mocks.checkToolPermission).not.toHaveBeenCalled();
+    expect(mocks.executeTool).not.toHaveBeenCalled();
+  });
+
+  it('a legitimate FULL-access admin (non-null perms, allowedSiteIds undefined) still gets all-site access', async () => {
+    // Default mock already models this (allowedSiteIds: undefined).
+    const res = await callListDevices();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error).toBeUndefined();
+
+    const [, , auth] = mocks.checkToolPermission.mock.calls[0] as [
+      string, unknown, { allowedSiteIds?: string[]; canAccessSite: (s: string | null | undefined) => boolean },
+    ];
+    expect(auth.allowedSiteIds).toBeUndefined();
+    // Unrestricted: every site allowed.
+    expect(auth.canAccessSite('any-site-at-all')).toBe(true);
+  });
+
+  it('a site-restricted creator keeps EXACTLY their sites (no widening)', async () => {
+    mocks.getUserPermissions.mockResolvedValueOnce({
+      permissions: [],
+      partnerId: null,
+      orgId: 'org-1',
+      roleId: 'role-1',
+      scope: 'organization',
+      allowedSiteIds: ['site-a'],
+    } as any);
+
+    const res = await callListDevices();
+
+    expect(res.status).toBe(200);
+    const [, , auth] = mocks.checkToolPermission.mock.calls[0] as [
+      string, unknown, { allowedSiteIds?: string[]; canAccessSite: (s: string | null | undefined) => boolean },
+    ];
+    expect(auth.allowedSiteIds).toEqual(['site-a']);
+    expect(auth.canAccessSite('site-a')).toBe(true);
+    expect(auth.canAccessSite('site-b')).toBe(false);
+  });
+});

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -465,6 +465,20 @@ async function buildCheckedAuthFromApiKey(
     createdBy: apiKey.createdBy,
   });
 
+  // SR2-15 fail-closed: buildAuthFromApiKey returns null when the key's creator
+  // has no resolvable authority for the owning org. Deny the request rather than
+  // fabricate an all-sites org auth context.
+  if (!auth) {
+    return c.json(
+      {
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32001, message: 'API key creator has no access to this organization' },
+      },
+      403,
+    );
+  }
+
   if (auth.scope === 'partner' && auth.partnerId) {
     let decision;
     try {
@@ -1823,7 +1837,7 @@ async function buildAuthFromApiKey(apiKey: {
   partnerId: string | null;
   name: string;
   createdBy: string;
-}): Promise<AuthContext> {
+}): Promise<AuthContext | null> {
   const user = {
     id: apiKey.createdBy,
     email: `apikey-${apiKey.name}@breeze.local`,
@@ -1853,7 +1867,25 @@ async function buildAuthFromApiKey(apiKey: {
       partnerId: partnerId || undefined,
       orgId: apiKey.orgId,
     });
-    const allowedSiteIds = creatorPerms?.allowedSiteIds;
+    // SR2-15 fail-closed: getUserPermissions returns null when the creating user
+    // has NO resolvable authority for this org — neither an organization_users
+    // role on the org NOR a partner_users role on the owning partner (e.g. a
+    // still-`active` user stripped of the membership this key derives from). We
+    // must NOT let that null collapse through the old `creatorPerms?.allowedSiteIds`
+    // into `undefined`, which siteAccessCheck() reads as "full access to EVERY
+    // site in the org" — the identical value a legitimate full-access admin gets.
+    // A key delegates its creator's authority; with none to delegate, the key has
+    // none. Reject it (buildCheckedAuthFromApiKey maps null → 403).
+    //
+    // Unaffected: a legitimate full-access admin returns a NON-null perms object
+    // whose allowedSiteIds is undefined (state 2) — still all-sites; a
+    // site-restricted creator returns a non-null object with an explicit list
+    // (state 3) — restriction preserved. A partner-admin-minted key resolves via
+    // the partner axis to a non-null object, so those keep working too.
+    if (!creatorPerms) {
+      return null;
+    }
+    const allowedSiteIds = creatorPerms.allowedSiteIds;
     return {
       user,
       token: {} as AuthContext['token'],


### PR DESCRIPTION
## The fail-open (verified against source)

`buildAuthFromApiKey` (`apps/api/src/routes/mcpServer.ts`) resolves an org-scoped MCP API key's site restriction from its creator's permissions:

```ts
const creatorPerms = await getUserPermissions(apiKey.createdBy, { partnerId, orgId: apiKey.orgId });
const allowedSiteIds = creatorPerms?.allowedSiteIds;   // <-- the bug
return { ..., canAccessSite: siteAccessCheck(allowedSiteIds) };
```

`getUserPermissions` returns **`null`** (confirmed in `services/permissions.ts` — no `organization_users` role for the org **and** no `partner_users` role on the owning partner) when the creator has **no resolvable authority** for this org. The `?.` collapsed that `null` into `undefined`, and `siteAccessCheck(undefined)` means **"full access to EVERY site in the org."** So `null` (no authority) produced the *same* value as a legitimate full-access admin — the key got unrestricted access to every site.

**Precondition:** the creating user is still `status='active'` (so PR 1's creator-status gate passes) but has been **stripped of the org/site membership** the key derives from.

## Fix — fail CLOSED

- `buildAuthFromApiKey` now **returns `null`** on null creator perms instead of fabricating an all-sites org auth context.
- `buildCheckedAuthFromApiKey` maps that `null` to a **403** (both `/message` and `/sse` dispatch sites already handle a `Response`/denied return), so the request is **rejected entirely** — the key delegates the creator's authority and there is none to delegate.

**Why full rejection (strongest option):** it closes every axis at once. There's no fabricated org context left behind, so neither the site axis (`canAccessSite`) nor the org axis (`canAccessOrg`) can be independently wide-open. Clamping `allowedSiteIds` to `[]` would have left `canAccessOrg` untouched; rejecting is cleaner and provably closes both.

**Full-access admins unaffected:** a legitimate admin returns a **non-null** perms object whose `allowedSiteIds` is `undefined` (state 2) → still all sites. A site-restricted creator (state 3) keeps exactly their list. Partner-admin-minted keys resolve via the partner axis to a non-null object and keep working (dual-axis preserved).

## Paths fixed

- **MCP path** (`routes/mcpServer.ts`): fixed (this is the vulnerable path).
- **REST path** (`middleware/apiKeyAuth.ts`): **inspected, no change needed.** It does **not** resolve site scope via `getUserPermissions` at all (no `allowedSiteIds`/`canAccessSite`), so it has no sibling `null → all-sites` hole. Left unchanged rather than inventing a fix.

## Tests (TDD + guard-bite)

New `mcpServer.creatorPermsNull.test.ts` drives the real `/message` endpoint:
- creator perms `null` → **403**, tool never dispatches (`checkToolPermission`/`executeTool` not called);
- full-access admin (non-null, `allowedSiteIds` undefined) → **200**, `canAccessSite('any')` true;
- site-restricted creator (`['site-a']`) → **200**, allows `site-a`, denies `site-b`.

**Guard-bite:** restoring the original `creatorPerms?.allowedSiteIds` line flips the null-creator test from 403 back to **200 (allowed)** — RED — while the other two stay green. Confirmed.

Also re-primed `mcpServer.bearer.test.ts`'s db shim with a `roleId` (+ `innerJoin` continuation) so its "unrestricted creator" row now yields **non-null** perms — those tests were previously green only because of the fail-open.

`pnpm exec tsc --noEmit --project apps/api/tsconfig.json` → clean.

## Relation

Relates to **SR2-15** / the **core-auth-hardening** epic. PR 5 will build the broader membership/permission-ceiling gate on top of this fail-closed baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)