### PR TITLE
fix(agent): keep PAM consent in requester session

### DIFF
--- a/agent/internal/etwlua/etwlua.go
+++ b/agent/internal/etwlua/etwlua.go
@@ -99,6 +99,10 @@ type Event struct {
 	// on standalone machines. Required.
 	SubjectUsername string `json:"subject_username"`
 
+	// SubjectSessionID is the local Windows session that owns the consent UI.
+	// It is used to route PAM locally and must not be sent to the server.
+	SubjectSessionID uint32 `json:"-"`
+
 	// TargetExecutablePath is the absolute path of the binary about to be
 	// elevated. Required.
 	TargetExecutablePath string `json:"target_executable_path"`

--- a/agent/internal/etwlua/etwlua_windows.go
+++ b/agent/internal/etwlua/etwlua_windows.go
@@ -14,7 +14,6 @@ import (
 	"unsafe"
 
 	"github.com/0xrawsec/golang-etw/etw"
-	"golang.org/x/sys/windows"
 )
 
 // providerGUID is the Microsoft-Windows-LUA ETW provider (lives in
@@ -162,18 +161,22 @@ func (s *etwSession) Stop() {
 func decodeConsentRequest(raw []byte) (Event, bool) {
 	targetPath, commandLine := parseConsentPayload(raw)
 	if targetPath == "" {
+		log.Debug("etwlua: unable to parse consent request payload", "payloadBytes", len(raw))
 		return Event{}, false
 	}
 
-	user := resolveConsentUser()
+	user, sessionID, attributionSource := resolveRequesterSession()
 	if user == "" {
-		// No interactive console user to attribute the prompt to; the server
-		// requires a subject, so drop rather than post a half record.
+		log.Debug("etwlua: dropping consent request with unresolved subject",
+			"attributionSource", attributionSource,
+			"targetPath", targetPath,
+		)
 		return Event{}, false
 	}
 
 	ev := Event{
 		SubjectUsername:      user,
+		SubjectSessionID:     sessionID,
 		TargetExecutablePath: targetPath,
 		CommandLine:          commandLine,
 		ObservedAt:           time.Now().UTC(),
@@ -191,54 +194,6 @@ func decodeConsentRequest(raw []byte) (Event, bool) {
 	// schema accepts a NULL signer and a NULL thumbprint, and a thumbprint-pinned
 	// rule fails closed until the agent emits one.
 	return ev, true
-}
-
-// consentUser caches the active console-session user; resolving it is a
-// syscall we don't want to run per consent event, and the console user
-// rarely changes.
-var (
-	consentUserMu    sync.Mutex
-	consentUserCache string
-	consentUserAt    time.Time
-)
-
-// resolveConsentUser returns the active console session's user as
-// "DOMAIN\\user". A UAC consent prompt is, by construction, raised in the
-// interactive session, so the console user is the requester in the common
-// case. Empty if there is no interactive session or the lookup fails.
-func resolveConsentUser() string {
-	consentUserMu.Lock()
-	defer consentUserMu.Unlock()
-	if consentUserCache != "" && time.Since(consentUserAt) < 60*time.Second {
-		return consentUserCache
-	}
-	if u := lookupConsoleUser(); u != "" {
-		consentUserCache = u
-		consentUserAt = time.Now()
-		return u
-	}
-	return ""
-}
-
-func lookupConsoleUser() string {
-	sid := windows.WTSGetActiveConsoleSessionId()
-	if sid == 0xFFFFFFFF { // no active console session
-		return ""
-	}
-	var token windows.Token
-	if err := windows.WTSQueryUserToken(sid, &token); err != nil {
-		return ""
-	}
-	defer token.Close()
-	tokenUser, err := token.GetTokenUser()
-	if err != nil {
-		return ""
-	}
-	account, domain, _, err := tokenUser.User.Sid.LookupAccount("")
-	if err != nil {
-		return ""
-	}
-	return domain + `\` + account
 }
 
 // hashFile returns the SHA-256 of the file at path as hex.

--- a/agent/internal/etwlua/requester_session.go
+++ b/agent/internal/etwlua/requester_session.go
@@ -1,0 +1,91 @@
+package etwlua
+
+import (
+	"strings"
+	"time"
+)
+
+const (
+	requesterSourceConsentProcess  = "consent_process"
+	requesterSourceConsoleFallback = "console_fallback"
+	requesterSourceUnresolved      = "unresolved"
+)
+
+// consentProcessCandidate is the trusted process metadata needed to attribute
+// a UAC request to the interactive session that owns the live consent UI.
+type consentProcessCandidate struct {
+	PID       uint32
+	SessionID uint32
+	ImagePath string
+	StartedAt time.Time
+}
+
+func selectNewestConsentProcess(
+	candidates []consentProcessCandidate,
+	trustedImagePath string,
+	now time.Time,
+) (consentProcessCandidate, bool) {
+	trustedImagePath = normalizeWindowsPath(trustedImagePath)
+	if trustedImagePath == "" {
+		return consentProcessCandidate{}, false
+	}
+
+	var selected consentProcessCandidate
+	found := false
+	for _, candidate := range candidates {
+		if !strings.EqualFold(normalizeWindowsPath(candidate.ImagePath), trustedImagePath) ||
+			!validInteractiveSessionID(candidate.SessionID) ||
+			candidate.StartedAt.IsZero() {
+			continue
+		}
+
+		age := now.Sub(candidate.StartedAt)
+		if age < 0 || age > dedupeWindow {
+			continue
+		}
+		if !found || candidate.StartedAt.After(selected.StartedAt) ||
+			(candidate.StartedAt.Equal(selected.StartedAt) && candidate.PID > selected.PID) {
+			selected = candidate
+			found = true
+		}
+	}
+	return selected, found
+}
+
+func resolveRequesterSessionWith(
+	candidates []consentProcessCandidate,
+	trustedImagePath string,
+	now time.Time,
+	consoleSessionID uint32,
+	lookupSessionUser func(sessionID uint32) string,
+) (username string, sessionID uint32, source string) {
+	if lookupSessionUser == nil {
+		return "", 0, requesterSourceUnresolved
+	}
+
+	if candidate, ok := selectNewestConsentProcess(candidates, trustedImagePath, now); ok {
+		if user := lookupSessionUser(candidate.SessionID); user != "" {
+			return user, candidate.SessionID, requesterSourceConsentProcess
+		}
+	}
+
+	if validInteractiveSessionID(consoleSessionID) {
+		if user := lookupSessionUser(consoleSessionID); user != "" {
+			return user, consoleSessionID, requesterSourceConsoleFallback
+		}
+	}
+	return "", 0, requesterSourceUnresolved
+}
+
+func normalizeWindowsPath(path string) string {
+	path = strings.TrimSpace(path)
+	if len(path) >= 4 && strings.EqualFold(path[:4], `\\?\`) {
+		path = path[4:]
+	}
+	path = strings.ReplaceAll(path, "/", `\`)
+	return strings.TrimRight(path, `\`)
+}
+
+func validInteractiveSessionID(sessionID uint32) bool {
+	return sessionID != 0 && sessionID != 0xFFFFFFFF
+}

--- a/agent/internal/etwlua/requester_session.go
+++ b/agent/internal/etwlua/requester_session.go
@@ -77,6 +77,26 @@ func resolveRequesterSessionWith(
 	return "", 0, requesterSourceUnresolved
 }
 
+func resolveRequesterSessionAfterEnumeration(
+	candidates []consentProcessCandidate,
+	enumerationErr error,
+	trustedImagePath string,
+	now time.Time,
+	consoleSessionID uint32,
+	lookupSessionUser func(sessionID uint32) string,
+) (username string, sessionID uint32, source string) {
+	if enumerationErr != nil {
+		candidates = nil
+	}
+	return resolveRequesterSessionWith(
+		candidates,
+		trustedImagePath,
+		now,
+		consoleSessionID,
+		lookupSessionUser,
+	)
+}
+
 func normalizeWindowsPath(path string) string {
 	path = strings.TrimSpace(path)
 	if len(path) >= 4 && strings.EqualFold(path[:4], `\\?\`) {

--- a/agent/internal/etwlua/requester_session_test.go
+++ b/agent/internal/etwlua/requester_session_test.go
@@ -2,6 +2,7 @@ package etwlua
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -197,6 +198,41 @@ func TestResolveRequesterSessionWith(t *testing.T) {
 				t.Fatalf("session lookups = %v, want %v", lookups, tc.wantLookups)
 			}
 		})
+	}
+}
+
+func TestResolveRequesterSessionAfterEnumerationDiscardsPartialResultsOnError(t *testing.T) {
+	now := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC)
+	trustedPath := `C:\Windows\System32\consent.exe`
+	partialCandidates := []consentProcessCandidate{
+		{PID: 300, SessionID: 3, ImagePath: trustedPath, StartedAt: now.Add(-time.Second)},
+	}
+	var lookups []uint32
+
+	username, sessionID, source := resolveRequesterSessionAfterEnumeration(
+		partialCandidates,
+		errors.New("Process32Next failed"),
+		trustedPath,
+		now,
+		1,
+		func(sessionID uint32) string {
+			lookups = append(lookups, sessionID)
+			return map[uint32]string{
+				1: `DOMAIN\console`,
+				3: `DOMAIN\requester`,
+			}[sessionID]
+		},
+	)
+
+	if username != `DOMAIN\console` || sessionID != 1 || source != requesterSourceConsoleFallback {
+		t.Fatalf(
+			"resolution = (%q, %d, %q), want (%q, %d, %q)",
+			username, sessionID, source,
+			`DOMAIN\console`, 1, requesterSourceConsoleFallback,
+		)
+	}
+	if !reflect.DeepEqual(lookups, []uint32{1}) {
+		t.Fatalf("session lookups = %v, want console fallback only", lookups)
 	}
 }
 

--- a/agent/internal/etwlua/requester_session_test.go
+++ b/agent/internal/etwlua/requester_session_test.go
@@ -1,0 +1,221 @@
+package etwlua
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestSelectNewestConsentProcess(t *testing.T) {
+	now := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC)
+	trustedPath := `C:\Windows\System32\consent.exe`
+	valid := consentProcessCandidate{
+		PID:       100,
+		SessionID: 2,
+		ImagePath: trustedPath,
+		StartedAt: now.Add(-5 * time.Second),
+	}
+
+	tests := []struct {
+		name       string
+		candidates []consentProcessCandidate
+		wantPID    uint32
+		wantOK     bool
+	}{
+		{
+			name: "newest recent trusted process wins",
+			candidates: []consentProcessCandidate{
+				valid,
+				{PID: 101, SessionID: 3, ImagePath: trustedPath, StartedAt: now.Add(-time.Second)},
+			},
+			wantPID: 101,
+			wantOK:  true,
+		},
+		{
+			name: "matching is case insensitive and accepts Win32 prefix",
+			candidates: []consentProcessCandidate{
+				{PID: 102, SessionID: 4, ImagePath: `  \\?\c:/WINDOWS/System32/CONSENT.EXE\  `, StartedAt: now.Add(-time.Second)},
+			},
+			wantPID: 102,
+			wantOK:  true,
+		},
+		{
+			name: "newer same-name process outside System32 is ignored",
+			candidates: []consentProcessCandidate{
+				valid,
+				{PID: 103, SessionID: 5, ImagePath: `C:\Temp\consent.exe`, StartedAt: now.Add(-time.Second)},
+			},
+			wantPID: 100,
+			wantOK:  true,
+		},
+		{
+			name: "process older than dedupe window is ignored",
+			candidates: []consentProcessCandidate{
+				{PID: 104, SessionID: 6, ImagePath: trustedPath, StartedAt: now.Add(-dedupeWindow - time.Nanosecond)},
+			},
+			wantOK: false,
+		},
+		{
+			name: "process in session zero is ignored",
+			candidates: []consentProcessCandidate{
+				{PID: 105, SessionID: 0, ImagePath: trustedPath, StartedAt: now.Add(-time.Second)},
+			},
+			wantOK: false,
+		},
+		{
+			name: "process with invalid session is ignored",
+			candidates: []consentProcessCandidate{
+				{PID: 106, SessionID: 0xFFFFFFFF, ImagePath: trustedPath, StartedAt: now.Add(-time.Second)},
+			},
+			wantOK: false,
+		},
+		{
+			name: "process with zero creation time is ignored",
+			candidates: []consentProcessCandidate{
+				{PID: 107, SessionID: 7, ImagePath: trustedPath},
+			},
+			wantOK: false,
+		},
+		{
+			name: "process created after observation time is ignored",
+			candidates: []consentProcessCandidate{
+				{PID: 108, SessionID: 8, ImagePath: trustedPath, StartedAt: now.Add(time.Nanosecond)},
+			},
+			wantOK: false,
+		},
+		{
+			name: "highest PID breaks an exact creation-time tie",
+			candidates: []consentProcessCandidate{
+				{PID: 109, SessionID: 9, ImagePath: trustedPath, StartedAt: now.Add(-time.Second)},
+				{PID: 110, SessionID: 10, ImagePath: trustedPath, StartedAt: now.Add(-time.Second)},
+			},
+			wantPID: 110,
+			wantOK:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := selectNewestConsentProcess(tc.candidates, trustedPath, now)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (candidate = %+v)", ok, tc.wantOK, got)
+			}
+			if ok && got.PID != tc.wantPID {
+				t.Fatalf("PID = %d, want %d", got.PID, tc.wantPID)
+			}
+		})
+	}
+}
+
+func TestResolveRequesterSessionWith(t *testing.T) {
+	now := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC)
+	trustedPath := `C:\Windows\System32\consent.exe`
+	candidates := []consentProcessCandidate{
+		{PID: 200, SessionID: 2, ImagePath: trustedPath, StartedAt: now.Add(-5 * time.Second)},
+		{PID: 201, SessionID: 3, ImagePath: trustedPath, StartedAt: now.Add(-time.Second)},
+	}
+
+	tests := []struct {
+		name             string
+		candidates       []consentProcessCandidate
+		consoleSessionID uint32
+		users            map[uint32]string
+		wantUsername     string
+		wantSessionID    uint32
+		wantSource       string
+		wantLookups      []uint32
+	}{
+		{
+			name:             "newest consent session resolves requester",
+			candidates:       candidates,
+			consoleSessionID: 1,
+			users:            map[uint32]string{3: `DOMAIN\requester`, 1: `DOMAIN\console`},
+			wantUsername:     `DOMAIN\requester`,
+			wantSessionID:    3,
+			wantSource:       "consent_process",
+			wantLookups:      []uint32{3},
+		},
+		{
+			name:             "unresolved consent session falls back to console",
+			candidates:       candidates,
+			consoleSessionID: 1,
+			users:            map[uint32]string{1: `DOMAIN\console`},
+			wantUsername:     `DOMAIN\console`,
+			wantSessionID:    1,
+			wantSource:       "console_fallback",
+			wantLookups:      []uint32{3, 1},
+		},
+		{
+			name:             "no consent candidate uses console fallback",
+			consoleSessionID: 1,
+			users:            map[uint32]string{1: `DOMAIN\console`},
+			wantUsername:     `DOMAIN\console`,
+			wantSessionID:    1,
+			wantSource:       "console_fallback",
+			wantLookups:      []uint32{1},
+		},
+		{
+			name:             "no consent user and no console user is unresolved",
+			candidates:       candidates,
+			consoleSessionID: 1,
+			users:            map[uint32]string{},
+			wantSource:       "unresolved",
+			wantLookups:      []uint32{3, 1},
+		},
+		{
+			name:             "invalid console session is not queried",
+			consoleSessionID: 0xFFFFFFFF,
+			users:            map[uint32]string{},
+			wantSource:       "unresolved",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var lookups []uint32
+			lookupUser := func(sessionID uint32) string {
+				lookups = append(lookups, sessionID)
+				return tc.users[sessionID]
+			}
+
+			username, sessionID, source := resolveRequesterSessionWith(
+				tc.candidates,
+				trustedPath,
+				now,
+				tc.consoleSessionID,
+				lookupUser,
+			)
+			if username != tc.wantUsername || sessionID != tc.wantSessionID || source != tc.wantSource {
+				t.Fatalf(
+					"resolution = (%q, %d, %q), want (%q, %d, %q)",
+					username, sessionID, source,
+					tc.wantUsername, tc.wantSessionID, tc.wantSource,
+				)
+			}
+			if !reflect.DeepEqual(lookups, tc.wantLookups) {
+				t.Fatalf("session lookups = %v, want %v", lookups, tc.wantLookups)
+			}
+		})
+	}
+}
+
+func TestEventSubjectSessionIDIsLocalOnly(t *testing.T) {
+	payload, err := json.Marshal(Event{
+		SubjectUsername:      `DOMAIN\requester`,
+		SubjectSessionID:     42,
+		TargetExecutablePath: `C:\Windows\System32\cmd.exe`,
+		ObservedAt:           time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("Marshal Event: %v", err)
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		t.Fatalf("Unmarshal Event JSON: %v", err)
+	}
+	if _, ok := fields["subject_session_id"]; ok {
+		t.Fatalf("subject_session_id must not be serialized: %s", payload)
+	}
+}

--- a/agent/internal/etwlua/requester_session_windows.go
+++ b/agent/internal/etwlua/requester_session_windows.go
@@ -29,8 +29,9 @@ func resolveRequesterSession() (username string, sessionID uint32, source string
 	if err != nil {
 		log.Debug("etwlua: consent process enumeration was incomplete", "error", err.Error())
 	}
-	return resolveRequesterSessionWith(
+	return resolveRequesterSessionAfterEnumeration(
 		candidates,
+		err,
 		trustedImagePath,
 		now,
 		consoleSessionID,

--- a/agent/internal/etwlua/requester_session_windows.go
+++ b/agent/internal/etwlua/requester_session_windows.go
@@ -1,0 +1,136 @@
+//go:build windows
+
+package etwlua
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const maxProcessImagePath = 32768
+
+func resolveRequesterSession() (username string, sessionID uint32, source string) {
+	now := time.Now().UTC()
+	consoleSessionID := windows.WTSGetActiveConsoleSessionId()
+
+	trustedImagePath, err := trustedConsentImagePath()
+	if err != nil {
+		log.Debug("etwlua: failed to resolve trusted consent image path", "error", err.Error())
+		return resolveRequesterSessionWith(nil, "", now, consoleSessionID, lookupSessionUser)
+	}
+
+	candidates, err := enumerateConsentProcesses()
+	if err != nil {
+		log.Debug("etwlua: consent process enumeration was incomplete", "error", err.Error())
+	}
+	return resolveRequesterSessionWith(
+		candidates,
+		trustedImagePath,
+		now,
+		consoleSessionID,
+		lookupSessionUser,
+	)
+}
+
+func trustedConsentImagePath() (string, error) {
+	windowsDirectory, err := windows.GetSystemWindowsDirectory()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(windowsDirectory, "System32", "consent.exe"), nil
+}
+
+func enumerateConsentProcesses() ([]consentProcessCandidate, error) {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return nil, fmt.Errorf("CreateToolhelp32Snapshot: %w", err)
+	}
+	defer windows.CloseHandle(snapshot)
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("Process32First: %w", err)
+	}
+
+	var candidates []consentProcessCandidate
+	for {
+		if strings.EqualFold(windows.UTF16ToString(entry.ExeFile[:]), "consent.exe") {
+			if candidate, ok := inspectConsentProcess(entry.ProcessID); ok {
+				candidates = append(candidates, candidate)
+			}
+		}
+
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+				return candidates, nil
+			}
+			return candidates, fmt.Errorf("Process32Next: %w", err)
+		}
+	}
+}
+
+func inspectConsentProcess(pid uint32) (consentProcessCandidate, bool) {
+	process, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+	if err != nil {
+		return consentProcessCandidate{}, false
+	}
+	defer windows.CloseHandle(process)
+
+	pathBuffer := make([]uint16, maxProcessImagePath)
+	pathLength := uint32(len(pathBuffer))
+	if err := windows.QueryFullProcessImageName(process, 0, &pathBuffer[0], &pathLength); err != nil {
+		return consentProcessCandidate{}, false
+	}
+
+	var creationTime, exitTime, kernelTime, userTime windows.Filetime
+	if err := windows.GetProcessTimes(process, &creationTime, &exitTime, &kernelTime, &userTime); err != nil {
+		return consentProcessCandidate{}, false
+	}
+
+	var sessionID uint32
+	if err := windows.ProcessIdToSessionId(pid, &sessionID); err != nil {
+		return consentProcessCandidate{}, false
+	}
+
+	return consentProcessCandidate{
+		PID:       pid,
+		SessionID: sessionID,
+		ImagePath: windows.UTF16ToString(pathBuffer[:pathLength]),
+		StartedAt: time.Unix(0, creationTime.Nanoseconds()).UTC(),
+	}, true
+}
+
+func lookupSessionUser(sessionID uint32) string {
+	if !validInteractiveSessionID(sessionID) {
+		return ""
+	}
+
+	var token windows.Token
+	if err := windows.WTSQueryUserToken(sessionID, &token); err != nil {
+		return ""
+	}
+	defer token.Close()
+
+	tokenUser, err := token.GetTokenUser()
+	if err != nil {
+		return ""
+	}
+	account, domain, _, err := tokenUser.User.Sid.LookupAccount("")
+	if err != nil || account == "" {
+		return ""
+	}
+	if domain == "" {
+		return account
+	}
+	return domain + `\` + account
+}

--- a/agent/internal/heartbeat/handlers_actuate.go
+++ b/agent/internal/heartbeat/handlers_actuate.go
@@ -105,6 +105,13 @@ func (h *Heartbeat) actuateElevation(ctx context.Context, requestID string, time
 	// would corrupt input injection. See Heartbeat.pamActuateMu.
 	h.pamActuateMu.Lock()
 	defer h.pamActuateMu.Unlock()
+	if h.pamDismissalUncertain {
+		return pamactuator.Result{
+			Success:       false,
+			Reason:        "dismissal_uncertain",
+			DetailMessage: "previous PAM consent dismissal has not reported completion",
+		}
+	}
 
 	manager := newElevationAccountManager()
 	cred, err := manager.Promote(ctx)

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -208,10 +208,11 @@ type Heartbeat struct {
 	stopBrokerAcceptingAndWait func(context.Context) error
 	stopHelperLifecycleAndWait func(context.Context) error
 	closeSessionBroker         func()
-	// pamFindSession / pamRequestDialog default to the real broker methods in
-	// RunPamFlow when nil; overridden in pam_flow_test.go.
-	pamFindSession   func(capability, targetWinSession string) *sessionbroker.Session
-	pamRequestDialog func(session *sessionbroker.Session, id string, req ipc.PamRequestDialog, timeout time.Duration) (ipc.PamDialogResult, error)
+	// PAM seams default to the real broker methods in RunPamFlow/denyConsent
+	// when nil; overridden in pam_flow_test.go.
+	pamFindSession    func(capability, targetWinSession string) *sessionbroker.Session
+	pamRequestDialog  func(session *sessionbroker.Session, id string, req ipc.PamRequestDialog, timeout time.Duration) (ipc.PamDialogResult, error)
+	pamDismissConsent func(session *sessionbroker.Session, id string, timeout time.Duration) (ipc.PamDismissConsentResult, error)
 	// pamActuateMu serializes consent.exe actuation/dismissal so the local
 	// etwlua flow (RunPamFlow) and the remote actuate_elevation command never
 	// drive SendInput/SetThreadDesktop against the same live consent.exe prompt

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -218,9 +218,13 @@ type Heartbeat struct {
 	// drive SendInput/SetThreadDesktop against the same live consent.exe prompt
 	// concurrently (e.g. an await_remote technician approval firing
 	// actuate_elevation while a re-fired ETW event re-enters RunPamFlow).
-	pamActuateMu   sync.Mutex
-	wsDesktopStart func(sessionID string, displayIndex int, config desktop.StreamConfig, sendFrame desktop.SendFrameFunc) (int, int, error)
-	desktopOwners  sync.Map // desktop session ID -> helper session ID
+	pamActuateMu sync.Mutex
+	// pamDismissalUncertain is protected by pamActuateMu. It keeps later PAM
+	// input fail-closed after a broker failure until the helper's correlated
+	// response proves the old dismissal command has stopped.
+	pamDismissalUncertain bool
+	wsDesktopStart        func(sessionID string, displayIndex int, config desktop.StreamConfig, sendFrame desktop.SendFrameFunc) (int, int, error)
+	desktopOwners         sync.Map // desktop session ID -> helper session ID
 
 	// Resilience & observability
 	pool        *workerpool.Pool

--- a/agent/internal/heartbeat/pam_flow.go
+++ b/agent/internal/heartbeat/pam_flow.go
@@ -2,6 +2,7 @@ package heartbeat
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/etwlua"
@@ -147,17 +148,40 @@ func (h *Heartbeat) denyConsent(session *sessionbroker.Session, requestID, reaso
 	}
 
 	var (
-		res ipc.PamDismissConsentResult
-		err error
+		res              ipc.PamDismissConsentResult
+		err              error
+		alreadyUncertain bool
 	)
-	// Serialize the complete synchronous helper IPC round trip against any
-	// concurrent actuateElevation. The closure's deferred unlock also keeps the
-	// mutex usable if an injected test seam panics and RunPamFlow recovers it.
+	// Serialize the helper command against any concurrent actuateElevation. If
+	// the broker cannot prove completion, mark PAM input fail-closed until the
+	// helper's correlated response proves its work is quiescent. New actuation
+	// attempts return immediately without promoting credentials or sending input.
 	func() {
 		h.pamActuateMu.Lock()
 		defer h.pamActuateMu.Unlock()
+		if h.pamDismissalUncertain {
+			alreadyUncertain = true
+			return
+		}
 		res, err = dismiss(session, requestID, pamDismissTimeout)
+		var uncertain *sessionbroker.PamDismissUncertainError
+		if errors.As(err, &uncertain) && uncertain.Quiesced != nil {
+			h.pamDismissalUncertain = true
+			go func(quiesced <-chan struct{}) {
+				<-quiesced
+				h.pamActuateMu.Lock()
+				h.pamDismissalUncertain = false
+				h.pamActuateMu.Unlock()
+				log.Info("pam: uncertain dismissal quiesced; PAM actuation gate released",
+					"elevationRequestId", requestID)
+			}(uncertain.Quiesced)
+		}
 	}()
+	if alreadyUncertain {
+		log.Warn("pam: deny enforcement skipped — previous dismissal completion remains uncertain",
+			"elevationRequestId", requestID, "reason", reason)
+		return
+	}
 	if err != nil {
 		log.Warn("pam: deny enforcement FAILED — dismissal IPC error; consent.exe may still be live",
 			"elevationRequestId", requestID, "reason", reason, "error", err.Error())

--- a/agent/internal/heartbeat/pam_flow.go
+++ b/agent/internal/heartbeat/pam_flow.go
@@ -59,7 +59,9 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 
 	targetWinSession := ""
 	sessionTarget := "physical_console_fallback"
-	if ev.SubjectSessionID != 0 {
+	// Zero and Windows' 0xFFFFFFFF invalid-session sentinel both mean the
+	// requester session is unresolved, so retain the existing console fallback.
+	if ev.SubjectSessionID != 0 && ev.SubjectSessionID != 0xFFFFFFFF {
 		targetWinSession = strconv.FormatUint(uint64(ev.SubjectSessionID), 10)
 		sessionTarget = "requester_session"
 	}

--- a/agent/internal/heartbeat/pam_flow.go
+++ b/agent/internal/heartbeat/pam_flow.go
@@ -3,6 +3,7 @@ package heartbeat
 import (
 	"context"
 	"errors"
+	"strconv"
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/etwlua"
@@ -48,11 +49,19 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 
 	switch outcome.Status {
 	case etwlua.ElevationDenied, etwlua.ElevationAutoApproved, etwlua.ElevationPending:
-		// All supported statuses need the console-bound SYSTEM+PAM helper. Hard
-		// deny skips the dialog only after resolving that target session.
+		// All supported statuses need the SYSTEM+PAM helper in the requester's
+		// Windows session when known. Hard deny skips the dialog only after
+		// resolving that target session.
 	default:
 		log.Debug("pam: no local flow for status", "status", string(outcome.Status), "elevationRequestId", outcome.RequestID)
 		return
+	}
+
+	targetWinSession := ""
+	sessionTarget := "physical_console_fallback"
+	if ev.SubjectSessionID != 0 {
+		targetWinSession = strconv.FormatUint(uint64(ev.SubjectSessionID), 10)
+		sessionTarget = "requester_session"
 	}
 
 	// Defensive: the PamRunner contract (see etwlua.PamRunner) says the caller
@@ -60,7 +69,8 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 	// slip can't panic the ETW hot path — every supported flow needs a helper.
 	if h.pamFindSession == nil && h.sessionBroker == nil {
 		log.Warn("pam: no session broker available; skipping elevation flow",
-			"elevationRequestId", outcome.RequestID)
+			"elevationRequestId", outcome.RequestID, "sessionTarget", sessionTarget,
+			"targetWinSession", targetWinSession)
 		return
 	}
 
@@ -68,10 +78,11 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 	if find == nil {
 		find = h.sessionBroker.FindCapableSession
 	}
-	session := find(ipc.ScopePam, "")
+	session := find(ipc.ScopePam, targetWinSession)
 	if session == nil {
 		log.Warn("pam: no capable SYSTEM helper session; cannot complete elevation flow, consent.exe will time out",
-			"elevationRequestId", outcome.RequestID)
+			"elevationRequestId", outcome.RequestID, "sessionTarget", sessionTarget,
+			"targetWinSession", targetWinSession)
 		return
 	}
 	if outcome.Status == etwlua.ElevationDenied {

--- a/agent/internal/heartbeat/pam_flow.go
+++ b/agent/internal/heartbeat/pam_flow.go
@@ -17,6 +17,9 @@ const (
 	// consent.exe's idle lifetime (~120s default). Timeout → deny+dismiss
 	// (RequestPamApproval already returns that on timeout).
 	pamDialogTimeout = 90 * time.Second
+	// pamDismissTimeout gives the helper's eight-second dismissal attempt time
+	// to complete and return its correlated IPC result.
+	pamDismissTimeout = 10 * time.Second
 	// defaultActuateTimeoutMs is the per-actuation consent.exe wait, matching
 	// the remote handler's fallback.
 	defaultActuateTimeoutMs = 8000
@@ -43,11 +46,9 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 	}()
 
 	switch outcome.Status {
-	case etwlua.ElevationDenied:
-		h.denyConsent(ctx, outcome.RequestID, "policy_denied") // policy hard-deny, no dialog
-		return
-	case etwlua.ElevationAutoApproved, etwlua.ElevationPending:
-		// fall through to the dialog gate
+	case etwlua.ElevationDenied, etwlua.ElevationAutoApproved, etwlua.ElevationPending:
+		// All supported statuses need the console-bound SYSTEM+PAM helper. Hard
+		// deny skips the dialog only after resolving that target session.
 	default:
 		log.Debug("pam: no local flow for status", "status", string(outcome.Status), "elevationRequestId", outcome.RequestID)
 		return
@@ -55,7 +56,7 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 
 	// Defensive: the PamRunner contract (see etwlua.PamRunner) says the caller
 	// passes a nil runner when the broker is absent. Guard anyway so a wiring
-	// slip can't panic the ETW hot path — only the dialog path needs the broker.
+	// slip can't panic the ETW hot path — every supported flow needs a helper.
 	if h.pamFindSession == nil && h.sessionBroker == nil {
 		log.Warn("pam: no session broker available; skipping elevation flow",
 			"elevationRequestId", outcome.RequestID)
@@ -68,8 +69,12 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 	}
 	session := find(ipc.ScopePam, "")
 	if session == nil {
-		log.Warn("pam: no capable SYSTEM helper session; cannot show dialog, consent.exe will time out",
+		log.Warn("pam: no capable SYSTEM helper session; cannot complete elevation flow, consent.exe will time out",
 			"elevationRequestId", outcome.RequestID)
+		return
+	}
+	if outcome.Status == etwlua.ElevationDenied {
+		h.denyConsent(session, outcome.RequestID, "policy_denied") // policy hard-deny, no dialog
 		return
 	}
 
@@ -94,7 +99,7 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 		// but fail closed if a new fall-through status is ever added upstream:
 		// never actuate on a status we don't recognize.
 		log.Warn("pam: unexpected status at verdict mapping; denying", "status", string(outcome.Status), "elevationRequestId", outcome.RequestID)
-		h.denyConsent(ctx, outcome.RequestID, "unexpected_status")
+		h.denyConsent(session, outcome.RequestID, "unexpected_status")
 		return
 	}
 
@@ -117,19 +122,47 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 			}
 		}()
 	case sessionbroker.PamActionDeny:
-		h.denyConsent(ctx, outcome.RequestID, dialog.Reason)
+		h.denyConsent(session, outcome.RequestID, dialog.Reason)
 	case sessionbroker.PamActionAwaitRemote:
 		log.Info("pam: awaiting remote technician approval; server will issue actuate_elevation", "elevationRequestId", outcome.RequestID)
 	}
 }
 
 // denyConsent cancels the live consent.exe prompt and logs the denial.
-func (h *Heartbeat) denyConsent(ctx context.Context, requestID, reason string) {
-	// Serialize the Dismiss against any concurrent actuateElevation so the two
-	// never drive SendInput against the same prompt at once. See pamActuateMu.
-	h.pamActuateMu.Lock()
-	res := newActuator().Dismiss(ctx)
-	h.pamActuateMu.Unlock()
+func (h *Heartbeat) denyConsent(session *sessionbroker.Session, requestID, reason string) {
+	if session == nil {
+		log.Warn("pam: deny enforcement FAILED — no SYSTEM helper session; consent.exe may still be live",
+			"elevationRequestId", requestID, "reason", reason)
+		return
+	}
+
+	dismiss := h.pamDismissConsent
+	if dismiss == nil {
+		if h.sessionBroker == nil {
+			log.Warn("pam: deny enforcement FAILED — dismissal IPC unavailable; consent.exe may still be live",
+				"elevationRequestId", requestID, "reason", reason)
+			return
+		}
+		dismiss = h.sessionBroker.DismissPamConsent
+	}
+
+	var (
+		res ipc.PamDismissConsentResult
+		err error
+	)
+	// Serialize the complete synchronous helper IPC round trip against any
+	// concurrent actuateElevation. The closure's deferred unlock also keeps the
+	// mutex usable if an injected test seam panics and RunPamFlow recovers it.
+	func() {
+		h.pamActuateMu.Lock()
+		defer h.pamActuateMu.Unlock()
+		res, err = dismiss(session, requestID, pamDismissTimeout)
+	}()
+	if err != nil {
+		log.Warn("pam: deny enforcement FAILED — dismissal IPC error; consent.exe may still be live",
+			"elevationRequestId", requestID, "reason", reason, "error", err.Error())
+		return
+	}
 
 	switch {
 	case res.Success:

--- a/agent/internal/heartbeat/pam_flow.go
+++ b/agent/internal/heartbeat/pam_flow.go
@@ -68,7 +68,7 @@ func (h *Heartbeat) RunPamFlow(ctx context.Context, ev etwlua.Event, outcome etw
 	}
 	session := find(ipc.ScopePam, "")
 	if session == nil {
-		log.Warn("pam: no capable user-helper session; cannot show dialog, consent.exe will time out",
+		log.Warn("pam: no capable SYSTEM helper session; cannot show dialog, consent.exe will time out",
 			"elevationRequestId", outcome.RequestID)
 		return
 	}

--- a/agent/internal/heartbeat/pam_flow_test.go
+++ b/agent/internal/heartbeat/pam_flow_test.go
@@ -485,6 +485,69 @@ func TestActuateAndDenyMutuallyExclusive(t *testing.T) {
 	}
 }
 
+func TestDenyConsentTimeoutKeepsGateUntilHelperQuiescent(t *testing.T) {
+	quiesced := make(chan struct{})
+	selectedSession := &sessionbroker.Session{SessionID: "selected-pam-helper"}
+	manager := &fakeElevationManager{promoteErr: errors.New("simulated promote failure")}
+	swapElevationManagerForTest(t, func() elevaccount.AccountManager { return manager })
+	var dismissCalls atomic.Int32
+	h := &Heartbeat{
+		pamDismissConsent: func(session *sessionbroker.Session, id string, timeout time.Duration) (ipc.PamDismissConsentResult, error) {
+			dismissCalls.Add(1)
+			return ipc.PamDismissConsentResult{}, &sessionbroker.PamDismissUncertainError{
+				Cause:    sessionbroker.ErrCommandTimeout,
+				Quiesced: quiesced,
+			}
+		},
+	}
+
+	h.denyConsent(selectedSession, "req-timeout", "policy_denied")
+
+	resultCh := make(chan pamactuator.Result, 1)
+	go func() {
+		resultCh <- h.actuateElevation(context.Background(), "req-after-timeout", defaultActuateTimeoutMs)
+	}()
+	select {
+	case result := <-resultCh:
+		if result.Reason != "dismissal_uncertain" {
+			t.Fatalf("actuation reason = %q, want dismissal_uncertain", result.Reason)
+		}
+	case <-time.After(250 * time.Millisecond):
+		close(quiesced)
+		t.Fatal("fail-closed actuation check blocked instead of returning promptly")
+	}
+	if manager.promoteSeen != 0 {
+		t.Fatalf("Promote calls while dismissal uncertain = %d, want 0", manager.promoteSeen)
+	}
+	h.denyConsent(selectedSession, "req-second-deny", "policy_denied")
+	if got := dismissCalls.Load(); got != 1 {
+		t.Fatalf("dismiss calls while previous completion uncertain = %d, want 1", got)
+	}
+
+	close(quiesced)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		h.pamActuateMu.Lock()
+		uncertain := h.pamDismissalUncertain
+		h.pamActuateMu.Unlock()
+		if !uncertain {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("PAM actuation gate stayed fail-closed after helper quiescence")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	result := h.actuateElevation(context.Background(), "req-after-quiescence", defaultActuateTimeoutMs)
+	if result.Reason == "dismissal_uncertain" {
+		t.Fatal("actuation remained fail-closed after helper quiescence")
+	}
+	if manager.promoteSeen != 1 {
+		t.Fatalf("Promote calls after helper quiescence = %d, want 1", manager.promoteSeen)
+	}
+}
+
 // TestRunPamFlowDismissPanicUnlocksPamActuateMutex proves the dismissal critical
 // section uses a deferred unlock. RunPamFlow contains the injected panic, after
 // which the mutex must remain usable by later actuation/dismissal work.

--- a/agent/internal/heartbeat/pam_flow_test.go
+++ b/agent/internal/heartbeat/pam_flow_test.go
@@ -20,9 +20,11 @@ func TestRunPamFlow(t *testing.T) {
 	dismissed := ipc.PamDialogResult{Approved: false, DismissedByUser: true}
 
 	cases := []struct {
-		name   string
-		status etwlua.ElevationStatus
-		dialog ipc.PamDialogResult
+		name                 string
+		status               etwlua.ElevationStatus
+		subjectSessionID     uint32
+		wantTargetWinSession string
+		dialog               ipc.PamDialogResult
 		// returnErr, when non-nil, is returned by the pamRequestDialog seam to
 		// simulate a broker round-trip failure. RunPamFlow must coerce that to
 		// deny+dismiss regardless of the (ignored) dialog result.
@@ -54,27 +56,33 @@ func TestRunPamFlow(t *testing.T) {
 		dismissErr error
 	}{
 		{
-			name:          "policy hard-deny dismisses without dialog",
-			status:        "denied",
-			dialog:        approved, // ignored — denied short-circuits before the dialog
-			wantFind:      true,
-			wantDialog:    false,
-			wantTriggered: false,
-			wantDismissed: true,
-			wantActuated:  false,
+			name:                 "policy hard-deny targets requester session and dismisses without dialog",
+			status:               "denied",
+			subjectSessionID:     7,
+			wantTargetWinSession: "7",
+			dialog:               approved, // ignored — denied short-circuits before the dialog
+			wantFind:             true,
+			wantDialog:           false,
+			wantTriggered:        false,
+			wantDismissed:        true,
+			wantActuated:         false,
 		},
 		{
-			name:          "auto-approved + user-approved actuates",
-			status:        "auto_approved",
-			dialog:        approved,
-			wantFind:      true,
-			wantDialog:    true,
-			wantTriggered: true,
-			wantDismissed: false,
-			wantActuated:  true,
+			name:                 "auto-approved targets requester session as unsigned decimal and actuates",
+			status:               "auto_approved",
+			subjectSessionID:     ^uint32(0),
+			wantTargetWinSession: "4294967295",
+			dialog:               approved,
+			wantFind:             true,
+			wantDialog:           true,
+			wantTriggered:        true,
+			wantDismissed:        false,
+			wantActuated:         true,
 		},
 		{
-			name:          "auto-approved + user-dismissed denies",
+			// Zero is the compatibility path for old/fake/non-Windows events: the
+			// empty target retains the broker's physical-console selection.
+			name:          "zero requester session retains console fallback and user dismissal denies",
 			status:        "auto_approved",
 			dialog:        dismissed,
 			wantFind:      true,
@@ -84,14 +92,16 @@ func TestRunPamFlow(t *testing.T) {
 			wantActuated:  false,
 		},
 		{
-			name:          "pending + user-approved awaits remote",
-			status:        "pending",
-			dialog:        approved,
-			wantFind:      true,
-			wantDialog:    true,
-			wantTriggered: false,
-			wantDismissed: false,
-			wantActuated:  false,
+			name:                 "pending targets requester session and user approval awaits remote",
+			status:               "pending",
+			subjectSessionID:     42,
+			wantTargetWinSession: "42",
+			dialog:               approved,
+			wantFind:             true,
+			wantDialog:           true,
+			wantTriggered:        false,
+			wantDismissed:        false,
+			wantActuated:         false,
 		},
 		{
 			name:          "pending + user-dismissed denies",
@@ -104,15 +114,17 @@ func TestRunPamFlow(t *testing.T) {
 			wantActuated:  false,
 		},
 		{
-			name:          "auto-approved but no capable session shows nothing",
-			status:        "auto_approved",
-			dialog:        approved,
-			noSession:     true,
-			wantFind:      true,
-			wantDialog:    false, // early return precedes the dialog round-trip
-			wantTriggered: false,
-			wantDismissed: false,
-			wantActuated:  false,
+			name:                 "exact requester session without capable helper performs no PAM action",
+			status:               "auto_approved",
+			subjectSessionID:     44,
+			wantTargetWinSession: "44",
+			dialog:               approved,
+			noSession:            true,
+			wantFind:             true,
+			wantDialog:           false, // early return precedes the dialog round-trip
+			wantTriggered:        false,
+			wantDismissed:        false,
+			wantActuated:         false,
 		},
 		{
 			// Production wiring: sessionBroker is nil (only built when
@@ -258,6 +270,7 @@ func TestRunPamFlow(t *testing.T) {
 			swapElevationManagerForTest(t, func() elevaccount.AccountManager { return manager })
 
 			var findCalled, dialogCalled bool
+			var gotTargetWinSession string
 			var gotDialog ipc.PamRequestDialog
 			var gotDialogTimeout time.Duration
 			var gotDialogSession, gotDismissSession *sessionbroker.Session
@@ -271,11 +284,9 @@ func TestRunPamFlow(t *testing.T) {
 			if !tc.noBroker {
 				h.pamFindSession = func(capability, targetWinSession string) *sessionbroker.Session {
 					findCalled = true
+					gotTargetWinSession = targetWinSession
 					if capability != ipc.ScopePam {
 						t.Fatalf("FindCapableSession capability = %q, want %q", capability, ipc.ScopePam)
-					}
-					if targetWinSession != "" {
-						t.Fatalf("FindCapableSession target = %q, want console selection", targetWinSession)
 					}
 					if tc.noSession {
 						return nil
@@ -305,6 +316,7 @@ func TestRunPamFlow(t *testing.T) {
 			// Signer↔Hash) in buildPamRequestDialog fails the mapping assertion.
 			ev := etwlua.Event{
 				SubjectUsername:        "CORP\\subjectuser",
+				SubjectSessionID:       tc.subjectSessionID,
 				TargetExecutablePath:   `C:\path\to\target.exe`,
 				TargetExecutableHash:   "hash-deadbeef",
 				TargetExecutableSigner: "signer-Acme Corp",
@@ -325,6 +337,9 @@ func TestRunPamFlow(t *testing.T) {
 			}
 			if findCalled != tc.wantFind {
 				t.Errorf("findCalled = %v, want %v", findCalled, tc.wantFind)
+			}
+			if findCalled && gotTargetWinSession != tc.wantTargetWinSession {
+				t.Errorf("FindCapableSession target = %q, want %q", gotTargetWinSession, tc.wantTargetWinSession)
 			}
 
 			// The dialog round-trip must only be reached when expected: denied skips

--- a/agent/internal/heartbeat/pam_flow_test.go
+++ b/agent/internal/heartbeat/pam_flow_test.go
@@ -33,6 +33,7 @@ func TestRunPamFlow(t *testing.T) {
 		// where the broker is absent. Proves RunPamFlow never panics in that shape.
 		noBroker bool
 		// wantDialog asserts whether the broker dialog round-trip was reached.
+		wantFind      bool
 		wantDialog    bool
 		wantTriggered bool
 		wantDismissed bool
@@ -45,15 +46,18 @@ func TestRunPamFlow(t *testing.T) {
 		// wantPromoteAttempt asserts Promote was called exactly once even though
 		// the actuation did not complete (used with promoteErr).
 		wantPromoteAttempt bool
-		// dismissResult, when non-nil, overrides the fake actuator's Dismiss
-		// return so the deny-path logging switch can be exercised against the
+		// dismissResult, when non-nil, overrides the broker-dismiss result so the
+		// deny-path logging switch can be exercised against the
 		// benign "no_consent_window" and the genuine-failure reasons.
-		dismissResult *pamactuator.Result
+		dismissResult *ipc.PamDismissConsentResult
+		// dismissErr simulates an IPC round-trip error from DismissPamConsent.
+		dismissErr error
 	}{
 		{
 			name:          "policy hard-deny dismisses without dialog",
 			status:        "denied",
 			dialog:        approved, // ignored — denied short-circuits before the dialog
+			wantFind:      true,
 			wantDialog:    false,
 			wantTriggered: false,
 			wantDismissed: true,
@@ -63,6 +67,7 @@ func TestRunPamFlow(t *testing.T) {
 			name:          "auto-approved + user-approved actuates",
 			status:        "auto_approved",
 			dialog:        approved,
+			wantFind:      true,
 			wantDialog:    true,
 			wantTriggered: true,
 			wantDismissed: false,
@@ -72,6 +77,7 @@ func TestRunPamFlow(t *testing.T) {
 			name:          "auto-approved + user-dismissed denies",
 			status:        "auto_approved",
 			dialog:        dismissed,
+			wantFind:      true,
 			wantDialog:    true,
 			wantTriggered: false,
 			wantDismissed: true,
@@ -81,6 +87,7 @@ func TestRunPamFlow(t *testing.T) {
 			name:          "pending + user-approved awaits remote",
 			status:        "pending",
 			dialog:        approved,
+			wantFind:      true,
 			wantDialog:    true,
 			wantTriggered: false,
 			wantDismissed: false,
@@ -90,6 +97,7 @@ func TestRunPamFlow(t *testing.T) {
 			name:          "pending + user-dismissed denies",
 			status:        "pending",
 			dialog:        dismissed,
+			wantFind:      true,
 			wantDialog:    true,
 			wantTriggered: false,
 			wantDismissed: true,
@@ -100,6 +108,7 @@ func TestRunPamFlow(t *testing.T) {
 			status:        "auto_approved",
 			dialog:        approved,
 			noSession:     true,
+			wantFind:      true,
 			wantDialog:    false, // early return precedes the dialog round-trip
 			wantTriggered: false,
 			wantDismissed: false,
@@ -119,15 +128,26 @@ func TestRunPamFlow(t *testing.T) {
 			wantActuated:  false,
 		},
 		{
-			// denied returns via denyConsent (Actuator.Dismiss, no broker)
-			// BEFORE the nil-broker guard, so it must still dismiss cleanly.
-			name:          "denied with nil broker still dismisses without panic",
+			// Session 0 cannot reach the console prompt. With no broker there is no
+			// dismissal attempt and, critically, no service-local actuator fallback.
+			name:          "denied with nil broker does not fall back to local dismiss",
 			status:        "denied",
 			dialog:        approved, // ignored
 			noBroker:      true,
 			wantDialog:    false,
 			wantTriggered: false,
-			wantDismissed: true,
+			wantDismissed: false,
+			wantActuated:  false,
+		},
+		{
+			name:          "denied without capable session does not fall back to local dismiss",
+			status:        "denied",
+			dialog:        approved, // ignored
+			noSession:     true,
+			wantFind:      true,
+			wantDialog:    false,
+			wantTriggered: false,
+			wantDismissed: false,
 			wantActuated:  false,
 		},
 		{
@@ -137,6 +157,7 @@ func TestRunPamFlow(t *testing.T) {
 			status:        "auto_approved",
 			dialog:        approved, // overridden by the error path
 			returnErr:     errors.New("broker pipe closed"),
+			wantFind:      true,
 			wantDialog:    true, // the ask(...) seam was reached (and errored)
 			wantTriggered: false,
 			wantDismissed: true,
@@ -163,6 +184,7 @@ func TestRunPamFlow(t *testing.T) {
 			status:             "auto_approved",
 			dialog:             approved,
 			promoteErr:         elevaccount.ErrUnsupportedPlatform,
+			wantFind:           true,
 			wantDialog:         true,
 			wantTriggered:      false, // Promote fails before Trigger
 			wantDismissed:      false, // actuate path never dismisses
@@ -177,7 +199,8 @@ func TestRunPamFlow(t *testing.T) {
 			name:          "deny with dismiss no_consent_window is benign",
 			status:        "denied",
 			dialog:        approved, // ignored — denied short-circuits
-			dismissResult: &pamactuator.Result{Success: false, Reason: "no_consent_window"},
+			dismissResult: &ipc.PamDismissConsentResult{Success: false, Reason: "no_consent_window"},
+			wantFind:      true,
 			wantDialog:    false,
 			wantTriggered: false,
 			wantDismissed: true,
@@ -190,7 +213,19 @@ func TestRunPamFlow(t *testing.T) {
 			name:          "deny with dismiss send_input_failed does not panic",
 			status:        "denied",
 			dialog:        approved, // ignored
-			dismissResult: &pamactuator.Result{Success: false, Reason: "send_input_failed"},
+			dismissResult: &ipc.PamDismissConsentResult{Success: false, Reason: "send_input_failed", DetailMessage: "SendInput returned zero"},
+			wantFind:      true,
+			wantDialog:    false,
+			wantTriggered: false,
+			wantDismissed: true,
+			wantActuated:  false,
+		},
+		{
+			name:          "deny with dismissal IPC error does not panic",
+			status:        "denied",
+			dialog:        approved, // ignored
+			dismissErr:    errors.New("helper pipe closed"),
+			wantFind:      true,
 			wantDialog:    false,
 			wantTriggered: false,
 			wantDismissed: true,
@@ -200,7 +235,7 @@ func TestRunPamFlow(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var triggered, dismissed bool
+			var triggered, localDismissed, dismissed bool
 			var gotRequest pamactuator.Request
 			swapActuatorForTest(t, func() pamactuator.Actuator {
 				return fakeActuator{
@@ -210,10 +245,7 @@ func TestRunPamFlow(t *testing.T) {
 						return pamactuator.Result{Success: true, Reason: "ok"}
 					},
 					dismiss: func(context.Context) pamactuator.Result {
-						dismissed = true
-						if tc.dismissResult != nil {
-							return *tc.dismissResult
-						}
+						localDismissed = true
 						return pamactuator.Result{Success: true, Reason: "dismissed"}
 					},
 				}
@@ -225,28 +257,47 @@ func TestRunPamFlow(t *testing.T) {
 			}
 			swapElevationManagerForTest(t, func() elevaccount.AccountManager { return manager })
 
-			var dialogCalled bool
+			var findCalled, dialogCalled bool
 			var gotDialog ipc.PamRequestDialog
 			var gotDialogTimeout time.Duration
-			// noBroker reproduces production wiring: both swappable seams nil
+			var gotDialogSession, gotDismissSession *sessionbroker.Session
+			var gotDismissID string
+			var gotDismissTimeout time.Duration
+			selectedSession := &sessionbroker.Session{SessionID: "selected-pam-helper"}
+			// noBroker reproduces production wiring: all swappable seams nil
 			// AND a nil sessionBroker. The defensive guard in RunPamFlow must
 			// keep this from dereferencing the nil broker.
 			h := &Heartbeat{}
 			if !tc.noBroker {
 				h.pamFindSession = func(capability, targetWinSession string) *sessionbroker.Session {
+					findCalled = true
 					if capability != ipc.ScopePam {
 						t.Fatalf("FindCapableSession capability = %q, want %q", capability, ipc.ScopePam)
+					}
+					if targetWinSession != "" {
+						t.Fatalf("FindCapableSession target = %q, want console selection", targetWinSession)
 					}
 					if tc.noSession {
 						return nil
 					}
-					return &sessionbroker.Session{}
+					return selectedSession
 				}
-				h.pamRequestDialog = func(_ *sessionbroker.Session, _ string, req ipc.PamRequestDialog, timeout time.Duration) (ipc.PamDialogResult, error) {
+				h.pamRequestDialog = func(session *sessionbroker.Session, _ string, req ipc.PamRequestDialog, timeout time.Duration) (ipc.PamDialogResult, error) {
 					dialogCalled = true
+					gotDialogSession = session
 					gotDialog = req
 					gotDialogTimeout = timeout
 					return tc.dialog, tc.returnErr
+				}
+				h.pamDismissConsent = func(session *sessionbroker.Session, id string, timeout time.Duration) (ipc.PamDismissConsentResult, error) {
+					dismissed = true
+					gotDismissSession = session
+					gotDismissID = id
+					gotDismissTimeout = timeout
+					if tc.dismissResult != nil {
+						return *tc.dismissResult, tc.dismissErr
+					}
+					return ipc.PamDismissConsentResult{Success: true, Reason: "dismissed"}, tc.dismissErr
 				}
 			}
 
@@ -269,13 +320,33 @@ func TestRunPamFlow(t *testing.T) {
 			if dismissed != tc.wantDismissed {
 				t.Errorf("dismissed = %v, want %v", dismissed, tc.wantDismissed)
 			}
+			if localDismissed {
+				t.Error("service-local actuator Dismiss was called; Session 0 fallback is forbidden")
+			}
+			if findCalled != tc.wantFind {
+				t.Errorf("findCalled = %v, want %v", findCalled, tc.wantFind)
+			}
 
-			// The dialog round-trip must only be reached when expected: denied
-			// short-circuits before it, and the no-session early return precedes
-			// the ask(...) call. (With a nil broker the seam is never installed,
-			// so dialogCalled stays false trivially.)
+			// The dialog round-trip must only be reached when expected: denied skips
+			// it after session resolution, while nil broker/session returns before
+			// ask(...). With a nil broker the seam is never installed, so
+			// dialogCalled stays false trivially.
 			if dialogCalled != tc.wantDialog {
 				t.Errorf("dialogCalled = %v, want %v", dialogCalled, tc.wantDialog)
+			}
+			if tc.wantDialog && gotDialogSession != selectedSession {
+				t.Errorf("dialog session = %p, want selected session %p", gotDialogSession, selectedSession)
+			}
+			if tc.wantDismissed {
+				if gotDismissSession != selectedSession {
+					t.Errorf("dismiss session = %p, want exact selected session %p", gotDismissSession, selectedSession)
+				}
+				if gotDismissID != outcome.RequestID {
+					t.Errorf("dismiss request ID = %q, want %q", gotDismissID, outcome.RequestID)
+				}
+				if gotDismissTimeout != pamDismissTimeout {
+					t.Errorf("dismiss timeout = %v, want %v", gotDismissTimeout, pamDismissTimeout)
+				}
 			}
 
 			// The actuate path runs Promote then a deferred Demote. When Promote
@@ -339,15 +410,17 @@ func TestRunPamFlow(t *testing.T) {
 // TestActuateAndDenyMutuallyExclusive proves pamActuateMu serializes consent.exe
 // actuation against dismissal: a remote actuate_elevation (actuateElevation) and
 // a re-fired local deny (denyConsent) must never drive SendInput against the same
-// prompt concurrently. The fake trigger/dismiss closures flip a shared `inside`
-// flag on entry, sleep to widen the overlap window, and fail the test if they
-// observe another invocation already inside the critical section. Run with -race.
+// prompt concurrently. The fake trigger/broker-dismiss closures flip a shared
+// `inside` flag on entry, sleep to widen the overlap window, and fail the test
+// if they observe another invocation already inside the critical section. Run
+// with -race.
 func TestActuateAndDenyMutuallyExclusive(t *testing.T) {
 	var inside atomic.Bool
 	var violation atomic.Bool
+	var localDismissed atomic.Bool
 
-	// guarded wraps a fake actuator op: assert nobody else is inside, hold the
-	// section briefly to widen the race window, then clear the flag.
+	// guarded wraps an actuation or broker-dismiss op: assert nobody else is
+	// inside, hold the section briefly to widen the race window, then clear it.
 	guarded := func() {
 		if !inside.CompareAndSwap(false, true) {
 			violation.Store(true) // someone else was already inside
@@ -363,8 +436,8 @@ func TestActuateAndDenyMutuallyExclusive(t *testing.T) {
 				return pamactuator.Result{Success: true, Reason: "ok"}
 			},
 			dismiss: func(context.Context) pamactuator.Result {
-				guarded()
-				return pamactuator.Result{Success: true, Reason: "dismissed"}
+				localDismissed.Store(true)
+				return pamactuator.Result{}
 			},
 		}
 	})
@@ -372,7 +445,22 @@ func TestActuateAndDenyMutuallyExclusive(t *testing.T) {
 		return &fakeElevationManager{cred: elevaccount.Credential{Username: "~breeze_elev", Password: "x"}}
 	})
 
-	h := &Heartbeat{}
+	selectedSession := &sessionbroker.Session{SessionID: "selected-pam-helper"}
+	h := &Heartbeat{
+		pamDismissConsent: func(session *sessionbroker.Session, id string, timeout time.Duration) (ipc.PamDismissConsentResult, error) {
+			if session != selectedSession {
+				t.Errorf("dismiss session = %p, want selected session %p", session, selectedSession)
+			}
+			if id != "req-deny" {
+				t.Errorf("dismiss request ID = %q, want req-deny", id)
+			}
+			if timeout != pamDismissTimeout {
+				t.Errorf("dismiss timeout = %v, want %v", timeout, pamDismissTimeout)
+			}
+			guarded()
+			return ipc.PamDismissConsentResult{Success: true, Reason: "dismissed"}, nil
+		},
+	}
 
 	const iterations = 40
 	var wg sync.WaitGroup
@@ -384,7 +472,7 @@ func TestActuateAndDenyMutuallyExclusive(t *testing.T) {
 		}()
 		go func() {
 			defer wg.Done()
-			h.denyConsent(context.Background(), "req-deny", "policy_denied")
+			h.denyConsent(selectedSession, "req-deny", "policy_denied")
 		}()
 	}
 	wg.Wait()
@@ -392,6 +480,34 @@ func TestActuateAndDenyMutuallyExclusive(t *testing.T) {
 	if violation.Load() {
 		t.Fatal("detected concurrent consent.exe actuation/dismissal — pamActuateMu is not serializing")
 	}
+	if localDismissed.Load() {
+		t.Fatal("service-local actuator Dismiss was called; Session 0 fallback is forbidden")
+	}
+}
+
+// TestRunPamFlowDismissPanicUnlocksPamActuateMutex proves the dismissal critical
+// section uses a deferred unlock. RunPamFlow contains the injected panic, after
+// which the mutex must remain usable by later actuation/dismissal work.
+func TestRunPamFlowDismissPanicUnlocksPamActuateMutex(t *testing.T) {
+	selectedSession := &sessionbroker.Session{SessionID: "selected-pam-helper"}
+	h := &Heartbeat{
+		pamFindSession: func(capability, targetWinSession string) *sessionbroker.Session {
+			return selectedSession
+		},
+		pamDismissConsent: func(session *sessionbroker.Session, id string, timeout time.Duration) (ipc.PamDismissConsentResult, error) {
+			panic("simulated broker-dismiss seam panic")
+		},
+	}
+
+	h.RunPamFlow(context.Background(), etwlua.Event{}, etwlua.ElevationOutcome{
+		RequestID: "req-dismiss-panic",
+		Status:    etwlua.ElevationDenied,
+	})
+
+	if !h.pamActuateMu.TryLock() {
+		t.Fatal("pamActuateMu remained locked after broker-dismiss seam panic")
+	}
+	h.pamActuateMu.Unlock()
 }
 
 // TestRunPamFlowSurvivesActuatorPanic proves the defer/recover at the top of

--- a/agent/internal/heartbeat/pam_flow_test.go
+++ b/agent/internal/heartbeat/pam_flow_test.go
@@ -68,16 +68,29 @@ func TestRunPamFlow(t *testing.T) {
 			wantActuated:         false,
 		},
 		{
-			name:                 "auto-approved targets requester session as unsigned decimal and actuates",
+			name:                 "auto-approved targets valid high requester session as unsigned decimal and actuates",
 			status:               "auto_approved",
-			subjectSessionID:     ^uint32(0),
-			wantTargetWinSession: "4294967295",
+			subjectSessionID:     0xFFFFFFFE,
+			wantTargetWinSession: "4294967294",
 			dialog:               approved,
 			wantFind:             true,
 			wantDialog:           true,
 			wantTriggered:        true,
 			wantDismissed:        false,
 			wantActuated:         true,
+		},
+		{
+			// 0xFFFFFFFF is Windows' invalid/unresolved session sentinel. Treat it
+			// like zero so the broker retains its physical-console fallback.
+			name:             "invalid requester session sentinel retains console fallback",
+			status:           "auto_approved",
+			subjectSessionID: 0xFFFFFFFF,
+			dialog:           approved,
+			wantFind:         true,
+			wantDialog:       true,
+			wantTriggered:    true,
+			wantDismissed:    false,
+			wantActuated:     true,
 		},
 		{
 			// Zero is the compatibility path for old/fake/non-Windows events: the

--- a/agent/internal/ipc/message.go
+++ b/agent/internal/ipc/message.go
@@ -129,7 +129,7 @@ const (
 // Scope constants identify the capabilities granted to a helper session.
 const (
 	ScopeAssist    = "assist"     // IPC scope granted to the assist helper
-	ScopePam       = "pam"        // IPC scope granted to the user helper for PAM dialogs
+	ScopePam       = "pam"        // IPC scope granted to the SYSTEM helper for PAM dialogs
 	ScopeConsentUI = "consent_ui" // narrow IPC scope: lets the assist helper receive remote-session consent prompt + active-session banner messages (UI only; NOT desktop/clipboard/notify)
 
 	// ScopeConsentUIFallback lets a user-role helper that advertised native

--- a/agent/internal/ipc/message.go
+++ b/agent/internal/ipc/message.go
@@ -257,7 +257,11 @@ type PamDialogResult struct {
 }
 
 // PamDismissConsentRequest asks the SYSTEM helper to dismiss consent.exe.
-type PamDismissConsentRequest struct{}
+// DeadlineUnixMs bounds input injection inside the target session and leaves
+// the broker time to receive the helper's correlated response.
+type PamDismissConsentRequest struct {
+	DeadlineUnixMs int64 `json:"deadlineUnixMs"`
+}
 
 // PamDismissConsentResult reports whether the helper dismissed consent.exe.
 type PamDismissConsentResult struct {

--- a/agent/internal/ipc/message.go
+++ b/agent/internal/ipc/message.go
@@ -22,9 +22,11 @@ const (
 	TypeTrayUpdate   = "tray_update"
 	TypeTrayAction   = "tray_action"
 
-	// PAM approval dialog
-	TypePamRequestDialog = "pam_request_dialog"
-	TypePamDialogResult  = "pam_dialog_result"
+	// PAM approval and consent dismissal
+	TypePamRequestDialog        = "pam_request_dialog"
+	TypePamDialogResult         = "pam_dialog_result"
+	TypePamDismissConsent       = "pam_dismiss_consent"
+	TypePamDismissConsentResult = "pam_dismiss_consent_result"
 
 	// Phase 4: Desktop + Clipboard
 	TypeDesktopStart  = "desktop_start"
@@ -252,6 +254,16 @@ type PamDialogResult struct {
 	Approved        bool   `json:"approved"`
 	Reason          string `json:"reason,omitempty"`
 	DismissedByUser bool   `json:"dismissedByUser"`
+}
+
+// PamDismissConsentRequest asks the SYSTEM helper to dismiss consent.exe.
+type PamDismissConsentRequest struct{}
+
+// PamDismissConsentResult reports whether the helper dismissed consent.exe.
+type PamDismissConsentResult struct {
+	Success       bool   `json:"success"`
+	Reason        string `json:"reason"`
+	DetailMessage string `json:"detailMessage,omitempty"`
 }
 
 // TrayUpdate tells the user helper to update the system tray icon/menu.

--- a/agent/internal/ipc/message_test.go
+++ b/agent/internal/ipc/message_test.go
@@ -101,3 +101,52 @@ func TestPamDialogMessagesRoundTrip(t *testing.T) {
 		t.Fatalf("ScopeConsentUI = %q, want consent_ui", ScopeConsentUI)
 	}
 }
+
+func TestPamDismissConsentMessagesRoundTrip(t *testing.T) {
+	if TypePamDismissConsent != "pam_dismiss_consent" {
+		t.Fatalf("TypePamDismissConsent = %q, want pam_dismiss_consent", TypePamDismissConsent)
+	}
+	if TypePamDismissConsentResult != "pam_dismiss_consent_result" {
+		t.Fatalf("TypePamDismissConsentResult = %q, want pam_dismiss_consent_result", TypePamDismissConsentResult)
+	}
+
+	requestBytes, err := json.Marshal(PamDismissConsentRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(requestBytes) != `{}` {
+		t.Fatalf("request JSON = %s, want {}", requestBytes)
+	}
+	var requestOut PamDismissConsentRequest
+	if err := json.Unmarshal(requestBytes, &requestOut); err != nil {
+		t.Fatal(err)
+	}
+
+	result := PamDismissConsentResult{
+		Success:       true,
+		Reason:        "dismissed",
+		DetailMessage: "consent process terminated",
+	}
+	resultBytes, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(resultBytes) != `{"success":true,"reason":"dismissed","detailMessage":"consent process terminated"}` {
+		t.Fatalf("result JSON = %s", resultBytes)
+	}
+	var resultOut PamDismissConsentResult
+	if err := json.Unmarshal(resultBytes, &resultOut); err != nil {
+		t.Fatal(err)
+	}
+	if resultOut != result {
+		t.Fatalf("result round-trip mismatch: %+v != %+v", resultOut, result)
+	}
+
+	withoutDetail, err := json.Marshal(PamDismissConsentResult{Success: false, Reason: "not_found"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(withoutDetail) != `{"success":false,"reason":"not_found"}` {
+		t.Fatalf("omitempty failed: %s", withoutDetail)
+	}
+}

--- a/agent/internal/ipc/message_test.go
+++ b/agent/internal/ipc/message_test.go
@@ -110,16 +110,20 @@ func TestPamDismissConsentMessagesRoundTrip(t *testing.T) {
 		t.Fatalf("TypePamDismissConsentResult = %q, want pam_dismiss_consent_result", TypePamDismissConsentResult)
 	}
 
-	requestBytes, err := json.Marshal(PamDismissConsentRequest{})
+	request := PamDismissConsentRequest{DeadlineUnixMs: 1784221200123}
+	requestBytes, err := json.Marshal(request)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(requestBytes) != `{}` {
-		t.Fatalf("request JSON = %s, want {}", requestBytes)
+	if string(requestBytes) != `{"deadlineUnixMs":1784221200123}` {
+		t.Fatalf("request JSON = %s", requestBytes)
 	}
 	var requestOut PamDismissConsentRequest
 	if err := json.Unmarshal(requestBytes, &requestOut); err != nil {
 		t.Fatal(err)
+	}
+	if requestOut != request {
+		t.Fatalf("request round-trip mismatch: %+v != %+v", requestOut, request)
 	}
 
 	result := PamDismissConsentResult{

--- a/agent/internal/pamactuator/actuator.go
+++ b/agent/internal/pamactuator/actuator.go
@@ -38,6 +38,8 @@ package pamactuator
 
 import "context"
 
+const dismissCancelledReason = "dismiss_cancelled"
+
 // Request is the input to Actuator.Trigger. Carries everything needed to
 // drive a single consent.exe prompt to completion. Username + password are
 // the cleartext dormant-admin credentials to type — they live in process
@@ -71,8 +73,9 @@ type Result struct {
 	// Reason is a short stable code suitable for switch statements on
 	// the server side. One of: "ok", "no_consent_window", "desktop_open_failed",
 	// "set_thread_desktop_failed", "send_input_failed", "consent_did_not_close",
-	// "unsupported_platform". Dismiss returns from this same code set (it shares
-	// Trigger's desktop-attach / input / close-verification failure reasons).
+	// "unsupported_platform", "dismiss_cancelled". Dismiss returns from this
+	// same code set (it shares Trigger's desktop-attach / input /
+	// close-verification failure reasons).
 	Reason string
 
 	// DetailMessage is a free-form human-readable string for logs. Never
@@ -95,8 +98,32 @@ type Actuator interface {
 	// "no_consent_window" if none was found, or one of Trigger's failure
 	// reasons for desktop-attach / input / close-verification failures
 	// ("desktop_open_failed", "set_thread_desktop_failed", "send_input_failed",
-	// "consent_did_not_close", "unsupported_platform").
+	// "consent_did_not_close", "unsupported_platform", "dismiss_cancelled").
 	Dismiss(ctx context.Context) Result
+}
+
+// dismissCancellationResult gives every platform implementation the same
+// stable result when the caller's input-injection window has closed.
+func dismissCancellationResult(ctx context.Context) (Result, bool) {
+	if err := ctx.Err(); err != nil {
+		return Result{
+			Success:       false,
+			Reason:        dismissCancelledReason,
+			DetailMessage: "PAM consent dismissal cancelled before input: " + err.Error(),
+		}, true
+	}
+	return Result{}, false
+}
+
+func dismissPostInputCancellationResult(ctx context.Context) (Result, bool) {
+	if err := ctx.Err(); err != nil {
+		return Result{
+			Success:       false,
+			Reason:        dismissCancelledReason,
+			DetailMessage: "PAM consent dismissal cancelled after Escape while waiting for consent.exe to close: " + err.Error(),
+		}, true
+	}
+	return Result{}, false
 }
 
 // New returns the platform-default Actuator. On non-Windows this returns

--- a/agent/internal/pamactuator/actuator_test.go
+++ b/agent/internal/pamactuator/actuator_test.go
@@ -82,6 +82,39 @@ func TestDismissUnsupportedOnNonWindows(t *testing.T) {
 	}
 }
 
+func TestDismissCancellationResult(t *testing.T) {
+	if result, ok := dismissCancellationResult(context.Background()); ok {
+		t.Fatalf("live context returned cancellation result: %+v", result)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result, ok := dismissCancellationResult(ctx)
+	if !ok {
+		t.Fatal("cancelled context did not return cancellation result")
+	}
+	if result.Success {
+		t.Fatal("cancelled dismissal should not succeed")
+	}
+	if result.Reason != "dismiss_cancelled" {
+		t.Fatalf("reason = %q, want dismiss_cancelled", result.Reason)
+	}
+	if result.DetailMessage == "" {
+		t.Fatal("cancelled dismissal should include detail")
+	}
+
+	result, ok = dismissPostInputCancellationResult(ctx)
+	if !ok {
+		t.Fatal("post-input cancellation did not return a cancellation result")
+	}
+	if result.Reason != "dismiss_cancelled" {
+		t.Fatalf("post-input reason = %q, want dismiss_cancelled", result.Reason)
+	}
+	if result.DetailMessage != "PAM consent dismissal cancelled after Escape while waiting for consent.exe to close: context canceled" {
+		t.Fatalf("post-input detail = %q", result.DetailMessage)
+	}
+}
+
 // TestRequestZeroValuesAreSafe sanity-checks that a zero-valued Request
 // doesn't make the stub panic. The Windows impl applies a default 8000ms
 // timeout when TimeoutMs<=0; the stub doesn't need to but must not crash.

--- a/agent/internal/pamactuator/actuator_windows.go
+++ b/agent/internal/pamactuator/actuator_windows.go
@@ -157,6 +157,10 @@ func (a *windowsActuator) Trigger(ctx context.Context, req Request) Result {
 // here (the deny path carries no credential), so it uses the same default
 // 8000ms window Trigger falls back to when TimeoutMs<=0.
 func (a *windowsActuator) Dismiss(ctx context.Context) Result {
+	if result, cancelled := dismissCancellationResult(ctx); cancelled {
+		return result
+	}
+
 	// SetThreadDesktop is per-thread; stay on the same OS thread for the
 	// duration so the desktop binding doesn't follow a reparked goroutine.
 	runtime.LockOSThread()
@@ -190,6 +194,9 @@ func (a *windowsActuator) Dismiss(ctx context.Context) Result {
 
 	hwnd := waitForConsent(ctx, deadline)
 	if hwnd == 0 {
+		if result, cancelled := dismissCancellationResult(ctx); cancelled {
+			return result
+		}
 		return Result{
 			Success:       false,
 			Reason:        "no_consent_window",
@@ -197,6 +204,13 @@ func (a *windowsActuator) Dismiss(ctx context.Context) Result {
 		}
 	}
 
+	// Minimize input after the broker-authorized window has closed. This check
+	// deliberately sits immediately next to pressVK; if the thread is delayed
+	// between the check and input, the broker retains the PAM actuation gate
+	// until this helper returns its correlated response.
+	if result, cancelled := dismissCancellationResult(ctx); cancelled {
+		return result
+	}
 	if err := pressVK(vkEscape); err != nil {
 		return Result{
 			Success:       false,
@@ -206,6 +220,9 @@ func (a *windowsActuator) Dismiss(ctx context.Context) Result {
 	}
 
 	if !waitForConsentClose(ctx, hwnd, deadline) {
+		if result, cancelled := dismissPostInputCancellationResult(ctx); cancelled {
+			return result
+		}
 		return Result{
 			Success:       false,
 			Reason:        "consent_did_not_close",
@@ -266,4 +283,3 @@ func typeString(s string) error {
 	}
 	return nil
 }
-

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -1448,6 +1448,41 @@ func (b *Broker) RequestPamApproval(session *Session, id string, req ipc.PamRequ
 	return result, nil
 }
 
+// DismissPamConsent asks the SYSTEM PAM helper to dismiss the active Windows
+// consent process and waits for the correlated result.
+func (b *Broker) DismissPamConsent(session *Session, id string, timeout time.Duration) (ipc.PamDismissConsentResult, error) {
+	var zero ipc.PamDismissConsentResult
+	if session == nil {
+		return zero, fmt.Errorf("nil PAM helper session")
+	}
+	if session.HelperRole != ipc.HelperRoleSystem {
+		return zero, fmt.Errorf("PAM dialog requires a SYSTEM helper session")
+	}
+	if !session.HasScope(ipc.ScopePam) {
+		return zero, fmt.Errorf("PAM SYSTEM helper session is missing %q scope", ipc.ScopePam)
+	}
+
+	resp, err := b.SendCommandAndWait(
+		session,
+		id,
+		ipc.TypePamDismissConsent,
+		ipc.PamDismissConsentRequest{},
+		timeout,
+	)
+	if err != nil {
+		return zero, err
+	}
+	if resp.Error != "" {
+		return zero, fmt.Errorf("PAM consent dismissal helper error: %s", resp.Error)
+	}
+
+	var result ipc.PamDismissConsentResult
+	if err := json.Unmarshal(resp.Payload, &result); err != nil {
+		return zero, fmt.Errorf("decode PAM consent dismissal result: %w", err)
+	}
+	return result, nil
+}
+
 // sendPreAuthRejectAndClose wraps rawConn, sends a PreAuthReject envelope
 // with a short write timeout so the broker isn't held up by a stuck client,
 // then closes the connection. All errors are ignored — this is best-effort.

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -207,10 +207,11 @@ func (b *Broker) maybeStartKeepalive(session *Session, role string) {
 	}
 }
 
-// Role-based scopes: SYSTEM helpers own desktop capture, user-token helpers own script execution.
+// Role-based scopes: SYSTEM helpers own desktop capture and secure-desktop PAM
+// dialogs; user-token helpers own script execution.
 var (
-	systemHelperScopes   = []string{"notify", "tray", "clipboard", "desktop"}
-	userHelperScopes     = []string{"notify", "clipboard", "run_as_user", ipc.ScopePam}
+	systemHelperScopes   = []string{"notify", "tray", "clipboard", "desktop", ipc.ScopePam}
+	userHelperScopes     = []string{"notify", "clipboard", "run_as_user"}
 	watchdogHelperScopes = []string{"watchdog"}
 	// assistHelperScopes is least-privilege: the Breeze Assist helper receives
 	// only the helper token and must NOT get desktop/clipboard/run_as_user/notify/tray.
@@ -1183,7 +1184,7 @@ func (b *Broker) FindCapableSession(capability string, targetWinSession string) 
 
 	hasCapability := func(s *Session) bool {
 		if capability == ipc.ScopePam {
-			return s.HelperRole == ipc.HelperRoleUser && s.HasScope(ipc.ScopePam)
+			return s.HelperRole == ipc.HelperRoleSystem && s.HasScope(ipc.ScopePam)
 		}
 		// GetCapabilities takes s.mu — required because the atomic snapshot
 		// only protects the outer map identity, not per-session fields. A
@@ -1418,6 +1419,12 @@ func (b *Broker) RequestPamApproval(session *Session, id string, req ipc.PamRequ
 	denyDismiss := ipc.PamDialogResult{Approved: false, DismissedByUser: true}
 	if session == nil {
 		return denyDismiss, fmt.Errorf("nil PAM helper session")
+	}
+	if session.HelperRole != ipc.HelperRoleSystem {
+		return denyDismiss, fmt.Errorf("PAM dialog requires a SYSTEM helper session")
+	}
+	if !session.HasScope(ipc.ScopePam) {
+		return denyDismiss, fmt.Errorf("PAM SYSTEM helper session is missing %q scope", ipc.ScopePam)
 	}
 
 	resp, err := b.SendCommandAndWait(session, id, ipc.TypePamRequestDialog, req, timeout)

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -1221,6 +1221,12 @@ func (b *Broker) FindCapableSession(capability string, targetWinSession string) 
 	if best != nil {
 		return best
 	}
+	// PAM approval is tied to the requested (normally console) Windows
+	// session. Never fall back to another active session: that would expose
+	// one user's elevation decision to a different interactive user.
+	if capability == ipc.ScopePam {
+		return nil
+	}
 
 	// Second pass: fall back to any capable session that isn't disconnected.
 	// IsSessionDisconnected makes a WTS syscall — safe outside any lock.

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -1456,20 +1456,26 @@ func (b *Broker) DismissPamConsent(session *Session, id string, timeout time.Dur
 		return zero, fmt.Errorf("nil PAM helper session")
 	}
 	if session.HelperRole != ipc.HelperRoleSystem {
-		return zero, fmt.Errorf("PAM dialog requires a SYSTEM helper session")
+		return zero, fmt.Errorf("PAM consent dismissal requires a SYSTEM helper session")
 	}
 	if !session.HasScope(ipc.ScopePam) {
 		return zero, fmt.Errorf("PAM SYSTEM helper session is missing %q scope", ipc.ScopePam)
 	}
+	deadline, err := pamDismissConsentDeadline(time.Now(), timeout)
+	if err != nil {
+		return zero, err
+	}
 
-	resp, err := b.SendCommandAndWait(
-		session,
+	resp, quiesced, err := session.sendCommandWithQuiescence(
 		id,
 		ipc.TypePamDismissConsent,
-		ipc.PamDismissConsentRequest{},
+		ipc.PamDismissConsentRequest{DeadlineUnixMs: deadline.UnixMilli()},
 		timeout,
 	)
 	if err != nil {
+		if quiesced != nil {
+			return zero, &PamDismissUncertainError{Cause: err, Quiesced: quiesced}
+		}
 		return zero, err
 	}
 	if resp.Error != "" {
@@ -1481,6 +1487,29 @@ func (b *Broker) DismissPamConsent(session *Session, id string, timeout time.Dur
 		return zero, fmt.Errorf("decode PAM consent dismissal result: %w", err)
 	}
 	return result, nil
+}
+
+// pamDismissConsentDeadline reserves enough of the broker timeout for the
+// helper to serialize and return its result after input injection stops. The
+// deadline is truncated to the request's millisecond wire precision.
+func pamDismissConsentDeadline(now time.Time, timeout time.Duration) (time.Time, error) {
+	if timeout <= 0 {
+		return time.Time{}, fmt.Errorf("PAM consent dismissal timeout must be positive")
+	}
+
+	grace := timeout / 5
+	if grace > time.Second {
+		grace = time.Second
+	}
+	if grace <= 0 {
+		return time.Time{}, fmt.Errorf("PAM consent dismissal timeout is too small")
+	}
+
+	deadline := now.Add(timeout - grace).Truncate(time.Millisecond)
+	if !deadline.After(now) {
+		return time.Time{}, fmt.Errorf("PAM consent dismissal timeout is too small for millisecond deadline precision")
+	}
+	return deadline, nil
 }
 
 // sendPreAuthRejectAndClose wraps rawConn, sends a PreAuthReject envelope

--- a/agent/internal/sessionbroker/broker_test.go
+++ b/agent/internal/sessionbroker/broker_test.go
@@ -969,26 +969,26 @@ func TestScopesForRoleAssist(t *testing.T) {
 	}
 }
 
-func TestPamScopeBelongsOnlyToUserHelper(t *testing.T) {
-	if !containsString(userHelperScopes, ipc.ScopePam) {
-		t.Fatalf("userHelperScopes = %v, want %q", userHelperScopes, ipc.ScopePam)
+func TestPamScopeBelongsOnlyToSystemHelper(t *testing.T) {
+	if containsString(userHelperScopes, ipc.ScopePam) {
+		t.Fatalf("userHelperScopes = %v, must not contain %q", userHelperScopes, ipc.ScopePam)
 	}
-	if containsString(systemHelperScopes, ipc.ScopePam) {
-		t.Fatalf("systemHelperScopes = %v, must not contain %q", systemHelperScopes, ipc.ScopePam)
+	if !containsString(systemHelperScopes, ipc.ScopePam) {
+		t.Fatalf("systemHelperScopes = %v, want %q", systemHelperScopes, ipc.ScopePam)
 	}
 
 	b := &Broker{}
 	userScopes := b.scopesForRole(ipc.HelperRoleUser, ipc.HelperBinaryUserHelper, "windows", `C:\Program Files\Breeze\breeze-user-helper.exe`)
-	if !containsString(userScopes, ipc.ScopePam) {
-		t.Fatalf("scopesForRole(user) = %v, want %q", userScopes, ipc.ScopePam)
+	if containsString(userScopes, ipc.ScopePam) {
+		t.Fatalf("scopesForRole(user) = %v, must not contain %q", userScopes, ipc.ScopePam)
 	}
 	systemScopes := b.scopesForRole(ipc.HelperRoleSystem, ipc.HelperBinaryUserHelper, "windows", `C:\Program Files\Breeze\breeze-user-helper.exe`)
-	if containsString(systemScopes, ipc.ScopePam) {
-		t.Fatalf("scopesForRole(system) = %v, must not contain %q", systemScopes, ipc.ScopePam)
+	if !containsString(systemScopes, ipc.ScopePam) {
+		t.Fatalf("scopesForRole(system) = %v, want %q", systemScopes, ipc.ScopePam)
 	}
 }
 
-func TestFindCapableSessionPamUsesUserPamScope(t *testing.T) {
+func TestFindCapableSessionPamUsesSystemPamScope(t *testing.T) {
 	now := time.Now()
 	userSession := &Session{
 		SessionID:     "user-pam",
@@ -1014,8 +1014,8 @@ func TestFindCapableSessionPamUsesUserPamScope(t *testing.T) {
 	}
 
 	got := b.FindCapableSession(ipc.ScopePam, "7")
-	if got != userSession {
-		t.Fatalf("FindCapableSession(pam) = %v, want user-token session", got)
+	if got != systemSession {
+		t.Fatalf("FindCapableSession(pam) = %v, want SYSTEM session", got)
 	}
 }
 

--- a/agent/internal/sessionbroker/broker_test.go
+++ b/agent/internal/sessionbroker/broker_test.go
@@ -1019,6 +1019,26 @@ func TestFindCapableSessionPamUsesSystemPamScope(t *testing.T) {
 	}
 }
 
+func TestFindCapableSessionPamDoesNotFallBackAcrossWindowsSessions(t *testing.T) {
+	otherSession := &Session{
+		SessionID:     "system-pam-other-session",
+		WinSessionID:  "8",
+		AllowedScopes: []string{ipc.ScopePam},
+		HelperRole:    ipc.HelperRoleSystem,
+		ConnectedAt:   time.Now(),
+		LastSeen:      time.Now(),
+	}
+	b := &Broker{
+		sessions: map[string]*Session{
+			otherSession.SessionID: otherSession,
+		},
+	}
+
+	if got := b.FindCapableSession(ipc.ScopePam, "7"); got != nil {
+		t.Fatalf("FindCapableSession(pam, target=7) = %v, want nil rather than session %q", got, otherSession.WinSessionID)
+	}
+}
+
 func TestAssistHelperBinaryPathsIncludeBreezeHelper(t *testing.T) {
 	paths := assistHelperBinaryPaths("/opt/breeze")
 	found := false

--- a/agent/internal/sessionbroker/errors.go
+++ b/agent/internal/sessionbroker/errors.go
@@ -13,3 +13,26 @@ var (
 	ErrInvalidBinary      = errors.New("sessionbroker: binary path verification failed")
 	ErrBinaryHashMismatch = errors.New("sessionbroker: binary hash mismatch")
 )
+
+// PamDismissUncertainError means a dismiss command may still be executing in
+// the target helper session. Quiesced closes only after the authenticated,
+// correlated helper response proves the command has finished. Callers that
+// serialize PAM input must remain fail-closed while it is open.
+type PamDismissUncertainError struct {
+	Cause    error
+	Quiesced <-chan struct{}
+}
+
+func (e *PamDismissUncertainError) Error() string {
+	if e == nil || e.Cause == nil {
+		return "sessionbroker: PAM consent dismissal completion uncertain"
+	}
+	return "sessionbroker: PAM consent dismissal completion uncertain: " + e.Cause.Error()
+}
+
+func (e *PamDismissUncertainError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}

--- a/agent/internal/sessionbroker/pam_approval_test.go
+++ b/agent/internal/sessionbroker/pam_approval_test.go
@@ -98,8 +98,8 @@ func TestRequestPamApprovalRequiresSystemPamSession(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			serverConn, clientConn := net.Pipe()
-			defer serverConn.Close()
-			defer clientConn.Close()
+			defer func() { _ = serverConn.Close() }()
+			defer func() { _ = clientConn.Close() }()
 			if err := serverConn.SetWriteDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
 				t.Fatalf("set write deadline: %v", err)
 			}

--- a/agent/internal/sessionbroker/pam_approval_test.go
+++ b/agent/internal/sessionbroker/pam_approval_test.go
@@ -3,6 +3,7 @@ package sessionbroker
 import (
 	"encoding/json"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -73,10 +74,54 @@ func TestRequestPamApprovalTimeoutDeniesAndDismisses(t *testing.T) {
 	}
 }
 
+func TestRequestPamApprovalRequiresSystemPamSession(t *testing.T) {
+	tests := []struct {
+		name    string
+		role    string
+		scopes  []string
+		wantErr string
+	}{
+		{
+			name:    "user helper with PAM scope",
+			role:    ipc.HelperRoleUser,
+			scopes:  []string{ipc.ScopePam},
+			wantErr: "SYSTEM helper",
+		},
+		{
+			name:    "system helper without PAM scope",
+			role:    ipc.HelperRoleSystem,
+			scopes:  []string{"desktop"},
+			wantErr: ipc.ScopePam,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			serverConn, clientConn := net.Pipe()
+			defer serverConn.Close()
+			defer clientConn.Close()
+			if err := serverConn.SetWriteDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
+				t.Fatalf("set write deadline: %v", err)
+			}
+
+			session := NewSession(ipc.NewConn(serverConn), 1000, "1000", "testuser", "x11:0", "test-session-1", tc.scopes)
+			session.HelperRole = tc.role
+			got, err := (&Broker{}).RequestPamApproval(session, "pam-rejected", ipc.PamRequestDialog{}, time.Millisecond)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("RequestPamApproval error = %v, want substring %q", err, tc.wantErr)
+			}
+			if got.Approved || !got.DismissedByUser {
+				t.Fatalf("rejected result = %+v, want deny+dismiss", got)
+			}
+		})
+	}
+}
+
 func createPamApprovalTestSession() (*Session, *ipc.Conn) {
 	serverConn, clientConn := net.Pipe()
 	serverIPC := ipc.NewConn(serverConn)
 	clientIPC := ipc.NewConn(clientConn)
 	session := NewSession(serverIPC, 1000, "1000", "testuser", "x11:0", "test-session-1", []string{ipc.ScopePam})
+	session.HelperRole = ipc.HelperRoleSystem
 	return session, clientIPC
 }

--- a/agent/internal/sessionbroker/pam_approval_test.go
+++ b/agent/internal/sessionbroker/pam_approval_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestRequestPamApprovalReturnsDialogResult(t *testing.T) {
 	session, clientIPC := createPamApprovalTestSession()
-	defer session.Close()
-	defer clientIPC.Close()
+	defer func() { _ = session.Close() }()
+	defer func() { _ = clientIPC.Close() }()
 
 	go func() {
 		clientIPC.SetReadDeadline(time.Now().Add(2 * time.Second))
@@ -54,8 +54,8 @@ func TestRequestPamApprovalReturnsDialogResult(t *testing.T) {
 
 func TestRequestPamApprovalTimeoutDeniesAndDismisses(t *testing.T) {
 	session, clientIPC := createPamApprovalTestSession()
-	defer session.Close()
-	defer clientIPC.Close()
+	defer func() { _ = session.Close() }()
+	defer func() { _ = clientIPC.Close() }()
 
 	go func() {
 		clientIPC.SetReadDeadline(time.Now().Add(2 * time.Second))

--- a/agent/internal/sessionbroker/pam_dismiss_test.go
+++ b/agent/internal/sessionbroker/pam_dismiss_test.go
@@ -168,6 +168,15 @@ func TestDismissPamConsentRejectsWrongResponseType(t *testing.T) {
 	if got != (ipc.PamDismissConsentResult{}) {
 		t.Fatalf("wrong-type result = %+v, want zero value", got)
 	}
+	var uncertain *PamDismissUncertainError
+	if !errors.As(err, &uncertain) || uncertain.Quiesced == nil {
+		t.Fatalf("wrong-type error = %T, want uncertain completion with quiescence", err)
+	}
+	select {
+	case <-uncertain.Quiesced:
+		t.Fatal("wrong response type must not prove helper quiescence")
+	default:
+	}
 }
 
 func TestDismissPamConsentTimesOut(t *testing.T) {
@@ -190,6 +199,128 @@ func TestDismissPamConsentTimesOut(t *testing.T) {
 	}
 	if got != (ipc.PamDismissConsentResult{}) {
 		t.Fatalf("timeout result = %+v, want zero value", got)
+	}
+}
+
+func TestDismissPamConsentTransportFailureIsUncertain(t *testing.T) {
+	session, clientIPC := createPamDismissTestSession()
+	defer session.Close()
+	if err := clientIPC.Close(); err != nil {
+		t.Fatalf("close helper connection: %v", err)
+	}
+
+	got, err := (&Broker{}).DismissPamConsent(session, "dismiss-send-failed", 2*time.Second)
+	if err == nil {
+		t.Fatal("DismissPamConsent error = nil, want transport error")
+	}
+	if got != (ipc.PamDismissConsentResult{}) {
+		t.Fatalf("transport-error result = %+v, want zero value", got)
+	}
+	var uncertain *PamDismissUncertainError
+	if !errors.As(err, &uncertain) || uncertain.Quiesced == nil {
+		t.Fatalf("transport error = %T, want uncertain completion with quiescence", err)
+	}
+	select {
+	case <-uncertain.Quiesced:
+		t.Fatal("transport failure must not prove helper quiescence")
+	default:
+	}
+}
+
+func TestDismissPamConsentTimeoutSignalsLateHelperQuiescence(t *testing.T) {
+	session, clientIPC := createPamDismissTestSession()
+	defer session.Close()
+	defer clientIPC.Close()
+
+	releaseResponse := make(chan struct{})
+	helperDone := make(chan error, 1)
+	go func() {
+		if err := clientIPC.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+			helperDone <- fmt.Errorf("set client read deadline: %w", err)
+			return
+		}
+		env, err := clientIPC.Recv()
+		if err != nil {
+			helperDone <- fmt.Errorf("client recv: %w", err)
+			return
+		}
+		<-releaseResponse
+		helperDone <- clientIPC.SendTyped(env.ID, ipc.TypePamDismissConsentResult, ipc.PamDismissConsentResult{
+			Success: true,
+			Reason:  "dismissed",
+		})
+	}()
+	go session.RecvLoop(func(s *Session, env *ipc.Envelope) {})
+
+	got, err := (&Broker{}).DismissPamConsent(session, "dismiss-late", 50*time.Millisecond)
+	if got != (ipc.PamDismissConsentResult{}) {
+		t.Fatalf("timeout result = %+v, want zero value", got)
+	}
+	if !errors.Is(err, ErrCommandTimeout) {
+		t.Fatalf("DismissPamConsent error = %v, want ErrCommandTimeout", err)
+	}
+	var uncertain *PamDismissUncertainError
+	if !errors.As(err, &uncertain) {
+		t.Fatalf("DismissPamConsent error = %T, want *PamDismissUncertainError", err)
+	}
+	if uncertain.Quiesced == nil {
+		t.Fatal("uncertain timeout did not expose helper quiescence")
+	}
+	select {
+	case <-uncertain.Quiesced:
+		t.Fatal("helper reported quiescent before its late response")
+	default:
+	}
+
+	close(releaseResponse)
+	select {
+	case <-uncertain.Quiesced:
+	case <-time.After(2 * time.Second):
+		t.Fatal("helper quiescence was not signaled after the correlated late response")
+	}
+	if helperErr := <-helperDone; helperErr != nil {
+		t.Fatalf("late helper response: %v", helperErr)
+	}
+}
+
+func TestPamDismissConsentDeadlineReservesResponseGrace(t *testing.T) {
+	now := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name:    "ten second timeout reserves one second",
+			timeout: 10 * time.Second,
+			want:    now.Add(9 * time.Second),
+		},
+		{
+			name:    "short timeout reserves one fifth",
+			timeout: 50 * time.Millisecond,
+			want:    now.Add(40 * time.Millisecond),
+		},
+		{name: "zero timeout", timeout: 0, wantErr: true},
+		{name: "timeout too small for grace", timeout: 4 * time.Nanosecond, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := pamDismissConsentDeadline(now, tc.timeout)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("pamDismissConsentDeadline(%v) error = nil, want error", tc.timeout)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("pamDismissConsentDeadline(%v): %v", tc.timeout, err)
+			}
+			if !got.Equal(tc.want) {
+				t.Fatalf("deadline = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -224,13 +355,19 @@ func exchangePamDismiss(
 			helperDone <- fmt.Errorf("request type = %q, want %q", env.Type, ipc.TypePamDismissConsent)
 			return
 		}
-		if string(env.Payload) != `{}` {
-			helperDone <- fmt.Errorf("request payload = %s, want {}", env.Payload)
-			return
-		}
 		var request ipc.PamDismissConsentRequest
 		if err := json.Unmarshal(env.Payload, &request); err != nil {
 			helperDone <- fmt.Errorf("decode request: %w", err)
+			return
+		}
+		receivedAt := time.Now()
+		deadline := time.UnixMilli(request.DeadlineUnixMs)
+		if request.DeadlineUnixMs <= 0 {
+			helperDone <- fmt.Errorf("request deadline = %v, want positive deadline", deadline)
+			return
+		}
+		if deadline.After(receivedAt.Add(timeout)) {
+			helperDone <- fmt.Errorf("request deadline = %v, want no later than broker timeout", deadline)
 			return
 		}
 

--- a/agent/internal/sessionbroker/pam_dismiss_test.go
+++ b/agent/internal/sessionbroker/pam_dismiss_test.go
@@ -204,7 +204,7 @@ func TestDismissPamConsentTimesOut(t *testing.T) {
 
 func TestDismissPamConsentTransportFailureIsUncertain(t *testing.T) {
 	session, clientIPC := createPamDismissTestSession()
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 	if err := clientIPC.Close(); err != nil {
 		t.Fatalf("close helper connection: %v", err)
 	}

--- a/agent/internal/sessionbroker/pam_dismiss_test.go
+++ b/agent/internal/sessionbroker/pam_dismiss_test.go
@@ -1,0 +1,267 @@
+package sessionbroker
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+func TestDismissPamConsentReturnsCorrelatedHelperResult(t *testing.T) {
+	tests := []struct {
+		name string
+		want ipc.PamDismissConsentResult
+	}{
+		{
+			name: "success",
+			want: ipc.PamDismissConsentResult{Success: true, Reason: "dismissed"},
+		},
+		{
+			name: "helper reports non-success",
+			want: ipc.PamDismissConsentResult{
+				Success:       false,
+				Reason:        "not_found",
+				DetailMessage: "consent.exe was not running",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			session, clientIPC := createPamDismissTestSession()
+			defer session.Close()
+			defer clientIPC.Close()
+
+			got, err := exchangePamDismiss(
+				t,
+				session,
+				clientIPC,
+				"dismiss-1",
+				ipc.TypePamDismissConsentResult,
+				tc.want,
+				"",
+				2*time.Second,
+			)
+			if err != nil {
+				t.Fatalf("DismissPamConsent: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("DismissPamConsent result = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDismissPamConsentRequiresSystemPamSession(t *testing.T) {
+	tests := []struct {
+		name    string
+		role    string
+		scopes  []string
+		wantErr string
+	}{
+		{
+			name:    "user helper with PAM scope",
+			role:    ipc.HelperRoleUser,
+			scopes:  []string{ipc.ScopePam},
+			wantErr: "SYSTEM helper",
+		},
+		{
+			name:    "system helper without PAM scope",
+			role:    ipc.HelperRoleSystem,
+			scopes:  []string{"desktop"},
+			wantErr: ipc.ScopePam,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			session := &Session{HelperRole: tc.role, AllowedScopes: tc.scopes}
+			got, err := (&Broker{}).DismissPamConsent(session, "dismiss-rejected", time.Millisecond)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("DismissPamConsent error = %v, want substring %q", err, tc.wantErr)
+			}
+			if got != (ipc.PamDismissConsentResult{}) {
+				t.Fatalf("rejected result = %+v, want zero value", got)
+			}
+		})
+	}
+}
+
+func TestDismissPamConsentRejectsNilSession(t *testing.T) {
+	got, err := (&Broker{}).DismissPamConsent(nil, "dismiss-nil", time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "nil PAM helper session") {
+		t.Fatalf("DismissPamConsent error = %v, want nil-session error", err)
+	}
+	if got != (ipc.PamDismissConsentResult{}) {
+		t.Fatalf("nil-session result = %+v, want zero value", got)
+	}
+}
+
+func TestDismissPamConsentReturnsEnvelopeAndDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		response      any
+		envelopeError string
+		wantErr       string
+	}{
+		{
+			name:          "error envelope",
+			envelopeError: "helper access denied",
+			wantErr:       "helper access denied",
+		},
+		{
+			name:     "malformed result JSON",
+			response: map[string]any{"success": "yes", "reason": 42},
+			wantErr:  "decode PAM consent dismissal result",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			session, clientIPC := createPamDismissTestSession()
+			defer session.Close()
+			defer clientIPC.Close()
+
+			got, err := exchangePamDismiss(
+				t,
+				session,
+				clientIPC,
+				"dismiss-error",
+				ipc.TypePamDismissConsentResult,
+				tc.response,
+				tc.envelopeError,
+				2*time.Second,
+			)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("DismissPamConsent error = %v, want substring %q", err, tc.wantErr)
+			}
+			if got != (ipc.PamDismissConsentResult{}) {
+				t.Fatalf("error result = %+v, want zero value", got)
+			}
+		})
+	}
+}
+
+func TestDismissPamConsentRejectsWrongResponseType(t *testing.T) {
+	session, clientIPC := createPamDismissTestSession()
+	defer session.Close()
+	defer clientIPC.Close()
+
+	got, err := exchangePamDismiss(
+		t,
+		session,
+		clientIPC,
+		"dismiss-wrong-type",
+		ipc.TypePamDialogResult,
+		ipc.PamDismissConsentResult{Success: true, Reason: "dismissed"},
+		"",
+		50*time.Millisecond,
+	)
+	if !errors.Is(err, ErrCommandTimeout) {
+		t.Fatalf("DismissPamConsent error = %v, want ErrCommandTimeout", err)
+	}
+	if got != (ipc.PamDismissConsentResult{}) {
+		t.Fatalf("wrong-type result = %+v, want zero value", got)
+	}
+}
+
+func TestDismissPamConsentTimesOut(t *testing.T) {
+	session, clientIPC := createPamDismissTestSession()
+	defer session.Close()
+	defer clientIPC.Close()
+
+	got, err := exchangePamDismiss(
+		t,
+		session,
+		clientIPC,
+		"dismiss-timeout",
+		"",
+		nil,
+		"",
+		50*time.Millisecond,
+	)
+	if !errors.Is(err, ErrCommandTimeout) {
+		t.Fatalf("DismissPamConsent error = %v, want ErrCommandTimeout", err)
+	}
+	if got != (ipc.PamDismissConsentResult{}) {
+		t.Fatalf("timeout result = %+v, want zero value", got)
+	}
+}
+
+func exchangePamDismiss(
+	t *testing.T,
+	session *Session,
+	clientIPC *ipc.Conn,
+	id string,
+	responseType string,
+	response any,
+	envelopeError string,
+	timeout time.Duration,
+) (ipc.PamDismissConsentResult, error) {
+	t.Helper()
+
+	helperDone := make(chan error, 1)
+	go func() {
+		if err := clientIPC.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+			helperDone <- fmt.Errorf("set client read deadline: %w", err)
+			return
+		}
+		env, err := clientIPC.Recv()
+		if err != nil {
+			helperDone <- fmt.Errorf("client recv: %w", err)
+			return
+		}
+		if env.ID != id {
+			helperDone <- fmt.Errorf("request ID = %q, want %q", env.ID, id)
+			return
+		}
+		if env.Type != ipc.TypePamDismissConsent {
+			helperDone <- fmt.Errorf("request type = %q, want %q", env.Type, ipc.TypePamDismissConsent)
+			return
+		}
+		if string(env.Payload) != `{}` {
+			helperDone <- fmt.Errorf("request payload = %s, want {}", env.Payload)
+			return
+		}
+		var request ipc.PamDismissConsentRequest
+		if err := json.Unmarshal(env.Payload, &request); err != nil {
+			helperDone <- fmt.Errorf("decode request: %w", err)
+			return
+		}
+
+		if responseType == "" {
+			helperDone <- nil
+			return
+		}
+		if envelopeError != "" {
+			helperDone <- clientIPC.Send(&ipc.Envelope{
+				ID:    env.ID,
+				Type:  responseType,
+				Error: envelopeError,
+			})
+			return
+		}
+		helperDone <- clientIPC.SendTyped(env.ID, responseType, response)
+	}()
+	go session.RecvLoop(func(s *Session, env *ipc.Envelope) {})
+
+	got, err := (&Broker{}).DismissPamConsent(session, id, timeout)
+	if helperErr := <-helperDone; helperErr != nil {
+		t.Fatalf("helper exchange: %v", helperErr)
+	}
+	return got, err
+}
+
+func createPamDismissTestSession() (*Session, *ipc.Conn) {
+	serverConn, clientConn := net.Pipe()
+	serverIPC := ipc.NewConn(serverConn)
+	clientIPC := ipc.NewConn(clientConn)
+	session := NewSession(serverIPC, 1000, "1000", "testuser", "x11:0", "test-session-1", []string{ipc.ScopePam})
+	session.HelperRole = ipc.HelperRoleSystem
+	return session, clientIPC
+}

--- a/agent/internal/sessionbroker/pam_dismiss_test.go
+++ b/agent/internal/sessionbroker/pam_dismiss_test.go
@@ -34,8 +34,8 @@ func TestDismissPamConsentReturnsCorrelatedHelperResult(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			session, clientIPC := createPamDismissTestSession()
-			defer session.Close()
-			defer clientIPC.Close()
+			defer func() { _ = session.Close() }()
+			defer func() { _ = clientIPC.Close() }()
 
 			got, err := exchangePamDismiss(
 				t,
@@ -124,8 +124,8 @@ func TestDismissPamConsentReturnsEnvelopeAndDecodeErrors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			session, clientIPC := createPamDismissTestSession()
-			defer session.Close()
-			defer clientIPC.Close()
+			defer func() { _ = session.Close() }()
+			defer func() { _ = clientIPC.Close() }()
 
 			got, err := exchangePamDismiss(
 				t,
@@ -149,8 +149,8 @@ func TestDismissPamConsentReturnsEnvelopeAndDecodeErrors(t *testing.T) {
 
 func TestDismissPamConsentRejectsWrongResponseType(t *testing.T) {
 	session, clientIPC := createPamDismissTestSession()
-	defer session.Close()
-	defer clientIPC.Close()
+	defer func() { _ = session.Close() }()
+	defer func() { _ = clientIPC.Close() }()
 
 	got, err := exchangePamDismiss(
 		t,
@@ -181,8 +181,8 @@ func TestDismissPamConsentRejectsWrongResponseType(t *testing.T) {
 
 func TestDismissPamConsentTimesOut(t *testing.T) {
 	session, clientIPC := createPamDismissTestSession()
-	defer session.Close()
-	defer clientIPC.Close()
+	defer func() { _ = session.Close() }()
+	defer func() { _ = clientIPC.Close() }()
 
 	got, err := exchangePamDismiss(
 		t,
@@ -229,8 +229,8 @@ func TestDismissPamConsentTransportFailureIsUncertain(t *testing.T) {
 
 func TestDismissPamConsentTimeoutSignalsLateHelperQuiescence(t *testing.T) {
 	session, clientIPC := createPamDismissTestSession()
-	defer session.Close()
-	defer clientIPC.Close()
+	defer func() { _ = session.Close() }()
+	defer func() { _ = clientIPC.Close() }()
 
 	releaseResponse := make(chan struct{})
 	helperDone := make(chan error, 1)

--- a/agent/internal/sessionbroker/session.go
+++ b/agent/internal/sessionbroker/session.go
@@ -377,6 +377,8 @@ func expectedResponseType(cmdType string) string {
 		return ipc.TypeNotifyResult
 	case ipc.TypePamRequestDialog:
 		return ipc.TypePamDialogResult
+	case ipc.TypePamDismissConsent:
+		return ipc.TypePamDismissConsentResult
 	case ipc.TypeClipboardGet:
 		return ipc.TypeClipboardData
 	case ipc.TypeClipboardSet:

--- a/agent/internal/sessionbroker/session.go
+++ b/agent/internal/sessionbroker/session.go
@@ -152,6 +152,86 @@ func (s *Session) SendCommand(id, cmdType string, payload any, timeout time.Dura
 	}
 }
 
+// sendCommandWithQuiescence sends a command while retaining its response
+// registration after a timeout or transport error. The returned channel is
+// non-nil only when execution is uncertain and closes only after a valid,
+// correlated helper response proves the command has finished. A session close
+// does not prove a helper goroutine has stopped, so it deliberately leaves the
+// channel open.
+func (s *Session) sendCommandWithQuiescence(id, cmdType string, payload any, timeout time.Duration) (*ipc.Envelope, <-chan struct{}, error) {
+	ch := make(chan *ipc.Envelope, 1)
+	quiesced := make(chan struct{})
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, nil, fmt.Errorf("session closed")
+	}
+	if _, exists := s.pending[id]; exists {
+		s.mu.Unlock()
+		return nil, nil, fmt.Errorf("%w: %q (session %q)", ErrDuplicateCommand, id, s.SessionID)
+	}
+	s.pending[id] = pendingResponse{
+		ch:           ch,
+		expectedType: expectedResponseType(cmdType),
+		validate:     responseValidator(cmdType, payload),
+	}
+	done := s.done
+	s.mu.Unlock()
+
+	var finishOnce sync.Once
+	finish := func(proven bool) {
+		finishOnce.Do(func() {
+			s.mu.Lock()
+			if current, ok := s.pending[id]; ok && current.ch == ch {
+				delete(s.pending, id)
+			}
+			s.mu.Unlock()
+			if proven {
+				close(quiesced)
+			}
+		})
+	}
+	waitForLateResponse := func() {
+		go func() {
+			select {
+			case resp := <-ch:
+				finish(resp != nil)
+			case <-done:
+				// Prefer a response already delivered concurrently with teardown.
+				select {
+				case resp := <-ch:
+					finish(resp != nil)
+				default:
+					finish(false)
+				}
+			}
+		}()
+	}
+
+	if err := s.conn.SendTyped(id, cmdType, payload); err != nil {
+		waitForLateResponse()
+		return nil, quiesced, err
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case resp, ok := <-ch:
+		if !ok || resp == nil {
+			finish(false)
+			return nil, quiesced, fmt.Errorf("session closed while waiting for response")
+		}
+		finish(true)
+		return resp, nil, nil
+	case <-done:
+		finish(false)
+		return nil, quiesced, fmt.Errorf("session closed while waiting for response")
+	case <-timer.C:
+		waitForLateResponse()
+		return nil, quiesced, ErrCommandTimeout
+	}
+}
+
 // SendNotify sends a fire-and-forget message (no response expected).
 func (s *Session) SendNotify(id, msgType string, payload any) error {
 	return s.conn.SendTyped(id, msgType, payload)

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -2,6 +2,7 @@ package userhelper
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -25,6 +26,7 @@ import (
 	"github.com/breeze-rmm/agent/internal/helper"
 	"github.com/breeze-rmm/agent/internal/ipc"
 	"github.com/breeze-rmm/agent/internal/logging"
+	"github.com/breeze-rmm/agent/internal/pamactuator"
 	"github.com/breeze-rmm/agent/internal/procoutput"
 	"github.com/breeze-rmm/agent/internal/remote/clipboard"
 	"github.com/breeze-rmm/agent/internal/remote/desktop"
@@ -32,6 +34,8 @@ import (
 )
 
 var log = logging.L("userhelper")
+
+var newPamActuator = pamactuator.New
 
 const (
 	maxLaunchBinaryPathBytes = 4096
@@ -378,6 +382,9 @@ func (c *Client) commandLoop() error {
 
 		case ipc.TypePamRequestDialog:
 			safeGo("pam_dialog", func() { c.handlePamDialog(env) })
+
+		case ipc.TypePamDismissConsent:
+			safeGo("pam_dismiss_consent", func() { c.handlePamDismissConsent(env) })
 
 		case ipc.TypeConsentRequest:
 			safeGo("consent_request", func() { c.handleConsentRequest(env) })
@@ -928,6 +935,41 @@ func (c *Client) handlePamDialog(env *ipc.Envelope) {
 	result := showPamDialog(req)
 	if err := c.conn.SendTyped(env.ID, ipc.TypePamDialogResult, result); err != nil {
 		log.Warn("failed to send PAM dialog result", "id", env.ID, "error", err)
+	}
+}
+
+func (c *Client) handlePamDismissConsent(env *ipc.Envelope) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("PAM dismiss handler panicked", "id", env.ID, "panic", fmt.Sprintf("%v", r))
+			if err := c.conn.SendError(env.ID, ipc.TypePamDismissConsentResult, "PAM dismiss handler panicked"); err != nil {
+				log.Warn("failed to send PAM dismiss panic response", "id", env.ID, "error", err)
+			}
+		}
+	}()
+
+	if c.role != ipc.HelperRoleSystem || !c.hasScope(ipc.ScopePam) {
+		if err := c.conn.SendError(env.ID, ipc.TypePamDismissConsentResult, "pam_dismiss_consent requires SYSTEM helper with pam scope"); err != nil {
+			log.Warn("failed to send unauthorized PAM dismiss response", "id", env.ID, "error", err)
+		}
+		return
+	}
+
+	var req ipc.PamDismissConsentRequest
+	if err := json.Unmarshal(env.Payload, &req); err != nil {
+		if sendErr := c.conn.SendError(env.ID, ipc.TypePamDismissConsentResult, fmt.Sprintf("invalid payload: %v", err)); sendErr != nil {
+			log.Warn("failed to send PAM dismiss payload error", "id", env.ID, "error", sendErr)
+		}
+		return
+	}
+
+	result := newPamActuator().Dismiss(context.Background())
+	if err := c.conn.SendTyped(env.ID, ipc.TypePamDismissConsentResult, ipc.PamDismissConsentResult{
+		Success:       result.Success,
+		Reason:        result.Reason,
+		DetailMessage: result.DetailMessage,
+	}); err != nil {
+		log.Warn("failed to send PAM dismiss result", "id", env.ID, "error", err)
 	}
 }
 

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -962,8 +962,23 @@ func (c *Client) handlePamDismissConsent(env *ipc.Envelope) {
 		}
 		return
 	}
+	if req.DeadlineUnixMs <= 0 {
+		if err := c.conn.SendError(env.ID, ipc.TypePamDismissConsentResult, "invalid PAM dismiss deadline"); err != nil {
+			log.Warn("failed to send PAM dismiss deadline error", "id", env.ID, "error", err)
+		}
+		return
+	}
+	deadline := time.UnixMilli(req.DeadlineUnixMs)
+	if !deadline.After(time.Now()) {
+		if err := c.conn.SendError(env.ID, ipc.TypePamDismissConsentResult, "PAM dismiss deadline expired"); err != nil {
+			log.Warn("failed to send expired PAM dismiss response", "id", env.ID, "error", err)
+		}
+		return
+	}
 
-	result := newPamActuator().Dismiss(context.Background())
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+	result := newPamActuator().Dismiss(ctx)
 	if err := c.conn.SendTyped(env.ID, ipc.TypePamDismissConsentResult, ipc.PamDismissConsentResult{
 		Success:       result.Success,
 		Reason:        result.Reason,

--- a/agent/internal/userhelper/pam_dialog_desktop.go
+++ b/agent/internal/userhelper/pam_dialog_desktop.go
@@ -1,0 +1,88 @@
+package userhelper
+
+import "github.com/breeze-rmm/agent/internal/ipc"
+
+// pamDesktopOps isolates the per-thread desktop lifecycle from the Win32
+// syscalls so fallback, restore, and handle ownership can be tested on every
+// development platform.
+type pamDesktopOps interface {
+	LockOSThread()
+	UnlockOSThread()
+	CurrentThreadDesktop() (uintptr, error)
+	OpenInputDesktop() (uintptr, error)
+	DesktopName(handle uintptr) (string, error)
+	SetThreadDesktop(handle uintptr) error
+	CloseDesktop(handle uintptr) error
+}
+
+// showPamDialogOnInputDesktop temporarily attaches the calling OS thread to
+// the desktop currently receiving input, shows the dialog there, then restores
+// the original desktop. Discovery failures preserve the old behavior by
+// showing on the helper thread's current desktop.
+func showPamDialogOnInputDesktop(ops pamDesktopOps, show func(inputDesktopName string) ipc.PamDialogResult) ipc.PamDialogResult {
+	ops.LockOSThread()
+	shouldUnlock := true
+	defer func() {
+		if shouldUnlock {
+			ops.UnlockOSThread()
+		}
+	}()
+
+	originalDesktop, err := ops.CurrentThreadDesktop()
+	if err != nil || originalDesktop == 0 {
+		log.Warn("pam: current thread desktop unavailable; showing dialog on current desktop", "error", pamDesktopErrorString(err))
+		return show("")
+	}
+
+	inputDesktop, err := ops.OpenInputDesktop()
+	if err != nil || inputDesktop == 0 {
+		log.Warn("pam: active input desktop unavailable; showing dialog on current desktop", "error", pamDesktopErrorString(err))
+		return show("")
+	}
+
+	inputDesktopName, err := ops.DesktopName(inputDesktop)
+	if err != nil || inputDesktopName == "" {
+		log.Warn("pam: active input desktop name unavailable; showing dialog on current desktop", "error", pamDesktopErrorString(err))
+		closePamDesktop(ops, inputDesktop)
+		return show("")
+	}
+
+	if err := ops.SetThreadDesktop(inputDesktop); err != nil {
+		log.Warn("pam: failed to attach dialog thread to active input desktop; showing on current desktop",
+			"desktop", inputDesktopName, "error", err.Error())
+		closePamDesktop(ops, inputDesktop)
+		return show("")
+	}
+
+	// Register restoration only after the switch succeeds. It runs before the
+	// unlock defer above, including if MessageBoxW panics. The input handle is
+	// safe to close only after this thread is no longer attached to it.
+	defer func() {
+		if err := ops.SetThreadDesktop(originalDesktop); err != nil {
+			// Returning a Winlogon-bound thread to Go's scheduler could put an
+			// unrelated goroutine on the secure desktop. Leave the goroutine
+			// locked; safeGo's short-lived handler goroutine will exit and Go will
+			// retire its OS thread. The input handle dies with that thread/process.
+			shouldUnlock = false
+			log.Error("pam: failed to restore original thread desktop; retiring locked OS thread",
+				"desktop", inputDesktopName, "error", err.Error())
+			return
+		}
+		closePamDesktop(ops, inputDesktop)
+	}()
+
+	return show(inputDesktopName)
+}
+
+func closePamDesktop(ops pamDesktopOps, handle uintptr) {
+	if err := ops.CloseDesktop(handle); err != nil {
+		log.Warn("pam: failed to close input desktop handle", "error", err.Error())
+	}
+}
+
+func pamDesktopErrorString(err error) string {
+	if err == nil {
+		return "unknown error"
+	}
+	return err.Error()
+}

--- a/agent/internal/userhelper/pam_dialog_desktop.go
+++ b/agent/internal/userhelper/pam_dialog_desktop.go
@@ -62,9 +62,11 @@ func showPamDialogOnInputDesktop(ops pamDesktopOps, show func(inputDesktopName s
 			// Returning a Winlogon-bound thread to Go's scheduler could put an
 			// unrelated goroutine on the secure desktop. Leave the goroutine
 			// locked; safeGo's short-lived handler goroutine will exit and Go will
-			// retire its OS thread. The input handle dies with that thread/process.
+			// retire its OS thread. CloseDesktop cannot close a handle still used
+			// by this thread, so this exceptional path intentionally leaves the
+			// process-owned handle open until the helper restarts or exits.
 			shouldUnlock = false
-			log.Error("pam: failed to restore original thread desktop; retiring locked OS thread",
+			log.Error("pam: failed to restore original thread desktop; retiring locked OS thread and leaving input handle open",
 				"desktop", inputDesktopName, "error", err.Error())
 			return
 		}

--- a/agent/internal/userhelper/pam_dialog_desktop_test.go
+++ b/agent/internal/userhelper/pam_dialog_desktop_test.go
@@ -1,0 +1,128 @@
+package userhelper
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+func TestShowPamDialogOnInputDesktop(t *testing.T) {
+	errDesktop := errors.New("desktop operation failed")
+	tests := []struct {
+		name          string
+		configure     func(*fakePamDesktopOps)
+		wantCalls     []string
+		wantInputName string
+	}{
+		{
+			name:      "current desktop lookup failure falls back",
+			configure: func(ops *fakePamDesktopOps) { ops.currentErr = errDesktop },
+			wantCalls: []string{"lock", "current", "show", "unlock"},
+		},
+		{
+			name:      "input desktop open failure falls back",
+			configure: func(ops *fakePamDesktopOps) { ops.openErr = errDesktop },
+			wantCalls: []string{"lock", "current", "open", "show", "unlock"},
+		},
+		{
+			name:      "input desktop name failure closes handle and falls back",
+			configure: func(ops *fakePamDesktopOps) { ops.nameErr = errDesktop },
+			wantCalls: []string{"lock", "current", "open", "name:2", "close:2", "show", "unlock"},
+		},
+		{
+			name: "input desktop switch failure closes handle and falls back",
+			configure: func(ops *fakePamDesktopOps) {
+				ops.setErrors[2] = errDesktop
+			},
+			wantCalls: []string{"lock", "current", "open", "name:2", "set:2", "close:2", "show", "unlock"},
+		},
+		{
+			name:          "success restores original before closing and unlocking",
+			configure:     func(*fakePamDesktopOps) {},
+			wantCalls:     []string{"lock", "current", "open", "name:2", "set:2", "show", "set:1", "close:2", "unlock"},
+			wantInputName: "Winlogon",
+		},
+		{
+			name: "restore failure does not close or unlock attached thread",
+			configure: func(ops *fakePamDesktopOps) {
+				ops.setErrors[1] = errDesktop
+			},
+			wantCalls:     []string{"lock", "current", "open", "name:2", "set:2", "show", "set:1"},
+			wantInputName: "Winlogon",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ops := newFakePamDesktopOps()
+			tc.configure(ops)
+
+			got := showPamDialogOnInputDesktop(ops, func(inputDesktopName string) ipc.PamDialogResult {
+				ops.calls = append(ops.calls, "show")
+				if inputDesktopName != tc.wantInputName {
+					t.Errorf("input desktop name = %q, want %q", inputDesktopName, tc.wantInputName)
+				}
+				return ipc.PamDialogResult{Approved: true}
+			})
+
+			if !got.Approved || got.DismissedByUser {
+				t.Fatalf("dialog result = %+v, want approved", got)
+			}
+			if !reflect.DeepEqual(ops.calls, tc.wantCalls) {
+				t.Fatalf("calls = %v, want %v", ops.calls, tc.wantCalls)
+			}
+		})
+	}
+}
+
+type fakePamDesktopOps struct {
+	calls       []string
+	currentErr  error
+	openErr     error
+	nameErr     error
+	setErrors   map[uintptr]error
+	closeErrors map[uintptr]error
+}
+
+func newFakePamDesktopOps() *fakePamDesktopOps {
+	return &fakePamDesktopOps{
+		setErrors:   make(map[uintptr]error),
+		closeErrors: make(map[uintptr]error),
+	}
+}
+
+func (f *fakePamDesktopOps) LockOSThread() {
+	f.calls = append(f.calls, "lock")
+}
+
+func (f *fakePamDesktopOps) UnlockOSThread() {
+	f.calls = append(f.calls, "unlock")
+}
+
+func (f *fakePamDesktopOps) CurrentThreadDesktop() (uintptr, error) {
+	f.calls = append(f.calls, "current")
+	return 1, f.currentErr
+}
+
+func (f *fakePamDesktopOps) OpenInputDesktop() (uintptr, error) {
+	f.calls = append(f.calls, "open")
+	return 2, f.openErr
+}
+
+func (f *fakePamDesktopOps) DesktopName(handle uintptr) (string, error) {
+	f.calls = append(f.calls, fmt.Sprintf("name:%d", handle))
+	return "Winlogon", f.nameErr
+}
+
+func (f *fakePamDesktopOps) SetThreadDesktop(handle uintptr) error {
+	f.calls = append(f.calls, fmt.Sprintf("set:%d", handle))
+	return f.setErrors[handle]
+}
+
+func (f *fakePamDesktopOps) CloseDesktop(handle uintptr) error {
+	f.calls = append(f.calls, fmt.Sprintf("close:%d", handle))
+	return f.closeErrors[handle]
+}

--- a/agent/internal/userhelper/pam_dialog_desktop_test.go
+++ b/agent/internal/userhelper/pam_dialog_desktop_test.go
@@ -78,6 +78,28 @@ func TestShowPamDialogOnInputDesktop(t *testing.T) {
 	}
 }
 
+func TestShowPamDialogOnInputDesktopRestoresAfterDialogPanic(t *testing.T) {
+	ops := newFakePamDesktopOps()
+	const panicValue = "MessageBoxW panic"
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		showPamDialogOnInputDesktop(ops, func(string) ipc.PamDialogResult {
+			ops.calls = append(ops.calls, "show")
+			panic(panicValue)
+		})
+	}()
+
+	if recovered != panicValue {
+		t.Fatalf("recovered panic = %v, want %q", recovered, panicValue)
+	}
+	wantCalls := []string{"lock", "current", "open", "name:2", "set:2", "show", "set:1", "close:2", "unlock"}
+	if !reflect.DeepEqual(ops.calls, wantCalls) {
+		t.Fatalf("calls after panic = %v, want %v", ops.calls, wantCalls)
+	}
+}
+
 type fakePamDesktopOps struct {
 	calls       []string
 	currentErr  error

--- a/agent/internal/userhelper/pam_dialog_windows.go
+++ b/agent/internal/userhelper/pam_dialog_windows.go
@@ -4,6 +4,7 @@ package userhelper
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -11,8 +12,18 @@ import (
 	"github.com/breeze-rmm/agent/internal/ipc"
 )
 
-var pamDialogUser32 = syscall.NewLazyDLL("user32.dll")
-var procMessageBoxW = pamDialogUser32.NewProc("MessageBoxW")
+var (
+	pamDialogUser32   = syscall.NewLazyDLL("user32.dll")
+	pamDialogKernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+	procMessageBoxW                  = pamDialogUser32.NewProc("MessageBoxW")
+	procPamOpenInputDesktop          = pamDialogUser32.NewProc("OpenInputDesktop")
+	procPamGetThreadDesktop          = pamDialogUser32.NewProc("GetThreadDesktop")
+	procPamSetThreadDesktop          = pamDialogUser32.NewProc("SetThreadDesktop")
+	procPamCloseDesktop              = pamDialogUser32.NewProc("CloseDesktop")
+	procPamGetUserObjectInformationW = pamDialogUser32.NewProc("GetUserObjectInformationW")
+	procPamGetCurrentThreadID        = pamDialogKernel32.NewProc("GetCurrentThreadId")
+)
 
 const (
 	mbYesNo         = 0x00000004
@@ -22,9 +33,18 @@ const (
 	mbTopMost       = 0x00040000
 
 	idYes = 6
+
+	pamDesktopGenericAll = 0x10000000
+	pamUOIName           = 2
 )
 
 func showPamDialog(req ipc.PamRequestDialog) ipc.PamDialogResult {
+	return showPamDialogOnInputDesktop(windowsPamDesktopOps{}, func(_ string) ipc.PamDialogResult {
+		return showPamMessageBox(req)
+	})
+}
+
+func showPamMessageBox(req ipc.PamRequestDialog) ipc.PamDialogResult {
 	title := syscall.StringToUTF16Ptr("Breeze — Elevation Request")
 	body := syscall.StringToUTF16Ptr(buildPamDialogBody(req))
 	flags := uintptr(mbYesNo | mbIconWarning | mbTopMost | mbSystemModal | mbSetForeground)
@@ -34,6 +54,75 @@ func showPamDialog(req ipc.PamRequestDialog) ipc.PamDialogResult {
 		return ipc.PamDialogResult{Approved: true}
 	}
 	return ipc.PamDialogResult{Approved: false, DismissedByUser: true}
+}
+
+type windowsPamDesktopOps struct{}
+
+func (windowsPamDesktopOps) LockOSThread()   { runtime.LockOSThread() }
+func (windowsPamDesktopOps) UnlockOSThread() { runtime.UnlockOSThread() }
+
+func (windowsPamDesktopOps) CurrentThreadDesktop() (uintptr, error) {
+	threadID, _, _ := procPamGetCurrentThreadID.Call()
+	handle, _, callErr := procPamGetThreadDesktop.Call(threadID)
+	if handle == 0 {
+		return 0, fmt.Errorf("GetThreadDesktop: %w", callErr)
+	}
+	return handle, nil
+}
+
+func (windowsPamDesktopOps) OpenInputDesktop() (uintptr, error) {
+	handle, _, callErr := procPamOpenInputDesktop.Call(0, 0, uintptr(pamDesktopGenericAll))
+	if handle == 0 {
+		return 0, fmt.Errorf("OpenInputDesktop: %w", callErr)
+	}
+	return handle, nil
+}
+
+func (windowsPamDesktopOps) DesktopName(handle uintptr) (string, error) {
+	var buffer [128]uint16
+	var needed uint32
+	ret, _, callErr := procPamGetUserObjectInformationW.Call(
+		handle,
+		pamUOIName,
+		uintptr(unsafe.Pointer(&buffer[0])),
+		uintptr(len(buffer)*2),
+		uintptr(unsafe.Pointer(&needed)),
+	)
+	if ret == 0 {
+		return "", fmt.Errorf("GetUserObjectInformationW(UOI_NAME): %w", callErr)
+	}
+
+	length := int(needed / 2)
+	if length > len(buffer) {
+		length = len(buffer)
+	}
+	for i := 0; i < length; i++ {
+		if buffer[i] == 0 {
+			length = i
+			break
+		}
+	}
+	name := syscall.UTF16ToString(buffer[:length])
+	if name == "" {
+		return "", fmt.Errorf("GetUserObjectInformationW(UOI_NAME) returned an empty name")
+	}
+	return name, nil
+}
+
+func (windowsPamDesktopOps) SetThreadDesktop(handle uintptr) error {
+	ret, _, callErr := procPamSetThreadDesktop.Call(handle)
+	if ret == 0 {
+		return fmt.Errorf("SetThreadDesktop: %w", callErr)
+	}
+	return nil
+}
+
+func (windowsPamDesktopOps) CloseDesktop(handle uintptr) error {
+	ret, _, callErr := procPamCloseDesktop.Call(handle)
+	if ret == 0 {
+		return fmt.Errorf("CloseDesktop: %w", callErr)
+	}
+	return nil
 }
 
 func buildPamDialogBody(req ipc.PamRequestDialog) string {

--- a/agent/internal/userhelper/pam_dismiss_test.go
+++ b/agent/internal/userhelper/pam_dismiss_test.go
@@ -74,7 +74,9 @@ func callPamDismissHandler(t *testing.T, client *Client, peer *ipc.Conn, payload
 		close(done)
 	}()
 
-	peer.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if err := peer.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
 	env, err := peer.Recv()
 	if err != nil {
 		t.Fatalf("receive PAM dismiss response: %v", err)
@@ -304,7 +306,9 @@ func TestCommandLoopPamDismissConsentPanicReturnsError(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("send PAM dismiss request: %v", err)
 	}
-	peer.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if err := peer.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
 	env, err := peer.Recv()
 	if err != nil {
 		t.Fatalf("receive panic response: %v", err)

--- a/agent/internal/userhelper/pam_dismiss_test.go
+++ b/agent/internal/userhelper/pam_dismiss_test.go
@@ -1,0 +1,228 @@
+package userhelper
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/pamactuator"
+)
+
+type stubPamDismissActuator struct {
+	dismissResult pamactuator.Result
+	panicValue    any
+	dismissCalls  atomic.Int32
+}
+
+func (s *stubPamDismissActuator) Trigger(context.Context, pamactuator.Request) pamactuator.Result {
+	return pamactuator.Result{}
+}
+
+func (s *stubPamDismissActuator) Dismiss(context.Context) pamactuator.Result {
+	s.dismissCalls.Add(1)
+	if s.panicValue != nil {
+		panic(s.panicValue)
+	}
+	return s.dismissResult
+}
+
+func newPamDismissPipe(t *testing.T, role string, scopes ...string) (*Client, *ipc.Conn) {
+	t.Helper()
+
+	helperConn, peerConn := net.Pipe()
+	client := New("/unused", role)
+	client.scopes = scopes
+	client.conn = ipc.NewConn(helperConn)
+	peer := ipc.NewConn(peerConn)
+	t.Cleanup(func() {
+		_ = client.conn.Close()
+		_ = peer.Close()
+	})
+	return client, peer
+}
+
+func pamDismissPayload(t *testing.T) json.RawMessage {
+	t.Helper()
+	payload, err := json.Marshal(ipc.PamDismissConsentRequest{})
+	if err != nil {
+		t.Fatalf("marshal PAM dismiss request: %v", err)
+	}
+	return payload
+}
+
+func callPamDismissHandler(t *testing.T, client *Client, peer *ipc.Conn, payload json.RawMessage) *ipc.Envelope {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		client.handlePamDismissConsent(&ipc.Envelope{
+			ID:      "pam-dismiss-1",
+			Type:    ipc.TypePamDismissConsent,
+			Payload: payload,
+		})
+		close(done)
+	}()
+
+	peer.SetReadDeadline(time.Now().Add(2 * time.Second))
+	env, err := peer.Recv()
+	if err != nil {
+		t.Fatalf("receive PAM dismiss response: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("PAM dismiss handler did not return promptly")
+	}
+	return env
+}
+
+func swapPamDismissActuator(t *testing.T, actuator pamactuator.Actuator) {
+	t.Helper()
+	original := newPamActuator
+	newPamActuator = func() pamactuator.Actuator { return actuator }
+	t.Cleanup(func() { newPamActuator = original })
+}
+
+func assertPamDismissEnvelope(t *testing.T, env *ipc.Envelope) {
+	t.Helper()
+	if env.ID != "pam-dismiss-1" {
+		t.Fatalf("response id = %q, want pam-dismiss-1", env.ID)
+	}
+	if env.Type != ipc.TypePamDismissConsentResult {
+		t.Fatalf("response type = %q, want %q", env.Type, ipc.TypePamDismissConsentResult)
+	}
+}
+
+func TestHandlePamDismissConsentInvokesActuatorAndReplies(t *testing.T) {
+	actuator := &stubPamDismissActuator{dismissResult: pamactuator.Result{
+		Success:       true,
+		Reason:        "ok",
+		DetailMessage: "consent window dismissed",
+	}}
+	swapPamDismissActuator(t, actuator)
+	client, peer := newPamDismissPipe(t, ipc.HelperRoleSystem, ipc.ScopePam)
+
+	env := callPamDismissHandler(t, client, peer, pamDismissPayload(t))
+
+	assertPamDismissEnvelope(t, env)
+	if env.Error != "" {
+		t.Fatalf("unexpected response error: %q", env.Error)
+	}
+	if got := actuator.dismissCalls.Load(); got != 1 {
+		t.Fatalf("Dismiss calls = %d, want 1", got)
+	}
+	var result ipc.PamDismissConsentResult
+	if err := json.Unmarshal(env.Payload, &result); err != nil {
+		t.Fatalf("unmarshal PAM dismiss result: %v", err)
+	}
+	if !result.Success || result.Reason != "ok" || result.DetailMessage != "consent window dismissed" {
+		t.Fatalf("unexpected PAM dismiss result: %+v", result)
+	}
+}
+
+func TestHandlePamDismissConsentPreservesNonSuccessResult(t *testing.T) {
+	actuator := &stubPamDismissActuator{dismissResult: pamactuator.Result{
+		Success:       false,
+		Reason:        "send_input_failed",
+		DetailMessage: "SendInput returned zero",
+	}}
+	swapPamDismissActuator(t, actuator)
+	client, peer := newPamDismissPipe(t, ipc.HelperRoleSystem, ipc.ScopePam)
+
+	env := callPamDismissHandler(t, client, peer, pamDismissPayload(t))
+
+	assertPamDismissEnvelope(t, env)
+	var result ipc.PamDismissConsentResult
+	if err := json.Unmarshal(env.Payload, &result); err != nil {
+		t.Fatalf("unmarshal PAM dismiss result: %v", err)
+	}
+	if result.Success || result.Reason != "send_input_failed" || result.DetailMessage != "SendInput returned zero" {
+		t.Fatalf("unexpected PAM dismiss result: %+v", result)
+	}
+}
+
+func TestHandlePamDismissConsentRejectsUnauthorizedHelpers(t *testing.T) {
+	tests := []struct {
+		name   string
+		role   string
+		scopes []string
+	}{
+		{name: "wrong role", role: ipc.HelperRoleUser, scopes: []string{ipc.ScopePam}},
+		{name: "missing PAM scope", role: ipc.HelperRoleSystem, scopes: []string{"desktop"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actuator := &stubPamDismissActuator{}
+			swapPamDismissActuator(t, actuator)
+			client, peer := newPamDismissPipe(t, tt.role, tt.scopes...)
+
+			env := callPamDismissHandler(t, client, peer, pamDismissPayload(t))
+
+			assertPamDismissEnvelope(t, env)
+			if env.Error == "" {
+				t.Fatal("expected unauthorized helper error response")
+			}
+			if got := actuator.dismissCalls.Load(); got != 0 {
+				t.Fatalf("Dismiss calls = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestHandlePamDismissConsentRejectsInvalidPayload(t *testing.T) {
+	actuator := &stubPamDismissActuator{}
+	swapPamDismissActuator(t, actuator)
+	client, peer := newPamDismissPipe(t, ipc.HelperRoleSystem, ipc.ScopePam)
+
+	env := callPamDismissHandler(t, client, peer, json.RawMessage(`{"unexpected"`))
+
+	assertPamDismissEnvelope(t, env)
+	if !strings.Contains(env.Error, "invalid payload") {
+		t.Fatalf("response error = %q, want invalid payload error", env.Error)
+	}
+	if got := actuator.dismissCalls.Load(); got != 0 {
+		t.Fatalf("Dismiss calls = %d, want 0", got)
+	}
+}
+
+func TestCommandLoopPamDismissConsentPanicReturnsError(t *testing.T) {
+	actuator := &stubPamDismissActuator{panicValue: "simulated actuator panic"}
+	swapPamDismissActuator(t, actuator)
+	client, peer := newPamDismissPipe(t, ipc.HelperRoleSystem, ipc.ScopePam)
+	loopDone := make(chan error, 1)
+	go func() { loopDone <- client.commandLoop() }()
+
+	if err := peer.SendTyped("pam-dismiss-1", ipc.TypePamDismissConsent, ipc.PamDismissConsentRequest{}); err != nil {
+		t.Fatalf("send PAM dismiss request: %v", err)
+	}
+	peer.SetReadDeadline(time.Now().Add(2 * time.Second))
+	env, err := peer.Recv()
+	if err != nil {
+		t.Fatalf("receive panic response: %v", err)
+	}
+	assertPamDismissEnvelope(t, env)
+	if env.Error == "" {
+		t.Fatal("expected actuator panic error response")
+	}
+	if got := actuator.dismissCalls.Load(); got != 1 {
+		t.Fatalf("Dismiss calls = %d, want 1", got)
+	}
+
+	if err := peer.SendTyped("disconnect", ipc.TypeDisconnect, nil); err != nil {
+		t.Fatalf("send disconnect: %v", err)
+	}
+	select {
+	case err := <-loopDone:
+		if err != nil {
+			t.Fatalf("command loop returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("command loop did not return promptly")
+	}
+}

--- a/agent/internal/userhelper/pam_dismiss_test.go
+++ b/agent/internal/userhelper/pam_dismiss_test.go
@@ -15,6 +15,7 @@ import (
 
 type stubPamDismissActuator struct {
 	dismissResult pamactuator.Result
+	dismissFunc   func(context.Context) pamactuator.Result
 	panicValue    any
 	dismissCalls  atomic.Int32
 }
@@ -23,10 +24,13 @@ func (s *stubPamDismissActuator) Trigger(context.Context, pamactuator.Request) p
 	return pamactuator.Result{}
 }
 
-func (s *stubPamDismissActuator) Dismiss(context.Context) pamactuator.Result {
+func (s *stubPamDismissActuator) Dismiss(ctx context.Context) pamactuator.Result {
 	s.dismissCalls.Add(1)
 	if s.panicValue != nil {
 		panic(s.panicValue)
+	}
+	if s.dismissFunc != nil {
+		return s.dismissFunc(ctx)
 	}
 	return s.dismissResult
 }
@@ -48,7 +52,9 @@ func newPamDismissPipe(t *testing.T, role string, scopes ...string) (*Client, *i
 
 func pamDismissPayload(t *testing.T) json.RawMessage {
 	t.Helper()
-	payload, err := json.Marshal(ipc.PamDismissConsentRequest{})
+	payload, err := json.Marshal(ipc.PamDismissConsentRequest{
+		DeadlineUnixMs: time.Now().Add(2 * time.Second).UnixMilli(),
+	})
 	if err != nil {
 		t.Fatalf("marshal PAM dismiss request: %v", err)
 	}
@@ -191,6 +197,101 @@ func TestHandlePamDismissConsentRejectsInvalidPayload(t *testing.T) {
 	}
 }
 
+func TestHandlePamDismissConsentRejectsInvalidDeadline(t *testing.T) {
+	tests := []struct {
+		name    string
+		request ipc.PamDismissConsentRequest
+	}{
+		{name: "missing deadline", request: ipc.PamDismissConsentRequest{}},
+		{
+			name: "expired deadline",
+			request: ipc.PamDismissConsentRequest{
+				DeadlineUnixMs: time.Now().Add(-time.Second).UnixMilli(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actuator := &stubPamDismissActuator{}
+			swapPamDismissActuator(t, actuator)
+			client, peer := newPamDismissPipe(t, ipc.HelperRoleSystem, ipc.ScopePam)
+			payload, err := json.Marshal(tt.request)
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
+
+			env := callPamDismissHandler(t, client, peer, payload)
+
+			assertPamDismissEnvelope(t, env)
+			if !strings.Contains(env.Error, "deadline") {
+				t.Fatalf("response error = %q, want deadline error", env.Error)
+			}
+			if got := actuator.dismissCalls.Load(); got != 0 {
+				t.Fatalf("Dismiss calls = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestHandlePamDismissConsentPropagatesDeadlineCancellation(t *testing.T) {
+	type observedDeadline struct {
+		value time.Time
+		ok    bool
+	}
+
+	deadline := time.Now().Add(500 * time.Millisecond).Truncate(time.Millisecond)
+	deadlineSeen := make(chan observedDeadline, 1)
+	var inputAfterDeadline atomic.Bool
+	actuator := &stubPamDismissActuator{dismissFunc: func(ctx context.Context) pamactuator.Result {
+		got, ok := ctx.Deadline()
+		deadlineSeen <- observedDeadline{value: got, ok: ok}
+		select {
+		case <-ctx.Done():
+			return pamactuator.Result{
+				Success:       false,
+				Reason:        "dismiss_cancelled",
+				DetailMessage: ctx.Err().Error(),
+			}
+		case <-time.After(2 * time.Second):
+			inputAfterDeadline.Store(true)
+			return pamactuator.Result{Success: true, Reason: "dismissed"}
+		}
+	}}
+	swapPamDismissActuator(t, actuator)
+	client, peer := newPamDismissPipe(t, ipc.HelperRoleSystem, ipc.ScopePam)
+	payload, err := json.Marshal(ipc.PamDismissConsentRequest{DeadlineUnixMs: deadline.UnixMilli()})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	env := callPamDismissHandler(t, client, peer, payload)
+
+	assertPamDismissEnvelope(t, env)
+	var seen observedDeadline
+	select {
+	case seen = <-deadlineSeen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("actuator did not observe the request deadline")
+	}
+	if !seen.ok {
+		t.Fatal("actuator context had no deadline")
+	}
+	if delta := seen.value.Sub(deadline); delta < -time.Millisecond || delta > time.Millisecond {
+		t.Fatalf("actuator deadline = %v, want %v", seen.value, deadline)
+	}
+	if inputAfterDeadline.Load() {
+		t.Fatal("actuator continued to simulated input after the request deadline")
+	}
+	var result ipc.PamDismissConsentResult
+	if err := json.Unmarshal(env.Payload, &result); err != nil {
+		t.Fatalf("unmarshal PAM dismiss result: %v", err)
+	}
+	if result.Success || result.Reason != "dismiss_cancelled" {
+		t.Fatalf("unexpected PAM dismiss result: %+v", result)
+	}
+}
+
 func TestCommandLoopPamDismissConsentPanicReturnsError(t *testing.T) {
 	actuator := &stubPamDismissActuator{panicValue: "simulated actuator panic"}
 	swapPamDismissActuator(t, actuator)
@@ -198,7 +299,9 @@ func TestCommandLoopPamDismissConsentPanicReturnsError(t *testing.T) {
 	loopDone := make(chan error, 1)
 	go func() { loopDone <- client.commandLoop() }()
 
-	if err := peer.SendTyped("pam-dismiss-1", ipc.TypePamDismissConsent, ipc.PamDismissConsentRequest{}); err != nil {
+	if err := peer.SendTyped("pam-dismiss-1", ipc.TypePamDismissConsent, ipc.PamDismissConsentRequest{
+		DeadlineUnixMs: time.Now().Add(2 * time.Second).UnixMilli(),
+	}); err != nil {
 		t.Fatalf("send PAM dismiss request: %v", err)
 	}
 	peer.SetReadDeadline(time.Now().Add(2 * time.Second))

--- a/docs/superpowers/plans/2026-07-16-pam-task-1-requester-session-attribution.md
+++ b/docs/superpowers/plans/2026-07-16-pam-task-1-requester-session-attribution.md
@@ -114,9 +114,9 @@
 
   Update the table seam to record `targetWinSession`. Add/adjust cases proving:
 
-  - a non-zero `SubjectSessionID` is passed to `pamFindSession` as an unsigned base-10 string for approve, pending, and hard-deny paths;
+  - a valid non-zero `SubjectSessionID` other than `0xFFFFFFFF` is passed to `pamFindSession` as an unsigned base-10 string for approve, pending, and hard-deny paths;
   - the exact selected session is still reused by dialog and dismissal;
-  - a zero `SubjectSessionID` passes `""`, retaining console fallback for old/fake/non-Windows events;
+  - a zero or `0xFFFFFFFF` `SubjectSessionID` passes `""`, retaining console fallback for unresolved, old, fake, and non-Windows events;
   - when no helper exists in the exact target session, no dialog, dismissal, credential promotion, or input actuation occurs.
 
 - [ ] **Step 2: Verify RED**
@@ -132,7 +132,7 @@
 
 - [ ] **Step 3: Implement exact-session targeting**
 
-  Build `targetWinSession` as `""` for zero and `strconv.FormatUint(uint64(ev.SubjectSessionID), 10)` otherwise, then call:
+  Build `targetWinSession` as `""` for zero or `0xFFFFFFFF` and `strconv.FormatUint(uint64(ev.SubjectSessionID), 10)` otherwise, then call:
 
   ```go
   session := find(ipc.ScopePam, targetWinSession)

--- a/docs/superpowers/plans/2026-07-16-pam-task-1-requester-session-attribution.md
+++ b/docs/superpowers/plans/2026-07-16-pam-task-1-requester-session-attribution.md
@@ -1,0 +1,196 @@
+# PAM Requester Session Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Attribute each intercepted UAC request to the interactive Windows session that owns the live `consent.exe`, then route the PAM dialog and denial handling through that session's SYSTEM helper instead of always targeting the physical console.
+
+**Architecture:** The Windows ETW decoder enumerates recent trusted `consent.exe` processes, selects the newest one inside the existing 30-second dedupe window, resolves its process SessionId to the logged-on user, and stores both values on the local event. Pure candidate-selection and fallback logic lives in a platform-neutral file so it is race-testable off Windows; Win32 process and WTS calls remain in a Windows-only adapter. `RunPamFlow` passes the decimal resolved SessionId into the broker's existing exact-session PAM selection, while a zero SessionId preserves the existing console fallback.
+
+**Tech Stack:** Go, Win32 Toolhelp/process/WTS APIs via `golang.org/x/sys/windows`, Breeze session broker, Go `testing` with `-race`.
+
+## Global Constraints
+
+- Trust only the real `%SystemRoot%\\System32\\consent.exe` image path; a same-name process elsewhere must never influence attribution.
+- Only consider consent processes created within the existing 30-second ETW dedupe window; choose the newest qualifying process.
+- Session `0` and `0xFFFFFFFF` are not interactive requester sessions.
+- Resolve the user from the selected SessionId with `WTSQueryUserToken`; remove the global 60-second console-user cache because it crosses session identities.
+- Preserve console attribution as the last-resort fallback when no trusted recent consent process and session user can be resolved.
+- A request with no subject after consent-session and console fallback must be dropped with a debug log, never silently.
+- `SubjectSessionID` is local-only (`json:"-"`); the corrected `SubjectUsername` continues to be the server-visible attribution.
+- PAM helper selection must use the resolved SessionId exactly. The broker must retain its existing no-cross-session-fallback behavior for PAM.
+- Do not import the unmerged Path B token-launch subsystem (`pamactuator/session_resolve.go` / `tokenlaunch_windows.go`) from the sibling branch. This branch's scope is requester attribution and exact helper routing.
+- Do not add dependencies or alter the IPC protocol.
+
+---
+
+### Task 1: Resolve the requester from the live consent process
+
+**Files:**
+- Modify: `agent/internal/etwlua/etwlua.go`
+- Create: `agent/internal/etwlua/requester_session.go`
+- Create: `agent/internal/etwlua/requester_session_test.go`
+- Create: `agent/internal/etwlua/requester_session_windows.go`
+- Modify: `agent/internal/etwlua/etwlua_windows.go`
+
+**Interfaces:**
+- Produces: `Event.SubjectSessionID uint32` with `json:"-"`.
+- Produces: `consentProcessCandidate`, `selectNewestConsentProcess`, and `resolveRequesterSessionWith` as platform-neutral attribution logic.
+- Produces: `resolveRequesterSession() (username string, sessionID uint32, source string)` backed by trusted Toolhelp/WTS lookups on Windows.
+
+- [ ] **Step 1: Write failing platform-neutral resolver tests**
+
+  Add table-driven tests proving:
+
+  - the newest recent trusted System32 `consent.exe` wins and its SessionId resolves the user;
+  - matching is case-insensitive and accepts the Win32 `\\?\\` path prefix;
+  - a newer same-name process outside System32 is ignored;
+  - processes older than `dedupeWindow`, in Session 0, or with SessionId `0xFFFFFFFF` are ignored;
+  - an unresolved consent candidate falls back to the console session user;
+  - no consent candidate uses the console fallback;
+  - no consent user and no console user returns an empty resolution.
+
+  Also add an event JSON test that sets `SubjectSessionID` and asserts `subject_session_id` is absent from the marshaled payload.
+
+- [ ] **Step 2: Verify RED**
+
+  Run:
+
+  ```bash
+  cd agent
+  go test -race ./internal/etwlua
+  ```
+
+  Expected: compile failures because `SubjectSessionID`, `consentProcessCandidate`, `selectNewestConsentProcess`, and `resolveRequesterSessionWith` do not exist.
+
+- [ ] **Step 3: Implement the platform-neutral resolver**
+
+  Add the local-only event field:
+
+  ```go
+  SubjectSessionID uint32 `json:"-"`
+  ```
+
+  Define a candidate with `PID`, `SessionID`, `ImagePath`, and `StartedAt`. Normalize Windows paths by trimming whitespace, accepting an optional `\\?\\` prefix, converting `/` to `\\`, trimming trailing separators, and comparing case-insensitively. `selectNewestConsentProcess` must enforce the trusted image path, valid interactive SessionId, non-zero creation time, and `0 <= now-StartedAt <= dedupeWindow` before choosing the latest candidate (highest PID as a deterministic exact-time tie-break).
+
+  `resolveRequesterSessionWith` must resolve the selected candidate's SessionId to a user first, then try the console SessionId, returning source strings `consent_process`, `console_fallback`, or `unresolved`.
+
+- [ ] **Step 4: Implement the Windows adapter and ETW wiring**
+
+  In `requester_session_windows.go`:
+
+  - obtain the trusted path with `windows.GetSystemWindowsDirectory()` plus `System32\\consent.exe`;
+  - enumerate processes with `CreateToolhelp32Snapshot` / `Process32First` / `Process32Next`;
+  - shortlist `consent.exe` by basename, then open each with `PROCESS_QUERY_LIMITED_INFORMATION`;
+  - read the full image path with `QueryFullProcessImageName`, creation time with `GetProcessTimes`, and SessionId with `ProcessIdToSessionId`;
+  - resolve a session user with `WTSQueryUserToken`, `GetTokenUser`, and `LookupAccount`.
+
+  In `decodeConsentRequest`, call `resolveRequesterSession`, set both `SubjectUsername` and `SubjectSessionID`, and emit debug logs for an unparseable payload and for a final empty-subject drop. Remove `consentUserCache`, `resolveConsentUser`, and `lookupConsoleUser` so identities are never cached across sessions.
+
+- [ ] **Step 5: Verify GREEN and Windows compilation**
+
+  Run:
+
+  ```bash
+  cd agent
+  go test -race ./internal/etwlua
+  GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c -o /tmp/breeze-etwlua.test.exe ./internal/etwlua
+  ```
+
+  Expected: host race tests pass and the Windows test binary compiles.
+
+---
+
+### Task 2: Route PAM through the resolved requester session
+
+**Files:**
+- Modify: `agent/internal/heartbeat/pam_flow.go`
+- Modify: `agent/internal/heartbeat/pam_flow_test.go`
+
+**Interfaces:**
+- Consumes: `etwlua.Event.SubjectSessionID` from Task 1.
+- Preserves: `Heartbeat.pamFindSession(capability, targetWinSession string)` and broker exact-session selection.
+
+- [ ] **Step 1: Rewrite the PAM flow test before production code**
+
+  Update the table seam to record `targetWinSession`. Add/adjust cases proving:
+
+  - a non-zero `SubjectSessionID` is passed to `pamFindSession` as an unsigned base-10 string for approve, pending, and hard-deny paths;
+  - the exact selected session is still reused by dialog and dismissal;
+  - a zero `SubjectSessionID` passes `""`, retaining console fallback for old/fake/non-Windows events;
+  - when no helper exists in the exact target session, no dialog, dismissal, credential promotion, or input actuation occurs.
+
+- [ ] **Step 2: Verify RED**
+
+  Run:
+
+  ```bash
+  cd agent
+  go test -race ./internal/heartbeat
+  ```
+
+  Expected: assertion failure because `RunPamFlow` still passes an empty target for a non-zero requester session.
+
+- [ ] **Step 3: Implement exact-session targeting**
+
+  Build `targetWinSession` as `""` for zero and `strconv.FormatUint(uint64(ev.SubjectSessionID), 10)` otherwise, then call:
+
+  ```go
+  session := find(ipc.ScopePam, targetWinSession)
+  ```
+
+  Update comments and structured logs to distinguish requester-session targeting from console fallback. Do not change broker fallback rules or the task-2 same-session dialog/dismiss reuse.
+
+- [ ] **Step 4: Verify GREEN**
+
+  Run:
+
+  ```bash
+  cd agent
+  go test -race ./internal/heartbeat ./internal/sessionbroker
+  ```
+
+  Expected: both packages pass under the race detector.
+
+---
+
+### Task 3: Cross-package verification
+
+**Files:**
+- Test only; no production changes unless verification exposes a defect.
+
+- [ ] **Step 1: Run focused race tests**
+
+  ```bash
+  cd agent
+  go test -race ./internal/etwlua ./internal/heartbeat ./internal/sessionbroker ./internal/userhelper ./internal/pamactuator
+  ```
+
+- [ ] **Step 2: Run the full agent race suite**
+
+  ```bash
+  cd agent
+  go test -race ./...
+  ```
+
+- [ ] **Step 3: Cross-compile affected Windows packages**
+
+  ```bash
+  cd agent
+  GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c -o /tmp/breeze-etwlua.test.exe ./internal/etwlua
+  GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c -o /tmp/breeze-heartbeat.test.exe ./internal/heartbeat
+  GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c -o /tmp/breeze-sessionbroker.test.exe ./internal/sessionbroker
+  ```
+
+- [ ] **Step 4: Run formatting, vet, and diff checks**
+
+  ```bash
+  cd agent
+  gofmt -w internal/etwlua/etwlua.go internal/etwlua/etwlua_windows.go internal/etwlua/requester_session.go internal/etwlua/requester_session_windows.go internal/etwlua/requester_session_test.go internal/heartbeat/pam_flow.go internal/heartbeat/pam_flow_test.go
+  go vet ./internal/etwlua ./internal/heartbeat ./internal/sessionbroker
+  cd ..
+  git diff --check
+  ```
+
+- [ ] **Step 5: Complete independent review**
+
+  Review each implementation task for spec compliance and code quality, then review the complete branch against the Global Constraints. Fix every Critical or Important finding and rerun the covering tests.

--- a/docs/superpowers/plans/2026-07-16-pam-task-2-in-session-consent-dismiss.md
+++ b/docs/superpowers/plans/2026-07-16-pam-task-2-in-session-consent-dismiss.md
@@ -1,0 +1,228 @@
+# PAM In-Session Consent Dismissal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clear a denied UAC prompt from the interactive Windows session that owns it instead of attempting dismissal from the Session 0 agent service.
+
+**Architecture:** Add a typed `pam_dismiss_consent` IPC request/result on the existing authenticated SYSTEM-helper channel. The broker validates `HelperRoleSystem` plus `ScopePam`, the target-session helper calls `pamactuator.Dismiss`, and `RunPamFlow` reuses the exact helper session selected for the PAM dialog. The service keeps `pamActuateMu` locked across the synchronous IPC round trip so approve and deny input cannot overlap.
+
+**Tech Stack:** Go, Breeze agent IPC envelopes, Windows session-bound SYSTEM helper, `pamactuator`, Go `testing` with `-race`.
+
+## Global Constraints
+
+- Never fall back to `pamactuator.Dismiss` in the Session 0 service; it cannot reach the target session's input desktop.
+- PAM dismissal is authorized only for a helper with `HelperRoleSystem` and `ScopePam`.
+- Reuse the exact selected PAM helper session after a dialog result; hard policy denials resolve the console-bound PAM helper first.
+- Preserve fail-closed behavior: missing helper, transport failure, malformed response, or helper error must never actuate elevation.
+- Preserve result semantics: `no_consent_window` is benign/already closed; other non-success reasons warn that the prompt may remain live.
+- Keep `pamActuateMu` held until the helper finishes dismissal and replies.
+- Do not add dependencies or alter the IPC protocol version.
+
+---
+
+### Task 1: Typed IPC and broker round trip
+
+**Files:**
+- Modify: `agent/internal/ipc/message.go`
+- Modify: `agent/internal/ipc/message_test.go`
+- Modify: `agent/internal/sessionbroker/session.go`
+- Create: `agent/internal/sessionbroker/pam_dismiss_test.go`
+- Modify: `agent/internal/sessionbroker/broker.go`
+
+**Interfaces:**
+- Produces: `ipc.TypePamDismissConsent`, `ipc.TypePamDismissConsentResult`, `ipc.PamDismissConsentRequest`, and `ipc.PamDismissConsentResult`.
+- Produces: `(*sessionbroker.Broker).DismissPamConsent(session *Session, id string, timeout time.Duration) (ipc.PamDismissConsentResult, error)`.
+
+- [ ] **Step 1: Write failing IPC and broker tests**
+
+  Add exact constant and JSON round-trip assertions for:
+
+  ```go
+  const TypePamDismissConsent = "pam_dismiss_consent"
+  const TypePamDismissConsentResult = "pam_dismiss_consent_result"
+
+  type PamDismissConsentRequest struct{}
+  type PamDismissConsentResult struct {
+      Success       bool   `json:"success"`
+      Reason        string `json:"reason"`
+      DetailMessage string `json:"detailMessage,omitempty"`
+  }
+  ```
+
+  Add broker cases for a successful same-ID/type round trip, wrong helper role, missing PAM scope, error envelope, malformed result JSON, wrong response type, and timeout.
+
+- [ ] **Step 2: Verify RED**
+
+  Run:
+
+  ```bash
+  cd agent
+  go test -race ./internal/ipc ./internal/sessionbroker
+  ```
+
+  Expected: compile/test failure because the new IPC types and `DismissPamConsent` do not exist.
+
+- [ ] **Step 3: Implement the minimal IPC contract**
+
+  Add the types above. Extend `expectedResponseType` so `TypePamDismissConsent` requires `TypePamDismissConsentResult`.
+
+  Implement `DismissPamConsent` with the same SYSTEM-role/PAM-scope checks as `RequestPamApproval`, then:
+
+  ```go
+  resp, err := b.SendCommandAndWait(
+      session,
+      id,
+      ipc.TypePamDismissConsent,
+      ipc.PamDismissConsentRequest{},
+      timeout,
+  )
+  ```
+
+  Treat envelope errors and JSON failures as Go errors. Return a decoded non-success result without converting it to a transport error.
+
+- [ ] **Step 4: Verify GREEN**
+
+  Run the Task 1 command and require both packages to pass under `-race`.
+
+---
+
+### Task 2: Target-session SYSTEM-helper handler
+
+**Files:**
+- Modify: `agent/internal/userhelper/client.go`
+- Create: `agent/internal/userhelper/pam_dismiss_test.go`
+
+**Interfaces:**
+- Consumes: Task 1's typed request/result messages.
+- Produces: `(*Client).handlePamDismissConsent(env *ipc.Envelope)`.
+
+- [ ] **Step 1: Write failing handler tests**
+
+  Add an injectable package-level actuator factory defaulting to `pamactuator.New`. Test that:
+
+  - SYSTEM + PAM scope invokes `Dismiss` exactly once and replies with the same envelope ID and `TypePamDismissConsentResult`.
+  - A non-success actuator result preserves `Success`, `Reason`, and `DetailMessage`.
+  - Wrong role or missing scope sends an error response and never invokes the actuator.
+  - An actuator panic is contained by the existing `safeGo` boundary and returns promptly rather than crashing the helper.
+
+- [ ] **Step 2: Verify RED**
+
+  Run:
+
+  ```bash
+  cd agent
+  go test -race ./internal/userhelper
+  ```
+
+  Expected: compile/test failure because the handler and dispatch case do not exist.
+
+- [ ] **Step 3: Implement the minimal handler**
+
+  Add a `commandLoop` case for `ipc.TypePamDismissConsent`. The handler independently checks:
+
+  ```go
+  if c.role != ipc.HelperRoleSystem || !c.hasScope(ipc.ScopePam) {
+      // SendError with the request ID and TypePamDismissConsentResult.
+      return
+  }
+  ```
+
+  Call `pamactuator.New().Dismiss(context.Background())` through the test seam, copy its fields into `ipc.PamDismissConsentResult`, and send the typed response.
+
+- [ ] **Step 4: Verify GREEN**
+
+  Run the Task 2 command and require the package to pass under `-race`.
+
+---
+
+### Task 3: Route every PAM denial through the selected helper session
+
+**Files:**
+- Modify: `agent/internal/heartbeat/heartbeat.go`
+- Modify: `agent/internal/heartbeat/pam_flow.go`
+- Modify: `agent/internal/heartbeat/pam_flow_test.go`
+
+**Interfaces:**
+- Consumes: `(*Broker).DismissPamConsent` from Task 1.
+- Produces: a `pamDismissConsent` test seam matching the broker signature.
+
+- [ ] **Step 1: Rewrite denial tests before production code**
+
+  Replace service-local fake-actuator dismissal expectations with a broker-dismiss fake. Assert:
+
+  - hard policy deny resolves a PAM helper and sends dismissal to it without showing the dialog;
+  - user deny and dialog-round-trip error dismiss through the exact `*Session` used for the dialog;
+  - missing broker or matching helper makes no dismissal attempt and never invokes the Session 0 actuator;
+  - `no_consent_window`, real actuator failures, and IPC errors do not panic;
+  - `pamActuateMu` serializes `actuateElevation` against the full synchronous dismiss callback.
+
+- [ ] **Step 2: Verify RED**
+
+  Run:
+
+  ```bash
+  cd agent
+  go test -race ./internal/heartbeat
+  ```
+
+  Expected: compile/assertion failure because `RunPamFlow` still dismisses locally.
+
+- [ ] **Step 3: Implement same-session denial routing**
+
+  Add the injectable broker-dismiss field to `Heartbeat`. Resolve the PAM session before processing hard deny. Change `denyConsent` to accept the selected session, hold `pamActuateMu`, call the injectable function or `sessionBroker.DismissPamConsent`, and retain the existing log classification.
+
+  Use a broker timeout slightly above the actuator's internal eight-second ceiling:
+
+  ```go
+  const pamDismissTimeout = 10 * time.Second
+  ```
+
+  Remove the service-local `newActuator().Dismiss(ctx)` path entirely. Continue to use the service actuator for approved actuation only.
+
+- [ ] **Step 4: Verify GREEN**
+
+  Run the Task 3 command and require the package to pass under `-race`.
+
+---
+
+### Task 4: Cross-package verification
+
+**Files:**
+- Test only; no production changes unless verification exposes a defect.
+
+- [ ] **Step 1: Run focused race tests**
+
+  ```bash
+  cd agent
+  go test -race ./internal/ipc ./internal/sessionbroker ./internal/userhelper ./internal/heartbeat
+  ```
+
+- [ ] **Step 2: Run the full agent race suite**
+
+  ```bash
+  cd agent
+  go test -race ./...
+  ```
+
+- [ ] **Step 3: Cross-compile affected Windows packages**
+
+  ```bash
+  cd agent
+  GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c -o /tmp/breeze-userhelper.test.exe ./internal/userhelper
+  GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c -o /tmp/breeze-sessionbroker.test.exe ./internal/sessionbroker
+  GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c -o /tmp/breeze-heartbeat.test.exe ./internal/heartbeat
+  ```
+
+- [ ] **Step 4: Run formatting, vet, and diff checks**
+
+  ```bash
+  cd agent
+  gofmt -w internal/ipc/message.go internal/ipc/message_test.go internal/sessionbroker/session.go internal/sessionbroker/broker.go internal/sessionbroker/pam_dismiss_test.go internal/userhelper/client.go internal/userhelper/pam_dismiss_test.go internal/heartbeat/heartbeat.go internal/heartbeat/pam_flow.go internal/heartbeat/pam_flow_test.go
+  go vet ./internal/ipc ./internal/sessionbroker ./internal/userhelper ./internal/heartbeat
+  cd ..
+  git diff --check
+  ```
+
+- [ ] **Step 5: Request one independent code review**
+
+  Review the complete task diff against the Global Constraints, fix every Critical or Important finding, and rerun the covering tests for any fix.

--- a/docs/superpowers/plans/2026-07-16-pam-task-2-in-session-consent-dismiss.md
+++ b/docs/superpowers/plans/2026-07-16-pam-task-2-in-session-consent-dismiss.md
@@ -4,7 +4,7 @@
 
 **Goal:** Clear a denied UAC prompt from the interactive Windows session that owns it instead of attempting dismissal from the Session 0 agent service.
 
-**Architecture:** Add a typed `pam_dismiss_consent` IPC request/result on the existing authenticated SYSTEM-helper channel. The broker validates `HelperRoleSystem` plus `ScopePam`, the target-session helper calls `pamactuator.Dismiss`, and `RunPamFlow` reuses the exact helper session selected for the PAM dialog. The service keeps `pamActuateMu` locked across the synchronous IPC round trip so approve and deny input cannot overlap.
+**Architecture:** Add a typed `pam_dismiss_consent` IPC request/result on the existing authenticated SYSTEM-helper channel. The broker validates `HelperRoleSystem` plus `ScopePam`, sends an absolute input deadline that expires before its response timeout, and the target-session helper passes that deadline to `pamactuator.Dismiss`. `RunPamFlow` reuses the exact helper session selected for the PAM dialog. The service keeps `pamActuateMu` locked across the synchronous IPC round trip so approve and deny input cannot overlap. If the round trip becomes uncertain, the broker retains response correlation and the heartbeat remains fail-closed until the helper's late response proves dismissal is quiescent.
 
 **Tech Stack:** Go, Breeze agent IPC envelopes, Windows session-bound SYSTEM helper, `pamactuator`, Go `testing` with `-race`.
 
@@ -15,7 +15,8 @@
 - Reuse the exact selected PAM helper session after a dialog result; hard policy denials resolve the console-bound PAM helper first.
 - Preserve fail-closed behavior: missing helper, transport failure, malformed response, or helper error must never actuate elevation.
 - Preserve result semantics: `no_consent_window` is benign/already closed; other non-success reasons warn that the prompt may remain live.
-- Keep `pamActuateMu` held until the helper finishes dismissal and replies.
+- Keep `pamActuateMu` held for the synchronous helper round trip. If completion becomes uncertain, reject later PAM actuation and repeated dismissal without credential promotion or input until the authenticated late response proves quiescence.
+- Bound the target-session input window before the broker timeout: reserve response grace in the broker-generated absolute deadline, reject missing or expired deadlines in the helper, check cancellation immediately before sending Escape, and keep later input fail-closed until a late completion is proven.
 - Do not add dependencies or alter the IPC protocol version.
 
 ---
@@ -41,7 +42,9 @@
   const TypePamDismissConsent = "pam_dismiss_consent"
   const TypePamDismissConsentResult = "pam_dismiss_consent_result"
 
-  type PamDismissConsentRequest struct{}
+  type PamDismissConsentRequest struct {
+      DeadlineUnixMs int64 `json:"deadlineUnixMs"`
+  }
   type PamDismissConsentResult struct {
       Success       bool   `json:"success"`
       Reason        string `json:"reason"`
@@ -69,16 +72,15 @@
   Implement `DismissPamConsent` with the same SYSTEM-role/PAM-scope checks as `RequestPamApproval`, then:
 
   ```go
-  resp, err := b.SendCommandAndWait(
-      session,
+  resp, quiesced, err := session.sendCommandWithQuiescence(
       id,
       ipc.TypePamDismissConsent,
-      ipc.PamDismissConsentRequest{},
+      ipc.PamDismissConsentRequest{DeadlineUnixMs: deadline.UnixMilli()},
       timeout,
   )
   ```
 
-  Treat envelope errors and JSON failures as Go errors. Return a decoded non-success result without converting it to a transport error.
+  Treat envelope errors and JSON failures as Go errors. Return a decoded non-success result without converting it to a transport error. On a timeout or uncertain transport failure after dispatch, retain the pending response correlation and return a `PamDismissUncertainError` whose `Quiesced` channel closes only when the valid late helper response arrives.
 
 - [ ] **Step 4: Verify GREEN**
 
@@ -127,7 +129,7 @@
   }
   ```
 
-  Call `pamactuator.New().Dismiss(context.Background())` through the test seam, copy its fields into `ipc.PamDismissConsentResult`, and send the typed response.
+  Reject a missing or expired `DeadlineUnixMs`, derive a context with that absolute deadline, and call `pamactuator.New().Dismiss(ctx)` through the test seam. Copy its fields into `ipc.PamDismissConsentResult` and send the typed response. The Windows actuator checks cancellation immediately before sending Escape and reports the stable `dismiss_cancelled` reason when the deadline closes.
 
 - [ ] **Step 4: Verify GREEN**
 
@@ -154,7 +156,8 @@
   - user deny and dialog-round-trip error dismiss through the exact `*Session` used for the dialog;
   - missing broker or matching helper makes no dismissal attempt and never invokes the Session 0 actuator;
   - `no_consent_window`, real actuator failures, and IPC errors do not panic;
-  - `pamActuateMu` serializes `actuateElevation` against the full synchronous dismiss callback.
+  - `pamActuateMu` serializes `actuateElevation` against the full synchronous dismiss callback;
+  - uncertain dismissal completion rejects later actuation before credential promotion and skips overlapping dismissals until the helper's correlated response proves quiescence.
 
 - [ ] **Step 2: Verify RED**
 
@@ -169,7 +172,7 @@
 
 - [ ] **Step 3: Implement same-session denial routing**
 
-  Add the injectable broker-dismiss field to `Heartbeat`. Resolve the PAM session before processing hard deny. Change `denyConsent` to accept the selected session, hold `pamActuateMu`, call the injectable function or `sessionBroker.DismissPamConsent`, and retain the existing log classification.
+  Add the injectable broker-dismiss field to `Heartbeat`. Resolve the PAM session before processing hard deny. Change `denyConsent` to accept the selected session, hold `pamActuateMu`, call the injectable function or `sessionBroker.DismissPamConsent`, and retain the existing log classification. Track uncertain completion under the same mutex: later actuation returns `dismissal_uncertain` before promotion/input, repeated denials are skipped, and the state clears only after the helper's correlated response closes the quiescence channel.
 
   Use a broker timeout slightly above the actuator's internal eight-second ceiling:
 

--- a/docs/testing/FEATURE_TEST_LOG.md
+++ b/docs/testing/FEATURE_TEST_LOG.md
@@ -3687,3 +3687,29 @@ Refined the review-round C1 handling — missing *required* artifacts now fails 
 - A required-artifact failure therefore propagates as a collection error → the system_image job fails loud (no green unbootable snapshot).
 - Genuinely optional classes (certs, iis, firewall, …) still complete with a surfaced warning — an MSP doesn't lose an otherwise-good backup over a non-critical step.
 - Tests: `TestMissingRequired` (policy table); partial-warning test switched to optional classes (certs/iis); required-failure → hard-fail is covered by the collection-error consumption test.
+
+## PAM approval dialog on the secure desktop — 2026-07-16
+
+**Branch:** `ToddHebebrand/PAM-Testing-2`
+**Commit:** `3e9046839`
+**Tested by:** Codex
+**Result:** PARTIAL
+
+### What was tested
+
+- [x] Agent: SYSTEM-only PAM scope/selection, same-Windows-session fail-closed routing, dialog IPC authorization, input-desktop fallback, restore/cleanup ordering, restore failure, and panic cleanup under Go unit tests with `-race`.
+- [x] Agent: full `go test -race ./...` suite.
+- [x] Windows build: `internal/userhelper`, `internal/sessionbroker`, and `internal/heartbeat` test binaries cross-compiled for Windows amd64 with CGO disabled.
+- [ ] Native Windows: real UAC interaction with `PromptOnSecureDesktop=1` and `=0` was unavailable because this worktree has no configured E2E/dev-push credentials or Windows device ID.
+
+### Evidence
+
+- Focused `sessionbroker`, `userhelper`, and `heartbeat` race tests passed.
+- Full agent race suite passed after all review fixes.
+- Focused Go vet, Windows cross-compilation, and diff whitespace checks passed.
+- Independent task review and final whole-branch review found no unresolved Critical or Important issues.
+
+### Issues Found
+
+- No implementation defects remain from automated review and verification.
+- Before release, manually verify Approve, Deny, timeout, default-desktop fallback, and console/RDP coexistence on a native Windows test host.


### PR DESCRIPTION
## Summary

- render PAM consent UI and dismissal through the Windows helper in the selected interactive session
- attribute an elevation request to the newest recent trusted `%SystemRoot%\System32\consent.exe` process and carry its SessionId locally
- route approval, denial, dialog, and dismissal through the exact requester-session helper
- reject invalid session IDs and discard partial process-enumeration results so attribution fails closed
- retain the physical-console path only as the documented fallback when requester attribution is unavailable

## Root cause

PAM requester identity and helper selection were tied to `WTSGetActiveConsoleSessionId`. That works for a single console user but misattributes elevations raised from RDP or another concurrent Windows session. Consent UI could consequently be routed to the wrong session or silently miss the requester.

The agent now resolves the live trusted `consent.exe` instance, validates its image path and recency, obtains its SessionId and user token, and selects the corresponding PAM-capable helper. The resolved SessionId is agent-local and is not serialized upstream.

## Impact

Windows RDP and multi-session elevations are associated with the session that raised them. Dialog and dismissal use the same exact helper session, and a missing exact helper fails closed instead of falling across user sessions.

## Validation

- `go test -race -count=1 ./...`
- focused race tests for ETW/Lua attribution, heartbeat routing, session broker, helper, and PAM actuator
- Windows amd64 cross-compilation for ETW/Lua, heartbeat, and session broker packages
- `go vet ./internal/etwlua ./internal/heartbeat ./internal/sessionbroker`
- independent code review completed with no remaining findings

The Windows code path was cross-compiled; live concurrent RDP-session validation remains an environment-level follow-up.
