### PR TITLE
fix(patches): stop installed inventory from erasing pending third-party patches

### DIFF
--- a/agent/internal/patching/winget_parse.go
+++ b/agent/internal/patching/winget_parse.go
@@ -202,6 +202,13 @@ func extractListColumns(line string, cols *columnPositions) (name, id, version s
 	}
 	name = safeSubstring(line, cols.name, cols.id)
 	id = safeSubstring(line, cols.id, cols.version)
+	// `winget list` grows an Available column when any package has an upgrade;
+	// slicing to end-of-line concatenated Version+Available into one string
+	// ("2.51.0.2   2.55.0.3"). Stop at the Available column when present.
+	if cols.available > 0 {
+		version = safeSubstring(line, cols.version, cols.available)
+		return
+	}
 	version = safeSubstring(line, cols.version, len(line))
 	// Version column may have Source appended — trim if present
 	if spaceIdx := strings.LastIndex(strings.TrimSpace(version), " "); spaceIdx > 0 {

--- a/agent/internal/patching/winget_parse_test.go
+++ b/agent/internal/patching/winget_parse_test.go
@@ -1,6 +1,8 @@
 package patching
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -42,5 +44,51 @@ Firefox  Mozilla.Firefox   128.0     129.0       winget
 	}
 	if patches[0].ID != "Mozilla.Firefox" {
 		t.Errorf("ID = %q, want %q", patches[0].ID, "Mozilla.Firefox")
+	}
+}
+
+func TestWingetListParseWithAvailableColumn(t *testing.T) {
+	// When any package has an upgrade, `winget list` grows an Available column;
+	// the Version cell must stop there instead of swallowing it (a row used to
+	// parse as Version "2.51.0.2   2.55.0.3").
+	row := func(name, id, version, available, source string) string {
+		return fmt.Sprintf("%-11s%-14s%-11s%-12s%s", name, id, version, available, source)
+	}
+	output := row("Name", "Id", "Version", "Available", "Source") + "\n" +
+		strings.Repeat("-", 55) + "\n" +
+		row("Git", "Git.Git", "2.51.0.2", "2.55.0.3", "winget") + "\n" +
+		row("7-Zip", "7zip.7zip", "26.00", "26.02", "winget") + "\n" +
+		row("Paint", "Corel.Paint", "1.2.3", "", "winget") + "\n"
+
+	installed := parseWingetListOutput(output)
+	if len(installed) != 3 {
+		t.Fatalf("expected 3 installed, got %d: %+v", len(installed), installed)
+	}
+	want := map[string]string{
+		"Git.Git":     "2.51.0.2",
+		"7zip.7zip":   "26.00",
+		"Corel.Paint": "1.2.3",
+	}
+	for _, p := range installed {
+		if p.Version != want[p.ID] {
+			t.Errorf("%s: Version = %q, want %q", p.ID, p.Version, want[p.ID])
+		}
+	}
+}
+
+func TestWingetListParseWithoutAvailableColumn(t *testing.T) {
+	row := func(name, id, version, source string) string {
+		return fmt.Sprintf("%-11s%-14s%-11s%s", name, id, version, source)
+	}
+	output := row("Name", "Id", "Version", "Source") + "\n" +
+		strings.Repeat("-", 45) + "\n" +
+		row("Git", "Git.Git", "2.51.0.2", "winget") + "\n"
+
+	installed := parseWingetListOutput(output)
+	if len(installed) != 1 {
+		t.Fatalf("expected 1 installed, got %d: %+v", len(installed), installed)
+	}
+	if installed[0].Version != "2.51.0.2" {
+		t.Errorf("Version = %q, want %q", installed[0].Version, "2.51.0.2")
 	}
 }

--- a/apps/api/src/routes/agents/patches.test.ts
+++ b/apps/api/src/routes/agents/patches.test.ts
@@ -713,6 +713,80 @@ describe('PUT /agents/:id/patches/pending - full scan coverage scoping (#2217)',
   });
 });
 
+describe('PUT /agents/:id/patches/installed - pending rows survive installed inventory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeviceLookup('windows');
+  });
+
+  function mockTxCapturingDevicePatchUpserts() {
+    const devicePatchUpserts: Array<{ values: Record<string, unknown>; set: Record<string, unknown> }> = [];
+    const tx = {
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn().mockResolvedValue(undefined),
+        })),
+      })),
+      insert: vi.fn((table) => ({
+        values: vi.fn((values) => ({
+          onConflictDoUpdate: vi.fn(({ set }) => {
+            if (table === patches) {
+              return { returning: vi.fn().mockResolvedValue([{ id: PATCH_ID, ...values }]) };
+            }
+            devicePatchUpserts.push({ values, set });
+            return { returning: vi.fn().mockResolvedValue([]) };
+          }),
+        })),
+      })),
+    };
+    return { tx, devicePatchUpserts };
+  }
+
+  it('conflict update keeps a pending row pending instead of flipping it to installed', async () => {
+    // winget reports a pending upgrade and the installed package under the same
+    // (source, externalId): `winget list` includes every package that
+    // `winget upgrade` just reported. The installed upsert must not downgrade
+    // the pending row the pending submit wrote ~200ms earlier.
+    const { tx, devicePatchUpserts } = mockTxCapturingDevicePatchUpserts();
+    vi.mocked(db.transaction).mockImplementation(async (fn) => fn(tx as unknown as Parameters<typeof fn>[0]));
+
+    const res = await mountAgentPatchRoutes().request(`/agents/${AGENT_ID}/patches/installed`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        installed: [
+          {
+            name: 'Git',
+            source: 'third_party',
+            externalId: 'Git.Git',
+            packageId: 'Git.Git',
+            version: '2.51.0.2',
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(devicePatchUpserts).toHaveLength(1);
+
+    const { values, set } = devicePatchUpserts[0]!;
+    // New rows (no conflict) are plainly installed.
+    expect(values.status).toBe('installed');
+    // The conflict update must be status-preserving for pending rows: a CASE
+    // expression referencing the existing row's status, not the bare literal.
+    expect(set.status).not.toBe('installed');
+    const statusSql = JSON.stringify(set.status);
+    expect(statusSql).toContain('pending');
+    expect(statusSql).toContain('installed');
+    expect((set.status as { values: unknown[] }).values).toContain(tables.devicePatches.status);
+    // installedAt is likewise preserved for pending rows.
+    expect((set.installedAt as { values: unknown[] }).values).toContain(tables.devicePatches.installedAt);
+    // installedVersion still updates — it reports the currently-installed
+    // version whether or not an upgrade is pending.
+    expect(set.installedVersion).toBe('2.51.0.2');
+  });
+});
+
 const patchIngestEndpoints = [
   {
     label: 'legacy combined patch ingest',

--- a/apps/api/src/routes/agents/patches.ts
+++ b/apps/api/src/routes/agents/patches.ts
@@ -236,6 +236,14 @@ async function upsertInstalledPatches(
     }
 
     const installedAt = parseDate(patchData.installedAt);
+    // Installed inventory must not downgrade an actionable 'pending' row.
+    // Package managers report a pending upgrade and the installed package under
+    // the SAME (source, externalId) — e.g. `winget list` includes every package
+    // that `winget upgrade` just reported — so an unconditional flip erased all
+    // pending third-party rows moments after the pending submit wrote them.
+    // installedVersion still updates: it's the currently-installed version
+    // either way. A row whose upgrade completed self-heals on the next scan
+    // (pending sweep → 'missing' → this upsert → 'installed').
     await executor
       .insert(devicePatches)
       .values({
@@ -250,8 +258,8 @@ async function upsertInstalledPatches(
       .onConflictDoUpdate({
         target: [devicePatches.deviceId, devicePatches.patchId],
         set: {
-          status: 'installed',
-          installedAt: installedAt,
+          status: sql`CASE WHEN ${devicePatches.status} = 'pending' THEN ${devicePatches.status} ELSE 'installed' END`,
+          installedAt: sql`CASE WHEN ${devicePatches.status} = 'pending' THEN ${devicePatches.installedAt} ELSE ${installedAt} END`,
           installedVersion: patchData.version || null,
           lastCheckedAt: new Date(),
           updatedAt: new Date()


### PR DESCRIPTION
## Problem

Third-party (winget) pending patches essentially never survive ingest — fleet-wide `device_patches` shows 1,880 `installed` vs 9 `pending` third-party rows. Investigated live on US prod (device KIT): a manual third-party scan found 23 pending updates, both agent submissions returned 200, yet the Patches tab showed nothing.

Root cause: the agent submits `PUT patches/pending` (`winget upgrade`) immediately followed by `PUT patches/installed` (`winget list`). On Windows both lists report a winget package under the **same `(source, externalId)`** (bare package id), so they upsert the same `patches` row and the same `(device_id, patch_id)` row in `device_patches`. `upsertInstalledPatches` unconditionally set `status:'installed'` on conflict, and since `winget list` includes every upgradable package, all pending rows flipped to `installed` within the same second.

## Fix

- **API** (`routes/agents/patches.ts`): the installed-inventory conflict update now preserves `pending` rows (`CASE` on the existing row's status); `installedVersion` still updates since it reports the currently-installed version either way. A row whose upgrade actually completed self-heals on the next scan cycle: the pending sweep tombstones it to `missing`, then the installed submit flips it to `installed`. No backfill needed — prod rows recover on the next scheduled scan.
- **Agent** (`patching/winget_parse.go`): `extractListColumns` now stops the Version cell at the `Available` column, which `winget list` grows whenever any package has an upgrade — `installed_version` was landing as a concatenated two-version string (`2.51.0.2   2.55.0.3`).

## Tests

- API: new conflict-update test asserting the devicePatches upsert is status-preserving for pending rows while new rows still insert as `installed` (20/20 pass).
- Agent: first coverage for `parseWingetListOutput` — with and without the `Available` column (`go test -race ./internal/patching/` passes).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)