### PR TITLE
fix(release): API image can't resolve @breeze/extension-sdk + executor image ref must be lowercase

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2395,6 +2395,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # IMAGE_NAME is ${{ github.repository }} (e.g. LanternOps/breeze), but a
+      # container reference must be lowercase. The api/web jobs launder this
+      # through docker/metadata-action (which lowercases); this job builds the
+      # ref by hand, so lowercase it explicitly.
+      - name: Compute lowercase image base
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        run: |
+          BASE="${REGISTRY}/${IMAGE_NAME}"
+          echo "IMAGE_BASE=${BASE,,}" >> "$GITHUB_ENV"
+
       # Push by digest only: no release-facing tag exists until this exact
       # manifest passes the blocking vulnerability scan below.
       - name: Build and push unadvertised executor digest
@@ -2403,14 +2415,14 @@ jobs:
         with:
           context: .
           file: apps/m365-graph-read-executor/Dockerfile
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/m365-graph-read-executor,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.IMAGE_BASE }}/m365-graph-read-executor,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Scan exact executor digest
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/m365-graph-read-executor@${{ steps.push-executor-digest.outputs.digest }}
+          image-ref: ${{ env.IMAGE_BASE }}/m365-graph-read-executor@${{ steps.push-executor-digest.outputs.digest }}
           severity: 'HIGH,CRITICAL'
           format: 'table'
           exit-code: '1'
@@ -2419,7 +2431,7 @@ jobs:
       # references; it never rebuilds or mutates the image layers.
       - name: Promote scanned executor digest
         env:
-          EXECUTOR_REPOSITORY: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/m365-graph-read-executor
+          EXECUTOR_REPOSITORY: ${{ env.IMAGE_BASE }}/m365-graph-read-executor
           EXECUTOR_IMAGE_DIGEST: ${{ steps.push-executor-digest.outputs.digest }}
           RELEASE_REF_NAME: ${{ github.ref_name }}
           RELEASE_SHA: ${{ github.sha }}

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -16,6 +16,11 @@ WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY apps/api/package.json ./apps/api/
 COPY packages/shared/package.json ./packages/shared/
+# apps/api depends on these source-only workspace packages (@breeze/extension-api
+# re-exports @breeze/extension-sdk); their manifests must be present so pnpm
+# creates the workspace symlinks the API's tsup bundle resolves at build time.
+COPY packages/extension-api/package.json ./packages/extension-api/
+COPY packages/extension-sdk/package.json ./packages/extension-sdk/
 
 # Install all dependencies
 RUN pnpm install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
The **v0.96.0** tag build failed on two release-only jobs (neither runs on PRs, so they slipped past CI). This fixes both. **No app code changes** — Dockerfile + workflow only.

## 1. Build & Push API Docker Image — failed (prod-blocking)
```
packages/extension-api/src/index.ts:1:14: ERROR: Could not resolve "@breeze/extension-sdk"
```
`release.yml` builds the API from **`apps/api/Dockerfile`**, whose deps stage never copies `packages/extension-api/package.json` or `packages/extension-sdk/package.json`. `apps/api` now depends on both (`@breeze/extension-api` re-exports `@breeze/extension-sdk`, both source-only `main → src/index.ts`), so pnpm never creates the workspace symlinks and the API's `tsup` bundle (`noExternal: [/^@breeze\//]`) can't resolve the SDK.

#2548 added the dependency and updated the *other* prod file (`docker/Dockerfile.api`); #2582 fixed the dev image — but the file `release.yml` actually builds was missed. Since the prod API image is built **only in `release.yml`**, it broke silently on `main` the moment #2548 merged and surfaced only at tag time.

**Fix:** copy the two manifests in the deps stage.

**Verified locally** against `apps/api/Dockerfile`:
- Before: reproduces the exact `Could not resolve "@breeze/extension-sdk"` at `pnpm build`.
- After: full image builds green (`pnpm build` + runner stage), `dist/index.cjs` present.

## 2. Build & Push M365 Graph Read Executor Image — failed
```
invalid reference format: repository name (LanternOps/breeze/m365-graph-read-executor) must be lowercase
```
`IMAGE_NAME` is `${{ github.repository }}` = `LanternOps/breeze`. The api/web jobs launder it through `docker/metadata-action` (which lowercases); the new executor job builds the ref by hand and didn't. **Fix:** add a step lowercasing the ref into `EXECUTOR_IMAGE`, used for build/scan/promote.

## Follow-up (not in this PR)
`apps/api/Dockerfile` and `docker/Dockerfile.api` are duplicate prod API Dockerfiles that have drifted — worth consolidating so a fix to one can't miss the other.

Unblocks re-cutting v0.96.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)