### PR TITLE
fix(web): defer scope-gated Update Rings tab to post-mount (SSR hydration mismatch)

### DIFF
--- a/apps/web/src/components/patches/PatchesPage.tsx
+++ b/apps/web/src/components/patches/PatchesPage.tsx
@@ -65,6 +65,16 @@ export default function PatchesPage() {
   const canManageRings = scope === 'partner' || scope === 'system';
   const RING_SCOPE_HINT = t('patchesPage.ringScopeHint');
 
+  // The Update Rings tab is gated on the client-only JWT scope (canManageRings),
+  // which is absent during SSR, so the server renders two tabs and the client
+  // three. Render the tab list from an SSR-stable value until after mount so the
+  // first client render matches the server markup — companion to the #2421
+  // active-tab fix below. canManageRings itself stays accurate everywhere else
+  // (the hash-resolution effect, ring actions) so the #rings deep-link and
+  // scope guards are unaffected.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
   // Start from the SSR-safe default; the hash (with the org-scope guard) is
   // applied post-mount by the sync effect below, avoiding an SSR hydration
   // mismatch (#2421).
@@ -119,9 +129,9 @@ export default function PatchesPage() {
     () => [
       { id: 'compliance' as TabKey, label: t('patchesPage.tabs.compliance'), icon: <BarChart3 className="h-4 w-4" /> },
       { id: 'patches' as TabKey, label: t('patchesPage.tabs.patches'), icon: <FileCog className="h-4 w-4" /> },
-      ...(canManageRings ? [{ id: 'rings' as TabKey, label: t('patchesPage.tabs.updateRings'), icon: <Layers className="h-4 w-4" /> }] : [])
+      ...(mounted && canManageRings ? [{ id: 'rings' as TabKey, label: t('patchesPage.tabs.updateRings'), icon: <Layers className="h-4 w-4" /> }] : [])
     ],
-    [canManageRings, t]
+    [mounted, canManageRings, t]
   );
 
   // Ring selector data (simplified for dropdown)


### PR DESCRIPTION
## Problem
`/patches` logs a React hydration mismatch on the tab-nav row. The "Update Rings" tab is gated on `canManageRings = scope === 'partner' || scope === 'system'`, and `scope` comes from the **client-only** JWT (`getJwtClaims`). During SSR the token is absent → server renders **2** tabs; the client renders **3** on the first paint → `Hydration failed because the server rendered HTML didn't match the client` (the whole tab tree regenerates client-side).

The #2421 hydration sweep fixed the *active-tab state* on this page but not the *tab list*, which still varied by client-only scope.

## Fix
Gate **only the tab-list entry** behind a post-mount flag (`mounted`), so the first client render matches the SSR markup:

```tsx
const [mounted, setMounted] = useState(false);
useEffect(() => setMounted(true), []);
// ...
...(mounted && canManageRings ? [ringsTab] : [])
```

`canManageRings` itself stays accurate everywhere else — the hash-resolution effect (`#rings` deep-link + org-scope downgrade guard), the ring action handlers, and the disabled ring controls are all unchanged. For partner/system users the Update Rings tab simply appears a tick after mount.

## Verification
Local dev stack on current `main`: fresh `/patches` load now has **0 console errors** (no hydration mismatch), and a partner user still sees all three tabs (Compliance / Patches / Update Rings). The `#rings` deep-link still resolves correctly and org-scoped users are still downgraded to Compliance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)