### PR TITLE
fix(agent): carry stdout/stderr/exitCode through the WS command result (#2474)

### DIFF
--- a/agent/internal/heartbeat/handlers_script.go
+++ b/agent/internal/heartbeat/handlers_script.go
@@ -41,7 +41,9 @@ func handleScript(h *Heartbeat, cmd Command) tools.CommandResult {
 	}
 	if script.Script == "" {
 		return tools.CommandResult{
-			Status:     "failed",
+			Status: "failed",
+			// Synthetic exit code: no process ran (see tools.CommandResult.ExitCode).
+			ExitCode:   1,
 			Error:      "script content is empty",
 			DurationMs: time.Since(start).Milliseconds(),
 		}
@@ -209,7 +211,9 @@ func (h *Heartbeat) executeViaUserHelper(session *sessionbroker.Session, cmd Com
 
 	if !session.HasScope("run_as_user") {
 		return tools.CommandResult{
-			Status:     "failed",
+			Status: "failed",
+			// Synthetic exit code: no process ran (see tools.CommandResult.ExitCode).
+			ExitCode:   1,
 			Error:      "user helper does not have run_as_user scope",
 			DurationMs: time.Since(start).Milliseconds(),
 		}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -3813,12 +3813,13 @@ func (h *Heartbeat) submitCommandResult(commandID string, result tools.CommandRe
 }
 
 // toWSCommandResult maps an internal tools.CommandResult onto the WebSocket
-// wire result. It carries stdout, stderr and the exit code through to the
-// server; before this they were dropped on the WS leg (only status/error and a
-// speculative stdout->result reparse survived), so script_executions persisted
-// blank stderr and NULL exit_code fleet-wide (#2474). The stdout->Result
-// reparse is preserved verbatim: several server handlers (discovery, backup,
-// snmp, monitor) still read the structured `result` field.
+// wire result, carrying stdout, stderr and the exit code through to the
+// server (#2474). The stdout->Result reparse is load-bearing: server handlers
+// for discovery, backup, snmp and monitor read the structured `result` field,
+// not stdout. Result is set ONLY when stdout parses as JSON — raw text rides
+// exclusively in Stdout. Duplicating it into Result would double the payload
+// and, for stdout near the executor's 1MB cap, trip the server's 1MB refine
+// on `result` and get the whole command_result rejected.
 func toWSCommandResult(commandID string, result tools.CommandResult) websocket.CommandResult {
 	wsResult := websocket.CommandResult{
 		CommandID: commandID,
@@ -3834,8 +3835,6 @@ func toWSCommandResult(commandID string, result tools.CommandResult) websocket.C
 		var jsonResult any
 		if err := json.Unmarshal([]byte(result.Stdout), &jsonResult); err == nil {
 			wsResult.Result = jsonResult
-		} else {
-			wsResult.Result = result.Stdout
 		}
 	}
 
@@ -3848,7 +3847,10 @@ func (h *Heartbeat) HandleCommand(wsCmd websocket.Command) websocket.CommandResu
 		return websocket.CommandResult{
 			CommandID: wsCmd.ID,
 			Status:    "failed",
-			Error:     "agent is shutting down",
+			// Synthetic exit code: no process ran. ExitCode is not omitempty,
+			// so leaving it zero would persist a false "exited 0".
+			ExitCode: 1,
+			Error:    "agent is shutting down",
 		}
 	}
 
@@ -3863,7 +3865,11 @@ func (h *Heartbeat) HandleCommand(wsCmd websocket.Command) websocket.CommandResu
 	wsResult := toWSCommandResult(cmd.ID, result)
 
 	if result.Status != "duplicate" && !isEphemeralCommand(cmd.Type) {
-		go h.submitCommandResult(cmd.ID, result)
+		go func() {
+			if err := h.submitCommandResult(cmd.ID, result); err != nil {
+				log.Error("failed to submit command result", logging.KeyCommandID, cmd.ID, "error", err.Error())
+			}
+		}()
 	}
 
 	return wsResult
@@ -3880,7 +3886,9 @@ func (h *Heartbeat) executeCommandViaPool(cmd Command) tools.CommandResult {
 	}) {
 		return tools.CommandResult{
 			Status: "failed",
-			Error:  "command rejected, worker pool full",
+			// Synthetic exit code: no process ran (see tools.CommandResult.ExitCode).
+			ExitCode: 1,
+			Error:    "command rejected, worker pool full",
 		}
 	}
 
@@ -3912,13 +3920,15 @@ func (h *Heartbeat) executeCommandViaPool(cmd Command) tools.CommandResult {
 			watchdog.Reset(warnAfter)
 		case <-h.stopChan:
 			return tools.CommandResult{
-				Status: "failed",
-				Error:  "agent is shutting down",
+				Status:   "failed",
+				ExitCode: 1, // synthetic: no exit code observed (shutdown)
+				Error:    "agent is shutting down",
 			}
 		case <-h.pool.Context().Done():
 			return tools.CommandResult{
-				Status: "failed",
-				Error:  "command execution interrupted during shutdown",
+				Status:   "failed",
+				ExitCode: 1, // synthetic: no exit code observed (shutdown)
+				Error:    "command execution interrupted during shutdown",
 			}
 		}
 	}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -3812,6 +3812,36 @@ func (h *Heartbeat) submitCommandResult(commandID string, result tools.CommandRe
 	return nil
 }
 
+// toWSCommandResult maps an internal tools.CommandResult onto the WebSocket
+// wire result. It carries stdout, stderr and the exit code through to the
+// server; before this they were dropped on the WS leg (only status/error and a
+// speculative stdout->result reparse survived), so script_executions persisted
+// blank stderr and NULL exit_code fleet-wide (#2474). The stdout->Result
+// reparse is preserved verbatim: several server handlers (discovery, backup,
+// snmp, monitor) still read the structured `result` field.
+func toWSCommandResult(commandID string, result tools.CommandResult) websocket.CommandResult {
+	wsResult := websocket.CommandResult{
+		CommandID: commandID,
+		Status:    result.Status,
+		ExitCode:  result.ExitCode,
+		Stdout:    result.Stdout,
+		Stderr:    result.Stderr,
+	}
+
+	if result.Error != "" {
+		wsResult.Error = result.Error
+	} else if result.Stdout != "" {
+		var jsonResult any
+		if err := json.Unmarshal([]byte(result.Stdout), &jsonResult); err == nil {
+			wsResult.Result = jsonResult
+		} else {
+			wsResult.Result = result.Stdout
+		}
+	}
+
+	return wsResult
+}
+
 // HandleCommand processes a command from WebSocket and returns a result
 func (h *Heartbeat) HandleCommand(wsCmd websocket.Command) websocket.CommandResult {
 	if !h.accepting.Load() {
@@ -3830,21 +3860,7 @@ func (h *Heartbeat) HandleCommand(wsCmd websocket.Command) websocket.CommandResu
 
 	result := h.executeCommandViaPool(cmd)
 
-	wsResult := websocket.CommandResult{
-		CommandID: cmd.ID,
-		Status:    result.Status,
-	}
-
-	if result.Error != "" {
-		wsResult.Error = result.Error
-	} else if result.Stdout != "" {
-		var jsonResult any
-		if err := json.Unmarshal([]byte(result.Stdout), &jsonResult); err == nil {
-			wsResult.Result = jsonResult
-		} else {
-			wsResult.Result = result.Stdout
-		}
-	}
+	wsResult := toWSCommandResult(cmd.ID, result)
 
 	if result.Status != "duplicate" && !isEphemeralCommand(cmd.Type) {
 		go h.submitCommandResult(cmd.ID, result)

--- a/agent/internal/heartbeat/result_mapping_test.go
+++ b/agent/internal/heartbeat/result_mapping_test.go
@@ -28,18 +28,50 @@ func TestToWSCommandResultCarriesStderrAndExitCode(t *testing.T) {
 		t.Errorf("Status = %q, want %q", got.Status, "failed")
 	}
 	if got.ExitCode != 3 {
-		t.Errorf("ExitCode = %d, want 3 (was dropped before #2474)", got.ExitCode)
+		t.Errorf("ExitCode = %d, want 3", got.ExitCode)
 	}
 	if got.Stderr != "something went wrong" {
-		t.Errorf("Stderr = %q, want %q (was dropped before #2474)", got.Stderr, "something went wrong")
+		t.Errorf("Stderr = %q, want %q", got.Stderr, "something went wrong")
 	}
 	if got.Stdout != "line one\nline two" {
-		t.Errorf("Stdout = %q, want the raw multi-line text (was mangled via Result before #2474)", got.Stdout)
+		t.Errorf("Stdout = %q, want the raw multi-line text", got.Stdout)
+	}
+	// Non-JSON stdout must ride ONLY in Stdout. Duplicating it into Result
+	// doubles the payload and, near the executor's 1MB stdout cap, trips the
+	// server's 1MB refine on `result` — rejecting the whole command_result.
+	if got.Result != nil {
+		t.Errorf("Result = %#v, want nil for non-JSON stdout", got.Result)
+	}
+}
+
+// TestToWSCommandResultErrorSuppressesResult pins the Error branch: when the
+// handler reports an error, Result stays empty but stdout/stderr still flow —
+// an errored script's captured output must remain visible in the UI.
+func TestToWSCommandResultErrorSuppressesResult(t *testing.T) {
+	got := toWSCommandResult("cmd-err", tools.CommandResult{
+		Status:   "failed",
+		ExitCode: 1,
+		Error:    "boom",
+		Stdout:   `{"partial":true}`,
+		Stderr:   "trace",
+	})
+
+	if got.Error != "boom" {
+		t.Errorf("Error = %q, want %q", got.Error, "boom")
+	}
+	if got.Result != nil {
+		t.Errorf("Result = %#v, want nil when Error is set", got.Result)
+	}
+	if got.Stdout != `{"partial":true}` {
+		t.Errorf("Stdout = %q, want it carried even when Error is set", got.Stdout)
+	}
+	if got.Stderr != "trace" {
+		t.Errorf("Stderr = %q, want it carried even when Error is set", got.Stderr)
 	}
 }
 
 // TestToWSCommandResultExitZeroIsWireVisible proves a successful command (exit
-// 0) still serializes an explicit "exitCode":0. If exitCode were omitempty the
+// 0) serializes an explicit "exitCode":0. If exitCode were omitempty the
 // server would coalesce it to NULL for every completed row — the exact symptom
 // #2474 set out to fix.
 func TestToWSCommandResultExitZeroIsWireVisible(t *testing.T) {

--- a/agent/internal/heartbeat/result_mapping_test.go
+++ b/agent/internal/heartbeat/result_mapping_test.go
@@ -1,0 +1,87 @@
+package heartbeat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+)
+
+// TestToWSCommandResultCarriesStderrAndExitCode is the regression guard for
+// #2474: the WS leg used to drop stderr and the exit code, so a script that
+// wrote only to stderr and exited nonzero persisted as failed with no visible
+// output and a NULL exit_code.
+func TestToWSCommandResultCarriesStderrAndExitCode(t *testing.T) {
+	in := tools.CommandResult{
+		Status:   "failed",
+		ExitCode: 3,
+		Stdout:   "line one\nline two",
+		Stderr:   "something went wrong",
+	}
+
+	got := toWSCommandResult("cmd-1", in)
+
+	if got.CommandID != "cmd-1" {
+		t.Errorf("CommandID = %q, want %q", got.CommandID, "cmd-1")
+	}
+	if got.Status != "failed" {
+		t.Errorf("Status = %q, want %q", got.Status, "failed")
+	}
+	if got.ExitCode != 3 {
+		t.Errorf("ExitCode = %d, want 3 (was dropped before #2474)", got.ExitCode)
+	}
+	if got.Stderr != "something went wrong" {
+		t.Errorf("Stderr = %q, want %q (was dropped before #2474)", got.Stderr, "something went wrong")
+	}
+	if got.Stdout != "line one\nline two" {
+		t.Errorf("Stdout = %q, want the raw multi-line text (was mangled via Result before #2474)", got.Stdout)
+	}
+}
+
+// TestToWSCommandResultExitZeroIsWireVisible proves a successful command (exit
+// 0) still serializes an explicit "exitCode":0. If exitCode were omitempty the
+// server would coalesce it to NULL for every completed row — the exact symptom
+// #2474 set out to fix.
+func TestToWSCommandResultExitZeroIsWireVisible(t *testing.T) {
+	got := toWSCommandResult("cmd-2", tools.CommandResult{
+		Status:   "completed",
+		ExitCode: 0,
+		Stdout:   "ok",
+	})
+
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	ec, ok := wire["exitCode"]
+	if !ok {
+		t.Fatalf("exitCode absent from wire result %s; a completed command must send exitCode:0, not omit it", raw)
+	}
+	if ec.(float64) != 0 {
+		t.Errorf("exitCode = %v, want 0", ec)
+	}
+}
+
+// TestToWSCommandResultPreservesStructuredResult confirms the stdout->Result
+// reparse that structured handlers (discovery/backup/snmp/monitor) depend on is
+// preserved: JSON stdout still lands in the `result` field.
+func TestToWSCommandResultPreservesStructuredResult(t *testing.T) {
+	got := toWSCommandResult("cmd-3", tools.CommandResult{
+		Status: "completed",
+		Stdout: `{"devices":2}`,
+	})
+
+	obj, ok := got.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("Result = %#v, want parsed JSON object", got.Result)
+	}
+	if obj["devices"].(float64) != 2 {
+		t.Errorf("Result[devices] = %v, want 2", obj["devices"])
+	}
+}

--- a/agent/internal/remote/tools/types.go
+++ b/agent/internal/remote/tools/types.go
@@ -230,8 +230,14 @@ const (
 
 // CommandResult represents the result of a command execution
 type CommandResult struct {
-	Status     string `json:"status"` // completed, failed, timeout
-	ExitCode   int    `json:"exitCode,omitempty"`
+	Status string `json:"status"` // completed, failed, timeout
+	// ExitCode is deliberately NOT omitempty (matching websocket.CommandResult):
+	// the server persists `result.exitCode ?? null`, so omitting the zero value
+	// would store NULL exit_code for every successful (exit-0) run (#2474).
+	// Failure paths that never spawn a process must set a synthetic nonzero
+	// exit code (NewErrorResult uses 1) so `exit_code = 0` always means "a
+	// process ran and exited cleanly".
+	ExitCode   int    `json:"exitCode"`
 	Stdout     string `json:"stdout,omitempty"`
 	Stderr     string `json:"stderr,omitempty"`
 	Error      string `json:"error,omitempty"`

--- a/agent/internal/remote/tools/types_test.go
+++ b/agent/internal/remote/tools/types_test.go
@@ -1,0 +1,35 @@
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestCommandResultExitZeroIsWireVisible guards the HTTP result leg against
+// the #2474 symptom: the server persists `result.exitCode ?? null`, so a
+// successful (exit-0) run must serialize an explicit "exitCode":0 — an
+// omitempty tag here would silently re-NULL exit_code for every completed row
+// whenever the HTTP leg wins the write race.
+func TestCommandResultExitZeroIsWireVisible(t *testing.T) {
+	raw, err := json.Marshal(CommandResult{
+		Status:   "completed",
+		ExitCode: 0,
+		Stdout:   "ok",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	ec, ok := wire["exitCode"]
+	if !ok {
+		t.Fatalf("exitCode absent from wire result %s; a completed command must send exitCode:0, not omit it", raw)
+	}
+	if ec.(float64) != 0 {
+		t.Errorf("exitCode = %v, want 0", ec)
+	}
+}

--- a/agent/internal/websocket/client.go
+++ b/agent/internal/websocket/client.go
@@ -62,11 +62,22 @@ type Command struct {
 	Payload map[string]any `json:"payload"`
 }
 
-// CommandResult represents the result of a command execution
+// CommandResult represents the result of a command execution.
+//
+// Stdout, Stderr and ExitCode mirror the fields the server's command_result
+// schema already accepts (apps/api/src/routes/agentWs.ts). They were absent
+// here before, so the WS leg silently dropped stderr and the exit code for
+// every command it carried — script_executions persisted blank stderr / NULL
+// exit_code fleet-wide (#2474). ExitCode is intentionally NOT omitempty: a
+// successful command exits 0, and omitting it would persist NULL for exactly
+// the completed rows the fix is meant to populate.
 type CommandResult struct {
 	Type      string `json:"type"`
 	CommandID string `json:"commandId"`
 	Status    string `json:"status"`
+	ExitCode  int    `json:"exitCode"`
+	Stdout    string `json:"stdout,omitempty"`
+	Stderr    string `json:"stderr,omitempty"`
 	Result    any    `json:"result,omitempty"`
 	Error     string `json:"error,omitempty"`
 }

--- a/agent/internal/websocket/client.go
+++ b/agent/internal/websocket/client.go
@@ -62,15 +62,15 @@ type Command struct {
 	Payload map[string]any `json:"payload"`
 }
 
-// CommandResult represents the result of a command execution.
+// CommandResult is the WS wire form of a command execution result.
 //
-// Stdout, Stderr and ExitCode mirror the fields the server's command_result
-// schema already accepts (apps/api/src/routes/agentWs.ts). They were absent
-// here before, so the WS leg silently dropped stderr and the exit code for
-// every command it carried — script_executions persisted blank stderr / NULL
-// exit_code fleet-wide (#2474). ExitCode is intentionally NOT omitempty: a
-// successful command exits 0, and omitting it would persist NULL for exactly
-// the completed rows the fix is meant to populate.
+// Stdout, Stderr and ExitCode mirror the server's command_result schema
+// (apps/api/src/routes/agentWs.ts, commandResultSchema). ExitCode is
+// deliberately NOT omitempty — matching tools.CommandResult — because the
+// server persists `result.exitCode ?? null`: omitting the zero value would
+// store NULL exit_code for every successful (exit-0) script run (#2474).
+// Failure paths that never spawn a process send a synthetic exit code 1 so
+// exitCode:0 always means "a process ran and exited cleanly".
 type CommandResult struct {
 	Type      string `json:"type"`
 	CommandID string `json:"commandId"`


### PR DESCRIPTION
Fixes #2474.

## Problem

The agent's `websocket.CommandResult` struct only had `{type, commandId, status, result, error}`, so the `HandleCommand` mapping dropped **stderr** and the **exit code** entirely and stuffed stdout into the generic `result` field via a speculative `json.Unmarshal`. Scripts are dispatched over the WS leg, and `script_executions` is written **only** from that leg, so:

- `stderr` persisted blank,
- `exit_code` persisted NULL fleet-wide,
- multi-line stdout was re-serialized/mangled.

A script that wrote only to stderr or exited nonzero with no stdout showed up complete/failed with **no visible output** in the Scripts UI.

## Fix (agent-only)

The server's `command_result` schema already accepts `exitCode`/`stdout`/`stderr` (`apps/api/src/routes/agentWs.ts`) and `handleScriptResult` already persists them — the agent just never sent them.

- Add `Stdout`/`Stderr`/`ExitCode` to `websocket.CommandResult`. `ExitCode` is intentionally **not** `omitempty`: a successful command exits 0, and omitting it would keep persisting NULL for exactly the completed rows this fixes.
- Extract the mapping into `toWSCommandResult()` and populate the new fields. The stdout->`result` reparse is preserved verbatim because discovery/backup/snmp/monitor handlers still read the structured `result` field.
- Regression tests: stderr+exitCode survive, exit 0 is wire-visible, structured JSON stdout still reaches `result`.

## Verification

- `go build`/`vet`/`gofmt` clean
- `go test -race ./internal/heartbeat/... ./internal/websocket/...` green
- `govulncheck` 0 reachable

🤖 Generated with Claude Code