### PR TITLE
fix(ci): copy extension-web-sdk manifest into the web Docker deps stage

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -13,9 +13,19 @@ FROM base AS deps
 WORKDIR /app
 
 # Copy workspace configuration
+#
+# EVERY workspace package in apps/web's dependency graph must be listed here.
+# Stage 3 copies all of packages/ as SOURCE (see `COPY packages ./packages`), so
+# a package missing from this list still gets compiled — but with no node_modules
+# of its own, which fails at bundle time with an unresolved bare import rather
+# than a missing-package error. CI's `Build Web` job does a full workspace
+# install and cannot catch this; only the Docker build has this narrow scope.
+# (v0.98.0 shipped without a web image this way: @breeze/extension-web-sdk was
+# absent here, so its `zod` never installed and Rolldown failed to resolve it.)
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY apps/web/package.json ./apps/web/
 COPY packages/shared/package.json ./packages/shared/
+COPY packages/extension-web-sdk/package.json ./packages/extension-web-sdk/
 
 # Install all dependencies
 RUN pnpm install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
## Summary

v0.98.0 published all 40 release artifacts and then failed on `Build & Push Web Docker Image`, so the release shipped with **no `breeze/web:0.98.0` container** and is not deployable. v0.98.0 has been marked pre-release with a warning banner; this fix goes out as v0.98.1.

**Root cause.** `apps/web/Dockerfile` copies workspace manifests one at a time into the deps stage:

```dockerfile
COPY apps/web/package.json ./apps/web/
COPY packages/shared/package.json ./packages/shared/
RUN pnpm install --frozen-lockfile --prefer-offline
```

`apps/web` gained a `@breeze/extension-web-sdk` workspace dependency in #2633 and that manifest was never added, so `pnpm install` skipped its dependencies. Stage 3 then copies **all** of `packages/` as source regardless, so the package compiled with no `node_modules` of its own and the Astro build failed at bundle time:

```
[vite]: Rolldown failed to resolve import "zod" from packages/extension-web-sdk/src/events.ts
```

The unresolved-import shape is why this reads as a bundler problem rather than a Dockerfile one.

**Why CI was green.** The `Build Web` job does a full workspace install with every manifest present. Only the Docker build uses the narrow copy scope, and it runs solely in the release workflow — so `main` stayed green and the gap only surfaced after the tag published.

## Change

One `COPY` line for the missing manifest, plus a comment explaining the invariant so the next workspace dependency does not repeat it.

## Verification

Built the same Dockerfile locally to the builder stage on the fix commit: Astro `[build] Complete!`, zero resolve errors, image exported. This is the exact build that failed in the release run.

## Follow-up

Structural guard for the class — asserting every workspace package in `apps/web`'s dependency graph is copied, and applying the same check to the api/portal Dockerfiles — is tracked in #2661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)