### PR TITLE
fix(ci): raise Type Check heap to avoid tsc OOM on heavy branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,11 @@ jobs:
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
+    env:
+      # tsc on the full apps/api project (dense Drizzle types) + astro check
+      # exceed Node's default heap on the type-heaviest branches. Give the
+      # type checker a larger old-space so it doesn't OOM. See release-prep OOM.
+      NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
**Problem:** the `typecheck` job (`tsc --noEmit` over the full `apps/api` project + `astro check`) OOMs — `FATAL ERROR: ... JavaScript heap out of memory` — on the type-heaviest feature branches (e.g. #2548 extensions, #2511 m365). Reproduced deterministically on re-run. Main passes today but is at the edge as the Drizzle type graph grows.

**Fix:** set `NODE_OPTIONS=--max-old-space-size=8192` at the `typecheck` job level (covers both `tsc` and `astro check`). No type errors were involved — this is purely heap headroom. ubuntu-latest runners have ~16 GB, so 8 GB old-space is safe.

Unblocks the release: the OOM'ing feature PRs pass Type Check once rebased onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)