### PR TITLE
fix(quotes): keep the PDF section label + column header with their first row

### DIFF
--- a/apps/api/src/services/quotePdf.test.ts
+++ b/apps/api/src/services/quotePdf.test.ts
@@ -189,6 +189,42 @@ describe('renderQuotePdf', () => {
     expect(pageCount).toBeGreaterThan(1);
   });
 
+  it('never strands a section label + column header on a page without its first row', async () => {
+    // Regression: the section label used to be drawn at the call site behind a
+    // FLAT 52pt "minimum first row" reservation. When the first row was a tall
+    // spec list (a 17-bullet laptop), the label + column header fit that guess and
+    // were drawn at the foot of the page, then the row-level break moved the row
+    // to the next page — leaving the label and header orphaned (seen live on
+    // Q-2026-0006). Sweeping the filler count walks the section label across the
+    // page boundary, so this catches the orphan without brittle height tuning.
+    const TALL_SPEC = Array.from({ length: 17 }, (_, i) => `Specification bullet number ${i + 1} for this configured machine`).join('\n');
+    for (const fillerCount of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]) {
+      const filler = Array.from({ length: fillerCount }, (_, i) => ({
+        id: `f${i}`, blockId: 'b1', name: `FillerItem${i}`,
+        description: 'A reasonably descriptive line so rows take realistic height.',
+        quantity: '1', unitPrice: '10', lineTotal: '10.00', recurrence: 'one_time' as const,
+      }));
+      const buf = await renderQuotePdf(
+        { id: 'q1', quoteNumber: 'Q-ORPHAN', oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', total: '100.00', currencyCode: 'USD' },
+        [
+          { id: 'b1', blockType: 'line_items', sortOrder: 0, content: { label: 'DesktopSection' } },
+          { id: 'b2', blockType: 'line_items', sortOrder: 1, content: { label: 'LaptopSection' } },
+        ],
+        [
+          ...filler,
+          { id: 'tall', blockId: 'b2', name: 'FourteenInchLaptop', description: TALL_SPEC, quantity: '1', unitPrice: '1224', lineTotal: '1224.00', recurrence: 'one_time' },
+        ],
+        async () => null,
+        { partnerName: 'Acme MSP' },
+      );
+      // Whichever page carries the label must also carry its first row's title.
+      const pages = extractPdfTextByStream(buf);
+      const labelPage = pages.find((p) => p.includes('LaptopSection'));
+      expect(labelPage, `no page contained the label (fillerCount=${fillerCount})`).toBeDefined();
+      expect(labelPage, `label orphaned from its first row (fillerCount=${fillerCount})`).toContain('FourteenInchLaptop');
+    }
+  });
+
   it('a single-page quote stays single-page after the footer pass (no blank trailing page)', async () => {
     const buf = await renderQuotePdf(
       { id: 'q1', quoteNumber: 'Q-6', oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', total: '100.00', currencyCode: 'USD' },

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -249,9 +249,10 @@ async function renderLineTable(
   taxRate = 0,
   showTax = false,
   showSubtotal = false,
+  label = '',
 ): Promise<number> {
   const c = columnsFor(doc, showTax);
-  let y = ensureSpace(doc, startY, 60);
+  let y = startY;
 
   // Pre-load product images (DB I/O): a per-line uploaded image wins, else the
   // catalog item's image. A failed load degrades to "no thumbnail" — never
@@ -307,24 +308,43 @@ async function renderLineTable(
     return rowY;
   };
 
-  y = drawTableHeader(y);
-
-  const descX = c.colDescX;
-  for (const l of lines) {
+  // Measure each fragment at the SAME font/size it is drawn with. The blurb is
+  // rendered at 8.5pt but used to be measured while the font was still 10pt,
+  // over-reserving ~1.5pt per wrapped line — a visible gap below tall spec-list
+  // rows (e.g. a 15-bullet PC). Measure title as bold-10, blurb as regular-8.5.
+  const measureRow = (l: QuoteLine) => {
     // Title falls back to description for legacy lines that predate the name/description split.
     const title = (l.name ?? l.description ?? '').trim() || '—';
     const blurb = l.name ? (l.description ?? '').trim() : '';
-    // Measure each fragment at the SAME font/size it is drawn with. The blurb is
-    // rendered at 8.5pt but used to be measured while the font was still 10pt,
-    // over-reserving ~1.5pt per wrapped line — a visible gap below tall spec-list
-    // rows (e.g. a 15-bullet PC). Measure title as bold-10, blurb as regular-8.5.
     doc.font('Helvetica-Bold').fontSize(10);
     const titleHeight = doc.heightOfString(title, { width: descW });
     doc.font('Helvetica').fontSize(8.5);
     const blurbHeight = blurb ? doc.heightOfString(blurb, { width: descW, lineGap: 1 }) + 2 : 0;
-    const descHeight = titleHeight + blurbHeight;
     const img = imageByLine.get(l.id);
-    const rowHeight = Math.max(descHeight, img ? THUMB : 12);
+    return { title, blurb, titleHeight, img, rowHeight: Math.max(titleHeight + blurbHeight, img ? THUMB : 12) };
+  };
+
+  // Keep the section label, the column header and the FIRST row together as one
+  // unit. Reserving a flat minimum row (the old 52pt at the call site) breaks
+  // whenever the first row is a tall spec list: the label + header fit the guess,
+  // got drawn at the foot of the page, then the row-level break moved the row to
+  // the next page and stranded them. Reserve the first row's real measured height
+  // instead, capped to a page so a taller-than-a-page row can't force a blank one.
+  const labelHeight = label ? (doc.font('Helvetica-Bold').fontSize(11).heightOfString(label, { width: c.contentWidth }) + 6) : 0;
+  const usable = doc.page.height - doc.page.margins.top - doc.page.margins.bottom;
+  const firstLine = lines[0];
+  const firstRowHeight = firstLine ? measureRow(firstLine).rowHeight + 6 : 0;
+  y = ensureSpace(doc, y, Math.min(labelHeight + 24 + firstRowHeight, usable));
+  if (label) {
+    doc.fillColor('#111827').fontSize(11).font('Helvetica-Bold').text(label, c.left, y, { width: c.contentWidth });
+    y = doc.y + 6;
+  }
+
+  y = drawTableHeader(y);
+
+  const descX = c.colDescX;
+  for (const l of lines) {
+    const { title, blurb, titleHeight, img, rowHeight } = measureRow(l);
     // Keep the whole row together: if it won't fit in the remaining page, break to
     // a fresh page (re-drawing the column header) rather than letting a long
     // description overflow into the footer band. (Old reserve was a flat 30/52pt,
@@ -723,18 +743,12 @@ export async function renderQuotePdf(
         // Section label above the table (parity with the web document), e.g.
         // "Recurring services" / "One-time".
         const label = String((b.content as { label?: string }).label ?? '').trim();
-        // Keep the section label glued to its table header + first row: reserve
-        // space for label + column header + a minimum first row up front. Without
-        // this, a label near the page bottom fit its own 36pt reservation but
-        // renderLineTable then broke, stranding the label (and later the column
-        // header) alone at the foot of the page.
-        y = ensureSpace(doc, y, (label ? 24 : 0) + 24 + 52);
-        if (label) {
-          doc.fillColor('#111827').fontSize(11).font('Helvetica-Bold').text(label, c.left, y, { width: c.contentWidth });
-          y = doc.y + 6;
-        }
+        // The label is drawn by renderLineTable so it shares one keep-together
+        // reservation with the column header and the first row, sized to that
+        // row's real height. Reserving a flat minimum here instead stranded the
+        // label + header at the foot of a page whenever the first row was tall.
         const showSubtotal = (b.content as { showSubtotal?: boolean }).showSubtotal === true;
-        y = await renderLineTable(doc, blockLines, currency, y, loadCatalogImage, loadImage, taxRate, showTax, showSubtotal);
+        y = await renderLineTable(doc, blockLines, currency, y, loadCatalogImage, loadImage, taxRate, showTax, showSubtotal, label);
       }
     } else if (b.blockType === 'contract') {
       // contractRenderData[b.id] is pre-fetched by the route (Task 14's


### PR DESCRIPTION
## Problem

On `Q-2026-0006.pdf`, page 1 ended with the `Laptop` section label and its `QTY / DESCRIPTION / UNIT / TAX / TOTAL` column header and **zero rows** — the actual rows started on page 2 under a re-drawn header.

## Cause

The section label was drawn at the call site behind a flat `52pt` "minimum first row" reservation:

```ts
y = ensureSpace(doc, y, (label ? 24 : 0) + 24 + 52);
```

When the section's first row is a tall spec list (the 17-bullet ThinkBook), the label + header fit that 52pt guess and were drawn at the foot of the page. `renderLineTable`'s row-level `ensureRowSpace` then correctly saw the ~200pt row wouldn't fit and broke to a new page — stranding the label and header behind it.

## Fix

Move the label into `renderLineTable` so the label, the column header and the first row share **one** keep-together reservation, sized to the first row's **real measured height** instead of a flat guess. The reservation is capped to one usable page height so a taller-than-a-page row can't force a blank page.

The per-row measurement is extracted into `measureRow` and reused by both the reservation and the draw loop, so the two can't drift apart.

## Tests

Added a regression test that sweeps filler-row counts (1–12) to walk the section label across the page boundary, asserting the page carrying the label also carries its first row's title — no brittle height tuning.

Verified non-vacuous: restoring the old flat `52pt` reserve fails the test with page 1 ending in `...LaptopSectionQTYDESCRIPTIONUNITTOTAL`, reproducing the reported PDF exactly.

- `quotePdf.test.ts`: 24/24 pass
- Full `src/services/` suite: 6498 pass, 22 skipped
- `tsc --noEmit` clean

## Note — unrelated portal deploy gap fixed separately

The "Customer Portal" header + narrow proposal card on the emailed link was **not** a code bug: `breeze-portal` was still running `0.94.0` on both droplets while api/web were on `0.98.1` (the release deploy line pulls only `api web`). Rolled both regions to `0.98.1`; both now serve the wide `PublicDocumentLayout` with no portal header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)