### PR TITLE
fix(vulnerabilities): honor the org selector on fleet endpoints

### DIFF
--- a/apps/api/src/__tests__/integration/vulnerabilitiesRoutes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/vulnerabilitiesRoutes.integration.test.ts
@@ -17,7 +17,7 @@ import {
 import { vulnerabilityRoutes } from '../../routes/vulnerabilities';
 import { clearPermissionCache } from '../../services/permissions';
 import { getTestDb } from './setup';
-import { createSite, setupTestEnvironment, type TestEnvironment } from './db-utils';
+import { createOrganization, createSite, setupTestEnvironment, type TestEnvironment } from './db-utils';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
@@ -634,6 +634,83 @@ describe('vulnerabilityRoutes', () => {
     expect(closedRes.status).toBe(200);
     const closed = await closedRes.json() as { items: unknown[] };
     expect(closed.items).toEqual([]);
+  });
+
+  // Org-selector narrowing (?orgId=, auto-injected by the web client): a partner
+  // caller with two orgs gets only the selected org's rows. Every unit test
+  // mocks the query layer, so this is the only place the eq(org_id) narrowing
+  // is proven against real Postgres — review mutation showed deleting it kept
+  // the unit suite green.
+  runDb('fleet reads narrow to ?orgId= for a partner-scope caller (and 403 an inaccessible org)', async () => {
+    const env = await setupTestEnvironment({ scope: 'partner' });
+    const orgB = await createOrganization({ partnerId: env.partner.id });
+    const siteB = await createSite({ orgId: orgB.id });
+
+    const deviceA = await seedDevice(env, 'orgsel-a');
+    const [deviceB] = await getTestDb()
+      .insert(devices)
+      .values({
+        orgId: orgB.id,
+        siteId: siteB.id,
+        agentId: `vuln-route-agent-orgsel-b-${Date.now()}`,
+        hostname: 'vuln-route-host-orgsel-b',
+        osType: 'windows',
+        osVersion: '11',
+        architecture: 'x86_64',
+        agentVersion: '0.0.0-test',
+        status: 'offline',
+      })
+      .returning({ id: devices.id });
+    if (!deviceB) throw new Error('failed to seed org-B device');
+
+    // Org A: plain high. Org B: KEV critical — a narrowing failure inflates
+    // org A's counts with org B's scarier finding.
+    const vulnA = await seedCatalogVulnerability({ cveId: 'CVE-2026-94001', severity: 'high', cvssScore: '7.5' });
+    const vulnB = await seedCatalogVulnerability({
+      cveId: 'CVE-2026-94002',
+      severity: 'critical',
+      cvssScore: '9.9',
+      knownExploited: true,
+    });
+    await seedDeviceFinding({ orgId: env.organization.id, deviceId: deviceA, vulnerabilityId: vulnA, riskScore: '7.50' });
+    await seedDeviceFinding({ orgId: orgB.id, deviceId: deviceB.id, vulnerabilityId: vulnB, riskScore: '9.90' });
+
+    // Baseline (no orgId): the partner caller sees BOTH orgs' findings — proves
+    // the narrowed assertions below aren't passing because org B is invisible.
+    const allStats = await buildApp().request('/api/v1/vulnerabilities/stats', { headers: authHeaders(env) });
+    expect(allStats.status).toBe(200);
+    expect(((await allStats.json()) as { totalFindings: number }).totalFindings).toBe(2);
+
+    const q = `?orgId=${env.organization.id}`;
+
+    // GET / — aggregated CVE table narrows to org A.
+    const listRes = await buildApp().request(`/api/v1/vulnerabilities${q}`, { headers: authHeaders(env) });
+    expect(listRes.status).toBe(200);
+    const list = await listRes.json() as { items: Array<{ cveId: string }> };
+    expect(list.items.map((i) => i.cveId)).toEqual(['CVE-2026-94001']);
+
+    // GET /software — work queue narrows to org A's single device.
+    const swRes = await buildApp().request(`/api/v1/vulnerabilities/software${q}`, { headers: authHeaders(env) });
+    expect(swRes.status).toBe(200);
+    const sw = await swRes.json() as { items: Array<{ deviceCount: number; cveIds: string[] }> };
+    expect(sw.items.reduce((sum, g) => sum + g.deviceCount, 0)).toBe(1);
+    expect(sw.items.some((g) => g.cveIds.includes('CVE-2026-94002'))).toBe(false);
+
+    // GET /stats — stat cards narrow to org A (no KEV/critical bleed-through).
+    const statsRes = await buildApp().request(`/api/v1/vulnerabilities/stats${q}`, { headers: authHeaders(env) });
+    expect(statsRes.status).toBe(200);
+    const stats = await statsRes.json() as { totalFindings: number; criticalOpen: number; kevCveCount: number };
+    expect(stats.totalFindings).toBe(1);
+    expect(stats.criticalOpen).toBe(0);
+    expect(stats.kevCveCount).toBe(0);
+
+    // An org outside the partner's accessible set: hard 403, not silent-empty.
+    const foreign = await setupTestEnvironment({ scope: 'organization' });
+    const denied = await buildApp().request(
+      `/api/v1/vulnerabilities/stats?orgId=${foreign.organization.id}`,
+      { headers: authHeaders(env) },
+    );
+    expect(denied.status).toBe(403);
   });
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/apps/api/src/routes/vulnerabilities.test.ts
+++ b/apps/api/src/routes/vulnerabilities.test.ts
@@ -292,11 +292,16 @@ describe('GET /vulnerabilities — kevOnly/patchAvailable params', () => {
   });
 
   it('accepts an accessible orgId (org-selector narrowing) and 403s a denied one', async () => {
+    const where = vi.fn().mockResolvedValue([]);
     vi.mocked(db.select).mockReturnValue({
-      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+      from: vi.fn().mockReturnValue({ where }),
     } as never);
     const ok = await app().request(`/vulnerabilities?orgId=${ORG_OK}`);
     expect(ok.status).toBe(200);
+    // The orgId must reach the WHERE clause — a bare 200 stays green even with
+    // the eq(org_id) narrowing deleted (this route forwards via {...query}
+    // spread, so nothing else pins the wiring).
+    expect(JSON.stringify(where.mock.calls[0]?.[0])).toContain(ORG_OK);
     expect((await app().request(`/vulnerabilities?orgId=${ORG_DENIED}`)).status).toBe(403);
     expect((await app().request('/vulnerabilities?orgId=acme')).status).toBe(400);
   });
@@ -619,6 +624,39 @@ describe('GET /vulnerabilities/devices/:deviceId/software', () => {
   });
 });
 
+describe('GET /vulnerabilities/devices/:deviceId', () => {
+  beforeEach(() => {
+    granted.clear();
+    granted.add('devices:read');
+    delete permissionsState.allowedSiteIds;
+    vi.mocked(db.select).mockReset();
+  });
+
+  // This route spreads the validated query straight into listVulnerabilities
+  // ({...query, deviceId}), so it is the one place an orgId added to the shared
+  // listQuerySchema would silently narrow a per-device lookup. Pins that zod
+  // strips the auto-injected param before the spread — see the schema comment
+  // at orgIdQuerySchema.
+  it('strips the auto-injected ?orgId= before the {...query} spread', async () => {
+    const listWhere = vi.fn().mockResolvedValue([]);
+    vi.mocked(db.select)
+      // assertDeviceSiteAccess: device lookup (site accessible).
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ siteId: 'site-1' }]) }),
+        }),
+      } as never)
+      // listVulnerabilities: the findings query whose WHERE we inspect.
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: listWhere }),
+      } as never);
+    const res = await app().request(`/vulnerabilities/devices/${ID}?orgId=${ORG_OK}`);
+    expect(res.status).toBe(200);
+    expect(listWhere).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(listWhere.mock.calls[0]?.[0])).not.toContain(ORG_OK);
+  });
+});
+
 describe('GET /vulnerabilities/:cveId/devices (CVE drawer payload)', () => {
   beforeEach(() => {
     vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);
@@ -662,12 +700,29 @@ describe('GET /vulnerabilities/:cveId/devices (CVE drawer payload)', () => {
     expect(body.findings[0].deviceVulnerabilityId).toBe('dv-1');
   });
 
-  it('forwards orgId and 403s a denied org (before the catalog lookup)', async () => {
-    await app().request(`/vulnerabilities/CVE-2026-0001/devices?orgId=${ORG_OK}`);
-    // 404s on the null catalog record, but the org gate passed; the fleet query
-    // is only reached with a real record, so assert the denied path instead.
+  it('forwards orgId into the fleet query and 403s a denied org (before the catalog lookup)', async () => {
+    vi.mocked(fetchCveCatalogRecord).mockResolvedValueOnce({
+      cveId: 'CVE-2026-0001',
+      description: 'Bad bug',
+      references: [],
+      cvssVersion: '3.1',
+      cvssVector: 'CVSS:3.1/AV:N',
+      cvssScore: 9.1,
+      epssScore: 0.4,
+      knownExploited: true,
+      patchAvailable: true,
+      severity: 'critical',
+      publishedAt: '2026-01-01T00:00:00.000Z',
+      modifiedAt: null,
+    });
+    const ok = await app().request(`/vulnerabilities/CVE-2026-0001/devices?orgId=${ORG_OK}`);
+    expect(ok.status).toBe(200);
+    expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'all', orgId: ORG_OK }),
+    );
     const denied = await app().request(`/vulnerabilities/CVE-2026-0001/devices?orgId=${ORG_DENIED}`);
     expect(denied.status).toBe(403);
+    // The gate runs BEFORE the catalog lookup: only the allowed request reached it.
     expect(vi.mocked(fetchCveCatalogRecord)).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/routes/vulnerabilities.test.ts
+++ b/apps/api/src/routes/vulnerabilities.test.ts
@@ -19,7 +19,9 @@ vi.mock('../middleware/auth', () => ({
       user: { id: 'u1', email: 't@example.test' },
       orgCondition: () => undefined,
       canAccessSite: () => true,
-      canAccessOrg: (id: string) => id !== 'org-denied',
+      // Denies both the legacy 'org-denied' marker (bulk-route row orgIds) and
+      // the uuid-shaped DENIED_ORG used by the ?orgId= query-narrowing tests.
+      canAccessOrg: (id: string) => id !== 'org-denied' && id !== 'de000000-0000-4000-8000-00000000dead',
     });
     return next();
   },
@@ -136,6 +138,11 @@ function fleetRow(overrides: Partial<FleetFindingRow> = {}): FleetFindingRow {
 }
 
 const future = new Date(Date.now() + 7 * 864e5).toISOString();
+
+// Org-selector narrowing (?orgId= auto-injected by the web client): one org the
+// mocked auth can access, one it denies (must match the canAccessOrg mock above).
+const ORG_OK = '11111111-2222-3333-8444-555555555555';
+const ORG_DENIED = 'de000000-0000-4000-8000-00000000dead';
 
 beforeEach(() => {
   granted.clear();
@@ -282,6 +289,16 @@ describe('GET /vulnerabilities — kevOnly/patchAvailable params', () => {
     expect((await app().request('/vulnerabilities?expiringWithinDays=abc')).status).toBe(400);
     expect((await app().request('/vulnerabilities?expiringWithinDays=0')).status).toBe(400);
     expect((await app().request('/vulnerabilities?expiringWithinDays=366')).status).toBe(400);
+  });
+
+  it('accepts an accessible orgId (org-selector narrowing) and 403s a denied one', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+    } as never);
+    const ok = await app().request(`/vulnerabilities?orgId=${ORG_OK}`);
+    expect(ok.status).toBe(200);
+    expect((await app().request(`/vulnerabilities?orgId=${ORG_DENIED}`)).status).toBe(403);
+    expect((await app().request('/vulnerabilities?orgId=acme')).status).toBe(400);
   });
 });
 
@@ -474,6 +491,25 @@ describe('GET /vulnerabilities/software (fleet work queue)', () => {
     const res = await app().request('/vulnerabilities/software?expiringWithinDays=soon');
     expect(res.status).toBe(400);
   });
+
+  it('forwards orgId (web org selector) into the fleet query', async () => {
+    const res = await app().request(`/vulnerabilities/software?orgId=${ORG_OK}`);
+    expect(res.status).toBe(200);
+    expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: ORG_OK }),
+    );
+  });
+
+  it('403s an orgId outside the caller accessible set', async () => {
+    const res = await app().request(`/vulnerabilities/software?orgId=${ORG_DENIED}`);
+    expect(res.status).toBe(403);
+    expect(vi.mocked(fetchFleetFindingRows)).not.toHaveBeenCalled();
+  });
+
+  it('400s a non-uuid orgId', async () => {
+    const res = await app().request('/vulnerabilities/software?orgId=acme');
+    expect(res.status).toBe(400);
+  });
 });
 
 describe('GET /vulnerabilities/software/:groupKey (drawer payload)', () => {
@@ -506,6 +542,16 @@ describe('GET /vulnerabilities/software/:groupKey (drawer payload)', () => {
     expect(body.cves).toHaveLength(2);
     expect(body.findings).toHaveLength(2);
     expect(body.findings[0]).toMatchObject({ deviceVulnerabilityId: expect.any(String), deviceName: expect.any(String) });
+  });
+
+  it('forwards orgId and 403s a denied org', async () => {
+    const key = encodeURIComponent('sw:google chrome|google llc');
+    await app().request(`/vulnerabilities/software/${key}?orgId=${ORG_OK}`);
+    expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'all', orgId: ORG_OK }),
+    );
+    const denied = await app().request(`/vulnerabilities/software/${key}?orgId=${ORG_DENIED}`);
+    expect(denied.status).toBe(403);
   });
 });
 
@@ -558,6 +604,19 @@ describe('GET /vulnerabilities/devices/:deviceId/software', () => {
     const res = await app().request(`/vulnerabilities/devices/${ID}/software`);
     expect(res.status).toBe(404);
   });
+
+  it('ignores the auto-injected ?orgId= (a stale org selector must not blank a cross-org device tab)', async () => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ siteId: 'site-1' }]) }),
+      }),
+    } as never);
+    const res = await app().request(`/vulnerabilities/devices/${ID}/software?orgId=${ORG_OK}`);
+    expect(res.status).toBe(200);
+    expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith(
+      expect.not.objectContaining({ orgId: expect.anything() }),
+    );
+  });
 });
 
 describe('GET /vulnerabilities/:cveId/devices (CVE drawer payload)', () => {
@@ -601,6 +660,15 @@ describe('GET /vulnerabilities/:cveId/devices (CVE drawer payload)', () => {
     expect(body.cve.cveId).toBe('CVE-2026-0001');
     expect(body.findings).toHaveLength(1);
     expect(body.findings[0].deviceVulnerabilityId).toBe('dv-1');
+  });
+
+  it('forwards orgId and 403s a denied org (before the catalog lookup)', async () => {
+    await app().request(`/vulnerabilities/CVE-2026-0001/devices?orgId=${ORG_OK}`);
+    // 404s on the null catalog record, but the org gate passed; the fleet query
+    // is only reached with a real record, so assert the denied path instead.
+    const denied = await app().request(`/vulnerabilities/CVE-2026-0001/devices?orgId=${ORG_DENIED}`);
+    expect(denied.status).toBe(403);
+    expect(vi.mocked(fetchCveCatalogRecord)).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -799,6 +867,19 @@ describe('GET /vulnerabilities/stats', () => {
       totalFindings: 2,
       lastDetectedAt: '2026-06-01T00:00:00.000Z',
     });
+  });
+
+  it('forwards orgId so the stat cards scope to the selected org', async () => {
+    const res = await app().request(`/vulnerabilities/stats?orgId=${ORG_OK}`);
+    expect(res.status).toBe(200);
+    expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'all', orgId: ORG_OK }),
+    );
+  });
+
+  it('403s an orgId outside the caller accessible set', async () => {
+    const res = await app().request(`/vulnerabilities/stats?orgId=${ORG_DENIED}`);
+    expect(res.status).toBe(403);
   });
 });
 

--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -76,11 +76,15 @@ const listQuerySchema = z.object({
 });
 
 // Fleet org narrowing: the web client auto-injects ?orgId= for the currently
-// selected organization (fetchWithAuth), same as patches/devices. Absent = all
+// selected organization (fetchWithAuth; /vulnerabilities is org-or-all in
+// routeScope.ts — reclassifying it silently stops the injection). Absent = all
 // accessible orgs. Access is enforced per-request via auth.canAccessOrg (403);
 // the eq() filter then narrows within the already-RLS-scoped set. Deliberately
-// NOT on listQuerySchema itself: the per-device routes share that schema, and a
-// stale selected org must never blank out a cross-org device's findings tab.
+// NOT on listQuerySchema itself: /devices/:deviceId spreads its validated
+// query straight into listVulnerabilities ({...query}), so an orgId on the
+// shared schema would let a stale org selector blank out a cross-org device's
+// findings. The device routes scope via assertDeviceSiteAccess instead and
+// rely on zod stripping the unknown key (pinned by tests).
 const orgIdQuerySchema = z.string().uuid().optional();
 const fleetListQuerySchema = listQuerySchema.extend({ orgId: orgIdQuerySchema });
 const orgScopeQuerySchema = z.object({ orgId: orgIdQuerySchema });

--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -75,6 +75,16 @@ const listQuerySchema = z.object({
   expiringWithinDays: expiringWithinDaysSchema.optional(),
 });
 
+// Fleet org narrowing: the web client auto-injects ?orgId= for the currently
+// selected organization (fetchWithAuth), same as patches/devices. Absent = all
+// accessible orgs. Access is enforced per-request via auth.canAccessOrg (403);
+// the eq() filter then narrows within the already-RLS-scoped set. Deliberately
+// NOT on listQuerySchema itself: the per-device routes share that schema, and a
+// stale selected org must never blank out a cross-org device's findings tab.
+const orgIdQuerySchema = z.string().uuid().optional();
+const fleetListQuerySchema = listQuerySchema.extend({ orgId: orgIdQuerySchema });
+const orgScopeQuerySchema = z.object({ orgId: orgIdQuerySchema });
+
 const deviceParamSchema = z.object({
   deviceId: z.string().uuid(),
 });
@@ -127,6 +137,7 @@ const softwareQuerySchema = z.object({
   kevOnly: boolQuerySchema.optional(),
   patchAvailable: boolQuerySchema.optional(),
   expiringWithinDays: expiringWithinDaysSchema.optional(),
+  orgId: orgIdQuerySchema,
 });
 
 const SOFTWARE_GROUP_CAP = 500;
@@ -422,12 +433,17 @@ async function listVulnerabilities(filters: {
   /** Site-axis narrowing: when set, only return findings for devices in these sites.
    *  Empty array = caller has no in-scope sites → return nothing (fail-closed). */
   allowedSiteIds?: string[];
+  /** Org narrowing (web org selector); access pre-checked via auth.canAccessOrg. */
+  orgId?: string;
 }) {
   const conditions: SQL[] = [];
   // 'all' means no status filter — return every status. Any other value is
   // treated as a specific status to match (open | patched | mitigated | accepted).
   if (filters.status !== 'all') {
     conditions.push(eq(deviceVulnerabilities.status, filters.status));
+  }
+  if (filters.orgId) {
+    conditions.push(eq(deviceVulnerabilities.orgId, filters.orgId));
   }
   if (filters.deviceId) {
     conditions.push(eq(deviceVulnerabilities.deviceId, filters.deviceId));
@@ -576,8 +592,12 @@ vulnerabilityRoutes.use('*', authMiddleware);
 vulnerabilityRoutes.use('*', requireScope('organization', 'partner', 'system'));
 vulnerabilityRoutes.use('*', requireVulnerabilityRead);
 
-vulnerabilityRoutes.get('/', zValidator('query', listQuerySchema), async (c) => {
+vulnerabilityRoutes.get('/', zValidator('query', fleetListQuerySchema), async (c) => {
+  const auth = c.get('auth');
   const query = c.req.valid('query');
+  if (query.orgId && !auth.canAccessOrg(query.orgId)) {
+    return c.json({ error: 'Access to this organization denied' }, 403);
+  }
   // Site-axis narrowing for the fleet view: per-device routes already gate via
   // assertDeviceSiteAccess; this fleet (all-devices) query must also restrict to
   // the caller's allowed sites. Mirrors the site-filter pattern in core.ts.
@@ -597,11 +617,16 @@ vulnerabilityRoutes.get('/', zValidator('query', listQuerySchema), async (c) => 
 // pseudo-group). Group cardinality is fleet-bounded; hard cap + hasMore
 // instead of pagination.
 vulnerabilityRoutes.get('/software', zValidator('query', softwareQuerySchema), async (c) => {
+  const auth = c.get('auth');
   const query = c.req.valid('query');
+  if (query.orgId && !auth.canAccessOrg(query.orgId)) {
+    return c.json({ error: 'Access to this organization denied' }, 403);
+  }
   const perms = c.get('permissions') as UserPermissions | undefined;
   const rows = await fetchFleetFindingRows({
     status: query.status,
     allowedSiteIds: perms?.allowedSiteIds,
+    orgId: query.orgId,
   });
   const filtered = filterFindings(rows, {
     status: query.status,
@@ -618,12 +643,17 @@ vulnerabilityRoutes.get('/software', zValidator('query', softwareQuerySchema), a
 });
 
 // Software-group drawer payload: group summary + per-CVE rollup + raw findings.
-vulnerabilityRoutes.get('/software/:groupKey', zValidator('param', groupKeyParamSchema), async (c) => {
+vulnerabilityRoutes.get('/software/:groupKey', zValidator('param', groupKeyParamSchema), zValidator('query', orgScopeQuerySchema), async (c) => {
+  const auth = c.get('auth');
   const { groupKey } = c.req.valid('param');
+  const { orgId } = c.req.valid('query');
+  if (orgId && !auth.canAccessOrg(orgId)) {
+    return c.json({ error: 'Access to this organization denied' }, 403);
+  }
   const perms = c.get('permissions') as UserPermissions | undefined;
   // status 'all' so the drawer can show accepted/mitigated findings alongside
   // open ones (reopen lives in the drawers).
-  const rows = await fetchFleetFindingRows({ status: 'all', allowedSiteIds: perms?.allowedSiteIds });
+  const rows = await fetchFleetFindingRows({ status: 'all', allowedSiteIds: perms?.allowedSiteIds, orgId });
   const detail = buildGroupDetail(groupKey, rows);
   if (!detail) {
     return c.json({ error: 'Group not found' }, 404);
@@ -635,11 +665,17 @@ vulnerabilityRoutes.get('/software/:groupKey', zValidator('param', groupKeyParam
 // feed three cards, accepted findings feed the expiring-soon card. Also carries
 // totalFindings/lastDetectedAt (computed from the same rows — no extra query)
 // so the empty states can tell a clean fleet from one that never produced data.
-vulnerabilityRoutes.get('/stats', async (c) => {
+vulnerabilityRoutes.get('/stats', zValidator('query', orgScopeQuerySchema), async (c) => {
+  const auth = c.get('auth');
+  const { orgId } = c.req.valid('query');
+  if (orgId && !auth.canAccessOrg(orgId)) {
+    return c.json({ error: 'Access to this organization denied' }, 403);
+  }
   const perms = c.get('permissions') as UserPermissions | undefined;
   const rows = await fetchFleetFindingRows({
     status: 'all',
     allowedSiteIds: perms?.allowedSiteIds,
+    orgId,
   });
   return c.json(computeStats(rows, new Date()));
 });
@@ -699,14 +735,19 @@ vulnerabilityRoutes.get(
 // otherwise shadow every static-first-segment GET route above it
 // (/software, /software/:groupKey, /stats, /devices/:deviceId,
 // /devices/:deviceId/software).
-vulnerabilityRoutes.get('/:cveId/devices', zValidator('param', cveIdParamSchema), async (c) => {
+vulnerabilityRoutes.get('/:cveId/devices', zValidator('param', cveIdParamSchema), zValidator('query', orgScopeQuerySchema), async (c) => {
+  const auth = c.get('auth');
   const { cveId } = c.req.valid('param');
+  const { orgId } = c.req.valid('query');
+  if (orgId && !auth.canAccessOrg(orgId)) {
+    return c.json({ error: 'Access to this organization denied' }, 403);
+  }
   const cve = await fetchCveCatalogRecord(cveId);
   if (!cve) {
     return c.json({ error: 'CVE not found' }, 404);
   }
   const perms = c.get('permissions') as UserPermissions | undefined;
-  const rows = await fetchFleetFindingRows({ status: 'all', allowedSiteIds: perms?.allowedSiteIds });
+  const rows = await fetchFleetFindingRows({ status: 'all', allowedSiteIds: perms?.allowedSiteIds, orgId });
   const target = cveId.toLowerCase();
   const findings = rows
     .filter((r) => r.cveId.toLowerCase() === target)

--- a/apps/api/src/services/vulnerabilityFleetQueries.ts
+++ b/apps/api/src/services/vulnerabilityFleetQueries.ts
@@ -28,10 +28,17 @@ export async function fetchFleetFindingRows(filters: {
   allowedSiteIds?: string[];
   /** When set, narrow to a single device (device tab). */
   deviceId?: string;
+  /** When set, narrow to a single org (the web org selector). Access must be
+   *  checked by the route (auth.canAccessOrg) before calling; this only narrows
+   *  within the RLS-scoped set. */
+  orgId?: string;
 }): Promise<FleetFindingRow[]> {
   const conditions: SQL[] = [];
   if (filters.status !== 'all') {
     conditions.push(eq(deviceVulnerabilities.status, filters.status));
+  }
+  if (filters.orgId) {
+    conditions.push(eq(deviceVulnerabilities.orgId, filters.orgId));
   }
   if (filters.deviceId) {
     conditions.push(eq(deviceVulnerabilities.deviceId, filters.deviceId));


### PR DESCRIPTION
## Summary

The Vulnerabilities page ignored the organization selector: the web client auto-injects `?orgId=<selected org>` on every request via `fetchWithAuth` (the same mechanism patches and other pages rely on), but the vulnerability fleet endpoints never read the param, so the page always showed all accessible orgs.

- `fetchFleetFindingRows` and `listVulnerabilities` accept an optional `orgId` and add an `eq(device_vulnerabilities.org_id)` condition, narrowing within the already-RLS-scoped set
- The five fleet reads honor `?orgId=`: `GET /vulnerabilities`, `/software`, `/stats` (stat cards), and the two drawer payloads `/software/:groupKey` and `/:cveId/devices`
- The param is uuid-validated (400 otherwise) and gated by `auth.canAccessOrg` (403 for an org outside the caller's accessible set), mirroring the established fleet-narrowing pattern (`patches`, `userRisk`, `peripheralControl`)
- The per-device routes (`/devices/:deviceId`, `/devices/:deviceId/software`) deliberately keep ignoring the injected param — a stale org selector must not blank the findings tab of a device in a different org

No web changes needed: org switching does a full page reload, so honoring the injected param server-side fixes the whole page (stat cards, both tables, both drawers).

## Testing

- 9 route tests covering the new behavior: orgId forwarded into the query layer per endpoint, 403 on a denied org, 400 on a non-uuid, and regression tests that both per-device routes strip `?orgId=` — 58/58 pass
- 1 integration test against real Postgres + RLS: a partner-scope caller with two orgs gets only the selected org's rows on `/`, `/software`, and `/stats`, and 403s on a foreign org — 14/14 pass
- Review ran mutation testing: deleting the `eq(org_id)` narrowing at any of its three sites now reds the suite (it originally survived all three — the follow-up commit hardens exactly those tests)
- API typecheck passes (CI-equivalent invocation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)