### PR TITLE
feat(quotes): editor UX overhaul + orphan-line fix (backfill, clone re-parent, unassigned-lines surface)

### DIFF
--- a/apps/api/migrations/2026-07-21-quote-orphan-line-and-number-backfill.sql
+++ b/apps/api/migrations/2026-07-21-quote-orphan-line-and-number-backfill.sql
@@ -41,6 +41,15 @@
 --
 -- No inner BEGIN;/COMMIT; — autoMigrate wraps each file in a transaction.
 
+-- quotes/quote_lines/quote_blocks are RLS-FORCED (org policies) and
+-- partner_quote_sequences is partner-RLS. The migration connection (managed-DB
+-- doadmin, no request GUCs) is NOT exempt: without system scope Part A's
+-- SELECTs match zero rows (silent no-op, recorded as applied) and Part B's
+-- INSERT fails its WITH CHECK with 42501, aborting the boot. Transaction-local
+-- elevation, same pattern as 2026-04-13-fix-uuid-hostnames.sql. (Superuser
+-- runs — CI, stock self-host compose — bypass RLS either way.)
+SELECT set_config('breeze.scope', 'system', true);
+
 -- ---------------------------------------------------------------------------
 -- PART A: attach orphan quote_lines to a line_items block.
 -- ---------------------------------------------------------------------------

--- a/apps/api/migrations/2026-07-21-quote-orphan-line-and-number-backfill.sql
+++ b/apps/api/migrations/2026-07-21-quote-orphan-line-and-number-backfill.sql
@@ -1,0 +1,177 @@
+-- Data-only repair for two quote defects that were fixed on the WRITE path only,
+-- leaving every pre-existing row permanently broken. No DDL: no new tables, no
+-- new columns, no RLS/cascade registration required.
+--
+-- PART A — orphan quote lines (#2553)
+--   `quote_lines.block_id` is nullable. A line with block_id IS NULL renders in
+--   the PDF, the portal and the preview and counts in every total, but the web
+--   editor walks `quote_blocks` only, so the line is invisible AND uneditable
+--   there — a quote showing a real dollar total while the builder says
+--   "No content yet". `resolveLineBlockId` (quoteService.ts, v0.96.0) fixed new
+--   writes; rows written before that were never repaired.
+--   Repair: attach every orphan to its quote's EARLIEST line_items block,
+--   creating exactly ONE such block per quote if the quote has none. Mirrors
+--   resolveLineBlockId exactly: content '{}'::jsonb, sort_order =
+--   COALESCE(MAX(sort_order), -1) + 1 over the quote's existing blocks.
+--
+-- PART B — quotes stuck with no number (#2227)
+--   quote_number used to be allocated at SEND time and is nullable. Commit
+--   0b718d658 (v0.92.0) moved allocation to CREATE time, but drafts created
+--   before that keep quote_number = NULL forever and there is NO UI to assign
+--   one — a user was left completely stuck.
+--   Repair: allocate ONLY for never-sent quotes (sent_at IS NULL). A quote a
+--   customer may already hold a copy of must never have its number rewritten,
+--   even if that number is NULL.
+--   Numbers are allocated THROUGH `partner_quote_sequences`, exactly as
+--   `allocateQuoteCounter` does, so this backfill cannot collide with future
+--   allocations or with the partial unique index
+--   `quotes_partner_number_uq ON quotes (partner_id, quote_number) WHERE quote_number IS NOT NULL`.
+--   Format matches formatQuoteNumber('Q', year, counter) -> 'Q-<year>-<0000>'.
+--
+-- IDEMPOTENCY: both parts are self-limiting — Part A only touches
+-- block_id IS NULL, Part B only quote_number IS NULL. After one successful run
+-- both predicates match nothing, so a re-run allocates no counters, creates no
+-- blocks and updates no rows. Re-application is a complete no-op.
+-- The ONE exception is the pathological Part B path where a quote is SKIPPED
+-- after 50 colliding allocations (see below): that quote stays NULL, so a
+-- re-run retries it and burns 50 more counter values. This cannot happen unless
+-- a partner's sequence has fallen behind its own quote numbers, and the
+-- migration RAISEs a WARNING naming the quote when it does — burning counters
+-- is strictly better than aborting the whole migration on a unique violation.
+--
+-- No inner BEGIN;/COMMIT; — autoMigrate wraps each file in a transaction.
+
+-- ---------------------------------------------------------------------------
+-- PART A: attach orphan quote_lines to a line_items block.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  q RECORD;
+  v_block_id UUID;
+  v_sort_order INTEGER;
+  v_blocks_created INTEGER := 0;
+  v_lines_attached INTEGER := 0;
+  n INTEGER;
+BEGIN
+  -- One iteration per affected QUOTE (not per line), so a quote with many
+  -- orphans gets exactly one block, reused across all of them.
+  FOR q IN
+    SELECT DISTINCT ql.quote_id AS quote_id, qt.org_id AS org_id
+    FROM quote_lines ql
+    JOIN quotes qt ON qt.id = ql.quote_id
+    WHERE ql.block_id IS NULL
+    ORDER BY 1
+  LOOP
+    -- Earliest existing line_items block. Tiebreakers make the pick
+    -- deterministic where resolveLineBlockId's bare ORDER BY sort_order is not.
+    SELECT qb.id INTO v_block_id
+    FROM quote_blocks qb
+    WHERE qb.quote_id = q.quote_id
+      AND qb.block_type = 'line_items'
+    ORDER BY qb.sort_order, qb.created_at, qb.id
+    LIMIT 1;
+
+    IF v_block_id IS NULL THEN
+      -- Mirrors nextBlockSortOrder(): append after every existing block.
+      SELECT COALESCE(MAX(qb.sort_order), -1) + 1 INTO v_sort_order
+      FROM quote_blocks qb
+      WHERE qb.quote_id = q.quote_id;
+
+      -- org_id is taken from the parent QUOTE, the authoritative tenant, not
+      -- from the orphan line.
+      INSERT INTO quote_blocks (quote_id, org_id, block_type, content, sort_order)
+      VALUES (q.quote_id, q.org_id, 'line_items', '{}'::jsonb, v_sort_order)
+      RETURNING id INTO v_block_id;
+
+      v_blocks_created := v_blocks_created + 1;
+    END IF;
+
+    UPDATE quote_lines
+    SET block_id = v_block_id
+    WHERE quote_id = q.quote_id
+      AND block_id IS NULL;
+    GET DIAGNOSTICS n = ROW_COUNT;
+    v_lines_attached := v_lines_attached + n;
+  END LOOP;
+
+  IF v_lines_attached > 0 THEN
+    RAISE WARNING 'repaired % orphan quote_lines (block_id was NULL) by attaching them to a line_items block', v_lines_attached;
+  END IF;
+  IF v_blocks_created > 0 THEN
+    RAISE WARNING 'repaired % quotes by creating a missing line_items quote_blocks row to hold their orphan lines', v_blocks_created;
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- PART B: allocate quote_number for never-sent quotes that have none.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  q RECORD;
+  v_counter INTEGER;
+  v_candidate VARCHAR(40);
+  v_number VARCHAR(40);
+  v_numbered INTEGER := 0;
+  v_skipped INTEGER := 0;
+  n INTEGER;
+BEGIN
+  FOR q IN
+    SELECT id, partner_id, EXTRACT(YEAR FROM created_at)::INTEGER AS yr
+    FROM quotes
+    WHERE quote_number IS NULL
+      AND sent_at IS NULL
+    -- Oldest first within a partner so assigned numbers follow creation order.
+    ORDER BY partner_id, created_at, id
+  LOOP
+    v_number := NULL;
+
+    -- Same race-safe gapless allocation as allocateQuoteCounter(). The retry
+    -- loop only matters if a partner's sequence counter has fallen BEHIND the
+    -- numbers actually present on its quotes (e.g. a partial restore). Without
+    -- it, one such collision would abort the entire migration on the unique
+    -- index; with it, we burn counters until we clear the occupied range and,
+    -- failing that, skip the single quote loudly.
+    -- `attempt` is implicitly declared by the integer FOR loop.
+    FOR attempt IN 1..50 LOOP
+      INSERT INTO partner_quote_sequences (partner_id, year, counter)
+      VALUES (q.partner_id, q.yr, 1)
+      ON CONFLICT (partner_id, year)
+      DO UPDATE SET counter = partner_quote_sequences.counter + 1
+      RETURNING counter INTO v_counter;
+
+      -- formatQuoteNumber('Q', year, counter)
+      v_candidate := 'Q-' || q.yr::TEXT || '-' || LPAD(v_counter::TEXT, 4, '0');
+
+      IF NOT EXISTS (
+        SELECT 1 FROM quotes
+        WHERE partner_id = q.partner_id
+          AND quote_number = v_candidate
+      ) THEN
+        v_number := v_candidate;
+        EXIT;
+      END IF;
+    END LOOP;
+
+    IF v_number IS NULL THEN
+      RAISE WARNING 'skipped quote % — 50 consecutive partner_quote_sequences allocations for partner %/year % were all already taken; assign a number manually', q.id, q.partner_id, q.yr;
+      v_skipped := v_skipped + 1;
+      CONTINUE;
+    END IF;
+
+    -- updated_at is deliberately NOT bumped: this is a repair, and touching it
+    -- would reorder every "recently updated" view for no user-visible reason.
+    UPDATE quotes
+    SET quote_number = v_number
+    WHERE id = q.id
+      AND quote_number IS NULL;
+    GET DIAGNOSTICS n = ROW_COUNT;
+    v_numbered := v_numbered + n;
+  END LOOP;
+
+  IF v_numbered > 0 THEN
+    RAISE WARNING 'repaired % never-sent quotes that had no quote_number by allocating one via partner_quote_sequences', v_numbered;
+  END IF;
+  IF v_skipped > 0 THEN
+    RAISE WARNING 'left % never-sent quotes UNREPAIRED (still quote_number IS NULL) — every allocation collided with an existing number; these need manual assignment', v_skipped;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/quoteBackfillOrphanLinesAndNumbers.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteBackfillOrphanLinesAndNumbers.integration.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Real-Postgres contract tests for the data-only repair migration
+ * `apps/api/migrations/2026-07-21-quote-orphan-line-and-number-backfill.sql`.
+ *
+ * Two quote defects were fixed on the WRITE path only, so every row written
+ * before the fix stays broken forever:
+ *   A. `quote_lines.block_id IS NULL` ("orphans") — rendered on the PDF/portal
+ *      and counted in totals, but silently invisible in the web editor, which
+ *      walks `quote_blocks` only.
+ *   B. `quotes.quote_number IS NULL` on drafts created before numbering moved
+ *      to create time (#2227) — with no UI to assign one, the quote is stuck.
+ *
+ * These tests execute the ACTUAL migration file (not a reimplementation of it)
+ * against seeded broken rows, exactly the way `autoMigrate` does: the whole
+ * file through `client.unsafe(content)` on a privileged connection. Anything
+ * that reimplements the SQL here would prove nothing about the shipped file.
+ *
+ * NOTE: globalSetup already applied this migration once, against an empty
+ * database — a no-op. Re-running it here is legitimate precisely because the
+ * file is required to be idempotent.
+ */
+import './setup';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import postgres, { type Sql } from 'postgres';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+const MIGRATION_PATH = path.resolve(
+  __dirname,
+  '../../../migrations/2026-07-21-quote-orphan-line-and-number-backfill.sql'
+);
+
+// Same privileged URL the rest of the integration setup uses for seeding. The
+// migration runner connects as the owner/superuser, so this mirrors production.
+const DATABASE_URL =
+  process.env.DATABASE_URL || 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+
+let sql: Sql;
+let migrationSql: string;
+
+beforeAll(() => {
+  if (!process.env.DATABASE_URL) return;
+  migrationSql = readFileSync(MIGRATION_PATH, 'utf8');
+  sql = postgres(DATABASE_URL, { max: 3, idle_timeout: 20, connect_timeout: 10, onnotice: () => {} });
+});
+
+afterAll(async () => {
+  if (sql) await sql.end();
+});
+
+/** Apply the migration file verbatim, exactly as autoMigrate does. */
+async function applyMigration(): Promise<void> {
+  await sql.unsafe(migrationSql);
+}
+
+async function seedTenant(): Promise<{ partnerId: string; orgId: string }> {
+  const sfx = Math.random().toString(36).slice(2, 10);
+  const [p] = await sql<{ id: string }[]>`
+    INSERT INTO partners (name, slug, type, plan, status)
+    VALUES (${`QB ${sfx}`}, ${`qb-${sfx}`}, 'msp', 'pro', 'active')
+    RETURNING id
+  `;
+  const [o] = await sql<{ id: string }[]>`
+    INSERT INTO organizations (partner_id, name, slug)
+    VALUES (${p!.id}, 'QB Org', ${`qb-org-${sfx}`})
+    RETURNING id
+  `;
+  return { partnerId: p!.id, orgId: o!.id };
+}
+
+async function seedQuote(
+  t: { partnerId: string; orgId: string },
+  opts: { quoteNumber?: string | null; sentAt?: string | null; createdAt?: string; status?: string } = {}
+): Promise<string> {
+  const [q] = await sql<{ id: string }[]>`
+    INSERT INTO quotes (partner_id, org_id, quote_number, status, sent_at, created_at)
+    VALUES (
+      ${t.partnerId},
+      ${t.orgId},
+      ${opts.quoteNumber ?? null},
+      ${(opts.status ?? 'draft') as string}::quote_status,
+      ${opts.sentAt ?? null},
+      ${opts.createdAt ?? '2026-01-15 10:00:00'}
+    )
+    RETURNING id
+  `;
+  return q!.id;
+}
+
+async function seedBlock(
+  t: { orgId: string },
+  quoteId: string,
+  blockType: string,
+  sortOrder: number
+): Promise<string> {
+  const [b] = await sql<{ id: string }[]>`
+    INSERT INTO quote_blocks (quote_id, org_id, block_type, content, sort_order)
+    VALUES (${quoteId}, ${t.orgId}, ${blockType}::quote_block_type, '{}'::jsonb, ${sortOrder})
+    RETURNING id
+  `;
+  return b!.id;
+}
+
+/** Seed a line with block_id explicitly NULL — the broken "orphan" shape. */
+async function seedOrphanLine(
+  t: { orgId: string },
+  quoteId: string,
+  sortOrder: number
+): Promise<string> {
+  const [l] = await sql<{ id: string }[]>`
+    INSERT INTO quote_lines (quote_id, block_id, org_id, source_type, description, quantity, unit_price, line_total, sort_order)
+    VALUES (${quoteId}, NULL, ${t.orgId}, 'manual', ${`Orphan ${sortOrder}`}, 1, 100.00, 100.00, ${sortOrder})
+    RETURNING id
+  `;
+  return l!.id;
+}
+
+async function blockIdOf(lineId: string): Promise<string | null> {
+  const [r] = await sql<{ block_id: string | null }[]>`
+    SELECT block_id FROM quote_lines WHERE id = ${lineId}
+  `;
+  return r!.block_id;
+}
+
+async function quoteNumberOf(quoteId: string): Promise<string | null> {
+  const [r] = await sql<{ quote_number: string | null }[]>`
+    SELECT quote_number FROM quotes WHERE id = ${quoteId}
+  `;
+  return r!.quote_number;
+}
+
+async function blocksOf(quoteId: string) {
+  return sql<{ id: string; block_type: string; content: unknown; sort_order: number; org_id: string }[]>`
+    SELECT id, block_type, content, sort_order, org_id
+    FROM quote_blocks WHERE quote_id = ${quoteId}
+    ORDER BY sort_order, created_at, id
+  `;
+}
+
+async function counterOf(partnerId: string, year: number): Promise<number | null> {
+  const [r] = await sql<{ counter: number }[]>`
+    SELECT counter FROM partner_quote_sequences WHERE partner_id = ${partnerId} AND year = ${year}
+  `;
+  return r ? Number(r.counter) : null;
+}
+
+describe('quote backfill migration — PART A: orphan quote_lines', () => {
+  runDb('attaches an orphan to the quote\'s EARLIEST existing line_items block', async () => {
+    const t = await seedTenant();
+    const quoteId = await seedQuote(t, { quoteNumber: 'Q-2026-9001' });
+    // Deliberately insert out of sort order so "earliest" can only be satisfied
+    // by sort_order, not by insertion/creation order.
+    const later = await seedBlock(t, quoteId, 'line_items', 5);
+    await seedBlock(t, quoteId, 'heading', 0);
+    const earliest = await seedBlock(t, quoteId, 'line_items', 2);
+    const orphan = await seedOrphanLine(t, quoteId, 0);
+
+    expect(await blockIdOf(orphan)).toBeNull();
+    await applyMigration();
+
+    expect(await blockIdOf(orphan)).toBe(earliest);
+    expect(await blockIdOf(orphan)).not.toBe(later);
+    // No block was invented when a usable one already existed.
+    expect((await blocksOf(quoteId)).length).toBe(3);
+  });
+
+  runDb('creates exactly ONE line_items block for a quote that has none, reused by every orphan', async () => {
+    const t = await seedTenant();
+    const quoteId = await seedQuote(t, { quoteNumber: 'Q-2026-9002' });
+    // A non-line_items block exists, so the migration must still create one AND
+    // must append after it (sort_order = max + 1), mirroring nextBlockSortOrder.
+    await seedBlock(t, quoteId, 'heading', 0);
+    await seedBlock(t, quoteId, 'rich_text', 3);
+    const orphans = [
+      await seedOrphanLine(t, quoteId, 0),
+      await seedOrphanLine(t, quoteId, 1),
+      await seedOrphanLine(t, quoteId, 2)
+    ];
+
+    await applyMigration();
+
+    const blocks = await blocksOf(quoteId);
+    const lineItemBlocks = blocks.filter((b) => b.block_type === 'line_items');
+    expect(lineItemBlocks).toHaveLength(1);
+
+    const created = lineItemBlocks[0]!;
+    expect(created.sort_order).toBe(4); // max(0,3) + 1
+    expect(created.content).toEqual({}); // mirrors resolveLineBlockId's `content: {}`
+    expect(created.org_id).toBe(t.orgId); // tenant taken from the parent quote
+
+    // ONE block per quote, not one per line.
+    const attached = await Promise.all(orphans.map(blockIdOf));
+    expect(attached).toEqual([created.id, created.id, created.id]);
+  });
+
+  runDb('leaves already-attached lines untouched', async () => {
+    const t = await seedTenant();
+    const quoteId = await seedQuote(t, { quoteNumber: 'Q-2026-9003' });
+    const blockA = await seedBlock(t, quoteId, 'line_items', 0);
+    const blockB = await seedBlock(t, quoteId, 'line_items', 1);
+    const [attached] = await sql<{ id: string }[]>`
+      INSERT INTO quote_lines (quote_id, block_id, org_id, source_type, description, quantity, unit_price, line_total, sort_order)
+      VALUES (${quoteId}, ${blockB}, ${t.orgId}, 'manual', 'Already placed', 1, 50.00, 50.00, 0)
+      RETURNING id
+    `;
+
+    await applyMigration();
+
+    // Still in block B — NOT relocated to the earliest block.
+    expect(await blockIdOf(attached!.id)).toBe(blockB);
+    expect(blockB).not.toBe(blockA);
+  });
+
+  runDb('does not leak a block across quotes — each affected quote gets its own', async () => {
+    const t = await seedTenant();
+    const q1 = await seedQuote(t, { quoteNumber: 'Q-2026-9004' });
+    const q2 = await seedQuote(t, { quoteNumber: 'Q-2026-9005' });
+    const o1 = await seedOrphanLine(t, q1, 0);
+    const o2 = await seedOrphanLine(t, q2, 0);
+
+    await applyMigration();
+
+    const b1 = await blockIdOf(o1);
+    const b2 = await blockIdOf(o2);
+    expect(b1).not.toBeNull();
+    expect(b2).not.toBeNull();
+    expect(b1).not.toBe(b2);
+    expect((await blocksOf(q1)).map((b) => b.id)).toEqual([b1]);
+    expect((await blocksOf(q2)).map((b) => b.id)).toEqual([b2]);
+  });
+});
+
+describe('quote backfill migration — PART B: missing quote_number', () => {
+  runDb('numbers a never-sent draft via partner_quote_sequences in formatQuoteNumber shape', async () => {
+    const t = await seedTenant();
+    const quoteId = await seedQuote(t, { quoteNumber: null, sentAt: null, createdAt: '2025-03-04 09:00:00' });
+
+    expect(await counterOf(t.partnerId, 2025)).toBeNull();
+    await applyMigration();
+
+    // Year comes from the quote's created_at, counter zero-padded to 4.
+    expect(await quoteNumberOf(quoteId)).toBe('Q-2025-0001');
+    // Allocation went THROUGH the sequence table, not computed inline.
+    expect(await counterOf(t.partnerId, 2025)).toBe(1);
+  });
+
+  runDb('continues an EXISTING partner sequence rather than restarting at 1', async () => {
+    const t = await seedTenant();
+    await sql`
+      INSERT INTO partner_quote_sequences (partner_id, year, counter)
+      VALUES (${t.partnerId}, 2026, 7)
+    `;
+    const quoteId = await seedQuote(t, { quoteNumber: null, sentAt: null, createdAt: '2026-05-02 09:00:00' });
+
+    await applyMigration();
+
+    expect(await quoteNumberOf(quoteId)).toBe('Q-2026-0008');
+    expect(await counterOf(t.partnerId, 2026)).toBe(8);
+  });
+
+  runDb('allocates distinct numbers to multiple drafts, oldest first, without colliding', async () => {
+    const t = await seedTenant();
+    const older = await seedQuote(t, { quoteNumber: null, createdAt: '2026-02-01 09:00:00' });
+    const newer = await seedQuote(t, { quoteNumber: null, createdAt: '2026-02-09 09:00:00' });
+
+    await applyMigration();
+
+    expect(await quoteNumberOf(older)).toBe('Q-2026-0001');
+    expect(await quoteNumberOf(newer)).toBe('Q-2026-0002');
+    expect(await counterOf(t.partnerId, 2026)).toBe(2);
+  });
+
+  runDb('skips a candidate number already held by another quote of the same partner', async () => {
+    const t = await seedTenant();
+    // Q-2026-0001 is taken; the sequence is behind (a partial-restore shape).
+    await seedQuote(t, { quoteNumber: 'Q-2026-0001', createdAt: '2026-01-02 09:00:00' });
+    const stuck = await seedQuote(t, { quoteNumber: null, createdAt: '2026-01-03 09:00:00' });
+
+    await applyMigration();
+
+    // Burned counter 1 (occupied), landed on 2 — no unique-index abort.
+    expect(await quoteNumberOf(stuck)).toBe('Q-2026-0002');
+  });
+
+  runDb('leaves a SENT quote with a NULL number ALONE (never renumber a delivered document)', async () => {
+    const t = await seedTenant();
+    const sent = await seedQuote(t, {
+      quoteNumber: null,
+      sentAt: '2026-04-01 12:00:00',
+      status: 'sent',
+      createdAt: '2026-03-01 09:00:00'
+    });
+
+    await applyMigration();
+
+    expect(await quoteNumberOf(sent)).toBeNull();
+    // And no counter was burned on its behalf.
+    expect(await counterOf(t.partnerId, 2026)).toBeNull();
+  });
+
+  runDb('does not rewrite an existing quote_number', async () => {
+    const t = await seedTenant();
+    const quoteId = await seedQuote(t, { quoteNumber: 'Q-2026-0042', createdAt: '2026-06-01 09:00:00' });
+
+    await applyMigration();
+
+    expect(await quoteNumberOf(quoteId)).toBe('Q-2026-0042');
+    expect(await counterOf(t.partnerId, 2026)).toBeNull();
+  });
+});
+
+describe('quote backfill migration — idempotency', () => {
+  runDb('a second application is a complete no-op (no re-number, no duplicate block)', async () => {
+    const t = await seedTenant();
+
+    // Orphan with no line_items block anywhere.
+    const qOrphan = await seedQuote(t, { quoteNumber: 'Q-2026-9100' });
+    const orphanA = await seedOrphanLine(t, qOrphan, 0);
+    const orphanB = await seedOrphanLine(t, qOrphan, 1);
+    // Unsent draft with no number.
+    const qUnnumbered = await seedQuote(t, { quoteNumber: null, createdAt: '2026-07-01 09:00:00' });
+    // Sent quote with no number — must stay NULL across both runs.
+    const qSent = await seedQuote(t, {
+      quoteNumber: null, sentAt: '2026-07-02 12:00:00', status: 'sent', createdAt: '2026-07-02 09:00:00'
+    });
+
+    await applyMigration();
+
+    const firstBlocks = await blocksOf(qOrphan);
+    const firstState = {
+      blockIds: firstBlocks.map((b) => b.id),
+      orphanA: await blockIdOf(orphanA),
+      orphanB: await blockIdOf(orphanB),
+      number: await quoteNumberOf(qUnnumbered),
+      sentNumber: await quoteNumberOf(qSent),
+      counter: await counterOf(t.partnerId, 2026)
+    };
+    expect(firstState.blockIds).toHaveLength(1);
+    expect(firstState.number).toBe('Q-2026-0001');
+    expect(firstState.counter).toBe(1);
+
+    // ---- second application ----
+    await applyMigration();
+
+    expect((await blocksOf(qOrphan)).map((b) => b.id)).toEqual(firstState.blockIds);
+    expect(await blockIdOf(orphanA)).toBe(firstState.orphanA);
+    expect(await blockIdOf(orphanB)).toBe(firstState.orphanB);
+    expect(await quoteNumberOf(qUnnumbered)).toBe(firstState.number);
+    expect(await quoteNumberOf(qSent)).toBeNull();
+    // The decisive assertion: no counter was burned on the re-run.
+    expect(await counterOf(t.partnerId, 2026)).toBe(firstState.counter);
+
+    // ---- third application, for good measure ----
+    await applyMigration();
+    expect(await counterOf(t.partnerId, 2026)).toBe(firstState.counter);
+    expect((await blocksOf(qOrphan)).map((b) => b.id)).toEqual(firstState.blockIds);
+  });
+
+  runDb('is a no-op on a database with nothing to repair', async () => {
+    const t = await seedTenant();
+    const quoteId = await seedQuote(t, { quoteNumber: 'Q-2026-0500', createdAt: '2026-08-01 09:00:00' });
+    const block = await seedBlock(t, quoteId, 'line_items', 0);
+    await sql`
+      INSERT INTO quote_lines (quote_id, block_id, org_id, source_type, description, quantity, unit_price, line_total, sort_order)
+      VALUES (${quoteId}, ${block}, ${t.orgId}, 'manual', 'Healthy', 1, 10.00, 10.00, 0)
+    `;
+
+    await applyMigration();
+
+    expect((await blocksOf(quoteId)).map((b) => b.id)).toEqual([block]);
+    expect(await quoteNumberOf(quoteId)).toBe('Q-2026-0500');
+    expect(await counterOf(t.partnerId, 2026)).toBeNull();
+  });
+});

--- a/apps/api/src/__tests__/integration/quoteService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteService.integration.test.ts
@@ -26,11 +26,12 @@ import {
   withSystemDbAccessContext,
   type DbAccessContext,
 } from '../../db';
-import { quotes, quoteLines } from '../../db/schema/quotes';
+import { quotes, quoteLines, quoteBlocks } from '../../db/schema/quotes';
 import { catalogItems } from '../../db/schema/catalog';
 import { createOrganization, createPartner } from './db-utils';
 import {
   createQuote,
+  cloneQuote,
   getQuote,
   addBlock,
   deleteBlock,
@@ -185,6 +186,74 @@ describe('quoteService (breeze_app, real DB)', () => {
     expect(l1.blockId).toBe(lineBlocks[0]!.id);
     expect(l2.blockId).toBe(lineBlocks[0]!.id);
     expect(fetched.lines.every((l) => l.blockId === lineBlocks[0]!.id)).toBe(true);
+  });
+
+  /**
+   * Forge the pre-#2553 orphan shape on an existing quote: null out every line's
+   * block_id, and optionally delete the blocks so the quote has no pricing
+   * section at all. Runs under system scope — the API can no longer create this
+   * shape, but legacy rows (and prod quote 50a25127) still carry it.
+   */
+  async function orphanAllLines(quoteId: string, opts: { dropBlocks?: boolean } = {}) {
+    await withSystemDbAccessContext(async () => {
+      await db.update(quoteLines).set({ blockId: null }).where(eq(quoteLines.quoteId, quoteId));
+      if (opts.dropBlocks) await db.delete(quoteBlocks).where(eq(quoteBlocks.quoteId, quoteId));
+    });
+  }
+
+  runDb('cloneQuote lands legacy orphan lines in ONE real pricing section on the clone', async () => {
+    const fx = await seedFixture();
+    const quote = await withDbAccessContext(fx.ctxA, () =>
+      createQuote({ orgId: fx.orgA.id, currencyCode: 'USD' }, fx.actorA)
+    );
+    for (const price of [100, 50]) {
+      await withDbAccessContext(fx.ctxA, () =>
+        addManualLine(quote.id, {
+          sourceType: 'manual', description: `Line ${price}`, quantity: 1, unitPrice: price,
+          taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false,
+        }, fx.actorA)
+      );
+    }
+    // Source has NO line_items block left, so the clone must mint one itself.
+    await orphanAllLines(quote.id, { dropBlocks: true });
+
+    const cloned = await withDbAccessContext(fx.ctxA, () => cloneQuote(quote.id, fx.actorA));
+    const fetched = await withDbAccessContext(fx.ctxA, () => getQuote(cloned.id, fx.actorA));
+
+    const lineBlocks = fetched.blocks.filter((b) => b.blockType === 'line_items');
+    expect(lineBlocks).toHaveLength(1); // ONE fallback section, not one per orphan
+    expect(fetched.lines).toHaveLength(2);
+    // The orphan never propagates: every cloned line is editable in the builder.
+    expect(fetched.lines.every((l) => l.blockId === lineBlocks[0]!.id)).toBe(true);
+
+    // The SOURCE is left exactly as it was — cloning repairs the copy, not the original.
+    const sourceLines = await withDbAccessContext(fx.ctxA, () =>
+      db.select({ blockId: quoteLines.blockId }).from(quoteLines).where(eq(quoteLines.quoteId, quote.id))
+    );
+    expect(sourceLines.every((l) => l.blockId === null)).toBe(true);
+  });
+
+  runDb('cloneQuote re-parents an orphan onto the clone of the source pricing section', async () => {
+    const fx = await seedFixture();
+    const quote = await withDbAccessContext(fx.ctxA, () =>
+      createQuote({ orgId: fx.orgA.id, currencyCode: 'USD' }, fx.actorA)
+    );
+    await withDbAccessContext(fx.ctxA, () =>
+      addManualLine(quote.id, {
+        sourceType: 'manual', description: 'Kept', quantity: 1, unitPrice: 100,
+        taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false,
+      }, fx.actorA)
+    );
+    // Keep the auto-created line_items block; only orphan the line.
+    await orphanAllLines(quote.id);
+
+    const cloned = await withDbAccessContext(fx.ctxA, () => cloneQuote(quote.id, fx.actorA));
+    const fetched = await withDbAccessContext(fx.ctxA, () => getQuote(cloned.id, fx.actorA));
+
+    // No extra section is spawned — the existing one is reused.
+    const lineBlocks = fetched.blocks.filter((b) => b.blockType === 'line_items');
+    expect(lineBlocks).toHaveLength(1);
+    expect(fetched.lines[0]!.blockId).toBe(lineBlocks[0]!.id);
   });
 
   runDb('addCatalogLine snapshots a recurring item (recurrence/term/price/MRR)', async () => {

--- a/apps/api/src/routes/portal/quotes.test.ts
+++ b/apps/api/src/routes/portal/quotes.test.ts
@@ -470,3 +470,54 @@ describe('portal quotes /:id/pdf', () => {
     expect(renderQuotePdfMock).not.toHaveBeenCalled();
   });
 });
+
+describe('portal quotes GET /quotes/:id/line-image/:lineId', () => {
+  const LINE_ID = '77777777-7777-7777-7777-777777777777';
+  const CATALOG_ID = '88888888-8888-8888-8888-888888888888';
+  beforeEach(() => { vi.clearAllMocks(); dbResults.length = 0; });
+
+  it('serves the per-line uploaded image bytes', async () => {
+    dbResults.push([{ id: QUOTE_ID }]); // quote ownership lookup
+    dbResults.push([{ imageId: 'img-1', catalogItemId: null, customerVisible: true }]); // line
+    dbResults.push([{ data: Buffer.from('PNGDATA'), mime: 'image/png', byteSize: 7 }]); // readQuoteImage
+    const res = await app().request(`/quotes/${QUOTE_ID}/line-image/${LINE_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('image/png');
+  });
+
+  it('falls back to the line catalog item image when no uploaded image', async () => {
+    dbResults.push([{ id: QUOTE_ID }]);
+    dbResults.push([{ imageId: null, catalogItemId: CATALOG_ID, customerVisible: true }]);
+    dbResults.push([{ data: Buffer.from('JPEG'), mime: 'image/jpeg', byteSize: 4 }]); // readCatalogItemImage
+    const res = await app().request(`/quotes/${QUOTE_ID}/line-image/${LINE_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('image/jpeg');
+  });
+
+  it('404s a line with no image', async () => {
+    dbResults.push([{ id: QUOTE_ID }]);
+    dbResults.push([{ imageId: null, catalogItemId: null, customerVisible: true }]);
+    const res = await app().request(`/quotes/${QUOTE_ID}/line-image/${LINE_ID}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('404s a cross-quote / unknown lineId (line lookup scoped to the quote)', async () => {
+    dbResults.push([{ id: QUOTE_ID }]);
+    dbResults.push([]); // line lookup: no row for this quote
+    const res = await app().request(`/quotes/${QUOTE_ID}/line-image/${LINE_ID}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('404s when the quote is not owned by the caller org', async () => {
+    dbResults.push([]); // quote ownership lookup → none
+    const res = await app().request(`/quotes/${QUOTE_ID}/line-image/${LINE_ID}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('does not serve an image for a non-customer-visible line', async () => {
+    dbResults.push([{ id: QUOTE_ID }]);
+    dbResults.push([{ imageId: 'img-1', catalogItemId: null, customerVisible: false }]);
+    const res = await app().request(`/quotes/${QUOTE_ID}/line-image/${LINE_ID}`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -11,9 +11,9 @@ import { markQuoteViewed, declineQuoteByActor } from '../../services/quoteLifecy
 import { acceptQuote, emitAcceptInvoiceIssued } from '../../services/quoteAcceptService';
 import { createQuotePayLink } from '../../services/quotePay';
 import { computeQuoteTotals, toQuoteDepositConfig, type QuoteLineForMath } from '../../services/quoteMath';
-import { readQuoteImage } from '../../services/quoteImageStorage';
+import { readQuoteImage, loadCustomerLineImage } from '../../services/quoteImageStorage';
 import { QuoteServiceError } from '../../services/quoteTypes';
-import { toCustomerLines, sanitizeQuoteBlocksForRead } from '../../services/quoteService';
+import { toCustomerLines, attachCustomerLineImages, sanitizeQuoteBlocksForRead } from '../../services/quoteService';
 import { loadContractBlockRenderData, renderContractBlocksForClient, loadContractPdfInputs } from '../../services/contractTemplateRender';
 import { ContractTemplateServiceError } from '../../services/contractTemplateService';
 import { PdfMergeError } from '../../services/pdfMerge';
@@ -27,6 +27,7 @@ export const quoteRoutes = new Hono();
 quoteRoutes.use('*', portalFinancialMutationGuard);
 const idParam = z.object({ id: z.string().guid() });
 const imageParam = z.object({ id: z.string().guid(), imageId: z.string().guid() });
+const lineImageParam = z.object({ id: z.string().guid(), lineId: z.string().guid() });
 const blockFileParam = z.object({ id: z.string().guid(), blockId: z.string().guid() });
 
 // GET /quotes — list (drafts filtered; org defense-in-depth atop RLS).
@@ -64,7 +65,8 @@ quoteRoutes.get('/quotes/:id', zValidator('param', idParam), async (c) => {
     // ahead of the response we're about to build below) and replaces its raw
     // authoring content with the render contract the portal understands.
     const blocks = await renderContractBlocksForClient(rawBlocks, quote, (blockId) => `/portal/quotes/${id}/contract-file/${blockId}`);
-    return c.json({ data: { quote: { ...quote, dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal, depositDueTotal: totals.depositDueTotal, categoryBreakdown: totals.categoryBreakdown }, blocks, lines, branding: { partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null } } });
+    const serializedLines = attachCustomerLineImages(lines, (lineId) => `/portal/quotes/${id}/line-image/${lineId}`);
+    return c.json({ data: { quote: { ...quote, dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal, depositDueTotal: totals.depositDueTotal, categoryBreakdown: totals.categoryBreakdown }, blocks, lines: serializedLines, branding: { partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null } } });
   } catch (err) {
     if (err instanceof ContractTemplateServiceError) return c.json({ error: err.message, code: err.code }, err.status);
     throw err;
@@ -149,6 +151,22 @@ quoteRoutes.get('/quotes/:id/images/:imageId', zValidator('param', imageParam), 
   const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId), ne(quotes.status, 'draft'))).limit(1);
   if (!quote) return c.json({ error: 'Quote not found' }, 404);
   const img = await readQuoteImage(imageId, id);
+  if (!img) return c.json({ error: 'Image not found' }, 404);
+  return new Response(new Uint8Array(img.data), { status: 200, headers: { 'Content-Type': img.mime, 'Content-Length': String(img.byteSize), 'Cache-Control': 'private, max-age=300' } });
+});
+
+// GET /quotes/:id/line-image/:lineId — per-line product thumbnail (uploaded image
+// or the line's snapshotted catalog item image), the customer-facing counterpart
+// to the in-app /catalog/:id/image route. The line lookup is quote-scoped
+// (id AND quoteId, customer-visible), closing the cross-quote case exactly like
+// the /images/:imageId route. The catalog-image branch reads a PARTNER-axis table
+// invisible to this org scope (#1375), so resolve under SYSTEM scope — ownership
+// is already established by the org-scoped quote lookup + the quote-scoped line.
+quoteRoutes.get('/quotes/:id/line-image/:lineId', zValidator('param', lineImageParam), async (c) => {
+  const auth = c.get('portalAuth'); const { id, lineId } = c.req.valid('param');
+  const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId), ne(quotes.status, 'draft'))).limit(1);
+  if (!quote) return c.json({ error: 'Quote not found' }, 404);
+  const img = await runOutsideDbContext(() => withSystemDbAccessContext(() => loadCustomerLineImage(id, lineId)));
   if (!img) return c.json({ error: 'Image not found' }, 404);
   return new Response(new Uint8Array(img.data), { status: 200, headers: { 'Content-Type': img.mime, 'Content-Length': String(img.byteSize), 'Cache-Control': 'private, max-age=300' } });
 });

--- a/apps/api/src/routes/quotesPublic.test.ts
+++ b/apps/api/src/routes/quotesPublic.test.ts
@@ -235,3 +235,47 @@ describe('quotesPublic GET /:token/contract-file/:blockId', () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe('quotesPublic GET /:token/line-image/:lineId', () => {
+  const LINE_ID = '77777777-7777-7777-7777-777777777777';
+  const CATALOG_ID = '88888888-8888-8888-8888-888888888888';
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbResults.length = 0;
+    (verifyQuoteAcceptToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+      quoteId: QUOTE_ID, orgId: ORG_ID, partnerId: PARTNER_ID, jti: 'jti-1',
+    });
+    (isQuoteAcceptJtiRevoked as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+  });
+
+  it('serves the per-line uploaded image for a valid token', async () => {
+    dbResults.push([{ id: QUOTE_ID }]); // quote (token-resolved) lookup
+    dbResults.push([{ imageId: 'img-1', catalogItemId: null, customerVisible: true }]); // line
+    dbResults.push([{ data: Buffer.from('PNGDATA'), mime: 'image/png', byteSize: 7 }]); // readQuoteImage
+    const res = await app().request(`/quotes/public/${TOKEN}/line-image/${LINE_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('image/png');
+  });
+
+  it('falls back to the catalog item image', async () => {
+    dbResults.push([{ id: QUOTE_ID }]);
+    dbResults.push([{ imageId: null, catalogItemId: CATALOG_ID, customerVisible: true }]);
+    dbResults.push([{ data: Buffer.from('JPEG'), mime: 'image/jpeg', byteSize: 4 }]);
+    const res = await app().request(`/quotes/public/${TOKEN}/line-image/${LINE_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('image/jpeg');
+  });
+
+  it('rejects an invalid/expired token with 401 (no db read)', async () => {
+    (verifyQuoteAcceptToken as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const res = await app().request(`/quotes/public/${TOKEN}/line-image/${LINE_ID}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('404s a cross-quote / unknown lineId (line lookup scoped to the token quote)', async () => {
+    dbResults.push([{ id: QUOTE_ID }]);
+    dbResults.push([]); // no line on this quote
+    const res = await app().request(`/quotes/public/${TOKEN}/line-image/${LINE_ID}`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/api/src/routes/quotesPublic.ts
+++ b/apps/api/src/routes/quotesPublic.ts
@@ -10,9 +10,9 @@ import { acceptQuoteSchema, declineQuoteSchema } from '@breeze/shared';
 import { verifyQuoteAcceptToken, isQuoteAcceptJtiRevoked, revokeQuoteAcceptJti } from '../services/quoteAcceptToken';
 import { markQuoteViewed } from '../services/quoteLifecycle';
 import { acceptQuote, emitAcceptInvoiceIssued } from '../services/quoteAcceptService';
-import { readQuoteImage } from '../services/quoteImageStorage';
+import { readQuoteImage, loadCustomerLineImage } from '../services/quoteImageStorage';
 import { QuoteServiceError } from '../services/quoteTypes';
-import { toCustomerLines, sanitizeQuoteBlocksForRead } from '../services/quoteService';
+import { toCustomerLines, attachCustomerLineImages, sanitizeQuoteBlocksForRead } from '../services/quoteService';
 import { loadContractBlockRenderData, renderContractBlocksForClient } from '../services/contractTemplateRender';
 import { ContractTemplateServiceError } from '../services/contractTemplateService';
 import { InvoiceServiceError } from '../services/invoiceTypes';
@@ -35,6 +35,7 @@ import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 export const quotesPublicRoutes = new Hono();
 const tokenParam = z.object({ token: z.string().min(10) });
 const tokenImageParam = z.object({ token: z.string().min(10), imageId: z.string().guid() });
+const tokenLineImageParam = z.object({ token: z.string().min(10), lineId: z.string().guid() });
 const tokenBlockParam = z.object({ token: z.string().min(10), blockId: z.string().guid() });
 
 // Resolve + verify the token, returning the scoped claims or null.
@@ -69,7 +70,8 @@ quotesPublicRoutes.get('/:token', zValidator('param', tokenParam), async (c) => 
       // Resolves every `contract` block's pinned template version (system context)
       // and replaces its raw authoring content with the token-gated render contract.
       const blocks = await renderContractBlocksForClient(rawBlocks, quote, (blockId) => `/quotes/public/${encodeURIComponent(token)}/contract-file/${blockId}`);
-      return { quote: { ...quote, status: quote.status === 'sent' ? 'viewed' : quote.status, dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal, depositDueTotal: totals.depositDueTotal, categoryBreakdown: totals.categoryBreakdown }, blocks, lines, branding: { partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null } };
+      const serializedLines = attachCustomerLineImages(lines, (lineId) => `/quotes/public/${encodeURIComponent(token)}/line-image/${lineId}`);
+      return { quote: { ...quote, status: quote.status === 'sent' ? 'viewed' : quote.status, dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal, depositDueTotal: totals.depositDueTotal, categoryBreakdown: totals.categoryBreakdown }, blocks, lines: serializedLines, branding: { partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null } };
     }));
     if (!data) return c.json({ error: 'Quote not found' }, 404);
     return c.json({ data });
@@ -87,6 +89,24 @@ quotesPublicRoutes.get('/:token/images/:imageId', zValidator('param', tokenImage
     const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
     if (!quote) return null;
     return readQuoteImage(imageId, quote.id);
+  }));
+  if (!img) return c.json({ error: 'Image not found' }, 404);
+  return new Response(new Uint8Array(img.data), { status: 200, headers: { 'Content-Type': img.mime, 'Content-Length': String(img.byteSize), 'Cache-Control': 'private, max-age=300' } });
+});
+
+// GET /:token/line-image/:lineId — per-line product thumbnail (uploaded image or
+// the line's snapshotted catalog item image), the customer counterpart to the
+// authed /catalog/:id/image route. Same token-gated, system-scope read as the
+// image route: quote_id resolved from the signature-verified token, the line
+// lookup scoped to that quote (id AND quoteId, customer-visible) so a token
+// holder can only reach images for lines on their own proposal.
+quotesPublicRoutes.get('/:token/line-image/:lineId', zValidator('param', tokenLineImageParam), async (c) => {
+  const claims = await resolve(c); const { lineId } = c.req.valid('param');
+  if (!claims) return c.json({ error: 'This link is invalid or has expired' }, 401);
+  const img = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
+    if (!quote) return null;
+    return loadCustomerLineImage(quote.id, lineId);
   }));
   if (!img) return c.json({ error: 'Image not found' }, 404);
   return new Response(new Uint8Array(img.data), { status: 200, headers: { 'Content-Type': img.mime, 'Content-Length': String(img.byteSize), 'Cache-Control': 'private, max-age=300' } });

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -222,6 +222,7 @@ export const TOOL_PERMISSIONS: Record<string, { resource: string; action: string
     add_catalog_line: { resource: 'quotes', action: 'write' },
     update_line: { resource: 'quotes', action: 'write' },
     remove_line: { resource: 'quotes', action: 'write' },
+    move_line: { resource: 'quotes', action: 'write' },
     reorder_lines: { resource: 'quotes', action: 'write' },
     send: { resource: 'quotes', action: 'send' },
     decline: { resource: 'quotes', action: 'write' },

--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -324,6 +324,7 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
       'add_catalog_line',
       'update_line',
       'remove_line',
+      'move_line',
       'reorder_lines',
       'send',
       'decline',

--- a/apps/api/src/services/aiToolsQuotes.test.ts
+++ b/apps/api/src/services/aiToolsQuotes.test.ts
@@ -29,6 +29,7 @@ vi.mock('./quoteService', () => ({
   addCatalogLine: vi.fn().mockResolvedValue({ id: 'line-2', catalogItemId: 'catalog-1' }),
   updateLine: vi.fn().mockResolvedValue({ id: 'line-1', quantity: '2' }),
   removeLine: vi.fn().mockResolvedValue(undefined),
+  moveLineToBlock: vi.fn().mockResolvedValue({ id: 'line-1', blockId: 'block-2', sortOrder: 0 }),
   reorderLines: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -196,6 +197,35 @@ describe('manage_quotes', () => {
     expect(JSON.parse(out)).toEqual({ id: 'line-2', catalogItemId: 'catalog-1' });
   });
 
+  it('move_line re-parents a line via moveLineToBlock (the orphan repair path, #2553)', async () => {
+    const out = await getTool().handler(
+      { action: 'move_line', quoteId: 'quote-1', lineId: 'line-1', blockId: 'block-2' },
+      auth,
+    );
+
+    // Reuses the same service the PATCH /:id/lines/:lineId/move route calls, so
+    // its guards (block belongs to the quote, block is line_items, bundle
+    // children ride with their parent) all apply to the AI path too.
+    expect(quoteService.moveLineToBlock).toHaveBeenCalledWith('quote-1', 'line-1', 'block-2', actor);
+    expect(JSON.parse(out)).toEqual({ id: 'line-1', blockId: 'block-2', sortOrder: 0 });
+  });
+
+  it('move_line surfaces a service rejection (e.g. non-pricing target block) as a structured error', async () => {
+    vi.mocked(quoteService.moveLineToBlock).mockRejectedValueOnce(
+      new QuoteServiceError('Target block is not a pricing table', 400, 'BLOCK_NOT_LINE_ITEMS'),
+    );
+
+    const out = await getTool().handler(
+      { action: 'move_line', quoteId: 'quote-1', lineId: 'line-1', blockId: 'block-2' },
+      auth,
+    );
+
+    expect(JSON.parse(out)).toEqual({
+      error: 'Target block is not a pricing table',
+      code: 'BLOCK_NOT_LINE_ITEMS',
+    });
+  });
+
   it('returns a JSON error when a service action rejects with QuoteServiceError', async () => {
     vi.mocked(quoteLifecycle.sendQuote).mockRejectedValueOnce(
       new QuoteServiceError('Cannot send a quote in status sent', 409, 'INVALID_STATE'),
@@ -337,6 +367,30 @@ describe('manage_quotes input validation (#2362)', () => {
     expect(parsed.code).toBe('VALIDATION_ERROR');
     expect(parsed.error).toContain('block.');
     expect(quoteService.addBlock).not.toHaveBeenCalled();
+  });
+
+  it('move_line without blockId returns a structured VALIDATION_ERROR', async () => {
+    const out = await getTool().handler(
+      { action: 'move_line', quoteId: 'quote-1', lineId: 'line-1' },
+      auth,
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(parsed.error).toContain('blockId');
+    expect(quoteService.moveLineToBlock).not.toHaveBeenCalled();
+  });
+
+  it('move_line without lineId returns a structured VALIDATION_ERROR', async () => {
+    const out = await getTool().handler(
+      { action: 'move_line', quoteId: 'quote-1', blockId: 'block-2' },
+      auth,
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(parsed.error).toContain('lineId');
+    expect(quoteService.moveLineToBlock).not.toHaveBeenCalled();
   });
 
   it('remove_line without lineId returns a structured VALIDATION_ERROR', async () => {

--- a/apps/api/src/services/aiToolsQuotes.ts
+++ b/apps/api/src/services/aiToolsQuotes.ts
@@ -55,6 +55,7 @@ import {
   addCatalogLine,
   updateLine,
   removeLine,
+  moveLineToBlock,
   reorderLines,
 } from './quoteService';
 import { sendQuote, declineQuoteByActor } from './quoteLifecycle';
@@ -99,6 +100,7 @@ const REQUIRED_PARAMS: Record<string, readonly string[]> = {
   add_catalog_line: ['quoteId', 'catalogItemId', 'quantity'],
   update_line: ['quoteId', 'lineId', 'patch'],
   remove_line: ['quoteId', 'lineId'],
+  move_line: ['quoteId', 'lineId', 'blockId'],
   reorder_lines: ['quoteId', 'blockId', 'lineIds'],
   send: ['quoteId'],
   decline: ['quoteId'],
@@ -199,7 +201,8 @@ export function registerQuoteTools(aiTools: Map<string, AiTool>): void {
         'create_pay_link: quoteId; add_block: quoteId, block; update_block: quoteId, blockId, block; delete_block: ' +
         'quoteId, blockId; reorder_blocks: quoteId, blockIds; add_manual_line: quoteId, line; add_catalog_line: ' +
         'quoteId, catalogItemId, quantity (blockId optional); update_line: quoteId, lineId, patch; remove_line: ' +
-        'quoteId, lineId; reorder_lines: quoteId, blockId, lineIds.',
+        'quoteId, lineId; move_line: quoteId, lineId, blockId (the TARGET line_items block); ' +
+        'reorder_lines: quoteId, blockId, lineIds.',
       input_schema: {
         type: 'object' as const,
         properties: {
@@ -217,6 +220,7 @@ export function registerQuoteTools(aiTools: Map<string, AiTool>): void {
               'add_catalog_line',
               'update_line',
               'remove_line',
+              'move_line',
               'reorder_lines',
               'send',
               'decline',
@@ -224,7 +228,12 @@ export function registerQuoteTools(aiTools: Map<string, AiTool>): void {
             ],
           },
           quoteId: { type: 'string', description: 'Quote UUID' },
-          blockId: { type: 'string' },
+          blockId: {
+            type: 'string',
+            description:
+              'Block UUID. For move_line this is the TARGET line_items block the line moves into; ' +
+              'for reorder_lines, the block whose lines are being reordered.',
+          },
           lineId: { type: 'string' },
           catalogItemId: {
             type: 'string',
@@ -390,6 +399,17 @@ export function registerQuoteTools(aiTools: Map<string, AiTool>): void {
           case 'remove_line':
             await removeLine(String(input.quoteId), String(input.lineId), actor);
             return JSON.stringify({ ok: true });
+          // Re-parents a line onto another pricing table on the SAME quote. The
+          // only repair path for a legacy orphan (block_id NULL) — those lines
+          // count toward the totals and print on the PDF but are invisible in
+          // the web editor, so without this they need raw SQL (#2553).
+          case 'move_line':
+            return JSON.stringify(await moveLineToBlock(
+              String(input.quoteId),
+              String(input.lineId),
+              String(input.blockId),
+              actor
+            ));
           case 'reorder_lines': {
             const { lineIds } = reorderLinesSchema.parse({ lineIds: input.lineIds });
             await reorderLines(String(input.quoteId), String(input.blockId), lineIds, actor);

--- a/apps/api/src/services/quoteImageStorage.ts
+++ b/apps/api/src/services/quoteImageStorage.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'node:crypto';
 import { and, eq } from 'drizzle-orm';
 import { db, runOutsideDbContext } from '../db';
-import { quoteImages } from '../db/schema/quotes';
+import { quoteImages, quoteLines } from '../db/schema/quotes';
+import { readCatalogItemImage } from './catalogImageStorage';
 import { sniffImageMime } from './avatarStorage';
 import { safeFetch, SsrfBlockedError } from './urlSafety';
 
@@ -27,6 +28,35 @@ export async function readQuoteImage(imageId: string, quoteId: string): Promise<
   const [img] = await db.select({ data: quoteImages.imageData, mime: quoteImages.mime, byteSize: quoteImages.byteSize })
     .from(quoteImages).where(and(eq(quoteImages.id, imageId), eq(quoteImages.quoteId, quoteId))).limit(1);
   return img?.data ? { data: img.data, mime: img.mime, byteSize: img.byteSize } : null;
+}
+
+/**
+ * Resolve the customer-facing thumbnail image for ONE quote line, for the portal
+ * + public proposal views (which serve the same product photos the in-app
+ * preview shows via the authed /catalog/:id/image route). The line is looked up
+ * scoped to its quote (`id AND quoteId`) — the same cross-quote IDOR guard as
+ * readQuoteImage — and must be customer-visible, so a token/session holder can
+ * only reach images for lines actually on their own proposal.
+ *
+ * Source precedence mirrors the web renderer's DocLineThumb: a per-line uploaded
+ * image (`image_id`, in quote_images, org-axis) wins; otherwise the line's
+ * snapshotted catalog item's image (catalog_item_images, PARTNER-axis). Because
+ * catalog_item_images is partner-scoped, callers on the ORG-scoped portal path
+ * must invoke this under a SYSTEM db access context (the #1375 class — a bare
+ * org-scoped read would RLS-filter to 0 rows); the public path already runs in
+ * system scope. Ownership is enforced by the quote-scoped line lookup above, not
+ * by RLS, so running under system scope here is safe.
+ */
+export async function loadCustomerLineImage(quoteId: string, lineId: string): Promise<{ data: Buffer; mime: string; byteSize: number } | null> {
+  const [line] = await db.select({
+    imageId: quoteLines.imageId,
+    catalogItemId: quoteLines.catalogItemId,
+    customerVisible: quoteLines.customerVisible,
+  }).from(quoteLines).where(and(eq(quoteLines.id, lineId), eq(quoteLines.quoteId, quoteId))).limit(1);
+  if (!line || !line.customerVisible) return null;
+  if (line.imageId) return readQuoteImage(line.imageId, quoteId);
+  if (line.catalogItemId) return readCatalogItemImage(line.catalogItemId);
+  return null;
 }
 
 export type RemoteImageFailureReason = 'unreachable' | 'not_image' | 'too_large' | 'timeout';

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -661,3 +661,35 @@ describe('quoteService deposits', () => {
     expect(updated.coverPage).toMatchObject({ coverImageId: 'img1' });
   });
 });
+
+describe('attachCustomerLineImages', () => {
+  const base = { id: 'l1', description: 'Widget', quantity: '1', unitPrice: '10', lineTotal: '10' };
+  const buildPath = (lineId: string) => `/quotes/public/tok/line-image/${lineId}`;
+
+  it('builds a quote-scoped imageUrl for a line with an uploaded image and drops the raw ids', () => {
+    const [line] = svc.attachCustomerLineImages(
+      [{ ...base, imageId: 'img1', catalogItemId: null }],
+      buildPath,
+    );
+    expect(line.imageUrl).toBe('/quotes/public/tok/line-image/l1');
+    expect(line).not.toHaveProperty('imageId');
+    expect(line).not.toHaveProperty('catalogItemId');
+    expect(line.description).toBe('Widget'); // other fields preserved
+  });
+
+  it('builds an imageUrl for a catalog-sourced line (no uploaded image)', () => {
+    const [line] = svc.attachCustomerLineImages(
+      [{ ...base, imageId: null, catalogItemId: 'cat1' }],
+      buildPath,
+    );
+    expect(line.imageUrl).toBe('/quotes/public/tok/line-image/l1');
+  });
+
+  it('emits null imageUrl for a line with neither an uploaded nor a catalog image', () => {
+    const [line] = svc.attachCustomerLineImages(
+      [{ ...base, imageId: null, catalogItemId: null }],
+      buildPath,
+    );
+    expect(line.imageUrl).toBeNull();
+  });
+});

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -316,6 +316,95 @@ describe('quoteService deposits', () => {
     expect((valuesMock.mock.calls.at(-1)![0] as { blockId?: string }).blockId).toBe('newblk');
   });
 
+  // -------------------------------------------------------------------------
+  // cloneQuote orphan re-parenting: a source line with block_id NULL (or one
+  // whose block failed to map) must NEVER be copied into the clone as another
+  // orphan — it lands in the clone's default pricing section instead.
+  // -------------------------------------------------------------------------
+
+  /** Queue every read cloneQuote issues before its transaction. */
+  function queueCloneReads(blocks: unknown[], lines: unknown[]) {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', taxRate: null, depositType: 'none', depositPercent: null, billToName: null, billToAddress: null, billToTaxId: null }]); // getQuote: quote
+    queueResult(blocks); // getQuote: blocks
+    queueResult(lines); // getQuote: lines
+    queueResult([]); // getQuote: no staged Pax8 order
+    queueResult([{ name: 'Org Inc' }]); // getQuote: draft bill-to org lookup
+    queueResult([]); // cloneQuote: quote images
+    queueResult([{ counter: 2 }]); // allocateQuoteCounter
+    queueResult([{ id: 'q2', orgId: 'org1' }]); // tx: quotes insert returning
+  }
+
+  const cloneLine = (over: Record<string, unknown>) => ({
+    id: 'lx', blockId: null, parentLineId: null, sourceType: 'manual', catalogItemId: null,
+    name: 'Widget', description: null, quantity: '1', unitPrice: '100.00', taxable: false,
+    customerVisible: true, lineTotal: '100.00', recurrence: 'one_time', termMonths: null,
+    billingFrequency: null, unitCost: null, depositEligible: false, itemType: null,
+    sku: null, partNumber: null, imageId: null, sortOrder: 0, ...over,
+  });
+
+  /** The array passed to `.values()` for a given insert (quote insert passes an object). */
+  function insertedArrays() {
+    const valuesMock = (db as unknown as Chain).values;
+    return valuesMock.mock.calls.map((c) => c[0]).filter(Array.isArray) as Record<string, unknown>[][];
+  }
+
+  it('cloneQuote re-parents a source orphan line onto the cloned default pricing section', async () => {
+    queueCloneReads(
+      [{ id: 'b1', blockType: 'line_items', content: {}, sortOrder: 0 }],
+      [cloneLine({ id: 'l1', blockId: null }), cloneLine({ id: 'l2', blockId: 'b1', sortOrder: 1 })],
+    );
+    queueResult([]); // tx: blocks insert
+    queueResult([]); // tx: lines insert
+
+    await svc.cloneQuote('q1', actor);
+
+    const [clonedBlocks, clonedLines] = insertedArrays();
+    // Exactly the one source block was cloned — no extra section spawned.
+    expect(clonedBlocks).toHaveLength(1);
+    const defaultBlockId = clonedBlocks![0]!.id;
+    // The orphan lands in the cloned pricing section; the mapped line is untouched.
+    expect(clonedLines!.every((l) => l.blockId === defaultBlockId)).toBe(true);
+    expect(clonedLines!.every((l) => l.blockId != null)).toBe(true);
+  });
+
+  it('cloneQuote creates ONE fallback pricing section for multiple orphans when the source has none', async () => {
+    queueCloneReads(
+      [{ id: 'b1', blockType: 'heading', content: { text: 'Intro', level: 2 }, sortOrder: 0 }],
+      [
+        cloneLine({ id: 'l1', blockId: null }),
+        cloneLine({ id: 'l2', blockId: null, sortOrder: 1 }),
+        // A line pointing at a block that never mapped is an orphan too — it used
+        // to be silently nulled by the `?? null` fallback.
+        cloneLine({ id: 'l3', blockId: 'missing-block', sortOrder: 2 }),
+      ],
+    );
+    queueResult([]); // tx: blocks insert
+    queueResult([]); // tx: lines insert
+
+    await svc.cloneQuote('q1', actor);
+
+    const [clonedBlocks, clonedLines] = insertedArrays();
+    const lineItemBlocks = clonedBlocks!.filter((b) => b.blockType === 'line_items');
+    // ONE fallback section shared by all three orphans — not one per line.
+    expect(lineItemBlocks).toHaveLength(1);
+    const fallbackId = lineItemBlocks[0]!.id;
+    expect(clonedLines!.map((l) => l.blockId)).toEqual([fallbackId, fallbackId, fallbackId]);
+  });
+
+  it('cloneQuote does not create a fallback section when no line is orphaned', async () => {
+    queueCloneReads(
+      [{ id: 'b1', blockType: 'line_items', content: {}, sortOrder: 0 }],
+      [cloneLine({ id: 'l1', blockId: 'b1' })],
+    );
+    queueResult([]); // tx: blocks insert
+    queueResult([]); // tx: lines insert
+
+    await svc.cloneQuote('q1', actor);
+
+    const [clonedBlocks] = insertedArrays();
+    expect(clonedBlocks).toHaveLength(1); // only the source block's clone
+  });
+
   it('getQuote returns depositDueTotal and categoryBreakdown', async () => {
     queueResult([{ id: 'q1', orgId: 'org1', taxRate: '0.10000', depositType: 'percent', depositPercent: '30.00' }]); // quote
     queueResult([]); // blocks

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -667,10 +667,10 @@ describe('attachCustomerLineImages', () => {
   const buildPath = (lineId: string) => `/quotes/public/tok/line-image/${lineId}`;
 
   it('builds a quote-scoped imageUrl for a line with an uploaded image and drops the raw ids', () => {
-    const [line] = svc.attachCustomerLineImages(
+    const line = svc.attachCustomerLineImages(
       [{ ...base, imageId: 'img1', catalogItemId: null }],
       buildPath,
-    );
+    )[0]!;
     expect(line.imageUrl).toBe('/quotes/public/tok/line-image/l1');
     expect(line).not.toHaveProperty('imageId');
     expect(line).not.toHaveProperty('catalogItemId');
@@ -678,18 +678,18 @@ describe('attachCustomerLineImages', () => {
   });
 
   it('builds an imageUrl for a catalog-sourced line (no uploaded image)', () => {
-    const [line] = svc.attachCustomerLineImages(
+    const line = svc.attachCustomerLineImages(
       [{ ...base, imageId: null, catalogItemId: 'cat1' }],
       buildPath,
-    );
+    )[0]!;
     expect(line.imageUrl).toBe('/quotes/public/tok/line-image/l1');
   });
 
   it('emits null imageUrl for a line with neither an uploaded nor a catalog image', () => {
-    const [line] = svc.attachCustomerLineImages(
+    const line = svc.attachCustomerLineImages(
       [{ ...base, imageId: null, catalogItemId: null }],
       buildPath,
-    );
+    )[0]!;
     expect(line.imageUrl).toBeNull();
   });
 });

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -35,6 +35,30 @@ export function toCustomerLines<T extends { unitCost: unknown }>(lines: T[]): Om
 }
 
 /**
+ * Attach a per-line `imageUrl` for the customer-facing portal + public proposal
+ * views and drop the raw `imageId`/`catalogItemId` (internal identifiers the
+ * customer document has no use for). A line gets a URL when it has EITHER a
+ * per-line uploaded image or a snapshotted catalog item — the same
+ * `imageId || catalogItemId` presence rule the web renderer's DocLineThumb uses;
+ * the URL points at the quote-scoped `line-image/:lineId` asset route (which
+ * resolves the actual source, see loadCustomerLineImage). Kept a pure mapper (no
+ * DB) so it runs correctly on either the org-scoped portal path or the
+ * system-scoped public path without a partner-axis RLS scoping hazard; a line
+ * whose catalog item happens to have no image simply 404s and the client hides
+ * the broken thumbnail, matching the preview's render-nothing-on-miss behaviour.
+ */
+export function attachCustomerLineImages<T extends { id: string; imageId: string | null; catalogItemId: string | null }>(
+  lines: T[],
+  buildLineImagePath: (lineId: string) => string,
+): (Omit<T, 'imageId' | 'catalogItemId'> & { imageUrl: string | null })[] {
+  return lines.map((line) => {
+    const { imageId, catalogItemId, ...rest } = line;
+    const hasImage = !!imageId || !!catalogItemId;
+    return { ...(rest as Omit<T, 'imageId' | 'catalogItemId'>), imageUrl: hasImage ? buildLineImagePath(line.id) : null };
+  });
+}
+
+/**
  * Sanitize every rich_text block's content.html at READ-serialization time —
  * defense in depth alongside the write-time sanitization in addBlock/updateBlock
  * below, covering rows written before this sanitizer existed (or by any future

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -305,6 +305,37 @@ export async function cloneQuote(id: string, actor: QuoteActor, input: CloneQuot
     toQuoteDepositConfig(source.depositType, source.depositPercent),
   );
 
+  // A clone must never mint a NEW orphan. Two source shapes produce one:
+  //  - the source line is itself an orphan (block_id NULL — pre-#2553 rows, and
+  //    prod quote 50a25127 cloned its orphan straight into becd81f4), or
+  //  - its block is missing from `blockIds` (the old `?? null` silently nulled
+  //    the line instead of failing loudly).
+  // Both re-parent onto ONE fallback pricing section: the clone of the source's
+  // earliest line_items block, or a fresh line_items block created in the SAME
+  // transaction as the rest of the clone. resolveLineBlockId is deliberately NOT
+  // reused here — it runs on the module-level `db`, outside this tx.
+  const orphanedLines = lines.filter((line) => !line.blockId || !blockIds.has(line.blockId));
+  // `blocks` comes back from getQuote ordered by sortOrder, so the first
+  // line_items block IS the earliest one.
+  const sourceDefaultBlock = blocks.find((block) => block.blockType === 'line_items');
+  let fallbackBlockId: string | null = null;
+  let fallbackBlock: typeof quoteBlocks.$inferInsert | null = null;
+  if (orphanedLines.length > 0) {
+    if (sourceDefaultBlock) {
+      fallbackBlockId = blockIds.get(sourceDefaultBlock.id)!;
+    } else {
+      fallbackBlockId = randomUUID();
+      fallbackBlock = {
+        id: fallbackBlockId,
+        quoteId,
+        orgId: targetOrgId,
+        blockType: 'line_items',
+        content: {},
+        sortOrder: blocks.reduce((max, block) => Math.max(max, block.sortOrder), -1) + 1,
+      };
+    }
+  }
+
   return db.transaction(async (tx) => {
     const [cloned] = await tx.insert(quotes).values({
       id: quoteId,
@@ -366,8 +397,8 @@ export async function cloneQuote(id: string, actor: QuoteActor, input: CloneQuot
       })));
     }
 
-    if (blocks.length > 0) {
-      await tx.insert(quoteBlocks).values(blocks.map((block) => {
+    if (blocks.length > 0 || fallbackBlock) {
+      const clonedBlocks = blocks.map((block) => {
         let content = block.content;
         if (block.blockType === 'image' && content && typeof content === 'object' && !Array.isArray(content)) {
           const sourceImageId = (content as Record<string, unknown>).imageId;
@@ -385,14 +416,16 @@ export async function cloneQuote(id: string, actor: QuoteActor, input: CloneQuot
           content,
           sortOrder: block.sortOrder,
         };
-      }));
+      });
+      if (fallbackBlock) clonedBlocks.push(fallbackBlock as (typeof clonedBlocks)[number]);
+      await tx.insert(quoteBlocks).values(clonedBlocks);
     }
 
     if (lines.length > 0) {
       await tx.insert(quoteLines).values(lines.map((line) => ({
         id: lineIds.get(line.id)!,
         quoteId,
-        blockId: line.blockId ? blockIds.get(line.blockId) ?? null : null,
+        blockId: (line.blockId ? blockIds.get(line.blockId) : undefined) ?? fallbackBlockId!,
         orgId: targetOrgId,
         sourceType: line.sourceType,
         catalogItemId: line.catalogItemId,

--- a/apps/portal/src/components/portal/SignaturePanel.tsx
+++ b/apps/portal/src/components/portal/SignaturePanel.tsx
@@ -86,7 +86,10 @@ export function SignaturePanel({ onAccept, onDecline, busy, testIdPrefix }: Sign
           onChange={(e) => setAgreed(e.target.checked)}
           disabled={busy}
           data-testid={`${testIdPrefix}-agree`}
-          className="mt-0.5 h-4 w-4 rounded border-input text-primary focus:ring-primary/40"
+          // border-input (== --border, a near-white slate) rendered the box as a
+          // barely-visible outline on the white card — customers couldn't see the
+          // agreement checkbox. Use a contrasty, theme-aware border instead.
+          className="mt-0.5 h-4 w-4 shrink-0 rounded border border-muted-foreground/50 text-primary focus:ring-primary/40"
         />
         <span className="leading-relaxed text-muted-foreground">
           I have reviewed this proposal and agree to its terms. Typing my name above is my electronic signature.

--- a/apps/portal/src/components/portal/quoteBlocks.test.tsx
+++ b/apps/portal/src/components/portal/quoteBlocks.test.tsx
@@ -90,3 +90,53 @@ describe('QuoteBlocks — contract block rendering', () => {
     expect(el.querySelector('iframe')).toBeNull();
   });
 });
+
+describe('QuoteBlocks — line rendering (title/blurb + thumbnail)', () => {
+  const lineItemsBlock: QuoteBlock = {
+    id: 'blk-lines', blockType: 'line_items', sortOrder: 0, content: { label: 'Hardware' },
+  };
+  function renderLines(lines: import('@/lib/api').QuoteLine[]) {
+    return render(
+      <QuoteBlocks
+        blocks={[lineItemsBlock]}
+        lines={lines}
+        currency="USD"
+        imageUrl={(imageId) => `https://portal.example.test/images/${imageId}`}
+        buildUrl={buildUrl}
+      />
+    );
+  }
+  const base = {
+    blockId: 'blk-lines', quantity: '1', unitPrice: '10', lineTotal: '10',
+    recurrence: 'one_time', customerVisible: true, sortOrder: 0,
+  };
+
+  it('renders a bold name title with the description as a separate blurb', () => {
+    renderLines([{ id: 'l1', name: 'Lenovo TIO 24 G5', description: '24 inch FHD display • IPS panel', ...base }]);
+    const row = screen.getByTestId('quote-line-l1');
+    expect(row.textContent).toContain('Lenovo TIO 24 G5');
+    expect(row.textContent).toContain('24 inch FHD display');
+    // Title is emphasized; the blurb is a distinct muted paragraph.
+    expect(row.querySelector('.font-medium')?.textContent).toContain('Lenovo TIO 24 G5');
+    expect(row.querySelector('p')?.textContent).toContain('24 inch FHD display');
+  });
+
+  it('falls back to description as the title for legacy lines with no name', () => {
+    renderLines([{ id: 'l2', name: null, description: 'Legacy line', ...base }]);
+    const row = screen.getByTestId('quote-line-l2');
+    expect(row.querySelector('.font-medium')?.textContent).toContain('Legacy line');
+    // No separate blurb paragraph when there's no distinct name.
+    expect(row.querySelector('p')).toBeNull();
+  });
+
+  it('renders a product thumbnail resolved through buildUrl when imageUrl is present', () => {
+    renderLines([{ id: 'l3', name: 'Widget', description: 'x', imageUrl: '/portal/quotes/q1/line-image/l3', ...base }]);
+    const img = screen.getByTestId('quote-line-image-l3') as HTMLImageElement;
+    expect(img.getAttribute('src')).toBe('https://portal.example.test/portal/quotes/q1/line-image/l3');
+  });
+
+  it('renders no thumbnail when imageUrl is null', () => {
+    renderLines([{ id: 'l4', name: 'Widget', description: 'x', imageUrl: null, ...base }]);
+    expect(screen.queryByTestId('quote-line-image-l4')).toBeNull();
+  });
+});

--- a/apps/portal/src/components/portal/quoteBlocks.tsx
+++ b/apps/portal/src/components/portal/quoteBlocks.tsx
@@ -35,6 +35,18 @@ const RECURRENCE_GROUPS: ReadonlyArray<{ key: string; label: string; suffix: str
   { key: 'annual', label: 'Annual', suffix: '/yr' },
 ];
 
+/** A line's title falls back to its description for legacy lines created before
+ *  the name/description split; the blurb only renders when a distinct name
+ *  exists. Mirrors the web renderer's lineTitle/lineBlurb (quoteTypes.ts) so the
+ *  portal shows the same bold product title + muted spec blurb as the preview. */
+function lineTitle(l: QuoteLine): string {
+  return (l.name ?? l.description ?? '').trim();
+}
+function lineBlurb(l: QuoteLine): string | null {
+  const b = l.name ? (l.description ?? '').trim() : '';
+  return b || null;
+}
+
 function PricingTable({
   lines,
   currency,
@@ -42,6 +54,7 @@ function PricingTable({
   testId,
   taxRate,
   showTax,
+  buildUrl,
 }: {
   lines: QuoteLine[];
   currency: string;
@@ -49,6 +62,8 @@ function PricingTable({
   testId: string;
   taxRate: number;
   showTax: boolean;
+  /** Resolves a server-built relative line-image path into a fetchable URL. */
+  buildUrl: (path: string) => string;
 }) {
   if (lines.length === 0) return null;
   // Preserve sortOrder within each recurrence group, in the canonical group order.
@@ -90,7 +105,29 @@ function PricingTable({
                   const tax = showTax ? lineTax(l.lineTotal, l.taxable, taxRate) : null;
                   return (
                   <tr key={l.id} data-testid={`quote-line-${l.id}`} className="border-b align-top last:border-0">
-                    <td className="px-4 py-3 text-foreground sm:px-5">{l.description}</td>
+                    <td className="px-4 py-3 text-foreground sm:px-5">
+                      <div className="flex items-start gap-2.5">
+                        {l.imageUrl && (
+                          // A line whose catalog item happens to have no image
+                          // 404s; hide the broken thumbnail (render-nothing-on-
+                          // miss parity with the in-app preview's DocLineThumb).
+                          <img
+                            src={buildUrl(l.imageUrl)}
+                            alt=""
+                            loading="lazy"
+                            data-testid={`quote-line-image-${l.id}`}
+                            onError={(e) => { e.currentTarget.style.display = 'none'; }}
+                            className="h-10 w-10 shrink-0 rounded border bg-card object-contain"
+                          />
+                        )}
+                        <div className="min-w-0">
+                          <span className="font-medium">{lineTitle(l)}</span>
+                          {lineBlurb(l) && (
+                            <p className="mt-0.5 whitespace-pre-line text-xs text-muted-foreground">{lineBlurb(l)}</p>
+                          )}
+                        </div>
+                      </div>
+                    </td>
                     <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{Number(l.quantity)}</td>
                     <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">
                       {money(l.unitPrice, currency)}{g.suffix && <span className="text-xs">{g.suffix}</span>}
@@ -251,6 +288,7 @@ export function QuoteBlocks({
           testId={`quote-lines-${block.id}`}
           taxRate={taxRate}
           showTax={showTax}
+          buildUrl={buildUrl}
         />
       );
     }
@@ -266,7 +304,7 @@ export function QuoteBlocks({
     <div className="space-y-6">
       {rendered}
       {orphanLines.length > 0 && (
-        <PricingTable lines={orphanLines} currency={currency} label="Pricing" testId="quote-lines-default" taxRate={taxRate} showTax={showTax} />
+        <PricingTable lines={orphanLines} currency={currency} label="Pricing" testId="quote-lines-default" taxRate={taxRate} showTax={showTax} buildUrl={buildUrl} />
       )}
     </div>
   );

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -436,6 +436,9 @@ export interface QuoteBlock {
 export interface QuoteLine {
   id: string;
   blockId?: string | null;
+  /** Product/display title; falls back to `description` for legacy lines with no
+   *  distinct name (mirrors the web renderer's lineTitle/lineBlurb split). */
+  name?: string | null;
   description: string;
   quantity: string;
   unitPrice: string;
@@ -444,6 +447,10 @@ export interface QuoteLine {
   recurrence: string;
   customerVisible: boolean;
   sortOrder: number;
+  /** Server-built relative path to this line's product thumbnail (uploaded image
+   *  or its catalog item's), or null when the line has no image. Resolve via
+   *  buildPortalApiUrl before use. */
+  imageUrl?: string | null;
 }
 
 export interface QuoteHeader extends QuoteSummary {

--- a/apps/portal/src/styles/globals.css
+++ b/apps/portal/src/styles/globals.css
@@ -156,6 +156,20 @@
   .quote-rich-text ol {
     @apply mb-2 list-decimal space-y-1 pl-5 last:mb-0;
   }
+  /* Tailwind's base reset neutralizes b/strong/em weight+style in some resets;
+   * restore the emphasis the sanitizer allows so bold/italic/underline in an
+   * author's rich_text renders with the same fidelity as the in-app preview. */
+  .quote-rich-text strong,
+  .quote-rich-text b {
+    @apply font-semibold text-foreground;
+  }
+  .quote-rich-text em,
+  .quote-rich-text i {
+    @apply italic;
+  }
+  .quote-rich-text u {
+    @apply underline underline-offset-2;
+  }
   .quote-rich-text a {
     @apply text-primary underline underline-offset-2;
   }

--- a/apps/web/src/components/billing/billingUi.test.tsx
+++ b/apps/web/src/components/billing/billingUi.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MarginPanel } from './billingUi';
+import type { QuoteProfit } from '@breeze/shared';
+
+// Task A(2) of the quote-editor UX follow-up pass: MarginPanel shows profit as
+// a percent (margin = net/revenue) alongside the dollar figure, guards
+// div-by-zero, and self-hides the percent when a cadence has nothing to
+// compute one from — never a misleading 0%/NaN.
+
+const profit = (over: Partial<QuoteProfit> = {}): QuoteProfit => ({
+  oneTimeNet: '0.00', monthlyRecurringNet: '0.00', annualRecurringNet: '0.00',
+  totalCost: '0.00', oneTimeRevenue: '0.00', monthlyRecurringRevenue: '0.00',
+  annualRecurringRevenue: '0.00', linesMissingCost: 0, ...over,
+});
+
+describe('MarginPanel — profit margin percent', () => {
+  it('shows the one-time profit percent (margin, not markup) alongside the dollar figure', () => {
+    render(<MarginPanel profit={profit({ oneTimeNet: '30.00', oneTimeRevenue: '50.00', totalCost: '20.00' })} currency="USD" />);
+    expect(screen.getByTestId('quote-margin-net-onetime')).toHaveTextContent('$30.00');
+    expect(screen.getByTestId('quote-margin-pct-onetime')).toHaveTextContent('(60.0%)');
+  });
+
+  it('hides the percent (div-by-zero guard) when the cadence has zero revenue', () => {
+    render(<MarginPanel profit={profit()} currency="USD" />);
+    expect(screen.getByTestId('quote-margin-net-onetime')).toHaveTextContent('$0.00');
+    expect(screen.queryByTestId('quote-margin-pct-onetime')).not.toBeInTheDocument();
+  });
+
+  it('hides the percent when every line in the cadence is missing cost (fully incomplete estimate)', () => {
+    render(<MarginPanel profit={profit({ oneTimeNet: '0.00', oneTimeRevenue: '0.00', linesMissingCost: 2 })} currency="USD" />);
+    expect(screen.queryByTestId('quote-margin-pct-onetime')).not.toBeInTheDocument();
+    // The existing missing-cost notice is the shared "estimate incomplete"
+    // caveat — no separate copy is needed for the suppressed percent.
+    expect(screen.getByTestId('quote-margin-missing-cost')).toBeInTheDocument();
+  });
+
+  it('still computes a percent from the available lines when only partially incomplete', () => {
+    // computeQuoteProfit already excludes missing-cost lines from both net and
+    // revenue, so a partial figure (1 of 2 lines missing cost) yields an exact
+    // percent for what IS knowable, alongside the missing-cost warning.
+    render(<MarginPanel profit={profit({ oneTimeNet: '30.00', oneTimeRevenue: '50.00', linesMissingCost: 1 })} currency="USD" />);
+    expect(screen.getByTestId('quote-margin-pct-onetime')).toHaveTextContent('(60.0%)');
+    expect(screen.getByTestId('quote-margin-missing-cost')).toBeInTheDocument();
+  });
+
+  it('shows independent monthly/annual percents next to their own rows', () => {
+    render(<MarginPanel profit={profit({
+      monthlyRecurringNet: '15.00', monthlyRecurringRevenue: '40.00',
+      annualRecurringNet: '200.00', annualRecurringRevenue: '1200.00',
+    })} currency="USD" />);
+    expect(screen.getByTestId('quote-margin-pct-monthly')).toHaveTextContent('(37.5%)');
+    expect(screen.getByTestId('quote-margin-pct-annual')).toHaveTextContent('(16.7%)');
+  });
+
+  it('handles a negative margin (a loss) without crashing', () => {
+    render(<MarginPanel profit={profit({ oneTimeNet: '-10.00', oneTimeRevenue: '50.00' })} currency="USD" />);
+    expect(screen.getByTestId('quote-margin-pct-onetime')).toHaveTextContent('(-20.0%)');
+  });
+
+  it('namespaces testids per idPrefix (invoice callers don\'t collide with quote callers)', () => {
+    render(<MarginPanel profit={profit({ oneTimeNet: '30.00', oneTimeRevenue: '50.00' })} currency="USD" idPrefix="invoice" />);
+    expect(screen.getByTestId('invoice-margin-pct-onetime')).toHaveTextContent('(60.0%)');
+  });
+});

--- a/apps/web/src/components/billing/billingUi.tsx
+++ b/apps/web/src/components/billing/billingUi.tsx
@@ -4,7 +4,7 @@
 import { AlertTriangle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import '../../lib/i18n';
-import type { QuoteProfit } from '@breeze/shared';
+import { marginPct, type QuoteProfit } from '@breeze/shared';
 import { formatMoney } from './quotes/quoteTypes';
 
 /**
@@ -74,6 +74,15 @@ export function MarginPanel({
   onMissingCostClick?: () => void;
 }) {
   const { t } = useTranslation('billing');
+  // Margin (net / revenue), NOT markup (net / cost) — null (and hidden) when a
+  // cadence has no cost-bearing lines to compute a percent from (div-by-zero
+  // guard lives in marginPct). Partially-incomplete cadences (some lines have
+  // cost, some don't) still show a percent computed over the available lines,
+  // same partial-figure contract the dollar net already has — the missing-cost
+  // notice below is the one shared caveat for both.
+  const oneTimePct = marginPct(profit.oneTimeNet, profit.oneTimeRevenue);
+  const monthlyPct = marginPct(profit.monthlyRecurringNet, profit.monthlyRecurringRevenue);
+  const annualPct = marginPct(profit.annualRecurringNet, profit.annualRecurringRevenue);
   return (
     <div className="mt-3 rounded-md bg-muted/40 p-2 text-sm" data-testid={`${idPrefix}-margin`}>
       <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -81,9 +90,31 @@ export function MarginPanel({
       </div>
       <dl className="space-y-1 tabular-nums">
         <div className="flex justify-between"><dt className="text-muted-foreground">{t('billingUi.margin.cost')}</dt><dd data-testid={`${idPrefix}-margin-cost`}>{formatMoney(profit.totalCost, currency)}</dd></div>
-        <div className="flex justify-between"><dt className="text-muted-foreground">{t('billingUi.margin.profitOneTime')}</dt><dd data-testid={`${idPrefix}-margin-net-onetime`}>{formatMoney(profit.oneTimeNet, currency)}</dd></div>
-        {Number(profit.monthlyRecurringNet) !== 0 && <div className="flex justify-between"><dt className="text-muted-foreground">{t('billingUi.margin.profitMonthly')}</dt><dd data-testid={`${idPrefix}-margin-net-monthly`}>{formatMoney(profit.monthlyRecurringNet, currency)}<span className="text-xs text-muted-foreground">{t('billingUi.units.perMonth')}</span></dd></div>}
-        {Number(profit.annualRecurringNet) !== 0 && <div className="flex justify-between"><dt className="text-muted-foreground">{t('billingUi.margin.profitAnnual')}</dt><dd data-testid={`${idPrefix}-margin-net-annual`}>{formatMoney(profit.annualRecurringNet, currency)}<span className="text-xs text-muted-foreground">{t('billingUi.units.perYear')}</span></dd></div>}
+        <div className="flex justify-between">
+          <dt className="text-muted-foreground">{t('billingUi.margin.profitOneTime')}</dt>
+          <dd data-testid={`${idPrefix}-margin-net-onetime`}>
+            {formatMoney(profit.oneTimeNet, currency)}
+            {oneTimePct !== null && <span className="ml-1 text-xs text-muted-foreground" data-testid={`${idPrefix}-margin-pct-onetime`}>({oneTimePct.toFixed(1)}%)</span>}
+          </dd>
+        </div>
+        {Number(profit.monthlyRecurringNet) !== 0 && (
+          <div className="flex justify-between">
+            <dt className="text-muted-foreground">{t('billingUi.margin.profitMonthly')}</dt>
+            <dd data-testid={`${idPrefix}-margin-net-monthly`}>
+              {formatMoney(profit.monthlyRecurringNet, currency)}<span className="text-xs text-muted-foreground">{t('billingUi.units.perMonth')}</span>
+              {monthlyPct !== null && <span className="ml-1 text-xs text-muted-foreground" data-testid={`${idPrefix}-margin-pct-monthly`}>({monthlyPct.toFixed(1)}%)</span>}
+            </dd>
+          </div>
+        )}
+        {Number(profit.annualRecurringNet) !== 0 && (
+          <div className="flex justify-between">
+            <dt className="text-muted-foreground">{t('billingUi.margin.profitAnnual')}</dt>
+            <dd data-testid={`${idPrefix}-margin-net-annual`}>
+              {formatMoney(profit.annualRecurringNet, currency)}<span className="text-xs text-muted-foreground">{t('billingUi.units.perYear')}</span>
+              {annualPct !== null && <span className="ml-1 text-xs text-muted-foreground" data-testid={`${idPrefix}-margin-pct-annual`}>({annualPct.toFixed(1)}%)</span>}
+            </dd>
+          </div>
+        )}
       </dl>
       {profit.linesMissingCost > 0 && (
         onMissingCostClick ? (

--- a/apps/web/src/components/billing/billingUi.tsx
+++ b/apps/web/src/components/billing/billingUi.tsx
@@ -62,15 +62,21 @@ export function MarginPanel({
   profit,
   currency,
   idPrefix = 'quote',
+  onMissingCostClick,
 }: {
   profit: QuoteProfit;
   currency: string;
   idPrefix?: string;
+  /** Optional: makes the missing-cost notice an actionable button (e.g. the
+   *  quote editor wires this to scroll/expand/focus the first offending line).
+   *  Callers with nothing to jump to (QuoteDetail, InvoiceDetail/Editor) omit
+   *  it and keep the plain static notice — MarginPanel itself stays generic. */
+  onMissingCostClick?: () => void;
 }) {
   const { t } = useTranslation('billing');
   return (
     <div className="mt-3 rounded-md bg-muted/40 p-2 text-sm" data-testid={`${idPrefix}-margin`}>
-      <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-[hsl(220_12%_40%)] dark:text-muted-foreground">
+      <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
         {t('billingUi.margin.title')}
       </div>
       <dl className="space-y-1 tabular-nums">
@@ -80,12 +86,26 @@ export function MarginPanel({
         {Number(profit.annualRecurringNet) !== 0 && <div className="flex justify-between"><dt className="text-muted-foreground">{t('billingUi.margin.profitAnnual')}</dt><dd data-testid={`${idPrefix}-margin-net-annual`}>{formatMoney(profit.annualRecurringNet, currency)}<span className="text-xs text-muted-foreground">{t('billingUi.units.perYear')}</span></dd></div>}
       </dl>
       {profit.linesMissingCost > 0 && (
-        <p className="mt-1 flex items-start gap-1 text-xs text-warning-foreground dark:text-warning" data-testid={`${idPrefix}-margin-missing-cost`}>
-          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" aria-hidden="true" />
-          <span>
-            {t('billingUi.margin.missingCost', { count: profit.linesMissingCost })}
-          </span>
-        </p>
+        onMissingCostClick ? (
+          <button
+            type="button"
+            onClick={onMissingCostClick}
+            className="mt-1 flex w-full items-start gap-1 rounded text-left text-xs text-warning-foreground hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring dark:text-warning"
+            data-testid={`${idPrefix}-margin-missing-cost`}
+          >
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" aria-hidden="true" />
+            <span>
+              {t('billingUi.margin.missingCost', { count: profit.linesMissingCost })}
+            </span>
+          </button>
+        ) : (
+          <p className="mt-1 flex items-start gap-1 text-xs text-warning-foreground dark:text-warning" data-testid={`${idPrefix}-margin-missing-cost`}>
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" aria-hidden="true" />
+            <span>
+              {t('billingUi.margin.missingCost', { count: profit.linesMissingCost })}
+            </span>
+          </p>
+        )
       )}
     </div>
   );

--- a/apps/web/src/components/billing/quotes/QuoteActions.margincheck.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.margincheck.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteActions from './QuoteActions';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+
+// Task 3 of the quote-editor UX pass: a NON-BLOCKING send-time notice when the
+// profit estimate is incomplete (some billed line has no cost) — visible only
+// to users who can already see margin (quotes:read), and never disabling Send.
+const state = vi.hoisted(() => ({ canSeeMargin: true }));
+vi.mock('../../../lib/permissions', () => ({
+  usePermissions: () => ({ can: (resource: string, action: string) => {
+    if (resource === 'quotes' && action === 'read') return state.canSeeMargin;
+    return true; // quotes:send / quotes:write etc. stay granted for these tests
+  } }),
+}));
+vi.mock('../../../stores/orgStore', () => ({ useOrgStore: (sel: (s: { organizations: unknown[] }) => unknown) => sel({ organizations: [] }) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(async () =>
+    ({ ok: true, json: async () => ({ billingContact: { email: 'ap@customer.example' } }) }) as unknown as Response),
+  useAuthStore: { getState: () => ({ tokens: null }) },
+}));
+const scheduleQuoteSendMock = vi.fn().mockResolvedValue({ data: { sendScheduledAt: '2099-01-01T00:00:00Z' } });
+vi.mock('../../../lib/api/quotes', () => ({
+  sendQuote: vi.fn(),
+  scheduleQuoteSend: (...args: unknown[]) => scheduleQuoteSendMock(...args),
+  cancelScheduledSend: vi.fn(),
+  deleteQuote: vi.fn(),
+  quotePdfUrl: vi.fn().mockReturnValue('/quotes/q-1/pdf'),
+}));
+
+function draft(lines: QuoteDetailData['lines']): QuoteDetailData {
+  return {
+    quote: {
+      id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+      taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+      annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '0.00', billToName: 'Acme Inc.', introNotes: null,
+      terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+      convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null,
+      createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+    },
+    blocks: [{ id: 'b-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items', content: {}, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z' }],
+    lines,
+  };
+}
+
+const lineMissingCost: QuoteDetailData['lines'][number] = {
+  id: 'l-1', quoteId: 'q-1', blockId: 'b-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+  name: 'Support', description: null, quantity: '1.00', unitPrice: '100.00', taxable: false,
+  customerVisible: true, lineTotal: '100.00', recurrence: 'one_time', termMonths: null,
+  billingFrequency: null, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+
+const lineWithCost: QuoteDetailData['lines'][number] = {
+  ...lineMissingCost, id: 'l-2', unitCost: '40.00',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  scheduleQuoteSendMock.mockResolvedValue({ data: { sendScheduledAt: '2099-01-01T00:00:00Z' } });
+  state.canSeeMargin = true;
+});
+
+describe('QuoteActions — send-time incomplete-profit notice', () => {
+  it('shows a non-blocking notice when a billed line has no cost and the user can see margin', async () => {
+    render(<QuoteActions detail={draft([lineMissingCost])} onChanged={vi.fn()} variant="rail" />);
+    fireEvent.click(screen.getByTestId('quote-send'));
+    await waitFor(() => expect(screen.getByTestId('quote-send-confirm')).toBeInTheDocument());
+
+    const notice = screen.getByTestId('quote-send-missing-cost-notice');
+    expect(notice).toHaveTextContent('Profit estimate is incomplete — 1 line missing a cost.');
+    // Non-blocking: Send stays enabled with the notice showing.
+    expect(screen.getByTestId('quote-send-confirm')).not.toBeDisabled();
+  });
+
+  it('is absent when every billed line has a cost', async () => {
+    render(<QuoteActions detail={draft([lineWithCost])} onChanged={vi.fn()} variant="rail" />);
+    fireEvent.click(screen.getByTestId('quote-send'));
+    await waitFor(() => expect(screen.getByTestId('quote-send-confirm')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('quote-send-missing-cost-notice')).not.toBeInTheDocument();
+  });
+
+  it('is absent for a user without margin visibility, even with a missing cost', async () => {
+    state.canSeeMargin = false;
+    render(<QuoteActions detail={draft([lineMissingCost])} onChanged={vi.fn()} variant="rail" />);
+    fireEvent.click(screen.getByTestId('quote-send'));
+    await waitFor(() => expect(screen.getByTestId('quote-send-confirm')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('quote-send-missing-cost-notice')).not.toBeInTheDocument();
+  });
+
+  it('sending still works with the notice showing', async () => {
+    render(<QuoteActions detail={draft([lineMissingCost])} onChanged={vi.fn()} variant="rail" />);
+    fireEvent.click(screen.getByTestId('quote-send'));
+    await waitFor(() => expect(screen.getByTestId('quote-send-to')).toHaveValue('ap@customer.example'));
+    expect(screen.getByTestId('quote-send-missing-cost-notice')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('quote-send-confirm'));
+    await waitFor(() => expect(scheduleQuoteSendMock).toHaveBeenCalledWith('q-1', expect.objectContaining({ to: ['ap@customer.example'] })));
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -15,6 +15,7 @@ import { isValidEmail } from '@/lib/email';
 import { cloneQuote, deleteQuote, sendQuote, type SendQuoteOptions, type QuoteSendEmailReason } from '../../../lib/api/quotes';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
 import { Dialog } from '../../shared/Dialog';
+import { computeQuoteProfit, type QuoteProfit } from '@breeze/shared';
 import { useQuotePdfDownload } from './useQuoteImage';
 import { type Quote, type QuoteDetail as QuoteDetailData, formatMoney } from './quoteTypes';
 
@@ -201,6 +202,24 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
   // Deposit configured → the composer must warn when Stripe isn't connected,
   // since the customer would have no way to actually pay that deposit online.
   const hasDeposit = Boolean(quote.depositType && quote.depositType !== 'none');
+
+  // Soft send-time warning (Task 3 UX pass): an incomplete profit estimate
+  // shouldn't block Send — a tech may not know every cost yet — but it should
+  // be visible at the one moment before the quote goes irreversible. Gated on
+  // margin visibility, same as MarginPanel: an org-scoped/read-only-cost user
+  // must never see this notice imply a permission they don't have.
+  const canSeeMargin = can('quotes', 'read');
+  const profit = useMemo<QuoteProfit>(
+    () => computeQuoteProfit(lines.map((l) => ({
+      quantity: l.quantity,
+      unitPrice: l.unitPrice,
+      taxable: l.taxable,
+      customerVisible: l.customerVisible,
+      recurrence: l.recurrence,
+      unitCost: l.unitCost,
+    }))),
+    [lines],
+  );
 
   const orgName = useMemo(() => {
     const billTo = quote.billToName?.trim();
@@ -699,6 +718,16 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
         {zeroTotal && (
           <p className="mt-2 rounded-md border border-warning/40 bg-warning/10 px-2 py-1 text-xs text-warning-foreground dark:text-warning" data-testid="quote-send-zero-warning">
             {t('quotes.actions.sendConfirm.zeroTotalWarning')}
+          </p>
+        )}
+        {/* Non-blocking: an incomplete profit estimate never disables Send (a
+            tech may genuinely not know every cost yet) — it's a heads-up, not a
+            gate. Reuses MarginPanel's own copy (billingUi.margin.missingCost) so
+            the wording can't drift between the rail and this dialog. */}
+        {canSeeMargin && profit.linesMissingCost > 0 && (
+          <p className="mt-2 flex items-start gap-1 rounded-md border border-warning/40 bg-warning/10 px-2 py-1 text-xs text-warning-foreground dark:text-warning" data-testid="quote-send-missing-cost-notice">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" aria-hidden="true" />
+            <span>{t('billingUi.margin.missingCost', { count: profit.linesMissingCost })}</span>
           </p>
         )}
 

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -122,6 +122,10 @@ interface Props {
    *  held (with a "Saving changes…" hint) until the quote is quiescent, so the
    *  confirm dialog can't quote a stale total or race a blur-save server-side. */
   savePending?: boolean;
+  /** Called when Send is clicked while savePending — lets the workspace flush
+   *  deferred work immediately (the editor's undo-grace deletions) so the held
+   *  Send opens as soon as those land instead of waiting out a grace window. */
+  onSendWhilePending?: () => void;
 }
 
 /**
@@ -130,7 +134,7 @@ interface Props {
  * Detail rail and the workspace header can't drift in behavior or copy; the
  * data-testids are stable across both variants.
  */
-export default function QuoteActions({ detail, onChanged, variant, savePending = false }: Props) {
+export default function QuoteActions({ detail, onChanged, variant, savePending = false, onSendWhilePending }: Props) {
   const { t } = useTranslation('billing');
   const { can } = usePermissions();
   const organizations = useOrgStore((s) => s.organizations);
@@ -540,8 +544,9 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
               // During savePending the click's job is the prerequisite: the
               // click itself blurs the dirty field (starting its save); queue
               // the composer to open the moment the editor goes quiescent —
-              // one click to the money moment, never a dead one.
-              if (savePending) { setOpenWhenQuiet(true); return; }
+              // one click to the money moment, never a dead one. Deferred
+              // deletions (undo grace window) flush now for the same reason.
+              if (savePending) { onSendWhilePending?.(); setOpenWhenQuiet(true); return; }
               openSend();
             }}
             disabled={sending || isEmpty}

--- a/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
@@ -32,6 +32,7 @@ import { ContractBlockEditor } from './QuoteContractBlockEditor';
 export function BlockCard({
   block, quoteId, lines, currency, taxRate, catalog, catalogLoadFailed, isPending, canWrite, showInternal, mixedCadence, depositSelectMode, ecActive, pax8Active, defaultMarkupPct, onAddCatalog, onImportAddDistributor, onImportAddPax8, onAddManual, onEditLine, onEditBlock, onMoveLine, onRemoveLine, onLineDraft,
   moveTargets, onMoveLineToBlock, revealRequest, hasDirtyLines, onDropLine,
+  selectionActive, isLineSelected, onToggleLineSelected, onSetBlockSelection,
 }: {
   block: QuoteBlock;
   quoteId: string;
@@ -79,6 +80,13 @@ export function BlockCard({
   /** Commit a row drag-drop: the dragged line id + the gap index it landed in
    *  (0..n). Routes to the SAME reorder path the ⋯ menu's Move up/down uses. */
   onDropLine: (dragLineId: string, targetIdx: number) => void;
+  /** Bulk-edit selection (Task D): true while ANY line on the quote is selected
+   *  (pins every row checkbox visible), plus the per-line membership check /
+   *  toggle and the block-level select-all setter. */
+  selectionActive: boolean;
+  isLineSelected: (lineId: string) => boolean;
+  onToggleLineSelected: (lineId: string) => void;
+  onSetBlockSelection: (lineIds: string[], selected: boolean) => void;
 }) {
   const { t } = useTranslation('billing');
   // Pending state scoped to this block: editing/removing this block, or adding a
@@ -172,6 +180,18 @@ export function BlockCard({
   // Collapsed-summary subtotal: the sum of the block's per-line totals (the
   // same persisted lineTotal figures the rows render), in cents.
   const blockSubtotalCents = lines.reduce((sum, l) => sum + toCents(l.lineTotal), 0);
+
+  // ---- bulk-select (Task D): per-block select-all --------------------------
+  // Indeterminate is a DOM property, not an attribute, so it's wired via a ref
+  // effect. The checkbox follows the same quiet reveal grammar as the row
+  // checkboxes: hidden at rest, revealed on block hover/focus-within, pinned
+  // visible while any selection is active.
+  const selectedInBlock = lines.reduce((n, l) => n + (isLineSelected(l.id) ? 1 : 0), 0);
+  const allInBlockSelected = lines.length > 0 && selectedInBlock === lines.length;
+  const selectAllRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (selectAllRef.current) selectAllRef.current.indeterminate = selectedInBlock > 0 && !allInBlockSelected;
+  }, [selectedInBlock, allInBlockSelected]);
 
   // ---- row drag-to-reorder (HTML5 DnD, same vocabulary as blocks) ----------
   // The drag state lives here (one drag per table); drop gaps render between
@@ -306,10 +326,10 @@ export function BlockCard({
               onBlur={() => void commitHeading()}
               disabled={blockBusy}
               data-testid={`quote-block-heading-input-${block.id}`}
-              className={`w-full rounded-md border bg-transparent px-2 py-1 text-lg font-semibold transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(headingDraft.trim() !== heading, blockSaved))}`}
+              className={`w-full rounded-md border bg-transparent px-2 py-1 text-lg font-bold transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(headingDraft.trim() !== heading, blockSaved))}`}
             />
           ) : (
-            <p className="text-lg font-semibold" data-testid={`quote-block-heading-content-${block.id}`}>{heading}</p>
+            <p className="text-lg font-bold" data-testid={`quote-block-heading-content-${block.id}`}>{heading}</p>
           )
         )}
         {block.blockType === 'rich_text' && (
@@ -364,6 +384,22 @@ export function BlockCard({
                 line count + block subtotal in one compact row (mirroring the
                 internal band's whole-strip trigger). */}
             <div className="flex items-center gap-2">
+              {/* Select-all for this table's lines (writers, expanded only —
+                  collapsed, the whole strip is the expand toggle). Indeterminate
+                  while a strict subset is selected. */}
+              {canWrite && blockExpanded && lines.length > 0 && (
+                <input
+                  ref={selectAllRef}
+                  type="checkbox"
+                  checked={allInBlockSelected}
+                  onChange={(e) => onSetBlockSelection(lines.map((l) => l.id), e.target.checked)}
+                  aria-label={t('quotes.editor.bulk.selectAllAria', { label: tableLabel.trim() || t('quotes.editor.blockTypes.pricingTable') })}
+                  data-testid={`quote-block-select-all-${block.id}`}
+                  className={`h-3.5 w-3.5 shrink-0 accent-primary transition-opacity focus-visible:opacity-100 ${
+                    selectionActive || selectedInBlock > 0 ? 'opacity-100' : 'opacity-0 group-focus-within/block:opacity-100 group-hover/block:opacity-100'
+                  }`}
+                />
+              )}
               <button
                 type="button"
                 onClick={() => setBlockOpen((v) => !v)}
@@ -382,7 +418,7 @@ export function BlockCard({
                     className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2 gap-y-0.5"
                     data-testid={`quote-block-collapsed-summary-${block.id}`}
                   >
-                    <span className="truncate text-sm font-semibold">
+                    <span className="truncate text-sm font-bold">
                       {tableLabel.trim() || t('quotes.editor.blockTypes.pricingTable')}
                     </span>
                     <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
@@ -402,7 +438,7 @@ export function BlockCard({
                     disabled={blockBusy}
                     placeholder={t('quotes.editor.table.labelPlaceholder')}
                     data-testid={`quote-block-table-label-input-${block.id}`}
-                    className={`h-9 w-full rounded-md border bg-transparent px-2 text-sm font-semibold transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(labelDraft.trim() !== tableLabel.trim(), blockSaved))}`}
+                    className={`h-9 w-full rounded-md border bg-transparent px-2 text-sm font-bold transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(labelDraft.trim() !== tableLabel.trim(), blockSaved))}`}
                   />
                 </div>
               )}
@@ -426,16 +462,25 @@ export function BlockCard({
                 visible without sideways scrolling at desktop widths. Billing cadence
                 rides in the Price cell; Taxable moved to each line's controls row;
                 per-line tax renders as a sub-line under the Total. The wrapper still
-                scrolls on genuinely narrow screens (phone), without a sticky column. */}
-            <div className="overflow-x-auto rounded-md focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring" role="region" aria-label={t('quotes.editor.table.scrollAria')} tabIndex={0}>
+                scrolls on genuinely narrow screens (phone), without a sticky column.
+                max-h + overflow-y-auto (in addition to the existing overflow-x-auto)
+                makes THIS div the sticky containing block for the header cells below —
+                position:sticky on a descendant binds to its nearest scroll-container
+                ancestor, and an unbounded overflow-x-auto div never actually scrolls
+                vertically, so a plain `sticky top-0` inside it is inert (verified: the
+                header just scrolls off with the rows). Bounding the height is what
+                makes the header cells' sticky top-0 do anything at all. The cap is
+                generous (70vh) so short blocks never show an inner scrollbar — it only
+                engages once a section has enough rows to need a pinned header. */}
+            <div className="max-h-[70vh] overflow-x-auto overflow-y-auto rounded-md focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring" role="region" aria-label={t('quotes.editor.table.scrollAria')} tabIndex={0}>
             <table className="w-full min-w-[36rem] text-sm" data-testid={`quote-block-lines-${block.id}`}>
               <thead>
                 <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
-                  <th className="min-w-[12rem] px-1.5 py-2 font-medium">{t('quotes.editor.table.item')}</th>
-                  <th className="px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.qty')}</th>
-                  <th className="px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.unitPrice')}</th>
-                  <th className="px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.total')}</th>
-                  {canWrite && <th className="px-1.5 py-2" />}
+                  <th className="sticky top-0 z-10 min-w-[12rem] bg-card px-1.5 py-2 font-medium">{t('quotes.editor.table.item')}</th>
+                  <th className="sticky top-0 z-10 bg-card px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.qty')}</th>
+                  <th className="sticky top-0 z-10 bg-card px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.unitPrice')}</th>
+                  <th className="sticky top-0 z-10 bg-card px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.total')}</th>
+                  {canWrite && <th className="sticky top-0 z-10 bg-card px-1.5 py-2" />}
                 </tr>
               </thead>
               <tbody>
@@ -481,6 +526,9 @@ export function BlockCard({
                           dragging={dragLineId === l.id}
                           onDragStartRow={() => setDragLineId(l.id)}
                           onDragEndRow={endLineDrag}
+                          selected={isLineSelected(l.id)}
+                          selectionActive={selectionActive}
+                          onToggleSelected={() => onToggleLineSelected(l.id)}
                         />
                       </Fragment>
                     ) : (
@@ -510,6 +558,24 @@ export function BlockCard({
                   />
                 )}
               </tbody>
+              {/* "Show subtotal row" previously only affected the document/PDF —
+                  checking it in the editor had no visible effect here. Mirrors
+                  it in the expanded table itself (same blockSubtotalCents the
+                  collapsed header summary already computes) so the toggle does
+                  something the tech can see without switching to Preview. */}
+              {showSubtotal && (
+                <tfoot>
+                  <tr className="border-t-2 bg-muted/20" data-testid={`quote-block-subtotal-row-${block.id}`}>
+                    <td className="px-1.5 py-2 text-right text-sm font-semibold text-foreground" colSpan={3}>
+                      {t('quotes.editor.liveTotals.subtotal')}
+                    </td>
+                    <td className="whitespace-nowrap px-1.5 py-2 text-right text-sm font-semibold tabular-nums text-foreground">
+                      {formatMoney(fromCents(blockSubtotalCents), currency)}
+                    </td>
+                    {canWrite && <td />}
+                  </tr>
+                </tfoot>
+              )}
             </table>
             </div>
 
@@ -676,6 +742,7 @@ export function BlockCard({
                   <input
                     type="text" placeholder={t('quotes.editor.line.namePlaceholder')} aria-label={t('quotes.editor.line.nameAria')} value={name}
                     onChange={(e) => setName(e.target.value)}
+                    title={name || undefined}
                     data-testid={`quote-manual-name-${block.id}`}
                     className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                   />
@@ -746,18 +813,24 @@ export function BlockCard({
                       <input
                         type="text" value={sku}
                         onChange={(e) => setSku(e.target.value)}
+                        title={t('quotes.editor.line.skuHelp')}
+                        aria-describedby={`quote-manual-sku-help-${block.id}`}
                         data-testid={`quote-manual-sku-${block.id}`}
                         className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                       />
+                      <span id={`quote-manual-sku-help-${block.id}`} className="sr-only">{t('quotes.editor.line.skuHelp')}</span>
                     </label>
                     <label className="block">
                       <span className="mb-1 block text-xs text-muted-foreground">{t('quotes.editor.line.partNumberOptional')}</span>
                       <input
                         type="text" value={partNumber}
                         onChange={(e) => setPartNumber(e.target.value)}
+                        title={t('quotes.editor.line.partNumberHelp')}
+                        aria-describedby={`quote-manual-partnumber-help-${block.id}`}
                         data-testid={`quote-manual-partnumber-${block.id}`}
                         className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                       />
+                      <span id={`quote-manual-partnumber-help-${block.id}`} className="sr-only">{t('quotes.editor.line.partNumberHelp')}</span>
                     </label>
                     <label className="block">
                       <span className="mb-1 block text-xs text-muted-foreground">{t('quotes.editor.line.unitCost')}</span>

--- a/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
@@ -3,11 +3,11 @@
 // the collapsed add-line picker. Row rendering lives in QuoteLineRows.tsx.
 // Split from QuoteEditor.tsx — see quoteEditorShared.tsx for the shared
 // save-language plumbing.
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Loader2 } from 'lucide-react';
+import { ChevronRight, Loader2, Package, Sparkles } from 'lucide-react';
 import '../../../lib/i18n';
-import { markupPct, priceFromMarkup, type QuoteLineForMath } from '@breeze/shared';
+import { fromCents, markupPct, priceFromMarkup, toCents, type QuoteLineForMath } from '@breeze/shared';
 import { quoteImageUrl } from '../../../lib/api/quotes';
 import { fetchWithAuth } from '../../../stores/auth';
 import { type CatalogItem } from '../../../lib/api/catalog';
@@ -25,13 +25,13 @@ import {
   formatMoney,
 } from './quoteTypes';
 import { type LineUpdate, SrSaved, fieldRing, pendingKey, seamless } from './quoteEditorShared';
-import { GhostRow, EditableLineRow, ReadonlyLineRow } from './QuoteLineRows';
+import { GhostRow, EditableLineRow, ReadonlyLineRow, type LineRevealRequest } from './QuoteLineRows';
 import { ContractBlockEditor } from './QuoteContractBlockEditor';
 
 // ── A single block, with an inline line builder when it is a pricing table ──
 export function BlockCard({
-  block, quoteId, lines, currency, taxRate, catalog, catalogLoadFailed, isPending, canWrite, showInternal, depositSelectMode, ecActive, pax8Active, defaultMarkupPct, onAddCatalog, onImportAddDistributor, onImportAddPax8, onAddManual, onEditLine, onEditBlock, onMoveLine, onRemoveLine, onLineDraft,
-  moveTargets, onMoveLineToBlock,
+  block, quoteId, lines, currency, taxRate, catalog, catalogLoadFailed, isPending, canWrite, showInternal, mixedCadence, depositSelectMode, ecActive, pax8Active, defaultMarkupPct, onAddCatalog, onImportAddDistributor, onImportAddPax8, onAddManual, onEditLine, onEditBlock, onMoveLine, onRemoveLine, onLineDraft,
+  moveTargets, onMoveLineToBlock, revealRequest, hasDirtyLines, onDropLine,
 }: {
   block: QuoteBlock;
   quoteId: string;
@@ -43,6 +43,13 @@ export function BlockCard({
   isPending: (key: string) => boolean;
   canWrite: boolean;
   showInternal: boolean;
+  /** Set (with a bumped nonce) when the rail's "missing cost" notice targets a
+   *  line in this block — forwarded to whichever row matches `lineId`. See
+   *  LineRevealRequest (QuoteLineRows) for the full contract. */
+  revealRequest?: LineRevealRequest | null;
+  /** True when the QUOTE's lines (all blocks, not just this one) span more than
+   *  one billing cadence — only then do rows repeat the '/mo' | '/yr' suffix. */
+  mixedCadence: boolean;
   /** When true (quote deposit = 'selected_lines'), each editable line row shows a
    *  deposit-eligible checkbox. */
   depositSelectMode: boolean;
@@ -65,6 +72,13 @@ export function BlockCard({
   /** Other pricing panels this block's lines can move to (empty → control hidden). */
   moveTargets: { id: string; label: string }[];
   onMoveLineToBlock: (line: QuoteLine, targetBlockId: string) => void;
+  /** True when any of this block's lines holds an uncommitted edit (parent's
+   *  lineDrafts) — pins a pricing block expanded so a collapse can never hide
+   *  unsaved work mid-flight (mirrors the internal band's dirty rule). */
+  hasDirtyLines: boolean;
+  /** Commit a row drag-drop: the dragged line id + the gap index it landed in
+   *  (0..n). Routes to the SAME reorder path the ⋯ menu's Move up/down uses. */
+  onDropLine: (dragLineId: string, targetIdx: number) => void;
 }) {
   const { t } = useTranslation('billing');
   // Pending state scoped to this block: editing/removing this block, or adding a
@@ -134,6 +148,44 @@ export function BlockCard({
   const showSubtotal = (block.content?.showSubtotal as boolean | undefined) === true;
   const imageId = (block.content?.imageId as string | undefined) ?? '';
   const imageCaption = (block.content?.caption as string | undefined) ?? '';
+
+  // ---- pricing-block collapse (line_items only) ----------------------------
+  // Component-local, default expanded, never persisted. Collapsed shows one
+  // compact header row (label + line count + block subtotal); the body stays
+  // MOUNTED (inert + aria-hidden, 0fr grid) so row-local field state, draft
+  // wiring and testids all survive a collapse — same shell as the per-line
+  // internal band. Dirty lines pin the block expanded (a collapse request only
+  // lands once the edits do), and a rail "missing cost" reveal that targets a
+  // line in this block force-expands it before the row's own reveal effect
+  // needs the cost input reachable. Non-pricing blocks (heading / rich text /
+  // image / contract) are NOT collapsible: their "header" is the content
+  // itself, so there's no uniform header row to collapse to.
+  const [blockOpen, setBlockOpen] = useState(true);
+  const blockExpanded = !isTable || blockOpen || hasDirtyLines;
+  useEffect(() => {
+    if (!revealRequest) return;
+    if (!lines.some((l) => l.id === revealRequest.lineId)) return;
+    setBlockOpen(true);
+    // Only the reveal identity should re-trigger — `lines` is read from the
+    // current closure when the nonce bumps (same contract as the row effect).
+  }, [revealRequest?.nonce, revealRequest?.lineId]);
+  // Collapsed-summary subtotal: the sum of the block's per-line totals (the
+  // same persisted lineTotal figures the rows render), in cents.
+  const blockSubtotalCents = lines.reduce((sum, l) => sum + toCents(l.lineTotal), 0);
+
+  // ---- row drag-to-reorder (HTML5 DnD, same vocabulary as blocks) ----------
+  // The drag state lives here (one drag per table); drop gaps render between
+  // rows only while a drag is active, and the drop commits through onDropLine
+  // → the parent's single line-reorder path. Cross-block moves stay menu-only.
+  const [dragLineId, setDragLineId] = useState<string | null>(null);
+  const [lineDropIndex, setLineDropIndex] = useState<number | null>(null);
+  const endLineDrag = useCallback(() => { setDragLineId(null); setLineDropIndex(null); }, []);
+  const commitLineDrop = useCallback((targetIdx: number) => {
+    const id = dragLineId;
+    endLineDrag();
+    if (!id) return;
+    onDropLine(id, targetIdx);
+  }, [dragLineId, endLineDrag, onDropLine]);
 
   // Inline drafts for editable block content; resync if the persisted value
   // changes (e.g. after a refresh) so server normalization wins.
@@ -307,19 +359,56 @@ export function BlockCard({
 
         {isTable && (
           <div className="space-y-3">
-            {canWrite && (
-              <input
-                type="text"
-                value={labelDraft}
-                aria-label={t('quotes.editor.table.labelAria')}
-                onChange={(e) => setLabelDraft(e.target.value)}
-                onBlur={() => void commitLabel()}
-                disabled={blockBusy}
-                placeholder={t('quotes.editor.table.labelPlaceholder')}
-                data-testid={`quote-block-table-label-input-${block.id}`}
-                className={`h-9 w-full rounded-md border bg-transparent px-2 text-sm font-semibold transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(labelDraft.trim() !== tableLabel.trim(), blockSaved))}`}
-              />
-            )}
+            {/* Header row: the collapse disclosure plus (expanded, writers) the
+                label input. Collapsed, the whole strip is the toggle — label +
+                line count + block subtotal in one compact row (mirroring the
+                internal band's whole-strip trigger). */}
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setBlockOpen((v) => !v)}
+                aria-expanded={blockExpanded}
+                aria-label={blockExpanded ? t('quotes.editor.actions.collapseSection') : undefined}
+                title={blockExpanded ? t('quotes.editor.actions.collapseSection') : t('quotes.editor.actions.expandSection')}
+                data-testid={`quote-block-collapse-${block.id}`}
+                className={`flex items-center gap-2 rounded text-left focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring ${blockExpanded ? 'h-6 w-6 shrink-0 justify-center text-muted-foreground hover:bg-muted' : 'min-w-0 flex-1 py-0.5'}`}
+              >
+                <ChevronRight
+                  className={`h-4 w-4 shrink-0 transition-transform duration-200 ease-out motion-reduce:transition-none ${blockExpanded ? 'rotate-90' : 'text-muted-foreground'}`}
+                  aria-hidden="true"
+                />
+                {!blockExpanded && (
+                  <span
+                    className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2 gap-y-0.5"
+                    data-testid={`quote-block-collapsed-summary-${block.id}`}
+                  >
+                    <span className="truncate text-sm font-semibold">
+                      {tableLabel.trim() || t('quotes.editor.blockTypes.pricingTable')}
+                    </span>
+                    <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                      {t('quotes.editor.table.collapsedSummary', { count: lines.length, amount: formatMoney(fromCents(blockSubtotalCents), currency) })}
+                    </span>
+                  </span>
+                )}
+              </button>
+              {blockExpanded && canWrite && (
+                <div className="min-w-0 flex-1">
+                  <input
+                    type="text"
+                    value={labelDraft}
+                    aria-label={t('quotes.editor.table.labelAria')}
+                    onChange={(e) => setLabelDraft(e.target.value)}
+                    onBlur={() => void commitLabel()}
+                    disabled={blockBusy}
+                    placeholder={t('quotes.editor.table.labelPlaceholder')}
+                    data-testid={`quote-block-table-label-input-${block.id}`}
+                    className={`h-9 w-full rounded-md border bg-transparent px-2 text-sm font-semibold transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(labelDraft.trim() !== tableLabel.trim(), blockSaved))}`}
+                  />
+                </div>
+              )}
+            </div>
+            <BlockCollapse expanded={blockExpanded} testId={`quote-block-body-${block.id}`}>
+            <div className="space-y-3">
             {canWrite && (
               <label className="flex items-center gap-2 text-xs text-muted-foreground">
                 <input
@@ -359,28 +448,55 @@ export function BlockCard({
                 ) : (
                   lines.map((l, idx) =>
                     canWrite ? (
-                      <EditableLineRow
-                        key={l.id}
-                        line={l}
-                        quoteId={quoteId}
-                        currency={currency}
-                        taxRate={taxRate}
-                        isPending={isPending}
-                        isFirst={idx === 0}
-                        isLast={idx === lines.length - 1}
-                        showInternal={showInternal}
-                        depositSelectMode={depositSelectMode}
-                        onEdit={onEditLine}
-                        onMove={onMoveLine}
-                        onRemove={onRemoveLine}
-                        onDraft={onLineDraft}
-                        moveTargets={moveTargets}
-                        onMoveTo={onMoveLineToBlock}
-                      />
+                      <Fragment key={l.id}>
+                        {/* Drop gap above each row — only mounted mid-drag, so
+                            the table's resting rhythm is untouched. */}
+                        {dragLineId !== null && (
+                          <LineDropGap
+                            colSpan={5}
+                            active={lineDropIndex === idx}
+                            onDragOver={(e) => { e.preventDefault(); setLineDropIndex(idx); }}
+                            onDrop={(e) => { e.preventDefault(); commitLineDrop(idx); }}
+                            testId={`quote-line-drop-gap-${block.id}-${idx}`}
+                          />
+                        )}
+                        <EditableLineRow
+                          line={l}
+                          quoteId={quoteId}
+                          currency={currency}
+                          taxRate={taxRate}
+                          isPending={isPending}
+                          isFirst={idx === 0}
+                          isLast={idx === lines.length - 1}
+                          showInternal={showInternal}
+                          mixedCadence={mixedCadence}
+                          depositSelectMode={depositSelectMode}
+                          onEdit={onEditLine}
+                          onMove={onMoveLine}
+                          onRemove={onRemoveLine}
+                          onDraft={onLineDraft}
+                          moveTargets={moveTargets}
+                          onMoveTo={onMoveLineToBlock}
+                          revealRequest={revealRequest}
+                          dragging={dragLineId === l.id}
+                          onDragStartRow={() => setDragLineId(l.id)}
+                          onDragEndRow={endLineDrag}
+                        />
+                      </Fragment>
                     ) : (
-                      <ReadonlyLineRow key={l.id} line={l} quoteId={quoteId} currency={currency} taxRate={taxRate} isFirst={idx === 0} showInternal={showInternal} />
+                      <ReadonlyLineRow key={l.id} line={l} quoteId={quoteId} currency={currency} taxRate={taxRate} isFirst={idx === 0} showInternal={showInternal} mixedCadence={mixedCadence} revealRequest={revealRequest} />
                     ),
                   )
+                )}
+                {/* Final drop gap (below the last row) while a drag is active. */}
+                {canWrite && dragLineId !== null && lines.length > 0 && (
+                  <LineDropGap
+                    colSpan={5}
+                    active={lineDropIndex === lines.length}
+                    onDragOver={(e) => { e.preventDefault(); setLineDropIndex(lines.length); }}
+                    onDrop={(e) => { e.preventDefault(); commitLineDrop(lines.length); }}
+                    testId={`quote-line-drop-gap-${block.id}-${lines.length}`}
+                  />
                 )}
                 {/* Ghost row: the fast lane for manual entry — always ready at
                     the table foot, Enter commits and refocuses for the next. */}
@@ -388,6 +504,7 @@ export function BlockCard({
                   <GhostRow
                     blockId={block.id}
                     busy={addLineBusy}
+                    currency={currency}
                     onAdd={(form) => onAddManual(block.id, form)}
                     colSpan={5}
                   />
@@ -399,17 +516,44 @@ export function BlockCard({
             {/* The full add-line picker (catalog / AI lookup / distributor /
                 SKU + cost fields) collapses behind a disclosure — the ghost row
                 covers the fast manual path, so this chrome only renders when a
-                tech asks for the heavier modes. */}
+                tech asks for the heavier modes. Three explicit, separately-
+                labeled entry points (rather than one "more ways to add (…)"
+                catch-all) so catalog search reads as a first-class action, not
+                a buried extra — each jumps straight to its mode instead of
+                requiring an open-then-pick-a-tab detour. */}
             {canWrite && (
-              <button
-                type="button"
-                onClick={() => setPickerOpen((v) => !v)}
-                aria-expanded={pickerOpen}
-                data-testid={`quote-block-add-line-toggle-${block.id}`}
-                className="mt-2 inline-flex items-center gap-1 rounded-md border border-transparent px-2 py-1 text-xs font-medium text-muted-foreground hover:border-border hover:text-foreground"
-              >
-                <span aria-hidden="true">{pickerOpen ? '−' : '+'}</span> {t('quotes.editor.addLine.moreWays')}
-              </button>
+              <div className="mt-2 flex flex-wrap items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => { setMode('catalog'); setPickerOpen(true); }}
+                  aria-expanded={pickerOpen && mode === 'catalog'}
+                  data-testid={`quote-block-add-catalog-${block.id}`}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-xs font-medium text-muted-foreground hover:border-border hover:text-foreground"
+                >
+                  <Package className="h-3.5 w-3.5" aria-hidden="true" /> {t('quotes.editor.addLine.addFromCatalog')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setMode('manual'); setPickerOpen(true); }}
+                  aria-expanded={pickerOpen && mode === 'manual'}
+                  data-testid={`quote-block-add-ai-lookup-${block.id}`}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-xs font-medium text-muted-foreground hover:border-border hover:text-foreground"
+                >
+                  <Sparkles className="h-3.5 w-3.5" aria-hidden="true" /> {t('quotes.editor.addLine.aiLookupAction')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!pickerOpen) setMode('manual');
+                    setPickerOpen((v) => !v);
+                  }}
+                  aria-expanded={pickerOpen}
+                  data-testid={`quote-block-add-line-toggle-${block.id}`}
+                  className="inline-flex items-center gap-1 rounded-md border border-transparent px-2 py-1 text-xs font-medium text-muted-foreground hover:border-border hover:text-foreground"
+                >
+                  <span aria-hidden="true">{pickerOpen ? '−' : '+'}</span> {t('quotes.editor.addLine.moreDetails')}
+                </button>
+              </div>
             )}
             {canWrite && pickerOpen && (
             <div className="mt-1 rounded-md border bg-background/40 p-4" data-testid={`quote-block-add-line-${block.id}`}>
@@ -512,6 +656,8 @@ export function BlockCard({
                     {(name.trim() || desc.trim()) && (
                       <PolishButton
                         idSuffix={`quote-manual-${block.id}`}
+                        label={t('quotes.editor.line.tidyWithAi')}
+                        icon={<Sparkles className="h-3.5 w-3.5" aria-hidden="true" />}
                         getText={() => ({ name, description: desc })}
                         onApply={(r) => {
                           if (r.name !== null) setName(r.name);
@@ -675,10 +821,55 @@ export function BlockCard({
               )}
             </div>
             )}
+            </div>
+            </BlockCollapse>
           </div>
         )}
       </div>
     </section>
+  );
+}
+
+// Animated expand/collapse shell for a pricing block's body (subtotal toggle +
+// lines table + add-line picker). Same contract as the per-line internal band's
+// collapse: a 0fr→1fr grid animation (200ms ease-out, instant under
+// motion-reduce) with the collapsed content kept MOUNTED but inert +
+// aria-hidden, so row-local field state, drafts and testids survive a collapse
+// and the reveal-request focus retry can wait out the `[inert]` attribute.
+function BlockCollapse({ expanded, testId, children }: { expanded: boolean; testId: string; children: ReactNode }) {
+  return (
+    <div
+      className={`grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none ${expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}
+      inert={!expanded || undefined}
+      aria-hidden={!expanded}
+      data-testid={testId}
+    >
+      <div className="min-h-0 overflow-hidden">{children}</div>
+    </div>
+  );
+}
+
+// A thin drop target between two line rows, mounted only while a row drag is
+// active (same role the editor's InsertGap plays for block drags). Highlights
+// while dragged over; drop commits through the parent's single reorder path.
+function LineDropGap({ colSpan, active, onDragOver, onDrop, testId }: {
+  colSpan: number;
+  active: boolean;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+  testId: string;
+}) {
+  return (
+    <tr className="border-0">
+      <td colSpan={colSpan} className="p-0">
+        <div
+          onDragOver={onDragOver}
+          onDrop={onDrop}
+          className={`h-2 rounded transition-colors duration-150 ease-out motion-reduce:transition-none ${active ? 'bg-primary/30' : ''}`}
+          data-testid={testId}
+        />
+      </td>
+    </tr>
   );
 }
 

--- a/apps/web/src/components/billing/quotes/QuoteBulkBar.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBulkBar.tsx
@@ -1,0 +1,191 @@
+// The quote editor's bulk-edit action bar (Task D). Renders only while at
+// least one line is selected; QuoteEditor mounts it inside the same sticky
+// viewport-bottom wrapper as the mobile totals strip, so the two bars stack
+// instead of colliding. Purely presentational + local input state — the apply
+// mechanics (one PATCH per line through the existing editLine commit path)
+// live in QuoteEditor.
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import '../../../lib/i18n';
+import { filterMoneyChars, filterPercentChars } from './QuoteLineRows';
+
+export function QuoteBulkBar({ count, busy, onSetMarkup, onSetCost, onSetTaxable, onClear }: {
+  count: number;
+  /** True while a bulk apply is running — disables the actions (the per-line
+   *  pending keys already disable the affected row inputs). */
+  busy: boolean;
+  onSetMarkup: (pct: number) => void;
+  onSetCost: (cost: number) => void;
+  onSetTaxable: (taxable: boolean) => void;
+  onClear: () => void;
+}) {
+  const { t } = useTranslation('billing');
+  // Which inline value editor is open ('markup' | 'cost'), its draft, and an
+  // inline validation error — the same input vocabulary as the row fields
+  // (filterPercentChars allows a leading '-', money chars don't).
+  const [input, setInput] = useState<'markup' | 'cost' | null>(null);
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const markupBtnRef = useRef<HTMLButtonElement>(null);
+  const costBtnRef = useRef<HTMLButtonElement>(null);
+  const valueRef = useRef<HTMLInputElement>(null);
+  useEffect(() => { if (input) valueRef.current?.focus(); }, [input]);
+
+  const openInput = (which: 'markup' | 'cost') => {
+    setInput((cur) => (cur === which ? null : which));
+    setDraft('');
+    setError(null);
+  };
+  const closeInput = () => {
+    const trigger = input === 'markup' ? markupBtnRef : costBtnRef;
+    setInput(null);
+    setError(null);
+    trigger.current?.focus();
+  };
+  const apply = () => {
+    if (!input) return;
+    const n = Number(draft);
+    if (draft.trim() === '' || !Number.isFinite(n) || (input === 'cost' && n < 0)) {
+      setError(input === 'cost' ? t('quotes.editor.errors.costZeroOrMore') : t('quotes.editor.bulk.invalidMarkup'));
+      return;
+    }
+    (input === 'markup' ? onSetMarkup : onSetCost)(n);
+    setInput(null);
+    setDraft('');
+    setError(null);
+  };
+
+  const actionBtn = 'inline-flex h-7 items-center rounded-md border px-2 text-xs font-medium hover:bg-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50';
+
+  return (
+    <div
+      role="region"
+      aria-label={t('quotes.editor.bulk.barAria')}
+      data-testid="quote-bulk-bar"
+      onKeyDown={(e) => {
+        if (e.key !== 'Escape') return;
+        e.stopPropagation();
+        // Escape steps out gradually: first closes an open value editor
+        // (back to its trigger), then clears the selection entirely.
+        if (input) closeInput();
+        else onClear();
+      }}
+      className="rounded-lg border bg-card px-4 py-2 text-sm shadow-md"
+    >
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        {/* role=status: a screen reader hears the count move as rows are
+            (de)selected without re-reading the whole bar. */}
+        <span role="status" className="text-xs font-medium tabular-nums" data-testid="quote-bulk-count">
+          {t('quotes.editor.bulk.selectedCount', { count })}
+        </span>
+        <div className="ml-auto flex flex-wrap items-center gap-1.5">
+          <button
+            ref={markupBtnRef}
+            type="button"
+            onClick={() => openInput('markup')}
+            aria-expanded={input === 'markup'}
+            disabled={busy}
+            data-testid="quote-bulk-set-markup"
+            className={`${actionBtn} ${input === 'markup' ? 'border-primary/40 bg-primary/10 text-primary' : ''}`}
+          >
+            {t('quotes.editor.bulk.setMarkup')}
+          </button>
+          <button
+            ref={costBtnRef}
+            type="button"
+            onClick={() => openInput('cost')}
+            aria-expanded={input === 'cost'}
+            disabled={busy}
+            data-testid="quote-bulk-set-cost"
+            className={`${actionBtn} ${input === 'cost' ? 'border-primary/40 bg-primary/10 text-primary' : ''}`}
+          >
+            {t('quotes.editor.bulk.setCost')}
+          </button>
+          <button
+            type="button"
+            onClick={() => onSetTaxable(true)}
+            disabled={busy}
+            data-testid="quote-bulk-taxable-on"
+            className={actionBtn}
+          >
+            {t('quotes.editor.bulk.taxableOn')}
+          </button>
+          <button
+            type="button"
+            onClick={() => onSetTaxable(false)}
+            disabled={busy}
+            data-testid="quote-bulk-taxable-off"
+            className={actionBtn}
+          >
+            {t('quotes.editor.bulk.taxableOff')}
+          </button>
+          <button
+            type="button"
+            onClick={onClear}
+            data-testid="quote-bulk-clear"
+            className="inline-flex h-7 items-center rounded-md px-2 text-xs font-medium text-muted-foreground hover:text-foreground focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('quotes.editor.bulk.clearSelection')}
+          </button>
+        </div>
+      </div>
+      {input && (
+        <div className="mt-2 flex flex-wrap items-center gap-2 border-t pt-2">
+          <label htmlFor="quote-bulk-value" className="text-xs text-muted-foreground">
+            {input === 'markup' ? t('quotes.editor.line.markup') : t('quotes.editor.line.cost')}
+          </label>
+          <span className="flex items-center gap-1">
+            <input
+              id="quote-bulk-value"
+              ref={valueRef}
+              type="text"
+              inputMode="decimal"
+              value={draft}
+              onChange={(e) => {
+                setDraft((input === 'markup' ? filterPercentChars : filterMoneyChars)(e.target.value));
+                setError(null);
+              }}
+              onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); apply(); } }}
+              disabled={busy}
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? 'quote-bulk-value-error' : undefined}
+              data-testid="quote-bulk-value"
+              className={`h-8 w-24 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${error ? 'border-destructive' : ''}`}
+            />
+            {input === 'markup' && <span className="text-xs text-muted-foreground">{t('quotes.editor.symbols.percent')}</span>}
+          </span>
+          <button
+            type="button"
+            onClick={apply}
+            disabled={busy}
+            data-testid="quote-bulk-apply"
+            className="inline-flex h-8 items-center rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          >
+            {t('quotes.editor.bulk.apply')}
+          </button>
+          <button
+            type="button"
+            onClick={closeInput}
+            disabled={busy}
+            data-testid="quote-bulk-value-cancel"
+            className="inline-flex h-8 items-center rounded-md border px-2 text-xs font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+          >
+            {t('quotes.editor.actions.cancel')}
+          </button>
+          {error && (
+            <p id="quote-bulk-value-error" className="w-full text-xs text-destructive" data-testid="quote-bulk-value-error">
+              {error}
+            </p>
+          )}
+          {/* Markup needs a cost base — say so up front rather than only in the
+              post-apply "skipped" toast. */}
+          {input === 'markup' && !error && (
+            <p className="w-full text-xs text-muted-foreground" data-testid="quote-bulk-markup-hint">
+              {t('quotes.editor.bulk.markupHint')}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/billing/quotes/QuoteEditor.bulkedit.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.bulkedit.test.tsx
@@ -1,0 +1,323 @@
+// Task D — bulk edit: multi-select lines → set markup / cost / taxable across
+// the selection, batched through the SAME per-line editLine commit path the
+// inline inputs use (no bulk endpoint). Covers selection mechanics (row
+// checkbox, per-block select-all + indeterminate, collapse survival, readonly
+// exclusion), the bar's actions, honest partial-failure reporting, and
+// Escape/Clear semantics.
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { updateLine } from '../../../lib/api/quotes';
+
+// Mutable permission set so the readonly test can drop quotes:write without a
+// second mock module (the factory below closes over this hoisted object).
+const authState = vi.hoisted(() => ({
+  permissions: [{ resource: '*', action: '*' }] as { resource: string; action: string }[],
+}));
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: authState.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+  catalogItemImagePath: vi.fn().mockReturnValue('/catalog/c-1/image'),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  updateBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  reorderBlocks: vi.fn(),
+  reorderLines: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  addQuoteImageFromUrl: vi.fn(),
+  updateQuote: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const block: QuoteDetailData['blocks'][number] = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: { label: 'Hardware' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+
+const baseLine: QuoteDetailData['lines'][number] = {
+  id: 'line-1', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, unitCost: '20.00', sku: null, partNumber: null,
+  name: 'Firewall', description: null, quantity: '1.00',
+  unitPrice: '50.00', taxable: false, customerVisible: true, lineTotal: '50.00',
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+// line-2 deliberately has NO cost (markup has no base there); line-3 has one.
+const lines: QuoteDetailData['lines'] = [
+  baseLine,
+  { ...baseLine, id: 'line-2', name: 'Onboarding labor', unitCost: null, sortOrder: 1 },
+  { ...baseLine, id: 'line-3', name: 'Access point', unitCost: '10.00', unitPrice: '25.00', lineTotal: '25.00', sortOrder: 2 },
+];
+
+const detail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '125.00', taxRate: null,
+    taxTotal: '0.00', total: '125.00', oneTimeTotal: '125.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+    termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+    createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [block],
+  lines,
+};
+
+const updateLineMock = vi.mocked(updateLine);
+const okResponse = () =>
+  ({ ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response);
+
+async function renderEditor(d: QuoteDetailData = detail) {
+  render(<QuoteEditor detail={d} onChanged={vi.fn()} />);
+  await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+}
+
+describe('QuoteEditor — bulk edit (Task D)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.permissions = [{ resource: '*', action: '*' }];
+    updateLineMock.mockResolvedValue(okResponse());
+  });
+
+  it('selecting a line shows the bulk bar with the count; more selections update it', async () => {
+    await renderEditor();
+    expect(screen.queryByTestId('quote-bulk-bar')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('quote-line-select-line-1'));
+    expect(screen.getByTestId('quote-bulk-bar')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-bulk-count')).toHaveTextContent('1 line selected');
+
+    fireEvent.click(screen.getByTestId('quote-line-select-line-3'));
+    expect(screen.getByTestId('quote-bulk-count')).toHaveTextContent('2 lines selected');
+    expect((screen.getByTestId('quote-line-select-line-1') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByTestId('quote-line-select-line-2') as HTMLInputElement).checked).toBe(false);
+  });
+
+  it('the block header select-all selects/deselects every line and goes indeterminate on a subset', async () => {
+    await renderEditor();
+    const selectAll = screen.getByTestId('quote-block-select-all-blk-1') as HTMLInputElement;
+
+    // Subset → indeterminate, not checked.
+    fireEvent.click(screen.getByTestId('quote-line-select-line-1'));
+    await waitFor(() => expect(selectAll.indeterminate).toBe(true));
+    expect(selectAll.checked).toBe(false);
+
+    // Select-all → every row checked, indeterminate cleared.
+    fireEvent.click(selectAll);
+    expect(screen.getByTestId('quote-bulk-count')).toHaveTextContent('3 lines selected');
+    for (const id of ['line-1', 'line-2', 'line-3']) {
+      expect((screen.getByTestId(`quote-line-select-${id}`) as HTMLInputElement).checked).toBe(true);
+    }
+    await waitFor(() => expect(selectAll.indeterminate).toBe(false));
+    expect(selectAll.checked).toBe(true);
+
+    // Unchecking select-all empties the selection and dismisses the bar.
+    fireEvent.click(selectAll);
+    expect(screen.queryByTestId('quote-bulk-bar')).not.toBeInTheDocument();
+  });
+
+  it('bulk Set markup rewrites each selected line’s price from its OWN cost via the per-line commit path', async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByTestId('quote-line-select-line-1'));
+    fireEvent.click(screen.getByTestId('quote-line-select-line-3'));
+
+    fireEvent.click(screen.getByTestId('quote-bulk-set-markup'));
+    fireEvent.change(screen.getByTestId('quote-bulk-value'), { target: { value: '50' } });
+    fireEvent.click(screen.getByTestId('quote-bulk-apply'));
+
+    // cost 20 → price 30; cost 10 → price 15 (price = cost·(1+m)), one PATCH per line.
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitPrice: 30 }));
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-3', { unitPrice: 15 }));
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Updated 2 lines.' })),
+    );
+    // Selection is deliberately kept after an apply (a follow-up bulk action on
+    // the same set is the common flow).
+    expect(screen.getByTestId('quote-bulk-count')).toHaveTextContent('2 lines selected');
+  });
+
+  it('bulk Set markup skips selected lines with no cost and reports the skipped count honestly', async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByTestId('quote-block-select-all-blk-1'));
+
+    fireEvent.click(screen.getByTestId('quote-bulk-set-markup'));
+    // The hint says up front that markup needs a cost base.
+    expect(screen.getByTestId('quote-bulk-markup-hint')).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId('quote-bulk-value'), { target: { value: '50' } });
+    fireEvent.click(screen.getByTestId('quote-bulk-apply'));
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning', message: 'Skipped 1 line with no cost.' })),
+    );
+    expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitPrice: 30 });
+    expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-3', { unitPrice: 15 });
+    expect(updateLineMock).not.toHaveBeenCalledWith('q-1', 'line-2', expect.anything());
+  });
+
+  // Task B1: an explicit cost of 0 ("no cost", e.g. labor/service) is a real,
+  // known cost — NOT the same as line-2's null/unknown cost — but markup still
+  // has no usable base at cost $0 (price = 0·(1+m) = 0 regardless of m%), so
+  // bulk markup skips it too and folds it into the same honest skip count.
+  it('bulk Set markup also skips lines with an explicit cost of 0, counted with the unknown-cost skips', async () => {
+    const withNoCostLine: QuoteDetailData = {
+      ...detail,
+      lines: [
+        ...lines,
+        { ...baseLine, id: 'line-4', name: 'Included setup', unitCost: '0.00', unitPrice: '10.00', lineTotal: '10.00', sortOrder: 3 },
+      ],
+    };
+    await renderEditor(withNoCostLine);
+    fireEvent.click(screen.getByTestId('quote-block-select-all-blk-1'));
+
+    fireEvent.click(screen.getByTestId('quote-bulk-set-markup'));
+    fireEvent.change(screen.getByTestId('quote-bulk-value'), { target: { value: '50' } });
+    fireEvent.click(screen.getByTestId('quote-bulk-apply'));
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning', message: 'Skipped 2 lines with no cost.' })),
+    );
+    expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitPrice: 30 });
+    expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-3', { unitPrice: 15 });
+    expect(updateLineMock).not.toHaveBeenCalledWith('q-1', 'line-2', expect.anything());
+    expect(updateLineMock).not.toHaveBeenCalledWith('q-1', 'line-4', expect.anything());
+  });
+
+  it('bulk Set cost PATCHes unitCost on every selected line', async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByTestId('quote-line-select-line-1'));
+    fireEvent.click(screen.getByTestId('quote-line-select-line-2'));
+
+    fireEvent.click(screen.getByTestId('quote-bulk-set-cost'));
+    fireEvent.change(screen.getByTestId('quote-bulk-value'), { target: { value: '12.5' } });
+    fireEvent.click(screen.getByTestId('quote-bulk-apply'));
+
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitCost: 12.5 }));
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-2', { unitCost: 12.5 }));
+  });
+
+  it('an empty bulk value shows an inline error and PATCHes nothing', async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByTestId('quote-line-select-line-1'));
+    fireEvent.click(screen.getByTestId('quote-bulk-set-cost'));
+    fireEvent.click(screen.getByTestId('quote-bulk-apply'));
+
+    expect(screen.getByTestId('quote-bulk-value-error')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-bulk-value')).toHaveAttribute('aria-invalid', 'true');
+    expect(updateLineMock).not.toHaveBeenCalled();
+  });
+
+  it('bulk Taxable on/off PATCHes taxable across the selection', async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByTestId('quote-line-select-line-1'));
+    fireEvent.click(screen.getByTestId('quote-line-select-line-2'));
+
+    fireEvent.click(screen.getByTestId('quote-bulk-taxable-on'));
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { taxable: true }));
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-2', { taxable: true }));
+
+    updateLineMock.mockClear();
+    fireEvent.click(screen.getByTestId('quote-bulk-taxable-off'));
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { taxable: false }));
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-2', { taxable: false }));
+  });
+
+  it('a partial failure keeps applying to the rest and reports the failed count in one aggregate toast', async () => {
+    updateLineMock.mockImplementation((_qid: string, lineId: string) =>
+      lineId === 'line-1'
+        ? Promise.resolve({ ok: false, status: 500, statusText: 'ERR', json: vi.fn().mockResolvedValue({}) } as unknown as Response)
+        : Promise.resolve(okResponse()));
+    await renderEditor();
+    fireEvent.click(screen.getByTestId('quote-line-select-line-1'));
+    fireEvent.click(screen.getByTestId('quote-line-select-line-3'));
+
+    fireEvent.click(screen.getByTestId('quote-bulk-taxable-on'));
+
+    // The failing line does not abort the rest…
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-3', { taxable: true }));
+    // …and the aggregate outcome states the failure count (no silent partial success).
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error', message: '1 of 2 lines failed to update.' })),
+    );
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringMatching(/^Updated/) }));
+  });
+
+  it('Escape on the bar clears the selection (closing an open value editor first); Clear selection clears too', async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByTestId('quote-line-select-line-1'));
+
+    // With a value editor open, the first Escape only closes the editor.
+    fireEvent.click(screen.getByTestId('quote-bulk-set-markup'));
+    expect(screen.getByTestId('quote-bulk-value')).toBeInTheDocument();
+    fireEvent.keyDown(screen.getByTestId('quote-bulk-bar'), { key: 'Escape' });
+    expect(screen.queryByTestId('quote-bulk-value')).not.toBeInTheDocument();
+    expect(screen.getByTestId('quote-bulk-bar')).toBeInTheDocument();
+
+    // The next Escape empties the selection.
+    fireEvent.keyDown(screen.getByTestId('quote-bulk-bar'), { key: 'Escape' });
+    expect(screen.queryByTestId('quote-bulk-bar')).not.toBeInTheDocument();
+    expect((screen.getByTestId('quote-line-select-line-1') as HTMLInputElement).checked).toBe(false);
+
+    // Clear selection button does the same.
+    fireEvent.click(screen.getByTestId('quote-line-select-line-1'));
+    fireEvent.click(screen.getByTestId('quote-bulk-clear'));
+    expect(screen.queryByTestId('quote-bulk-bar')).not.toBeInTheDocument();
+  });
+
+  it('selection survives collapsing and re-expanding the pricing block', async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByTestId('quote-line-select-line-1'));
+    expect(screen.getByTestId('quote-bulk-count')).toHaveTextContent('1 line selected');
+
+    fireEvent.click(screen.getByTestId('quote-block-collapse-blk-1')); // collapse
+    expect(screen.getByTestId('quote-bulk-count')).toHaveTextContent('1 line selected');
+
+    fireEvent.click(screen.getByTestId('quote-block-collapse-blk-1')); // expand
+    expect((screen.getByTestId('quote-line-select-line-1') as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('read-only users get no selection checkboxes (rows or block header)', async () => {
+    authState.permissions = [{ resource: 'quotes', action: 'read' }];
+    await renderEditor();
+
+    expect(screen.queryByTestId('quote-line-select-line-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quote-block-select-all-blk-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quote-bulk-bar')).not.toBeInTheDocument();
+  });
+
+  it('checkbox and select-all carry aria-labels naming the line / the table', async () => {
+    await renderEditor();
+    expect(screen.getByTestId('quote-line-select-line-1')).toHaveAttribute('aria-label', 'Select Firewall');
+    expect(screen.getByTestId('quote-block-select-all-blk-1')).toHaveAttribute('aria-label', 'Select all lines in Hardware');
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.costmarkup.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.costmarkup.test.tsx
@@ -103,8 +103,10 @@ describe('QuoteEditor — per-line cost/markup/net strip', () => {
     fireEvent.blur(markup);
 
     // Price reflects 150.00 optimistically, and the PATCH carries unitPrice 150.
+    // The field is unfocused after the markup blur, so it renders through
+    // formatMoney (currency-formatted), same as the adjacent Total/summary cells.
     await waitFor(() =>
-      expect((screen.getByTestId('quote-line-price-line-1') as HTMLInputElement).value).toBe('150.00'),
+      expect((screen.getByTestId('quote-line-price-line-1') as HTMLInputElement).value).toBe('$150.00'),
     );
     await waitFor(() =>
       expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitPrice: 150 }),

--- a/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
@@ -96,7 +96,9 @@ describe('QuoteEditor — inline line editing', () => {
     // Quantity shows its bare form ('1', not the stored '1.00') — matching the
     // input's step="1" and the customer-facing rendering.
     expect((screen.getByTestId('quote-line-qty-line-1') as HTMLInputElement).value).toBe('1');
-    expect((screen.getByTestId('quote-line-price-line-1') as HTMLInputElement).value).toBe('50.00');
+    // Unfocused, the price renders currency-formatted (same as the read-only
+    // Total/summary cells) — the raw "50.00" only shows once the field is focused.
+    expect((screen.getByTestId('quote-line-price-line-1') as HTMLInputElement).value).toBe('$50.00');
     expect(screen.getByTestId('quote-line-recurrence-line-1')).toBeInTheDocument();
     expect(screen.getByTestId('quote-line-taxable-line-1')).toBeInTheDocument();
     // the description editor is a multi-line textarea
@@ -162,6 +164,87 @@ describe('QuoteEditor — inline line editing', () => {
     await waitFor(() => {
       expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { description: 'Premium managed support.' });
     });
+  });
+
+  it('the per-line polish button carries the explicit "Tidy with AI" AI affordance', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-block-add-line-toggle-blk-1'));
+
+    expect(screen.getByTestId('polish-btn-quote-line-line-1')).toHaveTextContent('Tidy with AI');
+  });
+
+  it('"Tidy all descriptions" (block ⋯ menu) opens the per-line polish preview and applies it via updateLine on approval', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-actions-blk-1'));
+    expect(screen.getByTestId('quote-block-actions-menu-blk-1')).toHaveTextContent('Tidy all descriptions');
+    fireEvent.click(screen.getByTestId('quote-block-tidy-all-blk-1'));
+
+    // Same preview/apply testids the per-line PolishButton uses (idSuffix
+    // `quote-tidy-all-<lineId>`) — this reuses the real preview + fact-guard
+    // mechanics rather than bypassing them.
+    await waitFor(() => expect(screen.getByTestId('polish-apply-quote-tidy-all-line-1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('polish-apply-quote-tidy-all-line-1'));
+
+    await waitFor(() => {
+      expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { description: 'Premium managed support.' });
+    });
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: expect.stringContaining('1') })));
+  });
+
+  it('"Tidy all descriptions" steps through every described line one preview at a time, and cancelling one skips it without applying', async () => {
+    const lineB: QuoteDetailData['lines'][number] = { ...line, id: 'line-2', description: 'Backup service' };
+    const twoLineDetail: QuoteDetailData = { ...detail, lines: [line, lineB] };
+    render(<QuoteEditor detail={twoLineDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-actions-blk-1'));
+    fireEvent.click(screen.getByTestId('quote-block-tidy-all-blk-1'));
+
+    // First line's preview opens — cancel it: no PATCH, and the queue must
+    // still advance to the second line rather than stalling.
+    await waitFor(() => expect(screen.getByTestId('polish-cancel-quote-tidy-all-line-1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('polish-cancel-quote-tidy-all-line-1'));
+    expect(updateLineMock).not.toHaveBeenCalledWith('q-1', 'line-1', expect.anything());
+
+    await waitFor(() => expect(screen.getByTestId('polish-apply-quote-tidy-all-line-2')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('polish-apply-quote-tidy-all-line-2'));
+
+    await waitFor(() => {
+      expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-2', { description: 'Premium managed support.' });
+    });
+  });
+
+  it('"Tidy all descriptions" toasts instead of opening a preview when the block has no described lines', async () => {
+    const noDescDetail: QuoteDetailData = { ...detail, lines: [{ ...line, description: null }] };
+    render(<QuoteEditor detail={noDescDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-actions-blk-1'));
+    fireEvent.click(screen.getByTestId('quote-block-tidy-all-blk-1'));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' })));
+    expect(screen.queryByTestId('polish-apply-quote-tidy-all-line-1')).not.toBeInTheDocument();
+  });
+
+  it('the block footer offers three explicit, separately-labeled add affordances instead of one mystery-meat disclosure', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    // Catalog search is a first-class, one-click action — no open-then-pick-a-tab detour.
+    expect(screen.getByTestId('quote-block-add-catalog-blk-1')).toHaveTextContent('Add from catalog');
+    expect(screen.getByTestId('quote-block-add-ai-lookup-blk-1')).toHaveTextContent('AI lookup');
+    expect(screen.getByTestId('quote-block-add-line-toggle-blk-1')).toHaveTextContent('More details');
+
+    fireEvent.click(screen.getByTestId('quote-block-add-catalog-blk-1'));
+    // One click reaches the catalog mode directly (mode defaults to 'catalog').
+    expect(screen.getByTestId('quote-line-mode-blk-1-catalog')).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(screen.getByTestId('quote-block-add-ai-lookup-blk-1'));
+    // "AI lookup" jumps straight to the manual tab, where the AI enrich input lives.
+    expect(screen.getByTestId('quote-line-mode-blk-1-manual')).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('changing quantity sends a numeric quantity', async () => {
@@ -242,8 +325,10 @@ describe('QuoteEditor — inline line editing', () => {
     };
     rerender(<QuoteEditor detail={normalized} onChanged={vi.fn()} />);
 
+    // Unfocused after the blur/rerender, so the re-adopted value renders
+    // currency-formatted.
     await waitFor(() =>
-      expect((screen.getByTestId('quote-line-price-line-1') as HTMLInputElement).value).toBe('10.00'),
+      expect((screen.getByTestId('quote-line-price-line-1') as HTMLInputElement).value).toBe('$10.00'),
     );
     // Row total reflects the authoritative server value, not the raw 9.999 entry.
     expect(screen.getByTestId('quote-line-tax-line-1')).toBeInTheDocument();

--- a/apps/web/src/components/billing/quotes/QuoteEditor.internalband.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.internalband.test.tsx
@@ -1,0 +1,287 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { updateLine } from '../../../lib/api/quotes';
+
+type Perm = { resource: string; action: string };
+
+// Mutable grant set so the same file can exercise both editable rows (writer)
+// and readonly rows (quotes:read) — same pattern as QuoteEditor.permissions.test.
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../../stores/auth', () => ({
+  // orgStore (imported by QuoteEditor for the customer select) registers an
+  // org-id provider against the auth store at module scope.
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const block: QuoteDetailData['blocks'][number] = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: { label: 'Monthly services' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+
+const baseLine: QuoteDetailData['lines'][number] = {
+  id: 'line-1', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+  name: null, description: 'Managed support', quantity: '1.00',
+  unitPrice: '50.00', taxable: false, customerVisible: true, lineTotal: '50.00',
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const baseQuote: QuoteDetailData['quote'] = {
+  id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+  currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '50.00', taxRate: null,
+  taxTotal: '0.00', total: '50.00', oneTimeTotal: '50.00', monthlyRecurringTotal: '0.00',
+  annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+  termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+  convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+  createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const updateLineMock = vi.mocked(updateLine);
+
+const detailWith = (lines: QuoteDetailData['lines']): QuoteDetailData => ({
+  quote: baseQuote, blocks: [block], lines,
+});
+
+describe('QuoteEditor — internal band progressive disclosure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The cost/margin toggle persists to localStorage — clear it so every test
+    // starts from the collapsed default regardless of what a prior test toggled.
+    localStorage.clear();
+    state.permissions = [{ resource: '*', action: '*' }];
+    updateLineMock.mockResolvedValue(
+      { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+    );
+  });
+
+  it('defaults to a compact summary per line when cost & margin is shown', async () => {
+    const detail = detailWith([
+      { ...baseLine, unitCost: '100.00', unitPrice: '130.00', lineTotal: '130.00', sku: 'SW-1' },
+    ]);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+
+    // Collapsed by default: the toggle reports it, the full form is hidden from
+    // the a11y tree, and the summary carries SKU / Cost / Markup / Profit.
+    expect(screen.getByTestId('quote-line-internal-toggle-line-1')).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByTestId('quote-line-internal-detail-line-1')).toHaveAttribute('aria-hidden', 'true');
+    const summary = screen.getByTestId('quote-line-internal-summary-line-1').textContent ?? '';
+    expect(summary).toContain('SKU SW-1');
+    expect(summary).toContain('Cost $100.00');
+    expect(summary).toContain('Markup 30%');
+    expect(summary).toContain('Profit $30.00');
+  });
+
+  it('summary shows — for missing cost/profit and omits an unset SKU', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+
+    const summary = screen.getByTestId('quote-line-internal-summary-line-1').textContent ?? '';
+    expect(summary).toContain('Cost —');
+    expect(summary).toContain('Profit —');
+    expect(summary).not.toContain('SKU');
+  });
+
+  it('expanding a line reveals the editing band; its inputs commit as before', async () => {
+    const detail = detailWith([
+      { ...baseLine, unitCost: '100.00', unitPrice: '130.00', lineTotal: '130.00' },
+    ]);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+
+    fireEvent.click(screen.getByTestId('quote-line-internal-toggle-line-1'));
+    expect(screen.getByTestId('quote-line-internal-toggle-line-1')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('quote-line-internal-detail-line-1')).toHaveAttribute('aria-hidden', 'false');
+    // The summary yields to the full form while expanded.
+    expect(screen.queryByTestId('quote-line-internal-summary-line-1')).not.toBeInTheDocument();
+
+    const costEl = screen.getByTestId('quote-line-cost-line-1') as HTMLInputElement;
+    // Unfocused, cost renders currency-formatted (matches the Cost/Markup/Profit
+    // summary strip); the raw "100.00" only shows once the field is focused.
+    expect(costEl.value).toBe('$100.00');
+    fireEvent.change(costEl, { target: { value: '90' } });
+    fireEvent.blur(costEl);
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitCost: 90 }));
+  });
+
+  it('a line with a dirty cost never auto-collapses; collapse lands after the save resyncs', async () => {
+    const detail = detailWith([
+      { ...baseLine, unitCost: '100.00', unitPrice: '130.00', lineTotal: '130.00' },
+    ]);
+    const { rerender } = render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+
+    const toggle = screen.getByTestId('quote-line-internal-toggle-line-1');
+    fireEvent.click(toggle); // expand
+    fireEvent.change(screen.getByTestId('quote-line-cost-line-1'), { target: { value: '80' } });
+
+    // Collapse request while the edit is unsaved: the band stays open.
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('quote-line-internal-detail-line-1')).toHaveAttribute('aria-hidden', 'false');
+
+    // Commit, then the server resync clears the dirty flag — NOW it collapses.
+    fireEvent.blur(screen.getByTestId('quote-line-cost-line-1'));
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitCost: 80 }));
+    rerender(
+      <QuoteEditor
+        detail={detailWith([{ ...baseLine, unitCost: '80.00', unitPrice: '130.00', lineTotal: '130.00' }])}
+        onChanged={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(toggle).toHaveAttribute('aria-expanded', 'false'));
+  });
+
+  it('readonly rows get the same summary; expanding shows the full detail text', async () => {
+    state.permissions = [{ resource: 'quotes', action: 'read' }];
+    const detail = detailWith([
+      { ...baseLine, unitCost: '30.00', sku: 'SW-9', partNumber: 'PN-9' },
+    ]);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+
+    const toggle = screen.getByTestId('quote-line-internal-toggle-line-1');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByTestId('quote-line-internal-summary-line-1')).toHaveTextContent('Cost $30.00');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('quote-line-internal-detail-line-1')).toHaveAttribute('aria-hidden', 'false');
+    expect(screen.getByTestId('quote-line-sku-line-1')).toHaveTextContent('SKU SW-9');
+    expect(screen.getByTestId('quote-line-partnumber-line-1')).toHaveTextContent('PN PN-9');
+    expect(screen.getByTestId('quote-line-cost-line-1')).toHaveTextContent('$30.00');
+  });
+});
+
+describe('QuoteEditor — cadence suffix only on mixed-cadence quotes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    state.permissions = [{ resource: '*', action: '*' }];
+  });
+
+  it('uniform cadence: no /mo suffix in the rows (rail still carries it)', async () => {
+    const detail = detailWith([
+      { ...baseLine, id: 'A', recurrence: 'monthly' },
+      { ...baseLine, id: 'B', recurrence: 'monthly' },
+    ]);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    expect(within(screen.getByTestId('quote-line-A')).queryByText('/mo')).not.toBeInTheDocument();
+    expect(within(screen.getByTestId('quote-line-B')).queryByText('/mo')).not.toBeInTheDocument();
+  });
+
+  it('mixed cadences: recurring rows regain their /mo suffix', async () => {
+    const detail = detailWith([
+      { ...baseLine, id: 'A', recurrence: 'monthly' },
+      { ...baseLine, id: 'B', recurrence: 'one_time' },
+    ]);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    expect(within(screen.getByTestId('quote-line-A')).getByText('/mo')).toBeInTheDocument();
+    expect(within(screen.getByTestId('quote-line-B')).queryByText('/mo')).not.toBeInTheDocument();
+  });
+
+  it('readonly rows follow the same rule', async () => {
+    state.permissions = [{ resource: 'quotes', action: 'read' }];
+    const uniform = detailWith([
+      { ...baseLine, id: 'A', recurrence: 'monthly' },
+      { ...baseLine, id: 'B', recurrence: 'monthly' },
+    ]);
+    const { unmount } = render(<QuoteEditor detail={uniform} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(within(screen.getByTestId('quote-line-A')).queryAllByText('/mo')).toHaveLength(0);
+    unmount();
+
+    const mixed = detailWith([
+      { ...baseLine, id: 'A', recurrence: 'monthly' },
+      { ...baseLine, id: 'B', recurrence: 'one_time' },
+    ]);
+    render(<QuoteEditor detail={mixed} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    // Readonly rows suffix both the Unit price and Total cells.
+    expect(within(screen.getByTestId('quote-line-A')).getAllByText('/mo').length).toBeGreaterThan(0);
+    expect(within(screen.getByTestId('quote-line-B')).queryAllByText('/mo')).toHaveLength(0);
+  });
+});
+
+describe('QuoteEditor — quiet ghost row', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    state.permissions = [{ resource: '*', action: '*' }];
+  });
+
+  it('hides qty/price/cadence chrome until the name has content, and restores it', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    // Untouched ghost row: a single quiet name affordance.
+    expect(screen.getByTestId('quote-ghost-qty-blk-1')).toHaveClass('hidden');
+    expect(screen.getByTestId('quote-ghost-price-blk-1')).toHaveClass('hidden');
+    expect(screen.getByTestId('quote-ghost-recurrence-blk-1')).toHaveClass('hidden');
+
+    // Typing a name reveals the entry chrome…
+    fireEvent.change(screen.getByTestId('quote-ghost-name-blk-1'), { target: { value: 'Backup agent' } });
+    expect(screen.getByTestId('quote-ghost-qty-blk-1')).not.toHaveClass('hidden');
+    expect(screen.getByTestId('quote-ghost-price-blk-1')).not.toHaveClass('hidden');
+    expect(screen.getByTestId('quote-ghost-recurrence-blk-1')).not.toHaveClass('hidden');
+
+    // …and clearing it hides the chrome again (row not focused).
+    fireEvent.change(screen.getByTestId('quote-ghost-name-blk-1'), { target: { value: '' } });
+    expect(screen.getByTestId('quote-ghost-qty-blk-1')).toHaveClass('hidden');
+  });
+
+  it('shows the chrome while focus is inside the row even with an empty name', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.focus(screen.getByTestId('quote-ghost-name-blk-1'));
+    expect(screen.getByTestId('quote-ghost-qty-blk-1')).not.toHaveClass('hidden');
+    fireEvent.blur(screen.getByTestId('quote-ghost-name-blk-1'));
+    expect(screen.getByTestId('quote-ghost-qty-blk-1')).toHaveClass('hidden');
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.internalband.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.internalband.test.tsx
@@ -194,6 +194,89 @@ describe('QuoteEditor — internal band progressive disclosure', () => {
   });
 });
 
+// Task B1: an explicit cost of 0 ("no cost", e.g. a labor/service line) is a
+// real, known cost — deliberately distinct from a never-entered/unknown cost
+// (null) — so it's excluded from the "N lines missing a cost" warning and the
+// collapsed summary reads "No cost" rather than "Cost $0.00".
+describe('QuoteEditor — explicit "no cost" designation (Task B1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    state.permissions = [{ resource: '*', action: '*' }];
+    updateLineMock.mockResolvedValue(
+      { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+    );
+  });
+
+  it('checking "No cost" sets an explicit cost of 0 through the same commit path as typing it', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+    fireEvent.click(screen.getByTestId('quote-line-internal-toggle-line-1'));
+
+    fireEvent.click(screen.getByTestId('quote-line-nocost-line-1'));
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitCost: 0 }));
+    // Unfocused, the cost input renders currency-formatted (same as any commit).
+    expect((screen.getByTestId('quote-line-cost-line-1') as HTMLInputElement).value).toBe('$0.00');
+  });
+
+  it('unchecking "No cost" clears the cost back to null (the same as clearing the field by hand)', async () => {
+    const detail = detailWith([{ ...baseLine, unitCost: '0.00' }]);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+    fireEvent.click(screen.getByTestId('quote-line-internal-toggle-line-1'));
+
+    const checkbox = screen.getByTestId('quote-line-nocost-line-1') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    fireEvent.click(checkbox);
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitCost: null }));
+  });
+
+  it('collapsed summary reads "No cost · Profit $X" (not "Cost $0.00") and drops the Markup segment', async () => {
+    const detail = detailWith([
+      { ...baseLine, unitCost: '0.00', unitPrice: '130.00', lineTotal: '130.00' },
+    ]);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+
+    const summary = screen.getByTestId('quote-line-internal-summary-line-1');
+    expect(summary).toHaveTextContent('No cost');
+    expect(summary).toHaveTextContent('Profit $130.00');
+    expect(summary.textContent).not.toContain('Cost $0.00');
+    expect(summary.textContent).not.toContain('Markup');
+    expect(screen.queryByTestId('quote-line-cost-missing-line-1')).not.toBeInTheDocument();
+  });
+
+  it('readonly rows also swap the collapsed "Cost $0.00" figure for "No cost"', async () => {
+    state.permissions = [{ resource: 'quotes', action: 'read' }];
+    const detail = detailWith([
+      { ...baseLine, unitCost: '0.00', unitPrice: '75.00', lineTotal: '75.00' },
+    ]);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+
+    const summary = screen.getByTestId('quote-line-internal-summary-line-1');
+    expect(summary).toHaveTextContent('No cost');
+    expect(summary.textContent).not.toContain('Cost $0.00');
+  });
+
+  it('an explicit cost of 0 is excluded from the missing-cost warning; a null cost still triggers it', async () => {
+    const detail = detailWith([
+      { ...baseLine, id: 'line-1', unitCost: '0.00' },
+      { ...baseLine, id: 'line-2', unitCost: null, sortOrder: 1 },
+    ]);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+
+    // Only line-2 (the null-cost line) counts toward the warning.
+    expect(screen.getByTestId('quote-margin-missing-cost')).toHaveTextContent('1 line missing a cost');
+  });
+});
+
 describe('QuoteEditor — cadence suffix only on mixed-cadence quotes', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/components/billing/quotes/QuoteEditor.lastsaved.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.lastsaved.test.tsx
@@ -1,0 +1,91 @@
+// The quiet "Saving…" / "Saved 2:41 PM" sync indicator near the autosave hint
+// (QuoteEditor.tsx). Uses the terms-field PATCH as the mutation under test —
+// same runScoped path every other editor mutation goes through.
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { fetchWithAuth } from '../../../stores/auth';
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+function draftDetail(): QuoteDetailData {
+  return {
+    quote: {
+      id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+      taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+      annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+      termsAndConditions: null, sellerSnapshot: null,
+      acceptedAt: null, declinedAt: null, convertedAt: null, convertedInvoiceId: null,
+      sentAt: null, viewedAt: null, createdBy: null,
+      createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+    },
+    blocks: [],
+    lines: [],
+  };
+}
+
+describe('QuoteEditor — last-saved indicator', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('is absent before any save, shows "Saving…" while the mutation is in flight, then "Saved <time>" once it settles', async () => {
+    let resolvePatch!: (v: Response) => void;
+    const patchPromise = new Promise<Response>((resolve) => { resolvePatch = resolve; });
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input === '/quotes/q-1' && opts?.method === 'PATCH') return patchPromise;
+      return json({ data: {} });
+    });
+
+    render(<QuoteEditor detail={draftDetail()} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    // Nothing has saved yet this session — the indicator renders nothing at all
+    // (never an empty "Saved" line) rather than blocking anything.
+    expect(screen.queryByTestId('quote-editor-last-saved')).not.toBeInTheDocument();
+
+    const textarea = screen.getByTestId('quote-terms');
+    fireEvent.change(textarea, { target: { value: 'Net 30' } });
+    fireEvent.blur(textarea);
+
+    await waitFor(() => expect(screen.getByTestId('quote-editor-last-saved')).toHaveTextContent('Saving'));
+
+    resolvePatch(json({ data: {} }));
+
+    await waitFor(() => expect(screen.getByTestId('quote-editor-last-saved')).toHaveTextContent(/Saved/));
+    expect(screen.getByTestId('quote-editor-last-saved')).not.toHaveTextContent('Saving');
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.marginreveal.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.marginreveal.test.tsx
@@ -1,0 +1,203 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { updateLine } from '../../../lib/api/quotes';
+
+// Task 3 of the quote-editor UX pass: the rail's "missing cost" notice becomes
+// an actionable button that reveals the first offending line; the missing-cost
+// figure is flagged even while a line's internal band is collapsed; and a dirty
+// field exposes an sr-only "Unsaved" cue alongside the sighted amber ring.
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const block: QuoteDetailData['blocks'][number] = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: { label: 'Monthly services' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+
+const baseLine: QuoteDetailData['lines'][number] = {
+  id: 'line-1', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, unitCost: '20.00', sku: null, partNumber: null,
+  name: null, description: 'Managed support', quantity: '1.00',
+  unitPrice: '50.00', taxable: false, customerVisible: true, lineTotal: '50.00',
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const baseQuote: QuoteDetailData['quote'] = {
+  id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+  currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '50.00', taxRate: null,
+  taxTotal: '0.00', total: '50.00', oneTimeTotal: '50.00', monthlyRecurringTotal: '0.00',
+  annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+  termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+  convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+  createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const detailWith = (lines: QuoteDetailData['lines']): QuoteDetailData => ({
+  quote: baseQuote, blocks: [block], lines,
+});
+
+describe('QuoteEditor — missing-cost warning treatment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    state.permissions = [{ resource: '*', action: '*' }];
+  });
+
+  it('flags the collapsed summary\'s Cost figure when the line has no cost', async () => {
+    const detail = detailWith([{ ...baseLine, unitCost: null }]);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+
+    const missing = screen.getByTestId('quote-line-cost-missing-line-1');
+    expect(missing).toHaveTextContent('Cost —');
+    expect(missing).toHaveAttribute('aria-label', 'Cost not entered — this line is excluded from the profit estimate.');
+  });
+
+  it('does not flag a line that has a cost', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+
+    expect(screen.queryByTestId('quote-line-cost-missing-line-1')).not.toBeInTheDocument();
+  });
+});
+
+describe('QuoteEditor — actionable missing-cost reveal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    state.permissions = [{ resource: '*', action: '*' }];
+    // jsdom doesn't implement scrollIntoView; stub it so the reveal effect's
+    // call is observable and doesn't throw.
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('is a real button (not a static <p>) that reveals the first offending line', async () => {
+    const detail = detailWith([
+      { ...baseLine, id: 'line-1', unitCost: '20.00' }, // has a cost — not the target
+      { ...baseLine, id: 'line-2', unitCost: null }, // first offender
+      { ...baseLine, id: 'line-3', unitCost: null },
+    ]);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+
+    const notice = screen.getByTestId('quote-margin-missing-cost');
+    expect(notice.tagName).toBe('BUTTON');
+    // Both offending bands start collapsed.
+    expect(screen.getByTestId('quote-line-internal-toggle-line-2')).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(notice);
+
+    // Expands line-2 (the FIRST offender, not line-3) and scrolls it into view.
+    await waitFor(() => expect(screen.getByTestId('quote-line-internal-toggle-line-2')).toHaveAttribute('aria-expanded', 'true'));
+    expect(screen.getByTestId('quote-line-internal-toggle-line-3')).toHaveAttribute('aria-expanded', 'false');
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+
+    // Focuses the cost input once the band is reachable (not `inert`).
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByTestId('quote-line-cost-line-2')));
+  });
+
+  it('re-clicking after scrolling away re-reveals the same line', async () => {
+    const detail = detailWith([{ ...baseLine, id: 'line-1', unitCost: null }]);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+
+    const notice = screen.getByTestId('quote-margin-missing-cost');
+    fireEvent.click(notice);
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByTestId('quote-line-cost-line-1')));
+
+    // Manually blur + collapse, then click again — it re-expands and re-focuses.
+    fireEvent.click(screen.getByTestId('quote-line-internal-toggle-line-1'));
+    expect(screen.getByTestId('quote-line-internal-toggle-line-1')).toHaveAttribute('aria-expanded', 'false');
+    (document.activeElement as HTMLElement | null)?.blur();
+
+    fireEvent.click(notice);
+    await waitFor(() => expect(screen.getByTestId('quote-line-internal-toggle-line-1')).toHaveAttribute('aria-expanded', 'true'));
+  });
+});
+
+describe('QuoteEditor — sr-only unsaved cue for dirty line fields', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    state.permissions = [{ resource: '*', action: '*' }];
+  });
+
+  it('a dirty qty field gets an sr-only "Unsaved" description with no visible badge', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const qty = screen.getByTestId('quote-line-qty-line-1');
+    expect(qty).not.toHaveAttribute('aria-describedby');
+
+    fireEvent.change(qty, { target: { value: '3' } });
+    const describedBy = qty.getAttribute('aria-describedby') ?? '';
+    expect(describedBy).toContain('quote-line-qty-unsaved-line-1');
+
+    const hint = document.getElementById('quote-line-qty-unsaved-line-1');
+    expect(hint).toHaveTextContent('Unsaved');
+    expect(hint).toHaveClass('sr-only');
+
+    // Committing clears the dirty flag; jsdom's updateLine mock resolves with
+    // no persisted change here, so this only asserts the hint follows dirty —
+    // re-typing back to the persisted value un-dirties without a save.
+    fireEvent.change(qty, { target: { value: '1' } });
+    fireEvent.blur(qty);
+    expect(updateLine).not.toHaveBeenCalled();
+    expect(qty).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('a dirty cost field gets its own sr-only unsaved id, distinct from the missing-cost warning', async () => {
+    render(<QuoteEditor detail={detailWith([{ ...baseLine, unitCost: null }])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+    fireEvent.click(screen.getByTestId('quote-line-internal-toggle-line-1'));
+
+    const cost = screen.getByTestId('quote-line-cost-line-1');
+    fireEvent.change(cost, { target: { value: '10' } });
+    expect(cost.getAttribute('aria-describedby')).toContain('quote-line-cost-unsaved-line-1');
+    expect(document.getElementById('quote-line-cost-unsaved-line-1')).toHaveTextContent('Unsaved');
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.moneyinput.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.moneyinput.test.tsx
@@ -184,6 +184,30 @@ describe('QuoteLineRows — money-formatted price/cost inputs', () => {
     expect(widthCh).toBeGreaterThanOrEqual(7); // > the old fixed w-16 (~8ch) floor for short values
   });
 
+  it('markup is a text/inputMode=decimal field (no spinner) that sanitizes keystrokes but allows a leading minus for a loss', async () => {
+    render(<QuoteEditor detail={detailWith([{ ...baseLine, unitCost: '100.00', unitPrice: '80.00' }])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-block-add-line-toggle-blk-1'));
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+    fireEvent.click(screen.getByTestId('quote-line-internal-toggle-line-1'));
+
+    const markupEl = screen.getByTestId('quote-line-markup-line-1') as HTMLInputElement;
+    expect(markupEl.type).toBe('text');
+    expect(markupEl.getAttribute('inputmode')).toBe('decimal');
+    // Priced below cost is a real loss, not a typo — the negative markup that
+    // gave (80-100)/100 = -20 must round-trip through the field.
+    expect(markupEl.value).toBe('-20');
+
+    // Garbage keystrokes strip to digits/decimal/leading-minus only.
+    fireEvent.change(markupEl, { target: { value: 'abc-12.5xyz' } });
+    expect(markupEl.value).toBe('-12.5');
+    fireEvent.blur(markupEl);
+
+    // Commit semantics unchanged: markup edits still derive and PATCH price
+    // (unitPrice = cost·(1 + markup/100) = 100·0.875 = 87.50).
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitPrice: 87.5 }));
+  });
+
   it('ghost-row price formats on blur and shows the raw decimal while focused', async () => {
     render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());

--- a/apps/web/src/components/billing/quotes/QuoteEditor.moneyinput.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.moneyinput.test.tsx
@@ -1,0 +1,199 @@
+// Money correctness in the editable unit-price / internal-cost / ghost-price
+// inputs: formatted (currency, thousands-separated) while blurred — matching
+// the adjacent read-only Total/summary cells — raw editable decimal while
+// focused, commit + reformat on blur, sanitized keystrokes (no NaN commits),
+// and ch-based width so long values are never clipped.
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { updateLine } from '../../../lib/api/quotes';
+
+// Writer permissions so the inline line editor renders (read-only hides it).
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const block: QuoteDetailData['blocks'][number] = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: { label: 'Monthly services' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+
+const baseLine: QuoteDetailData['lines'][number] = {
+  id: 'line-1', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+  name: null, description: 'Managed support', quantity: '1.00',
+  unitPrice: '1234.00', taxable: false, customerVisible: true, lineTotal: '1234.00',
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const baseQuote: QuoteDetailData['quote'] = {
+  id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+  currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '1234.00', taxRate: null,
+  taxTotal: '0.00', total: '1234.00', oneTimeTotal: '1234.00', monthlyRecurringTotal: '0.00',
+  annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+  termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+  convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+  createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const detailWith = (lines: QuoteDetailData['lines']): QuoteDetailData => ({
+  quote: baseQuote, blocks: [block], lines,
+});
+
+const updateLineMock = vi.mocked(updateLine);
+
+describe('QuoteLineRows — money-formatted price/cost inputs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    updateLineMock.mockResolvedValue(
+      { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+    );
+  });
+
+  it('unit price renders currency-formatted while blurred and the raw decimal while focused', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-block-add-line-toggle-blk-1'));
+
+    const priceEl = screen.getByTestId('quote-line-price-line-1') as HTMLInputElement;
+    expect(priceEl.value).toBe('$1,234.00');
+
+    fireEvent.focus(priceEl);
+    expect(priceEl.value).toBe('1234.00');
+  });
+
+  it('commits the typed value on blur and reformats back to currency', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-block-add-line-toggle-blk-1'));
+
+    const priceEl = screen.getByTestId('quote-line-price-line-1') as HTMLInputElement;
+    fireEvent.focus(priceEl);
+    fireEvent.change(priceEl, { target: { value: '75' } });
+    expect(priceEl.value).toBe('75'); // still raw while focused
+    fireEvent.blur(priceEl);
+
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitPrice: 75 }));
+    expect(priceEl.value).toBe('$75.00'); // reformatted once unfocused
+  });
+
+  it('internal cost input formats the same way once the band is expanded', async () => {
+    render(<QuoteEditor detail={detailWith([{ ...baseLine, unitCost: '100.00' }])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-block-add-line-toggle-blk-1'));
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+    fireEvent.click(screen.getByTestId('quote-line-internal-toggle-line-1'));
+
+    const costEl = screen.getByTestId('quote-line-cost-line-1') as HTMLInputElement;
+    expect(costEl.value).toBe('$100.00');
+    fireEvent.focus(costEl);
+    expect(costEl.value).toBe('100.00');
+    fireEvent.blur(costEl);
+    expect(costEl.value).toBe('$100.00');
+  });
+
+  it('sanitizes garbage keystrokes so a non-numeric value can never commit', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-block-add-line-toggle-blk-1'));
+
+    const priceEl = screen.getByTestId('quote-line-price-line-1') as HTMLInputElement;
+    fireEvent.focus(priceEl);
+    // Letters around a real number are stripped rather than rejecting the
+    // whole keystroke — the digits/decimal point the user typed survive.
+    fireEvent.change(priceEl, { target: { value: 'abc123.45xyz' } });
+    expect(priceEl.value).toBe('123.45');
+    fireEvent.blur(priceEl);
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitPrice: 123.45 }));
+  });
+
+  it('a lone decimal point (no digits) is rejected on blur with no PATCH and no NaN in the field', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-block-add-line-toggle-blk-1'));
+
+    const priceEl = screen.getByTestId('quote-line-price-line-1') as HTMLInputElement;
+    fireEvent.focus(priceEl);
+    fireEvent.change(priceEl, { target: { value: '.' } });
+    fireEvent.blur(priceEl);
+
+    await waitFor(() => expect(screen.getByTestId('quote-line-price-error-line-1')).toBeInTheDocument());
+    expect(updateLineMock).not.toHaveBeenCalled();
+    // Rejected entry stays visible (raw, not "NaN" or a silently-formatted
+    // "$0.00") so the user can see and correct it.
+    expect(priceEl.value).toBe('.');
+  });
+
+  it('grows the input width for a long (7-digit) price instead of clipping it', async () => {
+    render(<QuoteEditor detail={detailWith([{ ...baseLine, unitPrice: '1234567.89', lineTotal: '1234567.89' }])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-block-add-line-toggle-blk-1'));
+
+    const priceEl = screen.getByTestId('quote-line-price-line-1') as HTMLInputElement;
+    // Unfocused display "$1,234,567.89" is 14 characters — width must grow well
+    // past the old fixed w-24 (~12ch) to avoid clipping the formatted value.
+    const widthCh = parseInt(priceEl.style.width, 10);
+    expect(widthCh).toBeGreaterThanOrEqual(14);
+  });
+
+  it('grows the markup input width for a longer value like "155.1"', async () => {
+    render(<QuoteEditor detail={detailWith([{ ...baseLine, unitCost: '100.00', unitPrice: '255.10' }])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-block-add-line-toggle-blk-1'));
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+    fireEvent.click(screen.getByTestId('quote-line-internal-toggle-line-1'));
+
+    const markupEl = screen.getByTestId('quote-line-markup-line-1') as HTMLInputElement;
+    expect(markupEl.value).toBe('155.1'); // (255.10-100)/100
+    const widthCh = parseInt(markupEl.style.width, 10);
+    expect(widthCh).toBeGreaterThanOrEqual(7); // > the old fixed w-16 (~8ch) floor for short values
+  });
+
+  it('ghost-row price formats on blur and shows the raw decimal while focused', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('quote-ghost-name-blk-1'), { target: { value: 'Backup agent' } });
+    const ghostPrice = screen.getByTestId('quote-ghost-price-blk-1') as HTMLInputElement;
+    fireEvent.focus(ghostPrice);
+    fireEvent.change(ghostPrice, { target: { value: '2500' } });
+    expect(ghostPrice.value).toBe('2500'); // raw while focused
+    fireEvent.blur(ghostPrice);
+    expect(ghostPrice.value).toBe('$2,500.00'); // formatted once unfocused
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.polish.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.polish.test.tsx
@@ -1,0 +1,188 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData, QuoteBlock, QuoteLine } from './quoteTypes';
+
+// Task F of the quote-editor UX follow-up pass ("polish sweep"): the ADD
+// SECTION heading-text gating, per-block sticky column headers, SKU/PN help
+// text, and the Alt+ArrowDown/Up block-jump shortcut.
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+  polishTextRequest: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  updateBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  reorderBlocks: vi.fn(),
+  reorderLines: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  addQuoteImageFromUrl: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const quote: QuoteDetailData['quote'] = {
+  id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+  currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '10.00', taxRate: null,
+  taxTotal: '0.00', total: '10.00', oneTimeTotal: '10.00', monthlyRecurringTotal: '0.00',
+  annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+  termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+  convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+  createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const mkTable = (id: string, sortOrder: number, label?: string): QuoteBlock => ({
+  id, quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: label ? { label } : {}, sortOrder, createdAt: '2026-06-01T00:00:00Z',
+});
+const mkHeading = (id: string, sortOrder: number, text: string): QuoteBlock => ({
+  id, quoteId: 'q-1', orgId: 'org-1', blockType: 'heading',
+  content: { text, level: 2 }, sortOrder, createdAt: '2026-06-01T00:00:00Z',
+});
+const mkLine = (id: string, blockId: string, sortOrder: number, overrides: Partial<QuoteLine> = {}): QuoteLine => ({
+  id, quoteId: 'q-1', blockId, orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, imageId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+  name: 'Widget', description: null, quantity: '1.00', unitPrice: '10.00', taxable: false,
+  customerVisible: true, lineTotal: '10.00', recurrence: 'one_time', termMonths: null,
+  billingFrequency: null, sortOrder, createdAt: '2026-06-01T00:00:00Z', ...overrides,
+});
+
+const emptyDetail: QuoteDetailData = { quote, blocks: [], lines: [] };
+
+const onePricingBlock: QuoteDetailData = {
+  quote,
+  blocks: [mkTable('blk-1', 0, 'Services')],
+  lines: [mkLine('l-1', 'blk-1', 0)],
+};
+
+const threeBlocks: QuoteDetailData = {
+  quote,
+  blocks: [mkTable('blk-1', 0, 'Services'), mkHeading('blk-2', 1, 'Summary'), mkTable('blk-3', 2)],
+  lines: [mkLine('l-1', 'blk-1', 0), mkLine('l-3', 'blk-3', 1)],
+};
+
+describe('QuoteEditor — ADD SECTION heading-text gating', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows the heading-text input for the default "Heading" chip', async () => {
+    render(<QuoteEditor detail={emptyDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-block-heading-text')).toBeInTheDocument();
+  });
+
+  it('hides the heading-text input for every other block type', async () => {
+    render(<QuoteEditor detail={emptyDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    for (const type of ['rich_text', 'image', 'line_items', 'contract']) {
+      fireEvent.click(screen.getByTestId(`quote-add-block-type-${type}`));
+      expect(screen.queryByTestId('quote-block-heading-text')).not.toBeInTheDocument();
+    }
+  });
+});
+
+describe('QuoteEditor — sticky per-block column headers', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('pins the header row (sticky + solid background) above the scrolling rows', async () => {
+    render(<QuoteEditor detail={onePricingBlock} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-block-lines-blk-1')).toBeInTheDocument());
+
+    const table = screen.getByTestId('quote-block-lines-blk-1');
+    const headerCells = table.querySelectorAll('thead th');
+    expect(headerCells.length).toBeGreaterThan(0);
+    headerCells.forEach((th) => {
+      expect(th.className).toMatch(/\bsticky\b/);
+      expect(th.className).toMatch(/\btop-0\b/);
+      expect(th.className).toMatch(/\bbg-card\b/);
+    });
+  });
+});
+
+describe('QuoteEditor — SKU vs PN help text', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('gives the SKU and PN inputs distinct, discoverable tooltips (not identical text)', async () => {
+    render(<QuoteEditor detail={onePricingBlock} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-line-l-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-line-internal-toggle-l-1'));
+    const skuInput = screen.getByTestId('quote-line-sku-l-1');
+    const pnInput = screen.getByTestId('quote-line-partnumber-l-1');
+
+    expect(skuInput.getAttribute('title')).toBeTruthy();
+    expect(pnInput.getAttribute('title')).toBeTruthy();
+    expect(skuInput.getAttribute('title')).not.toEqual(pnInput.getAttribute('title'));
+
+    // aria-describedby resolves to a real, non-empty node for screen readers too.
+    const skuHelpId = skuInput.getAttribute('aria-describedby')?.split(' ')[0];
+    const pnHelpId = pnInput.getAttribute('aria-describedby')?.split(' ')[0];
+    expect(skuHelpId && document.getElementById(skuHelpId)?.textContent).toBeTruthy();
+    expect(pnHelpId && document.getElementById(pnHelpId)?.textContent).toBeTruthy();
+  });
+});
+
+describe('QuoteEditor — Alt+ArrowDown/Up block-jump shortcut', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('Alt+ArrowDown from the first block focuses the next block container', async () => {
+    render(<QuoteEditor detail={threeBlocks} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    screen.getByTestId('quote-block-container-blk-1').focus();
+    fireEvent.keyDown(screen.getByTestId('quote-block-container-blk-1'), { key: 'ArrowDown', altKey: true });
+
+    expect(document.activeElement).toBe(screen.getByTestId('quote-block-container-blk-2'));
+  });
+
+  it('Alt+ArrowUp moves back to the previous block', async () => {
+    render(<QuoteEditor detail={threeBlocks} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    screen.getByTestId('quote-block-container-blk-2').focus();
+    fireEvent.keyDown(screen.getByTestId('quote-block-container-blk-2'), { key: 'ArrowUp', altKey: true });
+
+    expect(document.activeElement).toBe(screen.getByTestId('quote-block-container-blk-1'));
+  });
+
+  it('a bare (non-Alt) arrow key inside a name input is left alone — never hijacked', async () => {
+    render(<QuoteEditor detail={threeBlocks} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-line-l-1')).toBeInTheDocument());
+
+    const nameInput = screen.getByTestId('quote-line-name-l-1');
+    nameInput.focus();
+    fireEvent.keyDown(nameInput, { key: 'ArrowDown' });
+
+    // Focus never jumps away from the input the user is typing in.
+    expect(document.activeElement).toBe(nameInput);
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.removeblock.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.removeblock.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import QuoteEditor from './QuoteEditor';
 import * as quotesApi from '../../../lib/api/quotes';
 import type { QuoteBlock, QuoteDetail as QuoteDetailData, QuoteLine } from './quoteTypes';
 import { fetchWithAuth } from '../../../stores/auth';
+import { showToast } from '../../shared/Toast';
 
 vi.mock('../../../stores/auth', () => ({
   // orgStore (imported by QuoteEditor for the customer select) registers an
@@ -91,9 +92,36 @@ describe('QuoteEditor — block removal', () => {
     expect(deleteBlock).not.toHaveBeenCalled();
   });
 
-  it('deletes the block only after the confirm step', async () => {
+  it('deletes the block only after the confirm step (deferred through the undo grace window)', async () => {
+    // Confirm hides the section immediately but DEFERS the DELETE for the
+    // undo grace window — advance fake timers to flush it.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const deleteBlock = vi.mocked(quotesApi.deleteBlock);
+      deleteBlock.mockResolvedValue(json({ data: null }));
+
+      render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('quote-block-actions-blk-1'));
+      fireEvent.click(screen.getByTestId('quote-block-remove-blk-1'));
+      fireEvent.click(await screen.findByTestId('quote-block-remove-confirm'));
+
+      // Optimistically gone (its lines with it), but nothing sent yet.
+      expect(screen.queryByTestId('quote-block-container-blk-1')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('quote-line-l-1')).not.toBeInTheDocument();
+      expect(deleteBlock).not.toHaveBeenCalled();
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(6000); });
+      expect(deleteBlock).toHaveBeenCalledWith('q-1', 'blk-1');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('undo within the grace window restores the section without any DELETE', async () => {
     const deleteBlock = vi.mocked(quotesApi.deleteBlock);
-    deleteBlock.mockResolvedValue(json({ data: null }));
+    const showToastMock = vi.mocked(showToast);
 
     render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
@@ -101,7 +129,15 @@ describe('QuoteEditor — block removal', () => {
     fireEvent.click(screen.getByTestId('quote-block-actions-blk-1'));
     fireEvent.click(screen.getByTestId('quote-block-remove-blk-1'));
     fireEvent.click(await screen.findByTestId('quote-block-remove-confirm'));
+    expect(screen.queryByTestId('quote-block-container-blk-1')).not.toBeInTheDocument();
 
-    await waitFor(() => expect(deleteBlock).toHaveBeenCalledWith('q-1', 'blk-1'));
+    const undoCall = [...showToastMock.mock.calls].reverse()
+      .find((c) => (c[0] as { type: string }).type === 'undo');
+    expect(undoCall).toBeDefined();
+    act(() => { (undoCall![0] as { onUndo: () => void }).onUndo(); });
+
+    expect(screen.getByTestId('quote-block-container-blk-1')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-line-l-1')).toBeInTheDocument();
+    expect(deleteBlock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteEditor.structure.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.structure.test.tsx
@@ -1,0 +1,264 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { reorderLines } from '../../../lib/api/quotes';
+
+// Task 4 of the quote-editor UX pass: long-document navigation & structure —
+// the rail's "Contents" outline, collapsible pricing blocks, and row drag
+// handles that commit through the SAME reorder path as the ⋯ menu.
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+  catalogItemImagePath: vi.fn().mockReturnValue('/catalog/x/image'),
+}));
+
+const okResponse = () =>
+  ({ ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: { ok: true } }) } as unknown as Response);
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  removeLine: vi.fn(),
+  reorderBlocks: vi.fn(),
+  reorderLines: vi.fn(),
+  moveLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const mkTable = (id: string, sortOrder: number, label?: string): QuoteDetailData['blocks'][number] => ({
+  id, quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: label ? { label } : {}, sortOrder, createdAt: '2026-06-01T00:00:00Z',
+});
+const mkHeading = (id: string, sortOrder: number, text: string): QuoteDetailData['blocks'][number] => ({
+  id, quoteId: 'q-1', orgId: 'org-1', blockType: 'heading',
+  content: { text, level: 2 }, sortOrder, createdAt: '2026-06-01T00:00:00Z',
+});
+
+const mkLine = (
+  id: string, blockId: string, sortOrder: number, overrides: Partial<QuoteDetailData['lines'][number]> = {},
+): QuoteDetailData['lines'][number] => ({
+  id, quoteId: 'q-1', blockId, orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+  name: null, description: `Line ${id}`, quantity: '1.00',
+  unitPrice: '50.00', taxable: false, customerVisible: true, lineTotal: '50.00',
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder,
+  createdAt: '2026-06-01T00:00:00Z', ...overrides,
+});
+
+const quote: QuoteDetailData['quote'] = {
+  id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+  currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '150.00', taxRate: null,
+  taxTotal: '0.00', total: '150.00', oneTimeTotal: '150.00', monthlyRecurringTotal: '0.00',
+  annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+  termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+  convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+  createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+};
+
+// Three blocks (pricing / heading / unlabeled pricing) for outline + collapse.
+const threeBlocks: QuoteDetailData = {
+  quote,
+  blocks: [mkTable('blk-1', 0, 'Services'), mkHeading('blk-2', 1, 'Summary'), mkTable('blk-3', 2)],
+  lines: [mkLine('l-1', 'blk-1', 0), mkLine('l-2', 'blk-1', 1), mkLine('l-3', 'blk-3', 2)],
+};
+
+const onePanel: QuoteDetailData = {
+  quote,
+  blocks: [mkTable('blk-1', 0, 'Services')],
+  lines: [mkLine('l-1', 'blk-1', 0)],
+};
+
+const reorderLinesMock = vi.mocked(reorderLines);
+const dt = () => ({ setData: vi.fn(), effectAllowed: '' });
+
+describe('QuoteEditor — rail Contents outline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    state.permissions = [{ resource: '*', action: '*' }];
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('lists every block in document order, with authored labels and typed fallbacks', async () => {
+    render(<QuoteEditor detail={threeBlocks} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const outline = screen.getByTestId('quote-outline');
+    expect(outline.tagName).toBe('NAV');
+    expect(outline).toHaveAttribute('aria-label', 'Quote contents');
+    const items = within(outline).getAllByRole('button');
+    expect(items.map((b) => b.textContent)).toEqual(['Services', 'Summary', 'Pricing table 2']);
+  });
+
+  it('clicking an entry scrolls the block into view and moves focus to its container', async () => {
+    render(<QuoteEditor detail={threeBlocks} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-outline-item-blk-2'));
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    expect(document.activeElement).toBe(screen.getByTestId('quote-block-container-blk-2'));
+  });
+
+  it('does not render with a single block', async () => {
+    render(<QuoteEditor detail={onePanel} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.queryByTestId('quote-outline')).not.toBeInTheDocument();
+  });
+});
+
+describe('QuoteEditor — collapsible pricing blocks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    state.permissions = [{ resource: '*', action: '*' }];
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('collapsing hides the lines (inert body) and shows label + line count + subtotal', async () => {
+    render(<QuoteEditor detail={threeBlocks} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const toggle = screen.getByTestId('quote-block-collapse-blk-1');
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('quote-block-body-blk-1')).toHaveAttribute('aria-hidden', 'false');
+    expect(screen.queryByTestId('quote-block-collapsed-summary-blk-1')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    const body = screen.getByTestId('quote-block-body-blk-1');
+    expect(body).toHaveAttribute('aria-hidden', 'true');
+    // Content stays MOUNTED (state survives) but is out of the a11y tree.
+    expect(within(body).getByTestId('quote-line-qty-l-1')).toBeInTheDocument();
+    // Compact summary: label + line count + block subtotal (2 × $50.00).
+    const summary = screen.getByTestId('quote-block-collapsed-summary-blk-1');
+    expect(summary).toHaveTextContent('Services');
+    expect(summary).toHaveTextContent('2 lines · $100.00');
+
+    // Expanding restores the body.
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('quote-block-body-blk-1')).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('a block with dirty (uncommitted) line edits refuses to collapse', async () => {
+    render(<QuoteEditor detail={threeBlocks} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    // Dirty a line: the draft reaches the parent, which pins the block open.
+    fireEvent.change(screen.getByTestId('quote-line-qty-l-1'), { target: { value: '3' } });
+
+    const toggle = screen.getByTestId('quote-block-collapse-blk-1');
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('quote-block-body-blk-1')).toHaveAttribute('aria-hidden', 'false');
+    expect(screen.queryByTestId('quote-block-collapsed-summary-blk-1')).not.toBeInTheDocument();
+
+    // A sibling block without dirty edits still collapses.
+    fireEvent.click(screen.getByTestId('quote-block-collapse-blk-3'));
+    expect(screen.getByTestId('quote-block-body-blk-3')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('a missing-cost reveal expands a collapsed block, then the line band, then focuses the cost input', async () => {
+    render(<QuoteEditor detail={threeBlocks} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+
+    // Collapse the block that holds the first offender (l-1 has no cost).
+    fireEvent.click(screen.getByTestId('quote-block-collapse-blk-1'));
+    expect(screen.getByTestId('quote-block-body-blk-1')).toHaveAttribute('aria-hidden', 'true');
+
+    fireEvent.click(screen.getByTestId('quote-margin-missing-cost'));
+
+    // Block expands first, then the internal band, then focus lands.
+    await waitFor(() => expect(screen.getByTestId('quote-block-body-blk-1')).toHaveAttribute('aria-hidden', 'false'));
+    await waitFor(() => expect(screen.getByTestId('quote-line-internal-toggle-l-1')).toHaveAttribute('aria-expanded', 'true'));
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByTestId('quote-line-cost-l-1')));
+  });
+});
+
+describe('QuoteEditor — line drag-to-reorder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    state.permissions = [{ resource: '*', action: '*' }];
+    reorderLinesMock.mockResolvedValue(okResponse());
+  });
+
+  it('drop gaps only exist mid-drag; a drop commits the same reorderLines PATCH as the menu move', async () => {
+    render(<QuoteEditor detail={threeBlocks} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    // No gaps at rest.
+    expect(screen.queryByTestId('quote-line-drop-gap-blk-1-0')).not.toBeInTheDocument();
+
+    const handle = screen.getByTestId('quote-line-drag-l-1');
+    fireEvent.dragStart(handle, { dataTransfer: dt() });
+
+    // Gaps appear: one above each row + one after the last (indexes 0..2).
+    const gap = screen.getByTestId('quote-line-drop-gap-blk-1-2');
+    fireEvent.dragOver(gap, { dataTransfer: dt() });
+    fireEvent.drop(gap, { dataTransfer: dt() });
+
+    // Same persistence path as the ⋯ menu's Move up/down: full id list to
+    // reorderLines (debounced), l-1 dropped after l-2.
+    await waitFor(() => expect(reorderLinesMock).toHaveBeenCalledWith('q-1', 'blk-1', { lineIds: ['l-2', 'l-1'] }));
+    // Optimistic: the drag handle's row now renders after l-2 in the table.
+    const table = screen.getByTestId('quote-block-lines-blk-1');
+    const rows = within(table).getAllByTestId(/^quote-line-(l-1|l-2)$/);
+    expect(rows.map((r) => r.getAttribute('data-testid'))).toEqual(['quote-line-l-2', 'quote-line-l-1']);
+    // Gaps are gone after the drop.
+    expect(screen.queryByTestId('quote-line-drop-gap-blk-1-0')).not.toBeInTheDocument();
+  });
+
+  it('a drop back into the same slot sends nothing', async () => {
+    render(<QuoteEditor detail={threeBlocks} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.dragStart(screen.getByTestId('quote-line-drag-l-1'), { dataTransfer: dt() });
+    const gap = screen.getByTestId('quote-line-drop-gap-blk-1-0');
+    fireEvent.dragOver(gap, { dataTransfer: dt() });
+    fireEvent.drop(gap, { dataTransfer: dt() });
+
+    await new Promise((r) => setTimeout(r, 400)); // outlive the 250ms debounce
+    expect(reorderLinesMock).not.toHaveBeenCalled();
+  });
+
+  it('read-only rows render no drag handle', async () => {
+    state.permissions = [{ resource: 'quotes', action: 'read' }];
+    render(<QuoteEditor detail={threeBlocks} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    // Rows render (read-only variant) with no drag affordance.
+    expect(screen.getByTestId('quote-line-l-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('quote-line-drag-l-1')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.subtotalrow.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.subtotalrow.test.tsx
@@ -1,0 +1,117 @@
+// "Show subtotal row" previously only affected the customer-facing
+// document/PDF — checking it in the editor had no visible effect in the
+// expanded pricing table itself. This covers the editor-side footer row that
+// mirrors the toggle (QuoteBlockCard.tsx), independent of QuoteDocument's own
+// subtotal row (covered by QuoteDocument.test.tsx).
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  updateBlock: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn(),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const baseQuote: QuoteDetailData['quote'] = {
+  id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+  currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '150.00', taxRate: null,
+  taxTotal: '0.00', total: '150.00', oneTimeTotal: '150.00', monthlyRecurringTotal: '0.00',
+  annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+  termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+  convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+  createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const lines: QuoteDetailData['lines'] = [
+  {
+    id: 'line-1', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+    catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+    name: null, description: 'Managed support', quantity: '1.00',
+    unitPrice: '100.00', taxable: false, customerVisible: true, lineTotal: '100.00',
+    recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 0,
+    createdAt: '2026-06-01T00:00:00Z',
+  },
+  {
+    id: 'line-2', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+    catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+    name: null, description: 'Setup fee', quantity: '1.00',
+    unitPrice: '50.00', taxable: false, customerVisible: true, lineTotal: '50.00',
+    recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 1,
+    createdAt: '2026-06-01T00:00:00Z',
+  },
+];
+
+function detailWithSubtotal(showSubtotal: boolean | undefined): QuoteDetailData {
+  return {
+    quote: baseQuote,
+    blocks: [{
+      id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+      content: { label: 'Monthly services', ...(showSubtotal === undefined ? {} : { showSubtotal }) },
+      sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+    }],
+    lines,
+  };
+}
+
+describe('QuoteEditor — pricing-table subtotal footer row', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders a subtotal footer summing the block\'s line totals when the toggle is checked', async () => {
+    render(<QuoteEditor detail={detailWithSubtotal(true)} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const checkbox = screen.getByTestId('quote-block-subtotal-toggle-blk-1') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+
+    const row = screen.getByTestId('quote-block-subtotal-row-blk-1');
+    expect(row).toHaveTextContent('$150.00'); // 100.00 + 50.00
+  });
+
+  it('hides the footer row when the toggle is unchecked', async () => {
+    render(<QuoteEditor detail={detailWithSubtotal(false)} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    expect((screen.getByTestId('quote-block-subtotal-toggle-blk-1') as HTMLInputElement).checked).toBe(false);
+    expect(screen.queryByTestId('quote-block-subtotal-row-blk-1')).not.toBeInTheDocument();
+  });
+
+  it('hides the footer row by default (content carries no showSubtotal key)', async () => {
+    render(<QuoteEditor detail={detailWithSubtotal(undefined)} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('quote-block-subtotal-row-blk-1')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.totalsstack.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.totalsstack.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+
+// Task A of the quote-editor UX follow-up pass: a Subtotal → Tax → Total stack
+// in the rail (Total visually dominant, One-time explicitly labeled pre-tax),
+// mirrored as a Total figure in the `quote-totals-sticky` mobile bar.
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn(),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const block: QuoteDetailData['blocks'][number] = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: { label: 'Services' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+
+const baseLine: QuoteDetailData['lines'][number] = {
+  id: 'line-1', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+  name: null, description: 'Setup', quantity: '1.00',
+  unitPrice: '500.00', taxable: true, customerVisible: true, lineTotal: '500.00',
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const baseQuote: QuoteDetailData['quote'] = {
+  id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+  currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '500.00', taxRate: '0.1',
+  taxTotal: '50.00', total: '550.00', oneTimeTotal: '500.00', monthlyRecurringTotal: '0.00',
+  annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '550.00', billToName: null, introNotes: null,
+  terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+  convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+  createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const detailWith = (lines: QuoteDetailData['lines'], quoteOverride: Partial<QuoteDetailData['quote']> = {}): QuoteDetailData => ({
+  quote: { ...baseQuote, ...quoteOverride }, blocks: [block], lines,
+});
+
+describe('QuoteEditor — rail grand-total stack (Subtotal → Tax → Total)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders Subtotal, Tax, and a visually dominant Total with correct values; labels One-time as pre-tax', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    expect(screen.getByTestId('quote-total-onetime')).toHaveTextContent('$500.00');
+    expect(screen.getByText('One-time (pre-tax)')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-total-subtotal')).toHaveTextContent('$500.00');
+    expect(screen.getByTestId('quote-total-tax')).toHaveTextContent('$50.00');
+    expect(screen.getByTestId('quote-total-grand')).toHaveTextContent('$550.00');
+
+    // Total is the dominant figure in the stack — bold + larger than the
+    // Subtotal/Tax rows above it.
+    expect(screen.getByTestId('quote-total-grand').closest('div')).toHaveClass('font-semibold');
+  });
+
+  it('labels Subtotal/Total as bare "Subtotal"/"Total" for a one-time-only quote (no recurring)', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    // "Total" bare-text also appears as the line-items table's column header
+    // (Item/Qty/…/Total), so scope the label lookup to the sibling <dt> of the
+    // testid'd row rather than a page-wide text search.
+    expect(screen.getByTestId('quote-total-subtotal').closest('div')?.querySelector('dt')).toHaveTextContent('Subtotal');
+    expect(screen.getByTestId('quote-total-grand').closest('div')?.querySelector('dt')).toHaveTextContent('Total');
+  });
+
+  it('relabels Subtotal/Total as "First period …" once a recurring cadence is mixed in, matching the customer document', async () => {
+    const monthlyLine: QuoteDetailData['lines'][number] = {
+      ...baseLine, id: 'line-2', recurrence: 'monthly', taxable: false, unitPrice: '50.00', lineTotal: '50.00',
+    };
+    const detail = detailWith([baseLine, monthlyLine], {
+      subtotal: '550.00', total: '600.00', monthlyRecurringTotal: '50.00',
+    });
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    expect(screen.getByTestId('quote-total-subtotal').closest('div')?.querySelector('dt')).toHaveTextContent('First period subtotal');
+    expect(screen.getByTestId('quote-total-subtotal')).toHaveTextContent('$550.00');
+    expect(screen.getByTestId('quote-total-grand')).toHaveTextContent('$600.00');
+  });
+
+  it('is div-by-zero safe for an empty (all-zero) quote — no NaN, no crash', async () => {
+    const detail = detailWith([], {
+      subtotal: '0.00', taxTotal: '0.00', total: '0.00', taxRate: null,
+      oneTimeTotal: '0.00', dueOnAcceptanceTotal: '0.00',
+    });
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    expect(screen.getByTestId('quote-total-subtotal')).toHaveTextContent('$0.00');
+    expect(screen.getByTestId('quote-total-grand')).toHaveTextContent('$0.00');
+    // No tax rate set and no tax owed → the Tax row stays silent (matches the
+    // pre-existing zero-value-cadence convention for the other rows).
+    expect(screen.queryByTestId('quote-total-tax')).not.toBeInTheDocument();
+    expect(screen.getByTestId('quote-editor')).not.toHaveTextContent('NaN');
+  });
+
+  it('mirrors the Total figure in the quote-totals-sticky mobile bar', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    const sticky = screen.getByTestId('quote-totals-sticky');
+    expect(sticky).toContainElement(screen.getByTestId('quote-totals-sticky-total'));
+    expect(screen.getByTestId('quote-totals-sticky-total')).toHaveTextContent('$550.00');
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -32,8 +32,11 @@ import { computeQuoteTotals, computeQuoteProfit, toQuoteDepositConfig, type Quot
 import { listCatalog, createCatalogItem, type CatalogItem } from '../../../lib/api/catalog';
 import { ecExpressStatus, ecExpressImport, type EcProduct, type EcStatus, pax8Status, pax8Import, type Pax8Product, type Pax8PriceOption } from '../../../lib/api/distributors';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
+import { showToast } from '../../shared/Toast';
 import RichTextEditor from '../../common/RichTextEditor';
+import PolishButton from '../../catalog/PolishButton';
 import { BlockCard, QuoteImagePreview } from './QuoteBlockCard';
+import { UnassignedLines } from './QuoteUnassignedLines';
 import { UNAUTHORIZED, type LineUpdate, SrSaved, fieldRing, pendingKey, useSavedFlash } from './quoteEditorShared';
 import { useMenuKeyboard } from '../shared/menuKeyboard';
 import { UnsavedBadge, RecurringBillingNote, MarginPanel } from '../billingUi';
@@ -116,6 +119,10 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
   }, []);
   const { quote, blocks, lines } = detail;
   const currency = quote.currencyCode;
+  // Rows only repeat the '/mo' | '/yr' cadence suffix when the quote actually
+  // mixes cadences — on a uniform quote the suffix is per-line noise (the rail
+  // totals and each editable row's recurrence select still carry the cadence).
+  const mixedCadence = useMemo(() => new Set(lines.map((l) => l.recurrence)).size > 1, [lines]);
   // Focus anchor: after a confirmed block/line removal the triggering button is
   // gone, so we move focus here instead of letting it fall to <body> (which dumps
   // a keyboard user to the top of the page).
@@ -202,6 +209,16 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
     document.addEventListener('keydown', onKey);
     return () => { document.removeEventListener('mousedown', onDown); document.removeEventListener('keydown', onKey); };
   }, [blockMenu]);
+
+  // "Tidy all descriptions" (block kebab menu, pricing blocks only): queues the
+  // SAME per-line PolishButton preview+fact-guard flow across every line with a
+  // description, one dialog at a time — never applies without the user
+  // approving each preview. `tidyQueue` holds the remaining line ids for
+  // `tidyBlockId`; the invisible driver below (autoRun + hideTrigger, remounted
+  // per line via `key`) fires the next preview and `onSettled` advances the
+  // queue once the user approves or cancels.
+  const [tidyBlockId, setTidyBlockId] = useState<string | null>(null);
+  const [tidyQueue, setTidyQueue] = useState<string[]>([]);
 
   const [headingText, setHeadingText] = useState('');
   const [richText, setRichText] = useState('');
@@ -659,6 +676,146 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
       ),
     [lines, lineOrder, lineBlockOverride],
   );
+
+  // Kicks off the "Tidy all descriptions" queue for one block. Only lines that
+  // currently have a description are queued — an empty description would just
+  // hit PolishButton's "enter text first" guard for nothing. `tidyTotalRef`
+  // remembers how many were queued so the completion toast can report a count
+  // after `tidyQueue` has drained to empty.
+  const tidyTotalRef = useRef(0);
+  const startTidyAll = useCallback((blockId: string) => {
+    const ids = linesForBlock(blockId)
+      .filter((l) => (l.description ?? '').trim())
+      .map((l) => l.id);
+    if (ids.length === 0) {
+      showToast({ message: t('quotes.editor.tidyAll.noDescriptions'), type: 'warning' });
+      return;
+    }
+    tidyTotalRef.current = ids.length;
+    setTidyBlockId(blockId);
+    setTidyQueue(ids);
+  }, [linesForBlock, t]);
+
+  // Drop a queued line id that no longer exists (e.g. removed mid-tidy) without
+  // opening a preview for it.
+  useEffect(() => {
+    if (tidyQueue.length === 0) return;
+    if (!lines.some((l) => l.id === tidyQueue[0])) setTidyQueue((q) => q.slice(1));
+  }, [tidyQueue, lines]);
+
+  // Completion toast once the queue fully drains.
+  useEffect(() => {
+    if (tidyBlockId !== null && tidyQueue.length === 0) {
+      setTidyBlockId(null);
+      showToast({ message: t('quotes.editor.tidyAll.complete', { count: tidyTotalRef.current }), type: 'success' });
+    }
+  }, [tidyBlockId, tidyQueue, t]);
+
+  // ---- document outline (rail "Contents") ---------------------------------
+  // A quiet block-level nav for long quotes: each entry jumps to (and focuses)
+  // its block. Labels mirror what the canvas shows — the author's own text
+  // where one exists (table label, heading text, contract label), else the
+  // block-type default the add menu uses. Only rendered with 2+ blocks: a
+  // one-block quote has nothing to navigate.
+  const blockContainerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const setBlockContainerRef = useCallback((blockId: string, el: HTMLDivElement | null) => {
+    if (el) blockContainerRefs.current.set(blockId, el);
+    else blockContainerRefs.current.delete(blockId);
+  }, []);
+  const outlineLabel = useCallback((b: QuoteBlock): string => {
+    if (b.blockType === 'line_items') return pricingBlockLabel(b);
+    if (b.blockType === 'heading') {
+      const text = ((b.content?.text as string | undefined) ?? '').trim();
+      return text || t('quotes.editor.blockTypes.heading');
+    }
+    if (b.blockType === 'contract') {
+      const label = ((b.content?.label as string | undefined) ?? '').trim();
+      return label || t('quotes.editor.blockTypes.contract');
+    }
+    if (b.blockType === 'image') return t('quotes.editor.blockTypes.image');
+    return t('quotes.editor.blockTypes.richText');
+  }, [pricingBlockLabel, t]);
+  // Scroll-position highlight: the outline marks the topmost block currently in
+  // the viewport. IntersectionObserver is feature-detected — in jsdom (and any
+  // environment without it) the outline simply renders with no active entry.
+  const [activeOutlineId, setActiveOutlineId] = useState<string | null>(null);
+  const visibleBlockIds = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (typeof IntersectionObserver === 'undefined') return; // graceful no-op (jsdom)
+    const idsInOrder = sortedBlocks.map((b) => b.id);
+    const io = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        const id = (entry.target as HTMLElement).dataset.outlineBlockId;
+        if (!id) continue;
+        if (entry.isIntersecting) visibleBlockIds.current.add(id);
+        else visibleBlockIds.current.delete(id);
+      }
+      setActiveOutlineId(idsInOrder.find((id) => visibleBlockIds.current.has(id)) ?? null);
+    });
+    for (const id of idsInOrder) {
+      const el = blockContainerRefs.current.get(id);
+      if (el) io.observe(el);
+    }
+    return () => { io.disconnect(); visibleBlockIds.current.clear(); };
+  }, [sortedBlocks]);
+  // Jump: smooth-scroll the block into view (instant under reduced motion) and
+  // move focus to the block container (tabIndex=-1) so a keyboard/SR user's
+  // reading position follows the visual jump.
+  const jumpToBlock = useCallback((blockId: string) => {
+    const el = blockContainerRefs.current.get(blockId);
+    if (!el) return;
+    const reduceMotion = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    el.scrollIntoView?.({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
+    el.focus({ preventScroll: true });
+  }, []);
+
+  // Orphan lines: `block_id` is nullable, and `linesForBlock` can never surface
+  // them (a null blockId matches no block id, ever). They are NOT invisible to
+  // the customer — the PDF, the portal and the Preview all render them, and
+  // quoteMath counts them in every total — so the editor renders them in a
+  // dedicated bucket below the document (see UnassignedLines). An optimistic
+  // move writes a real block id into lineBlockOverride, which drops the line
+  // out of this list on the same tick it lands in its target panel.
+  const orphanLines = useMemo(
+    () =>
+      lines
+        .filter((l) => (lineBlockOverride[l.id] ?? l.blockId) === null)
+        .sort((a, b) => a.sortOrder - b.sortOrder),
+    [lines, lineBlockOverride],
+  );
+
+  // Reveal-on-demand plumbing for the rail's actionable "missing cost" notice
+  // (MarginPanel → here → QuoteLineRows): line ids missing a cost, filtered to
+  // customerVisible (mirroring computeQuoteProfit's own inclusion rule, so the
+  // reveal target is always one of the lines the count actually describes) and
+  // walked in the SAME document order the canvas renders — each pricing block
+  // in sortOrder, then that block's own line order. Orphan lines (rendered by
+  // UnassignedLines, a separate surface) are deliberately excluded: there is no
+  // reveal target there, so a click that lands on one just no-ops rather than
+  // throwing.
+  const missingCostLineIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const block of pricingBlocks) {
+      for (const l of linesForBlock(block.id)) {
+        if (!l.customerVisible) continue;
+        const cost = lineDrafts[l.id]?.unitCost ?? l.unitCost;
+        if (cost === null || cost === undefined || cost === '') ids.push(l.id);
+      }
+    }
+    return ids;
+  }, [pricingBlocks, linesForBlock, lineDrafts]);
+  // Bumps on every click so the SAME first offender can be re-revealed (e.g.
+  // the user scrolled away) — a repeated lineId alone wouldn't re-trigger the
+  // row's reveal effect.
+  const revealNonceRef = useRef(0);
+  const [revealRequest, setRevealRequest] = useState<{ lineId: string; nonce: number } | null>(null);
+  const revealFirstMissingCost = useCallback(() => {
+    const id = missingCostLineIds[0];
+    if (!id) return;
+    revealNonceRef.current += 1;
+    setRevealRequest({ lineId: id, nonce: revealNonceRef.current });
+  }, [missingCostLineIds]);
 
   // ---- add contract block --------------------------------------------------
   // Lazy-load the template library the first time the Contract add type opens,
@@ -1247,13 +1404,12 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
   }, [dragBlockId, sortedBlocks, quote.id, refresh, t]);
 
 
-  const moveLine = useCallback((blockId: string, line: QuoteLine, direction: 'up' | 'down') => {
-    const currentIds = lineReorderBase.current[blockId] ?? linesForBlock(blockId).map((l) => l.id);
-    const idx = currentIds.indexOf(line.id);
-    const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
-    if (idx < 0 || swapIdx < 0 || swapIdx >= currentIds.length) return;
-    const ids = [...currentIds];
-    [ids[idx], ids[swapIdx]] = [ids[swapIdx], ids[idx]];
+  // The ONE line-reorder persistence path: optimistic order + a debounced
+  // trailing PATCH per block (the server renumbers 0..n-1 from the full id
+  // list). Both the ⋯ menu's Move up/down (single-slot swap) and the row drag
+  // handle's drop (arbitrary splice) commit through here, so a failed reorder
+  // reverts identically regardless of which affordance drove it.
+  const commitLineOrder = useCallback((blockId: string, ids: string[]) => {
     lineReorderBase.current = { ...lineReorderBase.current, [blockId]: ids };
     setLineOrder((m) => ({ ...m, [blockId]: ids })); // optimistic, instant
     const existing = lineReorderTimers.current[blockId];
@@ -1276,7 +1432,32 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
         }
       })();
     }, 250);
-  }, [linesForBlock, quote.id, refresh, t]);
+  }, [quote.id, refresh, t]);
+
+  const moveLine = useCallback((blockId: string, line: QuoteLine, direction: 'up' | 'down') => {
+    const currentIds = lineReorderBase.current[blockId] ?? linesForBlock(blockId).map((l) => l.id);
+    const idx = currentIds.indexOf(line.id);
+    const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+    if (idx < 0 || swapIdx < 0 || swapIdx >= currentIds.length) return;
+    const ids = [...currentIds];
+    [ids[idx], ids[swapIdx]] = [ids[swapIdx], ids[idx]];
+    commitLineOrder(blockId, ids);
+  }, [linesForBlock, commitLineOrder]);
+
+  // Drag-to-reorder within one pricing table (HTML5 DnD on the row grip).
+  // `targetIdx` is the gap index the row was dropped into (0..n). Same splice
+  // arithmetic as commitBlockDrop; a no-op drop (same slot) sends nothing.
+  const dropLineInBlock = useCallback((blockId: string, dragLineId: string, targetIdx: number) => {
+    const currentIds = lineReorderBase.current[blockId] ?? linesForBlock(blockId).map((l) => l.id);
+    const from = currentIds.indexOf(dragLineId);
+    if (from < 0) return;
+    const ids = [...currentIds];
+    ids.splice(from, 1);
+    const to = targetIdx > from ? targetIdx - 1 : targetIdx;
+    ids.splice(Math.min(to, ids.length), 0, dragLineId);
+    if (ids.join() === currentIds.join()) return;
+    commitLineOrder(blockId, ids);
+  }, [linesForBlock, commitLineOrder]);
 
   // Cross-panel move: optimistic on both panels at once (the line leaves its
   // source table and appends to the target, bundle children in tow), committed
@@ -1284,32 +1465,48 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
   // is one discrete action. Failure reverts both panels and re-pulls the
   // authoritative server order (same recovery shape as moveBlock/moveLine).
   const moveLineTo = useCallback((line: QuoteLine, targetBlockId: string) => {
-    const sourceBlockId = line.blockId;
-    if (!sourceBlockId || sourceBlockId === targetBlockId) return;
+    // Null source = an ORPHAN line (block_id NULL) being adopted out of the
+    // Unassigned bucket. It has no source panel to re-order, so every
+    // source-side step below is skipped — but the target-side optimism, the
+    // PATCH and the revert path are identical, which is why this is the same
+    // handler rather than a parallel one that could drift from it.
+    const sourceBlockId = lineBlockOverride[line.id] ?? line.blockId;
+    if (sourceBlockId === targetBlockId) return;
     // A pending chevron-reorder PATCH for either panel would fire with a stale
     // id list that still contains the moved line — the server rejects it
     // (REORDER_IDS_MISMATCH) and its catch handler would then wipe this move's
     // optimistic order. Cancel those timers; the move's refresh() re-syncs
     // order from the server anyway.
     for (const bid of [sourceBlockId, targetBlockId]) {
+      if (!bid) continue;
       const t = lineReorderTimers.current[bid];
       if (t) { clearTimeout(t); delete lineReorderTimers.current[bid]; }
     }
     const movedIds = [line.id, ...lines.filter((l) => l.parentLineId === line.id).map((l) => l.id)];
-    const sourceIds = (lineReorderBase.current[sourceBlockId] ?? linesForBlock(sourceBlockId).map((l) => l.id))
-      .filter((id) => !movedIds.includes(id));
+    const sourceIds = sourceBlockId
+      ? (lineReorderBase.current[sourceBlockId] ?? linesForBlock(sourceBlockId).map((l) => l.id))
+        .filter((id) => !movedIds.includes(id))
+      : null;
     const targetIds = [
       ...(lineReorderBase.current[targetBlockId] ?? linesForBlock(targetBlockId).map((l) => l.id))
         .filter((id) => !movedIds.includes(id)),
       ...movedIds,
     ];
-    lineReorderBase.current = { ...lineReorderBase.current, [sourceBlockId]: sourceIds, [targetBlockId]: targetIds };
+    lineReorderBase.current = {
+      ...lineReorderBase.current,
+      ...(sourceBlockId && sourceIds ? { [sourceBlockId]: sourceIds } : {}),
+      [targetBlockId]: targetIds,
+    };
     setLineBlockOverride((m) => {
       const n = { ...m };
       for (const id of movedIds) n[id] = targetBlockId;
       return n;
     });
-    setLineOrder((m) => ({ ...m, [sourceBlockId]: sourceIds, [targetBlockId]: targetIds }));
+    setLineOrder((m) => ({
+      ...m,
+      ...(sourceBlockId && sourceIds ? { [sourceBlockId]: sourceIds } : {}),
+      [targetBlockId]: targetIds,
+    }));
     void (async () => {
       try {
         await runAction({
@@ -1326,13 +1523,18 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
           for (const id of movedIds) delete n[id];
           return n;
         });
-        setLineOrder((m) => { const n = { ...m }; delete n[sourceBlockId]; delete n[targetBlockId]; return n; });
-        delete lineReorderBase.current[sourceBlockId];
+        setLineOrder((m) => {
+          const n = { ...m };
+          if (sourceBlockId) delete n[sourceBlockId];
+          delete n[targetBlockId];
+          return n;
+        });
+        if (sourceBlockId) delete lineReorderBase.current[sourceBlockId];
         delete lineReorderBase.current[targetBlockId];
         refresh();
       }
     })();
-  }, [lines, linesForBlock, quote.id, refresh, t]);
+  }, [lines, lineBlockOverride, linesForBlock, quote.id, refresh, t]);
 
   const hasRecurring = Number(railMonthly) > 0 || Number(railAnnual) > 0;
 
@@ -1565,7 +1767,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                   (addType === 'contract' && !contractVersion)
                 }
                 data-testid="quote-add-block-submit"
-                className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                className="inline-flex h-9 items-center justify-center rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:opacity-50"
               >
                 {addType === 'image'
                   ? (imageSource === 'url' ? t('quotes.editor.actions.fetchAddImage') : t('quotes.editor.actions.uploadAddImage'))
@@ -1735,7 +1937,17 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                     />
                   )}
                   {canWrite && insertAt === idx && addSectionForm}
-                  <div className={`group/block relative ${dragBlockId === block.id ? 'opacity-40' : ''}`}>
+                  {/* tabIndex=-1 + ref: the rail outline's jump target — focus
+                      lands here so keyboard/SR reading position follows the
+                      scroll. data-outline-block-id feeds the outline's
+                      IntersectionObserver highlight. */}
+                  <div
+                    ref={(el) => setBlockContainerRef(block.id, el)}
+                    tabIndex={-1}
+                    data-outline-block-id={block.id}
+                    data-testid={`quote-block-container-${block.id}`}
+                    className={`group/block relative rounded-md focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${dragBlockId === block.id ? 'opacity-40' : ''}`}
+                  >
                     {canWrite && (
                       <div className="absolute -left-7 top-0.5 flex flex-col items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/block:opacity-100">
                         <button
@@ -1746,7 +1958,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                           aria-label={t('quotes.editor.actions.dragSection')}
                           title={t('quotes.editor.actions.dragSection')}
                           data-testid={`quote-block-drag-${block.id}`}
-                          className="inline-flex h-6 w-6 cursor-grab items-center justify-center rounded text-muted-foreground hover:bg-muted active:cursor-grabbing"
+                          className="inline-flex h-6 w-6 cursor-grab items-center justify-center rounded text-muted-foreground hover:bg-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
                         >
                           <GripVertical className="h-4 w-4" aria-hidden />
                         </button>
@@ -1763,7 +1975,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                           aria-expanded={blockMenu?.id === block.id}
                           aria-label={t('quotes.editor.actions.sectionActions')}
                           data-testid={`quote-block-actions-${block.id}`}
-                          className="inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted"
+                          className="inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
                         >
                           <MoreHorizontal className="h-4 w-4" aria-hidden />
                         </button>
@@ -1796,6 +2008,19 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                           >
                             {t('quotes.editor.actions.moveSectionDown')}
                           </button>
+                          {block.blockType === 'line_items' && (
+                            <div className="mt-1 border-t pt-1">
+                              <button
+                                type="button" role="menuitem" tabIndex={-1}
+                                disabled={tidyQueue.length > 0}
+                                onClick={() => { setBlockMenu(null); blockMenuTriggerRef.current?.focus(); startTidyAll(block.id); }}
+                                data-testid={`quote-block-tidy-all-${block.id}`}
+                                className="block w-full px-3 py-1.5 text-left text-sm hover:bg-muted focus:bg-muted focus:outline-hidden disabled:opacity-40"
+                              >
+                                {t('quotes.editor.actions.tidyAllDescriptions')}
+                              </button>
+                            </div>
+                          )}
                           <div className="mt-1 border-t pt-1">
                             <button
                               type="button" role="menuitem" tabIndex={-1}
@@ -1821,6 +2046,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                 isPending={isPending}
                 canWrite={canWrite}
                 showInternal={showInternal}
+                mixedCadence={mixedCadence}
                 depositSelectMode={depositSelectMode}
                 ecActive={ecActive}
                 pax8Active={pax8Active}
@@ -1840,6 +2066,9 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                 }
                 onRemoveLine={setPendingLineRemove}
                 onLineDraft={setLineDraft}
+                revealRequest={revealRequest}
+                hasDirtyLines={block.blockType === 'line_items' && linesForBlock(block.id).some((l) => l.id in lineDrafts)}
+                onDropLine={(dragLineId, targetIdx) => dropLineInBlock(block.id, dragLineId, targetIdx)}
               />
                   </div>
                 </Fragment>
@@ -1855,6 +2084,16 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                   onDrop={(e) => { e.preventDefault(); commitBlockDrop(sortedBlocks.length); }}
                 />
               )}
+              {/* Orphan bucket — lines with no pricing section. Rendered LAST,
+                  where the customer's document puts them ("Additional items" in
+                  the Preview / portal / PDF), and self-suppressing when empty. */}
+              <UnassignedLines
+                lines={orphanLines}
+                moveTargets={pricingBlocks.map((b) => ({ id: b.id, label: pricingBlockLabel(b) }))}
+                currency={currency}
+                canWrite={canWrite}
+                onMoveLineToBlock={moveLineTo}
+              />
             </div>
           </div>
 
@@ -1921,7 +2160,13 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                 ))}
               </div>
             )}
-            {canSeeMargin && showInternal && <MarginPanel profit={profit} currency={currency} />}
+            {canSeeMargin && showInternal && (
+              <MarginPanel
+                profit={profit}
+                currency={currency}
+                onMissingCostClick={missingCostLineIds.length > 0 ? revealFirstMissingCost : undefined}
+              />
+            )}
             {/* Read-only: the rate is resolved at quote creation (org tax settings,
                 falling back to the partner default) and isn't editable per-quote. */}
             <div className="mt-2 border-t pt-2">
@@ -2027,6 +2272,37 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
             )}
           </div>
 
+          {/* Contents outline — a quiet nav under the totals (the rail's primary
+              content). Only renders once there are 2+ blocks to navigate. */}
+          {sortedBlocks.length >= 2 && (
+            <nav
+              aria-label={t('quotes.editor.outline.aria')}
+              data-testid="quote-outline"
+              className="rounded-lg border bg-card p-3 shadow-xs"
+            >
+              <h2 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('quotes.editor.outline.title')}</h2>
+              <ul className="space-y-0.5">
+                {sortedBlocks.map((b) => (
+                  <li key={b.id}>
+                    <button
+                      type="button"
+                      onClick={() => jumpToBlock(b.id)}
+                      aria-current={activeOutlineId === b.id ? 'true' : undefined}
+                      data-testid={`quote-outline-item-${b.id}`}
+                      className={`block w-full truncate rounded px-1.5 py-0.5 text-left text-xs transition-colors duration-150 ease-out focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none ${
+                        activeOutlineId === b.id
+                          ? 'bg-muted font-medium text-foreground'
+                          : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                      }`}
+                    >
+                      {outlineLabel(b)}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          )}
+
           <div className="rounded-lg border bg-card p-4 shadow-xs">
             <div className="mb-2 flex items-center justify-between gap-2">
               <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('quotes.editor.terms.title')}</h2>
@@ -2080,6 +2356,32 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
           </span>
         )}
       </div>
+
+      {/* The "Tidy all descriptions" queue driver: an unattended PolishButton
+          instance (no visible trigger of its own) that fires its preview dialog
+          for the head of `tidyQueue`. Reusing PolishButton means the SAME
+          fact-guard + approve/cancel preview a tech gets from the per-line
+          button — nothing here applies AI output without that manual review.
+          Keyed by line id so each queue advance is a fresh mount (resets
+          PolishButton's internal state) and its mount-effect (`autoRun`) kicks
+          off the next request automatically. */}
+      {tidyQueue.length > 0 && (() => {
+        const tidyLine = lines.find((l) => l.id === tidyQueue[0]);
+        if (!tidyLine) return null;
+        return (
+          <PolishButton
+            key={tidyLine.id}
+            idSuffix={`quote-tidy-all-${tidyLine.id}`}
+            hideTrigger
+            autoRun
+            getText={() => ({ description: tidyLine.description })}
+            onApply={(r) => {
+              if (r.description !== null) void editLine(tidyLine.id, { description: r.description || null }, pendingKey.line(tidyLine.id));
+            }}
+            onSettled={() => setTidyQueue((q) => q.slice(1))}
+          />
+        );
+      })()}
 
       <ConfirmDialog
         open={pendingRemove !== null}

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -4,6 +4,7 @@ import { Eye, EyeOff, GripVertical, MoreHorizontal } from 'lucide-react';
 import '../../../lib/i18n';
 import { fetchWithAuth } from '../../../stores/auth';
 import { runAction, handleActionError, ActionError } from '../../../lib/runAction';
+import { formatTime } from '../../../lib/dateTimeFormat';
 import { usePermissions } from '../../../lib/permissions';
 import {
   addBlock,
@@ -28,7 +29,7 @@ import {
   type TemplateVersionSummary,
 } from '../../../lib/api/contractTemplates';
 import type { QuoteBlockInput, CoverPage } from '@breeze/shared';
-import { computeQuoteTotals, computeQuoteProfit, toQuoteDepositConfig, type QuoteLineForMath, type QuoteProfit, type QuoteTotals, type QuoteDepositType, type QuoteDepositConfig } from '@breeze/shared';
+import { computeQuoteTotals, computeQuoteProfit, priceFromMarkup, toQuoteDepositConfig, type QuoteLineForMath, type QuoteProfit, type QuoteTotals, type QuoteDepositType, type QuoteDepositConfig } from '@breeze/shared';
 import { listCatalog, createCatalogItem, type CatalogItem } from '../../../lib/api/catalog';
 import { ecExpressStatus, ecExpressImport, type EcProduct, type EcStatus, pax8Status, pax8Import, type Pax8Product, type Pax8PriceOption } from '../../../lib/api/distributors';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
@@ -36,6 +37,7 @@ import { showToast } from '../../shared/Toast';
 import RichTextEditor from '../../common/RichTextEditor';
 import PolishButton from '../../catalog/PolishButton';
 import { BlockCard, QuoteImagePreview } from './QuoteBlockCard';
+import { QuoteBulkBar } from './QuoteBulkBar';
 import { UnassignedLines } from './QuoteUnassignedLines';
 import { UNAUTHORIZED, type LineUpdate, SrSaved, fieldRing, pendingKey, useSavedFlash } from './quoteEditorShared';
 import { useMenuKeyboard } from '../shared/menuKeyboard';
@@ -65,6 +67,22 @@ const ADD_BLOCK_OPTIONS: { value: AddableBlockType; labelKey: string }[] = [
 ];
 
 
+// Grace window for undo-able line/section deletion: the item leaves the UI
+// immediately on confirm, but the real DELETE is deferred this long so Undo
+// can restore it with zero API traffic (nothing was sent yet). Long enough to
+// read the toast and react; short enough that the server state doesn't sit
+// lying for ages. Matches the toast's own display duration.
+const UNDO_GRACE_MS = 6000;
+
+/** One deferred deletion awaiting its grace window. `rows` lists every hidden
+ *  line row — a bundle parent carries its children (the server FK-cascades
+ *  them on delete) — each with its position at delete time, so reorder
+ *  PATCHes can splice the hidden ids back into the full-permutation id lists
+ *  the server validates against ALL its rows (hidden ones included). */
+type PendingDeleteEntry =
+  | { kind: 'line'; id: string; blockId: string | null; rows: { id: string; index: number }[]; timer: ReturnType<typeof setTimeout> }
+  | { kind: 'block'; id: string; index: number; timer: ReturnType<typeof setTimeout> };
+
 /** Latest PUBLISHED version of a template (design: attach pins the latest
  *  published version, never a newer draft). Returns null when the template has
  *  no published version yet — the picker blocks the attach in that case. */
@@ -89,10 +107,15 @@ interface Props {
    *  Send until the quote is quiescent, so the irreversible money-moment
    *  can't race a blur-save. */
   onPendingEditsChange?: (hasPendingEdits: boolean) => void;
+  /** Hands the workspace an imperative "flush deferred deletions now" hook
+   *  (called with null on unmount). QuoteActions invokes it when Send is
+   *  clicked during the undo grace window, so the held Send fires as soon as
+   *  the DELETE lands instead of waiting out the rest of the window. */
+  onRegisterPendingDeleteFlush?: (flush: (() => void) | null) => void;
 }
 
 
-export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }: Props) {
+export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, onRegisterPendingDeleteFlush }: Props) {
   const { t } = useTranslation('billing');
   const { can } = usePermissions();
   const canWrite = can('quotes', 'write');
@@ -117,8 +140,79 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
       return next;
     });
   }, []);
-  const { quote, blocks, lines } = detail;
+  const { quote, blocks: serverBlocks, lines: serverLines } = detail;
   const currency = quote.currencyCode;
+
+  // ---- undo-able deletion (deferred DELETE + grace window) -----------------
+  // Confirming a line/section removal hides it here and starts a grace timer;
+  // the real DELETE fires only when the window expires — or at an earlier
+  // flush point (Send, unmount, page-hide, a section delete swallowing a
+  // pending line delete). Undo cancels the timer and clears the id: nothing
+  // was sent, so restoration is exact and free. The entries ref carries what
+  // flushing and reorder-splicing need; the id sets drive rendering. All the
+  // derived state below consumes the FILTERED `blocks`/`lines`, so totals,
+  // profit, bulk selection, missing-cost ids, reveal targeting and reorder
+  // commits all treat a pending-deleted item as already gone.
+  const pendingDeleteEntries = useRef<Map<string, PendingDeleteEntry>>(new Map());
+  const [pendingDeletedLineIds, setPendingDeletedLineIds] = useState<ReadonlySet<string>>(() => new Set());
+  const [pendingDeletedBlockIds, setPendingDeletedBlockIds] = useState<ReadonlySet<string>>(() => new Set());
+  const blocks = useMemo(
+    () => serverBlocks.filter((b) => !pendingDeletedBlockIds.has(b.id)),
+    [serverBlocks, pendingDeletedBlockIds],
+  );
+  // A line hides when it (or the bundle parent it rides with) is
+  // pending-deleted, or when its whole section is — the server cascades a
+  // block delete to its lines, so the UI mirrors that immediately.
+  const lines = useMemo(
+    () => serverLines.filter((l) =>
+      !pendingDeletedLineIds.has(l.id) && (l.blockId === null || !pendingDeletedBlockIds.has(l.blockId))),
+    [serverLines, pendingDeletedLineIds, pendingDeletedBlockIds],
+  );
+  // Retire an id only once the post-flush refetch has dropped the row
+  // server-side — clearing on DELETE success would flash the row back for the
+  // refetch round-trip.
+  useEffect(() => {
+    setPendingDeletedLineIds((prev) => {
+      if (prev.size === 0) return prev;
+      const live = new Set(serverLines.map((l) => l.id));
+      const next = new Set([...prev].filter((id) => live.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [serverLines]);
+  useEffect(() => {
+    setPendingDeletedBlockIds((prev) => {
+      if (prev.size === 0) return prev;
+      const live = new Set(serverBlocks.map((b) => b.id));
+      const next = new Set([...prev].filter((id) => live.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [serverBlocks]);
+  // Reorder PATCHes send full-permutation id lists the server validates
+  // against ALL its rows — including ones only hidden here (their DELETE
+  // hasn't fired yet). These splice the hidden ids back in at (about) their
+  // original slots, so a reorder during a grace window neither 400s
+  // (REORDER_IDS_MISMATCH) nor teleports the hidden item if it's undone.
+  const withPendingDeletedLineIds = useCallback((blockId: string, ids: string[]): string[] => {
+    const hidden = [...pendingDeleteEntries.current.values()]
+      .flatMap((e) => (e.kind === 'line' && e.blockId === blockId ? e.rows : []))
+      .filter((r) => !ids.includes(r.id))
+      .sort((a, b) => a.index - b.index);
+    if (hidden.length === 0) return ids;
+    const full = [...ids];
+    for (const r of hidden) full.splice(Math.min(r.index, full.length), 0, r.id);
+    return full;
+  }, []);
+  const withPendingDeletedBlockIds = useCallback((ids: string[]): string[] => {
+    const hidden = [...pendingDeleteEntries.current.values()]
+      .filter((e): e is Extract<PendingDeleteEntry, { kind: 'block' }> => e.kind === 'block')
+      .filter((e) => !ids.includes(e.id))
+      .sort((a, b) => a.index - b.index);
+    if (hidden.length === 0) return ids;
+    const full = [...ids];
+    for (const e of hidden) full.splice(Math.min(e.index, full.length), 0, e.id);
+    return full;
+  }, []);
+
   // Rows only repeat the '/mo' | '/yr' cadence suffix when the quote actually
   // mixes cadences — on a uniform quote the suffix is per-line noise (the rail
   // totals and each editable row's recurrence select still carry the cadence).
@@ -136,6 +230,10 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
   const inFlight = useRef<Set<string>>(new Set());
   const [pending, setPending] = useState<ReadonlySet<string>>(() => new Set());
   const isPending = useCallback((key: string) => pending.has(key), [pending]);
+  // Timestamp of the last successful mutation, for the quiet "Saved 2:41 PM"
+  // indicator near the autosave hint — null until this session's first save
+  // (nothing to report before that; the indicator itself stays unrendered).
+  const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
 
   // Run a scoped mutation: mark the key pending, run, surface failures via the
   // standard handleActionError path, and always clear the key. Returns whether
@@ -147,6 +245,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
       setPending((s) => { const n = new Set(s); n.add(key); return n; });
       try {
         await fn();
+        setLastSavedAt(Date.now());
         return true;
       } catch (err) {
         handleActionError(err, errMsg);
@@ -177,7 +276,11 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
   // (line/block/terms/add/remove); the terms dirty flag covers the rail's
   // blur-to-save field. Per-line dirty state isn't lifted — clicking Send blurs
   // the focused field, whose commit lands in `pending` before the dialog opens.
-  const hasPendingEdits = pending.size > 0 || termsDirty;
+  // Deferred deletions count too: their DELETE hasn't fired yet, so a Send
+  // must not snapshot a quote the user has visibly already trimmed (clicking
+  // Send also flushes them immediately — see onRegisterPendingDeleteFlush).
+  const hasPendingEdits = pending.size > 0 || termsDirty
+    || pendingDeletedLineIds.size > 0 || pendingDeletedBlockIds.size > 0;
   useEffect(() => { onPendingEditsChange?.(hasPendingEdits); }, [hasPendingEdits, onPendingEditsChange]);
   // Clear on unmount so a stale `true` can't lock Send after the editor is gone
   // (e.g. the quote was just issued and the tab switched).
@@ -476,8 +579,11 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
   const blockReorderBase = useRef<string[] | null>(null);
   const lineReorderTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   const lineReorderBase = useRef<Record<string, string[]>>({});
-  useEffect(() => { setBlockOrder(null); blockReorderBase.current = null; }, [blocks]);
-  useEffect(() => { setLineOrder({}); lineReorderBase.current = {}; setLineBlockOverride({}); }, [lines]);
+  // Keyed to the SERVER arrays (not the pending-delete-filtered views): these
+  // overrides must clear when fresh server data lands, not when a deletion is
+  // merely hidden/undone client-side.
+  useEffect(() => { setBlockOrder(null); blockReorderBase.current = null; }, [serverBlocks]);
+  useEffect(() => { setLineOrder({}); lineReorderBase.current = {}; setLineBlockOverride({}); }, [serverLines]);
   useEffect(() => () => {
     if (blockReorderTimer.current) clearTimeout(blockReorderTimer.current);
     Object.values(lineReorderTimers.current).forEach(clearTimeout);
@@ -520,10 +626,13 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
   // server rate.
   const effectiveRate = quote.taxRate ? parseFloat(quote.taxRate) : null;
 
-  // The figures the rail renders: optimistic recompute when any line is mid-edit,
-  // otherwise the authoritative server values.
+  // The figures the rail renders: optimistic recompute when any line is
+  // mid-edit OR a deletion sits in its undo grace window (the server totals
+  // still include the hidden line until the deferred DELETE lands), otherwise
+  // the authoritative server values.
+  const hasPendingDeletes = pendingDeletedLineIds.size > 0 || pendingDeletedBlockIds.size > 0;
   const optimisticTotals = useMemo<QuoteTotals | null>(() => {
-    if (Object.keys(lineDrafts).length === 0) return null;
+    if (Object.keys(lineDrafts).length === 0 && !hasPendingDeletes) return null;
     const merged: QuoteLineForMath[] = lines.map((l) => {
       const d = lineDrafts[l.id];
       return d ?? {
@@ -532,10 +641,11 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
       };
     });
     return computeQuoteTotals(merged, effectiveRate);
-  }, [lineDrafts, lines, effectiveRate]);
+  }, [lineDrafts, lines, effectiveRate, hasPendingDeletes]);
   const railOneTime = optimisticTotals?.oneTimeTotal ?? quote.oneTimeTotal;
   const railMonthly = optimisticTotals?.monthlyRecurringTotal ?? quote.monthlyRecurringTotal;
   const railAnnual = optimisticTotals?.annualRecurringTotal ?? quote.annualRecurringTotal;
+  const railSubtotal = optimisticTotals?.subtotal ?? quote.subtotal;
   const railTax = optimisticTotals?.taxTotal ?? quote.taxTotal;
   const railTotal = optimisticTotals?.total ?? quote.total;
   const railDue = optimisticTotals?.dueOnAcceptanceTotal ?? quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal;
@@ -770,6 +880,30 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
     el.focus({ preventScroll: true });
   }, []);
 
+  // Keyboard shortcut: Alt+ArrowDown / Alt+ArrowUp jumps to the next/previous
+  // block, reusing the outline's own jumpToBlock (same scroll + focus contract).
+  // Scoped to a keydown handler on the blocks column (not document-level) and
+  // gated on the Alt modifier specifically so it can never fire while a writer
+  // is just typing into a name/description field — a bare arrow key inside an
+  // input is left completely alone. "Current" block is whichever container the
+  // focused element lives inside, falling back to the outline's scroll-position
+  // highlight, then the first block.
+  const jumpRelativeBlock = useCallback((direction: 1 | -1) => {
+    const ids = sortedBlocks.map((b) => b.id);
+    if (ids.length === 0) return;
+    const activeEl = typeof document !== 'undefined' ? (document.activeElement as HTMLElement | null) : null;
+    const containerEl = activeEl?.closest<HTMLElement>('[data-outline-block-id]');
+    const currentId = containerEl?.dataset.outlineBlockId ?? activeOutlineId ?? ids[0];
+    const idx = ids.indexOf(currentId);
+    const nextIdx = idx === -1 ? (direction === 1 ? 0 : ids.length - 1) : Math.min(ids.length - 1, Math.max(0, idx + direction));
+    jumpToBlock(ids[nextIdx]);
+  }, [sortedBlocks, activeOutlineId, jumpToBlock]);
+  const onBlocksColumnKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (!e.altKey || (e.key !== 'ArrowDown' && e.key !== 'ArrowUp')) return;
+    e.preventDefault();
+    jumpRelativeBlock(e.key === 'ArrowDown' ? 1 : -1);
+  }, [jumpRelativeBlock]);
+
   // Orphan lines: `block_id` is nullable, and `linesForBlock` can never surface
   // them (a null blockId matches no block id, ever). They are NOT invisible to
   // the customer — the PDF, the portal and the Preview all render them, and
@@ -949,12 +1083,12 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
     ids.splice(Math.min(insertAt, ids.length), 0, created.id);
     try {
       await runAction({
-        request: () => reorderBlocksApi(quote.id, { blockIds: ids }),
+        request: () => reorderBlocksApi(quote.id, { blockIds: withPendingDeletedBlockIds(ids) }),
         errorFallback: t('quotes.editor.errors.reorderSections'),
         onUnauthorized: UNAUTHORIZED,
       });
     } catch { /* toasted; the new section simply lands at the end */ }
-  }, [insertAt, sortedBlocks, quote.id, t]);
+  }, [insertAt, sortedBlocks, quote.id, withPendingDeletedBlockIds, t]);
 
   const submitBlock = useCallback(async () => {
     // Image blocks have no block-update endpoint, so the file must exist before
@@ -1099,12 +1233,14 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
   // Real block delete: removes the block and (server-side) any lines attached to
   // it. Works for every block type — heading, rich_text, and line_items — so the
   // "Remove" button is no longer a silent no-op for heading/rich_text blocks.
-  const removeBlock = useCallback((block: QuoteBlock) =>
-    runScoped(pendingKey.block(block.id), async () => {
+  // This is the deferred-flush executor (see startBlockDelete): the undo toast
+  // at delete time is the user-facing feedback, so no success toast here — a
+  // "Section removed" popping up seconds after the fact read as a second event.
+  const removeBlock = useCallback((blockId: string) =>
+    runScoped(pendingKey.block(blockId), async () => {
       await runAction({
-        request: () => deleteBlock(quote.id, block.id),
+        request: () => deleteBlock(quote.id, blockId),
         errorFallback: t('quotes.editor.errors.removeSection'),
-        successMessage: t('quotes.editor.success.sectionRemoved'),
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
@@ -1283,17 +1419,152 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
     }, t('quotes.editor.errors.addLine'));
   }, [quote.id, refresh, loadCatalog, runScoped, t]);
 
+  // Deferred-flush executor for a line delete (see startLineDelete). No
+  // success toast — the undo toast at delete time already told the user.
   const deleteLine = useCallback((lineId: string) =>
     runScoped(pendingKey.line(lineId), async () => {
       await runAction({
         request: () => removeLine(quote.id, lineId),
         errorFallback: t('quotes.editor.errors.removeLine'),
-        successMessage: t('quotes.editor.success.lineRemoved'),
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
     }, t('quotes.editor.errors.removeLine')),
   [quote.id, refresh, runScoped, t]);
+
+  // ---- deferred-deletion lifecycle (undo grace window) --------------------
+  // undo → cancel the timer, unhide (nothing was ever sent).
+  // flush → fire the real DELETE through the existing delete path; on failure
+  //         the item is honestly restored (it IS still there) on top of the
+  //         path's own error toast.
+  const undoLineDelete = useCallback((lineId: string) => {
+    const key = pendingKey.line(lineId);
+    const entry = pendingDeleteEntries.current.get(key);
+    if (!entry || entry.kind !== 'line') return; // already flushed — the deletion is real now
+    clearTimeout(entry.timer);
+    pendingDeleteEntries.current.delete(key);
+    setPendingDeletedLineIds((s) => {
+      const n = new Set(s);
+      for (const r of entry.rows) n.delete(r.id);
+      return n;
+    });
+  }, []);
+
+  const flushLineDelete = useCallback(async (lineId: string) => {
+    const key = pendingKey.line(lineId);
+    const entry = pendingDeleteEntries.current.get(key);
+    if (!entry || entry.kind !== 'line') return; // undone, or another flush already owns it
+    clearTimeout(entry.timer);
+    pendingDeleteEntries.current.delete(key);
+    // One DELETE for the parent row — the server FK-cascades bundle children.
+    const ok = await deleteLine(lineId);
+    if (!ok) {
+      // Honest failure: the DELETE didn't land (already toasted by the delete
+      // path), so the line is actually still there — put it back on screen.
+      setPendingDeletedLineIds((s) => {
+        const n = new Set(s);
+        for (const r of entry.rows) n.delete(r.id);
+        return n;
+      });
+    }
+    // On success the ids stay hidden until the refetch drops the rows (the
+    // retire effect near the top).
+  }, [deleteLine]);
+
+  const startLineDelete = useCallback((line: QuoteLine) => {
+    const key = pendingKey.line(line.id);
+    if (pendingDeleteEntries.current.has(key)) return;
+    const blockId = lineBlockOverride[line.id] ?? line.blockId;
+    const blockLines = blockId ? linesForBlock(blockId) : [];
+    // Bundle children ride with their parent (the server cascade deletes
+    // them), so they hide — and restore — as one unit.
+    const memberIds = [line.id, ...lines.filter((l) => l.parentLineId === line.id).map((l) => l.id)];
+    const rows = memberIds.map((id) => ({ id, index: Math.max(blockLines.findIndex((l) => l.id === id), 0) }));
+    const timer = setTimeout(() => { void flushLineDelete(line.id); }, UNDO_GRACE_MS);
+    pendingDeleteEntries.current.set(key, { kind: 'line', id: line.id, blockId, rows, timer });
+    setPendingDeletedLineIds((s) => {
+      const n = new Set(s);
+      for (const id of memberIds) n.add(id);
+      return n;
+    });
+    showToast({
+      type: 'undo',
+      message: t('quotes.editor.undo.lineDeleted'),
+      duration: UNDO_GRACE_MS,
+      onUndo: () => undoLineDelete(line.id),
+    });
+  }, [lines, lineBlockOverride, linesForBlock, flushLineDelete, undoLineDelete, t]);
+
+  const undoBlockDelete = useCallback((blockId: string) => {
+    const key = pendingKey.block(blockId);
+    const entry = pendingDeleteEntries.current.get(key);
+    if (!entry) return;
+    clearTimeout(entry.timer);
+    pendingDeleteEntries.current.delete(key);
+    setPendingDeletedBlockIds((s) => { const n = new Set(s); n.delete(blockId); return n; });
+  }, []);
+
+  const flushBlockDelete = useCallback(async (blockId: string) => {
+    const key = pendingKey.block(blockId);
+    const entry = pendingDeleteEntries.current.get(key);
+    if (!entry) return;
+    clearTimeout(entry.timer);
+    pendingDeleteEntries.current.delete(key);
+    const ok = await removeBlock(blockId);
+    if (!ok) {
+      setPendingDeletedBlockIds((s) => { const n = new Set(s); n.delete(blockId); return n; });
+    }
+  }, [removeBlock]);
+
+  const startBlockDelete = useCallback((block: QuoteBlock) => {
+    const key = pendingKey.block(block.id);
+    if (pendingDeleteEntries.current.has(key)) return;
+    // A pending line-deletion inside this section flushes NOW rather than
+    // merging into the section's window: the user deleted that line as its own
+    // action, so undoing the SECTION must not resurrect it — and its DELETE
+    // must land before the section's cascade would have raced it.
+    for (const e of [...pendingDeleteEntries.current.values()]) {
+      if (e.kind === 'line' && e.blockId === block.id) void flushLineDelete(e.id);
+    }
+    const index = Math.max(sortedBlocks.findIndex((b) => b.id === block.id), 0);
+    const timer = setTimeout(() => { void flushBlockDelete(block.id); }, UNDO_GRACE_MS);
+    pendingDeleteEntries.current.set(key, { kind: 'block', id: block.id, index, timer });
+    setPendingDeletedBlockIds((s) => { const n = new Set(s); n.add(block.id); return n; });
+    showToast({
+      type: 'undo',
+      message: t('quotes.editor.undo.sectionDeleted'),
+      duration: UNDO_GRACE_MS,
+      onUndo: () => undoBlockDelete(block.id),
+    });
+  }, [sortedBlocks, flushLineDelete, flushBlockDelete, undoBlockDelete, t]);
+
+  // Flush every deferred deletion immediately. Send (via the workspace),
+  // unmount and page-hide all route through here — the grace window is a UI
+  // nicety, never a way for a confirmed deletion to be lost or to outlive the
+  // editor.
+  const flushAllPendingDeletes = useCallback(() => {
+    for (const e of [...pendingDeleteEntries.current.values()]) {
+      if (e.kind === 'line') void flushLineDelete(e.id);
+      else void flushBlockDelete(e.id);
+    }
+  }, [flushLineDelete, flushBlockDelete]);
+  const flushAllRef = useRef(flushAllPendingDeletes);
+  useEffect(() => { flushAllRef.current = flushAllPendingDeletes; }, [flushAllPendingDeletes]);
+  useEffect(() => {
+    // pagehide (not beforeunload): it also fires on bfcache navigations, and
+    // the DELETEs go out with keepalive (see lib/api/quotes) so they survive
+    // the page teardown. Unmount gets the same treatment via the cleanup.
+    const onPageHide = () => flushAllRef.current();
+    window.addEventListener('pagehide', onPageHide);
+    return () => {
+      window.removeEventListener('pagehide', onPageHide);
+      flushAllRef.current();
+    };
+  }, []);
+  useEffect(() => {
+    onRegisterPendingDeleteFlush?.(flushAllPendingDeletes);
+    return () => onRegisterPendingDeleteFlush?.(null);
+  }, [onRegisterPendingDeleteFlush, flushAllPendingDeletes]);
 
   // Inline edit of an existing line. `body` carries only the changed fields
   // (matches updateQuoteLineSchema). Routed through runAction so failures are
@@ -1313,6 +1584,102 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
       refresh();
     }, t('quotes.editor.errors.updateLine')),
   [quote.id, refresh, runScoped, t]);
+
+  // ---- bulk edit (Task D) --------------------------------------------------
+  // Multi-select lines → set markup / cost / taxable across the selection.
+  // Selection lives here (rows stay mounted through internal-band and block
+  // collapse, so the set survives both); it's pruned when a selected line
+  // disappears from the server data and never persisted across reloads.
+  const [selectedLineIds, setSelectedLineIds] = useState<ReadonlySet<string>>(() => new Set());
+  const selectionActive = selectedLineIds.size > 0;
+  useEffect(() => {
+    setSelectedLineIds((prev) => {
+      if (prev.size === 0) return prev;
+      const live = new Set(lines.map((l) => l.id));
+      const next = new Set([...prev].filter((id) => live.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [lines]);
+  const isLineSelected = useCallback((id: string) => selectedLineIds.has(id), [selectedLineIds]);
+  const toggleLineSelected = useCallback((id: string) => {
+    setSelectedLineIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }, []);
+  const setBlockSelection = useCallback((ids: string[], selected: boolean) => {
+    setSelectedLineIds((prev) => {
+      const next = new Set(prev);
+      for (const id of ids) { if (selected) next.add(id); else next.delete(id); }
+      return next;
+    });
+  }, []);
+  const clearSelection = useCallback(() => {
+    setSelectedLineIds(new Set());
+    // The bar unmounts with the selection — park focus on the editor's stable
+    // anchor rather than letting it drop to <body>.
+    blocksColRef.current?.focus();
+  }, []);
+
+  // Apply one PATCH per selected line through the SAME editLine path the
+  // inline inputs use, so dirty rings, SrSaved, lastSavedAt and the
+  // pending-edits Send-hold all behave exactly as if each field were edited by
+  // hand. Sequential on purpose (each runs under its own scoped pending key):
+  // no request flood, and a failure never aborts the rest. One aggregate toast
+  // reports the honest outcome — per-line failures already toasted by runAction,
+  // the summary says how many.
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const applyBulk = useCallback(async (
+    targets: QuoteLine[],
+    body: (line: QuoteLine) => LineUpdate,
+    field: string,
+    skippedNoCost = 0,
+  ) => {
+    setBulkBusy(true);
+    let failed = 0;
+    try {
+      for (const l of targets) {
+        if (!(await editLine(l.id, body(l), pendingKey.lineField(l.id, field)))) failed += 1;
+      }
+    } finally {
+      setBulkBusy(false);
+    }
+    if (failed > 0) {
+      showToast({ type: 'error', message: t('quotes.editor.bulk.partialFailure', { failed, total: targets.length }) });
+    } else if (targets.length > 0) {
+      showToast({ type: 'success', message: t('quotes.editor.bulk.applied', { count: targets.length }) });
+    }
+    if (skippedNoCost > 0) {
+      showToast({ type: 'warning', message: t('quotes.editor.bulk.skippedNoCost', { count: skippedNoCost }) });
+    }
+  }, [editLine, t]);
+  const selectedLines = useMemo(
+    () => lines.filter((l) => selectedLineIds.has(l.id)),
+    [lines, selectedLineIds],
+  );
+  const bulkSetTaxable = useCallback((taxable: boolean) =>
+    void applyBulk(selectedLines, () => ({ taxable }), 'taxable'),
+  [applyBulk, selectedLines]);
+  const bulkSetCost = useCallback((cost: number) =>
+    void applyBulk(selectedLines, () => ({ unitCost: cost }), 'cost'),
+  [applyBulk, selectedLines]);
+  // Markup rewrites unitPrice from each line's OWN cost (price = cost·(1+m)) —
+  // the same derivation the per-row markup input commits. Lines with no cost
+  // (never entered — null) AND lines with an explicit cost of 0 (Task B1's
+  // deliberate "no cost" designation) both have no usable markup base — cost·
+  // (1+m) on a $0 base is $0 regardless of markup%, mirroring markupPct's own
+  // null-on-zero-or-less-cost rule — so both are skipped and counted together
+  // in the honest "skipped N" toast.
+  const bulkSetMarkup = useCallback((pct: number) => {
+    const withCost = selectedLines.filter((l) => l.unitCost !== null && Number(l.unitCost) > 0);
+    void applyBulk(
+      withCost,
+      (l) => ({ unitPrice: Number(priceFromMarkup(l.unitCost as string, pct)) }),
+      'price',
+      selectedLines.length - withCost.length,
+    );
+  }, [applyBulk, selectedLines]);
 
   // Inline edit of a block's content (heading text/level, rich-text html). The
   // block type is restated so the server validates the content shape; it is
@@ -1354,7 +1721,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
       void (async () => {
         try {
           await runAction({
-            request: () => reorderBlocksApi(quote.id, { blockIds: ids }),
+            request: () => reorderBlocksApi(quote.id, { blockIds: withPendingDeletedBlockIds(ids) }),
             errorFallback: t('quotes.editor.errors.reorderSections'),
             onUnauthorized: UNAUTHORIZED,
           });
@@ -1367,7 +1734,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
         }
       })();
     }, 250);
-  }, [sortedBlocks, quote.id, refresh, t]);
+  }, [sortedBlocks, quote.id, refresh, withPendingDeletedBlockIds, t]);
 
   // Drag-to-reorder for blocks (HTML5 DnD on the grip). Drop commits the full
   // reordered id list through the same optimistic + PATCH path the menu moves
@@ -1389,7 +1756,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
     void (async () => {
       try {
         await runAction({
-          request: () => reorderBlocksApi(quote.id, { blockIds: ids }),
+          request: () => reorderBlocksApi(quote.id, { blockIds: withPendingDeletedBlockIds(ids) }),
           errorFallback: t('quotes.editor.errors.reorderSections'),
           onUnauthorized: UNAUTHORIZED,
         });
@@ -1401,7 +1768,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
         refresh();
       }
     })();
-  }, [dragBlockId, sortedBlocks, quote.id, refresh, t]);
+  }, [dragBlockId, sortedBlocks, quote.id, refresh, withPendingDeletedBlockIds, t]);
 
 
   // The ONE line-reorder persistence path: optimistic order + a debounced
@@ -1419,7 +1786,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
       void (async () => {
         try {
           await runAction({
-            request: () => reorderLinesApi(quote.id, blockId, { lineIds: ids }),
+            request: () => reorderLinesApi(quote.id, blockId, { lineIds: withPendingDeletedLineIds(blockId, ids) }),
             errorFallback: t('quotes.editor.errors.reorderLines'),
             onUnauthorized: UNAUTHORIZED,
           });
@@ -1432,7 +1799,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
         }
       })();
     }, 250);
-  }, [quote.id, refresh, t]);
+  }, [quote.id, refresh, withPendingDeletedLineIds, t]);
 
   const moveLine = useCallback((blockId: string, line: QuoteLine, direction: 'up' | 'down') => {
     const currentIds = lineReorderBase.current[blockId] ?? linesForBlock(blockId).map((l) => l.id);
@@ -1789,6 +2156,16 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
             {t('quotes.editor.autosaveHint')}
           </p>
         )}
+        {/* Quiet sync indicator: "Saving…" while any mutation is in flight, else
+            "Saved 2:41 PM" once this session has saved at least once. Purely
+            informational — never disables Send or any other control. */}
+        {canWrite && (pending.size > 0 || lastSavedAt !== null) && (
+          <p className="text-xs text-muted-foreground" data-testid="quote-editor-last-saved">
+            {pending.size > 0
+              ? t('quotes.editor.lastSaved.saving')
+              : t('quotes.editor.lastSaved.saved', { time: formatTime(lastSavedAt as number, { hour: '2-digit', minute: '2-digit' }) })}
+          </p>
+        )}
         {canWrite && (
           <label className="inline-flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground" data-testid="quote-cover-page">
             <input
@@ -1911,6 +2288,8 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
           className="min-w-0 space-y-4 rounded-md focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           ref={blocksColRef}
           tabIndex={-1}
+          onKeyDown={onBlocksColumnKeyDown}
+          aria-keyshortcuts="Alt+ArrowDown Alt+ArrowUp"
         >
           {/* The paper: one continuous document-shaped surface. Blocks render in
               document typography inside it; the per-block card chrome is gone.
@@ -2069,6 +2448,10 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                 revealRequest={revealRequest}
                 hasDirtyLines={block.blockType === 'line_items' && linesForBlock(block.id).some((l) => l.id in lineDrafts)}
                 onDropLine={(dragLineId, targetIdx) => dropLineInBlock(block.id, dragLineId, targetIdx)}
+                selectionActive={selectionActive}
+                isLineSelected={isLineSelected}
+                onToggleLineSelected={toggleLineSelected}
+                onSetBlockSelection={setBlockSelection}
               />
                   </div>
                 </Fragment>
@@ -2134,12 +2517,30 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                   <dd data-testid="quote-total-annual">{formatMoney(railAnnual, currency)}<span className="text-xs text-muted-foreground">{t('quotes.editor.units.perYear')}</span></dd>
                 </div>
               )}
+              {/* Grand-total stack: Subtotal → Tax → Total, mirroring the customer
+                  document's terminology (bare "Subtotal"/"Total" when the quote is
+                  one-time only; "First period …" once a recurring cadence is mixed
+                  in, since the subtotal then also rolls in the first monthly/annual
+                  period). Total is deliberately the most visually dominant figure in
+                  this stack — the one-time row above is money BEFORE tax, so it's
+                  labeled as such to prevent it from being misread as the payable
+                  total. */}
+              <div className="flex items-baseline justify-between border-t pt-2">
+                <dt className="text-muted-foreground">
+                  {hasRecurring ? t('quotes.editor.liveTotals.firstPeriodSubtotal') : t('quotes.editor.liveTotals.subtotal')}
+                </dt>
+                <dd data-testid="quote-total-subtotal">{formatMoney(railSubtotal, currency)}</dd>
+              </div>
               {Number(railTax) > 0 && (
                 <div className="flex items-baseline justify-between">
                   <dt className="text-muted-foreground">{t('quotes.editor.liveTotals.tax')}</dt>
-                  <dd>{formatMoney(railTax, currency)}</dd>
+                  <dd data-testid="quote-total-tax">{formatMoney(railTax, currency)}</dd>
                 </div>
               )}
+              <div className="flex items-baseline justify-between text-base font-semibold">
+                <dt>{hasRecurring ? t('quotes.editor.liveTotals.firstPeriodTotal') : t('quotes.editor.liveTotals.total')}</dt>
+                <dd data-testid="quote-total-grand">{formatMoney(railTotal, currency)}</dd>
+              </div>
             </dl>
             {/* Per-category subtotals (hardware / software / service / other) — only
                 worth showing once the quote spans more than one category. Mirrors the
@@ -2261,15 +2662,12 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                 </div>
               )}
             </div>
-            {hasRecurring && (
-              <>
-                <div className="mt-2 flex items-baseline justify-between text-sm tabular-nums">
-                  <span className="text-muted-foreground">{t('quotes.editor.liveTotals.firstPeriodTotal')}</span>
-                  <span className="font-medium" data-testid="quote-total-first-period">{formatMoney(railTotal, currency)}</span>
-                </div>
-                <RecurringBillingNote className="mt-2" testId="quote-totals-recurring-hint" />
-              </>
-            )}
+            {/* The "First period total" figure itself now lives in the Subtotal →
+                Tax → Total stack above (dominant, data-testid="quote-total-grand");
+                this note just explains what "first period" means for a recurring
+                quote so the two numbers (due on acceptance vs. total) don't read
+                as a discrepancy. */}
+            {hasRecurring && <RecurringBillingNote className="mt-2" testId="quote-totals-recurring-hint" />}
           </div>
 
           {/* Contents outline — a quiet nav under the totals (the rail's primary
@@ -2280,7 +2678,12 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
               data-testid="quote-outline"
               className="rounded-lg border bg-card p-3 shadow-xs"
             >
-              <h2 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('quotes.editor.outline.title')}</h2>
+              <h2
+                className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                title={t('quotes.editor.outline.shortcutHint')}
+              >
+                {t('quotes.editor.outline.title')}
+              </h2>
               <ul className="space-y-0.5">
                 {sortedBlocks.map((b) => (
                   <li key={b.id}>
@@ -2325,6 +2728,22 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
         </div>
       </div>
 
+      {/* One sticky viewport-bottom stack for BOTH floating bars — the bulk-edit
+          action bar (any width, while a selection is active) above the slim
+          totals summary (below xl only). Stacking them in a single sticky
+          wrapper is what keeps them from colliding: two independent sticky
+          siblings would both pin to the same bottom offset and overlap. */}
+      <div className="sticky bottom-2 z-10 space-y-2">
+        {canWrite && selectionActive && (
+          <QuoteBulkBar
+            count={selectedLineIds.size}
+            busy={bulkBusy}
+            onSetMarkup={bulkSetMarkup}
+            onSetCost={bulkSetCost}
+            onSetTaxable={bulkSetTaxable}
+            onClear={clearSelection}
+          />
+        )}
       {/* Below xl the full totals rail stacks under all blocks, which would break
           the edit→see-total loop mid-task — so a slim summary stays pinned to the
           viewport bottom while the rail's natural position is below the fold
@@ -2334,11 +2753,18 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
       <div
         aria-hidden="true"
         data-testid="quote-totals-sticky"
-        className="sticky bottom-2 z-10 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 rounded-lg border bg-card px-4 py-2 text-sm shadow-md xl:hidden"
+        className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 rounded-lg border bg-card px-4 py-2 text-sm shadow-md xl:hidden"
       >
         <span className="flex items-baseline gap-2">
           <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{t('quotes.editor.liveTotals.dueOnAcceptance')}</span>
           <span className="text-base font-semibold tabular-nums">{formatMoney(railDue, currency)}</span>
+        </span>
+        {/* Grand total (subtotal + tax across all cadences' first period) mirrors
+            the rail's Subtotal → Tax → Total stack; a plain secondary chip here
+            since Due on acceptance stays the primary figure at this width. */}
+        <span className="flex items-baseline gap-1 text-muted-foreground">
+          <span className="text-xs">{t('quotes.editor.liveTotals.total')}</span>
+          <span className="font-medium tabular-nums text-foreground" data-testid="quote-totals-sticky-total">{formatMoney(railTotal, currency)}</span>
         </span>
         {Number(railMonthly) > 0 && (
           <span className="text-muted-foreground">
@@ -2355,6 +2781,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
             {t('quotes.editor.deposit.short')} <span className="font-medium tabular-nums text-foreground">{formatMoney(railDeposit, currency)}</span>
           </span>
         )}
+      </div>
       </div>
 
       {/* The "Tidy all descriptions" queue driver: an unattended PolishButton
@@ -2389,18 +2816,14 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
         onConfirm={() => {
           const block = pendingRemove;
           if (!block) return;
-          // Keep the dialog open and awaiting (so isLoading shows "Processing…")
-          // until the delete resolves. On failure (already toasted by runAction)
-          // leave the dialog open so the user can retry or cancel — don't close as
-          // if it worked while the block is still there. On success, close and move
-          // focus to a stable anchor — the triggering Remove button is gone.
-          void (async () => {
-            if (!(await removeBlock(block))) return;
-            setPendingRemove(null);
-            blocksColRef.current?.focus();
-          })();
+          // Confirm starts the undo grace window: the section leaves the UI
+          // now, the real DELETE fires when the window expires (undo toast
+          // shown by startBlockDelete). Focus moves to a stable anchor — the
+          // triggering Remove button is gone with the section.
+          startBlockDelete(block);
+          setPendingRemove(null);
+          blocksColRef.current?.focus();
         }}
-        isLoading={pendingRemove ? isPending(pendingKey.block(pendingRemove.id)) : false}
         title={t('quotes.editor.confirm.removeSectionTitle')}
         message={
           pendingRemove?.blockType === 'line_items' && linesForBlock(pendingRemove.id).length > 0
@@ -2417,15 +2840,12 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
         onConfirm={() => {
           const line = pendingLineRemove;
           if (!line) return;
-          // Leave the dialog open on failure (already toasted) so the user can
-          // retry; only close + restore focus once the line is actually gone.
-          void (async () => {
-            if (!(await deleteLine(line.id))) return;
-            setPendingLineRemove(null);
-            blocksColRef.current?.focus();
-          })();
+          // Confirm starts the undo grace window (deferred DELETE + undo
+          // toast, see startLineDelete); the row disappears immediately.
+          startLineDelete(line);
+          setPendingLineRemove(null);
+          blocksColRef.current?.focus();
         }}
-        isLoading={pendingLineRemove ? isPending(pendingKey.line(pendingLineRemove.id)) : false}
         title={t('quotes.editor.confirm.removeLineTitle')}
         message={
           pendingLineRemove

--- a/apps/web/src/components/billing/quotes/QuoteEditor.unassigned.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.unassigned.test.tsx
@@ -1,0 +1,189 @@
+// The orphan bucket: `quote_lines.block_id` is nullable, and a line with a NULL
+// block_id renders on every customer-facing surface (PDF, portal, Preview) and
+// counts in every total — but the editor drew blocks only, so it was money on a
+// real quote that the builder refused to show. These tests pin the bucket's
+// three load-bearing behaviours: it appears for an orphan, it is completely
+// absent without one, and its move actually PATCHes the move endpoint and
+// surfaces the outcome.
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { moveLine } from '../../../lib/api/quotes';
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+  catalogItemImagePath: vi.fn().mockReturnValue('/catalog/x/image'),
+}));
+
+const okResponse = () =>
+  ({ ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: { ok: true } }) } as unknown as Response);
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  updateBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn(),
+  removeLine: vi.fn(),
+  reorderBlocks: vi.fn(),
+  reorderLines: vi.fn(),
+  moveLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  addQuoteImageFromUrl: vi.fn(),
+  updateQuote: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const mkTable = (id: string, sortOrder: number, label?: string): QuoteDetailData['blocks'][number] => ({
+  id, quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: label ? { label } : {}, sortOrder, createdAt: '2026-06-01T00:00:00Z',
+});
+
+// blockId is deliberately typed `string | null` here — a null is the whole
+// point of the fixture (this is the shape the API really returns).
+const mkLine = (id: string, blockId: string | null, sortOrder: number, overrides: Partial<QuoteDetailData['lines'][number]> = {}): QuoteDetailData['lines'][number] => ({
+  id, quoteId: 'q-1', blockId, orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+  name: null, description: `Line ${id}`, quantity: '1.00',
+  unitPrice: '50.00', taxable: false, customerVisible: true, lineTotal: '50.00',
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder,
+  createdAt: '2026-06-01T00:00:00Z', ...overrides,
+});
+
+const quote: QuoteDetailData['quote'] = {
+  id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+  currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '92.00', taxRate: null,
+  taxTotal: '0.00', total: '92.00', oneTimeTotal: '92.00', monthlyRecurringTotal: '0.00',
+  annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+  termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+  convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+  createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+};
+
+// The shape that shipped a $42 line onto a real customer quote: one healthy
+// pricing panel, plus one line with no block at all.
+const withOrphan: QuoteDetailData = {
+  quote,
+  blocks: [mkTable('blk-1', 0, 'Services')],
+  lines: [
+    mkLine('l-1', 'blk-1', 0),
+    mkLine('orphan-1', null, 1, { name: 'Rush shipping', unitPrice: '42.00', lineTotal: '42.00' }),
+  ],
+};
+
+const healthy: QuoteDetailData = {
+  quote,
+  blocks: [mkTable('blk-1', 0, 'Services')],
+  lines: [mkLine('l-1', 'blk-1', 0)],
+};
+
+const moveLineMock = vi.mocked(moveLine);
+
+const renderEditor = async (detail: QuoteDetailData, onChanged = vi.fn()) => {
+  render(<QuoteEditor detail={detail} onChanged={onChanged} />);
+  await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+  return onChanged;
+};
+
+describe('QuoteEditor — unassigned (orphan) lines bucket', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    moveLineMock.mockResolvedValue(okResponse());
+  });
+
+  it('renders an orphan line in the bucket, with its money', async () => {
+    await renderEditor(withOrphan);
+
+    const bucket = screen.getByTestId('quote-unassigned-lines');
+    const row = within(bucket).getByTestId('quote-unassigned-line-orphan-1');
+    expect(row).toHaveTextContent('Rush shipping');
+    expect(row).toHaveTextContent('$42.00');
+  });
+
+  it('states that the lines are on the customer quote and in the total', async () => {
+    await renderEditor(withOrphan);
+
+    // This copy IS the fix — an orphan the tech reads as cosmetic ships anyway.
+    const explainer = screen.getByTestId('quote-unassigned-explainer');
+    expect(explainer).toHaveTextContent('appear on the customer’s quote');
+    expect(explainer).toHaveTextContent('count toward its totals');
+  });
+
+  it('renders nothing at all when the quote has no orphan lines', async () => {
+    await renderEditor(healthy);
+
+    expect(screen.queryByTestId('quote-unassigned-lines')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quote-unassigned-explainer')).not.toBeInTheDocument();
+    // The healthy quote still renders its pricing panel — the bucket's absence
+    // is not the editor failing to render.
+    expect(screen.getByTestId('quote-block-lines-blk-1')).toBeInTheDocument();
+  });
+
+  it('offers every pricing panel as a move target', async () => {
+    await renderEditor({
+      ...withOrphan,
+      blocks: [mkTable('blk-1', 0, 'Services'), mkTable('blk-2', 1)],
+    });
+
+    const select = screen.getByTestId('quote-unassigned-move-orphan-1');
+    expect(within(select).getByRole('option', { name: 'Services' })).toBeInTheDocument();
+    // Unlabeled panels fall back to the editor's positional name.
+    expect(within(select).getByRole('option', { name: 'Pricing table 2' })).toBeInTheDocument();
+  });
+
+  it('PATCHes the move endpoint with the chosen block and adopts the line', async () => {
+    const onChanged = await renderEditor(withOrphan);
+
+    fireEvent.change(screen.getByTestId('quote-unassigned-move-orphan-1'), { target: { value: 'blk-1' } });
+
+    await waitFor(() => expect(moveLineMock).toHaveBeenCalledWith('q-1', 'orphan-1', { blockId: 'blk-1' }));
+    // Optimistic: the line is now in the real panel and out of the bucket —
+    // and with no orphans left the bucket removes itself entirely.
+    const panel = screen.getByTestId('quote-block-lines-blk-1');
+    expect(within(panel).getByTestId('quote-line-qty-orphan-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('quote-unassigned-lines')).not.toBeInTheDocument();
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  it('surfaces a failed move and puts the line back in the bucket', async () => {
+    moveLineMock.mockResolvedValue(
+      { ok: false, status: 500, statusText: 'err', json: vi.fn().mockResolvedValue({ error: 'boom' }) } as unknown as Response,
+    );
+    await renderEditor(withOrphan);
+
+    fireEvent.change(screen.getByTestId('quote-unassigned-move-orphan-1'), { target: { value: 'blk-1' } });
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    await waitFor(() =>
+      expect(screen.getByTestId('quote-unassigned-line-orphan-1')).toBeInTheDocument());
+  });
+
+  it('tells the tech to add a pricing section when there is nowhere to move to', async () => {
+    await renderEditor({ ...withOrphan, blocks: [], lines: [withOrphan.lines[1]] });
+
+    expect(screen.getByTestId('quote-unassigned-lines')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-unassigned-no-targets')).toBeInTheDocument();
+    expect(screen.queryByTestId('quote-unassigned-move-orphan-1')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.undodelete.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.undodelete.test.tsx
@@ -1,0 +1,223 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import * as quotesApi from '../../../lib/api/quotes';
+import type { QuoteDetail as QuoteDetailData, QuoteLine } from './quoteTypes';
+
+// Writer permissions so the inline line editor + menus render.
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn(),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  reorderLines: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const okJson = (payload: unknown = { data: {} }): Response =>
+  ({ ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+const failJson = (): Response =>
+  ({ ok: false, status: 500, statusText: 'ERR', json: vi.fn().mockResolvedValue({ error: { message: 'boom' } }) }) as unknown as Response;
+
+const block: QuoteDetailData['blocks'][number] = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: { label: 'Pricing' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+
+const mkLine = (id: string, price: string, cost: string | null, sortOrder: number): QuoteLine => ({
+  id, quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, unitCost: cost, sku: null, partNumber: null,
+  name: `Item ${id}`, description: null, quantity: '1.00',
+  unitPrice: price, taxable: false, customerVisible: true, lineTotal: price,
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder,
+  createdAt: '2026-06-01T00:00:00Z',
+});
+
+// l-1 deliberately has NO cost (feeds the missing-cost notice); server totals
+// include all three lines, so the optimistic recompute after a delete is
+// observable against them.
+const detail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '600.00', taxRate: null,
+    taxTotal: '0.00', total: '600.00', oneTimeTotal: '600.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+    termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+    createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [block],
+  lines: [mkLine('l-1', '100.00', null, 0), mkLine('l-2', '200.00', '50.00', 1), mkLine('l-3', '300.00', '75.00', 2)],
+};
+
+const removeLineMock = vi.mocked(quotesApi.removeLine);
+
+async function renderEditor(props: Partial<Parameters<typeof QuoteEditor>[0]> = {}) {
+  const utils = render(<QuoteEditor detail={detail} onChanged={vi.fn()} {...props} />);
+  await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+  return utils;
+}
+
+async function deleteLineViaMenu(id: string) {
+  fireEvent.click(screen.getByTestId(`quote-line-actions-${id}`));
+  fireEvent.click(screen.getByTestId(`quote-line-remove-${id}`));
+  fireEvent.click(await screen.findByTestId('quote-line-remove-confirm'));
+}
+
+/** The undo callback of the most recent undo-type toast. */
+function lastUndo(): () => void {
+  const call = [...showToast.mock.calls].reverse()
+    .find((c) => (c[0] as { type: string }).type === 'undo');
+  expect(call).toBeDefined();
+  return (call![0] as { onUndo: () => void }).onUndo;
+}
+
+const visibleRowIds = () =>
+  screen.queryAllByTestId(/^quote-line-l-\d$/).map((el) => el.getAttribute('data-testid'));
+
+describe('QuoteEditor — undo-able line deletion (grace window)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    removeLineMock.mockResolvedValue(okJson());
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('removes the row optimistically, recomputes totals, and sends no DELETE inside the window', async () => {
+    await renderEditor();
+    expect(screen.getByTestId('quote-total-grand').textContent).toBe('$600.00');
+
+    await deleteLineViaMenu('l-2');
+
+    // Row gone instantly, totals recomputed from the remaining lines…
+    expect(screen.queryByTestId('quote-line-l-2')).not.toBeInTheDocument();
+    expect(screen.getByTestId('quote-total-grand').textContent).toBe('$400.00');
+    // …but the server has not been told yet.
+    expect(removeLineMock).not.toHaveBeenCalled();
+    // The undo toast fired with the grace-window duration.
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'undo', duration: 6000 }));
+  });
+
+  it('undo restores the line at its exact position with zero DELETE calls', async () => {
+    await renderEditor();
+    await deleteLineViaMenu('l-2');
+    expect(visibleRowIds()).toEqual(['quote-line-l-1', 'quote-line-l-3']);
+
+    act(() => { lastUndo()(); });
+
+    expect(visibleRowIds()).toEqual(['quote-line-l-1', 'quote-line-l-2', 'quote-line-l-3']);
+    expect(screen.getByTestId('quote-total-grand').textContent).toBe('$600.00');
+    expect(removeLineMock).not.toHaveBeenCalled();
+  });
+
+  it('fires the real DELETE through the existing path when the window expires', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const onChanged = vi.fn();
+    await renderEditor({ onChanged });
+    await deleteLineViaMenu('l-2');
+    expect(removeLineMock).not.toHaveBeenCalled();
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(6000); });
+
+    expect(removeLineMock).toHaveBeenCalledWith('q-1', 'l-2');
+    // The existing delete path still refreshes so server totals resync.
+    expect(onChanged).toHaveBeenCalled();
+    // Row stays hidden while we wait for the refetch to drop it.
+    expect(screen.queryByTestId('quote-line-l-2')).not.toBeInTheDocument();
+  });
+
+  it('restores the line and surfaces the error when the deferred DELETE fails', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    removeLineMock.mockResolvedValue(failJson());
+    await renderEditor();
+    await deleteLineViaMenu('l-2');
+    expect(screen.queryByTestId('quote-line-l-2')).not.toBeInTheDocument();
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(6000); });
+
+    // Honest failure: the DELETE didn't land, so the line is really still
+    // there — back on screen, error toasted by the existing path.
+    expect(screen.getByTestId('quote-line-l-2')).toBeInTheDocument();
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    expect(screen.getByTestId('quote-total-grand').textContent).toBe('$600.00');
+  });
+
+  it('counts as a pending edit and the registered flush fires the DELETE immediately (Send path)', async () => {
+    let flush: (() => void) | null = null;
+    const onPendingEditsChange = vi.fn();
+    await renderEditor({
+      onPendingEditsChange,
+      onRegisterPendingDeleteFlush: (fn) => { flush = fn; },
+    });
+    onPendingEditsChange.mockClear();
+
+    await deleteLineViaMenu('l-2');
+    // Send-hold plumbing: a deferred deletion reports as a pending edit.
+    expect(onPendingEditsChange).toHaveBeenLastCalledWith(true);
+    expect(removeLineMock).not.toHaveBeenCalled();
+
+    // Send clicked mid-window → the workspace calls the registered flush; the
+    // DELETE goes out now instead of waiting out the rest of the window.
+    expect(flush).not.toBeNull();
+    act(() => { flush!(); });
+    await waitFor(() => expect(removeLineMock).toHaveBeenCalledWith('q-1', 'l-2'));
+    expect(removeLineMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('excludes a pending-deleted line from bulk selection and the missing-cost notice', async () => {
+    await renderEditor();
+    // Reveal internal economics so the missing-cost notice renders (l-1 has no cost).
+    fireEvent.click(screen.getByTestId('quote-editor-toggle-internal'));
+    expect(screen.getByTestId('quote-margin-missing-cost')).toBeInTheDocument();
+    // Select the line → bulk bar appears.
+    fireEvent.click(screen.getByTestId('quote-line-select-l-1'));
+    expect(screen.getByTestId('quote-bulk-bar')).toBeInTheDocument();
+
+    await deleteLineViaMenu('l-1');
+
+    // Selection pruned (bar gone) and the missing-cost notice no longer counts
+    // the hidden line.
+    expect(screen.queryByTestId('quote-bulk-bar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quote-margin-missing-cost')).not.toBeInTheDocument();
+    expect(removeLineMock).not.toHaveBeenCalled();
+  });
+
+  it('flushes a pending deletion on unmount', async () => {
+    const { unmount } = await renderEditor();
+    await deleteLineViaMenu('l-2');
+    expect(removeLineMock).not.toHaveBeenCalled();
+
+    unmount();
+
+    await waitFor(() => expect(removeLineMock).toHaveBeenCalledWith('q-1', 'l-2'));
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.customer.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.customer.test.tsx
@@ -110,6 +110,22 @@ describe('QuoteHeaderMeta customer reassignment', () => {
     expect(customerPatchCalls()).toHaveLength(0);
   });
 
+  // The select clips a long org name at max-w-56 with no other way to read it —
+  // `title` is the mouse-hover escape hatch, so it must carry the actual
+  // selected name rather than generic static help copy.
+  it("the select's title carries the selected organization's full name", () => {
+    render(<QuoteHeaderMeta detail={detail()} onChanged={vi.fn()} />);
+
+    const select = screen.getByTestId('quote-customer');
+    expect(select).toHaveAttribute('title', 'Acme');
+
+    fireEvent.change(select, { target: { value: 'org-2' } });
+    fireEvent.click(screen.getByTestId('quote-customer-confirm'));
+    // The select snaps to the new value optimistically on confirm; its title
+    // follows the same selection, not the stale one.
+    return waitFor(() => expect(select).toHaveAttribute('title', 'Beta Corp'));
+  });
+
   it('snaps the select back when the move fails', async () => {
     fetchMock.mockImplementation(async (path, init) => {
       if (path === '/quotes/q-1' && (init as RequestInit | undefined)?.method === 'PATCH') {

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
@@ -67,6 +67,11 @@ export function QuoteHeaderMeta({ detail, onChanged, onPendingChange }: Props) {
   }, [organizations, quote.orgId, detail.billTo?.name]);
 
   const [customerOrgId, setCustomerOrgId] = useState(quote.orgId);
+  // The select's `title` is a mouse-hover tooltip — the ONLY way to read a long
+  // org name once the select's own max-w-56 clips it. Falls back to the
+  // generic help copy only when nothing resolves (shouldn't happen in
+  // practice: customerOrgId always defaults to the quote's own org).
+  const selectedOrgName = orgOptions.find((o) => o.id === customerOrgId)?.name?.trim();
   const [customerBusy, setCustomerBusy] = useState(false);
   useEffect(() => { setCustomerOrgId(quote.orgId); }, [quote.orgId]);
   // Reassignment clears site + bill-to and re-resolves tax, so a select change
@@ -124,7 +129,7 @@ export function QuoteHeaderMeta({ detail, onChanged, onPendingChange }: Props) {
       <select
         value={customerOrgId}
         aria-label={t('quotes.editor.customer.label')}
-        title={t('quotes.editor.customer.help')}
+        title={selectedOrgName || t('quotes.editor.customer.help')}
         onChange={(e) => {
           const id = e.target.value;
           if (id === customerOrgId) return;

--- a/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
@@ -1,9 +1,9 @@
 // The pricing-table rows: GhostRow (fast manual entry), EditableLineRow,
 // ReadonlyLineRow, and the per-line thumbnails. Split from QuoteEditor.tsx —
 // see quoteEditorShared.tsx for the shared save-language plumbing.
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Loader2, MoreHorizontal } from 'lucide-react';
+import { AlertTriangle, ChevronRight, GripVertical, Loader2, MoreHorizontal, Sparkles } from 'lucide-react';
 import '../../../lib/i18n';
 import { fetchWithAuth } from '../../../stores/auth';
 import { runAction, handleActionError } from '../../../lib/runAction';
@@ -23,16 +23,198 @@ import {
   lineTitle,
   lineBlurb,
 } from './quoteTypes';
-import { UNAUTHORIZED, type LineUpdate, SrSaved, fieldRing, pendingKey, seamless } from './quoteEditorShared';
+import { UNAUTHORIZED, type LineUpdate, SrSaved, fieldRing, pendingKey, seamless, unsavedHintId, UnsavedFieldHint } from './quoteEditorShared';
+
+/** A line's reveal-on-demand target for the rail's actionable "missing cost"
+ *  notice (MarginPanel → QuoteEditor → here): `nonce` bumps on every click so
+ *  the SAME first-offending line can be re-revealed after the user scrolls
+ *  away, since a repeated `lineId` alone wouldn't re-trigger the effect. */
+export interface LineRevealRequest {
+  lineId: string;
+  nonce: number;
+}
+
+/** Joins conditional aria-describedby ids (error + unsaved can co-occur). */
+function describedByIds(...ids: (string | null | undefined | false)[]): string | undefined {
+  const list = ids.filter((x): x is string => Boolean(x));
+  return list.length ? list.join(' ') : undefined;
+}
+
+// ── Money-input helpers (unit price / internal cost / ghost price) ────────
+// These fields show a currency-formatted value ("$1,234.56") while blurred and
+// the raw editable decimal while focused — the adjacent read-only cells (Total,
+// Cost/Markup/Profit summary) already render via formatMoney, so a plain
+// "1234.56" in the editable twin read as a formatting bug. Values keep
+// committing off the RAW decimal string (unchanged commit* functions below);
+// only the rendered `value` and the onChange filter live here.
+
+// Keystroke filter: keep digits and at most one decimal point. These fields are
+// all min=0 (price/cost never go negative), so stripping everything else means
+// a garbage/non-numeric commit is structurally impossible from typing — no "."-
+// only edge case aside, which the existing commit-time Number.isFinite guard
+// already rejects without losing the user's entry.
+function filterMoneyChars(raw: string): string {
+  let out = '';
+  let seenDot = false;
+  for (const ch of raw) {
+    if (ch >= '0' && ch <= '9') out += ch;
+    else if (ch === '.' && !seenDot) { out += ch; seenDot = true; }
+  }
+  return out;
+}
+
+// ch-based width so a 7-digit price or a "155.1" markup is never clipped by the
+// old fixed w-20/w-24/w-16 — grows with the displayed value, clamped so a
+// single keystroke can't make the row jump wildly and floored so short values
+// keep the prior visual width (row rhythm unchanged).
+function growWidth(value: string, minCh: number, maxCh: number): string {
+  const ch = Math.min(maxCh, Math.max(minCh, value.length + 2));
+  return `${ch}ch`;
+}
+
+// ── Internal-band progressive disclosure (shared by both row variants) ────
+// The cost/markup band defaults to a compact one-line summary per line
+// ("Cost $45.00 · Markup 20% · Profit $108.00"); the full micro-form only
+// appears after a per-line expand. Ten controls per line across a long quote
+// was a wall of forms — the summary keeps the glanceable numbers without it.
+
+// Compact summary shown while a line's band is collapsed. Values arrive as
+// pre-formatted strings so the editable variant can reflect live (uncommitted)
+// field state and the readonly variant the persisted line.
+function InternalBandSummary({ lineId, sku, costStr, costMissing, markupStr, profitStr }: {
+  lineId: string; sku: string; costStr: string;
+  /** True when the line has no cost — flags the "Cost —" figure warning-colored
+   *  (with an icon + aria-label) so the gap is visible even collapsed, not just
+   *  once the band is expanded. */
+  costMissing: boolean;
+  markupStr: string; profitStr: string;
+}) {
+  const { t } = useTranslation('billing');
+  const dot = <span aria-hidden="true">·</span>;
+  return (
+    <span
+      className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-0.5 text-left font-normal normal-case tracking-normal"
+      data-testid={`quote-line-internal-summary-${lineId}`}
+    >
+      {sku && (
+        <>
+          <span className="max-w-40 truncate">{t('quotes.editor.line.sku')} {sku}</span>
+          {dot}
+        </>
+      )}
+      {costMissing ? (
+        <span
+          className="inline-flex items-center gap-1 tabular-nums text-warning-foreground dark:text-warning"
+          aria-label={t('quotes.editor.line.costMissingAria')}
+          data-testid={`quote-line-cost-missing-${lineId}`}
+        >
+          <AlertTriangle className="h-3 w-3 shrink-0" aria-hidden="true" />
+          {t('quotes.editor.line.cost')} {costStr}
+        </span>
+      ) : (
+        <span className="tabular-nums">{t('quotes.editor.line.cost')} {costStr}</span>
+      )}
+      {dot}
+      <span className="tabular-nums">{t('quotes.editor.line.markup')} {markupStr}</span>
+      {dot}
+      <span>{t('quotes.editor.line.profit')}{' '}
+        <span className="font-medium tabular-nums text-foreground">{profitStr}</span>
+      </span>
+    </span>
+  );
+}
+
+// Animated expand/collapse shell for the band's full detail. A <tr> can't
+// height-animate, so the inner grid does (rows 0fr→1fr), 200ms ease-out with
+// an instant motion-reduce variant. Collapsed content stays MOUNTED — local
+// field state, draft wiring and testids survive — but is inert + aria-hidden
+// so it leaves the tab order and the a11y tree.
+function InternalBandCollapse({ expanded, testId, children }: { expanded: boolean; testId: string; children: ReactNode }) {
+  return (
+    <div
+      className={`grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none ${expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}
+      inert={!expanded || undefined}
+      aria-hidden={!expanded}
+      data-testid={testId}
+    >
+      <div className="min-h-0 overflow-hidden">{children}</div>
+    </div>
+  );
+}
+
+// The band's disclosure trigger: chevron + "Internal" tag + (when collapsed)
+// the summary. The whole strip is the button — a bigger target than a lone
+// chevron — with the focus-visible ring pattern used across the editor.
+function InternalBandToggle({ lineId, isFirst, expanded, onToggle, summary }: {
+  lineId: string; isFirst: boolean; expanded: boolean; onToggle: () => void; summary: ReactNode;
+}) {
+  const { t } = useTranslation('billing');
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={expanded}
+      title={t('quotes.editor.internal.full')}
+      data-testid={`quote-line-internal-toggle-${lineId}`}
+      className="flex w-full items-center gap-2 rounded text-left focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <ChevronRight
+        className={`h-3 w-3 shrink-0 transition-transform duration-200 ease-out motion-reduce:transition-none ${expanded ? 'rotate-90' : ''}`}
+        aria-hidden="true"
+      />
+      {/* Full disclaimer on the first row, the subtle "Internal" tag on the
+          rest (the title tooltip carries the full wording everywhere). */}
+      <span className="shrink-0 font-medium uppercase tracking-wide">
+        {isFirst ? t('quotes.editor.internal.full') : t('quotes.editor.internal.short')}
+      </span>
+      {!expanded && summary}
+    </button>
+  );
+}
+
+// Read-only long-description clamp: > ~4 lines collapses behind a Show more /
+// Show less affordance. Pure presentation — the full text always renders into
+// the DOM. jsdom reports zero heights, so unit tests exercise the unclamped path.
+function ClampedBlurb({ lineId, text }: { lineId: string; text: string }) {
+  const { t } = useTranslation('billing');
+  const ref = useRef<HTMLDivElement>(null);
+  const [long, setLong] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+  // Measure overflow only while clamped (expanded content never overflows);
+  // once `long` latches the toggle persists so the user can re-collapse.
+  useEffect(() => {
+    if (showAll) return;
+    const el = ref.current;
+    if (el) setLong(el.scrollHeight > el.clientHeight + 1);
+  }, [text, showAll]);
+  return (
+    <>
+      <div ref={ref} className={`whitespace-pre-line text-xs text-muted-foreground ${showAll ? '' : 'line-clamp-4'}`}>{text}</div>
+      {long && (
+        <button
+          type="button"
+          onClick={() => setShowAll((v) => !v)}
+          aria-expanded={showAll}
+          data-testid={`quote-line-blurb-toggle-${lineId}`}
+          className="mt-0.5 inline-flex items-center rounded text-xs font-medium text-muted-foreground hover:text-foreground focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {showAll ? t('quotes.editor.line.showLess') : t('quotes.editor.line.showMore')}
+        </button>
+      )}
+    </>
+  );
+}
 
 // The ghost row: an always-ready entry row at the foot of every pricing table.
 // Type a name, Tab through qty/price/cadence, press Enter — the line commits
 // and focus returns to the name for the next one. This is the fast lane for the
 // daily compose loop; the full picker (catalog / AI lookup / distributor / SKU
-// and cost fields) stays available behind the "More ways to add" disclosure.
-export function GhostRow({ blockId, busy, onAdd, colSpan }: {
+// and cost fields) stays available behind the explicit "Add from catalog" /
+// "AI lookup" / "More details" entry points (QuoteBlockCard).
+export function GhostRow({ blockId, busy, currency, onAdd, colSpan }: {
   blockId: string;
   busy: boolean;
+  currency: string;
   onAdd: (form: { name: string; description: string; quantity: string; unitPrice: string; cost: string; sku: string; partNumber: string; taxable: boolean; recurrence: QuoteLineRecurrence; saveToCatalog: boolean }) => Promise<boolean>;
   colSpan: number;
 }) {
@@ -40,6 +222,7 @@ export function GhostRow({ blockId, busy, onAdd, colSpan }: {
   const [name, setName] = useState('');
   const [qty, setQty] = useState('1');
   const [price, setPrice] = useState('');
+  const [priceFocused, setPriceFocused] = useState(false);
   const [rec, setRec] = useState<QuoteLineRecurrence>('one_time');
   const [error, setError] = useState<string | null>(null);
   const nameRef = useRef<HTMLInputElement>(null);
@@ -80,9 +263,25 @@ export function GhostRow({ blockId, busy, onAdd, colSpan }: {
   };
   const ghostField = 'h-9 rounded-md border border-transparent bg-transparent transition-colors hover:border-border focus:border-border focus:outline-hidden disabled:opacity-60';
 
+  // An untouched ghost row is a single quiet affordance: only the name field
+  // shows until the user types a name or focuses into the row — then the
+  // qty/price/cadence chrome appears. Focus is tracked on the row (bubbling
+  // focus/blur) so tabbing between the row's own fields never hides them.
+  const [focusWithin, setFocusWithin] = useState(false);
+  const active = name.trim() !== '' || focusWithin;
+  // Width is sized off whichever string is actually on screen — the formatted
+  // display ("$1,234.56") is longer than the raw decimal, so basing width on
+  // the raw value alone would clip the currency symbol/separators once unfocused.
+  const ghostPriceDisplay = priceFocused || price.trim() === '' ? price : formatMoney(price, currency);
+
   return (
     <>
-      <tr className="border-t" data-testid={`quote-ghost-row-${blockId}`}>
+      <tr
+        className="border-t"
+        data-testid={`quote-ghost-row-${blockId}`}
+        onFocus={() => setFocusWithin(true)}
+        onBlur={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setFocusWithin(false); }}
+      >
         <td className="px-1.5 py-1.5">
           <input
             ref={nameRef}
@@ -106,20 +305,23 @@ export function GhostRow({ blockId, busy, onAdd, colSpan }: {
             disabled={busy}
             aria-label={t('quotes.editor.line.quantityAria')}
             data-testid={`quote-ghost-qty-${blockId}`}
-            className={`${ghostField} w-14 px-2 text-right text-sm tabular-nums`}
+            className={`${ghostField} w-14 px-2 text-right text-sm tabular-nums ${active ? '' : 'hidden'}`}
           />
         </td>
         <td className="px-1.5 py-1.5 text-right">
           <input
-            type="number" min="0" step="0.01"
-            value={price}
-            onChange={(e) => { setPrice(e.target.value); setError(null); }}
+            type="text" inputMode="decimal"
+            value={ghostPriceDisplay}
+            onFocus={() => setPriceFocused(true)}
+            onChange={(e) => { setPrice(filterMoneyChars(e.target.value)); setError(null); }}
+            onBlur={() => setPriceFocused(false)}
             onKeyDown={onKeyDown}
             disabled={busy}
             placeholder="0.00"
             aria-label={t('quotes.editor.table.unitPrice')}
             data-testid={`quote-ghost-price-${blockId}`}
-            className={`${ghostField} w-24 px-2 text-right text-sm tabular-nums`}
+            style={{ width: growWidth(ghostPriceDisplay, 8, 16) }}
+            className={`${ghostField} px-2 text-right text-sm tabular-nums ${active ? '' : 'hidden'}`}
           />
           <select
             value={rec}
@@ -128,7 +330,7 @@ export function GhostRow({ blockId, busy, onAdd, colSpan }: {
             disabled={busy}
             aria-label={t('quotes.editor.line.billingFrequencyAria')}
             data-testid={`quote-ghost-recurrence-${blockId}`}
-            className="ml-auto mt-1 block h-7 w-24 rounded-md border border-transparent bg-transparent py-0 pl-2 pr-6 text-xs text-muted-foreground transition-colors hover:border-border focus:border-border focus:outline-hidden disabled:opacity-60"
+            className={`ml-auto mt-1 h-7 w-24 rounded-md border border-transparent bg-transparent py-0 pl-2 pr-6 text-xs text-muted-foreground transition-colors hover:border-border focus:border-border focus:outline-hidden disabled:opacity-60 ${active ? 'block' : 'hidden'}`}
           >
             <option value="one_time">{t('quotes.editor.recurrence.one_time')}</option>
             <option value="monthly">{t('quotes.editor.recurrence.monthly')}</option>
@@ -165,19 +367,37 @@ export function GhostRow({ blockId, busy, onAdd, colSpan }: {
 // ── A single read-only pricing-table line (no write permission) ───────────
 // Mirrors EditableLineRow's two-row shape — the customer-facing cells plus the
 // internal cost/markup/net band — but renders everything as plain text.
-export function ReadonlyLineRow({ line: l, quoteId, currency, taxRate, isFirst, showInternal }: { line: QuoteLine; quoteId: string; currency: string; taxRate: string | null; isFirst: boolean; showInternal: boolean }) {
+export function ReadonlyLineRow({ line: l, quoteId, currency, taxRate, isFirst, showInternal, mixedCadence, revealRequest }: { line: QuoteLine; quoteId: string; currency: string; taxRate: string | null; isFirst: boolean; showInternal: boolean; mixedCadence: boolean; revealRequest?: LineRevealRequest | null }) {
   const { t } = useTranslation('billing');
+  const na = t('quotes.editor.symbols.notAvailable');
   const mk = markupPct(l.unitPrice, l.unitCost);
-  const markupStr = mk === null ? t('quotes.editor.symbols.notAvailable') : formatPercent(mk / 100, { maximumFractionDigits: 2 });
+  const markupStr = mk === null ? na : formatPercent(mk / 100, { maximumFractionDigits: 2 });
   const netCents = l.unitCost === null
     ? null
     : toCents(computeLineTotal(l.quantity, l.unitPrice)) - toCents(computeLineTotal(l.quantity, l.unitCost));
   const tax = lineTaxAmount(l.lineTotal, l.taxable, taxRate);
-  // Billing cadence rides in the money cells ('/mo', '/yr'); one-time is unmarked.
-  const suffix = l.recurrence === 'monthly' ? t('quotes.editor.units.perMonth') : l.recurrence === 'annual' ? t('quotes.editor.units.perYear') : '';
+  // Billing cadence rides in the money cells ('/mo', '/yr'); one-time is
+  // unmarked. When every line on the quote shares one cadence the suffix is
+  // pure repetition, so it only renders when cadences are actually mixed.
+  const suffix = !mixedCadence ? '' : l.recurrence === 'monthly' ? t('quotes.editor.units.perMonth') : l.recurrence === 'annual' ? t('quotes.editor.units.perYear') : '';
+  const blurb = lineBlurb(l);
+  // Collapsed summary by default; expanding shows the full SKU/PN/cost detail.
+  const [internalOpen, setInternalOpen] = useState(false);
+  // Reveal-on-demand: the rail's "missing cost" notice can request this exact
+  // line be scrolled into view + expanded (see EditableLineRow for the fuller
+  // writer-side version, which also focuses the cost input). Read-only rows
+  // have no cost input to focus, so this is scroll + expand only.
+  const rowRef = useRef<HTMLTableRowElement>(null);
+  useEffect(() => {
+    if (!revealRequest || revealRequest.lineId !== l.id) return;
+    setInternalOpen(true);
+    const reduceMotion = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    rowRef.current?.scrollIntoView?.({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'center' });
+  }, [revealRequest?.nonce, revealRequest?.lineId, l.id]);
   return (
     <>
-      <tr className="border-t [&>td]:pt-4" data-testid={`quote-line-${l.id}`}>
+      <tr ref={rowRef} className="border-t [&>td]:pt-4" data-testid={`quote-line-${l.id}`}>
         <td className="px-1.5 py-2">
           <div className="flex items-start gap-2">
             {l.imageId
@@ -185,7 +405,7 @@ export function ReadonlyLineRow({ line: l, quoteId, currency, taxRate, isFirst, 
               : l.catalogItemId && <CatalogLineThumb catalogItemId={l.catalogItemId} />}
             <div>
               <div className="font-medium">{lineTitle(l)}</div>
-              {lineBlurb(l) && <div className="whitespace-pre-line text-xs text-muted-foreground">{lineBlurb(l)}</div>}
+              {blurb && <ClampedBlurb lineId={l.id} text={blurb} />}
             </div>
           </div>
         </td>
@@ -204,18 +424,36 @@ export function ReadonlyLineRow({ line: l, quoteId, currency, taxRate, isFirst, 
       </tr>
       <tr className={`border-0 ${showInternal ? '' : 'hidden'}`} data-testid={`quote-line-internal-${l.id}`}>
         <td colSpan={4} className="px-2 pb-2">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md bg-muted/40 px-2 py-1 text-xs text-foreground/70 dark:text-muted-foreground">
-            {/* Full disclaimer on the first row, a subtle "Internal" tag on the rest. */}
-            <span className="font-medium uppercase tracking-wide">{isFirst ? t('quotes.editor.internal.full') : t('quotes.editor.internal.short')}</span>
-            <span data-testid={`quote-line-sku-${l.id}`}>{t('quotes.editor.line.sku')} {l.sku || t('quotes.editor.symbols.notAvailable')}</span>
-            <span data-testid={`quote-line-partnumber-${l.id}`}>{t('quotes.editor.line.partNumberAbbr')} {l.partNumber || t('quotes.editor.symbols.notAvailable')}</span>
-            <span data-testid={`quote-line-cost-${l.id}`}>{t('quotes.editor.line.cost')} {l.unitCost === null ? t('quotes.editor.symbols.notAvailable') : formatMoney(l.unitCost, currency)}</span>
-            <span data-testid={`quote-line-markup-${l.id}`}>{t('quotes.editor.line.markup')} {markupStr}</span>
-            <span className="ml-auto">{t('quotes.editor.line.profit')}{' '}
-              <span className="font-medium tabular-nums text-foreground" data-testid={`quote-line-net-${l.id}`}>
-                {netCents === null ? t('quotes.editor.symbols.notAvailable') : formatMoney(fromCents(netCents), currency)}
-              </span>
-            </span>
+          <div className="rounded-md bg-muted/40 px-2 py-1 text-xs text-foreground/70 dark:text-muted-foreground">
+            <InternalBandToggle
+              lineId={l.id}
+              isFirst={isFirst}
+              expanded={internalOpen}
+              onToggle={() => setInternalOpen((v) => !v)}
+              summary={
+                <InternalBandSummary
+                  lineId={l.id}
+                  sku={l.sku ?? ''}
+                  costStr={l.unitCost === null ? na : formatMoney(l.unitCost, currency)}
+                  costMissing={l.unitCost === null}
+                  markupStr={markupStr}
+                  profitStr={netCents === null ? na : formatMoney(fromCents(netCents), currency)}
+                />
+              }
+            />
+            <InternalBandCollapse expanded={internalOpen} testId={`quote-line-internal-detail-${l.id}`}>
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pb-0.5 pt-1.5">
+                <span data-testid={`quote-line-sku-${l.id}`}>{t('quotes.editor.line.sku')} {l.sku || na}</span>
+                <span data-testid={`quote-line-partnumber-${l.id}`}>{t('quotes.editor.line.partNumberAbbr')} {l.partNumber || na}</span>
+                <span data-testid={`quote-line-cost-${l.id}`}>{t('quotes.editor.line.cost')} {l.unitCost === null ? na : formatMoney(l.unitCost, currency)}</span>
+                <span data-testid={`quote-line-markup-${l.id}`}>{t('quotes.editor.line.markup')} {markupStr}</span>
+                <span className="ml-auto">{t('quotes.editor.line.profit')}{' '}
+                  <span className="font-medium tabular-nums text-foreground" data-testid={`quote-line-net-${l.id}`}>
+                    {netCents === null ? na : formatMoney(fromCents(netCents), currency)}
+                  </span>
+                </span>
+              </div>
+            </InternalBandCollapse>
           </div>
         </td>
       </tr>
@@ -232,8 +470,8 @@ export function ReadonlyLineRow({ line: l, quoteId, currency, taxRate, isFirst, 
 // state to the incoming prop so server-side normalization (e.g. recomputed
 // totals, clamped quantity) wins.
 export function EditableLineRow({
-  line, quoteId, currency, taxRate, isPending, isFirst, isLast, showInternal, depositSelectMode, onEdit, onMove, onRemove, onDraft,
-  moveTargets, onMoveTo,
+  line, quoteId, currency, taxRate, isPending, isFirst, isLast, showInternal, mixedCadence, depositSelectMode, onEdit, onMove, onRemove, onDraft,
+  moveTargets, onMoveTo, revealRequest, dragging, onDragStartRow, onDragEndRow,
 }: {
   line: QuoteLine;
   quoteId: string;
@@ -243,6 +481,9 @@ export function EditableLineRow({
   isFirst: boolean;
   isLast: boolean;
   showInternal: boolean;
+  /** True when the quote's lines span more than one billing cadence — only then
+   *  does the Total cell repeat the '/mo' | '/yr' suffix. */
+  mixedCadence: boolean;
   /** Show the deposit-eligible checkbox (quote deposit = 'selected_lines'). */
   depositSelectMode: boolean;
   onEdit: (lineId: string, body: LineUpdate, scopeKey?: string) => Promise<boolean>;
@@ -252,6 +493,17 @@ export function EditableLineRow({
   /** Other pricing panels (empty → the Move-to control is hidden). */
   moveTargets: { id: string; label: string }[];
   onMoveTo: (line: QuoteLine, targetBlockId: string) => void;
+  /** Set (with a bumped nonce) when the rail's "missing cost" notice targets
+   *  THIS line: scrolls it into view, expands the internal band, and focuses
+   *  the cost input. See the effect below and LineRevealRequest's doc. */
+  revealRequest?: LineRevealRequest | null;
+  /** True while THIS row is being dragged (dims the row, like block drags). */
+  dragging?: boolean;
+  /** Wired by BlockCard when within-block drag-reorder is available: the grip
+   *  handle renders only when this is set. Keyboard users keep the ⋯ menu's
+   *  Move up/down as the accessible alternative (noted in the handle's title). */
+  onDragStartRow?: () => void;
+  onDragEndRow?: () => void;
 }) {
   const { t } = useTranslation('billing');
   // Per-field pending: only the in-flight control disables, so a slow qty save
@@ -271,6 +523,13 @@ export function EditableLineRow({
   // input matches its own step="1" and the customer-facing rendering.
   const [qty, setQty] = useState(formatQuantity(line.quantity));
   const [price, setPrice] = useState(line.unitPrice);
+  // Money-input focus tracking: formatted (currency, thousands-separated) while
+  // blurred, raw editable decimal while focused — see the filterMoneyChars /
+  // growWidth helpers above. An in-flight field error keeps the RAW string
+  // visible even unfocused, so a rejected entry stays legible to correct rather
+  // than collapsing into a misleading "$0.00".
+  const [priceFocused, setPriceFocused] = useState(false);
+  const [costFocused, setCostFocused] = useState(false);
   // recurrence/taxable are committed on change (not blur); keep them in local
   // state so the control updates instantly rather than lagging until the
   // refresh() round-trip lands, and revert if the save fails.
@@ -320,13 +579,17 @@ export function EditableLineRow({
   const descEdited = useRef(false);
   // Auto-grow the (full-width) description textarea to fit its content, while
   // still allowing the user to drag the resize handle for a bigger/smaller box.
+  // Long descriptions (> ~4 lines) clamp to a fixed cap while the field is
+  // neither focused nor explicitly expanded — a Show more/less affordance and
+  // focus both lift the cap. Presentation only: the full text always stays in
+  // the field value. (jsdom reports scrollHeight 0, so unit tests always take
+  // the unclamped path unless they stub the metric.)
+  const DESC_CLAMP_PX = 88; // ≈ 4 lines of text-sm (20px line-height) + padding
   const descRef = useRef<HTMLTextAreaElement>(null);
-  const autoGrowDesc = () => {
-    const el = descRef.current;
-    if (!el) return;
-    el.style.height = 'auto';
-    el.style.height = `${el.scrollHeight}px`;
-  };
+  const [descFocused, setDescFocused] = useState(false);
+  const [descShowAll, setDescShowAll] = useState(false);
+  const [descLong, setDescLong] = useState(false);
+  const descClamped = descLong && !descFocused && !descShowAll;
   const qtyEdited = useRef(false);
   const priceEdited = useRef(false);
   const costEdited = useRef(false);
@@ -334,8 +597,17 @@ export function EditableLineRow({
   const partEdited = useRef(false);
   useEffect(() => { if (!nameEdited.current) setName(line.name ?? ''); }, [line.name]);
   useEffect(() => { if (!descEdited.current) setDesc(line.description ?? ''); }, [line.description]);
-  // Re-fit the description box after any value change (typing or server resync).
-  useEffect(() => { autoGrowDesc(); }, [desc]);
+  // Re-fit the description box after any value change (typing or server resync)
+  // or clamp-state flip: measure the full height at auto, latch whether the
+  // content is long, then apply either the cap or the full height.
+  useEffect(() => {
+    const el = descRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    const full = el.scrollHeight;
+    setDescLong(full > DESC_CLAMP_PX + 8);
+    el.style.height = `${descClamped ? Math.min(full, DESC_CLAMP_PX) : full}px`;
+  }, [desc, descClamped, descOpen]);
   useEffect(() => { if (!qtyEdited.current) setQty(formatQuantity(line.quantity)); }, [line.quantity]);
   useEffect(() => { if (!priceEdited.current) setPrice(line.unitPrice); }, [line.unitPrice]);
   useEffect(() => { if (!costEdited.current) setCost(line.unitCost ?? ''); }, [line.unitCost]);
@@ -493,8 +765,57 @@ export function EditableLineRow({
     ? null
     : toCents(computeLineTotal(effQty, effPrice)) - toCents(computeLineTotal(effQty, cost));
   const costDirty = cost.trim() === '' ? line.unitCost !== null : Number(cost) !== Number(line.unitCost);
+  // Independent of `costDirty` (unsaved-vs-persisted): true whenever the FIELD
+  // is currently empty, saved or not — drives the warning treatment (Task 2)
+  // that flags a genuinely missing cost, as opposed to an in-flight edit.
+  const costMissing = cost.trim() === '';
+  // Displayed strings for the price/cost inputs — currency-formatted while
+  // blurred (matching the adjacent read-only Total/summary cells), the raw
+  // decimal while focused or mid-error (so a rejected entry stays legible to
+  // correct). Width is sized off these — the formatted form ("$1,234.56") is
+  // longer than the raw decimal, so basing width on the raw value alone would
+  // clip the currency symbol/separators once unfocused.
+  const priceDisplay = priceFocused || fieldErrors.price ? price : formatMoney(price, currency);
+  const costDisplay = costFocused || fieldErrors.cost ? cost : (cost.trim() === '' ? '' : formatMoney(cost, currency));
   const skuDirty = sku.trim() !== (line.sku ?? '');
   const partDirty = partNumber.trim() !== (line.partNumber ?? '');
+
+  // Per-line internal-band disclosure: collapsed (summary-only) by default,
+  // component-local, never persisted. An unsaved cost/SKU/PN edit (or an inline
+  // cost error) pins the band open — a collapse request only takes effect once
+  // the edit lands and the server prop resync clears the dirty flag, so unsaved
+  // internal edits are never hidden mid-flight.
+  const [internalOpen, setInternalOpen] = useState(false);
+  const internalDirty = costDirty || skuDirty || partDirty;
+  const internalExpanded = internalOpen || internalDirty || Boolean(fieldErrors.cost);
+
+  // Reveal-on-demand (Task 3 UX pass): the rail's actionable "missing cost"
+  // notice can target THIS line — scroll it into view, force the internal band
+  // open, and focus the cost input. `rowRef` anchors the scroll; `costInputRef`
+  // is the focus target.
+  const rowRef = useRef<HTMLTableRowElement>(null);
+  const costInputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (!revealRequest || revealRequest.lineId !== line.id) return;
+    setInternalOpen(true);
+    const reduceMotion = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    rowRef.current?.scrollIntoView?.({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'center' });
+    // The band can still be `inert` for one render right after setInternalOpen
+    // (React hasn't committed yet) — retry across a few frames until the input
+    // is actually reachable, the same idiom as GhostRow's post-save refocus
+    // above. Checked via the DOM attribute directly rather than relying on
+    // `inert`'s focus-blocking behavior, which jsdom doesn't implement.
+    const tryFocus = (tries: number) => {
+      const el = costInputRef.current;
+      if (el && !el.closest('[inert]')) { el.focus(); return; }
+      if (tries > 0) requestAnimationFrame(() => tryFocus(tries - 1));
+    };
+    requestAnimationFrame(() => tryFocus(10));
+    // Only the reveal request identity should re-trigger this — line.id is
+    // stable per row instance, and re-running on every internalOpen/dirty
+    // change would fight the user's own toggle.
+  }, [revealRequest?.nonce, revealRequest?.lineId, line.id]);
 
   // Report this row's effective values to the parent so the rail "Live totals"
   // recompute uses the same inputs. Emit null once nothing diverges, so the rail
@@ -596,7 +917,7 @@ export function EditableLineRow({
 
   return (
     <>
-    <tr className="border-t align-top [&>td]:pt-4" data-testid={`quote-line-${line.id}`}>
+    <tr ref={rowRef} className={`border-t align-top [&>td]:pt-4 ${dragging ? 'opacity-40' : ''}`} data-testid={`quote-line-${line.id}`}>
       {/* Column min-width (min-w-[12rem]) is declared on the cell so table
           auto-layout reserves the name column instead of squeezing it below the
           input's width (which used to overflow into the qty cell). */}
@@ -614,9 +935,11 @@ export function EditableLineRow({
               onChange={(e) => { setName(e.target.value); nameEdited.current = true; }}
               onBlur={commitName}
               disabled={fieldBusy('name')}
+              aria-describedby={nameDirty ? unsavedHintId(line.id, 'name') : undefined}
               data-testid={`quote-line-name-${line.id}`}
               className={`h-9 w-full rounded-md border bg-transparent px-2 py-1 text-sm font-medium transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(nameDirty, saved))}`}
             />
+            <UnsavedFieldHint id={unsavedHintId(line.id, 'name')} show={nameDirty} />
           </div>
         </div>
       </td>
@@ -629,24 +952,28 @@ export function EditableLineRow({
           onBlur={commitQty}
           disabled={fieldBusy('qty')}
           aria-invalid={fieldErrors.qty ? true : undefined}
-          aria-describedby={fieldErrors.qty ? `quote-line-qty-error-${line.id}` : undefined}
+          aria-describedby={describedByIds(fieldErrors.qty && `quote-line-qty-error-${line.id}`, qtyDirty && unsavedHintId(line.id, 'qty'))}
           data-testid={`quote-line-qty-${line.id}`}
           className={`h-9 w-14 rounded-md border bg-transparent px-2 text-right text-sm tabular-nums transition-colors focus:outline-hidden disabled:opacity-60 ${fieldErrors.qty ? 'border-destructive' : seamless(fieldRing(qtyDirty, saved))}`}
         />
+        <UnsavedFieldHint id={unsavedHintId(line.id, 'qty')} show={qtyDirty} />
       </td>
       <td className="px-1.5 py-2 text-right">
         <input
-          type="number" min="0" step="0.01"
-          value={price}
+          type="text" inputMode="decimal"
+          value={priceDisplay}
           aria-label={t('quotes.editor.table.unitPrice')}
-          onChange={(e) => { setPrice(e.target.value); priceEdited.current = true; setFieldError('price', null); }}
-          onBlur={commitPrice}
+          onFocus={() => setPriceFocused(true)}
+          onChange={(e) => { setPrice(filterMoneyChars(e.target.value)); priceEdited.current = true; setFieldError('price', null); }}
+          onBlur={() => { setPriceFocused(false); commitPrice(); }}
           disabled={fieldBusy('price')}
           aria-invalid={fieldErrors.price ? true : undefined}
-          aria-describedby={fieldErrors.price ? `quote-line-price-error-${line.id}` : undefined}
+          aria-describedby={describedByIds(fieldErrors.price && `quote-line-price-error-${line.id}`, priceDirty && unsavedHintId(line.id, 'price'))}
           data-testid={`quote-line-price-${line.id}`}
-          className={`h-9 w-24 rounded-md border bg-transparent px-2 text-right text-sm tabular-nums transition-colors focus:outline-hidden disabled:opacity-60 ${fieldErrors.price ? 'border-destructive' : seamless(fieldRing(priceDirty, saved))}`}
+          style={{ width: growWidth(priceDisplay, 8, 16) }}
+          className={`h-9 rounded-md border bg-transparent px-2 text-right text-sm tabular-nums transition-colors focus:outline-hidden disabled:opacity-60 ${fieldErrors.price ? 'border-destructive' : seamless(fieldRing(priceDirty, saved))}`}
         />
+        <UnsavedFieldHint id={unsavedHintId(line.id, 'price')} show={priceDirty} />
         {/* Billing cadence belongs with the price ("$1,499.00 /mo"), so its
             select rides directly under the price input instead of claiming a
             table column of its own. */}
@@ -669,7 +996,9 @@ export function EditableLineRow({
       </td>
       <td className="whitespace-nowrap px-1.5 py-2 text-right tabular-nums">
         <span data-testid={`quote-line-total-${line.id}`}>{formatMoney(displayTotal, currency)}</span>
-        {rec !== 'one_time' && (
+        {/* Cadence suffix only when the quote actually mixes cadences — on a
+            uniform quote it's repetition (the recurrence select still shows it). */}
+        {mixedCadence && rec !== 'one_time' && (
           <span className="text-xs text-muted-foreground">{rec === 'monthly' ? t('quotes.editor.units.perMonth') : t('quotes.editor.units.perYear')}</span>
         )}
         <div className="text-xs font-normal text-muted-foreground" data-testid={`quote-line-tax-${line.id}`}>
@@ -679,14 +1008,36 @@ export function EditableLineRow({
         </div>
         <SrSaved show={saved} testId={`quote-line-saved-${line.id}`} />
       </td>
-      <td className="px-1.5 py-2 text-right">
+      <td className="whitespace-nowrap px-1.5 py-2 text-right">
+        {/* Drag-to-reorder grip (writers, within this table only). Mouse/touch
+            affordance — keyboard users reorder via the ⋯ menu's Move up/down,
+            which the title spells out. Cross-block moves stay menu-only. */}
+        {onDragStartRow && (
+          <button
+            type="button"
+            draggable
+            onDragStart={(e) => {
+              e.dataTransfer.effectAllowed = 'move';
+              e.dataTransfer.setData('text/plain', line.id);
+              onDragStartRow();
+            }}
+            onDragEnd={() => onDragEndRow?.()}
+            disabled={removeBusy}
+            aria-label={t('quotes.editor.actions.dragLine')}
+            title={t('quotes.editor.actions.dragLineTitle')}
+            data-testid={`quote-line-drag-${line.id}`}
+            className="mr-0.5 inline-flex h-7 w-7 cursor-grab items-center justify-center rounded align-middle text-muted-foreground hover:bg-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing disabled:opacity-30"
+          >
+            <GripVertical className="h-4 w-4" aria-hidden />
+          </button>
+        )}
         {/* ALL row-level actions live behind one overflow menu, so tabbing
             through a line is data-entry only — one stop instead of four, and
             no destructive button sitting mid-path between the price fields and
             the description. Same menu grammar as the header kebab
             (useMenuKeyboard: focus-on-open + arrow cycling; Esc-to-trigger is
             the local document-level handler above). */}
-        <div ref={moveMenuRef} className="inline-block">
+        <div ref={moveMenuRef} className="inline-block align-middle">
           <button
             ref={moveTriggerRef}
             type="button"
@@ -703,7 +1054,7 @@ export function EditableLineRow({
             aria-haspopup="menu"
             aria-expanded={movePos !== null}
             data-testid={`quote-line-actions-${line.id}`}
-            className="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted disabled:opacity-30"
+            className="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-30"
           >
             <MoreHorizontal className="h-4 w-4" aria-hidden />
           </button>
@@ -814,7 +1165,7 @@ export function EditableLineRow({
     </tr>
     {/* Full-width description row, so writers get a roomy, expandable box instead
         of a cramped textarea squeezed into the narrow Description column. */}
-    <tr className="border-0" data-testid={`quote-line-desc-row-${line.id}`}>
+    <tr className={`border-0 ${dragging ? 'opacity-40' : ''}`} data-testid={`quote-line-desc-row-${line.id}`}>
       <td colSpan={5} className="px-2 pb-2">
         {/* Inline errors for the row's qty/price inputs — rendered full-width
             directly under the row (the narrow cells above can't hold a message);
@@ -834,19 +1185,37 @@ export function EditableLineRow({
           </div>
         )}
         {descOpen && (
-          <textarea
-            ref={descRef}
-            value={desc}
-            aria-label={t('quotes.editor.line.descriptionAria')}
-            placeholder={t('quotes.editor.line.descriptionOptional')}
-            onChange={(e) => { setDesc(e.target.value); descEdited.current = true; autoGrowDesc(); }}
-            onBlur={commitDesc}
-            rows={2}
-            autoFocus={!(line.description ?? '').trim()}
-            disabled={fieldBusy('desc')}
-            data-testid={`quote-line-desc-${line.id}`}
-            className={`min-h-9 w-full resize-y overflow-hidden rounded-md border bg-transparent px-2 py-1 text-sm text-muted-foreground transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(descDirty, saved))}`}
-          />
+          <>
+            <textarea
+              ref={descRef}
+              value={desc}
+              aria-label={t('quotes.editor.line.descriptionAria')}
+              placeholder={t('quotes.editor.line.descriptionOptional')}
+              onChange={(e) => { setDesc(e.target.value); descEdited.current = true; }}
+              onFocus={() => setDescFocused(true)}
+              onBlur={() => { setDescFocused(false); commitDesc(); }}
+              rows={2}
+              autoFocus={!(line.description ?? '').trim()}
+              disabled={fieldBusy('desc')}
+              aria-describedby={descDirty ? unsavedHintId(line.id, 'desc') : undefined}
+              data-testid={`quote-line-desc-${line.id}`}
+              className={`min-h-9 w-full resize-y overflow-hidden rounded-md border bg-transparent px-2 py-1 text-sm text-muted-foreground transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(descDirty, saved))}`}
+            />
+            <UnsavedFieldHint id={unsavedHintId(line.id, 'desc')} show={descDirty} />
+            {/* Show more/less for a clamped long description. Focusing the
+                textarea also expands it, so this is mainly the mouse/AT path. */}
+            {descLong && (
+              <button
+                type="button"
+                onClick={() => setDescShowAll((v) => !v)}
+                aria-expanded={!descClamped}
+                data-testid={`quote-line-desc-clamp-toggle-${line.id}`}
+                className="mt-0.5 inline-flex items-center rounded text-xs font-medium text-muted-foreground hover:text-foreground focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                {descClamped ? t('quotes.editor.line.showMore') : t('quotes.editor.line.showLess')}
+              </button>
+            )}
+          </>
         )}
         <div className="mt-1 flex flex-wrap items-center gap-2">
           {/* Taxable moved out of its own table column: it's an editing control,
@@ -899,6 +1268,8 @@ export function EditableLineRow({
               disabled={fieldBusy('polish')}
               idSuffix={`quote-line-${line.id}`}
               compact
+              label={t('quotes.editor.line.tidyWithAi')}
+              icon={<Sparkles className="h-3 w-3" aria-hidden="true" />}
               getText={() => ({ name, description: desc })}
               onApply={(r) => {
                 const patch: { name?: string | null; description?: string | null } = {};
@@ -970,15 +1341,35 @@ export function EditableLineRow({
       </td>
     </tr>
     {/* Internal-only cost/markup/profit band — never shown to the customer.
-        Collapsed by default via the editor's "Show cost & margin" toggle; kept in
-        the DOM (hidden) rather than unmounted so totals/draft wiring stays live. */}
-    <tr className={`border-0 ${showInternal ? '' : 'hidden'}`} data-testid={`quote-line-internal-${line.id}`}>
+        Hidden entirely via the editor's "Show cost & margin" toggle; kept in
+        the DOM (hidden) rather than unmounted so totals/draft wiring stays live.
+        When shown, each line defaults to the compact summary; the full editing
+        micro-form appears behind the per-line disclosure. */}
+    <tr className={`border-0 ${showInternal ? '' : 'hidden'} ${dragging ? 'opacity-40' : ''}`} data-testid={`quote-line-internal-${line.id}`}>
       <td colSpan={5} className="px-2 pb-2">
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md bg-muted/40 px-2 py-1 text-xs text-foreground/70 dark:text-muted-foreground">
-          {/* Full disclaimer on the first row; a subtle "Internal" tag persists on
-              every following row so a writer scanning mid-table never mistakes the
-              cost/markup band for customer-facing copy. */}
-          <span className="font-medium uppercase tracking-wide">{isFirst ? t('quotes.editor.internal.full') : t('quotes.editor.internal.short')}</span>
+        <div className="rounded-md bg-muted/40 px-2 py-1 text-xs text-foreground/70 dark:text-muted-foreground">
+          {/* The toggle carries the disclaimer (full wording on the first row, the
+              subtle "Internal" tag on the rest) so a writer scanning mid-table
+              never mistakes the cost/markup band for customer-facing copy. The
+              summary reflects LIVE field state, not just the persisted line. */}
+          <InternalBandToggle
+            lineId={line.id}
+            isFirst={isFirst}
+            expanded={internalExpanded}
+            onToggle={() => setInternalOpen((v) => !v)}
+            summary={
+              <InternalBandSummary
+                lineId={line.id}
+                sku={sku.trim()}
+                costStr={cost.trim() === '' ? t('quotes.editor.symbols.notAvailable') : formatMoney(cost, currency)}
+                costMissing={costMissing}
+                markupStr={markupStr === '' ? t('quotes.editor.symbols.notAvailable') : `${markupStr}${t('quotes.editor.symbols.percent')}`}
+                profitStr={netCents === null ? t('quotes.editor.symbols.notAvailable') : formatMoney(fromCents(netCents), currency)}
+              />
+            }
+          />
+          <InternalBandCollapse expanded={internalExpanded} testId={`quote-line-internal-detail-${line.id}`}>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pb-0.5 pt-1.5">
           <label className="flex items-center gap-1">{t('quotes.editor.line.sku')}
             <input
               type="text"
@@ -986,9 +1377,11 @@ export function EditableLineRow({
               onChange={(e) => { setSku(e.target.value); skuEdited.current = true; }}
               onBlur={commitSku}
               disabled={fieldBusy('sku')}
+              aria-describedby={skuDirty ? unsavedHintId(line.id, 'sku') : undefined}
               data-testid={`quote-line-sku-${line.id}`}
               className={`h-6 w-28 rounded border bg-background px-1 text-foreground transition-shadow ${fieldRing(skuDirty, saved)}`}
             />
+            <UnsavedFieldHint id={unsavedHintId(line.id, 'sku')} show={skuDirty} />
           </label>
           <label className="flex items-center gap-1">{t('quotes.editor.line.partNumberAbbr')}
             <input
@@ -997,22 +1390,44 @@ export function EditableLineRow({
               onChange={(e) => { setPartNumber(e.target.value); partEdited.current = true; }}
               onBlur={commitPartNumber}
               disabled={fieldBusy('pn')}
+              aria-describedby={partDirty ? unsavedHintId(line.id, 'pn') : undefined}
               data-testid={`quote-line-partnumber-${line.id}`}
               className={`h-6 w-28 rounded border bg-background px-1 text-foreground transition-shadow ${fieldRing(partDirty, saved)}`}
             />
+            <UnsavedFieldHint id={unsavedHintId(line.id, 'pn')} show={partDirty} />
           </label>
           <label className="flex items-center gap-1">{t('quotes.editor.line.cost')}
             <input
-              type="number" min="0" step="0.01"
-              value={cost}
-              onChange={(e) => { setCost(e.target.value); costEdited.current = true; setFieldError('cost', null); }}
-              onBlur={commitCost}
+              ref={costInputRef}
+              type="text" inputMode="decimal"
+              value={costDisplay}
+              onFocus={() => setCostFocused(true)}
+              onChange={(e) => { setCost(filterMoneyChars(e.target.value)); costEdited.current = true; setFieldError('cost', null); }}
+              onBlur={() => { setCostFocused(false); commitCost(); }}
               disabled={fieldBusy('cost')}
               aria-invalid={fieldErrors.cost ? true : undefined}
-              aria-describedby={fieldErrors.cost ? `quote-line-cost-error-${line.id}` : undefined}
+              aria-describedby={describedByIds(
+                fieldErrors.cost && `quote-line-cost-error-${line.id}`,
+                costDirty && unsavedHintId(line.id, 'cost'),
+              )}
               data-testid={`quote-line-cost-${line.id}`}
-              className={`h-6 w-20 rounded border bg-background px-1 text-right tabular-nums text-foreground transition-shadow ${fieldErrors.cost ? 'border-destructive ring-1 ring-destructive' : fieldRing(costDirty, saved)}`}
+              style={{ width: growWidth(costDisplay, 6, 14) }}
+              // Priority: validation error (destructive) > unsaved edit (amber
+              // dirty ring) > a genuinely missing cost (warning tint — Task 2's
+              // "distinct from the amber dirty ring" treatment, using the same
+              // warning token family at lower opacity so it reads as related but
+              // not identical) > saved flash / rest.
+              className={`h-6 rounded border bg-background px-1 text-right tabular-nums text-foreground transition-shadow ${
+                fieldErrors.cost
+                  ? 'border-destructive ring-1 ring-destructive'
+                  : costDirty
+                    ? fieldRing(costDirty, saved)
+                    : costMissing
+                      ? 'border-warning/50'
+                      : fieldRing(false, saved)
+              }`}
             />
+            <UnsavedFieldHint id={unsavedHintId(line.id, 'cost')} show={costDirty} />
           </label>
           {fieldErrors.cost && (
             <p id={`quote-line-cost-error-${line.id}`} className="w-full text-xs font-normal normal-case tracking-normal text-destructive" data-testid={`quote-line-cost-error-${line.id}`}>
@@ -1032,7 +1447,8 @@ export function EditableLineRow({
               title={cost.trim() === '' ? t('quotes.editor.line.enterCostFirstMarkup') : undefined}
               aria-describedby={cost.trim() === '' ? `quote-line-markup-hint-${line.id}` : undefined}
               data-testid={`quote-line-markup-${line.id}`}
-              className="h-6 w-16 rounded border bg-background px-1 text-right tabular-nums text-foreground disabled:opacity-60"
+              style={{ width: growWidth(markupInput, 5, 10) }}
+              className="h-6 rounded border bg-background px-1 text-right tabular-nums text-foreground disabled:opacity-60"
             />{t('quotes.editor.symbols.percent')}
             {cost.trim() === '' && <span id={`quote-line-markup-hint-${line.id}`} className="sr-only">{t('quotes.editor.line.enterCostFirstMarkupSentence')}</span>}
           </label>
@@ -1041,6 +1457,8 @@ export function EditableLineRow({
               {netCents === null ? t('quotes.editor.symbols.notAvailable') : formatMoney(fromCents(netCents), currency)}
             </span>
           </span>
+          </div>
+          </InternalBandCollapse>
         </div>
       </td>
     </tr>

--- a/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
@@ -53,11 +53,26 @@ function describedByIds(...ids: (string | null | undefined | false)[]): string |
 // a garbage/non-numeric commit is structurally impossible from typing — no "."-
 // only edge case aside, which the existing commit-time Number.isFinite guard
 // already rejects without losing the user's entry.
-function filterMoneyChars(raw: string): string {
+export function filterMoneyChars(raw: string): string {
   let out = '';
   let seenDot = false;
   for (const ch of raw) {
     if (ch >= '0' && ch <= '9') out += ch;
+    else if (ch === '.' && !seenDot) { out += ch; seenDot = true; }
+  }
+  return out;
+}
+
+// Percent-only sibling of filterMoneyChars: markup is derived from price/cost
+// and CAN legitimately go negative (a line priced below cost is a real loss,
+// not a typo), so — unlike the money fields above — a single leading '-' is
+// let through before the digits/decimal point.
+export function filterPercentChars(raw: string): string {
+  let out = '';
+  let seenDot = false;
+  for (const ch of raw) {
+    if (ch === '-' && out === '') out += ch;
+    else if (ch >= '0' && ch <= '9') out += ch;
     else if (ch === '.' && !seenDot) { out += ch; seenDot = true; }
   }
   return out;
@@ -81,12 +96,18 @@ function growWidth(value: string, minCh: number, maxCh: number): string {
 // Compact summary shown while a line's band is collapsed. Values arrive as
 // pre-formatted strings so the editable variant can reflect live (uncommitted)
 // field state and the readonly variant the persisted line.
-function InternalBandSummary({ lineId, sku, costStr, costMissing, markupStr, profitStr }: {
+function InternalBandSummary({ lineId, sku, costStr, costMissing, noCost, markupStr, profitStr }: {
   lineId: string; sku: string; costStr: string;
   /** True when the line has no cost — flags the "Cost —" figure warning-colored
    *  (with an icon + aria-label) so the gap is visible even collapsed, not just
    *  once the band is expanded. */
   costMissing: boolean;
+  /** True when the cost is an EXPLICIT 0 (deliberately "no cost", e.g. labor —
+   *  Task B1), as distinct from `costMissing` (never entered / unknown). Swaps
+   *  the "Cost $0.00" figure for a plain "No cost" label and drops the Markup
+   *  segment (markup on a $0 cost base is undefined, mirrors markupPct's own
+   *  null-on-zero-cost rule) rather than showing a confusing "Markup —". */
+  noCost: boolean;
   markupStr: string; profitStr: string;
 }) {
   const { t } = useTranslation('billing');
@@ -98,7 +119,7 @@ function InternalBandSummary({ lineId, sku, costStr, costMissing, markupStr, pro
     >
       {sku && (
         <>
-          <span className="max-w-40 truncate">{t('quotes.editor.line.sku')} {sku}</span>
+          <span className="max-w-40 truncate" title={t('quotes.editor.line.skuHelp')}>{t('quotes.editor.line.sku')} {sku}</span>
           {dot}
         </>
       )}
@@ -111,11 +132,17 @@ function InternalBandSummary({ lineId, sku, costStr, costMissing, markupStr, pro
           <AlertTriangle className="h-3 w-3 shrink-0" aria-hidden="true" />
           {t('quotes.editor.line.cost')} {costStr}
         </span>
+      ) : noCost ? (
+        <span className="tabular-nums" data-testid={`quote-line-nocost-summary-${lineId}`}>{t('quotes.editor.line.noCost')}</span>
       ) : (
         <span className="tabular-nums">{t('quotes.editor.line.cost')} {costStr}</span>
       )}
-      {dot}
-      <span className="tabular-nums">{t('quotes.editor.line.markup')} {markupStr}</span>
+      {!noCost && (
+        <>
+          {dot}
+          <span className="tabular-nums">{t('quotes.editor.line.markup')} {markupStr}</span>
+        </>
+      )}
       {dot}
       <span>{t('quotes.editor.line.profit')}{' '}
         <span className="font-medium tabular-nums text-foreground">{profitStr}</span>
@@ -292,6 +319,7 @@ export function GhostRow({ blockId, busy, currency, onAdd, colSpan }: {
             disabled={busy}
             placeholder={t('quotes.editor.ghost.placeholder')}
             aria-label={t('quotes.editor.ghost.nameAria')}
+            title={name || undefined}
             data-testid={`quote-ghost-name-${blockId}`}
             className={`${ghostField} w-full px-2 text-sm placeholder:text-muted-foreground/70`}
           />
@@ -375,6 +403,10 @@ export function ReadonlyLineRow({ line: l, quoteId, currency, taxRate, isFirst, 
   const netCents = l.unitCost === null
     ? null
     : toCents(computeLineTotal(l.quantity, l.unitPrice)) - toCents(computeLineTotal(l.quantity, l.unitCost));
+  // Explicit cost=0 ("no cost", e.g. labor/service — Task B1) is distinct from
+  // a never-entered cost (null, flagged by costMissing below): it's a real,
+  // deliberately-zero value, not a gap.
+  const noCost = l.unitCost !== null && Number(l.unitCost) === 0;
   const tax = lineTaxAmount(l.lineTotal, l.taxable, taxRate);
   // Billing cadence rides in the money cells ('/mo', '/yr'); one-time is
   // unmarked. When every line on the quote shares one cadence the suffix is
@@ -404,7 +436,7 @@ export function ReadonlyLineRow({ line: l, quoteId, currency, taxRate, isFirst, 
               ? <LineImageThumb quoteId={quoteId} imageId={l.imageId} />
               : l.catalogItemId && <CatalogLineThumb catalogItemId={l.catalogItemId} />}
             <div>
-              <div className="font-medium">{lineTitle(l)}</div>
+              <div className="font-medium" title={lineTitle(l) || undefined}>{lineTitle(l)}</div>
               {blurb && <ClampedBlurb lineId={l.id} text={blurb} />}
             </div>
           </div>
@@ -436,6 +468,7 @@ export function ReadonlyLineRow({ line: l, quoteId, currency, taxRate, isFirst, 
                   sku={l.sku ?? ''}
                   costStr={l.unitCost === null ? na : formatMoney(l.unitCost, currency)}
                   costMissing={l.unitCost === null}
+                  noCost={noCost}
                   markupStr={markupStr}
                   profitStr={netCents === null ? na : formatMoney(fromCents(netCents), currency)}
                 />
@@ -443,8 +476,8 @@ export function ReadonlyLineRow({ line: l, quoteId, currency, taxRate, isFirst, 
             />
             <InternalBandCollapse expanded={internalOpen} testId={`quote-line-internal-detail-${l.id}`}>
               <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pb-0.5 pt-1.5">
-                <span data-testid={`quote-line-sku-${l.id}`}>{t('quotes.editor.line.sku')} {l.sku || na}</span>
-                <span data-testid={`quote-line-partnumber-${l.id}`}>{t('quotes.editor.line.partNumberAbbr')} {l.partNumber || na}</span>
+                <span title={t('quotes.editor.line.skuHelp')} data-testid={`quote-line-sku-${l.id}`}>{t('quotes.editor.line.sku')} {l.sku || na}</span>
+                <span title={t('quotes.editor.line.partNumberHelp')} data-testid={`quote-line-partnumber-${l.id}`}>{t('quotes.editor.line.partNumberAbbr')} {l.partNumber || na}</span>
                 <span data-testid={`quote-line-cost-${l.id}`}>{t('quotes.editor.line.cost')} {l.unitCost === null ? na : formatMoney(l.unitCost, currency)}</span>
                 <span data-testid={`quote-line-markup-${l.id}`}>{t('quotes.editor.line.markup')} {markupStr}</span>
                 <span className="ml-auto">{t('quotes.editor.line.profit')}{' '}
@@ -472,6 +505,7 @@ export function ReadonlyLineRow({ line: l, quoteId, currency, taxRate, isFirst, 
 export function EditableLineRow({
   line, quoteId, currency, taxRate, isPending, isFirst, isLast, showInternal, mixedCadence, depositSelectMode, onEdit, onMove, onRemove, onDraft,
   moveTargets, onMoveTo, revealRequest, dragging, onDragStartRow, onDragEndRow,
+  selected, selectionActive, onToggleSelected,
 }: {
   line: QuoteLine;
   quoteId: string;
@@ -504,6 +538,13 @@ export function EditableLineRow({
    *  Move up/down as the accessible alternative (noted in the handle's title). */
   onDragStartRow?: () => void;
   onDragEndRow?: () => void;
+  /** Bulk-edit selection (Task D). The checkbox is quiet — visible on row
+   *  hover/focus-within, when THIS row is selected, or while any selection is
+   *  active anywhere (`selectionActive`), so a started selection keeps every
+   *  target visible without the resting table growing permanent chrome. */
+  selected?: boolean;
+  selectionActive?: boolean;
+  onToggleSelected?: () => void;
 }) {
   const { t } = useTranslation('billing');
   // Per-field pending: only the in-flight control disables, so a slow qty save
@@ -577,8 +618,9 @@ export function EditableLineRow({
   //     value (e.g. 9.999 → 10.00), clearing the dirty ring and the optimism.
   const nameEdited = useRef(false);
   const descEdited = useRef(false);
-  // Auto-grow the (full-width) description textarea to fit its content, while
-  // still allowing the user to drag the resize handle for a bigger/smaller box.
+  // Auto-grow the (full-width) description textarea to fit its content — the
+  // box always matches what's typed, so the manual corner resize handle is
+  // dropped (resize-none below) rather than left as redundant, fightable chrome.
   // Long descriptions (> ~4 lines) clamp to a fixed cap while the field is
   // neither focused nor explicitly expanded — a Show more/less affordance and
   // focus both lift the cap. Presentation only: the full text always stays in
@@ -769,6 +811,9 @@ export function EditableLineRow({
   // is currently empty, saved or not — drives the warning treatment (Task 2)
   // that flags a genuinely missing cost, as opposed to an in-flight edit.
   const costMissing = cost.trim() === '';
+  // Explicit cost=0 ("no cost", e.g. labor/service — Task B1): a real,
+  // deliberately-zero value, distinct from costMissing (never entered).
+  const noCost = cost.trim() !== '' && Number(cost) === 0;
   // Displayed strings for the price/cost inputs — currency-formatted while
   // blurred (matching the adjacent read-only Total/summary cells), the raw
   // decimal while focused or mid-error (so a rejected entry stays legible to
@@ -892,6 +937,23 @@ export function EditableLineRow({
     setFieldError('cost', null);
     if (n !== Number(line.unitCost)) void edit({ unitCost: n }, 'cost');
   };
+  // "No cost" (Task B1): an explicit shortcut for labor/service lines that
+  // genuinely have no cost basis — sets unitCost to a literal 0 through the
+  // SAME commit path as typing "0" into the field, so it's excluded from
+  // linesMissingCost exactly like any other cost-bearing line. Unchecking
+  // reverts to empty/null (the same "unknown cost" state as clearing the
+  // field by hand), which re-enters the missing-cost warning.
+  const toggleNoCost = (checked: boolean) => {
+    costEdited.current = false;
+    setFieldError('cost', null);
+    if (checked) {
+      setCost('0');
+      if (line.unitCost === null || Number(line.unitCost) !== 0) void edit({ unitCost: 0 }, 'cost');
+    } else {
+      setCost('');
+      if (line.unitCost !== null) void edit({ unitCost: null }, 'cost');
+    }
+  };
   const commitSku = () => {
     skuEdited.current = false;
     const next = sku.trim();
@@ -917,12 +979,31 @@ export function EditableLineRow({
 
   return (
     <>
-    <tr ref={rowRef} className={`border-t align-top [&>td]:pt-4 ${dragging ? 'opacity-40' : ''}`} data-testid={`quote-line-${line.id}`}>
+    <tr ref={rowRef} className={`group/row border-t align-top [&>td]:pt-4 ${dragging ? 'opacity-40' : ''}`} data-testid={`quote-line-${line.id}`}>
       {/* Column min-width (min-w-[12rem]) is declared on the cell so table
           auto-layout reserves the name column instead of squeezing it below the
           input's width (which used to overflow into the qty cell). */}
       <td className="min-w-[12rem] px-1.5 py-2">
         <div className="flex min-w-0 items-start gap-2">
+          {/* Bulk-select checkbox — leading, in the same quiet reveal grammar as
+              the gutter grip: hidden at rest, shown on row hover/focus-within,
+              and pinned visible once any selection is active (or this row is
+              selected) so mid-selection the targets never vanish. It stays a
+              real, focusable checkbox even while transparent, so keyboard users
+              can Tab to it (focus reveals it via focus-within). */}
+          {onToggleSelected && (
+            <input
+              type="checkbox"
+              checked={selected ?? false}
+              onChange={onToggleSelected}
+              disabled={removeBusy}
+              aria-label={t('quotes.editor.bulk.selectLineAria', { name: lineTitle(line) || t('quotes.editor.confirm.thisLine') })}
+              data-testid={`quote-line-select-${line.id}`}
+              className={`mt-2.5 h-3.5 w-3.5 shrink-0 accent-primary transition-opacity focus-visible:opacity-100 ${
+                selected || selectionActive ? 'opacity-100' : 'opacity-0 group-focus-within/row:opacity-100 group-hover/row:opacity-100'
+              }`}
+            />
+          )}
           {line.imageId
             ? <LineImageThumb quoteId={quoteId} imageId={line.imageId} />
             : line.catalogItemId && <CatalogLineThumb catalogItemId={line.catalogItemId} />}
@@ -935,6 +1016,9 @@ export function EditableLineRow({
               onChange={(e) => { setName(e.target.value); nameEdited.current = true; }}
               onBlur={commitName}
               disabled={fieldBusy('name')}
+              // Exposes the full value on hover when it overflows the input's width —
+              // harmless (native no-op tooltip) when the name already fits.
+              title={name || undefined}
               aria-describedby={nameDirty ? unsavedHintId(line.id, 'name') : undefined}
               data-testid={`quote-line-name-${line.id}`}
               className={`h-9 w-full rounded-md border bg-transparent px-2 py-1 text-sm font-medium transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(nameDirty, saved))}`}
@@ -1199,7 +1283,11 @@ export function EditableLineRow({
               disabled={fieldBusy('desc')}
               aria-describedby={descDirty ? unsavedHintId(line.id, 'desc') : undefined}
               data-testid={`quote-line-desc-${line.id}`}
-              className={`min-h-9 w-full resize-y overflow-hidden rounded-md border bg-transparent px-2 py-1 text-sm text-muted-foreground transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(descDirty, saved))}`}
+              // resize-none: the effect above already keeps the box fit to its
+              // content on every change/clamp-state flip, so the manual drag
+              // handle is redundant chrome that only lets a user fight the
+              // auto-fit (drag taller, then the next keystroke snaps it back).
+              className={`min-h-9 w-full resize-none overflow-hidden rounded-md border bg-transparent px-2 py-1 text-sm text-muted-foreground transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(descDirty, saved))}`}
             />
             <UnsavedFieldHint id={unsavedHintId(line.id, 'desc')} show={descDirty} />
             {/* Show more/less for a clamped long description. Focusing the
@@ -1363,6 +1451,7 @@ export function EditableLineRow({
                 sku={sku.trim()}
                 costStr={cost.trim() === '' ? t('quotes.editor.symbols.notAvailable') : formatMoney(cost, currency)}
                 costMissing={costMissing}
+                noCost={noCost}
                 markupStr={markupStr === '' ? t('quotes.editor.symbols.notAvailable') : `${markupStr}${t('quotes.editor.symbols.percent')}`}
                 profitStr={netCents === null ? t('quotes.editor.symbols.notAvailable') : formatMoney(fromCents(netCents), currency)}
               />
@@ -1377,10 +1466,12 @@ export function EditableLineRow({
               onChange={(e) => { setSku(e.target.value); skuEdited.current = true; }}
               onBlur={commitSku}
               disabled={fieldBusy('sku')}
-              aria-describedby={skuDirty ? unsavedHintId(line.id, 'sku') : undefined}
+              title={t('quotes.editor.line.skuHelp')}
+              aria-describedby={describedByIds(`quote-line-sku-help-${line.id}`, skuDirty && unsavedHintId(line.id, 'sku'))}
               data-testid={`quote-line-sku-${line.id}`}
               className={`h-6 w-28 rounded border bg-background px-1 text-foreground transition-shadow ${fieldRing(skuDirty, saved)}`}
             />
+            <span id={`quote-line-sku-help-${line.id}`} className="sr-only">{t('quotes.editor.line.skuHelp')}</span>
             <UnsavedFieldHint id={unsavedHintId(line.id, 'sku')} show={skuDirty} />
           </label>
           <label className="flex items-center gap-1">{t('quotes.editor.line.partNumberAbbr')}
@@ -1390,10 +1481,12 @@ export function EditableLineRow({
               onChange={(e) => { setPartNumber(e.target.value); partEdited.current = true; }}
               onBlur={commitPartNumber}
               disabled={fieldBusy('pn')}
-              aria-describedby={partDirty ? unsavedHintId(line.id, 'pn') : undefined}
+              title={t('quotes.editor.line.partNumberHelp')}
+              aria-describedby={describedByIds(`quote-line-partnumber-help-${line.id}`, partDirty && unsavedHintId(line.id, 'pn'))}
               data-testid={`quote-line-partnumber-${line.id}`}
               className={`h-6 w-28 rounded border bg-background px-1 text-foreground transition-shadow ${fieldRing(partDirty, saved)}`}
             />
+            <span id={`quote-line-partnumber-help-${line.id}`} className="sr-only">{t('quotes.editor.line.partNumberHelp')}</span>
             <UnsavedFieldHint id={unsavedHintId(line.id, 'pn')} show={partDirty} />
           </label>
           <label className="flex items-center gap-1">{t('quotes.editor.line.cost')}
@@ -1429,6 +1522,20 @@ export function EditableLineRow({
             />
             <UnsavedFieldHint id={unsavedHintId(line.id, 'cost')} show={costDirty} />
           </label>
+          {/* Explicit "no cost" shortcut (Task B1) — for labor/service lines
+              that deliberately have no cost. Checked whenever the cost is a
+              literal 0 (not just falls to 0 while typing); toggling off
+              reverts to empty/unknown, same as clearing the field by hand. */}
+          <label className="flex items-center gap-1 text-muted-foreground" title={t('quotes.editor.line.noCostHelp')}>
+            <input
+              type="checkbox"
+              checked={noCost}
+              onChange={(e) => toggleNoCost(e.target.checked)}
+              disabled={fieldBusy('cost')}
+              data-testid={`quote-line-nocost-${line.id}`}
+            />
+            {t('quotes.editor.line.noCost')}
+          </label>
           {fieldErrors.cost && (
             <p id={`quote-line-cost-error-${line.id}`} className="w-full text-xs font-normal normal-case tracking-normal text-destructive" data-testid={`quote-line-cost-error-${line.id}`}>
               {fieldErrors.cost}
@@ -1436,10 +1543,10 @@ export function EditableLineRow({
           )}
           <label className="flex items-center gap-1">{t('quotes.editor.line.markup')}
             <input
-              type="number" step="0.1"
+              type="text" inputMode="decimal"
               value={markupInput}
               onFocus={() => { markupFocused.current = true; }}
-              onChange={(e) => setMarkupInput(e.target.value)}
+              onChange={(e) => setMarkupInput(filterPercentChars(e.target.value))}
               onBlur={(e) => { markupFocused.current = false; onMarkupCommit(e.target.value); }}
               disabled={fieldBusy('price') || cost.trim() === ''}
               // Tell keyboard/SR users WHY the field is disabled — sighted users can

--- a/apps/web/src/components/billing/quotes/QuoteUnassignedLines.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteUnassignedLines.tsx
@@ -1,0 +1,138 @@
+// The editor's orphan bucket.
+//
+// `quote_lines.block_id` is nullable, and a line with a NULL block_id is a
+// first-class citizen on every CUSTOMER-FACING surface: the PDF renders it
+// (quotePdf.ts), the portal renders it as a "Pricing" table (quoteBlocks.tsx),
+// the in-app Preview renders it under "Additional items" (QuoteDocument.tsx),
+// and quoteMath.ts counts it in every total — it ignores blockId entirely.
+//
+// The BUILDER, however, draws lines block-by-block (`sortedBlocks.map`), so an
+// orphan was money on the customer's quote that the editor refused to show. A
+// $42 line shipped to a real customer that way. This component is the missing
+// bucket: it renders after the document's blocks (matching where the customer
+// sees these lines), states plainly that they are on the quote and in the
+// total, and offers the one repair that fixes it — move the line into a real
+// pricing section via the existing PATCH /quotes/:id/lines/:lineId/move.
+//
+// Deliberately NOT styled as another document section: this is a repair
+// affordance, not content the author arranged. It renders only when orphans
+// exist, so a healthy quote is visually unchanged.
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle } from 'lucide-react';
+import '../../../lib/i18n';
+import {
+  type QuoteLine,
+  formatMoney,
+  formatQuantity,
+  lineTitle,
+} from './quoteTypes';
+
+export interface UnassignedLinesProps {
+  /** Lines whose effective blockId is null, in sort order. */
+  lines: QuoteLine[];
+  /** Pricing panels a line can be moved into, in document order. */
+  moveTargets: { id: string; label: string }[];
+  currency: string;
+  canWrite: boolean;
+  /** Commits the move through the quote editor's shared move handler. */
+  onMoveLineToBlock: (line: QuoteLine, targetBlockId: string) => void;
+}
+
+export function UnassignedLines({
+  lines,
+  moveTargets,
+  currency,
+  canWrite,
+  onMoveLineToBlock,
+}: UnassignedLinesProps) {
+  const { t } = useTranslation('billing');
+  // Zero orphans must change nothing about the editor — no empty state, no
+  // spacing, no rule. The healthy quote is the overwhelming majority case.
+  if (lines.length === 0) return null;
+
+  const showPicker = canWrite && moveTargets.length > 0;
+
+  return (
+    <section
+      data-testid="quote-unassigned-lines"
+      aria-labelledby="quote-unassigned-title"
+      className="rounded-lg border border-warning/40 bg-warning/10 p-4"
+    >
+      <div className="flex items-start gap-2.5">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" aria-hidden />
+        <div className="min-w-0 flex-1">
+          <h3 id="quote-unassigned-title" className="text-sm font-semibold text-foreground">
+            {t('quotes.editor.unassigned.title')}
+          </h3>
+          {/* The whole point of this bucket. Full-contrast body text, not muted:
+              a tech who skims this as decoration ships the line unnoticed. */}
+          <p className="mt-1 max-w-[68ch] text-sm leading-relaxed text-foreground" data-testid="quote-unassigned-explainer">
+            {t('quotes.editor.unassigned.explainer')}
+          </p>
+        </div>
+      </div>
+
+      {/* A divided list, not a stack of inner cards — this panel is already a
+          surface, and nesting cards inside it reads as chrome-on-chrome. */}
+      <ul className="mt-3 divide-y divide-warning/25 border-t border-warning/25">
+        {lines.map((line) => {
+          const unit = t('quotes.editor.unassigned.qtyPrice', {
+            qty: formatQuantity(line.quantity),
+            price: formatMoney(line.unitPrice, currency),
+          });
+          const amount = formatMoney(line.lineTotal, currency);
+          return (
+            <li
+              key={line.id}
+              data-testid={`quote-unassigned-line-${line.id}`}
+              className="flex flex-wrap items-center gap-x-4 gap-y-2 py-2.5"
+            >
+              <span className="min-w-0 flex-1 basis-48 truncate text-sm text-foreground" title={lineTitle(line)}>
+                {lineTitle(line)}
+              </span>
+              <span className="text-sm tabular-nums text-muted-foreground">{unit}</span>
+              <span className="text-sm font-medium tabular-nums text-foreground">
+                {amount}
+                {line.recurrence === 'monthly' && (
+                  <span className="text-xs font-normal text-muted-foreground">{t('quotes.editor.units.perMonth')}</span>
+                )}
+                {line.recurrence === 'annual' && (
+                  <span className="text-xs font-normal text-muted-foreground">{t('quotes.editor.units.perYear')}</span>
+                )}
+              </span>
+              {showPicker && (
+                // A native select: it escapes the canvas's overflow context for
+                // free (no portal), keyboards and screen readers get it without
+                // extra ARIA, and the target list is short. Value is never held
+                // in state — the row leaves the bucket the moment the move is
+                // applied optimistically upstream.
+                <select
+                  value=""
+                  aria-label={t('quotes.editor.unassigned.moveAria', { line: lineTitle(line) })}
+                  data-testid={`quote-unassigned-move-${line.id}`}
+                  onChange={(e) => { if (e.target.value) onMoveLineToBlock(line, e.target.value); }}
+                  className="h-8 rounded-md border bg-background px-2 text-sm focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <option value="">{t('quotes.editor.unassigned.movePlaceholder')}</option>
+                  {moveTargets.map((target) => (
+                    <option key={target.id} value={target.id}>{target.label}</option>
+                  ))}
+                </select>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      {canWrite && moveTargets.length === 0 && (
+        // Nowhere to move them yet — say what to do instead of showing a dead
+        // control. (A quote can legitimately have orphans and no pricing table.)
+        <p className="mt-3 text-sm text-foreground" data-testid="quote-unassigned-no-targets">
+          {t('quotes.editor.unassigned.noTargets')}
+        </p>
+      )}
+    </section>
+  );
+}
+
+export default UnassignedLines;

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import QuoteWorkspace from './QuoteWorkspace';
+import { fetchWithAuth } from '../../../stores/auth';
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+// QuoteDocument (Preview tab) reads the org list off orgStore; stub it so the
+// real module (which registers an org-id provider at import time) never pulls
+// a partially-mocked auth store into scope.
+vi.mock('../../../stores/orgStore', () => ({
+  useOrgStore: (selector: (s: { organizations: { id: string; name: string }[] }) => unknown) =>
+    selector({ organizations: [] }),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+// A non-draft quote so the Editor tab (and QuoteEditor's own catalog/distributor
+// probes) never mounts — this test only cares about the tab bar's labels.
+const sentQuote = {
+  quote: {
+    id: 'q-1', quoteNumber: 'Q-2026-0001', partnerId: 'p-1', orgId: 'org-1', siteId: null,
+    status: 'sent', currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '100.00',
+    taxRate: null, taxTotal: '0.00', total: '100.00', oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', billToName: 'Acme', introNotes: null, terms: null,
+    termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: '2026-06-01T00:00:00Z', viewedAt: null,
+    createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [],
+  lines: [],
+};
+
+describe('QuoteWorkspace tabs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === '/quotes/q-1') return json({ data: sentQuote });
+      return json({ data: {} });
+    });
+  });
+
+  it('labels the third tab "Details" (not the bare, easy-to-misread "Detail")', async () => {
+    render(<QuoteWorkspace id="q-1" />);
+    await waitFor(() => expect(screen.getByTestId('quote-workspace')).toBeInTheDocument());
+
+    expect(screen.getByTestId('quote-tab-detail')).toHaveTextContent('Details');
+    // The Editor tab only renders for drafts (this quote is 'sent') — Preview
+    // is always present, confirming the tab bar itself rendered correctly.
+    expect(screen.getByTestId('quote-tab-preview')).toHaveTextContent('Preview');
+    expect(screen.queryByTestId('quote-tab-editor')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
@@ -62,4 +62,29 @@ describe('QuoteWorkspace tabs', () => {
     expect(screen.getByTestId('quote-tab-preview')).toHaveTextContent('Preview');
     expect(screen.queryByTestId('quote-tab-editor')).not.toBeInTheDocument();
   });
+
+  // The Editor tab previously had no status cue at all (only Preview/Details
+  // showed it) — the workspace header now always carries a status badge next
+  // to the title/tabs, reusing the same StatusPill + STATUS_ROLES vocabulary
+  // as QuotesPage/QuoteDetail/QuoteDocument.
+  it('shows a status badge in the workspace header matching the quote status', async () => {
+    render(<QuoteWorkspace id="q-1" />);
+    await waitFor(() => expect(screen.getByTestId('quote-workspace')).toBeInTheDocument());
+
+    expect(screen.getByTestId('quote-workspace-status')).toHaveTextContent('Sent');
+  });
+
+  it('renders an "Accepted" status badge for a different quote status (proves the badge is status-driven, not hardcoded)', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === '/quotes/q-1') {
+        return json({ data: { ...sentQuote, quote: { ...sentQuote.quote, status: 'accepted', acceptedAt: '2026-06-02T00:00:00Z' } } });
+      }
+      return json({ data: {} });
+    });
+
+    render(<QuoteWorkspace id="q-1" />);
+    await waitFor(() => expect(screen.getByTestId('quote-workspace')).toBeInTheDocument());
+
+    expect(screen.getByTestId('quote-workspace-status')).toHaveTextContent('Accepted');
+  });
 });

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
@@ -1,16 +1,17 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '../../../lib/i18n';
 import { fetchWithAuth } from '../../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { DocumentWorkspace, type DocumentTab } from '../shared/DocumentWorkspace';
+import { StatusPill } from '../shared/StatusPill';
 import QuoteEditor from './QuoteEditor';
 import QuoteDetail from './QuoteDetail';
 import QuoteDocumentPreview from './QuoteDocument';
 import QuoteActions, { QuoteSendOutcomeBanners } from './QuoteActions';
 import { QuoteHeaderMeta } from './QuoteHeaderMeta';
 import { useOrgStore } from '../../../stores/orgStore';
-import { type QuoteDetail as QuoteDetailData, resolveQuoteOrgName } from './quoteTypes';
+import { STATUS_ROLES, type QuoteDetail as QuoteDetailData, resolveQuoteOrgName } from './quoteTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -46,6 +47,18 @@ export default function QuoteWorkspace({ id }: Props) {
   // The header's editable title/customer (drafts) report their own pending
   // state; Send waits for BOTH surfaces to be quiescent.
   const [headerSavePending, setHeaderSavePending] = useState(false);
+  // Bridge between the editor's deferred deletions (undo grace window) and the
+  // header's Send: the editor registers a "flush now" hook, and QuoteActions
+  // calls it when Send is clicked while edits are pending — so a held Send
+  // fires as soon as the deferred DELETE lands instead of waiting out the
+  // remainder of the undo window.
+  const pendingDeleteFlushRef = useRef<(() => void) | null>(null);
+  const registerPendingDeleteFlush = useCallback((flush: (() => void) | null) => {
+    pendingDeleteFlushRef.current = flush;
+  }, []);
+  const flushEditorPendingDeletes = useCallback(() => {
+    pendingDeleteFlushRef.current?.();
+  }, []);
 
   // A `quiet` reload (after an inline edit) refetches without flipping `loading`,
   // so the editor stays mounted — a full-page spinner would remount the form and
@@ -126,6 +139,20 @@ export default function QuoteWorkspace({ id }: Props) {
   }));
   const activeTab: Tab = tabs.some((t) => t.id === tab && !t.hidden) ? tab : 'detail';
 
+  // Status was previously visible only on the Preview/Details tabs — a tech
+  // sitting in the Editor (the default landing tab for a draft) had no cue at
+  // all. Reuses the same StatusPill + STATUS_ROLES vocabulary as
+  // QuotesPage/QuoteDetail/QuoteDocument; display only, no new writes.
+  const statusRoles = STATUS_ROLES[detail.quote.status];
+  const statusPill = (
+    <StatusPill
+      role={statusRoles.role}
+      label={t(/* i18n-dynamic */ `quotes.status.${detail.quote.status}`)}
+      className={statusRoles.className ? `${statusRoles.className} shrink-0` : 'shrink-0'}
+      testId="quote-workspace-status"
+    />
+  );
+
   return (
     <DocumentWorkspace
       idPrefix="quote"
@@ -135,9 +162,10 @@ export default function QuoteWorkspace({ id }: Props) {
       // Drafts get the editable identity row (title input + customer select) in
       // place of the static h1 — the editor no longer carries a title strip.
       titleSlot={isDraft ? <QuoteHeaderMeta detail={detail} onChanged={() => void reload()} onPendingChange={setHeaderSavePending} /> : undefined}
+      statusPill={statusPill}
       // Primary actions live in the header so Send (the money-moment) and Download
       // are reachable from any tab, not buried inside the Detail tab.
-      actions={<QuoteActions detail={detail} onChanged={reload} variant="header" savePending={editorSavePending || headerSavePending} />}
+      actions={<QuoteActions detail={detail} onChanged={reload} variant="header" savePending={editorSavePending || headerSavePending} onSendWhilePending={flushEditorPendingDeletes} />}
       tabs={tabs}
       activeTab={activeTab}
       onTabChange={selectTab}
@@ -161,7 +189,7 @@ export default function QuoteWorkspace({ id }: Props) {
           while previewing. */}
       {isDraft && (
         <div className={activeTab === 'editor' ? '' : 'hidden'}>
-          <QuoteEditor detail={detail} onChanged={() => void reload()} onPendingEditsChange={setEditorSavePending} />
+          <QuoteEditor detail={detail} onChanged={() => void reload()} onPendingEditsChange={setEditorSavePending} onRegisterPendingDeleteFlush={registerPendingDeleteFlush} />
         </div>
       )}
       {activeTab === 'preview' && (

--- a/apps/web/src/components/billing/quotes/quoteEditorShared.tsx
+++ b/apps/web/src/components/billing/quotes/quoteEditorShared.tsx
@@ -93,3 +93,23 @@ export function fieldRing(dirty: boolean, saved: boolean): string {
 export function seamless(state: string): string {
   return state || 'border-transparent hover:border-border focus:border-border';
 }
+
+// The amber dirty ring (fieldRing) is a COLOR-only signal — a screen-reader
+// user tabbing through a pricing-table row gets no equivalent cue that a field
+// holds an unsaved edit. `unsavedHintId` builds a stable id for a field's
+// SR-only "Unsaved" description; wire it to the field's `aria-describedby`
+// while dirty and render `<UnsavedFieldHint id={that id} show={dirty} />`
+// immediately after the field. Deliberately NOT a visible badge (per-field
+// badges across a long pricing table were noisy) and NOT an aria-live
+// announcement (a live region would fire on every keystroke) — just parity for
+// AT users at the moment they land on the field, same as sighted users see the
+// border the moment they look at it.
+export function unsavedHintId(lineId: string, field: string): string {
+  return `quote-line-${field}-unsaved-${lineId}`;
+}
+
+export function UnsavedFieldHint({ id, show }: { id: string; show: boolean }) {
+  const { t } = useTranslation('billing');
+  if (!show) return null;
+  return <span id={id} className="sr-only">{t('billingUi.unsaved')}</span>;
+}

--- a/apps/web/src/components/catalog/PolishButton.tsx
+++ b/apps/web/src/components/catalog/PolishButton.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react';
+import { useEffect, useId, useState, type ReactNode } from 'react';
 import { Loader2 } from 'lucide-react';
 import { runAction, ActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
@@ -27,8 +27,23 @@ interface PolishButtonProps {
   disabled?: boolean;
   /** Override the button label. Default: "Tidy description". */
   label?: string;
+  /** Icon rendered before the label (e.g. a Sparkles glyph to signal AI). */
+  icon?: ReactNode;
   /** Render a smaller, condensed button (for inline use in line editors). */
   compact?: boolean;
+  /** Skip rendering the trigger `<button>` — used when a host drives `run()`
+   *  itself via `autoRun` (see below) and only wants the preview dialog. */
+  hideTrigger?: boolean;
+  /** Fire `run()` once, immediately on mount. Combine with `hideTrigger` and a
+   *  fresh `key` per target (e.g. `key={line.id}`) to drive an unattended,
+   *  one-line-at-a-time queue (a block's "Tidy all descriptions" action) — the
+   *  remount resets internal state, and the mount-effect kicks off the request. */
+  autoRun?: boolean;
+  /** Fires once the run cycle is fully settled: either no preview was shown
+   *  (blank input, "already looks good", or a hard error) or the preview was
+   *  dismissed (applied or cancelled). Lets a queue driver advance to the next
+   *  item without reaching into internal state. */
+  onSettled?: () => void;
 }
 
 interface Preview {
@@ -81,7 +96,7 @@ function FieldDiff({
 }
 
 export default function PolishButton({
-  getText, onApply, idSuffix, disabled, label, compact,
+  getText, onApply, idSuffix, disabled, label, icon, compact, hideTrigger, autoRun, onSettled,
 }: PolishButtonProps) {
   const { t } = useTranslation('common');
   const [busy, setBusy] = useState(false);
@@ -95,6 +110,7 @@ export default function PolishButton({
     const description = input.description?.trim() ? input.description : undefined;
     if (!name && !description) {
       showToast({ message: t('longTail.catalog.PolishButton.errors.enterText'), type: 'error' });
+      onSettled?.();
       return;
     }
     setBusy(true);
@@ -122,6 +138,7 @@ export default function PolishButton({
       const descVisiblySame = result.description === null || trimEq(result.description, description);
       if (!result.factChanges && (!result.changed || (nameVisiblySame && descVisiblySame))) {
         showToast({ message: t('longTail.catalog.PolishButton.messages.noChanges'), type: 'success' });
+        onSettled?.();
         return;
       }
       setPreview({
@@ -136,40 +153,59 @@ export default function PolishButton({
       if (!(err instanceof ActionError)) {
         showToast({ message: t('longTail.catalog.PolishButton.errors.polishFailed'), type: 'error' });
       }
+      onSettled?.();
     } finally {
       setBusy(false);
     }
   };
 
+  // Drives an unattended queue (see `autoRun` doc above): fire once per mount.
+  // Intentionally mount-only — the host remounts this component (fresh `key`)
+  // for each queued item rather than re-triggering via a dependency array.
+  useEffect(() => {
+    if (autoRun && !disabled) void run();
+  }, []);
+
+  // Closing the preview (Cancel, backdrop/Escape, or after a successful
+  // Apply) is always the end of this run's cycle — a queue driver listens on
+  // `onSettled` to advance regardless of which path got here.
+  const closePreview = () => {
+    setPreview(null);
+    onSettled?.();
+  };
+
   const apply = () => {
     if (!preview) return;
     onApply({ name: preview.afterName, description: preview.afterDescription });
-    setPreview(null);
     showToast({ message: t('longTail.catalog.PolishButton.messages.applied'), type: 'success' });
+    closePreview();
   };
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => void run()}
-        disabled={disabled || busy}
-        aria-busy={busy}
-        data-testid={`polish-btn-${idSuffix}`}
-        title={t('longTail.catalog.PolishButton.title')}
-        className={
-          compact
-            ? 'inline-flex h-8 items-center gap-1 rounded-md border px-2 text-xs font-medium hover:bg-muted disabled:opacity-50'
-            : 'inline-flex h-9 items-center gap-1.5 rounded-md border px-3 text-sm font-medium hover:bg-muted disabled:opacity-50'
-        }
-      >
-        {busy && <Loader2 className={`animate-spin ${compact ? 'h-3 w-3' : 'h-3.5 w-3.5'}`} aria-hidden="true" />}
-        {busy ? t('longTail.catalog.PolishButton.polishing') : (label ?? t('longTail.catalog.PolishButton.defaultLabel'))}
-      </button>
+      {!hideTrigger && (
+        <button
+          type="button"
+          onClick={() => void run()}
+          disabled={disabled || busy}
+          aria-busy={busy}
+          data-testid={`polish-btn-${idSuffix}`}
+          title={t('longTail.catalog.PolishButton.title')}
+          className={
+            compact
+              ? 'inline-flex h-8 items-center gap-1 rounded-md border px-2 text-xs font-medium hover:bg-muted disabled:opacity-50'
+              : 'inline-flex h-9 items-center gap-1.5 rounded-md border px-3 text-sm font-medium hover:bg-muted disabled:opacity-50'
+          }
+        >
+          {busy && <Loader2 className={`animate-spin ${compact ? 'h-3 w-3' : 'h-3.5 w-3.5'}`} aria-hidden="true" />}
+          {!busy && icon}
+          {busy ? t('longTail.catalog.PolishButton.polishing') : (label ?? t('longTail.catalog.PolishButton.defaultLabel'))}
+        </button>
+      )}
 
       <Dialog
         open={preview !== null}
-        onClose={() => setPreview(null)}
+        onClose={closePreview}
         title={t('longTail.catalog.PolishButton.preview.dialogTitle')}
         labelledBy={headingId}
         maxWidth="2xl"
@@ -227,7 +263,7 @@ export default function PolishButton({
             <div className="flex justify-end gap-2 border-t px-5 py-4">
               <button
                 type="button"
-                onClick={() => setPreview(null)}
+                onClick={closePreview}
                 data-testid={`polish-cancel-${idSuffix}`}
                 className="inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium hover:bg-muted"
               >

--- a/apps/web/src/components/layout/ContextScopeLine.tsx
+++ b/apps/web/src/components/layout/ContextScopeLine.tsx
@@ -55,7 +55,11 @@ export default function ContextScopeLine() {
       <p
         data-testid="context-scope-line"
         data-kind="fleet"
-        className="mb-4 flex items-center gap-1.5 text-sm text-primary"
+        // mt-1: the page's domain-accent strip sits flush against the top of
+        // the scrollable content area (no padding above it) — without this the
+        // banner immediately follows that strip with no breathing room, reading
+        // as clipped/cramped at the content's top edge.
+        className="mb-4 mt-1 flex items-center gap-1.5 text-sm text-primary"
       >
         <Globe className="h-3.5 w-3.5" aria-hidden="true" />
         {t('layout.scope.fleetLine', { count: orgCount })}

--- a/apps/web/src/lib/api/quotes.ts
+++ b/apps/web/src/lib/api/quotes.ts
@@ -126,9 +126,11 @@ export function updateBlock(id: string, blockId: string, body: QuoteBlockInput):
   });
 }
 
-/** Delete a block and its lines (DELETE /quotes/:id/blocks/:blockId). */
+/** Delete a block and its lines (DELETE /quotes/:id/blocks/:blockId).
+ *  keepalive: the editor defers deletions for an undo grace window and flushes
+ *  them on pagehide — the request must survive the page teardown. */
 export function deleteBlock(id: string, blockId: string): Promise<Response> {
-  return fetchWithAuth(`/quotes/${id}/blocks/${blockId}`, { method: 'DELETE' });
+  return fetchWithAuth(`/quotes/${id}/blocks/${blockId}`, { method: 'DELETE', keepalive: true });
 }
 
 export function addManualLine(
@@ -166,8 +168,9 @@ export function updateLine(
   });
 }
 
+/** keepalive: undo-grace deletions flush on pagehide (see deleteBlock). */
 export function removeLine(id: string, lineId: string): Promise<Response> {
-  return fetchWithAuth(`/quotes/${id}/lines/${lineId}`, { method: 'DELETE' });
+  return fetchWithAuth(`/quotes/${id}/lines/${lineId}`, { method: 'DELETE', keepalive: true });
 }
 
 /** Reorder a quote's blocks. Body is the full ordered id list; the server

--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -22,7 +22,9 @@ const namespaceDuplicateBaselines = {
     // legitimately identical to English.
     // +3: quote send composer — "Cc" (label + toggle) and the example email
     // placeholder are locale-invariant.
-    'billing.json': 45,
+    // +2: liveTotals "Subtotal"/"Total" — both spell identically to English in
+    // pt-BR (same cognate already accepted for document.totals.subtotal).
+    'billing.json': 47,
     // +1: richTextEditor.link — "Link" is the standard loanword in pt-BR.
     'common.json': 90,
     'devices.json': 159,
@@ -51,7 +53,9 @@ const namespaceDuplicateBaselines = {
     // to English in es-419.
     // +3: quote send composer — "Cc" (label + toggle) and the example email
     // placeholder are locale-invariant.
-    'billing.json': 38,
+    // +1: liveTotals "Total" — spells identically to English in es-419 (same
+    // cognate already accepted for document.totals.firstPeriodTotal's root word).
+    'billing.json': 39,
     'common.json': 75,
     'devices.json': 115,
     'discovery.json': 17,
@@ -83,7 +87,9 @@ const namespaceDuplicateBaselines = {
     // +1: the unassigned-lines row format ("{{qty}} × {{price}}") is two
     // interpolations and a multiplication sign — there is no French wording to
     // translate, and every other locale carries the identical value.
-    'billing.json': 49,
+    // +1: liveTotals "Total" — spells identically to English in fr-FR (same
+    // cognate already accepted for document.totals.firstPeriodTotal's root word).
+    'billing.json': 50,
     'common.json': 93,
     'devices.json': 136,
     'discovery.json': 15,

--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -80,7 +80,10 @@ const namespaceDuplicateBaselines = {
     // in fr-FR.
     // +3: quote send composer — "Cc" (label + toggle) and the example email
     // placeholder are locale-invariant.
-    'billing.json': 48,
+    // +1: the unassigned-lines row format ("{{qty}} × {{price}}") is two
+    // interpolations and a multiplication sign — there is no French wording to
+    // translate, and every other locale carries the identical value.
+    'billing.json': 49,
     'common.json': 93,
     'devices.json': 136,
     'discovery.json': 15,

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -447,7 +447,11 @@
         "addSection": "Abschnitt hinzufügen",
         "adding": "Hinzufügen…",
         "cancel": "Abbrechen",
+        "collapseSection": "Abschnitt einklappen",
+        "dragLine": "Ziehen, um die Position neu zu ordnen",
+        "dragLineTitle": "Ziehen, um innerhalb dieser Tabelle neu zu ordnen. Tastatur: „Nach oben/unten verschieben“ im Zeilenmenü verwenden.",
         "dragSection": "Ziehen, um den Abschnitt neu zu ordnen",
+        "expandSection": "Abschnitt ausklappen",
         "fetch": "Holen",
         "fetchAddImage": "Bild abrufen und hinzufügen",
         "fromUrl": "Ab URL",
@@ -468,13 +472,16 @@
         "replaceImage": "Bild ersetzen",
         "sectionActions": "Abschnittsaktionen",
         "showCostMargin": "Kosten und Marge anzeigen",
+        "tidyAllDescriptions": "Alle Beschreibungen überarbeiten",
         "uploadAddImage": "Bild hochladen und hinzufügen",
         "uploading": "Hochladen…"
       },
       "addLine": {
+        "addFromCatalog": "Aus dem Katalog hinzufügen",
+        "aiLookupAction": "KI-Suche",
         "catalogItem": "Katalogartikel",
         "manualLine": "Manuelle Position",
-        "moreWays": "Weitere Wege zum Hinzufügen (Katalog, KI-Suche, Details)",
+        "moreDetails": "Weitere Details",
         "searchDistributor": "Händler suchen",
         "searchPax8": "Pax8 durchsuchen"
       },
@@ -605,6 +612,7 @@
         "billing": "Abrechnung",
         "billingFrequencyAria": "Abrechnungshäufigkeit",
         "cost": "Kosten",
+        "costMissingAria": "Keine Kosten eingegeben – diese Position wird bei der Gewinnschätzung nicht berücksichtigt.",
         "descriptionAria": "Positionsbeschreibung",
         "descriptionOptional": "Beschreibung (optional)",
         "enterCostFirstMarkup": "Geben Sie zunächst Kosten ein, um den Aufschlag in % festzulegen.",
@@ -619,8 +627,11 @@
         "profit": "Gewinn",
         "quantityAria": "Menge",
         "saveToCatalog": "Im Katalog speichern",
+        "showLess": "Weniger anzeigen",
+        "showMore": "Mehr anzeigen",
         "sku": "SKU",
         "skuOptional": "SKU (optional)",
+        "tidyWithAi": "Mit KI überarbeiten",
         "unitCost": "Stückkosten"
       },
       "liveTotals": {
@@ -635,6 +646,10 @@
         "taxRate": "Steuersatz",
         "taxRateHelp": "Gilt für Positionen, die als steuerpflichtig gekennzeichnet sind. Wird in den Steuereinstellungen der Organisation festgelegt.",
         "title": "Live-Summen"
+      },
+      "outline": {
+        "aria": "Inhalt des Angebots",
+        "title": "Inhalt"
       },
       "recurrence": {
         "annual": "Jährlich",
@@ -662,6 +677,9 @@
         "plusSeparator": " + "
       },
       "table": {
+        "collapsedSummary": "{{count}} Positionen · {{amount}}",
+        "collapsedSummary_one": "{{count}} Position · {{amount}}",
+        "collapsedSummary_other": "{{count}} Positionen · {{amount}}",
         "emptyLines": "Noch keine Positionen. Fügen Sie unten einen Katalogartikel oder eine manuelle Position hinzu.",
         "fallbackName": "Preistabelle {{number}}",
         "item": "Artikel",
@@ -682,6 +700,10 @@
       "terms": {
         "placeholder": "Zahlungsbedingungen, Garantieklauseln usw.",
         "title": "Allgemeine Geschäftsbedingungen"
+      },
+      "tidyAll": {
+        "complete": "{{count}} Beschreibung(en) überprüft.",
+        "noDescriptions": "Keine Positionsbeschreibungen in diesem Abschnitt zum Überarbeiten."
       },
       "title": {
         "label": "Angebotstitel",
@@ -728,6 +750,14 @@
         "add": "Hinzufügen",
         "nameAria": "Name der neuen Zeile",
         "placeholder": "Artikelnamen eingeben…"
+      },
+      "unassigned": {
+        "explainer": "Diese Positionen gehören zu keinem Preisabschnitt, erscheinen aber trotzdem im Angebot des Kunden und zählen zu dessen Summen. Verschieben Sie jede Position in einen Preisabschnitt, um zu bestimmen, wo sie erscheint.",
+        "moveAria": "{{line}} in einen Preisabschnitt verschieben",
+        "movePlaceholder": "Verschieben nach…",
+        "noTargets": "Fügen Sie einen Preisabschnitt hinzu und verschieben Sie diese Positionen dann dorthin.",
+        "qtyPrice": "{{qty}} × {{price}}",
+        "title": "Nicht zugeordnete Positionen"
       }
     },
     "actions": {
@@ -1044,7 +1074,7 @@
       "tabs": {
         "editor": "Herausgeber",
         "preview": "Vorschau",
-        "detail": "Detailliert"
+        "detail": "Detailansicht"
       }
     }
   },

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -519,6 +519,26 @@
         "richText": "Rich-Text",
         "contract": "Vertrag"
       },
+      "bulk": {
+        "applied_one": "{{count}} Position aktualisiert.",
+        "applied_other": "{{count}} Positionen aktualisiert.",
+        "apply": "Anwenden",
+        "barAria": "Ausgewählte Positionen gesammelt bearbeiten",
+        "clearSelection": "Auswahl aufheben",
+        "invalidMarkup": "Geben Sie einen gültigen Markup-Prozentsatz ein.",
+        "markupHint": "Gilt für ausgewählte Positionen mit hinterlegten Kosten.",
+        "partialFailure": "{{failed}} von {{total}} Positionen konnten nicht aktualisiert werden.",
+        "selectAllAria": "Alle Positionen in {{label}} auswählen",
+        "selectLineAria": "{{name}} auswählen",
+        "selectedCount_one": "{{count}} Position ausgewählt",
+        "selectedCount_other": "{{count}} Positionen ausgewählt",
+        "setCost": "Kosten festlegen",
+        "setMarkup": "Markup % festlegen",
+        "skippedNoCost_one": "{{count}} Position ohne Kosten übersprungen.",
+        "skippedNoCost_other": "{{count}} Positionen ohne Kosten übersprungen.",
+        "taxableOff": "Steuerpflichtig: nein",
+        "taxableOn": "Steuerpflichtig: ja"
+      },
       "catalog": {
         "addSome": "Fügen Sie einige zum Produktkatalog hinzu",
         "empty": "Keine Katalogartikel.",
@@ -607,6 +627,10 @@
         "full": "Intern · dem Kunden nicht angezeigt",
         "short": "Intern"
       },
+      "lastSaved": {
+        "saved": "Gespeichert um {{time}} Uhr",
+        "saving": "Wird gespeichert…"
+      },
       "line": {
         "addDescription": "Beschreibung",
         "billing": "Abrechnung",
@@ -622,7 +646,10 @@
         "markupPercent": "Aufschlag %",
         "nameAria": "Positionsname",
         "namePlaceholder": "Name",
+        "noCost": "Keine Kosten",
+        "noCostHelp": "Diese Position bewusst als kostenlos markieren (z. B. Arbeitszeit oder eine Dienstleistung) – sie wird dann nicht in der Warnung für fehlende Kosten berücksichtigt.",
         "partNumberAbbr": "PN",
+        "partNumberHelp": "Die Herstellerteilenummer für diesen Artikel.",
         "partNumberOptional": "Teilenummer (optional)",
         "profit": "Gewinn",
         "quantityAria": "Menge",
@@ -630,6 +657,7 @@
         "showLess": "Weniger anzeigen",
         "showMore": "Mehr anzeigen",
         "sku": "SKU",
+        "skuHelp": "Ihre Katalog- oder Distributor-Lagernummer für diesen Artikel.",
         "skuOptional": "SKU (optional)",
         "tidyWithAi": "Mit KI überarbeiten",
         "unitCost": "Stückkosten"
@@ -637,18 +665,22 @@
       "liveTotals": {
         "annualRecurring": "Jährlich wiederkehrend",
         "dueOnAcceptance": "Fällig bei Abnahme",
+        "firstPeriodSubtotal": "Zwischensumme erster Zeitraum",
         "firstPeriodTotal": "Gesamtsumme der ersten Periode (inkl. wiederkehrende)",
         "monthlyRecurring": "Monatlich wiederkehrend",
-        "oneTime": "Einmalig",
+        "oneTime": "Einmalig (vor Steuern)",
         "srUpdated": "Summen aktualisiert. Einmalig {{oneTime}}, monatlich wiederkehrend {{monthly}}, jährlich wiederkehrend {{annual}}, fällig bei Abnahme {{due}}.",
         "srUpdatedWithTax": "Summen aktualisiert. Einmalig {{oneTime}}, monatlich wiederkehrend {{monthly}}, jährlich wiederkehrend {{annual}}, Steuer {{tax}}, fällig bei Abnahme {{due}}.",
+        "subtotal": "Zwischensumme",
         "tax": "Steuer",
         "taxRate": "Steuersatz",
         "taxRateHelp": "Gilt für Positionen, die als steuerpflichtig gekennzeichnet sind. Wird in den Steuereinstellungen der Organisation festgelegt.",
-        "title": "Live-Summen"
+        "title": "Live-Summen",
+        "total": "Gesamtsumme"
       },
       "outline": {
         "aria": "Inhalt des Angebots",
+        "shortcutHint": "Alt+Nach-unten / Alt+Nach-oben springt beim Bearbeiten zum nächsten oder vorherigen Abschnitt.",
         "title": "Inhalt"
       },
       "recurrence": {
@@ -688,7 +720,7 @@
         "notTaxable": "Nicht steuerpflichtig",
         "qty": "Menge",
         "recurrence": "Wiederholung",
-        "scrollAria": "Preistabelle – scrollen Sie auf schmalen Bildschirmen seitwärts für Gesamtsummen und Zeilenaktionen",
+        "scrollAria": "Preistabelle – scrollen Sie auf schmalen Bildschirmen seitwärts für Gesamtsummen und Zeilenaktionen; bei langen Abschnitten scrollt sie vertikal mit fixierter Kopfzeile",
         "showSubtotal": "Zwischensummenzeile anzeigen",
         "tax": "Steuer",
         "taxSuffix": "+ {{amount}} Steuer",
@@ -704,6 +736,10 @@
       "tidyAll": {
         "complete": "{{count}} Beschreibung(en) überprüft.",
         "noDescriptions": "Keine Positionsbeschreibungen in diesem Abschnitt zum Überarbeiten."
+      },
+      "undo": {
+        "lineDeleted": "Position gelöscht",
+        "sectionDeleted": "Abschnitt gelöscht"
       },
       "title": {
         "label": "Angebotstitel",

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -447,7 +447,11 @@
         "addSection": "Add section",
         "adding": "Adding…",
         "cancel": "Cancel",
+        "collapseSection": "Collapse section",
+        "dragLine": "Drag to reorder line",
+        "dragLineTitle": "Drag to reorder within this table. Keyboard: use the line menu's Move up / Move down.",
         "dragSection": "Drag to reorder section",
+        "expandSection": "Expand section",
         "fetch": "Fetch",
         "fetchAddImage": "Fetch & add image",
         "fromUrl": "From URL",
@@ -468,13 +472,16 @@
         "replaceImage": "Replace image",
         "sectionActions": "Section actions",
         "showCostMargin": "Show cost & margin",
+        "tidyAllDescriptions": "Tidy all descriptions",
         "uploadAddImage": "Upload & add image",
         "uploading": "Uploading…"
       },
       "addLine": {
+        "addFromCatalog": "Add from catalog",
+        "aiLookupAction": "AI lookup",
         "catalogItem": "Catalog item",
         "manualLine": "Manual line",
-        "moreWays": "More ways to add (catalog, AI lookup, details)",
+        "moreDetails": "More details",
         "searchDistributor": "Search distributor",
         "searchPax8": "Search Pax8"
       },
@@ -605,6 +612,7 @@
         "billing": "Billing",
         "billingFrequencyAria": "Billing frequency",
         "cost": "Cost",
+        "costMissingAria": "Cost not entered — this line is excluded from the profit estimate.",
         "descriptionAria": "Line description",
         "descriptionOptional": "Description (optional)",
         "enterCostFirstMarkup": "Enter a cost first to set markup %",
@@ -619,8 +627,11 @@
         "profit": "Profit",
         "quantityAria": "Quantity",
         "saveToCatalog": "Save to catalog",
+        "showLess": "Show less",
+        "showMore": "Show more",
         "sku": "SKU",
         "skuOptional": "SKU (optional)",
+        "tidyWithAi": "Tidy with AI",
         "unitCost": "Unit cost"
       },
       "liveTotals": {
@@ -635,6 +646,10 @@
         "taxRate": "Tax rate",
         "taxRateHelp": "Applies to lines marked taxable. Set in the organization’s tax settings.",
         "title": "Live totals"
+      },
+      "outline": {
+        "aria": "Quote contents",
+        "title": "Contents"
       },
       "recurrence": {
         "annual": "Annual",
@@ -662,6 +677,9 @@
         "plusSeparator": " + "
       },
       "table": {
+        "collapsedSummary": "{{count}} lines · {{amount}}",
+        "collapsedSummary_one": "{{count}} line · {{amount}}",
+        "collapsedSummary_other": "{{count}} lines · {{amount}}",
         "emptyLines": "No lines yet. Add a catalog item or a manual line below.",
         "fallbackName": "Pricing table {{number}}",
         "item": "Item",
@@ -682,6 +700,10 @@
       "terms": {
         "placeholder": "Payment terms, warranty clauses, etc.",
         "title": "Terms & Conditions"
+      },
+      "tidyAll": {
+        "complete": "Finished reviewing {{count}} description(s).",
+        "noDescriptions": "No line descriptions to tidy in this section."
       },
       "title": {
         "label": "Quote title",
@@ -728,6 +750,14 @@
         "add": "Add",
         "nameAria": "New line name",
         "placeholder": "Type an item name…"
+      },
+      "unassigned": {
+        "explainer": "These lines aren’t in any pricing section, but they still appear on the customer’s quote and count toward its totals. Move each one into a pricing section to control where it appears.",
+        "moveAria": "Move {{line}} into a pricing section",
+        "movePlaceholder": "Move to…",
+        "noTargets": "Add a pricing section, then move these lines into it.",
+        "qtyPrice": "{{qty}} × {{price}}",
+        "title": "Unassigned lines"
       }
     },
     "actions": {
@@ -1044,7 +1074,7 @@
       "tabs": {
         "editor": "Editor",
         "preview": "Preview",
-        "detail": "Detail"
+        "detail": "Details"
       }
     }
   },

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -519,6 +519,26 @@
         "richText": "Rich text",
         "contract": "Contract"
       },
+      "bulk": {
+        "applied_one": "Updated {{count}} line.",
+        "applied_other": "Updated {{count}} lines.",
+        "apply": "Apply",
+        "barAria": "Bulk edit selected lines",
+        "clearSelection": "Clear selection",
+        "invalidMarkup": "Enter a valid markup percent.",
+        "markupHint": "Applies to selected lines that have a cost.",
+        "partialFailure": "{{failed}} of {{total}} lines failed to update.",
+        "selectAllAria": "Select all lines in {{label}}",
+        "selectLineAria": "Select {{name}}",
+        "selectedCount_one": "{{count}} line selected",
+        "selectedCount_other": "{{count}} lines selected",
+        "setCost": "Set cost",
+        "setMarkup": "Set markup %",
+        "skippedNoCost_one": "Skipped {{count}} line with no cost.",
+        "skippedNoCost_other": "Skipped {{count}} lines with no cost.",
+        "taxableOff": "Taxable off",
+        "taxableOn": "Taxable on"
+      },
       "catalog": {
         "addSome": "Add some in Product Catalog",
         "empty": "No catalog items.",
@@ -607,6 +627,10 @@
         "full": "Internal · not shown to customer",
         "short": "Internal"
       },
+      "lastSaved": {
+        "saved": "Saved {{time}}",
+        "saving": "Saving…"
+      },
       "line": {
         "addDescription": "description",
         "billing": "Billing",
@@ -622,7 +646,10 @@
         "markupPercent": "Markup %",
         "nameAria": "Line name",
         "namePlaceholder": "Name",
+        "noCost": "No cost",
+        "noCostHelp": "Mark this line as deliberately having no cost (e.g. labor or a service) — excludes it from the missing-cost warning.",
         "partNumberAbbr": "PN",
+        "partNumberHelp": "The manufacturer's part number for this item.",
         "partNumberOptional": "Part # (optional)",
         "profit": "Profit",
         "quantityAria": "Quantity",
@@ -630,6 +657,7 @@
         "showLess": "Show less",
         "showMore": "Show more",
         "sku": "SKU",
+        "skuHelp": "Your catalog or distributor stock number for this item.",
         "skuOptional": "SKU (optional)",
         "tidyWithAi": "Tidy with AI",
         "unitCost": "Unit cost"
@@ -637,18 +665,22 @@
       "liveTotals": {
         "annualRecurring": "Annual recurring",
         "dueOnAcceptance": "Due on acceptance",
+        "firstPeriodSubtotal": "First period subtotal",
         "firstPeriodTotal": "First-period total (incl. recurring)",
         "monthlyRecurring": "Monthly recurring",
-        "oneTime": "One-time",
+        "oneTime": "One-time (pre-tax)",
         "srUpdated": "Totals updated. One-time {{oneTime}}, monthly recurring {{monthly}}, annual recurring {{annual}}, due on acceptance {{due}}.",
         "srUpdatedWithTax": "Totals updated. One-time {{oneTime}}, monthly recurring {{monthly}}, annual recurring {{annual}}, tax {{tax}}, due on acceptance {{due}}.",
+        "subtotal": "Subtotal",
         "tax": "Tax",
         "taxRate": "Tax rate",
         "taxRateHelp": "Applies to lines marked taxable. Set in the organization’s tax settings.",
-        "title": "Live totals"
+        "title": "Live totals",
+        "total": "Total"
       },
       "outline": {
         "aria": "Quote contents",
+        "shortcutHint": "Alt+Down / Alt+Up jumps to the next or previous section while editing.",
         "title": "Contents"
       },
       "recurrence": {
@@ -688,7 +720,7 @@
         "notTaxable": "Not taxable",
         "qty": "Qty",
         "recurrence": "Recurrence",
-        "scrollAria": "Pricing table — scrolls sideways on narrow screens for totals and row actions",
+        "scrollAria": "Pricing table — scrolls sideways on narrow screens for totals and row actions, and vertically (with the header pinned) once a section grows long",
         "showSubtotal": "Show subtotal row",
         "tax": "Tax",
         "taxSuffix": "+ {{amount}} tax",
@@ -704,6 +736,10 @@
       "tidyAll": {
         "complete": "Finished reviewing {{count}} description(s).",
         "noDescriptions": "No line descriptions to tidy in this section."
+      },
+      "undo": {
+        "lineDeleted": "Line deleted",
+        "sectionDeleted": "Section deleted"
       },
       "title": {
         "label": "Quote title",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -519,6 +519,26 @@
         "richText": "Texto enriquecido",
         "contract": "Contrato"
       },
+      "bulk": {
+        "applied_one": "Se actualizó {{count}} línea.",
+        "applied_other": "Se actualizaron {{count}} líneas.",
+        "apply": "Aplicar",
+        "barAria": "Edición masiva de las líneas seleccionadas",
+        "clearSelection": "Borrar selección",
+        "invalidMarkup": "Ingrese un porcentaje de margen válido.",
+        "markupHint": "Se aplica a las líneas seleccionadas que tienen costo.",
+        "partialFailure": "{{failed}} de {{total}} líneas no se pudieron actualizar.",
+        "selectAllAria": "Seleccionar todas las líneas de {{label}}",
+        "selectLineAria": "Seleccionar {{name}}",
+        "selectedCount_one": "{{count}} línea seleccionada",
+        "selectedCount_other": "{{count}} líneas seleccionadas",
+        "setCost": "Fijar costo",
+        "setMarkup": "Fijar margen %",
+        "skippedNoCost_one": "Se omitió {{count}} línea sin costo.",
+        "skippedNoCost_other": "Se omitieron {{count}} líneas sin costo.",
+        "taxableOff": "Imponible: no",
+        "taxableOn": "Imponible: sí"
+      },
       "catalog": {
         "addSome": "Agregue algunos en el catálogo de productos",
         "empty": "Sin artículos de catálogo.",
@@ -607,6 +627,10 @@
         "full": "Interno · no mostrado al cliente",
         "short": "Interno"
       },
+      "lastSaved": {
+        "saved": "Guardado a las {{time}}",
+        "saving": "Guardando…"
+      },
       "line": {
         "addDescription": "descripción",
         "billing": "Facturación",
@@ -622,7 +646,10 @@
         "markupPercent": "% de margen",
         "nameAria": "Nombre de línea",
         "namePlaceholder": "Nombre",
+        "noCost": "Sin costo",
+        "noCostHelp": "Marque esta línea como intencionalmente sin costo (por ejemplo, mano de obra o un servicio); se excluye de la advertencia de costo faltante.",
         "partNumberAbbr": "PN",
+        "partNumberHelp": "El número de pieza del fabricante para este artículo.",
         "partNumberOptional": "Número de pieza (opcional)",
         "profit": "Ganancia",
         "quantityAria": "Cantidad",
@@ -630,6 +657,7 @@
         "showLess": "Mostrar menos",
         "showMore": "Mostrar más",
         "sku": "SKU",
+        "skuHelp": "Su número de stock de catálogo o distribuidor para este artículo.",
         "skuOptional": "SKU (opcional)",
         "tidyWithAi": "Pulir con IA",
         "unitCost": "Costo unitario"
@@ -637,18 +665,22 @@
       "liveTotals": {
         "annualRecurring": "Recurrente anual",
         "dueOnAcceptance": "Vencimiento al momento de la aceptación",
+        "firstPeriodSubtotal": "Subtotal del primer período",
         "firstPeriodTotal": "Total del primer período (incl. recurrente)",
         "monthlyRecurring": "Recurrente mensual",
-        "oneTime": "una sola vez",
+        "oneTime": "Una sola vez (antes de impuestos)",
         "srUpdated": "Totales actualizados. {{oneTime}} por única vez, {{monthly}} recurrente mensual, {{annual}} recurrente anual, vence al momento de la aceptación {{due}}.",
         "srUpdatedWithTax": "Totales actualizados. {{oneTime}} por única vez, {{monthly}} recurrente mensual, {{annual}} recurrente anual, impuesto {{tax}}, vencido al momento de la aceptación {{due}}.",
+        "subtotal": "Total parcial",
         "tax": "Impuesto",
         "taxRate": "Tasa impositiva",
         "taxRateHelp": "Aplica a líneas marcadas como sujetas a impuestos. Establecido en la configuración fiscal de la organización.",
-        "title": "Totales en vivo"
+        "title": "Totales en vivo",
+        "total": "Total"
       },
       "outline": {
         "aria": "Contenido de la cotización",
+        "shortcutHint": "Alt+Abajo / Alt+Arriba salta a la sección siguiente o anterior mientras edita.",
         "title": "Contenido"
       },
       "recurrence": {
@@ -688,7 +720,7 @@
         "notTaxable": "No sujeto a impuestos",
         "qty": "Cantidad",
         "recurrence": "Recurrencia",
-        "scrollAria": "Tabla de precios: desplácese hacia los lados en pantallas angostas para ver totales y acciones de fila",
+        "scrollAria": "Tabla de precios: desplácese hacia los lados en pantallas angostas para ver totales y acciones de fila; en secciones largas, se desplaza verticalmente con el encabezado fijo",
         "showSubtotal": "Mostrar fila de subtotal",
         "tax": "Impuesto",
         "taxSuffix": "+ {{amount}} de impuesto",
@@ -704,6 +736,10 @@
       "tidyAll": {
         "complete": "Se revisaron {{count}} descripción(es).",
         "noDescriptions": "No hay descripciones de línea que pulir en esta sección."
+      },
+      "undo": {
+        "lineDeleted": "Línea eliminada",
+        "sectionDeleted": "Sección eliminada"
       },
       "title": {
         "label": "Título de la cita",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -447,7 +447,11 @@
         "addSection": "Agregar sección",
         "adding": "Añadiendo…",
         "cancel": "Cancelar",
+        "collapseSection": "Contraer sección",
+        "dragLine": "Arrastra para reordenar la línea",
+        "dragLineTitle": "Arrastra para reordenar dentro de esta tabla. Con teclado: usa Mover arriba/abajo en el menú de la línea.",
         "dragSection": "Arrastra para reordenar la sección",
+        "expandSection": "Expandir sección",
         "fetch": "Buscar",
         "fetchAddImage": "Buscar y agregar imagen",
         "fromUrl": "De URL",
@@ -468,13 +472,16 @@
         "replaceImage": "Reemplazar imagen",
         "sectionActions": "Acciones de la sección",
         "showCostMargin": "Mostrar costo y margen",
+        "tidyAllDescriptions": "Pulir todas las descripciones",
         "uploadAddImage": "Subir y agregar imagen",
         "uploading": "Subiendo…"
       },
       "addLine": {
+        "addFromCatalog": "Agregar desde el catálogo",
+        "aiLookupAction": "Búsqueda con IA",
         "catalogItem": "Artículo del catálogo",
         "manualLine": "linea manual",
-        "moreWays": "Más formas de agregar (catálogo, búsqueda con IA, detalles)",
+        "moreDetails": "Más detalles",
         "searchDistributor": "Buscar distribuidor",
         "searchPax8": "Buscar Pax8"
       },
@@ -605,6 +612,7 @@
         "billing": "Facturación",
         "billingFrequencyAria": "Frecuencia de facturación",
         "cost": "Costo",
+        "costMissingAria": "No se ingresó el costo — esta línea queda excluida de la estimación de ganancias.",
         "descriptionAria": "Descripción de línea",
         "descriptionOptional": "Descripción (opcional)",
         "enterCostFirstMarkup": "Ingrese un costo primero para establecer el porcentaje de margen",
@@ -619,8 +627,11 @@
         "profit": "Ganancia",
         "quantityAria": "Cantidad",
         "saveToCatalog": "Guardar en catálogo",
+        "showLess": "Mostrar menos",
+        "showMore": "Mostrar más",
         "sku": "SKU",
         "skuOptional": "SKU (opcional)",
+        "tidyWithAi": "Pulir con IA",
         "unitCost": "Costo unitario"
       },
       "liveTotals": {
@@ -635,6 +646,10 @@
         "taxRate": "Tasa impositiva",
         "taxRateHelp": "Aplica a líneas marcadas como sujetas a impuestos. Establecido en la configuración fiscal de la organización.",
         "title": "Totales en vivo"
+      },
+      "outline": {
+        "aria": "Contenido de la cotización",
+        "title": "Contenido"
       },
       "recurrence": {
         "annual": "Anual",
@@ -662,6 +677,9 @@
         "plusSeparator": " + "
       },
       "table": {
+        "collapsedSummary": "{{count}} líneas · {{amount}}",
+        "collapsedSummary_one": "{{count}} línea · {{amount}}",
+        "collapsedSummary_other": "{{count}} líneas · {{amount}}",
         "emptyLines": "Aún no hay líneas. Agregue un artículo del catálogo o una línea manual a continuación.",
         "fallbackName": "Tabla de precios {{number}}",
         "item": "Artículo",
@@ -682,6 +700,10 @@
       "terms": {
         "placeholder": "Condiciones de pago, cláusulas de garantía, etc.",
         "title": "Términos y condiciones"
+      },
+      "tidyAll": {
+        "complete": "Se revisaron {{count}} descripción(es).",
+        "noDescriptions": "No hay descripciones de línea que pulir en esta sección."
       },
       "title": {
         "label": "Título de la cita",
@@ -728,6 +750,14 @@
         "add": "Agregar",
         "nameAria": "Nombre de la nueva línea",
         "placeholder": "Escribe el nombre del ítem…"
+      },
+      "unassigned": {
+        "explainer": "Estas líneas no están en ninguna sección de precios, pero aun así aparecen en la cotización del cliente y se suman a sus totales. Mueve cada una a una sección de precios para controlar dónde aparece.",
+        "moveAria": "Mover {{line}} a una sección de precios",
+        "movePlaceholder": "Mover a…",
+        "noTargets": "Agrega una sección de precios y luego mueve estas líneas a ella.",
+        "qtyPrice": "{{qty}} × {{price}}",
+        "title": "Líneas sin asignar"
       }
     },
     "actions": {
@@ -1044,7 +1074,7 @@
       "tabs": {
         "editor": "Editor",
         "preview": "Vista previa",
-        "detail": "Detalle"
+        "detail": "Detalles"
       }
     }
   },

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -519,6 +519,26 @@
         "richText": "Texte enrichi",
         "contract": "Contrat"
       },
+      "bulk": {
+        "applied_one": "{{count}} ligne mise à jour.",
+        "applied_other": "{{count}} lignes mises à jour.",
+        "apply": "Appliquer",
+        "barAria": "Modification groupée des lignes sélectionnées",
+        "clearSelection": "Effacer la sélection",
+        "invalidMarkup": "Saisissez un pourcentage de marge valide.",
+        "markupHint": "S'applique aux lignes sélectionnées ayant un coût.",
+        "partialFailure": "{{failed}} lignes sur {{total}} n'ont pas pu être mises à jour.",
+        "selectAllAria": "Sélectionner toutes les lignes de {{label}}",
+        "selectLineAria": "Sélectionner {{name}}",
+        "selectedCount_one": "{{count}} ligne sélectionnée",
+        "selectedCount_other": "{{count}} lignes sélectionnées",
+        "setCost": "Définir le coût",
+        "setMarkup": "Définir la marge %",
+        "skippedNoCost_one": "{{count}} ligne sans coût ignorée.",
+        "skippedNoCost_other": "{{count}} lignes sans coût ignorées.",
+        "taxableOff": "Taxable : non",
+        "taxableOn": "Taxable : oui"
+      },
       "catalog": {
         "addSome": "Ajoutez-en dans Product Catalog",
         "empty": "Aucun article dans le catalogue.",
@@ -607,6 +627,10 @@
         "full": "Interne · non visible par le client",
         "short": "Interne"
       },
+      "lastSaved": {
+        "saved": "Enregistré à {{time}}",
+        "saving": "Enregistrement…"
+      },
       "line": {
         "addDescription": "description",
         "billing": "Facturation",
@@ -622,7 +646,10 @@
         "markupPercent": "Marge %",
         "nameAria": "Nom de la ligne",
         "namePlaceholder": "Nom",
+        "noCost": "Sans coût",
+        "noCostHelp": "Marquer cette ligne comme volontairement sans coût (par ex. main-d'œuvre ou prestation) — elle sera exclue de l'avertissement de coût manquant.",
         "partNumberAbbr": "PN",
+        "partNumberHelp": "La référence fabricant (numéro de pièce) de cet article.",
         "partNumberOptional": "Part # (facultatif)",
         "profit": "Profit",
         "quantityAria": "Quantité",
@@ -630,6 +657,7 @@
         "showLess": "Afficher moins",
         "showMore": "Afficher plus",
         "sku": "SKU",
+        "skuHelp": "Votre référence de catalogue ou de distributeur pour cet article.",
         "skuOptional": "SKU (facultatif)",
         "tidyWithAi": "Peaufiner avec l'IA",
         "unitCost": "Coût unitaire"
@@ -637,18 +665,22 @@
       "liveTotals": {
         "annualRecurring": "Récurrent annuel",
         "dueOnAcceptance": "Dû à l'acceptation",
+        "firstPeriodSubtotal": "Sous-total de la première période",
         "firstPeriodTotal": "Total de première période (récurrent inclus)",
         "monthlyRecurring": "Récurrent mensuel",
-        "oneTime": "Ponctuel",
+        "oneTime": "Ponctuel (avant taxes)",
         "srUpdated": "Totaux mis à jour. Ponctuel {{oneTime}}, récurrent mensuel {{monthly}}, récurrent annuel {{annual}}, dû à l'acceptation {{due}}.",
         "srUpdatedWithTax": "Totaux mis à jour. Ponctuel {{oneTime}}, récurrent mensuel {{monthly}}, récurrent annuel {{annual}}, taxe {{tax}}, dû à l'acceptation {{due}}.",
+        "subtotal": "Sous-total",
         "tax": "Taxe",
         "taxRate": "Taux de taxe",
         "taxRateHelp": "S'applique aux lignes marquées taxables. Défini dans les paramètres fiscaux de l'organisation.",
-        "title": "Totaux en direct"
+        "title": "Totaux en direct",
+        "total": "Total"
       },
       "outline": {
         "aria": "Sommaire du devis",
+        "shortcutHint": "Alt+Bas / Alt+Haut permet de passer à la section suivante ou précédente pendant l'édition.",
         "title": "Sommaire"
       },
       "recurrence": {
@@ -688,7 +720,7 @@
         "notTaxable": "Non taxable",
         "qty": "Qté",
         "recurrence": "Récurrence",
-        "scrollAria": "Tableau de prix — faites défiler horizontalement sur écrans étroits pour les totaux et les actions de ligne",
+        "scrollAria": "Tableau de prix — faites défiler horizontalement sur écrans étroits pour les totaux et les actions de ligne ; pour les sections longues, défilement vertical avec l'en-tête fixe",
         "showSubtotal": "Afficher la ligne de sous-total",
         "tax": "Taxe",
         "taxSuffix": "+ {{amount}} de taxe",
@@ -704,6 +736,10 @@
       "tidyAll": {
         "complete": "{{count}} description(s) passée(s) en revue.",
         "noDescriptions": "Aucune description de ligne à peaufiner dans cette section."
+      },
+      "undo": {
+        "lineDeleted": "Ligne supprimée",
+        "sectionDeleted": "Section supprimée"
       },
       "title": {
         "label": "Titre du devis",

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -447,7 +447,11 @@
         "addSection": "Ajouter une section",
         "adding": "Ajout…",
         "cancel": "Annuler",
+        "collapseSection": "Réduire la section",
+        "dragLine": "Glisser pour réordonner la ligne",
+        "dragLineTitle": "Glisser pour réordonner dans ce tableau. Au clavier : utilisez Monter/Descendre dans le menu de la ligne.",
         "dragSection": "Glisser pour réordonner la section",
+        "expandSection": "Développer la section",
         "fetch": "Récupérer",
         "fetchAddImage": "Récupérer et ajouter l'image",
         "fromUrl": "Depuis une URL",
@@ -468,13 +472,16 @@
         "replaceImage": "Remplacer l'image",
         "sectionActions": "Actions de la section",
         "showCostMargin": "Afficher coût et marge",
+        "tidyAllDescriptions": "Peaufiner toutes les descriptions",
         "uploadAddImage": "Téléverser et ajouter l'image",
         "uploading": "Téléversement…"
       },
       "addLine": {
+        "addFromCatalog": "Ajouter depuis le catalogue",
+        "aiLookupAction": "Recherche IA",
         "catalogItem": "Article du catalogue",
         "manualLine": "Ligne manuelle",
-        "moreWays": "Plus de façons d'ajouter (catalogue, recherche IA, détails)",
+        "moreDetails": "Plus de détails",
         "searchDistributor": "Rechercher un distributeur",
         "searchPax8": "Rechercher Pax8"
       },
@@ -605,6 +612,7 @@
         "billing": "Facturation",
         "billingFrequencyAria": "Fréquence de facturation",
         "cost": "Coût",
+        "costMissingAria": "Coût non renseigné — cette ligne est exclue de l'estimation du profit.",
         "descriptionAria": "Description de la ligne",
         "descriptionOptional": "Description (facultatif)",
         "enterCostFirstMarkup": "Saisissez d'abord un coût pour définir le % de marge",
@@ -619,8 +627,11 @@
         "profit": "Profit",
         "quantityAria": "Quantité",
         "saveToCatalog": "Enregistrer dans le catalogue",
+        "showLess": "Afficher moins",
+        "showMore": "Afficher plus",
         "sku": "SKU",
         "skuOptional": "SKU (facultatif)",
+        "tidyWithAi": "Peaufiner avec l'IA",
         "unitCost": "Coût unitaire"
       },
       "liveTotals": {
@@ -635,6 +646,10 @@
         "taxRate": "Taux de taxe",
         "taxRateHelp": "S'applique aux lignes marquées taxables. Défini dans les paramètres fiscaux de l'organisation.",
         "title": "Totaux en direct"
+      },
+      "outline": {
+        "aria": "Sommaire du devis",
+        "title": "Sommaire"
       },
       "recurrence": {
         "annual": "Annuel",
@@ -662,6 +677,9 @@
         "plusSeparator": " + "
       },
       "table": {
+        "collapsedSummary": "{{count}} lignes · {{amount}}",
+        "collapsedSummary_one": "{{count}} ligne · {{amount}}",
+        "collapsedSummary_other": "{{count}} lignes · {{amount}}",
         "emptyLines": "Aucune ligne pour le moment. Ajoutez un article du catalogue ou une ligne manuelle ci-dessous.",
         "fallbackName": "Tableau de prix {{number}}",
         "item": "Article",
@@ -682,6 +700,10 @@
       "terms": {
         "placeholder": "Conditions de paiement, clauses de garantie, etc.",
         "title": "Conditions générales"
+      },
+      "tidyAll": {
+        "complete": "{{count}} description(s) passée(s) en revue.",
+        "noDescriptions": "Aucune description de ligne à peaufiner dans cette section."
       },
       "title": {
         "label": "Titre du devis",
@@ -728,6 +750,14 @@
         "add": "Ajouter",
         "nameAria": "Nom de la nouvelle ligne",
         "placeholder": "Saisissez le nom de l'article…"
+      },
+      "unassigned": {
+        "explainer": "Ces lignes ne figurent dans aucune section tarifaire, mais elles apparaissent malgré tout sur le devis du client et sont comptées dans ses totaux. Déplacez chacune d'elles dans une section tarifaire pour maîtriser l'endroit où elle apparaît.",
+        "moveAria": "Déplacer {{line}} vers une section tarifaire",
+        "movePlaceholder": "Déplacer vers…",
+        "noTargets": "Ajoutez une section tarifaire, puis déplacez-y ces lignes.",
+        "qtyPrice": "{{qty}} × {{price}}",
+        "title": "Lignes non affectées"
       }
     },
     "actions": {
@@ -1044,7 +1074,7 @@
       "tabs": {
         "editor": "Éditeur",
         "preview": "Aperçu",
-        "detail": "Détail"
+        "detail": "Détails"
       }
     }
   },

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -447,7 +447,11 @@
         "addSection": "Adicionar seção",
         "adding": "Adicionando…",
         "cancel": "Cancelar",
+        "collapseSection": "Recolher seção",
+        "dragLine": "Arraste para reordenar a linha",
+        "dragLineTitle": "Arraste para reordenar dentro desta tabela. Pelo teclado: use Mover para cima/baixo no menu da linha.",
         "dragSection": "Arraste para reordenar a seção",
+        "expandSection": "Expandir seção",
         "fetch": "Buscar",
         "fetchAddImage": "Buscar e adicionar imagem",
         "fromUrl": "Da URL",
@@ -468,13 +472,16 @@
         "replaceImage": "Substituir imagem",
         "sectionActions": "Ações da seção",
         "showCostMargin": "Mostrar custo e margem",
+        "tidyAllDescriptions": "Aprimorar todas as descrições",
         "uploadAddImage": "Enviar e adicionar imagem",
         "uploading": "Enviando…"
       },
       "addLine": {
+        "addFromCatalog": "Adicionar do catálogo",
+        "aiLookupAction": "Busca com IA",
         "catalogItem": "Item do catálogo",
         "manualLine": "Linha manual",
-        "moreWays": "Mais formas de adicionar (catálogo, busca com IA, detalhes)",
+        "moreDetails": "Mais detalhes",
         "searchDistributor": "Pesquisar distribuidor",
         "searchPax8": "Pesquisar Pax8"
       },
@@ -605,6 +612,7 @@
         "billing": "Cobrança",
         "billingFrequencyAria": "Frequência de cobrança",
         "cost": "Custo",
+        "costMissingAria": "Custo não informado — esta linha é excluída da estimativa de lucro.",
         "descriptionAria": "Descrição da linha",
         "descriptionOptional": "Descrição (opcional)",
         "enterCostFirstMarkup": "Informe um custo primeiro para definir a margem %",
@@ -619,8 +627,11 @@
         "profit": "Lucro",
         "quantityAria": "Quantidade",
         "saveToCatalog": "Salvar no catálogo",
+        "showLess": "Mostrar menos",
+        "showMore": "Mostrar mais",
         "sku": "SKU",
         "skuOptional": "SKU (opcional)",
+        "tidyWithAi": "Aprimorar com IA",
         "unitCost": "Custo unitário"
       },
       "liveTotals": {
@@ -635,6 +646,10 @@
         "taxRate": "Alíquota de imposto",
         "taxRateHelp": "Aplica-se às linhas marcadas como tributáveis. Definido nas configurações de imposto da organização.",
         "title": "Totais ao vivo"
+      },
+      "outline": {
+        "aria": "Conteúdo do orçamento",
+        "title": "Conteúdo"
       },
       "recurrence": {
         "annual": "Anual",
@@ -662,6 +677,9 @@
         "plusSeparator": " + "
       },
       "table": {
+        "collapsedSummary": "{{count}} linhas · {{amount}}",
+        "collapsedSummary_one": "{{count}} linha · {{amount}}",
+        "collapsedSummary_other": "{{count}} linhas · {{amount}}",
         "emptyLines": "Ainda não há linhas. Adicione um item de catálogo ou uma linha manual abaixo.",
         "fallbackName": "Tabela de preços {{number}}",
         "item": "Item",
@@ -682,6 +700,10 @@
       "terms": {
         "placeholder": "Termos de pagamento, cláusulas de garantia, etc.",
         "title": "Termos e Condições"
+      },
+      "tidyAll": {
+        "complete": "{{count}} descrição(ões) revisada(s).",
+        "noDescriptions": "Nenhuma descrição de linha para aprimorar nesta seção."
       },
       "title": {
         "label": "Título da cotação",
@@ -728,6 +750,14 @@
         "add": "Adicionar",
         "nameAria": "Nome da nova linha",
         "placeholder": "Digite o nome do item…"
+      },
+      "unassigned": {
+        "explainer": "Estas linhas não estão em nenhuma seção de preços, mas mesmo assim aparecem na cotação do cliente e entram nos totais dela. Mova cada uma para uma seção de preços para controlar onde ela aparece.",
+        "moveAria": "Mover {{line}} para uma seção de preços",
+        "movePlaceholder": "Mover para…",
+        "noTargets": "Adicione uma seção de preços e depois mova estas linhas para ela.",
+        "qtyPrice": "{{qty}} × {{price}}",
+        "title": "Linhas não atribuídas"
       }
     },
     "actions": {

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -519,6 +519,26 @@
         "richText": "Texto rico",
         "contract": "Contrato"
       },
+      "bulk": {
+        "applied_one": "{{count}} linha atualizada.",
+        "applied_other": "{{count}} linhas atualizadas.",
+        "apply": "Aplicar",
+        "barAria": "Edição em massa das linhas selecionadas",
+        "clearSelection": "Limpar seleção",
+        "invalidMarkup": "Informe um percentual de margem válido.",
+        "markupHint": "Aplica-se às linhas selecionadas que têm custo.",
+        "partialFailure": "{{failed}} de {{total}} linhas não foram atualizadas.",
+        "selectAllAria": "Selecionar todas as linhas de {{label}}",
+        "selectLineAria": "Selecionar {{name}}",
+        "selectedCount_one": "{{count}} linha selecionada",
+        "selectedCount_other": "{{count}} linhas selecionadas",
+        "setCost": "Definir custo",
+        "setMarkup": "Definir margem %",
+        "skippedNoCost_one": "{{count}} linha sem custo ignorada.",
+        "skippedNoCost_other": "{{count}} linhas sem custo ignoradas.",
+        "taxableOff": "Tributável: não",
+        "taxableOn": "Tributável: sim"
+      },
       "catalog": {
         "addSome": "Adicione alguns no Catálogo de Produtos",
         "empty": "Nenhum item de catálogo.",
@@ -607,6 +627,10 @@
         "full": "Interno · não mostrado ao cliente",
         "short": "Interno"
       },
+      "lastSaved": {
+        "saved": "Salvo às {{time}}",
+        "saving": "Salvando…"
+      },
       "line": {
         "addDescription": "descrição",
         "billing": "Cobrança",
@@ -622,7 +646,10 @@
         "markupPercent": "Margem %",
         "nameAria": "Nome da linha",
         "namePlaceholder": "Nome",
+        "noCost": "Sem custo",
+        "noCostHelp": "Marque esta linha como intencionalmente sem custo (por exemplo, mão de obra ou um serviço) — ela é excluída do aviso de custo ausente.",
         "partNumberAbbr": "PN",
+        "partNumberHelp": "O número de peça do fabricante para este item.",
         "partNumberOptional": "Nº da peça (opcional)",
         "profit": "Lucro",
         "quantityAria": "Quantidade",
@@ -630,6 +657,7 @@
         "showLess": "Mostrar menos",
         "showMore": "Mostrar mais",
         "sku": "SKU",
+        "skuHelp": "Seu número de estoque de catálogo ou distribuidor para este item.",
         "skuOptional": "SKU (opcional)",
         "tidyWithAi": "Aprimorar com IA",
         "unitCost": "Custo unitário"
@@ -637,18 +665,22 @@
       "liveTotals": {
         "annualRecurring": "Recorrente anual",
         "dueOnAcceptance": "Devido na aceitação",
+        "firstPeriodSubtotal": "Subtotal do primeiro período",
         "firstPeriodTotal": "Total do primeiro período (incl. recorrente)",
         "monthlyRecurring": "Recorrente mensal",
-        "oneTime": "Único",
+        "oneTime": "Único (antes dos impostos)",
         "srUpdated": "Totais atualizados. Único {{oneTime}}, recorrente mensal {{monthly}}, recorrente anual {{annual}}, devido na aceitação {{due}}.",
         "srUpdatedWithTax": "Totais atualizados. Único {{oneTime}}, recorrente mensal {{monthly}}, recorrente anual {{annual}}, imposto {{tax}}, devido na aceitação {{due}}.",
+        "subtotal": "Subtotal",
         "tax": "Imposto",
         "taxRate": "Alíquota de imposto",
         "taxRateHelp": "Aplica-se às linhas marcadas como tributáveis. Definido nas configurações de imposto da organização.",
-        "title": "Totais ao vivo"
+        "title": "Totais ao vivo",
+        "total": "Total"
       },
       "outline": {
         "aria": "Conteúdo do orçamento",
+        "shortcutHint": "Alt+Seta para baixo / Alt+Seta para cima pula para a seção seguinte ou anterior durante a edição.",
         "title": "Conteúdo"
       },
       "recurrence": {
@@ -688,7 +720,7 @@
         "notTaxable": "Não tributável",
         "qty": "Qtd.",
         "recurrence": "Recorrência",
-        "scrollAria": "Tabela de preços — role lateralmente em telas estreitas para ver totais e ações da linha",
+        "scrollAria": "Tabela de preços — role lateralmente em telas estreitas para ver totais e ações da linha; em seções longas, role verticalmente com o cabeçalho fixo",
         "showSubtotal": "Mostrar linha de subtotal",
         "tax": "Imposto",
         "taxSuffix": "+ {{amount}} de imposto",
@@ -704,6 +736,10 @@
       "tidyAll": {
         "complete": "{{count}} descrição(ões) revisada(s).",
         "noDescriptions": "Nenhuma descrição de linha para aprimorar nesta seção."
+      },
+      "undo": {
+        "lineDeleted": "Linha excluída",
+        "sectionDeleted": "Seção excluída"
       },
       "title": {
         "label": "Título da cotação",

--- a/docs/superpowers/plans/open/2026-07-21-quote-editor-ux-followups.md
+++ b/docs/superpowers/plans/open/2026-07-21-quote-editor-ux-followups.md
@@ -1,0 +1,47 @@
+# Quote editor UX follow-ups (from two design reviews)
+
+**Status**: 2026-07-21 — Tasks A, C, D, E, F, B1 DONE (uncommitted in the shared worktree, 530 web + shared tests green; B1 also fixed a bulk-markup bug that zeroed prices on explicit-0-cost lines). **Only B2 (unit column, item 4) remains — HELD** because it needs `quoteService.ts`/PDF/portal, which the concurrent portal-render-parity session still has uncommitted. Resume B2 once that session's work is committed. Item 18 resolved as measure-only: contrast is 4.65–5.92:1, all AA-pass, token unchanged. Item 16's "clipped dark button" was a stale screenshot artifact — nothing to fix. · **Owner**: Todd · **Branch context**: builds on PR #2711 (`ToddHebebrand/quoting-mcp`).
+
+Source: an impeccable-skill critique (snapshot `.impeccable/critique/2026-07-21T20-02-29Z__web-src-components-billing-quotes-quoteeditor-tsx.md`, 23/40 baseline) plus an independent unstructured model review of the same screenshot. Items below are everything **not** addressed by #2711. Tags: [I] impeccable, [F] independent review.
+
+Verified facts (2026-07-21): totals rail is already `xl:sticky` with a `quote-totals-sticky` mobile bar — do not re-add. Markup input is still `type="number" step="0.1"` (price/cost were converted to format-on-blur text in #2711). Block "Show subtotal row" writes `content.showSubtotal`, which the expanded editor table never renders (document/PDF only).
+
+## Task A — rail money display (high value)
+1. [F] Grand total stack in the rail: Subtotal → Tax → **Total** (total visually dominant); label one-time as pre-tax. Mirror in the `quote-totals-sticky` mobile bar.
+2. [F] Profit as percent alongside dollars in MarginPanel ("Profit $2,292.36 (37.2%)"); visually separate from the tax-rate figure so 8.95% can't be misread as margin.
+
+## Task B — line semantics (full-stack: shared validators + API + web; maybe migration)
+3. [F] "No cost" designation for labor/service lines so they're deliberately excluded from the "N lines missing a cost" warning (distinguish explicit cost=0 from cost-unknown null; UI affordance on the internal band).
+4. [F] Optional unit label on qty (hrs/ea/drops) rendered in editor + document/PDF/portal ("18 hrs × $115.00"). Likely a nullable `unit` column on quote_lines (idempotent migration, no RLS change — existing table).
+
+## Task C — editor chrome
+5. [F] "Show subtotal row": render the subtotal row in the expanded editor table, or relabel to "Show subtotal on proposal".
+6. [F] Markup input → text/`inputMode="decimal"` pattern matching price/cost (kill the spinner).
+7. [F] "Last saved 2:41 PM" / sync indicator near the autosave notice.
+8. [F] Quote status (draft/sent) in the editor header next to Send proposal.
+
+## Task D — bulk edit (large)
+9. [I] Multi-select lines → bulk set markup / cost / taxable. Batch through existing per-line PATCH or a bulk endpoint; single undo-able action preferred.
+
+## Task E — undo (large)
+10. [I] Undo for line/block deletion (toast with Undo, or soft-delete grace window).
+
+## Task F — polish sweep
+11. [I] Section header typographic weight (headers barely heavier than item names).
+12. [I] SKU vs PN confusion — help text or merge (users enter identical values).
+13. [I/F] Tooltip on item-name inputs when value exceeds width.
+14. [F] Sticky per-block column headers (ITEM/QTY/…).
+15. [F] Auto-grow description textareas; remove manual resize handle.
+16. [F] ADD SECTION bar: heading-text input only for the "Heading" chip; investigate clipped dark button bottom-left of screenshot.
+17. [F] "Showing all organizations" banner clipped at top edge.
+18. [I] Measure `text-muted-foreground` contrast on card bg; adjust token if <4.5:1 (repo-wide impact — measure first, discuss before changing).
+19. [I] Keyboard shortcuts (add line, jump between blocks).
+
+## Not code
+20. [F] Data fixes in the demo quote: "Corfigure" typo, "OliveTech" internal-tooling leak in customer-visible description — run "Tidy all descriptions" on that quote in-app.
+
+## Conventions for implementers (learned in #2711)
+- Shared worktree possible; targeted edits only, no git stash/checkout, re-read before editing.
+- i18n: every new string in all five locales (en, de-DE, es-419, fr-FR, pt-BR), real translations (translationCoverage duplicate-baseline gate).
+- Preserve: amber dirty ring + SrSaved, per-line internal-band collapse (pins open when dirty), format-on-blur money inputs, revealRequest plumbing, block collapse + Contents outline.
+- Verify per task: `cd apps/web && npx vitest run src/components/billing/` + `src/lib/i18n/`, `npx astro check`, eslint (no react-hooks plugin — no disable comments).

--- a/packages/shared/src/utils/quoteMath.test.ts
+++ b/packages/shared/src/utils/quoteMath.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeQuoteTotals, computeLineTotal, toCents, fromCents, markupPct, priceFromMarkup, computeQuoteProfit, validateQuoteDeposit, toQuoteDepositConfig, type QuoteLineForMath } from './quoteMath';
+import { computeQuoteTotals, computeLineTotal, toCents, fromCents, markupPct, priceFromMarkup, computeQuoteProfit, marginPct, validateQuoteDeposit, toQuoteDepositConfig, type QuoteLineForMath } from './quoteMath';
 
 const line = (over: Partial<QuoteLineForMath>): QuoteLineForMath => ({
   quantity: '1', unitPrice: '0', taxable: false, recurrence: 'one_time', customerVisible: true, ...over,
@@ -77,6 +77,35 @@ describe('quoteMath (shared)', () => {
     expect(r.monthlyRecurringNet).toBe('15.00');
     expect(r.totalCost).toBe('125.00');
     expect(r.linesMissingCost).toBe(1);
+    // Revenue is split by the SAME cadence rule, over the SAME cost-bearing
+    // lines as net (the missing-cost line contributes to neither) — the
+    // denominator marginPct needs for a per-cadence percent.
+    expect(r.oneTimeRevenue).toBe('130.00');
+    expect(r.monthlyRecurringRevenue).toBe('40.00');
+    expect(r.annualRecurringRevenue).toBe('0.00');
+  });
+
+  it('computeQuoteProfit: an EXPLICIT cost of 0 ("no cost", Task B1) is NOT missing — full price counts as net, distinct from a null (never-entered) cost', () => {
+    const lineHelper = (o: Partial<QuoteLineForMath>) => ({
+      quantity: '1', unitPrice: '0', taxable: false, customerVisible: true, recurrence: 'one_time' as const, ...o,
+    });
+    const r = computeQuoteProfit([
+      lineHelper({ unitPrice: '150', unitCost: '0' }),   // explicit no-cost labor line — net = full price
+      lineHelper({ unitPrice: '80', unitCost: null }),   // genuinely missing/unknown cost
+    ]);
+    expect(r.linesMissingCost).toBe(1); // only the null line, NOT the explicit-0 line
+    expect(r.oneTimeNet).toBe('150.00'); // 150 - 0, the null-cost line contributes nothing
+    expect(r.totalCost).toBe('0.00');
+    expect(r.oneTimeRevenue).toBe('150.00'); // only the cost-bearing (incl. $0-cost) line's revenue
+  });
+
+  it('marginPct: net/revenue·100 (margin, not markup); null on div-by-zero/non-finite', () => {
+    expect(marginPct('30', '50')).toBeCloseTo(60);
+    expect(marginPct('-10', '50')).toBeCloseTo(-20); // a loss is a valid (negative) margin
+    expect(marginPct('10', '0')).toBeNull(); // no revenue to compute a percent from
+    expect(marginPct('10', '-5')).toBeNull(); // negative revenue is nonsensical, not "0%"
+    expect(marginPct('10', Number.NaN)).toBeNull();
+    expect(marginPct(Number.NaN, '50')).toBeNull();
   });
 });
 

--- a/packages/shared/src/utils/quoteMath.ts
+++ b/packages/shared/src/utils/quoteMath.ts
@@ -249,14 +249,33 @@ export interface QuoteProfit {
   monthlyRecurringNet: string;
   annualRecurringNet: string;
   totalCost: string;
+  /**
+   * Revenue (pre-tax) that the net figures above were computed from, split by
+   * the same cadence — ONLY lines that have a cost (a line missing cost
+   * contributes to neither the net nor the revenue here, same exclusion as
+   * `linesMissingCost`). This is the denominator for a margin percent
+   * (net / revenue · 100, see `marginPct`); a cadence with no cost-bearing
+   * lines yields '0.00', which is how callers detect "nothing to compute a
+   * percent from" rather than showing a misleading 0%.
+   */
+  oneTimeRevenue: string;
+  monthlyRecurringRevenue: string;
+  annualRecurringRevenue: string;
   /** Count of billed lines with no cost — excluded from net, so the figure is partial. */
   linesMissingCost: number;
 }
 
 /** Net = revenue − cost, EXCLUDING tax, over billed (customerVisible) lines, split
- *  by cadence. Lines with no unitCost are excluded and counted in linesMissingCost. */
+ *  by cadence. Lines with no unitCost (null/undefined/empty string — never entered)
+ *  are excluded and counted in linesMissingCost. An EXPLICIT cost of 0 (e.g. a
+ *  labor/service line deliberately marked "no cost" — Task B1) is NOT missing:
+ *  it's a real, known cost of $0, so the line counts fully toward net (net =
+ *  full revenue) and is never counted in linesMissingCost. Only the string
+ *  `l.unitCost === null | undefined | ''` triggers the exclusion below — '0'/'0.00'
+ *  fails that check and falls through to the normal cents math. */
 export function computeQuoteProfit(lines: QuoteLineForMath[]): QuoteProfit {
   let oneTimeNet = 0, monthlyNet = 0, annualNet = 0, totalCost = 0, missing = 0;
+  let oneTimeRevenue = 0, monthlyRevenue = 0, annualRevenue = 0;
   for (const l of lines) {
     if (!l.customerVisible) continue;
     if (l.unitCost === null || l.unitCost === undefined || l.unitCost === '') { missing++; continue; }
@@ -264,15 +283,31 @@ export function computeQuoteProfit(lines: QuoteLineForMath[]): QuoteProfit {
     const costCents = toCents(computeLineTotal(l.quantity, l.unitCost));
     const netCents = revenueCents - costCents;
     totalCost += costCents;
-    if (l.recurrence === 'monthly') monthlyNet += netCents;
-    else if (l.recurrence === 'annual') annualNet += netCents;
-    else oneTimeNet += netCents;
+    if (l.recurrence === 'monthly') { monthlyNet += netCents; monthlyRevenue += revenueCents; }
+    else if (l.recurrence === 'annual') { annualNet += netCents; annualRevenue += revenueCents; }
+    else { oneTimeNet += netCents; oneTimeRevenue += revenueCents; }
   }
   return {
     oneTimeNet: fromCents(oneTimeNet),
     monthlyRecurringNet: fromCents(monthlyNet),
     annualRecurringNet: fromCents(annualNet),
     totalCost: fromCents(totalCost),
+    oneTimeRevenue: fromCents(oneTimeRevenue),
+    monthlyRecurringRevenue: fromCents(monthlyRevenue),
+    annualRecurringRevenue: fromCents(annualRevenue),
     linesMissingCost: missing,
   };
+}
+
+/**
+ * Profit MARGIN = net / revenue · 100 — NOT markup (net / cost). Null when
+ * revenue is zero, negative, or non-finite, which also covers "no cost-bearing
+ * lines in this cadence" (computeQuoteProfit's revenue fields are 0 in that
+ * case) — callers use null to suppress the percent instead of showing a
+ * misleading 0% or NaN.
+ */
+export function marginPct(net: string | number, revenue: string | number): number | null {
+  const n = Number(net); const r = Number(revenue);
+  if (!Number.isFinite(n) || !Number.isFinite(r) || r <= 0) return null;
+  return (n / r) * 100;
 }


### PR DESCRIPTION
## Summary

Three bodies of work on the quote editor, developed in the same worktree:

### 1. Orphan-line fix (API + web)
- `e75001c2` — `cloneQuote` no longer mints orphan lines (`block_id NULL`): both orphan shapes (already-orphaned source line, and source block missing from `blockIds`) re-parent onto a fallback pricing section resolved before the transaction; migration backfills existing orphan rows and null `quote_number`s with row-count warnings.
- `86c39c55` — new `UnassignedLines` editor surface: orphan lines are now visible and editable in a dedicated bucket below the document instead of silently counting toward totals.

### 2. Editor UX overhaul (from a design critique, 23/40 baseline)
- **Progressive disclosure**: per-line internal cost band collapses to a `SKU · Cost · Markup · Profit` summary with per-line expand; dirty/errored lines pin open. Cadence chips only when mixed; ghost-row chrome hidden until used; long descriptions clamp with Show more/less.
- **Money correctness**: price/cost inputs show `$1,234.56` when blurred, raw decimal while editing; keystroke sanitization prevents NaN commits; ch-based auto-growing widths eliminate value clipping.
- **Actionable margin warning**: "N lines missing a cost" scrolls to / expands / focuses the first offender; warning-tinted `Cost —` flags in both band states; non-blocking notice in the send dialog (margin-visible users only); org-name tooltip; sr-only "Unsaved" for dirty fields.
- **Navigation**: sticky Contents outline in the rail, collapsible pricing blocks (dirty blocks refuse collapse; reveal auto-expands), line drag handles committing through the same reorder mutation as the ⋯ menu.
- **Copy**: "Tidy with AI" + Sparkles, block-level "Tidy all descriptions" driving the existing preview + fact-guard dialog per line (approval-gated), explicit "Add from catalog / AI lookup / More details" buttons, "Detail" → "Details".
- **Polish**: focus-visible rings on icon-only buttons, tokenized MarginPanel title, "Add section" demoted to secondary so "Send proposal" is the sole primary CTA.

### 3. Portal render parity + editor polish (`266c8da0`)
- **Portal/public render parity**: the customer-facing proposal now renders per-line images (new `GET /quotes/:id/line-image/:lineId` on both the portal and public routes, with catalog-item fallback and `customerVisible` gating), plus line names/blurbs that were previously dropped; the accept checkbox is actually visible; signature panel styling fixed.
- **Bulk edit**: new `QuoteBulkBar` — multi-select lines across blocks, bulk markup/visibility/delete.
- **Undo delete**: block and line deletions offer an undo toast instead of being immediately irreversible.
- **Totals**: optional per-block subtotal rows and a consolidated totals stack backed by new `quoteMath` helpers.
- **Last-saved indicator** in the workspace header.

## Test plan
- 478+ tests green across `src/components/billing/` + `src/lib/i18n/`, including new suites for bulkedit, undodelete, lastsaved, subtotalrow, totalsstack, polish, billingUi, and portal/public line-image routes
- `astro check` 0 errors / 0 warnings; eslint clean on touched files
- i18n parity/coverage/keyUsage gates green; all new strings translated in en, de-DE, es-419, fr-FR, pt-BR
- Integration test for the backfill migration (`quoteBackfillOrphanLinesAndNumbers.integration.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)