### PR TITLE
fix(deploy): map POSTGRES_PASSWORD and APNS_* into the api service env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -676,3 +676,23 @@ AUTOMATION_WEBHOOK_ALLOW_LEGACY_SECRET=false
 # AUTOMATION_WEBHOOK_ALLOW_QUERY_SECRET was removed entirely. The `?secret=`
 # query-string parameter is no longer accepted under any configuration —
 # query strings end up in every proxy/load-balancer/CDN access log on the path.
+
+# --------------------------------------------
+# Native APNs push (iOS app)
+# --------------------------------------------
+# All optional — leave every value unset (or empty) to disable push entirely.
+#
+# All-or-none: setting ANY APNS_* value makes APNS_AUTH_KEY, APNS_KEY_ID,
+# APNS_TEAM_ID and APNS_BUNDLE_ID all required, in every NODE_ENV. That is
+# deliberate — a half-configured relay would otherwise fail silently at first
+# send instead of loudly at boot. APNS_ENVIRONMENT stays optional.
+#
+# These must also be mapped in the api service `environment:` block of your
+# compose file — a value in .env alone is never seen by the API.
+#
+# APNS_AUTH_KEY is the .p8 signing key PEM (newlines included).
+# APNS_AUTH_KEY=
+# APNS_KEY_ID=
+# APNS_TEAM_ID=
+# APNS_BUNDLE_ID=
+# APNS_ENVIRONMENT=production

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -1509,6 +1509,55 @@ describe('validateConfig', () => {
       });
     });
 
+    // Compose maps these as `${APNS_*:-}`, so an operator who has not configured
+    // push still gets every key injected as "". That must read as "unset", not as
+    // an opted-in partial set, and the ENVIRONMENT enum must not reject "".
+    it('treats an all-empty APNS_* set as unset (compose injects "" for each)', () => {
+      withEnv(
+        {
+          ...validEnv,
+          APNS_AUTH_KEY: '',
+          APNS_KEY_ID: '',
+          APNS_TEAM_ID: '',
+          APNS_BUNDLE_ID: '',
+          APNS_ENVIRONMENT: '',
+        },
+        () => {
+          const config = validateConfig();
+          expect(config.APNS_ENVIRONMENT).toBeUndefined();
+        }
+      );
+    });
+
+    it('treats an empty APNS_ENVIRONMENT as unset when credentials are configured', () => {
+      withEnv({ ...validEnv, ...apnsFull, APNS_ENVIRONMENT: '' }, () => {
+        const config = validateConfig();
+        expect(config.APNS_ENVIRONMENT).toBeUndefined();
+      });
+    });
+
+    it('still refuses boot on an invalid APNS_ENVIRONMENT', () => {
+      withEnv({ ...validEnv, ...apnsFull, APNS_ENVIRONMENT: 'staging' }, () => {
+        expect(() => validateConfig()).toThrow('APNS_ENVIRONMENT');
+      });
+    });
+
+    it('still refuses boot on a partial set even when the empty keys are present', () => {
+      withEnv(
+        {
+          ...validEnv,
+          APNS_TEAM_ID: 'TEAM123456',
+          APNS_BUNDLE_ID: 'app.breeze.mobile',
+          APNS_AUTH_KEY: '',
+          APNS_KEY_ID: '',
+          APNS_ENVIRONMENT: '',
+        },
+        () => {
+          expect(() => validateConfig()).toThrow('APNS_AUTH_KEY');
+        }
+      );
+    });
+
     it.each(['APNS_AUTH_KEY', 'APNS_KEY_ID', 'APNS_TEAM_ID', 'APNS_BUNDLE_ID'])(
       'refuses boot when %s is missing but other APNS_* are set',
       (missing) => {

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -524,7 +524,15 @@ const envSchema = z
     APNS_KEY_ID: z.string().optional(),
     APNS_TEAM_ID: z.string().optional(),
     APNS_BUNDLE_ID: z.string().optional(),
-    APNS_ENVIRONMENT: z.enum(['sandbox', 'production']).optional(),
+    // Empty string means "unset", matching the trim() semantics the all-or-none
+    // block uses. Compose maps this as `${APNS_ENVIRONMENT:-}`, which always
+    // injects the key — as "" when the operator hasn't set it — and a bare
+    // `.optional()` enum rejects "" and refuses to boot. The string fields above
+    // tolerate "" natively; only the enum needs this.
+    APNS_ENVIRONMENT: z.preprocess(
+      (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+      z.enum(['sandbox', 'production']).optional()
+    ),
 
     // -- Optional with defaults -----------------------------------------------
     API_PORT: portSchema,

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -73,8 +73,14 @@ services:
       NODE_ENV: production
       API_PORT: 3001
       DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL in .env}
+      # Production requires ONE of DATABASE_URL_APP / BREEZE_APP_DB_PASSWORD /
+      # POSTGRES_PASSWORD to configure the unprivileged request role (#2368).
+      # All three must be mapped here — the validator names POSTGRES_PASSWORD as
+      # a valid option, and compose only interpolates vars listed in this block,
+      # so omitting it makes that advice silently fail.
       DATABASE_URL_APP: ${DATABASE_URL_APP:-}
       BREEZE_APP_DB_PASSWORD: ${BREEZE_APP_DB_PASSWORD:-}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_PASSWORD_FILE: /run/secrets/redis_password
@@ -157,6 +163,15 @@ services:
       OPS_ALERT_EMAIL: ${OPS_ALERT_EMAIL:-}
       OPS_ALERT_LABEL: ${OPS_ALERT_LABEL:-}
       ABUSE_SIGNAL_OVERRIDES: ${ABUSE_SIGNAL_OVERRIDES:-}
+      # Native APNs push for the iOS app (all optional; unset = push disabled).
+      # All-or-none: setting ANY of these makes the four credentials required,
+      # so a half-configured relay fails at boot instead of silently at first
+      # send. Empty values are treated as unset.
+      APNS_AUTH_KEY: ${APNS_AUTH_KEY:-}
+      APNS_KEY_ID: ${APNS_KEY_ID:-}
+      APNS_TEAM_ID: ${APNS_TEAM_ID:-}
+      APNS_BUNDLE_ID: ${APNS_BUNDLE_ID:-}
+      APNS_ENVIRONMENT: ${APNS_ENVIRONMENT:-}
     volumes:
       - api_data:/data
       - binaries:/data/binaries:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,15 @@ services:
       OPS_ALERT_EMAIL: ${OPS_ALERT_EMAIL:-}
       OPS_ALERT_LABEL: ${OPS_ALERT_LABEL:-}
       ABUSE_SIGNAL_OVERRIDES: ${ABUSE_SIGNAL_OVERRIDES:-}
+      # Native APNs push for the iOS app (all optional; unset = push disabled).
+      # All-or-none: setting ANY of these makes the four credentials required,
+      # so a half-configured relay fails at boot instead of silently at first
+      # send. Empty values are treated as unset.
+      APNS_AUTH_KEY: ${APNS_AUTH_KEY:-}
+      APNS_KEY_ID: ${APNS_KEY_ID:-}
+      APNS_TEAM_ID: ${APNS_TEAM_ID:-}
+      APNS_BUNDLE_ID: ${APNS_BUNDLE_ID:-}
+      APNS_ENVIRONMENT: ${APNS_ENVIRONMENT:-}
       SENTRY_DSN: ${SENTRY_DSN:-}
       SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-production}
       SENTRY_RELEASE: ${SENTRY_RELEASE:-}


### PR DESCRIPTION
## Summary

Two env-template gaps found while auditing the upgrade path for the next release. Both are the same trap: **compose only interpolates variables listed in a service's `environment:` block**, so a value in `.env` alone is never seen by the API.

### 1. `POSTGRES_PASSWORD` — the important one

#2368 made production **refuse to boot** without one of `DATABASE_URL_APP` / `BREEZE_APP_DB_PASSWORD` / `POSTGRES_PASSWORD`, and the validator's error message names all three:

> `Production requires DATABASE_URL_APP, BREEZE_APP_DB_PASSWORD, or POSTGRES_PASSWORD to configure the unprivileged request database role.`

But `deploy/docker-compose.prod.yml` mapped only the first two. An operator who followed that advice and set `POSTGRES_PASSWORD` in `.env` **still failed to boot — with an error telling them to do the thing they had already done.**

### 2. `APNS_*` — silent no-op

Absent from every template and compose block, so a configured push relay silently never delivered. Mapped with empty defaults, which the validator treats as unset (`v.trim() !== ''`), so "unset = push disabled" is preserved and the partial-set boot failure isn't triggered. The all-or-none rule is now documented in `.env.example`.

## Verification

- Both compose files render clean under `docker compose config`.
- `POSTGRES_PASSWORD` now reaches the prod api service — **it previously did not appear at all**.
- Every `APNS_*` renders as `""` when unset, so push stays disabled by default and no boot failure is introduced.
- `check-supply-chain-hardening.sh` passes.

## Why now

This lands ahead of the release because #2368's new boot requirement is the headline self-hoster breaking change, and this gap turns a clear error message into a misleading one at exactly the moment operators hit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)