### PR TITLE
fix(api): extension loader test writes temp dirs to tmpdir, not the repo

### DIFF
--- a/apps/api/src/extensions/loader.test.ts
+++ b/apps/api/src/extensions/loader.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Hono } from 'hono';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 vi.mock('../services/aiTools', () => {
@@ -127,7 +128,12 @@ function scaffoldCjsRuntimeExtension(root: string) {
 describe('mountExtensions', () => {
   let root: string;
   beforeEach(async () => {
-    root = mkdtempSync(join(process.cwd(), 'ext-rt-'));
+    // tmpdir(), not process.cwd(): cleanup only runs in afterEach, so a run
+    // killed mid-suite orphans this directory. Under cwd that means an
+    // untracked `ext-rt-*` left in apps/api — not gitignored, so a later
+    // `git add .` would commit fixture scaffolding. Every other mkdtempSync in
+    // the API suite already roots at tmpdir(); this was the lone exception.
+    root = mkdtempSync(join(tmpdir(), 'breeze-ext-rt-'));
     __resetSkipPrefixesForTests();
     vi.clearAllMocks();
     const { aiTools } = await import('../services/aiTools');


### PR DESCRIPTION
## The problem

`apps/api/src/extensions/loader.test.ts` rooted its scaffolding at the repo working tree:

```ts
root = mkdtempSync(join(process.cwd(), 'ext-rt-'));
```

Cleanup is `afterEach(() => rmSync(root, ...))`, which only runs if the test completes. A run killed mid-suite — Ctrl-C, a crash, a timeout — orphans the directory inside `apps/api/`.

`ext-rt-*` is **not gitignored** (`git check-ignore` confirms), so the leftovers surface as untracked files. A later `git add .` would commit fixture scaffolding — a fake `breeze-extension.json` declaring `demo_items` / `demo_events` cascade tables, plus a stub Hono entry point — straight into the repo.

## How it surfaced

An orphaned `apps/api/ext-rt-ogRXaT/` was sitting in a working tree, containing exactly that fixture. It looked like it might be someone's work in progress; it was test detritus.

## The fix

Point it at `tmpdir()`, matching what the rest of the suite already does.

Every other `mkdtempSync` under `apps/api/src` — 15+ call sites, including its sibling `discovery.test.ts:16` in the same directory — already roots at `tmpdir()`. This was the lone exception, so this aligns with existing convention rather than introducing one.

Chose the path fix over adding `ext-rt-*` to `.gitignore`: the temp API exists for precisely this, and an ignore rule would still litter the working tree on every interrupted run — it would only hide the mess.

## Verification

- `loader.test.ts` — 40 tests pass
- `src/extensions/` — 20 files, 266 tests pass
- After a full run, `git status` shows only the modified test file: no untracked `ext-rt-*` anywhere
- Temp dirs land under `$TMPDIR` and are cleaned by `afterEach` as designed

Behavior is unchanged; only the location of the scratch directory moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
