### PR TITLE
fix(approvals): re-derive sole-operator status at decide time (#2685)

### DIFF
--- a/apps/api/src/__tests__/integration/intentSelfApproveGuard.integration.test.ts
+++ b/apps/api/src/__tests__/integration/intentSelfApproveGuard.integration.test.ts
@@ -238,27 +238,37 @@ describe('sole-operator self-approve guard — re-derived at decide time (#2685,
 
     const res = await decideViaRoute(s, s.requester, forgedRowId, 'approve');
 
-    // A distinguishable refusal, not a generic 403 — the client can explain it
-    // and it is greppable in logs / audit details.
+    // THE load-bearing assertion of this test: the refusal carries the
+    // `not_sole_approver` token specifically. This is what distinguishes the
+    // guard from the pre-existing gates. Note that `decideViaRoute(...'approve')`
+    // presents NO L3 proof, so with the guard removed this call still 403s — but
+    // with `step_up_required` from the assurance gate, not `not_sole_approver`.
+    // So the status check alone is vacuous (403 either way); the token match on
+    // the next line is the whole proof. That the guard refuses even at FULL L3
+    // assurance (i.e. it is a four-eyes check, not an assurance check) is proven
+    // separately, and more cheaply, by the unit test in approvals.test.ts that
+    // mocks assertApprovalAssurance to a passing L3 and shows the CAS is never
+    // reached.
     expect(res.status).toBe(403);
     expect(await res.json()).toMatchObject({ error: 'not_sole_approver' });
 
     await withSystemDbAccessContext(async () => {
-      // THE property: the intent was never released. On the pre-#2685 handler
-      // this row is `approved` (the L3 gate is the only thing in the way, and
-      // it is an assurance check, not a four-eyes check).
+      // Corroborating side-effects of the refusal. These do NOT independently
+      // prove the guard (the L3 gate above would also leave the intent pending
+      // in this no-proof call) — they confirm the refusal happened cleanly:
+      // the intent was never released...
       const [intent] = await db.select().from(actionIntents).where(eq(actionIntents.id, snapshot.id));
       expect(intent?.status).toBe('pending_approval');
 
-      // No outbox row → the release worker never sees it.
+      // ...no outbox row was written, so the release worker never sees it...
       const outbox = await db
         .select({ id: intentOutbox.id })
         .from(intentOutbox)
         .where(and(eq(intentOutbox.intentId, snapshot.id), eq(intentOutbox.eventType, 'intent_approved')));
       expect(outbox).toHaveLength(0);
 
-      // The refusal is BEFORE the CAS, so no approval row flipped — the real
-      // approver's row is still decidable.
+      // ...and because the refusal is BEFORE the CAS, no approval row flipped —
+      // the real approver's row is still decidable.
       const rows = await db
         .select({ id: approvalRequests.id, userId: approvalRequests.userId, status: approvalRequests.status })
         .from(approvalRequests)

--- a/apps/api/src/__tests__/integration/intentSelfApproveGuard.integration.test.ts
+++ b/apps/api/src/__tests__/integration/intentSelfApproveGuard.integration.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Real-Postgres proof of the sole-operator self-approve guard (#2685).
+ *
+ * Four-eyes for a Tier-3 action intent used to be decided exactly ONCE, at
+ * fan-out (`services/actionIntents/intentService.ts`), by branch mutual
+ * exclusion: the multi-approver branch fans rows out to OTHER users, and only
+ * the sole-operator branch ever creates a requester-owned row. The decide
+ * handler then inferred "you were the only eligible approver" purely from
+ * "a row exists that you own" (`linkedIntent.requestedByUserId === userId`)
+ * plus an assurance >= L3 step-up. Since release is first-wins CAS, ANY future
+ * fan-out regression that leaked a requester-owned row into a multi-approver
+ * intent would have let the requester unilaterally release it, with no
+ * server-side check catching it.
+ *
+ * This suite forges exactly that state — a genuine multi-approver intent with
+ * a requester-owned `approval_requests` row inserted directly — and drives the
+ * REAL decide route (real JWT + `authMiddleware` + `breeze_app` RLS) against
+ * the test Postgres. `approvals.test.ts` mocks `../db` and
+ * `resolveIntentApprovers` wholesale, so only a real-DB suite can prove the
+ * resolver actually re-derives the live approver population (org members via
+ * `organization_users` AND partner members via `partner_users`, which is
+ * Shape-3 partner-axis RLS and invisible from an org-scoped context).
+ *
+ * Lives under `src/__tests__/integration/` so the directory-wide glob in
+ * `vitest.integration.config.ts` (include) and `vitest.config.ts` (exclude)
+ * both pick it up automatically — no dual hand-list edit to forget.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { randomUUID } from 'crypto';
+import { and, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { db, withSystemDbAccessContext } from '../../db';
+import { actionIntents, intentOutbox } from '../../db/schema/actionIntents';
+import { approvalRequests } from '../../db/schema/approvals';
+import { createActionIntent } from '../../services/actionIntents/intentService';
+import { PERMISSIONS } from '../../services/permissions';
+import { buildOrgAccessClosures, type AuthContext } from '../../middleware/auth';
+import { createAccessToken, type TokenPayload } from '../../services/jwt';
+import { approvalRoutes } from '../../routes/approvals';
+import {
+  assignUserToOrganization,
+  assignUserToPartner,
+  createOrganization,
+  createPartner,
+  createRole,
+  createUser,
+  grantRolePermissions,
+} from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+/** Real AuthContext for the requester acting on `orgId`, the same shape
+ * authMiddleware produces (reuses `buildOrgAccessClosures` so org-access
+ * semantics can't drift from the live path). Mirrors intentFanout's helper. */
+function requesterAuth(
+  user: { id: string; email: string },
+  orgId: string,
+  partnerId: string,
+  roleId: string,
+): AuthContext {
+  const { orgCondition, canAccessOrg } = buildOrgAccessClosures([orgId]);
+  return {
+    user: { id: user.id, email: user.email, name: 'Requester', isPlatformAdmin: false },
+    token: {
+      sub: user.id,
+      email: user.email,
+      roleId,
+      orgId,
+      partnerId,
+      scope: 'organization',
+      type: 'access',
+      mfa: true,
+    },
+    partnerId,
+    orgId,
+    scope: 'organization',
+    accessibleOrgIds: [orgId],
+    orgCondition,
+    canAccessOrg,
+  };
+}
+
+/** A real org-scoped access token, minted the way db-utils.setupTestEnvironment
+ * does (aep/mep = 1 matches the seeded row's default epochs; sid must be
+ * non-empty for authMiddleware). */
+async function accessTokenFor(
+  user: { id: string; email: string },
+  orgId: string,
+  partnerId: string,
+  roleId: string,
+): Promise<string> {
+  const payload: Omit<TokenPayload, 'type'> = {
+    sub: user.id,
+    email: user.email,
+    roleId,
+    orgId,
+    partnerId,
+    scope: 'organization',
+    mfa: false,
+    aep: 1,
+    mep: 1,
+    sid: randomUUID(),
+  };
+  return createAccessToken(payload);
+}
+
+interface Scenario {
+  partnerId: string;
+  orgId: string;
+  orgRoleId: string;
+  requester: { id: string; email: string };
+  /** Second eligible approver — seeded only for the multi-approver scenario. */
+  otherApprover: { id: string; email: string } | null;
+}
+
+/**
+ * Seeds one org under one partner and a requester who HOLDS approvals:decide
+ * (so they are genuinely in the eligible set — the guard must turn on whether
+ * anyone ELSE is, not on the requester's own eligibility).
+ *
+ * `withSecondApprover` adds a partner-scope approver (`partner_users`,
+ * org_access='all', NO organization_users row) — the CRITICAL-2 population
+ * that only the real resolver, under a system context, can see.
+ */
+async function seedScenario(opts: { withSecondApprover: boolean }): Promise<Scenario> {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+
+  const orgRole = await createRole({ scope: 'organization', orgId: org.id });
+  await grantRolePermissions(orgRole.id, [PERMISSIONS.APPROVALS_DECIDE]);
+
+  const partnerRole = await createRole({ scope: 'partner', partnerId: partner.id });
+  await grantRolePermissions(partnerRole.id, [PERMISSIONS.APPROVALS_DECIDE]);
+
+  const requester = await createUser({
+    partnerId: partner.id,
+    orgId: org.id,
+    email: `requester-${randomUUID()}@soleop.test`,
+  });
+  await assignUserToOrganization(requester.id, org.id, orgRole.id);
+
+  let otherApprover: { id: string; email: string } | null = null;
+  if (opts.withSecondApprover) {
+    const partnerApprover = await createUser({
+      partnerId: partner.id,
+      orgId: null,
+      email: `partner-approver-${randomUUID()}@soleop.test`,
+    });
+    await assignUserToPartner(partnerApprover.id, partner.id, partnerRole.id, 'all');
+    otherApprover = { id: partnerApprover.id, email: partnerApprover.email };
+  }
+
+  return {
+    partnerId: partner.id,
+    orgId: org.id,
+    orgRoleId: orgRole.id,
+    requester: { id: requester.id, email: requester.email },
+    otherApprover,
+  };
+}
+
+/** Creates a Tier-3 intent as the requester. `execute_command` is a base
+ * Tier-3 tool and createActionIntent never verifies the device exists (that
+ * happens at release time), so a bare random UUID is fine (mirrors
+ * intentFanout). */
+async function createIntent(s: Scenario) {
+  const auth = requesterAuth(s.requester, s.orgId, s.partnerId, s.orgRoleId);
+  return createActionIntent(auth, {
+    toolName: 'execute_command',
+    input: { deviceId: randomUUID(), commandType: 'list_processes' },
+    source: 'chat',
+  });
+}
+
+/**
+ * Forges the exact state a future fan-out regression would produce: a
+ * requester-owned `approval_requests` row on a MULTI-approver intent. Cloned
+ * from a real sibling row (so every NOT NULL column and the
+ * approval_requests_one_source_chk source-exclusivity constraint are satisfied
+ * exactly as the real fan-out satisfies them) with `user_id` swapped to the
+ * requester. Inserted under system scope — Shape-6 user-scoped RLS would deny
+ * a cross-user insert otherwise (42501).
+ */
+async function forgeRequesterOwnedRow(intentId: string, requesterId: string): Promise<string> {
+  return withSystemDbAccessContext(async () => {
+    const [sibling] = await db
+      .select()
+      .from(approvalRequests)
+      .where(eq(approvalRequests.intentId, intentId));
+    if (!sibling) throw new Error('forge: no sibling approval row to clone');
+    const { id: _ignoredId, ...rest } = sibling;
+    const [forged] = await db
+      .insert(approvalRequests)
+      .values({ ...rest, userId: requesterId })
+      .returning({ id: approvalRequests.id });
+    if (!forged) throw new Error('forge: insert returned no row');
+    return forged.id;
+  });
+}
+
+async function decideViaRoute(
+  s: Scenario,
+  user: { id: string; email: string },
+  approvalRowId: string,
+  decision: 'approve' | 'deny',
+): Promise<Response> {
+  const token = await accessTokenFor(user, s.orgId, s.partnerId, s.orgRoleId);
+  const app = new Hono();
+  app.route('/approvals', approvalRoutes);
+  return app.request(`/approvals/${approvalRowId}/${decision}`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(decision === 'deny' ? { reason: 'changed my mind' } : {}),
+  });
+}
+
+describe('sole-operator self-approve guard — re-derived at decide time (#2685, real Postgres)', () => {
+  runDb('refuses a self-approve on a MULTI-approver intent even when a requester-owned row is forced into existence', async () => {
+    const s = await seedScenario({ withSecondApprover: true });
+    const snapshot = await createIntent(s);
+
+    // Sanity: the real fan-out is correct today — one row, to the OTHER
+    // approver, never the requester. Without this the forge below could be
+    // asserting against an already-broken fan-out.
+    expect(snapshot.status).toBe('pending_approval');
+    expect(snapshot.approvalRequestIds).toHaveLength(1);
+    const fannedOut = await withSystemDbAccessContext(() =>
+      db
+        .select({ userId: approvalRequests.userId })
+        .from(approvalRequests)
+        .where(eq(approvalRequests.intentId, snapshot.id)),
+    );
+    expect(fannedOut.map((r) => r.userId)).toEqual([s.otherApprover!.id]);
+
+    // Now simulate the regression this guard exists for.
+    const forgedRowId = await forgeRequesterOwnedRow(snapshot.id, s.requester.id);
+
+    const res = await decideViaRoute(s, s.requester, forgedRowId, 'approve');
+
+    // A distinguishable refusal, not a generic 403 — the client can explain it
+    // and it is greppable in logs / audit details.
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: 'not_sole_approver' });
+
+    await withSystemDbAccessContext(async () => {
+      // THE property: the intent was never released. On the pre-#2685 handler
+      // this row is `approved` (the L3 gate is the only thing in the way, and
+      // it is an assurance check, not a four-eyes check).
+      const [intent] = await db.select().from(actionIntents).where(eq(actionIntents.id, snapshot.id));
+      expect(intent?.status).toBe('pending_approval');
+
+      // No outbox row → the release worker never sees it.
+      const outbox = await db
+        .select({ id: intentOutbox.id })
+        .from(intentOutbox)
+        .where(and(eq(intentOutbox.intentId, snapshot.id), eq(intentOutbox.eventType, 'intent_approved')));
+      expect(outbox).toHaveLength(0);
+
+      // The refusal is BEFORE the CAS, so no approval row flipped — the real
+      // approver's row is still decidable.
+      const rows = await db
+        .select({ id: approvalRequests.id, userId: approvalRequests.userId, status: approvalRequests.status })
+        .from(approvalRequests)
+        .where(eq(approvalRequests.intentId, snapshot.id));
+      expect(rows.every((r) => r.status === 'pending')).toBe(true);
+      expect(rows.find((r) => r.userId === s.otherApprover!.id)?.status).toBe('pending');
+    });
+  });
+
+  runDb('a genuinely SOLE-operator self-approve is not blocked by the guard (it reaches the L3 step-up gate)', async () => {
+    // Only the requester holds approvals:decide in this org, so the real
+    // fan-out takes the sole-operator branch. The guard must let this through;
+    // the ONLY thing that stops the L1 session-tap approve is the pre-existing
+    // assurance >= L3 step-up — proving the new check is not a blanket refusal
+    // and that it is ordered BEFORE the assurance proof.
+    const s = await seedScenario({ withSecondApprover: false });
+    const snapshot = await createIntent(s);
+    expect(snapshot.approvalRequestIds).toHaveLength(1);
+
+    const [ownRow] = await withSystemDbAccessContext(() =>
+      db
+        .select({ id: approvalRequests.id, userId: approvalRequests.userId })
+        .from(approvalRequests)
+        .where(eq(approvalRequests.intentId, snapshot.id)),
+    );
+    expect(ownRow?.userId).toBe(s.requester.id);
+
+    const res = await decideViaRoute(s, s.requester, ownRow!.id, 'approve');
+    expect(res.status).toBe(403);
+    // step_up_required, NOT not_sole_approver.
+    expect(await res.json()).toMatchObject({ error: 'step_up_required', requiredLevel: 3 });
+  });
+
+  runDb('a self-DENY is never blocked, even on a multi-approver intent', async () => {
+    // Denying only cancels the action, so it must stay available in every
+    // case — the guard is gated to `approved` only.
+    const s = await seedScenario({ withSecondApprover: true });
+    const snapshot = await createIntent(s);
+    const forgedRowId = await forgeRequesterOwnedRow(snapshot.id, s.requester.id);
+
+    const res = await decideViaRoute(s, s.requester, forgedRowId, 'deny');
+    expect(res.status).toBe(200);
+
+    await withSystemDbAccessContext(async () => {
+      const [intent] = await db.select().from(actionIntents).where(eq(actionIntents.id, snapshot.id));
+      expect(intent?.status).toBe('rejected');
+    });
+  });
+});

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -60,6 +60,16 @@ vi.mock('../services/actionIntents/metrics', () => ({
   recordActionIntentEvent: vi.fn(),
 }));
 
+// #2685: the decide handler RE-DERIVES the eligible approver set before
+// permitting a self-approve, instead of inferring sole-operator status from
+// "a requester-owned row exists". Default: the deciding user is the only
+// eligible approver (the genuine sole-operator org), so the pre-existing
+// sole-operator tests keep their behaviour; the refusal test overrides it.
+vi.mock('../services/actionIntents/intentApprovers', () => ({
+  // Literal id, not TEST_USER — vi.mock factories are hoisted above the const.
+  resolveIntentApprovers: vi.fn(async () => ['00000000-0000-0000-0000-000000000001']),
+}));
+
 // The decide handler re-resolves the DECIDER's live authorization before an
 // intent-backed approve (approvals:decide + org access). Mocked as a
 // collaborator with permissive defaults (a still-authorized approver); the
@@ -198,6 +208,7 @@ import { issueMobileAssertionNonce } from '../services/mobileHwKey';
 import { requireCurrentPasswordStepUp } from './auth/helpers';
 import { recordActionIntentEvent } from '../services/actionIntents/metrics';
 import { getUserPermissions, userCanDecideApprovals, canAccessOrg } from '../services/permissions';
+import { resolveIntentApprovers } from '../services/actionIntents/intentApprovers';
 
 function buildApp() {
   const app = new Hono();
@@ -291,6 +302,9 @@ beforeEach(() => {
   // Re-establish the default "password ok" (null = no error) after clearAllMocks
   // wipes the factory implementation; per-case overrides set their own.
   vi.mocked(requireCurrentPasswordStepUp).mockResolvedValue(null);
+  // #2685: re-establish the "decider is still the only eligible approver"
+  // default after clearAllMocks wipes the factory implementation.
+  vi.mocked(resolveIntentApprovers).mockResolvedValue([TEST_USER.id]);
   vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
     c.set('auth', {
       scope: 'partner',
@@ -1408,6 +1422,74 @@ describe('Task 5: decide-handler bound to action_intents', () => {
     );
     expect(recordActionIntentEvent).toHaveBeenCalledWith(
       expect.objectContaining({ outcome: 'self_approved_sole_operator' }),
+    );
+    // #2685: the happy path must have actually re-derived the approver set,
+    // not skipped the check.
+    expect(resolveIntentApprovers).toHaveBeenCalledWith('org-9');
+  });
+
+  // #2685: sole-operator status is RE-DERIVED at decide time, not inferred
+  // from row ownership.
+  it('refuses a self-approve (403 not_sole_approver) when the org now has another eligible approver, even at L3', async () => {
+    mockDecideWithIntent({ requestedByUserId: TEST_USER.id });
+    // Fully-assured self-approve — proves the refusal is the approver-set
+    // re-derivation, not the L3 step-up gate.
+    vi.mocked(assertApprovalAssurance).mockResolvedValueOnce({
+      requiredLevel: 3,
+      decidedAssuranceLevel: 3,
+      decidedVia: 'webauthn_platform',
+      authenticatorDeviceId: 'dev-1',
+    });
+    vi.mocked(resolveIntentApprovers).mockResolvedValueOnce([TEST_USER.id, 'other-approver']);
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('not_sole_approver');
+    // Fails closed BEFORE the CAS — the intent is never transitioned.
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: 'org-9',
+        intentId: 'intent-1',
+        outcome: 'approver_unauthorized',
+        actorId: TEST_USER.id,
+        details: expect.objectContaining({ errorCode: 'not_sole_approver' }),
+      }),
+    );
+  });
+
+  it('refuses a self-approve BEFORE consuming an assurance proof (no WebAuthn challenge burned)', async () => {
+    mockDecideWithIntent({ requestedByUserId: TEST_USER.id });
+    vi.mocked(resolveIntentApprovers).mockResolvedValueOnce([TEST_USER.id, 'other-approver']);
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(403);
+    expect(assertApprovalAssurance).not.toHaveBeenCalled();
+  });
+
+  it('never re-derives approvers for a cross-user approve (the check is self-approve only)', async () => {
+    mockDecideWithIntent({ requestedByUserId: 'requester-1' });
+    mockIntentFanInTx();
+
+    const res = await buildApp().request('/approvals/appr-1/approve', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(resolveIntentApprovers).not.toHaveBeenCalled();
+  });
+
+  it('still allows a self-DENY when the org gained another eligible approver (deny is never blocked)', async () => {
+    mockDecideWithIntent({ requestedByUserId: TEST_USER.id });
+    const { intentCasSet } = mockIntentFanInTx();
+    vi.mocked(resolveIntentApprovers).mockResolvedValueOnce([TEST_USER.id, 'other-approver']);
+
+    const res = await buildApp().request('/approvals/appr-1/deny', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'changed my mind' }),
+    });
+    expect(res.status).toBe(200);
+    expect(intentCasSet).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'rejected' }),
     );
   });
 

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -15,6 +15,7 @@ import { dispatchApprovalPush } from '../services/expoPush';
 import { revokeUserOauthClient } from './lifecycle';
 import { assertApprovalAssurance, StepUpRequiredError, ReauthRequiredError } from '../services/authenticatorAssurance';
 import { recordActionIntentEvent } from '../services/actionIntents/metrics';
+import { resolveIntentApprovers } from '../services/actionIntents/intentApprovers';
 import { getUserPermissions, userCanDecideApprovals, canAccessOrg } from '../services/permissions';
 import { generateApprovalAssertionOptions } from '../services/approverWebAuthn';
 import { issueMobileAssertionNonce } from '../services/mobileHwKey';
@@ -562,6 +563,69 @@ async function decideHandler(
           details: { approvalId: existing.id },
         });
         return c.json({ error: 'forbidden' }, 403);
+      }
+
+      // Sole-operator RE-DERIVATION (#2685). Four-eyes for a Tier-3 intent is
+      // otherwise decided exactly once, at fan-out
+      // (services/actionIntents/intentService.ts), by branch mutual exclusion:
+      // the multi-approver branch fans rows out to OTHER users, and only the
+      // sole-operator branch ever creates a requester-owned row. Nothing
+      // downstream re-establishes that — this handler used to infer "you were
+      // the only eligible approver" purely from "a row exists that you own".
+      // Since release is first-wins CAS, any future fan-out regression that
+      // leaked a requester-owned row into a multi-approver intent would let the
+      // requester unilaterally release it with no server-side check catching
+      // it. So re-derive the eligible set here and require the self-approver to
+      // STILL be the only eligible approver for the intent's org.
+      //
+      // This is deliberately a re-derivation, not a persisted `sole_operator`
+      // flag (issue #2685 option 2 over option 1): it fails closed, and "you
+      // are no longer the only approver, so you no longer get to self-approve"
+      // is what the four-eyes model implies. An intent created while solo and
+      // decided after the org gained a second approver is REFUSED — intended.
+      // A persisted flag would still let that self-approve through.
+      //
+      // Only runs on a self-approve (requester === decider), so the common
+      // cross-user approve pays nothing. `resolveIntentApprovers` opens its own
+      // system context internally (partner_users is Shape-3 partner-axis RLS,
+      // invisible from an org-scoped request context), so it must be called
+      // with runOutsideDbContext — a nested withDbAccessContext RETAINS the
+      // ambient context rather than elevating (db/index.ts) — and calling it
+      // outside any context also avoids holding a pooled connection across the
+      // round-trip (the #1105 connection-hold class).
+      //
+      // Ordered with the stale-approver check ABOVE the assurance proof for the
+      // same reason that one is: a refused decision must never consume a
+      // WebAuthn challenge. Gated to `approved` only — a deny stays available
+      // in every case, since denying only cancels the action.
+      if (linkedIntent.requestedByUserId === userId) {
+        const eligibleNow = await runOutsideDbContext(() =>
+          resolveIntentApprovers(linkedIntent!.orgId),
+        );
+        const othersEligible = eligibleNow.filter((candidate) => candidate !== userId);
+        // "ONLY eligible approver" is both halves: nobody else is eligible AND
+        // the self-approver still is. The second half is belt-and-braces over
+        // the live-authorization re-check above (which asks the permissions
+        // service rather than this resolver) — if the two ever disagree, refuse.
+        if (othersEligible.length > 0 || !eligibleNow.includes(userId)) {
+          recordActionIntentEvent({
+            orgId: linkedIntent.orgId,
+            intentId: linkedIntent.id,
+            actionName: linkedIntent.actionName,
+            argumentDigest: linkedIntent.argumentDigest,
+            source: linkedIntent.source,
+            outcome: 'approver_unauthorized',
+            actorId: userId,
+            details: {
+              approvalId: existing.id,
+              errorCode: 'not_sole_approver',
+              // Count only — never the approver ids (spec §7: ids of the
+              // event's own subjects, not a roster of other users).
+              eligibleApproverCount: eligibleNow.length,
+            },
+          });
+          return c.json({ error: 'not_sole_approver' }, 403);
+        }
       }
     }
   }

--- a/apps/api/src/services/actionIntents/metrics.ts
+++ b/apps/api/src/services/actionIntents/metrics.ts
@@ -27,7 +27,11 @@ import type { ActionIntentSource } from '../../db/schema/actionIntents';
  * (`existing.boundArgumentDigest !== linkedIntent.argumentDigest`);
  * `approver_unauthorized` fires when the deciding user no longer holds
  * approvals:decide / org access at decide time (a demoted approver reusing a
- * still-visible fanned-out row). Both are failure outcomes (see
+ * still-visible fanned-out row), and — per the "WHY belongs in
+ * details.errorCode" rule above — ALSO carries the sole-operator
+ * re-derivation refusal (#2685) as `details.errorCode:
+ * 'not_sole_approver'`: a requester self-approving an intent whose org now
+ * has another eligible approver. Both are failure outcomes (see
  * `FAILURE_OUTCOMES`).
  */
 export type ActionIntentOutcome =


### PR DESCRIPTION
Closes #2685.

Defense-in-depth on the Tier-3 durable action-intents approval layer (#2625). Not exploitable today — this moves the four-eyes invariant to where it is *checked*, not just where it is *created*.

## The gap

Four-eyes is decided exactly once, at fan-out, by branch mutual exclusion in `services/actionIntents/intentService.ts`: the multi-approver branch fans rows out to **other** users, and only the sole-operator branch ever creates a requester-owned row.

The decide handler then gated a self-approve on *"is this row mine"* plus assurance level 3. It never re-established that the requester was the **only** eligible approver — it inferred that from the row existing at all. Since release is first-wins CAS, any future fan-out regression that leaked a requester-owned row into a multi-approver intent would let that requester unilaterally release it, with nothing server-side catching it.

The mutation below is the clearest statement of the problem: with the new check disabled, the only thing standing in the way was the L3 assurance gate — which a requester with a registered authenticator clears trivially.

## What changed

`routes/approvals.ts` re-derives the eligible approver set at decide time and requires the self-approver to still be the only member. It runs **only** when `linkedIntent.requestedByUserId === userId`, so the common cross-user approve pays nothing.

Placed immediately after the existing live-authorization re-check and **before** `assertApprovalAssurance`, matching that check's rationale: a refused decision must never consume a WebAuthn challenge. Gated to `approved` only — a deny stays available in every case, since denying only cancels the action.

Uses `runOutsideDbContext(() => resolveIntentApprovers(orgId))`: the resolver opens its own system context internally (`partner_users` is Shape-3 partner-axis RLS and invisible from an org-scoped request context), a nested context would *retain* the ambient scope rather than elevate, and staying outside avoids holding a pooled connection across the round-trip (the #1105 class).

Refusal is `403 { error: 'not_sole_approver' }` plus `recordActionIntentEvent(... details: { errorCode: 'not_sole_approver', eligibleApproverCount })`. Per the existing metrics convention the *why* goes in `details.errorCode` rather than a new outcome value. Approver ids are deliberately not logged — count only.

It checks both halves (nobody else eligible **and** the decider still eligible), deliberately refusing if this resolver ever disagrees with the permissions-service check above it.

## Behaviour change — please read

This is **option 2 from the issue (re-derive), not option 1 (persisted flag)**, and the two differ in a user-visible way.

An intent created while the requester was solo, then decided **after** the org gained a second eligible approver, is now **refused**. A persisted `sole_operator` column would have let it through.

That is intended: it fails closed, and *"you are no longer the only approver, so you no longer get to self-approve"* is what the four-eyes model implies. Worth calling out in release notes.

## Tests

- **`intentSelfApproveGuard.integration.test.ts`** (new, real Postgres) — proves a multi-approver intent cannot be self-approved even when a requester-owned approval row is forced into existence. That is the exact regression this guards.
- Decide-handler unit coverage for the refusal path, the ordering, and the still-solo happy path (which must still succeed).

**Mutation evidence** — guard disabled, then restored:

```
× refuses a self-approve on a MULTI-approver intent...
  AssertionError: expected { error: 'step_up_required' } to match object { error: 'not_sole_approver' }
```

Unit: 3 failed / 50 passed with the guard off.

All executed locally against real Postgres on :5433. `approvals.test.ts` 53/53; with `services/actionIntents/` 128/128; `intentSelfApproveGuard` + `intentFanout` + `approvalsDecideAtomicity` 7/7. `tsc --noEmit` clean.

## Client note

No client special-cases `not_sole_approver` on `main` yet — the self-approve UI lives on the unmerged `feat/inline-intent-self-approve` branch. The copy mapping is being added there so the two compose correctly; without it the user would see a generic failure toast instead of "another approver is required".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
