### PR TITLE
feat(api-keys): live creator authorization + service principals — a key cannot outlive its creator's authority (SR2-15)

### DIFF
--- a/apps/api/migrations/2026-07-19-service-principals.sql
+++ b/apps/api/migrations/2026-07-19-service-principals.sql
@@ -1,0 +1,48 @@
+-- Core auth hardening PR 5 (SR2-15): explicit, opt-in service principals so
+-- automation owned by an off-boarded human can be migrated to a first-class
+-- non-human identity instead of silently surviving on a dead human's authority.
+-- Idempotent. No inner BEGIN/COMMIT (runner wraps the file in a transaction).
+
+CREATE TABLE IF NOT EXISTS service_principals (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  name varchar(255) NOT NULL,
+  status varchar(16) NOT NULL DEFAULT 'active',
+  scopes jsonb NOT NULL DEFAULT '[]'::jsonb,
+  created_by uuid NOT NULL REFERENCES users(id),
+  last_updated_by uuid REFERENCES users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT service_principals_status_chk CHECK (status IN ('active','disabled'))
+);
+
+ALTER TABLE service_principals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE service_principals FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'service_principals'
+      AND policyname = 'service_principals_org_access'
+  ) THEN
+    CREATE POLICY service_principals_org_access ON service_principals
+      USING (breeze_has_org_access(org_id))
+      WITH CHECK (breeze_has_org_access(org_id));
+  END IF;
+END $$;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON service_principals TO breeze_app;
+
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS principal_type varchar(16) NOT NULL DEFAULT 'human';
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS principal_id uuid REFERENCES service_principals(id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'api_keys_principal_type_chk'
+  ) THEN
+    ALTER TABLE api_keys ADD CONSTRAINT api_keys_principal_type_chk
+      CHECK (principal_type IN ('human','service'));
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/apiKeyPrincipals.integration.test.ts
+++ b/apps/api/src/__tests__/integration/apiKeyPrincipals.integration.test.ts
@@ -1,0 +1,314 @@
+/**
+ * PR5 Task 6 (SR2-15) — Real-DB proof of live API-key-creator authorization
+ * against real Postgres with FORCE-RLS.
+ *
+ * This is the whole point of the PR: a human-delegated API key's authority is
+ * LIVE-bound to its creator (`middleware/apiKeyAuth.ts` + resolvers in
+ * `services/apiKeyAuthorization.ts`, wired in PR5 Tasks 1-2 and 5). That
+ * property — "membership removal / permission reduction on a REAL Postgres
+ * row kills a live key on the NEXT request" — cannot be proven against a
+ * mock: a mocked `getUserPermissions` can only ever return what the test
+ * told it to return, never what forced RLS actually filters. Everything here
+ * drives the REAL `apiKeyAuthMiddleware` end to end against real Postgres +
+ * real Redis (Redis backs the API-key rate limiter AND the permission-cache
+ * version keys the middleware's resolvers depend on for live invalidation).
+ *
+ * PRIVATE DB (the shared :5433 rig is routinely contaminated by other
+ * worktrees and its docker-compose.test.yml ships an UNSIZED tmpfs that
+ * fabricates spurious failures). Stand up private containers with a SIZED
+ * tmpfs and a genuinely unprivileged `breeze_app` role — RLS is VACUOUS
+ * under a superuser, which would make every DENY assertion below pass for
+ * the WRONG reason:
+ *
+ *   export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+ *   docker rm -f pr5-int-pg pr5-int-redis 2>/dev/null || true
+ *   docker run -d --name pr5-int-pg -e POSTGRES_USER=breeze -e POSTGRES_PASSWORD=breeze \
+ *     -e POSTGRES_DB=breeze_test -p 5457:5432 \
+ *     --tmpfs /var/lib/postgresql/data:rw,size=2g postgres:16-alpine
+ *   docker run -d --name pr5-int-redis -p 6390:6379 redis:7-alpine
+ *   until docker exec pr5-int-pg pg_isready -U breeze >/dev/null 2>&1; do sleep 1; done
+ *   docker exec pr5-int-pg psql -U breeze -d breeze_test -c \
+ *     "CREATE ROLE breeze_app LOGIN PASSWORD 'breeze';"
+ *   docker exec pr5-int-pg psql -U breeze -d breeze_test -c \
+ *     "SELECT rolsuper FROM pg_roles WHERE rolname='breeze_app';"   -- MUST print f
+ *
+ *   cd apps/api && \
+ *   DATABASE_URL=postgresql://breeze:breeze@localhost:5457/breeze_test \
+ *   DATABASE_URL_APP=postgresql://breeze_app:breeze@localhost:5457/breeze_test \
+ *   BREEZE_APP_DB_PASSWORD=breeze POSTGRES_PASSWORD=breeze REDIS_URL=redis://localhost:6390 \
+ *   pnpm vitest run --config vitest.integration.config.ts \
+ *     src/__tests__/integration/apiKeyPrincipals.integration.test.ts
+ *
+ * The integration harness (setup.ts) runs autoMigrate() off DATABASE_URL /
+ * DATABASE_URL_APP, which applies 2026-07-19-service-principals.sql
+ * automatically.
+ */
+import './setup';
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { Hono } from 'hono';
+import { createHash, randomBytes } from 'crypto';
+import { and, eq } from 'drizzle-orm';
+
+import {
+  apiKeys,
+  organizationUsers,
+  partnerUsers,
+  permissions,
+  rolePermissions,
+  servicePrincipals,
+  users,
+} from '../../db/schema';
+import { PERMISSIONS, clearPermissionCache } from '../../services/permissions';
+import {
+  createOrganization,
+  createPartner,
+  createRole,
+  createUser,
+  grantRolePermissions,
+  assignUserToOrganization,
+  assignUserToPartner,
+} from './db-utils';
+import { getTestDb } from './setup';
+
+const uniq = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+// Mirrors the private, unexported `hashApiKey` in middleware/apiKeyAuth.ts —
+// duplicated here (test-only) so seeded rows hash exactly like a real mint.
+function hashApiKey(key: string): string {
+  return createHash('sha256').update(key).digest('hex');
+}
+
+function mintRawApiKey(): string {
+  return `brz_${randomBytes(24).toString('hex')}`;
+}
+
+async function insertApiKey(opts: {
+  orgId: string;
+  createdBy: string;
+  scopes: string[];
+  status?: 'active' | 'revoked' | 'expired';
+  principalType?: 'human' | 'service';
+  principalId?: string | null;
+}): Promise<{ rawKey: string; id: string }> {
+  const rawKey = mintRawApiKey();
+  const [row] = await getTestDb()
+    .insert(apiKeys)
+    .values({
+      orgId: opts.orgId,
+      name: `test-key-${uniq()}`,
+      keyHash: hashApiKey(rawKey),
+      keyPrefix: rawKey.slice(0, 12),
+      scopes: opts.scopes,
+      createdBy: opts.createdBy,
+      status: opts.status ?? 'active',
+      principalType: opts.principalType ?? 'human',
+      principalId: opts.principalId ?? null,
+    })
+    .returning();
+  return { rawKey, id: row!.id };
+}
+
+async function insertServicePrincipal(opts: {
+  orgId: string;
+  createdBy: string;
+  scopes: string[];
+  status?: 'active' | 'disabled';
+}) {
+  const [row] = await getTestDb()
+    .insert(servicePrincipals)
+    .values({
+      orgId: opts.orgId,
+      name: `svc-principal-${uniq()}`,
+      status: opts.status ?? 'active',
+      scopes: opts.scopes,
+      createdBy: opts.createdBy,
+    })
+    .returning();
+  return row!;
+}
+
+async function setPrincipalStatus(principalId: string, status: 'active' | 'disabled') {
+  await getTestDb().update(servicePrincipals).set({ status, updatedAt: new Date() }).where(eq(servicePrincipals.id, principalId));
+}
+
+async function setUserStatus(userId: string, status: 'active' | 'invited' | 'disabled') {
+  await getTestDb().update(users).set({ status, updatedAt: new Date() }).where(eq(users.id, userId));
+}
+
+// Revokes ONE resource:action grant from a role by deleting its
+// role_permissions row directly — the same DB-level effect a real
+// role-permissions PATCH route produces. clearPermissionCache(userId) below
+// mirrors the production call every such route makes afterward
+// (routes/roles.ts, routes/users.ts) — required because getUserPermissions
+// is Redis-version-cached; a raw DB mutation alone does not bump the version
+// key, so a live key would otherwise keep reading the pre-mutation cache
+// entry for up to 5 minutes.
+async function revokeRolePermission(roleId: string, resource: string, action: string) {
+  const [perm] = await getTestDb()
+    .select({ id: permissions.id })
+    .from(permissions)
+    .where(and(eq(permissions.resource, resource), eq(permissions.action, action)))
+    .limit(1);
+  if (!perm) throw new Error(`permission ${resource}:${action} not seeded`);
+  await getTestDb()
+    .delete(rolePermissions)
+    .where(and(eq(rolePermissions.roleId, roleId), eq(rolePermissions.permissionId, perm.id)));
+}
+
+// ---------------------------------------------------------------------------
+// App bootstrap: mount the REAL apiKeyAuthMiddleware on a throwaway route.
+// The middleware itself is the thing under test; the route handler only
+// echoes back what the middleware resolved so assertions can inspect it.
+// ---------------------------------------------------------------------------
+let app: Hono;
+
+beforeAll(async () => {
+  const { Hono: HonoCtor } = await import('hono');
+  const { apiKeyAuthMiddleware } = await import('../../middleware/apiKeyAuth');
+  app = new HonoCtor();
+  app.get('/keytest/protected', apiKeyAuthMiddleware, (c) => {
+    const apiKey = c.get('apiKey');
+    return c.json({ ok: true, scopes: apiKey.scopes, orgId: c.get('apiKeyOrgId') });
+  });
+});
+
+function callWithKey(rawKey: string) {
+  return app.request('/keytest/protected', { headers: { 'X-API-Key': rawKey } });
+}
+
+describe('SR2-15 real-DB API key principal authorization', () => {
+  it('scenario 1: membership removal kills the key (GUARD-BITE — the core SR2-15 property)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const creator = await createUser({ partnerId: partner.id, orgId: org.id, status: 'active' });
+
+    const role = await createRole({ scope: 'organization', orgId: org.id, partnerId: partner.id });
+    await grantRolePermissions(role.id, [{ resource: PERMISSIONS.DEVICES_READ.resource, action: PERMISSIONS.DEVICES_READ.action }]);
+    const membership = await assignUserToOrganization(creator.id, org.id, role.id);
+
+    const { rawKey } = await insertApiKey({ orgId: org.id, createdBy: creator.id, scopes: ['devices:read'] });
+
+    const before = await callWithKey(rawKey);
+    expect(before.status).toBe(200);
+
+    // Off-boarding: the creator's organization_users row is removed by some
+    // out-of-band SQL (or a real removal route) — no app call is made
+    // through apiKeyAuth's own resolver.
+    await getTestDb().delete(organizationUsers).where(eq(organizationUsers.id, membership.id));
+    // Mirrors the invalidation a real membership-removal route performs
+    // (routes/users.ts's runPostCommitCleanup -> clearPermissionCache).
+    await clearPermissionCache(creator.id);
+
+    const after = await callWithKey(rawKey);
+    expect(after.status).toBe(401);
+  });
+
+  it('scenario 2: partner-axis creator (no org row) authorizes via the partner axis; removing partner_users DENIES', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    // MSP staff: partner_id set, org_id null — NO organization_users row will
+    // ever exist for this creator.
+    const creator = await createUser({ partnerId: partner.id, orgId: null, status: 'active' });
+
+    const role = await createRole({ scope: 'partner', partnerId: partner.id });
+    await grantRolePermissions(role.id, [{ resource: PERMISSIONS.DEVICES_READ.resource, action: PERMISSIONS.DEVICES_READ.action }]);
+    const membership = await assignUserToPartner(creator.id, partner.id, role.id, 'all');
+
+    // The key itself is ORG-scoped (a manual key minted against org).
+    const { rawKey } = await insertApiKey({ orgId: org.id, createdBy: creator.id, scopes: ['devices:read'] });
+
+    const before = await callWithKey(rawKey);
+    // A resolver that only checked the org axis (no organization_users row
+    // exists) would falsely DENY here — proving the dual-axis pass (Q5).
+    expect(before.status).toBe(200);
+
+    await getTestDb().delete(partnerUsers).where(eq(partnerUsers.id, membership.id));
+    await clearPermissionCache(creator.id);
+
+    const after = await callWithKey(rawKey);
+    expect(after.status).toBe(401);
+  });
+
+  it('scenario 3: a permission reduction between mint and request re-clamps — a devices:write key DENIES while devices:read still works', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const creator = await createUser({ partnerId: partner.id, orgId: org.id, status: 'active' });
+
+    const role = await createRole({ scope: 'organization', orgId: org.id, partnerId: partner.id });
+    await grantRolePermissions(role.id, [
+      { resource: PERMISSIONS.DEVICES_READ.resource, action: PERMISSIONS.DEVICES_READ.action },
+      { resource: PERMISSIONS.DEVICES_WRITE.resource, action: PERMISSIONS.DEVICES_WRITE.action },
+    ]);
+    await assignUserToOrganization(creator.id, org.id, role.id);
+
+    const readKey = await insertApiKey({ orgId: org.id, createdBy: creator.id, scopes: ['devices:read'] });
+    const writeKey = await insertApiKey({ orgId: org.id, createdBy: creator.id, scopes: ['devices:write'] });
+
+    expect((await callWithKey(readKey.rawKey)).status).toBe(200);
+    expect((await callWithKey(writeKey.rawKey)).status).toBe(200);
+
+    // Role downgraded: the creator's role loses devices:write between mint
+    // and this request. No app-service call touched the key or the role
+    // assignment — only the underlying grant.
+    await revokeRolePermission(role.id, PERMISSIONS.DEVICES_WRITE.resource, PERMISSIONS.DEVICES_WRITE.action);
+    await clearPermissionCache(creator.id);
+
+    // The write-scoped key can no longer be delegated by its creator's
+    // CURRENT permissions — a permission reduction after mint cannot be
+    // out-run by a key minted while the creator was more powerful.
+    expect((await callWithKey(writeKey.rawKey)).status).toBe(401);
+    // The read-scoped key is unaffected — the creator still holds devices:read.
+    expect((await callWithKey(readKey.rawKey)).status).toBe(200);
+  });
+
+  it('scenario 4: fail-closed — a creator with NO visible membership row (neither axis) DENIES rather than authorizing', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    // Active user, but zero rows in organization_users AND zero rows in
+    // partner_users — a genuinely membership-less creator. This must never
+    // be read as "no restrictions apply" / "unrestricted" — a 0-row read on
+    // either axis must fail closed.
+    const creator = await createUser({ partnerId: partner.id, orgId: org.id, status: 'active' });
+
+    const { rawKey } = await insertApiKey({ orgId: org.id, createdBy: creator.id, scopes: ['devices:read'] });
+
+    const res = await callWithKey(rawKey);
+    expect(res.status).toBe(401);
+  });
+
+  it('scenario 5: service-principal lifecycle — active+covers authorizes, disabled DENIES, unaffected by creator off-boarding', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    // The human who created the principal — the whole point of a service
+    // principal is that ITS authority does not depend on this human staying
+    // active.
+    const humanCreator = await createUser({ partnerId: partner.id, orgId: org.id, status: 'active' });
+
+    const principal = await insertServicePrincipal({
+      orgId: org.id,
+      createdBy: humanCreator.id,
+      scopes: ['devices:read'],
+      status: 'active',
+    });
+    const { rawKey } = await insertApiKey({
+      orgId: org.id,
+      createdBy: humanCreator.id,
+      scopes: ['devices:read'],
+      principalType: 'service',
+      principalId: principal.id,
+    });
+
+    // Active principal, scopes covered by the principal's own ceiling -> authorizes.
+    expect((await callWithKey(rawKey)).status).toBe(200);
+
+    // Off-board the HUMAN creator. A service-principal key's authority does
+    // not derive from a human's live permissions, so this must NOT affect it.
+    await setUserStatus(humanCreator.id, 'disabled');
+    expect((await callWithKey(rawKey)).status).toBe(200);
+
+    // Disable the PRINCIPAL itself -> the disable-cascade gate denies.
+    await setPrincipalStatus(principal.id, 'disabled');
+    expect((await callWithKey(rawKey)).status).toBe(401);
+  });
+});

--- a/apps/api/src/db/schema/apiKeys.ts
+++ b/apps/api/src/db/schema/apiKeys.ts
@@ -1,6 +1,7 @@
 import { pgTable, uuid, varchar, text, timestamp, integer, jsonb, pgEnum } from 'drizzle-orm/pg-core';
 import { organizations } from './orgs';
 import { users } from './users';
+import { servicePrincipals } from './servicePrincipals';
 
 export const apiKeyStatusEnum = pgEnum('api_key_status', ['active', 'revoked', 'expired']);
 
@@ -20,4 +21,7 @@ export const apiKeys = pgTable('api_keys', {
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
   status: apiKeyStatusEnum('status').notNull().default('active'),
   source: text('source').notNull().default('manual'),
+  // 'human' | 'service' — non-human keys carry principalId (SR2-15).
+  principalType: varchar('principal_type', { length: 16 }).notNull().default('human'),
+  principalId: uuid('principal_id').references(() => servicePrincipals.id),
 });

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -104,3 +104,4 @@ export * from './vulnerabilityManagement';
 export * from './partnerLoginBranding';
 export * from './recoveryKeys';
 export * from './abuseSignals';
+export * from './servicePrincipals';

--- a/apps/api/src/db/schema/servicePrincipals.test.ts
+++ b/apps/api/src/db/schema/servicePrincipals.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { servicePrincipals } from './servicePrincipals';
+import { apiKeys } from './apiKeys';
+
+describe('servicePrincipals schema', () => {
+  it('exposes the org-owned identity columns (SR2-15)', () => {
+    expect(servicePrincipals.orgId).toBeDefined();
+    expect(servicePrincipals.status).toBeDefined();
+    expect(servicePrincipals.scopes).toBeDefined();
+  });
+
+  it('defaults status to active and scopes to an empty array', () => {
+    expect(servicePrincipals.status.default).toBe('active');
+    expect(servicePrincipals.scopes.default).toEqual([]);
+  });
+
+  it('carries audit columns for who created/last-updated it', () => {
+    expect(servicePrincipals.createdBy).toBeDefined();
+    expect(servicePrincipals.lastUpdatedBy).toBeDefined();
+  });
+});
+
+describe('apiKeys schema principal columns (SR2-15)', () => {
+  it('exposes principalType defaulting to human, and a nullable principalId', () => {
+    expect(apiKeys.principalType).toBeDefined();
+    expect(apiKeys.principalType.default).toBe('human');
+    expect(apiKeys.principalId).toBeDefined();
+    expect(apiKeys.principalId.notNull).toBe(false);
+  });
+});

--- a/apps/api/src/db/schema/servicePrincipals.ts
+++ b/apps/api/src/db/schema/servicePrincipals.ts
@@ -1,0 +1,20 @@
+import { pgTable, uuid, varchar, jsonb, timestamp } from 'drizzle-orm/pg-core';
+import { organizations } from './orgs';
+import { users } from './users';
+
+// Opt-in, first-class non-human identity (SR2-15). Org-owned (RLS shape-1):
+// `service_principals_org_access` policy in 2026-07-19-service-principals.sql
+// enforces `breeze_has_org_access(org_id)` for all four commands.
+export const servicePrincipals = pgTable('service_principals', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  name: varchar('name', { length: 255 }).notNull(),
+  // Plain varchar + CHECK (not pgEnum) to match the migration's
+  // `service_principals_status_chk CHECK (status IN ('active','disabled'))`.
+  status: varchar('status', { length: 16 }).notNull().default('active'),
+  scopes: jsonb('scopes').$type<string[]>().notNull().default([]),
+  createdBy: uuid('created_by').notNull().references(() => users.id),
+  lastUpdatedBy: uuid('last_updated_by').references(() => users.id),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -62,6 +62,7 @@ import { searchRoutes } from './routes/search';
 import { logsRoutes } from './routes/logs';
 import { remoteRoutes } from './routes/remote';
 import { apiKeyRoutes } from './routes/apiKeys';
+import { servicePrincipalRoutes } from './routes/servicePrincipals';
 import { enrollmentKeyRoutes, publicEnrollmentRoutes, publicShortLinkRoutes } from './routes/enrollmentKeys';
 import { installerRoutes } from './routes/installer';
 import { ssoRoutes } from './routes/sso';
@@ -830,6 +831,7 @@ api.route('/vnc-exchange', vncExchangeRoutes); // No auth — one-time code is t
 api.route('/vnc-viewer', vncViewerRoutes); // Viewer-token auth (purpose='viewer', scoped to a tunnel sessionId)
 api.route('/remote', remoteRoutes);
 api.route('/api-keys', apiKeyRoutes);
+api.route('/service-principals', servicePrincipalRoutes);
 api.route('/enrollment-keys', publicEnrollmentRoutes); // Public download (no auth) — must precede auth-protected routes
 api.route('/enrollment-keys', enrollmentKeyRoutes);
 api.route('/installer', installerRoutes);

--- a/apps/api/src/middleware/apiKeyAuth.test.ts
+++ b/apps/api/src/middleware/apiKeyAuth.test.ts
@@ -40,6 +40,10 @@ vi.mock('../services/tenantStatus', () => ({
   getActiveOrgTenant: vi.fn().mockResolvedValue({ orgId: 'org-1', partnerId: 'partner-1' })
 }));
 
+vi.mock('../services/apiKeyAuthorization', () => ({
+  authorizeHumanApiKeyCreator: vi.fn()
+}));
+
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn((left, right) => ({ left, right })),
   and: vi.fn()
@@ -49,6 +53,7 @@ import type { Context } from 'hono';
 import { db, withDbAccessContext } from '../db';
 import { getRedis, rateLimiter } from '../services';
 import { getActiveOrgTenant } from '../services/tenantStatus';
+import { authorizeHumanApiKeyCreator } from '../services/apiKeyAuthorization';
 import * as apiKeyAuthModule from './apiKeyAuth';
 
 const { apiKeyAuthMiddleware, requireApiKeyScope } = apiKeyAuthModule;
@@ -114,6 +119,12 @@ describe('apiKeyAuth middleware', () => {
       allowed: true,
       remaining: 299,
       resetAt: new Date(Date.now() + 60_000)
+    });
+    vi.mocked(authorizeHumanApiKeyCreator).mockResolvedValue({
+      ok: true,
+      permissions: {} as any,
+      allowedSiteIds: undefined,
+      clampedScopes: ['devices:read']
     });
   });
 
@@ -495,7 +506,10 @@ describe('apiKeyAuth middleware', () => {
       id: 'key-4',
       orgId: 'org-2',
       partnerId: null,
-      scopes: ['read'],
+      // SR2-15: context scopes are the LIVE-clamped output of
+      // authorizeHumanApiKeyCreator (mocked to ['devices:read'] by the
+      // beforeEach default), not the raw stored key scope (['read']).
+      scopes: ['devices:read'],
       rateLimit: 5,
       createdBy: 'user-2'
     });
@@ -614,6 +628,56 @@ describe('apiKeyAuth middleware', () => {
     // api_keys lookup + creator-status lookup — owner status is delegated to
     // tenantStatus, so no third select happens for that.
     expect(db.select).toHaveBeenCalledTimes(2);
+  });
+
+  describe('SR2-15: live creator membership + permission-ceiling', () => {
+    it('rejects with 401 when the creator has lost tenant membership', async () => {
+      buildSequentialSelectMock([
+        [{ id: 'key-1', orgId: 'org-1', name: 'k', keyPrefix: 'brz_x', keyHash: 'h', scopes: ['devices:read'], expiresAt: null, rateLimit: 1000, usageCount: 0, status: 'active', createdBy: 'user-1', source: 'manual' }],
+        [{ status: 'active' }],   // creator status still active (PR1 check passes)…
+      ]);
+      vi.mocked(authorizeHumanApiKeyCreator).mockResolvedValue({ ok: false, reason: 'no_membership' });
+      const c = createContext({ 'X-API-Key': 'brz_membership_gone' });
+      const next = vi.fn();
+      await expect(apiKeyAuthMiddleware(c, next)).rejects.toMatchObject({ status: 401 });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('rejects with 401 when the creator no longer holds a stored scope (permission reduction)', async () => {
+      buildSequentialSelectMock([
+        [{ id: 'key-1', orgId: 'org-1', name: 'k', keyPrefix: 'brz_x', keyHash: 'h', scopes: ['devices:read', 'devices:write'], expiresAt: null, rateLimit: 1000, usageCount: 0, status: 'active', createdBy: 'user-1', source: 'manual' }],
+        [{ status: 'active' }],
+      ]);
+      vi.mocked(authorizeHumanApiKeyCreator).mockResolvedValue({ ok: false, reason: 'scope_exceeds_current_permissions' });
+      const c = createContext({ 'X-API-Key': 'brz_perm_reduced' });
+      await expect(apiKeyAuthMiddleware(c, vi.fn())).rejects.toMatchObject({ status: 401 });
+    });
+
+    it('passes the org AND the org-owning partner to the resolver (partner-axis keys)', async () => {
+      buildSequentialSelectMock([
+        [{ id: 'key-1', orgId: 'org-1', name: 'k', keyPrefix: 'brz_x', keyHash: 'h', scopes: ['devices:read'], expiresAt: null, rateLimit: 1000, usageCount: 0, status: 'active', createdBy: 'user-1', source: 'manual' }],
+        [{ status: 'active' }],
+      ]);
+      const next = vi.fn();
+      await apiKeyAuthMiddleware(createContext({ 'X-API-Key': 'brz_ok' }), next);
+      expect(authorizeHumanApiKeyCreator).toHaveBeenCalledWith(
+        expect.objectContaining({ createdBy: 'user-1', orgId: 'org-1', partnerId: 'partner-1', scopes: ['devices:read'] }),
+      );
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('carries the LIVE-clamped scopes and allowedSiteIds into the request context', async () => {
+      buildSequentialSelectMock([
+        [{ id: 'key-1', orgId: 'org-1', name: 'k', keyPrefix: 'brz_x', keyHash: 'h', scopes: ['devices:read', 'devices:write'], expiresAt: null, rateLimit: 1000, usageCount: 0, status: 'active', createdBy: 'user-1', source: 'manual' }],
+        [{ status: 'active' }],
+      ]);
+      vi.mocked(authorizeHumanApiKeyCreator).mockResolvedValue({ ok: true, permissions: {} as any, allowedSiteIds: ['site-a'], clampedScopes: ['devices:read'] });
+      const c = createContext({ 'X-API-Key': 'brz_ok' });
+      await apiKeyAuthMiddleware(c, vi.fn());
+      const ctxKey = c.get('apiKey') as any;
+      expect(ctxKey.scopes).toEqual(['devices:read']);       // clamped, not the stored two
+      expect(ctxKey.allowedSiteIds).toEqual(['site-a']);
+    });
   });
 });
 

--- a/apps/api/src/middleware/apiKeyAuth.test.ts
+++ b/apps/api/src/middleware/apiKeyAuth.test.ts
@@ -41,7 +41,8 @@ vi.mock('../services/tenantStatus', () => ({
 }));
 
 vi.mock('../services/apiKeyAuthorization', () => ({
-  authorizeHumanApiKeyCreator: vi.fn()
+  authorizeHumanApiKeyCreator: vi.fn(),
+  authorizeServicePrincipalKey: vi.fn()
 }));
 
 vi.mock('drizzle-orm', () => ({
@@ -53,7 +54,7 @@ import type { Context } from 'hono';
 import { db, withDbAccessContext } from '../db';
 import { getRedis, rateLimiter } from '../services';
 import { getActiveOrgTenant } from '../services/tenantStatus';
-import { authorizeHumanApiKeyCreator } from '../services/apiKeyAuthorization';
+import { authorizeHumanApiKeyCreator, authorizeServicePrincipalKey } from '../services/apiKeyAuthorization';
 import * as apiKeyAuthModule from './apiKeyAuth';
 
 const { apiKeyAuthMiddleware, requireApiKeyScope } = apiKeyAuthModule;
@@ -677,6 +678,119 @@ describe('apiKeyAuth middleware', () => {
       const ctxKey = c.get('apiKey') as any;
       expect(ctxKey.scopes).toEqual(['devices:read']);       // clamped, not the stored two
       expect(ctxKey.allowedSiteIds).toEqual(['site-a']);
+    });
+  });
+
+  describe('SR2-15: service-principal keys branch on principalType', () => {
+    it('calls authorizeServicePrincipalKey (not the human resolver) and skips the creator-status lookup for a service key', async () => {
+      // Only ONE select (the api_keys row) — no second creator-status select,
+      // since a service-principal key has no human "creator active" gate.
+      buildSelectMock([
+        {
+          id: 'key-svc',
+          orgId: 'org-1',
+          name: 'CI bot key',
+          keyPrefix: 'brz_svc',
+          keyHash: 'h',
+          scopes: ['ai:read'],
+          expiresAt: null,
+          rateLimit: 1000,
+          usageCount: 0,
+          status: 'active',
+          createdBy: 'user-1',
+          source: 'manual',
+          principalType: 'service',
+          principalId: 'principal-1'
+        }
+      ]);
+      vi.mocked(authorizeServicePrincipalKey).mockResolvedValue({
+        ok: true,
+        permissions: null,
+        allowedSiteIds: undefined,
+        clampedScopes: ['ai:read']
+      });
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) })
+      } as any);
+
+      const c = createContext({ 'X-API-Key': 'brz_service' });
+      const next = vi.fn();
+      await apiKeyAuthMiddleware(c, next);
+
+      expect(authorizeServicePrincipalKey).toHaveBeenCalledWith({ principalId: 'principal-1', scopes: ['ai:read'] });
+      expect(authorizeHumanApiKeyCreator).not.toHaveBeenCalled();
+      expect(db.select).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalled();
+
+      const ctxKey = c.get('apiKey') as any;
+      expect(ctxKey.principalType).toBe('service');
+      expect(ctxKey.principalId).toBe('principal-1');
+      expect(ctxKey.scopes).toEqual(['ai:read']);
+    });
+
+    it('rejects with 401 when authorizeServicePrincipalKey denies (disabled principal / fail-closed / scope exceeded)', async () => {
+      buildSelectMock([
+        {
+          id: 'key-svc-2',
+          orgId: 'org-1',
+          name: 'CI bot key',
+          keyPrefix: 'brz_svc',
+          keyHash: 'h',
+          scopes: ['ai:read'],
+          expiresAt: null,
+          rateLimit: 1000,
+          usageCount: 0,
+          status: 'active',
+          createdBy: 'user-1',
+          source: 'manual',
+          principalType: 'service',
+          principalId: 'principal-disabled'
+        }
+      ]);
+      vi.mocked(authorizeServicePrincipalKey).mockResolvedValue({ ok: false, reason: 'no_membership' });
+
+      const c = createContext({ 'X-API-Key': 'brz_service_denied' });
+      const next = vi.fn();
+
+      await expect(apiKeyAuthMiddleware(c, next)).rejects.toMatchObject({ status: 401 });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('still runs the human creator-status + authorizeHumanApiKeyCreator path when principalType is the human default', async () => {
+      // Regression guard for the scope-freeze requirement: a human key
+      // (principalType 'human' or absent) must behave EXACTLY as before —
+      // creator-status select still runs, authorizeServicePrincipalKey is
+      // never invoked.
+      buildSequentialSelectMock([
+        [
+          {
+            id: 'key-human',
+            orgId: 'org-1',
+            name: 'k',
+            keyPrefix: 'brz_x',
+            keyHash: 'h',
+            scopes: ['devices:read'],
+            expiresAt: null,
+            rateLimit: 1000,
+            usageCount: 0,
+            status: 'active',
+            createdBy: 'user-1',
+            source: 'manual',
+            principalType: 'human',
+            principalId: null
+          }
+        ],
+        [{ status: 'active' }]
+      ]);
+
+      const c = createContext({ 'X-API-Key': 'brz_human' });
+      const next = vi.fn();
+      await apiKeyAuthMiddleware(c, next);
+
+      expect(authorizeHumanApiKeyCreator).toHaveBeenCalled();
+      expect(authorizeServicePrincipalKey).not.toHaveBeenCalled();
+      expect(db.select).toHaveBeenCalledTimes(2);
+      expect(next).toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/middleware/apiKeyAuth.ts
+++ b/apps/api/src/middleware/apiKeyAuth.ts
@@ -7,7 +7,7 @@ import { apiKeys, users } from '../db/schema';
 import { getRedis, rateLimiter } from '../services';
 import { getActiveOrgTenant } from '../services/tenantStatus';
 import { getTrustedClientIp } from '../services/clientIp';
-import { authorizeHumanApiKeyCreator } from '../services/apiKeyAuthorization';
+import { authorizeHumanApiKeyCreator, authorizeServicePrincipalKey } from '../services/apiKeyAuthorization';
 
 export interface ApiKeyContext {
   apiKey: {
@@ -20,6 +20,11 @@ export interface ApiKeyContext {
     rateLimit: number;
     createdBy: string;
     allowedSiteIds?: string[];
+    // SR2-15: 'human' (default) | 'service'. Service-principal keys carry a
+    // non-null principalId and are authorized against the PRINCIPAL, never
+    // a human creator's permissions.
+    principalType?: string;
+    principalId?: string | null;
   };
   orgId: string;
 }
@@ -112,7 +117,9 @@ export async function apiKeyAuthMiddleware(c: Context, next: Next) {
         usageCount: apiKeys.usageCount,
         status: apiKeys.status,
         createdBy: apiKeys.createdBy,
-        source: apiKeys.source
+        source: apiKeys.source,
+        principalType: apiKeys.principalType,
+        principalId: apiKeys.principalId
       })
       .from(apiKeys)
       .where(eq(apiKeys.keyHash, keyHash))
@@ -147,21 +154,33 @@ export async function apiKeyAuthMiddleware(c: Context, next: Next) {
     throw new HTTPException(401, { message: 'API key owner is not active' });
   }
 
-  // SR2-15 (PR 1 subset): a delegated human API key must not outlive its
-  // creator's active status. The full membership/permission-ceiling resolver
-  // and service principals land in PR 5; here we fail closed on a
-  // disabled/absent creator. (The MCP path's fail-OPEN null-perms bug is fixed
-  // in PR 5 — do not build on that behavior.)
-  const creator = await withSystemDbAccessContext(async () => {
-    const [row] = await db
-      .select({ status: users.status })
-      .from(users)
-      .where(eq(users.id, apiKey.createdBy))
-      .limit(1);
-    return row ?? null;
-  });
-  if (!creator || creator.status !== 'active') {
-    throw new HTTPException(401, { message: 'API key creator is not active' });
+  // SR2-15 (PR 5): service-principal keys (principalType === 'service') skip
+  // the human creator-status/liveness checks entirely — they are authorized
+  // against the PRINCIPAL, not a human. A service principal has no
+  // interactive login, so there is no "creator active" status to check; its
+  // liveness gate is the principal's own `status` column (see
+  // authorizeServicePrincipalKey). Human keys (the default, principalType
+  // undefined or 'human') take the existing creator-status + live-permission
+  // path below, unchanged.
+  const isServicePrincipalKey = apiKey.principalType === 'service' && !!apiKey.principalId;
+
+  if (!isServicePrincipalKey) {
+    // SR2-15 (PR 1 subset): a delegated human API key must not outlive its
+    // creator's active status. The full membership/permission-ceiling resolver
+    // and service principals land in PR 5; here we fail closed on a
+    // disabled/absent creator. (The MCP path's fail-OPEN null-perms bug is fixed
+    // in PR 5 — do not build on that behavior.)
+    const creator = await withSystemDbAccessContext(async () => {
+      const [row] = await db
+        .select({ status: users.status })
+        .from(users)
+        .where(eq(users.id, apiKey.createdBy))
+        .limit(1);
+      return row ?? null;
+    });
+    if (!creator || creator.status !== 'active') {
+      throw new HTTPException(401, { message: 'API key creator is not active' });
+    }
   }
 
   // SR2-15 (PR 5): a human-delegated key's authority is LIVE-bound to its
@@ -175,12 +194,21 @@ export async function apiKeyAuthMiddleware(c: Context, next: Next) {
   // getUserPermissions call (Redis-version-cached, 5-min TTL — a cache hit is an
   // mget + in-proc lookup, no Postgres round-trip) to the hot path; correctness
   // over cost per the PR 5 plan (Q1: live re-resolution, not an epoch).
-  const authz = await authorizeHumanApiKeyCreator({
-    createdBy: apiKey.createdBy,
-    orgId: apiKey.orgId,
-    partnerId: ownerTenant.partnerId,
-    scopes: apiKey.scopes ?? [],
-  });
+  //
+  // A service-principal key branches to authorizeServicePrincipalKey instead:
+  // it re-clamps against the PRINCIPAL's own current scopes (never a human's
+  // permissions) and denies on a disabled/missing principal.
+  const authz = isServicePrincipalKey
+    ? await authorizeServicePrincipalKey({
+        principalId: apiKey.principalId as string,
+        scopes: apiKey.scopes ?? [],
+      })
+    : await authorizeHumanApiKeyCreator({
+        createdBy: apiKey.createdBy,
+        orgId: apiKey.orgId,
+        partnerId: ownerTenant.partnerId,
+        scopes: apiKey.scopes ?? [],
+      });
   if (!authz.ok) {
     throw new HTTPException(401, { message: 'API key creator is no longer authorized' });
   }
@@ -249,6 +277,11 @@ export async function apiKeyAuthMiddleware(c: Context, next: Next) {
     allowedSiteIds: authz.allowedSiteIds,
     rateLimit: apiKey.rateLimit,
     createdBy: apiKey.createdBy,
+    // SR2-15: threaded through so the MCP path (mcpServer.ts's
+    // buildAuthFromApiKey, which reads this same c.get('apiKey')) can branch
+    // on principal type too, without a second DB read.
+    principalType: apiKey.principalType,
+    principalId: apiKey.principalId,
   });
   c.set('apiKeyOrgId', apiKey.orgId);
 

--- a/apps/api/src/middleware/apiKeyAuth.ts
+++ b/apps/api/src/middleware/apiKeyAuth.ts
@@ -7,6 +7,7 @@ import { apiKeys, users } from '../db/schema';
 import { getRedis, rateLimiter } from '../services';
 import { getActiveOrgTenant } from '../services/tenantStatus';
 import { getTrustedClientIp } from '../services/clientIp';
+import { authorizeHumanApiKeyCreator } from '../services/apiKeyAuthorization';
 
 export interface ApiKeyContext {
   apiKey: {
@@ -18,6 +19,7 @@ export interface ApiKeyContext {
     scopes: string[];
     rateLimit: number;
     createdBy: string;
+    allowedSiteIds?: string[];
   };
   orgId: string;
 }
@@ -162,6 +164,27 @@ export async function apiKeyAuthMiddleware(c: Context, next: Next) {
     throw new HTTPException(401, { message: 'API key creator is not active' });
   }
 
+  // SR2-15 (PR 5): a human-delegated key's authority is LIVE-bound to its
+  // creator. Beyond the status check above, the creator must (a) still hold a
+  // membership/role on this key's tenant (off-boarding gate) and (b) not have
+  // had their permissions reduced below the key's stored scopes since mint.
+  // We resolve the creator's CURRENT permissions on BOTH axes (org + the org's
+  // owning partner, since a Partner Admin has no organization_users row) and
+  // re-clamp. FAIL CLOSED: the resolver returns ok:false for a null/errored
+  // permission read, and we reject before opening the org context. This adds one
+  // getUserPermissions call (Redis-version-cached, 5-min TTL — a cache hit is an
+  // mget + in-proc lookup, no Postgres round-trip) to the hot path; correctness
+  // over cost per the PR 5 plan (Q1: live re-resolution, not an epoch).
+  const authz = await authorizeHumanApiKeyCreator({
+    createdBy: apiKey.createdBy,
+    orgId: apiKey.orgId,
+    partnerId: ownerTenant.partnerId,
+    scopes: apiKey.scopes ?? [],
+  });
+  if (!authz.ok) {
+    throw new HTTPException(401, { message: 'API key creator is no longer authorized' });
+  }
+
   // Check rate limits (requests per hour)
   const redis = getRedis();
   const rateLimitKey = `api_key_rate:${apiKey.id}`;
@@ -222,7 +245,8 @@ export async function apiKeyAuthMiddleware(c: Context, next: Next) {
     partnerId: resolvedPartnerId,
     name: apiKey.name,
     keyPrefix: apiKey.keyPrefix,
-    scopes: apiKey.scopes || [],
+    scopes: authz.clampedScopes,
+    allowedSiteIds: authz.allowedSiteIds,
     rateLimit: apiKey.rateLimit,
     createdBy: apiKey.createdBy,
   });

--- a/apps/api/src/routes/mcpServer.bearer.test.ts
+++ b/apps/api/src/routes/mcpServer.bearer.test.ts
@@ -45,16 +45,34 @@ vi.mock('../db', () => {
   // null perms (SR2-15). This row models a legitimate creator who HAS a role but
   // NO site restriction (siteIds null → allowedSiteIds undefined → all sites),
   // which is exactly the "unrestricted creator" these tests assert.
-  const rows = [{ partnerId: 'partner-1', orgAccess: 'all', orgIds: null, id: 'org-1', roleId: 'role-1', siteIds: null }];
-  const makeWhere = () => {
-    const thenable = Promise.resolve(rows) as Promise<typeof rows> & { limit: (n: number) => Promise<typeof rows> };
+  const membershipRows = [{ partnerId: 'partner-1', orgAccess: 'all', orgIds: null, id: 'org-1', roleId: 'role-1', siteIds: null }];
+  // SR2-15 (Task 3, scope re-clamp): buildAuthFromApiKey's org branch now
+  // re-validates the API key's stored scopes (always ['ai:read'] in this
+  // file) against the creator's live permissions via
+  // authorizeHumanApiKeyCreator -> validateApiKeyScopeDelegation. That reads
+  // permission rows shaped `{resource, action}` from the rolePermissions/
+  // permissions innerJoin — distinct from the plain membership select above —
+  // so buildPerms() sees a creator who actually holds the grants ai:read
+  // requires (devices/alerts/scripts/automations read), matching this file's
+  // "unrestricted creator" fixture instead of failing the NEW re-clamp guard.
+  const permissionRows = [
+    { resource: 'devices', action: 'read' },
+    { resource: 'alerts', action: 'read' },
+    { resource: 'scripts', action: 'read' },
+    { resource: 'automations', action: 'read' },
+  ];
+  const makeWhere = (rows: unknown[]) => {
+    const thenable = Promise.resolve(rows) as Promise<unknown[]> & { limit: (n: number) => Promise<unknown[]> };
     thenable.limit = async () => rows;
     return thenable;
   };
   // buildPerms resolves role→permissions via `.innerJoin(...).where(...)`, so the
   // chain must offer innerJoin (returning a `.where` continuation) alongside the
   // direct `.where` used by the membership/org-enumeration selects.
-  const makeFrom = () => ({ where: makeWhere, innerJoin: () => ({ where: makeWhere }) });
+  const makeFrom = () => ({
+    where: () => makeWhere(membershipRows),
+    innerJoin: () => ({ where: () => makeWhere(permissionRows) }),
+  });
   return {
     db: {
       select: () => ({ from: makeFrom }),

--- a/apps/api/src/routes/mcpServer.bootstrapLifecycle.test.ts
+++ b/apps/api/src/routes/mcpServer.bootstrapLifecycle.test.ts
@@ -185,23 +185,45 @@ function mockApiKey(scopes: string[]) {
   }));
 }
 
+// SR2-15 (Task 3, scope re-clamp): buildAuthFromApiKey's org branch now calls
+// getUserPermissions ONCE via authorizeHumanApiKeyCreator to re-validate the
+// key's coarse scopes (callBootstrap always drives ['ai:read', 'ai:execute'],
+// which bundles devices/alerts/scripts/automations read + devices/scripts
+// execute as a single all-or-nothing unit) BEFORE the REAL aiGuardrails
+// checkToolPermission runs its OWN, separate getUserPermissions call to
+// enforce the bootstrap tool's actual RBAC requirement (MCP-OAUTH-11 — the
+// concern this suite tests). So: the FIRST call (the coarse ceiling) gets a
+// full baseline that always satisfies 'ai:read' + 'ai:execute', and every
+// SUBSEQUENT call (the real per-tool RBAC gate) returns the scenario's actual
+// `permissions`, preserving every test's premise (including the "missing
+// devices.write" denial cases) without loosening any assertion.
+const FULL_AI_READ_EXECUTE_BASELINE = [
+  { resource: 'devices', action: 'read' },
+  { resource: 'alerts', action: 'read' },
+  { resource: 'scripts', action: 'read' },
+  { resource: 'automations', action: 'read' },
+  { resource: 'devices', action: 'execute' },
+  { resource: 'scripts', action: 'execute' },
+];
+
 function mockPerms(permissions: Array<{ resource: string; action: string }>, roleId: string | null = 'role-1') {
   vi.doMock('../services/permissions', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../services/permissions')>();
-    return {
-      ...actual,
-      getUserPermissions: vi.fn(async () =>
-        roleId === null
-          ? null
-          : {
-              permissions,
-              partnerId: 'partner-1',
-              orgId: 'org-1',
-              roleId,
-              scope: 'organization' as const,
-            },
-      ),
-    };
+    const buildResult = (perms: Array<{ resource: string; action: string }>) =>
+      roleId === null
+        ? null
+        : {
+            permissions: perms,
+            partnerId: 'partner-1',
+            orgId: 'org-1',
+            roleId,
+            scope: 'organization' as const,
+          };
+    const getUserPermissions = vi.fn(async () => buildResult(permissions));
+    if (roleId !== null) {
+      getUserPermissions.mockResolvedValueOnce(buildResult(FULL_AI_READ_EXECUTE_BASELINE));
+    }
+    return { ...actual, getUserPermissions };
   });
 }
 

--- a/apps/api/src/routes/mcpServer.creatorAuthz.test.ts
+++ b/apps/api/src/routes/mcpServer.creatorAuthz.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { z as zod } from 'zod';
 import { validateApiKeyScopeDelegation } from '../services/apiKeyScopes';
+import type { ApiKeyAuthorizationResult } from '../services/apiKeyAuthorization';
 
 // SR2-15 (core-auth-hardening, Task 3) regression: the MCP org-scope branch of
 // buildAuthFromApiKey now authorizes the human creator LIVE via the shared
@@ -48,6 +49,19 @@ const mocks = vi.hoisted(() => ({
     _auth: { allowedSiteIds?: string[]; canAccessSite: (s: string | null | undefined) => boolean },
   ) => null),
   executeTool: vi.fn(async () => JSON.stringify({ ok: true })),
+  // SR2-15 (Task 5): service-principal branch of buildAuthFromApiKey. Mocked
+  // (real authorizeHumanApiKeyCreator stays real above, exercised via the
+  // getUserPermissions mock) because the real implementation reads
+  // `service_principals` through the DB, which this file's `../db` mock
+  // (`db: {}`) has no select() to satisfy.
+  authorizeServicePrincipalKey: vi.fn(
+    async (_input: { principalId: string; scopes: string[] }): Promise<ApiKeyAuthorizationResult> => ({
+      ok: true,
+      permissions: null,
+      allowedSiteIds: undefined,
+      clampedScopes: _input.scopes,
+    }),
+  ),
 }));
 
 vi.mock('../services/tenantStatus', async (importOriginal) => {
@@ -58,6 +72,11 @@ vi.mock('../services/tenantStatus', async (importOriginal) => {
 vi.mock('../services/permissions', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../services/permissions')>();
   return { ...actual, getUserPermissions: mocks.getUserPermissions };
+});
+
+vi.mock('../services/apiKeyAuthorization', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/apiKeyAuthorization')>();
+  return { ...actual, authorizeServicePrincipalKey: mocks.authorizeServicePrincipalKey };
 });
 
 vi.mock('../services/aiGuardrails', () => ({
@@ -111,7 +130,7 @@ vi.mock('../services/mcpToolExecutionLedger', () => ({
   completeMcpToolExecutionLedger: async () => undefined,
 }));
 
-function mockApiKey(scopes: string[]) {
+function mockApiKey(scopes: string[], principal?: { principalType: string; principalId: string | null }) {
   vi.doMock('../middleware/apiKeyAuth', () => ({
     apiKeyAuthMiddleware: async (c: any, next: any) => {
       c.set('apiKey', {
@@ -123,6 +142,7 @@ function mockApiKey(scopes: string[]) {
         scopes,
         rateLimit: 1000,
         createdBy: 'creator-user',
+        ...(principal ?? {}),
       });
       c.set('apiKeyOrgId', 'org-1');
       await next();
@@ -131,8 +151,12 @@ function mockApiKey(scopes: string[]) {
   }));
 }
 
-async function callTool(scopes: string[], toolName: string) {
-  mockApiKey(scopes);
+async function callTool(
+  scopes: string[],
+  toolName: string,
+  principal?: { principalType: string; principalId: string | null },
+) {
+  mockApiKey(scopes, principal);
   const mod = await import('./mcpServer');
   return mod.mcpServerRoutes.request('/message', {
     method: 'POST',
@@ -153,6 +177,7 @@ describe('MCP org-scoped key: live scope re-clamp on top of #2510 null-deny (SR2
     mocks.getUserPermissions.mockClear();
     mocks.checkToolPermission.mockClear();
     mocks.executeTool.mockClear();
+    mocks.authorizeServicePrincipalKey.mockClear();
     delete process.env.IS_HOSTED;
   });
 
@@ -260,5 +285,72 @@ describe('MCP org-scoped key: live scope re-clamp on top of #2510 null-deny (SR2
     expect(res.status).toBe(403);
     expect(mocks.checkToolPermission).not.toHaveBeenCalled();
     expect(mocks.executeTool).not.toHaveBeenCalled();
+  });
+});
+
+// SR2-15 (Task 5): the MCP org-scope branch of buildAuthFromApiKey branches
+// on apiKey.principalType — a 'service' key is authorized against the
+// PRINCIPAL (authorizeServicePrincipalKey), never the human creator-permission
+// resolver above. This proves the branch is actually wired end-to-end through
+// the MCP request path (apiKeyAuthMiddleware's context -> buildAuthFromApiKey
+// -> tool dispatch), not just unit-tested in isolation.
+describe('MCP org-scoped key: service-principal branch (SR2-15 Task 5)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.getActiveOrgTenant.mockClear();
+    mocks.getUserPermissions.mockClear();
+    mocks.checkToolPermission.mockClear();
+    mocks.executeTool.mockClear();
+    mocks.authorizeServicePrincipalKey.mockClear();
+    delete process.env.IS_HOSTED;
+  });
+
+  afterEach(() => {
+    vi.doUnmock('../middleware/apiKeyAuth');
+  });
+
+  it('dispatches a service-principal key via authorizeServicePrincipalKey, never the human resolver', async () => {
+    const res = await callTool(['ai:read'], 'list_devices', { principalType: 'service', principalId: 'principal-1' });
+
+    expect(res.status).toBe(200);
+    expect(mocks.authorizeServicePrincipalKey).toHaveBeenCalledWith({ principalId: 'principal-1', scopes: ['ai:read'] });
+    expect(mocks.getUserPermissions).not.toHaveBeenCalled();
+    expect(mocks.checkToolPermission).toHaveBeenCalled();
+  });
+
+  // Guard-bite (a): a disabled principal's service key is rejected — proven
+  // here at the MCP transport boundary (403), with the DENY sourced from the
+  // resolver's own fail-closed logic (unit-proven in
+  // apiKeyAuthorization.test.ts; this test proves the WIRING).
+  it('rejects (403) when authorizeServicePrincipalKey denies (disabled principal / fail-closed)', async () => {
+    mocks.authorizeServicePrincipalKey.mockResolvedValueOnce({ ok: false, reason: 'no_membership' });
+
+    const res = await callTool(['ai:read'], 'list_devices', { principalType: 'service', principalId: 'principal-disabled' });
+
+    expect(res.status).toBe(403);
+    expect(mocks.checkToolPermission).not.toHaveBeenCalled();
+    expect(mocks.executeTool).not.toHaveBeenCalled();
+  });
+
+  // Guard-bite (b): a service key whose stored scope exceeds the principal's
+  // current scopes is rejected.
+  it('rejects (403) when authorizeServicePrincipalKey denies for scope_exceeds_current_permissions', async () => {
+    mocks.authorizeServicePrincipalKey.mockResolvedValueOnce({ ok: false, reason: 'scope_exceeds_current_permissions' });
+
+    const res = await callTool(['ai:read', 'ai:execute'], 'devices_execute_script', {
+      principalType: 'service',
+      principalId: 'principal-narrowed',
+    });
+
+    expect(res.status).toBe(403);
+    expect(mocks.checkToolPermission).not.toHaveBeenCalled();
+  });
+
+  it('a human key (principalType absent, the default) is unaffected — still routes through authorizeHumanApiKeyCreator/getUserPermissions', async () => {
+    const res = await callTool(['ai:read'], 'list_devices');
+
+    expect(res.status).toBe(200);
+    expect(mocks.getUserPermissions).toHaveBeenCalled();
+    expect(mocks.authorizeServicePrincipalKey).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/mcpServer.creatorAuthz.test.ts
+++ b/apps/api/src/routes/mcpServer.creatorAuthz.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { z as zod } from 'zod';
+import { validateApiKeyScopeDelegation } from '../services/apiKeyScopes';
 
 // SR2-15 (core-auth-hardening, Task 3) regression: the MCP org-scope branch of
 // buildAuthFromApiKey now authorizes the human creator LIVE via the shared
@@ -182,6 +183,59 @@ describe('MCP org-scoped key: live scope re-clamp on top of #2510 null-deny (SR2
     expect(body.result).toBeUndefined();
     expect(body.error).toBeDefined();
     // The tool never dispatched — auth was rejected before RBAC/execution.
+    expect(mocks.checkToolPermission).not.toHaveBeenCalled();
+    expect(mocks.executeTool).not.toHaveBeenCalled();
+  });
+
+  it('SR2-15 (sharper): ai:execute re-clamp bites for a creator who still holds the FULL ai:read baseline (isolated from the ai:read bundle clamp)', async () => {
+    // The companion test above ("a permission-reduced creator...") starves
+    // devices:read too, so validateApiKeyScopeDelegation actually trips on the
+    // ai:read bundle FIRST (devices:read is one of ai:read's four required
+    // grants) — it never isolates whether the ai:execute re-clamp itself
+    // bites. This test keeps every ai:read grant (devices/alerts/scripts/
+    // automations read) intact and strips ONLY the execute-backing
+    // permissions (devices:execute, scripts:execute), so a denial here can
+    // only be explained by the ai:execute re-clamp specifically.
+    const fullReadOnlyExecuteCreator = {
+      permissions: [
+        { resource: 'devices', action: 'read' },
+        { resource: 'alerts', action: 'read' },
+        { resource: 'scripts', action: 'read' },
+        { resource: 'automations', action: 'read' },
+        // Deliberately NO devices:execute / scripts:execute — demoted from an
+        // execute-capable role to read-only after the key was minted.
+      ],
+      partnerId: null,
+      orgId: 'org-1',
+      roleId: 'role-1',
+      scope: 'organization' as const,
+      allowedSiteIds: undefined,
+    } as const;
+
+    // Sanity-check the isolation directly against the REAL (unmocked)
+    // validateApiKeyScopeDelegation before driving the HTTP path: ai:read
+    // ALONE is satisfied by this fixture (so the denial below cannot be the
+    // ai:read bundle clamp), while ai:execute ALONE is not.
+    const readOnlyCheck = validateApiKeyScopeDelegation(['ai:read'], fullReadOnlyExecuteCreator as any);
+    expect(readOnlyCheck.ok).toBe(true);
+    const executeOnlyCheck = validateApiKeyScopeDelegation(['ai:execute'], fullReadOnlyExecuteCreator as any);
+    expect(executeOnlyCheck.ok).toBe(false);
+    if (!executeOnlyCheck.ok) {
+      expect(executeOnlyCheck.error).toContain('ai:execute');
+    }
+
+    mocks.getUserPermissions.mockResolvedValueOnce(fullReadOnlyExecuteCreator as any);
+
+    const res = await callTool(['ai:read', 'ai:execute'], 'devices_execute_script');
+
+    // Before this task's re-clamp, buildAuthFromApiKey never re-validated
+    // stored scopes at all, so this creator (non-null perms, key carries
+    // ai:execute) would have been served (200, tool dispatched) on stale
+    // authority.
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.result).toBeUndefined();
+    expect(body.error).toBeDefined();
     expect(mocks.checkToolPermission).not.toHaveBeenCalled();
     expect(mocks.executeTool).not.toHaveBeenCalled();
   });

--- a/apps/api/src/routes/mcpServer.creatorAuthz.test.ts
+++ b/apps/api/src/routes/mcpServer.creatorAuthz.test.ts
@@ -1,42 +1,38 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { z as zod } from 'zod';
 
-// SR2-15 (core-auth-hardening) regression: an org-scoped MCP API key inherits
-// its creator's site-axis restriction via getUserPermissions(...).allowedSiteIds.
+// SR2-15 (core-auth-hardening, Task 3) regression: the MCP org-scope branch of
+// buildAuthFromApiKey now authorizes the human creator LIVE via the shared
+// authorizeHumanApiKeyCreator() resolver instead of a raw getUserPermissions()
+// call. #2510 already fixed the null-perms fail-open (creatorPermsNull suite).
+// THIS suite pins the delta #2510 did NOT cover: the resolver ALSO re-clamps
+// the key's STORED scopes against the creator's CURRENT permissions.
 //
-// THE FAIL-OPEN this suite pins closed: when the creator has been stripped of the
-// membership the key derives from — they're still `status='active'`, so PR 1's
-// creator-status gate passes — getUserPermissions returns **null**. The old code
-// read `creatorPerms?.allowedSiteIds`, so null collapsed to `undefined`, and
-// siteAccessCheck(undefined) means "full access to EVERY site in the org". A key
-// whose creator has NO authority got unrestricted org+site access.
-//
-// Fix: buildAuthFromApiKey returns null on null perms → buildCheckedAuthFromApiKey
-// denies with 403 (fail CLOSED). A legitimate full-access admin (non-null perms,
-// allowedSiteIds undefined) and a site-restricted creator (explicit list) are
-// unaffected.
+// The guard-bite this suite adds: a creator whose live permissions have been
+// reduced below what the key's stored scopes require must be DENIED, not
+// served with the key's original (now stale) scope grant. Before this task,
+// buildAuthFromApiKey only null-checked getUserPermissions() and used
+// creatorPerms.allowedSiteIds — it never re-ran scope delegation, so a key
+// minted while its creator was e.g. an org admin kept working at full
+// ai:execute strength even after that creator was demoted to read-only.
 
 const mocks = vi.hoisted(() => ({
   getActiveOrgTenant: vi.fn(async (_orgId: string): Promise<{ orgId: string; partnerId: string } | null> => ({
     orgId: 'org-1',
     partnerId: 'partner-1',
   })),
-  // Default: a legitimate FULL-ACCESS org admin (non-null, allowedSiteIds
-  // undefined). Individual tests override with mockResolvedValueOnce.
-  //
-  // SR2-15 (scope re-clamp, this task): buildAuthFromApiKey's org branch now
-  // routes through authorizeHumanApiKeyCreator, which re-validates the key's
-  // stored scopes against these live permissions. The mocked key below carries
-  // scope 'ai:read' (API_KEY_SCOPE_POLICIES['ai:read'] = devices.read,
-  // alerts.read, scripts.read, automations.read), so the default perms object
-  // must actually hold those grants or every "still works" assertion in this
-  // suite would be denied by the NEW re-clamp guard rather than by the
-  // null-perms behavior this suite exists to pin.
+  // Default: a legitimate creator whose live permissions cover devices +
+  // alerts + scripts + automations read/write/execute — i.e. enough to back
+  // every scope this suite's keys carry. Individual tests override with
+  // mockResolvedValueOnce to model a REDUCED creator.
   getUserPermissions: vi.fn(async (_userId: string, _ctx: { partnerId?: string; orgId?: string }) => ({
     permissions: [
       { resource: 'devices', action: 'read' },
+      { resource: 'devices', action: 'write' },
+      { resource: 'devices', action: 'execute' },
       { resource: 'alerts', action: 'read' },
       { resource: 'scripts', action: 'read' },
+      { resource: 'scripts', action: 'execute' },
       { resource: 'automations', action: 'read' },
     ],
     partnerId: null,
@@ -45,8 +41,6 @@ const mocks = vi.hoisted(() => ({
     scope: 'organization' as const,
     allowedSiteIds: undefined as string[] | undefined,
   })),
-  // Capturing stub: 3rd arg is the full AuthContext handed to the RBAC gate, so
-  // we can inspect allowedSiteIds / canAccessSite. Returns null = allow.
   checkToolPermission: vi.fn(async (
     _toolName: string,
     _input: unknown,
@@ -74,6 +68,7 @@ vi.mock('../services/aiGuardrails', () => ({
 vi.mock('../services/aiTools', () => ({
   getToolDefinitions: () => [
     { name: 'list_devices', description: 'list', inputSchema: zod.object({}).passthrough() },
+    { name: 'devices_execute_script', description: 'execute a script on a device', inputSchema: zod.object({}).passthrough() },
   ],
   executeTool: mocks.executeTool,
   getToolTier: () => 1,
@@ -115,7 +110,7 @@ vi.mock('../services/mcpToolExecutionLedger', () => ({
   completeMcpToolExecutionLedger: async () => undefined,
 }));
 
-function mockApiKey() {
+function mockApiKey(scopes: string[]) {
   vi.doMock('../middleware/apiKeyAuth', () => ({
     apiKeyAuthMiddleware: async (c: any, next: any) => {
       c.set('apiKey', {
@@ -124,7 +119,7 @@ function mockApiKey() {
         partnerId: null,
         name: 'test',
         keyPrefix: 'brz_test',
-        scopes: ['ai:read'],
+        scopes,
         rateLimit: 1000,
         createdBy: 'creator-user',
       });
@@ -135,8 +130,8 @@ function mockApiKey() {
   }));
 }
 
-async function callListDevices() {
-  mockApiKey();
+async function callTool(scopes: string[], toolName: string) {
+  mockApiKey(scopes);
   const mod = await import('./mcpServer');
   return mod.mcpServerRoutes.request('/message', {
     method: 'POST',
@@ -145,12 +140,12 @@ async function callListDevices() {
       jsonrpc: '2.0',
       id: 1,
       method: 'tools/call',
-      params: { name: 'list_devices', arguments: {} },
+      params: { name: toolName, arguments: {} },
     }),
   });
 }
 
-describe('MCP org-scoped key: creator perms fail closed on null (SR2-15)', () => {
+describe('MCP org-scoped key: live scope re-clamp on top of #2510 null-deny (SR2-15)', () => {
   beforeEach(() => {
     vi.resetModules();
     mocks.getActiveOrgTenant.mockClear();
@@ -164,58 +159,52 @@ describe('MCP org-scoped key: creator perms fail closed on null (SR2-15)', () =>
     vi.doUnmock('../middleware/apiKeyAuth');
   });
 
-  it('DENIES the request (403) when getUserPermissions returns null (creator stripped of membership)', async () => {
-    // Creator is still active (PR 1 gate passes) but has NO org role and NO
-    // partner role → getUserPermissions returns null.
-    mocks.getUserPermissions.mockResolvedValueOnce(null as any);
+  it('SR2-15: a permission-reduced creator cannot use a scope above their current permissions', async () => {
+    // The key was minted with ai:execute (devices:execute + scripts:execute
+    // backing) but the creator's LIVE permissions now cover devices:read only
+    // — e.g. demoted from admin to read-only after the key was created.
+    mocks.getUserPermissions.mockResolvedValueOnce({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      partnerId: null,
+      orgId: 'org-1',
+      roleId: 'role-1',
+      scope: 'organization' as const,
+      allowedSiteIds: undefined,
+    } as any);
 
-    const res = await callListDevices();
+    const res = await callTool(['ai:read', 'ai:execute'], 'devices_execute_script');
 
+    // Before the fix: buildAuthFromApiKey only null-checked getUserPermissions
+    // and never re-validated the key's stored scopes, so this reduced creator's
+    // stale ai:execute grant would still be served (200, tool dispatched).
     expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.result).toBeUndefined();
+    expect(body.error).toBeDefined();
     // The tool never dispatched — auth was rejected before RBAC/execution.
     expect(mocks.checkToolPermission).not.toHaveBeenCalled();
     expect(mocks.executeTool).not.toHaveBeenCalled();
   });
 
-  it('a legitimate FULL-access admin (non-null perms, allowedSiteIds undefined) still gets all-site access', async () => {
-    // Default mock already models this (allowedSiteIds: undefined).
-    const res = await callListDevices();
+  it('SR2-15: a creator whose live permissions still cover the stored scopes is served normally', async () => {
+    // Default mock (module-level) already covers devices read/write/execute +
+    // scripts read/execute + alerts/automations read — enough for ai:read +
+    // ai:execute.
+    const res = await callTool(['ai:read', 'ai:execute'], 'devices_execute_script');
 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.error).toBeUndefined();
-
-    const [, , auth] = mocks.checkToolPermission.mock.calls[0] as [
-      string, unknown, { allowedSiteIds?: string[]; canAccessSite: (s: string | null | undefined) => boolean },
-    ];
-    expect(auth.allowedSiteIds).toBeUndefined();
-    // Unrestricted: every site allowed.
-    expect(auth.canAccessSite('any-site-at-all')).toBe(true);
+    expect(mocks.checkToolPermission).toHaveBeenCalled();
   });
 
-  it('a site-restricted creator keeps EXACTLY their sites (no widening)', async () => {
-    mocks.getUserPermissions.mockResolvedValueOnce({
-      permissions: [
-        { resource: 'devices', action: 'read' },
-        { resource: 'alerts', action: 'read' },
-        { resource: 'scripts', action: 'read' },
-        { resource: 'automations', action: 'read' },
-      ],
-      partnerId: null,
-      orgId: 'org-1',
-      roleId: 'role-1',
-      scope: 'organization',
-      allowedSiteIds: ['site-a'],
-    } as any);
+  it('SR2-15: a creator stripped of all membership (null perms) is still DENIED (guards #2510 stays intact)', async () => {
+    mocks.getUserPermissions.mockResolvedValueOnce(null as any);
 
-    const res = await callListDevices();
+    const res = await callTool(['ai:read'], 'list_devices');
 
-    expect(res.status).toBe(200);
-    const [, , auth] = mocks.checkToolPermission.mock.calls[0] as [
-      string, unknown, { allowedSiteIds?: string[]; canAccessSite: (s: string | null | undefined) => boolean },
-    ];
-    expect(auth.allowedSiteIds).toEqual(['site-a']);
-    expect(auth.canAccessSite('site-a')).toBe(true);
-    expect(auth.canAccessSite('site-b')).toBe(false);
+    expect(res.status).toBe(403);
+    expect(mocks.checkToolPermission).not.toHaveBeenCalled();
+    expect(mocks.executeTool).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/mcpServer.effectiveTier.test.ts
+++ b/apps/api/src/routes/mcpServer.effectiveTier.test.ts
@@ -67,12 +67,33 @@ vi.mock('../services/aiGuardrails', async (importOriginal) => {
 
 // Stub getUserPermissions so buildAuthFromApiKey for org keys doesn't hit the
 // permissions DB. Tests that need a site restriction override this per-case.
+//
+// SR2-15 (Task 3, scope re-clamp): buildAuthFromApiKey's org branch now
+// re-validates a key's stored scopes against these permissions via
+// authorizeHumanApiKeyCreator before an AuthContext is ever built. This
+// file's tests exercise tier/scope GATING (FIX 1) with `ai:read`/`ai:write`/
+// `ai:execute`-scoped keys, not scope delegation, so the default creator here
+// must hold every permission those coarse scopes require (devices/alerts/
+// scripts/automations read/write/execute) — otherwise every "still works"
+// assertion below would be denied by the NEW re-clamp before ever reaching
+// the tier-gating logic under test.
 vi.mock('../services/permissions', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../services/permissions')>();
   return {
     ...actual,
     getUserPermissions: vi.fn(async () => ({
-      permissions: [],
+      permissions: [
+        { resource: 'devices', action: 'read' },
+        { resource: 'devices', action: 'write' },
+        { resource: 'devices', action: 'execute' },
+        { resource: 'alerts', action: 'read' },
+        { resource: 'alerts', action: 'write' },
+        { resource: 'scripts', action: 'read' },
+        { resource: 'scripts', action: 'write' },
+        { resource: 'scripts', action: 'execute' },
+        { resource: 'automations', action: 'read' },
+        { resource: 'automations', action: 'write' },
+      ],
       partnerId: null,
       orgId: 'org-1',
       roleId: 'role-1',
@@ -99,6 +120,46 @@ afterEach(() => {
   vi.doUnmock('../services/aiTools');
   vi.doUnmock('../middleware/apiKeyAuth');
 });
+
+// SR2-15 (Task 3, scope re-clamp): buildAuthFromApiKey's org branch now calls
+// getUserPermissions ONCE via authorizeHumanApiKeyCreator to re-validate the
+// key's coarse 'ai:read' scope (API_KEY_SCOPE_POLICIES['ai:read'] bundles
+// devices+alerts+scripts+automations read as a single all-or-nothing unit)
+// BEFORE resources/read's own fine-grained checkPermissionRequirement runs
+// its OWN, separate getUserPermissions call. The site-axis (FIX 3) tests
+// below intentionally model a site-RESTRICTED creator who holds only ONE
+// resource's read grant — that's incompatible with the coarse 'ai:read'
+// ceiling on its own, so: the FIRST call (the coarse ceiling) gets a full
+// baseline that always satisfies 'ai:read', and every SUBSEQUENT call (the
+// fine-grained per-resource + site-axis gate) returns the scenario's actual
+// restricted permissions, preserving each test's premise without loosening
+// any assertion.
+const FULL_AI_READ_BASELINE = [
+  { resource: 'devices', action: 'read' },
+  { resource: 'alerts', action: 'read' },
+  { resource: 'scripts', action: 'read' },
+  { resource: 'automations', action: 'read' },
+];
+
+function mockSiteRestrictedPerms(
+  perms: Array<{ resource: string; action: string }>,
+  allowedSiteIds: string[],
+) {
+  vi.doMock('../services/permissions', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../services/permissions')>();
+    const buildResult = (permissions: Array<{ resource: string; action: string }>) => ({
+      permissions,
+      partnerId: null,
+      orgId: 'org-1',
+      roleId: 'role-1',
+      scope: 'organization' as const,
+      allowedSiteIds,
+    });
+    const getUserPermissions = vi.fn(async () => buildResult(perms));
+    getUserPermissions.mockResolvedValueOnce(buildResult(FULL_AI_READ_BASELINE));
+    return { ...actual, getUserPermissions };
+  });
+}
 
 function mockApiKey(scopes: string[]) {
   vi.doMock('../middleware/apiKeyAuth', () => ({
@@ -344,20 +405,7 @@ describe('MCP resources/read site-axis enforcement (FIX 3)', () => {
     // Restrict creator to site-A only. MCP-OAUTH-03: resources/read now
     // requires devices.read before it will even reach the site-axis
     // narrowing under test here, so the role must hold it.
-    vi.doMock('../services/permissions', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('../services/permissions')>();
-      return {
-        ...actual,
-        getUserPermissions: vi.fn(async () => ({
-          permissions: [{ resource: 'devices', action: 'read' }],
-          partnerId: null,
-          orgId: 'org-1',
-          roleId: 'role-1',
-          scope: 'organization' as const,
-          allowedSiteIds: ['site-A'],
-        })),
-      };
-    });
+    mockSiteRestrictedPerms([{ resource: 'devices', action: 'read' }], ['site-A']);
 
     // db mock: resolveSiteAllowedDeviceIds returns both devices with siteIds;
     // the real canAccessSite filter (built from allowedSiteIds) then narrows to
@@ -434,20 +482,7 @@ describe('MCP resources/read site-axis enforcement (FIX 3)', () => {
   it('C4: site-restricted caller does not see site-B alerts via resources/read', async () => {
     // MCP-OAUTH-03: resources/read now requires alerts.read before the
     // site-axis narrowing under test here even runs.
-    vi.doMock('../services/permissions', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('../services/permissions')>();
-      return {
-        ...actual,
-        getUserPermissions: vi.fn(async () => ({
-          permissions: [{ resource: 'alerts', action: 'read' }],
-          partnerId: null,
-          orgId: 'org-1',
-          roleId: 'role-1',
-          scope: 'organization' as const,
-          allowedSiteIds: ['site-A'],
-        })),
-      };
-    });
+    mockSiteRestrictedPerms([{ resource: 'alerts', action: 'read' }], ['site-A']);
 
     const capturedAlertConds: any[] = [];
     vi.doMock('../db', () => ({
@@ -550,20 +585,7 @@ describe('MCP resources/read site-axis enforcement (FIX 3)', () => {
   function restrictToSiteA() {
     // MCP-OAUTH-03: resources/read now requires devices.read before the
     // site-axis narrowing under test here even runs.
-    vi.doMock('../services/permissions', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('../services/permissions')>();
-      return {
-        ...actual,
-        getUserPermissions: vi.fn(async () => ({
-          permissions: [{ resource: 'devices', action: 'read' }],
-          partnerId: null,
-          orgId: 'org-1',
-          roleId: 'role-1',
-          scope: 'organization' as const,
-          allowedSiteIds: ['site-A'],
-        })),
-      };
-    });
+    mockSiteRestrictedPerms([{ resource: 'devices', action: 'read' }], ['site-A']);
   }
 
   async function readDevice(id: string) {

--- a/apps/api/src/routes/mcpServer.orgKeyPartnerRole.test.ts
+++ b/apps/api/src/routes/mcpServer.orgKeyPartnerRole.test.ts
@@ -16,10 +16,19 @@ const mocks = vi.hoisted(() => ({
   // that belongs to a partner (the fix) vs. an org with no usable partner.
   getActiveOrgTenant: vi.fn(async (_orgId: string): Promise<{ orgId: string; partnerId: string } | null> => null),
   // Spy so we can assert the partnerId buildAuthFromApiKey threads into role
-  // resolution. Returns a benign org-perms object (its shape is irrelevant to
-  // these assertions; checkToolPermission is stubbed below).
+  // resolution. Returns a benign org-perms object; checkToolPermission is
+  // stubbed below, but SR2-15 (Task 3) now also routes this through
+  // authorizeHumanApiKeyCreator's scope re-clamp, so the mocked key's
+  // scopes: ['ai:read'] must actually be backed by these permissions or every
+  // "still works" assertion in this suite gets denied by the NEW guard rather
+  // than exercising the partner-role-resolution behavior under test.
   getUserPermissions: vi.fn(async (_userId: string, _ctx: { partnerId?: string; orgId?: string }) => ({
-    permissions: [],
+    permissions: [
+      { resource: 'devices', action: 'read' },
+      { resource: 'alerts', action: 'read' },
+      { resource: 'scripts', action: 'read' },
+      { resource: 'automations', action: 'read' },
+    ],
     partnerId: null,
     orgId: 'org-1',
     roleId: 'role-1',

--- a/apps/api/src/routes/mcpServer.partnerCreatorPermsNull.test.ts
+++ b/apps/api/src/routes/mcpServer.partnerCreatorPermsNull.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { z as zod } from 'zod';
+
+// SR2-15 (core-auth-hardening, Task 3) regression: the MCP PARTNER-scope
+// branch of buildAuthFromApiKey (apiKey.orgId === null — OAuth bearer token,
+// or an API key with no org_id) previously had NO null-perms deny at all. An
+// off-boarded partner admin's key was only "data-starved"
+// (resolvePartnerAccessibleOrgIds reads partner_users fresh and returns []
+// for a gone membership, producing an unsatisfiable org filter) but never
+// outright rejected — tools/list still succeeded and the caller looked
+// authenticated. Task 3 added an explicit
+// `getUserPermissions(apiKey.createdBy, { partnerId: apiKey.partnerId })`
+// call in this branch with `return null` (-> 403 via buildCheckedAuthFromApiKey)
+// on a null/errored read, matching the org-scope branch's fail-closed
+// posture (see mcpServer.creatorPermsNull.test.ts for that sibling coverage).
+//
+// This suite pins THAT delta closed: an off-boarded partner-admin creator
+// (still `status='active'`, so the PR1 creator-status gate passes, but with
+// no partner_users row left) must be DENIED, not served on stale authority.
+
+const mocks = vi.hoisted(() => ({
+  // Default: a legitimate partner-admin creator whose live permissions still
+  // cover the key's stored scope (ai:read = devices/alerts/scripts/
+  // automations read). Individual tests override with mockResolvedValueOnce
+  // to model an off-boarded creator (null).
+  getUserPermissions: vi.fn(async (_userId: string, _ctx: { partnerId?: string; orgId?: string }) => ({
+    permissions: [
+      { resource: 'devices', action: 'read' },
+      { resource: 'alerts', action: 'read' },
+      { resource: 'scripts', action: 'read' },
+      { resource: 'automations', action: 'read' },
+    ],
+    partnerId: 'partner-1',
+    orgId: null,
+    roleId: 'role-1',
+    scope: 'partner' as const,
+    allowedSiteIds: undefined as string[] | undefined,
+  })),
+  checkToolPermission: vi.fn(async (
+    _toolName: string,
+    _input: unknown,
+    _auth: { scope?: string; partnerId?: string | null },
+  ) => null),
+  executeTool: vi.fn(async () => JSON.stringify({ ok: true })),
+}));
+
+vi.mock('../services/tenantStatus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/tenantStatus')>();
+  return { ...actual };
+});
+
+vi.mock('../services/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/permissions')>();
+  return { ...actual, getUserPermissions: mocks.getUserPermissions };
+});
+
+vi.mock('../services/aiGuardrails', () => ({
+  checkGuardrails: () => ({ allowed: true, tier: 1 }),
+  checkToolPermission: mocks.checkToolPermission,
+  checkToolRateLimit: async () => null,
+}));
+
+vi.mock('../services/aiTools', () => ({
+  getToolDefinitions: () => [
+    { name: 'list_devices', description: 'list', inputSchema: zod.object({}).passthrough() },
+  ],
+  executeTool: mocks.executeTool,
+  getToolTier: () => 1,
+}));
+
+vi.mock('../db', () => ({
+  db: {},
+  withDbAccessContext: vi.fn((_ctx: any, fn: any) => fn()),
+  withSystemDbAccessContext: vi.fn((fn: any) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => any) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: {}, alerts: {}, scripts: {}, automations: {},
+  organizations: { id: 'organizations.id', partnerId: 'organizations.partnerId' },
+  partners: { id: 'partners.id', billingEmail: 'partners.billingEmail' },
+  partnerUsers: {}, apiKeys: {},
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+  requestLikeFromSnapshot: vi.fn(),
+}));
+vi.mock('../services/redis', () => ({ getRedis: () => null }));
+vi.mock('../services/rate-limit', () => ({
+  rateLimiter: vi.fn(async () => ({ allowed: true, resetAt: new Date(Date.now() + 60000) })),
+}));
+vi.mock('../middleware/bearerTokenAuth', () => ({
+  bearerTokenAuthMiddleware: async () => { throw new Error('should not be called without a Bearer header'); },
+  // The off-boarded creator's actual org list is irrelevant to THIS guard —
+  // buildAuthFromApiKey must deny before it ever reaches this resolver. Kept
+  // empty like the sibling org-scope suite; resolveMcpExecutionOrgId is
+  // mocked separately below so it doesn't gate the positive-control test.
+  resolvePartnerAccessibleOrgIds: async () => [],
+}));
+vi.mock('./mcpExecutionOrg', () => ({
+  resolveMcpExecutionOrgId: () => 'org-1',
+  resolveMcpExecutionContext: async () => ({ orgId: 'org-1' }),
+  McpExecutionOrgError: class McpExecutionOrgError extends Error {},
+}));
+vi.mock('../services/mcpToolExecutionLedger', () => ({
+  beginMcpToolExecutionLedger: async () => ({ id: 'ledger-1' }),
+  completeMcpToolExecutionLedger: async () => undefined,
+}));
+
+// Partner-scope key: orgId null, partnerId set — an OAuth-provisioned key or
+// a manual key with no org_id, driven here via the X-API-Key middleware for
+// simplicity (buildAuthFromApiKey's branch selection is purely
+// `apiKey.orgId` truthy/falsy, independent of which auth header reached it —
+// see mcpServer.bearer.test.ts for the Bearer-header variant of this shape).
+function mockApiKey() {
+  vi.doMock('../middleware/apiKeyAuth', () => ({
+    apiKeyAuthMiddleware: async (c: any, next: any) => {
+      c.set('apiKey', {
+        id: 'key-1',
+        orgId: null,
+        partnerId: 'partner-1',
+        name: 'test',
+        keyPrefix: 'brz_test',
+        scopes: ['ai:read'],
+        rateLimit: 1000,
+        createdBy: 'partner-admin-user',
+      });
+      c.set('apiKeyOrgId', null);
+      await next();
+    },
+    requireApiKeyScope: () => async (_c: any, next: any) => next(),
+  }));
+}
+
+async function callListDevices() {
+  mockApiKey();
+  const mod = await import('./mcpServer');
+  return mod.mcpServerRoutes.request('/message', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'X-API-Key': 'brz_test' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'list_devices', arguments: {} },
+    }),
+  });
+}
+
+describe('MCP partner-scoped key: creator perms fail closed on null (SR2-15 off-boarding deny)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.getUserPermissions.mockClear();
+    mocks.checkToolPermission.mockClear();
+    mocks.executeTool.mockClear();
+    delete process.env.IS_HOSTED;
+  });
+
+  afterEach(() => {
+    vi.doUnmock('../middleware/apiKeyAuth');
+  });
+
+  it('DENIES the request (403) when getUserPermissions(partnerId) returns null (off-boarded partner-admin creator)', async () => {
+    // Creator is still active (PR1 gate passes) but their partner_users
+    // membership is gone, so the partner-axis getUserPermissions read
+    // resolves null. Before this task, the partner branch had no null-perms
+    // deny at all: this off-boarded creator's key would still be served
+    // (tools/list, tools/call all succeeding on stale authority), only
+    // silently data-starved by an empty accessibleOrgIds. This guard closes
+    // that: the branch must reject outright, matching the org-scope branch.
+    mocks.getUserPermissions.mockResolvedValueOnce(null as any);
+
+    const res = await callListDevices();
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.result).toBeUndefined();
+    expect(body.error).toBeDefined();
+    // The tool never dispatched — auth was rejected before RBAC/execution.
+    expect(mocks.checkToolPermission).not.toHaveBeenCalled();
+    expect(mocks.executeTool).not.toHaveBeenCalled();
+  });
+
+  it('a partner-scoped key whose creator still has an active partner membership is served normally (positive control)', async () => {
+    // Default mock (module-level) already models a legitimate partner-admin
+    // creator with non-null permissions covering the key's ai:read scope.
+    const res = await callListDevices();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error).toBeUndefined();
+    expect(mocks.getUserPermissions).toHaveBeenCalledWith(
+      'partner-admin-user',
+      expect.objectContaining({ partnerId: 'partner-1' }),
+    );
+    expect(mocks.checkToolPermission).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/mcpServer.resourceRbac.test.ts
+++ b/apps/api/src/routes/mcpServer.resourceRbac.test.ts
@@ -52,20 +52,41 @@ function mockDb(rows: any[]) {
   }));
 }
 
+// SR2-15 (Task 3, scope re-clamp): buildAuthFromApiKey's org branch now calls
+// getUserPermissions ONCE via authorizeHumanApiKeyCreator to re-validate the
+// API key's coarse 'ai:read' scope (API_KEY_SCOPE_POLICIES['ai:read'] bundles
+// devices+alerts+scripts+automations read as a single unit — ALL FOUR are
+// required or the whole scope is denied) BEFORE resources/read's own
+// fine-grained checkPermissionRequirement runs its OWN, SEPARATE
+// getUserPermissions call. This suite exists to test that fine-grained gate
+// in isolation (MCP-OAUTH-03), including states like "role lacking
+// scripts.read" that are otherwise impossible to reach with a valid 'ai:read'
+// key scope. So: the FIRST getUserPermissions call (the coarse ceiling) gets
+// a full baseline permission set — the creator genuinely holds 'ai:read' —
+// and every SUBSEQUENT call (the fine-grained per-resource check inside
+// resources/read) returns the scenario's real `perms`, preserving each
+// test's actual premise without loosening any resources/read assertion.
+const FULL_AI_READ_BASELINE = [
+  { resource: 'devices', action: 'read' },
+  { resource: 'alerts', action: 'read' },
+  { resource: 'scripts', action: 'read' },
+  { resource: 'automations', action: 'read' },
+];
+
 function mockPermissions(perms: { resource: string; action: string }[]) {
   vi.doMock('../services/permissions', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../services/permissions')>();
-    return {
-      ...actual,
-      getUserPermissions: vi.fn(async () => ({
-        permissions: perms,
-        partnerId: null,
-        orgId: 'org-1',
-        roleId: 'role-1',
-        scope: 'organization' as const,
-        allowedSiteIds: undefined,
-      })),
-    };
+    const buildResult = (permissions: { resource: string; action: string }[]) => ({
+      permissions,
+      partnerId: null,
+      orgId: 'org-1',
+      roleId: 'role-1',
+      scope: 'organization' as const,
+      allowedSiteIds: undefined,
+    });
+    const getUserPermissions = vi.fn(async () => buildResult(perms));
+    getUserPermissions.mockResolvedValueOnce(buildResult(FULL_AI_READ_BASELINE));
+    return { ...actual, getUserPermissions };
   });
 }
 

--- a/apps/api/src/routes/mcpServer.streamable.test.ts
+++ b/apps/api/src/routes/mcpServer.streamable.test.ts
@@ -68,12 +68,25 @@ vi.mock('../db/schema', () => ({
 // buildAuthFromApiKey now calls getUserPermissions for org keys (to inherit the
 // creator's site allowlist). Stub it to an unrestricted org perms object so the
 // transport tests don't need to model the permissions DB queries.
+//
+// SR2-15 (Task 3, scope re-clamp): buildAuthFromApiKey's org branch now
+// re-validates the mocked key's stored scopes (default ['ai:read']) against
+// these permissions via authorizeHumanApiKeyCreator. These are pure transport
+// tests, not scope-delegation tests, so the creator here must actually hold
+// the devices/alerts/scripts/automations read grants 'ai:read' requires —
+// otherwise every request in this file would be denied by the NEW re-clamp
+// before ever reaching the transport behavior under test.
 vi.mock('../services/permissions', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../services/permissions')>();
   return {
     ...actual,
     getUserPermissions: vi.fn(async () => ({
-      permissions: [],
+      permissions: [
+        { resource: 'devices', action: 'read' },
+        { resource: 'alerts', action: 'read' },
+        { resource: 'scripts', action: 'read' },
+        { resource: 'automations', action: 'read' },
+      ],
       partnerId: null,
       orgId: 'org-1',
       roleId: 'role-1',

--- a/apps/api/src/routes/mcpServer.test.ts
+++ b/apps/api/src/routes/mcpServer.test.ts
@@ -32,12 +32,35 @@ vi.mock('../db/schema', () => ({
 // creator's site allowlist). Keep every real export the route graph needs and
 // stub only getUserPermissions to an unrestricted org perms object so these
 // transport/bootstrap tests don't need to model the permissions DB queries.
+//
+// SR2-15 (Task 3, scope re-clamp): buildAuthFromApiKey's org branch now routes
+// through authorizeHumanApiKeyCreator, which re-validates the API key's
+// STORED scopes against these live permissions (validateApiKeyScopeDelegation)
+// before returning an AuthContext. This suite's tests are exercising
+// transport/session/tier concerns, not scope delegation, so the default
+// creator here must hold every non-admin permission the ai:read/ai:write/
+// ai:execute policies require — otherwise every test whose mocked apiKey
+// carries one of those scopes would now be denied by the NEW re-clamp guard
+// before ever reaching the behavior under test. `ai:execute_admin` (which
+// requires the wildcard ADMIN_ALL grant) is deliberately EXCLUDED so the
+// "key lacks ai:execute_admin" test still exercises a real denial.
 vi.mock('../services/permissions', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../services/permissions')>();
   return {
     ...actual,
     getUserPermissions: vi.fn(async () => ({
-      permissions: [],
+      permissions: [
+        { resource: 'devices', action: 'read' },
+        { resource: 'devices', action: 'write' },
+        { resource: 'devices', action: 'execute' },
+        { resource: 'alerts', action: 'read' },
+        { resource: 'alerts', action: 'write' },
+        { resource: 'scripts', action: 'read' },
+        { resource: 'scripts', action: 'write' },
+        { resource: 'scripts', action: 'execute' },
+        { resource: 'automations', action: 'read' },
+        { resource: 'automations', action: 'write' },
+      ],
       partnerId: null,
       orgId: 'org-1',
       roleId: 'role-1',
@@ -1523,6 +1546,26 @@ describe('MCP bootstrap carve-out', () => {
     process.env.NODE_ENV = 'production';
     process.env.MCP_EXECUTE_TOOL_ALLOWLIST = 'execute_command'; // registry_operations absent
     mockKeyWithScopes(['ai:read', 'ai:execute', 'ai:execute_admin']);
+    // SR2-15 (Task 3, scope re-clamp): this key's stored scopes include
+    // ai:execute_admin (requires the wildcard ADMIN_ALL grant). The module-
+    // level getUserPermissions mock deliberately withholds that grant (so the
+    // "key lacks ai:execute_admin" test below stays a real denial); override
+    // it here with a wildcard-permissioned creator so the coarse scope
+    // re-clamp passes and this test can exercise the ACTUAL concern under
+    // test — the MCP_EXECUTE_TOOL_ALLOWLIST gate, not scope delegation.
+    vi.doMock('../services/permissions', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../services/permissions')>();
+      return {
+        ...actual,
+        getUserPermissions: vi.fn(async () => ({
+          permissions: [{ resource: '*', action: '*' }],
+          partnerId: null,
+          orgId: 'org-1',
+          roleId: 'role-1',
+          scope: 'organization' as const,
+        })),
+      };
+    });
     mockRealGuardrailsWithRegistryTier1();
 
     const { mcpServerRoutes } = await import('./mcpServer');
@@ -1574,6 +1617,23 @@ describe('MCP bootstrap carve-out', () => {
     delete process.env.IS_HOSTED;
     process.env.NODE_ENV = 'development';
     mockKeyWithScopes(['ai:read', 'ai:execute', 'ai:execute_admin']);
+    // SR2-15 (Task 3, scope re-clamp): same override as the C2 allowlist test
+    // above — this key's ai:execute_admin scope needs the wildcard ADMIN_ALL
+    // grant to pass the coarse re-clamp; the concern under test here is the
+    // non-finite-tier fail-closed guard, not scope delegation.
+    vi.doMock('../services/permissions', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../services/permissions')>();
+      return {
+        ...actual,
+        getUserPermissions: vi.fn(async () => ({
+          permissions: [{ resource: '*', action: '*' }],
+          partnerId: null,
+          orgId: 'org-1',
+          roleId: 'role-1',
+          scope: 'organization' as const,
+        })),
+      };
+    });
 
     const executeTool = vi.fn(async () => JSON.stringify({ ok: true }));
     vi.doMock('../services/aiTools', () => ({
@@ -1604,6 +1664,36 @@ describe('MCP bootstrap carve-out', () => {
     expect(body.error?.code).toBe(-32000);
     expect(body.error?.message).toContain('Unable to evaluate tool guardrails');
     expect(executeTool).not.toHaveBeenCalled();
+
+    // `vi.doMock` registrations aren't cleared by `vi.resetModules()` — restore
+    // the file's default (non-wildcard) getUserPermissions mock so it doesn't
+    // leak forward into the "MCP instructions + prompts" tests below (doUnmock
+    // would strip the top-level `vi.mock` for the rest of the file, so we
+    // re-register the default factory explicitly instead).
+    vi.doMock('../services/permissions', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../services/permissions')>();
+      return {
+        ...actual,
+        getUserPermissions: vi.fn(async () => ({
+          permissions: [
+            { resource: 'devices', action: 'read' },
+            { resource: 'devices', action: 'write' },
+            { resource: 'devices', action: 'execute' },
+            { resource: 'alerts', action: 'read' },
+            { resource: 'alerts', action: 'write' },
+            { resource: 'scripts', action: 'read' },
+            { resource: 'scripts', action: 'write' },
+            { resource: 'scripts', action: 'execute' },
+            { resource: 'automations', action: 'read' },
+            { resource: 'automations', action: 'write' },
+          ],
+          partnerId: null,
+          orgId: 'org-1',
+          roleId: 'role-1',
+          scope: 'organization' as const,
+        })),
+      };
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -33,7 +33,7 @@ import type { PgColumn } from 'drizzle-orm/pg-core';
 import type { AuthContext } from '../middleware/auth';
 import { siteAccessCheck } from '../middleware/auth';
 import { getUserPermissions } from '../services/permissions';
-import { authorizeHumanApiKeyCreator } from '../services/apiKeyAuthorization';
+import { authorizeHumanApiKeyCreator, authorizeServicePrincipalKey } from '../services/apiKeyAuthorization';
 import { getActiveOrgTenant } from '../services/tenantStatus';
 import { resolveServerUrl } from '../services/recoveryBootstrap';
 import { resolveSiteAllowedDeviceIds, deviceSiteDenied } from '../services/aiToolsSiteScope';
@@ -256,6 +256,12 @@ type McpApiKeyWithAuthFields = McpApiKeyContext & {
   scopes: string[];
   name: string;
   createdBy: string;
+  // SR2-15: 'human' (default, or absent for OAuth-bearer callers) | 'service'.
+  // Set by apiKeyAuthMiddleware's `c.set('apiKey', ...)` for X-API-Key
+  // callers; OAuth bearer tokens never carry it (they're always human) so
+  // buildAuthFromApiKey treats an absent/undefined value as 'human'.
+  principalType?: string;
+  principalId?: string | null;
 };
 
 function buildMcpAuditAction(method: string): string {
@@ -465,6 +471,8 @@ async function buildCheckedAuthFromApiKey(
     name: apiKey.name,
     createdBy: apiKey.createdBy,
     scopes: apiKey.scopes,
+    principalType: apiKey.principalType,
+    principalId: apiKey.principalId ?? null,
   });
 
   // SR2-15 fail-closed: buildAuthFromApiKey returns null when the key's creator
@@ -1840,6 +1848,8 @@ async function buildAuthFromApiKey(apiKey: {
   name: string;
   createdBy: string;
   scopes: string[];
+  principalType?: string;
+  principalId?: string | null;
 }): Promise<AuthContext | null> {
   const user = {
     id: apiKey.createdBy,
@@ -1866,6 +1876,15 @@ async function buildAuthFromApiKey(apiKey: {
     // unreadable. The key remains org-scoped (orgCondition pins to this org).
     const partnerId =
       apiKey.partnerId ?? (await getActiveOrgTenant(apiKey.orgId))?.partnerId ?? null;
+
+    // SR2-15 (PR 5): a service-principal key (principalType === 'service')
+    // is authorized against the PRINCIPAL, never the human who last rotated
+    // it — `createdBy` on a service key is an audit trail (who minted the
+    // current key), not an acting identity to delegate from. Human keys (the
+    // default; also every OAuth-bearer caller, which never carries
+    // principalType) take the unchanged authorizeHumanApiKeyCreator path.
+    const isServicePrincipalKey = apiKey.principalType === 'service' && !!apiKey.principalId;
+
     // SR2-15: LIVE-authorize the human creator via the shared resolver — it does
     // BOTH the null-perms fail-closed deny (#2510) AND the scope re-clamp this
     // task adds. The old code read `creatorPerms?.allowedSiteIds` off a raw
@@ -1879,15 +1898,20 @@ async function buildAuthFromApiKey(apiKey: {
     // original, now-stale, broader scopes — the MCP path never re-clamped. A
     // key delegates its creator's authority; it must never outlive a reduction
     // in that authority, any more than it may outlive its total loss.
-    const authz = await authorizeHumanApiKeyCreator({
-      createdBy: apiKey.createdBy,
-      orgId: apiKey.orgId,
-      partnerId,
-      scopes: apiKey.scopes ?? [],
-    });
+    const authz = isServicePrincipalKey
+      ? await authorizeServicePrincipalKey({
+          principalId: apiKey.principalId as string,
+          scopes: apiKey.scopes ?? [],
+        })
+      : await authorizeHumanApiKeyCreator({
+          createdBy: apiKey.createdBy,
+          orgId: apiKey.orgId,
+          partnerId,
+          scopes: apiKey.scopes ?? [],
+        });
     if (!authz.ok) {
-      // buildCheckedAuthFromApiKey maps null -> 403 (creator has no access, or
-      // the key's scopes exceed the creator's current permissions).
+      // buildCheckedAuthFromApiKey maps null -> 403 (creator/principal has no
+      // access, or the key's scopes exceed the current permission/scope ceiling).
       return null;
     }
     const allowedSiteIds = authz.allowedSiteIds;

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -33,6 +33,7 @@ import type { PgColumn } from 'drizzle-orm/pg-core';
 import type { AuthContext } from '../middleware/auth';
 import { siteAccessCheck } from '../middleware/auth';
 import { getUserPermissions } from '../services/permissions';
+import { authorizeHumanApiKeyCreator } from '../services/apiKeyAuthorization';
 import { getActiveOrgTenant } from '../services/tenantStatus';
 import { resolveServerUrl } from '../services/recoveryBootstrap';
 import { resolveSiteAllowedDeviceIds, deviceSiteDenied } from '../services/aiToolsSiteScope';
@@ -463,6 +464,7 @@ async function buildCheckedAuthFromApiKey(
     partnerId: apiKey.partnerId ?? null,
     name: apiKey.name,
     createdBy: apiKey.createdBy,
+    scopes: apiKey.scopes,
   });
 
   // SR2-15 fail-closed: buildAuthFromApiKey returns null when the key's creator
@@ -1837,6 +1839,7 @@ async function buildAuthFromApiKey(apiKey: {
   partnerId: string | null;
   name: string;
   createdBy: string;
+  scopes: string[];
 }): Promise<AuthContext | null> {
   const user = {
     id: apiKey.createdBy,
@@ -1863,29 +1866,31 @@ async function buildAuthFromApiKey(apiKey: {
     // unreadable. The key remains org-scoped (orgCondition pins to this org).
     const partnerId =
       apiKey.partnerId ?? (await getActiveOrgTenant(apiKey.orgId))?.partnerId ?? null;
-    const creatorPerms = await getUserPermissions(apiKey.createdBy, {
-      partnerId: partnerId || undefined,
+    // SR2-15: LIVE-authorize the human creator via the shared resolver — it does
+    // BOTH the null-perms fail-closed deny (#2510) AND the scope re-clamp this
+    // task adds. The old code read `creatorPerms?.allowedSiteIds` off a raw
+    // getUserPermissions() call: a null read collapsed to `undefined`, and
+    // siteAccessCheck(undefined) means "full access to EVERY site in the org" —
+    // the same value a legitimate full-access admin gets. #2510 already closed
+    // that hole with an explicit null-check. What #2510 did NOT do: re-validate
+    // that the key's STORED scopes are still backed by the creator's CURRENT
+    // permissions. A creator whose role was downgraded after the key was minted
+    // (e.g. admin -> read-only) would still have their key served with the
+    // original, now-stale, broader scopes — the MCP path never re-clamped. A
+    // key delegates its creator's authority; it must never outlive a reduction
+    // in that authority, any more than it may outlive its total loss.
+    const authz = await authorizeHumanApiKeyCreator({
+      createdBy: apiKey.createdBy,
       orgId: apiKey.orgId,
+      partnerId,
+      scopes: apiKey.scopes ?? [],
     });
-    // SR2-15 fail-closed: getUserPermissions returns null when the creating user
-    // has NO resolvable authority for this org — neither an organization_users
-    // role on the org NOR a partner_users role on the owning partner (e.g. a
-    // still-`active` user stripped of the membership this key derives from). We
-    // must NOT let that null collapse through the old `creatorPerms?.allowedSiteIds`
-    // into `undefined`, which siteAccessCheck() reads as "full access to EVERY
-    // site in the org" — the identical value a legitimate full-access admin gets.
-    // A key delegates its creator's authority; with none to delegate, the key has
-    // none. Reject it (buildCheckedAuthFromApiKey maps null → 403).
-    //
-    // Unaffected: a legitimate full-access admin returns a NON-null perms object
-    // whose allowedSiteIds is undefined (state 2) — still all-sites; a
-    // site-restricted creator returns a non-null object with an explicit list
-    // (state 3) — restriction preserved. A partner-admin-minted key resolves via
-    // the partner axis to a non-null object, so those keep working too.
-    if (!creatorPerms) {
+    if (!authz.ok) {
+      // buildCheckedAuthFromApiKey maps null -> 403 (creator has no access, or
+      // the key's scopes exceed the creator's current permissions).
       return null;
     }
-    const allowedSiteIds = creatorPerms.allowedSiteIds;
+    const allowedSiteIds = authz.allowedSiteIds;
     return {
       user,
       token: {} as AuthContext['token'],
@@ -1901,6 +1906,28 @@ async function buildAuthFromApiKey(apiKey: {
   }
 
   // Partner-scope caller (OAuth bearer token, or API key with no orgId).
+  //
+  // SR2-15: this branch had no explicit null-perms deny — an off-boarded
+  // partner admin's bearer key was only "data-starved" (accessibleOrgIds
+  // resolves to [] via resolvePartnerAccessibleOrgIds, which reads
+  // partner_users fresh and returns [] when the membership row is gone),
+  // never outright rejected. That's an unsatisfiable org filter, not a
+  // denial: tools/list still succeeds and the caller looks authenticated.
+  // Add an explicit reject so an off-boarded partner admin's key is denied,
+  // matching the org-scope branch's fail-closed behavior above.
+  if (apiKey.partnerId) {
+    let partnerPerms: Awaited<ReturnType<typeof getUserPermissions>>;
+    try {
+      partnerPerms = await getUserPermissions(apiKey.createdBy, { partnerId: apiKey.partnerId });
+    } catch {
+      // FAIL CLOSED: a DB/RLS error is indistinguishable from "no access".
+      return null;
+    }
+    if (!partnerPerms) {
+      return null;
+    }
+  }
+
   // Resolve the concrete org allowlist so orgCondition / canAccessOrg are
   // consistent and defense-in-depth filtering works alongside RLS.
   const accessibleOrgIds = apiKey.partnerId

--- a/apps/api/src/routes/servicePrincipals.test.ts
+++ b/apps/api/src/routes/servicePrincipals.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { servicePrincipalRoutes } from './servicePrincipals';
+
+const ORG_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const OTHER_ORG_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const PRINCIPAL_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const KEY_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+vi.mock('../services', () => ({}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([]))
+        }))
+      }))
+    }))
+  }
+}));
+
+vi.mock('../db/schema', () => ({
+  servicePrincipals: { id: 'id', orgId: 'orgId', status: 'status', createdAt: 'createdAt' }
+}));
+
+vi.mock('../services/servicePrincipals', () => {
+  class ServicePrincipalNotFoundError extends Error {}
+  class ApiKeyNotFoundError extends Error {}
+  return {
+    createServicePrincipal: vi.fn(),
+    rotateServicePrincipalKey: vi.fn(),
+    disableServicePrincipal: vi.fn(),
+    migrateHumanKeyToServicePrincipal: vi.fn(),
+    ServicePrincipalNotFoundError,
+    ApiKeyNotFoundError
+  };
+});
+
+// Mutable switch for the requirePermission mock so individual tests can
+// simulate a caller whose role LACKS the gated permission (the real
+// middleware 403s). Hoisted because the vi.mock factory below references it.
+// Reset to granted in beforeEach. This is what proves guard-bite (c): the
+// migrate-key route actually runs through requirePermission, not a rubber
+// stamp — flip this to false and the 403 assertion goes RED.
+const permissionMockState = vi.hoisted(() => ({ granted: true }));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => next()),
+  requireScope: vi.fn((...scopes: string[]) => (c: any, next: any) => {
+    const auth = c.get('auth');
+    if (!auth || !scopes.includes(auth.scope)) {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+    return next();
+  }),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    if (!permissionMockState.granted) {
+      return c.json({ error: 'Permission denied' }, 403);
+    }
+    return next();
+  }),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next())
+}));
+
+import { db } from '../db';
+import { authMiddleware } from '../middleware/auth';
+import {
+  createServicePrincipal,
+  rotateServicePrincipalKey,
+  disableServicePrincipal,
+  migrateHumanKeyToServicePrincipal,
+  ServicePrincipalNotFoundError,
+  ApiKeyNotFoundError
+} from '../services/servicePrincipals';
+
+describe('service principal routes', () => {
+  let app: Hono;
+
+  const setAuth = (overrides: Partial<{ scope: 'system' | 'partner' | 'organization'; orgId: string | null }> = {}) => {
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        scope: overrides.scope ?? 'organization',
+        partnerId: null,
+        orgId: 'orgId' in overrides ? overrides.orgId : ORG_ID,
+        user: { id: 'user-123', email: 'test@example.com' },
+        accessibleOrgIds: [ORG_ID],
+        canAccessOrg: (orgId: string) => orgId === ORG_ID
+      });
+      return next();
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    permissionMockState.granted = true;
+    setAuth();
+    app = new Hono();
+    app.route('/service-principals', servicePrincipalRoutes);
+  });
+
+  describe('GET /service-principals', () => {
+    it('lists principals scoped to the caller org', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{ count: 1 }]) })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockResolvedValue([{ id: PRINCIPAL_ID, orgId: ORG_ID, status: 'active' }])
+                })
+              })
+            })
+          })
+        } as any);
+
+      const res = await app.request('/service-principals?page=1&limit=50');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+      expect(body.pagination.total).toBe(1);
+    });
+  });
+
+  describe('POST /service-principals', () => {
+    it('creates a principal for the caller org', async () => {
+      vi.mocked(createServicePrincipal).mockResolvedValue({
+        id: PRINCIPAL_ID,
+        orgId: ORG_ID,
+        name: 'CI bot',
+        status: 'active',
+        scopes: ['ai:read'],
+        createdBy: 'user-123',
+        lastUpdatedBy: null,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      } as any);
+
+      const res = await app.request('/service-principals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: ORG_ID, name: 'CI bot', scopes: ['ai:read'] })
+      });
+
+      expect(res.status).toBe(201);
+      expect(createServicePrincipal).toHaveBeenCalledWith({
+        orgId: ORG_ID,
+        name: 'CI bot',
+        scopes: ['ai:read'],
+        createdBy: 'user-123'
+      });
+    });
+
+    it('rejects creating a principal for a different org (organization scope)', async () => {
+      const res = await app.request('/service-principals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: OTHER_ORG_ID, name: 'CI bot', scopes: [] })
+      });
+
+      expect(res.status).toBe(403);
+      expect(createServicePrincipal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /service-principals/:id/rotate', () => {
+    it('404s when the principal does not exist (org-access gate query returns nothing)', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }) })
+      } as any);
+
+      const res = await app.request(`/service-principals/${PRINCIPAL_ID}/rotate`, { method: 'POST' });
+
+      expect(res.status).toBe(404);
+      expect(rotateServicePrincipalKey).not.toHaveBeenCalled();
+    });
+
+    it('rotates the key and returns the raw key once', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: PRINCIPAL_ID, orgId: ORG_ID }]) })
+        })
+      } as any);
+      vi.mocked(rotateServicePrincipalKey).mockResolvedValue({
+        apiKeyId: 'key-new',
+        key: 'brz_newkey',
+        keyPrefix: 'brz_newkey'
+      });
+
+      const res = await app.request(`/service-principals/${PRINCIPAL_ID}/rotate`, { method: 'POST' });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.key).toBe('brz_newkey');
+      expect(rotateServicePrincipalKey).toHaveBeenCalledWith(PRINCIPAL_ID, 'user-123');
+    });
+
+    it('denies cross-org rotate (org-access gate)', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: PRINCIPAL_ID, orgId: OTHER_ORG_ID }])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/service-principals/${PRINCIPAL_ID}/rotate`, { method: 'POST' });
+
+      expect(res.status).toBe(403);
+      expect(rotateServicePrincipalKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /service-principals/:id/disable', () => {
+    it('disables the principal (cascade revoke happens in the service layer)', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: PRINCIPAL_ID, orgId: ORG_ID }]) })
+        })
+      } as any);
+      vi.mocked(disableServicePrincipal).mockResolvedValue({
+        id: PRINCIPAL_ID,
+        orgId: ORG_ID,
+        name: 'CI bot',
+        status: 'disabled',
+        scopes: [],
+        createdBy: 'user-123',
+        lastUpdatedBy: 'user-123',
+        createdAt: new Date(),
+        updatedAt: new Date()
+      } as any);
+
+      const res = await app.request(`/service-principals/${PRINCIPAL_ID}/disable`, { method: 'POST' });
+
+      expect(res.status).toBe(200);
+      expect(disableServicePrincipal).toHaveBeenCalledWith(PRINCIPAL_ID, 'user-123');
+    });
+
+    it('maps ServicePrincipalNotFoundError from the service layer to 404', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: PRINCIPAL_ID, orgId: ORG_ID }]) })
+        })
+      } as any);
+      vi.mocked(disableServicePrincipal).mockRejectedValue(new ServicePrincipalNotFoundError(PRINCIPAL_ID));
+
+      const res = await app.request(`/service-principals/${PRINCIPAL_ID}/disable`, { method: 'POST' });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /service-principals/:id/migrate-key', () => {
+    // Guard-bite (c): migrateHumanKeyToServicePrincipal requires org-admin —
+    // a non-admin actor gets 403. This is the only route that flips
+    // api_keys.principal_type; if requirePermission were ever removed from
+    // this route's middleware chain, this test goes RED.
+    it('403s a non-admin caller (requirePermission gate) and never calls the service', async () => {
+      permissionMockState.granted = false;
+
+      const res = await app.request(`/service-principals/${PRINCIPAL_ID}/migrate-key`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ keyId: KEY_ID })
+      });
+
+      expect(res.status).toBe(403);
+      expect(migrateHumanKeyToServicePrincipal).not.toHaveBeenCalled();
+    });
+
+    it('migrates the key for an authorized org-admin caller', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: PRINCIPAL_ID, orgId: ORG_ID }]) })
+        })
+      } as any);
+      vi.mocked(migrateHumanKeyToServicePrincipal).mockResolvedValue({
+        id: KEY_ID,
+        orgId: ORG_ID,
+        principalType: 'service',
+        principalId: PRINCIPAL_ID,
+        scopes: ['ai:read']
+      } as any);
+
+      const res = await app.request(`/service-principals/${PRINCIPAL_ID}/migrate-key`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ keyId: KEY_ID })
+      });
+
+      expect(res.status).toBe(200);
+      expect(migrateHumanKeyToServicePrincipal).toHaveBeenCalledWith(KEY_ID, PRINCIPAL_ID, 'user-123');
+    });
+
+    it('maps ApiKeyNotFoundError from the service layer to 404', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: PRINCIPAL_ID, orgId: ORG_ID }]) })
+        })
+      } as any);
+      vi.mocked(migrateHumanKeyToServicePrincipal).mockRejectedValue(new ApiKeyNotFoundError(KEY_ID));
+
+      const res = await app.request(`/service-principals/${PRINCIPAL_ID}/migrate-key`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ keyId: KEY_ID })
+      });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('JWT-only surface', () => {
+    it('never imports apiKeyAuthMiddleware — a service-principal key has no management surface (SR2-15)', async () => {
+      // Structural guard: an API-key-authed request can never reach these
+      // routes because they are mounted behind authMiddleware (JWT) only.
+      // Assert the source itself never wires in the API-key auth path, so a
+      // future edit that adds `apiKeyAuthMiddleware` to this file's
+      // middleware chain fails loudly instead of silently opening a
+      // management surface to service-account credentials.
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const source = fs.readFileSync(path.join(__dirname, 'servicePrincipals.ts'), 'utf8');
+      expect(source).not.toContain("from '../middleware/apiKeyAuth'");
+    });
+  });
+});

--- a/apps/api/src/routes/servicePrincipals.ts
+++ b/apps/api/src/routes/servicePrincipals.ts
@@ -1,0 +1,310 @@
+import { Hono } from 'hono';
+import { zValidator } from '../lib/validation';
+import { z } from 'zod';
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { db } from '../db';
+import { servicePrincipals } from '../db/schema';
+import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
+import { PERMISSIONS } from '../services/permissions';
+import {
+  createServicePrincipal,
+  rotateServicePrincipalKey,
+  disableServicePrincipal,
+  migrateHumanKeyToServicePrincipal,
+  ServicePrincipalNotFoundError,
+  ApiKeyNotFoundError,
+} from '../services/servicePrincipals';
+
+// SR2-15: service-principal management. Mounted behind `authMiddleware` ONLY
+// (never `apiKeyAuthMiddleware`) — these routes are JWT-user-only by design.
+// A service-principal key itself has no interactive-login / MFA / recovery
+// surface, so it must never be able to reach its own management surface;
+// authMiddleware requires a `Bearer` JWT and rejects an X-API-Key-only
+// request outright, which is what enforces that here.
+export const servicePrincipalRoutes = new Hono();
+
+// ============================================
+// Helpers
+// ============================================
+
+async function ensureOrgAccess(
+  orgId: string,
+  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>
+) {
+  if (auth.scope === 'organization') {
+    return auth.orgId === orgId;
+  }
+  if (auth.scope === 'partner') {
+    return auth.canAccessOrg(orgId);
+  }
+  // system scope has access to all
+  return true;
+}
+
+function getPagination(query: { page?: string; limit?: string }) {
+  const page = Math.max(1, Number.parseInt(query.page ?? '1', 10) || 1);
+  const limit = Math.min(100, Math.max(1, Number.parseInt(query.limit ?? '50', 10) || 50));
+  return { page, limit, offset: (page - 1) * limit };
+}
+
+function mapServicePrincipalError(err: unknown): { status: 404 | 400; error: string } | null {
+  if (err instanceof ServicePrincipalNotFoundError) {
+    return { status: 404, error: 'Service principal not found' };
+  }
+  if (err instanceof ApiKeyNotFoundError) {
+    return { status: 404, error: 'API key not found' };
+  }
+  if (err instanceof Error && err.message.includes('different organization')) {
+    return { status: 400, error: err.message };
+  }
+  return null;
+}
+
+// ============================================
+// Validation schemas
+// ============================================
+
+const listServicePrincipalsSchema = z.object({
+  page: z.string().optional(),
+  limit: z.string().optional(),
+  orgId: z.string().guid().optional(),
+  status: z.enum(['active', 'disabled']).optional(),
+});
+
+const createServicePrincipalSchema = z.object({
+  orgId: z.string().guid(),
+  name: z.string().min(1).max(255),
+  scopes: z.array(z.string()).default([]),
+});
+
+const migrateKeySchema = z.object({
+  keyId: z.string().guid(),
+});
+
+const principalIdParamSchema = z.object({ id: z.string().guid() });
+
+// ============================================
+// Routes
+// ============================================
+
+servicePrincipalRoutes.use('*', authMiddleware);
+
+// GET /service-principals - list for org
+servicePrincipalRoutes.get(
+  '/',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action),
+  zValidator('query', listServicePrincipalsSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const query = c.req.valid('query');
+    const { page, limit, offset } = getPagination(query);
+
+    const conditions: ReturnType<typeof eq>[] = [];
+
+    if (auth.scope === 'organization') {
+      if (!auth.orgId) {
+        return c.json({ error: 'Organization context required' }, 403);
+      }
+      conditions.push(eq(servicePrincipals.orgId, auth.orgId));
+    } else if (auth.scope === 'partner') {
+      if (query.orgId) {
+        const hasAccess = await ensureOrgAccess(query.orgId, auth);
+        if (!hasAccess) {
+          return c.json({ error: 'Access to this organization denied' }, 403);
+        }
+        conditions.push(eq(servicePrincipals.orgId, query.orgId));
+      } else {
+        const orgIds = auth.accessibleOrgIds ?? [];
+        if (orgIds.length === 0) {
+          return c.json({ data: [], pagination: { page, limit, total: 0 } });
+        }
+        conditions.push(inArray(servicePrincipals.orgId, orgIds) as ReturnType<typeof eq>);
+      }
+    } else if (auth.scope === 'system' && query.orgId) {
+      conditions.push(eq(servicePrincipals.orgId, query.orgId));
+    }
+
+    if (query.status) {
+      conditions.push(eq(servicePrincipals.status, query.status));
+    }
+
+    const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const countResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(servicePrincipals)
+      .where(whereCondition);
+    const total = Number(countResult[0]?.count ?? 0);
+
+    const list = await db
+      .select()
+      .from(servicePrincipals)
+      .where(whereCondition)
+      .orderBy(desc(servicePrincipals.createdAt))
+      .limit(limit)
+      .offset(offset);
+
+    return c.json({ data: list, pagination: { page, limit, total } });
+  }
+);
+
+// POST /service-principals - create
+servicePrincipalRoutes.post(
+  '/',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
+  requireMfa(),
+  zValidator('json', createServicePrincipalSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const data = c.req.valid('json');
+
+    if (auth.scope === 'organization') {
+      if (!auth.orgId) {
+        return c.json({ error: 'Organization context required' }, 403);
+      }
+      if (data.orgId !== auth.orgId) {
+        return c.json({ error: 'Can only create service principals for your organization' }, 403);
+      }
+    } else if (auth.scope === 'partner') {
+      const hasAccess = await ensureOrgAccess(data.orgId, auth);
+      if (!hasAccess) {
+        return c.json({ error: 'Access to this organization denied' }, 403);
+      }
+    }
+
+    const principal = await createServicePrincipal({
+      orgId: data.orgId,
+      name: data.name,
+      scopes: data.scopes,
+      createdBy: auth.user.id,
+    });
+
+    return c.json(principal, 201);
+  }
+);
+
+// GET /service-principals/:id
+servicePrincipalRoutes.get(
+  '/:id',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action),
+  zValidator('param', principalIdParamSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id } = c.req.valid('param');
+
+    const [principal] = await db
+      .select()
+      .from(servicePrincipals)
+      .where(eq(servicePrincipals.id, id))
+      .limit(1);
+
+    if (!principal) {
+      return c.json({ error: 'Service principal not found' }, 404);
+    }
+
+    const hasAccess = await ensureOrgAccess(principal.orgId, auth);
+    if (!hasAccess) {
+      return c.json({ error: 'Access denied' }, 403);
+    }
+
+    return c.json(principal);
+  }
+);
+
+async function requirePrincipalOrgAccess(c: any, id: string) {
+  const auth = c.get('auth') as AuthContext;
+  const [principal] = await db
+    .select()
+    .from(servicePrincipals)
+    .where(eq(servicePrincipals.id, id))
+    .limit(1);
+
+  if (!principal) {
+    return { response: c.json({ error: 'Service principal not found' }, 404) };
+  }
+
+  const hasAccess = await ensureOrgAccess(principal.orgId, auth);
+  if (!hasAccess) {
+    return { response: c.json({ error: 'Access denied' }, 403) };
+  }
+
+  return { principal, auth };
+}
+
+// POST /service-principals/:id/rotate - mint a new key, revoke the prior one
+servicePrincipalRoutes.post(
+  '/:id/rotate',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
+  requireMfa(),
+  zValidator('param', principalIdParamSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const gate = await requirePrincipalOrgAccess(c, id);
+    if ('response' in gate) return gate.response;
+
+    try {
+      const rotated = await rotateServicePrincipalKey(id, gate.auth.user.id);
+      return c.json({
+        ...rotated,
+        warning: 'Store this new API key securely. The old key has been revoked and this new key will not be shown again.',
+      });
+    } catch (err) {
+      const mapped = mapServicePrincipalError(err);
+      if (mapped) return c.json({ error: mapped.error }, mapped.status);
+      throw err;
+    }
+  }
+);
+
+// POST /service-principals/:id/disable - disable and cascade-revoke keys
+servicePrincipalRoutes.post(
+  '/:id/disable',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
+  requireMfa(),
+  zValidator('param', principalIdParamSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const gate = await requirePrincipalOrgAccess(c, id);
+    if ('response' in gate) return gate.response;
+
+    try {
+      const disabled = await disableServicePrincipal(id, gate.auth.user.id);
+      return c.json(disabled);
+    } catch (err) {
+      const mapped = mapServicePrincipalError(err);
+      if (mapped) return c.json({ error: mapped.error }, mapped.status);
+      throw err;
+    }
+  }
+);
+
+// POST /service-principals/:id/migrate-key - re-point an existing human key
+// onto this principal. The ONLY path that flips api_keys.principal_type.
+servicePrincipalRoutes.post(
+  '/:id/migrate-key',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
+  requireMfa(),
+  zValidator('param', principalIdParamSchema),
+  zValidator('json', migrateKeySchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const { keyId } = c.req.valid('json');
+    const gate = await requirePrincipalOrgAccess(c, id);
+    if ('response' in gate) return gate.response;
+
+    try {
+      const migrated = await migrateHumanKeyToServicePrincipal(keyId, id, gate.auth.user.id);
+      return c.json(migrated);
+    } catch (err) {
+      const mapped = mapServicePrincipalError(err);
+      if (mapped) return c.json({ error: mapped.error }, mapped.status);
+      throw err;
+    }
+  }
+);

--- a/apps/api/src/services/apiKeyAuthorization.test.ts
+++ b/apps/api/src/services/apiKeyAuthorization.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// `apiKeyScopes.ts` (exercised for real below — it is NOT mocked) also imports
+// PERMISSIONS/hasPermission from this module, so a full-replacement factory
+// would blank those out for every importer in the graph. Keep the real
+// exports via importOriginal and only override getUserPermissions.
+vi.mock('./permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./permissions')>();
+  return {
+    ...actual,
+    getUserPermissions: vi.fn(),
+  };
+});
+
+import { authorizeHumanApiKeyCreator } from './apiKeyAuthorization';
+import { getUserPermissions } from './permissions';
+import type { UserPermissions } from './permissions';
+
+// A creator who holds devices:read + devices:write on the org axis.
+const fullPerms: UserPermissions = {
+  permissions: [
+    { resource: 'devices', action: 'read' },
+    { resource: 'devices', action: 'write' },
+  ],
+  partnerId: null,
+  orgId: 'org-1',
+  roleId: 'role-1',
+  scope: 'organization',
+  allowedSiteIds: ['site-a'],
+} as UserPermissions;
+
+describe('authorizeHumanApiKeyCreator', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('authorizes when the creator still holds every stored scope, returning live allowedSiteIds', async () => {
+    vi.mocked(getUserPermissions).mockResolvedValue(fullPerms);
+    const res = await authorizeHumanApiKeyCreator({
+      createdBy: 'user-1', orgId: 'org-1', partnerId: 'partner-1', scopes: ['devices:read', 'devices:write'],
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.allowedSiteIds).toEqual(['site-a']);
+      expect(res.clampedScopes).toEqual(['devices:read', 'devices:write']);
+    }
+    // Both axes offered so a partner-admin creator (no org row) still resolves.
+    expect(getUserPermissions).toHaveBeenCalledWith('user-1', { orgId: 'org-1', partnerId: 'partner-1' });
+  });
+
+  it('DENIES (no_membership) when the creator has no live membership on either axis (null perms) — the off-boarding gate and the fail-closed rule', async () => {
+    vi.mocked(getUserPermissions).mockResolvedValue(null);
+    const res = await authorizeHumanApiKeyCreator({
+      createdBy: 'user-1', orgId: 'org-1', partnerId: 'partner-1', scopes: ['devices:read'],
+    });
+    expect(res).toEqual({ ok: false, reason: 'no_membership' });
+  });
+
+  it('DENIES (scope_exceeds_current_permissions) when the creator no longer holds a stored scope (permission reduction re-clamp)', async () => {
+    const reduced = { ...fullPerms, permissions: [{ resource: 'devices', action: 'read' }] } as UserPermissions;
+    vi.mocked(getUserPermissions).mockResolvedValue(reduced);
+    const res = await authorizeHumanApiKeyCreator({
+      createdBy: 'user-1', orgId: 'org-1', partnerId: 'partner-1', scopes: ['devices:read', 'devices:write'],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('scope_exceeds_current_permissions');
+  });
+
+  it('FAILS CLOSED (no_membership) when the permission read THROWS (DB/RLS error), never authorizing', async () => {
+    vi.mocked(getUserPermissions).mockRejectedValue(new Error('RLS/DB down'));
+    const res = await authorizeHumanApiKeyCreator({
+      createdBy: 'user-1', orgId: 'org-1', partnerId: 'partner-1', scopes: ['devices:read'],
+    });
+    expect(res).toEqual({ ok: false, reason: 'no_membership' });
+  });
+});

--- a/apps/api/src/services/apiKeyAuthorization.test.ts
+++ b/apps/api/src/services/apiKeyAuthorization.test.ts
@@ -12,9 +12,28 @@ vi.mock('./permissions', async (importOriginal) => {
   };
 });
 
-import { authorizeHumanApiKeyCreator } from './apiKeyAuthorization';
+vi.mock('../db', () => ({
+  db: { select: vi.fn() },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  servicePrincipals: { id: 'id', status: 'status', scopes: 'scopes' },
+}));
+
+import { authorizeHumanApiKeyCreator, authorizeServicePrincipalKey } from './apiKeyAuthorization';
 import { getUserPermissions } from './permissions';
+import { db } from '../db';
 import type { UserPermissions } from './permissions';
+
+const buildSelectMock = (result: unknown[]) =>
+  vi.mocked(db.select).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(result),
+      }),
+    }),
+  } as any);
 
 // A creator who holds devices:read + devices:write on the org axis.
 const fullPerms: UserPermissions = {
@@ -70,5 +89,65 @@ describe('authorizeHumanApiKeyCreator', () => {
       createdBy: 'user-1', orgId: 'org-1', partnerId: 'partner-1', scopes: ['devices:read'],
     });
     expect(res).toEqual({ ok: false, reason: 'no_membership' });
+  });
+});
+
+describe('authorizeServicePrincipalKey', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('authorizes when the principal is active and the stored scopes are a subset of its current scopes', async () => {
+    buildSelectMock([{ status: 'active', scopes: ['ai:read', 'devices:read'] }]);
+    const res = await authorizeServicePrincipalKey({ principalId: 'principal-1', scopes: ['ai:read'] });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.clampedScopes).toEqual(['ai:read']);
+      expect(res.allowedSiteIds).toBeUndefined();
+      expect(res.permissions).toBeNull();
+    }
+  });
+
+  // Guard-bite (a): a disabled principal's key is rejected.
+  it('DENIES (no_membership) when the principal status is not active (disable-cascade gate)', async () => {
+    buildSelectMock([{ status: 'disabled', scopes: ['ai:read'] }]);
+    const res = await authorizeServicePrincipalKey({ principalId: 'principal-1', scopes: ['ai:read'] });
+    expect(res).toEqual({ ok: false, reason: 'no_membership' });
+  });
+
+  // Guard-bite (d): fail-closed on a missing/errored principal read.
+  it('DENIES (no_membership) when the principal row is missing', async () => {
+    buildSelectMock([]);
+    const res = await authorizeServicePrincipalKey({ principalId: 'principal-missing', scopes: ['ai:read'] });
+    expect(res).toEqual({ ok: false, reason: 'no_membership' });
+  });
+
+  it('FAILS CLOSED (no_membership) when the principal read THROWS (DB/RLS error), never authorizing', async () => {
+    vi.mocked(db.select).mockImplementation(() => {
+      throw new Error('RLS/DB down');
+    });
+    const res = await authorizeServicePrincipalKey({ principalId: 'principal-1', scopes: ['ai:read'] });
+    expect(res).toEqual({ ok: false, reason: 'no_membership' });
+  });
+
+  // Guard-bite (b): a service key's stored scope not covered by the
+  // principal's CURRENT scopes is rejected — this is a plain subset check
+  // against the principal's own ceiling, never a human permission lookup.
+  it('DENIES (scope_exceeds_current_permissions) when a stored scope is not in the principal\'s current scopes', async () => {
+    buildSelectMock([{ status: 'active', scopes: ['ai:read'] }]);
+    const res = await authorizeServicePrincipalKey({
+      principalId: 'principal-1',
+      scopes: ['ai:read', 'ai:execute_admin'],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.reason).toBe('scope_exceeds_current_permissions');
+      expect(res.detail).toMatchObject({ exceededScopes: ['ai:execute_admin'] });
+    }
+  });
+
+  it('reads the principal under withSystemDbAccessContext (auth path runs before request RLS context)', async () => {
+    const { withSystemDbAccessContext } = await import('../db');
+    buildSelectMock([{ status: 'active', scopes: ['ai:read'] }]);
+    await authorizeServicePrincipalKey({ principalId: 'principal-1', scopes: ['ai:read'] });
+    expect(withSystemDbAccessContext).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/apiKeyAuthorization.ts
+++ b/apps/api/src/services/apiKeyAuthorization.ts
@@ -1,0 +1,72 @@
+import { getUserPermissions, type UserPermissions } from './permissions';
+import { validateApiKeyScopeDelegation } from './apiKeyScopes';
+
+/**
+ * SR2-15 live authorization for HUMAN-delegated API keys.
+ *
+ * A human key's authority is DELEGATED from its creating user and must never
+ * outlive that user's authority. On every request we re-resolve the creator's
+ * CURRENT permissions and:
+ *   1. DENY if the creator has no live membership/role on the key's tenant
+ *      (getUserPermissions returns null when neither the org nor the partner
+ *      axis yields a role row) — this is both the off-boarding/membership gate
+ *      and the fail-closed rule for a contextless/errored read.
+ *   2. RE-CLAMP the key's stored scopes against those live permissions; a scope
+ *      the creator no longer holds DENIES (a permission reduction after mint
+ *      cannot be out-run by a key minted while the creator was more powerful).
+ *
+ * We resolve LIVE rather than trusting a mint-time snapshot or an epoch: the
+ * design requires catching out-of-band membership/role SQL changes that call no
+ * app service, and getUserPermissions is already Redis-version-cached and
+ * invalidated by every in-app membership/role mutation, so this is cheap and
+ * always correct. See the PR 5 plan Q1.
+ *
+ * Axis (Q5): BOTH orgId and the org's owning partnerId are offered so a
+ * Partner-Admin creator (who has NO organization_users row for the key's org,
+ * only a partner_users row) still resolves.
+ */
+export type ApiKeyAuthorizationResult =
+  | { ok: true; permissions: UserPermissions; allowedSiteIds: string[] | undefined; clampedScopes: string[] }
+  | { ok: false; reason: 'no_membership' | 'scope_exceeds_current_permissions'; detail?: Record<string, unknown> };
+
+export async function authorizeHumanApiKeyCreator(input: {
+  createdBy: string;
+  orgId: string;
+  partnerId: string | null;
+  scopes: string[];
+}): Promise<ApiKeyAuthorizationResult> {
+  let permissions: UserPermissions | null;
+  try {
+    permissions = await getUserPermissions(input.createdBy, {
+      orgId: input.orgId,
+      partnerId: input.partnerId ?? undefined,
+    });
+  } catch {
+    // FAIL CLOSED: a DB/RLS error is indistinguishable from "no access" and
+    // must never be read as "unrestricted".
+    return { ok: false, reason: 'no_membership' };
+  }
+
+  if (!permissions) {
+    return { ok: false, reason: 'no_membership' };
+  }
+
+  // Re-clamp: the stored scopes must still be fully backed by the creator's
+  // CURRENT permissions. validateApiKeyScopeDelegation returns ok:false (403)
+  // for any scope whose required permission the creator no longer holds.
+  const delegation = validateApiKeyScopeDelegation(input.scopes, permissions);
+  if (!delegation.ok) {
+    return {
+      ok: false,
+      reason: 'scope_exceeds_current_permissions',
+      detail: { error: delegation.error, ...(delegation.details ?? {}) },
+    };
+  }
+
+  return {
+    ok: true,
+    permissions,
+    allowedSiteIds: permissions.allowedSiteIds,
+    clampedScopes: delegation.scopes,
+  };
+}

--- a/apps/api/src/services/apiKeyAuthorization.ts
+++ b/apps/api/src/services/apiKeyAuthorization.ts
@@ -1,5 +1,8 @@
+import { eq } from 'drizzle-orm';
 import { getUserPermissions, type UserPermissions } from './permissions';
 import { validateApiKeyScopeDelegation } from './apiKeyScopes';
+import { db, withSystemDbAccessContext } from '../db';
+import { servicePrincipals } from '../db/schema';
 
 /**
  * SR2-15 live authorization for HUMAN-delegated API keys.
@@ -26,7 +29,15 @@ import { validateApiKeyScopeDelegation } from './apiKeyScopes';
  * only a partner_users row) still resolves.
  */
 export type ApiKeyAuthorizationResult =
-  | { ok: true; permissions: UserPermissions; allowedSiteIds: string[] | undefined; clampedScopes: string[] }
+  | {
+      ok: true;
+      // Service-principal keys have no human creator to derive permissions
+      // from — `permissions` is null for that path (see
+      // authorizeServicePrincipalKey below). Human keys always populate it.
+      permissions: UserPermissions | null;
+      allowedSiteIds: string[] | undefined;
+      clampedScopes: string[];
+    }
   | { ok: false; reason: 'no_membership' | 'scope_exceeds_current_permissions'; detail?: Record<string, unknown> };
 
 export async function authorizeHumanApiKeyCreator(input: {
@@ -68,5 +79,76 @@ export async function authorizeHumanApiKeyCreator(input: {
     permissions,
     allowedSiteIds: permissions.allowedSiteIds,
     clampedScopes: delegation.scopes,
+  };
+}
+
+/**
+ * SR2-15 live authorization for SERVICE-PRINCIPAL API keys.
+ *
+ * A service-principal key's authority is delegated from an explicit,
+ * opt-in `service_principals` row — NOT from a human's live permissions.
+ * On every request we reload the principal and:
+ *   1. DENY if the principal row is missing or `status !== 'active'`
+ *      (the disable-cascade gate).
+ *   2. RE-CLAMP the key's stored scopes against the principal's OWN CURRENT
+ *      `scopes` ceiling — a plain subset check, never a human permission
+ *      lookup. A principal's scopes can be narrowed independently of any
+ *      key minted against it, same shape as the human path's permission
+ *      reduction re-clamp.
+ *
+ * `allowedSiteIds` is always `undefined`: service principals are not
+ * site-restricted in this PR (they are org-scoped only).
+ *
+ * FAIL CLOSED: the DB read is wrapped in try/catch and a null/missing row is
+ * treated identically to an errored read — both DENY. A contextless or
+ * 0-row read that resolves to "authorize" would be a fail-OPEN and must
+ * never exist here.
+ *
+ * `service_principals` is a FORCE-RLS org-scoped (shape-1) table. This
+ * function runs in the pre-request auth path (apiKeyAuth middleware /
+ * mcpServer's buildAuthFromApiKey), before the request's own RLS context is
+ * established, so the read must go through `withSystemDbAccessContext` —
+ * mirroring the PR1 creator-status read in `apiKeyAuth.ts` and
+ * `getActiveOrgTenant`.
+ */
+export async function authorizeServicePrincipalKey(input: {
+  principalId: string;
+  scopes: string[];
+}): Promise<ApiKeyAuthorizationResult> {
+  let principal: { status: string; scopes: string[] | null } | null;
+  try {
+    principal = await withSystemDbAccessContext(async () => {
+      const [row] = await db
+        .select({ status: servicePrincipals.status, scopes: servicePrincipals.scopes })
+        .from(servicePrincipals)
+        .where(eq(servicePrincipals.id, input.principalId))
+        .limit(1);
+      return row ?? null;
+    });
+  } catch {
+    // FAIL CLOSED: a DB/RLS error is indistinguishable from "principal gone"
+    // and must never be read as "unrestricted".
+    return { ok: false, reason: 'no_membership' };
+  }
+
+  if (!principal || principal.status !== 'active') {
+    return { ok: false, reason: 'no_membership' };
+  }
+
+  const principalScopes = new Set(principal.scopes ?? []);
+  const exceededScopes = input.scopes.filter((scope) => !principalScopes.has(scope));
+  if (exceededScopes.length > 0) {
+    return {
+      ok: false,
+      reason: 'scope_exceeds_current_permissions',
+      detail: { exceededScopes, principalScopes: Array.from(principalScopes) },
+    };
+  }
+
+  return {
+    ok: true,
+    permissions: null,
+    allowedSiteIds: undefined,
+    clampedScopes: input.scopes,
   };
 }

--- a/apps/api/src/services/index.ts
+++ b/apps/api/src/services/index.ts
@@ -21,3 +21,5 @@ export { getUserEpochs } from './authEpochs';
 export { getRefreshFamily } from './refreshTokenFamily';
 export { getEffectiveMfaPolicy } from './mfaPolicy';
 export type { EffectiveMfaPolicy, MfaPolicyInput, MfaAllowedMethods } from './mfaPolicy';
+export { authorizeHumanApiKeyCreator } from './apiKeyAuthorization';
+export type { ApiKeyAuthorizationResult } from './apiKeyAuthorization';

--- a/apps/api/src/services/servicePrincipals.test.ts
+++ b/apps/api/src/services/servicePrincipals.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  servicePrincipals: { id: 'id', orgId: 'orgId', status: 'status', scopes: 'scopes' },
+  apiKeys: {
+    id: 'id',
+    orgId: 'orgId',
+    principalId: 'principalId',
+    principalType: 'principalType',
+    status: 'status',
+    scopes: 'scopes',
+  },
+}));
+
+vi.mock('./auditService', () => ({
+  createAuditLogAsync: vi.fn(),
+}));
+
+import { db } from '../db';
+import { createAuditLogAsync } from './auditService';
+import {
+  createServicePrincipal,
+  rotateServicePrincipalKey,
+  disableServicePrincipal,
+  migrateHumanKeyToServicePrincipal,
+  ServicePrincipalNotFoundError,
+  ApiKeyNotFoundError,
+} from './servicePrincipals';
+
+const PRINCIPAL_ID = 'principal-1';
+const ORG_ID = 'org-1';
+const ACTOR_ID = 'actor-1';
+
+function mockSelectOnce(result: unknown[]) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(result),
+      }),
+    }),
+  } as any);
+}
+
+function mockInsertOnce(result: unknown[]) {
+  vi.mocked(db.insert).mockReturnValueOnce({
+    values: vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue(result),
+    }),
+  } as any);
+}
+
+function mockUpdateOnce(result: unknown[]) {
+  const whereMock = vi.fn().mockReturnValue({
+    returning: vi.fn().mockResolvedValue(result),
+  });
+  vi.mocked(db.update).mockReturnValueOnce({
+    set: vi.fn().mockReturnValue({ where: whereMock }),
+  } as any);
+  return whereMock;
+}
+
+// The two "cascade revoke" writes (rotate, disable) don't call .returning() —
+// they're plain update().set().where() awaited directly.
+function mockBareUpdateOnce() {
+  const whereMock = vi.fn().mockResolvedValue(undefined);
+  vi.mocked(db.update).mockReturnValueOnce({
+    set: vi.fn().mockReturnValue({ where: whereMock }),
+  } as any);
+  return whereMock;
+}
+
+describe('createServicePrincipal', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('inserts an active principal row and audits the creation', async () => {
+    mockInsertOnce([
+      { id: PRINCIPAL_ID, orgId: ORG_ID, name: 'CI bot', status: 'active', scopes: ['ai:read'], createdBy: ACTOR_ID },
+    ]);
+
+    const result = await createServicePrincipal({ orgId: ORG_ID, name: 'CI bot', scopes: ['ai:read'], createdBy: ACTOR_ID });
+
+    expect(result).toMatchObject({ id: PRINCIPAL_ID, status: 'active' });
+    expect(createAuditLogAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: ORG_ID, actorId: ACTOR_ID, action: 'service_principal.create', resourceId: PRINCIPAL_ID }),
+    );
+  });
+
+  it('throws when the insert returns no row', async () => {
+    mockInsertOnce([]);
+    await expect(
+      createServicePrincipal({ orgId: ORG_ID, name: 'CI bot', scopes: [], createdBy: ACTOR_ID }),
+    ).rejects.toThrow('Failed to create service principal');
+  });
+});
+
+describe('rotateServicePrincipalKey', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('throws ServicePrincipalNotFoundError when the principal does not exist', async () => {
+    mockSelectOnce([]);
+    await expect(rotateServicePrincipalKey(PRINCIPAL_ID, ACTOR_ID)).rejects.toThrow(ServicePrincipalNotFoundError);
+  });
+
+  it('revokes any prior active key for the principal, mints a new one, and returns the raw key once', async () => {
+    mockSelectOnce([{ id: PRINCIPAL_ID, orgId: ORG_ID, name: 'CI bot', status: 'active', scopes: ['ai:read'] }]);
+    const revokeWhere = mockBareUpdateOnce();
+    mockInsertOnce([
+      { id: 'key-new', orgId: ORG_ID, name: 'CI bot (service key)', keyPrefix: 'brz_abcdefgh', scopes: ['ai:read'], status: 'active' },
+    ]);
+
+    const result = await rotateServicePrincipalKey(PRINCIPAL_ID, ACTOR_ID);
+
+    expect(revokeWhere).toHaveBeenCalled();
+    expect(result.apiKeyId).toBe('key-new');
+    expect(result.key).toMatch(/^brz_/);
+    expect(result.keyPrefix).toBe('brz_abcdefgh');
+    // NEVER audit the raw key or its hash.
+    expect(createAuditLogAsync).toHaveBeenCalledTimes(1);
+    const auditCall = vi.mocked(createAuditLogAsync).mock.calls[0]?.[0];
+    expect(JSON.stringify(auditCall)).not.toContain(result.key);
+  });
+});
+
+describe('disableServicePrincipal', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('throws ServicePrincipalNotFoundError when the principal does not exist', async () => {
+    mockUpdateOnce([]);
+    await expect(disableServicePrincipal(PRINCIPAL_ID, ACTOR_ID)).rejects.toThrow(ServicePrincipalNotFoundError);
+  });
+
+  // Guard-bite (a) supporting coverage: disable cascades to revoke every
+  // active key for the principal (the auth-time deny is proven separately
+  // in apiKeyAuthorization.test.ts).
+  it('sets status=disabled and cascades api_keys.status=revoked for the principal', async () => {
+    mockUpdateOnce([{ id: PRINCIPAL_ID, orgId: ORG_ID, name: 'CI bot', status: 'disabled' }]);
+    const cascadeWhere = mockBareUpdateOnce();
+
+    const result = await disableServicePrincipal(PRINCIPAL_ID, ACTOR_ID);
+
+    expect(result.status).toBe('disabled');
+    expect(cascadeWhere).toHaveBeenCalled();
+    expect(createAuditLogAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'service_principal.disable', resourceId: PRINCIPAL_ID }),
+    );
+  });
+});
+
+describe('migrateHumanKeyToServicePrincipal', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('throws ServicePrincipalNotFoundError when the principal does not exist', async () => {
+    mockSelectOnce([]);
+    await expect(migrateHumanKeyToServicePrincipal('key-1', PRINCIPAL_ID, ACTOR_ID)).rejects.toThrow(
+      ServicePrincipalNotFoundError,
+    );
+  });
+
+  it('throws ApiKeyNotFoundError when the key does not exist', async () => {
+    mockSelectOnce([{ id: PRINCIPAL_ID, orgId: ORG_ID, scopes: ['ai:read'] }]);
+    mockSelectOnce([]);
+    await expect(migrateHumanKeyToServicePrincipal('key-1', PRINCIPAL_ID, ACTOR_ID)).rejects.toThrow(
+      ApiKeyNotFoundError,
+    );
+  });
+
+  it('refuses to migrate a key belonging to a different org than the principal', async () => {
+    mockSelectOnce([{ id: PRINCIPAL_ID, orgId: ORG_ID, scopes: ['ai:read'] }]);
+    mockSelectOnce([{ id: 'key-1', orgId: 'org-other', principalType: 'human', scopes: ['ai:read'] }]);
+    await expect(migrateHumanKeyToServicePrincipal('key-1', PRINCIPAL_ID, ACTOR_ID)).rejects.toThrow(
+      /different organization/,
+    );
+  });
+
+  // This is THE ONLY mutation that flips principal_type human -> service.
+  // Route-level org-admin gating (403 for non-admin) is covered in
+  // routes/servicePrincipals.test.ts.
+  it('re-points the key to the principal, clamping scopes to the intersection', async () => {
+    mockSelectOnce([{ id: PRINCIPAL_ID, orgId: ORG_ID, scopes: ['ai:read'] }]);
+    mockSelectOnce([
+      { id: 'key-1', orgId: ORG_ID, name: 'Old human key', principalType: 'human', scopes: ['ai:read', 'ai:execute_admin'] },
+    ]);
+    const updateWhere = mockUpdateOnce([
+      { id: 'key-1', orgId: ORG_ID, name: 'Old human key', principalType: 'service', principalId: PRINCIPAL_ID, scopes: ['ai:read'] },
+    ]);
+
+    const result = await migrateHumanKeyToServicePrincipal('key-1', PRINCIPAL_ID, ACTOR_ID);
+
+    expect(result.principalType).toBe('service');
+    expect(result.principalId).toBe(PRINCIPAL_ID);
+    expect(result.scopes).toEqual(['ai:read']);
+    expect(updateWhere).toHaveBeenCalled();
+    expect(createAuditLogAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'service_principal.migrate_key',
+        details: expect.objectContaining({ previousPrincipalType: 'human', clampedScopes: ['ai:read'] }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/services/servicePrincipals.ts
+++ b/apps/api/src/services/servicePrincipals.ts
@@ -1,0 +1,265 @@
+import { randomBytes, createHash } from 'crypto';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../db';
+import { apiKeys, servicePrincipals } from '../db/schema';
+import { createAuditLogAsync } from './auditService';
+
+/**
+ * SR2-15: service-principal lifecycle service.
+ *
+ * A service principal is an explicit, opt-in, org-owned non-human identity
+ * (`service_principals`). It exists so automation owned by an off-boarded
+ * human can be migrated onto a first-class identity instead of silently
+ * surviving on a dead human's live permissions (the human-key path in
+ * `apiKeyAuthorization.ts` denies once the creator loses membership — a
+ * service principal is the deliberate, audited escape hatch when the
+ * automation itself is meant to keep running).
+ *
+ * Every mutation here runs inside the caller's already-established request
+ * DB context (routes/servicePrincipals.ts is mounted behind `authMiddleware`,
+ * which opens `withDbAccessContext` for the whole dispatch) — these functions
+ * do not open their own DB context.
+ */
+
+export type ServicePrincipal = typeof servicePrincipals.$inferSelect;
+export type ServicePrincipalApiKey = typeof apiKeys.$inferSelect;
+
+export class ServicePrincipalNotFoundError extends Error {
+  constructor(principalId: string) {
+    super(`Service principal not found: ${principalId}`);
+    this.name = 'ServicePrincipalNotFoundError';
+  }
+}
+
+export class ApiKeyNotFoundError extends Error {
+  constructor(keyId: string) {
+    super(`API key not found: ${keyId}`);
+    this.name = 'ApiKeyNotFoundError';
+  }
+}
+
+// Mirrors routes/apiKeys.ts's generateApiKey (identical brz_-prefix + SHA-256
+// hash scheme). Duplicated locally rather than cross-imported from a route
+// file — the same duplication already exists between routes/apiKeys.ts and
+// middleware/apiKeyAuth.ts for hashApiKey, so this matches established
+// convention for this exact helper rather than introducing a new shared
+// module or a service→route import.
+function generateApiKey(): { fullKey: string; keyPrefix: string; keyHash: string } {
+  const randomPart = randomBytes(32).toString('base64url').slice(0, 32);
+  const fullKey = `brz_${randomPart}`;
+  const keyPrefix = fullKey.slice(0, 12);
+  const keyHash = createHash('sha256').update(fullKey).digest('hex');
+  return { fullKey, keyPrefix, keyHash };
+}
+
+export async function createServicePrincipal(input: {
+  orgId: string;
+  name: string;
+  scopes: string[];
+  createdBy: string;
+}): Promise<ServicePrincipal> {
+  const [row] = await db
+    .insert(servicePrincipals)
+    .values({
+      orgId: input.orgId,
+      name: input.name,
+      scopes: input.scopes,
+      status: 'active',
+      createdBy: input.createdBy,
+    })
+    .returning();
+
+  if (!row) {
+    throw new Error('Failed to create service principal');
+  }
+
+  createAuditLogAsync({
+    orgId: row.orgId,
+    actorId: input.createdBy,
+    action: 'service_principal.create',
+    resourceType: 'service_principal',
+    resourceId: row.id,
+    resourceName: row.name,
+    details: { scopes: row.scopes },
+    result: 'success',
+  });
+
+  return row;
+}
+
+/**
+ * Mint a NEW api_keys row bound to `principalId` (principalType='service')
+ * and revoke any prior ACTIVE key for that principal. Returns the raw key
+ * exactly once — same "shown only on mint/rotate" contract as
+ * routes/apiKeys.ts. The revoke-then-mint ordering means there is never a
+ * window where two keys are simultaneously active for one principal.
+ */
+export async function rotateServicePrincipalKey(
+  principalId: string,
+  actorId: string,
+): Promise<{ apiKeyId: string; key: string; keyPrefix: string }> {
+  const [principal] = await db
+    .select()
+    .from(servicePrincipals)
+    .where(eq(servicePrincipals.id, principalId))
+    .limit(1);
+
+  if (!principal) {
+    throw new ServicePrincipalNotFoundError(principalId);
+  }
+
+  await db
+    .update(apiKeys)
+    .set({ status: 'revoked', updatedAt: new Date() })
+    .where(and(eq(apiKeys.principalId, principalId), eq(apiKeys.status, 'active')));
+
+  const { fullKey, keyPrefix, keyHash } = generateApiKey();
+
+  const [newKey] = await db
+    .insert(apiKeys)
+    .values({
+      orgId: principal.orgId,
+      name: `${principal.name} (service key)`,
+      keyHash,
+      keyPrefix,
+      scopes: principal.scopes,
+      createdBy: actorId,
+      status: 'active',
+      principalType: 'service',
+      principalId: principal.id,
+    })
+    .returning();
+
+  if (!newKey) {
+    throw new Error('Failed to mint service principal key');
+  }
+
+  createAuditLogAsync({
+    orgId: principal.orgId,
+    actorId,
+    action: 'service_principal.rotate_key',
+    resourceType: 'service_principal',
+    resourceId: principal.id,
+    resourceName: principal.name,
+    // NEVER log the raw key or its hash — prefix only.
+    details: { newKeyId: newKey.id, newKeyPrefix: newKey.keyPrefix },
+    result: 'success',
+  });
+
+  return { apiKeyId: newKey.id, key: fullKey, keyPrefix: newKey.keyPrefix };
+}
+
+/**
+ * Disable a principal (status='disabled') and cascade-revoke every active
+ * key bound to it. This is the disable-cascade gate that
+ * `authorizeServicePrincipalKey` relies on: a disabled principal denies at
+ * auth time regardless, but revoking the keys here means a re-enable (were
+ * one ever added) never silently resurrects old credentials.
+ */
+export async function disableServicePrincipal(
+  principalId: string,
+  actorId: string,
+): Promise<ServicePrincipal> {
+  const [updated] = await db
+    .update(servicePrincipals)
+    .set({ status: 'disabled', updatedAt: new Date(), lastUpdatedBy: actorId })
+    .where(eq(servicePrincipals.id, principalId))
+    .returning();
+
+  if (!updated) {
+    throw new ServicePrincipalNotFoundError(principalId);
+  }
+
+  await db
+    .update(apiKeys)
+    .set({ status: 'revoked', updatedAt: new Date() })
+    .where(and(eq(apiKeys.principalId, principalId), eq(apiKeys.status, 'active')));
+
+  createAuditLogAsync({
+    orgId: updated.orgId,
+    actorId,
+    action: 'service_principal.disable',
+    resourceType: 'service_principal',
+    resourceId: updated.id,
+    resourceName: updated.name,
+    result: 'success',
+  });
+
+  return updated;
+}
+
+/**
+ * Re-point an EXISTING human `api_keys` row onto an explicit service
+ * principal — flipping `principal_type` from 'human' to 'service' and
+ * setting `principal_id`. This is the ONLY mutation in the codebase that
+ * flips principal_type; it is deliberately never automatic (see the module
+ * docstring) and is gated at the route layer on an org-admin permission —
+ * never reachable from the auth path itself.
+ *
+ * The key's stored scopes are re-clamped to the INTERSECTION with the
+ * principal's current scopes: migrating a key that was minted with broader
+ * human-delegated scopes must not hand the principal authority it was never
+ * explicitly granted. (`authorizeServicePrincipalKey` would reject the
+ * un-intersected scopes on the very next request anyway — clamping here
+ * avoids leaving the key transiently broken.)
+ */
+export async function migrateHumanKeyToServicePrincipal(
+  keyId: string,
+  principalId: string,
+  actorId: string,
+): Promise<ServicePrincipalApiKey> {
+  const [principal] = await db
+    .select()
+    .from(servicePrincipals)
+    .where(eq(servicePrincipals.id, principalId))
+    .limit(1);
+
+  if (!principal) {
+    throw new ServicePrincipalNotFoundError(principalId);
+  }
+
+  const [existingKey] = await db.select().from(apiKeys).where(eq(apiKeys.id, keyId)).limit(1);
+
+  if (!existingKey) {
+    throw new ApiKeyNotFoundError(keyId);
+  }
+
+  if (existingKey.orgId !== principal.orgId) {
+    throw new Error('Cannot migrate an API key to a service principal in a different organization');
+  }
+
+  const principalScopeSet = new Set(principal.scopes ?? []);
+  const clampedScopes = (existingKey.scopes ?? []).filter((scope) => principalScopeSet.has(scope));
+
+  const [migrated] = await db
+    .update(apiKeys)
+    .set({
+      principalType: 'service',
+      principalId: principal.id,
+      scopes: clampedScopes,
+      updatedAt: new Date(),
+    })
+    .where(eq(apiKeys.id, keyId))
+    .returning();
+
+  if (!migrated) {
+    throw new Error('Failed to migrate API key to service principal');
+  }
+
+  createAuditLogAsync({
+    orgId: migrated.orgId,
+    actorId,
+    action: 'service_principal.migrate_key',
+    resourceType: 'api_key',
+    resourceId: migrated.id,
+    resourceName: migrated.name,
+    details: {
+      principalId: principal.id,
+      previousPrincipalType: existingKey.principalType,
+      clampedScopes,
+    },
+    result: 'success',
+  });
+
+  return migrated;
+}

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -277,6 +277,7 @@ const CORE_ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'sensitive_data_findings',
   'sensitive_data_policies',
   'sensitive_data_scans',
+  'service_principals',
   'service_process_check_results',
   'sites',
   'sla_compliance',


### PR DESCRIPTION
PR 5 of the six-PR core-authentication-hardening epic (#2489). **SR2-15** — human-delegated API keys cannot outlive their creator's authority; non-human automation gets an explicit service principal.

PRs 1 (#2378), 2 (#2385), 3 (#2492), 4 (#2507) and the MCP hotfix (#2510) are merged. This is based directly on `main` and builds **on top of** #2510.

## What this fixes

| Item | Before | After |
|---|---|---|
| **Off-boarding gate** | An API key kept working after its creator lost the tenant membership its authority derived from. PR 1 checked only that the creator's `users.status` was `active` — a user stripped of every role/membership but left `active` still had live keys. | Every API-key request re-resolves the creator's **current** permissions. No live membership/role on **either** axis → `getUserPermissions` returns `null` → **401/403 deny**. |
| **Permission-reduction re-clamp** | A key minted while its creator was powerful kept those scopes forever — the stored `scopes` were trusted at request time and delegation was only ever checked at mint. | The stored scopes are re-run through the **same** mint-time ceiling (`validateApiKeyScopeDelegation`) against the creator's live permissions on **every request**. A creator whose permissions dropped below a stored scope is denied. |
| **MCP partner-axis off-boarding** | The partner-scope branch had no null-perms deny — an off-boarded partner admin's bearer key authenticated and was merely data-starved by an unsatisfiable org filter. | Null/errored partner-axis perms now **deny outright**. |
| **Service principals** | Automation owned by a departing human had no migration path — it either died with them or survived on a dead human's authority. | New **opt-in** `service_principals` identity: org-owned, its own scope ceiling, own lifecycle (active/disabled). A service key authorizes against the **principal**, not a human. `migrateHumanKeyToServicePrincipal` is the **only** way a human key becomes a service key — never silent. |

**Design fork (documented in the plan):** live re-resolution, **not** an epoch. `getUserPermissions` is already Redis-version-cached (5-min TTL) and already invalidated by every membership/role mutation, so this costs at most one cached read on the hot path yet is always correct — and it catches out-of-band SQL membership changes that bump no epoch. An epoch would need a new advance-site at every membership/role/permission mutation (easy to miss one → fail-OPEN), and `auth_epoch` is the wrong signal (it advances on password changes that shouldn't kill a key, and *doesn't* advance on a pure role reduction).

## Security properties, proven

Every gate has a **guard-biting** test (delete the guard → test goes RED, verified by actually reverting the code, not by assertion). The fail-closed rule is absolute: **there is no path where a null / 0-row / errored read yields "authorized"** — on any of the four entry paths (REST `X-API-Key`, MCP org-scope, MCP partner-scope, service-principal).

A **real-DB integration suite** (`apiKeyPrincipals.integration.test.ts`) proves 5 scenarios against real Postgres as non-superuser `breeze_app` with **forced** RLS (superuser would make RLS vacuous and these pass for the wrong reason — the harness verifies `rolsuper = f`):
1. **Membership removal kills the key** — auth succeeds, `DELETE FROM organization_users`, auth now denies.
2. **Dual-axis:** a partner-admin creator with **no** `organization_users` row authorizes via the partner axis; removing the `partner_users` row denies. (An org-axis-only gate would falsely deny every partner-admin-minted key.)
3. **Permission reduction re-clamps** — the `devices:write` key denies while the `devices:read` key still works.
4. **Fail-closed:** a creator with no RLS-visible membership denies rather than authorizing.
5. **Service-principal lifecycle:** works while active; **unaffected by its `created_by` human being off-boarded** (the whole point); denies once the principal is disabled.

Reverting the resolver call sent all 5 DENY assertions RED, then restored GREEN.

## Deploy notes

- **Migration** `2026-07-19-service-principals.sql`: creates `service_principals` (org-owned) with RLS **enabled + forced** and a `breeze_has_org_access(org_id)` policy in the same file; adds `api_keys.principal_type` (NOT NULL **DEFAULT `'human'`** — existing rows backfill to human, **no silent conversion**) and `api_keys.principal_id`. Idempotent; re-apply is a clean no-op. `service_principals` carries `org_id` so the RLS coverage contract test auto-discovers it as shape-1 (no allowlist entry needed).
- **Hot-path cost:** one extra `getUserPermissions` per API-key request. Redis-version-cached — a cache hit is an `mget` + in-process lookup, no Postgres round-trip. Correctness over cost, deliberately.
- **No new required env vars.**

## ⚠️ Operator-visible behavior change (release note)

**`ai:read` is all-or-nothing.** `API_KEY_SCOPE_POLICIES['ai:read']` requires *all four* baseline reads (devices, alerts, scripts, automations) as one bundle, and the re-clamp fails the whole authorization on the first unbacked scope. So **trimming any single baseline read from a creator's role disables their entire MCP key**, not just that resource's tools. This is fail-closed and intentional (it is the existing mint-time policy applied live, now consistent with the REST path), but the blast radius is worth knowing before you trim a role.

## Known limitation (documented, follow-up filed)

**Service-principal keys are not yet fully independent on the MCP/AI path.** Transport auth correctly authorizes a service key against its principal, but the downstream *per-tool* RBAC (`aiGuardrails.checkPermissionRequirements`) still resolves `getUserPermissions(auth.user.id)`, and for an API-key context `user.id = apiKey.createdBy`. So a service key whose rotating admin is later off-boarded gets denied on MCP tools. This is **fail-closed** (denial, never over-grant) so it does not breach the SR2-15 invariant, but it partially defeats the service-principal value proposition *for MCP automations specifically*. Full independence (resolving service-key authority from the principal's scopes at the per-tool layer) is a tracked follow-up. Service principals work fully on the REST path today.

## Other follow-ups (non-blocking, from review)

- Shared `apiKeyCrypto` util — `generateApiKey`/`hashApiKey` now has a third copy; a silent desync would break rotated-key auth.
- `readAsSystem` for the service-principal resolver (currently a bare `withSystemDbAccessContext`; proven fail-closed today — worst case is a false deny, never a fail-open — but the escalation idiom is the cleaner, structurally-obvious choice).
- A runtime `rolsuper = false` assertion inside the integration harness (currently a documented manual step).
- A DB `CHECK (principal_type = 'human' OR principal_id IS NOT NULL)` to make the partial state structurally impossible (unreachable via code today, and it falls to the fail-closed human path if forced).
- A dedicated service-principal admin permission instead of reusing `ORGS_WRITE` (all mutating routes additionally require MFA).

## Testing

- `tsc` clean; **7 files / 75 tests** green together across the resolver, both auth paths, the lifecycle service, the routes, and the schema.
- **13 MCP suites / 118 tests** green — including the re-primed existing suites (creators given genuinely-authorized permission sets; **no assertion was weakened**).
- **5/5 real-DB scenarios** green on a private, correctly-provisioned Postgres; `db:check-drift` clean; migration idempotency verified by re-application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
