### PR TITLE
fix(security): force websocket-driver >=0.7.5 (GHSA-xv26-6w52-cph6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "pnpm": {
     "overrides": {
       "axios@>=1.0.0 <1.15.2": ">=1.15.2",
+      "websocket-driver@<0.7.5": ">=0.7.5",
       "fast-xml-parser@<5.5.7": ">=5.5.7",
       "fast-xml-parser@<5.7.0": ">=5.7.0",
       "brace-expansion@<1.1.13": ">=1.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   axios@>=1.0.0 <1.15.2: '>=1.15.2'
+  websocket-driver@<0.7.5: '>=0.7.5'
   fast-xml-parser@<5.5.7: '>=5.5.7'
   fast-xml-parser@<5.7.0: '>=5.7.0'
   brace-expansion@<1.1.13: '>=1.1.13'
@@ -10598,8 +10599,8 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -17379,7 +17380,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fb-dotslash@0.5.8: {}
 
@@ -22181,7 +22182,7 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1


### PR DESCRIPTION
The **NPM Audit** job (osv-scanner) reds main on a CRITICAL advisory in `websocket-driver@0.7.4` (transitive via `faye-websocket@0.11.4`): **GHSA-xv26-6w52-cph6** — message corruption via protocol length headers, fixed in **0.7.5** (also clears the moderate GHSA-mp7j-qc5w-4988).

Adds a `pnpm.overrides` entry `"websocket-driver@<0.7.5": ">=0.7.5"`, matching the existing override pattern; `pnpm install` swapped it in the lockfile (`+1 -1`).

Verified with the exact CI script `scripts/security/check-npm-audit.sh`: **0 advisories across 0 affected packages**, exit 0.