### PR TITLE
feat(quotes): add quote cloning

### DIFF
--- a/apps/api/src/routes/quotes/quotes.test.ts
+++ b/apps/api/src/routes/quotes/quotes.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock the service layer — routes are thin; we assert wiring, validation, error mapping.
 vi.mock('../../services/quoteService', () => ({
   createQuote: vi.fn(),
+  cloneQuote: vi.fn(),
   getQuote: vi.fn(),
   listQuotes: vi.fn(),
   updateQuote: vi.fn(),
@@ -108,6 +109,33 @@ describe('quote crud + lines routes', () => {
     const body = await res.json();
     expect(body.data.id).toBe(QUOTE_ID);
     expect(svc.createQuote).toHaveBeenCalledOnce();
+  });
+
+  it('POST /:id/clone clones a quote into a new draft', async () => {
+    (svc.cloneQuote as any).mockResolvedValue({ id: BLOCK_ID, status: 'draft' });
+    const res = await app().request(`/${QUOTE_ID}/clone`, { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ id: BLOCK_ID, status: 'draft' });
+    expect(svc.cloneQuote).toHaveBeenCalledWith(QUOTE_ID, expect.anything());
+  });
+
+  it('POST /:id/clone rejects an invalid quote id before calling the service', async () => {
+    const res = await app().request('/not-a-uuid/clone', { method: 'POST' });
+
+    expect(res.status).toBe(400);
+    expect(svc.cloneQuote).not.toHaveBeenCalled();
+  });
+
+  it('POST /:id/clone is blocked by the write-permission gate', async () => {
+    const { HTTPException } = await import('hono/http-exception');
+    gate.permGate = async () => { throw new HTTPException(403, { message: 'Permission denied' }); };
+
+    const res = await app().request(`/${QUOTE_ID}/clone`, { method: 'POST' });
+
+    expect(res.status).toBe(403);
+    expect(svc.cloneQuote).not.toHaveBeenCalled();
   });
 
   it('POST / rejects an invalid body (non-UUID orgId → 400, no service call)', async () => {

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -10,7 +10,7 @@ import {
   reorderBlocksSchema, reorderLinesSchema, moveQuoteLineSchema,
 } from '@breeze/shared';
 import {
-  createQuote, getQuote, listQuotes, updateQuote, deleteDraftQuote,
+  createQuote, cloneQuote, getQuote, listQuotes, updateQuote, deleteDraftQuote,
   addManualLine, addCatalogLine, updateLine, removeLine, addBlock, updateBlock, deleteBlock,
   reorderBlocks, reorderLines, moveLineToBlock,
 } from '../../services/quoteService';
@@ -47,6 +47,10 @@ quoteCrudRoutes.get('/', scopes, readPerm, zValidator('query', listQuotesQuerySc
 });
 quoteCrudRoutes.post('/', scopes, writePerm, zValidator('json', createQuoteSchema), async (c) => {
   try { return c.json({ data: await createQuote(c.req.valid('json'), quoteActorFrom(c)) }); }
+  catch (err) { return handleServiceError(c, err); }
+});
+quoteCrudRoutes.post('/:id/clone', scopes, writePerm, zValidator('param', idParam), async (c) => {
+  try { return c.json({ data: await cloneQuote(c.req.valid('param').id, quoteActorFrom(c)) }); }
   catch (err) { return handleServiceError(c, err); }
 });
 quoteCrudRoutes.get('/:id', scopes, readPerm, zValidator('param', idParam), async (c) => {

--- a/apps/api/src/services/quoteService.clone.test.ts
+++ b/apps/api/src/services/quoteService.clone.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  selectResults: [] as unknown[][],
+  insertedValues: [] as unknown[],
+  transactionCalls: 0,
+}));
+
+vi.mock('../db', () => {
+  const makeSelectChain = () => {
+    const chain: Record<string, unknown> = {};
+    for (const method of ['from', 'where', 'limit', 'orderBy']) {
+      chain[method] = vi.fn(() => chain);
+    }
+    (chain as { then: unknown }).then = (resolve: (value: unknown) => unknown) =>
+      Promise.resolve(state.selectResults.shift() ?? []).then(resolve);
+    return chain;
+  };
+
+  const makeInsertChain = () => {
+    let value: unknown;
+    const chain: Record<string, unknown> = {};
+    chain.values = vi.fn((next: unknown) => {
+      value = next;
+      state.insertedValues.push(next);
+      return chain;
+    });
+    chain.returning = vi.fn(() => Promise.resolve([value]));
+    (chain as { then: unknown }).then = (resolve: (result: unknown) => unknown) =>
+      Promise.resolve([]).then(resolve);
+    return chain;
+  };
+
+  const tx = { insert: vi.fn(() => makeInsertChain()) };
+  return {
+    db: {
+      select: vi.fn(() => makeSelectChain()),
+      transaction: vi.fn(async (run: (transaction: typeof tx) => unknown) => {
+        state.transactionCalls += 1;
+        return run(tx);
+      }),
+    },
+    runOutsideDbContext: (fn: () => unknown) => fn(),
+    withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  };
+});
+
+vi.mock('./quoteNumbers', () => ({
+  allocateQuoteCounter: vi.fn().mockResolvedValue(42),
+  formatQuoteNumber: vi.fn().mockReturnValue('Q-2026-000042'),
+}));
+
+import { cloneQuote } from './quoteService';
+
+const actor = { userId: 'user-1', partnerId: 'partner-1', accessibleOrgIds: ['org-1'] };
+
+function sourceQuote() {
+  return {
+    id: 'quote-1', partnerId: 'partner-1', orgId: 'org-1', siteId: 'site-1',
+    quoteNumber: 'Q-2025-000010', title: 'Managed services', status: 'accepted',
+    currencyCode: 'USD', issueDate: '2025-01-01', expiryDate: '2025-02-01',
+    acceptedAt: new Date('2025-01-10'), declinedAt: null, convertedAt: new Date('2025-01-10'),
+    subtotal: '100.00', taxRate: '0.05000', taxTotal: '5.00', total: '105.00',
+    oneTimeTotal: '105.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00',
+    depositType: 'percent', depositPercent: '25.00', depositAmount: '26.25',
+    billToName: 'Acme', billToAddress: { city: 'Denver' }, billToTaxId: 'TAX-1',
+    introNotes: 'Hello', terms: 'Net 30', sellerSnapshot: { name: 'Old seller' },
+    termsAndConditions: 'Terms', declineReason: null, convertedInvoiceId: 'invoice-1',
+    pdfDocumentRef: 'quote.pdf', pdfSha256: 'abc', sentAt: new Date('2025-01-02'),
+    firstViewedAt: new Date('2025-01-03'), viewedAt: new Date('2025-01-03'),
+    createdBy: 'user-old', createdAt: new Date('2025-01-01'), updatedAt: new Date('2025-01-10'),
+  };
+}
+
+describe('cloneQuote', () => {
+  beforeEach(() => {
+    state.selectResults.length = 0;
+    state.insertedValues.length = 0;
+    state.transactionCalls = 0;
+    vi.clearAllMocks();
+  });
+
+  it('copies quote content and remaps aggregate IDs into a fresh draft', async () => {
+    state.selectResults.push(
+      [sourceQuote()],
+      [
+        { id: 'block-image', quoteId: 'quote-1', orgId: 'org-1', blockType: 'image', content: { imageId: 'image-1', caption: 'Rack' }, sortOrder: 0, createdAt: new Date() },
+        { id: 'block-lines', quoteId: 'quote-1', orgId: 'org-1', blockType: 'line_items', content: { label: 'Services' }, sortOrder: 1, createdAt: new Date() },
+      ],
+      [
+        { id: 'line-parent', quoteId: 'quote-1', blockId: 'block-lines', orgId: 'org-1', sourceType: 'manual', catalogItemId: null, parentLineId: null, name: 'Server', description: null, quantity: '1.00', unitPrice: '100.00', taxable: true, customerVisible: true, lineTotal: '100.00', recurrence: 'one_time', termMonths: null, billingFrequency: null, unitCost: '50.00', depositEligible: true, itemType: 'hardware', sku: 'SKU-1', partNumber: 'PN-1', imageId: 'image-1', sortOrder: 0, createdAt: new Date() },
+        { id: 'line-child', quoteId: 'quote-1', blockId: 'block-lines', orgId: 'org-1', sourceType: 'manual', catalogItemId: null, parentLineId: 'line-parent', name: 'Setup', description: null, quantity: '1.00', unitPrice: '0.00', taxable: false, customerVisible: true, lineTotal: '0.00', recurrence: 'one_time', termMonths: null, billingFrequency: null, unitCost: null, depositEligible: false, itemType: 'service', sku: null, partNumber: null, imageId: null, sortOrder: 1, createdAt: new Date() },
+      ],
+      [{ id: 'image-1', quoteId: 'quote-1', orgId: 'org-1', imageData: Buffer.from('image'), mime: 'image/png', byteSize: 5, sha256: 'hash', createdAt: new Date() }],
+    );
+
+    const cloned = await cloneQuote('quote-1', actor);
+
+    expect(cloned).toMatchObject({ status: 'draft', quoteNumber: 'Q-2026-000042', title: 'Managed services' });
+    expect(cloned.id).not.toBe('quote-1');
+    expect(state.transactionCalls).toBe(1);
+
+    const [quoteInsert, imageInsert, blockInsert, lineInsert] = state.insertedValues as [
+      Record<string, unknown>, Array<Record<string, unknown>>, Array<Record<string, unknown>>, Array<Record<string, unknown>>,
+    ];
+    expect(quoteInsert).toMatchObject({
+      id: cloned.id, orgId: 'org-1', siteId: 'site-1', status: 'draft',
+      issueDate: null, acceptedAt: null, convertedInvoiceId: null, pdfDocumentRef: null,
+      sellerSnapshot: null, createdBy: 'user-1', expiryDate: null,
+    });
+
+    const clonedImage = imageInsert[0]!;
+    expect(clonedImage.id).not.toBe('image-1');
+    expect(clonedImage.quoteId).toBe(cloned.id);
+
+    const clonedImageBlock = blockInsert.find((block) => block.blockType === 'image')!;
+    const clonedLinesBlock = blockInsert.find((block) => block.blockType === 'line_items')!;
+    expect(clonedImageBlock.content).toMatchObject({ imageId: clonedImage.id, caption: 'Rack' });
+
+    const clonedParent = lineInsert.find((line) => line.name === 'Server')!;
+    const clonedChild = lineInsert.find((line) => line.name === 'Setup')!;
+    expect(clonedParent).toMatchObject({ quoteId: cloned.id, blockId: clonedLinesBlock.id, imageId: clonedImage.id });
+    expect(clonedChild.parentLineId).toBe(clonedParent.id);
+  });
+
+  it('rejects a cross-organization clone before creating anything', async () => {
+    state.selectResults.push([{ ...sourceQuote(), orgId: 'org-2' }]);
+
+    await expect(cloneQuote('quote-1', actor)).rejects.toMatchObject({ code: 'ORG_DENIED', status: 403 });
+    expect(state.transactionCalls).toBe(0);
+    expect(state.insertedValues).toEqual([]);
+  });
+
+  it('rejects a clone outside the actor site scope', async () => {
+    state.selectResults.push([sourceQuote()]);
+    const siteRestrictedActor = { ...actor, allowedSiteIds: ['site-2'] };
+
+    await expect(cloneQuote('quote-1', siteRestrictedActor)).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+    expect(state.transactionCalls).toBe(0);
+    expect(state.insertedValues).toEqual([]);
+  });
+});

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, inArray, lt, or, sql } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { quotes, quoteLines, quoteBlocks, quoteImages } from '../db/schema/quotes';
 import { invoices } from '../db/schema/invoices';
@@ -188,6 +189,140 @@ export async function createQuote(input: CreateQuoteInput, actor: QuoteActor) {
     createdBy: actor.userId,
   }).returning();
   return row!;
+}
+
+/**
+ * Deep-copy an accessible quote into a new draft. Images and every aggregate
+ * relationship receive fresh IDs because image rendering is constrained to
+ * image.quote_id and line items can reference blocks, images, and parent lines.
+ * Lifecycle, document, seller/customer snapshots, and expiry are intentionally
+ * reset so an old accepted/expired quote is safe to revise and send again.
+ */
+export async function cloneQuote(id: string, actor: QuoteActor) {
+  const { quote: source, blocks, lines } = await getQuote(id, actor);
+  const images = await db.select().from(quoteImages).where(eq(quoteImages.quoteId, id));
+
+  const year = new Date().getUTCFullYear();
+  const counter = await allocateQuoteCounter(source.partnerId, year);
+  const quoteNumber = formatQuoteNumber('Q', year, counter);
+  const quoteId = randomUUID();
+
+  const imageIds = new Map(images.map((image) => [image.id, randomUUID()]));
+  const blockIds = new Map(blocks.map((block) => [block.id, randomUUID()]));
+  const lineIds = new Map(lines.map((line) => [line.id, randomUUID()]));
+  const totals = computeQuoteTotals(
+    lines as QuoteLineForMath[],
+    source.taxRate ? parseFloat(source.taxRate) : null,
+    toQuoteDepositConfig(source.depositType, source.depositPercent),
+  );
+
+  return db.transaction(async (tx) => {
+    const [cloned] = await tx.insert(quotes).values({
+      id: quoteId,
+      partnerId: source.partnerId,
+      orgId: source.orgId,
+      siteId: source.siteId,
+      quoteNumber,
+      title: source.title,
+      status: 'draft',
+      currencyCode: source.currencyCode,
+      issueDate: null,
+      expiryDate: null,
+      acceptedAt: null,
+      declinedAt: null,
+      convertedAt: null,
+      subtotal: totals.subtotal,
+      taxRate: source.taxRate,
+      taxTotal: totals.taxTotal,
+      total: totals.total,
+      oneTimeTotal: totals.oneTimeTotal,
+      monthlyRecurringTotal: totals.monthlyRecurringTotal,
+      annualRecurringTotal: totals.annualRecurringTotal,
+      depositType: source.depositType,
+      depositPercent: source.depositPercent,
+      depositAmount: totals.depositDueTotal,
+      billToName: source.billToName,
+      billToAddress: null,
+      billToTaxId: null,
+      introNotes: source.introNotes,
+      terms: source.terms,
+      sellerSnapshot: null,
+      termsAndConditions: source.termsAndConditions,
+      declineReason: null,
+      convertedInvoiceId: null,
+      pdfDocumentRef: null,
+      pdfSha256: null,
+      sentAt: null,
+      firstViewedAt: null,
+      viewedAt: null,
+      createdBy: actor.userId,
+    }).returning();
+
+    if (images.length > 0) {
+      await tx.insert(quoteImages).values(images.map((image) => ({
+        id: imageIds.get(image.id)!,
+        quoteId,
+        orgId: source.orgId,
+        imageData: image.imageData,
+        mime: image.mime,
+        byteSize: image.byteSize,
+        sha256: image.sha256,
+      })));
+    }
+
+    if (blocks.length > 0) {
+      await tx.insert(quoteBlocks).values(blocks.map((block) => {
+        let content = block.content;
+        if (block.blockType === 'image' && content && typeof content === 'object' && !Array.isArray(content)) {
+          const sourceImageId = (content as Record<string, unknown>).imageId;
+          const clonedImageId = typeof sourceImageId === 'string' ? imageIds.get(sourceImageId) : undefined;
+          if (!clonedImageId) {
+            throw new QuoteServiceError('Quote image could not be cloned', 409, 'IMAGE_NOT_FOUND');
+          }
+          content = { ...(content as Record<string, unknown>), imageId: clonedImageId };
+        }
+        return {
+          id: blockIds.get(block.id)!,
+          quoteId,
+          orgId: source.orgId,
+          blockType: block.blockType,
+          content,
+          sortOrder: block.sortOrder,
+        };
+      }));
+    }
+
+    if (lines.length > 0) {
+      await tx.insert(quoteLines).values(lines.map((line) => ({
+        id: lineIds.get(line.id)!,
+        quoteId,
+        blockId: line.blockId ? blockIds.get(line.blockId) ?? null : null,
+        orgId: source.orgId,
+        sourceType: line.sourceType,
+        catalogItemId: line.catalogItemId,
+        parentLineId: line.parentLineId ? lineIds.get(line.parentLineId) ?? null : null,
+        name: line.name,
+        description: line.description,
+        quantity: line.quantity,
+        unitPrice: line.unitPrice,
+        taxable: line.taxable,
+        customerVisible: line.customerVisible,
+        lineTotal: line.lineTotal,
+        recurrence: line.recurrence,
+        termMonths: line.termMonths,
+        billingFrequency: line.billingFrequency,
+        unitCost: line.unitCost,
+        depositEligible: line.depositEligible,
+        itemType: line.itemType,
+        sku: line.sku,
+        partNumber: line.partNumber,
+        imageId: line.imageId ? imageIds.get(line.imageId) ?? null : null,
+        sortOrder: line.sortOrder,
+      })));
+    }
+
+    return cloned!;
+  });
 }
 
 export async function getQuote(id: string, actor: QuoteActor) {

--- a/apps/web/src/components/billing/quotes/QuoteActions.clone.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.clone.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteActions from './QuoteActions';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+
+const mocks = vi.hoisted(() => ({
+  can: vi.fn(),
+  cloneQuote: vi.fn(),
+  navigateTo: vi.fn(),
+  runAction: vi.fn(),
+}));
+
+vi.mock('../../../lib/permissions', () => ({ usePermissions: () => ({ can: mocks.can }) }));
+vi.mock('../../../stores/orgStore', () => ({ useOrgStore: (sel: (s: { organizations: unknown[] }) => unknown) => sel({ organizations: [] }) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: mocks.navigateTo }));
+vi.mock('../../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../../lib/api/quotes', () => ({
+  cloneQuote: mocks.cloneQuote,
+  sendQuote: vi.fn(),
+  deleteQuote: vi.fn(),
+  quotePdfUrl: vi.fn().mockReturnValue('/quotes/q-1/pdf'),
+}));
+vi.mock('../../../lib/runAction', () => ({
+  runAction: mocks.runAction,
+  handleActionError: vi.fn(),
+}));
+vi.mock('../../shared/ConfirmDialog', () => ({ ConfirmDialog: () => null }));
+
+const detail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: 'Q-2026-000001', partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'accepted',
+    currencyCode: 'USD', issueDate: '2026-06-01', expiryDate: null, subtotal: '100.00', taxRate: null,
+    taxTotal: '0.00', total: '100.00', oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '100.00', billToName: null, introNotes: null,
+    terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: '2026-06-02', declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: '2026-06-01', viewedAt: '2026-06-01',
+    createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-02T00:00:00Z',
+  },
+  blocks: [],
+  lines: [],
+};
+
+describe('QuoteActions cloning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.can.mockImplementation((_resource: string, action: string) => action === 'read' || action === 'write');
+    mocks.runAction.mockImplementation(async ({ request }: { request: () => Promise<unknown> }) => {
+      await request();
+      return { data: { id: 'q-2' } };
+    });
+    mocks.cloneQuote.mockResolvedValue(new Response(JSON.stringify({ data: { id: 'q-2' } }), { status: 200 }));
+  });
+
+  it('clones any readable quote with write permission and opens the new draft', async () => {
+    render(<QuoteActions detail={detail} variant="header" />);
+
+    fireEvent.click(screen.getByTestId('quote-clone'));
+
+    await waitFor(() => expect(mocks.cloneQuote).toHaveBeenCalledWith('q-1'));
+    expect(mocks.runAction).toHaveBeenCalledWith(expect.objectContaining({
+      successMessage: 'Quote cloned.',
+      errorFallback: 'Could not clone the quote.',
+    }));
+    expect(mocks.navigateTo).toHaveBeenCalledWith('/billing/quotes/q-2');
+  });
+
+  it('does not offer cloning to a read-only user', () => {
+    mocks.can.mockImplementation((_resource: string, action: string) => action === 'read');
+
+    render(<QuoteActions detail={detail} variant="header" />);
+
+    expect(screen.queryByTestId('quote-clone')).not.toBeInTheDocument();
+  });
+
+  it('holds cloning while draft changes are still saving', () => {
+    render(<QuoteActions detail={{ ...detail, quote: { ...detail.quote, status: 'draft' } }} variant="header" savePending />);
+
+    expect(screen.getByTestId('quote-clone')).toBeDisabled();
+    expect(screen.getByTestId('quote-clone')).toHaveAttribute(
+      'title',
+      'Wait for changes to finish saving before cloning.',
+    );
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -5,7 +5,7 @@ import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../../lib/runAction';
 import { usePermissions } from '../../../lib/permissions';
 import { useOrgStore } from '../../../stores/orgStore';
-import { deleteQuote, sendQuote } from '../../../lib/api/quotes';
+import { cloneQuote, deleteQuote, sendQuote } from '../../../lib/api/quotes';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
 import { useQuotePdfDownload } from './useQuoteImage';
 import { type QuoteDetail as QuoteDetailData, formatMoney } from './quoteTypes';
@@ -47,6 +47,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
   const [sendOpen, setSendOpen] = useState(false);
   const [delOpen, setDelOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [cloning, setCloning] = useState(false);
   const refresh = useCallback(() => onChanged?.(), [onChanged]);
 
   // An empty quote (no blocks, no lines) can't be sent.
@@ -100,6 +101,24 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
     }
   }, [deleting, quote.id, t]);
 
+  const clone = useCallback(async () => {
+    if (cloning || savePending) return;
+    setCloning(true);
+    try {
+      const result = await runAction<{ data: { id: string } }>({
+        request: () => cloneQuote(quote.id),
+        errorFallback: t('quotes.actions.cloneError'),
+        successMessage: t('quotes.actions.cloneSuccess'),
+        onUnauthorized: UNAUTHORIZED,
+      });
+      if (result?.data?.id) void navigateTo(`/billing/quotes/${result.data.id}`);
+    } catch (err) {
+      handleActionError(err, t('quotes.actions.cloneError'));
+    } finally {
+      setCloning(false);
+    }
+  }, [cloning, quote.id, savePending, t]);
+
   const header = variant === 'header';
   // Rail buttons stretch full-width and stack; header buttons size to content and
   // sit in a row. The class fragments below are the only thing the variant changes.
@@ -109,10 +128,11 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
     : 'inline-flex w-full items-center justify-center rounded-md px-4 py-2 text-sm font-medium';
 
   const canSend = can('quotes', 'send') && isDraft;
+  const canClone = can('quotes', 'write');
   const canDelete = can('quotes', 'write') && isDraft;
 
   // Nothing to show (e.g. a viewer on an issued quote) — render no empty container.
-  if (!canSend && !can('quotes', 'read') && !canDelete) return null;
+  if (!canSend && !can('quotes', 'read') && !canClone && !canDelete) return null;
 
   return (
     <>
@@ -141,6 +161,18 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             className={`${btnBase} bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50`}
           >
             {sending ? t('quotes.actions.sending') : savePending ? t('common:states.saving') : t('quotes.actions.sendProposal')}
+          </button>
+        )}
+        {canClone && (
+          <button
+            type="button"
+            onClick={() => void clone()}
+            disabled={cloning || savePending}
+            title={savePending ? t('quotes.actions.cloneSavingTitle') : undefined}
+            data-testid="quote-clone"
+            className={`${btnBase} border hover:bg-muted disabled:opacity-50`}
+          >
+            {cloning ? t('quotes.actions.cloning') : t('quotes.actions.cloneQuote')}
           </button>
         )}
         {/* PDF download is a read affordance (quotes has no dedicated export

--- a/apps/web/src/lib/api/quotes.ts
+++ b/apps/web/src/lib/api/quotes.ts
@@ -69,6 +69,10 @@ export function createQuote(body: CreateQuoteInput): Promise<Response> {
   });
 }
 
+export function cloneQuote(id: string): Promise<Response> {
+  return fetchWithAuth(`/quotes/${id}/clone`, { method: 'POST' });
+}
+
 export function updateQuote(id: string, body: UpdateQuoteInput): Promise<Response> {
   return fetchWithAuth(`/quotes/${id}`, {
     method: 'PATCH',

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -526,6 +526,11 @@
       }
     },
     "actions": {
+      "cloneError": "Das Angebot konnte nicht dupliziert werden.",
+      "cloneQuote": "Angebot duplizieren",
+      "cloneSavingTitle": "Warten Sie vor dem Duplizieren, bis die Änderungen gespeichert sind.",
+      "cloneSuccess": "Angebot dupliziert.",
+      "cloning": "Wird dupliziert…",
       "deleteConfirm": {
         "message": "Dadurch wird der Angebotsentwurf dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden.",
         "title": "Angebotsentwurf löschen"

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -526,6 +526,11 @@
       }
     },
     "actions": {
+      "cloneError": "Could not clone the quote.",
+      "cloneQuote": "Clone quote",
+      "cloneSavingTitle": "Wait for changes to finish saving before cloning.",
+      "cloneSuccess": "Quote cloned.",
+      "cloning": "Cloning…",
       "deleteConfirm": {
         "message": "This permanently deletes the draft quote. This can't be undone.",
         "title": "Delete draft quote"

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -526,6 +526,11 @@
       }
     },
     "actions": {
+      "cloneError": "No se pudo clonar la cotización.",
+      "cloneQuote": "Clonar cotización",
+      "cloneSavingTitle": "Espere a que se guarden los cambios antes de clonar.",
+      "cloneSuccess": "Cotización clonada.",
+      "cloning": "Clonando…",
       "deleteConfirm": {
         "message": "Esto elimina permanentemente el borrador de la cotización. Esto no se puede deshacer.",
         "title": "Eliminar borrador de cotización"

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -526,6 +526,11 @@
       }
     },
     "actions": {
+      "cloneError": "Impossible de dupliquer le devis.",
+      "cloneQuote": "Dupliquer le devis",
+      "cloneSavingTitle": "Attendez la fin de l'enregistrement avant de dupliquer.",
+      "cloneSuccess": "Devis dupliqué.",
+      "cloning": "Duplication…",
       "deleteConfirm": {
         "message": "Cette action supprime définitivement le devis brouillon. Elle est irréversible.",
         "title": "Supprimer le devis brouillon"

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -526,6 +526,11 @@
       }
     },
     "actions": {
+      "cloneError": "Não foi possível clonar a cotação.",
+      "cloneQuote": "Clonar cotação",
+      "cloneSavingTitle": "Aguarde até que as alterações sejam salvas antes de clonar.",
+      "cloneSuccess": "Cotação clonada.",
+      "cloning": "Clonando…",
       "deleteConfirm": {
         "message": "Esta ação exclui permanentemente a cotação em rascunho. Não é possível desfazê-la.",
         "title": "Excluir cotação em rascunho"


### PR DESCRIPTION
## Summary

- add `POST /quotes/:id/clone` with existing quote write authorization and tenant/site checks
- deep-copy quote blocks, lines, nested relationships, and quote-owned images with fresh IDs
- reset lifecycle, expiry, snapshot, PDF, and conversion state while assigning a new quote number
- add a localized **Clone quote** action that opens the new draft and waits for pending saves

## Why

Teams frequently reuse proposal structures and line items. Rebuilding an existing quote manually is slow and error-prone, especially when it contains nested blocks or product images.

## User impact

Users with `quotes:write` can clone any accessible quote from its action bar. The clone is a safe, editable draft in the same organization/site, with a fresh number and no carried-over acceptance or conversion state.

## Validation

- API quote suites: 62 tests passed
- Web quote-action suites: 18 tests passed
- API TypeScript check passed
- Web TypeScript check passed
- locale JSON validation passed
- `git diff --check` passed
