### PR TITLE
fix(mobile): surface approver-registration failure instead of silently capping approvals at L1

### DIFF
--- a/apps/mobile/STORE_SUBMISSION.md
+++ b/apps/mobile/STORE_SUBMISSION.md
@@ -1,0 +1,85 @@
+# Breeze RMM store-submission checklist
+
+## Current configuration
+
+- iOS bundle ID: `com.breeze.rmm`
+- Android application ID: `com.breeze.rmm`
+- Store version: `1.0.0`
+- First local build numbers: iOS `1`; Android `1`
+- The release path uses the local Xcode project; no Expo/EAS account is required.
+- Apple Team ID: `D8W6N2JYMA` (LanternOps LLC)
+
+## Push notifications — server side is already live
+
+iOS push uses **native APNs**, not the Expo relay (#2333), so no Expo account is
+needed. The provider credentials are configured in production on both regions
+(key `8BYB6K2AZP`, team `D8W6N2JYMA`, topic `com.breeze.rmm`,
+`APNS_ENVIRONMENT=production`).
+
+⚠️ **`APNS_ENVIRONMENT=production` accepts TestFlight/App Store tokens only.** A
+Debug build sideloaded from Xcode gets a *sandbox* token, which
+`api.push.apple.com` rejects with `BadDeviceToken` — and the sender treats that
+as permanently dead and **deletes the token from the database**. To test push
+from a local Debug build, switch the droplets to `APNS_ENVIRONMENT=sandbox`
+first.
+
+Android push is **not wired**: the server skips raw FCM tokens, and `app.json`
+no longer carries an Expo `projectId`, so `registerForPushNotifications()`
+returns `unsupported`. Android launch needs either the projectId restored or a
+real FCM sender added server-side.
+
+## App Store Connect record
+
+Create an iOS app record with:
+
+- Name: **Breeze RMM**
+- Primary language: English (U.S.)
+- Bundle ID: `com.breeze.rmm`
+- SKU: `breeze-rmm-ios`
+- User access: Full Access
+
+The app supports iPhone and iPad. Capture screenshots for every required iPhone and iPad display-size family after the first release candidate is installed.
+
+## Metadata ready to enter
+
+- Subtitle: `Manage and secure your IT fleet`
+- Primary category: Business
+- Secondary category: Productivity
+- Support URL: `https://breezermm.com/`
+- Marketing URL: `https://breezermm.com/`
+- Privacy policy: `https://breezermm.com/legal/privacy-policy/`
+- Terms: `https://breezermm.com/legal/terms-of-service/`
+- Account deletion: `https://us.2breeze.app/account/delete` (or `https://eu.2breeze.app/account/delete`)
+  - **Do not use `https://breezermm.com/account/delete` — it 404s.** That was the
+    Guideline 5.1.1(v) bug fixed in #2325; the page is served per-region by the
+    API, and in-app the URL is built from the user's selected server via
+    `serverConfig.buildAccountDeletionUrl`.
+
+Suggested description:
+
+> Breeze RMM gives IT teams and managed service providers a secure mobile command center for their fleet. Review alerts, investigate managed systems, approve sensitive actions with biometric protection, and stay informed with push notifications. Sign in with your Breeze organization account to manage the systems you are authorized to access.
+
+Suggested keywords: `IT management, RMM, remote monitoring, MSP, device management, IT operations, alerts`
+
+## Privacy declaration
+
+The implementation uses Sentry, PostHog (when configured), push notifications, biometric authentication, and optional voice input. Before submitting, complete the App Store Connect privacy questionnaire with the product and privacy owners. Code comments in `App.tsx` identify the implemented analytics collection; do not declare data collection that is disabled in the production environment.
+
+Likely declarations to validate:
+
+- Contact Info — Email Address: linked to the user; app functionality and analytics.
+- Usage Data — Product Interaction: linked to the user; analytics.
+- Diagnostics — Crash Data and Performance Data: app functionality and analytics.
+- Identifiers — User ID and Device ID: linked to the user; app functionality, security, and analytics.
+
+No IDFA or cross-app tracking is implemented, so App Tracking Transparency is not expected.
+
+## Build, screenshots, and submission sequence
+
+1. Regenerate the native project when app configuration changes: `npx expo prebuild --platform ios`. This carries the microphone and speech-recognition usage descriptions in `app.json` into the Xcode `Info.plist`.
+2. Configure `EXPO_PUBLIC_SENTRY_DSN`, `EXPO_PUBLIC_POSTHOG_KEY`, and `EXPO_PUBLIC_POSTHOG_HOST` in the local Xcode release build environment only when their corresponding services are approved for release.
+3. Run `npx pnpm@10.33.4 --filter=breeze-mobile typecheck` and `npx pnpm@10.33.4 --filter=breeze-mobile test`.
+4. In Xcode, run the `BreezeRMM` scheme on a current iPhone and iPad simulator. Capture the reviewed production UI in the simulator, not the development error or debug overlay.
+5. Save iPhone screenshots at the App Store Connect-required 6.5-inch size (1242 × 2688 or 1284 × 2778) and the iPad screenshots for the supported iPad display-size family. In Simulator, use **File → Save Screen** for each approved screen.
+6. In Xcode, select a physical device or **Any iOS Device**, use **Product → Archive**, then upload the archive to App Store Connect. Attach the processed build to version 1.0.
+7. Enter review notes and working reviewer credentials or an approved demo path, then submit the version to Apple for review.

--- a/apps/mobile/src/navigation/ApprovalGate.tsx
+++ b/apps/mobile/src/navigation/ApprovalGate.tsx
@@ -31,6 +31,7 @@ export function ApprovalGate({ children }: Props) {
   );
   const error = useAppSelector((s) => s.approvals.error);
   const pushRegistration = useAppSelector((s) => s.auth.pushRegistration);
+  const approverRegistration = useAppSelector((s) => s.auth.approverRegistration);
 
   useEffect(() => {
     dispatch(hydrateFromCache());
@@ -73,7 +74,13 @@ export function ApprovalGate({ children }: Props) {
       {error ? (
         <ApprovalErrorBanner message={error} onDismiss={() => dispatch(clearApprovalsError())} />
       ) : null}
+      {/* One banner at a time — they share the same absolute slot. Push failure
+          outranks approver failure: an approval that never arrives is worse
+          than one that arrives unsigned. */}
       {!error && pushRegistration === 'failed' ? <PushFailedBanner /> : null}
+      {!error && pushRegistration !== 'failed' && approverRegistration === 'failed' ? (
+        <ApproverFailedBanner />
+      ) : null}
     </>
   );
 }
@@ -103,6 +110,44 @@ function ApprovalErrorBanner({ message, onDismiss }: { message: string; onDismis
         <Text style={[type.bodyMd, { color: '#fff' }]}>{message}</Text>
         <Text style={[type.meta, { color: '#fff', opacity: 0.8, marginTop: spacing[1] }]}>Tap to dismiss</Text>
       </Pressable>
+    </View>
+  );
+}
+
+/**
+ * Shown when {@link ensureApproverDevice} could not register this phone's
+ * hardware key. Approvals still work — they are just recorded at the lowest
+ * assurance level (L1, session tap) instead of being hardware-signed. Without
+ * this banner that downgrade is completely invisible to the technician.
+ */
+function ApproverFailedBanner() {
+  const insets = useSafeAreaInsets();
+  const theme = useApprovalTheme('dark');
+  return (
+    <View
+      pointerEvents="box-none"
+      style={{
+        position: 'absolute',
+        top: insets.top + spacing[2],
+        left: spacing[4],
+        right: spacing[4],
+      }}
+    >
+      <View
+        style={{
+          backgroundColor: theme.bg2,
+          borderRadius: radii.md,
+          paddingVertical: spacing[3],
+          paddingHorizontal: spacing[4],
+          borderColor: theme.deny,
+          borderWidth: 1,
+        }}
+      >
+        <Text style={[type.meta, { color: theme.textHi }]}>
+          This device isn't set up for biometric approval — your approvals will be
+          recorded at the lowest assurance level.
+        </Text>
+      </View>
     </View>
   );
 }

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -87,9 +87,17 @@ export function RootNavigator() {
   // "Fails open" must not mean "fails invisibly": we record the outcome so
   // ApprovalGate can warn when registration failed, otherwise every approval
   // from this phone is silently capped at L1.
+  // `active` is not an optimisation: checkAuth dispatches setCredentials twice
+  // on a cold start (cached user, then the fresh one from /auth/me), so this
+  // effect re-runs with a new `user` identity while the first registration call
+  // is still in flight. Without the guard the slower call wins, and worse — a
+  // call started for user A can resolve after A signed out and B signed in,
+  // writing A's outcome into B's session.
   useEffect(() => {
     if (!token || !user) return;
+    let active = true;
     void ensureApproverDevice().then((outcome) => {
+      if (!active) return;
       dispatch(
         setApproverRegistration({
           status: outcome.status === 'already_registered' ? 'registered' : outcome.status,
@@ -97,6 +105,9 @@ export function RootNavigator() {
         })
       );
     });
+    return () => {
+      active = false;
+    };
   }, [token, user, dispatch]);
 
   useEffect(() => {

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -4,7 +4,7 @@ import { Alert, Pressable, Text, View } from 'react-native';
 import * as Sentry from '@sentry/react-native';
 
 import { useAppSelector, useAppDispatch } from '../store';
-import { setCredentials, logout, logoutAsync } from '../store/authSlice';
+import { setCredentials, logout, logoutAsync, setApproverRegistration } from '../store/authSlice';
 import { getStoredToken, getStoredUser, clearAuthData, SecureWipeError } from '../services/auth';
 import { getCurrentUser, onDeviceBlocked } from '../services/api';
 import { spacing, type } from '../theme';
@@ -83,11 +83,21 @@ export function RootNavigator() {
   // this phone an approver. Idempotent + fails open — never blocks the UI and
   // never prompts for biometrics here (the first real approval is the first
   // Face ID, which also activates the key server-side).
+  //
+  // "Fails open" must not mean "fails invisibly": we record the outcome so
+  // ApprovalGate can warn when registration failed, otherwise every approval
+  // from this phone is silently capped at L1.
   useEffect(() => {
-    if (token && user) {
-      void ensureApproverDevice();
-    }
-  }, [token, user]);
+    if (!token || !user) return;
+    void ensureApproverDevice().then((outcome) => {
+      dispatch(
+        setApproverRegistration({
+          status: outcome.status === 'already_registered' ? 'registered' : outcome.status,
+          reason: 'reason' in outcome ? outcome.reason : null,
+        })
+      );
+    });
+  }, [token, user, dispatch]);
 
   useEffect(() => {
     async function checkAuth() {

--- a/apps/mobile/src/services/approverDevice.test.ts
+++ b/apps/mobile/src/services/approverDevice.test.ts
@@ -68,7 +68,7 @@ describe('ensureApproverDevice', () => {
     );
     fetchMock.mockResolvedValueOnce(json({ device: { id: 'dev-1' } }));
 
-    await ensureApproverDevice(signer);
+    await expect(ensureApproverDevice(signer)).resolves.toEqual({ status: 'registered' });
 
     // No password step-up — passwordless registration body.
     expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
@@ -88,17 +88,23 @@ describe('ensureApproverDevice', () => {
       k === 'breeze_approver_credential_id' ? 'dev-1' : 'test-token',
     );
 
-    await ensureApproverDevice(signer);
+    await expect(ensureApproverDevice(signer)).resolves.toEqual({
+      status: 'already_registered',
+    });
 
     expect(signer.createKeys).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('no-ops silently when no biometric hardware (no throw on the login path)', async () => {
+  it('reports unsupported (not failed) when there is no biometric hardware', async () => {
     const signer = fakeSigner({ isAvailable: vi.fn().mockResolvedValue(false) });
     secureStore.getItemAsync.mockResolvedValue(null);
 
-    await expect(ensureApproverDevice(signer)).resolves.toBeUndefined();
+    // 'unsupported' is a normal resting state — the UI must NOT warn about it.
+    await expect(ensureApproverDevice(signer)).resolves.toEqual({
+      status: 'unsupported',
+      reason: 'no_hardware',
+    });
     expect(signer.createKeys).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -110,11 +116,63 @@ describe('ensureApproverDevice', () => {
     );
     fetchMock.mockResolvedValueOnce(json({ error: 'nope' }, 500));
 
-    await expect(ensureApproverDevice(signer)).resolves.toBeUndefined();
+    await expect(ensureApproverDevice(signer)).resolves.toEqual({
+      status: 'failed',
+      reason: 'http_500',
+    });
     expect(secureStore.setItemAsync).not.toHaveBeenCalledWith(
       'breeze_approver_credential_id',
       expect.anything(),
     );
+  });
+
+  it('REGRESSION: reports the 400 the server returns for the missing currentPassword step-up', async () => {
+    // The server's mobileRegisterSchema requires `currentPassword` (deliberately
+    // — passwordless enrollment was reverted as a HIGH security finding), and
+    // this client does not send it, so zValidator 400s before the handler runs.
+    // That used to be swallowed by `if (!res.ok) return;`, leaving every
+    // approval from this phone silently capped at L1. It must be reported.
+    const signer = fakeSigner();
+    secureStore.getItemAsync.mockImplementation(async (k: string) =>
+      k === 'breeze_approver_credential_id' ? null : 'test-token',
+    );
+    fetchMock.mockResolvedValueOnce(json({ error: 'Validation failed' }, 400));
+
+    await expect(ensureApproverDevice(signer)).resolves.toEqual({
+      status: 'failed',
+      reason: 'http_400',
+    });
+    expect(secureStore.setItemAsync).not.toHaveBeenCalledWith(
+      'breeze_approver_credential_id',
+      expect.anything(),
+    );
+  });
+
+  it('reports failure when the server 200s without a device id (no silent success)', async () => {
+    const signer = fakeSigner();
+    secureStore.getItemAsync.mockImplementation(async (k: string) =>
+      k === 'breeze_approver_credential_id' ? null : 'test-token',
+    );
+    fetchMock.mockResolvedValueOnce(json({ device: {} }));
+
+    await expect(ensureApproverDevice(signer)).resolves.toEqual({
+      status: 'failed',
+      reason: 'missing_device_id',
+    });
+    expect(secureStore.setItemAsync).not.toHaveBeenCalled();
+  });
+
+  it('never throws on the login path when the network blows up', async () => {
+    const signer = fakeSigner();
+    secureStore.getItemAsync.mockImplementation(async (k: string) =>
+      k === 'breeze_approver_credential_id' ? null : 'test-token',
+    );
+    fetchMock.mockRejectedValueOnce(new Error('offline'));
+
+    await expect(ensureApproverDevice(signer)).resolves.toEqual({
+      status: 'failed',
+      reason: 'exception',
+    });
   });
 });
 

--- a/apps/mobile/src/services/approverDevice.ts
+++ b/apps/mobile/src/services/approverDevice.ts
@@ -47,19 +47,44 @@ async function authedFetch(path: string, init?: RequestInit): Promise<Response> 
 }
 
 /**
+ * Outcome of an {@link ensureApproverDevice} attempt.
+ *
+ * `unsupported` is a normal resting state (simulator, no biometric hardware) and
+ * must NOT be surfaced as an error. `failed` means we tried and could not
+ * register — the user's approvals will silently stay at L1, so the UI is
+ * expected to tell them.
+ */
+export type ApproverRegistrationOutcome =
+  | { status: 'registered' }
+  | { status: 'already_registered' }
+  | { status: 'unsupported'; reason: 'no_hardware' }
+  | { status: 'failed'; reason: string };
+
+/**
  * Idempotent: ensure this phone has a registered approver key. Called after
  * auth lands (fresh login or restored session). FAILS OPEN — any error
  * (no hardware, offline) leaves the device unregistered; it provisions on a
  * later call. The biometric prompt is NOT triggered here (createKeys is
  * silent); the first approval signature is the first prompt and also activates
  * the device server-side.
+ *
+ * Fail-open is deliberate and unchanged: this never throws and never blocks
+ * login. What changed is that it no longer fails *silently* — it reports the
+ * outcome so the caller can surface it. The server currently requires a
+ * `currentPassword` step-up on this endpoint that the app does not send, so the
+ * common failure here is an HTTP 400, which used to be swallowed and left every
+ * approval from this phone stuck at L1 with no indication to the user.
  */
 export async function ensureApproverDevice(
   signer: HardwareSigner = getHardwareSigner(),
-): Promise<void> {
+): Promise<ApproverRegistrationOutcome> {
   try {
-    if (await SecureStore.getItemAsync(CRED_ID_KEY)) return;       // already registered
-    if (!(await signer.isAvailable())) return;                      // no hardware → skip
+    if (await SecureStore.getItemAsync(CRED_ID_KEY)) {
+      return { status: 'already_registered' };
+    }
+    if (!(await signer.isAvailable())) {
+      return { status: 'unsupported', reason: 'no_hardware' };
+    }
     const { publicKey } = await signer.createKeys();                // silent, no biometric
     const res = await authedFetch('/api/v1/authenticator/devices', {
       method: 'POST',
@@ -70,11 +95,19 @@ export async function ensureApproverDevice(
         isPlatformBound: true,
       }),
     });
-    if (!res.ok) return;                                            // fail open, retry later
+    if (!res.ok) {
+      // Still fail open (we retry on a later call) — but say so.
+      return { status: 'failed', reason: `http_${res.status}` };
+    }
     const { device } = await res.json();
-    if (device?.id) await SecureStore.setItemAsync(CRED_ID_KEY, device.id);
+    if (!device?.id) {
+      return { status: 'failed', reason: 'missing_device_id' };
+    }
+    await SecureStore.setItemAsync(CRED_ID_KEY, device.id);
+    return { status: 'registered' };
   } catch {
     // fail open — never block login on approver provisioning
+    return { status: 'failed', reason: 'exception' };
   }
 }
 

--- a/apps/mobile/src/services/notifications.test.ts
+++ b/apps/mobile/src/services/notifications.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Pure-logic coverage of the token-acquisition branch. Everything RN/Expo is
+// mocked with a factory so nothing pulls the React Native runtime into the
+// node-only vitest environment (see vitest.config.ts).
+// vi.hoisted: these are referenced from vi.mock factories, which are hoisted
+// above normal const declarations.
+const platform = vi.hoisted(() => ({ OS: 'ios' as 'ios' | 'android' }));
+vi.mock('react-native', () => ({ Platform: platform }));
+
+const device = vi.hoisted(() => ({ isDevice: true }));
+vi.mock('expo-device', () => ({
+  get isDevice() {
+    return device.isDevice;
+  },
+}));
+
+const constants = vi.hoisted(() => ({ expoConfig: { extra: {} } as Record<string, unknown> }));
+vi.mock('expo-constants', () => ({ default: constants }));
+
+const notif = vi.hoisted(() => ({
+  setNotificationHandler: vi.fn(),
+  getPermissionsAsync: vi.fn(),
+  requestPermissionsAsync: vi.fn(),
+  getDevicePushTokenAsync: vi.fn(),
+  getExpoPushTokenAsync: vi.fn(),
+  setNotificationChannelAsync: vi.fn(),
+  AndroidImportance: { MAX: 5 },
+}));
+vi.mock('expo-notifications', () => notif);
+
+const api = vi.hoisted(() => ({ registerPushToken: vi.fn() }));
+vi.mock('./api', () => ({ registerPushToken: (...a: unknown[]) => api.registerPushToken(...a) }));
+
+import { registerForPushNotifications } from './notifications';
+
+beforeEach(() => {
+  platform.OS = 'ios';
+  device.isDevice = true;
+  constants.expoConfig = { extra: {} };
+  notif.getPermissionsAsync.mockReset().mockResolvedValue({ status: 'granted' });
+  notif.requestPermissionsAsync.mockReset().mockResolvedValue({ status: 'granted' });
+  notif.getDevicePushTokenAsync.mockReset().mockResolvedValue({ data: 'APNS-TOKEN' });
+  notif.getExpoPushTokenAsync.mockReset().mockResolvedValue({ data: 'ExponentPushToken[x]' });
+  notif.setNotificationChannelAsync.mockReset().mockResolvedValue(undefined);
+  api.registerPushToken.mockReset().mockResolvedValue(undefined);
+});
+
+describe('registerForPushNotifications', () => {
+  it('iOS uses the NATIVE APNs token, never the Expo relay', async () => {
+    const out = await registerForPushNotifications();
+
+    expect(out).toEqual({ status: 'ok', token: 'APNS-TOKEN' });
+    expect(notif.getDevicePushTokenAsync).toHaveBeenCalledTimes(1);
+    // The whole point of the native-APNs switch: no Expo account involvement.
+    expect(notif.getExpoPushTokenAsync).not.toHaveBeenCalled();
+    expect(api.registerPushToken).toHaveBeenCalledWith('APNS-TOKEN', 'ios');
+  });
+
+  it('iOS does not need an EAS projectId', async () => {
+    constants.expoConfig = { extra: {} }; // no eas.projectId anywhere
+    await expect(registerForPushNotifications()).resolves.toMatchObject({ status: 'ok' });
+  });
+
+  it('Android without a projectId reports UNSUPPORTED, not failed', async () => {
+    // Regression: this used to throw 'EAS projectId missing', get caught, and
+    // surface as status:'failed' — showing a red "push failed" banner for a
+    // feature that was never wired after app.json dropped extra.eas.projectId.
+    platform.OS = 'android';
+
+    const out = await registerForPushNotifications();
+
+    expect(out).toEqual({ status: 'unsupported', reason: 'android_push_not_configured' });
+    expect(api.registerPushToken).not.toHaveBeenCalled();
+  });
+
+  it('Android WITH a projectId still uses the Expo relay', async () => {
+    platform.OS = 'android';
+    constants.expoConfig = { extra: { eas: { projectId: 'proj-1' } } };
+
+    const out = await registerForPushNotifications();
+
+    expect(out).toEqual({ status: 'ok', token: 'ExponentPushToken[x]' });
+    expect(notif.getExpoPushTokenAsync).toHaveBeenCalledWith({ projectId: 'proj-1' });
+    expect(api.registerPushToken).toHaveBeenCalledWith('ExponentPushToken[x]', 'android');
+  });
+
+  it('reports unsupported on a simulator', async () => {
+    device.isDevice = false;
+
+    await expect(registerForPushNotifications()).resolves.toEqual({
+      status: 'unsupported',
+      reason: 'not_physical_device',
+    });
+  });
+
+  it('reports failed when the user denies permission', async () => {
+    notif.getPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    notif.requestPermissionsAsync.mockResolvedValue({ status: 'denied' });
+
+    await expect(registerForPushNotifications()).resolves.toEqual({
+      status: 'failed',
+      reason: 'permission_denied',
+    });
+  });
+
+  it('reports failed when the token call throws', async () => {
+    notif.getDevicePushTokenAsync.mockRejectedValue(new Error('APNs unavailable'));
+
+    await expect(registerForPushNotifications()).resolves.toEqual({
+      status: 'failed',
+      reason: 'APNs unavailable',
+    });
+  });
+});

--- a/apps/mobile/src/services/notifications.ts
+++ b/apps/mobile/src/services/notifications.ts
@@ -51,10 +51,20 @@ export async function registerForPushNotifications(): Promise<PushRegistrationOu
       token = String(tokenData.data);
     } else {
       // Android stays on the Expo push relay: the API's approval dispatcher
-      // does not send to raw FCM tokens yet (deliberately skipped server-side),
-      // so a native device token here would silently drop approval pushes.
+      // does not send to raw FCM tokens yet (deliberately skipped server-side
+      // in expoPush.ts), so a native device token here would silently drop
+      // approval pushes.
+      //
+      // The iOS-native-APNs switch removed `extra.eas.projectId` from app.json,
+      // so on a stock build there is no relay to register with. That is a
+      // not-built-yet state, NOT a failure: reporting it as 'failed' would show
+      // Android users a red "push failed to register" banner for a feature that
+      // was never wired. Android push needs either an Expo projectId restored
+      // here or a real FCM sender added server-side.
       const projectId = Constants.expoConfig?.extra?.eas?.projectId;
-      if (!projectId) throw new Error('EAS projectId missing — run `eas init`');
+      if (!projectId) {
+        return { status: 'unsupported', reason: 'android_push_not_configured' };
+      }
       const tokenData = await Notifications.getExpoPushTokenAsync({ projectId });
       token = tokenData.data;
     }

--- a/apps/mobile/src/store/authSlice.test.ts
+++ b/apps/mobile/src/store/authSlice.test.ts
@@ -121,11 +121,29 @@ describe('approver registration status', () => {
     expect(makeStore().getState().auth.approverRegistration).toBe('idle');
   });
 
-  it('clears on logout — the next user must not inherit the previous banner', () => {
+  it('clears on the synchronous logout reducer', () => {
     const store = makeStore();
     store.dispatch(setApproverRegistration({ status: 'failed', reason: 'http_400' }));
 
     store.dispatch(logout());
+
+    expect(store.getState().auth.approverRegistration).toBe('idle');
+    expect(store.getState().auth.approverRegistrationReason).toBeNull();
+  });
+
+  // The Sign Out button and the device_blocked listener both dispatch
+  // logoutAsync, NOT the sync logout reducer — so these are the paths that
+  // actually run in production. The root-level withLogoutReset in resettable.ts
+  // would also blank the slice, but that safety net lives in another module:
+  // asserting it here keeps the guarantee true of authSlice on its own.
+  it.each([
+    ['fulfilled', () => logoutAsync.fulfilled(undefined, 'req-id')],
+    ['rejected', () => logoutAsync.rejected(null, 'req-id')],
+  ])('clears on logoutAsync.%s — the next user must not inherit the banner', (_name, action) => {
+    const store = makeStore();
+    store.dispatch(setApproverRegistration({ status: 'failed', reason: 'http_400' }));
+
+    store.dispatch(action() as never);
 
     expect(store.getState().auth.approverRegistration).toBe('idle');
     expect(store.getState().auth.approverRegistrationReason).toBeNull();

--- a/apps/mobile/src/store/authSlice.test.ts
+++ b/apps/mobile/src/store/authSlice.test.ts
@@ -31,7 +31,7 @@ vi.mock('@sentry/react-native', () => ({
   captureException: (...a: unknown[]) => sentry.captureException(...a),
 }));
 
-import authReducer, { logoutAsync } from './authSlice';
+import authReducer, { logoutAsync, logout, setApproverRegistration } from './authSlice';
 
 function makeStore() {
   return configureStore({ reducer: { auth: authReducer } });
@@ -95,5 +95,39 @@ describe('logoutAsync', () => {
     expect(result.payload).toBe('network down; Secure wipe failed: x');
     expect(auth.clearAuthData).toHaveBeenCalledTimes(1);
     expect(store.getState().auth.token).toBeNull();
+  });
+});
+
+describe('approver registration status', () => {
+  it('records a failed registration so the UI can warn', () => {
+    const store = makeStore();
+
+    store.dispatch(setApproverRegistration({ status: 'failed', reason: 'http_400' }));
+
+    expect(store.getState().auth.approverRegistration).toBe('failed');
+    expect(store.getState().auth.approverRegistrationReason).toBe('http_400');
+  });
+
+  it('defaults the reason to null when omitted', () => {
+    const store = makeStore();
+
+    store.dispatch(setApproverRegistration({ status: 'registered' }));
+
+    expect(store.getState().auth.approverRegistration).toBe('registered');
+    expect(store.getState().auth.approverRegistrationReason).toBeNull();
+  });
+
+  it('starts idle so a fresh install shows no banner', () => {
+    expect(makeStore().getState().auth.approverRegistration).toBe('idle');
+  });
+
+  it('clears on logout — the next user must not inherit the previous banner', () => {
+    const store = makeStore();
+    store.dispatch(setApproverRegistration({ status: 'failed', reason: 'http_400' }));
+
+    store.dispatch(logout());
+
+    expect(store.getState().auth.approverRegistration).toBe('idle');
+    expect(store.getState().auth.approverRegistrationReason).toBeNull();
   });
 });

--- a/apps/mobile/src/store/authSlice.ts
+++ b/apps/mobile/src/store/authSlice.ts
@@ -12,6 +12,14 @@ import { storeToken, storeUser, clearAuthData } from '../services/auth';
 
 export type PushRegistrationStatus = 'idle' | 'ok' | 'failed' | 'unsupported';
 
+/**
+ * Whether this phone managed to register as a hardware approver.
+ * `unsupported` (no biometric hardware / simulator) is a normal resting state;
+ * only `failed` is worth telling the user about, because it silently caps every
+ * approval from this device at L1.
+ */
+export type ApproverRegistrationStatus = 'idle' | 'registered' | 'failed' | 'unsupported';
+
 interface AuthState {
   user: User | null;
   token: string | null;
@@ -20,6 +28,8 @@ interface AuthState {
   mfaChallenge: MfaChallenge | null;
   pushRegistration: PushRegistrationStatus;
   pushRegistrationReason: string | null;
+  approverRegistration: ApproverRegistrationStatus;
+  approverRegistrationReason: string | null;
 }
 
 const initialState: AuthState = {
@@ -30,6 +40,8 @@ const initialState: AuthState = {
   mfaChallenge: null,
   pushRegistration: 'idle',
   pushRegistrationReason: null,
+  approverRegistration: 'idle',
+  approverRegistrationReason: null,
 };
 
 export const loginAsync = createAsyncThunk(
@@ -122,6 +134,10 @@ const authSlice = createSlice({
       state.isLoading = false;
       state.error = null;
       state.mfaChallenge = null;
+      // Approver registration is per-user, not per-device: leaving it set would
+      // show the next user on this phone the previous user's banner.
+      state.approverRegistration = 'idle';
+      state.approverRegistrationReason = null;
     },
     clearError: (state) => {
       state.error = null;
@@ -139,6 +155,13 @@ const authSlice = createSlice({
     ) => {
       state.pushRegistration = action.payload.status;
       state.pushRegistrationReason = action.payload.reason ?? null;
+    },
+    setApproverRegistration: (
+      state,
+      action: PayloadAction<{ status: ApproverRegistrationStatus; reason?: string | null }>
+    ) => {
+      state.approverRegistration = action.payload.status;
+      state.approverRegistrationReason = action.payload.reason ?? null;
     },
   },
   extraReducers: (builder) => {
@@ -206,5 +229,6 @@ export const {
   clearMfaChallenge,
   setLoading,
   setPushRegistration,
+  setApproverRegistration,
 } = authSlice.actions;
 export default authSlice.reducer;

--- a/apps/mobile/src/store/authSlice.ts
+++ b/apps/mobile/src/store/authSlice.ts
@@ -211,6 +211,8 @@ const authSlice = createSlice({
         state.isLoading = false;
         state.error = null;
         state.mfaChallenge = null;
+        state.approverRegistration = 'idle';
+        state.approverRegistrationReason = null;
       })
       .addCase(logoutAsync.rejected, (state) => {
         state.user = null;
@@ -218,6 +220,8 @@ const authSlice = createSlice({
         state.isLoading = false;
         state.error = null;
         state.mfaChallenge = null;
+        state.approverRegistration = 'idle';
+        state.approverRegistrationReason = null;
       });
   },
 });


### PR DESCRIPTION
## Why

`ensureApproverDevice()` runs on every login and swallowed **every** failure via `if (!res.ok) return;`.

The server's `mobileRegisterSchema` requires a `currentPassword` step-up (`routes/authenticator.ts:52-58`) that this client does not send, so the POST 400s at `zValidator` before the handler runs. No credential is ever stored, `gatherApprovalProof()` returns `null` forever, and **every approval from the phone is recorded at L1 (`session_tap`) with no indication to the technician**.

Two consequences today:
1. The app's headline feature ("approve sensitive actions with biometric protection") silently isn't doing that.
2. For any partner whose policy `isEnforcing`, `StepUpRequiredError` blocks the approval outright — those users' phone approvals fail completely.

## What this PR is NOT

**It does not remove the server-side password gate.** That requirement is deliberate: passwordless enrollment was reverted as a HIGH security finding — a stolen access token could otherwise enroll an attacker-controlled key and self-sign approvals to L2, and deferred proof-of-possession does not gate that. `authenticator.test.ts:399` asserts the password-required behaviour on purpose.

This PR makes the resulting downgrade **visible**. The durable fix needs a compensating control first (a short-lived `authenticator:register` re-auth token, an active-device co-sign, or an OOB email confirm before the pending row activates).

## What changed

- `ensureApproverDevice` returns an `ApproverRegistrationOutcome` instead of `void`. **Still fails open and never throws** — it just reports what happened. `unsupported` (no biometric hardware / simulator) is kept distinct from `failed` so the UI doesn't cry wolf.
- `authSlice`: `approverRegistration` + reason, cleared on logout — including `logoutAsync.fulfilled/rejected`, which are the paths the Sign Out button and the `device_blocked` listener actually take.
- `ApprovalGate`: warning banner on failure. Push failure still outranks it — an approval that never arrives is worse than one that arrives unsigned.
- `RootNavigator`: `active` cancellation flag on the effect. `checkAuth` dispatches `setCredentials` twice on a cold start (cached user, then fresh from `/auth/me`), so the effect re-runs while the first call is in flight; without the guard a call started for user A could resolve after A signed out and B signed in, writing A's outcome into B's session.

**Android push honesty:** with `extra.eas.projectId` gone (dropped by the native-APNs switch in #2333), the Expo path threw and surfaced as `failed`, showing a red "push failed to register" banner for a feature that was never wired. It now returns `unsupported: android_push_not_configured`.

**Docs:** salvages `STORE_SUBMISSION.md` from the stale `wip/mobile-notifications` branch (since deleted) — correcting the account-deletion URL, which still pointed at the `breezermm.com/account/delete` 404 that #2325 fixed, and recording that APNs is now configured in production.

## Tests

Mobile suite **25 files / 215 passing**, tsc clean (was 24 / 199).

- New `notifications.test.ts` — first coverage for that module; pins the iOS-native vs Android-relay branch.
- `approverDevice.test.ts` — regression test for the 400 specifically, plus `missing_device_id` and network-throw cases.
- `authSlice.test.ts` — reset asserted on all three sign-out paths. **Mutation-checked**: deleting the two `logoutAsync` resets fails exactly those two tests and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)