### PR TITLE
fix(setup): prevent guided setup exit in default directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,10 @@ jobs:
             exit 1
           fi
 
-      - name: Guard guided setup Compose rewrites
-        run: bash scripts/check-guided-setup-compose-rewrites.sh
+      - name: Guard guided setup behavior
+        run: |
+          bash scripts/check-guided-setup-compose-rewrites.sh
+          bash scripts/check-guided-setup-default-project.sh
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/scripts/check-guided-setup-default-project.sh
+++ b/scripts/check-guided-setup-default-project.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+FUNCTIONS_FILE="${TMP_DIR}/guided-setup-functions.sh"
+WORK_DIR="${TMP_DIR}/breeze"
+
+sed '/^main "\$@"$/d' "${REPO_ROOT}/scripts/guided-setup.sh" > "${FUNCTIONS_FILE}"
+mkdir -p "${WORK_DIR}"
+cp "${REPO_ROOT}/.env.example" "${WORK_DIR}/.env"
+
+(
+  set -- --work-dir "${WORK_DIR}" --env-file "${WORK_DIR}/.env" --no-download --no-up -y
+  # shellcheck source=/dev/null
+  source "${FUNCTIONS_FILE}"
+  preserve_existing_compose_project_name
+)
+
+printf 'guided setup default project name guard passed\n'

--- a/scripts/guided-setup.sh
+++ b/scripts/guided-setup.sh
@@ -614,7 +614,7 @@ preserve_existing_compose_project_name() {
   local configured name volume_name
 
   name="$(sanitize_compose_project_name "$(basename "${WORK_DIR}")")"
-  [[ -n "${name}" && "${name}" != "breeze" ]] || return
+  [[ -n "${name}" && "${name}" != "breeze" ]] || return 0
 
   volume_name="${name}_postgres_data"
   configured="$(get_env_value "COMPOSE_PROJECT_NAME")"


### PR DESCRIPTION
## Summary

- return success when Compose project-name preservation intentionally skips the default `breeze` directory
- add a regression guard that exercises the real guided-setup function from a directory named `breeze`
- run the new guard alongside the existing guided-setup CI check

## Root cause

`preserve_existing_compose_project_name` used a bare `return` after a false `[[ ... ]]` condition. For the normal installation directory named `breeze`, that inherited exit status 1. Because `main` invokes the function under `set -e`, guided setup terminated silently immediately after preparing `.env`.

## User impact

Guided setup now continues normally when run from the documented/default `breeze` directory, regardless of whether the user chooses to back up an existing `.env`.

## Validation

- `bash -n scripts/guided-setup.sh scripts/check-guided-setup-compose-rewrites.sh scripts/check-guided-setup-default-project.sh`
- `shellcheck scripts/guided-setup.sh scripts/check-guided-setup-compose-rewrites.sh scripts/check-guided-setup-default-project.sh`
- `bash scripts/check-guided-setup-compose-rewrites.sh`
- `bash scripts/check-guided-setup-default-project.sh`
- `actionlint -shellcheck= .github/workflows/ci.yml`
- `git diff --check origin/main...HEAD`
