### PR TITLE
fix(deploy): thread documented .env vars into api container + add parity guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -571,16 +571,9 @@ SENTRY_PROJECT=
 SENTRY_AUTH_TOKEN=
 
 # --------------------------------------------
-# Rate Limiting
-# --------------------------------------------
-RATE_LIMIT_WINDOW_MS=60000
-RATE_LIMIT_MAX_REQUESTS=100
-
-# --------------------------------------------
 # Session Configuration
 # --------------------------------------------
 SESSION_SECRET=another-secret-for-sessions-change-in-production
-SESSION_MAX_AGE=86400000
 
 # --------------------------------------------
 # Feature Flags
@@ -591,9 +584,9 @@ SESSION_MAX_AGE=86400000
 # with no web rebuild (the old build-time PUBLIC_ENABLE_REGISTRATION is gone).
 ENABLE_REGISTRATION=false               # gates both the API endpoints and the "Register your MSP" UI
 ENABLE_2FA=true
-ENABLE_API_DOCS=false
-# Interactive Swagger UI (loads scripts/styles from unpkg) is disabled by default in production.
-# Only applies when ENABLE_API_DOCS=true.
+# Interactive Swagger UI at /docs (loads scripts/styles from unpkg). Defaults to
+# ON outside production and OFF in production; the raw OpenAPI spec at /docs is
+# always served regardless.
 # ENABLE_API_DOCS_UI=false
 # Set to 1 to use the Claude Agent SDK for AI chat (instead of raw Anthropic SDK)
 # USE_AGENT_SDK=1

--- a/apps/api/src/config/envComposeParity.test.ts
+++ b/apps/api/src/config/envComposeParity.test.ts
@@ -99,7 +99,7 @@ function activeEnvExampleVars(relPath: string): string[] {
   const names = new Set<string>();
   for (const line of text.split('\n')) {
     const m = /^([A-Z][A-Z0-9_]*)=/.exec(line); // uncommented assignments only
-    if (m) names.add(m[1]);
+    if (m?.[1]) names.add(m[1]);
   }
   return [...names].sort();
 }

--- a/apps/api/src/config/envComposeParity.test.ts
+++ b/apps/api/src/config/envComposeParity.test.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// apps/api/src/config -> repo root is 4 levels up (same as proxyTrustCompose.test.ts).
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+const ENV_EXAMPLE_PATH = path.join(REPO_ROOT, '.env.example');
+const COMPOSE_PATH = path.join(REPO_ROOT, 'docker-compose.yml');
+
+/**
+ * Why this test exists
+ * --------------------
+ * The stock `docker-compose.yml` does NOT `env_file: .env` — it hand-threads
+ * each variable into a service `environment:` block as `${VAR:-default}`. That
+ * is deliberate (least-privilege per container, `:?required` fail-fast, baked
+ * defaults, derived values, file-backed secrets), but it has a sharp edge: a
+ * variable documented in `.env.example` that nobody remembered to add to a
+ * service block is **silently inert** — setting it in `.env` does nothing.
+ *
+ * This has shipped bad deploys repeatedly (IS_HOSTED / #570, the release-key,
+ * and — the reason this test exists — a self-hoster whose CORS/2FA/platform-admin
+ * settings all no-op'd because they were never threaded through Compose).
+ *
+ * The guard: every active variable in `.env.example` MUST be either
+ *   (a) referenced somewhere in docker-compose.yml (mapped into a container, or
+ *       used for interpolation), or
+ *   (b) listed in HOST_ONLY_ALLOWLIST below with a reason.
+ * Adding a new documented var without doing one of those two fails CI here,
+ * instead of silently in someone's production deploy.
+ */
+
+// Variables intentionally NOT threaded into the standalone API/web containers.
+// Every entry needs a reason; a stale entry (no longer in .env.example) also
+// fails this suite, so the list can't rot.
+const HOST_ONLY_ALLOWLIST: Record<string, string> = {
+  // Host / Compose-level, or consumed by a DIFFERENT service — never the API.
+  COMPOSE_PROJECT_NAME: 'Compose project name (host-level, not a container env)',
+  POSTGRES_PORT: 'postgres service host port',
+  WEB_PORT: 'web service host port',
+  MINIO_API_PORT: 'optional MinIO service host port',
+  MINIO_CONSOLE_PORT: 'optional MinIO console host port',
+  GRAFANA_ADMIN_USER: 'consumed by docker-compose.monitoring.yml, not the core stack',
+  GRAFANA_ADMIN_PASSWORD: 'consumed by docker-compose.monitoring.yml, not the core stack',
+  BREEZE_API_HOST_PORT: 'guided-setup external-proxy bookkeeping (host bind port)',
+  BREEZE_WEB_HOST_PORT: 'guided-setup external-proxy bookkeeping (host bind port)',
+  BREEZE_PROXY_BIND_HOST: 'guided-setup external-proxy bookkeeping',
+  BREEZE_PROXY_TARGET_HOST: 'guided-setup external-proxy bookkeeping',
+  BREEZE_EXTERNAL_PROXY: 'guided-setup external-proxy bookkeeping',
+  BREEZE_EXTERNAL_PROXY_CIDRS: 'guided-setup copies this into TRUSTED_PROXY_CIDRS (which IS mapped)',
+
+  // Redis is configured via the file-backed `redis_password` secret plus
+  // REDIS_HOST/REDIS_PORT in the api block — raw REDIS_PASSWORD/REDIS_URL are
+  // intentionally not passed to the API container.
+  REDIS_PASSWORD: 'API uses REDIS_PASSWORD_FILE secret + REDIS_HOST/REDIS_PORT (already mapped)',
+  REDIS_URL: 'API derives its Redis connection from REDIS_HOST/REDIS_PORT + the file secret',
+
+  // Web (Astro) build-time values. The web image is prebuilt in CI, so PUBLIC_*
+  // and the web Sentry vars are baked at build time and cannot be set at runtime
+  // on a pulled image. Threading them into the web `environment:` block would be
+  // misleading, not functional. (Tracked separately if runtime override is ever needed.)
+  PUBLIC_RELEASE_VERSION: 'web build-time (baked into the prebuilt web image)',
+  PUBLIC_TICKET_MAILBOX_APP_ID: 'web build-time PUBLIC_ var (baked into the prebuilt web image)',
+  ENABLE_SENTRY_SMOKE: 'web build/SSR smoke flag (baked into the prebuilt web image)',
+  SENTRY_DSN_WEB_SERVER: 'web SSR Sentry DSN (baked into the prebuilt web image)',
+  SENTRY_AUTH_TOKEN: 'build-time source-map upload (CI only, never a runtime container env)',
+  SENTRY_ORG: 'build-time source-map upload (CI only)',
+  SENTRY_PROJECT: 'build-time source-map upload (CI only)',
+
+  // Documented in .env.example but NOT read by any code path (verified by grep).
+  // Kept here so the guard passes; candidates for removal from .env.example.
+  ENABLE_API_DOCS: 'documented but not consumed by the API (vestigial in .env.example)',
+  RATE_LIMIT_MAX_REQUESTS: 'documented but not consumed by the API (vestigial in .env.example)',
+  RATE_LIMIT_WINDOW_MS: 'documented but not consumed by the API (vestigial in .env.example)',
+  SESSION_MAX_AGE: 'documented but not consumed by the API (SESSION_MAX_AGE_MS is a hardcoded constant)',
+};
+
+function activeEnvExampleVars(): string[] {
+  const text = readFileSync(ENV_EXAMPLE_PATH, 'utf8');
+  const names = new Set<string>();
+  for (const line of text.split('\n')) {
+    const m = /^([A-Z][A-Z0-9_]*)=/.exec(line); // uncommented assignments only
+    if (m) names.add(m[1]);
+  }
+  return [...names].sort();
+}
+
+function isReferencedInCompose(varName: string, compose: string): boolean {
+  const esc = varName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // (a) mapped as a service env key: `      VAR: ...`
+  const asKey = new RegExp(`^\\s*${esc}:(\\s|$)`, 'm');
+  // (b) used in `${VAR}` / `${VAR:-x}` / `${VAR:?x}` / `${VAR-x}` interpolation
+  const asInterp = new RegExp(`\\$\\{${esc}[-:}]`);
+  return asKey.test(compose) || asInterp.test(compose);
+}
+
+describe('.env.example ↔ docker-compose.yml parity', () => {
+  const compose = readFileSync(COMPOSE_PATH, 'utf8');
+  const envVars = activeEnvExampleVars();
+
+  it('every documented .env.example variable is either mapped in compose or explicitly allow-listed', () => {
+    const unwired = envVars.filter(
+      (v) => !isReferencedInCompose(v, compose) && !(v in HOST_ONLY_ALLOWLIST),
+    );
+    expect(
+      unwired,
+      `These vars are in .env.example but never reach a container (setting them in .env is a silent no-op). ` +
+        `Add each to a service 'environment:' block in docker-compose.yml, or to HOST_ONLY_ALLOWLIST with a reason:\n  ` +
+        unwired.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('has no stale allow-list entries (every allow-listed var still exists in .env.example)', () => {
+    const envSet = new Set(envVars);
+    const stale = Object.keys(HOST_ONLY_ALLOWLIST).filter((v) => !envSet.has(v));
+    expect(
+      stale,
+      `These vars are allow-listed but no longer active in .env.example — remove them from HOST_ONLY_ALLOWLIST:\n  ` +
+        stale.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('does not redundantly allow-list a var that is already mapped in compose', () => {
+    const redundant = Object.keys(HOST_ONLY_ALLOWLIST).filter((v) => isReferencedInCompose(v, compose));
+    expect(
+      redundant,
+      `These vars are BOTH mapped in compose and allow-listed — drop them from HOST_ONLY_ALLOWLIST:\n  ` +
+        redundant.join('\n  '),
+    ).toEqual([]);
+  });
+});

--- a/apps/api/src/config/envComposeParity.test.ts
+++ b/apps/api/src/config/envComposeParity.test.ts
@@ -5,35 +5,35 @@ import { describe, expect, it } from 'vitest';
 
 // apps/api/src/config -> repo root is 4 levels up (same as proxyTrustCompose.test.ts).
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
-const ENV_EXAMPLE_PATH = path.join(REPO_ROOT, '.env.example');
-const COMPOSE_PATH = path.join(REPO_ROOT, 'docker-compose.yml');
 
 /**
  * Why this test exists
  * --------------------
- * The stock `docker-compose.yml` does NOT `env_file: .env` — it hand-threads
- * each variable into a service `environment:` block as `${VAR:-default}`. That
- * is deliberate (least-privilege per container, `:?required` fail-fast, baked
- * defaults, derived values, file-backed secrets), but it has a sharp edge: a
- * variable documented in `.env.example` that nobody remembered to add to a
- * service block is **silently inert** — setting it in `.env` does nothing.
+ * Neither compose file uses `env_file: .env` — they hand-thread each variable
+ * into a service `environment:` block as `${VAR:-default}`. That is deliberate
+ * (least-privilege per container, `:?required` fail-fast, baked defaults,
+ * derived values, file-backed secrets), but it has a sharp edge: a variable
+ * documented in the paired `.env.example` that nobody added to a service block
+ * is **silently inert** — setting it in `.env` does nothing.
  *
- * This has shipped bad deploys repeatedly (IS_HOSTED / #570, the release-key,
+ * This has shipped bad deploys repeatedly (IS_HOSTED / #570, the release key,
  * and — the reason this test exists — a self-hoster whose CORS/2FA/platform-admin
  * settings all no-op'd because they were never threaded through Compose).
  *
- * The guard: every active variable in `.env.example` MUST be either
- *   (a) referenced somewhere in docker-compose.yml (mapped into a container, or
- *       used for interpolation), or
- *   (b) listed in HOST_ONLY_ALLOWLIST below with a reason.
- * Adding a new documented var without doing one of those two fails CI here,
- * instead of silently in someone's production deploy.
+ * The guard, per env-example ↔ compose pair: every active variable in the
+ * `.env.example` MUST be either
+ *   (a) referenced in the compose file (mapped into a container, sourced into a
+ *       secret, or used for interpolation), or
+ *   (b) listed in that pair's allow-list below with a reason.
+ * Adding a documented var without doing one of those two fails CI here, in the
+ * required test-api job, instead of silently in someone's production deploy.
  */
 
-// Variables intentionally NOT threaded into the standalone API/web containers.
-// Every entry needs a reason; a stale entry (no longer in .env.example) also
-// fails this suite, so the list can't rot.
-const HOST_ONLY_ALLOWLIST: Record<string, string> = {
+// Variables intentionally NOT threaded into the self-host (root) stack's
+// containers. Every entry needs a reason; a stale entry (no longer in
+// .env.example) or a redundant one (already mapped) also fails this suite, so
+// the list can't rot.
+const ROOT_ALLOWLIST: Record<string, string> = {
   // Host / Compose-level, or consumed by a DIFFERENT service — never the API.
   COMPOSE_PROJECT_NAME: 'Compose project name (host-level, not a container env)',
   POSTGRES_PORT: 'postgres service host port',
@@ -49,16 +49,16 @@ const HOST_ONLY_ALLOWLIST: Record<string, string> = {
   BREEZE_EXTERNAL_PROXY: 'guided-setup external-proxy bookkeeping',
   BREEZE_EXTERNAL_PROXY_CIDRS: 'guided-setup copies this into TRUSTED_PROXY_CIDRS (which IS mapped)',
 
-  // Redis is configured via the file-backed `redis_password` secret plus
-  // REDIS_HOST/REDIS_PORT in the api block — raw REDIS_PASSWORD/REDIS_URL are
-  // intentionally not passed to the API container.
-  REDIS_PASSWORD: 'API uses REDIS_PASSWORD_FILE secret + REDIS_HOST/REDIS_PORT (already mapped)',
+  // REDIS_URL is not consumed by the API container (it derives its connection
+  // from REDIS_HOST/REDIS_PORT + the file-backed redis_password secret).
+  // REDIS_PASSWORD is NOT here: it sources the redis_password secret via
+  // `environment: REDIS_PASSWORD`, which isReferencedInCompose() detects.
   REDIS_URL: 'API derives its Redis connection from REDIS_HOST/REDIS_PORT + the file secret',
 
   // Web (Astro) build-time values. The web image is prebuilt in CI, so PUBLIC_*
   // and the web Sentry vars are baked at build time and cannot be set at runtime
   // on a pulled image. Threading them into the web `environment:` block would be
-  // misleading, not functional. (Tracked separately if runtime override is ever needed.)
+  // misleading, not functional.
   PUBLIC_RELEASE_VERSION: 'web build-time (baked into the prebuilt web image)',
   PUBLIC_TICKET_MAILBOX_APP_ID: 'web build-time PUBLIC_ var (baked into the prebuilt web image)',
   ENABLE_SENTRY_SMOKE: 'web build/SSR smoke flag (baked into the prebuilt web image)',
@@ -66,17 +66,36 @@ const HOST_ONLY_ALLOWLIST: Record<string, string> = {
   SENTRY_AUTH_TOKEN: 'build-time source-map upload (CI only, never a runtime container env)',
   SENTRY_ORG: 'build-time source-map upload (CI only)',
   SENTRY_PROJECT: 'build-time source-map upload (CI only)',
-
-  // Documented in .env.example but NOT read by any code path (verified by grep).
-  // Kept here so the guard passes; candidates for removal from .env.example.
-  ENABLE_API_DOCS: 'documented but not consumed by the API (vestigial in .env.example)',
-  RATE_LIMIT_MAX_REQUESTS: 'documented but not consumed by the API (vestigial in .env.example)',
-  RATE_LIMIT_WINDOW_MS: 'documented but not consumed by the API (vestigial in .env.example)',
-  SESSION_MAX_AGE: 'documented but not consumed by the API (SESSION_MAX_AGE_MS is a hardcoded constant)',
 };
 
-function activeEnvExampleVars(): string[] {
-  const text = readFileSync(ENV_EXAMPLE_PATH, 'utf8');
+// The digest-pinned droplet stack. Its api block is well-maintained; after
+// wiring the parity gaps, nothing here needs an intentional exception.
+const PROD_ALLOWLIST: Record<string, string> = {};
+
+interface Pair {
+  name: string;
+  envExample: string;
+  compose: string;
+  allowlist: Record<string, string>;
+}
+
+const PAIRS: Pair[] = [
+  {
+    name: 'self-host (root .env.example ↔ docker-compose.yml)',
+    envExample: '.env.example',
+    compose: 'docker-compose.yml',
+    allowlist: ROOT_ALLOWLIST,
+  },
+  {
+    name: 'droplet (deploy/.env.example ↔ deploy/docker-compose.prod.yml)',
+    envExample: 'deploy/.env.example',
+    compose: 'deploy/docker-compose.prod.yml',
+    allowlist: PROD_ALLOWLIST,
+  },
+];
+
+function activeEnvExampleVars(relPath: string): string[] {
+  const text = readFileSync(path.join(REPO_ROOT, relPath), 'utf8');
   const names = new Set<string>();
   for (const line of text.split('\n')) {
     const m = /^([A-Z][A-Z0-9_]*)=/.exec(line); // uncommented assignments only
@@ -88,43 +107,46 @@ function activeEnvExampleVars(): string[] {
 function isReferencedInCompose(varName: string, compose: string): boolean {
   const esc = varName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   // (a) mapped as a service env key: `      VAR: ...`
-  const asKey = new RegExp(`^\\s*${esc}:(\\s|$)`, 'm');
-  // (b) used in `${VAR}` / `${VAR:-x}` / `${VAR:?x}` / `${VAR-x}` interpolation
-  const asInterp = new RegExp(`\\$\\{${esc}[-:}]`);
-  return asKey.test(compose) || asInterp.test(compose);
+  if (new RegExp(`^\\s*${esc}:(\\s|$)`, 'm').test(compose)) return true;
+  // (b) `${VAR}` / `${VAR:-x}` / `${VAR:?x}` / `${VAR-x}` interpolation
+  if (new RegExp(`\\$\\{${esc}[-:}]`).test(compose)) return true;
+  // (c) short-form passthrough / secret sourcing: `environment: VAR` or `- VAR`
+  if (new RegExp(`\\benvironment:\\s*${esc}\\b`).test(compose)) return true;
+  if (new RegExp(`^\\s*-\\s*${esc}(=|\\s*$)`, 'm').test(compose)) return true;
+  return false;
 }
 
-describe('.env.example ↔ docker-compose.yml parity', () => {
-  const compose = readFileSync(COMPOSE_PATH, 'utf8');
-  const envVars = activeEnvExampleVars();
+describe.each(PAIRS)('.env.example ↔ compose parity: $name', ({ envExample, compose, allowlist }) => {
+  const composeText = readFileSync(path.join(REPO_ROOT, compose), 'utf8');
+  const envVars = activeEnvExampleVars(envExample);
 
-  it('every documented .env.example variable is either mapped in compose or explicitly allow-listed', () => {
+  it('every documented variable is either mapped in compose or explicitly allow-listed', () => {
     const unwired = envVars.filter(
-      (v) => !isReferencedInCompose(v, compose) && !(v in HOST_ONLY_ALLOWLIST),
+      (v) => !isReferencedInCompose(v, composeText) && !(v in allowlist),
     );
     expect(
       unwired,
-      `These vars are in .env.example but never reach a container (setting them in .env is a silent no-op). ` +
-        `Add each to a service 'environment:' block in docker-compose.yml, or to HOST_ONLY_ALLOWLIST with a reason:\n  ` +
+      `These vars are in ${envExample} but never reach a container (setting them in .env is a silent no-op). ` +
+        `Add each to a service 'environment:' block in ${compose}, or to the allow-list with a reason:\n  ` +
         unwired.join('\n  '),
     ).toEqual([]);
   });
 
-  it('has no stale allow-list entries (every allow-listed var still exists in .env.example)', () => {
+  it('has no stale allow-list entries (every allow-listed var still exists in the .env.example)', () => {
     const envSet = new Set(envVars);
-    const stale = Object.keys(HOST_ONLY_ALLOWLIST).filter((v) => !envSet.has(v));
+    const stale = Object.keys(allowlist).filter((v) => !envSet.has(v));
     expect(
       stale,
-      `These vars are allow-listed but no longer active in .env.example — remove them from HOST_ONLY_ALLOWLIST:\n  ` +
+      `These vars are allow-listed but no longer active in ${envExample} — remove them from the allow-list:\n  ` +
         stale.join('\n  '),
     ).toEqual([]);
   });
 
-  it('does not redundantly allow-list a var that is already mapped in compose', () => {
-    const redundant = Object.keys(HOST_ONLY_ALLOWLIST).filter((v) => isReferencedInCompose(v, compose));
+  it('does not redundantly allow-list a var that is already referenced in compose', () => {
+    const redundant = Object.keys(allowlist).filter((v) => isReferencedInCompose(v, composeText));
     expect(
       redundant,
-      `These vars are BOTH mapped in compose and allow-listed — drop them from HOST_ONLY_ALLOWLIST:\n  ` +
+      `These vars are BOTH referenced in ${compose} and allow-listed — drop them from the allow-list:\n  ` +
         redundant.join('\n  '),
     ).toEqual([]);
   });

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -211,6 +211,19 @@ services:
       APNS_TEAM_ID: ${APNS_TEAM_ID:-}
       APNS_BUNDLE_ID: ${APNS_BUNDLE_ID:-}
       APNS_ENVIRONMENT: ${APNS_ENVIRONMENT:-}
+      # --- Additional API runtime settings (parity with deploy/.env.example) ---
+      # Documented in deploy/.env.example and read by the API but previously not
+      # threaded through this block, so setting them in .env was a silent no-op.
+      # `${VAR:-}` is non-regressive: empty is falsy to envFlag/envInt, which
+      # fall back to their in-code default. Enforced by
+      # apps/api/src/config/envComposeParity.test.ts.
+      IP_ALLOWLIST_ENFORCEMENT_MODE: ${IP_ALLOWLIST_ENFORCEMENT_MODE:-}
+      M365_GRAPH_READ_TOOLS_ENABLED: ${M365_GRAPH_READ_TOOLS_ENABLED:-}
+      M365_GRAPH_READ_TOOLS_ORG_IDS: ${M365_GRAPH_READ_TOOLS_ORG_IDS:-}
+      # Synthetic sign-up monitor endpoints (deploy/.env.example calls out that
+      # these MUST be mapped here for compose interpolation to reach the API).
+      SYNTHETIC_TEST_TOKEN: ${SYNTHETIC_TEST_TOKEN:-}
+      SYNTHETIC_TEST_IP_ALLOWLIST: ${SYNTHETIC_TEST_IP_ALLOWLIST:-}
     volumes:
       - api_data:/data
       - binaries:/data/binaries:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -230,6 +230,60 @@ services:
       OAUTH_JWKS_PRIVATE_JWK: ${OAUTH_JWKS_PRIVATE_JWK:-}
       OAUTH_JWKS_PUBLIC_JWK: ${OAUTH_JWKS_PUBLIC_JWK:-}
       OAUTH_CONSENT_URL_BASE: ${OAUTH_CONSENT_URL_BASE:-}
+      # --- Additional API runtime settings ---------------------------------
+      # These are documented in .env.example and read by the API, but were not
+      # previously threaded through Compose, so setting them in .env did nothing
+      # (the #570 / IS_HOSTED gap class). Every value uses `${VAR:-}`: an empty
+      # string is falsy to the API's envFlag/envInt helpers, which then fall
+      # back to their in-code default — so mapping them here is non-regressive
+      # (unset behaves exactly as before) and never drifts from the code default.
+      # Parity between .env.example and this block is enforced by
+      # apps/api/src/config/envComposeParity.test.ts.
+      # Auth / security / session
+      ENABLE_2FA: ${ENABLE_2FA:-}
+      BREEZE_PLATFORM_ADMINS: ${BREEZE_PLATFORM_ADMINS:-}
+      SESSION_SECRET: ${SESSION_SECRET:-}
+      IP_ALLOWLIST_ENFORCEMENT_MODE: ${IP_ALLOWLIST_ENFORCEMENT_MODE:-}
+      JWT_SIGNING_KEYRING: ${JWT_SIGNING_KEYRING:-}
+      JWT_ACTIVE_KID: ${JWT_ACTIVE_KID:-}
+      WS_TICKET_BIND_IP: ${WS_TICKET_BIND_IP:-}
+      ENROLLMENT_KEY_DEFAULT_TTL_MINUTES: ${ENROLLMENT_KEY_DEFAULT_TTL_MINUTES:-}
+      AUTOMATION_WEBHOOK_ALLOW_LEGACY_SECRET: ${AUTOMATION_WEBHOOK_ALLOW_LEGACY_SECRET:-}
+      # Email — SMTP extras + Mailgun provider
+      SMTP_FROM: ${SMTP_FROM:-}
+      SMTP_SECURE: ${SMTP_SECURE:-}
+      MAILGUN_API_KEY: ${MAILGUN_API_KEY:-}
+      MAILGUN_DOMAIN: ${MAILGUN_DOMAIN:-}
+      MAILGUN_FROM: ${MAILGUN_FROM:-}
+      MAILGUN_BASE_URL: ${MAILGUN_BASE_URL:-}
+      # SMS MFA + alert notifications (Twilio)
+      TWILIO_ACCOUNT_SID: ${TWILIO_ACCOUNT_SID:-}
+      TWILIO_AUTH_TOKEN: ${TWILIO_AUTH_TOKEN:-}
+      TWILIO_VERIFY_SERVICE_SID: ${TWILIO_VERIFY_SERVICE_SID:-}
+      TWILIO_MESSAGING_SERVICE_SID: ${TWILIO_MESSAGING_SERVICE_SID:-}
+      TWILIO_PHONE_NUMBER: ${TWILIO_PHONE_NUMBER:-}
+      # MCP OAuth Dynamic Client Registration
+      OAUTH_DCR_ENABLED: ${OAUTH_DCR_ENABLED:-}
+      OAUTH_DCR_REQUIRE_IAT: ${OAUTH_DCR_REQUIRE_IAT:-}
+      OAUTH_DCR_ALLOW_ANONYMOUS: ${OAUTH_DCR_ALLOW_ANONYMOUS:-}
+      # M365 ticket mailbox + C2C backup app + Graph-read AI tools
+      TICKET_MAILBOX_M365_CLIENT_ID: ${TICKET_MAILBOX_M365_CLIENT_ID:-}
+      TICKET_MAILBOX_M365_CLIENT_SECRET: ${TICKET_MAILBOX_M365_CLIENT_SECRET:-}
+      C2C_M365_CLIENT_ID: ${C2C_M365_CLIENT_ID:-}
+      C2C_M365_CLIENT_SECRET: ${C2C_M365_CLIENT_SECRET:-}
+      M365_GRAPH_READ_TOOLS_ENABLED: ${M365_GRAPH_READ_TOOLS_ENABLED:-}
+      M365_GRAPH_READ_TOOLS_ORG_IDS: ${M365_GRAPH_READ_TOOLS_ORG_IDS:-}
+      # Cloudflare mTLS (API Shield client certificates)
+      CLOUDFLARE_API_TOKEN: ${CLOUDFLARE_API_TOKEN:-}
+      CLOUDFLARE_ZONE_ID: ${CLOUDFLARE_ZONE_ID:-}
+      # Remote-session concurrency caps
+      MAX_ACTIVE_REMOTE_SESSIONS_PER_ORG: ${MAX_ACTIVE_REMOTE_SESSIONS_PER_ORG:-}
+      MAX_ACTIVE_REMOTE_SESSIONS_PER_USER: ${MAX_ACTIVE_REMOTE_SESSIONS_PER_USER:-}
+      # Metrics label controls
+      METRICS_INCLUDE_ORG_ID: ${METRICS_INCLUDE_ORG_ID:-}
+      METRICS_SCRAPE_IP_ALLOWLIST: ${METRICS_SCRAPE_IP_ALLOWLIST:-}
+      # Hosted billing redirect
+      BILLING_URL: ${BILLING_URL:-}
     volumes:
       - api_data:/data
       - binaries:/data/binaries:ro


### PR DESCRIPTION
## Why

The stock compose files don't `env_file: .env` — they **hand-thread** each variable into a service `environment:` block as `${VAR:-default}`. That's deliberate and correct (least-privilege per container, `:?required` fail-fast, baked defaults, derived values, file-backed secrets). But it has a sharp edge: **a documented var that nobody added to the block is silently inert** — setting it in `.env` does nothing.

Same gap class that previously bit `IS_HOSTED` (#570) and `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS`. It just cost a self-hoster hours: their `CORS_ALLOWED_ORIGINS`, `ENABLE_2FA`, and `BREEZE_PLATFORM_ADMINS` all no-op'd because the last two were never threaded through Compose (`No platform admins configured` in the logs despite `BREEZE_PLATFORM_ADMINS=…` set).

## What's in this PR

**1. Self-host compose (`docker-compose.yml`) — wire 36 API-read vars.** Auditing `.env.example` vs compose found 62 documented vars not threaded through; 36 are read by the API at runtime — entire feature families were unconfigurable: **all Twilio SMS-MFA vars**, **all Mailgun vars**, `SMTP_FROM`/`SMTP_SECURE`, `ENABLE_2FA`, `BREEZE_PLATFORM_ADMINS`, `IP_ALLOWLIST_ENFORCEMENT_MODE`, MCP OAuth DCR flags, JWT key-rotation, remote-session caps, M365 ticket-mailbox / C2C / graph-read, Cloudflare mTLS, `BILLING_URL`, and more.

**2. Droplet compose (`deploy/docker-compose.prod.yml`) — wire the 5 it was missing** vs `deploy/.env.example`: `IP_ALLOWLIST_ENFORCEMENT_MODE`, `M365_GRAPH_READ_TOOLS_ENABLED`/`ORG_IDS`, `SYNTHETIC_TEST_TOKEN`/`IP_ALLOWLIST` (the synthetic vars are explicitly documented as needing this mapping).

**3. Parity guard (`apps/api/src/config/envComposeParity.test.ts`).** Mirrors the existing `proxyTrustCompose.test.ts`. For **both** env-example↔compose pairs it asserts every documented var is either referenced in the compose or in a categorized allow-list with a reason. Runs in the **required `test-api` job**, so adding a documented var without wiring it now fails CI instead of silently in production. Also catches stale/redundant allow-list entries. `isReferencedInCompose` understands `${VAR}` interpolation, `VAR:` keys, and the `environment: VAR` secret-sourcing / `- VAR` short forms (so `REDIS_PASSWORD` is auto-detected).

**4. Remove 4 vestigial vars from `.env.example`** — verified dead repo-wide (0 non-test refs): `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX_REQUESTS`, `SESSION_MAX_AGE` (`SESSION_MAX_AGE_MS` is hardcoded), `ENABLE_API_DOCS` (the `/docs` route mounts unconditionally; only `ENABLE_API_DOCS_UI` is read — reworded that comment).

## Non-regressive by construction

Every wired var uses `${VAR:-}`. Empty is falsy to the API's `envFlag`/`envInt` helpers (`if (!raw) return default`), so an unset var falls back to its in-code default — and since all of these are currently *absent* yet the app runs, mapping them changes nothing when unset; it only *adds* the ability to set them, and never drifts from the code default.

## Verification

- Both pairs pass; **proven non-vacuous** (each fails when a mapping is removed, passes when restored).
- Full `config/` suite (incl. `proxyTrustCompose`): **233 tests green**.
- Both composes parse; 143 (root) / 104 (prod) `api` env keys, no duplicate keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)