### PR TITLE
fix(extensions): reserve 7 hijackable route namespaces + auto-derive CORE_NAMESPACES (#2634, #2635)

### DIFF
--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -15,6 +15,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/node": "^25.9.3",
     "drizzle-orm": "0.45.2",
     "hono": "^4.12.30",
     "typescript": "^5.7.2",

--- a/packages/extension-api/src/index.test.ts
+++ b/packages/extension-api/src/index.test.ts
@@ -171,9 +171,15 @@ describe('parseExtensionManifest', () => {
 });
 
 describe('RESERVED_ROUTE_NAMESPACES', () => {
-  // Ground truth is DERIVED from apps/api/src/index.ts at test time, not
-  // hand-maintained (#2635). A core mount added without reserving it fails
-  // this suite automatically — there is no list to keep in sync.
+  // Ground truth is DERIVED from apps/api/src/index.ts at test time rather
+  // than hand-maintained (#2635), so a core mount added without reserving it
+  // fails this suite automatically.
+  //
+  // KNOWN BLIND SPOT: `api.route('/', subRouter)` mounts a sub-router that
+  // declares its OWN top-level segments in another file, which this
+  // single-file derivation cannot see. Those namespaces are reserved by hand
+  // and pinned by the ROOT_MOUNT_COUNT tripwire below — if that count changes,
+  // resolve the new sub-router's paths manually and reserve them.
   const API_INDEX = fileURLToPath(
     new URL('../../../apps/api/src/index.ts', import.meta.url),
   );
@@ -186,36 +192,59 @@ describe('RESERVED_ROUTE_NAMESPACES', () => {
     tenancy: { orgCascadeDeleteTables: ['sample_items'] },
   };
 
-  /** Strip comments so a commented-out mount is not read as a live one. */
-  function stripComments(source: string): string {
-    return source
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
-  }
+  const source = readFileSync(API_INDEX, 'utf8');
+
+  // Matches are anchored to statement position (`^\s*`), which excludes
+  // commented-out mounts by construction — no comment stripping needed, and
+  // no risk of a stray `/*` in a route pattern eating real code.
+  // Mounts on the versioned router: api.route('/devices', …) → /api/v1/devices
+  const INNER_MOUNT_RE = /^\s*api\.route\(\s*['"`]\/([a-z0-9-]+)/gm;
+  // Mounts placed directly on the outer app under the same prefix:
+  // app.route('/api/v1/oauth', …) → oauth
+  const OUTER_MOUNT_RE = /^\s*app\.route\(\s*['"`]\/api\/v1\/([a-z0-9-]+)/gm;
+  // api.route('/', subRouter) — see the blind-spot note above.
+  const ROOT_MOUNT_RE = /^\s*api\.route\(\s*['"`]\/['"`]\s*,/gm;
 
   function deriveCoreNamespaces(): string[] {
-    const source = stripComments(readFileSync(API_INDEX, 'utf8'));
     const namespaces = new Set<string>();
-    // Mounts on the versioned router: api.route('/devices', …) → /api/v1/devices
-    for (const m of source.matchAll(/\bapi\.route\(\s*'\/([a-z0-9-]+)/g)) {
-      namespaces.add(m[1]);
-    }
-    // Mounts placed directly on the outer app under the same prefix:
-    // app.route('/api/v1/oauth', …) → oauth
-    for (const m of source.matchAll(/\bapp\.route\(\s*'\/api\/v1\/([a-z0-9-]+)/g)) {
-      namespaces.add(m[1]);
-    }
+    for (const m of source.matchAll(INNER_MOUNT_RE)) namespaces.add(m[1]);
+    for (const m of source.matchAll(OUTER_MOUNT_RE)) namespaces.add(m[1]);
     return [...namespaces].sort();
   }
 
   const coreNamespaces = deriveCoreNamespaces();
 
   it('derives the core mount list from apps/api/src/index.ts', () => {
-    // Guards against the derivation silently matching nothing (moved file,
-    // renamed router, changed mount style) and passing vacuously.
-    expect(coreNamespaces.length).toBeGreaterThan(100);
+    // Guards against the derivation silently matching nothing or only part of
+    // the file (moved file, renamed router, changed mount style) and passing
+    // vacuously. Keep the floor just under the real count.
+    expect(coreNamespaces.length).toBeGreaterThan(110);
     expect(coreNamespaces).toContain('devices');
     expect(coreNamespaces).toContain('service-principals');
+  });
+
+  it('pins the number of root-mounted sub-routers the derivation cannot see', () => {
+    // Tripwire for the blind spot documented above. These eight resolve to:
+    //   externalServices        → billing, support
+    //   invoices/assembly       → orgs, tickets
+    //   invoices/settings       → orgs, partner
+    //   tickets/ticketResponseTemplates → ticket-response-templates
+    //   tickets/forms           → ticket-forms
+    //   lifecycle (x2)          → admin, me
+    //   c2c/m365Auth callback   → c2c
+    // All are reserved. If this count changes, resolve the new sub-router's
+    // top-level segments by hand and add them to RESERVED_ROUTE_NAMESPACES.
+    const rootMounts = [...source.matchAll(ROOT_MOUNT_RE)].length;
+    expect(rootMounts).toBe(8);
+  });
+
+  it.each([
+    'billing',
+    'support',
+    'ticket-forms',
+    'ticket-response-templates',
+  ])('reserves root-mounted sub-router namespace %s', (namespace) => {
+    expect(RESERVED_ROUTE_NAMESPACES.has(namespace)).toBe(true);
   });
 
   it('reserves every core /api/v1 route namespace', () => {

--- a/packages/extension-api/src/index.test.ts
+++ b/packages/extension-api/src/index.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import {
   parseExtensionManifest,
@@ -5,6 +7,7 @@ import {
   RESERVED_ROUTE_NAMESPACES,
   SUPPORTED_EXTENSION_CAPABILITIES,
 } from './index';
+import { RESERVED_ROUTE_NAMESPACES as LEGACY_RESERVED_ROUTE_NAMESPACES } from './legacy';
 
 describe('versioned SDK adapter', () => {
   it('re-exports the v1 SDK alongside legacy names', () => {
@@ -168,43 +171,74 @@ describe('parseExtensionManifest', () => {
 });
 
 describe('RESERVED_ROUTE_NAMESPACES', () => {
-  // Hand-maintained contract. Regenerate the inner-mount list with:
-  //   grep -oE "api\.route\('/[a-z0-9-]+" apps/api/src/index.ts
-  // That yields the 111 `/api/v1/*` mounts inside the versioned router. Add
-  // the outer-app mounts that don't go through that router: `oauth`,
-  // `settings` (both mounted directly on the outer Hono app), and the
-  // shortlink prefix `s` (`app.route('/s', publicShortLinkRoutes)`).
-  const CORE_NAMESPACES = [
-    'access-reviews', 'accounting', 'admin', 'agent-versions', 'agent-ws',
-    'agents', 'ai', 'alert-templates', 'alerts', 'analytics', 'api-keys',
-    'audit-baselines', 'audit-logs', 'auth', 'authenticator', 'automations',
-    'backup', 'browser-security', 'c2c', 'catalog', 'changes', 'cis',
-    'client-ai', 'config', 'configuration-policies', 'contracts',
-    'custom-fields', 'deployments', 'desktop-ws', 'dev', 'device-groups',
-    'devices', 'discovery', 'dns-security', 'docs', 'dr', 'enrollment-keys',
-    'events', 'ext', 'extensions', 'filters', 'google', 'groups', 'helper',
-    'huntress',
-    'incidents', 'installer', 'integrations', 'internal', 'invoices', 'logs',
-    'm365', 'maintenance', 'mcp', 'me', 'metrics', 'mobile', 'monitoring',
-    'monitors', 'network', 'notifications', 'oauth', 'onedrive', 'orgs',
-    'pam', 'partner', 'partners', 'patch-policies', 'patches', 'pax8',
-    'peripherals', 'permissions', 'playbooks', 'plugins', 'policies',
-    'portal', 'psa', 'quotes', 'reliability', 'remediation-suggestions',
-    'remote', 'reports', 'roles', 's', 's1', 'script-library', 'scripts',
-    'search', 'security', 'sensitive-data', 'settings', 'snmp', 'software',
-    'software-inventory', 'software-policies', 'sso', 'system',
-    'system-tools', 'tags', 'third-party-catalog', 'ticket-categories',
-    'ticket-config', 'tickets', 'time-entries', 'tunnel-http', 'tunnel-ws',
-    'tunnels', 'unifi', 'update-rings', 'user-risk', 'users', 'viewers',
-    'vnc-exchange', 'vnc-viewer', 'vulnerabilities', 'webhooks',
-  ];
+  // Ground truth is DERIVED from apps/api/src/index.ts at test time, not
+  // hand-maintained (#2635). A core mount added without reserving it fails
+  // this suite automatically — there is no list to keep in sync.
+  const API_INDEX = fileURLToPath(
+    new URL('../../../apps/api/src/index.ts', import.meta.url),
+  );
 
-  it('has exactly 116 entries in the ground-truth contract', () => {
-    expect(CORE_NAMESPACES).toHaveLength(116);
+  const validManifest = {
+    name: 'sample',
+    routeNamespace: 'sample',
+    entry: 'src/index.ts',
+    migrationsDir: 'migrations',
+    tenancy: { orgCascadeDeleteTables: ['sample_items'] },
+  };
+
+  /** Strip comments so a commented-out mount is not read as a live one. */
+  function stripComments(source: string): string {
+    return source
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+  }
+
+  function deriveCoreNamespaces(): string[] {
+    const source = stripComments(readFileSync(API_INDEX, 'utf8'));
+    const namespaces = new Set<string>();
+    // Mounts on the versioned router: api.route('/devices', …) → /api/v1/devices
+    for (const m of source.matchAll(/\bapi\.route\(\s*'\/([a-z0-9-]+)/g)) {
+      namespaces.add(m[1]);
+    }
+    // Mounts placed directly on the outer app under the same prefix:
+    // app.route('/api/v1/oauth', …) → oauth
+    for (const m of source.matchAll(/\bapp\.route\(\s*'\/api\/v1\/([a-z0-9-]+)/g)) {
+      namespaces.add(m[1]);
+    }
+    return [...namespaces].sort();
+  }
+
+  const coreNamespaces = deriveCoreNamespaces();
+
+  it('derives the core mount list from apps/api/src/index.ts', () => {
+    // Guards against the derivation silently matching nothing (moved file,
+    // renamed router, changed mount style) and passing vacuously.
+    expect(coreNamespaces.length).toBeGreaterThan(100);
+    expect(coreNamespaces).toContain('devices');
+    expect(coreNamespaces).toContain('service-principals');
   });
 
   it('reserves every core /api/v1 route namespace', () => {
-    const missing = CORE_NAMESPACES.filter((ns) => !RESERVED_ROUTE_NAMESPACES.has(ns));
+    const missing = coreNamespaces.filter((ns) => !RESERVED_ROUTE_NAMESPACES.has(ns));
     expect(missing).toEqual([]);
+  });
+
+  it('keeps the extension-sdk and legacy reserved sets identical', () => {
+    // Both sets gate routeNamespace validation on their own code path, so a
+    // namespace reserved in only one of them is still hijackable via the other.
+    expect([...LEGACY_RESERVED_ROUTE_NAMESPACES].sort())
+      .toEqual([...RESERVED_ROUTE_NAMESPACES].sort());
+  });
+
+  it.each([
+    'service-principals',
+    'partner-service-principals',
+    'partner-api',
+  ])('rejects core auth surface %s as a routeNamespace', (namespace) => {
+    // Regression guard for #2634 — these three shipped unreserved, letting an
+    // installed+enabled extension shadow auth-sensitive core endpoints.
+    expect(RESERVED_ROUTE_NAMESPACES.has(namespace)).toBe(true);
+    expect(() => parseExtensionManifest({ ...validManifest, routeNamespace: namespace }))
+      .toThrow();
   });
 });

--- a/packages/extension-api/src/index.test.ts
+++ b/packages/extension-api/src/index.test.ts
@@ -175,11 +175,17 @@ describe('RESERVED_ROUTE_NAMESPACES', () => {
   // than hand-maintained (#2635), so a core mount added without reserving it
   // fails this suite automatically.
   //
-  // KNOWN BLIND SPOT: `api.route('/', subRouter)` mounts a sub-router that
-  // declares its OWN top-level segments in another file, which this
-  // single-file derivation cannot see. Those namespaces are reserved by hand
-  // and pinned by the ROOT_MOUNT_COUNT tripwire below — if that count changes,
-  // resolve the new sub-router's paths manually and reserve them.
+  // KNOWN BLIND SPOTS — two mount styles declare their paths in another file,
+  // so this single-file derivation cannot see them:
+  //
+  //   1. `api.route('/', subRouter)` — the sub-router declares its OWN
+  //      top-level segments. Reserved by hand and pinned by the root-mount
+  //      tripwire below.
+  //   2. `mountX(app)` helper-function mounts — 2 today
+  //      (`mountInviteLandingRoutes`, `mountExtensionGateway`), neither of
+  //      which adds a `/api/v1/<ns>` top-level segment. NOT tripwired; a new
+  //      helper that mounts under /api/v1 would escape this test, so reserve
+  //      its namespace by hand.
   const API_INDEX = fileURLToPath(
     new URL('../../../apps/api/src/index.ts', import.meta.url),
   );
@@ -202,8 +208,9 @@ describe('RESERVED_ROUTE_NAMESPACES', () => {
   // Mounts placed directly on the outer app under the same prefix:
   // app.route('/api/v1/oauth', …) → oauth
   const OUTER_MOUNT_RE = /^\s*app\.route\(\s*['"`]\/api\/v1\/([a-z0-9-]+)/gm;
-  // api.route('/', subRouter) — see the blind-spot note above.
-  const ROOT_MOUNT_RE = /^\s*api\.route\(\s*['"`]\/['"`]\s*,/gm;
+  // api.route('/', subRouter) — see the blind-spot note above. Captures the
+  // router identifier so the tripwire pins identity, not just a count.
+  const ROOT_MOUNT_RE = /^\s*api\.route\(\s*['"`]\/['"`]\s*,\s*([A-Za-z0-9_]+)/gm;
 
   function deriveCoreNamespaces(): string[] {
     const namespaces = new Set<string>();
@@ -223,19 +230,33 @@ describe('RESERVED_ROUTE_NAMESPACES', () => {
     expect(coreNamespaces).toContain('service-principals');
   });
 
-  it('pins the number of root-mounted sub-routers the derivation cannot see', () => {
-    // Tripwire for the blind spot documented above. These eight resolve to:
-    //   externalServices        → billing, support
-    //   invoices/assembly       → orgs, tickets
-    //   invoices/settings       → orgs, partner
-    //   tickets/ticketResponseTemplates → ticket-response-templates
-    //   tickets/forms           → ticket-forms
-    //   lifecycle (x2)          → admin, me
-    //   c2c/m365Auth callback   → c2c
-    // All are reserved. If this count changes, resolve the new sub-router's
-    // top-level segments by hand and add them to RESERVED_ROUTE_NAMESPACES.
-    const rootMounts = [...source.matchAll(ROOT_MOUNT_RE)].length;
-    expect(rootMounts).toBe(8);
+  it('pins which sub-routers are root-mounted where the derivation cannot see them', () => {
+    // Tripwire for the blind spot documented above. Pinning the identifiers
+    // rather than a count means swapping one root-mounted router for another
+    // still fails, instead of passing on an unchanged total.
+    //
+    // Resolved top-level segments (all reserved):
+    //   externalServicesRoutes        → billing, support
+    //   invoiceAssemblyRoutes         → orgs, tickets
+    //   invoiceSettingsRoutes         → orgs, partner
+    //   ticketResponseTemplateRoutes  → ticket-response-templates
+    //   ticketFormRoutes              → ticket-forms
+    //   lifecycleRoutes               → me
+    //   lifecycleAdminRoutes          → admin
+    //   m365CallbackRoute             → c2c
+    // If this list changes, open the new sub-router, resolve its top-level
+    // segments by hand, and add them to RESERVED_ROUTE_NAMESPACES.
+    const rootMounts = [...source.matchAll(ROOT_MOUNT_RE)].map((m) => m[1]).sort();
+    expect(rootMounts).toEqual([
+      'externalServicesRoutes',
+      'invoiceAssemblyRoutes',
+      'invoiceSettingsRoutes',
+      'lifecycleAdminRoutes',
+      'lifecycleRoutes',
+      'm365CallbackRoute',
+      'ticketFormRoutes',
+      'ticketResponseTemplateRoutes',
+    ]);
   });
 
   it.each([
@@ -243,8 +264,10 @@ describe('RESERVED_ROUTE_NAMESPACES', () => {
     'support',
     'ticket-forms',
     'ticket-response-templates',
-  ])('reserves root-mounted sub-router namespace %s', (namespace) => {
+  ])('reserves and rejects root-mounted sub-router namespace %s', (namespace) => {
     expect(RESERVED_ROUTE_NAMESPACES.has(namespace)).toBe(true);
+    expect(() => parseExtensionManifest({ ...validManifest, routeNamespace: namespace }))
+      .toThrow();
   });
 
   it('reserves every core /api/v1 route namespace', () => {

--- a/packages/extension-api/src/legacy.ts
+++ b/packages/extension-api/src/legacy.ts
@@ -6,14 +6,17 @@ import type { ExtensionJobDefinition } from '@breeze/extension-sdk';
 
 /**
  * Route namespaces already mounted by core (apps/api/src/index.ts, /api/v1/*).
- * An extension may not shadow them. Keep in sync when core adds mounts.
+ * An extension may not shadow them.
  *
- * Regenerate the inner-mount list with:
- *   grep -oE "api\.route\('/[a-z0-9-]+" apps/api/src/index.ts
- * then add the outer-app mounts `oauth`, `settings`, and the shortlink
- * prefix `s`, which are mounted directly on the outer Hono app rather than
- * through the versioned `/api/v1` router. See src/index.test.ts for the
- * hand-maintained ground-truth contract this set is checked against.
+ * This set must stay in sync with the identical set in
+ * `@breeze/extension-sdk` (packages/extension-sdk/src/manifest.ts) — both are
+ * asserted equal by src/index.test.ts.
+ *
+ * There is no manual regeneration step: src/index.test.ts derives the core
+ * mounts from apps/api/src/index.ts at test time and fails if any mount is
+ * missing here. Adding a core mount without reserving it breaks the build.
+ * Entries with no matching mount (e.g. `s`, `oauth`, `settings`, `ext`) are
+ * deliberate extra reservations and are allowed.
  */
 export const RESERVED_ROUTE_NAMESPACES = new Set([
   'access-reviews', 'accounting', 'admin', 'agent-versions', 'agent-ws',
@@ -28,11 +31,13 @@ export const RESERVED_ROUTE_NAMESPACES = new Set([
   'incidents', 'installer', 'integrations', 'internal', 'invoices', 'logs',
   'm365', 'maintenance', 'mcp', 'me', 'metrics', 'mobile', 'monitoring',
   'monitors', 'network', 'notifications', 'oauth', 'onedrive', 'orgs',
-  'pam', 'partner', 'partners', 'patch-policies', 'patches', 'pax8',
+  'pam', 'partner', 'partner-api', 'partner-service-principals', 'partners',
+  'patch-policies', 'patches', 'pax8',
   'peripherals', 'permissions', 'playbooks', 'plugins', 'policies',
   'portal', 'psa', 'quotes', 'reliability', 'remediation-suggestions',
   'remote', 'reports', 'roles', 's', 's1', 'script-library', 'scripts',
-  'search', 'security', 'sensitive-data', 'settings', 'snmp', 'software',
+  'search', 'security', 'sensitive-data', 'service-principals', 'settings',
+  'snmp', 'software',
   'software-inventory', 'software-policies', 'sso', 'system',
   'system-tools', 'tags', 'third-party-catalog', 'ticket-categories',
   'ticket-config', 'tickets', 'time-entries', 'tunnel-http', 'tunnel-ws',

--- a/packages/extension-api/src/legacy.ts
+++ b/packages/extension-api/src/legacy.ts
@@ -12,9 +12,17 @@ import type { ExtensionJobDefinition } from '@breeze/extension-sdk';
  * `@breeze/extension-sdk` (packages/extension-sdk/src/manifest.ts) — both are
  * asserted equal by src/index.test.ts.
  *
- * There is no manual regeneration step: src/index.test.ts derives the core
- * mounts from apps/api/src/index.ts at test time and fails if any mount is
- * missing here. Adding a core mount without reserving it breaks the build.
+ * There is no manual regeneration step for the common case: src/index.test.ts
+ * derives the core mounts from apps/api/src/index.ts at test time and fails if
+ * a `api.route('/<ns>', …)` or `app.route('/api/v1/<ns>', …)` mount is missing
+ * here.
+ *
+ * The one case that still needs a human: `api.route('/', subRouter)`, where the
+ * sub-router declares its own top-level segments in another file. The
+ * derivation cannot see those, so they are reserved by hand and the number of
+ * such mounts is pinned by a tripwire test. If that count changes, resolve the
+ * new sub-router's paths and reserve them here.
+ *
  * Entries with no matching mount (e.g. `s`, `oauth`, `settings`, `ext`) are
  * deliberate extra reservations and are allowed.
  */
@@ -22,7 +30,8 @@ export const RESERVED_ROUTE_NAMESPACES = new Set([
   'access-reviews', 'accounting', 'admin', 'agent-versions', 'agent-ws',
   'agents', 'ai', 'alert-templates', 'alerts', 'analytics', 'api-keys',
   'audit-baselines', 'audit-logs', 'auth', 'authenticator', 'automations',
-  'backup', 'browser-security', 'c2c', 'catalog', 'changes', 'cis',
+  'backup', 'billing', 'browser-security', 'c2c', 'catalog', 'changes',
+  'cis',
   'client-ai', 'config', 'configuration-policies', 'contracts',
   'custom-fields', 'deployments', 'desktop-ws', 'dev', 'device-groups',
   'devices', 'discovery', 'dns-security', 'docs', 'dr', 'enrollment-keys',
@@ -38,9 +47,10 @@ export const RESERVED_ROUTE_NAMESPACES = new Set([
   'remote', 'reports', 'roles', 's', 's1', 'script-library', 'scripts',
   'search', 'security', 'sensitive-data', 'service-principals', 'settings',
   'snmp', 'software',
-  'software-inventory', 'software-policies', 'sso', 'system',
-  'system-tools', 'tags', 'third-party-catalog', 'ticket-categories',
-  'ticket-config', 'tickets', 'time-entries', 'tunnel-http', 'tunnel-ws',
+  'software-inventory', 'software-policies', 'sso', 'support',
+  'system', 'system-tools', 'tags', 'third-party-catalog',
+  'ticket-categories', 'ticket-config', 'ticket-forms',
+  'ticket-response-templates', 'tickets', 'time-entries', 'tunnel-http', 'tunnel-ws',
   'tunnels', 'unifi', 'update-rings', 'user-risk', 'users', 'viewers',
   'vnc-exchange', 'vnc-viewer', 'vulnerabilities', 'webhooks',
 ]);

--- a/packages/extension-api/src/legacy.ts
+++ b/packages/extension-api/src/legacy.ts
@@ -17,11 +17,11 @@ import type { ExtensionJobDefinition } from '@breeze/extension-sdk';
  * a `api.route('/<ns>', …)` or `app.route('/api/v1/<ns>', …)` mount is missing
  * here.
  *
- * The one case that still needs a human: `api.route('/', subRouter)`, where the
- * sub-router declares its own top-level segments in another file. The
- * derivation cannot see those, so they are reserved by hand and the number of
- * such mounts is pinned by a tripwire test. If that count changes, resolve the
- * new sub-router's paths and reserve them here.
+ * Two cases still need a human, because they declare their paths in another
+ * file: `api.route('/', subRouter)` (pinned by a tripwire test that asserts
+ * exactly which sub-routers are root-mounted), and `mountX(app)` helper
+ * mounts (not tripwired; none currently add a `/api/v1` segment). If either
+ * changes, resolve the new paths by hand and reserve them here.
  *
  * Entries with no matching mount (e.g. `s`, `oauth`, `settings`, `ext`) are
  * deliberate extra reservations and are allowed.

--- a/packages/extension-sdk/src/manifest.test.ts
+++ b/packages/extension-sdk/src/manifest.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { SUPPORTED_EXTENSION_CAPABILITIES, parseExtensionManifestV1 } from './manifest';
+import {
+  RESERVED_ROUTE_NAMESPACES,
+  SUPPORTED_EXTENSION_CAPABILITIES,
+  parseExtensionManifestV1,
+  safeParseExtensionManifestV1,
+} from './manifest';
 
 const valid = {
   apiVersion: 'breeze.extensions/v1',
@@ -191,6 +196,27 @@ describe('parseExtensionManifestV1', () => {
       ...valid,
       tenancy: { ...valid.tenancy, orgCascadeDeleteTables: ['other_items'] },
     })).toThrow(/demo_/);
+  });
+
+  // safeParse is the non-throwing entry point the conformance testkit
+  // validates through (packages/extension-testkit/src/manifest.ts). It shares
+  // manifestSchemaV1 with parseExtensionManifestV1, so the namespace
+  // reservation must gate it too — otherwise a second validation surface
+  // could accept what the first rejects.
+  it.each([
+    'devices',
+    'extensions',
+    'service-principals',
+    'partner-service-principals',
+    'partner-api',
+    'billing',
+    'support',
+    'ticket-forms',
+    'ticket-response-templates',
+  ])('safeParse rejects reserved routeNamespace %s', (routeNamespace) => {
+    expect(RESERVED_ROUTE_NAMESPACES.has(routeNamespace)).toBe(true);
+    const result = safeParseExtensionManifestV1({ ...valid, routeNamespace });
+    expect(result.success).toBe(false);
   });
 
   it.each([

--- a/packages/extension-sdk/src/manifest.test.ts
+++ b/packages/extension-sdk/src/manifest.test.ts
@@ -181,6 +181,10 @@ describe('parseExtensionManifestV1', () => {
     expect(() => parseExtensionManifestV1({ ...valid, routeNamespace: 'devices' })).toThrow();
     expect(() => parseExtensionManifestV1({ ...valid, routeNamespace: 'ext' })).toThrow();
     expect(() => parseExtensionManifestV1({ ...valid, routeNamespace: 'extensions' })).toThrow();
+    // #2634 — auth-sensitive core mounts that shipped unreserved.
+    expect(() => parseExtensionManifestV1({ ...valid, routeNamespace: 'service-principals' })).toThrow();
+    expect(() => parseExtensionManifestV1({ ...valid, routeNamespace: 'partner-service-principals' })).toThrow();
+    expect(() => parseExtensionManifestV1({ ...valid, routeNamespace: 'partner-api' })).toThrow();
     expect(() => parseExtensionManifestV1({ ...valid, publicRoutes: ['/*'] })).toThrow();
     expect(() => parseExtensionManifestV1({ ...valid, publicRoutes: ['/agent/hook'] })).toThrow();
     expect(() => parseExtensionManifestV1({

--- a/packages/extension-sdk/src/manifest.ts
+++ b/packages/extension-sdk/src/manifest.ts
@@ -14,7 +14,14 @@ export const SUPPORTED_EXTENSION_CAPABILITIES = [
   'web.slots.v1',
 ] as const;
 
-/** Route namespaces already owned by the Breeze API. */
+/**
+ * Route namespaces already owned by the Breeze API.
+ *
+ * Mirrored verbatim in packages/extension-api/src/legacy.ts; the two sets are
+ * asserted equal by packages/extension-api/src/index.test.ts, which also
+ * derives the core mounts from apps/api/src/index.ts at test time so a new
+ * core mount that isn't reserved here fails the build automatically.
+ */
 export const RESERVED_ROUTE_NAMESPACES = new Set([
   'access-reviews', 'accounting', 'admin', 'agent-versions', 'agent-ws',
   'agents', 'ai', 'alert-templates', 'alerts', 'analytics', 'api-keys',
@@ -28,11 +35,13 @@ export const RESERVED_ROUTE_NAMESPACES = new Set([
   'incidents', 'installer', 'integrations', 'internal', 'invoices', 'logs',
   'm365', 'maintenance', 'mcp', 'me', 'metrics', 'mobile', 'monitoring',
   'monitors', 'network', 'notifications', 'oauth', 'onedrive', 'orgs',
-  'pam', 'partner', 'partners', 'patch-policies', 'patches', 'pax8',
+  'pam', 'partner', 'partner-api', 'partner-service-principals', 'partners',
+  'patch-policies', 'patches', 'pax8',
   'peripherals', 'permissions', 'playbooks', 'plugins', 'policies',
   'portal', 'psa', 'quotes', 'reliability', 'remediation-suggestions',
   'remote', 'reports', 'roles', 's', 's1', 'script-library', 'scripts',
-  'search', 'security', 'sensitive-data', 'settings', 'snmp', 'software',
+  'search', 'security', 'sensitive-data', 'service-principals', 'settings',
+  'snmp', 'software',
   'software-inventory', 'software-policies', 'sso', 'system',
   'system-tools', 'tags', 'third-party-catalog', 'ticket-categories',
   'ticket-config', 'tickets', 'time-entries', 'tunnel-http', 'tunnel-ws',

--- a/packages/extension-sdk/src/manifest.ts
+++ b/packages/extension-sdk/src/manifest.ts
@@ -21,12 +21,17 @@ export const SUPPORTED_EXTENSION_CAPABILITIES = [
  * asserted equal by packages/extension-api/src/index.test.ts, which also
  * derives the core mounts from apps/api/src/index.ts at test time so a new
  * core mount that isn't reserved here fails the build automatically.
+ *
+ * Exception: `api.route('/', subRouter)` mounts declare their segments in
+ * another file and are reserved by hand; a tripwire test pins how many exist.
+ * See the fuller note in packages/extension-api/src/legacy.ts.
  */
 export const RESERVED_ROUTE_NAMESPACES = new Set([
   'access-reviews', 'accounting', 'admin', 'agent-versions', 'agent-ws',
   'agents', 'ai', 'alert-templates', 'alerts', 'analytics', 'api-keys',
   'audit-baselines', 'audit-logs', 'auth', 'authenticator', 'automations',
-  'backup', 'browser-security', 'c2c', 'catalog', 'changes', 'cis',
+  'backup', 'billing', 'browser-security', 'c2c', 'catalog', 'changes',
+  'cis',
   'client-ai', 'config', 'configuration-policies', 'contracts',
   'custom-fields', 'deployments', 'desktop-ws', 'dev', 'device-groups',
   'devices', 'discovery', 'dns-security', 'docs', 'dr', 'enrollment-keys',
@@ -42,9 +47,10 @@ export const RESERVED_ROUTE_NAMESPACES = new Set([
   'remote', 'reports', 'roles', 's', 's1', 'script-library', 'scripts',
   'search', 'security', 'sensitive-data', 'service-principals', 'settings',
   'snmp', 'software',
-  'software-inventory', 'software-policies', 'sso', 'system',
-  'system-tools', 'tags', 'third-party-catalog', 'ticket-categories',
-  'ticket-config', 'tickets', 'time-entries', 'tunnel-http', 'tunnel-ws',
+  'software-inventory', 'software-policies', 'sso', 'support',
+  'system', 'system-tools', 'tags', 'third-party-catalog',
+  'ticket-categories', 'ticket-config', 'ticket-forms',
+  'ticket-response-templates', 'tickets', 'time-entries', 'tunnel-http', 'tunnel-ws',
   'tunnels', 'unifi', 'update-rings', 'user-risk', 'users', 'viewers',
   'vnc-exchange', 'vnc-viewer', 'vulnerabilities', 'webhooks',
 ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,6 +1061,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(gel@2.2.0)(pg@8.22.0)(postgres@3.4.9)
@@ -1072,7 +1075,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/extension-cli:
     dependencies:
@@ -15090,7 +15093,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.0': {}
 


### PR DESCRIPTION
Closes #2634
Closes #2635

## #2634 — unreserved auth-sensitive namespaces (security)

`mountExtensionGateway` registers `app.all('/api/v1/:routeNamespace/*', dispatchAlias)` at `apps/api/src/index.ts:955`, **before** `app.route('/api/v1', api)` at line 957. `dispatchAlias` only calls `next()` when no enabled extension claims the namespace, and manifest validation rejects a `routeNamespace` only if it appears in `RESERVED_ROUTE_NAMESPACES`. So an installed + enabled extension could declare an unreserved core namespace and shadow that surface fleet-wide, receiving the full request including the `Authorization` header.

**The issue named three. Reconciliation found seven.**

| Namespace | How it is mounted | Found by |
|---|---|---|
| `service-principals` | `api.route('/service-principals', …)` | issue |
| `partner-service-principals` | `api.route('/partner-service-principals', …)` | issue |
| `partner-api` | `api.route('/partner-api', …)` | issue |
| `billing` | `api.route('/', externalServicesRoutes)` | PR review |
| `support` | `api.route('/', externalServicesRoutes)` | PR review |
| `ticket-response-templates` | `api.route('/', ticketResponseTemplateRoutes)` | PR review |
| `ticket-forms` | `api.route('/', ticketFormRoutes)` | PR review |

The last four are the interesting ones: the issue's own verification command (`grep -oE "api\.route\('/[a-z0-9-]+"`) **cannot see them**. `index.ts` mounts eight sub-routers as `api.route('/', subRouter)`, where the router declares its own top-level segments in a different file. Resolving all eight by hand surfaced four more unreserved namespaces reachable by the identical mechanism — including `POST /api/v1/billing/portal`, which is MFA + `BILLING_MANAGE` gated and returns a Stripe customer-portal session URL.

All seven are now reserved in **both** copies that gate validation:

- `packages/extension-sdk/src/manifest.ts` (`parseExtensionManifestV1`)
- `packages/extension-api/src/legacy.ts` (`parseExtensionManifest`)

### Full root-mount resolution

| Mount | Sub-router | Top-level segments |
|---|---|---|
| `index.ts:783` | `externalServicesRoutes` | `billing`, `support` |
| `index.ts:815` | `invoiceAssemblyRoutes` | `orgs`, `tickets` |
| `index.ts:819` | `invoiceSettingsRoutes` | `orgs`, `partner` |
| `index.ts:823` | `ticketResponseTemplateRoutes` | `ticket-response-templates` |
| `index.ts:824` | `ticketFormRoutes` | `ticket-forms` |
| `index.ts:883` | `lifecycleRoutes` | `me` |
| `index.ts:884` | `lifecycleAdminRoutes` | `admin` |
| `index.ts:944` | `m365CallbackRoute` | `c2c` |

Final state: **120 reachable namespaces, 0 unreserved.** Both sets are byte-identical at 122 entries (the 2 extras, `ext` and `s`, are deliberate).

## #2635 — auto-derived CORE_NAMESPACES (test hardening)

The guard that should have caught #2634 was a hand-maintained `CORE_NAMESPACES` literal **copy-pasted from `RESERVED_ROUTE_NAMESPACES` itself**, so its assertion ("every CORE_NAMESPACE is reserved") was tautological — structurally incapable of detecting a mount that was never reserved. That is exactly how all seven shipped.

Replaced with truth derived from `apps/api/src/index.ts` at test time:

- parses `api.route('/<ns>', …)` **and** `app.route('/api/v1/<ns>', …)` — the second form shares the hijackable prefix
- matches are anchored to statement position (`^\s*` + `/m`), which excludes commented-out mounts by construction
- accepts `'`, `"` and backtick quoting (no lint rule enforces quote style)
- floor assertion (`> 110` against an actual 116) so a moved file or renamed router fails loudly instead of passing vacuously
- new test asserts the sdk and legacy sets are **identical**, since each gates its own validation path

### Honest about what it cannot see

The derivation reads one file, so two mount styles remain manual, and the comments now say so rather than claiming exhaustiveness:

1. `api.route('/', subRouter)` — **tripwired.** A test pins the sorted list of the eight root-mounted router *identifiers*. Pinning identity rather than a count means swapping one root-mounted router for another still fails.
2. `mountX(app)` helper mounts — **not tripwired.** Both existing helpers (`mountInviteLandingRoutes`, `mountExtensionGateway`) are benign; a future helper mounting under `/api/v1` would need manual reservation. Documented explicitly.

## Verification

Every guard was **mutation-tested**, not merely observed passing:

| Mutation | Expected | Result |
|---|---|---|
| Remove a reservation from both sets | fail | 2 tests fail |
| Add a new unreserved `api.route('/x', …)` | fail | fails (`missing: ['brand-new-surface']`) |
| Add a 9th root-mounted sub-router | fail | tripwire fails |
| Swap one root router for another (count stays 8) | fail | tripwire fails |
| Add a commented-out mount | pass | passes (correctly ignored) |

- `packages/extension-api`: 28 passed
- `packages/extension-sdk`: 51 passed
- `tsc --noEmit` clean in both

Both suites run in the **`test-api`** job (`.github/workflows/ci.yml:136-145`), which is a required check — so this guard is genuinely enforced.

`@types/node` (`^25.9.3`, matching the repo's dominant pin) was added to `packages/extension-api` devDependencies for the `node:fs` / `node:url` imports. The lockfile diff is pnpm's own output; the `@types/node` resolution shift is confined to this importer's vitest peer.

## Overlap with in-flight extension PRs

- **#2617** (`feat/runtime-ext-02-operations`) — touches `legacy.ts` but not the reserved set. No expected conflict.
- **#2633** (`feat/runtime-ext-03-web`) — **real overlap.** It adds `'extensions'` to the reserved set in all three files and bumps the `CORE_NAMESPACES` literal to 116 entries. The reserved-set additions land on different lines than this PR's and should auto-merge, but the `CORE_NAMESPACES` literal and its `toHaveLength(116)` assertion **will conflict**, since this PR deletes that block.

  Resolution for whoever merges second is mechanical: drop #2633's `CORE_NAMESPACES` / `toHaveLength` hunks, keep only its `'extensions'` reservation. After this PR, #2633's new `api.route('/extensions', …)` mount is covered automatically by the derivation.

  #2634 is pre-existing on `main` and independent of both.

## Deploy note

`extensions/discovery.ts` **throws** on an invalid manifest rather than skipping the extension, so reservation is retroactive and fail-closed (correct for auth-sensitive surfaces). Any deployment running an extension that already claims one of these seven namespaces will fail to boot after upgrade — worth a line in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)