### PR TITLE
docs(extensions): correct the deprecation-gate anchor (v0.98.0 predates the gate)

### DIFF
--- a/docs/extensions/build-time-transition.md
+++ b/docs/extensions/build-time-transition.md
@@ -33,14 +33,20 @@ that contains public SDK/host code only.
 ## Compatibility window and removal gate
 
 - **First stable release containing the server SDK v1 runtime host:**
-  **v0.98.0** (host descriptor: `breezeVersion 0.1.0`, `serverSdk 1.0.0`,
-  `breeze.extensions/v1`). This release deprecates source-directory loading and
-  introduces the `BREEZE_LEGACY_SOURCE_EXTENSIONS` gate.
+  **v0.98.0**, tagged 2026-07-19 (host descriptor: `breezeVersion 0.1.0`,
+  `serverSdk 1.0.0`, `breeze.extensions/v1`). Note v0.98.0 was cut hours
+  before this deprecation merged, so it carries the v1 host but NOT the
+  `BREEZE_LEGACY_SOURCE_EXTENSIONS` gate.
+- **The deprecation itself** (the flag gate, structured warnings, same-name
+  simultaneity check, and extension-free stock images) ships in the first
+  stable release cut after 2026-07-19 that contains it — call that release
+  **D** (v0.99.0, unless a v0.98.x patch release picks it up).
 - **Earliest stable release allowed to remove the legacy adapter and
-  source-directory discovery path: v0.99.0** — i.e. the legacy path ships for
-  at least the full v0.98.x series.
+  source-directory discovery path: the first stable minor release after D** —
+  i.e. the legacy path remains loadable, behind the flag, for D's entire
+  release series.
 
-Removal (in v0.99.0 or later) additionally requires ALL of:
+Removal additionally requires ALL of:
 
 1. The SDK v1 compatibility fixtures (`packages/extension-sdk/fixtures/v1/*`
    and the blocking API CI gate described in `sdk-compatibility.md`) are green
@@ -51,7 +57,7 @@ Removal (in v0.99.0 or later) additionally requires ALL of:
 3. A release-note entry announcing the removal.
 
 What removal covers: `loadSourceExtensions`, `discoverExtensions`'
-source-directory scanning, the legacy `breeze-extension.json` →  v1 manifest
+source-directory scanning, the legacy `breeze-extension.json` → v1 manifest
 adapter in the loader, and the `BREEZE_LEGACY_SOURCE_EXTENSIONS` flag itself.
 
 **What removal does NOT cover:** the public v1 SDK

--- a/docs/extensions/sdk-compatibility.md
+++ b/docs/extensions/sdk-compatibility.md
@@ -27,9 +27,10 @@ happen as incidental test cleanup.
 
 ## Legacy source-directory (build-time) loading
 
-Source-directory extension loading is deprecated as of v0.98.0 and gated
-behind `BREEZE_LEGACY_SOURCE_EXTENSIONS=true` for a one-release compatibility
-window; the earliest release allowed to remove it is v0.99.0, behind the dated
-gate recorded in `build-time-transition.md`. That removal retires a delivery
+The v1 runtime host first shipped in v0.98.0; source-directory extension
+loading is deprecated and gated behind `BREEZE_LEGACY_SOURCE_EXTENSIONS=true`
+starting with the first stable release after v0.98.0 that contains the gate,
+for a one-release-series compatibility window recorded (with its removal
+conditions) in `build-time-transition.md`. That removal retires a delivery
 path only — it does not remove the public v1 SDK, the v1 manifest schema, or
 this document's CI gate, which are governed by the SDK v2 window above.


### PR DESCRIPTION
v0.98.0 was tagged 2026-07-19 21:14 from f9a840c31 — 51 minutes before #2658 merged. So it carries the v1 host but not the `BREEZE_LEGACY_SOURCE_EXTENSIONS` gate, and the transition doc's claim that v0.98.0 introduces the gate was wrong by one release. This anchors the compatibility window on the first stable release that actually contains the gate (v0.99.0 unless a v0.98.x patch picks it up), with removal no earlier than the first stable minor after it. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)