### PR TITLE
feat(helper): Workspace Files — finder UI, content preview, and the Workspace Reshape

### DIFF
--- a/apps/api/src/extensions/gateway.test.ts
+++ b/apps/api/src/extensions/gateway.test.ts
@@ -5,7 +5,7 @@ import type { ExtensionManifestV1 } from '@breeze/extension-sdk';
 
 import { ExtensionContributionRegistry } from './contributionRegistry';
 
-const authLifetime = new AsyncLocalStorage<'user' | 'agent'>();
+const authLifetime = new AsyncLocalStorage<'user' | 'agent' | 'helper'>();
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn(async (
@@ -39,14 +39,38 @@ vi.mock('../middleware/agentAuth', () => ({
   }),
 }));
 
+vi.mock('../middleware/helperAuth', () => ({
+  helperAuth: vi.fn(async (
+    c: {
+      req: { header(name: string): string | undefined };
+      json(body: unknown, status: 401): Response;
+      set(key: string, value: unknown): void;
+    },
+    next: () => Promise<void>,
+  ) => {
+    if (!c.req.header('Authorization')) {
+      return c.json({ error: 'missing helper auth' }, 401);
+    }
+    c.set('helperDevice', { id: 'dev-1', orgId: 'org-1' });
+    c.set('auth', { orgId: 'org-1', helperDeviceId: 'dev-1', scope: 'organization' });
+    await authLifetime.run('helper', next);
+  }),
+}));
+
 import {
   legacyExtensionAgentAuthMiddleware,
   mountExtensionGateway,
 } from './gateway';
 import { authMiddleware } from '../middleware/auth';
 import { agentAuthMiddleware } from '../middleware/agentAuth';
+import { helperAuth } from '../middleware/helperAuth';
 
-function makeManifest(overrides: Partial<ExtensionManifestV1> = {}): ExtensionManifestV1 {
+// `helperRoutes` is a legacy-manifest flag carried on the staged manifest for
+// the gateway guard; it is not part of the v1 wire schema yet (see the TODO in
+// packages/extension-sdk/src/manifest.ts).
+type GatewayTestManifest = ExtensionManifestV1 & { helperRoutes?: boolean };
+
+function makeManifest(overrides: Partial<GatewayTestManifest> = {}): GatewayTestManifest {
   return {
     apiVersion: 'breeze.extensions/v1',
     name: 'demo',
@@ -169,6 +193,52 @@ describe('mountExtensionGateway', () => {
 
     expect(response.status).toBe(401);
     expect(agentAuthMiddleware).toHaveBeenCalledTimes(1);
+    expect(authMiddleware).not.toHaveBeenCalled();
+  });
+
+  it('routes /helper/* through helper auth when the manifest opts in', async () => {
+    const routeApp = new Hono();
+    routeApp.get('/helper/search', (c) => c.json({
+      deviceId: (c.get('helperDevice') as { id: string }).id,
+      authLifetime: authLifetime.getStore(),
+    }));
+    const manifest = makeManifest({ helperRoutes: true });
+    const { app } = makeGatewayFixture({ routeApp, manifest });
+
+    expect((await app.request('/api/v1/ext/demo/helper/search?q=x')).status).toBe(401);
+    const response = await app.request('/api/v1/ext/demo/helper/search?q=x', {
+      headers: { Authorization: 'Bearer brz_helper-test' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ deviceId: 'dev-1', authLifetime: 'helper' });
+    expect(helperAuth).toHaveBeenCalledTimes(2);
+    expect(authMiddleware).not.toHaveBeenCalled();
+    expect(agentAuthMiddleware).not.toHaveBeenCalled();
+  });
+
+  it('keeps /helper/* on user auth when the manifest does not opt in', async () => {
+    const routeApp = new Hono();
+    routeApp.get('/helper/search', (c) => c.json({ ok: true }));
+    const { app } = makeGatewayFixture({ routeApp });
+
+    const response = await app.request('/api/v1/ext/demo/helper/search');
+
+    expect(response.status).toBe(200);
+    expect(authMiddleware).toHaveBeenCalledTimes(1);
+    expect(helperAuth).not.toHaveBeenCalled();
+  });
+
+  it('uses helper auth for helper paths and never public-route exemptions', async () => {
+    const routeApp = new Hono();
+    routeApp.get('/helper/search', (c) => c.json({ ok: true }));
+    const manifest = makeManifest({ helperRoutes: true, publicRoutes: ['/helper/*'] });
+    const { app } = makeGatewayFixture({ routeApp, manifest });
+
+    const response = await app.request('/api/v1/ext/demo/helper/search');
+
+    expect(response.status).toBe(401);
+    expect(helperAuth).toHaveBeenCalledTimes(1);
     expect(authMiddleware).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/extensions/gateway.ts
+++ b/apps/api/src/extensions/gateway.ts
@@ -4,12 +4,13 @@ import type { ExtensionManifestV1 } from '@breeze/extension-sdk';
 
 import { agentAuthMiddleware } from '../middleware/agentAuth';
 import { authMiddleware } from '../middleware/auth';
+import { helperAuth } from '../middleware/helperAuth';
 import type {
   ExtensionContributionRegistry,
   StagedExtensionContributions,
 } from './contributionRegistry';
 
-type LoaderAuthKind = 'user' | 'agent';
+type LoaderAuthKind = 'user' | 'agent' | 'helper';
 const LOADER_AUTH_KIND = 'extensionLoaderAuthKind';
 
 function skipIfLoaderAuthed(
@@ -24,6 +25,14 @@ function skipIfLoaderAuthed(
 
 export const legacyExtensionAuthMiddleware = skipIfLoaderAuthed(authMiddleware, 'user');
 export const legacyExtensionAgentAuthMiddleware = skipIfLoaderAuthed(agentAuthMiddleware, 'agent');
+export const legacyExtensionHelperAuthMiddleware = skipIfLoaderAuthed(helperAuth, 'helper');
+
+/**
+ * `helperRoutes` is a legacy-manifest flag the loader carries on the staged
+ * manifest for this guard; it is not part of the v1 wire schema yet (see the
+ * TODO in packages/extension-sdk/src/manifest.ts).
+ */
+type GatewayManifest = Pick<ExtensionManifestV1, 'publicRoutes'> & { helperRoutes?: boolean };
 
 /**
  * Default-deny auth selection for an extension namespace.
@@ -34,7 +43,7 @@ export const legacyExtensionAgentAuthMiddleware = skipIfLoaderAuthed(agentAuthMi
  */
 export function buildExtensionAuthGuard(
   mountPrefix: string,
-  manifest: Pick<ExtensionManifestV1, 'publicRoutes'>,
+  manifest: GatewayManifest,
 ): MiddlewareHandler {
   const publicExact = new Set<string>();
   const publicPrefixes: string[] = [];
@@ -52,6 +61,15 @@ export function buildExtensionAuthGuard(
       if (c.get(LOADER_AUTH_KIND) === 'agent') return next();
       c.set(LOADER_AUTH_KIND, 'agent');
       return agentAuthMiddleware(c, next);
+    }
+    if (
+      manifest.helperRoutes
+      && (relativePath === '/helper' || relativePath.startsWith('/helper/'))
+    ) {
+      // Before the publicRoutes check — helper paths can never be public.
+      if (c.get(LOADER_AUTH_KIND) === 'helper') return next();
+      c.set(LOADER_AUTH_KIND, 'helper');
+      return helperAuth(c, next);
     }
     if (
       publicExact.has(relativePath)

--- a/apps/api/src/extensions/loader.test.ts
+++ b/apps/api/src/extensions/loader.test.ts
@@ -28,6 +28,14 @@ vi.mock('../middleware/agentAuth', () => ({
     },
   ),
 }));
+vi.mock('../middleware/helperAuth', () => ({
+  helperAuth: vi.fn(
+    async (c: { header: (k: string, v: string) => void }, next: () => Promise<void>) => {
+      c.header('x-guard', 'helper');
+      return next();
+    },
+  ),
+}));
 vi.mock('../services/auditService', () => ({ createAuditLogAsync: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../services/secretCrypto', () => ({
   encryptSecret: vi.fn((value: string, options: { aad?: string }) => `encrypted:${options.aad}:${value}`),
@@ -349,6 +357,84 @@ describe('mountExtensions', () => {
     // middleware silently evaporate — e.g. an extension applying
     // ctx.agentAuthMiddleware to a non-/agent/ route would get user auth
     // instead, with c.get('agent') undefined: an auth downgrade.
+    it('applies core helperAuth to /helper/ routes when the manifest opts in via helperRoutes', async () => {
+      scaffoldRuntimeExtension(
+        root,
+        { helperRoutes: true },
+        `import { Hono } from 'hono';
+         const ext = {
+           register(ctx) {
+             if (!ctx.helperAuthMiddleware) throw new Error('missing ctx.helperAuthMiddleware');
+             const app = new Hono();
+             app.get('/helper/health', (c) => c.json({ ok: true }));
+             app.get('/health', (c) => c.json({ ok: true }));
+             ctx.mountRoute(app);
+           },
+         };
+         export default ext;`,
+      );
+      const app = new Hono();
+      await mountExtensions(app, root);
+
+      const helperRoute = await app.request('/api/v1/ext/demo/helper/health');
+      expect(helperRoute.status).toBe(200);
+      expect(helperRoute.headers.get('x-guard')).toBe('helper');
+
+      // Everything outside /helper/ stays on the user default-deny.
+      const userRoute = await app.request('/api/v1/ext/demo/health');
+      expect(userRoute.headers.get('x-guard')).toBe('user');
+    });
+
+    it('keeps /helper/ routes on user auth when the manifest does NOT opt in', async () => {
+      scaffoldRuntimeExtension(
+        root,
+        {},
+        `import { Hono } from 'hono';
+         const ext = {
+           register(ctx) {
+             const app = new Hono();
+             app.get('/helper/health', (c) => c.json({ ok: true }));
+             ctx.mountRoute(app);
+           },
+         };
+         export default ext;`,
+      );
+      const app = new Hono();
+      await mountExtensions(app, root);
+
+      const res = await app.request('/api/v1/ext/demo/helper/health');
+      expect(res.status).toBe(200);
+      expect(res.headers.get('x-guard')).toBe('user');
+    });
+
+    it('no-ops a redundant ctx.helperAuthMiddleware when the loader already ran the SAME (helper) auth', async () => {
+      scaffoldRuntimeExtension(
+        root,
+        { helperRoutes: true },
+        `import { Hono } from 'hono';
+         const ext = {
+           register(ctx) {
+             const app = new Hono();
+             // Redundant belt-and-suspenders: the loader guard already applies
+             // helper auth to /helper/ paths for this manifest.
+             app.use('/helper/*', ctx.helperAuthMiddleware);
+             app.get('/helper/thing', (c) => c.json({ ok: true }));
+             ctx.mountRoute(app);
+           },
+         };
+         export default ext;`,
+      );
+      const app = new Hono();
+      await mountExtensions(app, root);
+
+      const { helperAuth } = await import('../middleware/helperAuth');
+      const res = await app.request('/api/v1/ext/demo/helper/thing');
+      expect(res.status).toBe(200);
+      // Core helper auth ran exactly ONCE (the loader's) — the extension's
+      // redundant call was skipped by the kind-matched wrapper.
+      expect(vi.mocked(helperAuth)).toHaveBeenCalledTimes(1);
+    });
+
     it('runs the extension\'s ctx.agentAuthMiddleware on a non-/agent/ route (loader ran USER auth — kinds differ, must not be skipped)', async () => {
       scaffoldRuntimeExtension(
         root,

--- a/apps/api/src/extensions/loader.ts
+++ b/apps/api/src/extensions/loader.ts
@@ -22,6 +22,7 @@ import {
 import {
   legacyExtensionAgentAuthMiddleware,
   legacyExtensionAuthMiddleware,
+  legacyExtensionHelperAuthMiddleware,
 } from './gateway';
 import { assertExtensionTenancyRls, assertNoUnaccountedPublicTables } from './tenancyTripwire';
 import { aiTools, hasCoreAiToolName } from '../services/aiTools';
@@ -45,7 +46,17 @@ async function loadEntry(dir: string, entry: string): Promise<BreezeExtension> {
   return ext;
 }
 
-function synthesizeLegacyManifest(extension: DiscoveredExtension): ExtensionManifestV1 {
+/**
+ * The staged manifest carries the legacy `helperRoutes` flag for the gateway's
+ * auth guard, but the flag is NOT part of the v1 wire schema yet — it must be
+ * stripped before `parseExtensionManifestV1` (strict) validates the rest.
+ * TODO(runtime-platform): drop this once helperRoutes lands in the v1 manifest
+ * as capability 'server.helper-routes.v1' (see the TODO in
+ * packages/extension-sdk/src/manifest.ts).
+ */
+type StagedLegacyManifest = ExtensionManifestV1 & { helperRoutes?: boolean };
+
+function synthesizeLegacyManifest(extension: DiscoveredExtension): StagedLegacyManifest {
   return {
     apiVersion: 'breeze.extensions/v1',
     name: extension.name,
@@ -61,6 +72,7 @@ function synthesizeLegacyManifest(extension: DiscoveredExtension): ExtensionMani
     schemaCompatibilityFloor: '0.0.0',
     publicRoutes: extension.manifest.publicRoutes,
     agentRoutes: extension.manifest.agentRoutes,
+    helperRoutes: extension.manifest.helperRoutes,
     jobs: [],
     aiTools: [],
     tenancy: extension.manifest.tenancy,
@@ -105,6 +117,7 @@ async function stageLegacyExtension(
     mountRoute: (subApp) => session.registrar.mountRoute(subApp),
     authMiddleware: legacyExtensionAuthMiddleware,
     agentAuthMiddleware: legacyExtensionAgentAuthMiddleware,
+    helperAuthMiddleware: legacyExtensionHelperAuthMiddleware,
     db: db as unknown as ExtensionDatabase,
     secrets: {
       encryptForColumn: (table, column, plaintext) =>
@@ -121,7 +134,8 @@ async function stageLegacyExtension(
   };
 
   await loaded.register(context);
-  parseExtensionManifestV1(manifest);
+  const { helperRoutes: _legacyHelperRoutes, ...v1Manifest } = manifest;
+  parseExtensionManifestV1(v1Manifest);
   return session.finish();
 }
 

--- a/apps/api/src/extensions/tenancyRegistry.test.ts
+++ b/apps/api/src/extensions/tenancyRegistry.test.ts
@@ -8,7 +8,7 @@ vi.mock('./discovery', () => ({
       migrationsDir: null,
       manifest: {
         name: 'sample', routeNamespace: 'sample', entry: 'src/index.ts',
-        migrationsDir: 'migrations',
+        migrationsDir: 'migrations', helperRoutes: false,
         tenancy: {
           orgCascadeDeleteTables: ['sample_items', 'memory_blocks'],
           deviceCascadeDeleteTables: ['sample_child', 'sample_parent'],
@@ -54,7 +54,7 @@ describe('tenancyRegistry', () => {
         migrationsDir: null,
         manifest: {
           name: 'sample', routeNamespace: 'sample', entry: 'src/index.ts',
-          migrationsDir: 'migrations',
+          migrationsDir: 'migrations', helperRoutes: false,
           tenancy: {
             orgCascadeDeleteTables: ['organizations', 'sample_items', 'organizations'],
             deviceCascadeDeleteTables: ['sample_child', 'sample_parent'],
@@ -100,7 +100,7 @@ describe('tenancyRegistry', () => {
   it('dedupes a shared table declared by two extensions in device-cascade lists', () => {
     const sampleManifest = {
       name: 'sample', routeNamespace: 'sample', entry: 'src/index.ts',
-      migrationsDir: 'migrations',
+      migrationsDir: 'migrations', helperRoutes: false,
       tenancy: {
         orgCascadeDeleteTables: [],
         deviceCascadeDeleteTables: ['memory_blocks', 'sample_child'],

--- a/apps/api/src/middleware/helperAuth.test.ts
+++ b/apps/api/src/middleware/helperAuth.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: {
+    id: 'devices.id',
+    agentId: 'devices.agentId',
+    orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
+    hostname: 'devices.hostname',
+    osType: 'devices.osType',
+    osVersion: 'devices.osVersion',
+    agentVersion: 'devices.agentVersion',
+    helperTokenHash: 'devices.helperTokenHash',
+    previousHelperTokenHash: 'devices.previousHelperTokenHash',
+    previousHelperTokenExpiresAt: 'devices.previousHelperTokenExpiresAt',
+    status: 'devices.status',
+  },
+  organizations: {
+    id: 'organizations.id',
+    partnerId: 'organizations.partnerId',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((...args: unknown[]) => ({ eq: args })),
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+  or: vi.fn((...args: unknown[]) => ({ or: args })),
+}));
+
+vi.mock('./agentAuth', () => ({
+  matchAgentTokenHash: vi.fn(() => true),
+}));
+
+import { helperAuth } from './helperAuth';
+import { db, withDbAccessContext } from '../db';
+import { matchAgentTokenHash } from './agentAuth';
+
+function mockDeviceRow(overrides: Record<string, unknown> = {}) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: 'dev-1',
+            agentId: 'agent-1',
+            orgId: 'org-1',
+            siteId: 'site-1',
+            hostname: 'host-1',
+            osType: 'linux',
+            osVersion: '6.8',
+            agentVersion: '1.0.0',
+            helperTokenHash: 'hash',
+            previousHelperTokenHash: null,
+            previousHelperTokenExpiresAt: null,
+            status: 'online',
+            partnerId: 'partner-1',
+            ...overrides,
+          }]),
+        }),
+      }),
+    }),
+  } as never);
+}
+
+describe('helperAuth middleware', () => {
+  const app = new Hono();
+  app.use('*', helperAuth);
+  app.get('/probe', (c) => {
+    const device = c.get('helperDevice');
+    const auth = c.get('auth');
+    return c.json({
+      deviceId: device.id,
+      orgId: auth.orgId,
+      helperDeviceId: auth.helperDeviceId,
+      scope: auth.scope,
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(matchAgentTokenHash).mockReturnValue(true as never);
+  });
+
+  it('rejects a missing bearer token', async () => {
+    const res = await app.request('/probe');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a non-brz token', async () => {
+    const res = await app.request('/probe', { headers: { Authorization: 'Bearer eyJhbGciOi' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a token that matches no device', async () => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    } as never);
+
+    const res = await app.request('/probe', { headers: { Authorization: 'Bearer brz_' + 'a'.repeat(64) } });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects when the token hash does not match', async () => {
+    mockDeviceRow();
+    vi.mocked(matchAgentTokenHash).mockReturnValue(null as never);
+
+    const res = await app.request('/probe', { headers: { Authorization: 'Bearer brz_' + 'a'.repeat(64) } });
+    expect(res.status).toBe(401);
+  });
+
+  it('sets helperDevice and synthetic org auth for a valid token', async () => {
+    mockDeviceRow();
+
+    const res = await app.request('/probe', { headers: { Authorization: 'Bearer brz_' + 'a'.repeat(64) } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      deviceId: 'dev-1',
+      orgId: 'org-1',
+      helperDeviceId: 'dev-1',
+      scope: 'organization',
+    });
+    expect(withDbAccessContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: 'organization',
+        orgId: 'org-1',
+        accessibleOrgIds: ['org-1'],
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('rejects decommissioned devices with 403', async () => {
+    mockDeviceRow({ status: 'decommissioned' });
+
+    const res = await app.request('/probe', { headers: { Authorization: 'Bearer brz_' + 'a'.repeat(64) } });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects quarantined devices with 403', async () => {
+    mockDeviceRow({ status: 'quarantined' });
+
+    const res = await app.request('/probe', { headers: { Authorization: 'Bearer brz_' + 'a'.repeat(64) } });
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/api/src/middleware/helperAuth.ts
+++ b/apps/api/src/middleware/helperAuth.ts
@@ -1,0 +1,152 @@
+/**
+ * Helper Auth Middleware
+ *
+ * Authenticates Breeze Helper (tray) requests using the helper-scoped
+ * bearer token (brz_ prefix). Extracted from routes/helper/index.ts for
+ * reuse (e.g. extension /helper/* routes); behavior unchanged.
+ */
+
+import type { MiddlewareHandler } from 'hono';
+import { createHash } from 'crypto';
+import { eq, or } from 'drizzle-orm';
+import { db, withSystemDbAccessContext, withDbAccessContext } from '../db';
+import { devices, organizations } from '../db/schema';
+import type { AuthContext } from './auth';
+import { matchAgentTokenHash } from './agentAuth';
+
+export interface HelperDevice {
+  id: string;
+  agentId: string;
+  orgId: string;
+  siteId: string;
+  hostname: string;
+  osType: string;
+  osVersion: string;
+  agentVersion: string;
+}
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    helperDevice: HelperDevice;
+  }
+}
+
+/**
+ * Authenticate helper requests using the helper-scoped bearer token.
+ * Similar to agentAuthMiddleware but sets helperDevice context
+ * and creates a synthetic AuthContext for the streaming session manager.
+ */
+export const helperAuth: MiddlewareHandler = async (c, next) => {
+  const authHeader = c.req.header('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return c.json({ error: 'Missing or invalid Authorization header' }, 401);
+  }
+
+  const token = authHeader.slice(7);
+  if (!token.startsWith('brz_')) {
+    return c.json({ error: 'Invalid agent token format' }, 401);
+  }
+
+  const tokenHash = createHash('sha256').update(token).digest('hex');
+
+  const device = await withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select({
+        id: devices.id,
+        agentId: devices.agentId,
+        orgId: devices.orgId,
+        siteId: devices.siteId,
+        hostname: devices.hostname,
+        osType: devices.osType,
+        osVersion: devices.osVersion,
+        agentVersion: devices.agentVersion,
+        helperTokenHash: devices.helperTokenHash,
+        previousHelperTokenHash: devices.previousHelperTokenHash,
+        previousHelperTokenExpiresAt: devices.previousHelperTokenExpiresAt,
+        status: devices.status,
+        partnerId: organizations.partnerId,
+      })
+      .from(devices)
+      .innerJoin(organizations, eq(organizations.id, devices.orgId))
+      .where(or(eq(devices.helperTokenHash, tokenHash), eq(devices.previousHelperTokenHash, tokenHash)))
+      .limit(1);
+    return row ?? null;
+  });
+
+  const match = device
+    ? matchAgentTokenHash({
+        agentTokenHash: device.helperTokenHash,
+        previousTokenHash: device.previousHelperTokenHash,
+        previousTokenExpiresAt: device.previousHelperTokenExpiresAt,
+        tokenHash,
+      })
+    : null;
+
+  if (!device || !match) {
+    return c.json({ error: 'Invalid agent credentials' }, 401);
+  }
+
+  if (device.status === 'decommissioned') {
+    return c.json({ error: 'Device has been decommissioned' }, 403);
+  }
+
+  if (device.status === 'quarantined') {
+    return c.json({ error: 'Device is quarantined pending admin approval' }, 403);
+  }
+
+  c.set('helperDevice', {
+    id: device.id,
+    agentId: device.agentId,
+    orgId: device.orgId,
+    siteId: device.siteId,
+    hostname: device.hostname,
+    osType: device.osType,
+    osVersion: device.osVersion,
+    agentVersion: device.agentVersion,
+  });
+
+  // Set a synthetic auth context for the streaming session manager
+  // Helper sessions use a synthetic "device" user identity
+  const syntheticAuth: AuthContext = {
+    user: {
+      id: device.id, // Use device ID as the "user" ID for helper sessions
+      email: `helper@${device.hostname}`,
+      name: device.hostname,
+      isPlatformAdmin: false,
+    },
+    token: {
+      sub: device.id,
+      email: `helper@${device.hostname}`,
+      roleId: null,
+      type: 'access' as const,
+      scope: 'organization' as const,
+      orgId: device.orgId,
+      partnerId: null,
+      iat: Math.floor(Date.now() / 1000),
+      mfa: false,
+    },
+    partnerId: null,
+    orgId: device.orgId,
+    scope: 'organization',
+    accessibleOrgIds: [device.orgId],
+    orgCondition: (orgIdColumn) => eq(orgIdColumn, device.orgId),
+    canAccessOrg: (orgId) => orgId === device.orgId,
+    helperDeviceId: device.id,
+  };
+
+  c.set('auth', syntheticAuth);
+
+  await withDbAccessContext(
+    {
+      scope: 'organization',
+      orgId: device.orgId,
+      accessibleOrgIds: [device.orgId],
+      accessiblePartnerIds: [device.partnerId],
+      // Own partner — read-visibility of partner-wide catalog rows.
+      currentPartnerId: device.partnerId ?? null,
+    },
+    async () => {
+      await next();
+    },
+  );
+};

--- a/apps/api/src/routes/helper/index.ts
+++ b/apps/api/src/routes/helper/index.ts
@@ -10,10 +10,9 @@ import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { streamSSE } from 'hono/streaming';
-import { createHash } from 'crypto';
-import { eq, and, desc, sql, asc, or } from 'drizzle-orm';
-import { db, withSystemDbAccessContext, withDbAccessContext } from '../../db';
-import { aiSessions, aiMessages, devices, organizations } from '../../db/schema';
+import { eq, and, desc, sql, asc } from 'drizzle-orm';
+import { db } from '../../db';
+import { aiSessions, aiMessages, devices } from '../../db/schema';
 import { streamingSessionManager } from '../../services/streamingSessionManager';
 import { buildHelperSystemPrompt } from '../../services/helperAiAgent';
 import { getHelperAllowedMcpToolNames, type HelperPermissionLevel } from '../../services/helperToolFilter';
@@ -23,8 +22,7 @@ import { storeScreenshot } from '../../services/screenshotStorage';
 import { checkBudget, getRemainingBudgetUsd } from '../../services/aiCostTracker';
 import { getRedis, rateLimiter } from '../../services';
 import { createSessionPreToolUse, createSessionPostToolUse } from '../../services/aiAgentSdk';
-import type { AuthContext } from '../../middleware/auth';
-import { matchAgentTokenHash } from '../../middleware/agentAuth';
+import { helperAuth, type HelperDevice } from '../../middleware/helperAuth';
 import type { ActiveSession } from '../../services/streamingSessionManager';
 
 const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -34,147 +32,8 @@ const DEFAULT_PERMISSION_LEVEL: HelperPermissionLevel = 'basic';
 
 export const helperRoutes = new Hono();
 
-// ============================================
-// Helper Auth Middleware (helper-scoped token based)
-// ============================================
-
-interface HelperDevice {
-  id: string;
-  agentId: string;
-  orgId: string;
-  siteId: string;
-  hostname: string;
-  osType: string;
-  osVersion: string;
-  agentVersion: string;
-}
-
-declare module 'hono' {
-  interface ContextVariableMap {
-    helperDevice: HelperDevice;
-  }
-}
-
-/**
- * Authenticate helper requests using the helper-scoped bearer token.
- * Similar to agentAuthMiddleware but sets helperDevice context
- * and creates a synthetic AuthContext for the streaming session manager.
- */
-async function helperAuth(c: import('hono').Context, next: import('hono').Next) {
-  const authHeader = c.req.header('Authorization');
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return c.json({ error: 'Missing or invalid Authorization header' }, 401);
-  }
-
-  const token = authHeader.slice(7);
-  if (!token.startsWith('brz_')) {
-    return c.json({ error: 'Invalid agent token format' }, 401);
-  }
-
-  const tokenHash = createHash('sha256').update(token).digest('hex');
-
-  const device = await withSystemDbAccessContext(async () => {
-    const [row] = await db
-      .select({
-        id: devices.id,
-        agentId: devices.agentId,
-        orgId: devices.orgId,
-        siteId: devices.siteId,
-        hostname: devices.hostname,
-        osType: devices.osType,
-        osVersion: devices.osVersion,
-        agentVersion: devices.agentVersion,
-        helperTokenHash: devices.helperTokenHash,
-        previousHelperTokenHash: devices.previousHelperTokenHash,
-        previousHelperTokenExpiresAt: devices.previousHelperTokenExpiresAt,
-        status: devices.status,
-        partnerId: organizations.partnerId,
-      })
-      .from(devices)
-      .innerJoin(organizations, eq(organizations.id, devices.orgId))
-      .where(or(eq(devices.helperTokenHash, tokenHash), eq(devices.previousHelperTokenHash, tokenHash)))
-      .limit(1);
-    return row ?? null;
-  });
-
-  const match = device
-    ? matchAgentTokenHash({
-        agentTokenHash: device.helperTokenHash,
-        previousTokenHash: device.previousHelperTokenHash,
-        previousTokenExpiresAt: device.previousHelperTokenExpiresAt,
-        tokenHash,
-      })
-    : null;
-
-  if (!device || !match) {
-    return c.json({ error: 'Invalid agent credentials' }, 401);
-  }
-
-  if (device.status === 'decommissioned') {
-    return c.json({ error: 'Device has been decommissioned' }, 403);
-  }
-
-  if (device.status === 'quarantined') {
-    return c.json({ error: 'Device is quarantined pending admin approval' }, 403);
-  }
-
-  c.set('helperDevice', {
-    id: device.id,
-    agentId: device.agentId,
-    orgId: device.orgId,
-    siteId: device.siteId,
-    hostname: device.hostname,
-    osType: device.osType,
-    osVersion: device.osVersion,
-    agentVersion: device.agentVersion,
-  });
-
-  // Set a synthetic auth context for the streaming session manager
-  // Helper sessions use a synthetic "device" user identity
-  const syntheticAuth: AuthContext = {
-    user: {
-      id: device.id, // Use device ID as the "user" ID for helper sessions
-      email: `helper@${device.hostname}`,
-      name: device.hostname,
-      isPlatformAdmin: false,
-    },
-    token: {
-      sub: device.id,
-      email: `helper@${device.hostname}`,
-      roleId: null,
-      type: 'access' as const,
-      scope: 'organization' as const,
-      orgId: device.orgId,
-      partnerId: null,
-      iat: Math.floor(Date.now() / 1000),
-      mfa: false,
-    },
-    partnerId: null,
-    orgId: device.orgId,
-    scope: 'organization',
-    accessibleOrgIds: [device.orgId],
-    orgCondition: (orgIdColumn) => eq(orgIdColumn, device.orgId),
-    canAccessOrg: (orgId) => orgId === device.orgId,
-    helperDeviceId: device.id,
-  };
-
-  c.set('auth', syntheticAuth);
-
-  await withDbAccessContext(
-    {
-      scope: 'organization',
-      orgId: device.orgId,
-      accessibleOrgIds: [device.orgId],
-      accessiblePartnerIds: [device.partnerId],
-      // Own partner — read-visibility of partner-wide catalog rows.
-      currentPartnerId: device.partnerId ?? null,
-    },
-    async () => {
-      await next();
-    },
-  );
-}
-
+// Helper auth middleware (helper-scoped token based) — extracted to
+// ../../middleware/helperAuth for reuse; behavior unchanged.
 helperRoutes.use('*', helperAuth);
 
 // ============================================

--- a/apps/helper/package.json
+++ b/apps/helper/package.json
@@ -13,6 +13,10 @@
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",
+    "@radix-ui/react-context-menu": "^2.3.3",
+    "@radix-ui/react-dropdown-menu": "^2.1.20",
+    "@radix-ui/react-toast": "^1.2.19",
+    "@radix-ui/react-tooltip": "^1.2.12",
     "@tauri-apps/api": "^2.11.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/apps/helper/package.json
+++ b/apps/helper/package.json
@@ -22,10 +22,13 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.11.3",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "autoprefixer": "^10.5.3",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5.19",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.5.0",

--- a/apps/helper/package.json
+++ b/apps/helper/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.3.0",
     "@tauri-apps/api": "^2.11.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/apps/helper/package.json
+++ b/apps/helper/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.11.0",
@@ -26,6 +28,7 @@
     "postcss": "^8.5.19",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.5.0",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/helper/src-tauri/src/lib.rs
+++ b/apps/helper/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod ipc;
+mod workspace_open;
 
 use crate::ipc::token::HelperToken;
 use futures_util::StreamExt;
@@ -1010,6 +1011,7 @@ pub fn run() {
             update_chat_active,
             helper_token_ready,
             submit_consent,
+            workspace_open::open_workspace_path,
         ])
         .setup(|app| {
             // Create main window manually (not from config) so we can set

--- a/apps/helper/src-tauri/src/lib.rs
+++ b/apps/helper/src-tauri/src/lib.rs
@@ -45,6 +45,14 @@ struct AgentConfigFull {
 // ---------------------------------------------------------------------------
 
 fn agent_config_path() -> PathBuf {
+    // Debug builds honor BREEZE_AGENT_CONFIG so a dev rig can point the helper
+    // at a seeded agent.yaml without touching the machine's real enrollment.
+    #[cfg(debug_assertions)]
+    if let Ok(p) = std::env::var("BREEZE_AGENT_CONFIG") {
+        if !p.is_empty() {
+            return PathBuf::from(p);
+        }
+    }
     #[cfg(target_os = "macos")]
     {
         PathBuf::from("/Library/Application Support/Breeze/agent.yaml")

--- a/apps/helper/src-tauri/src/lib.rs
+++ b/apps/helper/src-tauri/src/lib.rs
@@ -1035,7 +1035,7 @@ pub fn run() {
                 tauri::WebviewUrl::App("index.html".into()),
             )
             .title("Breeze Helper")
-            .inner_size(380.0, 600.0)
+            .inner_size(920.0, 640.0)
             .resizable(true)
             .center();
 

--- a/apps/helper/src-tauri/src/workspace_open.rs
+++ b/apps/helper/src-tauri/src/workspace_open.rs
@@ -1,0 +1,244 @@
+//! Validated open-in-place for workspace UNC paths.
+//!
+//! The Files view hands us an `openPath` produced by the Workspace extension
+//! (UNC-canonical for SMB sources). This module validates the path (UNC only —
+//! never arbitrary local paths, URLs, or relative paths), resolves a
+//! platform-appropriate open target, and opens it via the shell plugin (same
+//! mechanism as the portal-open path).
+
+use serde::Deserialize;
+use tauri_plugin_shell::open;
+
+/// The validated components of a UNC path: `\\host\share\<rel...>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UncParts {
+    pub host: String,
+    pub share: String,
+    /// Remaining path segments below the share root (may be empty).
+    pub rel: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Platform {
+    MacOs,
+    Windows,
+    Linux,
+}
+
+fn current_platform() -> Platform {
+    #[cfg(target_os = "macos")]
+    {
+        Platform::MacOs
+    }
+    #[cfg(target_os = "windows")]
+    {
+        Platform::Windows
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        Platform::Linux
+    }
+}
+
+/// Accepts only UNC paths: must start with `\\`, at least host + share
+/// segments, no `.`/`..` segment, no forward slashes, no interior NUL.
+/// Everything else -> Err. Never accepts local paths, URLs, or relative paths.
+fn validate_unc(path: &str) -> Result<UncParts, String> {
+    if path.contains('\0') {
+        return Err("Path must not contain NUL bytes".to_string());
+    }
+    if path.contains('/') {
+        return Err("Path must use backslash separators only".to_string());
+    }
+    let rest = path
+        .strip_prefix(r"\\")
+        .ok_or_else(|| r"Path must be a UNC path starting with \\".to_string())?;
+
+    let segments: Vec<&str> = rest.split('\\').collect();
+    if segments.len() < 2 {
+        return Err("UNC path must include a host and a share".to_string());
+    }
+    for segment in &segments {
+        if segment.is_empty() {
+            return Err("UNC path must not contain empty segments".to_string());
+        }
+        if *segment == "." || *segment == ".." {
+            return Err("UNC path must not contain dot segments".to_string());
+        }
+    }
+
+    Ok(UncParts {
+        host: segments[0].to_string(),
+        share: segments[1].to_string(),
+        rel: segments[2..].iter().map(|s| s.to_string()).collect(),
+    })
+}
+
+/// macOS: if `/Volumes/<share>/<rel>` exists, open that (share already
+/// mounted); otherwise open `smb://<host>/<share>/<rel-with-forward-slashes>`
+/// to trigger a mount. Windows: open the UNC string as-is. Linux: Err.
+fn resolve_open_target(
+    parts: &UncParts,
+    platform: Platform,
+    volumes_probe: impl Fn(&str) -> bool,
+) -> Result<String, String> {
+    match platform {
+        Platform::MacOs => {
+            let mut volumes_path = format!("/Volumes/{}", parts.share);
+            for segment in &parts.rel {
+                volumes_path.push('/');
+                volumes_path.push_str(segment);
+            }
+            if volumes_probe(&volumes_path) {
+                return Ok(volumes_path);
+            }
+            let mut url = format!("smb://{}/{}", parts.host, parts.share);
+            for segment in &parts.rel {
+                url.push('/');
+                url.push_str(segment);
+            }
+            Ok(url)
+        }
+        Platform::Windows => {
+            let mut unc = format!(r"\\{}\{}", parts.host, parts.share);
+            for segment in &parts.rel {
+                unc.push('\\');
+                unc.push_str(segment);
+            }
+            Ok(unc)
+        }
+        Platform::Linux => Err("Opening shared files is not supported on this platform".to_string()),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OpenWorkspacePathInput {
+    path: String,
+}
+
+/// Open a workspace file in place. UNC paths only in v1 — the Files view
+/// treats `openPath: null` (local-profile rows, directories) as
+/// copy-path-only, so anything that is not a well-formed UNC path is refused.
+#[tauri::command]
+pub async fn open_workspace_path(
+    app: tauri::AppHandle,
+    input: OpenWorkspacePathInput,
+) -> Result<(), String> {
+    let parts = validate_unc(&input.path)?;
+    let target = resolve_open_target(&parts, current_platform(), |candidate| {
+        std::path::Path::new(candidate).exists()
+    })?;
+
+    tauri_plugin_shell::ShellExt::shell(&app)
+        .open(&target, None::<open::Program>)
+        .map_err(|e| {
+            crate::log_helper_error(&format!(
+                "[helper] Failed to open workspace path {}: {}",
+                target, e
+            ));
+            "Couldn't open the file on this machine.".to_string()
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- validate_unc -------------------------------------------------------
+
+    #[test]
+    fn validate_unc_accepts_host_share_and_rel_path() {
+        let parts = validate_unc(r"\\srv\share\a\b.pdf").expect("valid UNC");
+        assert_eq!(parts.host, "srv");
+        assert_eq!(parts.share, "share");
+        assert_eq!(parts.rel, vec!["a".to_string(), "b.pdf".to_string()]);
+    }
+
+    #[test]
+    fn validate_unc_accepts_bare_share_root() {
+        let parts = validate_unc(r"\\srv\share").expect("share root is valid");
+        assert_eq!(parts.host, "srv");
+        assert_eq!(parts.share, "share");
+        assert!(parts.rel.is_empty());
+    }
+
+    #[test]
+    fn validate_unc_rejects_drive_letter_path() {
+        assert!(validate_unc(r"C:\x").is_err());
+    }
+
+    #[test]
+    fn validate_unc_rejects_url() {
+        assert!(validate_unc("smb://x").is_err());
+    }
+
+    #[test]
+    fn validate_unc_rejects_host_only() {
+        assert!(validate_unc(r"\\srv").is_err());
+    }
+
+    #[test]
+    fn validate_unc_rejects_dot_dot_segment() {
+        assert!(validate_unc(r"\\srv\share\..\x").is_err());
+    }
+
+    #[test]
+    fn validate_unc_rejects_forward_slashes() {
+        assert!(validate_unc(r"\\srv\share/a/b.pdf").is_err());
+    }
+
+    #[test]
+    fn validate_unc_rejects_empty_and_relative() {
+        assert!(validate_unc("").is_err());
+        assert!(validate_unc(r"share\a.pdf").is_err());
+    }
+
+    #[test]
+    fn validate_unc_rejects_interior_nul() {
+        assert!(validate_unc("\\\\srv\\share\\a\0b").is_err());
+    }
+
+    #[test]
+    fn validate_unc_rejects_empty_segments() {
+        assert!(validate_unc(r"\\srv\share\\a.pdf").is_err());
+        assert!(validate_unc(r"\\srv\share\a\").is_err());
+    }
+
+    // -- resolve_open_target ------------------------------------------------
+
+    fn parts() -> UncParts {
+        validate_unc(r"\\srv\share\a\b.pdf").expect("valid UNC")
+    }
+
+    #[test]
+    fn resolve_macos_mounted_share_opens_volumes_path() {
+        let target =
+            resolve_open_target(&parts(), Platform::MacOs, |p| p == "/Volumes/share/a/b.pdf")
+                .expect("resolves");
+        assert_eq!(target, "/Volumes/share/a/b.pdf");
+    }
+
+    #[test]
+    fn resolve_macos_unmounted_share_opens_smb_url() {
+        let target = resolve_open_target(&parts(), Platform::MacOs, |_| false).expect("resolves");
+        assert_eq!(target, "smb://srv/share/a/b.pdf");
+    }
+
+    #[test]
+    fn resolve_macos_share_root_unmounted() {
+        let root = validate_unc(r"\\srv\share").expect("valid UNC");
+        let target = resolve_open_target(&root, Platform::MacOs, |_| false).expect("resolves");
+        assert_eq!(target, "smb://srv/share");
+    }
+
+    #[test]
+    fn resolve_windows_passes_unc_through() {
+        let target = resolve_open_target(&parts(), Platform::Windows, |_| false).expect("resolves");
+        assert_eq!(target, r"\\srv\share\a\b.pdf");
+    }
+
+    #[test]
+    fn resolve_linux_is_not_supported() {
+        assert!(resolve_open_target(&parts(), Platform::Linux, |_| false).is_err());
+    }
+}

--- a/apps/helper/src/App.tsx
+++ b/apps/helper/src/App.tsx
@@ -5,6 +5,8 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useChatStore } from './stores/chatStore';
 import type { SessionSummary, PendingApproval, DeviceContext } from './stores/chatStore';
+import { useWorkspaceStore } from './stores/workspaceStore';
+import WorkspacePanel from './components/workspace/WorkspacePanel';
 
 function ToolCallIndicator({ toolName }: { toolName?: string }) {
   const label = toolName
@@ -397,14 +399,26 @@ export default function App() {
     flagSession,
   } = useChatStore();
 
+  const workspaceAvailable = useWorkspaceStore((s) => s.available);
+  const probeWorkspace = useWorkspaceStore((s) => s.probe);
+
   const [input, setInput] = useState('');
   const [showHistory, setShowHistory] = useState(false);
   const [showDeviceInfo, setShowDeviceInfo] = useState(false);
+  const [showWorkspace, setShowWorkspace] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     initialize();
   }, [initialize]);
+
+  // Probe the workspace files capability once the connection is ready.
+  // 404/401 leaves available=false and the Files affordance hidden.
+  useEffect(() => {
+    if (connectionState === 'connected' && workspaceAvailable === null) {
+      probeWorkspace();
+    }
+  }, [connectionState, workspaceAvailable, probeWorkspace]);
 
   // Listen for tray menu "Device Info" click
   useEffect(() => {
@@ -495,6 +509,11 @@ export default function App() {
     return <DeviceInfoView onClose={() => setShowDeviceInfo(false)} />;
   }
 
+  // Workspace files view (only reachable when the backend reports the capability)
+  if (showWorkspace) {
+    return <WorkspacePanel onClose={() => setShowWorkspace(false)} />;
+  }
+
   return (
     <div className="helper-container">
       {/* Header — draggable title bar */}
@@ -514,6 +533,15 @@ export default function App() {
               disabled={isFlagged}
             >
               {isFlagged ? 'Flagged' : 'Flag'}
+            </button>
+          )}
+          {workspaceAvailable === true && (
+            <button
+              onClick={() => setShowWorkspace(true)}
+              className="helper-btn helper-btn-sm"
+              title="Find your company's shared files"
+            >
+              Files
             </button>
           )}
           <button

--- a/apps/helper/src/App.tsx
+++ b/apps/helper/src/App.tsx
@@ -13,7 +13,7 @@ function ToolCallIndicator({ toolName }: { toolName?: string }) {
     ? `Using ${toolName.replace(/_/g, ' ')}...`
     : 'Checking your system...';
   return (
-    <div className="helper-tool-indicator">
+    <div className="helper-tool-indicator text-ws-secondary">
       <span className="helper-spinner" />
       <span>{label}</span>
     </div>
@@ -22,12 +22,12 @@ function ToolCallIndicator({ toolName }: { toolName?: string }) {
 
 function ThinkingIndicator() {
   return (
-    <div className="helper-message helper-message-assistant">
+    <div className="helper-message helper-message-assistant bg-ws-surface rounded-surface shadow-[var(--ws-shadow-1)]">
       <div className="helper-thinking">
         <span className="helper-thinking-dot" />
         <span className="helper-thinking-dot" />
         <span className="helper-thinking-dot" />
-        <span className="helper-thinking-label">Thinking</span>
+        <span className="helper-thinking-label text-ws-secondary">Thinking</span>
       </div>
     </div>
   );
@@ -518,7 +518,7 @@ export default function App() {
   }
 
   return (
-    <div className="helper-container">
+    <div className="helper-container bg-ws-canvas">
       {/* Header — draggable title bar */}
       <div className={`helper-header${isMacOS ? ' helper-header-macos' : ''}`} data-tauri-drag-region>
         <div className="helper-header-left" data-tauri-drag-region>
@@ -607,7 +607,7 @@ export default function App() {
       {/* Messages */}
       <div className="helper-messages">
         {messages.length === 0 && (
-          <div className="helper-empty">
+          <div className="helper-empty text-ws-secondary">
             <p>Hi{username ? `, ${username}` : ''}! I'm Breeze Helper.</p>
             <p>Ask me anything about your computer.</p>
           </div>
@@ -625,7 +625,7 @@ export default function App() {
           return (
             <div
               key={msg.id}
-              className={`helper-message helper-message-${msg.role}`}
+              className={`helper-message helper-message-${msg.role} bg-ws-surface rounded-surface shadow-[var(--ws-shadow-1)]`}
             >
               <div className="helper-message-content">
                 {msg.role === 'assistant' ? (
@@ -651,7 +651,7 @@ export default function App() {
       </div>
 
       {/* Input */}
-      <form onSubmit={handleSubmit} className="helper-input-form">
+      <form onSubmit={handleSubmit} className="helper-input-form bg-ws-surface border-ws-border-subtle shadow-[var(--ws-shadow-1)]">
         <textarea
           value={input}
           onChange={(e) => setInput(e.target.value)}
@@ -659,12 +659,12 @@ export default function App() {
           placeholder="Ask me anything..."
           disabled={isStreaming}
           rows={1}
-          className="helper-input"
+          className="helper-input bg-ws-canvas text-ws-ink"
         />
         <button
           type="submit"
           disabled={isStreaming || !input.trim()}
-          className="helper-btn helper-btn-send"
+          className="helper-btn helper-btn-send bg-ws-accent text-[var(--ws-accent-contrast)]"
         >
           Send
         </button>

--- a/apps/helper/src/App.tsx
+++ b/apps/helper/src/App.tsx
@@ -405,7 +405,9 @@ export default function App() {
   const [input, setInput] = useState('');
   const [showHistory, setShowHistory] = useState(false);
   const [showDeviceInfo, setShowDeviceInfo] = useState(false);
-  const [showWorkspace, setShowWorkspace] = useState(false);
+  // Files-first: land in the Files view; the render below still gates on the
+  // capability probe, so orgs without workspace files keep the chat home.
+  const [showWorkspace, setShowWorkspace] = useState(true);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -512,8 +514,8 @@ export default function App() {
     return <DeviceInfoView onClose={() => setShowDeviceInfo(false)} />;
   }
 
-  // Workspace files view (only reachable when the backend reports the capability)
-  if (showWorkspace) {
+  // Workspace files view (only renders once the backend reports the capability)
+  if (showWorkspace && workspaceAvailable) {
     return <WorkspacePanel onClose={() => setShowWorkspace(false)} />;
   }
 

--- a/apps/helper/src/App.tsx
+++ b/apps/helper/src/App.tsx
@@ -420,8 +420,11 @@ export default function App() {
     }
   }, [connectionState, workspaceAvailable, probeWorkspace]);
 
-  // Listen for tray menu "Device Info" click
+  // Listen for tray menu "Device Info" click. Tray events only exist inside
+  // Tauri; the direct listen() import throws in browser dev mode, so skip it
+  // when the Tauri IPC bridge is absent.
   useEffect(() => {
+    if (!('__TAURI_INTERNALS__' in window)) return;
     let unlisten: (() => void) | undefined;
     listen('show-device-info', () => {
       setShowDeviceInfo(true);

--- a/apps/helper/src/components/ui/EmptyState.tsx
+++ b/apps/helper/src/components/ui/EmptyState.tsx
@@ -1,0 +1,13 @@
+/**
+ * Centered placeholder for an empty list — a short title plus an optional
+ * hint line. Used by every Files view (Search, Browse, Recents, Filing) in
+ * place of an ad hoc "No files matched." string.
+ */
+export function EmptyState({ title, hint }: { title: string; hint?: string }) {
+  return (
+    <div className="ws-empty-state">
+      <div className="ws-empty-state-title">{title}</div>
+      {hint && <div className="ws-empty-state-hint">{hint}</div>}
+    </div>
+  );
+}

--- a/apps/helper/src/components/ui/RowMenu.test.tsx
+++ b/apps/helper/src/components/ui/RowMenu.test.tsx
@@ -45,3 +45,37 @@ it('the hover ⋯ button opens the same items via a dropdown menu', async () => 
   expect(within(menu).getByText('Open')).toBeInTheDocument();
   expect(within(menu).getByText('Copy path')).toBeInTheDocument();
 });
+
+it('Escape closes the context menu without bubbling to an ancestor handler', async () => {
+  const onOuterEscape = vi.fn();
+  render(
+    <div onKeyDown={(e) => { if (e.key === 'Escape') onOuterEscape(); }}>
+      <RowMenu items={items(vi.fn(), vi.fn())}>
+        <div>my-file.docx</div>
+      </RowMenu>
+    </div>,
+  );
+
+  fireEvent.contextMenu(screen.getByText('my-file.docx'));
+  const menu = await screen.findByRole('menu');
+
+  fireEvent.keyDown(menu, { key: 'Escape' });
+  expect(onOuterEscape).not.toHaveBeenCalled();
+});
+
+it('Escape closes the ⋯ dropdown menu without bubbling to an ancestor handler', async () => {
+  const onOuterEscape = vi.fn();
+  render(
+    <div onKeyDown={(e) => { if (e.key === 'Escape') onOuterEscape(); }}>
+      <RowMenu items={items(vi.fn(), vi.fn())}>
+        <div>my-file.docx</div>
+      </RowMenu>
+    </div>,
+  );
+
+  fireEvent.pointerDown(screen.getByRole('button', { name: 'More actions' }), { button: 0 });
+  const menu = await screen.findByRole('menu');
+
+  fireEvent.keyDown(menu, { key: 'Escape' });
+  expect(onOuterEscape).not.toHaveBeenCalled();
+});

--- a/apps/helper/src/components/ui/RowMenu.test.tsx
+++ b/apps/helper/src/components/ui/RowMenu.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { RowMenu, type MenuItem } from './RowMenu';
+
+function items(onOpen: () => void, onCopy: () => void): MenuItem[] {
+  return [
+    { label: 'Open', onSelect: onOpen },
+    { label: 'Copy path', onSelect: onCopy },
+  ];
+}
+
+it('right-click opens the context menu with the given items; selecting one calls its handler', async () => {
+  const onOpen = vi.fn();
+  const onCopy = vi.fn();
+  render(
+    <RowMenu items={items(onOpen, onCopy)}>
+      <div>my-file.docx</div>
+    </RowMenu>,
+  );
+
+  fireEvent.contextMenu(screen.getByText('my-file.docx'));
+
+  const menu = await screen.findByRole('menu');
+  const copyItem = within(menu).getByText('Copy path');
+  expect(within(menu).getByText('Open')).toBeInTheDocument();
+
+  fireEvent.click(copyItem);
+  expect(onCopy).toHaveBeenCalledTimes(1);
+  expect(onOpen).not.toHaveBeenCalled();
+});
+
+it('the hover ⋯ button opens the same items via a dropdown menu', async () => {
+  const onOpen = vi.fn();
+  const onCopy = vi.fn();
+  render(
+    <RowMenu items={items(onOpen, onCopy)}>
+      <div>my-file.docx</div>
+    </RowMenu>,
+  );
+
+  // Radix's DropdownMenuTrigger opens on pointerdown, not click.
+  fireEvent.pointerDown(screen.getByRole('button', { name: 'More actions' }), { button: 0 });
+
+  const menu = await screen.findByRole('menu');
+  expect(within(menu).getByText('Open')).toBeInTheDocument();
+  expect(within(menu).getByText('Copy path')).toBeInTheDocument();
+});

--- a/apps/helper/src/components/ui/RowMenu.tsx
+++ b/apps/helper/src/components/ui/RowMenu.tsx
@@ -14,6 +14,21 @@ export interface MenuItem {
  * (Radix DropdownMenu, triggered by a small button revealed on row hover),
  * both rendering the same menu list.
  */
+/**
+ * Radix's DismissableLayer closes an open menu on Escape via its own
+ * document-level capture listener (it only calls `preventDefault()`, never
+ * `stopPropagation()`), so the same keydown still bubbles through React's
+ * synthetic tree to whatever's listening above this row (FileTable, then
+ * WorkspacePanel's Back handler) — collapsing "close menu" and "go Back"
+ * into a single keystroke. Stop it here, on the portalled content itself,
+ * so Escape's first job is only ever to close *this* menu; the walk-back
+ * to selection-clear / Back resumes on the next Escape once the content
+ * (and this handler) has unmounted.
+ */
+function stopEscapePropagation(e: React.KeyboardEvent) {
+  if (e.key === 'Escape') e.stopPropagation();
+}
+
 export function RowMenu({ items, children }: { items: MenuItem[]; children: ReactNode }) {
   return (
     <ContextMenu.Root>
@@ -27,7 +42,12 @@ export function RowMenu({ items, children }: { items: MenuItem[]; children: Reac
               </button>
             </DropdownMenu.Trigger>
             <DropdownMenu.Portal>
-              <DropdownMenu.Content className="ws-row-menu-content" align="end" sideOffset={4}>
+              <DropdownMenu.Content
+                className="ws-row-menu-content"
+                align="end"
+                sideOffset={4}
+                onKeyDown={stopEscapePropagation}
+              >
                 {items.map((item) => (
                   <DropdownMenu.Item
                     key={item.label}
@@ -44,7 +64,7 @@ export function RowMenu({ items, children }: { items: MenuItem[]; children: Reac
         </div>
       </ContextMenu.Trigger>
       <ContextMenu.Portal>
-        <ContextMenu.Content className="ws-row-menu-content">
+        <ContextMenu.Content className="ws-row-menu-content" onKeyDown={stopEscapePropagation}>
           {items.map((item) => (
             <ContextMenu.Item
               key={item.label}

--- a/apps/helper/src/components/ui/RowMenu.tsx
+++ b/apps/helper/src/components/ui/RowMenu.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react';
+import * as ContextMenu from '@radix-ui/react-context-menu';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+
+export interface MenuItem {
+  label: string;
+  onSelect: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * Right-click AND the hover ⋯ button open the same `items` — a context menu
+ * (Radix ContextMenu, triggered by the whole row) and an overflow dropdown
+ * (Radix DropdownMenu, triggered by a small button revealed on row hover),
+ * both rendering the same menu list.
+ */
+export function RowMenu({ items, children }: { items: MenuItem[]; children: ReactNode }) {
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger asChild>
+        <div className="ws-row-menu">
+          {children}
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger asChild>
+              <button type="button" className="ws-row-menu-overflow" aria-label="More actions">
+                &#8943;
+              </button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content className="ws-row-menu-content" align="end" sideOffset={4}>
+                {items.map((item) => (
+                  <DropdownMenu.Item
+                    key={item.label}
+                    className="ws-row-menu-item"
+                    disabled={item.disabled}
+                    onSelect={item.onSelect}
+                  >
+                    {item.label}
+                  </DropdownMenu.Item>
+                ))}
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Root>
+        </div>
+      </ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content className="ws-row-menu-content">
+          {items.map((item) => (
+            <ContextMenu.Item
+              key={item.label}
+              className="ws-row-menu-item"
+              disabled={item.disabled}
+              onSelect={item.onSelect}
+            >
+              {item.label}
+            </ContextMenu.Item>
+          ))}
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
+  );
+}

--- a/apps/helper/src/components/ui/SegmentedControl.test.tsx
+++ b/apps/helper/src/components/ui/SegmentedControl.test.tsx
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SegmentedControl } from './SegmentedControl';
+
+const opts = [
+  { key: 'search', label: 'Search' },
+  { key: 'browse', label: 'Browse' },
+];
+
+it('renders options, marks active, fires onChange', () => {
+  const onChange = vi.fn();
+  render(<SegmentedControl options={opts} value="search" onChange={onChange} />);
+  expect(screen.getByRole('tab', { name: 'Search' })).toHaveAttribute('aria-selected', 'true');
+  fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
+  expect(onChange).toHaveBeenCalledWith('browse');
+});
+
+it('moves selection with arrow keys', () => {
+  const onChange = vi.fn();
+  render(<SegmentedControl options={opts} value="search" onChange={onChange} />);
+  fireEvent.keyDown(screen.getByRole('tablist'), { key: 'ArrowRight' });
+  expect(onChange).toHaveBeenCalledWith('browse');
+});

--- a/apps/helper/src/components/ui/SegmentedControl.tsx
+++ b/apps/helper/src/components/ui/SegmentedControl.tsx
@@ -1,0 +1,20 @@
+interface Option { key: string; label: string }
+export function SegmentedControl({ options, value, onChange }: {
+  options: Option[]; value: string; onChange: (key: string) => void;
+}) {
+  const idx = options.findIndex((o) => o.key === value);
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowRight' && idx < options.length - 1) onChange(options[idx + 1].key);
+    if (e.key === 'ArrowLeft' && idx > 0) onChange(options[idx - 1].key);
+  };
+  return (
+    <div role="tablist" tabIndex={0} className="ws-segmented" onKeyDown={onKeyDown}>
+      {options.map((o) => (
+        <button key={o.key} role="tab" aria-selected={o.key === value}
+          className="ws-segmented-item" onClick={() => onChange(o.key)}>
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/helper/src/components/ui/SkeletonRows.tsx
+++ b/apps/helper/src/components/ui/SkeletonRows.tsx
@@ -1,0 +1,17 @@
+/**
+ * Row-shaped loading placeholder for the Files list-table — a name bar and a
+ * shorter meta bar per row, shimmering between the subtle-border and canvas
+ * tokens. Replaces the old spinner + "Loading..." row in every Files view.
+ */
+export function SkeletonRows({ count = 8 }: { count?: number }) {
+  return (
+    <div className="ws-skeleton-rows" aria-hidden="true">
+      {Array.from({ length: count }, (_, i) => (
+        <div key={i} className="ws-skeleton-row">
+          <span className="ws-skeleton-bar ws-skeleton-bar-name" />
+          <span className="ws-skeleton-bar ws-skeleton-bar-meta" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/helper/src/components/ui/Toaster.tsx
+++ b/apps/helper/src/components/ui/Toaster.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import * as Toast from '@radix-ui/react-toast';
+
+interface ToastMessage {
+  id: number;
+  text: string;
+}
+
+const AUTO_DISMISS_MS = 2500;
+
+let nextId = 0;
+type Listener = (msg: ToastMessage) => void;
+const listeners = new Set<Listener>();
+
+/** Global, imperative toast trigger — call from anywhere, no hook required. */
+export function toast(message: string): void {
+  const msg: ToastMessage = { id: nextId++, text: message };
+  listeners.forEach((listener) => listener(msg));
+}
+
+/**
+ * Mount once near the root of a view that calls `toast()`. Renders Radix
+ * Toast.Provider + a bottom-center viewport; each toast auto-dismisses
+ * after `AUTO_DISMISS_MS`.
+ */
+export function Toaster() {
+  const [messages, setMessages] = useState<ToastMessage[]>([]);
+
+  useEffect(() => {
+    const listener: Listener = (msg) => setMessages((cur) => [...cur, msg]);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  const dismiss = (id: number) => {
+    setMessages((cur) => cur.filter((m) => m.id !== id));
+  };
+
+  return (
+    <Toast.Provider duration={AUTO_DISMISS_MS} swipeDirection="down">
+      {messages.map((m) => (
+        <Toast.Root
+          key={m.id}
+          className="ws-toast"
+          onOpenChange={(open) => {
+            if (!open) dismiss(m.id);
+          }}
+        >
+          <Toast.Description className="ws-toast-desc">{m.text}</Toast.Description>
+        </Toast.Root>
+      ))}
+      <Toast.Viewport className="ws-toast-viewport" />
+    </Toast.Provider>
+  );
+}

--- a/apps/helper/src/components/workspace/FileTable.test.tsx
+++ b/apps/helper/src/components/workspace/FileTable.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { FileTable } from './FileTable';
+import type { FinderFile } from '../../stores/workspaceStore';
+
+function file(overrides: Partial<FinderFile> = {}): FinderFile {
+  return {
+    id: overrides.id ?? 'f1',
+    sourceId: 's1',
+    deviceKey: '__shared__',
+    relPath: `clients/${overrides.name ?? 'a.pdf'}`,
+    parentPath: 'clients',
+    name: 'a.pdf',
+    isDir: false,
+    ext: 'pdf',
+    size: 1024,
+    mtime: '2026-07-01T00:00:00.000Z',
+    openPath: '\\\\srv\\share\\clients\\a.pdf',
+    ...overrides,
+  };
+}
+
+const rows = [file({ id: 'f1', name: 'a.pdf' }), file({ id: 'f2', name: 'b.pdf' })];
+
+it('ArrowDown selects the first row (aria-selected + .ws-row-selected)', () => {
+  render(<FileTable view="search" rows={rows} onOpen={vi.fn()} onCopy={vi.fn()} />);
+  fireEvent.keyDown(screen.getByRole('table'), { key: 'ArrowDown' });
+  const firstRow = screen.getByText('a.pdf').closest('[role="row"]')!;
+  expect(firstRow).toHaveAttribute('aria-selected', 'true');
+  expect(firstRow).toHaveClass('ws-row-selected');
+});
+
+it('Enter opens the selected row', () => {
+  const onOpen = vi.fn();
+  render(<FileTable view="search" rows={rows} onOpen={onOpen} onCopy={vi.fn()} />);
+  const table = screen.getByRole('table');
+  fireEvent.keyDown(table, { key: 'ArrowDown' });
+  fireEvent.keyDown(table, { key: 'Enter' });
+  expect(onOpen).toHaveBeenCalledWith(rows[0]);
+});
+
+it('Cmd+C copies the selected row', () => {
+  const onCopy = vi.fn();
+  render(<FileTable view="search" rows={rows} onOpen={vi.fn()} onCopy={onCopy} />);
+  const table = screen.getByRole('table');
+  fireEvent.keyDown(table, { key: 'ArrowDown' });
+  fireEvent.keyDown(table, { key: 'c', metaKey: true });
+  expect(onCopy).toHaveBeenCalledWith(rows[0]);
+});
+
+it('Escape clears the selection and does not bubble past the table; a second Escape bubbles (WorkspacePanel walk-back)', () => {
+  const onOpen = vi.fn();
+  // Mirrors WorkspacePanel's own panel-level Escape handler, which only
+  // reacts to Escape — matching the real bubble-vs-consume contract.
+  const onOuterEscape = vi.fn();
+  const onOuterKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') onOuterEscape();
+  };
+  render(
+    <div onKeyDown={onOuterKeyDown}>
+      <FileTable view="search" rows={rows} onOpen={onOpen} onCopy={vi.fn()} />
+    </div>,
+  );
+  const table = screen.getByRole('table');
+  fireEvent.keyDown(table, { key: 'ArrowDown' });
+  const firstRow = screen.getByText('a.pdf').closest('[role="row"]')!;
+  expect(firstRow).toHaveAttribute('aria-selected', 'true');
+
+  fireEvent.keyDown(table, { key: 'Escape' });
+  expect(firstRow).toHaveAttribute('aria-selected', 'false');
+  expect(onOuterEscape).not.toHaveBeenCalled();
+
+  // With no selection left, Escape bubbles up (WorkspacePanel walks back).
+  fireEvent.keyDown(table, { key: 'Escape' });
+  expect(onOuterEscape).toHaveBeenCalledTimes(1);
+});

--- a/apps/helper/src/components/workspace/FileTable.test.tsx
+++ b/apps/helper/src/components/workspace/FileTable.test.tsx
@@ -74,3 +74,25 @@ it('Escape clears the selection and does not bubble past the table; a second Esc
   fireEvent.keyDown(table, { key: 'Escape' });
   expect(onOuterEscape).toHaveBeenCalledTimes(1);
 });
+
+it('Escape closes a mouse-opened row context menu without also walking the panel back — RowMenu never sets `selected`, so this is not covered by the selection guard above', async () => {
+  const onOuterEscape = vi.fn();
+  const onOuterKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') onOuterEscape();
+  };
+  render(
+    <div onKeyDown={onOuterKeyDown}>
+      <FileTable view="search" rows={rows} onOpen={vi.fn()} onCopy={vi.fn()} />
+    </div>,
+  );
+
+  // Right-click opens the row's context menu via the mouse — this never
+  // calls setSelected, so `selected` stays null throughout.
+  fireEvent.contextMenu(screen.getByText('a.pdf'));
+  const menu = await screen.findByRole('menu');
+  const firstRow = screen.getByText('a.pdf').closest('[role="row"]')!;
+  expect(firstRow).toHaveAttribute('aria-selected', 'false');
+
+  fireEvent.keyDown(menu, { key: 'Escape' });
+  expect(onOuterEscape).not.toHaveBeenCalled();
+});

--- a/apps/helper/src/components/workspace/FileTable.test.tsx
+++ b/apps/helper/src/components/workspace/FileTable.test.tsx
@@ -39,6 +39,23 @@ it('Enter opens the selected row', () => {
   expect(onOpen).toHaveBeenCalledWith(rows[0]);
 });
 
+it('double-click on a file row opens it (mouse path — same handler as Enter/menu Open)', () => {
+  const onOpen = vi.fn();
+  render(<FileTable view="search" rows={rows} onOpen={onOpen} onCopy={vi.fn()} />);
+  const secondRow = screen.getByText('b.pdf').closest('[role="row"]')!;
+  fireEvent.doubleClick(secondRow);
+  expect(onOpen).toHaveBeenCalledWith(rows[1]);
+});
+
+it('double-click on a directory row drills in (Browse) via onOpen', () => {
+  const onOpen = vi.fn();
+  const dirRows = [file({ id: 'd1', name: 'clients', isDir: true, openPath: undefined })];
+  render(<FileTable view="browse" rows={dirRows} onOpen={onOpen} onCopy={vi.fn()} />);
+  const dirRow = screen.getByText('clients/').closest('[role="row"]')!;
+  fireEvent.doubleClick(dirRow);
+  expect(onOpen).toHaveBeenCalledWith(dirRows[0]);
+});
+
 it('Cmd+C copies the selected row', () => {
   const onCopy = vi.fn();
   render(<FileTable view="search" rows={rows} onOpen={vi.fn()} onCopy={onCopy} />);

--- a/apps/helper/src/components/workspace/FileTable.tsx
+++ b/apps/helper/src/components/workspace/FileTable.tsx
@@ -3,6 +3,7 @@ import {
   useWorkspaceStore, sortRows,
   type FinderFile, type SortCol, type View, type WorkspaceSource,
 } from '../../stores/workspaceStore';
+import { RowMenu, type MenuItem } from '../ui/RowMenu';
 
 const COLUMNS: Array<{ key: SortCol; label: string }> = [
   { key: 'name', label: 'Name' },
@@ -37,12 +38,9 @@ export interface FileTableProps {
   rows: FinderFile[];
   /** Opens a file, or — in Browse — drills into a directory. */
   onOpen: (file: FinderFile) => void;
-  /**
-   * Copy-path / reveal-in-Browse. Not yet exposed by this table's own UI —
-   * the row actions this task ships are a temporary hover Open button only.
-   * Tasks 7-8 wire these into the hover ⋯ context menu and keyboard model.
-   */
+  /** Copies the file's path to the clipboard (row menu: "Copy path"). */
   onCopy: (file: FinderFile) => void;
+  /** Reveals the file's folder in Browse (row menu: "Reveal in Browse"). Omitted in Browse itself. */
   onReveal?: (file: FinderFile) => void;
   /** Optional second line under the file name — snippet, mismatch banner, etc. */
   renderMeta?: (file: FinderFile) => ReactNode;
@@ -60,9 +58,30 @@ function sourceLabel(file: FinderFile, sources: WorkspaceSource[]): string {
   return sources.find((s) => s.id === file.sourceId)?.displayName ?? file.sourceId;
 }
 
+/**
+ * Directory rows: Open in Browse only. File rows: Open, Copy path, and
+ * (when the view supports it) Reveal in Browse.
+ */
+function rowMenuItems(
+  file: FinderFile,
+  { onOpen, onCopy, onReveal }: Pick<FileTableProps, 'onOpen' | 'onCopy' | 'onReveal'>,
+): MenuItem[] {
+  if (file.isDir) {
+    return [{ label: 'Open', onSelect: () => onOpen(file) }];
+  }
+  const items: MenuItem[] = [
+    { label: 'Open', onSelect: () => onOpen(file), disabled: !file.openPath },
+    { label: 'Copy path', onSelect: () => onCopy(file) },
+  ];
+  if (onReveal) {
+    items.push({ label: 'Reveal in Browse', onSelect: () => onReveal(file) });
+  }
+  return items;
+}
+
 /** Sortable list-table for the search/browse/recents file views. */
 export function FileTable(props: FileTableProps) {
-  const { view, rows, onOpen, renderMeta, sources } = props;
+  const { view, rows, onOpen, onCopy, onReveal, renderMeta, sources } = props;
   const sort = useWorkspaceStore((s) => s.sort[view]);
   const setSort = useWorkspaceStore((s) => s.setSort);
   const sorted = sortRows(rows, sort, { dirsFirst: view === 'browse' });
@@ -90,46 +109,38 @@ export function FileTable(props: FileTableProps) {
         {sorted.map((file) => {
           const meta = renderMeta?.(file);
           return (
-            <div key={file.id} className="ws-file-table-row" role="row">
-              <div className="ws-file-table-cell ws-file-table-name-cell">
-                <div className="ws-file-table-name-row">
-                  <span className="ws-file-table-name" title={file.relPath}>
-                    {file.isDir ? `${file.name}/` : file.name}
-                  </span>
-                  {showSource && (
-                    <span
-                      className="ws-file-table-source"
-                      title={sourceLabel(file, sources!)}
-                    >
-                      {sourceLabel(file, sources!).slice(0, 1).toUpperCase()}
+            <RowMenu key={file.id} items={rowMenuItems(file, { onOpen, onCopy, onReveal })}>
+              <div className="ws-file-table-row" role="row">
+                <div className="ws-file-table-cell ws-file-table-name-cell">
+                  <div className="ws-file-table-name-row">
+                    <span className="ws-file-table-name" title={file.relPath}>
+                      {file.isDir ? `${file.name}/` : file.name}
                     </span>
-                  )}
+                    {showSource && (
+                      <span
+                        className="ws-file-table-source"
+                        title={sourceLabel(file, sources!)}
+                      >
+                        {sourceLabel(file, sources!).slice(0, 1).toUpperCase()}
+                      </span>
+                    )}
+                  </div>
+                  {meta != null && <div className="ws-file-table-meta">{meta}</div>}
                 </div>
-                {meta != null && <div className="ws-file-table-meta">{meta}</div>}
+                <div className="ws-file-table-cell ws-file-table-secondary">
+                  {file.inferredProjectLabel ?? ''}
+                </div>
+                <div className="ws-file-table-cell ws-file-table-secondary">
+                  {file.inferredDocType ?? ''}
+                </div>
+                <div className="ws-file-table-cell ws-file-table-tertiary ws-tabular">
+                  {formatModified(file.mtime)}
+                </div>
+                <div className="ws-file-table-cell ws-file-table-tertiary ws-tabular">
+                  {file.isDir ? '' : formatSize(file.size)}
+                </div>
               </div>
-              <div className="ws-file-table-cell ws-file-table-secondary">
-                {file.inferredProjectLabel ?? ''}
-              </div>
-              <div className="ws-file-table-cell ws-file-table-secondary">
-                {file.inferredDocType ?? ''}
-              </div>
-              <div className="ws-file-table-cell ws-file-table-tertiary ws-tabular">
-                {formatModified(file.mtime)}
-              </div>
-              <div className="ws-file-table-cell ws-file-table-tertiary ws-tabular">
-                {file.isDir ? '' : formatSize(file.size)}
-              </div>
-              {(file.isDir || file.openPath) && (
-                <button
-                  type="button"
-                  className="ws-file-table-open"
-                  onClick={() => onOpen(file)}
-                  title={file.isDir ? 'Open this folder' : 'Open this file'}
-                >
-                  Open
-                </button>
-              )}
-            </div>
+            </RowMenu>
           );
         })}
       </div>

--- a/apps/helper/src/components/workspace/FileTable.tsx
+++ b/apps/helper/src/components/workspace/FileTable.tsx
@@ -1,9 +1,10 @@
-import type { ReactNode } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 import {
   useWorkspaceStore, sortRows,
   type FinderFile, type SortCol, type View, type WorkspaceSource,
 } from '../../stores/workspaceStore';
 import { RowMenu, type MenuItem } from '../ui/RowMenu';
+import { useListSelection } from '../../lib/useListSelection';
 
 const COLUMNS: Array<{ key: SortCol; label: string }> = [
   { key: 'name', label: 'Name' },
@@ -87,8 +88,34 @@ export function FileTable(props: FileTableProps) {
   const sorted = sortRows(rows, sort, { dirsFirst: view === 'browse' });
   const showSource = (sources?.length ?? 0) > 1;
 
+  const rowRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const { selected, onKeyDown } = useListSelection(sorted.length, {
+    onActivate: (i) => {
+      const file = sorted[i];
+      if (file) onOpen(file);
+    },
+    onCopy: (i) => {
+      const file = sorted[i];
+      if (file) onCopy(file);
+    },
+  });
+
+  // Keep the selected row in view as Arrow Up/Down move it.
+  useEffect(() => {
+    if (selected === null) return;
+    rowRefs.current[selected]?.scrollIntoView?.({ block: 'nearest' });
+  }, [selected]);
+
+  // Escape clears an active row selection without walking the panel back —
+  // only let it bubble to WorkspacePanel's Back handler once there's nothing
+  // left in this table to clear.
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape' && selected !== null) e.stopPropagation();
+    onKeyDown(e);
+  };
+
   return (
-    <div className="ws-file-table" role="table">
+    <div className="ws-file-table" role="table" tabIndex={0} onKeyDown={handleKeyDown}>
       <div className="ws-file-table-header" role="row">
         {COLUMNS.map((col) => (
           <button
@@ -106,11 +133,19 @@ export function FileTable(props: FileTableProps) {
         ))}
       </div>
       <div className="ws-file-table-body" role="rowgroup">
-        {sorted.map((file) => {
+        {sorted.map((file, i) => {
           const meta = renderMeta?.(file);
+          const isSelected = selected === i;
           return (
             <RowMenu key={file.id} items={rowMenuItems(file, { onOpen, onCopy, onReveal })}>
-              <div className="ws-file-table-row" role="row">
+              <div
+                ref={(el) => {
+                  rowRefs.current[i] = el;
+                }}
+                className={`ws-file-table-row${isSelected ? ' ws-row-selected' : ''}`}
+                role="row"
+                aria-selected={isSelected}
+              >
                 <div className="ws-file-table-cell ws-file-table-name-cell">
                   <div className="ws-file-table-name-row">
                     <span className="ws-file-table-name" title={file.relPath}>

--- a/apps/helper/src/components/workspace/FileTable.tsx
+++ b/apps/helper/src/components/workspace/FileTable.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import {
-  useWorkspaceStore, sortRows, type FinderFile, type SortCol, type View,
+  useWorkspaceStore, sortRows,
+  type FinderFile, type SortCol, type View, type WorkspaceSource,
 } from '../../stores/workspaceStore';
 
 const COLUMNS: Array<{ key: SortCol; label: string }> = [
@@ -45,14 +46,27 @@ export interface FileTableProps {
   onReveal?: (file: FinderFile) => void;
   /** Optional second line under the file name — snippet, mismatch banner, etc. */
   renderMeta?: (file: FinderFile) => ReactNode;
+  /**
+   * All configured sources. When more than one is configured, a small
+   * initial badge renders next to the file name (tooltip = full display
+   * name) so multi-share results stay distinguishable — the row's second
+   * line is reserved for snippet/mismatch/open-error content only, so this
+   * lives inline with the name instead. Single-source setups render nothing.
+   */
+  sources?: WorkspaceSource[];
+}
+
+function sourceLabel(file: FinderFile, sources: WorkspaceSource[]): string {
+  return sources.find((s) => s.id === file.sourceId)?.displayName ?? file.sourceId;
 }
 
 /** Sortable list-table for the search/browse/recents file views. */
 export function FileTable(props: FileTableProps) {
-  const { view, rows, onOpen, renderMeta } = props;
+  const { view, rows, onOpen, renderMeta, sources } = props;
   const sort = useWorkspaceStore((s) => s.sort[view]);
   const setSort = useWorkspaceStore((s) => s.setSort);
   const sorted = sortRows(rows, sort, { dirsFirst: view === 'browse' });
+  const showSource = (sources?.length ?? 0) > 1;
 
   return (
     <div className="ws-file-table" role="table">
@@ -78,9 +92,19 @@ export function FileTable(props: FileTableProps) {
           return (
             <div key={file.id} className="ws-file-table-row" role="row">
               <div className="ws-file-table-cell ws-file-table-name-cell">
-                <span className="ws-file-table-name" title={file.relPath}>
-                  {file.isDir ? `${file.name}/` : file.name}
-                </span>
+                <div className="ws-file-table-name-row">
+                  <span className="ws-file-table-name" title={file.relPath}>
+                    {file.isDir ? `${file.name}/` : file.name}
+                  </span>
+                  {showSource && (
+                    <span
+                      className="ws-file-table-source"
+                      title={sourceLabel(file, sources!)}
+                    >
+                      {sourceLabel(file, sources!).slice(0, 1).toUpperCase()}
+                    </span>
+                  )}
+                </div>
                 {meta != null && <div className="ws-file-table-meta">{meta}</div>}
               </div>
               <div className="ws-file-table-cell ws-file-table-secondary">

--- a/apps/helper/src/components/workspace/FileTable.tsx
+++ b/apps/helper/src/components/workspace/FileTable.tsx
@@ -145,6 +145,7 @@ export function FileTable(props: FileTableProps) {
                 className={`ws-file-table-row${isSelected ? ' ws-row-selected' : ''}`}
                 role="row"
                 aria-selected={isSelected}
+                onDoubleClick={() => onOpen(file)}
               >
                 <div className="ws-file-table-cell ws-file-table-name-cell">
                   <div className="ws-file-table-name-row">

--- a/apps/helper/src/components/workspace/FileTable.tsx
+++ b/apps/helper/src/components/workspace/FileTable.tsx
@@ -1,0 +1,114 @@
+import type { ReactNode } from 'react';
+import {
+  useWorkspaceStore, sortRows, type FinderFile, type SortCol, type View,
+} from '../../stores/workspaceStore';
+
+const COLUMNS: Array<{ key: SortCol; label: string }> = [
+  { key: 'name', label: 'Name' },
+  { key: 'project', label: 'Project' },
+  { key: 'docType', label: 'Doc type' },
+  { key: 'mtime', label: 'Modified' },
+  { key: 'size', label: 'Size' },
+];
+
+function formatSize(bytes: number | null): string {
+  if (bytes == null) return '';
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let n = bytes / 1024;
+  let i = 0;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i += 1;
+  }
+  return `${n.toFixed(n < 10 ? 1 : 0)} ${units[i]}`;
+}
+
+function formatModified(mtime: string | null): string {
+  if (!mtime) return '';
+  const d = new Date(mtime);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export interface FileTableProps {
+  view: View;
+  rows: FinderFile[];
+  /** Opens a file, or — in Browse — drills into a directory. */
+  onOpen: (file: FinderFile) => void;
+  /**
+   * Copy-path / reveal-in-Browse. Not yet exposed by this table's own UI —
+   * the row actions this task ships are a temporary hover Open button only.
+   * Tasks 7-8 wire these into the hover ⋯ context menu and keyboard model.
+   */
+  onCopy: (file: FinderFile) => void;
+  onReveal?: (file: FinderFile) => void;
+  /** Optional second line under the file name — snippet, mismatch banner, etc. */
+  renderMeta?: (file: FinderFile) => ReactNode;
+}
+
+/** Sortable list-table for the search/browse/recents file views. */
+export function FileTable(props: FileTableProps) {
+  const { view, rows, onOpen, renderMeta } = props;
+  const sort = useWorkspaceStore((s) => s.sort[view]);
+  const setSort = useWorkspaceStore((s) => s.setSort);
+  const sorted = sortRows(rows, sort, { dirsFirst: view === 'browse' });
+
+  return (
+    <div className="ws-file-table" role="table">
+      <div className="ws-file-table-header" role="row">
+        {COLUMNS.map((col) => (
+          <button
+            key={col.key}
+            type="button"
+            className="ws-file-table-colbtn"
+            onClick={() => setSort(view, col.key)}
+            aria-sort={sort?.col === col.key ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}
+          >
+            <span>{col.label}</span>
+            {sort?.col === col.key && (
+              <span className="ws-file-table-chevron">{sort.dir === 'asc' ? '▲' : '▼'}</span>
+            )}
+          </button>
+        ))}
+      </div>
+      <div className="ws-file-table-body" role="rowgroup">
+        {sorted.map((file) => {
+          const meta = renderMeta?.(file);
+          return (
+            <div key={file.id} className="ws-file-table-row" role="row">
+              <div className="ws-file-table-cell ws-file-table-name-cell">
+                <span className="ws-file-table-name" title={file.relPath}>
+                  {file.isDir ? `${file.name}/` : file.name}
+                </span>
+                {meta != null && <div className="ws-file-table-meta">{meta}</div>}
+              </div>
+              <div className="ws-file-table-cell ws-file-table-secondary">
+                {file.inferredProjectLabel ?? ''}
+              </div>
+              <div className="ws-file-table-cell ws-file-table-secondary">
+                {file.inferredDocType ?? ''}
+              </div>
+              <div className="ws-file-table-cell ws-file-table-tertiary ws-tabular">
+                {formatModified(file.mtime)}
+              </div>
+              <div className="ws-file-table-cell ws-file-table-tertiary ws-tabular">
+                {file.isDir ? '' : formatSize(file.size)}
+              </div>
+              {(file.isDir || file.openPath) && (
+                <button
+                  type="button"
+                  className="ws-file-table-open"
+                  onClick={() => onOpen(file)}
+                  title={file.isDir ? 'Open this folder' : 'Open this file'}
+                >
+                  Open
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/helper/src/components/workspace/FilingCard.tsx
+++ b/apps/helper/src/components/workspace/FilingCard.tsx
@@ -9,16 +9,23 @@ export interface FilingCardProps {
   busy: boolean;
   onClassify: (fileIndexId: string) => void;
   onAssign: (fileIndexId: string, projectKey: string) => void;
+  /**
+   * True only for the card most recently dropped onto a ProjectRail entry.
+   * Gates the settle animation + toast to the onDrop path per the brief —
+   * the pre-existing click-to-file ("File it") and select-to-reassign paths
+   * are unaffected, as they were before this card restyle.
+   */
+  viaDrop?: boolean;
 }
 
 /**
  * One unfiled email as a card in the Filing tab. Draggable onto a
  * ProjectRail entry (sets the `text/x-ws-email-id` payload DnD reads);
  * also files via the inline "Sort"/"File it"/reassign-select controls,
- * same as before the card restyle. Whichever path lands the decision,
- * the card settles (fade/collapse) and a toast confirms it.
+ * same as before the card restyle. Only the drag-drop path (`viaDrop`)
+ * triggers the settle (fade/collapse) + confirmation toast.
  */
-export function FilingCard({ filing, projects, busy, onClassify, onAssign }: FilingCardProps) {
+export function FilingCard({ filing, projects, busy, onClassify, onAssign, viaDrop }: FilingCardProps) {
   const subject = filing.emailMeta?.subject ?? filing.name;
   const decided = filing.status === 'confirmed' || filing.status === 'reassigned';
   const decidedLabel = filing.decidedProjectKey
@@ -29,12 +36,12 @@ export function FilingCard({ filing, projects, busy, onClassify, onAssign }: Fil
   const [settling, setSettling] = useState(false);
 
   useEffect(() => {
-    if (decided && !wasDecided.current) {
+    if (decided && !wasDecided.current && viaDrop) {
       setSettling(true);
       toast(`Filed to ${decidedLabel ?? 'project'}`);
     }
     wasDecided.current = decided;
-  }, [decided, decidedLabel]);
+  }, [decided, decidedLabel, viaDrop]);
 
   return (
     <div

--- a/apps/helper/src/components/workspace/FilingCard.tsx
+++ b/apps/helper/src/components/workspace/FilingCard.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from 'react';
+import type { FilingRecord, WorkspaceProject } from '../../stores/workspaceStore';
+import { toast } from '../ui/Toaster';
+import { formatWhen } from './WorkspacePanel';
+
+export interface FilingCardProps {
+  filing: FilingRecord;
+  projects: WorkspaceProject[];
+  busy: boolean;
+  onClassify: (fileIndexId: string) => void;
+  onAssign: (fileIndexId: string, projectKey: string) => void;
+}
+
+/**
+ * One unfiled email as a card in the Filing tab. Draggable onto a
+ * ProjectRail entry (sets the `text/x-ws-email-id` payload DnD reads);
+ * also files via the inline "Sort"/"File it"/reassign-select controls,
+ * same as before the card restyle. Whichever path lands the decision,
+ * the card settles (fade/collapse) and a toast confirms it.
+ */
+export function FilingCard({ filing, projects, busy, onClassify, onAssign }: FilingCardProps) {
+  const subject = filing.emailMeta?.subject ?? filing.name;
+  const decided = filing.status === 'confirmed' || filing.status === 'reassigned';
+  const decidedLabel = filing.decidedProjectKey
+    ? projects.find((p) => p.key === filing.decidedProjectKey)?.label ?? filing.decidedProjectKey
+    : null;
+
+  const wasDecided = useRef(decided);
+  const [settling, setSettling] = useState(false);
+
+  useEffect(() => {
+    if (decided && !wasDecided.current) {
+      setSettling(true);
+      toast(`Filed to ${decidedLabel ?? 'project'}`);
+    }
+    wasDecided.current = decided;
+  }, [decided, decidedLabel]);
+
+  return (
+    <div
+      className={`ws-filing-card${settling ? ' ws-filing-card-settling' : ''}`}
+      draggable
+      onDragStart={(e) => e.dataTransfer.setData('text/x-ws-email-id', filing.fileIndexId)}
+    >
+      <span className="ws-filing-card-subject">{subject}</span>
+      <span className="ws-filing-card-meta">
+        {[filing.emailMeta?.from, formatWhen(filing.emailMeta?.date)].filter(Boolean).join(' · ')}
+      </span>
+
+      {decided && (
+        <span className="ws-chip ws-chip-success">Filed to: {decidedLabel}</span>
+      )}
+      {!decided && filing.status === 'suggested' && filing.confidence === 'high' && (
+        <span className="ws-chip ws-chip-success">
+          Filed to: {filing.suggestedProjectLabel} — {filing.rationale}
+        </span>
+      )}
+      {!decided && filing.status === 'suggested' && filing.confidence !== 'high' && (
+        <>
+          <span className="ws-chip ws-chip-warning">
+            {filing.suggestedProjectLabel
+              ? `Possibly ${filing.suggestedProjectLabel} — ${filing.rationale}`
+              : 'No clear match — pick a project below.'}
+          </span>
+          <select
+            className="ws-filing-card-select"
+            value=""
+            onChange={(e) => {
+              const key = e.target.value;
+              if (key) onAssign(filing.fileIndexId, key);
+            }}
+            title="File to a different project"
+          >
+            <option value="">Move to…</option>
+            {projects.map((p) => (
+              <option key={p.key} value={p.key}>
+                {p.key} {p.label}
+              </option>
+            ))}
+          </select>
+        </>
+      )}
+
+      <div className="ws-filing-card-actions">
+        {busy && <span className="helper-spinner" />}
+        {!busy && filing.status === null && (
+          <button
+            className="helper-btn helper-btn-sm"
+            onClick={() => onClassify(filing.fileIndexId)}
+            title="Suggest where this email belongs"
+          >
+            Sort
+          </button>
+        )}
+        {!busy && filing.status === 'suggested' && filing.suggestedProjectKey && (
+          <button
+            className="ws-btn-accent"
+            onClick={() => onAssign(filing.fileIndexId, filing.suggestedProjectKey!)}
+            title="File to the suggested project"
+          >
+            File it
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/helper/src/components/workspace/FilterChips.test.tsx
+++ b/apps/helper/src/components/workspace/FilterChips.test.tsx
@@ -15,6 +15,32 @@ function renderChips(filters: WorkspaceFilters = {}) {
   );
 }
 
+it('renders only the requested chips (Browse tab: Project/Doc type only, no Date/Source/Kind)', () => {
+  render(
+    <FilterChips
+      rows={[]}
+      sources={[{ id: 's1', displayName: 'Firm Share', kind: 'smb_share' }]}
+      filters={{}}
+      onSetFilter={vi.fn()}
+      onClearFilter={vi.fn()}
+      chips={['project', 'docType']}
+    />,
+  );
+  expect(screen.getByRole('button', { name: 'Project' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Doc type' })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Date' })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Source' })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Kind' })).not.toBeInTheDocument();
+});
+
+it('defaults to all five chips when `chips` is omitted (Search tab)', () => {
+  renderChips();
+  expect(screen.getByRole('button', { name: 'Project' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Doc type' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Date' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Kind' })).toBeInTheDocument();
+});
+
 it('does not swallow Tab inside the Date chip custom From/To inputs (regression: Radix Menu.Content preventDefaults Tab)', async () => {
   renderChips();
 

--- a/apps/helper/src/components/workspace/FilterChips.test.tsx
+++ b/apps/helper/src/components/workspace/FilterChips.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FilterChips } from './FilterChips';
+import type { WorkspaceFilters } from '../../stores/workspaceStore';
+
+function renderChips(filters: WorkspaceFilters = {}) {
+  return render(
+    <FilterChips
+      rows={[]}
+      sources={[]}
+      filters={filters}
+      onSetFilter={vi.fn()}
+      onClearFilter={vi.fn()}
+    />,
+  );
+}
+
+it('does not swallow Tab inside the Date chip custom From/To inputs (regression: Radix Menu.Content preventDefaults Tab)', async () => {
+  renderChips();
+
+  // Radix DropdownMenuTrigger opens on pointerdown, not click.
+  fireEvent.pointerDown(screen.getByRole('button', { name: 'Date' }), { button: 0 });
+
+  const fromInput = await screen.findByLabelText('From');
+  const toInput = screen.getByLabelText('To');
+
+  fromInput.focus();
+  expect(document.activeElement).toBe(fromInput);
+
+  // Fire the same Tab keydown a real browser would send while focus is on
+  // the From input, inside DropdownMenu.Content. Radix's Menu.Content
+  // handler calls event.preventDefault() on Tab for any keydown target
+  // nested under [data-radix-menu-content] with no focus-boundary check —
+  // our capture-phase stopPropagation on the custom wrapper must stop that
+  // handler from ever seeing the event.
+  const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+  const notPrevented = fromInput.dispatchEvent(event);
+
+  expect(notPrevented).toBe(true); // true means preventDefault() was NOT called
+  expect(toInput).toBeInTheDocument();
+});

--- a/apps/helper/src/components/workspace/FilterChips.tsx
+++ b/apps/helper/src/components/workspace/FilterChips.tsx
@@ -1,7 +1,9 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import type { FinderFile, WorkspaceFilters, WorkspaceSource } from '../../stores/workspaceStore';
 
-type ChipKey = 'project' | 'docType' | 'date' | 'sourceId' | 'kind';
+export type ChipKey = 'project' | 'docType' | 'date' | 'sourceId' | 'kind';
+
+const ALL_CHIPS: ChipKey[] = ['project', 'docType', 'date', 'sourceId', 'kind'];
 
 const CHIP_LABELS: Record<ChipKey, string> = {
   project: 'Project',
@@ -46,10 +48,20 @@ export interface FilterChipsProps {
   filters: WorkspaceFilters;
   onSetFilter: <K extends keyof WorkspaceFilters>(key: K, value: WorkspaceFilters[K]) => void;
   onClearFilter: (key: keyof WorkspaceFilters) => void;
+  /**
+   * Which chips to render, in order. Defaults to all five (Search toolbar).
+   * Browse passes just `['project', 'docType']` — the only two params the
+   * browse endpoint accepts (see the Architecture note authorizing them
+   * there); Date/Source/Kind stay Search-only.
+   */
+  chips?: ChipKey[];
 }
 
-/** Chip row for the Search toolbar: Project, Doc type, Date, Source, Kind — each a Radix DropdownMenu. */
-export function FilterChips({ rows, sources, filters, onSetFilter, onClearFilter }: FilterChipsProps) {
+/** Chip row: Project, Doc type, Date, Source, Kind — each a Radix DropdownMenu; `chips` narrows which render. */
+export function FilterChips({
+  rows, sources, filters, onSetFilter, onClearFilter, chips = ALL_CHIPS,
+}: FilterChipsProps) {
+  const enabled = new Set(chips);
   function chip(
     key: ChipKey,
     activeLabel: string | null,
@@ -115,19 +127,19 @@ export function FilterChips({ rows, sources, filters, onSetFilter, onClearFilter
 
   return (
     <div className="ws-filter-chip-row">
-      {chip(
+      {enabled.has('project') && chip(
         'project',
         filters.project ?? null,
         () => onClearFilter('project'),
         optionList(projectValues, (v) => onSetFilter('project', v)),
       )}
-      {chip(
+      {enabled.has('docType') && chip(
         'docType',
         filters.docType ?? null,
         () => onClearFilter('docType'),
         optionList(docTypeValues, (v) => onSetFilter('docType', v)),
       )}
-      {chip(
+      {enabled.has('date') && chip(
         'date',
         dateChipLabel(filters),
         () => {
@@ -179,7 +191,7 @@ export function FilterChips({ rows, sources, filters, onSetFilter, onClearFilter
           </div>
         </div>,
       )}
-      {sources.length > 1 && chip(
+      {enabled.has('sourceId') && sources.length > 1 && chip(
         'sourceId',
         sources.find((s) => s.id === filters.sourceId)?.displayName ?? null,
         () => onClearFilter('sourceId'),
@@ -193,7 +205,7 @@ export function FilterChips({ rows, sources, filters, onSetFilter, onClearFilter
           </DropdownMenu.Item>
         )),
       )}
-      {chip(
+      {enabled.has('kind') && chip(
         'kind',
         filters.kind ?? null,
         () => onClearFilter('kind'),

--- a/apps/helper/src/components/workspace/FilterChips.tsx
+++ b/apps/helper/src/components/workspace/FilterChips.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useRef, useState } from 'react';
+import type { FinderFile, WorkspaceFilters, WorkspaceSource } from '../../stores/workspaceStore';
+
+type ChipKey = 'project' | 'docType' | 'date' | 'sourceId' | 'kind';
+
+const CHIP_LABELS: Record<ChipKey, string> = {
+  project: 'Project',
+  docType: 'Doc type',
+  date: 'Date',
+  sourceId: 'Source',
+  kind: 'Kind',
+};
+
+const DATE_PRESETS: Array<{ label: string; days: number }> = [
+  { label: 'Last 7 days', days: 7 },
+  { label: 'Last 30 days', days: 30 },
+];
+
+function isoDateDaysAgo(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Distinct, sorted, non-empty values of a field across the currently loaded rows. */
+function distinctValues(rows: FinderFile[], pick: (f: FinderFile) => string | null | undefined): string[] {
+  const values = new Set<string>();
+  for (const row of rows) {
+    const value = pick(row);
+    if (value) values.add(value);
+  }
+  return [...values].sort((a, b) => a.localeCompare(b));
+}
+
+function dateChipLabel(filters: WorkspaceFilters): string | null {
+  if (filters.dateFrom && filters.dateTo) return `${filters.dateFrom} – ${filters.dateTo}`;
+  if (filters.dateFrom) return `Since ${filters.dateFrom}`;
+  if (filters.dateTo) return `Until ${filters.dateTo}`;
+  return null;
+}
+
+export interface FilterChipsProps {
+  /** Currently loaded rows — the source for the Project/Doc type/Kind option lists. */
+  rows: FinderFile[];
+  sources: WorkspaceSource[];
+  filters: WorkspaceFilters;
+  onSetFilter: <K extends keyof WorkspaceFilters>(key: K, value: WorkspaceFilters[K]) => void;
+  onClearFilter: (key: keyof WorkspaceFilters) => void;
+}
+
+/**
+ * Chip row for the Search toolbar: Project, Doc type, Date, Source, Kind.
+ * Each chip opens a plain positioned listbox — a placeholder for the Radix
+ * DropdownMenu Task 7 swaps in once that dependency lands.
+ */
+export function FilterChips({ rows, sources, filters, onSetFilter, onClearFilter }: FilterChipsProps) {
+  const [open, setOpen] = useState<ChipKey | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) setOpen(null);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(null);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const select = (key: keyof WorkspaceFilters, value: string) => {
+    onSetFilter(key, value);
+    setOpen(null);
+  };
+
+  const projectValues = distinctValues(rows, (f) => f.inferredProjectLabel);
+  const docTypeValues = distinctValues(rows, (f) => f.inferredDocType);
+  const kindValues = distinctValues(rows, (f) => f.ext);
+
+  function chip(
+    key: ChipKey,
+    activeLabel: string | null,
+    onClear: () => void,
+    menu: React.ReactNode,
+  ) {
+    const active = activeLabel !== null;
+    return (
+      <div className="ws-filter-chip-wrap" key={key}>
+        <button
+          type="button"
+          className={`ws-filter-chip${active ? ' ws-filter-chip-active' : ''}`}
+          onClick={() => setOpen(open === key ? null : key)}
+          aria-expanded={open === key}
+        >
+          <span>{active ? `${CHIP_LABELS[key]}: ${activeLabel}` : CHIP_LABELS[key]}</span>
+          {active && (
+            <span
+              className="ws-filter-chip-close"
+              role="button"
+              tabIndex={0}
+              aria-label={`Clear ${CHIP_LABELS[key]} filter`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onClear();
+                setOpen(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onClear();
+                  setOpen(null);
+                }
+              }}
+            >
+              ✕
+            </span>
+          )}
+        </button>
+        {open === key && <div className="ws-filter-chip-menu">{menu}</div>}
+      </div>
+    );
+  }
+
+  function optionList(values: string[], onPick: (v: string) => void) {
+    if (values.length === 0) {
+      return <div className="ws-filter-chip-menu-empty">No values in the current results</div>;
+    }
+    return values.map((v) => (
+      <button key={v} type="button" className="ws-filter-chip-menu-item" onClick={() => onPick(v)}>
+        {v}
+      </button>
+    ));
+  }
+
+  return (
+    <div className="ws-filter-chip-row" ref={containerRef}>
+      {chip(
+        'project',
+        filters.project ?? null,
+        () => onClearFilter('project'),
+        optionList(projectValues, (v) => select('project', v)),
+      )}
+      {chip(
+        'docType',
+        filters.docType ?? null,
+        () => onClearFilter('docType'),
+        optionList(docTypeValues, (v) => select('docType', v)),
+      )}
+      {chip(
+        'date',
+        dateChipLabel(filters),
+        () => {
+          onClearFilter('dateFrom');
+          onClearFilter('dateTo');
+        },
+        <div className="ws-filter-chip-menu-date">
+          {DATE_PRESETS.map((preset) => (
+            <button
+              key={preset.label}
+              type="button"
+              className="ws-filter-chip-menu-item"
+              onClick={() => {
+                onSetFilter('dateFrom', isoDateDaysAgo(preset.days));
+                onClearFilter('dateTo');
+                setOpen(null);
+              }}
+            >
+              {preset.label}
+            </button>
+          ))}
+          <div className="ws-filter-chip-menu-custom">
+            <label>
+              From
+              <input
+                type="date"
+                value={filters.dateFrom?.slice(0, 10) ?? ''}
+                onChange={(e) => onSetFilter('dateFrom', e.target.value)}
+              />
+            </label>
+            <label>
+              To
+              <input
+                type="date"
+                value={filters.dateTo?.slice(0, 10) ?? ''}
+                onChange={(e) => onSetFilter('dateTo', e.target.value)}
+              />
+            </label>
+          </div>
+        </div>,
+      )}
+      {sources.length > 1 && chip(
+        'sourceId',
+        sources.find((s) => s.id === filters.sourceId)?.displayName ?? null,
+        () => onClearFilter('sourceId'),
+        sources.map((s) => (
+          <button
+            key={s.id}
+            type="button"
+            className="ws-filter-chip-menu-item"
+            onClick={() => select('sourceId', s.id)}
+          >
+            {s.displayName}
+          </button>
+        )),
+      )}
+      {chip(
+        'kind',
+        filters.kind ?? null,
+        () => onClearFilter('kind'),
+        optionList(kindValues, (v) => select('kind', v)),
+      )}
+    </div>
+  );
+}

--- a/apps/helper/src/components/workspace/FilterChips.tsx
+++ b/apps/helper/src/components/workspace/FilterChips.tsx
@@ -147,7 +147,19 @@ export function FilterChips({ rows, sources, filters, onSetFilter, onClearFilter
               {preset.label}
             </DropdownMenu.Item>
           ))}
-          <div className="ws-filter-chip-menu-custom">
+          <div
+            className="ws-filter-chip-menu-custom"
+            onKeyDownCapture={(e) => {
+              // Radix Menu.Content's onKeyDown unconditionally preventDefaults Tab
+              // for any keydown originating inside [data-radix-menu-content] (no
+              // focus-trap boundary check, unlike react-focus-scope). That leaves
+              // Tab non-functional between these two plain <input>s, which aren't
+              // registered Menu.Items and so get no arrow-key roving focus either.
+              // Stop the event here, in capture phase, before it reaches Content's
+              // bubble-phase handler, so native Tab focus movement is preserved.
+              if (e.key === 'Tab') e.stopPropagation();
+            }}
+          >
             <label>
               From
               <input

--- a/apps/helper/src/components/workspace/FilterChips.tsx
+++ b/apps/helper/src/components/workspace/FilterChips.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import type { FinderFile, WorkspaceFilters, WorkspaceSource } from '../../stores/workspaceStore';
 
 type ChipKey = 'project' | 'docType' | 'date' | 'sourceId' | 'kind';
@@ -48,40 +48,8 @@ export interface FilterChipsProps {
   onClearFilter: (key: keyof WorkspaceFilters) => void;
 }
 
-/**
- * Chip row for the Search toolbar: Project, Doc type, Date, Source, Kind.
- * Each chip opens a plain positioned listbox — a placeholder for the Radix
- * DropdownMenu Task 7 swaps in once that dependency lands.
- */
+/** Chip row for the Search toolbar: Project, Doc type, Date, Source, Kind — each a Radix DropdownMenu. */
 export function FilterChips({ rows, sources, filters, onSetFilter, onClearFilter }: FilterChipsProps) {
-  const [open, setOpen] = useState<ChipKey | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) setOpen(null);
-    };
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(null);
-    };
-    document.addEventListener('mousedown', onPointerDown);
-    document.addEventListener('keydown', onKeyDown);
-    return () => {
-      document.removeEventListener('mousedown', onPointerDown);
-      document.removeEventListener('keydown', onKeyDown);
-    };
-  }, [open]);
-
-  const select = (key: keyof WorkspaceFilters, value: string) => {
-    onSetFilter(key, value);
-    setOpen(null);
-  };
-
-  const projectValues = distinctValues(rows, (f) => f.inferredProjectLabel);
-  const docTypeValues = distinctValues(rows, (f) => f.inferredDocType);
-  const kindValues = distinctValues(rows, (f) => f.ext);
-
   function chip(
     key: ChipKey,
     activeLabel: string | null,
@@ -90,40 +58,43 @@ export function FilterChips({ rows, sources, filters, onSetFilter, onClearFilter
   ) {
     const active = activeLabel !== null;
     return (
-      <div className="ws-filter-chip-wrap" key={key}>
-        <button
-          type="button"
-          className={`ws-filter-chip${active ? ' ws-filter-chip-active' : ''}`}
-          onClick={() => setOpen(open === key ? null : key)}
-          aria-expanded={open === key}
-        >
-          <span>{active ? `${CHIP_LABELS[key]}: ${activeLabel}` : CHIP_LABELS[key]}</span>
-          {active && (
-            <span
-              className="ws-filter-chip-close"
-              role="button"
-              tabIndex={0}
-              aria-label={`Clear ${CHIP_LABELS[key]} filter`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onClear();
-                setOpen(null);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
+      <DropdownMenu.Root key={key}>
+        <DropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            className={`ws-filter-chip${active ? ' ws-filter-chip-active' : ''}`}
+          >
+            <span>{active ? `${CHIP_LABELS[key]}: ${activeLabel}` : CHIP_LABELS[key]}</span>
+            {active && (
+              <span
+                className="ws-filter-chip-close"
+                role="button"
+                tabIndex={0}
+                aria-label={`Clear ${CHIP_LABELS[key]} filter`}
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
                   e.stopPropagation();
                   onClear();
-                  setOpen(null);
-                }
-              }}
-            >
-              ✕
-            </span>
-          )}
-        </button>
-        {open === key && <div className="ws-filter-chip-menu">{menu}</div>}
-      </div>
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onClear();
+                  }
+                }}
+              >
+                ✕
+              </span>
+            )}
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content className="ws-filter-chip-menu" align="start" sideOffset={4}>
+            {menu}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
     );
   }
 
@@ -132,25 +103,29 @@ export function FilterChips({ rows, sources, filters, onSetFilter, onClearFilter
       return <div className="ws-filter-chip-menu-empty">No values in the current results</div>;
     }
     return values.map((v) => (
-      <button key={v} type="button" className="ws-filter-chip-menu-item" onClick={() => onPick(v)}>
+      <DropdownMenu.Item key={v} className="ws-filter-chip-menu-item" onSelect={() => onPick(v)}>
         {v}
-      </button>
+      </DropdownMenu.Item>
     ));
   }
 
+  const projectValues = distinctValues(rows, (f) => f.inferredProjectLabel);
+  const docTypeValues = distinctValues(rows, (f) => f.inferredDocType);
+  const kindValues = distinctValues(rows, (f) => f.ext);
+
   return (
-    <div className="ws-filter-chip-row" ref={containerRef}>
+    <div className="ws-filter-chip-row">
       {chip(
         'project',
         filters.project ?? null,
         () => onClearFilter('project'),
-        optionList(projectValues, (v) => select('project', v)),
+        optionList(projectValues, (v) => onSetFilter('project', v)),
       )}
       {chip(
         'docType',
         filters.docType ?? null,
         () => onClearFilter('docType'),
-        optionList(docTypeValues, (v) => select('docType', v)),
+        optionList(docTypeValues, (v) => onSetFilter('docType', v)),
       )}
       {chip(
         'date',
@@ -161,18 +136,16 @@ export function FilterChips({ rows, sources, filters, onSetFilter, onClearFilter
         },
         <div className="ws-filter-chip-menu-date">
           {DATE_PRESETS.map((preset) => (
-            <button
+            <DropdownMenu.Item
               key={preset.label}
-              type="button"
               className="ws-filter-chip-menu-item"
-              onClick={() => {
+              onSelect={() => {
                 onSetFilter('dateFrom', isoDateDaysAgo(preset.days));
                 onClearFilter('dateTo');
-                setOpen(null);
               }}
             >
               {preset.label}
-            </button>
+            </DropdownMenu.Item>
           ))}
           <div className="ws-filter-chip-menu-custom">
             <label>
@@ -199,21 +172,20 @@ export function FilterChips({ rows, sources, filters, onSetFilter, onClearFilter
         sources.find((s) => s.id === filters.sourceId)?.displayName ?? null,
         () => onClearFilter('sourceId'),
         sources.map((s) => (
-          <button
+          <DropdownMenu.Item
             key={s.id}
-            type="button"
             className="ws-filter-chip-menu-item"
-            onClick={() => select('sourceId', s.id)}
+            onSelect={() => onSetFilter('sourceId', s.id)}
           >
             {s.displayName}
-          </button>
+          </DropdownMenu.Item>
         )),
       )}
       {chip(
         'kind',
         filters.kind ?? null,
         () => onClearFilter('kind'),
-        optionList(kindValues, (v) => select('kind', v)),
+        optionList(kindValues, (v) => onSetFilter('kind', v)),
       )}
     </div>
   );

--- a/apps/helper/src/components/workspace/ProjectRail.tsx
+++ b/apps/helper/src/components/workspace/ProjectRail.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import type { WorkspaceProject } from '../../stores/workspaceStore';
+
+export interface ProjectRailProps {
+  projects: WorkspaceProject[];
+  /** Called when a FilingCard's drag payload is dropped on a project entry. */
+  onDropEmail: (emailId: string, projectKey: string) => void;
+}
+
+/** Drop targets for drag-to-file: one entry per project from the crosswalk. */
+export function ProjectRail({ projects, onDropEmail }: ProjectRailProps) {
+  const [dragOverKey, setDragOverKey] = useState<string | null>(null);
+
+  return (
+    <div className="ws-project-rail">
+      {projects.map((p) => (
+        <div
+          key={p.key}
+          className={`ws-project-rail-item${dragOverKey === p.key ? ' ws-drop-target' : ''}`}
+          title={p.label}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragOverKey(p.key);
+          }}
+          onDragLeave={() => setDragOverKey((cur) => (cur === p.key ? null : cur))}
+          onDrop={(e) => {
+            e.preventDefault();
+            setDragOverKey(null);
+            const emailId = e.dataTransfer.getData('text/x-ws-email-id');
+            if (emailId) onDropEmail(emailId, p.key);
+          }}
+        >
+          {p.label}
+        </div>
+      ))}
+      {projects.length === 0 && (
+        <span className="ws-project-rail-empty">No projects yet</span>
+      )}
+    </div>
+  );
+}

--- a/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 vi.mock('../../lib/helperFetch', () => ({
   helperRequest: vi.fn(),
@@ -53,24 +53,27 @@ beforeEach(() => {
 });
 
 // Regression test for the tab-switch stale-error bug: Browse successfully
-// loads entries (browsePath set), then an unrelated Search failure sets the
-// single global `error` field. Switching back to Browse must not mask the
-// already-loaded entries behind a stale ErrorRow — Browse's own mount effect
-// no-ops on revisit (browsePath is already set), so nothing re-fetches to
-// clear `error` on its own; WorkspacePanel's tab switch must clear it.
+// loads entries (browsePath set), then — while WorkspacePanel is already
+// mounted — an unrelated Search failure sets the single global `error`
+// field. Switching back to Browse must not mask the already-loaded entries
+// behind a stale ErrorRow — Browse's own mount effect no-ops on revisit
+// (browsePath is already set), so nothing re-fetches to clear `error` on
+// its own; WorkspacePanel's tab switch must clear it.
 it('switching tabs clears a stale error from a different view instead of masking already-loaded content', () => {
   useWorkspaceStore.setState({
     browsePath: { sourceId: 's1', parentPath: '' },
     entries: [file({ id: 'f1', name: 'alder-easement.pdf' })],
-    // Simulates a Search failure that happened while the user was on the
-    // Search tab (error is global, not scoped to the tab that set it).
-    error: 'Search is unavailable right now.',
   });
 
   render(<WorkspacePanel onClose={() => {}} />);
 
-  // Starts on the Search tab (component default) — the stale error is
-  // legitimately visible there.
+  // Simulates a Search failure that happens while the user is already on
+  // the Search tab (error is global, not scoped to the tab that set it) —
+  // set it *after* mount so this exercises the tab-switch guard, not the
+  // separate mount-time clear covered below.
+  act(() => {
+    useWorkspaceStore.setState({ error: 'Search is unavailable right now.' });
+  });
   expect(screen.getByText('Search is unavailable right now.')).toBeInTheDocument();
 
   fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
@@ -78,4 +81,26 @@ it('switching tabs clears a stale error from a different view instead of masking
   // The previously-loaded Browse entries render; the stale error is gone.
   expect(screen.getByText('alder-easement.pdf')).toBeInTheDocument();
   expect(screen.queryByText('Search is unavailable right now.')).not.toBeInTheDocument();
+});
+
+// Regression test for the mount-time stale-error bug: `error` lives in the
+// module-level store, which survives WorkspacePanel unmounting (App.tsx
+// conditionally renders the panel — closing and reopening Files is a normal
+// user action, not a tab switch, so the tab-switch guard above never runs
+// for it). A leftover error from a session before the panel was last closed
+// must not resurface as a stale ErrorRow on the freshly-mounted panel's
+// default (Search) tab, masking the correct empty-query EmptyState.
+it('mounting a fresh panel clears a leftover error instead of masking the default tab\'s correct state', () => {
+  useWorkspaceStore.setState({
+    // Simulates a Browse failure that happened before the panel was closed
+    // (or before the user ever switched tabs), left over in the store.
+    error: 'Could not reach the index.',
+  });
+
+  render(<WorkspacePanel onClose={() => {}} />);
+
+  // Search tab (the default) shows its correct empty-query EmptyState, not
+  // the stale error.
+  expect(screen.queryByText('Could not reach the index.')).not.toBeInTheDocument();
+  expect(screen.getByText("Search your firm's files")).toBeInTheDocument();
 });

--- a/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
@@ -104,3 +104,37 @@ it('mounting a fresh panel clears a leftover error instead of masking the defaul
   expect(screen.queryByText('Could not reach the index.')).not.toBeInTheDocument();
   expect(screen.getByText("Search your firm's files")).toBeInTheDocument();
 });
+
+// Regression test for the debounced-search-not-cancelled bug: typing a query
+// on Search arms a 300ms debounce timer. Switching to another tab before it
+// fires must cancel that timer outright — otherwise it fires later, calls
+// the (now wrong-context) `search()`, and a subsequent failure would mask
+// the tab the user actually navigated to behind a stale ErrorRow. Neither
+// the tab-switch nor the mount-time error clear (above) touch this, since
+// both only clear `error` at the moment of switching/mounting, not a timer
+// that fires afterward.
+it('switching tabs before the search debounce fires cancels the pending search', () => {
+  vi.useFakeTimers();
+  try {
+    const searchSpy = vi.fn().mockResolvedValue(undefined);
+    useWorkspaceStore.setState({ search: searchSpy });
+
+    render(<WorkspacePanel onClose={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText('Search shared files...'), {
+      target: { value: 'alder' },
+    });
+
+    // Switch away before the 300ms debounce elapses.
+    fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // The cancelled timer must never call search() at all.
+    expect(searchSpy).not.toHaveBeenCalled();
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
@@ -229,3 +229,59 @@ it('returning to Search with an unchanged query does not re-issue the search', a
     vi.useRealTimers();
   }
 });
+
+// Regression test for the finding: the skip guard above checked only the
+// (query, filters) key, not whether `error` was currently set, and nothing
+// else clears `error` when the query changes within the same tab. So: search
+// "alder" (succeeds, key recorded), search "boblegal" (fails — ErrorRow
+// shows; failures don't update the key), then retype "alder" exactly — the
+// guard saw a key match and bailed with no fetch and no error clear, leaving
+// the stale ErrorRow masking alder's valid results indefinitely. Gate the
+// skip on `!error` too so a revisit while an error is showing still re-fetches.
+it('retyping a previously-successful query clears a stale error left by an intervening failed search', async () => {
+  vi.useFakeTimers();
+  try {
+    const searchSpy = vi.fn(async (q: string) => {
+      if (q === 'alder') {
+        useWorkspaceStore.setState({
+          results: [file({ id: 'f1', name: 'alder-easement.pdf' })],
+          error: null,
+          loading: false,
+        });
+      } else {
+        useWorkspaceStore.setState({
+          error: 'Search is unavailable right now.',
+          loading: false,
+        });
+      }
+    });
+    useWorkspaceStore.setState({ search: searchSpy });
+
+    render(<WorkspacePanel onClose={() => {}} />);
+    const input = screen.getByPlaceholderText('Search shared files...');
+
+    fireEvent.change(input, { target: { value: 'alder' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(screen.getByText('alder-easement.pdf')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: 'boblegal' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(screen.getByText('Search is unavailable right now.')).toBeInTheDocument();
+
+    // Retype "alder" exactly — same query/filters key as the earlier success.
+    fireEvent.change(input, { target: { value: 'alder' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    // The stale ErrorRow must be gone and alder's results must render again.
+    expect(screen.queryByText('Search is unavailable right now.')).not.toBeInTheDocument();
+    expect(screen.getByText('alder-easement.pdf')).toBeInTheDocument();
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
@@ -83,6 +83,40 @@ it('switching tabs clears a stale error from a different view instead of masking
   expect(screen.queryByText('Search is unavailable right now.')).not.toBeInTheDocument();
 });
 
+// Finding 4b: an empty Browse folder must distinguish "genuinely empty" from
+// "filtered to nothing". With an active project/docType chip the copy has to
+// point at the filter, not imply the folder itself is empty.
+it('Browse empty state reflects an active filter: "No matches in this folder" + clear-filters hint', async () => {
+  useWorkspaceStore.setState({
+    browse: vi.fn().mockResolvedValue(undefined),
+    browsePath: { sourceId: 's1', parentPath: 'clients' },
+    entries: [],
+    filters: { docType: 'Contract' },
+  });
+
+  render(<WorkspacePanel onClose={() => {}} />);
+  fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
+
+  expect(await screen.findByText('No matches in this folder')).toBeInTheDocument();
+  expect(screen.getByText('Clear filters to see everything.')).toBeInTheDocument();
+  expect(screen.queryByText('This folder is empty')).not.toBeInTheDocument();
+});
+
+it('Browse empty state with no active filter still reads "This folder is empty"', async () => {
+  useWorkspaceStore.setState({
+    browse: vi.fn().mockResolvedValue(undefined),
+    browsePath: { sourceId: 's1', parentPath: 'clients' },
+    entries: [],
+    filters: {},
+  });
+
+  render(<WorkspacePanel onClose={() => {}} />);
+  fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
+
+  expect(await screen.findByText('This folder is empty')).toBeInTheDocument();
+  expect(screen.queryByText('No matches in this folder')).not.toBeInTheDocument();
+});
+
 // Regression test for the mount-time stale-error bug: `error` lives in the
 // module-level store, which survives WorkspacePanel unmounting (App.tsx
 // conditionally renders the panel — closing and reopening Files is a normal

--- a/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
@@ -173,8 +173,12 @@ it('Browse tab shows only Project/Doc type chips, and selecting one re-issues th
   expect(within(chipRow).queryByRole('button', { name: 'Kind' })).not.toBeInTheDocument();
 
   // The mount-time "open first source" effect must not have fired — browsePath
-  // was already set, so this isolates the assertion below to the chip pick.
-  expect(browseSpy).not.toHaveBeenCalled();
+  // was already set, so it no-ops. The chip/tab effect DOES fire once here
+  // though: lastBrowseKeyRef seeds to null (not from browsePath + current
+  // filters — see Finding 2 in WorkspacePanel.tsx), so the first Browse entry
+  // after mount always re-fetches once, regardless of a preset browsePath.
+  await waitFor(() => expect(browseSpy).toHaveBeenCalledTimes(1));
+  expect(browseSpy).toHaveBeenNthCalledWith(1, 's1', '');
 
   fireEvent.pointerDown(within(chipRow).getByRole('button', { name: 'Project' }), { button: 0 });
   // Menu item, not FileTable's own "Henderson Water Main Replacement" cell.
@@ -182,7 +186,8 @@ it('Browse tab shows only Project/Doc type chips, and selecting one re-issues th
   fireEvent.click(option);
 
   expect(useWorkspaceStore.getState().filters.project).toBe('Henderson Water Main Replacement');
-  await waitFor(() => expect(browseSpy).toHaveBeenCalledWith('s1', ''));
+  await waitFor(() => expect(browseSpy).toHaveBeenCalledTimes(2));
+  expect(browseSpy).toHaveBeenNthCalledWith(2, 's1', '');
 });
 
 // Regression test for the debounce-effect's `tab` dependency re-arming a
@@ -377,19 +382,110 @@ it('re-fetches Browse on return when a shared filter changed while off the tab',
 
   render(<WorkspacePanel onClose={() => {}} />);
 
-  // Enter Browse: the folder is already loaded (browsePath preset), so the
-  // seeded key means no redundant re-fetch on entry.
+  // Enter Browse: lastBrowseKeyRef seeds to null (Finding 2 — it no longer
+  // trusts browsePath + current filters at seed time), so this first entry
+  // after mount re-fetches once even though a folder was already loaded.
   fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
-  expect(browseSpy).not.toHaveBeenCalled();
+  await waitFor(() => expect(browseSpy).toHaveBeenCalledTimes(1));
+  expect(browseSpy).toHaveBeenNthCalledWith(1, 's1', 'docs');
 
   // Leave Browse, then change the shared filters.project slice from another tab.
   fireEvent.click(screen.getByRole('tab', { name: 'Search' }));
   act(() => {
     useWorkspaceStore.getState().setFilter('project', 'Henderson Water Main Replacement');
   });
-  expect(browseSpy).not.toHaveBeenCalled(); // still off Browse → no fetch yet
+  expect(browseSpy).toHaveBeenCalledTimes(1); // still off Browse → no new fetch yet
 
   // Return to Browse: the filter changed, so the current folder must re-fetch.
   fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
+  await waitFor(() => expect(browseSpy).toHaveBeenCalledTimes(2));
+  expect(browseSpy).toHaveBeenNthCalledWith(2, 's1', 'docs');
+});
+
+// Regression test for Finding 1 (verification review, asymmetric browse
+// guard): the browse skip guard checked only the (sourceId, parentPath,
+// project, docType) key, not whether `error` was currently set — unlike the
+// search debounce effect's guard, which is error-aware. Repro: browse
+// (s1, docs) unfiltered succeeds (key recorded) -> a project chip set while
+// on Browse re-issues the fetch and it FAILS (error set; the key is only
+// recorded on success, so lastBrowseKeyRef is unchanged) -> clearing the
+// chip mutates only `filters`, never `error` -> the effect re-runs with a
+// key that once again matches the earlier unfiltered success, and a
+// key-only guard skips, leaving a stale ErrorRow masking the folder's
+// still-valid entries indefinitely.
+it('clearing a filter after a failed browse re-fetches instead of leaving a stale ErrorRow', async () => {
+  const browseSpy = vi.fn(async () => {
+    const { project } = useWorkspaceStore.getState().filters;
+    if (project) {
+      useWorkspaceStore.setState({ error: 'Could not reach the index.', loading: false });
+    } else {
+      // Deliberately does NOT touch `browsePath` — it's already correct
+      // ({ sourceId: 's1', parentPath: 'docs' }) from the initial setState
+      // below, and reassigning it to a fresh object on every success would
+      // change its identity, which is itself a dependency of the effect
+      // under test — an unrelated re-render/re-run loop that has nothing to
+      // do with the guard behavior this test is verifying.
+      useWorkspaceStore.setState({
+        entries: [file({ id: 'f1', name: 'alder-easement.pdf' })],
+        error: null,
+        loading: false,
+      });
+    }
+  });
+  useWorkspaceStore.setState({
+    browse: browseSpy,
+    browsePath: { sourceId: 's1', parentPath: 'docs' },
+  });
+
+  render(<WorkspacePanel onClose={() => {}} />);
+  fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
+
+  // First entry after mount: lastBrowseKeyRef seeds to null (Finding 2), so
+  // this fetch runs, succeeds unfiltered, and records the success key.
+  await waitFor(() => expect(browseSpy).toHaveBeenCalledTimes(1));
+  expect(screen.getByText('alder-easement.pdf')).toBeInTheDocument();
+
+  // Set a project filter — the chip/tab effect re-fetches and it fails.
+  act(() => {
+    useWorkspaceStore.getState().setFilter('project', 'Henderson Water Main Replacement');
+  });
+  await waitFor(() => expect(browseSpy).toHaveBeenCalledTimes(2));
+  expect(screen.getByText('Could not reach the index.')).toBeInTheDocument();
+
+  // Clear the filter: the recomputed key matches the earlier unfiltered
+  // success, but `error` is still set, so the guard must still re-fetch
+  // instead of skipping and leaving the ErrorRow stuck over valid entries.
+  act(() => {
+    useWorkspaceStore.getState().clearFilter('project');
+  });
+  await waitFor(() => expect(browseSpy).toHaveBeenCalledTimes(3));
+  expect(screen.queryByText('Could not reach the index.')).not.toBeInTheDocument();
+  expect(screen.getByText('alder-easement.pdf')).toBeInTheDocument();
+});
+
+// Regression test for Finding 2 (verification review, over-trusting seed):
+// lastBrowseKeyRef used to be seeded on mount from persisted browsePath +
+// *current* filters, conflating "what was successfully fetched" with
+// "current filter state". Repro: browse unfiltered succeeds -> a project
+// chip gets set (e.g. from Search) -> the panel is closed and reopened
+// (WorkspacePanel unmounts/remounts; `browsePath`/`filters` survive in the
+// module-level store) -> entering Browse must re-fetch, since the old seed
+// would otherwise match the *current* (filtered) state at mount and skip,
+// rendering stale unfiltered entries under an active filter chip.
+it('remounting the panel with a filter set after the last fetch re-fetches Browse on entry', async () => {
+  const browseSpy = vi.fn().mockResolvedValue(undefined);
+  useWorkspaceStore.setState({
+    browse: browseSpy,
+    browsePath: { sourceId: 's1', parentPath: 'docs' },
+    entries: [file({ id: 'f1', name: 'alder-easement.pdf' })],
+    filters: { project: 'Henderson Water Main Replacement' },
+  });
+
+  const { unmount } = render(<WorkspacePanel onClose={() => {}} />);
+  unmount();
+
+  render(<WorkspacePanel onClose={() => {}} />);
+  fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
+
   await waitFor(() => expect(browseSpy).toHaveBeenCalledWith('s1', 'docs'));
 });

--- a/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+
+vi.mock('../../lib/helperFetch', () => ({
+  helperRequest: vi.fn(),
+  getTauriInvoke: vi.fn(async () => null),
+  requireDevBearerToken: vi.fn(),
+}));
+
+import WorkspacePanel from './WorkspacePanel';
+import { useWorkspaceStore, type FinderFile } from '../../stores/workspaceStore';
+import { useChatStore } from '../../stores/chatStore';
+
+function file(overrides: Partial<FinderFile> = {}): FinderFile {
+  return {
+    id: 'f1',
+    sourceId: 's1',
+    deviceKey: '__shared__',
+    relPath: 'clients/alder/b.pdf',
+    parentPath: 'clients/alder',
+    name: 'b.pdf',
+    isDir: false,
+    ext: 'pdf',
+    size: 1024,
+    mtime: '2026-07-01T00:00:00.000Z',
+    openPath: '\\\\srv\\share\\clients\\alder\\b.pdf',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useChatStore.setState({ username: 'todd', agentConfig: null });
+  useWorkspaceStore.setState({
+    available: true,
+    features: [],
+    contentEnabled: false,
+    contentFeatures: [],
+    sources: [{ id: 's1', displayName: 'Firm Share', kind: 'smb' }],
+    results: [],
+    entries: [],
+    recent: [],
+    department: [],
+    filings: [],
+    projects: [],
+    loading: false,
+    error: null,
+    filingBusy: null,
+    browsePath: null,
+    filters: {},
+    sort: { search: null, browse: { col: 'name', dir: 'asc' }, recents: { col: 'mtime', dir: 'desc' } },
+  });
+});
+
+// Regression test for the tab-switch stale-error bug: Browse successfully
+// loads entries (browsePath set), then an unrelated Search failure sets the
+// single global `error` field. Switching back to Browse must not mask the
+// already-loaded entries behind a stale ErrorRow — Browse's own mount effect
+// no-ops on revisit (browsePath is already set), so nothing re-fetches to
+// clear `error` on its own; WorkspacePanel's tab switch must clear it.
+it('switching tabs clears a stale error from a different view instead of masking already-loaded content', () => {
+  useWorkspaceStore.setState({
+    browsePath: { sourceId: 's1', parentPath: '' },
+    entries: [file({ id: 'f1', name: 'alder-easement.pdf' })],
+    // Simulates a Search failure that happened while the user was on the
+    // Search tab (error is global, not scoped to the tab that set it).
+    error: 'Search is unavailable right now.',
+  });
+
+  render(<WorkspacePanel onClose={() => {}} />);
+
+  // Starts on the Search tab (component default) — the stale error is
+  // legitimately visible there.
+  expect(screen.getByText('Search is unavailable right now.')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
+
+  // The previously-loaded Browse entries render; the stale error is gone.
+  expect(screen.getByText('alder-easement.pdf')).toBeInTheDocument();
+  expect(screen.queryByText('Search is unavailable right now.')).not.toBeInTheDocument();
+});

--- a/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
@@ -285,3 +285,111 @@ it('retyping a previously-successful query clears a stale error left by an inter
     vi.useRealTimers();
   }
 });
+
+// Regression test for the Critical auto-retry loop: the store's search() writes
+// `error` twice per attempt (null → message). When `error` was a dependency of
+// the debounce effect, those writes re-ran the effect, re-armed the timer, and
+// refetched a persistently failing query forever. With `error` read via
+// getState() (not a dependency), a single failing query must issue exactly ONE
+// search and hold a stable ErrorRow no matter how far fake timers advance.
+it('a persistently failing query issues exactly one search and holds a stable ErrorRow (no auto-retry loop)', async () => {
+  vi.useFakeTimers();
+  try {
+    const searchSpy = vi.fn(async () => {
+      // Mirror the real store search()'s two error writes per attempt — the
+      // exact writes that used to re-arm the debounce timer.
+      useWorkspaceStore.setState({ loading: true, error: null });
+      useWorkspaceStore.setState({ loading: false, error: 'Search is unavailable right now.' });
+    });
+    useWorkspaceStore.setState({ search: searchSpy });
+
+    render(<WorkspacePanel onClose={() => {}} />);
+    fireEvent.change(screen.getByPlaceholderText('Search shared files...'), {
+      target: { value: 'boblegal' },
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Search is unavailable right now.')).toBeInTheDocument();
+
+    // Advance well past many debounce windows with NO further input.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    // Still exactly one call; the ErrorRow is stable (no flicker/retry loop).
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Search is unavailable right now.')).toBeInTheDocument();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+// Regression test for the empty-query stale-error mask: a failed search leaves
+// the single global `error` set; clearing the input to '' must clear that
+// error (via the effect's empty-query branch) so the "Search your firm's
+// files" EmptyState shows instead of the stale ErrorRow.
+it('clearing the query to empty while an ErrorRow shows restores the empty state', async () => {
+  vi.useFakeTimers();
+  try {
+    const searchSpy = vi.fn(async () => {
+      useWorkspaceStore.setState({ error: 'Search is unavailable right now.', loading: false });
+    });
+    useWorkspaceStore.setState({ search: searchSpy });
+
+    render(<WorkspacePanel onClose={() => {}} />);
+    const input = screen.getByPlaceholderText('Search shared files...');
+
+    fireEvent.change(input, { target: { value: 'boblegal' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(screen.getByText('Search is unavailable right now.')).toBeInTheDocument();
+
+    // Clear the input — the empty-query branch clears the store error.
+    fireEvent.change(input, { target: { value: '' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.queryByText('Search is unavailable right now.')).not.toBeInTheDocument();
+    expect(screen.getByText("Search your firm's files")).toBeInTheDocument();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+// Regression test for the Browse tab/filter desync: the chip effect omitted
+// `tab` from its deps, so a filters.project change made while on another tab
+// (Search's chip row writes the same shared slice) left Browse showing active
+// chips over a stale list when the user returned. With `tab` in the deps and a
+// lastBrowseKeyRef guard, returning to Browse after such a change must re-issue
+// the current folder's browse with the new filter.
+it('re-fetches Browse on return when a shared filter changed while off the tab', async () => {
+  const browseSpy = vi.fn().mockResolvedValue(undefined);
+  useWorkspaceStore.setState({
+    browse: browseSpy,
+    browsePath: { sourceId: 's1', parentPath: 'docs' },
+    entries: [file({ id: 'f1', name: 'alder-easement.pdf' })],
+  });
+
+  render(<WorkspacePanel onClose={() => {}} />);
+
+  // Enter Browse: the folder is already loaded (browsePath preset), so the
+  // seeded key means no redundant re-fetch on entry.
+  fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
+  expect(browseSpy).not.toHaveBeenCalled();
+
+  // Leave Browse, then change the shared filters.project slice from another tab.
+  fireEvent.click(screen.getByRole('tab', { name: 'Search' }));
+  act(() => {
+    useWorkspaceStore.getState().setFilter('project', 'Henderson Water Main Replacement');
+  });
+  expect(browseSpy).not.toHaveBeenCalled(); // still off Browse → no fetch yet
+
+  // Return to Browse: the filter changed, so the current folder must re-fetch.
+  fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
+  await waitFor(() => expect(browseSpy).toHaveBeenCalledWith('s1', 'docs'));
+});

--- a/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
@@ -138,3 +138,48 @@ it('switching tabs before the search debounce fires cancels the pending search',
     vi.useRealTimers();
   }
 });
+
+// Regression test for the debounce-effect's `tab` dependency re-arming a
+// redundant fetch: type a query on Search (debounce fires, search succeeds,
+// FileTable renders), navigate to Browse, then back to Search with the same
+// query/filters. Nothing changed, so no new fetch should be scheduled —
+// otherwise the already-correct results would flicker back to SkeletonRows
+// (or worse, a flaky refetch could mask them behind a stale ErrorRow) purely
+// from revisiting an already-loaded view.
+it('returning to Search with an unchanged query does not re-issue the search', async () => {
+  vi.useFakeTimers();
+  try {
+    const searchSpy = vi.fn().mockResolvedValue(undefined);
+    useWorkspaceStore.setState({
+      search: searchSpy,
+      browsePath: { sourceId: 's1', parentPath: '' },
+      entries: [file({ id: 'f1', name: 'alder-easement.pdf' })],
+    });
+
+    render(<WorkspacePanel onClose={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText('Search shared files...'), {
+      target: { value: 'alder' },
+    });
+
+    // Let the debounce fire and the search's success handler (which records
+    // the query/filters key) run.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+
+    // Navigate away, then back to Search — query/filters are unchanged.
+    fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Search' }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    // No redundant re-fetch of the already-loaded results.
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 vi.mock('../../lib/helperFetch', () => ({
   helperRequest: vi.fn(),
@@ -137,6 +137,52 @@ it('switching tabs before the search debounce fires cancels the pending search',
   } finally {
     vi.useRealTimers();
   }
+});
+
+// Browse-chips extension (controller adjudication): the plan's Architecture
+// line authorizes project/docType — the same two params Task 6 gave
+// /helper/search — on the browse endpoint too. Browse's chip row must show
+// only those two (Date/Source/Kind stay Search-only, since browse doesn't
+// accept the other params), and picking a value must re-issue the browse
+// fetch for the current folder with the new filter.
+it('Browse tab shows only Project/Doc type chips, and selecting one re-issues the browse fetch', async () => {
+  const browseSpy = vi.fn().mockResolvedValue(undefined);
+  useWorkspaceStore.setState({
+    browse: browseSpy,
+    browsePath: { sourceId: 's1', parentPath: '' },
+    entries: [
+      file({
+        id: 'f1',
+        name: 'alder-easement.pdf',
+        inferredProjectLabel: 'Henderson Water Main Replacement',
+        inferredDocType: 'easement',
+      }),
+    ],
+  });
+
+  render(<WorkspacePanel onClose={() => {}} />);
+  fireEvent.click(screen.getByRole('tab', { name: 'Browse' }));
+
+  // Only Project/Doc type render — no Date/Source/Kind chips on Browse.
+  // Scoped to the chip row itself: FileTable's sortable "Project" column
+  // header button would otherwise collide with the chip's own "Project" name.
+  const chipRow = document.querySelector('.ws-filter-chip-row') as HTMLElement;
+  expect(within(chipRow).getByRole('button', { name: 'Project' })).toBeInTheDocument();
+  expect(within(chipRow).getByRole('button', { name: 'Doc type' })).toBeInTheDocument();
+  expect(within(chipRow).queryByRole('button', { name: 'Date' })).not.toBeInTheDocument();
+  expect(within(chipRow).queryByRole('button', { name: 'Kind' })).not.toBeInTheDocument();
+
+  // The mount-time "open first source" effect must not have fired — browsePath
+  // was already set, so this isolates the assertion below to the chip pick.
+  expect(browseSpy).not.toHaveBeenCalled();
+
+  fireEvent.pointerDown(within(chipRow).getByRole('button', { name: 'Project' }), { button: 0 });
+  // Menu item, not FileTable's own "Henderson Water Main Replacement" cell.
+  const option = await screen.findByRole('menuitem', { name: 'Henderson Water Main Replacement' });
+  fireEvent.click(option);
+
+  expect(useWorkspaceStore.getState().filters.project).toBe('Henderson Water Main Replacement');
+  await waitFor(() => expect(browseSpy).toHaveBeenCalledWith('s1', ''));
 });
 
 // Regression test for the debounce-effect's `tab` dependency re-arming a

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -5,6 +5,7 @@ import {
 import { useChatStore } from '../../stores/chatStore';
 import { getTauriInvoke } from '../../lib/helperFetch';
 import { SegmentedControl } from '../ui/SegmentedControl';
+import { Toaster, toast } from '../ui/Toaster';
 import { FileTable } from './FileTable';
 import { FilterChips } from './FilterChips';
 
@@ -243,11 +244,11 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
     browse(sources[0].id, '');
   }, [tab, browsePath, sources, browse]);
 
-  // Not yet wired to a row action — Task 7 hangs this off the ⋯ context menu.
   const handleCopyPath = (file: FinderFile) => {
     const path = file.openPath ?? file.relPath;
     navigator.clipboard.writeText(path).catch(() => {});
     recordActivity(file.id, 'copy_path', username);
+    toast('Path copied');
   };
 
   const handleOpen = async (file: FinderFile) => {
@@ -289,6 +290,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
 
   return (
     <div className="helper-container">
+      <Toaster />
       <div
         className={`helper-header${isMacOS ? ' helper-header-macos' : ''}`}
         data-tauri-drag-region

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -6,6 +6,7 @@ import { useChatStore } from '../../stores/chatStore';
 import { getTauriInvoke } from '../../lib/helperFetch';
 import { SegmentedControl } from '../ui/SegmentedControl';
 import { FileTable } from './FileTable';
+import { FilterChips } from './FilterChips';
 
 const isMacOS =
   navigator.platform.startsWith('Mac') || navigator.userAgent.includes('Macintosh');
@@ -197,6 +198,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
     error,
     filingBusy,
     browsePath,
+    filters,
     search,
     browse,
     loadRecents,
@@ -204,23 +206,25 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
     loadFilings,
     classifyEmail,
     assignFiling,
+    setFilter,
+    clearFilter,
   } = useWorkspaceStore();
   const username = useChatStore((s) => s.username);
 
   const [tab, setTab] = useState<WorkspaceTab>('search');
   const [query, setQuery] = useState('');
-  const [sourceFilter, setSourceFilter] = useState('');
   const [openErrorId, setOpenErrorId] = useState<string | null>(null);
 
-  // Debounced search (300 ms).
+  // Debounced search (300 ms). Filter chips re-issue this fetch too — they
+  // only ever change the store's `filters`, which this effect already watches.
   useEffect(() => {
     const q = query.trim();
     if (!q) return;
     const timer = setTimeout(() => {
-      search(q, sourceFilter ? { sourceId: sourceFilter } : undefined);
+      search(q, filters);
     }, 300);
     return () => clearTimeout(timer);
-  }, [query, sourceFilter, search]);
+  }, [query, filters, search]);
 
   // Load recents when the tab is shown.
   useEffect(() => {
@@ -331,22 +335,14 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
               className="helper-workspace-search-input"
               autoFocus
             />
-            {sources.length > 1 && (
-              <select
-                value={sourceFilter}
-                onChange={(e) => setSourceFilter(e.target.value)}
-                className="helper-workspace-select"
-                title="Limit search to one source"
-              >
-                <option value="">All sources</option>
-                {sources.map((s) => (
-                  <option key={s.id} value={s.id}>
-                    {s.displayName}
-                  </option>
-                ))}
-              </select>
-            )}
           </div>
+          <FilterChips
+            rows={results}
+            sources={sources}
+            filters={filters}
+            onSetFilter={setFilter}
+            onClearFilter={clearFilter}
+          />
           <div className="helper-workspace-list">
             {loading && <LoadingRow />}
             {!loading && !query.trim() && (

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -361,6 +361,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                 onCopy={handleCopyPath}
                 onReveal={handleReveal}
                 renderMeta={(file) => renderFileMeta(file, openErrorId === file.id)}
+                sources={sources}
               />
             )}
           </div>
@@ -475,6 +476,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                     onCopy={handleCopyPath}
                     onReveal={handleReveal}
                     renderMeta={(file) => renderFileMeta(file, openErrorId === file.id)}
+                    sources={sources}
                   />
                 )}
                 <div className="helper-workspace-section-title">
@@ -493,6 +495,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                     onCopy={handleCopyPath}
                     onReveal={handleReveal}
                     renderMeta={(file) => renderFileMeta(file, openErrorId === file.id)}
+                    sources={sources}
                   />
                 )}
               </>

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -200,18 +200,27 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   // correct FileTable back to SkeletonRows (and, on a flaky refetch, behind
   // a stale ErrorRow) for no reason. Guard against that by skipping the
   // (re)arm when this exact query/filters combo already succeeded.
+  //
+  // That key-only guard has its own gap, though: it doesn't check whether
+  // `error` is currently set. Search "alder" (succeeds, key recorded),
+  // search "boblegal" (fails — failures don't update the key), then retype
+  // "alder" exactly — the key matches, so the guard would bail with no
+  // fetch and nothing else clears `error` mid-tab, leaving the stale
+  // ErrorRow masking alder's valid results indefinitely. So also require
+  // `!error` to skip; `error` is a real dependency (not read via
+  // getState()) so the effect re-evaluates the instant it's set.
   useEffect(() => {
     if (tab !== 'search') return;
     const q = query.trim();
     if (!q) return;
     const key = JSON.stringify([q, filters]);
-    if (key === lastSearchKeyRef.current) return;
+    if (key === lastSearchKeyRef.current && !error) return;
     const timer = setTimeout(() => {
       runSearch(q, filters);
     }, 300);
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tab, query, filters, search]);
+  }, [tab, query, filters, search, error]);
 
   // Load recents when the tab is shown.
   useEffect(() => {

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -133,6 +133,19 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const focusSearchPending = useRef(false);
 
+  // `error` is a single store field shared by all four views (Search,
+  // Browse, Recents, Filing), cleared only when the view whose fetch set it
+  // re-runs. A tab's own mount/debounce effect can no-op on revisit (Browse
+  // when `browsePath` is already set; Search when `query`/`filters` haven't
+  // changed), so without this, an error from one tab can persist and
+  // incorrectly gate a different (already-loaded) tab's content after
+  // switching. Route every tab change through here so the stale error never
+  // outlives the tab that produced it.
+  const switchTab = (next: WorkspaceTab) => {
+    if (next !== tab) useWorkspaceStore.setState({ error: null });
+    setTab(next);
+  };
+
   // Debounced search (300 ms). Filter chips re-issue this fetch too — they
   // only ever change the store's `filters`, which this effect already watches.
   useEffect(() => {
@@ -169,7 +182,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
       e.preventDefault();
       if (tab !== 'search') {
         focusSearchPending.current = true;
-        setTab('search');
+        switchTab('search');
       } else {
         searchInputRef.current?.focus();
       }
@@ -211,7 +224,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
 
   const handleReveal = (file: FinderFile) => {
     recordActivity(file.id, 'reveal', username);
-    setTab('browse');
+    switchTab('browse');
     browse(file.sourceId, file.parentPath);
   };
 
@@ -265,7 +278,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
             ...(filingEnabled ? [{ key: 'filing', label: 'Filing' }] : []),
           ]}
           value={tab}
-          onChange={(key) => setTab(key as WorkspaceTab)}
+          onChange={(key) => switchTab(key as WorkspaceTab)}
         />
       </div>
 

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -539,7 +539,14 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                 />
               )}
               {!loading && !error && browsePath && entries.length === 0 && (
-                <EmptyState title="This folder is empty" />
+                filters.project || filters.docType ? (
+                  <EmptyState
+                    title="No matches in this folder"
+                    hint="Clear filters to see everything."
+                  />
+                ) : (
+                  <EmptyState title="This folder is empty" />
+                )
               )}
               {!loading && !error && entries.length > 0 && (
                 <FileTable

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -121,6 +121,10 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   const [tab, setTab] = useState<WorkspaceTab>('search');
   const [query, setQuery] = useState('');
   const [openErrorId, setOpenErrorId] = useState<string | null>(null);
+  // Tracks which FilingCard (by id) was most recently dropped onto the
+  // ProjectRail, so only the onDrop path — not click-to-file or the inline
+  // reassign select — triggers the card's settle animation + toast.
+  const [pendingDropId, setPendingDropId] = useState<string | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const focusSearchPending = useRef(false);
 
@@ -392,6 +396,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                       busy={filingBusy === filing.fileIndexId}
                       onClassify={classifyEmail}
                       onAssign={(id, key) => assignFiling(id, key, username)}
+                      viaDrop={pendingDropId === filing.fileIndexId}
                     />
                   ))}
                 </>
@@ -399,7 +404,10 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
             </div>
             <ProjectRail
               projects={projects}
-              onDropEmail={(id, key) => fileByDrop(id, key, username)}
+              onDropEmail={(id, key) => {
+                setPendingDropId(id);
+                fileByDrop(id, key, username);
+              }}
             />
           </div>
         </div>

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import {
   useWorkspaceStore, type FinderFile, type FilingRecord,
 } from '../../stores/workspaceStore';
@@ -215,6 +215,8 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   const [tab, setTab] = useState<WorkspaceTab>('search');
   const [query, setQuery] = useState('');
   const [openErrorId, setOpenErrorId] = useState<string | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const focusSearchPending = useRef(false);
 
   // Debounced search (300 ms). Filter chips re-issue this fetch too — they
   // only ever change the store's `filters`, which this effect already watches.
@@ -243,6 +245,30 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
     if (tab !== 'browse' || browsePath || sources.length === 0) return;
     browse(sources[0].id, '');
   }, [tab, browsePath, sources, browse]);
+
+  // Cmd/Ctrl+F focuses the search input from anywhere in Files, switching to
+  // the Search tab first if another tab is active.
+  useEffect(() => {
+    const handleShortcut = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== 'f') return;
+      e.preventDefault();
+      if (tab !== 'search') {
+        focusSearchPending.current = true;
+        setTab('search');
+      } else {
+        searchInputRef.current?.focus();
+      }
+    };
+    window.addEventListener('keydown', handleShortcut);
+    return () => window.removeEventListener('keydown', handleShortcut);
+  }, [tab]);
+
+  useEffect(() => {
+    if (tab === 'search' && focusSearchPending.current) {
+      focusSearchPending.current = false;
+      searchInputRef.current?.focus();
+    }
+  }, [tab]);
 
   const handleCopyPath = (file: FinderFile) => {
     const path = file.openPath ?? file.relPath;
@@ -288,8 +314,16 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
     ? browsePath.parentPath.split('/').filter(Boolean)
     : [];
 
+  // Escape walk-back: an open Radix menu handles its own Escape first; a
+  // FileTable with an active row selection stops this event from bubbling
+  // here (it clears the selection instead) — only once neither has anything
+  // left to clear does Escape reach the panel and go Back.
+  const handlePanelKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') onClose();
+  };
+
   return (
-    <div className="helper-container">
+    <div className="helper-container" onKeyDown={handlePanelKeyDown}>
       <Toaster />
       <div
         className={`helper-header${isMacOS ? ' helper-header-macos' : ''}`}
@@ -330,6 +364,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
         <div className="helper-workspace-body">
           <div className="helper-workspace-toolbar">
             <input
+              ref={searchInputRef}
               type="text"
               value={query}
               onChange={(e) => setQuery(e.target.value)}

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -144,14 +144,19 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   // last browse that completed successfully. The Browse chip/tab effect below
   // re-runs on browsePath *and* tab changes now, so without this a rail
   // click (which already fetched) or a tab revisit with unchanged state would
-  // redundantly re-fetch. Seeded from the initial browsePath: if a folder is
-  // already loaded when the panel first renders (a preloaded view, or a
-  // remount while a browse was showing), entering Browse must not re-fetch it.
-  const lastBrowseKeyRef = useRef<string | null>(
-    browsePath
-      ? JSON.stringify([browsePath.sourceId, browsePath.parentPath, filters.project, filters.docType])
-      : null,
-  );
+  // redundantly re-fetch. Seeded to null, NOT from the initial browsePath +
+  // current filters: `filters` reflects whatever is active right now, not
+  // what was actually fetched to produce the currently-loaded `entries` —
+  // those can diverge (e.g. a project chip set from Search after the last
+  // Browse fetch, then the panel closed and reopened while `browsePath`
+  // survives in the module-level store). Trusting current filters at seed
+  // time would let a stale, wrongly-filtered (or wrongly-unfiltered) view
+  // through unrefreshed. Seeding null means the first Browse entry after a
+  // fresh mount always re-fetches once — a one-time, acceptable cost for
+  // guaranteed correctness — after which this ref is only ever written from
+  // an actual successful fetch's key (see `runBrowse`), so subsequent
+  // skip/refetch decisions are always trustworthy.
+  const lastBrowseKeyRef = useRef<string | null>(null);
 
   // `error` is a single store field shared by all four views (Search,
   // Browse, Recents, Filing), cleared only when the view whose fetch set it
@@ -284,12 +289,26 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   // (sourceId, parentPath, project, docType) actually changed — so a rail
   // click (which already fetched via runBrowse) or a tab revisit with
   // unchanged state doesn't double-fetch.
+  //
+  // Skip guard: mirrors the search debounce effect's guard exactly — skip
+  // ONLY when the key matches the last *successful* browse AND no error is
+  // currently set (read via getState(), not a dependency, for the same
+  // reason as the search effect: adding `error` as a dependency would let
+  // browse()'s own error writes re-run this effect and auto-retry forever).
+  // Without the `!error` half: browse (s1, docs) unfiltered succeeds (key
+  // recorded) -> a project chip set on Search -> returning to Browse re-runs
+  // this effect, the filtered key doesn't match, so it fetches and FAILS
+  // (error set; the key is only recorded on success, so lastBrowseKeyRef is
+  // unchanged) -> clearing the chip mutates only `filters`, never `error` ->
+  // the effect re-runs with a key that once again matches the earlier
+  // unfiltered success, and a key-only guard would skip, leaving a stale
+  // ErrorRow masking the folder's still-valid entries indefinitely.
   useEffect(() => {
     if (tab !== 'browse' || !browsePath) return;
     const key = JSON.stringify([
       browsePath.sourceId, browsePath.parentPath, filters.project, filters.docType,
     ]);
-    if (key === lastBrowseKeyRef.current) return;
+    if (key === lastBrowseKeyRef.current && !useWorkspaceStore.getState().error) return;
     runBrowse(browsePath.sourceId, browsePath.parentPath);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab, browsePath, filters.project, filters.docType]);

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useWorkspaceStore, type FinderFile } from '../../stores/workspaceStore';
 import { useChatStore } from '../../stores/chatStore';
+import { getTauriInvoke } from '../../lib/helperFetch';
 
 const isMacOS =
   navigator.platform.startsWith('Mac') || navigator.userAgent.includes('Macintosh');
@@ -27,6 +28,7 @@ function FileRow({
   sourceName,
   timestamp,
   copied,
+  openError,
   onCopyPath,
   onReveal,
   onOpen,
@@ -35,9 +37,11 @@ function FileRow({
   sourceName?: string;
   timestamp?: string | null;
   copied: boolean;
+  /** Set when opening this row's file failed; shows the copy-path fallback note. */
+  openError?: boolean;
   onCopyPath: (file: FinderFile) => void;
   onReveal?: (file: FinderFile) => void;
-  /** Open-in-place — wired up by the open_workspace_path Tauri command task. */
+  /** Open-in-place via the open_workspace_path Tauri command. */
   onOpen?: (file: FinderFile) => void;
 }) {
   const metaParts = [
@@ -51,6 +55,12 @@ function FileRow({
       <div className="helper-file-main">
         <span className="helper-file-name">{file.isDir ? `${file.name}/` : file.name}</span>
         <span className="helper-file-meta">{metaParts.join(' · ')}</span>
+        {openError && (
+          <span className="helper-file-open-error">
+            Couldn't open — the share may be unreachable from this machine. Path copied
+            instead.
+          </span>
+        )}
       </div>
       <div className="helper-file-actions">
         {copied && <span className="helper-file-copied">Copied</span>}
@@ -114,6 +124,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   const [query, setQuery] = useState('');
   const [sourceFilter, setSourceFilter] = useState('');
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [openErrorId, setOpenErrorId] = useState<string | null>(null);
 
   const sourceName = (id: string) => sources.find((s) => s.id === id)?.displayName;
 
@@ -148,6 +159,23 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
       })
       .catch(() => {});
     recordActivity(file.id, 'copy_path', username);
+  };
+
+  const handleOpen = async (file: FinderFile) => {
+    if (!file.openPath) return;
+    setOpenErrorId((cur) => (cur === file.id ? null : cur));
+    await recordActivity(file.id, 'open', username);
+    try {
+      const invoke = await getTauriInvoke();
+      if (!invoke) {
+        throw new Error('Opening files requires the desktop app');
+      }
+      await invoke('open_workspace_path', { input: { path: file.openPath } });
+    } catch {
+      // Fallback: put the path on the clipboard and say so on the row.
+      navigator.clipboard.writeText(file.openPath).catch(() => {});
+      setOpenErrorId(file.id);
+    }
   };
 
   const handleReveal = (file: FinderFile) => {
@@ -242,8 +270,10 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                   file={file}
                   sourceName={sourceName(file.sourceId)}
                   copied={copiedId === file.id}
+                  openError={openErrorId === file.id}
                   onCopyPath={handleCopyPath}
                   onReveal={handleReveal}
+                  onOpen={handleOpen}
                 />
               ))}
           </div>
@@ -316,7 +346,9 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                       key={entry.id}
                       file={entry}
                       copied={copiedId === entry.id}
+                      openError={openErrorId === entry.id}
                       onCopyPath={handleCopyPath}
+                      onOpen={handleOpen}
                     />
                   ),
                 )}
@@ -343,8 +375,10 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                     file={file}
                     sourceName={sourceName(file.sourceId)}
                     copied={copiedId === file.id}
+                    openError={openErrorId === file.id}
                     onCopyPath={handleCopyPath}
                     onReveal={handleReveal}
+                    onOpen={handleOpen}
                   />
                 ))}
                 <div className="helper-workspace-section-title">
@@ -360,8 +394,10 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                     sourceName={sourceName(file.sourceId)}
                     timestamp={file.lastActivityAt}
                     copied={copiedId === file.id}
+                    openError={openErrorId === file.id}
                     onCopyPath={handleCopyPath}
                     onReveal={handleReveal}
+                    onOpen={handleOpen}
                   />
                 ))}
               </>

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -162,14 +162,26 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
 
   // Debounced search (300 ms). Filter chips re-issue this fetch too — they
   // only ever change the store's `filters`, which this effect already watches.
+  //
+  // `tab` is a dependency (not just read once) so that navigating away from
+  // Search runs this effect's cleanup — cancelling any pending timer —
+  // before the effect body re-evaluates and bails out via the guard below.
+  // Without this, a timer armed while on Search could still fire after the
+  // user switched to another (already-loaded) tab: `search()` would resolve
+  // later and set the store's global `error`, masking that other tab's
+  // correct content with a stale, wrong-context ErrorRow — the exact async-
+  // completion race the tab-switch and mount-time error clears don't cover,
+  // since both only clear `error` at the moment of switching/mounting, not
+  // when a since-abandoned view's in-flight fetch settles afterward.
   useEffect(() => {
+    if (tab !== 'search') return;
     const q = query.trim();
     if (!q) return;
     const timer = setTimeout(() => {
       search(q, filters);
     }, 300);
     return () => clearTimeout(timer);
-  }, [query, filters, search]);
+  }, [tab, query, filters, search]);
 
   // Load recents when the tab is shown.
   useEffect(() => {

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -132,6 +132,14 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   const [pendingDropId, setPendingDropId] = useState<string | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const focusSearchPending = useRef(false);
+  // Key (query + filters) of the last search that completed *successfully*,
+  // so the debounce effect below can tell "revisiting an already-loaded
+  // Search view" apart from "query/filters actually changed" and skip
+  // re-arming the timer in the former case. Not updated on failure: a
+  // failed fetch left no valid content to protect, so a later revisit
+  // re-attempting the fetch is fine (and is the only way it'd ever recover
+  // without the user retyping).
+  const lastSearchKeyRef = useRef<string | null>(null);
 
   // `error` is a single store field shared by all four views (Search,
   // Browse, Recents, Filing), cleared only when the view whose fetch set it
@@ -160,6 +168,17 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Runs a Search fetch and records its (query, filters) key on success only,
+  // so the debounce effect and the error row's "retry" button share one
+  // notion of "this exact query/filters combo is already loaded" — see
+  // `lastSearchKeyRef` above.
+  const runSearch = (q: string, searchFilters: typeof filters) => {
+    const key = JSON.stringify([q, searchFilters]);
+    void search(q, searchFilters).then(() => {
+      if (!useWorkspaceStore.getState().error) lastSearchKeyRef.current = key;
+    });
+  };
+
   // Debounced search (300 ms). Filter chips re-issue this fetch too — they
   // only ever change the store's `filters`, which this effect already watches.
   //
@@ -173,14 +192,25 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   // completion race the tab-switch and mount-time error clears don't cover,
   // since both only clear `error` at the moment of switching/mounting, not
   // when a since-abandoned view's in-flight fetch settles afterward.
+  //
+  // But `tab` being a dependency also means this effect re-runs every time
+  // the user navigates *back into* Search, even when neither `query` nor
+  // `filters` changed — which would otherwise re-arm a fresh timer that
+  // redundantly refetches an already-loaded result set, flipping the
+  // correct FileTable back to SkeletonRows (and, on a flaky refetch, behind
+  // a stale ErrorRow) for no reason. Guard against that by skipping the
+  // (re)arm when this exact query/filters combo already succeeded.
   useEffect(() => {
     if (tab !== 'search') return;
     const q = query.trim();
     if (!q) return;
+    const key = JSON.stringify([q, filters]);
+    if (key === lastSearchKeyRef.current) return;
     const timer = setTimeout(() => {
-      search(q, filters);
+      runSearch(q, filters);
     }, 300);
     return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab, query, filters, search]);
 
   // Load recents when the tab is shown.
@@ -331,7 +361,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
           <div className="helper-workspace-list">
             {loading && <SkeletonRows />}
             {!loading && error && (
-              <ErrorRow message={error} onRetry={() => search(query.trim(), filters)} />
+              <ErrorRow message={error} onRetry={() => runSearch(query.trim(), filters)} />
             )}
             {!loading && !error && !query.trim() && (
               <EmptyState

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -230,6 +230,17 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
     browse(sources[0].id, '');
   }, [tab, browsePath, sources, browse]);
 
+  // Browse's own chip row (Project/Doc type only — see FilterChips' `chips`
+  // prop below) writes to the same `filters` slice Search's chips use.
+  // Selecting or clearing either one re-issues the current folder's browse
+  // fetch with the new filters. Chips only render while browsePath is set
+  // (folder already loaded), so this never fights the mount effect above.
+  useEffect(() => {
+    if (tab !== 'browse' || !browsePath) return;
+    browse(browsePath.sourceId, browsePath.parentPath);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters.project, filters.docType]);
+
   // Cmd/Ctrl+F focuses the search input from anywhere in Files, switching to
   // the Search tab first if another tab is active.
   useEffect(() => {
@@ -410,6 +421,16 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
             )}
           </div>
           <div className="helper-workspace-main">
+            {browsePath && (
+              <FilterChips
+                rows={entries}
+                sources={sources}
+                filters={filters}
+                onSetFilter={setFilter}
+                onClearFilter={clearFilter}
+                chips={['project', 'docType']}
+              />
+            )}
             {browsePath && (
               <div className="helper-workspace-breadcrumb">
                 <button

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
-import {
-  useWorkspaceStore, type FinderFile, type FilingRecord,
-} from '../../stores/workspaceStore';
+import { useWorkspaceStore, type FinderFile } from '../../stores/workspaceStore';
 import { useChatStore } from '../../stores/chatStore';
 import { getTauriInvoke } from '../../lib/helperFetch';
 import { SegmentedControl } from '../ui/SegmentedControl';
 import { Toaster, toast } from '../ui/Toaster';
 import { FileTable } from './FileTable';
 import { FilterChips } from './FilterChips';
+import { FilingCard } from './FilingCard';
+import { ProjectRail } from './ProjectRail';
 
 const isMacOS =
   navigator.platform.startsWith('Mac') || navigator.userAgent.includes('Macintosh');
@@ -28,7 +28,7 @@ function safeSnippetHtml(snippet: string): string {
     .replaceAll('&lt;/b&gt;', '</b>');
 }
 
-function formatWhen(dateStr: string | null | undefined): string | null {
+export function formatWhen(dateStr: string | null | undefined): string | null {
   if (!dateStr) return null;
   const d = new Date(dateStr);
   if (Number.isNaN(d.getTime())) return null;
@@ -89,101 +89,6 @@ function LoadingRow() {
   );
 }
 
-function FilingRow({
-  filing,
-  projects,
-  busy,
-  onClassify,
-  onAssign,
-}: {
-  filing: FilingRecord;
-  projects: Array<{ key: string; label: string }>;
-  busy: boolean;
-  onClassify: (fileIndexId: string) => void;
-  onAssign: (fileIndexId: string, projectKey: string) => void;
-}) {
-  const [choice, setChoice] = useState('');
-  const subject = filing.emailMeta?.subject ?? filing.name;
-  const decided = filing.status === 'confirmed' || filing.status === 'reassigned';
-  const decidedLabel = filing.decidedProjectKey
-    ? projects.find((p) => p.key === filing.decidedProjectKey)?.label ?? filing.decidedProjectKey
-    : null;
-
-  return (
-    <div className="helper-file-row helper-filing-row">
-      <div className="helper-file-main">
-        <span className="helper-file-name">{subject}</span>
-        <span className="helper-file-meta">
-          {[filing.emailMeta?.from, formatWhen(filing.emailMeta?.date)].filter(Boolean).join(' · ')}
-        </span>
-        {decided && (
-          <span className="helper-filing-banner helper-filing-decided">
-            Filed to: {decidedLabel}
-          </span>
-        )}
-        {!decided && filing.status === 'suggested' && filing.suggestedProjectLabel && (
-          <span
-            className={`helper-filing-banner${
-              filing.confidence === 'high' ? ' helper-filing-confident' : ' helper-filing-tentative'
-            }`}
-          >
-            {filing.confidence === 'high'
-              ? `Filed to: ${filing.suggestedProjectLabel} — ${filing.rationale}`
-              : `Possibly ${filing.suggestedProjectLabel} — ${filing.rationale}`}
-          </span>
-        )}
-        {!decided && filing.status === 'suggested' && !filing.suggestedProjectLabel && (
-          <span className="helper-filing-banner helper-filing-tentative">
-            No clear match — pick a project below.
-          </span>
-        )}
-      </div>
-      <div className="helper-file-actions helper-filing-actions">
-        {busy && <span className="helper-spinner" />}
-        {!busy && filing.status === null && (
-          <button
-            className="helper-btn helper-btn-sm"
-            onClick={() => onClassify(filing.fileIndexId)}
-            title="Suggest where this email belongs"
-          >
-            Sort
-          </button>
-        )}
-        {!busy && filing.status === 'suggested' && (
-          <>
-            {filing.suggestedProjectKey && (
-              <button
-                className="helper-btn helper-btn-sm"
-                onClick={() => onAssign(filing.fileIndexId, filing.suggestedProjectKey!)}
-                title="File to the suggested project"
-              >
-                File it
-              </button>
-            )}
-            <select
-              className="helper-workspace-select"
-              value={choice}
-              onChange={(e) => {
-                const key = e.target.value;
-                setChoice(key);
-                if (key) onAssign(filing.fileIndexId, key);
-              }}
-              title="File to a different project"
-            >
-              <option value="">Move to…</option>
-              {projects.map((p) => (
-                <option key={p.key} value={p.key}>
-                  {p.key} {p.label}
-                </option>
-              ))}
-            </select>
-          </>
-        )}
-      </div>
-    </div>
-  );
-}
-
 export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   const {
     sources,
@@ -207,6 +112,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
     loadFilings,
     classifyEmail,
     assignFiling,
+    fileByDrop,
     setFilter,
     clearFilter,
   } = useWorkspaceStore();
@@ -469,26 +375,32 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
 
       {tab === 'filing' && (
         <div className="helper-workspace-body">
-          <div className="helper-workspace-list">
-            {loading && <LoadingRow />}
-            {!loading && filings.length === 0 && (
-              <div className="helper-history-empty">No unfiled mail right now.</div>
-            )}
-            {!loading && filings.length > 0 && (
-              <>
-                <div className="helper-workspace-section-title">Unfiled mail</div>
-                {filings.map((filing) => (
-                  <FilingRow
-                    key={filing.fileIndexId}
-                    filing={filing}
-                    projects={projects}
-                    busy={filingBusy === filing.fileIndexId}
-                    onClassify={classifyEmail}
-                    onAssign={(id, key) => assignFiling(id, key, username)}
-                  />
-                ))}
-              </>
-            )}
+          <div className="ws-filing-layout">
+            <div className="ws-filing-cards">
+              {loading && <LoadingRow />}
+              {!loading && filings.length === 0 && (
+                <div className="helper-history-empty">No unfiled mail right now.</div>
+              )}
+              {!loading && filings.length > 0 && (
+                <>
+                  <div className="helper-workspace-section-title">Unfiled mail</div>
+                  {filings.map((filing) => (
+                    <FilingCard
+                      key={filing.fileIndexId}
+                      filing={filing}
+                      projects={projects}
+                      busy={filingBusy === filing.fileIndexId}
+                      onClassify={classifyEmail}
+                      onAssign={(id, key) => assignFiling(id, key, username)}
+                    />
+                  ))}
+                </>
+              )}
+            </div>
+            <ProjectRail
+              projects={projects}
+              onDropEmail={(id, key) => fileByDrop(id, key, username)}
+            />
           </div>
         </div>
       )}

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -4,6 +4,8 @@ import { useChatStore } from '../../stores/chatStore';
 import { getTauriInvoke } from '../../lib/helperFetch';
 import { SegmentedControl } from '../ui/SegmentedControl';
 import { Toaster, toast } from '../ui/Toaster';
+import { EmptyState } from '../ui/EmptyState';
+import { SkeletonRows } from '../ui/SkeletonRows';
 import { FileTable } from './FileTable';
 import { FilterChips } from './FilterChips';
 import { FilingCard } from './FilingCard';
@@ -80,11 +82,14 @@ function renderFileMeta(file: FinderFile, openError: boolean): ReactNode {
   );
 }
 
-function LoadingRow() {
+/** List-level fetch failure: the store's error message plus a retry action. */
+function ErrorRow({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
-    <div className="helper-history-loading">
-      <span className="helper-spinner" />
-      <span>Loading...</span>
+    <div className="ws-error-row">
+      <span>{message}</span> —{' '}
+      <button type="button" className="ws-error-retry" onClick={onRetry}>
+        retry
+      </button>
     </div>
   );
 }
@@ -264,12 +269,6 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
         />
       </div>
 
-      {error && (
-        <div className="helper-error-banner">
-          <span>{error}</span>
-        </div>
-      )}
-
       {tab === 'search' && (
         <div className="helper-workspace-body">
           <div className="helper-workspace-toolbar">
@@ -291,16 +290,23 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
             onClearFilter={clearFilter}
           />
           <div className="helper-workspace-list">
-            {loading && <LoadingRow />}
-            {!loading && !query.trim() && (
-              <div className="helper-history-empty">
-                Search your company's shared files by name.
-              </div>
+            {loading && <SkeletonRows />}
+            {!loading && error && (
+              <ErrorRow message={error} onRetry={() => search(query.trim(), filters)} />
             )}
-            {!loading && query.trim() && results.length === 0 && (
-              <div className="helper-history-empty">No files matched.</div>
+            {!loading && !error && !query.trim() && (
+              <EmptyState
+                title="Search your firm's files"
+                hint="Everything indexed from your shares, searchable by name and content."
+              />
             )}
-            {!loading && query.trim() && results.length > 0 && (
+            {!loading && !error && query.trim() && results.length === 0 && (
+              <EmptyState
+                title={`No matches for '${query.trim()}'`}
+                hint="Try fewer words, or clear filters."
+              />
+            )}
+            {!loading && !error && query.trim() && results.length > 0 && (
               <FileTable
                 view="search"
                 rows={results}
@@ -359,11 +365,21 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
               </div>
             )}
             <div className="helper-workspace-list">
-              {loading && <LoadingRow />}
-              {!loading && browsePath && entries.length === 0 && (
-                <div className="helper-history-empty">This folder is empty.</div>
+              {loading && <SkeletonRows />}
+              {!loading && error && (
+                <ErrorRow
+                  message={error}
+                  onRetry={() =>
+                    browsePath
+                      ? browse(browsePath.sourceId, browsePath.parentPath)
+                      : sources[0] && browse(sources[0].id, '')
+                  }
+                />
               )}
-              {!loading && entries.length > 0 && (
+              {!loading && !error && browsePath && entries.length === 0 && (
+                <EmptyState title="This folder is empty" />
+              )}
+              {!loading && !error && entries.length > 0 && (
                 <FileTable
                   view="browse"
                   rows={entries}
@@ -381,11 +397,17 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
         <div className="helper-workspace-body">
           <div className="ws-filing-layout">
             <div className="ws-filing-cards">
-              {loading && <LoadingRow />}
-              {!loading && filings.length === 0 && (
-                <div className="helper-history-empty">No unfiled mail right now.</div>
+              {loading && <SkeletonRows />}
+              {!loading && error && (
+                <ErrorRow message={error} onRetry={loadFilings} />
               )}
-              {!loading && filings.length > 0 && (
+              {!loading && !error && filings.length === 0 && (
+                <EmptyState
+                  title="All mail filed"
+                  hint="New unfiled mail will appear here."
+                />
+              )}
+              {!loading && !error && filings.length > 0 && (
                 <>
                   <div className="helper-workspace-section-title">Unfiled mail</div>
                   {filings.map((filing) => (
@@ -416,14 +438,18 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
       {tab === 'recents' && (
         <div className="helper-workspace-body">
           <div className="helper-workspace-list">
-            {loading && <LoadingRow />}
-            {!loading && (
+            {loading && <SkeletonRows />}
+            {!loading && error && (
+              <ErrorRow message={error} onRetry={() => loadRecents(username)} />
+            )}
+            {!loading && !error && (
               <>
                 <div className="helper-workspace-section-title">Your recent files</div>
                 {recent.length === 0 && (
-                  <div className="helper-history-empty">
-                    Files you open or copy will show up here.
-                  </div>
+                  <EmptyState
+                    title="Nothing recent yet"
+                    hint="Files you open or copy will show up here."
+                  />
                 )}
                 {recent.length > 0 && (
                   <FileTable

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -1,0 +1,374 @@
+import { useEffect, useState } from 'react';
+import { useWorkspaceStore, type FinderFile } from '../../stores/workspaceStore';
+import { useChatStore } from '../../stores/chatStore';
+
+const isMacOS =
+  navigator.platform.startsWith('Mac') || navigator.userAgent.includes('Macintosh');
+
+type WorkspaceTab = 'search' | 'browse' | 'recents';
+
+function formatWhen(dateStr: string | null | undefined): string | null {
+  if (!dateStr) return null;
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return null;
+  const diffMs = Date.now() - d.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return d.toLocaleDateString();
+}
+
+function FileRow({
+  file,
+  sourceName,
+  timestamp,
+  copied,
+  onCopyPath,
+  onReveal,
+  onOpen,
+}: {
+  file: FinderFile;
+  sourceName?: string;
+  timestamp?: string | null;
+  copied: boolean;
+  onCopyPath: (file: FinderFile) => void;
+  onReveal?: (file: FinderFile) => void;
+  /** Open-in-place — wired up by the open_workspace_path Tauri command task. */
+  onOpen?: (file: FinderFile) => void;
+}) {
+  const metaParts = [
+    sourceName,
+    file.parentPath || null,
+    formatWhen(timestamp ?? file.mtime),
+  ].filter(Boolean);
+
+  return (
+    <div className="helper-file-row">
+      <div className="helper-file-main">
+        <span className="helper-file-name">{file.isDir ? `${file.name}/` : file.name}</span>
+        <span className="helper-file-meta">{metaParts.join(' · ')}</span>
+      </div>
+      <div className="helper-file-actions">
+        {copied && <span className="helper-file-copied">Copied</span>}
+        {onOpen && file.openPath && (
+          <button
+            className="helper-btn helper-btn-sm"
+            onClick={() => onOpen(file)}
+            title="Open this file"
+          >
+            Open
+          </button>
+        )}
+        <button
+          className="helper-btn helper-btn-sm"
+          onClick={() => onCopyPath(file)}
+          title="Copy the file path"
+        >
+          Copy
+        </button>
+        {onReveal && (
+          <button
+            className="helper-btn helper-btn-sm"
+            onClick={() => onReveal(file)}
+            title="Show this file's folder in Browse"
+          >
+            Reveal
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LoadingRow() {
+  return (
+    <div className="helper-history-loading">
+      <span className="helper-spinner" />
+      <span>Loading...</span>
+    </div>
+  );
+}
+
+export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
+  const {
+    sources,
+    results,
+    entries,
+    recent,
+    department,
+    loading,
+    error,
+    browsePath,
+    search,
+    browse,
+    loadRecents,
+    recordActivity,
+  } = useWorkspaceStore();
+  const username = useChatStore((s) => s.username);
+
+  const [tab, setTab] = useState<WorkspaceTab>('search');
+  const [query, setQuery] = useState('');
+  const [sourceFilter, setSourceFilter] = useState('');
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const sourceName = (id: string) => sources.find((s) => s.id === id)?.displayName;
+
+  // Debounced search (300 ms).
+  useEffect(() => {
+    const q = query.trim();
+    if (!q) return;
+    const timer = setTimeout(() => {
+      search(q, sourceFilter ? { sourceId: sourceFilter } : undefined);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [query, sourceFilter, search]);
+
+  // Load recents when the tab is shown.
+  useEffect(() => {
+    if (tab === 'recents') loadRecents(username);
+  }, [tab, username, loadRecents]);
+
+  // Open the first source when Browse is shown for the first time.
+  useEffect(() => {
+    if (tab !== 'browse' || browsePath || sources.length === 0) return;
+    browse(sources[0].id, '');
+  }, [tab, browsePath, sources, browse]);
+
+  const handleCopyPath = (file: FinderFile) => {
+    const path = file.openPath ?? file.relPath;
+    navigator.clipboard
+      .writeText(path)
+      .then(() => {
+        setCopiedId(file.id);
+        setTimeout(() => setCopiedId((cur) => (cur === file.id ? null : cur)), 1500);
+      })
+      .catch(() => {});
+    recordActivity(file.id, 'copy_path', username);
+  };
+
+  const handleReveal = (file: FinderFile) => {
+    recordActivity(file.id, 'reveal', username);
+    setTab('browse');
+    browse(file.sourceId, file.parentPath);
+  };
+
+  const activeSource = browsePath ? sources.find((s) => s.id === browsePath.sourceId) : null;
+  const crumbSegments = browsePath
+    ? browsePath.parentPath.split('/').filter(Boolean)
+    : [];
+
+  return (
+    <div className="helper-container">
+      <div
+        className={`helper-header${isMacOS ? ' helper-header-macos' : ''}`}
+        data-tauri-drag-region
+      >
+        <div className="helper-header-left" data-tauri-drag-region>
+          {isMacOS && <div className="helper-traffic-light-spacer" />}
+          <span className="helper-title">Files</span>
+        </div>
+        <div className="helper-header-drag-spacer" data-tauri-drag-region />
+        <div className="helper-header-actions">
+          <button onClick={onClose} className="helper-btn helper-btn-sm">
+            Back
+          </button>
+        </div>
+      </div>
+
+      <div className="helper-workspace-tabs">
+        {(['search', 'browse', 'recents'] as const).map((t) => (
+          <button
+            key={t}
+            className={`helper-workspace-tab${tab === t ? ' helper-workspace-tab-active' : ''}`}
+            onClick={() => setTab(t)}
+          >
+            {t === 'search' ? 'Search' : t === 'browse' ? 'Browse' : 'Recents'}
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <div className="helper-error-banner">
+          <span>{error}</span>
+        </div>
+      )}
+
+      {tab === 'search' && (
+        <div className="helper-workspace-body">
+          <div className="helper-workspace-toolbar">
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search shared files..."
+              className="helper-workspace-search-input"
+              autoFocus
+            />
+            {sources.length > 1 && (
+              <select
+                value={sourceFilter}
+                onChange={(e) => setSourceFilter(e.target.value)}
+                className="helper-workspace-select"
+                title="Limit search to one source"
+              >
+                <option value="">All sources</option>
+                {sources.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.displayName}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+          <div className="helper-workspace-list">
+            {loading && <LoadingRow />}
+            {!loading && !query.trim() && (
+              <div className="helper-history-empty">
+                Search your company's shared files by name.
+              </div>
+            )}
+            {!loading && query.trim() && results.length === 0 && (
+              <div className="helper-history-empty">No files matched.</div>
+            )}
+            {!loading &&
+              query.trim() &&
+              results.map((file) => (
+                <FileRow
+                  key={file.id}
+                  file={file}
+                  sourceName={sourceName(file.sourceId)}
+                  copied={copiedId === file.id}
+                  onCopyPath={handleCopyPath}
+                  onReveal={handleReveal}
+                />
+              ))}
+          </div>
+        </div>
+      )}
+
+      {tab === 'browse' && (
+        <div className="helper-workspace-browse">
+          <div className="helper-workspace-rail">
+            {sources.map((s) => (
+              <button
+                key={s.id}
+                className={`helper-workspace-rail-item${
+                  browsePath?.sourceId === s.id ? ' helper-workspace-rail-item-active' : ''
+                }`}
+                onClick={() => browse(s.id, '')}
+                title={s.displayName}
+              >
+                {s.displayName}
+              </button>
+            ))}
+            {sources.length === 0 && (
+              <span className="helper-workspace-rail-empty">No sources yet</span>
+            )}
+          </div>
+          <div className="helper-workspace-main">
+            {browsePath && (
+              <div className="helper-workspace-breadcrumb">
+                <button
+                  className="helper-workspace-crumb"
+                  onClick={() => browse(browsePath.sourceId, '')}
+                >
+                  {activeSource?.displayName ?? 'Top'}
+                </button>
+                {crumbSegments.map((seg, i) => (
+                  <span key={`${seg}-${i}`}>
+                    <span className="helper-workspace-crumb-sep"> / </span>
+                    <button
+                      className="helper-workspace-crumb"
+                      onClick={() =>
+                        browse(browsePath.sourceId, crumbSegments.slice(0, i + 1).join('/'))
+                      }
+                    >
+                      {seg}
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="helper-workspace-list">
+              {loading && <LoadingRow />}
+              {!loading && browsePath && entries.length === 0 && (
+                <div className="helper-history-empty">This folder is empty.</div>
+              )}
+              {!loading &&
+                entries.map((entry) =>
+                  entry.isDir ? (
+                    <button
+                      key={entry.id}
+                      className="helper-file-row helper-file-row-dir"
+                      onClick={() => browsePath && browse(browsePath.sourceId, entry.relPath)}
+                    >
+                      <div className="helper-file-main">
+                        <span className="helper-file-name">{entry.name}/</span>
+                        <span className="helper-file-meta">Folder</span>
+                      </div>
+                    </button>
+                  ) : (
+                    <FileRow
+                      key={entry.id}
+                      file={entry}
+                      copied={copiedId === entry.id}
+                      onCopyPath={handleCopyPath}
+                    />
+                  ),
+                )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {tab === 'recents' && (
+        <div className="helper-workspace-body">
+          <div className="helper-workspace-list">
+            {loading && <LoadingRow />}
+            {!loading && (
+              <>
+                <div className="helper-workspace-section-title">Your recent files</div>
+                {recent.length === 0 && (
+                  <div className="helper-history-empty">
+                    Files you open or copy will show up here.
+                  </div>
+                )}
+                {recent.map((file) => (
+                  <FileRow
+                    key={file.id}
+                    file={file}
+                    sourceName={sourceName(file.sourceId)}
+                    copied={copiedId === file.id}
+                    onCopyPath={handleCopyPath}
+                    onReveal={handleReveal}
+                  />
+                ))}
+                <div className="helper-workspace-section-title">
+                  Recently active in your company
+                </div>
+                {department.length === 0 && (
+                  <div className="helper-history-empty">Nothing here yet.</div>
+                )}
+                {department.map((file) => (
+                  <FileRow
+                    key={file.id}
+                    file={file}
+                    sourceName={sourceName(file.sourceId)}
+                    timestamp={file.lastActivityAt}
+                    copied={copiedId === file.id}
+                    onCopyPath={handleCopyPath}
+                    onReveal={handleReveal}
+                  />
+                ))}
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import {
   useWorkspaceStore, type FinderFile, type FilingRecord,
 } from '../../stores/workspaceStore';
 import { useChatStore } from '../../stores/chatStore';
 import { getTauriInvoke } from '../../lib/helperFetch';
 import { SegmentedControl } from '../ui/SegmentedControl';
+import { FileTable } from './FileTable';
 
 const isMacOS =
   navigator.platform.startsWith('Mac') || navigator.userAgent.includes('Macintosh');
@@ -40,95 +41,40 @@ function formatWhen(dateStr: string | null | undefined): string | null {
   return d.toLocaleDateString();
 }
 
-function FileRow({
-  file,
-  sourceName,
-  timestamp,
-  copied,
-  openError,
-  onCopyPath,
-  onReveal,
-  onOpen,
-}: {
-  file: FinderFile;
-  sourceName?: string;
-  timestamp?: string | null;
-  copied: boolean;
-  /** Set when opening this row's file failed; shows the copy-path fallback note. */
-  openError?: boolean;
-  onCopyPath: (file: FinderFile) => void;
-  onReveal?: (file: FinderFile) => void;
-  /** Open-in-place via the open_workspace_path Tauri command. */
-  onOpen?: (file: FinderFile) => void;
-}) {
-  const metaParts = [
-    sourceName,
-    file.parentPath || null,
-    formatWhen(timestamp ?? file.mtime),
-  ].filter(Boolean);
-
-  // Content-preview extras: a snippet under the name, and — when the content
-  // reads as a different project than the folder says — both, side by side.
+/**
+ * Second line under a file's name in the list-table: content-preview extras
+ * only (the Project/Doc-type columns already cover the plain inferred
+ * fields) — a search snippet, a filed-vs-reads-as mismatch banner, and the
+ * open-failure fallback note. Returns null when a row has none of these.
+ */
+function renderFileMeta(file: FinderFile, openError: boolean): ReactNode {
   const showDisagreement = file.metadataDisagreement
     && (file.inferredDocType || file.inferredProjectLabel);
   const readsAs = [file.inferredDocType, file.inferredProjectLabel]
     .filter(Boolean).join(' — ');
 
+  if (!file.snippet && !showDisagreement && !openError) return null;
+
   return (
-    <div className="helper-file-row">
-      <div className="helper-file-main">
-        <span className="helper-file-name">{file.isDir ? `${file.name}/` : file.name}</span>
-        <span className="helper-file-meta">{metaParts.join(' · ')}</span>
-        {file.snippet && (
-          <span
-            className="helper-file-snippet"
-            dangerouslySetInnerHTML={{ __html: safeSnippetHtml(file.snippet) }}
-          />
-        )}
-        {!showDisagreement && file.inferredDocType && (
-          <span className="helper-file-inferred">{file.inferredDocType}</span>
-        )}
-        {showDisagreement && (
-          <span className="helper-file-inferred helper-file-mismatch">
-            Filed in: {file.declaredProjectLabel ?? file.parentPath} · Reads as: {readsAs}
-          </span>
-        )}
-        {openError && (
-          <span className="helper-file-open-error">
-            Couldn't open — the share may be unreachable from this machine. Path copied
-            instead.
-          </span>
-        )}
-      </div>
-      <div className="helper-file-actions">
-        {copied && <span className="helper-file-copied">Copied</span>}
-        {onOpen && file.openPath && (
-          <button
-            className="helper-btn helper-btn-sm"
-            onClick={() => onOpen(file)}
-            title="Open this file"
-          >
-            Open
-          </button>
-        )}
-        <button
-          className="helper-btn helper-btn-sm"
-          onClick={() => onCopyPath(file)}
-          title="Copy the file path"
-        >
-          Copy
-        </button>
-        {onReveal && (
-          <button
-            className="helper-btn helper-btn-sm"
-            onClick={() => onReveal(file)}
-            title="Show this file's folder in Browse"
-          >
-            Reveal
-          </button>
-        )}
-      </div>
-    </div>
+    <>
+      {file.snippet && (
+        <span
+          className="ws-file-table-snippet"
+          dangerouslySetInnerHTML={{ __html: safeSnippetHtml(file.snippet) }}
+        />
+      )}
+      {showDisagreement && (
+        <span className="ws-file-table-mismatch">
+          Filed in: {file.declaredProjectLabel ?? file.parentPath} · Reads as: {readsAs}
+        </span>
+      )}
+      {openError && (
+        <span className="ws-file-table-open-error">
+          Couldn't open — the share may be unreachable from this machine. Path copied
+          instead.
+        </span>
+      )}
+    </>
   );
 }
 
@@ -264,10 +210,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   const [tab, setTab] = useState<WorkspaceTab>('search');
   const [query, setQuery] = useState('');
   const [sourceFilter, setSourceFilter] = useState('');
-  const [copiedId, setCopiedId] = useState<string | null>(null);
   const [openErrorId, setOpenErrorId] = useState<string | null>(null);
-
-  const sourceName = (id: string) => sources.find((s) => s.id === id)?.displayName;
 
   // Debounced search (300 ms).
   useEffect(() => {
@@ -296,15 +239,10 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
     browse(sources[0].id, '');
   }, [tab, browsePath, sources, browse]);
 
+  // Not yet wired to a row action — Task 7 hangs this off the ⋯ context menu.
   const handleCopyPath = (file: FinderFile) => {
     const path = file.openPath ?? file.relPath;
-    navigator.clipboard
-      .writeText(path)
-      .then(() => {
-        setCopiedId(file.id);
-        setTimeout(() => setCopiedId((cur) => (cur === file.id ? null : cur)), 1500);
-      })
-      .catch(() => {});
+    navigator.clipboard.writeText(path).catch(() => {});
     recordActivity(file.id, 'copy_path', username);
   };
 
@@ -329,6 +267,15 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
     recordActivity(file.id, 'reveal', username);
     setTab('browse');
     browse(file.sourceId, file.parentPath);
+  };
+
+  // Browse's Open drills into directories instead of opening them in place.
+  const handleBrowseOpen = (file: FinderFile) => {
+    if (file.isDir) {
+      if (browsePath) browse(browsePath.sourceId, file.relPath);
+      return;
+    }
+    handleOpen(file);
   };
 
   const activeSource = browsePath ? sources.find((s) => s.id === browsePath.sourceId) : null;
@@ -410,20 +357,16 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
             {!loading && query.trim() && results.length === 0 && (
               <div className="helper-history-empty">No files matched.</div>
             )}
-            {!loading &&
-              query.trim() &&
-              results.map((file) => (
-                <FileRow
-                  key={file.id}
-                  file={file}
-                  sourceName={sourceName(file.sourceId)}
-                  copied={copiedId === file.id}
-                  openError={openErrorId === file.id}
-                  onCopyPath={handleCopyPath}
-                  onReveal={handleReveal}
-                  onOpen={handleOpen}
-                />
-              ))}
+            {!loading && query.trim() && results.length > 0 && (
+              <FileTable
+                view="search"
+                rows={results}
+                onOpen={handleOpen}
+                onCopy={handleCopyPath}
+                onReveal={handleReveal}
+                renderMeta={(file) => renderFileMeta(file, openErrorId === file.id)}
+              />
+            )}
           </div>
         </div>
       )}
@@ -476,30 +419,15 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
               {!loading && browsePath && entries.length === 0 && (
                 <div className="helper-history-empty">This folder is empty.</div>
               )}
-              {!loading &&
-                entries.map((entry) =>
-                  entry.isDir ? (
-                    <button
-                      key={entry.id}
-                      className="helper-file-row helper-file-row-dir"
-                      onClick={() => browsePath && browse(browsePath.sourceId, entry.relPath)}
-                    >
-                      <div className="helper-file-main">
-                        <span className="helper-file-name">{entry.name}/</span>
-                        <span className="helper-file-meta">Folder</span>
-                      </div>
-                    </button>
-                  ) : (
-                    <FileRow
-                      key={entry.id}
-                      file={entry}
-                      copied={copiedId === entry.id}
-                      openError={openErrorId === entry.id}
-                      onCopyPath={handleCopyPath}
-                      onOpen={handleOpen}
-                    />
-                  ),
-                )}
+              {!loading && entries.length > 0 && (
+                <FileTable
+                  view="browse"
+                  rows={entries}
+                  onOpen={handleBrowseOpen}
+                  onCopy={handleCopyPath}
+                  renderMeta={(file) => renderFileMeta(file, openErrorId === file.id)}
+                />
+              )}
             </div>
           </div>
         </div>
@@ -543,37 +471,34 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                     Files you open or copy will show up here.
                   </div>
                 )}
-                {recent.map((file) => (
-                  <FileRow
-                    key={file.id}
-                    file={file}
-                    sourceName={sourceName(file.sourceId)}
-                    copied={copiedId === file.id}
-                    openError={openErrorId === file.id}
-                    onCopyPath={handleCopyPath}
-                    onReveal={handleReveal}
+                {recent.length > 0 && (
+                  <FileTable
+                    view="recents"
+                    rows={recent}
                     onOpen={handleOpen}
+                    onCopy={handleCopyPath}
+                    onReveal={handleReveal}
+                    renderMeta={(file) => renderFileMeta(file, openErrorId === file.id)}
                   />
-                ))}
+                )}
                 <div className="helper-workspace-section-title">
                   Recently active in your company
                 </div>
                 {department.length === 0 && (
                   <div className="helper-history-empty">Nothing here yet.</div>
                 )}
-                {department.map((file) => (
-                  <FileRow
-                    key={file.id}
-                    file={file}
-                    sourceName={sourceName(file.sourceId)}
-                    timestamp={file.lastActivityAt}
-                    copied={copiedId === file.id}
-                    openError={openErrorId === file.id}
-                    onCopyPath={handleCopyPath}
-                    onReveal={handleReveal}
+                {department.length > 0 && (
+                  <FileTable
+                    view="recents"
+                    // "Modified" reflects the activity feed's timestamp here,
+                    // not the file's own mtime — same field sortRows reads.
+                    rows={department.map((d) => ({ ...d, mtime: d.lastActivityAt }))}
                     onOpen={handleOpen}
+                    onCopy={handleCopyPath}
+                    onReveal={handleReveal}
+                    renderMeta={(file) => renderFileMeta(file, openErrorId === file.id)}
                   />
-                ))}
+                )}
               </>
             )}
           </div>

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -146,6 +146,20 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
     setTab(next);
   };
 
+  // `error` lives in the module-level store, so it survives this component's
+  // own unmount/remount (WorkspacePanel is conditionally rendered by
+  // App.tsx's `showWorkspace` gate — closing and reopening Files is a normal
+  // user action, not a tab switch, so `switchTab`'s guard above never runs
+  // for it). Without this, a leftover error from a session before the panel
+  // was last closed (or before the user ever switched tabs) would render as
+  // a stale `ErrorRow` on whichever tab mounts first (`search`), masking
+  // that tab's correct empty/loaded state. Clear it once, on mount, the same
+  // way `switchTab` clears it on an in-panel tab change.
+  useEffect(() => {
+    useWorkspaceStore.setState({ error: null });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Debounced search (300 ms). Filter chips re-issue this fetch too — they
   // only ever change the store's `filters`, which this effect already watches.
   useEffect(() => {

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -4,6 +4,7 @@ import {
 } from '../../stores/workspaceStore';
 import { useChatStore } from '../../stores/chatStore';
 import { getTauriInvoke } from '../../lib/helperFetch';
+import { SegmentedControl } from '../ui/SegmentedControl';
 
 const isMacOS =
   navigator.platform.startsWith('Mac') || navigator.userAgent.includes('Macintosh');
@@ -354,20 +355,16 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
       </div>
 
       <div className="helper-workspace-tabs">
-        {([
-          ['search', 'Search'],
-          ['browse', 'Browse'],
-          ['recents', 'Recents'],
-          ...(filingEnabled ? ([['filing', 'Filing']] as const) : []),
-        ] as ReadonlyArray<readonly [WorkspaceTab, string]>).map(([t, label]) => (
-          <button
-            key={t}
-            className={`helper-workspace-tab${tab === t ? ' helper-workspace-tab-active' : ''}`}
-            onClick={() => setTab(t)}
-          >
-            {label}
-          </button>
-        ))}
+        <SegmentedControl
+          options={[
+            { key: 'search', label: 'Search' },
+            { key: 'browse', label: 'Browse' },
+            { key: 'recents', label: 'Recents' },
+            ...(filingEnabled ? [{ key: 'filing', label: 'Filing' }] : []),
+          ]}
+          value={tab}
+          onChange={(key) => setTab(key as WorkspaceTab)}
+        />
       </div>
 
       {error && (

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -139,7 +139,19 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   // failed fetch left no valid content to protect, so a later revisit
   // re-attempting the fetch is fine (and is the only way it'd ever recover
   // without the user retyping).
-  const lastSearchKeyRef = useRef<string | null>(null);
+  const lastSuccessKeyRef = useRef<string | null>(null);
+  // Browse's analogue: key (sourceId, parentPath, project, docType) of the
+  // last browse that completed successfully. The Browse chip/tab effect below
+  // re-runs on browsePath *and* tab changes now, so without this a rail
+  // click (which already fetched) or a tab revisit with unchanged state would
+  // redundantly re-fetch. Seeded from the initial browsePath: if a folder is
+  // already loaded when the panel first renders (a preloaded view, or a
+  // remount while a browse was showing), entering Browse must not re-fetch it.
+  const lastBrowseKeyRef = useRef<string | null>(
+    browsePath
+      ? JSON.stringify([browsePath.sourceId, browsePath.parentPath, filters.project, filters.docType])
+      : null,
+  );
 
   // `error` is a single store field shared by all four views (Search,
   // Browse, Recents, Filing), cleared only when the view whose fetch set it
@@ -175,12 +187,32 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   const runSearch = (q: string, searchFilters: typeof filters) => {
     const key = JSON.stringify([q, searchFilters]);
     void search(q, searchFilters).then(() => {
-      if (!useWorkspaceStore.getState().error) lastSearchKeyRef.current = key;
+      if (!useWorkspaceStore.getState().error) lastSuccessKeyRef.current = key;
     });
   };
 
-  // Debounced search (300 ms). Filter chips re-issue this fetch too — they
-  // only ever change the store's `filters`, which this effect already watches.
+  // Browse's single choke point (mirrors runSearch): every browse call site —
+  // the mount "open first source" effect, the chip/tab effect, rail clicks,
+  // breadcrumbs, drill-down, reveal, and the ErrorRow retry — routes through
+  // here so the (sourceId, parentPath, filters) key is recorded on success
+  // only. That lets the chip/tab effect below skip re-fetching a folder that's
+  // already loaded (browse() reads the same `filters` slice via getState()).
+  const runBrowse = (sourceId: string, parentPath: string) => {
+    const { project, docType } = useWorkspaceStore.getState().filters;
+    const key = JSON.stringify([sourceId, parentPath, project, docType]);
+    void browse(sourceId, parentPath).then(() => {
+      if (!useWorkspaceStore.getState().error) lastBrowseKeyRef.current = key;
+    });
+  };
+
+  // Debounced search (300 ms). This effect is reactive ONLY to user-meaningful
+  // inputs — query, filters, tab. It is deliberately NOT reactive to `error`
+  // or `loading`: making `error` a dependency creates an auto-retry loop,
+  // because `search()` writes `error` (null → message) on every failed attempt,
+  // which would re-run the effect, re-arm the timer, and refetch the failing
+  // query forever. Instead the effect reads transient store state
+  // non-reactively via `getState()` when it runs (the standard zustand
+  // pattern — no dependency entry, no eslint-disable needed for those reads).
   //
   // `tab` is a dependency (not just read once) so that navigating away from
   // Search runs this effect's cleanup — cancelling any pending timer —
@@ -188,39 +220,36 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   // Without this, a timer armed while on Search could still fire after the
   // user switched to another (already-loaded) tab: `search()` would resolve
   // later and set the store's global `error`, masking that other tab's
-  // correct content with a stale, wrong-context ErrorRow — the exact async-
-  // completion race the tab-switch and mount-time error clears don't cover,
-  // since both only clear `error` at the moment of switching/mounting, not
-  // when a since-abandoned view's in-flight fetch settles afterward.
+  // correct content with a stale, wrong-context ErrorRow.
   //
-  // But `tab` being a dependency also means this effect re-runs every time
-  // the user navigates *back into* Search, even when neither `query` nor
-  // `filters` changed — which would otherwise re-arm a fresh timer that
-  // redundantly refetches an already-loaded result set, flipping the
-  // correct FileTable back to SkeletonRows (and, on a flaky refetch, behind
-  // a stale ErrorRow) for no reason. Guard against that by skipping the
-  // (re)arm when this exact query/filters combo already succeeded.
+  // Empty query: if an ErrorRow is currently showing (e.g. the user just
+  // cleared a failed query), clear the store `error` so the "Search your
+  // firm's files" EmptyState shows instead of a stale error, then return
+  // without arming a timer.
   //
-  // That key-only guard has its own gap, though: it doesn't check whether
-  // `error` is currently set. Search "alder" (succeeds, key recorded),
-  // search "boblegal" (fails — failures don't update the key), then retype
-  // "alder" exactly — the key matches, so the guard would bail with no
-  // fetch and nothing else clears `error` mid-tab, leaving the stale
-  // ErrorRow masking alder's valid results indefinitely. So also require
-  // `!error` to skip; `error` is a real dependency (not read via
-  // getState()) so the effect re-evaluates the instant it's set.
+  // Skip guard: skip arming ONLY when the (query, filters) key matches the
+  // last *successful* search AND no error is currently set. The `error == null`
+  // half is what lets "search alder (ok) → search boblegal (fails) → retype
+  // alder" recover: the key matches alder's earlier success, but because an
+  // error is set the guard falls through and refetches (clearing the error).
+  // Reading `error` via getState() here — not as a dependency — is exactly
+  // what keeps a failing query's own `error` writes from re-running the effect.
   useEffect(() => {
     if (tab !== 'search') return;
     const q = query.trim();
-    if (!q) return;
+    const store = useWorkspaceStore.getState();
+    if (!q) {
+      if (store.error) useWorkspaceStore.setState({ error: null });
+      return;
+    }
     const key = JSON.stringify([q, filters]);
-    if (key === lastSearchKeyRef.current && !error) return;
+    if (key === lastSuccessKeyRef.current && store.error == null) return;
     const timer = setTimeout(() => {
       runSearch(q, filters);
     }, 300);
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tab, query, filters, search, error]);
+  }, [tab, query, filters, search]);
 
   // Load recents when the tab is shown.
   useEffect(() => {
@@ -236,19 +265,34 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   // Open the first source when Browse is shown for the first time.
   useEffect(() => {
     if (tab !== 'browse' || browsePath || sources.length === 0) return;
-    browse(sources[0].id, '');
-  }, [tab, browsePath, sources, browse]);
+    runBrowse(sources[0].id, '');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab, browsePath, sources]);
 
   // Browse's own chip row (Project/Doc type only — see FilterChips' `chips`
   // prop below) writes to the same `filters` slice Search's chips use.
   // Selecting or clearing either one re-issues the current folder's browse
-  // fetch with the new filters. Chips only render while browsePath is set
-  // (folder already loaded), so this never fights the mount effect above.
+  // fetch with the new filters.
+  //
+  // `tab` is a dependency (mirroring the search effect): the shared `filters`
+  // slice can change while the user is on *another* tab (Search's chip row
+  // writes the same filters.project/docType). Without `tab` here, returning to
+  // Browse after such a change wouldn't re-run this effect, leaving Browse
+  // showing active chips over a stale list. `browsePath` is a dependency too so
+  // a rail click / drill-down re-evaluates the guard. The lastBrowseKeyRef
+  // guard then skips the redundant re-fetch when nothing that browse() reads
+  // (sourceId, parentPath, project, docType) actually changed — so a rail
+  // click (which already fetched via runBrowse) or a tab revisit with
+  // unchanged state doesn't double-fetch.
   useEffect(() => {
     if (tab !== 'browse' || !browsePath) return;
-    browse(browsePath.sourceId, browsePath.parentPath);
+    const key = JSON.stringify([
+      browsePath.sourceId, browsePath.parentPath, filters.project, filters.docType,
+    ]);
+    if (key === lastBrowseKeyRef.current) return;
+    runBrowse(browsePath.sourceId, browsePath.parentPath);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters.project, filters.docType]);
+  }, [tab, browsePath, filters.project, filters.docType]);
 
   // Cmd/Ctrl+F focuses the search input from anywhere in Files, switching to
   // the Search tab first if another tab is active.
@@ -301,13 +345,13 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   const handleReveal = (file: FinderFile) => {
     recordActivity(file.id, 'reveal', username);
     switchTab('browse');
-    browse(file.sourceId, file.parentPath);
+    runBrowse(file.sourceId, file.parentPath);
   };
 
   // Browse's Open drills into directories instead of opening them in place.
   const handleBrowseOpen = (file: FinderFile) => {
     if (file.isDir) {
-      if (browsePath) browse(browsePath.sourceId, file.relPath);
+      if (browsePath) runBrowse(browsePath.sourceId, file.relPath);
       return;
     }
     handleOpen(file);
@@ -419,7 +463,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                 className={`helper-workspace-rail-item${
                   browsePath?.sourceId === s.id ? ' helper-workspace-rail-item-active' : ''
                 }`}
-                onClick={() => browse(s.id, '')}
+                onClick={() => runBrowse(s.id, '')}
                 title={s.displayName}
               >
                 {s.displayName}
@@ -444,7 +488,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
               <div className="helper-workspace-breadcrumb">
                 <button
                   className="helper-workspace-crumb"
-                  onClick={() => browse(browsePath.sourceId, '')}
+                  onClick={() => runBrowse(browsePath.sourceId, '')}
                 >
                   {activeSource?.displayName ?? 'Top'}
                 </button>
@@ -454,7 +498,7 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                     <button
                       className="helper-workspace-crumb"
                       onClick={() =>
-                        browse(browsePath.sourceId, crumbSegments.slice(0, i + 1).join('/'))
+                        runBrowse(browsePath.sourceId, crumbSegments.slice(0, i + 1).join('/'))
                       }
                     >
                       {seg}
@@ -470,8 +514,8 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                   message={error}
                   onRetry={() =>
                     browsePath
-                      ? browse(browsePath.sourceId, browsePath.parentPath)
-                      : sources[0] && browse(sources[0].id, '')
+                      ? runBrowse(browsePath.sourceId, browsePath.parentPath)
+                      : sources[0] && runBrowse(sources[0].id, '')
                   }
                 />
               )}

--- a/apps/helper/src/components/workspace/WorkspacePanel.tsx
+++ b/apps/helper/src/components/workspace/WorkspacePanel.tsx
@@ -1,12 +1,28 @@
 import { useEffect, useState } from 'react';
-import { useWorkspaceStore, type FinderFile } from '../../stores/workspaceStore';
+import {
+  useWorkspaceStore, type FinderFile, type FilingRecord,
+} from '../../stores/workspaceStore';
 import { useChatStore } from '../../stores/chatStore';
 import { getTauriInvoke } from '../../lib/helperFetch';
 
 const isMacOS =
   navigator.platform.startsWith('Mac') || navigator.userAgent.includes('Macintosh');
 
-type WorkspaceTab = 'search' | 'browse' | 'recents';
+type WorkspaceTab = 'search' | 'browse' | 'recents' | 'filing';
+
+/**
+ * The search snippet arrives as ts_headline output: plain text plus <b> marks.
+ * Escape EVERYTHING, then restore only the exact <b>/</b> tokens — no other
+ * markup (or attributes) can survive, whatever the indexed file contained.
+ */
+function safeSnippetHtml(snippet: string): string {
+  return snippet
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replaceAll('&lt;b&gt;', '<b>')
+    .replaceAll('&lt;/b&gt;', '</b>');
+}
 
 function formatWhen(dateStr: string | null | undefined): string | null {
   if (!dateStr) return null;
@@ -50,11 +66,32 @@ function FileRow({
     formatWhen(timestamp ?? file.mtime),
   ].filter(Boolean);
 
+  // Content-preview extras: a snippet under the name, and — when the content
+  // reads as a different project than the folder says — both, side by side.
+  const showDisagreement = file.metadataDisagreement
+    && (file.inferredDocType || file.inferredProjectLabel);
+  const readsAs = [file.inferredDocType, file.inferredProjectLabel]
+    .filter(Boolean).join(' — ');
+
   return (
     <div className="helper-file-row">
       <div className="helper-file-main">
         <span className="helper-file-name">{file.isDir ? `${file.name}/` : file.name}</span>
         <span className="helper-file-meta">{metaParts.join(' · ')}</span>
+        {file.snippet && (
+          <span
+            className="helper-file-snippet"
+            dangerouslySetInnerHTML={{ __html: safeSnippetHtml(file.snippet) }}
+          />
+        )}
+        {!showDisagreement && file.inferredDocType && (
+          <span className="helper-file-inferred">{file.inferredDocType}</span>
+        )}
+        {showDisagreement && (
+          <span className="helper-file-inferred helper-file-mismatch">
+            Filed in: {file.declaredProjectLabel ?? file.parentPath} · Reads as: {readsAs}
+          </span>
+        )}
         {openError && (
           <span className="helper-file-open-error">
             Couldn't open — the share may be unreachable from this machine. Path copied
@@ -103,6 +140,101 @@ function LoadingRow() {
   );
 }
 
+function FilingRow({
+  filing,
+  projects,
+  busy,
+  onClassify,
+  onAssign,
+}: {
+  filing: FilingRecord;
+  projects: Array<{ key: string; label: string }>;
+  busy: boolean;
+  onClassify: (fileIndexId: string) => void;
+  onAssign: (fileIndexId: string, projectKey: string) => void;
+}) {
+  const [choice, setChoice] = useState('');
+  const subject = filing.emailMeta?.subject ?? filing.name;
+  const decided = filing.status === 'confirmed' || filing.status === 'reassigned';
+  const decidedLabel = filing.decidedProjectKey
+    ? projects.find((p) => p.key === filing.decidedProjectKey)?.label ?? filing.decidedProjectKey
+    : null;
+
+  return (
+    <div className="helper-file-row helper-filing-row">
+      <div className="helper-file-main">
+        <span className="helper-file-name">{subject}</span>
+        <span className="helper-file-meta">
+          {[filing.emailMeta?.from, formatWhen(filing.emailMeta?.date)].filter(Boolean).join(' · ')}
+        </span>
+        {decided && (
+          <span className="helper-filing-banner helper-filing-decided">
+            Filed to: {decidedLabel}
+          </span>
+        )}
+        {!decided && filing.status === 'suggested' && filing.suggestedProjectLabel && (
+          <span
+            className={`helper-filing-banner${
+              filing.confidence === 'high' ? ' helper-filing-confident' : ' helper-filing-tentative'
+            }`}
+          >
+            {filing.confidence === 'high'
+              ? `Filed to: ${filing.suggestedProjectLabel} — ${filing.rationale}`
+              : `Possibly ${filing.suggestedProjectLabel} — ${filing.rationale}`}
+          </span>
+        )}
+        {!decided && filing.status === 'suggested' && !filing.suggestedProjectLabel && (
+          <span className="helper-filing-banner helper-filing-tentative">
+            No clear match — pick a project below.
+          </span>
+        )}
+      </div>
+      <div className="helper-file-actions helper-filing-actions">
+        {busy && <span className="helper-spinner" />}
+        {!busy && filing.status === null && (
+          <button
+            className="helper-btn helper-btn-sm"
+            onClick={() => onClassify(filing.fileIndexId)}
+            title="Suggest where this email belongs"
+          >
+            Sort
+          </button>
+        )}
+        {!busy && filing.status === 'suggested' && (
+          <>
+            {filing.suggestedProjectKey && (
+              <button
+                className="helper-btn helper-btn-sm"
+                onClick={() => onAssign(filing.fileIndexId, filing.suggestedProjectKey!)}
+                title="File to the suggested project"
+              >
+                File it
+              </button>
+            )}
+            <select
+              className="helper-workspace-select"
+              value={choice}
+              onChange={(e) => {
+                const key = e.target.value;
+                setChoice(key);
+                if (key) onAssign(filing.fileIndexId, key);
+              }}
+              title="File to a different project"
+            >
+              <option value="">Move to…</option>
+              {projects.map((p) => (
+                <option key={p.key} value={p.key}>
+                  {p.key} {p.label}
+                </option>
+              ))}
+            </select>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   const {
     sources,
@@ -110,13 +242,21 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
     entries,
     recent,
     department,
+    filings,
+    projects,
+    contentEnabled,
+    contentFeatures,
     loading,
     error,
+    filingBusy,
     browsePath,
     search,
     browse,
     loadRecents,
     recordActivity,
+    loadFilings,
+    classifyEmail,
+    assignFiling,
   } = useWorkspaceStore();
   const username = useChatStore((s) => s.username);
 
@@ -142,6 +282,12 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
   useEffect(() => {
     if (tab === 'recents') loadRecents(username);
   }, [tab, username, loadRecents]);
+
+  // Load unfiled mail when the Filing tab is shown.
+  const filingEnabled = contentEnabled === true && contentFeatures.includes('filing');
+  useEffect(() => {
+    if (tab === 'filing' && filingEnabled) loadFilings();
+  }, [tab, filingEnabled, loadFilings]);
 
   // Open the first source when Browse is shown for the first time.
   useEffect(() => {
@@ -208,13 +354,18 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
       </div>
 
       <div className="helper-workspace-tabs">
-        {(['search', 'browse', 'recents'] as const).map((t) => (
+        {([
+          ['search', 'Search'],
+          ['browse', 'Browse'],
+          ['recents', 'Recents'],
+          ...(filingEnabled ? ([['filing', 'Filing']] as const) : []),
+        ] as ReadonlyArray<readonly [WorkspaceTab, string]>).map(([t, label]) => (
           <button
             key={t}
             className={`helper-workspace-tab${tab === t ? ' helper-workspace-tab-active' : ''}`}
             onClick={() => setTab(t)}
           >
-            {t === 'search' ? 'Search' : t === 'browse' ? 'Browse' : 'Recents'}
+            {label}
           </button>
         ))}
       </div>
@@ -353,6 +504,32 @@ export default function WorkspacePanel({ onClose }: { onClose: () => void }) {
                   ),
                 )}
             </div>
+          </div>
+        </div>
+      )}
+
+      {tab === 'filing' && (
+        <div className="helper-workspace-body">
+          <div className="helper-workspace-list">
+            {loading && <LoadingRow />}
+            {!loading && filings.length === 0 && (
+              <div className="helper-history-empty">No unfiled mail right now.</div>
+            )}
+            {!loading && filings.length > 0 && (
+              <>
+                <div className="helper-workspace-section-title">Unfiled mail</div>
+                {filings.map((filing) => (
+                  <FilingRow
+                    key={filing.fileIndexId}
+                    filing={filing}
+                    projects={projects}
+                    busy={filingBusy === filing.fileIndexId}
+                    onClassify={classifyEmail}
+                    onAssign={(id, key) => assignFiling(id, key, username)}
+                  />
+                ))}
+              </>
+            )}
           </div>
         </div>
       )}

--- a/apps/helper/src/lib/helperFetch.ts
+++ b/apps/helper/src/lib/helperFetch.ts
@@ -1,0 +1,112 @@
+// Shared HTTP plumbing for talking to the Breeze API from the Helper.
+// Extracted verbatim from chatStore.ts — no behavior change.
+
+declare global {
+  interface Window {
+    __TAURI_INTERNALS__?: unknown;
+  }
+}
+
+export interface AgentConfig {
+  api_url: string;
+  token?: string;
+  agent_id: string;
+  has_mtls?: boolean;
+  os_username?: string;
+  helper_version?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tauri bridge helpers
+// ---------------------------------------------------------------------------
+
+/** Cached reference to the Tauri invoke function, or null if not in Tauri. */
+let _tauriInvoke: ((cmd: string, args?: Record<string, unknown>) => Promise<unknown>) | null = null;
+let _tauriInvokeResolved = false;
+
+/**
+ * Dynamically import Tauri invoke -- returns null in non-Tauri environments.
+ */
+export async function getTauriInvoke(): Promise<
+  ((cmd: string, args?: Record<string, unknown>) => Promise<unknown>) | null
+> {
+  if (_tauriInvokeResolved) return _tauriInvoke;
+  try {
+    if (!window.__TAURI_INTERNALS__) {
+      _tauriInvokeResolved = true;
+      return null;
+    }
+    const mod = await import('@tauri-apps/api/core');
+    _tauriInvoke = mod.invoke as (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+    _tauriInvokeResolved = true;
+    return _tauriInvoke;
+  } catch {
+    _tauriInvokeResolved = true;
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// helper_fetch response types (match Rust structs)
+// ---------------------------------------------------------------------------
+
+export interface HelperFetchResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+  stream_id: string | null;
+}
+
+export function requireDevBearerToken(config: AgentConfig): string {
+  if (!config.token) {
+    throw new Error('Browser dev mode requires VITE_AGENT_TOKEN');
+  }
+  return config.token;
+}
+
+// ---------------------------------------------------------------------------
+// Unified HTTP helper that uses helper_fetch in Tauri, plain fetch otherwise
+// ---------------------------------------------------------------------------
+
+/**
+ * Make a non-streaming HTTP request. In Tauri, uses the Rust backend
+ * (which attaches the mTLS client cert). In browser dev mode, uses fetch().
+ */
+export async function helperRequest(
+  config: AgentConfig,
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: string },
+): Promise<{ ok: boolean; status: number; body: string }> {
+  const invoke = await getTauriInvoke();
+
+  if (invoke) {
+    const resp = (await invoke('helper_fetch', {
+      request: {
+        url,
+        method: options.method ?? 'GET',
+        headers: options.headers ?? {},
+        body: options.body,
+        stream: false,
+      },
+    })) as HelperFetchResponse;
+
+    return {
+      ok: resp.status >= 200 && resp.status < 300,
+      status: resp.status,
+      body: resp.body,
+    };
+  }
+
+  // Dev fallback: use native fetch
+  const res = await fetch(url, {
+    method: options.method ?? 'GET',
+    headers: {
+      Authorization: `Bearer ${requireDevBearerToken(config)}`,
+      ...(options.headers ?? {}),
+    },
+    body: options.body,
+  });
+
+  const body = await res.text();
+  return { ok: res.ok, status: res.status, body };
+}

--- a/apps/helper/src/lib/theme.ts
+++ b/apps/helper/src/lib/theme.ts
@@ -1,0 +1,13 @@
+export type WsTheme = 'light' | 'dark';
+const KEY = 'ws-theme';
+
+export function setTheme(theme: WsTheme): void {
+  localStorage.setItem(KEY, theme);
+  if (theme === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+  else document.documentElement.removeAttribute('data-theme');
+}
+
+export function initTheme(): void {
+  const stored = localStorage.getItem(KEY);
+  if (stored === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+}

--- a/apps/helper/src/lib/useListSelection.test.ts
+++ b/apps/helper/src/lib/useListSelection.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { useListSelection } from './useListSelection';
+
+function key(k: string, extra: Partial<{ metaKey: boolean; ctrlKey: boolean }> = {}) {
+  return { key: k, preventDefault: vi.fn(), ...extra } as unknown as React.KeyboardEvent;
+}
+
+function setup(count = 3) {
+  const onActivate = vi.fn();
+  const onCopy = vi.fn();
+  const { result } = renderHook(() => useListSelection(count, { onActivate, onCopy }));
+  return { result, onActivate, onCopy };
+}
+
+it('ArrowDown from null selects the first row', () => {
+  const { result } = setup();
+  act(() => result.current.onKeyDown(key('ArrowDown')));
+  expect(result.current.selected).toBe(0);
+});
+
+it('ArrowDown clamps at count - 1', () => {
+  const { result } = setup(3);
+  act(() => result.current.onKeyDown(key('ArrowDown')));
+  act(() => result.current.onKeyDown(key('ArrowDown')));
+  act(() => result.current.onKeyDown(key('ArrowDown')));
+  act(() => result.current.onKeyDown(key('ArrowDown')));
+  expect(result.current.selected).toBe(2);
+});
+
+it('Enter fires onActivate with the selected index', () => {
+  const { result, onActivate } = setup();
+  act(() => result.current.onKeyDown(key('ArrowDown')));
+  act(() => result.current.onKeyDown(key('ArrowDown')));
+  act(() => result.current.onKeyDown(key('Enter')));
+  expect(onActivate).toHaveBeenCalledWith(1);
+});
+
+it('meta+c fires onCopy with the selected index', () => {
+  const { result, onCopy } = setup();
+  act(() => result.current.onKeyDown(key('ArrowDown')));
+  act(() => result.current.onKeyDown(key('c', { metaKey: true })));
+  expect(onCopy).toHaveBeenCalledWith(0);
+});
+
+it('Escape clears the selection first', () => {
+  const { result } = setup();
+  act(() => result.current.onKeyDown(key('ArrowDown')));
+  expect(result.current.selected).toBe(0);
+  act(() => result.current.onKeyDown(key('Escape')));
+  expect(result.current.selected).toBeNull();
+});

--- a/apps/helper/src/lib/useListSelection.ts
+++ b/apps/helper/src/lib/useListSelection.ts
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+
+/**
+ * Keyboard selection model shared by the search/browse/recents/filing
+ * list-tables: Arrow Up/Down move a single selected row index, Enter
+ * activates it (open), Cmd/Ctrl+C copies it, Escape clears the selection.
+ * Row rendering (aria-selected, .ws-row-selected) and scroll-into-view are
+ * the caller's responsibility — this hook only owns the index + key routing.
+ */
+export function useListSelection(count: number, h: { onActivate: (i: number) => void; onCopy: (i: number) => void }) {
+  const [selected, setSelected] = useState<number | null>(null);
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') { e.preventDefault(); setSelected(s => s === null ? 0 : Math.min(count - 1, s + 1)); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setSelected(s => s === null ? 0 : Math.max(0, s - 1)); }
+    else if (e.key === 'Enter' && selected !== null) h.onActivate(selected);
+    else if (e.key === 'c' && (e.metaKey || e.ctrlKey) && selected !== null) { e.preventDefault(); h.onCopy(selected); }
+    else if (e.key === 'Escape') setSelected(null);
+  };
+  return { selected, setSelected, onKeyDown };
+}

--- a/apps/helper/src/main.tsx
+++ b/apps/helper/src/main.tsx
@@ -7,6 +7,10 @@ import App from './App';
 import { ConsentDialog } from './windows/ConsentDialog';
 import type { ConsentRequest } from './windows/ConsentDialog';
 import { SessionBanner } from './windows/SessionBanner';
+import { initTheme } from './lib/theme';
+
+// Initialize theme before rendering
+initTheme();
 
 // ── Consent window ──────────────────────────────────────────────────────────
 

--- a/apps/helper/src/main.tsx
+++ b/apps/helper/src/main.tsx
@@ -1,3 +1,4 @@
+import '@fontsource-variable/inter';
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import { listen } from '@tauri-apps/api/event';

--- a/apps/helper/src/stores/chatStore.ts
+++ b/apps/helper/src/stores/chatStore.ts
@@ -1,19 +1,11 @@
 import { create } from 'zustand';
-
-declare global {
-  interface Window {
-    __TAURI_INTERNALS__?: unknown;
-  }
-}
-
-interface AgentConfig {
-  api_url: string;
-  token?: string;
-  agent_id: string;
-  has_mtls?: boolean;
-  os_username?: string;
-  helper_version?: string;
-}
+import {
+  getTauriInvoke,
+  helperRequest,
+  requireDevBearerToken,
+  type AgentConfig,
+  type HelperFetchResponse,
+} from '../lib/helperFetch';
 
 interface ChatMessage {
   id: string;
@@ -89,32 +81,6 @@ interface ChatState {
 // Tauri bridge helpers
 // ---------------------------------------------------------------------------
 
-/** Cached reference to the Tauri invoke function, or null if not in Tauri. */
-let _tauriInvoke: ((cmd: string, args?: Record<string, unknown>) => Promise<unknown>) | null = null;
-let _tauriInvokeResolved = false;
-
-/**
- * Dynamically import Tauri invoke -- returns null in non-Tauri environments.
- */
-async function getTauriInvoke(): Promise<
-  ((cmd: string, args?: Record<string, unknown>) => Promise<unknown>) | null
-> {
-  if (_tauriInvokeResolved) return _tauriInvoke;
-  try {
-    if (!window.__TAURI_INTERNALS__) {
-      _tauriInvokeResolved = true;
-      return null;
-    }
-    const mod = await import('@tauri-apps/api/core');
-    _tauriInvoke = mod.invoke as (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
-    _tauriInvokeResolved = true;
-    return _tauriInvoke;
-  } catch {
-    _tauriInvokeResolved = true;
-    return null;
-  }
-}
-
 /** Cached reference to the Tauri event listen function. */
 let _tauriListen: ((
   event: string,
@@ -143,75 +109,14 @@ async function getTauriListen() {
 }
 
 // ---------------------------------------------------------------------------
-// helper_fetch response types (match Rust structs)
+// helper_fetch stream event type (matches Rust struct)
 // ---------------------------------------------------------------------------
-
-interface HelperFetchResponse {
-  status: number;
-  headers: Record<string, string>;
-  body: string;
-  stream_id: string | null;
-}
 
 interface StreamChunkEvent {
   stream_id: string;
   chunk: string | null;
   done: boolean;
   error: string | null;
-}
-
-function requireDevBearerToken(config: AgentConfig): string {
-  if (!config.token) {
-    throw new Error('Browser dev mode requires VITE_AGENT_TOKEN');
-  }
-  return config.token;
-}
-
-// ---------------------------------------------------------------------------
-// Unified HTTP helpers that use helper_fetch in Tauri, plain fetch otherwise
-// ---------------------------------------------------------------------------
-
-/**
- * Make a non-streaming HTTP request. In Tauri, uses the Rust backend
- * (which attaches the mTLS client cert). In browser dev mode, uses fetch().
- */
-async function helperRequest(
-  config: AgentConfig,
-  url: string,
-  options: { method?: string; headers?: Record<string, string>; body?: string },
-): Promise<{ ok: boolean; status: number; body: string }> {
-  const invoke = await getTauriInvoke();
-
-  if (invoke) {
-    const resp = (await invoke('helper_fetch', {
-      request: {
-        url,
-        method: options.method ?? 'GET',
-        headers: options.headers ?? {},
-        body: options.body,
-        stream: false,
-      },
-    })) as HelperFetchResponse;
-
-    return {
-      ok: resp.status >= 200 && resp.status < 300,
-      status: resp.status,
-      body: resp.body,
-    };
-  }
-
-  // Dev fallback: use native fetch
-  const res = await fetch(url, {
-    method: options.method ?? 'GET',
-    headers: {
-      Authorization: `Bearer ${requireDevBearerToken(config)}`,
-      ...(options.headers ?? {}),
-    },
-    body: options.body,
-  });
-
-  const body = await res.text();
-  return { ok: res.ok, status: res.status, body };
 }
 
 /**

--- a/apps/helper/src/stores/themeInit.test.ts
+++ b/apps/helper/src/stores/themeInit.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { initTheme, setTheme } from '../lib/theme';
+
+describe('theme init', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('defaults to light (no data-theme attribute)', () => {
+    initTheme();
+    expect(document.documentElement.getAttribute('data-theme')).toBeNull();
+  });
+
+  it('applies persisted dark theme', () => {
+    localStorage.setItem('ws-theme', 'dark');
+    initTheme();
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('setTheme persists and applies', () => {
+    setTheme('dark');
+    expect(localStorage.getItem('ws-theme')).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    setTheme('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBeNull();
+  });
+});

--- a/apps/helper/src/stores/workspaceStore.test.ts
+++ b/apps/helper/src/stores/workspaceStore.test.ts
@@ -8,7 +8,9 @@ vi.mock('../lib/helperFetch', () => ({
 
 import { helperRequest } from '../lib/helperFetch';
 import { useChatStore } from './chatStore';
-import { useWorkspaceStore, sortRows, buildSearchParams, type FinderFile } from './workspaceStore';
+import {
+  useWorkspaceStore, sortRows, buildSearchParams, buildBrowseParams, type FinderFile,
+} from './workspaceStore';
 
 const helperRequestMock = vi.mocked(helperRequest);
 
@@ -87,6 +89,29 @@ describe('buildSearchParams', () => {
     const params = buildSearchParams('x', {});
     expect(params.toString()).toBe('q=x');
     expect(buildSearchParams('x').toString()).toBe('q=x');
+  });
+});
+
+describe('buildBrowseParams', () => {
+  it('passes sourceId + parentPath through and omits absent project/docType', () => {
+    const params = buildBrowseParams('s1', 'clients/alder', {});
+    expect(params.toString()).toBe('sourceId=s1&parentPath=clients%2Falder');
+    expect(buildBrowseParams('s1', '').toString()).toBe('sourceId=s1&parentPath=');
+  });
+
+  it('forwards project/docType only; other filter keys are not browse params', () => {
+    const params = buildBrowseParams('s1', '', {
+      project: 'Henderson Water Main Replacement',
+      docType: 'easement',
+      kind: 'pdf',
+      dateFrom: '2020-01-01',
+      sourceId: 'ignored-should-not-override',
+    });
+    expect(params.get('sourceId')).toBe('s1');
+    expect(params.get('project')).toBe('Henderson Water Main Replacement');
+    expect(params.get('docType')).toBe('easement');
+    expect(params.has('ext')).toBe(false);
+    expect(params.has('modifiedAfter')).toBe(false);
   });
 });
 
@@ -228,6 +253,19 @@ describe('browse', () => {
     expect(url.pathname).toBe('/api/v1/workspace/helper/browse');
     expect(url.searchParams.get('sourceId')).toBe('s1');
     expect(url.searchParams.get('parentPath')).toBe('clients/alder');
+  });
+
+  it('forwards project/docType from the filters slice to the browse request', async () => {
+    useWorkspaceStore.setState({
+      filters: { project: 'Henderson Water Main Replacement', docType: 'easement' },
+    });
+    helperRequestMock.mockResolvedValueOnce(ok({ entries: [] }));
+
+    await useWorkspaceStore.getState().browse('s1', '');
+
+    const url = new URL(helperRequestMock.mock.calls[0][1]);
+    expect(url.searchParams.get('project')).toBe('Henderson Water Main Replacement');
+    expect(url.searchParams.get('docType')).toBe('easement');
   });
 
   it('surfaces a browse failure and keeps the previous browsePath', async () => {

--- a/apps/helper/src/stores/workspaceStore.test.ts
+++ b/apps/helper/src/stores/workspaceStore.test.ts
@@ -8,7 +8,7 @@ vi.mock('../lib/helperFetch', () => ({
 
 import { helperRequest } from '../lib/helperFetch';
 import { useChatStore } from './chatStore';
-import { useWorkspaceStore, type FinderFile } from './workspaceStore';
+import { useWorkspaceStore, sortRows, type FinderFile } from './workspaceStore';
 
 const helperRequestMock = vi.mocked(helperRequest);
 
@@ -54,6 +54,9 @@ beforeEach(() => {
     error: null,
     filingBusy: null,
     browsePath: null,
+    // Neutral baseline for sort tests — the store's real production defaults
+    // (browse: name/asc, recents: mtime/desc) are asserted separately.
+    sort: { search: null, browse: null, recents: null },
   });
 });
 
@@ -335,5 +338,52 @@ describe('filing', () => {
     await useWorkspaceStore.getState().assignFiling('e1', '9999-999', null);
     expect(useWorkspaceStore.getState().error).toBe('not found');
     expect(useWorkspaceStore.getState().filingBusy).toBeNull();
+  });
+});
+
+describe('sort', () => {
+  it('setSort toggles direction on repeated column', () => {
+    const s = useWorkspaceStore.getState();
+    s.setSort('browse', 'name');
+    expect(useWorkspaceStore.getState().sort.browse).toEqual({ col: 'name', dir: 'asc' });
+    s.setSort('browse', 'name');
+    expect(useWorkspaceStore.getState().sort.browse).toEqual({ col: 'name', dir: 'desc' });
+  });
+
+  it('setSort resets to asc when the column changes', () => {
+    const s = useWorkspaceStore.getState();
+    s.setSort('recents', 'mtime');
+    s.setSort('recents', 'mtime');
+    expect(useWorkspaceStore.getState().sort.recents).toEqual({ col: 'mtime', dir: 'desc' });
+    s.setSort('recents', 'name');
+    expect(useWorkspaceStore.getState().sort.recents).toEqual({ col: 'name', dir: 'asc' });
+  });
+
+  it('sortRows: null sort preserves input order (relevance)', () => {
+    const rows = [file({ name: 'b' }), file({ name: 'a' })];
+    expect(sortRows(rows, null).map((r) => r.name)).toEqual(['b', 'a']);
+  });
+
+  it('sortRows orders by mtime desc and size asc; dirs before files on name in browse mode', () => {
+    const byMtime = [
+      file({ id: 'm1', name: 'old', mtime: '2026-01-01T00:00:00.000Z' }),
+      file({ id: 'm2', name: 'new', mtime: '2026-07-01T00:00:00.000Z' }),
+    ];
+    expect(sortRows(byMtime, { col: 'mtime', dir: 'desc' }).map((r) => r.name)).toEqual([
+      'new', 'old',
+    ]);
+
+    const bySize = [
+      file({ id: 's1', name: 'big', size: 2048 }),
+      file({ id: 's2', name: 'small', size: 512 }),
+    ];
+    expect(sortRows(bySize, { col: 'size', dir: 'asc' }).map((r) => r.name)).toEqual([
+      'small', 'big',
+    ]);
+
+    const rows = [file({ name: 'z', isDir: true }), file({ name: 'a', isDir: false })];
+    expect(sortRows(rows, { col: 'name', dir: 'asc' }, { dirsFirst: true }).map((r) => r.name)).toEqual([
+      'z', 'a',
+    ]);
   });
 });

--- a/apps/helper/src/stores/workspaceStore.test.ts
+++ b/apps/helper/src/stores/workspaceStore.test.ts
@@ -1,0 +1,261 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../lib/helperFetch', () => ({
+  helperRequest: vi.fn(),
+  getTauriInvoke: vi.fn(async () => null),
+  requireDevBearerToken: vi.fn(),
+}));
+
+import { helperRequest } from '../lib/helperFetch';
+import { useChatStore } from './chatStore';
+import { useWorkspaceStore, type FinderFile } from './workspaceStore';
+
+const helperRequestMock = vi.mocked(helperRequest);
+
+const AGENT_CONFIG = { api_url: 'http://localhost:3001', agent_id: 'agent-1' };
+
+function ok(body: unknown, status = 200) {
+  return { ok: true, status, body: JSON.stringify(body) };
+}
+
+function file(overrides: Partial<FinderFile> = {}): FinderFile {
+  return {
+    id: 'f1',
+    sourceId: 's1',
+    deviceKey: '__shared__',
+    relPath: 'clients/alder/b.pdf',
+    parentPath: 'clients/alder',
+    name: 'b.pdf',
+    isDir: false,
+    ext: 'pdf',
+    size: 1024,
+    mtime: '2026-07-01T00:00:00.000Z',
+    openPath: '\\\\srv\\share\\clients\\alder\\b.pdf',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useChatStore.setState({ agentConfig: AGENT_CONFIG });
+  useWorkspaceStore.setState({
+    available: null,
+    features: [],
+    sources: [],
+    results: [],
+    entries: [],
+    recent: [],
+    department: [],
+    loading: false,
+    error: null,
+    browsePath: null,
+  });
+});
+
+describe('probe', () => {
+  it('marks the workspace available and loads features + sources on 200', async () => {
+    helperRequestMock
+      .mockResolvedValueOnce(ok({ ok: true, features: ['search', 'browse', 'recents', 'open'] }))
+      .mockResolvedValueOnce(ok({ sources: [{ id: 's1', displayName: 'Alder Creek', kind: 'smb_share' }] }));
+
+    await useWorkspaceStore.getState().probe();
+
+    const s = useWorkspaceStore.getState();
+    expect(s.available).toBe(true);
+    expect(s.features).toEqual(['search', 'browse', 'recents', 'open']);
+    expect(s.sources).toEqual([{ id: 's1', displayName: 'Alder Creek', kind: 'smb_share' }]);
+    expect(s.error).toBeNull();
+    expect(helperRequestMock.mock.calls[0][1]).toBe(
+      'http://localhost:3001/api/v1/workspace/helper/capabilities',
+    );
+    expect(helperRequestMock.mock.calls[1][1]).toBe(
+      'http://localhost:3001/api/v1/workspace/helper/sources',
+    );
+  });
+
+  it('hides the workspace on 404 without surfacing an error', async () => {
+    helperRequestMock.mockResolvedValueOnce({ ok: false, status: 404, body: 'Not found' });
+
+    await useWorkspaceStore.getState().probe();
+
+    const s = useWorkspaceStore.getState();
+    expect(s.available).toBe(false);
+    expect(s.error).toBeNull();
+    expect(helperRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the workspace on 401 without surfacing an error', async () => {
+    helperRequestMock.mockResolvedValueOnce({ ok: false, status: 401, body: '{"error":"unauthorized"}' });
+
+    await useWorkspaceStore.getState().probe();
+
+    const s = useWorkspaceStore.getState();
+    expect(s.available).toBe(false);
+    expect(s.error).toBeNull();
+  });
+
+  it('hides the workspace when the probe request throws', async () => {
+    helperRequestMock.mockRejectedValueOnce(new Error('network down'));
+
+    await useWorkspaceStore.getState().probe();
+
+    const s = useWorkspaceStore.getState();
+    expect(s.available).toBe(false);
+    expect(s.error).toBeNull();
+  });
+});
+
+describe('search', () => {
+  it('populates results and encodes query params', async () => {
+    const row = file();
+    helperRequestMock.mockResolvedValueOnce(ok({ results: [row] }));
+
+    await useWorkspaceStore.getState().search('quarterly report', { sourceId: 's1', ext: 'pdf' });
+
+    const s = useWorkspaceStore.getState();
+    expect(s.results).toEqual([row]);
+    expect(s.loading).toBe(false);
+    expect(s.error).toBeNull();
+
+    const url = new URL(helperRequestMock.mock.calls[0][1]);
+    expect(url.pathname).toBe('/api/v1/workspace/helper/search');
+    expect(url.searchParams.get('q')).toBe('quarterly report');
+    expect(url.searchParams.get('sourceId')).toBe('s1');
+    expect(url.searchParams.get('ext')).toBe('pdf');
+  });
+
+  it('omits absent filters from the query string', async () => {
+    helperRequestMock.mockResolvedValueOnce(ok({ results: [] }));
+
+    await useWorkspaceStore.getState().search('henderson');
+
+    const url = new URL(helperRequestMock.mock.calls[0][1]);
+    expect(url.searchParams.get('q')).toBe('henderson');
+    expect(url.searchParams.has('sourceId')).toBe(false);
+    expect(url.searchParams.has('ext')).toBe(false);
+  });
+
+  it('surfaces an API failure as error and clears loading', async () => {
+    helperRequestMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      body: JSON.stringify({ error: 'Search unavailable' }),
+    });
+
+    await useWorkspaceStore.getState().search('x');
+
+    const s = useWorkspaceStore.getState();
+    expect(s.error).toBe('Search unavailable');
+    expect(s.loading).toBe(false);
+    expect(s.results).toEqual([]);
+  });
+
+  it('does nothing without an agent config', async () => {
+    useChatStore.setState({ agentConfig: null });
+
+    await useWorkspaceStore.getState().search('x');
+
+    expect(helperRequestMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('browse', () => {
+  it('sets entries and browsePath from a folder listing', async () => {
+    const dir = file({ id: 'd1', isDir: true, name: 'contracts', ext: null, openPath: null });
+    helperRequestMock.mockResolvedValueOnce(ok({ entries: [dir] }));
+
+    await useWorkspaceStore.getState().browse('s1', 'clients/alder');
+
+    const s = useWorkspaceStore.getState();
+    expect(s.entries).toEqual([dir]);
+    expect(s.browsePath).toEqual({ sourceId: 's1', parentPath: 'clients/alder' });
+    expect(s.loading).toBe(false);
+
+    const url = new URL(helperRequestMock.mock.calls[0][1]);
+    expect(url.pathname).toBe('/api/v1/workspace/helper/browse');
+    expect(url.searchParams.get('sourceId')).toBe('s1');
+    expect(url.searchParams.get('parentPath')).toBe('clients/alder');
+  });
+
+  it('surfaces a browse failure and keeps the previous browsePath', async () => {
+    useWorkspaceStore.setState({ browsePath: { sourceId: 's1', parentPath: '' } });
+    helperRequestMock.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      body: JSON.stringify({ error: 'Not found' }),
+    });
+
+    await useWorkspaceStore.getState().browse('s2', 'x');
+
+    const s = useWorkspaceStore.getState();
+    expect(s.error).toBe('Not found');
+    expect(s.loading).toBe(false);
+    expect(s.browsePath).toEqual({ sourceId: 's1', parentPath: '' });
+  });
+});
+
+describe('loadRecents', () => {
+  it('fills recent and department feeds', async () => {
+    const mine = file();
+    const dept = { ...file({ id: 'f2', name: 'notes.docx' }), lastActivityAt: '2026-07-17T10:00:00.000Z' };
+    helperRequestMock.mockResolvedValueOnce(ok({ recent: [mine], department: [dept] }));
+
+    await useWorkspaceStore.getState().loadRecents('todd');
+
+    const s = useWorkspaceStore.getState();
+    expect(s.recent).toEqual([mine]);
+    expect(s.department).toEqual([dept]);
+
+    const url = new URL(helperRequestMock.mock.calls[0][1]);
+    expect(url.pathname).toBe('/api/v1/workspace/helper/recents');
+    expect(url.searchParams.get('helperUser')).toBe('todd');
+  });
+
+  it('omits helperUser param when null', async () => {
+    helperRequestMock.mockResolvedValueOnce(ok({ recent: [], department: [] }));
+
+    await useWorkspaceStore.getState().loadRecents(null);
+
+    const url = new URL(helperRequestMock.mock.calls[0][1]);
+    expect(url.searchParams.has('helperUser')).toBe(false);
+  });
+});
+
+describe('recordActivity', () => {
+  it('POSTs the strict activity body', async () => {
+    helperRequestMock.mockResolvedValueOnce(ok({ recorded: true }, 201));
+
+    await useWorkspaceStore.getState().recordActivity('f1', 'open', 'todd');
+
+    expect(helperRequestMock).toHaveBeenCalledTimes(1);
+    const [, url, options] = helperRequestMock.mock.calls[0];
+    expect(url).toBe('http://localhost:3001/api/v1/workspace/helper/activity');
+    expect(options.method).toBe('POST');
+    expect(options.headers?.['Content-Type']).toBe('application/json');
+    expect(JSON.parse(options.body as string)).toEqual({
+      fileIndexId: 'f1',
+      action: 'open',
+      helperUser: 'todd',
+    });
+  });
+
+  it('omits helperUser from the body when null', async () => {
+    helperRequestMock.mockResolvedValueOnce(ok({ recorded: true }, 201));
+
+    await useWorkspaceStore.getState().recordActivity('f1', 'copy_path', null);
+
+    const [, , options] = helperRequestMock.mock.calls[0];
+    expect(JSON.parse(options.body as string)).toEqual({
+      fileIndexId: 'f1',
+      action: 'copy_path',
+    });
+  });
+
+  it('is best-effort: a failure does not surface an error', async () => {
+    helperRequestMock.mockRejectedValueOnce(new Error('network down'));
+
+    await useWorkspaceStore.getState().recordActivity('f1', 'open', null);
+
+    expect(useWorkspaceStore.getState().error).toBeNull();
+  });
+});

--- a/apps/helper/src/stores/workspaceStore.test.ts
+++ b/apps/helper/src/stores/workspaceStore.test.ts
@@ -384,6 +384,29 @@ describe('filing', () => {
     expect(useWorkspaceStore.getState().error).toBe('not found');
     expect(useWorkspaceStore.getState().filingBusy).toBeNull();
   });
+
+  it('fileByDrop delegates to assignFiling: identical API call and state transition', async () => {
+    // Run assignFiling directly first and capture the resulting call + state.
+    useWorkspaceStore.setState({ filings: [FILING] });
+    const decided = { ...FILING, status: 'reassigned', decidedProjectKey: '2025-012' };
+    helperRequestMock.mockResolvedValueOnce(ok({ filing: decided }));
+    await useWorkspaceStore.getState().assignFiling('e1', '2025-012', 'Front desk');
+    const assignCall = helperRequestMock.mock.calls[0];
+    const assignState = useWorkspaceStore.getState().filings;
+
+    // Reset to the pre-decision state and run fileByDrop with the same args.
+    vi.clearAllMocks();
+    useWorkspaceStore.setState({ filings: [FILING], filingBusy: null, error: null });
+    helperRequestMock.mockResolvedValueOnce(ok({ filing: decided }));
+    await useWorkspaceStore.getState().fileByDrop('e1', '2025-012', 'Front desk');
+    const dropCall = helperRequestMock.mock.calls[0];
+
+    expect(helperRequestMock).toHaveBeenCalledTimes(1);
+    expect(dropCall[1]).toBe(assignCall[1]); // same URL
+    expect(dropCall[2]).toEqual(assignCall[2]); // same method/headers/body
+    expect(useWorkspaceStore.getState().filings).toEqual(assignState);
+    expect(useWorkspaceStore.getState().filingBusy).toBeNull();
+  });
 });
 
 describe('sort', () => {

--- a/apps/helper/src/stores/workspaceStore.test.ts
+++ b/apps/helper/src/stores/workspaceStore.test.ts
@@ -41,13 +41,18 @@ beforeEach(() => {
   useWorkspaceStore.setState({
     available: null,
     features: [],
+    contentEnabled: null,
+    contentFeatures: [],
     sources: [],
     results: [],
     entries: [],
     recent: [],
     department: [],
+    filings: [],
+    projects: [],
     loading: false,
     error: null,
+    filingBusy: null,
     browsePath: null,
   });
 });
@@ -257,5 +262,78 @@ describe('recordActivity', () => {
     await useWorkspaceStore.getState().recordActivity('f1', 'open', null);
 
     expect(useWorkspaceStore.getState().error).toBeNull();
+  });
+});
+
+describe('content preview probe', () => {
+  it('sets contentEnabled + features when the capabilities endpoint answers 200', async () => {
+    helperRequestMock
+      .mockResolvedValueOnce(ok({ ok: true, features: ['search'] }))
+      .mockResolvedValueOnce(ok({ sources: [] }))
+      .mockResolvedValueOnce(ok({ enabled: true, features: ['contentSearch', 'filing', 'projects'] }));
+    await useWorkspaceStore.getState().probe();
+    expect(useWorkspaceStore.getState().contentEnabled).toBe(true);
+    expect(useWorkspaceStore.getState().contentFeatures).toEqual(['contentSearch', 'filing', 'projects']);
+  });
+
+  it('quietly disables content on 404 (flag off) without touching availability', async () => {
+    helperRequestMock
+      .mockResolvedValueOnce(ok({ ok: true, features: ['search'] }))
+      .mockResolvedValueOnce(ok({ sources: [] }))
+      .mockResolvedValueOnce({ ok: false, status: 404, body: '{"error":"not found"}' });
+    await useWorkspaceStore.getState().probe();
+    expect(useWorkspaceStore.getState().available).toBe(true);
+    expect(useWorkspaceStore.getState().contentEnabled).toBe(false);
+    expect(useWorkspaceStore.getState().error).toBeNull();
+  });
+});
+
+describe('filing', () => {
+  const FILING = {
+    fileIndexId: 'e1', relPath: 'Emails/Unfiled/x.eml', name: 'x.eml',
+    emailMeta: { subject: 'RE: PO 4021' }, status: null,
+    suggestedProjectKey: null, suggestedProjectLabel: null,
+    matchedEntityType: null, matchedEntityValue: null,
+    confidence: null, rationale: null, decidedProjectKey: null,
+  };
+
+  it('loadFilings fills filings and projects', async () => {
+    helperRequestMock
+      .mockResolvedValueOnce(ok({ filings: [FILING] }))
+      .mockResolvedValueOnce(ok({ projects: [{ key: '2023-041', label: 'Henderson Water Main Replacement' }] }));
+    await useWorkspaceStore.getState().loadFilings();
+    expect(useWorkspaceStore.getState().filings).toHaveLength(1);
+    expect(useWorkspaceStore.getState().projects[0].key).toBe('2023-041');
+  });
+
+  it('classifyEmail POSTs the id and swaps the row in place', async () => {
+    useWorkspaceStore.setState({ filings: [FILING] });
+    const suggested = {
+      ...FILING, status: 'suggested', suggestedProjectKey: '2023-041',
+      suggestedProjectLabel: 'Henderson Water Main Replacement', confidence: 'high',
+      rationale: 'matched City of Fairoaks PO #4021',
+    };
+    helperRequestMock.mockResolvedValueOnce(ok({ filing: suggested }));
+    await useWorkspaceStore.getState().classifyEmail('e1');
+    const [, url, init] = helperRequestMock.mock.calls[0];
+    expect(url).toContain('/filing/classify');
+    expect(JSON.parse((init as { body: string }).body)).toEqual({ fileIndexId: 'e1' });
+    expect(useWorkspaceStore.getState().filings[0].confidence).toBe('high');
+    expect(useWorkspaceStore.getState().filingBusy).toBeNull();
+  });
+
+  it('assignFiling posts projectKey + helperUser and surfaces failures', async () => {
+    useWorkspaceStore.setState({ filings: [FILING] });
+    helperRequestMock.mockResolvedValueOnce(ok({ filing: { ...FILING, status: 'reassigned', decidedProjectKey: '2025-012' } }));
+    await useWorkspaceStore.getState().assignFiling('e1', '2025-012', 'Front desk');
+    const [, url, init] = helperRequestMock.mock.calls[0];
+    expect(url).toContain('/filing/e1/assign');
+    expect(JSON.parse((init as { body: string }).body)).toEqual({ projectKey: '2025-012', helperUser: 'Front desk' });
+    expect(useWorkspaceStore.getState().filings[0].status).toBe('reassigned');
+
+    helperRequestMock.mockResolvedValueOnce({ ok: false, status: 404, body: '{"error":"not found"}' });
+    await useWorkspaceStore.getState().assignFiling('e1', '9999-999', null);
+    expect(useWorkspaceStore.getState().error).toBe('not found');
+    expect(useWorkspaceStore.getState().filingBusy).toBeNull();
   });
 });

--- a/apps/helper/src/stores/workspaceStore.test.ts
+++ b/apps/helper/src/stores/workspaceStore.test.ts
@@ -8,7 +8,7 @@ vi.mock('../lib/helperFetch', () => ({
 
 import { helperRequest } from '../lib/helperFetch';
 import { useChatStore } from './chatStore';
-import { useWorkspaceStore, sortRows, type FinderFile } from './workspaceStore';
+import { useWorkspaceStore, sortRows, buildSearchParams, type FinderFile } from './workspaceStore';
 
 const helperRequestMock = vi.mocked(helperRequest);
 
@@ -54,9 +54,54 @@ beforeEach(() => {
     error: null,
     filingBusy: null,
     browsePath: null,
+    filters: {},
     // Neutral baseline for sort tests — the store's real production defaults
     // (browse: name/asc, recents: mtime/desc) are asserted separately.
     sort: { search: null, browse: null, recents: null },
+  });
+});
+
+describe('buildSearchParams', () => {
+  it('maps dateFrom/dateTo to modifiedAfter/modifiedBefore and passes q + docType through', () => {
+    const params = buildSearchParams('x', { docType: 'easement', dateFrom: '2020-01-01' });
+    expect(params.toString()).toBe('q=x&docType=easement&modifiedAfter=2020-01-01T00%3A00%3A00.000Z');
+  });
+
+  it('maps kind to ext and passes project/sourceId through unchanged', () => {
+    const params = buildSearchParams('henderson', {
+      project: 'Henderson Water Main Replacement', sourceId: 's1', kind: 'pdf',
+    });
+    expect(params.get('q')).toBe('henderson');
+    expect(params.get('project')).toBe('Henderson Water Main Replacement');
+    expect(params.get('sourceId')).toBe('s1');
+    expect(params.get('ext')).toBe('pdf');
+    expect(params.has('kind')).toBe(false);
+  });
+
+  it('maps dateTo to modifiedBefore', () => {
+    const params = buildSearchParams('x', { dateTo: '2020-06-30' });
+    expect(params.get('modifiedBefore')).toBe('2020-06-30T00:00:00.000Z');
+  });
+
+  it('omits absent filters and defaults to just q', () => {
+    const params = buildSearchParams('x', {});
+    expect(params.toString()).toBe('q=x');
+    expect(buildSearchParams('x').toString()).toBe('q=x');
+  });
+});
+
+describe('filters slice', () => {
+  it('setFilter/clearFilter round-trip', () => {
+    useWorkspaceStore.getState().setFilter('docType', 'easement');
+    expect(useWorkspaceStore.getState().filters.docType).toBe('easement');
+    useWorkspaceStore.getState().setFilter('project', 'Henderson Water Main Replacement');
+    expect(useWorkspaceStore.getState().filters).toEqual({
+      docType: 'easement', project: 'Henderson Water Main Replacement',
+    });
+    useWorkspaceStore.getState().clearFilter('docType');
+    expect(useWorkspaceStore.getState().filters).toEqual({
+      project: 'Henderson Water Main Replacement',
+    });
   });
 });
 
@@ -118,7 +163,7 @@ describe('search', () => {
     const row = file();
     helperRequestMock.mockResolvedValueOnce(ok({ results: [row] }));
 
-    await useWorkspaceStore.getState().search('quarterly report', { sourceId: 's1', ext: 'pdf' });
+    await useWorkspaceStore.getState().search('quarterly report', { sourceId: 's1', kind: 'pdf' });
 
     const s = useWorkspaceStore.getState();
     expect(s.results).toEqual([row]);

--- a/apps/helper/src/stores/workspaceStore.ts
+++ b/apps/helper/src/stores/workspaceStore.ts
@@ -19,6 +19,36 @@ export interface FinderFile {
   mtime: string | null;
   openPath: string | null;
   score?: number;
+  // Content-preview extras (present only when the backend reports the
+  // contentSearch capability; absent fields render nothing).
+  snippet?: string | null;
+  inferredDocType?: string | null;
+  inferredProjectKey?: string | null;
+  inferredProjectLabel?: string | null;
+  declaredProjectKey?: string | null;
+  declaredProjectLabel?: string | null;
+  metadataDisagreement?: boolean;
+  group?: 'document' | 'email';
+}
+
+export interface FilingRecord {
+  fileIndexId: string;
+  relPath: string;
+  name: string;
+  emailMeta: { from?: string; to?: string[]; subject?: string; date?: string } | null;
+  status: 'suggested' | 'confirmed' | 'reassigned' | null;
+  suggestedProjectKey: string | null;
+  suggestedProjectLabel: string | null;
+  matchedEntityType: string | null;
+  matchedEntityValue: string | null;
+  confidence: 'high' | 'low' | null;
+  rationale: string | null;
+  decidedProjectKey: string | null;
+}
+
+export interface WorkspaceProject {
+  key: string;
+  label: string;
 }
 
 export type DepartmentFile = FinderFile & { lastActivityAt: string };
@@ -34,13 +64,20 @@ export type ActivityAction = 'open' | 'reveal' | 'copy_path';
 interface WorkspaceState {
   available: boolean | null; // null = not probed; false = hide UI
   features: string[];
+  // Content preview (dev estates only): null = not probed, false = absent.
+  // Gates snippets/inferred-metadata rendering and the Filing tab.
+  contentEnabled: boolean | null;
+  contentFeatures: string[];
   sources: WorkspaceSource[];
   results: FinderFile[];
   entries: FinderFile[];
   recent: FinderFile[];
   department: DepartmentFile[];
+  filings: FilingRecord[];
+  projects: WorkspaceProject[];
   loading: boolean;
   error: string | null;
+  filingBusy: string | null; // fileIndexId being classified/assigned
   browsePath: { sourceId: string; parentPath: string } | null;
 
   probe: () => Promise<void>;
@@ -52,6 +89,9 @@ interface WorkspaceState {
     action: ActivityAction,
     helperUser: string | null,
   ) => Promise<void>;
+  loadFilings: () => Promise<void>;
+  classifyEmail: (fileIndexId: string) => Promise<void>;
+  assignFiling: (fileIndexId: string, projectKey: string, helperUser: string | null) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -80,16 +120,21 @@ function parseErrorBody(body: string, fallback: string): string {
 // Store
 // ---------------------------------------------------------------------------
 
-export const useWorkspaceStore = create<WorkspaceState>((set) => ({
+export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   available: null,
   features: [],
+  contentEnabled: null,
+  contentFeatures: [],
   sources: [],
   results: [],
   entries: [],
   recent: [],
   department: [],
+  filings: [],
+  projects: [],
   loading: false,
   error: null,
+  filingBusy: null,
   browsePath: null,
 
   probe: async () => {
@@ -117,6 +162,21 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
       if (srcRes.ok) {
         const srcData = JSON.parse(srcRes.body) as { sources?: WorkspaceSource[] };
         set({ sources: srcData.sources ?? [] });
+      }
+
+      // Content-preview probe: 404 simply means the preview is off — silent.
+      try {
+        const contentRes = await helperRequest(
+          config, workspaceUrl(config, '/content/capabilities'), { method: 'GET' },
+        );
+        if (contentRes.ok) {
+          const contentData = JSON.parse(contentRes.body) as { features?: string[] };
+          set({ contentEnabled: true, contentFeatures: contentData.features ?? [] });
+        } else {
+          set({ contentEnabled: false });
+        }
+      } catch {
+        set({ contentEnabled: false });
       }
     } catch {
       // Probe is silent by design: no error surfaced, view stays hidden.
@@ -235,6 +295,102 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
     } catch (err) {
       // Best-effort: activity logging must never break the finder UI.
       console.error('[Helper] Failed to record workspace activity:', err);
+    }
+  },
+
+  loadFilings: async () => {
+    const config = agentConfig();
+    if (!config) return;
+    set({ loading: true, error: null });
+    try {
+      const [filingRes, projectsRes] = await Promise.all([
+        helperRequest(config, workspaceUrl(config, '/filing'), { method: 'GET' }),
+        helperRequest(config, workspaceUrl(config, '/content/projects'), { method: 'GET' }),
+      ]);
+      if (!filingRes.ok) {
+        set({ loading: false, error: parseErrorBody(filingRes.body, "Couldn't load unfiled mail.") });
+        return;
+      }
+      const filingData = JSON.parse(filingRes.body) as { filings?: FilingRecord[] };
+      const projectsData = projectsRes.ok
+        ? (JSON.parse(projectsRes.body) as { projects?: WorkspaceProject[] })
+        : {};
+      set({
+        filings: filingData.filings ?? [],
+        projects: projectsData.projects ?? get().projects,
+        loading: false,
+      });
+    } catch (err) {
+      set({
+        loading: false,
+        error: err instanceof Error ? err.message : "Couldn't load unfiled mail.",
+      });
+    }
+  },
+
+  classifyEmail: async (fileIndexId) => {
+    const config = agentConfig();
+    if (!config) return;
+    set({ filingBusy: fileIndexId, error: null });
+    try {
+      const res = await helperRequest(config, workspaceUrl(config, '/filing/classify'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fileIndexId }),
+      });
+      if (!res.ok) {
+        set({ filingBusy: null, error: parseErrorBody(res.body, "Couldn't sort this email.") });
+        return;
+      }
+      const data = JSON.parse(res.body) as { filing?: FilingRecord };
+      if (data.filing) {
+        set({
+          filings: get().filings.map((f) => (f.fileIndexId === fileIndexId ? data.filing! : f)),
+          filingBusy: null,
+        });
+      } else {
+        set({ filingBusy: null });
+      }
+    } catch (err) {
+      set({
+        filingBusy: null,
+        error: err instanceof Error ? err.message : "Couldn't sort this email.",
+      });
+    }
+  },
+
+  assignFiling: async (fileIndexId, projectKey, helperUser) => {
+    const config = agentConfig();
+    if (!config) return;
+    set({ filingBusy: fileIndexId, error: null });
+    try {
+      const res = await helperRequest(
+        config,
+        workspaceUrl(config, `/filing/${fileIndexId}/assign`),
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ projectKey, ...(helperUser ? { helperUser } : {}) }),
+        },
+      );
+      if (!res.ok) {
+        set({ filingBusy: null, error: parseErrorBody(res.body, "Couldn't move this email.") });
+        return;
+      }
+      const data = JSON.parse(res.body) as { filing?: FilingRecord };
+      if (data.filing) {
+        set({
+          filings: get().filings.map((f) => (f.fileIndexId === fileIndexId ? data.filing! : f)),
+          filingBusy: null,
+        });
+      } else {
+        set({ filingBusy: null });
+      }
+    } catch (err) {
+      set({
+        filingBusy: null,
+        error: err instanceof Error ? err.message : "Couldn't move this email.",
+      });
     }
   },
 }));

--- a/apps/helper/src/stores/workspaceStore.ts
+++ b/apps/helper/src/stores/workspaceStore.ts
@@ -156,6 +156,8 @@ interface WorkspaceState {
   loadFilings: () => Promise<void>;
   classifyEmail: (fileIndexId: string) => Promise<void>;
   assignFiling: (fileIndexId: string, projectKey: string, helperUser: string | null) => Promise<void>;
+  /** Drag-to-project filing (ProjectRail drop). Same code path as assignFiling. */
+  fileByDrop: (fileIndexId: string, projectKey: string, helperUser: string | null) => Promise<void>;
   setSort: (view: View, col: SortCol) => void;
   setFilter: <K extends keyof WorkspaceFilters>(key: K, value: WorkspaceFilters[K]) => void;
   clearFilter: (key: keyof WorkspaceFilters) => void;
@@ -460,6 +462,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       });
     }
   },
+
+  fileByDrop: (fileIndexId, projectKey, helperUser) =>
+    get().assignFiling(fileIndexId, projectKey, helperUser),
 
   setSort: (view, col) => {
     const current = get().sort[view];

--- a/apps/helper/src/stores/workspaceStore.ts
+++ b/apps/helper/src/stores/workspaceStore.ts
@@ -53,6 +53,37 @@ export interface WorkspaceProject {
 
 export type DepartmentFile = FinderFile & { lastActivityAt: string };
 
+// ---------------------------------------------------------------------------
+// Sorting (list-table column sort; File views only — Filing has its own UI)
+// ---------------------------------------------------------------------------
+
+export type View = 'search' | 'browse' | 'recents';
+export type SortCol = 'name' | 'project' | 'docType' | 'mtime' | 'size';
+export interface SortSpec { col: SortCol; dir: 'asc' | 'desc' }
+
+export function sortRows(
+  rows: FinderFile[],
+  sort: SortSpec | null,
+  opts: { dirsFirst?: boolean } = {},
+): FinderFile[] {
+  if (!sort) return rows;
+  const val = (r: FinderFile): string | number => {
+    switch (sort.col) {
+      case 'name': return r.name.toLowerCase();
+      case 'project': return (r.inferredProjectLabel ?? '').toLowerCase();
+      case 'docType': return (r.inferredDocType ?? '').toLowerCase();
+      case 'mtime': return Date.parse(r.mtime ?? '') || 0;
+      case 'size': return r.size ?? 0;
+    }
+  };
+  const sign = sort.dir === 'asc' ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    if (opts.dirsFirst && a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+    const av = val(a), bv = val(b);
+    return av < bv ? -sign : av > bv ? sign : 0;
+  });
+}
+
 export interface WorkspaceSource {
   id: string;
   displayName: string;
@@ -79,6 +110,7 @@ interface WorkspaceState {
   error: string | null;
   filingBusy: string | null; // fileIndexId being classified/assigned
   browsePath: { sourceId: string; parentPath: string } | null;
+  sort: Record<View, SortSpec | null>;
 
   probe: () => Promise<void>;
   search: (q: string, filters?: { sourceId?: string; ext?: string }) => Promise<void>;
@@ -92,6 +124,7 @@ interface WorkspaceState {
   loadFilings: () => Promise<void>;
   classifyEmail: (fileIndexId: string) => Promise<void>;
   assignFiling: (fileIndexId: string, projectKey: string, helperUser: string | null) => Promise<void>;
+  setSort: (view: View, col: SortCol) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -136,6 +169,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   error: null,
   filingBusy: null,
   browsePath: null,
+  sort: { search: null, browse: { col: 'name', dir: 'asc' }, recents: { col: 'mtime', dir: 'desc' } },
 
   probe: async () => {
     const config = agentConfig();
@@ -392,5 +426,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         error: err instanceof Error ? err.message : "Couldn't move this email.",
       });
     }
+  },
+
+  setSort: (view, col) => {
+    const current = get().sort[view];
+    const dir: 'asc' | 'desc' = current && current.col === col
+      ? (current.dir === 'asc' ? 'desc' : 'asc')
+      : 'asc';
+    set({ sort: { ...get().sort, [view]: { col, dir } } });
   },
 }));

--- a/apps/helper/src/stores/workspaceStore.ts
+++ b/apps/helper/src/stores/workspaceStore.ts
@@ -1,0 +1,240 @@
+import { create } from 'zustand';
+import { helperRequest, type AgentConfig } from '../lib/helperFetch';
+import { useChatStore } from './chatStore';
+
+// ---------------------------------------------------------------------------
+// Wire types (match the Workspace extension /helper/* contract)
+// ---------------------------------------------------------------------------
+
+export interface FinderFile {
+  id: string;
+  sourceId: string;
+  deviceKey: string;
+  relPath: string;
+  parentPath: string;
+  name: string;
+  isDir: boolean;
+  ext: string | null;
+  size: number | null;
+  mtime: string | null;
+  openPath: string | null;
+  score?: number;
+}
+
+export type DepartmentFile = FinderFile & { lastActivityAt: string };
+
+export interface WorkspaceSource {
+  id: string;
+  displayName: string;
+  kind: string;
+}
+
+export type ActivityAction = 'open' | 'reveal' | 'copy_path';
+
+interface WorkspaceState {
+  available: boolean | null; // null = not probed; false = hide UI
+  features: string[];
+  sources: WorkspaceSource[];
+  results: FinderFile[];
+  entries: FinderFile[];
+  recent: FinderFile[];
+  department: DepartmentFile[];
+  loading: boolean;
+  error: string | null;
+  browsePath: { sourceId: string; parentPath: string } | null;
+
+  probe: () => Promise<void>;
+  search: (q: string, filters?: { sourceId?: string; ext?: string }) => Promise<void>;
+  browse: (sourceId: string, parentPath: string) => Promise<void>;
+  loadRecents: (helperUser: string | null) => Promise<void>;
+  recordActivity: (
+    fileIndexId: string,
+    action: ActivityAction,
+    helperUser: string | null,
+  ) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function agentConfig(): AgentConfig | null {
+  return useChatStore.getState().agentConfig;
+}
+
+function workspaceUrl(config: AgentConfig, path: string, params?: URLSearchParams): string {
+  const qs = params && params.size > 0 ? `?${params.toString()}` : '';
+  return `${config.api_url}/api/v1/workspace/helper${path}${qs}`;
+}
+
+function parseErrorBody(body: string, fallback: string): string {
+  try {
+    const data = JSON.parse(body) as { error?: unknown };
+    return typeof data.error === 'string' && data.error ? data.error : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useWorkspaceStore = create<WorkspaceState>((set) => ({
+  available: null,
+  features: [],
+  sources: [],
+  results: [],
+  entries: [],
+  recent: [],
+  department: [],
+  loading: false,
+  error: null,
+  browsePath: null,
+
+  probe: async () => {
+    const config = agentConfig();
+    if (!config) return;
+
+    try {
+      const res = await helperRequest(config, workspaceUrl(config, '/capabilities'), {
+        method: 'GET',
+      });
+
+      if (!res.ok) {
+        // Extension absent or token rejected — hide the UI, say nothing.
+        set({ available: false });
+        return;
+      }
+
+      const data = JSON.parse(res.body) as { ok?: boolean; features?: string[] };
+      set({ available: true, features: data.features ?? [] });
+
+      // Best-effort source list for the Browse rail and search filter.
+      const srcRes = await helperRequest(config, workspaceUrl(config, '/sources'), {
+        method: 'GET',
+      });
+      if (srcRes.ok) {
+        const srcData = JSON.parse(srcRes.body) as { sources?: WorkspaceSource[] };
+        set({ sources: srcData.sources ?? [] });
+      }
+    } catch {
+      // Probe is silent by design: no error surfaced, view stays hidden.
+      set({ available: false });
+    }
+  },
+
+  search: async (q, filters) => {
+    const config = agentConfig();
+    if (!config) return;
+
+    const params = new URLSearchParams({ q });
+    if (filters?.sourceId) params.set('sourceId', filters.sourceId);
+    if (filters?.ext) params.set('ext', filters.ext);
+
+    set({ loading: true, error: null });
+
+    try {
+      const res = await helperRequest(config, workspaceUrl(config, '/search', params), {
+        method: 'GET',
+      });
+
+      if (!res.ok) {
+        set({ loading: false, error: parseErrorBody(res.body, 'Search is unavailable right now.') });
+        return;
+      }
+
+      const data = JSON.parse(res.body) as { results?: FinderFile[] };
+      set({ results: data.results ?? [], loading: false });
+    } catch (err) {
+      set({
+        loading: false,
+        error: err instanceof Error ? err.message : 'Search is unavailable right now.',
+      });
+    }
+  },
+
+  browse: async (sourceId, parentPath) => {
+    const config = agentConfig();
+    if (!config) return;
+
+    const params = new URLSearchParams({ sourceId, parentPath });
+
+    set({ loading: true, error: null });
+
+    try {
+      const res = await helperRequest(config, workspaceUrl(config, '/browse', params), {
+        method: 'GET',
+      });
+
+      if (!res.ok) {
+        set({ loading: false, error: parseErrorBody(res.body, "Couldn't open this folder.") });
+        return;
+      }
+
+      const data = JSON.parse(res.body) as { entries?: FinderFile[] };
+      set({
+        entries: data.entries ?? [],
+        browsePath: { sourceId, parentPath },
+        loading: false,
+      });
+    } catch (err) {
+      set({
+        loading: false,
+        error: err instanceof Error ? err.message : "Couldn't open this folder.",
+      });
+    }
+  },
+
+  loadRecents: async (helperUser) => {
+    const config = agentConfig();
+    if (!config) return;
+
+    const params = new URLSearchParams();
+    if (helperUser) params.set('helperUser', helperUser);
+
+    set({ loading: true, error: null });
+
+    try {
+      const res = await helperRequest(config, workspaceUrl(config, '/recents', params), {
+        method: 'GET',
+      });
+
+      if (!res.ok) {
+        set({ loading: false, error: parseErrorBody(res.body, "Couldn't load recent files.") });
+        return;
+      }
+
+      const data = JSON.parse(res.body) as {
+        recent?: FinderFile[];
+        department?: DepartmentFile[];
+      };
+      set({ recent: data.recent ?? [], department: data.department ?? [], loading: false });
+    } catch (err) {
+      set({
+        loading: false,
+        error: err instanceof Error ? err.message : "Couldn't load recent files.",
+      });
+    }
+  },
+
+  recordActivity: async (fileIndexId, action, helperUser) => {
+    const config = agentConfig();
+    if (!config) return;
+
+    try {
+      await helperRequest(config, workspaceUrl(config, '/activity'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          fileIndexId,
+          action,
+          ...(helperUser ? { helperUser } : {}),
+        }),
+      });
+    } catch (err) {
+      // Best-effort: activity logging must never break the finder UI.
+      console.error('[Helper] Failed to record workspace activity:', err);
+    }
+  },
+}));

--- a/apps/helper/src/stores/workspaceStore.ts
+++ b/apps/helper/src/stores/workspaceStore.ts
@@ -121,6 +121,24 @@ export function buildSearchParams(q: string, filters: WorkspaceFilters = {}): UR
   return params;
 }
 
+/**
+ * Pure query-param builder for /helper/browse. Unlike search, browse's
+ * Architecture-authorized extension is just project + docType (Date/Source/
+ * Kind are Search-only — Source is a path segment there, not a filter, and
+ * the browse endpoint doesn't accept the other three params), so every other
+ * WorkspaceFilters key is deliberately ignored here.
+ */
+export function buildBrowseParams(
+  sourceId: string,
+  parentPath: string,
+  filters: WorkspaceFilters = {},
+): URLSearchParams {
+  const params = new URLSearchParams({ sourceId, parentPath });
+  if (filters.project) params.set('project', filters.project);
+  if (filters.docType) params.set('docType', filters.docType);
+  return params;
+}
+
 export type ActivityAction = 'open' | 'reveal' | 'copy_path';
 
 interface WorkspaceState {
@@ -287,7 +305,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     const config = agentConfig();
     if (!config) return;
 
-    const params = new URLSearchParams({ sourceId, parentPath });
+    // project/docType are shared state (the same `filters` slice Search's
+    // chips write to) — the Browse tab's own chips write to the identical
+    // slice, so reading it here means callers never need to thread filters
+    // through every browse() call site (rail clicks, breadcrumbs, drill-down).
+    const params = buildBrowseParams(sourceId, parentPath, get().filters);
 
     set({ loading: true, error: null });
 

--- a/apps/helper/src/stores/workspaceStore.ts
+++ b/apps/helper/src/stores/workspaceStore.ts
@@ -90,6 +90,37 @@ export interface WorkspaceSource {
   kind: string;
 }
 
+// ---------------------------------------------------------------------------
+// Filter chips (Search view; content-preview fields are absent when the flag
+// is off, so those chips simply have nothing to list).
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceFilters {
+  project?: string;
+  docType?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  sourceId?: string;
+  kind?: string;
+}
+
+/**
+ * Pure query-param builder for /helper/search: dateFrom/dateTo become
+ * modifiedAfter/modifiedBefore (ISO datetimes, as the extension's schema
+ * requires), kind becomes ext (the wire field name), everything else passes
+ * through unchanged. Insertion order matches the filters' declared order.
+ */
+export function buildSearchParams(q: string, filters: WorkspaceFilters = {}): URLSearchParams {
+  const params = new URLSearchParams({ q });
+  if (filters.sourceId) params.set('sourceId', filters.sourceId);
+  if (filters.kind) params.set('ext', filters.kind);
+  if (filters.project) params.set('project', filters.project);
+  if (filters.docType) params.set('docType', filters.docType);
+  if (filters.dateFrom) params.set('modifiedAfter', new Date(filters.dateFrom).toISOString());
+  if (filters.dateTo) params.set('modifiedBefore', new Date(filters.dateTo).toISOString());
+  return params;
+}
+
 export type ActivityAction = 'open' | 'reveal' | 'copy_path';
 
 interface WorkspaceState {
@@ -111,9 +142,10 @@ interface WorkspaceState {
   filingBusy: string | null; // fileIndexId being classified/assigned
   browsePath: { sourceId: string; parentPath: string } | null;
   sort: Record<View, SortSpec | null>;
+  filters: WorkspaceFilters;
 
   probe: () => Promise<void>;
-  search: (q: string, filters?: { sourceId?: string; ext?: string }) => Promise<void>;
+  search: (q: string, filters?: WorkspaceFilters) => Promise<void>;
   browse: (sourceId: string, parentPath: string) => Promise<void>;
   loadRecents: (helperUser: string | null) => Promise<void>;
   recordActivity: (
@@ -125,6 +157,8 @@ interface WorkspaceState {
   classifyEmail: (fileIndexId: string) => Promise<void>;
   assignFiling: (fileIndexId: string, projectKey: string, helperUser: string | null) => Promise<void>;
   setSort: (view: View, col: SortCol) => void;
+  setFilter: <K extends keyof WorkspaceFilters>(key: K, value: WorkspaceFilters[K]) => void;
+  clearFilter: (key: keyof WorkspaceFilters) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -169,6 +203,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   error: null,
   filingBusy: null,
   browsePath: null,
+  filters: {},
   sort: { search: null, browse: { col: 'name', dir: 'asc' }, recents: { col: 'mtime', dir: 'desc' } },
 
   probe: async () => {
@@ -222,9 +257,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     const config = agentConfig();
     if (!config) return;
 
-    const params = new URLSearchParams({ q });
-    if (filters?.sourceId) params.set('sourceId', filters.sourceId);
-    if (filters?.ext) params.set('ext', filters.ext);
+    const params = buildSearchParams(q, filters);
 
     set({ loading: true, error: null });
 
@@ -434,5 +467,15 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       ? (current.dir === 'asc' ? 'desc' : 'asc')
       : 'asc';
     set({ sort: { ...get().sort, [view]: { col, dir } } });
+  },
+
+  setFilter: (key, value) => {
+    set({ filters: { ...get().filters, [key]: value } });
+  },
+
+  clearFilter: (key) => {
+    const next = { ...get().filters };
+    delete next[key];
+    set({ filters: next });
   },
 }));

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -985,6 +985,164 @@ body {
   border-radius: 3px;
 }
 
+/* ----------------------------------------------------------
+   File table (sortable list-table — search/browse/recents)
+   ---------------------------------------------------------- */
+.ws-file-table {
+  display: flex;
+  flex-direction: column;
+}
+
+.ws-file-table-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 140px 120px 110px 70px;
+  gap: 8px;
+  padding: 4px 8px 6px;
+  position: sticky;
+  top: 0;
+  background: var(--ws-canvas);
+  z-index: 1;
+}
+
+.ws-file-table-colbtn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border: none;
+  background: transparent;
+  padding: 2px 0;
+  font-size: var(--ws-text-11);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--ws-text-tertiary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.ws-file-table-colbtn:hover {
+  color: var(--ws-text-secondary);
+}
+
+.ws-file-table-chevron {
+  font-size: var(--ws-text-11);
+  color: var(--ws-text-tertiary);
+}
+
+.ws-file-table-body {
+  display: flex;
+  flex-direction: column;
+}
+
+.ws-file-table-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 140px 120px 110px 70px;
+  gap: 8px;
+  align-items: center;
+  padding: 7px 8px;
+  border-radius: var(--ws-radius-control);
+  transition: background var(--ws-dur-fast) var(--ws-ease);
+}
+
+.ws-file-table-row:hover {
+  background: var(--ws-accent-soft);
+}
+
+.ws-file-table-cell {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ws-file-table-name-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  white-space: normal;
+}
+
+.ws-file-table-name {
+  font-size: var(--ws-text-13);
+  font-weight: 500;
+  color: var(--ws-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ws-file-table-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: var(--ws-text-12);
+  color: var(--ws-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ws-file-table-secondary {
+  font-size: var(--ws-text-12);
+  color: var(--ws-text-secondary);
+}
+
+.ws-file-table-tertiary {
+  font-size: var(--ws-text-12);
+  color: var(--ws-text-tertiary);
+}
+
+.ws-file-table-open {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0;
+  pointer-events: none;
+  border: 1px solid var(--ws-border);
+  border-radius: var(--ws-radius-control);
+  background: var(--ws-surface);
+  color: var(--ws-ink);
+  font-size: var(--ws-text-12);
+  padding: 3px 10px;
+  cursor: pointer;
+  box-shadow: var(--ws-shadow-1);
+  transition: opacity var(--ws-dur-fast) var(--ws-ease);
+}
+
+.ws-file-table-row:hover .ws-file-table-open,
+.ws-file-table-row:focus-within .ws-file-table-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.ws-file-table-snippet {
+  font-size: var(--ws-text-12);
+  color: var(--ws-text-secondary);
+  white-space: normal;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.ws-file-table-snippet b {
+  color: var(--ws-ink);
+  font-weight: 600;
+}
+
+.ws-file-table-mismatch {
+  border-left: 2px solid var(--ws-border);
+  padding-left: 6px;
+  color: var(--ws-ink);
+}
+
+.ws-file-table-open-error {
+  font-size: var(--ws-text-12);
+  color: var(--ws-text-tertiary);
+  white-space: normal;
+}
+
 .helper-file-row {
   display: flex;
   align-items: center;
@@ -1000,10 +1158,6 @@ body {
 
 .helper-file-row:hover {
   background: var(--bg-tertiary);
-}
-
-.helper-file-row-dir {
-  cursor: pointer;
 }
 
 .helper-file-main {

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -1196,6 +1196,13 @@ body {
   white-space: normal;
 }
 
+.ws-file-table-name-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
 .ws-file-table-name {
   font-size: var(--ws-text-13);
   font-weight: 500;
@@ -1203,6 +1210,22 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
+}
+
+.ws-file-table-source {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: var(--ws-accent-soft);
+  color: var(--ws-accent);
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1;
 }
 
 .ws-file-table-meta {

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -131,8 +131,8 @@ body {
   align-items: center;
   justify-content: space-between;
   padding: 10px 14px;
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border);
+  background: var(--ws-canvas);
+  border-bottom: 1px solid var(--ws-border-subtle);
   -webkit-app-region: drag;
   app-region: drag;
   user-select: none;
@@ -161,9 +161,9 @@ body {
 }
 
 .helper-title {
-  font-size: 13px;
+  font-size: var(--ws-text-15);
   font-weight: 600;
-  color: var(--text-primary);
+  color: var(--ws-ink);
   letter-spacing: 0.01em;
   pointer-events: none;
 }
@@ -206,21 +206,20 @@ body {
   align-items: center;
   justify-content: center;
   padding: 6px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
+  border: 1px solid var(--ws-border);
+  border-radius: var(--ws-radius-control);
+  background: var(--ws-surface);
+  color: var(--ws-ink);
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
-  transition: background var(--transition-fast), border-color var(--transition-fast);
+  transition: background var(--ws-dur-fast) var(--ws-ease), box-shadow var(--ws-dur-fast) var(--ws-ease);
   -webkit-app-region: no-drag;
   user-select: none;
 }
 
 .helper-btn:hover {
-  background: var(--bg-hover);
-  border-color: var(--text-muted);
+  box-shadow: var(--ws-shadow-1);
 }
 
 .helper-btn:active {
@@ -895,32 +894,35 @@ body {
    ---------------------------------------------------------- */
 .helper-workspace-tabs {
   display: flex;
-  gap: 4px;
-  padding: 6px 14px 0;
-  background: var(--bg-primary);
-  border-bottom: 1px solid var(--border);
+  padding: 8px 14px;
+  background: var(--ws-canvas);
+  border-bottom: 1px solid var(--ws-border-subtle);
   flex-shrink: 0;
 }
 
-.helper-workspace-tab {
-  padding: 6px 12px;
-  border: none;
-  border-bottom: 2px solid transparent;
+.ws-segmented {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  background: var(--ws-accent-soft);
+  border-radius: var(--ws-radius-control);
+}
+
+.ws-segmented-item {
+  border: 0;
   background: transparent;
-  color: var(--text-secondary);
-  font-size: 12px;
-  font-weight: 500;
+  padding: 4px 12px;
+  font-size: var(--ws-text-13);
+  color: var(--ws-text-secondary);
+  border-radius: calc(var(--ws-radius-control) - 2px);
   cursor: pointer;
-  transition: color var(--transition-fast), border-color var(--transition-fast);
+  transition: background var(--ws-dur-fast) var(--ws-ease), color var(--ws-dur-fast) var(--ws-ease);
 }
 
-.helper-workspace-tab:hover {
-  color: var(--text-primary);
-}
-
-.helper-workspace-tab-active {
-  color: var(--text-primary);
-  border-bottom-color: var(--accent);
+.ws-segmented-item[aria-selected='true'] {
+  background: var(--ws-surface);
+  color: var(--ws-ink);
+  box-shadow: var(--ws-shadow-1);
 }
 
 .helper-workspace-body {

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -20,34 +20,32 @@
    CSS Variables
    ---------------------------------------------------------- */
 :root {
-  --bg-primary: #1a1b1e;
-  --bg-secondary: #25262b;
-  --bg-tertiary: #2c2e33;
-  --bg-hover: #343a40;
-  --bg-input: #2c2e33;
+  /* Legacy dark-era aliases remapped onto --ws-* tokens so every screen that
+     still references them re-coheres in BOTH light and dark themes. The raw
+     hex values above were dark-only and rendered light-on-light once html/body
+     moved to --ws-canvas. Keep these as thin aliases; do not reintroduce hex. */
+  --bg-primary: var(--ws-canvas);
+  --bg-secondary: var(--ws-surface);
+  --bg-tertiary: var(--ws-raised);
+  --bg-hover: var(--ws-accent-soft);
+  --bg-input: var(--ws-surface);
 
-  --text-primary: #e4e5e7;
-  --text-secondary: #909296;
-  --text-muted: #6b6e73;
-  --text-placeholder: #555860;
+  --text-primary: var(--ws-ink);
+  --text-secondary: var(--ws-text-secondary);
+  --text-muted: var(--ws-text-tertiary);
+  --text-placeholder: var(--ws-text-tertiary);
 
-  --accent: #4c9aff;
-  --accent-hover: #3d8af0;
-  --accent-subtle: rgba(76, 154, 255, 0.12);
+  --accent: var(--ws-accent);
+  --accent-subtle: var(--ws-accent-soft);
 
-  --user-bubble: #2b5a9e;
-  --user-bubble-text: #e4e5e7;
-  --assistant-bubble: #2c2e33;
-  --assistant-bubble-text: #e4e5e7;
+  --error-bg: var(--ws-danger-soft);
+  --error-text: var(--ws-danger);
+  --error-border: var(--ws-danger-soft);
 
-  --error-bg: rgba(255, 69, 58, 0.12);
-  --error-text: #ff6b6b;
-  --error-border: rgba(255, 69, 58, 0.25);
+  --success: var(--ws-success);
 
-  --success: #51cf66;
-
-  --border: #373a40;
-  --border-light: #2c2e33;
+  --border: var(--ws-border);
+  --border-light: var(--ws-border-subtle);
 
   --radius-sm: 6px;
   --radius-md: 10px;
@@ -1177,6 +1175,25 @@ body {
 .ws-file-table-row.ws-row-selected {
   background: var(--ws-accent-soft);
   box-shadow: inset 0 0 0 2px var(--ws-accent);
+}
+
+/* Narrow-window layout: the native Tauri popup opens at inner_size 380x600,
+   below the ~488px minimum of the 5-column grid. At <=480px collapse to three
+   tracks and hide the Modified (4th) + Size (5th) columns — header buttons AND
+   row cells — via display:none so the DOM order and grid column counts stay in
+   lockstep (the grid simply lays out the 3 remaining tracks). */
+@media (max-width: 480px) {
+  .ws-file-table-header,
+  .ws-file-table-row {
+    grid-template-columns: minmax(0, 1fr) 90px 80px;
+  }
+
+  .ws-file-table-header > .ws-file-table-colbtn:nth-child(4),
+  .ws-file-table-header > .ws-file-table-colbtn:nth-child(5),
+  .ws-file-table-row > .ws-file-table-cell:nth-child(4),
+  .ws-file-table-row > .ws-file-table-cell:nth-child(5) {
+    display: none;
+  }
 }
 
 .ws-file-table-cell {

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -1406,3 +1406,47 @@ body {
   .helper-sessionbanner { animation: none; }
   .helper-sessionbanner-dot { animation: none; }
 }
+
+/* ---- Workspace content preview (dev estates): snippets, inferred metadata,
+   filing panel. Calm/editorial; no amber except genuine system state. ---- */
+.helper-file-snippet {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: normal;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+.helper-file-snippet b {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.helper-file-inferred {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: normal;
+}
+.helper-file-mismatch {
+  border-left: 2px solid var(--helper-border);
+  padding-left: 6px;
+  color: var(--text-primary);
+}
+.helper-filing-row .helper-file-actions {
+  align-items: center;
+}
+.helper-filing-banner {
+  font-size: 11px;
+  white-space: normal;
+}
+.helper-filing-confident {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+.helper-filing-tentative {
+  color: var(--text-muted);
+}
+.helper-filing-decided {
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -871,6 +871,261 @@ body {
 }
 
 /* ----------------------------------------------------------
+   Workspace Files View
+   ---------------------------------------------------------- */
+.helper-workspace-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 6px 14px 0;
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.helper-workspace-tab {
+  padding: 6px 12px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.helper-workspace-tab:hover {
+  color: var(--text-primary);
+}
+
+.helper-workspace-tab-active {
+  color: var(--text-primary);
+  border-bottom-color: var(--accent);
+}
+
+.helper-workspace-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.helper-workspace-toolbar {
+  display: flex;
+  gap: 8px;
+  padding: 10px 14px 6px;
+  flex-shrink: 0;
+}
+
+.helper-workspace-search-input {
+  flex: 1;
+  min-width: 0;
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+
+.helper-workspace-search-input::placeholder {
+  color: var(--text-placeholder);
+}
+
+.helper-workspace-search-input:focus {
+  border-color: var(--accent);
+}
+
+.helper-workspace-select {
+  max-width: 120px;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  outline: none;
+}
+
+.helper-workspace-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 8px 8px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.helper-workspace-list::-webkit-scrollbar {
+  width: 5px;
+}
+
+.helper-workspace-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.helper-workspace-list::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+.helper-file-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 8px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  text-align: left;
+  transition: background var(--transition-fast);
+}
+
+.helper-file-row:hover {
+  background: var(--bg-tertiary);
+}
+
+.helper-file-row-dir {
+  cursor: pointer;
+}
+
+.helper-file-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.helper-file-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.helper-file-meta {
+  font-size: 11px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.helper-file-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.helper-file-copied {
+  font-size: 11px;
+  color: var(--success);
+}
+
+.helper-workspace-browse {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.helper-workspace-rail {
+  width: 104px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 6px;
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+}
+
+.helper-workspace-rail-item {
+  padding: 6px 8px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.helper-workspace-rail-item:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.helper-workspace-rail-item-active {
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+
+.helper-workspace-rail-empty {
+  padding: 6px 8px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.helper-workspace-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.helper-workspace-breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1px;
+  padding: 8px 10px 2px;
+  font-size: 11px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.helper-workspace-crumb {
+  padding: 1px 3px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.helper-workspace-crumb:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.helper-workspace-crumb-sep {
+  color: var(--text-muted);
+}
+
+.helper-workspace-section-title {
+  padding: 10px 8px 2px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+/* ----------------------------------------------------------
    Tool Approval Popup
    ---------------------------------------------------------- */
 .helper-approval-overlay {

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -1382,55 +1382,6 @@ body {
   white-space: normal;
 }
 
-.helper-file-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 7px 8px;
-  border: none;
-  border-radius: var(--radius-md);
-  background: transparent;
-  text-align: left;
-  transition: background var(--transition-fast);
-}
-
-.helper-file-row:hover {
-  background: var(--bg-tertiary);
-}
-
-.helper-file-main {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.helper-file-name {
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.helper-file-meta {
-  font-size: 11px;
-  color: var(--text-muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.helper-file-actions {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  flex-shrink: 0;
-}
-
 .helper-file-copied {
   font-size: 11px;
   color: var(--success);
@@ -1838,21 +1789,145 @@ body {
   padding-left: 6px;
   color: var(--text-primary);
 }
-.helper-filing-row .helper-file-actions {
-  align-items: center;
+/* ----------------------------------------------------------
+   Filing tab: cards column + ProjectRail drop targets. ws-* tokens
+   (light-default reshape) — see FilingCard.tsx / ProjectRail.tsx.
+   ---------------------------------------------------------- */
+.ws-filing-layout {
+  flex: 1;
+  display: flex;
+  min-height: 0;
 }
-.helper-filing-banner {
-  font-size: 11px;
+
+.ws-filing-cards {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 4px 8px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ws-filing-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--ws-surface);
+  border-radius: var(--ws-radius-surface);
+  box-shadow: var(--ws-shadow-1);
+  padding: 12px;
+  cursor: grab;
+  max-height: 240px;
+  overflow: hidden;
+  transition: opacity var(--ws-dur-slow) var(--ws-ease),
+    max-height var(--ws-dur-slow) var(--ws-ease),
+    padding var(--ws-dur-slow) var(--ws-ease);
+}
+
+.ws-filing-card-settling {
+  opacity: 0;
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.ws-filing-card-subject {
+  font-size: var(--ws-text-13);
+  font-weight: 600;
+  color: var(--ws-ink);
+}
+
+.ws-filing-card-meta {
+  font-size: var(--ws-text-12);
+  color: var(--ws-text-secondary);
+}
+
+.ws-filing-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.ws-filing-card-select {
+  padding: 5px 8px;
+  border: 1px solid var(--ws-border);
+  border-radius: var(--ws-radius-control);
+  background: var(--ws-surface);
+  color: var(--ws-text-secondary);
+  font-family: var(--ws-font);
+  font-size: var(--ws-text-12);
+  outline: none;
+}
+
+.ws-chip {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  max-width: 100%;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: var(--ws-text-12);
   white-space: normal;
 }
-.helper-filing-confident {
-  color: var(--text-primary);
-  font-weight: 500;
+
+.ws-chip-success {
+  background: var(--ws-success-soft);
+  color: var(--ws-success);
 }
-.helper-filing-tentative {
-  color: var(--text-muted);
+
+.ws-chip-warning {
+  background: var(--ws-warning-soft);
+  color: var(--ws-warning);
 }
-.helper-filing-decided {
-  color: var(--text-muted);
-  font-style: italic;
+
+.ws-btn-accent {
+  border: none;
+  border-radius: var(--ws-radius-control);
+  background: var(--ws-accent);
+  color: var(--ws-accent-contrast);
+  padding: 6px 14px;
+  font-size: var(--ws-text-12);
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter var(--ws-dur-fast) var(--ws-ease);
+}
+
+.ws-btn-accent:hover {
+  filter: brightness(1.08);
+}
+
+.ws-project-rail {
+  width: 180px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 6px;
+  border-left: 1px solid var(--ws-border);
+  overflow-y: auto;
+}
+
+.ws-project-rail-item {
+  padding: 6px 8px;
+  border: 1px solid transparent;
+  border-radius: var(--ws-radius-control);
+  font-size: var(--ws-text-13);
+  color: var(--ws-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: background var(--ws-dur-fast) var(--ws-ease), border-color var(--ws-dur-fast) var(--ws-ease);
+}
+
+.ws-project-rail-item.ws-drop-target {
+  background: var(--ws-accent-soft);
+  border-color: var(--ws-accent);
+}
+
+.ws-project-rail-empty {
+  padding: 6px 8px;
+  font-size: var(--ws-text-12);
+  color: var(--ws-text-tertiary);
 }

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -1174,6 +1174,11 @@ body {
   background: var(--ws-accent-soft);
 }
 
+.ws-file-table-row.ws-row-selected {
+  background: var(--ws-accent-soft);
+  box-shadow: inset 0 0 0 2px var(--ws-accent);
+}
+
 .ws-file-table-cell {
   min-width: 0;
   overflow: hidden;

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -106,7 +106,7 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: var(--bg-primary);
+  background: var(--ws-canvas);
 }
 
 .helper-center {
@@ -323,7 +323,7 @@ body {
   align-items: center;
   justify-content: center;
   gap: 6px;
-  color: var(--text-muted);
+  color: var(--ws-text-secondary);
   text-align: center;
 }
 
@@ -335,7 +335,7 @@ body {
 .helper-empty p:first-child {
   font-size: 15px;
   font-weight: 500;
-  color: var(--text-secondary);
+  color: var(--ws-ink);
 }
 
 /* ----------------------------------------------------------
@@ -344,7 +344,6 @@ body {
 .helper-message {
   max-width: 85%;
   padding: 8px 12px;
-  border-radius: var(--radius-lg);
   font-size: 13px;
   line-height: 1.45;
   word-wrap: break-word;
@@ -365,15 +364,13 @@ body {
 
 .helper-message-user {
   align-self: flex-end;
-  background: var(--user-bubble);
-  color: var(--user-bubble-text);
+  color: var(--ws-ink);
   border-bottom-right-radius: var(--radius-sm);
 }
 
 .helper-message-assistant {
   align-self: flex-start;
-  background: var(--assistant-bubble);
-  color: var(--assistant-bubble-text);
+  color: var(--ws-ink);
   border-bottom-left-radius: var(--radius-sm);
 }
 
@@ -404,7 +401,7 @@ body {
 
 .helper-message-assistant .helper-message-content strong {
   font-weight: 600;
-  color: var(--text-primary);
+  color: var(--ws-ink);
 }
 
 .helper-message-assistant .helper-message-content em {
@@ -414,17 +411,17 @@ body {
 .helper-message-assistant .helper-message-content code {
   padding: 1px 5px;
   border-radius: 4px;
-  background: var(--bg-primary);
+  background: var(--ws-canvas);
   font-family: var(--font-mono);
   font-size: 12px;
-  color: var(--accent);
+  color: var(--ws-accent);
 }
 
 .helper-message-assistant .helper-message-content pre {
   margin: 6px 0;
   padding: 8px 10px;
   border-radius: var(--radius-sm);
-  background: var(--bg-primary);
+  background: var(--ws-canvas);
   overflow-x: auto;
   white-space: pre;
 }
@@ -432,7 +429,7 @@ body {
 .helper-message-assistant .helper-message-content pre code {
   padding: 0;
   background: none;
-  color: var(--text-secondary);
+  color: var(--ws-text-secondary);
   font-size: 11px;
   line-height: 1.5;
 }
@@ -448,7 +445,7 @@ body {
 }
 
 .helper-message-assistant .helper-message-content a {
-  color: var(--accent);
+  color: var(--ws-accent);
   text-decoration: none;
 }
 
@@ -462,7 +459,7 @@ body {
   font-size: 13px;
   font-weight: 600;
   margin: 8px 0 4px;
-  color: var(--text-primary);
+  color: var(--ws-ink);
 }
 
 .helper-message-assistant .helper-message-content table {
@@ -475,26 +472,26 @@ body {
 .helper-message-assistant .helper-message-content th,
 .helper-message-assistant .helper-message-content td {
   padding: 3px 8px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--ws-border);
   text-align: left;
 }
 
 .helper-message-assistant .helper-message-content th {
-  background: var(--bg-primary);
+  background: var(--ws-canvas);
   font-weight: 600;
-  color: var(--text-primary);
+  color: var(--ws-ink);
 }
 
 .helper-message-assistant .helper-message-content blockquote {
   margin: 6px 0;
   padding: 4px 10px;
-  border-left: 3px solid var(--border);
-  color: var(--text-secondary);
+  border-left: 3px solid var(--ws-border);
+  color: var(--ws-text-secondary);
 }
 
 .helper-message-assistant .helper-message-content hr {
   border: none;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--ws-border);
   margin: 8px 0;
 }
 
@@ -512,7 +509,7 @@ body {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--text-muted);
+  background: var(--ws-text-tertiary);
   animation: thinkingBounce 1.4s ease-in-out infinite;
 }
 
@@ -523,7 +520,7 @@ body {
 .helper-thinking-label {
   margin-left: 4px;
   font-size: 12px;
-  color: var(--text-muted);
+  color: var(--ws-text-secondary);
 }
 
 @keyframes thinkingBounce {
@@ -545,7 +542,7 @@ body {
   width: 2px;
   height: 14px;
   margin-left: 2px;
-  background: var(--accent);
+  background: var(--ws-accent);
   vertical-align: text-bottom;
   animation: blink 800ms step-end infinite;
 }
@@ -569,8 +566,7 @@ body {
   gap: 8px;
   padding: 6px 12px;
   border-radius: var(--radius-md);
-  background: var(--accent-subtle);
-  color: var(--accent);
+  background: var(--ws-accent-soft);
   font-size: 12px;
   font-weight: 500;
   align-self: flex-start;
@@ -585,8 +581,8 @@ body {
   display: inline-block;
   width: 14px;
   height: 14px;
-  border: 2px solid var(--border);
-  border-top-color: var(--accent);
+  border: 2px solid var(--ws-border);
+  border-top-color: var(--ws-accent);
   border-radius: 50%;
   animation: spin 700ms linear infinite;
   flex-shrink: 0;
@@ -606,8 +602,7 @@ body {
   align-items: flex-end;
   gap: 8px;
   padding: 10px 14px;
-  background: var(--bg-secondary);
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--ws-border-subtle);
   flex-shrink: 0;
 }
 
@@ -616,24 +611,22 @@ body {
   min-height: 34px;
   max-height: 100px;
   padding: 7px 10px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--ws-border);
   border-radius: var(--radius-md);
-  background: var(--bg-input);
-  color: var(--text-primary);
-  font-family: var(--font-sans);
+  font-family: var(--ws-font);
   font-size: 13px;
   line-height: 1.4;
   resize: none;
   outline: none;
-  transition: border-color var(--transition-fast);
+  transition: border-color var(--ws-dur-fast) var(--ws-ease);
 }
 
 .helper-input::placeholder {
-  color: var(--text-placeholder);
+  color: var(--ws-text-tertiary);
 }
 
 .helper-input:focus {
-  border-color: var(--accent);
+  border-color: var(--ws-accent);
 }
 
 .helper-input:disabled {
@@ -648,19 +641,17 @@ body {
   padding: 7px 14px;
   border: none;
   border-radius: var(--radius-md);
-  background: var(--accent);
-  color: #ffffff;
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
-  transition: background var(--transition-fast), transform var(--transition-fast);
+  transition: filter var(--ws-dur-fast) var(--ws-ease), transform var(--ws-dur-fast) var(--ws-ease);
   -webkit-app-region: no-drag;
   flex-shrink: 0;
   height: 34px;
 }
 
 .helper-btn-send:hover:not(:disabled) {
-  background: var(--accent-hover);
+  filter: brightness(0.92);
 }
 
 .helper-btn-send:active:not(:disabled) {

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -1030,6 +1030,12 @@ body {
   color: var(--success);
 }
 
+.helper-file-open-error {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: normal;
+}
+
 .helper-workspace-browse {
   flex: 1;
   display: flex;

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -1382,6 +1382,96 @@ body {
   white-space: normal;
 }
 
+/* ----------------------------------------------------------
+   Empty state
+   ---------------------------------------------------------- */
+.ws-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 40px 20px;
+  text-align: center;
+}
+
+.ws-empty-state-title {
+  font-size: var(--ws-text-15);
+  font-weight: 600;
+  color: var(--ws-text-secondary);
+}
+
+.ws-empty-state-hint {
+  font-size: var(--ws-text-13);
+  color: var(--ws-text-tertiary);
+  max-width: 320px;
+}
+
+/* ----------------------------------------------------------
+   Skeleton rows (loading)
+   ---------------------------------------------------------- */
+.ws-skeleton-rows {
+  display: flex;
+  flex-direction: column;
+}
+
+.ws-skeleton-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 7px 8px;
+}
+
+.ws-skeleton-bar {
+  display: block;
+  border-radius: var(--ws-radius-control);
+  background: var(--ws-border-subtle);
+  animation: ws-shimmer 1.2s ease-in-out infinite;
+}
+
+.ws-skeleton-bar-name {
+  width: 60%;
+  height: var(--ws-text-13);
+}
+
+.ws-skeleton-bar-meta {
+  width: 30%;
+  height: var(--ws-text-11);
+}
+
+@keyframes ws-shimmer {
+  0%, 100% {
+    background-color: var(--ws-border-subtle);
+  }
+  50% {
+    background-color: var(--ws-canvas);
+  }
+}
+
+/* ----------------------------------------------------------
+   Error row (list-level fetch failure, with retry)
+   ---------------------------------------------------------- */
+.ws-error-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 24px 20px;
+  font-size: var(--ws-text-13);
+  color: var(--ws-danger);
+  text-align: center;
+}
+
+.ws-error-retry {
+  border: none;
+  background: transparent;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 .helper-file-copied {
   font-size: 11px;
   color: var(--success);

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -3,6 +3,19 @@
    Dark theme, compact, frameless, 380x600 popup
    ============================================================ */
 
+/* Workspace design tokens + Tailwind layers. This is the only stylesheet
+   index.html actually loads (<link rel="stylesheet" href="/src/styles.css">),
+   so the --ws-* custom properties and Tailwind's generated utility CSS must
+   be pulled in here. (src/styles/globals.css duplicates this @import +
+   @tailwind block but is not linked/imported from anywhere and stays
+   orphaned — see task-2-report.md for why its scrollbar rules were not
+   used either.) */
+@import './styles/tokens.css';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 /* ----------------------------------------------------------
    CSS Variables
    ---------------------------------------------------------- */

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -965,8 +965,8 @@ body {
 }
 
 /* ----------------------------------------------------------
-   Filter chips (Search toolbar) — plain positioned listbox for now;
-   Task 7 swaps the menu body for a Radix DropdownMenu.
+   Filter chips (Search toolbar) — each chip is a Radix DropdownMenu;
+   the menu body below styles DropdownMenu.Content/Item.
    ---------------------------------------------------------- */
 .ws-filter-chip-row {
   display: flex;
@@ -974,10 +974,6 @@ body {
   gap: 6px;
   padding: 0 14px 8px;
   flex-shrink: 0;
-}
-
-.ws-filter-chip-wrap {
-  position: relative;
 }
 
 .ws-filter-chip {
@@ -1020,9 +1016,6 @@ body {
 }
 
 .ws-filter-chip-menu {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
   z-index: 5;
   min-width: 180px;
   max-height: 220px;
@@ -1168,7 +1161,6 @@ body {
 }
 
 .ws-file-table-row {
-  position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr) 140px 120px 110px 70px;
   gap: 8px;
@@ -1248,28 +1240,114 @@ body {
   color: var(--ws-text-tertiary);
 }
 
-.ws-file-table-open {
+/* ----------------------------------------------------------
+   RowMenu — right-click context menu + hover ⋯ overflow button,
+   both opening the same items (file/directory rows in FileTable).
+   ---------------------------------------------------------- */
+.ws-row-menu {
+  position: relative;
+}
+
+.ws-row-menu-overflow {
   position: absolute;
   right: 8px;
   top: 50%;
   transform: translateY(-50%);
   opacity: 0;
   pointer-events: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
   border: 1px solid var(--ws-border);
   border-radius: var(--ws-radius-control);
   background: var(--ws-surface);
-  color: var(--ws-ink);
-  font-size: var(--ws-text-12);
-  padding: 3px 10px;
+  color: var(--ws-text-secondary);
+  font-size: var(--ws-text-13);
+  line-height: 1;
   cursor: pointer;
   box-shadow: var(--ws-shadow-1);
   transition: opacity var(--ws-dur-fast) var(--ws-ease);
 }
 
-.ws-file-table-row:hover .ws-file-table-open,
-.ws-file-table-row:focus-within .ws-file-table-open {
+.ws-row-menu:hover .ws-row-menu-overflow,
+.ws-row-menu:focus-within .ws-row-menu-overflow,
+.ws-row-menu-overflow[data-state='open'] {
   opacity: 1;
   pointer-events: auto;
+}
+
+.ws-row-menu-content {
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  background: var(--ws-raised);
+  border: 1px solid var(--ws-border-subtle);
+  border-radius: var(--ws-radius-control);
+  box-shadow: var(--ws-shadow-2);
+  z-index: 5;
+}
+
+.ws-row-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 6px 10px;
+  border: none;
+  background: transparent;
+  color: var(--ws-ink);
+  font-family: var(--ws-font);
+  font-size: var(--ws-text-13);
+  border-radius: 4px;
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+}
+
+.ws-row-menu-item[data-highlighted] {
+  background: var(--ws-accent-soft);
+}
+
+.ws-row-menu-item[data-disabled] {
+  color: var(--ws-text-tertiary);
+  cursor: default;
+}
+
+/* ----------------------------------------------------------
+   Toaster — bottom-center, auto-dismissing confirmation (e.g. "Path copied").
+   ---------------------------------------------------------- */
+.ws-toast-viewport {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  outline: none;
+}
+
+.ws-toast {
+  background: var(--ws-raised);
+  border: 1px solid var(--ws-border-subtle);
+  border-radius: var(--ws-radius-control);
+  box-shadow: var(--ws-shadow-2);
+  padding: 4px;
+}
+
+.ws-toast-desc {
+  display: block;
+  padding: 6px 10px;
+  font-family: var(--ws-font);
+  font-size: var(--ws-text-13);
+  color: var(--ws-ink);
 }
 
 .ws-file-table-snippet {

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -66,10 +66,10 @@ html,
 body {
   height: 100%;
   overflow: hidden;
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  font-family: var(--font-sans);
-  font-size: 13px;
+  font-family: var(--ws-font);
+  background: var(--ws-canvas);
+  color: var(--ws-ink);
+  font-size: var(--ws-text-13);
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -77,6 +77,13 @@ body {
 
 #root {
   height: 100%;
+}
+
+/* ----------------------------------------------------------
+   Utility Classes
+   ---------------------------------------------------------- */
+.ws-tabular {
+  font-feature-settings: 'tnum';
 }
 
 /* ----------------------------------------------------------
@@ -665,18 +672,18 @@ body {
 }
 
 .helper-messages::-webkit-scrollbar-thumb {
-  background: var(--border);
+  background: var(--ws-border);
   border-radius: 3px;
 }
 
 .helper-messages::-webkit-scrollbar-thumb:hover {
-  background: var(--text-muted);
+  background: var(--ws-text-tertiary);
 }
 
 /* Firefox scrollbar */
 .helper-messages {
   scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
+  scrollbar-color: var(--ws-border) transparent;
 }
 
 /* ----------------------------------------------------------
@@ -861,13 +868,13 @@ body {
 }
 
 .helper-history-list::-webkit-scrollbar-thumb {
-  background: var(--border);
+  background: var(--ws-border);
   border-radius: 3px;
 }
 
 .helper-history-list {
   scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
+  scrollbar-color: var(--ws-border) transparent;
 }
 
 /* ----------------------------------------------------------
@@ -956,7 +963,7 @@ body {
   overflow-y: auto;
   padding: 4px 8px 8px;
   scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
+  scrollbar-color: var(--ws-border) transparent;
 }
 
 .helper-workspace-list::-webkit-scrollbar {
@@ -968,7 +975,7 @@ body {
 }
 
 .helper-workspace-list::-webkit-scrollbar-thumb {
-  background: var(--border);
+  background: var(--ws-border);
   border-radius: 3px;
 }
 

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -964,6 +964,139 @@ body {
   outline: none;
 }
 
+/* ----------------------------------------------------------
+   Filter chips (Search toolbar) — plain positioned listbox for now;
+   Task 7 swaps the menu body for a Radix DropdownMenu.
+   ---------------------------------------------------------- */
+.ws-filter-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 14px 8px;
+  flex-shrink: 0;
+}
+
+.ws-filter-chip-wrap {
+  position: relative;
+}
+
+.ws-filter-chip {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 8px;
+  border: 1px solid var(--ws-border);
+  border-radius: 999px;
+  background: var(--ws-surface);
+  color: var(--ws-text-secondary);
+  font-family: var(--ws-font);
+  font-size: var(--ws-text-12);
+  line-height: 1.2;
+  cursor: pointer;
+  transition: background var(--ws-dur-fast) var(--ws-ease), color var(--ws-dur-fast) var(--ws-ease);
+}
+
+.ws-filter-chip:hover {
+  color: var(--ws-ink);
+}
+
+.ws-filter-chip-active {
+  border-color: transparent;
+  background: var(--ws-accent-soft);
+  color: var(--ws-accent);
+}
+
+.ws-filter-chip-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  border-radius: 50%;
+  padding: 1px;
+}
+
+.ws-filter-chip-close:hover {
+  background: hsl(0 0% 0% / 0.08);
+}
+
+.ws-filter-chip-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 5;
+  min-width: 180px;
+  max-height: 220px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  background: var(--ws-raised);
+  border: 1px solid var(--ws-border);
+  border-radius: var(--ws-radius-control);
+  box-shadow: var(--ws-shadow-2);
+}
+
+.ws-filter-chip-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 6px 8px;
+  border: none;
+  background: transparent;
+  color: var(--ws-ink);
+  font-family: var(--ws-font);
+  font-size: var(--ws-text-13);
+  border-radius: var(--ws-radius-control);
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ws-filter-chip-menu-item:hover {
+  background: var(--ws-accent-soft);
+}
+
+.ws-filter-chip-menu-empty {
+  padding: 6px 8px;
+  color: var(--ws-text-tertiary);
+  font-size: var(--ws-text-12);
+}
+
+.ws-filter-chip-menu-date {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ws-filter-chip-menu-custom {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 8px 2px;
+  margin-top: 4px;
+  border-top: 1px solid var(--ws-border-subtle);
+}
+
+.ws-filter-chip-menu-custom label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: var(--ws-text-12);
+  color: var(--ws-text-secondary);
+}
+
+.ws-filter-chip-menu-custom input[type='date'] {
+  border: 1px solid var(--ws-border);
+  border-radius: var(--ws-radius-control);
+  background: var(--ws-surface);
+  color: var(--ws-ink);
+  font-family: var(--ws-font);
+  font-size: var(--ws-text-12);
+  padding: 3px 5px;
+}
+
 .helper-workspace-list {
   flex: 1;
   overflow-y: auto;

--- a/apps/helper/src/styles/globals.css
+++ b/apps/helper/src/styles/globals.css
@@ -1,3 +1,5 @@
+@import './tokens.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/apps/helper/src/styles/tokens.css
+++ b/apps/helper/src/styles/tokens.css
@@ -1,0 +1,61 @@
+/* Workspace design tokens. Light is default; dark is the rollback theme.  */
+:root {
+  /* color: canvas/surfaces */
+  --ws-canvas: hsl(40 20% 98%);
+  --ws-surface: hsl(0 0% 100%);
+  --ws-raised: hsl(0 0% 100%);
+  /* color: ink */
+  --ws-ink: hsl(230 15% 12%);
+  --ws-text-secondary: hsl(230 8% 38%);
+  --ws-text-tertiary: hsl(230 6% 56%);
+  /* color: borders (two strengths only) */
+  --ws-border-subtle: hsl(230 10% 92%);
+  --ws-border: hsl(230 10% 85%);
+  /* color: accent (console brand hue) */
+  --ws-accent: hsl(225 62% 48%);
+  --ws-accent-contrast: hsl(0 0% 100%);
+  --ws-accent-soft: hsl(225 62% 48% / 0.1);
+  /* color: semantic */
+  --ws-success: hsl(152 45% 34%);
+  --ws-success-soft: hsl(152 45% 34% / 0.12);
+  --ws-warning: hsl(38 85% 40%);
+  --ws-warning-soft: hsl(38 85% 40% / 0.12);
+  --ws-danger: hsl(0 62% 46%);
+  --ws-danger-soft: hsl(0 62% 46% / 0.1);
+  /* elevation */
+  --ws-shadow-1: 0 1px 2px hsl(230 20% 10% / 0.06);
+  --ws-shadow-2: 0 2px 8px hsl(230 20% 10% / 0.08), 0 1px 2px hsl(230 20% 10% / 0.05);
+  /* shape */
+  --ws-radius-control: 6px;
+  --ws-radius-surface: 10px;
+  /* type scale */
+  --ws-text-11: 11px; --ws-text-12: 12px; --ws-text-13: 13px;
+  --ws-text-15: 15px; --ws-text-17: 17px; --ws-text-20: 20px;
+  --ws-font: 'Inter Variable', -apple-system, 'Segoe UI', system-ui, sans-serif;
+  /* motion */
+  --ws-dur-fast: 120ms;
+  --ws-dur-slow: 200ms;
+  --ws-ease: cubic-bezier(0.2, 0, 0, 1);
+}
+
+:root[data-theme='dark'] {
+  --ws-canvas: hsl(230 12% 11%);
+  --ws-surface: hsl(230 11% 14%);
+  --ws-raised: hsl(230 10% 17%);
+  --ws-ink: hsl(230 15% 92%);
+  --ws-text-secondary: hsl(230 8% 68%);
+  --ws-text-tertiary: hsl(230 6% 50%);
+  --ws-border-subtle: hsl(230 10% 20%);
+  --ws-border: hsl(230 10% 26%);
+  --ws-accent: hsl(225 70% 62%);
+  --ws-accent-contrast: hsl(230 15% 10%);
+  --ws-accent-soft: hsl(225 70% 62% / 0.14);
+  --ws-success: hsl(152 40% 55%);
+  --ws-success-soft: hsl(152 40% 55% / 0.14);
+  --ws-warning: hsl(38 80% 58%);
+  --ws-warning-soft: hsl(38 80% 58% / 0.14);
+  --ws-danger: hsl(0 62% 62%);
+  --ws-danger-soft: hsl(0 62% 62% / 0.14);
+  --ws-shadow-1: 0 1px 2px hsl(0 0% 0% / 0.35);
+  --ws-shadow-2: 0 2px 10px hsl(0 0% 0% / 0.45);
+}

--- a/apps/helper/tailwind.config.js
+++ b/apps/helper/tailwind.config.js
@@ -2,7 +2,22 @@
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'ws-canvas': 'var(--ws-canvas)',
+        'ws-surface': 'var(--ws-surface)',
+        'ws-raised': 'var(--ws-raised)',
+        'ws-ink': 'var(--ws-ink)',
+        'ws-secondary': 'var(--ws-text-secondary)',
+        'ws-tertiary': 'var(--ws-text-tertiary)',
+        'ws-accent': 'var(--ws-accent)',
+        'ws-accent-soft': 'var(--ws-accent-soft)',
+        'ws-border': 'var(--ws-border)',
+        'ws-border-subtle': 'var(--ws-border-subtle)',
+      },
+      fontFamily: { sans: ['Inter Variable', '-apple-system', 'Segoe UI', 'system-ui', 'sans-serif'] },
+      borderRadius: { control: 'var(--ws-radius-control)', surface: 'var(--ws-radius-surface)' },
+    },
   },
   plugins: [],
 };

--- a/apps/helper/tsconfig.json
+++ b/apps/helper/tsconfig.json
@@ -11,6 +11,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/apps/helper/tsconfig.node.json
+++ b/apps/helper/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/apps/helper/vitest.config.ts
+++ b/apps/helper/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/apps/helper/vitest.config.ts
+++ b/apps/helper/vitest.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    globals: true,
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    setupFiles: ['./vitest.setup.ts'],
   },
 });

--- a/apps/helper/vitest.setup.ts
+++ b/apps/helper/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,9 @@
 services:
   # PostgreSQL Database
   postgres:
-    image: postgres:16-alpine
+    # pgvector/pgvector is the official postgres image + the vector extension
+    # (drop-in superset; same data dir format as postgres:16).
+    image: pgvector/pgvector:pg16
     container_name: breeze-postgres-dev
     restart: unless-stopped
     environment:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,7 +5,9 @@
 services:
   # PostgreSQL Database for Tests
   postgres-test:
-    image: postgres:16-alpine
+    # pgvector/pgvector is the official postgres image + the vector extension
+    # (drop-in superset of postgres:16).
+    image: pgvector/pgvector:pg16
     container_name: breeze-postgres-test
     environment:
       POSTGRES_USER: breeze_test

--- a/packages/extension-api/src/index.test.ts
+++ b/packages/extension-api/src/index.test.ts
@@ -44,6 +44,23 @@ describe('parseExtensionManifest', () => {
     expect(m.tenancy.deviceOrgMoveDeleteTables).toEqual(['demo_things']);
   });
 
+  it('accepts helperRoutes flag', () => {
+    const m = parseExtensionManifest({
+      name: 'demo', routeNamespace: 'demo', entry: 'src/index.ts',
+      helperRoutes: true,
+      tenancy: {},
+    });
+    expect(m.helperRoutes).toBe(true);
+  });
+
+  it('defaults helperRoutes to false', () => {
+    const m = parseExtensionManifest({
+      name: 'demo', routeNamespace: 'demo', entry: 'src/index.ts',
+      tenancy: {},
+    });
+    expect(m.helperRoutes).toBe(false);
+  });
+
   it('rejects unprefixed tables in deviceOrgMoveDeleteTables', () => {
     expect(() => parseExtensionManifest({
       name: 'demo', routeNamespace: 'demo', entry: 'src/index.ts',
@@ -86,6 +103,12 @@ describe('parseExtensionManifest', () => {
   it('rejects publicRoutes under /agent/ — they must stay behind agentAuthMiddleware', () => {
     for (const route of ['/agent', '/agent/hook', '/agent/*']) {
       expect(() => parseExtensionManifest({ ...valid, publicRoutes: [route] })).toThrow(/agent/i);
+    }
+  });
+
+  it('rejects publicRoutes under /helper/ — they must stay behind core helper auth', () => {
+    for (const route of ['/helper', '/helper/search', '/helper/*']) {
+      expect(() => parseExtensionManifest({ ...valid, publicRoutes: [route] })).toThrow(/helper/i);
     }
   });
 

--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -6,6 +6,7 @@ export {
   type LegacyExtensionContext as ExtensionContext,
   type AiToolLike,
   type ExtensionAgentContext,
+  type ExtensionHelperDevice,
   type ExtensionAuditEvent,
   type ExtensionSecrets,
   type ExtensionDatabase,

--- a/packages/extension-api/src/legacy.ts
+++ b/packages/extension-api/src/legacy.ts
@@ -118,6 +118,10 @@ const manifestSchema = z
     // loader grants the exemption only for prefixes it wraps with
     // agentAuthMiddleware itself — manifest trust alone never lifts the limit.
     agentRoutes: z.boolean().optional(),
+    // Routes /api/v1/<routeNamespace>/helper/ through the core helper
+    // (Breeze Assist device-token) auth middleware instead of user auth.
+    // Helper paths can never be listed in publicRoutes.
+    helperRoutes: z.boolean().default(false),
     // Default-deny escape hatch: sub-paths (relative to /api/v1/<routeNamespace>)
     // served WITHOUT core auth. Exact paths ('/health') or prefix wildcards
     // ('/webhooks/*'). Everything not listed here gets authMiddleware
@@ -134,6 +138,9 @@ const manifestSchema = z
           })
           .refine((p) => p !== '/agent' && !p.startsWith('/agent/'), {
             message: 'publicRoutes may not expose /agent/ paths — they must stay behind agentAuthMiddleware (they are exempt from the global rate limiter)',
+          })
+          .refine((p) => p !== '/helper' && !p.startsWith('/helper/'), {
+            message: 'publicRoutes may not expose /helper/ paths — they must stay behind the core helper auth middleware',
           }),
       )
       .optional(),
@@ -201,6 +208,18 @@ export interface AiToolLike {
   deviceArgs?: readonly string[];
 }
 
+/** Helper-device identity injected by the core helper authentication middleware. */
+export interface ExtensionHelperDevice {
+  id: string;
+  agentId: string;
+  orgId: string;
+  siteId: string | null;
+  hostname: string;
+  osType: string;
+  osVersion: string;
+  agentVersion: string;
+}
+
 /** Agent identity injected by the core agent authentication middleware. */
 export interface ExtensionAgentContext {
   deviceId: string;
@@ -254,6 +273,12 @@ export interface LegacyExtensionContext {
   authMiddleware: MiddlewareHandler;
   /** Core agent auth middleware; sets `c.get('agent')` and opens the org RLS context. */
   agentAuthMiddleware: MiddlewareHandler;
+  /**
+   * Core helper (Breeze Assist device-token) auth; sets `c.get('helperDevice')`
+   * and an org-scoped synthetic auth, opens org RLS. Only meaningful when
+   * manifest.helperRoutes is true.
+   */
+  helperAuthMiddleware: MiddlewareHandler;
   /** Core ALS-bound Drizzle handle; active RLS GUCs apply. */
   db: ExtensionDatabase;
   /** Core column-bound encryption helpers. */

--- a/packages/extension-sdk/src/manifest.ts
+++ b/packages/extension-sdk/src/manifest.ts
@@ -180,6 +180,8 @@ const manifestSchemaV1 = z.object({
       }),
   ).optional(),
   agentRoutes: z.boolean().optional(),
+  // TODO(runtime-platform): carry legacy helperRoutes forward as capability
+  // 'server.helper-routes.v1' (see internal/plans/2026-07-18-workspace-finder-phase3-plan.md).
   jobs: z.array(jobSchema),
   aiTools: z.array(aiToolSchema),
   tenancy: tenancySchema.default({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,6 +404,9 @@ importers:
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/m365-graph-read-executor:
     dependencies:
@@ -16162,7 +16165,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -16172,6 +16175,14 @@ snapshots:
       '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
@@ -16386,7 +16397,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 4.0.5
+      picomatch: 4.0.4
 
   anynum@1.0.1: {}
 
@@ -22947,6 +22958,36 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.3
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.1
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1046,8 +1046,6 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
-  extensions/workspace: {}
-
   packages/extension-api:
     dependencies:
       '@breeze/extension-sdk':
@@ -14998,9 +14996,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.0': {}
 
@@ -16884,7 +16880,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,6 +358,9 @@ importers:
 
   apps/helper:
     dependencies:
+      '@fontsource-variable/inter':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
@@ -1021,6 +1024,8 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  extensions/workspace: {}
 
   packages/extension-api:
     dependencies:
@@ -2593,6 +2598,9 @@ packages:
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@fontsource-variable/inter@5.3.0':
+    resolution: {integrity: sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==}
 
   '@fontsource/plus-jakarta-sans@5.2.8':
     resolution: {integrity: sha512-P5qE49fqdeD+7DXH1KBxmMPlB17LTz1zvBhFH0tFzfnYTKVJVyb0pR6plh0ZGXxcB+Oayb54FZZw3V42/DawTw==}
@@ -13292,6 +13300,8 @@ snapshots:
 
   '@floating-ui/utils@0.2.12':
     optional: true
+
+  '@fontsource-variable/inter@5.3.0': {}
 
   '@fontsource/plus-jakarta-sans@5.2.8': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,6 +383,12 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2.11.3
         version: 2.11.3
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -395,6 +401,9 @@ importers:
       autoprefixer:
         specifier: ^10.5.3
         version: 10.5.3(postcss@8.5.19)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       postcss:
         specifier: ^8.5.19
         version: 8.5.19
@@ -8236,10 +8245,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@11.5.1:
-    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
-    engines: {node: 20 || >=22}
 
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
@@ -19280,7 +19285,7 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.5.1
+      lru-cache: 11.5.2
       parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
@@ -19594,8 +19599,6 @@ snapshots:
       js-tokens: 4.0.0
 
   lru-cache@10.4.3: {}
-
-  lru-cache@11.5.1: {}
 
   lru-cache@11.5.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,6 +361,18 @@ importers:
       '@fontsource-variable/inter':
         specifier: ^5.3.0
         version: 5.3.0
+      '@radix-ui/react-context-menu':
+        specifier: ^2.3.3
+        version: 2.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.20
+        version: 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toast':
+        specifier: ^1.2.19
+        version: 1.2.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.12
+        version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
@@ -2605,6 +2617,12 @@ packages:
   '@floating-ui/dom@1.8.0':
     resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
 
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
@@ -3226,6 +3244,324 @@ packages:
 
   '@posthog/types@1.376.2':
     resolution: {integrity: sha512-Y3ROpAxNqgcy2G0w6JoG5Gt+P6WNY2lkHTPMPzWqexRwemYbFegDi5AifDyD9/tstKTlOYKTTExtaJ5EBcghyQ==}
+
+  '@radix-ui/primitive@1.1.5':
+    resolution: {integrity: sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==}
+
+  '@radix-ui/react-arrow@1.1.11':
+    resolution: {integrity: sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.12':
+    resolution: {integrity: sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.3.3':
+    resolution: {integrity: sha512-PS+gKE0z2prJ74Y0sM+brAGK4mYOHIR7TlcV5EJgUQ6E0xMvyswkK2X4yRqyganrzsRL+WCSKAPu0NQITICRWg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-context@1.2.0':
+    resolution: {integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.2':
+    resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.15':
+    resolution: {integrity: sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.20':
+    resolution: {integrity: sha512-slfm+rRaZRuQBvHq60lXvSVUPhid0IPtjSZzIuUlWZMUs01iYZNlGS3mJgRD3ChLQVBAYlKiL/tFyWGX+dz8Xw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.4':
+    resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.12':
+    resolution: {integrity: sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.2':
+    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.20':
+    resolution: {integrity: sha512-VsUrXxFe9d2ScbZF0fR/oPR1+qjyeLs5p0jzG8h90puMoA9bq4SirYlXbE+USRg9Q2qTeJSFNqjw2nts8jJe4w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.3.3':
+    resolution: {integrity: sha512-mS7dGpyjv6b+gsDjLF7e0ia1W4Im1B1hSCy2yuXlHuvnZxHKagfDaobt/KAKt27EpZMit2pss8eJBVyVjEWM+g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.13':
+    resolution: {integrity: sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.7':
+    resolution: {integrity: sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.7':
+    resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.15':
+    resolution: {integrity: sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.19':
+    resolution: {integrity: sha512-SxfVZfVOibWKWdkf0Xx1awW2d09fQu4V4PXDY1j5hi4MVf7MWdJZqTBJMa1KWtOr1S6GGtCk02nniZ0Iia+dHw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.12':
+    resolution: {integrity: sha512-U3HoftgWnmla78vzQbLvKKb7bUYJxoiiqYFzp1wu/TBMyDqMZSuCl3aRICsD6EfVEwcJD2mumGDGUXLFVqQHKA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.2':
+    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.1':
+    resolution: {integrity: sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.2':
+    resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.2':
+    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.7':
+    resolution: {integrity: sha512-1wNZBggTDK3GRuuQ6nP4k2yi7a6l7I5qbMPbZcRsrGsGVead/f/d5FhEzUvqFs0bcrDLx7n1zKQ3JvLR6whaaw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.2':
+    resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
   '@react-email/render@0.0.16':
     resolution: {integrity: sha512-wDaMy27xAq1cJHtSFptp0DTKPuV2GYhloqia95ub/DH9Dea1aWYsbdM918MOc/b/HvVS3w1z8DWzfAk13bGStQ==}
@@ -5534,6 +5870,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -6498,6 +6838,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
@@ -7336,6 +7679,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -9607,11 +9954,41 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-smooth@4.0.4:
     resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -10704,10 +11081,30 @@ packages:
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-latest-callback@0.2.6:
     resolution: {integrity: sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==}
     peerDependencies:
       react: '>=16.8'
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -13295,16 +13692,19 @@ snapshots:
   '@floating-ui/core@1.8.0':
     dependencies:
       '@floating-ui/utils': 0.2.12
-    optional: true
 
   '@floating-ui/dom@1.8.0':
     dependencies:
       '@floating-ui/core': 1.8.0
       '@floating-ui/utils': 0.2.12
-    optional: true
 
-  '@floating-ui/utils@0.2.12':
-    optional: true
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@fontsource-variable/inter@5.3.0': {}
 
@@ -13996,6 +14396,308 @@ snapshots:
 
   '@posthog/types@1.376.2': {}
 
+  '@radix-ui/primitive@1.1.5': {}
+
+  '@radix-ui/react-arrow@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-collection@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-context-menu@2.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-context@1.2.0(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-direction@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-dismissable-layer@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-dropdown-menu@2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-focus-scope@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-id@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-menu@2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-popper@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-arrow': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-portal@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-presence@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-primitive@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-roving-focus@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-toast@1.2.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-tooltip@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-is-hydrated@0.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-rect@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-size@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-visually-hidden@1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/rect@1.1.2': {}
+
   '@react-email/render@0.0.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       html-to-text: 9.0.5
@@ -14296,7 +14998,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.0': {}
 
@@ -16459,6 +17163,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -17543,6 +18251,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  detect-node-es@1.1.0: {}
+
   devalue@5.8.1: {}
 
   devlop@1.1.0:
@@ -18485,6 +19195,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.4
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -21426,6 +22138,25 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  react-remove-scroll@2.7.2(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@19.2.7)
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@19.2.7)
+      use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   react-smooth@4.0.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       fast-equals: 5.4.0
@@ -21433,6 +22164,14 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
+  react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.7
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   react-transition-group@4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -22807,9 +23546,24 @@ snapshots:
 
   url-template@2.0.8: {}
 
+  use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   use-latest-callback@0.2.6(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.7
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:


### PR DESCRIPTION
## Summary

Helper-side Workspace Files experience for the pilot demo (35 commits): the finder UI, content-preview surfaces, and the full Workspace Reshape.

**Finder + content UI** — workspace files view (search/browse/recents) on a new store, validated open-in-place for workspace UNC paths, search snippets with inferred-metadata line, and the filing panel. Helper-auth route mapping via the `helperRoutes` manifest flag with extracted auth middleware.

**Workspace Reshape** — light-default `--ws-*` token system with a complete dark rollback (verified at computed-style level), Inter, segmented-control shell chrome, restyled chat home, sortable list-table, Project/Doc-type/Date/Kind filter chips (Search) and Project/Doc-type chips (Browse), Radix context/overflow menus + toasts, keyboard selection + shortcuts, filing cards with drag-to-project filing, and designed empty/loading/error states.

**Hardening from review** — the search/browse refetch effects are deliberately **non-reactive to `error`** (a reviewer proved the reactive version was an unbounded auto-retry loop); legacy dark-era color aliases remapped onto ws tokens so untouched screens (first-run prompt, history) stay legible on the light canvas; file table collapses to 3 columns ≤480px to fit the real 380px Tauri window; double-click opens rows/folders; Escape/Tab layering fixes in Radix menus.

## Cross-repo note

Depends on the extension PR in `LanternOps/breeze-workspace` (branch `ToddHebebrand/demo-preparation-bcre`) for the optional `project`/`docType` params on search/browse. **Merge that PR first.**

## Test plan

- 70/70 helper unit tests + typecheck clean at tip
- Four-beat pilot acceptance harness PASS at final tips
- Hand-driven browser pass of all four beats in the reshaped UI (chip narrowing, right-click menus, drag-to-file onto a project); screenshots committed in the workspace worktree's `dev/`
- Remaining human step before the demo: the 2-minute interactive Tauri eyeball checklist in the workspace worktree's `dev/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

