### PR TITLE
fix(api): cap agent event-log message length server-side (#2642)

### DIFF
--- a/apps/api/src/routes/agents/schemas.test.ts
+++ b/apps/api/src/routes/agents/schemas.test.ts
@@ -6,7 +6,19 @@ import {
   agentWarrantyInfoSchema,
   enrollSchema,
   heartbeatSchema,
+  submitEventLogsSchema,
 } from './schemas';
+
+// Build a minimal valid event-log entry the schema accepts.
+function makeEvent(message: string) {
+  return {
+    timestamp: '2026-05-19T01:00:00.000Z',
+    level: 'info' as const,
+    category: 'system' as const,
+    source: 'test',
+    message,
+  };
+}
 
 // Build a minimal valid change item the schema accepts.
 function makeChange(suffix: number) {
@@ -178,5 +190,38 @@ describe('virtualization attribute — heartbeatSchema (tolerant)', () => {
     if (parsed.success) {
       expect(parsed.data.isVirtual).toBeUndefined();
     }
+  });
+});
+
+describe('submitEventLogsSchema — server-side message length cap (#2642)', () => {
+  const MAX = 2000;
+
+  it('accepts a message at the 2000-char cap', () => {
+    const parsed = submitEventLogsSchema.safeParse({
+      events: [makeEvent('a'.repeat(MAX))],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects a message one char over the cap — an unbounded agent message can no longer reach device_event_logs', () => {
+    const parsed = submitEventLogsSchema.safeParse({
+      events: [makeEvent('a'.repeat(MAX + 1))],
+    });
+    // Mutation guard: this reds if the `.max()` is dropped from `message`.
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects the whole batch when any single event message is oversized', () => {
+    const parsed = submitEventLogsSchema.safeParse({
+      events: [makeEvent('ok'), makeEvent('a'.repeat(MAX + 1)), makeEvent('ok')],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('still enforces the pre-existing min(1) — an empty message is rejected', () => {
+    const parsed = submitEventLogsSchema.safeParse({
+      events: [makeEvent('')],
+    });
+    expect(parsed.success).toBe(false);
   });
 });

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -662,7 +662,15 @@ export const submitEventLogsSchema = z.object({
     category: z.enum(['security', 'hardware', 'application', 'system']),
     source: z.string().min(1),
     eventId: z.string().optional(),
-    message: z.string().min(1),
+    // The agent truncates every event message to 500 chars on all collector
+    // paths (eventlogs_{windows,darwin,linux}.go), but that cap is agent-side
+    // only — a compromised or older agent could POST arbitrarily large messages
+    // into device_event_logs, which carries a GIN trigram index (search) that
+    // bloats super-linearly in value size. Re-bound it server-side. 2000 (4x the
+    // agent truncation) leaves headroom for the one un-truncated darwin path
+    // (crash-report synthesized messages, eventlogs_darwin.go) and future
+    // collectors while still hard-bounding the abuse vector. (#2642)
+    message: z.string().min(1).max(2000),
     details: z.record(z.string(), z.any()).optional().refine(
       (val) => !val || JSON.stringify(val).length <= 65536,
       { message: 'Object too large (max 64KB)' }


### PR DESCRIPTION
Fixes #2642.

## Problem
`submitEventLogsSchema` validated the event-log `message` field as `z.string().min(1)` with no upper bound. The 500-char limit is agent-side only (`truncateString(..., 500)` in `agent/internal/collectors/eventlogs_{windows,darwin,linux}.go`), so a compromised or older agent could POST arbitrarily large `message` values — up to 5000 events per request — into `device_event_logs`. That column carries a GIN trigram index (log search), so oversized values amplify into index bloat, not just row storage. Every other large field on this ingest path (`details` at 64KB, the array at 5000) is already bounded server-side; `message` was the gap.

## Fix
Add a server-side `.max(2000)` to `message`.

Bound rationale (why 2000, not exactly 500): all platform collectors truncate to 500, **except** the darwin crash-report synthesis path (`eventlogs_darwin.go`, `fmt.Sprintf("%s: %s (%s)", ...)`) which is not run through `truncateString`. Since Zod rejects the *entire* batch if one event's message fails, an exact-500 cap risks dropping a legitimate batch on that path. 2000 (4× the agent truncation) leaves headroom for that path and future collectors while still hard-bounding the abuse/index-bloat vector. Matches the reject-oversized posture the sibling `details` refine already uses.

## Tests
Added to `schemas.test.ts` — mutation-checked (dropping the `.max()` reds the two over-cap cases): at-cap passes, one-over rejects, a batch with one oversized message rejects, and the pre-existing `min(1)` still rejects empty.

Local gate green: `tsc --noEmit` 0 errors, `vitest schemas.test.ts` 26/26, eslint clean. No Go/deps touched.