### PR TITLE
fix(jobs): scan-orgs enqueues outside held DB context + dedupe #1105 tripwire Sentry captures

### DIFF
--- a/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
@@ -156,6 +156,9 @@ const SITE_SCOPE_INPUT_EXEMPT: ReadonlySet<string> = new Set<string>([
   'routes/helper/index.ts:GET /chat/sessions',
   'routes/helper/index.ts:GET /chat/sessions/:id/messages',
   'routes/helper/index.ts:POST /chat/sessions/:id/flag',
+  // helperAuth device-token path; query pinned to the caller's own device via
+  // eq(aiSessions.deviceId, device.id) (#2637 client-declared tool results).
+  'routes/helper/index.ts:POST /chat/sessions/:id/tool-results',
   'routes/tunnels.ts:GET /desktop-access',
   'routes/tunnels.ts:POST /downgrade-to-vnc',
   'routes/tunnels.ts:POST /upgrade-to-webrtc',

--- a/apps/api/src/db/heldContextCaptureThrottle.test.ts
+++ b/apps/api/src/db/heldContextCaptureThrottle.test.ts
@@ -9,7 +9,9 @@ vi.mock('../services/sentry', () => ({
 
 import {
   shouldCaptureHeldContext,
+  shouldReportHeldContextSite,
   __resetHeldContextCaptureThrottleForTests,
+  __resetHeldContextAssertDedupeForTests,
 } from './index';
 
 // Guards the #1105 quota fix: the held-context warning must NOT emit one Sentry
@@ -59,5 +61,35 @@ describe('shouldCaptureHeldContext (held-context Sentry-capture throttle)', () =
     expect(shouldCaptureHeldContext('system', 2, W)).toBe(false);
     __resetHeldContextCaptureThrottleForTests();
     expect(shouldCaptureHeldContext('system', 2, W)).toBe(true);
+  });
+});
+
+// Guards the second flavor of the same quota failure: the enqueue tripwire
+// (assertOutsideHeldDbContext) marks a wrong CALL SITE, not N distinct errors.
+// Unthrottled it produced ~2.2k Sentry events in a day from seven call sites
+// (BREEZE-H) and helped exhaust the org quota. One capture per site per process
+// is the whole signal; console.warn stays per-occurrence.
+describe('shouldReportHeldContextSite (enqueue-tripwire Sentry-capture dedupe)', () => {
+  beforeEach(() => {
+    __resetHeldContextAssertDedupeForTests();
+  });
+
+  it('reports a given call site once, then suppresses it', () => {
+    expect(shouldReportHeldContextSite('stack-a')).toBe(true);
+    expect(shouldReportHeldContextSite('stack-a')).toBe(false);
+    expect(shouldReportHeldContextSite('stack-a')).toBe(false);
+  });
+
+  it('tracks distinct call sites independently', () => {
+    expect(shouldReportHeldContextSite('stack-a')).toBe(true);
+    expect(shouldReportHeldContextSite('stack-b')).toBe(true);
+    expect(shouldReportHeldContextSite('stack-a')).toBe(false);
+    expect(shouldReportHeldContextSite('stack-b')).toBe(false);
+  });
+
+  it('reset clears the seen-set', () => {
+    expect(shouldReportHeldContextSite('stack-a')).toBe(true);
+    __resetHeldContextAssertDedupeForTests();
+    expect(shouldReportHeldContextSite('stack-a')).toBe(true);
   });
 });

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -505,6 +505,28 @@ export function classifyContextlessExecuteVerb(arg: unknown): string | null {
  */
 const STRICT_TRIPWIRE_VALUES = new Set(['1', 'true', 'yes', 'on']);
 
+// Dedup the Sentry capture per call site, mirroring the contextless-write
+// guard above: the tripwire marks a wrong CALL SITE, not N distinct errors, so
+// one report per site per process is the whole signal. Unthrottled, a single
+// hot path burned ~2.2k events/day (BREEZE-H) against the org quota — the same
+// flood-then-blackout failure mode #1894 fixed for the held-duration warning.
+// `console.warn` still fires every time so logs stay complete.
+const reportedHeldContextSites = new Set<string>();
+export function __resetHeldContextAssertDedupeForTests(): void {
+  reportedHeldContextSites.clear();
+}
+
+/**
+ * Returns true at most once per key (originating call site) for the lifetime of
+ * the process; subsequent calls with the same key return false. Pure apart from
+ * the module-level seen-set — exported for unit testing.
+ */
+export function shouldReportHeldContextSite(key: string): boolean {
+  if (reportedHeldContextSites.has(key)) return false;
+  reportedHeldContextSites.add(key);
+  return true;
+}
+
 export function assertOutsideHeldDbContext(operation: string): void {
   if (!hasDbAccessContext()) {
     return;
@@ -517,7 +539,9 @@ export function assertOutsideHeldDbContext(operation: string): void {
     throw new Error(message);
   }
   console.warn(message);
-  captureMessage(message, 'warning', { operation, stack: new Error().stack });
+  const stack = new Error().stack;
+  if (!shouldReportHeldContextSite(stack ?? operation)) return;
+  captureMessage(message, 'warning', { operation, stack });
 }
 
 const proxiedDb = new Proxy(baseDb, {

--- a/apps/api/src/jobs/reliabilityWorker.test.ts
+++ b/apps/api/src/jobs/reliabilityWorker.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getJobMock, addMock, addBulkMock, closeMock, selectMock, fromMock, whereMock, groupByMock, workerProcessors, workerOptionsCalls } = vi.hoisted(() => ({
+const { getJobMock, addMock, addBulkMock, closeMock, selectMock, fromMock, whereMock, groupByMock, workerProcessors, workerOptionsCalls, dbCtx } = vi.hoisted(() => ({
   getJobMock: vi.fn(),
   addMock: vi.fn(),
   addBulkMock: vi.fn(),
@@ -11,6 +11,9 @@ const { getJobMock, addMock, addBulkMock, closeMock, selectMock, fromMock, where
   groupByMock: vi.fn(),
   workerProcessors: [] as Array<(job: { data: unknown }) => Promise<unknown>>,
   workerOptionsCalls: [] as Array<{ concurrency?: number }>,
+  // Tracks simulated withSystemDbAccessContext nesting so tests can assert
+  // WHERE an enqueue ran relative to the held context (#1105, BREEZE-K).
+  dbCtx: { depth: 0 },
 }));
 
 vi.mock('bullmq', () => ({
@@ -39,7 +42,14 @@ vi.mock('../services/redis', () => ({
 }));
 
 vi.mock('../db', () => ({
-  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+    dbCtx.depth++;
+    try {
+      return await fn();
+    } finally {
+      dbCtx.depth--;
+    }
+  }),
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
   // #1105 tripwire used by createInstrumentedQueue (the queue factory this
   // worker now constructs through). No-op here — no held context under test.
@@ -89,6 +99,7 @@ describe('enqueueDeviceReliabilityComputation', () => {
     groupByMock.mockResolvedValue([{ orgId: 'org-1' }]);
     workerProcessors.length = 0;
     workerOptionsCalls.length = 0;
+    dbCtx.depth = 0;
     await shutdownReliabilityWorker();
   });
 
@@ -165,5 +176,25 @@ describe('enqueueDeviceReliabilityComputation', () => {
         }),
       }),
     ]);
+  });
+
+  it('fans out scan-orgs enqueues OUTSIDE the held system DB context, read inside it (#1105, BREEZE-K)', async () => {
+    createReliabilityWorker();
+
+    let depthAtRead = -1;
+    groupByMock.mockImplementation(async () => {
+      depthAtRead = dbCtx.depth;
+      return [{ orgId: 'org-1' }];
+    });
+    const depthAtEnqueue: number[] = [];
+    addBulkMock.mockImplementation(async () => {
+      depthAtEnqueue.push(dbCtx.depth);
+      return [];
+    });
+
+    await workerProcessors[0]!({ data: { type: 'scan-orgs' } });
+
+    expect(depthAtRead).toBe(1);
+    expect(depthAtEnqueue).toEqual([0]);
   });
 });

--- a/apps/api/src/jobs/reliabilityWorker.ts
+++ b/apps/api/src/jobs/reliabilityWorker.ts
@@ -65,11 +65,18 @@ export function getReliabilityQueue(): Queue<ReliabilityJobData> {
 }
 
 async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number }> {
-  const orgRows = await db
-    .select({ orgId: devices.orgId })
-    .from(devices)
-    .where(sql`${devices.status} <> 'decommissioned'`)
-    .groupBy(devices.orgId);
+  // #1105 (BREEZE-K): read the org list in its own short-lived context so the
+  // fan-out enqueue below runs AFTER the transaction closes — addBulk is a
+  // Redis round-trip that must not run while a pooled Postgres connection sits
+  // idle-in-transaction. Mirrors metricAnomalies.ts; the worker handler
+  // deliberately does not wrap this job type.
+  const orgRows = await runWithSystemDbAccess(async () =>
+    db
+      .select({ orgId: devices.orgId })
+      .from(devices)
+      .where(sql`${devices.status} <> 'decommissioned'`)
+      .groupBy(devices.orgId)
+  );
 
   if (orgRows.length === 0) {
     return { queued: 0 };
@@ -113,14 +120,16 @@ export function createReliabilityWorker(): Worker<ReliabilityJobData> {
   return new Worker<ReliabilityJobData>(
     RELIABILITY_QUEUE,
     async (job: Job<ReliabilityJobData>) => {
+      const data = job.data;
+      if (data.type === 'scan-orgs') {
+        // Manages its own context: DB read inside, enqueue outside (#1105).
+        return processScanOrgs(data);
+      }
       return runWithSystemDbAccess(async () => {
-        if (job.data.type === 'scan-orgs') {
-          return processScanOrgs(job.data);
+        if (data.type === 'compute-org') {
+          return processComputeOrg(data);
         }
-        if (job.data.type === 'compute-org') {
-          return processComputeOrg(job.data);
-        }
-        return processComputeDevice(job.data);
+        return processComputeDevice(data);
       });
     },
     {

--- a/apps/api/src/jobs/securityPostureQueue.test.ts
+++ b/apps/api/src/jobs/securityPostureQueue.test.ts
@@ -22,6 +22,9 @@ vi.mock('bullmq', () => ({
 vi.mock('../db', () => ({
   db: {},
   withSystemDbAccessContext: undefined,
+  // #1105 tripwire used by createInstrumentedQueue (the queue factory the
+  // security-posture queue now constructs through).
+  assertOutsideHeldDbContext: vi.fn(),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/jobs/securityPostureWorker.test.ts
+++ b/apps/api/src/jobs/securityPostureWorker.test.ts
@@ -1,17 +1,50 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const { addBulkMock, selectMock, fromMock, whereMock, groupByMock, workerProcessors, dbCtx } = vi.hoisted(() => ({
+  addBulkMock: vi.fn(),
+  selectMock: vi.fn(),
+  fromMock: vi.fn(),
+  whereMock: vi.fn(),
+  groupByMock: vi.fn(),
+  workerProcessors: [] as Array<(job: { data: unknown }) => Promise<unknown>>,
+  // Tracks simulated withSystemDbAccessContext nesting so tests can assert
+  // WHERE an enqueue ran relative to the held context (#1105, BREEZE-K class).
+  dbCtx: { depth: 0 },
+}));
+
 vi.mock('bullmq', () => ({
-  Queue: class {},
-  Worker: class {},
+  Queue: class {
+    add = vi.fn();
+    addBulk = addBulkMock;
+    close = vi.fn();
+  },
+  Worker: class {
+    constructor(_name: string, processor: (job: { data: unknown }) => Promise<unknown>) {
+      workerProcessors.push(processor);
+    }
+
+    close = vi.fn();
+    on = vi.fn();
+  },
   Job: class {}
 }));
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
   db: {
-    select: vi.fn()
+    select: selectMock
   },
-  withSystemDbAccessContext: undefined
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+    dbCtx.depth++;
+    try {
+      return await fn();
+    } finally {
+      dbCtx.depth--;
+    }
+  }),
+  // #1105 tripwire used by createInstrumentedQueue (the queue factory this
+  // worker now constructs through). No-op here — no held context under test.
+  assertOutsideHeldDbContext: vi.fn()
 }));
 
 vi.mock('../db/schema', () => ({
@@ -36,7 +69,11 @@ vi.mock('../services/eventBus', () => ({
 }));
 
 import { publishEvent } from '../services/eventBus';
-import { publishSecurityScoreChangedEvents } from './securityPostureWorker';
+import {
+  createSecurityPostureWorker,
+  publishSecurityScoreChangedEvents,
+  shutdownSecurityPostureWorker
+} from './securityPostureWorker';
 
 function buildChanges(count: number) {
   return Array.from({ length: count }, (_, index) => ({
@@ -116,5 +153,40 @@ describe('publishSecurityScoreChangedEvents', () => {
     expect(result.failed).toBe(0);
     expect(result.published).toBe(12);
     expect(maxActive).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('scan-orgs enqueue context (#1105, BREEZE-K class)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    workerProcessors.length = 0;
+    dbCtx.depth = 0;
+    selectMock.mockReturnValue({ from: fromMock });
+    fromMock.mockReturnValue({ where: whereMock });
+    whereMock.mockReturnValue({ groupBy: groupByMock });
+    await shutdownSecurityPostureWorker();
+  });
+
+  it('fans out scan-orgs enqueues OUTSIDE the held system DB context, read inside it', async () => {
+    createSecurityPostureWorker();
+
+    let depthAtRead = -1;
+    groupByMock.mockImplementation(async () => {
+      depthAtRead = dbCtx.depth;
+      return [{ orgId: '11111111-1111-1111-1111-111111111111' }];
+    });
+    const depthAtEnqueue: number[] = [];
+    addBulkMock.mockImplementation(async () => {
+      depthAtEnqueue.push(dbCtx.depth);
+      return [];
+    });
+
+    const result = await workerProcessors[0]!({
+      data: { type: 'scan-orgs', queuedAt: '2026-02-22T00:00:00.000Z' }
+    });
+
+    expect(result).toEqual({ queued: 1 });
+    expect(depthAtRead).toBe(1);
+    expect(depthAtEnqueue).toEqual([0]);
   });
 });

--- a/apps/api/src/jobs/securityPostureWorker.ts
+++ b/apps/api/src/jobs/securityPostureWorker.ts
@@ -5,6 +5,7 @@ import * as dbModule from '../db';
 import { devices } from '../db/schema';
 import { publishEvent } from '../services/eventBus';
 import { getBullMQConnection } from '../services/redis';
+import { createInstrumentedQueue } from '../services/bullmqQueue';
 import { computeAndPersistOrgSecurityPosture } from '../services/securityPosture';
 import { attachWorkerObservability } from './workerObservability';
 import { isReusableState } from '../services/bullmqUtils';
@@ -136,19 +137,27 @@ export async function publishSecurityScoreChangedEvents(
 
 export function getSecurityPostureQueue(): Queue<SecurityPostureJobData> {
   if (!securityPostureQueue) {
-    securityPostureQueue = new Queue<SecurityPostureJobData>(SECURITY_POSTURE_QUEUE, {
-      connection: getBullMQConnection()
-    });
+    // Instrumented so an enqueue inside a held DB context trips the #1105
+    // tripwire instead of silently pinning a pooled connection (the bare
+    // `new Queue` here is how the scan-orgs addBulk hold went unnoticed).
+    securityPostureQueue = createInstrumentedQueue<SecurityPostureJobData>(SECURITY_POSTURE_QUEUE);
   }
   return securityPostureQueue;
 }
 
 async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number }> {
-  const orgRows = await db
-    .select({ orgId: devices.orgId })
-    .from(devices)
-    .where(sql`${devices.status} <> 'decommissioned'`)
-    .groupBy(devices.orgId);
+  // #1105 (BREEZE-K class): read the org list in its own short-lived context so
+  // the fan-out enqueue below runs AFTER the transaction closes — addBulk is a
+  // Redis round-trip that must not run while a pooled Postgres connection sits
+  // idle-in-transaction. Mirrors metricAnomalies.ts; the worker handler
+  // deliberately does not wrap this job type.
+  const orgRows = await runWithSystemDbAccess(async () =>
+    db
+      .select({ orgId: devices.orgId })
+      .from(devices)
+      .where(sql`${devices.status} <> 'decommissioned'`)
+      .groupBy(devices.orgId)
+  );
 
   if (orgRows.length === 0) {
     return { queued: 0 };
@@ -199,12 +208,12 @@ export function createSecurityPostureWorker(): Worker<SecurityPostureJobData> {
   return new Worker<SecurityPostureJobData>(
     SECURITY_POSTURE_QUEUE,
     async (job: Job<SecurityPostureJobData>) => {
-      return runWithSystemDbAccess(async () => {
-        if (job.data.type === 'scan-orgs') {
-          return processScanOrgs(job.data);
-        }
-        return processComputeOrg(job.data);
-      });
+      const data = job.data;
+      if (data.type === 'scan-orgs') {
+        // Manages its own context: DB read inside, enqueue outside (#1105).
+        return processScanOrgs(data);
+      }
+      return runWithSystemDbAccess(async () => processComputeOrg(data));
     },
     {
       connection: getBullMQConnection(),


### PR DESCRIPTION
## Summary

Sentry follow-up to #2613. Post-deploy baseline confirmed both #2613 fixes are quiet in production; this PR closes what the sweep found still open:

- **reliabilityWorker.ts (Sentry BREEZE-K)** — the daily 02:00 UTC `scan-orgs` job ran `queue.addBulk` inside the worker's held `withSystemDbAccessContext` transaction, pinning a pooled connection idle-in-transaction across the Redis round-trip. #2613 only covered `agentWs.ts`. The org list is now read in its own short-lived context and the fan-out enqueue runs after it closes (mirrors `metricAnomalies.ts`, which already did this correctly).
- **securityPostureWorker.ts** — identical latent bug in its hourly `scan-orgs`, but invisible: its queue was a bare `new Queue(...)`, so the #1105 tripwire never instrumented it. Same restructure, plus the queue now constructs through `createInstrumentedQueue` so future regressions are visible.
- **db/index.ts quota guard** — `assertOutsideHeldDbContext` captured to Sentry on every occurrence: ~2.2k events/day from seven call sites (BREEZE-H) helped exhaust the org's event quota — the same flood-then-blackout failure mode #1894 throttled for the held-*duration* warning. The Sentry capture is now deduped once per call site per process (`console.warn` stays per-occurrence, logs remain complete), mirroring the contextless-write guard's dedupe.

## Testing

- `reliabilityWorker.test.ts` / `securityPostureWorker.test.ts`: context-depth tracking mocks now assert the scan-orgs org-list read happens **inside** the system context and the `addBulk` fan-out **outside** it.
- `heldContextCaptureThrottle.test.ts`: dedupe gate covered alongside the existing #1894 throttle tests.
- Full `src/jobs/` (726) and `src/db/` (1256) unit suites green; API `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)