### PR TITLE
fix(security): only trust CF-Connecting-IP when explicitly behind Cloudflare (SR2-16)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -402,6 +402,14 @@ FORCE_HTTPS=true
 # Example for a Cloudflare-fronted deploy: TRUSTED_PROXY_CIDRS=173.245.48.0/20,103.21.244.0/22
 # (Do NOT set 0.0.0.0/0 or broad RFC1918 ranges — the validator rejects those.)
 TRUSTED_PROXY_CIDRS=172.31.0.10/32
+# Trust the CF-Connecting-IP header for the real client IP. Set to true ONLY
+# when this deployment is genuinely fronted by Cloudflare (which overwrites the
+# header at its edge). A non-Cloudflare reverse proxy — including the bundled
+# Caddy — does NOT strip CF-Connecting-IP, so trusting it without a Cloudflare
+# front would let a client spoof the header to choose its own rate-limit bucket
+# or defeat a partner IP allowlist. Off by default; X-Forwarded-For (managed by
+# your proxy) is used instead. Leave unset unless you front Breeze with Cloudflare.
+TRUST_CF_CONNECTING_IP=false
 
 # Docker network layout for the bundled stack. Leave these commented unless the
 # default range clashes with something already on the host — both this default

--- a/apps/api/src/__tests__/integration/ipAllowlistTrustBoundary.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ipAllowlistTrustBoundary.integration.test.ts
@@ -81,6 +81,7 @@ describe('SR2-16 — partner IP allowlist trust boundary (real DB)', () => {
   const originalTrust = process.env.TRUST_PROXY_HEADERS;
   const originalCidrs = process.env.TRUSTED_PROXY_CIDRS;
   const originalMode = process.env.IP_ALLOWLIST_ENFORCEMENT_MODE;
+  const originalTrustCf = process.env.TRUST_CF_CONNECTING_IP;
 
   afterEach(() => {
     if (originalTrust === undefined) delete process.env.TRUST_PROXY_HEADERS;
@@ -89,12 +90,15 @@ describe('SR2-16 — partner IP allowlist trust boundary (real DB)', () => {
     else process.env.TRUSTED_PROXY_CIDRS = originalCidrs;
     if (originalMode === undefined) delete process.env.IP_ALLOWLIST_ENFORCEMENT_MODE;
     else process.env.IP_ALLOWLIST_ENFORCEMENT_MODE = originalMode;
+    if (originalTrustCf === undefined) delete process.env.TRUST_CF_CONNECTING_IP;
+    else process.env.TRUST_CF_CONNECTING_IP = originalTrustCf;
   });
 
   describe('Hosted / Cloudflare mode — trusted peer, CF-Connecting-IP honored', () => {
     it('allows when CF-Connecting-IP (from the trusted Caddy/CF peer) matches the allowlist', async () => {
       process.env.TRUST_PROXY_HEADERS = 'true';
       process.env.TRUSTED_PROXY_CIDRS = `${TRUSTED_PROXY_PEER}/32`;
+      process.env.TRUST_CF_CONNECTING_IP = 'true';
 
       const partner = await createPartner();
       await setPartnerAllowlist(partner.id, [ALLOWLISTED_IP]);
@@ -109,6 +113,7 @@ describe('SR2-16 — partner IP allowlist trust boundary (real DB)', () => {
     it('denies with not_in_list when CF-Connecting-IP (from the trusted peer) is NOT in the allowlist', async () => {
       process.env.TRUST_PROXY_HEADERS = 'true';
       process.env.TRUSTED_PROXY_CIDRS = `${TRUSTED_PROXY_PEER}/32`;
+      process.env.TRUST_CF_CONNECTING_IP = 'true';
 
       const partner = await createPartner();
       await setPartnerAllowlist(partner.id, [ALLOWLISTED_IP]);
@@ -117,6 +122,29 @@ describe('SR2-16 — partner IP allowlist trust boundary (real DB)', () => {
       const decision = await enforceIpAllowlist(c, { partnerId: partner.id, isPlatformAdmin: false });
 
       expect(decision).toEqual({ decision: 'deny', reason: 'not_in_list' });
+      expect(isBlocked(decision)).toBe(true);
+    });
+  });
+
+  describe('Self-hosted, NOT behind Cloudflare — CF-Connecting-IP is not trusted (TRUST_CF_CONNECTING_IP unset)', () => {
+    // The bundled Caddy does not strip CF-Connecting-IP. With the flag off, a
+    // CF-Connecting-IP even from the TRUSTED proxy peer must be ignored — the
+    // request is attributed to the real peer IP, not the header — so an
+    // attacker cannot spoof an allowlisted IP by sending the header.
+    it('ignores CF-Connecting-IP and attributes to the peer IP, denying a spoofed allowlisted value', async () => {
+      process.env.TRUST_PROXY_HEADERS = 'true';
+      process.env.TRUSTED_PROXY_CIDRS = `${TRUSTED_PROXY_PEER}/32`;
+      delete process.env.TRUST_CF_CONNECTING_IP;
+
+      const partner = await createPartner();
+      await setPartnerAllowlist(partner.id, [ALLOWLISTED_IP]);
+
+      // CF-Connecting-IP claims the allowlisted IP, but the flag is off and there
+      // is no XFF, so resolution falls to the (trusted) peer IP, which is not on
+      // the allowlist → deny.
+      const c = makeContext({ 'cf-connecting-ip': ALLOWLISTED_IP }, TRUSTED_PROXY_PEER);
+      const decision = await enforceIpAllowlist(c, { partnerId: partner.id, isPlatformAdmin: false });
+
       expect(isBlocked(decision)).toBe(true);
     });
   });

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -726,6 +726,40 @@ describe('validateConfig', () => {
     warnSpy.mockRestore();
   });
 
+  it('warns when proxy trust is on but TRUST_CF_CONNECTING_IP is off in production (SR2-16)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    withEnv({
+      ...validEnv,
+      NODE_ENV: 'production',
+      CORS_ALLOWED_ORIGINS: 'https://app.breeze.io',
+      TRUST_PROXY_HEADERS: 'true',
+    }, () => {
+      validateConfig();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('TRUST_CF_CONNECTING_IP')
+      );
+    });
+    warnSpy.mockRestore();
+  });
+
+  it('does not warn about TRUST_CF_CONNECTING_IP when it is enabled', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    withEnv({
+      ...validEnv,
+      NODE_ENV: 'production',
+      CORS_ALLOWED_ORIGINS: 'https://app.breeze.io',
+      TRUST_PROXY_HEADERS: 'true',
+      TRUST_CF_CONNECTING_IP: 'true',
+    }, () => {
+      validateConfig();
+      const cfWarnings = warnSpy.mock.calls
+        .flat()
+        .filter((m) => typeof m === 'string' && m.includes('TRUST_CF_CONNECTING_IP'));
+      expect(cfWarnings).toHaveLength(0);
+    });
+    warnSpy.mockRestore();
+  });
+
   it('accepts optional Stripe env vars (API-key model — no Connect OAuth)', () => {
     withEnv({
       ...validEnv,

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -1299,6 +1299,28 @@ function collectWarnings(env: Record<string, string | undefined>): ConfigWarning
     // (AGENT_ENROLLMENT_SECRET is now a hard error in production — see the
     // schema superRefine. No warning needed here; the validator throws if
     // it's missing or weak.)
+
+    // SR2-16: a prod deploy that trusts proxy headers but leaves
+    // TRUST_CF_CONNECTING_IP off resolves client IPs from X-Forwarded-For only.
+    // That is correct for a non-Cloudflare front, but a Cloudflare-fronted
+    // deploy that forgets the flag silently loses CF-Connecting-IP attribution —
+    // rate limits, audit-log IPs and partner IP allowlists then key off XFF (or
+    // the proxy hop if XFF isn't populated). Warn so the flag is a conscious
+    // choice; hard-failing would break legitimate non-Cloudflare self-hosters.
+    const trustProxy = (env.TRUST_PROXY_HEADERS ?? '').trim().toLowerCase();
+    const proxyTrustOn = ['1', 'true', 'yes', 'on'].includes(trustProxy);
+    const trustCf = (env.TRUST_CF_CONNECTING_IP ?? '').trim().toLowerCase();
+    const cfTrustOff = !['1', 'true', 'yes', 'on'].includes(trustCf);
+    if (proxyTrustOn && cfTrustOff) {
+      warnings.push({
+        key: 'TRUST_CF_CONNECTING_IP',
+        message:
+          'Proxy header trust is enabled but TRUST_CF_CONNECTING_IP is off, so CF-Connecting-IP is ignored. ' +
+          'This is correct for a non-Cloudflare front. If this deployment IS behind Cloudflare, set ' +
+          'TRUST_CF_CONNECTING_IP=true — otherwise client IPs (rate limits, audit logs, IP allowlists) resolve ' +
+          'from X-Forwarded-For instead of the Cloudflare edge IP.',
+      });
+    }
   }
 
   // Warn when 2FA is globally disabled: this neuters ALL requireMfa() step-up

--- a/apps/api/src/routes/auth/helpers.test.ts
+++ b/apps/api/src/routes/auth/helpers.test.ts
@@ -269,7 +269,7 @@ describe('evaluatePendingMfa (SR2-06)', () => {
 describe('getClientRateLimitKey — spoof-proof per-IP key (SR2-16)', () => {
   const origTrust = process.env.TRUST_PROXY_HEADERS;
   beforeEach(() => { process.env.TRUST_PROXY_HEADERS = 'false'; }); // untrusted / no proxy trust
-  afterEach(() => { if (origTrust === undefined) delete process.env.TRUST_PROXY_HEADERS; else process.env.TRUST_PROXY_HEADERS = origTrust; });
+  afterEach(() => { if (origTrust === undefined) delete process.env.TRUST_PROXY_HEADERS; else process.env.TRUST_PROXY_HEADERS = origTrust; delete process.env.TRUST_CF_CONNECTING_IP; });
 
   it('keys on the SOCKET peer, so a rotating spoofed X-Forwarded-For from the same peer yields the SAME key (cannot evade the per-IP limit)', () => {
     // GUARD-BITE: RED today — the fingerprint hashes x-forwarded-for, so the two
@@ -291,6 +291,7 @@ describe('getClientRateLimitKey — spoof-proof per-IP key (SR2-16)', () => {
   it('prefers the trusted client IP when proxy trust is properly configured', () => {
     process.env.TRUST_PROXY_HEADERS = 'true';
     process.env.TRUSTED_PROXY_CIDRS = '198.51.100.77/32';
+    process.env.TRUST_CF_CONNECTING_IP = 'true';
     const key = getClientRateLimitKey(makeContext({ 'cf-connecting-ip': '203.0.113.5' }, '198.51.100.77'));
     expect(key).toBe('ip:203.0.113.5');
     delete process.env.TRUSTED_PROXY_CIDRS;

--- a/apps/api/src/routes/devices/provision.test.ts
+++ b/apps/api/src/routes/devices/provision.test.ts
@@ -579,6 +579,7 @@ describe('POST /devices/provision', () => {
         else process.env.TRUST_PROXY_HEADERS = origTrust;
         if (origCidrs === undefined) delete process.env.TRUSTED_PROXY_CIDRS;
         else process.env.TRUSTED_PROXY_CIDRS = origCidrs;
+        delete process.env.TRUST_CF_CONNECTING_IP;
       });
 
       function fetchReqWithPeer(headers: Record<string, string>, remoteAddress?: string) {
@@ -624,6 +625,7 @@ describe('POST /devices/provision', () => {
       it('records the real cf-connecting-ip when the peer is a trusted proxy (SR2-16)', async () => {
         process.env.TRUST_PROXY_HEADERS = 'true';
         process.env.TRUSTED_PROXY_CIDRS = '198.51.100.77/32';
+        process.env.TRUST_CF_CONNECTING_IP = 'true';
 
         mockHandleSelect([
           {

--- a/apps/api/src/routes/installer.test.ts
+++ b/apps/api/src/routes/installer.test.ts
@@ -497,6 +497,7 @@ describe("POST /api/v1/installer/bootstrap — trusted client IP (SR2-16)", () =
     else process.env.TRUST_PROXY_HEADERS = origTrust;
     if (origCidrs === undefined) delete process.env.TRUSTED_PROXY_CIDRS;
     else process.env.TRUSTED_PROXY_CIDRS = origCidrs;
+    delete process.env.TRUST_CF_CONNECTING_IP;
   });
 
   function mockRedeemChain(tokenRow: Record<string, unknown>, parentKey: Record<string, unknown>, org: Record<string, unknown>) {
@@ -562,6 +563,7 @@ describe("POST /api/v1/installer/bootstrap — trusted client IP (SR2-16)", () =
   it("records the real cf-connecting-ip when the peer is a trusted proxy (SR2-16)", async () => {
     process.env.TRUST_PROXY_HEADERS = "true";
     process.env.TRUSTED_PROXY_CIDRS = "198.51.100.77/32";
+    process.env.TRUST_CF_CONNECTING_IP = "true";
 
     const tokenRow = {
       id: "ip-t2", token: "JJJJJJJJJJ", orgId: "o-ip2", parentEnrollmentKeyId: "pk-ip2", siteId: "s-ip2",

--- a/apps/api/src/services/clientIp.test.ts
+++ b/apps/api/src/services/clientIp.test.ts
@@ -30,11 +30,16 @@ describe('clientIp', () => {
   const originalTrust = process.env.TRUST_PROXY_HEADERS;
   const originalTrustedCidrs = process.env.TRUSTED_PROXY_CIDRS;
   const originalNodeEnv = process.env.NODE_ENV;
+  const originalTrustCf = process.env.TRUST_CF_CONNECTING_IP;
 
   beforeEach(() => {
     // Force trust on so tests don't depend on NODE_ENV defaults.
     process.env.TRUST_PROXY_HEADERS = 'true';
     delete process.env.TRUSTED_PROXY_CIDRS;
+    // The CF-Connecting-IP precedence tests below assume a deployment genuinely
+    // behind Cloudflare; opt in explicitly. The secure default (off) is covered
+    // in its own block.
+    process.env.TRUST_CF_CONNECTING_IP = 'true';
   });
 
   afterEach(() => {
@@ -44,6 +49,39 @@ describe('clientIp', () => {
     else process.env.TRUSTED_PROXY_CIDRS = originalTrustedCidrs;
     if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
     else process.env.NODE_ENV = originalNodeEnv;
+    if (originalTrustCf === undefined) delete process.env.TRUST_CF_CONNECTING_IP;
+    else process.env.TRUST_CF_CONNECTING_IP = originalTrustCf;
+  });
+
+  describe('CF-Connecting-IP trust is opt-in (secure default)', () => {
+    // A bundled Caddy does NOT strip CF-Connecting-IP, so a self-hoster not
+    // behind Cloudflare must not trust it — otherwise a client spoofs the
+    // header to choose its own rate-limit bucket / defeat an IP allowlist.
+    it('IGNORES cf-connecting-ip when TRUST_CF_CONNECTING_IP is unset, using XFF instead', () => {
+      delete process.env.TRUST_CF_CONNECTING_IP;
+      const ip = getTrustedClientIp(
+        makeContext({
+          'cf-connecting-ip': '203.0.113.10',
+          'x-forwarded-for': '198.51.100.1, 10.0.0.5',
+        }),
+      );
+      expect(ip).toBe('198.51.100.1');
+    });
+
+    it('does not let a spoofed cf-connecting-ip win when only that header is present (unset flag)', () => {
+      delete process.env.TRUST_CF_CONNECTING_IP;
+      const ip = getTrustedClientIp(
+        makeContext({ 'cf-connecting-ip': '203.0.113.10' }),
+        'sentinel',
+      );
+      expect(ip).toBe('sentinel');
+    });
+
+    it('trusts cf-connecting-ip when TRUST_CF_CONNECTING_IP is enabled', () => {
+      process.env.TRUST_CF_CONNECTING_IP = 'true';
+      const ip = getTrustedClientIp(makeContext({ 'cf-connecting-ip': '203.0.113.10' }));
+      expect(ip).toBe('203.0.113.10');
+    });
   });
 
   describe('getTrustedClientIp', () => {

--- a/apps/api/src/services/clientIp.ts
+++ b/apps/api/src/services/clientIp.ts
@@ -20,6 +20,16 @@ function shouldTrustProxyHeaders(): boolean {
   return isTruthy(mode);
 }
 
+function trustCloudflareConnectingIp(): boolean {
+  // CF-Connecting-IP is only trustworthy when the deployment is genuinely
+  // behind Cloudflare: CF's edge overwrites the header on every request, but a
+  // reverse proxy like the bundled Caddy does NOT strip it. A self-hoster not
+  // behind Cloudflare who trusts it lets a client spoof CF-Connecting-IP to
+  // choose its own per-IP rate-limit bucket and defeat IP allowlists. Off
+  // unless the operator explicitly declares a Cloudflare front.
+  return isTruthy(process.env.TRUST_CF_CONNECTING_IP);
+}
+
 function trustedProxyCidrs(): string[] {
   const configured = (process.env.TRUSTED_PROXY_CIDRS ?? '')
     .split(',')
@@ -218,16 +228,20 @@ export function getTrustedClientIp(c: RequestLike, fallback = 'unknown'): string
 
   // Precedence rationale:
   // 1. CF-Connecting-IP — set directly by Cloudflare's edge for every tunneled
-  //    request. It is a single canonical IP (not a chain) and cannot be
-  //    appended-to by intermediaries the way XFF can, so when present it is
-  //    the most trustworthy source. Our prod stack is always behind CF.
+  //    request; a single canonical IP that intermediaries cannot append to the
+  //    way they can XFF. Trusted ONLY when TRUST_CF_CONNECTING_IP is set,
+  //    because a reverse proxy that is not Cloudflare does not strip this
+  //    header, so trusting it unconditionally would let a client spoof it.
+  //    Enable only when the deployment is genuinely fronted by Cloudflare.
   // 2. X-Forwarded-For — emitted by Caddy with the real client at the head of
   //    the chain (now that `trusted_proxies` + `client_ip_headers` is set,
   //    see docker/Caddyfile.prod). Fallback for non-CF deployments / dev.
   // 3. X-Real-IP — single-IP variant some proxies emit instead of XFF.
-  const cloudflare = normalizeIpCandidate(c.req.header('cf-connecting-ip') ?? c.req.header('CF-Connecting-IP') ?? '');
-  if (cloudflare) {
-    return cloudflare;
+  if (trustCloudflareConnectingIp()) {
+    const cloudflare = normalizeIpCandidate(c.req.header('cf-connecting-ip') ?? c.req.header('CF-Connecting-IP') ?? '');
+    if (cloudflare) {
+      return cloudflare;
+    }
   }
 
   const forwarded = firstValidIpFromCsv(c.req.header('x-forwarded-for') ?? c.req.header('X-Forwarded-For'));

--- a/apps/api/src/services/llm/openaiSessionManager.test.ts
+++ b/apps/api/src/services/llm/openaiSessionManager.test.ts
@@ -32,6 +32,7 @@ describe('OpenAISessionManager.getOrCreate — auditSnapshot.ip via trusted reso
     else process.env.TRUST_PROXY_HEADERS = origTrust;
     if (origCidrs === undefined) delete process.env.TRUSTED_PROXY_CIDRS;
     else process.env.TRUSTED_PROXY_CIDRS = origCidrs;
+    delete process.env.TRUST_CF_CONNECTING_IP;
   });
 
   it('records undefined, not a spoofed x-forwarded-for, when the peer is untrusted (SR2-16)', () => {
@@ -51,6 +52,7 @@ describe('OpenAISessionManager.getOrCreate — auditSnapshot.ip via trusted reso
   it('records the real trusted client IP when the peer is a trusted proxy (SR2-16)', () => {
     process.env.TRUST_PROXY_HEADERS = 'true';
     process.env.TRUSTED_PROXY_CIDRS = '198.51.100.77/32';
+    process.env.TRUST_CF_CONNECTING_IP = 'true';
 
     manager = new OpenAISessionManager({} as OpenAICompatibleProvider);
     const ctx = makeContext({ 'cf-connecting-ip': '203.0.113.5' }, '198.51.100.77');

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -150,6 +150,10 @@ services:
       TURN_CREDENTIAL_TTL_SECONDS: ${TURN_CREDENTIAL_TTL_SECONDS:-600}
       TRUST_PROXY_HEADERS: "true"
       TRUSTED_PROXY_CIDRS: "${TRUSTED_PROXY_CIDRS:-172.30.0.11/32}"
+      # This reference stack is fronted by Cloudflare (cloudflared → Caddy), so
+      # CF-Connecting-IP is authoritative. Self-hosters NOT behind Cloudflare
+      # must leave this unset — see the base docker-compose.yml note.
+      TRUST_CF_CONNECTING_IP: "${TRUST_CF_CONNECTING_IP:-true}"
       PARTNER_HOOKS_URL: http://billing:3002/hooks
       BILLING_SERVICE_URL: http://billing:3002
       BILLING_SERVICE_API_KEY: ${BILLING_SERVICE_API_KEY:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,11 @@ services:
       # it — a CIDR that matches nothing simply means no headers are trusted.
       TRUST_PROXY_HEADERS: ${TRUST_PROXY_HEADERS:-true}
       TRUSTED_PROXY_CIDRS: ${TRUSTED_PROXY_CIDRS:-${BREEZE_CADDY_IP:-172.31.0.10}/32}
+      # Only trust CF-Connecting-IP when this deployment is genuinely fronted by
+      # Cloudflare — a non-CF reverse proxy does not strip the header, so a
+      # client could otherwise spoof it. Off by default; set true in .env only
+      # if you front Breeze with Cloudflare.
+      TRUST_CF_CONNECTING_IP: ${TRUST_CF_CONNECTING_IP:-}
       APP_ENCRYPTION_KEY: ${APP_ENCRYPTION_KEY:?Set APP_ENCRYPTION_KEY in .env}
       MFA_ENCRYPTION_KEY: ${MFA_ENCRYPTION_KEY:?Set MFA_ENCRYPTION_KEY in .env}
       ENROLLMENT_KEY_PEPPER: ${ENROLLMENT_KEY_PEPPER:?Set ENROLLMENT_KEY_PEPPER in .env}


### PR DESCRIPTION
## BLOCKER — rate-limit / IP-allowlist bypass for non-Cloudflare self-hosters

`getTrustedClientIp` (`services/clientIp.ts`) gave `CF-Connecting-IP` top precedence **unconditionally** once the immediate peer was a trusted proxy. #2516 flipped `TRUST_PROXY_HEADERS` `false → true` on the bundled stack, and the bundled Caddy does **not** strip `CF-Connecting-IP` — `client_ip_headers` only affects Caddy's own `{client_ip}` placeholder, it forwards the header untouched.

**Attack (any bundled deployment not behind Cloudflare — exactly the new default's population):**
1. Attacker sends `CF-Connecting-IP: <allowlisted-ip>` straight to Caddy.
2. Caddy overwrites XFF (correct) but passes `CF-Connecting-IP` through.
3. API sees a trusted peer (Caddy) → returns the attacker-chosen IP.

Defeats the partner IP allowlist and per-IP auth rate limits (rotate the header per request for unlimited buckets — the credential-stuffing surface #2516 claimed to close). Prod (behind Cloudflare, which overwrites the header at its edge) is safe; self-hosters were not. The code comment "Our prod stack is always behind CF" was a prod assumption baked into code self-hosters also run.

## Fix

Trust `CF-Connecting-IP` only when `TRUST_CF_CONNECTING_IP` is set, defaulting **off**. `X-Forwarded-For` (which Caddy manages correctly for untrusted clients) is used otherwise.

- `deploy/docker-compose.prod.yml` sets it `true` (this reference stack is Cloudflare-fronted).
- Base `docker-compose.yml` leaves it unset (self-host safe by default; behind-CF self-hosters opt in via `.env`).
- `.env.example` documents exactly when to enable it.

## Tests
- **Unit** (49/49): `CF-Connecting-IP` ignored when the flag is unset (falls to XFF; a spoofed CF value does not win), honored when enabled.
- **Integration** (`ipAllowlistTrustBoundary`): new self-hosted case proves a `CF-Connecting-IP` from the *trusted* peer is ignored with the flag off — attribution falls to the real peer IP, denying a spoofed allowlisted value. Hosted-mode cases opt in explicitly.

## Deploy note (release)
Prod is Cloudflare-fronted, so `TRUST_CF_CONNECTING_IP=true` must be set in the droplet `.env` and is mapped in the prod compose. Behavior/config change for the v0.95.0 notes.

Blocks v0.95.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)