### PR TITLE
refactor(extensions): deprecate build-time loading (Plan 05, Task 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+- Source-directory ("build-time") extension loading. Stock API images no longer install, build, or bake in `extensions/*` sources, and `extensions/*` is no longer a pnpm workspace glob. For one compatibility window, source extensions still load when `BREEZE_LEGACY_SOURCE_EXTENSIONS=true` is set (each emits a structured deprecation warning); an extension name may not be delivered as a source directory and a signed runtime artifact simultaneously — the boot fails instead of letting one silently shadow the other. Signed runtime bundles declared in `extensions.yaml` are the supported path. Earliest removal and its gate are recorded in `docs/extensions/build-time-transition.md`.
+
 ### Security
 - Microsoft 365 ticket mailbox consent now verifies the Microsoft tenant and consenting administrator identity and binds verified tenant ownership to the Breeze partner. Existing active connections, plus disabled rows that retain legacy tenant or cursor state, require consent again after upgrade; clean disabled rows remain disabled.
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -75,6 +75,14 @@ COPY --from=builder --chown=hono:nodejs /app/packages ./packages
 
 # Copy migration files for auto-migrate on startup
 COPY --from=builder --chown=hono:nodejs /app/apps/api/migrations ./apps/api/migrations
+# Runtime-extension mount point: deployments deliver extensions as SIGNED
+# bundles by mounting extensions.yaml (+ artifacts) here. Created empty and
+# owned by the runtime user; without a mount both the reconciler and the
+# (deprecated, flag-gated) legacy source loader treat it as a clean no-op.
+# Without this ENV the CJS bundle would fall back to a cwd-derived path that
+# does not exist in this image's layout, silently ignoring any mount.
+RUN mkdir -p /app/extensions && chown hono:nodejs /app/extensions
+ENV BREEZE_EXTENSIONS_DIR=/app/extensions
 # Run the API from its workspace path so module resolution uses apps/api/node_modules first.
 WORKDIR /app/apps/api
 

--- a/apps/api/src/extensions/discovery.test.ts
+++ b/apps/api/src/extensions/discovery.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { discoverExtensions } from './discovery';
+import { discoverExtensions, listSourceExtensionCandidates } from './discovery';
 
 const MANIFEST = {
   name: 'sample',
@@ -85,5 +85,37 @@ describe('discoverExtensions', () => {
     expect(discoverExtensions(root).map((e) => e.manifest.routeNamespace)).toEqual([
       'alpha-routes', 'beta-routes',
     ]);
+  });
+});
+
+describe('listSourceExtensionCandidates', () => {
+  it('returns [] for a missing or empty root', () => {
+    expect(listSourceExtensionCandidates(join(root, 'nope'))).toEqual([]);
+    expect(listSourceExtensionCandidates(root)).toEqual([]);
+  });
+
+  it('lists directories carrying a manifest file, ignoring everything else', () => {
+    scaffold('sample', MANIFEST);
+    mkdirSync(join(root, 'node_modules'));
+    writeFileSync(join(root, 'README.md'), 'seam docs');
+    symlinkSync(join(root, 'missing-target'), join(root, 'dangling'));
+    expect(listSourceExtensionCandidates(root)).toEqual(['sample']);
+  });
+
+  // The candidate scan feeds the flag-off deprecation warning in the loader. It
+  // must never PARSE the manifest: a broken manifest in a disabled legacy path
+  // must not be able to fail the boot.
+  it('lists a candidate whose manifest is unparseable JSON, without throwing', () => {
+    const dir = join(root, 'broken');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'breeze-extension.json'), '{ not json');
+    expect(listSourceExtensionCandidates(root)).toEqual(['broken']);
+    expect(() => listSourceExtensionCandidates(root)).not.toThrow();
+  });
+
+  it('sorts candidates by name', () => {
+    scaffold('zeta', { ...MANIFEST, name: 'zeta', routeNamespace: 'zeta', tenancy: {} });
+    scaffold('alpha', { ...MANIFEST, name: 'alpha', routeNamespace: 'alpha', tenancy: {} });
+    expect(listSourceExtensionCandidates(root)).toEqual(['alpha', 'zeta']);
   });
 });

--- a/apps/api/src/extensions/discovery.ts
+++ b/apps/api/src/extensions/discovery.ts
@@ -16,8 +16,9 @@ const MANIFEST_FILENAME = 'breeze-extension.json';
  * Repo-root extensions/ dir. Mirrors resolveMigrationsDir() in autoMigrate.ts:
  * ESM dev resolves relative to this file (src/extensions/ → ../../../../extensions
  * = <repo>/extensions); the CJS Docker bundle falls back to cwd. Overridable via
- * BREEZE_EXTENSIONS_DIR (used by the prod image, where extensions are copied
- * next to the bundle).
+ * BREEZE_EXTENSIONS_DIR (the prod image points it at an empty mount directory
+ * where deployments place extensions.yaml and, for the deprecated legacy path,
+ * source extension directories).
  */
 export function resolveExtensionsRoot(): string {
   if (process.env.BREEZE_EXTENSIONS_DIR) {
@@ -30,6 +31,27 @@ export function resolveExtensionsRoot(): string {
   } catch {
     return path.join(process.cwd(), 'extensions');
   }
+}
+
+/**
+ * Names of directories under `root` that carry a legacy source-extension
+ * manifest. Deliberately does NOT parse the manifests: this scan feeds the
+ * flag-off deprecation warning in the loader, and a broken manifest on a
+ * disabled legacy path must not be able to fail the boot.
+ */
+export function listSourceExtensionCandidates(root: string = resolveExtensionsRoot()): string[] {
+  if (!existsSync(root)) return [];
+  const candidates: string[] = [];
+  for (const entry of readdirSync(root)) {
+    const dir = path.join(root, entry);
+    try {
+      if (!statSync(dir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    if (existsSync(path.join(dir, MANIFEST_FILENAME))) candidates.push(entry);
+  }
+  return candidates.sort((a, b) => a.localeCompare(b));
 }
 
 export function discoverExtensions(root: string = resolveExtensionsRoot()): DiscoveredExtension[] {

--- a/apps/api/src/extensions/loader.test.ts
+++ b/apps/api/src/extensions/loader.test.ts
@@ -130,10 +130,17 @@ describe('mountExtensions', () => {
     root = mkdtempSync(join(process.cwd(), 'ext-rt-'));
     __resetSkipPrefixesForTests();
     vi.clearAllMocks();
+    // The legacy source-directory path is deprecated and flag-gated; these
+    // suites exercise the compatibility window, so opt in by default. The
+    // "compatibility window" describe below covers the flag-off behavior.
+    vi.stubEnv('BREEZE_LEGACY_SOURCE_EXTENSIONS', 'true');
     const { aiTools } = await import('../services/aiTools');
     aiTools.clear();
   });
-  afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
 
   it('stages and activates legacy route and AI contributions under the stable namespace', async () => {
     scaffoldRuntimeExtension(root, { routeNamespace: 'legacy-alias' });
@@ -289,6 +296,174 @@ describe('mountExtensions', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, ext: 'stale-dist' });
     vi.unstubAllEnvs();
+  });
+
+  describe('compatibility window (BREEZE_LEGACY_SOURCE_EXTENSIONS)', () => {
+    it('does NOT load a present source extension when the flag is unset, warning once per candidate', async () => {
+      vi.unstubAllEnvs(); // genuinely unset, not merely !== 'true'
+      scaffoldRuntimeExtension(root);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const registry = new ExtensionContributionRegistry();
+      const app = new Hono();
+      mountExtensionGateway(app, registry, async () => true);
+
+      await loadSourceExtensions(registry, root);
+
+      expect(registry.get('demo')).toBeUndefined();
+      expect((await app.request('/api/v1/ext/demo/health')).status).toBe(503);
+      const skipWarnings = warn.mock.calls.filter(
+        (call) => String(call[0]).includes('legacy_source_extension_skipped'),
+      );
+      expect(skipWarnings).toHaveLength(1);
+      expect(String(skipWarnings[0]![0])).toContain('"demo"');
+      expect(String(skipWarnings[0]![0])).toContain('BREEZE_LEGACY_SOURCE_EXTENSIONS');
+      warn.mockRestore();
+    });
+
+    it('does not load when the flag is explicitly false', async () => {
+      vi.stubEnv('BREEZE_LEGACY_SOURCE_EXTENSIONS', 'false');
+      scaffoldRuntimeExtension(root);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const registry = new ExtensionContributionRegistry();
+      await loadSourceExtensions(registry, root);
+      expect(registry.get('demo')).toBeUndefined();
+      warn.mockRestore();
+    });
+
+    // A broken manifest on the DISABLED legacy path must not be able to fail
+    // the boot — the flag-off scan may not parse manifests.
+    it('skips (never throws on) an unparseable manifest when the flag is off', async () => {
+      vi.unstubAllEnvs();
+      const dir = join(root, 'broken');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'breeze-extension.json'), '{ not json');
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const registry = new ExtensionContributionRegistry();
+
+      await expect(loadSourceExtensions(registry, root)).resolves.toBeUndefined();
+
+      const skipWarnings = warn.mock.calls.filter(
+        (call) => String(call[0]).includes('legacy_source_extension_skipped'),
+      );
+      expect(skipWarnings).toHaveLength(1);
+      expect(String(skipWarnings[0]![0])).toContain('"broken"');
+      warn.mockRestore();
+    });
+
+    it('emits exactly one structured deprecation warning per loaded extension when the flag is on', async () => {
+      scaffoldRuntimeExtension(root);
+      scaffoldCjsRuntimeExtension(root);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const registry = new ExtensionContributionRegistry();
+
+      await loadSourceExtensions(registry, root);
+
+      expect(registry.get('demo')).toBeDefined();
+      expect(registry.get('cjs-demo')).toBeDefined();
+      const deprecations = warn.mock.calls.filter(
+        (call) => String(call[0]).includes('legacy_source_extension_loaded'),
+      );
+      expect(deprecations).toHaveLength(2);
+      const messages = deprecations.map((call) => String(call[0]));
+      expect(messages.some((m) => m.includes('"demo"'))).toBe(true);
+      expect(messages.some((m) => m.includes('"cjs-demo"'))).toBe(true);
+      for (const message of messages) expect(message).toContain('DEPRECATION');
+      warn.mockRestore();
+    });
+
+    // Same-name simultaneity gate: registry.activate() REPLACES a same-name
+    // snapshot, so without this check a signed runtime artifact staged after
+    // the source extension would silently shadow it (and a failed optional
+    // artifact would withdraw the source extension's live routes). Fail the
+    // boot instead — the operator must pick one delivery path per name.
+    it('refuses to load a source extension whose name is also declared in extensions.yaml', async () => {
+      scaffoldRuntimeExtension(root);
+      writeFileSync(
+        join(root, 'extensions.yaml'),
+        'extensions:\n  - name: demo\n    uri: file:./demo.tar\n    version: 1.0.0\n    publisher: acme\n',
+      );
+      const registry = new ExtensionContributionRegistry();
+
+      await expect(loadSourceExtensions(registry, root)).rejects.toThrow(
+        /"demo".*(source directory).*(runtime artifact|extensions\.yaml)/s,
+      );
+      expect(registry.get('demo')).toBeUndefined();
+    });
+
+    it('loads normally alongside an extensions.yaml declaring only OTHER names', async () => {
+      scaffoldRuntimeExtension(root);
+      writeFileSync(
+        join(root, 'extensions.yaml'),
+        'extensions:\n  - name: other\n    uri: file:./other.tar\n    version: 1.0.0\n    publisher: acme\n',
+      );
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const registry = new ExtensionContributionRegistry();
+      await loadSourceExtensions(registry, root);
+      expect(registry.get('demo')).toBeDefined();
+      warn.mockRestore();
+    });
+
+    // Coexistence: a runtime artifact's tables (migrated on a prior boot)
+    // exist BEFORE reconcileExtensions publishes their tenancy on this boot.
+    // The loader's repo-wide sweep would misread them as unaccounted and
+    // abort a healthy boot — it must defer to the reconciler's own
+    // post-publish sweep whenever extensions.yaml declares runtime artifacts.
+    it('defers the repo-wide sweep to the reconciler when extensions.yaml declares runtime artifacts', async () => {
+      scaffoldRuntimeExtension(root);
+      writeFileSync(
+        join(root, 'extensions.yaml'),
+        'extensions:\n  - name: other\n    uri: file:./other.tar\n    version: 1.0.0\n    publisher: acme\n',
+      );
+      const { db } = await import('../db');
+      // A tenant-scoped table owned by the runtime extension, visible in the
+      // catalog. Without the deferral the loader's second (repo-wide) query
+      // reads this as unaccounted and throws.
+      (db.execute as ReturnType<typeof vi.fn>).mockResolvedValue([
+        {
+          table_name: 'other_docs',
+          relkind: 'r',
+          rls_enabled: true,
+          rls_forced: true,
+          policy_count: 1,
+          tenant_column_count: 1,
+          tenant_fk_count: 1,
+        },
+      ]);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const registry = new ExtensionContributionRegistry();
+
+      await expect(loadSourceExtensions(registry, root)).resolves.toBeUndefined();
+
+      expect(registry.get('demo')).toBeDefined();
+      // Only the per-extension prefix scan ran; the repo-wide sweep is the
+      // reconciler's job on this boot shape.
+      expect(db.execute).toHaveBeenCalledTimes(1);
+      warn.mockRestore();
+    });
+
+    it('still runs the repo-wide sweep itself when NO runtime artifacts are declared', async () => {
+      scaffoldRuntimeExtension(root);
+      const { db } = await import('../db');
+      (db.execute as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const registry = new ExtensionContributionRegistry();
+
+      await loadSourceExtensions(registry, root);
+
+      // Per-extension scan + repo-wide sweep, exactly as before the window.
+      expect(db.execute).toHaveBeenCalledTimes(2);
+      warn.mockRestore();
+    });
+
+    // Fail closed: if the deployment config exists but cannot be read, the
+    // collision gate cannot prove the absence of a same-name artifact.
+    it('fails the boot when extensions.yaml is present but unparseable', async () => {
+      scaffoldRuntimeExtension(root);
+      writeFileSync(join(root, 'extensions.yaml'), 'extensions: [ {{ nope');
+      const registry = new ExtensionContributionRegistry();
+      await expect(loadSourceExtensions(registry, root)).rejects.toThrow(/not valid YAML/);
+      expect(registry.get('demo')).toBeUndefined();
+    });
   });
 
   it('respects BREEZE_EXTENSIONS_ENABLED=false', async () => {

--- a/apps/api/src/extensions/loader.ts
+++ b/apps/api/src/extensions/loader.ts
@@ -1,9 +1,10 @@
 // Legacy source-directory extensions register against an isolated staging
 // adapter. The stable gateway owns routing and auth; this loader publishes no
 // route or AI contribution until all registration and tenancy checks pass.
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { load as loadYaml } from 'js-yaml';
 import type {
   AiToolLike,
   BreezeExtension,
@@ -14,7 +15,12 @@ import {
   parseExtensionManifestV1,
   type ExtensionManifestV1,
 } from '@breeze/extension-sdk';
-import { discoverExtensions, type DiscoveredExtension } from './discovery';
+import {
+  discoverExtensions,
+  listSourceExtensionCandidates,
+  resolveExtensionsRoot,
+  type DiscoveredExtension,
+} from './discovery';
 import {
   ExtensionContributionRegistry,
   type StagedExtensionContributions,
@@ -148,10 +154,44 @@ async function stageLegacyExtension(
   return session.finish();
 }
 
+const DEPRECATION_DOCS = 'docs/extensions/build-time-transition.md';
+
+/**
+ * Names declared in the runtime deployment config (`extensions.yaml`) in the
+ * same extensions root. Only names are extracted — full validation stays the
+ * reconciler's job (config.ts) — but a PRESENT-yet-unreadable file fails
+ * closed: the same-name gate cannot prove the absence of a collision.
+ */
+function declaredRuntimeExtensionNames(root: string): Set<string> {
+  const configPath = path.join(root, 'extensions.yaml');
+  if (!existsSync(configPath)) return new Set();
+  let raw: unknown;
+  try {
+    raw = loadYaml(readFileSync(configPath, 'utf8'));
+  } catch {
+    // Never surface the raw parser exception (it can echo file contents).
+    throw new Error('[extensions] extensions.yaml is not valid YAML');
+  }
+  const names = new Set<string>();
+  const extensions = (raw as { extensions?: unknown } | null)?.extensions;
+  if (Array.isArray(extensions)) {
+    for (const entry of extensions) {
+      const name = (entry as { name?: unknown } | null)?.name;
+      if (typeof name === 'string') names.add(name);
+    }
+  }
+  return names;
+}
+
 /**
  * Adapts source-directory extensions to the staged v1 contribution registry.
  * No route or AI contribution becomes live until every extension has
  * registered, validated, and passed both tenancy tripwires.
+ *
+ * DEPRECATED delivery path (compatibility window): source-directory loading is
+ * gated behind BREEZE_LEGACY_SOURCE_EXTENSIONS=true and will be removed — see
+ * docs/extensions/build-time-transition.md for the dated gate. Signed runtime
+ * bundles (extensions.yaml + reconcileExtensions) are the supported path.
  */
 export async function loadSourceExtensions(
   registry: ExtensionContributionRegistry,
@@ -162,17 +202,68 @@ export async function loadSourceExtensions(
     return;
   }
 
-  const discovered = discoverExtensions(root);
+  const resolvedRoot = root ?? resolveExtensionsRoot();
+
+  if (process.env.BREEZE_LEGACY_SOURCE_EXTENSIONS !== 'true') {
+    // Candidate scan only — no manifest parsing, so a broken manifest on the
+    // disabled legacy path cannot fail the boot.
+    for (const name of listSourceExtensionCandidates(resolvedRoot)) {
+      console.warn(
+        `[extensions] ${JSON.stringify({
+          event: 'legacy_source_extension_skipped',
+          extension: name,
+          reason: 'source-directory extension loading is deprecated and disabled by default',
+          enableFlag: 'BREEZE_LEGACY_SOURCE_EXTENSIONS',
+          docs: DEPRECATION_DOCS,
+        })}`,
+      );
+    }
+    return;
+  }
+
+  const discovered = discoverExtensions(resolvedRoot);
   if (discovered.length === 0) return;
+
+  // Same-name simultaneity gate. registry.activate() REPLACES a same-name
+  // snapshot, so a signed runtime artifact reconciled after this loader would
+  // silently shadow the source extension — and a failed optional artifact
+  // would withdraw the source extension's live routes. One delivery path per
+  // name; fail the boot before staging anything.
+  const runtimeNames = declaredRuntimeExtensionNames(resolvedRoot);
+  for (const extension of discovered) {
+    if (runtimeNames.has(extension.name)) {
+      throw new Error(
+        `[extensions] "${extension.name}" is present as a legacy source directory AND declared as a runtime artifact in extensions.yaml; a source-directory extension cannot be enabled simultaneously with a runtime artifact of the same name — remove the source directory or the extensions.yaml entry`,
+      );
+    }
+  }
 
   const staged: StagedExtensionContributions[] = [];
   for (const extension of discovered) {
+    console.warn(
+      `[extensions] DEPRECATION ${JSON.stringify({
+        event: 'legacy_source_extension_loaded',
+        extension: extension.name,
+        message: 'source-directory extension loading is deprecated and will be removed; ship a signed runtime bundle instead',
+        docs: DEPRECATION_DOCS,
+      })}`,
+    );
     const contributions = await stageLegacyExtension(extension, registry);
     await assertExtensionTenancyRls(extension.name, extension.manifest.tenancy);
     staged.push(contributions);
   }
 
-  await assertNoUnaccountedPublicTables(discovered.map((extension) => extension.manifest.tenancy));
+  // Repo-wide sweep — but only when this loader is the ONLY extension path on
+  // this boot. When extensions.yaml also declares runtime artifacts, their
+  // tables (migrated on a prior boot) already exist while their tenancy is
+  // published only later by reconcileExtensions — sweeping here would misread
+  // them as unaccounted and abort a healthy boot. The reconciler runs this
+  // same sweep once per boot AFTER publishing runtime tenancy, over
+  // getExtensionTenancy()'s union of source manifests and runtime
+  // declarations, so deferring keeps the fail-closed contract.
+  if (runtimeNames.size === 0) {
+    await assertNoUnaccountedPublicTables(discovered.map((extension) => extension.manifest.tenancy));
+  }
 
   const aiToolOwners = new Map<string, string>();
   for (const contributions of staged) {

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -19,17 +19,6 @@ COPY --from=deps /app/packages/extension-api/node_modules ./packages/extension-a
 COPY --from=deps /app/packages/extension-sdk/node_modules ./packages/extension-sdk/node_modules
 COPY . .
 RUN pnpm --filter @breeze/api build
-# Build any extension packages present in the build context (gitignored dir —
-# empty on public builds; hosted builds clone extensions in beforehand).
-# The deps stage installs only core workspace packages, and the committed
-# lockfile deliberately carries no extension importers (a private extension's
-# dependency graph must not leak into the public lockfile) — so extensions get
-# a scoped, non-frozen install here before building.
-# `|| true` is NOT used: if an extension is present but fails to build, fail the image.
-RUN if [ -n "$(ls -A extensions 2>/dev/null | grep -v README.md)" ]; then \
-      pnpm install --filter './extensions/*' --no-frozen-lockfile --prefer-offline && \
-      pnpm --filter './extensions/*' build; \
-    fi
 # Create a self-contained deployment (resolves pnpm symlinks).
 # pnpm 10's deploy command requires workspace deps be declared injected.
 # TODO: declare @breeze/shared (and other workspace deps) as injected in
@@ -59,10 +48,11 @@ COPY --from=builder --chown=hono:nodejs /deployed/package.json ./
 
 # Copy migration files for auto-migrate on startup
 COPY --from=builder --chown=hono:nodejs /app/apps/api/migrations ./migrations
-# Extension artifacts: manifest + built entry + raw migrations. The trailing
-# glob-on-source with a guaranteed-present file (README.md) keeps COPY happy
-# when no extensions exist.
-COPY --from=builder --chown=hono:nodejs /app/extensions ./extensions
+# The stock image contains public SDK/host code only — no extension source or
+# builds are baked in. Deployments deliver extensions as SIGNED runtime bundles
+# by mounting extensions.yaml (+ artifacts) into this directory; it is created
+# empty so the mount point exists and is owned by the runtime user.
+RUN mkdir -p /app/extensions && chown hono:nodejs /app/extensions
 ENV BREEZE_EXTENSIONS_DIR=/app/extensions
 USER hono
 

--- a/docs/extensions/build-time-transition.md
+++ b/docs/extensions/build-time-transition.md
@@ -1,0 +1,78 @@
+# Build-time extension loading: transition and removal gate
+
+Breeze historically supported loading extensions from source directories under
+`extensions/` ("build-time" or "source-directory" loading): hosted images
+cloned extension repos into the build context, built them with the API image,
+and the loader imported their entry at boot. That path is **deprecated**. The
+supported delivery mechanism is a **signed runtime bundle**: a
+`breeze-ext`-packed artifact declared in `extensions.yaml`, verified against a
+pinned digest and trusted publisher key, migrated, staged through the v1 SDK
+contract, and activated by the reconciler — all against a stock Breeze image
+that contains public SDK/host code only.
+
+## What changed
+
+- Stock images (`docker/Dockerfile.api`, `apps/api/Dockerfile`) no longer
+  install, build, or bake in anything from `extensions/*`. The runtime image
+  ships an empty `/app/extensions` mount point (`BREEZE_EXTENSIONS_DIR`) where
+  deployments place `extensions.yaml` and artifacts.
+- `extensions/*` was removed from `pnpm-workspace.yaml`. A legacy source
+  checkout builds standalone inside its own directory.
+- Source-directory loading is gated behind
+  **`BREEZE_LEGACY_SOURCE_EXTENSIONS=true`**. Without the flag, present source
+  extensions are skipped with a structured
+  `legacy_source_extension_skipped` warning naming the flag.
+- With the flag set, every loaded source extension emits one structured
+  `legacy_source_extension_loaded` deprecation warning, and still runs through
+  the same staged v1 contribution registry, auth default-deny gateway, and
+  tenancy/RLS tripwires as runtime bundles.
+- An extension name may be delivered by **only one path at a time**: if a
+  source directory and an `extensions.yaml` runtime artifact share a name, the
+  boot fails (previously the second activation silently replaced the first).
+
+## Compatibility window and removal gate
+
+- **First stable release containing the server SDK v1 runtime host:**
+  **v0.98.0** (host descriptor: `breezeVersion 0.1.0`, `serverSdk 1.0.0`,
+  `breeze.extensions/v1`). This release deprecates source-directory loading and
+  introduces the `BREEZE_LEGACY_SOURCE_EXTENSIONS` gate.
+- **Earliest stable release allowed to remove the legacy adapter and
+  source-directory discovery path: v0.99.0** — i.e. the legacy path ships for
+  at least the full v0.98.x series.
+
+Removal (in v0.99.0 or later) additionally requires ALL of:
+
+1. The SDK v1 compatibility fixtures (`packages/extension-sdk/fixtures/v1/*`
+   and the blocking API CI gate described in `sdk-compatibility.md`) are green
+   on the release candidate.
+2. A published migration guide covering the source-directory → signed-bundle
+   conversion (pack, sign, declare in `extensions.yaml`), with
+   `breeze-workspace` as the reference implementation.
+3. A release-note entry announcing the removal.
+
+What removal covers: `loadSourceExtensions`, `discoverExtensions`'
+source-directory scanning, the legacy `breeze-extension.json` →  v1 manifest
+adapter in the loader, and the `BREEZE_LEGACY_SOURCE_EXTENSIONS` flag itself.
+
+**What removal does NOT cover:** the public v1 SDK
+(`@breeze/extension-sdk`, `@breeze/extension-web-sdk`), the v1 manifest
+schema, the runtime reconciler, or the SDK v1 CI gate. Removing the
+source-directory loader is a delivery-path retirement, not an SDK version
+bump; the v1 SDK remains governed by the separate policy in
+`sdk-compatibility.md`.
+
+## Migrating an extension
+
+1. Adopt the v1 manifest (`manifest.json`, `breeze.extensions/v1`) and the
+   two-argument `register(registrar, context)` SDK contract.
+2. Build server (CJS) and web (ESM) entries; pack and sign with `breeze-ext
+   pack` / `breeze-ext sign`.
+3. Declare the artifact in `extensions.yaml` (name, uri, pinned `sha256:`
+   digest — required in production — and a publisher declared in the
+   `publishers` map).
+4. Remove the source checkout from `extensions/` (or leave it and drop the
+   flag: it will be skipped with a warning; the same NAME cannot be both).
+
+The end-to-end conformance reference is the `breeze-workspace` repository
+(`test/conformance`), which proves this pipeline against an unmodified stock
+image.

--- a/docs/extensions/sdk-compatibility.md
+++ b/docs/extensions/sdk-compatibility.md
@@ -24,3 +24,12 @@ release has shipped after SDK v2 first ships. Removing the v1 fixture or gate
 before that release is not supported. After the window closes, removal requires
 an intentional compatibility-policy change and release-note entry; it must not
 happen as incidental test cleanup.
+
+## Legacy source-directory (build-time) loading
+
+Source-directory extension loading is deprecated as of v0.98.0 and gated
+behind `BREEZE_LEGACY_SOURCE_EXTENSIONS=true` for a one-release compatibility
+window; the earliest release allowed to remove it is v0.99.0, behind the dated
+gate recorded in `build-time-transition.md`. That removal retires a delivery
+path only — it does not remove the public v1 SDK, the v1 manifest schema, or
+this document's CI gate, which are governed by the SDK v2 window above.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,12 +1,28 @@
 # Breeze Extensions
 
-This directory hosts optional extension packages. It is empty in the public
-repo — extensions are separate (possibly private) repos cloned in:
+> **DEPRECATED: source-directory (build-time) extension loading.**
+> The supported delivery path is a **signed runtime bundle**: declare the
+> artifact in `extensions.yaml` in this directory and the host verifies,
+> migrates, stages, and activates it at startup (see
+> `docs/extensions/build-time-transition.md` for the transition and its dated
+> removal gate). Source-directory loading described below still works for **one
+> compatibility window** and only when `BREEZE_LEGACY_SOURCE_EXTENSIONS=true`
+> is set; each loaded source extension emits a structured deprecation warning.
+> A source directory and a runtime artifact may **not** be enabled under the
+> same extension name — the boot fails rather than letting one silently shadow
+> the other. Stock images no longer build or bake in `extensions/*` sources.
+
+This directory hosts the runtime deployment config (`extensions.yaml`) and,
+during the compatibility window only, legacy source extension checkouts:
 
     git clone <extension-repo-url> extensions/<name>
-    pnpm install
 
-Each extension is a pnpm workspace package carrying a `breeze-extension.json`
+Note `extensions/*` is no longer a pnpm workspace glob: a cloned extension
+manages its own dependencies and build (`pnpm install && pnpm build` inside the
+checkout); the loader runs `dist/index.cjs` in production and the TS source
+entry in dev.
+
+Each legacy extension carries a `breeze-extension.json`
 manifest (validated by `@breeze/extension-api`) that declares:
 
 - `name` — lowercase slug; also the migration-ledger prefix (`<name>/<file>.sql`)
@@ -27,13 +43,12 @@ loading even when extensions are present.
 
 ## Lockfile policy
 
-Extension importers must NOT be committed to the public `pnpm-lock.yaml` — a
-private extension's dependency graph would leak. Running `pnpm install` with an
-extension present adds an `extensions/<name>` importer hunk locally; leave it
-out of commits (`git checkout pnpm-lock.yaml` before staging). Docker builds
-account for this: the builder stage runs a scoped
-`pnpm install --filter './extensions/*' --no-frozen-lockfile` before building
-extensions, so the committed lockfile stays extension-free.
+Extension importers must NOT appear in the public `pnpm-lock.yaml` — a private
+extension's dependency graph would leak. Since `extensions/*` is no longer a
+workspace glob this now holds automatically: `pnpm install` at the repo root
+ignores extension checkouts, and stock Docker images neither install nor build
+them. A legacy checkout installs and builds inside its own directory with its
+own lockfile.
 
 ## Seam v2: manifest flags and ExtensionContext
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,6 @@
 packages:
   - 'apps/*'
   - 'packages/*'
-  - 'extensions/*'
 
 # pnpm 11+ refuses to run install scripts unless they're in this allowlist.
 # Add packages here only after confirming what their install script does:


### PR DESCRIPTION
Closes out Plan 05 Task 6 (`docs/superpowers/plans/2026-07-15-runtime-extension-platform-05-workspace.md` in breeze-workspace): the legacy source-directory ("build-time") extension path enters a one-release compatibility window now that the signed runtime-bundle pipeline is live-proven (workspace conformance 8/8 on a stock image; breeze-workspace `test/conformance`).

## Loader compatibility window (`apps/api/src/extensions/loader.ts`)
- Source-directory loading now requires **`BREEZE_LEGACY_SOURCE_EXTENSIONS=true`**. Flag off: present candidates are skipped with a structured `legacy_source_extension_skipped` warning — via a scan that never parses manifests, so a broken manifest on the disabled path cannot fail boot.
- Flag on: one structured `legacy_source_extension_loaded` DEPRECATION warning per extension; everything still runs through the staged v1 contribution registry, default-deny auth gateway, and tenancy/RLS tripwires.
- **Same-name simultaneity gate:** a source extension whose name is also declared as a runtime artifact in `extensions.yaml` fails the boot. Previously `registry.activate()` silently *replaced* the same-name snapshot, so the second delivery path shadowed the first (and a failed optional artifact would `withdraw()` the source extension's live routes). A present-but-unparseable `extensions.yaml` fails closed.

- **Repo-wide tenancy sweep deferral (coexistence fix, found by live estate restart):** with the flag on, a source extension plus an already-installed runtime artifact aborted a healthy boot — the loader's repo-wide `assertNoUnaccountedPublicTables` runs *before* `reconcileExtensions` publishes runtime tenancy, so the runtime extension's tables (migrated on a prior boot) read as unaccounted. The loader now defers the repo-wide sweep to the reconciler's own post-publish sweep whenever `extensions.yaml` declares runtime artifacts (with no runtime config it sweeps itself, exactly as before). Proven red-first both ways (defer when declared / self-sweep when not).

## Stock images contain host/SDK code only
- `docker/Dockerfile.api`: dropped the `extensions/*` scoped install/build and the COPY of extension sources; ships an empty, `hono`-owned `/app/extensions` mount point (`BREEZE_EXTENSIONS_DIR`).
- `apps/api/Dockerfile` (the GHCR release image): was already source-free, but had **no** `BREEZE_EXTENSIONS_DIR` and no `/app/extensions` — mounting `extensions.yaml` on the released image silently no-oped (cwd-fallback path doesn't exist in that layout). Now ships the same owned mount point + ENV. (Found by review.)
- `extensions/*` removed from `pnpm-workspace.yaml`; legacy checkouts build standalone. Committed lockfile unchanged (`--frozen-lockfile` verified).

## Dated removal gate (docs)
- New `docs/extensions/build-time-transition.md`: deprecated in **v0.98.0** (first stable with the v1 host — hostDescriptor `breezeVersion 0.1.0` / `serverSdk 1.0.0`); earliest removal **v0.99.0**, and only with green v1 fixtures + a shipped migration guide + a release note. Removal retires the delivery path only — never the public v1 SDK (cross-referenced in `sdk-compatibility.md`).
- `extensions/README.md` rewritten around the deprecation; CHANGELOG entry under Unreleased.

## Verification
- TDD: every new control (flag gate, no-parse skip scan, per-extension warning, collision gate, yaml fail-closed) was proven red before implementation; `src/extensions/` suite 277/277 green; `pnpm --filter @breeze/api build` clean.
- Independent review round completed; its one Important finding (release image lacking the mount point) is fixed in this PR.
- Live: stock image rebuilt from this branch via `docker/Dockerfile.api` and re-run against the breeze-workspace conformance estate (results in PR comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
