### PR TITLE
fix(sso): reject clearing an OIDC provider's issuer with a clear 400 (#2494)

### DIFF
--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -746,6 +746,34 @@ describe('sso routes', () => {
       expect(setMock).toHaveBeenCalledWith(expect.objectContaining({ defaultRoleId: null }));
     });
 
+    it('rejects clearing the issuer on an OIDC provider with a clear 400, not a null-deref discovery crash', async () => {
+      // The web edit form resubmits every field, so blanking the Issuer sends
+      // issuer:'' -> null. issuerChanged becomes true and, for an OIDC provider,
+      // the old code called discoverOIDCConfig(null) -> issuer.replace on null
+      // -> TypeError -> opaque 400 'OIDC discovery failed for issuer "null"'.
+      // An OIDC provider requires an issuer; reject clearly before discovery.
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              { id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null, type: 'oidc', issuer: 'https://issuer.example.com' }
+            ])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ issuer: '' })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.code).toBe('oidc_issuer_required');
+      expect(discoverOIDCConfig).not.toHaveBeenCalled();
+    });
+
     it('clears a partner-owned provider default role without re-running the partner-role permission check', async () => {
       // existing.partnerId is truthy — the update route's role-ceiling check
       // only fires `if (existing.partnerId && body.defaultRoleId)`. Clearing

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -1146,6 +1146,27 @@ ssoRoutes.patch(
   const issuerChanged = body.issuer !== undefined && body.issuer !== existing.issuer;
   const rediscovered: Partial<typeof ssoProviders.$inferInsert> = {};
   if (issuerChanged && (body.type ?? existing.type) === 'oidc') {
+    // The web form resubmits every field, so a blanked Issuer arrives as
+    // issuer:'' → null (nullableOptional). An OIDC provider cannot function
+    // without an issuer, and discoverOIDCConfig(null) would null-deref into an
+    // opaque `issuer "null"` 400. Reject clearly before attempting discovery.
+    if (!body.issuer) {
+      writeRouteAudit(c, {
+        orgId: existing.orgId,
+        action: 'sso.provider.update.rejected',
+        resourceType: 'sso_provider',
+        resourceId: existing.id,
+        details: {
+          reason: 'oidc_issuer_cleared',
+          partnerId: existing.partnerId,
+        },
+      });
+      return c.json({
+        error: 'An OIDC provider requires an Issuer URL; it cannot be cleared. '
+          + 'To remove this provider, delete it instead.',
+        code: 'oidc_issuer_required',
+      }, 400);
+    }
     try {
       const discovery = await discoverOIDCConfig(body.issuer!, {
         allowPrivateNetwork: selfHostAllowsPrivateNetwork()


### PR DESCRIPTION
## SHOULD-FIX — #2494 was a partial fix

#2494 fixed `defaultRoleId:''` and the never-set-issuer cases, but **clearing the issuer on an existing OIDC provider** still failed. The web edit form resubmits every field, so a blanked Issuer arrives as `issuer:'' → null` (`nullableOptional`). `issuerChanged` becomes true and, for an OIDC provider, the handler called `discoverOIDCConfig(null)` → `issuer.replace(...)` on null → `TypeError` → an opaque `400 'OIDC discovery failed for issuer "null"'` (the exact scenario named in #2494's own commit message).

## Fix

An OIDC provider cannot function without an issuer, so reject the clear explicitly **before** discovery — `code: 'oidc_issuer_required'` with an actionable message (delete the provider instead) — and write the rejection audit. SAML and never-set-issuer paths are unaffected; `defaultRoleId:''` (the primary #2494 bug) stays fixed.

## Test
`PATCH {issuer:''}` on an OIDC provider → `400`, `code: 'oidc_issuer_required'`, `discoverOIDCConfig` never called. 140/140 green.

Part of the v0.95.0 pre-tag cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)