### PR TITLE
fix(migrations): non-superuser custom-GUC elevation (v0.97.1)

### DIFF
--- a/apps/api/migrations/2026-07-27-a-feature-policy-reference-ownership.sql
+++ b/apps/api/migrations/2026-07-27-a-feature-policy-reference-ownership.sql
@@ -220,7 +220,12 @@ BEGIN
   END IF;
 END $$;
 
-CREATE OR REPLACE FUNCTION public.breeze_config_policy_feature_reference_is_valid(
+-- Internal worker: assumes the caller has already established system scope.
+-- The public entry point below elevates + restores around it. (A non-superuser
+-- migration owner such as prod `doadmin` cannot use a `SET "breeze.scope"`
+-- function attribute — that requires privilege to set a custom GUC — so scope is
+-- managed explicitly in the wrapper instead.)
+CREATE OR REPLACE FUNCTION public.breeze_config_policy_feature_reference_is_valid_impl(
   checked_config_policy_id uuid,
   checked_feature_type public.config_feature_type,
   checked_feature_policy_id uuid
@@ -229,7 +234,6 @@ RETURNS boolean
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET "breeze.scope" = 'system'
 AS $$
 DECLARE
   parent_org_id uuid;
@@ -342,6 +346,36 @@ BEGIN
 END;
 $$;
 
+-- Public entry point. Elevates to system scope for the cross-tenant read and
+-- ALWAYS restores the caller's prior scope before returning. This matters
+-- because withDbAccessContext sets breeze.scope once per transaction and holds
+-- it for the whole transaction, so a bare SET LOCAL here would leak 'system'
+-- into the rest of the request. On any exception the subtransaction/transaction
+-- rollback restores breeze.scope automatically, so an explicit restore is only
+-- required on the normal return path.
+CREATE OR REPLACE FUNCTION public.breeze_config_policy_feature_reference_is_valid(
+  checked_config_policy_id uuid,
+  checked_feature_type public.config_feature_type,
+  checked_feature_policy_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _result boolean;
+BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  _result := public.breeze_config_policy_feature_reference_is_valid_impl(
+    checked_config_policy_id, checked_feature_type, checked_feature_policy_id
+  );
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  RETURN _result;
+END;
+$$;
+
 CREATE OR REPLACE FUNCTION public.breeze_validate_config_policy_feature_reference(
   checked_config_policy_id uuid,
   checked_feature_type public.config_feature_type,
@@ -351,7 +385,6 @@ RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET "breeze.scope" = 'system'
 AS $$
 BEGIN
   IF NOT public.breeze_config_policy_feature_reference_is_valid(
@@ -397,13 +430,17 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET "breeze.scope" = 'system'
 AS $$
 DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
   link record;
   reference_id uuid;
   prior_reference_id uuid;
 BEGIN
+  -- Elevate for the cross-tenant candidate reads below; restore before the
+  -- (single, end-of-body) return so 'system' does not leak into the rest of the
+  -- request transaction. On exception the (sub)transaction rollback restores it.
+  PERFORM set_config('breeze.scope', 'system', true);
   reference_id := CASE WHEN TG_OP = 'DELETE' THEN OLD.id ELSE NEW.id END;
   prior_reference_id := CASE WHEN TG_OP = 'UPDATE' THEN OLD.id ELSE reference_id END;
 
@@ -440,6 +477,7 @@ BEGIN
       );
     END LOOP;
   END IF;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
   IF TG_OP = 'DELETE' THEN
     RETURN OLD;
   END IF;

--- a/apps/api/migrations/2026-07-27-c-backup-feature-settings-parity.sql
+++ b/apps/api/migrations/2026-07-27-c-backup-feature-settings-parity.sql
@@ -46,14 +46,16 @@ BEGIN
   END IF;
 END $$;
 
-CREATE OR REPLACE FUNCTION public.breeze_backup_feature_settings_parity_is_valid(
+-- Internal worker: assumes system scope is already established by the public
+-- wrapper below. (Prod `doadmin` is a non-superuser and cannot set the custom
+-- breeze.scope GUC via a function attribute, so scope is managed in the wrapper.)
+CREATE OR REPLACE FUNCTION public.breeze_backup_feature_settings_parity_is_valid_impl(
   checked_feature_link_id uuid
 )
 RETURNS boolean
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET "breeze.scope" = 'system'
 AS $$
 DECLARE
   checked_feature_type public.config_feature_type;
@@ -116,12 +118,35 @@ BEGIN
 END;
 $$;
 
+-- Public entry point. Elevates to system scope for the cross-tenant reads and
+-- restores the caller's prior scope before returning (breeze.scope is held for
+-- the whole request transaction, so a bare SET LOCAL would leak 'system').
+CREATE OR REPLACE FUNCTION public.breeze_backup_feature_settings_parity_is_valid(
+  checked_feature_link_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _result boolean;
+BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  _result := public.breeze_backup_feature_settings_parity_is_valid_impl(checked_feature_link_id);
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  RETURN _result;
+END;
+$$;
+
+-- Trigger reads only OLD/NEW and delegates the cross-tenant check to the
+-- self-elevating parity validator above, so it needs no scope attribute itself.
 CREATE OR REPLACE FUNCTION public.breeze_enforce_backup_feature_settings_parity()
 RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET "breeze.scope" = 'system'
 AS $$
 DECLARE
   old_link_id uuid;

--- a/apps/api/migrations/2026-07-29-serialize-config-policy-assignment-integrity.sql
+++ b/apps/api/migrations/2026-07-29-serialize-config-policy-assignment-integrity.sql
@@ -58,14 +58,22 @@ RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  -- Prod migrates as a non-superuser that cannot SET custom breeze.* GUCs as
+  -- function attributes (42501), so elevate in-body and restore the caller's
+  -- context before every normal return. breeze.* is held for the whole request
+  -- transaction, so a leaked 'system' scope would be an RLS hole; error paths
+  -- restore automatically via (sub)transaction rollback.
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   org_ids uuid[];
   partner_ids uuid[];
 BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
   WITH assignment_rows AS (
     SELECT value,
       NULLIF(value->>'config_policy_id', '')::uuid AS policy_id,
@@ -127,6 +135,9 @@ BEGIN
   IF cardinality(org_ids) > 0 THEN
     PERFORM public.breeze_partner_export_lock_orgs_under_exclusive_partners(org_ids, partner_ids);
   END IF;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
 END;
 $$;
 
@@ -139,16 +150,19 @@ RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   policy_org_id uuid;
   policy_partner_id uuid;
   target_org_id uuid;
   target_partner_id uuid;
 BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
   -- The assignment FK already holds KEY SHARE on this policy for INSERT and
   -- config_policy_id UPDATE. Keep the explicit lock for direct validation
   -- callers; target rows deliberately rely on the canonical advisory lock so
@@ -175,6 +189,9 @@ BEGIN
       RAISE EXCEPTION 'partner assignment target must match the policy owner partner'
         USING ERRCODE = '23503', CONSTRAINT = 'config_policy_assignments_target_owner_fk';
     END IF;
+    PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+    PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+    PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
     RETURN;
   ELSIF checked_level = 'organization' THEN
     SELECT organization.id, organization.partner_id INTO target_org_id, target_partner_id
@@ -202,6 +219,9 @@ BEGIN
     RAISE EXCEPTION 'configuration assignment target is incompatible with the policy owner'
       USING ERRCODE = '23503', CONSTRAINT = 'config_policy_assignments_target_owner_fk';
   END IF;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
 END;
 $$;
 
@@ -210,12 +230,16 @@ RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
-DECLARE assignment_row jsonb;
+DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
+  assignment_row jsonb;
 BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
   FOR assignment_row IN
     SELECT value FROM unnest(COALESCE(row_values, ARRAY[]::jsonb[])) value
     ORDER BY value->>'config_policy_id', value->>'level', value->>'target_id', value->>'id'
@@ -226,20 +250,31 @@ BEGIN
       (assignment_row->>'target_id')::uuid
     );
   END LOOP;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
 END;
 $$;
 
 CREATE OR REPLACE FUNCTION public.breeze_enforce_config_policy_assignment_insert()
 RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = '' AS $$
-DECLARE values jsonb[];
+AS $$
+DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
+  values jsonb[];
 BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
   SELECT array_agg(to_jsonb(row)) INTO values FROM new_rows row;
   PERFORM public.breeze_lock_config_policy_assignment_rows(values);
   PERFORM public.breeze_validate_config_policy_assignment_new_rows(values);
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;
@@ -247,16 +282,24 @@ $$;
 CREATE OR REPLACE FUNCTION public.breeze_enforce_config_policy_assignment_update()
 RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = '' AS $$
-DECLARE old_values jsonb[]; new_values jsonb[]; all_values jsonb[];
+AS $$
+DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
+  old_values jsonb[]; new_values jsonb[]; all_values jsonb[];
 BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
   SELECT array_agg(to_jsonb(row)) INTO old_values FROM old_rows row;
   SELECT array_agg(to_jsonb(row)) INTO new_values FROM new_rows row;
   all_values := COALESCE(old_values, ARRAY[]::jsonb[]) || COALESCE(new_values, ARRAY[]::jsonb[]);
   PERFORM public.breeze_lock_config_policy_assignment_rows(all_values);
   PERFORM public.breeze_validate_config_policy_assignment_new_rows(new_values);
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;
@@ -264,13 +307,21 @@ $$;
 CREATE OR REPLACE FUNCTION public.breeze_enforce_config_policy_assignment_delete()
 RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = '' AS $$
-DECLARE values jsonb[];
+AS $$
+DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
+  values jsonb[];
 BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
   SELECT array_agg(to_jsonb(row)) INTO values FROM old_rows row;
   PERFORM public.breeze_lock_config_policy_assignment_rows(values);
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;
@@ -280,15 +331,18 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   values jsonb[] := ARRAY[]::jsonb[];
   org_ids uuid[] := ARRAY[]::uuid[];
   partner_ids uuid[] := ARRAY[]::uuid[];
 BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
   IF TG_TABLE_NAME = 'configuration_policies' THEN
     SELECT COALESCE(array_agg(to_jsonb(assignment)), ARRAY[]::jsonb[]) INTO values
     FROM public.config_policy_assignments assignment WHERE assignment.config_policy_id = OLD.id;
@@ -324,24 +378,119 @@ BEGIN
     ], NULL);
   END IF;
   PERFORM public.breeze_lock_config_policy_assignment_rows(values, org_ids, partner_ids);
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
 END;
 $$;
 
--- Recreate the 07-28 reverse validator with a fixed system context. Its AFTER
--- checks run under locks acquired by the BEFORE serializer above.
-ALTER FUNCTION public.breeze_enforce_config_policy_assignment_target()
-  SET breeze.scope = 'system';
-ALTER FUNCTION public.breeze_enforce_config_policy_assignment_target()
-  SET breeze.accessible_org_ids = '';
-ALTER FUNCTION public.breeze_enforce_config_policy_assignment_target()
-  SET breeze.accessible_partner_ids = '';
-ALTER FUNCTION public.breeze_revalidate_config_policy_assignment_targets()
-  SET breeze.scope = 'system';
-ALTER FUNCTION public.breeze_revalidate_config_policy_assignment_targets()
-  SET breeze.accessible_org_ids = '';
-ALTER FUNCTION public.breeze_revalidate_config_policy_assignment_targets()
-  SET breeze.accessible_partner_ids = '';
+-- Recreate the 07-28 reverse validators with a system context. Their AFTER
+-- checks run under locks acquired by the BEFORE serializer above. Elevation is
+-- in-body (ALTER FUNCTION ... SET on a custom GUC needs superuser, same as the
+-- attribute form), with the caller's context restored before normal returns.
+CREATE OR REPLACE FUNCTION public.breeze_enforce_config_policy_assignment_target()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
+BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
+  PERFORM public.breeze_validate_config_policy_assignment_target(
+    NEW.config_policy_id, NEW.level::text, NEW.target_id
+  );
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.breeze_revalidate_config_policy_assignment_targets()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
+  assignment_row record;
+BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
+  IF TG_TABLE_NAME = 'configuration_policies' THEN
+    FOR assignment_row IN
+      SELECT assignment.config_policy_id, assignment.level::text AS level, assignment.target_id
+      FROM public.config_policy_assignments assignment
+      WHERE assignment.config_policy_id = NEW.id
+    LOOP
+      PERFORM public.breeze_validate_config_policy_assignment_target(
+        assignment_row.config_policy_id, assignment_row.level, assignment_row.target_id
+      );
+    END LOOP;
+    PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+    PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+    PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
+    RETURN NEW;
+  END IF;
+
+  IF TG_TABLE_NAME = 'organizations' THEN
+    FOR assignment_row IN
+      SELECT DISTINCT assignment.config_policy_id, assignment.level::text AS level, assignment.target_id
+      FROM public.config_policy_assignments assignment
+      JOIN public.configuration_policies policy ON policy.id = assignment.config_policy_id
+      WHERE policy.org_id = OLD.id
+         OR (assignment.level = 'organization' AND assignment.target_id = OLD.id)
+         OR (assignment.level = 'site' AND EXISTS (
+           SELECT 1 FROM public.sites site
+           WHERE site.id = assignment.target_id AND site.org_id = OLD.id
+         ))
+         OR (assignment.level = 'device_group' AND EXISTS (
+           SELECT 1 FROM public.device_groups device_group
+           WHERE device_group.id = assignment.target_id AND device_group.org_id = OLD.id
+         ))
+         OR (assignment.level = 'device' AND EXISTS (
+           SELECT 1 FROM public.devices device
+           WHERE device.id = assignment.target_id AND device.org_id = OLD.id
+         ))
+    LOOP
+      PERFORM public.breeze_validate_config_policy_assignment_target(
+        assignment_row.config_policy_id, assignment_row.level, assignment_row.target_id
+      );
+    END LOOP;
+  ELSE
+    FOR assignment_row IN
+      SELECT assignment.config_policy_id, assignment.level::text AS level, assignment.target_id
+      FROM public.config_policy_assignments assignment
+      WHERE assignment.target_id = OLD.id
+        AND assignment.level = CASE TG_TABLE_NAME
+          WHEN 'sites' THEN 'site'::public.config_assignment_level
+          WHEN 'device_groups' THEN 'device_group'::public.config_assignment_level
+          WHEN 'devices' THEN 'device'::public.config_assignment_level
+        END
+    LOOP
+      PERFORM public.breeze_validate_config_policy_assignment_target(
+        assignment_row.config_policy_id, assignment_row.level, assignment_row.target_id
+      );
+    END LOOP;
+  END IF;
+
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
 
 DROP TRIGGER IF EXISTS config_policy_assignment_target_integrity ON public.config_policy_assignments;
 DROP TRIGGER IF EXISTS a_config_policy_assignment_integrity_insert ON public.config_policy_assignments;

--- a/apps/api/migrations/2026-07-30-serialize-bulk-config-assignment-target-moves.sql
+++ b/apps/api/migrations/2026-07-30-serialize-bulk-config-assignment-target-moves.sql
@@ -9,16 +9,24 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  -- Prod migrates as a non-superuser that cannot SET custom breeze.* GUCs as
+  -- function attributes (42501), so elevate in-body and restore the caller's
+  -- context before every normal return. breeze.* is held for the whole request
+  -- transaction, so a leaked 'system' scope would be an RLS hole; error paths
+  -- restore automatically via (sub)transaction rollback.
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   row_values jsonb[] := ARRAY[]::jsonb[];
   new_values jsonb[] := ARRAY[]::jsonb[];
   target_row record;
   lock_key integer;
 BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
   IF TG_OP = 'INSERT' THEN
     SELECT COALESCE(array_agg(to_jsonb(row)), ARRAY[]::jsonb[])
       INTO row_values FROM new_rows row;
@@ -166,6 +174,9 @@ BEGIN
   IF TG_OP <> 'DELETE' THEN
     PERFORM public.breeze_validate_config_policy_assignment_new_rows(new_values);
   END IF;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;
@@ -175,11 +186,11 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   identities text[] := ARRAY[]::text[];
   values jsonb[] := ARRAY[]::jsonb[];
   lock_key integer;
@@ -208,6 +219,12 @@ BEGIN
       (SELECT id, org_id FROM new_rows EXCEPT SELECT id, org_id FROM old_rows)
     ) THEN RETURN NULL; END IF;
   END IF;
+
+  -- Elevate only past the no-op gates above: they read nothing but transition
+  -- tables, so their RETURN NULL paths carry no scope to restore.
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
 
   IF TG_TABLE_NAME = 'configuration_policies' THEN
     SELECT COALESCE(array_agg(identity), ARRAY[]::text[]) INTO identities FROM (
@@ -309,6 +326,9 @@ BEGIN
     END;
   END IF;
   PERFORM public.breeze_validate_config_policy_assignment_new_rows(values);
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;
@@ -318,15 +338,18 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   identities text[] := ARRAY[]::text[];
   values jsonb[] := ARRAY[]::jsonb[];
   lock_key integer;
 BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
   IF TG_TABLE_NAME = 'configuration_policies' THEN
     SELECT COALESCE(array_agg(identity), ARRAY[]::text[]) INTO identities FROM (
       SELECT 'policy:' || id::text AS identity FROM old_rows

--- a/apps/api/migrations/2026-08-01-a-serialize-feature-policy-references.sql
+++ b/apps/api/migrations/2026-08-01-a-serialize-feature-policy-references.sql
@@ -8,16 +8,24 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  -- Prod migrates as a non-superuser that cannot SET custom breeze.* GUCs as
+  -- function attributes (42501), so elevate in-body and restore the caller's
+  -- context before every normal return. breeze.* is held for the whole request
+  -- transaction, so a leaked 'system' scope would be an RLS hole; error paths
+  -- restore automatically via (sub)transaction rollback.
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   row_values jsonb[] := ARRAY[]::jsonb[];
   new_values jsonb[] := ARRAY[]::jsonb[];
   lock_key integer;
   candidate record;
 BEGIN
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
   IF TG_OP = 'INSERT' THEN
     SELECT COALESCE(array_agg(to_jsonb(row)), ARRAY[]::jsonb[])
       INTO row_values FROM new_rows row;
@@ -199,6 +207,9 @@ BEGIN
       );
     END LOOP;
   END IF;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;
@@ -208,11 +219,11 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   row_values jsonb[] := ARRAY[]::jsonb[];
   lock_key integer;
   candidate record;
@@ -237,6 +248,12 @@ BEGIN
     SELECT COALESCE(array_agg(to_jsonb(row)), ARRAY[]::jsonb[])
       INTO row_values FROM old_rows row;
   END IF;
+
+  -- Elevate only here: everything above reads nothing but transition tables,
+  -- so the no-op RETURN NULL path carries no scope to restore.
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
 
   -- Stabilize every currently-visible affected link before entering 1000302.
   -- A concurrently-uncommitted link is instead serialized by the shared
@@ -275,6 +292,9 @@ BEGIN
       candidate.config_policy_id, candidate.feature_type, candidate.feature_policy_id
     );
   END LOOP;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;
@@ -287,11 +307,11 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   row_values jsonb[] := ARRAY[]::jsonb[];
   target_feature_type public.config_feature_type;
   changed_values boolean;
@@ -382,6 +402,12 @@ BEGIN
       INTO row_values FROM old_rows row;
   END IF;
 
+  -- Elevate only here: everything above reads nothing but transition tables,
+  -- so the no-op RETURN NULL path carries no scope to restore.
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
+
   -- Stabilize links visible before the serializer.  A link that is still
   -- uncommitted is serialized by the shared ref identity and is picked up by
   -- the post-lock query under a fresh command snapshot.
@@ -416,6 +442,9 @@ BEGIN
       candidate.config_policy_id, candidate.feature_type, candidate.feature_policy_id
     );
   END LOOP;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;
@@ -425,11 +454,11 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   row_values jsonb[] := ARRAY[]::jsonb[];
   lock_key integer;
   candidate record;
@@ -449,6 +478,12 @@ BEGIN
     UNION ALL
     SELECT to_jsonb(row) AS value FROM new_rows row
   ) rows;
+
+  -- Elevate only here: everything above reads nothing but transition tables,
+  -- so the no-op RETURN NULL path carries no scope to restore.
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
 
   PERFORM link.id
   FROM public.config_policy_feature_links link
@@ -492,6 +527,9 @@ BEGIN
       candidate.config_policy_id, candidate.feature_type, candidate.feature_policy_id
     );
   END LOOP;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;

--- a/apps/api/migrations/2026-08-01-b-serialize-backup-policy-references.sql
+++ b/apps/api/migrations/2026-08-01-b-serialize-backup-policy-references.sql
@@ -7,11 +7,17 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  -- Prod migrates as a non-superuser that cannot SET custom breeze.* GUCs as
+  -- function attributes (42501), so elevate in-body — after the transition-
+  -- table-only no-op gates — and restore the caller's context before every
+  -- normal return. breeze.* is held for the whole request transaction, so a
+  -- leaked 'system' scope would be an RLS hole; error paths restore
+  -- automatically via (sub)transaction rollback.
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   row_values jsonb[] := ARRAY[]::jsonb[];
   new_values jsonb[] := ARRAY[]::jsonb[];
   lock_key integer;
@@ -53,6 +59,10 @@ BEGIN
     SELECT COALESCE(array_agg(to_jsonb(row)), ARRAY[]::jsonb[])
       INTO row_values FROM old_rows row;
   END IF;
+
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
 
   PERFORM link.id
   FROM public.config_policy_feature_links link
@@ -167,6 +177,9 @@ BEGIN
       );
     END LOOP;
   END IF;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;
@@ -176,11 +189,11 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   row_values jsonb[] := ARRAY[]::jsonb[];
   changed_values boolean := true;
   lock_key integer;
@@ -260,6 +273,12 @@ BEGIN
     SELECT COALESCE(array_agg(to_jsonb(row)), ARRAY[]::jsonb[])
       INTO row_values FROM old_rows row;
   END IF;
+
+  -- Elevate only here: everything above reads nothing but transition tables,
+  -- so the no-op RETURN NULL path carries no scope to restore.
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
 
   -- Stabilize currently-visible normalized rows.  Uncommitted rows overlap on
   -- the transition-derived link/policy/ref/org key acquired below.
@@ -401,6 +420,9 @@ BEGIN
       END IF;
     END LOOP;
   END IF;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;

--- a/apps/api/migrations/2026-08-01-c-serialize-onedrive-policy-references.sql
+++ b/apps/api/migrations/2026-08-01-c-serialize-onedrive-policy-references.sql
@@ -9,11 +9,17 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  -- Prod migrates as a non-superuser that cannot SET custom breeze.* GUCs as
+  -- function attributes (42501), so elevate in-body — after the transition-
+  -- table-only no-op gates — and restore the caller's context before every
+  -- normal return. breeze.* is held for the whole request transaction, so a
+  -- leaked 'system' scope would be an RLS hole; error paths restore
+  -- automatically via (sub)transaction rollback.
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   row_values jsonb[] := ARRAY[]::jsonb[];
   new_values jsonb[] := ARRAY[]::jsonb[];
   lock_key integer;
@@ -45,6 +51,12 @@ BEGIN
     SELECT COALESCE(array_agg(to_jsonb(row)), ARRAY[]::jsonb[])
       INTO row_values FROM old_rows row;
   END IF;
+
+  -- Elevate only here: everything above reads nothing but transition tables,
+  -- so the no-op RETURN NULL path carries no scope to restore.
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
 
   -- Stabilize existing rows in one closed relation order before 1000302.
   PERFORM link.id
@@ -134,6 +146,9 @@ BEGIN
       candidate.settings_id, candidate.org_id
     );
   END LOOP;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;
@@ -143,11 +158,11 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   row_values jsonb[] := ARRAY[]::jsonb[];
   new_values jsonb[] := ARRAY[]::jsonb[];
   lock_key integer;
@@ -179,6 +194,12 @@ BEGIN
     SELECT COALESCE(array_agg(to_jsonb(row)), ARRAY[]::jsonb[])
       INTO row_values FROM old_rows row;
   END IF;
+
+  -- Elevate only here: everything above reads nothing but transition tables,
+  -- so the no-op RETURN NULL path carries no scope to restore.
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
 
   PERFORM link.id
   FROM public.config_policy_feature_links link
@@ -256,6 +277,9 @@ BEGIN
       );
     END LOOP;
   END IF;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;
@@ -265,11 +289,11 @@ RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 DECLARE
+  _prev_scope text := current_setting('breeze.scope', true);
+  _prev_org_ids text := current_setting('breeze.accessible_org_ids', true);
+  _prev_partner_ids text := current_setting('breeze.accessible_partner_ids', true);
   row_values jsonb[] := ARRAY[]::jsonb[];
   lock_key integer;
   candidate record;
@@ -308,6 +332,12 @@ BEGIN
     SELECT COALESCE(array_agg(to_jsonb(row)), ARRAY[]::jsonb[])
       INTO row_values FROM old_rows row;
   END IF;
+
+  -- Elevate only here: everything above reads nothing but transition tables,
+  -- so the no-op RETURN NULL path carries no scope to restore.
+  PERFORM set_config('breeze.scope', 'system', true);
+  PERFORM set_config('breeze.accessible_org_ids', '', true);
+  PERFORM set_config('breeze.accessible_partner_ids', '', true);
 
   -- The parent statement already owns its changed rows. Lock every currently
   -- visible descendant in the same physical order used by child writers.
@@ -422,6 +452,9 @@ BEGIN
       candidate.feature_link_id, candidate.org_id
     );
   END LOOP;
+  PERFORM set_config('breeze.scope', COALESCE(_prev_scope, ''), true);
+  PERFORM set_config('breeze.accessible_org_ids', COALESCE(_prev_org_ids, ''), true);
+  PERFORM set_config('breeze.accessible_partner_ids', COALESCE(_prev_partner_ids, ''), true);
   RETURN NULL;
 END;
 $$;

--- a/apps/api/migrations/2026-08-01-d-harden-feature-reference-serialization.sql
+++ b/apps/api/migrations/2026-08-01-d-harden-feature-reference-serialization.sql
@@ -10,14 +10,14 @@
 --   * two physical candidates for one polymorphic UUID changing together;
 --   * a link DELETE/retarget racing a referenced-row DELETE/owner change.
 
+-- No breeze.* elevation: the gate only takes an advisory lock and reads no
+-- RLS-governed rows. (Prod migrates as a non-superuser that cannot SET custom
+-- GUCs as function attributes anyway — 42501.)
 CREATE OR REPLACE FUNCTION public.breeze_feature_reference_integrity_gate()
 RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
-SET breeze.scope = 'system'
-SET breeze.accessible_org_ids = ''
-SET breeze.accessible_partner_ids = ''
 AS $$
 BEGIN
   PERFORM pg_catalog.pg_advisory_xact_lock(1000302, -2147483648);

--- a/apps/api/src/__tests__/integration/backupProfilesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/backupProfilesPartnerRls.integration.test.ts
@@ -1436,7 +1436,7 @@ describe('backup feature-link / normalized-settings parity', () => {
       }))).resolves.toBeDefined();
   });
 
-  it('resolves FORCE-RLS backup rows under fixed system GUCs for non-bypass B definers', async () => {
+  it('resolves FORCE-RLS backup rows via in-body system elevation for non-bypass B definers', async () => {
     const admin = getTestDb();
     const partnerA = await createPartner();
     const orgA = await createOrganization({ partnerId: partnerA.id });
@@ -1520,11 +1520,12 @@ describe('backup feature-link / normalized-settings parity', () => {
         ORDER BY p.proname
       `);
       expect(configured).toHaveLength(2);
+      // Elevation moved into the function bodies (set_config save/restore):
+      // prod's non-superuser migration role cannot SET custom GUCs as
+      // function attributes (42501), so proconfig must stay breeze.*-free.
       expect(configured.every((fn) => fn.owner === ownerRole
-        && fn.config.includes('breeze.scope=system')
-        && fn.config.includes('breeze.accessible_org_ids=')
-        && fn.config.includes('breeze.accessible_partner_ids=')
-        && fn.config.includes('search_path=pg_catalog, public'))).toBe(true);
+        && fn.config.includes('search_path=pg_catalog, public')
+        && !fn.config.some((entry) => entry.startsWith('breeze.')))).toBe(true);
 
       const setUnrelatedCallerContext = async (tx: Parameters<Parameters<typeof admin.transaction>[0]>[0]) => {
         await tx.execute(sql`SELECT pg_catalog.set_config('breeze.scope', 'organization', true)`);
@@ -1601,7 +1602,7 @@ describe('backup feature-link / normalized-settings parity', () => {
       serializeReverse: boolean;
       publicSerializeSettings: boolean;
       publicSerializeReverse: boolean;
-      fixedSecurityDefinerConfig: boolean;
+      inBodyElevationConfig: boolean;
       fixedPathBodies: boolean;
       appSuper: boolean;
       appBypassRls: boolean;
@@ -1642,14 +1643,16 @@ describe('backup feature-link / normalized-settings parity', () => {
           'public', 'public.breeze_revalidate_backup_refs_stmt()', 'EXECUTE'
         ) AS "publicSerializeReverse",
         (
+          -- Elevation is in-body (set_config save/restore); the attribute form
+          -- needs superuser in prod, so proconfig must stay breeze.*-free.
           SELECT count(*) = 2 AND bool_and(
             prosecdef
-            AND proconfig @> ARRAY[
-              'search_path=pg_catalog, public', 'breeze.scope=system',
-              'breeze.accessible_org_ids=', 'breeze.accessible_partner_ids='
-            ]::text[]
+            AND proconfig @> ARRAY['search_path=pg_catalog, public']::text[]
+            AND NOT EXISTS (
+              SELECT 1 FROM unnest(proconfig) cfg WHERE cfg LIKE 'breeze.%'
+            )
           ) FROM serialization_functions
-        ) AS "fixedSecurityDefinerConfig",
+        ) AS "inBodyElevationConfig",
         (
           SELECT count(*) = 2
             AND bool_and(pg_catalog.strpos(pg_catalog.pg_get_functiondef(oid), 'EXECUTE format') = 0)
@@ -1696,7 +1699,7 @@ describe('backup feature-link / normalized-settings parity', () => {
       serializeReverse: false,
       publicSerializeSettings: false,
       publicSerializeReverse: false,
-      fixedSecurityDefinerConfig: true,
+      inBodyElevationConfig: true,
       fixedPathBodies: true,
       appSuper: false,
       appBypassRls: false,

--- a/apps/api/src/__tests__/integration/configPolicyReferenceConcurrency.integration.test.ts
+++ b/apps/api/src/__tests__/integration/configPolicyReferenceConcurrency.integration.test.ts
@@ -481,18 +481,18 @@ runDb('serialization migration is idempotent and installs private statement trig
   const helpers = await admin.execute<{
     name: string;
     securityDefiner: boolean;
-    fixedSystemScope: boolean;
+    inBodyElevationScope: boolean;
     publicExecute: boolean;
     appExecute: boolean;
   }>(sql`
     SELECT proc.proname AS name,
       proc.prosecdef AS "securityDefiner",
-      proc.proconfig @> ARRAY[
-        'search_path=pg_catalog, public',
-        'breeze.scope=system',
-        'breeze.accessible_org_ids=',
-        'breeze.accessible_partner_ids='
-      ]::text[] AS "fixedSystemScope",
+      -- Elevation is in-body (set_config save/restore); the attribute
+      -- form needs superuser in prod, so proconfig stays breeze.*-free.
+      (proc.proconfig @> ARRAY['search_path=pg_catalog, public']::text[]
+        AND NOT EXISTS (
+          SELECT 1 FROM unnest(proc.proconfig) cfg WHERE cfg LIKE 'breeze.%'
+        )) AS "inBodyElevationScope",
       EXISTS (
         SELECT 1 FROM pg_catalog.aclexplode(
           COALESCE(proc.proacl, pg_catalog.acldefault('f', proc.proowner))
@@ -513,7 +513,7 @@ runDb('serialization migration is idempotent and installs private statement trig
   expect(helpers).toEqual(helpers.map((helper) => ({
     ...helper,
     securityDefiner: true,
-    fixedSystemScope: true,
+    inBodyElevationScope: true,
     publicExecute: false,
     appExecute: false,
   })));

--- a/apps/api/src/__tests__/integration/configPolicyReferenceGateConcurrency.integration.test.ts
+++ b/apps/api/src/__tests__/integration/configPolicyReferenceGateConcurrency.integration.test.ts
@@ -624,19 +624,20 @@ runDb('reapplies idempotently and installs the exact private BEFORE STATEMENT ga
   const [helper] = await admin.execute<{
     schemaName: string;
     securityDefiner: boolean;
-    fixedConfiguration: boolean;
+    inBodyElevationConfiguration: boolean;
     exactGate: boolean;
     publicExecute: boolean;
     appExecute: boolean;
   }>(sql`
     SELECT namespace.nspname AS "schemaName",
       proc.prosecdef AS "securityDefiner",
-      proc.proconfig @> ARRAY[
-        'search_path=pg_catalog, public',
-        'breeze.scope=system',
-        'breeze.accessible_org_ids=',
-        'breeze.accessible_partner_ids='
-      ]::text[] AS "fixedConfiguration",
+      -- The gate takes only an advisory lock and reads no RLS-governed
+      -- rows, so it carries no breeze.* elevation at all (the attribute form
+      -- needs superuser in prod).
+      (proc.proconfig @> ARRAY['search_path=pg_catalog, public']::text[]
+        AND NOT EXISTS (
+          SELECT 1 FROM unnest(proc.proconfig) cfg WHERE cfg LIKE 'breeze.%'
+        )) AS "inBodyElevationConfiguration",
       proc.prosrc LIKE '%pg_catalog.pg_advisory_xact_lock(1000302, -2147483648)%' AS "exactGate",
       EXISTS (
         SELECT 1 FROM pg_catalog.aclexplode(
@@ -654,7 +655,7 @@ runDb('reapplies idempotently and installs the exact private BEFORE STATEMENT ga
   expect(helper).toEqual({
     schemaName: 'public',
     securityDefiner: true,
-    fixedConfiguration: true,
+    inBodyElevationConfiguration: true,
     exactGate: true,
     publicExecute: false,
     appExecute: false,

--- a/apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/onedrive-helper-rls.integration.test.ts
@@ -1447,19 +1447,19 @@ describe('OneDrive normalized-reference serialization', () => {
     const helpers = await admin.execute<{
       name: string;
       securityDefiner: boolean;
-      fixedContext: boolean;
+      inBodyElevationContext: boolean;
       namespaceCount: number;
       publicExecute: boolean;
       appExecute: boolean;
     }>(sql`
       SELECT proc.proname AS name,
         proc.prosecdef AS "securityDefiner",
-        proc.proconfig @> ARRAY[
-          'search_path=pg_catalog, public',
-          'breeze.scope=system',
-          'breeze.accessible_org_ids=',
-          'breeze.accessible_partner_ids='
-        ]::text[] AS "fixedContext",
+        -- Elevation is in-body (set_config save/restore); the attribute
+        -- form needs superuser in prod, so proconfig stays breeze.*-free.
+        (proc.proconfig @> ARRAY['search_path=pg_catalog, public']::text[]
+          AND NOT EXISTS (
+            SELECT 1 FROM unnest(proc.proconfig) cfg WHERE cfg LIKE 'breeze.%'
+          )) AS "inBodyElevationContext",
         (length(pg_catalog.pg_get_functiondef(proc.oid))
           - length(replace(pg_catalog.pg_get_functiondef(proc.oid),
             'pg_advisory_xact_lock(1000302', '')))::integer
@@ -1483,7 +1483,7 @@ describe('OneDrive normalized-reference serialization', () => {
     expect(helpers).toEqual(helpers.map((helper) => ({
       ...helper,
       securityDefiner: true,
-      fixedContext: true,
+      inBodyElevationContext: true,
       namespaceCount: 1,
       publicExecute: false,
       appExecute: false,

--- a/apps/api/src/__tests__/integration/partnerApiRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerApiRls.integration.test.ts
@@ -662,7 +662,7 @@ describe('partner reconstruction export RLS traversal', () => {
     }))).toBe('23503');
   }, 20_000);
 
-  runDb('resolves FORCE-RLS owners under fixed system GUCs for a non-bypass definer', async () => {
+  runDb('resolves FORCE-RLS owners via in-body system elevation for a non-bypass definer', async () => {
     const admin = getTestDb();
     const [current] = await admin.execute<{ roleName: string }>(sql`
       SELECT current_user AS "roleName"
@@ -705,9 +705,12 @@ describe('partner reconstruction export RLS traversal', () => {
         )
       `);
       expect(configured).toHaveLength(5);
+      // Elevation moved into the function bodies (set_config save/restore):
+      // prod's non-superuser migration role cannot SET custom GUCs as
+      // function attributes (42501), so proconfig must stay breeze.*-free.
       expect(configured.every((fn) =>
-        fn.config.includes('breeze.scope=system')
-        && fn.config.includes('search_path=pg_catalog, public'),
+        fn.config.includes('search_path=pg_catalog, public')
+        && !fn.config.some((entry) => entry.startsWith('breeze.')),
       )).toBe(true);
 
       const partnerA = await seedPartner('A');

--- a/apps/api/src/db/migrationGucAttributes.test.ts
+++ b/apps/api/src/db/migrationGucAttributes.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Guard against the v0.97.0 EU crash-loop class: setting a custom (dotted)
+ * GUC like `breeze.scope` via a function ATTRIBUTE (`CREATE FUNCTION ... SET
+ * breeze.scope = 'system'`) or via `ALTER FUNCTION/ROLE/DATABASE ... SET`
+ * requires a privilege that prod's non-superuser migration role (doadmin on
+ * DO managed Postgres) does not have — the API then crash-loops on boot with
+ * 42501 "permission denied to set parameter". CI and local dev migrate as
+ * the Postgres superuser, so nothing else catches this.
+ *
+ * The allowed alternative is in-body elevation with save/restore:
+ *   _prev := current_setting('breeze.scope', true)  -- in DECLARE
+ *   PERFORM set_config('breeze.scope', 'system', true)
+ *   PERFORM set_config('breeze.scope', COALESCE(_prev, ''), true)  -- before
+ *   each normal RETURN (error paths restore via transaction rollback).
+ * See apps/api/migrations/2026-07-29-*.sql for the reference pattern.
+ */
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '../../migrations');
+
+/** Matches `SET some.dotted_guc =` (optionally quoted). A dotted GUC name is
+ * always a custom GUC. Runtime statement-form `SET x.y = ...;` and
+ * `set_config(...)` calls are fine for non-superusers and stay allowed —
+ * only the attribute form (line not terminated by `;`) and ALTER form are
+ * superuser-gated. */
+const DOTTED_GUC_SET = /SET\s+"?[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z0-9_]+"?\s*=/;
+
+function stripLineComments(sql: string): string {
+  return sql
+    .split('\n')
+    .map((line) => line.replace(/--.*$/, ''))
+    .join('\n');
+}
+
+describe('migration files never set custom GUCs superuser-style', () => {
+  const files = readdirSync(MIGRATIONS_DIR)
+    .filter((name) => /^\d{4}-.*\.sql$/.test(name))
+    .sort((a, b) => a.localeCompare(b));
+
+  it('discovers migration files', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files)('%s has no custom-GUC function attributes', (file) => {
+    const content = stripLineComments(readFileSync(path.join(MIGRATIONS_DIR, file), 'utf8'));
+    const offending = content
+      .split('\n')
+      .map((line, index) => ({ line, lineNo: index + 1 }))
+      .filter(
+        ({ line }) =>
+          DOTTED_GUC_SET.test(line) && /^\s*SET\s/.test(line) && !/;\s*$/.test(line.trimEnd()),
+      );
+    expect(
+      offending.map(({ lineNo, line }) => `${file}:${lineNo}: ${line.trim()}`),
+      'custom-GUC SET function attribute needs superuser in prod (42501); use in-body set_config save/restore instead',
+    ).toEqual([]);
+  });
+
+  it.each(files)('%s has no ALTER ... SET custom-GUC statements', (file) => {
+    const content = stripLineComments(readFileSync(path.join(MIGRATIONS_DIR, file), 'utf8'));
+    const alterStatements = content.match(/ALTER\s+(FUNCTION|PROCEDURE|ROLE|DATABASE)[^;]*;/gi) ?? [];
+    const offending = alterStatements.filter((statement) => DOTTED_GUC_SET.test(statement));
+    expect(
+      offending.map((statement) => `${file}: ${statement.replace(/\s+/g, ' ').trim()}`),
+      'ALTER FUNCTION/ROLE/DATABASE ... SET on a custom GUC needs superuser in prod (42501); recreate the function with in-body set_config save/restore instead',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

v0.97.0 failed to deploy on EU: the API crash-looped on boot with `permission denied to set parameter "breeze.scope"` (42501) and was rolled back. Prod migrates as DigitalOcean's non-superuser `doadmin`, which cannot set custom (dotted) GUCs via `CREATE FUNCTION ... SET` attributes or `ALTER FUNCTION ... SET`. CI and local dev migrate as the Postgres superuser, so nothing caught it.

The full offending set (larger than first triaged): 8 migration files defining `SECURITY DEFINER` functions with `SET breeze.scope` **plus** `SET breeze.accessible_org_ids` / `SET breeze.accessible_partner_ids` attributes (20 CREATE sites), and one `ALTER FUNCTION ... SET breeze.*` block (2 functions × 3 GUCs).

## Fix

Move elevation into the function body with save/restore, keeping function names intact (later migrations `DROP FUNCTION` by name):

- capture `current_setting('breeze.*', true)` in `DECLARE`
- `set_config('breeze.*', 'system'/'', true)` before the first RLS-relevant read
- restore all three GUCs before **every normal return** — a leaked `system` scope would be an RLS hole because `withDbAccessContext` holds `breeze.*` for the whole request transaction; error paths restore via (sub)transaction rollback
- functions whose no-op gates read only transition tables elevate after the gate, so early `RETURN NULL` paths carry no scope to restore
- `2026-08-01-d`'s gate function takes only an advisory lock — attributes dropped outright
- `2026-07-27-a/c` were fixed earlier on this branch with a wrapper/`_impl` split (safe: those functions are never DROPped later)

Editing these shipped-but-unapplied migrations in place is safe: none are recorded in `breeze_migrations` on any prod DB (EU committed through `2026-07-26-b`; US is behind that).

## Permanent guard

`apps/api/src/db/migrationGucAttributes.test.ts` statically rejects any attribute-form or `ALTER FUNCTION/ROLE/DATABASE ... SET` of a dotted GUC in any migration file (runtime `SET x.y = ...;` statements and `set_config()` remain allowed). Negative-tested against a synthetic offender: both forms are caught.

## Verification

- Structural: zero attribute-form `breeze.*` lines across all migrations; `$$` balance intact.
- Fresh Postgres 16 in Docker, migrating as a `NOSUPERUSER CREATEDB CREATEROLE REPLICATION BYPASSRLS` role (doadmin-alike): full fresh-DB migration path (0001 baseline + post-cutoff files, `@no-transaction` semantics honored) applies clean.
- **Real EU prod DB as real doadmin** (PG 16.14): all 13 EU-pending files applied inside `BEGIN ... ROLLBACK` with `ON_ERROR_STOP` — no errors, no 42501.
- Scope-restore assertion (both rigs, same rolled-back txn): set `breeze.scope='tenant-x'` + sentinel org/partner ids, fire the full elevation path (config-policy assignment INSERT → lock/validate functions, plus an owner-adjacent UPDATE), then assert all three GUCs read back the caller's values — no `system` leak.
- `apps/api` db unit suite: 29 files / 1214 tests green, including the new guard.

## Deploy plan (after merge)

Re-cut as **0.97.1** (the broken files are baked into the v0.97.0 image), deploy night region first with fresh DB backups; US additionally needs `PARTNER_API_CURSOR_SIGNING_KEY` seeded. Agent-fleet promote held for explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)