### PR TITLE
docs: add cascade registration to the new-tenant-table checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,24 @@ API connects to Postgres as unprivileged `breeze_app`. Every tenant-scoped table
 1. Pick a shape; add policies in the same migration that creates the table — never defer.
 2. Migration must be idempotent (`IF NOT EXISTS` / `DO $$`). Never edit a shipped migration.
 3. Add to the relevant allowlist in `rls-coverage.integration.test.ts` in the same PR (shapes 2-6).
-4. Run the contract test locally (needs real DB).
-5. Verify as `breeze_app`: `docker exec -it breeze-postgres psql -U breeze_app -d breeze` and forge a cross-tenant insert — must fail with `new row violates row-level security policy`.
+4. **Register the table in every cascade list that applies (see below). RLS coverage does NOT imply cascade coverage — they are separate contracts, and this step is the one that gets missed.**
+5. Run the contract tests locally (needs real DB).
+6. Verify as `breeze_app`: `docker exec -it breeze-postgres psql -U breeze_app -d breeze` and forge a cross-tenant insert — must fail with `new row violates row-level security policy`.
+
+**Cascade registration (step 4) — a new `org_id` table is NOT done until it's in these:**
+
+| If the table… | Add it to | Enforced by (CI job) |
+|---|---|---|
+| has an `org_id` column (**always**) | `CORE_ORG_CASCADE_DELETE_ORDER` in `services/tenantCascade.ts` — alphabetical, `organizations` last | `tenantCascade.integration.test.ts` (**Integration Tests**) |
+| has a `device_id` column | `CORE_DEVICE_CASCADE_DELETE_TABLES` in `routes/devices/core.ts` | `cascadeDelete.test.ts` (**Test API**) |
+| has `device_id` **and** a denormalized `org_id` | also `CORE_DEVICE_ORG_DENORMALIZED_TABLES` (same file) | `moveOrg.coverage.test.ts` (**Test API**) |
+| is append-only (REVOKE DELETE + immutability trigger) | also `AUDIT_ADMIN_REQUIRED_TABLES` in `tenantCascade.ts` | runtime `permission denied` during erasure |
+
+Why this list exists: missing a cascade list is a **latent GDPR org-erasure bug** — the org delete either strands rows under a dead tenant or aborts on an FK violation. It has shipped or blocked CI five times (#1359, #1351, #1365, #2179, #2514). Code review has caught it **0/5**; the contract tests caught it **5/5**. Treat it as a mechanical grep (`grep -rn '<table>' apps/api/src/services/tenantCascade.ts`), not a judgement call.
+
+**Check the FK direction, not just membership.** Ordering is children-before-parents. An FK declared without an explicit `ON DELETE` defaults to `NO ACTION`, so a referencing table must be deleted *first* or the cascade raises an FK violation. Alphabetical order often satisfies this by luck (`api_keys` < `service_principals`) — verify, don't assume. `tenantCascade.integration.test.ts` asserts five properties: alphabetised by `localeCompare` with `organizations` last; every `org_id` table present; no entry naming a non-existent table; every cascade table exactly once; FK children before parents.
+
+Only the device-side lists fail in the **Test API** unit job (they read the Drizzle schema statically). The org cascade list only fails under **Integration Tests**, so a PR on a stale base can go green and then red main after merge.
 
 For production backfills of `org_id` on hot tables (>1M rows), batch via `UPDATE ... WHERE ctid IN (... LIMIT N)` loops before `SET NOT NULL`. Full narrative and rationale: `docs/superpowers/plans/2026-04-11-rls-coverage-gaps.md`.
 


### PR DESCRIPTION
The **"Workflow for a new tenant-scoped table"** checklist in `CLAUDE.md` covers RLS shape, migration idempotency, and the `rls-coverage` allowlist — but never mentions the cascade lists at all. Anyone following it to the letter still ships a latent **GDPR org-erasure bug**: the org delete either strands rows under a dead tenant, or aborts on an FK violation.

That gap has now shipped or blocked CI **five times** — #1359, #1351, #1365, #2179, and #2514 (`service_principals`, today). The pattern is consistent:

| | caught it |
|---|---|
| Code review | **0/5** |
| Cascade contract tests | **5/5** |

On #2514 it slipped past both the implementer and a full whole-branch review that returned SHIP. When the same defect recurs five times against five different authors, the checklist is the defect — so this fixes the docs rather than asking people to remember harder.

## What changed

- Cascade registration is now its **own numbered step**, with the reason it gets missed stated inline: **RLS coverage does not imply cascade coverage** — they are separate contracts.
- A table mapping **table shape → required list → enforcing CI job**, so it reads as a mechanical grep rather than a judgement call.
- **FK direction matters independently of list membership.** An FK declared without an explicit `ON DELETE` defaults to `NO ACTION`, so a referencing table must be deleted *first*. Alphabetical order often satisfies this **by luck** (`api_keys` < `service_principals`) — the doc now says verify, don't assume.
- Notes that only the device-side lists fail in the **Test API** unit job; the org list fails only under **Integration Tests**, so a PR on a stale base can go green and red main after merge.

## Verification

Every symbol and path checked against `main` (not from memory — the constants are `CORE_`-prefixed behind accessors, which an earlier note had wrong):

- `CORE_ORG_CASCADE_DELETE_ORDER`, `AUDIT_ADMIN_REQUIRED_TABLES` → `services/tenantCascade.ts` ✅
- `CORE_DEVICE_CASCADE_DELETE_TABLES`, `CORE_DEVICE_ORG_DENORMALIZED_TABLES` → `routes/devices/core.ts` ✅
- `tenantCascade.integration.test.ts`, `cascadeDelete.test.ts`, `moveOrg.coverage.test.ts` ✅
- Corrected the assertion count to the **five** properties the contract actually asserts.

**Docs only — no code change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)