### PR TITLE
fix(backup): integrity/test-restore detect corruption; restore preserves mode+mtime; install breeze-backup helper

### DIFF
--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -326,6 +326,7 @@ type backupFile struct {
 	snapshotPath string
 	size         int64
 	modTime      time.Time
+	mode         os.FileMode
 }
 
 func (m *BackupManager) collectBackupFiles(cutoff time.Time) ([]backupFile, error) {
@@ -372,6 +373,7 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				snapshotPath: snapshotPath,
 				size:         info.Size(),
 				modTime:      info.ModTime(),
+				mode:         info.Mode(),
 			})
 			continue
 		}
@@ -425,6 +427,7 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				snapshotPath: snapshotPath,
 				size:         info.Size(),
 				modTime:      info.ModTime(),
+				mode:         info.Mode(),
 			})
 			return nil
 		})

--- a/agent/internal/backup/fidelity_test.go
+++ b/agent/internal/backup/fidelity_test.go
@@ -1,0 +1,398 @@
+package backup
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/backup/providers"
+)
+
+// writeFidelityManifest writes a manifest.json for snapshotID under basePath.
+func writeFidelityManifest(t *testing.T, basePath, snapshotID string, manifest Snapshot) {
+	t.Helper()
+	prefix := path.Join(snapshotRootDir, snapshotID)
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(basePath, prefix)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, snapshotManifestKey), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// uploadFidelityObject uploads content as the snapshot object and returns its
+// backupPath. The LocalProvider gzips on upload / gunzips on download, so a
+// verify downloads the original bytes back.
+func uploadFidelityObject(t *testing.T, provider *providers.LocalProvider, snapshotID, name, content string) string {
+	t.Helper()
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, name)
+	if err := os.WriteFile(srcFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	backupPath := path.Join(snapshotRootDir, snapshotID, snapshotFilesDir, name+".gz")
+	if err := provider.Upload(srcFile, backupPath); err != nil {
+		t.Fatal(err)
+	}
+	return backupPath
+}
+
+// U11: a checksum that doesn't match the stored bytes must FAIL integrity —
+// this is the corruption case that previously passed (verify only checked
+// presence, never content).
+func TestVerifyIntegrity_ChecksumMismatchFails(t *testing.T) {
+	basePath := t.TempDir()
+	provider := providers.NewLocalProvider(basePath)
+	snapshotID := "snap-cksum-mismatch"
+	backupPath := uploadFidelityObject(t, provider, snapshotID, "a.txt", "hello world")
+
+	writeFidelityManifest(t, basePath, snapshotID, Snapshot{
+		ID: snapshotID,
+		Files: []SnapshotFile{{
+			SourcePath: "/src/a.txt",
+			BackupPath: backupPath,
+			Size:       11, // correct size, so only the checksum catches it
+			Checksum:   "0000000000000000000000000000000000000000000000000000000000000000",
+		}},
+		Size: 11,
+	})
+
+	result, err := VerifyIntegrity(provider, snapshotID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "failed" {
+		t.Errorf("expected failed on checksum mismatch, got %s", result.Status)
+	}
+	if result.FilesFailed != 1 {
+		t.Errorf("expected 1 file failed, got %d", result.FilesFailed)
+	}
+}
+
+// U11: a size that doesn't match must FAIL (catches truncation / the live
+// 59-vs-39-byte corruption class even on old manifests with no checksum).
+func TestVerifyIntegrity_SizeMismatchFails(t *testing.T) {
+	basePath := t.TempDir()
+	provider := providers.NewLocalProvider(basePath)
+	snapshotID := "snap-size-mismatch"
+	backupPath := uploadFidelityObject(t, provider, snapshotID, "b.txt", "hello world")
+
+	writeFidelityManifest(t, basePath, snapshotID, Snapshot{
+		ID:    snapshotID,
+		Files: []SnapshotFile{{SourcePath: "/src/b.txt", BackupPath: backupPath, Size: 999}}, // wrong size, no checksum
+		Size:  999,
+	})
+
+	result, err := VerifyIntegrity(provider, snapshotID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "failed" {
+		t.Errorf("expected failed on size mismatch, got %s", result.Status)
+	}
+}
+
+// Backward-compat: a manifest with no checksum but a correct size still passes
+// (pre-checksum snapshots must remain verifiable).
+func TestVerifyIntegrity_NoChecksumCorrectSizePasses(t *testing.T) {
+	basePath := t.TempDir()
+	provider := providers.NewLocalProvider(basePath)
+	snapshotID := "snap-legacy-ok"
+	backupPath := uploadFidelityObject(t, provider, snapshotID, "c.txt", "hello world")
+
+	writeFidelityManifest(t, basePath, snapshotID, Snapshot{
+		ID:    snapshotID,
+		Files: []SnapshotFile{{SourcePath: "/src/c.txt", BackupPath: backupPath, Size: 11}}, // no checksum
+		Size:  11,
+	})
+
+	result, err := VerifyIntegrity(provider, snapshotID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "passed" {
+		t.Errorf("legacy (no-checksum) snapshot should pass, got %s (%s)", result.Status, result.Error)
+	}
+	// A size-only verification must be observable, not silently reported as a
+	// full checksum verification.
+	if result.FilesSizeOnly != 1 {
+		t.Errorf("expected FilesSizeOnly=1 for a no-checksum manifest, got %d", result.FilesSizeOnly)
+	}
+}
+
+// A multi-file snapshot with one good + one corrupt file must report "partial",
+// not "passed" — a partially-corrupt backup reported as fully good is a
+// silent-data-loss reporting bug.
+func TestVerifyIntegrity_PartialOnMixedFiles(t *testing.T) {
+	basePath := t.TempDir()
+	provider := providers.NewLocalProvider(basePath)
+	snapshotID := "snap-partial"
+	good := uploadFidelityObject(t, provider, snapshotID, "good.txt", "hello world")
+	bad := uploadFidelityObject(t, provider, snapshotID, "bad.txt", "hello world")
+
+	writeFidelityManifest(t, basePath, snapshotID, Snapshot{
+		ID: snapshotID,
+		Files: []SnapshotFile{
+			{SourcePath: "/src/good.txt", BackupPath: good, Size: 11}, // size-only, matches
+			{SourcePath: "/src/bad.txt", BackupPath: bad, Size: 11,
+				Checksum: "0000000000000000000000000000000000000000000000000000000000000000"}, // wrong checksum
+		},
+		Size: 22,
+	})
+
+	result, err := VerifyIntegrity(provider, snapshotID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "partial" {
+		t.Errorf("expected partial, got %s", result.Status)
+	}
+	if result.FilesVerified != 1 || result.FilesFailed != 1 {
+		t.Errorf("expected 1 verified + 1 failed, got %d/%d", result.FilesVerified, result.FilesFailed)
+	}
+}
+
+// U11 for the TestRestore path: it shares VerifyIntegrity's corruption-detection
+// logic, so it must also fail on a checksum mismatch (correct size).
+func TestTestRestore_ChecksumMismatchFails(t *testing.T) {
+	basePath := t.TempDir()
+	provider := providers.NewLocalProvider(basePath)
+	snapshotID := "snap-tr-cksum"
+	backupPath := uploadFidelityObject(t, provider, snapshotID, "a.txt", "hello world")
+
+	writeFidelityManifest(t, basePath, snapshotID, Snapshot{
+		ID: snapshotID,
+		Files: []SnapshotFile{{SourcePath: "/src/a.txt", BackupPath: backupPath, Size: 11,
+			Checksum: "0000000000000000000000000000000000000000000000000000000000000000"}},
+		Size: 11,
+	})
+
+	result, err := TestRestore(provider, snapshotID, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "failed" || result.FilesFailed != 1 {
+		t.Errorf("expected failed/1, got %s/%d", result.Status, result.FilesFailed)
+	}
+}
+
+// TestRestore must also fail on a size mismatch (catches truncation on legacy
+// no-checksum manifests).
+func TestTestRestore_SizeMismatchFails(t *testing.T) {
+	basePath := t.TempDir()
+	provider := providers.NewLocalProvider(basePath)
+	snapshotID := "snap-tr-size"
+	backupPath := uploadFidelityObject(t, provider, snapshotID, "b.txt", "hello world")
+
+	writeFidelityManifest(t, basePath, snapshotID, Snapshot{
+		ID:    snapshotID,
+		Files: []SnapshotFile{{SourcePath: "/src/b.txt", BackupPath: backupPath, Size: 999}},
+		Size:  999,
+	})
+
+	result, err := TestRestore(provider, snapshotID, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "failed" {
+		t.Errorf("expected failed, got %s", result.Status)
+	}
+}
+
+// The REAL restore path (writes actual user data) must reject a corrupt object,
+// not silently report it "restored".
+func TestRestoreFromSnapshot_ChecksumMismatchFails(t *testing.T) {
+	basePath := t.TempDir()
+	provider := providers.NewLocalProvider(basePath)
+	snapshotID := "snap-restore-cksum"
+	backupPath := uploadFidelityObject(t, provider, snapshotID, "a.txt", "hello world")
+
+	writeFidelityManifest(t, basePath, snapshotID, Snapshot{
+		ID: snapshotID,
+		Files: []SnapshotFile{{SourcePath: "/src/a.txt", BackupPath: backupPath, Size: 11,
+			Checksum: "0000000000000000000000000000000000000000000000000000000000000000"}},
+		Size: 11,
+	})
+
+	targetDir := t.TempDir()
+	result, err := RestoreFromSnapshot(provider, RestoreConfig{SnapshotID: snapshotID, TargetPath: targetDir}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "failed" || result.FilesFailed != 1 {
+		t.Errorf("expected failed/1, got %s/%d", result.Status, result.FilesFailed)
+	}
+	if result.FilesRestored != 0 {
+		t.Errorf("corrupt file must not count as restored, got FilesRestored=%d", result.FilesRestored)
+	}
+	if len(result.Warnings) == 0 {
+		t.Error("expected a warning describing the failed checksum")
+	}
+}
+
+// Backward-compat: a manifest with Mode==0 (older manifest, or a 0000-perm file)
+// must restore cleanly and NOT be chmod'd to 0000.
+func TestRestoreFromSnapshot_Mode0LeavesDefault(t *testing.T) {
+	basePath := t.TempDir()
+	provider := providers.NewLocalProvider(basePath)
+
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "legacy.txt")
+	if err := os.WriteFile(srcFile, []byte("legacy content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, _ := os.Stat(srcFile)
+	// mode: 0 → manifest Mode omitted → restore must leave OS default, not 0000.
+	snap, err := CreateSnapshot(provider, []backupFile{{
+		sourcePath: srcFile, snapshotPath: "path_0/legacy.txt",
+		size: info.Size(), modTime: info.ModTime(), mode: 0,
+	}})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if snap.Files[0].Mode != 0 {
+		t.Fatalf("expected Mode 0 in manifest, got %o", snap.Files[0].Mode)
+	}
+
+	targetDir := t.TempDir()
+	result, err := RestoreFromSnapshot(provider, RestoreConfig{SnapshotID: snap.ID, TargetPath: targetDir}, nil)
+	if err != nil {
+		t.Fatalf("RestoreFromSnapshot: %v", err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("restore status = %s (%v)", result.Status, result.FailedFiles)
+	}
+	restored := resolveTargetPath(targetDir, srcFile)
+	ri, err := os.Stat(restored)
+	if err != nil {
+		t.Fatalf("stat restored: %v", err)
+	}
+	if ri.Mode().Perm() == 0 {
+		t.Error("Mode==0 manifest must NOT chmod the restored file to 0000")
+	}
+}
+
+// The collector is the source of the mode that ends up in the manifest; assert
+// it end-to-end so a regression dropping `mode:` from collectBackupFilesFromPaths
+// can't ship green.
+func TestCollectBackupFiles_CapturesMode(t *testing.T) {
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "m.txt")
+	if err := os.WriteFile(srcFile, []byte("x"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	mgr := NewBackupManager(BackupConfig{Paths: []string{srcFile}})
+	files, err := mgr.collectBackupFiles(time.Time{})
+	if err != nil {
+		t.Fatalf("collectBackupFiles: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	if files[0].mode.Perm() != 0o640 {
+		t.Errorf("expected captured mode 0640, got %o", files[0].mode.Perm())
+	}
+}
+
+// Roundtrip: CreateSnapshot records a real checksum + mode, and a clean verify
+// passes against it (proves the write side and read side agree).
+func TestCreateSnapshot_RecordsChecksumAndMode_VerifyPasses(t *testing.T) {
+	basePath := t.TempDir()
+	provider := providers.NewLocalProvider(basePath)
+
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "r.txt")
+	content := "roundtrip content"
+	if err := os.WriteFile(srcFile, []byte(content), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(srcFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := CreateSnapshot(provider, []backupFile{{
+		sourcePath:   srcFile,
+		snapshotPath: "path_0/r.txt",
+		size:         info.Size(),
+		modTime:      info.ModTime(),
+		mode:         info.Mode(),
+	}})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if snap.Files[0].Checksum == "" {
+		t.Error("expected a checksum in the manifest")
+	}
+	if snap.Files[0].Mode != 0o640 {
+		t.Errorf("expected mode 0640 captured, got %o", snap.Files[0].Mode)
+	}
+
+	result, err := VerifyIntegrity(provider, snap.ID)
+	if err != nil {
+		t.Fatalf("VerifyIntegrity: %v", err)
+	}
+	if result.Status != "passed" {
+		t.Errorf("clean roundtrip verify should pass, got %s (%s)", result.Status, result.Error)
+	}
+}
+
+// U9: restore reapplies the original Unix mode and mtime.
+func TestRestoreFromSnapshot_ReappliesModeAndMtime(t *testing.T) {
+	basePath := t.TempDir()
+	provider := providers.NewLocalProvider(basePath)
+
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "exec.sh")
+	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\necho hi\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	wantMtime := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+	if err := os.Chtimes(srcFile, wantMtime, wantMtime); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(srcFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := CreateSnapshot(provider, []backupFile{{
+		sourcePath:   srcFile,
+		snapshotPath: "path_0/exec.sh",
+		size:         info.Size(),
+		modTime:      info.ModTime(),
+		mode:         info.Mode(),
+	}})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	targetDir := t.TempDir()
+	result, err := RestoreFromSnapshot(provider, RestoreConfig{SnapshotID: snap.ID, TargetPath: targetDir}, nil)
+	if err != nil {
+		t.Fatalf("RestoreFromSnapshot: %v", err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("restore status = %s (%v)", result.Status, result.FailedFiles)
+	}
+
+	restored := resolveTargetPath(targetDir, srcFile)
+	ri, err := os.Stat(restored)
+	if err != nil {
+		t.Fatalf("stat restored file: %v", err)
+	}
+	if ri.Mode().Perm() != 0o700 {
+		t.Errorf("mode not preserved on restore: got %o, want 0700", ri.Mode().Perm())
+	}
+	if !ri.ModTime().Truncate(time.Second).Equal(wantMtime) {
+		t.Errorf("mtime not preserved on restore: got %v, want %v", ri.ModTime(), wantMtime)
+	}
+}

--- a/agent/internal/backup/restore.go
+++ b/agent/internal/backup/restore.go
@@ -203,6 +203,58 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 			continue
 		}
 
+		// Verify the restored bytes against the manifest BEFORE declaring the
+		// file restored. This is the path that writes real user data, so a
+		// corrupt/truncated object must not be silently reported "restored"
+		// (VerifyIntegrity/TestRestore run this same fail-closed check, but only
+		// against throwaway dirs — the real restore needs it too). Size is
+		// always checked; the SHA-256 when the manifest carries one.
+		if info, statErr := os.Stat(targetPath); statErr != nil || info == nil {
+			result.FilesFailed++
+			result.FailedFiles = append(result.FailedFiles, file.SourcePath)
+			slog.Warn("failed to stat restored file", "target", targetPath, "error", fmt.Sprint(statErr))
+			continue
+		} else if info.Size() != file.Size {
+			result.FilesFailed++
+			result.FailedFiles = append(result.FailedFiles, file.SourcePath)
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("restored %s failed size check: manifest %d, restored %d", file.SourcePath, file.Size, info.Size()))
+			slog.Warn("restored file failed size check",
+				"target", targetPath, "manifestSize", file.Size, "restoredSize", info.Size())
+			continue
+		}
+		if file.Checksum != "" && !checksumMatches(targetPath, file.Checksum) {
+			result.FilesFailed++
+			result.FailedFiles = append(result.FailedFiles, file.SourcePath)
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("restored %s failed checksum check (manifest %s)", file.SourcePath, file.Checksum))
+			slog.Warn("restored file failed checksum check", "target", targetPath)
+			continue
+		}
+
+		// Reapply the original Unix permissions + modification time so a restore
+		// is faithful (executables keep +x, 0600 secrets stay private, mtimes
+		// are preserved). Both are best-effort: a chmod/chtimes failure must not
+		// fail an otherwise-good restore, but IS surfaced in result.Warnings so
+		// the caller knows fidelity was partial. Pre-checksum manifests carry
+		// Mode==0 (leave the OS default) / a zero ModTime (leave as written).
+		if file.Mode != 0 {
+			if err := os.Chmod(targetPath, os.FileMode(file.Mode).Perm()); err != nil {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("could not reapply mode %o to %s: %v", os.FileMode(file.Mode).Perm(), file.SourcePath, err))
+				slog.Warn("failed to reapply file mode on restore",
+					"target", targetPath, "mode", file.Mode, "error", err.Error())
+			}
+		}
+		if !file.ModTime.IsZero() {
+			if err := os.Chtimes(targetPath, file.ModTime, file.ModTime); err != nil {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("could not reapply mtime to %s: %v", file.SourcePath, err))
+				slog.Warn("failed to reapply mtime on restore",
+					"target", targetPath, "error", err.Error())
+			}
+		}
+
 		result.FilesRestored++
 		result.BytesRestored += file.Size
 		resumeState.CompletedFiles[file.BackupPath] = true

--- a/agent/internal/backup/snapshot.go
+++ b/agent/internal/backup/snapshot.go
@@ -3,9 +3,12 @@ package backup
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"log/slog"
 	"os"
@@ -16,6 +19,29 @@ import (
 
 	"github.com/breeze-rmm/agent/internal/backup/providers"
 )
+
+// sha256File streams a file through SHA-256 and returns the lowercase-hex
+// digest. Streaming keeps memory flat for large files.
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// checksumMatches reports whether the file at path hashes to want. A hashing
+// error counts as a mismatch (fail-closed) so verification never passes a file
+// it could not read.
+func checksumMatches(path, want string) bool {
+	got, err := sha256File(path)
+	return err == nil && got == want
+}
 
 const (
 	snapshotRootDir     = "snapshots"
@@ -32,11 +58,32 @@ type Snapshot struct {
 }
 
 // SnapshotFile captures metadata for a backed up file.
+//
+// Checksum + Mode were added so integrity/test-restore can detect silent
+// corruption and so restore can reapply Unix permissions. Both are
+// `omitempty`: manifests written before this change carry neither, and the
+// verify/restore paths treat an absent value as "not available" and fall back
+// gracefully (size-only check on verify, default mode on restore).
 type SnapshotFile struct {
 	SourcePath string    `json:"sourcePath"`
 	BackupPath string    `json:"backupPath"`
 	Size       int64     `json:"size"`
 	ModTime    time.Time `json:"modTime"`
+	// Checksum is the lowercase-hex SHA-256 of the ORIGINAL (uncompressed)
+	// source bytes. Verify/restore compare it against the bytes returned by
+	// provider.Download(), which yields the original source bytes for every
+	// provider: the cloud providers (S3/B2/Azure/GCS) store the object verbatim,
+	// and LocalProvider stores it gzip-compressed (the .gz suffix) but
+	// decompresses on download. Do NOT assume the *stored* object equals the
+	// source bytes — that holds only for the cloud providers, not LocalProvider.
+	Checksum string `json:"checksum,omitempty"`
+	// Mode is the file's Unix permission bits (os.FileMode.Perm(), low 9 bits
+	// only — setuid/setgid/sticky are intentionally NOT captured or restored),
+	// reapplied on restore. 0 means "unknown" (an older manifest) → restore
+	// leaves the OS default. Caveat: a file legitimately at mode 0000 also
+	// stores as 0 and is therefore treated as "unknown" (left at the OS default
+	// rather than restored to 0000) — an accepted limitation.
+	Mode uint32 `json:"mode,omitempty"`
 }
 
 type contextUploader interface {
@@ -87,11 +134,31 @@ func CreateSnapshotContext(ctx context.Context, provider providers.BackupProvide
 			continue
 		}
 
+		// Checksum the source bytes so integrity/test-restore can detect silent
+		// corruption of the stored object. A hash failure here is non-fatal —
+		// the file is still backed up; it just won't carry a checksum (verify
+		// falls back to a size check for it).
+		//
+		// NOTE: this re-reads the source after the upload above. On a host with
+		// no snapshotting (Unix has no VSS), a file that mutates between the
+		// upload read and this hash read yields a checksum that won't match the
+		// stored object, so a later verify raises a false "corruption" alert.
+		// That's the safe direction (a false alarm, not a silent pass) and is
+		// consistent with the pre-existing size-from-collection vs content-from-
+		// upload race. Eliminating it fully requires hashing the bytes as they
+		// stream to the provider (a provider-interface change) — left as future work.
+		checksum, sumErr := sha256File(file.sourcePath)
+		if sumErr != nil {
+			log.Printf("[backup] checksum failed for %s: %v", file.sourcePath, sumErr)
+		}
+
 		snapshot.Files = append(snapshot.Files, SnapshotFile{
 			SourcePath: file.sourcePath,
 			BackupPath: backupPath,
 			Size:       file.size,
 			ModTime:    file.modTime,
+			Checksum:   checksum,
+			Mode:       uint32(file.mode.Perm()),
 		})
 		snapshot.Size += file.size
 	}

--- a/agent/internal/backup/verify.go
+++ b/agent/internal/backup/verify.go
@@ -15,9 +15,14 @@ import (
 
 // VerifyResult holds the outcome of a backup integrity check.
 type VerifyResult struct {
-	SnapshotID    string   `json:"snapshotId"`
-	Status        string   `json:"status"` // passed, failed, partial
-	FilesVerified int      `json:"filesVerified"`
+	SnapshotID    string `json:"snapshotId"`
+	Status        string `json:"status"` // passed, failed, partial
+	FilesVerified int    `json:"filesVerified"`
+	// FilesSizeOnly counts files verified by size only because the manifest
+	// carried no checksum for them (an older manifest, or a checksum that
+	// failed to compute at backup time). Non-zero means "passed" is weaker than
+	// a full checksum verification — size-only can't catch same-size bit-rot.
+	FilesSizeOnly int      `json:"filesSizeOnly,omitempty"`
 	FilesFailed   int      `json:"filesFailed"`
 	SizeBytes     int64    `json:"sizeBytes"`
 	DurationMs    int64    `json:"durationMs"`
@@ -103,10 +108,43 @@ func VerifyIntegrity(provider providers.BackupProvider, snapshotID string) (*Ver
 			continue
 		}
 
-		info, _ := os.Stat(tempPath)
-		if info != nil {
-			result.SizeBytes += info.Size()
+		// Validate the downloaded object against the manifest so SILENT
+		// corruption (bit-rot, truncation, tampering) is caught — not just a
+		// missing object. Downloading proves presence; without this a wrong-bytes
+		// object passed as "verified" (the remote/cloud providers, unlike
+		// LocalProvider, do not gzip-validate, and the manifest previously stored
+		// no checksum). Size is always checked; the SHA-256 is checked whenever
+		// the manifest carries one (manifests written before checksums were added
+		// do not — those are counted as size-only via FilesSizeOnly).
+		info, statErr := os.Stat(tempPath)
+		if statErr != nil || info == nil {
+			os.Remove(tempPath)
+			result.FilesFailed++
+			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
+			log.Printf("[backup-verify] stat failed for %s: %v", file.BackupPath, statErr)
+			continue
 		}
+		if info.Size() != file.Size {
+			os.Remove(tempPath)
+			result.FilesFailed++
+			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
+			log.Printf("[backup-verify] size mismatch for %s: manifest %d, stored %d",
+				file.BackupPath, file.Size, info.Size())
+			continue
+		}
+		if file.Checksum != "" {
+			if !checksumMatches(tempPath, file.Checksum) {
+				os.Remove(tempPath)
+				result.FilesFailed++
+				result.FailedFiles = append(result.FailedFiles, file.BackupPath)
+				log.Printf("[backup-verify] checksum mismatch for %s (manifest %s)",
+					file.BackupPath, file.Checksum)
+				continue
+			}
+		} else {
+			result.FilesSizeOnly++
+		}
+		result.SizeBytes += info.Size()
 		os.Remove(tempPath)
 		result.FilesVerified++
 	}
@@ -193,19 +231,30 @@ func TestRestore(provider providers.BackupProvider, snapshotID string, progressF
 		}
 
 		dlErr := provider.Download(file.BackupPath, destPath)
-		if dlErr != nil {
+		info, statErr := os.Stat(destPath)
+		switch {
+		case dlErr != nil:
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
 			log.Printf("[backup-restore] download failed for %s: %v", file.BackupPath, dlErr)
-		} else {
-			info, statErr := os.Stat(destPath)
-			if statErr != nil {
-				result.FilesFailed++
-				result.FailedFiles = append(result.FailedFiles, file.BackupPath)
-			} else {
-				result.FilesVerified++
-				result.SizeBytes += info.Size()
-			}
+		case statErr != nil || info == nil:
+			result.FilesFailed++
+			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
+			log.Printf("[backup-restore] stat failed for %s: %v", file.BackupPath, statErr)
+		case info.Size() != file.Size:
+			// A real test-restore must confirm the bytes came back intact, not
+			// just that a file appeared (same blind spot as VerifyIntegrity).
+			result.FilesFailed++
+			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
+			log.Printf("[backup-restore] size mismatch for %s: manifest %d, restored %d",
+				file.BackupPath, file.Size, info.Size())
+		case file.Checksum != "" && !checksumMatches(destPath, file.Checksum):
+			result.FilesFailed++
+			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
+			log.Printf("[backup-restore] checksum mismatch for %s", file.BackupPath)
+		default:
+			result.FilesVerified++
+			result.SizeBytes += info.Size()
 		}
 
 		if progressFn != nil {

--- a/agent/scripts/install/install-darwin.sh
+++ b/agent/scripts/install/install-darwin.sh
@@ -75,6 +75,25 @@ elif [ -f "breeze-watchdog" ]; then
     chmod 755 /usr/local/bin/breeze-watchdog
 fi
 
+# Install backup helper. The agent spawns breeze-backup from its own directory
+# (os.Executable dir), and neither the updater nor the heartbeat delivers it, so
+# it MUST be on disk next to breeze-agent or every backup fails with
+# "backup binary not found at /usr/local/bin/breeze-backup". The production .pkg
+# (installer/macos/build-pkg.sh) already bundles it; this dev/manual install path
+# must match so `make install-service` yields a working backup setup.
+if [ -f "bin/breeze-backup" ]; then
+    echo "Installing backup helper..."
+    cp bin/breeze-backup /usr/local/bin/breeze-backup
+    chmod 755 /usr/local/bin/breeze-backup
+elif [ -f "breeze-backup" ]; then
+    echo "Installing backup helper..."
+    cp breeze-backup /usr/local/bin/breeze-backup
+    chmod 755 /usr/local/bin/breeze-backup
+else
+    echo "Warning: breeze-backup binary not found — backups will fail with" \
+         "'backup binary not found'. Run 'make build' (or 'make build-backup') first." >&2
+fi
+
 # Register watchdog service
 if [ -f "/usr/local/bin/breeze-watchdog" ]; then
     if [ ! -f "/Library/LaunchDaemons/com.breeze.watchdog.plist" ]; then

--- a/agent/scripts/install/install-linux.sh
+++ b/agent/scripts/install/install-linux.sh
@@ -52,6 +52,25 @@ elif [ -f "breeze-watchdog" ]; then
     chmod 755 /usr/local/bin/breeze-watchdog
 fi
 
+# Install backup helper. The agent spawns breeze-backup from its own directory
+# (os.Executable dir), and neither the updater nor the heartbeat delivers it, so
+# it MUST be on disk next to breeze-agent or every backup fails with
+# "backup binary not found at /usr/local/bin/breeze-backup". The macOS .pkg and
+# Windows MSI already bundle it; this shell-script install path is the Linux
+# install path, so it has to install it too.
+if [ -f "bin/breeze-backup" ]; then
+    echo "Installing backup helper..."
+    cp bin/breeze-backup /usr/local/bin/breeze-backup
+    chmod 755 /usr/local/bin/breeze-backup
+elif [ -f "breeze-backup" ]; then
+    echo "Installing backup helper..."
+    cp breeze-backup /usr/local/bin/breeze-backup
+    chmod 755 /usr/local/bin/breeze-backup
+else
+    echo "Warning: breeze-backup binary not found — backups will fail with" \
+         "'backup binary not found'. Run 'make build' (or 'make build-backup') first." >&2
+fi
+
 # (Re)install the watchdog systemd unit on EVERY install/upgrade.
 #
 # `breeze-watchdog service install` always rewrites the unit file (and runs


### PR DESCRIPTION
Fixes found and verified during a macOS + Linux backup E2E pass (Files mode, Backblaze B2). Two independent fixes to the agent backup subsystem, split into two commits.

## 1. Integrity/Test-Restore was presence-only; restore dropped Unix mode + mtime
`fix(backup): detect corruption in integrity/test-restore + preserve mode/mtime on restore`

**The bug (HIGH):** `VerifyIntegrity` (and `TestRestore`) downloaded each object and summed sizes but **never compared the downloaded size or a checksum against the manifest** — and the manifest stored **no checksum at all**. A backup object corrupted to different bytes (even a different length) passed as "verified". Reproduced live: a corrupted B2 object returned `status=passed, filesVerified=N, failedFiles=[]`. This gives an MSP false confidence that a backup is recoverable when it is not.

**Also (MED):** restore reapplied neither Unix permissions (a `0700` file came back `0644`) nor mtime — the manifest didn't record mode and `restore.go` had no `Chmod`/`Chtimes`. Executables lose `+x`, `0600` secrets become world-readable.

**The fix:**
- `snapshot.go`: `SnapshotFile` now carries `checksum` (SHA-256 of the source bytes) + `mode` (Unix perm bits), both `omitempty` and backward-compatible; added `sha256File` / `checksumMatches` helpers and capture both when building the manifest.
- `backup.go`: `backupFile` records `os.FileMode` at both collection sites.
- `verify.go`: `VerifyIntegrity` **and** `TestRestore` compare downloaded size vs manifest (always) and SHA-256 vs manifest checksum (when present). Pre-checksum manifests still verify via the size check.
- `restore.go`: reapply `os.Chmod` + `os.Chtimes` after each file, best-effort (a chmod/chtimes failure never fails an otherwise-good restore).
- `fidelity_test.go`: checksum-mismatch fails, size-mismatch fails, legacy no-checksum passes, `CreateSnapshot` roundtrip records+verifies, restore reapplies mode+mtime.

**Verified live (macOS + Linux, Backblaze B2):** after the fix, a corrupted object makes Integrity Check report the exact failed file (`partial` + `failedFiles`), and a full restore preserves `0700` + the original mtime with byte-for-byte content.

## 2. Install scripts never installed the backup helper
`fix(agent-install): install breeze-backup helper from install-darwin.sh / install-linux.sh`

**The bug (MED):** the agent resolves `breeze-backup` from its own directory, the updater doesn't manage it, and nothing downloads it at runtime — so it must be on disk at install time. The macOS `.pkg` and Windows MSI bundle it, but the shell-script install path (which **is** the Linux install path, and `make install-service`) copied `breeze-agent` + `breeze-watchdog` and never `breeze-backup`. Every backup on such an install failed with `backup binary not found at /usr/local/bin/breeze-backup`. Fix mirrors the existing `breeze-watchdog` install block.

---

`go test -race ./internal/backup/` + `go vet` clean. Related lower-severity UX/config paper cuts from the same pass are tracked in #2562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
