### PR TITLE
feat(extensions): breeze-ext packer/signer + two-replica reconcile (Plan 04 T3 / #2619)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -92,6 +92,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@breeze/extension-cli": "workspace:*",
     "@types/archiver": "^7.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.9.3",

--- a/apps/api/src/extensions/__fixtures__/reconcileChild.ts
+++ b/apps/api/src/extensions/__fixtures__/reconcileChild.ts
@@ -1,0 +1,101 @@
+/**
+ * Two-replica reconcile harness (Task 8, issue #2619) — child entry point.
+ *
+ * Launched via `child_process.fork` from
+ * `../twoReplicaReconcile.integration.test.ts` as a genuinely SEPARATE OS
+ * process. This is the smallest faithful thing that drives the real
+ * reconciler: no `index.ts` bootstrap, no HTTP server, no workers, no seeds —
+ * just a direct `reconcileExtensions(...)` call, exactly mirroring the boot
+ * call at `index.ts:1596-1602`.
+ *
+ * Why a real child process instead of a second in-process call: the
+ * reconciler's DI only covers the bundle/verify/migration path. The `db`
+ * pool (`../db`), the tenancy registry (`../tenancyRegistry`), and the
+ * extracted-root map (`../faultAttribution`) are hardwired process-global
+ * singletons with no constructor seam — two in-process calls would silently
+ * share all three, which is precisely NOT what two replicas do. A forked
+ * process gives genuinely separate globals, matching what actually differs
+ * between real replicas.
+ *
+ * ENV CONTRACT: `DATABASE_URL`, `DATABASE_URL_APP`, `NODE_ENV`,
+ * `JWT_SECRET`, and `BREEZE_EXTENSIONS_ARTIFACTS_DIR` MUST already be set on
+ * this process's environment before this module's first import runs — the
+ * parent test sets them via `fork(...)`'s `env` option (never via code in
+ * this file), because `../db` opens its postgres pool at module-load time
+ * (`db/index.ts:31`), before any line of `main()` below could run.
+ *
+ * OUTPUT CONTRACT: exactly one JSON object is written to stdout, followed by
+ * a newline, as the LAST thing this process does before exiting. The parent
+ * test scans stdout backwards for the last line that parses as JSON (postgres
+ * NOTICE output and the reconciler's own `console.log` lines are not
+ * suppressed, so other lines may precede it). Exit codes:
+ *   0 — reconcileExtensions resolved (ok:true; inspect `failed` for optional
+ *       extensions that were withdrawn).
+ *   1 — reconcileExtensions rejected with RequiredExtensionError (a REQUIRED
+ *       extension failed a phase) — the faithful analogue of aborted boot
+ *       (production: `index.ts`'s `bootstrap().catch(() => process.exit(1))`).
+ *   2 — reconcileExtensions rejected with anything else (a genuine harness or
+ *       fixture bug, not a modeled failure-policy outcome).
+ *   3 — this file's own argv contract was violated before reconcileExtensions
+ *       was even called.
+ */
+import { Hono } from 'hono';
+import { reconcileExtensions } from '../reconciler';
+import { ExtensionContributionRegistry } from '../contributionRegistry';
+import { createExtensionStateStore } from '../stateStore';
+import { RequiredExtensionError } from '../errors';
+
+interface ChildResult {
+  ok: boolean;
+  requiredAbort: boolean;
+  activated?: string[];
+  failed?: string[];
+  skipped?: string[];
+  extensionName?: string;
+  phase?: string;
+  error?: string;
+}
+
+/**
+ * Write the result as the LAST stdout write, then exit only once the write
+ * has actually flushed. `process.exit()` immediately after an async pipe
+ * write can truncate it (a well-known Node gotcha for piped — not TTY —
+ * stdout, which is exactly what `child_process.fork` gives the parent).
+ */
+function emit(result: ChildResult, exitCode: number): void {
+  process.stdout.write(`${JSON.stringify(result)}\n`, () => {
+    process.exit(exitCode);
+  });
+}
+
+async function main(): Promise<void> {
+  const [configPath, storeRoot] = process.argv.slice(2);
+  if (!configPath || !storeRoot) {
+    throw new Error('reconcileChild requires <configPath> <storeRoot> as argv[2]/argv[3]');
+  }
+
+  try {
+    const summary = await reconcileExtensions({
+      app: new Hono(),
+      configPath,
+      storeRoot,
+      registry: new ExtensionContributionRegistry(),
+      stateStore: createExtensionStateStore(),
+      // No `ports` override: this must drive the REAL pipeline end to end.
+    });
+    emit(
+      { ok: true, requiredAbort: false, activated: summary.activated, failed: summary.failed, skipped: summary.skipped },
+      0,
+    );
+  } catch (error) {
+    if (error instanceof RequiredExtensionError) {
+      emit({ ok: false, requiredAbort: true, extensionName: error.extensionName, phase: error.phase }, 1);
+      return;
+    }
+    emit({ ok: false, requiredAbort: false, error: String((error as Error)?.message ?? error) }, 2);
+  }
+}
+
+main().catch((error) => {
+  emit({ ok: false, requiredAbort: false, error: String((error as Error)?.message ?? error) }, 3);
+});

--- a/apps/api/src/extensions/__fixtures__/twoReplica.ts
+++ b/apps/api/src/extensions/__fixtures__/twoReplica.ts
@@ -1,0 +1,177 @@
+/**
+ * Fixture authoring for the two-replica reconcile integration test (Task 8,
+ * issue #2619). Builds REAL signed `.breeze-ext` bundles with the REAL
+ * `@breeze/extension-cli` (mirroring `packerConformance.test.ts`'s
+ * `buildSignedFixture`), writes a real `extensions.yaml` + PEM publisher
+ * public key, and hands back everything
+ * `twoReplicaReconcile.integration.test.ts` needs to fork two children
+ * against the same on-disk deployment config.
+ *
+ * Nothing here runs in the CHILD process — only the parent test authors
+ * fixtures; the child (`reconcileChild.ts`) only ever reads the paths this
+ * module writes.
+ */
+import { generateKeyPairSync } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { dump as dumpYaml } from 'js-yaml';
+import { packExtension, signArtifact } from '@breeze/extension-cli';
+
+/** One extension to author, pack, and sign for a scenario. */
+export interface FixtureExtensionSpec {
+  /** Must be a valid lowercase kebab-ish extension name (NAME_RE in config.ts). */
+  name: string;
+  required: boolean;
+  /**
+   * Raw SQL for `migrations/0001_init.sql`. Deliberately authored by the
+   * CALLER (not this module) so each scenario controls its own
+   * idempotency/failure shape — e.g. the happy path uses a non-idempotent
+   * `CREATE TABLE` (no `IF NOT EXISTS`) so a genuine second execution would
+   * throw, which is half of the exactly-once proof.
+   */
+  migrationSql: string;
+  /**
+   * Tables to declare in the manifest's `tenancy.nonTenantTables`. MUST be
+   * prefixed `${name}_` (the manifest schema enforces this) and MUST cover
+   * every table `migrationSql` creates — otherwise the reconciler's
+   * boot-time tenancy tripwire (`tenancyTripwire.ts`,
+   * `assertNoUnaccountedPublicTables`) fails BOTH extensions in the
+   * scenario, not just this one.
+   */
+  nonTenantTables: string[];
+}
+
+/** A single packed+signed extension, ready to reference from `extensions.yaml`. */
+export interface BuiltFixtureExtension {
+  name: string;
+  required: boolean;
+  artifactPath: string;
+  digest: `sha256:${string}`;
+}
+
+/** Everything the parent test needs to fork children against this scenario. */
+export interface ScenarioFixture {
+  /** Absolute path to the scenario's `extensions.yaml`. */
+  configPath: string;
+  extensions: BuiltFixtureExtension[];
+}
+
+function manifestFor(spec: FixtureExtensionSpec): Record<string, unknown> {
+  return {
+    apiVersion: 'breeze.extensions/v1',
+    name: spec.name,
+    version: '1.0.0',
+    routeNamespace: spec.name,
+    requires: {
+      // The host descriptor (hostDescriptor.ts) advertises breezeVersion
+      // '0.1.0' / serverSdkVersion '1.0.0' — these ranges must be satisfied
+      // against THOSE numbers, not the artifact's own version.
+      breeze: '^0.1.0',
+      serverSdk: '^1.0.0',
+      capabilities: [],
+    },
+    server: { entry: 'server/index.cjs' },
+    schemaCompatibilityFloor: '1.0.0',
+    jobs: [],
+    aiTools: [],
+    tenancy: {
+      orgCascadeDeleteTables: [],
+      deviceCascadeDeleteTables: [],
+      deviceOrgDenormalizedTables: [],
+      nonTenantTables: spec.nonTenantTables,
+    },
+  };
+}
+
+/** Write a minimal, SDK-valid extension source tree that `collectPayload` accepts. */
+async function writeExtensionSourceTree(dir: string, spec: FixtureExtensionSpec): Promise<void> {
+  await mkdir(join(dir, 'server'), { recursive: true });
+  await mkdir(join(dir, 'migrations'), { recursive: true });
+  await writeFile(join(dir, 'manifest.json'), JSON.stringify(manifestFor(spec)));
+  await writeFile(join(dir, 'server/index.cjs'), 'module.exports = { register() {} };\n');
+  await writeFile(join(dir, 'migrations/0001_init.sql'), spec.migrationSql);
+}
+
+/** Pack + sign one extension with the real CLI, under `<root>/<name>/...`. */
+async function buildSignedExtension(
+  root: string,
+  spec: FixtureExtensionSpec,
+  privateKeyPath: string,
+): Promise<BuiltFixtureExtension> {
+  const sourceDir = join(root, spec.name, 'src');
+  const outDir = join(root, spec.name, 'out');
+  await mkdir(sourceDir, { recursive: true });
+  await mkdir(outDir, { recursive: true });
+  await writeExtensionSourceTree(sourceDir, spec);
+
+  const packResult = await packExtension({
+    path: sourceDir,
+    out: join(outDir, 'unsigned.breeze-ext'),
+    sourceDateEpoch: 0,
+  });
+  const signResult = await signArtifact({
+    artifact: packResult.artifactPath,
+    key: privateKeyPath,
+    out: join(outDir, 'signed.breeze-ext'),
+  });
+
+  return {
+    name: spec.name,
+    required: spec.required,
+    artifactPath: signResult.artifactPath,
+    digest: signResult.digest as `sha256:${string}`,
+  };
+}
+
+/**
+ * Build a full scenario under `root`: generate ONE Ed25519 keypair for the
+ * scenario's publisher, pack + sign every extension in `specs` with it, and
+ * write `extensions.yaml` + the publisher's PEM public key to disk. No key
+ * material is committed anywhere — everything lives under the caller's temp
+ * `root`, generated fresh per test run.
+ */
+export async function buildScenarioFixture(
+  root: string,
+  publisherId: string,
+  specs: readonly FixtureExtensionSpec[],
+): Promise<ScenarioFixture> {
+  const keyDir = join(root, 'keys');
+  await mkdir(keyDir, { recursive: true });
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const privateKeyPath = join(keyDir, 'signing-key.pem');
+  const publicKeyPath = join(keyDir, 'publisher.pem');
+  await writeFile(privateKeyPath, privateKey.export({ type: 'pkcs8', format: 'pem' }));
+  await writeFile(publicKeyPath, publicKey.export({ type: 'spki', format: 'pem' }));
+
+  const built: BuiltFixtureExtension[] = [];
+  for (const spec of specs) {
+    // Sequential on purpose: pack/sign is cheap, and sequencing keeps each
+    // extension's temp subtree fully written before the next starts, which
+    // makes any failure's error message unambiguous about which extension it
+    // came from.
+    built.push(await buildSignedExtension(root, spec, privateKeyPath));
+  }
+
+  const config = {
+    publishers: {
+      [publisherId]: { publicKeyFile: publicKeyPath },
+    },
+    extensions: built.map((ext) => ({
+      name: ext.name,
+      uri: pathToFileURL(ext.artifactPath).href,
+      version: '1.0.0',
+      digest: ext.digest,
+      publisher: publisherId,
+      required: ext.required,
+      rollout: 'rolling' as const,
+    })),
+  };
+
+  const configDir = join(root, 'config');
+  await mkdir(configDir, { recursive: true });
+  const configPath = join(configDir, 'extensions.yaml');
+  await writeFile(configPath, dumpYaml(config));
+
+  return { configPath, extensions: built };
+}

--- a/apps/api/src/extensions/packerConformance.test.ts
+++ b/apps/api/src/extensions/packerConformance.test.ts
@@ -1,0 +1,382 @@
+import { createHash, generateKeyPairSync, type KeyObject } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import JSZip from 'jszip';
+import StreamZip from 'node-stream-zip';
+import { afterEach, describe, expect, it } from 'vitest';
+// Deliberately NOT `@breeze/extension-cli` package-root imports for the
+// command internals: the package's `exports` map only publishes `"."`
+// (`src/index.ts`, which re-exports only the `run*` CLI entry points), so
+// `packExtension`/`signArtifact`/`signingPayload` — none of which are
+// re-exported — are reached via a plain relative filesystem import into the
+// package's source, same as any other in-repo cross-package test import.
+// This does NOT create a runtime dependency of the CLI package on apps/api;
+// the arrow still points app -> package, one file, test-only.
+import { packExtension } from '../../../../packages/extension-cli/src/commands/pack';
+import { signArtifact } from '../../../../packages/extension-cli/src/commands/sign';
+import { signingPayload } from '../../../../packages/extension-cli/src/artifact/integrity';
+import type { ExtensionSelection } from './config';
+import {
+  canonicalSigningPayload,
+  verifyExtensionBundle,
+  type TrustedPublisher,
+} from './bundleVerifier';
+
+/**
+ * Task 6 (runtime extension platform, issue #2619) — the load-bearing
+ * conformance test. Everything here packs and signs a REAL fixture with the
+ * REAL `@breeze/extension-cli`, then runs the REAL, frozen
+ * `verifyExtensionBundle`. No in-process fixture builder stands in for the
+ * packer or the signer: if the CLI's wire format ever drifts from what the
+ * verifier expects, this file — not a hand-rolled fixture — is what breaks.
+ */
+
+function manifestObject(overrides: Record<string, unknown> = {}) {
+  return {
+    apiVersion: 'breeze.extensions/v1',
+    name: 'demo-ext',
+    version: '1.2.3',
+    routeNamespace: 'demo-ext',
+    requires: {
+      breeze: '^1.0.0',
+      serverSdk: '^1.0.0',
+      capabilities: ['server.routes.v1'],
+    },
+    server: { entry: 'server/index.cjs' },
+    schemaCompatibilityFloor: '1.0.0',
+    jobs: [],
+    aiTools: [],
+    ...overrides,
+  };
+}
+
+function sha256Hex(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+function digestOf(data: Buffer): `sha256:${string}` {
+  return `sha256:${sha256Hex(data)}`;
+}
+
+const scratchDirs: string[] = [];
+
+async function scratchDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+/** Write a minimal, SDK-valid extension source tree that `collectPayload` accepts. */
+async function writeSourceTree(dir: string, manifestOverrides: Record<string, unknown> = {}): Promise<void> {
+  await mkdir(join(dir, 'server'), { recursive: true });
+  await mkdir(join(dir, 'migrations'), { recursive: true });
+  await writeFile(join(dir, 'manifest.json'), JSON.stringify(manifestObject(manifestOverrides)));
+  await writeFile(join(dir, 'server/index.cjs'), 'module.exports = { register() {} };\n');
+  await writeFile(join(dir, 'migrations/0001_init.sql'), 'select 1;\n');
+}
+
+interface SignedFixture {
+  /** Path to the packed+signed `.breeze-ext` artifact. Never mutated by a test. */
+  artifactPath: string;
+  /** The digest `signArtifact` returned for `artifactPath` — the SIGNED digest. */
+  digest: `sha256:${string}`;
+  publicKey: KeyObject;
+  privateKey: KeyObject;
+  selection: ExtensionSelection;
+  trust: TrustedPublisher;
+}
+
+/**
+ * Pack and sign a fresh fixture with the real CLI: a real source tree on
+ * disk, a real generated Ed25519 keypair (private key written to a temp PEM
+ * file and handed to `signArtifact` via its `key` option, exactly as
+ * `breeze-ext sign --key <path>` would), and the real `packExtension` /
+ * `signArtifact` pipeline. No key material is committed; everything here
+ * lives under a per-test temp directory cleaned up in `afterEach`.
+ */
+async function buildSignedFixture(manifestOverrides: Record<string, unknown> = {}): Promise<SignedFixture> {
+  const sourceDir = await scratchDir('breeze-ext-conformance-src-');
+  const outDir = await scratchDir('breeze-ext-conformance-out-');
+  const keyDir = await scratchDir('breeze-ext-conformance-key-');
+
+  await writeSourceTree(sourceDir, manifestOverrides);
+
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const keyPath = join(keyDir, 'signing-key.pem');
+  await writeFile(keyPath, privateKey.export({ type: 'pkcs8', format: 'pem' }));
+
+  const packResult = await packExtension({
+    path: sourceDir,
+    out: join(outDir, 'unsigned.breeze-ext'),
+    sourceDateEpoch: 0,
+  });
+  const signResult = await signArtifact({
+    artifact: packResult.artifactPath,
+    key: keyPath,
+    out: join(outDir, 'signed.breeze-ext'),
+  });
+
+  const digest = signResult.digest as `sha256:${string}`;
+  const selection: ExtensionSelection = {
+    name: 'demo-ext',
+    uri: 'file://local',
+    version: '1.2.3',
+    digest,
+    publisher: 'acme',
+    required: false,
+    rollout: 'rolling',
+  };
+  const trust: TrustedPublisher = { publisher: 'acme', publicKey };
+
+  return { artifactPath: signResult.artifactPath, digest, publicKey, privateKey, selection, trust };
+}
+
+/**
+ * Load a signed artifact into an in-memory JSZip, let `mutate` edit it, and
+ * write the result to a NEW path (the original, valid artifact is left
+ * untouched on disk so a test can verify it too, as the "without the
+ * mutation" control). Returns the mutated path and the digest of the
+ * mutated bytes — pinning THAT digest is what isolates each negative test
+ * to the single control it targets, rather than tripping the (separately
+ * tested) pinned-digest mismatch check.
+ */
+async function mutateArtifact(
+  sourcePath: string,
+  mutate: (zip: JSZip) => void | Promise<void>,
+): Promise<{ path: string; digest: `sha256:${string}` }> {
+  const original = await readFile(sourcePath);
+  const zip = await JSZip.loadAsync(original);
+  await mutate(zip);
+  const mutatedBytes = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+
+  const outDir = await scratchDir('breeze-ext-conformance-mutated-');
+  const mutatedPath = join(outDir, 'mutated.breeze-ext');
+  await writeFile(mutatedPath, mutatedBytes);
+
+  return { path: mutatedPath, digest: digestOf(mutatedBytes) };
+}
+
+async function readZipMember(archivePath: string, member: string): Promise<Buffer> {
+  const zip = new StreamZip.async({ file: archivePath });
+  try {
+    return await zip.entryData(member);
+  } finally {
+    await zip.close();
+  }
+}
+
+async function listZipMembers(archivePath: string): Promise<string[]> {
+  const zip = new StreamZip.async({ file: archivePath });
+  try {
+    const entries = await zip.entries();
+    return Object.values(entries)
+      .filter((entry) => !entry.isDirectory)
+      .map((entry) => entry.name);
+  } finally {
+    await zip.close();
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(scratchDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('packer/signer output verifies against the frozen verifier', () => {
+  describe('positive case', () => {
+    it('resolves for a real packed+signed artifact, matching what the packer/signer produced', async () => {
+      const fixture = await buildSignedFixture();
+
+      const bundle = await verifyExtensionBundle(fixture.artifactPath, fixture.selection, fixture.trust);
+
+      expect(bundle.manifest.name).toBe('demo-ext');
+      expect(bundle.manifest.version).toBe('1.2.3');
+      expect(bundle.artifactDigest).toBe(fixture.digest);
+      expect(Object.isFrozen(bundle)).toBe(true);
+
+      // `bundle.files` must be exactly the non-reserved members the packer
+      // actually wrote to the archive -- cross-checked against the archive
+      // itself, not against a hand-maintained expected list.
+      const actualMembers = await listZipMembers(fixture.artifactPath);
+      const expectedFiles = actualMembers.filter((name) => name !== 'integrity.json' && name !== 'signature');
+      expect([...bundle.files.keys()].sort()).toEqual(expectedFiles.sort());
+      expect(expectedFiles.sort()).toEqual(['manifest.json', 'migrations/0001_init.sql', 'server/index.cjs']);
+
+      for (const [name, info] of bundle.files) {
+        const bytes = await readZipMember(fixture.artifactPath, name);
+        expect(info.sha256).toBe(sha256Hex(bytes));
+        expect(info.uncompressedSize).toBe(bytes.length);
+      }
+    });
+
+    it('produces a signingPayload byte-identical to the verifier\'s canonicalSigningPayload (live drift guard)', async () => {
+      const fixture = await buildSignedFixture();
+
+      const manifestBytes = await readZipMember(fixture.artifactPath, 'manifest.json');
+      const integrityBytes = await readZipMember(fixture.artifactPath, 'integrity.json');
+      const bundle = await verifyExtensionBundle(fixture.artifactPath, fixture.selection, fixture.trust);
+
+      const cliPayload = signingPayload(bundle.manifest, manifestBytes, integrityBytes);
+      const verifierPayload = canonicalSigningPayload(bundle.manifest, manifestBytes, integrityBytes);
+
+      expect(cliPayload.equals(verifierPayload)).toBe(true);
+    });
+  });
+
+  describe('negative cases (each must reject, and each is proven load-bearing)', () => {
+    it('rejects a payload member mutated after signing', async () => {
+      const fixture = await buildSignedFixture();
+
+      // Control: the artifact as the CLI produced it, untouched, verifies fine.
+      await expect(
+        verifyExtensionBundle(fixture.artifactPath, fixture.selection, fixture.trust),
+      ).resolves.toBeDefined();
+
+      const mutated = await mutateArtifact(fixture.artifactPath, (zip) => {
+        zip.file('server/index.cjs', 'module.exports = { register() { /* tampered */ } };\n');
+      });
+      const mutatedSelection: ExtensionSelection = { ...fixture.selection, digest: mutated.digest };
+
+      // With ONLY the payload byte mutation applied (pinned digest updated to
+      // match, so the digest check -- covered separately below -- can't be
+      // what's catching this), rejection must come from the per-member
+      // integrity check.
+      await expect(
+        verifyExtensionBundle(mutated.path, mutatedSelection, fixture.trust),
+      ).rejects.toThrow(/integrity check/i);
+    });
+
+    it('rejects a signature made by a keypair the trust config does not list', async () => {
+      const fixture = await buildSignedFixture();
+
+      // Control: the real signer's public key verifies the real artifact.
+      await expect(
+        verifyExtensionBundle(fixture.artifactPath, fixture.selection, fixture.trust),
+      ).resolves.toBeDefined();
+
+      const stranger = generateKeyPairSync('ed25519').publicKey;
+      const strangerTrust: TrustedPublisher = { publisher: 'acme', publicKey: stranger };
+
+      await expect(
+        verifyExtensionBundle(fixture.artifactPath, fixture.selection, strangerTrust),
+      ).rejects.toThrow(/signature/i);
+    });
+
+    it('rejects an extra member added to the archive after signing (not in the inventory)', async () => {
+      const fixture = await buildSignedFixture();
+
+      await expect(
+        verifyExtensionBundle(fixture.artifactPath, fixture.selection, fixture.trust),
+      ).resolves.toBeDefined();
+
+      const mutated = await mutateArtifact(fixture.artifactPath, (zip) => {
+        zip.file('extra/not-in-inventory.txt', 'malicious payload\n');
+      });
+      const mutatedSelection: ExtensionSelection = { ...fixture.selection, digest: mutated.digest };
+
+      await expect(
+        verifyExtensionBundle(mutated.path, mutatedSelection, fixture.trust),
+      ).rejects.toThrow(/not covered by the signed integrity inventory/i);
+    });
+
+    it('rejects an inventoried member deleted from the archive', async () => {
+      const fixture = await buildSignedFixture();
+
+      await expect(
+        verifyExtensionBundle(fixture.artifactPath, fixture.selection, fixture.trust),
+      ).resolves.toBeDefined();
+
+      const mutated = await mutateArtifact(fixture.artifactPath, (zip) => {
+        zip.remove('migrations/0001_init.sql');
+      });
+      const mutatedSelection: ExtensionSelection = { ...fixture.selection, digest: mutated.digest };
+
+      await expect(
+        verifyExtensionBundle(mutated.path, mutatedSelection, fixture.trust),
+      ).rejects.toThrow(/missing from the archive/i);
+    });
+
+    it('rejects integrity.json mutated after signing', async () => {
+      const fixture = await buildSignedFixture();
+
+      await expect(
+        verifyExtensionBundle(fixture.artifactPath, fixture.selection, fixture.trust),
+      ).resolves.toBeDefined();
+
+      const mutated = await mutateArtifact(fixture.artifactPath, async (zip) => {
+        const entry = zip.file('integrity.json');
+        if (!entry) throw new Error('fixture is missing integrity.json');
+        const raw = JSON.parse(await entry.async('string'));
+        // Corrupt a real, present member's recorded size -- still valid JSON,
+        // still schema-valid -- so the ONLY defect is the signed
+        // integrity.json no longer matching what was actually signed.
+        raw.members['server/index.cjs'].size += 1;
+        zip.file('integrity.json', JSON.stringify(raw));
+      });
+      const mutatedSelection: ExtensionSelection = { ...fixture.selection, digest: mutated.digest };
+
+      // integrity.json's hash is bound into the signed payload, so mutating it
+      // invalidates the Ed25519 signature -- rejection surfaces as a signature
+      // failure, not a separate "integrity.json changed" check.
+      await expect(
+        verifyExtensionBundle(mutated.path, mutatedSelection, fixture.trust),
+      ).rejects.toThrow(/signature/i);
+    });
+
+    it('rejects a reserved member ("signature") added to the integrity inventory', async () => {
+      const fixture = await buildSignedFixture();
+
+      await expect(
+        verifyExtensionBundle(fixture.artifactPath, fixture.selection, fixture.trust),
+      ).resolves.toBeDefined();
+
+      const mutated = await mutateArtifact(fixture.artifactPath, async (zip) => {
+        const entry = zip.file('integrity.json');
+        if (!entry) throw new Error('fixture is missing integrity.json');
+        const raw = JSON.parse(await entry.async('string'));
+        raw.members.signature = { sha256: '0'.repeat(64), size: 64 };
+        zip.file('integrity.json', JSON.stringify(raw));
+      });
+      const mutatedSelection: ExtensionSelection = { ...fixture.selection, digest: mutated.digest };
+
+      // This is parsed and rejected before signature verification is even
+      // attempted (a mutated integrity.json also breaks the signature, but
+      // that is a DIFFERENT control -- this assertion's message pins the
+      // rejection to the reserved-member check specifically).
+      await expect(
+        verifyExtensionBundle(mutated.path, mutatedSelection, fixture.trust),
+      ).rejects.toThrow(/reserved member/i);
+    });
+
+    it('rejects when the pinned digest does not match the artifact', async () => {
+      const fixture = await buildSignedFixture();
+
+      await expect(
+        verifyExtensionBundle(fixture.artifactPath, fixture.selection, fixture.trust),
+      ).resolves.toBeDefined();
+
+      const wrongDigestSelection: ExtensionSelection = {
+        ...fixture.selection,
+        digest: `sha256:${'0'.repeat(64)}`,
+      };
+
+      await expect(
+        verifyExtensionBundle(fixture.artifactPath, wrongDigestSelection, fixture.trust),
+      ).rejects.toThrow(/digest/i);
+    });
+
+    it('rejects a selection.version that disagrees with the manifest', async () => {
+      const fixture = await buildSignedFixture();
+
+      await expect(
+        verifyExtensionBundle(fixture.artifactPath, fixture.selection, fixture.trust),
+      ).resolves.toBeDefined();
+
+      const wrongVersionSelection: ExtensionSelection = { ...fixture.selection, version: '9.9.9' };
+
+      await expect(
+        verifyExtensionBundle(fixture.artifactPath, wrongVersionSelection, fixture.trust),
+      ).rejects.toThrow(/version/i);
+    });
+  });
+});

--- a/apps/api/src/extensions/packerConformance.test.ts
+++ b/apps/api/src/extensions/packerConformance.test.ts
@@ -13,9 +13,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 // package's source, same as any other in-repo cross-package test import.
 // This does NOT create a runtime dependency of the CLI package on apps/api;
 // the arrow still points app -> package, one file, test-only.
-import { packExtension } from '../../../../packages/extension-cli/src/commands/pack';
-import { signArtifact } from '../../../../packages/extension-cli/src/commands/sign';
-import { signingPayload } from '../../../../packages/extension-cli/src/artifact/integrity';
+import { packExtension, signArtifact, signingPayload } from '@breeze/extension-cli';
 import type { ExtensionSelection } from './config';
 import {
   canonicalSigningPayload,

--- a/apps/api/src/extensions/twoReplicaReconcile.integration.test.ts
+++ b/apps/api/src/extensions/twoReplicaReconcile.integration.test.ts
@@ -171,6 +171,11 @@ describe('two-replica reconcile and failure policy (issue #2619, exit criteria 2
     // the duration of this call migrates it — the parent's import-time `db` pool
     // (bound to the base DB) is untouched. Restore env afterward so nothing else
     // in the process observes the swap.
+    // Mutating process.env here is safe ONLY because the integration config
+    // sets `fileParallelism: false` (vitest.integration.config.ts) — files run
+    // strictly sequentially, so no other test file's module graph can observe
+    // this swap during the autoMigrate() window. If file parallelism is ever
+    // enabled, this must move to a child process or a per-call config override.
     const prevUrl = process.env.DATABASE_URL;
     const prevApp = process.env.DATABASE_URL_APP;
     process.env.DATABASE_URL = DATABASE_URL;

--- a/apps/api/src/extensions/twoReplicaReconcile.integration.test.ts
+++ b/apps/api/src/extensions/twoReplicaReconcile.integration.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import postgres, { type Sql } from 'postgres';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { autoMigrate } from '../db/autoMigrate';
 import { buildScenarioFixture, type FixtureExtensionSpec } from './__fixtures__/twoReplica';
 
 /**
@@ -49,10 +50,32 @@ const ALL_FIXTURE_EXTENSION_NAMES = ['happyreq', 'happyopt', 'reqfail', 'optfail
  * `test:docker:down`.
  */
 
-const DATABASE_URL =
+// This test drives the FULL `reconcileExtensions`, whose tenancy phase
+// (`assertNoUnaccountedPublicTables`) sweeps the ENTIRE `public` schema — so it
+// cannot share the standard `breeze_test` database, which accumulates tables
+// from other extensions' integration runs across worktrees (e.g. `workspace_*`)
+// that would read as "unaccounted" and abort every reconcile here. Instead the
+// suite provisions its OWN throwaway database (created + migrated in beforeAll,
+// dropped in afterAll), so the schema contains only core tables plus this
+// test's own accounted-for extension tables. The name matches the test-DB
+// safety allowlist (`/^breeze_test(_[a-z0-9]+)?$/`).
+const THROWAWAY_DB = 'breeze_test_2rep';
+
+const BASE_DATABASE_URL =
   process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
-const DATABASE_URL_APP =
+const BASE_DATABASE_URL_APP =
   process.env.DATABASE_URL_APP ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+
+function withDbName(connectionUrl: string, databaseName: string): string {
+  const parsed = new URL(connectionUrl);
+  parsed.pathname = `/${databaseName}`;
+  return parsed.toString();
+}
+
+// Children and the parent's `admin` pool all target the throwaway DB; only the
+// create/drop DDL runs against the base DB (via `baseAdmin`).
+const DATABASE_URL = withDbName(BASE_DATABASE_URL, THROWAWAY_DB);
+const DATABASE_URL_APP = withDbName(BASE_DATABASE_URL_APP, THROWAWAY_DB);
 const CHILD_JWT_SECRET = 'test-jwt-secret-for-two-replica-reconcile-min-32-chars';
 
 const CHILD_ENTRY_PATH = fileURLToPath(new URL('./__fixtures__/reconcileChild.ts', import.meta.url));
@@ -132,9 +155,33 @@ function runChild(configPath: string, storeRoot: string, artifactsDir: string): 
 
 describe('two-replica reconcile and failure policy (issue #2619, exit criteria 2 & 3)', () => {
   let admin: Sql;
+  let baseAdmin: Sql;
   let scratchRoot: string;
 
   beforeAll(async () => {
+    // Provision a pristine throwaway database. FORCE-drop first so a prior
+    // interrupted run can't leave stale schema behind (PG 13+; container is 16).
+    baseAdmin = postgres(BASE_DATABASE_URL, { max: 1, onnotice: () => {} });
+    await baseAdmin.unsafe(`DROP DATABASE IF EXISTS ${THROWAWAY_DB} WITH (FORCE)`);
+    await baseAdmin.unsafe(`CREATE DATABASE ${THROWAWAY_DB}`);
+
+    // Migrate the throwaway DB. autoMigrate() (and the ensureAppRole it calls)
+    // read DATABASE_URL / DATABASE_URL_APP from the environment at call time and
+    // open their own short-lived clients, so pointing env at the throwaway for
+    // the duration of this call migrates it — the parent's import-time `db` pool
+    // (bound to the base DB) is untouched. Restore env afterward so nothing else
+    // in the process observes the swap.
+    const prevUrl = process.env.DATABASE_URL;
+    const prevApp = process.env.DATABASE_URL_APP;
+    process.env.DATABASE_URL = DATABASE_URL;
+    process.env.DATABASE_URL_APP = DATABASE_URL_APP;
+    try {
+      await autoMigrate();
+    } finally {
+      process.env.DATABASE_URL = prevUrl;
+      process.env.DATABASE_URL_APP = prevApp;
+    }
+
     admin = postgres(DATABASE_URL, { max: 4, onnotice: () => {} });
     scratchRoot = await mkdtemp(join(tmpdir(), 'breeze-ext-two-replica-'));
   });
@@ -155,9 +202,12 @@ describe('two-replica reconcile and failure policy (issue #2619, exit criteria 2
   }
 
   afterAll(async () => {
-    if (admin) {
-      await resetExtensionState(ALL_FIXTURE_EXTENSION_NAMES);
-      await admin.end({ timeout: 5 });
+    // Close the throwaway pool BEFORE dropping the database — FORCE also
+    // terminates any lingering sessions (e.g. a child's pool that outlived it).
+    if (admin) await admin.end({ timeout: 5 });
+    if (baseAdmin) {
+      await baseAdmin.unsafe(`DROP DATABASE IF EXISTS ${THROWAWAY_DB} WITH (FORCE)`);
+      await baseAdmin.end({ timeout: 5 });
     }
     if (scratchRoot) await rm(scratchRoot, { recursive: true, force: true }).catch(() => {});
   });

--- a/apps/api/src/extensions/twoReplicaReconcile.integration.test.ts
+++ b/apps/api/src/extensions/twoReplicaReconcile.integration.test.ts
@@ -1,0 +1,339 @@
+import '../__tests__/integration/setup';
+import { fork } from 'node:child_process';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import postgres, { type Sql } from 'postgres';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildScenarioFixture, type FixtureExtensionSpec } from './__fixtures__/twoReplica';
+
+/**
+ * Every extension name used by ANY scenario below. The reconciler's
+ * boot-time tenancy tripwire (`tenancyTripwire.ts`,
+ * `assertNoUnaccountedPublicTables`) scans the WHOLE `public` schema, not
+ * just the extensions configured for the current reconcile — so a table left
+ * behind by an EARLIER scenario in this same file (extension migrations have
+ * no rollback/uninstall path; the table just persists) would read as an
+ * unaccounted table to a LATER scenario's child processes, which only
+ * declare their own extensions' tenancy. Resetting the full set before every
+ * test — not just the current scenario's own names — is what keeps the three
+ * scenarios independent of run order and of each other's leftovers.
+ */
+const ALL_FIXTURE_EXTENSION_NAMES = ['happyreq', 'happyopt', 'reqfail', 'optfail', 'optfailhealthy'] as const;
+
+/**
+ * Two-replica reconcile + failure-policy integration test (Task 8 of the
+ * `breeze-ext` packer/signer plan, exit criteria 2 & 3 of issue #2619).
+ *
+ * ARCHITECTURE — why two CHILD PROCESSES, not two in-process calls: the
+ * reconciler's DI (`ReconcilePorts`) only covers the bundle/verify/migration
+ * path. The DB pool (`db/index.ts`), the tenancy registry
+ * (`tenancyRegistry.ts`), and the extracted-root map (`faultAttribution.ts`)
+ * are hardwired process-global singletons with no constructor seam — two
+ * `reconcileExtensions()` calls in this one Vitest worker would silently
+ * SHARE all three, which would prove "one process reconciling twice", not
+ * replica convergence. Each child (`__fixtures__/reconcileChild.ts`) is
+ * forked as a genuinely separate OS process — separate `db` pool, separate
+ * tenancy registry — with its own env set via `fork()`'s `env` option
+ * BEFORE the child's first import (the `db` pool opens at module-load time).
+ *
+ * This file (the parent) authors every fixture: it packs + signs real
+ * `.breeze-ext` bundles with the real `@breeze/extension-cli`
+ * (`__fixtures__/twoReplica.ts`, mirroring `packerConformance.test.ts`),
+ * forks two children per scenario against the SAME `extensions.yaml`, waits
+ * for both, then asserts against the shared `:5433` database.
+ *
+ * DB is migrated once by `globalSetup.ts` (autoMigrate) before any test file
+ * runs, so both children connect to an already-migrated schema. Never runs
+ * `test:docker:down`.
+ */
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const DATABASE_URL_APP =
+  process.env.DATABASE_URL_APP ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+const CHILD_JWT_SECRET = 'test-jwt-secret-for-two-replica-reconcile-min-32-chars';
+
+const CHILD_ENTRY_PATH = fileURLToPath(new URL('./__fixtures__/reconcileChild.ts', import.meta.url));
+
+interface ChildResult {
+  ok: boolean;
+  requiredAbort: boolean;
+  activated?: string[];
+  failed?: string[];
+  skipped?: string[];
+  extensionName?: string;
+  phase?: string;
+  error?: string;
+}
+
+interface ChildOutcome {
+  exitCode: number | null;
+  result: ChildResult | null;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Scan stdout BACKWARDS for the last line that parses as JSON. The
+ * reconciler and postgres.js both write plain `console.log` lines (e.g.
+ * `[extensions] reconciled "..."`, dotenv's `injected env` banner, NOTICE
+ * output) ahead of the child's single structured result line
+ * (`reconcileChild.ts`'s `emit`), so the LAST line is not a safe assumption —
+ * the last line that actually parses is.
+ */
+function parseChildResult(stdout: string): ChildResult | null {
+  const lines = stdout.split('\n').map((line) => line.trim()).filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    try {
+      return JSON.parse(line) as ChildResult;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/**
+ * Fork one replica: `reconcileChild.ts` under `tsx`'s `--import` loader hook
+ * (Node 22's native ESM `--import` registration — no build step needed for a
+ * `.ts` entry). `silent: true` pipes the child's stdout/stderr to this
+ * process instead of inheriting the parent's, so they can be captured and
+ * parsed rather than interleaving with Vitest's own output.
+ */
+function runChild(configPath: string, storeRoot: string, artifactsDir: string): Promise<ChildOutcome> {
+  return new Promise((resolve, reject) => {
+    const child = fork(CHILD_ENTRY_PATH, [configPath, storeRoot], {
+      execArgv: ['--import', 'tsx'],
+      env: {
+        ...process.env,
+        DATABASE_URL,
+        DATABASE_URL_APP,
+        NODE_ENV: 'test',
+        JWT_SECRET: CHILD_JWT_SECRET,
+        BREEZE_EXTENSIONS_ARTIFACTS_DIR: artifactsDir,
+      },
+      silent: true,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+    child.on('error', reject);
+    child.on('exit', (exitCode) => {
+      resolve({ exitCode, result: parseChildResult(stdout), stdout, stderr });
+    });
+  });
+}
+
+describe('two-replica reconcile and failure policy (issue #2619, exit criteria 2 & 3)', () => {
+  let admin: Sql;
+  let scratchRoot: string;
+
+  beforeAll(async () => {
+    admin = postgres(DATABASE_URL, { max: 4, onnotice: () => {} });
+    scratchRoot = await mkdtemp(join(tmpdir(), 'breeze-ext-two-replica-'));
+  });
+
+  /**
+   * Delete only rows/tables THIS test created, scoped by extension name —
+   * never a blanket wipe. `breeze_migrations` is shared with core
+   * migrations, so the filename filter is load-bearing (matches
+   * migrator.ts's `<name>/<file>` ledger namespacing).
+   */
+  async function resetExtensionState(names: readonly string[]): Promise<void> {
+    for (const name of names) {
+      await admin`DELETE FROM breeze_migrations WHERE filename LIKE ${`${name}/%`}`;
+      await admin`DELETE FROM extension_schema_history WHERE extension_name = ${name}`;
+      await admin`DELETE FROM installed_extensions WHERE name = ${name}`;
+      await admin.unsafe(`DROP TABLE IF EXISTS ${name}_x`);
+    }
+  }
+
+  afterAll(async () => {
+    if (admin) {
+      await resetExtensionState(ALL_FIXTURE_EXTENSION_NAMES);
+      await admin.end({ timeout: 5 });
+    }
+    if (scratchRoot) await rm(scratchRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  // See ALL_FIXTURE_EXTENSION_NAMES: reset every scenario's tables/rows before
+  // EVERY test (not just the current one's), so leftovers from an earlier
+  // scenario in this run — or a previous, interrupted run — can never read as
+  // "unaccounted" to a later scenario's tenancy tripwire check.
+  beforeEach(async () => {
+    await resetExtensionState(ALL_FIXTURE_EXTENSION_NAMES);
+  });
+
+  async function makeChildRoots(scenario: string, replica: 'a' | 'b') {
+    const artifactsDir = join(scratchRoot, scenario, `artifacts-${replica}`);
+    const storeRoot = join(scratchRoot, scenario, `store-${replica}`);
+    await mkdir(artifactsDir, { recursive: true });
+    await mkdir(storeRoot, { recursive: true });
+    return { artifactsDir, storeRoot };
+  }
+
+  /** Build a scenario's fixtures, fork two replicas against it, and return both outcomes. */
+  async function runScenario(
+    scenario: string,
+    specs: readonly FixtureExtensionSpec[],
+  ): Promise<[ChildOutcome, ChildOutcome]> {
+    const root = join(scratchRoot, scenario);
+    await mkdir(root, { recursive: true });
+    const fixture = await buildScenarioFixture(root, 'acme', specs);
+    const [rootA, rootB] = await Promise.all([
+      makeChildRoots(scenario, 'a'),
+      makeChildRoots(scenario, 'b'),
+    ]);
+    return Promise.all([
+      runChild(fixture.configPath, rootA.storeRoot, rootA.artifactsDir),
+      runChild(fixture.configPath, rootB.storeRoot, rootB.artifactsDir),
+    ]);
+  }
+
+  it('happy path: both replicas activate a required + optional extension; each migration applies exactly once', async () => {
+    const names = ['happyreq', 'happyopt'] as const;
+
+    const specs: FixtureExtensionSpec[] = [
+      {
+        name: 'happyreq',
+        required: true,
+        // No `IF NOT EXISTS`: a genuine second execution of this DDL would
+        // throw "relation already exists" — half of the exactly-once proof.
+        migrationSql: 'CREATE TABLE happyreq_x (id int NOT NULL);\n',
+        nonTenantTables: ['happyreq_x'],
+      },
+      {
+        name: 'happyopt',
+        required: false,
+        migrationSql: 'CREATE TABLE happyopt_x (id int NOT NULL);\n',
+        nonTenantTables: ['happyopt_x'],
+      },
+    ];
+
+    const [outcomeA, outcomeB] = await runScenario('happy', specs);
+
+    for (const [label, outcome] of [['A', outcomeA], ['B', outcomeB]] as const) {
+      expect(outcome.exitCode, `child ${label} did not exit 0 — stdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`).toBe(0);
+      expect(outcome.result?.ok, `child ${label} result: ${JSON.stringify(outcome.result)}`).toBe(true);
+      expect(outcome.result?.failed).toEqual([]);
+      // Both replicas converge on the SAME active set.
+      expect([...(outcome.result?.activated ?? [])].sort()).toEqual(['happyopt', 'happyreq']);
+    }
+
+    // Exactly-once, evidence 1: the ledger row count for each migration is
+    // exactly 1 — `recordMigration` is `ON CONFLICT (filename) DO NOTHING`
+    // (autoMigrate.ts), so a bare count of 1 alone can't distinguish "applied
+    // once" from "applied twice, second insert absorbed". Evidence 2 (below)
+    // closes that gap.
+    for (const name of names) {
+      const rows = await admin<{ n: number }[]>`
+        SELECT count(*)::int AS n FROM breeze_migrations WHERE filename = ${`${name}/0001_init.sql`}`;
+      expect(rows[0]?.n, `${name} ledger row count`).toBe(1);
+    }
+    // Exactly-once, evidence 2: the fixture migration is deliberately
+    // NON-IDEMPOTENT (CREATE TABLE with no IF NOT EXISTS). Both children
+    // reported ok:true with no failures above; had the migrator's
+    // advisory-lock + ledger-skip guard NOT serialized the two replicas, the
+    // second replica's raw DDL execution would have thrown "relation
+    // \"happyreq_x\" already exists" and that child would have reported a
+    // failure instead. A clean pass on both children IS the proof the second
+    // replica took the ledger-skip path, not a second real execution.
+
+    const stateRows = await admin<{ name: string; lifecycle_state: string }[]>`
+      SELECT name, lifecycle_state FROM installed_extensions WHERE name = ANY(${names as unknown as string[]})`;
+    const byName = Object.fromEntries(stateRows.map((row) => [row.name, row.lifecycle_state]));
+    expect(byName.happyreq).toBe('active');
+    expect(byName.happyopt).toBe('active');
+  });
+
+  it('required failure: a genuinely failing required extension aborts boot on both replicas', async () => {
+    const names = ['reqfail'] as const;
+
+    const specs: FixtureExtensionSpec[] = [
+      {
+        name: 'reqfail',
+        required: true,
+        // Genuinely failing DDL (a real NOT NULL constraint violation, not a
+        // stubbed error path): the whole file runs in one transaction, so
+        // this rolls back the CREATE TABLE too — no table, no ledger row.
+        migrationSql: 'CREATE TABLE reqfail_x (id int NOT NULL);\nINSERT INTO reqfail_x (id) VALUES (NULL);\n',
+        nonTenantTables: ['reqfail_x'],
+      },
+    ];
+
+    const [outcomeA, outcomeB] = await runScenario('reqfail', specs);
+
+    for (const [label, outcome] of [['A', outcomeA], ['B', outcomeB]] as const) {
+      expect(outcome.exitCode, `child ${label} — stdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`).toBe(1);
+      expect(outcome.result?.requiredAbort, `child ${label} result: ${JSON.stringify(outcome.result)}`).toBe(true);
+      expect(outcome.result?.extensionName).toBe('reqfail');
+      expect(outcome.result?.phase).toBe('migration');
+    }
+
+    // Atomic rollback: the failing file never committed, so its table was
+    // never created — by EITHER replica.
+    const tableRows = await admin<{ present: boolean }[]>`
+      SELECT EXISTS (
+        SELECT FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'reqfail_x'
+      ) AS present`;
+    expect(tableRows[0]?.present).toBe(false);
+
+    const ledgerRows = await admin<{ n: number }[]>`
+      SELECT count(*)::int AS n FROM breeze_migrations WHERE filename = 'reqfail/0001_init.sql'`;
+    expect(ledgerRows[0]?.n).toBe(0);
+
+    const stateRows = await admin<{ lifecycle_state: string }[]>`
+      SELECT lifecycle_state FROM installed_extensions WHERE name = 'reqfail'`;
+    expect(stateRows[0]?.lifecycle_state).toBe('failed');
+  });
+
+  it('optional failure: a genuinely failing optional extension is withdrawn while a co-installed healthy extension still activates on both replicas', async () => {
+    const names = ['optfail', 'optfailhealthy'] as const;
+
+    const specs: FixtureExtensionSpec[] = [
+      {
+        name: 'optfail',
+        required: false,
+        migrationSql: 'CREATE TABLE optfail_x (id int NOT NULL);\nINSERT INTO optfail_x (id) VALUES (NULL);\n',
+        nonTenantTables: ['optfail_x'],
+      },
+      {
+        name: 'optfailhealthy',
+        required: true,
+        migrationSql: 'CREATE TABLE optfailhealthy_x (id int NOT NULL);\n',
+        nonTenantTables: ['optfailhealthy_x'],
+      },
+    ];
+
+    const [outcomeA, outcomeB] = await runScenario('optfail', specs);
+
+    for (const [label, outcome] of [['A', outcomeA], ['B', outcomeB]] as const) {
+      // No throw, resolves, and boot continues: BOTH replicas keep booting.
+      expect(outcome.exitCode, `child ${label} — stdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`).toBe(0);
+      expect(outcome.result?.ok, `child ${label} result: ${JSON.stringify(outcome.result)}`).toBe(true);
+      expect(outcome.result?.failed).toEqual(['optfail']);
+      // The co-installed healthy extension still activates.
+      expect(outcome.result?.activated).toEqual(['optfailhealthy']);
+    }
+
+    const stateRows = await admin<{ name: string; lifecycle_state: string }[]>`
+      SELECT name, lifecycle_state FROM installed_extensions WHERE name = ANY(${names as unknown as string[]})`;
+    const byName = Object.fromEntries(stateRows.map((row) => [row.name, row.lifecycle_state]));
+    // recordSanitizedFailure maps a plain Error to 'failed' (not 'incompatible',
+    // which is reserved for ExtensionIncompatibleError — see reconciler.ts).
+    expect(byName.optfail).toBe('failed');
+    expect(byName.optfailhealthy).toBe('active');
+
+    const tableRows = await admin<{ present: boolean }[]>`
+      SELECT EXISTS (
+        SELECT FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'optfail_x'
+      ) AS present`;
+    expect(tableRows[0]?.present).toBe(false);
+  });
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -53,6 +53,11 @@ export default defineConfig({
       // the `src/__tests__/integration/**` glob above — so the no-DB unit runner would
       // fail it on connect. Belongs to vitest.integration.config.ts (already in its include).
       'src/jobs/authEmailWorker.integration.test.ts',
+      // Two-replica runtime extension reconcile + failure policy (Task 8,
+      // issue #2619): imports `__tests__/integration/setup` (real postgres
+      // pool) and forks real child processes against `:5433`. Belongs to
+      // vitest.integration.config.ts (already in its include).
+      'src/extensions/twoReplicaReconcile.integration.test.ts',
     ],
     setupFiles: ['src/__tests__/setup.ts'],
     coverage: {

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -78,6 +78,13 @@ export default defineConfig({
       // (and the unit runner's `src/__tests__/integration/**` exclude drops it);
       // named here for discoverability.
       'src/__tests__/integration/staleBackupReaper.integration.test.ts',
+      // Co-located real-DB integration test for the two-replica runtime
+      // extension reconcile + failure policy (Task 8, issue #2619). Forks two
+      // genuinely separate child processes against the real reconciler/
+      // migrator/state-store; needs the real, already-migrated :5433 database
+      // this config's globalSetup provides. Belongs here, not the unit
+      // runner (no DB, no child-process fork target).
+      'src/extensions/twoReplicaReconcile.integration.test.ts',
     ],
     exclude: [
       // Uses fresh request-pool modules and manages its own temporary role;

--- a/docs/superpowers/plans/2026-07-18-runtime-extension-platform-05-packer.md
+++ b/docs/superpowers/plans/2026-07-18-runtime-extension-platform-05-packer.md
@@ -438,15 +438,35 @@ git commit -m "feat(extensions): artifact inspection"
 
 **Exit criteria 2 and 3 of issue #2619.**
 
-- [ ] **Step 1: Build the two-replica harness**
+- [ ] **Step 1: Build the two-replica harness as two CHILD PROCESSES**
 
-Two independent reconciler instances against the same `:5433` database, each with its own artifact-store root and its own state-store connection, run concurrently. The harness must be able to (a) start both and await convergence, and (b) observe how many times each migration actually applied.
+**Do not attempt an in-process harness.** This was investigated before the task was written, and two `reconcileExtensions()` calls in one Node process are not two replicas. The reconciler's DI covers only the bundle/verify/migration path; these are hardwired process-global singletons that both "replicas" would silently share:
 
-Read `reconciler.ts`, `migrator.ts`, and `stateStore.ts` first and build the harness against their real seams. If those seams do not permit two genuinely independent instances in one process, report that as a BLOCKED finding rather than faking concurrency — a harness where both "replicas" share a lock manager proves nothing about advisory-lock serialization.
+| Shared state | Location |
+|---|---|
+| the single `postgres()` pool backing the state store and every extension `context.db` | `apps/api/src/db/index.ts:31`, consumed at `reconciler.ts:75,497` and `stateStore.ts:3` |
+| `DrizzleExtensionStateBackend` — no constructor seam to point at another pool | `stateStore.ts:188-338,341-343` |
+| `cache` and `runtimeTenancy[]` | `tenancyRegistry.ts:4,14` |
+| `extractedRoots` Map | `faultAttribution.ts:35` |
+| `skipPrefixes[]` | `middleware/globalRateLimit.ts:25` |
+
+Node's module cache makes a second copy of these unobtainable in-process. An in-process test would prove "one process reconciling twice" while claiming to prove replica convergence — precisely the false end-to-end guarantee issue #2619 exists to prevent.
+
+Instead: a small entry script that imports and runs `reconcileExtensions` against config supplied by environment, launched twice via `child_process.fork`. Each child gets genuinely separate `db` pools and registries, matching what actually differs between real replicas. Children report outcomes as JSON on stdout plus an exit code; the parent test asserts on both.
+
+Set `DATABASE_URL` and `DATABASE_URL_APP` to `:5433` in the child environment.
 
 - [ ] **Step 2: Write the happy-path two-replica test**
 
-One **required** and one **optional** signed extension, both packed and signed by the real CLI. Assert: both replicas activate both extensions; each migration is applied exactly once (advisory-lock serialized, verified against the migration ledger, not by counting log lines); both replicas converge on the same active set.
+One **required** and one **optional** signed extension, both packed and signed by the real CLI. Assert: both replicas activate both extensions; each migration is applied exactly once; both replicas converge on the same active set.
+
+**Exactly-once needs two pieces of evidence, not one.** The ledger is `breeze_migrations` (`autoMigrate.ts:18`, schema at `:300-305`), with extension rows namespaced `<extension>/<filename>` (`migrator.ts:196`). But `recordMigration` inserts `ON CONFLICT (filename) DO NOTHING` (`autoMigrate.ts:322-330`), so a row count of 1 cannot by itself distinguish "applied once" from "applied twice, second insert absorbed." Therefore:
+1. assert `SELECT count(*) FROM breeze_migrations WHERE filename = '<ext>/<file>'` is exactly 1, **and**
+2. make the fixture migration deliberately **non-idempotent** (`CREATE TABLE ...` with no `IF NOT EXISTS`) so a genuine second execution of the DDL throws.
+
+The existing `apps/api/src/__tests__/integration/extensionMigrator.integration.test.ts:149-194` uses exactly this pairing — follow it.
+
+The lock is session-scoped `pg_advisory_lock` (`migrator.ts:114,119`, rationale at `:25-37`), taken on a dedicated `sql.reserve()` connection (`migrator.ts:190-219`). Separate processes give separate sessions, so contention is real.
 
 - [ ] **Step 3: Write the failure-policy tests**
 
@@ -454,6 +474,11 @@ One **required** and one **optional** signed extension, both packed and signed b
 - A failing **optional** extension leaves **both** replicas booting, with the extension recorded failed and withdrawn from the active set.
 
 Induce failure through a genuinely failing extension (e.g. a migration that violates a constraint), not by stubbing the reconciler's error path.
+
+Observable outcomes, confirmed against the code (the branch is `reconciler.ts:657-674`):
+- Both paths first call `recordSanitizedFailure` (`reconciler.ts:658`, impl `:178-190`), setting `installed_extensions.lifecycle_state` to `'incompatible'` for an `ExtensionIncompatibleError` and `'failed'` otherwise. Full state set: `discovered | verified | migrated | active | disabled | failed | incompatible` (`db/schema/extensions.ts:18-26`). Both then `registry.withdraw(name)` and `clearExtensionRoot(name)` (`:659-660`).
+- **Optional**: no throw, loop continues (`:661-666`); extension appears in `summary.failed`.
+- **Required**: throws `RequiredExtensionError` (`:667-673`, class at `errors.ts:23-34` — it deliberately carries no `cause`, so do not assert on one). In production this reaches `bootstrap().catch` at `index.ts:1712-1714` → `process.exit(1)`. In the child-process harness, assert the **child's nonzero exit code**, which is the faithful analogue of aborted boot.
 
 - [ ] **Step 4: Run verification**
 

--- a/docs/superpowers/plans/2026-07-18-runtime-extension-platform-05-packer.md
+++ b/docs/superpowers/plans/2026-07-18-runtime-extension-platform-05-packer.md
@@ -1,0 +1,508 @@
+# `breeze-ext` Packer/Signer + Two-Replica Reconcile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the `breeze-ext` deterministic packer and Ed25519 signer that produces `.breeze-ext` bundles the already-shipped Plan 02 verifier accepts byte-exactly, then use real signed bundles to prove two-replica reconciliation and required/optional failure policy.
+
+**Scope note:** This plan implements the exit criteria of issue #2619. It corresponds to **Task 3 of the Plan 04 toolchain plan** (`2026-07-15-runtime-extension-platform-04-toolchain.md`), not to the Plan 05 Workspace plan — the issue's "Plan 05" label is a misnomer carried forward from PR #2617. Plan 04's other tasks (testkit, scaffolder, publish adapters, dev host, CI templates) are explicitly out of scope.
+
+**Architecture:** A new `@breeze/extension-cli` package owns artifact production: canonical JSON, deterministic ZIP, integrity inventory, Ed25519 signing, inspection. It has no dependency on `apps/api`. The wire-format conformance test lives in `apps/api` (which takes the CLI as a devDependency) so the dependency arrow points from app to package, and so the test exercises the genuine `verifyExtensionBundle`.
+
+**Tech Stack:** TypeScript 5.7, Node.js 22, Commander, Zod 4, Vitest 4, `archiver`, Ed25519 via `node:crypto`, PostgreSQL.
+
+**Base:** branch `feat/runtime-ext-05-packer`, cut from `feat/runtime-ext-02-operations` (PR #2617, unmerged). The verifier and reconciler this plan tests against exist only on that branch.
+
+---
+
+## Global Constraints
+
+- **`apps/api/src/extensions/bundleVerifier.ts` is FROZEN public surface.** The packer conforms to it. Do not modify it, and do not modify any Plan 02 verification behavior to accommodate the packer. If the packer cannot produce bytes it accepts, the packer is wrong.
+- Never log, persist, embed in an error message, or commit as a fixture: private key material, bundle bytes, config secrets, raw exceptions/stacks, or SQL. Private keys are read from a file path or an environment variable name and held only in memory.
+- No test fixture may contain a real private key committed to the repo. Generate keypairs at test runtime.
+- Determinism contract: identical source tree + identical `SOURCE_DATE_EPOCH` + identical lockfile ⇒ byte-identical artifact. Cross-library-version byte-identity is explicitly NOT promised (digests are re-pinned per release).
+- The CLI package must not import from `apps/api` or any Breeze-private app module.
+- `pnpm-workspace.yaml` already globs `packages/*`; no workspace change is needed.
+
+## Frozen Wire Format (transcribe exactly)
+
+Read `apps/api/src/extensions/bundleVerifier.ts` before implementing. Summary, authoritative values:
+
+**Archive:** ZIP. Reserved members are exactly `integrity.json` and `signature` (`bundleVerifier.ts:56`). Reserved members MUST NOT appear in the integrity inventory — the verifier throws if they do (`:208-212`).
+
+**`integrity.json`** — strict Zod, extra keys rejected at both object levels (`:181-190`):
+
+```json
+{
+  "algorithm": "sha256",
+  "members": {
+    "<archive-relative path>": { "sha256": "<64 lowercase hex>", "size": <non-negative int> }
+  }
+}
+```
+
+Every non-reserved archive member must appear, exactly 1:1 — the verifier checks both directions (`:273-291`). `manifest.json` is non-reserved and MUST be inventoried. `size` is the **uncompressed** byte length.
+
+**`signature`** — **raw Ed25519 signature bytes**, nothing else. Verified with `crypto.verify(null, payload, publicKey, signature)` (`:254-266`). It is NOT a JSON envelope; there is no keyId, algorithm, or payload-hash field. (Plan 04 Task 3 Step 5 describes an envelope; that text is stale and is corrected by Task 9 of this plan.)
+
+**Canonical signing payload** (`canonicalSigningPayload`, `:237-252`) — UTF-8 canonical JSON over exactly these five fields, no more:
+
+```
+apiVersion        // manifest.apiVersion
+name              // manifest.name
+version           // manifest.version
+manifestSha256    // sha256 hex of the raw manifest.json BYTES
+integritySha256   // sha256 hex of the raw integrity.json BYTES
+```
+
+`canonicalJson` (`:217-229`): object keys sorted by `Object.keys(...).sort()`, no whitespace, `JSON.stringify` for scalars and for key strings, arrays preserved in order. Hashes are **bare lowercase hex** — no `sha256:` prefix.
+
+Ordering is load-bearing: write `integrity.json` first, hash its bytes, then sign. The signature covers the integrity doc, which covers every payload member. There is no recursive archive hash.
+
+**Member name rules** (`assertSafeMemberName`, `:93-106`) — the packer must never emit a name that violates these:
+- no leading `/`, no backslash anywhere, no empty/`.`/`..` path segment (so no `./` prefix)
+- no name ending in `.node`
+- forward slashes only
+- no duplicate names (the verifier detects duplicates via central-directory count vs deduped map, `:137`)
+- no symlink entries (Unix mode `S_IFLNK` in the high 16 bits of external attributes, `:108-112`)
+
+**Archive limits** (`DEFAULT_ARCHIVE_LIMITS`, `:65-68`) — the packer must refuse to exceed: 10,000 members; 32 MiB per member; 128 MiB total uncompressed payload.
+
+**Digest forms — do not mix:**
+| Where | Form |
+|---|---|
+| `extensions.yaml` pinned digest, `VerifiedExtensionBundle.artifactDigest` | `sha256:<hex>` |
+| `integrity.json` member hashes, `breeze_migrations.checksum` | bare `<hex>` |
+| artifact store filename | `sha256-<hex>.breeze-ext` |
+
+## Verification Gates
+
+Every task that touches `packages/extension-cli`:
+```
+pnpm -F @breeze/extension-cli typecheck && pnpm -F @breeze/extension-cli test
+```
+
+Every task that touches `apps/api` (there is **no** `typecheck` script in `apps/api` — this is the real command):
+```
+NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit --project apps/api/tsconfig.json
+```
+
+Unit tests: `pnpm -F @breeze/api test:run <paths>`. Integration: `pnpm -F @breeze/api test:integration --run <paths>`.
+
+Integration DB is Docker Postgres on **:5433**. Set both `DATABASE_URL` and `DATABASE_URL_APP` to it — root `.env.test` sets neither and defaults to :5432. `pnpm -F @breeze/api test:docker:up` is idempotent. The `breeze-postgres-test` container is **shared across worktrees** — never run `test:docker:down -v`.
+
+---
+
+### Task 1: Create the `@breeze/extension-cli` package skeleton
+
+**Files:**
+- Create: `packages/extension-cli/package.json`
+- Create: `packages/extension-cli/tsconfig.json`
+- Create: `packages/extension-cli/vitest.config.ts`
+- Create: `packages/extension-cli/src/index.ts`
+- Create: `packages/extension-cli/src/cli.ts`
+- Create: `packages/extension-cli/src/cli.test.ts`
+
+**Interfaces:**
+- Produces: the `breeze-ext` binary entrypoint and the package's public module surface.
+
+- [ ] **Step 1: Write a failing CLI-surface test**
+
+Assert that the Commander program registers exactly the commands `validate`, `pack`, `sign`, `inspect`; that `--help` exits 0; and that importing `src/index.ts` performs no filesystem or network work at module load.
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `pnpm -F @breeze/extension-cli test --run src/cli.test.ts`
+
+Expected: FAIL because the package does not exist.
+
+- [ ] **Step 3: Create the package**
+
+Mirror `packages/extension-sdk/package.json` conventions: `"private": true`, `"type": "module"`, `main`/`types`/`exports` pointing at `./src/index.ts`, and `test` / `typecheck` scripts. Add a `"bin": { "breeze-ext": "./src/cli.ts" }`. Dependencies: `commander`, `zod`, `archiver`, `@breeze/extension-sdk` (workspace, for manifest parsing). Dev: `@types/archiver`, `@types/node`, `typescript`, `vitest`. Pin the same major versions the sibling packages already use.
+
+`tsconfig.json` mirrors `packages/extension-sdk/tsconfig.json`.
+
+- [ ] **Step 4: Wire the command skeletons**
+
+Each of the four commands is registered with its flags and a handler that delegates to a module in `src/commands/`. Subcommand bodies land in later tasks; this task only fixes the surface. `src/cli.ts` must not execute on import — guard the `program.parse()` behind a main-module check so tests can import it.
+
+- [ ] **Step 5: Run verification**
+
+Run: `pnpm install && pnpm -F @breeze/extension-cli typecheck && pnpm -F @breeze/extension-cli test`
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/extension-cli pnpm-lock.yaml
+git commit -m "feat(extensions): scaffold breeze-ext CLI package"
+```
+
+### Task 2: Canonical JSON and the integrity inventory
+
+**Files:**
+- Create: `packages/extension-cli/src/artifact/canonicalJson.ts`
+- Create: `packages/extension-cli/src/artifact/canonicalJson.test.ts`
+- Create: `packages/extension-cli/src/artifact/integrity.ts`
+- Create: `packages/extension-cli/src/artifact/integrity.test.ts`
+
+**Interfaces:**
+- Produces: `canonicalJson(value): string`, `buildIntegrityDocument(members): Buffer`, `signingPayload(manifest, manifestBytes, integrityBytes): Buffer`.
+
+- [ ] **Step 1: Write failing canonicalization tests**
+
+Cover: key sorting is bytewise via `Object.keys().sort()`; nested objects sort at every level; arrays preserve order; no whitespace anywhere; string keys and string values both go through `JSON.stringify` (so escaping matches); `null`, numbers, and booleans serialize as `JSON.stringify` does.
+
+Include a **drift guard**: a test that constructs a payload and asserts our `signingPayload` output is byte-identical to the verifier's exported `canonicalSigningPayload`. Because the CLI package may not import `apps/api`, express this in Task 2 as a locked-down golden-vector test (hard-coded expected bytes for a fixture manifest), and let Task 6's conformance test in `apps/api` do the live cross-check against the real export.
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pnpm -F @breeze/extension-cli test --run src/artifact`
+
+Expected: FAIL because the modules do not exist.
+
+- [ ] **Step 3: Implement `canonicalJson`**
+
+Transcribe the algorithm from `bundleVerifier.ts:217-229` exactly. Do not "improve" it — a divergence here silently produces unverifiable bundles.
+
+- [ ] **Step 4: Implement the integrity document builder**
+
+Input: an ordered list of `{ path, bytes }` payload members. Output: the `integrity.json` **bytes**.
+
+- Throw if any path is a reserved member (`integrity.json`, `signature`).
+- Throw if any path is duplicated.
+- `algorithm` is the literal `"sha256"`.
+- `members` maps path → `{ sha256: <bare lowercase hex>, size: <uncompressed byte length> }`.
+- Emit keys in sorted order and serialize via `canonicalJson` so the bytes are deterministic. The verifier's Zod schema is `.strict()` at both levels — emit no other keys.
+
+- [ ] **Step 5: Implement `signingPayload`**
+
+Exactly five fields, per the Frozen Wire Format section. Hashes bare hex. Return a UTF-8 `Buffer`.
+
+- [ ] **Step 6: Run verification**
+
+Run: `pnpm -F @breeze/extension-cli typecheck && pnpm -F @breeze/extension-cli test --run src/artifact`
+
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/extension-cli/src/artifact
+git commit -m "feat(extensions): canonical JSON and integrity inventory"
+```
+
+### Task 3: Deterministic ZIP writer
+
+**Files:**
+- Create: `packages/extension-cli/src/artifact/deterministicZip.ts`
+- Create: `packages/extension-cli/src/artifact/deterministicZip.test.ts`
+
+**Interfaces:**
+- Produces: `writeDeterministicZip(members: Array<{ path: string; bytes: Buffer }>, destination: string, options: { sourceDateEpoch: number }): Promise<void>`.
+
+- [ ] **Step 1: Write failing determinism and rejection tests**
+
+```ts
+it('packs identical inputs to identical bytes', async () => {
+  const first = await packToBuffer(MEMBERS, { sourceDateEpoch: 0 });
+  const second = await packToBuffer(MEMBERS, { sourceDateEpoch: 0 });
+  expect(sha256(first)).toBe(sha256(second));
+});
+
+it('is insensitive to input member order', async () => {
+  const forward = await packToBuffer(MEMBERS, { sourceDateEpoch: 0 });
+  const reversed = await packToBuffer([...MEMBERS].reverse(), { sourceDateEpoch: 0 });
+  expect(sha256(forward)).toBe(sha256(reversed));
+});
+```
+
+Also cover rejection of: absolute paths, `..` segments, `./` prefixes, backslashes, empty segments, `.node` suffixes, duplicate names, case-fold collisions (`Server/a.js` vs `server/a.js`), and each of the three archive limits (member count, per-member bytes, total bytes). Assert that a different `sourceDateEpoch` changes the bytes (proving the timestamp is actually applied, not ignored).
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pnpm -F @breeze/extension-cli test --run src/artifact/deterministicZip.test.ts`
+
+Expected: FAIL because the module does not exist.
+
+- [ ] **Step 3: Implement the writer**
+
+Use `archiver` in `zip` mode. Determinism requires pinning every varying field explicitly:
+
+- Add entries in **bytewise-sorted path order** (`Buffer.compare` on the UTF-8 bytes, not locale `localeCompare`).
+- Fixed `date` per entry, derived from `sourceDateEpoch` (seconds since epoch; default `0` when the env var is absent).
+- Fixed `mode`: `0o644` for files. Emit **no directory entries** — the verifier does not need them and they are one more source of drift.
+- Fixed `zlib: { level: 9 }`.
+- No symlink entries, ever.
+- Never emit a `.node` member.
+
+Validate every path against the member-name rules from the Frozen Wire Format section *before* writing anything, and enforce the archive limits, so a bad tree fails before an artifact exists.
+
+- [ ] **Step 4: Run verification**
+
+Run: `pnpm -F @breeze/extension-cli typecheck && pnpm -F @breeze/extension-cli test --run src/artifact`
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/extension-cli/src/artifact/deterministicZip.ts packages/extension-cli/src/artifact/deterministicZip.test.ts
+git commit -m "feat(extensions): deterministic zip writer"
+```
+
+### Task 4: `breeze-ext pack`
+
+**Files:**
+- Create: `packages/extension-cli/src/commands/pack.ts`
+- Create: `packages/extension-cli/src/commands/pack.test.ts`
+- Create: `packages/extension-cli/src/artifact/collectPayload.ts`
+- Create: `packages/extension-cli/src/artifact/collectPayload.test.ts`
+
+**Interfaces:**
+- Produces: `breeze-ext pack <sourceDir> --out <path>` and `packExtension(options): Promise<{ artifactPath: string; digest: string }>`.
+
+- [ ] **Step 1: Write failing pack tests**
+
+Cover: a fixture source tree packs to an archive containing `manifest.json`, `integrity.json`, the server entry, and migrations; `integrity.json` inventories every non-reserved member and nothing else; `manifest.json` IS inventoried; the manifest is parsed and rejected when invalid; the command refuses a source tree that already contains a file named `integrity.json` or `signature`; symlinks in the source tree are refused rather than followed; the output filename is `<name>-<version>.breeze-ext` when `--out` is a directory.
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pnpm -F @breeze/extension-cli test --run src/commands/pack.test.ts src/artifact/collectPayload.test.ts`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement payload collection**
+
+Walk the source directory. Use `lstat`, not `stat`, so symlinks are detected and refused instead of silently dereferenced. Normalize paths to forward slashes relative to the source root. Sort bytewise. Parse `manifest.json` through `parseExtensionManifestV1` from `@breeze/extension-sdk` and fail on any manifest the host would reject — packing an unverifiable bundle is a wasted release cycle.
+
+- [ ] **Step 4: Implement `pack`**
+
+Order is load-bearing:
+1. Collect payload members (manifest, server, optional web, optional migrations).
+2. Build `integrity.json` bytes over those members.
+3. Write the ZIP: payload members **plus** `integrity.json`, no `signature` yet.
+4. Print the artifact path and its `sha256:<hex>` digest.
+
+An unsigned artifact is a valid intermediate; `sign` completes it.
+
+- [ ] **Step 5: Run verification**
+
+Run: `pnpm -F @breeze/extension-cli typecheck && pnpm -F @breeze/extension-cli test`
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/extension-cli/src/commands/pack.ts packages/extension-cli/src/commands/pack.test.ts packages/extension-cli/src/artifact/collectPayload.ts packages/extension-cli/src/artifact/collectPayload.test.ts
+git commit -m "feat(extensions): deterministic bundle packing"
+```
+
+### Task 5: `breeze-ext sign`
+
+**Files:**
+- Create: `packages/extension-cli/src/artifact/signature.ts`
+- Create: `packages/extension-cli/src/artifact/signature.test.ts`
+- Create: `packages/extension-cli/src/commands/sign.ts`
+- Create: `packages/extension-cli/src/commands/sign.test.ts`
+
+**Interfaces:**
+- Produces: `breeze-ext sign <artifact> --key <path> | --key-env <VAR>` and `signArtifact(options): Promise<{ artifactPath: string; digest: string }>`.
+
+- [ ] **Step 1: Write failing signing tests**
+
+Cover: signing an unsigned artifact produces a `signature` member whose bytes verify under the matching public key via `crypto.verify(null, payload, publicKey, signature)`; a different keypair fails verification; a mutated `integrity.json` invalidates the signature; the `signature` member is raw bytes, not JSON; re-signing an already-signed artifact is refused (or replaces the member — pick one and test it); a non-Ed25519 key is rejected with a clear message.
+
+Add an explicit **secret-hygiene test**: capture stdout, stderr, and any thrown error from a failed signing run with a real (test-generated) private key, and assert none of them contain the key's PEM or raw bytes. Generate keypairs with `generateKeyPairSync('ed25519')` at test time; commit no key material.
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pnpm -F @breeze/extension-cli test --run src/artifact/signature.test.ts src/commands/sign.test.ts`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement signing**
+
+Read the private key from `--key <path>` or `--key-env <VAR>` (the variable *name*, never the key on the command line — argv is world-readable via `ps`). Load with `createPrivateKey`; reject any key whose `asymmetricKeyType` is not `ed25519`.
+
+Read `manifest.json` and `integrity.json` bytes back out of the packed artifact, rebuild the signing payload with the same `signingPayload` function `pack` used, and sign with `crypto.sign(null, payload, privateKey)`. Write the resulting **raw signature bytes** as the `signature` member.
+
+The artifact is rewritten deterministically through the same ZIP writer, with `signature` included as one more member. Print the final `sha256:<hex>` — this is the digest that goes in `extensions.yaml`, and it necessarily differs from the unsigned digest.
+
+Never place key material, key paths' contents, or raw crypto exceptions into logs or error messages.
+
+- [ ] **Step 4: Run verification**
+
+Run: `pnpm -F @breeze/extension-cli typecheck && pnpm -F @breeze/extension-cli test`
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/extension-cli/src/artifact/signature.ts packages/extension-cli/src/artifact/signature.test.ts packages/extension-cli/src/commands/sign.ts packages/extension-cli/src/commands/sign.test.ts
+git commit -m "feat(extensions): ed25519 bundle signing"
+```
+
+### Task 6: Wire-format conformance against the real verifier
+
+**Files:**
+- Create: `apps/api/src/extensions/packerConformance.test.ts`
+- Modify: `apps/api/package.json`
+
+**Interfaces:**
+- Consumes: `@breeze/extension-cli` (new devDependency of `apps/api`) and the frozen `verifyExtensionBundle`.
+
+**This is the load-bearing task — exit criterion 1 of issue #2619.**
+
+- [ ] **Step 1: Write the positive conformance test**
+
+Pack and sign a fixture extension with the real CLI, then run the real `verifyExtensionBundle` over the result with a matching `TrustedPublisher` and a pinned digest. Assert it resolves, and that `bundle.manifest.name`, `bundle.artifactDigest`, and `bundle.files` match what the packer reported.
+
+Also assert `signingPayload` from the CLI is byte-identical to `canonicalSigningPayload` from the verifier for the same inputs — the live drift guard Task 2 deferred here.
+
+- [ ] **Step 2: Write the negative conformance tests**
+
+Each must make `verifyExtensionBundle` **reject**:
+- a payload member's bytes mutated after signing
+- signed with a keypair the trust config does not list
+- an extra member added to the archive after signing (not in the inventory)
+- an inventoried member deleted from the archive
+- `integrity.json` mutated after signing
+- a reserved member added to the inventory
+- the pinned digest not matching the artifact
+- a `selection.version` that disagrees with the manifest
+
+- [ ] **Step 3: Prove the negative tests are load-bearing**
+
+For each negative case, temporarily neutralize the control it targets and confirm the test goes red; restore, and record the result in the task report. A security test that passes whether or not the control exists is worse than no test — it manufactures false confidence. Do not commit the neutralized state.
+
+- [ ] **Step 4: Run verification**
+
+Run: `pnpm -F @breeze/api test:run src/extensions/packerConformance.test.ts` and `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit --project apps/api/tsconfig.json`
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/extensions/packerConformance.test.ts apps/api/package.json pnpm-lock.yaml
+git commit -m "test(extensions): packer output verifies against the frozen verifier"
+```
+
+### Task 7: `breeze-ext inspect`
+
+**Files:**
+- Create: `packages/extension-cli/src/commands/inspect.ts`
+- Create: `packages/extension-cli/src/commands/inspect.test.ts`
+
+**Interfaces:**
+- Produces: `breeze-ext inspect <artifact> [--json]`.
+
+- [ ] **Step 1: Write failing inspection tests**
+
+Cover: `--json` reports artifact digest, manifest identity, signature validity, inventory validity, and the migration list; a tampered member is reported with a stable machine-readable code (`integrity_mismatch`); exit code is nonzero on any verification failure and zero on a clean artifact; human output contains no environment data, no absolute checkout paths, and no key material.
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pnpm -F @breeze/extension-cli test --run src/commands/inspect.test.ts`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement inspection**
+
+Inspection re-derives the inventory from the archive and compares. Signature validity is reported only when a public key is supplied (`--public-key`); with no key, report `signature: "unverified"` rather than implying validity. Do not reimplement the verifier's trust decisions — `inspect` is an author-side diagnostic, and it must never be presented as equivalent to host verification.
+
+- [ ] **Step 4: Run verification**
+
+Run: `pnpm -F @breeze/extension-cli typecheck && pnpm -F @breeze/extension-cli test`
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/extension-cli/src/commands/inspect.ts packages/extension-cli/src/commands/inspect.test.ts
+git commit -m "feat(extensions): artifact inspection"
+```
+
+### Task 8: Two-replica reconcile and failure policy
+
+**Files:**
+- Create: `apps/api/src/extensions/twoReplicaReconcile.integration.test.ts`
+- Create: `apps/api/src/extensions/__fixtures__/twoReplica.ts`
+
+**Interfaces:**
+- Consumes: the reconciler, migrator, state store, and artifact store from Plan 02; real signed bundles from Tasks 4–5.
+
+**Exit criteria 2 and 3 of issue #2619.**
+
+- [ ] **Step 1: Build the two-replica harness**
+
+Two independent reconciler instances against the same `:5433` database, each with its own artifact-store root and its own state-store connection, run concurrently. The harness must be able to (a) start both and await convergence, and (b) observe how many times each migration actually applied.
+
+Read `reconciler.ts`, `migrator.ts`, and `stateStore.ts` first and build the harness against their real seams. If those seams do not permit two genuinely independent instances in one process, report that as a BLOCKED finding rather than faking concurrency — a harness where both "replicas" share a lock manager proves nothing about advisory-lock serialization.
+
+- [ ] **Step 2: Write the happy-path two-replica test**
+
+One **required** and one **optional** signed extension, both packed and signed by the real CLI. Assert: both replicas activate both extensions; each migration is applied exactly once (advisory-lock serialized, verified against the migration ledger, not by counting log lines); both replicas converge on the same active set.
+
+- [ ] **Step 3: Write the failure-policy tests**
+
+- A failing **required** extension aborts boot on **both** replicas.
+- A failing **optional** extension leaves **both** replicas booting, with the extension recorded failed and withdrawn from the active set.
+
+Induce failure through a genuinely failing extension (e.g. a migration that violates a constraint), not by stubbing the reconciler's error path.
+
+- [ ] **Step 4: Run verification**
+
+Run:
+```
+pnpm -F @breeze/api test:docker:up
+DATABASE_URL=postgresql://...:5433/... DATABASE_URL_APP=postgresql://...:5433/... \
+  pnpm -F @breeze/api test:integration --run src/extensions/twoReplicaReconcile.integration.test.ts
+```
+and the `apps/api` typecheck command.
+
+Expected: all PASS. Do **not** run `test:docker:down -v`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/extensions/twoReplicaReconcile.integration.test.ts apps/api/src/extensions/__fixtures__/twoReplica.ts
+git commit -m "test(extensions): two-replica reconcile and failure policy"
+```
+
+### Task 9: Correct the stale Plan 04 signature spec
+
+**Repository:** `breeze-workspace` (a separate repo — commit there, not in Breeze).
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-15-runtime-extension-platform-04-toolchain.md`
+
+- [ ] **Step 1: Correct Task 3 Step 5**
+
+Replace the sentence describing a `signature` member containing "the key ID, algorithm, signature, and signing-payload SHA-256" with the shipped reality: the `signature` member is raw Ed25519 signature bytes over the canonical signing payload, and publisher/key selection comes from `extensions.yaml` trust configuration rather than from anything inside the artifact.
+
+- [ ] **Step 2: Note the plan-numbering correction**
+
+Add a line to the plan sequence in `2026-07-15-runtime-extension-platform-plan.md` noting that the packer/signer of Plan 04 Task 3 was delivered separately under issue #2619 and this plan file.
+
+- [ ] **Step 3: Commit in `breeze-workspace`**
+
+```bash
+git add docs/superpowers/plans
+git commit -m "docs: correct signature envelope spec to shipped raw-bytes format"
+```
+
+## Plan Verification
+
+- [ ] `pnpm -F @breeze/extension-cli typecheck && pnpm -F @breeze/extension-cli test` — all PASS.
+- [ ] `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit --project apps/api/tsconfig.json` — clean.
+- [ ] Bundles produced by `breeze-ext pack` + `sign` verify against an **unmodified** `verifyExtensionBundle` (Task 6).
+- [ ] Every negative conformance test is demonstrated to fail when its control is neutralized (Task 6 Step 3).
+- [ ] Two API replicas reconcile one required and one optional signed extension; migrations apply exactly once; both converge (Task 8).
+- [ ] A failing required extension aborts boot on both replicas; a failing optional one leaves both booting, recorded failed and withdrawn (Task 8).
+- [ ] `git diff` confirms `apps/api/src/extensions/bundleVerifier.ts` is unmodified on this branch.
+- [ ] No committed key material: `git log -p` over the branch contains no `PRIVATE KEY` block.

--- a/docs/superpowers/plans/2026-07-18-runtime-extension-platform-05-packer.md
+++ b/docs/superpowers/plans/2026-07-18-runtime-extension-platform-05-packer.md
@@ -454,7 +454,19 @@ Node's module cache makes a second copy of these unobtainable in-process. An in-
 
 Instead: a small entry script that imports and runs `reconcileExtensions` against config supplied by environment, launched twice via `child_process.fork`. Each child gets genuinely separate `db` pools and registries, matching what actually differs between real replicas. Children report outcomes as JSON on stdout plus an exit code; the parent test asserts on both.
 
-Set `DATABASE_URL` and `DATABASE_URL_APP` to `:5433` in the child environment.
+**A full seam map with file:line for every call is at `.superpowers/sdd/task-8-seams.md` — READ IT FIRST.** The load-bearing facts distilled:
+
+- **Parent = the vitest integration test** (runs under `vitest.integration.config.ts`, so `globalSetup` migrates `:5433` once and both forked children connect to the already-migrated shared DB). The parent authors all fixtures (pack+sign via the real CLI, writes `extensions.yaml` + the PEM public key), forks the children, then queries the DB for convergence. Never `test:docker:down -v`.
+
+- **Child entry = the smallest faithful thing: call `reconcileExtensions` DIRECTLY.** No `index.ts` bootstrap, HTTP server, workers, or seeds. It rejects with `RequiredExtensionError` on a required failure (child exits nonzero — the faithful "aborts boot") and resolves with `summary.failed` on an optional failure. Args: `app: new Hono()` (declared but never read by the reconciler), `configPath` (absolute path to the test `extensions.yaml`), `storeRoot` (a tmp extraction dir), `registry: new ExtensionContributionRegistry()`, `stateStore: createExtensionStateStore()` (the REAL Drizzle backend — not the in-memory fake). Do NOT pass `ports`.
+
+- **Env MUST be set before the child imports any `apps/api` module** (the `db` pool opens at import time): `DATABASE_URL` and `DATABASE_URL_APP` → `:5433`, `NODE_ENV=test`, `JWT_SECRET=<32+ chars>`, and `BREEZE_EXTENSIONS_ARTIFACTS_DIR=<tmp>`. Pass them via `fork`'s `env` option.
+
+- **Two DISTINCT roots — do not conflate:** `BREEZE_EXTENSIONS_ARTIFACTS_DIR` (env) is the fetched-bundle cache; `args.storeRoot` is the extraction tree (`<storeRoot>/extracted/...`). Make them sibling tmp dirs per child.
+
+- **Selection `uri` = `pathToFileURL(absSignedBundlePath).href`** (only `file:`/`https:` allowed). Pin `digest: signResult.digest`.
+
+- **TENANCY TRIPWIRE — this silently fails the happy path if ignored.** The `'tenancy'` reconcile phase (`reconciler.ts:636-637`) runs `assertNoUnaccountedPublicTables`; a fixture migration that creates a plain new `public` table fails BOTH extensions regardless of the required/optional scenario. Fixture rule: name any created table `<extensionName>_...` AND declare it in the manifest's `tenancy.nonTenantTables` with no tenant column/FK. Build the happy-path fixture this way from the start, or the "both activate" assertion will never pass and you'll misdiagnose it as a harness bug.
 
 - [ ] **Step 2: Write the happy-path two-replica test**
 

--- a/packages/extension-cli/package.json
+++ b/packages/extension-cli/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@types/archiver": "^7.0.0",
     "@types/node": "^25.9.3",
+    "node-stream-zip": "^1.15.0",
     "typescript": "^5.7.2",
     "vitest": "^4.1.9"
   }

--- a/packages/extension-cli/package.json
+++ b/packages/extension-cli/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@breeze/extension-cli",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": { ".": "./src/index.ts" },
+  "bin": { "breeze-ext": "./src/cli.ts" },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@breeze/extension-sdk": "workspace:*",
+    "archiver": "^7.0.1",
+    "commander": "^15.0.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/archiver": "^7.0.0",
+    "@types/node": "^25.9.3",
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/extension-cli/src/artifact/canonicalJson.test.ts
+++ b/packages/extension-cli/src/artifact/canonicalJson.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalJson } from './canonicalJson';
+
+describe('canonicalJson', () => {
+  it('sorts object keys bytewise via Object.keys().sort()', () => {
+    expect(canonicalJson({ b: 1, a: 2, c: 3 })).toBe('{"a":2,"b":1,"c":3}');
+  });
+
+  it('sorts keys bytewise, not locale-aware (uppercase before lowercase)', () => {
+    // "B" (0x42) sorts before "a" (0x61) in default Array.sort, unlike a
+    // locale-aware collation which would put "a" first.
+    expect(canonicalJson({ a: 1, B: 2 })).toBe('{"B":2,"a":1}');
+  });
+
+  it('sorts nested objects at every level', () => {
+    const value = { z: { d: 1, c: 2 }, a: { y: 1, x: 2 } };
+    expect(canonicalJson(value)).toBe('{"a":{"x":2,"y":1},"z":{"c":2,"d":1}}');
+  });
+
+  it('preserves array order without sorting elements', () => {
+    expect(canonicalJson([3, 1, 2])).toBe('[3,1,2]');
+  });
+
+  it('recurses into objects nested inside arrays', () => {
+    expect(canonicalJson([{ b: 1, a: 2 }])).toBe('[{"a":2,"b":1}]');
+  });
+
+  it('emits no whitespace anywhere', () => {
+    const value = { a: [1, 2, { b: 'x' }], c: { d: null } };
+    expect(canonicalJson(value)).not.toMatch(/\s/);
+  });
+
+  it('serializes string keys and string values via JSON.stringify so escaping matches', () => {
+    const value = { 'a"b': 'c\nd', 'e\\f': 'g\tunicode: é' };
+    expect(canonicalJson(value)).toBe(
+      `{${JSON.stringify('a"b')}:${JSON.stringify('c\nd')},${JSON.stringify('e\\f')}:${JSON.stringify('g\tunicode: é')}}`,
+    );
+  });
+
+  it('serializes null, numbers, and booleans exactly as JSON.stringify does', () => {
+    expect(canonicalJson(null)).toBe('null');
+    expect(canonicalJson(42)).toBe('42');
+    expect(canonicalJson(3.14)).toBe('3.14');
+    expect(canonicalJson(true)).toBe('true');
+    expect(canonicalJson(false)).toBe('false');
+  });
+
+  it('serializes an empty object and empty array', () => {
+    expect(canonicalJson({})).toBe('{}');
+    expect(canonicalJson([])).toBe('[]');
+  });
+});

--- a/packages/extension-cli/src/artifact/canonicalJson.ts
+++ b/packages/extension-cli/src/artifact/canonicalJson.ts
@@ -1,0 +1,21 @@
+/**
+ * Deterministic, key-sorted JSON so the signer and the frozen verifier agree
+ * byte-for-byte.
+ *
+ * This is a verbatim transcription of
+ * `apps/api/src/extensions/bundleVerifier.ts:217-229`. Do not "improve" it —
+ * any divergence here silently produces bundles the verifier cannot accept.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(',')}]`;
+  }
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  const entries = keys.map(
+    (key) => `${JSON.stringify(key)}:${canonicalJson((value as Record<string, unknown>)[key])}`,
+  );
+  return `{${entries.join(',')}}`;
+}

--- a/packages/extension-cli/src/artifact/collectPayload.test.ts
+++ b/packages/extension-cli/src/artifact/collectPayload.test.ts
@@ -1,0 +1,98 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { collectPayload } from './collectPayload';
+
+const VALID_MANIFEST = {
+  apiVersion: 'breeze.extensions/v1',
+  name: 'acme-widgets',
+  version: '1.0.0',
+  routeNamespace: 'acme-widgets',
+  requires: { breeze: '>=0.1.0 <0.2.0', serverSdk: '^1.0.0', capabilities: [] },
+  server: { entry: 'server/index.js' },
+  schemaCompatibilityFloor: '1.0.0',
+  jobs: [],
+  aiTools: [],
+};
+
+let sourceDir: string;
+
+beforeEach(async () => {
+  sourceDir = await mkdtemp(join(tmpdir(), 'breeze-ext-collect-'));
+});
+
+afterEach(async () => {
+  await rm(sourceDir, { recursive: true, force: true });
+});
+
+async function writeFixture(relPath: string, contents: string | object): Promise<void> {
+  const fullPath = join(sourceDir, ...relPath.split('/'));
+  await mkdir(join(fullPath, '..'), { recursive: true });
+  const body = typeof contents === 'string' ? contents : JSON.stringify(contents);
+  await writeFile(fullPath, body);
+}
+
+async function writeValidFixtureTree(): Promise<void> {
+  await writeFixture('manifest.json', VALID_MANIFEST);
+  await writeFixture('server/index.js', 'module.exports = () => {};');
+  await writeFixture('migrations/0001_init.sql', 'select 1;');
+}
+
+describe('collectPayload', () => {
+  it('collects every file as a forward-slash relative path, sorted bytewise', async () => {
+    await writeValidFixtureTree();
+
+    const members = await collectPayload(sourceDir);
+
+    expect(members.map((m) => m.path)).toEqual([
+      'manifest.json',
+      'migrations/0001_init.sql',
+      'server/index.js',
+    ]);
+  });
+
+  it('includes manifest.json in the returned members', async () => {
+    await writeValidFixtureTree();
+
+    const members = await collectPayload(sourceDir);
+    const manifestMember = members.find((m) => m.path === 'manifest.json');
+
+    expect(manifestMember).toBeDefined();
+    expect(manifestMember?.bytes.toString('utf8')).toBe(JSON.stringify(VALID_MANIFEST));
+  });
+
+  it('rejects a manifest.json that fails schema validation', async () => {
+    await writeFixture('manifest.json', { ...VALID_MANIFEST, apiVersion: 'breeze.extensions/v2' });
+    await writeFixture('server/index.js', 'module.exports = () => {};');
+
+    await expect(collectPayload(sourceDir)).rejects.toThrow();
+  });
+
+  it('refuses a source tree containing a reserved member "integrity.json"', async () => {
+    await writeValidFixtureTree();
+    await writeFixture('integrity.json', '{}');
+
+    await expect(collectPayload(sourceDir)).rejects.toThrow(/reserved member "integrity\.json"/);
+  });
+
+  it('refuses a source tree containing a reserved member "signature"', async () => {
+    await writeValidFixtureTree();
+    await writeFixture('signature', 'sig-bytes');
+
+    await expect(collectPayload(sourceDir)).rejects.toThrow(/reserved member "signature"/);
+  });
+
+  it('refuses a symlink instead of following it', async () => {
+    await writeValidFixtureTree();
+    await symlink(join(sourceDir, 'server/index.js'), join(sourceDir, 'server/linked.js'));
+
+    await expect(collectPayload(sourceDir)).rejects.toThrow(/symlink/);
+  });
+
+  it('rejects a source tree missing manifest.json', async () => {
+    await writeFixture('server/index.js', 'module.exports = () => {};');
+
+    await expect(collectPayload(sourceDir)).rejects.toThrow(/manifest\.json/);
+  });
+});

--- a/packages/extension-cli/src/artifact/collectPayload.ts
+++ b/packages/extension-cli/src/artifact/collectPayload.ts
@@ -1,0 +1,96 @@
+import { lstat, readdir, readFile } from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
+import { parseExtensionManifestV1 } from '@breeze/extension-sdk';
+import { RESERVED_MEMBERS } from './integrity';
+
+/** A single collected payload member: a source-relative path and its raw bytes. */
+export interface PayloadMember {
+  path: string;
+  bytes: Buffer;
+}
+
+function toPosixPath(rawPath: string): string {
+  return rawPath.split(sep).join('/');
+}
+
+/**
+ * Bytewise comparison of UTF-8 path bytes, matching
+ * `writeDeterministicZip`'s own sort so the integrity document and the
+ * archive agree on member order.
+ */
+function compareBytewise(a: string, b: string): number {
+  return Buffer.compare(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'));
+}
+
+/**
+ * Recursively walk `dir`, appending every regular file found to `out` as a
+ * root-relative, forward-slash path. Uses `lstat` (never `stat`) on every
+ * entry so a symlink is detected and refused rather than silently
+ * dereferenced — a followed symlink could pull arbitrary bytes outside the
+ * source tree into a signed bundle.
+ */
+async function walk(dir: string, root: string, out: PayloadMember[]): Promise<void> {
+  const entryNames = await readdir(dir);
+  for (const name of entryNames) {
+    const fullPath = join(dir, name);
+    const info = await lstat(fullPath);
+    const relPath = toPosixPath(relative(root, fullPath));
+
+    if (info.isSymbolicLink()) {
+      throw new Error(`collectPayload: refusing to follow symlink at "${relPath}"`);
+    }
+    if (info.isDirectory()) {
+      await walk(fullPath, root, out);
+      continue;
+    }
+    if (!info.isFile()) {
+      throw new Error(`collectPayload: unsupported file type at "${relPath}"`);
+    }
+
+    out.push({ path: relPath, bytes: await readFile(fullPath) });
+  }
+}
+
+/**
+ * Collect an extension source directory into sorted payload members, ready
+ * to be inventoried (`buildIntegrityDocument`) and archived
+ * (`writeDeterministicZip`).
+ *
+ * Refuses (throws, writes nothing): symlinks anywhere in the tree; a source
+ * tree that already contains a file named `integrity.json` or `signature`
+ * (those are reserved, generated during packing — never carried in from
+ * source); a missing or schema-invalid `manifest.json`. `manifest.json`
+ * itself IS included in the returned members — it is a normal payload
+ * member and must be inventoried like any other.
+ */
+export async function collectPayload(sourceDir: string): Promise<PayloadMember[]> {
+  const members: PayloadMember[] = [];
+  await walk(sourceDir, sourceDir, members);
+  members.sort((a, b) => compareBytewise(a.path, b.path));
+
+  for (const member of members) {
+    if (RESERVED_MEMBERS.has(member.path)) {
+      throw new Error(
+        `collectPayload: source tree contains reserved member "${member.path}"; `
+          + 'this file is generated during packing and must not be part of the source tree',
+      );
+    }
+  }
+
+  const manifestMember = members.find((member) => member.path === 'manifest.json');
+  if (!manifestMember) {
+    throw new Error('collectPayload: source tree is missing required "manifest.json"');
+  }
+
+  let manifestJson: unknown;
+  try {
+    manifestJson = JSON.parse(manifestMember.bytes.toString('utf8'));
+  } catch {
+    throw new Error('collectPayload: manifest.json is not valid JSON');
+  }
+  // Throws with a schema-validation message on any manifest the host would
+  // reject — packing a bundle the verifier can't accept is a wasted release.
+  parseExtensionManifestV1(manifestJson);
+
+  return members;
+}

--- a/packages/extension-cli/src/artifact/deterministicZip.test.ts
+++ b/packages/extension-cli/src/artifact/deterministicZip.test.ts
@@ -61,6 +61,29 @@ describe('writeDeterministicZip: determinism', () => {
   });
 });
 
+describe('writeDeterministicZip: output stream errors', () => {
+  it('rejects (does not crash the process) when the output directory does not exist', async () => {
+    // A missing --out directory makes createWriteStream emit ENOENT. The error
+    // must surface as a rejection of THIS promise — never as an orphaned
+    // unhandled rejection, which Node's default --unhandled-rejections=throw
+    // turns into a hard process crash that the CLI's top-level catch can't see.
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => { unhandled.push(reason); };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const missing = join(workDir, 'does', 'not', 'exist', 'out.zip');
+      await expect(
+        writeDeterministicZip(MEMBERS, missing, { sourceDateEpoch: 0 }),
+      ).rejects.toThrow();
+      // Give any orphaned rejection a tick to surface before asserting.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+});
+
 describe('writeDeterministicZip: path safety', () => {
   async function expectRejected(members: DeterministicZipMember[]): Promise<string> {
     const destination = destinationPath();

--- a/packages/extension-cli/src/artifact/deterministicZip.test.ts
+++ b/packages/extension-cli/src/artifact/deterministicZip.test.ts
@@ -1,0 +1,145 @@
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { writeDeterministicZip, type DeterministicZipMember } from './deterministicZip';
+
+function sha256(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+let workDir: string;
+let counter = 0;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), 'breeze-ext-zip-'));
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+function destinationPath(): string {
+  counter += 1;
+  return join(workDir, `out-${counter}.zip`);
+}
+
+async function packToBuffer(
+  members: DeterministicZipMember[],
+  options: { sourceDateEpoch: number },
+): Promise<Buffer> {
+  const destination = destinationPath();
+  await writeDeterministicZip(members, destination, options);
+  return readFile(destination);
+}
+
+const MEMBERS: DeterministicZipMember[] = [
+  { path: 'manifest.json', bytes: Buffer.from('{"name":"acme-widgets"}') },
+  { path: 'server/index.js', bytes: Buffer.from('module.exports = () => {};') },
+  { path: 'assets/logo.png', bytes: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]) },
+];
+
+describe('writeDeterministicZip: determinism', () => {
+  it('packs identical inputs to identical bytes', async () => {
+    const first = await packToBuffer(MEMBERS, { sourceDateEpoch: 0 });
+    const second = await packToBuffer(MEMBERS, { sourceDateEpoch: 0 });
+    expect(sha256(first)).toBe(sha256(second));
+  });
+
+  it('is insensitive to input member order', async () => {
+    const forward = await packToBuffer(MEMBERS, { sourceDateEpoch: 0 });
+    const reversed = await packToBuffer([...MEMBERS].reverse(), { sourceDateEpoch: 0 });
+    expect(sha256(forward)).toBe(sha256(reversed));
+  });
+
+  it('changes bytes when sourceDateEpoch differs', async () => {
+    const epochA = await packToBuffer(MEMBERS, { sourceDateEpoch: 1_000_000_000 });
+    const epochB = await packToBuffer(MEMBERS, { sourceDateEpoch: 1_700_000_000 });
+    expect(sha256(epochA)).not.toBe(sha256(epochB));
+  });
+});
+
+describe('writeDeterministicZip: path safety', () => {
+  async function expectRejected(members: DeterministicZipMember[]): Promise<string> {
+    const destination = destinationPath();
+    await expect(writeDeterministicZip(members, destination, { sourceDateEpoch: 0 })).rejects.toThrow();
+    return destination;
+  }
+
+  it('rejects an absolute path', async () => {
+    await expectRejected([{ path: '/etc/passwd', bytes: Buffer.from('x') }]);
+  });
+
+  it('rejects a path with a ".." segment', async () => {
+    await expectRejected([{ path: '../escape.txt', bytes: Buffer.from('x') }]);
+  });
+
+  it('rejects a path with a "./" prefix', async () => {
+    await expectRejected([{ path: './sneaky.txt', bytes: Buffer.from('x') }]);
+  });
+
+  it('rejects a path containing a backslash', async () => {
+    await expectRejected([{ path: 'server\\index.js', bytes: Buffer.from('x') }]);
+  });
+
+  it('rejects a path with an empty segment', async () => {
+    await expectRejected([{ path: 'server//index.js', bytes: Buffer.from('x') }]);
+  });
+
+  it('rejects a member ending in .node', async () => {
+    await expectRejected([{ path: 'native/addon.node', bytes: Buffer.from('x') }]);
+  });
+
+  it('rejects a duplicate member name', async () => {
+    await expectRejected([
+      { path: 'a.txt', bytes: Buffer.from('one') },
+      { path: 'a.txt', bytes: Buffer.from('two') },
+    ]);
+  });
+
+  it('rejects a case-fold collision', async () => {
+    await expectRejected([
+      { path: 'Server/a.js', bytes: Buffer.from('one') },
+      { path: 'server/a.js', bytes: Buffer.from('two') },
+    ]);
+  });
+
+  it('does not write a partial artifact when rejecting a bad path', async () => {
+    const destination = await expectRejected([{ path: '/etc/passwd', bytes: Buffer.from('x') }]);
+    expect(existsSync(destination)).toBe(false);
+  });
+});
+
+describe('writeDeterministicZip: archive limits', () => {
+  it('rejects more than 10,000 members', async () => {
+    const members: DeterministicZipMember[] = Array.from({ length: 10_001 }, (_, i) => ({
+      path: `f${i}.txt`,
+      bytes: Buffer.from('x'),
+    }));
+    const destination = destinationPath();
+    await expect(writeDeterministicZip(members, destination, { sourceDateEpoch: 0 })).rejects.toThrow();
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  it('rejects a member larger than 32 MiB', async () => {
+    const destination = destinationPath();
+    const oversized = Buffer.alloc(32 * 1024 * 1024 + 1);
+    await expect(
+      writeDeterministicZip([{ path: 'big.bin', bytes: oversized }], destination, { sourceDateEpoch: 0 }),
+    ).rejects.toThrow();
+    expect(existsSync(destination)).toBe(false);
+  }, 30_000);
+
+  it('rejects a total payload larger than 128 MiB', async () => {
+    const destination = destinationPath();
+    const chunk = Buffer.alloc(27 * 1024 * 1024); // under the per-member cap
+    const members: DeterministicZipMember[] = Array.from({ length: 5 }, (_, i) => ({
+      path: `chunk${i}.bin`,
+      bytes: chunk,
+    })); // 5 * 27 MiB = 135 MiB total, over the 128 MiB cap
+    await expect(writeDeterministicZip(members, destination, { sourceDateEpoch: 0 })).rejects.toThrow();
+    expect(existsSync(destination)).toBe(false);
+  }, 30_000);
+});

--- a/packages/extension-cli/src/artifact/deterministicZip.ts
+++ b/packages/extension-cli/src/artifact/deterministicZip.ts
@@ -83,6 +83,9 @@ function validateMembers(members: readonly DeterministicZipMember[]): void {
     }
     seenExact.add(member.path);
 
+    // toLowerCase (NOT toLocaleLowerCase): case folding here must be
+    // locale-independent so the same member set is accepted or rejected
+    // identically on every machine, matching the determinism contract.
     const folded = member.path.toLowerCase();
     if (seenCaseFold.has(folded)) {
       throw new Error(`deterministic zip rejected: case-fold collision for member path "${member.path}"`);
@@ -149,6 +152,12 @@ export async function writeDeterministicZip(
     });
   }
 
-  await archive.finalize();
-  await finished;
+  // Await BOTH promises together. If we awaited `finalize()` first and it
+  // rejected (e.g. the output stream failed with ENOENT on a missing --out
+  // directory), `finished` — which also rejects on that same stream error —
+  // would be left with no awaiter: an orphaned unhandled rejection that Node's
+  // default --unhandled-rejections=throw turns into a hard process crash the
+  // CLI's top-level catch never sees. Promise.all attaches a handler to both
+  // up front, so either failure surfaces as a clean rejection of this call.
+  await Promise.all([archive.finalize(), finished]);
 }

--- a/packages/extension-cli/src/artifact/deterministicZip.ts
+++ b/packages/extension-cli/src/artifact/deterministicZip.ts
@@ -1,0 +1,154 @@
+import { createWriteStream } from 'node:fs';
+import archiver from 'archiver';
+
+/**
+ * A single payload member to pack into a `.breeze-ext` archive: a safe
+ * relative path plus its raw bytes.
+ */
+export interface DeterministicZipMember {
+  path: string;
+  bytes: Buffer;
+}
+
+export interface WriteDeterministicZipOptions {
+  /** Seconds since the Unix epoch. Pinned into every entry's timestamp. */
+  sourceDateEpoch: number;
+}
+
+/**
+ * Archive limits, duplicated (not imported) from
+ * `apps/api/src/extensions/bundleVerifier.ts` (`DEFAULT_ARCHIVE_LIMITS`).
+ * This package must not import from `apps/api`; a conformance test in a
+ * later task cross-checks these values against the real verifier export.
+ */
+const MAX_MEMBERS = 10_000;
+const MAX_MEMBER_BYTES = 32 * 1024 * 1024; // 32 MiB per member
+const MAX_TOTAL_BYTES = 128 * 1024 * 1024; // 128 MiB total payload
+
+/** Fixed unix mode for every file entry. No directory entries are ever emitted. */
+const FILE_MODE = 0o644;
+
+/**
+ * Reject any member path that is not a safe forward-relative path, mirroring
+ * `assertSafeMemberName` in `apps/api/src/extensions/bundleVerifier.ts`:
+ * no absolute paths, no backslashes, no `.`/`..`/empty segments (which also
+ * catches a `./` prefix and any doubled `//`), and no `.node` suffix.
+ */
+function assertSafeMemberPath(rawPath: string): void {
+  if (rawPath === '') {
+    throw new Error('deterministic zip rejected: empty member path');
+  }
+  if (rawPath.startsWith('/')) {
+    throw new Error(`deterministic zip rejected: absolute member path "${rawPath}"`);
+  }
+  if (rawPath.includes('\\')) {
+    throw new Error(`deterministic zip rejected: backslash in member path "${rawPath}"`);
+  }
+  for (const segment of rawPath.split('/')) {
+    if (segment === '' || segment === '.' || segment === '..') {
+      throw new Error(`deterministic zip rejected: unsafe path segment in "${rawPath}"`);
+    }
+  }
+  if (rawPath.endsWith('.node')) {
+    throw new Error(`deterministic zip rejected: native .node member "${rawPath}"`);
+  }
+}
+
+/**
+ * Validate every member up front — path safety, duplicate/case-fold
+ * collisions, and the three archive limits — so a bad tree is rejected
+ * before any bytes are written to disk.
+ */
+function validateMembers(members: readonly DeterministicZipMember[]): void {
+  if (members.length > MAX_MEMBERS) {
+    throw new Error(`deterministic zip rejected: too many members (>${MAX_MEMBERS})`);
+  }
+
+  const seenExact = new Set<string>();
+  const seenCaseFold = new Set<string>();
+  let totalBytes = 0;
+
+  for (const member of members) {
+    assertSafeMemberPath(member.path);
+
+    if (member.bytes.length > MAX_MEMBER_BYTES) {
+      throw new Error(
+        `deterministic zip rejected: member "${member.path}" exceeds ${MAX_MEMBER_BYTES} bytes`,
+      );
+    }
+    totalBytes += member.bytes.length;
+
+    if (seenExact.has(member.path)) {
+      throw new Error(`deterministic zip rejected: duplicate member path "${member.path}"`);
+    }
+    seenExact.add(member.path);
+
+    const folded = member.path.toLowerCase();
+    if (seenCaseFold.has(folded)) {
+      throw new Error(`deterministic zip rejected: case-fold collision for member path "${member.path}"`);
+    }
+    seenCaseFold.add(folded);
+  }
+
+  if (totalBytes > MAX_TOTAL_BYTES) {
+    throw new Error(`deterministic zip rejected: total payload exceeds ${MAX_TOTAL_BYTES} bytes`);
+  }
+}
+
+/**
+ * Bytewise comparison of UTF-8 path bytes. Deliberately NOT `localeCompare`
+ * — locale-aware sorting is non-deterministic across environments/locales,
+ * and archive byte order must be pinned.
+ */
+function compareBytewise(a: string, b: string): number {
+  return Buffer.compare(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'));
+}
+
+/**
+ * Write a `.breeze-ext` payload as a deterministic ZIP archive: identical
+ * `members` always produce byte-identical output, regardless of input order
+ * or the host environment (locale, timezone, platform). Every field archiver
+ * could otherwise vary is pinned: bytewise-sorted entry order, a fixed
+ * per-entry date derived from `sourceDateEpoch`, fixed unix file mode, no
+ * directory entries, and fixed zlib level 9 compression.
+ *
+ * Rejects (before writing anything to disk) unsafe member paths, `.node`
+ * members, duplicate or case-folded-colliding names, and archives that
+ * exceed the member-count, per-member-size, or total-size limits enforced
+ * by the frozen verifier (`apps/api/src/extensions/bundleVerifier.ts`).
+ */
+export async function writeDeterministicZip(
+  members: DeterministicZipMember[],
+  destination: string,
+  options: WriteDeterministicZipOptions,
+): Promise<void> {
+  validateMembers(members);
+
+  const sortedMembers = [...members].sort((a, b) => compareBytewise(a.path, b.path));
+  const entryDate = new Date(options.sourceDateEpoch * 1000);
+
+  const output = createWriteStream(destination);
+  const archive = archiver('zip', { zlib: { level: 9 } });
+
+  const finished = new Promise<void>((resolve, reject) => {
+    output.on('close', resolve);
+    output.on('error', reject);
+    archive.on('error', reject);
+    archive.on('warning', (err) => {
+      reject(err instanceof Error ? err : new Error(String(err)));
+    });
+  });
+
+  archive.pipe(output);
+
+  for (const member of sortedMembers) {
+    archive.append(member.bytes, {
+      name: member.path,
+      date: entryDate,
+      mode: FILE_MODE,
+    });
+  }
+
+  await archive.finalize();
+  await finished;
+}

--- a/packages/extension-cli/src/artifact/integrity.test.ts
+++ b/packages/extension-cli/src/artifact/integrity.test.ts
@@ -1,0 +1,136 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { buildIntegrityDocument, signingPayload } from './integrity';
+
+function sha256Hex(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+describe('buildIntegrityDocument', () => {
+  it('produces a strict {algorithm, members} document with sha256 + size per member', () => {
+    const fileA = Buffer.from('hello world');
+    const fileB = Buffer.from('{}');
+    const bytes = buildIntegrityDocument([
+      { path: 'server/index.js', bytes: fileA },
+      { path: 'manifest.json', bytes: fileB },
+    ]);
+
+    const parsed = JSON.parse(bytes.toString('utf8'));
+    expect(parsed).toEqual({
+      algorithm: 'sha256',
+      members: {
+        'server/index.js': { sha256: sha256Hex(fileA), size: fileA.length },
+        'manifest.json': { sha256: sha256Hex(fileB), size: fileB.length },
+      },
+    });
+  });
+
+  it('emits bare lowercase hex digests', () => {
+    const bytes = buildIntegrityDocument([{ path: 'a.txt', bytes: Buffer.from('x') }]);
+    const parsed = JSON.parse(bytes.toString('utf8'));
+    expect(parsed.members['a.txt'].sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('emits keys in sorted order, deterministic regardless of input order', () => {
+    const inOrder = buildIntegrityDocument([
+      { path: 'b.txt', bytes: Buffer.from('b') },
+      { path: 'a.txt', bytes: Buffer.from('a') },
+    ]);
+    const reordered = buildIntegrityDocument([
+      { path: 'a.txt', bytes: Buffer.from('a') },
+      { path: 'b.txt', bytes: Buffer.from('b') },
+    ]);
+    expect(inOrder.toString('utf8')).toBe(reordered.toString('utf8'));
+    expect(inOrder.toString('utf8')).toBe(
+      '{"algorithm":"sha256","members":{"a.txt":{"sha256":"'
+      + sha256Hex(Buffer.from('a'))
+      + '","size":1},"b.txt":{"sha256":"'
+      + sha256Hex(Buffer.from('b'))
+      + '","size":1}}}',
+    );
+  });
+
+  it('emits no whitespace (canonical JSON bytes)', () => {
+    const bytes = buildIntegrityDocument([{ path: 'a.txt', bytes: Buffer.from('a') }]);
+    expect(bytes.toString('utf8')).not.toMatch(/\s/);
+  });
+
+  it('throws when a path is the reserved member "integrity.json"', () => {
+    expect(() => buildIntegrityDocument([{ path: 'integrity.json', bytes: Buffer.from('x') }])).toThrow();
+  });
+
+  it('throws when a path is the reserved member "signature"', () => {
+    expect(() => buildIntegrityDocument([{ path: 'signature', bytes: Buffer.from('x') }])).toThrow();
+  });
+
+  it('throws on a duplicate path', () => {
+    expect(() => buildIntegrityDocument([
+      { path: 'a.txt', bytes: Buffer.from('a') },
+      { path: 'a.txt', bytes: Buffer.from('b') },
+    ])).toThrow();
+  });
+
+  it('returns an empty members map for an empty member list', () => {
+    const bytes = buildIntegrityDocument([]);
+    expect(JSON.parse(bytes.toString('utf8'))).toEqual({ algorithm: 'sha256', members: {} });
+  });
+});
+
+describe('signingPayload', () => {
+  const manifest = { apiVersion: 'breeze.extensions/v1', name: 'acme-widgets', version: '1.2.3' } as const;
+
+  it('is a UTF-8 buffer of exactly five canonical fields with bare hex hashes', () => {
+    const manifestBytes = Buffer.from('manifest-bytes');
+    const integrityBytes = Buffer.from('integrity-bytes');
+    const payload = signingPayload(manifest, manifestBytes, integrityBytes);
+    const parsed = JSON.parse(payload.toString('utf8'));
+
+    expect(Object.keys(parsed).sort()).toEqual([
+      'apiVersion', 'integritySha256', 'manifestSha256', 'name', 'version',
+    ]);
+    expect(parsed.apiVersion).toBe(manifest.apiVersion);
+    expect(parsed.name).toBe(manifest.name);
+    expect(parsed.version).toBe(manifest.version);
+    expect(parsed.manifestSha256).toBe(sha256Hex(manifestBytes));
+    expect(parsed.integritySha256).toBe(sha256Hex(integrityBytes));
+    expect(parsed.manifestSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(parsed.integritySha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('emits no whitespace', () => {
+    const payload = signingPayload(manifest, Buffer.from('m'), Buffer.from('i'));
+    expect(payload.toString('utf8')).not.toMatch(/\s/);
+  });
+
+  // Drift guard: hard-coded golden bytes produced by feeding this exact
+  // fixture into the REAL `canonicalSigningPayload` export from
+  // apps/api/src/extensions/bundleVerifier.ts, via a one-off scratch script
+  // (not committed). This package must not import apps/api, so the live
+  // cross-check against the real export happens in Task 6's conformance
+  // test; this test locks our independent implementation to that captured
+  // golden value in the meantime.
+  it('matches the golden vector captured from the real bundleVerifier export', () => {
+    const goldenManifest = {
+      apiVersion: 'breeze.extensions/v1',
+      name: 'acme-widgets',
+      version: '1.2.3',
+    } as const;
+    const manifestBytes = Buffer.from(
+      '7b2268656c6c6f223a226d616e6966657374222c226e223a317d',
+      'hex',
+    );
+    const integrityBytes = Buffer.from(
+      '7b22616c676f726974686d223a22736861323536222c226d656d62657273223a7b7d7d',
+      'hex',
+    );
+
+    const payload = signingPayload(goldenManifest, manifestBytes, integrityBytes);
+
+    const goldenHex = '7b2261706956657273696f6e223a22627265657a652e657874656e73696f6e732f7631222c22696e74656772697479536861323536223a2233313538316636333035656264356632666630346439646363646437333865393865616464396464646264623066336366306234336236613432373162633562222c226d616e6966657374536861323536223a2262373161663963383337353962336636333538313931393736616331346330376566376532363864666339613331393265353362373337333337323563623764222c226e616d65223a2261636d652d77696467657473222c2276657273696f6e223a22312e322e33227d';
+
+    expect(payload.toString('hex')).toBe(goldenHex);
+    expect(payload.toString('utf8')).toBe(
+      '{"apiVersion":"breeze.extensions/v1","integritySha256":"31581f6305ebd5f2ff04d9dccdd738e98eadd9dddbdb0f3cf0b43b6a4271bc5b","manifestSha256":"b71af9c83759b3f6358191976ac14c07ef7e268dfc9a3192e53b73733725cb7d","name":"acme-widgets","version":"1.2.3"}',
+    );
+  });
+});

--- a/packages/extension-cli/src/artifact/integrity.ts
+++ b/packages/extension-cli/src/artifact/integrity.ts
@@ -1,0 +1,68 @@
+import { createHash } from 'node:crypto';
+import type { ExtensionManifestV1 } from '@breeze/extension-sdk';
+import { canonicalJson } from './canonicalJson';
+
+/**
+ * Reserved metadata members that a payload's own integrity inventory must
+ * never list, per `apps/api/src/extensions/bundleVerifier.ts` (RESERVED_MEMBERS).
+ * They are authenticated by the signature envelope itself, so inventorying
+ * them would be a recursive hash — the verifier rejects it.
+ */
+export const RESERVED_MEMBERS: ReadonlySet<string> = new Set(['integrity.json', 'signature']);
+
+export interface IntegrityMemberInput {
+  path: string;
+  bytes: Buffer;
+}
+
+function sha256Hex(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+/**
+ * Build the `integrity.json` bytes for a set of payload members. Throws if
+ * any path is a reserved member or duplicated. Keys are emitted in sorted
+ * order (via {@link canonicalJson}, which sorts regardless of insertion
+ * order) so the output bytes are deterministic. Matches the verifier's
+ * `.strict()` Zod schema at both levels: no keys beyond `algorithm` and
+ * `members`, and no member keys beyond `sha256` and `size`.
+ */
+export function buildIntegrityDocument(members: readonly IntegrityMemberInput[]): Buffer {
+  const entries: Record<string, { sha256: string; size: number }> = {};
+  const seen = new Set<string>();
+  for (const { path, bytes } of members) {
+    if (RESERVED_MEMBERS.has(path)) {
+      throw new Error(`integrity inventory must not include the reserved member "${path}"`);
+    }
+    if (seen.has(path)) {
+      throw new Error(`integrity inventory has a duplicate member path "${path}"`);
+    }
+    seen.add(path);
+    entries[path] = { sha256: sha256Hex(bytes), size: bytes.length };
+  }
+  return Buffer.from(canonicalJson({ algorithm: 'sha256', members: entries }), 'utf8');
+}
+
+/**
+ * The Ed25519 signing payload: canonical JSON binding the extension identity
+ * to the raw manifest.json and integrity.json bytes. Exactly five fields;
+ * the two hashes are bare lowercase hex (no `sha256:` prefix). Must match
+ * `canonicalSigningPayload` in `apps/api/src/extensions/bundleVerifier.ts`
+ * byte-for-byte.
+ */
+export function signingPayload(
+  manifest: Pick<ExtensionManifestV1, 'apiVersion' | 'name' | 'version'>,
+  manifestBytes: Buffer,
+  integrityBytes: Buffer,
+): Buffer {
+  return Buffer.from(
+    canonicalJson({
+      apiVersion: manifest.apiVersion,
+      name: manifest.name,
+      version: manifest.version,
+      manifestSha256: sha256Hex(manifestBytes),
+      integritySha256: sha256Hex(integrityBytes),
+    }),
+    'utf8',
+  );
+}

--- a/packages/extension-cli/src/artifact/signature.test.ts
+++ b/packages/extension-cli/src/artifact/signature.test.ts
@@ -1,0 +1,103 @@
+import { createPublicKey, generateKeyPairSync, verify as cryptoVerify } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadEd25519PrivateKey, signEd25519 } from './signature';
+
+let workDir: string;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), 'breeze-ext-signature-'));
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+function generateEd25519Pem() {
+  return generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+
+function generateRsaPem() {
+  return generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+
+describe('loadEd25519PrivateKey', () => {
+  it('loads a key from a file path', async () => {
+    const { privateKey } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pem');
+    await writeFile(keyPath, privateKey);
+
+    const loaded = await loadEd25519PrivateKey({ key: keyPath });
+
+    expect(loaded.asymmetricKeyType).toBe('ed25519');
+  });
+
+  it('loads a key from the named environment variable', async () => {
+    const { privateKey } = generateEd25519Pem();
+    process.env.TEST_BREEZE_SIGNING_KEY = privateKey;
+    try {
+      const loaded = await loadEd25519PrivateKey({ keyEnv: 'TEST_BREEZE_SIGNING_KEY' });
+      expect(loaded.asymmetricKeyType).toBe('ed25519');
+    } finally {
+      delete process.env.TEST_BREEZE_SIGNING_KEY;
+    }
+  });
+
+  it('rejects a non-Ed25519 (RSA) key with a clear message', async () => {
+    const { privateKey } = generateRsaPem();
+    const keyPath = join(workDir, 'rsa-key.pem');
+    await writeFile(keyPath, privateKey);
+
+    await expect(loadEd25519PrivateKey({ key: keyPath })).rejects.toThrow(/ed25519/i);
+  });
+
+  it('throws when the named environment variable is unset', async () => {
+    await expect(
+      loadEd25519PrivateKey({ keyEnv: 'NOT_A_REAL_ENV_VAR_XYZ' }),
+    ).rejects.toThrow(/NOT_A_REAL_ENV_VAR_XYZ/);
+  });
+
+  it('throws when neither key nor keyEnv is provided', async () => {
+    await expect(loadEd25519PrivateKey({})).rejects.toThrow();
+  });
+});
+
+describe('signEd25519', () => {
+  it('produces raw signature bytes that verify under the matching public key', async () => {
+    const { privateKey: privateKeyPem, publicKey: publicKeyPem } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pem');
+    await writeFile(keyPath, privateKeyPem);
+    const privateKey = await loadEd25519PrivateKey({ key: keyPath });
+    const publicKey = createPublicKey(publicKeyPem);
+    const payload = Buffer.from('hello world');
+
+    const signature = signEd25519(privateKey, payload);
+
+    expect(Buffer.isBuffer(signature)).toBe(true);
+    expect(signature.length).toBe(64); // raw Ed25519 signature length
+    expect(cryptoVerify(null, payload, publicKey, signature)).toBe(true);
+  });
+
+  it('fails verification under a different keypair', async () => {
+    const { privateKey: privateKeyPem } = generateEd25519Pem();
+    const { publicKey: otherPublicKeyPem } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pem');
+    await writeFile(keyPath, privateKeyPem);
+    const privateKey = await loadEd25519PrivateKey({ key: keyPath });
+    const otherPublicKey = createPublicKey(otherPublicKeyPem);
+    const payload = Buffer.from('hello world');
+
+    const signature = signEd25519(privateKey, payload);
+
+    expect(cryptoVerify(null, payload, otherPublicKey, signature)).toBe(false);
+  });
+});

--- a/packages/extension-cli/src/artifact/signature.test.ts
+++ b/packages/extension-cli/src/artifact/signature.test.ts
@@ -3,7 +3,12 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { loadEd25519PrivateKey, signEd25519 } from './signature';
+import {
+  loadEd25519PrivateKey,
+  loadEd25519PublicKey,
+  signEd25519,
+  verifyEd25519,
+} from './signature';
 
 let workDir: string;
 
@@ -99,5 +104,75 @@ describe('signEd25519', () => {
     const signature = signEd25519(privateKey, payload);
 
     expect(cryptoVerify(null, payload, otherPublicKey, signature)).toBe(false);
+  });
+});
+
+describe('loadEd25519PublicKey', () => {
+  it('loads a key from a file path', async () => {
+    const { publicKey } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pub.pem');
+    await writeFile(keyPath, publicKey);
+
+    const loaded = await loadEd25519PublicKey(keyPath);
+
+    expect(loaded.asymmetricKeyType).toBe('ed25519');
+  });
+
+  it('rejects a non-Ed25519 (RSA) key with a clear message', async () => {
+    const { publicKey } = generateRsaPem();
+    const keyPath = join(workDir, 'rsa-key.pub.pem');
+    await writeFile(keyPath, publicKey);
+
+    await expect(loadEd25519PublicKey(keyPath)).rejects.toThrow(/ed25519/i);
+  });
+
+  it('rejects a file that is not a valid public key', async () => {
+    const keyPath = join(workDir, 'not-a-key.pem');
+    await writeFile(keyPath, 'not a key at all');
+
+    await expect(loadEd25519PublicKey(keyPath)).rejects.toThrow(/not a valid public key/i);
+  });
+});
+
+describe('verifyEd25519', () => {
+  it('returns true for a signature that verifies under the matching public key', async () => {
+    const { privateKey: privateKeyPem, publicKey: publicKeyPem } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pem');
+    await writeFile(keyPath, privateKeyPem);
+    const privateKey = await loadEd25519PrivateKey({ key: keyPath });
+    const publicKeyPath = join(workDir, 'key.pub.pem');
+    await writeFile(publicKeyPath, publicKeyPem);
+    const publicKey = await loadEd25519PublicKey(publicKeyPath);
+    const payload = Buffer.from('hello world');
+
+    const signature = signEd25519(privateKey, payload);
+
+    expect(verifyEd25519(publicKey, payload, signature)).toBe(true);
+  });
+
+  it('returns false under a mismatched public key', async () => {
+    const { privateKey: privateKeyPem } = generateEd25519Pem();
+    const { publicKey: otherPublicKeyPem } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pem');
+    await writeFile(keyPath, privateKeyPem);
+    const privateKey = await loadEd25519PrivateKey({ key: keyPath });
+    const otherPublicKeyPath = join(workDir, 'other-key.pub.pem');
+    await writeFile(otherPublicKeyPath, otherPublicKeyPem);
+    const otherPublicKey = await loadEd25519PublicKey(otherPublicKeyPath);
+    const payload = Buffer.from('hello world');
+
+    const signature = signEd25519(privateKey, payload);
+
+    expect(verifyEd25519(otherPublicKey, payload, signature)).toBe(false);
+  });
+
+  it('returns false (does not throw) for a malformed signature', async () => {
+    const { publicKey: publicKeyPem } = generateEd25519Pem();
+    const publicKeyPath = join(workDir, 'key.pub.pem');
+    await writeFile(publicKeyPath, publicKeyPem);
+    const publicKey = await loadEd25519PublicKey(publicKeyPath);
+    const payload = Buffer.from('hello world');
+
+    expect(verifyEd25519(publicKey, payload, Buffer.from('too short'))).toBe(false);
   });
 });

--- a/packages/extension-cli/src/artifact/signature.ts
+++ b/packages/extension-cli/src/artifact/signature.ts
@@ -1,0 +1,74 @@
+import { createPrivateKey, sign as cryptoSign, type KeyObject } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+
+/**
+ * Where to load an Ed25519 private key from: a file path, or the NAME of an
+ * environment variable holding it. The key value itself must never be
+ * accepted on argv -- process arguments are world-readable via `ps` -- so
+ * `--key-env` on the CLI carries a variable name, never a key
+ * (see `src/commands/sign.ts`, `src/cli.ts`). Exactly one of the two is
+ * expected to be set; that "exactly one" rule is enforced by the CLI action,
+ * not here.
+ */
+export interface PrivateKeySource {
+  /** Path to a file holding the PEM-encoded private key. */
+  key?: string;
+  /** Name of an environment variable holding the PEM-encoded private key. */
+  keyEnv?: string;
+}
+
+async function readKeyMaterial(source: PrivateKeySource): Promise<Buffer> {
+  if (source.key !== undefined) {
+    return readFile(source.key);
+  }
+  if (source.keyEnv !== undefined) {
+    const value = process.env[source.keyEnv];
+    if (value === undefined) {
+      throw new Error(`environment variable "${source.keyEnv}" is not set`);
+    }
+    return Buffer.from(value, 'utf8');
+  }
+  throw new Error('no private key source provided: supply "key" or "keyEnv"');
+}
+
+/**
+ * Load a private key from `source` and require that it be Ed25519.
+ *
+ * SECURITY: never surfaces key material, key bytes, or a raw `createPrivateKey`
+ * exception (which can otherwise echo back fragments of malformed input) --
+ * both are caught here and replaced with a sanitized message.
+ */
+export async function loadEd25519PrivateKey(source: PrivateKeySource): Promise<KeyObject> {
+  const material = await readKeyMaterial(source);
+
+  let privateKey: KeyObject;
+  try {
+    privateKey = createPrivateKey(material);
+  } catch {
+    throw new Error('failed to load private key: not a valid private key');
+  }
+
+  if (privateKey.asymmetricKeyType !== 'ed25519') {
+    throw new Error(
+      `private key must be Ed25519, got "${privateKey.asymmetricKeyType ?? 'unknown'}"`,
+    );
+  }
+
+  return privateKey;
+}
+
+/**
+ * Sign `payload` with `privateKey`, returning the RAW Ed25519 signature bytes
+ * -- NOT a JSON envelope, no keyId, no algorithm field. Per the frozen
+ * verifier (`apps/api/src/extensions/bundleVerifier.ts`, which does
+ * `crypto.verify(null, payload, publicKey, signatureBytes)`), the archive's
+ * `signature` member is exactly these bytes.
+ */
+export function signEd25519(privateKey: KeyObject, payload: Buffer): Buffer {
+  try {
+    return cryptoSign(null, payload, privateKey);
+  } catch {
+    // Never surface a raw crypto exception.
+    throw new Error('failed to sign payload');
+  }
+}

--- a/packages/extension-cli/src/artifact/signature.ts
+++ b/packages/extension-cli/src/artifact/signature.ts
@@ -1,4 +1,10 @@
-import { createPrivateKey, sign as cryptoSign, type KeyObject } from 'node:crypto';
+import {
+  createPrivateKey,
+  createPublicKey,
+  sign as cryptoSign,
+  verify as cryptoVerify,
+  type KeyObject,
+} from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 
 /**
@@ -70,5 +76,44 @@ export function signEd25519(privateKey: KeyObject, payload: Buffer): Buffer {
   } catch {
     // Never surface a raw crypto exception.
     throw new Error('failed to sign payload');
+  }
+}
+
+/**
+ * Load a public key from a PEM file at `path` and require that it be
+ * Ed25519. Used by `breeze-ext inspect --public-key` -- an author-side,
+ * opt-in check, distinct from the host's trust-policy public keys
+ * (`apps/api/src/extensions/bundleVerifier.ts`'s `TrustedPublisher`).
+ */
+export async function loadEd25519PublicKey(path: string): Promise<KeyObject> {
+  const material = await readFile(path);
+
+  let publicKey: KeyObject;
+  try {
+    publicKey = createPublicKey(material);
+  } catch {
+    throw new Error('failed to load public key: not a valid public key');
+  }
+
+  if (publicKey.asymmetricKeyType !== 'ed25519') {
+    throw new Error(
+      `public key must be Ed25519, got "${publicKey.asymmetricKeyType ?? 'unknown'}"`,
+    );
+  }
+
+  return publicKey;
+}
+
+/**
+ * Verify a RAW Ed25519 `signature` over `payload` under `publicKey`. Returns
+ * `false` rather than throwing on malformed input (e.g. a wrong-length
+ * signature) -- an inspection tool reports "invalid", it does not crash on
+ * adversarial or corrupted archive bytes.
+ */
+export function verifyEd25519(publicKey: KeyObject, payload: Buffer, signature: Buffer): boolean {
+  try {
+    return cryptoVerify(null, payload, publicKey, signature);
+  } catch {
+    return false;
   }
 }

--- a/packages/extension-cli/src/cli.test.ts
+++ b/packages/extension-cli/src/cli.test.ts
@@ -51,6 +51,53 @@ describe('breeze-ext CLI surface', () => {
   });
 });
 
+describe('breeze-ext sign key source', () => {
+  // The private key must be supplied as EITHER a file path (--key) or the NAME
+  // of an environment variable holding it (--key-env). Exactly one is required.
+  // The key value itself is never accepted on argv, because process arguments
+  // are world-readable via `ps`; --key-env carries the variable name, not the
+  // key. The action stub throws "not implemented yet"; reaching that error is
+  // proof the option surface accepted the input, whereas an option-parsing
+  // rejection surfaces as a distinct commander error before the action runs.
+  async function runSignArgs(args: string[]): Promise<unknown> {
+    const program = createProgram();
+    program.exitOverride();
+    for (const command of program.commands) command.exitOverride();
+    try {
+      await program.parseAsync(['node', 'breeze-ext', 'sign', ...args]);
+      return undefined;
+    } catch (error) {
+      return error;
+    }
+  }
+
+  it('accepts --key alone', async () => {
+    const error = await runSignArgs(['bundle.breeze-ext', '--key', '/tmp/key.pem']);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('not implemented yet');
+  });
+
+  it('accepts --key-env alone', async () => {
+    const error = await runSignArgs(['bundle.breeze-ext', '--key-env', 'BREEZE_SIGNING_KEY']);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('not implemented yet');
+  });
+
+  it('rejects supplying both --key and --key-env', async () => {
+    const error = await runSignArgs([
+      'bundle.breeze-ext', '--key', '/tmp/key.pem', '--key-env', 'BREEZE_SIGNING_KEY',
+    ]);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/exactly one of --key or --key-env/i);
+  });
+
+  it('rejects supplying neither --key nor --key-env', async () => {
+    const error = await runSignArgs(['bundle.breeze-ext']);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/exactly one of --key or --key-env/i);
+  });
+});
+
 describe('module load purity', () => {
   it('importing src/index.ts performs no filesystem or network work at module load', async () => {
     // Structural assertion, not a global fs/network mock: a mock here would

--- a/packages/extension-cli/src/cli.test.ts
+++ b/packages/extension-cli/src/cli.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { createProgram } from './cli';
+
+describe('breeze-ext CLI surface', () => {
+  it('registers exactly the commands validate, pack, sign, inspect', () => {
+    const program = createProgram();
+    const names = program.commands.map((command) => command.name()).sort();
+    expect(names).toEqual(['inspect', 'pack', 'sign', 'validate']);
+  });
+
+  it('exits 0 on --help', async () => {
+    const program = createProgram();
+    program.exitOverride();
+
+    let caught: unknown;
+    try {
+      await program.parseAsync(['node', 'breeze-ext', '--help']);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toMatchObject({
+      code: 'commander.helpDisplayed',
+      exitCode: 0,
+    });
+  });
+
+  it('exits 0 on <command> --help for each registered command', async () => {
+    const program = createProgram();
+    // exitOverride() is copied to a subcommand only at the moment the
+    // subcommand is created (Commander's copyInheritedSettings), so it must
+    // be applied to each already-registered subcommand explicitly here.
+    program.exitOverride();
+    for (const command of program.commands) {
+      command.exitOverride();
+    }
+
+    for (const commandName of ['validate', 'pack', 'sign', 'inspect']) {
+      let caught: unknown;
+      try {
+        await program.parseAsync(['node', 'breeze-ext', commandName, '--help']);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toMatchObject({
+        code: 'commander.helpDisplayed',
+        exitCode: 0,
+      });
+    }
+  });
+});
+
+describe('module load purity', () => {
+  it('importing src/index.ts performs no filesystem or network work at module load', async () => {
+    // Structural assertion, not a global fs/network mock: a mock here would
+    // fight the packer/signer tests added in later tasks. Instead we assert
+    // that the import itself never throws (i.e. no eager fs/network calls
+    // that could fail in a sandboxed test environment) and that every export
+    // is a plain function or object -- never an already-settled Promise,
+    // Buffer, or other value that could only exist if I/O had already run at
+    // import time.
+    const module = await import('./index');
+
+    expect(Object.keys(module).length).toBeGreaterThan(0);
+
+    for (const [name, value] of Object.entries(module)) {
+      const type = typeof value;
+      expect(
+        type === 'function' || type === 'object',
+        `expected export "${name}" to be a function or object, got ${type}`,
+      ).toBe(true);
+      expect(
+        value,
+        `expected export "${name}" to not be a Promise (would imply eager async I/O)`,
+      ).not.toBeInstanceOf(Promise);
+    }
+  });
+});

--- a/packages/extension-cli/src/cli.test.ts
+++ b/packages/extension-cli/src/cli.test.ts
@@ -56,9 +56,11 @@ describe('breeze-ext sign key source', () => {
   // of an environment variable holding it (--key-env). Exactly one is required.
   // The key value itself is never accepted on argv, because process arguments
   // are world-readable via `ps`; --key-env carries the variable name, not the
-  // key. The action stub throws "not implemented yet"; reaching that error is
-  // proof the option surface accepted the input, whereas an option-parsing
-  // rejection surfaces as a distinct commander error before the action runs.
+  // key. `sign.test.ts` covers the fully-implemented signing behavior; here we
+  // only need proof the option surface accepted the input and reached the
+  // action -- i.e. failed on trying to read a nonexistent artifact file,
+  // rather than on option parsing (a distinct commander error raised before
+  // the action ever runs).
   async function runSignArgs(args: string[]): Promise<unknown> {
     const program = createProgram();
     program.exitOverride();
@@ -74,13 +76,15 @@ describe('breeze-ext sign key source', () => {
   it('accepts --key alone', async () => {
     const error = await runSignArgs(['bundle.breeze-ext', '--key', '/tmp/key.pem']);
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain('not implemented yet');
+    expect((error as Error).message).not.toMatch(/exactly one of --key or --key-env/i);
+    expect((error as { code?: string }).code?.startsWith('commander.')).not.toBe(true);
   });
 
   it('accepts --key-env alone', async () => {
     const error = await runSignArgs(['bundle.breeze-ext', '--key-env', 'BREEZE_SIGNING_KEY']);
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain('not implemented yet');
+    expect((error as Error).message).not.toMatch(/exactly one of --key or --key-env/i);
+    expect((error as { code?: string }).code?.startsWith('commander.')).not.toBe(true);
   });
 
   it('rejects supplying both --key and --key-env', async () => {

--- a/packages/extension-cli/src/cli.ts
+++ b/packages/extension-cli/src/cli.ts
@@ -44,20 +44,29 @@ export function createProgram(): Command {
   program
     .command('sign')
     .description('Sign a .breeze-ext bundle with an Ed25519 private key')
-    .argument('<bundle>', 'path to the .breeze-ext bundle to sign')
-    .requiredOption('-k, --key <path>', 'path to the Ed25519 private key')
+    .argument('<artifact>', 'path to the .breeze-ext artifact to sign')
+    // The key value is NEVER accepted on argv — process arguments are
+    // world-readable via `ps`. Supply the key as a file path (--key) or as the
+    // NAME of an environment variable holding it (--key-env). Exactly one is
+    // required; Commander cannot express "exactly one of" natively, so it is
+    // enforced in the action.
+    .option('-k, --key <path>', 'path to the Ed25519 private key file')
+    .option('--key-env <var>', 'name of an environment variable holding the Ed25519 private key')
     .option('-o, --out <file>', 'output path for the signed bundle (defaults to signing in place)')
-    .action(async (bundle: string, options: { key: string; out?: string }) => {
-      await runSign({ bundle, key: options.key, out: options.out });
+    .action(async (artifact: string, options: { key?: string; keyEnv?: string; out?: string }) => {
+      if ((options.key === undefined) === (options.keyEnv === undefined)) {
+        throw new Error('breeze-ext sign: provide exactly one of --key or --key-env');
+      }
+      await runSign({ artifact, key: options.key, keyEnv: options.keyEnv, out: options.out });
     });
 
   program
     .command('inspect')
-    .description('Print a .breeze-ext bundle\'s manifest, integrity inventory, and signature status')
-    .argument('<bundle>', 'path to the .breeze-ext bundle to inspect')
+    .description('Print a .breeze-ext artifact\'s manifest, integrity inventory, and signature status')
+    .argument('<artifact>', 'path to the .breeze-ext artifact to inspect')
     .option('--json', 'emit machine-readable JSON output')
-    .action(async (bundle: string, options: { json?: boolean }) => {
-      await runInspect({ bundle, json: options.json });
+    .action(async (artifact: string, options: { json?: boolean }) => {
+      await runInspect({ artifact, json: options.json });
     });
 
   return program;

--- a/packages/extension-cli/src/cli.ts
+++ b/packages/extension-cli/src/cli.ts
@@ -65,8 +65,9 @@ export function createProgram(): Command {
     .description('Print a .breeze-ext artifact\'s manifest, integrity inventory, and signature status')
     .argument('<artifact>', 'path to the .breeze-ext artifact to inspect')
     .option('--json', 'emit machine-readable JSON output')
-    .action(async (artifact: string, options: { json?: boolean }) => {
-      await runInspect({ artifact, json: options.json });
+    .option('--public-key <path>', 'path to an Ed25519 public key file to check the signature against')
+    .action(async (artifact: string, options: { json?: boolean; publicKey?: string }) => {
+      await runInspect({ artifact, json: options.json, publicKey: options.publicKey });
     });
 
   return program;

--- a/packages/extension-cli/src/cli.ts
+++ b/packages/extension-cli/src/cli.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { pathToFileURL } from 'node:url';
+import { runInspect } from './commands/inspect';
+import { runPack } from './commands/pack';
+import { runSign } from './commands/sign';
+import { runValidate } from './commands/validate';
+
+/**
+ * Builds a fresh `breeze-ext` Commander program. A factory (rather than a
+ * module-level singleton) so tests can construct and exercise the program
+ * without mutating shared state across test cases.
+ *
+ * Command bodies are minimal stubs for now — see `src/commands/*.ts`. This
+ * task only fixes the CLI surface (commands, arguments, flags); packing,
+ * signing, and inspection logic land in later tasks.
+ */
+export function createProgram(): Command {
+  const program = new Command();
+
+  program
+    .name('breeze-ext')
+    .description('Pack and sign .breeze-ext extension bundles for the Breeze RMM runtime extension platform')
+    .version('1.0.0');
+
+  program
+    .command('validate')
+    .description('Validate an extension source directory against the manifest schema')
+    .argument('<path>', 'path to the extension source directory')
+    .option('--json', 'emit machine-readable JSON output')
+    .action(async (path: string, options: { json?: boolean }) => {
+      await runValidate({ path, json: options.json });
+    });
+
+  program
+    .command('pack')
+    .description('Pack an extension source directory into a deterministic .breeze-ext bundle')
+    .argument('<path>', 'path to the extension source directory')
+    .requiredOption('-o, --out <file>', 'output path for the .breeze-ext bundle')
+    .action(async (path: string, options: { out: string }) => {
+      await runPack({ path, out: options.out });
+    });
+
+  program
+    .command('sign')
+    .description('Sign a .breeze-ext bundle with an Ed25519 private key')
+    .argument('<bundle>', 'path to the .breeze-ext bundle to sign')
+    .requiredOption('-k, --key <path>', 'path to the Ed25519 private key')
+    .option('-o, --out <file>', 'output path for the signed bundle (defaults to signing in place)')
+    .action(async (bundle: string, options: { key: string; out?: string }) => {
+      await runSign({ bundle, key: options.key, out: options.out });
+    });
+
+  program
+    .command('inspect')
+    .description('Print a .breeze-ext bundle\'s manifest, integrity inventory, and signature status')
+    .argument('<bundle>', 'path to the .breeze-ext bundle to inspect')
+    .option('--json', 'emit machine-readable JSON output')
+    .action(async (bundle: string, options: { json?: boolean }) => {
+      await runInspect({ bundle, json: options.json });
+    });
+
+  return program;
+}
+
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return import.meta.url === pathToFileURL(entry).href;
+}
+
+if (isMainModule()) {
+  const program = createProgram();
+  program.parseAsync(process.argv).catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/packages/extension-cli/src/commands/inspect.test.ts
+++ b/packages/extension-cli/src/commands/inspect.test.ts
@@ -1,0 +1,414 @@
+import { createHash, generateKeyPairSync } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import StreamZip from 'node-stream-zip';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createProgram } from '../cli';
+import { packExtension } from './pack';
+import { signArtifact } from './sign';
+import { inspectArtifact, runInspect } from './inspect';
+import { writeDeterministicZip } from '../artifact/deterministicZip';
+
+const VALID_MANIFEST = {
+  apiVersion: 'breeze.extensions/v1',
+  name: 'acme-widgets',
+  version: '1.0.0',
+  routeNamespace: 'acme-widgets',
+  requires: { breeze: '>=0.1.0 <0.2.0', serverSdk: '^1.0.0', capabilities: [] },
+  server: { entry: 'server/index.js' },
+  schemaCompatibilityFloor: '1.0.0',
+  jobs: [],
+  aiTools: [],
+};
+
+let sourceDir: string;
+let workDir: string;
+
+beforeEach(async () => {
+  sourceDir = await mkdtemp(join(tmpdir(), 'breeze-ext-inspect-src-'));
+  workDir = await mkdtemp(join(tmpdir(), 'breeze-ext-inspect-out-'));
+});
+
+afterEach(async () => {
+  await rm(sourceDir, { recursive: true, force: true });
+  await rm(workDir, { recursive: true, force: true });
+});
+
+async function writeFixture(relPath: string, contents: string | object): Promise<void> {
+  const fullPath = join(sourceDir, ...relPath.split('/'));
+  await mkdir(join(fullPath, '..'), { recursive: true });
+  const body = typeof contents === 'string' ? contents : JSON.stringify(contents);
+  await writeFile(fullPath, body);
+}
+
+async function writeValidFixtureTree(): Promise<void> {
+  await writeFixture('manifest.json', VALID_MANIFEST);
+  await writeFixture('server/index.js', 'module.exports = () => {};');
+  await writeFixture('migrations/0001_init.sql', 'select 1;');
+  await writeFixture('migrations/0002_add_widgets.sql', 'select 2;');
+}
+
+async function readZipEntries(archivePath: string): Promise<Record<string, Buffer>> {
+  const zip = new StreamZip.async({ file: archivePath });
+  try {
+    const entries = await zip.entries();
+    const out: Record<string, Buffer> = {};
+    for (const name of Object.keys(entries)) {
+      out[name] = await zip.entryData(name);
+    }
+    return out;
+  } finally {
+    await zip.close();
+  }
+}
+
+function generateEd25519Pem() {
+  return generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+
+async function packFixture(): Promise<{ artifactPath: string; digest: string }> {
+  await writeValidFixtureTree();
+  return packExtension({ path: sourceDir, out: join(workDir, 'unsigned.breeze-ext') });
+}
+
+async function packAndSignFixture(): Promise<{
+  artifactPath: string;
+  digest: string;
+  publicKeyPath: string;
+  privateKeyPath: string;
+}> {
+  const packed = await packFixture();
+  const { privateKey, publicKey } = generateEd25519Pem();
+  const privateKeyPath = join(workDir, 'signing-key.pem');
+  const publicKeyPath = join(workDir, 'signing-key.pub.pem');
+  await writeFile(privateKeyPath, privateKey);
+  await writeFile(publicKeyPath, publicKey);
+
+  const signed = await signArtifact({ artifact: packed.artifactPath, key: privateKeyPath });
+  return { artifactPath: signed.artifactPath, digest: signed.digest, publicKeyPath, privateKeyPath };
+}
+
+describe('inspectArtifact', () => {
+  it('reports digest, manifest identity, unverified signature, valid inventory, and the migration list with no key', async () => {
+    const packed = await packFixture();
+
+    const result = await inspectArtifact({ artifact: packed.artifactPath });
+
+    expect(result.digest).toBe(packed.digest);
+    expect(result.manifest).toEqual({
+      name: 'acme-widgets',
+      version: '1.0.0',
+      apiVersion: 'breeze.extensions/v1',
+    });
+    expect(result.signature).toBe('unverified');
+    expect(result.integrity).toEqual({ valid: true, findings: [] });
+    expect(result.migrations).toEqual(['0001_init.sql', '0002_add_widgets.sql']);
+  });
+
+  it('reports a valid signature when the matching public key is supplied', async () => {
+    const { artifactPath, publicKeyPath } = await packAndSignFixture();
+
+    const result = await inspectArtifact({ artifact: artifactPath, publicKey: publicKeyPath });
+
+    expect(result.signature).toBe('valid');
+    expect(result.integrity.valid).toBe(true);
+    expect(result.ok).toBe(true);
+  });
+
+  it('reports an invalid signature under a mismatched public key', async () => {
+    const { artifactPath } = await packAndSignFixture();
+    const { publicKey: otherPublicKey } = generateEd25519Pem();
+    const otherPublicKeyPath = join(workDir, 'other-key.pub.pem');
+    await writeFile(otherPublicKeyPath, otherPublicKey);
+
+    const result = await inspectArtifact({ artifact: artifactPath, publicKey: otherPublicKeyPath });
+
+    expect(result.signature).toBe('invalid');
+    expect(result.ok).toBe(false);
+  });
+
+  it('reports "missing" signature status when a public key is given but the artifact is unsigned', async () => {
+    const packed = await packFixture();
+    const { publicKey } = generateEd25519Pem();
+    const publicKeyPath = join(workDir, 'key.pub.pem');
+    await writeFile(publicKeyPath, publicKey);
+
+    const result = await inspectArtifact({ artifact: packed.artifactPath, publicKey: publicKeyPath });
+
+    expect(result.signature).toBe('missing');
+    expect(result.ok).toBe(false);
+  });
+
+  it('flags a tampered member with the stable "integrity_mismatch" code', async () => {
+    const packed = await packFixture();
+    const entries = await readZipEntries(packed.artifactPath);
+
+    const tamperedMembers = Object.entries(entries)
+      .filter(([name]) => name !== 'server/index.js')
+      .map(([path, bytes]) => ({ path, bytes }));
+    tamperedMembers.push({
+      path: 'server/index.js',
+      bytes: Buffer.concat([entries['server/index.js'], Buffer.from('// tampered')]),
+    });
+
+    const tamperedPath = join(workDir, 'tampered.breeze-ext');
+    await writeDeterministicZip(tamperedMembers, tamperedPath, { sourceDateEpoch: 0 });
+
+    const result = await inspectArtifact({ artifact: tamperedPath });
+
+    expect(result.integrity.valid).toBe(false);
+    expect(result.integrity.findings).toContainEqual({
+      code: 'integrity_mismatch',
+      path: 'server/index.js',
+      reason: 'digest_mismatch',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('flags a member added to the archive after packing as "missing_from_inventory"', async () => {
+    const packed = await packFixture();
+    const entries = await readZipEntries(packed.artifactPath);
+
+    const members = Object.entries(entries).map(([path, bytes]) => ({ path, bytes }));
+    members.push({ path: 'server/extra.js', bytes: Buffer.from('module.exports = {};') });
+
+    const tamperedPath = join(workDir, 'extra-member.breeze-ext');
+    await writeDeterministicZip(members, tamperedPath, { sourceDateEpoch: 0 });
+
+    const result = await inspectArtifact({ artifact: tamperedPath });
+
+    expect(result.integrity.valid).toBe(false);
+    expect(result.integrity.findings).toContainEqual({
+      code: 'integrity_mismatch',
+      path: 'server/extra.js',
+      reason: 'missing_from_inventory',
+    });
+  });
+
+  it('flags a member removed from the archive after packing as "missing_from_archive"', async () => {
+    const packed = await packFixture();
+    const entries = await readZipEntries(packed.artifactPath);
+
+    const members = Object.entries(entries)
+      .filter(([name]) => name !== 'migrations/0002_add_widgets.sql')
+      .map(([path, bytes]) => ({ path, bytes }));
+
+    const tamperedPath = join(workDir, 'missing-member.breeze-ext');
+    await writeDeterministicZip(members, tamperedPath, { sourceDateEpoch: 0 });
+
+    const result = await inspectArtifact({ artifact: tamperedPath });
+
+    expect(result.integrity.valid).toBe(false);
+    expect(result.integrity.findings).toContainEqual({
+      code: 'integrity_mismatch',
+      path: 'migrations/0002_add_widgets.sql',
+      reason: 'missing_from_archive',
+    });
+  });
+
+  it('the whole-artifact digest is sha256 of the actual file bytes', async () => {
+    const packed = await packFixture();
+    const fileBytes = await readFile(packed.artifactPath);
+    const expected = `sha256:${createHash('sha256').update(fileBytes).digest('hex')}`;
+
+    const result = await inspectArtifact({ artifact: packed.artifactPath });
+
+    expect(result.digest).toBe(expected);
+  });
+});
+
+describe('runInspect exit codes', () => {
+  it('leaves process.exitCode unset (zero) on a clean, unsigned artifact', async () => {
+    const packed = await packFixture();
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await runInspect({ artifact: packed.artifactPath, json: true });
+      expect(process.exitCode).toBeUndefined();
+    } finally {
+      logSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    }
+  });
+
+  it('leaves process.exitCode unset (zero) on a clean, validly-signed artifact', async () => {
+    const { artifactPath, publicKeyPath } = await packAndSignFixture();
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await runInspect({ artifact: artifactPath, json: true, publicKey: publicKeyPath });
+      expect(process.exitCode).toBeUndefined();
+    } finally {
+      logSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    }
+  });
+
+  it('sets a nonzero process.exitCode on an integrity mismatch', async () => {
+    const packed = await packFixture();
+    const entries = await readZipEntries(packed.artifactPath);
+    const tamperedMembers = Object.entries(entries)
+      .filter(([name]) => name !== 'server/index.js')
+      .map(([path, bytes]) => ({ path, bytes }));
+    tamperedMembers.push({
+      path: 'server/index.js',
+      bytes: Buffer.concat([entries['server/index.js'], Buffer.from('// tampered')]),
+    });
+    const tamperedPath = join(workDir, 'tampered.breeze-ext');
+    await writeDeterministicZip(tamperedMembers, tamperedPath, { sourceDateEpoch: 0 });
+
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await runInspect({ artifact: tamperedPath, json: true });
+      expect(process.exitCode).toBeTruthy();
+      expect(process.exitCode).not.toBe(0);
+    } finally {
+      logSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    }
+  });
+
+  it('sets a nonzero process.exitCode when signature verification fails', async () => {
+    const { artifactPath } = await packAndSignFixture();
+    const { publicKey: otherPublicKey } = generateEd25519Pem();
+    const otherPublicKeyPath = join(workDir, 'other-key.pub.pem');
+    await writeFile(otherPublicKeyPath, otherPublicKey);
+
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await runInspect({ artifact: artifactPath, json: true, publicKey: otherPublicKeyPath });
+      expect(process.exitCode).toBeTruthy();
+      expect(process.exitCode).not.toBe(0);
+    } finally {
+      logSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    }
+  });
+});
+
+// NOTE: capture printed lines into a local array from WITHIN the mock
+// implementation, rather than reading `spy.mock.calls` after `mockRestore()`
+// -- Vitest's `mockRestore()` also clears recorded call history (like
+// `mockReset()`), so anything read off the spy after restoring is always
+// empty. `sign.test.ts`'s "never leaks key material" test uses this same
+// side-channel-array pattern for the identical reason.
+function captureConsoleLog(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((msg: unknown) => {
+    lines.push(String(msg));
+  });
+  return { lines, restore: () => spy.mockRestore() };
+}
+
+describe('runInspect --json output', () => {
+  it('prints a single JSON document with the expected fields', async () => {
+    const { artifactPath, publicKeyPath } = await packAndSignFixture();
+    const { lines, restore } = captureConsoleLog();
+
+    try {
+      await runInspect({ artifact: artifactPath, json: true, publicKey: publicKeyPath });
+    } finally {
+      restore();
+    }
+
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed).toMatchObject({
+      digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+      manifest: { name: 'acme-widgets', version: '1.0.0', apiVersion: 'breeze.extensions/v1' },
+      signature: 'valid',
+      integrity: { valid: true, findings: [] },
+      migrations: ['0001_init.sql', '0002_add_widgets.sql'],
+    });
+  });
+});
+
+describe('runInspect human output hygiene', () => {
+  it('contains no absolute checkout paths, environment data, or key material', async () => {
+    const { artifactPath, privateKeyPath, publicKeyPath } = await packAndSignFixture();
+    const privateKeyPem = await readFile(privateKeyPath, 'utf8');
+    const { lines, restore } = captureConsoleLog();
+
+    try {
+      await runInspect({ artifact: artifactPath, publicKey: publicKeyPath });
+    } finally {
+      restore();
+    }
+
+    expect(lines.length).toBeGreaterThan(0);
+    const output = lines.join('\n');
+
+    // No absolute checkout paths: neither the artifact path, the source
+    // fixture path, nor the CWD workDir/sourceDir should ever be echoed.
+    expect(output).not.toContain(artifactPath);
+    expect(output).not.toContain(sourceDir);
+    expect(output).not.toContain(workDir);
+    expect(output).not.toContain(process.cwd());
+
+    // No key material.
+    const keyBase64Body = privateKeyPem
+      .split('\n')
+      .filter((line) => line.length > 0 && !line.startsWith('-----'))
+      .join('');
+    expect(output).not.toContain(privateKeyPem);
+    expect(output).not.toContain(keyBase64Body);
+    expect(output.toLowerCase()).not.toContain('begin private key');
+
+    // No raw environment dumps.
+    expect(output).not.toContain('PATH=');
+    expect(output).not.toMatch(/HOME=\//);
+  });
+});
+
+describe('breeze-ext inspect CLI', () => {
+  it('inspects via the CLI command form: inspect <artifact> --json', async () => {
+    const packed = await packFixture();
+    const { lines, restore } = captureConsoleLog();
+
+    const program = createProgram();
+    program.exitOverride();
+
+    try {
+      await program.parseAsync(['node', 'breeze-ext', 'inspect', packed.artifactPath, '--json']);
+    } finally {
+      restore();
+    }
+
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.manifest.name).toBe('acme-widgets');
+  });
+
+  it('accepts --public-key on the CLI and verifies the signature', async () => {
+    const { artifactPath, publicKeyPath } = await packAndSignFixture();
+    const { lines, restore } = captureConsoleLog();
+
+    const program = createProgram();
+    program.exitOverride();
+
+    try {
+      await program.parseAsync([
+        'node', 'breeze-ext', 'inspect', artifactPath, '--json', '--public-key', publicKeyPath,
+      ]);
+    } finally {
+      restore();
+    }
+
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.signature).toBe('valid');
+  });
+});

--- a/packages/extension-cli/src/commands/inspect.ts
+++ b/packages/extension-cli/src/commands/inspect.ts
@@ -1,17 +1,279 @@
 /**
- * `breeze-ext inspect` — prints a `.breeze-ext` bundle's manifest,
- * integrity inventory, and signature status without installing it.
+ * `breeze-ext inspect` — an AUTHOR-SIDE DIAGNOSTIC that reports what's
+ * inside a `.breeze-ext` artifact: the whole-artifact digest, the manifest
+ * identity, whether the archive's actual members still match the committed
+ * `integrity.json`, an optional signature check, and the migration list.
  *
- * Not implemented yet: bundle inspection lands in Task 7 of this plan.
+ * This is NOT the host's trust decision. `apps/api/src/extensions/bundleVerifier.ts`
+ * (`verifyExtensionBundle`) is the only place that enforces publisher trust
+ * config, digest pinning, and archive-safety limits before code is allowed
+ * to load. `inspect` re-derives the inventory from the archive and,
+ * optionally, checks a raw Ed25519 signature against a caller-supplied
+ * public key — nothing more. It must never be presented as equivalent to
+ * host verification, and it does not import or duplicate `apps/api` trust
+ * logic.
  */
+
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { pipeline } from 'node:stream/promises';
+import StreamZip from 'node-stream-zip';
+import { parseExtensionManifestV1 } from '@breeze/extension-sdk';
+import { RESERVED_MEMBERS, signingPayload } from '../artifact/integrity';
+import { loadEd25519PublicKey, verifyEd25519 } from '../artifact/signature';
 
 export interface InspectOptions {
   /** Path to the `.breeze-ext` artifact to inspect. */
   artifact: string;
   /** Emit machine-readable JSON instead of human-readable text. */
   json?: boolean;
+  /**
+   * Path to an Ed25519 public key file. When supplied, the archive's
+   * `signature` member is checked against it. When omitted, the signature is
+   * NOT checked and is reported as `"unverified"` — inspect never implies a
+   * validity it did not actually check.
+   */
+  publicKey?: string;
 }
 
-export async function runInspect(_options: InspectOptions): Promise<never> {
-  throw new Error('breeze-ext inspect: not implemented yet');
+/**
+ * `"unverified"` — no `--public-key` was supplied; the signature was not
+ *   checked at all.
+ * `"missing"` — a public key was supplied but the archive has no
+ *   `signature` member to check it against.
+ * `"valid"` / `"invalid"` — the signature was checked against the supplied
+ *   public key and either verified or did not.
+ */
+export type SignatureStatus = 'unverified' | 'missing' | 'valid' | 'invalid';
+
+/**
+ * A re-derived inventory disagreement between the archive's actual members
+ * and the committed `integrity.json`. `code` is a stable, machine-readable
+ * identifier: callers (CI, other tooling) can match on it without parsing
+ * `reason` prose.
+ */
+export interface InspectFinding {
+  code: 'integrity_mismatch';
+  path: string;
+  reason: 'digest_mismatch' | 'missing_from_archive' | 'missing_from_inventory';
+}
+
+export interface InspectResult {
+  /** `sha256:` + hex digest of the whole artifact file. */
+  digest: string;
+  manifest: { name: string; version: string; apiVersion: string };
+  signature: SignatureStatus;
+  integrity: { valid: boolean; findings: InspectFinding[] };
+  /** Filenames (relative to the manifest's `migrationsDir`), sorted. */
+  migrations: string[];
+  /** `true` iff nothing here failed verification — drives the exit code. */
+  ok: boolean;
+}
+
+function sha256Hex(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(filePath), hash);
+  return hash.digest('hex');
+}
+
+/** Read every non-directory member out of a `.breeze-ext` archive, fully into memory. */
+async function readArtifactMembers(archivePath: string): Promise<Map<string, Buffer>> {
+  const zip = new StreamZip.async({ file: archivePath });
+  try {
+    const entries = await zip.entries();
+    const members = new Map<string, Buffer>();
+    for (const entry of Object.values(entries)) {
+      if (entry.isDirectory) continue;
+      members.set(entry.name, await zip.entryData(entry.name));
+    }
+    return members;
+  } finally {
+    await zip.close();
+  }
+}
+
+interface CommittedIntegrityDocument {
+  members: Record<string, { sha256: string; size: number }>;
+}
+
+/**
+ * Parse the committed `integrity.json` bytes loosely — just enough shape to
+ * re-derive against. Schema enforcement (the verifier's `.strict()` Zod
+ * shape) is the host's job at trust time, not this diagnostic's.
+ */
+function parseCommittedIntegrity(bytes: Buffer): CommittedIntegrityDocument {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    throw new Error('integrity.json is not valid JSON');
+  }
+  if (
+    typeof raw !== 'object' || raw === null
+    || !('members' in raw) || typeof (raw as { members: unknown }).members !== 'object'
+    || (raw as { members: unknown }).members === null
+  ) {
+    throw new Error('integrity.json has an unexpected shape (missing "members")');
+  }
+  return raw as CommittedIntegrityDocument;
+}
+
+/**
+ * Re-derive the inventory from the archive's actual non-reserved members and
+ * compare it, member by member, against the committed `integrity.json`.
+ * Every disagreement — a changed digest, a member the archive has that the
+ * inventory doesn't, or vice versa — becomes an `integrity_mismatch`
+ * finding.
+ */
+function checkIntegrity(
+  members: ReadonlyMap<string, Buffer>,
+  committed: CommittedIntegrityDocument,
+): InspectFinding[] {
+  const findings: InspectFinding[] = [];
+  const actualPaths = new Set([...members.keys()].filter((path) => !RESERVED_MEMBERS.has(path)));
+  const committedPaths = new Set(Object.keys(committed.members));
+
+  for (const path of committedPaths) {
+    if (!actualPaths.has(path)) {
+      findings.push({ code: 'integrity_mismatch', path, reason: 'missing_from_archive' });
+      continue;
+    }
+    const bytes = members.get(path)!;
+    const expected = committed.members[path];
+    if (sha256Hex(bytes) !== expected.sha256 || bytes.length !== expected.size) {
+      findings.push({ code: 'integrity_mismatch', path, reason: 'digest_mismatch' });
+    }
+  }
+  for (const path of actualPaths) {
+    if (!committedPaths.has(path)) {
+      findings.push({ code: 'integrity_mismatch', path, reason: 'missing_from_inventory' });
+    }
+  }
+
+  findings.sort((a, b) => a.path.localeCompare(b.path));
+  return findings;
+}
+
+/**
+ * List the migration filenames: direct `*.sql` children of the manifest's
+ * `migrationsDir`, sorted. Mirrors the selection rule
+ * `readBundleMigrations` (`apps/api/src/extensions/migrator.ts`) applies at
+ * apply-time, kept independent so this package never imports `apps/api`.
+ */
+function listMigrations(members: ReadonlyMap<string, Buffer>, migrationsDir: string): string[] {
+  const prefix = `${migrationsDir}/`;
+  return [...members.keys()]
+    .filter((path) => (
+      !RESERVED_MEMBERS.has(path)
+      && path.startsWith(prefix)
+      && path.endsWith('.sql')
+      && !path.slice(prefix.length).includes('/')
+    ))
+    .map((path) => path.slice(prefix.length))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Inspect a `.breeze-ext` artifact and report its contents. See the module
+ * doc comment for the trust-boundary scoping of this function.
+ */
+export async function inspectArtifact(options: InspectOptions): Promise<InspectResult> {
+  const digest = `sha256:${await sha256File(options.artifact)}`;
+  const members = await readArtifactMembers(options.artifact);
+
+  const manifestBytes = members.get('manifest.json');
+  if (!manifestBytes) {
+    throw new Error('artifact is missing required member "manifest.json"');
+  }
+  let manifestRaw: unknown;
+  try {
+    manifestRaw = JSON.parse(manifestBytes.toString('utf8'));
+  } catch {
+    throw new Error('manifest.json is not valid JSON');
+  }
+  const manifest = parseExtensionManifestV1(manifestRaw);
+
+  const integrityBytes = members.get('integrity.json');
+  if (!integrityBytes) {
+    throw new Error('artifact is missing required member "integrity.json"');
+  }
+  const committed = parseCommittedIntegrity(integrityBytes);
+  const findings = checkIntegrity(members, committed);
+  const migrations = listMigrations(members, manifest.migrationsDir);
+
+  let signature: SignatureStatus = 'unverified';
+  if (options.publicKey !== undefined) {
+    const signatureBytes = members.get('signature');
+    if (!signatureBytes) {
+      signature = 'missing';
+    } else {
+      const publicKey = await loadEd25519PublicKey(options.publicKey);
+      const payload = signingPayload(manifest, manifestBytes, integrityBytes);
+      signature = verifyEd25519(publicKey, payload, signatureBytes) ? 'valid' : 'invalid';
+    }
+  }
+
+  const ok = findings.length === 0 && signature !== 'invalid' && signature !== 'missing';
+
+  return {
+    digest,
+    manifest: { name: manifest.name, version: manifest.version, apiVersion: manifest.apiVersion },
+    signature,
+    integrity: { valid: findings.length === 0, findings },
+    migrations,
+    ok,
+  };
+}
+
+/**
+ * Human-readable report. Deliberately contains only artifact-relative
+ * member paths and result data — never `options.artifact` (an absolute
+ * checkout path), environment data, or key material.
+ */
+function formatHuman(result: InspectResult): string {
+  const lines: string[] = [
+    `digest: ${result.digest}`,
+    `name: ${result.manifest.name}`,
+    `version: ${result.manifest.version}`,
+    `apiVersion: ${result.manifest.apiVersion}`,
+    `signature: ${result.signature}`,
+    `integrity: ${result.integrity.valid ? 'ok' : `${result.integrity.findings.length} problem(s) found`}`,
+  ];
+  for (const finding of result.integrity.findings) {
+    lines.push(`  - ${finding.code}: ${finding.path} (${finding.reason})`);
+  }
+  if (result.migrations.length === 0) {
+    lines.push('migrations: none');
+  } else {
+    lines.push('migrations:');
+    for (const migration of result.migrations) {
+      lines.push(`  - ${migration}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Run `inspect` and print its report. Exit code is nonzero on ANY
+ * verification failure (an integrity mismatch, or an invalid/missing
+ * signature when a public key was supplied) and zero on a clean artifact —
+ * set via `process.exitCode` (not `throw`) so the report itself is still
+ * printed before the process exits.
+ */
+export async function runInspect(options: InspectOptions): Promise<void> {
+  const result = await inspectArtifact(options);
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatHuman(result));
+  }
+
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
 }

--- a/packages/extension-cli/src/commands/inspect.ts
+++ b/packages/extension-cli/src/commands/inspect.ts
@@ -6,8 +6,8 @@
  */
 
 export interface InspectOptions {
-  /** Path to the `.breeze-ext` bundle to inspect. */
-  bundle: string;
+  /** Path to the `.breeze-ext` artifact to inspect. */
+  artifact: string;
   /** Emit machine-readable JSON instead of human-readable text. */
   json?: boolean;
 }

--- a/packages/extension-cli/src/commands/inspect.ts
+++ b/packages/extension-cli/src/commands/inspect.ts
@@ -137,13 +137,15 @@ function checkIntegrity(
   const actualPaths = new Set([...members.keys()].filter((path) => !RESERVED_MEMBERS.has(path)));
   const committedPaths = new Set(Object.keys(committed.members));
 
-  for (const path of committedPaths) {
+  // Iterate entries (not keys) so `expected` is narrowed to the member shape
+  // rather than `... | undefined` under `noUncheckedIndexedAccess` — the value
+  // always exists here, but the compiler can't know that from a keyed lookup.
+  for (const [path, expected] of Object.entries(committed.members)) {
     if (!actualPaths.has(path)) {
       findings.push({ code: 'integrity_mismatch', path, reason: 'missing_from_archive' });
       continue;
     }
     const bytes = members.get(path)!;
-    const expected = committed.members[path];
     if (sha256Hex(bytes) !== expected.sha256 || bytes.length !== expected.size) {
       findings.push({ code: 'integrity_mismatch', path, reason: 'digest_mismatch' });
     }

--- a/packages/extension-cli/src/commands/inspect.ts
+++ b/packages/extension-cli/src/commands/inspect.ts
@@ -1,0 +1,17 @@
+/**
+ * `breeze-ext inspect` — prints a `.breeze-ext` bundle's manifest,
+ * integrity inventory, and signature status without installing it.
+ *
+ * Not implemented yet: bundle inspection lands in Task 7 of this plan.
+ */
+
+export interface InspectOptions {
+  /** Path to the `.breeze-ext` bundle to inspect. */
+  bundle: string;
+  /** Emit machine-readable JSON instead of human-readable text. */
+  json?: boolean;
+}
+
+export async function runInspect(_options: InspectOptions): Promise<never> {
+  throw new Error('breeze-ext inspect: not implemented yet');
+}

--- a/packages/extension-cli/src/commands/pack.test.ts
+++ b/packages/extension-cli/src/commands/pack.test.ts
@@ -152,6 +152,37 @@ describe('packExtension', () => {
 
     expect(resultA.digest).toBe(resultB.digest);
   });
+
+  it('reads SOURCE_DATE_EPOCH from the environment so a caller can pin build time', async () => {
+    await writeValidFixtureTree();
+    const original = process.env.SOURCE_DATE_EPOCH;
+    try {
+      process.env.SOURCE_DATE_EPOCH = '0';
+      const zero = await packExtension({ path: sourceDir, out: join(workDir, 'epoch-0.breeze-ext') });
+      process.env.SOURCE_DATE_EPOCH = '1700000000';
+      const later = await packExtension({ path: sourceDir, out: join(workDir, 'epoch-1.breeze-ext') });
+      // A different epoch must change the archive bytes — proof the env value is
+      // actually threaded to the timestamp, not silently ignored.
+      expect(zero.digest).not.toBe(later.digest);
+    } finally {
+      if (original === undefined) delete process.env.SOURCE_DATE_EPOCH;
+      else process.env.SOURCE_DATE_EPOCH = original;
+    }
+  });
+
+  it('rejects a non-integer SOURCE_DATE_EPOCH rather than silently defaulting', async () => {
+    await writeValidFixtureTree();
+    const original = process.env.SOURCE_DATE_EPOCH;
+    try {
+      process.env.SOURCE_DATE_EPOCH = 'not-a-number';
+      await expect(
+        packExtension({ path: sourceDir, out: join(workDir, 'bad-epoch.breeze-ext') }),
+      ).rejects.toThrow(/SOURCE_DATE_EPOCH/);
+    } finally {
+      if (original === undefined) delete process.env.SOURCE_DATE_EPOCH;
+      else process.env.SOURCE_DATE_EPOCH = original;
+    }
+  });
 });
 
 describe('breeze-ext pack CLI', () => {

--- a/packages/extension-cli/src/commands/pack.test.ts
+++ b/packages/extension-cli/src/commands/pack.test.ts
@@ -1,0 +1,169 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import StreamZip from 'node-stream-zip';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createProgram } from '../cli';
+import { packExtension } from './pack';
+
+const VALID_MANIFEST = {
+  apiVersion: 'breeze.extensions/v1',
+  name: 'acme-widgets',
+  version: '1.0.0',
+  routeNamespace: 'acme-widgets',
+  requires: { breeze: '>=0.1.0 <0.2.0', serverSdk: '^1.0.0', capabilities: [] },
+  server: { entry: 'server/index.js' },
+  schemaCompatibilityFloor: '1.0.0',
+  jobs: [],
+  aiTools: [],
+};
+
+let sourceDir: string;
+let workDir: string;
+
+beforeEach(async () => {
+  sourceDir = await mkdtemp(join(tmpdir(), 'breeze-ext-pack-src-'));
+  workDir = await mkdtemp(join(tmpdir(), 'breeze-ext-pack-out-'));
+});
+
+afterEach(async () => {
+  await rm(sourceDir, { recursive: true, force: true });
+  await rm(workDir, { recursive: true, force: true });
+});
+
+async function writeFixture(relPath: string, contents: string | object): Promise<void> {
+  const fullPath = join(sourceDir, ...relPath.split('/'));
+  await mkdir(join(fullPath, '..'), { recursive: true });
+  const body = typeof contents === 'string' ? contents : JSON.stringify(contents);
+  await writeFile(fullPath, body);
+}
+
+async function writeValidFixtureTree(): Promise<void> {
+  await writeFixture('manifest.json', VALID_MANIFEST);
+  await writeFixture('server/index.js', 'module.exports = () => {};');
+  await writeFixture('migrations/0001_init.sql', 'select 1;');
+}
+
+async function readZipEntries(archivePath: string): Promise<Record<string, Buffer>> {
+  const zip = new StreamZip.async({ file: archivePath });
+  try {
+    const entries = await zip.entries();
+    const out: Record<string, Buffer> = {};
+    for (const name of Object.keys(entries)) {
+      out[name] = await zip.entryData(name);
+    }
+    return out;
+  } finally {
+    await zip.close();
+  }
+}
+
+describe('packExtension', () => {
+  it('packs a fixture source tree to an archive containing manifest.json, integrity.json, the server entry, and migrations', async () => {
+    await writeValidFixtureTree();
+    const destination = join(workDir, 'out.breeze-ext');
+
+    const result = await packExtension({ path: sourceDir, out: destination });
+
+    expect(result.artifactPath).toBe(destination);
+    const entries = await readZipEntries(destination);
+    expect(Object.keys(entries).sort()).toEqual([
+      'integrity.json',
+      'manifest.json',
+      'migrations/0001_init.sql',
+      'server/index.js',
+    ]);
+    expect(entries['signature']).toBeUndefined();
+  });
+
+  it('inventories every non-reserved member and nothing else in integrity.json, including manifest.json', async () => {
+    await writeValidFixtureTree();
+    const destination = join(workDir, 'out.breeze-ext');
+
+    await packExtension({ path: sourceDir, out: destination });
+
+    const entries = await readZipEntries(destination);
+    const integrity = JSON.parse(entries['integrity.json'].toString('utf8'));
+    expect(Object.keys(integrity.members).sort()).toEqual([
+      'manifest.json',
+      'migrations/0001_init.sql',
+      'server/index.js',
+    ]);
+  });
+
+  it('rejects an invalid manifest', async () => {
+    await writeFixture('manifest.json', { ...VALID_MANIFEST, apiVersion: 'breeze.extensions/v2' });
+    await writeFixture('server/index.js', 'module.exports = () => {};');
+    const destination = join(workDir, 'out.breeze-ext');
+
+    await expect(packExtension({ path: sourceDir, out: destination })).rejects.toThrow();
+  });
+
+  it('refuses a source tree containing a reserved "integrity.json" member', async () => {
+    await writeValidFixtureTree();
+    await writeFixture('integrity.json', '{}');
+    const destination = join(workDir, 'out.breeze-ext');
+
+    await expect(packExtension({ path: sourceDir, out: destination })).rejects.toThrow(/reserved member/);
+  });
+
+  it('refuses a source tree containing a reserved "signature" member', async () => {
+    await writeValidFixtureTree();
+    await writeFixture('signature', 'sig-bytes');
+    const destination = join(workDir, 'out.breeze-ext');
+
+    await expect(packExtension({ path: sourceDir, out: destination })).rejects.toThrow(/reserved member/);
+  });
+
+  it('refuses to follow a symlink in the source tree', async () => {
+    await writeValidFixtureTree();
+    await symlink(join(sourceDir, 'server/index.js'), join(sourceDir, 'server/linked.js'));
+    const destination = join(workDir, 'out.breeze-ext');
+
+    await expect(packExtension({ path: sourceDir, out: destination })).rejects.toThrow(/symlink/);
+  });
+
+  it('writes <name>-<version>.breeze-ext when --out is a directory', async () => {
+    await writeValidFixtureTree();
+
+    const result = await packExtension({ path: sourceDir, out: workDir });
+
+    expect(result.artifactPath).toBe(join(workDir, 'acme-widgets-1.0.0.breeze-ext'));
+    const entries = await readZipEntries(result.artifactPath);
+    expect(Object.keys(entries)).toContain('manifest.json');
+  });
+
+  it('returns a digest in the sha256:<hex> artifact-digest form', async () => {
+    await writeValidFixtureTree();
+    const destination = join(workDir, 'out.breeze-ext');
+
+    const result = await packExtension({ path: sourceDir, out: destination });
+
+    expect(result.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it('packs identical source trees to identical artifact bytes', async () => {
+    await writeValidFixtureTree();
+    const destinationA = join(workDir, 'a.breeze-ext');
+    const destinationB = join(workDir, 'b.breeze-ext');
+
+    const resultA = await packExtension({ path: sourceDir, out: destinationA });
+    const resultB = await packExtension({ path: sourceDir, out: destinationB });
+
+    expect(resultA.digest).toBe(resultB.digest);
+  });
+});
+
+describe('breeze-ext pack CLI', () => {
+  it('packs via the CLI command form: pack <sourceDir> --out <path>', async () => {
+    await writeValidFixtureTree();
+    const destination = join(workDir, 'cli-out.breeze-ext');
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'breeze-ext', 'pack', sourceDir, '--out', destination]);
+
+    const entries = await readZipEntries(destination);
+    expect(Object.keys(entries)).toContain('integrity.json');
+  });
+});

--- a/packages/extension-cli/src/commands/pack.ts
+++ b/packages/extension-cli/src/commands/pack.ts
@@ -1,0 +1,18 @@
+/**
+ * `breeze-ext pack` — writes a deterministic `.breeze-ext` ZIP bundle (with
+ * integrity inventory) from an extension source directory.
+ *
+ * Not implemented yet: the deterministic ZIP writer and integrity inventory
+ * land in later tasks (Task 2 and Task 3 of this plan).
+ */
+
+export interface PackOptions {
+  /** Path to the extension source directory (contains the manifest). */
+  path: string;
+  /** Output path for the produced `.breeze-ext` bundle. */
+  out: string;
+}
+
+export async function runPack(_options: PackOptions): Promise<never> {
+  throw new Error('breeze-ext pack: not implemented yet');
+}

--- a/packages/extension-cli/src/commands/pack.ts
+++ b/packages/extension-cli/src/commands/pack.ts
@@ -2,17 +2,94 @@
  * `breeze-ext pack` — writes a deterministic `.breeze-ext` ZIP bundle (with
  * integrity inventory) from an extension source directory.
  *
- * Not implemented yet: the deterministic ZIP writer and integrity inventory
- * land in later tasks (Task 2 and Task 3 of this plan).
+ * Signing is not implemented yet — `sign` (Task 5 of this plan) turns the
+ * unsigned artifact this command produces into a verifiable one by adding a
+ * `signature` member. An unsigned artifact is a valid intermediate.
  */
+
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { parseExtensionManifestV1 } from '@breeze/extension-sdk';
+import { collectPayload } from '../artifact/collectPayload';
+import { writeDeterministicZip } from '../artifact/deterministicZip';
+import { buildIntegrityDocument } from '../artifact/integrity';
 
 export interface PackOptions {
   /** Path to the extension source directory (contains the manifest). */
   path: string;
-  /** Output path for the produced `.breeze-ext` bundle. */
+  /**
+   * Output path for the produced `.breeze-ext` bundle. If this names an
+   * existing directory, the artifact is written inside it as
+   * `<name>-<version>.breeze-ext`, taken from the manifest.
+   */
   out: string;
 }
 
-export async function runPack(_options: PackOptions): Promise<never> {
-  throw new Error('breeze-ext pack: not implemented yet');
+export interface PackResult {
+  /** Path the `.breeze-ext` artifact was actually written to. */
+  artifactPath: string;
+  /** `sha256:` + hex digest of the whole artifact file (not a bare payload member hash). */
+  digest: string;
+}
+
+/**
+ * Pinned to the Unix epoch rather than the current time so that packing the
+ * same source tree twice — on any machine, at any time — produces
+ * byte-identical archives. `writeDeterministicZip` bakes this into every
+ * entry's timestamp.
+ */
+const SOURCE_DATE_EPOCH = 0;
+
+async function sha256File(filePath: string): Promise<string> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(filePath), hash);
+  return hash.digest('hex');
+}
+
+async function resolveArtifactPath(out: string, name: string, version: string): Promise<string> {
+  const outIsDirectory = await stat(out).then((info) => info.isDirectory(), () => false);
+  return outIsDirectory ? join(out, `${name}-${version}.breeze-ext`) : out;
+}
+
+/**
+ * Pack an extension source directory into an unsigned `.breeze-ext` bundle.
+ *
+ * Order is load-bearing:
+ *   1. Collect payload members (manifest, server entry, optional web,
+ *      optional migrations) via `collectPayload` — which also validates the
+ *      manifest and refuses symlinks and reserved member names.
+ *   2. Build `integrity.json` over exactly those members.
+ *   3. Write the ZIP containing the payload members plus `integrity.json` —
+ *      no `signature` yet.
+ *   4. Hash the finished artifact file for the returned digest.
+ */
+export async function packExtension(options: PackOptions): Promise<PackResult> {
+  const members = await collectPayload(options.path);
+
+  // collectPayload already validates manifest.json and guarantees its
+  // presence; re-parse the already-known-good bytes here only to read
+  // name/version for the output filename.
+  const manifestMember = members.find((member) => member.path === 'manifest.json')!;
+  const manifest = parseExtensionManifestV1(JSON.parse(manifestMember.bytes.toString('utf8')));
+
+  const integrityBytes = buildIntegrityDocument(members);
+  const artifactPath = await resolveArtifactPath(options.out, manifest.name, manifest.version);
+
+  await writeDeterministicZip(
+    [...members, { path: 'integrity.json', bytes: integrityBytes }],
+    artifactPath,
+    { sourceDateEpoch: SOURCE_DATE_EPOCH },
+  );
+
+  const digest = `sha256:${await sha256File(artifactPath)}`;
+  return { artifactPath, digest };
+}
+
+export async function runPack(options: PackOptions): Promise<void> {
+  const result = await packExtension(options);
+  console.log(result.artifactPath);
+  console.log(result.digest);
 }

--- a/packages/extension-cli/src/commands/pack.ts
+++ b/packages/extension-cli/src/commands/pack.ts
@@ -52,7 +52,7 @@ export interface PackResult {
  * a caller who sets `SOURCE_DATE_EPOCH` expects it honored, and quietly
  * ignoring a typo would produce a differently-timestamped artifact than intended.
  */
-function resolveSourceDateEpoch(explicit: number | undefined): number {
+export function resolveSourceDateEpoch(explicit: number | undefined): number {
   if (explicit !== undefined) return explicit;
   const raw = process.env.SOURCE_DATE_EPOCH;
   if (raw === undefined || raw === '') return 0;

--- a/packages/extension-cli/src/commands/pack.ts
+++ b/packages/extension-cli/src/commands/pack.ts
@@ -26,6 +26,12 @@ export interface PackOptions {
    * `<name>-<version>.breeze-ext`, taken from the manifest.
    */
   out: string;
+  /**
+   * Unix timestamp (seconds) baked into every archive entry so identical
+   * source trees produce byte-identical artifacts. When omitted, resolved from
+   * the `SOURCE_DATE_EPOCH` environment variable, falling back to `0`.
+   */
+  sourceDateEpoch?: number;
 }
 
 export interface PackResult {
@@ -36,12 +42,25 @@ export interface PackResult {
 }
 
 /**
- * Pinned to the Unix epoch rather than the current time so that packing the
- * same source tree twice — on any machine, at any time — produces
- * byte-identical archives. `writeDeterministicZip` bakes this into every
- * entry's timestamp.
+ * Resolve the timestamp baked into every archive entry. Precedence: an explicit
+ * `options.sourceDateEpoch`, then the `SOURCE_DATE_EPOCH` environment variable
+ * (the reproducible-builds convention), then `0`. Pinning it — rather than
+ * using the current time — is what makes packing the same source tree twice, on
+ * any machine at any time, produce byte-identical archives.
+ *
+ * A present-but-unparseable env value is an error, not a silent fallback to 0:
+ * a caller who sets `SOURCE_DATE_EPOCH` expects it honored, and quietly
+ * ignoring a typo would produce a differently-timestamped artifact than intended.
  */
-const SOURCE_DATE_EPOCH = 0;
+function resolveSourceDateEpoch(explicit: number | undefined): number {
+  if (explicit !== undefined) return explicit;
+  const raw = process.env.SOURCE_DATE_EPOCH;
+  if (raw === undefined || raw === '') return 0;
+  if (!/^\d+$/.test(raw)) {
+    throw new Error('SOURCE_DATE_EPOCH must be a non-negative integer number of seconds');
+  }
+  return Number(raw);
+}
 
 async function sha256File(filePath: string): Promise<string> {
   const hash = createHash('sha256');
@@ -77,11 +96,12 @@ export async function packExtension(options: PackOptions): Promise<PackResult> {
 
   const integrityBytes = buildIntegrityDocument(members);
   const artifactPath = await resolveArtifactPath(options.out, manifest.name, manifest.version);
+  const sourceDateEpoch = resolveSourceDateEpoch(options.sourceDateEpoch);
 
   await writeDeterministicZip(
     [...members, { path: 'integrity.json', bytes: integrityBytes }],
     artifactPath,
-    { sourceDateEpoch: SOURCE_DATE_EPOCH },
+    { sourceDateEpoch },
   );
 
   const digest = `sha256:${await sha256File(artifactPath)}`;

--- a/packages/extension-cli/src/commands/sign.test.ts
+++ b/packages/extension-cli/src/commands/sign.test.ts
@@ -1,0 +1,328 @@
+import { createPublicKey, generateKeyPairSync, verify as cryptoVerify } from 'node:crypto';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import StreamZip from 'node-stream-zip';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseExtensionManifestV1 } from '@breeze/extension-sdk';
+import { writeDeterministicZip } from '../artifact/deterministicZip';
+import { signingPayload } from '../artifact/integrity';
+import { createProgram } from '../cli';
+import { packExtension } from './pack';
+import { runSign, signArtifact } from './sign';
+
+const VALID_MANIFEST = {
+  apiVersion: 'breeze.extensions/v1',
+  name: 'acme-widgets',
+  version: '1.0.0',
+  routeNamespace: 'acme-widgets',
+  requires: { breeze: '>=0.1.0 <0.2.0', serverSdk: '^1.0.0', capabilities: [] },
+  server: { entry: 'server/index.js' },
+  schemaCompatibilityFloor: '1.0.0',
+  jobs: [],
+  aiTools: [],
+};
+
+let sourceDir: string;
+let workDir: string;
+
+beforeEach(async () => {
+  sourceDir = await mkdtemp(join(tmpdir(), 'breeze-ext-sign-src-'));
+  workDir = await mkdtemp(join(tmpdir(), 'breeze-ext-sign-out-'));
+});
+
+afterEach(async () => {
+  await rm(sourceDir, { recursive: true, force: true });
+  await rm(workDir, { recursive: true, force: true });
+});
+
+async function writeFixture(relPath: string, contents: string | object): Promise<void> {
+  const fullPath = join(sourceDir, ...relPath.split('/'));
+  await mkdir(join(fullPath, '..'), { recursive: true });
+  const body = typeof contents === 'string' ? contents : JSON.stringify(contents);
+  await writeFile(fullPath, body);
+}
+
+async function writeValidFixtureTree(): Promise<void> {
+  await writeFixture('manifest.json', VALID_MANIFEST);
+  await writeFixture('server/index.js', 'module.exports = () => {};');
+  await writeFixture('migrations/0001_init.sql', 'select 1;');
+}
+
+async function readZipEntries(archivePath: string): Promise<Record<string, Buffer>> {
+  const zip = new StreamZip.async({ file: archivePath });
+  try {
+    const entries = await zip.entries();
+    const out: Record<string, Buffer> = {};
+    for (const name of Object.keys(entries)) {
+      out[name] = await zip.entryData(name);
+    }
+    return out;
+  } finally {
+    await zip.close();
+  }
+}
+
+function generateEd25519Pem() {
+  return generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+
+function generateRsaPem() {
+  return generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+
+async function packFixture(): Promise<{ artifactPath: string; digest: string }> {
+  await writeValidFixtureTree();
+  return packExtension({ path: sourceDir, out: join(workDir, 'unsigned.breeze-ext') });
+}
+
+describe('signArtifact', () => {
+  it('signs an unsigned artifact so the signature member verifies under the matching public key', async () => {
+    const packed = await packFixture();
+    const { privateKey, publicKey } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pem');
+    await writeFile(keyPath, privateKey);
+
+    const signed = await signArtifact({ artifact: packed.artifactPath, key: keyPath });
+
+    const entries = await readZipEntries(signed.artifactPath);
+    const manifest = parseExtensionManifestV1(JSON.parse(entries['manifest.json'].toString('utf8')));
+    const payload = signingPayload(manifest, entries['manifest.json'], entries['integrity.json']);
+
+    expect(cryptoVerify(null, payload, createPublicKey(publicKey), entries['signature'])).toBe(true);
+  });
+
+  it('fails verification under a different keypair', async () => {
+    const packed = await packFixture();
+    const { privateKey } = generateEd25519Pem();
+    const { publicKey: otherPublicKey } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pem');
+    await writeFile(keyPath, privateKey);
+
+    const signed = await signArtifact({ artifact: packed.artifactPath, key: keyPath });
+
+    const entries = await readZipEntries(signed.artifactPath);
+    const manifest = parseExtensionManifestV1(JSON.parse(entries['manifest.json'].toString('utf8')));
+    const payload = signingPayload(manifest, entries['manifest.json'], entries['integrity.json']);
+
+    expect(
+      cryptoVerify(null, payload, createPublicKey(otherPublicKey), entries['signature']),
+    ).toBe(false);
+  });
+
+  it('a mutated integrity.json invalidates the signature', async () => {
+    const packed = await packFixture();
+    const { privateKey, publicKey } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pem');
+    await writeFile(keyPath, privateKey);
+
+    const signed = await signArtifact({ artifact: packed.artifactPath, key: keyPath });
+    const entries = await readZipEntries(signed.artifactPath);
+
+    // Tamper with integrity.json bytes but carry over the original signature.
+    const tamperedIntegrityBytes = Buffer.concat([entries['integrity.json'], Buffer.from(' ')]);
+    const tamperedMembers = Object.entries(entries)
+      .filter(([name]) => name !== 'integrity.json')
+      .map(([path, bytes]) => ({ path, bytes }));
+    tamperedMembers.push({ path: 'integrity.json', bytes: tamperedIntegrityBytes });
+
+    const tamperedPath = join(workDir, 'tampered.breeze-ext');
+    await writeDeterministicZip(tamperedMembers, tamperedPath, { sourceDateEpoch: 0 });
+
+    const tamperedEntries = await readZipEntries(tamperedPath);
+    const manifest = parseExtensionManifestV1(JSON.parse(tamperedEntries['manifest.json'].toString('utf8')));
+    const payload = signingPayload(manifest, tamperedEntries['manifest.json'], tamperedEntries['integrity.json']);
+
+    expect(
+      cryptoVerify(null, payload, createPublicKey(publicKey), tamperedEntries['signature']),
+    ).toBe(false);
+  });
+
+  it('writes the signature member as raw bytes, not parseable JSON', async () => {
+    const packed = await packFixture();
+    const { privateKey } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pem');
+    await writeFile(keyPath, privateKey);
+
+    const signed = await signArtifact({ artifact: packed.artifactPath, key: keyPath });
+    const entries = await readZipEntries(signed.artifactPath);
+
+    expect(entries['signature'].length).toBe(64); // raw Ed25519 signature length
+    expect(() => JSON.parse(entries['signature'].toString('utf8'))).toThrow();
+  });
+
+  it('rejects a non-Ed25519 (RSA) key', async () => {
+    const packed = await packFixture();
+    const { privateKey } = generateRsaPem();
+    const keyPath = join(workDir, 'rsa-key.pem');
+    await writeFile(keyPath, privateKey);
+
+    await expect(
+      signArtifact({ artifact: packed.artifactPath, key: keyPath }),
+    ).rejects.toThrow(/ed25519/i);
+  });
+
+  it('re-signing an already-signed artifact replaces the signature member', async () => {
+    const packed = await packFixture();
+    const keyA = generateEd25519Pem();
+    const keyAPath = join(workDir, 'key-a.pem');
+    await writeFile(keyAPath, keyA.privateKey);
+
+    const firstSigned = await signArtifact({ artifact: packed.artifactPath, key: keyAPath });
+
+    const keyB = generateEd25519Pem();
+    const keyBPath = join(workDir, 'key-b.pem');
+    await writeFile(keyBPath, keyB.privateKey);
+
+    const resigned = await signArtifact({ artifact: firstSigned.artifactPath, key: keyBPath });
+
+    const entries = await readZipEntries(resigned.artifactPath);
+    expect(Object.keys(entries).filter((name) => name === 'signature')).toHaveLength(1);
+
+    const manifest = parseExtensionManifestV1(JSON.parse(entries['manifest.json'].toString('utf8')));
+    const payload = signingPayload(manifest, entries['manifest.json'], entries['integrity.json']);
+
+    expect(cryptoVerify(null, payload, createPublicKey(keyB.publicKey), entries['signature'])).toBe(true);
+    expect(cryptoVerify(null, payload, createPublicKey(keyA.publicKey), entries['signature'])).toBe(false);
+    expect(resigned.digest).not.toBe(firstSigned.digest);
+  });
+
+  it('prints/returns a digest that differs from the unsigned artifact digest', async () => {
+    const packed = await packFixture();
+    const { privateKey } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pem');
+    await writeFile(keyPath, privateKey);
+
+    const signed = await signArtifact({ artifact: packed.artifactPath, key: keyPath });
+
+    expect(signed.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(signed.digest).not.toBe(packed.digest);
+  });
+
+  it('writes to --out when given, leaving the original artifact untouched', async () => {
+    const packed = await packFixture();
+    const { privateKey } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pem');
+    await writeFile(keyPath, privateKey);
+    const outPath = join(workDir, 'signed.breeze-ext');
+
+    const signed = await signArtifact({ artifact: packed.artifactPath, key: keyPath, out: outPath });
+
+    expect(signed.artifactPath).toBe(outPath);
+    const unsignedEntries = await readZipEntries(packed.artifactPath);
+    expect(unsignedEntries['signature']).toBeUndefined();
+    const signedEntries = await readZipEntries(outPath);
+    expect(signedEntries['signature']).toBeDefined();
+  });
+});
+
+describe('secret hygiene', () => {
+  it('never leaks key material into stdout, stderr, or thrown error text on a failed signing run', async () => {
+    const packed = await packFixture();
+    const { privateKey } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pem');
+    await writeFile(keyPath, privateKey);
+
+    // Fails AFTER the real key has been read and used to sign the payload:
+    // SOURCE_DATE_EPOCH is unparseable, which the ZIP writer's epoch
+    // resolution rejects synchronously, before any output file is opened.
+    const originalEpoch = process.env.SOURCE_DATE_EPOCH;
+    process.env.SOURCE_DATE_EPOCH = 'not-a-number';
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((msg: unknown) => {
+      stdout.push(String(msg));
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation((msg: unknown) => {
+      stderr.push(String(msg));
+    });
+
+    let thrown: unknown;
+    try {
+      await runSign({ artifact: packed.artifactPath, key: keyPath });
+    } catch (error) {
+      thrown = error;
+      console.error(error instanceof Error ? error.message : String(error));
+    } finally {
+      if (originalEpoch === undefined) delete process.env.SOURCE_DATE_EPOCH;
+      else process.env.SOURCE_DATE_EPOCH = originalEpoch;
+    }
+
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+
+    expect(thrown).toBeInstanceOf(Error);
+
+    const keyBase64Body = privateKey
+      .split('\n')
+      .filter((line) => line.length > 0 && !line.startsWith('-----'))
+      .join('');
+    expect(keyBase64Body.length).toBeGreaterThan(0);
+
+    const haystacks = [
+      ...stdout,
+      ...stderr,
+      (thrown as Error).message,
+      (thrown as Error).stack ?? '',
+    ];
+    for (const haystack of haystacks) {
+      expect(haystack).not.toContain(privateKey);
+      expect(haystack).not.toContain(keyBase64Body);
+      expect(haystack.toLowerCase()).not.toContain('begin private key');
+    }
+  });
+});
+
+describe('breeze-ext sign CLI', () => {
+  it('signs via the CLI command form: sign <artifact> --key <path>', async () => {
+    const packed = await packFixture();
+    const { privateKey, publicKey } = generateEd25519Pem();
+    const keyPath = join(workDir, 'key.pem');
+    await writeFile(keyPath, privateKey);
+    const outPath = join(workDir, 'cli-signed.breeze-ext');
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync([
+      'node', 'breeze-ext', 'sign', packed.artifactPath, '--key', keyPath, '--out', outPath,
+    ]);
+
+    const entries = await readZipEntries(outPath);
+    const manifest = parseExtensionManifestV1(JSON.parse(entries['manifest.json'].toString('utf8')));
+    const payload = signingPayload(manifest, entries['manifest.json'], entries['integrity.json']);
+    expect(cryptoVerify(null, payload, createPublicKey(publicKey), entries['signature'])).toBe(true);
+  });
+
+  it('signs via the CLI command form: sign <artifact> --key-env <VAR>', async () => {
+    const packed = await packFixture();
+    const { privateKey, publicKey } = generateEd25519Pem();
+    process.env.TEST_BREEZE_SIGN_CLI_KEY = privateKey;
+    const outPath = join(workDir, 'cli-signed-env.breeze-ext');
+
+    try {
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync([
+        'node', 'breeze-ext', 'sign', packed.artifactPath,
+        '--key-env', 'TEST_BREEZE_SIGN_CLI_KEY', '--out', outPath,
+      ]);
+
+      const entries = await readZipEntries(outPath);
+      const manifest = parseExtensionManifestV1(JSON.parse(entries['manifest.json'].toString('utf8')));
+      const payload = signingPayload(manifest, entries['manifest.json'], entries['integrity.json']);
+      expect(cryptoVerify(null, payload, createPublicKey(publicKey), entries['signature'])).toBe(true);
+    } finally {
+      delete process.env.TEST_BREEZE_SIGN_CLI_KEY;
+    }
+  });
+});

--- a/packages/extension-cli/src/commands/sign.ts
+++ b/packages/extension-cli/src/commands/sign.ts
@@ -7,10 +7,19 @@
  */
 
 export interface SignOptions {
-  /** Path to the `.breeze-ext` bundle to sign. */
-  bundle: string;
-  /** Path to the Ed25519 private key used to sign the bundle. */
-  key: string;
+  /** Path to the `.breeze-ext` artifact to sign. */
+  artifact: string;
+  /**
+   * Path to a file holding the Ed25519 private key. Mutually exclusive with
+   * {@link keyEnv}; exactly one is supplied.
+   */
+  key?: string;
+  /**
+   * Name of an environment variable holding the Ed25519 private key. The key
+   * value is never accepted on argv, which is world-readable via `ps`.
+   * Mutually exclusive with {@link key}; exactly one is supplied.
+   */
+  keyEnv?: string;
   /** Output path for the signed bundle. Defaults to signing in place. */
   out?: string;
 }

--- a/packages/extension-cli/src/commands/sign.ts
+++ b/packages/extension-cli/src/commands/sign.ts
@@ -1,10 +1,21 @@
 /**
- * `breeze-ext sign` — signs a `.breeze-ext` bundle's integrity inventory
- * with an Ed25519 private key, per the frozen wire format that
- * `apps/api/src/extensions/bundleVerifier.ts` expects.
- *
- * Not implemented yet: Ed25519 signing lands in Task 5 of this plan.
+ * `breeze-ext sign` — signs a `.breeze-ext` bundle's payload with an Ed25519
+ * private key, per the frozen wire format that
+ * `apps/api/src/extensions/bundleVerifier.ts` expects: the `signature`
+ * archive member is RAW Ed25519 signature bytes over `signingPayload`
+ * (`../artifact/integrity.ts`, kept byte-identical to the verifier's
+ * `canonicalSigningPayload`) — no JSON envelope, no keyId, no algorithm field.
  */
+
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { pipeline } from 'node:stream/promises';
+import StreamZip from 'node-stream-zip';
+import { parseExtensionManifestV1 } from '@breeze/extension-sdk';
+import { type DeterministicZipMember, writeDeterministicZip } from '../artifact/deterministicZip';
+import { signingPayload } from '../artifact/integrity';
+import { loadEd25519PrivateKey, signEd25519 } from '../artifact/signature';
+import { resolveSourceDateEpoch } from './pack';
 
 export interface SignOptions {
   /** Path to the `.breeze-ext` artifact to sign. */
@@ -24,6 +35,103 @@ export interface SignOptions {
   out?: string;
 }
 
-export async function runSign(_options: SignOptions): Promise<never> {
-  throw new Error('breeze-ext sign: not implemented yet');
+export interface SignResult {
+  /** Path the signed `.breeze-ext` artifact was actually written to. */
+  artifactPath: string;
+  /** `sha256:` + hex digest of the signed artifact file. */
+  digest: string;
+}
+
+/**
+ * Read every non-directory member out of a `.breeze-ext` archive, fully into
+ * memory, and close the reader. Reading everything up front (rather than
+ * streaming lazily) is what makes signing in place safe: the reader is closed
+ * before {@link writeDeterministicZip} ever opens the same path for writing.
+ */
+async function readArtifactMembers(archivePath: string): Promise<DeterministicZipMember[]> {
+  const zip = new StreamZip.async({ file: archivePath });
+  try {
+    const entries = await zip.entries();
+    const members: DeterministicZipMember[] = [];
+    for (const entry of Object.values(entries)) {
+      if (entry.isDirectory) continue;
+      members.push({ path: entry.name, bytes: await zip.entryData(entry.name) });
+    }
+    return members;
+  } finally {
+    await zip.close();
+  }
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(filePath), hash);
+  return hash.digest('hex');
+}
+
+/**
+ * Sign a `.breeze-ext` artifact.
+ *
+ * Steps (order is load-bearing):
+ *   1. Read every member out of the artifact (payload members, `integrity.json`,
+ *      and any pre-existing `signature`).
+ *   2. Parse `manifest.json` (via the SDK) for the payload's identity fields.
+ *   3. Rebuild the signing payload with the SAME `signingPayload` function
+ *      `pack` relied on to build `integrity.json`.
+ *   4. Sign with the loaded Ed25519 private key.
+ *   5. Re-emit the archive through the same deterministic ZIP writer `pack`
+ *      uses: every existing member except any prior `signature`, plus the new
+ *      `signature`.
+ *
+ * Re-signing an already-signed artifact REPLACES the existing `signature`
+ * member rather than refusing. The caller supplied a key and explicitly asked
+ * to sign this artifact; producing a freshly (re-)signed artifact under that
+ * key is the useful behavior for re-keying or re-signing after a `pack`
+ * re-run, and the archive still ends up with exactly one `signature` member,
+ * matching the frozen verifier's expectations.
+ */
+export async function signArtifact(options: SignOptions): Promise<SignResult> {
+  const members = await readArtifactMembers(options.artifact);
+  const memberBytes = new Map(members.map((member) => [member.path, member.bytes]));
+
+  const manifestBytes = memberBytes.get('manifest.json');
+  if (!manifestBytes) {
+    throw new Error('artifact is missing required member "manifest.json"');
+  }
+  const integrityBytes = memberBytes.get('integrity.json');
+  if (!integrityBytes) {
+    throw new Error('artifact is missing required member "integrity.json"');
+  }
+
+  let manifestRaw: unknown;
+  try {
+    manifestRaw = JSON.parse(manifestBytes.toString('utf8'));
+  } catch {
+    throw new Error('manifest.json is not valid JSON');
+  }
+  const manifest = parseExtensionManifestV1(manifestRaw);
+
+  const privateKey = await loadEd25519PrivateKey({ key: options.key, keyEnv: options.keyEnv });
+  const payload = signingPayload(manifest, manifestBytes, integrityBytes);
+  const signature = signEd25519(privateKey, payload);
+
+  // Drop any prior `signature` member -- re-signing replaces it, never stacks.
+  const payloadMembers = members.filter((member) => member.path !== 'signature');
+  const artifactPath = options.out ?? options.artifact;
+  const sourceDateEpoch = resolveSourceDateEpoch(undefined);
+
+  await writeDeterministicZip(
+    [...payloadMembers, { path: 'signature', bytes: signature }],
+    artifactPath,
+    { sourceDateEpoch },
+  );
+
+  const digest = `sha256:${await sha256File(artifactPath)}`;
+  return { artifactPath, digest };
+}
+
+export async function runSign(options: SignOptions): Promise<void> {
+  const result = await signArtifact(options);
+  console.log(result.artifactPath);
+  console.log(result.digest);
 }

--- a/packages/extension-cli/src/commands/sign.ts
+++ b/packages/extension-cli/src/commands/sign.ts
@@ -1,0 +1,20 @@
+/**
+ * `breeze-ext sign` — signs a `.breeze-ext` bundle's integrity inventory
+ * with an Ed25519 private key, per the frozen wire format that
+ * `apps/api/src/extensions/bundleVerifier.ts` expects.
+ *
+ * Not implemented yet: Ed25519 signing lands in Task 5 of this plan.
+ */
+
+export interface SignOptions {
+  /** Path to the `.breeze-ext` bundle to sign. */
+  bundle: string;
+  /** Path to the Ed25519 private key used to sign the bundle. */
+  key: string;
+  /** Output path for the signed bundle. Defaults to signing in place. */
+  out?: string;
+}
+
+export async function runSign(_options: SignOptions): Promise<never> {
+  throw new Error('breeze-ext sign: not implemented yet');
+}

--- a/packages/extension-cli/src/commands/validate.ts
+++ b/packages/extension-cli/src/commands/validate.ts
@@ -1,0 +1,18 @@
+/**
+ * `breeze-ext validate` — checks an extension source directory's manifest
+ * and layout for conformance before packing.
+ *
+ * Not implemented yet: manifest schema validation, capability checks, and
+ * route-namespace collision checks land in a later task.
+ */
+
+export interface ValidateOptions {
+  /** Path to the extension source directory (contains the manifest). */
+  path: string;
+  /** Emit machine-readable JSON instead of human-readable text. */
+  json?: boolean;
+}
+
+export async function runValidate(_options: ValidateOptions): Promise<never> {
+  throw new Error('breeze-ext validate: not implemented yet');
+}

--- a/packages/extension-cli/src/index.ts
+++ b/packages/extension-cli/src/index.ts
@@ -11,6 +11,13 @@
 export { createProgram } from './cli';
 
 export { runInspect, type InspectOptions } from './commands/inspect';
-export { runPack, type PackOptions } from './commands/pack';
-export { runSign, type SignOptions } from './commands/sign';
+export { packExtension, runPack, type PackOptions, type PackResult } from './commands/pack';
+export { runSign, signArtifact, type SignOptions, type SignResult } from './commands/sign';
 export { runValidate, type ValidateOptions } from './commands/validate';
+
+// Artifact-building primitives, exposed so conformance tests and downstream
+// tooling can drive the same functions the CLI commands use — notably
+// `signingPayload`, which must stay byte-identical to the host verifier's
+// canonical signing payload.
+export { buildIntegrityDocument, signingPayload } from './artifact/integrity';
+export { canonicalJson } from './artifact/canonicalJson';

--- a/packages/extension-cli/src/index.ts
+++ b/packages/extension-cli/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Public module surface of `@breeze/extension-cli`.
+ *
+ * Importing this module must never touch the filesystem or network: it only
+ * exports the CLI program factory and the individual command entry points,
+ * all of which are plain functions that perform I/O when *called*, not when
+ * *imported*. The `breeze-ext` binary (`src/cli.ts`) is the only module that
+ * executes anything at load time, and only when run as the main module.
+ */
+
+export { createProgram } from './cli';
+
+export { runInspect, type InspectOptions } from './commands/inspect';
+export { runPack, type PackOptions } from './commands/pack';
+export { runSign, type SignOptions } from './commands/sign';
+export { runValidate, type ValidateOptions } from './commands/validate';

--- a/packages/extension-cli/src/index.ts
+++ b/packages/extension-cli/src/index.ts
@@ -10,7 +10,14 @@
 
 export { createProgram } from './cli';
 
-export { runInspect, type InspectOptions } from './commands/inspect';
+export {
+  inspectArtifact,
+  runInspect,
+  type InspectFinding,
+  type InspectOptions,
+  type InspectResult,
+  type SignatureStatus,
+} from './commands/inspect';
 export { packExtension, runPack, type PackOptions, type PackResult } from './commands/pack';
 export { runSign, signArtifact, type SignOptions, type SignResult } from './commands/sign';
 export { runValidate, type ValidateOptions } from './commands/validate';

--- a/packages/extension-cli/tsconfig.json
+++ b/packages/extension-cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/extension-cli/vitest.config.ts
+++ b/packages/extension-cli/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1062,6 +1062,9 @@ importers:
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.3
+      node-stream-zip:
+        specifier: ^1.15.0
+        version: 1.15.0
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -14310,7 +14313,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1041,6 +1041,34 @@ importers:
         specifier: ^4.1.9
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/extension-cli:
+    dependencies:
+      '@breeze/extension-sdk':
+        specifier: workspace:*
+        version: link:../extension-sdk
+      archiver:
+        specifier: ^7.0.1
+        version: 7.0.1
+      commander:
+        specifier: ^15.0.0
+        version: 15.0.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/archiver':
+        specifier: ^7.0.0
+        version: 7.0.0
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/extension-sdk:
     dependencies:
       semver:
@@ -6033,6 +6061,10 @@ packages:
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -17081,6 +17113,8 @@ snapshots:
   commander@12.1.0: {}
 
   commander@13.1.0: {}
+
+  commander@15.0.0: {}
 
   commander@2.20.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@breeze/extension-cli':
+        specifier: workspace:*
+        version: link:../../packages/extension-cli
       '@types/archiver':
         specifier: ^7.0.0
         version: 7.0.0
@@ -14313,9 +14316,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.0': {}
 


### PR DESCRIPTION
Implements the `breeze-ext` packer/signer (Plan 04 Task 3) and the two-replica reconcile proof — the exit criteria of #2619, carried forward from Plan 02 (#2617).

**Stacked on #2617** (base branch `feat/runtime-ext-02-operations`). Review/merge after #2617.

## What this delivers

- **`@breeze/extension-cli`** — the `breeze-ext` CLI: `pack`, `sign`, `inspect`.
  - Deterministic ZIP writer (byte-identical output; verified cross-process).
  - `canonicalJson` transcribed from the frozen verifier; single shared `signingPayload`.
  - Ed25519 signing — the `signature` member is **raw bytes** (matching the shipped verifier; not a JSON envelope). Keys via `--key <path>` or `--key-env <VAR>`, never on argv; no key material touches logs/errors.
  - `SOURCE_DATE_EPOCH` support for reproducible releases.

- **Exit criterion 1 — wire-format conformance** (`apps/api/src/extensions/packerConformance.test.ts`): bundles produced by the real CLI verify against the **unmodified** `verifyExtensionBundle`. 8 negative/tamper cases, each proven load-bearing. Live drift-guard asserts the CLI's `signingPayload` is byte-identical to the verifier's `canonicalSigningPayload`.

- **Exit criteria 2 & 3 — two-replica reconcile + failure policy** (`apps/api/src/extensions/twoReplicaReconcile.integration.test.ts`): two forked OS processes reconcile one required + one optional signed extension; both activate, migrations apply **exactly once** (advisory-lock serialized — proven via ledger count *and* a non-idempotent migration), both converge. A failing required extension aborts boot on both; a failing optional one leaves both booting, recorded failed and withdrawn. The test self-provisions and drops its own isolated database, so it's robust against shared-container state.

## Frozen surface

`apps/api/src/extensions/bundleVerifier.ts` and all other Plan 02 code are **unmodified** on this branch — the packer conforms to the verifier, never the reverse.

## Verification

- `@breeze/extension-cli`: 103/103 tests, typecheck clean.
- `apps/api`: typecheck clean (0 errors); conformance 10/10; two-replica 3/3 (twice).
- No key material committed.

Also corrects the stale Plan 04 signature spec in `breeze-workspace` (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
