### PR TITLE
feat(auth): admin MFA reset for lost-authenticator recovery

### DIFF
--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -2011,6 +2011,130 @@ describe('user routes', () => {
     });
   });
 
+  describe('POST /users/:id/mfa/reset (admin recovery: clear factor + invalidate assurance)', () => {
+    const TARGET = '11111111-1111-1111-1111-111111111111';
+
+    // getScopedUser (partner scope) reads partnerUsers ⋈ users ⋈ roles; return a
+    // membership so the target resolves inside the caller's tenant.
+    function mockScopedUser(found: boolean) {
+      return {
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue(
+                  found ? [{ id: TARGET, email: 'target@example.com', name: 'Target', status: 'active', roleId: 'r1', roleName: 'Tech' }] : []
+                )
+              })
+            })
+          })
+        })
+      } as any;
+    }
+
+    // The MFA-state probe: select({mfaEnabled,mfaMethod}).from(users).where().limit(1).
+    function mockMfaState(row: { mfaEnabled: boolean; mfaMethod: string | null } | null) {
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(row ? [row] : [])
+          })
+        })
+      } as any;
+    }
+
+    // tx stub for invalidateMfaAssuranceAfterFactorChange: the clear update takes
+    // no .returning(); advanceUserEpochs({mfa}) sets `mfaEpoch` and RETURNs the
+    // epoch row; revokeAllRefreshFamilies sets revoked_at/revoked_reason.
+    function mockFactorChangeTx() {
+      const capturedUpdates: Array<Record<string, unknown>> = [];
+      const txUpdate = vi.fn((_table: any) => ({
+        set: (values: Record<string, unknown>) => {
+          capturedUpdates.push(values);
+          return {
+            where: () => {
+              const ret: any = Promise.resolve(undefined);
+              ret.returning = () =>
+                values && 'mfaEpoch' in values
+                  ? Promise.resolve([{ authEpoch: 0, mfaEpoch: 7, emailEpoch: 0, passwordResetEpoch: 0 }])
+                  : Promise.resolve([]);
+              return ret;
+            }
+          };
+        }
+      }));
+      vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn({ update: txUpdate }));
+      return { capturedUpdates };
+    }
+
+    it('clears the factor, bumps mfa_epoch + revokes families in-tx (system context), then post-commit cleanup', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(mockScopedUser(true))
+        .mockReturnValueOnce(mockMfaState({ mfaEnabled: true, mfaMethod: 'totp' }));
+      const { capturedUpdates } = mockFactorChangeTx();
+
+      const res = await app.request(`/users/${TARGET}/mfa/reset`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      // Cross-user write went through the system-context escape.
+      expect(runOutsideDbContext).toHaveBeenCalled();
+      expect(withSystemDbAccessContext).toHaveBeenCalled();
+      // Factor cleared (mfaEnabled:false) + mfa_epoch bumped + families revoked.
+      expect(capturedUpdates.some((v) => v.mfaEnabled === false && v.mfaSecret === null)).toBe(true);
+      expect(capturedUpdates.some((v) => 'mfaEpoch' in v)).toBe(true);
+      expect(capturedUpdates.some((v) => 'revokedReason' in v)).toBe(true);
+      expect(runPostCommitCleanup).toHaveBeenCalledWith(TARGET);
+      // Audit records the admin action against the target.
+      expect(createAuditLogAsyncMock).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'user.mfa_reset', resourceId: TARGET, actorId: 'user-123' })
+      );
+    });
+
+    it('refuses to reset the caller’s own MFA (must use self-service disable)', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', { scope: 'partner', partnerId: 'partner-123', orgId: null, user: { id: TARGET, email: 't@e.com' } });
+        return next();
+      });
+
+      const res = await app.request(`/users/${TARGET}/mfa/reset`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(400);
+      expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+    });
+
+    it('404s for a target outside the caller’s tenant (no cross-tenant reset)', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(mockScopedUser(false));
+
+      const res = await app.request(`/users/${TARGET}/mfa/reset`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(404);
+      expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+    });
+
+    it('400s when the target has no MFA enabled (nothing to reset)', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(mockScopedUser(true))
+        .mockReturnValueOnce(mockMfaState({ mfaEnabled: false, mfaMethod: null }));
+
+      const res = await app.request(`/users/${TARGET}/mfa/reset`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(400);
+      expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+    });
+  });
+
   describe('PATCH /users/:id remote session teardown on deactivation', () => {
     const teardownMock = vi.mocked(terminateUserRemoteSessions);
 

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -2095,7 +2095,7 @@ describe('user routes', () => {
 
     it('refuses to reset the caller’s own MFA (must use self-service disable)', async () => {
       vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
-        c.set('auth', { scope: 'partner', partnerId: 'partner-123', orgId: null, user: { id: TARGET, email: 't@e.com' } });
+        c.set('auth', { scope: 'partner', partnerId: 'partner-123', orgId: null, user: { id: TARGET, email: 'target@example.com' } });
         return next();
       });
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -39,6 +39,7 @@ import { enforceExistingFactorStepUp, hashInviteToken, inviteRedisKey, inviteUse
 import { isPasswordAuthDisabledBySso } from './auth/ssoPolicy';
 import { terminateUserRemoteSessions, TEARDOWN_FAILED } from '../services/remoteSessionTeardown';
 import { advanceUserEpochs, revokeAllRefreshFamilies, runPostCommitCleanup, type Tx } from '../services/authLifecycle';
+import { invalidateMfaAssuranceAfterFactorChange } from '../services/mfaAssurance';
 import { getEffectiveMfaPolicy } from '../services/mfaPolicy';
 import { requestPendingEmailChange } from '../services/pendingEmail';
 
@@ -950,6 +951,7 @@ userRoutes.get(
           name: users.name,
           status: users.status,
           lastLoginAt: users.lastLoginAt,
+          mfaEnabled: users.mfaEnabled,
           roleId: roles.id,
           roleName: roles.name,
           orgAccess: partnerUsers.orgAccess,
@@ -970,6 +972,7 @@ userRoutes.get(
         name: users.name,
         status: users.status,
         lastLoginAt: users.lastLoginAt,
+        mfaEnabled: users.mfaEnabled,
         roleId: roles.id,
         roleName: roles.name,
         siteIds: organizationUsers.siteIds,
@@ -1618,6 +1621,97 @@ userRoutes.delete(
     await runPostCommitCleanup(userId);
 
     return c.json({ success: true });
+  }
+);
+
+// Admin MFA reset — recovery path for a user who lost their authenticator and
+// has no recovery codes (self-service POST /auth/mfa/disable is impossible for
+// them: it demands a live code). An admin with USERS_WRITE over the target's
+// tenant clears the factor and forces re-enrollment on next login.
+//
+// Deliberate design choices:
+//  - NOT gated on the org/partner MFA-enforcement policy: enforcement blocks
+//    self-disable, but this IS the recovery lever, and a still-enforced policy
+//    simply forces the user to re-enroll at next login (which is the goal).
+//  - NOT gated on ENABLE_2FA: if 2FA was turned off platform-wide, legacy
+//    enabled rows can't be cleared via self-service (that path early-returns),
+//    so admin reset is the ONLY recovery — it must keep working.
+//  - Self is refused: an admin must not strip their OWN factor here (that would
+//    bypass the code + password step-up the self-service flow requires).
+//  - requireMfa() forces the acting admin's session to have satisfied MFA, so a
+//    stolen access token alone cannot reset another user's second factor.
+userRoutes.post(
+  '/:id/mfa/reset',
+  requirePermission(PERMISSIONS.USERS_WRITE.resource, PERMISSIONS.USERS_WRITE.action),
+  requireMfa(),
+  async (c) => {
+    const auth = c.get('auth');
+    const scopeContext = getScopeContext(auth);
+    const userId = c.req.param('id')!;
+
+    if (userId === auth.user.id) {
+      return c.json(
+        { error: 'Use the self-service MFA disable flow to remove your own second factor' },
+        400
+      );
+    }
+
+    // Tenant boundary: getScopedUser only resolves a target that has a
+    // membership in the caller's org/partner, so an admin cannot reset a user
+    // outside their tenant (RLS on `users` is the second line of defense).
+    const record = await getScopedUser(userId, scopeContext);
+    if (!record) {
+      return c.json({ error: 'User not found' }, 404);
+    }
+
+    const [mfaState] = await db
+      .select({ mfaEnabled: users.mfaEnabled, mfaMethod: users.mfaMethod })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    if (!mfaState?.mfaEnabled) {
+      return c.json({ error: 'MFA is not enabled for this user' }, 400);
+    }
+    const previousMethod = mfaState.mfaMethod || 'totp';
+
+    // Cross-user write: clear the factor + advance mfa_epoch (kills the target's
+    // live access/refresh JWTs) + revoke refresh families + post-commit token/
+    // OAuth cutoff + remote-session teardown, via the same primitive the
+    // self-service disable uses. MUST run in system context — the target's
+    // `refresh_token_families` rows are user-scoped RLS and the admin's ambient
+    // context would revoke zero of them (see invalidateMfaAssuranceAfterFactorChange).
+    const result = await runOutsideDbContext(() =>
+      withSystemDbAccessContext(() =>
+        invalidateMfaAssuranceAfterFactorChange(userId, 'admin-mfa-reset', async (tx: Tx) => {
+          await tx
+            .update(users)
+            .set({
+              mfaSecret: null,
+              mfaEnabled: false,
+              mfaMethod: null,
+              mfaRecoveryCodes: null,
+              phoneNumber: null,
+              phoneVerified: false,
+              updatedAt: new Date()
+            })
+            .where(eq(users.id, userId));
+        })
+      )
+    );
+
+    writeUserAudit(c, auth, scopeContext, {
+      action: 'user.mfa_reset',
+      resourceId: userId,
+      resourceName: record.email,
+      details: {
+        method: previousMethod,
+        mfaEpoch: result.mfaEpoch,
+        teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED
+      }
+    });
+
+    return c.json({ success: true, message: 'MFA reset for user' });
   }
 );
 

--- a/apps/api/src/services/mfaAssurance.ts
+++ b/apps/api/src/services/mfaAssurance.ts
@@ -36,11 +36,21 @@ export interface FactorChangeResult {
  * suspended/rogue-factor session could keep a live remote session, and the
  * caller (route audit) must be able to record that.
  *
- * Runs under the caller's ambient (user-scoped) request context: every
- * caller here is a self-service `authMiddleware`-gated handler writing the
- * caller's OWN `users` row + OWN `refresh_token_families` rows, which
- * Shape-6 / user-id-scoped RLS admits without a system-context escape (same
- * precedent as /change-password). Do NOT wrap this in system context.
+ * Context: the SELF-SERVICE callers (mfa.ts setup/disable/enable/step-up,
+ * change-password) run under the caller's ambient (user-scoped) request
+ * context, writing the caller's OWN `users` + OWN `refresh_token_families`
+ * rows, which Shape-6 / user-id-scoped RLS admits without a system-context
+ * escape. Those callers must NOT wrap this in system context — the ambient
+ * context is exactly what scopes the write to themselves.
+ *
+ * The ONE cross-user caller — the admin MFA-reset route (POST
+ * /users/:id/mfa/reset in routes/users.ts) — is the exception: it writes a
+ * DIFFERENT user's rows, and `refresh_token_families` RLS only admits
+ * `user_id = self OR scope = 'system'`, so the admin's ambient context would
+ * silently revoke ZERO families. That caller MUST wrap this in
+ * `runOutsideDbContext(() => withSystemDbAccessContext(() => ...))`, and gates
+ * the cross-tenant authorization itself (requirePermission + getScopedUser)
+ * BEFORE calling in — RLS is defense-in-depth there, not the primary check.
  */
 export async function invalidateMfaAssuranceAfterFactorChange(
   userId: string,

--- a/apps/web/src/components/settings/UserList.tsx
+++ b/apps/web/src/components/settings/UserList.tsx
@@ -12,6 +12,7 @@ export type User = {
   role: string;
   status: UserStatus | string;
   lastLogin: string;
+  mfaEnabled?: boolean;
 };
 
 type UserListProps = {
@@ -21,6 +22,7 @@ type UserListProps = {
   onEdit?: (user: User) => void;
   onRemove?: (user: User) => void;
   onResendInvite?: (user: User) => void;
+  onResetMfa?: (user: User) => void;
 };
 
 const statusStyles: Record<string, string> = {
@@ -36,7 +38,7 @@ const statusLabelKeys: Record<UserStatus, string> = {
   pending: 'userList.status.pending',
 };
 
-export default function UserList({ users, currentUserId, onInvite, onEdit, onRemove, onResendInvite }: UserListProps) {
+export default function UserList({ users, currentUserId, onInvite, onEdit, onRemove, onResendInvite, onResetMfa }: UserListProps) {
   const { t } = useTranslation('settings');
   const [query, setQuery] = useState('');
 
@@ -150,6 +152,18 @@ export default function UserList({ users, currentUserId, onInvite, onEdit, onRem
                         >
                           {t('userList.actions.devices')}
                         </a>
+                        {user.mfaEnabled && (
+                          <>
+                            <span className="text-muted-foreground">|</span>
+                            <button
+                              type="button"
+                              onClick={() => onResetMfa?.(user)}
+                              className="text-sm font-medium text-primary hover:underline"
+                            >
+                              {t('userList.actions.resetMfa')}
+                            </button>
+                          </>
+                        )}
                         <span className="text-muted-foreground">|</span>
                         <button
                           type="button"

--- a/apps/web/src/components/settings/UsersPage.tsx
+++ b/apps/web/src/components/settings/UsersPage.tsx
@@ -8,7 +8,7 @@ import { useOrgStore } from '../../stores/orgStore';
 import { navigateTo } from '@/lib/navigation';
 import AccessDenied from '../shared/AccessDenied';
 
-type ModalMode = 'closed' | 'invite' | 'edit' | 'remove';
+type ModalMode = 'closed' | 'invite' | 'edit' | 'remove' | 'resetMfa';
 
 type InviteFormValues = {
   email: string;
@@ -76,6 +76,7 @@ export default function UsersPage() {
         lastLogin: u.lastLoginAt
           ? new Date(u.lastLoginAt as string).toLocaleDateString()
           : t('usersPage.never'),
+        mfaEnabled: Boolean(u.mfaEnabled),
       }));
       setUsers(rows);
     } catch (err) {
@@ -120,6 +121,35 @@ export default function UsersPage() {
   const handleRemove = (user: User) => {
     setSelectedUser(user);
     setModalMode('remove');
+  };
+
+  const handleResetMfa = (user: User) => {
+    setSelectedUser(user);
+    setModalMode('resetMfa');
+  };
+
+  const handleConfirmResetMfa = async () => {
+    if (!selectedUser) return;
+
+    setSubmitting(true);
+    try {
+      const response = await fetchWithAuth(`/users/${selectedUser.id}/mfa/reset`, {
+        method: 'POST'
+      });
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => null);
+        throw new Error(body?.error || t('usersPage.errors.resetMfa'));
+      }
+
+      await fetchUsers();
+      handleCloseModal();
+      addToast('success', t('usersPage.toasts.mfaReset', { email: selectedUser.email }));
+    } catch (err) {
+      addToast('error', err instanceof Error ? err.message : t('usersPage.errors.resetMfa'));
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const handleResendInvite = async (user: User) => {
@@ -310,6 +340,7 @@ export default function UsersPage() {
         onEdit={handleEdit}
         onRemove={handleRemove}
         onResendInvite={handleResendInvite}
+        onResetMfa={handleResetMfa}
       />
 
       {/* Invite Modal */}
@@ -426,6 +457,36 @@ export default function UsersPage() {
                 className="inline-flex h-10 items-center justify-center rounded-md bg-destructive px-4 text-sm font-medium text-destructive-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {submitting ? t('usersPage.actions.removing') : t('common:actions.remove')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Reset MFA Confirmation Modal */}
+      {modalMode === 'resetMfa' && selectedUser && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-8">
+          <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-xs">
+            <h2 className="text-lg font-semibold">{t('usersPage.resetMfa.title')}</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {t('usersPage.resetMfa.messagePrefix')} <span className="font-medium">{selectedUser.name}</span> ({selectedUser.email})?
+              {t('usersPage.resetMfa.messageSuffix')}
+            </p>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={handleCloseModal}
+                className="h-10 rounded-md border px-4 text-sm font-medium text-muted-foreground transition hover:text-foreground"
+              >
+                {t('common:actions.cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmResetMfa}
+                disabled={submitting}
+                className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {submitting ? t('usersPage.actions.resetting') : t('usersPage.resetMfa.confirm')}
               </button>
             </div>
           </div>

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -3067,7 +3067,8 @@
       "invite": "Benutzer einladen",
       "resendInvite": "Einladung erneut senden",
       "manageMobileDevices": "Verwalten Sie die Mobilgeräte dieses Benutzers",
-      "devices": "Geräte"
+      "devices": "Geräte",
+      "resetMfa": "MFA zurücksetzen"
     },
     "searchLabel": "Benutzer suchen",
     "searchPlaceholder": "Nach Name, E-Mail oder Rolle suchen",
@@ -3094,7 +3095,8 @@
     "actions": {
       "tryAgain": "Versuchen Sie es erneut",
       "saveChanges": "Änderungen speichern",
-      "removing": "Entfernen..."
+      "removing": "Entfernen...",
+      "resetting": "Wird zurückgesetzt..."
     },
     "errors": {
       "fetchUsers": "Benutzer konnten nicht abgerufen werden",
@@ -3103,7 +3105,8 @@
       "sendInvite": "Einladung konnte nicht gesendet werden",
       "updateUser": "Benutzer konnte nicht aktualisiert werden",
       "updateRole": "Die Rolle konnte nicht aktualisiert werden",
-      "removeUser": "Benutzer konnte nicht entfernt werden"
+      "removeUser": "Benutzer konnte nicht entfernt werden",
+      "resetMfa": "MFA konnte nicht zurückgesetzt werden"
     },
     "invite": {
       "title": "Benutzer einladen",
@@ -3128,7 +3131,14 @@
       "inviteManual": "Einladung für {{email}} erstellt, aber die E-Mail konnte nicht gesendet werden. Kopieren Sie den Einladungslink, um ihn manuell zu teilen.",
       "inviteSent": "Einladung an {{email}} gesendet",
       "copied": "Kopiert!",
-      "copyLink": "Link kopieren"
+      "copyLink": "Link kopieren",
+      "mfaReset": "MFA für {{email}} zurückgesetzt"
+    },
+    "resetMfa": {
+      "title": "MFA zurücksetzen?",
+      "messagePrefix": "Dies entfernt den zweiten Faktor für",
+      "messageSuffix": " Die Anmeldung erfolgt dann nur mit dem Passwort, MFA muss erneut eingerichtet werden, und aktive Sitzungen werden abgemeldet.",
+      "confirm": "MFA zurücksetzen"
     }
   },
   "tdSynnexSftpPanel": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -3120,7 +3120,8 @@
       "invite": "Invite user",
       "resendInvite": "Resend invite",
       "manageMobileDevices": "Manage this user's mobile devices",
-      "devices": "Devices"
+      "devices": "Devices",
+      "resetMfa": "Reset MFA"
     },
     "searchLabel": "Search users",
     "searchPlaceholder": "Search by name, email, or role",
@@ -3147,7 +3148,8 @@
     "actions": {
       "tryAgain": "Try again",
       "saveChanges": "Save changes",
-      "removing": "Removing..."
+      "removing": "Removing...",
+      "resetting": "Resetting..."
     },
     "errors": {
       "fetchUsers": "Failed to fetch users",
@@ -3156,7 +3158,8 @@
       "sendInvite": "Failed to send invitation",
       "updateUser": "Failed to update user",
       "updateRole": "Failed to update role",
-      "removeUser": "Failed to remove user"
+      "removeUser": "Failed to remove user",
+      "resetMfa": "Failed to reset MFA"
     },
     "invite": {
       "title": "Invite User",
@@ -3181,7 +3184,14 @@
       "inviteManual": "Invite created for {{email}} but the email could not be sent. Copy the invite link to share manually.",
       "inviteSent": "Invitation sent to {{email}}",
       "copied": "Copied!",
-      "copyLink": "Copy link"
+      "copyLink": "Copy link",
+      "mfaReset": "MFA reset for {{email}}"
+    },
+    "resetMfa": {
+      "title": "Reset MFA?",
+      "messagePrefix": "This removes the second factor for",
+      "messageSuffix": " They'll sign in with just their password, be prompted to set up MFA again, and any active sessions are signed out.",
+      "confirm": "Reset MFA"
     }
   }
 }

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -3067,7 +3067,8 @@
       "invite": "Invitar usuario",
       "resendInvite": "Reenviar invitación",
       "manageMobileDevices": "Administrar los dispositivos móviles de este usuario",
-      "devices": "Dispositivos"
+      "devices": "Dispositivos",
+      "resetMfa": "Restablecer MFA"
     },
     "searchLabel": "Buscar usuarios",
     "searchPlaceholder": "Buscar por nombre, correo electrónico o rol",
@@ -3094,7 +3095,8 @@
     "actions": {
       "tryAgain": "Intentar otra vez",
       "saveChanges": "Guardar cambios",
-      "removing": "Eliminando..."
+      "removing": "Eliminando...",
+      "resetting": "Restableciendo..."
     },
     "errors": {
       "fetchUsers": "No se pudieron recuperar los usuarios",
@@ -3103,7 +3105,8 @@
       "sendInvite": "No se pudo enviar la invitación",
       "updateUser": "No se pudo actualizar el usuario",
       "updateRole": "No se pudo actualizar el rol",
-      "removeUser": "No se pudo eliminar el usuario"
+      "removeUser": "No se pudo eliminar el usuario",
+      "resetMfa": "No se pudo restablecer MFA"
     },
     "invite": {
       "title": "Invitar usuario",
@@ -3128,7 +3131,14 @@
       "inviteManual": "Invitación creada para {{email}} pero no se pudo enviar el correo electrónico. Copie el enlace de invitación para compartirlo manualmente.",
       "inviteSent": "Invitación enviada a {{email}}",
       "copied": "¡Copiado!",
-      "copyLink": "Copiar enlace"
+      "copyLink": "Copiar enlace",
+      "mfaReset": "MFA restablecido para {{email}}"
+    },
+    "resetMfa": {
+      "title": "¿Restablecer MFA?",
+      "messagePrefix": "Esto elimina el segundo factor de",
+      "messageSuffix": " Iniciará sesión solo con su contraseña, se le pedirá configurar MFA de nuevo y se cerrarán las sesiones activas.",
+      "confirm": "Restablecer MFA"
     }
   },
   "tdSynnexSftpPanel": {

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -3067,7 +3067,8 @@
       "invite": "Inviter l’utilisateur",
       "resendInvite": "Réenvoyer l’invitation",
       "manageMobileDevices": "Gérez les appareils mobiles de cet utilisateur",
-      "devices": "Dispositifs"
+      "devices": "Dispositifs",
+      "resetMfa": "Réinitialiser la MFA"
     },
     "searchLabel": "Rechercher des utilisateurs",
     "searchPlaceholder": "Rechercher par nom, e-mail ou rôle",
@@ -3094,7 +3095,8 @@
     "actions": {
       "tryAgain": "Réessayer",
       "saveChanges": "Enregistrer les modifications",
-      "removing": "Enlèvement..."
+      "removing": "Enlèvement...",
+      "resetting": "Réinitialisation..."
     },
     "errors": {
       "fetchUsers": "Impossible de récupérer les utilisateurs",
@@ -3103,7 +3105,8 @@
       "sendInvite": "Impossible d’envoyer l’invitation",
       "updateUser": "Impossible de mettre à jour l’utilisateur",
       "updateRole": "Impossible de mettre à jour le rôle",
-      "removeUser": "Impossible de supprimer l’utilisateur"
+      "removeUser": "Impossible de supprimer l’utilisateur",
+      "resetMfa": "Échec de la réinitialisation de la MFA"
     },
     "invite": {
       "title": "Inviter l’utilisateur",
@@ -3128,7 +3131,14 @@
       "inviteManual": "Invitation créée pour {{email}} mais l’e-mail n’a pas pu être envoyé. Copiez le lien de l’invitation pour le partager manuellement.",
       "inviteSent": "Invitation envoyée à {{email}}",
       "copied": "Copié !",
-      "copyLink": "Copier le lien"
+      "copyLink": "Copier le lien",
+      "mfaReset": "MFA réinitialisée pour {{email}}"
+    },
+    "resetMfa": {
+      "title": "Réinitialiser la MFA ?",
+      "messagePrefix": "Cela supprime le second facteur de",
+      "messageSuffix": " La connexion se fera avec le seul mot de passe, la MFA devra être reconfigurée, et les sessions actives seront déconnectées.",
+      "confirm": "Réinitialiser la MFA"
     }
   },
   "tdSynnexSftpPanel": {

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -3120,7 +3120,8 @@
       "invite": "Convidar usuário",
       "resendInvite": "Reenviar convite",
       "manageMobileDevices": "Gerenciar os dispositivos móveis deste usuário",
-      "devices": "Dispositivos"
+      "devices": "Dispositivos",
+      "resetMfa": "Redefinir MFA"
     },
     "searchLabel": "Pesquisar usuários",
     "searchPlaceholder": "Pesquise por nome, e-mail ou função",
@@ -3147,7 +3148,8 @@
     "actions": {
       "tryAgain": "Tente novamente",
       "saveChanges": "Salvar alterações",
-      "removing": "Removendo..."
+      "removing": "Removendo...",
+      "resetting": "Redefinindo..."
     },
     "errors": {
       "fetchUsers": "Falha ao buscar usuários",
@@ -3156,7 +3158,8 @@
       "sendInvite": "Falha ao enviar convite",
       "updateUser": "Falha ao atualizar o usuário",
       "updateRole": "Falha ao atualizar a função",
-      "removeUser": "Falha ao remover usuário"
+      "removeUser": "Falha ao remover usuário",
+      "resetMfa": "Falha ao redefinir a MFA"
     },
     "invite": {
       "title": "Convidar usuário",
@@ -3181,7 +3184,14 @@
       "inviteManual": "Convite criado para {{email}}, mas não foi possível enviar o e-mail. Copie o link do convite para compartilhar manualmente.",
       "inviteSent": "Convite enviado para {{email}}",
       "copied": "Copiado!",
-      "copyLink": "Copiar link"
+      "copyLink": "Copiar link",
+      "mfaReset": "MFA redefinida para {{email}}"
+    },
+    "resetMfa": {
+      "title": "Redefinir MFA?",
+      "messagePrefix": "Isso remove o segundo fator de",
+      "messageSuffix": " O login passará a exigir apenas a senha, será solicitada a configuração da MFA novamente e as sessões ativas serão encerradas.",
+      "confirm": "Redefinir MFA"
     }
   }
 }


### PR DESCRIPTION
## Problem

When a user loses their authenticator **and** has no recovery codes, there is no way to get them back in. Self-service `POST /auth/mfa/disable` can't help — it requires a live 6-digit code. The only remedy today is a raw `UPDATE` against production Postgres (as a `BYPASSRLS` role, remembering to bump `mfa_epoch`). This adds a proper admin recovery lever.

## What this adds

**`POST /users/:id/mfa/reset`** — an org/partner admin with `USERS_WRITE` clears another user's MFA, forcing fresh re-enrollment at next login.

- **Tenant-scoped** via `getScopedUser` — an admin can only reset users inside their own org/partner. RLS on `users` is the second line of defense.
- **Reuses the canonical** `invalidateMfaAssuranceAfterFactorChange` primitive (clear factor + bump `mfa_epoch` → kills live JWTs + revoke refresh families + OAuth/Redis cutoff + remote-session teardown), wrapped in **system context** because the target's `refresh_token_families` rows are user-scoped RLS (the admin's ambient context would revoke zero).
- **Gate:** `requirePermission(USERS_WRITE)` + `requireMfa()` — the acting admin's own session must have satisfied MFA, so a stolen access token alone can't strip another user's second factor.
- **Refuses self-reset** — your own factor must go through the code+password self-service flow (this path would bypass that step-up).
- **Deliberately NOT gated** on the org MFA-enforcement policy or `ENABLE_2FA` — this *is* the recovery lever; an enforced policy simply forces re-enrollment at next login, and a platform-wide 2FA-off state is exactly when self-service can't clear a legacy factor.
- Writes a `user.mfa_reset` audit record (actor, target, method, epoch, teardown status).

**Web:** "Reset MFA" action in **Settings → Users** (shown only for other users with MFA enabled), with a confirmation modal. Adds `mfaEnabled` to `GET /users`; i18n keys across all 5 locales.

## Design notes / deliberate choices

- The doc comment on `invalidateMfaAssuranceAfterFactorChange` is updated to name this one cross-user caller and the required system-context wrapping (all other callers are self-service and must **not** system-wrap).
- Mirrors the existing cross-user idiom used by `PATCH /:id` (status) and `DELETE /:id`.

## Testing

- **API:** 4 new tests (success: factor cleared + `mfa_epoch` bump + family revoke + post-commit cleanup + audit; 404 out-of-tenant; 400 self; 400 not-enabled). Full `users.test.ts` green (91).
- **Web:** `UsersPage` + `no-silent-mutations` + i18n parity/coverage/keyUsage green (147).
- API `tsc --noEmit` clean; touched web files clean.
- One focused auth/multi-tenant review pass: no defects (tenant isolation, self-guard, system-context correctness, permission gate all confirmed).

## Deploy note

Nothing new required — no migration, no new env var. Once merged + deployed, the raw-SQL workaround is retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)