### PR TITLE
feat(quotes): clone with company/title selection, draft company reassignment, tidier header actions

### DIFF
--- a/apps/api/src/routes/quotes/quotes.test.ts
+++ b/apps/api/src/routes/quotes/quotes.test.ts
@@ -111,14 +111,62 @@ describe('quote crud + lines routes', () => {
     expect(svc.createQuote).toHaveBeenCalledOnce();
   });
 
-  it('POST /:id/clone clones a quote into a new draft', async () => {
+  it('POST /:id/clone clones a quote into a new draft (bodyless legacy call → no retarget)', async () => {
     (svc.cloneQuote as any).mockResolvedValue({ id: BLOCK_ID, status: 'draft' });
     const res = await app().request(`/${QUOTE_ID}/clone`, { method: 'POST' });
 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data).toEqual({ id: BLOCK_ID, status: 'draft' });
-    expect(svc.cloneQuote).toHaveBeenCalledWith(QUOTE_ID, expect.anything());
+    expect(svc.cloneQuote).toHaveBeenCalledWith(QUOTE_ID, expect.anything(), {});
+  });
+
+  it('POST /:id/clone passes retarget/rename options through to the service', async () => {
+    (svc.cloneQuote as any).mockResolvedValue({ id: BLOCK_ID, status: 'draft' });
+    const res = await app().request(`/${QUOTE_ID}/clone`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ orgId: ORG_ID, title: 'Clone of Q-1' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(svc.cloneQuote).toHaveBeenCalledWith(QUOTE_ID, expect.anything(), { orgId: ORG_ID, title: 'Clone of Q-1' });
+  });
+
+  it('POST /:id/clone honors a JSON retarget body even without a content-type header', async () => {
+    // No content-type gate: a caller that forgets the header must still get the
+    // retarget it asked for, never a silent same-org clone.
+    (svc.cloneQuote as any).mockResolvedValue({ id: BLOCK_ID, status: 'draft' });
+    const res = await app().request(`/${QUOTE_ID}/clone`, {
+      method: 'POST',
+      body: JSON.stringify({ orgId: ORG_ID }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(svc.cloneQuote).toHaveBeenCalledWith(QUOTE_ID, expect.anything(), { orgId: ORG_ID });
+  });
+
+  it('POST /:id/clone rejects a non-JSON body instead of silently cloning', async () => {
+    const res = await app().request(`/${QUOTE_ID}/clone`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: `orgId=${ORG_ID}`,
+    });
+
+    expect(res.status).toBe(400);
+    expect(svc.cloneQuote).not.toHaveBeenCalled();
+  });
+
+  it('POST /:id/clone rejects a malformed retarget body instead of silently cloning', async () => {
+    // A mis-keyed field must 400 (strict schema), not fall back to a same-org clone.
+    const res = await app().request(`/${QUOTE_ID}/clone`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ orgID: ORG_ID }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(svc.cloneQuote).not.toHaveBeenCalled();
   });
 
   it('POST /:id/clone rejects an invalid quote id before calling the service', async () => {

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -5,9 +5,9 @@ import { and, eq } from 'drizzle-orm';
 import { requireScope, requirePermission, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import {
-  createQuoteSchema, updateQuoteSchema, quoteLineInputSchema, catalogQuoteLineSchema,
+  createQuoteSchema, cloneQuoteSchema, updateQuoteSchema, quoteLineInputSchema, catalogQuoteLineSchema,
   updateQuoteLineSchema, quoteBlockInputSchema, listQuotesQuerySchema,
-  reorderBlocksSchema, reorderLinesSchema, moveQuoteLineSchema,
+  reorderBlocksSchema, reorderLinesSchema, moveQuoteLineSchema, type CloneQuoteInput,
 } from '@breeze/shared';
 import {
   createQuote, cloneQuote, getQuote, listQuotes, updateQuote, deleteDraftQuote,
@@ -50,7 +50,23 @@ quoteCrudRoutes.post('/', scopes, writePerm, zValidator('json', createQuoteSchem
   catch (err) { return handleServiceError(c, err); }
 });
 quoteCrudRoutes.post('/:id/clone', scopes, writePerm, zValidator('param', idParam), async (c) => {
-  try { return c.json({ data: await cloneQuote(c.req.valid('param').id, quoteActorFrom(c)) }); }
+  // Optional retarget/rename body. Distinguish an ABSENT body (legacy callers
+  // POST nothing) from a PRESENT-but-broken one: an empty body degrades to a
+  // plain same-org clone; ANY non-empty body that fails to read, parse, or
+  // validate is a 400 — never a silent same-org clone of a retarget the caller
+  // intended. Read unconditionally (no content-type gate): a JSON body sent
+  // without the header must still be honored, and a non-JSON body must 400.
+  let input: CloneQuoteInput = {};
+  let raw: string;
+  try { raw = await c.req.text(); } catch { return c.json({ error: 'Failed to read request body' }, 400); }
+  if (raw.trim()) {
+    let json: unknown;
+    try { json = JSON.parse(raw); } catch { return c.json({ error: 'Invalid JSON body' }, 400); }
+    const parsed = cloneQuoteSchema.safeParse(json);
+    if (!parsed.success) return c.json({ error: 'Invalid clone options' }, 400);
+    input = parsed.data;
+  }
+  try { return c.json({ data: await cloneQuote(c.req.valid('param').id, quoteActorFrom(c), input) }); }
   catch (err) { return handleServiceError(c, err); }
 });
 quoteCrudRoutes.get('/:id', scopes, readPerm, zValidator('param', idParam), async (c) => {

--- a/apps/api/src/services/quoteService.clone.test.ts
+++ b/apps/api/src/services/quoteService.clone.test.ts
@@ -53,6 +53,8 @@ vi.mock('./quoteNumbers', () => ({
 import { cloneQuote } from './quoteService';
 
 const actor = { userId: 'user-1', partnerId: 'partner-1', accessibleOrgIds: ['org-1'] };
+// For retarget tests: may clone INTO org-2 (source stays org-1).
+const retargetActor = { userId: 'user-1', partnerId: 'partner-1', accessibleOrgIds: ['org-1', 'org-2'] };
 
 function sourceQuote() {
   return {
@@ -125,6 +127,73 @@ describe('cloneQuote', () => {
     const clonedChild = lineInsert.find((line) => line.name === 'Setup')!;
     expect(clonedParent).toMatchObject({ quoteId: cloned.id, blockId: clonedLinesBlock.id, imageId: clonedImage.id });
     expect(clonedChild.parentLineId).toBe(clonedParent.id);
+  });
+
+  it('retargets a clone to another company: new org on all rows, site/bill-to reset, tax re-resolved', async () => {
+    state.selectResults.push(
+      [sourceQuote()],
+      [{ id: 'block-lines', quoteId: 'quote-1', orgId: 'org-1', blockType: 'line_items', content: { label: 'Services' }, sortOrder: 0, createdAt: new Date() }],
+      [{ id: 'line-1', quoteId: 'quote-1', blockId: 'block-lines', orgId: 'org-1', sourceType: 'manual', catalogItemId: null, parentLineId: null, name: 'Server', description: null, quantity: '1.00', unitPrice: '100.00', taxable: true, customerVisible: true, lineTotal: '100.00', recurrence: 'one_time', termMonths: null, billingFrequency: null, unitCost: null, depositEligible: true, itemType: 'hardware', sku: null, partNumber: null, imageId: 'image-1', sortOrder: 0, createdAt: new Date() }],
+      [], // no staged Pax8 order
+      [{ id: 'image-1', quoteId: 'quote-1', orgId: 'org-1', imageData: Buffer.from('image'), mime: 'image/png', byteSize: 5, sha256: 'hash', createdAt: new Date() }],
+      [{ id: 'org-2' }], // target org same-partner membership check
+      // resolveQuoteTaxRate for the NEW org: 8% org rate, no partner default
+      [{ taxExempt: false, taxRate: '0.08000' }],
+      [{ defaultTaxRate: null }],
+    );
+
+    const cloned = await cloneQuote('quote-1', retargetActor, { orgId: 'org-2', title: 'Beta rollout' });
+
+    expect(state.transactionCalls).toBe(1);
+    const [quoteInsert, imageInsert, blockInsert, lineInsert] = state.insertedValues as [
+      Record<string, unknown>, Array<Record<string, unknown>>, Array<Record<string, unknown>>, Array<Record<string, unknown>>,
+    ];
+    expect(quoteInsert).toMatchObject({
+      id: cloned.id,
+      orgId: 'org-2',
+      // The site and bill-to override belonged to the OLD customer.
+      siteId: null,
+      billToName: null,
+      title: 'Beta rollout',
+      status: 'draft',
+      // Re-resolved for the new org, not the source's 5%.
+      taxRate: '0.08000',
+    });
+    // Denormalized org_id on EVERY child row follows the new company — a stray
+    // source.orgId on images would RLS-hide them from the new org's readers.
+    expect(imageInsert.every((i) => i.orgId === 'org-2')).toBe(true);
+    expect(blockInsert.every((b) => b.orgId === 'org-2')).toBe(true);
+    expect(lineInsert.every((l) => l.orgId === 'org-2')).toBe(true);
+  });
+
+  it('rejects a retarget by a site-restricted actor (the clone would land site-less)', async () => {
+    // The actor CAN see the source quote (site-1 is allowlisted) but retargeting
+    // clears the site — mirroring updateQuote, that must be denied.
+    state.selectResults.push([sourceQuote()], [], [], [], []);
+    const siteRestricted = { ...retargetActor, allowedSiteIds: ['site-1'] };
+
+    await expect(cloneQuote('quote-1', siteRestricted, { orgId: 'org-2' })).rejects.toMatchObject({ code: 'SITE_DENIED', status: 403 });
+    expect(state.transactionCalls).toBe(0);
+    expect(state.insertedValues).toEqual([]);
+  });
+
+  it('rejects retargeting to an org outside the actor scope', async () => {
+    state.selectResults.push([sourceQuote()], [], [], [], []);
+
+    await expect(cloneQuote('quote-1', actor, { orgId: 'org-2' })).rejects.toMatchObject({ code: 'ORG_DENIED', status: 403 });
+    expect(state.transactionCalls).toBe(0);
+    expect(state.insertedValues).toEqual([]);
+  });
+
+  it('rejects retargeting to an org of another partner (membership lookup misses)', async () => {
+    state.selectResults.push(
+      [sourceQuote()], [], [], [], [],
+      [], // membership check finds no org-2 row under partner-1
+    );
+
+    await expect(cloneQuote('quote-1', retargetActor, { orgId: 'org-2' })).rejects.toMatchObject({ code: 'ORG_NOT_FOUND', status: 404 });
+    expect(state.transactionCalls).toBe(0);
+    expect(state.insertedValues).toEqual([]);
   });
 
   it('rejects a cross-organization clone before creating anything', async () => {

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -10,8 +10,11 @@ function queueResult(rows: unknown[]) { results.push(rows); }
 vi.mock('../db', () => {
   const makeChain = () => {
     const chain: Record<string, unknown> = {};
-    const methods = ['select', 'from', 'where', 'limit', 'orderBy', 'insert', 'values', 'returning', 'update', 'set', 'delete', 'for', 'innerJoin', 'leftJoin', 'execute', 'transaction'];
+    const methods = ['select', 'from', 'where', 'limit', 'orderBy', 'insert', 'values', 'returning', 'update', 'set', 'delete', 'for', 'innerJoin', 'leftJoin', 'execute'];
     for (const m of methods) chain[m] = vi.fn(() => chain);
+    // Execute the callback with the same chain as `tx` — each awaited tx call
+    // still consumes one queued result, exactly like a bare db call.
+    chain.transaction = vi.fn(async (run: (tx: unknown) => unknown) => run(chain));
     (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) => {
       const rows = results.shift() ?? [];
       return Promise.resolve(rows).then(resolve);
@@ -89,6 +92,98 @@ describe('quoteService deposits', () => {
     expect(setMock.mock.calls[0]![0]).toMatchObject({ taxRate: '0.25000', depositType: 'percent', depositPercent: '50.00' });
     // Recompute persists the deposit_amount computed on the NEW 25% rate.
     expect(setMock.mock.calls[1]![0]).toMatchObject({ depositAmount: '62.50' });
+  });
+
+  it('updateQuote reassigns a draft to another company: children re-tenanted, site/bill-to reset, tax re-resolved', async () => {
+    const orgActor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1', 'org2'] };
+    // loadDraft
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', siteId: 's1', billToName: 'Old Co', taxRate: '0.10000', depositType: 'none', depositPercent: null }]);
+    queueResult([{ id: 'org2' }]); // target org same-partner membership check
+    // resolveQuoteTaxRate for the NEW org: 5% org rate, no partner default
+    queueResult([{ taxExempt: false, taxRate: '0.05000' }]);
+    queueResult([{ defaultTaxRate: null }]);
+    queueResult([]); // tx: quotes header update
+    queueResult([]); // tx: blocks org move
+    queueResult([]); // tx: lines org move
+    queueResult([]); // tx: images org move
+    // recomputeAndPersist: header select (new rate), lines, own update
+    queueResult([{ taxRate: '0.05000', depositType: 'none', depositPercent: null }]);
+    queueResult([{ quantity: '1', unitPrice: '100.00', taxable: true, customerVisible: true, recurrence: 'one_time', depositEligible: false, itemType: 'hardware' }]);
+    queueResult([]);
+    // final re-select
+    queueResult([{ id: 'q1', orgId: 'org2', siteId: null, billToName: null, taxRate: '0.05000' }]);
+
+    const updated = await svc.updateQuote('q1', { orgId: 'org2' }, orgActor);
+
+    expect(updated.orgId).toBe('org2');
+    const setMock = (db as unknown as Chain).set;
+    // Call 0: the header update moves the org, clears the old customer's site +
+    // bill-to override, and applies the new org's resolved tax rate.
+    expect(setMock.mock.calls[0]![0]).toMatchObject({ orgId: 'org2', siteId: null, billToName: null, taxRate: '0.05000' });
+    // Calls 1-3: denormalized org_id moves on blocks, lines, and images.
+    expect(setMock.mock.calls[1]![0]).toEqual({ orgId: 'org2' });
+    expect(setMock.mock.calls[2]![0]).toEqual({ orgId: 'org2' });
+    expect(setMock.mock.calls[3]![0]).toEqual({ orgId: 'org2' });
+  });
+
+  it('updateQuote org change with an explicit taxRate in the same patch skips re-resolution and keeps the explicit rate', async () => {
+    const orgActor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1', 'org2'] };
+    // loadDraft
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', siteId: null, billToName: null, taxRate: '0.10000', depositType: 'none', depositPercent: null }]);
+    queueResult([{ id: 'org2' }]); // membership check — NO resolveQuoteTaxRate selects follow
+    queueResult([]); // tx: quotes header update
+    queueResult([]); // tx: blocks org move
+    queueResult([]); // tx: lines org move
+    queueResult([]); // tx: images org move
+    queueResult([{ taxRate: '0.20000', depositType: 'none', depositPercent: null }]); // recompute header
+    queueResult([]); // recompute lines
+    queueResult([]); // recompute update
+    queueResult([{ id: 'q1', orgId: 'org2', taxRate: '0.20000' }]); // final re-select
+
+    const updated = await svc.updateQuote('q1', { orgId: 'org2', taxRate: 0.2 }, orgActor);
+
+    expect(updated.taxRate).toBe('0.20000');
+    const setMock = (db as unknown as Chain).set;
+    // The explicit rate wins — the org-change branch must not clobber it with a
+    // re-resolved default (nor consume the resolveQuoteTaxRate selects at all).
+    expect(setMock.mock.calls[0]![0]).toMatchObject({ orgId: 'org2', taxRate: '0.20000' });
+  });
+
+  it('updateQuote org change preserves a billToName supplied in the same patch', async () => {
+    const orgActor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1', 'org2'] };
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', siteId: null, billToName: 'Old Co', taxRate: null, depositType: 'none', depositPercent: null }]); // loadDraft
+    queueResult([{ id: 'org2' }]); // membership check
+    queueResult([{ taxExempt: false, taxRate: null }]); // resolveQuoteTaxRate org
+    queueResult([{ defaultTaxRate: null }]); // resolveQuoteTaxRate partner
+    queueResult([]); // tx: quotes header update
+    queueResult([]); // tx: blocks org move
+    queueResult([]); // tx: lines org move
+    queueResult([]); // tx: images org move
+    queueResult([{ taxRate: null, depositType: 'none', depositPercent: null }]); // recompute header
+    queueResult([]); // recompute lines
+    queueResult([]); // recompute update
+    queueResult([{ id: 'q1', orgId: 'org2', billToName: 'Fresh Contact' }]); // final re-select
+
+    await svc.updateQuote('q1', { orgId: 'org2', billToName: 'Fresh Contact' }, orgActor);
+
+    const setMock = (db as unknown as Chain).set;
+    // The fresh override survives the org change; only an unsupplied billToName
+    // is nulled as a stale reference to the old customer.
+    expect(setMock.mock.calls[0]![0]).toMatchObject({ orgId: 'org2', billToName: 'Fresh Contact' });
+  });
+
+  it('updateQuote rejects reassignment to an org outside the actor scope', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', taxRate: null, depositType: 'none', depositPercent: null }]);
+
+    await expect(svc.updateQuote('q1', { orgId: 'org2' }, actor)).rejects.toMatchObject({ code: 'ORG_DENIED', status: 403 });
+  });
+
+  it('updateQuote rejects reassignment to an org of another partner', async () => {
+    const orgActor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1', 'org2'] };
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', taxRate: null, depositType: 'none', depositPercent: null }]);
+    queueResult([]); // membership check finds no org2 row under p1
+
+    await expect(svc.updateQuote('q1', { orgId: 'org2' }, orgActor)).rejects.toMatchObject({ code: 'ORG_NOT_FOUND', status: 404 });
   });
 
   it('updateQuote throws DEPOSIT_REQUIRES_ONE_TIME_LINES when the quote has no one-time visible lines', async () => {

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -12,7 +12,7 @@ import { computeQuoteTotals, validateQuoteDeposit, toQuoteDepositConfig, type Qu
 import { QuoteServiceError, type QuoteActor } from './quoteTypes';
 import { allocateQuoteCounter, formatQuoteNumber } from './quoteNumbers';
 import type {
-  CreateQuoteInput, UpdateQuoteInput, QuoteLineInput, QuoteBlockInput, ListQuotesQuery
+  CreateQuoteInput, CloneQuoteInput, UpdateQuoteInput, QuoteLineInput, QuoteBlockInput, ListQuotesQuery
 } from '@breeze/shared';
 
 // ---------------------------------------------------------------------------
@@ -78,14 +78,18 @@ export function assertQuoteAccess(actor: QuoteActor, quote: { orgId: string; sit
  * totals). Routes per-line cents through the shared
  * computeLineTotal/toCents discipline (via computeQuoteTotals) so the header
  * totals are penny-consistent with the persisted line_total and with invoices.
+ *
+ * `dbc` lets a caller run the recompute inside its own transaction (updateQuote's
+ * org reassignment) so a mid-flight failure can't commit the header move while
+ * leaving totals computed under the old tax rate.
  */
-async function recomputeAndPersist(quoteId: string): Promise<void> {
-  const [q] = await db.select({
+async function recomputeAndPersist(quoteId: string, dbc: Pick<typeof db, 'select' | 'update'> = db): Promise<void> {
+  const [q] = await dbc.select({
     taxRate: quotes.taxRate,
     depositType: quotes.depositType,
     depositPercent: quotes.depositPercent,
   }).from(quotes).where(eq(quotes.id, quoteId)).limit(1);
-  const lines = await db.select({
+  const lines = await dbc.select({
     quantity: quoteLines.quantity,
     unitPrice: quoteLines.unitPrice,
     taxable: quoteLines.taxable,
@@ -96,7 +100,7 @@ async function recomputeAndPersist(quoteId: string): Promise<void> {
   }).from(quoteLines).where(eq(quoteLines.quoteId, quoteId));
   const deposit = toQuoteDepositConfig(q?.depositType, q?.depositPercent);
   const totals = computeQuoteTotals(lines as QuoteLineForMath[], q?.taxRate ? parseFloat(q.taxRate) : null, deposit);
-  await db.update(quotes).set({
+  await dbc.update(quotes).set({
     subtotal: totals.subtotal,
     taxTotal: totals.taxTotal,
     total: totals.total,
@@ -199,10 +203,37 @@ export async function createQuote(input: CreateQuoteInput, actor: QuoteActor) {
  * image.quote_id and line items can reference blocks, images, and parent lines.
  * Lifecycle, document, seller/customer snapshots, and expiry are intentionally
  * reset so an old accepted/expired quote is safe to revise and send again.
+ *
+ * `input` optionally retargets the clone to another organization of the same
+ * partner and/or renames it. Retargeting clears the site and billToName (both
+ * belong to the OLD customer) and re-resolves the tax rate for the new org —
+ * the same precedence createQuote uses — so totals are correct for the new
+ * customer; a same-org clone keeps the source rate verbatim (it may have been
+ * hand-set via the API).
  */
-export async function cloneQuote(id: string, actor: QuoteActor) {
+export async function cloneQuote(id: string, actor: QuoteActor, input: CloneQuoteInput = {}) {
   const { quote: source, blocks, lines } = await getQuote(id, actor);
   const images = await db.select().from(quoteImages).where(eq(quoteImages.quoteId, id));
+
+  const targetOrgId = input.orgId ?? source.orgId;
+  const orgChanged = targetOrgId !== source.orgId;
+  if (orgChanged) {
+    assertOrg(actor, targetOrgId);
+    // Retargeting lands the clone with a null site (the source's site belongs to
+    // the OLD org), which a site-restricted caller can never see — deny exactly
+    // as updateQuote's reassignment path does.
+    assertSite(actor, null);
+    // Same-partner guard. RLS hides other partners' orgs from this context, so a
+    // cross-partner id resolves to "not found" rather than leaking existence.
+    const [target] = await db.select({ id: organizations.id }).from(organizations)
+      .where(and(eq(organizations.id, targetOrgId), eq(organizations.partnerId, source.partnerId)))
+      .limit(1);
+    if (!target) throw new QuoteServiceError('Organization not found', 404, 'ORG_NOT_FOUND');
+  }
+  const taxRate = orgChanged
+    ? await resolveQuoteTaxRate(targetOrgId, source.partnerId)
+    : source.taxRate;
+  const title = input.title !== undefined ? (input.title.trim() || null) : source.title;
 
   const year = new Date().getUTCFullYear();
   const counter = await allocateQuoteCounter(source.partnerId, year);
@@ -214,7 +245,7 @@ export async function cloneQuote(id: string, actor: QuoteActor) {
   const lineIds = new Map(lines.map((line) => [line.id, randomUUID()]));
   const totals = computeQuoteTotals(
     lines as QuoteLineForMath[],
-    source.taxRate ? parseFloat(source.taxRate) : null,
+    taxRate ? parseFloat(taxRate) : null,
     toQuoteDepositConfig(source.depositType, source.depositPercent),
   );
 
@@ -222,10 +253,10 @@ export async function cloneQuote(id: string, actor: QuoteActor) {
     const [cloned] = await tx.insert(quotes).values({
       id: quoteId,
       partnerId: source.partnerId,
-      orgId: source.orgId,
-      siteId: source.siteId,
+      orgId: targetOrgId,
+      siteId: orgChanged ? null : source.siteId,
       quoteNumber,
-      title: source.title,
+      title,
       status: 'draft',
       currencyCode: source.currencyCode,
       issueDate: null,
@@ -234,7 +265,7 @@ export async function cloneQuote(id: string, actor: QuoteActor) {
       declinedAt: null,
       convertedAt: null,
       subtotal: totals.subtotal,
-      taxRate: source.taxRate,
+      taxRate,
       taxTotal: totals.taxTotal,
       total: totals.total,
       oneTimeTotal: totals.oneTimeTotal,
@@ -243,7 +274,7 @@ export async function cloneQuote(id: string, actor: QuoteActor) {
       depositType: source.depositType,
       depositPercent: source.depositPercent,
       depositAmount: totals.depositDueTotal,
-      billToName: source.billToName,
+      billToName: orgChanged ? null : source.billToName,
       billToAddress: null,
       billToTaxId: null,
       introNotes: source.introNotes,
@@ -264,7 +295,7 @@ export async function cloneQuote(id: string, actor: QuoteActor) {
       await tx.insert(quoteImages).values(images.map((image) => ({
         id: imageIds.get(image.id)!,
         quoteId,
-        orgId: source.orgId,
+        orgId: targetOrgId,
         imageData: image.imageData,
         mime: image.mime,
         byteSize: image.byteSize,
@@ -286,7 +317,7 @@ export async function cloneQuote(id: string, actor: QuoteActor) {
         return {
           id: blockIds.get(block.id)!,
           quoteId,
-          orgId: source.orgId,
+          orgId: targetOrgId,
           blockType: block.blockType,
           content,
           sortOrder: block.sortOrder,
@@ -299,7 +330,7 @@ export async function cloneQuote(id: string, actor: QuoteActor) {
         id: lineIds.get(line.id)!,
         quoteId,
         blockId: line.blockId ? blockIds.get(line.blockId) ?? null : null,
-        orgId: source.orgId,
+        orgId: targetOrgId,
         sourceType: line.sourceType,
         catalogItemId: line.catalogItemId,
         parentLineId: line.parentLineId ? lineIds.get(line.parentLineId) ?? null : null,
@@ -456,12 +487,36 @@ export async function listQuotes(query: ListQuotesQuery, actor: QuoteActor) {
 }
 
 /** Draft-only header edit. Only provided fields are written; nullable fields can be
- *  explicitly cleared with null. A tax-rate change triggers a totals recompute. */
+ *  explicitly cleared with null. A tax-rate change triggers a totals recompute.
+ *
+ *  `orgId` reassigns the draft to another organization of the same partner:
+ *  the site is cleared (it belongs to the old customer), the billToName
+ *  override is cleared and the tax rate re-resolved for the new org (each
+ *  unless the same patch sets a fresh value explicitly), and the denormalized
+ *  org_id on blocks/lines/images is moved in the same transaction so
+ *  RLS-scoped readers never see a half-moved quote. */
 export async function updateQuote(id: string, input: UpdateQuoteInput, actor: QuoteActor) {
   const q = await loadDraft(id, actor);
   // A site-restricted caller may not move the quote to a site it can't access
   // (nor clear it to null, which a restricted caller can never see).
   if (input.siteId !== undefined) assertSite(actor, input.siteId);
+  const orgChanged = input.orgId !== undefined && input.orgId !== q.orgId;
+  // Re-resolved org tax default; undefined = org unchanged (keep current rate).
+  let orgTaxRate: string | null | undefined;
+  if (orgChanged) {
+    const targetOrgId = input.orgId!;
+    assertOrg(actor, targetOrgId);
+    // Reassignment clears the site, and a site-restricted caller can never see a
+    // null-site quote — deny exactly as assertSite would for an explicit null.
+    assertSite(actor, null);
+    // Same-partner guard; RLS hides other partners' orgs so a cross-partner id
+    // resolves to "not found" rather than leaking existence.
+    const [target] = await db.select({ id: organizations.id }).from(organizations)
+      .where(and(eq(organizations.id, targetOrgId), eq(organizations.partnerId, q.partnerId)))
+      .limit(1);
+    if (!target) throw new QuoteServiceError('Organization not found', 404, 'ORG_NOT_FOUND');
+    if (input.taxRate === undefined) orgTaxRate = await resolveQuoteTaxRate(targetOrgId, q.partnerId);
+  }
   const set: Record<string, unknown> = { updatedAt: new Date() };
   if (input.siteId !== undefined) set.siteId = input.siteId;
   if (input.title !== undefined) set.title = input.title === null ? null : input.title.trim() || null;
@@ -483,7 +538,13 @@ export async function updateQuote(id: string, input: UpdateQuoteInput, actor: Qu
     // Include an in-flight taxRate change from THIS SAME patch — a deposit
     // validated against the stale persisted rate could pass here and then fail
     // (or silently mis-total) once the new tax rate lands via recomputeAndPersist.
-    const effectiveTaxRate = (input.taxRate !== undefined ? input.taxRate : (q.taxRate ? parseFloat(q.taxRate) : null));
+    // An org change re-resolves the rate too (orgTaxRate) and must be coherent
+    // the same way.
+    const effectiveTaxRate = input.taxRate !== undefined
+      ? input.taxRate
+      : orgTaxRate !== undefined
+        ? (orgTaxRate ? parseFloat(orgTaxRate) : null)
+        : (q.taxRate ? parseFloat(q.taxRate) : null);
     const check = validateQuoteDeposit(
       lines as QuoteLineForMath[],
       effectiveTaxRate === null ? null : Number(effectiveTaxRate),
@@ -493,8 +554,32 @@ export async function updateQuote(id: string, input: UpdateQuoteInput, actor: Qu
     set.depositType = nextType;
     set.depositPercent = nextType === 'percent' && nextPercent != null ? Number(nextPercent).toFixed(2) : null;
   }
-  await db.update(quotes).set(set).where(eq(quotes.id, id));
-  await recomputeAndPersist(id);
+  if (orgChanged) {
+    const targetOrgId = input.orgId!;
+    set.orgId = targetOrgId;
+    // The site belongs to the OLD org — always cleared, even if the same patch
+    // named one (a site can't be validated against the new org here).
+    set.siteId = null;
+    // A billToName override referenced the old customer; drop it so the draft
+    // bill-to falls back to the new org's name/address, unless this same patch
+    // sets a fresh override explicitly.
+    if (input.billToName === undefined) set.billToName = null;
+    if (orgTaxRate !== undefined) set.taxRate = orgTaxRate;
+    await db.transaction(async (tx) => {
+      await tx.update(quotes).set(set).where(eq(quotes.id, id));
+      // Move the denormalized org_id on every child row in the same transaction.
+      await tx.update(quoteBlocks).set({ orgId: targetOrgId }).where(eq(quoteBlocks.quoteId, id));
+      await tx.update(quoteLines).set({ orgId: targetOrgId }).where(eq(quoteLines.quoteId, id));
+      await tx.update(quoteImages).set({ orgId: targetOrgId }).where(eq(quoteImages.quoteId, id));
+      // Recompute INSIDE the transaction: a failure here must roll back the org
+      // move too, never commit the quote onto the new org with totals still
+      // computed under the old tax rate.
+      await recomputeAndPersist(id, tx);
+    });
+  } else {
+    await db.update(quotes).set(set).where(eq(quotes.id, id));
+    await recomputeAndPersist(id);
+  }
   const [updated] = await db.select().from(quotes).where(eq(quotes.id, id)).limit(1);
   return updated!;
 }

--- a/apps/api/src/services/quoteTypes.ts
+++ b/apps/api/src/services/quoteTypes.ts
@@ -25,6 +25,7 @@ export interface QuoteActor {
 export type QuoteServiceErrorCode =
   | 'PARTNER_UNRESOLVABLE'
   | 'ORG_DENIED'
+  | 'ORG_NOT_FOUND'
   | 'SITE_DENIED'
   | 'QUOTE_NOT_FOUND'
   | 'NOT_A_DRAFT'

--- a/apps/web/src/components/billing/quotes/QuoteActions.clone.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.clone.test.tsx
@@ -9,10 +9,13 @@ const mocks = vi.hoisted(() => ({
   cloneQuote: vi.fn(),
   navigateTo: vi.fn(),
   runAction: vi.fn(),
+  organizations: [] as Array<{ id: string; name: string }>,
 }));
 
 vi.mock('../../../lib/permissions', () => ({ usePermissions: () => ({ can: mocks.can }) }));
-vi.mock('../../../stores/orgStore', () => ({ useOrgStore: (sel: (s: { organizations: unknown[] }) => unknown) => sel({ organizations: [] }) }));
+vi.mock('../../../stores/orgStore', () => ({
+  useOrgStore: (sel: (s: { organizations: unknown[] }) => unknown) => sel({ organizations: mocks.organizations }),
+}));
 vi.mock('@/lib/navigation', () => ({ navigateTo: mocks.navigateTo }));
 vi.mock('../../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
 vi.mock('../../../lib/api/quotes', () => ({
@@ -41,9 +44,19 @@ const detail: QuoteDetailData = {
   lines: [],
 };
 
+/** Header variant folds Clone into the ⋯ overflow menu; open it first. */
+function openCloneDialog() {
+  fireEvent.click(screen.getByTestId('quote-actions-menu'));
+  fireEvent.click(screen.getByTestId('quote-clone'));
+}
+
 describe('QuoteActions cloning', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.organizations = [
+      { id: 'org-2', name: 'Beta Corp' },
+      { id: 'org-1', name: 'Acme' },
+    ];
     mocks.can.mockImplementation((_resource: string, action: string) => action === 'read' || action === 'write');
     mocks.runAction.mockImplementation(async ({ request }: { request: () => Promise<unknown> }) => {
       await request();
@@ -55,9 +68,16 @@ describe('QuoteActions cloning', () => {
   it('clones any readable quote with write permission and opens the new draft', async () => {
     render(<QuoteActions detail={detail} variant="header" />);
 
-    fireEvent.click(screen.getByTestId('quote-clone'));
+    openCloneDialog();
+    // The dialog defaults to the source company and a "Clone of …" title.
+    expect(screen.getByTestId('quote-clone-org')).toHaveValue('org-1');
+    expect(screen.getByTestId('quote-clone-title')).toHaveValue('Clone of Q-2026-000001');
+    fireEvent.click(screen.getByTestId('quote-clone-confirm'));
 
-    await waitFor(() => expect(mocks.cloneQuote).toHaveBeenCalledWith('q-1'));
+    await waitFor(() => expect(mocks.cloneQuote).toHaveBeenCalledWith('q-1', {
+      orgId: 'org-1',
+      title: 'Clone of Q-2026-000001',
+    }));
     expect(mocks.runAction).toHaveBeenCalledWith(expect.objectContaining({
       successMessage: 'Quote cloned.',
       errorFallback: 'Could not clone the quote.',
@@ -65,21 +85,58 @@ describe('QuoteActions cloning', () => {
     expect(mocks.navigateTo).toHaveBeenCalledWith('/billing/quotes/q-2');
   });
 
+  it('retargets the clone to another company chosen in the dialog', async () => {
+    render(<QuoteActions detail={detail} variant="header" />);
+
+    openCloneDialog();
+    fireEvent.change(screen.getByTestId('quote-clone-org'), { target: { value: 'org-2' } });
+    // Retargeting surfaces the billing/tax consequences before confirming.
+    expect(screen.getByTestId('quote-clone-retarget-hint')).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId('quote-clone-title'), { target: { value: 'Beta rollout' } });
+    fireEvent.click(screen.getByTestId('quote-clone-confirm'));
+
+    await waitFor(() => expect(mocks.cloneQuote).toHaveBeenCalledWith('q-1', {
+      orgId: 'org-2',
+      title: 'Beta rollout',
+    }));
+    expect(mocks.navigateTo).toHaveBeenCalledWith('/billing/quotes/q-2');
+  });
+
+  it('sends an emptied title as "" so the clone is untitled, not silently renamed back', async () => {
+    render(<QuoteActions detail={detail} variant="header" />);
+
+    openCloneDialog();
+    fireEvent.change(screen.getByTestId('quote-clone-title'), { target: { value: '   ' } });
+    fireEvent.click(screen.getByTestId('quote-clone-confirm'));
+
+    await waitFor(() => expect(mocks.cloneQuote).toHaveBeenCalledWith('q-1', { orgId: 'org-1', title: '' }));
+  });
+
   it('does not offer cloning to a read-only user', () => {
     mocks.can.mockImplementation((_resource: string, action: string) => action === 'read');
 
     render(<QuoteActions detail={detail} variant="header" />);
 
+    expect(screen.queryByTestId('quote-actions-menu')).not.toBeInTheDocument();
     expect(screen.queryByTestId('quote-clone')).not.toBeInTheDocument();
   });
 
   it('holds cloning while draft changes are still saving', () => {
     render(<QuoteActions detail={{ ...detail, quote: { ...detail.quote, status: 'draft' } }} variant="header" savePending />);
 
+    fireEvent.click(screen.getByTestId('quote-actions-menu'));
     expect(screen.getByTestId('quote-clone')).toBeDisabled();
     expect(screen.getByTestId('quote-clone')).toHaveAttribute(
       'title',
       'Wait for changes to finish saving before cloning.',
     );
+  });
+
+  it('keeps Clone as a visible stacked button in the rail variant', () => {
+    render(<QuoteActions detail={detail} variant="rail" />);
+
+    expect(screen.queryByTestId('quote-actions-menu')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('quote-clone'));
+    expect(screen.getByTestId('quote-clone-confirm')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { MoreHorizontal } from 'lucide-react';
 import '../../../lib/i18n';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../../lib/runAction';
@@ -7,6 +8,7 @@ import { usePermissions } from '../../../lib/permissions';
 import { useOrgStore } from '../../../stores/orgStore';
 import { cloneQuote, deleteQuote, sendQuote } from '../../../lib/api/quotes';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
+import { Dialog } from '../../shared/Dialog';
 import { useQuotePdfDownload } from './useQuoteImage';
 import { type QuoteDetail as QuoteDetailData, formatMoney } from './quoteTypes';
 
@@ -49,7 +51,28 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
   const [delOpen, setDelOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [cloning, setCloning] = useState(false);
+  const [cloneOpen, setCloneOpen] = useState(false);
+  const [cloneOrgId, setCloneOrgId] = useState(quote.orgId);
+  const [cloneTitle, setCloneTitle] = useState('');
+  // Header-variant overflow menu (Clone / Delete) so the header cluster stays a
+  // stable two-buttons-plus-kebab instead of a wrapping four-button row.
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
   const refresh = useCallback(() => onChanged?.(), [onChanged]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onPointerDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
+    };
+    const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') setMenuOpen(false); };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [menuOpen]);
 
   // An empty quote (no blocks, no lines) can't be sent.
   const isEmpty = blocks.length === 0 && lines.length === 0;
@@ -61,6 +84,17 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
     const resolved = organizations.find((o) => o.id === quote.orgId)?.name?.trim();
     return resolved || quote.orgId.slice(0, 8);
   }, [quote.billToName, quote.orgId, organizations]);
+
+  // Company choices for the clone dialog: the partner's org list, with the
+  // quote's own org prepended if it isn't loaded (e.g. All-orgs scope) so the
+  // select always has a valid default.
+  const orgOptions = useMemo(() => {
+    const sorted = [...organizations].sort((a, b) => a.name.localeCompare(b.name));
+    if (!sorted.some((o) => o.id === quote.orgId)) {
+      sorted.unshift({ id: quote.orgId, name: orgName } as (typeof sorted)[number]);
+    }
+    return sorted;
+  }, [organizations, quote.orgId, orgName]);
 
   const send = useCallback(async () => {
     if (sending) return;
@@ -103,23 +137,39 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
     }
   }, [deleting, quote.id, t]);
 
+  // Prime the dialog with the current company and a "Clone of …" title the user
+  // can overwrite. maxLength mirrors the API's 200-char title cap.
+  const openClone = useCallback(() => {
+    setMenuOpen(false);
+    setCloneOrgId(quote.orgId);
+    setCloneTitle(
+      t('quotes.actions.cloneDialog.defaultTitle', {
+        name: quote.title?.trim() || quote.quoteNumber || '',
+      }).slice(0, 200),
+    );
+    setCloneOpen(true);
+  }, [quote.orgId, quote.title, quote.quoteNumber, t]);
+
   const clone = useCallback(async () => {
     if (cloning || savePending) return;
     setCloning(true);
     try {
+      // Always send the title — an emptied field means "untitled clone" (the API
+      // nulls a blank), not "inherit the source title".
       const result = await runAction<{ data: { id: string } }>({
-        request: () => cloneQuote(quote.id),
+        request: () => cloneQuote(quote.id, { orgId: cloneOrgId, title: cloneTitle.trim() }),
         errorFallback: t('quotes.actions.cloneError'),
         successMessage: t('quotes.actions.cloneSuccess'),
         onUnauthorized: UNAUTHORIZED,
       });
+      setCloneOpen(false);
       if (result?.data?.id) void navigateTo(`/billing/quotes/${result.data.id}`);
     } catch (err) {
       handleActionError(err, t('quotes.actions.cloneError'));
     } finally {
       setCloning(false);
     }
-  }, [cloning, quote.id, savePending, t]);
+  }, [cloning, quote.id, cloneOrgId, cloneTitle, savePending, t]);
 
   const header = variant === 'header';
   // Rail buttons stretch full-width and stack; header buttons size to content and
@@ -165,10 +215,13 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             {sending ? t('quotes.actions.sending') : savePending ? t('common:states.saving') : t('quotes.actions.sendProposal')}
           </button>
         )}
-        {canClone && (
+        {/* In the rail the secondary actions stack as full-width buttons; in the
+            header they fold into the kebab menu below so the cluster stays a
+            stable Send + Download + ⋯ row that doesn't wrap awkwardly. */}
+        {!header && canClone && (
           <button
             type="button"
-            onClick={() => void clone()}
+            onClick={openClone}
             disabled={cloning || savePending}
             title={savePending ? t('quotes.actions.cloneSavingTitle') : undefined}
             data-testid="quote-clone"
@@ -190,7 +243,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             {t('quotes.actions.downloadPdf')}
           </button>
         )}
-        {canDelete && (
+        {!header && canDelete && (
           <button
             type="button"
             onClick={() => setDelOpen(true)}
@@ -199,6 +252,54 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
           >
             {t('quotes.actions.deleteDraft')}
           </button>
+        )}
+        {header && (canClone || canDelete) && (
+          <div className="relative" ref={menuRef}>
+            <button
+              type="button"
+              onClick={() => setMenuOpen((v) => !v)}
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              aria-label={t('quotes.actions.moreActions')}
+              title={t('quotes.actions.moreActions')}
+              data-testid="quote-actions-menu"
+              className="inline-flex items-center justify-center rounded-md border px-2.5 py-2 text-sm font-medium hover:bg-muted"
+            >
+              <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
+            </button>
+            {menuOpen && (
+              <div
+                role="menu"
+                data-testid="quote-actions-menu-list"
+                className="absolute right-0 top-full z-20 mt-1 w-44 rounded-md border bg-card py-1 shadow-lg"
+              >
+                {canClone && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={openClone}
+                    disabled={cloning || savePending}
+                    title={savePending ? t('quotes.actions.cloneSavingTitle') : undefined}
+                    data-testid="quote-clone"
+                    className="block w-full px-3 py-2 text-left text-sm hover:bg-muted disabled:opacity-50"
+                  >
+                    {cloning ? t('quotes.actions.cloning') : t('quotes.actions.cloneQuote')}
+                  </button>
+                )}
+                {canDelete && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => { setMenuOpen(false); setDelOpen(true); }}
+                    data-testid="quote-delete-open"
+                    className="block w-full px-3 py-2 text-left text-sm text-destructive hover:bg-destructive/10"
+                  >
+                    {t('quotes.actions.deleteDraft')}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
         )}
         {canSend && isEmpty && (
           // Visible in BOTH variants — a sighted keyboard user (or anyone not
@@ -268,6 +369,78 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
         confirmLabel={t('quotes.actions.deleteDraft')}
         confirmTestId="quote-delete-confirm"
       />
+      {/* Clone dialog: pick the company the new draft is for (defaults to the
+          source quote's company) and a title (defaults to "Clone of …"). */}
+      <Dialog
+        open={cloneOpen}
+        onClose={() => { if (!cloning) setCloneOpen(false); }}
+        title={t('quotes.actions.cloneDialog.title')}
+        labelledBy="quote-clone-dialog-title"
+        maxWidth="md"
+        className="p-6"
+      >
+        <h3 id="quote-clone-dialog-title" className="text-base font-semibold text-foreground">
+          {t('quotes.actions.cloneDialog.title')}
+        </h3>
+        <p className="mt-1 text-sm text-muted-foreground">{t('quotes.actions.cloneDialog.message')}</p>
+        <div className="mt-4 space-y-3">
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-foreground">
+              {t('quotes.actions.cloneDialog.companyLabel')}
+            </span>
+            <select
+              value={cloneOrgId}
+              onChange={(e) => setCloneOrgId(e.target.value)}
+              disabled={cloning}
+              data-testid="quote-clone-org"
+              className="h-9 w-full rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+            >
+              {orgOptions.map((o) => (
+                <option key={o.id} value={o.id}>{o.name}</option>
+              ))}
+            </select>
+          </label>
+          {cloneOrgId !== quote.orgId && (
+            <p className="text-xs text-muted-foreground" data-testid="quote-clone-retarget-hint">
+              {t('quotes.actions.cloneDialog.retargetHint')}
+            </p>
+          )}
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-foreground">
+              {t('quotes.actions.cloneDialog.titleLabel')}
+            </span>
+            <input
+              type="text"
+              value={cloneTitle}
+              maxLength={200}
+              onChange={(e) => setCloneTitle(e.target.value)}
+              disabled={cloning}
+              placeholder={t('quotes.editor.title.placeholder')}
+              data-testid="quote-clone-title"
+              className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+            />
+          </label>
+        </div>
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={() => setCloneOpen(false)}
+            disabled={cloning}
+            className="rounded-md border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+          >
+            {t('common:actions.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={() => void clone()}
+            disabled={cloning || savePending}
+            data-testid="quote-clone-confirm"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:opacity-90 disabled:opacity-50"
+          >
+            {cloning ? t('quotes.actions.cloning') : t('quotes.actions.cloneDialog.confirm')}
+          </button>
+        </div>
+      </Dialog>
     </>
   );
 }

--- a/apps/web/src/components/billing/quotes/QuoteEditor.costmarkup.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.costmarkup.test.tsx
@@ -9,6 +9,9 @@ import { enrichCatalogItemRequest } from '../../../lib/api/catalog';
 
 // Writer permissions so the inline line editor renders (read-only hides it).
 vi.mock('../../../stores/auth', () => ({
+  // orgStore (imported by QuoteEditor for the customer select) registers an
+  // org-id provider against the auth store at module scope.
+  registerOrgIdProvider: vi.fn(),
   fetchWithAuth: vi.fn().mockResolvedValue(
     { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
   ),

--- a/apps/web/src/components/billing/quotes/QuoteEditor.customer.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.customer.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { fetchWithAuth } from '../../../stores/auth';
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../../../stores/orgStore', () => ({
+  useOrgStore: (sel: (s: { organizations: unknown[] }) => unknown) => sel({
+    organizations: [
+      { id: 'org-2', name: 'Beta Corp' },
+      { id: 'org-1', name: 'Acme' },
+    ],
+  }),
+}));
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+  catalogItemImagePath: vi.fn().mockReturnValue('/catalog/img'),
+}));
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(), deleteBlock: vi.fn(), addManualLine: vi.fn(), addCatalogLine: vi.fn(),
+  updateLine: vi.fn(), removeLine: vi.fn(), moveLine: vi.fn(), reorderBlocks: vi.fn(), reorderLines: vi.fn(),
+  uploadQuoteImage: vi.fn(), quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+  updateBlock: vi.fn(),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+function detail(): QuoteDetailData {
+  return {
+    quote: {
+      id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+      taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+      annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '0.00', depositType: 'none', depositPercent: null,
+      billToName: null, introNotes: null, terms: null, termsAndConditions: null, sellerSnapshot: null,
+      acceptedAt: null, declinedAt: null, convertedAt: null, convertedInvoiceId: null,
+      sentAt: null, viewedAt: null, createdBy: null,
+      createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+    },
+    blocks: [],
+    lines: [],
+  };
+}
+
+const customerPatchCalls = () =>
+  fetchMock.mock.calls.filter((c) => c[0] === '/quotes/q-1' && (c[1] as RequestInit | undefined)?.method === 'PATCH'
+    && String((c[1] as RequestInit).body).includes('orgId'));
+
+describe('QuoteEditor customer reassignment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockImplementation(async () => json({ data: {} }));
+  });
+
+  it('changing the customer PATCHes { orgId } and refreshes the detail', async () => {
+    const onChanged = vi.fn();
+    render(<QuoteEditor detail={detail()} onChanged={onChanged} />);
+
+    const select = screen.getByTestId('quote-customer');
+    expect(select).toHaveValue('org-1');
+    fireEvent.change(select, { target: { value: 'org-2' } });
+
+    await waitFor(() => expect(customerPatchCalls()).toHaveLength(1));
+    expect(JSON.parse(String((customerPatchCalls()[0]![1] as RequestInit).body))).toEqual({ orgId: 'org-2' });
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  it('re-selecting the current customer is a no-op', () => {
+    render(<QuoteEditor detail={detail()} onChanged={vi.fn()} />);
+
+    fireEvent.change(screen.getByTestId('quote-customer'), { target: { value: 'org-1' } });
+
+    expect(customerPatchCalls()).toHaveLength(0);
+  });
+
+  it('snaps the select back when the move fails', async () => {
+    fetchMock.mockImplementation(async (path, init) => {
+      if (path === '/quotes/q-1' && (init as RequestInit | undefined)?.method === 'PATCH') {
+        return json({ error: 'Organization not found' }, false, 404);
+      }
+      return json({ data: {} });
+    });
+    render(<QuoteEditor detail={detail()} onChanged={vi.fn()} />);
+
+    const select = screen.getByTestId('quote-customer');
+    fireEvent.change(select, { target: { value: 'org-2' } });
+
+    await waitFor(() => expect(select).toHaveValue('org-1'));
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.deposit.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.deposit.test.tsx
@@ -7,6 +7,9 @@ import { fetchWithAuth } from '../../../stores/auth';
 import { updateLine } from '../../../lib/api/quotes';
 
 vi.mock('../../../stores/auth', () => ({
+  // orgStore (imported by QuoteEditor for the customer select) registers an
+  // org-id provider against the auth store at module scope.
+  registerOrgIdProvider: vi.fn(),
   fetchWithAuth: vi.fn(),
   useAuthStore: Object.assign(
     (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>

--- a/apps/web/src/components/billing/quotes/QuoteEditor.distributor.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.distributor.test.tsx
@@ -32,7 +32,7 @@ const newItem = { id: 'cat-1', sku: 'ABC123', name: 'Widget', unitPrice: '120.00
 
 // Minimal detail with one line_items block.
 const detail: QuoteDetail = {
-  quote: { id: 'q1', currencyCode: 'USD', termsAndConditions: '', status: 'draft' } as never,
+  quote: { id: 'q1', orgId: 'org-1', currencyCode: 'USD', termsAndConditions: '', status: 'draft' } as never,
   blocks: [{ id: 'blk1', blockType: 'line_items', sortOrder: 0, content: {} } as never],
   lines: [],
 };

--- a/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
@@ -7,6 +7,9 @@ import { updateLine, uploadQuoteImage } from '../../../lib/api/quotes';
 
 // Writer permissions so the inline line editor renders (read-only hides it).
 vi.mock('../../../stores/auth', () => ({
+  // orgStore (imported by QuoteEditor for the customer select) registers an
+  // org-id provider against the auth store at module scope.
+  registerOrgIdProvider: vi.fn(),
   fetchWithAuth: vi.fn().mockResolvedValue(
     { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
   ),

--- a/apps/web/src/components/billing/quotes/QuoteEditor.imageurl.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.imageurl.test.tsx
@@ -6,6 +6,9 @@ import type { QuoteDetail as QuoteDetailData, QuoteBlock, QuoteLine } from './qu
 import { addBlock, addQuoteImageFromUrl, updateLine } from '../../../lib/api/quotes';
 
 vi.mock('../../../stores/auth', () => ({
+  // orgStore (imported by QuoteEditor for the customer select) registers an
+  // org-id provider against the auth store at module scope.
+  registerOrgIdProvider: vi.fn(),
   fetchWithAuth: vi.fn().mockResolvedValue(
     { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
   ),

--- a/apps/web/src/components/billing/quotes/QuoteEditor.moveline.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.moveline.test.tsx
@@ -6,6 +6,9 @@ import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
 import { moveLine, reorderLines } from '../../../lib/api/quotes';
 
 vi.mock('../../../stores/auth', () => ({
+  // orgStore (imported by QuoteEditor for the customer select) registers an
+  // org-id provider against the auth store at module scope.
+  registerOrgIdProvider: vi.fn(),
   fetchWithAuth: vi.fn().mockResolvedValue(
     { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
   ),

--- a/apps/web/src/components/billing/quotes/QuoteEditor.permissions.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.permissions.test.tsx
@@ -16,6 +16,9 @@ type Perm = { resource: string; action: string };
 const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
 
 vi.mock('../../../stores/auth', () => ({
+  // orgStore (imported by QuoteEditor for the customer select) registers an
+  // org-id provider against the auth store at module scope.
+  registerOrgIdProvider: vi.fn(),
   fetchWithAuth: vi.fn(),
   useAuthStore: Object.assign(
     (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>

--- a/apps/web/src/components/billing/quotes/QuoteEditor.removeblock.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.removeblock.test.tsx
@@ -7,6 +7,9 @@ import type { QuoteBlock, QuoteDetail as QuoteDetailData, QuoteLine } from './qu
 import { fetchWithAuth } from '../../../stores/auth';
 
 vi.mock('../../../stores/auth', () => ({
+  // orgStore (imported by QuoteEditor for the customer select) registers an
+  // org-id provider against the auth store at module scope.
+  registerOrgIdProvider: vi.fn(),
   fetchWithAuth: vi.fn(),
   useAuthStore: Object.assign(
     (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>

--- a/apps/web/src/components/billing/quotes/QuoteEditor.reorder.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.reorder.test.tsx
@@ -7,6 +7,9 @@ import { reorderBlocks, reorderLines } from '../../../lib/api/quotes';
 
 // Writer permissions so the editor controls (incl. move buttons) render.
 vi.mock('../../../stores/auth', () => ({
+  // orgStore (imported by QuoteEditor for the customer select) registers an
+  // org-id provider against the auth store at module scope.
+  registerOrgIdProvider: vi.fn(),
   fetchWithAuth: vi.fn().mockResolvedValue(
     { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
   ),

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tablelabel.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tablelabel.test.tsx
@@ -7,6 +7,9 @@ import { updateBlock } from '../../../lib/api/quotes';
 
 // Writer permissions so the inline label editor renders (read-only hides it).
 vi.mock('../../../stores/auth', () => ({
+  // orgStore (imported by QuoteEditor for the customer select) registers an
+  // org-id provider against the auth store at module scope.
+  registerOrgIdProvider: vi.fn(),
   fetchWithAuth: vi.fn().mockResolvedValue(
     { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
   ),

--- a/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
@@ -6,6 +6,9 @@ import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
 import { fetchWithAuth } from '../../../stores/auth';
 
 vi.mock('../../../stores/auth', () => ({
+  // orgStore (imported by QuoteEditor for the customer select) registers an
+  // org-id provider against the auth store at module scope.
+  registerOrgIdProvider: vi.fn(),
   fetchWithAuth: vi.fn(),
   useAuthStore: Object.assign(
     (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -6,6 +6,7 @@ import { navigateTo } from '@/lib/navigation';
 import { fetchWithAuth } from '../../../stores/auth';
 import { runAction, handleActionError } from '../../../lib/runAction';
 import { usePermissions } from '../../../lib/permissions';
+import { useOrgStore } from '../../../stores/orgStore';
 import { formatPercent } from '@/lib/i18n/format';
 import {
   addBlock,
@@ -340,6 +341,57 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
     }, t('quotes.editor.errors.saveTitle'));
     if (ok) flashTitleSaved();
   }, [titleDirty, title, quote.id, refresh, runScoped, flashTitleSaved, t]);
+
+  // ---- customer (organization) reassignment --------------------------------
+  // Company choices for the customer select: the partner's org list, with the
+  // quote's own org prepended if it isn't loaded (e.g. All-orgs scope) so the
+  // select always shows a valid current value.
+  const organizations = useOrgStore((s) => s.organizations);
+  const orgOptions = useMemo(() => {
+    const sorted = [...organizations].sort((a, b) => a.name.localeCompare(b.name));
+    if (!sorted.some((o) => o.id === quote.orgId)) {
+      sorted.unshift({
+        id: quote.orgId,
+        name: detail.billTo?.name?.trim() || quote.orgId.slice(0, 8),
+      } as (typeof sorted)[number]);
+    }
+    return sorted;
+  }, [organizations, quote.orgId, detail.billTo?.name]);
+
+  // Local mirror so the select shows the chosen company instantly instead of
+  // snapping back to the prop value while the PATCH is in flight (same pattern
+  // as the deposit controls); resyncs from the server after each refresh().
+  const [customerOrgId, setCustomerOrgId] = useState(quote.orgId);
+  useEffect(() => { setCustomerOrgId(quote.orgId); }, [quote.orgId]);
+
+  // Reassign the draft to another company. The server clears the site + bill-to
+  // override and re-resolves the org's tax rate, so refresh() re-pulls the whole
+  // detail to land the recomputed totals and the new bill-to in one hop.
+  const saveCustomer = useCallback((orgId: string) => {
+    if (orgId === quote.orgId) return;
+    const name = orgOptions.find((o) => o.id === orgId)?.name ?? '';
+    setCustomerOrgId(orgId);
+    void runScoped('customer', async () => {
+      try {
+        await runAction({
+          request: () => fetchWithAuth(`/quotes/${quote.id}`, {
+            method: 'PATCH', body: JSON.stringify({ orgId }),
+          }),
+          errorFallback: t('quotes.editor.errors.saveCustomer'),
+          successMessage: t('quotes.editor.customer.success', { name }),
+          onUnauthorized: UNAUTHORIZED,
+        });
+      } catch (err) {
+        // Snap back to the last-known server value, then re-pull: on an error
+        // the client can't know whether the move landed, so re-converge on
+        // server truth instead of asserting a rollback.
+        setCustomerOrgId(quote.orgId);
+        refresh();
+        throw err;
+      }
+      refresh();
+    }, t('quotes.editor.errors.saveCustomer'));
+  }, [quote.id, quote.orgId, orgOptions, refresh, runScoped, t]);
 
   // Persist a deposit-config change via the quote-header PATCH. runAction surfaces
   // the API's 400 DEPOSIT_* validation message (e.g. "Deposit must be less than the
@@ -1125,21 +1177,42 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
         </button>
       </div>
       {canWrite && (
-        <div className="max-w-xl">
-          <label htmlFor="quote-title" className="mb-1 block text-xs text-muted-foreground">{t('quotes.editor.title.label')}</label>
-          <input
-            id="quote-title"
-            type="text"
-            value={title}
-            maxLength={200}
-            placeholder={t('quotes.editor.title.placeholder')}
-            onChange={(e) => { setTitle(e.target.value); setTitleDirty(true); }}
-            onBlur={() => void saveTitle()}
-            disabled={isPending('title')}
-            data-testid="quote-title"
-            className={`h-9 w-full rounded-md border bg-background px-3 text-sm font-medium transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(titleDirty, titleSaved)}`}
-          />
-          <SrSaved show={titleSaved} testId="quote-title-saved" />
+        <div className="flex max-w-3xl flex-wrap items-start gap-3">
+          <div className="min-w-64 flex-1">
+            <label htmlFor="quote-title" className="mb-1 block text-xs text-muted-foreground">{t('quotes.editor.title.label')}</label>
+            <input
+              id="quote-title"
+              type="text"
+              value={title}
+              maxLength={200}
+              placeholder={t('quotes.editor.title.placeholder')}
+              onChange={(e) => { setTitle(e.target.value); setTitleDirty(true); }}
+              onBlur={() => void saveTitle()}
+              disabled={isPending('title')}
+              data-testid="quote-title"
+              className={`h-9 w-full rounded-md border bg-background px-3 text-sm font-medium transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(titleDirty, titleSaved)}`}
+            />
+            <SrSaved show={titleSaved} testId="quote-title-saved" />
+          </div>
+          {/* Customer reassignment (drafts only — this editor only mounts for
+              drafts). Selecting a company saves immediately; the server clears
+              the site + bill-to override and applies the new org's tax rate. */}
+          <div className="w-64 max-w-full">
+            <label htmlFor="quote-customer" className="mb-1 block text-xs text-muted-foreground">{t('quotes.editor.customer.label')}</label>
+            <select
+              id="quote-customer"
+              value={customerOrgId}
+              onChange={(e) => saveCustomer(e.target.value)}
+              disabled={isPending('customer')}
+              title={t('quotes.editor.customer.help')}
+              data-testid="quote-customer"
+              className="h-9 w-full rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+            >
+              {orgOptions.map((o) => (
+                <option key={o.id} value={o.id}>{o.name}</option>
+              ))}
+            </select>
+          </div>
         </div>
       )}
       <div className="grid gap-6 lg:grid-cols-[1fr_320px]">

--- a/apps/web/src/lib/api/quotes.ts
+++ b/apps/web/src/lib/api/quotes.ts
@@ -69,8 +69,14 @@ export function createQuote(body: CreateQuoteInput): Promise<Response> {
   });
 }
 
-export function cloneQuote(id: string): Promise<Response> {
-  return fetchWithAuth(`/quotes/${id}/clone`, { method: 'POST' });
+/** Clone a quote into a new draft. Optional body retargets it to another
+ *  organization (same partner) and/or renames it — omitted fields fall back to
+ *  the source quote (matches `cloneQuoteSchema` in shared). */
+export function cloneQuote(id: string, body?: { orgId?: string; title?: string }): Promise<Response> {
+  return fetchWithAuth(`/quotes/${id}/clone`, {
+    method: 'POST',
+    ...(body ? { headers: JSON_HEADERS, body: JSON.stringify(body) } : {}),
+  });
 }
 
 export function updateQuote(id: string, body: UpdateQuoteInput): Promise<Response> {

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -386,6 +386,11 @@
         "thisLine": "diese Position",
         "removeSectionWithLines": "Dadurch werden die Preistabelle und ihre Positionen entfernt. Dies kann nicht rückgängig gemacht werden."
       },
+      "customer": {
+        "help": "Wird ein Entwurf einem anderen Unternehmen zugewiesen, wird die Standort-Zuordnung entfernt und der Steuersatz dieses Unternehmens angewendet.",
+        "label": "Kunde",
+        "success": "Angebot zu {{name}} verschoben."
+      },
       "deposit": {
         "due": "Anzahlung fällig",
         "eligibleAria": "Anzahlung möglich",
@@ -420,6 +425,7 @@
         "reorderBlocks": "Blöcke konnten nicht neu angeordnet werden.",
         "reorderLines": "Positionen konnten nicht neu angeordnet werden.",
         "reorderSections": "Abschnitte konnten nicht neu angeordnet werden.",
+        "saveCustomer": "Kunde konnte nicht geändert werden.",
         "saveTerms": "Die Bedingungen konnten nicht gespeichert werden.",
         "saveTitle": "Der Titel konnte nicht gespeichert werden.",
         "unitPriceZeroOrMore": "Geben Sie einen Stückpreis von 0 oder mehr ein.",
@@ -527,6 +533,15 @@
       }
     },
     "actions": {
+      "cloneDialog": {
+        "companyLabel": "Unternehmen",
+        "confirm": "Kopie erstellen",
+        "defaultTitle": "Kopie von {{name}}",
+        "message": "Erstellt einen neuen Entwurf mit demselben Inhalt. Wählen Sie das Unternehmen aus und vergeben Sie einen Titel.",
+        "retargetHint": "Der neue Entwurf verwendet die Rechnungsdaten und den Steuersatz dieses Unternehmens; die Standort-Zuordnung wird entfernt.",
+        "title": "Angebot duplizieren",
+        "titleLabel": "Titel"
+      },
       "cloneError": "Das Angebot konnte nicht dupliziert werden.",
       "cloneQuote": "Angebot duplizieren",
       "cloneSavingTitle": "Warten Sie vor dem Duplizieren, bis die Änderungen gespeichert sind.",
@@ -541,6 +556,7 @@
       "deleteSuccess": "Entwurf gelöscht",
       "downloadPdf": "Laden Sie PDF herunter",
       "emptyHint": "Fügen Sie vor dem Senden mindestens einen Artikel hinzu.",
+      "moreActions": "Weitere Aktionen",
       "savingHint": "Änderungen speichern… Entsperrungen senden, wenn alles gespeichert ist.",
       "savingTitle": "Speichern Ihrer Änderungen – Entsperrungen senden, wenn alles gespeichert ist.",
       "sendConfirm": {

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -386,6 +386,11 @@
         "thisLine": "this line",
         "removeSectionWithLines": "This removes the pricing table and its lines. This can't be undone."
       },
+      "customer": {
+        "help": "Moving a draft to another company clears the site assignment and applies that company’s tax rate.",
+        "label": "Customer",
+        "success": "Quote moved to {{name}}."
+      },
       "deposit": {
         "due": "Deposit due",
         "eligibleAria": "Deposit eligible",
@@ -420,6 +425,7 @@
         "reorderBlocks": "Could not reorder blocks.",
         "reorderLines": "Could not reorder lines.",
         "reorderSections": "Could not reorder sections.",
+        "saveCustomer": "Could not change the customer.",
         "saveTerms": "Could not save terms.",
         "saveTitle": "Could not save the title.",
         "unitPriceZeroOrMore": "Enter a unit price of 0 or more.",
@@ -527,6 +533,15 @@
       }
     },
     "actions": {
+      "cloneDialog": {
+        "companyLabel": "Company",
+        "confirm": "Create clone",
+        "defaultTitle": "Clone of {{name}}",
+        "message": "Creates a new draft with the same content. Pick the company it’s for and give it a title.",
+        "retargetHint": "The new draft will use this company’s billing details and tax rate; the site assignment is cleared.",
+        "title": "Clone quote",
+        "titleLabel": "Title"
+      },
       "cloneError": "Could not clone the quote.",
       "cloneQuote": "Clone quote",
       "cloneSavingTitle": "Wait for changes to finish saving before cloning.",
@@ -541,6 +556,7 @@
       "deleteSuccess": "Draft deleted",
       "downloadPdf": "Download PDF",
       "emptyHint": "Add at least one item before sending.",
+      "moreActions": "More actions",
       "savingHint": "Saving changes… Send unlocks when everything is saved.",
       "savingTitle": "Saving your changes — Send unlocks when everything is saved.",
       "sendConfirm": {
@@ -897,9 +913,9 @@
     "unapprovedTime_other": "{{count}} lines reference unapproved time. Review before issuing."
   },
   "invoiceActions": {
-      "deleteConfirm": {
-        "message": "This permanently deletes the draft invoice. This cannot be undone.",
-        "title": "Delete draft invoice"
+    "deleteConfirm": {
+      "message": "This permanently deletes the draft invoice. This cannot be undone.",
+      "title": "Delete draft invoice"
     },
     "deleteDraft": "Delete draft",
     "deleteError": "Could not delete the draft.",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -386,6 +386,11 @@
         "thisLine": "esta linea",
         "removeSectionWithLines": "Esto elimina la tabla de precios y sus líneas. Esto no se puede deshacer."
       },
+      "customer": {
+        "help": "Mover un borrador a otra empresa quita la asignación de sitio y aplica la tasa de impuestos de esa empresa.",
+        "label": "Cliente",
+        "success": "Cotización movida a {{name}}."
+      },
       "deposit": {
         "due": "Depósito adeudado",
         "eligibleAria": "Depósito elegible",
@@ -420,6 +425,7 @@
         "reorderBlocks": "No se pudieron reordenar los bloques.",
         "reorderLines": "No se pudieron reordenar las líneas.",
         "reorderSections": "No se pudieron reordenar las secciones.",
+        "saveCustomer": "No se pudo cambiar el cliente.",
         "saveTerms": "No se pudieron guardar los términos.",
         "saveTitle": "No se pudo guardar el título.",
         "unitPriceZeroOrMore": "Introduzca un precio unitario de 0 o más.",
@@ -527,6 +533,15 @@
       }
     },
     "actions": {
+      "cloneDialog": {
+        "companyLabel": "Empresa",
+        "confirm": "Crear copia",
+        "defaultTitle": "Copia de {{name}}",
+        "message": "Crea un nuevo borrador con el mismo contenido. Elige la empresa a la que va dirigido y asígnale un título.",
+        "retargetHint": "El nuevo borrador usará los datos de facturación y la tasa de impuestos de esta empresa; se quitará la asignación de sitio.",
+        "title": "Duplicar cotización",
+        "titleLabel": "Título"
+      },
       "cloneError": "No se pudo clonar la cotización.",
       "cloneQuote": "Clonar cotización",
       "cloneSavingTitle": "Espere a que se guarden los cambios antes de clonar.",
@@ -541,6 +556,7 @@
       "deleteSuccess": "Borrador eliminado",
       "downloadPdf": "Descargar PDF",
       "emptyHint": "Agregue al menos un artículo antes de enviar.",
+      "moreActions": "Más acciones",
       "savingHint": "Guardando cambios... Enviar desbloqueos cuando todo esté guardado.",
       "savingTitle": "Guardar sus cambios: envíe desbloqueos cuando todo esté guardado.",
       "sendConfirm": {

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -386,6 +386,11 @@
         "thisLine": "cette ligne",
         "removeSectionWithLines": "Cette action supprime le tableau de prix et ses lignes. Elle est irréversible."
       },
+      "customer": {
+        "help": "Déplacer un brouillon vers une autre entreprise retire l’affectation de site et applique le taux de taxe de cette entreprise.",
+        "label": "Client",
+        "success": "Devis déplacé vers {{name}}."
+      },
       "deposit": {
         "due": "Acompte dû",
         "eligibleAria": "Éligible à l'acompte",
@@ -420,6 +425,7 @@
         "reorderBlocks": "Impossible de réordonner les blocs.",
         "reorderLines": "Impossible de réordonner les lignes.",
         "reorderSections": "Impossible de réordonner les sections.",
+        "saveCustomer": "Impossible de changer le client.",
         "saveTerms": "Impossible d'enregistrer les conditions.",
         "saveTitle": "Impossible d'enregistrer le titre.",
         "unitPriceZeroOrMore": "Saisissez un prix unitaire supérieur ou égal à 0.",
@@ -527,6 +533,15 @@
       }
     },
     "actions": {
+      "cloneDialog": {
+        "companyLabel": "Entreprise",
+        "confirm": "Créer la copie",
+        "defaultTitle": "Copie de {{name}}",
+        "message": "Crée un nouveau brouillon avec le même contenu. Choisissez l’entreprise concernée et donnez-lui un titre.",
+        "retargetHint": "Le nouveau brouillon utilisera les informations de facturation et le taux de taxe de cette entreprise ; l’affectation de site sera retirée.",
+        "title": "Dupliquer le devis",
+        "titleLabel": "Titre"
+      },
       "cloneError": "Impossible de dupliquer le devis.",
       "cloneQuote": "Dupliquer le devis",
       "cloneSavingTitle": "Attendez la fin de l'enregistrement avant de dupliquer.",
@@ -541,6 +556,7 @@
       "deleteSuccess": "Brouillon supprimé",
       "downloadPdf": "Télécharger le PDF",
       "emptyHint": "Ajoutez au moins un article avant l'envoi.",
+      "moreActions": "Plus d’actions",
       "savingHint": "Enregistrement des modifications… L'envoi sera disponible une fois tout enregistré.",
       "savingTitle": "Enregistrement de vos modifications — l'envoi sera disponible une fois tout enregistré.",
       "sendConfirm": {

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -386,6 +386,11 @@
         "thisLine": "esta linha",
         "removeSectionWithLines": "Remover seção com linhas"
       },
+      "customer": {
+        "help": "Mover um rascunho para outra empresa remove a atribuição de site e aplica a alíquota de imposto dessa empresa.",
+        "label": "Cliente",
+        "success": "Orçamento movido para {{name}}."
+      },
       "deposit": {
         "due": "Depósito devido",
         "eligibleAria": "Elegível para depósito",
@@ -420,6 +425,7 @@
         "reorderBlocks": "Não foi possível reordenar os blocos.",
         "reorderLines": "Não foi possível reordenar as linhas.",
         "reorderSections": "Não foi possível reordenar as seções.",
+        "saveCustomer": "Não foi possível alterar o cliente.",
         "saveTerms": "Não foi possível salvar os termos.",
         "saveTitle": "Não foi possível salvar o título.",
         "unitPriceZeroOrMore": "Informe um preço unitário de 0 ou mais.",
@@ -527,6 +533,15 @@
       }
     },
     "actions": {
+      "cloneDialog": {
+        "companyLabel": "Empresa",
+        "confirm": "Criar cópia",
+        "defaultTitle": "Cópia de {{name}}",
+        "message": "Cria um novo rascunho com o mesmo conteúdo. Escolha a empresa de destino e dê um título.",
+        "retargetHint": "O novo rascunho usará os dados de faturamento e a alíquota de imposto desta empresa; a atribuição de site será removida.",
+        "title": "Duplicar orçamento",
+        "titleLabel": "Título"
+      },
       "cloneError": "Não foi possível clonar a cotação.",
       "cloneQuote": "Clonar cotação",
       "cloneSavingTitle": "Aguarde até que as alterações sejam salvas antes de clonar.",
@@ -541,6 +556,7 @@
       "deleteSuccess": "Rascunho excluído",
       "downloadPdf": "Baixar PDF",
       "emptyHint": "Adicione pelo menos um item antes de enviar.",
+      "moreActions": "Mais ações",
       "savingHint": "Salvando alterações… O envio será liberado quando tudo estiver salvo.",
       "savingTitle": "Salvando suas alterações — o envio será liberado quando tudo estiver salvo.",
       "sendConfirm": {

--- a/packages/shared/src/validators/quotes.test.ts
+++ b/packages/shared/src/validators/quotes.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  createQuoteSchema, quoteLineInputSchema, quoteBlockInputSchema, listQuotesQuerySchema,
+  createQuoteSchema, cloneQuoteSchema, quoteLineInputSchema, quoteBlockInputSchema, listQuotesQuerySchema,
   acceptQuoteSchema, declineQuoteSchema,
   updateQuoteSchema, reorderBlocksSchema, reorderLinesSchema,
   updateQuoteLineSchema, catalogQuoteLineSchema, moveQuoteLineSchema,
@@ -34,6 +34,33 @@ describe('quote validators', () => {
       .toBe('33333333-3333-3333-3333-333333333333');
     expect(updateQuoteLineSchema.parse({ imageId: null }).imageId).toBeNull();
     expect(updateQuoteLineSchema.safeParse({ imageId: 'not-a-guid' }).success).toBe(false);
+  });
+
+  it('clone options accept orgId/title, tolerate an empty body, and reject unknown keys', () => {
+    expect(cloneQuoteSchema.parse({})).toEqual({});
+    expect(cloneQuoteSchema.parse({ orgId: '11111111-1111-1111-1111-111111111111', title: 'Clone of Q-1' }))
+      .toEqual({ orgId: '11111111-1111-1111-1111-111111111111', title: 'Clone of Q-1' });
+    expect(cloneQuoteSchema.safeParse({ orgId: 'not-a-guid' }).success).toBe(false);
+    expect(cloneQuoteSchema.safeParse({ title: 'x'.repeat(201) }).success).toBe(false);
+    // strict: a mis-keyed field is a 400, not a silent same-org clone
+    expect(cloneQuoteSchema.safeParse({ orgID: '11111111-1111-1111-1111-111111111111' }).success).toBe(false);
+  });
+
+  it('update accepts an orgId reassignment guid and rejects a non-guid', () => {
+    expect(updateQuoteSchema.parse({ orgId: '22222222-2222-2222-2222-222222222222' }).orgId)
+      .toBe('22222222-2222-2222-2222-222222222222');
+    expect(updateQuoteSchema.safeParse({ orgId: 'not-a-guid' }).success).toBe(false);
+    expect(updateQuoteSchema.safeParse({ orgId: null }).success).toBe(false); // a quote always has an org
+  });
+
+  it('update strips unknown keys (non-strict) — a mis-keyed orgID is a no-op, unlike the strict clone body', () => {
+    // Documented asymmetry: updateQuoteSchema predates orgId and stays
+    // non-strict for existing callers, so { orgID } parses to an empty patch
+    // (200, nothing reassigned) rather than a 400. cloneQuoteSchema is strict
+    // because its only purpose is retarget/rename.
+    const parsed = updateQuoteSchema.parse({ orgID: '22222222-2222-2222-2222-222222222222' });
+    expect(parsed).toEqual({});
+    expect('orgId' in parsed).toBe(false);
   });
 
   it('create/update accept a bounded title and reject an oversized one', () => {

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -90,7 +90,20 @@ export const createQuoteSchema = z.object({
   termsAndConditions: z.string().max(20_000).optional(),
 });
 
+// Optional retarget/rename for POST /quotes/:id/clone. Omitted fields fall back
+// to the source quote. `.strict()` so a mis-keyed field is a 400, not silently
+// ignored (mirrors sendBodySchema).
+export const cloneQuoteSchema = z.object({
+  orgId: z.string().guid().optional(),
+  title: z.string().max(200).optional(),
+}).strict();
+
 export const updateQuoteSchema = z.object({
+  // Reassign the draft to another organization of the same partner. The service
+  // clears the site, and clears the billToName override / re-resolves the tax
+  // rate for the new org unless the same patch provides them (drafts only, like
+  // every other header field here — see updateQuote in quoteService).
+  orgId: z.string().guid().optional(),
   siteId: z.string().guid().nullable().optional(),
   title: z.string().max(200).nullable().optional(),
   expiryDate: isoDate.nullable().optional(),
@@ -157,6 +170,7 @@ export const bulkQuoteIdsSchema = z.object({
 export type QuoteLineInput = z.infer<typeof quoteLineInputSchema>;
 export type QuoteBlockInput = z.infer<typeof quoteBlockInputSchema>;
 export type CreateQuoteInput = z.infer<typeof createQuoteSchema>;
+export type CloneQuoteInput = z.infer<typeof cloneQuoteSchema>;
 export type UpdateQuoteInput = z.infer<typeof updateQuoteSchema>;
 export type ListQuotesQuery = z.infer<typeof listQuotesQuerySchema>;
 export type AcceptQuoteInput = z.infer<typeof acceptQuoteSchema>;


### PR DESCRIPTION
## What

Extends the quote clone feature and adds company reassignment, plus a header-layout cleanup.

### 1. Clone dialog — pick the company and title
Clicking **Clone quote** now opens a dialog instead of cloning immediately:
- **Company** select (partner org list), defaulting to the source quote's company
- **Title** prefilled with `Clone of {title or quote number}`; blanking it makes the clone untitled
- Retargeting to a different company shows a hint: the draft uses that company's billing details and tax rate, and the site assignment is cleared

API: `POST /quotes/:id/clone` accepts an optional **strict** JSON body `{ orgId?, title? }` (`cloneQuoteSchema`). Retargeting is same-partner only (cross-partner ids 404 via the RLS-backed membership lookup), clears `siteId`/`billToName`, re-resolves the tax rate with the same precedence as quote creation, and stamps the new `org_id` on the quote **and** its blocks/lines/images. A body-less POST behaves exactly as before.

### 2. Change the company on a draft quote
The editor gains a **Customer** select next to the title. `PATCH /quotes/:id` accepts `orgId` (drafts only, like every other header field): clears site + bill-to override (unless the same patch supplies fresh values), re-resolves tax, and moves the denormalized `org_id` on `quote_blocks`/`quote_lines`/`quote_images` — with the totals recompute — in **one transaction**, so a mid-flight failure can't strand a half-moved quote.

Issued (sent/accepted) quotes stay immutable — they carry a frozen bill-to snapshot and a live customer accept link. Re-targeting an issued quote is the clone dialog's job.

### 3. Header buttons
The workspace header was four wrapping text buttons with ragged gaps. It's now a stable **Send · Download PDF · ⋯** cluster, with Clone and Delete in an accessible overflow menu. The Detail-rail keeps all four stacked full-width buttons.

## Review hardening (multi-agent review round)
- `assertSite(actor, null)` on retarget clone — parity with `updateQuote`, so a site-restricted actor can't clone into a site-less quote it could never see
- Clone route reads the body unconditionally (no content-type gate): a JSON retarget sent without the header is honored, a non-JSON body 400s, and a failed body read 400s — a retarget can never silently degrade to a same-org clone
- Totals recompute runs inside the org-move transaction
- Editor customer-select snap-back re-pulls server truth on error instead of asserting a rollback
- `updateQuoteSchema`'s non-strict unknown-key stripping pinned by a validator test as a documented asymmetry vs the strict clone body

## Testing
- **Shared**: `cloneQuoteSchema` + `updateQuoteSchema.orgId` validator cases (31 pass)
- **API**: retarget clone (org/site/billTo/tax + image/block/line re-tenanting), ORG_DENIED / ORG_NOT_FOUND / SITE_DENIED, updateQuote reassignment incl. same-patch `taxRate` and `billToName` interactions, route body-parsing matrix (bodyless, retarget, header-less JSON, non-JSON, mis-keyed) — 73 pass; `tsc` clean
- **Web**: clone dialog flow (defaults, retarget hint, emptied title, rail variant, read-only, savePending), new `QuoteEditor.customer.test.tsx` (PATCH body, no-op reselect, snap-back), locale parity + no-silent-mutations guards — 154 pass; `astro check` clean
- i18n keys added to all five locales (en, de-DE, es-419, fr-FR, pt-BR)

No schema changes, no migrations (all columns pre-exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)