### PR TITLE
feat(w7): chat over the estate — client-declared session tools, cited RAG answers in helper chat

### DIFF
--- a/apps/api/src/routes/helper/index.test.ts
+++ b/apps/api/src/routes/helper/index.test.ts
@@ -367,7 +367,7 @@ describe('helper client-declared session tools', () => {
     expect(typeof call?.[7]).toBe('function');
   });
 
-  it('resolves a client tool result (200)', async () => {
+  it('resolves a client tool result (200) and persists a tool_result row with the posted output', async () => {
     mockHelperAuthDevice();
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
@@ -378,6 +378,14 @@ describe('helper client-declared session tools', () => {
     } as never);
     vi.mocked(resolveClientDeclaredTool).mockReturnValue('resolved');
 
+    let insertedResult: Record<string, unknown> | undefined;
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn((values: Record<string, unknown>) => {
+        insertedResult = values;
+        return undefined;
+      }),
+    } as never);
+
     const res = await app.request('/helper/chat/sessions/session-1/tool-results', {
       method: 'POST',
       headers: { Authorization: 'Bearer brz_agent_token', 'Content-Type': 'application/json' },
@@ -386,6 +394,10 @@ describe('helper client-declared session tools', () => {
 
     expect(res.status).toBe(200);
     expect(resolveClientDeclaredTool).toHaveBeenCalledWith('session-1', 'tu-1', { output: { files: [] }, error: undefined });
+    // A generic tool_result transcript row is written so History reopens render.
+    expect(insertedResult?.role).toBe('tool_result');
+    expect(insertedResult?.toolUseId).toBe('tu-1');
+    expect(insertedResult?.toolOutput).toEqual({ files: [] });
   });
 
   it('409s a duplicate tool result post', async () => {

--- a/apps/api/src/routes/helper/index.test.ts
+++ b/apps/api/src/routes/helper/index.test.ts
@@ -93,12 +93,33 @@ vi.mock('../../services/aiAgentSdk', () => ({
   createSessionPostToolUse: vi.fn(),
 }));
 
+// Keep the real declaration schema + name helpers (used at route-construction
+// time and for the allowlist), but stub the bridge resolver so tool-results
+// tests can drive its outcome without a live SDK session.
+vi.mock('../../services/clientSessionTools', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/clientSessionTools')>();
+  return {
+    ...actual,
+    resolveClientDeclaredTool: vi.fn(),
+    requestClientDeclaredTool: vi.fn(),
+    createClientDeclaredMcpServer: vi.fn(() => ({ type: 'sdk', name: 'client_tools' })),
+    failPendingClientDeclaredForSession: vi.fn(),
+  };
+});
+
 import { helperRoutes } from './index';
 import { db } from '../../db';
 import { matchAgentTokenHash } from '../../middleware/agentAuth';
 import { resolveHelperPermissionLevelForDevice } from '../../services/helperPermissions';
 import { buildHelperSystemPrompt } from '../../services/helperAiAgent';
 import { streamingSessionManager } from '../../services/streamingSessionManager';
+import { resolveClientDeclaredTool } from '../../services/clientSessionTools';
+
+const VALID_TOOL_DECL = {
+  name: 'search_files',
+  description: 'search the estate for files',
+  inputSchema: { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] },
+};
 
 function mockHelperAuthDevice() {
   vi.mocked(db.select).mockReturnValueOnce({
@@ -241,6 +262,190 @@ describe('helper routes permission derivation', () => {
     expect(systemPrompt).toBe('helper system prompt');
     expect(allowedTools).toContain('mcp__breeze__file_operations');
     expect(allowedTools).not.toContain('mcp__breeze__execute_command');
+    // Isolation: sessions without client tools pass NO mcpServerFactory — the
+    // default breeze MCP path is byte-identical to today.
+    expect(getOrCreateCall?.[7]).toBeUndefined();
     expect(resolveHelperPermissionLevelForDevice).toHaveBeenCalledWith('device-1', 'basic');
+  });
+});
+
+describe('helper client-declared session tools', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/helper', helperRoutes);
+  });
+
+  it('persists validated clientTools into the session contextSnapshot at create', async () => {
+    mockHelperAuthDevice();
+    vi.mocked(resolveHelperPermissionLevelForDevice).mockResolvedValue('basic');
+
+    let insertedValues: Record<string, unknown> | undefined;
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn((values: Record<string, unknown>) => {
+        insertedValues = values;
+        return { returning: vi.fn().mockResolvedValue([{ id: 'session-1' }]) };
+      }),
+    } as never);
+
+    const res = await app.request('/helper/chat/sessions', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer brz_agent_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientTools: [VALID_TOOL_DECL] }),
+    });
+
+    expect(res.status).toBe(201);
+    const snapshot = insertedValues?.contextSnapshot as Record<string, unknown>;
+    expect(snapshot.clientTools).toEqual([VALID_TOOL_DECL]);
+  });
+
+  it('rejects an invalid clientTools declaration at create (400)', async () => {
+    mockHelperAuthDevice();
+
+    const res = await app.request('/helper/chat/sessions', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer brz_agent_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientTools: [{ name: 'Bad-Name', description: 'x', inputSchema: { type: 'object' } }] }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('passes the client-declared MCP factory + tool allowlist when the session has clientTools', async () => {
+    mockHelperAuthDevice();
+    vi.mocked(resolveHelperPermissionLevelForDevice).mockResolvedValue('standard');
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: 'session-1',
+            orgId: 'org-1',
+            deviceId: 'device-1',
+            sdkSessionId: null,
+            model: 'claude-sonnet-4-5-20250929',
+            maxTurns: 50,
+            turnCount: 0,
+            status: 'active',
+            title: 'Existing title',
+            systemPrompt: 'prompt',
+            contextSnapshot: { clientTools: [VALID_TOOL_DECL] },
+            createdAt: new Date(),
+          }]),
+        }),
+      }),
+    } as never);
+
+    vi.mocked(db.insert).mockReturnValueOnce({ values: vi.fn().mockResolvedValue(undefined) } as never);
+
+    const activeSession = {
+      inputController: { pushMessage: vi.fn() },
+      eventBus: {
+        subscribe: vi.fn(async function* () { yield { type: 'done' }; }),
+        unsubscribe: vi.fn(),
+        publish: vi.fn(),
+      },
+      state: 'idle',
+    };
+    vi.mocked(streamingSessionManager.getOrCreate).mockResolvedValue(activeSession as never);
+    vi.mocked(streamingSessionManager.tryTransitionToProcessing).mockReturnValue(true);
+
+    const res = await app.request('/helper/chat/sessions/session-1/messages', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer brz_agent_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'find the henderson easement' }),
+    });
+    await res.text();
+
+    expect(res.status).toBe(200);
+    const call = vi.mocked(streamingSessionManager.getOrCreate).mock.calls[0];
+    const allowedTools = call?.[6] as string[] | undefined;
+    expect(allowedTools).toEqual(['mcp__client_tools__search_files']);
+    // The client-declared MCP factory is passed (a function), replacing the default.
+    expect(typeof call?.[7]).toBe('function');
+  });
+
+  it('resolves a client tool result (200)', async () => {
+    mockHelperAuthDevice();
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: 'session-1' }]),
+        }),
+      }),
+    } as never);
+    vi.mocked(resolveClientDeclaredTool).mockReturnValue('resolved');
+
+    const res = await app.request('/helper/chat/sessions/session-1/tool-results', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer brz_agent_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ toolUseId: 'tu-1', output: { files: [] } }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(resolveClientDeclaredTool).toHaveBeenCalledWith('session-1', 'tu-1', { output: { files: [] }, error: undefined });
+  });
+
+  it('409s a duplicate tool result post', async () => {
+    mockHelperAuthDevice();
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: 'session-1' }]),
+        }),
+      }),
+    } as never);
+    vi.mocked(resolveClientDeclaredTool).mockReturnValue('duplicate');
+
+    const res = await app.request('/helper/chat/sessions/session-1/tool-results', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer brz_agent_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ toolUseId: 'tu-1', output: {} }),
+    });
+
+    expect(res.status).toBe(409);
+  });
+
+  it('404s an unknown tool result post', async () => {
+    mockHelperAuthDevice();
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: 'session-1' }]),
+        }),
+      }),
+    } as never);
+    vi.mocked(resolveClientDeclaredTool).mockReturnValue('not_found');
+
+    const res = await app.request('/helper/chat/sessions/session-1/tool-results', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer brz_agent_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ toolUseId: 'tu-x', output: {} }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('404s a tool result for a session owned by another device', async () => {
+    mockHelperAuthDevice();
+    // Session-owner select returns no row (wrong device).
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    } as never);
+
+    const res = await app.request('/helper/chat/sessions/session-9/tool-results', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer brz_agent_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ toolUseId: 'tu-1', output: {} }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(resolveClientDeclaredTool).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/helper/index.ts
+++ b/apps/api/src/routes/helper/index.ts
@@ -15,6 +15,16 @@ import { db } from '../../db';
 import { aiSessions, aiMessages, devices } from '../../db/schema';
 import { streamingSessionManager } from '../../services/streamingSessionManager';
 import { buildHelperSystemPrompt } from '../../services/helperAiAgent';
+import {
+  clientToolsSchema,
+  createClientDeclaredMcpServer,
+  clientDeclaredToolMcpNames,
+  requestClientDeclaredTool,
+  resolveClientDeclaredTool,
+  failPendingClientDeclaredForSession,
+  CLIENT_DECLARED_MCP_SERVER_NAME,
+  type ClientToolDeclaration,
+} from '../../services/clientSessionTools';
 import { getHelperAllowedMcpToolNames, type HelperPermissionLevel } from '../../services/helperToolFilter';
 import { resolveHelperPermissionLevelForDevice } from '../../services/helperPermissions';
 import { sanitizeUserMessage } from '../../services/aiInputSanitizer';
@@ -40,12 +50,19 @@ helperRoutes.use('*', helperAuth);
 // Helper Pre-flight Checks
 // ============================================
 
+/** Read persisted client-declared tools (stored in contextSnapshot at create). */
+function clientToolsFromSession(session: typeof aiSessions.$inferSelect): ClientToolDeclaration[] {
+  const snapshot = session.contextSnapshot as Record<string, unknown> | null;
+  const raw = snapshot?.clientTools;
+  return Array.isArray(raw) ? (raw as ClientToolDeclaration[]) : [];
+}
+
 async function runHelperPreFlight(
   sessionId: string,
   content: string,
   device: HelperDevice,
 ): Promise<
-  | { ok: true; session: typeof aiSessions.$inferSelect; sanitizedContent: string; systemPrompt: string; maxBudgetUsd: number | undefined; allowedTools: string[] }
+  | { ok: true; session: typeof aiSessions.$inferSelect; sanitizedContent: string; systemPrompt: string; maxBudgetUsd: number | undefined; allowedTools: string[]; clientTools: ClientToolDeclaration[] }
   | { ok: false; error: string; status: number }
 > {
   // Fetch session
@@ -104,6 +121,12 @@ async function runHelperPreFlight(
 
   const permissionLevel = await resolveHelperPermissionLevelForDevice(device.id, DEFAULT_PERMISSION_LEVEL);
 
+  // When the session declared its own tools, the model runs against THOSE
+  // (client-declared MCP server + their allowlist) instead of the built-in
+  // device toolset — the generic client-tools seam.
+  const clientTools = clientToolsFromSession(session);
+  const hasClientTools = clientTools.length > 0;
+
   const systemPrompt = buildHelperSystemPrompt({
     hostname: device.hostname,
     deviceId: device.id,
@@ -112,9 +135,12 @@ async function runHelperPreFlight(
     osType: device.osType,
     osVersion: device.osVersion,
     agentVersion: device.agentVersion,
+    hasClientTools,
   });
 
-  const allowedTools = getHelperAllowedMcpToolNames(permissionLevel);
+  const allowedTools = hasClientTools
+    ? clientDeclaredToolMcpNames(clientTools)
+    : getHelperAllowedMcpToolNames(permissionLevel);
 
   let maxBudgetUsd: number | undefined;
   try {
@@ -124,7 +150,7 @@ async function runHelperPreFlight(
     // Non-fatal
   }
 
-  return { ok: true, session, sanitizedContent, systemPrompt, maxBudgetUsd, allowedTools };
+  return { ok: true, session, sanitizedContent, systemPrompt, maxBudgetUsd, allowedTools, clientTools };
 }
 
 // ============================================
@@ -147,6 +173,7 @@ helperRoutes.post(
   '/chat/sessions',
   zValidator('json', z.object({
     helperUser: z.string().max(100).optional(),
+    clientTools: clientToolsSchema.optional(),
   }).optional()),
   async (c) => {
     const device = c.get('helperDevice');
@@ -156,6 +183,9 @@ helperRoutes.post(
       DEFAULT_PERMISSION_LEVEL,
     );
 
+    const clientTools = body.clientTools ?? [];
+    const hasClientTools = clientTools.length > 0;
+
     const systemPrompt = buildHelperSystemPrompt({
       hostname: device.hostname,
       deviceId: device.id,
@@ -164,6 +194,7 @@ helperRoutes.post(
       osType: device.osType,
       osVersion: device.osVersion,
       agentVersion: device.agentVersion,
+      hasClientTools,
     });
 
     const [session] = await db
@@ -181,6 +212,7 @@ helperRoutes.post(
           osType: device.osType,
           source: 'helper',
           ...(body.helperUser ? { helperUser: body.helperUser } : {}),
+          ...(hasClientTools ? { clientTools } : {}),
         },
       })
       .returning();
@@ -214,7 +246,27 @@ helperRoutes.post(
       return c.json({ error: preflight.error }, preflight.status as 400);
     }
 
-    const { session: dbSession, sanitizedContent, systemPrompt, maxBudgetUsd, allowedTools } = preflight;
+    const { session: dbSession, sanitizedContent, systemPrompt, maxBudgetUsd, allowedTools, clientTools } = preflight;
+
+    // When the session declared client tools, build the generic client-declared
+    // MCP server: each model tool call publishes `client_tool_request` and parks
+    // a resolver until the helper posts to /tool-results. Sessions without
+    // declarations pass no factory and keep the built-in device MCP path.
+    const mcpServerFactory = clientTools.length > 0
+      ? (
+          _getAuth: unknown,
+          _onPreToolUse: unknown,
+          _onPostToolUse: unknown,
+          getSession: () => ActiveSession,
+        ) => ({
+          server: createClientDeclaredMcpServer(clientTools, (toolName, input) => {
+            const session = getSession();
+            const toolUseId = session.toolUseIdQueue.shift() ?? crypto.randomUUID();
+            return requestClientDeclaredTool(session, toolUseId, toolName, input);
+          }),
+          name: CLIENT_DECLARED_MCP_SERVER_NAME,
+        })
+      : undefined;
 
     // Get or create streaming session
     const activeSession = await streamingSessionManager.getOrCreate(
@@ -232,6 +284,7 @@ helperRoutes.post(
       systemPrompt,
       maxBudgetUsd,
       allowedTools,
+      mcpServerFactory as Parameters<typeof streamingSessionManager.getOrCreate>[7],
     );
 
     // Concurrent message guard
@@ -296,6 +349,47 @@ helperRoutes.post(
         activeSession.eventBus.unsubscribe(subscriptionId);
       }
     });
+  },
+);
+
+// ============================================
+// POST /chat/sessions/:id/tool-results — the helper reports a client-declared
+// tool outcome. helperAuth (applied to all routes) + session-owner check pin it
+// to the same device; the bridge resolves the parked SDK tool call.
+// ============================================
+
+helperRoutes.post(
+  '/chat/sessions/:id/tool-results',
+  zValidator('json', z.object({
+    toolUseId: z.string().min(1).max(200),
+    output: z.unknown().optional(),
+    error: z.string().max(10000).optional(),
+  })),
+  async (c) => {
+    const device = c.get('helperDevice');
+    const sessionId = c.req.param('id');
+    const { toolUseId, output, error } = c.req.valid('json');
+
+    // Session-owner check: the session must belong to this device.
+    const [session] = await db
+      .select({ id: aiSessions.id })
+      .from(aiSessions)
+      .where(and(eq(aiSessions.id, sessionId), eq(aiSessions.deviceId, device.id)))
+      .limit(1);
+
+    if (!session) {
+      return c.json({ error: 'Session not found' }, 404);
+    }
+
+    const outcome = resolveClientDeclaredTool(sessionId, toolUseId, { output, error });
+    if (outcome === 'duplicate') {
+      return c.json({ error: 'Tool result already submitted' }, 409);
+    }
+    if (outcome === 'not_found') {
+      return c.json({ error: 'unknown_tool_request' }, 404);
+    }
+
+    return c.json({ ok: true });
   },
 );
 
@@ -490,6 +584,8 @@ helperRoutes.delete('/chat/sessions/:id', async (c) => {
     .set({ status: 'closed', updatedAt: new Date() })
     .where(eq(aiSessions.id, sessionId));
 
+  // Unblock and drain any parked client-declared tool calls before teardown.
+  failPendingClientDeclaredForSession(sessionId);
   streamingSessionManager.remove(sessionId);
 
   return c.json({ success: true });

--- a/apps/api/src/routes/helper/index.ts
+++ b/apps/api/src/routes/helper/index.ts
@@ -21,6 +21,7 @@ import {
   clientDeclaredToolMcpNames,
   requestClientDeclaredTool,
   resolveClientDeclaredTool,
+  peekClientDeclaredToolName,
   failPendingClientDeclaredForSession,
   CLIENT_DECLARED_MCP_SERVER_NAME,
   type ClientToolDeclaration,
@@ -381,12 +382,34 @@ helperRoutes.post(
       return c.json({ error: 'Session not found' }, 404);
     }
 
+    // Recover the parked call's tool name BEFORE resolving (which drains the
+    // entry), so the persisted transcript row carries it. Generic: this route
+    // has no knowledge of any specific tool.
+    const toolName = peekClientDeclaredToolName(sessionId, toolUseId);
+
     const outcome = resolveClientDeclaredTool(sessionId, toolUseId, { output, error });
     if (outcome === 'duplicate') {
       return c.json({ error: 'Tool result already submitted' }, 409);
     }
     if (outcome === 'not_found') {
       return c.json({ error: 'unknown_tool_request' }, 404);
+    }
+
+    // Persist a tool_result row so reopening the session from History renders
+    // the same cards/citations the live stream did. The SDK's post-tool-use
+    // hook never runs for the bridged client-declared path, so this is the only
+    // place a client tool's output is recorded. Generic: output = whatever the
+    // client posted (its output, or an { error } payload).
+    try {
+      await db.insert(aiMessages).values({
+        sessionId,
+        role: 'tool_result',
+        toolName: toolName ?? null,
+        toolOutput: error !== undefined ? { error } : (output ?? null),
+        toolUseId,
+      });
+    } catch (err) {
+      console.error('[Helper] Failed to persist tool_result message:', err);
     }
 
     return c.json({ ok: true });
@@ -552,6 +575,7 @@ helperRoutes.get('/chat/sessions/:id/messages', async (c) => {
       role: aiMessages.role,
       content: aiMessages.content,
       toolName: aiMessages.toolName,
+      toolOutput: aiMessages.toolOutput,
       createdAt: aiMessages.createdAt,
     })
     .from(aiMessages)

--- a/apps/api/src/services/clientSessionTools.test.ts
+++ b/apps/api/src/services/clientSessionTools.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  clientToolsSchema,
+  requestClientDeclaredTool,
+  resolveClientDeclaredTool,
+  failPendingClientDeclaredForSession,
+  makeClientDeclaredToolHandler,
+  createClientDeclaredMcpServer,
+  clientDeclaredToolMcpNames,
+  CLIENT_DECLARED_MCP_SERVER_NAME,
+  CLIENT_DECLARED_TOOL_TIMEOUT_MS,
+  MAX_CLIENT_DECLARED_TOOLS,
+  _pendingClientDeclaredCountForTests,
+  type ClientToolDeclaration,
+} from './clientSessionTools';
+import type { ActiveSession } from './streamingSessionManager';
+
+// ============================================
+// Validation
+// ============================================
+
+function decl(name: string, extra: Partial<ClientToolDeclaration> = {}): ClientToolDeclaration {
+  return {
+    name,
+    description: `does ${name}`,
+    inputSchema: { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] },
+    ...extra,
+  };
+}
+
+describe('clientToolsSchema validation', () => {
+  it('accepts a well-formed declaration array', () => {
+    const parsed = clientToolsSchema.safeParse([decl('find_files'), decl('get_passages')]);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects more than the max number of tools', () => {
+    const tools = Array.from({ length: MAX_CLIENT_DECLARED_TOOLS + 1 }, (_, i) => decl(`tool_${i}`));
+    const parsed = clientToolsSchema.safeParse(tools);
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects a tool with a bad name', () => {
+    expect(clientToolsSchema.safeParse([decl('Bad-Name')]).success).toBe(false);
+    expect(clientToolsSchema.safeParse([decl('a')]).success).toBe(false); // too short
+    expect(clientToolsSchema.safeParse([decl('1abc')]).success).toBe(false); // leading digit
+  });
+
+  it('rejects duplicate tool names', () => {
+    const parsed = clientToolsSchema.safeParse([decl('find_files'), decl('find_files')]);
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects an inputSchema deeper than 3 levels', () => {
+    const deep: ClientToolDeclaration = decl('deep', {
+      inputSchema: {
+        type: 'object',
+        properties: {
+          a: { type: 'object', properties: { b: { type: 'object', properties: { c: { type: 'string' } } } } },
+        },
+      },
+    });
+    expect(clientToolsSchema.safeParse([deep]).success).toBe(false);
+  });
+
+  it('accepts an inputSchema exactly 3 levels deep', () => {
+    const okay: ClientToolDeclaration = decl('okay', {
+      inputSchema: {
+        type: 'object',
+        properties: { a: { type: 'object', properties: { b: { type: 'string' } } } },
+      },
+    });
+    expect(clientToolsSchema.safeParse([okay]).success).toBe(true);
+  });
+
+  it('rejects an inputSchema whose type is not object', () => {
+    const bad: ClientToolDeclaration = decl('bad', {
+      inputSchema: { type: 'string' } as unknown as ClientToolDeclaration['inputSchema'],
+    });
+    expect(clientToolsSchema.safeParse([bad]).success).toBe(false);
+  });
+});
+
+// ============================================
+// Bridge loop (park → publish → resolve/timeout)
+// ============================================
+
+function fakeSession(id: string) {
+  const publish = vi.fn();
+  return {
+    session: { breezeSessionId: id, eventBus: { publish } } as unknown as ActiveSession,
+    publish,
+  };
+}
+
+describe('client-declared tool bridge', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    failPendingClientDeclaredForSession('sess-1');
+    failPendingClientDeclaredForSession('sess-2');
+    vi.useRealTimers();
+  });
+
+  it('publishes client_tool_request and resolves with the posted output', async () => {
+    const { session, publish } = fakeSession('sess-1');
+    const p = requestClientDeclaredTool(session, 'tu-1', 'find_files', { q: 'henderson' });
+
+    expect(publish).toHaveBeenCalledWith({
+      type: 'client_tool_request',
+      toolUseId: 'tu-1',
+      toolName: 'find_files',
+      input: { q: 'henderson' },
+    });
+
+    expect(resolveClientDeclaredTool('sess-1', 'tu-1', { output: { files: [1, 2] } })).toBe('resolved');
+    await expect(p).resolves.toEqual({ output: { files: [1, 2] } });
+    expect(_pendingClientDeclaredCountForTests()).toBe(0);
+  });
+
+  it('resolves as a tool error when the client posts { error }', async () => {
+    const { session } = fakeSession('sess-1');
+    const p = requestClientDeclaredTool(session, 'tu-2', 'find_files', {});
+    expect(resolveClientDeclaredTool('sess-1', 'tu-2', { error: 'boom' })).toBe('resolved');
+    await expect(p).resolves.toEqual({ error: 'boom' });
+  });
+
+  it('resolves with a timeout error text when the client never responds', async () => {
+    const { session } = fakeSession('sess-1');
+    const p = requestClientDeclaredTool(session, 'tu-3', 'find_files', {});
+
+    vi.advanceTimersByTime(CLIENT_DECLARED_TOOL_TIMEOUT_MS - 1);
+    expect(_pendingClientDeclaredCountForTests()).toBe(1);
+    vi.advanceTimersByTime(1);
+
+    const result = await p;
+    expect(result.error).toContain('client did not respond');
+    expect(_pendingClientDeclaredCountForTests()).toBe(0);
+  });
+
+  it('reports a duplicate post for an already-resolved toolUseId (409 signal)', async () => {
+    const { session } = fakeSession('sess-1');
+    const p = requestClientDeclaredTool(session, 'tu-4', 'find_files', {});
+    expect(resolveClientDeclaredTool('sess-1', 'tu-4', { output: 1 })).toBe('resolved');
+    expect(resolveClientDeclaredTool('sess-1', 'tu-4', { output: 2 })).toBe('duplicate');
+    await p;
+  });
+
+  it('reports not_found for unknown ids and cross-session posts', async () => {
+    const { session } = fakeSession('sess-1');
+    const p = requestClientDeclaredTool(session, 'tu-5', 'find_files', {});
+    expect(resolveClientDeclaredTool('sess-1', 'nope', { output: null })).toBe('not_found');
+    expect(resolveClientDeclaredTool('sess-2', 'tu-5', { output: null })).toBe('not_found');
+    expect(resolveClientDeclaredTool('sess-1', 'tu-5', { output: null })).toBe('resolved');
+    await p;
+  });
+
+  it('fails every pending request of one session on teardown', async () => {
+    const a = fakeSession('sess-1');
+    const b = fakeSession('sess-2');
+    const p1 = requestClientDeclaredTool(a.session, 'tu-6', 'find_files', {});
+    const p2 = requestClientDeclaredTool(b.session, 'tu-7', 'find_files', {});
+
+    expect(failPendingClientDeclaredForSession('sess-1')).toBe(1);
+    await expect(p1).resolves.toMatchObject({ error: expect.any(String) });
+    expect(_pendingClientDeclaredCountForTests()).toBe(1);
+
+    expect(resolveClientDeclaredTool('sess-2', 'tu-7', { output: null })).toBe('resolved');
+    await p2;
+  });
+});
+
+// ============================================
+// SDK tool handler mapping
+// ============================================
+
+describe('makeClientDeclaredToolHandler', () => {
+  it('maps a dispatch output to a text CallToolResult', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ output: { files: ['a'] } });
+    const handler = makeClientDeclaredToolHandler('find_files', dispatch);
+    const result = await handler({ q: 'x' });
+    expect(dispatch).toHaveBeenCalledWith('find_files', { q: 'x' });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toBe(JSON.stringify({ files: ['a'] }));
+  });
+
+  it('maps a dispatch error to an isError CallToolResult', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ error: 'nope' });
+    const handler = makeClientDeclaredToolHandler('find_files', dispatch);
+    const result = await handler({});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('nope');
+  });
+
+  it('passes a plain string output through without double-encoding', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ output: 'hello' });
+    const handler = makeClientDeclaredToolHandler('find_files', dispatch);
+    const result = await handler({});
+    expect(result.content[0].text).toBe('hello');
+  });
+});
+
+// ============================================
+// MCP server construction
+// ============================================
+
+describe('createClientDeclaredMcpServer', () => {
+  it('builds an SDK MCP server named for the generic client-tools namespace', () => {
+    const server = createClientDeclaredMcpServer([decl('find_files')], vi.fn());
+    expect(server).toBeTruthy();
+    expect(server.name).toBe(CLIENT_DECLARED_MCP_SERVER_NAME);
+  });
+
+  it('prefixes the MCP tool allowlist names for the declared tools', () => {
+    expect(clientDeclaredToolMcpNames([decl('find_files'), decl('get_passages')])).toEqual([
+      `mcp__${CLIENT_DECLARED_MCP_SERVER_NAME}__find_files`,
+      `mcp__${CLIENT_DECLARED_MCP_SERVER_NAME}__get_passages`,
+    ]);
+  });
+});

--- a/apps/api/src/services/clientSessionTools.test.ts
+++ b/apps/api/src/services/clientSessionTools.test.ts
@@ -183,7 +183,7 @@ describe('makeClientDeclaredToolHandler', () => {
     const result = await handler({ q: 'x' });
     expect(dispatch).toHaveBeenCalledWith('find_files', { q: 'x' });
     expect(result.isError).toBeFalsy();
-    expect(result.content[0].text).toBe(JSON.stringify({ files: ['a'] }));
+    expect(result.content[0]?.text).toBe(JSON.stringify({ files: ['a'] }));
   });
 
   it('maps a dispatch error to an isError CallToolResult', async () => {
@@ -191,14 +191,14 @@ describe('makeClientDeclaredToolHandler', () => {
     const handler = makeClientDeclaredToolHandler('find_files', dispatch);
     const result = await handler({});
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('nope');
+    expect(result.content[0]?.text).toContain('nope');
   });
 
   it('passes a plain string output through without double-encoding', async () => {
     const dispatch = vi.fn().mockResolvedValue({ output: 'hello' });
     const handler = makeClientDeclaredToolHandler('find_files', dispatch);
     const result = await handler({});
-    expect(result.content[0].text).toBe('hello');
+    expect(result.content[0]?.text).toBe('hello');
   });
 });
 

--- a/apps/api/src/services/clientSessionTools.ts
+++ b/apps/api/src/services/clientSessionTools.ts
@@ -172,6 +172,9 @@ export type ResolveClientDeclaredOutcome = 'resolved' | 'duplicate' | 'not_found
 
 interface PendingClientDeclaredTool {
   sessionId: string;
+  /** The declared tool name for this call, kept so a resolved result can be
+   *  persisted with its tool name (recovered via peekClientDeclaredToolName). */
+  toolName: string;
   timer: ReturnType<typeof setTimeout>;
   resolve: (result: ClientToolDispatchResult) => void;
 }
@@ -201,7 +204,7 @@ export function requestClientDeclaredTool(
       });
     }, CLIENT_DECLARED_TOOL_TIMEOUT_MS);
 
-    pending.set(toolUseId, { sessionId: session.breezeSessionId, timer, resolve });
+    pending.set(toolUseId, { sessionId: session.breezeSessionId, toolName, timer, resolve });
     session.eventBus.publish({ type: 'client_tool_request', toolUseId, toolName, input });
   });
 }
@@ -228,6 +231,17 @@ export function resolveClientDeclaredTool(
   resolvedIds.set(toolUseId, sessionId);
   entry.resolve(result.error !== undefined ? { error: result.error } : { output: result.output ?? null });
   return 'resolved';
+}
+
+/**
+ * Return the declared tool name of a still-pending call owned by `sessionId`,
+ * or undefined if no such call is parked. Read BEFORE resolveClientDeclaredTool
+ * (which deletes the entry) so a resolved result can be persisted with its name.
+ * Generic: carries no knowledge of any specific tool's semantics.
+ */
+export function peekClientDeclaredToolName(sessionId: string, toolUseId: string): string | undefined {
+  const entry = pending.get(toolUseId);
+  return entry && entry.sessionId === sessionId ? entry.toolName : undefined;
 }
 
 /** Fail + drain every parked call of a session on teardown. Returns the count. */

--- a/apps/api/src/services/clientSessionTools.ts
+++ b/apps/api/src/services/clientSessionTools.ts
@@ -1,0 +1,312 @@
+/**
+ * Client-declared session tools — a GENERIC bridge that lets a session client
+ * (e.g. the tray Helper) declare its own tools at session creation and execute
+ * them itself, while the Agent SDK loop on the server drives them.
+ *
+ * This mirrors the AI-for-Office tool bridge (clientAiToolBridge.ts +
+ * clientAiTools.ts) but carries NO product vocabulary: the declarations, their
+ * schemas, and the HTTP execution path all live in the client. The server only:
+ *   1. validates the declarations (zod),
+ *   2. builds an SDK MCP server from them (createSdkMcpServer/tool()),
+ *   3. on each model tool call, publishes a `client_tool_request` SSE event and
+ *      parks a resolver, then awaits the client's POST /tool-results (or a 60s
+ *      timeout).
+ *
+ * The pending map is in-process memory by design — the SDK session is a child
+ * subprocess of this API instance and each session is pinned to one instance,
+ * the same affinity the technician approval endpoint already relies on. Entries
+ * are keyed by toolUseId (not secrets: a cross-session guard rejects a post that
+ * carries another session's id) and are drained on session teardown.
+ */
+
+import { z } from 'zod';
+import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
+import type { ActiveSession } from './streamingSessionManager';
+
+// ============================================
+// Declaration validation (zod)
+// ============================================
+
+/** Generic namespace for the SDK MCP server built from client declarations. */
+export const CLIENT_DECLARED_MCP_SERVER_NAME = 'client_tools';
+export const MAX_CLIENT_DECLARED_TOOLS = 8;
+export const MAX_CLIENT_DECLARED_SCHEMA_DEPTH = 3;
+export const CLIENT_DECLARED_TOOL_TIMEOUT_MS = 60_000;
+
+const TOOL_NAME_RE = /^[a-z][a-z0-9_]{2,40}$/;
+
+/**
+ * A JSON Schema node. Intentionally a flat, NON-recursive record: the wire
+ * schema is validated structurally (depth capped at MAX_CLIENT_DECLARED_SCHEMA_DEPTH)
+ * and walked at runtime, so a recursive compile-time type buys nothing and only
+ * risks exploding the type checker.
+ */
+export type JsonSchemaNode = Record<string, unknown>;
+
+export interface ClientToolDeclaration {
+  name: string;
+  description: string;
+  inputSchema: JsonSchemaNode;
+}
+
+/**
+ * Max nesting depth of a JSON Schema node. A flat object of scalar properties is
+ * depth 2 (the object is 1, each property node is 2); one level of nested object
+ * is depth 3. Anything deeper than MAX_CLIENT_DECLARED_SCHEMA_DEPTH is rejected
+ * so a client cannot smuggle an unbounded/pathological schema into the model.
+ */
+export function jsonSchemaDepth(node: unknown, depth = 1): number {
+  if (!node || typeof node !== 'object') return depth;
+  const n = node as Record<string, unknown>;
+  let max = depth;
+  if (n.properties && typeof n.properties === 'object') {
+    for (const child of Object.values(n.properties as Record<string, unknown>)) {
+      max = Math.max(max, jsonSchemaDepth(child, depth + 1));
+    }
+  }
+  if (n.items && typeof n.items === 'object') {
+    max = Math.max(max, jsonSchemaDepth(n.items, depth + 1));
+  }
+  return max;
+}
+
+const jsonSchemaObjectSchema = z
+  .record(z.string(), z.unknown())
+  .refine((s) => s.type === 'object', { message: 'inputSchema.type must be "object"' })
+  .refine((s) => jsonSchemaDepth(s) <= MAX_CLIENT_DECLARED_SCHEMA_DEPTH, {
+    message: `inputSchema must be at most ${MAX_CLIENT_DECLARED_SCHEMA_DEPTH} levels deep`,
+  });
+
+export const clientToolDeclarationSchema = z.object({
+  name: z.string().regex(TOOL_NAME_RE, 'invalid tool name'),
+  description: z.string().min(1).max(2048),
+  inputSchema: jsonSchemaObjectSchema,
+});
+
+export const clientToolsSchema = z
+  .array(clientToolDeclarationSchema)
+  .max(MAX_CLIENT_DECLARED_TOOLS)
+  .superRefine((tools, ctx) => {
+    const seen = new Set<string>();
+    for (const t of tools) {
+      if (seen.has(t.name)) {
+        ctx.addIssue({ code: 'custom', message: `duplicate tool name: ${t.name}` });
+      }
+      seen.add(t.name);
+    }
+  });
+
+// ============================================
+// JSON Schema → Zod raw shape (for the SDK's tool())
+// ============================================
+
+/**
+ * The SDK's tool() takes a Zod raw shape and re-derives the wire JSON Schema
+ * from it (zod v4 toJSONSchema). The client sends JSON Schema, so convert the
+ * supported subset back to zod so the model sees the right parameter names,
+ * types, descriptions, and required-ness. Unknown constructs degrade to
+ * z.unknown() rather than throwing — the client, not the server, owns semantics.
+ */
+function jsonSchemaNodeToZodType(node: Record<string, unknown>): z.ZodTypeAny {
+  const description = typeof node.description === 'string' ? node.description : undefined;
+  let t: z.ZodTypeAny;
+
+  if (Array.isArray(node.enum) && node.enum.length > 0) {
+    const values = node.enum.filter((v): v is string => typeof v === 'string');
+    t = values.length > 0 ? z.enum(values as [string, ...string[]]) : z.string();
+  } else {
+    switch (node.type) {
+      case 'string':
+        t = z.string();
+        break;
+      case 'number':
+        t = z.number();
+        break;
+      case 'integer':
+        t = z.number().int();
+        break;
+      case 'boolean':
+        t = z.boolean();
+        break;
+      case 'array':
+        t = z.array(
+          node.items && typeof node.items === 'object'
+            ? jsonSchemaNodeToZodType(node.items as Record<string, unknown>)
+            : z.unknown(),
+        );
+        break;
+      case 'object':
+        t = z.object(jsonSchemaObjectToZodShape(node));
+        break;
+      default:
+        t = z.unknown();
+    }
+  }
+
+  return description ? t.describe(description) : t;
+}
+
+export function jsonSchemaObjectToZodShape(schema: Record<string, unknown>): z.ZodRawShape {
+  const shape: z.ZodRawShape = {};
+  const required = new Set(Array.isArray(schema.required) ? (schema.required as string[]) : []);
+  const properties = (schema.properties as Record<string, unknown> | undefined) ?? {};
+  for (const [key, prop] of Object.entries(properties)) {
+    if (!prop || typeof prop !== 'object') continue;
+    let t = jsonSchemaNodeToZodType(prop as Record<string, unknown>);
+    if (!required.has(key)) t = t.optional();
+    shape[key] = t;
+  }
+  return shape;
+}
+
+// ============================================
+// Pending-call bridge (park → publish → resolve/timeout)
+// ============================================
+
+export interface ClientToolDispatchResult {
+  output?: unknown;
+  error?: string;
+}
+
+export type ResolveClientDeclaredOutcome = 'resolved' | 'duplicate' | 'not_found';
+
+interface PendingClientDeclaredTool {
+  sessionId: string;
+  timer: ReturnType<typeof setTimeout>;
+  resolve: (result: ClientToolDispatchResult) => void;
+}
+
+const pending = new Map<string, PendingClientDeclaredTool>();
+/** toolUseId → owning sessionId, kept only to answer a duplicate post with 409. */
+const resolvedIds = new Map<string, string>();
+
+/**
+ * Park a resolver for one model tool call and publish `client_tool_request`.
+ * The returned promise settles when the client posts a result, or after
+ * CLIENT_DECLARED_TOOL_TIMEOUT_MS with a "client did not respond" error.
+ */
+export function requestClientDeclaredTool(
+  session: ActiveSession,
+  toolUseId: string,
+  toolName: string,
+  input: Record<string, unknown>,
+): Promise<ClientToolDispatchResult> {
+  return new Promise<ClientToolDispatchResult>((resolve) => {
+    const timer = setTimeout(() => {
+      pending.delete(toolUseId);
+      resolve({
+        error: `Tool '${toolName}' timed out after ${Math.round(
+          CLIENT_DECLARED_TOOL_TIMEOUT_MS / 1000,
+        )}s — the client did not respond.`,
+      });
+    }, CLIENT_DECLARED_TOOL_TIMEOUT_MS);
+
+    pending.set(toolUseId, { sessionId: session.breezeSessionId, timer, resolve });
+    session.eventBus.publish({ type: 'client_tool_request', toolUseId, toolName, input });
+  });
+}
+
+/**
+ * Resolve a parked call from POST /tool-results.
+ *  - 'resolved'  — the call was pending for this session and is now settled.
+ *  - 'duplicate' — this session already resolved this id (→ HTTP 409).
+ *  - 'not_found' — unknown id, timed out, or owned by another session (→ 404).
+ */
+export function resolveClientDeclaredTool(
+  sessionId: string,
+  toolUseId: string,
+  result: ClientToolDispatchResult,
+): ResolveClientDeclaredOutcome {
+  const entry = pending.get(toolUseId);
+  if (!entry) {
+    return resolvedIds.get(toolUseId) === sessionId ? 'duplicate' : 'not_found';
+  }
+  if (entry.sessionId !== sessionId) return 'not_found';
+
+  clearTimeout(entry.timer);
+  pending.delete(toolUseId);
+  resolvedIds.set(toolUseId, sessionId);
+  entry.resolve(result.error !== undefined ? { error: result.error } : { output: result.output ?? null });
+  return 'resolved';
+}
+
+/** Fail + drain every parked call of a session on teardown. Returns the count. */
+export function failPendingClientDeclaredForSession(sessionId: string, reason = 'session_closed'): number {
+  let failed = 0;
+  for (const [toolUseId, entry] of [...pending.entries()]) {
+    if (entry.sessionId !== sessionId) continue;
+    clearTimeout(entry.timer);
+    pending.delete(toolUseId);
+    entry.resolve({ error: reason });
+    failed++;
+  }
+  for (const [toolUseId, owner] of [...resolvedIds.entries()]) {
+    if (owner === sessionId) resolvedIds.delete(toolUseId);
+  }
+  return failed;
+}
+
+/** Test-only visibility into the pending map. */
+export function _pendingClientDeclaredCountForTests(): number {
+  return pending.size;
+}
+
+// ============================================
+// SDK MCP server construction
+// ============================================
+
+export type ClientDeclaredToolHandlerResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+};
+
+/** A session-bound dispatcher: publish + park + await for one tool call. */
+export type ClientToolDispatch = (
+  toolName: string,
+  input: Record<string, unknown>,
+) => Promise<ClientToolDispatchResult>;
+
+function textResult(text: string, isError = false): ClientDeclaredToolHandlerResult {
+  return { content: [{ type: 'text' as const, text }], isError };
+}
+
+/**
+ * Build the SDK tool handler for one declared tool: dispatch to the client and
+ * map its result to a CallToolResult. Extracted for direct unit testing.
+ */
+export function makeClientDeclaredToolHandler(toolName: string, dispatch: ClientToolDispatch) {
+  return async (args: Record<string, unknown>): Promise<ClientDeclaredToolHandlerResult> => {
+    const result = await dispatch(toolName, args ?? {});
+    if (result.error !== undefined) {
+      return textResult(result.error, true);
+    }
+    const text = typeof result.output === 'string' ? result.output : JSON.stringify(result.output ?? null);
+    return textResult(text);
+  };
+}
+
+/** Prefixed MCP tool names (the SDK allowlist) for a set of declarations. */
+export function clientDeclaredToolMcpNames(decls: ClientToolDeclaration[]): string[] {
+  return decls.map((d) => `mcp__${CLIENT_DECLARED_MCP_SERVER_NAME}__${d.name}`);
+}
+
+/**
+ * Build the SDK MCP server from validated declarations. `dispatch` is bound to
+ * the live session by the caller (see the helper chat route). Plug the returned
+ * server into streamingSessionManager.getOrCreate via its mcpServerFactory
+ * parameter (the clientAi/sessions.ts precedent).
+ */
+export function createClientDeclaredMcpServer(decls: ClientToolDeclaration[], dispatch: ClientToolDispatch) {
+  return createSdkMcpServer({
+    name: CLIENT_DECLARED_MCP_SERVER_NAME,
+    version: '1.0.0',
+    tools: decls.map((decl) =>
+      tool(
+        decl.name,
+        decl.description,
+        jsonSchemaObjectToZodShape(decl.inputSchema),
+        makeClientDeclaredToolHandler(decl.name, dispatch),
+      ),
+    ),
+  });
+}

--- a/apps/api/src/services/clientSessionTools.ts
+++ b/apps/api/src/services/clientSessionTools.ts
@@ -147,7 +147,8 @@ function jsonSchemaNodeToZodType(node: Record<string, unknown>): z.ZodTypeAny {
 }
 
 export function jsonSchemaObjectToZodShape(schema: Record<string, unknown>): z.ZodRawShape {
-  const shape: z.ZodRawShape = {};
+  // Mutable accumulator: ZodRawShape's index signature is read-only.
+  const shape: Record<string, z.ZodType> = {};
   const required = new Set(Array.isArray(schema.required) ? (schema.required as string[]) : []);
   const properties = (schema.properties as Record<string, unknown> | undefined) ?? {};
   for (const [key, prop] of Object.entries(properties)) {

--- a/apps/api/src/services/helperAiAgent.test.ts
+++ b/apps/api/src/services/helperAiAgent.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { buildHelperSystemPrompt } from './helperAiAgent';
+
+const BASE = {
+  hostname: 'host-1',
+  deviceId: 'device-1',
+  orgId: 'org-1',
+  permissionLevel: 'basic' as const,
+  osType: 'linux',
+  osVersion: '6.8',
+  agentVersion: '1.0.0',
+};
+
+describe('buildHelperSystemPrompt — device capabilities vs client tools', () => {
+  it('advertises the device-capability section for a normal (no client-tools) session', () => {
+    const prompt = buildHelperSystemPrompt({ ...BASE, hasClientTools: false });
+    expect(prompt).toContain('## Your Capabilities');
+    // basic permission includes get_device_details → its capability line.
+    expect(prompt).toContain('detailed hardware, software, and network information');
+    expect(prompt).not.toContain('## Client Tools');
+  });
+
+  it('suppresses the device-capability section when the session declared client tools', () => {
+    const prompt = buildHelperSystemPrompt({ ...BASE, hasClientTools: true });
+    // The device toolset is unavailable to a client-tools session, so its
+    // capability advertisement must be gone — no "what can you do?" mismatch.
+    expect(prompt).not.toContain('## Your Capabilities');
+    expect(prompt).not.toContain('detailed hardware, software, and network information');
+    // The generic client-tools paragraph is still present.
+    expect(prompt).toContain('## Client Tools');
+    expect(prompt).toContain('client-provided tools');
+    // Core rules survive.
+    expect(prompt).toContain('## Important Rules');
+  });
+});

--- a/apps/api/src/services/helperAiAgent.ts
+++ b/apps/api/src/services/helperAiAgent.ts
@@ -73,10 +73,15 @@ export function buildHelperSystemPrompt(ctx: HelperContext): string {
 
   const parts: string[] = [];
 
-  parts.push(`You are Breeze Helper, an AI assistant running on the user's computer. You help end-users understand their system status, troubleshoot issues, and get IT support.
+  // When the session runs against client-declared tools, the built-in device
+  // toolset is not available to the model — so advertising the device
+  // capabilities would invite requests the session cannot fulfil. Suppress that
+  // section entirely; the generic Client Tools paragraph below is what applies.
+  const capabilitiesSection = ctx.hasClientTools
+    ? ''
+    : `\n\n## Your Capabilities\n${capabilities.join('\n')}`;
 
-## Your Capabilities
-${capabilities.join('\n')}
+  parts.push(`You are Breeze Helper, an AI assistant running on the user's computer. You help end-users understand their system status, troubleshoot issues, and get IT support.${capabilitiesSection}
 
 ## Important Rules
 1. You can ONLY see and act on this specific computer — "${ctx.hostname}".

--- a/apps/api/src/services/helperAiAgent.ts
+++ b/apps/api/src/services/helperAiAgent.ts
@@ -17,6 +17,8 @@ interface HelperContext {
   osType?: string;
   osVersion?: string;
   agentVersion?: string;
+  /** True when the session declared client-provided tools (generic seam). */
+  hasClientTools?: boolean;
 }
 
 /**
@@ -93,6 +95,12 @@ ${capabilities.join('\n')}
 
   if (ctx.osType) parts.push(`- OS: ${ctx.osType}${ctx.osVersion ? ` ${ctx.osVersion}` : ''}`);
   if (ctx.agentVersion) parts.push(`- Agent Version: ${ctx.agentVersion}`);
+
+  if (ctx.hasClientTools) {
+    parts.push(
+      '\n## Client Tools\nThis session has client-provided tools; prefer them for questions about the user\'s files/content, and follow each tool description\'s citation instructions.',
+    );
+  }
 
   return parts.join('\n');
 }

--- a/apps/helper/src/components/shell/ChatView.test.tsx
+++ b/apps/helper/src/components/shell/ChatView.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+
+// jsdom doesn't implement scrollIntoView; ChatView's messages-end effect calls
+// it unconditionally on every render.
+Element.prototype.scrollIntoView = vi.fn();
+
+const { mockInvoke } = vi.hoisted(() => ({ mockInvoke: vi.fn(async () => undefined) }));
+
+vi.mock('../../lib/helperFetch', () => ({
+  helperRequest: vi.fn(),
+  getTauriInvoke: vi.fn(async () => mockInvoke),
+  requireDevBearerToken: vi.fn(),
+}));
+
+import ChatView from './ChatView';
+import { useChatStore } from '../../stores/chatStore';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
+
+function baseChatState(overrides: Record<string, unknown> = {}) {
+  return {
+    connectionState: 'connected' as const,
+    connectionError: null,
+    agentConfig: null,
+    sessionId: 's1',
+    messages: [],
+    isStreaming: false,
+    error: null,
+    username: 'todd',
+    sessions: [],
+    sessionsLoading: false,
+    pendingApproval: null,
+    isFlagged: false,
+    sendMessage: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderChatView() {
+  return render(<ChatView draft="" setDraft={() => {}} />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockInvoke.mockResolvedValue(undefined);
+  useChatStore.setState(baseChatState());
+});
+
+describe('tool_result rendering', () => {
+  it('a search_workspace_files tool_result renders a file card list (name + project/docType + Open) instead of nothing', () => {
+    useChatStore.setState(
+      baseChatState({
+        messages: [
+          {
+            id: 'result-t1',
+            role: 'tool_result',
+            content: '{}',
+            toolName: 'search_workspace_files',
+            toolUseId: 't1',
+            toolOutput: {
+              files: [
+                {
+                  fileIndexId: 'abc',
+                  relPath: 'Projects/Henderson/easement.pdf',
+                  project: 'Henderson',
+                  docType: 'Easement',
+                  openPath: '/srv/share/Projects/Henderson/easement.pdf',
+                },
+              ],
+            },
+            createdAt: new Date(),
+          },
+        ],
+      }),
+    );
+
+    renderChatView();
+
+    expect(screen.getByText('easement.pdf')).toBeInTheDocument();
+    expect(screen.getByText('Henderson — Easement')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open' })).toBeInTheDocument();
+  });
+
+  it('a get_file_passages tool_result (not a file search) still renders nothing, matching today\'s behavior', () => {
+    useChatStore.setState(
+      baseChatState({
+        messages: [
+          {
+            id: 'result-t2',
+            role: 'tool_result',
+            content: '{}',
+            toolName: 'get_file_passages',
+            toolUseId: 't2',
+            toolOutput: {
+              passages: [
+                {
+                  fileIndexId: 'abc',
+                  relPath: 'Projects/Henderson/easement.pdf',
+                  sourceId: 's1',
+                  openPath: '/srv/share/Projects/Henderson/easement.pdf',
+                  snippet: 'The easement runs along...',
+                  score: 0.9,
+                },
+              ],
+            },
+            createdAt: new Date(),
+          },
+        ],
+      }),
+    );
+
+    const { container } = renderChatView();
+    // Only the empty-state / composer chrome renders — no card, no snippet text.
+    expect(screen.queryByText('easement.pdf')).not.toBeInTheDocument();
+    expect(screen.queryByText(/easement runs along/)).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="chat-file-card-list"]')).toBeNull();
+  });
+});
+
+describe('citation chips', () => {
+  function messagesWithCitation(content: string) {
+    return [
+      {
+        id: 'result-t1',
+        role: 'tool_result' as const,
+        content: '{}',
+        toolName: 'get_file_passages',
+        toolUseId: 't1',
+        toolOutput: {
+          passages: [
+            {
+              fileIndexId: 'abc',
+              relPath: 'Projects/Henderson/easement.pdf',
+              sourceId: 's1',
+              openPath: '/srv/share/Projects/Henderson/easement.pdf',
+              snippet: 'text',
+              score: 0.9,
+            },
+          ],
+        },
+        createdAt: new Date(),
+      },
+      {
+        id: 'a1',
+        role: 'assistant' as const,
+        content,
+        createdAt: new Date(),
+      },
+    ];
+  }
+
+  it('a resolvable citation token renders as a chip labeled with the file basename', () => {
+    useChatStore.setState(
+      baseChatState({
+        messages: messagesWithCitation(
+          'The easement is described in [file:abc|Projects/Henderson/easement.pdf].',
+        ),
+      }),
+    );
+
+    renderChatView();
+
+    const chip = screen.getByRole('button', { name: 'easement.pdf' });
+    expect(chip).toBeInTheDocument();
+  });
+
+  it('clicking a citation chip opens the resolved openPath', async () => {
+    const recordActivitySpy = vi.spyOn(useWorkspaceStore.getState(), 'recordActivity');
+    useChatStore.setState(
+      baseChatState({
+        messages: messagesWithCitation('See [file:abc|Projects/Henderson/easement.pdf].'),
+      }),
+    );
+
+    renderChatView();
+    fireEvent.click(screen.getByRole('button', { name: 'easement.pdf' }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(recordActivitySpy).toHaveBeenCalledWith('abc', 'open', 'todd');
+    expect(mockInvoke).toHaveBeenCalledWith('open_workspace_path', {
+      input: { path: '/srv/share/Projects/Henderson/easement.pdf' },
+    });
+  });
+
+  it('an unresolvable citation id renders as plain text, not a chip', () => {
+    useChatStore.setState(
+      baseChatState({
+        messages: messagesWithCitation('See [file:zzz|Projects/unknown.pdf] for details.'),
+      }),
+    );
+
+    renderChatView();
+
+    expect(screen.queryByRole('button', { name: 'unknown.pdf' })).not.toBeInTheDocument();
+    expect(screen.getByText(/\[file:zzz\|Projects\/unknown\.pdf\]/)).toBeInTheDocument();
+  });
+});

--- a/apps/helper/src/components/shell/ChatView.test.tsx
+++ b/apps/helper/src/components/shell/ChatView.test.tsx
@@ -183,6 +183,50 @@ describe('citation chips', () => {
     });
   });
 
+  it('a resolved-but-null openPath citation renders a disabled chip that does not open', async () => {
+    useChatStore.setState(
+      baseChatState({
+        messages: [
+          {
+            id: 'result-t1',
+            role: 'tool_result' as const,
+            content: '{}',
+            toolName: 'get_file_passages',
+            toolUseId: 't1',
+            toolOutput: {
+              passages: [
+                {
+                  fileIndexId: 'abc',
+                  relPath: 'Projects/Henderson/easement.pdf',
+                  sourceId: 's1',
+                  openPath: null,
+                  snippet: 'text',
+                  score: 0.9,
+                },
+              ],
+            },
+            createdAt: new Date(),
+          },
+          {
+            id: 'a1',
+            role: 'assistant' as const,
+            content: 'See [file:abc|Projects/Henderson/easement.pdf].',
+            createdAt: new Date(),
+          },
+        ],
+      }),
+    );
+
+    renderChatView();
+
+    const chip = screen.getByRole('button', { name: 'easement.pdf' });
+    expect(chip).toBeDisabled();
+    fireEvent.click(chip);
+    await Promise.resolve();
+    // A disabled chip must not trigger the open path (no Tauri invoke).
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
   it('an unresolvable citation id renders as plain text, not a chip', () => {
     useChatStore.setState(
       baseChatState({

--- a/apps/helper/src/components/shell/ChatView.tsx
+++ b/apps/helper/src/components/shell/ChatView.tsx
@@ -1,12 +1,130 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useChatStore } from '../../stores/chatStore';
+import ChatFileCard, {
+  openWorkspaceFile,
+  type WorkspaceFileSummary,
+} from '../workspace/ChatFileCard';
 
 // Extracted from App.tsx's default return (messages map, composer,
 // ThinkingIndicator). Reads the chat store directly, as App did. The composer
 // draft is owned by the shell (single definition) and threaded through props so
 // text survives a panel <-> full-swap conversion across the breakpoint.
+
+// Citation token the model is instructed to emit for every passage it cites
+// (see workspaceChatTools.ts's get_file_passages description): [file:<id>|<relPath>].
+const CITATION_RE = /\[file:([^|\]]+)\|([^\]]+)\]/g;
+
+interface FileResolution {
+  relPath: string;
+  openPath: string | null;
+}
+
+/**
+ * Resolves citation tokens to an openable file: scans every tool_result in
+ * the session for `search_workspace_files`/`get_file_passages` output rows
+ * (duck-typed by an output `files`/`passages` array — robust to toolName
+ * being unset on live-streamed tool_result messages, since the wire's
+ * `tool_result` SSE event carries no toolName, only toolUseId) and keeps the
+ * last row seen per fileIndexId.
+ */
+function buildFileResolutionMap(messages: { role: string; toolOutput?: unknown }[]) {
+  const map = new Map<string, FileResolution>();
+  for (const msg of messages) {
+    if (msg.role !== 'tool_result') continue;
+    const output = msg.toolOutput as
+      | { files?: WorkspaceFileSummary[]; passages?: WorkspaceFileSummary[] }
+      | undefined;
+    const rows = output?.files ?? output?.passages;
+    if (!Array.isArray(rows)) continue;
+    for (const row of rows) {
+      if (row && typeof row.fileIndexId === 'string' && typeof row.relPath === 'string') {
+        map.set(row.fileIndexId, { relPath: row.relPath, openPath: row.openPath ?? null });
+      }
+    }
+  }
+  return map;
+}
+
+function fileBaseName(relPath: string): string {
+  const parts = relPath.split('/');
+  return parts[parts.length - 1] || relPath;
+}
+
+function CitationChip({
+  fileIndexId,
+  resolution,
+  username,
+}: {
+  fileIndexId: string;
+  resolution: FileResolution;
+  username: string | null;
+}) {
+  return (
+    <button
+      type="button"
+      className="helper-citation-chip"
+      title={resolution.relPath}
+      onClick={() => {
+        openWorkspaceFile(fileIndexId, resolution.openPath, username);
+      }}
+    >
+      {fileBaseName(resolution.relPath)}
+    </button>
+  );
+}
+
+/**
+ * Replaces `[file:<id>|<relPath>]` citation tokens found in markdown text
+ * children with clickable chips; an id that doesn't resolve (not seen in any
+ * tool_result this session) is left as plain text — no chip. Only string
+ * children are scanned; nested markdown elements (links, code, bold) pass
+ * through untouched.
+ */
+function withCitations(
+  children: React.ReactNode,
+  resolveMap: Map<string, FileResolution>,
+  username: string | null,
+): React.ReactNode {
+  const items = Array.isArray(children) ? children : [children];
+  const out: React.ReactNode[] = [];
+
+  items.forEach((child, itemIndex) => {
+    if (typeof child !== 'string') {
+      out.push(child);
+      return;
+    }
+
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+    let matchIndex = 0;
+    CITATION_RE.lastIndex = 0;
+    while ((match = CITATION_RE.exec(child))) {
+      const [full, fileIndexId] = match;
+      if (match.index > lastIndex) out.push(child.slice(lastIndex, match.index));
+
+      const resolution = resolveMap.get(fileIndexId);
+      if (resolution) {
+        out.push(
+          <CitationChip
+            key={`cite-${itemIndex}-${matchIndex}`}
+            fileIndexId={fileIndexId}
+            resolution={resolution}
+            username={username}
+          />,
+        );
+      } else {
+        out.push(full);
+      }
+      lastIndex = match.index + full.length;
+      matchIndex += 1;
+    }
+    if (lastIndex < child.length) out.push(child.slice(lastIndex));
+  });
+
+  return out;
+}
 
 function ToolCallIndicator({ toolName }: { toolName?: string }) {
   const label = toolName
@@ -42,6 +160,7 @@ export default function ChatView({
 }) {
   const { messages, isStreaming, username, sendMessage } = useChatStore();
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const fileResolutionMap = useMemo(() => buildFileResolutionMap(messages), [messages]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -78,6 +197,13 @@ export default function ChatView({
           }
 
           if (msg.role === 'tool_result') {
+            // Only search_workspace_files results render as cards (duck-typed
+            // via an output `files` array — get_file_passages and any other
+            // tool result stay internal, today's behavior, rendering nothing).
+            const output = msg.toolOutput as { files?: WorkspaceFileSummary[] } | undefined;
+            if (Array.isArray(output?.files)) {
+              return <ChatFileCard key={msg.id} files={output.files} />;
+            }
             return null; // Tool results are internal, not shown to end users
           }
 
@@ -89,7 +215,13 @@ export default function ChatView({
               <div className="helper-message-content">
                 {msg.role === 'assistant' ? (
                   <>
-                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm]}
+                      components={{
+                        p: ({ children }) => <p>{withCitations(children, fileResolutionMap, username)}</p>,
+                        li: ({ children }) => <li>{withCitations(children, fileResolutionMap, username)}</li>,
+                      }}
+                    >
                       {msg.content}
                     </ReactMarkdown>
                     {msg.isStreaming && <span className="helper-cursor" />}

--- a/apps/helper/src/components/shell/ChatView.tsx
+++ b/apps/helper/src/components/shell/ChatView.tsx
@@ -61,11 +61,17 @@ function CitationChip({
   resolution: FileResolution;
   username: string | null;
 }) {
+  // A resolution with a null openPath cannot be opened (openWorkspaceFile
+  // no-ops immediately), so render the chip disabled/non-interactive — matching
+  // ChatFileCard's Open button — rather than a clickable chip that silently
+  // does nothing. Still labeled and title-tooltipped.
+  const openable = resolution.openPath !== null;
   return (
     <button
       type="button"
       className="helper-citation-chip"
       title={resolution.relPath}
+      disabled={!openable}
       onClick={() => {
         openWorkspaceFile(fileIndexId, resolution.openPath, username);
       }}

--- a/apps/helper/src/components/workspace/ChatFileCard.test.tsx
+++ b/apps/helper/src/components/workspace/ChatFileCard.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+
+const { mockInvoke } = vi.hoisted(() => ({ mockInvoke: vi.fn(async () => undefined) }));
+
+vi.mock('../../lib/helperFetch', () => ({
+  helperRequest: vi.fn(),
+  getTauriInvoke: vi.fn(async () => mockInvoke),
+  requireDevBearerToken: vi.fn(),
+}));
+
+import ChatFileCard, { openWorkspaceFile, type WorkspaceFileSummary } from './ChatFileCard';
+import { useChatStore } from '../../stores/chatStore';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
+
+function summary(overrides: Partial<WorkspaceFileSummary> = {}): WorkspaceFileSummary {
+  return {
+    fileIndexId: 'f1',
+    relPath: 'Projects/Henderson/easement.pdf',
+    project: 'Henderson',
+    docType: 'Easement',
+    openPath: '/srv/share/Projects/Henderson/easement.pdf',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockInvoke.mockResolvedValue(undefined);
+  useChatStore.setState({ username: 'todd', agentConfig: null });
+});
+
+it('renders name and a project — docType meta line, and an Open button', () => {
+  render(<ChatFileCard files={[summary()]} />);
+  expect(screen.getByText('easement.pdf')).toBeInTheDocument();
+  expect(screen.getByText('Henderson — Easement')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Open' })).toBeInTheDocument();
+});
+
+it('renders nothing for an empty file list', () => {
+  const { container } = render(<ChatFileCard files={[]} />);
+  expect(container).toBeEmptyDOMElement();
+});
+
+it('omits the meta line when project and docType are both absent', () => {
+  render(<ChatFileCard files={[summary({ project: null, docType: null })]} />);
+  expect(screen.getByText('easement.pdf')).toBeInTheDocument();
+  expect(screen.queryByText('Henderson — Easement')).not.toBeInTheDocument();
+});
+
+it('clicking Open records activity and invokes open_workspace_path with the openPath', async () => {
+  const recordActivitySpy = vi.spyOn(useWorkspaceStore.getState(), 'recordActivity');
+  render(<ChatFileCard files={[summary()]} />);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+  await Promise.resolve();
+  await Promise.resolve();
+
+  expect(recordActivitySpy).toHaveBeenCalledWith('f1', 'open', 'todd');
+  expect(mockInvoke).toHaveBeenCalledWith('open_workspace_path', {
+    input: { path: '/srv/share/Projects/Henderson/easement.pdf' },
+  });
+});
+
+it('the Open button is disabled when openPath is null', () => {
+  render(<ChatFileCard files={[summary({ openPath: null })]} />);
+  expect(screen.getByRole('button', { name: 'Open' })).toBeDisabled();
+});
+
+describe('openWorkspaceFile', () => {
+  it('returns false and does nothing when openPath is null', async () => {
+    const ok = await openWorkspaceFile('f1', null, 'todd');
+    expect(ok).toBe(false);
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the clipboard and returns false when invoke throws', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    mockInvoke.mockRejectedValueOnce(new Error('nope'));
+
+    const ok = await openWorkspaceFile('f1', '/a/b.pdf', 'todd');
+
+    expect(ok).toBe(false);
+    expect(writeText).toHaveBeenCalledWith('/a/b.pdf');
+  });
+});

--- a/apps/helper/src/components/workspace/ChatFileCard.tsx
+++ b/apps/helper/src/components/workspace/ChatFileCard.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { getTauriInvoke } from '../../lib/helperFetch';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
+import { useChatStore } from '../../stores/chatStore';
+
+/**
+ * A `search_workspace_files` tool-result row: the fields ChatFileCard and
+ * ChatView's citation chips need to display and open a file. Matches the
+ * shape `executeWorkspaceChatTool('search_workspace_files', ...)` returns
+ * (see lib/workspaceChatTools.ts) — `project`/`docType` may be absent from a
+ * `get_file_passages` row, which is fine: ChatFileCard never renders those.
+ */
+export interface WorkspaceFileSummary {
+  fileIndexId: string;
+  relPath: string;
+  project?: string | null;
+  docType?: string | null;
+  openPath: string | null;
+}
+
+function fileBaseName(relPath: string): string {
+  const parts = relPath.split('/');
+  return parts[parts.length - 1] || relPath;
+}
+
+/**
+ * Opens a workspace file exactly the way WorkspacePanel's row "Open" action
+ * does (WorkspacePanel.tsx `handleOpen`): record the activity, invoke the
+ * Tauri `open_workspace_path` command, and fall back to copying the path to
+ * the clipboard when opening fails (no Tauri bridge, e.g. dev-browser mode).
+ * Shared by ChatFileCard's Open button and ChatView's citation chips so both
+ * paths behave identically. Returns whether the file was actually opened.
+ */
+export async function openWorkspaceFile(
+  fileIndexId: string,
+  openPath: string | null,
+  username: string | null,
+): Promise<boolean> {
+  if (!openPath) return false;
+  await useWorkspaceStore.getState().recordActivity(fileIndexId, 'open', username);
+  try {
+    const invoke = await getTauriInvoke();
+    if (!invoke) {
+      throw new Error('Opening files requires the desktop app');
+    }
+    await invoke('open_workspace_path', { input: { path: openPath } });
+    return true;
+  } catch {
+    navigator.clipboard.writeText(openPath).catch(() => {});
+    return false;
+  }
+}
+
+/**
+ * Result cards for a `search_workspace_files` tool result, rendered inline in
+ * chat (ChatView). Styled on the same `--ws-*` tokens and typography scale as
+ * FileTable's rows (13px name / 12px secondary meta) so a card reads as the
+ * same "file row" language wherever it appears — including the 340px side
+ * panel, so the layout stays fluid with no fixed widths.
+ */
+export default function ChatFileCard({ files }: { files: WorkspaceFileSummary[] }) {
+  const username = useChatStore((s) => s.username);
+  const [errorId, setErrorId] = useState<string | null>(null);
+
+  if (files.length === 0) return null;
+
+  const handleOpen = async (file: WorkspaceFileSummary) => {
+    setErrorId((cur) => (cur === file.fileIndexId ? null : cur));
+    const opened = await openWorkspaceFile(file.fileIndexId, file.openPath, username);
+    if (!opened) setErrorId(file.fileIndexId);
+  };
+
+  return (
+    <div className="helper-file-card-list" data-testid="chat-file-card-list">
+      {files.map((file) => {
+        const meta = [file.project, file.docType].filter(Boolean).join(' — ');
+        return (
+          <div
+            key={file.fileIndexId}
+            className="helper-file-card-row bg-ws-surface rounded-surface shadow-[var(--ws-shadow-1)]"
+          >
+
+            <div className="helper-file-card-info">
+              <span className="helper-file-card-name" title={file.relPath}>
+                {fileBaseName(file.relPath)}
+              </span>
+              {meta && <span className="helper-file-card-meta">{meta}</span>}
+              {errorId === file.fileIndexId && (
+                <span className="helper-file-card-error">Couldn't open — path copied instead</span>
+              )}
+            </div>
+            <button
+              type="button"
+              className="helper-file-card-open"
+              onClick={() => handleOpen(file)}
+              disabled={!file.openPath}
+            >
+              Open
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/helper/src/lib/workspaceChatTools.test.ts
+++ b/apps/helper/src/lib/workspaceChatTools.test.ts
@@ -108,6 +108,15 @@ describe('search_workspace_files executor', () => {
     expect(url).not.toContain('project=');
     expect(url).not.toContain('docType=');
   });
+
+  it('truncates a q longer than 200 chars in the request URL', async () => {
+    helperRequestMock.mockResolvedValue(ok({ results: [] }));
+    const longQ = 'a'.repeat(300);
+    await executeWorkspaceChatTool('search_workspace_files', { q: longQ });
+    const [, url] = helperRequestMock.mock.calls[0];
+    const sent = new URL(url).searchParams.get('q');
+    expect(sent).toBe('a'.repeat(200));
+  });
 });
 
 describe('get_file_passages executor', () => {
@@ -143,6 +152,15 @@ describe('get_file_passages executor', () => {
     await executeWorkspaceChatTool('get_file_passages', { q: 'q' });
     const [, url] = helperRequestMock.mock.calls[0];
     expect(url).not.toContain('fileIndexId=');
+  });
+
+  it('truncates a q longer than 200 chars in the request URL', async () => {
+    helperRequestMock.mockResolvedValue(ok({ passages: [] }));
+    const longQ = 'b'.repeat(500);
+    await executeWorkspaceChatTool('get_file_passages', { q: longQ });
+    const [, url] = helperRequestMock.mock.calls[0];
+    const sent = new URL(url).searchParams.get('q');
+    expect(sent).toBe('b'.repeat(200));
   });
 });
 

--- a/apps/helper/src/lib/workspaceChatTools.test.ts
+++ b/apps/helper/src/lib/workspaceChatTools.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./helperFetch', () => ({
+  helperRequest: vi.fn(),
+  getTauriInvoke: vi.fn(async () => null),
+  requireDevBearerToken: vi.fn(),
+}));
+
+import { helperRequest } from './helperFetch';
+import { useChatStore } from '../stores/chatStore';
+import { WORKSPACE_CHAT_TOOLS, executeWorkspaceChatTool } from './workspaceChatTools';
+
+const helperRequestMock = vi.mocked(helperRequest);
+const AGENT_CONFIG = { api_url: 'http://localhost:3001', agent_id: 'agent-1' };
+
+function ok(body: unknown, status = 200) {
+  return { ok: true, status, body: JSON.stringify(body) };
+}
+function fail(body: unknown, status = 500) {
+  return { ok: false, status, body: JSON.stringify(body) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useChatStore.setState({ agentConfig: AGENT_CONFIG });
+});
+
+describe('WORKSPACE_CHAT_TOOLS declarations', () => {
+  it('declares exactly the two chat tools with valid names and object schemas', () => {
+    expect(WORKSPACE_CHAT_TOOLS.map((t) => t.name)).toEqual([
+      'search_workspace_files',
+      'get_file_passages',
+    ]);
+    for (const t of WORKSPACE_CHAT_TOOLS) {
+      expect(t.name).toMatch(/^[a-z][a-z0-9_]{2,40}$/);
+      expect(t.description.length).toBeGreaterThan(0);
+      expect(t.inputSchema.type).toBe('object');
+      expect(t.inputSchema.required).toContain('q');
+    }
+  });
+
+  it('instructs the citation format in get_file_passages description', () => {
+    const passages = WORKSPACE_CHAT_TOOLS.find((t) => t.name === 'get_file_passages')!;
+    expect(passages.description).toContain('[file:<fileIndexId>|<relPath>]');
+  });
+});
+
+describe('search_workspace_files executor', () => {
+  it('calls /search with q/project/docType and returns files trimmed to 8 summaries', async () => {
+    const results = Array.from({ length: 10 }, (_, i) => ({
+      id: `f${i}`,
+      relPath: `clients/henderson/${i}.pdf`,
+      openPath: `\\\\srv\\share\\${i}.pdf`,
+      inferredProjectLabel: 'Henderson',
+      inferredDocType: 'easement',
+      // extraneous FinderFile fields that must NOT leak into the summary
+      name: `${i}.pdf`,
+      sourceId: 's1',
+      size: 1024,
+    }));
+    helperRequestMock.mockResolvedValue(ok({ results }));
+
+    const out = (await executeWorkspaceChatTool('search_workspace_files', {
+      q: 'henderson',
+      project: 'Henderson',
+      docType: 'easement',
+    })) as { files: Array<Record<string, unknown>> };
+
+    expect(helperRequestMock).toHaveBeenCalledTimes(1);
+    const [, url, opts] = helperRequestMock.mock.calls[0];
+    expect(url).toContain('/api/v1/workspace/helper/search?');
+    expect(url).toContain('q=henderson');
+    expect(url).toContain('project=Henderson');
+    expect(url).toContain('docType=easement');
+    expect(opts?.method).toBe('GET');
+
+    expect(out.files).toHaveLength(8);
+    expect(out.files[0]).toEqual({
+      fileIndexId: 'f0',
+      relPath: 'clients/henderson/0.pdf',
+      project: 'Henderson',
+      docType: 'easement',
+      openPath: '\\\\srv\\share\\0.pdf',
+    });
+  });
+
+  it('falls back to declaredProjectLabel and null docType/openPath', async () => {
+    helperRequestMock.mockResolvedValue(
+      ok({ results: [{ id: 'f1', relPath: 'a.pdf', declaredProjectLabel: 'Alder', openPath: null }] }),
+    );
+    const out = (await executeWorkspaceChatTool('search_workspace_files', { q: 'a' })) as {
+      files: Array<Record<string, unknown>>;
+    };
+    expect(out.files[0]).toEqual({
+      fileIndexId: 'f1',
+      relPath: 'a.pdf',
+      project: 'Alder',
+      docType: null,
+      openPath: null,
+    });
+  });
+
+  it('omits absent optional params from the query string', async () => {
+    helperRequestMock.mockResolvedValue(ok({ results: [] }));
+    await executeWorkspaceChatTool('search_workspace_files', { q: 'x' });
+    const [, url] = helperRequestMock.mock.calls[0];
+    expect(url).toContain('q=x');
+    expect(url).not.toContain('project=');
+    expect(url).not.toContain('docType=');
+  });
+});
+
+describe('get_file_passages executor', () => {
+  it('hits /content/passages, caps to 6 passages and 700-char snippets', async () => {
+    const long = 'x'.repeat(1000);
+    const passages = Array.from({ length: 8 }, (_, i) => ({
+      fileIndexId: `f${i}`,
+      relPath: `p${i}.pdf`,
+      sourceId: 's1',
+      openPath: null,
+      snippet: long,
+      score: 1 - i * 0.1,
+    }));
+    helperRequestMock.mockResolvedValue(ok({ passages }));
+
+    const out = (await executeWorkspaceChatTool('get_file_passages', {
+      q: 'easement terms',
+      fileIndexId: '11111111-1111-1111-1111-111111111111',
+    })) as { passages: Array<{ snippet: string }> };
+
+    const [, url] = helperRequestMock.mock.calls[0];
+    expect(url).toContain('/api/v1/workspace/helper/content/passages?');
+    expect(url).toContain('q=easement');
+    expect(url).toContain('fileIndexId=11111111-1111-1111-1111-111111111111');
+    expect(url).toContain('limit=6');
+
+    expect(out.passages).toHaveLength(6);
+    expect(out.passages[0].snippet.length).toBe(700);
+  });
+
+  it('omits fileIndexId when not provided', async () => {
+    helperRequestMock.mockResolvedValue(ok({ passages: [] }));
+    await executeWorkspaceChatTool('get_file_passages', { q: 'q' });
+    const [, url] = helperRequestMock.mock.calls[0];
+    expect(url).not.toContain('fileIndexId=');
+  });
+});
+
+describe('executor error handling (never throws)', () => {
+  it('returns {error} on a non-ok response', async () => {
+    helperRequestMock.mockResolvedValue(fail({ error: 'boom' }));
+    const out = (await executeWorkspaceChatTool('search_workspace_files', { q: 'x' })) as {
+      error: string;
+    };
+    expect(out.error).toBe('boom');
+  });
+
+  it('returns {error} when helperRequest rejects', async () => {
+    helperRequestMock.mockRejectedValue(new Error('network down'));
+    const out = (await executeWorkspaceChatTool('get_file_passages', { q: 'x' })) as {
+      error: string;
+    };
+    expect(out).toEqual({ error: 'network down' });
+  });
+
+  it('returns {error} for an unknown tool name', async () => {
+    const out = (await executeWorkspaceChatTool('no_such_tool', {})) as { error: string };
+    expect(out.error).toContain('no_such_tool');
+    expect(helperRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('returns {error} when the workspace is not connected', async () => {
+    useChatStore.setState({ agentConfig: null });
+    const out = (await executeWorkspaceChatTool('search_workspace_files', { q: 'x' })) as {
+      error: string;
+    };
+    expect(typeof out.error).toBe('string');
+    expect(helperRequestMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/helper/src/lib/workspaceChatTools.ts
+++ b/apps/helper/src/lib/workspaceChatTools.ts
@@ -28,6 +28,14 @@ export interface ClientToolDeclaration {
 const FILE_LIMIT = 8;
 const PASSAGE_LIMIT = 6;
 const SNIPPET_MAX = 700;
+// The extension's search/passages routes cap `q` at 200 chars and 400 beyond
+// it; a long model question would otherwise be rejected, so truncate here.
+const Q_MAX = 200;
+
+/** Coerce an unknown input value to a query string, capped at Q_MAX chars. */
+function queryString(value: unknown): string {
+  return (typeof value === 'string' ? value : '').slice(0, Q_MAX);
+}
 
 export const WORKSPACE_CHAT_TOOLS: ClientToolDeclaration[] = [
   {
@@ -112,7 +120,7 @@ export async function executeWorkspaceChatTool(
     if (!config) return { error: 'Workspace is not connected.' };
 
     if (name === 'search_workspace_files') {
-      const params = new URLSearchParams({ q: typeof input.q === 'string' ? input.q : '' });
+      const params = new URLSearchParams({ q: queryString(input.q) });
       if (typeof input.project === 'string' && input.project) params.set('project', input.project);
       if (typeof input.docType === 'string' && input.docType) params.set('docType', input.docType);
 
@@ -133,7 +141,7 @@ export async function executeWorkspaceChatTool(
     }
 
     if (name === 'get_file_passages') {
-      const params = new URLSearchParams({ q: typeof input.q === 'string' ? input.q : '' });
+      const params = new URLSearchParams({ q: queryString(input.q) });
       if (typeof input.fileIndexId === 'string' && input.fileIndexId) {
         params.set('fileIndexId', input.fileIndexId);
       }

--- a/apps/helper/src/lib/workspaceChatTools.ts
+++ b/apps/helper/src/lib/workspaceChatTools.ts
@@ -1,0 +1,165 @@
+// Workspace chat tools: the two client-declared tools the helper exposes to the
+// chat model, plus their client-side executors. The declarations are sent to
+// core at session creation (chatStore); execution happens here against the
+// Workspace extension's authenticated `/helper/*` endpoints — the same
+// URL-builder + helperRequest path workspaceStore uses, so device mTLS, org
+// scoping, visibility, and DLP-redacted content all apply by construction.
+//
+// Executor failures degrade to `{ error: string }` and NEVER throw: the model
+// must see a readable, degradable string (the client-ai convention), not a
+// rejected tool call.
+
+import { helperRequest } from './helperFetch';
+import { workspaceUrl } from './workspaceUrl';
+import { useChatStore } from '../stores/chatStore';
+
+/** Wire shape accepted by core's `clientTools` (generic, workspace-agnostic). */
+export interface ClientToolDeclaration {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: 'object';
+    properties: Record<string, { type: string; description?: string }>;
+    required?: string[];
+    additionalProperties?: boolean;
+  };
+}
+
+const FILE_LIMIT = 8;
+const PASSAGE_LIMIT = 6;
+const SNIPPET_MAX = 700;
+
+export const WORKSPACE_CHAT_TOOLS: ClientToolDeclaration[] = [
+  {
+    name: 'search_workspace_files',
+    description:
+      "Find files in the user's workspace by keyword. Returns up to 8 matching " +
+      'files, each with its file id, relative path, inferred project and document ' +
+      'type, and an openable path. Use this to locate documents before reading them.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        q: { type: 'string', description: 'Keywords to search filenames and content for.' },
+        project: { type: 'string', description: 'Optional project label to narrow results.' },
+        docType: { type: 'string', description: 'Optional document type to narrow results.' },
+      },
+      required: ['q'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'get_file_passages',
+    description:
+      'Retrieve up to 6 relevant text passages from workspace file content to answer ' +
+      'a content question. Pass the optional fileIndexId to read passages from one ' +
+      'specific file. ALWAYS cite every passage you rely on in your answer using the ' +
+      'exact form [file:<fileIndexId>|<relPath>] so the user can open the source file.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        q: { type: 'string', description: 'The question or keywords to retrieve passages for.' },
+        fileIndexId: {
+          type: 'string',
+          description: 'Optional file id to restrict passages to a single file.',
+        },
+      },
+      required: ['q'],
+      additionalProperties: false,
+    },
+  },
+];
+
+// The extension's /search returns FinderFile rows; we surface only the summary
+// fields the model needs to cite and open a result.
+interface SearchResultFile {
+  id: string;
+  relPath: string;
+  openPath: string | null;
+  inferredProjectLabel?: string | null;
+  declaredProjectLabel?: string | null;
+  inferredDocType?: string | null;
+}
+
+interface PassageRow {
+  fileIndexId: string;
+  relPath: string;
+  sourceId: string;
+  openPath: string | null;
+  snippet: string;
+  score: number;
+}
+
+function errorString(body: string, fallback: string): string {
+  try {
+    const data = JSON.parse(body) as { error?: unknown };
+    return typeof data.error === 'string' && data.error ? data.error : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Execute one client-declared workspace tool by name. Returns the tool output
+ * (plain JSON the model reads) or a degradable `{ error: string }` — never
+ * throws, never surfaces a raw exception to the model.
+ */
+export async function executeWorkspaceChatTool(
+  name: string,
+  input: Record<string, unknown>,
+): Promise<unknown> {
+  try {
+    const config = useChatStore.getState().agentConfig;
+    if (!config) return { error: 'Workspace is not connected.' };
+
+    if (name === 'search_workspace_files') {
+      const params = new URLSearchParams({ q: typeof input.q === 'string' ? input.q : '' });
+      if (typeof input.project === 'string' && input.project) params.set('project', input.project);
+      if (typeof input.docType === 'string' && input.docType) params.set('docType', input.docType);
+
+      const res = await helperRequest(config, workspaceUrl(config, '/search', params), {
+        method: 'GET',
+      });
+      if (!res.ok) return { error: errorString(res.body, 'File search is unavailable right now.') };
+
+      const data = JSON.parse(res.body) as { results?: SearchResultFile[] };
+      const files = (data.results ?? []).slice(0, FILE_LIMIT).map((f) => ({
+        fileIndexId: f.id,
+        relPath: f.relPath,
+        project: f.inferredProjectLabel ?? f.declaredProjectLabel ?? null,
+        docType: f.inferredDocType ?? null,
+        openPath: f.openPath ?? null,
+      }));
+      return { files };
+    }
+
+    if (name === 'get_file_passages') {
+      const params = new URLSearchParams({ q: typeof input.q === 'string' ? input.q : '' });
+      if (typeof input.fileIndexId === 'string' && input.fileIndexId) {
+        params.set('fileIndexId', input.fileIndexId);
+      }
+      params.set('limit', String(PASSAGE_LIMIT));
+
+      const res = await helperRequest(config, workspaceUrl(config, '/content/passages', params), {
+        method: 'GET',
+      });
+      if (!res.ok) {
+        return { error: errorString(res.body, 'Passage retrieval is unavailable right now.') };
+      }
+
+      const data = JSON.parse(res.body) as { passages?: PassageRow[] };
+      const passages = (data.passages ?? []).slice(0, PASSAGE_LIMIT).map((p) => ({
+        fileIndexId: p.fileIndexId,
+        relPath: p.relPath,
+        sourceId: p.sourceId,
+        openPath: p.openPath ?? null,
+        snippet: typeof p.snippet === 'string' ? p.snippet.slice(0, SNIPPET_MAX) : '',
+        score: p.score,
+      }));
+      return { passages };
+    }
+
+    return { error: `Unknown tool: ${name}` };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/apps/helper/src/lib/workspaceUrl.ts
+++ b/apps/helper/src/lib/workspaceUrl.ts
@@ -1,0 +1,15 @@
+import type { AgentConfig } from './helperFetch';
+
+/**
+ * Build a URL for the Workspace extension's `/helper/*` surface. Extracted
+ * verbatim from workspaceStore so the chat tool executors hit the identical
+ * base path (device mTLS, org scoping, visibility all apply by construction).
+ */
+export function workspaceUrl(
+  config: AgentConfig,
+  path: string,
+  params?: URLSearchParams,
+): string {
+  const qs = params && params.size > 0 ? `?${params.toString()}` : '';
+  return `${config.api_url}/api/v1/workspace/helper${path}${qs}`;
+}

--- a/apps/helper/src/stores/chatStore.test.ts
+++ b/apps/helper/src/stores/chatStore.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../lib/helperFetch', () => ({
+  helperRequest: vi.fn(),
+  getTauriInvoke: vi.fn(async () => null),
+  requireDevBearerToken: vi.fn(() => 'dev-token'),
+}));
+
+import { helperRequest } from '../lib/helperFetch';
+import { WORKSPACE_CHAT_TOOLS } from '../lib/workspaceChatTools';
+import { processSSELines, useChatStore } from './chatStore';
+import { useWorkspaceStore } from './workspaceStore';
+
+const helperRequestMock = vi.mocked(helperRequest);
+const AGENT_CONFIG = { api_url: 'http://localhost:3001', agent_id: 'agent-1' };
+
+function ok(body: unknown, status = 200) {
+  return { ok: true, status, body: JSON.stringify(body) };
+}
+
+// A tiny set/setDirect bridge onto the real store, matching how sendMessage
+// wires processSSELines in production.
+function run(lines: string[], currentId = { value: null as string | null }) {
+  const set = (fn: (s: never) => object) => useChatStore.setState(fn as never);
+  const setDirect = (partial: object) => useChatStore.setState(partial as never);
+  return processSSELines(lines, currentId, set as never, setDirect as never);
+}
+
+function sse(event: unknown): string {
+  return `data: ${JSON.stringify(event)}`;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useChatStore.setState({
+    agentConfig: AGENT_CONFIG,
+    connectionState: 'connected',
+    sessionId: null,
+    messages: [],
+    isStreaming: false,
+    error: null,
+    username: null,
+    pendingApproval: null,
+  });
+  useWorkspaceStore.setState({ available: null });
+});
+
+// ---------------------------------------------------------------------------
+// processSSELines regression baseline (this is the first chatStore suite, so
+// pin the existing content_delta/done behavior before layering the tool loop).
+// ---------------------------------------------------------------------------
+
+describe('processSSELines — SSE baseline (regression)', () => {
+  it('appends content_delta to the current streaming assistant message', async () => {
+    useChatStore.setState({
+      messages: [
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: 'Hello',
+          isStreaming: true,
+          createdAt: new Date(),
+        },
+      ],
+    });
+    await run([sse({ type: 'content_delta', delta: ' world' })], { value: 'a1' });
+    expect(useChatStore.getState().messages[0].content).toBe('Hello world');
+  });
+
+  it('clears isStreaming on the done event', async () => {
+    useChatStore.setState({ isStreaming: true });
+    await run([sse({ type: 'done' })]);
+    expect(useChatStore.getState().isStreaming).toBe(false);
+  });
+
+  it('ignores non-data and blank lines without throwing', async () => {
+    await expect(run([': keep-alive', '', 'event: ping'])).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// client_tool_request round-trip
+// ---------------------------------------------------------------------------
+
+describe('processSSELines — client_tool_request round-trip', () => {
+  it('executes a known tool and POSTs its output to /tool-results', async () => {
+    useChatStore.setState({ sessionId: 'sess-1' });
+    helperRequestMock.mockImplementation(async (_config, url) => {
+      if (url.includes('/workspace/helper/search')) {
+        return ok({ results: [{ id: 'f1', relPath: 'a.pdf', openPath: null }] });
+      }
+      return ok({ ok: true });
+    });
+
+    await run([
+      sse({
+        type: 'client_tool_request',
+        toolUseId: 't1',
+        toolName: 'search_workspace_files',
+        input: { q: 'henderson' },
+      }),
+    ]);
+
+    const post = helperRequestMock.mock.calls.find(([, url]) => url.endsWith('/tool-results'));
+    expect(post).toBeDefined();
+    const body = JSON.parse(post![2]!.body as string);
+    expect(body.toolUseId).toBe('t1');
+    expect(body.output.files[0].fileIndexId).toBe('f1');
+    expect(body.error).toBeUndefined();
+  });
+
+  it('posts {error} (not output) for an unknown tool name', async () => {
+    useChatStore.setState({ sessionId: 'sess-1' });
+    helperRequestMock.mockResolvedValue(ok({ ok: true }));
+
+    await run([
+      sse({ type: 'client_tool_request', toolUseId: 't2', toolName: 'no_such_tool', input: {} }),
+    ]);
+
+    const post = helperRequestMock.mock.calls.find(([, url]) => url.endsWith('/tool-results'));
+    expect(post).toBeDefined();
+    const body = JSON.parse(post![2]!.body as string);
+    expect(body.toolUseId).toBe('t2');
+    expect(typeof body.error).toBe('string');
+    expect(body.error).toContain('no_such_tool');
+    expect(body.output).toBeUndefined();
+    // The unknown tool must not have hit any workspace endpoint.
+    expect(helperRequestMock.mock.calls.every(([, url]) => url.endsWith('/tool-results'))).toBe(true);
+  });
+
+  it('does nothing when there is no active session', async () => {
+    useChatStore.setState({ sessionId: null });
+    await run([
+      sse({
+        type: 'client_tool_request',
+        toolUseId: 't3',
+        toolName: 'search_workspace_files',
+        input: { q: 'x' },
+      }),
+    ]);
+    expect(helperRequestMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session-create body gating on workspace availability
+// ---------------------------------------------------------------------------
+
+describe('sendMessage — clientTools declaration', () => {
+  function stubStream() {
+    // sendMessage streams via native fetch in non-Tauri mode; return a body-less
+    // response so the stream ends immediately (we only assert the create body).
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { forEach: () => {} },
+      body: null,
+    })) as unknown as typeof fetch;
+  }
+
+  it('includes clientTools: WORKSPACE_CHAT_TOOLS when the workspace is available', async () => {
+    useWorkspaceStore.setState({ available: true });
+    helperRequestMock.mockResolvedValue(ok({ id: 'sess-1' }));
+    stubStream();
+
+    await useChatStore.getState().sendMessage('hi');
+
+    const create = helperRequestMock.mock.calls.find(([, url]) => url.endsWith('/chat/sessions'));
+    expect(create).toBeDefined();
+    const body = JSON.parse(create![2]!.body as string);
+    expect(body.clientTools).toEqual(WORKSPACE_CHAT_TOOLS);
+  });
+
+  it('omits clientTools when the workspace is not available', async () => {
+    useWorkspaceStore.setState({ available: false });
+    helperRequestMock.mockResolvedValue(ok({ id: 'sess-1' }));
+    stubStream();
+
+    await useChatStore.getState().sendMessage('hi');
+
+    const create = helperRequestMock.mock.calls.find(([, url]) => url.endsWith('/chat/sessions'));
+    const body = JSON.parse(create![2]!.body as string);
+    expect(body.clientTools).toBeUndefined();
+  });
+});

--- a/apps/helper/src/stores/chatStore.test.ts
+++ b/apps/helper/src/stores/chatStore.test.ts
@@ -169,6 +169,34 @@ describe('processSSELines — client_tool_request round-trip', () => {
     expect(post).toBeDefined();
   });
 
+  it('logs console.error when the tool-results POST responds not-ok', async () => {
+    useChatStore.setState({ sessionId: 'sess-1' });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    helperRequestMock.mockImplementation(async (_config, url) => {
+      if (url.includes('/workspace/helper/search')) {
+        return { ok: true, status: 200, body: JSON.stringify({ results: [] }) };
+      }
+      // The /tool-results POST fails — helperRequest resolves (never throws).
+      return { ok: false, status: 500, body: JSON.stringify({ error: 'boom' }) };
+    });
+
+    await run([
+      sse({
+        type: 'client_tool_request',
+        toolUseId: 't9',
+        toolName: 'search_workspace_files',
+        input: { q: 'x' },
+      }),
+    ]);
+
+    expect(errSpy).toHaveBeenCalledWith(
+      '[Helper] tool-results POST failed:',
+      500,
+      expect.stringContaining('boom'),
+    );
+    errSpy.mockRestore();
+  });
+
   it('does nothing when there is no active session', async () => {
     useChatStore.setState({ sessionId: null });
     await run([
@@ -199,28 +227,90 @@ describe('sendMessage — clientTools declaration', () => {
     })) as unknown as typeof fetch;
   }
 
-  it('includes clientTools: WORKSPACE_CHAT_TOOLS when the workspace is available', async () => {
-    useWorkspaceStore.setState({ available: true });
-    helperRequestMock.mockResolvedValue(ok({ id: 'sess-1' }));
-    stubStream();
-
-    await useChatStore.getState().sendMessage('hi');
-
+  function createBody() {
     const create = helperRequestMock.mock.calls.find(([, url]) => url.endsWith('/chat/sessions'));
     expect(create).toBeDefined();
-    const body = JSON.parse(create![2]!.body as string);
-    expect(body.clientTools).toEqual(WORKSPACE_CHAT_TOOLS);
-  });
+    return JSON.parse(create![2]!.body as string) as { clientTools?: Array<{ name: string }> };
+  }
 
   it('omits clientTools when the workspace is not available', async () => {
-    useWorkspaceStore.setState({ available: false });
+    useWorkspaceStore.setState({ available: false, contentEnabled: false });
     helperRequestMock.mockResolvedValue(ok({ id: 'sess-1' }));
     stubStream();
 
     await useChatStore.getState().sendMessage('hi');
 
-    const create = helperRequestMock.mock.calls.find(([, url]) => url.endsWith('/chat/sessions'));
-    const body = JSON.parse(create![2]!.body as string);
-    expect(body.clientTools).toBeUndefined();
+    expect(createBody().clientTools).toBeUndefined();
+  });
+
+  it('declares only search_workspace_files when available but content preview is off', async () => {
+    useWorkspaceStore.setState({ available: true, contentEnabled: false });
+    helperRequestMock.mockResolvedValue(ok({ id: 'sess-1' }));
+    stubStream();
+
+    await useChatStore.getState().sendMessage('hi');
+
+    const names = createBody().clientTools?.map((t) => t.name);
+    expect(names).toEqual(['search_workspace_files']);
+  });
+
+  it('declares both tools when available and content preview is on', async () => {
+    useWorkspaceStore.setState({ available: true, contentEnabled: true });
+    helperRequestMock.mockResolvedValue(ok({ id: 'sess-1' }));
+    stubStream();
+
+    await useChatStore.getState().sendMessage('hi');
+
+    expect(createBody().clientTools).toEqual(WORKSPACE_CHAT_TOOLS);
+  });
+
+  it('cold-start: awaits the capabilities probe when available is null and includes the tools it reports', async () => {
+    useWorkspaceStore.setState({ available: null, contentEnabled: null });
+    // The first message beats the startup probe: resolving it flips the estate
+    // to available + content on, so the created session declares both tools.
+    const probeSpy = vi
+      .spyOn(useWorkspaceStore.getState(), 'probe')
+      .mockImplementation(async () => {
+        useWorkspaceStore.setState({ available: true, contentEnabled: true });
+      });
+    helperRequestMock.mockResolvedValue(ok({ id: 'sess-1' }));
+    stubStream();
+
+    await useChatStore.getState().sendMessage('hi');
+
+    expect(probeSpy).toHaveBeenCalled();
+    expect(createBody().clientTools).toEqual(WORKSPACE_CHAT_TOOLS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSession maps a persisted tool_result (with toolOutput) back into the store
+// ---------------------------------------------------------------------------
+
+describe('loadSession — persisted tool_result rehydration', () => {
+  it('maps a persisted tool_result row into a tool_result message carrying toolOutput', async () => {
+    useChatStore.setState({ agentConfig: AGENT_CONFIG });
+    helperRequestMock.mockResolvedValue(
+      ok([
+        { id: 'u1', role: 'user', content: 'find henderson', toolName: null, createdAt: '2026-07-19T00:00:00Z' },
+        {
+          id: 'r1',
+          role: 'tool_result',
+          content: '{}',
+          toolName: 'search_workspace_files',
+          toolOutput: { files: [{ fileIndexId: 'f1', relPath: 'a.pdf', openPath: null }] },
+          createdAt: '2026-07-19T00:00:01Z',
+        },
+        { id: 'a1', role: 'assistant', content: 'See [file:f1|a.pdf].', toolName: null, createdAt: '2026-07-19T00:00:02Z' },
+      ]),
+    );
+
+    await useChatStore.getState().loadSession('sess-1');
+
+    const result = useChatStore.getState().messages.find((m) => m.role === 'tool_result');
+    expect(result).toBeDefined();
+    expect(result!.toolName).toBe('search_workspace_files');
+    const output = result!.toolOutput as { files: Array<{ fileIndexId: string }> };
+    expect(output.files[0].fileIndexId).toBe('f1');
   });
 });

--- a/apps/helper/src/stores/chatStore.test.ts
+++ b/apps/helper/src/stores/chatStore.test.ts
@@ -128,6 +128,47 @@ describe('processSSELines — client_tool_request round-trip', () => {
     expect(helperRequestMock.mock.calls.every(([, url]) => url.endsWith('/tool-results'))).toBe(true);
   });
 
+  it('appends a tool_result transcript message carrying the executor output for a known tool', async () => {
+    // The server never echoes a tool_result SSE event for client-declared tools,
+    // so the client must record its own executed result in the transcript —
+    // otherwise ChatView's resolution map and result cards see nothing.
+    useChatStore.setState({ sessionId: 'sess-1' });
+    helperRequestMock.mockImplementation(async (_config, url) => {
+      if (url.includes('/workspace/helper/search')) {
+        return ok({ results: [{ id: 'f1', relPath: 'a.pdf', openPath: null }] });
+      }
+      return ok({ ok: true });
+    });
+
+    await run([
+      sse({
+        type: 'client_tool_request',
+        toolUseId: 't1',
+        toolName: 'search_workspace_files',
+        input: { q: 'henderson' },
+      }),
+    ]);
+
+    const result = useChatStore.getState().messages.find((m) => m.role === 'tool_result');
+    expect(result).toBeDefined();
+    expect(result!.toolName).toBe('search_workspace_files');
+    const output = result!.toolOutput as { files: Array<{ fileIndexId: string }> };
+    expect(output.files[0].fileIndexId).toBe('f1');
+  });
+
+  it('appends NO transcript message for an unknown tool (only the error POST)', async () => {
+    useChatStore.setState({ sessionId: 'sess-1' });
+    helperRequestMock.mockResolvedValue(ok({ ok: true }));
+
+    await run([
+      sse({ type: 'client_tool_request', toolUseId: 't2', toolName: 'no_such_tool', input: {} }),
+    ]);
+
+    expect(useChatStore.getState().messages).toHaveLength(0);
+    const post = helperRequestMock.mock.calls.find(([, url]) => url.endsWith('/tool-results'));
+    expect(post).toBeDefined();
+  });
+
   it('does nothing when there is no active session', async () => {
     useChatStore.setState({ sessionId: null });
     await run([

--- a/apps/helper/src/stores/chatStore.ts
+++ b/apps/helper/src/stores/chatStore.ts
@@ -6,7 +6,11 @@ import {
   type AgentConfig,
   type HelperFetchResponse,
 } from '../lib/helperFetch';
-import { WORKSPACE_CHAT_TOOLS, executeWorkspaceChatTool } from '../lib/workspaceChatTools';
+import {
+  WORKSPACE_CHAT_TOOLS,
+  executeWorkspaceChatTool,
+  type ClientToolDeclaration,
+} from '../lib/workspaceChatTools';
 import { useWorkspaceStore } from './workspaceStore';
 
 interface ChatMessage {
@@ -317,7 +321,9 @@ async function handleClientToolRequest(event: {
   }
 
   try {
-    await helperRequest(
+    // helperRequest resolves (does not throw) on a non-2xx response, so a
+    // rejected/failed tool-result POST would otherwise be silently swallowed.
+    const res = await helperRequest(
       agentConfig,
       `${agentConfig.api_url}/api/v1/helper/chat/sessions/${sessionId}/tool-results`,
       {
@@ -326,6 +332,13 @@ async function handleClientToolRequest(event: {
         body: JSON.stringify(body),
       },
     );
+    if (!res.ok) {
+      console.error(
+        '[Helper] tool-results POST failed:',
+        res.status,
+        res.body?.slice(0, 200),
+      );
+    }
   } catch (err) {
     console.error('[Helper] Failed to post client tool result:', err);
   }
@@ -473,6 +486,46 @@ export async function processSSELines(
 // ---------------------------------------------------------------------------
 
 const USERNAME_KEY = 'breeze-helper-username';
+
+/** Max time to wait on a cold-start capabilities probe before creating a session. */
+const WORKSPACE_PROBE_TIMEOUT_MS = 3000;
+
+/**
+ * Await the workspace capabilities probe, bounded. On timeout or failure the
+ * session simply proceeds without client tools (today's degraded behavior).
+ * Used to close the cold-start race: client-tool declarations are fixed at
+ * session create, so a first message that beats the startup probe would
+ * otherwise permanently degrade the session.
+ */
+async function awaitWorkspaceProbe(): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      useWorkspaceStore.getState().probe(),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, WORKSPACE_PROBE_TIMEOUT_MS);
+      }),
+    ]);
+  } catch {
+    // Probe is silent by design; proceed without tools.
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Client-tool declarations to send at session create, gated on the estate's
+ * REAL capabilities: file-search needs the estate reachable (`available`);
+ * passage retrieval additionally needs content preview (`contentEnabled`),
+ * else get_file_passages would 404 forever while the prompt still prefers it.
+ */
+function selectWorkspaceChatTools(): ClientToolDeclaration[] {
+  const { available, contentEnabled } = useWorkspaceStore.getState();
+  if (available !== true) return [];
+  return WORKSPACE_CHAT_TOOLS.filter(
+    (t) => t.name !== 'get_file_passages' || contentEnabled === true,
+  );
+}
 
 export const useChatStore = create<ChatState>((set, get) => ({
   connectionState: 'disconnected',
@@ -627,14 +680,19 @@ export const useChatStore = create<ChatState>((set, get) => ({
         role: 'user' | 'assistant' | 'tool_use' | 'tool_result';
         content: string | null;
         toolName: string | null;
+        toolOutput?: unknown;
         createdAt: string;
       }>;
 
+      // Persisted tool_result rows carry toolOutput (the executed tool's return),
+      // so ChatView's citation-resolution map and result cards work on reload —
+      // otherwise citations render as raw [file:<id>|<path>] tokens and cards vanish.
       const messages: ChatMessage[] = rawMessages.map((m) => ({
         id: m.id,
         role: m.role,
         content: m.content ?? '',
         toolName: m.toolName ?? undefined,
+        ...(m.role === 'tool_result' ? { toolOutput: m.toolOutput } : {}),
         createdAt: new Date(m.createdAt),
       }));
 
@@ -673,10 +731,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // Create session if needed
       let currentSessionId = sessionId;
       if (!currentSessionId) {
-        // Declare the workspace chat tools only when the estate is reachable;
+        // Cold-start race: `available` is null until the startup probe finishes.
+        // Declarations are fixed at create, so if a first message beats the
+        // probe we briefly await it — otherwise the session is permanently
+        // degraded (no tools). On timeout/failure we proceed without tools.
+        if (useWorkspaceStore.getState().available === null) {
+          await awaitWorkspaceProbe();
+        }
+        // Declare the workspace chat tools that the estate can actually serve;
         // core builds the bridged MCP server from them and drives file-search /
         // cited-RAG through the client executors.
-        const workspaceAvailable = useWorkspaceStore.getState().available === true;
+        const clientTools = selectWorkspaceChatTools();
         const createRes = await helperRequest(
           agentConfig,
           `${agentConfig.api_url}/api/v1/helper/chat/sessions`,
@@ -685,7 +750,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               ...(username ? { helperUser: username } : {}),
-              ...(workspaceAvailable ? { clientTools: WORKSPACE_CHAT_TOOLS } : {}),
+              ...(clientTools.length > 0 ? { clientTools } : {}),
             }),
           },
         );

--- a/apps/helper/src/stores/chatStore.ts
+++ b/apps/helper/src/stores/chatStore.ts
@@ -6,6 +6,8 @@ import {
   type AgentConfig,
   type HelperFetchResponse,
 } from '../lib/helperFetch';
+import { WORKSPACE_CHAT_TOOLS, executeWorkspaceChatTool } from '../lib/workspaceChatTools';
+import { useWorkspaceStore } from './workspaceStore';
 
 interface ChatMessage {
   id: string;
@@ -266,12 +268,48 @@ async function helperStreamRequest(
 // SSE line parser (shared between Tauri and browser paths)
 // ---------------------------------------------------------------------------
 
-function processSSELines(
+/**
+ * Handle a `client_tool_request` SSE event: execute the named workspace tool
+ * client-side and POST the result back to `/tool-results`. A known tool's
+ * output is posted under `output` (including a degradable `{ error }` payload
+ * from a failed executor, which the model reads as tool output); an unknown
+ * tool name is posted under `error` so the model sees a hard tool failure.
+ */
+async function handleClientToolRequest(event: {
+  toolUseId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+}): Promise<void> {
+  const { agentConfig, sessionId } = useChatStore.getState();
+  if (!agentConfig || !sessionId) return;
+
+  const known = WORKSPACE_CHAT_TOOLS.some((t) => t.name === event.toolName);
+  const body = known
+    ? { toolUseId: event.toolUseId, output: await executeWorkspaceChatTool(event.toolName, event.input ?? {}) }
+    : { toolUseId: event.toolUseId, error: `Unknown tool: ${event.toolName}` };
+
+  try {
+    await helperRequest(
+      agentConfig,
+      `${agentConfig.api_url}/api/v1/helper/chat/sessions/${sessionId}/tool-results`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    );
+  } catch (err) {
+    console.error('[Helper] Failed to post client tool result:', err);
+  }
+}
+
+export async function processSSELines(
   lines: string[],
   currentAssistantId: { value: string | null },
   set: (fn: (s: ChatState) => Partial<ChatState>) => void,
   setDirect: (partial: Partial<ChatState>) => void,
-) {
+): Promise<void> {
+  const pending: Promise<void>[] = [];
   for (const line of lines) {
     if (!line.startsWith('data:')) continue;
     const jsonStr = line.slice(5).trim();
@@ -367,6 +405,19 @@ function processSSELines(
           break;
         }
 
+        case 'client_tool_request': {
+          // Fire the executor + POST asynchronously; awaited via `pending`
+          // below so the synchronous UI updates above are never blocked.
+          pending.push(
+            handleClientToolRequest({
+              toolUseId: event.toolUseId,
+              toolName: event.toolName,
+              input: event.input,
+            }),
+          );
+          break;
+        }
+
         case 'done': {
           setDirect({ isStreaming: false });
           break;
@@ -385,6 +436,8 @@ function processSSELines(
       console.error('[Helper] Failed to parse SSE event:', jsonStr.slice(0, 200), parseErr);
     }
   }
+
+  await Promise.all(pending);
 }
 
 // ---------------------------------------------------------------------------
@@ -592,6 +645,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // Create session if needed
       let currentSessionId = sessionId;
       if (!currentSessionId) {
+        // Declare the workspace chat tools only when the estate is reachable;
+        // core builds the bridged MCP server from them and drives file-search /
+        // cited-RAG through the client executors.
+        const workspaceAvailable = useWorkspaceStore.getState().available === true;
         const createRes = await helperRequest(
           agentConfig,
           `${agentConfig.api_url}/api/v1/helper/chat/sessions`,
@@ -600,6 +657,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               ...(username ? { helperUser: username } : {}),
+              ...(workspaceAvailable ? { clientTools: WORKSPACE_CHAT_TOOLS } : {}),
             }),
           },
         );

--- a/apps/helper/src/stores/chatStore.ts
+++ b/apps/helper/src/stores/chatStore.ts
@@ -274,6 +274,11 @@ async function helperStreamRequest(
  * output is posted under `output` (including a degradable `{ error }` payload
  * from a failed executor, which the model reads as tool output); an unknown
  * tool name is posted under `error` so the model sees a hard tool failure.
+ *
+ * For a known tool, the executed result is ALSO appended to the store's
+ * messages as a `tool_result` entry — the server does not echo one for
+ * client-declared tools, and ChatView needs that transcript entry to render
+ * citation chips and result cards.
  */
 async function handleClientToolRequest(event: {
   toolUseId: string;
@@ -284,9 +289,32 @@ async function handleClientToolRequest(event: {
   if (!agentConfig || !sessionId) return;
 
   const known = WORKSPACE_CHAT_TOOLS.some((t) => t.name === event.toolName);
-  const body = known
-    ? { toolUseId: event.toolUseId, output: await executeWorkspaceChatTool(event.toolName, event.input ?? {}) }
-    : { toolUseId: event.toolUseId, error: `Unknown tool: ${event.toolName}` };
+
+  let body: { toolUseId: string; output?: unknown; error?: string };
+  if (known) {
+    const output = await executeWorkspaceChatTool(event.toolName, event.input ?? {});
+    // The server never emits a `tool_result` SSE event for client-declared
+    // tools (its post-tool-use hook isn't wired into the bridged-MCP path), so
+    // the client — which executed the tool — records its own transcript entry.
+    // ChatView's buildFileResolutionMap (citation chips) and its result-card
+    // render both scan `role === 'tool_result'` messages and duck-type on
+    // `toolOutput.files`/`toolOutput.passages`; the raw executor return is that
+    // exact shape. Appended for KNOWN tools only, regardless of whether the POST
+    // below succeeds — resolution/cards reflect what was actually executed.
+    const resultMsg: ChatMessage = {
+      id: `result-${event.toolUseId}`,
+      role: 'tool_result',
+      content: typeof output === 'string' ? output : JSON.stringify(output, null, 2),
+      toolName: event.toolName,
+      toolOutput: output,
+      toolUseId: event.toolUseId,
+      createdAt: new Date(),
+    };
+    useChatStore.setState((s) => ({ messages: [...s.messages, resultMsg] }));
+    body = { toolUseId: event.toolUseId, output };
+  } else {
+    body = { toolUseId: event.toolUseId, error: `Unknown tool: ${event.toolName}` };
+  }
 
   try {
     await helperRequest(

--- a/apps/helper/src/stores/workspaceStore.ts
+++ b/apps/helper/src/stores/workspaceStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { helperRequest, type AgentConfig } from '../lib/helperFetch';
+import { workspaceUrl } from '../lib/workspaceUrl';
 import { useChatStore } from './chatStore';
 
 // ---------------------------------------------------------------------------
@@ -187,11 +188,6 @@ interface WorkspaceState {
 
 function agentConfig(): AgentConfig | null {
   return useChatStore.getState().agentConfig;
-}
-
-function workspaceUrl(config: AgentConfig, path: string, params?: URLSearchParams): string {
-  const qs = params && params.size > 0 ? `?${params.toString()}` : '';
-  return `${config.api_url}/api/v1/workspace/helper${path}${qs}`;
 }
 
 function parseErrorBody(body: string, fallback: string): string {

--- a/apps/helper/src/styles.css
+++ b/apps/helper/src/styles.css
@@ -593,6 +593,112 @@ body {
 }
 
 /* ----------------------------------------------------------
+   Chat file result cards (search_workspace_files tool results) — typography
+   matches FileTable's row styles (.ws-file-table-name / .ws-file-table-
+   secondary) so a card reads as the same "file row" language wherever it
+   renders (full-swap chat or the 340px side panel). Width stays relative
+   (max-width: 85%, matching .helper-message) — no fixed widths, so the card
+   is fluid at panel width too.
+   ---------------------------------------------------------- */
+.helper-file-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-self: flex-start;
+  max-width: 85%;
+  animation: messageIn 200ms ease-out;
+}
+
+.helper-file-card-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 6px 8px;
+  border-radius: var(--ws-radius-control);
+}
+
+.helper-file-card-row:hover {
+  background: var(--ws-accent-soft);
+}
+
+.helper-file-card-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.helper-file-card-name {
+  font-size: var(--ws-text-13);
+  font-weight: 500;
+  color: var(--ws-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.helper-file-card-meta {
+  font-size: var(--ws-text-12);
+  color: var(--ws-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.helper-file-card-error {
+  font-size: var(--ws-text-12);
+  color: var(--error-text);
+}
+
+.helper-file-card-open {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  border: 1px solid var(--ws-border);
+  border-radius: var(--ws-radius-control);
+  background: var(--ws-surface);
+  color: var(--ws-ink);
+  font-size: var(--ws-text-12);
+  font-weight: 500;
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.helper-file-card-open:hover {
+  border-color: var(--ws-accent);
+  color: var(--ws-accent);
+}
+
+.helper-file-card-open:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* ----------------------------------------------------------
+   Citation chips — inline in assistant markdown, replacing
+   [file:<id>|<relPath>] tokens the model cites passages with.
+   ---------------------------------------------------------- */
+.helper-citation-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  margin: 0 1px;
+  border: 1px solid var(--ws-border);
+  border-radius: 999px;
+  background: var(--ws-accent-soft);
+  color: var(--ws-accent);
+  font-size: var(--ws-text-12);
+  font-weight: 500;
+  line-height: 1.5;
+  cursor: pointer;
+}
+
+.helper-citation-chip:hover {
+  text-decoration: underline;
+}
+
+/* ----------------------------------------------------------
    Thinking Indicator
    ---------------------------------------------------------- */
 .helper-thinking {

--- a/packages/shared/src/types/ai.ts
+++ b/packages/shared/src/types/ai.ts
@@ -129,6 +129,9 @@ export type AiStreamEvent =
   | { type: 'message_end'; inputTokens: number; outputTokens: number }
   | { type: 'warning'; message: string; context?: string }
   | { type: 'error'; message: string }
+  // ── Generic client-declared session tools (e.g. Helper chat) — published by
+  //    services/clientSessionTools.ts when the model calls a client-declared tool.
+  | { type: 'client_tool_request'; toolUseId: string; toolName: string; input: Record<string, unknown> }
   // ── AI for Office (client sessions) — published by the client tool bridge/handlers ──
   | { type: 'tool_request'; toolUseId: string; toolName: string; input: Record<string, unknown>; mutating: boolean }
   | {


### PR DESCRIPTION
## Summary

Core + helper half of W7 (companion: LanternOps/breeze-workspace#7 — **merge that first**; the helper's tools call its passages endpoint at runtime).

Helper chat can now find files and answer content questions with citations — "which easement covers the site water main?" returns a cited answer whose `scan_0034.md` chip opens the file. The Agent SDK session loop **is** the RAG pipeline; no separate retrieval orchestration.

- **Core (`apps/api`) — fully generic, zero workspace vocabulary** (grep-gated): session create accepts `clientTools` declarations (validated: ≤8, name pattern, schema depth-capped); a bridged MCP server parks each call, emits an additive `client_tool_request` SSE event, and resolves on `POST /chat/sessions/:id/tool-results` (60s timeout, duplicate-post 409). Client tool results persist as generic `tool_result` rows so sessions reload faithfully. Existing SSE contract unchanged; sessions without `clientTools` are byte-identical to today.
- **Helper** — declares `search_workspace_files` (on workspace availability) + `get_file_passages` (additionally requires content preview) and executes them client-side over its existing authenticated request path, so device mTLS, org scoping, and visibility apply by construction. First-ever `chatStore` test suite. Result cards + citation chips render in `ChatView` (both the side panel and full-swap contexts); chips disable when no openable path.

## Verification

- Suites: helper 136/136 + tsc; api targeted 30/30 (`clientSessionTools`, helper routes) + tsc clean (note: apps/api tsc needs `node --stack-size=4000` at project scale); extension 265 + 77 in the companion PR; four-beat harness green after every task.
- `chat-beat.mjs` acceptance: real model round trip, `get_file_passages` in trace, scan_0034 cited by fileIndexId.
- Live browser E2E: easement question → 8 result cards + working citation chip; **full reload → History → reopen renders cards + chip from the persisted transcript**.
- Whole-branch review + fix wave (persistence, capability gating, cold-start probe race, prompt/chip consistency) independently re-reviewed as closed.

## Notes for reviewers

- Two integration bugs were caught live at the gate that all unit suites missed (each side mocked the other): no `tool_result` SSE for client-declared tools (helper now records its own transcript entry) and no persistence of client tool results (route now inserts a generic row). Both have regression tests pinning the reason.
- Known-minor list (post-demo cleanup class) is tracked in the workstream ledger: chat-beat drift fixture, pending-map lifecycle on non-DELETE teardown, chunk FTS expression index before real estates, error-helper dedup.
- W2 (DLP/visibility) coordination: `passages()` shares `/search`'s scope path; W2's `visibility.ts` adopts it when it lands (recorded coordination point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
