### PR TITLE
fix(reports): don't score stale firewall/encryption as current in Security & Compliance Posture

### DIFF
--- a/apps/api/src/routes/reports/schemas.ts
+++ b/apps/api/src/routes/reports/schemas.ts
@@ -22,6 +22,10 @@ export const securityCompliancePostureConfigSchema = z.object({
   maxLocalAdmins: z.number().int().min(0).max(50).optional().default(2),
   // AV definitions older than this many days count as stale.
   maxAvDefinitionsAgeDays: z.number().int().min(1).max(365).optional().default(7),
+  // A device's security_status row (firewall/encryption) older than this many
+  // days is treated as "unknown", not scored as a current pass or fail — an
+  // offline device's stale last-known posture shouldn't count either way.
+  maxSecurityStatusAgeDays: z.number().int().min(1).max(365).optional().default(30),
   // Include the CIS hardening section. Defaults on; renders "Not yet assessed"
   // until baseline scans exist, or is omitted entirely when set false.
   includeCis: z.boolean().optional().default(true),
@@ -41,6 +45,7 @@ export const securityCompliancePostureConfigFields = {
   minPasswordLength: z.number().int().min(1).max(64).optional(),
   maxLocalAdmins: z.number().int().min(0).max(50).optional(),
   maxAvDefinitionsAgeDays: z.number().int().min(1).max(365).optional(),
+  maxSecurityStatusAgeDays: z.number().int().min(1).max(365).optional(),
   includeCis: z.boolean().optional(),
   backupRequired: z.boolean().optional()
 };

--- a/apps/api/src/services/securityComplianceReport.test.ts
+++ b/apps/api/src/services/securityComplianceReport.test.ts
@@ -138,6 +138,120 @@ describe('generateSecurityCompliancePostureReport', () => {
     expect(c.passwordComplexityPct).toBe(50);
   });
 
+  it('excludes a stale security_status row from firewall/encryption, marking it unknown', async () => {
+    const stale = new Date(Date.now() - 60 * 86400000); // 60 days ago
+    mockGeneratorQueries({
+      2: [
+        { id: 'fresh', hostname: 'pc-fresh', osType: 'windows', siteName: 'S' },
+        { id: 'stale', hostname: 'pc-stale', osType: 'windows', siteName: 'S' },
+      ],
+      3: [
+        { deviceId: 'fresh', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: { minLength: 12, lockoutThreshold: 5 }, localAdminSummary: { adminCount: 1 }, updatedAt: new Date() },
+        { deviceId: 'stale', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'unencrypted', firewallEnabled: false, passwordPolicySummary: { minLength: 4 }, localAdminSummary: { adminCount: 5 }, updatedAt: stale },
+      ],
+      4: [],
+      5: [],
+    });
+    // Default cutoff is 30 days → the 60-day-old row is excluded from both controls.
+    const r = await generateSecurityCompliancePostureReport(ORG, {});
+    const c = (r.summary as any).controls;
+    // Only pc-fresh is assessed: 1/1 encrypted, 1/1 firewall on. The stale
+    // 'unencrypted'/firewall-off row does NOT drag the pass rate down.
+    expect(c.encryptionPct).toBe(100);
+    expect(c.firewallPct).toBe(100);
+    // Two in-scope devices, one assessed → one unknown each.
+    expect(c.encryptionUnknownCount).toBe(1);
+    expect(c.firewallUnknownCount).toBe(1);
+    // The stale device's per-row cells read as "no data", matching the aggregate.
+    const byHost = Object.fromEntries((r.rows as any[]).map((x) => [x.hostname, x]));
+    expect(byHost['pc-stale'].encryption).toBe('no data');
+    expect(byHost['pc-stale'].firewall).toBeNull();
+  });
+
+  it('honors a custom maxSecurityStatusAgeDays cutoff', async () => {
+    const tenDaysAgo = new Date(Date.now() - 10 * 86400000);
+    mockGeneratorQueries({
+      2: [{ id: 'd', hostname: 'h', osType: 'windows', siteName: 'S' }],
+      3: [
+        { deviceId: 'd', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null, updatedAt: tenDaysAgo },
+      ],
+      4: [],
+      5: [],
+    });
+    // A 10-day-old row is fresh under the 30-day default but stale under a 7-day cutoff.
+    const c = (await generateSecurityCompliancePostureReport(ORG, { maxSecurityStatusAgeDays: 7 })).summary!.controls as any;
+    expect(c.encryptionPct).toBeNull();
+    expect(c.firewallPct).toBeNull();
+    expect(c.encryptionUnknownCount).toBe(1);
+    expect(c.firewallUnknownCount).toBe(1);
+  });
+
+  it('counts a device with no security_status row toward the unknown tally (deviceCount basis)', async () => {
+    const stale = new Date(Date.now() - 60 * 86400000);
+    mockGeneratorQueries({
+      2: [
+        { id: 'assessed', hostname: 'pc-a', osType: 'windows', siteName: 'S' },
+        { id: 'stale', hostname: 'pc-s', osType: 'windows', siteName: 'S' },
+        { id: 'norow', hostname: 'pc-n', osType: 'windows', siteName: 'S' },
+      ],
+      3: [
+        { deviceId: 'assessed', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null, updatedAt: new Date() },
+        { deviceId: 'stale', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null, updatedAt: stale },
+        // 'norow' intentionally has no security_status row.
+      ],
+      4: [],
+      5: [],
+    });
+    const c = (await generateSecurityCompliancePostureReport(ORG, {})).summary!.controls as any;
+    // 3 in-scope devices, only 'assessed' is fresh with data. Unknown must be 2
+    // (stale + no-row). A `reporting - assessed` basis would wrongly yield 1 by
+    // dropping the no-row device — this pins the deviceCount denominator.
+    expect(c.encryptionPct).toBe(100);
+    expect(c.firewallPct).toBe(100);
+    expect(c.encryptionUnknownCount).toBe(2);
+    expect(c.firewallUnknownCount).toBe(2);
+  });
+
+  it('treats a row exactly at the cutoff as fresh and one day past it as stale', async () => {
+    mockGeneratorQueries({
+      2: [
+        { id: 'edge', hostname: 'pc-edge', osType: 'windows', siteName: 'S' },
+        { id: 'past', hostname: 'pc-past', osType: 'windows', siteName: 'S' },
+      ],
+      3: [
+        // daysAgo floors to whole days: exactly 30d → 30 (<= 30, fresh); 31d → stale.
+        { deviceId: 'edge', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null, updatedAt: new Date(Date.now() - 30 * 86400000) },
+        { deviceId: 'past', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null, updatedAt: new Date(Date.now() - 31 * 86400000) },
+      ],
+      4: [],
+      5: [],
+    });
+    const c = (await generateSecurityCompliancePostureReport(ORG, {})).summary!.controls as any;
+    // Only 'edge' (exactly at the inclusive 30-day cutoff) is assessed; 'past' is unknown.
+    expect(c.encryptionPct).toBe(100);
+    expect(c.firewallPct).toBe(100);
+    expect(c.encryptionUnknownCount).toBe(1);
+    expect(c.firewallUnknownCount).toBe(1);
+  });
+
+  it('fails open: a row with no updatedAt is treated as fresh, not stale', async () => {
+    mockGeneratorQueries({
+      2: [{ id: 'd', hostname: 'h', osType: 'windows', siteName: 'S' }],
+      3: [
+        // updatedAt omitted → daysAgo returns null → fail-open as fresh (defensive;
+        // the column is NOT NULL in prod, so this documents the intended default).
+        { deviceId: 'd', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null },
+      ],
+      4: [],
+      5: [],
+    });
+    const c = (await generateSecurityCompliancePostureReport(ORG, {})).summary!.controls as any;
+    expect(c.encryptionPct).toBe(100);
+    expect(c.firewallPct).toBe(100);
+    expect(c.encryptionUnknownCount).toBe(0);
+    expect(c.firewallUnknownCount).toBe(0);
+  });
+
   it('carries the backup requirement without changing posture score', async () => {
     mockGeneratorQueries();
     const summary = (await generateSecurityCompliancePostureReport(ORG, {

--- a/apps/api/src/services/securityComplianceReport.ts
+++ b/apps/api/src/services/securityComplianceReport.ts
@@ -103,7 +103,9 @@ function emptySummary(
       anyAvCoveragePct: null,
       unprotectedCount: 0,
       encryptionPct: null,
+      encryptionUnknownCount: 0,
       firewallPct: null,
+      firewallUnknownCount: 0,
       patchCurrentPct: null,
       patchUnknownCount: 0,
       passwordComplexityPct: null,
@@ -214,7 +216,8 @@ export async function generateSecurityCompliancePostureReport(
       encryptionStatus: securityStatus.encryptionStatus,
       firewallEnabled: securityStatus.firewallEnabled,
       passwordPolicySummary: securityStatus.passwordPolicySummary,
-      localAdminSummary: securityStatus.localAdminSummary
+      localAdminSummary: securityStatus.localAdminSummary,
+      updatedAt: securityStatus.updatedAt
     })
     .from(securityStatus)
     .where(and(eq(securityStatus.orgId, orgId), inArray(securityStatus.deviceId, deviceIds)));
@@ -382,12 +385,19 @@ export async function generateSecurityCompliancePostureReport(
     if (isManaged || hasNativeAv) anyAv += 1;
     if (!protectedDevice) unprotected += 1;
 
+    // Firewall/encryption are live device states that stop updating when a device
+    // goes offline, so a row older than the cutoff is treated as unknown rather
+    // than counted as a current pass/fail. (updatedAt is NOT NULL in schema; a
+    // null age can only be a legacy/edge row, which we fail-open as fresh.)
+    const ssAgeDays = ss ? daysAgo(ss.updatedAt) : null;
+    const ssFresh = Boolean(ss) && (ssAgeDays == null || ssAgeDays <= cfg.maxSecurityStatusAgeDays);
+
     const enc = ss?.encryptionStatus ?? 'unknown';
-    if (ss && enc !== 'unknown') {
+    if (ssFresh && enc !== 'unknown') {
       encAssessed += 1;
       if (enc === 'encrypted') encrypted += 1;
     }
-    if (ss && ss.firewallEnabled != null) {
+    if (ss && ssFresh && ss.firewallEnabled != null) {
       fwAssessed += 1;
       if (ss.firewallEnabled === true) firewall += 1;
     }
@@ -428,8 +438,8 @@ export async function generateSecurityCompliancePostureReport(
       protectionManaged: isManaged,
       realTimeProtection: rtp,
       avDefinitionsAgeDays: avAge,
-      encryption: ss ? enc : 'no data',
-      firewall: ss ? ss.firewallEnabled : null,
+      encryption: ssFresh ? enc : 'no data',
+      firewall: ss && ssFresh ? ss.firewallEnabled : null,
       localAdmins: admins,
       patchAssessed: patchScannedDevices.has(d.id),
       pendingPatches: pend.total,
@@ -493,7 +503,9 @@ export async function generateSecurityCompliancePostureReport(
         anyAvCoveragePct: pctOrNull(anyAv, deviceCount),
         unprotectedCount: unprotected,
         encryptionPct: pctOrNull(encrypted, encAssessed),
+        encryptionUnknownCount: deviceCount - encAssessed,
         firewallPct: pctOrNull(firewall, fwAssessed),
+        firewallUnknownCount: deviceCount - fwAssessed,
         patchCurrentPct: pctOrNull(patchCurrent, patchScanned),
         patchUnknownCount: deviceCount - patchScanned,
         passwordComplexityPct: pctOrNull(pwPass, pwAssessed),

--- a/packages/shared/src/types/postureReport.ts
+++ b/packages/shared/src/types/postureReport.ts
@@ -35,7 +35,11 @@ export type PostureControls = {
   unprotectedCount?: number;
   avDefinitionsCurrentPct?: number | null;
   encryptionPct?: number | null;
+  /** In-scope devices whose encryption state was unknown or too stale to assess. */
+  encryptionUnknownCount?: number;
   firewallPct?: number | null;
+  /** In-scope devices whose firewall state was unknown or too stale to assess. */
+  firewallUnknownCount?: number;
   patchCurrentPct?: number | null;
   patchUnknownCount?: number;
   passwordComplexityPct?: number | null;


### PR DESCRIPTION
## Problem

The **Security & Compliance Posture** report (an insurance/attestation report) read each device's firewall and encryption state from the last-known `security_status` row with **no freshness check**. An offline device's months-old reading was counted toward the compliance percentages as a *current* pass/fail — the two controls most likely to have silently changed on a device that dropped off the network.

This was inconsistent with the report's own stated design principle (*"an unmeasured control must never read as a measured failure or pass"*), which it already honors for patches (`patchUnknownCount`), passwords/local-admins (tri-state null), and AV definitions (`maxAvDefinitionsAgeDays` cutoff). Firewall and encryption had none of that.

To be clear: generating the report never required a device to be online — everything is read from stored tables. The bug was **staleness**, not a live device dependency.

## Fix

- New config field `maxSecurityStatusAgeDays` (int 1–365, **default 30**), added to both parallel posture config lists (parity test enforces sync).
- A per-device `ssFresh` flag gates the firewall/encryption "assessed" counters and the per-device table cells; a stale row is treated as **unknown** instead of scored, and its row cells render as "no data"/`—` so the detail view matches the aggregates.
- New summary fields `encryptionUnknownCount` / `firewallUnknownCount` (`deviceCount - assessed`), following the existing `patchUnknownCount` pattern.
- **No DB migration** — `updatedAt` already exists on `security_status` and is set on every agent upsert, so it reflects the last time the device reported.

## Scope note

Password-complexity and local-admin counts come from the same `security_status` row and share the identical staleness characteristic. This PR keeps the change scoped to firewall/encryption (the controls flagged); extending `ssFresh` to those two is a small follow-up if desired.

## Tests

Added 5 tests to `securityComplianceReport.test.ts`: stale row excluded under default cutoff, custom cutoff honored, **exact-cutoff boundary** (30d fresh / 31d stale), **no-row device counted as unknown** (pins the `deviceCount` denominator), and the fail-open null-`updatedAt` path. All API report suites green.

## Review

Ran a 4-agent review (code / tests / types / comments). No high-confidence bugs; logic confirmed correct. Applied the review feedback: reworded a one-directional comment and added the boundary + denominator + fail-open tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)