### PR TITLE
fix(security): enforce scope-delegation ceiling on service principals (SR2-15)

### DIFF
--- a/apps/api/src/routes/servicePrincipals.test.ts
+++ b/apps/api/src/routes/servicePrincipals.test.ts
@@ -44,7 +44,21 @@ vi.mock('../services/servicePrincipals', () => {
 // Reset to granted in beforeEach. This is what proves guard-bite (c): the
 // migrate-key route actually runs through requirePermission, not a rubber
 // stamp — flip this to false and the 403 assertion goes RED.
-const permissionMockState = vi.hoisted(() => ({ granted: true }));
+// `permissions` mirrors what the real requirePermission sets via
+// c.set('permissions', ...). Default is an all-permissions caller (wildcard)
+// with no site restriction, so the scope-delegation ceiling passes for the
+// happy path; individual tests narrow it to exercise the ceiling.
+const permissionMockState = vi.hoisted(() => ({
+  granted: true,
+  permissions: {
+    permissions: [{ resource: '*', action: '*' }],
+    partnerId: null,
+    orgId: null,
+    roleId: 'role-1',
+    scope: 'organization',
+    allowedSiteIds: undefined,
+  } as any,
+}));
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => next()),
@@ -59,6 +73,7 @@ vi.mock('../middleware/auth', () => ({
     if (!permissionMockState.granted) {
       return c.json({ error: 'Permission denied' }, 403);
     }
+    c.set('permissions', permissionMockState.permissions);
     return next();
   }),
   requireMfa: vi.fn(() => async (_c: any, next: any) => next())
@@ -95,6 +110,14 @@ describe('service principal routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     permissionMockState.granted = true;
+    permissionMockState.permissions = {
+      permissions: [{ resource: '*', action: '*' }],
+      partnerId: null,
+      orgId: null,
+      roleId: 'role-1',
+      scope: 'organization',
+      allowedSiteIds: undefined,
+    } as any;
     setAuth();
     app = new Hono();
     app.route('/service-principals', servicePrincipalRoutes);
@@ -161,6 +184,52 @@ describe('service principal routes', () => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ orgId: OTHER_ORG_ID, name: 'CI bot', scopes: [] })
+      });
+
+      expect(res.status).toBe(403);
+      expect(createServicePrincipal).not.toHaveBeenCalled();
+    });
+
+    // SR2-15 ceiling: a principal must never carry a scope its creator lacks.
+    // Without this, an org admin holding only orgs:write could mint a principal
+    // with devices:execute and reach /dev/push (arbitrary binary → fleet).
+    it('rejects a scope the creator does not hold (delegation ceiling) and never creates', async () => {
+      permissionMockState.permissions = {
+        permissions: [{ resource: 'organizations', action: 'write' }],
+        partnerId: null,
+        orgId: ORG_ID,
+        roleId: 'role-1',
+        scope: 'organization',
+        allowedSiteIds: undefined,
+      } as any;
+
+      const res = await app.request('/service-principals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: ORG_ID, name: 'escalate', scopes: ['devices:execute'] })
+      });
+
+      expect(res.status).toBe(403);
+      expect(createServicePrincipal).not.toHaveBeenCalled();
+    });
+
+    // A service principal is organization-wide (no site axis). A site-restricted
+    // creator must not mint one, or they escape their own restriction across
+    // every site in the org.
+    it('rejects creation by a site-restricted caller and never creates', async () => {
+      permissionMockState.permissions = {
+        permissions: [{ resource: '*', action: '*' }],
+        partnerId: null,
+        orgId: ORG_ID,
+        roleId: 'role-1',
+        scope: 'organization',
+        allowedSiteIds: ['site-a'],
+      } as any;
+
+      const res = await app.request('/service-principals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: ORG_ID, name: 'CI bot', scopes: ['ai:read'] })
       });
 
       expect(res.status).toBe(403);

--- a/apps/api/src/routes/servicePrincipals.test.ts
+++ b/apps/api/src/routes/servicePrincipals.test.ts
@@ -283,6 +283,33 @@ describe('service principal routes', () => {
       expect(res.status).toBe(403);
       expect(rotateServicePrincipalKey).not.toHaveBeenCalled();
     });
+
+    // Ceiling bypass guard: rotate hands out a fresh live key with the
+    // principal's scopes. A caller who does NOT hold those scopes must not be
+    // able to capture that credential from an over-scoped principal — the same
+    // fleet-RCE escalation the create ceiling closes, via the rotate door.
+    it('denies rotate by a sub-ceiling caller on an over-scoped principal', async () => {
+      permissionMockState.permissions = {
+        permissions: [{ resource: 'organizations', action: 'write' }],
+        partnerId: null,
+        orgId: ORG_ID,
+        roleId: 'role-1',
+        scope: 'organization',
+        allowedSiteIds: undefined,
+      } as any;
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: PRINCIPAL_ID, orgId: ORG_ID, scopes: ['devices:execute'] }])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/service-principals/${PRINCIPAL_ID}/rotate`, { method: 'POST' });
+
+      expect(res.status).toBe(403);
+      expect(rotateServicePrincipalKey).not.toHaveBeenCalled();
+    });
   });
 
   describe('POST /service-principals/:id/disable', () => {
@@ -364,6 +391,33 @@ describe('service principal routes', () => {
 
       expect(res.status).toBe(200);
       expect(migrateHumanKeyToServicePrincipal).toHaveBeenCalledWith(KEY_ID, PRINCIPAL_ID, 'user-123');
+    });
+
+    it('denies migrate-key by a sub-ceiling caller on an over-scoped principal', async () => {
+      permissionMockState.permissions = {
+        permissions: [{ resource: 'organizations', action: 'write' }],
+        partnerId: null,
+        orgId: ORG_ID,
+        roleId: 'role-1',
+        scope: 'organization',
+        allowedSiteIds: undefined,
+      } as any;
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: PRINCIPAL_ID, orgId: ORG_ID, scopes: ['devices:execute'] }])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/service-principals/${PRINCIPAL_ID}/migrate-key`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ keyId: KEY_ID })
+      });
+
+      expect(res.status).toBe(403);
+      expect(migrateHumanKeyToServicePrincipal).not.toHaveBeenCalled();
     });
 
     it('maps ApiKeyNotFoundError from the service layer to 404', async () => {

--- a/apps/api/src/routes/servicePrincipals.ts
+++ b/apps/api/src/routes/servicePrincipals.ts
@@ -175,30 +175,8 @@ servicePrincipalRoutes.post(
       }
     }
 
-    const permissions = c.get('permissions') as UserPermissions | undefined;
-
-    // A service principal is organization-wide — service_principals has no site
-    // axis — so a site-restricted creator must not mint one, or the principal
-    // would reach every site in the org and escape the creator's restriction.
-    if (permissions?.allowedSiteIds) {
-      return c.json(
-        { error: 'Site-restricted users cannot create service principals, which are organization-wide' },
-        403,
-      );
-    }
-
-    // SR2-15 delegation ceiling: a principal must never carry a scope its
-    // creator does not currently hold. Mirrors the human API-key mint path
-    // (routes/apiKeys.ts → validateRequestedScopes); without it, an org admin
-    // with only orgs:write could mint a devices:execute principal and push an
-    // arbitrary binary to the fleet via /dev/push.
-    const delegation = validateApiKeyScopeDelegation(data.scopes, permissions);
-    if (!delegation.ok) {
-      return c.json(
-        { error: delegation.error, ...(delegation.details ? { details: delegation.details } : {}) },
-        delegation.status,
-      );
-    }
+    const denied = enforceScopeDelegation(c, data.scopes);
+    if (denied) return denied;
 
     const principal = await createServicePrincipal({
       orgId: data.orgId,
@@ -260,6 +238,37 @@ async function requirePrincipalOrgAccess(c: any, id: string) {
   return { principal, auth };
 }
 
+// SR2-15 delegation ceiling. A service-principal key must never carry a scope
+// its human actor does not currently hold, and a site-restricted actor cannot
+// manage an org-wide principal. Enforced on create AND on every path that hands
+// out or re-points a live key (rotate, migrate-key) — guarding create alone is a
+// front-door-only check: rotate would still let a sub-ceiling actor capture a
+// full-scope credential from an over-scoped principal. Returns a 403 Response to
+// short-circuit, or null when the actor is within their ceiling.
+function enforceScopeDelegation(c: any, scopes: string[]) {
+  const permissions = c.get('permissions') as UserPermissions | undefined;
+
+  // A service principal is organization-wide — service_principals has no site
+  // axis — so a site-restricted actor must not manage one, or the principal
+  // reaches every site in the org and escapes their restriction.
+  if (permissions?.allowedSiteIds) {
+    return c.json(
+      { error: 'Site-restricted users cannot manage service principals, which are organization-wide' },
+      403,
+    );
+  }
+
+  const delegation = validateApiKeyScopeDelegation(scopes, permissions);
+  if (!delegation.ok) {
+    return c.json(
+      { error: delegation.error, ...(delegation.details ? { details: delegation.details } : {}) },
+      delegation.status,
+    );
+  }
+
+  return null;
+}
+
 // POST /service-principals/:id/rotate - mint a new key, revoke the prior one
 servicePrincipalRoutes.post(
   '/:id/rotate',
@@ -271,6 +280,13 @@ servicePrincipalRoutes.post(
     const { id } = c.req.valid('param');
     const gate = await requirePrincipalOrgAccess(c, id);
     if ('response' in gate) return gate.response;
+
+    // Rotate hands the caller a fresh live key carrying the principal's scopes,
+    // so the actor must currently hold every one of them — otherwise a
+    // sub-ceiling actor could capture a full-scope credential from a principal
+    // an over-privileged colleague created.
+    const denied = enforceScopeDelegation(c, gate.principal.scopes ?? []);
+    if (denied) return denied;
 
     try {
       const rotated = await rotateServicePrincipalKey(id, gate.auth.user.id);
@@ -323,6 +339,12 @@ servicePrincipalRoutes.post(
     const { keyId } = c.req.valid('json');
     const gate = await requirePrincipalOrgAccess(c, id);
     if ('response' in gate) return gate.response;
+
+    // Re-pointing a human key onto this principal makes it outlive its human
+    // creator's off-boarding gate, so the actor must hold the principal's
+    // scopes — the same ceiling as create/rotate.
+    const denied = enforceScopeDelegation(c, gate.principal.scopes ?? []);
+    if (denied) return denied;
 
     try {
       const migrated = await migrateHumanKeyToServicePrincipal(keyId, id, gate.auth.user.id);

--- a/apps/api/src/routes/servicePrincipals.ts
+++ b/apps/api/src/routes/servicePrincipals.ts
@@ -5,7 +5,8 @@ import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import { db } from '../db';
 import { servicePrincipals } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
-import { PERMISSIONS } from '../services/permissions';
+import { PERMISSIONS, type UserPermissions } from '../services/permissions';
+import { validateApiKeyScopeDelegation } from '../services/apiKeyScopes';
 import {
   createServicePrincipal,
   rotateServicePrincipalKey,
@@ -172,6 +173,31 @@ servicePrincipalRoutes.post(
       if (!hasAccess) {
         return c.json({ error: 'Access to this organization denied' }, 403);
       }
+    }
+
+    const permissions = c.get('permissions') as UserPermissions | undefined;
+
+    // A service principal is organization-wide — service_principals has no site
+    // axis — so a site-restricted creator must not mint one, or the principal
+    // would reach every site in the org and escape the creator's restriction.
+    if (permissions?.allowedSiteIds) {
+      return c.json(
+        { error: 'Site-restricted users cannot create service principals, which are organization-wide' },
+        403,
+      );
+    }
+
+    // SR2-15 delegation ceiling: a principal must never carry a scope its
+    // creator does not currently hold. Mirrors the human API-key mint path
+    // (routes/apiKeys.ts → validateRequestedScopes); without it, an org admin
+    // with only orgs:write could mint a devices:execute principal and push an
+    // arbitrary binary to the fleet via /dev/push.
+    const delegation = validateApiKeyScopeDelegation(data.scopes, permissions);
+    if (!delegation.ok) {
+      return c.json(
+        { error: delegation.error, ...(delegation.details ? { details: delegation.details } : {}) },
+        delegation.status,
+      );
     }
 
     const principal = await createServicePrincipal({

--- a/apps/api/src/services/apiKeyAuthorization.test.ts
+++ b/apps/api/src/services/apiKeyAuthorization.test.ts
@@ -90,6 +90,46 @@ describe('authorizeHumanApiKeyCreator', () => {
     });
     expect(res).toEqual({ ok: false, reason: 'no_membership' });
   });
+
+  // A partner creator's org access can be narrowed (orgAccess/allowedOrgIds)
+  // without removing their partner_users role row — so getUserPermissions still
+  // resolves a role, but the creator can no longer reach the key's org. The key
+  // must not outlive that access.
+  it('DENIES (no_membership) when a partner creator lost access to the key org (orgAccess narrowed) despite a live partner role', async () => {
+    const narrowedPartner = {
+      permissions: [{ resource: 'devices', action: 'read' }],
+      partnerId: 'partner-1',
+      orgId: null,
+      roleId: 'role-1',
+      scope: 'partner',
+      orgAccess: 'selected',
+      allowedOrgIds: ['org-2'],
+      allowedSiteIds: undefined,
+    } as UserPermissions;
+    vi.mocked(getUserPermissions).mockResolvedValue(narrowedPartner);
+    const res = await authorizeHumanApiKeyCreator({
+      createdBy: 'user-1', orgId: 'org-1', partnerId: 'partner-1', scopes: ['devices:read'],
+    });
+    expect(res).toEqual({ ok: false, reason: 'no_membership' });
+  });
+
+  it('authorizes a partner creator who still has access to the key org', async () => {
+    const partnerWithAccess = {
+      permissions: [{ resource: 'devices', action: 'read' }],
+      partnerId: 'partner-1',
+      orgId: null,
+      roleId: 'role-1',
+      scope: 'partner',
+      orgAccess: 'selected',
+      allowedOrgIds: ['org-1'],
+      allowedSiteIds: undefined,
+    } as UserPermissions;
+    vi.mocked(getUserPermissions).mockResolvedValue(partnerWithAccess);
+    const res = await authorizeHumanApiKeyCreator({
+      createdBy: 'user-1', orgId: 'org-1', partnerId: 'partner-1', scopes: ['devices:read'],
+    });
+    expect(res.ok).toBe(true);
+  });
 });
 
 describe('authorizeServicePrincipalKey', () => {

--- a/apps/api/src/services/apiKeyAuthorization.ts
+++ b/apps/api/src/services/apiKeyAuthorization.ts
@@ -1,5 +1,5 @@
 import { eq } from 'drizzle-orm';
-import { getUserPermissions, type UserPermissions } from './permissions';
+import { canAccessOrg, getUserPermissions, type UserPermissions } from './permissions';
 import { validateApiKeyScopeDelegation } from './apiKeyScopes';
 import { db, withSystemDbAccessContext } from '../db';
 import { servicePrincipals } from '../db/schema';
@@ -59,6 +59,15 @@ export async function authorizeHumanApiKeyCreator(input: {
   }
 
   if (!permissions) {
+    return { ok: false, reason: 'no_membership' };
+  }
+
+  // A partner creator's org access can be narrowed (orgAccess/allowedOrgIds)
+  // without removing their partner_users role row — getUserPermissions still
+  // resolves a role, but the creator can no longer reach the key's org. Deny so
+  // the key does not outlive that access. (Org-scoped creators are already
+  // pinned to their own org by getUserPermissions's null return above.)
+  if (permissions.scope === 'partner' && !canAccessOrg(permissions, input.orgId)) {
     return { ok: false, reason: 'no_membership' };
   }
 


### PR DESCRIPTION
## BLOCKER — privilege escalation to fleet RCE

The service-principal create route (`routes/servicePrincipals.ts`) passed `scopes` to the DB **unvalidated**, while the human key path calls `validateApiKeyScopeDelegation` (`routes/apiKeys.ts:254`). At request time `authorizeServicePrincipalKey` re-clamps **only** against the principal's own stored scopes (`permissions: null`, `allowedSiteIds: undefined` = all sites), so nothing ever checks a principal's scopes against its creator's authority.

**Exploit:** an org admin holding only `orgs:write` (not `devices:execute`):
1. `POST /service-principals {scopes:['devices:execute']}` → 201
2. `POST /service-principals/:id/rotate` → raw key
3. `POST /dev/push` with `X-API-Key` — that route gates the API-key path solely on `requireApiKeyScope('devices:execute')` (`devPush.ts:80`), no permission check, no MFA → **upload an arbitrary 150 MB binary and push it to every managed agent.** Fleet RCE via a scope the creator never held.

The site-axis variant reintroduces the `null → all-sites` collapse #2510 just fixed on the human path.

## Fix

In `POST /service-principals`, before create:
- **Refuse a site-restricted caller** — `service_principals` has no site axis, so an org-wide principal would escape the creator's restriction.
- **Run `validateApiKeyScopeDelegation(scopes, caller permissions)`** — the same ceiling the human mint path enforces.

## Also (SHOULD-FIX, #2514)

`authorizeHumanApiKeyCreator` resolved a partner creator via `getUserPermissions` but never called `canAccessOrg`, so narrowing a partner tech's org access left their existing keys live on orgs they lost. Now denies when a partner creator can no longer reach the key's org — closing the gap in the PR's own "a key cannot outlive its creator's authority" thesis.

## Tests
- scope-ceiling create → 403, never creates
- site-restricted create → 403, never creates
- partner org-access narrowed → `no_membership`; still-entitled partner authorizes
- 26/26 green; happy path preserved.

Blocks v0.95.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)