### PR TITLE
fix(backup): Windows system_image (system state) broken end-to-end

### DIFF
--- a/agent/cmd/breeze-backup/exec_backup.go
+++ b/agent/cmd/breeze-backup/exec_backup.go
@@ -88,6 +88,7 @@ func managerFromBackupRunPayload(payload json.RawMessage) (*backup.BackupManager
 		Provider       string                   `json:"provider"`
 		ProviderConfig *backupRunProviderConfig `json:"providerConfig"`
 		Paths          []string                 `json:"paths"`
+		SystemImage    bool                     `json:"systemImage"`
 	}
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return nil, fmt.Errorf("invalid backup_run payload: %w", err)
@@ -105,6 +106,20 @@ func managerFromBackupRunPayload(payload json.RawMessage) (*backup.BackupManager
 		provider = providers.NewLocalProvider(p.ProviderConfig.Path)
 	default:
 		return nil, fmt.Errorf("unsupported backup provider %q", p.Provider)
+	}
+	// system_image mode carries no file paths: the backup content is the
+	// collected system-state staging dir. The server fans a `system_image`
+	// selection out as a backup_run with `systemImage:true` and no `paths`
+	// (backupWorker.ts resolveBackupTargets), so enable system-state collection
+	// and skip the file-paths requirement below.
+	if p.SystemImage {
+		// Retention: 0 — same server-owns-retention invariant as the file-mode
+		// path below: the agent must never prune remote storage itself and race
+		// the server's GFS/legal-hold/immutability authority.
+		return backup.NewBackupManager(backup.BackupConfig{
+			Provider:           provider,
+			SystemStateEnabled: true,
+		}), nil
 	}
 	if len(p.Paths) == 0 {
 		return nil, fmt.Errorf("backup_run payload has no paths")

--- a/agent/cmd/breeze-backup/exec_backup.go
+++ b/agent/cmd/breeze-backup/exec_backup.go
@@ -113,9 +113,10 @@ func managerFromBackupRunPayload(payload json.RawMessage) (*backup.BackupManager
 	// (backupWorker.ts resolveBackupTargets), so enable system-state collection
 	// and skip the file-paths requirement below.
 	if p.SystemImage {
-		// Retention: 0 — same server-owns-retention invariant as the file-mode
-		// path below: the agent must never prune remote storage itself and race
-		// the server's GFS/legal-hold/immutability authority.
+		// BackupConfig.Retention is left at its zero value (0) — same
+		// server-owns-retention invariant as the file-mode path below (which
+		// sets it explicitly): the agent must never prune remote storage itself
+		// and race the server's GFS/legal-hold/immutability authority.
 		return backup.NewBackupManager(backup.BackupConfig{
 			Provider:           provider,
 			SystemStateEnabled: true,

--- a/agent/cmd/breeze-backup/exec_backup_test.go
+++ b/agent/cmd/breeze-backup/exec_backup_test.go
@@ -252,14 +252,15 @@ func TestExecBMRRecoverUsesTokenDrivenRunner(t *testing.T) {
 
 func TestManagerFromBackupRunPayload(t *testing.T) {
 	tests := []struct {
-		name         string
-		payload      string
-		wantNil      bool // manager is nil (fall back to agent.yaml manager)
-		wantErr      bool
-		wantProvider string   // "s3" | "local" | "" (skip provider assertion)
-		wantBucket   string   // for s3
-		wantBasePath string   // for local
-		wantPaths    []string // expected manager paths
+		name            string
+		payload         string
+		wantNil         bool // manager is nil (fall back to agent.yaml manager)
+		wantErr         bool
+		wantProvider    string   // "s3" | "local" | "" (skip provider assertion)
+		wantBucket      string   // for s3
+		wantBasePath    string   // for local
+		wantPaths       []string // expected manager paths
+		wantSystemImage bool     // expected SystemStateEnabled
 	}{
 		{
 			name:    "empty payload falls back to agent.yaml manager",
@@ -305,6 +306,17 @@ func TestManagerFromBackupRunPayload(t *testing.T) {
 			payload: `{"provider":`,
 			wantErr: true,
 		},
+		{
+			// The server fans a `system_image` selection out as a backup_run
+			// carrying `systemImage:true` and no `paths` (backupWorker.ts
+			// resolveBackupTargets). Before the fix this tripped the "backup_run
+			// payload has no paths" guard and the job failed outright.
+			name:            "system_image mode needs no paths",
+			payload:         `{"provider":"s3","providerConfig":{"bucket":"my-bucket","region":"us-east-1","accessKey":"AK","secretKey":"SK"},"systemImage":true}`,
+			wantProvider:    "s3",
+			wantBucket:      "my-bucket",
+			wantSystemImage: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -343,6 +355,10 @@ func TestManagerFromBackupRunPayload(t *testing.T) {
 				if gotPaths[i] != tt.wantPaths[i] {
 					t.Errorf("paths[%d] = %q, want %q", i, gotPaths[i], tt.wantPaths[i])
 				}
+			}
+
+			if got := mgr.GetSystemStateEnabled(); got != tt.wantSystemImage {
+				t.Fatalf("SystemStateEnabled = %v, want %v", got, tt.wantSystemImage)
 			}
 
 			provider := mgr.GetProvider()

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -266,10 +266,11 @@ func (m *BackupManager) RunBackupWithExcludes(excludes []string) (*BackupJob, er
 			log.Printf("[backup] system state collection failed, proceeding without: %v", ssErr)
 		} else {
 			job.SystemStateManifest = manifest
-			// A partial collection still returns a manifest (best-effort steps).
-			// Surface which classes failed as a completion warning so a degraded
-			// system_image — e.g. missing registry/boot, which a bare-metal
-			// restore can't boot without — doesn't pass as a full capture.
+			// Collection succeeded on all *required* artifacts (missing a
+			// required class returns an error above and fails the run). Any
+			// remaining incomplete steps are best-effort classes (certs, iis,
+			// ...) — surface them as a completion warning so a degraded capture
+			// is visible without discarding an otherwise-usable backup.
 			if len(manifest.IncompleteSteps) > 0 {
 				job.Warning = fmt.Sprintf("system state collection incomplete: %v failed", manifest.IncompleteSteps)
 				log.Printf("[backup] %s", job.Warning)

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -47,13 +47,13 @@ type BackupConfig struct {
 // `bytesBackedUp`, `filesBackedUp`). Without tags Go emits PascalCase and the
 // server can't record snapshot id / size (total_size stays null).
 type BackupJob struct {
-	ID                  string                           `json:"id"`
-	StartedAt           time.Time                        `json:"startedAt"`
-	CompletedAt         time.Time                        `json:"completedAt"`
-	Snapshot            *Snapshot                        `json:"snapshot"`
-	FilesBackedUp       int                              `json:"filesBackedUp"`
-	BytesBackedUp       int64                            `json:"bytesBackedUp"`
-	Status              string                           `json:"status"`
+	ID            string    `json:"id"`
+	StartedAt     time.Time `json:"startedAt"`
+	CompletedAt   time.Time `json:"completedAt"`
+	Snapshot      *Snapshot `json:"snapshot"`
+	FilesBackedUp int       `json:"filesBackedUp"`
+	BytesBackedUp int64     `json:"bytesBackedUp"`
+	Status        string    `json:"status"`
 	// Error is the agent's internal failure record. It is NOT the wire failure
 	// carrier: marshaling a non-nil `error` interface yields `{}`, and the
 	// server's backupCommandResultSchema doesn't read an `error` field anyway.
@@ -111,6 +111,12 @@ func (m *BackupManager) GetStagingDir() string {
 	return m.config.StagingDir
 }
 
+// GetSystemStateEnabled reports whether this manager collects system state
+// (system_image mode) alongside/instead of file paths.
+func (m *BackupManager) GetSystemStateEnabled() bool {
+	return m.config.SystemStateEnabled
+}
+
 // Stop cancels an in-flight backup job and waits for it to unwind. It reports
 // whether a job was actually running (false = nothing to stop).
 func (m *BackupManager) Stop() bool {
@@ -158,7 +164,11 @@ func (m *BackupManager) RunBackupWithExcludes(excludes []string) (*BackupJob, er
 	if m.config.Provider == nil {
 		return nil, errors.New("backup provider is required")
 	}
-	if len(m.config.Paths) == 0 {
+	// A system-state-only run (system_image mode) legitimately has no file
+	// paths — the collected system-state staging dir is appended to
+	// backupPaths below and becomes the entire snapshot. Only require file
+	// paths when system-state collection is off.
+	if len(m.config.Paths) == 0 && !m.config.SystemStateEnabled {
 		return nil, errors.New("backup paths are required")
 	}
 
@@ -233,12 +243,14 @@ func (m *BackupManager) RunBackupWithExcludes(excludes []string) (*BackupJob, er
 	}
 
 	// System state collection: gather OS config, hardware profile, etc.
+	var systemStateErr error
 	if m.config.SystemStateEnabled {
 		if err := ctx.Err(); err != nil {
 			return stopBackupRun()
 		}
 		manifest, stagingDir, ssErr := systemstate.CollectSystemState()
 		if ssErr != nil {
+			systemStateErr = ssErr
 			log.Printf("[backup] system state collection failed, proceeding without: %v", ssErr)
 		} else {
 			job.SystemStateManifest = manifest
@@ -271,6 +283,20 @@ func (m *BackupManager) RunBackupWithExcludes(excludes []string) (*BackupJob, er
 	if len(files) == 0 {
 		if err := ctx.Err(); err != nil {
 			return stopBackupRun()
+		}
+		// A system-state-only run (no configured file paths) that produced
+		// nothing is a hard failure, not a no-op skip: there are no files to
+		// fall back on, so a green empty snapshot would silently protect
+		// nothing. Surface the collection error (or a synthetic one).
+		if m.config.SystemStateEnabled && len(m.config.Paths) == 0 {
+			runErr := systemStateErr
+			if runErr == nil {
+				runErr = errors.New("system state collection produced no artifacts")
+			}
+			job.Status = jobStatusFailed
+			job.CompletedAt = time.Now().UTC()
+			job.Error = errors.Join(scanErr, runErr)
+			return job, job.Error
 		}
 		job.Status = jobStatusSkipped
 		job.CompletedAt = time.Now().UTC()

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -29,6 +29,12 @@ const (
 
 var errBackupStopped = errors.New("backup stopped")
 
+// collectSystemState is a seam over systemstate.CollectSystemState so tests can
+// exercise the failure and partial-collection paths deterministically — the
+// real collector shells out to OS tools and succeeds on any CI host, which
+// would otherwise leave the system-state fail-loud/warning branches uncovered.
+var collectSystemState = systemstate.CollectSystemState
+
 // BackupConfig defines backup configuration settings.
 type BackupConfig struct {
 	Provider           providers.BackupProvider
@@ -61,7 +67,13 @@ type BackupJob struct {
 	// routes it to the command result's stderr, and the server reads the reason
 	// from `result.error || result.stderr` (routes/agentWs.ts). Keep this field
 	// for in-process inspection (e.g. autoSyncToVault) only.
-	Error               error                            `json:"error,omitempty"`
+	Error error `json:"error,omitempty"`
+	// Warning is a non-fatal completion note surfaced to the server (the
+	// backupCommandResultSchema `warning` field → the job's errorLog → UI). Used
+	// when a run completes but is degraded — e.g. a partial system-state
+	// collection where some artifact classes failed — so a partial system_image
+	// backup doesn't silently present as a full, restorable capture.
+	Warning             string                           `json:"warning,omitempty"`
 	VSSMetadata         *vss.VSSMetadata                 `json:"vssMetadata,omitempty"`         // nil when VSS was not used
 	SystemStateManifest *systemstate.SystemStateManifest `json:"systemStateManifest,omitempty"` // nil when system state was not collected
 }
@@ -248,12 +260,20 @@ func (m *BackupManager) RunBackupWithExcludes(excludes []string) (*BackupJob, er
 		if err := ctx.Err(); err != nil {
 			return stopBackupRun()
 		}
-		manifest, stagingDir, ssErr := systemstate.CollectSystemState()
+		manifest, stagingDir, ssErr := collectSystemState()
 		if ssErr != nil {
 			systemStateErr = ssErr
 			log.Printf("[backup] system state collection failed, proceeding without: %v", ssErr)
 		} else {
 			job.SystemStateManifest = manifest
+			// A partial collection still returns a manifest (best-effort steps).
+			// Surface which classes failed as a completion warning so a degraded
+			// system_image — e.g. missing registry/boot, which a bare-metal
+			// restore can't boot without — doesn't pass as a full capture.
+			if len(manifest.IncompleteSteps) > 0 {
+				job.Warning = fmt.Sprintf("system state collection incomplete: %v failed", manifest.IncompleteSteps)
+				log.Printf("[backup] %s", job.Warning)
+			}
 			// Append staging dir to backup paths so artifacts are included in snapshot
 			backupPaths = append(backupPaths, stagingDir)
 			defer func() {

--- a/agent/internal/backup/backup_test.go
+++ b/agent/internal/backup/backup_test.go
@@ -263,6 +263,23 @@ func TestRunBackup_SystemStateDoesNotMutateConfiguredPaths(t *testing.T) {
 	}
 }
 
+func TestRunBackup_SystemStateOnly_NoPathsAllowed(t *testing.T) {
+	// system_image mode runs with no configured file paths — the collected
+	// system-state staging dir is the whole snapshot. The "backup paths are
+	// required" guard must NOT fire. Collection itself may succeed or fail
+	// depending on the host, so we only assert the guard is not what stopped it.
+	provider := newMockProvider()
+	mgr := NewBackupManager(BackupConfig{
+		Provider:           provider,
+		SystemStateEnabled: true,
+	})
+
+	_, err := mgr.RunBackup()
+	if err != nil && strings.Contains(err.Error(), "backup paths are required") {
+		t.Fatalf("system-state-only run must not be rejected for missing paths: %v", err)
+	}
+}
+
 func TestRunBackup_MultiplePaths(t *testing.T) {
 	tmpDir := t.TempDir()
 	dir1 := pathpkg.Join(tmpDir, "dir1")

--- a/agent/internal/backup/backup_test.go
+++ b/agent/internal/backup/backup_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/breeze-rmm/agent/internal/backup/systemstate"
 )
 
 type blockingUploadProvider struct {
@@ -263,20 +265,98 @@ func TestRunBackup_SystemStateDoesNotMutateConfiguredPaths(t *testing.T) {
 	}
 }
 
-func TestRunBackup_SystemStateOnly_NoPathsAllowed(t *testing.T) {
+// stubCollectSystemState swaps the package-level collector seam for the test
+// and restores it on cleanup.
+func stubCollectSystemState(t *testing.T, fn func() (*systemstate.SystemStateManifest, string, error)) {
+	t.Helper()
+	orig := collectSystemState
+	t.Cleanup(func() { collectSystemState = orig })
+	collectSystemState = fn
+}
+
+func TestRunBackup_SystemImage_NoPathsAllowed(t *testing.T) {
 	// system_image mode runs with no configured file paths — the collected
-	// system-state staging dir is the whole snapshot. The "backup paths are
-	// required" guard must NOT fire. Collection itself may succeed or fail
-	// depending on the host, so we only assert the guard is not what stopped it.
-	provider := newMockProvider()
-	mgr := NewBackupManager(BackupConfig{
-		Provider:           provider,
-		SystemStateEnabled: true,
+	// system-state staging dir is the whole snapshot, so the "backup paths are
+	// required" guard must NOT fire.
+	stagingDir := t.TempDir()
+	if err := os.WriteFile(pathpkg.Join(stagingDir, "services.txt"), []byte("svc"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
+		return &systemstate.SystemStateManifest{Platform: "test"}, stagingDir, nil
 	})
 
-	_, err := mgr.RunBackup()
-	if err != nil && strings.Contains(err.Error(), "backup paths are required") {
-		t.Fatalf("system-state-only run must not be rejected for missing paths: %v", err)
+	mgr := NewBackupManager(BackupConfig{Provider: newMockProvider(), SystemStateEnabled: true})
+	job, err := mgr.RunBackup()
+	if err != nil {
+		t.Fatalf("system-state-only run should succeed with collected artifacts: %v", err)
+	}
+	if job.Status != jobStatusCompleted {
+		t.Fatalf("status = %q, want completed", job.Status)
+	}
+}
+
+func TestRunBackup_SystemImage_CollectionFailureFailsLoud(t *testing.T) {
+	// A system-state-only run whose collection fails entirely must fail loudly,
+	// not fall through to a green empty snapshot (it has no file paths to fall
+	// back on). The bug this guards: silently "protecting nothing".
+	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
+		return nil, "", fmt.Errorf("forced collection failure")
+	})
+
+	mgr := NewBackupManager(BackupConfig{Provider: newMockProvider(), SystemStateEnabled: true})
+	job, err := mgr.RunBackup()
+	if err == nil {
+		t.Fatal("expected failed collection to surface as an error")
+	}
+	if job == nil || job.Status != jobStatusFailed {
+		t.Fatalf("status = %v, want %q", job, jobStatusFailed)
+	}
+}
+
+func TestRunBackup_SystemImage_EmptyCollectionFailsLoud(t *testing.T) {
+	// Collection "succeeded" but produced zero artifacts (empty staging dir) →
+	// still a hard failure with a synthetic reason, not a skip.
+	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
+		return &systemstate.SystemStateManifest{Platform: "test"}, t.TempDir(), nil
+	})
+
+	mgr := NewBackupManager(BackupConfig{Provider: newMockProvider(), SystemStateEnabled: true})
+	job, err := mgr.RunBackup()
+	if err == nil || job == nil || job.Status != jobStatusFailed {
+		t.Fatalf("empty system-state collection should fail loudly; got job=%v err=%v", job, err)
+	}
+	if !strings.Contains(err.Error(), "no artifacts") {
+		t.Fatalf("expected synthetic no-artifacts error, got: %v", err)
+	}
+}
+
+func TestRunBackup_SystemImage_PartialCollectionWarns(t *testing.T) {
+	// A partial collection (some artifact classes captured, others failed) still
+	// completes, but must surface a warning so a degraded system_image doesn't
+	// silently present as a full, restorable capture.
+	stagingDir := t.TempDir()
+	if err := os.WriteFile(pathpkg.Join(stagingDir, "services.txt"), []byte("svc"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
+		return &systemstate.SystemStateManifest{
+			Platform:        "test",
+			Artifacts:       []systemstate.Artifact{{Name: "services", Category: "services"}},
+			IncompleteSteps: []string{"registry", "boot"},
+		}, stagingDir, nil
+	})
+
+	mgr := NewBackupManager(BackupConfig{Provider: newMockProvider(), SystemStateEnabled: true})
+	job, err := mgr.RunBackup()
+	if err != nil {
+		t.Fatalf("partial collection with artifacts should complete: %v", err)
+	}
+	if job.Status != jobStatusCompleted {
+		t.Fatalf("status = %q, want completed", job.Status)
+	}
+	if !strings.Contains(job.Warning, "registry") || !strings.Contains(job.Warning, "incomplete") {
+		t.Fatalf("expected incomplete-steps warning, got %q", job.Warning)
 	}
 }
 

--- a/agent/internal/backup/backup_test.go
+++ b/agent/internal/backup/backup_test.go
@@ -332,9 +332,10 @@ func TestRunBackup_SystemImage_EmptyCollectionFailsLoud(t *testing.T) {
 }
 
 func TestRunBackup_SystemImage_PartialCollectionWarns(t *testing.T) {
-	// A partial collection (some artifact classes captured, others failed) still
-	// completes, but must surface a warning so a degraded system_image doesn't
-	// silently present as a full, restorable capture.
+	// A partial collection of *optional* classes (certs/iis) still completes,
+	// but must surface a warning so a degraded system_image is visible. (A
+	// missing *required* class returns an error from the collector and fails the
+	// run instead — see TestRunBackup_SystemImage_CollectionFailureFailsLoud.)
 	stagingDir := t.TempDir()
 	if err := os.WriteFile(pathpkg.Join(stagingDir, "services.txt"), []byte("svc"), 0o600); err != nil {
 		t.Fatal(err)
@@ -343,7 +344,7 @@ func TestRunBackup_SystemImage_PartialCollectionWarns(t *testing.T) {
 		return &systemstate.SystemStateManifest{
 			Platform:        "test",
 			Artifacts:       []systemstate.Artifact{{Name: "services", Category: "services"}},
-			IncompleteSteps: []string{"registry", "boot"},
+			IncompleteSteps: []string{"certs", "iis"},
 		}, stagingDir, nil
 	})
 
@@ -355,7 +356,7 @@ func TestRunBackup_SystemImage_PartialCollectionWarns(t *testing.T) {
 	if job.Status != jobStatusCompleted {
 		t.Fatalf("status = %q, want completed", job.Status)
 	}
-	if !strings.Contains(job.Warning, "registry") || !strings.Contains(job.Warning, "incomplete") {
+	if !strings.Contains(job.Warning, "certs") || !strings.Contains(job.Warning, "incomplete") {
 		t.Fatalf("expected incomplete-steps warning, got %q", job.Warning)
 	}
 }

--- a/agent/internal/backup/systemstate/hw_windows.go
+++ b/agent/internal/backup/systemstate/hw_windows.go
@@ -4,7 +4,9 @@ package systemstate
 
 import (
 	"encoding/csv"
+	"errors"
 	"io"
+	"log/slog"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -116,16 +118,35 @@ func (c *WindowsCollector) CollectHardwareProfile() (*HardwareProfile, error) {
 // cimCSV queries a CIM/WMI class via PowerShell and returns CSV (header row =
 // the requested property names, matching csvField lookups). filter is an
 // optional WQL filter (e.g. "NetConnectionStatus=2"); pass "" for none.
+//
+// SAFETY: className, filter, and props are ALL interpolated raw into the
+// PowerShell -Command script. Every current caller passes code-defined string
+// literals, so there is no injection surface. This invariant MUST hold — never
+// pass a caller/agent/server-controlled value here. A dynamic -Filter in
+// particular would allow PowerShell/WQL injection into a script that runs with
+// the agent's (typically SYSTEM) privileges; parameterize or strictly validate
+// before introducing any non-literal argument.
 func cimCSV(className, filter string, props ...string) ([]byte, error) {
-	// Property names are compile-time constants from this file (never user
-	// input), so string interpolation into the -Command script is safe here.
 	script := "Get-CimInstance -ClassName " + className
 	if filter != "" {
 		script += " -Filter '" + filter + "'"
 	}
 	script += " | Select-Object " + strings.Join(props, ",") + " | ConvertTo-Csv -NoTypeInformation"
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
-	return cmd.Output()
+	out, err := cmd.Output()
+	if err != nil {
+		// Don't let CIM failures vanish silently: an unlogged failure here is
+		// exactly how the wmic path shipped all-zero hardware profiles. Include
+		// PowerShell's stderr (blocked execution policy, Constrained Language
+		// Mode, missing binary, etc.) so the zeros are diagnosable.
+		var stderr string
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			stderr = strings.TrimSpace(string(exitErr.Stderr))
+		}
+		slog.Warn("systemstate: CIM query failed", "class", className, "error", err.Error(), "stderr", stderr)
+	}
+	return out, err
 }
 
 func firstCSVRow(data []byte) map[string]string {
@@ -136,7 +157,7 @@ func firstCSVRow(data []byte) map[string]string {
 	return rows[0]
 }
 
-// allCSVRows parses WMIC CSV output into a slice of header->value maps.
+// allCSVRows parses ConvertTo-Csv output into a slice of header->value maps.
 func allCSVRows(data []byte) []map[string]string {
 	r := csv.NewReader(strings.NewReader(string(data)))
 	r.LazyQuotes = true

--- a/agent/internal/backup/systemstate/hw_windows.go
+++ b/agent/internal/backup/systemstate/hw_windows.go
@@ -10,12 +10,16 @@ import (
 	"strings"
 )
 
-// CollectHardwareProfile captures hardware info using WMI queries.
+// CollectHardwareProfile captures hardware info via CIM/WMI. It uses PowerShell
+// Get-CimInstance rather than wmic.exe: wmic is deprecated and, on Windows
+// Server 2022 / Windows 11 (build 20348+), no longer installed by default, so
+// the old wmic path silently returned zero cores / zero memory (see the
+// system_image backup E2E — hardware_profile came back all-zero on Server 2022).
 func (c *WindowsCollector) CollectHardwareProfile() (*HardwareProfile, error) {
 	hw := &HardwareProfile{}
 
 	// CPU
-	if out, err := wmicCSV("cpu", "name", "numberofcores"); err == nil {
+	if out, err := cimCSV("Win32_Processor", "", "Name", "NumberOfCores"); err == nil {
 		if row := firstCSVRow(out); row != nil {
 			hw.CPUModel = csvField(row, "Name")
 			hw.CPUCores, _ = strconv.Atoi(csvField(row, "NumberOfCores"))
@@ -23,7 +27,7 @@ func (c *WindowsCollector) CollectHardwareProfile() (*HardwareProfile, error) {
 	}
 
 	// Memory
-	if out, err := wmicCSV("computersystem", "totalphysicalmemory"); err == nil {
+	if out, err := cimCSV("Win32_ComputerSystem", "", "TotalPhysicalMemory"); err == nil {
 		if row := firstCSVRow(out); row != nil {
 			bytes, _ := strconv.ParseInt(csvField(row, "TotalPhysicalMemory"), 10, 64)
 			hw.TotalMemoryMB = bytes / (1024 * 1024)
@@ -31,7 +35,7 @@ func (c *WindowsCollector) CollectHardwareProfile() (*HardwareProfile, error) {
 	}
 
 	// Disks
-	if out, err := wmicCSV("diskdrive", "name", "size", "model"); err == nil {
+	if out, err := cimCSV("Win32_DiskDrive", "", "Name", "Size", "Model"); err == nil {
 		for _, row := range allCSVRows(out) {
 			sz, _ := strconv.ParseInt(csvField(row, "Size"), 10, 64)
 			hw.Disks = append(hw.Disks, DiskInfo{
@@ -43,7 +47,7 @@ func (c *WindowsCollector) CollectHardwareProfile() (*HardwareProfile, error) {
 	}
 
 	// Partitions (logical disks)
-	if out, err := wmicCSV("logicaldisk", "name", "filesystem", "size", "freespace", "volumename"); err == nil {
+	if out, err := cimCSV("Win32_LogicalDisk", "", "Name", "FileSystem", "Size", "FreeSpace", "VolumeName"); err == nil {
 		for _, row := range allCSVRows(out) {
 			sz, _ := strconv.ParseInt(csvField(row, "Size"), 10, 64)
 			free, _ := strconv.ParseInt(csvField(row, "FreeSpace"), 10, 64)
@@ -73,8 +77,8 @@ func (c *WindowsCollector) CollectHardwareProfile() (*HardwareProfile, error) {
 		}
 	}
 
-	// NICs
-	if out, err := wmicCSV("nic where \"netconnectionstatus=2\"", "name", "macaddress"); err == nil {
+	// NICs (connected: NetConnectionStatus=2)
+	if out, err := cimCSV("Win32_NetworkAdapter", "NetConnectionStatus=2", "Name", "MACAddress"); err == nil {
 		for _, row := range allCSVRows(out) {
 			hw.NetworkAdapters = append(hw.NetworkAdapters, NICInfo{
 				Name:       csvField(row, "Name"),
@@ -84,7 +88,7 @@ func (c *WindowsCollector) CollectHardwareProfile() (*HardwareProfile, error) {
 	}
 
 	// BIOS
-	if out, err := wmicCSV("bios", "smbiosbiosversion"); err == nil {
+	if out, err := cimCSV("Win32_BIOS", "", "SMBIOSBIOSVersion"); err == nil {
 		if row := firstCSVRow(out); row != nil {
 			hw.BIOSVersion = csvField(row, "SMBIOSBIOSVersion")
 		}
@@ -96,7 +100,7 @@ func (c *WindowsCollector) CollectHardwareProfile() (*HardwareProfile, error) {
 	}
 
 	// Motherboard
-	if out, err := wmicCSV("baseboard", "manufacturer", "product"); err == nil {
+	if out, err := cimCSV("Win32_BaseBoard", "", "Manufacturer", "Product"); err == nil {
 		if row := firstCSVRow(out); row != nil {
 			hw.Motherboard = csvField(row, "Manufacturer") + " " + csvField(row, "Product")
 		}
@@ -106,13 +110,21 @@ func (c *WindowsCollector) CollectHardwareProfile() (*HardwareProfile, error) {
 }
 
 // ---------------------------------------------------------------------------
-// WMIC CSV helpers
+// CIM (Get-CimInstance) CSV helpers
 // ---------------------------------------------------------------------------
 
-func wmicCSV(alias string, fields ...string) ([]byte, error) {
-	parts := strings.Fields(alias)
-	cmdArgs := append(parts[1:], "get", strings.Join(fields, ","), "/format:csv")
-	cmd := exec.Command("wmic", append([]string{parts[0]}, cmdArgs...)...)
+// cimCSV queries a CIM/WMI class via PowerShell and returns CSV (header row =
+// the requested property names, matching csvField lookups). filter is an
+// optional WQL filter (e.g. "NetConnectionStatus=2"); pass "" for none.
+func cimCSV(className, filter string, props ...string) ([]byte, error) {
+	// Property names are compile-time constants from this file (never user
+	// input), so string interpolation into the -Command script is safe here.
+	script := "Get-CimInstance -ClassName " + className
+	if filter != "" {
+		script += " -Filter '" + filter + "'"
+	}
+	script += " | Select-Object " + strings.Join(props, ",") + " | ConvertTo-Csv -NoTypeInformation"
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
 	return cmd.Output()
 }
 

--- a/agent/internal/backup/systemstate/state_windows.go
+++ b/agent/internal/backup/systemstate/state_windows.go
@@ -18,6 +18,15 @@ import (
 // Windows features, and IIS configuration.
 type WindowsCollector struct{}
 
+// windowsRequiredSteps are the collection steps whose failure makes a Windows
+// system_image unbootable/unrestorable. If any of these fails, CollectState
+// returns an error so the backup fails hard instead of shipping a partial that
+// presents as a complete capture.
+var windowsRequiredSteps = map[string]bool{
+	"registry": true,
+	"boot":     true,
+}
+
 // NewCollector returns a WindowsCollector.
 func NewCollector() Collector {
 	return &WindowsCollector{}
@@ -62,6 +71,14 @@ func (c *WindowsCollector) CollectState(stagingDir string) (*SystemStateManifest
 
 	if len(manifest.Artifacts) == 0 {
 		return manifest, fmt.Errorf("system state collection produced no artifacts — all %d steps failed", len(steps))
+	}
+
+	// Registry hives and boot config are required for a bootable bare-metal
+	// restore; a system_image missing either is not restorable, so fail hard
+	// rather than shipping a partial that looks complete. Other steps (certs,
+	// iis, firewall, ...) are best-effort and only warn (see IncompleteSteps).
+	if missing := missingRequired(manifest.IncompleteSteps, windowsRequiredSteps); len(missing) > 0 {
+		return manifest, fmt.Errorf("system state collection missing required artifact(s) %v — image would not be restorable", missing)
 	}
 
 	// Attach hardware profile (best-effort).

--- a/agent/internal/backup/systemstate/state_windows.go
+++ b/agent/internal/backup/systemstate/state_windows.go
@@ -54,6 +54,7 @@ func (c *WindowsCollector) CollectState(stagingDir string) (*SystemStateManifest
 		arts, err := s.fn(stagingDir)
 		if err != nil {
 			slog.Warn("systemstate: step failed", "step", s.name, "error", err.Error())
+			manifest.IncompleteSteps = append(manifest.IncompleteSteps, s.name)
 			continue
 		}
 		manifest.Artifacts = append(manifest.Artifacts, arts...)
@@ -94,6 +95,13 @@ func (c *WindowsCollector) collectRegistry(stagingDir string) ([]Artifact, error
 			continue
 		}
 		artifacts = append(artifacts, artifactFromFile("registry_"+hive, "registry", outPath, stagingDir))
+	}
+	// Every Windows machine has SYSTEM/SOFTWARE hives, so capturing none is a
+	// real failure (e.g. the helper lacks the required privilege), not an
+	// "optional artifact absent" case. Report it so CollectState flags the
+	// step incomplete rather than silently producing an unbootable backup.
+	if len(artifacts) == 0 {
+		return nil, fmt.Errorf("reg save captured no registry hives")
 	}
 	return artifacts, nil
 }

--- a/agent/internal/backup/systemstate/systemstate.go
+++ b/agent/internal/backup/systemstate/systemstate.go
@@ -35,6 +35,22 @@ func CollectSystemState() (manifest *SystemStateManifest, stagingDir string, err
 	return manifest, stagingDir, nil
 }
 
+// missingRequired returns the subset of failed (incomplete) collection steps
+// that are required for a restorable system image. A non-empty result means the
+// collection must be treated as a hard failure rather than a best-effort
+// partial — an image missing these classes (e.g. registry/boot on Windows)
+// would not boot at restore time, so it must not present as a full capture.
+// The required set is supplied by each platform collector.
+func missingRequired(incomplete []string, required map[string]bool) []string {
+	var missing []string
+	for _, s := range incomplete {
+		if required[s] {
+			missing = append(missing, s)
+		}
+	}
+	return missing
+}
+
 // CollectHardwareOnly captures hardware information without performing
 // a full system state collection. Useful for inventory and recovery planning.
 func CollectHardwareOnly() (*HardwareProfile, error) {

--- a/agent/internal/backup/systemstate/systemstate_test.go
+++ b/agent/internal/backup/systemstate/systemstate_test.go
@@ -277,3 +277,31 @@ func TestHelperCopyTree(t *testing.T) {
 		}
 	}
 }
+
+func TestMissingRequired(t *testing.T) {
+	required := map[string]bool{"registry": true, "boot": true}
+	tests := []struct {
+		name       string
+		incomplete []string
+		want       []string
+	}{
+		{"nothing incomplete", nil, nil},
+		{"only optional failed", []string{"certs", "iis"}, nil},
+		{"one required failed", []string{"registry"}, []string{"registry"}},
+		{"required + optional failed", []string{"iis", "boot", "certs"}, []string{"boot"}},
+		{"both required failed", []string{"registry", "boot"}, []string{"registry", "boot"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := missingRequired(tt.incomplete, required)
+			if len(got) != len(tt.want) {
+				t.Fatalf("missingRequired(%v) = %v, want %v", tt.incomplete, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("missingRequired[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/agent/internal/backup/systemstate/types.go
+++ b/agent/internal/backup/systemstate/types.go
@@ -8,11 +8,17 @@ import "time"
 
 // SystemStateManifest describes all collected system state artifacts.
 type SystemStateManifest struct {
-	Platform        string           `json:"platform"`
-	OSVersion       string           `json:"osVersion"`
-	Hostname        string           `json:"hostname"`
-	CollectedAt     time.Time        `json:"collectedAt"`
-	Artifacts       []Artifact       `json:"artifacts"`
+	Platform    string     `json:"platform"`
+	OSVersion   string     `json:"osVersion"`
+	Hostname    string     `json:"hostname"`
+	CollectedAt time.Time  `json:"collectedAt"`
+	Artifacts   []Artifact `json:"artifacts"`
+	// IncompleteSteps names the collection steps that failed to run (e.g.
+	// "registry", "boot"). System state is collected best-effort — a partial
+	// collection still produces a manifest — so this is how callers learn the
+	// backup is incomplete instead of it silently passing as a full capture.
+	// Empty/omitted means every step succeeded.
+	IncompleteSteps []string         `json:"incompleteSteps,omitempty"`
 	HardwareProfile *HardwareProfile `json:"hardwareProfile,omitempty"`
 }
 

--- a/apps/api/src/jobs/backupEnqueue.ts
+++ b/apps/api/src/jobs/backupEnqueue.ts
@@ -47,6 +47,10 @@ export interface ProcessResultsResult {
   filesBackedUp?: number;
   bytesBackedUp?: number;
   warning?: string;
+  // system_image (system-state) backups carry these; the WS handler must
+  // forward them or the snapshot loses its type label + BMR restore manifest.
+  backupType?: 'file' | 'system_image' | 'database' | 'application';
+  systemStateManifest?: Record<string, unknown> | null;
   snapshot?: {
     id: string;
     timestamp?: string;

--- a/apps/api/src/jobs/queueSchemas.test.ts
+++ b/apps/api/src/jobs/queueSchemas.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   automationQueueJobDataSchema,
+  backupProcessResultSchema,
   deviceAdjacencySchema,
   discoveryQueueJobDataSchema,
   fdbEntrySchema,
@@ -181,6 +182,53 @@ describe('sensitiveDataQueueJobDataSchema', () => {
 
   it.each(malformedCases)('rejects a malformed $name job', ({ payload }) => {
     expect(() => sensitiveDataQueueJobDataSchema.parse(payload)).toThrow();
+  });
+});
+
+describe('backupProcessResultSchema — system_image manifest passthrough', () => {
+  // Regression guard: this strict schema previously lacked backupType/
+  // systemStateManifest, so enqueueBackupResults threw an unrecognized_keys
+  // ZodError and the system_image job hung in "running" forever.
+  it('accepts a system_image result carrying backupType + systemStateManifest', () => {
+    const result = backupProcessResultSchema.parse({
+      status: 'completed',
+      snapshotId: 'snap-1',
+      filesBackedUp: 13,
+      bytesBackedUp: 103,
+      backupType: 'system_image',
+      systemStateManifest: {
+        platform: 'windows',
+        osVersion: 'Windows Server 2022',
+        artifacts: [{ name: 'registry_SYSTEM', category: 'registry' }],
+        hardwareProfile: { cpuCores: 4, totalMemoryMB: 8192 },
+      },
+    });
+    expect(result.backupType).toBe('system_image');
+    // The record is open — arbitrary manifest keys survive intact.
+    expect((result.systemStateManifest as { platform: string }).platform).toBe('windows');
+  });
+
+  it('allows an unmodeled manifest key (open record) without failing the job', () => {
+    expect(() =>
+      backupProcessResultSchema.parse({
+        status: 'completed',
+        systemStateManifest: { platform: 'windows', someFutureField: { nested: true } },
+      }),
+    ).not.toThrow();
+  });
+
+  it('still rejects an unknown TOP-LEVEL key (schema is .strict())', () => {
+    // The manifest is permissive, but the result envelope is not — a new
+    // top-level field must be declared or the whole job fails validation.
+    expect(() =>
+      backupProcessResultSchema.parse({ status: 'completed', bogusTopLevel: true }),
+    ).toThrow();
+  });
+
+  it('accepts a null systemStateManifest (file/mssql/hyperv results)', () => {
+    expect(() =>
+      backupProcessResultSchema.parse({ status: 'completed', systemStateManifest: null }),
+    ).not.toThrow();
   });
 });
 

--- a/apps/api/src/jobs/queueSchemas.ts
+++ b/apps/api/src/jobs/queueSchemas.ts
@@ -27,6 +27,12 @@ export const backupProcessResultSchema = z.object({
   filesBackedUp: z.number().int().nonnegative().optional(),
   bytesBackedUp: z.number().nonnegative().optional(),
   warning: z.string().min(1).optional(),
+  // system_image (system-state) backups carry the OS-artifact manifest and a
+  // derived backup type; forwarded through the queue so persistence can label
+  // the snapshot and BMR restore can read the manifest. Manifest kept
+  // permissive (passthrough) so an unmodeled field never fails the job.
+  backupType: z.enum(['file', 'system_image', 'database', 'application']).optional(),
+  systemStateManifest: z.record(z.string(), z.unknown()).nullish(),
   snapshot: backupSnapshotSummarySchema.optional(),
   error: z.string().min(1).optional(),
 }).strict();

--- a/apps/api/src/jobs/queueSchemas.ts
+++ b/apps/api/src/jobs/queueSchemas.ts
@@ -29,8 +29,10 @@ export const backupProcessResultSchema = z.object({
   warning: z.string().min(1).optional(),
   // system_image (system-state) backups carry the OS-artifact manifest and a
   // derived backup type; forwarded through the queue so persistence can label
-  // the snapshot and BMR restore can read the manifest. Manifest kept
-  // permissive (passthrough) so an unmodeled field never fails the job.
+  // the snapshot and BMR restore can read the manifest. Manifest typed as an
+  // open z.record (arbitrary keys allowed) so an unmodeled field never fails
+  // the job. NOTE: this schema itself is .strict(), so new *top-level* fields
+  // still must be declared here or the whole job fails validation.
   backupType: z.enum(['file', 'system_image', 'database', 'application']).optional(),
   systemStateManifest: z.record(z.string(), z.unknown()).nullish(),
   snapshot: backupSnapshotSummarySchema.optional(),

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1370,7 +1370,11 @@ export async function processOrphanedCommandResult(
           backupJob.orgId,
           backupJob.deviceId,
           {
-            status: result.status ?? 'failed',
+            // A malformed stdout must not ride an agent-reported 'completed'
+            // through to a completed job with no snapshot (mirrors the inline
+            // path below). Without this, a truncated/invalid system_image
+            // result completes green and the parse error is discarded.
+            status: result.status === 'completed' && parsedBackup.success ? 'completed' : 'failed',
             snapshotId: backupData?.snapshotId,
             filesBackedUp: backupData?.filesBackedUp,
             bytesBackedUp: backupData?.bytesBackedUp,

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1375,6 +1375,8 @@ export async function processOrphanedCommandResult(
             filesBackedUp: backupData?.filesBackedUp,
             bytesBackedUp: backupData?.bytesBackedUp,
             warning: backupData?.warning,
+            backupType: backupData?.backupType,
+            systemStateManifest: backupData?.systemStateManifest,
             snapshot: backupData?.snapshot,
             error: malformedPayloadError || result.error || result.stderr,
           },

--- a/apps/api/src/routes/backup/resultSchemas.test.ts
+++ b/apps/api/src/routes/backup/resultSchemas.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { backupCommandResultSchema } from './resultSchemas';
+
+describe('backupCommandResultSchema — system_image manifest', () => {
+  it('parses a system_image result and preserves the manifest + backupType', () => {
+    const parsed = backupCommandResultSchema.parse({
+      jobId: 'job-1',
+      snapshotId: 'snap-1',
+      filesBackedUp: 13,
+      bytesBackedUp: 103,
+      backupType: 'system_image',
+      systemStateManifest: {
+        platform: 'windows',
+        osVersion: 'Windows Server 2022',
+        artifacts: [{ name: 'registry_SYSTEM', category: 'registry' }],
+        hardwareProfile: { cpuCores: 4, totalMemoryMB: 8192 },
+      },
+    });
+    expect(parsed.backupType).toBe('system_image');
+    expect(parsed.systemStateManifest?.platform).toBe('windows');
+    expect(parsed.systemStateManifest?.hardwareProfile).toEqual({ cpuCores: 4, totalMemoryMB: 8192 });
+  });
+
+  it('passes through an unmodeled manifest field instead of dropping/rejecting it (F13)', () => {
+    // A forward-compatible agent may add manifest fields we do not model yet.
+    // .passthrough() must keep them AND must not fail the parse — otherwise the
+    // whole result is rejected and snapshot id / size are silently lost.
+    const parsed = backupCommandResultSchema.parse({
+      snapshotId: 'snap-1',
+      systemStateManifest: { platform: 'windows', incompleteSteps: ['certs'], futureField: 42 },
+    });
+    expect(parsed.snapshotId).toBe('snap-1');
+    expect((parsed.systemStateManifest as { futureField: number }).futureField).toBe(42);
+    expect((parsed.systemStateManifest as { incompleteSteps: string[] }).incompleteSteps).toEqual(['certs']);
+  });
+
+  it('parses a plain file result with no manifest', () => {
+    const parsed = backupCommandResultSchema.parse({
+      snapshotId: 'snap-1',
+      filesBackedUp: 5,
+    });
+    expect(parsed.systemStateManifest).toBeUndefined();
+    expect(parsed.backupType).toBeUndefined();
+  });
+
+  it('rejects an invalid backupType', () => {
+    expect(() =>
+      backupCommandResultSchema.parse({ snapshotId: 'snap-1', backupType: 'bogus' }),
+    ).toThrow();
+  });
+});

--- a/apps/api/src/routes/backup/resultSchemas.ts
+++ b/apps/api/src/routes/backup/resultSchemas.ts
@@ -19,6 +19,23 @@ export const backupSnapshotResultSchema = z.object({
   files: z.array(backupSnapshotFileResultSchema).optional(),
 });
 
+// system_image (Windows/macOS/Linux system-state) backups return a manifest
+// describing the collected OS artifacts plus an optional hardware profile. It
+// is stored verbatim as JSONB and read back by BMR restore, so we keep the
+// shape permissive (.passthrough(), every field optional) — a manifest field
+// we don't model must never fail the whole result parse and silently drop the
+// snapshot id / size (same F13 lesson as the file mtimes above).
+export const backupSystemStateManifestResultSchema = z
+  .object({
+    platform: z.string().optional(),
+    osVersion: z.string().optional(),
+    hostname: z.string().optional(),
+    collectedAt: z.string().optional(),
+    artifacts: z.array(z.record(z.string(), z.unknown())).optional(),
+    hardwareProfile: z.record(z.string(), z.unknown()).nullish(),
+  })
+  .passthrough();
+
 export const backupCommandResultSchema = z.object({
   jobId: z.string().optional(),
   snapshotId: z.string().optional(),
@@ -26,6 +43,7 @@ export const backupCommandResultSchema = z.object({
   bytesBackedUp: z.number().nonnegative().refine(Number.isInteger, 'expected integer').optional(),
   warning: z.string().optional(),
   backupType: z.enum(['file', 'system_image', 'database', 'application']).optional(),
+  systemStateManifest: backupSystemStateManifestResultSchema.optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
   snapshot: backupSnapshotResultSchema.optional(),
 });

--- a/apps/api/src/routes/backup/snapshots.ts
+++ b/apps/api/src/routes/backup/snapshots.ts
@@ -658,6 +658,7 @@ function toSnapshotResponse(row: typeof backupSnapshots.$inferSelect) {
     configId: row.configId ?? null,
     jobId: row.jobId,
     createdAt: row.timestamp.toISOString(),
+    backupType: row.backupType ?? 'file',
     sizeBytes: row.size ?? null,
     fileCount: row.fileCount ?? null,
     label: row.label ?? null,

--- a/apps/api/src/services/backupResultPersistence.test.ts
+++ b/apps/api/src/services/backupResultPersistence.test.ts
@@ -270,6 +270,64 @@ describe('backup result persistence', () => {
     }));
   });
 
+  it('does not mislabel a file backup: no backupType, non-system_image mode → file', async () => {
+    // Regression guard: the system_image derivation must not leak onto file
+    // jobs. A file backup_run sends no backupType and backupMode='file', so the
+    // snapshot must fall through to 'file' (and carry no manifest).
+    vi.mocked(db.update)
+      .mockReturnValueOnce(chainMock([{ id: 'job-1', configId: 'config-1', backupType: null, backupMode: 'file' }]) as any)
+      .mockReturnValueOnce(chainMock([]) as any)
+      .mockReturnValueOnce(chainMock([]) as any);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(chainMock([]) as any)
+      .mockReturnValueOnce(chainMock([{ featureLinkId: 'feature-1', policyId: null, deviceId: 'device-1' }]) as any);
+    vi.mocked(db.insert).mockReturnValueOnce(chainMock([{ id: 'snapshot-db-1', jobId: 'job-1', snapshotId: 'provider-snap-1' }]) as any);
+    vi.mocked(applyGfsTagsToSnapshot).mockResolvedValue({ daily: true });
+    vi.mocked(resolveGfsConfigForJob).mockResolvedValue(null);
+    vi.mocked(computeExpiresAt).mockReturnValue(null);
+
+    await applyBackupCommandResultToJob({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      resultStatus: 'completed',
+      result: { snapshotId: 'provider-snap-1', filesBackedUp: 5 } as any,
+    });
+
+    const insertValues = vi.mocked(db.insert).mock.results[0]?.value?.values;
+    expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({
+      backupType: 'file',
+      systemStateManifest: null,
+      hardwareProfile: null,
+    }));
+  });
+
+  it('honors an explicit result.backupType over the mode-derived value', async () => {
+    // mssql/hyperv send an explicit backupType; it must win over derivation.
+    vi.mocked(db.update)
+      .mockReturnValueOnce(chainMock([{ id: 'job-1', configId: 'config-1', backupType: null, backupMode: 'mssql' }]) as any)
+      .mockReturnValueOnce(chainMock([]) as any)
+      .mockReturnValueOnce(chainMock([]) as any);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(chainMock([]) as any)
+      .mockReturnValueOnce(chainMock([{ featureLinkId: 'feature-1', policyId: null, deviceId: 'device-1' }]) as any);
+    vi.mocked(db.insert).mockReturnValueOnce(chainMock([{ id: 'snapshot-db-1', jobId: 'job-1', snapshotId: 'provider-snap-1' }]) as any);
+    vi.mocked(applyGfsTagsToSnapshot).mockResolvedValue({ daily: true });
+    vi.mocked(resolveGfsConfigForJob).mockResolvedValue(null);
+    vi.mocked(computeExpiresAt).mockReturnValue(null);
+
+    await applyBackupCommandResultToJob({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      resultStatus: 'completed',
+      result: { snapshotId: 'provider-snap-1', filesBackedUp: 1, backupType: 'database' } as any,
+    });
+
+    const insertValues = vi.mocked(db.insert).mock.results[0]?.value?.values;
+    expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ backupType: 'database' }));
+  });
+
   it('applies provider immutability when the winning feature link requests it', async () => {
     resolveBackupProtectionForDeviceMock.mockResolvedValueOnce({
       legalHold: false,

--- a/apps/api/src/services/backupResultPersistence.test.ts
+++ b/apps/api/src/services/backupResultPersistence.test.ts
@@ -223,6 +223,53 @@ describe('backup result persistence', () => {
     }));
   });
 
+  it('labels a system_image snapshot and persists its system-state manifest + hardware profile', async () => {
+    vi.mocked(db.update)
+      .mockReturnValueOnce(chainMock([{ id: 'job-1', configId: 'config-1', backupType: null, backupMode: 'system_image' }]) as any)
+      .mockReturnValueOnce(chainMock([]) as any)
+      .mockReturnValueOnce(chainMock([]) as any);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(chainMock([]) as any)
+      .mockReturnValueOnce(chainMock([{ featureLinkId: 'feature-1', policyId: null, deviceId: 'device-1' }]) as any);
+    vi.mocked(db.insert).mockReturnValueOnce(chainMock([{
+      id: 'snapshot-db-1',
+      jobId: 'job-1',
+      snapshotId: 'provider-snap-1',
+    }]) as any);
+    vi.mocked(applyGfsTagsToSnapshot).mockResolvedValue({ daily: true });
+    vi.mocked(resolveGfsConfigForJob).mockResolvedValue(null);
+    vi.mocked(computeExpiresAt).mockReturnValue(null);
+
+    const manifest = {
+      platform: 'windows',
+      osVersion: 'Microsoft Windows [Version 10.0.20348.169]',
+      hostname: 'WIN-TEST',
+      artifacts: [{ name: 'registry_SYSTEM', category: 'registry', path: 'registry/SYSTEM', sizeBytes: 100 }],
+      hardwareProfile: { cpuModel: 'Xeon', cpuCores: 4, totalMemoryMB: 8192 },
+    };
+
+    await applyBackupCommandResultToJob({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      resultStatus: 'completed',
+      result: {
+        snapshotId: 'provider-snap-1',
+        filesBackedUp: 13,
+        // backup_run for system_image carries no backupType — it must be
+        // derived from the job's backup_mode, not defaulted to 'file'.
+        systemStateManifest: manifest,
+      } as any,
+    });
+
+    const insertValues = vi.mocked(db.insert).mock.results[0]?.value?.values;
+    expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({
+      backupType: 'system_image',
+      systemStateManifest: manifest,
+      hardwareProfile: manifest.hardwareProfile,
+    }));
+  });
+
   it('applies provider immutability when the winning feature link requests it', async () => {
     resolveBackupProtectionForDeviceMock.mockResolvedValueOnce({
       legalHold: false,

--- a/apps/api/src/services/backupResultPersistence.ts
+++ b/apps/api/src/services/backupResultPersistence.ts
@@ -450,6 +450,7 @@ export async function applyBackupCommandResultToJob(params: {
       id: backupJobs.id,
       configId: backupJobs.configId,
       backupType: backupJobs.backupType,
+      backupMode: backupJobs.backupMode,
     });
 
   if (!updatedJob) {
@@ -471,8 +472,15 @@ export async function applyBackupCommandResultToJob(params: {
   const timestamp = result.snapshot?.timestamp
     ? new Date(result.snapshot.timestamp)
     : now;
+  // A system_image job dispatches a generic backup_run whose result carries no
+  // backupType, so derive it from the job's backup_mode; otherwise the snapshot
+  // (and BMR restore, which keys off snapshot.backupType) mislabels it 'file'.
+  const derivedBackupType =
+    updatedJob.backupMode === 'system_image' ? 'system_image' : undefined;
   const snapshotBackupType =
-    result.backupType ?? updatedJob.backupType ?? 'file';
+    result.backupType ?? derivedBackupType ?? updatedJob.backupType ?? 'file';
+  const systemStateManifest = result.systemStateManifest ?? null;
+  const hardwareProfile = systemStateManifest?.hardwareProfile ?? null;
   const snapshotMetadata: Record<string, unknown> = {
     ...metadata,
     hasIndexedFiles: Boolean(result.snapshot?.files?.length),
@@ -497,6 +505,8 @@ export async function applyBackupCommandResultToJob(params: {
     metadata: snapshotMetadata,
     encryptionKeyId: resolveSnapshotEncryptionKeyId(snapshotMetadata),
     backupType: snapshotBackupType,
+    systemStateManifest,
+    hardwareProfile,
   } as const;
 
   const [existingSnapshot] = await db

--- a/apps/web/src/components/backup/SnapshotBrowser.test.tsx
+++ b/apps/web/src/components/backup/SnapshotBrowser.test.tsx
@@ -142,4 +142,32 @@ describe('SnapshotBrowser', () => {
     expect(await screen.findByText(/Provider immutability was requested by policy/i)).toBeTruthy();
     expect(screen.getByText(/Bucket object lock no longer enabled/i)).toBeTruthy();
   });
+
+  it('badges a system_image snapshot with its backup type', async () => {
+    fetchMock.mockImplementationOnce(async () => makeJsonResponse({
+      data: [
+        {
+          id: 'snap-1',
+          label: 'Nightly Snapshot',
+          createdAt: '2026-03-31T00:00:00Z',
+          backupType: 'system_image',
+          sizeBytes: 1048576,
+          fileCount: 13,
+          location: 'snapshots/provider-snap-1',
+          expiresAt: '2026-04-30T00:00:00Z',
+          legalHold: false,
+          legalHoldReason: null,
+          isImmutable: false,
+          immutableUntil: null,
+          immutabilityEnforcement: null,
+          requestedImmutabilityEnforcement: null,
+          immutabilityFallbackReason: null,
+        },
+      ],
+    }));
+
+    render(<SnapshotBrowser />);
+
+    expect(await screen.findByText(/System image/i)).toBeTruthy();
+  });
 });

--- a/apps/web/src/components/backup/SnapshotBrowser.tsx
+++ b/apps/web/src/components/backup/SnapshotBrowser.tsx
@@ -37,9 +37,11 @@ type SnapshotFile = {
 
 type BackupType = 'file' | 'system_image' | 'database' | 'application';
 
-// Human labels for non-file backup types. Kept as literals (matching the
-// existing immutability badge in this file) so a new snapshot type doesn't
-// fan a locale key out across all five translation bundles.
+// Human labels for non-file backup types. Deliberately untranslated literals
+// (like the sibling immutability badge, though the legal-hold badge next to it
+// does use t()): these render in English across all locales as a tradeoff to
+// avoid fanning a new key out across all five translation bundles. Move to t()
+// keys if/when the badge cluster is localized as a whole.
 const BACKUP_TYPE_LABELS: Record<Exclude<BackupType, 'file'>, string> = {
   system_image: 'System image',
   database: 'Database',

--- a/apps/web/src/components/backup/SnapshotBrowser.tsx
+++ b/apps/web/src/components/backup/SnapshotBrowser.tsx
@@ -35,10 +35,22 @@ type SnapshotFile = {
   path?: string;
 };
 
+type BackupType = 'file' | 'system_image' | 'database' | 'application';
+
+// Human labels for non-file backup types. Kept as literals (matching the
+// existing immutability badge in this file) so a new snapshot type doesn't
+// fan a locale key out across all five translation bundles.
+const BACKUP_TYPE_LABELS: Record<Exclude<BackupType, 'file'>, string> = {
+  system_image: 'System image',
+  database: 'Database',
+  application: 'Application',
+};
+
 type Snapshot = {
   id: string;
   label: string | null;
   createdAt: string;
+  backupType?: BackupType;
   sizeBytes: number | null;
   fileCount: number | null;
   location: string | null;
@@ -443,6 +455,9 @@ export default function SnapshotBrowser() {
               {snapshots.map((snapshot) => (
                 <option key={snapshot.id} value={snapshot.id}>
                   {snapshot.label ?? snapshot.id}
+                  {snapshot.backupType && snapshot.backupType !== 'file'
+                    ? ` — ${BACKUP_TYPE_LABELS[snapshot.backupType]}`
+                    : ''}
                 </option>
               ))}
             </select>
@@ -460,6 +475,11 @@ export default function SnapshotBrowser() {
             <div className="space-y-3">
               <div className="flex flex-wrap items-center gap-2">
                 <span className="text-sm font-semibold text-foreground">{selectedSnapshotDisplayLabel}</span>
+                {selectedSnapshot.backupType && selectedSnapshot.backupType !== 'file' && (
+                  <span className="rounded-full border border-violet-500/40 bg-violet-500/10 px-2 py-0.5 text-xs font-medium text-violet-700">
+                    {BACKUP_TYPE_LABELS[selectedSnapshot.backupType]}
+                  </span>
+                )}
                 {selectedSnapshot.legalHold && (
                   <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700">
                     {t('snapshotBrowser.legalHold')} </span>

--- a/docs/testing/FEATURE_TEST_LOG.md
+++ b/docs/testing/FEATURE_TEST_LOG.md
@@ -3641,3 +3641,32 @@ tests never exercised the real browser payloads** — worth a validator/UI-contr
 - The live walkthrough also exposed and fixed a stored-locale hydration race that could render pt-BR before English SSR islands hydrated.
 - Final read-only code review found no unresolved Critical or Important issues after runtime, enforcement, formatter, and copy-quality remediation.
 - Brazilian Portuguese copy remains machine-drafted and should receive native-speaker review before production rollout.
+
+## Windows System State Backup (system_image mode) — 2026-07-15
+
+**Branch:** `backup-fixes-wip`
+**Base commit:** `e2df3b691`
+**Tested by:** Claude
+**Result:** PASS (backend E2E; UI badge display is an unblocked follow-up)
+
+### What was tested
+- [x] Agent: `system_image` backup_run on the live Windows VM (`WIN-DHQNR1F8LO2`) collects OS system state (registry hives, BCD, drivers, services, tasks, firewall, features) and uploads it as a snapshot.
+- [x] API: server labels the snapshot `backup_type=system_image` and persists `system_state_manifest` + `hardware_profile`; snapshots list DTO surfaces `backupType`.
+- [x] Full-stack fan-out: manual run creates one `file` + one `system_image` job; both complete.
+
+### Bug found (before fix)
+`system_image` job failed immediately with `backup_run payload has no paths`. The worker maps `system_image` → `backup_run {systemImage:true}` (no file paths), but the agent's `backup_run` handler required file paths and never read `systemImage`. Nothing captured Windows system state through the server-driven flow.
+
+### Fixes
+- **agent/cmd/breeze-backup/exec_backup.go** — `managerFromBackupRunPayload` honors `systemImage:true`: builds the manager with `SystemStateEnabled`, no file paths required.
+- **agent/internal/backup/backup.go** — `RunBackupWithExcludes` allows a paths-less run when system state is enabled; an empty system-state-only run now FAILS loudly instead of a silent `skipped`.
+- **apps/api** — result manifest was dropped in three places, all fixed: `resultSchemas.ts` (schema passthrough), `queueSchemas.ts` (strict queue schema rejected the new keys → job hung), `agentWs.ts` (enqueue subset omitted the fields), `backupResultPersistence.ts` (persist manifest/hardware_profile + derive `backupType` from `backup_mode`), `snapshots.ts` (list DTO surfaces `backupType`).
+
+### Evidence
+- Snapshot `snapshot-20260716T042714Z-4c7abb8b`: `backup_type=system_image`, 13 files, 103 MB, `has_manifest=t`, `has_hw=t`, platform=windows, os=Windows Server 2022, 10 manifest artifacts.
+- Tests: Go `internal/backup` + `cmd/breeze-backup` green; API backup/agentWs/queue/persistence/snapshots suites green (new cases added for the systemImage payload guard and the manifest-persistence/labeling).
+
+### Follow-ups — all completed + verified in the same session
+- **UI badge (done):** `SnapshotBrowser.tsx` now shows a "System image" badge on the snapshot header + a type suffix in the selector dropdown (`backupType !== 'file'`). Web test added; `astro check` 0 errors.
+- **Windows hardware profile (done):** root cause was `wmic.exe`, deprecated/removed on Server 2022 — the whole collector silently returned zeros. Rewrote `hw_windows.go` to use PowerShell `Get-CimInstance`. Verified live: `AMD Ryzen 7 3800X`, 4 cores, 4255 MB, 4 disks, 2 NICs, BIOS `090008`, `Microsoft Corporation Virtual Machine`.
+- **Restore round-trip (done, non-destructive):** restored the system_image snapshot to `C:\tmp\restore-test` via `POST /backup/restore` (full). 13 files / 103,584,508 bytes / 0 failed; on-disk artifacts byte-match the backup (registry SOFTWARE 84,037,632, SYSTEM 18,776,064, SAM/SECURITY, BCD, drivers, services, tasks, firewall, features). Full BMR (destructive, needs boot media) intentionally not run on the live VM.

--- a/docs/testing/FEATURE_TEST_LOG.md
+++ b/docs/testing/FEATURE_TEST_LOG.md
@@ -3679,3 +3679,11 @@ A 4-agent review (code / silent-failure / tests / comments) confirmed the core c
 - **Malformed-completed backup result now fails, not silently completes (H2):** the Redis enqueue path in `agentWs.ts` gates `status` on parse success, mirroring the inline path.
 - **Tests added:** Go seam (`collectSystemState`) + fail-loud/partial-warning assertions (the prior test was vacuous on CI hosts); `backupProcessResultSchema` + `backupCommandResultSchema` manifest round-trip (the strict-schema rejection that hung the job); backupType precedence (file not mislabeled, explicit type wins).
 - **Deferred (noted, not fixed):** H1 (server null-manifest guard — verified unreachable in practice); M2 (combined file+system_image mode — not dispatched); hard-fail-on-missing-registry policy (product decision); hw perf (8 PowerShell spawns).
+
+### Partial-collection policy: hard-fail on required artifacts (per Todd)
+
+Refined the review-round C1 handling — missing *required* artifacts now fails the run rather than warning:
+- `systemstate.go` adds a pure, CI-testable `missingRequired(incomplete, required)` policy helper; the Windows collector declares `windowsRequiredSteps = {registry, boot}` (the classes a bare-metal restore can't boot without) and `CollectState` returns an error when any is missing.
+- A required-artifact failure therefore propagates as a collection error → the system_image job fails loud (no green unbootable snapshot).
+- Genuinely optional classes (certs, iis, firewall, …) still complete with a surfaced warning — an MSP doesn't lose an otherwise-good backup over a non-critical step.
+- Tests: `TestMissingRequired` (policy table); partial-warning test switched to optional classes (certs/iis); required-failure → hard-fail is covered by the collection-error consumption test.

--- a/docs/testing/FEATURE_TEST_LOG.md
+++ b/docs/testing/FEATURE_TEST_LOG.md
@@ -3670,3 +3670,12 @@ tests never exercised the real browser payloads** — worth a validator/UI-contr
 - **UI badge (done):** `SnapshotBrowser.tsx` now shows a "System image" badge on the snapshot header + a type suffix in the selector dropdown (`backupType !== 'file'`). Web test added; `astro check` 0 errors.
 - **Windows hardware profile (done):** root cause was `wmic.exe`, deprecated/removed on Server 2022 — the whole collector silently returned zeros. Rewrote `hw_windows.go` to use PowerShell `Get-CimInstance`. Verified live: `AMD Ryzen 7 3800X`, 4 cores, 4255 MB, 4 disks, 2 NICs, BIOS `090008`, `Microsoft Corporation Virtual Machine`.
 - **Restore round-trip (done, non-destructive):** restored the system_image snapshot to `C:\tmp\restore-test` via `POST /backup/restore` (full). 13 files / 103,584,508 bytes / 0 failed; on-disk artifacts byte-match the backup (registry SOFTWARE 84,037,632, SYSTEM 18,776,064, SAM/SECURITY, BCD, drivers, services, tasks, firewall, features). Full BMR (destructive, needs boot media) intentionally not run on the live VM.
+
+### Code review round (PR #2581) — hardening applied
+
+A 4-agent review (code / silent-failure / tests / comments) confirmed the core change sound and surfaced partial-failure gaps, now fixed:
+- **Partial system-state collection no longer silent (C1):** `state_windows.go` records failed steps in `manifest.IncompleteSteps`, `collectRegistry` reports failure when it captures zero hives (every Windows box has SYSTEM/SOFTWARE), and `backup.go` surfaces a completion `Warning` (→ result `warning` → job errorLog → UI) so a degraded system_image can't pass as a full, restorable capture.
+- **CIM failures now logged (M1):** `cimCSV` logs each failure with PowerShell stderr — an unlogged failure was how the wmic path shipped all-zero profiles.
+- **Malformed-completed backup result now fails, not silently completes (H2):** the Redis enqueue path in `agentWs.ts` gates `status` on parse success, mirroring the inline path.
+- **Tests added:** Go seam (`collectSystemState`) + fail-loud/partial-warning assertions (the prior test was vacuous on CI hosts); `backupProcessResultSchema` + `backupCommandResultSchema` manifest round-trip (the strict-schema rejection that hung the job); backupType precedence (file not mislabeled, explicit type wins).
+- **Deferred (noted, not fixed):** H1 (server null-manifest guard — verified unreachable in practice); M2 (combined file+system_image mode — not dispatched); hard-fail-on-missing-registry policy (product decision); hw perf (8 PowerShell spawns).


### PR DESCRIPTION
## Summary

Windows system-state backup (`system_image` mode) failed on every agent — the worker dispatches it as `backup_run{systemImage:true}` with no file paths, but the agent's `backup_run` handler required paths and never read the `systemImage` flag, so the job immediately failed with `backup_run payload has no paths`. Nothing captured Windows system state through the server-driven flow.

Found and fixed via a live end-to-end test against a real Windows Server 2022 VM.

## Changes

**Agent** (`agent/`):
- `managerFromBackupRunPayload` honors `systemImage:true` — builds the manager with `SystemStateEnabled`, no file paths required. Retention stays 0 (server owns retention/GFS/legal-hold, matching the existing file-mode invariant).
- `RunBackupWithExcludes` allows a paths-less run when system state is enabled, and now **fails loudly** instead of silently marking an empty collection `"skipped"` — an empty system-state-only run has nothing to fall back on, so a green empty snapshot would silently protect nothing.
- `hw_windows.go`: `CollectHardwareProfile` used `wmic.exe`, which is deprecated/removed on Windows Server 2022+, so hardware profiles (CPU/memory/disks/NICs/BIOS) silently came back all-zero. Rewritten on PowerShell `Get-CimInstance`.
- Added `BackupManager.GetSystemStateEnabled()` accessor (test-only need, mirrors the existing `GetProvider`/`GetPaths`/`GetRetention` pattern).

**API** (`apps/api/src`): the agent's `systemStateManifest`/`backupType` were dropped at every hop between the WS result handler and persistence:
- `resultSchemas.ts` stripped them from the parsed agent result — added a permissive passthrough schema for the manifest.
- `queueSchemas.ts`'s strict BullMQ job-data schema rejected the new keys outright (this actually **hung the job**, since the enqueue call threw).
- `agentWs.ts`'s Redis enqueue payload hand-picked a subset of fields that omitted them.
- `backupResultPersistence.ts` never wrote the `system_state_manifest`/`hardware_profile` columns and defaulted `backupType` to `'file'` — now derives it from the job's `backup_mode` when the agent doesn't send one.
- `snapshots.ts` list DTO now surfaces `backupType` so the UI can distinguish snapshot types.

**Web** (`apps/web/src`): `SnapshotBrowser.tsx` badges non-file snapshot types ("System image") in the detail header and selector dropdown.

## Verification (live, real Windows Server 2022 VM)

- `system_image` job completes and produces a real snapshot: 13 artifacts (all 4 registry hives, BCD boot export, driver inventory, services, scheduled tasks, firewall rules, Windows features), 103 MB.
- Snapshot correctly labeled `backup_type=system_image`, with `system_state_manifest` and `hardware_profile` populated (`platform=windows`, real OS version string, 10 manifest artifacts).
- Hardware profile now populated with real values after the wmic→CIM fix: AMD Ryzen 7 3800X, 4 cores, 4255 MB RAM, 4 disks, 2 NICs, BIOS version, motherboard.
- **Restore round-trip** (non-destructive, to a scratch directory): `POST /backup/restore` restored the snapshot — 13 files / 103,584,508 bytes / 0 failed — and the on-disk artifacts byte-match the original backup (e.g. registry `SOFTWARE` 84,037,632 bytes exact).

Full narrative in `docs/testing/FEATURE_TEST_LOG.md`.

## Test plan

- [x] Go: `internal/backup` + `cmd/breeze-backup` full suites green (native + Windows cross-compile build/vet)
- [x] New Go tests: `system_image mode needs no paths` table case (retention=0, provider, `SystemStateEnabled` asserted) + `TestRunBackup_SystemStateOnly_NoPathsAllowed`
- [x] API: `backupResultPersistence`, `resultSchemas`, `queueSchemas`, `backup/jobs`, `routes/backup/snapshots`, `agentWs` suites green (117 tests); `tsc --noEmit` clean
- [x] Web: `SnapshotBrowser` suite green (new badge test); `astro check` 0 errors
- [x] Live E2E on a real Windows VM: capture → correct labeling/manifest/hardware profile → UI-ready DTO → verified byte-exact restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)