### PR TITLE
fix(db): restore shipped migration bytes edited by the docs reorg (release blocker)

### DIFF
--- a/apps/api/migrations/2026-04-29-a-cleanup-mcp-bootstrap.sql
+++ b/apps/api/migrations/2026-04-29-a-cleanup-mcp-bootstrap.sql
@@ -1,5 +1,5 @@
 -- Cleanup of unused tables/columns from the deleted mcpBootstrap module.
--- See docs/superpowers/plans/onboarding-signup/2026-04-29-mcp-bootstrap-cleanup.md for context.
+-- See docs/superpowers/plans/2026-04-29-mcp-bootstrap-cleanup.md for context.
 --
 -- Idempotent (per CLAUDE.md migration rules). Safe to apply multiple times.
 

--- a/apps/api/migrations/2026-06-09-a-native-ticketing-core.sql
+++ b/apps/api/migrations/2026-06-09-a-native-ticketing-core.sql
@@ -1,5 +1,5 @@
 -- Native ticketing Phase 1 (core).
--- Spec: docs/superpowers/specs/ticketing/2026-06-09-native-ticketing-design.md
+-- Spec: docs/superpowers/specs/2026-06-09-native-ticketing-design.md
 -- Extends tickets/ticket_comments, adds ticket_categories (partner-axis),
 -- ticket_alert_links (org-axis), partner_ticket_sequences (partner-axis),
 -- seeds tickets permissions, adds 'ticket' notification type.

--- a/apps/api/migrations/2026-06-11-g-audit-chain-table.sql
+++ b/apps/api/migrations/2026-06-11-g-audit-chain-table.sql
@@ -5,7 +5,7 @@
 -- the BEFORE INSERT trigger — deadlocks against the codebase's two-connection
 -- audit-write pattern (caller-tx insert + logSessionAudit on a separate pooled
 -- connection; see draft PR #1240 and
--- docs/superpowers/specs/security-auth/2026-06-11-audit-chain-deferred-sealing-design.md).
+-- docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md).
 --
 -- Linkage moves into this append-only side table, written by a DEFERRED
 -- commit-time trigger (the -h- migration). chain_seq (bigserial) is the chain

--- a/apps/api/migrations/2026-06-11-h-audit-chain-seal-and-verify.sql
+++ b/apps/api/migrations/2026-06-11-h-audit-chain-seal-and-verify.sql
@@ -7,7 +7,7 @@
 --    lock; the DEFERRED constraint trigger calls it at COMMIT, so the lock is
 --    held only through commit processing — never across application awaits.
 --    (The held-to-commit variant deadlocks; see draft PR #1240 and the design
---    spec docs/superpowers/specs/security-auth/2026-06-11-audit-chain-deferred-sealing-design.md.)
+--    spec docs/superpowers/specs/2026-06-11-audit-chain-deferred-sealing-design.md.)
 -- 3. Backfill seals every existing audit row per org in (timestamp, id) order,
 --    ignoring the legacy (possibly forked) prev_checksum values entirely.
 -- 4. audit_log_verify_chain keeps its signature but walks the side table.

--- a/apps/api/migrations/2026-06-11-j-device-pending-reboot.sql
+++ b/apps/api/migrations/2026-06-11-j-device-pending-reboot.sql
@@ -2,7 +2,7 @@
 -- heartbeat (Windows registry checks; Linux reboot-required markers /
 -- needs-restarting). Self-clears on the first post-reboot heartbeat.
 -- Backs the system.rebootRequired device filter and the "Reboot pending"
--- UI badge. Spec: docs/superpowers/specs/vuln-patch/2026-06-11-pending-reboot-indicator-design.md
+-- UI badge. Spec: docs/superpowers/specs/2026-06-11-pending-reboot-indicator-design.md
 ALTER TABLE devices ADD COLUMN IF NOT EXISTS pending_reboot boolean NOT NULL DEFAULT false;
 
 -- Partial index: the fleet-wide system.rebootRequired filter only ever looks

--- a/apps/api/migrations/2026-06-12-a-ticketing-time-parts.sql
+++ b/apps/api/migrations/2026-06-12-a-ticketing-time-parts.sql
@@ -1,5 +1,5 @@
 -- Phase 3 (native ticketing): time_entries + ticket_parts
--- Spec: docs/superpowers/specs/ticketing/2026-06-11-ticketing-phase3-time-tracking-parts-design.md
+-- Spec: docs/superpowers/specs/2026-06-11-ticketing-phase3-time-tracking-parts-design.md
 
 DO $$ BEGIN
   CREATE TYPE billing_status AS ENUM ('not_billed','billed','no_charge','contract');

--- a/apps/api/migrations/2026-06-12-b-client-ai-foundation.sql
+++ b/apps/api/migrations/2026-06-12-b-client-ai-foundation.sql
@@ -1,6 +1,6 @@
 -- 2026-06-12-b-client-ai-foundation.sql
 -- Breeze AI for Office, Plan 1 (Foundation).
--- Spec: docs/superpowers/specs/ai-mcp/2026-06-12-breeze-ai-for-office-design.md §3, §7, §8, §10, §12.
+-- Spec: docs/superpowers/specs/2026-06-12-breeze-ai-for-office-design.md §3, §7, §8, §10, §12.
 --
 -- 1. portal_users: Entra identity columns + partial unique identity index.
 -- 2. client_ai_tenant_mappings  — Entra tenant GUID -> org (RLS shape 1).

--- a/apps/api/migrations/2026-06-13-a-ticketing-configuration.sql
+++ b/apps/api/migrations/2026-06-13-a-ticketing-configuration.sql
@@ -1,5 +1,5 @@
 -- Ticketing configuration: custom statuses, priority SLA settings, org overrides.
--- Spec: docs/superpowers/specs/ticketing/2026-06-12-ticketing-configuration-design.md
+-- Spec: docs/superpowers/specs/2026-06-12-ticketing-configuration-design.md
 
 CREATE TABLE IF NOT EXISTS ticket_statuses (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/apps/api/migrations/2026-06-13-d-ticketing-email-inbound.sql
+++ b/apps/api/migrations/2026-06-13-d-ticketing-email-inbound.sql
@@ -1,5 +1,5 @@
 -- Phase 4 (native ticketing): email-to-ticket ingest tables
--- Spec: docs/superpowers/specs/ticketing/2026-06-13-ticketing-phase4-email-to-ticket-design.md
+-- Spec: docs/superpowers/specs/2026-06-13-ticketing-phase4-email-to-ticket-design.md
 
 CREATE TABLE IF NOT EXISTS ticket_email_inbound (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/apps/api/migrations/2026-06-20-a-customer-email-domains.sql
+++ b/apps/api/migrations/2026-06-20-a-customer-email-domains.sql
@@ -1,5 +1,5 @@
 -- Phase 5 (native ticketing): sender-domain -> customer-org routing for email-to-ticket
--- Spec: docs/superpowers/specs/ticketing/2026-06-20-ticketing-phase5-email-customer-routing-design.md
+-- Spec: docs/superpowers/specs/2026-06-20-ticketing-phase5-email-customer-routing-design.md
 
 CREATE TABLE IF NOT EXISTS customer_email_domains (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/apps/api/migrations/2026-07-04-device-vulnerabilities-ticket-link.sql
+++ b/apps/api/migrations/2026-07-04-device-vulnerabilities-ticket-link.sql
@@ -1,5 +1,5 @@
 -- Vulnerabilities fleet triage UI: link findings to native tickets.
--- Spec: docs/superpowers/specs/vuln-patch/2026-07-04-vulnerabilities-triage-ui-design.md
+-- Spec: docs/superpowers/specs/2026-07-04-vulnerabilities-triage-ui-design.md
 -- Idempotent; no inner BEGIN/COMMIT (autoMigrate wraps each file in a transaction).
 
 ALTER TABLE device_vulnerabilities ADD COLUMN IF NOT EXISTS ticket_id uuid;

--- a/apps/api/migrations/2026-07-05-partner-inbound-local-part.sql
+++ b/apps/api/migrations/2026-07-05-partner-inbound-local-part.sql
@@ -1,4 +1,4 @@
 -- Decouple the partner inbound ticket address from partners.slug.
 -- NULL means "use slug" (resolver/outbound fall back). See
--- docs/superpowers/specs/ticketing/2026-06-29-inbound-alias-design.md.
+-- docs/superpowers/specs/2026-06-29-inbound-alias-design.md.
 ALTER TABLE partners ADD COLUMN IF NOT EXISTS inbound_local_part varchar(63);

--- a/apps/api/migrations/2026-07-06-quote-deposits.sql
+++ b/apps/api/migrations/2026-07-06-quote-deposits.sql
@@ -1,4 +1,4 @@
--- Quote deposits (spec: docs/superpowers/specs/billing/2026-07-05-quote-deposits-design.md).
+-- Quote deposits (spec: docs/superpowers/specs/2026-07-05-quote-deposits-design.md).
 -- Columns only — no new tables, RLS untouched.
 
 DO $$ BEGIN

--- a/apps/api/migrations/2026-07-10-ticket-forms.sql
+++ b/apps/api/migrations/2026-07-10-ticket-forms.sql
@@ -1,4 +1,4 @@
--- Ticket intake forms (spec: docs/superpowers/specs/ticketing/2026-07-10-ticket-intake-forms-design.md).
+-- Ticket intake forms (spec: docs/superpowers/specs/2026-07-10-ticket-intake-forms-design.md).
 -- Dual-axis config table (Partner-Wide First, epic #2135): org_id XOR partner_id.
 -- Idempotent: CREATE IF NOT EXISTS, guarded CHECK, DROP POLICY IF EXISTS then CREATE.
 -- No inner BEGIN/COMMIT (autoMigrate wraps each file in a transaction).

--- a/apps/api/migrations/2026-07-11-ticket-form-org-links.sql
+++ b/apps/api/migrations/2026-07-11-ticket-form-org-links.sql
@@ -1,5 +1,5 @@
 -- Org allowlist for partner-wide ticket_forms (spec §5, epic #2135 follow-on;
--- plan: docs/superpowers/plans/ticketing/2026-07-11-ticket-intake-forms-phase2.md).
+-- plan: docs/superpowers/plans/2026-07-11-ticket-intake-forms-phase2.md).
 --
 -- Semantics: no link rows for a form = visible to every org under the owning
 -- partner; rows present = allowlist (only the linked orgs see the form).

--- a/apps/api/migrations/2026-07-13-backup-profiles.sql
+++ b/apps/api/migrations/2026-07-13-backup-profiles.sql
@@ -1,4 +1,4 @@
--- Backup profiles (docs/superpowers/specs/backup/2026-07-13-backup-profiles-design.md).
+-- Backup profiles (docs/superpowers/specs/2026-07-13-backup-profiles-design.md).
 --
 -- A backup profile is a Cove-style selection entity answering "what to
 -- protect" for a device class (Files / System State / SQL / Hyper-V, each

--- a/apps/api/migrations/2026-07-16-contract-documents.sql
+++ b/apps/api/migrations/2026-07-16-contract-documents.sql
@@ -1,5 +1,5 @@
 -- Contract template library + executed contract documents (spec:
--- docs/superpowers/specs/billing/2026-07-16-contract-documents-and-enhanced-proposals-design.md).
+-- docs/superpowers/specs/2026-07-16-contract-documents-and-enhanced-proposals-design.md).
 --
 -- contract_templates / contract_template_versions are PARTNER-WIDE-FIRST config
 -- tables (epic #2135 shape): org_id XOR partner_id, one dual-axis RLS policy,

--- a/apps/api/migrations/2026-07-18-action-intents.sql
+++ b/apps/api/migrations/2026-07-18-action-intents.sql
@@ -1,5 +1,5 @@
 -- 2026-07-18: Action intents & durable approval layer — schema foundation
--- (spec docs/superpowers/specs/ai-mcp/2026-07-18-action-intents-approval-layer-design.md).
+-- (spec docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md).
 --
 -- action_intents: org-scoped (Shape 1, direct org_id), durable record of a
 -- Tier-3 tool call awaiting/undergoing human approval. Identity/attribution

--- a/apps/api/migrations/2026-07-18-c-ai-executions-intent-id.sql
+++ b/apps/api/migrations/2026-07-18-c-ai-executions-intent-id.sql
@@ -1,6 +1,6 @@
 -- 2026-07-18-c: link ai_tool_executions rows to the durable action_intents
 -- row they were created for (spec
--- docs/superpowers/specs/ai-mcp/2026-07-18-action-intents-approval-layer-design.md,
+-- docs/superpowers/specs/2026-07-18-action-intents-approval-layer-design.md,
 -- whole-branch review CRITICAL-3).
 --
 -- The web chat's per-step approval card (POST


### PR DESCRIPTION
## ⚠️ This blocks the next release. Do not tag `main` until this lands.

## What happened

#2708 (docs reorg) updated a doc-path reference inside an **SQL comment** in 19 migrations that had **already been applied in production**:

```diff
--- a/apps/api/migrations/2026-07-13-backup-profiles.sql
+++ b/apps/api/migrations/2026-07-13-backup-profiles.sql
-- - Backup profiles (docs/superpowers/specs/2026-07-13-backup-profiles-design.md).
+-- Backup profiles (docs/superpowers/specs/backup/2026-07-13-backup-profiles-design.md).
```

Semantically inert. But `autoMigrate` checksums file **content** (SHA-256), so all 19 recorded checksums changed, and step 6 throws:

> `Migration checksum mismatch for <file>. The file changed after being applied. Add a new migration instead.`

`autoMigrate` runs on **API boot**. Tagging a release off current `main` would mean the API **refuses to start** on every database that already applied these migrations — EU prod, US prod, and every self-hoster upgrading from ≤0.98.1.

**Why CI didn't catch it:** CI migrates a *fresh* database, which has no recorded checksums to mismatch. The guard only fires against a DB with history. Green CI is not evidence here.

## The fix

Restores the exact v0.98.1 bytes for all 19 files. Verified 19/19 SHA-256 match the values prod recorded.

Chosen over adding 19 `CHECKSUM_HEALS` entries: heals are permanent carry-forward code that every self-hoster inherits, and they exist for *forward-fixes with real semantic value*. Preserving a comment edit does not qualify.

## Not touched

The two genuinely-new migrations in this range still ship — reverting the whole directory would have dropped them, including a security fix:

- `2026-07-20-network-known-guests-partner-rls.sql` (partner-axis RLS isolation)
- `2026-07-20-portal-quote-recipients.sql` (#2679 security-review remediation)

## Follow-up worth considering

The class of bug is "a docs/tooling change edits a shipped migration and nothing catches it until prod boot." A CI check asserting that no file under `apps/api/migrations/` present in the previous release tag has changed content would catch this at PR time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)