### PR TITLE
fix(deploy): map DATABASE_URL_APP into the base compose api service

### DIFF
--- a/apps/api/src/db/requestDatabaseCompose.test.ts
+++ b/apps/api/src/db/requestDatabaseCompose.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest';
 const REPOSITORY_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
 const IMAGE_DIGEST = `example.invalid/breeze@sha256:${'0'.repeat(64)}`;
 
-function renderApiEnvironment(appPassword: string): Record<string, string> {
+function renderApiEnvironment(overrides: Record<string, string>): Record<string, string> {
   const rendered = execFileSync('docker', [
     'compose', '--project-directory', REPOSITORY_ROOT,
     '-f', path.join(REPOSITORY_ROOT, 'docker-compose.yml'),
@@ -19,7 +19,6 @@ function renderApiEnvironment(appPassword: string): Record<string, string> {
       AGENT_ENROLLMENT_SECRET: 'compose-agent-enrollment-secret',
       APP_ENCRYPTION_KEY: 'compose-app-encryption-key',
       BREEZE_API_IMAGE_REF: IMAGE_DIGEST,
-      BREEZE_APP_DB_PASSWORD: appPassword,
       BREEZE_BINARIES_IMAGE_REF: IMAGE_DIGEST,
       BREEZE_DOMAIN: 'breeze.example.test',
       BREEZE_PORTAL_IMAGE_REF: IMAGE_DIGEST,
@@ -35,6 +34,7 @@ function renderApiEnvironment(appPassword: string): Record<string, string> {
       POSTGRES_PASSWORD: 'compose-postgres-password',
       REDIS_IMAGE_REF: IMAGE_DIGEST,
       TURN_SECRET: 'compose-turn-secret',
+      ...overrides,
     },
   });
   return (JSON.parse(rendered) as { services: { api: { environment: Record<string, string> } } })
@@ -42,12 +42,25 @@ function renderApiEnvironment(appPassword: string): Record<string, string> {
 }
 
 describe('standard Compose request database configuration', () => {
+  // When DATABASE_URL_APP is unset, compose maps it to an empty string. The
+  // resolver treats a blank value as "not set" (resolveRequestDatabaseConfig
+  // trims and checks truthiness) and derives the breeze_app URL from the
+  // effective role password, so the empty mapping must not shadow derivation.
   it.each([
     ['', 'compose-postgres-password'],
     ['compose-app-role-password', 'compose-app-role-password'],
-  ])('lets the resolver derive with the effective role password %s', (appPassword, expected) => {
-    const environment = renderApiEnvironment(appPassword);
-    expect(Object.hasOwn(environment, 'DATABASE_URL_APP')).toBe(false);
+  ])('maps DATABASE_URL_APP as blank and derives with the effective role password %s', (appPassword, expected) => {
+    const environment = renderApiEnvironment({ BREEZE_APP_DB_PASSWORD: appPassword });
+    expect(environment.DATABASE_URL_APP).toBe('');
     expect(environment.BREEZE_APP_DB_PASSWORD || environment.POSTGRES_PASSWORD).toBe(expected);
+  });
+
+  it('passes an explicit DATABASE_URL_APP through to the api service', () => {
+    // The reason this mapping exists: a value set in .env must reach the api
+    // service, or multi-host/HA operators (whose URL cannot be derived) have no
+    // way to point the request pool at an explicit role.
+    const explicit = 'postgresql://breeze_app:secret@h1:5432,h2:5432/breeze';
+    const environment = renderApiEnvironment({ DATABASE_URL_APP: explicit });
+    expect(environment.DATABASE_URL_APP).toBe(explicit);
   });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,11 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER:-breeze}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-breeze}
       # The request pool derives its breeze_app URL from DATABASE_URL and the same
       # effective password ensureAppRole uses to CREATE/ALTER that unprivileged role.
+      # DATABASE_URL_APP takes precedence and is required for multi-host/HA URLs,
+      # which cannot be derived. All three must be mapped here — compose only
+      # interpolates vars listed in this block, so omitting one makes a value set
+      # in .env silently inert.
+      DATABASE_URL_APP: ${DATABASE_URL_APP:-}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
       BREEZE_APP_DB_PASSWORD: ${BREEZE_APP_DB_PASSWORD:-}
       REDIS_HOST: redis


### PR DESCRIPTION
## Problem

v0.95.0 makes `DATABASE_URL_APP` the **preferred** way to point the request pool at the unprivileged `breeze_app` role, and the **only** option for multi-host/HA URLs — `requestDatabaseConfig.ts` throws rather than derive one:

> `Cannot derive the request database URL from DATABASE_URL. Set an explicit DATABASE_URL_APP for postgres.js multi-host/HA URLs.`

The base `docker-compose.yml` never mapped it into the `api` service `environment:` block. Compose only interpolates vars listed there, so a self-hoster setting `DATABASE_URL_APP` in `.env` had it **silently dropped**.

This is the same failure mode #2522 fixed for `deploy/docker-compose.prod.yml` — which already carries a comment spelling out why all three must be mapped, while the base file it mirrors omitted one of them.

## Fix

Map `DATABASE_URL_APP: ${DATABASE_URL_APP:-}` alongside the existing `POSTGRES_PASSWORD` / `BREEZE_APP_DB_PASSWORD`.

## Verification

`docker compose config` against an env file, base compose:

| | `DATABASE_URL_APP` occurrences in rendered `api` |
|---|---|
| main today | **0** — silently dropped |
| with this fix | **1** — value intact, incl. comma-separated HA hosts |
| fix + var unset | renders `""`, config still valid (rc=0) |

Confirmed via `awk` that the var lands in the `api` service specifically.

## Why now

Blocks cutting v0.95.0 — this is the release that introduces the variable, so shipping it inert on the default compose file would strand base-compose HA users on the exact footgun the release is meant to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)