### PR TITLE
feat(extensions): add extension testkit (Plan 04, Task 1)

### DIFF
--- a/packages/extension-sdk/src/manifest.ts
+++ b/packages/extension-sdk/src/manifest.ts
@@ -245,3 +245,14 @@ export function parseExtensionManifestV1(raw: unknown): ExtensionManifestV1 {
     throw error;
   }
 }
+
+/**
+ * Non-throwing counterpart to {@link parseExtensionManifestV1}. Returns the raw
+ * Zod result so callers (e.g. the conformance testkit) can enumerate every issue
+ * with its structured `path`/`code`, rather than a flattened, prettified string.
+ */
+export function safeParseExtensionManifestV1(
+  raw: unknown,
+): z.ZodSafeParseResult<ExtensionManifestV1> {
+  return manifestSchemaV1.safeParse(raw);
+}

--- a/packages/extension-testkit/package.json
+++ b/packages/extension-testkit/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@breeze/extension-testkit",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@breeze/extension-sdk": "workspace:*",
+    "@breeze/extension-web-sdk": "workspace:*",
+    "hono": "^4.12.30"
+  },
+  "devDependencies": {
+    "happy-dom": "^20.11.0",
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/extension-testkit/src/host.test.ts
+++ b/packages/extension-testkit/src/host.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { probeStockHost, type StockHostProbeOptions } from './host';
+
+const COOKIE = 'breeze_session=super-secret-value';
+const IMMUTABLE = 'private, max-age=31536000, immutable';
+
+function json(body: unknown, init: { status?: number; headers?: Record<string, string> } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'content-type': 'application/json', ...init.headers },
+  });
+}
+
+function baseOptions(fetchImpl: typeof fetch): StockHostProbeOptions {
+  return {
+    baseUrl: 'http://host',
+    extensionName: 'acme',
+    expectedDigest: 'sha256-abc',
+    auth: { cookie: COOKIE },
+    assetMember: 'index.html',
+    fetchImpl,
+  };
+}
+
+// A well-behaved host, with a single overridable endpoint for negative tests.
+function goodFetch(overrides: (url: string) => Response | undefined = () => undefined): typeof fetch {
+  return (async (input: unknown) => {
+    const url = String(input);
+    const override = overrides(url);
+    if (override) return override;
+    if (url.endsWith('/health')) return json({ ok: true });
+    if (url.endsWith('/api/v1/admin/extensions')) return json({ extensions: [{ name: 'acme' }] });
+    if (url.endsWith('/api/v1/extensions/registry')) return json({ pages: [], navigation: [], slots: [] });
+    if (url.includes('/assets/')) return new Response('<html>', { status: 200, headers: { 'cache-control': IMMUTABLE } });
+    if (url.includes('/api/v1/ext/acme')) return json({ error: 'unauthorized' }, { status: 401 });
+    return new Response('not found', { status: 404 });
+  }) as typeof fetch;
+}
+
+describe('probeStockHost', () => {
+  it('reports all-green observations against a well-behaved host', async () => {
+    const result = await probeStockHost(baseOptions(goodFetch()));
+    expect(result.ok).toBe(true);
+    expect(result.observations.map((observation) => observation.name)).toEqual(
+      expect.arrayContaining(['health', 'adminState', 'registry', 'assetImmutable', 'routeAuth']),
+    );
+  });
+
+  it('fails the asset probe when Cache-Control is not immutable', async () => {
+    const fetchImpl = goodFetch((url) =>
+      url.includes('/assets/') ? new Response('<html>', { status: 200, headers: { 'cache-control': 'no-store' } }) : undefined,
+    );
+    const result = await probeStockHost(baseOptions(fetchImpl));
+    expect(result.observations.find((o) => o.name === 'assetImmutable')?.ok).toBe(false);
+    expect(result.ok).toBe(false);
+  });
+
+  it('flags the extension namespace when it does NOT reject unauthenticated access', async () => {
+    const fetchImpl = goodFetch((url) =>
+      url.includes('/api/v1/ext/acme') ? json({ leaked: true }, { status: 200 }) : undefined,
+    );
+    const result = await probeStockHost(baseOptions(fetchImpl));
+    expect(result.observations.find((o) => o.name === 'routeAuth')?.ok).toBe(false);
+  });
+
+  it('flags admin state when the extension is not listed', async () => {
+    const fetchImpl = goodFetch((url) =>
+      url.endsWith('/api/v1/admin/extensions') ? json({ extensions: [{ name: 'other' }] }) : undefined,
+    );
+    const result = await probeStockHost(baseOptions(fetchImpl));
+    expect(result.observations.find((o) => o.name === 'adminState')?.ok).toBe(false);
+  });
+
+  it('never leaks the auth cookie, even when a probe throws', async () => {
+    // Load-bearing: if redaction is removed, the cookie flows into `detail` and this fails.
+    const fetchImpl = (async () => {
+      throw new Error(`connect ECONNREFUSED; sent header "cookie: ${COOKIE}"`);
+    }) as typeof fetch;
+    const result = await probeStockHost(baseOptions(fetchImpl));
+    expect(JSON.stringify(result)).not.toContain('super-secret-value');
+    expect(result.observations.length).toBeGreaterThan(0);
+    expect(result.observations.every((o) => !o.detail.includes('super-secret-value'))).toBe(true);
+  });
+});

--- a/packages/extension-testkit/src/host.ts
+++ b/packages/extension-testkit/src/host.ts
@@ -1,0 +1,114 @@
+/** Options for a black-box probe of a running stock Breeze host. */
+export interface StockHostProbeOptions {
+  /** Base origin of the host, e.g. `https://localhost:3000`. */
+  baseUrl: string;
+  /** The extension's manifest `name`. */
+  extensionName: string;
+  /** The digest the enabled extension is expected to serve assets under. */
+  expectedDigest: string;
+  /** Session auth. The cookie is sent only where auth is required and is never surfaced. */
+  auth: { cookie: string };
+  /** Relative asset member under `assets/:name/:digest/` to probe (default `index.html`). */
+  assetMember?: string;
+  /** Injectable fetch (defaults to the global) — supply a fake in tests. */
+  fetchImpl?: typeof fetch;
+}
+
+/** A single black-box observation. `detail` is always cookie-redacted. */
+export interface ProbeObservation {
+  name: string;
+  ok: boolean;
+  status: number | null;
+  detail: string;
+}
+
+export interface HostProbeResult {
+  ok: boolean;
+  observations: ProbeObservation[];
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Black-box HTTP conformance probes against a running stock host. Verifies the
+ * health route, admin state (lists the extension), the runtime registry, the
+ * immutable asset cache header, and that the extension's own namespace rejects
+ * unauthenticated requests. The auth cookie is redacted from every observation
+ * and error — it is never logged or returned in the clear.
+ */
+export async function probeStockHost(options: StockHostProbeOptions): Promise<HostProbeResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const cookie = options.auth.cookie;
+  const base = options.baseUrl.replace(/\/+$/, '');
+  const authedInit: RequestInit = { headers: { cookie } };
+  const member = options.assetMember ?? 'index.html';
+
+  // Never let the cookie value escape into a detail string or error message.
+  const redact = (text: string): string => (cookie ? text.split(cookie).join('[redacted]') : text);
+
+  const observations: ProbeObservation[] = [];
+  const probe = async (name: string, run: () => Promise<ProbeObservation>): Promise<void> => {
+    try {
+      observations.push(await run());
+    } catch (error) {
+      observations.push({ name, ok: false, status: null, detail: redact(errorMessage(error)) });
+    }
+  };
+
+  await probe('health', async () => {
+    const res = await fetchImpl(`${base}/health`, {});
+    return { name: 'health', ok: res.ok, status: res.status, detail: redact(`GET /health -> ${res.status}`) };
+  });
+
+  await probe('adminState', async () => {
+    const res = await fetchImpl(`${base}/api/v1/admin/extensions`, authedInit);
+    let listed = false;
+    try {
+      const body = (await res.json()) as { extensions?: Array<{ name?: unknown }> };
+      listed = Array.isArray(body?.extensions)
+        && body.extensions.some((row) => row?.name === options.extensionName);
+    } catch {
+      listed = false;
+    }
+    return {
+      name: 'adminState',
+      ok: res.ok && listed,
+      status: res.status,
+      detail: redact(`GET /api/v1/admin/extensions -> ${res.status}${listed ? `, lists "${options.extensionName}"` : ', extension not listed'}`),
+    };
+  });
+
+  await probe('registry', async () => {
+    const res = await fetchImpl(`${base}/api/v1/extensions/registry`, authedInit);
+    return { name: 'registry', ok: res.ok, status: res.status, detail: redact(`GET /api/v1/extensions/registry -> ${res.status}`) };
+  });
+
+  await probe('assetImmutable', async () => {
+    const url = `${base}/api/v1/extensions/assets/${options.extensionName}/${options.expectedDigest}/${member}`;
+    const res = await fetchImpl(url, authedInit);
+    const cacheControl = res.headers.get('cache-control') ?? '';
+    const immutable = cacheControl.includes('immutable');
+    return {
+      name: 'assetImmutable',
+      ok: res.ok && immutable,
+      status: res.status,
+      detail: redact(`GET assets/${options.extensionName}/${options.expectedDigest}/${member} -> ${res.status}, Cache-Control="${cacheControl}"`),
+    };
+  });
+
+  await probe('routeAuth', async () => {
+    // Deliberately unauthenticated: the extension namespace must reject anonymous access.
+    const res = await fetchImpl(`${base}/api/v1/ext/${options.extensionName}`, {});
+    const rejected = res.status === 401 || res.status === 403;
+    return {
+      name: 'routeAuth',
+      ok: rejected,
+      status: res.status,
+      detail: redact(`unauthenticated GET /api/v1/ext/${options.extensionName} -> ${res.status} (${rejected ? 'rejected' : 'NOT rejected'})`),
+    };
+  });
+
+  return { ok: observations.every((observation) => observation.ok), observations };
+}

--- a/packages/extension-testkit/src/host.ts
+++ b/packages/extension-testkit/src/host.ts
@@ -41,7 +41,10 @@ function errorMessage(error: unknown): string {
 export async function probeStockHost(options: StockHostProbeOptions): Promise<HostProbeResult> {
   const fetchImpl = options.fetchImpl ?? fetch;
   const cookie = options.auth.cookie;
-  const base = options.baseUrl.replace(/\/+$/, '');
+  // Trim trailing slashes without a regex: /\/+$/ backtracks polynomially
+  // on adversarial input (CodeQL js/polynomial-redos).
+  let base = options.baseUrl;
+  while (base.endsWith('/')) base = base.slice(0, -1);
   const authedInit: RequestInit = { headers: { cookie } };
   const member = options.assetMember ?? 'index.html';
 

--- a/packages/extension-testkit/src/index.ts
+++ b/packages/extension-testkit/src/index.ts
@@ -1,0 +1,4 @@
+export * from './manifest';
+export * from './server';
+export * from './web';
+export * from './host';

--- a/packages/extension-testkit/src/manifest.test.ts
+++ b/packages/extension-testkit/src/manifest.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { assertManifestConformance } from './manifest';
+
+function validManifest(): Record<string, unknown> {
+  return {
+    apiVersion: 'breeze.extensions/v1',
+    name: 'acme-widgets',
+    version: '1.0.0',
+    routeNamespace: 'acme-widgets',
+    requires: { breeze: '>=1.0.0', serverSdk: '^1.0.0', capabilities: [] },
+    server: { entry: 'server.js' },
+    schemaCompatibilityFloor: '1.0.0',
+    jobs: [],
+    aiTools: [],
+  };
+}
+
+describe('assertManifestConformance', () => {
+  it('reports all manifest contract errors in one result', () => {
+    const result = assertManifestConformance({ apiVersion: 'bad', name: 'Breeze', version: 'latest' });
+    expect(result.ok).toBe(false);
+    expect(result.issues.map((issue) => issue.path)).toEqual(
+      expect.arrayContaining(['apiVersion', 'name', 'version']),
+    );
+  });
+
+  it('never fails fast — surfaces more than the first issue', () => {
+    const result = assertManifestConformance({ apiVersion: 'bad', name: 'Breeze', version: 'latest' });
+    expect(result.issues.length).toBeGreaterThan(2);
+  });
+
+  it('attaches a non-empty machine-readable code to every issue', () => {
+    // Load-bearing: this fails if diagnostics regress to string-parsing (no `code`).
+    const result = assertManifestConformance({ apiVersion: 'bad', name: 'Breeze', version: 'latest' });
+    for (const issue of result.issues) {
+      expect(typeof issue.code).toBe('string');
+      expect(issue.code.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('accepts a valid manifest', () => {
+    expect(assertManifestConformance(validManifest())).toEqual({ ok: true, issues: [] });
+  });
+});

--- a/packages/extension-testkit/src/manifest.ts
+++ b/packages/extension-testkit/src/manifest.ts
@@ -1,0 +1,33 @@
+import { safeParseExtensionManifestV1 } from '@breeze/extension-sdk';
+
+/** A single conformance problem, addressed by a dotted `path` and a stable `code`. */
+export interface Issue {
+  path: string;
+  code: string;
+  message: string;
+}
+
+/** Result shape shared by the in-process conformance assertions. */
+export interface ConformanceResult {
+  ok: boolean;
+  issues: Issue[];
+}
+
+/**
+ * Validate a manifest against the frozen v1 schema and report **every** problem
+ * in one pass. Unlike the SDK's throwing `parseExtensionManifestV1` (which
+ * flattens to a prettified string), this maps each Zod issue to a structured
+ * `{ path, code, message }` so an author's test can assert on specific fields.
+ */
+export function assertManifestConformance(manifest: unknown): ConformanceResult {
+  const result = safeParseExtensionManifestV1(manifest);
+  if (result.success) return { ok: true, issues: [] };
+  return {
+    ok: false,
+    issues: result.error.issues.map((issue) => ({
+      path: issue.path.map((segment) => String(segment)).join('.'),
+      code: issue.code,
+      message: issue.message,
+    })),
+  };
+}

--- a/packages/extension-testkit/src/server.test.ts
+++ b/packages/extension-testkit/src/server.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import type { BreezeExtensionV1 } from '@breeze/extension-sdk';
+import { stageExtensionForTest } from './server';
+
+function manifest(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return { name: 'acme', jobs: [], aiTools: [], ...over };
+}
+
+const noopJob = (name: string) => ({ name, cron: '* * * * *', handler: async () => {} });
+
+describe('stageExtensionForTest', () => {
+  it('rejects contributions not declared in the manifest', async () => {
+    const extension: BreezeExtensionV1 = {
+      register(registrar) {
+        registrar.registerJob(noopJob('ghost'));
+      },
+    };
+    const result = await stageExtensionForTest(extension, manifest());
+    expect(result.ok).toBe(false);
+    expect(result.issues[0].code).toBe('undeclared_contribution');
+  });
+
+  it('accepts contributions that are declared', async () => {
+    const extension: BreezeExtensionV1 = {
+      register(registrar) {
+        registrar.registerJob(noopJob('sync'));
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registrar.registerAiTool('lookup', {} as any);
+      },
+    };
+    const result = await stageExtensionForTest(
+      extension,
+      manifest({ jobs: [{ name: 'sync' }], aiTools: [{ name: 'lookup' }] }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.recorded.jobs).toEqual(['sync']);
+    expect(result.recorded.aiTools).toEqual(['lookup']);
+  });
+
+  it('flags a job the manifest declares but the extension never registers', async () => {
+    const extension: BreezeExtensionV1 = { register() {} };
+    const result = await stageExtensionForTest(extension, manifest({ jobs: [{ name: 'sync' }] }));
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((issue) => issue.code === 'declared_not_registered')).toBe(true);
+  });
+
+  it('throws when the extension touches the db without a supplied adapter', async () => {
+    // Load-bearing: replacing the throwing db with a permissive stub makes this pass, which it must not.
+    const extension: BreezeExtensionV1 = {
+      async register(_registrar, context) {
+        await context.db.execute('SELECT 1');
+      },
+    };
+    const result = await stageExtensionForTest(extension, manifest());
+    expect(result.ok).toBe(false);
+    expect(result.issues[0].code).toBe('register_threw');
+  });
+
+  it('exercises db code when an adapter is supplied', async () => {
+    const queries: unknown[] = [];
+    const extension: BreezeExtensionV1 = {
+      async register(_registrar, context) {
+        await context.db.execute('SELECT 1');
+      },
+    };
+    const result = await stageExtensionForTest(extension, manifest(), {
+      db: {
+        execute: async (query) => {
+          queries.push(query);
+          return [];
+        },
+      },
+    });
+    expect(queries).toEqual(['SELECT 1']);
+    expect(result.ok).toBe(true);
+  });
+
+  it('leaves the recorder empty when registration throws', async () => {
+    const extension: BreezeExtensionV1 = {
+      register(registrar) {
+        registrar.registerJob(noopJob('half'));
+        throw new Error('boom during registration');
+      },
+    };
+    const result = await stageExtensionForTest(extension, manifest());
+    expect(result.issues[0].code).toBe('register_threw');
+    expect(result.recorded.jobs).toEqual([]);
+  });
+});

--- a/packages/extension-testkit/src/server.ts
+++ b/packages/extension-testkit/src/server.ts
@@ -1,0 +1,156 @@
+import type { Hono } from 'hono';
+import type {
+  BreezeExtensionV1,
+  ExtensionAiTool,
+  ExtensionJobDefinition,
+  ExtensionRegistrar,
+  ExtensionRuntimeContext,
+} from '@breeze/extension-sdk';
+import type { ConformanceResult, Issue } from './manifest';
+
+/** Minimal database seam a test can supply to exercise real query code. */
+export interface StageDbAdapter {
+  execute(query: unknown): Promise<unknown>;
+}
+
+export interface StageExtensionOptions {
+  /**
+   * Optional database adapter. When omitted, the staged context's `db` THROWS on
+   * any access — a permissive stub would let a broken extension pass unnoticed.
+   */
+  db?: StageDbAdapter;
+}
+
+/** What the recording registrar captured during a successful `register`. */
+export interface RecordedContributions {
+  routes: number;
+  jobs: string[];
+  aiTools: string[];
+}
+
+export interface StageExtensionResult extends ConformanceResult {
+  recorded: RecordedContributions;
+}
+
+class RecordingRegistrar implements ExtensionRegistrar {
+  routes = 0;
+  readonly jobs: string[] = [];
+  readonly aiTools: string[] = [];
+
+  mountRoute(_app: Hono): void {
+    this.routes += 1;
+  }
+
+  registerJob(job: ExtensionJobDefinition): void {
+    this.jobs.push(job.name);
+  }
+
+  registerAiTool(name: string, _tool: ExtensionAiTool): void {
+    this.aiTools.push(name);
+  }
+}
+
+function throwingDb(): ExtensionRuntimeContext['db'] {
+  const fail = (): never => {
+    throw new Error(
+      'extension accessed the database, but stageExtensionForTest was called without a db adapter. '
+      + 'Pass `opts.db` to exercise database code under test. A permissive stub is intentionally refused.',
+    );
+  };
+  return new Proxy({} as ExtensionRuntimeContext['db'], {
+    get: () => fail,
+  });
+}
+
+function createContext(options: StageExtensionOptions): ExtensionRuntimeContext {
+  const db: ExtensionRuntimeContext['db'] = options.db
+    ? ({ execute: (query: unknown) => options.db!.execute(query) } as ExtensionRuntimeContext['db'])
+    : throwingDb();
+  return {
+    db,
+    secrets: {
+      encryptForColumn: (_table, _column, plaintext) => plaintext,
+      decryptForColumn: (_table, _column, ciphertext) => ciphertext,
+    },
+    audit: async () => {},
+    log: () => {},
+    config: Object.freeze({}),
+  };
+}
+
+function declaredNames(manifest: unknown, key: 'jobs' | 'aiTools'): Set<string> {
+  const list = (manifest as Record<string, unknown> | null | undefined)?.[key];
+  if (!Array.isArray(list)) return new Set();
+  const names = list
+    .map((entry) => (entry as { name?: unknown } | null)?.name)
+    .filter((name): name is string => typeof name === 'string');
+  return new Set(names);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Register an extension against a recording registrar and a deliberately hostile
+ * runtime context, then cross-check what it registered against its manifest.
+ *
+ * Safety properties:
+ * - the `db` throws unless the test supplies an adapter (see {@link throwingDb});
+ * - a thrown `register` yields a single `register_threw` issue and leaves the
+ *   recorder empty (no partial contributions are surfaced);
+ * - any job/AI-tool registered but not declared in the manifest is an
+ *   `undeclared_contribution`; declared-but-unregistered is the softer
+ *   `declared_not_registered`.
+ */
+export async function stageExtensionForTest(
+  extension: BreezeExtensionV1,
+  manifest: unknown,
+  opts: StageExtensionOptions = {},
+): Promise<StageExtensionResult> {
+  const registrar = new RecordingRegistrar();
+  const context = createContext(opts);
+
+  try {
+    await extension.register(registrar, context);
+  } catch (error) {
+    return {
+      ok: false,
+      issues: [{ path: '', code: 'register_threw', message: errorMessage(error) }],
+      recorded: { routes: 0, jobs: [], aiTools: [] },
+    };
+  }
+
+  const declaredJobs = declaredNames(manifest, 'jobs');
+  const declaredAiTools = declaredNames(manifest, 'aiTools');
+  const issues: Issue[] = [];
+
+  // Undeclared contributions first — the load-bearing "manifest lies by omission" check.
+  for (const name of registrar.jobs) {
+    if (!declaredJobs.has(name)) {
+      issues.push({ path: `jobs.${name}`, code: 'undeclared_contribution', message: `job "${name}" is registered but not declared in the manifest` });
+    }
+  }
+  for (const name of registrar.aiTools) {
+    if (!declaredAiTools.has(name)) {
+      issues.push({ path: `aiTools.${name}`, code: 'undeclared_contribution', message: `AI tool "${name}" is registered but not declared in the manifest` });
+    }
+  }
+  // Declared-but-unregistered second — a softer signal that the manifest overpromises.
+  for (const name of declaredJobs) {
+    if (!registrar.jobs.includes(name)) {
+      issues.push({ path: `jobs.${name}`, code: 'declared_not_registered', message: `job "${name}" is declared in the manifest but was never registered` });
+    }
+  }
+  for (const name of declaredAiTools) {
+    if (!registrar.aiTools.includes(name)) {
+      issues.push({ path: `aiTools.${name}`, code: 'declared_not_registered', message: `AI tool "${name}" is declared in the manifest but was never registered` });
+    }
+  }
+
+  return {
+    ok: issues.length === 0,
+    issues,
+    recorded: { routes: registrar.routes, jobs: registrar.jobs, aiTools: registrar.aiTools },
+  };
+}

--- a/packages/extension-testkit/src/web.test.ts
+++ b/packages/extension-testkit/src/web.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest';
+import { parseDeviceDetailTabContextV1 } from '@breeze/extension-web-sdk';
+import { assertWebContributionConformance } from './web';
+
+// Each test uses unique element names because the custom-element registry is
+// global to the happy-dom window and persists across `it` blocks.
+function manifestFor(page: string, slot: string): Record<string, unknown> {
+  return {
+    web: {
+      pages: [{ path: '/x', element: page }],
+      slots: [{ slot: 'device-detail-tab', contractVersion: 1, element: slot }],
+    },
+  };
+}
+
+function defineOnce(name: string): void {
+  if (!customElements.get(name)) {
+    customElements.define(name, class extends HTMLElement {});
+  }
+}
+
+describe('assertWebContributionConformance', () => {
+  it('passes when declared elements are registered and the entry is idempotent', async () => {
+    const result = await assertWebContributionConformance({
+      manifest: manifestFor('acme-page-a', 'acme-tab-a'),
+      loadEntry: () => {
+        defineOnce('acme-page-a');
+        defineOnce('acme-tab-a');
+      },
+      contracts: [{ label: 'device-detail-tab', parse: parseDeviceDetailTabContextV1, badInput: {} }],
+    });
+    expect(result).toEqual({ ok: true, issues: [] });
+  });
+
+  it('flags an element the manifest declares but the entry never registers', async () => {
+    const result = await assertWebContributionConformance({
+      manifest: manifestFor('acme-page-b', 'acme-tab-b'),
+      loadEntry: () => {
+        defineOnce('acme-page-b'); // acme-tab-b intentionally omitted
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((issue) => issue.code === 'element_not_registered')).toBe(true);
+  });
+
+  it('flags a host-context contract that accepts invalid input', async () => {
+    const result = await assertWebContributionConformance({
+      manifest: manifestFor('acme-page-c', 'acme-tab-c'),
+      loadEntry: () => {
+        defineOnce('acme-page-c');
+        defineOnce('acme-tab-c');
+      },
+      contracts: [{ label: 'permissive', parse: (input) => input, badInput: {} }],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((issue) => issue.code === 'context_not_validated')).toBe(true);
+  });
+
+  it('flags a declared element already defined before the entry loaded', async () => {
+    // Someone else (a prior test / import / other extension) already defined it.
+    customElements.define('acme-page-e', class extends HTMLElement {});
+    const result = await assertWebContributionConformance({
+      manifest: manifestFor('acme-page-e', 'acme-tab-e'),
+      loadEntry: () => {
+        defineOnce('acme-tab-e'); // entry registers the tab, but never the pre-existing page
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((issue) => issue.code === 'element_preexisting')).toBe(true);
+  });
+
+  it('allows a pre-existing element when the caller opts in', async () => {
+    customElements.define('acme-page-f', class extends HTMLElement {});
+    const result = await assertWebContributionConformance({
+      manifest: manifestFor('acme-page-f', 'acme-tab-f'),
+      loadEntry: () => {
+        defineOnce('acme-tab-f');
+      },
+      allowPreexistingElements: true,
+    });
+    expect(result.issues.some((issue) => issue.code === 'element_preexisting')).toBe(false);
+  });
+
+  it('flags an entry whose element definitions are not idempotent', async () => {
+    let loads = 0;
+    const result = await assertWebContributionConformance({
+      manifest: manifestFor('acme-page-d', 'acme-tab-d'),
+      loadEntry: () => {
+        loads += 1;
+        // Unguarded define: first load registers, second load throws.
+        customElements.define('acme-page-d', class extends HTMLElement {});
+        defineOnce('acme-tab-d');
+      },
+    });
+    expect(loads).toBe(2);
+    expect(result.issues.some((issue) => issue.code === 'entry_not_idempotent')).toBe(true);
+  });
+});

--- a/packages/extension-testkit/src/web.ts
+++ b/packages/extension-testkit/src/web.ts
@@ -1,0 +1,124 @@
+import type { ConformanceResult, Issue } from './manifest';
+
+/**
+ * A host-context contract to exercise. `parse` is the web-sdk `parse*` function
+ * the element relies on; `badInput` is a deliberately invalid context that a
+ * conforming contract must reject (throw) rather than accept.
+ */
+export interface WebContractProbe {
+  label: string;
+  parse: (input: unknown) => unknown;
+  badInput: unknown;
+}
+
+export interface WebConformanceOptions {
+  /** The extension manifest (raw or parsed); `web.pages`/`web.slots` are read for element names. */
+  manifest: unknown;
+  /**
+   * Loads the extension's web entry, registering its custom elements. Called
+   * TWICE.
+   *
+   * IMPORTANT — `customElements` is a process-global registry and ES modules are
+   * cached by specifier, which shapes what this check can and cannot prove:
+   *
+   * - Registration is verified by an **undefined → defined transition across the
+   *   first call**, not merely by "is defined now". An element already present
+   *   before load (from a prior test, a shared entry, or another extension)
+   *   cannot be attributed to this entry and is reported as `element_preexisting`
+   *   unless {@link allowPreexistingElements} is set. Run each entry against a
+   *   fresh registry (e.g. a new happy-dom window per case) for a clean result.
+   * - Idempotency is only meaningfully tested when the second call **re-executes**
+   *   the entry's `customElements.define` logic. A bare `() => import('./web.js')`
+   *   returns the cached module on the second call WITHOUT re-running top-level
+   *   code, so an unguarded `define` will silently pass. To exercise idempotency,
+   *   make `loadEntry` re-run the registration (e.g. a cache-busted import, or a
+   *   function that calls the entry's `register()` directly).
+   */
+  loadEntry: () => unknown | Promise<unknown>;
+  /**
+   * Skip the `element_preexisting` check — for callers that deliberately verify
+   * against an already-populated registry and manage its lifecycle themselves.
+   */
+  allowPreexistingElements?: boolean;
+  /** Optional host-context contracts to prove reject invalid input. */
+  contracts?: WebContractProbe[];
+}
+
+function declaredElements(manifest: unknown): string[] {
+  const web = (manifest as { web?: unknown } | null | undefined)?.web as
+    | { pages?: unknown; slots?: unknown }
+    | undefined;
+  if (!web) return [];
+  const pages = Array.isArray(web.pages) ? web.pages : [];
+  const slots = Array.isArray(web.slots) ? web.slots : [];
+  return [...pages, ...slots]
+    .map((entry) => (entry as { element?: unknown } | null)?.element)
+    .filter((element): element is string => typeof element === 'string');
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Validate an extension's web contributions in a DOM (e.g. happy-dom) WITHOUT
+ * importing any host component:
+ * - every element declared in `web.pages`/`web.slots` becomes defined across the
+ *   load (undefined -> defined); already-defined elements are flagged rather than
+ *   silently passed (see {@link WebConformanceOptions.loadEntry});
+ * - re-loading the entry does not throw (definitions are idempotent — only
+ *   meaningful when `loadEntry` re-executes; see its docs);
+ * - each supplied host-context contract rejects invalid input.
+ */
+export async function assertWebContributionConformance(
+  options: WebConformanceOptions,
+): Promise<ConformanceResult> {
+  if (typeof customElements === 'undefined') {
+    throw new Error(
+      'assertWebContributionConformance requires a DOM environment; `customElements` is undefined. '
+      + 'Run this test under happy-dom (e.g. `// @vitest-environment happy-dom`).',
+    );
+  }
+
+  const issues: Issue[] = [];
+  const declared = declaredElements(options.manifest);
+
+  // Snapshot BEFORE the first load so registration is judged by an
+  // undefined -> defined transition, not by a global registry that some other
+  // test or import may already have populated (see `loadEntry` docs).
+  const definedBeforeLoad = new Set(declared.filter((name) => customElements.get(name)));
+
+  try {
+    await options.loadEntry();
+  } catch (error) {
+    return { ok: false, issues: [{ path: 'web.entry', code: 'entry_threw', message: errorMessage(error) }] };
+  }
+
+  for (const name of declared) {
+    if (!customElements.get(name)) {
+      issues.push({ path: `web.element.${name}`, code: 'element_not_registered', message: `custom element "${name}" was not defined after loading the web entry` });
+    } else if (definedBeforeLoad.has(name) && !options.allowPreexistingElements) {
+      issues.push({ path: `web.element.${name}`, code: 'element_preexisting', message: `custom element "${name}" was already defined before the entry loaded, so this entry's registration of it cannot be verified; run against a fresh registry or set allowPreexistingElements` });
+    }
+  }
+
+  try {
+    await options.loadEntry();
+  } catch (error) {
+    issues.push({ path: 'web.entry', code: 'entry_not_idempotent', message: `re-loading the web entry threw (likely an unguarded customElements.define): ${errorMessage(error)}` });
+  }
+
+  for (const probe of options.contracts ?? []) {
+    let rejected = false;
+    try {
+      probe.parse(probe.badInput);
+    } catch {
+      rejected = true;
+    }
+    if (!rejected) {
+      issues.push({ path: `web.contract.${probe.label}`, code: 'context_not_validated', message: `host-context contract "${probe.label}" accepted an invalid context instead of rejecting it` });
+    }
+  }
+
+  return { ok: issues.length === 0, issues };
+}

--- a/packages/extension-testkit/tsconfig.json
+++ b/packages/extension-testkit/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,7 +293,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/docs:
     dependencies:
@@ -357,7 +357,7 @@ importers:
         version: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/helper:
     dependencies:
@@ -433,7 +433,7 @@ importers:
         version: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/m365-graph-read-executor:
     dependencies:
@@ -473,7 +473,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/mobile:
     dependencies:
@@ -579,7 +579,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/outlook-addin:
     dependencies:
@@ -631,7 +631,7 @@ importers:
         version: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/portal:
     dependencies:
@@ -710,7 +710,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/powerpoint-addin:
     dependencies:
@@ -762,7 +762,7 @@ importers:
         version: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/viewer:
     dependencies:
@@ -823,7 +823,7 @@ importers:
         version: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/web:
     dependencies:
@@ -998,7 +998,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/word-addin:
     dependencies:
@@ -1050,7 +1050,7 @@ importers:
         version: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/extension-api:
     dependencies:
@@ -1072,7 +1072,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/extension-cli:
     dependencies:
@@ -1103,7 +1103,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/extension-sdk:
     dependencies:
@@ -1125,7 +1125,29 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/extension-testkit:
+    dependencies:
+      '@breeze/extension-sdk':
+        specifier: workspace:*
+        version: link:../extension-sdk
+      '@breeze/extension-web-sdk':
+        specifier: workspace:*
+        version: link:../extension-web-sdk
+      hono:
+        specifier: ^4.12.30
+        version: 4.12.30
+    devDependencies:
+      happy-dom:
+        specifier: ^20.11.0
+        version: 20.11.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/extension-web-sdk:
     dependencies:
@@ -1138,7 +1160,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/office-addin-core:
     dependencies:
@@ -1181,7 +1203,7 @@ importers:
         version: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/shared:
     dependencies:
@@ -1206,7 +1228,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -5618,6 +5640,12 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
@@ -6204,6 +6232,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -7816,6 +7848,10 @@ packages:
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
+  happy-dom@20.11.0:
+    resolution: {integrity: sha512-XogN4asPd1a56di9prVG6bZxteNcXsZxxKmAvcEfc5Px5Ca2hMyMgk8wvqK2K1V8zXg40j9VANXsDaJYh9DeNA==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
@@ -11514,6 +11550,10 @@ packages:
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -16823,6 +16863,12 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.3
+
   '@types/yargs-parser@21.0.3': {}
 
   '@types/yargs@15.0.20':
@@ -16934,7 +16980,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -17625,6 +17671,10 @@ snapshots:
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 25.9.3
 
   buffer@5.7.1:
     dependencies:
@@ -19385,6 +19435,19 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.4
       uncrypto: 0.1.3
+
+  happy-dom@20.11.0:
+    dependencies:
+      '@types/node': 25.9.3
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@3.0.0: {}
 
@@ -21984,7 +22047,7 @@ snapshots:
   react-devtools-core@6.1.5:
     dependencies:
       shell-quote: 1.8.4
-      ws: 7.5.11
+      ws: 7.5.12
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -23752,7 +23815,7 @@ snapshots:
     optionalDependencies:
       vite: 8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -23778,11 +23841,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.3
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.11.0
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -23808,11 +23872,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.1.1
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.11.0
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -23838,11 +23903,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.1.1
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.11.0
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -23868,6 +23934,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.1.1
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.11.0
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
@@ -24006,6 +24073,8 @@ snapshots:
   websocket-extensions@0.1.4: {}
 
   whatwg-fetch@3.6.20: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@5.0.0: {}
 


### PR DESCRIPTION
Adds `@breeze/extension-testkit` — the conformance toolkit extension authors run against their own extension, plus an additive `safeParseExtensionManifestV1` on `@breeze/extension-sdk`.

Four exports:
- `assertManifestConformance` — v1 manifest validation with actionable errors
- `stageExtensionForTest` — stages `register()` against a recording host context (throws on any db access, records routes/jobs/aiTools)
- `assertWebContributionConformance` — web entry idempotency + contribution shape checks
- `probeStockHost` — black-box probes for a running host (used by extension conformance suites)

21/21 tests; each of the 4 safety controls verified to fail when removed (mutation-checked). One documented residual: the web idempotency check needs `loadEntry` to re-execute — module import caching hides unguarded defines.

Rebased past the #2617/#2633 squash-merges as a single cherry-picked commit; lockfile regenerated against main.

Already consumed downstream: breeze-workspace vendors this package (its PR #11, merged) and its unit suite runs `stageExtensionForTest` against the real Workspace extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)