### PR TITLE
fix(web): scroll Disk Cleanup preview into view + log dropped fs snapshots

### DIFF
--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -1549,6 +1549,11 @@ export async function handleFilesystemAnalysisCommandResult(
 
   const parsed = parseFilesystemAnalysisStdout(resultData.stdout ?? '');
   if (Object.keys(parsed).length === 0) {
+    // A completed scan whose stdout is empty or non-JSON produces no snapshot,
+    // which surfaces to the user as an empty Disk Cleanup tab with no error.
+    console.warn(
+      `[agents/helpers] filesystem_analysis command ${command.id} (device ${command.deviceId}) completed with unparseable/empty stdout (len=${resultData.stdout?.length ?? 0}); no snapshot written`
+    );
     return;
   }
 
@@ -1558,6 +1563,9 @@ export async function handleFilesystemAnalysisCommandResult(
     .where(eq(devices.id, command.deviceId))
     .limit(1);
   if (!device) {
+    console.warn(
+      `[agents/helpers] filesystem_analysis command ${command.id}: device ${command.deviceId} not found; no snapshot written`
+    );
     return;
   }
 

--- a/apps/web/src/components/devices/DeviceFilesystemTab.tsx
+++ b/apps/web/src/components/devices/DeviceFilesystemTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   HardDrive,
   RefreshCw,
@@ -277,6 +277,10 @@ export default function DeviceFilesystemTab({
   const [snapshot, setSnapshot] = useState<FilesystemSnapshot | null>(null);
   const [cleanupPreview, setCleanupPreview] =
     useState<FilesystemCleanupPreview | null>(null);
+  // The cleanup-preview result renders at the bottom of a long page. Without
+  // this, clicking "Cleanup Preview" succeeds silently below the fold and reads
+  // as "nothing happened". Scroll the freshly-rendered panel into view.
+  const cleanupPreviewRef = useRef<HTMLDivElement | null>(null);
   const [thresholdEvents, setThresholdEvents] = useState<ThresholdEvent[]>([]);
   const [scanCommand, setScanCommand] = useState<{
     id: string;
@@ -485,6 +489,17 @@ export default function DeviceFilesystemTab({
       setActionLoading(null);
     }
   }, [deviceId]);
+
+  // Bring the preview panel into view once it renders. Optional-chain the
+  // method so jsdom (no scrollIntoView impl) doesn't throw in tests.
+  useEffect(() => {
+    if (cleanupPreview) {
+      cleanupPreviewRef.current?.scrollIntoView?.({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+  }, [cleanupPreview]);
 
   const summary = snapshot?.summary ?? {};
   const cleanupCandidateCount = snapshot?.cleanupCandidates?.length ?? 0;
@@ -844,7 +859,10 @@ export default function DeviceFilesystemTab({
       </div>
 
       {cleanupPreview && (
-        <div className="rounded-lg border bg-card p-6 shadow-xs">
+        <div
+          ref={cleanupPreviewRef}
+          className="rounded-lg border bg-card p-6 shadow-xs scroll-mt-4"
+        >
           <div className="flex items-center gap-2">
             <Clock className="h-4 w-4 text-muted-foreground" />
             <h4 className="font-semibold">


### PR DESCRIPTION
## Summary

The **Disk Cleanup Intelligence (BE-1)** tab's "Cleanup Preview" button appeared broken in prod — clicking it did *nothing*. Investigation (device `5672423a-…` on us.2breeze.app) showed the `POST .../filesystem/cleanup-preview` returning **HTTP 200** with a valid preview. The backend was fine.

The real bug is **visibility**: the preview result panel renders as the *last block on a long page* (`DeviceFilesystemTab.tsx`), far below the fold, with no scroll and no toast. You click the button at the top; the panel appears off-screen. From the user's viewport, "nothing happened."

## Changes

**Web (`DeviceFilesystemTab.tsx`)** — the actual fix
- Attach a `ref` to the preview panel; `scrollIntoView({ behavior: "smooth", block: "start" })` in a `useEffect` whenever a preview is set.
- `scroll-mt-4` for a small top gap.
- Method is optional-chained (`?.scrollIntoView?.(`) so jsdom can't throw if a test mounts this later.
- The panel already renders honest empty states ("No safe cleanup categories found" / "No candidates available"), so even a zero-candidate preview now scrolls into view instead of reading as silence.

**API (`routes/agents/helpers.ts`)** — observability
- `handleFilesystemAnalysisCommandResult` silently dropped a **completed** scan on two paths — unparseable/empty stdout and device-not-found — leaving an empty tab with zero server-side trace. Added `console.warn` at both, so the next "it stopped working" is diagnosable from logs.
- Left the `status !== 'completed'` early-return alone: a failed/timed-out scan is already recorded on the `device_commands` row, so logging there would just be noise.

## Testing

⚠️ **Not run locally** — `node_modules` isn't installed in this worktree, so no `tsc`/vitest run. Changes are small and idiomatic (a typed ref, a guarded effect, two template-string logs). Reviewer/CI should confirm `test-web` + typecheck are green.

Recommended manual check: on a device with a filesystem snapshot, click **Cleanup Preview** — the page should scroll to the preview panel (populated or with a clear empty state), instead of appearing to do nothing.

## Notes / follow-ups
- If a device's preview shows **zero candidates**, that's a *separate* data question (snapshot has no `safe` candidates in the four allowed categories), not this UI bug.
- Related: MEMORY note `filesystem_analysis_agent_deadline_unenforced` tracks an agent-side deadline gap in this same feature — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)