### PR TITLE
fix(quotes): fix stale mock in cloneQuote test after pax8 select insertion

### DIFF
--- a/apps/api/src/services/quoteService.clone.test.ts
+++ b/apps/api/src/services/quoteService.clone.test.ts
@@ -91,6 +91,10 @@ describe('cloneQuote', () => {
         { id: 'line-parent', quoteId: 'quote-1', blockId: 'block-lines', orgId: 'org-1', sourceType: 'manual', catalogItemId: null, parentLineId: null, name: 'Server', description: null, quantity: '1.00', unitPrice: '100.00', taxable: true, customerVisible: true, lineTotal: '100.00', recurrence: 'one_time', termMonths: null, billingFrequency: null, unitCost: '50.00', depositEligible: true, itemType: 'hardware', sku: 'SKU-1', partNumber: 'PN-1', imageId: 'image-1', sortOrder: 0, createdAt: new Date() },
         { id: 'line-child', quoteId: 'quote-1', blockId: 'block-lines', orgId: 'org-1', sourceType: 'manual', catalogItemId: null, parentLineId: 'line-parent', name: 'Setup', description: null, quantity: '1.00', unitPrice: '0.00', taxable: false, customerVisible: true, lineTotal: '0.00', recurrence: 'one_time', termMonths: null, billingFrequency: null, unitCost: null, depositEligible: false, itemType: 'service', sku: null, partNumber: null, imageId: null, sortOrder: 1, createdAt: new Date() },
       ],
+      // getQuote() also looks up a staged Pax8 order for this quote (#2501); empty
+      // here means "no staged order", which short-circuits the pax8OrderLineSummary
+      // query below it so no extra select is consumed from this queue.
+      [],
       [{ id: 'image-1', quoteId: 'quote-1', orgId: 'org-1', imageData: Buffer.from('image'), mime: 'image/png', byteSize: 5, sha256: 'hash', createdAt: new Date() }],
     );
 


### PR DESCRIPTION
## Summary

Fixes the red `Test API` CI job on `main` (`quoteService.clone.test.ts`).

## Root cause

**Not a product bug** — a stale mock in `quoteService.clone.test.ts` after two independently-merged PRs interacted:

- #2501 (pax8 ordering) added two DB selects inside `getQuote()`: a `pax8OrderSummary` lookup and a conditional `pax8OrderLineSummary` lookup, inserted between the existing `lines` select and `getQuote()`'s return.
- #2535 (quote cloning) added `cloneQuote()`, which calls `getQuote()` and then issues its own `quoteImages` select immediately after.

`quoteService.clone.test.ts` mocks `db.select()` with a shared FIFO queue of canned results, and pushed exactly 4 entries (`quote`, `blocks`, `lines`, `images`) — the correct count *before* #2501 landed. With the extra `pax8OrderSummary` select now spliced into `getQuote()`, the queue's "images" entry was consumed by the `pax8OrderSummary` destructure instead, so the real `quoteImages` select fell through to the queue's empty-array default. `imageIds` ended up an empty `Map`, so remapping the image block's `imageId` legitimately found nothing and `cloneQuote` correctly threw `QuoteServiceError('Quote image could not be cloned', 409, 'IMAGE_NOT_FOUND')`.

Confirmed this can't happen in production: real Postgres queries are scoped by real `WHERE` clauses per table and can't cross-contaminate the way the mock's shared queue does.

## Fix

`apps/api/src/services/quoteService.clone.test.ts`: push one extra empty result for the `pax8OrderSummary` select (i.e. "no staged Pax8 order for this quote"), which also correctly short-circuits the conditional `pax8OrderLineSummary` select exactly as the real code does. This makes the mock's select order match `getQuote()`'s actual current select order.

## Verification

- `pnpm vitest run src/services/quoteService.clone.test.ts src/services/quoteService.test.ts src/services/quoteLifecycle.test.ts` — 31/31 passing (was 1 failing).
- `pnpm vitest run src/services/` (full suite, 5825 tests) — all green except one unrelated pre-existing timing flake in `encryptedColumnRegistry.test.ts` (5000ms scrypt timeout), confirmed to pass in isolation and untouched by this change.
- Node 22.20.0, matching `.nvmrc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)