### PR TITLE
fix(mcp-oauth): accept http://localhost redirect_uri so Claude Code CLI can register

### DIFF
--- a/apps/api/src/__tests__/integration/dcr-redirect-policy.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dcr-redirect-policy.integration.test.ts
@@ -98,4 +98,13 @@ describe.skipIf(!SHOULD_RUN)('DCR redirect-URI transport policy (live)', () => {
     expect(res.status).toBe(201);
     expect(((await res.json()) as { client_id?: string }).client_id).toBeTruthy();
   });
+
+  it('registers a client with a localhost-hostname http redirect URI (claude-code CLI shape)', async () => {
+    // Regression guard for the 2026-07-12..21 outage: the CLI's native SDK auth
+    // registers `http://localhost:<ephemeral>/callback`, which #2377 rejected.
+    // This asserts the shape survives the full route, not just the pure policy.
+    const res = await register(live.url, ['http://localhost:52765/callback']);
+    expect(res.status).toBe(201);
+    expect(((await res.json()) as { client_id?: string }).client_id).toBeTruthy();
+  });
 });

--- a/apps/api/src/oauth/redirectUriPolicy.test.ts
+++ b/apps/api/src/oauth/redirectUriPolicy.test.ts
@@ -1,6 +1,51 @@
 import { describe, expect, it } from 'vitest';
 import { validateRedirectUris } from './redirectUriPolicy';
 
+/**
+ * Real callback shapes emitted by MCP clients we intend to support.
+ *
+ * This is a COMPATIBILITY CONTRACT, not a convenience fixture. Every entry is a
+ * client that will silently fail to connect — with no server-side error anyone
+ * looks at — if the transport policy stops accepting its shape. Registration is
+ * step 4 of the OAuth handshake; steps 1-3 keep returning 200, so the break
+ * presents to the user as an inscrutable "not authenticated" and gets found
+ * weeks later by hand.
+ *
+ * If a policy change turns one of these red, DO NOT relax the test to match the
+ * code. Either keep the client working, or delete its entry deliberately and
+ * say so in the PR body — dropping a client must be a decision, not a side
+ * effect. Two outages came from exactly this being tracked in prose instead:
+ * #2193 (IAT gate vs Claude Desktop) and the `localhost` rejection in #2377.
+ *
+ * Ports are ephemeral: native clients bind a random port at runtime, so the
+ * specific number here is arbitrary but the shape is not.
+ */
+const REAL_CLIENT_CALLBACKS: ReadonlyArray<{ client: string; uri: string }> = [
+  // Hosted web connector — HTTPS callback on Anthropic's domain.
+  { client: 'claude.ai hosted connector', uri: 'https://claude.ai/api/mcp/auth_callback' },
+  // Claude Code CLI native SDK auth — binds a local server, uses the
+  // `localhost` HOSTNAME (not the IP literal). Rejecting this is what broke
+  // MCP auth for CLI users between 2026-07-12 (#2377) and 2026-07-21.
+  { client: 'claude-code CLI (native SDK auth)', uri: 'http://localhost:52765/callback' },
+  // mcp-remote stdio bridge — uses the IPv4 loopback literal.
+  { client: 'mcp-remote bridge', uri: 'http://127.0.0.1:49152/oauth/callback' },
+  // IPv6-only hosts: same bridge, bracketed IPv6 loopback.
+  { client: 'mcp-remote bridge (IPv6 host)', uri: 'http://[::1]:49152/oauth/callback' },
+];
+
+describe('validateRedirectUris — real MCP client compatibility', () => {
+  it.each(REAL_CLIENT_CALLBACKS)(
+    'accepts the callback registered by $client',
+    ({ uri }) => {
+      expect(validateRedirectUris([uri])).toEqual({ ok: true });
+    },
+  );
+
+  it('accepts every real client callback registered together in one array', () => {
+    expect(validateRedirectUris(REAL_CLIENT_CALLBACKS.map((c) => c.uri))).toEqual({ ok: true });
+  });
+});
+
 describe('validateRedirectUris', () => {
   it('accepts a plain HTTPS callback', () => {
     expect(validateRedirectUris(['https://client.example/cb'])).toEqual({ ok: true });
@@ -22,9 +67,21 @@ describe('validateRedirectUris', () => {
     expect(validateRedirectUris(['http://[::1]:8080/cb'])).toEqual({ ok: true });
   });
 
-  it('rejects http://localhost (hostname, not a loopback IP) per RFC 8252 §7.3', () => {
-    const result = validateRedirectUris(['http://localhost/cb']);
-    expect(result.ok).toBe(false);
+  it('accepts HTTP for the localhost hostname with no port', () => {
+    // RFC 8252 §7.3 prefers IP literals, but permitting `localhost` is a
+    // deliberate compatibility choice — see the policy docblock. Real clients
+    // hardcode it; see REAL_CLIENT_CALLBACKS above.
+    expect(validateRedirectUris(['http://localhost/cb'])).toEqual({ ok: true });
+  });
+
+  it('accepts HTTP for the localhost hostname with an ephemeral port', () => {
+    expect(validateRedirectUris(['http://localhost:52765/cb'])).toEqual({ ok: true });
+  });
+
+  it('rejects a hostname that merely starts with the localhost label', () => {
+    // `localhost.evil.com` is an ordinary DNS name — the loopback allowance is
+    // exact-match only, never a prefix/suffix test.
+    expect(validateRedirectUris(['http://localhost.evil.com/cb']).ok).toBe(false);
   });
 
   it('rejects a private-network HTTP address', () => {

--- a/apps/api/src/oauth/redirectUriPolicy.ts
+++ b/apps/api/src/oauth/redirectUriPolicy.ts
@@ -12,30 +12,51 @@
  * Policy (RFC 8252 §7.3 native-app loopback guidance):
  *   - HTTPS is accepted for any host, provided it carries no userinfo
  *     credentials and no fragment.
- *   - HTTP is accepted ONLY for the literal loopback IP hosts `127.0.0.1` and
- *     `[::1]`, with any (or no) port. Ephemeral ports are expected — native
- *     apps bind a random port at runtime.
- *   - Everything else is rejected: `localhost` as a *hostname* (RFC 8252 warns
- *     it can resolve to a non-loopback interface and is DNS-spoofable),
- *     private-network addresses, public HTTP hosts, protocol-relative URLs,
- *     malformed URLs, credentials, fragments, and custom/app schemes.
+ *   - HTTP is accepted ONLY for the loopback hosts `127.0.0.1`, `[::1]`, and
+ *     `localhost`, with any (or no) port. Ephemeral ports are expected —
+ *     native apps bind a random port at runtime.
+ *   - Everything else is rejected: private-network addresses, public HTTP
+ *     hosts, protocol-relative URLs, malformed URLs, credentials, fragments,
+ *     and custom/app schemes.
  *
  * A single invalid URI rejects the ENTIRE registration (fail closed) — we never
  * silently drop the bad entry and register the rest.
  *
- * ROLLOUT NOTE (RFC 8252): rejecting `localhost` while allowing loopback IPs is
- * RFC-correct but has broken real MCP clients before (issue #2193). Claude's
- * hosted callback is HTTPS and mcp-remote uses a `127.0.0.1` loopback IP, so
- * both pass — but verify against a staging registration before deploy.
+ * WHY `localhost` IS ALLOWED (reversed 2026-07-21, see below): RFC 8252 §7.3
+ * *recommends* IP literals over the `localhost` hostname because `localhost`
+ * can in principle resolve to a non-loopback interface via a doctored
+ * hosts/DNS entry. That is a SHOULD, not a MUST, and the attack presupposes an
+ * already-compromised client host — at which point the authorization code is
+ * readable anyway. Meanwhile every client that hardcodes `http://localhost`
+ * simply cannot register. Stock `oidc-provider` (our own dependency) treats all
+ * three spellings as loopback (`LOOPBACKS` in lib/consts/client_attributes.js),
+ * so rejecting `localhost` made this policy stricter than the library it wraps.
+ *
+ * The bypass hardening is unaffected: exact host equality still rejects
+ * hostname-prefix tricks (`127.0.0.1.evil.com`, `localhost.evil.com`), and
+ * userinfo/fragment/scheme checks are unchanged.
+ *
+ * CLIENT COMPATIBILITY IS A TEST, NOT A CHECKLIST: `redirectUriPolicy.test.ts`
+ * carries a `REAL_CLIENT_CALLBACKS` fixture naming the exact callback shape each
+ * MCP client emits. Tightening this policy such that a named client no longer
+ * registers must be a deliberate edit to that fixture. Prose "verify on staging
+ * before deploy" notes have failed twice: #2193 (the `OAUTH_DCR_REQUIRE_IAT`
+ * gate blocked Claude Desktop's anonymous DCR) and this rule, which blocked
+ * Claude Code's CLI auth for 9 days because "Claude" was assumed to be a single
+ * client with an HTTPS hosted callback.
  */
 
 export type RedirectUriValidation = { ok: true } | { ok: false; reason: string };
 
-// RFC 8252 §7.3: only the literal loopback IP addresses are trusted for HTTP.
-// Node's WHATWG URL parser reports the IPv6 loopback host as the bracketed
-// form `[::1]`; accept the un-bracketed spelling too for defense in depth.
-function isLoopbackIpHost(hostname: string): boolean {
-  return hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1';
+// Loopback hosts trusted for plain HTTP. Matched by EXACT equality — a
+// substring/suffix test would admit `127.0.0.1.evil.com` and `localhost.evil.com`,
+// which are ordinary DNS names that merely start with a loopback label.
+// Node's WHATWG URL parser reports the IPv6 loopback host as the bracketed form
+// `[::1]`; accept the un-bracketed spelling too for defense in depth.
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '[::1]', '::1', 'localhost']);
+
+function isLoopbackHost(hostname: string): boolean {
+  return LOOPBACK_HOSTS.has(hostname);
 }
 
 function validateOne(uri: unknown): RedirectUriValidation {
@@ -64,12 +85,12 @@ function validateOne(uri: unknown): RedirectUriValidation {
   }
 
   if (url.protocol === 'http:') {
-    if (isLoopbackIpHost(url.hostname)) {
+    if (isLoopbackHost(url.hostname)) {
       return { ok: true };
     }
     return {
       ok: false,
-      reason: `http redirect_uri is permitted only for the loopback IPs 127.0.0.1 or [::1] (got host "${url.hostname}")`,
+      reason: `http redirect_uri is permitted only for the loopback hosts 127.0.0.1, [::1] or localhost (got host "${url.hostname}")`,
     };
   }
 

--- a/apps/api/src/routes/oauth.rate-limit.test.ts
+++ b/apps/api/src/routes/oauth.rate-limit.test.ts
@@ -351,25 +351,44 @@ describe('oauthRoutes rate limits', () => {
     expect(body.error).toBe('invalid_redirect_uri');
   });
 
-  it('rejects http://localhost redirect_uri but not the loopback IP (RFC 8252)', async () => {
+  it('accepts every loopback spelling — localhost and the literal IPs alike', async () => {
+    // Was "rejects http://localhost but not the loopback IP (RFC 8252)".
+    // Reversed deliberately: §7.3's IP-literal preference is a SHOULD, and
+    // rejecting the hostname blocked Claude Code's CLI auth, which registers
+    // `http://localhost:<ephemeral>/callback`. Rationale in the
+    // redirectUriPolicy.ts docblock; client shapes in REAL_CLIENT_CALLBACKS
+    // (redirectUriPolicy.test.ts). Non-loopback http is still rejected — see
+    // the `attacker.example` case above.
+    const rateLimiter = vi.fn(async () => ({ allowed: true, remaining: 9, resetAt }));
+
+    // Each passes the pre-handler and falls through to the provider bridge
+    // (mocked to throw → onError yields the 200 sentinel).
+    for (const redirectUri of [
+      'http://localhost:8080/cb',
+      'http://127.0.0.1:49152/cb',
+      'http://[::1]:49152/cb',
+    ]) {
+      const accepted = await (await loadApp(rateLimiter)).request('/oauth/reg', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-forwarded-for': '203.0.113.31' },
+        body: JSON.stringify({ client_name: 'x', redirect_uris: [redirectUri] }),
+      });
+      expect(accepted.status, `expected ${redirectUri} to pass the transport policy`).toBe(200);
+    }
+  });
+
+  it('still rejects a hostname that merely starts with a loopback label', async () => {
+    // Guards the relaxation above: `localhost` is matched by exact equality,
+    // so attacker-controlled DNS names carrying it as a prefix stay rejected.
     const rateLimiter = vi.fn(async () => ({ allowed: true, remaining: 9, resetAt }));
 
     const rejected = await (await loadApp(rateLimiter)).request('/oauth/reg', {
       method: 'POST',
       headers: { 'content-type': 'application/json', 'x-forwarded-for': '203.0.113.31' },
-      body: JSON.stringify({ client_name: 'x', redirect_uris: ['http://localhost:8080/cb'] }),
+      body: JSON.stringify({ client_name: 'x', redirect_uris: ['http://localhost.evil.com/cb'] }),
     });
     expect(rejected.status).toBe(400);
     expect((await rejected.json() as { error: string }).error).toBe('invalid_redirect_uri');
-
-    // The literal loopback IP passes the pre-handler and falls through to the
-    // provider bridge (mocked to throw → onError yields the 200 sentinel).
-    const accepted = await (await loadApp(rateLimiter)).request('/oauth/reg', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-forwarded-for': '203.0.113.31' },
-      body: JSON.stringify({ client_name: 'x', redirect_uris: ['http://127.0.0.1:49152/cb'] }),
-    });
-    expect(accepted.status).toBe(200);
   });
 
   it('applies the redirect-uri transport policy to registration-management updates (MCP-OAUTH-09)', async () => {


### PR DESCRIPTION
The DCR transport policy added in #2377 (MCP-OAUTH-08/09) accepted plain
HTTP only for the literal loopback IPs `127.0.0.1` / `[::1]` and rejected
the `localhost` hostname per RFC 8252 §7.3. That blocks Claude Code's
native SDK auth, which binds a local callback server and registers
`http://localhost:<ephemeral>/callback` — users see only
"needs authentication" with no server-side signal, because registration
is step 4 of the handshake and steps 1-3 keep returning 200.

RFC 8252 §7.3 *recommends* IP literals; it does not require them. The
threat it cites (a doctored hosts/DNS entry resolving `localhost` off
the loopback interface) presupposes an already-compromised client host,
where the authorization code is readable regardless. Stock
`oidc-provider` — our own dependency — already treats all three
spellings as loopback (`LOOPBACKS` in lib/consts/client_attributes.js),
so this policy was stricter than the library it wraps for no gain.

Bypass hardening is unchanged: loopback matching stays exact-equality,
so `127.0.0.1.evil.com` and `localhost.evil.com` are still rejected, as
are userinfo, fragments, private/public HTTP hosts and custom schemes.
Scope is limited to DCR — /authorize does normalized-href equality
against the registered set (oidc-provider client.js:429), so there is no
second transport policy to relax.

## Why this recurred, and what changes about it

This is the second hardening to break MCP client registration. #2193 was
the first (`OAUTH_DCR_REQUIRE_IAT` blocked Claude Desktop's anonymous
DCR). Both times the risk was identified in review — #2377's own rollout
notes said "verify Claude and mcp-remote still register on staging" —
and both times the check failed because it lived as prose aimed at an
incomplete client inventory. "Claude" is not one client: the hosted
connector uses an HTTPS callback, the CLI uses `http://localhost`, and
only the former was considered.

So the inventory is now executable. `REAL_CLIENT_CALLBACKS` in
redirectUriPolicy.test.ts names the exact callback shape each supported
client emits; tightening the policy such that one stops registering
turns that client's own test red, by name:

    × accepts the callback registered by 'claude-code CLI (native SDK auth)'

Dropping support for a client is now a deliberate fixture edit rather
than a silent side effect. Verified non-vacuous by reverting the policy
and confirming 4 targeted failures.

Also corrects a mis-citation: the #2377 docblock credited #2193 as prior
`localhost` breakage. #2193 was the IAT gate — unrelated root cause, so
the extra caution was justified by the wrong incident.

## Verification

- `redirectUriPolicy.test.ts` 29/29; full oauth suites 164/164 across 13 files.
- `tsc --noEmit` clean.
- Integration: added a localhost registration case asserting 201 through
  the real route, alongside the existing mcp-remote 127.0.0.1 case.

## Deploy note

Code-only; no env or migration changes. Per #2193, confirm in prod after
deploy rather than inferring from the tag — `POST /oauth/reg` with a
`http://localhost:<port>/callback` redirect_uri must return 201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)