### PR TITLE
perf(ci): shard integration tests 4 ways + run migrations once per run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1223,16 +1223,31 @@ jobs:
   # main red for 8 days. No Docker image builds, but the real-DB suite plus
   # RLS coverage regularly needs more than 15 minutes as the migration/test
   # surface grows.
+  #
+  # Sharded 4 ways with vitest `--shard` (2026-07): the suite had grown to
+  # 212 files / ~1170 tests ≈ 21 min of strictly sequential wall clock
+  # (fileParallelism stays false — the shared TRUNCATE-based cleanup in
+  # setup.ts requires it). Each shard is a full job with its own fresh
+  # Postgres/Redis containers, so per-file isolation semantics are
+  # unchanged; only the file list is split. Branch protection requires the
+  # "CI Success" fan-in, and `needs.integration-test.result` there already
+  # aggregates across the matrix (success only if every shard passed).
   integration-test:
-    name: Integration Tests
+    name: Integration Tests (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     needs: [lint, typecheck]
-    # The suite (138 files / ~690 tests) runs ~29 min and was tipping over the
-    # old 30-min ceiling at the boundary (passed/cancelled non-deterministically
-    # on the same commit). Raised to 40 for headroom — the tests pass, this is
-    # runtime growth, not a hang. By 2026-07 the baseline hit ~36 min and PRs
-    # adding integration suites tipped over 40 the same way; raised to 55.
-    timeout-minutes: 55
+    strategy:
+      # Report every shard's result — a red shard must not cancel the others
+      # (same rationale as the no-bail rule inside the suite: masking stacked
+      # breakages hid #1092 behind #1042 for a day).
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    # ~1/4 of the suite (~6 min) + env/container setup + one autoMigrate
+    # pass. 25 leaves generous headroom for suite growth; before sharding
+    # this ceiling had to be raised twice (30→40→55) as the sequential
+    # runtime grew.
+    timeout-minutes: 25
 
     steps:
       - name: Checkout
@@ -1281,13 +1296,19 @@ jobs:
           # guarded `db` proxy. Production code must always carry an access
           # context, so a genuine offender here is a real bug, not test noise.
           DB_CONTEXTLESS_WRITE_STRICT: 'true'
-        run: pnpm --filter=@breeze/api test:integration
+        # pnpm forwards args after the script name to the script itself, so
+        # --shard reaches vitest. Sharding only splits the file list; files
+        # within a shard still run sequentially (fileParallelism: false).
+        run: pnpm --filter=@breeze/api test:integration --shard=${{ matrix.shard }}/4
 
       # Dedicated exact-role enforcement runner. The general integration config
       # excludes it because this suite manages a temporary BYPASSRLS role and
       # must not inherit the shared TRUNCATE hooks. The preceding suite has
-      # already applied migrations and ensured the breeze_app login exists.
+      # already applied migrations (globalSetup runs autoMigrate on every
+      # shard's fresh DB) and ensured the breeze_app login exists. Runs on
+      # shard 1 only — it's a single-DB contract check, not a sharded suite.
       - name: Run request database role enforcement tests
+        if: matrix.shard == 1
         env:
           DATABASE_URL: postgresql://breeze_test:breeze_test@localhost:5433/breeze_test
           DATABASE_URL_APP: postgresql://breeze_app:breeze_test@localhost:5433/breeze_test
@@ -1299,11 +1320,13 @@ jobs:
       # The rls-coverage contract test inspects pg_catalog to verify every
       # tenant-scoped table has policies covering SELECT/INSERT/UPDATE/DELETE
       # via the right access helper. Runs against the same test DB AFTER
-      # the integration suite (which has already triggered autoMigrate).
-      # Has its own runner because vitest.integration.config.ts excludes it:
-      # the read-only catalog inspection must not be hooked to setup.ts,
-      # which TRUNCATEs core tables on beforeEach.
+      # the integration suite (whose globalSetup has already triggered
+      # autoMigrate). Has its own runner because vitest.integration.config.ts
+      # excludes it: the read-only catalog inspection must not be hooked to
+      # setup.ts, which TRUNCATEs core tables on beforeEach. Shard 1 only —
+      # a single-DB contract check, identical on every shard.
       - name: Run RLS coverage contract test
+        if: matrix.shard == 1
         env:
           DATABASE_URL: postgresql://breeze_test:breeze_test@localhost:5433/breeze_test
           DATABASE_URL_APP: postgresql://breeze_app:breeze_test@localhost:5433/breeze_test

--- a/apps/api/src/__tests__/integration/apiKeyPrincipals.integration.test.ts
+++ b/apps/api/src/__tests__/integration/apiKeyPrincipals.integration.test.ts
@@ -39,9 +39,9 @@
  *   pnpm vitest run --config vitest.integration.config.ts \
  *     src/__tests__/integration/apiKeyPrincipals.integration.test.ts
  *
- * The integration harness (setup.ts) runs autoMigrate() off DATABASE_URL /
- * DATABASE_URL_APP, which applies 2026-07-19-service-principals.sql
- * automatically.
+ * The integration harness (globalSetup.ts) runs autoMigrate() off
+ * DATABASE_URL / DATABASE_URL_APP, which applies
+ * 2026-07-19-service-principals.sql automatically.
  */
 import './setup';
 

--- a/apps/api/src/__tests__/integration/emailRecoveryRegistration.integration.test.ts
+++ b/apps/api/src/__tests__/integration/emailRecoveryRegistration.integration.test.ts
@@ -27,8 +27,8 @@
  *   pnpm vitest run --config vitest.integration.config.ts \
  *     src/__tests__/integration/emailRecoveryRegistration.integration.test.ts
  *
- * The integration harness (setup.ts) runs autoMigrate() — which creates the
- * unprivileged `breeze_app` RLS role — off DATABASE_URL/DATABASE_URL_APP.
+ * The integration harness (globalSetup.ts) runs autoMigrate() — which creates
+ * the unprivileged `breeze_app` RLS role — off DATABASE_URL/DATABASE_URL_APP.
  */
 import './setup';
 

--- a/apps/api/src/__tests__/integration/globalSetup.ts
+++ b/apps/api/src/__tests__/integration/globalSetup.ts
@@ -1,0 +1,35 @@
+/**
+ * One-time global setup for the integration suite (vitest `globalSetup`).
+ *
+ * Runs ONCE per `vitest run` invocation, in its own Node context, before any
+ * test-file worker starts. Migrations are applied here — hoisted out of
+ * setup.ts's per-file `beforeAll` because re-running autoMigrate for every
+ * one of 200+ test files cost ~1.1s each (~4 min of CI wall clock) in pure
+ * no-op verification: re-reading and re-checksumming all 400+ migration
+ * files against an unchanged ledger.
+ *
+ * The auto-seed inside autoMigrate (step 8) is intentionally NOT re-run per
+ * file either: setup.ts's global `beforeEach` TRUNCATEs the core tables
+ * before every single test, so rows seeded in a per-file beforeAll were
+ * always gone by the time the first test ran. Test files own their fixtures.
+ */
+import './loadEnv';
+
+import { autoMigrate } from '../../db/autoMigrate';
+import { assertTestDatabaseUrlSafe } from '../../testUtils/integrationDatabaseSafety';
+
+export default async function globalSetup(): Promise<void> {
+  // Fail loud if either URL points at anything other than a known test DB —
+  // autoMigrate would otherwise happily run DDL against it. setup.ts repeats
+  // this guard before opening its own pools; guard here too so the very first
+  // connection of the run is already covered.
+  assertTestDatabaseUrlSafe(process.env.DATABASE_URL ?? '', 'globalSetup');
+  assertTestDatabaseUrlSafe(
+    process.env.DATABASE_URL_APP ?? '',
+    'globalSetup (DATABASE_URL_APP)',
+  );
+
+  console.log('[integration global-setup] Running migrations (once per run)...');
+  await autoMigrate();
+  console.log('[integration global-setup] Database ready for testing');
+}

--- a/apps/api/src/__tests__/integration/setup.ts
+++ b/apps/api/src/__tests__/integration/setup.ts
@@ -22,7 +22,6 @@ import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import postgres, { type Sql } from 'postgres';
 import Redis, { type RedisOptions } from 'ioredis';
 import * as schema from '../../db/schema';
-import { autoMigrate } from '../../db/autoMigrate';
 import { assertTestDatabaseUrlSafe } from '../../testUtils/integrationDatabaseSafety';
 
 // Load test environment variables
@@ -138,7 +137,10 @@ export async function setupIntegrationTests() {
     retryStrategy: (times) => Math.min(times * 100, 3000)
   } as RedisOptions);
 
-  // Wait for connections to be ready
+  // Wait for connections to be ready. Migrations are NOT run here: they are
+  // applied exactly once per `vitest run` by globalSetup.ts (see
+  // vitest.integration.config.ts) — re-running autoMigrate in every file's
+  // beforeAll was a ~1.1s/file no-op verification tax (~4 min of CI time).
   try {
     // Test PostgreSQL connection
     await testClient`SELECT 1`;
@@ -147,16 +149,6 @@ export async function setupIntegrationTests() {
     // Test Redis connection
     await testRedis.ping();
     console.log('Redis connection established');
-
-    // Run all hand-written SQL migrations against the test DB and ensure
-    // the unprivileged `breeze_app` role exists with the right password
-    // and privileges. `autoMigrate()` is idempotent and internally calls
-    // `ensureAppRole()`, so integration tests see the same schema state
-    // as a freshly-started API process.
-    console.log('Running migrations...');
-    await autoMigrate();
-
-    console.log('Database ready for testing');
   } catch (error) {
     console.error('Failed to connect to test services:', error);
     console.error('\nMake sure test containers are running:');
@@ -258,7 +250,7 @@ const CLEANUP_TABLES = [
 // Resolved once per test file (module instance): which of CLEANUP_TABLES exist
 // in this branch's schema. Replaces the old per-statement 42P01 tolerance —
 // filtering up front lets the truncate run as ONE statement, and the schema
-// cannot change mid-run (autoMigrate runs in beforeAll, before any cleanup).
+// cannot change mid-run (autoMigrate runs in globalSetup, before any worker).
 let existingCleanupTables: string[] | null = null;
 
 async function resolveCleanupTables(): Promise<string[]> {

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -100,6 +100,10 @@ export default defineConfig({
       // file needs a dedicated audit against current auth route shapes.
       'src/__tests__/integration/auth.integration.test.ts',
     ],
+    // Migrations run ONCE per invocation here (not in setup.ts's per-file
+    // beforeAll): re-verifying 400+ migration checksums for every test file
+    // was ~4 min of pure no-op work per CI run.
+    globalSetup: ['src/__tests__/integration/globalSetup.ts'],
     setupFiles: ['src/__tests__/integration/setup.ts'],
     // Integration tests run sequentially to avoid database conflicts.
     // `fileParallelism: false` forces vitest to run test files one at a
@@ -112,7 +116,7 @@ export default defineConfig({
     // Longer timeouts for database operations
     testTimeout: 30000,
     hookTimeout: 30000,
-    // No `bail` here on purpose: the suite is ~90s, and bail:1 masks
+    // No `bail` here on purpose: bail:1 masks
     // stacked breakages — in June 2026 it hid #1092's org-scope lockout
     // behind #1042's RBAC 403 for a day because each CI run only ever
     // surfaced the first failure. Always report every failure.


### PR DESCRIPTION
## Why

The blocking **Integration Tests** job has grown to ~22–36 min (212 files / ~1170 tests running strictly sequentially) and its timeout has been raised twice (30 → 40 → 55) chasing runtime growth.

Timing breakdown from a recent main run (job 22m18s, vitest step 21m04s):

- `tests 969s` — a uniform ~830ms/test floor (per-test TRUNCATE-based reset), linear in test count
- `setup 236s` — **every** test file's `beforeAll` re-ran `autoMigrate()`, re-reading + re-checksumming all 400+ migrations as a no-op (~1.1s × 212 files)
- everything else ~2 min

## What

**1. Shard the job 4 ways** (`strategy.matrix.shard`, `vitest --shard=N/4`, `fail-fast: false`, timeout 25m/shard). Each shard is a full job with its own fresh Postgres/Redis containers; files within a shard still run sequentially (`fileParallelism` stays `false` — the shared TRUNCATE cleanup requires it), so per-file isolation semantics are unchanged. Only the file list is split.
   - Branch protection requires only the **CI Success** fan-in, and `needs.integration-test.result` there already aggregates across the matrix (success only if every shard passes) — no rule change needed.
   - The single-DB contract steps (`test:request-db-role`, `test:rls-coverage`) run on shard 1 only; they depend on migrations, which every shard's globalSetup applies to its own DB.

**2. Hoist `autoMigrate()` into a vitest `globalSetup`** (once per invocation) instead of `setup.ts`'s per-file `beforeAll`.
   - The per-file auto-seed this also triggered was dead weight: the global `beforeEach` TRUNCATE always wiped seeded rows before the first test of a file ran, so no test could ever observe it. Test files own their fixtures (and already do).

Expected wall clock: **~22 min → ~7–8 min** (~6 min of tests per shard + setup).

## Verification

- All 4 shards run locally against the docker test stack: **212 files, 1168 passed / 3 skipped** — identical counts to the sequential run, every file in exactly one shard
- Shard-1 follow-up runners (`test:request-db-role` 4/4, `test:rls-coverage` 55/55) green with CI-equivalent env
- `tsc --noEmit --project apps/api/tsconfig.json` green
- `actionlint` clean on the edited region

🤖 Generated with [Claude Code](https://claude.com/claude-code)