### PR TITLE
feat(ai): live TD SYNNEX distributor lookup as an MCP tool (lookup_distributor_product)

### DIFF
--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -166,6 +166,7 @@ export const TOOL_PERMISSIONS: Record<string, { resource: string; action: string
   },
   search_catalog: { resource: 'catalog', action: 'read' },
   get_catalog_item: { resource: 'catalog', action: 'read' },
+  lookup_distributor_product: { resource: 'catalog', action: 'read' },
   manage_catalog: {
     create_item: { resource: 'catalog', action: 'write' },
     update_item: { resource: 'catalog', action: 'write' },

--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -354,6 +354,10 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
     catalogItemId: uuid,
   }),
 
+  lookup_distributor_product: z.object({
+    query: z.string().min(1).max(40),
+  }),
+
   manage_catalog: z.object({
     action: z.enum([
       'create_item',

--- a/apps/api/src/services/aiToolsCatalog.test.ts
+++ b/apps/api/src/services/aiToolsCatalog.test.ts
@@ -41,8 +41,27 @@ vi.mock('../db/schema', () => ({
   },
 }));
 
+// Mock the live TD SYNNEX EC Express service so lookup_distributor_product tests
+// never make an outbound call. TdSynnexEcExpressError must be a real class so the
+// handler's `instanceof` check matches.
+vi.mock('./tdSynnexEcExpress', () => {
+  class TdSynnexEcExpressError extends Error {
+    code: string;
+    constructor(message: string, code = 'EC_PROVIDER_ERROR') { super(message); this.code = code; }
+  }
+  return { lookupEcExpressProducts: vi.fn(), TdSynnexEcExpressError };
+});
+
 import { registerCatalogTools } from './aiToolsCatalog';
 import { db } from '../db';
+import { lookupEcExpressProducts, TdSynnexEcExpressError } from './tdSynnexEcExpress';
+
+const EC_PRODUCT = {
+  source: 'td_synnex_ec_express', synnexSku: '14753620', mfgPartNo: 'PC14250', status: 'OK',
+  name: 'Dell Pro 14', description: 'Ultra 5', currency: 'USD', cost: 1120.5, msrp: 1499,
+  discount: null, totalQty: 42, warehouses: [{ code: 'CA', available: 42, onOrder: 0, bo: 0, eta: null }],
+  weight: 3.1, parcelShippable: 'Y', raw: { soap: 'internal-dump' },
+} as const;
 
 const PARTNER_ID = '22222222-2222-2222-2222-222222222222';
 const ITEM_ID = '33333333-3333-3333-3333-333333333333';
@@ -377,5 +396,49 @@ describe('aiToolsCatalog: get_catalog_item', () => {
     const conds = flattenConditions(compCapture.where);
     expect(conds).toContainEqual({ _op: 'eq', a: 'cbc.bundle_item_id', b: ITEM_ID });
     expect(conds).toContainEqual({ _op: 'eq', a: 'cbc.partner_id', b: PARTNER_ID });
+  });
+});
+
+describe('aiToolsCatalog: lookup_distributor_product', () => {
+  function orgAuth() {
+    return { user: { id: 'u1' }, partnerId: PARTNER_ID, scope: 'organization', orgId: 'o1', accessibleOrgIds: ['o1'] } as any;
+  }
+
+  it('rejects an empty query without calling the distributor', async () => {
+    const out = await tools().get('lookup_distributor_product')!.handler({ query: '   ' }, partnerAuth());
+    expect(JSON.parse(out).error).toMatch(/SKU or manufacturer part number/);
+    expect(lookupEcExpressProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns a partner-scoped error (and no outbound call) when there is no partner', async () => {
+    const out = await tools().get('lookup_distributor_product')!.handler({ query: '14753620' }, noPartnerAuth());
+    expect(JSON.parse(out)).toEqual({ error: 'Distributor lookup is partner-scoped; no partner in context' });
+    expect(lookupEcExpressProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns products with cost for a partner-scoped caller, dropping the raw SOAP payload', async () => {
+    vi.mocked(lookupEcExpressProducts).mockResolvedValue([EC_PRODUCT as any]);
+    const out = await tools().get('lookup_distributor_product')!.handler({ query: '14753620' }, partnerAuth());
+    expect(lookupEcExpressProducts).toHaveBeenCalledWith('14753620', expect.objectContaining({ partnerId: PARTNER_ID }));
+    const parsed = JSON.parse(out);
+    expect(parsed.showing).toBe(1);
+    expect(parsed.products[0].cost).toBe(1120.5); // partner keeps cost
+    expect(parsed.products[0].synnexSku).toBe('14753620');
+    expect(parsed.products[0].raw).toBeUndefined(); // internal SOAP dump never exposed
+  });
+
+  it('redacts reseller cost for an organization-scoped caller', async () => {
+    vi.mocked(lookupEcExpressProducts).mockResolvedValue([EC_PRODUCT as any]);
+    const out = await tools().get('lookup_distributor_product')!.handler({ query: '14753620' }, orgAuth());
+    const parsed = JSON.parse(out);
+    expect(parsed.products[0].cost).toBeUndefined(); // cost is partner-sensitive
+    expect(parsed.products[0].msrp).toBe(1499);      // customer-facing fields stay
+    expect(parsed.products[0].raw).toBeUndefined();
+  });
+
+  it('surfaces a typed provider error as JSON instead of throwing', async () => {
+    vi.mocked(lookupEcExpressProducts).mockRejectedValue(new TdSynnexEcExpressError('No results for that SKU/part #', 'EC_NO_RESULTS'));
+    const out = await tools().get('lookup_distributor_product')!.handler({ query: 'NOPE' }, partnerAuth());
+    expect(JSON.parse(out)).toEqual({ error: 'No results for that SKU/part #', code: 'EC_NO_RESULTS' });
   });
 });

--- a/apps/api/src/services/aiToolsCatalog.test.ts
+++ b/apps/api/src/services/aiToolsCatalog.test.ts
@@ -59,7 +59,7 @@ import { lookupEcExpressProducts, TdSynnexEcExpressError } from './tdSynnexEcExp
 const EC_PRODUCT = {
   source: 'td_synnex_ec_express', synnexSku: '14753620', mfgPartNo: 'PC14250', status: 'OK',
   name: 'Dell Pro 14', description: 'Ultra 5', currency: 'USD', cost: 1120.5, msrp: 1499,
-  discount: null, totalQty: 42, warehouses: [{ code: 'CA', available: 42, onOrder: 0, bo: 0, eta: null }],
+  discount: 12, totalQty: 42, warehouses: [{ code: 'CA', available: 42, onOrder: 0, bo: 0, eta: null }],
   weight: 3.1, parcelShippable: 'Y', raw: { soap: 'internal-dump' },
 } as const;
 
@@ -416,24 +416,25 @@ describe('aiToolsCatalog: lookup_distributor_product', () => {
     expect(lookupEcExpressProducts).not.toHaveBeenCalled();
   });
 
-  it('returns products with cost for a partner-scoped caller, dropping the raw SOAP payload', async () => {
+  it('returns products with cost AND discount for a partner-scoped caller, dropping the raw SOAP payload', async () => {
     vi.mocked(lookupEcExpressProducts).mockResolvedValue([EC_PRODUCT as any]);
     const out = await tools().get('lookup_distributor_product')!.handler({ query: '14753620' }, partnerAuth());
     expect(lookupEcExpressProducts).toHaveBeenCalledWith('14753620', expect.objectContaining({ partnerId: PARTNER_ID }));
     const parsed = JSON.parse(out);
     expect(parsed.showing).toBe(1);
     expect(parsed.products[0].cost).toBe(1120.5); // partner keeps cost
+    expect(parsed.products[0].discount).toBe(12); // …and discount (margin-derivable)
+    expect(parsed.products[0].msrp).toBe(1499);
     expect(parsed.products[0].synnexSku).toBe('14753620');
     expect(parsed.products[0].raw).toBeUndefined(); // internal SOAP dump never exposed
   });
 
-  it('redacts reseller cost for an organization-scoped caller', async () => {
-    vi.mocked(lookupEcExpressProducts).mockResolvedValue([EC_PRODUCT as any]);
+  it('refuses organization-scoped callers entirely — no outbound call, no margin data', async () => {
+    // An org MCP token carries the owning partner's partnerId, so a bare partnerId
+    // check would let it through. It must be blocked on SCOPE before any lookup.
     const out = await tools().get('lookup_distributor_product')!.handler({ query: '14753620' }, orgAuth());
-    const parsed = JSON.parse(out);
-    expect(parsed.products[0].cost).toBeUndefined(); // cost is partner-sensitive
-    expect(parsed.products[0].msrp).toBe(1499);      // customer-facing fields stay
-    expect(parsed.products[0].raw).toBeUndefined();
+    expect(JSON.parse(out)).toEqual({ error: 'Distributor lookup is not available to organization-scoped callers' });
+    expect(lookupEcExpressProducts).not.toHaveBeenCalled();
   });
 
   it('surfaces a typed provider error as JSON instead of throwing', async () => {

--- a/apps/api/src/services/aiToolsCatalog.ts
+++ b/apps/api/src/services/aiToolsCatalog.ts
@@ -34,6 +34,7 @@ import {
   type CatalogActor
 } from './catalogService';
 import { missingParamsJson, zodErrorToJson } from './aiToolValidation';
+import { lookupEcExpressProducts, TdSynnexEcExpressError, type TdSynnexEcProduct } from './tdSynnexEcExpress';
 
 /**
  * Params each manage_catalog action requires, presence-checked BEFORE any
@@ -165,6 +166,19 @@ function sanitizeCatalogItemForAi(item: CatalogItemRow, auth: AuthContext): Reco
   return out;
 }
 
+/**
+ * Shape a live distributor price-&-availability product for AI/MCP output. Drops
+ * the verbose raw SOAP payload (internal), and redacts the reseller `cost` for
+ * organization-scoped callers — cost is partner-sensitive, mirroring the catalog
+ * item redaction above. Partner-scoped callers keep cost (they need it to price).
+ */
+function sanitizeDistributorProductForAi(p: TdSynnexEcProduct, auth: AuthContext): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...p };
+  delete out.raw;
+  if (auth.scope === 'organization') delete out.cost;
+  return out;
+}
+
 export function registerCatalogTools(aiTools: Map<string, AiTool>): void {
   aiTools.set('search_catalog', {
     tier: 2 as AiToolTier,
@@ -236,6 +250,50 @@ export function registerCatalogTools(aiTools: Map<string, AiTool>): void {
         .orderBy(asc(catalogItems.name))
         .limit(limit);
       return JSON.stringify({ items: rows, showing: rows.length });
+    }
+  });
+
+  aiTools.set('lookup_distributor_product', {
+    tier: 2 as AiToolTier,
+    deviceArgs: [],
+    definition: {
+      name: 'lookup_distributor_product',
+      description:
+        'Live TD SYNNEX (EC Express) price & availability lookup for a SINGLE distributor SKU or manufacturer part number. Returns reseller cost, MSRP, currency, total stock, and per-warehouse availability. Read-only, but makes an outbound call to the distributor (partner-scoped). Use this to price a distributor product that is NOT yet in the catalog before adding it to a quote; for items already in the catalog use search_catalog instead.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          query: {
+            type: 'string',
+            description: 'Exactly one TD SYNNEX SKU (all digits) or manufacturer part number to look up.'
+          }
+        },
+        required: ['query']
+      }
+    },
+    handler: async (input, auth) => {
+      if (input.query == null || String(input.query).trim() === '') {
+        return JSON.stringify({ error: 'Provide a SYNNEX SKU or manufacturer part number in "query"' });
+      }
+      const partnerId = auth.partnerId;
+      if (!partnerId) {
+        return JSON.stringify({ error: 'Distributor lookup is partner-scoped; no partner in context' });
+      }
+      try {
+        const products = await lookupEcExpressProducts(String(input.query), actorFromAuth(auth));
+        return JSON.stringify({
+          products: products.map((p) => sanitizeDistributorProductForAi(p, auth)),
+          showing: products.length
+        });
+      } catch (err) {
+        // Surface the typed provider/no-results error to the model instead of a
+        // generic 500, so it can retry with a different SKU or fall back to a
+        // manual line — never a blind retry loop.
+        if (err instanceof TdSynnexEcExpressError) {
+          return JSON.stringify({ error: err.message, code: err.code });
+        }
+        throw err;
+      }
     }
   });
 

--- a/apps/api/src/services/aiToolsCatalog.ts
+++ b/apps/api/src/services/aiToolsCatalog.ts
@@ -166,16 +166,31 @@ function sanitizeCatalogItemForAi(item: CatalogItemRow, auth: AuthContext): Reco
   return out;
 }
 
+// Allowlist for AI/MCP distributor-lookup output. Public fields (list price,
+// availability, identifiers) are always safe. Margin-sensitive fields (reseller
+// cost + the discount it derives from) are added only for seller scopes.
+const AI_DISTRIBUTOR_PRODUCT_PUBLIC_FIELDS = [
+  'source', 'synnexSku', 'mfgPartNo', 'status', 'name', 'description',
+  'currency', 'msrp', 'totalQty', 'warehouses', 'weight', 'parcelShippable',
+] as const;
+const AI_DISTRIBUTOR_PRODUCT_MARGIN_FIELDS = ['cost', 'discount'] as const;
+
 /**
- * Shape a live distributor price-&-availability product for AI/MCP output. Drops
- * the verbose raw SOAP payload (internal), and redacts the reseller `cost` for
- * organization-scoped callers — cost is partner-sensitive, mirroring the catalog
- * item redaction above. Partner-scoped callers keep cost (they need it to price).
+ * Allowlist-project a live distributor product for AI/MCP output — never a
+ * blocklist, so a field TD SYNNEX or an importer adds later can't auto-leak. The
+ * raw SOAP payload is dropped by construction (not in the allowlist). The
+ * margin-sensitive fields (`cost` AND the `discount` it's derivable from) are
+ * included only for seller scopes (partner/system); the tool's handler already
+ * refuses organization scope, so this is defense-in-depth if that gate loosens.
  */
 function sanitizeDistributorProductForAi(p: TdSynnexEcProduct, auth: AuthContext): Record<string, unknown> {
-  const out: Record<string, unknown> = { ...p };
-  delete out.raw;
-  if (auth.scope === 'organization') delete out.cost;
+  const src = p as unknown as Record<string, unknown>;
+  const out = pickAllowed(src, AI_DISTRIBUTOR_PRODUCT_PUBLIC_FIELDS);
+  if (auth.scope === 'partner' || auth.scope === 'system') {
+    for (const key of AI_DISTRIBUTOR_PRODUCT_MARGIN_FIELDS) {
+      if (key in src) out[key] = src[key];
+    }
+  }
   return out;
 }
 
@@ -265,6 +280,7 @@ export function registerCatalogTools(aiTools: Map<string, AiTool>): void {
         properties: {
           query: {
             type: 'string',
+            maxLength: 40,
             description: 'Exactly one TD SYNNEX SKU (all digits) or manufacturer part number to look up.'
           }
         },
@@ -274,6 +290,16 @@ export function registerCatalogTools(aiTools: Map<string, AiTool>): void {
     handler: async (input, auth) => {
       if (input.query == null || String(input.query).trim() === '') {
         return JSON.stringify({ error: 'Provide a SYNNEX SKU or manufacturer part number in "query"' });
+      }
+      // Seller-side tool: it calls the PARTNER's TD SYNNEX contract (a billed
+      // outbound call) and returns margin data. Organization-scoped callers (an
+      // MSP's customers) must not reach it — and an org MCP token carries the
+      // owning partner's partnerId, so a bare partnerId-presence check is NOT
+      // enough. Gate on scope, matching the web route's requireScope('partner',
+      // 'system'). This also makes the margin redaction in the sanitizer moot for
+      // org (they never get a product back at all).
+      if (auth.scope === 'organization') {
+        return JSON.stringify({ error: 'Distributor lookup is not available to organization-scoped callers' });
       }
       const partnerId = auth.partnerId;
       if (!partnerId) {


### PR DESCRIPTION
Closes #2552.

## Problem
Over the AI/MCP surface you could only reach distributor SKUs **already imported** into the catalog (`search_catalog` matches `attributes.distributor.mfgPartNo`/`.synnexSku`). There was no way to do a **live** price-&-availability lookup for a SKU that isn't catalogued yet — so "price this distributor SKU into a quote" was impossible for the AI, even though the web quote editor's "Search distributor" mode does exactly that.

## Change
New tier-2 read tool **`lookup_distributor_product`** that wraps the existing `lookupEcExpressProducts` (TD SYNNEX EC Express SOAP PNA) service — the same backend the web `DistributorLookup` uses. Given one SKU or manufacturer part number it returns reseller cost, MSRP, currency, total stock, and per-warehouse availability.

### Safety / scoping
- **Partner-scoped** — returns a clear error with **no outbound call** when there's no partner in context (org MCP keys with a null partner can't reach the distributor).
- **Cost redaction** — reseller `cost` is dropped for organization-scoped callers (partner-sensitive), mirroring `sanitizeCatalogItemForAi`. The raw SOAP payload is never exposed to the model.
- **Typed errors as JSON** — provider / no-results errors are returned as `{error, code}` rather than thrown, so the model retries with another SKU or falls back to a manual line instead of a blind loop.
- **Tier 2** (gated on `ai:write`, audited) — consistent with `search_catalog` / `get_catalog_item`; it makes a billed outbound call, so not `ai:read`-only.

### Registered in all three maps (the dual/triple-map parity guard)
`aiToolsCatalog.ts` registry + `aiToolSchemas.ts` (`toolInputSchemas`) + `aiGuardrails.ts` (`TOOL_PERMISSIONS` → `catalog:read`). Surfaces over MCP `tools/list` automatically.

## Tests
`aiToolsCatalog.test.ts` — empty query, no-partner (no outbound call), partner (cost visible, raw dropped), org-scope (cost redacted), and typed provider-error paths. `aiToolsRegistryParity`, `mcpServer`, and `aiGuardrails` suites green; `tsc --noEmit` clean.

## Verification note
Unit-tested against a mocked EC Express service. A true end-to-end check needs a partner with EC Express credentials configured; the live SOAP call is exercised by the existing `tdSynnexEcExpress` tests, which this tool reuses unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)