### PR TITLE
fix(docker): copy extension-sdk into the dev API image (#2548 follow-up)

### DIFF
--- a/docker/Dockerfile.api.dev
+++ b/docker/Dockerfile.api.dev
@@ -15,6 +15,7 @@ COPY turbo.json tsconfig.json ./
 COPY apps/api/package.json ./apps/api/
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/extension-api/package.json ./packages/extension-api/
+COPY packages/extension-sdk/package.json ./packages/extension-sdk/
 
 # Install all dependencies (including devDependencies for development)
 RUN pnpm install
@@ -23,6 +24,7 @@ RUN pnpm install
 COPY apps/api ./apps/api
 COPY packages/shared ./packages/shared
 COPY packages/extension-api ./packages/extension-api
+COPY packages/extension-sdk ./packages/extension-sdk
 
 # Set working directory to api
 WORKDIR /app/apps/api


### PR DESCRIPTION
## Problem
PR #2548 (`feat(extensions): add versioned runtime extension contract`) added `@breeze/extension-sdk@workspace:*` as an `apps/api` dependency. It updated the **prod** `docker/Dockerfile.api` (copies `packages/extension-sdk/package.json` + its `node_modules`), but **not** the **dev** `docker/Dockerfile.api.dev`.

As a result, the dev API image's `pnpm install` fails on current `main`:

```
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  In apps/api: "@breeze/extension-sdk@workspace:*"
is in the dependencies but no package named "@breeze/extension-sdk" is present in the workspace
```

This breaks **every developer's local dev stack** — `docker compose -f docker-compose.yml -f docker-compose.override.yml.dev up` and the `wt-stack` helper both build from `Dockerfile.api.dev`. CI does not catch it because CI builds the prod Dockerfile.

## Fix
Mirror the prod Dockerfile: `COPY packages/extension-sdk/package.json` into the pnpm-install layer, and copy the package source alongside the other workspace packages. `@breeze/extension-sdk` has only npm deps, so no further workspace copies are needed.

## Verification
Rebuilt the local dev stack (`pnpm wt-stack up --rebuild`) on current `main` with this change — the API image `pnpm install` succeeds and all six containers come up healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)