### PR TITLE
fix(ci): remove duplicate websocket-driver override breaking pnpm-lock

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,6 @@ overrides:
   '@astrojs/node@<10.0.5': '>=10.0.5'
   shell-quote@<1.8.4: '>=1.8.4'
   '@grpc/grpc-js@<1.14.4': '>=1.14.4'
-  websocket-driver@<0.7.5: '>=0.7.5'
 
 importers:
 


### PR DESCRIPTION
**Root cause:** #2547 re-added `websocket-driver@<0.7.5: '>=0.7.5'` to the `overrides:` block in `pnpm-lock.yaml`, which already contained it (lines 9 and 57). Duplicate YAML mapping key → `pnpm install --frozen-lockfile` aborts with `ERR_PNPM_BROKEN_LOCKFILE: duplicated mapping key (57:3)`, which fails **every** JS/TS CI job (Lint, Type Check, Test API/Web/Portal, all add-in tests, Security Audit) on main.

**Fix:** remove the redundant second occurrence; the override remains once at line 9.

**Verified:** `pnpm install --frozen-lockfile` succeeds after the dedupe (Node 22.20.0). Diff is a single line deletion.

Unblocks the release — every PR rebased onto main currently inherits the broken lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)