### PR TITLE
feat(quotes): editor/PDF/email polish + customer bill-to + per-table subtotals

### DIFF
--- a/apps/api/src/__tests__/integration/quoteService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteService.integration.test.ts
@@ -155,6 +155,38 @@ describe('quoteService (breeze_app, real DB)', () => {
     expect(fetched.quote.annualRecurringTotal).toBe('0.00');
   });
 
+  runDb('addManualLine without a blockId lands in an auto-created pricing section, reused across lines (#2553)', async () => {
+    const fx = await seedFixture();
+    const quote = await withDbAccessContext(fx.ctxA, () =>
+      createQuote({ orgId: fx.orgA.id, currencyCode: 'USD' }, fx.actorA)
+    );
+
+    const l1 = await withDbAccessContext(fx.ctxA, () =>
+      addManualLine(quote.id, {
+        sourceType: 'manual', description: 'First', quantity: 1, unitPrice: 100,
+        taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false,
+      }, fx.actorA)
+    );
+    // Never orphaned — the line carries a real blockId.
+    expect(l1.blockId).toBeTruthy();
+
+    const l2 = await withDbAccessContext(fx.ctxA, () =>
+      addManualLine(quote.id, {
+        sourceType: 'manual', description: 'Second', quantity: 1, unitPrice: 50,
+        taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false,
+      }, fx.actorA)
+    );
+
+    const fetched = await withDbAccessContext(fx.ctxA, () => getQuote(quote.id, fx.actorA));
+    // One default line_items section is created and REUSED for both lines, so the
+    // editor (which renders lines only inside blocks) shows them — no ghost line.
+    const lineBlocks = fetched.blocks.filter((b) => b.blockType === 'line_items');
+    expect(lineBlocks).toHaveLength(1);
+    expect(l1.blockId).toBe(lineBlocks[0]!.id);
+    expect(l2.blockId).toBe(lineBlocks[0]!.id);
+    expect(fetched.lines.every((l) => l.blockId === lineBlocks[0]!.id)).toBe(true);
+  });
+
   runDb('addCatalogLine snapshots a recurring item (recurrence/term/price/MRR)', async () => {
     const fx = await seedFixture();
     const item = await seedCatalogItem(fx.partnerA.id, {

--- a/apps/api/src/routes/quotes/lifecycle.ts
+++ b/apps/api/src/routes/quotes/lifecycle.ts
@@ -34,21 +34,27 @@ function remoteImageStatus(reason: RemoteImageFailureReason): 413 | 415 | 502 | 
   }
 }
 
-// Optional sender note included in the customer email. Parsed defensively: most
-// callers (bulk-send, tests, MCP) POST no body, yet fetchWithAuth always stamps a
-// JSON content-type — so an absent/empty/invalid body degrades to "no message"
-// rather than 400-ing a send that used to work.
-const sendBodySchema = z.object({ message: z.string().trim().max(2000).optional() });
+// Optional sender note included in the customer email. `.strict()` so a mis-keyed
+// field (e.g. {"mesage":"hi"}) is a 400, not a silently dropped note.
+const sendBodySchema = z.object({ message: z.string().trim().max(2000).optional() }).strict();
 
 // POST /:id/send — issue + email. Gated on the (previously dead) quotes:send permission.
 quoteLifecycleRoutes.post('/:id/send', scopes, sendPerm, zValidator('param', idParam), async (c) => {
   let message: string | undefined;
+  // Distinguish an ABSENT body (most callers — bulk-send/MCP/tests POST nothing,
+  // yet fetchWithAuth still stamps a JSON content-type) from a PRESENT-but-broken
+  // one. An empty body degrades to "no message"; a non-empty body that fails to
+  // parse/validate is rejected 400 rather than silently swallowing a note the
+  // sender intended (mirrors the image-from-URL route below).
   if ((c.req.header('content-type') ?? '').includes('application/json')) {
-    let json: unknown = {};
-    try { json = await c.req.json(); } catch { json = {}; }
-    const parsed = sendBodySchema.safeParse(json ?? {});
-    if (!parsed.success) return c.json({ error: 'Invalid message' }, 400);
-    message = parsed.data.message && parsed.data.message.length > 0 ? parsed.data.message : undefined;
+    const raw = await c.req.text().catch(() => '');
+    if (raw.trim()) {
+      let json: unknown;
+      try { json = JSON.parse(raw); } catch { return c.json({ error: 'Invalid JSON body' }, 400); }
+      const parsed = sendBodySchema.safeParse(json);
+      if (!parsed.success) return c.json({ error: 'Invalid message' }, 400);
+      message = parsed.data.message && parsed.data.message.length > 0 ? parsed.data.message : undefined;
+    }
   }
   try { return c.json({ data: await sendQuote(c.req.valid('param').id, quoteActorFrom(c), { message }) }); }
   catch (err) { return handleServiceError(c, err); }

--- a/apps/api/src/routes/quotes/lifecycle.ts
+++ b/apps/api/src/routes/quotes/lifecycle.ts
@@ -34,9 +34,23 @@ function remoteImageStatus(reason: RemoteImageFailureReason): 413 | 415 | 502 | 
   }
 }
 
+// Optional sender note included in the customer email. Parsed defensively: most
+// callers (bulk-send, tests, MCP) POST no body, yet fetchWithAuth always stamps a
+// JSON content-type — so an absent/empty/invalid body degrades to "no message"
+// rather than 400-ing a send that used to work.
+const sendBodySchema = z.object({ message: z.string().trim().max(2000).optional() });
+
 // POST /:id/send — issue + email. Gated on the (previously dead) quotes:send permission.
 quoteLifecycleRoutes.post('/:id/send', scopes, sendPerm, zValidator('param', idParam), async (c) => {
-  try { return c.json({ data: await sendQuote(c.req.valid('param').id, quoteActorFrom(c)) }); }
+  let message: string | undefined;
+  if ((c.req.header('content-type') ?? '').includes('application/json')) {
+    let json: unknown = {};
+    try { json = await c.req.json(); } catch { json = {}; }
+    const parsed = sendBodySchema.safeParse(json ?? {});
+    if (!parsed.success) return c.json({ error: 'Invalid message' }, 400);
+    message = parsed.data.message && parsed.data.message.length > 0 ? parsed.data.message : undefined;
+  }
+  try { return c.json({ data: await sendQuote(c.req.valid('param').id, quoteActorFrom(c), { message }) }); }
   catch (err) { return handleServiceError(c, err); }
 });
 

--- a/apps/api/src/routes/quotes/quotes.test.ts
+++ b/apps/api/src/routes/quotes/quotes.test.ts
@@ -423,7 +423,10 @@ describe('quote crud + lines routes', () => {
       ],
       lines: [
         { id: 'l1', blockId: 'b2', description: 'Onsite hour', quantity: '2', unitPrice: '150', lineTotal: '300', recurrence: 'one_time' }
-      ]
+      ],
+      // getQuote resolves the customer bill-to (from the org for drafts); the route
+      // overlays it onto the render payload.
+      billTo: { name: 'Acme Customer', address: null, taxId: null }
     };
 
     it('streams the rendered PDF inline (200, application/pdf, inline filename)', async () => {

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -122,7 +122,7 @@ quoteCrudRoutes.delete('/:id/lines/:lineId', scopes, writePerm, zValidator('para
 quoteCrudRoutes.get('/:id/pdf', scopes, readPerm, zValidator('param', idParam), async (c) => {
   const id = c.req.valid('param').id;
   try {
-    const { quote, blocks, lines } = await getQuote(id, quoteActorFrom(c));
+    const { quote, blocks, lines, billTo } = await getQuote(id, quoteActorFrom(c));
 
     const branding = await resolveQuoteBranding(quote);
 
@@ -131,6 +131,13 @@ quoteCrudRoutes.get('/:id/pdf', scopes, readPerm, zValidator('param', idParam), 
       // Legacy/draft docs have no frozen snapshot; resolveQuoteBranding synthesizes
       // one from the live partner so the From block still renders.
       sellerSnapshot: branding.seller,
+      // Overlay the resolved customer bill-to so a DRAFT (whose billTo* columns are
+      // still null) renders the org's billing address in the "Prepared for" block,
+      // matching what the customer will get once sent. Falls back to the quote's
+      // own frozen fields if a caller supplies no resolved billTo.
+      billToName: billTo?.name ?? quote.billToName,
+      billToAddress: billTo?.address ?? quote.billToAddress,
+      billToTaxId: billTo?.taxId ?? quote.billToTaxId,
     };
 
     // Real image loader: pull bytes from quote_images, constrained to BOTH the

--- a/apps/api/src/services/quoteEmail.ts
+++ b/apps/api/src/services/quoteEmail.ts
@@ -8,6 +8,8 @@ export interface QuoteEmailParams {
   expiryDate?: string;  // pre-formatted date or empty
   acceptUrl: string;
   supportEmail?: string;
+  /** Optional free-text note from the sender, shown above the accept CTA. */
+  message?: string;
 }
 
 /**
@@ -22,9 +24,16 @@ export function buildQuoteTemplate(params: QuoteEmailParams): EmailTemplate {
   const expiryLine = params.expiryDate
     ? `<p style="${MUTED_PARA}">This proposal is valid until <strong>${escapeHtml(params.expiryDate)}</strong>.</p>`
     : '';
+  // Sender's personal note, if any. Escaped, with newlines preserved as <br> so a
+  // multi-line note keeps its shape. Rendered between the intro and the CTA.
+  const note = params.message?.trim();
+  const messageBlock = note
+    ? `<p style="${BODY_PARA}">${escapeHtml(note).replace(/\r?\n/g, '<br>')}</p>`
+    : '';
   const body = `
       <p style="${BODY_PARA}">Hi there,</p>
       <p style="${BODY_PARA}">${escapeHtml(params.partnerName)} has sent you proposal <strong>${escapeHtml(number)}</strong> for <strong>${escapeHtml(params.total)}</strong>. A PDF copy is attached.</p>
+      ${messageBlock}
       ${renderButton('Review & accept', params.acceptUrl)}
       ${expiryLine}
   `;
@@ -33,6 +42,7 @@ export function buildQuoteTemplate(params: QuoteEmailParams): EmailTemplate {
   const text = [
     'Hi there,',
     `${params.partnerName} has sent you proposal ${number} for ${params.total}. A PDF copy is attached.`,
+    note || null,
     `Review & accept: ${params.acceptUrl}`,
     params.expiryDate ? `Valid until ${params.expiryDate}.` : null,
     support ? `Questions? Contact ${support}.` : null,

--- a/apps/api/src/services/quoteLifecycle.test.ts
+++ b/apps/api/src/services/quoteLifecycle.test.ts
@@ -264,6 +264,7 @@ describe('sendQuote customer-facing PDF', () => {
     queueResult([]); // blocks
     queueResult([visibleLine, internalLine]); // lines
     queueResult([]); // no staged Pax8 order
+    queueResult([{ name: 'Customer Co', taxId: null, billingAddressLine1: null, billingAddressLine2: null, billingAddressCity: null, billingAddressRegion: null, billingAddressPostalCode: null, billingAddressCountry: null }]); // getQuote's own draft billTo org lookup
 
     queueResult([{ id: 'p1', name: 'Acme MSP', billingTermsAndConditions: null, invoiceFooter: null }]); // partnerRow (reused for partner name)
     queueResult([{ name: 'Customer Co', taxId: null, billingContact: { email: 'billing@customer.example' } }]); // org (billing snapshot + recipient)
@@ -312,6 +313,7 @@ describe('sendQuote bill-to snapshot', () => {
     queueResult([]);       // getQuote: blocks
     queueResult([{ quantity: '1', unitPrice: '100.00', taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false, lineTotal: '100.00' }]); // getQuote: lines
     queueResult([]);       // getQuote: no staged Pax8 order
+    queueResult([org]);    // getQuote's own draft billTo org lookup (status is 'draft' for every quote sent through this helper)
     queueResult([{ id: 'p1', name: 'Acme MSP', billingTermsAndConditions: null, invoiceFooter: null }]); // partnerRow (reused for partner name)
     queueResult([org]);    // org (billing snapshot + recipient)
     queueResult([{ id: 'q1' }]); // update ... returning (claimed)

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -82,7 +82,11 @@ function formatMoneyish(n: string | null | undefined, currency: string): string 
 }
 
 /** Issue (if draft) + send: assign number, status→sent, sentAt, mint token, best-effort email. */
-export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote: QuoteRow; emailed: boolean; acceptUrl: string }> {
+export async function sendQuote(
+  id: string,
+  actor: QuoteActor,
+  opts: { message?: string } = {},
+): Promise<{ quote: QuoteRow; emailed: boolean; acceptUrl: string }> {
   const { quote, blocks, lines } = await getQuote(id, actor); // getQuote enforces org-access (404)
   if (quote.status !== 'draft') {
     // Phase 2 send is issue-once: a non-draft quote (already sent/viewed/etc.) cannot be re-sent.
@@ -220,6 +224,7 @@ export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote:
         quoteNumber, partnerName: partnerName ?? 'your provider',
         total: formatMoneyish(quote.total, quote.currencyCode), acceptUrl,
         expiryDate: quote.expiryDate ?? undefined,
+        message: opts.message,
       });
       await emailService.sendEmail({ to: recipient, subject: template.subject, html: template.html, text: template.text, attachments: [{ filename: `${quoteNumber}.pdf`, content: pdf, contentType: 'application/pdf' }] });
       emailed = true;

--- a/apps/api/src/services/quotePdf.test.ts
+++ b/apps/api/src/services/quotePdf.test.ts
@@ -286,6 +286,24 @@ describe('renderQuotePdf', () => {
     expect(summaryStream).not.toContain('Item ');
   });
 
+  it('renders a per-table Subtotal row only when the block opts in', async () => {
+    const lines = [
+      { id: 'l1', blockId: 'b1', description: 'Widget', quantity: '2', unitPrice: '100', lineTotal: '200.00', recurrence: 'one_time' as const },
+      { id: 'l2', blockId: 'b1', description: 'Service', quantity: '1', unitPrice: '50', lineTotal: '50.00', recurrence: 'monthly' as const },
+    ];
+    const base = { id: 'q1', quoteNumber: 'Q-SUB', currencyCode: 'USD', oneTimeTotal: '200.00', monthlyRecurringTotal: '50.00', total: '250.00', dueOnAcceptanceTotal: '200.00' };
+
+    const off = await renderQuotePdf(base as never, [{ id: 'b1', blockType: 'line_items', sortOrder: 0, content: {} }], lines, async () => null, {});
+    expect(extractPdfText(off)).not.toContain('Subtotal');
+
+    const on = await renderQuotePdf(base as never, [{ id: 'b1', blockType: 'line_items', sortOrder: 0, content: { showSubtotal: true } }], lines, async () => null, {});
+    const text = extractPdfText(on);
+    expect(text).toContain('Subtotal');
+    // Split by recurrence: one-time $200 and $50/mo.
+    expect(text).toContain('200.00');
+    expect(text).toContain('50.00/mo');
+  });
+
   it('renderQuotePdf includes the From block and T&C', async () => {
     const buf = await renderQuotePdf(
       { id: 'q1', quoteNumber: 'Q-1', currencyCode: 'USD', billToName: 'Cust',

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -298,7 +298,15 @@ async function renderLineTable(
     doc.fillColor('#1f2937').font('Helvetica').fontSize(10);
     doc.text(String(Number(l.quantity)), c.colQtyX, y, { width: c.contentWidth * 0.10, align: 'left' });
     if (img) {
-      try { doc.image(img, descX, y, { fit: [THUMB, THUMB] }); } catch { /* corrupt image: skip */ }
+      // A buffer that loaded but pdfkit can't decode: skip the thumbnail (never
+      // abort the document) but REPORT it — the pre-load loop above logs byte-level
+      // failures, so a decode-at-draw failure must not be the one silent gap.
+      try {
+        doc.image(img, descX, y, { fit: [THUMB, THUMB] });
+      } catch (e) {
+        console.error('[quotePdf] doc.image (line thumbnail) failed', l.id, e instanceof Error ? e.message : e);
+        captureException(e instanceof Error ? e : new Error(String(e)));
+      }
     }
     doc.fillColor('#1f2937').font('Helvetica-Bold').fontSize(10).text(title, descX + gutter, y, { width: descW });
     if (blurb) {
@@ -319,15 +327,18 @@ async function renderLineTable(
   // Opt-in per-table subtotal: sum THIS table's lines split by recurrence, shown
   // as non-zero parts joined with " + " (matches the document footer style).
   if (showSubtotal) {
-    const sums: Record<string, number> = { one_time: 0, monthly: 0, annual: 0 };
+    const sums = { one_time: 0, monthly: 0, annual: 0 };
     for (const l of lines) {
-      const key = l.recurrence ?? 'one_time';
-      sums[key] = (sums[key] ?? 0) + Number(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice));
+      // Fold any unrecognized recurrence (e.g. a future re-enabled 'quarterly')
+      // into one_time so the printed Subtotal always covers every rendered row —
+      // never silently omit a bucket the parts list below doesn't know about.
+      const key = l.recurrence === 'monthly' || l.recurrence === 'annual' ? l.recurrence : 'one_time';
+      sums[key] += Number(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice));
     }
     const parts: string[] = [];
-    if (sums.one_time! > 0) parts.push(formatMoney(sums.one_time, currency));
-    if (sums.monthly! > 0) parts.push(`${formatMoney(sums.monthly, currency)}/mo`);
-    if (sums.annual! > 0) parts.push(`${formatMoney(sums.annual, currency)}/yr`);
+    if (sums.one_time > 0) parts.push(formatMoney(sums.one_time, currency));
+    if (sums.monthly > 0) parts.push(`${formatMoney(sums.monthly, currency)}/mo`);
+    if (sums.annual > 0) parts.push(`${formatMoney(sums.annual, currency)}/yr`);
     if (parts.length) {
       y = ensureRowSpace(y, 24);
       doc.moveTo(c.colUnitX, y).lineTo(c.right, y).lineWidth(0.5).strokeColor('#e5e7eb').stroke();

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -213,6 +213,7 @@ async function renderLineTable(
   loadQuoteImage: (imageId: string) => Promise<{ data: Buffer } | null>,
   taxRate = 0,
   showTax = false,
+  showSubtotal = false,
 ): Promise<number> {
   const c = columnsFor(doc, showTax);
   let y = ensureSpace(doc, startY, 60);
@@ -275,33 +276,66 @@ async function renderLineTable(
 
   const descX = c.colDescX;
   for (const l of lines) {
-    y = ensureRowSpace(y, Math.max(30, gutter));
     // Title falls back to description for legacy lines that predate the name/description split.
     const title = (l.name ?? l.description ?? '').trim() || '—';
     const blurb = l.name ? (l.description ?? '').trim() : '';
-    doc.fillColor('#1f2937').fontSize(10).font('Helvetica');
+    // Measure each fragment at the SAME font/size it is drawn with. The blurb is
+    // rendered at 8.5pt but used to be measured while the font was still 10pt,
+    // over-reserving ~1.5pt per wrapped line — a visible gap below tall spec-list
+    // rows (e.g. a 15-bullet PC). Measure title as bold-10, blurb as regular-8.5.
+    doc.font('Helvetica-Bold').fontSize(10);
     const titleHeight = doc.heightOfString(title, { width: descW });
-    const blurbHeight = blurb ? doc.heightOfString(blurb, { width: descW }) + 2 : 0;
+    doc.font('Helvetica').fontSize(8.5);
+    const blurbHeight = blurb ? doc.heightOfString(blurb, { width: descW, lineGap: 1 }) + 2 : 0;
     const descHeight = titleHeight + blurbHeight;
-    doc.text(String(Number(l.quantity)), c.colQtyX, y, { width: c.contentWidth * 0.10, align: 'left' });
     const img = imageByLine.get(l.id);
+    const rowHeight = Math.max(descHeight, img ? THUMB : 12);
+    // Keep the whole row together: if it won't fit in the remaining page, break to
+    // a fresh page (re-drawing the column header) rather than letting a long
+    // description overflow into the footer band. (Old reserve was a flat 30/52pt,
+    // so tall rows spilled past the bottom margin.)
+    y = ensureRowSpace(y, rowHeight + 6);
+    doc.fillColor('#1f2937').font('Helvetica').fontSize(10);
+    doc.text(String(Number(l.quantity)), c.colQtyX, y, { width: c.contentWidth * 0.10, align: 'left' });
     if (img) {
       try { doc.image(img, descX, y, { fit: [THUMB, THUMB] }); } catch { /* corrupt image: skip */ }
     }
-    doc.font('Helvetica-Bold').text(title, descX + gutter, y, { width: descW });
+    doc.fillColor('#1f2937').font('Helvetica-Bold').fontSize(10).text(title, descX + gutter, y, { width: descW });
     if (blurb) {
-      doc.fillColor('#6b7280').fontSize(8.5).font('Helvetica').text(blurb, descX + gutter, y + titleHeight + 2, { width: descW });
+      doc.fillColor('#6b7280').fontSize(8.5).font('Helvetica').text(blurb, descX + gutter, y + titleHeight + 2, { width: descW, lineGap: 1 });
       doc.fillColor('#1f2937').fontSize(10);
     }
-    doc.font('Helvetica').text(formatMoney(l.unitPrice, currency), c.colUnitX, y, { width: c.colNumW, align: 'right' });
+    doc.font('Helvetica').fontSize(10).text(formatMoney(l.unitPrice, currency), c.colUnitX, y, { width: c.colNumW, align: 'right' });
     if (showTax) {
       const t = lineTax(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice), !!l.taxable, taxRate);
       doc.fillColor('#6b7280').text(t === null ? '—' : formatMoney(t, currency), c.colTaxX, y, { width: c.colNumW, align: 'right' });
       doc.fillColor('#1f2937');
     }
     const suffix = recurrenceSuffix(l.recurrence);
-    doc.text(`${formatMoney(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice), currency)}${suffix}`, c.colAmtX, y, { width: c.colNumW, align: 'right' });
-    y += Math.max(descHeight, img ? THUMB : 12) + 6;
+    doc.font('Helvetica').fontSize(10).text(`${formatMoney(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice), currency)}${suffix}`, c.colAmtX, y, { width: c.colNumW, align: 'right' });
+    y += rowHeight + 6;
+  }
+
+  // Opt-in per-table subtotal: sum THIS table's lines split by recurrence, shown
+  // as non-zero parts joined with " + " (matches the document footer style).
+  if (showSubtotal) {
+    const sums: Record<string, number> = { one_time: 0, monthly: 0, annual: 0 };
+    for (const l of lines) {
+      const key = l.recurrence ?? 'one_time';
+      sums[key] = (sums[key] ?? 0) + Number(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice));
+    }
+    const parts: string[] = [];
+    if (sums.one_time! > 0) parts.push(formatMoney(sums.one_time, currency));
+    if (sums.monthly! > 0) parts.push(`${formatMoney(sums.monthly, currency)}/mo`);
+    if (sums.annual! > 0) parts.push(`${formatMoney(sums.annual, currency)}/yr`);
+    if (parts.length) {
+      y = ensureRowSpace(y, 24);
+      doc.moveTo(c.colUnitX, y).lineTo(c.right, y).lineWidth(0.5).strokeColor('#e5e7eb').stroke();
+      y += 6;
+      doc.font('Helvetica-Bold').fontSize(9.5).fillColor('#374151').text('Subtotal', c.colUnitX, y, { width: c.contentWidth * 0.2, align: 'left' });
+      doc.fillColor('#111827').text(parts.join('  +  '), c.colUnitX, y, { width: c.right - c.colUnitX, align: 'right' });
+      y += 18;
+    }
   }
   return y + 6;
 }
@@ -531,12 +565,18 @@ export async function renderQuotePdf(
         // Section label above the table (parity with the web document), e.g.
         // "Recurring services" / "One-time".
         const label = String((b.content as { label?: string }).label ?? '').trim();
+        // Keep the section label glued to its table header + first row: reserve
+        // space for label + column header + a minimum first row up front. Without
+        // this, a label near the page bottom fit its own 36pt reservation but
+        // renderLineTable then broke, stranding the label (and later the column
+        // header) alone at the foot of the page.
+        y = ensureSpace(doc, y, (label ? 24 : 0) + 24 + 52);
         if (label) {
-          y = ensureSpace(doc, y, 36);
           doc.fillColor('#111827').fontSize(11).font('Helvetica-Bold').text(label, c.left, y, { width: c.contentWidth });
           y = doc.y + 6;
         }
-        y = await renderLineTable(doc, blockLines, currency, y, loadCatalogImage, loadImage, taxRate, showTax);
+        const showSubtotal = (b.content as { showSubtotal?: boolean }).showSubtotal === true;
+        y = await renderLineTable(doc, blockLines, currency, y, loadCatalogImage, loadImage, taxRate, showTax, showSubtotal);
       }
     }
   }

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -215,6 +215,35 @@ describe('quoteService deposits', () => {
     expect(detail.pax8OrderLineCount).toBe(0);
   });
 
+  it('getQuote returns a SENT quote bill-to from the frozen snapshot, never the live org', async () => {
+    // Frozen at send when the org had no address → an all-null block. That blank is
+    // the immutable record; getQuote must NOT re-derive from the (now-populated) org.
+    const frozen = { line1: null, line2: null, city: null, region: null, postalCode: null, country: null };
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent', billToName: 'Frozen Co', billToAddress: frozen, billToTaxId: null, taxRate: null, depositType: 'none', depositPercent: null }]); // quote
+    queueResult([]); // blocks
+    queueResult([]); // lines
+    queueResult([]); // no staged Pax8 order
+    // Deliberately queue NO org row: a sent quote must not query the live org at all.
+
+    const { billTo } = await svc.getQuote('q1', actor);
+    expect(billTo.name).toBe('Frozen Co');
+    expect(billTo.address).toEqual(frozen); // the all-null frozen block, not re-derived
+    expect(billTo.taxId).toBeNull();
+  });
+
+  it('getQuote resolves a DRAFT quote bill-to from the org billing settings', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', billToName: null, billToAddress: null, billToTaxId: null, taxRate: null, depositType: 'none', depositPercent: null }]); // quote
+    queueResult([]); // blocks
+    queueResult([]); // lines
+    queueResult([]); // no staged Pax8 order
+    queueResult([{ name: 'Org Inc', taxId: 'ORG-TAX', billingAddressLine1: 'Org St', billingAddressLine2: null, billingAddressCity: 'Berthoud', billingAddressRegion: 'CO', billingAddressPostalCode: '80513', billingAddressCountry: 'US' }]); // org billing
+
+    const { billTo } = await svc.getQuote('q1', actor);
+    expect(billTo.name).toBe('Org Inc');
+    expect(billTo.address?.line1).toBe('Org St');
+    expect(billTo.taxId).toBe('ORG-TAX');
+  });
+
   it('listQuotes left-joins the converted invoice and flattens invoiceDepositDue/invoiceAmountPaid onto each row', async () => {
     // The chain mock yields queued rows regardless of shape; queue the joined
     // projection shape the real select({ quote, invoiceDepositDue, invoiceAmountPaid }) returns.

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -106,6 +106,7 @@ describe('quoteService deposits', () => {
       billingType: 'one_time', billingFrequency: null, commitmentTermMonths: null,
       costBasis: '300.00', sku: 'SKU1', itemType: 'hardware',
     }]);
+    queueResult([{ id: 'blk1' }]); // resolveLineBlockId: existing line_items block
     queueResult([{ max: -1 }]); // nextLineSortOrder
     queueResult([{ id: 'l1', depositEligible: true, itemType: 'hardware' }]); // insert returning
     queueResult([{ taxRate: null, depositType: 'none', depositPercent: null }]); // recompute header
@@ -125,6 +126,7 @@ describe('quoteService deposits', () => {
       billingType: 'one_time', billingFrequency: null, commitmentTermMonths: null,
       costBasis: null, sku: null, itemType: 'service',
     }]);
+    queueResult([{ id: 'blk1' }]); // resolveLineBlockId: existing line_items block
     queueResult([{ max: -1 }]); // nextLineSortOrder
     queueResult([{ id: 'l2', depositEligible: false, itemType: 'service' }]); // insert returning
     queueResult([{ taxRate: null, depositType: 'none', depositPercent: null }]); // recompute header
@@ -135,6 +137,43 @@ describe('quoteService deposits', () => {
 
     const valuesMock = (db as unknown as Chain).values;
     expect(valuesMock.mock.calls.at(-1)![0]).toMatchObject({ depositEligible: false, itemType: 'service' });
+  });
+
+  it('addManualLine without a blockId attaches to the existing pricing section (no orphan)', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft' }]); // loadDraft
+    queueResult([{ id: 'blk1' }]); // resolveLineBlockId: existing line_items block
+    queueResult([{ max: -1 }]); // nextLineSortOrder
+    queueResult([{ id: 'l1', blockId: 'blk1' }]); // insert line returning
+    queueResult([{ taxRate: null, depositType: 'none', depositPercent: null }]); // recompute header
+    queueResult([]); // recompute lines
+    queueResult([]); // recompute update
+
+    await svc.addManualLine('q1', { sourceType: 'manual', name: 'Widget', quantity: 2, unitPrice: 100, taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false } as never, actor);
+
+    const valuesMock = (db as unknown as Chain).values;
+    // No new block created; the line lands in the existing section, not as an orphan.
+    expect(valuesMock.mock.calls.every((c) => (c[0] as { blockType?: string }).blockType !== 'line_items')).toBe(true);
+    expect((valuesMock.mock.calls.at(-1)![0] as { blockId?: string }).blockId).toBe('blk1');
+  });
+
+  it('addManualLine without a blockId creates a default pricing section when none exists', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft' }]); // loadDraft
+    queueResult([]); // resolveLineBlockId: no existing line_items block
+    queueResult([{ max: -1 }]); // nextBlockSortOrder
+    queueResult([{ id: 'newblk' }]); // block insert returning
+    queueResult([{ max: -1 }]); // nextLineSortOrder
+    queueResult([{ id: 'l1', blockId: 'newblk' }]); // insert line returning
+    queueResult([{ taxRate: null, depositType: 'none', depositPercent: null }]); // recompute header
+    queueResult([]); // recompute lines
+    queueResult([]); // recompute update
+
+    await svc.addManualLine('q1', { sourceType: 'manual', name: 'Widget', quantity: 1, unitPrice: 50, taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false } as never, actor);
+
+    const valuesMock = (db as unknown as Chain).values;
+    // A default line_items block was created…
+    expect(valuesMock.mock.calls.some((c) => (c[0] as { blockType?: string }).blockType === 'line_items')).toBe(true);
+    // …and the line attached to it (never orphaned with a null blockId).
+    expect((valuesMock.mock.calls.at(-1)![0] as { blockId?: string }).blockId).toBe('newblk');
   });
 
   it('getQuote returns depositDueTotal and categoryBreakdown', async () => {

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -359,35 +359,54 @@ export async function getQuote(id: string, actor: QuoteActor) {
     q.taxRate ? parseFloat(q.taxRate) : null,
     toQuoteDepositConfig(q.depositType, q.depositPercent),
   );
-  // Resolve the customer "bill to" for display. A sent quote carries its own
-  // frozen snapshot (billTo* columns filled at send from the org's Billing
-  // settings); a draft has none, so we fall back to the SAME org columns the send
-  // path freezes. This is what makes the customer name + billing address show on
-  // a draft's PDF/preview instead of a blank block — the data always lived on the
-  // org, it just wasn't surfaced until send. A tech-entered billToName override
-  // still wins over the org name.
-  const [org] = await db
-    .select({
-      name: organizations.name,
-      taxId: organizations.taxId,
-      billingAddressLine1: organizations.billingAddressLine1,
-      billingAddressLine2: organizations.billingAddressLine2,
-      billingAddressCity: organizations.billingAddressCity,
-      billingAddressRegion: organizations.billingAddressRegion,
-      billingAddressPostalCode: organizations.billingAddressPostalCode,
-      billingAddressCountry: organizations.billingAddressCountry,
-    })
-    .from(organizations)
-    .where(eq(organizations.id, q.orgId))
-    .limit(1);
+  // Resolve the customer "bill to" for display. Keyed on quote STATUS, not on
+  // whether the frozen fields happen to be populated:
+  //  - A NON-DRAFT quote carries its own frozen snapshot, written at send time
+  //    from the org's Billing settings. Return it VERBATIM — never re-derive from
+  //    the live org — so the issued document stays immutable even if the org's
+  //    billing address is edited afterwards. (An org with no address at send time
+  //    froze an all-null block; that blank is the correct, immutable record.)
+  //  - A DRAFT has no frozen snapshot yet, so fall back to the SAME org columns
+  //    the send path will freeze, surfacing the customer name + address on the
+  //    draft's preview/PDF instead of a blank block. A tech-entered billToName
+  //    override still wins over the org name.
   const frozenAddress = (q.billToAddress as BillToAddress | null) ?? null;
-  const hasFrozenAddress = !!frozenAddress
-    && Object.values(frozenAddress).some((v) => typeof v === 'string' && v.trim().length > 0);
-  const billTo = {
-    name: q.billToName?.trim() ? q.billToName : (org?.name ?? null),
-    address: hasFrozenAddress ? frozenAddress : buildBillToAddress(org),
-    taxId: q.billToTaxId ?? org?.taxId ?? null,
-  };
+  let billTo: { name: string | null; address: BillToAddress | null; taxId: string | null };
+  if (q.status === 'draft') {
+    const [org] = await db
+      .select({
+        name: organizations.name,
+        taxId: organizations.taxId,
+        billingAddressLine1: organizations.billingAddressLine1,
+        billingAddressLine2: organizations.billingAddressLine2,
+        billingAddressCity: organizations.billingAddressCity,
+        billingAddressRegion: organizations.billingAddressRegion,
+        billingAddressPostalCode: organizations.billingAddressPostalCode,
+        billingAddressCountry: organizations.billingAddressCountry,
+      })
+      .from(organizations)
+      .where(eq(organizations.id, q.orgId))
+      .limit(1);
+    if (!org) {
+      // getQuote just read this quote in the SAME context, so its org should be
+      // visible too — an unreadable org is anomalous. Mirror the send path's
+      // telemetry (quoteLifecycle) rather than let a blank bill-to be silent.
+      console.error(`[quoteService] org ${q.orgId} not readable while resolving draft bill-to for quote ${q.id} — showing an empty bill-to`);
+    }
+    const hasFrozenAddress = !!frozenAddress
+      && Object.values(frozenAddress).some((v) => typeof v === 'string' && v.trim().length > 0);
+    billTo = {
+      name: q.billToName?.trim() ? q.billToName : (org?.name ?? null),
+      address: hasFrozenAddress ? frozenAddress : buildBillToAddress(org),
+      taxId: q.billToTaxId ?? org?.taxId ?? null,
+    };
+  } else {
+    billTo = {
+      name: q.billToName ?? null,
+      address: frozenAddress,
+      taxId: q.billToTaxId ?? null,
+    };
+  }
   return {
     quote: {
       ...q,

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -7,6 +7,7 @@ import { organizations, partners } from '../db/schema/orgs';
 import { catalogItems } from '../db/schema/catalog';
 import { pax8OrderLines, pax8Orders } from '../db/schema/pax8Orders';
 import { computeLineTotal, resolveEffectiveTaxRate } from './invoiceMath';
+import { buildBillToAddress, type BillToAddress } from './sellerSnapshot';
 import { computeQuoteTotals, validateQuoteDeposit, toQuoteDepositConfig, type QuoteLineForMath } from './quoteMath';
 import { QuoteServiceError, type QuoteActor } from './quoteTypes';
 import { allocateQuoteCounter, formatQuoteNumber } from './quoteNumbers';
@@ -358,6 +359,35 @@ export async function getQuote(id: string, actor: QuoteActor) {
     q.taxRate ? parseFloat(q.taxRate) : null,
     toQuoteDepositConfig(q.depositType, q.depositPercent),
   );
+  // Resolve the customer "bill to" for display. A sent quote carries its own
+  // frozen snapshot (billTo* columns filled at send from the org's Billing
+  // settings); a draft has none, so we fall back to the SAME org columns the send
+  // path freezes. This is what makes the customer name + billing address show on
+  // a draft's PDF/preview instead of a blank block — the data always lived on the
+  // org, it just wasn't surfaced until send. A tech-entered billToName override
+  // still wins over the org name.
+  const [org] = await db
+    .select({
+      name: organizations.name,
+      taxId: organizations.taxId,
+      billingAddressLine1: organizations.billingAddressLine1,
+      billingAddressLine2: organizations.billingAddressLine2,
+      billingAddressCity: organizations.billingAddressCity,
+      billingAddressRegion: organizations.billingAddressRegion,
+      billingAddressPostalCode: organizations.billingAddressPostalCode,
+      billingAddressCountry: organizations.billingAddressCountry,
+    })
+    .from(organizations)
+    .where(eq(organizations.id, q.orgId))
+    .limit(1);
+  const frozenAddress = (q.billToAddress as BillToAddress | null) ?? null;
+  const hasFrozenAddress = !!frozenAddress
+    && Object.values(frozenAddress).some((v) => typeof v === 'string' && v.trim().length > 0);
+  const billTo = {
+    name: q.billToName?.trim() ? q.billToName : (org?.name ?? null),
+    address: hasFrozenAddress ? frozenAddress : buildBillToAddress(org),
+    taxId: q.billToTaxId ?? org?.taxId ?? null,
+  };
   return {
     quote: {
       ...q,
@@ -367,6 +397,7 @@ export async function getQuote(id: string, actor: QuoteActor) {
     },
     blocks,
     lines,
+    billTo,
     pax8OrderId: pax8OrderSummary?.pax8OrderId ?? null,
     pax8OrderLineCount: Number(pax8OrderLineSummary?.count ?? 0),
   };

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -544,15 +544,44 @@ export async function deleteBlock(quoteId: string, blockId: string, actor: Quote
 // Lines
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolve the block a new line should live in. A caller-supplied blockId is used
+ * as-is; when it's omitted (the API / MCP add-line path — the web editor always
+ * passes one), the line is attached to the quote's default pricing section: the
+ * earliest existing line_items block, or a fresh one created on demand.
+ *
+ * Without this, a blockId-less line became an "orphan" — counted in the totals
+ * and drawn in the PDF's trailing table, but NEVER rendered in the editor (which
+ * only walks line_items blocks). The result was a quote showing a real dollar
+ * total while the builder said "No content yet", uneditable from the UI (#2553).
+ */
+async function resolveLineBlockId(quoteId: string, orgId: string, blockId: string | null | undefined): Promise<string> {
+  if (blockId) return blockId;
+  const [existing] = await db
+    .select({ id: quoteBlocks.id })
+    .from(quoteBlocks)
+    .where(and(eq(quoteBlocks.quoteId, quoteId), eq(quoteBlocks.blockType, 'line_items')))
+    .orderBy(quoteBlocks.sortOrder)
+    .limit(1);
+  if (existing) return existing.id;
+  const sortOrder = await nextBlockSortOrder(quoteId);
+  const [block] = await db
+    .insert(quoteBlocks)
+    .values({ quoteId, orgId, blockType: 'line_items', content: {}, sortOrder })
+    .returning({ id: quoteBlocks.id });
+  return block!.id;
+}
+
 export async function addManualLine(quoteId: string, input: QuoteLineInput, actor: QuoteActor) {
   const q = await loadDraft(quoteId, actor);
   const quantity = String(input.quantity);
   const unitPrice = Number(input.unitPrice).toFixed(2);
+  const blockId = await resolveLineBlockId(quoteId, q.orgId, input.blockId);
   const sortOrder = await nextLineSortOrder(quoteId);
   const [row] = await db.insert(quoteLines).values({
     quoteId,
     orgId: q.orgId,
-    blockId: input.blockId ?? null,
+    blockId,
     sourceType: input.sourceType,
     catalogItemId: input.catalogItemId ?? null,
     name: input.name ?? null,
@@ -610,11 +639,12 @@ export async function addCatalogLine(
     ? (item.billingFrequency === 'annual' ? 'annual' : 'monthly')
     : 'one_time';
   const qty = String(quantity);
+  const resolvedBlockId = await resolveLineBlockId(quoteId, q.orgId, blockId);
   const sortOrder = await nextLineSortOrder(quoteId);
   const [row] = await db.insert(quoteLines).values({
     quoteId,
     orgId: q.orgId,
-    blockId: blockId ?? null,
+    blockId: resolvedBlockId,
     sourceType: 'catalog',
     catalogItemId,
     // Mirror the catalog item: its name is the line title, its description the blurb.

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -45,6 +45,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
   const { busy, downloadPdf } = useQuotePdfDownload(quote);
   const [sending, setSending] = useState(false);
   const [sendOpen, setSendOpen] = useState(false);
+  const [sendMessage, setSendMessage] = useState('');
   const [delOpen, setDelOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [cloning, setCloning] = useState(false);
@@ -66,7 +67,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
     setSending(true);
     try {
       await runAction({
-        request: () => sendQuote(quote.id),
+        request: () => sendQuote(quote.id, sendMessage),
         errorFallback: t('quotes.actions.sendError'),
         // Tell the seller what happens next: the quote advances to Viewed and
         // Accepted on its own as the customer engages — no further action here.
@@ -74,13 +75,14 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
         onUnauthorized: UNAUTHORIZED,
       });
       setSendOpen(false);
+      setSendMessage('');
       refresh();
     } catch (err) {
       handleActionError(err, t('quotes.actions.sendError'));
     } finally {
       setSending(false);
     }
-  }, [sending, quote.id, orgName, refresh, t]);
+  }, [sending, quote.id, sendMessage, orgName, refresh, t]);
 
   const remove = useCallback(async () => {
     if (deleting) return;
@@ -228,7 +230,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
 
       <ConfirmDialog
         open={sendOpen}
-        onClose={() => setSendOpen(false)}
+        onClose={() => { setSendOpen(false); setSendMessage(''); }}
         onConfirm={() => void send()}
         isLoading={sending}
         variant="warning"
@@ -239,7 +241,23 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
         })}
         confirmLabel={t('quotes.actions.sendProposal')}
         confirmTestId="quote-send-confirm"
-      />
+      >
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-foreground">
+            {t('quotes.actions.sendConfirm.messageLabel')}
+          </span>
+          <textarea
+            value={sendMessage}
+            onChange={(e) => setSendMessage(e.target.value)}
+            rows={3}
+            maxLength={2000}
+            disabled={sending}
+            placeholder={t('quotes.actions.sendConfirm.messagePlaceholder')}
+            data-testid="quote-send-message"
+            className="w-full resize-y rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+          />
+        </label>
+      </ConfirmDialog>
       <ConfirmDialog
         open={delOpen}
         onClose={() => setDelOpen(false)}

--- a/apps/web/src/components/billing/quotes/QuoteDetail.send.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.send.test.tsx
@@ -96,8 +96,24 @@ describe('QuoteDetail — send proposal', () => {
 
     fireEvent.click(screen.getByTestId('quote-send-confirm'));
     await waitFor(() => {
-      expect(sendQuote).toHaveBeenCalledWith('q-1');
+      // No note typed → the empty string is forwarded (the API client trims it away).
+      expect(sendQuote).toHaveBeenCalledWith('q-1', '');
       expect(onChanged).toHaveBeenCalled();
     });
+  });
+
+  it('forwards a typed personal message to the send call', async () => {
+    const sendQuote = vi.mocked(quotesApi.sendQuote);
+    sendQuote.mockResolvedValue(resp({ data: null }));
+
+    render(<QuoteDetail detail={filledDraft} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-send'));
+    await waitFor(() => expect(screen.getByTestId('quote-send-message')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('quote-send-message'), { target: { value: 'Thanks for your business!' } });
+
+    fireEvent.click(screen.getByTestId('quote-send-confirm'));
+    await waitFor(() => expect(sendQuote).toHaveBeenCalledWith('q-1', 'Thanks for your business!'));
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteDocument.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.test.tsx
@@ -75,6 +75,44 @@ describe('QuoteDocument', () => {
     expect(screen.getByTestId('quote-document-wordmark')).toHaveTextContent('Lantern IT'); // no logoUrl → wordmark
   });
 
+  it('renders the resolved customer billing address and tax id in the Prepared for block', () => {
+    const detail = makeDetail({
+      billTo: {
+        name: 'Animal Health at Home',
+        address: { line1: '123 Vet Way', line2: 'Suite 4', city: 'Berthoud', region: 'CO', postalCode: '80513', country: 'US' },
+        taxId: '84-1234567',
+      },
+    });
+    render(<QuoteDocument detail={detail} customerName="Animal Health at Home" />);
+    const addr = screen.getByTestId('quote-document-billto-address');
+    expect(addr).toHaveTextContent('123 Vet Way');
+    expect(addr).toHaveTextContent('Berthoud, CO, 80513');
+    expect(screen.getByTestId('quote-document-billto-taxid')).toHaveTextContent('84-1234567');
+  });
+
+  it('omits the address block when the org has saved no billing address', () => {
+    const detail = makeDetail({ billTo: { name: 'Acme', address: null, taxId: null } });
+    render(<QuoteDocument detail={detail} customerName="Acme" />);
+    expect(screen.queryByTestId('quote-document-billto-address')).toBeNull();
+    expect(screen.queryByTestId('quote-document-billto-taxid')).toBeNull();
+  });
+
+  it('shows a per-table subtotal row only when the block opts in', () => {
+    // Default block has no showSubtotal → no subtotal row.
+    render(<QuoteDocument detail={makeDetail()} customerName="Acme" />);
+    expect(screen.queryByTestId('quote-table-subtotal')).toBeNull();
+  });
+
+  it('renders the opt-in subtotal split by recurrence', () => {
+    const d = makeDetail();
+    d.blocks[0].content = { label: 'Services', showSubtotal: true };
+    render(<QuoteDocument detail={d} customerName="Acme" />);
+    const row = screen.getByTestId('quote-table-subtotal');
+    // Fixture: $500 one-time + $450/mo.
+    expect(row).toHaveTextContent('$500.00');
+    expect(row.textContent).toMatch(/\$450\.00/);
+  });
+
   it('never renders internal cost/markup/net on the customer document', () => {
     const detail = makeDetail({
       lines: [

--- a/apps/web/src/components/billing/quotes/QuoteDocument.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.tsx
@@ -96,8 +96,13 @@ function PricingTable({ lines, quoteId, currency, label, taxRate, showTax, showS
   // buckets are shown, joined with " + " — matching the document footer style.
   const subtotalParts: string[] = [];
   if (showSubtotal) {
-    const sums = { one_time: 0, monthly: 0, annual: 0 } as Record<string, number>;
-    for (const l of sorted) sums[l.recurrence] = (sums[l.recurrence] ?? 0) + Number(l.lineTotal);
+    const sums = { one_time: 0, monthly: 0, annual: 0 };
+    for (const l of sorted) {
+      // Fold any unrecognized recurrence into one_time so the subtotal always
+      // covers every rendered row (parity with the PDF renderer).
+      const key = l.recurrence === 'monthly' || l.recurrence === 'annual' ? l.recurrence : 'one_time';
+      sums[key] += Number(l.lineTotal);
+    }
     if (sums.one_time > 0) subtotalParts.push(formatMoney(sums.one_time, currency));
     if (sums.monthly > 0) subtotalParts.push(`${formatMoney(sums.monthly, currency)}${t('billingUi.units.perMonth')}`);
     if (sums.annual > 0) subtotalParts.push(`${formatMoney(sums.annual, currency)}${t('billingUi.units.perYear')}`);

--- a/apps/web/src/components/billing/quotes/QuoteDocument.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type CSSProperties } from 'react';
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import '../../../lib/i18n';
 import { useOrgStore } from '../../../stores/orgStore';
@@ -37,6 +37,15 @@ function DocLineThumb({ path }: { path: string }) {
 function DocImage({ quoteId, imageId, caption }: { quoteId: string; imageId: string; caption?: string }) {
   const { t } = useTranslation('billing');
   const { url, failed } = useAuthedImage(quoteImageUrl(quoteId, imageId));
+  const [zoomed, setZoomed] = useState(false);
+
+  // Escape closes the zoom overlay (parity with clicking the backdrop).
+  useEffect(() => {
+    if (!zoomed) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setZoomed(false); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [zoomed]);
 
   if (failed) {
     return (
@@ -48,18 +57,51 @@ function DocImage({ quoteId, imageId, caption }: { quoteId: string; imageId: str
   if (!url) {
     return <div className="h-40 animate-pulse rounded-lg bg-muted/60" aria-hidden />;
   }
+  const alt = caption || t('quotes.document.proposalImageAlt');
   return (
     <figure className="space-y-2">
-      <img src={url} alt={caption || t('quotes.document.proposalImageAlt')} className="w-full rounded-lg border bg-card object-contain" />
+      {/* Click to view a larger version — a button keeps it keyboard-reachable. */}
+      <button
+        type="button"
+        onClick={() => setZoomed(true)}
+        aria-label={t('quotes.document.imageZoomAria')}
+        data-testid="quote-image-zoom-trigger"
+        className="block w-full cursor-zoom-in rounded-lg focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <img src={url} alt={alt} className="w-full rounded-lg border bg-card object-contain" />
+      </button>
       {caption && <figcaption className="text-center text-xs text-muted-foreground">{caption}</figcaption>}
+      {zoomed && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={alt}
+          onClick={() => setZoomed(false)}
+          data-testid="quote-image-lightbox"
+          className="fixed inset-0 z-50 flex cursor-zoom-out items-center justify-center bg-black/80 p-4"
+        >
+          <img src={url} alt={alt} className="max-h-full max-w-full rounded-lg object-contain shadow-2xl" />
+        </div>
+      )}
     </figure>
   );
 }
 
-function PricingTable({ lines, quoteId, currency, label, taxRate, showTax }: { lines: QuoteLine[]; quoteId: string; currency: string; label?: string; taxRate: string | null; showTax: boolean }) {
+function PricingTable({ lines, quoteId, currency, label, taxRate, showTax, showSubtotal }: { lines: QuoteLine[]; quoteId: string; currency: string; label?: string; taxRate: string | null; showTax: boolean; showSubtotal?: boolean }) {
   const { t } = useTranslation('billing');
   if (lines.length === 0) return null;
   const sorted = [...lines].sort((a, b) => a.sortOrder - b.sortOrder);
+  // Opt-in per-table subtotal, summed from THIS table's rows and split by
+  // recurrence (a table can mix one-time / monthly / annual). Only non-zero
+  // buckets are shown, joined with " + " — matching the document footer style.
+  const subtotalParts: string[] = [];
+  if (showSubtotal) {
+    const sums = { one_time: 0, monthly: 0, annual: 0 } as Record<string, number>;
+    for (const l of sorted) sums[l.recurrence] = (sums[l.recurrence] ?? 0) + Number(l.lineTotal);
+    if (sums.one_time > 0) subtotalParts.push(formatMoney(sums.one_time, currency));
+    if (sums.monthly > 0) subtotalParts.push(`${formatMoney(sums.monthly, currency)}${t('billingUi.units.perMonth')}`);
+    if (sums.annual > 0) subtotalParts.push(`${formatMoney(sums.annual, currency)}${t('billingUi.units.perYear')}`);
+  }
   return (
     <div className="overflow-hidden rounded-lg border bg-card">
       {label && (
@@ -117,6 +159,18 @@ function PricingTable({ lines, quoteId, currency, label, taxRate, showTax }: { l
               );
             })}
           </tbody>
+          {showSubtotal && subtotalParts.length > 0 && (
+            <tfoot>
+              <tr className="border-t-2 bg-muted/20" data-testid="quote-table-subtotal">
+                <td className="px-4 py-2.5 text-right text-sm font-semibold text-foreground sm:px-5" colSpan={showTax ? 4 : 3}>
+                  {t('quotes.document.totals.subtotal')}
+                </td>
+                <td className="whitespace-nowrap px-4 py-2.5 text-right text-sm font-semibold tabular-nums text-foreground sm:px-5">
+                  {subtotalParts.join(' + ')}
+                </td>
+              </tr>
+            </tfoot>
+          )}
         </table>
       </div>
     </div>
@@ -143,7 +197,8 @@ function DocBlock({ block, lines, quoteId, currency, taxRate, showTax }: { block
   }
   // line_items
   const label = (block.content?.label as string | undefined)?.trim() || t('quotes.document.pricing');
-  return <PricingTable lines={lines} quoteId={quoteId} currency={currency} label={label} taxRate={taxRate} showTax={showTax} />;
+  const showSubtotal = block.content?.showSubtotal === true;
+  return <PricingTable lines={lines} quoteId={quoteId} currency={currency} label={label} taxRate={taxRate} showTax={showTax} showSubtotal={showSubtotal} />;
 }
 
 interface DocumentProps {
@@ -157,7 +212,16 @@ interface DocumentProps {
  *  logo/accent. Works for drafts (no portal round-trip). */
 export function QuoteDocument({ detail, customerName }: DocumentProps) {
   const { t } = useTranslation('billing');
-  const { quote, blocks, lines, branding } = detail;
+  const { quote, blocks, lines, branding, billTo } = detail;
+  // Customer billing address lines (resolved server-side from the org's Billing
+  // settings for drafts, or the frozen snapshot once sent). Empty when the org
+  // has saved no billing address — the block then shows just the name.
+  const billToLines = useMemo(() => {
+    const a = billTo?.address;
+    if (!a) return [] as string[];
+    const cityLine = [a.city, a.region, a.postalCode].filter(Boolean).join(', ');
+    return [a.line1, a.line2, cityLine, a.country].filter((s): s is string => !!s && s.trim().length > 0);
+  }, [billTo?.address]);
   const currency = branding?.currencyCode ?? quote.currencyCode;
   const seller = branding?.seller ?? quote.sellerSnapshot ?? null;
   const accent = branding?.primaryColor || 'hsl(var(--primary))';
@@ -245,6 +309,16 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
           <div>
             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('quotes.document.preparedFor')}</p>
             <p className="mt-1 text-base font-medium text-foreground" data-testid="quote-document-customer">{customerName}</p>
+            {billToLines.length > 0 && (
+              <address className="mt-0.5 not-italic text-sm leading-relaxed text-muted-foreground" data-testid="quote-document-billto-address">
+                {billToLines.map((l, i) => <div key={i}>{l}</div>)}
+              </address>
+            )}
+            {billTo?.taxId?.trim() && (
+              <p className="mt-0.5 text-xs text-muted-foreground" data-testid="quote-document-billto-taxid">
+                {t('quotes.document.taxId', { id: billTo.taxId })}
+              </p>
+            )}
           </div>
           {quote.introNotes?.trim() && (
             <p className="max-w-prose whitespace-pre-wrap text-pretty text-sm leading-relaxed text-foreground/90">
@@ -383,13 +457,15 @@ export default function QuoteDocumentPreview({ detail }: { detail: QuoteDetailDa
   const { busy, downloadPdf } = useQuotePdfDownload(quote);
 
   const customerName = useMemo(() => {
-    const billTo = quote.billToName?.trim();
-    if (billTo) return billTo;
+    // Server-resolved name wins (billToName override, else the org's name); the
+    // org store is only a backstop for payloads/fixtures without a resolved billTo.
+    const resolvedBillTo = detail.billTo?.name?.trim() || quote.billToName?.trim();
+    if (resolvedBillTo) return resolvedBillTo;
     const resolved = organizations.find((o) => o.id === quote.orgId)?.name?.trim();
     // Never leak a raw org UUID fragment onto a customer-facing document — if the
     // org store hasn't resolved a name yet, show a neutral em-dash instead.
     return resolved || '—';
-  }, [quote.billToName, quote.orgId, organizations]);
+  }, [detail.billTo?.name, quote.billToName, quote.orgId, organizations]);
 
   return (
     <div className="space-y-4" data-testid="quote-preview">

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -1650,6 +1650,7 @@ function BlockCard({
   const heading = (block.content?.text as string | undefined) ?? '';
   const html = (block.content?.html as string | undefined) ?? '';
   const tableLabel = (block.content?.label as string | undefined) ?? '';
+  const showSubtotal = (block.content?.showSubtotal as boolean | undefined) === true;
   const imageId = (block.content?.imageId as string | undefined) ?? '';
   const imageCaption = (block.content?.caption as string | undefined) ?? '';
 
@@ -1701,10 +1702,20 @@ function BlockCard({
   // Rename a pricing table. An empty label is a valid clear (the document falls
   // back to its "Pricing" default), so — unlike heading — we commit the trimmed
   // value even when blank, only skipping when nothing actually changed.
+  // Both the label and the subtotal toggle live in the SAME line_items content
+  // object, and onEditBlock REPLACES content wholesale — so each edit must carry
+  // the other's current value forward or it gets dropped.
+  const lineItemsContent = (nextLabel: string, nextSubtotal: boolean) => ({
+    ...(nextLabel.trim() ? { label: nextLabel.trim() } : {}),
+    ...(nextSubtotal ? { showSubtotal: true } : {}),
+  });
   const commitLabel = async () => {
     const label = labelDraft.trim();
     if (label === tableLabel.trim()) { setLabelDraft(tableLabel); return; }
-    if (await onEditBlock(block, label ? { label } : {})) flashSaved();
+    if (await onEditBlock(block, lineItemsContent(label, showSubtotal))) flashSaved();
+  };
+  const toggleSubtotal = async (next: boolean) => {
+    if (await onEditBlock(block, lineItemsContent(tableLabel, next))) flashSaved();
   };
 
   const submitManual = async () => {
@@ -1809,14 +1820,26 @@ function BlockCard({
                 className={`h-9 w-full rounded-md border bg-background px-3 text-sm font-semibold transition-shadow disabled:opacity-60 ${fieldRing(labelDraft.trim() !== tableLabel.trim(), blockSaved)}`}
               />
             )}
+            {canWrite && (
+              <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                <input
+                  type="checkbox"
+                  checked={showSubtotal}
+                  onChange={(e) => void toggleSubtotal(e.target.checked)}
+                  disabled={blockBusy}
+                  data-testid={`quote-block-subtotal-toggle-${block.id}`}
+                />
+                {t('quotes.editor.table.showSubtotal')}
+              </label>
+            )}
             {/* The 7-column row (description + 4 inline controls + total + actions)
                 can't compress gracefully on a tablet, so the table keeps a sensible
                 min width and the wrapper scrolls horizontally below that. */}
             <div className="overflow-x-auto rounded-md focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring" role="region" aria-label={t('quotes.editor.table.scrollAria')} tabIndex={0}>
-            <table className="w-full min-w-[640px] text-sm" data-testid={`quote-block-lines-${block.id}`}>
+            <table className="w-full min-w-[800px] text-sm" data-testid={`quote-block-lines-${block.id}`}>
               <thead>
                 <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
-                  <th className="px-2 py-2 font-medium">{t('quotes.editor.table.item')}</th>
+                  <th className="min-w-[13rem] px-2 py-2 font-medium">{t('quotes.editor.table.item')}</th>
                   <th className="px-2 py-2 text-right font-medium">{t('quotes.editor.table.qty')}</th>
                   <th className="px-2 py-2 text-right font-medium">{t('quotes.editor.table.unitPrice')}</th>
                   <th className="px-2 py-2 font-medium">{t('quotes.editor.table.recurrence')}</th>
@@ -1872,8 +1895,8 @@ function BlockCard({
 
             {/* Add line to this pricing table */}
             {canWrite && (
-            <div className="rounded-md border bg-background/40 p-3" data-testid={`quote-block-add-line-${block.id}`}>
-              <div className="mb-2 flex gap-2">
+            <div className="mt-3 rounded-md border bg-background/40 p-4" data-testid={`quote-block-add-line-${block.id}`}>
+              <div className="mb-3 flex gap-2">
                 {(['catalog', 'manual', ...(ecActive ? ['distributor'] as const : []), ...(pax8Active ? ['pax8'] as const : [])] as const).map((m) => (
                   <button
                     key={m}
@@ -1931,7 +1954,7 @@ function BlockCard({
                   />
                 )
               ) : (
-                <div className="space-y-2">
+                <div className="space-y-3">
                   <div className="flex flex-wrap items-center gap-2">
                     <CatalogEnrichButton
                       idSuffix={`quote-${block.id}`}
@@ -2036,8 +2059,10 @@ function BlockCard({
                       </select>
                     </label>
                   </div>
-                  {/* Internal-only cost & identity fields (never shown to the customer). */}
-                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{t('quotes.editor.internal.full')}</p>
+                  {/* Internal-only cost & identity fields (never shown to the customer).
+                      Divider + top padding sets them apart from the customer-facing
+                      fields above so the two groups don't read as one dense block. */}
+                  <p className="mt-1 border-t pt-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">{t('quotes.editor.internal.full')}</p>
                   <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_1fr_110px_100px]">
                     <label className="block">
                       <span className="mb-1 block text-xs text-muted-foreground">{t('quotes.editor.line.skuOptional')}</span>
@@ -2526,9 +2551,10 @@ function EditableLineRow({
   return (
     <>
     <tr className="border-t align-top [&>td]:pt-4" data-testid={`quote-line-${line.id}`}>
-      <td className="px-2 py-2">
-        {/* min-w-0 lets the name input honour its own min-w-[12rem] floor rather
-            than the flex row's min-content, so a catalog thumbnail can't crush it. */}
+      {/* Column min-width (min-w-[13rem]) is declared on the cell so table
+          auto-layout reserves the name column instead of squeezing it below the
+          input's width (which used to overflow into the qty cell). */}
+      <td className="min-w-[13rem] px-2 py-2">
         <div className="flex min-w-0 items-start gap-2">
           {line.imageId
             ? <LineImageThumb quoteId={quoteId} imageId={line.imageId} />
@@ -2543,7 +2569,7 @@ function EditableLineRow({
               onBlur={commitName}
               disabled={fieldBusy('name')}
               data-testid={`quote-line-name-${line.id}`}
-              className={`h-9 w-full min-w-[12rem] rounded-md border bg-background px-2 py-1 text-sm font-medium transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(nameDirty, saved)}`}
+              className={`h-9 w-full rounded-md border bg-background px-2 py-1 text-sm font-medium transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(nameDirty, saved)}`}
             />
           </div>
         </div>

--- a/apps/web/src/components/billing/quotes/quoteTypes.ts
+++ b/apps/web/src/components/billing/quotes/quoteTypes.ts
@@ -143,12 +143,33 @@ export interface QuoteBranding {
   seller: SellerSnapshot | null;
 }
 
-/** Shape of `GET /quotes/:id` — `{ data: { quote, blocks, lines, branding } }`. */
+/** Frozen (sent) or org-resolved (draft) customer billing address. */
+export interface QuoteBillToAddress {
+  line1: string | null;
+  line2: string | null;
+  city: string | null;
+  region: string | null;
+  postalCode: string | null;
+  country: string | null;
+}
+
+/** Resolved customer "bill to" for display — server-side `getQuote` fills it from
+ *  the quote's frozen snapshot (sent) or the org's Billing settings (draft), so
+ *  the customer name + address render on the document even before the quote is
+ *  sent. Optional because list fixtures / older payloads don't carry it. */
+export interface QuoteBillTo {
+  name: string | null;
+  address: QuoteBillToAddress | null;
+  taxId: string | null;
+}
+
+/** Shape of `GET /quotes/:id` — `{ data: { quote, blocks, lines, branding, billTo } }`. */
 export interface QuoteDetail {
   quote: Quote;
   blocks: QuoteBlock[];
   lines: QuoteLine[];
   branding?: QuoteBranding;
+  billTo?: QuoteBillTo;
   /** Persisted fulfillment staged during acceptance. Included in the detail
    * read model so technicians can discover the order after a reload. */
   pax8OrderId?: string | null;

--- a/apps/web/src/components/shared/ConfirmDialog.tsx
+++ b/apps/web/src/components/shared/ConfirmDialog.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { AlertOctagon, AlertTriangle } from 'lucide-react';
 import { Dialog } from './Dialog';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +14,8 @@ export interface ConfirmDialogProps {
   isLoading?: boolean;
   /** data-testid for the confirm button (e2e suites are testid-only). */
   confirmTestId?: string;
+  /** Optional extra content (e.g. a note field) rendered under the message. */
+  children?: ReactNode;
 }
 
 export function ConfirmDialog({
@@ -25,6 +28,7 @@ export function ConfirmDialog({
   variant = 'destructive',
   isLoading = false,
   confirmTestId,
+  children,
 }: ConfirmDialogProps) {
   const { t } = useTranslation('common');
   // Encode severity by SHAPE, not color alone: a stop-octagon for destructive
@@ -50,6 +54,7 @@ export function ConfirmDialog({
         <div className="flex-1">
           <h3 className="text-base font-semibold text-foreground">{title}</h3>
           <p className="mt-1 text-sm text-muted-foreground">{message}</p>
+          {children != null && <div className="mt-4">{children}</div>}
         </div>
       </div>
       <div className="mt-6 flex justify-end gap-3">

--- a/apps/web/src/lib/api/quotes.ts
+++ b/apps/web/src/lib/api/quotes.ts
@@ -188,9 +188,14 @@ export function quotePdfUrl(id: string): string {
 // ---- Phase 2 lifecycle / image upload -------------------------------------
 
 /** Issue + send a draft quote (POST /quotes/:id/send). Gated server-side on
- *  quotes:send. Responds with the updated quote in a `{ data }` envelope. */
-export function sendQuote(id: string): Promise<Response> {
-  return fetchWithAuth(`/quotes/${id}/send`, { method: 'POST' });
+ *  quotes:send. An optional `message` is included in the customer email above the
+ *  accept link. Responds with the updated quote in a `{ data }` envelope. */
+export function sendQuote(id: string, message?: string): Promise<Response> {
+  const note = message?.trim();
+  return fetchWithAuth(`/quotes/${id}/send`, {
+    method: 'POST',
+    ...(note ? { body: JSON.stringify({ message: note }) } : {}),
+  });
 }
 
 /** Upload an image for a quote (POST /quotes/:id/images). The body is multipart

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -506,6 +506,7 @@
         "qty": "Menge",
         "recurrence": "Wiederholung",
         "scrollAria": "Preistabelle – scrollen Sie seitwärts für Steuer-, Gesamt- und Zeilenaktionen",
+        "showSubtotal": "Zwischensummenzeile anzeigen",
         "tax": "Steuer",
         "taxTitle": "Steuer pro Position. Maßgeblich ist die Überschrift „Steuersumme“, die um einen Rundungscent abweichen kann.",
         "taxable": "Steuerpflichtig",
@@ -544,6 +545,8 @@
       "savingTitle": "Speichern Ihrer Änderungen – Entsperrungen senden, wenn alles gespeichert ist.",
       "sendConfirm": {
         "message": "Wir senden dieses Angebot per E-Mail an {{orgName}} und markieren es als „Gesendet“ – {{amount}} fällig bei Annahme. Dies kann nicht rückgängig gemacht werden.",
+        "messageLabel": "Persönliche Nachricht hinzufügen (optional)",
+        "messagePlaceholder": "Fügen Sie eine kurze Notiz hinzu – sie erscheint in der E-Mail über dem Zusage-Link.",
         "title": "Dieses Angebot senden?"
       },
       "sendError": "Der Vorschlag konnte nicht gesendet werden.",
@@ -630,6 +633,8 @@
       "imageUnavailable": "Bild nicht verfügbar",
       "issued": "Ausgestellt",
       "preparedFor": "Vorbereitet für",
+      "taxId": "Steuernummer: {{id}}",
+      "imageZoomAria": "Größeres Bild anzeigen",
       "preview": {
         "description": "Das sieht Ihr Kunde auf seinem Angebotslink.",
         "downloadPdf": "Laden Sie PDF herunter",

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -506,6 +506,7 @@
         "qty": "Qty",
         "recurrence": "Recurrence",
         "scrollAria": "Pricing table — scroll sideways for tax, total and row actions",
+        "showSubtotal": "Show subtotal row",
         "tax": "Tax",
         "taxTitle": "Per-line tax. The header Tax total is authoritative and may differ by a rounding cent.",
         "taxable": "Taxable",
@@ -544,6 +545,8 @@
       "savingTitle": "Saving your changes — Send unlocks when everything is saved.",
       "sendConfirm": {
         "message": "We'll email this proposal to {{orgName}} and mark it Sent — {{amount}} due on acceptance. This can't be undone.",
+        "messageLabel": "Add a personal message (optional)",
+        "messagePlaceholder": "Include a short note — it appears in the email above the accept link.",
         "title": "Send this proposal?"
       },
       "sendError": "Could not send the proposal.",
@@ -630,6 +633,8 @@
       "imageUnavailable": "Image unavailable",
       "issued": "Issued",
       "preparedFor": "Prepared for",
+      "taxId": "Tax ID: {{id}}",
+      "imageZoomAria": "View larger image",
       "preview": {
         "description": "This is what your customer sees on their proposal link.",
         "downloadPdf": "Download PDF",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -506,6 +506,7 @@
         "qty": "Cantidad",
         "recurrence": "Recurrencia",
         "scrollAria": "Tabla de precios: desplácese hacia los lados para ver las acciones de impuestos, totales y filas",
+        "showSubtotal": "Mostrar fila de subtotal",
         "tax": "Impuesto",
         "taxTitle": "Impuesto por línea. El encabezado Total de impuestos es determinante y puede diferir en un centavo redondeado.",
         "taxable": "Imponible",
@@ -544,6 +545,8 @@
       "savingTitle": "Guardar sus cambios: envíe desbloqueos cuando todo esté guardado.",
       "sendConfirm": {
         "message": "Enviaremos esta propuesta por correo electrónico a {{orgName}} y la marcaremos como Enviada - {{amount}} al momento de su aceptación. Esto no se puede deshacer.",
+        "messageLabel": "Agregar un mensaje personal (opcional)",
+        "messagePlaceholder": "Incluye una nota breve: aparecerá en el correo, encima del enlace para aceptar.",
         "title": "¿Enviar esta propuesta?"
       },
       "sendError": "No se pudo enviar la propuesta.",
@@ -630,6 +633,8 @@
       "imageUnavailable": "Imagen no disponible",
       "issued": "Emitido",
       "preparedFor": "preparado para",
+      "taxId": "ID fiscal: {{id}}",
+      "imageZoomAria": "Ver imagen más grande",
       "preview": {
         "description": "Esto es lo que su cliente ve en el enlace de su propuesta.",
         "downloadPdf": "Descargar PDF",

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -506,6 +506,7 @@
         "qty": "Qté",
         "recurrence": "Récurrence",
         "scrollAria": "Tableau de prix — faites défiler horizontalement pour la taxe, le total et les actions de ligne",
+        "showSubtotal": "Afficher la ligne de sous-total",
         "tax": "Taxe",
         "taxTitle": "Taxe par ligne. L'en-tête Total taxe fait foi et peut différer d'un centime par arrondi.",
         "taxable": "Taxable",
@@ -544,6 +545,8 @@
       "savingTitle": "Enregistrement de vos modifications — l'envoi sera disponible une fois tout enregistré.",
       "sendConfirm": {
         "message": "Nous enverrons cette proposition par e-mail à {{orgName}} et la marquerons Envoyée — {{amount}} dû à l'acceptation. Cette action est irréversible.",
+        "messageLabel": "Ajouter un message personnel (facultatif)",
+        "messagePlaceholder": "Ajoutez une courte note : elle apparaît dans l'e-mail, au-dessus du lien d'acceptation.",
         "title": "Envoyer cette proposition ?"
       },
       "sendError": "Impossible d'envoyer la proposition.",
@@ -630,6 +633,8 @@
       "imageUnavailable": "Image indisponible",
       "issued": "Émis",
       "preparedFor": "Préparé pour",
+      "taxId": "Identifiant fiscal : {{id}}",
+      "imageZoomAria": "Voir l'image en grand",
       "preview": {
         "description": "Voici ce que votre client voit sur son lien de proposition.",
         "downloadPdf": "Télécharger le PDF",

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -506,6 +506,7 @@
         "qty": "Qtd.",
         "recurrence": "Recorrência",
         "scrollAria": "Tabela de preços — role lateralmente para imposto, total e ações da linha",
+        "showSubtotal": "Mostrar linha de subtotal",
         "tax": "Imposto",
         "taxTitle": "Imposto por linha. O total de imposto do cabeçalho é autoritativo e pode diferir por um centavo de arredondamento.",
         "taxable": "Tributável",
@@ -544,6 +545,8 @@
       "savingTitle": "Salvando suas alterações — o envio será liberado quando tudo estiver salvo.",
       "sendConfirm": {
         "message": "Enviaremos esta proposta por e-mail para {{orgName}} e a marcaremos como Enviada — {{amount}} devidos na aceitação. Não é possível desfazer esta ação.",
+        "messageLabel": "Adicionar uma mensagem pessoal (opcional)",
+        "messagePlaceholder": "Inclua uma breve nota — ela aparece no e-mail, acima do link de aceitação.",
         "title": "Enviar esta proposta?"
       },
       "sendError": "Não foi possível enviar a proposta.",
@@ -630,6 +633,8 @@
       "imageUnavailable": "Imagem indisponível",
       "issued": "Emitida",
       "preparedFor": "Preparado para",
+      "taxId": "Identificação fiscal: {{id}}",
+      "imageZoomAria": "Ver imagem maior",
       "preview": {
         "description": "Isto é o que o cliente vê no link da proposta.",
         "downloadPdf": "Baixar PDF",

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -22,7 +22,10 @@ const depositPercent = z.number().gt(0).lt(100).multipleOf(0.01);
 const headingContent = z.object({ text: z.string().min(1).max(300), level: z.number().int().min(1).max(3).default(2) });
 const richTextContent = z.object({ html: z.string().max(50_000) });
 const imageContent = z.object({ imageId: z.string().guid(), caption: z.string().max(500).optional(), width: z.number().int().min(50).max(2000).optional() });
-const lineItemsContent = z.object({ label: z.string().max(200).optional() });
+// `showSubtotal` opts this pricing table into a per-table subtotal row (summed
+// from its own lines, split by recurrence). Off by default so existing tables
+// render unchanged.
+const lineItemsContent = z.object({ label: z.string().max(200).optional(), showSubtotal: z.boolean().optional() });
 
 export const quoteBlockInputSchema = z.discriminatedUnion('blockType', [
   z.object({ blockType: z.literal('heading'), content: headingContent }),


### PR DESCRIPTION
Dogfooding pass over the quote/proposal builder. Six improvements, one per commit theme, all typechecked (`tsc` / `astro check`) and tested.

## What changed

### 1. Customer bill-to on the quote (was missing on drafts)
`getQuote` now resolves the customer **name + billing address + tax id** from the org's Billing settings for **drafts**, not only frozen at send. The draft **PDF** and in-app **Preview** now render a "Prepared for" block with the address instead of a blank one. Data source is the org's dedicated billing address (the send path already froze it there at send — this surfaces it earlier everywhere).
- **Scope note:** per-quote *address override* is deferred as a follow-up; the address is read from the org (per design that the org owns it). The display name still honors a `billToName` override.

### 2. PDF page breaks + spacing
- Fixed the spec-list blurb being **measured at 10pt but rendered at 8.5pt** → it over-reserved height and opened big gaps under tall rows.
- **Keep each row together** across page breaks (no overflow into the footer band).
- **Glue a section label to its table header + first row** — fixes the orphaned "Laptop" header stranded at the bottom of page 1.

### 3. Send-proposal email: optional personal message
Optional note in the Send dialog, threaded to the API (defensive optional JSON body — bodyless callers unaffected) and rendered in the email (html + text) above the accept link.

### 4. Editor line-row overlap + add-item spacing
- The name input overflowed into the qty cell; now the name **column** is floored at the cell so table auto-layout reserves it, and the table min-width fits all 8 columns.
- Added padding + a section divider to the add-item form.

### 5. Optional per-pricing-table subtotals
Opt-in `showSubtotal` flag per `line_items` block, an editor toggle, rendered (split by recurrence) in both the **preview** and the **PDF**.

### 6. Clickable/zoomable preview images
Click-to-zoom lightbox on image blocks (Escape / backdrop to close), keyboard-reachable.

## Tests
- API: `quotePdf.test.ts` (subtotal), `quotes.test.ts` (bill-to overlay), `quoteEmail`/`quoteLifecycle`/`lifecycle` route (message).
- Web: `QuoteDocument.test.tsx` (bill-to address, subtotal), `QuoteDetail.send.test.tsx` (message forwarding).
- New billing i18n keys added across **all five locales** (locale-parity guard green).

## Follow-ups (noted, not in scope)
- Per-quote billing-address **override** UI (currently read from the org).
- `getQuote` + `sendQuote` each query the org once during send (minor double-read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)