### PR TITLE
feat(auth): grant-based approver-device registration (#2707)

### DIFF
--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -124,7 +124,12 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
           user: { $ref: '#/components/schemas/User' },
           tokens: { $ref: '#/components/schemas/Tokens' },
           mfaRequired: { type: 'boolean' },
-          tempToken: { type: 'string', description: 'Temporary token for MFA verification' }
+          tempToken: { type: 'string', description: 'Temporary token for MFA verification' },
+          authenticatorRegisterGrantId: {
+            type: 'string',
+            description:
+              'Single-use 300s grant for registering this device as an approver. Only returned on POST /auth/login and /auth/mfa/verify to clients sending X-Breeze-Mobile-Device-Id; never on /auth/register or /auth/refresh.',
+          },
         }
       },
       RegisterRequest: {

--- a/apps/api/src/routes/auth/helpers.registerStepUp.test.ts
+++ b/apps/api/src/routes/auth/helpers.registerStepUp.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { AuthContext } from '../../middleware/auth';
+
+// A8: ENABLE_2FA=false escape hatch for userHasStrongerReauthFactor. Mutable
+// flag so individual tests can flip the flag without a per-test module
+// re-import — mirrors the enable2faState pattern in login.test.ts.
+const enable2faState = vi.hoisted(() => ({ value: true }));
 
 // --- Mocks must be declared before importing the unit under test ---
 // Mirrors the vi.hoisted/vi.mock harness in helpers.mfaStepUp.test.ts, extended
@@ -86,9 +91,26 @@ vi.mock('../../services/corsOrigins', () => ({
 }));
 vi.mock('../../services/tenantStatus', () => ({ assertActiveTenantContext: vi.fn() }));
 
-import { enforceApproverRegisterStepUp, userHasStrongerReauthFactor } from './helpers';
+// A8: real ./schemas module, but ENABLE_2FA is overridden via a live getter so
+// individual tests can toggle it (this file does NOT mock the './helpers'
+// module itself — enforceApproverRegisterStepUp/userHasStrongerReauthFactor
+// run for real, and userHasStrongerReauthFactor reads ENABLE_2FA from here).
+vi.mock('./schemas', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./schemas')>();
+  return {
+    ...actual,
+    get ENABLE_2FA() {
+      return enable2faState.value;
+    },
+  };
+});
 
-// Minimal Hono Context stub: only c.json is exercised by the helpers under test.
+import { enforceApproverRegisterStepUp, userHasStrongerReauthFactor } from './helpers';
+import { createAuditLogAsync } from '../../services/auditService';
+
+// Minimal Hono Context stub. c.json is exercised by every helper under test;
+// c.req.header is additionally needed now that the 403 deny path audits via
+// writeAuthAudit (A4), which reads c.req.header('user-agent') directly.
 function ctx() {
   const json = vi.fn((body: unknown, status?: number) => ({
     __body: body,
@@ -96,7 +118,8 @@ function ctx() {
     json: async () => body,
     status: status ?? 200,
   }));
-  return { json } as any;
+  const req = { header: vi.fn(() => undefined) };
+  return { json, req } as any;
 }
 
 const USER_ID = 'user-1';
@@ -151,10 +174,53 @@ describe('enforceApproverRegisterStepUp', () => {
     expect(await res!.json()).toEqual({ error: 'register_step_up_required' });
   });
 
+  // A4 (review finding): a deny must be audited — this is the only signal an
+  // operator gets that someone tried to register an approver key without a
+  // valid grant. Assert on the real writeAuthAudit -> createAuditLogAsync
+  // call (this file does not mock ./helpers, so enforceApproverRegisterStepUp
+  // is the real implementation).
+  it('audits the 403 deny as a failure event, recording only whether a grantId was present', async () => {
+    grantMocks.validateStepUpGrant.mockResolvedValue(false);
+    epochsMock.getUserEpochs.mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 });
+    const res = await enforceApproverRegisterStepUp(ctx(), authCtx({ sid: 'sid-1' }), 'stale-grant', { consume: false });
+    expect(res?.status).toBe(403);
+    expect(createAuditLogAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'auth.authenticator.register.denied',
+        result: 'failure',
+        details: expect.objectContaining({ reason: 'register_step_up_required', hadGrantId: true }),
+      }),
+    );
+    // NEVER log the grant value itself.
+    const call = vi.mocked(createAuditLogAsync).mock.calls[0]?.[0] as { details?: Record<string, unknown> };
+    expect(JSON.stringify(call?.details ?? {})).not.toContain('stale-grant');
+  });
+
+  it('audits hadGrantId: false when no grant was presented at all', async () => {
+    epochsMock.getUserEpochs.mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 });
+    const res = await enforceApproverRegisterStepUp(ctx(), authCtx({ sid: 'sid-1' }), undefined, { consume: false });
+    expect(res?.status).toBe(403);
+    expect(createAuditLogAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ hadGrantId: false }),
+      }),
+    );
+  });
+
   it('503s when sid or epochs are missing', async () => {
     epochsMock.getUserEpochs.mockResolvedValue(null);
     const res = await enforceApproverRegisterStepUp(ctx(), authCtx({ sid: 'sid-1' }), 'g-1', { consume: false });
     expect(res?.status).toBe(503);
+  });
+
+  // A6 (previously untested branch): epochs present but the session has no
+  // `sid` (e.g. a legacy token minted before sid binding existed).
+  it('503s when epochs are present but auth.token.sid is missing', async () => {
+    epochsMock.getUserEpochs.mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 });
+    const res = await enforceApproverRegisterStepUp(ctx(), authCtx(), 'g-1', { consume: false });
+    expect(res?.status).toBe(503);
+    expect(grantMocks.validateStepUpGrant).not.toHaveBeenCalled();
+    expect(grantMocks.consumeStepUpGrant).not.toHaveBeenCalled();
   });
 
   it('validates without consuming at the options phase', async () => {
@@ -196,5 +262,36 @@ describe('userHasStrongerReauthFactor', () => {
   ])('%o -> %s', async (row, expected) => {
     dbState.selectQueue.push([row]);
     await expect(userHasStrongerReauthFactor('user-1')).resolves.toBe(expected);
+  });
+});
+
+// A8 (review finding): with 2FA disabled cluster-wide, POST /auth/mfa/step-up
+// (the "stronger factor" gate's escape route) is dead, so the
+// password-fallback mint must stay available even for accounts that still
+// hold a TOTP secret or passkey row.
+describe('userHasStrongerReauthFactor — ENABLE_2FA=false escape hatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState.selectQueue = [];
+    selectLimit.mockImplementation(() => Promise.resolve(dbState.selectQueue.shift() ?? []));
+  });
+
+  afterEach(() => {
+    enable2faState.value = true;
+  });
+
+  it('returns false immediately without querying the DB when ENABLE_2FA=false, even for a TOTP-protected user', async () => {
+    enable2faState.value = false;
+    dbState.selectQueue.push([{ mfaEnabled: true, mfaMethod: 'totp', passkeyCount: 0 }]);
+
+    await expect(userHasStrongerReauthFactor('user-1')).resolves.toBe(false);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('still evaluates the real factor state when ENABLE_2FA=true', async () => {
+    enable2faState.value = true;
+    dbState.selectQueue.push([{ mfaEnabled: true, mfaMethod: 'totp', passkeyCount: 0 }]);
+
+    await expect(userHasStrongerReauthFactor('user-1')).resolves.toBe(true);
   });
 });

--- a/apps/api/src/routes/auth/helpers.registerStepUp.test.ts
+++ b/apps/api/src/routes/auth/helpers.registerStepUp.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { AuthContext } from '../../middleware/auth';
+
+// --- Mocks must be declared before importing the unit under test ---
+// Mirrors the vi.hoisted/vi.mock harness in helpers.mfaStepUp.test.ts, extended
+// with getUserEpochs (../../services) and mfaStepUpGrant (validateStepUpGrant /
+// consumeStepUpGrant) since enforceApproverRegisterStepUp exercises both.
+const {
+  selectLimit,
+  db,
+  getRedis,
+  rateLimiter,
+  consumeMFAToken,
+  decryptMfaTotpSecret,
+  getUserEpochs,
+  validateStepUpGrant,
+  consumeStepUpGrant,
+} = vi.hoisted(() => {
+  const selectLimit = vi.fn();
+  const db = {
+    // db.select(...).from(...).where(...).limit(...) chain returning the mocked user row.
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: selectLimit,
+        })),
+      })),
+    })),
+  };
+  return {
+    selectLimit,
+    db,
+    getRedis: vi.fn(),
+    rateLimiter: vi.fn(),
+    consumeMFAToken: vi.fn(),
+    decryptMfaTotpSecret: vi.fn(),
+    getUserEpochs: vi.fn(),
+    validateStepUpGrant: vi.fn(),
+    consumeStepUpGrant: vi.fn(),
+  };
+});
+
+vi.mock('../../db', () => ({
+  db,
+  withSystemDbAccessContext: undefined,
+}));
+
+vi.mock('../../db/schema', () => ({
+  users: { id: 'id', mfaEnabled: 'mfa_enabled', mfaSecret: 'mfa_secret', mfaMethod: 'mfa_method' },
+  partnerUsers: {},
+  organizationUsers: {},
+  organizations: {},
+}));
+
+vi.mock('../../services', () => ({
+  verifyToken: vi.fn(),
+  isUserTokenRevoked: vi.fn(),
+  revokeRefreshTokenJti: vi.fn(),
+  getTrustedClientIp: vi.fn(() => 'unknown'),
+  getRedis,
+  rateLimiter,
+  verifyPassword: vi.fn(),
+  getUserEpochs,
+}));
+
+vi.mock('../../services/mfa', () => ({
+  consumeMFAToken,
+}));
+
+vi.mock('../../services/mfaSecretCrypto', () => ({
+  decryptMfaTotpSecret,
+  decryptMfaTotpSecretForMigration: vi.fn(),
+  encryptMfaTotpSecret: vi.fn(),
+}));
+
+vi.mock('../../services/mfaStepUpGrant', () => ({
+  validateStepUpGrant,
+  consumeStepUpGrant,
+}));
+
+vi.mock('../../services/auditService', () => ({ createAuditLogAsync: vi.fn() }));
+vi.mock('../../services/anomalyMetrics', () => ({ recordFailedLogin: vi.fn() }));
+vi.mock('../../services/corsOrigins', () => ({
+  DEFAULT_ALLOWED_ORIGINS: [],
+  shouldIncludeDefaultOrigins: vi.fn(() => false),
+}));
+vi.mock('../../services/tenantStatus', () => ({ assertActiveTenantContext: vi.fn() }));
+
+import { enforceApproverRegisterStepUp, userHasStrongerReauthFactor } from './helpers';
+
+// Minimal Hono Context stub: only c.json is exercised by the helpers under test.
+function ctx() {
+  const json = vi.fn((body: unknown, status?: number) => ({
+    __body: body,
+    __status: status ?? 200,
+    json: async () => body,
+    status: status ?? 200,
+  }));
+  return { json } as any;
+}
+
+const USER_ID = 'user-1';
+
+// Minimal AuthContext stub: only auth.user.id and auth.token.sid are read by
+// enforceApproverRegisterStepUp. The remaining required fields are stubbed
+// with values that are never exercised by the helper under test.
+function authCtx(tokenOverrides: { sid?: string } = {}): AuthContext {
+  return {
+    user: { id: USER_ID, email: 'user@example.com', name: 'Test User', isPlatformAdmin: false },
+    token: {
+      sub: USER_ID,
+      email: 'user@example.com',
+      roleId: null,
+      orgId: null,
+      partnerId: null,
+      scope: 'organization',
+      type: 'access',
+      mfa: false,
+      sid: tokenOverrides.sid,
+    },
+    partnerId: null,
+    orgId: null,
+    scope: 'organization',
+    accessibleOrgIds: null,
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+  } as unknown as AuthContext;
+}
+
+// Queue-based stand-in for sequential db.select(...).limit() resolutions, used
+// by the userHasStrongerReauthFactor it.each cases (each case pushes exactly
+// one row's worth of results before invoking the helper once).
+const dbState = { selectQueue: [] as unknown[][] };
+
+const grantMocks = { validateStepUpGrant, consumeStepUpGrant };
+const epochsMock = { getUserEpochs };
+
+describe('enforceApproverRegisterStepUp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState.selectQueue = [];
+    selectLimit.mockImplementation(() => Promise.resolve(dbState.selectQueue.shift() ?? []));
+  });
+
+  it('403s a NON-MFA-protected user with no grant (no bypass — the spec pin)', async () => {
+    // arrange: userIsMfaProtected-style state irrelevant — helper must not consult it.
+    grantMocks.validateStepUpGrant.mockResolvedValue(false);
+    epochsMock.getUserEpochs.mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 });
+    const res = await enforceApproverRegisterStepUp(ctx(), authCtx({ sid: 'sid-1' }), undefined, { consume: false });
+    expect(res?.status).toBe(403);
+    expect(await res!.json()).toEqual({ error: 'register_step_up_required' });
+  });
+
+  it('503s when sid or epochs are missing', async () => {
+    epochsMock.getUserEpochs.mockResolvedValue(null);
+    const res = await enforceApproverRegisterStepUp(ctx(), authCtx({ sid: 'sid-1' }), 'g-1', { consume: false });
+    expect(res?.status).toBe(503);
+  });
+
+  it('validates without consuming at the options phase', async () => {
+    epochsMock.getUserEpochs.mockResolvedValue({ authEpoch: 1, mfaEpoch: 2 });
+    grantMocks.validateStepUpGrant.mockResolvedValue(true);
+    const res = await enforceApproverRegisterStepUp(ctx(), authCtx({ sid: 'sid-1' }), 'g-1', { consume: false });
+    expect(res).toBeNull();
+    expect(grantMocks.validateStepUpGrant).toHaveBeenCalledWith('g-1', {
+      userId: 'user-1',
+      operation: 'register_approver_device',
+      authEpoch: 1,
+      mfaEpoch: 2,
+      sid: 'sid-1',
+    });
+    expect(grantMocks.consumeStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('consumes at the terminal phase', async () => {
+    epochsMock.getUserEpochs.mockResolvedValue({ authEpoch: 1, mfaEpoch: 2 });
+    grantMocks.consumeStepUpGrant.mockResolvedValue(true);
+    const res = await enforceApproverRegisterStepUp(ctx(), authCtx({ sid: 'sid-1' }), 'g-1', { consume: true });
+    expect(res).toBeNull();
+    expect(grantMocks.consumeStepUpGrant).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('userHasStrongerReauthFactor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState.selectQueue = [];
+    selectLimit.mockImplementation(() => Promise.resolve(dbState.selectQueue.shift() ?? []));
+  });
+
+  it.each([
+    [{ mfaEnabled: true, mfaMethod: 'totp', passkeyCount: 0 }, true],
+    [{ mfaEnabled: true, mfaMethod: 'sms', passkeyCount: 0 }, false], // SMS keeps password path
+    [{ mfaEnabled: false, mfaMethod: null, passkeyCount: 1 }, true],
+    [{ mfaEnabled: false, mfaMethod: null, passkeyCount: 0 }, false],
+  ])('%o -> %s', async (row, expected) => {
+    dbState.selectQueue.push([row]);
+    await expect(userHasStrongerReauthFactor('user-1')).resolves.toBe(expected);
+  });
+});

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -312,6 +312,66 @@ export async function enforceExistingFactorStepUp(
   return null;
 }
 
+/**
+ * True when the account holds a re-auth factor STRONGER than a password that
+ * the browser register UI can actually exercise: TOTP MFA or an active
+ * passkey. Deliberately excludes SMS (no authenticated step-up SMS sender
+ * exists; SMS-method users use the password path — see the #2707 spec).
+ * Gates POST /authenticator/register-grant: password re-auth is refused when
+ * this returns true, keeping the server tiering identical to the UI tiering.
+ */
+export async function userHasStrongerReauthFactor(userId: string): Promise<boolean> {
+  const [row] = await runWithSystemDbAccess(() =>
+    db
+      .select({
+        mfaEnabled: users.mfaEnabled,
+        mfaMethod: users.mfaMethod,
+        passkeyCount: sql<number>`(SELECT COUNT(*)::int FROM user_passkeys WHERE user_id = ${userId} AND disabled_at IS NULL)`,
+      })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+  );
+  return (row?.mfaEnabled === true && row?.mfaMethod === 'totp') || Number(row?.passkeyCount ?? 0) > 0;
+}
+
+/**
+ * #2707: enforce a register_approver_device grant on the approver-device
+ * registration routes. Same two-phase validate/consume contract as
+ * `enforceExistingFactorStepUp` above, with one CRITICAL difference: NO
+ * `userIsMfaProtected` bypass. Registration is deferred-proof-of-possession —
+ * a stolen bearer token must never be able to register an approver key, so
+ * the grant is required for EVERY account, MFA-protected or not.
+ */
+export async function enforceApproverRegisterStepUp(
+  c: Context,
+  auth: AuthContext,
+  grantId: string | undefined,
+  opts: { consume: boolean },
+): Promise<Response | null> {
+  const epochs = await getUserEpochs(auth.user.id);
+  if (!epochs || !auth.token.sid) {
+    return c.json({ error: 'Service temporarily unavailable' }, 503);
+  }
+
+  const bind = {
+    userId: auth.user.id,
+    operation: 'register_approver_device' as const,
+    authEpoch: epochs.authEpoch,
+    mfaEpoch: epochs.mfaEpoch,
+    sid: auth.token.sid,
+  };
+
+  const ok = grantId
+    ? (opts.consume ? await consumeStepUpGrant(grantId, bind) : await validateStepUpGrant(grantId, bind))
+    : false;
+
+  if (!ok) {
+    return c.json({ error: 'register_step_up_required' }, 403);
+  }
+  return null;
+}
+
 export function isSecureCookieEnvironment(): boolean {
   return process.env.NODE_ENV === 'production';
 }

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -16,7 +16,8 @@ import { getImmediatePeerIpOrUndefined, trustsForwardedHeadersFrom } from '../..
 import { createAuditLogAsync } from '../../services/auditService';
 import { recordFailedLogin } from '../../services/anomalyMetrics';
 import { consumeMFAToken } from '../../services/mfa';
-import { validateStepUpGrant, consumeStepUpGrant } from '../../services/mfaStepUpGrant';
+import { mintStepUpGrant, validateStepUpGrant, consumeStepUpGrant } from '../../services/mfaStepUpGrant';
+import { readMobileDeviceId } from '../../services/mobileDeviceBinding';
 import type { AuthContext } from '../../middleware/auth';
 import type { RequestLike } from '../../services/auditEvents';
 import { createHash, randomBytes, timingSafeEqual } from 'crypto';
@@ -370,6 +371,37 @@ export async function enforceApproverRegisterStepUp(
     return c.json({ error: 'register_step_up_required' }, 403);
   }
   return null;
+}
+
+/**
+ * #2707: best-effort login-time mint of a register_approver_device grant,
+ * returned to the MOBILE client as `authenticatorRegisterGrantId` so the app
+ * can register its approver key promptlessly right after login.
+ *
+ * Gated on the mobile device-id header: web logins hit the same endpoints and
+ * must NEVER receive a live register grant (300s XSS-readable window for a
+ * grant the page can't use). Returns null on any failure — login must not
+ * break because Redis is down; the phone simply registers on a later login.
+ *
+ * NEVER call this from the /auth/refresh handler: a stolen refresh token
+ * would then mint a fresh register grant on every rotation, defeating the
+ * stolen-session protection the grant exists to provide.
+ */
+export async function mintLoginRegisterGrant(
+  c: Context,
+  userId: string,
+  sid: string
+): Promise<string | null> {
+  if (!readMobileDeviceId(c)) return null;
+  const epochs = await getUserEpochs(userId);
+  if (!epochs) return null;
+  return mintStepUpGrant({
+    userId,
+    operation: 'register_approver_device',
+    authEpoch: epochs.authEpoch,
+    mfaEpoch: epochs.mfaEpoch,
+    sid,
+  });
 }
 
 export function isSecureCookieEnvironment(): boolean {

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -37,7 +37,8 @@ import {
   CSRF_HEADER_NAME,
   CSRF_COOKIE_NAME,
   CSRF_COOKIE_PATH,
-  ANONYMOUS_ACTOR_ID
+  ANONYMOUS_ACTOR_ID,
+  ENABLE_2FA
 } from './schemas';
 
 const { db } = dbModule;
@@ -322,6 +323,18 @@ export async function enforceExistingFactorStepUp(
  * this returns true, keeping the server tiering identical to the UI tiering.
  */
 export async function userHasStrongerReauthFactor(userId: string): Promise<boolean> {
+  // #2707 review: with 2FA disabled cluster-wide (ENABLE_2FA=false), the
+  // step-up endpoint (POST /auth/mfa/step-up) that would normally satisfy a
+  // "stronger factor" is dead — every requireMfa() gate in the API is
+  // disabled along with it (see the ENABLE_2FA warning in ./schemas). If this
+  // still reported true for a user with a leftover TOTP secret or passkey
+  // row, the password-fallback mint (POST /authenticator/register-grant)
+  // would refuse them with no route left to satisfy the alternative,
+  // permanently locking that account out of approver-device registration.
+  // Fail open on the gate (not the grant itself — the grant is still
+  // required) by always reporting no stronger factor when 2FA is off.
+  if (!ENABLE_2FA) return false;
+
   const [row] = await runWithSystemDbAccess(() =>
     db
       .select({
@@ -368,6 +381,20 @@ export async function enforceApproverRegisterStepUp(
     : false;
 
   if (!ok) {
+    // Registration is deferred-proof-of-possession with no other write-time
+    // check — a denial here is the only signal an operator gets that someone
+    // tried to register an approver key without a valid grant (stolen
+    // token, replayed/expired grant, etc). NEVER include the grant value —
+    // only whether one was presented.
+    writeAuthAudit(c, {
+      orgId: auth.orgId ?? undefined,
+      action: 'auth.authenticator.register.denied',
+      result: 'failure',
+      reason: 'register_step_up_required',
+      userId: auth.user.id,
+      email: auth.user.email,
+      details: { hadGrantId: Boolean(grantId) },
+    });
     return c.json({ error: 'register_step_up_required' }, 403);
   }
   return null;
@@ -379,9 +406,20 @@ export async function enforceApproverRegisterStepUp(
  * can register its approver key promptlessly right after login.
  *
  * Gated on the mobile device-id header: web logins hit the same endpoints and
- * must NEVER receive a live register grant (300s XSS-readable window for a
- * grant the page can't use). Returns null on any failure — login must not
- * break because Redis is down; the phone simply registers on a later login.
+ * must NEVER receive a live register grant — an XSS on the web app COULD
+ * redeem it directly against `POST /authenticator/devices` (arbitrary SPKI,
+ * no further ceremony) to register an attacker-controlled approver key. Only
+ * a genuine mobile client (proven by the device-id header) is ever handed
+ * one.
+ *
+ * NEVER throws: every failure mode (missing epochs, Redis down, or any other
+ * unexpected rejection from a collaborator) is caught here and mapped to
+ * null, so a mint failure can never 500 an otherwise-successful login — the
+ * phone simply registers on a later login. When the mobile header IS
+ * present and the mint declines for any reason, an operator-visible error is
+ * logged (the grant value itself is NEVER logged) so a systemic failure
+ * (e.g. Redis down) is observable instead of silently degrading every mobile
+ * login.
  *
  * NEVER call this from the /auth/refresh handler: a stolen refresh token
  * would then mint a fresh register grant on every rotation, defeating the
@@ -393,15 +431,27 @@ export async function mintLoginRegisterGrant(
   sid: string
 ): Promise<string | null> {
   if (!readMobileDeviceId(c)) return null;
-  const epochs = await getUserEpochs(userId);
-  if (!epochs) return null;
-  return mintStepUpGrant({
-    userId,
-    operation: 'register_approver_device',
-    authEpoch: epochs.authEpoch,
-    mfaEpoch: epochs.mfaEpoch,
-    sid,
-  });
+  try {
+    const epochs = await getUserEpochs(userId);
+    if (!epochs) {
+      console.error(`[auth] mintLoginRegisterGrant: epochs unavailable for user ${userId}; login proceeds without a grant`);
+      return null;
+    }
+    const grantId = await mintStepUpGrant({
+      userId,
+      operation: 'register_approver_device',
+      authEpoch: epochs.authEpoch,
+      mfaEpoch: epochs.mfaEpoch,
+      sid,
+    });
+    if (!grantId) {
+      console.error(`[auth] mintLoginRegisterGrant: mint declined (Redis unavailable?) for user ${userId}; login proceeds without a grant`);
+    }
+    return grantId;
+  } catch (err) {
+    console.error(`[auth] mintLoginRegisterGrant: unexpected failure minting register grant for user ${userId}; login proceeds without a grant:`, err);
+    return null;
+  }
 }
 
 export function isSecureCookieEnvironment(): boolean {

--- a/apps/api/src/routes/auth/login.test.ts
+++ b/apps/api/src/routes/auth/login.test.ts
@@ -1318,6 +1318,31 @@ describe('authenticatorRegisterGrantId login mint (#2707)', () => {
     expect(body.tokens).toBeDefined();
   });
 
+  // A1 (review finding): mintStepUpGrant REJECTING (not just resolving null)
+  // must not propagate — mintLoginRegisterGrant's doc comment promises
+  // "NEVER throws", but pre-fix there was no try/catch around the mint call,
+  // so a Redis error thrown mid-await would 500 an otherwise-successful,
+  // already-authenticated login. Login must degrade to "no grant", not fail.
+  it('mintStepUpGrant REJECTING still returns 200 with tokens and no grant field', async () => {
+    grantMocks.mintStepUpGrant.mockRejectedValue(new Error('redis connection reset'));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const res = await successfulLoginRequest({ headers: { 'X-Breeze-Mobile-Device-Id': 'install-1' } });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).not.toHaveProperty('authenticatorRegisterGrantId');
+    expect(body.tokens).toBeDefined();
+    // A2: an operator-visible error must be logged for a mobile-header mint
+    // decline, but it must NEVER include the grant value (there is none here).
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mock.calls.forEach((call) => {
+      expect(String(call[0])).not.toContain('login-grant-1');
+    });
+
+    errSpy.mockRestore();
+  });
+
   it('POST /auth/refresh NEVER includes the field, even with the mobile header', async () => {
     grantMocks.mintStepUpGrant.mockResolvedValue('should-never-appear');
 

--- a/apps/api/src/routes/auth/login.test.ts
+++ b/apps/api/src/routes/auth/login.test.ts
@@ -93,8 +93,28 @@ vi.mock('../../services/tenantStatus', () => ({
 }));
 
 vi.mock('../../services/mobileDeviceBinding', () => ({
-  readMobileDeviceId: vi.fn(() => null),
+  // Reads the real request header so tests can drive mobile-vs-web behaviour
+  // (#2707 authenticatorRegisterGrantId gate) just by setting/omitting
+  // 'X-Breeze-Mobile-Device-Id' on the request — no per-test mock wiring.
+  readMobileDeviceId: vi.fn((c: { req: { header: (name: string) => string | undefined } }) => {
+    const raw = c.req.header('x-breeze-mobile-device-id');
+    const trimmed = raw?.trim();
+    return trimmed && trimmed.length > 0 ? trimmed : null;
+  }),
   carryForwardBinding: vi.fn(() => undefined),
+}));
+
+// #2707: mintLoginRegisterGrant (the REAL implementation, kept unmocked in
+// the './helpers' factory below) calls this to mint the mobile approver
+// register grant. Mocked here so tests control it without touching Redis.
+const grantMocks = vi.hoisted(() => ({
+  mintStepUpGrant: vi.fn(async () => null as string | null),
+}));
+
+vi.mock('../../services/mfaStepUpGrant', () => ({
+  mintStepUpGrant: grantMocks.mintStepUpGrant,
+  validateStepUpGrant: vi.fn(),
+  consumeStepUpGrant: vi.fn(),
 }));
 
 vi.mock('../../middleware/auth', () => ({
@@ -118,7 +138,14 @@ vi.mock('../../middleware/auth', () => ({
 // real helper's SINGLE internal emission, so the "called exactly once"
 // assertions in the inactive-tenant/account tests will fail if anyone
 // reintroduces a redundant recordFailedLogin() in login.ts (#719 regression).
-vi.mock('./helpers', () => ({
+// #2707: keep this as an importOriginal-based partial mock (not a bare
+// object) so the REAL mintLoginRegisterGrant runs. It is the unit under test
+// for the authenticatorRegisterGrantId describe block below — it exercises
+// the real readMobileDeviceId/getUserEpochs/mintStepUpGrant wiring, all of
+// which are mocked at their own module boundaries above/below. Every other
+// export here is still an explicit vi.fn() override, unchanged from before.
+vi.mock('./helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./helpers')>()),
   getClientIP: vi.fn(() => '203.0.113.10'),
   getClientRateLimitKey: vi.fn(() => 'test-client'),
   setRefreshTokenCookie: vi.fn(),
@@ -251,10 +278,10 @@ function updateChain() {
   };
 }
 
-async function postLogin(body: { email: string; password: string }) {
+async function postLogin(body: { email: string; password: string }, extraHeaders: Record<string, string> = {}) {
   return loginRoutes.request('/login', {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...extraHeaders },
     body: JSON.stringify(body),
   });
 }
@@ -1186,5 +1213,119 @@ describe('POST /login — SR2-23: a locked account is publicly indistinguishable
 
     expect(res.status).toBe(200);
     expect(createTokenPair).toHaveBeenCalled();
+  });
+});
+
+// #2707: authenticatorRegisterGrantId — login-time mint of a
+// register_approver_device grant for the mobile app, mobile-only, and never
+// on refresh. mintLoginRegisterGrant itself runs FOR REAL here (see the
+// './helpers' mock above); only its two collaborators outside this file
+// (readMobileDeviceId, mintStepUpGrant) are mocked, so these tests exercise
+// the real gate + wiring in login.ts/helpers.ts, not a re-description of it.
+describe('authenticatorRegisterGrantId login mint (#2707)', () => {
+  async function successfulLoginRequest(opts: { headers?: Record<string, string> } = {}) {
+    vi.mocked(enforceIpAllowlist).mockResolvedValue({ decision: 'allow' });
+    vi.mocked(db.select).mockReturnValue(selectChain([{
+      id: 'user-1',
+      email: 'admin@msp.com',
+      name: 'Admin User',
+      passwordHash: 'password-hash',
+      status: 'active',
+      mfaEnabled: false,
+      mfaSecret: null,
+      mfaMethod: null,
+      phoneNumber: null,
+      avatarUrl: null,
+    }]) as any);
+    vi.mocked(db.update).mockReturnValue(updateChain() as any);
+    vi.mocked(getUserEpochs).mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 });
+    return postLogin({ email: 'admin@msp.com', password: 'correct-horse' }, opts.headers);
+  }
+
+  async function successfulRefreshRequest(opts: { headers?: Record<string, string> } = {}) {
+    vi.mocked(resolveRefreshToken).mockReturnValue('refresh-token');
+    vi.mocked(validateCookieCsrfRequest).mockReturnValue(null);
+    vi.mocked(db.select).mockReturnValue(selectChain([{
+      id: 'user-1',
+      email: 'admin@msp.com',
+      status: 'active',
+      authEpoch: 1,
+      mfaEpoch: 1,
+    }]) as any);
+    vi.mocked(isRefreshTokenJtiRevoked).mockResolvedValue(false);
+    vi.mocked(revokeRefreshTokenJti).mockResolvedValue(true);
+    vi.mocked(resolveCurrentUserTokenContext).mockResolvedValue({
+      roleId: 'role-1',
+      partnerId: 'partner-1',
+      orgId: null,
+      scope: 'partner',
+    } as any);
+    vi.mocked(getRefreshFamily).mockResolvedValue({
+      revokedAt: null,
+      absoluteExpiresAt: new Date(Date.now() + 86_400_000),
+    });
+    vi.mocked(verifyToken).mockResolvedValue({
+      sub: 'user-1',
+      email: 'admin@msp.com',
+      type: 'refresh',
+      jti: 'jti-current',
+      fam: 'family-42',
+      aep: 1,
+      mep: 1,
+    } as any);
+    return loginRoutes.request('/refresh', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...(opts.headers ?? {}) },
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = 'test';
+    process.env.E2E_MODE = 'true';
+    grantMocks.mintStepUpGrant.mockResolvedValue(null);
+  });
+
+  it('successful login WITH the mobile device-id header includes the grant', async () => {
+    grantMocks.mintStepUpGrant.mockResolvedValue('login-grant-1');
+
+    const res = await successfulLoginRequest({ headers: { 'X-Breeze-Mobile-Device-Id': 'install-1' } });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).authenticatorRegisterGrantId).toBe('login-grant-1');
+    expect(grantMocks.mintStepUpGrant).toHaveBeenCalledWith(
+      expect.objectContaining({ operation: 'register_approver_device' })
+    );
+  });
+
+  it('successful login WITHOUT the header omits the field entirely (web never gets a grant)', async () => {
+    const res = await successfulLoginRequest();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).not.toHaveProperty('authenticatorRegisterGrantId');
+    expect(grantMocks.mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('a mint failure (Redis down) still returns tokens', async () => {
+    grantMocks.mintStepUpGrant.mockResolvedValue(null);
+
+    const res = await successfulLoginRequest({ headers: { 'X-Breeze-Mobile-Device-Id': 'install-1' } });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).not.toHaveProperty('authenticatorRegisterGrantId');
+    expect(body.tokens).toBeDefined();
+  });
+
+  it('POST /auth/refresh NEVER includes the field, even with the mobile header', async () => {
+    grantMocks.mintStepUpGrant.mockResolvedValue('should-never-appear');
+
+    const res = await successfulRefreshRequest({ headers: { 'X-Breeze-Mobile-Device-Id': 'install-1' } });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).not.toHaveProperty('authenticatorRegisterGrantId');
+    expect(grantMocks.mintStepUpGrant).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -55,7 +55,8 @@ import {
   auditLogin,
   userRequiresSetup,
   userHasUsablePasskey,
-  authResponseFloorPromise
+  authResponseFloorPromise,
+  mintLoginRegisterGrant
 } from './helpers';
 import { assertPasswordAuthAllowedBySso, SsoPasswordAuthRequiredError } from './ssoPolicy';
 import { readMobileDeviceId, carryForwardBinding } from '../../services/mobileDeviceBinding';
@@ -611,6 +612,13 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
   // shape. The floor is calibrated above the slowest legitimate denial
   // path so a successful login is no faster than any other outcome.
   await floorPromise;
+
+  // #2707: mobile-only best-effort mint of a register_approver_device grant,
+  // so the app can register its approver key promptlessly right after login.
+  // Gated inside mintLoginRegisterGrant on the mobile device-id header — web
+  // logins never get a value here.
+  const authenticatorRegisterGrantId = await mintLoginRegisterGrant(c, user.id, familyId);
+
   return c.json({
     user: {
       id: user.id,
@@ -627,7 +635,8 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
     mfaRequired: false,
     requiresSetup,
     mfaEnrollmentRequired,
-    enrollUrl: mfaEnrollmentRequired ? '/auth/mfa/setup' : undefined
+    enrollUrl: mfaEnrollmentRequired ? '/auth/mfa/setup' : undefined,
+    ...(authenticatorRegisterGrantId ? { authenticatorRegisterGrantId } : {})
   });
 });
 

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -712,8 +712,9 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithPa
 
 // SR2-20: existing-factor step-up. Proves an EXISTING MFA factor (TOTP, SMS,
 // or passkey — a discriminated union on `method` so a passkey-only user is
-// never locked out) and mints a short-lived single-use grant, which the
-// caller then presents as `stepUpGrantId` to a factor-ADDITION endpoint
+// never locked out) and mints a short-lived single-use grant scoped to the
+// requested operation (defaulting to add_factor; #2707 adds register_approver_device),
+// which the caller then presents as `stepUpGrantId` to a factor-ADDITION endpoint
 // (`/mfa/enable`, setup-confirm, `/mfa/sms/enable`, `/passkeys/register/*`)
 // on an already-protected account. The passkey branch expects the client to
 // have already called `POST /auth/mfa/step-up/options` (passkeys.ts) to get
@@ -795,7 +796,7 @@ mfaRoutes.post('/mfa/step-up', authMiddleware, zValidator('json', mfaStepUpSchem
   }
   const grantId = await mintStepUpGrant({
     userId: auth.user.id,
-    operation: 'add_factor',
+    operation: body.operation,
     authEpoch: epochs.authEpoch,
     mfaEpoch: epochs.mfaEpoch,
     sid: auth.token.sid
@@ -810,7 +811,7 @@ mfaRoutes.post('/mfa/step-up', authMiddleware, zValidator('json', mfaStepUpSchem
     result: 'success',
     userId: auth.user.id,
     email: auth.user.email,
-    details: { method: body.method, operation: 'add_factor' }
+    details: { method: body.method, operation: body.operation }
   });
 
   return c.json({ stepUpGrantId: grantId });

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -46,7 +46,8 @@ import {
   requireCurrentPasswordStepUp,
   enforceExistingFactorStepUp,
   parsePendingMfa,
-  evaluatePendingMfa
+  evaluatePendingMfa,
+  mintLoginRegisterGrant
 } from './helpers';
 
 const { db, withSystemDbAccessContext, runOutsideDbContext } = dbModule;
@@ -361,6 +362,10 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
 
     const requiresSetup = userRequiresSetup(user);
 
+    // #2707: mobile-only best-effort mint of a register_approver_device
+    // grant — same rationale as the /auth/login no-MFA success response.
+    const authenticatorRegisterGrantId = await mintLoginRegisterGrant(c, user.id, mfaFamilyId);
+
     return c.json({
       user: {
         id: user.id,
@@ -375,7 +380,8 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
       },
       tokens: toPublicTokens(tokens),
       mfaRequired: false,
-      requiresSetup
+      requiresSetup,
+      ...(authenticatorRegisterGrantId ? { authenticatorRegisterGrantId } : {})
     });
   }
 

--- a/apps/api/src/routes/auth/schemas.test.ts
+++ b/apps/api/src/routes/auth/schemas.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mfaVerifySchema } from './schemas';
+import { mfaVerifySchema, mfaStepUpSchema } from './schemas';
 
 // SR2-09: mfaVerifySchema must accept a 6-digit TOTP/SMS code OR the
 // `XXXX-XXXX` recovery-code form, and the `method` enum must include
@@ -56,5 +56,29 @@ describe('auth feature flag defaults', () => {
     const { ENABLE_REGISTRATION } = await import('./schemas');
 
     expect(ENABLE_REGISTRATION).toBe(true);
+  });
+});
+
+describe('mfaStepUpSchema operation field', () => {
+  it('defaults operation to add_factor on every branch', () => {
+    const totp = mfaStepUpSchema.parse({ method: 'totp', code: '123456' });
+    expect(totp.operation).toBe('add_factor');
+    const passkey = mfaStepUpSchema.parse({ method: 'passkey', credential: { id: 'cred-1' } });
+    expect(passkey.operation).toBe('add_factor');
+  });
+
+  it('accepts register_approver_device', () => {
+    const parsed = mfaStepUpSchema.parse({
+      method: 'totp',
+      code: '123456',
+      operation: 'register_approver_device',
+    });
+    expect(parsed.operation).toBe('register_approver_device');
+  });
+
+  it('rejects unknown operations', () => {
+    expect(() =>
+      mfaStepUpSchema.parse({ method: 'totp', code: '123456', operation: 'admin_takeover' })
+    ).toThrow();
   });
 });

--- a/apps/api/src/routes/auth/schemas.ts
+++ b/apps/api/src/routes/auth/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { envFlag } from '../../utils/envFlag';
+import type { StepUpOperation } from '../../services/mfaStepUpGrant';
 
 // ============================================
 // Feature flags
@@ -121,8 +122,16 @@ const stepUpAssertion = z.object({ id: z.string().min(1) }).passthrough();
 // Which grant the proven factor mints. Defaults to the original add_factor so
 // existing clients are untouched; register_approver_device gates the
 // /authenticator register routes (#2707).
+//
+// `satisfies readonly StepUpOperation[]` compile-time-links this literal
+// array to the service's StepUpOperation union — if the two ever diverge
+// (a new operation added to one but not the other), this fails typecheck
+// instead of silently letting a grant type this schema doesn't know about
+// slip through validation, or letting a value this schema accepts fail to
+// match any real operation.
+const STEP_UP_OPERATIONS = ['add_factor', 'register_approver_device'] as const satisfies readonly StepUpOperation[];
 const stepUpOperation = z
-  .enum(['add_factor', 'register_approver_device'])
+  .enum(STEP_UP_OPERATIONS)
   .default('add_factor');
 export const mfaStepUpSchema = z.discriminatedUnion('method', [
   z.object({ method: z.literal('totp'), code: stepUpSixDigit, operation: stepUpOperation }),

--- a/apps/api/src/routes/auth/schemas.ts
+++ b/apps/api/src/routes/auth/schemas.ts
@@ -118,10 +118,16 @@ export const mfaEnableSchema = z.object({
 // avoid a schemas.ts <-> passkeys.ts import cycle.
 const stepUpSixDigit = z.string().refine((v) => /^\d{6}$/.test(v.trim()), { message: 'Invalid code' });
 const stepUpAssertion = z.object({ id: z.string().min(1) }).passthrough();
+// Which grant the proven factor mints. Defaults to the original add_factor so
+// existing clients are untouched; register_approver_device gates the
+// /authenticator register routes (#2707).
+const stepUpOperation = z
+  .enum(['add_factor', 'register_approver_device'])
+  .default('add_factor');
 export const mfaStepUpSchema = z.discriminatedUnion('method', [
-  z.object({ method: z.literal('totp'), code: stepUpSixDigit }),
-  z.object({ method: z.literal('sms'), code: stepUpSixDigit }),
-  z.object({ method: z.literal('passkey'), credential: stepUpAssertion }),
+  z.object({ method: z.literal('totp'), code: stepUpSixDigit, operation: stepUpOperation }),
+  z.object({ method: z.literal('sms'), code: stepUpSixDigit, operation: stepUpOperation }),
+  z.object({ method: z.literal('passkey'), credential: stepUpAssertion, operation: stepUpOperation }),
 ]);
 
 export const acceptInviteSchema = z.object({

--- a/apps/api/src/routes/authenticator.test.ts
+++ b/apps/api/src/routes/authenticator.test.ts
@@ -523,6 +523,25 @@ describe('approver device routes', () => {
     expect(dbState.insertValues).toHaveLength(0);
   });
 
+  // A3 (review finding): the payload must be schema-validated BEFORE the
+  // single-use grant is consumed, so a malformed request never burns a
+  // caller's valid grant. A valid grant is supplied here to isolate the
+  // ordering — if consume-then-parse regresses, enforceApproverRegisterStepUp
+  // would be called (and "consumed") even though the request 400s.
+  it('a malformed publicKey with a valid grant 400s WITHOUT ever consuming the grant', async () => {
+    helperMocks.enforceApproverRegisterStepUp.mockResolvedValue(null);
+
+    const res = await postJson('/devices', {
+      registerGrantId: 'g-mobile-5',
+      publicKey: 12345, // not a string — fails mobileHwKeyRegisterSchema
+      label: 'iPhone',
+    });
+
+    expect(res.status).toBe(400);
+    expect(dbState.insertValues).toHaveLength(0);
+    expect(helperMocks.enforceApproverRegisterStepUp).not.toHaveBeenCalled();
+  });
+
   describe('POST /register-grant', () => {
     it('mints a grant after password step-up when no stronger factor exists', async () => {
       helperMocks.userHasStrongerReauthFactor.mockResolvedValue(false);
@@ -544,6 +563,15 @@ describe('approver device routes', () => {
       expect(res.status).toBe(403);
       expect(await res.json()).toEqual({ error: 'stronger_factor_required' });
       expect(helperMocks.requireCurrentPasswordStepUp).not.toHaveBeenCalled();
+      // A4: the deny must be audited (failure result, reason on the details).
+      expect(helperMocks.writeAuthAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'auth.authenticator.register_grant.denied',
+          result: 'failure',
+          reason: 'stronger_factor_required',
+        }),
+      );
     });
 
     it('propagates password step-up failures (401/429/503)', async () => {
@@ -561,6 +589,38 @@ describe('approver device routes', () => {
       epochsMock.getUserEpochs.mockResolvedValue(null);
       const res = await postJson('/register-grant', { currentPassword: 'hunter2!' });
       expect(res.status).toBe(503);
+      // A4: the mint-failure 503 must be audited too.
+      expect(helperMocks.writeAuthAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'auth.authenticator.register_grant.mint_failed',
+          result: 'failure',
+          reason: 'epochs_unavailable',
+        }),
+      );
+    });
+
+    // A5 (previously untested): mintStepUpGrant itself resolving null (e.g.
+    // Redis down) — distinct from the epochs/sid-unavailable 503 above — must
+    // also 503 and be audited.
+    it('503 when mintStepUpGrant resolves null even though epochs/sid are present', async () => {
+      helperMocks.userHasStrongerReauthFactor.mockResolvedValue(false);
+      helperMocks.requireCurrentPasswordStepUp.mockResolvedValue(null);
+      epochsMock.getUserEpochs.mockResolvedValue({ authEpoch: 1, mfaEpoch: 2 });
+      grantMocks.mintStepUpGrant.mockResolvedValue(null);
+
+      const res = await postJson('/register-grant', { currentPassword: 'hunter2!' });
+
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: 'Service temporarily unavailable' });
+      expect(helperMocks.writeAuthAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'auth.authenticator.register_grant.mint_failed',
+          result: 'failure',
+          reason: 'mint_failed',
+        }),
+      );
     });
   });
 

--- a/apps/api/src/routes/authenticator.test.ts
+++ b/apps/api/src/routes/authenticator.test.ts
@@ -11,6 +11,8 @@ const {
   approverMocks,
   mobileHwKeyMocks,
   helperMocks,
+  grantMocks,
+  epochsMock,
   authState,
 } = vi.hoisted(() => {
   const makeSelectChain = (rows: unknown[]) => {
@@ -52,6 +54,14 @@ const {
     helperMocks: {
       requireCurrentPasswordStepUp: vi.fn(),
       writeAuthAudit: vi.fn(),
+      enforceApproverRegisterStepUp: vi.fn(),
+      userHasStrongerReauthFactor: vi.fn(),
+    },
+    grantMocks: {
+      mintStepUpGrant: vi.fn(),
+    },
+    epochsMock: {
+      getUserEpochs: vi.fn(),
     },
     authState: {
       requireAuthorizationHeader: true,
@@ -72,8 +82,13 @@ vi.mock('./auth/helpers', () => ({
   ...helperMocks,
 }));
 
+vi.mock('../services/mfaStepUpGrant', () => ({
+  ...grantMocks,
+}));
+
 vi.mock('../services', () => ({
   getRedis: vi.fn(() => redisMock),
+  getUserEpochs: epochsMock.getUserEpochs,
 }));
 
 vi.mock('../db', () => ({
@@ -135,7 +150,7 @@ vi.mock('../middleware/auth', () => ({
       user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
       orgId: 'org-123',
       partnerId: 'partner-123',
-      token: { mfa: true },
+      token: { mfa: true, sid: 'sid-123' },
     });
     return next();
   }),
@@ -190,6 +205,10 @@ describe('approver device routes', () => {
     authState.denyPermission = false;
     helperMocks.requireCurrentPasswordStepUp.mockResolvedValue(null);
     helperMocks.writeAuthAudit.mockReturnValue(undefined);
+    helperMocks.enforceApproverRegisterStepUp.mockResolvedValue(null);
+    helperMocks.userHasStrongerReauthFactor.mockResolvedValue(false);
+    epochsMock.getUserEpochs.mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 });
+    grantMocks.mintStepUpGrant.mockResolvedValue('grant-uuid');
     approverMocks.generateApproverRegistrationOptions.mockResolvedValue({
       challenge: 'register-challenge',
       rp: { name: 'Breeze' },
@@ -210,61 +229,69 @@ describe('approver device routes', () => {
     app.route('/me/approver-devices', approverDevicesRoutes);
   });
 
-  it('requires authentication for registration options', async () => {
-    const res = await app.request('/authenticator/devices/webauthn/options', {
+  // Shared request-builder for the authenticator routes — mirrors the file's
+  // existing app.request(...) style, defaulting to an authenticated caller.
+  async function postJson(path: string, body: unknown, opts: { authorized?: boolean } = {}) {
+    const authorized = opts.authorized ?? true;
+    return app.request(`/authenticator${path}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ currentPassword: 'pw' }),
+      headers: {
+        'Content-Type': 'application/json',
+        ...(authorized ? { Authorization: 'Bearer access-token' } : {}),
+      },
+      body: JSON.stringify(body),
     });
+  }
+
+  it('requires authentication for registration options', async () => {
+    const res = await postJson('/devices/webauthn/options', { registerGrantId: 'g-1' }, { authorized: false });
     expect(res.status).toBe(401);
     expect(approverMocks.generateApproverRegistrationOptions).not.toHaveBeenCalled();
   });
 
-  it('returns registration options after the current-password step-up', async () => {
-    const res = await app.request('/authenticator/devices/webauthn/options', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
-      body: JSON.stringify({ currentPassword: 'correct-password' }),
-    });
+  it('returns registration options after grant validation (non-consuming)', async () => {
+    const res = await postJson('/devices/webauthn/options', { registerGrantId: 'g-1' });
 
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ options: { challenge: 'register-challenge' } });
-    expect(helperMocks.requireCurrentPasswordStepUp).toHaveBeenCalledWith(
+    expect(helperMocks.enforceApproverRegisterStepUp).toHaveBeenCalledWith(
       expect.anything(),
-      'user-123',
-      'correct-password',
-      expect.any(String),
+      expect.anything(),
+      'g-1',
+      { consume: false },
     );
     expect(approverMocks.generateApproverRegistrationOptions).toHaveBeenCalledWith(
       expect.objectContaining({ user: expect.objectContaining({ id: 'user-123' }) }),
     );
   });
 
-  it('blocks registration options when the password step-up fails', async () => {
-    helperMocks.requireCurrentPasswordStepUp.mockResolvedValueOnce(
+  it('blocks registration options when grant enforcement fails', async () => {
+    helperMocks.enforceApproverRegisterStepUp.mockResolvedValueOnce(
       // a Response from the helper signals failure
-      new Response(JSON.stringify({ error: 'Invalid credentials' }), { status: 401 }),
+      new Response(JSON.stringify({ error: 'register_step_up_required' }), { status: 403 }),
     );
 
-    const res = await app.request('/authenticator/devices/webauthn/options', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
-      body: JSON.stringify({ currentPassword: 'wrong-password' }),
-    });
+    const res = await postJson('/devices/webauthn/options', { registerGrantId: 'bad-grant' });
 
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(403);
     expect(approverMocks.generateApproverRegistrationOptions).not.toHaveBeenCalled();
   });
 
   it('verifies registration and inserts a webauthn_platform device row', async () => {
-    const res = await app.request('/authenticator/devices/webauthn/verify', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
-      body: JSON.stringify({ label: 'My Laptop', response: { id: 'credential-1', response: {} } }),
+    const res = await postJson('/devices/webauthn/verify', {
+      registerGrantId: 'g-1',
+      label: 'My Laptop',
+      response: { id: 'credential-1', response: {} },
     });
 
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ success: true, device: { id: 'device-1' } });
+    expect(helperMocks.enforceApproverRegisterStepUp).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'g-1',
+      { consume: true },
+    );
 
     const inserted = dbState.insertValues[0];
     expect(inserted).toMatchObject({
@@ -341,9 +368,9 @@ describe('approver device routes', () => {
     expect(dbState.updateSets).toContainEqual(expect.objectContaining({ label: 'New Name' }));
   });
 
-  // --- Mobile hardware-key registration (POST /devices) — password step-up required, activates on first signature ---
+  // --- Mobile hardware-key registration (POST /devices) — register-grant required, activates on first signature ---
 
-  it('registers a mobile_hw_key after the current-password step-up and stores it pending', async () => {
+  it('registers a mobile_hw_key after grant consumption and stores it pending', async () => {
     dbState.insertReturning = [
       {
         ...deviceRow,
@@ -356,10 +383,12 @@ describe('approver device routes', () => {
       },
     ];
 
-    const res = await app.request('/authenticator/devices', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
-      body: JSON.stringify({ kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true, currentPassword: 'correct-password' }),
+    const res = await postJson('/devices', {
+      registerGrantId: 'g-mobile-1',
+      kind: 'mobile_hw_key',
+      publicKey: 'pk',
+      label: 'iPhone',
+      isPlatformBound: true,
     });
 
     expect(res.status).toBe(201);
@@ -367,13 +396,14 @@ describe('approver device routes', () => {
     expect(body.device.id).toBe('mobile-pending-1');
     expect(body.device.label).toBe('iPhone');
 
-    // Step-up must have been called before insert, matching the sibling's key prefix.
-    expect(helperMocks.requireCurrentPasswordStepUp).toHaveBeenCalledWith(
+    // Grant must be consumed before insert, matching the sibling's contract.
+    expect(helperMocks.enforceApproverRegisterStepUp).toHaveBeenCalledWith(
       expect.anything(),
-      'user-123',
-      'correct-password',
-      'authenticator:pwd',
+      expect.anything(),
+      'g-mobile-1',
+      { consume: true },
     );
+    expect(helperMocks.requireCurrentPasswordStepUp).not.toHaveBeenCalled();
 
     const inserted = dbState.insertValues[0];
     expect(inserted).toMatchObject({
@@ -396,36 +426,50 @@ describe('approver device routes', () => {
     );
   });
 
-  it('rejects mobile_hw_key registration when currentPassword is missing (400)', async () => {
-    const res = await app.request('/authenticator/devices', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
-      body: JSON.stringify({ kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true }),
+  it('rejects mobile_hw_key registration when grant enforcement fails, including a missing registerGrantId (403)', async () => {
+    // registerGrantId is optional at the schema layer (mirrors the existing
+    // stepUpGrantId fields) — a missing grant reaches the security helper and
+    // gets the uniform 403, not a generic validation 400.
+    helperMocks.enforceApproverRegisterStepUp.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'register_step_up_required' }), { status: 403 }),
+    );
+    const missingGrantRes = await postJson('/devices', {
+      kind: 'mobile_hw_key',
+      publicKey: 'pk',
+      label: 'iPhone',
+      isPlatformBound: true,
     });
-    expect(res.status).toBe(400);
-    expect(helperMocks.requireCurrentPasswordStepUp).not.toHaveBeenCalled();
+    expect(missingGrantRes.status).toBe(403);
+    expect(helperMocks.enforceApproverRegisterStepUp).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      { consume: true },
+    );
     expect(dbState.insertValues).toHaveLength(0);
   });
 
-  it('rejects mobile_hw_key registration when the password step-up fails (401)', async () => {
-    helperMocks.requireCurrentPasswordStepUp.mockResolvedValueOnce(
-      new Response(JSON.stringify({ error: 'Invalid credentials' }), { status: 401 }),
+  it('rejects mobile_hw_key registration when grant enforcement fails (403)', async () => {
+    helperMocks.enforceApproverRegisterStepUp.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'register_step_up_required' }), { status: 403 }),
     );
 
-    const res = await app.request('/authenticator/devices', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
-      body: JSON.stringify({ kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true, currentPassword: 'wrong-password' }),
+    const res = await postJson('/devices', {
+      registerGrantId: 'g-bad',
+      kind: 'mobile_hw_key',
+      publicKey: 'pk',
+      label: 'iPhone',
+      isPlatformBound: true,
     });
 
-    expect(res.status).toBe(401);
-    expect(helperMocks.requireCurrentPasswordStepUp).toHaveBeenCalledWith(
+    expect(res.status).toBe(403);
+    expect(helperMocks.enforceApproverRegisterStepUp).toHaveBeenCalledWith(
       expect.anything(),
-      'user-123',
-      'wrong-password',
-      'authenticator:pwd',
+      expect.anything(),
+      'g-bad',
+      { consume: true },
     );
-    // No insert should happen when the step-up is rejected.
+    // No insert should happen when the grant is rejected.
     expect(dbState.insertValues).toHaveLength(0);
   });
 
@@ -448,7 +492,7 @@ describe('approver device routes', () => {
         Authorization: 'Bearer access-token',
         'X-Breeze-Mobile-Device-Id': '11111111-2222-3333-4444-555555555555',
       },
-      body: JSON.stringify({ kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true, currentPassword: 'correct-password' }),
+      body: JSON.stringify({ registerGrantId: 'g-mobile-2', kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true }),
     });
 
     expect(res.status).toBe(201);
@@ -457,23 +501,114 @@ describe('approver device routes', () => {
   });
 
   it('requires authentication for mobile_hw_key registration', async () => {
-    const res = await app.request('/authenticator/devices', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true, currentPassword: 'correct-password' }),
-    });
+    const res = await postJson('/devices', {
+      registerGrantId: 'g-mobile-3',
+      kind: 'mobile_hw_key',
+      publicKey: 'pk',
+      label: 'iPhone',
+      isPlatformBound: true,
+    }, { authorized: false });
     expect(res.status).toBe(401);
     expect(dbState.insertValues).toHaveLength(0);
   });
 
   it('rejects mobile_hw_key registration with a missing publicKey (400)', async () => {
-    const res = await app.request('/authenticator/devices', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
-      body: JSON.stringify({ kind: 'mobile_hw_key', label: 'iPhone', isPlatformBound: true, currentPassword: 'correct-password' }),
+    const res = await postJson('/devices', {
+      registerGrantId: 'g-mobile-4',
+      kind: 'mobile_hw_key',
+      label: 'iPhone',
+      isPlatformBound: true,
     });
     expect(res.status).toBe(400);
     expect(dbState.insertValues).toHaveLength(0);
+  });
+
+  describe('POST /register-grant', () => {
+    it('mints a grant after password step-up when no stronger factor exists', async () => {
+      helperMocks.userHasStrongerReauthFactor.mockResolvedValue(false);
+      helperMocks.requireCurrentPasswordStepUp.mockResolvedValue(null);
+      epochsMock.getUserEpochs.mockResolvedValue({ authEpoch: 1, mfaEpoch: 2 });
+      grantMocks.mintStepUpGrant.mockResolvedValue('grant-uuid');
+
+      const res = await postJson('/register-grant', { currentPassword: 'hunter2!' });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ registerGrantId: 'grant-uuid' });
+      expect(grantMocks.mintStepUpGrant).toHaveBeenCalledWith(
+        expect.objectContaining({ operation: 'register_approver_device' }),
+      );
+    });
+
+    it('403 stronger_factor_required when the account has TOTP or a passkey', async () => {
+      helperMocks.userHasStrongerReauthFactor.mockResolvedValue(true);
+      const res = await postJson('/register-grant', { currentPassword: 'hunter2!' });
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: 'stronger_factor_required' });
+      expect(helperMocks.requireCurrentPasswordStepUp).not.toHaveBeenCalled();
+    });
+
+    it('propagates password step-up failures (401/429/503)', async () => {
+      helperMocks.userHasStrongerReauthFactor.mockResolvedValue(false);
+      helperMocks.requireCurrentPasswordStepUp.mockImplementation(async (c: any) =>
+        c.json({ error: 'Invalid credentials' }, 401),
+      );
+      const res = await postJson('/register-grant', { currentPassword: 'wrong' });
+      expect(res.status).toBe(401);
+    });
+
+    it('503 when sid/epochs unavailable', async () => {
+      helperMocks.userHasStrongerReauthFactor.mockResolvedValue(false);
+      helperMocks.requireCurrentPasswordStepUp.mockResolvedValue(null);
+      epochsMock.getUserEpochs.mockResolvedValue(null);
+      const res = await postJson('/register-grant', { currentPassword: 'hunter2!' });
+      expect(res.status).toBe(503);
+    });
+  });
+
+  describe('register routes take registerGrantId', () => {
+    it('options validates (consume:false); verify consumes (consume:true)', async () => {
+      helperMocks.enforceApproverRegisterStepUp.mockResolvedValue(null);
+      approverMocks.generateApproverRegistrationOptions.mockResolvedValue({ challenge: 'c' });
+      await postJson('/devices/webauthn/options', { registerGrantId: 'g-1' });
+      expect(helperMocks.enforceApproverRegisterStepUp).toHaveBeenLastCalledWith(
+        expect.anything(), expect.anything(), 'g-1', { consume: false },
+      );
+
+      approverMocks.verifyApproverRegistration.mockResolvedValue({
+        publicKey: 'pk', credentialId: 'cid', counter: 0, aaguid: null, transports: null, isPlatformBound: true,
+      });
+      dbState.insertReturning = [{ id: 'dev-1', label: 'x', kind: 'webauthn_platform', isPlatformBound: true, transports: [] }];
+      await postJson('/devices/webauthn/verify', { registerGrantId: 'g-1', response: { id: 'att' } });
+      expect(helperMocks.enforceApproverRegisterStepUp).toHaveBeenLastCalledWith(
+        expect.anything(), expect.anything(), 'g-1', { consume: true },
+      );
+    });
+
+    it('mobile POST /devices consumes the grant and no longer reads currentPassword', async () => {
+      helperMocks.enforceApproverRegisterStepUp.mockResolvedValue(null);
+      dbState.insertReturning = [{ id: 'dev-2', label: 'This device', kind: 'mobile_hw_key', isPlatformBound: true, transports: [] }];
+      const res = await postJson('/devices', { registerGrantId: 'g-2', publicKey: 'SPKI', label: 'This device' });
+      // The mobile route returns 201 on insert (unchanged by #2707 — only the
+      // step-up mechanism moved from currentPassword to a register grant).
+      expect(res.status).toBe(201);
+      expect(helperMocks.enforceApproverRegisterStepUp).toHaveBeenLastCalledWith(
+        expect.anything(), expect.anything(), 'g-2', { consume: true },
+      );
+      expect(helperMocks.requireCurrentPasswordStepUp).not.toHaveBeenCalled();
+    });
+
+    it('403s all three routes when enforcement rejects — including a missing grant', async () => {
+      helperMocks.enforceApproverRegisterStepUp.mockImplementation(async (c: any) =>
+        c.json({ error: 'register_step_up_required' }, 403),
+      );
+      for (const [path, body] of [
+        ['/devices/webauthn/options', {}],
+        ['/devices/webauthn/verify', { response: { id: 'att' } }],
+        ['/devices', { publicKey: 'SPKI', label: 'x' }],
+      ] as const) {
+        const res = await postJson(path, body);
+        expect(res.status, path).toBe(403);
+      }
+    });
   });
 });
 

--- a/apps/api/src/routes/authenticator.ts
+++ b/apps/api/src/routes/authenticator.ts
@@ -128,6 +128,14 @@ authenticatorRoutes.post(
     const { currentPassword } = c.req.valid('json');
 
     if (await userHasStrongerReauthFactor(auth.user.id)) {
+      writeAuthAudit(c, {
+        orgId: auth.orgId ?? undefined,
+        action: 'auth.authenticator.register_grant.denied',
+        result: 'failure',
+        reason: 'stronger_factor_required',
+        userId: auth.user.id,
+        email: auth.user.email,
+      });
       return c.json({ error: 'stronger_factor_required' }, 403);
     }
 
@@ -141,6 +149,14 @@ authenticatorRoutes.post(
 
     const epochs = await getUserEpochs(auth.user.id);
     if (!epochs || !auth.token.sid) {
+      writeAuthAudit(c, {
+        orgId: auth.orgId ?? undefined,
+        action: 'auth.authenticator.register_grant.mint_failed',
+        result: 'failure',
+        reason: 'epochs_unavailable',
+        userId: auth.user.id,
+        email: auth.user.email,
+      });
       return c.json({ error: 'Service temporarily unavailable' }, 503);
     }
     const registerGrantId = await mintStepUpGrant({
@@ -151,6 +167,14 @@ authenticatorRoutes.post(
       sid: auth.token.sid,
     });
     if (!registerGrantId) {
+      writeAuthAudit(c, {
+        orgId: auth.orgId ?? undefined,
+        action: 'auth.authenticator.register_grant.mint_failed',
+        result: 'failure',
+        reason: 'mint_failed',
+        userId: auth.user.id,
+        email: auth.user.email,
+      });
       return c.json({ error: 'Service temporarily unavailable' }, 503);
     }
 
@@ -272,13 +296,16 @@ authenticatorRoutes.post(
     const auth = c.get('auth');
     const body = c.req.valid('json');
 
-    const grantError = await enforceApproverRegisterStepUp(c, auth, body.registerGrantId, { consume: true });
-    if (grantError) return grantError;
-
-    // Re-validate the authoritative fields through the shared strict schema; the
-    // client-asserted kind/isPlatformBound discriminators are ignored (the server
-    // forces kind='mobile_hw_key' + is_platform_bound=true). A bad/missing
-    // publicKey or label is a 400 here, never an insert.
+    // Re-validate the authoritative fields through the shared strict schema
+    // BEFORE consuming the single-use grant: the client-asserted
+    // kind/isPlatformBound discriminators are ignored (the server forces
+    // kind='mobile_hw_key' + is_platform_bound=true). A bad/missing publicKey
+    // or label is a 400 here, never an insert — and parsing first means a
+    // malformed payload never burns a caller's valid grant (unlike the
+    // consume-first ordering, which is correct for /devices/webauthn/verify
+    // because that route's body has no comparable pre-consume validation to
+    // do — the WebAuthn response itself is verified cryptographically, not
+    // schema-parsed).
     const parsed = mobileHwKeyRegisterSchema.safeParse({
       publicKey: (body as { publicKey?: unknown }).publicKey,
       label: (body as { label?: unknown }).label,
@@ -287,6 +314,9 @@ authenticatorRoutes.post(
       return c.json({ error: 'invalid_registration', detail: parsed.error.issues }, 400);
     }
     const { publicKey, label } = parsed.data;
+
+    const grantError = await enforceApproverRegisterStepUp(c, auth, body.registerGrantId, { consume: true });
+    if (grantError) return grantError;
 
     // Per-install device id is a UX/migration hint only (client-controlled,
     // SR-001) — null when the header is absent.

--- a/apps/api/src/routes/authenticator.ts
+++ b/apps/api/src/routes/authenticator.ts
@@ -12,7 +12,14 @@ import {
 } from '../services/approverWebAuthn';
 import { loadPartnerPolicy, validateRaiseOnly } from '../services/authenticatorPolicy';
 import { readMobileDeviceId } from '../services/mobileDeviceBinding';
-import { requireCurrentPasswordStepUp, writeAuthAudit } from './auth/helpers';
+import {
+  requireCurrentPasswordStepUp,
+  writeAuthAudit,
+  enforceApproverRegisterStepUp,
+  userHasStrongerReauthFactor,
+} from './auth/helpers';
+import { mintStepUpGrant } from '../services/mfaStepUpGrant';
+import { getUserEpochs } from '../services';
 import { authenticatorPolicySchema, mobileHwKeyRegisterSchema } from '@breeze/shared';
 
 // Attestation payload is a large nested object validated structurally by
@@ -27,33 +34,35 @@ const attestationResponseSchema = z
 
 const deviceLabelSchema = z.string().trim().min(1).max(255);
 
+// #2707: registration is grant-gated (enforceApproverRegisterStepUp), not
+// re-validated password-by-password on every call. `registerGrantId` is
+// optional at the wire/schema layer — same pattern as the existing
+// `stepUpGrantId` fields (auth/passkeys.ts, auth/mfa.ts, auth/phone.ts) — so a
+// missing grant still reaches the security helper and gets the uniform
+// `register_step_up_required` 403 instead of a generic validation 400.
+const registerGrantIdSchema = z.string().min(1).max(128).optional();
+
 const registerOptionsSchema = z.object({
-  currentPassword: z.string().min(1).max(256),
+  registerGrantId: registerGrantIdSchema,
 });
 const registerVerifySchema = z.object({
+  registerGrantId: registerGrantIdSchema,
   response: attestationResponseSchema,
   label: deviceLabelSchema.optional(),
 });
+const registerGrantMintSchema = z.object({
+  currentPassword: z.string().min(1).max(256),
+});
 
-// Mobile hardware-key registration — requires a current-password step-up.
-// The phone POSTs its freshly generated Secure-Enclave / Keystore SPKI public
-// key + a label, plus the account password to prove the caller controls the
-// account (not merely a stolen access token). No registration-time signature —
-// the key is stored PENDING (last_used_at null) and ACTIVATES on its first
-// approval signature, which is verified in the assurance path.
-//
-// The wire body also carries client-asserted `kind` / `isPlatformBound`
-// discriminators (the mobile client sends them); we tolerate but do NOT trust
-// them — the server forces kind='mobile_hw_key' and is_platform_bound=true. The
-// authoritative `publicKey` + `label` are re-validated through the shared
-// `mobileHwKeyRegisterSchema` (`.strict()`) before insert; `currentPassword` is
-// intentionally stripped prior to that parse so the strict schema doesn't reject
-// the field.
+// Mobile hardware-key registration — requires a register_approver_device grant
+// (minted at login, returned as authenticatorRegisterGrantId). The old
+// client-asserted kind/isPlatformBound discriminators are ignored entirely; the
+// server forces kind='mobile_hw_key' and is_platform_bound=true. publicKey +
+// label are re-validated through the shared mobileHwKeyRegisterSchema
+// (`.strict()`) before insert; registerGrantId is stripped prior to that parse.
 const mobileRegisterSchema = z
   .object({
-    currentPassword: z.string().min(1).max(256),
-    kind: z.literal('mobile_hw_key').optional(),
-    isPlatformBound: z.boolean().optional(),
+    registerGrantId: registerGrantIdSchema,
   })
   .passthrough();
 const revokeSchema = z.object({
@@ -106,16 +115,22 @@ function findOwnedDevice(id: string, userId: string): Promise<ApproverDeviceRow[
 // the /me/* group (mirrors users/me + auth/passkeys conventions).
 export const authenticatorRoutes = new Hono();
 
+// #2707: password-fallback grant mint for the browser register flow. Gated:
+// accounts holding a stronger factor (TOTP or a passkey) must mint via
+// POST /auth/mfa/step-up instead — otherwise a stolen session + phished
+// password could register an approver key on an MFA-protected account.
 authenticatorRoutes.post(
-  '/devices/webauthn/options',
+  '/register-grant',
   authMiddleware,
-  zValidator('json', registerOptionsSchema),
+  zValidator('json', registerGrantMintSchema),
   async (c) => {
     const auth = c.get('auth');
     const { currentPassword } = c.req.valid('json');
 
-    // Password step-up mirrors routes/auth/passkeys.ts — registering an approver
-    // device is a security-sensitive action and must reconfirm the password.
+    if (await userHasStrongerReauthFactor(auth.user.id)) {
+      return c.json({ error: 'stronger_factor_required' }, 403);
+    }
+
     const passwordError = await requireCurrentPasswordStepUp(
       c,
       auth.user.id,
@@ -123,6 +138,51 @@ authenticatorRoutes.post(
       'authenticator:pwd'
     );
     if (passwordError) return passwordError;
+
+    const epochs = await getUserEpochs(auth.user.id);
+    if (!epochs || !auth.token.sid) {
+      return c.json({ error: 'Service temporarily unavailable' }, 503);
+    }
+    const registerGrantId = await mintStepUpGrant({
+      userId: auth.user.id,
+      operation: 'register_approver_device',
+      authEpoch: epochs.authEpoch,
+      mfaEpoch: epochs.mfaEpoch,
+      sid: auth.token.sid,
+    });
+    if (!registerGrantId) {
+      return c.json({ error: 'Service temporarily unavailable' }, 503);
+    }
+
+    writeAuthAudit(c, {
+      orgId: auth.orgId ?? undefined,
+      action: 'auth.authenticator.register_grant.minted',
+      result: 'success',
+      userId: auth.user.id,
+      email: auth.user.email,
+      details: { method: 'password' },
+    });
+
+    return c.json({ registerGrantId });
+  }
+);
+
+// Registration is grant-gated (#2707): the browser mints a register grant via
+// POST /register-grant (password fallback) or POST /auth/mfa/step-up (stronger
+// factor), then presents it here as registerGrantId. The SAME grant validated
+// here (non-consuming) is consumed at /devices/webauthn/verify.
+authenticatorRoutes.post(
+  '/devices/webauthn/options',
+  authMiddleware,
+  zValidator('json', registerOptionsSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { registerGrantId } = c.req.valid('json');
+
+    // Non-consuming validate — the SAME grant is consumed at /verify. A
+    // missing/expired/mismatched grant 403s before any challenge is issued.
+    const grantError = await enforceApproverRegisterStepUp(c, auth, registerGrantId, { consume: false });
+    if (grantError) return grantError;
 
     const existing = await listActiveDevices(auth.user.id);
     const options = await generateApproverRegistrationOptions({
@@ -146,7 +206,12 @@ authenticatorRoutes.post(
   zValidator('json', registerVerifySchema),
   async (c) => {
     const auth = c.get('auth');
-    const { response, label } = c.req.valid('json');
+    const { registerGrantId, response, label } = c.req.valid('json');
+
+    // Terminal write — consume the grant (single-use, closes the previously
+    // unguarded verify step: pre-#2707 this route had NO step-up at all).
+    const grantError = await enforceApproverRegisterStepUp(c, auth, registerGrantId, { consume: true });
+    if (grantError) return grantError;
 
     const fields = await verifyApproverRegistration({
       userId: auth.user.id,
@@ -189,12 +254,13 @@ authenticatorRoutes.post(
   }
 );
 
-// Mobile hardware-key registration — password step-up required, then deferred PoP.
-// The phone POSTs its Secure-Enclave / Keystore public key plus the account
-// password (step-up), which proves the caller controls the account and not merely
-// a stolen access token. There is NO registration-time proof-of-possession
-// signature — the row is inserted PENDING (`last_used_at` null) and is ACTIVATED
-// on its first real approval signature, verified in
+// Mobile hardware-key registration — register-grant required (minted at
+// login), then deferred PoP. The phone POSTs its Secure-Enclave / Keystore
+// public key plus the register_approver_device grant, which proves the caller
+// completed the login-time step-up and not merely holds a stolen access
+// token. There is NO registration-time proof-of-possession signature — the
+// row is inserted PENDING (`last_used_at` null) and is ACTIVATED on its first
+// real approval signature, verified in
 // `authenticatorAssurance.verifyMobileFactor` (which sets `last_used_at`). The
 // deferred-PoP design means a registered-but-never-used key can never satisfy an
 // approval until it has signed at least once.
@@ -206,18 +272,8 @@ authenticatorRoutes.post(
     const auth = c.get('auth');
     const body = c.req.valid('json');
 
-    // Password step-up mirrors /devices/webauthn/options — registering an
-    // approver device with a stolen access token is the attack this guards
-    // against. The caller proves they know the account password before any SPKI
-    // key is stored. `currentPassword` is validated by the outer
-    // `mobileRegisterSchema` (required, non-empty) before reaching here.
-    const passwordError = await requireCurrentPasswordStepUp(
-      c,
-      auth.user.id,
-      body.currentPassword,
-      'authenticator:pwd'
-    );
-    if (passwordError) return passwordError;
+    const grantError = await enforceApproverRegisterStepUp(c, auth, body.registerGrantId, { consume: true });
+    if (grantError) return grantError;
 
     // Re-validate the authoritative fields through the shared strict schema; the
     // client-asserted kind/isPlatformBound discriminators are ignored (the server

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -810,6 +810,37 @@ describe('user routes', () => {
       expect(runOutsideDbContext).toHaveBeenCalled();
       expect(withSystemDbAccessContext).toHaveBeenCalled();
     });
+
+    it('includes mfaMethod so the web can pick the register re-auth tier (#2707)', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'user-123',
+              email: 'admin@example.com',
+              name: 'Admin',
+              avatarUrl: null,
+              status: 'active',
+              mfaEnabled: true,
+              mfaMethod: 'totp',
+              isPlatformAdmin: false,
+              createdAt: new Date(),
+              lastLoginAt: new Date(),
+              setupCompletedAt: new Date(),
+              passwordChangedAt: new Date(),
+              preferences: {}
+            }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/users/me', {
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as { mfaMethod?: unknown };
+      expect(body.mfaMethod).toBe('totp');
+    });
   });
 
   describe('PATCH /users/me validation', () => {

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -318,6 +318,9 @@ userRoutes.get('/me', async (c) => {
       avatarUrl: users.avatarUrl,
       status: users.status,
       mfaEnabled: users.mfaEnabled,
+      // #2707: lets the profile UI pick the approver-register re-auth tier
+      // (passkey → TOTP code → password) without a second endpoint.
+      mfaMethod: users.mfaMethod,
       // Exposed so the web sidebar can hide platform-admin-only nav (e.g.
       // account-deletion-requests) and skip its badge fetch — otherwise that
       // fetch 403s ("platform admin access required") on every page load for

--- a/apps/api/src/services/mfaStepUpGrant.integration.test.ts
+++ b/apps/api/src/services/mfaStepUpGrant.integration.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Real-Redis integration coverage for the #2707 approver-device register
+ * grant chain (`mfaStepUpGrant.ts`).
+ *
+ * The unit suites around this feature mock the seam from BOTH sides:
+ *   - `mfaStepUpGrant.test.ts` mocks `./redis` entirely (an in-memory Map
+ *     stands in for Redis).
+ *   - the route-level tests (e.g. `routes/auth/authenticator.test.ts`) mock
+ *     `enforceApproverRegisterStepUp` itself, so they never call into the
+ *     real mint/validate/consume functions at all.
+ *
+ * Nothing therefore exercises the REAL chain against a REAL Redis: mint (as
+ * `mintLoginRegisterGrant` mints at login, bound to userId/epochs/sid, for
+ * operation `register_approver_device`) -> non-consuming `validateStepUpGrant`
+ * (the `webauthn/options` phase) -> single-use `consumeStepUpGrant` (getdel,
+ * the terminal `webauthn/verify` phase) -> replay rejected -> a grant minted
+ * for the OTHER operation (`add_factor`) never validates/consumes against a
+ * `register_approver_device` bind, and vice versa. This file drives exactly
+ * that chain with only the service under test + a real `ioredis` client — no
+ * mocks on `mfaStepUpGrant.ts` or `./redis`.
+ *
+ * No Postgres fixtures are needed: `bindsMatch` and the grant lifecycle are
+ * pure Redis-key semantics, so this is scoped to `getRedis()` from
+ * `./redis`, which the shared integration `setup.ts` (auto-applied via this
+ * config's `setupFiles`) already points at the real test Redis
+ * (`REDIS_URL`, defaulting to `redis://localhost:6380` — see
+ * `__tests__/integration/loadEnv.ts`). `setup.ts`'s global `beforeEach` also
+ * `flushdb()`s that same Redis before every test in this file, so each test
+ * starts from an empty keyspace.
+ *
+ * `SHOULD_RUN` mirrors the same env-presence skip idiom already used by
+ * `oauth-code-flow.integration.test.ts` so this file degrades the same way
+ * the rest of the integration suite does when the local rig isn't up
+ * (`docker compose -f docker-compose.test.yml up -d` — see setup.ts's own
+ * header). Note the shared `setup.ts` beforeAll unconditionally pings BOTH
+ * Postgres and Redis for every file in this config (its hard connect-or-throw
+ * predates this file), so in practice this suite already requires the whole
+ * :5433/:6380 rig up regardless of this flag; it's kept for consistency with
+ * the existing convention and as defense-in-depth against a future setup.ts
+ * change that makes DB/Redis independently optional.
+ *
+ * Run:
+ *   docker compose -f docker-compose.test.yml up -d
+ *   cd apps/api && pnpm vitest run --config vitest.integration.config.ts \
+ *     src/services/mfaStepUpGrant.integration.test.ts
+ */
+import '../__tests__/integration/setup';
+
+import { randomUUID } from 'crypto';
+import { afterAll, describe, expect, it } from 'vitest';
+import { getRedis, closeRedis } from './redis';
+import {
+  mintStepUpGrant,
+  validateStepUpGrant,
+  consumeStepUpGrant,
+  type StepUpOperation,
+} from './mfaStepUpGrant';
+
+const SHOULD_RUN = Boolean(process.env.REDIS_URL || process.env.DATABASE_URL);
+
+function bind(operation: StepUpOperation) {
+  return {
+    userId: randomUUID(),
+    operation,
+    authEpoch: 1,
+    mfaEpoch: 2,
+    sid: randomUUID(),
+  };
+}
+
+describe.skipIf(!SHOULD_RUN)('mfaStepUpGrant real-Redis chain (#2707)', () => {
+  afterAll(async () => {
+    // Quit the shared ioredis singleton so vitest can exit cleanly; the
+    // module under test rides this same connection (getRedis() singleton in
+    // ./redis). Mirrors quoteSendQueue.integration.test.ts's afterAll.
+    await closeRedis();
+  });
+
+  it('mint -> non-consuming validate x2 -> single-use consume -> replay rejected, with a <=300s TTL', async () => {
+    const registerBind = bind('register_approver_device');
+
+    const id = await mintStepUpGrant(registerBind);
+    expect(id).toBeTruthy();
+
+    // Real Redis TTL on the minted key, via the exact key format documented
+    // at the top of mfaStepUpGrant.ts (`mfa:stepup:<id>`).
+    const redis = getRedis();
+    expect(redis).not.toBeNull();
+    const ttl = await redis!.ttl(`mfa:stepup:${id}`);
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(300);
+
+    // Non-consuming validate (the webauthn/options phase): can be called
+    // repeatedly without burning the grant.
+    await expect(validateStepUpGrant(id!, registerBind)).resolves.toBe(true);
+    await expect(validateStepUpGrant(id!, registerBind)).resolves.toBe(true);
+
+    // Single-use consume (the webauthn/verify phase, getdel).
+    await expect(consumeStepUpGrant(id!, registerBind)).resolves.toBe(true);
+
+    // Replay: the grant is gone. Both consume and (non-consuming) validate
+    // now fail — proving consume genuinely deleted the Redis key rather than
+    // just returning false for an unrelated reason.
+    await expect(consumeStepUpGrant(id!, registerBind)).resolves.toBe(false);
+    await expect(validateStepUpGrant(id!, registerBind)).resolves.toBe(false);
+  });
+
+  it('a grant minted for one operation never validates/consumes against the other operation\'s bind', async () => {
+    // add_factor -> presented against a register_approver_device bind.
+    const addFactorBind = bind('add_factor');
+    const addFactorId = await mintStepUpGrant(addFactorBind);
+    expect(addFactorId).toBeTruthy();
+
+    const crossOpBindForAddFactorGrant = { ...addFactorBind, operation: 'register_approver_device' as const };
+    await expect(validateStepUpGrant(addFactorId!, crossOpBindForAddFactorGrant)).resolves.toBe(false);
+    await expect(consumeStepUpGrant(addFactorId!, crossOpBindForAddFactorGrant)).resolves.toBe(false);
+
+    // register_approver_device -> presented against an add_factor bind.
+    const registerBind = bind('register_approver_device');
+    const registerId = await mintStepUpGrant(registerBind);
+    expect(registerId).toBeTruthy();
+
+    const crossOpBindForRegisterGrant = { ...registerBind, operation: 'add_factor' as const };
+    await expect(validateStepUpGrant(registerId!, crossOpBindForRegisterGrant)).resolves.toBe(false);
+    // getdel deletes the record on ANY lookup hit, match or not — pinning the
+    // documented behavior from the mocked unit suite (mfaStepUpGrant.test.ts,
+    // "operation isolation" describe block): the failed cross-operation
+    // consume attempt above still destroys the register grant, so even a
+    // subsequent SAME-operation validate below also fails.
+    await expect(consumeStepUpGrant(registerId!, crossOpBindForRegisterGrant)).resolves.toBe(false);
+    await expect(validateStepUpGrant(registerId!, registerBind)).resolves.toBe(false);
+  });
+});

--- a/apps/api/src/services/mfaStepUpGrant.test.ts
+++ b/apps/api/src/services/mfaStepUpGrant.test.ts
@@ -1,117 +1,65 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const redisStore = new Map<string, string>();
-const ttls = new Map<string, number>();
-let redisDown = false;
-
-vi.mock('./redis', () => ({
-  getRedis: () => {
-    if (redisDown) return null;
-    return {
-      setex: vi.fn(async (k: string, ttl: number, v: string) => {
-        redisStore.set(k, v);
-        ttls.set(k, ttl);
-        return 'OK';
-      }),
+const { redisMock, redisStore } = vi.hoisted(() => {
+  const redisStore = new Map<string, string>();
+  return {
+    redisStore,
+    redisMock: {
+      setex: vi.fn(async (k: string, _ttl: number, v: string) => { redisStore.set(k, v); }),
       get: vi.fn(async (k: string) => redisStore.get(k) ?? null),
       getdel: vi.fn(async (k: string) => {
         const v = redisStore.get(k) ?? null;
         redisStore.delete(k);
-        ttls.delete(k);
         return v;
       }),
-    };
-  },
-}));
+    },
+  };
+});
+
+vi.mock('./redis', () => ({ getRedis: vi.fn(() => redisMock) }));
 
 import { mintStepUpGrant, validateStepUpGrant, consumeStepUpGrant } from './mfaStepUpGrant';
 
-const BIND = {
+const bind = (operation: 'add_factor' | 'register_approver_device') => ({
   userId: 'user-1',
-  operation: 'add_factor' as const,
+  operation,
   authEpoch: 1,
   mfaEpoch: 2,
-  sid: 'family-1',
-};
+  sid: 'sid-1',
+});
 
-describe('mfaStepUpGrant', () => {
+describe('mfaStepUpGrant operation isolation', () => {
   beforeEach(() => {
     redisStore.clear();
-    ttls.clear();
-    redisDown = false;
+    vi.clearAllMocks();
   });
 
-  describe('mintStepUpGrant', () => {
-    it('writes mfa:stepup:<id> with a 300s TTL and returns the id', async () => {
-      const id = await mintStepUpGrant(BIND);
-      expect(id).toBeTruthy();
-      const key = `mfa:stepup:${id}`;
-      expect(redisStore.has(key)).toBe(true);
-      expect(ttls.get(key)).toBe(300);
-      expect(JSON.parse(redisStore.get(key)!)).toEqual(BIND);
-    });
-
-    it('returns null when Redis is down', async () => {
-      redisDown = true;
-      const id = await mintStepUpGrant(BIND);
-      expect(id).toBeNull();
-    });
+  it('mints and consumes a register_approver_device grant', async () => {
+    const id = await mintStepUpGrant(bind('register_approver_device'));
+    expect(id).toBeTruthy();
+    await expect(validateStepUpGrant(id!, bind('register_approver_device'))).resolves.toBe(true);
+    await expect(consumeStepUpGrant(id!, bind('register_approver_device'))).resolves.toBe(true);
+    // single-use: second consume fails
+    await expect(consumeStepUpGrant(id!, bind('register_approver_device'))).resolves.toBe(false);
   });
 
-  describe('validateStepUpGrant', () => {
-    it('returns true when the id exists and every bind field matches', async () => {
-      const id = await mintStepUpGrant(BIND);
-      const ok = await validateStepUpGrant(id!, BIND);
-      expect(ok).toBe(true);
-      // Non-consuming: the record is still present afterward.
-      expect(redisStore.has(`mfa:stepup:${id}`)).toBe(true);
-    });
-
-    it('returns false when the id does not exist', async () => {
-      const ok = await validateStepUpGrant('nonexistent-id', BIND);
-      expect(ok).toBe(false);
-    });
-
-    it.each([
-      ['userId', { ...BIND, userId: 'other-user' }],
-      ['operation', { ...BIND, operation: 'other_op' as unknown as 'add_factor' }],
-      ['authEpoch', { ...BIND, authEpoch: 999 }],
-      ['mfaEpoch', { ...BIND, mfaEpoch: 999 }],
-      ['sid', { ...BIND, sid: 'other-sid' }],
-    ])('returns false on a %s mismatch', async (_field, mismatchedBind) => {
-      const id = await mintStepUpGrant(BIND);
-      const ok = await validateStepUpGrant(id!, mismatchedBind);
-      expect(ok).toBe(false);
-    });
-
-    it('returns false when Redis is null', async () => {
-      const id = await mintStepUpGrant(BIND);
-      redisDown = true;
-      const ok = await validateStepUpGrant(id!, BIND);
-      expect(ok).toBe(false);
-    });
+  it('an add_factor grant can never validate/consume as register_approver_device (and vice versa)', async () => {
+    const addFactor = await mintStepUpGrant(bind('add_factor'));
+    const register = await mintStepUpGrant(bind('register_approver_device'));
+    await expect(validateStepUpGrant(addFactor!, bind('register_approver_device'))).resolves.toBe(false);
+    await expect(consumeStepUpGrant(addFactor!, bind('register_approver_device'))).resolves.toBe(false);
+    await expect(validateStepUpGrant(register!, bind('add_factor'))).resolves.toBe(false);
+    // cross-operation consume must NOT burn the grant: getdel deletes, so assert
+    // the register grant was destroyed by the failed add_factor consume attempt
+    // ONLY IF the service deletes on mismatch — current behavior: getdel removes
+    // the key regardless. Pin current behavior:
+    await expect(consumeStepUpGrant(register!, bind('add_factor'))).resolves.toBe(false);
+    await expect(validateStepUpGrant(register!, bind('register_approver_device'))).resolves.toBe(false);
   });
 
-  describe('consumeStepUpGrant', () => {
-    it('uses getdel and is single-use: a second consume of the same id returns false', async () => {
-      const id = await mintStepUpGrant(BIND);
-      const first = await consumeStepUpGrant(id!, BIND);
-      expect(first).toBe(true);
-      const second = await consumeStepUpGrant(id!, BIND);
-      expect(second).toBe(false);
-    });
-
-    it('returns false on a bind mismatch (and still consumes the record)', async () => {
-      const id = await mintStepUpGrant(BIND);
-      const ok = await consumeStepUpGrant(id!, { ...BIND, sid: 'other-sid' });
-      expect(ok).toBe(false);
-    });
-
-    it('returns false when Redis is null', async () => {
-      const id = await mintStepUpGrant(BIND);
-      redisDown = true;
-      const ok = await consumeStepUpGrant(id!, BIND);
-      expect(ok).toBe(false);
-    });
+  it('validate is non-consuming', async () => {
+    const id = await mintStepUpGrant(bind('register_approver_device'));
+    await expect(validateStepUpGrant(id!, bind('register_approver_device'))).resolves.toBe(true);
+    await expect(validateStepUpGrant(id!, bind('register_approver_device'))).resolves.toBe(true);
   });
 });

--- a/apps/api/src/services/mfaStepUpGrant.test.ts
+++ b/apps/api/src/services/mfaStepUpGrant.test.ts
@@ -122,10 +122,9 @@ describe('mfaStepUpGrant operation isolation', () => {
     await expect(validateStepUpGrant(addFactor!, bind('register_approver_device'))).resolves.toBe(false);
     await expect(consumeStepUpGrant(addFactor!, bind('register_approver_device'))).resolves.toBe(false);
     await expect(validateStepUpGrant(register!, bind('add_factor'))).resolves.toBe(false);
-    // cross-operation consume must NOT burn the grant: getdel deletes, so assert
-    // the register grant was destroyed by the failed add_factor consume attempt
-    // ONLY IF the service deletes on mismatch — current behavior: getdel removes
-    // the key regardless. Pin current behavior:
+    // getdel deletes on mismatch — pinning current behavior: the failed
+    // cross-operation consume attempt above still destroys the register
+    // grant, so even a subsequent same-operation validate below also fails.
     await expect(consumeStepUpGrant(register!, bind('add_factor'))).resolves.toBe(false);
     await expect(validateStepUpGrant(register!, bind('register_approver_device'))).resolves.toBe(false);
   });

--- a/apps/api/src/services/mfaStepUpGrant.test.ts
+++ b/apps/api/src/services/mfaStepUpGrant.test.ts
@@ -1,22 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { redisMock, redisStore } = vi.hoisted(() => {
+const { redisMock, redisStore, ttls, getRedisMock } = vi.hoisted(() => {
   const redisStore = new Map<string, string>();
-  return {
-    redisStore,
-    redisMock: {
-      setex: vi.fn(async (k: string, _ttl: number, v: string) => { redisStore.set(k, v); }),
-      get: vi.fn(async (k: string) => redisStore.get(k) ?? null),
-      getdel: vi.fn(async (k: string) => {
-        const v = redisStore.get(k) ?? null;
-        redisStore.delete(k);
-        return v;
-      }),
-    },
+  const ttls = new Map<string, number>();
+  const redisMock = {
+    setex: vi.fn(async (k: string, ttl: number, v: string) => {
+      redisStore.set(k, v);
+      ttls.set(k, ttl);
+    }),
+    get: vi.fn(async (k: string) => redisStore.get(k) ?? null),
+    getdel: vi.fn(async (k: string) => {
+      const v = redisStore.get(k) ?? null;
+      redisStore.delete(k);
+      ttls.delete(k);
+      return v;
+    }),
   };
+  const getRedisMock = vi.fn<() => typeof redisMock | null>(() => redisMock);
+  return { redisMock, redisStore, ttls, getRedisMock };
 });
 
-vi.mock('./redis', () => ({ getRedis: vi.fn(() => redisMock) }));
+vi.mock('./redis', () => ({ getRedis: getRedisMock }));
 
 import { mintStepUpGrant, validateStepUpGrant, consumeStepUpGrant } from './mfaStepUpGrant';
 
@@ -28,10 +32,79 @@ const bind = (operation: 'add_factor' | 'register_approver_device') => ({
   sid: 'sid-1',
 });
 
+describe('mfaStepUpGrant', () => {
+  beforeEach(() => {
+    redisStore.clear();
+    ttls.clear();
+    vi.clearAllMocks();
+    getRedisMock.mockReturnValue(redisMock);
+  });
+
+  describe('mintStepUpGrant', () => {
+    it('writes mfa:stepup:<id> with a 300s TTL and returns the id', async () => {
+      const b = bind('add_factor');
+      const id = await mintStepUpGrant(b);
+      expect(id).toBeTruthy();
+      const key = `mfa:stepup:${id}`;
+      expect(redisStore.has(key)).toBe(true);
+      expect(ttls.get(key)).toBe(300);
+      expect(JSON.parse(redisStore.get(key)!)).toEqual(b);
+    });
+
+    it('returns null when Redis is down', async () => {
+      getRedisMock.mockReturnValue(null);
+      const id = await mintStepUpGrant(bind('add_factor'));
+      expect(id).toBeNull();
+    });
+  });
+
+  describe('validateStepUpGrant', () => {
+    it('returns false when the id does not exist', async () => {
+      const ok = await validateStepUpGrant('nonexistent-id', bind('add_factor'));
+      expect(ok).toBe(false);
+    });
+
+    it.each([
+      ['userId', { ...bind('add_factor'), userId: 'other-user' }],
+      ['authEpoch', { ...bind('add_factor'), authEpoch: 999 }],
+      ['mfaEpoch', { ...bind('add_factor'), mfaEpoch: 999 }],
+      ['sid', { ...bind('add_factor'), sid: 'other-sid' }],
+    ])('returns false on a %s mismatch', async (_field, mismatchedBind) => {
+      const id = await mintStepUpGrant(bind('add_factor'));
+      const ok = await validateStepUpGrant(id!, mismatchedBind);
+      expect(ok).toBe(false);
+    });
+
+    it('returns false when Redis is null', async () => {
+      const id = await mintStepUpGrant(bind('add_factor'));
+      getRedisMock.mockReturnValue(null);
+      const ok = await validateStepUpGrant(id!, bind('add_factor'));
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe('consumeStepUpGrant', () => {
+    it('returns false on a single-field mismatch (sid)', async () => {
+      const id = await mintStepUpGrant(bind('add_factor'));
+      const ok = await consumeStepUpGrant(id!, { ...bind('add_factor'), sid: 'other-sid' });
+      expect(ok).toBe(false);
+    });
+
+    it('returns false when Redis is null', async () => {
+      const id = await mintStepUpGrant(bind('add_factor'));
+      getRedisMock.mockReturnValue(null);
+      const ok = await consumeStepUpGrant(id!, bind('add_factor'));
+      expect(ok).toBe(false);
+    });
+  });
+});
+
 describe('mfaStepUpGrant operation isolation', () => {
   beforeEach(() => {
     redisStore.clear();
+    ttls.clear();
     vi.clearAllMocks();
+    getRedisMock.mockReturnValue(redisMock);
   });
 
   it('mints and consumes a register_approver_device grant', async () => {
@@ -61,5 +134,7 @@ describe('mfaStepUpGrant operation isolation', () => {
     const id = await mintStepUpGrant(bind('register_approver_device'));
     await expect(validateStepUpGrant(id!, bind('register_approver_device'))).resolves.toBe(true);
     await expect(validateStepUpGrant(id!, bind('register_approver_device'))).resolves.toBe(true);
+    // Non-consuming: the record is still present afterward.
+    expect(redisStore.has(`mfa:stepup:${id}`)).toBe(true);
   });
 });

--- a/apps/api/src/services/mfaStepUpGrant.ts
+++ b/apps/api/src/services/mfaStepUpGrant.ts
@@ -3,10 +3,12 @@ import { getRedis } from './redis';
 
 /**
  * SR2-20: existing-factor step-up grant for adding a NEW MFA factor to an
- * ALREADY-PROTECTED account. Minted by `POST /auth/mfa/step-up` after the
- * caller proves an existing factor (TOTP/SMS/passkey), then presented back
- * to a factor-addition endpoint (`/mfa/enable`, setup-confirm, `/mfa/sms/enable`,
- * `/passkeys/register/*`) as `stepUpGrantId`.
+ * ALREADY-PROTECTED account, OR registering an authenticator device as an
+ * approver. Minted by `POST /auth/mfa/step-up` after the caller proves an
+ * existing factor (TOTP/SMS/passkey), then presented back to a factor-addition
+ * endpoint (`/mfa/enable`, setup-confirm, `/mfa/sms/enable`, `/passkeys/register/*`)
+ * as `stepUpGrantId`, or to an authenticator registration route
+ * (`POST /authenticator/register/options`, `/authenticator/register/verify`).
  *
  * Bound to the live `authEpoch`/`mfaEpoch` + the initiating session's `sid` so
  * a factor change (which bumps `mfa_epoch` + revokes refresh families) or a
@@ -15,10 +17,14 @@ import { getRedis } from './redis';
  * for the intermediate `register/options` step (the SAME grant is consumed
  * later at `/register/verify`).
  */
+/** Operations a step-up grant can authorize. A grant minted for one operation
+ * can never validate/consume for another (bindsMatch checks equality). */
+export type StepUpOperation = 'add_factor' | 'register_approver_device';
+
 export interface StepUpGrant {
   id: string;
   userId: string;
-  operation: 'add_factor';
+  operation: StepUpOperation;
   authEpoch: number;
   mfaEpoch: number;
   sid: string;

--- a/apps/api/src/services/mfaStepUpGrant.ts
+++ b/apps/api/src/services/mfaStepUpGrant.ts
@@ -2,20 +2,31 @@ import { randomUUID } from 'crypto';
 import { getRedis } from './redis';
 
 /**
- * SR2-20: existing-factor step-up grant for adding a NEW MFA factor to an
- * ALREADY-PROTECTED account, OR registering an authenticator device as an
- * approver. Minted by `POST /auth/mfa/step-up` after the caller proves an
- * existing factor (TOTP/SMS/passkey), then presented back to a factor-addition
- * endpoint (`/mfa/enable`, setup-confirm, `/mfa/sms/enable`, `/passkeys/register/*`)
- * as `stepUpGrantId`, or to an authenticator registration route
- * (`POST /authenticator/register/options`, `/authenticator/register/verify`).
+ * SR2-20 / #2707: existing-factor step-up grant for adding a NEW MFA factor to
+ * an ALREADY-PROTECTED account, OR registering an authenticator device as an
+ * approver.
+ *
+ * Minted by THREE sources: (1) `POST /auth/mfa/step-up`, after the caller
+ * proves an existing factor (TOTP/SMS/passkey); (2)
+ * `POST /authenticator/register-grant`, the password-proof fallback for
+ * accounts with no stronger factor; (3) `mintLoginRegisterGrant`
+ * (`routes/auth/helpers.ts`), a best-effort login-time mint for mobile
+ * clients only.
+ *
+ * Grants from (1) are presented back to a factor-addition endpoint
+ * (`/mfa/enable`, setup-confirm, `/mfa/sms/enable`, `/passkeys/register/*`) as
+ * `stepUpGrantId`. Grants for approver-device registration (from any of the
+ * three sources) are presented as `registerGrantId` to
+ * `POST /authenticator/devices/webauthn/options`,
+ * `POST /authenticator/devices/webauthn/verify`, or the mobile
+ * `POST /authenticator/devices`.
  *
  * Bound to the live `authEpoch`/`mfaEpoch` + the initiating session's `sid` so
  * a factor change (which bumps `mfa_epoch` + revokes refresh families) or a
  * session switch invalidates any outstanding grant. Single-use via Redis
  * `getdel` at the terminal write; non-consuming `validateStepUpGrant` exists
- * for the intermediate `register/options` step (the SAME grant is consumed
- * later at `/register/verify`).
+ * for the intermediate `webauthn/options` step (the SAME grant is consumed
+ * later at `webauthn/verify`).
  */
 /** Operations a step-up grant can authorize. A grant minted for one operation
  * can never validate/consume for another (bindsMatch checks equality). */
@@ -43,13 +54,23 @@ function bindsMatch(record: GrantBind, bind: GrantBind): boolean {
     && record.sid === bind.sid;
 }
 
-/** Mint a short-lived single-use step-up grant. Returns null if Redis is down (caller fails closed). */
+/**
+ * Mint a short-lived single-use step-up grant. Returns null if Redis is down
+ * OR the write itself rejects (fails closed) — mirrors the try/catch already
+ * present on validate/consume below, so a transient Redis error here can
+ * never propagate as an uncaught rejection into a caller like
+ * `mintLoginRegisterGrant` that must never throw.
+ */
 export async function mintStepUpGrant(bind: GrantBind): Promise<string | null> {
   const redis = getRedis();
   if (!redis) return null;
-  const id = randomUUID();
-  await redis.setex(key(id), TTL_SECONDS, JSON.stringify(bind));
-  return id;
+  try {
+    const id = randomUUID();
+    await redis.setex(key(id), TTL_SECONDS, JSON.stringify(bind));
+    return id;
+  } catch {
+    return null;
+  }
 }
 
 /** Non-consuming check (register/options). Fails closed on Redis down/error/miss/mismatch. */

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -106,6 +106,13 @@ export default defineConfig({
       // fail it on connect. Belongs to vitest.integration.config.ts
       // (registered in its include list).
       'src/services/actionIntents/resultSecrets.integration.test.ts',
+      // Real-Redis integration test for the #2707 approver-device register
+      // grant chain: imports `__tests__/integration/setup` (real Redis via
+      // ioredis), so the no-Redis unit runner would fail it on connect.
+      // Belongs to vitest.integration.config.ts (registered in its include
+      // list). NOT the same file as the co-located mocked unit suite
+      // `mfaStepUpGrant.test.ts`, which stays on this runner.
+      'src/services/mfaStepUpGrant.integration.test.ts',
     ],
     setupFiles: ['src/__tests__/setup.ts'],
     coverage: {

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -136,6 +136,12 @@ export default defineConfig({
       // this config's globalSetup provides. Belongs here, not the unit
       // runner (no DB, no child-process fork target).
       'src/extensions/twoReplicaReconcile.integration.test.ts',
+      // Co-located real-Redis integration test for the #2707 approver-device
+      // register grant chain (mint -> validate -> consume -> replay rejected,
+      // cross-operation isolation, TTL): imports `__tests__/integration/setup`
+      // (real Redis; no Postgres fixtures used). Belongs to
+      // vitest.integration.config.ts, not the no-Redis unit runner.
+      'src/services/mfaStepUpGrant.integration.test.ts',
     ],
     exclude: [
       // Uses fresh request-pool modules and manages its own temporary role;

--- a/apps/mobile/src/navigation/ApprovalGate.tsx
+++ b/apps/mobile/src/navigation/ApprovalGate.tsx
@@ -156,11 +156,15 @@ function ApproverFailedBanner() {
 }
 
 /**
- * Shown when {@link ensureApproverDevice} deferred registration because the
- * login-minted grant was consumed or absent (e.g. a restored session, not a
+ * Shown when {@link ensureApproverDevice} deferred registration because there
+ * was no login-minted grant available to use — either it was already taken
+ * out of the Redux store (read-and-clear) by an earlier attempt this session,
+ * or none was ever minted at all (a restored/cold-start session rather than a
  * fresh interactive login). This is informational, not an error — approvals
  * still work at L1 — so it uses the neutral/brand border rather than the
- * `deny` styling {@link ApproverFailedBanner} uses.
+ * `deny` styling {@link ApproverFailedBanner} uses. A grant that WAS minted
+ * but got consumed server-side (Redis) surfaces as `failed`/`http_403`
+ * instead, not `deferred`.
  */
 function ApproverDeferredBanner() {
   const insets = useSafeAreaInsets();

--- a/apps/mobile/src/navigation/ApprovalGate.tsx
+++ b/apps/mobile/src/navigation/ApprovalGate.tsx
@@ -81,6 +81,9 @@ export function ApprovalGate({ children }: Props) {
       {!error && pushRegistration !== 'failed' && approverRegistration === 'failed' ? (
         <ApproverFailedBanner />
       ) : null}
+      {!error && pushRegistration !== 'failed' && approverRegistration === 'deferred' ? (
+        <ApproverDeferredBanner />
+      ) : null}
     </>
   );
 }
@@ -146,6 +149,45 @@ function ApproverFailedBanner() {
         <Text style={[type.meta, { color: theme.textHi }]}>
           This device isn't set up for biometric approval — your approvals will be
           recorded at the lowest assurance level.
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Shown when {@link ensureApproverDevice} deferred registration because the
+ * login-minted grant was consumed or absent (e.g. a restored session, not a
+ * fresh interactive login). This is informational, not an error — approvals
+ * still work at L1 — so it uses the neutral/brand border rather than the
+ * `deny` styling {@link ApproverFailedBanner} uses.
+ */
+function ApproverDeferredBanner() {
+  const insets = useSafeAreaInsets();
+  const theme = useApprovalTheme('dark');
+  return (
+    <View
+      pointerEvents="box-none"
+      style={{
+        position: 'absolute',
+        top: insets.top + spacing[2],
+        left: spacing[4],
+        right: spacing[4],
+      }}
+    >
+      <View
+        style={{
+          backgroundColor: theme.bg2,
+          borderRadius: radii.md,
+          paddingVertical: spacing[3],
+          paddingHorizontal: spacing[4],
+          borderColor: theme.border,
+          borderWidth: 1,
+        }}
+      >
+        <Text style={[type.bodyMd, { color: theme.textHi }]}>Finish approver setup</Text>
+        <Text style={[type.meta, { color: theme.textHi, marginTop: spacing[1] }]}>
+          Sign out and back in to let this phone approve requests with Face ID.
         </Text>
       </View>
     </View>

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -111,6 +111,15 @@ export function RootNavigator() {
     if (registerGrant) dispatch(clearAuthenticatorRegisterGrant());
     void ensureApproverDevice(undefined, registerGrant ?? undefined).then((outcome) => {
       if (!active) return;
+      if (outcome.status === 'failed') {
+        // Telemetry only, so a silent registration failure is at least visible
+        // in Sentry — this is otherwise invisible until the user reports it.
+        // NEVER include the grant value here; it's a single-use credential.
+        Sentry.captureMessage('approver-device registration failed', {
+          level: 'warning',
+          tags: { area: 'approver-device-registration', reason: outcome.reason },
+        });
+      }
       dispatch(
         setApproverRegistration({
           status: outcome.status === 'already_registered' ? 'registered' : outcome.status,

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -3,8 +3,14 @@ import { NavigationContainer, DefaultTheme as NavDefaultTheme } from '@react-nav
 import { Alert, Pressable, Text, View } from 'react-native';
 import * as Sentry from '@sentry/react-native';
 
-import { useAppSelector, useAppDispatch } from '../store';
-import { setCredentials, logout, logoutAsync, setApproverRegistration } from '../store/authSlice';
+import { useAppSelector, useAppDispatch, store } from '../store';
+import {
+  setCredentials,
+  logout,
+  logoutAsync,
+  setApproverRegistration,
+  clearAuthenticatorRegisterGrant,
+} from '../store/authSlice';
 import { getStoredToken, getStoredUser, clearAuthData, SecureWipeError } from '../services/auth';
 import { getCurrentUser, onDeviceBlocked } from '../services/api';
 import { spacing, type } from '../theme';
@@ -96,7 +102,14 @@ export function RootNavigator() {
   useEffect(() => {
     if (!token || !user) return;
     let active = true;
-    void ensureApproverDevice().then((outcome) => {
+    // #2707 read-and-clear: take the login-minted grant OUT of Redux before the
+    // async attempt. The grant is deliberately NOT in this effect's deps — the
+    // effect re-fires on every `user` identity change (checkAuth double-fires on
+    // cold start), and a replayed single-use grant would 403 and overwrite a
+    // successful registration with `failed`.
+    const registerGrant = store.getState().auth.authenticatorRegisterGrantId;
+    if (registerGrant) dispatch(clearAuthenticatorRegisterGrant());
+    void ensureApproverDevice(undefined, registerGrant ?? undefined).then((outcome) => {
       if (!active) return;
       dispatch(
         setApproverRegistration({

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -1,4 +1,5 @@
 import * as SecureStore from 'expo-secure-store';
+import * as Sentry from '@sentry/react-native';
 
 import { getServerUrl } from './serverConfig';
 import { getOrCreateInstallationId } from './installationId';
@@ -213,16 +214,25 @@ async function requestWithPrefix<T>(
     (headers as Record<string, string>)[CSRF_HEADER_NAME] = CSRF_HEADER_VALUE;
   }
 
-  // Always send the per-install id so the API can recognise this phone for
-  // the lifecycle/lockout flow. Failures (SecureStore disabled in tests)
-  // fall through silently — a missing header simply means "no row to match".
+  // Always send the per-install id so the API can recognise this phone. This
+  // used to be a harmless soft-matching hint (the lifecycle/lockout flow), but
+  // post-#2707 the server also gates login-time register_approver_device grant
+  // minting on this header — if SecureStore fails here, the phone never gets a
+  // grant, approver registration permanently defers, and there is no recovery:
+  // ApprovalGate's deferred-banner "sign out and back in" advice cannot fix a
+  // device that can't produce an installation id at all. Report failures so
+  // they're observable instead of silently capping the phone at L1 forever.
   try {
     const installationId = await getOrCreateInstallationId();
     if (installationId) {
       (headers as Record<string, string>)[MOBILE_DEVICE_ID_HEADER] = installationId;
     }
-  } catch {
-    // ignore
+  } catch (e) {
+    Sentry.captureMessage('installation id unavailable for mobile-device header', {
+      level: 'warning',
+      tags: { area: 'mobile-device-id-header' },
+      extra: { errorName: (e as Error)?.name ?? 'unknown' },
+    });
   }
 
   const baseUrl = (await getServerUrl()) || FALLBACK_API_BASE_URL;

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -91,6 +91,8 @@ export interface User {
 export interface LoginResponse {
   token: string;
   user: User;
+  /** #2707: single-use approver-register grant minted at login; memory-only. */
+  registerGrant: string | null;
 }
 
 export type MfaMethod = 'totp' | 'sms';
@@ -102,7 +104,7 @@ export interface MfaChallenge {
 }
 
 export type LoginResult =
-  | { kind: 'success'; token: string; user: User }
+  | { kind: 'success'; token: string; user: User; registerGrant: string | null }
   | { kind: 'mfaRequired'; challenge: MfaChallenge };
 
 export interface ApiError {
@@ -134,6 +136,8 @@ interface LoginPayload {
   mfaMethod?: MfaMethod;
   phoneLast4?: string | null;
   error?: string;
+  /** #2707: single-use approver-register grant; mobile-header-gated. */
+  authenticatorRegisterGrantId?: string;
 }
 
 type MobileAlertRecord = {
@@ -337,7 +341,12 @@ export async function login(email: string, password: string): Promise<LoginResul
     throw { message: response.error || 'Invalid login response' } as ApiError;
   }
 
-  return { kind: 'success', token, user: response.user };
+  return {
+    kind: 'success',
+    token,
+    user: response.user,
+    registerGrant: response.authenticatorRegisterGrantId ?? null,
+  };
 }
 
 export async function verifyMfa(code: string, tempToken: string): Promise<LoginResponse> {
@@ -351,7 +360,7 @@ export async function verifyMfa(code: string, tempToken: string): Promise<LoginR
     throw { message: response.error || 'Invalid MFA response' } as ApiError;
   }
 
-  return { token, user: response.user };
+  return { token, user: response.user, registerGrant: response.authenticatorRegisterGrantId ?? null };
 }
 
 export async function sendMfaSms(tempToken: string): Promise<void> {

--- a/apps/mobile/src/services/approverDevice.test.ts
+++ b/apps/mobile/src/services/approverDevice.test.ts
@@ -122,6 +122,10 @@ describe('ensureApproverDevice', () => {
     await expect(first).resolves.toEqual({ status: 'registered' });
     await expect(second).resolves.toEqual({ status: 'registered' });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    // B4: the grant is single-use — a second key mint would mean a second
+    // (wasted, or worse duplicate) attempt slipped through the single-flight
+    // gate.
+    expect(signer.createKeys).toHaveBeenCalledTimes(1);
   });
 
   it('is a no-op when a credential id already exists', async () => {
@@ -204,17 +208,58 @@ describe('ensureApproverDevice', () => {
     expect(secureStore.setItemAsync).not.toHaveBeenCalled();
   });
 
-  it('never throws on the login path when the network blows up', async () => {
+  it('never throws on the login path when the network blows up; reason names the exception', async () => {
     const signer = fakeSigner();
     secureStore.getItemAsync.mockImplementation(async (k: string) =>
       k === 'breeze_approver_credential_id' ? null : 'test-token',
     );
     fetchMock.mockRejectedValueOnce(new Error('offline'));
 
+    // B2: the reason must name the exception (not the bare literal 'exception')
+    // so a failure that never leaves the device is at least distinguishable in
+    // aggregate telemetry once RootNavigator reports it.
     await expect(ensureApproverDevice(signer, 'grant-1')).resolves.toEqual({
       status: 'failed',
-      reason: 'exception',
+      reason: 'exception:Error',
     });
+  });
+
+  it('starts a FRESH attempt after a failed outcome — the in-flight slot is cleared', async () => {
+    const signer = fakeSigner();
+    secureStore.getItemAsync.mockImplementation(async (k: string) =>
+      k === 'breeze_approver_credential_id' ? null : 'test-token',
+    );
+    fetchMock.mockResolvedValueOnce(json({ error: 'nope' }, 500));
+
+    await expect(ensureApproverDevice(signer, 'grant-1')).resolves.toEqual({
+      status: 'failed',
+      reason: 'http_500',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockResolvedValueOnce(json({ device: { id: 'dev-2' } }));
+    await expect(ensureApproverDevice(signer, 'grant-2')).resolves.toEqual({ status: 'registered' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('B1: a grant-bearing call joins a grant-less in-flight attempt, then fires its OWN POST once it resolves non-registered', async () => {
+    const signer = fakeSigner();
+    secureStore.getItemAsync.mockImplementation(async (k: string) =>
+      k === 'breeze_approver_credential_id' ? null : 'test-token',
+    );
+    // Grant-less caller — RootNavigator can start this before its grant read
+    // resolves. No POST: it resolves 'deferred' without touching the network.
+    const grantless = ensureApproverDevice(signer);
+    // A grant-bearing caller shows up while the grant-less attempt is still
+    // in flight — it must NOT be dropped (that's the B1 bug): it should join,
+    // see the non-registered outcome, and fire its own POST with the grant.
+    fetchMock.mockResolvedValueOnce(json({ device: { id: 'dev-1' } }));
+    const withGrant = ensureApproverDevice(signer, 'grant-1');
+
+    await expect(grantless).resolves.toEqual({ status: 'deferred', reason: 'no_reauth_grant' });
+    await expect(withGrant).resolves.toEqual({ status: 'registered' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({ registerGrantId: 'grant-1' });
   });
 });
 

--- a/apps/mobile/src/services/approverDevice.test.ts
+++ b/apps/mobile/src/services/approverDevice.test.ts
@@ -68,18 +68,60 @@ describe('ensureApproverDevice', () => {
     );
     fetchMock.mockResolvedValueOnce(json({ device: { id: 'dev-1' } }));
 
-    await expect(ensureApproverDevice(signer)).resolves.toEqual({ status: 'registered' });
+    await expect(ensureApproverDevice(signer, 'grant-1')).resolves.toEqual({ status: 'registered' });
 
-    // No password step-up — passwordless registration body.
+    // Grant-based registration body — no kind/isPlatformBound/currentPassword.
     expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
-      kind: 'mobile_hw_key',
+      registerGrantId: 'grant-1',
       publicKey: 'SPKI-PUBKEY-B64',
-      isPlatformBound: true,
+      label: 'This device',
     });
     expect(JSON.parse(fetchMock.mock.calls[0][1].body)).not.toHaveProperty('currentPassword');
     expect(signer.createKeys).toHaveBeenCalledTimes(1);
     // credential id persisted for later assertions
     expect(secureStore.setItemAsync).toHaveBeenCalledWith('breeze_approver_credential_id', 'dev-1');
+  });
+
+  it('returns deferred and does NOT POST when no grant is available', async () => {
+    const signer = fakeSigner();
+    secureStore.getItemAsync.mockImplementation(async (k: string) =>
+      k === 'breeze_approver_credential_id' ? null : 'test-token',
+    );
+    await expect(ensureApproverDevice(signer)).resolves.toEqual({
+      status: 'deferred',
+      reason: 'no_reauth_grant',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(signer.createKeys).not.toHaveBeenCalled();
+  });
+
+  it('POSTs registerGrantId (and neither kind nor isPlatformBound) when a grant is provided', async () => {
+    const signer = fakeSigner();
+    secureStore.getItemAsync.mockImplementation(async (k: string) =>
+      k === 'breeze_approver_credential_id' ? null : 'test-token',
+    );
+    fetchMock.mockResolvedValueOnce(json({ device: { id: 'dev-1' } }));
+    await expect(ensureApproverDevice(signer, 'grant-1')).resolves.toEqual({ status: 'registered' });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toMatchObject({ registerGrantId: 'grant-1', publicKey: 'SPKI-PUBKEY-B64', label: 'This device' });
+    expect(body).not.toHaveProperty('kind');
+    expect(body).not.toHaveProperty('isPlatformBound');
+    expect(body).not.toHaveProperty('currentPassword');
+  });
+
+  it('concurrent calls share one in-flight attempt (single POST, one grant burn)', async () => {
+    const signer = fakeSigner();
+    secureStore.getItemAsync.mockImplementation(async (k: string) =>
+      k === 'breeze_approver_credential_id' ? null : 'test-token',
+    );
+    let release!: (v: unknown) => void;
+    fetchMock.mockReturnValueOnce(new Promise((r) => { release = r; }));
+    const first = ensureApproverDevice(signer, 'grant-1');
+    const second = ensureApproverDevice(signer, 'grant-1');
+    release(json({ device: { id: 'dev-1' } }));
+    await expect(first).resolves.toEqual({ status: 'registered' });
+    await expect(second).resolves.toEqual({ status: 'registered' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('is a no-op when a credential id already exists', async () => {
@@ -116,7 +158,7 @@ describe('ensureApproverDevice', () => {
     );
     fetchMock.mockResolvedValueOnce(json({ error: 'nope' }, 500));
 
-    await expect(ensureApproverDevice(signer)).resolves.toEqual({
+    await expect(ensureApproverDevice(signer, 'grant-1')).resolves.toEqual({
       status: 'failed',
       reason: 'http_500',
     });
@@ -138,7 +180,7 @@ describe('ensureApproverDevice', () => {
     );
     fetchMock.mockResolvedValueOnce(json({ error: 'Validation failed' }, 400));
 
-    await expect(ensureApproverDevice(signer)).resolves.toEqual({
+    await expect(ensureApproverDevice(signer, 'grant-1')).resolves.toEqual({
       status: 'failed',
       reason: 'http_400',
     });
@@ -155,7 +197,7 @@ describe('ensureApproverDevice', () => {
     );
     fetchMock.mockResolvedValueOnce(json({ device: {} }));
 
-    await expect(ensureApproverDevice(signer)).resolves.toEqual({
+    await expect(ensureApproverDevice(signer, 'grant-1')).resolves.toEqual({
       status: 'failed',
       reason: 'missing_device_id',
     });
@@ -169,7 +211,7 @@ describe('ensureApproverDevice', () => {
     );
     fetchMock.mockRejectedValueOnce(new Error('offline'));
 
-    await expect(ensureApproverDevice(signer)).resolves.toEqual({
+    await expect(ensureApproverDevice(signer, 'grant-1')).resolves.toEqual({
       status: 'failed',
       reason: 'exception',
     });

--- a/apps/mobile/src/services/approverDevice.ts
+++ b/apps/mobile/src/services/approverDevice.ts
@@ -62,27 +62,24 @@ export type ApproverRegistrationOutcome =
   | { status: 'failed'; reason: string };
 
 // Single-flight: RootNavigator's effect can re-fire while a registration is in
-// flight (checkAuth double-dispatches setCredentials on cold start). The grant
-// is single-use, so a duplicate attempt would burn a consumed grant into a 403
-// and overwrite a successful outcome. Concurrent callers share one attempt.
+// flight (checkAuth double-dispatches setCredentials on cold start). With the
+// read-and-clear grant handoff a re-fired effect can never carry the SAME grant
+// twice, so the real races are: a grant-less duplicate call resolving `deferred`
+// and racing the effect's `active` cleanup to overwrite a real success, and a
+// duplicate POST racing the SecureStore write of the credential id. Grant-less
+// callers therefore just join whatever attempt is already running. A caller
+// that DOES carry a grant is different: dropping it silently strands a fresh,
+// unused grant (see below), so it first awaits the in-flight attempt — if that
+// attempt already registered the device, the grant is simply left unused
+// (harmless, it just expires); otherwise it fires its own attempt with the
+// grant, still funnelled through the same single in-flight slot.
 let inFlight: Promise<ApproverRegistrationOutcome> | null = null;
 
-/**
- * Idempotent: ensure this phone has a registered approver key. Called after
- * auth lands. FAILS OPEN — never throws, never blocks login.
- *
- * #2707: registration requires a `register_approver_device` grant minted at
- * login (`authenticatorRegisterGrantId` in the login/mfa-verify response) —
- * proof of a fresh interactive login, independent of the bearer token. With no
- * grant (cold-start restored session) there is nothing to prove with: return
- * `deferred` WITHOUT touching the network; the device registers on the next
- * real login. The #2683 banner surfaces this state with actionable copy.
- */
-export async function ensureApproverDevice(
-  signer: HardwareSigner = getHardwareSigner(),
-  registerGrant?: string,
+/** Run one registration attempt, occupying (and then releasing) `inFlight`. */
+function runAttempt(
+  signer: HardwareSigner,
+  registerGrant: string | undefined,
 ): Promise<ApproverRegistrationOutcome> {
-  if (inFlight) return inFlight;
   inFlight = (async (): Promise<ApproverRegistrationOutcome> => {
     try {
       if (await SecureStore.getItemAsync(CRED_ID_KEY)) {
@@ -112,15 +109,49 @@ export async function ensureApproverDevice(
       }
       await SecureStore.setItemAsync(CRED_ID_KEY, device.id);
       return { status: 'registered' };
-    } catch {
-      return { status: 'failed', reason: 'exception' };
+    } catch (e) {
+      return { status: 'failed', reason: `exception:${(e as Error)?.name ?? 'unknown'}` };
     }
   })();
-  try {
-    return await inFlight;
-  } finally {
-    inFlight = null;
+  return (async () => {
+    try {
+      return await inFlight!;
+    } finally {
+      inFlight = null;
+    }
+  })();
+}
+
+/**
+ * Idempotent: ensure this phone has a registered approver key. Called after
+ * auth lands. FAILS OPEN — never throws, never blocks login.
+ *
+ * #2707: registration requires a `register_approver_device` grant minted at
+ * login (`authenticatorRegisterGrantId` in the login/mfa-verify response) —
+ * proof of a fresh interactive login, independent of the bearer token. With no
+ * grant (cold-start restored session) there is nothing to prove with: return
+ * `deferred` WITHOUT touching the network; the device registers on the next
+ * real login. The ApprovalGate banner (mechanism introduced in #2683) surfaces
+ * this state with actionable copy.
+ */
+export async function ensureApproverDevice(
+  signer: HardwareSigner = getHardwareSigner(),
+  registerGrant?: string,
+): Promise<ApproverRegistrationOutcome> {
+  if (inFlight) {
+    if (!registerGrant) return inFlight;
+    // A grant-bearing call showed up while an attempt (almost certainly
+    // grant-less, since grants are read-and-cleared before the attempt even
+    // starts) is already running. Wait for it — if it already registered the
+    // device, our grant is simply unused and expires harmlessly; otherwise run
+    // our own attempt WITH the grant, still through the single in-flight slot.
+    const priorOutcome = await inFlight;
+    if (priorOutcome.status === 'registered' || priorOutcome.status === 'already_registered') {
+      return priorOutcome;
+    }
+    return runAttempt(signer, registerGrant);
   }
+  return runAttempt(signer, registerGrant);
 }
 
 /**

--- a/apps/mobile/src/services/approverDevice.ts
+++ b/apps/mobile/src/services/approverDevice.ts
@@ -8,10 +8,10 @@
  *
  * All functions are best-effort and FAIL OPEN: a technician with no registered
  * device (or no biometric hardware) simply approves without a proof (recorded
- * as L1). Registration now happens silently at login via
- * {@link ensureApproverDevice} — there is no manual setup step and no PIN. The
- * key activates server-side on its first approval signature (deferred
- * proof-of-possession).
+ * as L1). Registration now happens silently at login, using the login-minted
+ * grant, via {@link ensureApproverDevice} — there is no manual setup step and
+ * no PIN. The key activates server-side on its first approval signature
+ * (deferred proof-of-possession).
  */
 import * as SecureStore from 'expo-secure-store';
 import { getServerUrl } from './serverConfig';
@@ -57,57 +57,69 @@ async function authedFetch(path: string, init?: RequestInit): Promise<Response> 
 export type ApproverRegistrationOutcome =
   | { status: 'registered' }
   | { status: 'already_registered' }
+  | { status: 'deferred'; reason: 'no_reauth_grant' }
   | { status: 'unsupported'; reason: 'no_hardware' }
   | { status: 'failed'; reason: string };
 
+// Single-flight: RootNavigator's effect can re-fire while a registration is in
+// flight (checkAuth double-dispatches setCredentials on cold start). The grant
+// is single-use, so a duplicate attempt would burn a consumed grant into a 403
+// and overwrite a successful outcome. Concurrent callers share one attempt.
+let inFlight: Promise<ApproverRegistrationOutcome> | null = null;
+
 /**
  * Idempotent: ensure this phone has a registered approver key. Called after
- * auth lands (fresh login or restored session). FAILS OPEN — any error
- * (no hardware, offline) leaves the device unregistered; it provisions on a
- * later call. The biometric prompt is NOT triggered here (createKeys is
- * silent); the first approval signature is the first prompt and also activates
- * the device server-side.
+ * auth lands. FAILS OPEN — never throws, never blocks login.
  *
- * Fail-open is deliberate and unchanged: this never throws and never blocks
- * login. What changed is that it no longer fails *silently* — it reports the
- * outcome so the caller can surface it. The server currently requires a
- * `currentPassword` step-up on this endpoint that the app does not send, so the
- * common failure here is an HTTP 400, which used to be swallowed and left every
- * approval from this phone stuck at L1 with no indication to the user.
+ * #2707: registration requires a `register_approver_device` grant minted at
+ * login (`authenticatorRegisterGrantId` in the login/mfa-verify response) —
+ * proof of a fresh interactive login, independent of the bearer token. With no
+ * grant (cold-start restored session) there is nothing to prove with: return
+ * `deferred` WITHOUT touching the network; the device registers on the next
+ * real login. The #2683 banner surfaces this state with actionable copy.
  */
 export async function ensureApproverDevice(
   signer: HardwareSigner = getHardwareSigner(),
+  registerGrant?: string,
 ): Promise<ApproverRegistrationOutcome> {
+  if (inFlight) return inFlight;
+  inFlight = (async (): Promise<ApproverRegistrationOutcome> => {
+    try {
+      if (await SecureStore.getItemAsync(CRED_ID_KEY)) {
+        return { status: 'already_registered' };
+      }
+      if (!(await signer.isAvailable())) {
+        return { status: 'unsupported', reason: 'no_hardware' };
+      }
+      if (!registerGrant) {
+        return { status: 'deferred', reason: 'no_reauth_grant' };
+      }
+      const { publicKey } = await signer.createKeys();              // silent, no biometric
+      const res = await authedFetch('/api/v1/authenticator/devices', {
+        method: 'POST',
+        body: JSON.stringify({
+          publicKey,
+          label: 'This device',
+          registerGrantId: registerGrant,
+        }),
+      });
+      if (!res.ok) {
+        return { status: 'failed', reason: `http_${res.status}` };
+      }
+      const { device } = await res.json();
+      if (!device?.id) {
+        return { status: 'failed', reason: 'missing_device_id' };
+      }
+      await SecureStore.setItemAsync(CRED_ID_KEY, device.id);
+      return { status: 'registered' };
+    } catch {
+      return { status: 'failed', reason: 'exception' };
+    }
+  })();
   try {
-    if (await SecureStore.getItemAsync(CRED_ID_KEY)) {
-      return { status: 'already_registered' };
-    }
-    if (!(await signer.isAvailable())) {
-      return { status: 'unsupported', reason: 'no_hardware' };
-    }
-    const { publicKey } = await signer.createKeys();                // silent, no biometric
-    const res = await authedFetch('/api/v1/authenticator/devices', {
-      method: 'POST',
-      body: JSON.stringify({
-        kind: 'mobile_hw_key',
-        publicKey,
-        label: 'This device',
-        isPlatformBound: true,
-      }),
-    });
-    if (!res.ok) {
-      // Still fail open (we retry on a later call) — but say so.
-      return { status: 'failed', reason: `http_${res.status}` };
-    }
-    const { device } = await res.json();
-    if (!device?.id) {
-      return { status: 'failed', reason: 'missing_device_id' };
-    }
-    await SecureStore.setItemAsync(CRED_ID_KEY, device.id);
-    return { status: 'registered' };
-  } catch {
-    // fail open — never block login on approver provisioning
-    return { status: 'failed', reason: 'exception' };
+    return await inFlight;
+  } finally {
+    inFlight = null;
   }
 }
 

--- a/apps/mobile/src/store/authSlice.test.ts
+++ b/apps/mobile/src/store/authSlice.test.ts
@@ -155,14 +155,25 @@ describe('approver registration status', () => {
   it.each([
     ['fulfilled', () => logoutAsync.fulfilled(undefined, 'req-id')],
     ['rejected', () => logoutAsync.rejected(null, 'req-id')],
-  ])('clears on logoutAsync.%s — the next user must not inherit the banner', (_name, action) => {
+  ])('clears on logoutAsync.%s — the next user must not inherit the banner or grant', (_name, action) => {
     const store = makeStore();
     store.dispatch(setApproverRegistration({ status: 'failed', reason: 'http_400' }));
+    // Seed a live grant via loginAsync.fulfilled so we can prove logoutAsync
+    // clears it too — not just the synchronous `logout()` reducer.
+    store.dispatch(
+      loginAsync.fulfilled(
+        { token: 't', user: fakeUser, registerGrant: 'grant-1' } as any,
+        '',
+        { email: 'e', password: 'p' },
+      ),
+    );
+    expect(store.getState().auth.authenticatorRegisterGrantId).toBe('grant-1');
 
     store.dispatch(action() as never);
 
     expect(store.getState().auth.approverRegistration).toBe('idle');
     expect(store.getState().auth.approverRegistrationReason).toBeNull();
+    expect(store.getState().auth.authenticatorRegisterGrantId).toBeNull();
   });
 });
 

--- a/apps/mobile/src/store/authSlice.test.ts
+++ b/apps/mobile/src/store/authSlice.test.ts
@@ -31,11 +31,27 @@ vi.mock('@sentry/react-native', () => ({
   captureException: (...a: unknown[]) => sentry.captureException(...a),
 }));
 
-import authReducer, { logoutAsync, logout, setApproverRegistration } from './authSlice';
+import authReducer, {
+  loginAsync,
+  logoutAsync,
+  verifyMfaAsync,
+  logout,
+  setApproverRegistration,
+  setCredentials,
+  clearAuthenticatorRegisterGrant,
+} from './authSlice';
+import type { User } from '../services/api';
 
 function makeStore() {
   return configureStore({ reducer: { auth: authReducer } });
 }
+
+const fakeUser: User = {
+  id: 'user-1',
+  email: 'tech@example.com',
+  name: 'Tech Nician',
+  role: 'technician',
+};
 
 beforeEach(() => {
   api.logout.mockReset().mockResolvedValue(undefined);
@@ -147,5 +163,30 @@ describe('approver registration status', () => {
 
     expect(store.getState().auth.approverRegistration).toBe('idle');
     expect(store.getState().auth.approverRegistrationReason).toBeNull();
+  });
+});
+
+describe('authenticatorRegisterGrantId (#2707)', () => {
+  it('loginAsync.fulfilled stores the register grant; clearAuthenticatorRegisterGrant drops it', () => {
+    let state = authReducer(undefined, loginAsync.fulfilled(
+      { token: 't', user: fakeUser, registerGrant: 'grant-1' } as any, '', { email: 'e', password: 'p' }
+    ));
+    expect(state.authenticatorRegisterGrantId).toBe('grant-1');
+    state = authReducer(state, clearAuthenticatorRegisterGrant());
+    expect(state.authenticatorRegisterGrantId).toBeNull();
+  });
+
+  it('verifyMfaAsync.fulfilled stores the grant; logout clears it', () => {
+    let state = authReducer(undefined, verifyMfaAsync.fulfilled(
+      { token: 't', user: fakeUser, registerGrant: 'grant-2' } as any, '', { code: '123456', tempToken: 'tmp' }
+    ));
+    expect(state.authenticatorRegisterGrantId).toBe('grant-2');
+    state = authReducer(state, logout());
+    expect(state.authenticatorRegisterGrantId).toBeNull();
+  });
+
+  it('setCredentials (cold-start restore) does NOT set a grant', () => {
+    const state = authReducer(undefined, setCredentials({ token: 't', user: fakeUser }));
+    expect(state.authenticatorRegisterGrantId).toBeNull();
   });
 });

--- a/apps/mobile/src/store/authSlice.ts
+++ b/apps/mobile/src/store/authSlice.ts
@@ -18,7 +18,12 @@ export type PushRegistrationStatus = 'idle' | 'ok' | 'failed' | 'unsupported';
  * only `failed` is worth telling the user about, because it silently caps every
  * approval from this device at L1.
  */
-export type ApproverRegistrationStatus = 'idle' | 'registered' | 'failed' | 'unsupported';
+export type ApproverRegistrationStatus =
+  | 'idle'
+  | 'registered'
+  | 'deferred'
+  | 'failed'
+  | 'unsupported';
 
 interface AuthState {
   user: User | null;
@@ -30,6 +35,13 @@ interface AuthState {
   pushRegistrationReason: string | null;
   approverRegistration: ApproverRegistrationStatus;
   approverRegistrationReason: string | null;
+  /**
+   * #2707: single-use approver-register grant minted at login/mfa-verify.
+   * Memory-only — RootNavigator reads-and-clears it before attempting
+   * registration; it must never be persisted to SecureStore (see
+   * services/auth.ts storeToken/storeUser, which stay untouched).
+   */
+  authenticatorRegisterGrantId: string | null;
 }
 
 const initialState: AuthState = {
@@ -42,6 +54,7 @@ const initialState: AuthState = {
   pushRegistrationReason: null,
   approverRegistration: 'idle',
   approverRegistrationReason: null,
+  authenticatorRegisterGrantId: null,
 };
 
 export const loginAsync = createAsyncThunk(
@@ -57,7 +70,7 @@ export const loginAsync = createAsyncThunk(
       await storeToken(result.token);
       await storeUser(result.user);
 
-      return { token: result.token, user: result.user };
+      return { token: result.token, user: result.user, registerGrant: result.registerGrant };
     } catch (error: unknown) {
       const apiError = error as { message?: string };
       return rejectWithValue(apiError.message || 'Login failed');
@@ -138,6 +151,7 @@ const authSlice = createSlice({
       // show the next user on this phone the previous user's banner.
       state.approverRegistration = 'idle';
       state.approverRegistrationReason = null;
+      state.authenticatorRegisterGrantId = null;
     },
     clearError: (state) => {
       state.error = null;
@@ -163,6 +177,11 @@ const authSlice = createSlice({
       state.approverRegistration = action.payload.status;
       state.approverRegistrationReason = action.payload.reason ?? null;
     },
+    // #2707: the grant is single-use — RootNavigator takes it (read-and-clear)
+    // BEFORE the registration attempt so a re-fired effect can't replay it.
+    clearAuthenticatorRegisterGrant: (state) => {
+      state.authenticatorRegisterGrantId = null;
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -181,6 +200,7 @@ const authSlice = createSlice({
           state.token = action.payload.token;
           state.user = action.payload.user;
           state.mfaChallenge = null;
+          state.authenticatorRegisterGrantId = action.payload.registerGrant ?? null;
         }
       })
       .addCase(loginAsync.rejected, (state, action) => {
@@ -197,6 +217,7 @@ const authSlice = createSlice({
         state.user = action.payload.user;
         state.error = null;
         state.mfaChallenge = null;
+        state.authenticatorRegisterGrantId = action.payload.registerGrant ?? null;
       })
       .addCase(verifyMfaAsync.rejected, (state, action) => {
         state.isLoading = false;
@@ -213,6 +234,7 @@ const authSlice = createSlice({
         state.mfaChallenge = null;
         state.approverRegistration = 'idle';
         state.approverRegistrationReason = null;
+        state.authenticatorRegisterGrantId = null;
       })
       .addCase(logoutAsync.rejected, (state) => {
         state.user = null;
@@ -222,6 +244,7 @@ const authSlice = createSlice({
         state.mfaChallenge = null;
         state.approverRegistration = 'idle';
         state.approverRegistrationReason = null;
+        state.authenticatorRegisterGrantId = null;
       });
   },
 });
@@ -234,5 +257,6 @@ export const {
   setLoading,
   setPushRegistration,
   setApproverRegistration,
+  clearAuthenticatorRegisterGrant,
 } = authSlice.actions;
 export default authSlice.reducer;

--- a/apps/mobile/src/store/lifecycleSlice.test.ts
+++ b/apps/mobile/src/store/lifecycleSlice.test.ts
@@ -14,6 +14,13 @@ vi.mock('../services/installationId', () => ({
   getOrCreateInstallationId: async () => 'install-test',
 }));
 
+// services/api now imports @sentry/react-native (#2707 header-loss breadcrumb);
+// mock it so this jsdom-less suite doesn't pull real react-native in.
+vi.mock('@sentry/react-native', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}));
+
 import reducer, {
   blockPairedDevice,
   fetchPairedDevices,

--- a/apps/web/src/components/settings/ApproverDevicesSection.test.tsx
+++ b/apps/web/src/components/settings/ApproverDevicesSection.test.tsx
@@ -107,8 +107,10 @@ describe('ApproverDevicesSection', () => {
     await waitFor(() => expect(listApproverDevicesMock).toHaveBeenCalledTimes(2));
   });
 
-  it('shows an incorrect-password error and preserves the label on a 401', async () => {
-    const err = Object.assign(new Error('Verification failed.'), { status: 401 });
+  it('shows an incorrect-password error and preserves the label on a 401 (credential failure)', async () => {
+    // The real API returns the literal string "Invalid credentials" for a
+    // rejected re-auth proof (routes/auth/helpers.ts, routes/auth/mfa.ts).
+    const err = Object.assign(new Error('Invalid credentials'), { status: 401 });
     registerApproverDeviceMock.mockRejectedValueOnce(err);
     render(<ApproverDevicesSection passkeyCount={0} mfaMethod={null} />);
     await screen.findByTestId('approver-device-dev-1');
@@ -123,6 +125,31 @@ describe('ApproverDevicesSection', () => {
 
     await waitFor(() => expect(showToastMock).toHaveBeenCalledWith({ type: 'error', message: 'Incorrect password.' }));
     expect((screen.getByTestId('approver-device-label-input') as HTMLInputElement).value).toBe('My workstation');
+  });
+
+  it('shows a session-expired error (not "Incorrect password") on a 401 whose message is NOT the credential-failure string', async () => {
+    // A rejected bearer token (auth middleware) also 401s, but with a message
+    // like "Invalid or expired token" rather than the literal "Invalid
+    // credentials" the credential-check handlers return. Because the mint
+    // calls use `skipUnauthorizedRetry`, this must not be mislabeled as a
+    // wrong password.
+    const err = Object.assign(new Error('Invalid or expired token'), { status: 401 });
+    registerApproverDeviceMock.mockRejectedValueOnce(err);
+    render(<ApproverDevicesSection passkeyCount={0} mfaMethod={null} />);
+    await screen.findByTestId('approver-device-dev-1');
+
+    fireEvent.change(screen.getByTestId('approver-stepup-password'), {
+      target: { value: 'hunter2' },
+    });
+    fireEvent.click(screen.getByTestId('approver-device-register'));
+
+    await waitFor(() =>
+      expect(showToastMock).toHaveBeenCalledWith({
+        type: 'error',
+        message: 'Session expired — reload the page and try again.',
+      }),
+    );
+    expect(showToastMock).not.toHaveBeenCalledWith({ type: 'error', message: 'Incorrect password.' });
   });
 
   it('clears the re-auth value but keeps the label on a 403 (grant expired)', async () => {
@@ -147,7 +174,7 @@ describe('ApproverDevicesSection', () => {
   });
 
   it('shows a passkey-specific error (not "Incorrect password") on a 401 in the passkey tier', async () => {
-    const err = Object.assign(new Error('Verification failed.'), { status: 401 });
+    const err = Object.assign(new Error('Invalid credentials'), { status: 401 });
     registerApproverDeviceMock.mockRejectedValueOnce(err);
     render(<ApproverDevicesSection passkeyCount={1} mfaMethod={null} />);
     await screen.findByTestId('approver-device-dev-1');
@@ -159,6 +186,25 @@ describe('ApproverDevicesSection', () => {
     );
     expect(showToastMock).not.toHaveBeenCalledWith({ type: 'error', message: 'Incorrect password.' });
   });
+
+  it.each(['NotAllowedError', 'AbortError'])(
+    'shows a cancellation message (not raw DOMException text) when the WebAuthn ceremony rejects with %s',
+    async (name) => {
+      const domException = Object.assign(new Error('The operation either timed out or was not allowed.'), { name });
+      registerApproverDeviceMock.mockRejectedValueOnce(domException);
+      render(<ApproverDevicesSection passkeyCount={1} mfaMethod={null} />);
+      await screen.findByTestId('approver-device-dev-1');
+
+      fireEvent.click(screen.getByTestId('approver-device-register'));
+
+      await waitFor(() =>
+        expect(showToastMock).toHaveBeenCalledWith({ type: 'error', message: 'Registration was cancelled.' }),
+      );
+      expect(showToastMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('operation either timed out') }),
+      );
+    },
+  );
 
   it('shows stronger-factor guidance on a 403 whose message is stronger_factor_required', async () => {
     const err = Object.assign(new Error('stronger_factor_required'), { status: 403 });

--- a/apps/web/src/components/settings/ApproverDevicesSection.test.tsx
+++ b/apps/web/src/components/settings/ApproverDevicesSection.test.tsx
@@ -53,7 +53,7 @@ describe('ApproverDevicesSection', () => {
   });
 
   it('lists approver devices with label, platform-bound badge, and dates', async () => {
-    render(<ApproverDevicesSection />);
+    render(<ApproverDevicesSection passkeyCount={0} mfaMethod={null} />);
 
     const row = await screen.findByTestId('approver-device-dev-1');
     expect(row).toBeTruthy();
@@ -64,13 +64,13 @@ describe('ApproverDevicesSection', () => {
 
   it('shows an empty state when no devices are registered', async () => {
     listApproverDevicesMock.mockResolvedValueOnce([]);
-    render(<ApproverDevicesSection />);
+    render(<ApproverDevicesSection passkeyCount={0} mfaMethod={null} />);
 
     expect(await screen.findByTestId('approver-devices-empty')).toBeTruthy();
   });
 
-  it('registers this device via registerApproverDevice and reloads the list', async () => {
-    render(<ApproverDevicesSection />);
+  it('registers this device via registerApproverDevice (passkey tier) and reloads the list', async () => {
+    render(<ApproverDevicesSection passkeyCount={1} mfaMethod={null} />);
     await screen.findByTestId('approver-device-dev-1');
 
     fireEvent.change(screen.getByTestId('approver-device-label-input'), {
@@ -78,9 +78,72 @@ describe('ApproverDevicesSection', () => {
     });
     fireEvent.click(screen.getByTestId('approver-device-register'));
 
-    await waitFor(() => expect(registerApproverDeviceMock).toHaveBeenCalledWith('My workstation'));
+    await waitFor(() =>
+      expect(registerApproverDeviceMock).toHaveBeenCalledWith('My workstation', { method: 'passkey' }),
+    );
     // List is reloaded after a successful registration.
     await waitFor(() => expect(listApproverDevicesMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('registers via password re-auth when the user has no passkey/TOTP', async () => {
+    render(<ApproverDevicesSection passkeyCount={0} mfaMethod={null} />);
+    await screen.findByTestId('approver-device-dev-1');
+
+    // Submit is disabled until a password is entered.
+    expect(screen.getByTestId('approver-device-register')).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('approver-stepup-password'), {
+      target: { value: 'hunter2' },
+    });
+    expect(screen.getByTestId('approver-device-register')).not.toBeDisabled();
+    fireEvent.click(screen.getByTestId('approver-device-register'));
+
+    await waitFor(() =>
+      expect(registerApproverDeviceMock).toHaveBeenCalledWith('This device', {
+        method: 'password',
+        password: 'hunter2',
+      }),
+    );
+    await waitFor(() => expect(listApproverDevicesMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows an incorrect-password error and preserves the label on a 401', async () => {
+    const err = Object.assign(new Error('Verification failed.'), { status: 401 });
+    registerApproverDeviceMock.mockRejectedValueOnce(err);
+    render(<ApproverDevicesSection passkeyCount={0} mfaMethod={null} />);
+    await screen.findByTestId('approver-device-dev-1');
+
+    fireEvent.change(screen.getByTestId('approver-device-label-input'), {
+      target: { value: 'My workstation' },
+    });
+    fireEvent.change(screen.getByTestId('approver-stepup-password'), {
+      target: { value: 'wrong' },
+    });
+    fireEvent.click(screen.getByTestId('approver-device-register'));
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith({ type: 'error', message: 'Incorrect password.' }));
+    expect((screen.getByTestId('approver-device-label-input') as HTMLInputElement).value).toBe('My workstation');
+  });
+
+  it('clears the re-auth value but keeps the label on a 403 (grant expired)', async () => {
+    const err = Object.assign(new Error('Grant expired.'), { status: 403 });
+    registerApproverDeviceMock.mockRejectedValueOnce(err);
+    render(<ApproverDevicesSection passkeyCount={0} mfaMethod={null} />);
+    await screen.findByTestId('approver-device-dev-1');
+
+    fireEvent.change(screen.getByTestId('approver-device-label-input'), {
+      target: { value: 'My workstation' },
+    });
+    fireEvent.change(screen.getByTestId('approver-stepup-password'), {
+      target: { value: 'hunter2' },
+    });
+    fireEvent.click(screen.getByTestId('approver-device-register'));
+
+    await waitFor(() =>
+      expect(showToastMock).toHaveBeenCalledWith({ type: 'error', message: 'Verification expired — please verify again.' }),
+    );
+    expect((screen.getByTestId('approver-device-label-input') as HTMLInputElement).value).toBe('My workstation');
+    expect((screen.getByTestId('approver-stepup-password') as HTMLInputElement).value).toBe('');
   });
 
   it('lists a registered mobile_hw_key phone alongside the register-this-browser action', async () => {
@@ -93,10 +156,13 @@ describe('ApproverDevicesSection', () => {
         lastUsedAt: null,
       }),
     ]);
-    render(<ApproverDevicesSection />);
+    render(<ApproverDevicesSection passkeyCount={0} mfaMethod={null} />);
 
     await waitFor(() => screen.getByText('iPhone 16 Pro'));
     expect(screen.getByTestId('approver-device-d1')).toBeTruthy();
+    // A device that has never been used yet (lastUsedAt === null) shows the
+    // pending badge until it completes its first approval.
+    expect(screen.getByTestId('approver-device-pending-d1')).toBeTruthy();
     // The browser-registration affordance is reframed as an additive, optional
     // path below the list (not the only way to get an approver device).
     expect(screen.getByRole('heading', { name: /register this browser/i })).toBeTruthy();
@@ -104,14 +170,14 @@ describe('ApproverDevicesSection', () => {
 
   it('points unregistered users to the mobile app in the empty state', async () => {
     listApproverDevicesMock.mockResolvedValueOnce([]);
-    render(<ApproverDevicesSection />);
+    render(<ApproverDevicesSection passkeyCount={0} mfaMethod={null} />);
 
     const empty = await screen.findByTestId('approver-devices-empty');
     expect(empty.textContent).toMatch(/mobile app/i);
   });
 
   it('revokes a device after confirming in the dialog', async () => {
-    render(<ApproverDevicesSection />);
+    render(<ApproverDevicesSection passkeyCount={0} mfaMethod={null} />);
     await screen.findByTestId('approver-device-dev-1');
 
     fireEvent.click(screen.getByTestId('approver-device-revoke-dev-1'));

--- a/apps/web/src/components/settings/ApproverDevicesSection.test.tsx
+++ b/apps/web/src/components/settings/ApproverDevicesSection.test.tsx
@@ -146,6 +146,42 @@ describe('ApproverDevicesSection', () => {
     expect((screen.getByTestId('approver-stepup-password') as HTMLInputElement).value).toBe('');
   });
 
+  it('shows a passkey-specific error (not "Incorrect password") on a 401 in the passkey tier', async () => {
+    const err = Object.assign(new Error('Verification failed.'), { status: 401 });
+    registerApproverDeviceMock.mockRejectedValueOnce(err);
+    render(<ApproverDevicesSection passkeyCount={1} mfaMethod={null} />);
+    await screen.findByTestId('approver-device-dev-1');
+
+    fireEvent.click(screen.getByTestId('approver-device-register'));
+
+    await waitFor(() =>
+      expect(showToastMock).toHaveBeenCalledWith({ type: 'error', message: 'Passkey verification failed — try again.' }),
+    );
+    expect(showToastMock).not.toHaveBeenCalledWith({ type: 'error', message: 'Incorrect password.' });
+  });
+
+  it('shows stronger-factor guidance on a 403 whose message is stronger_factor_required', async () => {
+    const err = Object.assign(new Error('stronger_factor_required'), { status: 403 });
+    registerApproverDeviceMock.mockRejectedValueOnce(err);
+    render(<ApproverDevicesSection passkeyCount={0} mfaMethod={null} />);
+    await screen.findByTestId('approver-device-dev-1');
+
+    fireEvent.change(screen.getByTestId('approver-device-label-input'), {
+      target: { value: 'My workstation' },
+    });
+    fireEvent.change(screen.getByTestId('approver-stepup-password'), {
+      target: { value: 'hunter2' },
+    });
+    fireEvent.click(screen.getByTestId('approver-device-register'));
+
+    await waitFor(() =>
+      expect(showToastMock).toHaveBeenCalledWith({
+        type: 'error',
+        message: 'Use your passkey or authenticator code instead — reload the page to update your options.',
+      }),
+    );
+  });
+
   it('lists a registered mobile_hw_key phone alongside the register-this-browser action', async () => {
     listApproverDevicesMock.mockResolvedValueOnce([
       deviceFixture({

--- a/apps/web/src/components/settings/ApproverDevicesSection.tsx
+++ b/apps/web/src/components/settings/ApproverDevicesSection.tsx
@@ -8,10 +8,12 @@ import {
   revokeApproverDevice,
   renameApproverDevice,
   type ApproverDevice,
+  type RegisterReauth,
 } from '../../stores/authenticator';
 import { runAction, ActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
 import { formatAbsolute, formatRelative } from '../account/relativeTime';
+import StepUpPrompt, { pickReauthTier, type ReauthTier } from './StepUpPrompt';
 
 /**
  * Profile "Approval security" section (Breeze Authenticator Phase 2).
@@ -37,17 +39,25 @@ function deviceTitle(d: ApproverDevice): string {
 
 const OK_RESPONSE = { ok: true, status: 200, json: async () => ({ success: true }) } as Response;
 
-export default function ApproverDevicesSection() {
+export default function ApproverDevicesSection({
+  passkeyCount,
+  mfaMethod,
+}: {
+  passkeyCount: number;
+  mfaMethod: string | null;
+}) {
   const { t } = useTranslation('settings');
   const [devices, setDevices] = useState<ApproverDevice[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | undefined>();
   const [label, setLabel] = useState('');
+  const [reauthValue, setReauthValue] = useState('');
   const [isRegistering, setIsRegistering] = useState(false);
   const [confirm, setConfirm] = useState<ConfirmState | null>(null);
   const [mutatingId, setMutatingId] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingLabel, setEditingLabel] = useState('');
+  const tier: ReauthTier = pickReauthTier(passkeyCount, mfaMethod);
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -68,28 +78,67 @@ export default function ApproverDevicesSection() {
 
   const activeDevices = useMemo(() => devices.filter((d) => !d.disabledAt), [devices]);
 
+  const buildReauth = (): RegisterReauth | null => {
+    if (tier === 'passkey') return { method: 'passkey' };
+    if (tier === 'totp') return reauthValue.length === 6 ? { method: 'totp', code: reauthValue } : null;
+    return reauthValue.length > 0 ? { method: 'password', password: reauthValue } : null;
+  };
+
+  const mapRegisterError = (err: unknown): string => {
+    const status = (err as { status?: number })?.status;
+    if (status === 401) {
+      return tier === 'totp'
+        ? t('approverDevicesSection.incorrectCode')
+        : t('approverDevicesSection.incorrectPassword');
+    }
+    if (status === 429) return t('approverDevicesSection.tooManyAttemptsTryAgainInAFewMinutes');
+    if (status === 403) return t('approverDevicesSection.verificationExpiredPleaseVerifyAgain');
+    return err instanceof Error ? err.message : t('approverDevicesSection.failedToRegisterThisDevice');
+  };
+
   const handleRegister = async () => {
     if (isRegistering) return;
+    const reauth = buildReauth();
+    if (!reauth) return; // submit disabled anyway
     const trimmed = label.trim() || 'This device';
     setIsRegistering(true);
     try {
       await runAction({
         // registerApproverDevice runs the full WebAuthn registration ceremony
-        // (options → Touch ID/Hello → verify) and resolves void on success; a
-        // user cancellation or a non-2xx verify rejects, which runAction turns
-        // into an error toast.
+        // (options → Touch ID/Hello → verify) and resolves void on success. A
+        // rejected re-auth (wrong code/password, rate-limited, expired grant)
+        // throws with a `status`. Convert that into a non-2xx Response here —
+        // rather than letting it escape request() as a throw — so runAction's
+        // status-aware isApiFailure branch carries the real status through to
+        // the toast and to the 403 handling below (a throw straight out of
+        // `request()` always collapses to a generic status-0 "network error"
+        // toast, per runAction's documented contract in runAction.test.ts).
         request: async () => {
-          await registerApproverDevice(trimmed);
-          return OK_RESPONSE;
+          try {
+            await registerApproverDevice(trimmed, reauth);
+            return OK_RESPONSE;
+          } catch (err) {
+            const status = (err as { status?: number })?.status ?? 500;
+            return { ok: false, status, json: async () => ({ error: mapRegisterError(err) }) } as Response;
+          }
         },
         errorFallback: t('approverDevicesSection.failedToRegisterThisDevice'),
         successMessage: t('approverDevicesSection.thisDeviceCanNowApproveRequests'),
+        // A 401 here means "wrong code/password", not "stale access token" —
+        // must be toasted, not silently swallowed into a login redirect.
+        treatUnauthorizedAsError: true,
       });
       setLabel('');
+      setReauthValue('');
       await load();
     } catch (err) {
-      if (err instanceof ActionError) return; // already toasted by runAction
-      showToast({ type: 'error', message: err instanceof Error ? err.message : t('approverDevicesSection.failedToRegisterThisDevice') });
+      if (err instanceof ActionError) {
+        // 403 = grant expired mid-ceremony (>300s in the WebAuthn prompt):
+        // keep the label, clear the proof, and ask the user to verify again.
+        if (err.status === 403) setReauthValue('');
+        return; // already toasted by runAction
+      }
+      showToast({ type: 'error', message: mapRegisterError(err) });
     } finally {
       setIsRegistering(false);
     }
@@ -209,6 +258,14 @@ export default function ApproverDevicesSection() {
                         >
                           {t('approverDevicesSection.platformBound')}</span>
                       )}
+                      {device.lastUsedAt === null && (
+                        <span
+                          data-testid={`approver-device-pending-${device.id}`}
+                          className="rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600"
+                        >
+                          {t('approverDevicesSection.pendingActivatesOnFirstApproval')}
+                        </span>
+                      )}
                     </div>
                     <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
                       <dt>{t('approverDevicesSection.registered')}</dt>
@@ -291,10 +348,11 @@ export default function ApproverDevicesSection() {
             data-testid="approver-device-label-input"
           />
         </div>
+        <StepUpPrompt tier={tier} reauthValue={reauthValue} onChange={setReauthValue} disabled={isRegistering} />
         <button
           type="button"
           onClick={() => void handleRegister()}
-          disabled={isRegistering}
+          disabled={isRegistering || buildReauth() === null}
           data-testid="approver-device-register"
           className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
         >

--- a/apps/web/src/components/settings/ApproverDevicesSection.tsx
+++ b/apps/web/src/components/settings/ApproverDevicesSection.tsx
@@ -85,22 +85,43 @@ export default function ApproverDevicesSection({
   };
 
   const mapRegisterError = (err: unknown): string => {
+    // A user-cancelled/dismissed WebAuthn ceremony (startRegistration in the
+    // register call itself, or startAuthentication inside the passkey re-auth
+    // mint) rejects with a DOMException — `NotAllowedError` (dismissed/denied)
+    // or `AbortError` (browser aborted it) — that carries no `status`. Must be
+    // caught before the status checks below, or it falls through to the final
+    // `err.message` branch and shows raw browser jargon.
+    if (err instanceof Error && (err.name === 'NotAllowedError' || err.name === 'AbortError')) {
+      return t('approverDevicesSection.registrationCancelled');
+    }
     const status = (err as { status?: number })?.status;
     if (status === 401) {
+      // Because the mint calls use `skipUnauthorizedRetry`, a 401 here is
+      // EITHER a rejected re-auth proof (wrong password/code, burned/replayed
+      // WebAuthn assertion — the handler returns the literal string
+      // "Invalid credentials", see routes/auth/helpers.ts and routes/auth/mfa.ts)
+      // OR a rejected bearer token (auth middleware — various messages, e.g.
+      // "Invalid or expired token"; see middleware/auth.ts). Only the former
+      // is fixed by retyping the same field; the latter needs a page reload.
+      const isCredentialFailure = err instanceof Error && err.message === 'Invalid credentials';
+      if (!isCredentialFailure) return t('approverDevicesSection.sessionExpiredReloadAndTryAgain');
       if (tier === 'totp') return t('approverDevicesSection.incorrectCode');
-      // The passkey tier never shows a password field — a 401 here means the
-      // WebAuthn assertion itself was rejected (burned/replayed challenge),
-      // not a wrong password, so "Incorrect password." would be nonsensical.
+      // The passkey tier never shows a password field — a credential-failure
+      // 401 here means the WebAuthn assertion itself was rejected
+      // (burned/replayed challenge), not a wrong password, so "Incorrect
+      // password." would be nonsensical.
       if (tier === 'passkey') return t('approverDevicesSection.passkeyVerificationFailed');
       return t('approverDevicesSection.incorrectPassword');
     }
     if (status === 429) return t('approverDevicesSection.tooManyAttemptsTryAgainInAFewMinutes');
     if (status === 403) {
-      // POST /authenticator/register-grant 403s with this exact error string
-      // when the account gained a stronger factor (passkey/TOTP) in another
-      // tab since the page loaded — the password field shown here is stale.
-      // Point the user at reloading rather than letting them retry the same
-      // password forever.
+      // POST /authenticator/register-grant (and the step-up mint) 403 for two
+      // distinct reasons: the register/step-up grant expired mid-ceremony
+      // (>300s in the WebAuthn prompt), or the account gained a stronger
+      // factor (passkey/TOTP) in another tab since the page loaded — signaled
+      // by the exact error string "stronger_factor_required" below, where the
+      // password field shown here is stale. Point the user at reloading
+      // rather than letting them retry the same password forever.
       if (err instanceof Error && err.message === 'stronger_factor_required') {
         return t('approverDevicesSection.useYourPasskeyOrAuthenticatorCodeInstead');
       }

--- a/apps/web/src/components/settings/ApproverDevicesSection.tsx
+++ b/apps/web/src/components/settings/ApproverDevicesSection.tsx
@@ -87,12 +87,25 @@ export default function ApproverDevicesSection({
   const mapRegisterError = (err: unknown): string => {
     const status = (err as { status?: number })?.status;
     if (status === 401) {
-      return tier === 'totp'
-        ? t('approverDevicesSection.incorrectCode')
-        : t('approverDevicesSection.incorrectPassword');
+      if (tier === 'totp') return t('approverDevicesSection.incorrectCode');
+      // The passkey tier never shows a password field — a 401 here means the
+      // WebAuthn assertion itself was rejected (burned/replayed challenge),
+      // not a wrong password, so "Incorrect password." would be nonsensical.
+      if (tier === 'passkey') return t('approverDevicesSection.passkeyVerificationFailed');
+      return t('approverDevicesSection.incorrectPassword');
     }
     if (status === 429) return t('approverDevicesSection.tooManyAttemptsTryAgainInAFewMinutes');
-    if (status === 403) return t('approverDevicesSection.verificationExpiredPleaseVerifyAgain');
+    if (status === 403) {
+      // POST /authenticator/register-grant 403s with this exact error string
+      // when the account gained a stronger factor (passkey/TOTP) in another
+      // tab since the page loaded — the password field shown here is stale.
+      // Point the user at reloading rather than letting them retry the same
+      // password forever.
+      if (err instanceof Error && err.message === 'stronger_factor_required') {
+        return t('approverDevicesSection.useYourPasskeyOrAuthenticatorCodeInstead');
+      }
+      return t('approverDevicesSection.verificationExpiredPleaseVerifyAgain');
+    }
     return err instanceof Error ? err.message : t('approverDevicesSection.failedToRegisterThisDevice');
   };
 
@@ -138,6 +151,10 @@ export default function ApproverDevicesSection({
         if (err.status === 403) setReauthValue('');
         return; // already toasted by runAction
       }
+      // Defensive net only: every documented failure path (401/403/429) is
+      // converted into a Response above and surfaced via runAction's
+      // ActionError branch. This only fires for an error escaping runAction
+      // itself (e.g. a bug in runAction), not a live path in normal use.
       showToast({ type: 'error', message: mapRegisterError(err) });
     } finally {
       setIsRegistering(false);

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -28,6 +28,7 @@ type User = {
   email: string;
   avatarUrl?: string;
   mfaEnabled?: boolean;
+  mfaMethod?: string | null;
   preferences?: UserPreferences;
 };
 
@@ -911,7 +912,7 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       </div>
 
       {/* Approval security (Breeze Authenticator) */}
-      <ApproverDevicesSection />
+      <ApproverDevicesSection passkeyCount={passkeys.length} mfaMethod={user?.mfaMethod ?? null} />
       <ThemingSettings
         preferences={user?.preferences}
         onSaved={(preferences) => setUser(prev => (prev ? { ...prev, preferences } : prev))}

--- a/apps/web/src/components/settings/StepUpPrompt.test.tsx
+++ b/apps/web/src/components/settings/StepUpPrompt.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StepUpPrompt, { pickReauthTier } from './StepUpPrompt';
+
+describe('pickReauthTier', () => {
+  it.each([
+    [2, 'totp', 'passkey'],     // passkey wins even with TOTP
+    [0, 'totp', 'totp'],
+    [0, 'sms', 'password'],     // SMS users take the password path (spec)
+    [0, null, 'password'],
+  ] as const)('passkeys=%s mfaMethod=%s → %s', (passkeyCount, mfaMethod, expected) => {
+    expect(pickReauthTier(passkeyCount, mfaMethod)).toBe(expected);
+  });
+});
+
+describe('StepUpPrompt', () => {
+  it('renders a code input for totp tier', () => {
+    render(<StepUpPrompt tier="totp" reauthValue="" onChange={vi.fn()} disabled={false} />);
+    expect(screen.getByTestId('approver-stepup-code')).toBeTruthy();
+  });
+  it('renders a password input for password tier', () => {
+    render(<StepUpPrompt tier="password" reauthValue="" onChange={vi.fn()} disabled={false} />);
+    expect(screen.getByTestId('approver-stepup-password')).toBeTruthy();
+  });
+  it('renders only the explainer for passkey tier (ceremony happens on submit)', () => {
+    render(<StepUpPrompt tier="passkey" reauthValue="" onChange={vi.fn()} disabled={false} />);
+    expect(screen.queryByTestId('approver-stepup-code')).toBeNull();
+    expect(screen.queryByTestId('approver-stepup-password')).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/StepUpPrompt.tsx
+++ b/apps/web/src/components/settings/StepUpPrompt.tsx
@@ -21,7 +21,8 @@ type Props = {
 /**
  * Re-auth input for approver-device registration. Reusable: ProfilePage's
  * add-passkey flow (currently dead-ends for MFA-protected users on
- * existing_factor_step_up_required) is the intended second consumer.
+ * existing_factor_step_up_required) is the intended second consumer —
+ * tracked as a PR #2710 follow-up, not yet wired up.
  */
 export default function StepUpPrompt({ tier, reauthValue, onChange, disabled }: Props) {
   const { t } = useTranslation('settings');

--- a/apps/web/src/components/settings/StepUpPrompt.tsx
+++ b/apps/web/src/components/settings/StepUpPrompt.tsx
@@ -1,0 +1,76 @@
+import { useTranslation } from 'react-i18next';
+
+export type ReauthTier = 'passkey' | 'totp' | 'password';
+
+/** Strongest-available-factor tiering — mirrors the server gate
+ * (`userHasStrongerReauthFactor`): passkey → TOTP → password. SMS-method
+ * accounts fall to password (no authenticated step-up SMS sender; spec #2707). */
+export function pickReauthTier(passkeyCount: number, mfaMethod: string | null): ReauthTier {
+  if (passkeyCount > 0) return 'passkey';
+  if (mfaMethod === 'totp') return 'totp';
+  return 'password';
+}
+
+type Props = {
+  tier: ReauthTier;
+  reauthValue: string;
+  onChange: (value: string) => void;
+  disabled: boolean;
+};
+
+/**
+ * Re-auth input for approver-device registration. Reusable: ProfilePage's
+ * add-passkey flow (currently dead-ends for MFA-protected users on
+ * existing_factor_step_up_required) is the intended second consumer.
+ */
+export default function StepUpPrompt({ tier, reauthValue, onChange, disabled }: Props) {
+  const { t } = useTranslation('settings');
+
+  if (tier === 'passkey') {
+    return (
+      <p className="text-xs text-muted-foreground" data-testid="approver-stepup-passkey-note">
+        {t('stepUpPrompt.youWillConfirmWithYourPasskey')}
+      </p>
+    );
+  }
+
+  if (tier === 'totp') {
+    return (
+      <div className="space-y-2">
+        <label className="text-sm font-medium" htmlFor="approver-stepup-code">
+          {t('stepUpPrompt.authenticatorCode')}
+        </label>
+        <input
+          id="approver-stepup-code"
+          type="text"
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          maxLength={6}
+          value={reauthValue}
+          onChange={(e) => onChange(e.target.value.replace(/\D/g, ''))}
+          className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+          disabled={disabled}
+          data-testid="approver-stepup-code"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-medium" htmlFor="approver-stepup-password">
+        {t('stepUpPrompt.confirmYourPassword')}
+      </label>
+      <input
+        id="approver-stepup-password"
+        type="password"
+        autoComplete="current-password"
+        value={reauthValue}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+        disabled={disabled}
+        data-testid="approver-stepup-password"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1398,7 +1398,17 @@
     "registering": "Registrieren…",
     "registerThisDevice": "Registrieren Sie dieses Gerät",
     "revoking": "Widerrufen…",
-    "revokeDevice": "Gerät widerrufen"
+    "revokeDevice": "Gerät widerrufen",
+    "incorrectCode": "Falscher Code.",
+    "incorrectPassword": "Falsches Passwort.",
+    "tooManyAttemptsTryAgainInAFewMinutes": "Zu viele Versuche – versuchen Sie es in ein paar Minuten erneut.",
+    "verificationExpiredPleaseVerifyAgain": "Verifizierung abgelaufen – bitte erneut verifizieren.",
+    "pendingActivatesOnFirstApproval": "Ausstehend – wird bei der ersten Genehmigung aktiviert"
+  },
+  "stepUpPrompt": {
+    "youWillConfirmWithYourPasskey": "Sie bestätigen bei der Registrierung mit Ihrem Passkey (Touch ID / Windows Hello).",
+    "authenticatorCode": "Authentifizierungscode",
+    "confirmYourPassword": "Bestätigen Sie Ihr Passwort"
   },
   "cannedResponsesCard": {
     "cannedResponses": "Vorgefertigte Antworten",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1401,8 +1401,10 @@
     "revokeDevice": "Gerät widerrufen",
     "incorrectCode": "Falscher Code.",
     "incorrectPassword": "Falsches Passwort.",
+    "passkeyVerificationFailed": "Passkey-Verifizierung fehlgeschlagen – bitte erneut versuchen.",
     "tooManyAttemptsTryAgainInAFewMinutes": "Zu viele Versuche – versuchen Sie es in ein paar Minuten erneut.",
     "verificationExpiredPleaseVerifyAgain": "Verifizierung abgelaufen – bitte erneut verifizieren.",
+    "useYourPasskeyOrAuthenticatorCodeInstead": "Verwenden Sie stattdessen Ihren Passkey oder Authentifizierungscode – laden Sie die Seite neu, um Ihre Optionen zu aktualisieren.",
     "pendingActivatesOnFirstApproval": "Ausstehend – wird bei der ersten Genehmigung aktiviert"
   },
   "stepUpPrompt": {

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1405,7 +1405,9 @@
     "tooManyAttemptsTryAgainInAFewMinutes": "Zu viele Versuche – versuchen Sie es in ein paar Minuten erneut.",
     "verificationExpiredPleaseVerifyAgain": "Verifizierung abgelaufen – bitte erneut verifizieren.",
     "useYourPasskeyOrAuthenticatorCodeInstead": "Verwenden Sie stattdessen Ihren Passkey oder Authentifizierungscode – laden Sie die Seite neu, um Ihre Optionen zu aktualisieren.",
-    "pendingActivatesOnFirstApproval": "Ausstehend – wird bei der ersten Genehmigung aktiviert"
+    "pendingActivatesOnFirstApproval": "Ausstehend – wird bei der ersten Genehmigung aktiviert",
+    "sessionExpiredReloadAndTryAgain": "Sitzung abgelaufen – laden Sie die Seite neu und versuchen Sie es erneut.",
+    "registrationCancelled": "Die Registrierung wurde abgebrochen."
   },
   "stepUpPrompt": {
     "youWillConfirmWithYourPasskey": "Sie bestätigen bei der Registrierung mit Ihrem Passkey (Touch ID / Windows Hello).",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1398,7 +1398,17 @@
     "registering": "Registering…",
     "registerThisDevice": "Register this device",
     "revoking": "Revoking…",
-    "revokeDevice": "Revoke device"
+    "revokeDevice": "Revoke device",
+    "incorrectCode": "Incorrect code.",
+    "incorrectPassword": "Incorrect password.",
+    "tooManyAttemptsTryAgainInAFewMinutes": "Too many attempts — try again in a few minutes.",
+    "verificationExpiredPleaseVerifyAgain": "Verification expired — please verify again.",
+    "pendingActivatesOnFirstApproval": "Pending — activates on first approval"
+  },
+  "stepUpPrompt": {
+    "youWillConfirmWithYourPasskey": "You'll confirm with your passkey (Touch ID / Windows Hello) when you register.",
+    "authenticatorCode": "Authenticator code",
+    "confirmYourPassword": "Confirm your password"
   },
   "cannedResponsesCard": {
     "cannedResponses": "Canned responses",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1401,8 +1401,10 @@
     "revokeDevice": "Revoke device",
     "incorrectCode": "Incorrect code.",
     "incorrectPassword": "Incorrect password.",
+    "passkeyVerificationFailed": "Passkey verification failed — try again.",
     "tooManyAttemptsTryAgainInAFewMinutes": "Too many attempts — try again in a few minutes.",
     "verificationExpiredPleaseVerifyAgain": "Verification expired — please verify again.",
+    "useYourPasskeyOrAuthenticatorCodeInstead": "Use your passkey or authenticator code instead — reload the page to update your options.",
     "pendingActivatesOnFirstApproval": "Pending — activates on first approval"
   },
   "stepUpPrompt": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1405,7 +1405,9 @@
     "tooManyAttemptsTryAgainInAFewMinutes": "Too many attempts — try again in a few minutes.",
     "verificationExpiredPleaseVerifyAgain": "Verification expired — please verify again.",
     "useYourPasskeyOrAuthenticatorCodeInstead": "Use your passkey or authenticator code instead — reload the page to update your options.",
-    "pendingActivatesOnFirstApproval": "Pending — activates on first approval"
+    "pendingActivatesOnFirstApproval": "Pending — activates on first approval",
+    "sessionExpiredReloadAndTryAgain": "Session expired — reload the page and try again.",
+    "registrationCancelled": "Registration was cancelled."
   },
   "stepUpPrompt": {
     "youWillConfirmWithYourPasskey": "You'll confirm with your passkey (Touch ID / Windows Hello) when you register.",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1398,7 +1398,17 @@
     "registering": "Registrándose…",
     "registerThisDevice": "Registre este dispositivo",
     "revoking": "Revocando…",
-    "revokeDevice": "Revocar dispositivo"
+    "revokeDevice": "Revocar dispositivo",
+    "incorrectCode": "Código incorrecto.",
+    "incorrectPassword": "Contraseña incorrecta.",
+    "tooManyAttemptsTryAgainInAFewMinutes": "Demasiados intentos: vuelva a intentarlo en unos minutos.",
+    "verificationExpiredPleaseVerifyAgain": "La verificación expiró: vuelva a verificar.",
+    "pendingActivatesOnFirstApproval": "Pendiente: se activa con la primera aprobación"
+  },
+  "stepUpPrompt": {
+    "youWillConfirmWithYourPasskey": "Confirmará con su clave de acceso (Touch ID/Windows Hello) al registrarse.",
+    "authenticatorCode": "Código del autenticador",
+    "confirmYourPassword": "Confirme su contraseña"
   },
   "cannedResponsesCard": {
     "cannedResponses": "Respuestas enlatadas",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1405,7 +1405,9 @@
     "tooManyAttemptsTryAgainInAFewMinutes": "Demasiados intentos: vuelva a intentarlo en unos minutos.",
     "verificationExpiredPleaseVerifyAgain": "La verificación expiró: vuelva a verificar.",
     "useYourPasskeyOrAuthenticatorCodeInstead": "Use su clave de acceso o código del autenticador en su lugar: recargue la página para actualizar sus opciones.",
-    "pendingActivatesOnFirstApproval": "Pendiente: se activa con la primera aprobación"
+    "pendingActivatesOnFirstApproval": "Pendiente: se activa con la primera aprobación",
+    "sessionExpiredReloadAndTryAgain": "La sesión expiró: recargue la página y vuelva a intentarlo.",
+    "registrationCancelled": "Se canceló el registro."
   },
   "stepUpPrompt": {
     "youWillConfirmWithYourPasskey": "Confirmará con su clave de acceso (Touch ID/Windows Hello) al registrarse.",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1401,8 +1401,10 @@
     "revokeDevice": "Revocar dispositivo",
     "incorrectCode": "Código incorrecto.",
     "incorrectPassword": "Contraseña incorrecta.",
+    "passkeyVerificationFailed": "Verificación con clave de acceso fallida: vuelva a intentarlo.",
     "tooManyAttemptsTryAgainInAFewMinutes": "Demasiados intentos: vuelva a intentarlo en unos minutos.",
     "verificationExpiredPleaseVerifyAgain": "La verificación expiró: vuelva a verificar.",
+    "useYourPasskeyOrAuthenticatorCodeInstead": "Use su clave de acceso o código del autenticador en su lugar: recargue la página para actualizar sus opciones.",
     "pendingActivatesOnFirstApproval": "Pendiente: se activa con la primera aprobación"
   },
   "stepUpPrompt": {

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1401,8 +1401,10 @@
     "revokeDevice": "Révoquer le dispositif",
     "incorrectCode": "Code incorrect.",
     "incorrectPassword": "Mot de passe incorrect.",
+    "passkeyVerificationFailed": "Échec de la vérification par clé d’accès — veuillez réessayer.",
     "tooManyAttemptsTryAgainInAFewMinutes": "Trop de tentatives — réessayez dans quelques minutes.",
     "verificationExpiredPleaseVerifyAgain": "Vérification expirée — veuillez vérifier à nouveau.",
+    "useYourPasskeyOrAuthenticatorCodeInstead": "Utilisez plutôt votre clé d’accès ou votre code d’authentification — actualisez la page pour mettre à jour vos options.",
     "pendingActivatesOnFirstApproval": "En attente — s’active à la première approbation"
   },
   "stepUpPrompt": {

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1398,7 +1398,17 @@
     "registering": "Enregistrement...",
     "registerThisDevice": "Enregistrez cet appareil",
     "revoking": "Révoque...",
-    "revokeDevice": "Révoquer le dispositif"
+    "revokeDevice": "Révoquer le dispositif",
+    "incorrectCode": "Code incorrect.",
+    "incorrectPassword": "Mot de passe incorrect.",
+    "tooManyAttemptsTryAgainInAFewMinutes": "Trop de tentatives — réessayez dans quelques minutes.",
+    "verificationExpiredPleaseVerifyAgain": "Vérification expirée — veuillez vérifier à nouveau.",
+    "pendingActivatesOnFirstApproval": "En attente — s’active à la première approbation"
+  },
+  "stepUpPrompt": {
+    "youWillConfirmWithYourPasskey": "Vous confirmerez avec votre clé d’accès (Touch ID / Windows Hello) lors de l’enregistrement.",
+    "authenticatorCode": "Code d’authentification",
+    "confirmYourPassword": "Confirmez votre mot de passe"
   },
   "cannedResponsesCard": {
     "cannedResponses": "Réponses préfabriquées",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1405,7 +1405,9 @@
     "tooManyAttemptsTryAgainInAFewMinutes": "Trop de tentatives — réessayez dans quelques minutes.",
     "verificationExpiredPleaseVerifyAgain": "Vérification expirée — veuillez vérifier à nouveau.",
     "useYourPasskeyOrAuthenticatorCodeInstead": "Utilisez plutôt votre clé d’accès ou votre code d’authentification — actualisez la page pour mettre à jour vos options.",
-    "pendingActivatesOnFirstApproval": "En attente — s’active à la première approbation"
+    "pendingActivatesOnFirstApproval": "En attente — s’active à la première approbation",
+    "sessionExpiredReloadAndTryAgain": "Session expirée — actualisez la page et réessayez.",
+    "registrationCancelled": "L’enregistrement a été annulé."
   },
   "stepUpPrompt": {
     "youWillConfirmWithYourPasskey": "Vous confirmerez avec votre clé d’accès (Touch ID / Windows Hello) lors de l’enregistrement.",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1401,8 +1401,10 @@
     "revokeDevice": "Revogar dispositivo",
     "incorrectCode": "Código incorreto.",
     "incorrectPassword": "Senha incorreta.",
+    "passkeyVerificationFailed": "Falha na verificação com chave de acesso — tente novamente.",
     "tooManyAttemptsTryAgainInAFewMinutes": "Muitas tentativas — tente novamente em alguns minutos.",
     "verificationExpiredPleaseVerifyAgain": "Verificação expirada — verifique novamente.",
+    "useYourPasskeyOrAuthenticatorCodeInstead": "Use sua chave de acesso ou código do autenticador em vez disso — recarregue a página para atualizar suas opções.",
     "pendingActivatesOnFirstApproval": "Pendente — ativa na primeira aprovação"
   },
   "stepUpPrompt": {

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1405,7 +1405,9 @@
     "tooManyAttemptsTryAgainInAFewMinutes": "Muitas tentativas — tente novamente em alguns minutos.",
     "verificationExpiredPleaseVerifyAgain": "Verificação expirada — verifique novamente.",
     "useYourPasskeyOrAuthenticatorCodeInstead": "Use sua chave de acesso ou código do autenticador em vez disso — recarregue a página para atualizar suas opções.",
-    "pendingActivatesOnFirstApproval": "Pendente — ativa na primeira aprovação"
+    "pendingActivatesOnFirstApproval": "Pendente — ativa na primeira aprovação",
+    "sessionExpiredReloadAndTryAgain": "Sessão expirada — recarregue a página e tente novamente.",
+    "registrationCancelled": "O registro foi cancelado."
   },
   "stepUpPrompt": {
     "youWillConfirmWithYourPasskey": "Você confirmará com sua chave de acesso (Touch ID/Windows Hello) ao se registrar.",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1398,7 +1398,17 @@
     "registering": "Registrando…",
     "registerThisDevice": "Registre este dispositivo",
     "revoking": "Revogando…",
-    "revokeDevice": "Revogar dispositivo"
+    "revokeDevice": "Revogar dispositivo",
+    "incorrectCode": "Código incorreto.",
+    "incorrectPassword": "Senha incorreta.",
+    "tooManyAttemptsTryAgainInAFewMinutes": "Muitas tentativas — tente novamente em alguns minutos.",
+    "verificationExpiredPleaseVerifyAgain": "Verificação expirada — verifique novamente.",
+    "pendingActivatesOnFirstApproval": "Pendente — ativa na primeira aprovação"
+  },
+  "stepUpPrompt": {
+    "youWillConfirmWithYourPasskey": "Você confirmará com sua chave de acesso (Touch ID/Windows Hello) ao se registrar.",
+    "authenticatorCode": "Código do autenticador",
+    "confirmYourPassword": "Confirme sua senha"
   },
   "cannedResponsesCard": {
     "cannedResponses": "Respostas automáticas",

--- a/apps/web/src/stores/authenticator.test.ts
+++ b/apps/web/src/stores/authenticator.test.ts
@@ -293,7 +293,16 @@ describe('registerApproverDevice re-auth mint paths (#2707)', () => {
     expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
       method: 'totp', code: '123456', operation: 'register_approver_device',
     });
+    // Register-options POST carries the minted grant.
+    expect(fetchMock.mock.calls[1][0]).toContain('/authenticator/devices/webauthn/options');
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ registerGrantId: 'g-totp' });
+    // Verify POST carries the grant, label, and attestation response.
+    expect(fetchMock.mock.calls[2][0]).toContain('/authenticator/devices/webauthn/verify');
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body)).toEqual({
+      registerGrantId: 'g-totp',
+      label: 'Laptop',
+      response: { id: 'cred-1', response: {} },
+    });
   });
 
   it('passkey path: step-up options → startAuthentication → step-up mint → register', async () => {
@@ -316,6 +325,16 @@ describe('registerApproverDevice re-auth mint paths (#2707)', () => {
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
       method: 'passkey', credential: assertion, operation: 'register_approver_device',
     });
+    // Register-options POST carries the minted grant.
+    expect(fetchMock.mock.calls[2][0]).toContain('/authenticator/devices/webauthn/options');
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body)).toEqual({ registerGrantId: 'g-pk' });
+    // Verify POST carries the grant, label, and attestation response.
+    expect(fetchMock.mock.calls[3][0]).toContain('/authenticator/devices/webauthn/verify');
+    expect(JSON.parse(fetchMock.mock.calls[3][1].body)).toEqual({
+      registerGrantId: 'g-pk',
+      label: 'Laptop',
+      response: { id: 'cred-1', response: {} },
+    });
   });
 
   it('mint failure rejects with the status attached (so the UI can map 401/403/429)', async () => {
@@ -324,6 +343,24 @@ describe('registerApproverDevice re-auth mint paths (#2707)', () => {
     await expect(
       registerApproverDevice('x', { method: 'password', password: 'nope' })
     ).rejects.toMatchObject({ status: 401 });
+    expect(webauthnMocks.startRegistration).not.toHaveBeenCalled();
+  });
+
+  it('a 2xx with an unparseable body throws a clean RegisterStepError instead of returning null (no downstream null-deref)', async () => {
+    // e.g. an empty body or a truncated proxy response — response.ok is true
+    // but response.json() rejects. Must not resolve to `null`: every caller
+    // immediately reads a field off the result (data.registerGrantId), which
+    // would otherwise throw a raw TypeError deep in the ceremony.
+    const unparseableOkResponse = {
+      ok: true,
+      status: 200,
+      json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected end of JSON input')),
+    } as unknown as Response;
+    const fetchMock = vi.fn().mockResolvedValueOnce(unparseableOkResponse);
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(
+      registerApproverDevice('x', { method: 'password', password: 'hunter2!' })
+    ).rejects.toMatchObject({ message: 'Unexpected server response.' });
     expect(webauthnMocks.startRegistration).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/stores/authenticator.test.ts
+++ b/apps/web/src/stores/authenticator.test.ts
@@ -32,7 +32,7 @@ describe('authenticator store approver helpers', () => {
     localStorage.removeItem('breeze-auth');
   });
 
-  it('registerApproverDevice fetches options, runs startRegistration, and posts the attestation', async () => {
+  it('registerApproverDevice (password path) mints a grant, fetches options, runs startRegistration, and posts the attestation', async () => {
     const options = {
       challenge: 'reg-challenge-b64url',
       rp: { id: 'breeze.example', name: 'Breeze' },
@@ -49,23 +49,34 @@ describe('authenticator store approver helpers', () => {
     webauthnMocks.startRegistration.mockResolvedValueOnce(attResp);
     const fetchMock = vi
       .fn()
+      .mockResolvedValueOnce(makeResponse({ registerGrantId: 'g-1' }))
       .mockResolvedValueOnce(makeResponse(options))
       .mockResolvedValueOnce(makeResponse({ success: true }));
     vi.stubGlobal('fetch', fetchMock);
 
-    await registerApproverDevice('My laptop');
+    await registerApproverDevice('My laptop', { method: 'password', password: 'hunter2!' });
 
-    // Step 1: options request
-    expect(fetchMock.mock.calls[0][0]).toContain('/authenticator/devices/webauthn/options');
-    expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: 'POST' });
+    // Step 1: mint the register grant via the password re-auth path
+    expect(fetchMock.mock.calls[0][0]).toContain('/authenticator/register-grant');
+    expect(JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string)).toEqual({
+      currentPassword: 'hunter2!',
+    });
 
-    // Step 2: startRegistration called with { optionsJSON }
-    expect(webauthnMocks.startRegistration).toHaveBeenCalledWith({ optionsJSON: options });
-
-    // Step 3: verify request carries label + the attestation response
-    expect(fetchMock.mock.calls[1][0]).toContain('/authenticator/devices/webauthn/verify');
+    // Step 2: options request, threading the minted grant
+    expect(fetchMock.mock.calls[1][0]).toContain('/authenticator/devices/webauthn/options');
     expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: 'POST' });
     expect(JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string)).toEqual({
+      registerGrantId: 'g-1',
+    });
+
+    // Step 3: startRegistration called with { optionsJSON }
+    expect(webauthnMocks.startRegistration).toHaveBeenCalledWith({ optionsJSON: options });
+
+    // Step 4: verify request carries the grant, label, and the attestation response
+    expect(fetchMock.mock.calls[2][0]).toContain('/authenticator/devices/webauthn/verify');
+    expect(fetchMock.mock.calls[2][1]).toMatchObject({ method: 'POST' });
+    expect(JSON.parse((fetchMock.mock.calls[2][1] as RequestInit).body as string)).toEqual({
+      registerGrantId: 'g-1',
       label: 'My laptop',
       response: attResp,
     });
@@ -87,17 +98,25 @@ describe('authenticator store approver helpers', () => {
     webauthnMocks.startRegistration.mockResolvedValueOnce({ id: 'cred-1', response: {} });
     const fetchMock = vi
       .fn()
+      .mockResolvedValueOnce(makeResponse({ registerGrantId: 'g-2' })) // mint ok
       .mockResolvedValueOnce(makeResponse({ challenge: 'c' })) // options ok
       .mockResolvedValueOnce(makeResponse({ error: 'challenge expired' }, false, 400)); // verify fails
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(registerApproverDevice('My laptop')).rejects.toThrow(/challenge expired|registration failed/i);
+    await expect(
+      registerApproverDevice('My laptop', { method: 'password', password: 'hunter2!' })
+    ).rejects.toThrow(/challenge expired|registration failed/i);
   });
 
   it('registerApproverDevice REJECTS on a non-2xx options response', async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce(makeResponse({ error: 'nope' }, false, 401));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ registerGrantId: 'g-3' })) // mint ok
+      .mockResolvedValueOnce(makeResponse({ error: 'nope' }, false, 401)); // options fails
     vi.stubGlobal('fetch', fetchMock);
-    await expect(registerApproverDevice('x')).rejects.toThrow();
+    await expect(
+      registerApproverDevice('x', { method: 'password', password: 'hunter2!' })
+    ).rejects.toThrow();
     expect(webauthnMocks.startRegistration).not.toHaveBeenCalled();
   });
 
@@ -231,5 +250,80 @@ describe('authenticator store approver helpers', () => {
       getApprovalAssertion('/pam/elevation-requests', 'req-x'),
     ).rejects.toMatchObject({ name: 'NoApproverDeviceError' });
     expect(webauthnMocks.startAuthentication).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerApproverDevice re-auth mint paths (#2707)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.removeItem('breeze-auth');
+  });
+
+  const optionsPayload = { options: { challenge: 'reg-challenge', rp: { id: 'x', name: 'x' } } };
+
+  it('password path: mints via /authenticator/register-grant then threads registerGrantId to options+verify', async () => {
+    webauthnMocks.startRegistration.mockResolvedValueOnce({ id: 'cred-1', response: {} });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(makeResponse({ registerGrantId: 'g-pass' }))   // mint
+      .mockResolvedValueOnce(makeResponse(optionsPayload))                  // options
+      .mockResolvedValueOnce(makeResponse({ success: true }));              // verify
+    vi.stubGlobal('fetch', fetchMock);
+
+    await registerApproverDevice('Front desk', { method: 'password', password: 'hunter2!' });
+
+    expect(fetchMock.mock.calls[0][0]).toContain('/authenticator/register-grant');
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ currentPassword: 'hunter2!' });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ registerGrantId: 'g-pass' });
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body)).toMatchObject({
+      registerGrantId: 'g-pass', label: 'Front desk',
+    });
+  });
+
+  it('totp path: mints via /auth/mfa/step-up with operation register_approver_device', async () => {
+    webauthnMocks.startRegistration.mockResolvedValueOnce({ id: 'cred-1', response: {} });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(makeResponse({ stepUpGrantId: 'g-totp' }))
+      .mockResolvedValueOnce(makeResponse(optionsPayload))
+      .mockResolvedValueOnce(makeResponse({ success: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await registerApproverDevice('Laptop', { method: 'totp', code: '123456' });
+
+    expect(fetchMock.mock.calls[0][0]).toContain('/auth/mfa/step-up');
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      method: 'totp', code: '123456', operation: 'register_approver_device',
+    });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ registerGrantId: 'g-totp' });
+  });
+
+  it('passkey path: step-up options → startAuthentication → step-up mint → register', async () => {
+    const assertion = { id: 'pk-cred', response: { signature: 's' } };
+    webauthnMocks.startAuthentication.mockResolvedValueOnce(assertion);
+    webauthnMocks.startRegistration.mockResolvedValueOnce({ id: 'cred-1', response: {} });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(makeResponse({ options: { challenge: 'auth-challenge' } })) // step-up options
+      .mockResolvedValueOnce(makeResponse({ stepUpGrantId: 'g-pk' }))                    // step-up mint
+      .mockResolvedValueOnce(makeResponse(optionsPayload))                               // register options
+      .mockResolvedValueOnce(makeResponse({ success: true }));                           // verify
+    vi.stubGlobal('fetch', fetchMock);
+
+    await registerApproverDevice('Laptop', { method: 'passkey' });
+
+    expect(fetchMock.mock.calls[0][0]).toContain('/auth/mfa/step-up/options');
+    expect(webauthnMocks.startAuthentication).toHaveBeenCalledWith({
+      optionsJSON: { challenge: 'auth-challenge' },
+    });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      method: 'passkey', credential: assertion, operation: 'register_approver_device',
+    });
+  });
+
+  it('mint failure rejects with the status attached (so the UI can map 401/403/429)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(makeResponse({ error: 'Invalid credentials' }, false, 401));
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(
+      registerApproverDevice('x', { method: 'password', password: 'nope' })
+    ).rejects.toMatchObject({ status: 401 });
+    expect(webauthnMocks.startRegistration).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/stores/authenticator.ts
+++ b/apps/web/src/stores/authenticator.ts
@@ -32,34 +32,110 @@ export interface ApproverDevice {
   disabledAt?: string | null;
 }
 
+export type RegisterReauth =
+  | { method: 'passkey' }
+  | { method: 'totp'; code: string }
+  | { method: 'password'; password: string };
+
+class RegisterStepError extends Error {
+  status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function jsonOrThrow(response: Response, fallback: string): Promise<any> {
+  const data = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new RegisterStepError(data?.error ?? fallback, response.status);
+  }
+  return data;
+}
+
+/**
+ * Mint a single-use register_approver_device grant with whichever re-auth
+ * factor the caller proved (#2707 — spec: strongest available factor; the
+ * password endpoint 403s `stronger_factor_required` if TOTP/passkey exist).
+ */
+async function mintRegisterGrant(reauth: RegisterReauth): Promise<string> {
+  if (reauth.method === 'password') {
+    const data = await jsonOrThrow(
+      await fetchWithAuth('/authenticator/register-grant', {
+        method: 'POST',
+        body: JSON.stringify({ currentPassword: reauth.password }),
+        // A 401 here means "wrong password", not "stale access token" — unlike
+        // most fetchWithAuth callers, replaying after a token refresh would
+        // just resubmit the same bad password and fail again. Same rationale
+        // as the single-use webauthn assertion in intentApprovals.ts.
+        skipUnauthorizedRetry: true,
+      }),
+      'Verification failed.'
+    );
+    if (!data?.registerGrantId) throw new RegisterStepError('Verification failed.');
+    return data.registerGrantId;
+  }
+
+  let stepUpBody: Record<string, unknown>;
+  if (reauth.method === 'totp') {
+    stepUpBody = { method: 'totp', code: reauth.code, operation: 'register_approver_device' };
+  } else {
+    // Passkey: fetch an authenticated step-up challenge, run the assertion
+    // ceremony, then prove it to /auth/mfa/step-up.
+    const challengeData = await jsonOrThrow(
+      await fetchWithAuth('/auth/mfa/step-up/options', { method: 'POST' }),
+      'Could not start passkey verification.'
+    );
+    const optionsJSON: PublicKeyCredentialRequestOptionsJSON =
+      challengeData.options ?? challengeData.optionsJSON ?? challengeData;
+    const credential = await startAuthentication({ optionsJSON });
+    stepUpBody = { method: 'passkey', credential, operation: 'register_approver_device' };
+  }
+
+  const data = await jsonOrThrow(
+    await fetchWithAuth('/auth/mfa/step-up', {
+      method: 'POST',
+      body: JSON.stringify(stepUpBody),
+      // Same reasoning: a 401 means the TOTP code / passkey assertion was
+      // rejected (wrong code, or the assertion is already burned), not that
+      // the access token is stale — never replay it.
+      skipUnauthorizedRetry: true,
+    }),
+    'Verification failed.'
+  );
+  if (!data?.stepUpGrantId) throw new RegisterStepError('Verification failed.');
+  // The step-up endpoint names it stepUpGrantId; the register routes take it
+  // as registerGrantId — same value, different field name.
+  return data.stepUpGrantId;
+}
+
 /**
  * Register the current browser/platform authenticator as an approver device.
- * options → Windows Hello / Touch ID registration ceremony → verify.
+ * re-auth mint → options (validates the grant) → Windows Hello / Touch ID
+ * registration ceremony → verify (consumes the grant).
  */
-export async function registerApproverDevice(label: string): Promise<void> {
-  const optionsResponse = await fetchWithAuth('/authenticator/devices/webauthn/options', {
-    method: 'POST',
-  });
-  const optionsData = await optionsResponse.json().catch(() => null);
-  // fetchWithAuth does NOT throw on a non-2xx — guard explicitly so a failed
-  // options/verify rejects and runAction surfaces an error toast instead of a
-  // false success (CLAUDE.md no-silent-mutations).
-  if (!optionsResponse.ok) {
-    throw new Error(optionsData?.error ?? 'Failed to start device registration.');
-  }
+export async function registerApproverDevice(label: string, reauth: RegisterReauth): Promise<void> {
+  const registerGrantId = await mintRegisterGrant(reauth);
+
+  const optionsData = await jsonOrThrow(
+    await fetchWithAuth('/authenticator/devices/webauthn/options', {
+      method: 'POST',
+      body: JSON.stringify({ registerGrantId }),
+    }),
+    'Failed to start device registration.'
+  );
   const optionsJSON: PublicKeyCredentialCreationOptionsJSON =
     optionsData.options ?? optionsData.optionsJSON ?? optionsData;
 
   const response = await startRegistration({ optionsJSON });
 
-  const verifyResponse = await fetchWithAuth('/authenticator/devices/webauthn/verify', {
-    method: 'POST',
-    body: JSON.stringify({ label, response }),
-  });
-  if (!verifyResponse.ok) {
-    const verifyData = await verifyResponse.json().catch(() => null);
-    throw new Error(verifyData?.error ?? 'Device registration failed.');
-  }
+  await jsonOrThrow(
+    await fetchWithAuth('/authenticator/devices/webauthn/verify', {
+      method: 'POST',
+      body: JSON.stringify({ registerGrantId, label, response }),
+    }),
+    'Device registration failed.'
+  );
 }
 
 /** List the caller's active approver devices. */

--- a/apps/web/src/stores/authenticator.ts
+++ b/apps/web/src/stores/authenticator.ts
@@ -46,11 +46,20 @@ class RegisterStepError extends Error {
 }
 
 async function jsonOrThrow(response: Response, fallback: string): Promise<any> {
-  const data = await response.json().catch(() => null);
   if (!response.ok) {
+    const data = await response.json().catch(() => null);
     throw new RegisterStepError(data?.error ?? fallback, response.status);
   }
-  return data;
+  // A 2xx with an unparseable body (empty body, truncated proxy response) must
+  // not silently resolve to `null` — every caller immediately reads a field
+  // off the result (e.g. `data.registerGrantId`), which would throw a raw
+  // TypeError deep in the ceremony instead of surfacing a clean, catchable
+  // RegisterStepError the UI can map to a toast.
+  try {
+    return await response.json();
+  } catch {
+    throw new RegisterStepError('Unexpected server response.');
+  }
 }
 
 /**

--- a/docs/superpowers/plans/2026-07-21-authenticator-register-grant.md
+++ b/docs/superpowers/plans/2026-07-21-authenticator-register-grant.md
@@ -1,0 +1,1701 @@
+# Authenticator Register-Grant Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the broken `currentPassword` step-up on approver-device registration with single-use re-auth grants (`mfaStepUpGrant`), so mobile registers promptlessly at login and the browser registers with one passkey/TOTP/password gesture.
+
+**Architecture:** Extend the existing Redis-backed `mfaStepUpGrant` service with a `'register_approver_device'` operation. Three mint paths: `/auth/mfa/step-up` (passkey/TOTP, browser), a new `POST /authenticator/register-grant` password endpoint (browser fallback, gated to accounts with no stronger factor), and login-time minting (mobile only, gated on the mobile device-id header). The three register routes swap `currentPassword` → `registerGrantId` with unconditional enforcement (validate at options, consume at verify/mobile-POST).
+
+**Tech Stack:** Hono + Zod + Drizzle (API), Vitest everywhere, Redux Toolkit + Expo SecureStore (mobile), React + `@simplewebauthn/browser` + runAction (web).
+
+**Spec:** `docs/superpowers/specs/2026-07-21-authenticator-register-grant-design.md` — read it before starting; it explains every security decision referenced below.
+
+## Global Constraints
+
+- **No DB migrations in this plan.** Nothing touches schema. If you think you need one, re-read the spec.
+- **NEVER mint a grant in the `/auth/refresh` handler** (`login.ts:700-932`). A test pins this (Task 5).
+- **Do NOT reuse `enforceExistingFactorStepUp`** for the register routes — its `userIsMfaProtected` early-return would let non-MFA users skip the grant entirely. Task 3 builds the unconditional sibling.
+- **Grant enforcement is unconditional for ALL users** on all three register routes.
+- New web UI strings: every new `t()` key MUST be added to `apps/web/src/locales/<locale>/settings.json` for ALL FIVE locales (`en`, `de-DE`, `es-419`, `fr-FR`, `pt-BR`) — the locale-parity check reds main otherwise.
+- Web mutations stay wrapped in `runAction` (already true for `ApproverDevicesSection`; keep it that way).
+- Mobile registration remains fail-open: `ensureApproverDevice` never throws, never blocks login.
+- Run commands from the repo root unless a `cd` is shown. Node is pinned (see `.nvmrc` / memory: wrong Node → false test failures).
+
+---
+
+### Task 1: Widen the grant `operation` union
+
+**Files:**
+- Modify: `apps/api/src/services/mfaStepUpGrant.ts`
+- Test: `apps/api/src/services/mfaStepUpGrant.test.ts` (new)
+
+**Interfaces:**
+- Produces: `StepUpOperation = 'add_factor' | 'register_approver_device'` (exported type); `StepUpGrant.operation` widened. `mintStepUpGrant` / `validateStepUpGrant` / `consumeStepUpGrant` signatures unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/services/mfaStepUpGrant.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { redisMock, redisStore } = vi.hoisted(() => {
+  const redisStore = new Map<string, string>();
+  return {
+    redisStore,
+    redisMock: {
+      setex: vi.fn(async (k: string, _ttl: number, v: string) => { redisStore.set(k, v); }),
+      get: vi.fn(async (k: string) => redisStore.get(k) ?? null),
+      getdel: vi.fn(async (k: string) => {
+        const v = redisStore.get(k) ?? null;
+        redisStore.delete(k);
+        return v;
+      }),
+    },
+  };
+});
+
+vi.mock('./redis', () => ({ getRedis: vi.fn(() => redisMock) }));
+
+import { mintStepUpGrant, validateStepUpGrant, consumeStepUpGrant } from './mfaStepUpGrant';
+
+const bind = (operation: 'add_factor' | 'register_approver_device') => ({
+  userId: 'user-1',
+  operation,
+  authEpoch: 1,
+  mfaEpoch: 2,
+  sid: 'sid-1',
+});
+
+describe('mfaStepUpGrant operation isolation', () => {
+  beforeEach(() => {
+    redisStore.clear();
+    vi.clearAllMocks();
+  });
+
+  it('mints and consumes a register_approver_device grant', async () => {
+    const id = await mintStepUpGrant(bind('register_approver_device'));
+    expect(id).toBeTruthy();
+    await expect(validateStepUpGrant(id!, bind('register_approver_device'))).resolves.toBe(true);
+    await expect(consumeStepUpGrant(id!, bind('register_approver_device'))).resolves.toBe(true);
+    // single-use: second consume fails
+    await expect(consumeStepUpGrant(id!, bind('register_approver_device'))).resolves.toBe(false);
+  });
+
+  it('an add_factor grant can never validate/consume as register_approver_device (and vice versa)', async () => {
+    const addFactor = await mintStepUpGrant(bind('add_factor'));
+    const register = await mintStepUpGrant(bind('register_approver_device'));
+    await expect(validateStepUpGrant(addFactor!, bind('register_approver_device'))).resolves.toBe(false);
+    await expect(consumeStepUpGrant(addFactor!, bind('register_approver_device'))).resolves.toBe(false);
+    await expect(validateStepUpGrant(register!, bind('add_factor'))).resolves.toBe(false);
+    // cross-operation consume must NOT burn the grant: getdel deletes, so assert
+    // the register grant was destroyed by the failed add_factor consume attempt
+    // ONLY IF the service deletes on mismatch — current behavior: getdel removes
+    // the key regardless. Pin current behavior:
+    await expect(consumeStepUpGrant(register!, bind('add_factor'))).resolves.toBe(false);
+    await expect(validateStepUpGrant(register!, bind('register_approver_device'))).resolves.toBe(false);
+  });
+
+  it('validate is non-consuming', async () => {
+    const id = await mintStepUpGrant(bind('register_approver_device'));
+    await expect(validateStepUpGrant(id!, bind('register_approver_device'))).resolves.toBe(true);
+    await expect(validateStepUpGrant(id!, bind('register_approver_device'))).resolves.toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && pnpm vitest run src/services/mfaStepUpGrant.test.ts`
+Expected: FAIL — TypeScript rejects `operation: 'register_approver_device'` (not assignable to `'add_factor'`). If vitest doesn't type-check, the mint succeeds but this task's Step 3 is still required for `tsc`; run `pnpm typecheck` in `apps/api` to see the type error.
+
+- [ ] **Step 3: Widen the union**
+
+In `apps/api/src/services/mfaStepUpGrant.ts` replace lines 18-25 with:
+
+```ts
+/** Operations a step-up grant can authorize. A grant minted for one operation
+ * can never validate/consume for another (bindsMatch checks equality). */
+export type StepUpOperation = 'add_factor' | 'register_approver_device';
+
+export interface StepUpGrant {
+  id: string;
+  userId: string;
+  operation: StepUpOperation;
+  authEpoch: number;
+  mfaEpoch: number;
+  sid: string;
+}
+```
+
+Also update the doc comment above the interface (lines 4-17) to mention the second operation and its consumers (the `/authenticator` register routes).
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `cd apps/api && pnpm vitest run src/services/mfaStepUpGrant.test.ts && pnpm typecheck`
+Expected: PASS / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/mfaStepUpGrant.ts apps/api/src/services/mfaStepUpGrant.test.ts
+git commit -m "feat(auth): add register_approver_device step-up grant operation (#2707)"
+```
+
+---
+
+### Task 2: `/auth/mfa/step-up` accepts an `operation` field
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/schemas.ts:119-125`
+- Modify: `apps/api/src/routes/auth/mfa.ts:721-816` (the `POST /mfa/step-up` handler)
+- Test: `apps/api/src/routes/auth/schemas.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `StepUpOperation` from Task 1.
+- Produces: `mfaStepUpSchema` branches each carry `operation: z.enum(['add_factor','register_approver_device']).default('add_factor')`. The step-up endpoint mints a grant with the REQUESTED operation and still returns `{ stepUpGrantId }`.
+
+- [ ] **Step 1: Write the failing schema tests**
+
+Append to `apps/api/src/routes/auth/schemas.test.ts` (mirror its existing describe style):
+
+```ts
+describe('mfaStepUpSchema operation field', () => {
+  it('defaults operation to add_factor on every branch', () => {
+    const totp = mfaStepUpSchema.parse({ method: 'totp', code: '123456' });
+    expect(totp.operation).toBe('add_factor');
+    const passkey = mfaStepUpSchema.parse({ method: 'passkey', credential: { id: 'cred-1' } });
+    expect(passkey.operation).toBe('add_factor');
+  });
+
+  it('accepts register_approver_device', () => {
+    const parsed = mfaStepUpSchema.parse({
+      method: 'totp',
+      code: '123456',
+      operation: 'register_approver_device',
+    });
+    expect(parsed.operation).toBe('register_approver_device');
+  });
+
+  it('rejects unknown operations', () => {
+    expect(() =>
+      mfaStepUpSchema.parse({ method: 'totp', code: '123456', operation: 'admin_takeover' })
+    ).toThrow();
+  });
+});
+```
+
+(Add `mfaStepUpSchema` to the file's imports from `./schemas` if not already imported.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && pnpm vitest run src/routes/auth/schemas.test.ts`
+Expected: FAIL — `operation` is `undefined` / unknown key.
+
+- [ ] **Step 3: Extend the schema**
+
+In `apps/api/src/routes/auth/schemas.ts`, replace lines 119-125. **You cannot `.extend()` a `z.discriminatedUnion`** — add the field to each branch:
+
+```ts
+const stepUpSixDigit = z.string().refine((v) => /^\d{6}$/.test(v.trim()), { message: 'Invalid code' });
+const stepUpAssertion = z.object({ id: z.string().min(1) }).passthrough();
+// Which grant the proven factor mints. Defaults to the original add_factor so
+// existing clients are untouched; register_approver_device gates the
+// /authenticator register routes (#2707).
+const stepUpOperation = z
+  .enum(['add_factor', 'register_approver_device'])
+  .default('add_factor');
+export const mfaStepUpSchema = z.discriminatedUnion('method', [
+  z.object({ method: z.literal('totp'), code: stepUpSixDigit, operation: stepUpOperation }),
+  z.object({ method: z.literal('sms'), code: stepUpSixDigit, operation: stepUpOperation }),
+  z.object({ method: z.literal('passkey'), credential: stepUpAssertion, operation: stepUpOperation }),
+]);
+```
+
+- [ ] **Step 4: Thread `operation` through the handler**
+
+In `apps/api/src/routes/auth/mfa.ts`, in the `POST /mfa/step-up` handler:
+
+At line 796-802, replace the hardcoded operation:
+
+```ts
+  const grantId = await mintStepUpGrant({
+    userId: auth.user.id,
+    operation: body.operation,
+    authEpoch: epochs.authEpoch,
+    mfaEpoch: epochs.mfaEpoch,
+    sid: auth.token.sid
+  });
+```
+
+At line 807-814, the success audit already records `operation: 'add_factor'` — change to `operation: body.operation`. Also update the SR2-20 doc comment above the route (lines 713-720) to mention the second operation.
+
+- [ ] **Step 5: Run tests + typecheck**
+
+Run: `cd apps/api && pnpm vitest run src/routes/auth/schemas.test.ts && pnpm typecheck`
+Expected: PASS / clean. (`body.operation` is always defined thanks to the zod default, so no `??` needed — the type is `'add_factor' | 'register_approver_device'`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/auth/schemas.ts apps/api/src/routes/auth/schemas.test.ts apps/api/src/routes/auth/mfa.ts
+git commit -m "feat(auth): mfa step-up mints operation-scoped grants (#2707)"
+```
+
+---
+
+### Task 3: Unconditional register-grant enforcement + stronger-factor predicate (helpers)
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/helpers.ts` (add two exports next to `enforceExistingFactorStepUp`, ~line 314)
+- Test: `apps/api/src/routes/auth/helpers.registerStepUp.test.ts` (new; mirror the mock harness of `apps/api/src/routes/auth/helpers.mfaStepUp.test.ts`)
+
+**Interfaces:**
+- Consumes: `validateStepUpGrant`, `consumeStepUpGrant` (Task 1), `getUserEpochs` (from `../../services`).
+- Produces:
+  - `enforceApproverRegisterStepUp(c: Context, auth: AuthContext, grantId: string | undefined, opts: { consume: boolean }): Promise<Response | null>` — 403 `{ error: 'register_step_up_required' }` on bad/missing grant, 503 on missing sid/epochs, null to proceed. **NO MFA-protected bypass.**
+  - `userHasStrongerReauthFactor(userId: string): Promise<boolean>` — true when the account has TOTP MFA or ≥1 active passkey (NOT SMS — SMS users keep the password path, see spec).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/api/src/routes/auth/helpers.registerStepUp.test.ts`. Open `helpers.mfaStepUp.test.ts` first and copy its `vi.hoisted`/`vi.mock` harness for `../../db`, `../../services` (getUserEpochs, redis), and `../../services/mfaStepUpGrant` — then add these cases:
+
+```ts
+describe('enforceApproverRegisterStepUp', () => {
+  it('403s a NON-MFA-protected user with no grant (no bypass — the spec pin)', async () => {
+    // arrange: userIsMfaProtected-style state irrelevant — helper must not consult it.
+    grantMocks.validateStepUpGrant.mockResolvedValue(false);
+    epochsMock.getUserEpochs.mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 });
+    const res = await enforceApproverRegisterStepUp(ctx(), authCtx({ sid: 'sid-1' }), undefined, { consume: false });
+    expect(res?.status).toBe(403);
+    expect(await res!.json()).toEqual({ error: 'register_step_up_required' });
+  });
+
+  it('503s when sid or epochs are missing', async () => {
+    epochsMock.getUserEpochs.mockResolvedValue(null);
+    const res = await enforceApproverRegisterStepUp(ctx(), authCtx({ sid: 'sid-1' }), 'g-1', { consume: false });
+    expect(res?.status).toBe(503);
+  });
+
+  it('validates without consuming at the options phase', async () => {
+    epochsMock.getUserEpochs.mockResolvedValue({ authEpoch: 1, mfaEpoch: 2 });
+    grantMocks.validateStepUpGrant.mockResolvedValue(true);
+    const res = await enforceApproverRegisterStepUp(ctx(), authCtx({ sid: 'sid-1' }), 'g-1', { consume: false });
+    expect(res).toBeNull();
+    expect(grantMocks.validateStepUpGrant).toHaveBeenCalledWith('g-1', {
+      userId: 'user-1',
+      operation: 'register_approver_device',
+      authEpoch: 1,
+      mfaEpoch: 2,
+      sid: 'sid-1',
+    });
+    expect(grantMocks.consumeStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('consumes at the terminal phase', async () => {
+    epochsMock.getUserEpochs.mockResolvedValue({ authEpoch: 1, mfaEpoch: 2 });
+    grantMocks.consumeStepUpGrant.mockResolvedValue(true);
+    const res = await enforceApproverRegisterStepUp(ctx(), authCtx({ sid: 'sid-1' }), 'g-1', { consume: true });
+    expect(res).toBeNull();
+    expect(grantMocks.consumeStepUpGrant).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('userHasStrongerReauthFactor', () => {
+  it.each([
+    [{ mfaEnabled: true, mfaMethod: 'totp', passkeyCount: 0 }, true],
+    [{ mfaEnabled: true, mfaMethod: 'sms', passkeyCount: 0 }, false],  // SMS keeps password path
+    [{ mfaEnabled: false, mfaMethod: null, passkeyCount: 1 }, true],
+    [{ mfaEnabled: false, mfaMethod: null, passkeyCount: 0 }, false],
+  ])('%o → %s', async (row, expected) => {
+    dbState.selectQueue.push([row]);
+    await expect(userHasStrongerReauthFactor('user-1')).resolves.toBe(expected);
+  });
+});
+```
+
+(`ctx()` / `authCtx()` / `grantMocks` / `epochsMock` / `dbState`: reuse the exact fixture names the sibling `helpers.mfaStepUp.test.ts` harness defines; rename these references to match if they differ.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && pnpm vitest run src/routes/auth/helpers.registerStepUp.test.ts`
+Expected: FAIL — exports don't exist.
+
+- [ ] **Step 3: Implement in `helpers.ts`**
+
+Add after `enforceExistingFactorStepUp` (after line 313):
+
+```ts
+/**
+ * True when the account holds a re-auth factor STRONGER than a password that
+ * the browser register UI can actually exercise: TOTP MFA or an active
+ * passkey. Deliberately excludes SMS (no authenticated step-up SMS sender
+ * exists; SMS-method users use the password path — see the #2707 spec).
+ * Gates POST /authenticator/register-grant: password re-auth is refused when
+ * this returns true, keeping the server tiering identical to the UI tiering.
+ */
+export async function userHasStrongerReauthFactor(userId: string): Promise<boolean> {
+  const [row] = await runWithSystemDbAccess(() =>
+    db
+      .select({
+        mfaEnabled: users.mfaEnabled,
+        mfaMethod: users.mfaMethod,
+        passkeyCount: sql<number>`(SELECT COUNT(*)::int FROM user_passkeys WHERE user_id = ${userId} AND disabled_at IS NULL)`,
+      })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+  );
+  return (row?.mfaEnabled === true && row?.mfaMethod === 'totp') || Number(row?.passkeyCount ?? 0) > 0;
+}
+
+/**
+ * #2707: enforce a register_approver_device grant on the approver-device
+ * registration routes. Same two-phase validate/consume contract as
+ * `enforceExistingFactorStepUp` above, with one CRITICAL difference: NO
+ * `userIsMfaProtected` bypass. Registration is deferred-proof-of-possession —
+ * a stolen bearer token must never be able to register an approver key, so
+ * the grant is required for EVERY account, MFA-protected or not.
+ */
+export async function enforceApproverRegisterStepUp(
+  c: Context,
+  auth: AuthContext,
+  grantId: string | undefined,
+  opts: { consume: boolean },
+): Promise<Response | null> {
+  const epochs = await getUserEpochs(auth.user.id);
+  if (!epochs || !auth.token.sid) {
+    return c.json({ error: 'Service temporarily unavailable' }, 503);
+  }
+
+  const bind = {
+    userId: auth.user.id,
+    operation: 'register_approver_device' as const,
+    authEpoch: epochs.authEpoch,
+    mfaEpoch: epochs.mfaEpoch,
+    sid: auth.token.sid,
+  };
+
+  const ok = grantId
+    ? (opts.consume ? await consumeStepUpGrant(grantId, bind) : await validateStepUpGrant(grantId, bind))
+    : false;
+
+  if (!ok) {
+    return c.json({ error: 'register_step_up_required' }, 403);
+  }
+  return null;
+}
+```
+
+All imports (`runWithSystemDbAccess`, `sql`, `users`, `getUserEpochs`, `validateStepUpGrant`, `consumeStepUpGrant`, `Context`, `AuthContext`) already exist in `helpers.ts` for the sibling functions — verify with the file's import block, add any missing.
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `cd apps/api && pnpm vitest run src/routes/auth/helpers.registerStepUp.test.ts && pnpm typecheck`
+Expected: PASS / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/auth/helpers.ts apps/api/src/routes/auth/helpers.registerStepUp.test.ts
+git commit -m "feat(auth): unconditional approver-register step-up enforcement (#2707)"
+```
+
+---
+
+### Task 4: Swap the three register routes to grants + `POST /authenticator/register-grant`
+
+**Files:**
+- Modify: `apps/api/src/routes/authenticator.ts:28-270`
+- Test: `apps/api/src/routes/authenticator.test.ts` (extend; harness already mocks `./auth/helpers` wholesale — add the two new helper mocks there)
+
+**Interfaces:**
+- Consumes: `enforceApproverRegisterStepUp`, `userHasStrongerReauthFactor`, `requireCurrentPasswordStepUp` (helpers); `mintStepUpGrant` (service); `getUserEpochs` (from `../services`).
+- Produces (wire contract — web/mobile tasks depend on these exact shapes):
+  - `POST /authenticator/register-grant` body `{ currentPassword: string }` → 200 `{ registerGrantId: string }` | 403 `{ error: 'stronger_factor_required' }` | 401/429/503.
+  - `POST /authenticator/devices/webauthn/options` body `{ registerGrantId: string }` (validate, non-consuming).
+  - `POST /authenticator/devices/webauthn/verify` body `{ registerGrantId: string, response, label? }` (consume).
+  - `POST /authenticator/devices` body `{ registerGrantId: string, publicKey: string, label: string }` (consume) — `currentPassword`/`kind`/`isPlatformBound` no longer read.
+
+- [ ] **Step 1: Write the failing route tests**
+
+In `apps/api/src/routes/authenticator.test.ts`: extend the hoisted `helperMocks` (line 52-55) with the new helpers and mock the grant service:
+
+```ts
+    helperMocks: {
+      requireCurrentPasswordStepUp: vi.fn(),
+      writeAuthAudit: vi.fn(),
+      enforceApproverRegisterStepUp: vi.fn(),
+      userHasStrongerReauthFactor: vi.fn(),
+    },
+    grantMocks: {
+      mintStepUpGrant: vi.fn(),
+    },
+    epochsMock: {
+      getUserEpochs: vi.fn(),
+    },
+```
+
+Add alongside the existing `vi.mock` calls:
+
+```ts
+vi.mock('../services/mfaStepUpGrant', () => ({ ...grantMocks }));
+```
+
+and extend the existing `vi.mock('../services', ...)` factory with `getUserEpochs: epochsMock.getUserEpochs` (keep `getRedis`).
+
+New test cases (adapt request-building style from the file's existing tests — it mounts `authenticatorRoutes` on a `Hono` app and fires `app.request(...)`):
+
+```ts
+describe('POST /register-grant', () => {
+  it('mints a grant after password step-up when no stronger factor exists', async () => {
+    helperMocks.userHasStrongerReauthFactor.mockResolvedValue(false);
+    helperMocks.requireCurrentPasswordStepUp.mockResolvedValue(null);
+    epochsMock.getUserEpochs.mockResolvedValue({ authEpoch: 1, mfaEpoch: 2 });
+    grantMocks.mintStepUpGrant.mockResolvedValue('grant-uuid');
+
+    const res = await postJson('/register-grant', { currentPassword: 'hunter2!' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ registerGrantId: 'grant-uuid' });
+    expect(grantMocks.mintStepUpGrant).toHaveBeenCalledWith(
+      expect.objectContaining({ operation: 'register_approver_device' })
+    );
+  });
+
+  it('403 stronger_factor_required when the account has TOTP or a passkey', async () => {
+    helperMocks.userHasStrongerReauthFactor.mockResolvedValue(true);
+    const res = await postJson('/register-grant', { currentPassword: 'hunter2!' });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'stronger_factor_required' });
+    expect(helperMocks.requireCurrentPasswordStepUp).not.toHaveBeenCalled();
+  });
+
+  it('propagates password step-up failures (401/429/503)', async () => {
+    helperMocks.userHasStrongerReauthFactor.mockResolvedValue(false);
+    helperMocks.requireCurrentPasswordStepUp.mockImplementation(async (c: any) =>
+      c.json({ error: 'Invalid credentials' }, 401)
+    );
+    const res = await postJson('/register-grant', { currentPassword: 'wrong' });
+    expect(res.status).toBe(401);
+  });
+
+  it('503 when sid/epochs unavailable', async () => {
+    helperMocks.userHasStrongerReauthFactor.mockResolvedValue(false);
+    helperMocks.requireCurrentPasswordStepUp.mockResolvedValue(null);
+    epochsMock.getUserEpochs.mockResolvedValue(null);
+    const res = await postJson('/register-grant', { currentPassword: 'hunter2!' });
+    expect(res.status).toBe(503);
+  });
+});
+
+describe('register routes take registerGrantId', () => {
+  it('options validates (consume:false); verify consumes (consume:true)', async () => {
+    helperMocks.enforceApproverRegisterStepUp.mockResolvedValue(null);
+    approverMocks.generateApproverRegistrationOptions.mockResolvedValue({ challenge: 'c' });
+    await postJson('/devices/webauthn/options', { registerGrantId: 'g-1' });
+    expect(helperMocks.enforceApproverRegisterStepUp).toHaveBeenLastCalledWith(
+      expect.anything(), expect.anything(), 'g-1', { consume: false }
+    );
+
+    approverMocks.verifyApproverRegistration.mockResolvedValue({
+      publicKey: 'pk', credentialId: 'cid', counter: 0, aaguid: null, transports: null, isPlatformBound: true,
+    });
+    dbState.insertReturning = [{ id: 'dev-1', label: 'x', kind: 'webauthn_platform', isPlatformBound: true, transports: [] }];
+    await postJson('/devices/webauthn/verify', { registerGrantId: 'g-1', response: { id: 'att' } });
+    expect(helperMocks.enforceApproverRegisterStepUp).toHaveBeenLastCalledWith(
+      expect.anything(), expect.anything(), 'g-1', { consume: true }
+    );
+  });
+
+  it('mobile POST /devices consumes the grant and no longer reads currentPassword', async () => {
+    helperMocks.enforceApproverRegisterStepUp.mockResolvedValue(null);
+    dbState.insertReturning = [{ id: 'dev-2', label: 'This device', kind: 'mobile_hw_key', isPlatformBound: true, transports: [] }];
+    const res = await postJson('/devices', { registerGrantId: 'g-2', publicKey: 'SPKI', label: 'This device' });
+    expect(res.status).toBe(200);
+    expect(helperMocks.enforceApproverRegisterStepUp).toHaveBeenLastCalledWith(
+      expect.anything(), expect.anything(), 'g-2', { consume: true }
+    );
+    expect(helperMocks.requireCurrentPasswordStepUp).not.toHaveBeenCalled();
+  });
+
+  it('403s all three routes when enforcement rejects — including a missing grant', async () => {
+    helperMocks.enforceApproverRegisterStepUp.mockImplementation(async (c: any) =>
+      c.json({ error: 'register_step_up_required' }, 403)
+    );
+    for (const [path, body] of [
+      ['/devices/webauthn/options', {}],
+      ['/devices/webauthn/verify', { response: { id: 'att' } }],
+      ['/devices', { publicKey: 'SPKI', label: 'x' }],
+    ] as const) {
+      const res = await postJson(path, body);
+      expect(res.status, path).toBe(403);
+    }
+  });
+});
+```
+
+(`postJson` = whatever request helper the file already uses; reuse it. If the file's existing `currentPassword`-era tests now contradict the new contract, UPDATE them in this step — they encode the old broken behavior.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && pnpm vitest run src/routes/authenticator.test.ts`
+Expected: FAIL — routes still demand `currentPassword`, `/register-grant` 404s.
+
+- [ ] **Step 3: Implement the route changes**
+
+In `apps/api/src/routes/authenticator.ts`:
+
+1. Imports: add `enforceApproverRegisterStepUp, userHasStrongerReauthFactor` to the `./auth/helpers` import; add `import { mintStepUpGrant } from '../services/mfaStepUpGrant';` and `import { getUserEpochs } from '../services';`.
+
+2. Replace the schemas (lines 30-58):
+
+```ts
+const registerGrantIdSchema = z.string().min(1).max(128);
+
+const registerOptionsSchema = z.object({
+  registerGrantId: registerGrantIdSchema,
+});
+const registerVerifySchema = z.object({
+  registerGrantId: registerGrantIdSchema,
+  response: attestationResponseSchema,
+  label: deviceLabelSchema.optional(),
+});
+const registerGrantMintSchema = z.object({
+  currentPassword: z.string().min(1).max(256),
+});
+// Mobile hardware-key registration — requires a register_approver_device grant
+// (minted at login, returned as authenticatorRegisterGrantId). The old
+// client-asserted kind/isPlatformBound discriminators are ignored entirely; the
+// server forces kind='mobile_hw_key' and is_platform_bound=true. publicKey +
+// label are re-validated through the shared mobileHwKeyRegisterSchema
+// (`.strict()`) before insert; registerGrantId is stripped prior to that parse.
+const mobileRegisterSchema = z
+  .object({
+    registerGrantId: registerGrantIdSchema,
+  })
+  .passthrough();
+```
+
+3. New mint endpoint — insert before the `/devices/webauthn/options` route:
+
+```ts
+// #2707: password-fallback grant mint for the browser register flow. Gated:
+// accounts holding a stronger factor (TOTP or a passkey) must mint via
+// POST /auth/mfa/step-up instead — otherwise a stolen session + phished
+// password could register an approver key on an MFA-protected account.
+authenticatorRoutes.post(
+  '/register-grant',
+  authMiddleware,
+  zValidator('json', registerGrantMintSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { currentPassword } = c.req.valid('json');
+
+    if (await userHasStrongerReauthFactor(auth.user.id)) {
+      return c.json({ error: 'stronger_factor_required' }, 403);
+    }
+
+    const passwordError = await requireCurrentPasswordStepUp(
+      c,
+      auth.user.id,
+      currentPassword,
+      'authenticator:pwd'
+    );
+    if (passwordError) return passwordError;
+
+    const epochs = await getUserEpochs(auth.user.id);
+    if (!epochs || !auth.token.sid) {
+      return c.json({ error: 'Service temporarily unavailable' }, 503);
+    }
+    const registerGrantId = await mintStepUpGrant({
+      userId: auth.user.id,
+      operation: 'register_approver_device',
+      authEpoch: epochs.authEpoch,
+      mfaEpoch: epochs.mfaEpoch,
+      sid: auth.token.sid,
+    });
+    if (!registerGrantId) {
+      return c.json({ error: 'Service temporarily unavailable' }, 503);
+    }
+
+    writeAuthAudit(c, {
+      orgId: auth.orgId ?? undefined,
+      action: 'auth.authenticator.register_grant.minted',
+      result: 'success',
+      userId: auth.user.id,
+      email: auth.user.email,
+      details: { method: 'password' },
+    });
+
+    return c.json({ registerGrantId });
+  }
+);
+```
+
+4. `/devices/webauthn/options` (lines 113-125): replace the password block with:
+
+```ts
+    const auth = c.get('auth');
+    const { registerGrantId } = c.req.valid('json');
+
+    // Non-consuming validate — the SAME grant is consumed at /verify. A
+    // missing/expired/mismatched grant 403s before any challenge is issued.
+    const grantError = await enforceApproverRegisterStepUp(c, auth, registerGrantId, { consume: false });
+    if (grantError) return grantError;
+```
+
+5. `/devices/webauthn/verify` (line 147-149): after reading the body, consume:
+
+```ts
+    const auth = c.get('auth');
+    const { registerGrantId, response, label } = c.req.valid('json');
+
+    // Terminal write — consume the grant (single-use, closes the previously
+    // unguarded verify step: pre-#2707 this route had NO step-up at all).
+    const grantError = await enforceApproverRegisterStepUp(c, auth, registerGrantId, { consume: true });
+    if (grantError) return grantError;
+```
+
+6. Mobile `POST /devices` (lines 205-233): replace the password block with grant consumption and keep the strict re-parse:
+
+```ts
+    const auth = c.get('auth');
+    const body = c.req.valid('json');
+
+    const grantError = await enforceApproverRegisterStepUp(c, auth, body.registerGrantId, { consume: true });
+    if (grantError) return grantError;
+
+    const parsed = mobileHwKeyRegisterSchema.safeParse({
+      publicKey: (body as { publicKey?: unknown }).publicKey,
+      label: (body as { label?: unknown }).label,
+    });
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_registration', detail: parsed.error.issues }, 400);
+    }
+    const { publicKey, label } = parsed.data;
+```
+
+Update the route doc comments (lines 38-51, 192-200): registration is now grant-gated; the grant is minted at login (mobile) or `/register-grant` / `/auth/mfa/step-up` (browser).
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `cd apps/api && pnpm vitest run src/routes/authenticator.test.ts && pnpm typecheck`
+Expected: PASS / clean. Fix any pre-existing tests still sending `currentPassword`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/authenticator.ts apps/api/src/routes/authenticator.test.ts
+git commit -m "feat(auth): approver-device registration takes register grants, adds register-grant mint endpoint (#2707)"
+```
+
+---
+
+### Task 5: Login-time mint (mobile only) — login.ts + mfa.ts, never refresh
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/helpers.ts` (one small helper)
+- Modify: `apps/api/src/routes/auth/login.ts` (no-MFA success, ~line 604-631 — NOT the `/refresh` handler at :700+)
+- Modify: `apps/api/src/routes/auth/mfa.ts` (`/mfa/verify` success, ~line 358-379)
+- Modify: `apps/api/src/openapi.ts:121` area (document the optional field; note `LoginResponse` is `$ref`'d by `/auth/register` too — add a description saying only login/mfa-verify return it)
+- Test: `apps/api/src/routes/auth/login.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `mintStepUpGrant` (Task 1), `readMobileDeviceId` (`../../services/mobileDeviceBinding`), `getUserEpochs`.
+- Produces: `mintLoginRegisterGrant(c: Context, userId: string, sid: string): Promise<string | null>` in helpers.ts; login + mfa-verify responses gain optional `authenticatorRegisterGrantId: string` **only when the mobile device-id header is present**.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `apps/api/src/routes/auth/login.test.ts`, add (mirror the file's existing successful-login fixture; it already fabricates a login that reaches the 200 response — reuse that setup; the mobile header is `X-Breeze-Mobile-Device-Id`, read via the already-mocked-or-real `readMobileDeviceId`):
+
+```ts
+describe('authenticatorRegisterGrantId login mint (#2707)', () => {
+  it('successful login WITH the mobile device-id header includes the grant', async () => {
+    grantMocks.mintStepUpGrant.mockResolvedValue('login-grant-1');
+    const res = await successfulLoginRequest({ headers: { 'X-Breeze-Mobile-Device-Id': 'install-1' } });
+    expect(res.status).toBe(200);
+    expect((await res.json()).authenticatorRegisterGrantId).toBe('login-grant-1');
+    expect(grantMocks.mintStepUpGrant).toHaveBeenCalledWith(
+      expect.objectContaining({ operation: 'register_approver_device' })
+    );
+  });
+
+  it('successful login WITHOUT the header omits the field entirely (web never gets a grant)', async () => {
+    const res = await successfulLoginRequest();
+    const body = await res.json();
+    expect(body).not.toHaveProperty('authenticatorRegisterGrantId');
+    expect(grantMocks.mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('a mint failure (Redis down) still returns tokens', async () => {
+    grantMocks.mintStepUpGrant.mockResolvedValue(null);
+    const res = await successfulLoginRequest({ headers: { 'X-Breeze-Mobile-Device-Id': 'install-1' } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).not.toHaveProperty('authenticatorRegisterGrantId');
+  });
+
+  it('POST /auth/refresh NEVER includes the field, even with the mobile header', async () => {
+    grantMocks.mintStepUpGrant.mockResolvedValue('should-never-appear');
+    const res = await successfulRefreshRequest({ headers: { 'X-Breeze-Mobile-Device-Id': 'install-1' } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).not.toHaveProperty('authenticatorRegisterGrantId');
+  });
+});
+```
+
+`successfulLoginRequest` / `successfulRefreshRequest`: build from the file's existing happy-path login and refresh tests (both exist — the refresh handler is tested in this file). Add `grantMocks` via `vi.mock('../../services/mfaStepUpGrant', ...)` in the hoisted block, following the file's existing mock style.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && pnpm vitest run src/routes/auth/login.test.ts`
+Expected: New tests FAIL (field absent when expected present).
+
+- [ ] **Step 3: Implement**
+
+In `apps/api/src/routes/auth/helpers.ts`, after `enforceApproverRegisterStepUp` (Task 3):
+
+```ts
+/**
+ * #2707: best-effort login-time mint of a register_approver_device grant,
+ * returned to the MOBILE client as `authenticatorRegisterGrantId` so the app
+ * can register its approver key promptlessly right after login.
+ *
+ * Gated on the mobile device-id header: web logins hit the same endpoints and
+ * must NEVER receive a live register grant (300s XSS-readable window for a
+ * grant the page can't use). Returns null on any failure — login must not
+ * break because Redis is down; the phone simply registers on a later login.
+ *
+ * NEVER call this from the /auth/refresh handler: a stolen refresh token
+ * would then mint a fresh register grant on every rotation, defeating the
+ * stolen-session protection the grant exists to provide.
+ */
+export async function mintLoginRegisterGrant(
+  c: Context,
+  userId: string,
+  sid: string
+): Promise<string | null> {
+  if (!readMobileDeviceId(c)) return null;
+  const epochs = await getUserEpochs(userId);
+  if (!epochs) return null;
+  return mintStepUpGrant({
+    userId,
+    operation: 'register_approver_device',
+    authEpoch: epochs.authEpoch,
+    mfaEpoch: epochs.mfaEpoch,
+    sid,
+  });
+}
+```
+
+Add `readMobileDeviceId` and `mintStepUpGrant` to helpers.ts imports (`../../services/mobileDeviceBinding`, `../../services/mfaStepUpGrant`).
+
+In `apps/api/src/routes/auth/login.ts`, just before the success response (after `await floorPromise;`, line 613):
+
+```ts
+  const authenticatorRegisterGrantId = await mintLoginRegisterGrant(c, user.id, familyId);
+```
+
+and in the response object (line 614-631) add:
+
+```ts
+    ...(authenticatorRegisterGrantId ? { authenticatorRegisterGrantId } : {}),
+```
+
+In `apps/api/src/routes/auth/mfa.ts`, before the `/mfa/verify` success response (line 364):
+
+```ts
+    const authenticatorRegisterGrantId = await mintLoginRegisterGrant(c, user.id, mfaFamilyId);
+```
+
+and add the same spread to the response object (lines 364-379). Import `mintLoginRegisterGrant` from `./helpers` in both files.
+
+**Do NOT touch the `/auth/refresh` handler (`login.ts:700-932`).**
+
+In `apps/api/src/openapi.ts` around line 121, add to the `LoginResponse` schema properties:
+
+```ts
+        authenticatorRegisterGrantId: {
+          type: 'string',
+          description:
+            'Single-use 300s grant for registering this device as an approver. Only returned on POST /auth/login and /auth/mfa/verify to clients sending X-Breeze-Mobile-Device-Id; never on /auth/register or /auth/refresh.',
+        },
+```
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `cd apps/api && pnpm vitest run src/routes/auth/login.test.ts && pnpm typecheck`
+Expected: PASS / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/auth/helpers.ts apps/api/src/routes/auth/login.ts apps/api/src/routes/auth/mfa.ts apps/api/src/openapi.ts apps/api/src/routes/auth/login.test.ts
+git commit -m "feat(auth): mint mobile approver register grant at login, never on refresh (#2707)"
+```
+
+---
+
+### Task 6: `GET /users/me` exposes `mfaMethod`
+
+**Files:**
+- Modify: `apps/api/src/routes/users.ts:313-331`
+- Test: whichever sibling test file covers `GET /users/me` (run `grep -rln "'/me'" apps/api/src/routes/users*.test.ts` — extend it; if none covers /me, add the case to `apps/api/src/routes/users.test.ts`)
+
+**Interfaces:**
+- Produces: `/users/me` response gains `mfaMethod: 'totp' | 'sms' | 'passkey' | null`. Web Task 9 consumes it.
+
+- [ ] **Step 1: Failing test** — assert the /me payload includes `mfaMethod` when the user row has `mfaMethod: 'totp'` (mirror the existing /me test's row fixture and add the field).
+
+```ts
+it('includes mfaMethod so the web can pick the register re-auth tier (#2707)', async () => {
+  dbState.selectQueue.push([{ id: 'user-1', email: 't@x.io', name: 'T', mfaEnabled: true, mfaMethod: 'totp' }]);
+  const res = await getMe();
+  expect((await res.json()).mfaMethod).toBe('totp');
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — `cd apps/api && pnpm vitest run <that test file>` → FAIL (`mfaMethod` undefined).
+
+- [ ] **Step 3: Implement** — in the `/me` select (users.ts line 314-331) add after `mfaEnabled`:
+
+```ts
+      // #2707: lets the profile UI pick the approver-register re-auth tier
+      // (passkey → TOTP code → password) without a second endpoint.
+      mfaMethod: users.mfaMethod,
+```
+
+- [ ] **Step 4: Run tests + typecheck** — PASS / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/users.ts apps/api/src/routes/users*.test.ts
+git commit -m "feat(users): expose mfaMethod on GET /users/me (#2707)"
+```
+
+---
+
+### Task 7: Mobile — `ensureApproverDevice` takes a grant, `deferred` outcome, single-flight
+
+**Files:**
+- Modify: `apps/mobile/src/services/approverDevice.ts:57-112`
+- Test: `apps/mobile/src/services/approverDevice.test.ts` (extend; harness shown at its top already mocks SecureStore/fetch/signer)
+
+**Interfaces:**
+- Produces:
+  - `ApproverRegistrationOutcome` gains `| { status: 'deferred'; reason: 'no_reauth_grant' }`.
+  - `ensureApproverDevice(signer?: HardwareSigner, registerGrant?: string): Promise<ApproverRegistrationOutcome>` — POSTs `{ publicKey, label, registerGrantId }` (no `kind`, no `isPlatformBound`), only when a grant is present; module-level single-flight so concurrent calls share one attempt.
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend `approverDevice.test.ts` (reuse `fakeSigner`, `json`, `secureStore`, `fetchMock` fixtures):
+
+```ts
+it('returns deferred and does NOT POST when no grant is available', async () => {
+  const signer = fakeSigner();
+  secureStore.getItemAsync.mockImplementation(async (k: string) =>
+    k === 'breeze_approver_credential_id' ? null : 'test-token',
+  );
+  await expect(ensureApproverDevice(signer)).resolves.toEqual({
+    status: 'deferred',
+    reason: 'no_reauth_grant',
+  });
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(signer.createKeys).not.toHaveBeenCalled();
+});
+
+it('POSTs registerGrantId (and neither kind nor isPlatformBound) when a grant is provided', async () => {
+  const signer = fakeSigner();
+  secureStore.getItemAsync.mockImplementation(async (k: string) =>
+    k === 'breeze_approver_credential_id' ? null : 'test-token',
+  );
+  fetchMock.mockResolvedValueOnce(json({ device: { id: 'dev-1' } }));
+  await expect(ensureApproverDevice(signer, 'grant-1')).resolves.toEqual({ status: 'registered' });
+  const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+  expect(body).toMatchObject({ registerGrantId: 'grant-1', publicKey: 'SPKI-PUBKEY-B64', label: 'This device' });
+  expect(body).not.toHaveProperty('kind');
+  expect(body).not.toHaveProperty('isPlatformBound');
+  expect(body).not.toHaveProperty('currentPassword');
+});
+
+it('concurrent calls share one in-flight attempt (single POST, one grant burn)', async () => {
+  const signer = fakeSigner();
+  secureStore.getItemAsync.mockImplementation(async (k: string) =>
+    k === 'breeze_approver_credential_id' ? null : 'test-token',
+  );
+  let release!: (v: unknown) => void;
+  fetchMock.mockReturnValueOnce(new Promise((r) => { release = r; }));
+  const first = ensureApproverDevice(signer, 'grant-1');
+  const second = ensureApproverDevice(signer, 'grant-1');
+  release(json({ device: { id: 'dev-1' } }));
+  await expect(first).resolves.toEqual({ status: 'registered' });
+  await expect(second).resolves.toEqual({ status: 'registered' });
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+```
+
+Also UPDATE the existing "mints + registers" test (line 63-80): it currently asserts the old body shape — pass a grant and assert the new shape (its `not.toHaveProperty('currentPassword')` assertion stays).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/mobile && pnpm vitest run src/services/approverDevice.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `approverDevice.ts`, replace the outcome type and `ensureApproverDevice` (lines 57-112):
+
+```ts
+export type ApproverRegistrationOutcome =
+  | { status: 'registered' }
+  | { status: 'already_registered' }
+  | { status: 'deferred'; reason: 'no_reauth_grant' }
+  | { status: 'unsupported'; reason: 'no_hardware' }
+  | { status: 'failed'; reason: string };
+
+// Single-flight: RootNavigator's effect can re-fire while a registration is in
+// flight (checkAuth double-dispatches setCredentials on cold start). The grant
+// is single-use, so a duplicate attempt would burn a consumed grant into a 403
+// and overwrite a successful outcome. Concurrent callers share one attempt.
+let inFlight: Promise<ApproverRegistrationOutcome> | null = null;
+
+/**
+ * Idempotent: ensure this phone has a registered approver key. Called after
+ * auth lands. FAILS OPEN — never throws, never blocks login.
+ *
+ * #2707: registration requires a `register_approver_device` grant minted at
+ * login (`authenticatorRegisterGrantId` in the login/mfa-verify response) —
+ * proof of a fresh interactive login, independent of the bearer token. With no
+ * grant (cold-start restored session) there is nothing to prove with: return
+ * `deferred` WITHOUT touching the network; the device registers on the next
+ * real login. The #2683 banner surfaces this state with actionable copy.
+ */
+export async function ensureApproverDevice(
+  signer: HardwareSigner = getHardwareSigner(),
+  registerGrant?: string,
+): Promise<ApproverRegistrationOutcome> {
+  if (inFlight) return inFlight;
+  inFlight = (async (): Promise<ApproverRegistrationOutcome> => {
+    try {
+      if (await SecureStore.getItemAsync(CRED_ID_KEY)) {
+        return { status: 'already_registered' };
+      }
+      if (!(await signer.isAvailable())) {
+        return { status: 'unsupported', reason: 'no_hardware' };
+      }
+      if (!registerGrant) {
+        return { status: 'deferred', reason: 'no_reauth_grant' };
+      }
+      const { publicKey } = await signer.createKeys();              // silent, no biometric
+      const res = await authedFetch('/api/v1/authenticator/devices', {
+        method: 'POST',
+        body: JSON.stringify({
+          publicKey,
+          label: 'This device',
+          registerGrantId: registerGrant,
+        }),
+      });
+      if (!res.ok) {
+        return { status: 'failed', reason: `http_${res.status}` };
+      }
+      const { device } = await res.json();
+      if (!device?.id) {
+        return { status: 'failed', reason: 'missing_device_id' };
+      }
+      await SecureStore.setItemAsync(CRED_ID_KEY, device.id);
+      return { status: 'registered' };
+    } catch {
+      return { status: 'failed', reason: 'exception' };
+    }
+  })();
+  try {
+    return await inFlight;
+  } finally {
+    inFlight = null;
+  }
+}
+```
+
+Update the file-header doc comment (lines 9-14): registration now happens at login **using the login-minted grant**.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd apps/mobile && pnpm vitest run src/services/approverDevice.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mobile/src/services/approverDevice.ts apps/mobile/src/services/approverDevice.test.ts
+git commit -m "feat(mobile): approver registration uses login grant, deferred outcome, single-flight (#2707)"
+```
+
+---
+
+### Task 8: Mobile — capture the grant (api.ts → authSlice → RootNavigator → banner)
+
+**Files:**
+- Modify: `apps/mobile/src/services/api.ts:91-106, 315-355`
+- Modify: `apps/mobile/src/store/authSlice.ts`
+- Modify: `apps/mobile/src/navigation/RootNavigator.tsx:96-111`
+- Modify: `apps/mobile/src/navigation/ApprovalGate.tsx:71-86` (+ a new banner component in that file, cloned from `ApproverFailedBanner`)
+- Test: `apps/mobile/src/store/authSlice.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `ensureApproverDevice(signer?, registerGrant?)` + `'deferred'` outcome (Task 7); `authenticatorRegisterGrantId` in login/mfa-verify responses (Task 5).
+- Produces:
+  - `LoginResult` success variant and `LoginResponse` gain `registerGrant: string | null`.
+  - `AuthState.authenticatorRegisterGrantId: string | null`; action `clearAuthenticatorRegisterGrant()`.
+  - `ApproverRegistrationStatus` gains `'deferred'`.
+
+- [ ] **Step 1: Write the failing slice tests**
+
+Extend `apps/mobile/src/store/authSlice.test.ts` (mirror its existing reducer-test style):
+
+```ts
+it('loginAsync.fulfilled stores the register grant; clearAuthenticatorRegisterGrant drops it', () => {
+  let state = reducer(undefined, loginAsync.fulfilled(
+    { token: 't', user: fakeUser, registerGrant: 'grant-1' } as any, '', { email: 'e', password: 'p' }
+  ));
+  expect(state.authenticatorRegisterGrantId).toBe('grant-1');
+  state = reducer(state, clearAuthenticatorRegisterGrant());
+  expect(state.authenticatorRegisterGrantId).toBeNull();
+});
+
+it('verifyMfaAsync.fulfilled stores the grant; logout clears it', () => {
+  let state = reducer(undefined, verifyMfaAsync.fulfilled(
+    { token: 't', user: fakeUser, registerGrant: 'grant-2' } as any, '', { code: '123456', tempToken: 'tmp' }
+  ));
+  expect(state.authenticatorRegisterGrantId).toBe('grant-2');
+  state = reducer(state, logout());
+  expect(state.authenticatorRegisterGrantId).toBeNull();
+});
+
+it('setCredentials (cold-start restore) does NOT set a grant', () => {
+  const state = reducer(undefined, setCredentials({ token: 't', user: fakeUser }));
+  expect(state.authenticatorRegisterGrantId).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/mobile && pnpm vitest run src/store/authSlice.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`apps/mobile/src/services/api.ts`:
+
+```ts
+export interface LoginResponse {
+  token: string;
+  user: User;
+  /** #2707: single-use approver-register grant minted at login; memory-only. */
+  registerGrant: string | null;
+}
+// LoginResult success variant:
+export type LoginResult =
+  | { kind: 'success'; token: string; user: User; registerGrant: string | null }
+  | { kind: 'mfaRequired'; challenge: MfaChallenge };
+// LoginPayload gains:
+  authenticatorRegisterGrantId?: string;
+```
+
+`login()` (line 340): `return { kind: 'success', token, user: response.user, registerGrant: response.authenticatorRegisterGrantId ?? null };`
+`verifyMfa()` (line 354): `return { token, user: response.user, registerGrant: response.authenticatorRegisterGrantId ?? null };`
+
+`apps/mobile/src/store/authSlice.ts`:
+- `ApproverRegistrationStatus` (line 21): add `'deferred'` → `'idle' | 'registered' | 'deferred' | 'failed' | 'unsupported'`.
+- `AuthState` + `initialState`: add `authenticatorRegisterGrantId: string | null` (initial `null`).
+- `loginAsync` thunk success return (line 60): `return { token: result.token, user: result.user, registerGrant: result.registerGrant };`
+- `loginAsync.fulfilled` (line 180-184): add `state.authenticatorRegisterGrantId = action.payload.registerGrant ?? null;` inside the token branch.
+- `verifyMfaAsync.fulfilled` (line 194-200): add `state.authenticatorRegisterGrantId = action.payload.registerGrant ?? null;`
+- New reducer:
+
+```ts
+    // #2707: the grant is single-use — RootNavigator takes it (read-and-clear)
+    // BEFORE the registration attempt so a re-fired effect can't replay it.
+    clearAuthenticatorRegisterGrant: (state) => {
+      state.authenticatorRegisterGrantId = null;
+    },
+```
+
+- `logout` reducer (line 131-141) and BOTH `logoutAsync.fulfilled`/`.rejected` (lines 208-225): add `state.authenticatorRegisterGrantId = null;`
+- Export `clearAuthenticatorRegisterGrant` from the actions destructure.
+
+`apps/mobile/src/navigation/RootNavigator.tsx` (lines 96-111) — read-and-clear BEFORE the async call. Import the app's Redux store instance directly (find the export: `grep -n "export const store" apps/mobile/src/store/index.ts` — adjust the import to match) plus `clearAuthenticatorRegisterGrant`:
+
+```ts
+  useEffect(() => {
+    if (!token || !user) return;
+    let active = true;
+    // #2707 read-and-clear: take the login-minted grant OUT of Redux before the
+    // async attempt. The grant is deliberately NOT in this effect's deps — the
+    // effect re-fires on every `user` identity change (checkAuth double-fires on
+    // cold start), and a replayed single-use grant would 403 and overwrite a
+    // successful registration with `failed`.
+    const registerGrant = store.getState().auth.authenticatorRegisterGrantId;
+    if (registerGrant) dispatch(clearAuthenticatorRegisterGrant());
+    void ensureApproverDevice(undefined, registerGrant ?? undefined).then((outcome) => {
+      if (!active) return;
+      dispatch(
+        setApproverRegistration({
+          status: outcome.status === 'already_registered' ? 'registered' : outcome.status,
+          reason: 'reason' in outcome ? outcome.reason : null,
+        })
+      );
+    });
+    return () => {
+      active = false;
+    };
+  }, [token, user, dispatch]);
+```
+
+(`ensureApproverDevice(undefined, ...)`: `undefined` triggers the signer default parameter. The `outcome.status` mapping already passes `'deferred'` straight through into the widened `ApproverRegistrationStatus`.)
+
+`apps/mobile/src/navigation/ApprovalGate.tsx` — after the `ApproverFailedBanner` slot (line 81-83), add a lower-priority deferred banner:
+
+```tsx
+      {!error && pushRegistration !== 'failed' && approverRegistration === 'deferred' ? (
+        <ApproverDeferredBanner />
+      ) : null}
+```
+
+Clone `ApproverFailedBanner` in the same file as `ApproverDeferredBanner`, with informational (non-destructive) styling and the copy:
+
+> **Finish approver setup** — Sign out and back in to let this phone approve requests with Face ID.
+
+(Keep the same safe-area/absolute-slot layout the sibling banners use.)
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `cd apps/mobile && pnpm vitest run src/store/authSlice.test.ts src/services/approverDevice.test.ts && pnpm typecheck --filter=@breeze/mobile 2>/dev/null || (cd apps/mobile && pnpm tsc --noEmit)`
+Expected: PASS / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mobile/src/services/api.ts apps/mobile/src/store/authSlice.ts apps/mobile/src/store/authSlice.test.ts apps/mobile/src/navigation/RootNavigator.tsx apps/mobile/src/navigation/ApprovalGate.tsx
+git commit -m "feat(mobile): thread login register grant to approver registration, deferred banner (#2707)"
+```
+
+---
+
+### Task 9: Web store — `registerApproverDevice(label, reauth)` with three mint paths
+
+**Files:**
+- Modify: `apps/web/src/stores/authenticator.ts:36-63`
+- Test: `apps/web/src/stores/authenticator.test.ts` (extend; harness mocks `@simplewebauthn/browser` + global fetch)
+
+**Interfaces:**
+- Consumes: wire contract from Task 4 (`registerGrantId` on all three register calls; `/authenticator/register-grant`), Task 2 (`/auth/mfa/step-up` + `operation`, returns `{ stepUpGrantId }`), `POST /auth/mfa/step-up/options` (existing, returns `{ options }`).
+- Produces (Task 10 consumes):
+
+```ts
+export type RegisterReauth =
+  | { method: 'passkey' }
+  | { method: 'totp'; code: string }
+  | { method: 'password'; password: string };
+export async function registerApproverDevice(label: string, reauth: RegisterReauth): Promise<void>
+```
+
+Thrown errors carry `status?: number` so the component can map 401/403/429.
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend `stores/authenticator.test.ts`:
+
+```ts
+describe('registerApproverDevice re-auth mint paths (#2707)', () => {
+  const optionsPayload = { options: { challenge: 'reg-challenge', rp: { id: 'x', name: 'x' } } };
+
+  it('password path: mints via /authenticator/register-grant then threads registerGrantId to options+verify', async () => {
+    webauthnMocks.startRegistration.mockResolvedValueOnce({ id: 'cred-1', response: {} });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(makeResponse({ registerGrantId: 'g-pass' }))   // mint
+      .mockResolvedValueOnce(makeResponse(optionsPayload))                  // options
+      .mockResolvedValueOnce(makeResponse({ success: true }));              // verify
+    vi.stubGlobal('fetch', fetchMock);
+
+    await registerApproverDevice('Front desk', { method: 'password', password: 'hunter2!' });
+
+    expect(fetchMock.mock.calls[0][0]).toContain('/authenticator/register-grant');
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ currentPassword: 'hunter2!' });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ registerGrantId: 'g-pass' });
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body)).toMatchObject({
+      registerGrantId: 'g-pass', label: 'Front desk',
+    });
+  });
+
+  it('totp path: mints via /auth/mfa/step-up with operation register_approver_device', async () => {
+    webauthnMocks.startRegistration.mockResolvedValueOnce({ id: 'cred-1', response: {} });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(makeResponse({ stepUpGrantId: 'g-totp' }))
+      .mockResolvedValueOnce(makeResponse(optionsPayload))
+      .mockResolvedValueOnce(makeResponse({ success: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await registerApproverDevice('Laptop', { method: 'totp', code: '123456' });
+
+    expect(fetchMock.mock.calls[0][0]).toContain('/auth/mfa/step-up');
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      method: 'totp', code: '123456', operation: 'register_approver_device',
+    });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ registerGrantId: 'g-totp' });
+  });
+
+  it('passkey path: step-up options → startAuthentication → step-up mint → register', async () => {
+    const assertion = { id: 'pk-cred', response: { signature: 's' } };
+    webauthnMocks.startAuthentication.mockResolvedValueOnce(assertion);
+    webauthnMocks.startRegistration.mockResolvedValueOnce({ id: 'cred-1', response: {} });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(makeResponse({ options: { challenge: 'auth-challenge' } })) // step-up options
+      .mockResolvedValueOnce(makeResponse({ stepUpGrantId: 'g-pk' }))                    // step-up mint
+      .mockResolvedValueOnce(makeResponse(optionsPayload))                               // register options
+      .mockResolvedValueOnce(makeResponse({ success: true }));                           // verify
+    vi.stubGlobal('fetch', fetchMock);
+
+    await registerApproverDevice('Laptop', { method: 'passkey' });
+
+    expect(fetchMock.mock.calls[0][0]).toContain('/auth/mfa/step-up/options');
+    expect(webauthnMocks.startAuthentication).toHaveBeenCalledWith({
+      optionsJSON: { challenge: 'auth-challenge' },
+    });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      method: 'passkey', credential: assertion, operation: 'register_approver_device',
+    });
+  });
+
+  it('mint failure rejects with the status attached (so the UI can map 401/403/429)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(makeResponse({ error: 'Invalid credentials' }, false, 401));
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(
+      registerApproverDevice('x', { method: 'password', password: 'nope' })
+    ).rejects.toMatchObject({ status: 401 });
+    expect(webauthnMocks.startRegistration).not.toHaveBeenCalled();
+  });
+});
+```
+
+Also UPDATE the pre-existing `registerApproverDevice` test (line 35-70): it calls the old single-argument signature — convert it to the password path or delete it in favor of the new suite.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/web && pnpm vitest run src/stores/authenticator.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Replace `registerApproverDevice` in `stores/authenticator.ts` (lines 36-63):
+
+```ts
+export type RegisterReauth =
+  | { method: 'passkey' }
+  | { method: 'totp'; code: string }
+  | { method: 'password'; password: string };
+
+class RegisterStepError extends Error {
+  status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function jsonOrThrow(response: Response, fallback: string): Promise<any> {
+  const data = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new RegisterStepError(data?.error ?? fallback, response.status);
+  }
+  return data;
+}
+
+/**
+ * Mint a single-use register_approver_device grant with whichever re-auth
+ * factor the caller proved (#2707 — spec: strongest available factor; the
+ * password endpoint 403s `stronger_factor_required` if TOTP/passkey exist).
+ */
+async function mintRegisterGrant(reauth: RegisterReauth): Promise<string> {
+  if (reauth.method === 'password') {
+    const data = await jsonOrThrow(
+      await fetchWithAuth('/authenticator/register-grant', {
+        method: 'POST',
+        body: JSON.stringify({ currentPassword: reauth.password }),
+      }),
+      'Verification failed.'
+    );
+    if (!data?.registerGrantId) throw new RegisterStepError('Verification failed.');
+    return data.registerGrantId;
+  }
+
+  let stepUpBody: Record<string, unknown>;
+  if (reauth.method === 'totp') {
+    stepUpBody = { method: 'totp', code: reauth.code, operation: 'register_approver_device' };
+  } else {
+    // Passkey: fetch an authenticated step-up challenge, run the assertion
+    // ceremony, then prove it to /auth/mfa/step-up.
+    const challengeData = await jsonOrThrow(
+      await fetchWithAuth('/auth/mfa/step-up/options', { method: 'POST' }),
+      'Could not start passkey verification.'
+    );
+    const optionsJSON: PublicKeyCredentialRequestOptionsJSON =
+      challengeData.options ?? challengeData.optionsJSON ?? challengeData;
+    const credential = await startAuthentication({ optionsJSON });
+    stepUpBody = { method: 'passkey', credential, operation: 'register_approver_device' };
+  }
+
+  const data = await jsonOrThrow(
+    await fetchWithAuth('/auth/mfa/step-up', {
+      method: 'POST',
+      body: JSON.stringify(stepUpBody),
+    }),
+    'Verification failed.'
+  );
+  if (!data?.stepUpGrantId) throw new RegisterStepError('Verification failed.');
+  // The step-up endpoint names it stepUpGrantId; the register routes take it
+  // as registerGrantId — same value, different field name.
+  return data.stepUpGrantId;
+}
+
+/**
+ * Register the current browser/platform authenticator as an approver device.
+ * re-auth mint → options (validates the grant) → Windows Hello / Touch ID
+ * registration ceremony → verify (consumes the grant).
+ */
+export async function registerApproverDevice(label: string, reauth: RegisterReauth): Promise<void> {
+  const registerGrantId = await mintRegisterGrant(reauth);
+
+  const optionsData = await jsonOrThrow(
+    await fetchWithAuth('/authenticator/devices/webauthn/options', {
+      method: 'POST',
+      body: JSON.stringify({ registerGrantId }),
+    }),
+    'Failed to start device registration.'
+  );
+  const optionsJSON: PublicKeyCredentialCreationOptionsJSON =
+    optionsData.options ?? optionsData.optionsJSON ?? optionsData;
+
+  const response = await startRegistration({ optionsJSON });
+
+  await jsonOrThrow(
+    await fetchWithAuth('/authenticator/devices/webauthn/verify', {
+      method: 'POST',
+      body: JSON.stringify({ registerGrantId, label, response }),
+    }),
+    'Device registration failed.'
+  );
+}
+```
+
+(`startAuthentication` and `PublicKeyCredentialRequestOptionsJSON` are already imported at the top of the file.)
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `cd apps/web && pnpm vitest run src/stores/authenticator.test.ts && pnpm tsc --noEmit`
+Expected: PASS. The typecheck WILL flag `ApproverDevicesSection.tsx` calling the old one-arg signature — that's Task 10; if you need green now, leave the old call temporarily as `registerApproverDevice(trimmed, { method: 'password', password: '' })` is NOT acceptable — instead do Tasks 9 and 10 in one PR-visible sequence and only require the full `tsc` pass at the end of Task 10.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/stores/authenticator.ts apps/web/src/stores/authenticator.test.ts
+git commit -m "feat(web): registerApproverDevice mints re-auth grants (passkey/totp/password) (#2707)"
+```
+
+---
+
+### Task 10: Web UI — re-auth step in `ApproverDevicesSection` + ProfilePage plumbing + i18n
+
+**Files:**
+- Create: `apps/web/src/components/settings/StepUpPrompt.tsx`
+- Modify: `apps/web/src/components/settings/ApproverDevicesSection.tsx`
+- Modify: `apps/web/src/components/settings/ProfilePage.tsx:25-32, 914`
+- Modify: `apps/web/src/locales/{en,de-DE,es-419,fr-FR,pt-BR}/settings.json`
+- Test: `apps/web/src/components/settings/StepUpPrompt.test.tsx` (new)
+
+**Interfaces:**
+- Consumes: `registerApproverDevice(label, reauth)` + `RegisterReauth` (Task 9); `mfaMethod` from `/users/me` (Task 6); `passkeys.length` from ProfilePage state.
+- Produces: `<StepUpPrompt tier reauthValue onChange />` and `<ApproverDevicesSection passkeyCount={number} mfaMethod={string | null} />`.
+
+- [ ] **Step 1: Write the failing StepUpPrompt test**
+
+Create `apps/web/src/components/settings/StepUpPrompt.test.tsx` (jsdom, mirror the render style of other settings component tests):
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StepUpPrompt, { pickReauthTier } from './StepUpPrompt';
+
+describe('pickReauthTier', () => {
+  it.each([
+    [2, 'totp', 'passkey'],     // passkey wins even with TOTP
+    [0, 'totp', 'totp'],
+    [0, 'sms', 'password'],     // SMS users take the password path (spec)
+    [0, null, 'password'],
+  ] as const)('passkeys=%s mfaMethod=%s → %s', (passkeyCount, mfaMethod, expected) => {
+    expect(pickReauthTier(passkeyCount, mfaMethod)).toBe(expected);
+  });
+});
+
+describe('StepUpPrompt', () => {
+  it('renders a code input for totp tier', () => {
+    render(<StepUpPrompt tier="totp" reauthValue="" onChange={vi.fn()} disabled={false} />);
+    expect(screen.getByTestId('approver-stepup-code')).toBeTruthy();
+  });
+  it('renders a password input for password tier', () => {
+    render(<StepUpPrompt tier="password" reauthValue="" onChange={vi.fn()} disabled={false} />);
+    expect(screen.getByTestId('approver-stepup-password')).toBeTruthy();
+  });
+  it('renders only the explainer for passkey tier (ceremony happens on submit)', () => {
+    render(<StepUpPrompt tier="passkey" reauthValue="" onChange={vi.fn()} disabled={false} />);
+    expect(screen.queryByTestId('approver-stepup-code')).toBeNull();
+    expect(screen.queryByTestId('approver-stepup-password')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — `cd apps/web && pnpm vitest run src/components/settings/StepUpPrompt.test.tsx` → FAIL (module missing).
+
+- [ ] **Step 3: Implement StepUpPrompt**
+
+Create `apps/web/src/components/settings/StepUpPrompt.tsx`:
+
+```tsx
+import { useTranslation } from 'react-i18next';
+
+export type ReauthTier = 'passkey' | 'totp' | 'password';
+
+/** Strongest-available-factor tiering — mirrors the server gate
+ * (`userHasStrongerReauthFactor`): passkey → TOTP → password. SMS-method
+ * accounts fall to password (no authenticated step-up SMS sender; spec #2707). */
+export function pickReauthTier(passkeyCount: number, mfaMethod: string | null): ReauthTier {
+  if (passkeyCount > 0) return 'passkey';
+  if (mfaMethod === 'totp') return 'totp';
+  return 'password';
+}
+
+type Props = {
+  tier: ReauthTier;
+  reauthValue: string;
+  onChange: (value: string) => void;
+  disabled: boolean;
+};
+
+/**
+ * Re-auth input for approver-device registration. Reusable: ProfilePage's
+ * add-passkey flow (currently dead-ends for MFA-protected users on
+ * existing_factor_step_up_required) is the intended second consumer.
+ */
+export default function StepUpPrompt({ tier, reauthValue, onChange, disabled }: Props) {
+  const { t } = useTranslation('settings');
+
+  if (tier === 'passkey') {
+    return (
+      <p className="text-xs text-muted-foreground" data-testid="approver-stepup-passkey-note">
+        {t('stepUpPrompt.youWillConfirmWithYourPasskey')}
+      </p>
+    );
+  }
+
+  if (tier === 'totp') {
+    return (
+      <div className="space-y-2">
+        <label className="text-sm font-medium" htmlFor="approver-stepup-code">
+          {t('stepUpPrompt.authenticatorCode')}
+        </label>
+        <input
+          id="approver-stepup-code"
+          type="text"
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          maxLength={6}
+          value={reauthValue}
+          onChange={(e) => onChange(e.target.value.replace(/\D/g, ''))}
+          className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+          disabled={disabled}
+          data-testid="approver-stepup-code"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-medium" htmlFor="approver-stepup-password">
+        {t('stepUpPrompt.confirmYourPassword')}
+      </label>
+      <input
+        id="approver-stepup-password"
+        type="password"
+        autoComplete="current-password"
+        value={reauthValue}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+        disabled={disabled}
+        data-testid="approver-stepup-password"
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Wire `ApproverDevicesSection`**
+
+In `ApproverDevicesSection.tsx`:
+
+1. Props: `export default function ApproverDevicesSection({ passkeyCount, mfaMethod }: { passkeyCount: number; mfaMethod: string | null })`.
+2. Imports: `StepUpPrompt, { pickReauthTier, type ReauthTier }` and `type RegisterReauth` from `../../stores/authenticator`.
+3. State: add `const [reauthValue, setReauthValue] = useState('');` and `const tier: ReauthTier = pickReauthTier(passkeyCount, mfaMethod);`
+4. Replace `handleRegister` (lines 71-96):
+
+```tsx
+  const buildReauth = (): RegisterReauth | null => {
+    if (tier === 'passkey') return { method: 'passkey' };
+    if (tier === 'totp') return reauthValue.length === 6 ? { method: 'totp', code: reauthValue } : null;
+    return reauthValue.length > 0 ? { method: 'password', password: reauthValue } : null;
+  };
+
+  const mapRegisterError = (err: unknown): string => {
+    const status = (err as { status?: number })?.status;
+    if (status === 401) {
+      return tier === 'totp'
+        ? t('approverDevicesSection.incorrectCode')
+        : t('approverDevicesSection.incorrectPassword');
+    }
+    if (status === 429) return t('approverDevicesSection.tooManyAttemptsTryAgainInAFewMinutes');
+    if (status === 403) return t('approverDevicesSection.verificationExpiredPleaseVerifyAgain');
+    return err instanceof Error ? err.message : t('approverDevicesSection.failedToRegisterThisDevice');
+  };
+
+  const handleRegister = async () => {
+    if (isRegistering) return;
+    const reauth = buildReauth();
+    if (!reauth) return; // submit disabled anyway
+    const trimmed = label.trim() || 'This device';
+    setIsRegistering(true);
+    try {
+      await runAction({
+        request: async () => {
+          await registerApproverDevice(trimmed, reauth);
+          return OK_RESPONSE;
+        },
+        errorFallback: t('approverDevicesSection.failedToRegisterThisDevice'),
+        successMessage: t('approverDevicesSection.thisDeviceCanNowApproveRequests'),
+      });
+      setLabel('');
+      setReauthValue('');
+      await load();
+    } catch (err) {
+      if (err instanceof ActionError) return; // already toasted by runAction
+      // 403 = grant expired mid-ceremony (>300s in the WebAuthn prompt): keep
+      // the label, clear the proof, and ask the user to verify again.
+      if ((err as { status?: number })?.status === 403) setReauthValue('');
+      showToast({ type: 'error', message: mapRegisterError(err) });
+    } finally {
+      setIsRegistering(false);
+    }
+  };
+```
+
+5. In the register form JSX (after the label input, line 293), add `<StepUpPrompt tier={tier} reauthValue={reauthValue} onChange={setReauthValue} disabled={isRegistering} />`, and disable the submit button when `buildReauth() === null`.
+6. Pending-state success UI: in the device row, next to the platform-bound badge (line 205-211), when `device.lastUsedAt === null` render:
+
+```tsx
+    {device.lastUsedAt === null && (
+      <span
+        data-testid={`approver-device-pending-${device.id}`}
+        className="rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600"
+      >
+        {t('approverDevicesSection.pendingActivatesOnFirstApproval')}
+      </span>
+    )}
+```
+
+In `ProfilePage.tsx`:
+- `User` type (line 25-32): add `mfaMethod?: string | null;` (populated by Task 6's `/users/me` change — the fetch at line 131 already spreads the payload).
+- Line 914: `<ApproverDevicesSection passkeyCount={passkeys.length} mfaMethod={user?.mfaMethod ?? null} />`.
+
+- [ ] **Step 5: Add the i18n keys to ALL FIVE locales**
+
+`apps/web/src/locales/en/settings.json` — add inside the existing `approverDevicesSection` object:
+
+```json
+"incorrectCode": "Incorrect code.",
+"incorrectPassword": "Incorrect password.",
+"tooManyAttemptsTryAgainInAFewMinutes": "Too many attempts — try again in a few minutes.",
+"verificationExpiredPleaseVerifyAgain": "Verification expired — please verify again.",
+"pendingActivatesOnFirstApproval": "Pending — activates on first approval"
+```
+
+and a new top-level `stepUpPrompt` object:
+
+```json
+"stepUpPrompt": {
+  "youWillConfirmWithYourPasskey": "You'll confirm with your passkey (Touch ID / Windows Hello) when you register.",
+  "authenticatorCode": "Authenticator code",
+  "confirmYourPassword": "Confirm your password"
+}
+```
+
+Then add the SAME keys with translated values to `de-DE`, `es-419`, `fr-FR`, `pt-BR` `settings.json` (translate faithfully; the parity check only needs the keys present, but don't ship English into the other locales — match the tone of neighboring keys in each file).
+
+- [ ] **Step 6: Run tests + typecheck + locale parity**
+
+Run: `cd apps/web && pnpm vitest run src/components/settings/StepUpPrompt.test.tsx src/stores/authenticator.test.ts && pnpm vitest run src/lib/__tests__/no-silent-mutations.test.ts && pnpm tsc --noEmit`
+Also run whichever test enforces locale key parity (`grep -rln "locale" apps/web/src --include="*.test.ts" | head` to find it) — it must pass.
+Expected: all PASS; the full-project `tsc` now passes (Task 9's temporary breakage resolved).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/settings/StepUpPrompt.tsx apps/web/src/components/settings/StepUpPrompt.test.tsx apps/web/src/components/settings/ApproverDevicesSection.tsx apps/web/src/components/settings/ProfilePage.tsx apps/web/src/locales/*/settings.json
+git commit -m "feat(web): approver registration re-auth step (passkey/totp/password) with pending badge (#2707)"
+```
+
+---
+
+### Task 11: Full verification sweep
+
+**Files:** none new — verification only.
+
+- [ ] **Step 1: Full unit suites**
+
+```bash
+pnpm test --filter=@breeze/api
+cd apps/web && pnpm vitest run
+cd ../mobile && pnpm vitest run
+```
+Expected: all green. Known flaky suites (memory: durationMs truncation, AutomationTab catalog) may need one retry — a NEW red is yours.
+
+- [ ] **Step 2: Repo-wide contract greps**
+
+```bash
+# No register route still reads currentPassword (only /register-grant + unrelated routes may):
+grep -n "currentPassword" apps/api/src/routes/authenticator.ts
+# Expect exactly the registerGrantMintSchema + /register-grant handler hits.
+
+# The refresh handler never mints:
+grep -n "mintLoginRegisterGrant\|authenticatorRegisterGrantId" apps/api/src/routes/auth/login.ts
+# Expect hits ONLY in the password-login success block (before line ~632), NONE in /refresh (line 700+).
+
+# Mobile client no longer sends kind/isPlatformBound:
+grep -n "isPlatformBound\|'kind'" apps/mobile/src/services/approverDevice.ts
+# Expect no hits in the POST body.
+```
+
+- [ ] **Step 3: Manual smoke against the worktree stack** (optional but recommended; use the `worktree-stack` skill): login on web → Settings → register this browser with each available tier; confirm the pending badge; forge a POST to `/authenticator/devices` with a bearer token and NO grant → expect 403 `register_step_up_required`.
+
+- [ ] **Step 4: Commit any test-only fixups, then hand off**
+
+```bash
+git add -A && git commit -m "test: verification fixups for approver register grants (#2707)" --allow-empty
+```
+
+Open the PR per the repo's normal flow (`commit-commands:commit-push-pr` or manual `gh pr create`), body referencing issue #2707 and the spec.
+
+---
+
+## Self-Review (done at plan-writing time)
+
+- **Spec coverage:** operation union (T1), step-up operation (T2), unconditional enforcement + no-bypass pin (T3), route swap + password mint + stronger-factor gate (T4), login mints mobile-gated + refresh-never + OpenAPI (T5), mfaMethod on /me (T6), mobile grant flow + deferred + single-flight + read-and-clear + banner (T7-8), web three mint paths + naming seam (T9), UI tiering + error mapping + pending badge + i18n (T10). Out-of-scope items (SSO-only lockout, ProfilePage passkey dead-end, SMS sender) intentionally have no tasks.
+- **Known softness (acceptable):** three test-harness details are discovered at execution time by mirroring named sibling files (`helpers.mfaStepUp.test.ts` fixtures in T3, login.test.ts request builders in T5, the /me test file in T6). The assertions and scenarios are fully specified; only fixture plumbing is inherited.
+- **Type consistency:** `RegisterReauth` (T9) ↔ StepUpPrompt tiers (T10); `registerGrant: string | null` (T8 api.ts ↔ authSlice); `enforceApproverRegisterStepUp` signature identical in T3 (definition) and T4 (call sites); wire field names `registerGrantId` / `stepUpGrantId` / `authenticatorRegisterGrantId` used consistently per the spec's naming-seam note.

--- a/docs/superpowers/specs/2026-07-21-authenticator-register-grant-design.md
+++ b/docs/superpowers/specs/2026-07-21-authenticator-register-grant-design.md
@@ -1,7 +1,8 @@
 # Authenticator approver-device registration — grant-based re-auth
 
 **Issue:** #2707
-**Date:** 2026-07-21
+**Date:** 2026-07-21 (rev 2 — corrected mint points, added MFA/passkey re-auth
+path, UX pass; re-verified against code after a second review round)
 **Status:** Design approved, pending implementation plan
 
 ## Problem
@@ -23,15 +24,18 @@ Two distinct defects:
 2. **Browser** — never worked; `stores/authenticator.ts` has never sent
    `currentPassword` since the first Authenticator commit (#1369).
 
-## Constraint (do NOT drop `currentPassword`)
+## Constraint (do NOT drop re-auth)
 
 Per #1890's security review: registration is deferred-proof-of-possession — a new
 key is stored `pending` (`last_used_at` null) and activates on its first approval
 signature, with no signature at registration time. If a live access token *alone*
 could register a key, a stolen-session attacker could enroll their own approver
 key and self-sign approvals up to L2/L3, defeating the possession factor.
-Registration must be tied to a factor **independent of the bearer token**:
-knowledge of the account password, or a fresh interactive login.
+Registration must be tied to **one factor independent of the bearer token**:
+knowledge of the account password, proof of an existing MFA factor
+(TOTP/SMS/passkey), or a fresh interactive login. This matches the bar #1890 set
+(password alone — a single independent factor — was sufficient); we widen *which*
+factor qualifies, not how many are required.
 
 ## Key realization about the browser
 
@@ -39,26 +43,89 @@ A re-auth grant minted at login has a short TTL (300s). By the time a user
 navigates to Settings → "Register this browser," a login-time grant is expired;
 making it long-lived would reintroduce the exact stolen-session risk above.
 Therefore the **browser must mint a fresh grant at register-time**, which means a
-password prompt either way. For the browser, "full re-auth token" and "the
-stopgap" converge on the same UX (one password prompt); only the wire path
-differs. The token genuinely earns its keep on **mobile**, which must stay
-promptless.
+re-auth prompt either way. The login-time grant genuinely earns its keep on
+**mobile**, which must stay promptless.
+
+## Browser re-auth: existing factor preferred, password as fallback
+
+Decision (rev 2): the browser prompt is **not** password-only. The API already
+has `POST /auth/mfa/step-up` (`routes/auth/mfa.ts:721`, SR2-20): a discriminated
+union on `method` verifying **TOTP, SMS, or a passkey assertion** (passkey
+challenge from `POST /auth/mfa/step-up/options`), per-user rate-limited
+(`mfa:stepup-rl:`), audited, minting a 300s single-use grant — today hardcoded to
+`operation: 'add_factor'` (`mfa.ts:798`).
+
+Method selection, best UX first — the UI offers exactly one, and the server
+enforces the same tiering:
+
+1. **Passkey** (user has ≥1 passkey): one Touch ID / Windows Hello tap. No
+   typing, phishing-resistant, and it's the natural gesture right before a
+   WebAuthn *registration* ceremony.
+2. **TOTP code** (`mfaMethod === 'totp'`, no passkey): 6-digit code entry.
+3. **Password** (no passkey and no TOTP — including SMS-method MFA users, see
+   below): password field, exactly the pre-rev-2 flow.
+
+**SMS is deliberately NOT offered** as a browser re-auth method: the step-up
+endpoint can *check* an SMS code (`mfa.ts:750-773`) but nothing can *send* one
+to an authenticated user — the login sender `POST /auth/mfa/sms/send`
+(`routes/auth/phone.ts:322`) is pre-auth and tempToken-gated, and
+`/phone/verify` sends to a client-supplied number for phone *setup*. An
+authenticated "send step-up SMS" endpoint would be new abuse surface for
+marginal gain; SMS-method users take the password path instead (SIM-swap-prone
+SMS is not meaningfully stronger than password re-auth).
+
+**Server-side gate on the password path**: `POST /authenticator/register-grant`
+refuses password re-auth (403, distinct error code, e.g.
+`stronger_factor_required`) when the account has a TOTP secret or ≥1 passkey.
+Without this the UI tiering is decoration — a direct API caller with a stolen
+session + phished password could register an approver key on an MFA-protected
+account, an asymmetry vs. the SR2-20 `add_factor` contract (which blocks
+exactly that via `enforceExistingFactorStepUp`). With it, server and UI agree:
+strongest available factor, password only when nothing stronger exists.
+
+**Data source for the UI**: passkey count is already in ProfilePage's data and
+`mfaEnabled` is on `GET /users/me`, but **`mfaMethod` is not exposed post-login
+anywhere** — add it to `GET /users/me` (`routes/users.ts`, one field off the
+user's own row).
+
+This also unlocks **SSO-only / passwordless accounts** (`users.password_hash` is
+nullable; `requireCurrentPasswordStepUp` 401s them) as long as they have a
+passkey or TOTP. SSO-only accounts with neither remain unable to register a
+browser approver device — documented limitation (see Known tradeoffs).
+
+Considered and rejected: requiring password **and** existing-factor step-up
+together (the SR2-20 `add_factor` contract for MFA-protected accounts). #1890's
+bar is one independent factor, the mobile path (fresh login) already satisfies it
+with one composite event, and double-prompting is exactly the friction that keeps
+approver enrollment at zero. The server-side gate above keeps the one-factor bar
+but requires it to be the *strongest available* factor.
 
 ## Approach: reuse `mfaStepUpGrant`, one unified register contract
 
-The codebase already has the primitive the issue describes:
-`services/mfaStepUpGrant.ts` — Redis-backed, 300s TTL, single-use (`getdel`),
-bound to `(userId, operation, authEpoch, mfaEpoch, sid)`. Its only `operation`
-today is `'add_factor'`.
+`services/mfaStepUpGrant.ts` — Redis-backed, 300s TTL, single-use
+(`consumeStepUpGrant` = GETDEL) with a separate non-consuming
+`validateStepUpGrant` (GET), keys are **random UUIDs** (`mfa:stepup:<uuid>`, so
+concurrent grants for the same user coexist — two devices logging in within the
+TTL never clobber each other), bound to
+`(userId, operation, authEpoch, mfaEpoch, sid)` via `bindsMatch`.
 
-**Extend the union with `'register_approver_device'`** and reuse
+**Extend the `operation` union with `'register_approver_device'`** and reuse
 `mintStepUpGrant` / `validateStepUpGrant` / `consumeStepUpGrant` verbatim. No new
 token type, no schema/migration. A grant minted for one operation can never be
 consumed for another (`bindsMatch` checks operation equality).
 
+> **Implementation warning — do NOT reuse `enforceExistingFactorStepUp`**
+> (`routes/auth/helpers.ts:284`). That helper early-returns null (pass) for
+> non-MFA-protected accounts (`userIsMfaProtected` check at `helpers.ts:290`) —
+> correct for `add_factor`, catastrophic here: it would let a stolen bearer
+> token register an approver key for every non-MFA user. Write an unconditional
+> sibling (same 503-on-missing-sid/epochs, same 403 shape) that enforces the
+> grant for **all** users. A test must pin this: non-MFA user, no grant → 403.
+
 ### Server contract
 
-Both register routes stop taking `currentPassword` and take `registerGrantId`:
+All three register routes stop taking `currentPassword` and take
+`registerGrantId`:
 
 | Route | Grant handling |
 |---|---|
@@ -66,116 +133,246 @@ Both register routes stop taking `currentPassword` and take `registerGrantId`:
 | `POST /authenticator/devices/webauthn/verify` (browser) | **consume** |
 | `POST /authenticator/devices` (mobile) | **consume** |
 
-Two-phase validate→consume on the browser flow mirrors the existing passkey
-`enforceExistingFactorStepUp(..., { consume })` pattern (`routes/auth/passkeys.ts`,
-`routes/auth/phone.ts`): the SAME grant is validated at `options` and consumed at
-`verify`. A wrong/missing/expired/mismatched grant is a 403 (`register_step_up_required`);
-a malformed request stays 400.
+Two-phase validate→consume mirrors the passkey/phone/TOTP
+`{ consume: false }` → `{ consume: true }` pattern: the SAME grant is validated
+at `options` and consumed at `verify`. A wrong/missing/expired/mismatched grant
+is a 403 (`register_step_up_required`); a malformed request stays 400. Note this
+*strengthens* the browser flow: today `registerVerifySchema` has no step-up at
+all — the password is only checked at `options`.
 
-Grants are minted two ways:
+Grants are minted three ways:
 
-1. **`POST /authenticator/register-grant { currentPassword }`** — new mint
-   endpoint. Runs `requireCurrentPasswordStepUp(c, userId, currentPassword,
-   'authenticator:pwd')` (existing rate-limit + argon2 verify), then
-   `mintStepUpGrant({ operation: 'register_approver_device', authEpoch, mfaEpoch,
-   sid })`. Returns `{ registerGrantId }`. Requires `auth.token.sid` + epochs
-   (503 if absent, matching the mfa step-up endpoint). Used by the **browser**.
-2. **At login** — `login.ts` mints a `register_approver_device` grant bound to
-   the freshly-issued access token's `sid` and returns it as
-   `authenticatorRegisterGrantId` in the login response. Minted at BOTH
-   interactive-login return points (no-MFA success ~`login.ts:614`, MFA-completed
-   success ~`login.ts:920`), never on refresh-token rotation. Best-effort: a mint
+1. **`POST /auth/mfa/step-up` with `operation: 'register_approver_device'`** —
+   extend `mfaStepUpSchema` with an optional `operation` enum defaulting to
+   `'add_factor'` (back-compat). The schema is a `z.discriminatedUnion` on
+   `method` (`schemas.ts:121-125`), so the field goes on each branch (or a
+   merged base) — you can't `.extend()` the union; with a per-branch
+   `.default('add_factor')` the existing `zValidator` usage is unaffected.
+   Verification, rate limiting, and the `auth.mfa.stepup.granted` audit (which
+   already records `operation`) are untouched. The endpoint returns
+   `{ stepUpGrantId }` (`mfa.ts:816`); the client passes that value as
+   `registerGrantId` to the register routes. Used by the **browser** for the
+   passkey and TOTP methods (the SMS branch stays API-only, see above).
+2. **`POST /authenticator/register-grant { currentPassword }`** — new mint
+   endpoint. Refuses (403 `stronger_factor_required`) when the account has a
+   TOTP secret or ≥1 passkey — the server-side gate above. Otherwise runs
+   `requireCurrentPasswordStepUp(c, userId, currentPassword,
+   'authenticator:pwd')` — deliberately the SAME rate-limit prefix the register
+   routes use today, so the 5 / 5 min per-user bucket carries over — then
+   `mintStepUpGrant({ operation: 'register_approver_device', ... })`. Returns
+   `{ registerGrantId }`. 503 if `sid`/epochs absent (matching `/auth/mfa/step-up`).
+   Used by the **browser** password fallback.
+3. **At login** — mint a `register_approver_device` grant bound to the
+   freshly-issued access token's `sid` and return it as
+   `authenticatorRegisterGrantId` — **only when the request carries the mobile
+   device-id header** both handlers already read (`login.ts:568` /
+   `mfa.ts:338`). Web logins hit these same endpoints; without the gate every
+   browser login would mint a needless Redis grant and hand a live register
+   grant to the page context (readable by XSS for 300s). Best-effort: a mint
    failure (Redis down) omits the field and login still succeeds — mobile simply
-   registers on a later login. Used by **mobile**.
+   registers on a later login. Used by **mobile** only.
+
+### Login mint points (corrected in rev 2 — verify against code, not this doc's line numbers)
+
+The two mint points are the two endpoints mobile actually logs in through:
+
+| Path | Where | Response |
+|---|---|---|
+| No-MFA password login | `routes/auth/login.ts` `POST /auth/login` success (mint ~`login.ts:555`, response ~`:614`) | add field |
+| MFA-completed login | **`routes/auth/mfa.ts`** `POST /auth/mfa/verify` success (mint ~`mfa.ts:327`, response ~`:364`) | add field |
+
+At the `mfa.ts` point all bind material is in scope: `epochs` (`mfa.ts:325`) and
+`sid` = the refresh family id (`mfa.ts:324`; `jwt.ts:373` sets `sid:
+options.refreshFam`).
+
+**NEVER mint on `POST /auth/refresh`** (`login.ts:700`, re-mint `:907`, response
+`:932`). rev 1 misidentified this block ("~line 920") as the MFA success point —
+it is token *rotation*. Minting there would hand a stolen-refresh-token attacker
+a fresh register grant every rotation, inverting the Constraint above. A test
+must assert the refresh response never contains `authenticatorRegisterGrantId`.
+
+**Deliberately skipped** fresh-login paths — all web-only, and the browser mints
+at register time so a login-time grant would only expire unused: passkey-as-MFA
+(`passkeys.ts:476`), SSO callback (`sso.ts:2937`), both Cloudflare Access paths
+(`cfAccessLogin.ts:241`, `cfAccessRedirectLogin.ts:215`), accept-invite
+(`invite.ts:205`), verify-email (`verifyEmail.ts:438`). Mobile supports only
+password + TOTP/SMS (`MfaMethod` in `apps/mobile/src/services/api.ts:96`), so
+these paths cannot serve a mobile registration.
+
+There is **no shared login-response type to edit**: each handler returns an
+inline literal, and `packages/shared/src/types/auth.ts` `LoginResponse` is
+imported nowhere (dead). Add the optional field to both handler literals, the
+OpenAPI `LoginResponse` schema (`openapi.ts:121`), and mobile's own
+`LoginResponse` in `services/api.ts`.
 
 ## Mobile flow (promptless)
 
-- Login response carries `authenticatorRegisterGrantId`. Store it in **Redux
-  (memory only)**, alongside credentials — NOT SecureStore. A cold-start restored
-  session (`checkAuth`) does not set it, so a restored session legitimately has no
+- Both `login()` (`api.ts:315`) and `verifyMfa()` (`api.ts:343`) capture
+  `authenticatorRegisterGrantId` from their responses — MFA users get the grant
+  from `/auth/mfa/verify`, not the initial login POST.
+- Store it in **Redux (memory only)** — NOT SecureStore. Cold-start restore
+  (`checkAuth` → `setCredentials`) rebuilds state solely from
+  `getStoredToken`/`getStoredUser`, so a restored session legitimately has no
   grant and correctly skips registration until the next real login. Keeps the
   grant off-disk.
-- `RootNavigator`'s existing reactive `[token, user]` effect reads the grant from
-  Redux, passes it to `ensureApproverDevice(grant)`, and clears it from Redux
-  after the attempt (single-use anyway).
+- `RootNavigator`'s existing reactive `[token, user]` effect reads the grant
+  from Redux and passes it to `ensureApproverDevice(signer, grant)`.
+  **Read-and-clear the grant from Redux synchronously BEFORE the async
+  attempt**, not after: the effect re-fires on every `user` identity change
+  (`checkAuth` double-dispatches on cold start; the `active` cleanup discards
+  stale outcomes but does not prevent concurrent in-flight calls). Clearing
+  first means a second firing sees no grant → `deferred`, instead of racing a
+  consumed grant to a 403 whose `failed` outcome could overwrite a successful
+  registration. Belt-and-braces: a module-level single-flight guard in
+  `ensureApproverDevice`.
 - `ensureApproverDevice(signer, registerGrant?)`:
   - If no grant available → return a new non-error outcome
     `{ status: 'deferred', reason: 'no_reauth_grant' }` (do NOT POST; there is
     nothing to prove with). Treated by the UI like the existing benign
     unregistered state, not a hard failure.
   - If grant available → POST `/authenticator/devices` with `registerGrantId`
-    (drop the untrusted `kind`/`isPlatformBound` — server forces them anyway; keep
-    `publicKey`, `label`). On success store cred id in SecureStore as today.
+    (drop the untrusted `kind`/`isPlatformBound` — the server already forces
+    `mobile_hw_key`/`true` on insert; keep `publicKey`, `label`). On success
+    store cred id in SecureStore as today.
 - Fail-open unchanged: never throws, never blocks login.
 
-## Browser flow (one password prompt, mirrors passkeys)
+## Browser flow (one re-auth gesture, best method offered first)
 
-- `ApproverDevicesSection.tsx` gains a password field + submit, mirroring
-  `ProfilePage.handleAddPasskey`'s password collection. Keep the device-label
-  input.
-- `stores/authenticator.ts` `registerApproverDevice(label, currentPassword)`:
-  1. POST `/authenticator/register-grant` `{ currentPassword }` → `{ registerGrantId }`
-     (throw on non-2xx so `runAction` surfaces a real toast — e.g. wrong password → 401).
-  2. POST `/authenticator/devices/webauthn/options` `{ registerGrantId }` → options.
+- `ApproverDevicesSection.tsx` (already `runAction`-wrapped for register /
+  revoke / rename — no allowlist entry needed) gains a small **re-auth step**
+  ahead of the existing label input:
+  - user has ≥1 passkey (from the profile factor data) → primary button
+    **"Verify with passkey"**;
+  - else `mfaMethod === 'totp'` (newly exposed on `/users/me`) → 6-digit TOTP
+    input;
+  - else → password field (SMS-method users land here — see Browser re-auth).
+  Build it as a small reusable component (e.g. `StepUpPrompt`) — ProfilePage's
+  add-passkey flow currently dead-ends for MFA-protected users, surfacing the
+  raw `existing_factor_step_up_required` code with no way to satisfy it, and
+  will want the same component (follow-up, out of scope here).
+- `stores/authenticator.ts` `registerApproverDevice(label, reauth)` where
+  `reauth` is `{ password } | { method: 'totp' | 'sms', code } |
+  { method: 'passkey' }`:
+  1. Mint: password → `POST /authenticator/register-grant`; code →
+     `POST /auth/mfa/step-up { method, code, operation }`; passkey →
+     `POST /auth/mfa/step-up/options` → `startAuthentication` →
+     `POST /auth/mfa/step-up { method: 'passkey', credential, operation }`.
+     Throw on non-2xx so `runAction` surfaces a real toast.
+  2. `POST /authenticator/devices/webauthn/options` `{ registerGrantId }`.
   3. `startRegistration({ optionsJSON })`.
-  4. POST `/authenticator/devices/webauthn/verify` `{ registerGrantId, label, response }`.
-- Caller (`ApproverDevicesSection`) wraps the mutation in `runAction` per the
-  no-silent-mutations contract; improve the error toast.
+  4. `POST /authenticator/devices/webauthn/verify` `{ registerGrantId, label, response }`.
+
+### UX details
+
+- **Error mapping, not raw codes**: 401 → "Incorrect password" / "Incorrect
+  code"; 429 → "Too many attempts — try again in a few minutes"; 403
+  `register_step_up_required` at options/verify → the grant expired mid-ceremony
+  (>300s in the WebAuthn prompt) — reset to the re-auth step with the label
+  preserved and say "Verification expired — please verify again," don't
+  dead-toast.
+- **Success state**: refresh the device list and show the new device row with
+  its "pending — activates on first approval" state so the user isn't left
+  wondering whether it worked.
+- **Mobile banner copy** (#2683 banner): the new `deferred` status is
+  actionable — "Sign out and back in to finish approver setup" — distinct from
+  the generic unregistered state.
 
 ## Security properties preserved
 
-- Registration requires knowledge-of-password (browser) or a fresh interactive
-  login (mobile), independent of the bearer token. A stolen access token alone
-  cannot mint or replay a grant: single-use (`getdel`), 300s TTL, bound to
-  `sid` + `authEpoch` + `mfaEpoch`.
+- Registration requires an independent factor: password or existing MFA factor
+  (browser), or a fresh interactive login (mobile). A stolen access token alone
+  cannot mint or replay a grant: single-use (GETDEL), 300s TTL, bound to
+  `sid` + `authEpoch` + `mfaEpoch` (an epoch bump — e.g. admin MFA reset —
+  invalidates outstanding grants via `bindsMatch`).
+- Grant enforcement on the register routes is **unconditional** (see the
+  `enforceExistingFactorStepUp` warning above) — no MFA-protected bypass.
 - Deferred-PoP unchanged: rows still insert PENDING (`last_used_at` null) and
-  activate on first approval signature.
-- The mint endpoint inherits `requireCurrentPasswordStepUp`'s per-user rate limit
-  (5 / 5 min); the login-mint adds no new interactive surface.
+  activate on first approval signature (`authenticatorAssurance.ts:333`/`:391`).
+- Repo-wide, the only inserts into `authenticator_devices` are the two in
+  `authenticator.ts` — no other registration path needs the gate.
+- Rate limits: password path inherits `authenticator:pwd` (5 / 5 min per user);
+  step-up path inherits `mfa:stepup-rl:`; login-mint adds no new interactive
+  surface.
 
 ## Test gap closed
 
-- **API** (`routes/authenticator.test.ts`, new sibling for the mint endpoint):
-  - `register-grant`: password happy-path → mints; wrong password → 401;
-    rate-limit → 429; missing `sid`/epochs → 503.
-  - `options` / `verify` / `devices`: missing grant → 403; mismatched-operation /
-    expired / wrong-sid grant → 403; valid grant → 200/201; a valid `add_factor`
-    grant is REJECTED on these routes (operation isolation).
-  - `login.ts`: successful login response includes `authenticatorRegisterGrantId`;
-    a grant-mint failure still returns tokens.
+- **API** (`routes/authenticator.test.ts` + sibling for the mint endpoint):
+  - `register-grant`: password happy-path (no stronger factor) → mints; wrong
+    password → 401; passwordless account → 401; account with TOTP or a passkey
+    → 403 `stronger_factor_required` (password path gated); rate-limit → 429;
+    missing `sid`/epochs → 503.
+  - `/auth/mfa/step-up` with `operation: 'register_approver_device'`: mints a
+    grant the register routes accept; omitted `operation` still mints
+    `add_factor` (back-compat); a `register_approver_device` grant is REJECTED
+    by the `add_factor` consumers and vice versa (operation isolation, both
+    directions).
+  - `options` / `verify` / `devices`: missing grant → 403 **including for a
+    non-MFA-protected user** (pins the no-bypass requirement); mismatched-operation /
+    expired / wrong-sid grant → 403; valid grant → 200/201; same grant validated
+    at options then consumed at verify; replayed consumed grant → 403.
+  - Login mints: `POST /auth/login` (no-MFA) and `POST /auth/mfa/verify`
+    responses include `authenticatorRegisterGrantId` **when the mobile
+    device-id header is present, and omit it when absent** (web logins never
+    receive a grant); a grant-mint failure still returns tokens;
+    **`POST /auth/refresh` response NEVER includes it**.
+  - `GET /users/me` includes `mfaMethod`.
 - **Web** (`stores/authenticator.test.ts` — real store, not a mocked
-  `registerApproverDevice`): exercises the full client→route sequence against a
-  mocked `fetchWithAuth`, asserting the grant is minted then threaded to
-  options+verify. This is the drift guard the issue asks for.
+  `registerApproverDevice`): for each re-auth method, exercises the full
+  client→route sequence against a mocked `fetchWithAuth`, asserting the grant is
+  minted then threaded to options+verify. This is the drift guard the issue
+  asks for.
 - **Mobile** (`services/approverDevice.test.ts`): no grant → no POST, returns
-  `deferred`; valid grant → POST body carries `registerGrantId`; existing
-  fail-open cases preserved.
+  `deferred`; valid grant → POST body carries `registerGrantId` and no
+  `kind`/`isPlatformBound`; concurrent double-invoke consumes the grant once;
+  existing fail-open cases preserved.
 
-## Known tradeoff (documented, not fixed here)
+## Known tradeoffs (documented, not fixed here)
 
-A mobile user who stays logged in for weeks without re-authenticating won't
-register until their next fresh login. Acceptable — matches the existing
-"provisions on a later login" fail-open behavior, and the #2683 banner already
-surfaces the unregistered state to the user.
+- A mobile user who stays logged in for weeks without re-authenticating won't
+  register until their next fresh login. Acceptable — matches the existing
+  "provisions on a later login" fail-open behavior; the #2683 banner surfaces it
+  with the new actionable copy.
+- **SSO-only accounts with neither a passkey nor TOTP** (including SMS-only
+  MFA) cannot register a browser approver device (nothing independent of the
+  bearer token to prove). Not a regression — they were equally locked out of
+  the password-only flow — but now explicit. Follow-up option: mint a
+  browser-usable grant at the SSO callback and auto-prompt registration
+  immediately after login, within the 300s window.
+- ProfilePage's add-passkey dead-end for MFA-protected users (unhandled
+  `existing_factor_step_up_required` 403) is a pre-existing bug this spec does
+  not fix; the `StepUpPrompt` component built here is the intended vehicle.
 
 ## Files touched
 
 - `apps/api/src/services/mfaStepUpGrant.ts` — widen `operation` union.
+- `apps/api/src/routes/auth/schemas.ts` — add optional `operation` to
+  `mfaStepUpSchema`.
+- `apps/api/src/routes/auth/mfa.ts` — thread `operation` through
+  `POST /auth/mfa/step-up`; mint + return `authenticatorRegisterGrantId` at the
+  `POST /auth/mfa/verify` success point.
+- `apps/api/src/routes/auth/login.ts` — mint + return the field at the no-MFA
+  success point ONLY (not refresh).
+- `apps/api/src/routes/auth/helpers.ts` (or `authenticator.ts`) — unconditional
+  grant-enforcement helper (see warning).
 - `apps/api/src/routes/authenticator.ts` — swap `currentPassword` → grant on 3
-  routes; add `POST /authenticator/register-grant`.
-- `apps/api/src/routes/auth/login.ts` — mint + return `authenticatorRegisterGrantId`
-  at both success return points.
-- `apps/api/src/routes/auth/schemas.ts` (or the login response type) — add the
-  optional field.
+  routes; add `POST /authenticator/register-grant` (with the
+  stronger-factor gate).
+- `apps/api/src/routes/users.ts` — expose `mfaMethod` on `GET /users/me`.
+- `apps/api/src/openapi.ts` — document the login-response field (note:
+  `LoginResponse` is also `$ref`'d by `/auth/register`, which won't return it —
+  scope the doc accordingly).
+- `apps/mobile/src/services/api.ts` — capture the grant in `login()` and
+  `verifyMfa()`; extend mobile `LoginResponse`.
 - `apps/mobile/src/services/approverDevice.ts` — accept + send grant; `deferred`
-  outcome.
-- `apps/mobile/src/navigation/RootNavigator.tsx` — thread grant from Redux.
-- `apps/mobile/src/store/…` (auth slice) — hold `authenticatorRegisterGrantId` in
-  memory; set on login, clear on use/logout.
-- `apps/mobile/src/services/auth.ts` (login) — capture the grant from the login
-  response into Redux.
-- `apps/web/src/stores/authenticator.ts` — `registerApproverDevice(label, currentPassword)`.
-- `apps/web/src/components/…/ApproverDevicesSection.tsx` — password field + toast.
+  outcome; single-flight guard.
+- `apps/mobile/src/navigation/RootNavigator.tsx` — thread grant from Redux
+  (read-and-clear before the attempt).
+- `apps/mobile/src/store/authSlice.ts` — hold `authenticatorRegisterGrantId` in
+  memory; set on login/verifyMfa, clear on read/logout.
+- `apps/web/src/stores/authenticator.ts` — `registerApproverDevice(label, reauth)`.
+- `apps/web/src/components/settings/ApproverDevicesSection.tsx` — re-auth step
+  (`StepUpPrompt`), error mapping, pending-state success UI (plus profile-store
+  plumbing for `mfaMethod`).
 - Test files listed above.
 
 ## Out of scope
@@ -184,3 +381,8 @@ surfaces the unregistered state to the user.
   #2707, rejected).
 - Any change to the assurance/enforcement path (`authenticatorAssurance.ts`).
 - SecureStore persistence of the grant (deliberately avoided).
+- Fixing ProfilePage's add-passkey step-up dead-end (follow-up; reuse
+  `StepUpPrompt`).
+- Requiring password + existing factor together (rejected, see Browser re-auth).
+- An authenticated step-up SMS-send endpoint (rejected — new abuse surface;
+  SMS-method users use the password path).

--- a/docs/superpowers/specs/2026-07-21-authenticator-register-grant-design.md
+++ b/docs/superpowers/specs/2026-07-21-authenticator-register-grant-design.md
@@ -1,0 +1,186 @@
+# Authenticator approver-device registration — grant-based re-auth
+
+**Issue:** #2707
+**Date:** 2026-07-21
+**Status:** Design approved, pending implementation plan
+
+## Problem
+
+Approver-device registration for the Breeze Authenticator returns **HTTP 400 on
+both the mobile app and the browser client** because neither client sends the
+`currentPassword` step-up the server requires (`routes/authenticator.ts`
+`registerOptionsSchema` / `mobileRegisterSchema`). Consequences:
+
+- Partners with `authenticator_policies.require_enrollment = true`: any approval
+  whose risk tier requires ≥L2 throws `StepUpRequiredError` → **403, approval
+  hard-blocked** (a real outage).
+- Everyone else: a silent security **downgrade** — every approval is recorded at
+  L1 (`session_tap`) instead of the hardware-backed factor.
+
+Two distinct defects:
+1. **Mobile** — regression since #1890 (`92ccd8226`) reintroduced the password
+   requirement without updating the mobile client.
+2. **Browser** — never worked; `stores/authenticator.ts` has never sent
+   `currentPassword` since the first Authenticator commit (#1369).
+
+## Constraint (do NOT drop `currentPassword`)
+
+Per #1890's security review: registration is deferred-proof-of-possession — a new
+key is stored `pending` (`last_used_at` null) and activates on its first approval
+signature, with no signature at registration time. If a live access token *alone*
+could register a key, a stolen-session attacker could enroll their own approver
+key and self-sign approvals up to L2/L3, defeating the possession factor.
+Registration must be tied to a factor **independent of the bearer token**:
+knowledge of the account password, or a fresh interactive login.
+
+## Key realization about the browser
+
+A re-auth grant minted at login has a short TTL (300s). By the time a user
+navigates to Settings → "Register this browser," a login-time grant is expired;
+making it long-lived would reintroduce the exact stolen-session risk above.
+Therefore the **browser must mint a fresh grant at register-time**, which means a
+password prompt either way. For the browser, "full re-auth token" and "the
+stopgap" converge on the same UX (one password prompt); only the wire path
+differs. The token genuinely earns its keep on **mobile**, which must stay
+promptless.
+
+## Approach: reuse `mfaStepUpGrant`, one unified register contract
+
+The codebase already has the primitive the issue describes:
+`services/mfaStepUpGrant.ts` — Redis-backed, 300s TTL, single-use (`getdel`),
+bound to `(userId, operation, authEpoch, mfaEpoch, sid)`. Its only `operation`
+today is `'add_factor'`.
+
+**Extend the union with `'register_approver_device'`** and reuse
+`mintStepUpGrant` / `validateStepUpGrant` / `consumeStepUpGrant` verbatim. No new
+token type, no schema/migration. A grant minted for one operation can never be
+consumed for another (`bindsMatch` checks operation equality).
+
+### Server contract
+
+Both register routes stop taking `currentPassword` and take `registerGrantId`:
+
+| Route | Grant handling |
+|---|---|
+| `POST /authenticator/devices/webauthn/options` (browser) | **validate** (non-consuming) |
+| `POST /authenticator/devices/webauthn/verify` (browser) | **consume** |
+| `POST /authenticator/devices` (mobile) | **consume** |
+
+Two-phase validate→consume on the browser flow mirrors the existing passkey
+`enforceExistingFactorStepUp(..., { consume })` pattern (`routes/auth/passkeys.ts`,
+`routes/auth/phone.ts`): the SAME grant is validated at `options` and consumed at
+`verify`. A wrong/missing/expired/mismatched grant is a 403 (`register_step_up_required`);
+a malformed request stays 400.
+
+Grants are minted two ways:
+
+1. **`POST /authenticator/register-grant { currentPassword }`** — new mint
+   endpoint. Runs `requireCurrentPasswordStepUp(c, userId, currentPassword,
+   'authenticator:pwd')` (existing rate-limit + argon2 verify), then
+   `mintStepUpGrant({ operation: 'register_approver_device', authEpoch, mfaEpoch,
+   sid })`. Returns `{ registerGrantId }`. Requires `auth.token.sid` + epochs
+   (503 if absent, matching the mfa step-up endpoint). Used by the **browser**.
+2. **At login** — `login.ts` mints a `register_approver_device` grant bound to
+   the freshly-issued access token's `sid` and returns it as
+   `authenticatorRegisterGrantId` in the login response. Minted at BOTH
+   interactive-login return points (no-MFA success ~`login.ts:614`, MFA-completed
+   success ~`login.ts:920`), never on refresh-token rotation. Best-effort: a mint
+   failure (Redis down) omits the field and login still succeeds — mobile simply
+   registers on a later login. Used by **mobile**.
+
+## Mobile flow (promptless)
+
+- Login response carries `authenticatorRegisterGrantId`. Store it in **Redux
+  (memory only)**, alongside credentials — NOT SecureStore. A cold-start restored
+  session (`checkAuth`) does not set it, so a restored session legitimately has no
+  grant and correctly skips registration until the next real login. Keeps the
+  grant off-disk.
+- `RootNavigator`'s existing reactive `[token, user]` effect reads the grant from
+  Redux, passes it to `ensureApproverDevice(grant)`, and clears it from Redux
+  after the attempt (single-use anyway).
+- `ensureApproverDevice(signer, registerGrant?)`:
+  - If no grant available → return a new non-error outcome
+    `{ status: 'deferred', reason: 'no_reauth_grant' }` (do NOT POST; there is
+    nothing to prove with). Treated by the UI like the existing benign
+    unregistered state, not a hard failure.
+  - If grant available → POST `/authenticator/devices` with `registerGrantId`
+    (drop the untrusted `kind`/`isPlatformBound` — server forces them anyway; keep
+    `publicKey`, `label`). On success store cred id in SecureStore as today.
+- Fail-open unchanged: never throws, never blocks login.
+
+## Browser flow (one password prompt, mirrors passkeys)
+
+- `ApproverDevicesSection.tsx` gains a password field + submit, mirroring
+  `ProfilePage.handleAddPasskey`'s password collection. Keep the device-label
+  input.
+- `stores/authenticator.ts` `registerApproverDevice(label, currentPassword)`:
+  1. POST `/authenticator/register-grant` `{ currentPassword }` → `{ registerGrantId }`
+     (throw on non-2xx so `runAction` surfaces a real toast — e.g. wrong password → 401).
+  2. POST `/authenticator/devices/webauthn/options` `{ registerGrantId }` → options.
+  3. `startRegistration({ optionsJSON })`.
+  4. POST `/authenticator/devices/webauthn/verify` `{ registerGrantId, label, response }`.
+- Caller (`ApproverDevicesSection`) wraps the mutation in `runAction` per the
+  no-silent-mutations contract; improve the error toast.
+
+## Security properties preserved
+
+- Registration requires knowledge-of-password (browser) or a fresh interactive
+  login (mobile), independent of the bearer token. A stolen access token alone
+  cannot mint or replay a grant: single-use (`getdel`), 300s TTL, bound to
+  `sid` + `authEpoch` + `mfaEpoch`.
+- Deferred-PoP unchanged: rows still insert PENDING (`last_used_at` null) and
+  activate on first approval signature.
+- The mint endpoint inherits `requireCurrentPasswordStepUp`'s per-user rate limit
+  (5 / 5 min); the login-mint adds no new interactive surface.
+
+## Test gap closed
+
+- **API** (`routes/authenticator.test.ts`, new sibling for the mint endpoint):
+  - `register-grant`: password happy-path → mints; wrong password → 401;
+    rate-limit → 429; missing `sid`/epochs → 503.
+  - `options` / `verify` / `devices`: missing grant → 403; mismatched-operation /
+    expired / wrong-sid grant → 403; valid grant → 200/201; a valid `add_factor`
+    grant is REJECTED on these routes (operation isolation).
+  - `login.ts`: successful login response includes `authenticatorRegisterGrantId`;
+    a grant-mint failure still returns tokens.
+- **Web** (`stores/authenticator.test.ts` — real store, not a mocked
+  `registerApproverDevice`): exercises the full client→route sequence against a
+  mocked `fetchWithAuth`, asserting the grant is minted then threaded to
+  options+verify. This is the drift guard the issue asks for.
+- **Mobile** (`services/approverDevice.test.ts`): no grant → no POST, returns
+  `deferred`; valid grant → POST body carries `registerGrantId`; existing
+  fail-open cases preserved.
+
+## Known tradeoff (documented, not fixed here)
+
+A mobile user who stays logged in for weeks without re-authenticating won't
+register until their next fresh login. Acceptable — matches the existing
+"provisions on a later login" fail-open behavior, and the #2683 banner already
+surfaces the unregistered state to the user.
+
+## Files touched
+
+- `apps/api/src/services/mfaStepUpGrant.ts` — widen `operation` union.
+- `apps/api/src/routes/authenticator.ts` — swap `currentPassword` → grant on 3
+  routes; add `POST /authenticator/register-grant`.
+- `apps/api/src/routes/auth/login.ts` — mint + return `authenticatorRegisterGrantId`
+  at both success return points.
+- `apps/api/src/routes/auth/schemas.ts` (or the login response type) — add the
+  optional field.
+- `apps/mobile/src/services/approverDevice.ts` — accept + send grant; `deferred`
+  outcome.
+- `apps/mobile/src/navigation/RootNavigator.tsx` — thread grant from Redux.
+- `apps/mobile/src/store/…` (auth slice) — hold `authenticatorRegisterGrantId` in
+  memory; set on login, clear on use/logout.
+- `apps/mobile/src/services/auth.ts` (login) — capture the grant from the login
+  response into Redux.
+- `apps/web/src/stores/authenticator.ts` — `registerApproverDevice(label, currentPassword)`.
+- `apps/web/src/components/…/ApproverDevicesSection.tsx` — password field + toast.
+- Test files listed above.
+
+## Out of scope
+
+- Active-device co-sign and OOB email confirmation (alternatives considered in
+  #2707, rejected).
+- Any change to the assurance/enforcement path (`authenticatorAssurance.ts`).
+- SecureStore persistence of the grant (deliberately avoided).


### PR DESCRIPTION
Closes #2707.

Approver-device registration returned HTTP 400 on both clients (neither sent the `currentPassword` step-up), hard-blocking approvals for `require_enrollment` partners and silently downgrading everyone else to L1. This replaces the password requirement with single-use re-auth grants while preserving #1890's constraint: registration always requires a factor independent of the bearer token.

Design: `docs/superpowers/specs/2026-07-21-authenticator-register-grant-design.md` · Plan: `docs/superpowers/plans/2026-07-21-authenticator-register-grant.md`

## What changed

**API**
- `mfaStepUpGrant` operation union gains `register_approver_device` (zod enum compile-linked via `satisfies`); `POST /auth/mfa/step-up` mints operation-scoped grants (defaulted `operation` field, back-compat).
- The three register routes swap `currentPassword` → `registerGrantId`: validate (non-consuming) at `options`, consume at `verify` and mobile `POST /devices`. Enforcement is **unconditional for all users** via a new `enforceApproverRegisterStepUp` (deliberately NOT `enforceExistingFactorStepUp`, whose MFA-protected early-return would exempt non-MFA users), and denials are audited (`auth.authenticator.register.denied`, no grant values logged). The mobile route validates the payload **before** consuming the grant, so a malformed body can't burn it. Note this also *hardens* the browser flow — the old `verify` step had no step-up at all.
- New `POST /authenticator/register-grant { currentPassword }` password mint, refused (`403 stronger_factor_required`, audited) when the account has TOTP or a passkey — server enforces the same tiering the UI shows. SMS-method users keep the password path (no authenticated step-up SMS sender exists; SIM-swappable SMS ≈ password strength). When `ENABLE_2FA=false` the stronger-factor gate stands down (step-up is dead in that deployment, so password must stay available).
- `/auth/login` and `/auth/mfa/verify` mint a mobile grant (`authenticatorRegisterGrantId`) **only when the mobile device-id header is present** — web logins never receive one. **`/auth/refresh` never mints**, pinned by test. Minting is genuinely fail-open (try/catch parity restored in `mintStepUpGrant`; a Redis hiccup can no longer 500 a successful login) and declines are operator-logged.
- `GET /users/me` exposes `mfaMethod` (own row only) for the UI tier selection.

**Mobile** — grant captured from login/mfa-verify into memory-only Redux (never SecureStore; cold-start restore has none), read-and-cleared *before* a single-flight registration attempt; a grant-bearing call arriving during an in-flight grant-less attempt hands off to a fresh attempt so the grant is never dropped. New benign `deferred` outcome + actionable banner. Failures now carry `exception:<Name>` reasons and Sentry telemetry (never the grant value), including the installation-id header loss that would otherwise silently disable minting. Client stops sending `kind`/`isPlatformBound` (server forces them anyway).

**Web** — `registerApproverDevice(label, reauth)` with three mint paths (passkey one-tap → TOTP code → password fallback) via a reusable `StepUpPrompt`; tier-aware error mapping distinguishes wrong credential vs **session expiry** vs **user-cancelled WebAuthn** vs grant expiry mid-ceremony vs `stronger_factor_required`; "pending — activates on first approval" badge; i18n keys in all five locales.

## Review notes / deliberate tradeoffs

- The mint calls use `skipUnauthorizedRetry` (`fetchWithAuth`): a 401 means wrong credential, and the default refresh-and-replay would re-submit the same wrong password/code, burning a rate-limit attempt. Tradeoff: an access token that goes stale exactly at the mint call surfaces as the session-expired toast instead of a transparent refresh. Mirrors the `intentApprovals.ts` precedent.
- `registerGrantId` is `.optional()` in the register schemas so a *missing* grant reaches enforcement and 403s `register_step_up_required` (spec contract: missing grant = 403; malformed request = 400), matching the `stepUpGrantId` convention.
- Old mobile clients still POSTing `currentPassword`+`kind` now get 403 instead of 400 — they were already broken (fail-open, benign), and updated clients self-heal on next login.

## Verification

11 plan tasks implemented TDD with per-task independent reviews, a whole-branch security review ("ready to merge", no Critical/Important), then targeted comment-accuracy and silent-failure audits whose findings — including two HIGH (login-500-on-Redis-hiccup, invisible mint declines) — were fixed in a follow-up wave that itself passed a contract-survival review. Full suites green: API 16,879 unit + real-Redis integration stitch (mint→validate→consume→replay/cross-op rejection against live Redis), web 4,333+, mobile 223. Contract greps: `currentPassword` confined to the mint endpoint; no mint references in the refresh handler; no `kind`/`isPlatformBound` in the mobile POST body.

Accepted residual nits (documented, deliberate): `mintStepUpGrant`'s catch returns null without its own log (every caller logs/audits the decline); `'Unexpected server response.'` on an unparseable-2xx edge is untranslated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)