### PR TITLE
fix(viewer): register breeze:// on Linux so the AppImage actually connects (#2614)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1231,6 +1231,16 @@ jobs:
         working-directory: apps/viewer/src-tauri
         run: cargo check --locked --all-targets
 
+      # `cargo check` compiles #[cfg(test)] code but never runs it, so until
+      # this step existed every Rust unit test in the viewer was documentation.
+      # The suite is pure functions — no display server, no Tauri runtime, ~0s.
+      # apps/helper/src-tauri has 53 more tests in the same position; they pass
+      # on macOS but are unverified on this runner, so wiring them up is left to
+      # its own PR rather than gating unrelated work on the outcome.
+      - name: Test viewer
+        working-directory: apps/viewer/src-tauri
+        run: cargo test --locked --lib
+
   # ─── Rust Check (Windows) ─────────────────────────────────────────────
   # The ubuntu rust-check can't compile [target.'cfg(windows)'] deps (the
   # `windows` crate family) — historically only the release build verified

--- a/apps/viewer/src-tauri/src/lib.rs
+++ b/apps/viewer/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+#[cfg(any(target_os = "linux", test))]
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
 use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder, WindowEvent};
@@ -12,34 +13,33 @@ const MAX_ID_PARAM_BYTES: usize = 128;
 const MAX_CODE_PARAM_BYTES: usize = 512;
 const MAX_API_PARAM_BYTES: usize = 2048;
 
+/// How long a launch waits before concluding no deep link is coming and showing
+/// the idle card. See the comment at its use site in `setup()`.
+const IDLE_CARD_DELAY: std::time::Duration = std::time::Duration::from_millis(800);
+
 /// Register this app bundle with macOS Launch Services so the `breeze://`
 /// URL scheme always resolves to the current install location (not a stale
 /// DMG mount path). This is a no-op on non-macOS platforms.
 #[cfg(target_os = "macos")]
-fn register_url_scheme() {
-    if let Ok(exe) = std::env::current_exe() {
-        // Walk up from .app/Contents/MacOS/binary → .app
-        if let Some(app_bundle) = exe
-            .parent()
-            .and_then(|p| p.parent())
-            .and_then(|p| p.parent())
-        {
-            match std::process::Command::new("/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister")
-                .arg("-f")
-                .arg(app_bundle)
-                .output()
-            {
-                Ok(output) => {
-                    if !output.status.success() {
-                        eprintln!("lsregister failed with status: {}", output.status);
-                    }
-                }
-                Err(err) => {
-                    eprintln!("Failed to run lsregister: {}", err);
-                }
-            }
-        }
+fn register_url_scheme() -> Result<(), String> {
+    let exe = std::env::current_exe().map_err(|e| format!("cannot resolve own path: {e}"))?;
+    // Walk up from .app/Contents/MacOS/binary → .app
+    let app_bundle = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .ok_or_else(|| format!("{} is not inside an .app bundle", exe.display()))?;
+
+    let output = std::process::Command::new("/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister")
+        .arg("-f")
+        .arg(app_bundle)
+        .output()
+        .map_err(|e| format!("failed to run lsregister: {e}"))?;
+
+    if !output.status.success() {
+        return Err(format!("lsregister failed with status {}", output.status));
     }
+    Ok(())
 }
 
 /// Set once the app has asked to exit, so the shutdown that follows — which
@@ -49,9 +49,19 @@ fn register_url_scheme() {
 /// workaround at the bottom of `run()`; re-entering it is not worth finding out.
 static EXIT_REQUESTED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
+// ── Linux `breeze://` registration ───────────────────────────────────────
+// The helpers below are compiled on Linux, and under `cfg(test)` everywhere so
+// they stay unit-testable on any dev machine. Only the fs/subprocess half
+// (`register_url_scheme`, `scheme_association_is_ours`, `run_best_effort`) is
+// Linux-only, and CI's ubuntu `cargo check` is what compiles it.
+
 /// Filename of the desktop entry this app owns under the XDG applications dir.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 const LINUX_DESKTOP_ENTRY_NAME: &str = "breeze-viewer.desktop";
+
+/// The MIME type that carries the `breeze://` scheme association.
+#[cfg(target_os = "linux")]
+const BREEZE_SCHEME_MIME: &str = "x-scheme-handler/breeze";
 
 /// Resolve the launcher path to record in the Linux desktop entry.
 ///
@@ -65,9 +75,6 @@ const LINUX_DESKTOP_ENTRY_NAME: &str = "breeze-viewer.desktop";
 /// Relative paths are rejected: `Exec=` is resolved against an unspecified
 /// working directory, so anything non-absolute is a handler that fails later
 /// instead of failing here.
-/// Compiled on Linux, and under `cfg(test)` everywhere so the pure helpers
-/// stay unit-testable on any dev machine — only the fs/subprocess half of
-/// registration is Linux-only.
 #[cfg(any(target_os = "linux", test))]
 fn resolve_launcher_path(
     appimage_env: Option<&str>,
@@ -81,9 +88,6 @@ fn resolve_launcher_path(
 }
 
 /// Directory the desktop entry is written to, per the XDG base directory spec.
-/// Compiled on Linux, and under `cfg(test)` everywhere so the pure helpers
-/// stay unit-testable on any dev machine — only the fs/subprocess half of
-/// registration is Linux-only.
 #[cfg(any(target_os = "linux", test))]
 fn xdg_applications_dir(xdg_data_home: Option<&str>, home: Option<&str>) -> Option<PathBuf> {
     let base = match xdg_data_home.map(str::trim).filter(|s| !s.is_empty()) {
@@ -98,24 +102,35 @@ fn xdg_applications_dir(xdg_data_home: Option<&str>, home: Option<&str>) -> Opti
 /// Always quotes rather than deciding whether quoting is needed — the
 /// "does this character require quoting" branch is the bug-prone half, and an
 /// unconditionally quoted argument is valid per the Desktop Entry spec.
-/// Returns `None` for paths containing characters that would corrupt the
-/// key-value file format outright; we would rather skip registration than
-/// write a malformed entry that breaks every other handler in the file.
-/// Compiled on Linux, and under `cfg(test)` everywhere so the pure helpers
-/// stay unit-testable on any dev machine — only the fs/subprocess half of
-/// registration is Linux-only.
+///
+/// Returns `None` rather than emitting something subtly wrong:
+/// - **Control characters** — a newline would terminate the `Exec=` key and
+///   corrupt every handler below it in the file. The rest are rejected on
+///   principle, not because each one individually breaks parsing.
+/// - **Literal backslashes** — these would have to survive two unescaping
+///   passes (the `.desktop` value decoding, then `Exec=` argument parsing) and
+///   the correct encoding differs between them. For a path shape that
+///   essentially never occurs on Linux, declining to register and logging why
+///   beats shipping an encoding that varies by desktop environment.
 #[cfg(any(target_os = "linux", test))]
 fn escape_desktop_exec(path: &str) -> Option<String> {
-    if path.chars().any(|c| c.is_control()) {
+    if path.chars().any(|c| c.is_control() || c == '\\') {
         return None;
     }
     let mut out = String::with_capacity(path.len() + 2);
     out.push('"');
     for ch in path.chars() {
-        if matches!(ch, '"' | '`' | '$' | '\\') {
-            out.push('\\');
+        match ch {
+            // Reserved inside a quoted Exec argument.
+            '"' | '`' | '$' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            // `%` introduces a field code (`%u`, `%f`); a literal must be
+            // doubled or the parser reads e.g. `%2` as an undefined code.
+            '%' => out.push_str("%%"),
+            _ => out.push(ch),
         }
-        out.push(ch);
     }
     out.push('"');
     Some(out)
@@ -126,9 +141,6 @@ fn escape_desktop_exec(path: &str) -> Option<String> {
 /// `NoDisplay=true` because this entry exists only to register the URL scheme —
 /// the viewer is launched by the Breeze console, not from an app menu, and a
 /// visible entry would linger after the user deletes the AppImage.
-/// Compiled on Linux, and under `cfg(test)` everywhere so the pure helpers
-/// stay unit-testable on any dev machine — only the fs/subprocess half of
-/// registration is Linux-only.
 #[cfg(any(target_os = "linux", test))]
 fn desktop_entry_contents(exec_quoted: &str) -> String {
     format!(
@@ -146,6 +158,45 @@ fn desktop_entry_contents(exec_quoted: &str) -> String {
     )
 }
 
+/// Everything the Linux registration needs, derived purely from the process
+/// environment. Split from the fs/subprocess work so the derivation is
+/// unit-testable without a real `$HOME`: which env var feeds which slot, and
+/// that the file we write is the same name we hand to `xdg-mime`. Wiring those
+/// wrong compiles fine and fails silently — indistinguishable from no fix.
+#[cfg(any(target_os = "linux", test))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LinuxRegistration {
+    dir: PathBuf,
+    entry_path: PathBuf,
+    entry_name: &'static str,
+    contents: String,
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn linux_registration_plan(
+    appimage_env: Option<&str>,
+    current_exe: Option<&Path>,
+    xdg_data_home: Option<&str>,
+    home: Option<&str>,
+) -> Result<LinuxRegistration, String> {
+    let launcher = resolve_launcher_path(appimage_env, current_exe)
+        .ok_or_else(|| "no absolute launcher path".to_string())?;
+    let exec_quoted = escape_desktop_exec(&launcher.to_string_lossy()).ok_or_else(|| {
+        format!(
+            "launcher path cannot be represented in a desktop entry: {}",
+            launcher.display()
+        )
+    })?;
+    let dir = xdg_applications_dir(xdg_data_home, home)
+        .ok_or_else(|| "cannot locate the XDG applications directory".to_string())?;
+    Ok(LinuxRegistration {
+        entry_path: dir.join(LINUX_DESKTOP_ENTRY_NAME),
+        dir,
+        entry_name: LINUX_DESKTOP_ENTRY_NAME,
+        contents: desktop_entry_contents(&exec_quoted),
+    })
+}
+
 /// Register this install as the `breeze://` handler on Linux.
 ///
 /// Nothing else does this. An AppImage is a single self-contained file that is
@@ -156,86 +207,100 @@ fn desktop_entry_contents(exec_quoted: &str) -> String {
 /// with the viewer already downloaded and running (issue #2614).
 ///
 /// Runs on every launch so the handler follows the AppImage if the user moves
-/// it, but rewrites (and re-runs the two xdg subprocesses) only when the
-/// content actually changes.
+/// it.
 #[cfg(target_os = "linux")]
-fn register_url_scheme() {
-    let launcher = match resolve_launcher_path(
+fn register_url_scheme() -> Result<(), String> {
+    let plan = linux_registration_plan(
         std::env::var("APPIMAGE").ok().as_deref(),
         std::env::current_exe().ok().as_deref(),
-    ) {
-        Some(path) => path,
-        None => {
-            eprintln!("Skipping breeze:// registration: no absolute launcher path");
-            return;
-        }
-    };
-
-    let exec_quoted = match escape_desktop_exec(&launcher.to_string_lossy()) {
-        Some(quoted) => quoted,
-        None => {
-            eprintln!(
-                "Skipping breeze:// registration: launcher path is not representable in a desktop entry"
-            );
-            return;
-        }
-    };
-
-    let dir = match xdg_applications_dir(
         std::env::var("XDG_DATA_HOME").ok().as_deref(),
         std::env::var("HOME").ok().as_deref(),
-    ) {
-        Some(dir) => dir,
-        None => {
-            eprintln!("Skipping breeze:// registration: cannot locate XDG applications directory");
-            return;
-        }
-    };
+    )?;
 
-    let entry_path = dir.join(LINUX_DESKTOP_ENTRY_NAME);
-    let contents = desktop_entry_contents(&exec_quoted);
-
-    if std::fs::read_to_string(&entry_path).ok().as_deref() == Some(contents.as_str()) {
-        return; // Already registered at this path — skip the subprocesses.
+    // Write only when the entry is missing or stale. Unreadable, truncated and
+    // corrupt all compare unequal and get rewritten, so a bad file self-heals.
+    if std::fs::read_to_string(&plan.entry_path).ok().as_deref() != Some(plan.contents.as_str()) {
+        std::fs::create_dir_all(&plan.dir)
+            .map_err(|e| format!("could not create {}: {}", plan.dir.display(), e))?;
+        std::fs::write(&plan.entry_path, &plan.contents)
+            .map_err(|e| format!("could not write {}: {}", plan.entry_path.display(), e))?;
     }
 
-    if let Err(err) = std::fs::create_dir_all(&dir) {
-        eprintln!("Failed to create {}: {}", dir.display(), err);
-        return;
+    // Re-assert the association on every launch unless it already points at us.
+    // Matching file content proves only that the launcher path is current — it
+    // says nothing about whether xdg ever *accepted* the association. If
+    // `xdg-mime` failed the first time (xdg-utils absent, mimeapps.list
+    // unwritable, association later clobbered by another installer), the entry
+    // would sit on disk looking perfectly correct while `breeze://` stayed
+    // unclaimed. Gating this on content alone would then never retry: #2614
+    // forever, with no way out short of deleting the file by hand.
+    if !scheme_association_is_ours(plan.entry_name) {
+        run_best_effort("update-desktop-database", &[plan.dir.as_os_str()]);
+        run_best_effort(
+            "xdg-mime",
+            &[
+                std::ffi::OsStr::new("default"),
+                std::ffi::OsStr::new(plan.entry_name),
+                std::ffi::OsStr::new(BREEZE_SCHEME_MIME),
+            ],
+        );
     }
-    if let Err(err) = std::fs::write(&entry_path, &contents) {
-        eprintln!("Failed to write {}: {}", entry_path.display(), err);
-        return;
-    }
-
-    // Both are best-effort: some minimal desktops ship neither, and a missing
-    // cache refresh still leaves a valid entry on disk for the next login.
-    run_best_effort("update-desktop-database", &[dir.as_os_str()]);
-    run_best_effort(
-        "xdg-mime",
-        &[
-            std::ffi::OsStr::new("default"),
-            std::ffi::OsStr::new(LINUX_DESKTOP_ENTRY_NAME),
-            std::ffi::OsStr::new("x-scheme-handler/breeze"),
-        ],
-    );
+    Ok(())
 }
 
+/// True only when xdg already resolves the scheme to our entry.
+///
+/// "Can't tell" — query failed, xdg-utils missing — deliberately returns false.
+/// Re-running registration costs two fast spawns; wrongly assuming success is
+/// the unrecoverable state described above.
+#[cfg(target_os = "linux")]
+fn scheme_association_is_ours(entry_name: &str) -> bool {
+    std::process::Command::new("xdg-mime")
+        .args(["query", "default", BREEZE_SCHEME_MIME])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim() == entry_name)
+        .unwrap_or(false)
+}
+
+/// Best-effort because minimal desktops genuinely ship neither tool, and a
+/// missing cache refresh still leaves a valid entry for the next login. The
+/// captured stderr is logged rather than discarded: `xdg-mime`'s own message
+/// ("no method available for setting default applications", a mimeapps.list
+/// permission error) is the only thing that makes a field report diagnosable —
+/// an exit status alone is unactionable.
 #[cfg(target_os = "linux")]
 fn run_best_effort(program: &str, args: &[&std::ffi::OsStr]) {
     match std::process::Command::new(program).args(args).output() {
         Ok(output) if !output.status.success() => {
-            eprintln!("{} exited with status {}", program, output.status);
+            eprintln!(
+                "{} exited with {}: {}",
+                program,
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
         }
-        Err(err) => eprintln!("Failed to run {}: {}", program, err),
+        // Expected on minimal desktops — kept distinct from real failures so
+        // the benign case doesn't train anyone to ignore this log line.
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("{program} is not installed — breeze:// association not refreshed");
+        }
+        Err(err) => eprintln!("failed to run {program}: {err}"),
         Ok(_) => {}
     }
 }
 
-/// No URL-scheme registration is needed on Windows — the MSI installer writes
-/// the `breeze` scheme into the registry at install time.
+/// Windows (and every other non-macOS, non-Linux target) self-registers nothing
+/// at runtime. The `breeze` scheme declared in `tauri.conf.json`
+/// (`plugins.deep-link.desktop.schemes`) is baked into the bundler's stock WiX
+/// template, which writes `HKLM\Software\Classes\breeze` at MSI install time.
+/// The source of truth is that config array — not this file, and not
+/// tauri-plugin-deep-link's unused HKCU `register()`.
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-fn register_url_scheme() {}
+fn register_url_scheme() -> Result<(), String> {
+    Ok(())
+}
 
 /// Per-window pending deep link URLs. Key = window label, value = deep link URL.
 struct DeepLinkState(Mutex<HashMap<String, String>>);
@@ -264,6 +329,17 @@ struct WindowCounter(Mutex<u32>);
 /// time (an active session defers instead); a session may start afterwards
 /// while a value is still staged, so `is_some()` does not imply "no session now".
 struct PendingUpdate(Mutex<Option<(tauri_plugin_updater::Update, Vec<u8>)>>);
+
+/// `None` once URL-scheme registration succeeded, `Some(reason)` when it did
+/// not. The idle card reads this so it cannot tell the user the viewer is ready
+/// when `breeze://` will never reach it — a card asserting a success nobody
+/// checked is how this class of bug stays invisible.
+struct SchemeRegistration(Mutex<Option<String>>);
+
+#[tauri::command]
+fn get_scheme_registration_error(state: tauri::State<SchemeRegistration>) -> Option<String> {
+    lock_or_recover(&state.0, "scheme_registration").clone()
+}
 
 fn lock_or_recover<'a, T>(mutex: &'a Mutex<T>, name: &str) -> MutexGuard<'a, T> {
     match mutex.lock() {
@@ -660,12 +736,17 @@ fn emit_with_retry(app: &tauri::AppHandle, label: &str, url: String) {
 }
 
 /// Create a new WebviewWindow for an independent remote desktop session.
-fn create_session_window(app: &tauri::AppHandle, url: String) {
+///
+/// Returns whether a session window is on screen afterwards. The caller at
+/// startup needs to know: if the deep link that launched us produces no window
+/// and nothing else is showing, the process would sit alive and invisible —
+/// the invisible-process symptom this change exists to remove.
+fn create_session_window(app: &tauri::AppHandle, url: String) -> bool {
     let url = match validate_deep_link(&url) {
         Ok(url) => url,
         Err(err) => {
             eprintln!("Rejected invalid deep link before window creation: {}", err);
-            return;
+            return false;
         }
     };
 
@@ -675,7 +756,9 @@ fn create_session_window(app: &tauri::AppHandle, url: String) {
             MAX_SESSION_WINDOWS
         );
         focus_any_session_window(app);
-        return;
+        // The limit is only reachable when windows already exist, so something
+        // is on screen — just not a new one.
+        return true;
     }
 
     let n = {
@@ -698,13 +781,17 @@ fn create_session_window(app: &tauri::AppHandle, url: String) {
         .build()
     {
         Ok(_) => {
-            // A real session took over — retire the idle anchor window if a
-            // manual launch had made it visible. Hidden, not closed: it is
-            // still the process anchor.
+            // A real session took over — retire the anchor window. Hidden, not
+            // closed: it is still the process anchor. Failure is cosmetic (the
+            // idle card lingers beside the session) and cannot strand the exit
+            // path, so log and carry on.
             if let Some(main) = app.get_webview_window("main") {
-                let _ = main.hide();
+                if let Err(err) = main.hide() {
+                    eprintln!("Failed to hide the idle window: {}", err);
+                }
             }
             emit_with_retry(app, &label, url);
+            true
         }
         Err(e) => {
             eprintln!("Failed to create session window: {}", e);
@@ -713,8 +800,52 @@ fn create_session_window(app: &tauri::AppHandle, url: String) {
                 let mut links = lock_or_recover(&state.0, "deep_link_state");
                 links.remove(&label);
             }
+            false
         }
     }
+}
+
+/// Put the anchor window on screen, or exit rather than run invisibly.
+///
+/// A viewer process with no window and no output is indistinguishable from a
+/// crash — exactly the state that was reported. If we cannot show anything,
+/// quitting at least gives the user a result they can act on.
+fn show_idle_window(app: &tauri::AppHandle) {
+    match app.get_webview_window("main") {
+        Some(main) => {
+            if let Err(err) = main.show() {
+                eprintln!("Could not show the idle window ({err}) — exiting rather than running invisibly");
+                request_exit(app, 1);
+                return;
+            }
+            // Window managers routinely refuse focus steals; purely cosmetic.
+            let _ = main.set_focus();
+        }
+        None => {
+            eprintln!("No 'main' window to show — exiting rather than running invisibly");
+            request_exit(app, 1);
+        }
+    }
+}
+
+/// Exit once. Tauri's shutdown destroys every remaining window, which re-enters
+/// the `Destroyed` handler — without this latch that handler would call `exit`
+/// a second time from inside the teardown it was triggered by.
+fn request_exit(app: &tauri::AppHandle, code: i32) {
+    if !EXIT_REQUESTED.swap(true, std::sync::atomic::Ordering::SeqCst) {
+        app.exit(code);
+    }
+}
+
+/// Whether the app should quit now that `label` was destroyed.
+///
+/// Session windows are the app's reason to exist; `main` is only on screen
+/// after a manual launch. Either kind closing with no sessions left means
+/// nothing is on screen. Pure so this branch is testable without a Tauri
+/// runtime — getting it wrong either strands an invisible process or kills a
+/// live session out from under the user.
+fn should_exit_on_window_destroyed(label: &str, remaining_session_labels: &[String]) -> bool {
+    (label == "main" || label.starts_with("session-")) && remaining_session_labels.is_empty()
 }
 
 /// Update lifecycle status broadcast to all windows on the `update-status`
@@ -906,6 +1037,7 @@ pub fn run() {
             update_session_hostname,
             apply_pending_update,
             dismiss_pending_update,
+            get_scheme_registration_error,
         ]);
 
     // Single instance plugin (desktop only) — ensures deep links open in existing
@@ -948,7 +1080,13 @@ pub fn run() {
 
     let app = builder
         .setup(|app| {
-            register_url_scheme();
+            // Kept so the idle card can say registration failed instead of
+            // claiming the viewer is ready when `breeze://` will not resolve.
+            let scheme_registration = register_url_scheme();
+            if let Err(ref err) = scheme_registration {
+                eprintln!("breeze:// registration failed: {err}");
+            }
+            app.manage(SchemeRegistration(Mutex::new(scheme_registration.err())));
 
             let initial_url = app
                 .deep_link()
@@ -971,7 +1109,13 @@ pub fn run() {
             if let Some(url) = initial_url {
                 let handle = app.handle().clone();
                 let _ = app.handle().run_on_main_thread(move || {
-                    create_session_window(&handle, url);
+                    // A rejected URL or a failed build would otherwise leave the
+                    // process alive with no window at all — the same invisible
+                    // state the `else` branch below exists to prevent, reached
+                    // by a different road.
+                    if !create_session_window(&handle, url) {
+                        show_idle_window(&handle);
+                    }
                 });
             } else {
                 // Launched with no deep link — which on Linux is the required
@@ -980,7 +1124,7 @@ pub fn run() {
                 // is `visible: false` in tauri.conf.json, so without this the
                 // process starts, registers, and then sits in the process list
                 // with no window and no output: indistinguishable from a crash
-                // (issue #2614). Show it so the launch has a visible result.
+                // Show it so the launch has a visible result.
                 //
                 // Deferred rather than immediate because "no deep link at
                 // setup() time" is not the same as "no deep link": on a macOS
@@ -988,19 +1132,18 @@ pub fn run() {
                 // to on_open_url *after* setup() returns. Showing the card
                 // straight away would flash it on screen before the session
                 // window replaces it. Waiting a beat and re-checking means the
-                // card appears only when nothing else claimed the launch.
+                // card usually does not appear in that case — IDLE_CARD_DELAY is
+                // a heuristic, not a guarantee, and a slower delivery will still
+                // flash the card before the session window replaces it.
                 let handle = app.handle().clone();
                 std::thread::spawn(move || {
-                    std::thread::sleep(std::time::Duration::from_millis(800));
+                    std::thread::sleep(IDLE_CARD_DELAY);
                     let h = handle.clone();
                     let _ = handle.run_on_main_thread(move || {
                         if active_session_window_count(&h) > 0 {
                             return;
                         }
-                        if let Some(main) = h.get_webview_window("main") {
-                            let _ = main.show();
-                            let _ = main.set_focus();
-                        }
+                        show_idle_window(&h);
                     });
                 });
             }
@@ -1058,23 +1201,19 @@ pub fn run() {
                         map.remove(&label);
                     }
 
-                    // When the last on-screen window closes, exit the app
-                    // cleanly. The anchor window serves no purpose on its own,
-                    // so closing it with no sessions left must quit rather than
-                    // leave an invisible process behind (#2614) — it is only
-                    // ever visible after a manual launch (see setup()).
-                    if label == "main" || label.starts_with("session-") {
+                    // When the last on-screen window closes, exit cleanly rather
+                    // than leave an invisible process behind. See
+                    // `should_exit_on_window_destroyed` for the rule.
+                    let remaining_sessions: Vec<String> = {
                         let counter = app_handle.state::<WindowCounter>();
                         let n = *lock_or_recover(&counter.0, "window_counter");
-                        let has_remaining = (1..=n).any(|i| {
-                            let l = format!("session-{}", i);
-                            l != label && app_handle.get_webview_window(&l).is_some()
-                        });
-                        if !has_remaining
-                            && !EXIT_REQUESTED.swap(true, std::sync::atomic::Ordering::SeqCst)
-                        {
-                            app_handle.exit(0);
-                        }
+                        (1..=n)
+                            .map(|i| format!("session-{}", i))
+                            .filter(|l| l != &label && app_handle.get_webview_window(l).is_some())
+                            .collect()
+                    };
+                    if should_exit_on_window_destroyed(&label, &remaining_sessions) {
+                        request_exit(app_handle, 0);
                     }
                 }
             }
@@ -1101,7 +1240,7 @@ mod tests {
 
     /// `$APPIMAGE` must win over `current_exe()`. Inside an AppImage the latter
     /// is the ephemeral squashfs mount, so registering it produces a handler
-    /// that breaks the moment the process exits (#2614).
+    /// that breaks the moment the process exits.
     #[test]
     fn resolve_launcher_path_prefers_appimage_over_current_exe() {
         let exe = PathBuf::from("/tmp/.mount_abc123/usr/bin/breeze-viewer");
@@ -1132,6 +1271,11 @@ mod tests {
             None
         );
         assert_eq!(resolve_launcher_path(None, None), None);
+        // A valid $APPIMAGE stands alone — current_exe() is never consulted.
+        assert_eq!(
+            resolve_launcher_path(Some("/opt/breeze.AppImage"), None),
+            Some(PathBuf::from("/opt/breeze.AppImage"))
+        );
     }
 
     #[test]
@@ -1168,19 +1312,111 @@ mod tests {
             escape_desktop_exec("/home/u/My Apps/breeze.AppImage").as_deref(),
             Some("\"/home/u/My Apps/breeze.AppImage\"")
         );
+        // Non-ASCII survives untouched — ~/Téléchargements on a localized desktop.
+        assert_eq!(
+            escape_desktop_exec("/home/u/Téléchargements/breeze.AppImage").as_deref(),
+            Some("\"/home/u/Téléchargements/breeze.AppImage\"")
+        );
         // Shell-significant characters are backslash-escaped inside the quotes.
         assert_eq!(
-            escape_desktop_exec("/home/u/a$b`c\"d\\e").as_deref(),
-            Some("\"/home/u/a\\$b\\`c\\\"d\\\\e\"")
+            escape_desktop_exec("/home/u/a$b`c\"d").as_deref(),
+            Some("\"/home/u/a\\$b\\`c\\\"d\"")
+        );
+        // `%` starts a field code: a literal one must be doubled, or a path like
+        // breeze%20viewer.AppImage feeds the parser an undefined `%2` code.
+        assert_eq!(
+            escape_desktop_exec("/home/u/breeze%20viewer.AppImage").as_deref(),
+            Some("\"/home/u/breeze%%20viewer.AppImage\"")
         );
         // A newline would terminate the Exec= key and corrupt the whole file.
         assert_eq!(escape_desktop_exec("/home/u/a\nb"), None);
         assert_eq!(escape_desktop_exec("/home/u/a\tb"), None);
+        // Backslash needs a different encoding at each of the two unescaping
+        // layers; we decline rather than emit something DE-dependent.
+        assert_eq!(escape_desktop_exec("/home/u/a\\b"), None);
+    }
+
+    /// The planner is where the env wiring lives — passing HOME where
+    /// XDG_DATA_HOME belongs still compiles and still passes every helper test.
+    #[test]
+    fn linux_registration_plan_wires_env_to_paths() {
+        let exe = PathBuf::from("/tmp/.mount_abc/usr/bin/breeze-viewer");
+        let plan = linux_registration_plan(
+            Some("/home/u/Apps/breeze-viewer-linux.AppImage"),
+            Some(&exe),
+            None,
+            Some("/home/u"),
+        )
+        .expect("plan");
+
+        assert_eq!(plan.dir, PathBuf::from("/home/u/.local/share/applications"));
+        assert_eq!(
+            plan.entry_path,
+            PathBuf::from("/home/u/.local/share/applications/breeze-viewer.desktop")
+        );
+        // The AppImage path wins over the ephemeral mount, and reaches Exec=.
+        assert!(
+            plan.contents
+                .contains("Exec=\"/home/u/Apps/breeze-viewer-linux.AppImage\" %u\n"),
+            "{}",
+            plan.contents
+        );
+        // The file we write must be the name we hand to `xdg-mime default`;
+        // a desync here is silent non-registration.
+        assert_eq!(
+            plan.entry_path.file_name().unwrap().to_str().unwrap(),
+            plan.entry_name
+        );
+        // XDG_DATA_HOME takes precedence when set.
+        let via_xdg =
+            linux_registration_plan(Some("/opt/b.AppImage"), None, Some("/xdg"), Some("/home/u"))
+                .expect("plan");
+        assert_eq!(via_xdg.dir, PathBuf::from("/xdg/applications"));
+    }
+
+    #[test]
+    fn linux_registration_plan_reports_why_it_gave_up() {
+        // Relative launcher, unrepresentable launcher, and no home directory —
+        // each aborts with a reason the idle card can show the user.
+        assert!(
+            linux_registration_plan(Some("./rel.AppImage"), None, None, Some("/home/u"))
+                .unwrap_err()
+                .contains("launcher path")
+        );
+        assert!(
+            linux_registration_plan(Some("/home/u/a\nb"), None, None, Some("/home/u"))
+                .unwrap_err()
+                .contains("desktop entry")
+        );
+        assert!(
+            linux_registration_plan(Some("/opt/b.AppImage"), None, None, None)
+                .unwrap_err()
+                .contains("XDG")
+        );
+    }
+
+    /// The riskiest new branch: closing the idle card must not kill a live
+    /// session, and closing the last session must not strand a ghost process.
+    #[test]
+    fn exit_only_when_nothing_is_left_on_screen() {
+        let one = vec!["session-1".to_string()];
+        assert!(
+            !should_exit_on_window_destroyed("main", &one),
+            "closing the idle card with a live session must not exit"
+        );
+        assert!(
+            !should_exit_on_window_destroyed("session-2", &one),
+            "closing one of two sessions must not exit"
+        );
+        assert!(should_exit_on_window_destroyed("session-1", &[]));
+        assert!(should_exit_on_window_destroyed("main", &[]));
+        // Windows we don't own shouldn't drive the lifecycle either way.
+        assert!(!should_exit_on_window_destroyed("devtools", &[]));
     }
 
     /// The entry is worthless unless it claims the scheme and forwards the URL,
     /// so lock both: a missing `%u` launches the viewer with no deep link, and
-    /// a missing MimeType leaves `breeze://` unclaimed — the exact #2614 bug.
+    /// a missing MimeType leaves `breeze://` unclaimed — the exact bug.
     #[test]
     fn desktop_entry_declares_scheme_handler_and_forwards_url() {
         let entry = desktop_entry_contents("\"/home/u/breeze.AppImage\"");
@@ -1194,6 +1430,9 @@ mod tests {
             "{entry}"
         );
         assert!(entry.contains("Type=Application\n"), "{entry}");
+        // NoDisplay is deliberate: without it a deleted AppImage leaves a
+        // dead entry in the application menu.
+        assert!(entry.contains("NoDisplay=true\n"), "{entry}");
         assert!(entry.ends_with('\n'), "{entry}");
     }
 

--- a/apps/viewer/src-tauri/src/lib.rs
+++ b/apps/viewer/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
 use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder, WindowEvent};
 use tauri_plugin_deep_link::DeepLinkExt;
@@ -40,6 +41,201 @@ fn register_url_scheme() {
         }
     }
 }
+
+/// Set once the app has asked to exit, so the shutdown that follows — which
+/// destroys every remaining window and re-enters the `Destroyed` handler — can't
+/// call `exit(0)` a second time from inside Tauri's own teardown. The macOS
+/// terminate sequence is already fragile enough to need the `RunEvent::Exit`
+/// workaround at the bottom of `run()`; re-entering it is not worth finding out.
+static EXIT_REQUESTED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Filename of the desktop entry this app owns under the XDG applications dir.
+#[cfg(target_os = "linux")]
+const LINUX_DESKTOP_ENTRY_NAME: &str = "breeze-viewer.desktop";
+
+/// Resolve the launcher path to record in the Linux desktop entry.
+///
+/// Inside an AppImage, `current_exe()` points at the ephemeral squashfs mount
+/// (`/tmp/.mount_XXXXXX/usr/bin/breeze-viewer`), which disappears the moment the
+/// process exits — a desktop entry pointing there is dead on arrival. The
+/// AppImage runtime sets `$APPIMAGE` to the real, persistent path of the
+/// `.AppImage` file, so that always wins when present. A plain (non-AppImage)
+/// build falls back to `current_exe()`.
+///
+/// Relative paths are rejected: `Exec=` is resolved against an unspecified
+/// working directory, so anything non-absolute is a handler that fails later
+/// instead of failing here.
+/// Compiled on Linux, and under `cfg(test)` everywhere so the pure helpers
+/// stay unit-testable on any dev machine — only the fs/subprocess half of
+/// registration is Linux-only.
+#[cfg(any(target_os = "linux", test))]
+fn resolve_launcher_path(
+    appimage_env: Option<&str>,
+    current_exe: Option<&Path>,
+) -> Option<PathBuf> {
+    let candidate = match appimage_env.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(appimage) => PathBuf::from(appimage),
+        None => current_exe?.to_path_buf(),
+    };
+    candidate.is_absolute().then_some(candidate)
+}
+
+/// Directory the desktop entry is written to, per the XDG base directory spec.
+/// Compiled on Linux, and under `cfg(test)` everywhere so the pure helpers
+/// stay unit-testable on any dev machine — only the fs/subprocess half of
+/// registration is Linux-only.
+#[cfg(any(target_os = "linux", test))]
+fn xdg_applications_dir(xdg_data_home: Option<&str>, home: Option<&str>) -> Option<PathBuf> {
+    let base = match xdg_data_home.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(data_home) => PathBuf::from(data_home),
+        None => Path::new(home.map(str::trim).filter(|s| !s.is_empty())?).join(".local/share"),
+    };
+    base.is_absolute().then(|| base.join("applications"))
+}
+
+/// Quote a path for the `Exec=` key of a desktop entry.
+///
+/// Always quotes rather than deciding whether quoting is needed — the
+/// "does this character require quoting" branch is the bug-prone half, and an
+/// unconditionally quoted argument is valid per the Desktop Entry spec.
+/// Returns `None` for paths containing characters that would corrupt the
+/// key-value file format outright; we would rather skip registration than
+/// write a malformed entry that breaks every other handler in the file.
+/// Compiled on Linux, and under `cfg(test)` everywhere so the pure helpers
+/// stay unit-testable on any dev machine — only the fs/subprocess half of
+/// registration is Linux-only.
+#[cfg(any(target_os = "linux", test))]
+fn escape_desktop_exec(path: &str) -> Option<String> {
+    if path.chars().any(|c| c.is_control()) {
+        return None;
+    }
+    let mut out = String::with_capacity(path.len() + 2);
+    out.push('"');
+    for ch in path.chars() {
+        if matches!(ch, '"' | '`' | '$' | '\\') {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out.push('"');
+    Some(out)
+}
+
+/// Body of the desktop entry that claims `breeze://` for this install.
+///
+/// `NoDisplay=true` because this entry exists only to register the URL scheme —
+/// the viewer is launched by the Breeze console, not from an app menu, and a
+/// visible entry would linger after the user deletes the AppImage.
+/// Compiled on Linux, and under `cfg(test)` everywhere so the pure helpers
+/// stay unit-testable on any dev machine — only the fs/subprocess half of
+/// registration is Linux-only.
+#[cfg(any(target_os = "linux", test))]
+fn desktop_entry_contents(exec_quoted: &str) -> String {
+    format!(
+        "[Desktop Entry]\n\
+         Type=Application\n\
+         Name=Breeze Viewer\n\
+         Comment=Breeze remote desktop viewer\n\
+         Exec={exec_quoted} %u\n\
+         Terminal=false\n\
+         NoDisplay=true\n\
+         StartupNotify=true\n\
+         StartupWMClass=breeze-viewer\n\
+         Categories=Network;RemoteAccess;\n\
+         MimeType=x-scheme-handler/breeze;\n"
+    )
+}
+
+/// Register this install as the `breeze://` handler on Linux.
+///
+/// Nothing else does this. An AppImage is a single self-contained file that is
+/// never installed into the XDG applications directory, so no `.desktop` file
+/// is ever seen by `update-desktop-database` and `x-scheme-handler/breeze`
+/// stays unclaimed. The console's deep link is then a silent no-op, its session
+/// poll times out, and the user is told to "Download for Linux" forever — even
+/// with the viewer already downloaded and running (issue #2614).
+///
+/// Runs on every launch so the handler follows the AppImage if the user moves
+/// it, but rewrites (and re-runs the two xdg subprocesses) only when the
+/// content actually changes.
+#[cfg(target_os = "linux")]
+fn register_url_scheme() {
+    let launcher = match resolve_launcher_path(
+        std::env::var("APPIMAGE").ok().as_deref(),
+        std::env::current_exe().ok().as_deref(),
+    ) {
+        Some(path) => path,
+        None => {
+            eprintln!("Skipping breeze:// registration: no absolute launcher path");
+            return;
+        }
+    };
+
+    let exec_quoted = match escape_desktop_exec(&launcher.to_string_lossy()) {
+        Some(quoted) => quoted,
+        None => {
+            eprintln!(
+                "Skipping breeze:// registration: launcher path is not representable in a desktop entry"
+            );
+            return;
+        }
+    };
+
+    let dir = match xdg_applications_dir(
+        std::env::var("XDG_DATA_HOME").ok().as_deref(),
+        std::env::var("HOME").ok().as_deref(),
+    ) {
+        Some(dir) => dir,
+        None => {
+            eprintln!("Skipping breeze:// registration: cannot locate XDG applications directory");
+            return;
+        }
+    };
+
+    let entry_path = dir.join(LINUX_DESKTOP_ENTRY_NAME);
+    let contents = desktop_entry_contents(&exec_quoted);
+
+    if std::fs::read_to_string(&entry_path).ok().as_deref() == Some(contents.as_str()) {
+        return; // Already registered at this path — skip the subprocesses.
+    }
+
+    if let Err(err) = std::fs::create_dir_all(&dir) {
+        eprintln!("Failed to create {}: {}", dir.display(), err);
+        return;
+    }
+    if let Err(err) = std::fs::write(&entry_path, &contents) {
+        eprintln!("Failed to write {}: {}", entry_path.display(), err);
+        return;
+    }
+
+    // Both are best-effort: some minimal desktops ship neither, and a missing
+    // cache refresh still leaves a valid entry on disk for the next login.
+    run_best_effort("update-desktop-database", &[dir.as_os_str()]);
+    run_best_effort(
+        "xdg-mime",
+        &[
+            std::ffi::OsStr::new("default"),
+            std::ffi::OsStr::new(LINUX_DESKTOP_ENTRY_NAME),
+            std::ffi::OsStr::new("x-scheme-handler/breeze"),
+        ],
+    );
+}
+
+#[cfg(target_os = "linux")]
+fn run_best_effort(program: &str, args: &[&std::ffi::OsStr]) {
+    match std::process::Command::new(program).args(args).output() {
+        Ok(output) if !output.status.success() => {
+            eprintln!("{} exited with status {}", program, output.status);
+        }
+        Err(err) => eprintln!("Failed to run {}: {}", program, err),
+        Ok(_) => {}
+    }
+}
+
+/// No URL-scheme registration is needed on Windows — the MSI installer writes
+/// the `breeze` scheme into the registry at install time.
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn register_url_scheme() {}
 
 /// Per-window pending deep link URLs. Key = window label, value = deep link URL.
 struct DeepLinkState(Mutex<HashMap<String, String>>);
@@ -502,6 +698,12 @@ fn create_session_window(app: &tauri::AppHandle, url: String) {
         .build()
     {
         Ok(_) => {
+            // A real session took over — retire the idle anchor window if a
+            // manual launch had made it visible. Hidden, not closed: it is
+            // still the process anchor.
+            if let Some(main) = app.get_webview_window("main") {
+                let _ = main.hide();
+            }
             emit_with_retry(app, &label, url);
         }
         Err(e) => {
@@ -746,7 +948,6 @@ pub fn run() {
 
     let app = builder
         .setup(|app| {
-            #[cfg(target_os = "macos")]
             register_url_scheme();
 
             let initial_url = app
@@ -771,6 +972,36 @@ pub fn run() {
                 let handle = app.handle().clone();
                 let _ = app.handle().run_on_main_thread(move || {
                     create_session_window(&handle, url);
+                });
+            } else {
+                // Launched with no deep link — which on Linux is the required
+                // first run, since the AppImage has to be executed once to
+                // register itself as the `breeze://` handler. The anchor window
+                // is `visible: false` in tauri.conf.json, so without this the
+                // process starts, registers, and then sits in the process list
+                // with no window and no output: indistinguishable from a crash
+                // (issue #2614). Show it so the launch has a visible result.
+                //
+                // Deferred rather than immediate because "no deep link at
+                // setup() time" is not the same as "no deep link": on a macOS
+                // cold start via `breeze://`, LaunchServices can deliver the URL
+                // to on_open_url *after* setup() returns. Showing the card
+                // straight away would flash it on screen before the session
+                // window replaces it. Waiting a beat and re-checking means the
+                // card appears only when nothing else claimed the launch.
+                let handle = app.handle().clone();
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(800));
+                    let h = handle.clone();
+                    let _ = handle.run_on_main_thread(move || {
+                        if active_session_window_count(&h) > 0 {
+                            return;
+                        }
+                        if let Some(main) = h.get_webview_window("main") {
+                            let _ = main.show();
+                            let _ = main.set_focus();
+                        }
+                    });
                 });
             }
 
@@ -827,16 +1058,21 @@ pub fn run() {
                         map.remove(&label);
                     }
 
-                    // When the last session window closes, exit the app cleanly.
-                    // The hidden anchor window serves no purpose on its own.
-                    if label.starts_with("session-") {
+                    // When the last on-screen window closes, exit the app
+                    // cleanly. The anchor window serves no purpose on its own,
+                    // so closing it with no sessions left must quit rather than
+                    // leave an invisible process behind (#2614) — it is only
+                    // ever visible after a manual launch (see setup()).
+                    if label == "main" || label.starts_with("session-") {
                         let counter = app_handle.state::<WindowCounter>();
                         let n = *lock_or_recover(&counter.0, "window_counter");
                         let has_remaining = (1..=n).any(|i| {
                             let l = format!("session-{}", i);
                             l != label && app_handle.get_webview_window(&l).is_some()
                         });
-                        if !has_remaining {
+                        if !has_remaining
+                            && !EXIT_REQUESTED.swap(true, std::sync::atomic::Ordering::SeqCst)
+                        {
                             app_handle.exit(0);
                         }
                     }
@@ -862,6 +1098,104 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `$APPIMAGE` must win over `current_exe()`. Inside an AppImage the latter
+    /// is the ephemeral squashfs mount, so registering it produces a handler
+    /// that breaks the moment the process exits (#2614).
+    #[test]
+    fn resolve_launcher_path_prefers_appimage_over_current_exe() {
+        let exe = PathBuf::from("/tmp/.mount_abc123/usr/bin/breeze-viewer");
+        assert_eq!(
+            resolve_launcher_path(Some("/home/u/breeze-viewer-linux.AppImage"), Some(&exe)),
+            Some(PathBuf::from("/home/u/breeze-viewer-linux.AppImage"))
+        );
+    }
+
+    #[test]
+    fn resolve_launcher_path_falls_back_and_rejects_non_absolute() {
+        let exe = PathBuf::from("/opt/breeze/breeze-viewer");
+        // Unset, empty, and whitespace-only $APPIMAGE all fall back to the exe.
+        for env in [None, Some(""), Some("   ")] {
+            assert_eq!(
+                resolve_launcher_path(env, Some(&exe)),
+                Some(exe.clone()),
+                "APPIMAGE={env:?}"
+            );
+        }
+        // Relative paths are useless in Exec= — reject rather than half-register.
+        assert_eq!(
+            resolve_launcher_path(Some("./breeze.AppImage"), Some(&exe)),
+            None
+        );
+        assert_eq!(
+            resolve_launcher_path(None, Some(Path::new("breeze-viewer"))),
+            None
+        );
+        assert_eq!(resolve_launcher_path(None, None), None);
+    }
+
+    #[test]
+    fn xdg_applications_dir_cases() {
+        assert_eq!(
+            xdg_applications_dir(Some("/home/u/.xdgdata"), Some("/home/u")),
+            Some(PathBuf::from("/home/u/.xdgdata/applications"))
+        );
+        assert_eq!(
+            xdg_applications_dir(None, Some("/home/u")),
+            Some(PathBuf::from("/home/u/.local/share/applications"))
+        );
+        // Empty XDG_DATA_HOME is "unset" per the spec, not an empty base path.
+        assert_eq!(
+            xdg_applications_dir(Some(""), Some("/home/u")),
+            Some(PathBuf::from("/home/u/.local/share/applications"))
+        );
+        // Nothing usable, and a relative base, both yield no directory.
+        assert_eq!(xdg_applications_dir(None, None), None);
+        assert_eq!(
+            xdg_applications_dir(Some("relative/data"), Some("/home/u")),
+            None
+        );
+    }
+
+    #[test]
+    fn escape_desktop_exec_quotes_and_escapes() {
+        assert_eq!(
+            escape_desktop_exec("/home/u/breeze-viewer-linux.AppImage").as_deref(),
+            Some("\"/home/u/breeze-viewer-linux.AppImage\"")
+        );
+        // Spaces are the realistic case (~/Downloads on a localized desktop).
+        assert_eq!(
+            escape_desktop_exec("/home/u/My Apps/breeze.AppImage").as_deref(),
+            Some("\"/home/u/My Apps/breeze.AppImage\"")
+        );
+        // Shell-significant characters are backslash-escaped inside the quotes.
+        assert_eq!(
+            escape_desktop_exec("/home/u/a$b`c\"d\\e").as_deref(),
+            Some("\"/home/u/a\\$b\\`c\\\"d\\\\e\"")
+        );
+        // A newline would terminate the Exec= key and corrupt the whole file.
+        assert_eq!(escape_desktop_exec("/home/u/a\nb"), None);
+        assert_eq!(escape_desktop_exec("/home/u/a\tb"), None);
+    }
+
+    /// The entry is worthless unless it claims the scheme and forwards the URL,
+    /// so lock both: a missing `%u` launches the viewer with no deep link, and
+    /// a missing MimeType leaves `breeze://` unclaimed — the exact #2614 bug.
+    #[test]
+    fn desktop_entry_declares_scheme_handler_and_forwards_url() {
+        let entry = desktop_entry_contents("\"/home/u/breeze.AppImage\"");
+        assert!(entry.starts_with("[Desktop Entry]\n"), "{entry}");
+        assert!(
+            entry.contains("Exec=\"/home/u/breeze.AppImage\" %u\n"),
+            "{entry}"
+        );
+        assert!(
+            entry.contains("MimeType=x-scheme-handler/breeze;\n"),
+            "{entry}"
+        );
+        assert!(entry.contains("Type=Application\n"), "{entry}");
+        assert!(entry.ends_with('\n'), "{entry}");
+    }
 
     #[test]
     fn download_percent_cases() {

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { Monitor } from 'lucide-react';
+import { Monitor, AlertTriangle } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import DesktopViewer from './components/DesktopViewer';
@@ -14,6 +14,8 @@ export default function App() {
   const [windowLabel, setWindowLabel] = useState<string>('main');
   const [params, setParams] = useState<ConnectionParams | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Why URL-scheme registration failed, if it did — surfaced on the idle card.
+  const [schemeError, setSchemeError] = useState<string | null>(null);
   const lastDeepLinkRef = useRef<{ key: string; at: number } | null>(null);
 
   // Detect window role on mount
@@ -25,6 +27,17 @@ export default function App() {
       // fallback: main
     }
   }, []);
+
+  // Only the anchor window reports registration; session windows never show it.
+  useEffect(() => {
+    if (windowLabel !== 'main') return;
+    invoke<string | null>('get_scheme_registration_error')
+      .then((err) => setSchemeError(err ?? null))
+      .catch(() => {
+        // Command unavailable (older shell) — say nothing rather than invent a
+        // failure. Registration may well have succeeded.
+      });
+  }, [windowLabel]);
 
   // ── Session window: deep link polling + events ─────────────────────
   const applyDeepLink = useCallback((url: string) => {
@@ -95,8 +108,24 @@ export default function App() {
   // viewer is launched by hand with no deep link. On Linux that is the required
   // first run — the AppImage has to be executed once to register itself as the
   // `breeze://` handler — so this window is the only confirmation the user gets
-  // that the install worked (#2614).
+  // that the viewer launched at all.
+  //
+  // It reports what registration actually did rather than assuming success: a
+  // card claiming "ready" while `breeze://` stays unclaimed would send the user
+  // straight back into the download loop, now with the UI vouching for it.
   if (windowLabel === 'main') {
+    if (schemeError) {
+      return (
+        <div className="flex h-screen flex-col items-center justify-center gap-3 bg-gray-900 px-8 text-center">
+          <AlertTriangle className="h-8 w-8 text-amber-400" />
+          <h1 className="text-base font-semibold text-white">Breeze links aren't registered</h1>
+          <p className="text-sm leading-relaxed text-gray-400">
+            Remote sessions won't open automatically on this machine.
+          </p>
+          <p className="max-w-full break-words text-xs text-gray-500">{schemeError}</p>
+        </div>
+      );
+    }
     return (
       <div className="flex h-screen flex-col items-center justify-center gap-3 bg-gray-900 px-8 text-center">
         <Monitor className="h-8 w-8 text-accent-soft" />

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
+import { Monitor } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import DesktopViewer from './components/DesktopViewer';
@@ -89,9 +90,26 @@ export default function App() {
     setError(msg);
   }, []);
 
-  // ── Main window: hidden, render nothing ─────────────────────────────
+  // ── Main window: idle card ──────────────────────────────────────────
+  // Normally hidden (it is just the process anchor), but Rust shows it when the
+  // viewer is launched by hand with no deep link. On Linux that is the required
+  // first run — the AppImage has to be executed once to register itself as the
+  // `breeze://` handler — so this window is the only confirmation the user gets
+  // that the install worked (#2614).
   if (windowLabel === 'main') {
-    return null;
+    return (
+      <div className="flex h-screen flex-col items-center justify-center gap-3 bg-gray-900 px-8 text-center">
+        <Monitor className="h-8 w-8 text-accent-soft" />
+        <h1 className="text-base font-semibold text-white">Breeze Viewer is ready</h1>
+        <p className="text-sm leading-relaxed text-gray-400">
+          Remote sessions open automatically when you choose{' '}
+          <span className="font-medium text-gray-200">Connect Desktop</span> in the Breeze console.
+        </p>
+        <p className="text-xs text-gray-500">
+          You can close this window — Breeze reopens the viewer when a session starts.
+        </p>
+      </div>
+    );
   }
 
   // ── Session window: viewer ─────────────────────────────────────────

--- a/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
@@ -306,7 +306,7 @@ describe('ConnectDesktopButton — viewer-not-installed fallback card', () => {
   it('renders the restored fallback copy, not the humanized key placeholders', async () => {
     // Regression guard for the i18n extraction that replaced real English with
     // machine-humanized key names ("Title" / "Viewer Description"), which is
-    // what the #2614 reporter actually saw on screen.
+    // what the reporter actually saw on screen.
     downloadMock.mockReturnValue({
       os: 'linux',
       label: 'Linux',

--- a/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
@@ -1,12 +1,20 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ConnectDesktopButton from './ConnectDesktopButton';
 import { fetchWithAuth } from '../../stores/auth';
 import { showToast, _resetToastQueueForTests } from '../shared/Toast';
+import { getViewerDownloadInfo } from '@/lib/viewerDownload';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+}));
+
+// Platform detection reads navigator, which jsdom fixes to the host machine —
+// stub it so the per-OS download card is exercised deterministically.
+vi.mock('@/lib/viewerDownload', () => ({
+  getViewerDownloadInfo: vi.fn(),
+  getAllViewerDownloads: vi.fn(() => []),
 }));
 
 vi.mock('../shared/Toast', async () => {
@@ -215,5 +223,101 @@ describe('ConnectDesktopButton — disabled prop gating (issue #2013)', () => {
     expect(btn).toBeDisabled();
     expect(btn).toHaveAttribute('title', 'Device is offline');
     expect(screen.queryByText(/connection failed/i)).toBeNull();
+  });
+});
+
+describe('ConnectDesktopButton — viewer-not-installed fallback card', () => {
+  const downloadMock = vi.mocked(getViewerDownloadInfo);
+
+  /** Drive the button all the way to the "viewer didn't open" fallback card. */
+  async function reachFallbackCard() {
+    // Device lookup → no partner launcher, so the built-in WebRTC path runs.
+    fetchMock.mockImplementation((path: string) => {
+      if (path.startsWith('/devices/')) {
+        return Promise.resolve(jsonRes({ desktopAccess: null, hasRemoteAccessLauncher: false }));
+      }
+      if (path.includes('/desktop-connect-code')) {
+        return Promise.resolve(jsonRes({ code: 'code-1' }));
+      }
+      if (path === '/remote/sessions') {
+        return Promise.resolve(jsonRes({ id: 'sess-1' }));
+      }
+      // The session poll: never leaves 'pending', which is exactly what happens
+      // when the OS has no breeze:// handler registered and the deep link is a
+      // silent no-op — the #2614 symptom.
+      return Promise.resolve(jsonRes({ status: 'pending' }));
+    });
+
+    render(<ConnectDesktopButton deviceId="dev-1" />);
+    fireEvent.click(screen.getByRole('button', { name: /connect desktop/i }));
+
+    // 5 polls × 1.5s before the card appears. Driven by explicit timer advance
+    // rather than findByText: the queries poll on real timers, which never tick
+    // while fake timers are installed.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(9000);
+    });
+    expect(screen.getByText(/viewer didn't open/i)).toBeInTheDocument();
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _resetToastQueueForTests();
+    fetchMock.mockReset();
+    toastMock.mockReset();
+    downloadMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('tells Linux users to chmod +x and run the AppImage once', async () => {
+    downloadMock.mockReturnValue({
+      os: 'linux',
+      label: 'Linux',
+      url: 'https://example.test/breeze-viewer-linux.AppImage',
+      filename: 'breeze-viewer-linux.AppImage',
+    });
+
+    await reachFallbackCard();
+
+    // Without this hint the download looks like it did nothing: the browser
+    // strips the executable bit, and the AppImage has to be run once before it
+    // registers breeze:// — until then this same card returns every attempt.
+    expect(screen.getByText(/chmod \+x/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /download for linux/i })).toBeInTheDocument();
+  });
+
+  it('omits the Linux first-run hint on other platforms', async () => {
+    downloadMock.mockReturnValue({
+      os: 'macos',
+      label: 'macOS',
+      url: 'https://example.test/breeze-viewer-macos.dmg',
+      filename: 'breeze-viewer-macos.dmg',
+    });
+
+    await reachFallbackCard();
+
+    expect(screen.getByRole('link', { name: /download for macos/i })).toBeInTheDocument();
+    expect(screen.queryByText(/chmod \+x/i)).toBeNull();
+  });
+
+  it('renders the restored fallback copy, not the humanized key placeholders', async () => {
+    // Regression guard for the i18n extraction that replaced real English with
+    // machine-humanized key names ("Title" / "Viewer Description"), which is
+    // what the #2614 reporter actually saw on screen.
+    downloadMock.mockReturnValue({
+      os: 'linux',
+      label: 'Linux',
+      url: 'https://example.test/breeze-viewer-linux.AppImage',
+      filename: 'breeze-viewer-linux.AppImage',
+    });
+
+    await reachFallbackCard();
+
+    expect(screen.getByText(/if the viewer opened, you can dismiss this/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Viewer Description$/)).toBeNull();
+    expect(screen.queryByText(/^Title$/)).toBeNull();
   });
 });

--- a/apps/web/src/components/remote/ConnectDesktopButton.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.tsx
@@ -580,25 +580,37 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
               const downloadInfo = getViewerDownloadInfo();
               if (downloadInfo) {
                 return (
-                  <div className="mt-2.5 flex items-center gap-3">
-                    <a
-                      href={downloadInfo.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={() => handleDismissAndCleanup()}
-                      className="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-blue-700"
-                    >
-                      <Download className="h-3.5 w-3.5" />
-                      {t('connectDesktopButton.downloadFor', { platform: downloadInfo.label })}
-                    </a>
-                    <button
-                      type="button"
-                      onClick={handleDismiss}
-                      className="text-xs text-muted-foreground transition hover:text-foreground"
-                    >
-                      {t('connectDesktopButton.dismiss')}
-                    </button>
-                  </div>
+                  <>
+                    {/* The Linux build ships as an AppImage, which the browser
+                        saves without the executable bit and which registers the
+                        breeze:// handler only once it has been run. Without
+                        saying so, downloading looks like it did nothing and this
+                        same card reappears on every attempt (issue #2614). */}
+                    {downloadInfo.os === 'linux' && (
+                      <p className="mt-2 text-xs text-amber-700 dark:text-amber-400">
+                        {t('connectDesktopButton.fallback.linuxFirstRun')}
+                      </p>
+                    )}
+                    <div className="mt-2.5 flex items-center gap-3">
+                      <a
+                        href={downloadInfo.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() => handleDismissAndCleanup()}
+                        className="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-blue-700"
+                      >
+                        <Download className="h-3.5 w-3.5" />
+                        {t('connectDesktopButton.downloadFor', { platform: downloadInfo.label })}
+                      </a>
+                      <button
+                        type="button"
+                        onClick={handleDismiss}
+                        className="text-xs text-muted-foreground transition hover:text-foreground"
+                      >
+                        {t('connectDesktopButton.dismiss')}
+                      </button>
+                    </div>
+                  </>
                 );
               }
               return (

--- a/apps/web/src/locales/de-DE/remote.json
+++ b/apps/web/src/locales/de-DE/remote.json
@@ -28,33 +28,34 @@
     "downloadFor": "Für {{platform}} herunterladen",
     "errors": {
       "connectionFailed": "Verbindung fehlgeschlagen",
-      "createDesktopCode": "Fehler beim Erstellen des Desktop-Codes",
+      "createDesktopCode": "Desktop-Verbindungscode konnte nicht erstellt werden",
       "createDesktopSession": "Die Desktop-Sitzung konnte nicht erstellt werden",
       "createVncTunnel": "VNC-Tunnel konnte nicht erstellt werden",
-      "deviceChanged": "Gerät konnte nicht geändert werden",
+      "deviceChanged": "Remote-Start fehlgeschlagen: Gerätedatensatz hat sich geändert. Bitte aktualisieren und erneut versuchen.",
       "http": "Fernstart fehlgeschlagen (HTTP {{status}})",
-      "invalidDesktopCode": "Fehler beim ungültigen Desktop-Code",
-      "issueVncCode": "VNC-Code konnte nicht ausgegeben werden",
-      "securityCheckToast": "Sicherheitsüberprüfung des Toasts fehlgeschlagen",
-      "securityPolicy": "Sicherheitsrichtlinie fehlgeschlagen",
-      "server": "Fehler beim Server",
-      "vncTunnelFailed": "Fehler beim VNC-Tunnel"
+      "invalidDesktopCode": "Ungültige Antwort für den Desktop-Verbindungscode",
+      "issueVncCode": "VNC-Verbindungscode konnte nicht ausgestellt werden",
+      "securityCheckToast": "Remote-Start nicht verfügbar: Sicherheitsprüfung fehlgeschlagen. Bitte wenden Sie sich an Ihren Administrator.",
+      "securityPolicy": "Remote-Start durch Sicherheitsrichtlinie blockiert",
+      "server": "Remote-Start fehlgeschlagen: Serverfehler. Bitte wenden Sie sich an Ihren Administrator.",
+      "vncTunnelFailed": "VNC-Tunnel konnte nicht geöffnet werden"
     },
     "fallback": {
-      "title": "Titel",
-      "viewerDescription": "Beschreibung des Betrachters",
-      "vncDescription": "Vnc-Beschreibung"
+      "linuxFirstRun": "Machen Sie die heruntergeladene Datei unter Linux ausführbar (chmod +x) und starten Sie sie einmal. Damit wird der Viewer registriert und Sitzungen öffnen sich danach automatisch.",
+      "title": "Viewer nicht geöffnet?",
+      "viewerDescription": "Wenn sich der Viewer geöffnet hat, können Sie dies schließen. Andernfalls laden Sie ihn unten herunter.",
+      "vncDescription": "Öffnen Sie die VNC-Sitzung stattdessen im Browser."
     },
     "launcherSkip": {
-      "configError": "Konfigurationsfehler",
-      "emptyUrlTemplate": "Leere URL-Vorlage",
+      "configError": "Das vom Partner konfigurierte Remote-Tool konnte nicht aufgelöst werden (Konfigurationsfehler). Es wird auf den integrierten Remote-Desktop zurückgegriffen.",
+      "emptyUrlTemplate": "Für das vom Partner konfigurierte Remote-Tool ist keine URL-Vorlage festgelegt. Es wird auf den integrierten Remote-Desktop zurückgegriffen.",
       "missingIdentifier": "Diesem Gerät fehlt die gerätespezifische Kennung, die das vom Partner konfigurierte Remote-Tool benötigt (z. B. die RustDesk-Peer-ID). Zurückgreifen auf den integrierten Remote-Desktop. Legen Sie die Kennung unter Geräteeinstellungen → Benutzerdefinierte Felder fest.",
       "providerDisabled": "Das vom Partner konfigurierte Remote-Tool für dieses Gerät ist derzeit deaktiviert. Zurückgreifen auf den integrierten Remote-Desktop."
     },
     "launching": "Start...",
     "launchingViewer": "Viewer wird gestartet...",
     "openInBrowser": "Im Browser öffnen",
-    "policyDisabled": "Richtlinie deaktiviert",
+    "policyDisabled": "Remote-Desktop ist durch Richtlinie deaktiviert",
     "policyDisabledNamed": "Der Remotedesktop ist durch die Richtlinie „{{name}}“ deaktiviert.",
     "unavailable": {
       "default": "Desktop ist auf diesem Gerät nicht verfügbar",
@@ -77,20 +78,20 @@
       "connectionFailed": "Verbindung fehlgeschlagen",
       "createTunnel": "Tunnel konnte nicht erstellt werden",
       "createVncTunnel": "VNC-Tunnel konnte nicht erstellt werden",
-      "issueConnectCode": "Verbindungscode konnte nicht ausgegeben werden",
-      "tunnelFailed": "Fehler beim Tunneln"
+      "issueConnectCode": "VNC-Verbindungscode konnte nicht ausgestellt werden",
+      "tunnelFailed": "Tunnel konnte nicht geöffnet werden"
     },
     "fallback": {
-      "description": "Beschreibung",
-      "title": "Titel"
+      "description": "Öffnen Sie die VNC-Sitzung stattdessen im Browser.",
+      "title": "Viewer nicht geöffnet?"
     },
     "launching": "Start...",
     "openInBrowser": "Im Browser öffnen",
-    "policyDisabled": "Richtlinie deaktiviert",
-    "policyDisabledNamed": "Richtlinie deaktiviert benannt",
-    "unavailable": "Nicht verfügbar",
+    "policyDisabled": "VNC-Relay ist durch Richtlinie deaktiviert",
+    "policyDisabledNamed": "VNC-Relay ist durch Richtlinie „{{name}}“ deaktiviert",
+    "unavailable": "VNC nicht verfügbar",
     "vncDesktop": "VNC-Desktop",
-    "vncRemote": "VNC-Remotezugriff"
+    "vncRemote": "VNC-Remote"
   },
   "deleteConfirmDialog": {
     "deletePermanently": "Dauerhaft löschen",

--- a/apps/web/src/locales/en/remote.json
+++ b/apps/web/src/locales/en/remote.json
@@ -28,33 +28,34 @@
     "downloadFor": "Download for {{platform}}",
     "errors": {
       "connectionFailed": "Connection failed",
-      "createDesktopCode": "Failed to create desktop code",
+      "createDesktopCode": "Failed to create desktop connect code",
       "createDesktopSession": "Failed to create desktop session",
-      "createVncTunnel": "Failed to create vnc tunnel",
-      "deviceChanged": "Failed to device changed",
+      "createVncTunnel": "Failed to create VNC tunnel",
+      "deviceChanged": "Remote launch failed: device record changed. Please refresh and try again.",
       "http": "Remote launch failed (HTTP {{status}})",
-      "invalidDesktopCode": "Failed to invalid desktop code",
-      "issueVncCode": "Failed to issue vnc code",
-      "securityCheckToast": "Failed to security check toast",
-      "securityPolicy": "Failed to security policy",
-      "server": "Failed to server",
-      "vncTunnelFailed": "Failed to vnc tunnel failed"
+      "invalidDesktopCode": "Invalid desktop connect code response",
+      "issueVncCode": "Failed to issue VNC connect code",
+      "securityCheckToast": "Remote launch unavailable: security check failed. Please contact your administrator.",
+      "securityPolicy": "Remote launch blocked by security policy",
+      "server": "Remote launch failed: server error. Please contact your administrator.",
+      "vncTunnelFailed": "VNC tunnel failed to open"
     },
     "fallback": {
-      "title": "Title",
-      "viewerDescription": "Viewer Description",
-      "vncDescription": "Vnc Description"
+      "linuxFirstRun": "On Linux, make the download executable (chmod +x) and run it once. That registers the viewer, so sessions open automatically from then on.",
+      "title": "Viewer didn't open?",
+      "viewerDescription": "If the viewer opened, you can dismiss this. Otherwise, download it below.",
+      "vncDescription": "Open the VNC session in your browser instead."
     },
     "launcherSkip": {
-      "configError": "Config Error",
-      "emptyUrlTemplate": "Empty Url Template",
+      "configError": "Could not resolve the partner-configured remote tool (config error). Falling back to built-in remote desktop.",
+      "emptyUrlTemplate": "The partner-configured remote tool has no URL template set. Falling back to built-in remote desktop.",
       "missingIdentifier": "This device is missing the per-device identifier the partner-configured remote tool needs (e.g. the RustDesk peer ID). Falling back to built-in remote desktop. Set the identifier in Device Settings → Custom Fields.",
       "providerDisabled": "The partner-configured remote tool for this device is currently disabled. Falling back to built-in remote desktop."
     },
     "launching": "Launching...",
     "launchingViewer": "Launching viewer...",
-    "openInBrowser": "Open In Browser",
-    "policyDisabled": "Policy Disabled",
+    "openInBrowser": "Open in Browser",
+    "policyDisabled": "Remote desktop is disabled by policy",
     "policyDisabledNamed": "Remote desktop is disabled by policy \"{{name}}\"",
     "unavailable": {
       "default": "Desktop is unavailable on this device",
@@ -76,21 +77,21 @@
     "errors": {
       "connectionFailed": "Connection failed",
       "createTunnel": "Failed to create tunnel",
-      "createVncTunnel": "Failed to create vnc tunnel",
-      "issueConnectCode": "Failed to issue connect code",
-      "tunnelFailed": "Failed to tunnel failed"
+      "createVncTunnel": "Failed to create VNC tunnel",
+      "issueConnectCode": "Failed to issue VNC connect code",
+      "tunnelFailed": "Tunnel failed to open"
     },
     "fallback": {
-      "description": "Description",
-      "title": "Title"
+      "description": "Open the VNC session in your browser instead.",
+      "title": "Viewer didn't open?"
     },
     "launching": "Launching...",
-    "openInBrowser": "Open In Browser",
-    "policyDisabled": "Policy Disabled",
-    "policyDisabledNamed": "Policy Disabled Named",
-    "unavailable": "Unavailable",
-    "vncDesktop": "Vnc Desktop",
-    "vncRemote": "Vnc Remote"
+    "openInBrowser": "Open in Browser",
+    "policyDisabled": "VNC relay is disabled by policy",
+    "policyDisabledNamed": "VNC relay is disabled by policy \"{{name}}\"",
+    "unavailable": "VNC Unavailable",
+    "vncDesktop": "VNC Desktop",
+    "vncRemote": "VNC Remote"
   },
   "deleteConfirmDialog": {
     "deletePermanently": "Delete Permanently",

--- a/apps/web/src/locales/es-419/remote.json
+++ b/apps/web/src/locales/es-419/remote.json
@@ -28,33 +28,34 @@
     "downloadFor": "Descargar para {{platform}}",
     "errors": {
       "connectionFailed": "La conexión falló",
-      "createDesktopCode": "No se pudo crear el código de escritorio",
+      "createDesktopCode": "No se pudo crear el código de conexión al escritorio",
       "createDesktopSession": "No se pudo crear la sesión de escritorio",
-      "createVncTunnel": "No se pudo crear el túnel vnc",
-      "deviceChanged": "No se pudo cambiar el dispositivo",
+      "createVncTunnel": "No se pudo crear el túnel VNC",
+      "deviceChanged": "Falló el inicio remoto: el registro del dispositivo cambió. Actualiza e inténtalo de nuevo.",
       "http": "Error en el inicio remoto (HTTP {{status}})",
-      "invalidDesktopCode": "El código de escritorio no es válido",
-      "issueVncCode": "No se pudo emitir el código vnc",
-      "securityCheckToast": "No se pudo realizar el control de seguridad",
-      "securityPolicy": "No se pudo cumplir con la política de seguridad",
-      "server": "Error al servidor",
-      "vncTunnelFailed": "No se pudo realizar el túnel vnc"
+      "invalidDesktopCode": "Respuesta inválida del código de conexión al escritorio",
+      "issueVncCode": "No se pudo emitir el código de conexión VNC",
+      "securityCheckToast": "Inicio remoto no disponible: falló la verificación de seguridad. Comunícate con tu administrador.",
+      "securityPolicy": "Inicio remoto bloqueado por la política de seguridad",
+      "server": "Falló el inicio remoto: error del servidor. Comunícate con tu administrador.",
+      "vncTunnelFailed": "El túnel VNC no se pudo abrir"
     },
     "fallback": {
-      "title": "Título",
-      "viewerDescription": "Descripción del visor",
-      "vncDescription": "Descripción de VNC"
+      "linuxFirstRun": "En Linux, haz que el archivo descargado sea ejecutable (chmod +x) y ábrelo una vez. Eso registra el visor y, a partir de entonces, las sesiones se abren automáticamente.",
+      "title": "¿No se abrió el visor?",
+      "viewerDescription": "Si el visor se abrió, puedes descartar esto. Si no, descárgalo abajo.",
+      "vncDescription": "Abre la sesión VNC en tu navegador."
     },
     "launcherSkip": {
-      "configError": "Error de configuración",
-      "emptyUrlTemplate": "Plantilla de URL vacía",
+      "configError": "No se pudo resolver la herramienta remota configurada por el partner (error de configuración). Se usará el escritorio remoto integrado.",
+      "emptyUrlTemplate": "La herramienta remota configurada por el partner no tiene una plantilla de URL definida. Se usará el escritorio remoto integrado.",
       "missingIdentifier": "A este dispositivo le falta el identificador por dispositivo que necesita la herramienta remota configurada por el socio (por ejemplo, el par RustDesk ID). Recurrir al escritorio remoto integrado. Configure el identificador en Configuración del dispositivo → Campos personalizados.",
       "providerDisabled": "La herramienta remota configurada por el socio para este dispositivo está actualmente deshabilitada. Recurrir al escritorio remoto integrado."
     },
     "launching": "Iniciando...",
     "launchingViewer": "Lanzando visor...",
     "openInBrowser": "Abrir en el navegador",
-    "policyDisabled": "Política deshabilitada",
+    "policyDisabled": "El escritorio remoto está deshabilitado por la política",
     "policyDisabledNamed": "El escritorio remoto está deshabilitado por la política \"{{name}}\"",
     "unavailable": {
       "default": "El escritorio no está disponible en este dispositivo",
@@ -76,21 +77,21 @@
     "errors": {
       "connectionFailed": "La conexión falló",
       "createTunnel": "No se pudo crear el túnel",
-      "createVncTunnel": "No se pudo crear el túnel vnc",
-      "issueConnectCode": "No se pudo emitir el código de conexión",
-      "tunnelFailed": "No se pudo realizar el túnel"
+      "createVncTunnel": "No se pudo crear el túnel VNC",
+      "issueConnectCode": "No se pudo emitir el código de conexión VNC",
+      "tunnelFailed": "El túnel no se pudo abrir"
     },
     "fallback": {
-      "description": "Descripción",
-      "title": "Título"
+      "description": "Abre la sesión VNC en tu navegador.",
+      "title": "¿No se abrió el visor?"
     },
     "launching": "Iniciando...",
     "openInBrowser": "Abrir en el navegador",
-    "policyDisabled": "Política deshabilitada",
-    "policyDisabledNamed": "Política deshabilitada Nombrada",
-    "unavailable": "Indisponible",
-    "vncDesktop": "Escritorio Vnc",
-    "vncRemote": "control remoto vnc"
+    "policyDisabled": "El relay VNC está deshabilitado por la política",
+    "policyDisabledNamed": "El relay VNC está deshabilitado por la política «{{name}}»",
+    "unavailable": "VNC no disponible",
+    "vncDesktop": "Escritorio VNC",
+    "vncRemote": "VNC remoto"
   },
   "deleteConfirmDialog": {
     "deletePermanently": "Eliminar permanentemente",

--- a/apps/web/src/locales/fr-FR/remote.json
+++ b/apps/web/src/locales/fr-FR/remote.json
@@ -28,33 +28,34 @@
     "downloadFor": "Télécharger pour {{platform}}",
     "errors": {
       "connectionFailed": "Connexion défaillante",
-      "createDesktopCode": "Impossible de créer du code de bureau",
+      "createDesktopCode": "Échec de la création du code de connexion au bureau",
       "createDesktopSession": "Impossible de créer une session de bureau",
-      "createVncTunnel": "Impossible de créer un tunnel vnc",
-      "deviceChanged": "Impossible de changer l’appareil",
+      "createVncTunnel": "Échec de la création du tunnel VNC",
+      "deviceChanged": "Échec du lancement à distance : la fiche de l'appareil a changé. Actualisez et réessayez.",
       "http": "Échec du lancement à distance (HTTP {{status}})",
-      "invalidDesktopCode": "Impossible de valider le code de bureau",
-      "issueVncCode": "Impossible d’émettre un code vnc",
-      "securityCheckToast": "Impossible de vérifier la sécurité grillée",
-      "securityPolicy": "Échec lié à la stratégie de sécurité",
-      "server": "Impossible de servir",
-      "vncTunnelFailed": "Impossible de faire échouer le tunnel VNC"
+      "invalidDesktopCode": "Réponse de code de connexion au bureau invalide",
+      "issueVncCode": "Échec de l'émission du code de connexion VNC",
+      "securityCheckToast": "Lancement à distance indisponible : le contrôle de sécurité a échoué. Contactez votre administrateur.",
+      "securityPolicy": "Lancement à distance bloqué par la politique de sécurité",
+      "server": "Échec du lancement à distance : erreur serveur. Contactez votre administrateur.",
+      "vncTunnelFailed": "Le tunnel VNC n'a pas pu s'ouvrir"
     },
     "fallback": {
-      "title": "Titre",
-      "viewerDescription": "Description du spectateur",
-      "vncDescription": "Description VNC"
+      "linuxFirstRun": "Sous Linux, rendez le fichier téléchargé exécutable (chmod +x) et lancez-le une fois. Cela enregistre la visionneuse ; les sessions s'ouvriront ensuite automatiquement.",
+      "title": "La visionneuse ne s'est pas ouverte ?",
+      "viewerDescription": "Si la visionneuse s'est ouverte, vous pouvez ignorer ce message. Sinon, téléchargez-la ci-dessous.",
+      "vncDescription": "Ouvrez plutôt la session VNC dans votre navigateur."
     },
     "launcherSkip": {
-      "configError": "Erreur de configuration",
-      "emptyUrlTemplate": "Modèle d’URL vide",
+      "configError": "Impossible de résoudre l'outil distant configuré par le partenaire (erreur de configuration). Retour au bureau à distance intégré.",
+      "emptyUrlTemplate": "L'outil distant configuré par le partenaire n'a aucun modèle d'URL défini. Retour au bureau à distance intégré.",
       "missingIdentifier": "Cet appareil manque l’identifiant par appareil dont l’outil distant configuré par partenaire a besoin (par exemple le pair RustDesk ID). Je revenais au bureau à distance intégré. Définissez l’identifiant dans les paramètres de l’appareil → dans les champs personnalisés.",
       "providerDisabled": "L’outil distant configuré par le partenaire pour cet appareil est actuellement désactivé. Je revenais au bureau à distance intégré."
     },
     "launching": "Lancement...",
     "launchingViewer": "Lancement du visionnement...",
-    "openInBrowser": "Ouvrir le navigateur",
-    "policyDisabled": "Stratégie désactivée",
+    "openInBrowser": "Ouvrir dans le navigateur",
+    "policyDisabled": "Le bureau à distance est désactivé par la politique",
     "policyDisabledNamed": "Le bureau à distance est désactivé par la politique « {{name}} »",
     "unavailable": {
       "default": "Le mode de bureau n’est pas disponible sur cet appareil",
@@ -76,21 +77,21 @@
     "errors": {
       "connectionFailed": "Connexion défaillante",
       "createTunnel": "Impossible de créer un tunnel",
-      "createVncTunnel": "Impossible de créer un tunnel vnc",
-      "issueConnectCode": "Impossible d’émettre un code de connexion",
-      "tunnelFailed": "Impossible de creuser un tunnel échoué"
+      "createVncTunnel": "Échec de la création du tunnel VNC",
+      "issueConnectCode": "Échec de l'émission du code de connexion VNC",
+      "tunnelFailed": "Le tunnel n'a pas pu s'ouvrir"
     },
     "fallback": {
-      "description": "Description",
-      "title": "Titre"
+      "description": "Ouvrez plutôt la session VNC dans votre navigateur.",
+      "title": "La visionneuse ne s'est pas ouverte ?"
     },
     "launching": "Lancement...",
-    "openInBrowser": "Ouvrir le navigateur",
-    "policyDisabled": "Stratégie désactivée",
-    "policyDisabledNamed": "Stratégie désactivée :",
-    "unavailable": "Indisponible",
+    "openInBrowser": "Ouvrir dans le navigateur",
+    "policyDisabled": "Le relais VNC est désactivé par la politique",
+    "policyDisabledNamed": "Le relais VNC est désactivé par la politique « {{name}} »",
+    "unavailable": "VNC indisponible",
     "vncDesktop": "Bureau VNC",
-    "vncRemote": "Télécommande VNC"
+    "vncRemote": "VNC à distance"
   },
   "deleteConfirmDialog": {
     "deletePermanently": "Supprimer définitivement",

--- a/apps/web/src/locales/pt-BR/remote.json
+++ b/apps/web/src/locales/pt-BR/remote.json
@@ -28,33 +28,34 @@
     "downloadFor": "Baixar para {{platform}}",
     "errors": {
       "connectionFailed": "Falha na conexão",
-      "createDesktopCode": "Falha ao criar o código da área de trabalho",
+      "createDesktopCode": "Não foi possível criar o código de conexão da área de trabalho",
       "createDesktopSession": "Falha ao criar a sessão da área de trabalho",
-      "createVncTunnel": "Falha ao criar o túnel VNC",
-      "deviceChanged": "O dispositivo foi alterado durante a conexão",
+      "createVncTunnel": "Não foi possível criar o túnel VNC",
+      "deviceChanged": "Falha no início remoto: o registro do dispositivo mudou. Atualize e tente novamente.",
       "http": "Falha ao iniciar o acesso remoto (HTTP {{status}})",
-      "invalidDesktopCode": "Código da área de trabalho inválido",
-      "issueVncCode": "Falha ao emitir o código VNC",
-      "securityCheckToast": "Falha na verificação de segurança",
-      "securityPolicy": "A política de segurança bloqueou a conexão",
-      "server": "Erro no servidor remoto",
-      "vncTunnelFailed": "Falha no túnel VNC"
+      "invalidDesktopCode": "Resposta inválida do código de conexão da área de trabalho",
+      "issueVncCode": "Não foi possível emitir o código de conexão VNC",
+      "securityCheckToast": "Início remoto indisponível: a verificação de segurança falhou. Fale com seu administrador.",
+      "securityPolicy": "Início remoto bloqueado pela política de segurança",
+      "server": "Falha no início remoto: erro do servidor. Fale com seu administrador.",
+      "vncTunnelFailed": "O túnel VNC não pôde ser aberto"
     },
     "fallback": {
-      "title": "Título",
-      "viewerDescription": "Descrição do visualizador",
-      "vncDescription": "Descrição do VNC"
+      "linuxFirstRun": "No Linux, torne o arquivo baixado executável (chmod +x) e execute-o uma vez. Isso registra o visualizador, e as sessões passam a abrir automaticamente.",
+      "title": "O visualizador não abriu?",
+      "viewerDescription": "Se o visualizador abriu, você pode dispensar este aviso. Caso contrário, baixe-o abaixo.",
+      "vncDescription": "Abra a sessão VNC no seu navegador."
     },
     "launcherSkip": {
-      "configError": "Erro de configuração",
-      "emptyUrlTemplate": "O modelo de URL está vazio",
+      "configError": "Não foi possível resolver a ferramenta remota configurada pelo parceiro (erro de configuração). Voltando para a área de trabalho remota integrada.",
+      "emptyUrlTemplate": "A ferramenta remota configurada pelo parceiro não tem um modelo de URL definido. Voltando para a área de trabalho remota integrada.",
       "missingIdentifier": "Este dispositivo não possui o identificador individual exigido pela ferramenta remota configurada pelo parceiro (por exemplo, o ID do RustDesk). Usando a área de trabalho remota integrada. Defina o identificador em Configurações do Dispositivo → Campos Personalizados.",
       "providerDisabled": "A ferramenta remota configurada pelo parceiro está desativada para este dispositivo. Usando a área de trabalho remota integrada."
     },
     "launching": "Iniciando...",
     "launchingViewer": "Abrindo visualizador...",
     "openInBrowser": "Abrir no navegador",
-    "policyDisabled": "Desativado pela política",
+    "policyDisabled": "A área de trabalho remota está desativada pela política",
     "policyDisabledNamed": "A área de trabalho remota foi desativada pela política \"{{name}}\"",
     "unavailable": {
       "default": "A área de trabalho não está disponível neste dispositivo",
@@ -76,21 +77,21 @@
     "errors": {
       "connectionFailed": "Falha na conexão",
       "createTunnel": "Falha ao criar o túnel",
-      "createVncTunnel": "Falha ao criar o túnel VNC",
-      "issueConnectCode": "Falha ao emitir o código de conexão",
-      "tunnelFailed": "Falha no túnel"
+      "createVncTunnel": "Não foi possível criar o túnel VNC",
+      "issueConnectCode": "Não foi possível emitir o código de conexão VNC",
+      "tunnelFailed": "O túnel não pôde ser aberto"
     },
     "fallback": {
-      "description": "Descrição",
-      "title": "Título"
+      "description": "Abra a sessão VNC no seu navegador.",
+      "title": "O visualizador não abriu?"
     },
     "launching": "Iniciando...",
     "openInBrowser": "Abrir no navegador",
-    "policyDisabled": "Desativado pela política",
-    "policyDisabledNamed": "Desativado por uma política específica",
-    "unavailable": "Indisponível",
+    "policyDisabled": "O relay VNC está desativado pela política",
+    "policyDisabledNamed": "O relay VNC está desativado pela política \"{{name}}\"",
+    "unavailable": "VNC indisponível",
     "vncDesktop": "Área de trabalho VNC",
-    "vncRemote": "Acesso remoto VNC"
+    "vncRemote": "VNC remoto"
   },
   "deleteConfirmDialog": {
     "deletePermanently": "Excluir permanentemente",


### PR DESCRIPTION
Closes #2614.

## The bug

The Linux viewer could never pick up a deep link. `register_url_scheme()` in `apps/viewer/src-tauri/src/lib.rs` was gated `#[cfg(target_os = "macos")]` with no Linux branch and no stub.

Tauri does declare the scheme in `tauri.conf.json`, which writes `MimeType=x-scheme-handler/breeze` into the `.desktop` file *inside* the AppImage — but an AppImage is a single self-contained file that is never installed into `~/.local/share/applications/`. Nothing ever runs `update-desktop-database`, so xdg never learns the scheme exists. Ubuntu 24.04 ships neither `appimaged` nor AppImageLauncher by default, so nothing integrates it either.

Result: `breeze://` was a silent no-op, the console's session poll timed out after ~7.5s, and the "Download for Linux" card appeared — **every time, forever**, no matter how many times the reporter downloaded and ran the viewer. There is no port probe or handler feature-test anywhere; detection is purely that inferred timeout.

Two further bugs made this present as a crash rather than a missing handler:

1. **Bare launch showed no window.** The only configured window is `visible: false` (it's the process anchor); session windows are built at runtime from a deep link. Running the AppImage produced a live process with no UI, no tray icon, and no output — exactly the `ps aux` output in the issue. Invisible on macOS/Windows because nobody launches it by hand there; on Linux it's the *only* way to launch it.
2. **The card rendered placeholder text.** `en/remote.json` literally read `"viewerDescription": "Viewer Description"`. The i18n extraction in #2340 replaced real English with machine-humanized key names, and the four translations then translated the placeholders — French read "Description du spectateur" (*description of the spectator*).

## The fix

**Linux scheme registration.** Writes `~/.local/share/applications/breeze-viewer.desktop` on launch, then runs `update-desktop-database` and `xdg-mime default`. Path comes from `$APPIMAGE`, **not** `current_exe()` — inside an AppImage the latter is the ephemeral `/tmp/.mount_XXXX` squashfs, so registering it would produce a handler that dies with the process. Rewrites only when content changes, so moving the AppImage re-points the handler while an unchanged launch costs nothing. Both xdg calls are best-effort: minimal desktops ship neither, and a missing cache refresh still leaves a valid entry for next login.

**Idle window on bare launch.** Deferred ~800ms and skipped if a session window appeared — "no deep link at `setup()` time" isn't the same as "no deep link", since a macOS cold start via `breeze://` can deliver the URL after `setup()` returns, and showing immediately would flash the card before the session window replaced it. Closing it now exits rather than leaving a ghost process; that made the exit path re-entrant (teardown destroys `main`, re-firing the handler mid-exit), so `exit(0)` is latched behind an atomic — this file already carries a macOS SIGABRT workaround and re-entering it isn't worth finding out about.

**Copy.** Restores 28 keys across `ConnectDesktopButton` and `ConnectVncButton`, recovered from the pre-i18n components at `944bb8d18^` rather than rewritten, in all five locales. Adds a Linux-only hint to `chmod +x` and run the download once — the browser strips the executable bit, and the AppImage must be run once before it registers anything, so without saying so the download looks like it did nothing.

## Verification

- Full web suite: **469 files, 4164 tests, all pass.** Locale parity passes (enforces identical key sets, interpolation tokens and rich-text tags across all five locales).
- Viewer Rust: **12 tests pass** (4 new — `$APPIMAGE` precedence, relative-path rejection, XDG dir resolution, `Exec=` quoting/escaping, and that the entry declares the scheme and forwards `%u`). `cargo check --locked --all-targets` clean, no new warnings, no new rustfmt drift.
- 3 new tests on the fallback card. The two behavioural ones were mutation-tested by inverting the `os === 'linux'` condition — both failed, then passed again on restore, so they're load-bearing in both directions.
- The Linux-only function isn't compiled on macOS, so it was extracted into a scratch crate and both compiled *and ran* against a fake `$HOME`: writes a well-formed entry, quotes a space-containing path correctly, silent no-op on unchanged rerun, rewrites when the AppImage moves, and degrades gracefully with a logged reason when the xdg tools are absent.

## Not verified

**None of this has run on a real Ubuntu 24.04 box** — that needs a CI AppImage build and a live test against the desktop. Worth doing before closing the issue.

The GTK/gvfs messages in the report (`undefined symbol: g_task_set_static_name`, `Failed to load module "xapp-gtk3-module"`) are unrelated noise from glib version skew between the bundle and system gvfs modules, and are expected to persist harmlessly.

## Out of scope

The i18n placeholder regression is much wider than these two components — a conservative scan suggests it hit thousands of multi-word keys across all 21 `en` namespaces. That number is a heuristic and needs verifying; it should be its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
