### PR TITLE
fix(backup): record agent results, deliver config to verify/restore, surface failed backups

### DIFF
--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -934,7 +934,7 @@ describe('agent websocket command results', () => {
     expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
   });
 
-  it('rejects malformed critical verification payloads before readiness processing', async () => {
+  it('fails the backup_verifications record when a critical verification payload is malformed (not left running)', async () => {
     const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
 
     vi.mocked(db.select)
@@ -957,14 +957,70 @@ describe('agent websocket command results', () => {
         type: 'command_result',
         commandId: '66666666-6666-4666-8666-666666666666',
         status: 'completed',
+        // Missing the required `status` field — schema rejects, so the result is
+        // a genuine malformed payload deepJsonParse cannot rescue.
         result: {
           filesVerified: 10
         }
       })
     } as any, ws as any);
 
-    expect(vi.mocked(processBackupVerificationResult)).not.toHaveBeenCalled();
+    // device_commands still transitions to failed...
     expect(db.update).toHaveBeenCalled();
+    // ...AND the linked backup_verifications row is driven to a terminal failed
+    // state via the normal failure path (IMPORTANT #1, #2556) rather than being
+    // stranded in 'running'/'pending' until the 30-min stale-timeout sweep.
+    expect(vi.mocked(processBackupVerificationResult)).toHaveBeenCalledTimes(1);
+    const [commandId, handed] = vi.mocked(processBackupVerificationResult).mock.calls[0]! as [
+      string,
+      { status: string; error?: string }
+    ];
+    expect(commandId).toBe('66666666-6666-4666-8666-666666666666');
+    expect(handed.status).toBe('failed');
+    expect(handed.error).toContain('Rejected malformed backup_verify result');
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
+  });
+
+  it('fails the backup_verifications record when verification stdout exceeds the size limit', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectOwnedCommandResult([
+        {
+          id: 'cmd-verify-2',
+          type: 'backup_verify',
+          payload: {},
+          deviceId: 'device-123'
+        }
+      ]) as any);
+
+    vi.mocked(db.update).mockReturnValue(updateResult([{ id: 'cmd-verify-2' }]) as any);
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+
+    // stdout beyond CRITICAL_RESULT_STDOUT_MAX_BYTES (1 MiB) trips
+    // ensureCriticalResultSizeLimits, which is the second way a critical result
+    // gets rejected.
+    const oversizeStdout = 'x'.repeat(1_048_576 + 16);
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: '77777777-7777-4777-8777-777777777777',
+        status: 'completed',
+        stdout: oversizeStdout,
+      })
+    } as any, ws as any);
+
+    expect(db.update).toHaveBeenCalled();
+    expect(vi.mocked(processBackupVerificationResult)).toHaveBeenCalledTimes(1);
+    const [, handed] = vi.mocked(processBackupVerificationResult).mock.calls[0]! as [
+      string,
+      { status: string; error?: string }
+    ];
+    expect(handed.status).toBe('failed');
+    expect(handed.error).toContain('exceeds');
     expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
   });
 

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1325,7 +1325,23 @@ export async function processOrphanedCommandResult(
     }
     console.log(`[AgentWs] Processing backup result for job ${backupJob.id} from agent ${agentId}`);
     try {
-      const parsedBackup = backupCommandResultSchema.safeParse(result.result ?? {});
+      // backup_run is not a "critical family", so the WS layer does not populate
+      // result.result from the agent's stdout. Fall back to parsing stdout JSON so
+      // snapshot id / total size / file count get recorded (F13 — otherwise a
+      // completed backup shows Size "-" and Storage Used stays 0 B).
+      // The agent forwards backup stdout as a JSON *string* in result.result (or
+      // result.stdout), never a pre-parsed object. Decode it so the schema can
+      // read snapshot id / total size / file count (F13). Without this a
+      // completed backup shows Size "-" and Storage Used stays 0 B.
+      let backupStructured: unknown = result.result ?? result.stdout;
+      if (typeof backupStructured === 'string') {
+        try {
+          backupStructured = JSON.parse(backupStructured);
+        } catch {
+          backupStructured = undefined;
+        }
+      }
+      const parsedBackup = backupCommandResultSchema.safeParse(backupStructured ?? {});
       const backupData = parsedBackup.success ? parsedBackup.data : undefined;
       const malformedPayloadError = parsedBackup.success
         ? null

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -31,7 +31,7 @@ import { createAuditLogAsync } from '../services/auditService';
 import { ANONYMOUS_ACTOR_ID, writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
 import { redactSecretsFromOutput, redactOptionalSecretText, redactAgentResultErrorFields } from '../services/secretRedaction';
 import { isRawStdoutArtifactCommand } from '../services/commandAudit';
-import { detectResultValidationFamily, validateCriticalCommandResult, DR_COMMAND_TYPES } from '../services/agentCommandResultValidation';
+import { detectResultValidationFamily, validateCriticalCommandResult, DR_COMMAND_TYPES, type CriticalResultFamily } from '../services/agentCommandResultValidation';
 import { updateRestoreJobByCommandId, updateRestoreJobFromResult } from '../services/restoreResultPersistence';
 import { captureException } from '../services/sentry';
 import { publishEvent } from '../services/eventBus';
@@ -487,6 +487,23 @@ const commandResultHandlers: Record<string, CommandResultHandler> = {
   cis_benchmark: handleCisResult,
   apply_cis_remediation: handleCisResult,
 };
+
+// IMPORTANT #1 (#2556): when a verify/restore result is REJECTED by validation
+// (malformed payload deepJsonParse can't rescue, or oversize stdout tripping the
+// size limits), device_commands transitions to 'failed' but the per-type handler
+// dispatch is skipped by the early return below — stranding the associated
+// backup_verifications / restore_jobs row in 'running'/'pending' until the 30-min
+// stale-timeout sweep. For these families we still run the handler on rejection
+// so it drives the linked record to a terminal 'failed' via its normal failure
+// path (normalizedResult.status === 'failed', error === the validation reason).
+// Scoped to the verify (backup_verify / backup_test_restore) and restore
+// (backup_restore) families — exactly the command types whose handlers finalize
+// a linked record. The 'dr' family is deliberately excluded: its records are
+// reconciled by the separate drExecution path above, not by a single handler.
+const TERMINAL_TRANSITION_FAMILIES_ON_VALIDATION_FAILURE = new Set<CriticalResultFamily>([
+  'verification',
+  'restore',
+]);
 
 // Store active WebSocket connections by agentId
 // Map<agentId, WSContext>
@@ -1614,6 +1631,23 @@ async function processCommandResult(
 
     if (validationError) {
       console.warn(`[AgentWs] ${validationError} — command ${result.commandId} rejected for agent ${agentId}`);
+      // Still dispatch to the per-type handler for verify/restore families so
+      // the linked backup_verifications / restore_jobs record transitions to a
+      // terminal 'failed' state instead of stranding until the stale-timeout
+      // sweep. normalizedResult already carries status 'failed' + the rejection
+      // reason as `error`, so the handler's normal failure path applies.
+      const rejectedFamily = detectResultValidationFamily(command.type);
+      if (rejectedFamily && TERMINAL_TRANSITION_FAMILIES_ON_VALIDATION_FAILURE.has(rejectedFamily)) {
+        const rejectedHandler = commandResultHandlers[command.type];
+        if (rejectedHandler) {
+          try {
+            await rejectedHandler({ agentId, command, result: normalizedResult, resolvedDeviceId: resolvedDeviceId!, stdout });
+          } catch (handlerErr) {
+            console.error(`[AgentWs] Failed to finalize rejected ${command.type} result ${result.commandId}:`, handlerErr);
+            captureException(handlerErr);
+          }
+        }
+      }
       return;
     }
 

--- a/apps/api/src/routes/backup.test.ts
+++ b/apps/api/src/routes/backup.test.ts
@@ -72,6 +72,7 @@ vi.mock('../db/schema', async () => {
     id: 'backup_configs.id',
     orgId: 'backup_configs.org_id',
     provider: 'backup_configs.provider',
+    providerConfig: 'backup_configs.provider_config',
     name: 'backup_configs.name',
   },
   backupJobs: {
@@ -304,6 +305,7 @@ describe('backup routes', () => {
     expect(unprotected.data.protected).toBe(false);
     expect(unprotected.data.featureLinkId).toBeNull();
     expect(unprotected.data.configId).toBeNull();
+    expect(unprotected.data.timezone).toBeNull();
     expect(unprotected.data.lastJob).toBeNull();
   });
 
@@ -328,11 +330,13 @@ describe('backup routes', () => {
       orgId: ORG_ID,
       deviceId: DEVICE_ID,
       snapshotId: 'snap-ext-001',
+      configId: 'cfg-ext-001',
     };
 
     selectMock
       .mockReturnValueOnce(chainMock([snapshot]))
-      .mockReturnValueOnce(chainMock([{ id: DEVICE_ID, status: 'online' }]));
+      .mockReturnValueOnce(chainMock([{ id: DEVICE_ID, status: 'online' }]))
+      .mockReturnValueOnce(chainMock([{ provider: 's3', providerConfig: { bucket: 'breeze-backups', region: 'us-east-1' } }]));
 
     const restoreRecord = {
       id: RESTORE_ID,

--- a/apps/api/src/routes/backup/dashboard.test.ts
+++ b/apps/api/src/routes/backup/dashboard.test.ts
@@ -7,12 +7,13 @@ const DEVICE_ID = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
 const OTHER_DEVICE_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
 const SITE_A = '11111111-1111-4111-8111-111111111111';
 const SITE_B = '22222222-2222-4222-8222-222222222222';
+const FAILING_DEVICE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
 
 let permissionsState: any;
 
 function chainMock(resolvedValue: unknown = []) {
   const chain: Record<string, any> = {};
-  for (const method of ['from', 'where', 'leftJoin', 'orderBy', 'limit']) {
+  for (const method of ['from', 'where', 'leftJoin', 'orderBy', 'limit', 'as']) {
     chain[method] = vi.fn(() => Object.assign(Promise.resolve(resolvedValue), chain));
   }
   chain.then = (onFulfilled: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) =>
@@ -79,9 +80,15 @@ vi.mock('drizzle-orm', () => ({
   and: (...conditions: unknown[]) => ({ op: 'and', conditions }),
   eq: (column: unknown, value: unknown) => ({ op: 'eq', column, value }),
   gte: (column: unknown, value: unknown) => ({ op: 'gte', column, value }),
+  lte: (column: unknown, value: unknown) => ({ op: 'lte', column, value }),
   inArray: (column: unknown, values: unknown[]) => ({ op: 'inArray', column, values }),
   desc: (value: unknown) => ({ op: 'desc', value }),
-  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ op: 'sql', strings, values }),
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    op: 'sql',
+    strings,
+    values,
+    as: (alias: string) => ({ op: 'sql', strings, values, alias }),
+  }),
 }));
 
 describe('backup dashboard routes', () => {
@@ -163,7 +170,96 @@ describe('backup dashboard routes', () => {
     const body = await res.json();
     expect(body.data.totals.policies).toBe(2);
     expect(body.data.latestJobs).toHaveLength(2);
-    expect(selectMock).toHaveBeenCalledTimes(6);
+    // 6 base aggregation queries + 2 for the attention-items ranked-jobs lookup
+    // (subquery build + the awaited select over it).
+    expect(selectMock).toHaveBeenCalledTimes(8);
+    expect(body.data.attentionItems).toEqual([]);
+  });
+
+  it('flags a device whose recent backups are failing in attentionItems', async () => {
+    resolveAllBackupAssignedDevicesMock.mockResolvedValueOnce([]);
+    selectMock
+      .mockReturnValueOnce(chainMock([{ count: 0 }])) // configCount
+      .mockReturnValueOnce(chainMock([{ count: 2 }])) // jobCount
+      .mockReturnValueOnce(chainMock([{ count: 0 }])) // snapshotCount
+      .mockReturnValueOnce(chainMock([{ completed: 0, failed: 2, running: 0, pending: 0 }])) // last24hStats
+      .mockReturnValueOnce(chainMock([{ totalBytes: 0, count: 0 }])) // storageStats
+      .mockReturnValueOnce(chainMock([])) // recentJobsRaw
+      .mockReturnValueOnce(chainMock([])) // ranked-jobs subquery build (value unused)
+      .mockReturnValueOnce(chainMock([
+        {
+          deviceId: FAILING_DEVICE_ID,
+          status: 'failed',
+          errorLog: 'Disk quota exceeded',
+          completedAt: new Date('2026-07-14T10:00:00.000Z'),
+          createdAt: new Date('2026-07-14T09:55:00.000Z'),
+          rn: 1,
+          deviceName: 'Finance Laptop',
+          deviceHostname: 'fin-laptop-01',
+        },
+        {
+          deviceId: FAILING_DEVICE_ID,
+          status: 'failed',
+          errorLog: null,
+          completedAt: new Date('2026-07-13T10:00:00.000Z'),
+          createdAt: new Date('2026-07-13T09:55:00.000Z'),
+          rn: 2,
+          deviceName: 'Finance Laptop',
+          deviceHostname: 'fin-laptop-01',
+        },
+      ])); // ranked-jobs rows
+
+    const res = await app.request('/backup/dashboard');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.attentionItems).toHaveLength(1);
+    expect(body.data.attentionItems[0]).toMatchObject({
+      id: `backup-failing-${FAILING_DEVICE_ID}`,
+      severity: 'critical',
+    });
+    expect(body.data.attentionItems[0].title).toContain('2 consecutive backup failures');
+    expect(body.data.attentionItems[0].description).toContain('Disk quota exceeded');
+  });
+
+  it('does not flag a device whose latest backup succeeded even after a prior failure', async () => {
+    resolveAllBackupAssignedDevicesMock.mockResolvedValueOnce([]);
+    selectMock
+      .mockReturnValueOnce(chainMock([{ count: 0 }])) // configCount
+      .mockReturnValueOnce(chainMock([{ count: 2 }])) // jobCount
+      .mockReturnValueOnce(chainMock([{ count: 0 }])) // snapshotCount
+      .mockReturnValueOnce(chainMock([{ completed: 1, failed: 1, running: 0, pending: 0 }])) // last24hStats
+      .mockReturnValueOnce(chainMock([{ totalBytes: 0, count: 0 }])) // storageStats
+      .mockReturnValueOnce(chainMock([])) // recentJobsRaw
+      .mockReturnValueOnce(chainMock([])) // ranked-jobs subquery build (value unused)
+      .mockReturnValueOnce(chainMock([
+        {
+          deviceId: FAILING_DEVICE_ID,
+          status: 'completed',
+          errorLog: null,
+          completedAt: new Date('2026-07-14T10:00:00.000Z'),
+          createdAt: new Date('2026-07-14T09:55:00.000Z'),
+          rn: 1,
+          deviceName: 'Finance Laptop',
+          deviceHostname: 'fin-laptop-01',
+        },
+        {
+          deviceId: FAILING_DEVICE_ID,
+          status: 'failed',
+          errorLog: 'Disk quota exceeded',
+          completedAt: new Date('2026-07-13T10:00:00.000Z'),
+          createdAt: new Date('2026-07-13T09:55:00.000Z'),
+          rn: 2,
+          deviceName: 'Finance Laptop',
+          deviceHostname: 'fin-laptop-01',
+        },
+      ])); // ranked-jobs rows
+
+    const res = await app.request('/backup/dashboard');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.attentionItems).toEqual([]);
   });
 });
 

--- a/apps/api/src/routes/backup/dashboard.test.ts
+++ b/apps/api/src/routes/backup/dashboard.test.ts
@@ -220,6 +220,48 @@ describe('backup dashboard routes', () => {
     });
     expect(body.data.attentionItems[0].title).toContain('2 consecutive backup failures');
     expect(body.data.attentionItems[0].description).toContain('Disk quota exceeded');
+    // Happy path: the list computed successfully, so no degraded signal.
+    expect(body.data.attentionError).toBe(false);
+  });
+
+  it('surfaces a degraded attentionError flag when the attention-items query fails (not a silent all-clear)', async () => {
+    resolveAllBackupAssignedDevicesMock.mockResolvedValueOnce([]);
+
+    // A chain whose terminal orderBy() rejects simulates a transient DB error
+    // inside resolveAttentionItems. Intermediate builders still resolve so only
+    // the awaited select throws.
+    const failingRankedRows = (() => {
+      const chain: Record<string, any> = {};
+      for (const method of ['from', 'where', 'leftJoin', 'limit', 'as']) {
+        chain[method] = vi.fn(() => Object.assign(Promise.resolve([]), chain));
+      }
+      chain.orderBy = vi.fn(() => Promise.reject(new Error('connection terminated unexpectedly')));
+      chain.then = (f: any, r: any) => Promise.resolve([]).then(f, r);
+      chain.catch = (r: any) => Promise.resolve([]).catch(r);
+      return chain;
+    })();
+
+    selectMock
+      .mockReturnValueOnce(chainMock([{ count: 0 }])) // configCount
+      .mockReturnValueOnce(chainMock([{ count: 1 }])) // jobCount
+      .mockReturnValueOnce(chainMock([{ count: 0 }])) // snapshotCount
+      .mockReturnValueOnce(chainMock([{ completed: 0, failed: 1, running: 0, pending: 0 }])) // last24hStats
+      .mockReturnValueOnce(chainMock([{ totalBytes: 0, count: 0 }])) // storageStats
+      .mockReturnValueOnce(chainMock([])) // recentJobsRaw
+      .mockReturnValueOnce(chainMock([])) // ranked-jobs subquery build (value unused)
+      .mockReturnValueOnce(failingRankedRows); // awaited ranked-jobs select rejects
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const res = await app.request('/backup/dashboard');
+
+    // The dashboard must NOT 500 for one failed sub-query...
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // ...but it must NOT imply an all-clear either. Empty items + degraded flag.
+    expect(body.data.attentionItems).toEqual([]);
+    expect(body.data.attentionError).toBe(true);
+    errSpy.mockRestore();
   });
 
   it('does not flag a device whose latest backup succeeded even after a prior failure', async () => {

--- a/apps/api/src/routes/backup/dashboard.ts
+++ b/apps/api/src/routes/backup/dashboard.ts
@@ -34,6 +34,13 @@ type AttentionItem = {
   severity: 'warning' | 'critical';
 };
 
+// Result of an attention-items computation. `error: true` means we could NOT
+// compute the list (transient DB failure), which is meaningfully different from
+// an empty list (genuinely no failing devices). Surfacing this lets the UI show
+// a degraded/error state instead of implying an all-clear — F11's whole purpose
+// is surfacing failures, so a swallowed error must never render as "healthy".
+type AttentionItemsResult = { items: AttentionItem[]; error: boolean };
+
 // A device needs attention when its most-recently created backup job
 // failed. Severity escalates to 'critical' once the two most recent jobs
 // both failed (a single blip stays 'warning'). This is intentionally
@@ -44,8 +51,8 @@ async function resolveAttentionItems(
   jobDeviceScope: ReturnType<typeof inArray> | undefined,
   allowedDeviceIds: string[] | null,
   noSiteAllowedDevices: boolean
-): Promise<AttentionItem[]> {
-  if (noSiteAllowedDevices) return [];
+): Promise<AttentionItemsResult> {
+  if (noSiteAllowedDevices) return { items: [], error: false };
 
   try {
     const rankedJobs = db
@@ -118,10 +125,15 @@ async function resolveAttentionItems(
     }
 
     items.sort((a, b) => new Date(b.lastFailureAt).getTime() - new Date(a.lastFailureAt).getTime());
-    return items.slice(0, ATTENTION_MAX_ITEMS).map(({ lastFailureAt: _lastFailureAt, ...item }) => item);
+    return {
+      items: items.slice(0, ATTENTION_MAX_ITEMS).map(({ lastFailureAt: _lastFailureAt, ...item }) => item),
+      error: false,
+    };
   } catch (err) {
     console.error('[BackupDashboard] Failed to resolve attention items:', err instanceof Error ? err.message : err);
-    return [];
+    // Do NOT 500 the whole dashboard for one failed sub-query, but signal the
+    // degraded state so the UI does not render an all-clear it can't vouch for.
+    return { items: [], error: true };
   }
 }
 
@@ -242,7 +254,7 @@ dashboardRoutes.get('/dashboard', requirePermission(PERMISSIONS.ORGS_READ.resour
     : undefined;
 
   // Run aggregation queries in parallel
-  const [configCount, jobCount, snapshotCount, last24hStats, storageStats, assignedDevicesRaw, recentJobsRaw, attentionItems] =
+  const [configCount, jobCount, snapshotCount, last24hStats, storageStats, assignedDevicesRaw, recentJobsRaw, attention] =
     await Promise.all([
       db
         .select({ count: sql<number>`count(*)::int` })
@@ -349,7 +361,11 @@ dashboardRoutes.get('/dashboard', requirePermission(PERMISSIONS.ORGS_READ.resour
         protectedDevices: protectedDevices.size,
       },
       latestJobs,
-      attentionItems,
+      attentionItems: attention.items,
+      // Additive, backward-compatible degraded signal: true when the
+      // attention-items sub-query failed and the list could not be computed.
+      // The UI must treat this as "unknown", not "all clear".
+      attentionError: attention.error,
     },
   });
 });

--- a/apps/api/src/routes/backup/dashboard.ts
+++ b/apps/api/src/routes/backup/dashboard.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
-import { eq, and, sql, gte, desc, inArray } from 'drizzle-orm';
+import { eq, and, sql, gte, lte, desc, inArray } from 'drizzle-orm';
 import { db } from '../../db';
 import { requirePermission } from '../../middleware/auth';
 import {
@@ -20,6 +20,109 @@ async function resolveSiteAllowedDeviceIds(orgId: string, perms: UserPermissions
   if (!perms?.allowedSiteIds) return null;
   const orgDevices = await db.select({ id: devices.id, siteId: devices.siteId }).from(devices).where(eq(devices.orgId, orgId));
   return orgDevices.filter((d) => typeof d.siteId === 'string' && canAccessSite(perms, d.siteId)).map((d) => d.id);
+}
+
+// How many of a device's most-recent backup jobs we look at to decide
+// whether it "needs attention" (last-job-failed + consecutive-failure count).
+const ATTENTION_LOOKBACK_JOBS = 5;
+const ATTENTION_MAX_ITEMS = 20;
+
+type AttentionItem = {
+  id: string;
+  title: string;
+  description: string;
+  severity: 'warning' | 'critical';
+};
+
+// A device needs attention when its most-recently created backup job
+// failed. Severity escalates to 'critical' once the two most recent jobs
+// both failed (a single blip stays 'warning'). This is intentionally
+// data-driven from real backup_jobs rows, scoped the same way the rest of
+// this route scopes org/site access (see jobDeviceScope / allowedDeviceIds).
+async function resolveAttentionItems(
+  orgId: string,
+  jobDeviceScope: ReturnType<typeof inArray> | undefined,
+  allowedDeviceIds: string[] | null,
+  noSiteAllowedDevices: boolean
+): Promise<AttentionItem[]> {
+  if (noSiteAllowedDevices) return [];
+
+  try {
+    const rankedJobs = db
+      .select({
+        deviceId: backupJobs.deviceId,
+        status: backupJobs.status,
+        errorLog: backupJobs.errorLog,
+        completedAt: backupJobs.completedAt,
+        createdAt: backupJobs.createdAt,
+        rn: sql<number>`row_number() over (partition by ${backupJobs.deviceId} order by ${backupJobs.createdAt} desc)`.as('rn'),
+      })
+      .from(backupJobs)
+      .where(and(eq(backupJobs.orgId, orgId), jobDeviceScope))
+      .as('ranked_backup_jobs_for_attention');
+
+    const rows = await db
+      .select({
+        deviceId: rankedJobs.deviceId,
+        status: rankedJobs.status,
+        errorLog: rankedJobs.errorLog,
+        completedAt: rankedJobs.completedAt,
+        createdAt: rankedJobs.createdAt,
+        rn: rankedJobs.rn,
+        deviceName: devices.displayName,
+        deviceHostname: devices.hostname,
+      })
+      .from(rankedJobs)
+      .leftJoin(devices, eq(rankedJobs.deviceId, devices.id))
+      .where(lte(rankedJobs.rn, ATTENTION_LOOKBACK_JOBS))
+      .orderBy(rankedJobs.deviceId, rankedJobs.rn);
+
+    const scopedRows = allowedDeviceIds
+      ? rows.filter((row) => allowedDeviceIds.includes(row.deviceId))
+      : rows;
+
+    const byDevice = new Map<string, typeof scopedRows>();
+    for (const row of scopedRows) {
+      const list = byDevice.get(row.deviceId) ?? [];
+      list.push(row);
+      byDevice.set(row.deviceId, list);
+    }
+
+    const items: Array<AttentionItem & { lastFailureAt: string }> = [];
+    for (const [deviceId, jobs] of byDevice) {
+      const sorted = [...jobs].sort((a, b) => a.rn - b.rn);
+      const latest = sorted[0];
+      if (!latest || latest.status !== 'failed') continue;
+
+      let consecutiveFailures = 0;
+      let reason: string | null = null;
+      for (const job of sorted) {
+        if (job.status !== 'failed') break;
+        consecutiveFailures += 1;
+        if (!reason && job.errorLog) reason = job.errorLog;
+      }
+
+      const deviceName = latest.deviceName ?? latest.deviceHostname ?? deviceId.slice(0, 8);
+      const lastFailureAt = (latest.completedAt ?? latest.createdAt).toISOString();
+
+      items.push({
+        id: `backup-failing-${deviceId}`,
+        title:
+          consecutiveFailures > 1
+            ? `${deviceName}: ${consecutiveFailures} consecutive backup failures`
+            : `${deviceName}: latest backup failed`,
+        description: [reason, `Last failed ${lastFailureAt}`].filter(Boolean).join(' · '),
+        severity: consecutiveFailures >= 2 ? 'critical' : 'warning',
+        lastFailureAt,
+      });
+    }
+
+    items.sort((a, b) => new Date(b.lastFailureAt).getTime() - new Date(a.lastFailureAt).getTime());
+    return items.slice(0, ATTENTION_MAX_ITEMS).map(({ lastFailureAt: _lastFailureAt, ...item }) => item);
+  } catch (err) {
+    console.error('[BackupDashboard] Failed to resolve attention items:', err instanceof Error ? err.message : err);
+    return [];
+  }
 }
 
 dashboardRoutes.get(
@@ -139,7 +242,7 @@ dashboardRoutes.get('/dashboard', requirePermission(PERMISSIONS.ORGS_READ.resour
     : undefined;
 
   // Run aggregation queries in parallel
-  const [configCount, jobCount, snapshotCount, last24hStats, storageStats, assignedDevicesRaw, recentJobsRaw] =
+  const [configCount, jobCount, snapshotCount, last24hStats, storageStats, assignedDevicesRaw, recentJobsRaw, attentionItems] =
     await Promise.all([
       db
         .select({ count: sql<number>`count(*)::int` })
@@ -197,6 +300,7 @@ dashboardRoutes.get('/dashboard', requirePermission(PERMISSIONS.ORGS_READ.resour
         .where(and(eq(backupJobs.orgId, orgId), jobDeviceScope))
         .orderBy(desc(backupJobs.createdAt))
         .limit(5),
+      resolveAttentionItems(orgId, jobDeviceScope, allowedDeviceIds, noSiteAllowedDevices),
     ]);
 
   const assignedDevices = allowedDeviceIds
@@ -245,6 +349,7 @@ dashboardRoutes.get('/dashboard', requirePermission(PERMISSIONS.ORGS_READ.resour
         protectedDevices: protectedDevices.size,
       },
       latestJobs,
+      attentionItems,
     },
   });
 });
@@ -300,6 +405,7 @@ dashboardRoutes.get('/status/:deviceId', requirePermission(PERMISSIONS.ORGS_READ
       protected: Boolean(resolved),
       featureLinkId: resolved?.featureLinkId ?? null,
       configId: resolved?.configId ?? null,
+      timezone: resolved?.resolvedTimezone ?? null,
       lastJob: lastJob
         ? {
             id: lastJob.id,

--- a/apps/api/src/routes/backup/restore.test.ts
+++ b/apps/api/src/routes/backup/restore.test.ts
@@ -306,6 +306,32 @@ describe('restore routes', () => {
     expect(queueCommandForExecutionMock).not.toHaveBeenCalled();
   });
 
+  it('returns a legacy-snapshot message (not a misleading "not found") when configId is null', async () => {
+    // Legacy snapshot: configId was never recorded, so there is no destination
+    // to resolve. Only two selects run (snapshot + device) — the provider-config
+    // lookup is skipped entirely because snapshot.configId is null.
+    selectMock
+      .mockReturnValueOnce(
+        chainMock([{ id: 'snap-db-1', orgId: 'org-1', deviceId: 'device-1', snapshotId: 'provider-snap-1', configId: null }])
+      )
+      .mockReturnValueOnce(chainMock([{ id: 'device-1', status: 'online' }]));
+
+    const res = await app.request('/restore', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ snapshotId: 'snap-db-1', restoreType: 'full' }),
+    });
+
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.reason).toBe('legacy_snapshot');
+    expect(body.error).toContain('predates backup destination tracking');
+    // Must NOT masquerade as a genuine misconfiguration.
+    expect(body.error).not.toBe('Backup destination configuration not found for this snapshot');
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(queueCommandForExecutionMock).not.toHaveBeenCalled();
+  });
+
   it('returns a restore job by id', async () => {
     selectMock.mockReturnValueOnce(
       chainMock([{

--- a/apps/api/src/routes/backup/restore.test.ts
+++ b/apps/api/src/routes/backup/restore.test.ts
@@ -48,6 +48,12 @@ vi.mock('../../db/schema', () => ({
     deviceId: 'backup_snapshots.device_id',
     snapshotId: 'backup_snapshots.snapshot_id',
   },
+  backupConfigs: {
+    id: 'backup_configs.id',
+    orgId: 'backup_configs.org_id',
+    provider: 'backup_configs.provider',
+    providerConfig: 'backup_configs.provider_config',
+  },
   restoreJobs: {
     id: 'restore_jobs.id',
     orgId: 'restore_jobs.org_id',
@@ -210,9 +216,10 @@ describe('restore routes', () => {
   it('creates a restore job and persists the queued command id', async () => {
     selectMock
       .mockReturnValueOnce(
-        chainMock([{ id: 'snap-db-1', orgId: 'org-1', deviceId: 'device-1', snapshotId: 'provider-snap-1' }])
+        chainMock([{ id: 'snap-db-1', orgId: 'org-1', deviceId: 'device-1', snapshotId: 'provider-snap-1', configId: 'cfg-1' }])
       )
-      .mockReturnValueOnce(chainMock([{ id: 'device-1', status: 'online' }]));
+      .mockReturnValueOnce(chainMock([{ id: 'device-1', status: 'online' }]))
+      .mockReturnValueOnce(chainMock([{ provider: 's3', providerConfig: { bucket: 'breeze-backups', region: 'us-east-1' } }]));
     insertMock.mockReturnValueOnce(
       chainMock([{
         id: 'restore-1',
@@ -273,9 +280,30 @@ describe('restore routes', () => {
         snapshotId: 'provider-snap-1',
         targetPath: '',
         selectedPaths: [],
+        provider: 's3',
+        providerConfig: { bucket: 'breeze-backups', region: 'us-east-1' },
       },
       { userId: 'user-1' }
     );
+  });
+
+  it('fails the restore request when no backup destination config can be resolved for the snapshot', async () => {
+    selectMock
+      .mockReturnValueOnce(
+        chainMock([{ id: 'snap-db-1', orgId: 'org-1', deviceId: 'device-1', snapshotId: 'provider-snap-1', configId: 'cfg-missing' }])
+      )
+      .mockReturnValueOnce(chainMock([{ id: 'device-1', status: 'online' }]))
+      .mockReturnValueOnce(chainMock([]));
+
+    const res = await app.request('/restore', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ snapshotId: 'snap-db-1', restoreType: 'full' }),
+    });
+
+    expect(res.status).toBe(422);
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(queueCommandForExecutionMock).not.toHaveBeenCalled();
   });
 
   it('returns a restore job by id', async () => {
@@ -384,9 +412,10 @@ describe('restore routes', () => {
   it('marks the restore failed and returns 502 when command dispatch fails after row creation', async () => {
     selectMock
       .mockReturnValueOnce(
-        chainMock([{ id: 'snap-db-1', orgId: 'org-1', deviceId: 'device-1', snapshotId: 'provider-snap-1' }])
+        chainMock([{ id: 'snap-db-1', orgId: 'org-1', deviceId: 'device-1', snapshotId: 'provider-snap-1', configId: 'cfg-1' }])
       )
-      .mockReturnValueOnce(chainMock([{ id: 'device-1', status: 'online' }]));
+      .mockReturnValueOnce(chainMock([{ id: 'device-1', status: 'online' }]))
+      .mockReturnValueOnce(chainMock([{ provider: 's3', providerConfig: { bucket: 'breeze-backups', region: 'us-east-1' } }]));
     insertMock.mockReturnValueOnce(
       chainMock([{
         id: 'restore-1',

--- a/apps/api/src/routes/backup/restore.ts
+++ b/apps/api/src/routes/backup/restore.ts
@@ -8,6 +8,7 @@ import { writeRouteAudit } from '../../services/auditEvents';
 import { recordBackupDispatchFailure } from '../../services/backupMetrics';
 import { CommandTypes, queueBackupStopCommand, queueCommandForExecution } from '../../services/commandQueue';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { resolveBackupProviderConfig } from '../../services/backupProviderConfig';
 import { resolveScopedOrgId } from './helpers';
 import { restoreListSchema, restoreSchema } from './schemas';
 
@@ -229,6 +230,18 @@ restoreRoutes.post(
       return c.json({ error: `Device is ${targetDevice.status}, cannot execute command` }, 409);
     }
 
+    // The agent needs the same provider + providerConfig the BACKUP command
+    // used to write this snapshot, so it can build a storage provider to
+    // read it back. Fail loudly rather than dispatch a config-less restore
+    // that the agent can't act on.
+    const backupProviderConfig = snapshot.configId
+      ? await resolveBackupProviderConfig(snapshot.configId, orgId)
+      : null;
+    if (!backupProviderConfig) {
+      recordBackupDispatchFailure('manual_restore', 'missing_provider_config');
+      return c.json({ error: 'Backup destination configuration not found for this snapshot' }, 422);
+    }
+
     const [row] = await runInOrg(orgId, async () =>
       db
         .insert(restoreJobs)
@@ -263,6 +276,8 @@ restoreRoutes.post(
             snapshotId: snapshot.snapshotId,
             targetPath: row.targetPath ?? '',
             selectedPaths: payload.restoreType === 'selective' ? (payload.selectedPaths ?? []) : [],
+            provider: backupProviderConfig.provider,
+            providerConfig: backupProviderConfig.providerConfig,
           },
           { userId: auth?.user?.id ?? undefined }
         )

--- a/apps/api/src/routes/backup/restore.ts
+++ b/apps/api/src/routes/backup/restore.ts
@@ -8,7 +8,7 @@ import { writeRouteAudit } from '../../services/auditEvents';
 import { recordBackupDispatchFailure } from '../../services/backupMetrics';
 import { CommandTypes, queueBackupStopCommand, queueCommandForExecution } from '../../services/commandQueue';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
-import { resolveBackupProviderConfig } from '../../services/backupProviderConfig';
+import { resolveBackupProviderConfig, resolveBackupDestinationError } from '../../services/backupProviderConfig';
 import { resolveScopedOrgId } from './helpers';
 import { restoreListSchema, restoreSchema } from './schemas';
 
@@ -238,8 +238,17 @@ restoreRoutes.post(
       ? await resolveBackupProviderConfig(snapshot.configId, orgId)
       : null;
     if (!backupProviderConfig) {
-      recordBackupDispatchFailure('manual_restore', 'missing_provider_config');
-      return c.json({ error: 'Backup destination configuration not found for this snapshot' }, 422);
+      // Distinguish a legacy snapshot (configId never recorded → cannot be
+      // auto-restored) from a genuine misconfiguration, so operators aren't
+      // misled into hunting a "missing config" that never existed. We do NOT
+      // fall back to the device's current config — the snapshot's objects may
+      // live at a different destination than the device backs up to today.
+      const { reason, message } = resolveBackupDestinationError(snapshot.configId);
+      recordBackupDispatchFailure(
+        'manual_restore',
+        reason === 'legacy_snapshot' ? 'snapshot_predates_config_tracking' : 'missing_provider_config'
+      );
+      return c.json({ error: message, reason }, 422);
     }
 
     const [row] = await runInOrg(orgId, async () =>

--- a/apps/api/src/routes/backup/resultSchemas.ts
+++ b/apps/api/src/routes/backup/resultSchemas.ts
@@ -1,15 +1,20 @@
 import { z } from 'zod';
 
+// File/snapshot timestamps come straight from the agent's OS. File mtimes in
+// particular carry a local UTC offset (e.g. Windows: ...-07:00), not a `Z`, so
+// `.datetime()` (which requires Z) rejects them — and one bad modTime fails the
+// whole result parse, so total_size / snapshot id / file_count silently never
+// get recorded (F13). Accept an offset.
 export const backupSnapshotFileResultSchema = z.object({
   sourcePath: z.string().min(1),
   backupPath: z.string().min(1),
   size: z.number().int().nonnegative().optional(),
-  modTime: z.string().datetime().optional(),
+  modTime: z.string().datetime({ offset: true }).optional(),
 });
 
 export const backupSnapshotResultSchema = z.object({
   id: z.string().min(1),
-  timestamp: z.string().datetime().optional(),
+  timestamp: z.string().datetime({ offset: true }).optional(),
   size: z.number().int().nonnegative().optional(),
   files: z.array(backupSnapshotFileResultSchema).optional(),
 });

--- a/apps/api/src/routes/backup/verificationService.test.ts
+++ b/apps/api/src/routes/backup/verificationService.test.ts
@@ -23,7 +23,7 @@ vi.mock('../../services/backupMetrics', () => ({
 }));
 
 import { recomputeRecoveryReadinessForDevice, runBackupVerification, processBackupVerificationResult, timeoutStaleVerifications, listRecoveryReadiness, getBackupHealthSummary } from './verificationService';
-import { backupVerifications, verificationOrgById } from './store';
+import { backupJobs, backupVerifications, jobOrgById, verificationOrgById } from './store';
 import { queueCommandForExecution } from '../../services/commandQueue';
 
 describe('backup verification service', () => {
@@ -205,6 +205,66 @@ describe('backup verification service', () => {
 
     const summary = await getBackupHealthSummary(orgId);
     expect(summary.verification.coveragePercent).toBe(0);
+  });
+
+  it('includes the resolved provider + providerConfig in the dispatched verification command', async () => {
+    vi.mocked(queueCommandForExecution).mockResolvedValueOnce({
+      command: { id: 'cmd-verify-1', status: 'sent' } as any,
+    });
+
+    const { verification } = await runBackupVerification({
+      orgId: 'org-123',
+      deviceId: 'dev-001',
+      backupJobId: 'job-001', // seeded with configId 'cfg-s3-primary' (provider 's3')
+      verificationType: 'integrity',
+      source: 'test'
+    });
+
+    expect(queueCommandForExecution).toHaveBeenCalledWith(
+      'dev-001',
+      'backup_verify',
+      expect.objectContaining({
+        provider: 's3',
+        providerConfig: expect.objectContaining({ bucket: 'breeze-backups' }),
+      }),
+      expect.anything()
+    );
+
+    const idx = backupVerifications.findIndex((v) => v.id === verification.id);
+    if (idx >= 0) backupVerifications.splice(idx, 1);
+    verificationOrgById.delete(verification.id);
+  });
+
+  it('fails loudly instead of dispatching a config-less command when no backup destination can be resolved', async () => {
+    const orgId = `org-noconfig-${Date.now()}`;
+    const jobId = `job-noconfig-${Date.now()}`;
+    const deviceId = `dev-noconfig-${Date.now()}`;
+
+    backupJobs.push({
+      id: jobId,
+      type: 'manual',
+      deviceId,
+      configId: 'cfg-does-not-exist',
+      status: 'completed',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    jobOrgById.set(jobId, orgId);
+
+    try {
+      await expect(runBackupVerification({
+        orgId,
+        deviceId,
+        backupJobId: jobId,
+        verificationType: 'integrity',
+        source: 'test'
+      })).rejects.toThrow('Backup destination configuration not found');
+      expect(queueCommandForExecution).not.toHaveBeenCalled();
+    } finally {
+      const idx = backupJobs.findIndex((j) => j.id === jobId);
+      if (idx >= 0) backupJobs.splice(idx, 1);
+      jobOrgById.delete(jobId);
+    }
   });
 
   it('fails verification startup instead of fabricating a simulated result when dispatch is unavailable', async () => {

--- a/apps/api/src/routes/backup/verificationService.test.ts
+++ b/apps/api/src/routes/backup/verificationService.test.ts
@@ -267,6 +267,49 @@ describe('backup verification service', () => {
     }
   });
 
+  it('reports a legacy-snapshot message (not a misleading "not found") when the backup job configId is null', async () => {
+    const orgId = `org-legacy-${Date.now()}`;
+    const jobId = `job-legacy-${Date.now()}`;
+    const deviceId = `dev-legacy-${Date.now()}`;
+
+    backupJobs.push({
+      id: jobId,
+      type: 'manual',
+      deviceId,
+      // Legacy job: destination was never recorded. The in-memory BackupJob
+      // type declares configId as string, but the schema (and real legacy rows)
+      // allow null — cast to reproduce that reality.
+      configId: null as unknown as string,
+      status: 'completed',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    jobOrgById.set(jobId, orgId);
+
+    try {
+      await expect(runBackupVerification({
+        orgId,
+        deviceId,
+        backupJobId: jobId,
+        verificationType: 'integrity',
+        source: 'test'
+      })).rejects.toThrow(/predates backup destination tracking/);
+      // Must NOT surface the generic misconfiguration message.
+      await expect(runBackupVerification({
+        orgId,
+        deviceId,
+        backupJobId: jobId,
+        verificationType: 'integrity',
+        source: 'test'
+      })).rejects.not.toThrow(/not found for backup job/);
+      expect(queueCommandForExecution).not.toHaveBeenCalled();
+    } finally {
+      const idx = backupJobs.findIndex((j) => j.id === jobId);
+      if (idx >= 0) backupJobs.splice(idx, 1);
+      jobOrgById.delete(jobId);
+    }
+  });
+
   it('fails verification startup instead of fabricating a simulated result when dispatch is unavailable', async () => {
     const priorCount = backupVerifications.length;
     vi.mocked(queueCommandForExecution).mockResolvedValueOnce({

--- a/apps/api/src/routes/backup/verificationService.ts
+++ b/apps/api/src/routes/backup/verificationService.ts
@@ -6,7 +6,7 @@ import {
   backupVerifications as backupVerificationsTable,
 } from '../../db/schema';
 import { recordBackupDispatchFailure } from '../../services/backupMetrics';
-import { resolveBackupProviderConfig, type BackupProviderConfig } from '../../services/backupProviderConfig';
+import { resolveBackupProviderConfig, resolveBackupDestinationError, type BackupProviderConfig } from '../../services/backupProviderConfig';
 import { queueCommandForExecution } from '../../services/commandQueue';
 import { publishEvent } from '../../services/eventBus';
 import {
@@ -547,7 +547,16 @@ export async function runBackupVerification(input: RunBackupVerificationInput): 
 
   const providerConfig = await resolveVerificationProviderConfig(input.orgId, backupJob);
   if (!providerConfig) {
-    throw new Error(`Backup destination configuration not found for backup job ${backupJob.id}`);
+    // A backup job with a null configId predates destination tracking: we can't
+    // reconstruct where its snapshot was written, and reading the device's
+    // current config could point at the wrong destination. Fail with a clear,
+    // legacy-specific message instead of a misleading "not found".
+    const { message } = resolveBackupDestinationError(backupJob.configId);
+    throw new Error(
+      backupJob.configId == null
+        ? message
+        : `Backup destination configuration not found for backup job ${backupJob.id}`
+    );
   }
 
   const commandType = input.verificationType === 'integrity' ? 'backup_verify' : 'backup_test_restore';

--- a/apps/api/src/routes/backup/verificationService.ts
+++ b/apps/api/src/routes/backup/verificationService.ts
@@ -6,13 +6,16 @@ import {
   backupVerifications as backupVerificationsTable,
 } from '../../db/schema';
 import { recordBackupDispatchFailure } from '../../services/backupMetrics';
+import { resolveBackupProviderConfig, type BackupProviderConfig } from '../../services/backupProviderConfig';
 import { queueCommandForExecution } from '../../services/commandQueue';
 import { publishEvent } from '../../services/eventBus';
 import {
   addBackupVerification,
+  backupConfigs as backupConfigsMemory,
   backupJobs,
   backupSnapshots,
   backupVerifications,
+  configOrgById,
   jobOrgById,
   snapshotOrgById,
   verificationOrgById
@@ -457,6 +460,37 @@ async function resolveSnapshotForBackupJob(
   return resolved;
 }
 
+// The agent needs the same provider + providerConfig the BACKUP command used
+// to write the snapshot, so it can build a storage provider to read it back
+// for backup_verify / backup_test_restore. Mirrors backupWorker.ts's
+// processDispatchBackup, with a memory-store fallback for the legacy/test
+// org path the rest of this file already supports (see resolveBackupJob).
+async function resolveVerificationProviderConfig(
+  orgId: string,
+  backupJob: BackupJob
+): Promise<BackupProviderConfig | null> {
+  if (supportsDbOrg(orgId) && isUuid(backupJob.configId)) {
+    try {
+      const resolved = await runWithSystemDbAccess(() =>
+        resolveBackupProviderConfig(backupJob.configId, orgId)
+      );
+      if (resolved) return resolved;
+    } catch (error) {
+      console.warn('[backupVerification] DB provider config lookup failed; falling back to memory:', error);
+    }
+  }
+
+  const memoryConfig = backupConfigsMemory.find(
+    (config) => config.id === backupJob.configId && configOrgById.get(config.id) === orgId
+  );
+  if (!memoryConfig) return null;
+
+  return {
+    provider: memoryConfig.provider,
+    providerConfig: (memoryConfig.details as Record<string, unknown> | undefined) ?? {},
+  };
+}
+
 // ---- Public API ----
 
 export async function listBackupVerifications(
@@ -511,11 +545,21 @@ export async function runBackupVerification(input: RunBackupVerificationInput): 
   const now = new Date().toISOString();
   const agentSnapshotId = snapshot?.providerSnapshotId ?? backupJob.snapshotId ?? snapshot?.id ?? undefined;
 
+  const providerConfig = await resolveVerificationProviderConfig(input.orgId, backupJob);
+  if (!providerConfig) {
+    throw new Error(`Backup destination configuration not found for backup job ${backupJob.id}`);
+  }
+
   const commandType = input.verificationType === 'integrity' ? 'backup_verify' : 'backup_test_restore';
   const dispatchResult = await queueCommandForExecution(
     input.deviceId,
     commandType,
-    { snapshotId: agentSnapshotId, verificationType: input.verificationType },
+    {
+      snapshotId: agentSnapshotId,
+      verificationType: input.verificationType,
+      provider: providerConfig.provider,
+      providerConfig: providerConfig.providerConfig,
+    },
     { userId: input.requestedBy || undefined }
   );
 

--- a/apps/api/src/services/agentCommandResultValidation.ts
+++ b/apps/api/src/services/agentCommandResultValidation.ts
@@ -131,18 +131,32 @@ function ensureCriticalResultSizeLimits(envelope: GenericCommandResultEnvelope):
   }
 }
 
+// Agents encode the structured result as a JSON string (marshalResult → stdout),
+// and depending on the path it can arrive double-encoded (a JSON string whose
+// value is itself the JSON object). Parse repeatedly until we reach a non-string,
+// so critical-family validation (ensureObjectLike + the family schemas) sees an
+// object — otherwise verify/test-restore/restore results are rejected as "must be
+// a JSON object" and the record never leaves running.
+function deepJsonParse(value: unknown): unknown {
+  let current = value;
+  for (let i = 0; i < 3 && typeof current === 'string'; i++) {
+    try {
+      current = JSON.parse(current);
+    } catch {
+      return undefined;
+    }
+  }
+  return current;
+}
+
 function parseStructuredResult(envelope: GenericCommandResultEnvelope): unknown {
   if (envelope.result !== undefined) {
-    return envelope.result;
+    return deepJsonParse(envelope.result);
   }
   if (!envelope.stdout) {
     return undefined;
   }
-  try {
-    return JSON.parse(envelope.stdout);
-  } catch {
-    return undefined;
-  }
+  return deepJsonParse(envelope.stdout);
 }
 
 function ensureObjectLike(commandType: string, value: unknown): Record<string, unknown> {

--- a/apps/api/src/services/aiToolsBackup.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsBackup.siteScope.test.ts
@@ -127,8 +127,9 @@ describe('restore_snapshot — cross-site snapshot authorization (source device 
 
   const snapshotRow = {
     id: 's1', orgId: 'org-1', providerSnapshotId: 'provider-xyz', deviceId: 'src-dev',
-    metadata: {}, size: 1024, hardwareProfile: {},
+    configId: 'cfg-1', metadata: {}, size: 1024, hardwareProfile: {},
   };
+  const providerConfigRow = { provider: 's3', providerConfig: { bucket: 'breeze-backups', region: 'us-east-1' } };
 
   // Return the queued selects in order.
   function seqSelect(results: Array<unknown[]>) {
@@ -156,6 +157,7 @@ describe('restore_snapshot — cross-site snapshot authorization (source device 
       [snapshotRow],                      // snapshot row
       [{ siteId: 'site-A' }],             // snapshot source device → same site, allowed
       [{ id: 'd1', status: 'online' }],   // target device online check
+      [providerConfigRow],                // backup destination config lookup
     ]);
     const now = new Date();
     const rj = {
@@ -177,6 +179,7 @@ describe('restore_snapshot — cross-site snapshot authorization (source device 
       [{ id: 'd1', siteId: 'site-Z' }], // target device
       [snapshotRow],                    // snapshot row
       [{ id: 'd1', status: 'online' }], // target device online check
+      [providerConfigRow],              // backup destination config lookup
     ]);
     const now = new Date();
     const rj = {

--- a/apps/api/src/services/aiToolsBackup.ts
+++ b/apps/api/src/services/aiToolsBackup.ts
@@ -22,7 +22,7 @@ import { eq, and, desc, sql, gte, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { CommandTypes, queueCommandForExecution } from './commandQueue';
-import { resolveBackupProviderConfig } from './backupProviderConfig';
+import { resolveBackupProviderConfig, resolveBackupDestinationError } from './backupProviderConfig';
 import { createManualBackupJobIfIdle } from './backupJobCreation';
 import { enqueueBackupDispatch } from '../jobs/backupEnqueue';
 import { deviceSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
@@ -649,7 +649,12 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
         ? await resolveBackupProviderConfig(snapshot.configId, orgId)
         : null;
       if (!backupProviderConfig) {
-        return JSON.stringify({ error: 'Backup destination configuration not found for this snapshot' });
+        // Legacy snapshot (null configId) predates destination tracking and
+        // can't be auto-restored — surface a distinct, non-misleading message
+        // rather than a generic "not found" (and never a current-config
+        // fallback, which could read the wrong destination).
+        const { reason, message } = resolveBackupDestinationError(snapshot.configId);
+        return JSON.stringify({ error: message, reason });
       }
 
       // Insert restore job

--- a/apps/api/src/services/aiToolsBackup.ts
+++ b/apps/api/src/services/aiToolsBackup.ts
@@ -22,6 +22,7 @@ import { eq, and, desc, sql, gte, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { CommandTypes, queueCommandForExecution } from './commandQueue';
+import { resolveBackupProviderConfig } from './backupProviderConfig';
 import { createManualBackupJobIfIdle } from './backupJobCreation';
 import { enqueueBackupDispatch } from '../jobs/backupEnqueue';
 import { deviceSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
@@ -641,6 +642,16 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
         return JSON.stringify({ error: `Device is ${targetDevice.status}, cannot execute command` });
       }
 
+      // The agent needs the same provider + providerConfig the BACKUP command
+      // used to write this snapshot, so it can build a storage provider to
+      // read it back. Fail loudly rather than dispatch a config-less restore.
+      const backupProviderConfig = snapshot.configId
+        ? await resolveBackupProviderConfig(snapshot.configId, orgId)
+        : null;
+      if (!backupProviderConfig) {
+        return JSON.stringify({ error: 'Backup destination configuration not found for this snapshot' });
+      }
+
       // Insert restore job
       const [restoreJob] = await db.insert(restoreJobs).values({
         orgId,
@@ -666,6 +677,8 @@ export function registerBackupTools(aiTools: Map<string, AiTool>): void {
             snapshotId: snapshot.providerSnapshotId,
             targetPath: restoreJob.targetPath ?? '',
             selectedPaths: restoreType === 'selective' ? (selectedPaths ?? []) : [],
+            provider: backupProviderConfig.provider,
+            providerConfig: backupProviderConfig.providerConfig,
           },
           { userId: auth.user?.id ?? undefined }
         );

--- a/apps/api/src/services/aiToolsBackupShared.ts
+++ b/apps/api/src/services/aiToolsBackupShared.ts
@@ -32,6 +32,8 @@ export type SiteScopedSnapshot = {
   providerSnapshotId: string;
   /** Source device the snapshot was captured from. */
   deviceId: string;
+  /** backup_configs.id this snapshot was written under (nullable on legacy rows). */
+  configId: string | null;
   metadata: unknown;
   size: number | null;
   hardwareProfile: unknown;
@@ -62,6 +64,7 @@ export async function loadSnapshotWithSiteAccess(
       orgId: backupSnapshots.orgId,
       providerSnapshotId: backupSnapshots.snapshotId,
       deviceId: backupSnapshots.deviceId,
+      configId: backupSnapshots.configId,
       metadata: backupSnapshots.metadata,
       size: backupSnapshots.size,
       hardwareProfile: backupSnapshots.hardwareProfile,

--- a/apps/api/src/services/backupProviderConfig.ts
+++ b/apps/api/src/services/backupProviderConfig.ts
@@ -1,0 +1,49 @@
+/**
+ * Resolves the storage destination (provider + providerConfig) for a
+ * backup_configs row.
+ *
+ * VERIFY and RESTORE agent commands need to read a snapshot back from the
+ * same bucket/share the BACKUP command wrote it to. `backupWorker.ts`
+ * already attaches `provider` + `providerConfig` to `backup_run` commands
+ * (see processDispatchBackup) — this helper produces the same shape so
+ * backup_verify / backup_test_restore / backup_restore commands can carry
+ * it too. Deliberately does NOT apply the storage-encryption patch that
+ * backupWorker layers onto write commands (resolveBackupStorageEncryptionPlan)
+ * — verify/restore only need to READ, and callers here don't have (nor
+ * need) an encryption-plan decision to make.
+ */
+import { and, eq } from 'drizzle-orm';
+import { db } from '../db';
+import { backupConfigs } from '../db/schema';
+
+export type BackupProviderConfig = {
+  provider: string;
+  providerConfig: Record<string, unknown>;
+};
+
+/**
+ * Looks up `backup_configs` by id, scoped to `orgId` (tenant-safe — a
+ * mismatched org returns null exactly like a missing row). Returns null
+ * when no config can be resolved; callers must fail the verify/restore
+ * request rather than dispatch a command the agent can't act on.
+ */
+export async function resolveBackupProviderConfig(
+  configId: string,
+  orgId: string
+): Promise<BackupProviderConfig | null> {
+  const [config] = await db
+    .select({
+      provider: backupConfigs.provider,
+      providerConfig: backupConfigs.providerConfig,
+    })
+    .from(backupConfigs)
+    .where(and(eq(backupConfigs.id, configId), eq(backupConfigs.orgId, orgId)))
+    .limit(1);
+
+  if (!config) return null;
+
+  return {
+    provider: config.provider,
+    providerConfig: (config.providerConfig as Record<string, unknown> | null) ?? {},
+  };
+}

--- a/apps/api/src/services/backupProviderConfig.ts
+++ b/apps/api/src/services/backupProviderConfig.ts
@@ -22,6 +22,38 @@ export type BackupProviderConfig = {
 };
 
 /**
+ * A snapshot / backup job written before destination tracking existed carries
+ * a NULL `configId`, so we can't reconstruct the exact bucket/share it was
+ * written to. We deliberately do NOT fall back to the device's CURRENT
+ * effective config — the snapshot's objects live at the destination used AT
+ * WRITE TIME, which may differ from where the device backs up today; reading
+ * the current bucket could look in the wrong place. So callers surface a
+ * CLEARER error (not a fallback) that distinguishes this legacy case from a
+ * genuine misconfiguration (configId set but no config resolves).
+ */
+export const SNAPSHOT_PREDATES_DESTINATION_TRACKING_MESSAGE =
+  'This snapshot predates backup destination tracking: its storage destination was not recorded when it was written, so it cannot be automatically restored or verified. Restore or verify it manually against the original storage destination.';
+
+export const BACKUP_DESTINATION_CONFIG_NOT_FOUND_MESSAGE =
+  'Backup destination configuration not found for this snapshot';
+
+export type BackupDestinationErrorReason = 'legacy_snapshot' | 'config_not_found';
+
+/**
+ * Builds the operator-facing error for a verify/restore request that could not
+ * resolve a provider config. When `configId` is null the snapshot predates
+ * destination tracking (auto-restore/verify impossible) — a distinct, non-
+ * misleading message; otherwise the referenced config is genuinely missing.
+ */
+export function resolveBackupDestinationError(
+  configId: string | null | undefined
+): { reason: BackupDestinationErrorReason; message: string } {
+  return configId == null
+    ? { reason: 'legacy_snapshot', message: SNAPSHOT_PREDATES_DESTINATION_TRACKING_MESSAGE }
+    : { reason: 'config_not_found', message: BACKUP_DESTINATION_CONFIG_NOT_FOUND_MESSAGE };
+}
+
+/**
  * Looks up `backup_configs` by id, scoped to `orgId` (tenant-safe — a
  * mismatched org returns null exactly like a missing row). Returns null
  * when no config can be resolved; callers must fail the verify/restore


### PR DESCRIPTION
The API-backend backup fixes. Grouped into one PR because `dashboard.ts` and `backup.test.ts` are shared across them (a finer split would need per-hunk surgery). Found + verified end-to-end on a live Windows agent → Backblaze B2.

## Record backup results (F13)
- `agentWs`: the agent sends its result as a JSON string in `stdout`; parse it so **snapshot id / total size / file count** are recorded. Without this a completed backup showed Size "-", Storage Used stayed 0 B, and **no restore points were created**.
- `resultSchemas`: accept `datetime({ offset: true })` for snapshot/file timestamps — Windows file mtimes carry a local offset (`-07:00`), and one bad `modTime` failed the whole result parse, dropping the size too.

## Deliver destination config to verify/restore (F15) + parse the result (F16)
- `restore.ts`, `verificationService.ts`, `aiToolsBackup*`, new `backupProviderConfig` helper: include `provider` + `providerConfig` in `backup_verify` / `backup_test_restore` / `backup_restore` payloads so the agent can reach the bucket to read snapshots back. Fails loudly if no config resolves.
- `agentCommandResultValidation`: `deepJsonParse` in `parseStructuredResult` — the verify/restore result arrives as a (sometimes double-) JSON-encoded string and was rejected as "must be a JSON object", leaving verification records stuck in `running`.

## Surface failing backups (F11) + timezone (F7 api half)
- `dashboard`: Backup Overview "Attention Needed" now lists devices whose recent backups are failing (was always "healthy"), and device backup status returns the device's effective timezone for correct next-run display.

## Verification (live)
Integrity Check **passed**, Test Restore **passed**, full Restore **completed** with restored files matching originals byte-for-byte. 220+ API tests updated/green.

## Dependencies
Pairs with the agent PR (#2554) — F13/F15 need both halves; both are additive/backward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)