### PR TITLE
fix(auth): derive cookie Secure flag from real transport, not NODE_ENV (#1618)

### DIFF
--- a/apps/api/src/routes/auth/helpers.test.ts
+++ b/apps/api/src/routes/auth/helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { createHash } from 'crypto';
 import {
   getAllowedOrigins,
@@ -13,6 +13,7 @@ import {
   buildClearRefreshTokenCookie,
   setRefreshTokenCookie,
   clearRefreshTokenCookie,
+  _resetAuthCookieWarnStateForTests,
   type PendingMfaRecord,
 } from './helpers';
 import type { RequestLike } from '../../services/auditEvents';
@@ -306,15 +307,27 @@ describe('getClientRateLimitKey — spoof-proof per-IP key (SR2-16)', () => {
 });
 
 // Build a minimal Hono-ish Context for the auth-cookie helpers: a request with
-// header lookup + url, and a `header()` sink that records appended Set-Cookie
-// values so we can assert on the exact cookie strings emitted.
-function makeCookieContext(opts: { forwardedProto?: string; url?: string }): {
+// header lookup + url, a socket peer (X-Forwarded-Proto is only honored when
+// the TCP peer passes the TRUSTED_PROXY_CIDRS gate), and a `header()` sink
+// that records appended Set-Cookie values so we can assert on the exact cookie
+// strings emitted. Peer defaults to the stock compose Caddy IP; pass
+// `remoteAddress: null` to simulate a context with no socket info.
+const TRUSTED_PROXY_IP = '172.31.0.10';
+
+function makeCookieContext(opts: {
+  forwardedProto?: string;
+  url?: string;
+  host?: string;
+  remoteAddress?: string | null;
+}): {
   c: Context;
   setCookies: string[];
 } {
   const setCookies: string[] = [];
   const headers: Record<string, string> = {};
   if (opts.forwardedProto !== undefined) headers['x-forwarded-proto'] = opts.forwardedProto;
+  if (opts.host !== undefined) headers['host'] = opts.host;
+  const remoteAddress = opts.remoteAddress === null ? undefined : (opts.remoteAddress ?? TRUSTED_PROXY_IP);
   const c = {
     req: {
       header: (name: string) => headers[name.toLowerCase()],
@@ -323,8 +336,22 @@ function makeCookieContext(opts: { forwardedProto?: string; url?: string }): {
     header: (name: string, value: string) => {
       if (name.toLowerCase() === 'set-cookie') setCookies.push(value);
     },
+    ...(remoteAddress ? { env: { incoming: { socket: { remoteAddress } } } } : {}),
   } as unknown as Context;
   return { c, setCookies };
+}
+
+// The production-mode suites need the proxy-trust gate open (in production the
+// gate defaults CLOSED), mirroring the out-of-the-box compose config: Caddy's
+// static IP in TRUSTED_PROXY_CIDRS.
+function enableProxyTrust(): void {
+  process.env.TRUST_PROXY_HEADERS = 'true';
+  process.env.TRUSTED_PROXY_CIDRS = `${TRUSTED_PROXY_IP}/32`;
+}
+
+function disableProxyTrustEnv(): void {
+  delete process.env.TRUST_PROXY_HEADERS;
+  delete process.env.TRUSTED_PROXY_CIDRS;
 }
 
 describe('isRequestConnectionSecure (#1618 — Secure flag tracks real transport)', () => {
@@ -339,6 +366,13 @@ describe('isRequestConnectionSecure (#1618 — Secure flag tracks real transport
   it('uses the first (client-facing) hop of a proxy chain', () => {
     expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: 'https, http' }).c)).toBe(true);
     expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: 'http, https' }).c)).toBe(false);
+  });
+
+  it('normalizes header casing and whitespace (real proxies send mixed case)', () => {
+    expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: 'HTTPS' }).c)).toBe(true);
+    expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: 'Https' }).c)).toBe(true);
+    expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: ' https , http' }).c)).toBe(true);
+    expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: 'HTTP' }).c)).toBe(false);
   });
 
   it('treats an https:// request URL as a positive signal when no X-Forwarded-Proto is present (direct-to-API TLS)', () => {
@@ -360,13 +394,60 @@ describe('isRequestConnectionSecure (#1618 — Secure flag tracks real transport
       else process.env.NODE_ENV = originalNodeEnv;
     }
   });
+
+  it('a malformed request URL is just another ambiguous case — falls back to NODE_ENV', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    try {
+      process.env.NODE_ENV = 'production';
+      expect(isRequestConnectionSecure(makeCookieContext({ url: 'not a url' }).c)).toBe(true);
+    } finally {
+      if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+});
+
+describe('isRequestConnectionSecure — proxy-trust gate on X-Forwarded-Proto', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  beforeEach(() => {
+    process.env.NODE_ENV = 'production';
+    enableProxyTrust();
+  });
+  afterEach(() => {
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    disableProxyTrustEnv();
+  });
+
+  it('honors a downgrade (http) only from a trusted proxy peer', () => {
+    expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: 'http', remoteAddress: TRUSTED_PROXY_IP }).c)).toBe(false);
+  });
+
+  it('IGNORES X-Forwarded-Proto from an untrusted peer — an arbitrary client cannot strip Secure', () => {
+    const untrusted = makeCookieContext({ forwardedProto: 'http', remoteAddress: '203.0.113.9' });
+    // Header dropped -> ambiguous -> NODE_ENV=production default (Secure).
+    expect(isRequestConnectionSecure(untrusted.c)).toBe(true);
+  });
+
+  it('IGNORES X-Forwarded-Proto entirely when TRUST_PROXY_HEADERS is off', () => {
+    process.env.TRUST_PROXY_HEADERS = 'false';
+    expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: 'http', remoteAddress: TRUSTED_PROXY_IP }).c)).toBe(true);
+  });
+
+  it('a context with no socket info fails the gate closed in production', () => {
+    expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: 'http', remoteAddress: null }).c)).toBe(true);
+  });
 });
 
 describe('auth cookie Secure flag (#1618 regression)', () => {
   const originalNodeEnv = process.env.NODE_ENV;
+  beforeEach(() => {
+    enableProxyTrust();
+  });
   afterEach(() => {
     if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
     else process.env.NODE_ENV = originalNodeEnv;
+    disableProxyTrustEnv();
     delete process.env.AUTH_COOKIE_FORCE_SECURE;
     delete process.env.AUTH_COOKIE_SAME_SITE;
   });
@@ -402,6 +483,15 @@ describe('auth cookie Secure flag (#1618 regression)', () => {
     expect(setCookies[1]).toContain('; Secure');
   });
 
+  it('SameSite=None forces Secure regardless of transport (browsers reject SameSite=None without it)', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.AUTH_COOKIE_SAME_SITE = 'None';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    setRefreshTokenCookie(c, 'refresh.jwt.value');
+    expect(setCookies[0]).toContain('SameSite=None; Secure');
+    expect(setCookies[1]).toContain('SameSite=None; Secure');
+  });
+
   it('clear cookies mirror the set-cookie Secure flag for the same transport', () => {
     process.env.NODE_ENV = 'production';
     const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
@@ -412,12 +502,122 @@ describe('auth cookie Secure flag (#1618 regression)', () => {
     expect(setCookies[1]).not.toContain('Secure');
   });
 
-  it('build* functions default to the NODE_ENV heuristic when no transport is threaded', () => {
+  it('clear cookies carry Secure over an https transport', () => {
     process.env.NODE_ENV = 'production';
-    expect(buildRefreshTokenCookie('t')).toContain('; Secure');
-    expect(buildCsrfTokenCookie('t')).toContain('; Secure');
-    expect(buildClearRefreshTokenCookie()).toContain('; Secure');
-    // explicit transport wins over the default
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'https' });
+    clearRefreshTokenCookie(c);
+    expect(setCookies[0]).toContain('Max-Age=0');
+    expect(setCookies[0]).toContain('; Secure');
+    expect(setCookies[1]).toContain('; Secure');
+  });
+
+  it('build* functions require an explicit transport — no silent NODE_ENV fallback', () => {
+    process.env.NODE_ENV = 'production';
+    expect(buildRefreshTokenCookie('t', true)).toContain('; Secure');
     expect(buildRefreshTokenCookie('t', false)).not.toContain('Secure');
+    expect(buildCsrfTokenCookie('t', true)).toContain('; Secure');
+    expect(buildCsrfTokenCookie('t', false)).not.toContain('Secure');
+    expect(buildClearRefreshTokenCookie(true)).toContain('; Secure');
+    expect(buildClearRefreshTokenCookie(false)).not.toContain('Secure');
+  });
+});
+
+describe('auth cookie transport warnings (#1618 diagnostics)', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _resetAuthCookieWarnStateForTests();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    enableProxyTrust();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    warnSpy.mockRestore();
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    disableProxyTrustEnv();
+    delete process.env.AUTH_COOKIE_FORCE_SECURE;
+    delete process.env.AUTH_COOKIE_SAME_SITE;
+  });
+
+  function allWarnings(): string {
+    return warnSpy.mock.calls.map((call: unknown[]) => String(call[0])).join('\n');
+  }
+
+  it('warns (throttled) when production issues non-Secure cookies over HTTP, with host + observed proto', () => {
+    process.env.NODE_ENV = 'production';
+    setRefreshTokenCookie(makeCookieContext({ forwardedProto: 'http', host: 'rmm.example.com' }).c, 't');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(allWarnings()).toContain('NON-Secure auth cookies');
+    expect(allWarnings()).toContain('rmm.example.com');
+    expect(allWarnings()).toContain('"http"');
+    // The old text suggested AUTH_COOKIE_FORCE_SECURE as a remedy — that traps
+    // operators into silently broken logins; it must stay gone.
+    expect(allWarnings()).not.toContain('AUTH_COOKIE_FORCE_SECURE');
+
+    // Suppressed inside the throttle window…
+    setRefreshTokenCookie(makeCookieContext({ forwardedProto: 'http' }).c, 't');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    // …and fires again after it.
+    vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+    setRefreshTokenCookie(makeCookieContext({ forwardedProto: 'http' }).c, 't');
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('stays quiet for dev-over-http (the normal local flow)', () => {
+    process.env.NODE_ENV = 'development';
+    setRefreshTokenCookie(makeCookieContext({ forwardedProto: 'http' }).c, 't');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet for production-over-https', () => {
+    process.env.NODE_ENV = 'production';
+    setRefreshTokenCookie(makeCookieContext({ forwardedProto: 'https' }).c, 't');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns that login WILL break when AUTH_COOKIE_FORCE_SECURE forces Secure onto an http transport', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.AUTH_COOKIE_FORCE_SECURE = 'true';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    setRefreshTokenCookie(c, 't');
+    expect(setCookies[0]).toContain('; Secure'); // cookie really is forced Secure
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(allWarnings()).toContain('WILL silently discard');
+    expect(allWarnings()).toContain('AUTH_COOKIE_FORCE_SECURE');
+  });
+
+  it('warns with the SameSite=None cause when SameSite=None forces Secure onto an http transport', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.AUTH_COOKIE_SAME_SITE = 'None';
+    setRefreshTokenCookie(makeCookieContext({ forwardedProto: 'http' }).c, 't');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(allWarnings()).toContain('AUTH_COOKIE_SAME_SITE=None');
+    expect(allWarnings()).toContain('WILL silently discard');
+  });
+
+  it('breadcrumbs the blind NODE_ENV fallback in production when no X-Forwarded-Proto is present', () => {
+    process.env.NODE_ENV = 'production';
+    expect(isRequestConnectionSecure(makeCookieContext({}).c)).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(allWarnings()).toContain('Cannot determine');
+    expect(allWarnings()).toContain('no `X-Forwarded-Proto` header was present');
+  });
+
+  it('breadcrumbs an IGNORED X-Forwarded-Proto from an untrusted peer in production', () => {
+    process.env.NODE_ENV = 'production';
+    expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: 'http', remoteAddress: '203.0.113.9' }).c)).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(allWarnings()).toContain('IGNORED');
+    expect(allWarnings()).toContain('not a trusted proxy');
+  });
+
+  it('the ambiguous-fallback breadcrumb stays quiet outside production', () => {
+    process.env.NODE_ENV = 'development';
+    expect(isRequestConnectionSecure(makeCookieContext({}).c)).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/auth/helpers.test.ts
+++ b/apps/api/src/routes/auth/helpers.test.ts
@@ -7,9 +7,16 @@ import {
   parsePendingMfa,
   evaluatePendingMfa,
   getClientRateLimitKey,
+  isRequestConnectionSecure,
+  buildRefreshTokenCookie,
+  buildCsrfTokenCookie,
+  buildClearRefreshTokenCookie,
+  setRefreshTokenCookie,
+  clearRefreshTokenCookie,
   type PendingMfaRecord,
 } from './helpers';
 import type { RequestLike } from '../../services/auditEvents';
+import type { Context } from 'hono';
 
 // Mirrors the canonical shim in services/clientIp.test.ts.
 function makeContext(headers: Record<string, string | undefined>, remoteAddress?: string): RequestLike {
@@ -295,5 +302,122 @@ describe('getClientRateLimitKey — spoof-proof per-IP key (SR2-16)', () => {
     const key = getClientRateLimitKey(makeContext({ 'cf-connecting-ip': '203.0.113.5' }, '198.51.100.77'));
     expect(key).toBe('ip:203.0.113.5');
     delete process.env.TRUSTED_PROXY_CIDRS;
+  });
+});
+
+// Build a minimal Hono-ish Context for the auth-cookie helpers: a request with
+// header lookup + url, and a `header()` sink that records appended Set-Cookie
+// values so we can assert on the exact cookie strings emitted.
+function makeCookieContext(opts: { forwardedProto?: string; url?: string }): {
+  c: Context;
+  setCookies: string[];
+} {
+  const setCookies: string[] = [];
+  const headers: Record<string, string> = {};
+  if (opts.forwardedProto !== undefined) headers['x-forwarded-proto'] = opts.forwardedProto;
+  const c = {
+    req: {
+      header: (name: string) => headers[name.toLowerCase()],
+      url: opts.url ?? 'http://api:3001/api/v1/auth/refresh',
+    },
+    header: (name: string, value: string) => {
+      if (name.toLowerCase() === 'set-cookie') setCookies.push(value);
+    },
+  } as unknown as Context;
+  return { c, setCookies };
+}
+
+describe('isRequestConnectionSecure (#1618 — Secure flag tracks real transport)', () => {
+  it('true when X-Forwarded-Proto is https (Caddy behind TLS)', () => {
+    expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: 'https' }).c)).toBe(true);
+  });
+
+  it('false when X-Forwarded-Proto is http (browser reached the site over HTTP)', () => {
+    expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: 'http' }).c)).toBe(false);
+  });
+
+  it('uses the first (client-facing) hop of a proxy chain', () => {
+    expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: 'https, http' }).c)).toBe(true);
+    expect(isRequestConnectionSecure(makeCookieContext({ forwardedProto: 'http, https' }).c)).toBe(false);
+  });
+
+  it('treats an https:// request URL as a positive signal when no X-Forwarded-Proto is present (direct-to-API TLS)', () => {
+    expect(isRequestConnectionSecure(makeCookieContext({ url: 'https://api.example.com/x' }).c)).toBe(true);
+  });
+
+  it('does NOT downgrade on an ambiguous http:// internal hop with no X-Forwarded-Proto — falls back to NODE_ENV', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    try {
+      // In the standard topology c.req.url is the internal Caddy->API hop (http),
+      // which must not force non-Secure on a genuinely HTTPS deployment whose
+      // proxy stripped the header.
+      process.env.NODE_ENV = 'production';
+      expect(isRequestConnectionSecure(makeCookieContext({ url: 'http://api:3001/x' }).c)).toBe(true);
+      process.env.NODE_ENV = 'development';
+      expect(isRequestConnectionSecure(makeCookieContext({ url: 'http://api:3001/x' }).c)).toBe(false);
+    } finally {
+      if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+});
+
+describe('auth cookie Secure flag (#1618 regression)', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  afterEach(() => {
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    delete process.env.AUTH_COOKIE_FORCE_SECURE;
+    delete process.env.AUTH_COOKIE_SAME_SITE;
+  });
+
+  it('REGRESSION: production served over HTTP issues NON-Secure cookies so the browser keeps them', () => {
+    process.env.NODE_ENV = 'production';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    setRefreshTokenCookie(c, 'refresh.jwt.value');
+    expect(setCookies).toHaveLength(2);
+    const [refresh, csrf] = setCookies;
+    expect(refresh).toContain('breeze_refresh_token=');
+    expect(refresh).not.toContain('Secure');
+    expect(csrf).not.toContain('Secure');
+    // Attributes that must survive regardless of transport.
+    expect(refresh).toContain('HttpOnly');
+    expect(refresh).toContain('SameSite=Lax');
+  });
+
+  it('production served over HTTPS still issues Secure cookies', () => {
+    process.env.NODE_ENV = 'production';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'https' });
+    setRefreshTokenCookie(c, 'refresh.jwt.value');
+    expect(setCookies[0]).toContain('; Secure');
+    expect(setCookies[1]).toContain('; Secure');
+  });
+
+  it('AUTH_COOKIE_FORCE_SECURE overrides an http transport (paranoid setups)', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.AUTH_COOKIE_FORCE_SECURE = 'true';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    setRefreshTokenCookie(c, 'refresh.jwt.value');
+    expect(setCookies[0]).toContain('; Secure');
+    expect(setCookies[1]).toContain('; Secure');
+  });
+
+  it('clear cookies mirror the set-cookie Secure flag for the same transport', () => {
+    process.env.NODE_ENV = 'production';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    clearRefreshTokenCookie(c);
+    expect(setCookies).toHaveLength(2);
+    expect(setCookies[0]).toContain('Max-Age=0');
+    expect(setCookies[0]).not.toContain('Secure'); // an http clear must NOT be Secure or the browser ignores it
+    expect(setCookies[1]).not.toContain('Secure');
+  });
+
+  it('build* functions default to the NODE_ENV heuristic when no transport is threaded', () => {
+    process.env.NODE_ENV = 'production';
+    expect(buildRefreshTokenCookie('t')).toContain('; Secure');
+    expect(buildCsrfTokenCookie('t')).toContain('; Secure');
+    expect(buildClearRefreshTokenCookie()).toContain('; Secure');
+    // explicit transport wins over the default
+    expect(buildRefreshTokenCookie('t', false)).not.toContain('Secure');
   });
 });

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -12,7 +12,7 @@ import {
   verifyPassword,
   getUserEpochs
 } from '../../services';
-import { getImmediatePeerIpOrUndefined } from '../../services/clientIp';
+import { getImmediatePeerIpOrUndefined, trustsForwardedHeadersFrom } from '../../services/clientIp';
 import { createAuditLogAsync } from '../../services/auditService';
 import { recordFailedLogin } from '../../services/anomalyMetrics';
 import { consumeMFAToken } from '../../services/mfa';
@@ -322,28 +322,45 @@ export function isSecureCookieEnvironment(): boolean {
  * #1618: the auth cookies' `Secure` flag MUST track the real transport, not
  * `NODE_ENV`. A production deploy the browser reaches over plain HTTP — ACME
  * failed (port 80 blocked / DNS not pointed), the site is opened via `http://`,
- * or a TLS-terminating front proxy forwards HTTP to Caddy — would otherwise
- * stamp `Secure` on the refresh cookie, which the browser then *silently
- * discards*. Login still "succeeds" (the access token rides back in the JSON
- * body and lives in memory), but every reload 401s because the refresh cookie
- * was never stored. That is exactly the "persistent login" failure reporters
- * hit, with no diagnostic anywhere.
+ * or the browser's path to us has a plain-HTTP hop end-to-end (TLS-stripping
+ * proxy) — would otherwise stamp `Secure` on the refresh cookie, which the
+ * browser then *silently discards*. Login still "succeeds" (the access token
+ * rides back in the JSON body and lives in memory), but every reload 401s
+ * because the refresh cookie was never stored. That is exactly the "persistent
+ * login" failure reporters hit, with no diagnostic anywhere.
  *
- * Resolution order: the reverse proxy's `X-Forwarded-Proto` (Caddy always sets
- * it to the true client-hop scheme) → an `https://` request URL as a positive
- * signal (direct-to-API TLS, no proxy) → `NODE_ENV` as the safe default.
- * Trusting `X-Forwarded-Proto` is safe here: Caddy overwrites any client-supplied
- * value, and a spoofed `https` only makes cookies *more* restrictive.
+ * Resolution order:
+ * 1. `X-Forwarded-Proto` (first, client-facing hop) — but only when the
+ *    immediate TCP peer passes the same TRUST_PROXY_HEADERS /
+ *    TRUSTED_PROXY_CIDRS gate as forwarded-ip headers (`clientIp.ts`).
+ *    Without the gate, any client that can reach the API around the proxy
+ *    could send `X-Forwarded-Proto: http` over genuine TLS and strip `Secure`
+ *    from its own cookies. The stock compose topology trusts Caddy's static
+ *    IP out of the box (locked by `config/proxyTrustCompose.test.ts`). Note
+ *    Caddy REPLACES `X-Forwarded-*` from untrusted clients but PASSES THROUGH
+ *    values from `CADDY_TRUSTED_PROXIES`: in the hosted Cloudflare-Tunnel
+ *    topology the `https` the API sees originates at the Cloudflare edge and
+ *    is passed through by Caddy, whose own inbound hop (cloudflared → Caddy)
+ *    is plain HTTP — the fix *relies* on that passthrough.
+ * 2. An `https://` request URL as a positive-only signal (direct-to-API TLS,
+ *    no proxy in front).
+ * 3. `NODE_ENV` as the safe default, with a throttled production breadcrumb
+ *    (`warnAmbiguousCookieTransport`) because this branch is genuinely blind:
+ *    a proxy that never sends `X-Forwarded-Proto` (or isn't in
+ *    TRUSTED_PROXY_CIDRS) with a browser on plain HTTP lands here and still
+ *    gets `Secure` — the pre-fix #1618 behavior — so we leave a grep-able
+ *    trail instead of failing silently.
  *
- * Note the URL scheme is only ever a POSITIVE signal: in the standard topology
- * `c.req.url` is the internal Caddy→API hop (`http://api:3001/...`), which does
- * NOT reflect the browser's transport. So an `http` URL with no `X-Forwarded-Proto`
- * is ambiguous — we fall back to `NODE_ENV` rather than downgrading a genuinely
- * HTTPS deployment whose proxy happens to strip the header to non-Secure cookies.
+ * The URL scheme is only ever a POSITIVE signal: in the standard topology the
+ * request URL's *scheme* reflects the internal plain-HTTP Caddy→API hop
+ * (`http://<original-host>/...` — Caddy preserves the Host header), which does
+ * NOT reflect the browser's transport. So an `http` URL with no trusted
+ * `X-Forwarded-Proto` is ambiguous — we fall back to `NODE_ENV` rather than
+ * downgrading a genuinely HTTPS deployment whose proxy strips the header.
  */
 export function isRequestConnectionSecure(c: Context): boolean {
   const forwardedProto = c.req.header('x-forwarded-proto');
-  if (forwardedProto) {
+  if (forwardedProto && trustsForwardedHeadersFrom(c)) {
     // A proxy chain may append hops ("https, http"); the first is client-facing.
     return forwardedProto.split(',')[0]?.trim().toLowerCase() === 'https';
   }
@@ -352,8 +369,9 @@ export function isRequestConnectionSecure(c: Context): boolean {
       return true;
     }
   } catch {
-    // Malformed URL — fall through to the NODE_ENV default.
+    // Malformed URL — no positive signal; same ambiguous fall-through below.
   }
+  warnAmbiguousCookieTransport(c, forwardedProto);
   return isSecureCookieEnvironment();
 }
 
@@ -391,57 +409,119 @@ function buildCookieSecuritySuffix(sameSite: SameSiteValue, connectionSecure: bo
   return `; SameSite=${sameSite}${secure}`;
 }
 
-// The build* functions default `connectionSecure` to the NODE_ENV heuristic so
-// any caller without a request context keeps the historical behaviour; the
-// set/clear entry points below always pass the request-derived value.
-export function buildRefreshTokenCookie(refreshToken: string, connectionSecure = isSecureCookieEnvironment()): string {
+// `connectionSecure` is required on every build* function so no caller can
+// silently fall back to the pre-#1618 NODE_ENV heuristic — derive it from the
+// request via isRequestConnectionSecure(c), or use the set/clear entry points
+// below, which also emit the misconfiguration warnings.
+export function buildRefreshTokenCookie(refreshToken: string, connectionSecure: boolean): string {
   const sameSite = resolveAuthCookieSameSite();
   return `${REFRESH_COOKIE_NAME}=${encodeURIComponent(refreshToken)}; Path=${REFRESH_COOKIE_PATH}; HttpOnly${buildCookieSecuritySuffix(sameSite, connectionSecure)}; Max-Age=${REFRESH_COOKIE_MAX_AGE_SECONDS}`;
 }
 
-export function buildCsrfTokenCookie(csrfToken: string, connectionSecure = isSecureCookieEnvironment()): string {
+export function buildCsrfTokenCookie(csrfToken: string, connectionSecure: boolean): string {
   const sameSite = resolveAuthCookieSameSite();
   return `${CSRF_COOKIE_NAME}=${encodeURIComponent(csrfToken)}; Path=${CSRF_COOKIE_PATH}${buildCookieSecuritySuffix(sameSite, connectionSecure)}; Max-Age=${REFRESH_COOKIE_MAX_AGE_SECONDS}`;
 }
 
-export function buildClearRefreshTokenCookie(connectionSecure = isSecureCookieEnvironment()): string {
+export function buildClearRefreshTokenCookie(connectionSecure: boolean): string {
   const sameSite = resolveAuthCookieSameSite();
   return `${REFRESH_COOKIE_NAME}=; Path=${REFRESH_COOKIE_PATH}; HttpOnly${buildCookieSecuritySuffix(sameSite, connectionSecure)}; Max-Age=0`;
 }
 
-export function buildClearCsrfTokenCookie(connectionSecure = isSecureCookieEnvironment()): string {
+export function buildClearCsrfTokenCookie(connectionSecure: boolean): string {
   const sameSite = resolveAuthCookieSameSite();
   return `${CSRF_COOKIE_NAME}=; Path=${CSRF_COOKIE_PATH}${buildCookieSecuritySuffix(sameSite, connectionSecure)}; Max-Age=0`;
 }
 
-// Throttled warning so a busy HTTP-served deployment logs the misconfiguration
-// periodically without flooding. Module-scoped; resets on process restart.
-let lastInsecureCookieWarnAt = 0;
-const INSECURE_COOKIE_WARN_INTERVAL_MS = 10 * 60 * 1000;
+// Throttled warnings so a busy misconfigured deployment logs periodically
+// without flooding. Keyed per warning kind (a small fixed set — never by
+// host/peer) so one misconfiguration class can't suppress reports of another.
+// Module-scoped; resets on process restart.
+const AUTH_COOKIE_WARN_INTERVAL_MS = 10 * 60 * 1000;
+const authCookieLastWarnAt = new Map<string, number>();
 
-function warnIfInsecureAuthCookie(connectionSecure: boolean): void {
-  // Only actionable when we believe we're deployed (production) yet the browser
-  // reached us over HTTP. Dev-over-http is the normal local flow — stay quiet.
-  if (connectionSecure || !isSecureCookieEnvironment() || forceSecureCookie()) {
-    return;
-  }
+function warnAuthCookieThrottled(kind: string, message: string): void {
   const now = Date.now();
-  if (now - lastInsecureCookieWarnAt < INSECURE_COOKIE_WARN_INTERVAL_MS) {
+  const last = authCookieLastWarnAt.get(kind);
+  if (last !== undefined && now - last < AUTH_COOKIE_WARN_INTERVAL_MS) {
     return;
   }
-  lastInsecureCookieWarnAt = now;
-  console.warn(
-    '[auth] Issuing NON-Secure auth cookies: this production request did not arrive over HTTPS ' +
-    '(no `X-Forwarded-Proto: https`). Persistent login will work over HTTP, but the connection is ' +
-    'not encrypted. If Breeze should be served over HTTPS, fix TLS / your reverse proxy so the ' +
-    'browser reaches it over https and Caddy forwards `X-Forwarded-Proto=https` (see issue #1618). ' +
-    'To force `Secure` regardless, set AUTH_COOKIE_FORCE_SECURE=true.'
+  authCookieLastWarnAt.set(kind, now);
+  console.warn(message);
+}
+
+export function _resetAuthCookieWarnStateForTests(): void {
+  authCookieLastWarnAt.clear();
+}
+
+function describeCookieTransport(c: Context): string {
+  const host = c.req.header('host') ?? 'unknown-host';
+  const observedProto = c.req.header('x-forwarded-proto');
+  return `host "${host}", X-Forwarded-Proto ${observedProto ? `"${observedProto}"` : 'absent'}`;
+}
+
+// Production breadcrumb for the blind NODE_ENV fallback in
+// isRequestConnectionSecure: nothing told us the browser's transport, we are
+// about to assume HTTPS, and if that assumption is wrong the browser discards
+// the Secure cookie with no other diagnostic anywhere (the original #1618).
+function warnAmbiguousCookieTransport(c: Context, forwardedProto: string | undefined): void {
+  if (!isSecureCookieEnvironment()) {
+    return;
+  }
+  const cause = forwardedProto
+    ? `\`X-Forwarded-Proto: ${forwardedProto}\` was IGNORED because the TCP peer is not a trusted proxy (TRUST_PROXY_HEADERS / TRUSTED_PROXY_CIDRS)`
+    : 'no `X-Forwarded-Proto` header was present';
+  warnAuthCookieThrottled(
+    'ambiguous-transport',
+    `[auth] Cannot determine the browser's transport for auth cookies (${describeCookieTransport(c)}): ${cause}, ` +
+    'and the request URL is not https. Assuming HTTPS because NODE_ENV=production, so cookies get `Secure`. ' +
+    'If users cannot stay logged in (issue #1618), the browser is likely reaching Breeze over plain HTTP: ' +
+    'make your reverse proxy forward `X-Forwarded-Proto` and list its IP in TRUSTED_PROXY_CIDRS.'
+  );
+}
+
+// Keyed off the ACTUAL Secure decision, not just the transport: `Secure` can be
+// forced onto an insecure transport (AUTH_COOKIE_FORCE_SECURE / SameSite=None),
+// and that case breaks login outright — the warning must say so, not claim the
+// cookies are non-Secure.
+function warnOnAuthCookieTransportMismatch(c: Context, sameSite: SameSiteValue, connectionSecure: boolean, secure: boolean): void {
+  if (connectionSecure) {
+    return;
+  }
+  if (secure) {
+    // Explicit config forces `Secure` onto a transport the browser will reject
+    // it on. Only reachable via deliberate configuration, so warn in every
+    // environment — this is the #1618 symptom by operator choice.
+    const cause = sameSite === 'None'
+      ? 'AUTH_COOKIE_SAME_SITE=None requires the Secure attribute'
+      : 'AUTH_COOKIE_FORCE_SECURE is set';
+    warnAuthCookieThrottled(
+      'forced-secure-over-http',
+      `[auth] Issuing \`Secure\` auth cookies over a NON-HTTPS request (${describeCookieTransport(c)}) because ${cause}. ` +
+      'The browser WILL silently discard them and persistent login WILL break (issue #1618). Fix TLS so the ' +
+      'browser reaches Breeze over https, or remove that configuration.'
+    );
+    return;
+  }
+  // Non-Secure cookies over HTTP: login works, but credentials transit
+  // unencrypted. Dev-over-http is the normal local flow — only warn when
+  // deployed (production).
+  if (!isSecureCookieEnvironment()) {
+    return;
+  }
+  warnAuthCookieThrottled(
+    'insecure-transport',
+    `[auth] Issuing NON-Secure auth cookies: this production request arrived over HTTP (${describeCookieTransport(c)}). ` +
+    'Persistent login will work, but the connection is not encrypted. If Breeze should be served over HTTPS, ' +
+    'fix TLS / your reverse proxy so the browser reaches it over https and the proxy forwards ' +
+    '`X-Forwarded-Proto: https` (see issue #1618).'
   );
 }
 
 export function setRefreshTokenCookie(c: Context, refreshToken: string): void {
   const connectionSecure = isRequestConnectionSecure(c);
-  warnIfInsecureAuthCookie(connectionSecure);
+  const sameSite = resolveAuthCookieSameSite();
+  warnOnAuthCookieTransportMismatch(c, sameSite, connectionSecure, shouldSetSecureCookie(sameSite, connectionSecure));
   const csrfToken = randomBytes(32).toString('hex');
   c.header('Set-Cookie', buildRefreshTokenCookie(refreshToken, connectionSecure), { append: true });
   c.header('Set-Cookie', buildCsrfTokenCookie(csrfToken, connectionSecure), { append: true });

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -316,6 +316,47 @@ export function isSecureCookieEnvironment(): boolean {
   return process.env.NODE_ENV === 'production';
 }
 
+/**
+ * Whether the browser's connection to us actually arrived over HTTPS.
+ *
+ * #1618: the auth cookies' `Secure` flag MUST track the real transport, not
+ * `NODE_ENV`. A production deploy the browser reaches over plain HTTP — ACME
+ * failed (port 80 blocked / DNS not pointed), the site is opened via `http://`,
+ * or a TLS-terminating front proxy forwards HTTP to Caddy — would otherwise
+ * stamp `Secure` on the refresh cookie, which the browser then *silently
+ * discards*. Login still "succeeds" (the access token rides back in the JSON
+ * body and lives in memory), but every reload 401s because the refresh cookie
+ * was never stored. That is exactly the "persistent login" failure reporters
+ * hit, with no diagnostic anywhere.
+ *
+ * Resolution order: the reverse proxy's `X-Forwarded-Proto` (Caddy always sets
+ * it to the true client-hop scheme) → an `https://` request URL as a positive
+ * signal (direct-to-API TLS, no proxy) → `NODE_ENV` as the safe default.
+ * Trusting `X-Forwarded-Proto` is safe here: Caddy overwrites any client-supplied
+ * value, and a spoofed `https` only makes cookies *more* restrictive.
+ *
+ * Note the URL scheme is only ever a POSITIVE signal: in the standard topology
+ * `c.req.url` is the internal Caddy→API hop (`http://api:3001/...`), which does
+ * NOT reflect the browser's transport. So an `http` URL with no `X-Forwarded-Proto`
+ * is ambiguous — we fall back to `NODE_ENV` rather than downgrading a genuinely
+ * HTTPS deployment whose proxy happens to strip the header to non-Secure cookies.
+ */
+export function isRequestConnectionSecure(c: Context): boolean {
+  const forwardedProto = c.req.header('x-forwarded-proto');
+  if (forwardedProto) {
+    // A proxy chain may append hops ("https, http"); the first is client-facing.
+    return forwardedProto.split(',')[0]?.trim().toLowerCase() === 'https';
+  }
+  try {
+    if (new URL(c.req.url).protocol === 'https:') {
+      return true;
+    }
+  } catch {
+    // Malformed URL — fall through to the NODE_ENV default.
+  }
+  return isSecureCookieEnvironment();
+}
+
 type SameSiteValue = 'Lax' | 'Strict' | 'None';
 
 function normalizeSameSite(raw: string | undefined): SameSiteValue {
@@ -329,52 +370,90 @@ function resolveAuthCookieSameSite(): SameSiteValue {
   return normalizeSameSite(process.env.AUTH_COOKIE_SAME_SITE ?? process.env.COOKIE_SAME_SITE);
 }
 
-function shouldSetSecureCookie(sameSite: SameSiteValue): boolean {
+function forceSecureCookie(): boolean {
+  const forceSecure = (process.env.AUTH_COOKIE_FORCE_SECURE ?? process.env.COOKIE_FORCE_SECURE)?.trim().toLowerCase();
+  return forceSecure === '1' || forceSecure === 'true';
+}
+
+function shouldSetSecureCookie(sameSite: SameSiteValue, connectionSecure: boolean): boolean {
   if (sameSite === 'None') {
     // Browsers require Secure when SameSite=None.
     return true;
   }
-  const forceSecure = (process.env.AUTH_COOKIE_FORCE_SECURE ?? process.env.COOKIE_FORCE_SECURE)?.trim().toLowerCase();
-  if (forceSecure === '1' || forceSecure === 'true') {
+  if (forceSecureCookie()) {
     return true;
   }
-  return isSecureCookieEnvironment();
+  return connectionSecure;
 }
 
-function buildCookieSecuritySuffix(sameSite: SameSiteValue): string {
-  const secure = shouldSetSecureCookie(sameSite) ? '; Secure' : '';
+function buildCookieSecuritySuffix(sameSite: SameSiteValue, connectionSecure: boolean): string {
+  const secure = shouldSetSecureCookie(sameSite, connectionSecure) ? '; Secure' : '';
   return `; SameSite=${sameSite}${secure}`;
 }
 
-export function buildRefreshTokenCookie(refreshToken: string): string {
+// The build* functions default `connectionSecure` to the NODE_ENV heuristic so
+// any caller without a request context keeps the historical behaviour; the
+// set/clear entry points below always pass the request-derived value.
+export function buildRefreshTokenCookie(refreshToken: string, connectionSecure = isSecureCookieEnvironment()): string {
   const sameSite = resolveAuthCookieSameSite();
-  return `${REFRESH_COOKIE_NAME}=${encodeURIComponent(refreshToken)}; Path=${REFRESH_COOKIE_PATH}; HttpOnly${buildCookieSecuritySuffix(sameSite)}; Max-Age=${REFRESH_COOKIE_MAX_AGE_SECONDS}`;
+  return `${REFRESH_COOKIE_NAME}=${encodeURIComponent(refreshToken)}; Path=${REFRESH_COOKIE_PATH}; HttpOnly${buildCookieSecuritySuffix(sameSite, connectionSecure)}; Max-Age=${REFRESH_COOKIE_MAX_AGE_SECONDS}`;
 }
 
-export function buildCsrfTokenCookie(csrfToken: string): string {
+export function buildCsrfTokenCookie(csrfToken: string, connectionSecure = isSecureCookieEnvironment()): string {
   const sameSite = resolveAuthCookieSameSite();
-  return `${CSRF_COOKIE_NAME}=${encodeURIComponent(csrfToken)}; Path=${CSRF_COOKIE_PATH}${buildCookieSecuritySuffix(sameSite)}; Max-Age=${REFRESH_COOKIE_MAX_AGE_SECONDS}`;
+  return `${CSRF_COOKIE_NAME}=${encodeURIComponent(csrfToken)}; Path=${CSRF_COOKIE_PATH}${buildCookieSecuritySuffix(sameSite, connectionSecure)}; Max-Age=${REFRESH_COOKIE_MAX_AGE_SECONDS}`;
 }
 
-export function buildClearRefreshTokenCookie(): string {
+export function buildClearRefreshTokenCookie(connectionSecure = isSecureCookieEnvironment()): string {
   const sameSite = resolveAuthCookieSameSite();
-  return `${REFRESH_COOKIE_NAME}=; Path=${REFRESH_COOKIE_PATH}; HttpOnly${buildCookieSecuritySuffix(sameSite)}; Max-Age=0`;
+  return `${REFRESH_COOKIE_NAME}=; Path=${REFRESH_COOKIE_PATH}; HttpOnly${buildCookieSecuritySuffix(sameSite, connectionSecure)}; Max-Age=0`;
 }
 
-export function buildClearCsrfTokenCookie(): string {
+export function buildClearCsrfTokenCookie(connectionSecure = isSecureCookieEnvironment()): string {
   const sameSite = resolveAuthCookieSameSite();
-  return `${CSRF_COOKIE_NAME}=; Path=${CSRF_COOKIE_PATH}${buildCookieSecuritySuffix(sameSite)}; Max-Age=0`;
+  return `${CSRF_COOKIE_NAME}=; Path=${CSRF_COOKIE_PATH}${buildCookieSecuritySuffix(sameSite, connectionSecure)}; Max-Age=0`;
+}
+
+// Throttled warning so a busy HTTP-served deployment logs the misconfiguration
+// periodically without flooding. Module-scoped; resets on process restart.
+let lastInsecureCookieWarnAt = 0;
+const INSECURE_COOKIE_WARN_INTERVAL_MS = 10 * 60 * 1000;
+
+function warnIfInsecureAuthCookie(connectionSecure: boolean): void {
+  // Only actionable when we believe we're deployed (production) yet the browser
+  // reached us over HTTP. Dev-over-http is the normal local flow — stay quiet.
+  if (connectionSecure || !isSecureCookieEnvironment() || forceSecureCookie()) {
+    return;
+  }
+  const now = Date.now();
+  if (now - lastInsecureCookieWarnAt < INSECURE_COOKIE_WARN_INTERVAL_MS) {
+    return;
+  }
+  lastInsecureCookieWarnAt = now;
+  console.warn(
+    '[auth] Issuing NON-Secure auth cookies: this production request did not arrive over HTTPS ' +
+    '(no `X-Forwarded-Proto: https`). Persistent login will work over HTTP, but the connection is ' +
+    'not encrypted. If Breeze should be served over HTTPS, fix TLS / your reverse proxy so the ' +
+    'browser reaches it over https and Caddy forwards `X-Forwarded-Proto=https` (see issue #1618). ' +
+    'To force `Secure` regardless, set AUTH_COOKIE_FORCE_SECURE=true.'
+  );
 }
 
 export function setRefreshTokenCookie(c: Context, refreshToken: string): void {
+  const connectionSecure = isRequestConnectionSecure(c);
+  warnIfInsecureAuthCookie(connectionSecure);
   const csrfToken = randomBytes(32).toString('hex');
-  c.header('Set-Cookie', buildRefreshTokenCookie(refreshToken), { append: true });
-  c.header('Set-Cookie', buildCsrfTokenCookie(csrfToken), { append: true });
+  c.header('Set-Cookie', buildRefreshTokenCookie(refreshToken, connectionSecure), { append: true });
+  c.header('Set-Cookie', buildCsrfTokenCookie(csrfToken, connectionSecure), { append: true });
 }
 
 export function clearRefreshTokenCookie(c: Context): void {
-  c.header('Set-Cookie', buildClearRefreshTokenCookie(), { append: true });
-  c.header('Set-Cookie', buildClearCsrfTokenCookie(), { append: true });
+  // Derive from the same request so the clearing cookie's attributes match the
+  // set cookie's within this transport (a `Secure` clear sent over HTTP would
+  // itself be ignored by the browser, stranding the cookie).
+  const connectionSecure = isRequestConnectionSecure(c);
+  c.header('Set-Cookie', buildClearRefreshTokenCookie(connectionSecure), { append: true });
+  c.header('Set-Cookie', buildClearCsrfTokenCookie(connectionSecure), { append: true });
 }
 
 export function getCookieValue(cookieHeader: string | undefined, name: string): string | null {

--- a/apps/api/src/services/clientIp.ts
+++ b/apps/api/src/services/clientIp.ts
@@ -262,6 +262,19 @@ export function getTrustedClientIpOrUndefined(c: RequestLike): string | undefine
   return ip || undefined;
 }
 
+// Whether forwarded metadata headers (X-Forwarded-Proto, X-Forwarded-For, …)
+// from this request may be honored: proxy-header trust is enabled AND the
+// immediate TCP peer is in TRUSTED_PROXY_CIDRS. This is the same gate
+// getTrustedClientIp applies before reading forwarded-ip headers — use it for
+// any other forwarded header whose value must not be client-controllable
+// (e.g. the auth-cookie Secure flag derives from X-Forwarded-Proto).
+export function trustsForwardedHeadersFrom(c: RequestLike): boolean {
+  if (!shouldTrustProxyHeaders()) {
+    return false;
+  }
+  return isTrustedProxySource(getImmediatePeerIp(c, ''));
+}
+
 // The immediate TCP peer, socket-only — NEVER consults forwarded headers, so
 // it cannot be spoofed at L7. Used as a rate-limit key of last resort when no
 // trusted client IP is available. Unlike getTrustedClientIp this does NOT gate


### PR DESCRIPTION
## Summary

Fixes the "persistent login" failure in #1618: a production deployment the browser reaches over plain HTTP (failed ACME, `http://` URL, TLS-stripping hop) stamped `Secure` on the refresh cookie, which browsers silently discard. Login appears to succeed (the access token rides in the JSON body), but every reload 401s because the refresh cookie was never stored — with no diagnostic anywhere.

Intentionally **not** auto-closing #1618 — leaving it open for the reporter to verify.

## What changed

**Transport detection** (`routes/auth/helpers.ts`)
- New `isRequestConnectionSecure(c)`: resolves `X-Forwarded-Proto` (first, client-facing hop) → `https://` request URL as a positive-only signal → `NODE_ENV` as the safe fallback.
- The header is only honored when the immediate TCP peer passes the same `TRUST_PROXY_HEADERS` / `TRUSTED_PROXY_CIDRS` gate as forwarded-IP headers (new `trustsForwardedHeadersFrom()` in `services/clientIp.ts`), so an arbitrary client reaching the API around the proxy cannot strip `Secure` by spoofing a downgrade. The stock compose config trusts Caddy's static IP out of the box (locked by `proxyTrustCompose.test.ts`).
- `connectionSecure` is a **required** parameter on all `build*` cookie functions — no caller can silently fall back to the pre-fix NODE_ENV heuristic.
- Clear-cookie attributes derive from the same request as set-cookie: a `Secure` clear sent over HTTP is rejected by browsers and strands the cookie.

**Diagnostics** (the "no diagnostic anywhere" half of the bug)
- Warnings key off the **actual** Secure decision, not the transport alone: forcing `Secure` over HTTP (`AUTH_COOKIE_FORCE_SECURE`, `SameSite=None`) warns that the browser WILL discard the cookies and login WILL break; non-Secure-over-HTTP in production warns about the unencrypted transport; the blind NODE_ENV fallback leaves an ambiguous-transport breadcrumb (covers proxies that never send `X-Forwarded-Proto` or aren't in `TRUSTED_PROXY_CIDRS`).
- All warnings include the host and observed `X-Forwarded-Proto` value, throttled per warning kind (10 min) with a test reset seam.

**Behavior notes**
- `SameSite=None` still forces `Secure` unconditionally (browser requirement); `AUTH_COOKIE_FORCE_SECURE` still forces it explicitly.
- Deployments with no trusted `X-Forwarded-Proto` and an `http` internal URL keep today's NODE_ENV behavior (never downgrading a genuinely-HTTPS deploy), now with a breadcrumb instead of silence.

## Follow-up

The client portal has an independent copy of the old NODE_ENV logic and retains this bug on its surface — tracked in #2611.

## Testing

- `routes/auth/helpers.test.ts`: 52 tests — the #1618 regression (production over HTTP → non-Secure cookies, HttpOnly/SameSite preserved), proxy-trust gate (trusted downgrade honored; untrusted peer / trust-off / no-socket ignored), first-hop resolution, header casing/whitespace, `SameSite=None` forces Secure, force-secure override, set/clear symmetry both directions, malformed-URL fallback, and the full warning suite (throttle window via fake timers, per-cause messages, quiet in dev).
- Full auth route + clientIp suites: 281 tests green. API typecheck clean.
- Reviewed by a four-agent review pass (general/security, test coverage, comment accuracy, silent-failure hunt); all findings addressed in 993a35bd7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)