### PR TITLE
fix(agent): make backup, verify, and restore actually execute on real agents

### DIFF
--- a/agent/cmd/breeze-backup/exec_backup.go
+++ b/agent/cmd/breeze-backup/exec_backup.go
@@ -74,7 +74,6 @@ type backupRunProviderConfig struct {
 	Endpoint  string `json:"endpoint"`
 	AccessKey string `json:"accessKey"`
 	SecretKey string `json:"secretKey"`
-	Prefix    string `json:"prefix"`
 	Path      string `json:"path"` // local provider destination
 }
 
@@ -110,10 +109,17 @@ func managerFromBackupRunPayload(payload json.RawMessage) (*backup.BackupManager
 	if len(p.Paths) == 0 {
 		return nil, fmt.Errorf("backup_run payload has no paths")
 	}
+	// Retention is owned entirely by the server: GFS tiering, legal-hold and
+	// object-immutability live in apps/api/src/jobs/backupRetention.ts, and the
+	// backup_run payload carries no retention field. The agent MUST NOT prune —
+	// BackupManager.Backup would otherwise call DeleteSnapshotContext and delete
+	// objects directly from S3/B2/local storage, racing the server's authority.
+	// Retention: 0 makes DeleteSnapshotContext a no-op (it returns early on
+	// retention <= 0), leaving the server as the sole retention authority.
 	return backup.NewBackupManager(backup.BackupConfig{
 		Provider:  provider,
 		Paths:     p.Paths,
-		Retention: 7,
+		Retention: 0,
 	}), nil
 }
 

--- a/agent/cmd/breeze-backup/exec_backup.go
+++ b/agent/cmd/breeze-backup/exec_backup.go
@@ -66,6 +66,57 @@ func applyCommandStorageEncryption(provider providers.BackupProvider, payload js
 	return nil
 }
 
+// backupRunProviderConfig mirrors the providerConfig the API sends in a backup
+// command payload (apps/api/src/jobs/backupWorker.ts). Creds arrive plaintext.
+type backupRunProviderConfig struct {
+	Bucket    string `json:"bucket"`
+	Region    string `json:"region"`
+	Endpoint  string `json:"endpoint"`
+	AccessKey string `json:"accessKey"`
+	SecretKey string `json:"secretKey"`
+	Prefix    string `json:"prefix"`
+	Path      string `json:"path"` // local provider destination
+}
+
+// managerFromBackupRunPayload builds a BackupManager from the backup_run command
+// payload's provider + providerConfig + paths. Returns (nil,nil) when the payload
+// carries no provider config so the caller falls back to the agent.yaml manager.
+func managerFromBackupRunPayload(payload json.RawMessage) (*backup.BackupManager, error) {
+	if len(payload) == 0 {
+		return nil, nil
+	}
+	var p struct {
+		Provider       string                   `json:"provider"`
+		ProviderConfig *backupRunProviderConfig `json:"providerConfig"`
+		Paths          []string                 `json:"paths"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return nil, fmt.Errorf("invalid backup_run payload: %w", err)
+	}
+	if p.ProviderConfig == nil || p.Provider == "" {
+		return nil, nil
+	}
+	var provider providers.BackupProvider
+	switch p.Provider {
+	case "s3":
+		provider = providers.NewS3ProviderWithEndpoint(
+			p.ProviderConfig.Bucket, p.ProviderConfig.Region, p.ProviderConfig.Endpoint,
+			p.ProviderConfig.AccessKey, p.ProviderConfig.SecretKey, "")
+	case "local":
+		provider = providers.NewLocalProvider(p.ProviderConfig.Path)
+	default:
+		return nil, fmt.Errorf("unsupported backup provider %q", p.Provider)
+	}
+	if len(p.Paths) == 0 {
+		return nil, fmt.Errorf("backup_run payload has no paths")
+	}
+	return backup.NewBackupManager(backup.BackupConfig{
+		Provider:  provider,
+		Paths:     p.Paths,
+		Retention: 7,
+	}), nil
+}
+
 // parseBackupRunExcludes extracts file-exclusion glob patterns from a
 // backup_run command payload (#2418). Returns nil when the payload omits the
 // field so locally-configured excludes still apply; a server that sends an
@@ -82,6 +133,61 @@ func parseBackupRunExcludes(payload json.RawMessage) ([]string, error) {
 		return nil, fmt.Errorf("invalid backup payload: %w", err)
 	}
 	return p.Excludes, nil
+}
+
+// restoreProviderFromPayload builds a BackupProvider directly from a restore/
+// verify/test-restore command payload's provider + providerConfig, mirroring
+// managerFromBackupRunPayload's parsing. Returns (nil, nil) when the payload
+// carries no provider config so callers fall back to resolveRestoreProvider.
+func restoreProviderFromPayload(payload json.RawMessage) (providers.BackupProvider, error) {
+	if len(payload) == 0 {
+		return nil, nil
+	}
+	var p struct {
+		Provider       string                   `json:"provider"`
+		ProviderConfig *backupRunProviderConfig `json:"providerConfig"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return nil, fmt.Errorf("invalid backup restore payload: %w", err)
+	}
+	if p.ProviderConfig == nil || p.Provider == "" {
+		return nil, nil
+	}
+	switch p.Provider {
+	case "s3":
+		return providers.NewS3ProviderWithEndpoint(
+			p.ProviderConfig.Bucket, p.ProviderConfig.Region, p.ProviderConfig.Endpoint,
+			p.ProviderConfig.AccessKey, p.ProviderConfig.SecretKey, ""), nil
+	case "local":
+		return providers.NewLocalProvider(p.ProviderConfig.Path), nil
+	default:
+		return nil, fmt.Errorf("unsupported backup provider %q", p.Provider)
+	}
+}
+
+// restoreProviderForCommand resolves the provider to use for restore/verify/
+// test-restore commands. The payload's provider+providerConfig (sent by the
+// API, mirroring backup_run) takes precedence over the agent.yaml-configured
+// manager, since mgr is empty on most real agents. Vault fallback is
+// preserved: when a vault provider is configured it still wraps the resolved
+// primary via NewFallbackProvider, whether the primary came from the payload
+// or from mgr.
+func restoreProviderForCommand(payload json.RawMessage, mgr *backup.BackupManager, vaultState *vaultManagerRef) (providers.BackupProvider, error) {
+	payloadProvider, err := restoreProviderFromPayload(payload)
+	if err != nil {
+		return nil, err
+	}
+	if payloadProvider == nil {
+		return resolveRestoreProvider(mgr, vaultState), nil
+	}
+	if vaultState != nil {
+		if vaultMgr := vaultState.Get(); vaultMgr != nil {
+			if vaultProvider := vaultMgr.GetProvider(); vaultProvider != nil {
+				return providers.NewFallbackProvider(vaultProvider, payloadProvider), nil
+			}
+		}
+	}
+	return payloadProvider, nil
 }
 
 func resolveRestoreProvider(mgr *backup.BackupManager, vaultState *vaultManagerRef) providers.BackupProvider {
@@ -111,7 +217,10 @@ func execBackupRestore(payload json.RawMessage, mgr *backup.BackupManager, vault
 }
 
 func execBackupRestoreWithProgress(ctx context.Context, commandID string, payload json.RawMessage, mgr *backup.BackupManager, vaultState *vaultManagerRef, conn *ipc.Conn) backupipc.BackupCommandResult {
-	restoreProvider := resolveRestoreProvider(mgr, vaultState)
+	restoreProvider, err := restoreProviderForCommand(payload, mgr, vaultState)
+	if err != nil {
+		return fail(err.Error())
+	}
 	if restoreProvider == nil {
 		return fail("backup not configured on this device")
 	}
@@ -157,7 +266,10 @@ func execBackupRestoreWithProgress(ctx context.Context, commandID string, payloa
 }
 
 func execBackupVerify(payload json.RawMessage, mgr *backup.BackupManager, vaultState *vaultManagerRef) backupipc.BackupCommandResult {
-	restoreProvider := resolveRestoreProvider(mgr, vaultState)
+	restoreProvider, err := restoreProviderForCommand(payload, mgr, vaultState)
+	if err != nil {
+		return fail(err.Error())
+	}
 	if restoreProvider == nil {
 		return fail("backup not configured on this device")
 	}
@@ -172,7 +284,10 @@ func execBackupVerify(payload json.RawMessage, mgr *backup.BackupManager, vaultS
 }
 
 func execBackupTestRestore(payload json.RawMessage, mgr *backup.BackupManager, vaultState *vaultManagerRef) backupipc.BackupCommandResult {
-	restoreProvider := resolveRestoreProvider(mgr, vaultState)
+	restoreProvider, err := restoreProviderForCommand(payload, mgr, vaultState)
+	if err != nil {
+		return fail(err.Error())
+	}
 	if restoreProvider == nil {
 		return fail("backup not configured on this device")
 	}

--- a/agent/cmd/breeze-backup/exec_backup_test.go
+++ b/agent/cmd/breeze-backup/exec_backup_test.go
@@ -250,6 +250,124 @@ func TestExecBMRRecoverUsesTokenDrivenRunner(t *testing.T) {
 	}
 }
 
+func TestManagerFromBackupRunPayload(t *testing.T) {
+	tests := []struct {
+		name         string
+		payload      string
+		wantNil      bool // manager is nil (fall back to agent.yaml manager)
+		wantErr      bool
+		wantProvider string   // "s3" | "local" | "" (skip provider assertion)
+		wantBucket   string   // for s3
+		wantBasePath string   // for local
+		wantPaths    []string // expected manager paths
+	}{
+		{
+			name:    "empty payload falls back to agent.yaml manager",
+			payload: "",
+			wantNil: true,
+		},
+		{
+			name:    "missing providerConfig falls back",
+			payload: `{"provider":"s3","paths":["/data"]}`,
+			wantNil: true,
+		},
+		{
+			name:    "missing provider falls back",
+			payload: `{"providerConfig":{"bucket":"b"},"paths":["/data"]}`,
+			wantNil: true,
+		},
+		{
+			name:         "s3 provider with paths",
+			payload:      `{"provider":"s3","providerConfig":{"bucket":"my-bucket","region":"us-east-1","accessKey":"AK","secretKey":"SK"},"paths":["/etc","/home/user"]}`,
+			wantProvider: "s3",
+			wantBucket:   "my-bucket",
+			wantPaths:    []string{"/etc", "/home/user"},
+		},
+		{
+			name:         "local provider with path",
+			payload:      `{"provider":"local","providerConfig":{"path":"/var/backups"},"paths":["/data"]}`,
+			wantProvider: "local",
+			wantBasePath: filepath.Clean("/var/backups"),
+			wantPaths:    []string{"/data"},
+		},
+		{
+			name:    "unsupported provider errors",
+			payload: `{"provider":"dropbox","providerConfig":{"bucket":"b"},"paths":["/data"]}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty paths errors",
+			payload: `{"provider":"s3","providerConfig":{"bucket":"b","region":"r"},"paths":[]}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed payload errors",
+			payload: `{"provider":`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr, err := managerFromBackupRunPayload(json.RawMessage(tt.payload))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got mgr=%v err=nil", mgr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if mgr != nil {
+					t.Fatalf("expected nil manager (fallback), got %+v", mgr)
+				}
+				return
+			}
+			if mgr == nil {
+				t.Fatal("expected a manager, got nil")
+			}
+
+			// Retention MUST be 0: the server owns retention and the agent must
+			// never prune remote storage (DeleteSnapshotContext no-ops on 0).
+			if got := mgr.GetRetention(); got != 0 {
+				t.Fatalf("retention = %d, want 0 (server owns retention)", got)
+			}
+
+			gotPaths := mgr.GetPaths()
+			if len(gotPaths) != len(tt.wantPaths) {
+				t.Fatalf("paths = %v, want %v", gotPaths, tt.wantPaths)
+			}
+			for i := range tt.wantPaths {
+				if gotPaths[i] != tt.wantPaths[i] {
+					t.Errorf("paths[%d] = %q, want %q", i, gotPaths[i], tt.wantPaths[i])
+				}
+			}
+
+			provider := mgr.GetProvider()
+			switch tt.wantProvider {
+			case "s3":
+				s3p, ok := provider.(*providers.S3Provider)
+				if !ok {
+					t.Fatalf("provider type = %T, want *providers.S3Provider", provider)
+				}
+				if s3p.Bucket != tt.wantBucket {
+					t.Errorf("bucket = %q, want %q", s3p.Bucket, tt.wantBucket)
+				}
+			case "local":
+				localP, ok := provider.(*providers.LocalProvider)
+				if !ok {
+					t.Fatalf("provider type = %T, want *providers.LocalProvider", provider)
+				}
+				if localP.BasePath != tt.wantBasePath {
+					t.Errorf("basePath = %q, want %q", localP.BasePath, tt.wantBasePath)
+				}
+			}
+		})
+	}
+}
+
 func TestParseBackupRunExcludes(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/agent/cmd/breeze-backup/main.go
+++ b/agent/cmd/breeze-backup/main.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -414,6 +415,16 @@ func handleBackupCommand(conn *ipc.Conn, env *ipc.Envelope, mgr *backup.BackupMa
 }
 
 func executeCommand(req backupipc.BackupCommandRequest, mgr *backup.BackupManager, vaultState *vaultManagerRef, conn *ipc.Conn, commandCanceller *activeCommandCanceller) backupipc.BackupCommandResult {
+	if req.CommandType == "backup_run" {
+		payloadMgr, err := managerFromBackupRunPayload(req.Payload)
+		if err != nil {
+			return fail(err.Error())
+		}
+		if payloadMgr != nil {
+			mgr = payloadMgr
+		}
+	}
+
 	if mgr == nil {
 		// Some commands don't need the manager (e.g., discovery, hardware profile)
 		switch req.CommandType {
@@ -431,6 +442,14 @@ func executeCommand(req backupipc.BackupCommandRequest, mgr *backup.BackupManage
 			ctx, cleanup := commandCanceller.track(req.CommandID)
 			defer cleanup()
 			return execBMRRecover(ctx, req.Payload, nil)
+		case "backup_verify":
+			// Verify/test-restore build their read provider from the command
+			// payload's providerConfig (restoreProviderForCommand), so they work
+			// even with no agent.yaml manager. Route them here instead of falling
+			// through to "backup not configured".
+			return execBackupVerify(req.Payload, mgr, vaultState)
+		case "backup_test_restore":
+			return execBackupTestRestore(req.Payload, mgr, vaultState)
 		default:
 			return fail("backup not configured on this device")
 		}
@@ -555,7 +574,18 @@ func sendError(conn *ipc.Conn, id, msg string) {
 }
 
 func isTimeoutError(err error) bool {
-	if netErr, ok := err.(interface{ Timeout() bool }); ok {
+	if err == nil {
+		return false
+	}
+	// The IPC layer wraps read errors (`ipc: read header: %w`), so a plain type
+	// assertion misses the net-timeout / deadline-exceeded error underneath and
+	// the command loop treats a routine 1s idle read-deadline as fatal, exiting
+	// the helper ~1s after connecting. Unwrap the chain instead.
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+	var netErr interface{ Timeout() bool }
+	if errors.As(err, &netErr) {
 		return netErr.Timeout()
 	}
 	return false

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -41,17 +41,22 @@ type BackupConfig struct {
 }
 
 // BackupJob tracks the state of a backup run.
+// JSON tags matter: this struct is serialized into the backup command result's
+// `stdout`, and both the server (backupCommandResultSchema / applyBackupCommandResultToJob)
+// and the agent's own autoSyncToVault read camelCase fields (`snapshot`,
+// `bytesBackedUp`, `filesBackedUp`). Without tags Go emits PascalCase and the
+// server can't record snapshot id / size (total_size stays null).
 type BackupJob struct {
-	ID                  string
-	StartedAt           time.Time
-	CompletedAt         time.Time
-	Snapshot            *Snapshot
-	FilesBackedUp       int
-	BytesBackedUp       int64
-	Status              string
-	Error               error
-	VSSMetadata         *vss.VSSMetadata                 // nil when VSS was not used
-	SystemStateManifest *systemstate.SystemStateManifest // nil when system state was not collected
+	ID                  string                           `json:"id"`
+	StartedAt           time.Time                        `json:"startedAt"`
+	CompletedAt         time.Time                        `json:"completedAt"`
+	Snapshot            *Snapshot                        `json:"snapshot"`
+	FilesBackedUp       int                              `json:"filesBackedUp"`
+	BytesBackedUp       int64                            `json:"bytesBackedUp"`
+	Status              string                           `json:"status"`
+	Error               error                            `json:"error,omitempty"`
+	VSSMetadata         *vss.VSSMetadata                 `json:"vssMetadata,omitempty"`         // nil when VSS was not used
+	SystemStateManifest *systemstate.SystemStateManifest `json:"systemStateManifest,omitempty"` // nil when system state was not collected
 }
 
 // BackupManager orchestrates on-demand backups. Backup scheduling is owned by

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -54,6 +54,13 @@ type BackupJob struct {
 	FilesBackedUp       int                              `json:"filesBackedUp"`
 	BytesBackedUp       int64                            `json:"bytesBackedUp"`
 	Status              string                           `json:"status"`
+	// Error is the agent's internal failure record. It is NOT the wire failure
+	// carrier: marshaling a non-nil `error` interface yields `{}`, and the
+	// server's backupCommandResultSchema doesn't read an `error` field anyway.
+	// On failure RunBackupWithExcludes returns the error separately, marshalResult
+	// routes it to the command result's stderr, and the server reads the reason
+	// from `result.error || result.stderr` (routes/agentWs.ts). Keep this field
+	// for in-process inspection (e.g. autoSyncToVault) only.
 	Error               error                            `json:"error,omitempty"`
 	VSSMetadata         *vss.VSSMetadata                 `json:"vssMetadata,omitempty"`         // nil when VSS was not used
 	SystemStateManifest *systemstate.SystemStateManifest `json:"systemStateManifest,omitempty"` // nil when system state was not collected
@@ -83,6 +90,18 @@ func NewBackupManager(config BackupConfig) *BackupManager {
 // GetProvider returns the configured backup provider.
 func (m *BackupManager) GetProvider() providers.BackupProvider {
 	return m.config.Provider
+}
+
+// GetPaths returns the configured backup source paths.
+func (m *BackupManager) GetPaths() []string {
+	return m.config.Paths
+}
+
+// GetRetention returns the configured retention count. On the helper's
+// backup_run path this is 0: retention is owned by the server, and 0 makes
+// DeleteSnapshotContext a no-op so the agent never prunes remote storage.
+func (m *BackupManager) GetRetention() int {
+	return m.config.Retention
 }
 
 // GetStagingDir returns the configured staging base directory, or an empty

--- a/agent/internal/backup/restore.go
+++ b/agent/internal/backup/restore.go
@@ -292,21 +292,32 @@ func filterFiles(files []SnapshotFile, selectedPaths []string) []SnapshotFile {
 	return matched
 }
 
+// volumeName strips a leading volume/drive name (e.g. "C:") from a path. It
+// defaults to filepath.VolumeName, which is a no-op off Windows. Tests override
+// it with a Windows-style implementation so the embedded-drive case can be
+// exercised on any host (Linux/macOS CI would otherwise assert the wrong
+// behavior, since filepath.VolumeName never strips a drive letter there).
+var volumeName = filepath.VolumeName
+
+// stripVolumeAndLeadingSeparators removes the volume/drive (e.g. "C:") and any
+// leading separators so an ABSOLUTE source path maps UNDER a target base.
+// Otherwise filepath.Join("C:\\restore", "C:\\Users\\x") yields an invalid
+// Windows path with an embedded drive letter, and MkdirAll fails for every
+// file — i.e. restore-to-an-alternate-location was completely broken on Windows.
+func stripVolumeAndLeadingSeparators(sourcePath string) string {
+	rel := sourcePath
+	if vol := volumeName(rel); vol != "" {
+		rel = rel[len(vol):]
+	}
+	return strings.TrimLeft(rel, `\/`)
+}
+
 // resolveTargetPath determines where to restore a file. If targetBase is set,
 // the full relative source path is preserved under targetBase to maintain
 // directory structure and prevent name collisions. Otherwise the original
 // source path is used.
 func resolveTargetPath(targetBase, sourcePath string) string {
-	// Strip the volume/drive (e.g. "C:") and any leading separators so an
-	// ABSOLUTE source path maps UNDER the target base. Otherwise
-	// filepath.Join("C:\\restore", "C:\\Users\\x") yields an invalid Windows path
-	// with an embedded drive letter, and MkdirAll fails for every file — i.e.
-	// restore-to-an-alternate-location was completely broken on Windows.
-	rel := sourcePath
-	if vol := filepath.VolumeName(rel); vol != "" {
-		rel = rel[len(vol):]
-	}
-	rel = strings.TrimLeft(rel, `\/`)
+	rel := stripVolumeAndLeadingSeparators(sourcePath)
 	if targetBase == "" {
 		// Use a safe temp directory instead of the original absolute path
 		return filepath.Join(os.TempDir(), "breeze-restore", rel)

--- a/agent/internal/backup/restore.go
+++ b/agent/internal/backup/restore.go
@@ -297,14 +297,24 @@ func filterFiles(files []SnapshotFile, selectedPaths []string) []SnapshotFile {
 // directory structure and prevent name collisions. Otherwise the original
 // source path is used.
 func resolveTargetPath(targetBase, sourcePath string) string {
+	// Strip the volume/drive (e.g. "C:") and any leading separators so an
+	// ABSOLUTE source path maps UNDER the target base. Otherwise
+	// filepath.Join("C:\\restore", "C:\\Users\\x") yields an invalid Windows path
+	// with an embedded drive letter, and MkdirAll fails for every file — i.e.
+	// restore-to-an-alternate-location was completely broken on Windows.
+	rel := sourcePath
+	if vol := filepath.VolumeName(rel); vol != "" {
+		rel = rel[len(vol):]
+	}
+	rel = strings.TrimLeft(rel, `\/`)
 	if targetBase == "" {
 		// Use a safe temp directory instead of the original absolute path
-		return filepath.Join(os.TempDir(), "breeze-restore", sourcePath)
+		return filepath.Join(os.TempDir(), "breeze-restore", rel)
 	}
 	// Preserve full path structure under the target base
 	// e.g., targetBase="/restore", sourcePath="path_0/reports/config.json"
 	// → "/restore/path_0/reports/config.json"
-	return filepath.Join(targetBase, sourcePath)
+	return filepath.Join(targetBase, rel)
 }
 
 func restoreStagingDir(cfg RestoreConfig) (string, error) {

--- a/agent/internal/backup/restore_volume_test.go
+++ b/agent/internal/backup/restore_volume_test.go
@@ -1,0 +1,95 @@
+package backup
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// windowsVolumeName mimics filepath.VolumeName's drive-letter handling on
+// Windows (e.g. "C:") so the embedded-drive restore bug can be exercised on any
+// host. filepath.VolumeName is a no-op off Windows, so without this injection a
+// Linux/macOS CI run would assert the wrong (unstripped) behavior.
+func windowsVolumeName(p string) string {
+	if len(p) >= 2 && p[1] == ':' &&
+		((p[0] >= 'A' && p[0] <= 'Z') || (p[0] >= 'a' && p[0] <= 'z')) {
+		return p[:2]
+	}
+	return ""
+}
+
+func withWindowsVolumeName(t *testing.T) {
+	t.Helper()
+	orig := volumeName
+	volumeName = windowsVolumeName
+	t.Cleanup(func() { volumeName = orig })
+}
+
+func TestStripVolumeAndLeadingSeparators(t *testing.T) {
+	withWindowsVolumeName(t)
+
+	tests := []struct {
+		name       string
+		sourcePath string
+		want       string
+	}{
+		{
+			name:       "windows absolute path strips drive and leading separator",
+			sourcePath: `C:\Users\alice\report.txt`,
+			want:       `Users\alice\report.txt`,
+		},
+		{
+			name:       "lowercase drive letter",
+			sourcePath: `d:\data\file.bin`,
+			want:       `data\file.bin`,
+		},
+		{
+			name:       "unix absolute path strips leading slash (no volume)",
+			sourcePath: `/home/alice/report.txt`,
+			want:       `home/alice/report.txt`,
+		},
+		{
+			name:       "relative path unchanged",
+			sourcePath: `path_0/reports/config.json`,
+			want:       `path_0/reports/config.json`,
+		},
+		{
+			name:       "drive with no trailing separator",
+			sourcePath: `C:file.txt`,
+			want:       `file.txt`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripVolumeAndLeadingSeparators(tt.sourcePath); got != tt.want {
+				t.Errorf("stripVolumeAndLeadingSeparators(%q) = %q, want %q", tt.sourcePath, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveTargetPathStripsEmbeddedDrive reproduces the PR's failing case:
+// restoring a Windows absolute source path under a Windows target base must not
+// produce an embedded drive letter like "C:\restore\C:\Users\...". With the
+// volume stripped, the file maps cleanly UNDER the target base.
+func TestResolveTargetPathStripsEmbeddedDrive(t *testing.T) {
+	withWindowsVolumeName(t)
+
+	const targetBase = `C:\restore`
+	const sourcePath = `C:\Users\alice\report.txt`
+
+	got := resolveTargetPath(targetBase, sourcePath)
+
+	// The result is a host-native join of targetBase + the volume-stripped
+	// source, so compute the expectation with filepath.Join for GOOS-independence.
+	want := filepath.Join(targetBase, `Users\alice\report.txt`)
+	if got != want {
+		t.Fatalf("resolveTargetPath(%q, %q) = %q, want %q", targetBase, sourcePath, got, want)
+	}
+
+	// Regression guard: the stripped source's drive letter must not survive into
+	// the joined path a second time.
+	if got == filepath.Join(targetBase, sourcePath) {
+		t.Fatalf("embedded drive not stripped: %q contains the full source path", got)
+	}
+}

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -1962,6 +1962,10 @@ func (b *Broker) allowedHelperPaths() []string {
 		filepath.Join(dir, "breeze-desktop-helper.exe"),
 		filepath.Join(dir, UserHelperBinaryName),
 		filepath.Join(dir, "breeze-watchdog.exe"),
+		// Backup helper (breeze-backup / breeze-backup.exe) connects to the same
+		// IPC socket and must be allowed, else backup_run always times out.
+		filepath.Join(dir, "breeze-backup"),
+		filepath.Join(dir, "breeze-backup.exe"),
 	}
 	if runtime.GOOS != "windows" {
 		paths = append(paths,

--- a/agent/internal/sessionbroker/broker_binary_path_test.go
+++ b/agent/internal/sessionbroker/broker_binary_path_test.go
@@ -32,3 +32,28 @@ func TestBinaryPathMatchesAllowedResolvesSymlinks(t *testing.T) {
 		t.Fatal("symlinked peer path did not match resolved allowed helper path")
 	}
 }
+
+// TestAllowedHelperPathsIncludesBackupHelper guards against a regression where
+// the backup helper (breeze-backup / breeze-backup.exe) is missing from the IPC
+// peer allowlist. Without it, verifyBinaryPath rejects the backup helper before
+// it can register, and every backup_run command fails with
+// "backup helper failed to connect within 15s".
+func TestAllowedHelperPathsIncludesBackupHelper(t *testing.T) {
+	b := &Broker{}
+	paths := b.allowedHelperPaths()
+	var hasBackup, hasBackupExe bool
+	for _, p := range paths {
+		switch filepath.Base(p) {
+		case "breeze-backup":
+			hasBackup = true
+		case "breeze-backup.exe":
+			hasBackupExe = true
+		}
+	}
+	if !hasBackup {
+		t.Errorf("allowedHelperPaths() must include breeze-backup (non-Windows); got %v", paths)
+	}
+	if !hasBackupExe {
+		t.Errorf("allowedHelperPaths() must include breeze-backup.exe (Windows); got %v", paths)
+	}
+}


### PR DESCRIPTION
Agent-side backup was fundamentally non-functional against a real agent — it had only ever been exercised with synthetic job fixtures. Found + fixed end-to-end by configuring backup through the UI on a live Windows agent backing up to Backblaze B2, then running Integrity Check / Test Restore / full Restore.

## Fixes
- **Helper allowlist:** `breeze-backup(.exe)` was missing from the sessionbroker IPC peer allowlist, so the backup helper was rejected at `verifyBinaryPath` before it could register → every `backup_run` timed out (`backup helper failed to connect within 15s`). Adds a regression test on `allowedHelperPaths()`.
- **Payload config:** the helper built its `BackupManager` only from `agent.yaml` (always empty on real agents). Now `managerFromBackupRunPayload` builds the provider/paths (incl. custom S3 endpoint) from the `backup_run` payload the API already sends.
- **Idle-timeout misclassification:** `isTimeoutError` didn't unwrap the wrapped IPC read error, so a routine 1s idle read-deadline was treated as fatal — the helper exited ~1s after connecting and results never returned (`session closed while waiting for response`). This was the root cause of the intermittent backup failures.
- **Result json tags:** `backup.BackupJob` serialized PascalCase, so the server never recorded snapshot id / size → Storage Used stayed 0 and no restore points were created.
- **Verify/restore provider:** build the restore provider from the command payload for `backup_verify` / `backup_test_restore` / `backup_restore`, and route verify/test-restore past the `mgr==nil` bail so they reach their handlers.
- **Restore path (Windows):** `resolveTargetPath` joined an absolute source path, producing an invalid path with an embedded drive letter (`C:\restore\C:\Users\...`) → restore-to-an-alternate-location failed for every file. Strip the volume/drive first.

## Verification (live)
Backup → B2 upload → job completed with size/snapshot → Integrity Check **passed** → Test Restore **passed** → full Restore **completed**, restored files match the originals **byte-for-byte (SHA256)**.

## Dependencies
Pairs with the API PR that sends `provider`/`providerConfig` in backup/verify/restore commands and parses the agent result. Both sides are additive and backward-compatible (this PR alone doesn't regress anything; the feature completes when both land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)