### PR TITLE
chore: gitignore .githooks (LFS-managed hooks)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ backups/
 
 # brainstorming visual companion mockups
 .superpowers/
+
+# Git LFS hooks regenerated per-workspace (core.hooksPath=.githooks)
+.githooks/


### PR DESCRIPTION
`core.hooksPath` is set to `.githooks`, and git-lfs regenerates the four hook scripts (`post-checkout`, `post-commit`, `post-merge`, `pre-push`) there on every fresh checkout/worktree. They're never committed, so they surface as untracked noise in every new workspace. This ignores the directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)