### PR TITLE
ci(agent): gate Go vet + lint, race the full agent tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -805,6 +805,11 @@ jobs:
   lint-agent:
     name: Lint Agent (Go)
     runs-on: ubuntu-latest
+    # CGO off (matches test-agent): the agent's only cgo files are the linux
+    # X11/pcap capture backends, whose C headers are not on the runner. vet +
+    # lint cover the CGO-off build; the cgo backends are compiled by build-agent.
+    env:
+      CGO_ENABLED: '0'
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -831,13 +836,15 @@ jobs:
 
   # ─── Go agent race tests (broad) ──────────────────────────────────────
   # test-agent runs the suite CGO-off (no race detector). This job races the
-  # ENTIRE linux-buildable agent tree so new concurrency-heavy packages are
-  # covered automatically without a hand-maintained list (~80s locally). CGO is
-  # required by the race detector. Windows-only concurrency is covered by the
-  # agent's own windows race jobs.
+  # ENTIRE agent tree so new concurrency-heavy packages are covered
+  # automatically without a hand-maintained list (~80s). The race detector
+  # requires CGO; it runs on macOS to match the repo's only cgo agent build
+  # (build-agent darwin) — the linux agent is never cgo-built in CI, and the
+  # concurrency logic under test is platform-independent. Windows-only
+  # concurrency is covered by the agent's own windows race jobs.
   test-agent-race:
     name: Test Agent (race)
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -855,6 +862,8 @@ jobs:
 
       - name: go test -race ./...
         working-directory: agent
+        env:
+          CGO_LDFLAGS_ALLOW: '-weak_framework|ScreenCaptureKit'
         run: CGO_ENABLED=1 go test -race -count=1 ./...
 
   # ─── Windows runtime smoke (#1000) ────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -796,6 +796,67 @@ jobs:
         working-directory: agent
         run: go test -race ./internal/sessionbroker ./internal/eventlog ./internal/watchdog ./cmd/breeze-watchdog
 
+  # ─── Go agent lint ────────────────────────────────────────────────────
+  # The `lint` job above is JS/TS + compose guards only; the Go agent was
+  # never vet/lint-gated in CI (golangci-lint lived only in agent/Makefile).
+  # `go vet` is an unconditional gate (the tree is already vet-clean).
+  # golangci-lint runs in new-issues-only mode so the pre-existing backlog
+  # (incl. ~20 unformatted files) does not block PRs — burn it down separately.
+  lint-agent:
+    name: Lint Agent (Go)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: agent/go.sum
+
+      - name: go vet
+        working-directory: agent
+        run: go vet ./...
+
+      - name: golangci-lint (new issues only)
+        working-directory: agent
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+          golangci-lint run --new-from-rev="origin/${BASE_REF}" ./...
+
+  # ─── Go agent race tests (broad) ──────────────────────────────────────
+  # test-agent runs the suite CGO-off (no race detector). This job races the
+  # ENTIRE linux-buildable agent tree so new concurrency-heavy packages are
+  # covered automatically without a hand-maintained list (~80s locally). CGO is
+  # required by the race detector. Windows-only concurrency is covered by the
+  # agent's own windows race jobs.
+  test-agent-race:
+    name: Test Agent (race)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: agent/go.sum
+
+      - name: Download Go dependencies
+        working-directory: agent
+        run: go mod download
+
+      - name: go test -race ./...
+        working-directory: agent
+        run: CGO_ENABLED=1 go test -race -count=1 ./...
+
   # ─── Windows runtime smoke (#1000) ────────────────────────────────────
   # CI cross-compiles the Windows agent (build-agent matrix) but never RAN
   # it on Windows, so runtime-only Windows regressions shipped green. This

--- a/agent/.golangci.yml
+++ b/agent/.golangci.yml
@@ -1,0 +1,17 @@
+# golangci-lint config for the Breeze Go agent.
+#
+# Introduced red-safe: CI runs this with `--new-from-rev=origin/<base>` so only
+# issues on code a PR actually changes are reported. The pre-existing backlog
+# (including ~20 unformatted files on main) is NOT gated — it can be burned down
+# separately. `go vet` runs as an unconditional gate because the tree is already
+# vet-clean.
+version: "2"
+
+linters:
+  # Standard set: errcheck, govet, ineffassign, staticcheck, unused.
+  default: standard
+
+formatters:
+  # gofmt is reported (new code only via --new-from-rev); does not rewrite.
+  enable:
+    - gofmt


### PR DESCRIPTION
## What

Closes the deterministic-CI gaps for the Go agent that the recent agent work surfaced. Two new jobs + a golangci config — no product code changes.

### `lint-agent`
- **`go vet ./...`** as an unconditional gate. The tree is already vet-clean, so this is safe today and catches vet regressions going forward.
- **golangci-lint in new-issues-only mode** (`--new-from-rev=origin/<base>`). Introduced red-safe: the pre-existing lint backlog (including ~20 unformatted files on `main`) does **not** block PRs; only issues on code a PR actually changes are reported. Burn down the backlog separately.
- The existing `lint` job is JS/TS + compose guards only — the Go agent was never vet/lint-gated in CI (golangci-lint lived only in `agent/Makefile`).

### `test-agent-race`
- **`go test -race ./...`** across the whole linux-buildable agent tree (~80s locally). `test-agent` runs CGO-off, so the race detector never ran broadly. This covers new concurrency-heavy packages automatically — no hand-maintained package list to drift. Windows-only concurrency stays covered by the agent's Windows race/smoke jobs.

### `agent/.golangci.yml`
- golangci-lint v2 config: standard linters (errcheck, govet, ineffassign, staticcheck, unused) + gofmt formatter.

## Verification (local)
- `go vet ./...` → clean
- `go test -race -count=1 ./...` → **green, 81s**
- `golangci-lint config verify` → exit 0
- `golangci-lint run --new-from-rev=origin/main ./...` → **0 issues** (red-safe confirmed)
- `actionlint .github/workflows/ci.yml` → clean (the one SC2155 warning it reports is a pre-existing script, not these jobs)

## Note for reviewer
These jobs are **not** required checks until added to branch protection. To enforce them as merge gates, add **`Lint Agent (Go)`** and **`Test Agent (race)`** to the required status checks.

LLM-based review (`/code-review`, `/pr-review-toolkit:review-pr`, `/security-review`) is intentionally kept local/on-demand, not wired into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)