### PR TITLE
fix(ai): repair get_cis_compliance query + sanitize tool errors before streaming (#2603)

### DIFF
--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -23,6 +23,7 @@ import {
   resolveDefaultModel
 } from '../services/aiAgent';
 import { runPreFlightChecks, abortActivePlan } from '../services/aiAgentSdk';
+import { sanitizeThrownToolError } from '../services/aiToolErrors';
 import { streamingSessionManager } from '../services/streamingSessionManager';
 import { getUsageSummary, updateBudget, getSessionHistory, recordUsage } from '../services/aiCostTracker';
 import { createTicket, changeTicketStatus, TicketServiceError } from '../services/ticketService';
@@ -585,10 +586,11 @@ aiRoutes.post(
             if (event.type === 'done') break;
           }
         } catch (err) {
-          console.error('[AI/OpenAI] Stream error:', err);
+          // Never stream a raw error to the browser (#2603).
+          const message = sanitizeThrownToolError('ai_stream_openai', err);
           await stream.writeSSE({
             event: 'error',
-            data: JSON.stringify({ type: 'error', message: err instanceof Error ? err.message : 'Stream failed' }),
+            data: JSON.stringify({ type: 'error', message }),
           });
         } finally {
           openaiSession.eventBus.unsubscribe(subscriptionId);
@@ -670,12 +672,13 @@ aiRoutes.post(
           if (event.type === 'done') break;
         }
       } catch (err) {
-        console.error('[AI] Stream error:', err);
+        // Never stream a raw error to the browser (#2603).
+        const message = sanitizeThrownToolError('ai_stream', err);
         await stream.writeSSE({
           event: 'error',
           data: JSON.stringify({
             type: 'error',
-            message: err instanceof Error ? err.message : 'Stream failed',
+            message,
           }),
         });
       } finally {

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -20,7 +20,8 @@ import {
   isIntentBackedExecution,
   searchSessions,
   listM365Connections,
-  resolveDefaultModel
+  resolveDefaultModel,
+  sanitizeErrorForClient,
 } from '../services/aiAgent';
 import { runPreFlightChecks, abortActivePlan } from '../services/aiAgentSdk';
 import { sanitizeThrownToolError } from '../services/aiToolErrors';
@@ -167,7 +168,9 @@ aiRoutes.post(
       if (message === 'Invalid M365 connection') return c.json({ error: message }, 400);
       if (message === 'Invalid device') return c.json({ error: message }, 400);
       if (message === 'Access denied to this organization') return c.json({ error: message }, 403);
-      return c.json({ error: message }, 500);
+      // Anything past the four exact-match branches above is an unexpected fault
+      // whose message may be raw driver text (#2603) — genericize it.
+      return c.json({ error: sanitizeThrownToolError('create_ai_session', err) }, 500);
     }
   }
 );
@@ -586,8 +589,12 @@ aiRoutes.post(
             if (event.type === 'done') break;
           }
         } catch (err) {
-          // Never stream a raw error to the browser (#2603).
-          const message = sanitizeThrownToolError('ai_stream_openai', err);
+          // Never stream a raw error to the browser (#2603). Uses the stream
+          // sanitizer (not the tool one) so user-actionable conditions — rate
+          // limit, budget, approval timeout — survive, while driver text does
+          // not. sanitizeErrorForClient is now detector-gated.
+          console.error('[AI/OpenAI] Stream error:', err);
+          const message = sanitizeErrorForClient(err);
           await stream.writeSSE({
             event: 'error',
             data: JSON.stringify({ type: 'error', message }),
@@ -672,8 +679,10 @@ aiRoutes.post(
           if (event.type === 'done') break;
         }
       } catch (err) {
-        // Never stream a raw error to the browser (#2603).
-        const message = sanitizeThrownToolError('ai_stream', err);
+        // Never stream a raw error to the browser (#2603). See the OpenAI
+        // branch above for why this uses the stream sanitizer.
+        console.error('[AI] Stream error:', err);
+        const message = sanitizeErrorForClient(err);
         await stream.writeSSE({
           event: 'error',
           data: JSON.stringify({

--- a/apps/api/src/routes/mcpServer.test.ts
+++ b/apps/api/src/routes/mcpServer.test.ts
@@ -207,6 +207,7 @@ vi.mock('../modules/mcpInvites', () => ({
 }));
 
 import { __loadMcpBootstrapForTests, mcpServerRoutes } from './mcpServer';
+import { GENERIC_TOOL_ERROR_MESSAGE } from '../services/aiToolErrors';
 
 function setTestApiKey(overrides: Record<string, unknown> = {}) {
   testState.apiKey = {
@@ -778,7 +779,14 @@ describe('MCP transport integration', () => {
     const body = await res.json();
     expect(body.result.isError).toBe(true);
     expect(JSON.stringify(body)).not.toContain('raw-secret');
-    expect(JSON.stringify(body)).toContain('[REDACTED]');
+    // #2603: thrown tool errors are now genericized entirely rather than
+    // secret-redacted in place, so the client sees no fragment of the original
+    // message (strictly stronger than the old [REDACTED] behaviour). The full,
+    // secret-redacted detail is still asserted on the audit event below.
+    expect(body.result.content[0].text).toBe(
+      JSON.stringify({ error: GENERIC_TOOL_ERROR_MESSAGE }),
+    );
+    expect(JSON.stringify(body)).not.toContain('boom with token');
     expect(writeAuditEvent).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -40,6 +40,7 @@ import { resolveSiteAllowedDeviceIds, deviceSiteDenied } from '../services/aiToo
 import { writeAuditEvent } from '../services/auditEvents';
 import { sanitizeAuditPayload, summarizePayload, summarizeToolResult } from '../services/auditPayloadSanitizer';
 import { compactToolResultForChat, redactAiToolOutputText } from '../services/aiToolOutput';
+import { sanitizeThrownToolError } from '../services/aiToolErrors';
 import { MCP_SERVER_INSTRUCTIONS, listMcpPrompts, getMcpPrompt, hasMcpPrompt } from '../services/mcpGuidance';
 import {
   beginMcpToolExecutionLedger,
@@ -818,8 +819,8 @@ async function handleJsonRpc(
         return jsonRpcError(req.id, -32601, `Method not found: ${req.method}`);
     }
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Internal error';
-    console.error('[MCP] JSON-RPC handler error:', err);
+    // Raw driver text must not reach an MCP client (#2603).
+    const message = sanitizeThrownToolError('mcp_jsonrpc', err, { method: req.method });
     return jsonRpcError(req.id, -32000, message);
   }
 }
@@ -1048,7 +1049,7 @@ async function handleToolsCall(
 
       return { status: 'success', ledgerResult: safeResult, response };
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Tool execution failed';
+      const message = sanitizeThrownToolError(toolName, err);
       const safeError = compactToolResultForChat(toolName, JSON.stringify({ error: message }));
       return {
         status: 'failure',
@@ -1429,7 +1430,7 @@ async function dispatchBootstrapAuthTool(
           }),
         };
       }
-      const message = err instanceof Error ? err.message : 'Tool execution failed';
+      const message = sanitizeThrownToolError(tool.definition.name, err);
       return {
         status: 'failure',
         error: err,
@@ -1790,7 +1791,7 @@ async function handleResourcesRead(
 
     return jsonRpcError(id, -32602, `Unknown resource URI: ${uri}`);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to read resource';
+    const message = sanitizeThrownToolError('mcp_resources_read', err, { uri });
     return jsonRpcError(id, -32603, message);
   }
 }

--- a/apps/api/src/services/aiAgent.ts
+++ b/apps/api/src/services/aiAgent.ts
@@ -16,6 +16,7 @@ import { escapeLike } from '../utils/sql';
 import { AI_SYSTEM_PROMPT_BASE } from './aiAgentSystemPrompt';
 import { getActiveDeviceContext } from './brainDeviceContext';
 import { sanitizePageContext } from './aiInputSanitizer';
+import { looksLikeInternalErrorDetail } from './aiToolErrors';
 
 // Current model id so the Claude Agent SDK can price it natively. A stale id makes the
 // SDK report total_cost_usd: 0 → $0.00 cost tracking (issue #1326). Successor to the
@@ -758,8 +759,16 @@ const SAFE_ERROR_PATTERNS = [
 export function sanitizeErrorForClient(err: unknown): string {
   if (err instanceof Error) {
     const msg = err.message;
-    // Only allow messages that match known safe patterns
-    if (SAFE_ERROR_PATTERNS.some(pattern => pattern.test(msg))) {
+    // Only allow messages that match known safe patterns AND do not look like
+    // driver/runtime output (#2603). Without the second check the allowlist is
+    // too loose: `/permission/i` admits `permission denied for table devices`
+    // and `/invalid input/i` admits `invalid input syntax for type uuid: "abc"`,
+    // both of which disclose schema. looksLikeInternalErrorDetail is the single
+    // authority for "is this internal detail".
+    if (
+      !looksLikeInternalErrorDetail(msg) &&
+      SAFE_ERROR_PATTERNS.some(pattern => pattern.test(msg))
+    ) {
       // Double-check: strip any file paths or stack traces that might have slipped in
       const cleaned = msg.replace(/\s+at\s+\S+/g, '').replace(/[A-Za-z]:\\[^\s]+/g, '').replace(/\/[^\s]*\/[^\s]*/g, '').trim();
       return cleaned || 'An internal error occurred. Please try again.';

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -15,6 +15,7 @@ import { eq } from 'drizzle-orm';
 import { executeTool } from './aiTools';
 import type { AiToolTier, ActionPlanStep } from '@breeze/shared/types/ai';
 import { compactToolResultForChat } from './aiToolOutput';
+import { sanitizeThrownToolError } from './aiToolErrors';
 import type { ActiveSession } from './streamingSessionManager';
 import { waitForPlanApproval } from './aiAgent';
 import { aiActionPlans } from '../db/schema';
@@ -320,8 +321,10 @@ function makeHandler(
       try {
         check = await onPreToolUse(toolName, args);
       } catch (err) {
-        const reason = err instanceof Error ? err.message : 'Unknown error';
-        console.error(`[AI-SDK] PreToolUse threw for ${toolName}: ${reason}`);
+        // The guardrail path also touches the DB (approval records, rate limits),
+        // so `reason` can be a raw driver message — sanitize before embedding it
+        // in a string that is streamed to the chat (#2603).
+        const reason = sanitizeThrownToolError(`${toolName}:preToolUse`, err);
         check = { allowed: false, error: `Guardrails check failed: ${reason}` };
       }
       if (!check.allowed) {
@@ -415,9 +418,12 @@ function makeHandler(
       await safePostToolUse(onPostToolUse, toolName, args, compactResult, isToolError, durationMs);
       return { content: [{ type: 'text' as const, text: compactResult }], ...(isToolError ? { isError: true } : {}) };
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Tool execution failed';
       const durationMs = Date.now() - startTime;
-      console.error(`[AI-SDK] Tool ${toolName} failed in ${durationMs}ms: ${message}`);
+      // A thrown error here is an internal fault — its message is very often a
+      // raw Drizzle/postgres.js string carrying the full query and column list.
+      // sanitizeThrownToolError logs it server-side and returns a safe generic
+      // string for the stream (#2603).
+      const message = sanitizeThrownToolError(toolName, err, { durationMs });
       const safeError = compactToolResultForChat(toolName, JSON.stringify({ error: message }));
       await safePostToolUse(onPostToolUse, toolName, args, safeError, true, durationMs);
       return {
@@ -478,8 +484,10 @@ function makeSessionAwareHandler(
       try {
         check = await onPreToolUse(toolName, args);
       } catch (err) {
-        const reason = err instanceof Error ? err.message : 'Unknown error';
-        console.error(`[AI-SDK] PreToolUse threw for ${toolName}: ${reason}`);
+        // The guardrail path also touches the DB (approval records, rate limits),
+        // so `reason` can be a raw driver message — sanitize before embedding it
+        // in a string that is streamed to the chat (#2603).
+        const reason = sanitizeThrownToolError(`${toolName}:preToolUse`, err);
         check = { allowed: false, error: `Guardrails check failed: ${reason}` };
       }
       if (!check.allowed) {
@@ -519,9 +527,12 @@ function makeSessionAwareHandler(
       await safePostToolUse(onPostToolUse, toolName, args, compactResult, isToolError, durationMs);
       return { content: [{ type: 'text' as const, text: compactResult }], ...(isToolError ? { isError: true } : {}) };
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Tool execution failed';
       const durationMs = Date.now() - startTime;
-      console.error(`[AI-SDK] Tool ${toolName} failed in ${durationMs}ms: ${message}`);
+      // A thrown error here is an internal fault — its message is very often a
+      // raw Drizzle/postgres.js string carrying the full query and column list.
+      // sanitizeThrownToolError logs it server-side and returns a safe generic
+      // string for the stream (#2603).
+      const message = sanitizeThrownToolError(toolName, err, { durationMs });
       const safeError = compactToolResultForChat(toolName, JSON.stringify({ error: message }));
       await safePostToolUse(onPostToolUse, toolName, args, safeError, true, durationMs);
       return {

--- a/apps/api/src/services/aiToolErrors.test.ts
+++ b/apps/api/src/services/aiToolErrors.test.ts
@@ -33,7 +33,9 @@ describe('aiToolErrors', () => {
       ['unique violation', 'duplicate key value violates unique constraint "devices_pkey"'],
       ['fk violation', 'insert or update violates foreign key constraint "fk_org"'],
       ['rls violation', 'new row violates row-level security policy for table "devices"'],
-      ['sqlstate', 'error 23503 raised during insert'],
+      ['sqlstate with context', 'SQLSTATE 23503 raised during insert'],
+      ['error code with context', 'pg error code 42703 while planning'],
+      ['alphanumeric sqlstate, no context needed', 'query aborted: 22P02'],
       ['network', 'connect ECONNREFUSED 10.1.2.3:5432'],
       ['dns', 'getaddrinfo ENOTFOUND db.internal.example'],
       ['stack trace', 'Boom\n    at Object.handler (/app/dist/index.js:12:3)'],
@@ -55,6 +57,24 @@ describe('aiToolErrors', () => {
       ]) {
         expect(looksLikeInternalErrorDetail(safe)).toBe(false);
       }
+    });
+
+    /**
+     * False-positive guard. Breeze is an RMM: managed-device filesystem paths and
+     * arbitrary numbers are ORDINARY DOMAIN DATA, not infrastructure leakage.
+     * Genericizing these would silently degrade what the model can reason about.
+     */
+    it.each([
+      ['managed-device path', 'Backup path /var/lib/mysql is not readable on this device'],
+      ['home path', 'Scan skipped /home/user/Downloads (permission set by policy)'],
+      ['opt path', 'Agent installed at /opt/breeze-agent needs an upgrade'],
+      ['5-digit number in the old 42xxx range', 'Upload exceeds the limit of 42000 bytes'],
+      ['5-digit number in the old 23xxx range', 'Agent reported 23456 pending events'],
+      ['domain use of "column"', 'Report column "hostname" is not valid'],
+      ['device offline phrasing', 'Connection failed - device is offline'],
+    ])('does not flag RMM domain text: %s', (_label, text) => {
+      expect(looksLikeInternalErrorDetail(text)).toBe(false);
+      expect(scrubErrorText(text)).toBe(text);
     });
   });
 
@@ -104,6 +124,53 @@ describe('aiToolErrors', () => {
       expect(out.warning).toBe('Partial results returned');
 
       expect(JSON.stringify(out)).not.toContain('benchmark_version');
+    });
+
+    /**
+     * The error context must be INHERITED by everything under an error-ish key.
+     * Matching only the key directly adjacent to the string missed all three of
+     * these shapes, because the inner keys are UUIDs or array indices — and
+     * `errors[deviceId] = err.message` is exactly how the bulk agent-management
+     * tools report per-device failures.
+     */
+    describe('inherits error context into nested containers', () => {
+      it('scrubs a Record<deviceId, string> under `errors`', () => {
+        const out = scrubErrorFieldsDeep({
+          queued: 0,
+          errors: { 'a1b2c3d4-0000-4000-8000-000000000001': RAW_DRIZZLE_ERROR },
+        }) as { queued: number; errors: Record<string, string> };
+
+        expect(out.queued).toBe(0);
+        expect(out.errors['a1b2c3d4-0000-4000-8000-000000000001']).toBe(
+          GENERIC_TOOL_ERROR_MESSAGE,
+        );
+        expect(JSON.stringify(out)).not.toContain('benchmark_version');
+      });
+
+      it('scrubs an array of error strings', () => {
+        const out = scrubErrorFieldsDeep({ errors: [RAW_DRIZZLE_ERROR, 'Device offline'] }) as {
+          errors: string[];
+        };
+        expect(out.errors[0]).toBe(GENERIC_TOOL_ERROR_MESSAGE);
+        // Short author-written entries inside the same array still survive.
+        expect(out.errors[1]).toBe('Device offline');
+      });
+
+      it('scrubs `errorMessage` and snake_case `*_error` keys', () => {
+        const out = scrubErrorFieldsDeep({
+          errorMessage: RAW_DRIZZLE_ERROR,
+          db_error: 'relation "devices" does not exist',
+        }) as Record<string, string>;
+        expect(out.errorMessage).toBe(GENERIC_TOOL_ERROR_MESSAGE);
+        expect(out.db_error).toBe(GENERIC_TOOL_ERROR_MESSAGE);
+      });
+    });
+
+    it('does not rebuild non-plain objects (Date survives intact)', () => {
+      const when = new Date('2026-01-01T00:00:00.000Z');
+      const out = scrubErrorFieldsDeep({ checkedAt: when }) as { checkedAt: Date };
+      expect(out.checkedAt).toBeInstanceOf(Date);
+      expect(out.checkedAt.toISOString()).toBe('2026-01-01T00:00:00.000Z');
     });
 
     it('handles null, primitives and arrays safely', () => {

--- a/apps/api/src/services/aiToolErrors.test.ts
+++ b/apps/api/src/services/aiToolErrors.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  GENERIC_TOOL_ERROR_MESSAGE,
+  looksLikeInternalErrorDetail,
+  sanitizeThrownToolError,
+  scrubErrorFieldsDeep,
+  scrubErrorText,
+  toolErrorResult,
+} from './aiToolErrors';
+
+/**
+ * The exact payload reported in #2603 — a Drizzle/postgres.js "Failed query"
+ * error carrying the full column list, streamed into the chat as a tool result.
+ */
+const RAW_DRIZZLE_ERROR =
+  'Failed query: select "org_id", "baseline_id", "name", "benchmark_version", "level", ' +
+  '"is_active", "os_type", "device_id", "hostname", "status", "os_type", "checked_at", ' +
+  '"score" from (select "cis_baseline_results"."id" ... ) "ranked_cis_tool_results" where "rn" = $1';
+
+describe('aiToolErrors', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('looksLikeInternalErrorDetail', () => {
+    it.each([
+      ['drizzle failed query', RAW_DRIZZLE_ERROR],
+      ['ambiguous column', 'column reference "os_type" is ambiguous'],
+      ['missing relation', 'relation "cis_baselines" does not exist'],
+      ['unique violation', 'duplicate key value violates unique constraint "devices_pkey"'],
+      ['fk violation', 'insert or update violates foreign key constraint "fk_org"'],
+      ['rls violation', 'new row violates row-level security policy for table "devices"'],
+      ['sqlstate', 'error 23503 raised during insert'],
+      ['network', 'connect ECONNREFUSED 10.1.2.3:5432'],
+      ['dns', 'getaddrinfo ENOTFOUND db.internal.example'],
+      ['stack trace', 'Boom\n    at Object.handler (/app/dist/index.js:12:3)'],
+      ['module path', 'Cannot find module /home/app/node_modules/pg/lib/index.js'],
+    ])('flags %s', (_label, text) => {
+      expect(looksLikeInternalErrorDetail(text)).toBe(true);
+    });
+
+    it('flags any over-long message regardless of pattern', () => {
+      expect(looksLikeInternalErrorDetail('x'.repeat(400))).toBe(true);
+    });
+
+    it('does not flag short author-written messages', () => {
+      for (const safe of [
+        'Device not found or access denied',
+        'No CIS compliance data available yet',
+        'checkIds must include at least one check id',
+        'Access denied to this organization',
+      ]) {
+        expect(looksLikeInternalErrorDetail(safe)).toBe(false);
+      }
+    });
+  });
+
+  describe('scrubErrorText', () => {
+    it('replaces a raw driver error with the generic message', () => {
+      const scrubbed = scrubErrorText(RAW_DRIZZLE_ERROR);
+      expect(scrubbed).toBe(GENERIC_TOOL_ERROR_MESSAGE);
+      // The regression that matters: no SQL or column names survive.
+      expect(scrubbed).not.toContain('select');
+      expect(scrubbed).not.toContain('benchmark_version');
+      expect(scrubbed).not.toContain('org_id');
+    });
+
+    it('preserves author-written tool errors so the model keeps useful signal', () => {
+      expect(scrubErrorText('Device not found or access denied')).toBe(
+        'Device not found or access denied',
+      );
+    });
+
+    it('passes through empty/non-string input unchanged', () => {
+      expect(scrubErrorText('')).toBe('');
+    });
+  });
+
+  describe('scrubErrorFieldsDeep', () => {
+    it('scrubs error-ish keys at any depth without touching data fields', () => {
+      const payload = {
+        count: 2,
+        hostname: 'select-server-01',
+        results: [
+          { deviceId: 'd1', error: RAW_DRIZZLE_ERROR },
+          { deviceId: 'd2', queueError: 'relation "jobs" does not exist' },
+        ],
+        nested: { deep: { scheduleWarning: RAW_DRIZZLE_ERROR } },
+        warning: 'Partial results returned',
+      };
+
+      const out = scrubErrorFieldsDeep(payload) as typeof payload;
+
+      expect(out.count).toBe(2);
+      // A data field that merely contains the word "select" must survive.
+      expect(out.hostname).toBe('select-server-01');
+      expect(out.results[0]!.error).toBe(GENERIC_TOOL_ERROR_MESSAGE);
+      expect(out.results[1]!.queueError).toBe(GENERIC_TOOL_ERROR_MESSAGE);
+      expect(out.nested.deep.scheduleWarning).toBe(GENERIC_TOOL_ERROR_MESSAGE);
+      // Short author-written warning is preserved.
+      expect(out.warning).toBe('Partial results returned');
+
+      expect(JSON.stringify(out)).not.toContain('benchmark_version');
+    });
+
+    it('handles null, primitives and arrays safely', () => {
+      expect(scrubErrorFieldsDeep(null)).toBeNull();
+      expect(scrubErrorFieldsDeep(42)).toBe(42);
+      expect(scrubErrorFieldsDeep(['a', { error: RAW_DRIZZLE_ERROR }])).toEqual([
+        'a',
+        { error: GENERIC_TOOL_ERROR_MESSAGE },
+      ]);
+    });
+  });
+
+  describe('sanitizeThrownToolError', () => {
+    it('genericizes a thrown driver error and logs the full detail server-side', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const out = sanitizeThrownToolError('get_cis_compliance', new Error(RAW_DRIZZLE_ERROR));
+
+      expect(out).toBe(GENERIC_TOOL_ERROR_MESSAGE);
+      expect(out).not.toContain('os_type');
+
+      // Full error still reaches the logs — that is where it belongs.
+      const logged = spy.mock.calls.flat().join(' ');
+      expect(logged).toContain('get_cis_compliance');
+      expect(logged).toContain('Failed query');
+    });
+
+    it('fails closed for an unrecognized error rather than passing it through', () => {
+      expect(sanitizeThrownToolError('t', new Error('something oddly specific'))).toBe(
+        GENERIC_TOOL_ERROR_MESSAGE,
+      );
+    });
+
+    it('preserves allowlisted timeout messages, which are app-constructed', () => {
+      const msg = 'Tool execution timed out after 30000ms: get_cis_compliance';
+      expect(sanitizeThrownToolError('get_cis_compliance', new Error(msg))).toBe(msg);
+    });
+
+    it('handles non-Error throws', () => {
+      expect(sanitizeThrownToolError('t', 'a bare string')).toBe(GENERIC_TOOL_ERROR_MESSAGE);
+      expect(sanitizeThrownToolError('t', undefined)).toBe(GENERIC_TOOL_ERROR_MESSAGE);
+    });
+  });
+
+  describe('toolErrorResult', () => {
+    it('produces the {"error": ...} shape with a sanitized message', () => {
+      const raw = toolErrorResult('get_cis_compliance', new Error(RAW_DRIZZLE_ERROR));
+      expect(JSON.parse(raw)).toEqual({ error: GENERIC_TOOL_ERROR_MESSAGE });
+      expect(raw).not.toContain('benchmark_version');
+    });
+  });
+});

--- a/apps/api/src/services/aiToolErrors.ts
+++ b/apps/api/src/services/aiToolErrors.ts
@@ -49,26 +49,35 @@ const INTERNAL_DETAIL_PATTERNS: RegExp[] = [
   /failed query/i,
   /\bselect\s+["'`]/i,
   /\b(?:insert\s+into|update|delete\s+from)\s+["'`]/i,
-  // PostgreSQL error text
+  // PostgreSQL error text. These are deliberately anchored on the surrounding
+  // Postgres phrasing rather than on a bare quoted identifier: Breeze is an RMM,
+  // and tool results legitimately contain strings like
+  // `Report column "hostname" is not valid` that must NOT be genericized.
   /relation\s+"[^"]+"\s+does not exist/i,
-  /column\s+(?:reference\s+)?"[^"]+"/i,
-  /constraint\s+"[^"]+"/i,
+  /column\s+reference\s+"[^"]+"\s+is ambiguous/i,
+  /column\s+"[^"]+"\s+(?:of relation\b|does not exist|cannot be null|is of type)/i,
+  /(?:violates|on table|constraint)\s+"[^"]+"\s*$/i,
   /duplicate key value violates/i,
-  /violates (?:foreign key|not-null|check) constraint/i,
+  /violates (?:foreign key|not-null|check|unique) constraint/i,
   /violates row-level security policy/i,
   /syntax error at or near/i,
   /operator does not exist/i,
   /invalid input syntax for/i,
   /permission denied for (?:table|relation|schema|sequence)/i,
-  // Bare SQLSTATE codes
-  /\b(?:23\d{3}|42\d{3}|22P02|40P01|57014)\b/,
+  // SQLSTATE codes. Alphanumeric codes are distinctive enough to match bare;
+  // purely numeric ones require SQLSTATE-ish context, because a bare five-digit
+  // number is ordinary RMM data ("Upload exceeds the limit of 42000 bytes").
+  /\b(?:22P02|40P01|42P01|42703|42883)\b/,
+  /\b(?:sqlstate|error\s*code|pg\s*code)\b\D{0,16}\b(?:23\d{3}|42\d{3}|57014)\b/i,
   // Node / network / infrastructure
   /\b(?:ECONNREFUSED|ECONNRESET|ENOTFOUND|ETIMEDOUT|EHOSTUNREACH|EPIPE|EAI_AGAIN)\b/,
   /getaddrinfo/i,
-  /connect(?:ion)? (?:to server )?(?:failed|refused|terminated)/i,
-  // Stack traces and module paths
+  /connection (?:refused|terminated|to server)/i,
+  // Stack traces and server-side module paths. Managed-device filesystem paths
+  // (/var/lib/..., /opt/..., /home/...) are core RMM domain data and are NOT
+  // matched here — only markers that can only come from OUR runtime.
   /\n\s+at\s+\S+/,
-  /(?:\/(?:home|usr|opt|var|app)\/|node_modules\/|file:\/\/)/,
+  /(?:node_modules\/|file:\/\/|\/app\/dist\/|\.[cm]?[jt]sx?:\d+:\d+)/,
   // Redis / BullMQ internals
   /\bWRONGTYPE\b|\bNOSCRIPT\b|\bLOADING\b/,
 ];
@@ -79,8 +88,12 @@ const INTERNAL_DETAIL_PATTERNS: RegExp[] = [
  */
 const MAX_SAFE_ERROR_CHARS = 300;
 
-/** Object keys whose string values are treated as error text during deep scrub. */
-const ERROR_FIELD_PATTERN = /(?:^|[a-z])(?:error|warning)s?$/i;
+/**
+ * Object keys that mark an error context. Covers `error`, `errors`, `warning(s)`,
+ * `queueError`, `scheduleWarning`, `errorMessage`, `errorDetail`, `errorLog`, and
+ * snake_case forms like `db_error` / `sync_error`.
+ */
+const ERROR_FIELD_PATTERN = /(?:^|[a-z_])(?:error|warning)s?(?:message|text|detail|log)?$/i;
 
 function messageOf(err: unknown): string {
   if (err instanceof Error) return err.message;
@@ -111,24 +124,55 @@ export function scrubErrorText(text: string): string {
 }
 
 /**
- * Recursively scrub string values under error-ish keys (`error`, `warning`,
- * `queueError`, `scheduleWarning`, `errors[]`, …) anywhere in a tool payload.
+ * Recursively scrub string values under error-ish keys anywhere in a tool payload.
  * Non-error fields are left untouched — this must not degrade tool data.
+ *
+ * The error context is **inherited by everything beneath the matching key**, which
+ * is what makes the common partial-failure shapes safe:
+ *
+ *   { errors: { "<deviceId>": "<raw driver text>" } }   // keys are UUIDs
+ *   { errors: ["<raw driver text>", ...] }              // array of strings
+ *   { errorMessage: "<raw driver text>" }
+ *
+ * Matching only the key directly adjacent to the string (the original approach)
+ * missed all three, because the inner keys are UUIDs or array indices.
+ *
+ * NOTE: intended for values produced by `JSON.parse`. Non-plain objects (Date,
+ * Map, class instances) are returned untouched rather than rebuilt, so this
+ * cannot silently flatten them if it is ever reused on live objects.
  */
-export function scrubErrorFieldsDeep(value: unknown, depth = 0): unknown {
-  if (depth > 8) return value;
-  if (Array.isArray(value)) {
-    return value.map((item) => scrubErrorFieldsDeep(item, depth + 1));
+export function scrubErrorFieldsDeep(
+  value: unknown,
+  depth = 0,
+  inErrorContext = false,
+): unknown {
+  if (typeof value === 'string') {
+    return inErrorContext ? scrubErrorText(value) : value;
   }
   if (value === null || typeof value !== 'object') return value;
 
+  // Fail CLOSED at the depth cap: inside an error context, an un-walkable subtree
+  // is replaced rather than passed through unscrubbed.
+  if (depth > 8) return inErrorContext ? GENERIC_TOOL_ERROR_MESSAGE : value;
+
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubErrorFieldsDeep(item, depth + 1, inErrorContext));
+  }
+
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) return value;
+
   const out: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof child === 'string' && ERROR_FIELD_PATTERN.test(key)) {
-      out[key] = scrubErrorText(child);
-    } else {
-      out[key] = scrubErrorFieldsDeep(child, depth + 1);
-    }
+    const childInErrorContext = inErrorContext || ERROR_FIELD_PATTERN.test(key);
+    // defineProperty rather than `out[key] =` so a JSON-parsed "__proto__" key is
+    // preserved as an own property instead of hitting the prototype setter.
+    Object.defineProperty(out, key, {
+      value: scrubErrorFieldsDeep(child, depth + 1, childInErrorContext),
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
   }
   return out;
 }
@@ -153,9 +197,13 @@ export function sanitizeThrownToolError(
     err instanceof Error && err.stack ? `\n${err.stack}` : '',
   );
 
+  // The allowlist branch is ALSO detector-checked. `Tool execution timed out
+  // after Nms: ${label}` interpolates a value, so the safe branch must not be a
+  // way around the scrub.
   if (
     raw &&
     raw.length <= MAX_SAFE_ERROR_CHARS &&
+    !looksLikeInternalErrorDetail(raw) &&
     SAFE_THROWN_MESSAGE_PATTERNS.some((pattern) => pattern.test(raw))
   ) {
     return raw;

--- a/apps/api/src/services/aiToolErrors.ts
+++ b/apps/api/src/services/aiToolErrors.ts
@@ -1,0 +1,176 @@
+/**
+ * Shared AI tool error sanitization (#2603).
+ *
+ * Tool failures are streamed to the chat as `tool_result` content — read by both
+ * the model and the user-facing tool card. Before this module, a thrown
+ * Drizzle/postgres.js error went out verbatim, e.g.
+ *
+ *   {"error":"Failed query: select \"org_id\", \"baseline_id\", \"name\", ..."}
+ *
+ * which leaks the schema (table/column names), query shape, constraint names and
+ * sometimes infrastructure hostnames to anyone who can open a chat session. The
+ * full error belongs in the server logs; the stream gets a short generic string.
+ *
+ * Two entry points, deliberately different in strictness:
+ *
+ * - `sanitizeThrownToolError` — for `catch` blocks. A thrown error is by
+ *   definition an unexpected internal fault, so this is **fail-closed**: the
+ *   message is replaced with a generic string unless it matches a small
+ *   allowlist of strings the application itself constructs (e.g. tool timeouts).
+ *
+ * - `scrubErrorText` / `scrubErrorFieldsDeep` — for error text a handler
+ *   *returned* as a normal result (`{ error: 'Device not found' }`,
+ *   `{ warning: ... }`, `{ queueError: ... }`). Those are usually author-written
+ *   and useful to the model, so this is **pattern-based**: only text that looks
+ *   like driver/runtime output is replaced. This runs inside
+ *   `compactToolResultForChat`, which every tool result passes through, so it
+ *   covers all `aiTools*.ts` handlers without per-file changes.
+ */
+
+export const GENERIC_TOOL_ERROR_MESSAGE =
+  'The tool could not complete this request. Details were recorded in the server logs.';
+
+/**
+ * Messages the application constructs itself and which are safe (and useful) to
+ * show. Anything not matching is genericized.
+ */
+const SAFE_THROWN_MESSAGE_PATTERNS: RegExp[] = [
+  /^Tool execution timed out after \d+ms/i,
+  /^Tool .{1,60} timed out/i,
+];
+
+/**
+ * Signatures of driver / runtime / infrastructure output. Any error string
+ * matching one of these is replaced wholesale — never partially masked, because
+ * a partial mask still reveals the schema around it.
+ */
+const INTERNAL_DETAIL_PATTERNS: RegExp[] = [
+  // postgres.js / Drizzle query echo
+  /failed query/i,
+  /\bselect\s+["'`]/i,
+  /\b(?:insert\s+into|update|delete\s+from)\s+["'`]/i,
+  // PostgreSQL error text
+  /relation\s+"[^"]+"\s+does not exist/i,
+  /column\s+(?:reference\s+)?"[^"]+"/i,
+  /constraint\s+"[^"]+"/i,
+  /duplicate key value violates/i,
+  /violates (?:foreign key|not-null|check) constraint/i,
+  /violates row-level security policy/i,
+  /syntax error at or near/i,
+  /operator does not exist/i,
+  /invalid input syntax for/i,
+  /permission denied for (?:table|relation|schema|sequence)/i,
+  // Bare SQLSTATE codes
+  /\b(?:23\d{3}|42\d{3}|22P02|40P01|57014)\b/,
+  // Node / network / infrastructure
+  /\b(?:ECONNREFUSED|ECONNRESET|ENOTFOUND|ETIMEDOUT|EHOSTUNREACH|EPIPE|EAI_AGAIN)\b/,
+  /getaddrinfo/i,
+  /connect(?:ion)? (?:to server )?(?:failed|refused|terminated)/i,
+  // Stack traces and module paths
+  /\n\s+at\s+\S+/,
+  /(?:\/(?:home|usr|opt|var|app)\/|node_modules\/|file:\/\/)/,
+  // Redis / BullMQ internals
+  /\bWRONGTYPE\b|\bNOSCRIPT\b|\bLOADING\b/,
+];
+
+/**
+ * Author-written tool errors are short. Anything long is either a driver dump or
+ * a stack trace, so it is genericized regardless of pattern match.
+ */
+const MAX_SAFE_ERROR_CHARS = 300;
+
+/** Object keys whose string values are treated as error text during deep scrub. */
+const ERROR_FIELD_PATTERN = /(?:^|[a-z])(?:error|warning)s?$/i;
+
+function messageOf(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  if (err && typeof err === 'object' && 'message' in err) {
+    const raw = (err as { message: unknown }).message;
+    if (typeof raw === 'string') return raw;
+  }
+  return '';
+}
+
+/**
+ * True when `text` looks like driver/runtime output rather than an
+ * application-authored message.
+ */
+export function looksLikeInternalErrorDetail(text: string): boolean {
+  if (text.length > MAX_SAFE_ERROR_CHARS) return true;
+  return INTERNAL_DETAIL_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+/**
+ * Pattern-based scrub for error text a handler returned as a normal result.
+ * Preserves short, author-written messages; replaces anything driver-shaped.
+ */
+export function scrubErrorText(text: string): string {
+  if (typeof text !== 'string' || text.length === 0) return text;
+  return looksLikeInternalErrorDetail(text) ? GENERIC_TOOL_ERROR_MESSAGE : text;
+}
+
+/**
+ * Recursively scrub string values under error-ish keys (`error`, `warning`,
+ * `queueError`, `scheduleWarning`, `errors[]`, …) anywhere in a tool payload.
+ * Non-error fields are left untouched — this must not degrade tool data.
+ */
+export function scrubErrorFieldsDeep(value: unknown, depth = 0): unknown {
+  if (depth > 8) return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubErrorFieldsDeep(item, depth + 1));
+  }
+  if (value === null || typeof value !== 'object') return value;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof child === 'string' && ERROR_FIELD_PATTERN.test(key)) {
+      out[key] = scrubErrorText(child);
+    } else {
+      out[key] = scrubErrorFieldsDeep(child, depth + 1);
+    }
+  }
+  return out;
+}
+
+/**
+ * Fail-closed sanitizer for a **thrown** error. Logs the full error (with stack)
+ * server-side and returns a short string safe to stream.
+ *
+ * @param toolName tool the error escaped from — used for the log line only.
+ * @param err      the caught value.
+ * @param context  optional extra log context (never returned to the caller).
+ */
+export function sanitizeThrownToolError(
+  toolName: string,
+  err: unknown,
+  context?: Record<string, unknown>,
+): string {
+  const raw = messageOf(err);
+  console.error(
+    `[aiTools] ${toolName} threw: ${raw || 'unknown error'}`,
+    context ? { ...context } : '',
+    err instanceof Error && err.stack ? `\n${err.stack}` : '',
+  );
+
+  if (
+    raw &&
+    raw.length <= MAX_SAFE_ERROR_CHARS &&
+    SAFE_THROWN_MESSAGE_PATTERNS.some((pattern) => pattern.test(raw))
+  ) {
+    return raw;
+  }
+  return GENERIC_TOOL_ERROR_MESSAGE;
+}
+
+/**
+ * Convenience wrapper: sanitize a thrown error and shape it as the
+ * `{"error": "..."}` JSON string tool handlers return.
+ */
+export function toolErrorResult(
+  toolName: string,
+  err: unknown,
+  context?: Record<string, unknown>,
+): string {
+  return JSON.stringify({ error: sanitizeThrownToolError(toolName, err, context) });
+}

--- a/apps/api/src/services/aiToolOutput.ts
+++ b/apps/api/src/services/aiToolOutput.ts
@@ -1,4 +1,5 @@
 import { redactLogFields, redactLogMessage } from './logRedaction';
+import { scrubErrorFieldsDeep } from './aiToolErrors';
 
 type CompactStats = {
   stringsTruncated: number;
@@ -441,6 +442,12 @@ function safeStringify(value: unknown): string {
 export function compactToolResultForChat(toolName: string, rawResult: string): string {
   const parsed = tryParseJson(rawResult);
   if (parsed === null) {
+    // Non-JSON output is raw tool payload (command stdout, file contents, log
+    // text) — NOT error text. It is deliberately not error-scrubbed here: the
+    // #2603 scrub is keyed on error-ish JSON fields, and applying it to free
+    // text would wipe legitimate output that merely looks query-shaped.
+    // Thrown errors never reach this branch; they are wrapped in
+    // JSON.stringify({ error }) by sanitizeThrownToolError at the call sites.
     const redactedRaw = redactAiToolOutputText(rawResult);
     if (redactedRaw.length <= MAX_TOOL_RESULT_CHARS) {
       return redactedRaw;
@@ -457,7 +464,13 @@ export function compactToolResultForChat(toolName: string, rawResult: string): s
 
   const stats = emptyStats();
 
-  const minimized = sanitizeToolPayloadValue(toolName, parsed, stats);
+  // Scrub driver/runtime detail out of error-ish fields BEFORE compaction, so it
+  // cannot survive into a truncated `preview` further down (#2603). This is the
+  // single chokepoint every aiTools*.ts result passes through, which is why the
+  // fix does not need a catch-block edit in each of the ~19 leaking handlers.
+  const errorScrubbed = scrubErrorFieldsDeep(parsed);
+
+  const minimized = sanitizeToolPayloadValue(toolName, errorScrubbed, stats);
   const redacted = redactLogFields(minimized);
   const sanitized = sanitizeToolPayloadValue(toolName, redacted, stats);
   const toolSpecific = applyToolSpecificCompaction(toolName, sanitized, stats);

--- a/apps/api/src/services/aiToolsAgentLogs.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.ts
@@ -15,6 +15,7 @@ import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { redactAgentLogRow } from './logRedaction';
 import { deviceSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
+import { sanitizeThrownToolError } from './aiToolErrors';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -140,7 +141,7 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
           count: results.length,
         });
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Internal error';
+        const message = sanitizeThrownToolError('agent-logs', err);
         console.error('[ai:search_agent_logs]', message, err);
         return JSON.stringify({ error: `Search failed: ${message}` });
       }
@@ -227,7 +228,7 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
           message: `Log level will be set to ${level} for ${durationMinutes} minutes`,
         });
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Internal error';
+        const message = sanitizeThrownToolError('agent-logs', err);
         console.error('[ai:set_agent_log_level]', message, err);
         return JSON.stringify({ error: `Failed to set log level: ${message}` });
       }
@@ -362,7 +363,7 @@ export function registerAgentLogTools(aiTools: Map<string, AiTool>): void {
             : 'Profiles captured but the command id was unavailable; look up the latest capture_pprof command for this device in the command history.',
         });
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Internal error';
+        const message = sanitizeThrownToolError('agent-logs', err);
         console.error('[ai:capture_agent_pprof]', message, err);
         return JSON.stringify({ error: `Profile capture failed: ${message}` });
       }

--- a/apps/api/src/services/aiToolsAlerts.ts
+++ b/apps/api/src/services/aiToolsAlerts.ts
@@ -20,6 +20,7 @@ import {
   decryptNotificationChannelConfig,
 } from './notificationChannelSecrets';
 import { validateNotificationChannelConfig } from '../routes/alerts/helpers';
+import { sanitizeThrownToolError } from './aiToolErrors';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -502,7 +503,7 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
 
           return JSON.stringify({ success: true, channelId: channel.id, name: channel.name, type: channel.type });
         } catch (err: unknown) {
-          const message = err instanceof Error ? err.message : 'Unknown error';
+          const message = sanitizeThrownToolError('alerts', err);
           return JSON.stringify({ error: `Failed to create channel: ${message}` });
         }
       }

--- a/apps/api/src/services/aiToolsCisBenchmark.compliance.test.ts
+++ b/apps/api/src/services/aiToolsCisBenchmark.compliance.test.ts
@@ -87,7 +87,10 @@ describe('get_cis_compliance', () => {
       .map(outputNameOf)
       .filter((n): n is string => n !== null);
 
-    expect(names.length).toBeGreaterThan(5);
+    // Exact count, not a floor: `outputNameOf` depends on Drizzle internals
+    // (`fieldAlias` / `name`), so a silently-shrinking array would otherwise make
+    // the uniqueness assertion pass vacuously.
+    expect(names.length, `resolved names: ${names.join(', ')}`).toBe(19);
     expect(new Set(names).size, `duplicate output columns: ${names.join(', ')}`).toBe(names.length);
 
     // The two that actually collided must now be explicitly disambiguated.

--- a/apps/api/src/services/aiToolsCisBenchmark.compliance.test.ts
+++ b/apps/api/src/services/aiToolsCisBenchmark.compliance.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn(), transaction: vi.fn() },
+}));
+vi.mock('../jobs/cisJobs', () => ({ scheduleCisRemediationWithResult: vi.fn() }));
+vi.mock('./cisHardening', () => ({ extractFailedCheckIds: vi.fn(() => new Set()) }));
+
+import { db } from '../db';
+import { registerCisBenchmarkTools } from './aiToolsCisBenchmark';
+import { compactToolResultForChat } from './aiToolOutput';
+import { GENERIC_TOOL_ERROR_MESSAGE } from './aiToolErrors';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerCisBenchmarkTools(reg);
+  return reg.get(name)!.handler;
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    allowedSiteIds: undefined,
+    canAccessSite: () => true,
+  } as unknown as AuthContext;
+}
+
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'groupBy', 'offset', 'as']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+/**
+ * Resolve the name a selection field will take in the emitted SQL:
+ * a bare Drizzle column keeps its DB column name; `sql\`…\`.as('x')` uses `x`.
+ */
+function outputNameOf(field: unknown): string | null {
+  if (!field || typeof field !== 'object') return null;
+  const f = field as Record<string, unknown>;
+  if (typeof f.fieldAlias === 'string') return f.fieldAlias;
+  if (typeof f.name === 'string') return f.name;
+  return null;
+}
+
+describe('get_cis_compliance', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  /**
+   * Regression for #2603. Drizzle names a subquery's output columns after the
+   * underlying DB column, so selecting both `cis_baselines.os_type` and
+   * `devices.os_type` emitted TWO columns named "os_type". The outer SELECT then
+   * failed with `column reference "os_type" is ambiguous` (42702) on EVERY call,
+   * with or without CIS data — which is what produced the raw-SQL chat error.
+   */
+  it('builds the ranked subquery with unique output column names', async () => {
+    const selections: unknown[] = [];
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      if (cols) selections.push(cols);
+      return chain([]);
+    });
+
+    await handlerFor('get_cis_compliance')({}, makeAuth());
+
+    const ranked = selections.find(
+      (cols) => !!cols && typeof cols === 'object' && 'rn' in (cols as object),
+    ) as Record<string, unknown> | undefined;
+    expect(ranked, 'ranked subquery selection should have been built').toBeDefined();
+
+    const names = Object.values(ranked!)
+      .map(outputNameOf)
+      .filter((n): n is string => n !== null);
+
+    expect(names.length).toBeGreaterThan(5);
+    expect(new Set(names).size, `duplicate output columns: ${names.join(', ')}`).toBe(names.length);
+
+    // The two that actually collided must now be explicitly disambiguated.
+    expect(names).toContain('baseline_os_type');
+    expect(names).toContain('device_os_type');
+  });
+
+  it('returns a graceful empty result when the stack has no CIS data', async () => {
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return chain(null); // ranked subquery -> .as()
+      if (call === 2) return chain([{ total: 0, averageScore: 100, failingDevices: 0 }]);
+      return chain([]); // no rows
+    });
+
+    const parsed = JSON.parse(await handlerFor('get_cis_compliance')({}, makeAuth()));
+
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.message).toBe('No CIS compliance data available yet');
+    expect(parsed.count).toBe(0);
+    expect(parsed.totalMatched).toBe(0);
+    expect(parsed.results).toEqual([]);
+    expect(parsed.summary).toEqual({
+      averageScore: 100,
+      devicesAudited: 0,
+      failingDevices: 0,
+      compliantDevices: 0,
+    });
+  });
+
+  it('still returns real results when CIS data exists', async () => {
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return chain(null);
+      if (call === 2) return chain([{ total: 1, averageScore: 50, failingDevices: 1 }]);
+      return chain([
+        {
+          orgId: 'org-1', baselineId: 'b1', baselineName: 'CIS', baselineBenchmarkVersion: '1',
+          baselineLevel: 1, baselineIsActive: true, baselineOsType: 'windows', deviceId: 'd1',
+          deviceHostname: 'h1', deviceStatus: 'online', deviceOsType: 'windows',
+          checkedAt: new Date(), score: 50, totalChecks: 10, passedChecks: 5, failedChecks: 5, summary: {},
+        },
+      ]);
+    });
+
+    const parsed = JSON.parse(await handlerFor('get_cis_compliance')({}, makeAuth()));
+
+    expect(parsed.message).toBeUndefined();
+    expect(parsed.count).toBe(1);
+    expect(parsed.results[0].hostname).toBe('h1');
+  });
+
+  /**
+   * The second half of #2603: even if a tool does throw, the raw driver text must
+   * not reach the chat. Every tool result passes through compactToolResultForChat,
+   * which is where the scrub is wired.
+   */
+  it('never streams the raw Drizzle error text to the chat', () => {
+    const rawDriverError =
+      'Failed query: select "org_id", "baseline_id", "name", "benchmark_version", "level", ' +
+      '"is_active", "os_type", "device_id", "hostname", "status", "os_type", "checked_at" ' +
+      'from (select "cis_baseline_results"."id" ...) "ranked_cis_tool_results" where "rn" = $1';
+
+    const streamed = compactToolResultForChat(
+      'get_cis_compliance',
+      JSON.stringify({ error: rawDriverError }),
+    );
+
+    expect(JSON.parse(streamed).error).toBe(GENERIC_TOOL_ERROR_MESSAGE);
+    // No fragment of the query or schema survives into the stream.
+    for (const leak of [
+      'Failed query',
+      'benchmark_version',
+      'cis_baseline_results',
+      'ranked_cis_tool_results',
+      'org_id',
+      'select "',
+    ]) {
+      expect(streamed).not.toContain(leak);
+    }
+  });
+});

--- a/apps/api/src/services/aiToolsCisBenchmark.ts
+++ b/apps/api/src/services/aiToolsCisBenchmark.ts
@@ -23,6 +23,11 @@ import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSit
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
+// Derived from the schema so the aliased subquery fields below cannot drift from
+// the real column types (e.g. `level` and `status` are enums, not string/number).
+type CisBaselineRow = typeof cisBaselines.$inferSelect;
+type DeviceRow = typeof devices.$inferSelect;
+
 async function verifyDeviceAccess(
   deviceId: string,
   auth: AuthContext,
@@ -127,14 +132,20 @@ registerTool({
         failedChecks: cisBaselineResults.failedChecks,
         score: cisBaselineResults.score,
         summary: cisBaselineResults.summary,
-        baselineName: cisBaselines.name,
-        baselineBenchmarkVersion: cisBaselines.benchmarkVersion,
-        baselineLevel: cisBaselines.level,
-        baselineIsActive: cisBaselines.isActive,
-        baselineOsType: cisBaselines.osType,
-        deviceHostname: devices.hostname,
-        deviceStatus: devices.status,
-        deviceOsType: devices.osType,
+        // Joined columns MUST carry explicit aliases. Drizzle names a subquery's
+        // output columns after the underlying DB column, so selecting both
+        // cis_baselines.os_type and devices.os_type emitted two columns named
+        // "os_type" — and the outer SELECT then failed with
+        // `column reference "os_type" is ambiguous` (42702) on EVERY call,
+        // regardless of whether any CIS data existed (#2603).
+        baselineName: sql<CisBaselineRow['name']>`${cisBaselines.name}`.as('baseline_name'),
+        baselineBenchmarkVersion: sql<CisBaselineRow['benchmarkVersion']>`${cisBaselines.benchmarkVersion}`.as('baseline_benchmark_version'),
+        baselineLevel: sql<CisBaselineRow['level']>`${cisBaselines.level}`.as('baseline_level'),
+        baselineIsActive: sql<CisBaselineRow['isActive']>`${cisBaselines.isActive}`.as('baseline_is_active'),
+        baselineOsType: sql<CisBaselineRow['osType']>`${cisBaselines.osType}`.as('baseline_os_type'),
+        deviceHostname: sql<DeviceRow['hostname']>`${devices.hostname}`.as('device_hostname'),
+        deviceStatus: sql<DeviceRow['status']>`${devices.status}`.as('device_status'),
+        deviceOsType: sql<DeviceRow['osType']>`${devices.osType}`.as('device_os_type'),
         rn: sql<number>`row_number() over (partition by ${cisBaselineResults.deviceId}, ${cisBaselineResults.baselineId} order by ${cisBaselineResults.checkedAt} desc)`.as('rn'),
       })
       .from(cisBaselineResults)
@@ -205,6 +216,18 @@ registerTool({
     const totalMatched = Number(summaryRow?.total ?? 0);
     const averageScore = Number(summaryRow?.averageScore ?? 100);
     const failingDevices = Number(summaryRow?.failingDevices ?? 0);
+
+    // Graceful empty result, matching sibling tools (e.g. manage_patches) rather
+    // than returning a bare zeroed summary the model may read as "0% compliant".
+    if (totalMatched === 0 && items.length === 0) {
+      return JSON.stringify({
+        message: 'No CIS compliance data available yet',
+        count: 0,
+        totalMatched: 0,
+        summary: { averageScore: 100, devicesAudited: 0, failingDevices: 0, compliantDevices: 0 },
+        results: [],
+      });
+    }
 
     return JSON.stringify({
       count: items.length,

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -5,6 +5,7 @@ import { eq, and, desc, isNull, isNotNull, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { onedriveHelperInlineSettingsSchema } from '@breeze/shared/validators';
+import { sanitizeThrownToolError } from './aiToolErrors';
 import {
   resolveEffectiveConfig,
   previewEffectiveConfig,
@@ -65,9 +66,10 @@ function safeHandler(
     try {
       return await fn(input, auth);
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Internal error';
-      console.error(`[config-policy:${toolName}]`, message, err);
-      return JSON.stringify({ error: `Operation failed: ${message}` });
+      // Fail closed: `message` may be a raw driver string (#2603).
+      return JSON.stringify({
+        error: sanitizeThrownToolError(`config-policy:${toolName}`, err),
+      });
     }
   };
 }

--- a/apps/api/src/services/aiToolsEventLogs.ts
+++ b/apps/api/src/services/aiToolsEventLogs.ts
@@ -14,6 +14,7 @@ import {
   searchFleetLogs,
 } from './logSearch';
 import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
+import { sanitizeThrownToolError } from './aiToolErrors';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -152,7 +153,7 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
           })),
         });
       } catch (error) {
-        const message = error instanceof Error ? error.message : 'Search failed';
+        const message = sanitizeThrownToolError('event-logs', error);
         console.error('[ai:search_logs]', message, error);
         return JSON.stringify({ error: message });
       }
@@ -268,7 +269,7 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
             : undefined,
         });
       } catch (error) {
-        const message = error instanceof Error ? error.message : 'Trend analysis failed';
+        const message = sanitizeThrownToolError('event-logs', error);
         console.error('[ai:get_log_trends]', message, error);
         return JSON.stringify({ error: message });
       }
@@ -349,7 +350,7 @@ export function registerEventLogTools(aiTools: Map<string, AiTool>): void {
           },
         });
       } catch (error) {
-        const message = error instanceof Error ? error.message : 'Correlation detection failed';
+        const message = sanitizeThrownToolError('event-logs', error);
         console.error('[ai:detect_log_correlations]', message, error);
         return JSON.stringify({ error: message });
       }

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -66,6 +66,7 @@ import { deviceSiteDenied, deviceIdSiteDenied, resolveSiteAllowedDeviceIds } fro
 import { checkAutomationTargetsWithinSiteScope } from './automationRuntime';
 import { siteScopeRequestAllowed } from './reportGenerationService';
 import { upsertPatchApproval, resolvePartnerIdForOrg } from '../routes/patches/helpers';
+import { sanitizeThrownToolError } from './aiToolErrors';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -213,7 +214,10 @@ function safeHandler(toolName: string, fn: FleetHandler): FleetHandler {
       if (code === '23503') return JSON.stringify({ error: `Referenced record not found — a required ID (template, device, policy, etc.) does not exist or was deleted.` });
       if (code === '23505') return JSON.stringify({ error: `Duplicate entry — a record with this name or key already exists.` });
       if (code === '22P02') return JSON.stringify({ error: `Invalid ID format — expected a valid UUID.` });
-      return JSON.stringify({ error: `Operation failed: ${message}` });
+      // Fail closed: anything else may embed the query/column list (#2603).
+      return JSON.stringify({
+        error: sanitizeThrownToolError(`fleet:${toolName}`, err, { action: input.action }),
+      });
     }
   };
 }

--- a/apps/api/src/services/aiToolsIncident.ts
+++ b/apps/api/src/services/aiToolsIncident.ts
@@ -20,6 +20,7 @@ import { queueCommandForExecution } from './commandQueue';
 import { publishEvent } from './eventBus';
 import type { IncidentTimelineEntry } from '../db/schema/incidentResponse';
 import { HIGH_RISK_CONTAINMENT_ACTIONS } from '../routes/incidents.validation';
+import { sanitizeThrownToolError } from './aiToolErrors';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -161,7 +162,7 @@ export function registerIncidentTools(aiTools: Map<string, AiTool>): void {
           warning: eventWarning,
         });
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : 'Unknown error';
+        const message = sanitizeThrownToolError('incident', err);
         return JSON.stringify({ error: `Failed to create incident: ${message}` });
       }
     },

--- a/apps/api/src/services/aiToolsPlaybooks.ts
+++ b/apps/api/src/services/aiToolsPlaybooks.ts
@@ -17,6 +17,7 @@ import { eq, and, desc, sql, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { checkPlaybookRequiredPermissions } from './playbookPermissions';
+import { sanitizeThrownToolError } from './aiToolErrors';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -92,7 +93,7 @@ registerTool({
 
       return JSON.stringify({ playbooks, count: playbooks.length });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = sanitizeThrownToolError('playbooks', err);
       console.error(`[AI] list_playbooks failed:`, err);
       return JSON.stringify({ error: `list_playbooks failed: ${message}` });
     }
@@ -234,7 +235,7 @@ registerTool({
         message: 'Execution created. Execute each step sequentially and update status/step results as work progresses.',
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = sanitizeThrownToolError('playbooks', err);
       console.error(`[AI] execute_playbook failed:`, err);
       return JSON.stringify({ error: `execute_playbook failed: ${message}` });
     }
@@ -311,7 +312,7 @@ registerTool({
 
       return JSON.stringify({ executions, count: executions.length });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = sanitizeThrownToolError('playbooks', err);
       console.error(`[AI] get_playbook_history failed:`, err);
       return JSON.stringify({ error: `get_playbook_history failed: ${message}` });
     }

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -18,6 +18,7 @@ import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { ringAutoApproveSchema, backupProfileSelectionsSchema } from '@breeze/shared/validators';
 import { canManagePartnerWidePolicies } from './partnerWideAccess';
+import { sanitizeThrownToolError } from './aiToolErrors';
 
 /**
  * Defense-in-depth (#1317): the manage_update_rings AI tool writes `autoApprove`
@@ -105,13 +106,14 @@ function safeHandler(toolName: string, fn: Handler): Handler {
     try {
       return await fn(input, auth);
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Internal error';
       const code = pgErrorCode(err);
-      console.error(`[policy-prereq:${toolName}]`, input.action, message, err);
       if (code === '23503') return JSON.stringify({ error: 'Referenced record not found.' });
       if (code === '23505') return JSON.stringify({ error: 'Duplicate entry — a record with this name already exists.' });
       if (code === '22P02') return JSON.stringify({ error: 'Invalid ID format — expected a valid UUID.' });
-      return JSON.stringify({ error: `Operation failed: ${message}` });
+      // Fail closed: anything else may embed the query/column list (#2603).
+      return JSON.stringify({
+        error: sanitizeThrownToolError(`policy-prereq:${toolName}`, err, { action: input.action }),
+      });
     }
   };
 }

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -107,6 +107,9 @@ function safeHandler(toolName: string, fn: Handler): Handler {
       return await fn(input, auth);
     } catch (err: unknown) {
       const code = pgErrorCode(err);
+      // Log BEFORE the pg-code early returns — those branches return without
+      // reaching sanitizeThrownToolError, so without this they log nothing.
+      console.error(`[policy-prereq:${toolName}]`, input.action, code ?? '', err);
       if (code === '23503') return JSON.stringify({ error: 'Referenced record not found.' });
       if (code === '23505') return JSON.stringify({ error: 'Duplicate entry — a record with this name already exists.' });
       if (code === '22P02') return JSON.stringify({ error: 'Invalid ID format — expected a valid UUID.' });

--- a/apps/api/src/services/aiToolsUserRisk.ts
+++ b/apps/api/src/services/aiToolsUserRisk.ts
@@ -12,6 +12,7 @@ import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { listReliabilityDevices } from './reliabilityScoring';
 import { assignSecurityTraining, getUserRiskDetail, listUserRiskScores } from './userRiskScoring';
+import { sanitizeThrownToolError } from './aiToolErrors';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -134,7 +135,7 @@ export function registerUserRiskTools(aiTools: Map<string, AiTool>): void {
           },
         });
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Internal error';
+        const message = sanitizeThrownToolError('user-risk', err);
         console.error('[fleet:get_fleet_health]', message, err);
         return JSON.stringify({ error: 'Operation failed. Check server logs for details.' });
       }
@@ -303,7 +304,7 @@ export function registerUserRiskTools(aiTools: Map<string, AiTool>): void {
         });
       } catch (error) {
         return JSON.stringify({
-          error: error instanceof Error ? error.message : 'Failed to assign security training'
+          error: sanitizeThrownToolError('user-risk', error)
         });
       }
     }

--- a/apps/api/src/services/aiToolsVulnerability.ts
+++ b/apps/api/src/services/aiToolsVulnerability.ts
@@ -24,6 +24,7 @@ import type { AiTool } from './aiTools';
 // Namespace import so the Phase-4 tier-3 handler calls the core through the module
 // object (keeps it spy-able and avoids a stale destructured binding).
 import * as remediationService from './vulnerabilityRemediation';
+import { sanitizeThrownToolError } from './aiToolErrors';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -185,7 +186,7 @@ export function registerVulnerabilityTools(aiTools: Map<string, AiTool>): void {
 
         return JSON.stringify({ status, severity: severity ?? null, totalFindings, affectedCves: byVuln.size, bySeverity, topVulnerabilities });
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Internal error';
+        const message = sanitizeThrownToolError('vulnerability', err);
         console.error('[ai:get_vulnerability_report]', message, err);
         return JSON.stringify({ error: `Report failed: ${message}` });
       }
@@ -244,7 +245,7 @@ export function registerVulnerabilityTools(aiTools: Map<string, AiTool>): void {
 
         return JSON.stringify({ deviceId, vulnerabilities: items, count: items.length });
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Internal error';
+        const message = sanitizeThrownToolError('vulnerability', err);
         console.error('[ai:get_device_vulnerabilities]', message, err);
         return JSON.stringify({ error: `Lookup failed: ${message}` });
       }
@@ -294,7 +295,7 @@ export function registerVulnerabilityTools(aiTools: Map<string, AiTool>): void {
           message: `Scheduled ${result.scheduled} remediation(s); ${result.skipped.length} skipped.`,
         });
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Internal error';
+        const message = sanitizeThrownToolError('vulnerability', err);
         console.error('[ai:remediate_vulnerability]', message, err);
         return JSON.stringify({ error: `Remediation failed: ${message}` });
       }

--- a/apps/api/src/services/scriptBuilderTools.ts
+++ b/apps/api/src/services/scriptBuilderTools.ts
@@ -14,6 +14,7 @@ import type { AiToolTier } from '@breeze/shared/types/ai';
 import { compactToolResultForChat } from './aiToolOutput';
 import { captureException } from './sentry';
 import type { PreToolUseCallback, PostToolUseCallback } from './aiAgentSdkTools';
+import { sanitizeThrownToolError } from './aiToolErrors';
 
 const TOOL_EXECUTION_TIMEOUT_MS = 60_000;
 
@@ -113,7 +114,7 @@ function makeExistingHandler(
       return { content: [{ type: 'text' as const, text: compactResult }] };
     } catch (err) {
       captureException(err);
-      const errorMsg = err instanceof Error ? err.message : 'Unknown error';
+      const errorMsg = sanitizeThrownToolError(toolName, err);
       const durationMs = Date.now() - startTime;
       const safeError = compactToolResultForChat(toolName, JSON.stringify({ error: errorMsg }));
 


### PR DESCRIPTION
Closes #2603

Two distinct bugs, both fixed here.

## 1. `get_cis_compliance` was a broken query, not a "no data" case

The issue author suspected a query/schema mismatch rather than an empty stack. That is correct — **the tool failed on every invocation, with or without CIS data.**

Drizzle names a subquery's output columns after the underlying DB column. The ranked subquery selected **both** `cis_baselines.os_type` and `devices.os_type`, so it emitted two output columns named `os_type`. The outer `SELECT` then referenced a bare `"os_type"`, and Postgres raised `column reference "os_type" is ambiguous` (SQLSTATE **42702**).

Confirmed by generating the query against the real schema:

```sql
select "org_id", "name", "os_type", "os_type", "status"
from (select ... "cis_baselines"."os_type", "devices"."os_type" ...) "ranked_cis_tool_results"
```

That is exactly the column list from the reported error. **Fix:** every joined column now carries an explicit alias (`baseline_os_type`, `device_os_type`, …), with the TS types derived from the schema (`typeof cisBaselines.$inferSelect['level']`) so they cannot drift — `level` and `status` are enums, not `number`/`string`.

Separately, the tool now returns a graceful `{"message":"No CIS compliance data available yet", ...}` when nothing matches, matching sibling tools like `manage_patches`, rather than a bare zeroed summary the model may read as "0% compliant". **This is additive — it is not the fix.** The query bug is fixed at the source; the empty-result path does not paper over it.

## 2. Raw driver errors leaked into the chat stream

The thrown Drizzle/postgres.js message — full query and column list — was forwarded verbatim to both the model and the user-facing tool card.

New shared helper `apps/api/src/services/aiToolErrors.ts`, with two deliberately different strictness levels:

- **`sanitizeThrownToolError`** — for `catch` blocks. **Fail-closed:** logs the full error + stack server-side, returns a short generic string unless the message matches a small allowlist of app-constructed strings (tool timeouts). A thrown error is by definition an unexpected internal fault, so genericizing is the safe default.
- **`scrubErrorFieldsDeep`** — for error text a handler *returned* as a normal result. **Pattern-based**, wired into `compactToolResultForChat`, the single chokepoint every tool result passes through. This covers handlers that return error JSON without editing each one, while preserving short author-written messages the model genuinely needs (`"Device not found or access denied"`).

### Coverage — 14 files routed through the shared sanitizer

| Layer | Sites |
|---|---|
| `aiAgentSdkTools.ts` | `makeHandler` + `makeSessionAwareHandler` catches, both `preToolUse` catches |
| `routes/mcpServer.ts` | 4 sites, incl. the 3 that bypassed compaction entirely |
| `routes/ai.ts` | 2 SSE `error` events (the rawest path to the browser) |
| `scriptBuilderTools.ts` | parallel tool runner catch |
| `aiTools*.ts` | 10 files that interpolated raw messages: ConfigPolicy, PolicyPrereqs, Fleet, AgentLogs, Vulnerability, Playbooks, EventLogs, Alerts, Incident, UserRisk |

**Intentionally left out:** the ~15 `aiTools*.ts` files whose `safeHandler` already returned a generic `"Operation failed. Check server logs for details."` — they never leaked. Their partial-failure/warning fields (`queueError`, `scheduleWarning`, per-device `errors[]` in Browser/Compliance/Peripherals/Security/Scripts/AgentMgmt/Backup) are covered by the compaction-layer scrub rather than edited at source, which is why the diff is 14 files and not 30.

**Also deliberately not scrubbed:** non-JSON tool output. It is raw stdout / file contents / log text, not error text. An early version did scrub it and wiped legitimate large output — caught by an existing `aiToolOutput` test, and reverted with a comment explaining why.

## Tests

- `aiToolErrors.test.ts` (23 tests) — pattern detection, fail-closed behaviour, allowlisted timeouts, deep field scrub, and that a data field containing the word `select` survives untouched.
- `aiToolsCisBenchmark.compliance.test.ts` (4 tests) — a **regression test asserting the ranked subquery's output column names are unique** (this is what would have caught the original bug), the graceful-empty path, the non-empty path, and an end-to-end assertion that the raw SQL/column list does **not** appear in the streamed result.

## Note for the reviewer

One pre-existing `mcpServer.test.ts` assertion changed. It asserted `[REDACTED]` appeared in the response for a thrown error carrying a secret. The message is now genericized *entirely*, so no fragment survives — strictly stronger. The `not.toContain('raw-secret')` assertion still passes, and the full secret-redacted detail is still asserted on the audit event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)