### PR TITLE
ci(migrations): non-superuser migration guard (prevents the v0.97.0 class)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,71 @@ jobs:
       - name: Apply migrations against empty Postgres
         run: pnpm --filter @breeze/api run check:migrations
 
+  # Real-Postgres apply of every migration as a NON-SUPERUSER role that mirrors
+  # a managed-Postgres admin (DigitalOcean doadmin / AWS RDS). The class-complete
+  # guard against superuser-only DDL: `check-migrations` above (and every
+  # integration shard) migrates as the container superuser, which silently
+  # tolerates statements prod's non-superuser role cannot run, then prod
+  # crash-loops on boot. This has shipped twice — v0.95.0 (ALTER FUNCTION ...
+  # OWNER TO) and v0.97.0 (SET breeze.scope GUC attribute). Cheap (~1 min) and
+  # blocking on PRs. See apps/api/scripts/check-migrations-nonsuperuser.ts.
+  check-migrations-nonsuperuser:
+    name: Check Migrations (non-superuser)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      # The superuser connection is used ONLY to provision the non-superuser
+      # migration role + its owned database; the migration set itself runs as
+      # breeze_migrator (NOSUPERUSER). See the script for the role attributes.
+      SUPERUSER_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      MIGRATOR_PASSWORD: migrator
+      # The migration role (non-superuser) and the unprivileged request role.
+      # Set statically so src/db/index.ts resolves them at module-load time.
+      DATABASE_URL: postgresql://breeze_migrator:migrator@localhost:5432/breeze
+      DATABASE_URL_APP: postgresql://breeze_app:breeze_app_ci@localhost:5432/breeze
+      # breeze_app password (ensureAppRole reads BREEZE_APP_DB_PASSWORD first);
+      # must match the password in DATABASE_URL_APP above.
+      BREEZE_APP_DB_PASSWORD: breeze_app_ci
+      # Seed runs at the end of autoMigrate when users is empty; provide
+      # non-secret CI values so it doesn't bail on missing env.
+      JWT_SECRET: ci-nonsuperuser-migrations-jwt-secret-not-used-in-prod
+      APP_ENCRYPTION_KEY: ci-nonsuperuser-migrations-app-key-32bytes-pad
+      MFA_ENCRYPTION_KEY: ci-nonsuperuser-migrations-mfa-key-32bytes-pad
+      AGENT_ENROLLMENT_SECRET: ci-nonsuperuser-migrations-agent-enrollment
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply migrations as a non-superuser role
+        run: pnpm --filter @breeze/api run check:migrations:nonsuperuser
+
   test-web:
     name: Test Web
     runs-on: ubuntu-latest
@@ -1596,7 +1661,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test-api, test-m365-graph-read-executor, test-web, test-portal, test-office-addin-core, test-excel-addin, test-word-addin, test-powerpoint-addin, test-outlook-addin, security-audit, build-api, build-m365-graph-read-executor, build-web, build-portal, build-agent, test-agent, test-agent-windows, windows-runtime-smoke, integration-test, rust-check, smoke-test]
+    needs: [lint, typecheck, test-api, test-m365-graph-read-executor, test-web, test-portal, test-office-addin-core, test-excel-addin, test-word-addin, test-powerpoint-addin, test-outlook-addin, security-audit, build-api, build-m365-graph-read-executor, build-web, build-portal, build-agent, test-agent, test-agent-windows, windows-runtime-smoke, integration-test, check-migrations-nonsuperuser, rust-check, smoke-test]
     if: ${{ !cancelled() }}
     steps:
       - name: Check all jobs passed
@@ -1622,6 +1687,7 @@ jobs:
           TEST_AGENT_WINDOWS_RESULT: ${{ needs.test-agent-windows.result }}
           WINDOWS_RUNTIME_SMOKE_RESULT: ${{ needs.windows-runtime-smoke.result }}
           INTEGRATION_TEST_RESULT: ${{ needs.integration-test.result }}
+          CHECK_MIGRATIONS_NONSUPERUSER_RESULT: ${{ needs.check-migrations-nonsuperuser.result }}
           RUST_CHECK_RESULT: ${{ needs.rust-check.result }}
           SMOKE_TEST_RESULT: ${{ needs.smoke-test.result }}
           IS_PR: ${{ github.event_name == 'pull_request' }}
@@ -1647,6 +1713,7 @@ jobs:
              [[ "${TEST_AGENT_WINDOWS_RESULT}" != "success" ]] || \
              [[ "${WINDOWS_RUNTIME_SMOKE_RESULT}" != "success" ]] || \
              [[ "${INTEGRATION_TEST_RESULT}" != "success" ]] || \
+             [[ "${CHECK_MIGRATIONS_NONSUPERUSER_RESULT}" != "success" ]] || \
              [[ "${RUST_CHECK_RESULT}" != "success" ]]; then
             echo "One or more required jobs failed"
             exit 1

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
     "db:seed": "tsx src/db/seed.ts",
     "db:seed:e2e": "tsx src/db/seedE2eFixtures.ts",
     "check:migrations": "tsx scripts/check-migrations.ts",
+    "check:migrations:nonsuperuser": "tsx scripts/check-migrations-nonsuperuser.ts",
     "db:studio": "drizzle-kit studio",
     "dev": "tsx watch src/index.ts",
     "lint": "eslint src",

--- a/apps/api/scripts/check-migrations-nonsuperuser.ts
+++ b/apps/api/scripts/check-migrations-nonsuperuser.ts
@@ -1,0 +1,105 @@
+// CI-only: apply EVERY migration through the real autoMigrate() entrypoint as
+// a NON-SUPERUSER role that mirrors a managed-Postgres admin (DigitalOcean
+// `doadmin`, AWS RDS master, etc.): it has LOGIN, CREATEDB, CREATEROLE,
+// REPLICATION, and BYPASSRLS, but is NOT a superuser.
+//
+// Why this exists — this is the class-complete guard against superuser-only
+// DDL slipping into a migration. Superuser-only statements
+// (`ALTER FUNCTION ... OWNER TO`, `SET <custom.guc> = ...` as a function
+// attribute, `ALTER ROLE|DATABASE ... SET`, `ALTER SYSTEM`, `CREATE ROLE`,
+// `COPY ... FROM PROGRAM`, ...) all succeed when migrations are applied as the
+// Postgres superuser — which is exactly what CI's `check-migrations` job and
+// every integration shard's autoMigrate do. Prod migrates as a non-superuser
+// and crash-loops on boot instead. This has shipped twice: v0.95.0
+// (`ALTER FUNCTION ... OWNER TO`) and v0.97.0 (`SET breeze.scope` GUC
+// attribute), each invisible until prod. A static grep is a blocklist that
+// always lags the next novel construct; running the real migration set under
+// the constrained role lets Postgres itself reject the whole class.
+//
+// The static guard `src/db/migrationGucAttributes.test.ts` remains as fast,
+// precise feedback for the specific GUC-attribute form; this job is the
+// backstop that catches everything else.
+import postgres from 'postgres';
+
+const SUPERUSER_URL =
+  process.env.SUPERUSER_DATABASE_URL ||
+  'postgresql://postgres:postgres@localhost:5432/postgres';
+const MIGRATOR_ROLE = process.env.MIGRATOR_ROLE || 'breeze_migrator';
+const MIGRATOR_PASSWORD = process.env.MIGRATOR_PASSWORD || 'migrator';
+const MIGRATOR_DB = process.env.MIGRATOR_DB || 'breeze';
+
+/**
+ * As the superuser, create the doadmin-alike migration role and a database it
+ * owns. Everything else — including the unprivileged `breeze_app` login — is
+ * created by autoMigrate()/ensureAppRole() running AS the migration role, so
+ * those code paths are exercised under the same privilege constraints as prod.
+ */
+async function provisionMigratorRole(): Promise<void> {
+  const admin = postgres(SUPERUSER_URL, { max: 1 });
+  try {
+    await admin.unsafe(`
+      DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${MIGRATOR_ROLE}') THEN
+          -- NOSUPERUSER is the whole point. The other attributes match a real
+          -- managed-Postgres admin so the run is faithful: BYPASSRLS (doadmin
+          -- has it — it is why RLS-seeding migrations apply), CREATEROLE (to
+          -- create breeze_app), CREATEDB, REPLICATION.
+          CREATE ROLE ${MIGRATOR_ROLE} LOGIN PASSWORD '${MIGRATOR_PASSWORD}'
+            NOSUPERUSER CREATEDB CREATEROLE REPLICATION BYPASSRLS;
+        END IF;
+      END $$;
+    `);
+    // PG16 tightened CREATEROLE: a non-superuser creator no longer implicitly
+    // administers the roles it makes. doadmin behaves as if self-grant is on,
+    // so set it here — without it, ensureAppRole()'s CREATE ROLE breeze_app
+    // and the migrations' `REVOKE ... FROM breeze_app` fail with a privilege
+    // error that prod would not hit.
+    await admin.unsafe(
+      `ALTER ROLE ${MIGRATOR_ROLE} SET createrole_self_grant = 'set, inherit'`,
+    );
+    const dbExists = await admin`SELECT 1 FROM pg_database WHERE datname = ${MIGRATOR_DB}`;
+    if (dbExists.length === 0) {
+      await admin.unsafe(`CREATE DATABASE ${MIGRATOR_DB} OWNER ${MIGRATOR_ROLE}`);
+    }
+  } finally {
+    await admin.end();
+  }
+}
+
+async function main(): Promise<void> {
+  // DATABASE_URL (the migrator role) and DATABASE_URL_APP (breeze_app) are set
+  // by the caller/CI job so the db modules resolve them at import time — do not
+  // mutate DATABASE_URL here, because src/db/index.ts derives the unprivileged
+  // request pool at module load, before this function runs.
+  if (!process.env.DATABASE_URL) {
+    throw new Error(
+      'DATABASE_URL must point at the non-superuser migration role (breeze_migrator). ' +
+        'Set it (and DATABASE_URL_APP for breeze_app) in the environment before running.',
+    );
+  }
+  await provisionMigratorRole();
+  // Imported lazily so the module-load-time db pool derivation reads the
+  // already-set DATABASE_URL / DATABASE_URL_APP rather than a default.
+  const { autoMigrate } = await import('../src/db/autoMigrate');
+  await autoMigrate();
+}
+
+main()
+  .then(() => {
+    console.log(
+      '[check-migrations-nonsuperuser] OK — full migration set applied as a non-superuser role',
+    );
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('[check-migrations-nonsuperuser] FAILED');
+    console.error(
+      'A migration used a statement the non-superuser migration role could not run.\n' +
+        'This is the class that crash-loops prod on boot (e.g. SET <custom.guc> as a\n' +
+        'function attribute, ALTER FUNCTION ... OWNER TO, ALTER ROLE/DATABASE ... SET,\n' +
+        'ALTER SYSTEM). Move the effect into a form a non-superuser may run (e.g. in-body\n' +
+        'set_config with save/restore) and re-run.',
+    );
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Why

Follow-up to #2622. The custom-GUC static guard shipped there catches the *specific* construct that broke v0.97.0, but the underlying failure is a recurring **class**: a migration uses a **superuser-only** statement, which passes CI (migrations run as the container **superuser**) and then crash-loops prod on boot, where migrations run as a **non-superuser** managed-Postgres admin (DigitalOcean `doadmin`, RDS master).

It has shipped twice with two *different* statements:
- **v0.95.0** — `ALTER FUNCTION … OWNER TO`
- **v0.97.0** — `SET breeze.scope = …` as a function attribute

A static grep is a blocklist that always lags the next novel construct (`ALTER SYSTEM`, `CREATE ROLE`, `ALTER ROLE/DATABASE … SET`, `COPY … FROM PROGRAM`, event triggers, …). The durable fix is to **run the real migration set once under the constrained role** and let Postgres reject the whole class.

## What

- **`apps/api/scripts/check-migrations-nonsuperuser.ts`** — provisions a doadmin-alike role (`NOSUPERUSER`, but `CREATEDB CREATEROLE REPLICATION BYPASSRLS` + `createrole_self_grant`, matching real managed-Postgres admins — including `BYPASSRLS`, which doadmin has) and runs the real `autoMigrate()` as that role. `breeze_app` and everything else are created by `ensureAppRole()` running **as** the non-superuser role, so those paths get the same privilege constraints as prod.
- **New blocking CI job `check-migrations-nonsuperuser`**, wired into the `ci-success` fan-in gate.
- The GUC-attribute static guard (`migrationGucAttributes.test.ts`, from #2622) stays as fast, precise feedback; this job is the backstop for everything else.

## Verified (real Postgres 16, locally)

- **Positive:** full **382-migration set + initial seed** applies clean as the non-superuser role. (It also exercises the codebase's existing non-superuser fallbacks — e.g. the `LEAKPROOF requires superuser` DO-block skips — which CI never ran before.)
- **Negative (faithful):** injecting an in-transaction superuser-only statement (`CREATE ROLE … SUPERUSER`) fails the job with exit 1 and `permission denied to create role` — proving it catches the broad class, not just the GUC form, and not merely the transaction rule.

## Cost

~1 minute, one `postgres:16` service container — same shape as the existing `check-migrations` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)