### PR TITLE
fix(migrations): let a NOSUPERUSER migrator complete the td-synnex owner change (0.95.1)

### DIFF
--- a/apps/api/migrations/2026-07-16-td-synnex-sftp-price-file.sql
+++ b/apps/api/migrations/2026-07-16-td-synnex-sftp-price-file.sql
@@ -216,8 +216,20 @@ BEGIN
 END;
 $$;
 
+-- Reassigning ownership requires the NEW owner (breeze_search) to hold CREATE on
+-- the function's schema. Grant it just for the ALTER, then revoke immediately.
+-- Without this a NOSUPERUSER migrator (e.g. DO-managed `doadmin`, and any
+-- managed-Postgres self-hoster) fails the OWNER TO with `permission denied for
+-- schema public` — a superuser bypasses the check, which is why this passed on
+-- the docker-compose superuser (CI + local smoke) but broke on managed prod.
+GRANT CREATE ON SCHEMA public TO breeze_search;
+
 ALTER FUNCTION public.breeze_search_td_synnex_pa(TEXT[], BOOLEAN, INT, INT)
   OWNER TO breeze_search;
+
+-- breeze_search only needs to OWN the SECURITY DEFINER function, never to create
+-- objects in public; drop the temporary grant so the role stays minimal.
+REVOKE CREATE ON SCHEMA public FROM breeze_search;
 
 REVOKE ALL ON FUNCTION public.breeze_search_td_synnex_pa(TEXT[], BOOLEAN, INT, INT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.breeze_search_td_synnex_pa(TEXT[], BOOLEAN, INT, INT) TO breeze_app;

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -120,6 +120,11 @@ export const CHECKSUM_RECONCILIATIONS: Record<
     to: '83cf9d01bf2030bb1cf063c4624c3847d9eac71ce90ae4d511228a98d14eaca6',
     reason: '#1936: guard patch_approvals org_id backfill for already partner-scoped reruns; note why step-3 dedup needs no org_id guard',
   },
+  '2026-07-16-td-synnex-sftp-price-file.sql': {
+    from: '8e08c23f4e1dfc6ceeb8c4624d9536c037f4062d287598b2ae106c3529d5dc08',
+    to: 'dc7be5f3209a46f4120f653eb4575ec5b64a6a23126e937a412afad7f26efc6a',
+    reason: '0.95.1: GRANT/REVOKE CREATE ON SCHEMA public around ALTER FUNCTION ... OWNER TO breeze_search so a NOSUPERUSER migrator (DO managed doadmin) can complete the owner change. v0.95.0 succeeded only on superuser DBs; heal those (already applied) instead of crashing their upgrade.',
+  },
 };
 
 /**


### PR DESCRIPTION
## The defect (took EU down during the v0.95.0 rollout)

`2026-07-16-td-synnex-sftp-price-file.sql` runs `ALTER FUNCTION public.breeze_search_td_synnex_pa(...) OWNER TO breeze_search`. Reassigning ownership requires the **new owner** to hold `CREATE` on the function's schema — and the freshly-created NOLOGIN `breeze_search` role has none. A **superuser bypasses this check**; a NOSUPERUSER migrator does not. So it passed on the docker-compose superuser (CI + my local smoke test) but failed on **DO-managed `doadmin`** — and every managed-PG self-hoster — with `permission denied for schema public` (42501). The API crash-looped; EU was rolled back to 0.94.0 and is healthy.

## Fix

`GRANT CREATE ON SCHEMA public TO breeze_search` immediately before the `ALTER OWNER`, then `REVOKE` it immediately after (the role only needs to **own** the SECURITY DEFINER function, never to create objects).

## Checksum reconciliation

v0.95.0 **succeeded on superuser DBs** (recorded the old checksum) and **failed on managed DBs** (never recorded). Editing the shipped file therefore needs a `CHECKSUM_RECONCILIATIONS` entry so already-applied superuser DBs **heal** (skip) instead of crashing their upgrade, while managed DBs apply the fixed version fresh. Added `from`/`to` for this file.

## Verification

- **Real EU managed DB (doadmin, NOSUPERUSER), rolled-back transaction:** `GRANT` → `ALTER FUNCTION` (owner change succeeds) → `REVOKE` → rest → clean.
- `autoMigrate` tests: **39/39**.

## Process fix

The root miss: CI and local smoke tests both used the docker Postgres **superuser**, which masks any statement that only a non-superuser would be denied. Following up to add a non-superuser migration smoke step to the release process.

Ships in **v0.95.1**. (Prod remains on 0.94.0, healthy; EU has a one-line `SET DEFAULT` patch on `refresh_token_families` to keep 0.94.0's login path working after the partial-migration rollback.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)