### PR TITLE
fix(api): close two Sentry regressions — contextless device_commands writes (#1375) and unnormalized S3 endpoints

### DIFF
--- a/apps/api/src/db/contextlessWriteGuard.test.ts
+++ b/apps/api/src/db/contextlessWriteGuard.test.ts
@@ -12,7 +12,9 @@ import {
   db,
   hasDbAccessContext,
   classifyContextlessExecuteVerb,
+  runOutsideDbContext,
   __resetContextlessWriteGuardForTests,
+  __runInDbContextForTests as runInDbContextForTests,
 } from './index';
 
 // The builder guard fires at CALL time (not on getter access). Query builders
@@ -170,4 +172,51 @@ describe('contextless-write guard on proxiedDb (#1375/#1379)', () => {
       expect(classifyContextlessExecuteVerb({})).toBeNull();
     });
   });
+
+  // These exercise the REAL guard against the REAL wrapper composition — no
+  // hand-mocked context helpers. Route-level suites (agentWs.test.ts) mock
+  // `../db` wholesale, so they can only prove that two stubs were entered;
+  // they cannot prove the guard actually goes quiet. That gap is what let an
+  // inverted-nesting regression survive review, so it is pinned here instead.
+  describe('wrapper composition around a device_commands-style write', () => {
+    it('DOES fire when runOutsideDbContext is nested INSIDE a system context', () => {
+      // The inversion. runOutsideDbContext exits BOTH ALS stores, so the
+      // freshly-established system context is discarded and the write lands on
+      // the bare pool contextless — exactly the #1375 bug, with an orphaned
+      // open transaction pinning a pooled connection on top (#1105).
+      runOutsideDbContextInsideSystemContextShape(() => {
+        callBuilder(() => db.update({} as never));
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(captureMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT fire when the write runs inside an active context', () => {
+      // The correct shape: whatever exits the ambient context does so FIRST,
+      // and the context the write actually runs in is still active when the
+      // builder is called.
+      withActiveDbContextShape(() => {
+        callBuilder(() => db.update({} as never));
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(captureMessage).not.toHaveBeenCalled();
+    });
+  });
 });
+
+// Minimal stand-ins for the two nesting orders, driving the real
+// dbContextStorage via the real exported helpers. We cannot open a real
+// transaction without a database, so these assert the property the guard
+// itself keys on: whether a context is active at the moment the write builder
+// is called.
+function runOutsideDbContextInsideSystemContextShape(fn: () => void): void {
+  runInDbContextForTests(() => {
+    runOutsideDbContext(fn);
+  });
+}
+
+function withActiveDbContextShape(fn: () => void): void {
+  runInDbContextForTests(fn);
+}

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -371,6 +371,18 @@ export const runOutsideDbContext: RunOutsideDbContextFn = <T>(fn: () => T): T =>
   return dbContextStorage.exit(() => dbContextMetaStorage.exit(fn));
 };
 
+/**
+ * TEST ONLY. Enters the tx-routing store without opening a real transaction,
+ * so the contextless-write guard can be exercised against the REAL `db` proxy
+ * with no database. Production code must use withDbAccessContext /
+ * withSystemDbAccessContext — this sets no GUCs and grants no RLS visibility;
+ * it only makes `hasDbAccessContext()` true, which is precisely the condition
+ * the guard keys on.
+ */
+export function __runInDbContextForTests<T>(fn: () => T): T {
+  return dbContextStorage.run(baseDb, fn);
+}
+
 // Query-builder write methods that, when invoked on the bare pool (no active
 // RLS access context), silently match 0 rows under the forced-RLS `breeze_app`
 // role instead of erroring (#1375). We instrument these to surface the
@@ -424,10 +436,26 @@ function reportContextlessWrite(label: string): void {
   // negative-control integration tests deliberately issue contextless writes
   // through this proxy to prove DB-layer rejection, and must be migrated off
   // the proxy (or opt out) before the gate can be flipped on suite-wide
-  // (tracked as a #1379 follow-up). The genuinely-intentional production paths
-  // never reach here anyway: auditAdminPool bypasses this proxy, and
-  // device_commands writes under an explicit system context. Mirrors
-  // assertOutsideHeldDbContext's strict gate.
+  // (tracked as a #1379 follow-up). Mirrors assertOutsideHeldDbContext's
+  // strict gate.
+  //
+  // This comment used to assert, flatly, that "device_commands writes run
+  // under an explicit system context" and therefore nothing intentional ever
+  // reaches here. That was FALSE for ~2 months and produced BREEZE-7: the
+  // agent WS result path, its REST twin, and the restore-cancel path all wrote
+  // device_commands contextless. All three are fixed (agentWs.ts,
+  // routes/agents/commands.ts, routes/backup/restore.ts) — but the claim is
+  // stated narrowly now, because the broad version is what stopped anyone
+  // checking:
+  //   - auditAdminPool bypasses this proxy entirely (verified: separate pool).
+  //   - The three device_commands paths above nest withSystemDbAccessContext
+  //     inside runOutsideDbContext.
+  // It is NOT a verified claim about every device_commands write in the repo
+  // (there are ~30), nor about writes issued through db.transaction(...) —
+  // `transaction` is not in CONTEXTLESS_WRITE_GUARD_METHODS and the `tx` handed
+  // to the callback is a raw Drizzle transaction, not this Proxy, so those
+  // writes are invisible to the guard entirely. Before flipping the strict gate
+  // on suite-wide, re-verify rather than trusting this paragraph.
   if (STRICT_TRIPWIRE_VALUES.has((process.env.DB_CONTEXTLESS_WRITE_STRICT ?? '').trim().toLowerCase())) {
     throw new Error(message);
   }

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -187,8 +187,8 @@ vi.mock('../services/backupResultPersistence', async (importOriginal) => {
   };
 });
 
-import { db, runOutsideDbContext } from '../db';
-import { devices } from '../db/schema';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { devices, deviceCommands } from '../db/schema';
 import {
   createAgentWsHandlers,
   createAgentWsRoutes,
@@ -2069,5 +2069,120 @@ describe('#2434 — secret redaction on non-device_commands persistence surfaces
     const stored = sessionSetSpy.mock.calls[0]![0] as { errorMessage: string };
     expect(stored.errorMessage).toContain('[PRIVATE_KEY_REDACTED]');
     expect(stored.errorMessage).not.toContain('BEGIN RSA PRIVATE KEY');
+  });
+});
+
+// #1375 / BREEZE-7: the device_commands lookup + terminal compare-and-set on the
+// WS result path deliberately run OUTSIDE the held org-scoped transaction (fresh
+// snapshot visibility), but for a long time they ran with NO DB access context at
+// all — tripping the contextless-write guard in db/index.ts on every fresh
+// process and flooding Sentry. device_commands has no RLS so the write always
+// landed; the bug was the false invariant + the noise. The fix nests
+// withSystemDbAccessContext INSIDE runOutsideDbContext (same shape as
+// isAgentDeviceStillAuthorized here and the insert in services/commandQueue.ts).
+//
+// The READ is intentionally NOT wrapped in a system context: only
+// insert/update/delete are instrumented by the guard, and device_commands has
+// no RLS, so wrapping the read would add a BEGIN + set_config×6 + COMMIT per
+// command result on the hottest agent path for zero #1375 coverage (#1105).
+//
+// NOTE ON WHAT THIS SUITE CAN AND CANNOT PROVE: `../db` is mocked wholesale
+// here, so these assertions cover the WRAPPER COMPOSITION only — they cannot
+// prove the real guard goes quiet, because the real proxy, the real
+// AsyncLocalStorage, and withDbAccessContext's already-in-a-context early
+// return never execute. The real-guard assertions live in
+// db/contextlessWriteGuard.test.ts ('wrapper composition around a
+// device_commands-style write'), which drives the actual proxy. Keep both:
+// this one pins the call site, that one pins the mechanism.
+describe('device_commands access context on the WS result path (#1375)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('runs the device_commands write inside a system context nested in runOutsideDbContext, and the read outside any context', async () => {
+    // Track the ACTIVE WRAPPER STACK, not just depth counters. Depth counters
+    // are order-blind: `system(outside(write))` — the inverted nesting, which
+    // is the #1375 bug re-introduced, since runOutsideDbContext exits the
+    // context that was just established — produces the same non-zero counts as
+    // the correct `outside(system(write))`. Snapshotting the stack at the
+    // moment of each DB call is what makes that mutant detectable.
+    const stack: string[] = [];
+    const observed: Array<{ op: 'select' | 'update'; table: unknown; stack: string[] }> = [];
+
+    vi.mocked(runOutsideDbContext).mockImplementation((async (fn: any) => {
+      stack.push('outside');
+      try {
+        return await fn();
+      } finally {
+        stack.pop();
+      }
+    }) as any);
+    vi.mocked(withSystemDbAccessContext).mockImplementation((async (fn: any) => {
+      stack.push('system');
+      try {
+        return await fn();
+      } finally {
+        stack.pop();
+      }
+    }) as any);
+
+    const record = (op: 'select' | 'update', table: unknown) => {
+      observed.push({ op, table, stack: [...stack] });
+    };
+
+    // device_commands lookup returns the owned command; every other select
+    // (the devices lifecycle recheck) returns no rows and fails open.
+    const commandRow = { id: 'cmd-1375', type: 'run_script', payload: {}, deviceId: 'device-123' };
+    vi.mocked(db.select).mockImplementation((() => ({
+      from: vi.fn((table: unknown) => {
+        record('select', table);
+        const rows = table === deviceCommands ? [commandRow] : [];
+        return {
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        };
+      }),
+    })) as any);
+
+    vi.mocked(db.update).mockImplementation(((table: unknown) => {
+      record('update', table);
+      const returning = vi.fn().mockResolvedValue([{ id: 'cmd-1375' }]);
+      return {
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ returning }),
+          returning,
+        }),
+      };
+    }) as any);
+
+    const handlers = createAgentWsHandlers('agent-123', { deviceId: 'device-123', orgId: 'org-123' });
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: '33333333-3333-4333-8333-333333333333',
+        status: 'completed',
+        exitCode: 0,
+        stdout: 'ok',
+      }),
+    } as any, ws as any);
+
+    const commandOps = observed.filter((o) => o.table === deviceCommands);
+    expect(commandOps.map((o) => o.op)).toEqual(['select', 'update']);
+
+    const read = commandOps.find((o) => o.op === 'select')!;
+    const write = commandOps.find((o) => o.op === 'update')!;
+
+    // Read: outside the held tenant transaction for fresh-snapshot visibility,
+    // and deliberately NOT in a system context (see the note above).
+    expect(read.stack).toEqual(['outside']);
+
+    // Write: outside the held tenant transaction AND inside an explicit system
+    // context — in that exact order. Asserting the full stack (rather than
+    // "both are non-zero") is what fails if the two wrappers are ever swapped.
+    expect(write.stack).toEqual(['outside', 'system']);
   });
 });

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { eq, and, inArray, notInArray, sql } from 'drizzle-orm';
 import { createHash } from 'crypto';
 import { db, withDbAccessContext, withSystemDbAccessContext, runOutsideDbContext } from '../db';
+import { dbWriteExpectingRows } from '../db/dbWriteExpectingRows';
 import { devices, deviceCommands, discoveryJobs, scriptExecutions, scriptExecutionBatches, remoteSessions, backupJobs, restoreJobs, tunnelSessions } from '../db/schema';
 import { handleTerminalOutput, getActiveTerminalSession, unregisterTerminalOutputCallback } from './terminalWs';
 import { handleDesktopFrame, isDesktopSessionOwnedByAgent } from './desktopWs';
@@ -1596,8 +1597,23 @@ async function processCommandResult(
 
     if (resolvedDeviceId) {
       // Query device_commands OUTSIDE the current transaction context.
-      // device_commands has no RLS; querying via the pool (auto-commit)
-      // guarantees visibility of recently committed rows.
+      // device_commands has no RLS; leaving the held org-scoped transaction
+      // guarantees visibility of rows committed by the dispatcher after this
+      // transaction began.
+      //
+      // The READ deliberately stays on the bare pool while the write below
+      // takes an explicit system context. Only insert/update/delete are
+      // instrumented by the contextless-write guard
+      // (CONTEXTLESS_WRITE_GUARD_METHODS, db/index.ts), and a bare-pool read of
+      // an RLS-free table returns exactly the rows a system-context read would
+      // — so wrapping it would buy no #1375 coverage while costing a full
+      // BEGIN + set_config×6 + COMMIT round-trip per command result on the
+      // hottest agent path, against a connection pool we are actively trying to
+      // relieve (#1105). Contrast isAgentDeviceStillAuthorized below, which
+      // reads `devices` — that table DOES have RLS, so its read genuinely needs
+      // the system context. If device_commands ever gains an RLS policy, this
+      // read becomes a silent 0-row no-op and MUST move into
+      // withSystemDbAccessContext — same caveat as services/commandDispatch.ts.
       const did = resolvedDeviceId;
       const [row] = await runOutsideDbContext(() =>
         db
@@ -1675,24 +1691,42 @@ async function processCommandResult(
       validationError,
     } = normalizeCriticalResultIfNeeded(command.type, result);
 
-    // Update outside transaction for same visibility reasons as the lookup.
+    // Update outside transaction for same visibility reasons as the lookup, and
+    // under an explicit system context so the compare-and-set is not a
+    // contextless bare-pool write (#1375). device_commands is intentionally
+    // system-scoped (no RLS), so this changes nothing about what the write can
+    // touch — it just makes the guard's invariant ("device_commands writes run
+    // under an explicit system context", db/index.ts) actually true here.
+    //
+    // dbWriteExpectingRows (#1379 A2): the SELECT above matched this exact
+    // predicate and returned a row, so a 0-row result here is only *benign*
+    // when another writer (the REST twin in routes/agents/commands.ts, or a
+    // second socket) drove the command terminal in the intervening window.
+    // Every other cause — a contextless/denied write, a future RLS policy on
+    // device_commands, a misrouted connection — is a defect that would
+    // otherwise vanish into the console.warn below. Non-throwing, so the stale
+    // -result early-return keeps its existing behaviour.
     const updatedCommands = await runOutsideDbContext(() =>
-      db
-        .update(deviceCommands)
-        .set({
-            status: normalizedResult.status === 'completed' ? 'completed' : 'failed',
-            completedAt: new Date(),
-            result: buildStoredCommandResult(command.type, normalizedResult, stdout)
-        })
-        .where(
-          and(
-            eq(deviceCommands.id, result.commandId),
-            eq(deviceCommands.deviceId, resolvedDeviceId!),
-            eq(deviceCommands.targetRole, 'agent'),
-            inArray(deviceCommands.status, ACCEPTED_COMMAND_RESULT_STATUSES)
-          )
+      withSystemDbAccessContext(() =>
+        dbWriteExpectingRows('device_commands.ws_result_terminal_cas', () =>
+          db
+            .update(deviceCommands)
+            .set({
+                status: normalizedResult.status === 'completed' ? 'completed' : 'failed',
+                completedAt: new Date(),
+                result: buildStoredCommandResult(command.type, normalizedResult, stdout)
+            })
+            .where(
+              and(
+                eq(deviceCommands.id, result.commandId),
+                eq(deviceCommands.deviceId, resolvedDeviceId!),
+                eq(deviceCommands.targetRole, 'agent'),
+                inArray(deviceCommands.status, ACCEPTED_COMMAND_RESULT_STATUSES)
+              )
+            )
+            .returning({ id: deviceCommands.id })
         )
-        .returning({ id: deviceCommands.id })
+      )
     );
 
     if (updatedCommands.length === 0) {

--- a/apps/api/src/routes/agents.test.ts
+++ b/apps/api/src/routes/agents.test.ts
@@ -1310,7 +1310,13 @@ describe('agent routes', () => {
       expect(res.status).toBe(200);
       // runOutsideDbContext is called 3 times: command lookup, command update, and audit policy queueing
       expect(vi.mocked(runOutsideDbContext)).toHaveBeenCalledTimes(3);
-      expect(vi.mocked(withSystemDbAccessContext)).toHaveBeenCalledTimes(1);
+      // withSystemDbAccessContext is called twice: once by the pre-existing
+      // path, and once wrapping the terminal device_commands compare-and-set.
+      // That second call is the #1375 fix (Sentry BREEZE-7) — this route is the
+      // REST twin of agentWs.processCommandResult and was writing
+      // device_commands with no access context. The count is load-bearing:
+      // dropping back to 1 means the write went contextless again.
+      expect(vi.mocked(withSystemDbAccessContext)).toHaveBeenCalledTimes(2);
       expect(vi.mocked(queueCommandForExecution)).toHaveBeenCalledWith(
         'device-123',
         'collect_audit_policy',

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -219,6 +219,17 @@ commandsRoutes.post(
     // Query device_commands OUTSIDE the agentAuth transaction.
     // device_commands has no RLS; querying via the pool (auto-commit)
     // guarantees visibility of recently committed rows.
+    //
+    // The READ deliberately stays on the bare pool while the write below takes
+    // an explicit system context. Only insert/update/delete are instrumented by
+    // the contextless-write guard (CONTEXTLESS_WRITE_GUARD_METHODS, db/index.ts),
+    // and a bare-pool read of an RLS-free table returns the same rows a
+    // system-context read would — so wrapping it would buy nothing and cost a
+    // full BEGIN + set_config×6 + COMMIT round-trip on a hot agent path we are
+    // actively trying to keep off the connection pool (#1105). If
+    // device_commands ever gains an RLS policy, this read becomes a silent
+    // 0-row no-op and MUST move into withSystemDbAccessContext — same caveat as
+    // services/commandDispatch.ts.
     const [command] = await runOutsideDbContext(() =>
       db
         .select()
@@ -262,7 +273,15 @@ commandsRoutes.post(
     // + capture_pprof artifacts); persisted stdout is redacted per-site.
     const normalizedData = redactAgentResultErrorFields(rawNormalizedData);
 
-    const updated = await runOutsideDbContext(async () => {
+    // Terminal compare-and-set, outside the agentAuth transaction for the same
+    // visibility reasons as the lookup above, and under an explicit system
+    // context so this is not a contextless bare-pool write (#1375). Mirrors the
+    // WS twin in agentWs.processCommandResult; device_commands is intentionally
+    // system-scoped (no RLS), so the context changes nothing about what the
+    // write can touch — it makes the guard's invariant in db/index.ts true on
+    // this path too. Without it, this route was the largest remaining source of
+    // BREEZE-7 events after the WS path was fixed.
+    const updated = await runOutsideDbContext(async () => withSystemDbAccessContext(async () => {
       const query = db
         .update(deviceCommands)
         .set({
@@ -283,7 +302,7 @@ commandsRoutes.post(
       return typeof query.returning === 'function'
         ? query.returning({ id: deviceCommands.id })
         : query;
-    });
+    }));
 
     const updatedRows = Array.isArray(updated)
       ? updated

--- a/apps/api/src/routes/backup/configs.test.ts
+++ b/apps/api/src/routes/backup/configs.test.ts
@@ -535,6 +535,228 @@ describe('backup config routes', () => {
     );
   });
 
+  // Sentry BREEZE-P: a scheme-less or otherwise unparseable endpoint used to
+  // reach the AWS SDK unmodified and throw a bare `TypeError: Invalid URL`
+  // deep inside @smithy/core's endpoint resolver. These tests cover the two
+  // places that guard against it: rejecting a bad endpoint at save time
+  // (validateS3Details), and normalizing/erroring gracefully at probe time
+  // for configs saved before that validation existed.
+  describe('S3 endpoint validation (Sentry BREEZE-P)', () => {
+    it('rejects S3 config creation with a genuinely malformed endpoint, with a clear message', async () => {
+      const res = await app.request('/backup/configs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          name: 'Broken endpoint',
+          provider: 's3',
+          details: {
+            bucket: 'backups',
+            region: 'us-east-1',
+            accessKey: 'key',
+            secretKey: 'secret',
+            endpoint: 'not a valid url with spaces',
+          },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(JSON.stringify(body)).toContain('not a valid URL');
+      // Deliberately case-insensitive: the raw SDK failure is the string
+      // "Invalid URL", and our message is "...is not a valid URL...". A
+      // case-SENSITIVE `not.toContain('Invalid URL')` can never fire against
+      // our own message, so it would assert nothing.
+      expect(JSON.stringify(body)).not.toMatch(/TypeError|\bInvalid URL\b/i);
+      expect(insertMock).not.toHaveBeenCalled();
+    });
+
+    it('accepts a scheme-less endpoint on create (still just a host:port)', async () => {
+      insertMock.mockReturnValueOnce(chainMock([makeConfig({
+        providerConfig: {
+          bucket: 'backups',
+          region: 'us-east-1',
+          accessKey: 'key',
+          secretKey: 'secret',
+          endpoint: 'minio.internal.example.com:9000',
+        },
+      })]));
+
+      const res = await app.request('/backup/configs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          name: 'MinIO backups',
+          provider: 's3',
+          details: {
+            bucket: 'backups',
+            region: 'us-east-1',
+            accessKey: 'key',
+            secretKey: 'secret',
+            endpoint: 'minio.internal.example.com:9000',
+          },
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(insertMock).toHaveBeenCalled();
+
+      // The NORMALIZED endpoint must be what lands in the database, not the
+      // raw scheme-less string. providerConfig.endpoint is shipped verbatim to
+      // the Go agent (jobs/backupWorker.ts -> agent/internal/backup/providers/
+      // s3.go), which does no coercion of its own — so persisting the raw value
+      // would let this config pass its own connectivity test while every real
+      // backup run kept failing on the device.
+      const insertValues = insertMock.mock.results[0]?.value?.values;
+      expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({
+        providerConfig: expect.objectContaining({
+          endpoint: 'https://minio.internal.example.com:9000/',
+        }),
+      }));
+    });
+
+    it('persists the normalized endpoint on update (PATCH), not the raw value', async () => {
+      selectMock.mockReturnValueOnce(chainMock([makeConfig()]));
+      updateMock.mockReturnValueOnce(chainMock([makeConfig({
+        providerConfig: {
+          bucket: 'backups',
+          region: 'us-east-1',
+          accessKey: 'key',
+          secretKey: 'secret',
+          endpoint: 'https://minio.internal.example.com:9000/',
+        },
+      })]));
+
+      const res = await app.request(`/backup/configs/${CONFIG_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          details: {
+            bucket: 'backups',
+            region: 'us-east-1',
+            accessKey: 'key',
+            secretKey: 'secret',
+            endpoint: 'minio.internal.example.com:9000',
+          },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const updateValues = updateMock.mock.results[0]?.value?.set;
+      expect(updateValues).toHaveBeenCalledWith(expect.objectContaining({
+        providerConfig: expect.objectContaining({
+          endpoint: 'https://minio.internal.example.com:9000/',
+        }),
+      }));
+    });
+
+    it('rejects a malformed endpoint on update (PATCH) — configUpdateSchema has no superRefine', async () => {
+      // The ONLY guard on this path is the hand-rolled validateS3Details call
+      // in the PATCH handler: configUpdateSchema cannot carry a superRefine
+      // because `provider` is not part of an update payload. If that call is
+      // ever removed, this test is what catches it.
+      selectMock.mockReturnValueOnce(chainMock([makeConfig()]));
+
+      const res = await app.request(`/backup/configs/${CONFIG_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          details: {
+            bucket: 'backups',
+            region: 'us-east-1',
+            accessKey: 'key',
+            secretKey: 'secret',
+            endpoint: 'not a valid url with spaces',
+          },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(JSON.stringify(body)).toContain('not a valid URL');
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-http(s) scheme on create (e.g. a pasted s3:// bucket URI)', async () => {
+      const res = await app.request('/backup/configs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          name: 'Pasted s3 URI',
+          provider: 's3',
+          details: {
+            bucket: 'backups',
+            region: 'us-east-1',
+            accessKey: 'key',
+            secretKey: 'secret',
+            endpoint: 's3://my-bucket',
+          },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(insertMock).not.toHaveBeenCalled();
+    });
+
+    it('normalizes a stored scheme-less endpoint to https:// before probing', async () => {
+      selectMock.mockReturnValueOnce(chainMock([makeConfig({
+        providerConfig: {
+          bucket: 'backups',
+          region: 'us-east-1',
+          accessKey: 'key',
+          secretKey: 'secret',
+          endpoint: 'minio.internal.example.com:9000',
+        },
+      })]));
+      updateMock.mockReturnValueOnce(chainMock([makeConfig()]));
+      s3SendMock.mockResolvedValue({});
+      checkBackupProviderCapabilitiesMock.mockResolvedValue({
+        objectLock: { supported: true, error: null },
+      });
+
+      const res = await app.request(`/backup/configs/${CONFIG_ID}/test`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe('success');
+      expect(s3ClientCtorMock).toHaveBeenCalledWith(
+        expect.objectContaining({ endpoint: 'https://minio.internal.example.com:9000/' }),
+      );
+    });
+
+    it('surfaces a clear error (not "Invalid URL") when testing a config with a pre-existing malformed endpoint', async () => {
+      // Simulates a row saved before endpoint validation existed at the
+      // config-save boundary.
+      selectMock.mockReturnValueOnce(chainMock([makeConfig({
+        providerConfig: {
+          bucket: 'backups',
+          region: 'us-east-1',
+          accessKey: 'key',
+          secretKey: 'secret',
+          endpoint: 'not a valid url with spaces',
+        },
+      })]));
+      updateMock.mockReturnValueOnce(chainMock([makeConfig()]));
+      checkBackupProviderCapabilitiesMock.mockResolvedValue({
+        objectLock: { supported: false, error: null },
+      });
+
+      const res = await app.request(`/backup/configs/${CONFIG_ID}/test`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.status).toBe('failed');
+      expect(body.error).toContain('not a valid URL');
+      expect(body.error).not.toBe('Invalid URL');
+      expect(s3ClientCtorMock).not.toHaveBeenCalled();
+    });
+  });
+
   // The org DEFAULT destination is what every partner-wide and profile-linked
   // backup resolves to at job time. Demoting the current default and THEN
   // bailing out on a validation/existence error would silently leave the org

--- a/apps/api/src/routes/backup/configs.ts
+++ b/apps/api/src/routes/backup/configs.ts
@@ -16,7 +16,7 @@ import {
 } from '../../services/backupEncryption';
 import { checkBackupProviderCapabilities, type ProviderCapabilityStatus } from '../../services/backupSnapshotStorage';
 import { PERMISSIONS } from '../../services/permissions';
-import { deriveS3RegionFromEndpoint } from '@breeze/shared';
+import { coerceS3EndpointUrl, deriveS3RegionFromEndpoint } from '@breeze/shared';
 import { resolveScopedOrgId } from './helpers';
 import { configSchema, configUpdateSchema, validateS3Details } from './schemas';
 
@@ -165,10 +165,18 @@ async function probeS3Config(details: Record<string, unknown>): Promise<void> {
     throw new Error('S3 region is not configured — edit the storage configuration and set the region for this endpoint');
   }
 
+  // Coerce here too (not just at config-save time in validateS3Details) —
+  // configs saved before that validation existed can still carry a
+  // scheme-less endpoint, which would otherwise reach the SDK and fail
+  // opaquely deep inside @smithy/core's endpoint resolver instead of giving a
+  // message a user can act on (Sentry BREEZE-P). See coerceS3EndpointUrl for
+  // the two distinct failure modes a scheme-less value produces.
+  const normalizedEndpoint = coerceS3EndpointUrl(endpoint);
+
   const client = new S3Client({
     region,
-    endpoint,
-    forcePathStyle: Boolean(endpoint),
+    endpoint: normalizedEndpoint,
+    forcePathStyle: Boolean(normalizedEndpoint),
     credentials: {
       accessKeyId,
       secretAccessKey,
@@ -220,9 +228,14 @@ configsRoutes.post(
     const details: Record<string, unknown> = { ...(payload.details ?? {}) };
     if (payload.provider === 's3') {
       // Schema already rejected unresolvable configs; persist the resolved
-      // region so endpoint-derived regions are explicit in storage.
-      const { region } = validateS3Details(details);
+      // region AND the normalized endpoint so both are explicit in storage.
+      // The endpoint matters most: it is shipped verbatim to the Go agent
+      // (jobs/backupWorker.ts -> agent/internal/backup/providers/s3.go), which
+      // does no scheme coercion of its own, so a scheme-less value stored here
+      // fails on every device while this API's own test probe passes.
+      const { region, endpoint } = validateS3Details(details);
       if (region) details.region = region;
+      if (endpoint) details.endpoint = endpoint;
     }
     const encryption = payload.encryption ?? false;
     try {
@@ -346,11 +359,18 @@ configsRoutes.patch(
         ? preserveSecretFields(payload.details, current.providerConfig)
         : current.providerConfig;
       if (payload.details !== undefined && current.provider === 's3' && isRecord(nextProviderConfig)) {
-        const { error, region } = validateS3Details(nextProviderConfig);
+        // NOTE: configUpdateSchema has no superRefine (it cannot — `provider`
+        // is not part of an update payload, so the schema can't tell an s3
+        // config from a local one). This hand-rolled call is therefore the
+        // ONLY thing standing between a malformed endpoint and the database on
+        // the PATCH path. Do not remove it without adding equivalent
+        // validation elsewhere. Covered by the PATCH tests in configs.test.ts.
+        const { error, region, endpoint } = validateS3Details(nextProviderConfig);
         if (error) {
           return c.json({ error }, 400);
         }
         if (region) nextProviderConfig.region = region;
+        if (endpoint) nextProviderConfig.endpoint = endpoint;
       }
       const nextEncryption = payload.encryption ?? current.encryption;
 

--- a/apps/api/src/routes/backup/restore.ts
+++ b/apps/api/src/routes/backup/restore.ts
@@ -1,7 +1,7 @@
 import { Hono, type Context } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { eq, and, desc, gte, lte, sql, inArray } from 'drizzle-orm';
-import { db, runOutsideDbContext, withDbAccessContext } from '../../db';
+import { db, runOutsideDbContext, withDbAccessContext, withSystemDbAccessContext } from '../../db';
 import { backupSnapshotFiles, backupSnapshots, restoreJobs, devices, deviceCommands } from '../../db/schema';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
@@ -63,16 +63,23 @@ async function markRestoreJobFailed(orgId: string, restoreJobId: string, error: 
   });
 }
 
+// Cancels a not-yet-delivered restore dispatch. Runs outside the caller's
+// tenant transaction (device_commands has no RLS and the dispatcher may have
+// committed the row after that transaction began), but under an explicit
+// system context so the DELETE is not a contextless bare-pool write (#1375) —
+// same shape as the agent result paths in agentWs.ts and agents/commands.ts.
 async function removeQueuedRestoreDispatch(commandId: string | null | undefined): Promise<boolean> {
   if (!commandId) return false;
   const deleted = await runOutsideDbContext(async () =>
-    db
-      .delete(deviceCommands)
-      .where(and(
-        eq(deviceCommands.id, commandId),
-        eq(deviceCommands.status, 'pending'),
-      ))
-      .returning({ id: deviceCommands.id })
+    withSystemDbAccessContext(async () =>
+      db
+        .delete(deviceCommands)
+        .where(and(
+          eq(deviceCommands.id, commandId),
+          eq(deviceCommands.status, 'pending'),
+        ))
+        .returning({ id: deviceCommands.id })
+    )
   );
   return deleted.length > 0;
 }

--- a/apps/api/src/routes/backup/schemas.ts
+++ b/apps/api/src/routes/backup/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { deriveS3RegionFromEndpoint } from '@breeze/shared';
+import { coerceS3EndpointUrl, deriveS3RegionFromEndpoint } from '@breeze/shared';
 import {
   backupRetentionSchema as sharedBackupRetentionSchema,
   backupRetentionUpdateSchema as sharedBackupRetentionUpdateSchema,
@@ -26,21 +26,49 @@ const queryBoolean = z.preprocess((value) => {
 export function validateS3Details(details: Record<string, unknown>): {
   error: string | null;
   region: string | null;
+  endpoint: string | undefined;
 } {
   const bucket = typeof details.bucket === 'string' ? details.bucket.trim() : '';
   if (!bucket) {
-    return { error: 'S3 bucket is required', region: null };
+    return { error: 'S3 bucket is required', region: null, endpoint: undefined };
   }
   const explicitRegion = typeof details.region === 'string' ? details.region.trim() : '';
   const endpoint = typeof details.endpoint === 'string' ? details.endpoint : undefined;
+
+  // Reject an endpoint the AWS SDK can't parse *before* it's persisted —
+  // otherwise it survives into a stored config and only surfaces later as an
+  // opaque `TypeError: Invalid URL` from deep inside @smithy/core's endpoint
+  // resolver the first time something calls S3 with it (Sentry BREEZE-P).
+  //
+  // The coerced value is RETURNED so callers persist the normalized form.
+  // Storing the raw string instead would leave every consumer responsible for
+  // re-coercing it, and the Go agent (agent/internal/backup/providers/s3.go)
+  // does NOT — it passes providerConfig.endpoint to the AWS Go SDK verbatim.
+  // A scheme-less endpoint would then pass this API's own connectivity test
+  // while every real backup run kept failing on the device: a green test that
+  // lies. Normalize once, here, at the boundary.
+  let normalizedEndpoint: string | undefined;
+  if (endpoint !== undefined) {
+    try {
+      normalizedEndpoint = coerceS3EndpointUrl(endpoint);
+    } catch (error) {
+      return {
+        error: error instanceof Error ? error.message : 'S3 endpoint is not a valid URL',
+        region: null,
+        endpoint: undefined,
+      };
+    }
+  }
+
   const region = explicitRegion || deriveS3RegionFromEndpoint(endpoint);
   if (!region) {
     return {
       error: 'S3 region is required (set it explicitly or use an endpoint that includes it, e.g. s3.us-west-004.backblazeb2.com)',
       region: null,
+      endpoint: normalizedEndpoint,
     };
   }
-  return { error: null, region };
+  return { error: null, region, endpoint: normalizedEndpoint };
 }
 
 export const configSchema = z.object({

--- a/apps/api/src/routes/backup/snapshots.ts
+++ b/apps/api/src/routes/backup/snapshots.ts
@@ -525,10 +525,23 @@ snapshotsRoutes.post(
       if (!storage) {
         return c.json({ error: 'Snapshot storage configuration is unavailable' }, 409);
       }
-      const capability = await checkBackupProviderCapabilities({
-        provider: storage.provider,
-        providerConfig: storage.providerConfig,
-      });
+      // checkBackupProviderCapabilities now throws (rather than answering
+      // "unsupported") when the stored config itself is unusable — e.g. a
+      // malformed endpoint. Surface that as its own message instead of
+      // reporting a config error to the user as "object lock is not enabled".
+      let capability: Awaited<ReturnType<typeof checkBackupProviderCapabilities>>;
+      try {
+        capability = await checkBackupProviderCapabilities({
+          provider: storage.provider,
+          providerConfig: storage.providerConfig,
+        });
+      } catch (error) {
+        return c.json({
+          error: error instanceof Error
+            ? `Snapshot storage configuration is invalid: ${error.message}`
+            : 'Snapshot storage configuration is invalid',
+        }, 409);
+      }
       if (!capability.objectLock.supported) {
         return c.json({
           error: capability.objectLock.error ?? 'Bucket object lock is not enabled',

--- a/apps/api/src/services/backupResultPersistence.ts
+++ b/apps/api/src/services/backupResultPersistence.ts
@@ -643,16 +643,43 @@ export async function applyBackupCommandResultToJob(params: {
             retainUntil: protection.immutableUntil,
           });
         } catch (err) {
-          console.warn(
-            `[BackupPersistence] Provider immutability unavailable for snapshot ${snapshot.id}; falling back to application enforcement:`,
-            err instanceof Error ? err.message : err
+          // COMPLIANCE EVENT — never let this pass quietly. The operator asked
+          // for provider-enforced WORM (S3 Object Lock, i.e. immutability the
+          // storage provider guarantees and nobody can revoke); we failed to
+          // apply it and are recording the weaker application-level
+          // enforcement, which any admin with DB access can undo. The row is
+          // still written so the DB reflects REALITY rather than claiming a
+          // provider lock that does not exist — but a silent downgrade of a
+          // compliance control is not acceptable, so this escalates to Sentry
+          // at error level rather than a console.warn nobody reads.
+          //
+          // Note this is reachable from an ordinary config mistake: a
+          // malformed stored endpoint now throws out of
+          // checkBackupProviderCapabilities -> buildS3StorageClient ->
+          // coerceS3EndpointUrl, so a typo in the endpoint field would
+          // otherwise silently cost every snapshot its WORM guarantee.
+          const reason = err instanceof Error
+            ? err.message
+            : 'Provider-enforced immutability unavailable';
+          console.error(
+            `[BackupPersistence] WORM DOWNGRADE for snapshot ${snapshot.id}: provider-enforced immutability was requested but could not be applied; recording application-level enforcement instead:`,
+            reason
+          );
+          captureException(
+            err instanceof Error ? err : new Error(reason),
+            undefined,
+            {
+              worm_downgrade: 'true',
+              snapshot_id: snapshot.id,
+              config_id: String(updatedJob.configId ?? 'unknown'),
+              requested_enforcement: 'provider',
+              recorded_enforcement: 'application',
+            }
           );
           protectionUpdate = {
             ...protectionUpdate,
             immutabilityEnforcement: 'application',
-            immutabilityFallbackReason: err instanceof Error
-              ? err.message
-              : 'Provider-enforced immutability unavailable',
+            immutabilityFallbackReason: reason,
           };
         }
       }

--- a/apps/api/src/services/backupSnapshotStorage.ts
+++ b/apps/api/src/services/backupSnapshotStorage.ts
@@ -6,6 +6,7 @@ import {
   GetObjectLockConfigurationCommand,
   ListObjectsV2Command,
   PutObjectRetentionCommand,
+  type S3Client,
 } from '@aws-sdk/client-s3';
 import { deriveS3RegionFromEndpoint } from '@breeze/shared';
 import { buildS3Client } from './recoveryMediaService';
@@ -309,9 +310,21 @@ async function deleteS3ObjectKeys(
   providerConfig: Record<string, unknown>,
   keys: string[],
 ): Promise<BackupObjectDeleteResult> {
-  const { bucket, client } = buildS3StorageClient(providerConfig);
   const deletedKeys: string[] = [];
   const failedKeys: { key: string; error: string }[] = [];
+
+  // Client construction is inside the soft-failure contract this function
+  // documents: a config error (bad endpoint, missing bucket/region) must be
+  // reported as "these keys were not confirmed deleted", not thrown, or the GC
+  // sweep aborts wholesale instead of recording a resumable partial failure.
+  let bucket: string;
+  let client: S3Client;
+  try {
+    ({ bucket, client } = buildS3StorageClient(providerConfig));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { deletedKeys, failedKeys: keys.map((key) => ({ key, error: message })) };
+  }
 
   for (let i = 0; i < keys.length; i += 1000) {
     const batch = keys.slice(i, i + 1000);
@@ -553,8 +566,16 @@ export async function checkBackupProviderCapabilities(input: {
 
   const providerConfig = asRecord(input.providerConfig);
 
+  // Client construction is deliberately OUTSIDE the try below. A failure here
+  // means the stored config itself is unusable (bad endpoint, missing bucket
+  // or region) — that is not an "object lock is unsupported" answer, and
+  // folding it into objectLock.error made callers report a broken endpoint to
+  // the user as "Bucket object lock is not enabled" (routes/backup/snapshots.ts)
+  // and silently downgrade WORM enforcement (services/backupResultPersistence.ts).
+  // Let a config error propagate so callers can tell the two apart.
+  const { bucket, client } = buildS3StorageClient(providerConfig);
+
   try {
-    const { bucket, client } = buildS3StorageClient(providerConfig);
     const response = await client.send(new GetObjectLockConfigurationCommand({
       Bucket: bucket,
     }));

--- a/apps/api/src/services/recoveryDownloadService.test.ts
+++ b/apps/api/src/services/recoveryDownloadService.test.ts
@@ -19,6 +19,24 @@ vi.mock('./recoveryBootstrap', () => ({
   resolveSnapshotProviderConfig: (...args: unknown[]) => resolveSnapshotProviderConfigMock(...args),
 }));
 
+const s3ClientCtorMock = vi.fn();
+const getSignedUrlMock = vi.fn(async () => 'https://signed.example.com/object');
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: class S3Client {
+    constructor(config: unknown) {
+      s3ClientCtorMock(config);
+    }
+  },
+  GetObjectCommand: class GetObjectCommand {
+    constructor(public input: unknown) {}
+  },
+}));
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: (...args: unknown[]) => getSignedUrlMock(...(args as [])),
+}));
+
 import { getAuthenticatedRecoveryDownloadTarget } from './recoveryDownloadService';
 
 describe('getAuthenticatedRecoveryDownloadTarget', () => {
@@ -96,6 +114,70 @@ describe('getAuthenticatedRecoveryDownloadTarget', () => {
     expect(result).toEqual({
       unavailable: true,
       reason: 'Requested path is outside the allowed snapshot scope.',
+    });
+  });
+
+  // Sentry BREEZE-P: buildS3Client (private to this file) used to pass a
+  // stored endpoint straight to the SDK. A scheme-less value throws an
+  // opaque `TypeError: Invalid URL` deep inside @smithy/core instead of a
+  // usable message. Exercised here through the public entry point since
+  // buildS3Client isn't exported.
+  describe('S3 endpoint handling (Sentry BREEZE-P)', () => {
+    it('normalizes a scheme-less stored endpoint to https:// before constructing the S3Client', async () => {
+      resolveSnapshotProviderConfigMock.mockResolvedValue({
+        snapshot: { snapshotId: 'snap-ext-001', metadata: {} },
+        providerType: 's3',
+        providerConfig: {
+          bucket: 'backups',
+          region: 'us-east-1',
+          endpoint: 'minio.internal.example.com:9000',
+          accessKey: 'key',
+          secretKey: 'secret',
+        },
+      });
+
+      const result = await getAuthenticatedRecoveryDownloadTarget(
+        {
+          id: 'token-4',
+          snapshotId: 'snapshot-db-4',
+          status: 'authenticated',
+          authenticatedAt: new Date('2099-04-01T00:00:00.000Z'),
+          expiresAt: new Date('2099-04-02T00:00:00.000Z'),
+        } as any,
+        'snapshots/snap-ext-001/manifest.json'
+      );
+
+      expect(result.unavailable).toBe(false);
+      expect(s3ClientCtorMock).toHaveBeenCalledWith(
+        expect.objectContaining({ endpoint: 'https://minio.internal.example.com:9000/' }),
+      );
+    });
+
+    it('throws a clear "not a valid URL" error (not "Invalid URL") for a stored malformed endpoint', async () => {
+      resolveSnapshotProviderConfigMock.mockResolvedValue({
+        snapshot: { snapshotId: 'snap-ext-001', metadata: {} },
+        providerType: 's3',
+        providerConfig: {
+          bucket: 'backups',
+          region: 'us-east-1',
+          endpoint: 'not a valid url with spaces',
+          accessKey: 'key',
+          secretKey: 'secret',
+        },
+      });
+
+      await expect(
+        getAuthenticatedRecoveryDownloadTarget(
+          {
+            id: 'token-5',
+            snapshotId: 'snapshot-db-5',
+            status: 'authenticated',
+            authenticatedAt: new Date('2099-04-01T00:00:00.000Z'),
+            expiresAt: new Date('2099-04-02T00:00:00.000Z'),
+          } as any,
+          'snapshots/snap-ext-001/manifest.json'
+        )
+      ).rejects.toThrow(/not a valid URL/);
     });
   });
 });

--- a/apps/api/src/services/recoveryDownloadService.ts
+++ b/apps/api/src/services/recoveryDownloadService.ts
@@ -3,6 +3,7 @@ import { stat } from 'node:fs/promises';
 import { posix as pathPosix, resolve as resolvePath } from 'node:path';
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { coerceS3EndpointUrl } from '@breeze/shared';
 import { recoveryTokens } from '../db/schema';
 import {
   asRecord,
@@ -46,10 +47,17 @@ function buildS3Client(config: {
   secretAccessKey?: string;
   sessionToken?: string;
 }) {
+  // These configs may have been persisted before endpoint validation existed
+  // (validateS3Details in routes/backup/schemas.ts), so a scheme-less
+  // endpoint here would otherwise reach the SDK and fail opaquely inside
+  // @smithy/core's endpoint resolver instead of pointing at the actual
+  // problem (Sentry BREEZE-P). See coerceS3EndpointUrl for the two distinct
+  // failure modes a scheme-less value produces.
+  const endpoint = coerceS3EndpointUrl(config.endpoint);
   return new S3Client({
     region: config.region,
-    endpoint: config.endpoint,
-    forcePathStyle: Boolean(config.endpoint),
+    endpoint,
+    forcePathStyle: Boolean(endpoint),
     credentials:
       config.accessKeyId && config.secretAccessKey
         ? {

--- a/apps/api/src/services/recoveryMediaService.ts
+++ b/apps/api/src/services/recoveryMediaService.ts
@@ -11,6 +11,7 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { coerceS3EndpointUrl } from '@breeze/shared';
 import { and, desc, eq } from 'drizzle-orm';
 import { db } from '../db';
 import { recoveryMediaArtifacts, recoveryTokens } from '../db/schema';
@@ -196,10 +197,18 @@ async function createBundleArchive(bundleDir: string, archivePath: string): Prom
 }
 
 export function buildS3Client(config: Extract<RecoveryMediaStorageConfig, { provider: 's3' }>) {
+  // Shared by backupSnapshotStorage.ts (retention/GC/immutability) and
+  // recoveryBootMediaService.ts. These configs may have been persisted
+  // before endpoint validation existed (validateS3Details in
+  // routes/backup/schemas.ts), so a scheme-less endpoint here would
+  // otherwise reach the SDK and fail opaquely inside @smithy/core's endpoint
+  // resolver (Sentry BREEZE-P). See coerceS3EndpointUrl for the two distinct
+  // failure modes a scheme-less value produces.
+  const endpoint = coerceS3EndpointUrl(config.endpoint);
   return new S3Client({
     region: config.region,
-    endpoint: config.endpoint,
-    forcePathStyle: Boolean(config.endpoint),
+    endpoint,
+    forcePathStyle: Boolean(endpoint),
     credentials: {
       accessKeyId: config.accessKeyId,
       secretAccessKey: config.secretAccessKey,

--- a/apps/api/src/services/s3Storage.test.ts
+++ b/apps/api/src/services/s3Storage.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const s3ClientCtorMock = vi.fn();
+const s3SendMock = vi.fn(async () => ({}));
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: class S3Client {
+    constructor(config: unknown) {
+      s3ClientCtorMock(config);
+    }
+    send = s3SendMock;
+  },
+  PutObjectCommand: class PutObjectCommand {
+    constructor(public input: unknown) {}
+  },
+  GetObjectCommand: class GetObjectCommand {
+    constructor(public input: unknown) {}
+  },
+  HeadObjectCommand: class HeadObjectCommand {
+    constructor(public input: unknown) {}
+  },
+}));
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: vi.fn(async () => 'https://signed.example.com/object'),
+}));
+
+vi.mock('node:fs', () => ({
+  createReadStream: vi.fn(() => ({})),
+  statSync: vi.fn(() => ({ size: 42 })),
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+// Sentry BREEZE-P: S3_ENDPOINT is operator-set (not per-tenant user input),
+// but a scheme-less value used to reach the SDK unmodified and fail opaquely
+// inside @smithy/core's endpoint resolver the first time S3 was used, instead
+// of naming the misconfigured env var. Note the two shapes fail differently:
+// a bare host ("s3.example.com") throws `TypeError: Invalid URL`, while
+// "minio.local:9000" parses into a URL with an empty host and fails later as
+// a connection error — see coerceS3EndpointUrl.
+describe('s3Storage getS3Client (via uploadBinary)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    process.env.S3_BUCKET = 'binaries';
+    process.env.S3_ACCESS_KEY = 'key';
+    process.env.S3_SECRET_KEY = 'secret';
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('normalizes a scheme-less S3_ENDPOINT to https:// before constructing the client', async () => {
+    process.env.S3_ENDPOINT = 'minio.local:9000';
+    const { uploadBinary } = await import('./s3Storage');
+
+    await uploadBinary('/tmp/binary', 'binaries/agent.bin');
+
+    expect(s3ClientCtorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: 'https://minio.local:9000/' }),
+    );
+  });
+
+  it('passes through an already-schemed S3_ENDPOINT unchanged', async () => {
+    process.env.S3_ENDPOINT = 'https://minio.local:9000';
+    const { uploadBinary } = await import('./s3Storage');
+
+    await uploadBinary('/tmp/binary', 'binaries/agent.bin');
+
+    expect(s3ClientCtorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: 'https://minio.local:9000/' }),
+    );
+  });
+
+  it('omits endpoint entirely when S3_ENDPOINT is unset (default AWS endpoint)', async () => {
+    delete process.env.S3_ENDPOINT;
+    const { uploadBinary } = await import('./s3Storage');
+
+    await uploadBinary('/tmp/binary', 'binaries/agent.bin');
+
+    expect(s3ClientCtorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: undefined }),
+    );
+  });
+
+  it('throws a clear error naming S3_ENDPOINT (not "Invalid URL") for a malformed value', async () => {
+    process.env.S3_ENDPOINT = 'not a valid url with spaces';
+    const { uploadBinary } = await import('./s3Storage');
+
+    await expect(uploadBinary('/tmp/binary', 'binaries/agent.bin')).rejects.toThrow(
+      /Invalid S3_ENDPOINT env var/,
+    );
+    expect(s3ClientCtorMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/s3Storage.ts
+++ b/apps/api/src/services/s3Storage.ts
@@ -1,5 +1,6 @@
 import { S3Client, PutObjectCommand, GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { coerceS3EndpointUrl } from '@breeze/shared';
 import { createReadStream, statSync } from 'node:fs';
 import { readdir } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
@@ -23,8 +24,22 @@ function getS3Client(): S3Client {
     const accessKeyId = requireEnv('S3_ACCESS_KEY');
     const secretAccessKey = requireEnv('S3_SECRET_KEY');
 
+    // A scheme-less S3_ENDPOINT would otherwise reach the SDK and fail
+    // opaquely inside @smithy/core's endpoint resolver the first time it's
+    // used, instead of naming the misconfigured env var (Sentry BREEZE-P).
+    // Two distinct failure modes depending on the shape — a bare host throws
+    // `TypeError: Invalid URL`, a `host:port` parses to an empty host and
+    // fails later as a connection error. See coerceS3EndpointUrl.
+    let endpoint: string | undefined;
+    try {
+      endpoint = coerceS3EndpointUrl(process.env.S3_ENDPOINT);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`Invalid S3_ENDPOINT env var: ${detail}`);
+    }
+
     s3Client = new S3Client({
-      endpoint: process.env.S3_ENDPOINT || undefined,
+      endpoint,
       region: process.env.S3_REGION || 'us-east-1',
       credentials: { accessKeyId, secretAccessKey },
       // Required for MinIO and other S3-compatible providers that use path-style URLs

--- a/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/BackupTab.tsx
@@ -807,7 +807,12 @@ export default function BackupTab({
       setTestStatus(
         response.ok && data.status === "success" ? "success" : "failed",
       );
-    } catch {
+    } catch (err) {
+      // Bind and log: this catch also swallows network faults, JSON parse
+      // failures, and any bug in the handler body above. Collapsing all of
+      // those into a generic string with the error object discarded leaves no
+      // way to tell "storage rejected us" from "our own code threw".
+      console.error("[BackupTab] Connection test failed:", err);
       setTestStatus("failed");
       setTestMessage(
         i18n.t(

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -9,6 +9,7 @@ export * from './depositMath';
 export * from './csvExport';
 export * from './reportSchedule';
 export * from './s3Region';
+export * from './s3Endpoint';
 // Deliberately NOT `export *`. `compileExcludeMatcher` is a code-point port of
 // the agent's matcher and knowingly diverges from Go on mid-rune byte offsets
 // and Unicode special-casing (see matcherPortLimitations in

--- a/packages/shared/src/utils/s3Endpoint.test.ts
+++ b/packages/shared/src/utils/s3Endpoint.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { coerceS3EndpointUrl } from './s3Endpoint';
+
+describe('coerceS3EndpointUrl', () => {
+  it('adds https:// to a scheme-less host', () => {
+    expect(coerceS3EndpointUrl('s3.example.com')).toBe('https://s3.example.com/');
+  });
+
+  it('adds https:// to a scheme-less host:port', () => {
+    expect(coerceS3EndpointUrl('minio.local:9000')).toBe('https://minio.local:9000/');
+  });
+
+  it('preserves an already-schemed https endpoint', () => {
+    expect(coerceS3EndpointUrl('https://minio.local:9000')).toBe('https://minio.local:9000/');
+  });
+
+  it('preserves an already-schemed http endpoint (self-hosted, no TLS)', () => {
+    expect(coerceS3EndpointUrl('http://minio.local:9000')).toBe('http://minio.local:9000/');
+  });
+
+  it('is idempotent on a trailing slash', () => {
+    expect(coerceS3EndpointUrl('https://minio.local:9000/')).toBe('https://minio.local:9000/');
+    expect(coerceS3EndpointUrl('minio.local:9000/')).toBe('https://minio.local:9000/');
+  });
+
+  it('returns undefined for empty, blank, or absent input', () => {
+    expect(coerceS3EndpointUrl('')).toBeUndefined();
+    expect(coerceS3EndpointUrl('   ')).toBeUndefined();
+    expect(coerceS3EndpointUrl(null)).toBeUndefined();
+    expect(coerceS3EndpointUrl(undefined)).toBeUndefined();
+  });
+
+  it('throws a clear, actionable error for a genuinely malformed endpoint', () => {
+    expect(() => coerceS3EndpointUrl('not a valid url with spaces')).toThrow(
+      /not a valid URL/,
+    );
+    expect(() => coerceS3EndpointUrl('http://')).toThrow(/not a valid URL/);
+    expect(() => coerceS3EndpointUrl('::::')).toThrow(/not a valid URL/);
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(coerceS3EndpointUrl('  s3.example.com  ')).toBe('https://s3.example.com/');
+  });
+
+  it('rejects a non-http(s) scheme instead of passing it to the SDK', () => {
+    // `new URL` accepts arbitrary schemes, so without an explicit protocol
+    // check these reach S3Client and fail opaquely inside @smithy/core — the
+    // same class of bug as BREEZE-P. `s3://bucket` in particular is a very
+    // plausible paste into an "endpoint" field.
+    expect(() => coerceS3EndpointUrl('s3://my-bucket')).toThrow(/not a valid URL/);
+    expect(() => coerceS3EndpointUrl('ftp://storage.example.com')).toThrow(/not a valid URL/);
+    expect(() => coerceS3EndpointUrl('file:///etc/passwd')).toThrow(/not a valid URL/);
+  });
+
+  it('documents the two DISTINCT native new URL() failure modes it exists to close', () => {
+    // Pinned deliberately: the comments in this module (and six call sites)
+    // previously claimed BOTH of these threw `TypeError: Invalid URL`. Only
+    // the bare-host form does. The host:port form parses into a URL with a
+    // bogus scheme and an EMPTY host, which is why it failed later, and
+    // differently, inside the SDK. If a future Node changes either behaviour,
+    // this test should fail loudly rather than let the docs drift again.
+    expect(() => new URL('s3.example.com')).toThrow();
+
+    const parsed = new URL('minio.local:9000');
+    expect(parsed.protocol).toBe('minio.local:');
+    expect(parsed.host).toBe('');
+    expect(parsed.pathname).toBe('9000');
+
+    // Both are normalized to the same usable shape by the helper.
+    expect(coerceS3EndpointUrl('s3.example.com')).toBe('https://s3.example.com/');
+    expect(coerceS3EndpointUrl('minio.local:9000')).toBe('https://minio.local:9000/');
+  });
+
+  it('preserves a path prefix on the endpoint', () => {
+    // Some S3-compatible gateways sit behind a path prefix. Pinned so the
+    // behaviour is a decision rather than an accident — a path DOES survive
+    // coercion and will affect key resolution.
+    expect(coerceS3EndpointUrl('s3.example.com/gateway')).toBe('https://s3.example.com/gateway');
+  });
+
+  it('accepts an IPv6 literal host', () => {
+    // Classic URL-parser regression shape; pinned as a positive case.
+    expect(coerceS3EndpointUrl('[::1]:9000')).toBe('https://[::1]:9000/');
+  });
+});

--- a/packages/shared/src/utils/s3Endpoint.ts
+++ b/packages/shared/src/utils/s3Endpoint.ts
@@ -1,0 +1,83 @@
+/**
+ * Coerce a user-supplied S3-compatible endpoint into a fully-schemed URL
+ * string safe to hand to `@aws-sdk/client-s3`'s `S3Client({ endpoint })`.
+ *
+ * Background: the SDK's endpoint resolver (@smithy/core's `parseUrl` /
+ * `toEndpointV1`) calls `new URL(endpoint)` deep inside its call stack with no
+ * scheme normalization. A scheme-less endpoint — which humans type all the
+ * time — fails there in TWO different ways, and it matters that they are not
+ * the same bug:
+ *
+ *   new URL('s3.example.com')    -> throws TypeError: Invalid URL
+ *   new URL('minio.local:9000')  -> SUCCEEDS, as protocol 'minio.local:'
+ *                                   with an EMPTY host and pathname '9000'
+ *
+ * The bare-host form is what produced the opaque `TypeError: Invalid URL` in
+ * Sentry BREEZE-P. The `host:port` form is arguably worse: it parses, so
+ * nothing throws, and the SDK goes on to build requests against a URL with no
+ * host — surfacing later as a confusing connection/malformed-request error
+ * that looks nothing like a config mistake. Coercing at the input boundary,
+ * before the value ever reaches the SDK, turns both into either a normalized
+ * value or one clear validation error.
+ *
+ * Mirrors the same "default to https:// when no scheme is present" rule
+ * `deriveS3RegionFromEndpoint` (./s3Region.ts) already uses for region
+ * derivation. There are three endpoint parsers in this repo and they are
+ * deliberately distinct, by failure mode:
+ *
+ *   - deriveS3RegionFromEndpoint (./s3Region.ts) — fails SOFT to null, so the
+ *     caller can fall back to a default region.
+ *   - normalizeS3Endpoint (api/src/jobs/backupRetention.ts) — fails SOFT to a
+ *     trimmed/lowercased raw string. It builds a storage *identity* key, where
+ *     a wrong answer must fail toward "different bucket" (safe: splits one
+ *     bucket in two) and must never throw, since that would break retention.
+ *   - coerceS3EndpointUrl (this function) — fails LOUD, because an endpoint
+ *     the SDK cannot parse is not something we can silently work around.
+ *
+ * All three share the default-to-https rule and must stay in sync on it.
+ *
+ * Returns `undefined` for a blank/absent endpoint so callers can pass the
+ * result straight through to `S3Client({ endpoint })` and get the SDK's
+ * default per-region AWS endpoint. Throws when the value can't be parsed as a
+ * URL even after a scheme is added, or when it carries a scheme other than
+ * http/https.
+ */
+export function coerceS3EndpointUrl(endpoint: string | null | undefined): string | undefined {
+  const raw = endpoint?.trim();
+  if (!raw) return undefined;
+
+  const withScheme = raw.includes('://') ? raw : `https://${raw}`;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(withScheme);
+  } catch {
+    throw new Error(invalidEndpointMessage(raw));
+  }
+
+  // Reject anything that isn't http(s). `new URL` happily accepts arbitrary
+  // schemes, so without this check `s3://my-bucket` (a very common paste into
+  // an "endpoint" field), `ftp://host`, and `file:///etc/passwd` all sail
+  // through to S3Client and fail opaquely inside the SDK — the exact
+  // BREEZE-P class this helper exists to close.
+  //
+  // The scheme-less `minio.local:9000` shape never reaches this check, since
+  // we prepend https:// above and it then parses with a real host. The empty
+  // -host guard below is for explicitly-schemed input that parses to nothing
+  // usable (e.g. a bare 'https://'), which would otherwise reach the SDK.
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(invalidEndpointMessage(raw));
+  }
+  if (!parsed.host) {
+    throw new Error(invalidEndpointMessage(raw));
+  }
+
+  return parsed.toString();
+}
+
+function invalidEndpointMessage(raw: string): string {
+  return (
+    `S3 endpoint "${raw}" is not a valid URL. Use a host (e.g. s3.example.com) `
+    + `or host:port (e.g. minio.local:9000), optionally prefixed with http:// or https://.`
+  );
+}


### PR DESCRIPTION
Triaged from a Sentry release-regression alert on 0.98.1. **Nothing in 0.98.1 actually broke** — the "regression" email was BREEZE-7 re-opening because the contextless-write guard dedups per-process, so every deploy re-fires a resolved issue. But triage surfaced two genuine defects and one compliance hole.

## 1. BREEZE-7 — contextless `device_commands` writes (#1375)

Three paths wrote `device_commands` inside `runOutsideDbContext` with no access context:

- `routes/agentWs.ts` `processCommandResult` (agent WebSocket result path)
- `routes/agents/commands.ts` (the REST twin — every HTTP-delivery agent)
- `routes/backup/restore.ts` `removeQueuedRestoreDispatch`

`device_commands` is intentionally system-scoped (no RLS), so the writes always landed — this was a false invariant plus Sentry noise, **not data loss**. All three now nest `withSystemDbAccessContext` inside `runOutsideDbContext`.

Nesting order is load-bearing: `runOutsideDbContext` exits both ALS stores, so the reverse order discards the context it just established *and* strands an open transaction pinning a pooled connection (#1105).

Reads deliberately stay on the bare pool — only insert/update/delete are guarded, and a bare-pool read of an RLS-free table returns identical rows. Wrapping them would add `BEGIN` + `set_config`×6 + `COMMIT` per command result on the hottest agent path for zero coverage. Documented inline, including the caveat if `device_commands` ever gains an RLS policy.

Also wraps the WS compare-and-set in `dbWriteExpectingRows` (#1379 A2), and corrects the comment in `db/index.ts` that asserted this invariant was already true. It was false for ~2 months, which is precisely why nobody re-checked; it now states only what is verified and notes that `db.transaction(...)` writes bypass the guard entirely.

## 2. BREEZE-P — unnormalized S3 endpoints

A scheme-less endpoint fails two *different* ways, which the initial diagnosis conflated:

```
new URL('s3.example.com')   -> throws TypeError: Invalid URL
new URL('minio.local:9000') -> SUCCEEDS as protocol 'minio.local:' with an
                               EMPTY host, failing later as a connection error
```

New `coerceS3EndpointUrl` normalizes both, rejects non-http(s) schemes (`s3://`, `ftp://`, `file://` all previously reached the SDK), and rejects a parse yielding no host. Applied at all four `S3Client` sites.

**The normalized value is now persisted, not just validated.** `providerConfig.endpoint` ships verbatim to the Go agent (`agent/internal/backup/providers/s3.go`), which does no coercion — so storing the raw string made a config pass this API's own connectivity test while every real backup run kept failing on the device. A green test that lies is worse than the opaque `TypeError` it replaced.

## 3. Silent WORM downgrades

A malformed endpoint threw out of `checkBackupProviderCapabilities`, which folded it into `objectLock.error`. Two consequences: users saw "Bucket object lock is not enabled" for what was actually a broken endpoint, and operator-requested **provider-enforced immutability (S3 Object Lock) was silently converted to application-level enforcement** that any admin with DB access can undo. `console.warn` only, no Sentry.

Config errors now propagate distinctly, and the fallback logs at error level and reports to Sentry with `worm_downgrade` / `snapshot_id` / `config_id` tags.

The row still records `'application'` so the DB reflects reality rather than claiming a lock that does not exist — the snapshot is already written to storage and cannot be retroactively locked. **If the preferred policy is to fail the backup outright instead, that is a follow-up and a deliberate behavior change.**

## Testing

The original `agentWs` test used order-blind depth counters and **passed with the two wrappers inverted** — i.e. with the bug reintroduced. It now snapshots the active wrapper stack per operation; verified by applying that mutant and observing red:

```
AssertionError: expected [ 'system', 'outside' ] to deeply equal [ 'outside', 'system' ]
```

Added real-guard tests in `contextlessWriteGuard.test.ts` driving the actual `db` proxy, since route suites mock `../db` wholesale and can only prove two stubs were entered. Added PATCH-path validation tests (`configUpdateSchema` cannot carry a `superRefine`, so a hand-rolled check is the only guard there), and pinned the two native `new URL()` behaviours so the docs cannot drift again.

| Suite | Result |
|---|---|
| API | 16,495 passed / 61 skipped |
| Shared | 1,280 passed |
| Web | 953 passed |
| `tsc --noEmit` (api, shared) | clean |

## Not addressed here

Triage also found that **BREEZE-J was a real connection-exhaustion event on 2026-07-18** (105× `CONNECT_TIMEOUT`), that `DB_POOL_MAX` defaults to 30 across two containers against a 25-connection US ceiling, and that several shipped "#1105 fixed" commits wrap slow work in `runOutsideDbContext` while still inside a held context — which does not release the outer connection and therefore reduces hold time by zero. Those need their own plan. EU is also still on 0.97.1, which is the only reason BREEZE-K is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
