### PR TITLE
fix(agent): persist credentials before the server commits rotation (#2621)

### DIFF
--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -607,41 +608,53 @@ func SaveTo(cfg *Config, cfgFile string) error {
 	// Write secrets to a separate root-only file.
 	secretsPath := secretsFilePathFor(cfgPath)
 	sv := viper.New()
-	// Only overwrite auth_token if non-empty. At runtime the token may be
-	// cleared from the config struct for security; writing "" would wipe
-	// the persisted token and break the agent on next startup.
-	if cfg.AuthToken != "" {
-		sv.Set("auth_token", cfg.AuthToken)
+
+	// Issue #2621 — SaveTo rebuilds the secrets file from scratch, so every
+	// credential it does not re-write is DROPPED. Two ways that bites:
+	//
+	//   - Staged rotation credentials on disk are invisible to an unrelated
+	//     caller (the mTLS renewal path calls config.Save mid-flight), so a cert
+	//     renewal during a rotation would delete the staged set the server may
+	//     already have promoted.
+	//   - The in-memory config clears tokens for security (AuthToken is zeroed
+	//     after startup) and applyRotatedCredentials updates the credential file
+	//     directly rather than the struct, so cfg's watchdog/helper tokens can be
+	//     stale or empty relative to disk.
+	//
+	// So for every credential: prefer a non-empty in-memory value, otherwise
+	// preserve exactly what is on disk. Never write an empty token over a real
+	// one. A read failure is logged rather than swallowed — silently proceeding
+	// would delete credentials this fallback exists to protect.
+	credsOnDisk, readErr := readPersistedCredentialsAt(cfgPath)
+	// A missing secrets file is the normal first-save/enrollment case, not a
+	// problem — there is simply nothing to preserve. Anything else means the file
+	// exists but could not be parsed, and we are about to overwrite it, so say so.
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		log.Warn("could not read existing credentials while saving config; on-disk credential preservation is degraded",
+			"error", readErr.Error())
 	}
-	if cfg.WatchdogAuthToken != "" {
-		sv.Set("watchdog_auth_token", cfg.WatchdogAuthToken)
-	}
-	if cfg.HelperAuthToken != "" {
-		sv.Set("helper_auth_token", cfg.HelperAuthToken)
-	}
-	// Issue #2621 — SaveTo rebuilds the secrets file from scratch, so any staged
-	// rotation credentials on disk would be silently dropped by an unrelated
-	// caller (the mTLS renewal path calls config.Save mid-flight). Losing them
-	// would strand an agent whose staged set is the only one the server still
-	// accepts, which is the very failure this design removes. Carry them
-	// forward: prefer the in-memory values, else preserve what is on disk.
-	pendingOnDisk, _ := readPersistedCredentialsAt(cfgPath)
-	setPendingSecret := func(key, fromCfg string, fromDisk func(*PersistedCredentials) string) {
+	setCredential := func(key, fromCfg string, fromDisk func(*PersistedCredentials) string) {
 		if fromCfg != "" {
 			sv.Set(key, fromCfg)
 			return
 		}
-		if pendingOnDisk != nil {
-			if v := fromDisk(pendingOnDisk); v != "" {
+		if credsOnDisk != nil {
+			if v := fromDisk(credsOnDisk); v != "" {
 				sv.Set(key, v)
 			}
 		}
 	}
-	setPendingSecret(secretKeyPendingAuthToken, cfg.PendingAuthToken,
+	setCredential(secretKeyAuthToken, cfg.AuthToken,
+		func(p *PersistedCredentials) string { return p.AuthToken })
+	setCredential(secretKeyWatchdogAuthToken, cfg.WatchdogAuthToken,
+		func(p *PersistedCredentials) string { return p.WatchdogAuthToken })
+	setCredential(secretKeyHelperAuthToken, cfg.HelperAuthToken,
+		func(p *PersistedCredentials) string { return p.HelperAuthToken })
+	setCredential(secretKeyPendingAuthToken, cfg.PendingAuthToken,
 		func(p *PersistedCredentials) string { return p.PendingAuthToken })
-	setPendingSecret(secretKeyPendingWatchdogAuthToken, cfg.PendingWatchdogAuthToken,
+	setCredential(secretKeyPendingWatchdogAuthToken, cfg.PendingWatchdogAuthToken,
 		func(p *PersistedCredentials) string { return p.PendingWatchdogAuthToken })
-	setPendingSecret(secretKeyPendingHelperAuthToken, cfg.PendingHelperAuthToken,
+	setCredential(secretKeyPendingHelperAuthToken, cfg.PendingHelperAuthToken,
 		func(p *PersistedCredentials) string { return p.PendingHelperAuthToken })
 
 	sv.Set("mtls_cert_pem", cfg.MtlsCertPEM)

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -48,10 +48,18 @@ type Config struct {
 	// via heartbeat configUpdate (#2288). The heartbeat loop probes it after
 	// backupProbeThreshold consecutive primary failures and promote-swaps on
 	// a successful authenticated heartbeat. Never a secret; lives in agent.yaml.
-	BackupServerURL              string `mapstructure:"backup_server_url"`
-	AuthToken                    string `mapstructure:"auth_token"`
-	WatchdogAuthToken            string `mapstructure:"watchdog_auth_token"`
-	HelperAuthToken              string `mapstructure:"helper_auth_token"`
+	BackupServerURL   string `mapstructure:"backup_server_url"`
+	AuthToken         string `mapstructure:"auth_token"`
+	WatchdogAuthToken string `mapstructure:"watchdog_auth_token"`
+	HelperAuthToken   string `mapstructure:"helper_auth_token"`
+	// Issue #2621 — staged credentials from a rotation that has been durably
+	// written but not yet confirmed to the server. They are persisted ALONGSIDE
+	// the still-current set, never in place of it: that is what makes a crash at
+	// any point during rotation survivable. On startup an agent that finds these
+	// populated re-drives the confirmation instead of silently dropping them.
+	PendingAuthToken             string `mapstructure:"pending_auth_token"`
+	PendingWatchdogAuthToken     string `mapstructure:"pending_watchdog_auth_token"`
+	PendingHelperAuthToken       string `mapstructure:"pending_helper_auth_token"`
 	OrgID                        string `mapstructure:"org_id"`
 	SiteID                       string `mapstructure:"site_id"`
 	HeartbeatIntervalSeconds     int    `mapstructure:"heartbeat_interval_seconds"`
@@ -319,6 +327,18 @@ func Load(cfgFile string) (*Config, error) {
 		}
 		if v := sv.GetString("helper_auth_token"); v != "" {
 			cfg.HelperAuthToken = v
+		}
+		// Issue #2621 — staged rotation credentials. Losing these on load would
+		// reintroduce the stranding bug from the other direction: the server may
+		// already have promoted them, and this is the agent's only durable copy.
+		if v := sv.GetString("pending_auth_token"); v != "" {
+			cfg.PendingAuthToken = v
+		}
+		if v := sv.GetString("pending_watchdog_auth_token"); v != "" {
+			cfg.PendingWatchdogAuthToken = v
+		}
+		if v := sv.GetString("pending_helper_auth_token"); v != "" {
+			cfg.PendingHelperAuthToken = v
 		}
 		if v := sv.GetString("mtls_cert_pem"); v != "" {
 			cfg.MtlsCertPEM = v
@@ -599,6 +619,31 @@ func SaveTo(cfg *Config, cfgFile string) error {
 	if cfg.HelperAuthToken != "" {
 		sv.Set("helper_auth_token", cfg.HelperAuthToken)
 	}
+	// Issue #2621 — SaveTo rebuilds the secrets file from scratch, so any staged
+	// rotation credentials on disk would be silently dropped by an unrelated
+	// caller (the mTLS renewal path calls config.Save mid-flight). Losing them
+	// would strand an agent whose staged set is the only one the server still
+	// accepts, which is the very failure this design removes. Carry them
+	// forward: prefer the in-memory values, else preserve what is on disk.
+	pendingOnDisk, _ := readPersistedCredentialsAt(cfgPath)
+	setPendingSecret := func(key, fromCfg string, fromDisk func(*PersistedCredentials) string) {
+		if fromCfg != "" {
+			sv.Set(key, fromCfg)
+			return
+		}
+		if pendingOnDisk != nil {
+			if v := fromDisk(pendingOnDisk); v != "" {
+				sv.Set(key, v)
+			}
+		}
+	}
+	setPendingSecret(secretKeyPendingAuthToken, cfg.PendingAuthToken,
+		func(p *PersistedCredentials) string { return p.PendingAuthToken })
+	setPendingSecret(secretKeyPendingWatchdogAuthToken, cfg.PendingWatchdogAuthToken,
+		func(p *PersistedCredentials) string { return p.PendingWatchdogAuthToken })
+	setPendingSecret(secretKeyPendingHelperAuthToken, cfg.PendingHelperAuthToken,
+		func(p *PersistedCredentials) string { return p.PendingHelperAuthToken })
+
 	sv.Set("mtls_cert_pem", cfg.MtlsCertPEM)
 	sv.Set("mtls_key_pem", cfg.MtlsKeyPEM)
 	sv.Set("mtls_cert_expires", cfg.MtlsCertExpires)

--- a/agent/internal/config/credentials.go
+++ b/agent/internal/config/credentials.go
@@ -32,6 +32,21 @@ const (
 	secretKeyPendingHelperAuthToken   = "pending_helper_auth_token"
 )
 
+// atomicWriteFileForTests is the write seam for credential persistence. Tests
+// override it to inject the failure modes the issue actually reported (ENOSPC,
+// EROFS, ACL denial on the rename) and to simulate a write that lands but does
+// not contain what was asked for — neither of which can be provoked through the
+// filesystem here, because the config layer re-asserts directory permissions on
+// every write. Nil in production; see mutateSecretsAndPersist.
+var atomicWriteFileForTests func(string, []byte, os.FileMode) error
+
+func writeSecretsFile(path string, data []byte, perm os.FileMode) error {
+	if atomicWriteFileForTests != nil {
+		return atomicWriteFileForTests(path, data, perm)
+	}
+	return atomicWriteFile(path, data, perm)
+}
+
 // PersistedCredentials is the credential state actually on disk, as read back
 // from secrets.yaml.
 type PersistedCredentials struct {
@@ -82,7 +97,7 @@ func mutateSecretsAndPersist(mutate func(map[string]any)) error {
 	if err != nil {
 		return fmt.Errorf("marshaling secrets file: %w", err)
 	}
-	if err := atomicWriteFile(path, secretsYAML, 0600); err != nil {
+	if err := writeSecretsFile(path, secretsYAML, 0600); err != nil {
 		return err
 	}
 	return enforceSecretFilePermissions(path)
@@ -194,6 +209,16 @@ func PromotePendingCredentials(authToken, watchdogAuthToken, helperAuthToken str
 		persisted.WatchdogAuthToken != watchdogAuthToken ||
 		persisted.HelperAuthToken != helperAuthToken {
 		return fmt.Errorf("promoted credentials failed readback verification")
+	}
+
+	// The Breeze Helper runs as the logged-in user and cannot read the root-only
+	// secrets.yaml, so helper_auth_token is deliberately exempted from stripping
+	// and also lives in agent.yaml (see secretKeyAllowedInAgentYAML). Promoting
+	// only into secrets.yaml would leave the Helper reading the SUPERSEDED token
+	// and 401ing as soon as its 5-minute grace lapsed — the same stranding bug,
+	// one component over.
+	if err := SetAndPersist(secretKeyHelperAuthToken, helperAuthToken); err != nil {
+		return fmt.Errorf("persisting rotated helper token to agent config: %w", err)
 	}
 	return nil
 }

--- a/agent/internal/config/credentials.go
+++ b/agent/internal/config/credentials.go
@@ -1,0 +1,210 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+// Issue #2621 — durable credential persistence for two-phase token rotation.
+//
+// The stranding bug this file exists to prevent: the server used to commit new
+// credential hashes BEFORE the agent had written the matching plaintext to
+// disk. A failed write left the agent running on in-memory credentials that no
+// copy on disk could reproduce, so the next restart loaded stale credentials
+// and 401'd forever.
+//
+// The invariant enforced here is: at every instant, secrets.yaml holds at least
+// one credential set the server will accept. During a rotation it holds two —
+// the current set and the staged set — and only collapses back to one after the
+// server has confirmed the promotion.
+
+const (
+	secretKeyAuthToken         = "auth_token"
+	secretKeyWatchdogAuthToken = "watchdog_auth_token"
+	secretKeyHelperAuthToken   = "helper_auth_token"
+
+	secretKeyPendingAuthToken         = "pending_auth_token"
+	secretKeyPendingWatchdogAuthToken = "pending_watchdog_auth_token"
+	secretKeyPendingHelperAuthToken   = "pending_helper_auth_token"
+)
+
+// PersistedCredentials is the credential state actually on disk, as read back
+// from secrets.yaml.
+type PersistedCredentials struct {
+	AuthToken                string
+	WatchdogAuthToken        string
+	HelperAuthToken          string
+	PendingAuthToken         string
+	PendingWatchdogAuthToken string
+	PendingHelperAuthToken   string
+}
+
+// mutateSecretsAndPersist applies mutate to the parsed contents of secrets.yaml
+// and writes the result back atomically at 0600 (tmp file → fsync → rename →
+// dir fsync, via atomicWriteFile). Deleting a key is expressed by removing it
+// from the map, which viper.Set cannot express — that is why this exists
+// alongside setSecretAndPersistLocked.
+//
+// The whole read-modify-write runs under persistMu so concurrent credential
+// updates cannot interleave and lose a key.
+func mutateSecretsAndPersist(mutate func(map[string]any)) error {
+	persistMu.Lock()
+	defer persistMu.Unlock()
+
+	path := secretsFilePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	if err := enforceConfigDirPermissions(filepath.Dir(path)); err != nil {
+		return err
+	}
+
+	sv := viper.New()
+	sv.SetConfigFile(path)
+	sv.SetConfigType("yaml")
+	if err := sv.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	settings := sv.AllSettings()
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	mutate(settings)
+
+	secretsYAML, err := yaml.Marshal(settings)
+	if err != nil {
+		return fmt.Errorf("marshaling secrets file: %w", err)
+	}
+	if err := atomicWriteFile(path, secretsYAML, 0600); err != nil {
+		return err
+	}
+	return enforceSecretFilePermissions(path)
+}
+
+// ReadPersistedCredentials reads the credential state straight off disk,
+// bypassing any in-memory config. This is the read-back half of
+// write-then-verify: a Save that returned nil but produced an unreadable or
+// truncated file must not be treated as durable.
+func ReadPersistedCredentials() (*PersistedCredentials, error) {
+	return readPersistedCredentialsFrom(secretsFilePath())
+}
+
+// readPersistedCredentialsAt reads the credential state from the secrets file
+// belonging to an explicit agent.yaml path. SaveTo can target a config file
+// other than the process-bound one, and resolving the wrong secrets file there
+// would make it look like there are no staged credentials to preserve.
+func readPersistedCredentialsAt(cfgPath string) (*PersistedCredentials, error) {
+	return readPersistedCredentialsFrom(secretsFilePathFor(cfgPath))
+}
+
+func readPersistedCredentialsFrom(path string) (*PersistedCredentials, error) {
+	sv := viper.New()
+	sv.SetConfigFile(path)
+	sv.SetConfigType("yaml")
+	if err := sv.ReadInConfig(); err != nil {
+		return nil, fmt.Errorf("reading secrets file: %w", err)
+	}
+
+	return &PersistedCredentials{
+		AuthToken:                sv.GetString(secretKeyAuthToken),
+		WatchdogAuthToken:        sv.GetString(secretKeyWatchdogAuthToken),
+		HelperAuthToken:          sv.GetString(secretKeyHelperAuthToken),
+		PendingAuthToken:         sv.GetString(secretKeyPendingAuthToken),
+		PendingWatchdogAuthToken: sv.GetString(secretKeyPendingWatchdogAuthToken),
+		PendingHelperAuthToken:   sv.GetString(secretKeyPendingHelperAuthToken),
+	}, nil
+}
+
+// StagePendingCredentials durably writes a staged credential set ALONGSIDE the
+// current one, then reads it back to prove the write landed.
+//
+// Critically, it does not touch auth_token / watchdog_auth_token /
+// helper_auth_token. If this call fails — or the process dies mid-write — the
+// agent still has its working credentials on disk, and the server has not
+// promoted anything, so the rotation is simply abandoned with no divergence.
+//
+// Returns an error if the readback does not match what was written; the caller
+// MUST NOT confirm the rotation to the server in that case.
+func StagePendingCredentials(authToken, watchdogAuthToken, helperAuthToken string) error {
+	if authToken == "" || watchdogAuthToken == "" || helperAuthToken == "" {
+		return fmt.Errorf("refusing to stage an incomplete credential set")
+	}
+
+	if err := mutateSecretsAndPersist(func(settings map[string]any) {
+		settings[secretKeyPendingAuthToken] = authToken
+		settings[secretKeyPendingWatchdogAuthToken] = watchdogAuthToken
+		settings[secretKeyPendingHelperAuthToken] = helperAuthToken
+	}); err != nil {
+		return fmt.Errorf("staging pending credentials: %w", err)
+	}
+
+	persisted, err := ReadPersistedCredentials()
+	if err != nil {
+		return fmt.Errorf("verifying staged credentials: %w", err)
+	}
+	if persisted.PendingAuthToken != authToken ||
+		persisted.PendingWatchdogAuthToken != watchdogAuthToken ||
+		persisted.PendingHelperAuthToken != helperAuthToken {
+		return fmt.Errorf("staged credentials failed readback verification")
+	}
+	// The current set must still be intact — a staging write that clobbered it
+	// would have destroyed the fallback the whole design depends on.
+	if persisted.AuthToken == "" {
+		return fmt.Errorf("staging clobbered the current auth token")
+	}
+	return nil
+}
+
+// PromotePendingCredentials collapses the staged set into the current set in a
+// single atomic write, once the server has confirmed the promotion.
+//
+// Ordering note: this runs strictly AFTER the server confirms. If the process
+// dies before this call, secrets.yaml still carries the staged tokens under
+// their pending_* keys and startup reconciliation recovers them; if it dies
+// during, atomicWriteFile's rename means the file is either fully the old
+// content or fully the new one, never a torn mix.
+func PromotePendingCredentials(authToken, watchdogAuthToken, helperAuthToken string) error {
+	if authToken == "" || watchdogAuthToken == "" || helperAuthToken == "" {
+		return fmt.Errorf("refusing to promote an incomplete credential set")
+	}
+
+	if err := mutateSecretsAndPersist(func(settings map[string]any) {
+		settings[secretKeyAuthToken] = authToken
+		settings[secretKeyWatchdogAuthToken] = watchdogAuthToken
+		settings[secretKeyHelperAuthToken] = helperAuthToken
+		delete(settings, secretKeyPendingAuthToken)
+		delete(settings, secretKeyPendingWatchdogAuthToken)
+		delete(settings, secretKeyPendingHelperAuthToken)
+	}); err != nil {
+		return fmt.Errorf("promoting pending credentials: %w", err)
+	}
+
+	persisted, err := ReadPersistedCredentials()
+	if err != nil {
+		return fmt.Errorf("verifying promoted credentials: %w", err)
+	}
+	if persisted.AuthToken != authToken ||
+		persisted.WatchdogAuthToken != watchdogAuthToken ||
+		persisted.HelperAuthToken != helperAuthToken {
+		return fmt.Errorf("promoted credentials failed readback verification")
+	}
+	return nil
+}
+
+// ClearPendingCredentials drops a staged set that can never be promoted (the
+// server reported it expired). The current credentials are left untouched, so
+// this is always safe: the worst case is a rotation that has to start over.
+func ClearPendingCredentials() error {
+	return mutateSecretsAndPersist(func(settings map[string]any) {
+		delete(settings, secretKeyPendingAuthToken)
+		delete(settings, secretKeyPendingWatchdogAuthToken)
+		delete(settings, secretKeyPendingHelperAuthToken)
+	})
+}

--- a/agent/internal/config/credentials_test.go
+++ b/agent/internal/config/credentials_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -111,22 +112,53 @@ func TestStagePendingCredentialsFailsWhenDiskWriteFails(t *testing.T) {
 	}
 }
 
-// A write that lands but reads back wrong must be reported as a failure. The
-// readback is the agent's only evidence that config.Save actually produced a
-// durable, parseable credential file — reporting success on an unverified write
-// is the assumption that #2621 punished.
-func TestStagePendingCredentialsVerifiesReadback(t *testing.T) {
+// The failure mode the issue actually reported: the write itself fails (full or
+// read-only volume, ACL denial on the atomic rename). Injected at the write seam
+// because the config layer re-asserts directory permissions on every write, so a
+// filesystem-level injection is undone by the code under test.
+func TestStagePendingCredentialsFailsWhenWriteReturnsError(t *testing.T) {
+	bindConfig(t)
+
+	atomicWriteFileForTests = func(string, []byte, os.FileMode) error {
+		return errors.New("no space left on device")
+	}
+	t.Cleanup(func() { atomicWriteFileForTests = nil })
+
+	err := StagePendingCredentials("brz_new_agent", "brz_new_watchdog", "brz_new_helper")
+	if err == nil {
+		t.Fatal("StagePendingCredentials swallowed a write error — the rotation would " +
+			"confirm credentials that never reached disk (#2621)")
+	}
+
+	// The credentials the agent is actually using must be untouched.
+	atomicWriteFileForTests = nil
+	got, readErr := ReadPersistedCredentials()
+	if readErr != nil {
+		t.Fatalf("ReadPersistedCredentials: %v", readErr)
+	}
+	if got.AuthToken != "brz_current_agent" {
+		t.Errorf("current auth token = %q, want brz_current_agent", got.AuthToken)
+	}
+	if got.PendingAuthToken != "" {
+		t.Errorf("pending auth token persisted despite the write failure: %q", got.PendingAuthToken)
+	}
+}
+
+// ReadPersistedCredentials must report what is actually on disk, not what a
+// previous call believed it wrote. It is the evidence the whole persist-verify
+// step rests on, so it must not be satisfiable by stale in-memory state.
+func TestReadPersistedCredentialsReflectsDiskNotMemory(t *testing.T) {
 	cfgPath := bindConfig(t)
 
 	if err := StagePendingCredentials("brz_new_agent", "brz_new_watchdog", "brz_new_helper"); err != nil {
 		t.Fatalf("StagePendingCredentials: %v", err)
 	}
 
-	// Corrupt the file behind the staged write, then prove a fresh read surfaces
-	// the divergence rather than trusting the earlier success.
+	// Rewrite the file behind the staged write; a fresh read must surface the
+	// divergence rather than echo the earlier success.
 	secretsPath := secretsFilePathFor(cfgPath)
 	if err := os.WriteFile(secretsPath, []byte("auth_token: brz_current_agent\n"), 0600); err != nil {
-		t.Fatalf("corrupt secrets file: %v", err)
+		t.Fatalf("rewrite secrets file: %v", err)
 	}
 
 	got, err := ReadPersistedCredentials()
@@ -135,6 +167,46 @@ func TestStagePendingCredentialsVerifiesReadback(t *testing.T) {
 	}
 	if got.PendingAuthToken != "" {
 		t.Errorf("readback reported a staged token that is not on disk: %q", got.PendingAuthToken)
+	}
+}
+
+// The readback-mismatch branch itself: if the write lands but the file does not
+// contain what we asked for, staging MUST fail. Reporting success on an
+// unverified write is the assumption #2621 punished.
+func TestStagePendingCredentialsFailsWhenReadbackDisagrees(t *testing.T) {
+	bindConfig(t)
+
+	// Inject a write that lands but silently drops the helper token, so the
+	// readback disagrees with what staging was asked to persist. Delegates to the
+	// real atomicWriteFile — NOT to the seam's previous value, which is nil in
+	// production and would panic.
+	atomicWriteFileForTests = func(path string, data []byte, perm os.FileMode) error {
+		return atomicWriteFile(path, []byte(strings.ReplaceAll(string(data), "brz_new_helper", "")), perm)
+	}
+	t.Cleanup(func() { atomicWriteFileForTests = nil })
+
+	err := StagePendingCredentials("brz_new_agent", "brz_new_watchdog", "brz_new_helper")
+	if err == nil {
+		t.Fatal("StagePendingCredentials succeeded even though the readback did not match what was written")
+	}
+	if !strings.Contains(err.Error(), "readback") {
+		t.Errorf("error = %v, want a readback-verification failure", err)
+	}
+}
+
+// Staging must never clobber the credentials the agent is currently using —
+// they are the fallback the whole design depends on.
+func TestStagePendingCredentialsFailsIfCurrentTokenLost(t *testing.T) {
+	bindConfig(t)
+
+	atomicWriteFileForTests = func(path string, data []byte, perm os.FileMode) error {
+		return atomicWriteFile(path, []byte(strings.ReplaceAll(string(data), "brz_current_agent", "")), perm)
+	}
+	t.Cleanup(func() { atomicWriteFileForTests = nil })
+
+	err := StagePendingCredentials("brz_new_agent", "brz_new_watchdog", "brz_new_helper")
+	if err == nil {
+		t.Fatal("StagePendingCredentials succeeded despite losing the current auth token")
 	}
 }
 
@@ -294,13 +366,15 @@ func TestSaveToPreservesStagedCredentials(t *testing.T) {
 		t.Fatalf("StagePendingCredentials: %v", err)
 	}
 
-	// An unrelated save, as the cert-renewal path would issue.
+	// Model the REAL caller: the cert-renewal path calls config.Save(h.config)
+	// with a config whose token fields have been cleared for security (AuthToken
+	// is zeroed after startup) and which never carried the rotated watchdog and
+	// helper tokens in the first place. An earlier version of this test set all
+	// three, which hid the bug — SaveTo rebuilds secrets.yaml from scratch, so
+	// empty fields mean "delete" unless the on-disk fallback rescues them.
 	cfg := Default()
 	cfg.AgentID = "ab3c20eddb470acffd33bbe00f25e0348e89298ab80cece542bb1fbf921e5776"
 	cfg.ServerURL = "https://api.example.test"
-	cfg.AuthToken = "brz_current_agent"
-	cfg.WatchdogAuthToken = "brz_current_watchdog"
-	cfg.HelperAuthToken = "brz_current_helper"
 	cfg.MtlsCertPEM = "cert"
 	if err := SaveTo(cfg, cfgPath); err != nil {
 		t.Fatalf("SaveTo: %v", err)
@@ -309,6 +383,13 @@ func TestSaveToPreservesStagedCredentials(t *testing.T) {
 	got, err := ReadPersistedCredentials()
 	if err != nil {
 		t.Fatalf("ReadPersistedCredentials: %v", err)
+	}
+	// Every credential must survive a save that carried none of them in memory.
+	if got.WatchdogAuthToken != "brz_current_watchdog" {
+		t.Errorf("watchdog token = %q, want brz_current_watchdog — an unrelated SaveTo wiped it", got.WatchdogAuthToken)
+	}
+	if got.HelperAuthToken != "brz_current_helper" {
+		t.Errorf("helper token = %q, want brz_current_helper — an unrelated SaveTo wiped it", got.HelperAuthToken)
 	}
 	if got.PendingAuthToken != "brz_new_agent" {
 		t.Errorf("staged auth token = %q, want brz_new_agent — an unrelated SaveTo dropped it", got.PendingAuthToken)
@@ -324,16 +405,21 @@ func TestSaveToPreservesStagedCredentials(t *testing.T) {
 	}
 }
 
-// The pending_* keys must be classified as secrets so the generic strip/migrate
-// machinery keeps them out of agent.yaml.
-func TestPendingTokenKeysAreSecretKeys(t *testing.T) {
-	for _, key := range []string{
-		"pending_auth_token",
-		"pending_watchdog_auth_token",
-		"pending_helper_auth_token",
-	} {
-		if !isSecretYAMLKey(key) {
-			t.Errorf("isSecretYAMLKey(%q) = false, want true", key)
-		}
+// helper_auth_token is deliberately exempted from stripping because the Breeze
+// Helper runs as the logged-in user and reads it from agent.yaml. Its STAGED
+// counterpart must NOT inherit that exemption: a staged credential is not yet
+// the Helper's identity, and putting it in the 0644 agent.yaml would publish an
+// unpromoted token to every local user. This asymmetry is easy to "tidy up" by
+// accident, so pin it.
+func TestPendingHelperTokenIsNotExemptedFromStripping(t *testing.T) {
+	if !secretKeyAllowedInAgentYAML["helper_auth_token"] {
+		t.Fatal("precondition changed: helper_auth_token is no longer agent.yaml-exempt; " +
+			"revisit whether the Helper still reads it from there")
+	}
+	if secretKeyAllowedInAgentYAML[secretKeyPendingHelperAuthToken] {
+		t.Error("pending_helper_auth_token must not be exempted into the world-readable agent.yaml")
+	}
+	if !isSecretYAMLKey(secretKeyPendingHelperAuthToken) {
+		t.Error("isSecretYAMLKey(pending_helper_auth_token) = false, want true")
 	}
 }

--- a/agent/internal/config/credentials_test.go
+++ b/agent/internal/config/credentials_test.go
@@ -1,0 +1,339 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// Issue #2621 — regression coverage for the credential-rotation stranding bug.
+//
+// The property under test throughout: a rotation must never reach the point of
+// telling the server "promote these" unless the new credentials are durably on
+// disk, AND a failure to persist must always leave the previously working
+// credentials intact.
+
+// bindConfig points the package-level viper at a temp agent.yaml so
+// secretsFilePath() resolves inside the test's sandbox.
+func bindConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+
+	cfg := Default()
+	cfg.AgentID = "ab3c20eddb470acffd33bbe00f25e0348e89298ab80cece542bb1fbf921e5776"
+	cfg.ServerURL = "https://api.example.test"
+	cfg.AuthToken = "brz_current_agent"
+	cfg.WatchdogAuthToken = "brz_current_watchdog"
+	cfg.HelperAuthToken = "brz_current_helper"
+	cfg.OrgID = "org-1"
+	cfg.SiteID = "site-1"
+
+	if err := SaveTo(cfg, cfgPath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+	viper.SetConfigFile(cfgPath)
+	t.Cleanup(viper.Reset)
+	return cfgPath
+}
+
+func TestStagePendingCredentialsPreservesCurrentSet(t *testing.T) {
+	bindConfig(t)
+
+	if err := StagePendingCredentials("brz_new_agent", "brz_new_watchdog", "brz_new_helper"); err != nil {
+		t.Fatalf("StagePendingCredentials: %v", err)
+	}
+
+	got, err := ReadPersistedCredentials()
+	if err != nil {
+		t.Fatalf("ReadPersistedCredentials: %v", err)
+	}
+
+	// The whole point of staging: the credentials the agent is currently
+	// authenticating with must survive untouched, because the server still
+	// treats them as current until confirmation.
+	if got.AuthToken != "brz_current_agent" {
+		t.Errorf("current auth token was modified by staging: %q", got.AuthToken)
+	}
+	if got.WatchdogAuthToken != "brz_current_watchdog" {
+		t.Errorf("current watchdog token was modified by staging: %q", got.WatchdogAuthToken)
+	}
+	if got.HelperAuthToken != "brz_current_helper" {
+		t.Errorf("current helper token was modified by staging: %q", got.HelperAuthToken)
+	}
+
+	if got.PendingAuthToken != "brz_new_agent" {
+		t.Errorf("pending auth token = %q, want brz_new_agent", got.PendingAuthToken)
+	}
+	if got.PendingWatchdogAuthToken != "brz_new_watchdog" {
+		t.Errorf("pending watchdog token = %q, want brz_new_watchdog", got.PendingWatchdogAuthToken)
+	}
+	if got.PendingHelperAuthToken != "brz_new_helper" {
+		t.Errorf("pending helper token = %q, want brz_new_helper", got.PendingHelperAuthToken)
+	}
+}
+
+// THE core regression test for #2621: when the disk write fails, staging must
+// report failure. The caller contract is that a failed stage aborts the rotation
+// before the server is ever asked to promote — so the server can never end up
+// holding hashes the agent cannot reproduce after a restart.
+func TestStagePendingCredentialsFailsWhenDiskWriteFails(t *testing.T) {
+	cfgPath := bindConfig(t)
+	secretsPath := secretsFilePathFor(cfgPath)
+
+	// Injection: replace the secrets file with a NON-EMPTY DIRECTORY. The atomic
+	// write's final rename onto that path cannot succeed, which models the
+	// real-world failures in the issue report (ACLs, a locked/undeletable target,
+	// a full or read-only volume) without depending on chmod — the config layer
+	// deliberately re-asserts directory permissions on every write, so a
+	// permission-based injection would be undone by the code under test.
+	if err := os.Remove(secretsPath); err != nil {
+		t.Fatalf("remove secrets file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(secretsPath, "occupied"), 0700); err != nil {
+		t.Fatalf("create blocking directory: %v", err)
+	}
+
+	err := StagePendingCredentials("brz_new_agent", "brz_new_watchdog", "brz_new_helper")
+	if err == nil {
+		t.Fatal("StagePendingCredentials reported success despite an unwritable secrets path — " +
+			"the rotation would go on to confirm credentials that are not on disk, which is exactly " +
+			"how #2621 stranded agents")
+	}
+
+	// Nothing may be observable as staged after a failed write.
+	if _, statErr := os.Stat(filepath.Join(secretsPath, "occupied")); statErr != nil {
+		t.Errorf("blocking directory disappeared: %v", statErr)
+	}
+}
+
+// A write that lands but reads back wrong must be reported as a failure. The
+// readback is the agent's only evidence that config.Save actually produced a
+// durable, parseable credential file — reporting success on an unverified write
+// is the assumption that #2621 punished.
+func TestStagePendingCredentialsVerifiesReadback(t *testing.T) {
+	cfgPath := bindConfig(t)
+
+	if err := StagePendingCredentials("brz_new_agent", "brz_new_watchdog", "brz_new_helper"); err != nil {
+		t.Fatalf("StagePendingCredentials: %v", err)
+	}
+
+	// Corrupt the file behind the staged write, then prove a fresh read surfaces
+	// the divergence rather than trusting the earlier success.
+	secretsPath := secretsFilePathFor(cfgPath)
+	if err := os.WriteFile(secretsPath, []byte("auth_token: brz_current_agent\n"), 0600); err != nil {
+		t.Fatalf("corrupt secrets file: %v", err)
+	}
+
+	got, err := ReadPersistedCredentials()
+	if err != nil {
+		t.Fatalf("ReadPersistedCredentials: %v", err)
+	}
+	if got.PendingAuthToken != "" {
+		t.Errorf("readback reported a staged token that is not on disk: %q", got.PendingAuthToken)
+	}
+}
+
+func TestStagePendingCredentialsRejectsIncompleteSet(t *testing.T) {
+	bindConfig(t)
+
+	cases := []struct {
+		name                    string
+		agent, watchdog, helper string
+	}{
+		{"missing agent", "", "brz_w", "brz_h"},
+		{"missing watchdog", "brz_a", "", "brz_h"},
+		{"missing helper", "brz_a", "brz_w", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := StagePendingCredentials(tc.agent, tc.watchdog, tc.helper); err == nil {
+				t.Fatal("expected an error for an incomplete credential set")
+			}
+			got, err := ReadPersistedCredentials()
+			if err != nil {
+				t.Fatalf("ReadPersistedCredentials: %v", err)
+			}
+			if got.PendingAuthToken != "" || got.PendingWatchdogAuthToken != "" || got.PendingHelperAuthToken != "" {
+				t.Error("a partial credential set was staged")
+			}
+		})
+	}
+}
+
+func TestPromotePendingCredentialsSwapsAndClears(t *testing.T) {
+	bindConfig(t)
+
+	if err := StagePendingCredentials("brz_new_agent", "brz_new_watchdog", "brz_new_helper"); err != nil {
+		t.Fatalf("StagePendingCredentials: %v", err)
+	}
+	if err := PromotePendingCredentials("brz_new_agent", "brz_new_watchdog", "brz_new_helper"); err != nil {
+		t.Fatalf("PromotePendingCredentials: %v", err)
+	}
+
+	got, err := ReadPersistedCredentials()
+	if err != nil {
+		t.Fatalf("ReadPersistedCredentials: %v", err)
+	}
+	if got.AuthToken != "brz_new_agent" {
+		t.Errorf("auth token = %q, want brz_new_agent", got.AuthToken)
+	}
+	if got.WatchdogAuthToken != "brz_new_watchdog" {
+		t.Errorf("watchdog token = %q, want brz_new_watchdog", got.WatchdogAuthToken)
+	}
+	if got.HelperAuthToken != "brz_new_helper" {
+		t.Errorf("helper token = %q, want brz_new_helper", got.HelperAuthToken)
+	}
+	// Promotion must clear the staged copy, otherwise startup reconciliation
+	// would keep re-confirming a rotation that already completed.
+	if got.PendingAuthToken != "" || got.PendingWatchdogAuthToken != "" || got.PendingHelperAuthToken != "" {
+		t.Errorf("staged credentials survived promotion: %+v", got)
+	}
+}
+
+func TestClearPendingCredentialsLeavesCurrentSetIntact(t *testing.T) {
+	bindConfig(t)
+
+	if err := StagePendingCredentials("brz_new_agent", "brz_new_watchdog", "brz_new_helper"); err != nil {
+		t.Fatalf("StagePendingCredentials: %v", err)
+	}
+	if err := ClearPendingCredentials(); err != nil {
+		t.Fatalf("ClearPendingCredentials: %v", err)
+	}
+
+	got, err := ReadPersistedCredentials()
+	if err != nil {
+		t.Fatalf("ReadPersistedCredentials: %v", err)
+	}
+	if got.PendingAuthToken != "" {
+		t.Errorf("pending auth token survived clear: %q", got.PendingAuthToken)
+	}
+	// Abandoning a rotation must never cost the agent its working credentials.
+	if got.AuthToken != "brz_current_agent" {
+		t.Errorf("current auth token = %q, want brz_current_agent", got.AuthToken)
+	}
+	if got.WatchdogAuthToken != "brz_current_watchdog" {
+		t.Errorf("current watchdog token = %q, want brz_current_watchdog", got.WatchdogAuthToken)
+	}
+}
+
+// Simulates the crash window: credentials staged, process dies before it could
+// confirm. After a restart the agent must still find BOTH sets on disk, since
+// the staged one may be the only credential the server still accepts.
+func TestStagedCredentialsSurviveReload(t *testing.T) {
+	cfgPath := bindConfig(t)
+
+	if err := StagePendingCredentials("brz_new_agent", "brz_new_watchdog", "brz_new_helper"); err != nil {
+		t.Fatalf("StagePendingCredentials: %v", err)
+	}
+
+	// Restart: fresh viper, reload from disk.
+	viper.Reset()
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.AuthToken != "brz_current_agent" {
+		t.Errorf("reloaded auth token = %q, want brz_current_agent", cfg.AuthToken)
+	}
+	if cfg.PendingAuthToken != "brz_new_agent" {
+		t.Errorf("reloaded pending auth token = %q, want brz_new_agent — "+
+			"an agent that crashed mid-rotation would lose the only credential the server may accept", cfg.PendingAuthToken)
+	}
+	if cfg.PendingWatchdogAuthToken != "brz_new_watchdog" {
+		t.Errorf("reloaded pending watchdog token = %q, want brz_new_watchdog", cfg.PendingWatchdogAuthToken)
+	}
+	if cfg.PendingHelperAuthToken != "brz_new_helper" {
+		t.Errorf("reloaded pending helper token = %q, want brz_new_helper", cfg.PendingHelperAuthToken)
+	}
+}
+
+// Staged credentials are secrets and must land in the 0600 secrets file, never
+// in the world-readable agent.yaml.
+func TestStagedCredentialsStayOutOfAgentYAML(t *testing.T) {
+	cfgPath := bindConfig(t)
+
+	if err := StagePendingCredentials("brz_new_agent", "brz_new_watchdog", "brz_new_helper"); err != nil {
+		t.Fatalf("StagePendingCredentials: %v", err)
+	}
+
+	agentYAML, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read agent.yaml: %v", err)
+	}
+	for _, forbidden := range []string{"brz_new_agent", "brz_new_watchdog", "brz_new_helper", "pending_auth_token"} {
+		if strings.Contains(string(agentYAML), forbidden) {
+			t.Errorf("agent.yaml leaked %q:\n%s", forbidden, agentYAML)
+		}
+	}
+
+	secretsPath := secretsFilePathFor(cfgPath)
+	info, err := os.Stat(secretsPath)
+	if err != nil {
+		t.Fatalf("stat secrets file: %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
+		t.Errorf("secrets file mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+// SaveTo rebuilds secrets.yaml from scratch, and unrelated callers invoke it
+// mid-flight (the mTLS renewal path calls config.Save). It must not drop a
+// staged credential set: during the rotation window that set may be the only
+// credential the server still accepts, so losing it would strand the agent —
+// the exact class of failure #2621 is about.
+func TestSaveToPreservesStagedCredentials(t *testing.T) {
+	cfgPath := bindConfig(t)
+
+	if err := StagePendingCredentials("brz_new_agent", "brz_new_watchdog", "brz_new_helper"); err != nil {
+		t.Fatalf("StagePendingCredentials: %v", err)
+	}
+
+	// An unrelated save, as the cert-renewal path would issue.
+	cfg := Default()
+	cfg.AgentID = "ab3c20eddb470acffd33bbe00f25e0348e89298ab80cece542bb1fbf921e5776"
+	cfg.ServerURL = "https://api.example.test"
+	cfg.AuthToken = "brz_current_agent"
+	cfg.WatchdogAuthToken = "brz_current_watchdog"
+	cfg.HelperAuthToken = "brz_current_helper"
+	cfg.MtlsCertPEM = "cert"
+	if err := SaveTo(cfg, cfgPath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	got, err := ReadPersistedCredentials()
+	if err != nil {
+		t.Fatalf("ReadPersistedCredentials: %v", err)
+	}
+	if got.PendingAuthToken != "brz_new_agent" {
+		t.Errorf("staged auth token = %q, want brz_new_agent — an unrelated SaveTo dropped it", got.PendingAuthToken)
+	}
+	if got.PendingWatchdogAuthToken != "brz_new_watchdog" {
+		t.Errorf("staged watchdog token = %q, want brz_new_watchdog", got.PendingWatchdogAuthToken)
+	}
+	if got.PendingHelperAuthToken != "brz_new_helper" {
+		t.Errorf("staged helper token = %q, want brz_new_helper", got.PendingHelperAuthToken)
+	}
+	if got.AuthToken != "brz_current_agent" {
+		t.Errorf("current auth token = %q, want brz_current_agent", got.AuthToken)
+	}
+}
+
+// The pending_* keys must be classified as secrets so the generic strip/migrate
+// machinery keeps them out of agent.yaml.
+func TestPendingTokenKeysAreSecretKeys(t *testing.T) {
+	for _, key := range []string{
+		"pending_auth_token",
+		"pending_watchdog_auth_token",
+		"pending_helper_auth_token",
+	} {
+		if !isSecretYAMLKey(key) {
+			t.Errorf("isSecretYAMLKey(%q) = false, want true", key)
+		}
+	}
+}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -116,11 +116,14 @@ type DesktopAccessState struct {
 }
 
 type HeartbeatResponse struct {
-	Commands               []Command              `json:"commands"`
-	ConfigUpdate           map[string]any         `json:"configUpdate,omitempty"`
-	UpgradeTo              string                 `json:"upgradeTo,omitempty"`
-	RenewCert              bool                   `json:"renewCert,omitempty"`
-	RotateToken            bool                   `json:"rotateToken,omitempty"`
+	Commands     []Command      `json:"commands"`
+	ConfigUpdate map[string]any `json:"configUpdate,omitempty"`
+	UpgradeTo    string         `json:"upgradeTo,omitempty"`
+	RenewCert    bool           `json:"renewCert,omitempty"`
+	RotateToken  bool           `json:"rotateToken,omitempty"`
+	// Issue #2621 — the server sees this agent authenticating with the STAGED
+	// credentials of an unconfirmed rotation. Finish phase two.
+	ConfirmTokenRotation   bool                   `json:"confirmTokenRotation,omitempty"`
 	HelperEnabled          bool                   `json:"helperEnabled,omitempty"`
 	UacInterceptionEnabled *bool                  `json:"uacInterceptionEnabled,omitempty"`
 	HelperSettings         *HelperSettings        `json:"helperSettings,omitempty"`
@@ -964,6 +967,15 @@ func bootstrapThenListenWithRetry(ctx context.Context, bootstrap func() error, l
 }
 
 func (h *Heartbeat) Start() {
+	// Issue #2621 — before the first heartbeat, finish any credential rotation
+	// that was interrupted between the durable disk write and the server
+	// confirmation. This runs first on purpose: if the agent was offline long
+	// enough for its old credentials to fall out of the previous-token grace
+	// window, the staged credentials are the ONLY ones the server still accepts,
+	// and reconciling here is what gets the agent back on a current credential
+	// instead of 401-looping.
+	go h.reconcilePendingRotation()
+
 	// Proactively spawn helpers into user sessions so remote desktop works
 	// instantly after reboot (Windows service only). The SCM session event
 	// channel (created in constructor) is fed by the service handler
@@ -3416,6 +3428,14 @@ func (h *Heartbeat) processHeartbeatResponse(response *HeartbeatResponse) {
 		go h.handleTokenRotation()
 	}
 
+	// Issue #2621 — the server is telling us we are running on staged
+	// credentials it never promoted (we confirmed late, or crashed before
+	// confirming). Finish phase two so the rotation stops depending on the
+	// pending window staying open.
+	if response.ConfirmTokenRotation {
+		go h.reconcilePendingRotation()
+	}
+
 	// Handle helper upgrade if requested
 	if response.HelperUpgradeTo != "" {
 		installedHelper := h.helperMgr.InstalledVersion()
@@ -3617,33 +3637,152 @@ func (h *Heartbeat) handleTokenRotation() {
 		return
 	}
 
-	h.mu.Lock()
-	h.secureToken.Replace(rotateResp.AuthToken)
-	h.config.AuthToken = rotateResp.AuthToken
-	h.config.WatchdogAuthToken = rotateResp.WatchdogAuthToken
-	h.config.HelperAuthToken = rotateResp.HelperAuthToken
-	saveErr := config.Save(h.config)
-	h.config.AuthToken = ""
-	h.config.WatchdogAuthToken = ""
-	h.config.HelperAuthToken = ""
-	h.mu.Unlock()
-
-	if saveErr != nil {
-		log.Error("agent token rotated in memory but failed to persist new token", "error", saveErr.Error())
-	} else {
-		log.Info("agent token rotated", "rotatedAt", rotateResp.RotatedAt)
+	// Issue #2621 — PERSIST BEFORE COMMIT.
+	//
+	// The old sequence swapped credentials in memory and only then tried to save,
+	// treating a save failure as a log line. Because the server had already
+	// committed the new hashes, that log line was the last warning before the
+	// device was stranded: the next restart loaded stale credentials and every
+	// request 401'd once the grace window closed.
+	//
+	// Now the server has merely STAGED these credentials — the agent's existing
+	// ones are still current server-side. So a failure anywhere below is
+	// recoverable: we abort, keep using credentials we know are both durable and
+	// valid, and the staged set expires harmlessly.
+	if err := config.StagePendingCredentials(
+		rotateResp.AuthToken,
+		rotateResp.WatchdogAuthToken,
+		rotateResp.HelperAuthToken,
+	); err != nil {
+		// Deliberately NOT swapping the in-memory credentials here. Continuing on
+		// unpersisted credentials is exactly the divergence that caused #2621.
+		log.Error("agent token rotation aborted — new credentials could not be durably persisted; continuing on the existing durable credentials",
+			"error", err.Error())
+		return
 	}
 
+	// The staged set is on disk and verified by readback. Only now is it safe to
+	// ask the server to promote it, authenticating WITH the new token — that is
+	// the proof of durable possession the server requires.
+	if !h.confirmTokenRotation(rotateResp.AuthToken) {
+		// Confirmation failed. Both credential sets are on disk and both are
+		// accepted by the server while the staged set lives, so the agent keeps
+		// working either way. Startup reconciliation and the heartbeat
+		// confirmTokenRotation flag will retry the promotion.
+		log.Warn("rotation credentials persisted but confirmation failed; will retry — agent remains authenticated on its current credentials")
+		return
+	}
+
+	h.applyRotatedCredentials(rotateResp.AuthToken, rotateResp.WatchdogAuthToken, rotateResp.HelperAuthToken)
+	log.Info("agent token rotated", "rotatedAt", rotateResp.RotatedAt)
+}
+
+// confirmTokenRotation runs phase two: it tells the server the staged
+// credentials are durably held, which promotes them to current. Returns true
+// only on a confirmed promotion.
+//
+// A failure here is safe by construction — the server keeps the agent's
+// previous credentials current until it succeeds — so the caller can simply
+// retry later rather than unwinding anything.
+func (h *Heartbeat) confirmTokenRotation(newAuthToken string) bool {
+	confirmClient := api.NewClient(h.serverURL(), newAuthToken, h.config.AgentID)
+	resp, err := confirmClient.ConfirmTokenRotation()
+	if err != nil {
+		if errors.Is(err, api.ErrPendingRotationExpired) {
+			// The staged set can never be promoted now. Drop it so startup
+			// reconciliation doesn't retry forever; the durable current
+			// credentials are untouched and still valid.
+			log.Warn("pending token rotation expired before it could be confirmed; discarding staged credentials")
+			if clearErr := config.ClearPendingCredentials(); clearErr != nil {
+				log.Error("failed to clear expired staged credentials", "error", clearErr.Error())
+			}
+			return false
+		}
+		log.Error("agent token rotation confirmation failed", "error", err.Error())
+		return false
+	}
+
+	return resp.Confirmed
+}
+
+// applyRotatedCredentials collapses a confirmed rotation into the agent's
+// durable current credentials and refreshes every in-memory consumer.
+//
+// Called only after the server has confirmed the promotion, so writing these as
+// current can no longer diverge from the server's view.
+func (h *Heartbeat) applyRotatedCredentials(authToken, watchdogAuthToken, helperAuthToken string) {
+	if err := config.PromotePendingCredentials(authToken, watchdogAuthToken, helperAuthToken); err != nil {
+		// The server has promoted, and the tokens remain on disk under their
+		// pending_* keys, which startup reconciliation reads back. The agent is
+		// not stranded, but this file is now in a shape that needs attention.
+		log.Error("rotation confirmed by server but promoting staged credentials on disk failed; staged copy is still on disk and will be recovered on restart",
+			"error", err.Error())
+	}
+
+	h.mu.Lock()
+	h.secureToken.Replace(authToken)
+	h.mu.Unlock()
+
 	// Notify the watchdog of its role-scoped token so it can use it for failover heartbeats.
-	h.sendWatchdogTokenUpdate(rotateResp.WatchdogAuthToken)
+	h.sendWatchdogTokenUpdate(watchdogAuthToken)
 
 	// Retain and push the rotated helper token to any connected assist sessions.
-	h.setHelperToken(rotateResp.HelperAuthToken)
-	h.sendHelperTokenUpdate(rotateResp.HelperAuthToken)
+	h.setHelperToken(helperAuthToken)
+	h.sendHelperTokenUpdate(helperAuthToken)
 
 	if h.wsClient != nil {
 		h.wsClient.ForceReconnect()
 	}
+}
+
+// reconcilePendingRotation recovers a rotation that was interrupted between the
+// durable disk write and the server confirmation — the crash window the
+// two-phase design is built to survive.
+//
+// Both credential sets are on disk at that point and the server accepts either
+// while the staged set is live, so the agent is never locked out; this just
+// finishes the handshake. Safe to call on every startup: it is a no-op when
+// there is nothing staged.
+func (h *Heartbeat) reconcilePendingRotation() {
+	// Share the rotation mutex with handleTokenRotation: a startup reconcile, a
+	// heartbeat-triggered reconcile and a fresh rotation can all fire at once,
+	// and two concurrent confirms would race the server's compare-and-swap.
+	if !h.tokenRotating.CompareAndSwap(false, true) {
+		return
+	}
+	defer h.tokenRotating.Store(false)
+
+	persisted, err := config.ReadPersistedCredentials()
+	if err != nil {
+		log.Warn("could not read persisted credentials for rotation reconciliation", "error", err.Error())
+		return
+	}
+
+	if persisted.PendingAuthToken == "" {
+		return
+	}
+	if persisted.PendingWatchdogAuthToken == "" || persisted.PendingHelperAuthToken == "" {
+		// An incomplete staged set can never be promoted — the server only ever
+		// stages all three together. Drop it rather than confirm a partial set.
+		log.Warn("discarding incomplete staged credential set")
+		if clearErr := config.ClearPendingCredentials(); clearErr != nil {
+			log.Error("failed to clear incomplete staged credentials", "error", clearErr.Error())
+		}
+		return
+	}
+
+	log.Info("found an unconfirmed credential rotation on disk; resuming confirmation")
+
+	if !h.confirmTokenRotation(persisted.PendingAuthToken) {
+		return
+	}
+
+	h.applyRotatedCredentials(
+		persisted.PendingAuthToken,
+		persisted.PendingWatchdogAuthToken,
+		persisted.PendingHelperAuthToken,
+	)
+	log.Info("resumed credential rotation confirmed and promoted")
 }
 
 // sendWatchdogStateSync sends a state_sync IPC message to the watchdog

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -279,9 +279,12 @@ type Heartbeat struct {
 	inFlightSeq      atomic.Uint64
 
 	// Guard against concurrent cert renewals from successive heartbeats
-	certRenewing      atomic.Bool
-	tokenRotating     atomic.Bool
-	upgradeInProgress atomic.Bool
+	certRenewing  atomic.Bool
+	tokenRotating atomic.Bool
+	// Issue #2621 — a staged credential rotation is sitting on disk unconfirmed.
+	// Drives the per-tick retry so recovery does not depend on a process restart.
+	pendingRotationOnDisk atomic.Bool
+	upgradeInProgress     atomic.Bool
 
 	// Set when PinManifestKeys returns ErrManifestTrustRotationRejected.
 	// Suspends auto-update until the rotation conflict is resolved (server
@@ -1080,6 +1083,16 @@ func (h *Heartbeat) Start() {
 	for {
 		select {
 		case <-ticker.C:
+			// Issue #2621 — retry an unfinished credential rotation on every tick
+			// while one is outstanding. This runs BEFORE the auth-dead skip on
+			// purpose: if the server already promoted but the confirmation
+			// response was lost, the agent is heartbeating with a credential that
+			// is about to stop working, and the staged token on disk is the way
+			// out. Waiting for a process restart to reconcile would leave the
+			// device dark until someone restarted the service.
+			if h.pendingRotationOnDisk.Load() {
+				go h.reconcilePendingRotation()
+			}
 			if h.authMon != nil && h.authMon.ShouldSkip() {
 				log.Debug("skipping heartbeat tick, auth-dead",
 					"backoff", h.authMon.BackoffDuration())
@@ -3660,6 +3673,21 @@ func (h *Heartbeat) handleTokenRotation() {
 			"error", err.Error())
 		return
 	}
+	h.pendingRotationOnDisk.Store(true)
+
+	// A pre-#2621 server has ALREADY committed these hashes as current — its
+	// response carries no confirmationRequired and it has no confirm endpoint.
+	// Treating that as a two-phase rotation would be fatal: the confirm would
+	// 404, we would never promote locally, and the agent would sit on a
+	// credential the server has already demoted — permanently stranded once the
+	// grace window closed. So against an old server, promote immediately; the
+	// durable write above already happened, which is still strictly better
+	// ordering than the code this replaces.
+	if !rotateResp.ConfirmationRequired {
+		log.Info("server committed the rotation without a confirmation phase (pre-#2621 server); promoting locally")
+		h.applyRotatedCredentials(rotateResp.AuthToken, rotateResp.WatchdogAuthToken, rotateResp.HelperAuthToken)
+		return
+	}
 
 	// The staged set is on disk and verified by readback. Only now is it safe to
 	// ask the server to promote it, authenticating WITH the new token — that is
@@ -3692,9 +3720,11 @@ func (h *Heartbeat) confirmTokenRotation(newAuthToken string) bool {
 			// The staged set can never be promoted now. Drop it so startup
 			// reconciliation doesn't retry forever; the durable current
 			// credentials are untouched and still valid.
-			log.Warn("pending token rotation expired before it could be confirmed; discarding staged credentials")
+			log.Warn("pending token rotation can no longer be promoted (expired or revoked); discarding staged credentials")
 			if clearErr := config.ClearPendingCredentials(); clearErr != nil {
-				log.Error("failed to clear expired staged credentials", "error", clearErr.Error())
+				log.Error("failed to clear unusable staged credentials", "error", clearErr.Error())
+			} else {
+				h.pendingRotationOnDisk.Store(false)
 			}
 			return false
 		}
@@ -3715,12 +3745,24 @@ func (h *Heartbeat) applyRotatedCredentials(authToken, watchdogAuthToken, helper
 		// The server has promoted, and the tokens remain on disk under their
 		// pending_* keys, which startup reconciliation reads back. The agent is
 		// not stranded, but this file is now in a shape that needs attention.
-		log.Error("rotation confirmed by server but promoting staged credentials on disk failed; staged copy is still on disk and will be recovered on restart",
+		log.Error("rotation confirmed by server but promoting staged credentials on disk failed; staged copy is still on disk and the per-tick retry will recover it",
 			"error", err.Error())
+		// Leave pendingRotationOnDisk set so the retry keeps trying; the server
+		// has already promoted, so the reconcile will take the alreadyCurrent
+		// path and finish the local write.
+	} else {
+		h.pendingRotationOnDisk.Store(false)
 	}
 
 	h.mu.Lock()
 	h.secureToken.Replace(authToken)
+	// Keep the in-memory config in step with disk. SaveTo rebuilds secrets.yaml
+	// from this struct, so leaving these stale would let an unrelated save (the
+	// cert-renewal path calls config.Save) write PRE-rotation watchdog/helper
+	// tokens back over the promoted ones. AuthToken stays cleared — secureToken
+	// is the authority for it and the struct copy is zeroed after startup.
+	h.config.WatchdogAuthToken = watchdogAuthToken
+	h.config.HelperAuthToken = helperAuthToken
 	h.mu.Unlock()
 
 	// Notify the watchdog of its role-scoped token so it can use it for failover heartbeats.
@@ -3759,6 +3801,7 @@ func (h *Heartbeat) reconcilePendingRotation() {
 	}
 
 	if persisted.PendingAuthToken == "" {
+		h.pendingRotationOnDisk.Store(false)
 		return
 	}
 	if persisted.PendingWatchdogAuthToken == "" || persisted.PendingHelperAuthToken == "" {
@@ -3767,9 +3810,14 @@ func (h *Heartbeat) reconcilePendingRotation() {
 		log.Warn("discarding incomplete staged credential set")
 		if clearErr := config.ClearPendingCredentials(); clearErr != nil {
 			log.Error("failed to clear incomplete staged credentials", "error", clearErr.Error())
+		} else {
+			h.pendingRotationOnDisk.Store(false)
 		}
 		return
 	}
+
+	// Keep the per-tick retry armed until this rotation actually resolves.
+	h.pendingRotationOnDisk.Store(true)
 
 	log.Info("found an unconfirmed credential rotation on disk; resuming confirmation")
 

--- a/agent/internal/heartbeat/token_rotation_test.go
+++ b/agent/internal/heartbeat/token_rotation_test.go
@@ -1,0 +1,341 @@
+package heartbeat
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/secmem"
+)
+
+// Issue #2621 — ordering regression tests for agent credential rotation.
+//
+// The bug: the server committed new credential hashes BEFORE the agent had
+// persisted the matching plaintext. When config.Save failed, the agent logged
+// the error and carried on in memory; after a restart it loaded stale
+// credentials from secrets.yaml and every request 401'd once the 5-minute
+// previous-token grace window closed, with no automatic recovery.
+//
+// The contract these tests pin down is the ordering that fixes it: the server
+// only commits when the agent CONFIRMS, and the agent only confirms after the
+// credentials are durably on disk and verified by readback.
+
+type rotationServer struct {
+	*httptest.Server
+	mu           sync.Mutex
+	rotateCalls  int
+	confirmCalls int
+	// confirmedWith records the bearer token each confirm arrived with — the
+	// server's proof-of-possession check depends on it being the NEW token.
+	confirmedWith []string
+}
+
+func (s *rotationServer) counts() (rotate, confirm int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rotateCalls, s.confirmCalls
+}
+
+func (s *rotationServer) tokensUsedForConfirm() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.confirmedWith...)
+}
+
+// newRotationServer stands up a two-phase-capable rotation endpoint pair.
+func newRotationServer(t *testing.T) *rotationServer {
+	t.Helper()
+	rs := &rotationServer{}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v1/agents/", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case pathHasSuffix(r.URL.Path, "/rotate-token/confirm"):
+			rs.mu.Lock()
+			rs.confirmCalls++
+			rs.confirmedWith = append(rs.confirmedWith, r.Header.Get("Authorization"))
+			rs.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"confirmed": true})
+		case pathHasSuffix(r.URL.Path, "/rotate-token"):
+			rs.mu.Lock()
+			rs.rotateCalls++
+			rs.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"authToken":            "brz_staged_agent",
+				"watchdogAuthToken":    "brz_staged_watchdog",
+				"helperAuthToken":      "brz_staged_helper",
+				"rotatedAt":            "2026-07-19T00:00:00Z",
+				"confirmationRequired": true,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	rs.Server = httptest.NewServer(mux)
+	t.Cleanup(rs.Close)
+	return rs
+}
+
+func pathHasSuffix(path, suffix string) bool {
+	return len(path) >= len(suffix) && path[len(path)-len(suffix):] == suffix
+}
+
+// newRotationTestHeartbeat wires a Heartbeat against a real temp config so the
+// credential-persistence path exercises actual file I/O.
+func newRotationTestHeartbeat(t *testing.T, serverURL string) (*Heartbeat, string) {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+
+	cfg := config.Default()
+	cfg.AgentID = "ab3c20eddb470acffd33bbe00f25e0348e89298ab80cece542bb1fbf921e5776"
+	cfg.ServerURL = serverURL
+	cfg.AuthToken = "brz_current_agent"
+	cfg.WatchdogAuthToken = "brz_current_watchdog"
+	cfg.HelperAuthToken = "brz_current_helper"
+	cfg.OrgID = "org-1"
+	cfg.SiteID = "site-1"
+
+	if err := config.SaveTo(cfg, cfgPath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+	viper.SetConfigFile(cfgPath)
+
+	h := &Heartbeat{
+		config:      cfg,
+		secureToken: secmem.NewSecureString("brz_current_agent"),
+		client:      &http.Client{},
+	}
+	return h, cfgPath
+}
+
+// THE regression test for #2621.
+//
+// With the secrets file unwritable, rotation must abort BEFORE confirming. If
+// the agent confirmed here, the server would commit hashes whose plaintext
+// exists nowhere on disk — the agent would run fine until its next restart and
+// then be permanently locked out.
+func TestTokenRotationDoesNotConfirmWhenPersistenceFails(t *testing.T) {
+	srv := newRotationServer(t)
+	h, cfgPath := newRotationTestHeartbeat(t, srv.URL)
+
+	// Block the secrets write with a non-empty directory at the target path.
+	secretsPath := secretsPathFor(cfgPath)
+	if err := os.Remove(secretsPath); err != nil {
+		t.Fatalf("remove secrets file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(secretsPath, "occupied"), 0700); err != nil {
+		t.Fatalf("create blocking directory: %v", err)
+	}
+
+	h.handleTokenRotation()
+
+	rotate, confirm := srv.counts()
+	if rotate != 1 {
+		t.Fatalf("rotate-token calls = %d, want 1", rotate)
+	}
+	if confirm != 0 {
+		t.Fatalf("rotate-token/confirm was called %d time(s) after a failed disk write — "+
+			"the server would commit credentials the agent cannot reproduce after a restart (#2621)", confirm)
+	}
+
+	// The agent must still be using the credentials it can actually prove it has.
+	if got := h.secureToken.Reveal(); got != "brz_current_agent" {
+		t.Errorf("in-memory token = %q, want brz_current_agent — the agent swapped to "+
+			"credentials it failed to persist", got)
+	}
+}
+
+// Happy path: persist, verify, confirm, promote — in that order.
+func TestTokenRotationPersistsBeforeConfirming(t *testing.T) {
+	srv := newRotationServer(t)
+	h, _ := newRotationTestHeartbeat(t, srv.URL)
+
+	h.handleTokenRotation()
+
+	rotate, confirm := srv.counts()
+	if rotate != 1 || confirm != 1 {
+		t.Fatalf("rotate=%d confirm=%d, want 1 and 1", rotate, confirm)
+	}
+
+	// Confirmation must be authenticated with the NEW token: that is the
+	// server's evidence the endpoint holds a durable copy. Confirming with the
+	// old token would prove nothing about what got written.
+	used := srv.tokensUsedForConfirm()
+	if len(used) != 1 || used[0] != "Bearer brz_staged_agent" {
+		t.Fatalf("confirm authenticated with %v, want [Bearer brz_staged_agent]", used)
+	}
+
+	persisted, err := config.ReadPersistedCredentials()
+	if err != nil {
+		t.Fatalf("ReadPersistedCredentials: %v", err)
+	}
+	if persisted.AuthToken != "brz_staged_agent" {
+		t.Errorf("persisted auth token = %q, want brz_staged_agent", persisted.AuthToken)
+	}
+	if persisted.WatchdogAuthToken != "brz_staged_watchdog" {
+		t.Errorf("persisted watchdog token = %q, want brz_staged_watchdog", persisted.WatchdogAuthToken)
+	}
+	if persisted.HelperAuthToken != "brz_staged_helper" {
+		t.Errorf("persisted helper token = %q, want brz_staged_helper", persisted.HelperAuthToken)
+	}
+	// A confirmed rotation collapses to a single credential set.
+	if persisted.PendingAuthToken != "" {
+		t.Errorf("staged credentials survived a confirmed rotation: %q", persisted.PendingAuthToken)
+	}
+	if got := h.secureToken.Reveal(); got != "brz_staged_agent" {
+		t.Errorf("in-memory token = %q, want brz_staged_agent", got)
+	}
+}
+
+// A confirm that never lands leaves BOTH sets on disk. That is deliberate: the
+// server still accepts the old credentials (it never promoted) and also accepts
+// the staged ones, so a restart in this window authenticates either way.
+func TestTokenRotationKeepsBothCredentialSetsWhenConfirmFails(t *testing.T) {
+	rs := &rotationServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agents/", func(w http.ResponseWriter, r *http.Request) {
+		if pathHasSuffix(r.URL.Path, "/rotate-token/confirm") {
+			rs.mu.Lock()
+			rs.confirmCalls++
+			rs.mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"boom"}`))
+			return
+		}
+		rs.mu.Lock()
+		rs.rotateCalls++
+		rs.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"authToken":            "brz_staged_agent",
+			"watchdogAuthToken":    "brz_staged_watchdog",
+			"helperAuthToken":      "brz_staged_helper",
+			"confirmationRequired": true,
+		})
+	})
+	rs.Server = httptest.NewServer(mux)
+	t.Cleanup(rs.Close)
+
+	h, _ := newRotationTestHeartbeat(t, rs.URL)
+	h.handleTokenRotation()
+
+	persisted, err := config.ReadPersistedCredentials()
+	if err != nil {
+		t.Fatalf("ReadPersistedCredentials: %v", err)
+	}
+	if persisted.AuthToken != "brz_current_agent" {
+		t.Errorf("current auth token = %q, want brz_current_agent — the agent must not "+
+			"promote credentials the server never confirmed", persisted.AuthToken)
+	}
+	if persisted.PendingAuthToken != "brz_staged_agent" {
+		t.Errorf("staged auth token = %q, want brz_staged_agent — dropping it would lose "+
+			"the credential the server may already accept", persisted.PendingAuthToken)
+	}
+}
+
+// Startup reconciliation: the agent finds a staged set on disk (it crashed
+// after persisting but before confirming) and finishes the handshake. This is
+// the recovery path for the crash window.
+func TestReconcilePendingRotationConfirmsStagedCredentials(t *testing.T) {
+	srv := newRotationServer(t)
+	h, _ := newRotationTestHeartbeat(t, srv.URL)
+
+	if err := config.StagePendingCredentials("brz_staged_agent", "brz_staged_watchdog", "brz_staged_helper"); err != nil {
+		t.Fatalf("StagePendingCredentials: %v", err)
+	}
+
+	h.reconcilePendingRotation()
+
+	_, confirm := srv.counts()
+	if confirm != 1 {
+		t.Fatalf("confirm calls = %d, want 1", confirm)
+	}
+	used := srv.tokensUsedForConfirm()
+	if len(used) != 1 || used[0] != "Bearer brz_staged_agent" {
+		t.Fatalf("reconciliation confirmed with %v, want [Bearer brz_staged_agent]", used)
+	}
+
+	persisted, err := config.ReadPersistedCredentials()
+	if err != nil {
+		t.Fatalf("ReadPersistedCredentials: %v", err)
+	}
+	if persisted.AuthToken != "brz_staged_agent" {
+		t.Errorf("auth token = %q, want brz_staged_agent", persisted.AuthToken)
+	}
+	if persisted.PendingAuthToken != "" {
+		t.Errorf("staged credentials survived reconciliation: %q", persisted.PendingAuthToken)
+	}
+}
+
+// Nothing staged => nothing to do. Reconciliation runs on every startup, so it
+// must be a cheap no-op that never touches the server.
+func TestReconcilePendingRotationNoOpWithoutStagedCredentials(t *testing.T) {
+	srv := newRotationServer(t)
+	h, _ := newRotationTestHeartbeat(t, srv.URL)
+
+	h.reconcilePendingRotation()
+
+	rotate, confirm := srv.counts()
+	if rotate != 0 || confirm != 0 {
+		t.Fatalf("rotate=%d confirm=%d, want no server calls", rotate, confirm)
+	}
+}
+
+// An expired staged set can never be promoted. The agent must discard it rather
+// than retry forever — and must keep its durable current credentials.
+func TestReconcilePendingRotationDiscardsExpiredStagedSet(t *testing.T) {
+	rs := &rotationServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agents/", func(w http.ResponseWriter, r *http.Request) {
+		rs.mu.Lock()
+		rs.confirmCalls++
+		rs.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": "Pending rotation has expired; request a new rotation",
+			"code":  "pending_rotation_expired",
+		})
+	})
+	rs.Server = httptest.NewServer(mux)
+	t.Cleanup(rs.Close)
+
+	h, _ := newRotationTestHeartbeat(t, rs.URL)
+	if err := config.StagePendingCredentials("brz_staged_agent", "brz_staged_watchdog", "brz_staged_helper"); err != nil {
+		t.Fatalf("StagePendingCredentials: %v", err)
+	}
+
+	h.reconcilePendingRotation()
+
+	persisted, err := config.ReadPersistedCredentials()
+	if err != nil {
+		t.Fatalf("ReadPersistedCredentials: %v", err)
+	}
+	if persisted.PendingAuthToken != "" {
+		t.Errorf("expired staged credentials were retained: %q", persisted.PendingAuthToken)
+	}
+	if persisted.AuthToken != "brz_current_agent" {
+		t.Errorf("current auth token = %q, want brz_current_agent — an expired rotation "+
+			"must not cost the agent its working credentials", persisted.AuthToken)
+	}
+}
+
+// secretsPathFor mirrors the config package's secrets-file layout for tests
+// that need to manipulate the file directly.
+func secretsPathFor(cfgPath string) string {
+	return filepath.Join(filepath.Dir(cfgPath), "secrets.yaml")
+}

--- a/agent/internal/heartbeat/token_rotation_test.go
+++ b/agent/internal/heartbeat/token_rotation_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -152,10 +153,90 @@ func TestTokenRotationDoesNotConfirmWhenPersistenceFails(t *testing.T) {
 			"the server would commit credentials the agent cannot reproduce after a restart (#2621)", confirm)
 	}
 
-	// The agent must still be using the credentials it can actually prove it has.
+	// THE load-bearing assertion. Pre-fix, handleTokenRotation called
+	// secureToken.Replace BEFORE config.Save and treated a save error as a log
+	// line, so this would read "brz_staged_agent". Do not weaken this to
+	// t.Errorf-and-continue or delete it as redundant — the confirm-count checks
+	// above are vacuous against the old code (it had no confirm endpoint at all),
+	// and this is what actually pins the bug.
 	if got := h.secureToken.Reveal(); got != "brz_current_agent" {
-		t.Errorf("in-memory token = %q, want brz_current_agent — the agent swapped to "+
-			"credentials it failed to persist", got)
+		t.Fatalf("in-memory token = %q, want brz_current_agent — the agent swapped to "+
+			"credentials it failed to persist (#2621)", got)
+	}
+}
+
+// A pre-#2621 server commits the rotation in the initial call and has no confirm
+// endpoint. Taking the two-phase path against it would be fatal: the confirm
+// 404s, the agent never promotes locally, and it keeps using a credential the
+// server has already demoted — stranded permanently once the grace lapses.
+func TestTokenRotationPromotesImmediatelyAgainstLegacyServer(t *testing.T) {
+	rs := &rotationServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agents/", func(w http.ResponseWriter, r *http.Request) {
+		if pathHasSuffix(r.URL.Path, "/rotate-token/confirm") {
+			rs.mu.Lock()
+			rs.confirmCalls++
+			rs.mu.Unlock()
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		rs.mu.Lock()
+		rs.rotateCalls++
+		rs.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		// No confirmationRequired: the legacy server already committed.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"authToken":         "brz_staged_agent",
+			"watchdogAuthToken": "brz_staged_watchdog",
+			"helperAuthToken":   "brz_staged_helper",
+			"rotatedAt":         "2026-07-19T00:00:00Z",
+		})
+	})
+	rs.Server = httptest.NewServer(mux)
+	t.Cleanup(rs.Close)
+
+	h, _ := newRotationTestHeartbeat(t, rs.URL)
+	h.handleTokenRotation()
+
+	if _, confirm := rs.counts(); confirm != 0 {
+		t.Errorf("confirm was called %d time(s) against a server that has no confirm phase", confirm)
+	}
+
+	persisted, err := config.ReadPersistedCredentials()
+	if err != nil {
+		t.Fatalf("ReadPersistedCredentials: %v", err)
+	}
+	if persisted.AuthToken != "brz_staged_agent" {
+		t.Errorf("persisted auth token = %q, want brz_staged_agent — against a legacy "+
+			"server the agent must promote locally or it strands itself", persisted.AuthToken)
+	}
+	if persisted.PendingAuthToken != "" {
+		t.Errorf("staged credentials were left behind: %q", persisted.PendingAuthToken)
+	}
+	if got := h.secureToken.Reveal(); got != "brz_staged_agent" {
+		t.Errorf("in-memory token = %q, want brz_staged_agent", got)
+	}
+}
+
+// The Helper runs as the logged-in user, cannot read the root-only secrets.yaml,
+// and reads helper_auth_token from agent.yaml. A promotion that only rewrote
+// secrets.yaml would leave it on the superseded token.
+func TestTokenRotationUpdatesHelperTokenInAgentYAML(t *testing.T) {
+	srv := newRotationServer(t)
+	h, cfgPath := newRotationTestHeartbeat(t, srv.URL)
+
+	h.handleTokenRotation()
+
+	agentYAML, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read agent.yaml: %v", err)
+	}
+	if !strings.Contains(string(agentYAML), "brz_staged_helper") {
+		t.Errorf("agent.yaml does not carry the rotated helper token — the Breeze Helper "+
+			"reads it from here and would 401 after the grace window:\n%s", agentYAML)
+	}
+	if strings.Contains(string(agentYAML), "brz_current_helper") {
+		t.Errorf("agent.yaml still carries the superseded helper token:\n%s", agentYAML)
 	}
 }
 

--- a/agent/pkg/api/client.go
+++ b/agent/pkg/api/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -32,14 +33,14 @@ type Client struct {
 }
 
 type EnrollRequest struct {
-	EnrollmentKey    string        `json:"enrollmentKey"`
-	EnrollmentSecret string        `json:"enrollmentSecret,omitempty"`
-	Hostname         string        `json:"hostname"`
-	OSType           string        `json:"osType"`
-	OSVersion        string        `json:"osVersion"`
-	Architecture     string        `json:"architecture"`
-	AgentVersion     string        `json:"agentVersion,omitempty"`
-	DeviceRole       string        `json:"deviceRole,omitempty"`
+	EnrollmentKey    string `json:"enrollmentKey"`
+	EnrollmentSecret string `json:"enrollmentSecret,omitempty"`
+	Hostname         string `json:"hostname"`
+	OSType           string `json:"osType"`
+	OSVersion        string `json:"osVersion"`
+	Architecture     string `json:"architecture"`
+	AgentVersion     string `json:"agentVersion,omitempty"`
+	DeviceRole       string `json:"deviceRole,omitempty"`
 	// IsVirtual / VirtualizationPlatform are the orthogonal "is this a VM and
 	// on what hypervisor" attribute (issue #1387), derived by the agent from
 	// the same hardware identity strings that drive DeviceRole. They are a
@@ -105,6 +106,21 @@ type RotateTokenResponse struct {
 	WatchdogAuthToken string `json:"watchdogAuthToken"`
 	HelperAuthToken   string `json:"helperAuthToken"`
 	RotatedAt         string `json:"rotatedAt"`
+	// Issue #2621 — set by two-phase-capable servers. The credentials above are
+	// STAGED: the server still treats the agent's previous set as current until
+	// ConfirmTokenRotation succeeds. The agent must durably persist and read
+	// back the new set BEFORE confirming.
+	ConfirmationRequired bool   `json:"confirmationRequired"`
+	PendingExpiresAt     string `json:"pendingExpiresAt"`
+}
+
+// ConfirmTokenRotationResponse is the reply to phase two of a rotation.
+type ConfirmTokenRotationResponse struct {
+	Confirmed      bool   `json:"confirmed"`
+	AlreadyCurrent bool   `json:"alreadyCurrent"`
+	ConfirmedAt    string `json:"confirmedAt"`
+	Error          string `json:"error"`
+	Code           string `json:"code"`
 }
 
 type AgentConfig struct {
@@ -317,6 +333,50 @@ func (c *Client) RotateToken() (*RotateTokenResponse, error) {
 	var result RotateTokenResponse
 	if err := json.Unmarshal(bodyBytes, &result); err != nil {
 		return nil, fmt.Errorf("failed to decode rotate-token response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ErrPendingRotationExpired reports that the staged credential set died before
+// the agent could confirm it. The caller must fall back to its durable
+// credentials and start a fresh rotation.
+var ErrPendingRotationExpired = errors.New("pending rotation expired")
+
+// ConfirmTokenRotation completes phase two of a two-phase rotation. It MUST be
+// called on a client built with the NEW (staged) agent token — the server treats
+// possession of that token as the endpoint's proof that the credential was
+// durably persisted, and only then promotes it to current.
+func (c *Client) ConfirmTokenRotation() (*ConfirmTokenRotationResponse, error) {
+	url := fmt.Sprintf("%s/api/v1/agents/%s/rotate-token/confirm", c.baseURL, c.agentID)
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create rotate-token confirm request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.authToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send rotate-token confirm request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read rotate-token confirm response body: %w", err)
+	}
+
+	var result ConfirmTokenRotationResponse
+	// Decode before the status check: the 409 body carries the machine-readable
+	// code that tells us whether retrying can ever succeed.
+	_ = json.Unmarshal(bodyBytes, &result)
+
+	if resp.StatusCode != http.StatusOK {
+		if result.Code == "pending_rotation_expired" {
+			return nil, ErrPendingRotationExpired
+		}
+		return nil, fmt.Errorf("rotate-token confirm failed with status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
 	return &result, nil

--- a/agent/pkg/api/client.go
+++ b/agent/pkg/api/client.go
@@ -360,7 +360,7 @@ func (c *Client) ConfirmTokenRotation() (*ConfirmTokenRotationResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to send rotate-token confirm request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -374,6 +374,15 @@ func (c *Client) ConfirmTokenRotation() (*ConfirmTokenRotationResponse, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		if result.Code == "pending_rotation_expired" {
+			return nil, ErrPendingRotationExpired
+		}
+		// A 401 here means the server would not accept the STAGED token at all —
+		// it expired (auth rejects an expired pending hash before this route ever
+		// runs, so the code above is not reachable in that case), or it was
+		// revoked by an admin rotation or re-enrollment. Either way it can never
+		// be promoted, so treat it as expired and stop retrying. This is safe:
+		// the agent's current credentials are untouched by a failed confirm.
+		if resp.StatusCode == http.StatusUnauthorized {
 			return nil, ErrPendingRotationExpired
 		}
 		return nil, fmt.Errorf("rotate-token confirm failed with status %d: %s", resp.StatusCode, string(bodyBytes))

--- a/apps/api/migrations/2026-08-03-agent-token-pending-rotation.sql
+++ b/apps/api/migrations/2026-08-03-agent-token-pending-rotation.sql
@@ -1,0 +1,33 @@
+-- Issue #2621 — two-phase agent credential rotation (persist-before-commit).
+--
+-- Before this migration, POST /agents/:id/rotate-token minted new agent,
+-- watchdog and helper credentials AND committed their hashes as current in a
+-- single UPDATE. The agent only afterwards attempted to write the plaintext to
+-- secrets.yaml. A failed disk write left the server holding hashes the endpoint
+-- could not reproduce: the agent kept running on in-memory credentials, then
+-- loaded stale ones from disk on restart and 401'd forever once the 5-minute
+-- previous-token grace window expired.
+--
+-- These columns let rotation stage the new hashes as PENDING while the current
+-- credentials stay fully valid. The agent durably persists + reads back the new
+-- plaintext, then calls /rotate-token/confirm authenticated WITH the new token
+-- (proof it holds a durable copy) to promote pending -> current. An abandoned
+-- rotation simply expires and the last known durable credentials stay
+-- authoritative, so a disk failure can no longer strand the endpoint.
+
+ALTER TABLE devices
+  ADD COLUMN IF NOT EXISTS pending_token_hash varchar(64),
+  ADD COLUMN IF NOT EXISTS pending_watchdog_token_hash varchar(64),
+  ADD COLUMN IF NOT EXISTS pending_helper_token_hash varchar(64),
+  ADD COLUMN IF NOT EXISTS pending_token_expires_at timestamptz;
+
+COMMENT ON COLUMN devices.pending_token_hash IS
+  'Issue #2621: staged agent-token hash from a two-phase rotation. Accepted for auth until pending_token_expires_at; promoted to agent_token_hash only once the agent confirms durable persistence.';
+COMMENT ON COLUMN devices.pending_token_expires_at IS
+  'Issue #2621: expiry for the staged (pending) agent/watchdog/helper token hashes. After this instant an unconfirmed rotation is dead and the current credentials remain authoritative.';
+
+-- Partial index: the auth path only probes rows with a live staged rotation,
+-- which is a vanishingly small slice of the fleet at any instant.
+CREATE INDEX IF NOT EXISTS devices_pending_token_expires_at_idx
+  ON devices (pending_token_expires_at)
+  WHERE pending_token_hash IS NOT NULL;

--- a/apps/api/src/db/schema/devices.ts
+++ b/apps/api/src/db/schema/devices.ts
@@ -27,6 +27,13 @@ export const devices = pgTable('devices', {
   helperTokenIssuedAt: timestamp('helper_token_issued_at', { withTimezone: true }),
   previousHelperTokenHash: varchar('previous_helper_token_hash', { length: 64 }),
   previousHelperTokenExpiresAt: timestamp('previous_helper_token_expires_at', { withTimezone: true }),
+  // Issue #2621 — staged credentials for a two-phase rotation. These hashes are
+  // accepted for auth while pending, but only become current once the agent
+  // confirms it durably persisted the matching plaintext.
+  pendingTokenHash: varchar('pending_token_hash', { length: 64 }),
+  pendingWatchdogTokenHash: varchar('pending_watchdog_token_hash', { length: 64 }),
+  pendingHelperTokenHash: varchar('pending_helper_token_hash', { length: 64 }),
+  pendingTokenExpiresAt: timestamp('pending_token_expires_at', { withTimezone: true }),
   mtlsCertSerialNumber: varchar('mtls_cert_serial_number', { length: 128 }),
   mtlsCertExpiresAt: timestamp('mtls_cert_expires_at'),
   mtlsCertIssuedAt: timestamp('mtls_cert_issued_at'),

--- a/apps/api/src/middleware/agentAuth.test.ts
+++ b/apps/api/src/middleware/agentAuth.test.ts
@@ -81,7 +81,7 @@ describe('matchAgentTokenHash', () => {
       tokenHash: sha('brz_current'),
     });
 
-    expect(result).toEqual({ tokenRotationRequired: false });
+    expect(result).toEqual({ tokenRotationRequired: false, pendingTokenPresented: false });
   });
 
   it('matches the previous token hash only while the grace window is active', () => {
@@ -93,7 +93,7 @@ describe('matchAgentTokenHash', () => {
       now: new Date('2026-03-31T18:00:00Z'),
     });
 
-    expect(result).toEqual({ tokenRotationRequired: true });
+    expect(result).toEqual({ tokenRotationRequired: true, pendingTokenPresented: false });
   });
 
   it('rejects the previous token once the grace window expires', () => {
@@ -102,6 +102,53 @@ describe('matchAgentTokenHash', () => {
       previousTokenHash: sha('brz_previous'),
       previousTokenExpiresAt: new Date('2026-03-31T17:59:00Z'),
       tokenHash: sha('brz_previous'),
+      now: new Date('2026-03-31T18:00:00Z'),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  // Issue #2621 — the staged credential of an unconfirmed rotation must
+  // authenticate. This is what keeps an agent alive if it crashes after writing
+  // the new credentials to disk but before confirming them.
+  it('accepts a live pending token and flags it as such', () => {
+    const result = matchAgentTokenHash({
+      agentTokenHash: sha('brz_current'),
+      previousTokenHash: null,
+      previousTokenExpiresAt: null,
+      pendingTokenHash: sha('brz_pending'),
+      pendingTokenExpiresAt: new Date('2026-03-31T19:00:00Z'),
+      tokenHash: sha('brz_pending'),
+      now: new Date('2026-03-31T18:00:00Z'),
+    });
+
+    expect(result).toEqual({ tokenRotationRequired: false, pendingTokenPresented: true });
+  });
+
+  // The current credential stays fully valid for the whole pending window —
+  // that is the property that makes a failed/abandoned rotation harmless.
+  it('still accepts the current token while a rotation is staged', () => {
+    const result = matchAgentTokenHash({
+      agentTokenHash: sha('brz_current'),
+      previousTokenHash: null,
+      previousTokenExpiresAt: null,
+      pendingTokenHash: sha('brz_pending'),
+      pendingTokenExpiresAt: new Date('2026-03-31T19:00:00Z'),
+      tokenHash: sha('brz_current'),
+      now: new Date('2026-03-31T18:00:00Z'),
+    });
+
+    expect(result).toEqual({ tokenRotationRequired: false, pendingTokenPresented: false });
+  });
+
+  it('rejects a pending token once the staging window expires', () => {
+    const result = matchAgentTokenHash({
+      agentTokenHash: sha('brz_current'),
+      previousTokenHash: null,
+      previousTokenExpiresAt: null,
+      pendingTokenHash: sha('brz_pending'),
+      pendingTokenExpiresAt: new Date('2026-03-31T17:59:00Z'),
+      tokenHash: sha('brz_pending'),
       now: new Date('2026-03-31T18:00:00Z'),
     });
 
@@ -121,7 +168,7 @@ describe('matchRoleScopedAgentTokenHash', () => {
       tokenHash: sha('brz_agent'),
     });
 
-    expect(result).toEqual({ role: 'agent', tokenRotationRequired: false });
+    expect(result).toEqual({ role: 'agent', tokenRotationRequired: false, pendingTokenPresented: false });
   });
 
   it('returns watchdog role for watchdog-scoped tokens', () => {
@@ -135,7 +182,7 @@ describe('matchRoleScopedAgentTokenHash', () => {
       tokenHash: sha('brz_watchdog'),
     });
 
-    expect(result).toEqual({ role: 'watchdog', tokenRotationRequired: false });
+    expect(result).toEqual({ role: 'watchdog', tokenRotationRequired: false, pendingTokenPresented: false });
   });
 });
 

--- a/apps/api/src/middleware/agentAuth.ts
+++ b/apps/api/src/middleware/agentAuth.ts
@@ -38,6 +38,8 @@ declare module 'hono' {
   interface ContextVariableMap {
     agent: AgentAuthContext;
     agentTokenRotationRequired: boolean;
+    /** Issue #2621 — caller authenticated with a staged (pending) rotation credential. */
+    agentPendingTokenPresented: boolean;
   }
 }
 
@@ -81,19 +83,38 @@ export function matchAgentTokenHash(params: {
   agentTokenHash: string | null | undefined;
   previousTokenHash: string | null | undefined;
   previousTokenExpiresAt: Date | null | undefined;
+  pendingTokenHash?: string | null | undefined;
+  pendingTokenExpiresAt?: Date | null | undefined;
   tokenHash: string;
   now?: Date;
-}): { tokenRotationRequired: boolean } | null {
+}): { tokenRotationRequired: boolean; pendingTokenPresented: boolean } | null {
   const {
     agentTokenHash,
     previousTokenHash,
     previousTokenExpiresAt,
+    pendingTokenHash,
+    pendingTokenExpiresAt,
     tokenHash,
     now = new Date(),
   } = params;
 
   if (agentTokenHash && tokenHashMatches(agentTokenHash, tokenHash)) {
-    return { tokenRotationRequired: false };
+    return { tokenRotationRequired: false, pendingTokenPresented: false };
+  }
+
+  // Issue #2621 — a staged (pending) credential authenticates for real while the
+  // rotation is unconfirmed. This is what makes two-phase rotation crash-safe:
+  // between the agent's durable disk write and its confirm call, EITHER
+  // credential on disk is accepted, so a crash at any point in that window
+  // cannot strand the endpoint. Presenting it is also proof the agent holds the
+  // new token, which /rotate-token/confirm converts into a promotion.
+  if (
+    pendingTokenHash &&
+    pendingTokenExpiresAt &&
+    pendingTokenExpiresAt > now &&
+    tokenHashMatches(pendingTokenHash, tokenHash)
+  ) {
+    return { tokenRotationRequired: false, pendingTokenPresented: true };
   }
 
   if (
@@ -102,7 +123,7 @@ export function matchAgentTokenHash(params: {
     previousTokenExpiresAt > now &&
     tokenHashMatches(previousTokenHash, tokenHash)
   ) {
-    return { tokenRotationRequired: true };
+    return { tokenRotationRequired: true, pendingTokenPresented: false };
   }
 
   return null;
@@ -115,9 +136,12 @@ export function matchRoleScopedAgentTokenHash(params: {
   watchdogTokenHash: string | null | undefined;
   previousWatchdogTokenHash: string | null | undefined;
   previousWatchdogTokenExpiresAt: Date | null | undefined;
+  pendingTokenHash?: string | null | undefined;
+  pendingWatchdogTokenHash?: string | null | undefined;
+  pendingTokenExpiresAt?: Date | null | undefined;
   tokenHash: string;
   now?: Date;
-}): ({ role: AgentCredentialRole; tokenRotationRequired: boolean }) | null {
+}): ({ role: AgentCredentialRole; tokenRotationRequired: boolean; pendingTokenPresented: boolean }) | null {
   const {
     agentTokenHash,
     previousTokenHash,
@@ -125,6 +149,9 @@ export function matchRoleScopedAgentTokenHash(params: {
     watchdogTokenHash,
     previousWatchdogTokenHash,
     previousWatchdogTokenExpiresAt,
+    pendingTokenHash,
+    pendingWatchdogTokenHash,
+    pendingTokenExpiresAt,
     tokenHash,
     now = new Date(),
   } = params;
@@ -133,22 +160,36 @@ export function matchRoleScopedAgentTokenHash(params: {
     agentTokenHash,
     previousTokenHash,
     previousTokenExpiresAt,
+    pendingTokenHash,
+    pendingTokenExpiresAt,
     tokenHash,
     now,
   });
   if (agentMatch) {
-    return { role: 'agent', tokenRotationRequired: agentMatch.tokenRotationRequired };
+    return {
+      role: 'agent',
+      tokenRotationRequired: agentMatch.tokenRotationRequired,
+      pendingTokenPresented: agentMatch.pendingTokenPresented,
+    };
   }
 
   const watchdogMatch = matchAgentTokenHash({
     agentTokenHash: watchdogTokenHash,
     previousTokenHash: previousWatchdogTokenHash,
     previousTokenExpiresAt: previousWatchdogTokenExpiresAt,
+    // The watchdog's staged credential shares the agent rotation's expiry —
+    // both are minted and promoted by the same two-phase rotation.
+    pendingTokenHash: pendingWatchdogTokenHash,
+    pendingTokenExpiresAt,
     tokenHash,
     now,
   });
   if (watchdogMatch) {
-    return { role: 'watchdog', tokenRotationRequired: watchdogMatch.tokenRotationRequired };
+    return {
+      role: 'watchdog',
+      tokenRotationRequired: watchdogMatch.tokenRotationRequired,
+      pendingTokenPresented: watchdogMatch.pendingTokenPresented,
+    };
   }
 
   return null;
@@ -250,6 +291,9 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
         watchdogTokenHash: devices.watchdogTokenHash,
         previousWatchdogTokenHash: devices.previousWatchdogTokenHash,
         previousWatchdogTokenExpiresAt: devices.previousWatchdogTokenExpiresAt,
+        pendingTokenHash: devices.pendingTokenHash,
+        pendingWatchdogTokenHash: devices.pendingWatchdogTokenHash,
+        pendingTokenExpiresAt: devices.pendingTokenExpiresAt,
         status: devices.status,
         agentTokenSuspendedAt: devices.agentTokenSuspendedAt,
         hostname: devices.hostname,
@@ -292,6 +336,9 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
     watchdogTokenHash: device.watchdogTokenHash,
     previousWatchdogTokenHash: device.previousWatchdogTokenHash,
     previousWatchdogTokenExpiresAt: device.previousWatchdogTokenExpiresAt,
+    pendingTokenHash: device.pendingTokenHash,
+    pendingWatchdogTokenHash: device.pendingWatchdogTokenHash,
+    pendingTokenExpiresAt: device.pendingTokenExpiresAt,
     tokenHash,
   });
   if (!match) {
@@ -425,6 +472,10 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
     c.header('x-token-rotation-required', 'true');
   }
   c.set('agentTokenRotationRequired', match.tokenRotationRequired);
+  // Issue #2621 — true when the caller authenticated with the STAGED credential
+  // of an unconfirmed rotation. /rotate-token/confirm treats this as proof the
+  // agent holds a durable copy of the new token and promotes pending->current.
+  c.set('agentPendingTokenPresented', match.pendingTokenPresented);
 
   c.set('agent', {
     deviceId: device.id,

--- a/apps/api/src/middleware/helperAuth.ts
+++ b/apps/api/src/middleware/helperAuth.ts
@@ -63,12 +63,22 @@ export const helperAuth: MiddlewareHandler = async (c, next) => {
         helperTokenHash: devices.helperTokenHash,
         previousHelperTokenHash: devices.previousHelperTokenHash,
         previousHelperTokenExpiresAt: devices.previousHelperTokenExpiresAt,
+        pendingHelperTokenHash: devices.pendingHelperTokenHash,
+        pendingTokenExpiresAt: devices.pendingTokenExpiresAt,
         status: devices.status,
         partnerId: organizations.partnerId,
       })
       .from(devices)
       .innerJoin(organizations, eq(organizations.id, devices.orgId))
-      .where(or(eq(devices.helperTokenHash, tokenHash), eq(devices.previousHelperTokenHash, tokenHash)))
+      // Issue #2621 — the staged helper credential must be findable here too,
+      // otherwise a helper holding the persisted-but-unconfirmed token 401s.
+      .where(
+        or(
+          eq(devices.helperTokenHash, tokenHash),
+          eq(devices.previousHelperTokenHash, tokenHash),
+          eq(devices.pendingHelperTokenHash, tokenHash)
+        )
+      )
       .limit(1);
     return row ?? null;
   });
@@ -78,6 +88,8 @@ export const helperAuth: MiddlewareHandler = async (c, next) => {
         agentTokenHash: device.helperTokenHash,
         previousTokenHash: device.previousHelperTokenHash,
         previousTokenExpiresAt: device.previousHelperTokenExpiresAt,
+        pendingTokenHash: device.pendingHelperTokenHash,
+        pendingTokenExpiresAt: device.pendingTokenExpiresAt,
         tokenHash,
       })
     : null;

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -885,6 +885,9 @@ export async function validateAgentToken(agentId: string, token: string): Promis
         watchdogTokenHash: devices.watchdogTokenHash,
         previousWatchdogTokenHash: devices.previousWatchdogTokenHash,
         previousWatchdogTokenExpiresAt: devices.previousWatchdogTokenExpiresAt,
+        pendingTokenHash: devices.pendingTokenHash,
+        pendingWatchdogTokenHash: devices.pendingWatchdogTokenHash,
+        pendingTokenExpiresAt: devices.pendingTokenExpiresAt,
         status: devices.status,
         agentTokenSuspendedAt: devices.agentTokenSuspendedAt,
       })
@@ -926,6 +929,13 @@ export async function validateAgentToken(agentId: string, token: string): Promis
     watchdogTokenHash: device.watchdogTokenHash,
     previousWatchdogTokenHash: device.previousWatchdogTokenHash,
     previousWatchdogTokenExpiresAt: device.previousWatchdogTokenExpiresAt,
+    // Issue #2621 — an agent that persisted a staged rotation and restarted
+    // before confirming reconnects with the staged token. The WS path must
+    // accept it, or the control channel dies in exactly the crash window the
+    // two-phase design exists to make survivable.
+    pendingTokenHash: device.pendingTokenHash,
+    pendingWatchdogTokenHash: device.pendingWatchdogTokenHash,
+    pendingTokenExpiresAt: device.pendingTokenExpiresAt,
     tokenHash,
   });
   if (!match || match.role !== 'agent') {

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -641,6 +641,14 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
             previousWatchdogTokenExpiresAt: null,
             previousHelperTokenHash: null,
             previousHelperTokenExpiresAt: null,
+            // Issue #2621 — re-enrollment is a full credential reset, so it must
+            // also drop any staged rotation. Leaving it would let a staged set
+            // minted before the re-enrollment keep authenticating, and be
+            // promoted over the freshly issued credentials.
+            pendingTokenHash: null,
+            pendingWatchdogTokenHash: null,
+            pendingHelperTokenHash: null,
+            pendingTokenExpiresAt: null,
             deviceRole: data.deviceRole || 'unknown',
             deviceRoleSource: 'auto',
             isVirtual: data.isVirtual ?? false,

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -935,8 +935,20 @@ if (latestHelper) {
   }
 
   const authenticatedWithPreviousToken = c.get('agentTokenRotationRequired') === true;
+
+  // Issue #2621 — a staged rotation is still outstanding. Don't ask for another
+  // one (that would churn the staged set and re-open the divergence window);
+  // ask the agent to finish the one it has. This is also the recovery path for
+  // an agent that persisted the new credentials and then crashed before
+  // confirming: it reconnects on the staged token and gets told to confirm.
+  const pendingRotationLive =
+    !!device.pendingTokenHash &&
+    !!device.pendingTokenExpiresAt &&
+    device.pendingTokenExpiresAt > new Date();
+
   const rotateToken =
     !authenticatedWithPreviousToken &&
+    !pendingRotationLive &&
     (!device.watchdogTokenHash || isAgentTokenRotationDue(device.tokenIssuedAt));
 
   let manageRemoteManagement = false;
@@ -966,6 +978,11 @@ if (latestHelper) {
       watchdogUpgradeTo: watchdogUpgradeTo ?? undefined,
       renewCert: renewCert || undefined,
       rotateToken: rotateToken || undefined,
+      // Issue #2621 — set when the caller authenticated with the STAGED
+      // credential, i.e. it demonstrably holds the new token but never
+      // confirmed. Tells the agent to call /rotate-token/confirm and finish.
+      confirmTokenRotation:
+        (pendingRotationLive && c.get('agentPendingTokenPresented') === true) || undefined,
       helperEnabled: helperSettings?.enabled ?? false,
       helperSettings: helperSettings ?? undefined,
       // Opt-in default: a null pamSettings (resolver error, logged above) sends

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -11,6 +11,7 @@ import {
   onedriveDeviceState,
 } from '../../db/schema';
 import type { BatteryStatus } from '@breeze/shared';
+import { promotePendingAgentCredentials } from '../../services/agentTokenPromotion';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { heartbeatSchema } from './schemas';
 import type { PolicyProbeConfigUpdate } from './schemas';
@@ -941,10 +942,41 @@ if (latestHelper) {
   // ask the agent to finish the one it has. This is also the recovery path for
   // an agent that persisted the new credentials and then crashed before
   // confirming: it reconnects on the staged token and gets told to confirm.
-  const pendingRotationLive =
+  let pendingRotationLive =
     !!device.pendingTokenHash &&
     !!device.pendingTokenExpiresAt &&
     device.pendingTokenExpiresAt > new Date();
+
+  // Issue #2621 — IMPLICIT PROMOTION. The agent is authenticating with the
+  // staged credential, which is the same proof of durable possession that
+  // /rotate-token/confirm requires, so promote it here too.
+  //
+  // This is what keeps PRE-#2621 agents alive. An old agent overwrites its own
+  // token file on rotation and never calls confirm; without this it would run on
+  // the pending hash until the staging window closed and then be locked out
+  // permanently, with no way to self-heal (rotateToken is suppressed while a
+  // rotation is staged, and after expiry it can no longer authenticate at all).
+  // It also backstops a current agent whose confirm response was lost in flight.
+  if (pendingRotationLive && c.get('agentPendingTokenPresented') === true && device.agentTokenHash) {
+    try {
+      const promoted = await promotePendingAgentCredentials({
+        deviceId: device.id,
+        pendingTokenHash: device.pendingTokenHash!,
+        expectedAgentTokenHash: device.agentTokenHash,
+        pendingWatchdogTokenHash: device.pendingWatchdogTokenHash,
+        pendingHelperTokenHash: device.pendingHelperTokenHash,
+        watchdogTokenHash: device.watchdogTokenHash,
+        helperTokenHash: device.helperTokenHash,
+      });
+      if (promoted) {
+        pendingRotationLive = false;
+      }
+    } catch (err) {
+      // Best-effort: the staged credential still authenticates for the rest of
+      // its window, and confirm/the next heartbeat will retry the promotion.
+      console.error('[heartbeat] implicit pending-rotation promotion failed:', err);
+    }
+  }
 
   const rotateToken =
     !authenticatedWithPreviousToken &&

--- a/apps/api/src/routes/agents/mtls.ts
+++ b/apps/api/src/routes/agents/mtls.ts
@@ -173,6 +173,12 @@ mtlsRoutes.post('/renew-cert', async (c) => {
     return row ?? null;
   });
 
+  // Issue #2621 — deliberately NOT passing pendingTokenHash here. Staged
+  // credentials from an unconfirmed rotation authenticate for ordinary agent
+  // traffic, but this route mints fresh cert material and stays fail-closed on
+  // the CURRENT token only (same rationale as the superseded-token rejection
+  // below). A legitimate agent confirms its rotation on the next request and
+  // renews immediately after; the pending set is never the long-term identity.
   const match = device
     ? matchAgentTokenHash({
         agentTokenHash: device.agentTokenHash,

--- a/apps/api/src/routes/agents/token.test.ts
+++ b/apps/api/src/routes/agents/token.test.ts
@@ -30,6 +30,10 @@ vi.mock('../../db/schema', () => ({
     helperTokenIssuedAt: 'helperTokenIssuedAt',
     previousHelperTokenHash: 'previousHelperTokenHash',
     previousHelperTokenExpiresAt: 'previousHelperTokenExpiresAt',
+    pendingTokenHash: 'pendingTokenHash',
+    pendingWatchdogTokenHash: 'pendingWatchdogTokenHash',
+    pendingHelperTokenHash: 'pendingHelperTokenHash',
+    pendingTokenExpiresAt: 'pendingTokenExpiresAt',
     updatedAt: 'updatedAt',
   },
 }));
@@ -60,6 +64,8 @@ const CURRENT_AGENT_TOKEN_HASH = 'current-agent-token-hash';
 
 function buildApp(opts?: {
   rotationRequired?: boolean;
+  /** Issue #2621 — caller authenticated with a staged (pending) credential. */
+  pendingTokenPresented?: boolean;
   authTokenHash?: string;
   // Force the middleware to set an agent context with NO authTokenHash, so the
   // fail-closed `if (!authTokenHash) return 401` guard becomes reachable. The
@@ -80,6 +86,7 @@ function buildApp(opts?: {
         : (opts?.authTokenHash ?? CURRENT_AGENT_TOKEN_HASH),
     });
     c.set('agentTokenRotationRequired', opts?.rotationRequired ?? false);
+    c.set('agentPendingTokenPresented', opts?.pendingTokenPresented ?? false);
     await next();
   });
   app.route('/agents', tokenRoutes);
@@ -122,7 +129,11 @@ describe('agent token rotation route', () => {
     vi.useRealTimers();
   });
 
-  it('rotates the token and returns the new plaintext token', async () => {
+  // Issue #2621 — rotation STAGES the new credentials. It must not touch the
+  // current agent/watchdog/helper hashes: those stay authoritative until the
+  // agent proves it durably persisted the replacements. Committing here is what
+  // stranded agents whose config.Save failed.
+  it('stages the new credentials without committing them as current', async () => {
     vi.mocked(generateApiKey)
       .mockReturnValueOnce('brz_rotated_agent_token')
       .mockReturnValueOnce('brz_rotated_watchdog_token')
@@ -144,6 +155,8 @@ describe('agent token rotation route', () => {
       watchdogAuthToken: 'brz_rotated_watchdog_token',
       helperAuthToken: 'brz_rotated_helper_token',
       rotatedAt: '2026-03-31T18:45:00.000Z',
+      confirmationRequired: true,
+      pendingExpiresAt: '2026-03-31T19:45:00.000Z',
     });
 
     // The UPDATE is compare-and-swapped against the hash that authenticated
@@ -153,21 +166,26 @@ describe('agent token rotation route', () => {
 
     expect(generateApiKey).toHaveBeenCalledTimes(3);
     expect(set).toHaveBeenCalledWith({
-      // previousTokenHash snapshots the authenticating (current-at-rotation) hash.
-      previousTokenHash: CURRENT_AGENT_TOKEN_HASH,
-      previousTokenExpiresAt: new Date('2026-03-31T18:50:00.000Z'),
-      agentTokenHash: createHash('sha256').update('brz_rotated_agent_token').digest('hex'),
-      tokenIssuedAt: new Date('2026-03-31T18:45:00.000Z'),
-      previousWatchdogTokenHash: 'old-watchdog-token-hash',
-      previousWatchdogTokenExpiresAt: new Date('2026-03-31T18:50:00.000Z'),
-      watchdogTokenHash: createHash('sha256').update('brz_rotated_watchdog_token').digest('hex'),
-      watchdogTokenIssuedAt: new Date('2026-03-31T18:45:00.000Z'),
-      previousHelperTokenHash: 'old-helper-token-hash',
-      previousHelperTokenExpiresAt: new Date('2026-03-31T18:50:00.000Z'),
-      helperTokenHash: createHash('sha256').update('brz_rotated_helper_token').digest('hex'),
-      helperTokenIssuedAt: new Date('2026-03-31T18:45:00.000Z'),
+      pendingTokenHash: createHash('sha256').update('brz_rotated_agent_token').digest('hex'),
+      pendingWatchdogTokenHash: createHash('sha256').update('brz_rotated_watchdog_token').digest('hex'),
+      pendingHelperTokenHash: createHash('sha256').update('brz_rotated_helper_token').digest('hex'),
+      pendingTokenExpiresAt: new Date('2026-03-31T19:45:00.000Z'),
       updatedAt: new Date('2026-03-31T18:45:00.000Z'),
     });
+
+    // Explicitly assert the fields that MUST NOT move during staging. If any of
+    // these ever reappear here, the persist-before-commit ordering is broken and
+    // #2621 is back.
+    const staged = (set.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]![0];
+    for (const forbidden of [
+      'agentTokenHash',
+      'watchdogTokenHash',
+      'helperTokenHash',
+      'previousTokenHash',
+      'tokenIssuedAt',
+    ]) {
+      expect(staged).not.toHaveProperty(forbidden);
+    }
 
     expect(writeAuditEvent).toHaveBeenCalledWith(
       expect.anything(),
@@ -175,16 +193,30 @@ describe('agent token rotation route', () => {
         orgId: 'org-1',
         actorType: 'agent',
         actorId: 'agent-123',
-        action: 'agent.token.rotate',
+        action: 'agent.token.rotate.staged',
         resourceType: 'device',
         resourceId: 'device-1',
         resourceName: 'host-1',
         details: {
-          rotatedAt: '2026-03-31T18:45:00.000Z',
-          previousTokenGracePeriodSeconds: 300,
+          stagedAt: '2026-03-31T18:45:00.000Z',
+          pendingExpiresAt: '2026-03-31T19:45:00.000Z',
         },
       })
     );
+  });
+
+  it('refuses to start a new rotation while one is staged but unconfirmed', async () => {
+    const response = await buildApp({ pendingTokenPresented: true }).request(
+      '/agents/agent-123/rotate-token',
+      { method: 'POST' }
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Confirm the pending rotation before starting a new one',
+      code: 'pending_rotation_unconfirmed',
+    });
+    expect(db.update).not.toHaveBeenCalled();
   });
 
   it('returns 404 when the authenticated device record is not found', async () => {
@@ -299,5 +331,151 @@ describe('agent token rotation route', () => {
     expect(writeAuditEvent).not.toHaveBeenCalled();
 
     consoleWarn.mockRestore();
+  });
+});
+
+// Issue #2621 — phase two. Promotion is gated on the agent presenting the
+// STAGED token, which is the endpoint's proof that it durably persisted the
+// credential. Without that gate the server would again be committing hashes on
+// faith, which is the original bug.
+describe('agent token rotation confirm route', () => {
+  const PENDING_HASH = 'pending-agent-token-hash';
+
+  function mockDevice(overrides: Record<string, unknown> = {}) {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue([
+            {
+              id: 'device-1',
+              hostname: 'host-1',
+              agentTokenHash: 'old-token-hash',
+              watchdogTokenHash: 'old-watchdog-token-hash',
+              helperTokenHash: 'old-helper-token-hash',
+              pendingTokenHash: PENDING_HASH,
+              pendingWatchdogTokenHash: 'pending-watchdog-token-hash',
+              pendingHelperTokenHash: 'pending-helper-token-hash',
+              pendingTokenExpiresAt: new Date('2026-03-31T19:45:00.000Z'),
+              ...overrides,
+            },
+          ]),
+        })),
+      })),
+    } as any);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-31T18:45:00.000Z'));
+    mockDevice();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('promotes the staged credentials when the caller presents the staged token', async () => {
+    const where = vi.fn(() => ({
+      returning: vi.fn().mockResolvedValue([{ id: 'device-1' }]),
+    }));
+    const set = vi.fn(() => ({ where }));
+    vi.mocked(db.update).mockReturnValue({ set } as any);
+
+    const response = await buildApp({ authTokenHash: PENDING_HASH }).request(
+      '/agents/agent-123/rotate-token/confirm',
+      { method: 'POST' }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      confirmed: true,
+      confirmedAt: '2026-03-31T18:45:00.000Z',
+    });
+
+    expect(set).toHaveBeenCalledWith({
+      previousTokenHash: 'old-token-hash',
+      previousTokenExpiresAt: new Date('2026-03-31T18:50:00.000Z'),
+      agentTokenHash: PENDING_HASH,
+      tokenIssuedAt: new Date('2026-03-31T18:45:00.000Z'),
+      previousWatchdogTokenHash: 'old-watchdog-token-hash',
+      previousWatchdogTokenExpiresAt: new Date('2026-03-31T18:50:00.000Z'),
+      watchdogTokenHash: 'pending-watchdog-token-hash',
+      watchdogTokenIssuedAt: new Date('2026-03-31T18:45:00.000Z'),
+      previousHelperTokenHash: 'old-helper-token-hash',
+      previousHelperTokenExpiresAt: new Date('2026-03-31T18:50:00.000Z'),
+      helperTokenHash: 'pending-helper-token-hash',
+      helperTokenIssuedAt: new Date('2026-03-31T18:45:00.000Z'),
+      pendingTokenHash: null,
+      pendingWatchdogTokenHash: null,
+      pendingHelperTokenHash: null,
+      pendingTokenExpiresAt: null,
+      updatedAt: new Date('2026-03-31T18:45:00.000Z'),
+    });
+
+    // The promotion CAS binds to the staged hash so a stale confirm cannot
+    // promote a credential set that has since been re-staged.
+    expect(eq).toHaveBeenCalledWith('pendingTokenHash', PENDING_HASH);
+
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'agent.token.rotate.confirmed' })
+    );
+  });
+
+  // A confirm arriving on the OLD token proves nothing about what the endpoint
+  // wrote to disk. Promoting on it would recreate #2621 exactly.
+  it('refuses to promote when the caller presents the current (not staged) token', async () => {
+    const response = await buildApp({ authTokenHash: 'old-token-hash' }).request(
+      '/agents/agent-123/rotate-token/confirm',
+      { method: 'POST' }
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Confirm must be sent with the pending rotation token',
+      code: 'pending_token_required',
+    });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses to promote an expired staged set', async () => {
+    mockDevice({ pendingTokenExpiresAt: new Date('2026-03-31T18:00:00.000Z') });
+
+    const response = await buildApp({ authTokenHash: PENDING_HASH }).request(
+      '/agents/agent-123/rotate-token/confirm',
+      { method: 'POST' }
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Pending rotation has expired; request a new rotation',
+      code: 'pending_rotation_expired',
+    });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  // The agent retries confirmation until it succeeds. A retry whose predecessor
+  // actually landed must read as success, or a healthy device retries forever.
+  it('is idempotent when the rotation was already promoted', async () => {
+    mockDevice({
+      agentTokenHash: PENDING_HASH,
+      pendingTokenHash: null,
+      pendingWatchdogTokenHash: null,
+      pendingHelperTokenHash: null,
+      pendingTokenExpiresAt: null,
+    });
+
+    const response = await buildApp({ authTokenHash: PENDING_HASH }).request(
+      '/agents/agent-123/rotate-token/confirm',
+      { method: 'POST' }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      confirmed: true,
+      alreadyCurrent: true,
+    });
+    expect(db.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/agents/token.ts
+++ b/apps/api/src/routes/agents/token.ts
@@ -10,6 +10,18 @@ import { generateApiKey } from './helpers';
 
 export const tokenRoutes = new Hono();
 
+/**
+ * Issue #2621 — how long a staged (pending) credential set stays usable before
+ * an unconfirmed rotation is abandoned. Generous on purpose: the window has to
+ * cover an agent that persisted the new credentials and then lost connectivity
+ * or crashed before it could confirm. Until it elapses BOTH the current and the
+ * staged credentials authenticate, so no crash point can strand the endpoint.
+ */
+const PENDING_ROTATION_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+/** Grace window the superseded credential keeps after a confirmed promotion. */
+const PREVIOUS_TOKEN_GRACE_MS = 5 * 60 * 1000;
+
 tokenRoutes.post('/:id/rotate-token', async (c) => {
   const agentId = c.req.param('id');
   const agent = c.get('agent') as AgentAuthContext;
@@ -27,6 +39,18 @@ tokenRoutes.post('/:id/rotate-token', async (c) => {
     return c.json(
       { error: 'Rotate using the current token; superseded tokens cannot rotate' },
       401
+    );
+  }
+
+  // Issue #2621 — a caller holding only the STAGED credential of an unconfirmed
+  // rotation must confirm that rotation rather than start a new one. Allowing a
+  // chain of staged-on-staged rotations would let the durable, server-current
+  // credential drift arbitrarily far from anything the endpoint has on disk,
+  // which is precisely the divergence this design exists to prevent.
+  if (c.get('agentPendingTokenPresented')) {
+    return c.json(
+      { error: 'Confirm the pending rotation before starting a new one', code: 'pending_rotation_unconfirmed' },
+      409
     );
   }
 
@@ -61,7 +85,7 @@ tokenRoutes.post('/:id/rotate-token', async (c) => {
   }
 
   const rotatedAt = new Date();
-  const previousTokenExpiresAt = new Date(rotatedAt.getTime() + 5 * 60 * 1000);
+  const pendingExpiresAt = new Date(rotatedAt.getTime() + PENDING_ROTATION_TTL_MS);
   const authToken = generateApiKey();
   const watchdogAuthToken = generateApiKey();
   const helperAuthToken = generateApiKey();
@@ -74,29 +98,34 @@ tokenRoutes.post('/:id/rotate-token', async (c) => {
   // lgtm[js/insufficient-password-hash]
   const helperTokenHash = createHash('sha256').update(helperAuthToken).digest('hex');
 
-  // PART B — bind the rotation atomically to the hash that actually
-  // authenticated this request. The UPDATE is a compare-and-swap on the
-  // CURRENT agent-token hash (the value the middleware matched), so a race
-  // (someone else rotated first) or any hash mismatch touches zero rows and
-  // mints nothing. previousTokenHash becomes the authenticating hash — the
-  // token that was current at rotation time.
+  // PART B — Issue #2621: STAGE the new credential set; do not commit it.
+  //
+  // The old code promoted these hashes to current here, before the endpoint had
+  // written anything to disk. A failed config.Save then left the server holding
+  // hashes the agent could not reproduce after a restart — a permanent 401 once
+  // the previous-token grace expired, with no recovery path.
+  //
+  // Now agent_token_hash / watchdog_token_hash / helper_token_hash are left
+  // untouched and fully authoritative. The new hashes land in the pending_*
+  // columns, where auth accepts them but a restart does not depend on them.
+  // Promotion happens only in /rotate-token/confirm, which requires the agent to
+  // authenticate WITH the new token — proof it read the credential back off
+  // disk. If that confirmation never arrives, the staged set simply expires and
+  // the endpoint keeps working on the credentials it durably holds.
+  //
+  // The UPDATE is still a compare-and-swap on the CURRENT agent-token hash, so a
+  // concurrent rotation or hash mismatch touches zero rows and stages nothing.
+  // Re-staging over an existing pending set is deliberate and safe: it is how an
+  // agent that lost the plaintext (crash before the disk write) retries.
   let rotatedRows: { id: string }[];
   try {
     rotatedRows = await db
       .update(devices)
       .set({
-        previousTokenHash: authTokenHash,
-        previousTokenExpiresAt,
-        agentTokenHash,
-        tokenIssuedAt: rotatedAt,
-        previousWatchdogTokenHash: device.watchdogTokenHash,
-        previousWatchdogTokenExpiresAt: previousTokenExpiresAt,
-        watchdogTokenHash,
-        watchdogTokenIssuedAt: rotatedAt,
-        previousHelperTokenHash: device.helperTokenHash,
-        previousHelperTokenExpiresAt: previousTokenExpiresAt,
-        helperTokenHash,
-        helperTokenIssuedAt: rotatedAt,
+        pendingTokenHash: agentTokenHash,
+        pendingWatchdogTokenHash: watchdogTokenHash,
+        pendingHelperTokenHash: helperTokenHash,
+        pendingTokenExpiresAt: pendingExpiresAt,
         updatedAt: rotatedAt,
       })
       .where(
@@ -107,7 +136,7 @@ tokenRoutes.post('/:id/rotate-token', async (c) => {
       )
       .returning({ id: devices.id });
   } catch (error) {
-    console.error('[agents] token rotation DB update failed:', {
+    console.error('[agents] token rotation staging DB update failed:', {
       agentId,
       deviceId: device.id,
       error,
@@ -131,17 +160,17 @@ tokenRoutes.post('/:id/rotate-token', async (c) => {
       orgId: agent.orgId,
       actorType: 'agent',
       actorId: agent.agentId,
-      action: 'agent.token.rotate',
+      action: 'agent.token.rotate.staged',
       resourceType: 'device',
       resourceId: device.id,
       resourceName: device.hostname,
       details: {
-        rotatedAt: rotatedAt.toISOString(),
-        previousTokenGracePeriodSeconds: 300,
+        stagedAt: rotatedAt.toISOString(),
+        pendingExpiresAt: pendingExpiresAt.toISOString(),
       },
     });
   } catch (auditErr) {
-    console.error('[agents] audit event write failed for token rotation:', auditErr);
+    console.error('[agents] audit event write failed for token rotation staging:', auditErr);
   }
 
   return c.json(
@@ -150,7 +179,151 @@ tokenRoutes.post('/:id/rotate-token', async (c) => {
       watchdogAuthToken,
       helperAuthToken,
       rotatedAt: rotatedAt.toISOString(),
+      // Signals a two-phase-capable server. Agents that see this MUST persist +
+      // read back, then call /rotate-token/confirm. Older agents that ignore it
+      // still work: their new credentials authenticate immediately as pending,
+      // and the very next request they make carrying the new token is what a
+      // confirm would have proven anyway.
+      confirmationRequired: true,
+      pendingExpiresAt: pendingExpiresAt.toISOString(),
     },
     200
   );
+});
+
+/**
+ * Issue #2621 — phase two: promote a staged credential set to current.
+ *
+ * The caller MUST authenticate with the staged agent token itself. That is the
+ * whole point: possession of the new token after the agent has written it to
+ * disk and read it back is the endpoint's proof that the credential is durable.
+ * Only then is it safe to demote the credential the endpoint was previously
+ * relying on.
+ */
+tokenRoutes.post('/:id/rotate-token/confirm', async (c) => {
+  const agentId = c.req.param('id');
+  const agent = c.get('agent') as AgentAuthContext;
+  if (agent.role !== 'agent') {
+    return c.json({ error: 'Agent credential role mismatch' }, 403);
+  }
+
+  const authTokenHash = agent.authTokenHash;
+  if (!authTokenHash) {
+    return c.json({ error: 'Missing authenticated token binding' }, 401);
+  }
+
+  const [device] = await db
+    .select({
+      id: devices.id,
+      hostname: devices.hostname,
+      agentTokenHash: devices.agentTokenHash,
+      watchdogTokenHash: devices.watchdogTokenHash,
+      helperTokenHash: devices.helperTokenHash,
+      pendingTokenHash: devices.pendingTokenHash,
+      pendingWatchdogTokenHash: devices.pendingWatchdogTokenHash,
+      pendingHelperTokenHash: devices.pendingHelperTokenHash,
+      pendingTokenExpiresAt: devices.pendingTokenExpiresAt,
+    })
+    .from(devices)
+    .where(and(eq(devices.id, agent.deviceId), eq(devices.agentId, agentId)))
+    .limit(1);
+
+  if (!device) {
+    return c.json({ error: 'Device not found' }, 404);
+  }
+
+  // Idempotency: the agent retries confirmation until it succeeds, and a retry
+  // whose predecessor actually landed arrives authenticated with what is now the
+  // CURRENT token and finds no pending set. That is success, not a conflict —
+  // returning an error here would drive an infinite retry loop on a healthy
+  // device.
+  if (!device.pendingTokenHash && device.agentTokenHash === authTokenHash) {
+    return c.json({ confirmed: true, alreadyCurrent: true }, 200);
+  }
+
+  // The caller must be presenting the staged token, not the current one. A
+  // confirm sent with the OLD token would promote a credential the endpoint has
+  // given no evidence of holding — exactly the unverified commit that caused
+  // this bug.
+  if (!device.pendingTokenHash || device.pendingTokenHash !== authTokenHash) {
+    return c.json(
+      { error: 'Confirm must be sent with the pending rotation token', code: 'pending_token_required' },
+      409
+    );
+  }
+
+  if (!device.pendingTokenExpiresAt || device.pendingTokenExpiresAt <= new Date()) {
+    return c.json(
+      { error: 'Pending rotation has expired; request a new rotation', code: 'pending_rotation_expired' },
+      409
+    );
+  }
+
+  const confirmedAt = new Date();
+  const previousTokenExpiresAt = new Date(confirmedAt.getTime() + PREVIOUS_TOKEN_GRACE_MS);
+
+  // Promote pending -> current and demote current -> previous, in one CAS bound
+  // to the staged hash so a concurrent re-stage cannot be promoted by a stale
+  // confirmation.
+  let promotedRows: { id: string }[];
+  try {
+    promotedRows = await db
+      .update(devices)
+      .set({
+        previousTokenHash: device.agentTokenHash,
+        previousTokenExpiresAt,
+        agentTokenHash: device.pendingTokenHash,
+        tokenIssuedAt: confirmedAt,
+        previousWatchdogTokenHash: device.watchdogTokenHash,
+        previousWatchdogTokenExpiresAt: previousTokenExpiresAt,
+        watchdogTokenHash: device.pendingWatchdogTokenHash,
+        watchdogTokenIssuedAt: confirmedAt,
+        previousHelperTokenHash: device.helperTokenHash,
+        previousHelperTokenExpiresAt: previousTokenExpiresAt,
+        helperTokenHash: device.pendingHelperTokenHash,
+        helperTokenIssuedAt: confirmedAt,
+        pendingTokenHash: null,
+        pendingWatchdogTokenHash: null,
+        pendingHelperTokenHash: null,
+        pendingTokenExpiresAt: null,
+        updatedAt: confirmedAt,
+      })
+      .where(and(eq(devices.id, device.id), eq(devices.pendingTokenHash, authTokenHash)))
+      .returning({ id: devices.id });
+  } catch (error) {
+    console.error('[agents] token rotation confirm DB update failed:', {
+      agentId,
+      deviceId: device.id,
+      error,
+    });
+    return c.json({ error: 'Failed to confirm agent token rotation' }, 500);
+  }
+
+  if (promotedRows.length !== 1) {
+    console.warn('[agents] token rotation confirm compare-and-swap matched no rows:', {
+      agentId,
+      deviceId: device.id,
+    });
+    return c.json({ error: 'Rotation confirm conflict; re-authenticate and retry' }, 409);
+  }
+
+  try {
+    writeAuditEvent(c, {
+      orgId: agent.orgId,
+      actorType: 'agent',
+      actorId: agent.agentId,
+      action: 'agent.token.rotate.confirmed',
+      resourceType: 'device',
+      resourceId: device.id,
+      resourceName: device.hostname,
+      details: {
+        confirmedAt: confirmedAt.toISOString(),
+        previousTokenGracePeriodSeconds: PREVIOUS_TOKEN_GRACE_MS / 1000,
+      },
+    });
+  } catch (auditErr) {
+    console.error('[agents] audit event write failed for token rotation confirm:', auditErr);
+  }
+
+  return c.json({ confirmed: true, confirmedAt: confirmedAt.toISOString() }, 200);
 });

--- a/apps/api/src/routes/agents/token.ts
+++ b/apps/api/src/routes/agents/token.ts
@@ -5,6 +5,10 @@ import { Hono } from 'hono';
 import { db } from '../../db';
 import { devices } from '../../db/schema';
 import type { AgentAuthContext } from '../../middleware/agentAuth';
+import {
+  PREVIOUS_TOKEN_GRACE_MS,
+  promotePendingAgentCredentials,
+} from '../../services/agentTokenPromotion';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { generateApiKey } from './helpers';
 
@@ -18,9 +22,6 @@ export const tokenRoutes = new Hono();
  * staged credentials authenticate, so no crash point can strand the endpoint.
  */
 const PENDING_ROTATION_TTL_MS = 60 * 60 * 1000; // 1 hour
-
-/** Grace window the superseded credential keeps after a confirmed promotion. */
-const PREVIOUS_TOKEN_GRACE_MS = 5 * 60 * 1000;
 
 tokenRoutes.post('/:id/rotate-token', async (c) => {
   const agentId = c.req.param('id');
@@ -260,36 +261,23 @@ tokenRoutes.post('/:id/rotate-token/confirm', async (c) => {
   }
 
   const confirmedAt = new Date();
-  const previousTokenExpiresAt = new Date(confirmedAt.getTime() + PREVIOUS_TOKEN_GRACE_MS);
 
-  // Promote pending -> current and demote current -> previous, in one CAS bound
-  // to the staged hash so a concurrent re-stage cannot be promoted by a stale
-  // confirmation.
-  let promotedRows: { id: string }[];
+  if (!device.agentTokenHash) {
+    return c.json({ error: 'Rotation confirm conflict; re-authenticate and retry' }, 409);
+  }
+
+  let promoted: boolean;
   try {
-    promotedRows = await db
-      .update(devices)
-      .set({
-        previousTokenHash: device.agentTokenHash,
-        previousTokenExpiresAt,
-        agentTokenHash: device.pendingTokenHash,
-        tokenIssuedAt: confirmedAt,
-        previousWatchdogTokenHash: device.watchdogTokenHash,
-        previousWatchdogTokenExpiresAt: previousTokenExpiresAt,
-        watchdogTokenHash: device.pendingWatchdogTokenHash,
-        watchdogTokenIssuedAt: confirmedAt,
-        previousHelperTokenHash: device.helperTokenHash,
-        previousHelperTokenExpiresAt: previousTokenExpiresAt,
-        helperTokenHash: device.pendingHelperTokenHash,
-        helperTokenIssuedAt: confirmedAt,
-        pendingTokenHash: null,
-        pendingWatchdogTokenHash: null,
-        pendingHelperTokenHash: null,
-        pendingTokenExpiresAt: null,
-        updatedAt: confirmedAt,
-      })
-      .where(and(eq(devices.id, device.id), eq(devices.pendingTokenHash, authTokenHash)))
-      .returning({ id: devices.id });
+    promoted = await promotePendingAgentCredentials({
+      deviceId: device.id,
+      pendingTokenHash: authTokenHash,
+      expectedAgentTokenHash: device.agentTokenHash,
+      pendingWatchdogTokenHash: device.pendingWatchdogTokenHash,
+      pendingHelperTokenHash: device.pendingHelperTokenHash,
+      watchdogTokenHash: device.watchdogTokenHash,
+      helperTokenHash: device.helperTokenHash,
+      now: confirmedAt,
+    });
   } catch (error) {
     console.error('[agents] token rotation confirm DB update failed:', {
       agentId,
@@ -299,7 +287,7 @@ tokenRoutes.post('/:id/rotate-token/confirm', async (c) => {
     return c.json({ error: 'Failed to confirm agent token rotation' }, 500);
   }
 
-  if (promotedRows.length !== 1) {
+  if (!promoted) {
     console.warn('[agents] token rotation confirm compare-and-swap matched no rows:', {
       agentId,
       deviceId: device.id,

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -1202,6 +1202,14 @@ coreRoutes.post(
         tokenIssuedAt: new Date(),
         previousTokenHash: null,
         previousTokenExpiresAt: null,
+        // Issue #2621 — this is the incident-response revocation path, so it must
+        // also kill any staged (pending) rotation. A staged credential minted
+        // before the revocation would otherwise keep authenticating for the rest
+        // of its window, and could be promoted over this admin-issued token.
+        pendingTokenHash: null,
+        pendingWatchdogTokenHash: null,
+        pendingHelperTokenHash: null,
+        pendingTokenExpiresAt: null,
         updatedAt: new Date()
       })
       .where(eq(devices.id, deviceId))

--- a/apps/api/src/services/agentTokenPromotion.test.ts
+++ b/apps/api/src/services/agentTokenPromotion.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: { update: vi.fn() },
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: {
+    id: 'id',
+    agentTokenHash: 'agentTokenHash',
+    tokenIssuedAt: 'tokenIssuedAt',
+    previousTokenHash: 'previousTokenHash',
+    previousTokenExpiresAt: 'previousTokenExpiresAt',
+    watchdogTokenHash: 'watchdogTokenHash',
+    watchdogTokenIssuedAt: 'watchdogTokenIssuedAt',
+    previousWatchdogTokenHash: 'previousWatchdogTokenHash',
+    previousWatchdogTokenExpiresAt: 'previousWatchdogTokenExpiresAt',
+    helperTokenHash: 'helperTokenHash',
+    helperTokenIssuedAt: 'helperTokenIssuedAt',
+    previousHelperTokenHash: 'previousHelperTokenHash',
+    previousHelperTokenExpiresAt: 'previousHelperTokenExpiresAt',
+    pendingTokenHash: 'pendingTokenHash',
+    pendingWatchdogTokenHash: 'pendingWatchdogTokenHash',
+    pendingHelperTokenHash: 'pendingHelperTokenHash',
+    pendingTokenExpiresAt: 'pendingTokenExpiresAt',
+    updatedAt: 'updatedAt',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ __and: args })),
+  eq: vi.fn((col: unknown, val: unknown) => ({ __eq: [col, val] })),
+}));
+
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { promotePendingAgentCredentials } from './agentTokenPromotion';
+
+const NOW = new Date('2026-03-31T18:45:00.000Z');
+
+function mockUpdate(returning: Array<{ id: string }>) {
+  const where = vi.fn(() => ({ returning: vi.fn().mockResolvedValue(returning) }));
+  const set = vi.fn(() => ({ where }));
+  vi.mocked(db.update).mockReturnValue({ set } as never);
+  return { set, where };
+}
+
+const BASE = {
+  deviceId: 'device-1',
+  pendingTokenHash: 'pending-hash',
+  expectedAgentTokenHash: 'current-hash',
+  pendingWatchdogTokenHash: 'pending-watchdog-hash',
+  pendingHelperTokenHash: 'pending-helper-hash',
+  watchdogTokenHash: 'current-watchdog-hash',
+  helperTokenHash: 'current-helper-hash',
+  now: NOW,
+};
+
+// Issue #2621 — this is the single point where a staged credential becomes the
+// device's real identity. Both the explicit confirm route and the heartbeat's
+// implicit promotion go through it, so its compare-and-swap is what stands
+// between a normal rotation and a silently rolled-back credential revocation.
+describe('promotePendingAgentCredentials', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('promotes pending to current, demotes current to previous, and clears the staged set', async () => {
+    const { set } = mockUpdate([{ id: 'device-1' }]);
+
+    await expect(promotePendingAgentCredentials(BASE)).resolves.toBe(true);
+
+    expect(set).toHaveBeenCalledWith({
+      previousTokenHash: 'current-hash',
+      previousTokenExpiresAt: new Date('2026-03-31T18:50:00.000Z'),
+      agentTokenHash: 'pending-hash',
+      tokenIssuedAt: NOW,
+      previousWatchdogTokenHash: 'current-watchdog-hash',
+      previousWatchdogTokenExpiresAt: new Date('2026-03-31T18:50:00.000Z'),
+      watchdogTokenHash: 'pending-watchdog-hash',
+      watchdogTokenIssuedAt: NOW,
+      previousHelperTokenHash: 'current-helper-hash',
+      previousHelperTokenExpiresAt: new Date('2026-03-31T18:50:00.000Z'),
+      helperTokenHash: 'pending-helper-hash',
+      helperTokenIssuedAt: NOW,
+      pendingTokenHash: null,
+      pendingWatchdogTokenHash: null,
+      pendingHelperTokenHash: null,
+      pendingTokenExpiresAt: null,
+      updatedAt: NOW,
+    });
+  });
+
+  // The revocation-rollback guard. If the CAS bound only to the staged hash, a
+  // credential staged BEFORE an admin rotation or re-enrollment could promote
+  // itself over the replacement and quietly undo the revocation.
+  it('binds the compare-and-swap to the observed current hash as well as the staged hash', async () => {
+    mockUpdate([{ id: 'device-1' }]);
+
+    await promotePendingAgentCredentials(BASE);
+
+    expect(eq).toHaveBeenCalledWith('pendingTokenHash', 'pending-hash');
+    expect(eq).toHaveBeenCalledWith('agentTokenHash', 'current-hash');
+  });
+
+  // Zero rows means the row moved underneath us — a concurrent re-stage, or the
+  // revocation above. Reporting false keeps the caller from telling the agent a
+  // promotion happened when it did not.
+  it('reports failure when the compare-and-swap matches no rows', async () => {
+    mockUpdate([]);
+
+    await expect(promotePendingAgentCredentials(BASE)).resolves.toBe(false);
+  });
+});

--- a/apps/api/src/services/agentTokenPromotion.ts
+++ b/apps/api/src/services/agentTokenPromotion.ts
@@ -1,0 +1,91 @@
+import { and, eq } from 'drizzle-orm';
+
+import { db } from '../db';
+import { devices } from '../db/schema';
+
+/** Grace window the superseded credential keeps after a confirmed promotion. */
+export const PREVIOUS_TOKEN_GRACE_MS = 5 * 60 * 1000;
+
+/**
+ * Issue #2621 — promote a staged (pending) credential set to current.
+ *
+ * Shared by two callers with the same safety requirement:
+ *
+ *  - `POST /agents/:id/rotate-token/confirm` — a #2621-aware agent explicitly
+ *    confirming that it durably persisted the staged credentials.
+ *  - the heartbeat path — an agent that is *authenticating with* the staged
+ *    token but never confirmed. That covers pre-#2621 agents, which overwrite
+ *    their own token file and never call confirm; without this implicit
+ *    promotion they would authenticate on the pending hash until it expired and
+ *    then be locked out permanently. It also backstops a newer agent whose
+ *    confirm response was lost in flight.
+ *
+ * In both cases the trigger is identical and is the only evidence that matters:
+ * the endpoint presented the staged token, so it demonstrably holds it.
+ *
+ * The UPDATE is a compare-and-swap on BOTH the staged hash and the current hash
+ * the caller observed. Binding to the staged hash alone is not enough — if the
+ * current credential moved in between (admin token rotation, re-enrollment), a
+ * staged token minted before that revocation could promote itself over the
+ * replacement and roll the revocation back, and `previousTokenHash` would be
+ * written from a stale read, re-arming an already-dead credential.
+ *
+ * Returns true when exactly one row was promoted.
+ */
+export async function promotePendingAgentCredentials(params: {
+  deviceId: string;
+  /** Hash of the token the caller authenticated with — must be the staged one. */
+  pendingTokenHash: string;
+  /** Current-token hash as observed by the caller; part of the CAS. */
+  expectedAgentTokenHash: string;
+  pendingWatchdogTokenHash: string | null;
+  pendingHelperTokenHash: string | null;
+  watchdogTokenHash: string | null;
+  helperTokenHash: string | null;
+  now?: Date;
+}): Promise<boolean> {
+  const {
+    deviceId,
+    pendingTokenHash,
+    expectedAgentTokenHash,
+    pendingWatchdogTokenHash,
+    pendingHelperTokenHash,
+    watchdogTokenHash,
+    helperTokenHash,
+    now = new Date(),
+  } = params;
+
+  const previousTokenExpiresAt = new Date(now.getTime() + PREVIOUS_TOKEN_GRACE_MS);
+
+  const promotedRows = await db
+    .update(devices)
+    .set({
+      previousTokenHash: expectedAgentTokenHash,
+      previousTokenExpiresAt,
+      agentTokenHash: pendingTokenHash,
+      tokenIssuedAt: now,
+      previousWatchdogTokenHash: watchdogTokenHash,
+      previousWatchdogTokenExpiresAt: previousTokenExpiresAt,
+      watchdogTokenHash: pendingWatchdogTokenHash,
+      watchdogTokenIssuedAt: now,
+      previousHelperTokenHash: helperTokenHash,
+      previousHelperTokenExpiresAt: previousTokenExpiresAt,
+      helperTokenHash: pendingHelperTokenHash,
+      helperTokenIssuedAt: now,
+      pendingTokenHash: null,
+      pendingWatchdogTokenHash: null,
+      pendingHelperTokenHash: null,
+      pendingTokenExpiresAt: null,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(devices.id, deviceId),
+        eq(devices.pendingTokenHash, pendingTokenHash),
+        eq(devices.agentTokenHash, expectedAgentTokenHash)
+      )
+    )
+    .returning({ id: devices.id });
+
+  return promotedRows.length === 1;
+}


### PR DESCRIPTION
Closes #2621

## The bug

Credential rotation committed on the server **before** the agent had persisted anything. In `agent/internal/heartbeat/heartbeat.go` the order was: request credentials → server commits hashes → swap in memory → `config.Save` → **on failure, log and continue**.

That last step is not a logging problem, it is a durability problem. Once the server had committed, a failed disk write meant the agent ran fine on in-memory credentials until its next restart, then loaded stale credentials from `secrets.yaml` and returned `401 Invalid agent credentials` on every authenticated route as soon as the 5-minute previous-token grace expired — heartbeat, inventory, WebSocket, watchdog failover. No automatic recovery, and the auth-dead retry logic just retried the same permanently invalid credential.

## The fix: two-phase, persist-before-commit

**Phase 1 — stage.** `POST /agents/:id/rotate-token` writes the new agent/watchdog/helper hashes to new `pending_*` columns. `agent_token_hash`, `watchdog_token_hash` and `helper_token_hash` are **not touched** and remain authoritative.

**Phase 2 — persist, verify, confirm.** The agent writes the staged set to `secrets.yaml` *alongside* the current set, reads it back to verify the write landed, and only then calls `POST /agents/:id/rotate-token/confirm` **authenticated with the new token**. Possession of that token after a verified readback is the endpoint's proof the credential is durable. The server then promotes pending → current and demotes current → previous.

If anything fails, rotation aborts while the old credentials are still valid server-side. An unconfirmed rotation expires (1 hour) and the last known durable credentials stay authoritative.

## Crash safety at each step

While a rotation is staged, auth accepts **both** the current and the staged credential, and **both are on disk**. So every crash point leaves the agent holding something the server accepts:

| Process dies… | Disk | Server current | Outcome |
|---|---|---|---|
| after mint, before disk write | old only | old | rotation abandoned, agent fine |
| after disk write, before confirm | old + staged | old (staged also valid) | either credential authenticates; reconciliation confirms |
| after confirm, before local promote | old + staged | staged | staged is on disk under `pending_*`; startup reconciliation recovers it |

Recovery is driven from two places: `reconcilePendingRotation()` runs at agent startup, and the heartbeat returns a `confirmTokenRotation` flag when it sees an agent authenticating with an unpromoted staged credential.

## Design decisions worth reviewing

- **Staged credentials authenticate.** This is what removes the stranding window entirely, and it is no weaker than the existing previous-token grace: a staged credential is only ever minted by a call authenticated with the *current* token. Wired into REST, WebSocket and helper auth — a restarted agent must be able to reconnect its control channel on the staged token, otherwise the crash window is only half closed.
- **mTLS renewal stays fail-closed on the current token.** That route mints fresh cert material, so it deliberately does *not* accept staged credentials (same rationale as its existing superseded-token rejection).
- **Rotating on a staged credential is rejected (409).** Chaining staged-on-staged would let the server-current credential drift arbitrarily far from anything on disk — the divergence this design exists to prevent.
- **Confirm is idempotent.** A retry whose predecessor actually landed arrives on what is now the current token and returns `{confirmed: true, alreadyCurrent: true}` rather than an error, so a healthy device cannot get stuck in a retry loop.
- **Backward compatible.** An older agent that ignores `confirmationRequired` still works: its new credentials authenticate immediately as pending, and the next request it makes carrying that token is exactly what a confirm would have proven.
- **Latent clobber fixed.** `SaveTo` rebuilds `secrets.yaml` wholesale, so an unrelated caller (the mTLS renewal path calls `config.Save`) would have silently dropped a staged set. It now carries `pending_*` forward. Covered by a regression test.

## Deliberately out of scope

The issue also proposes an **admin "Repair Agent Credentials" recovery workflow** (one-time recovery grants, MFA step-up, stale-token proof-of-possession). That is a separate feature for devices *already* stranded, and it needs its own security review — I did not want to bundle a new privileged recovery route into an ordering fix. This PR removes the cause; the recovery workflow is worth tracking as a follow-up for any device already in the bad state (the issue documents a working manual recovery via forced re-enrollment that preserves the device UUID).

## Verification

- `go build ./...`, `go vet`, and the **full Go agent suite** green. New: `agent/internal/heartbeat/token_rotation_test.go`, `agent/internal/config/credentials_test.go`.
  - The core ordering test — with the secrets write blocked, `/rotate-token/confirm` is **never called** and the in-memory token stays on the old credential. This fails against the old implementation, which swapped in memory before saving.
  - Plus: staging preserves the current set, staging failure is reported, both sets survive a failed confirm, startup reconciliation confirms staged credentials, expired staged sets are discarded, staged credentials survive a reload and stay out of `agent.yaml`.
- `apps/api`: `token.test.ts`, `agentAuth.test.ts`, `helperAuth.test.ts`, `heartbeat.test.ts`, `mtls.test.ts`, `agentWs.test.ts`, `autoMigrate.test.ts` — all green single-fork. `tsc --noEmit` clean.
- Migration is idempotent (`ADD COLUMN IF NOT EXISTS`, partial index `IF NOT EXISTS`), adds no new table, so no RLS shape or cascade-list registration applies — columns only, on the existing `devices` table.

**Not run locally** (no Postgres or Docker in this environment): `pnpm db:check-drift` and the RLS/integration suites. Schema and migration were kept in lockstep by hand — please let CI confirm. `go test -race` also could not run locally (no cgo toolchain); the suite passes without `-race` and CI runs it with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)