### PR TITLE
perf(agent): optimize filesystem scanner hot path (BE-1)

### DIFF
--- a/agent/internal/remote/tools/file_owner_unix.go
+++ b/agent/internal/remote/tools/file_owner_unix.go
@@ -6,8 +6,16 @@ import (
 	"os"
 	"os/user"
 	"strconv"
+	"sync"
 	"syscall"
 )
+
+// uidNameCache memoizes uid -> username resolution for the lifetime of the
+// process. A filesystem scan touches millions of files but only a handful of
+// distinct UIDs; without this, getFileOwner issued a fresh user.LookupId
+// (getpwuid_r via cgo/NSS — can reach files, sss, LDAP) per file. The cache
+// collapses that to one lookup per distinct UID.
+var uidNameCache sync.Map // map[uint32]string
 
 func getFileOwner(info os.FileInfo) string {
 	if info == nil || info.Sys() == nil {
@@ -18,10 +26,15 @@ func getFileOwner(info os.FileInfo) string {
 		return ""
 	}
 
-	uid := strconv.FormatUint(uint64(stat.Uid), 10)
-	usr, err := user.LookupId(uid)
-	if err != nil {
-		return uid
+	if cached, ok := uidNameCache.Load(stat.Uid); ok {
+		return cached.(string)
 	}
-	return usr.Username
+
+	uid := strconv.FormatUint(uint64(stat.Uid), 10)
+	name := uid
+	if usr, err := user.LookupId(uid); err == nil {
+		name = usr.Username
+	}
+	uidNameCache.Store(stat.Uid, name)
+	return name
 }

--- a/agent/internal/remote/tools/file_owner_unix.go
+++ b/agent/internal/remote/tools/file_owner_unix.go
@@ -31,10 +31,13 @@ func getFileOwner(info os.FileInfo) string {
 	}
 
 	uid := strconv.FormatUint(uint64(stat.Uid), 10)
-	name := uid
-	if usr, err := user.LookupId(uid); err == nil {
-		name = usr.Username
+	usr, err := user.LookupId(uid)
+	if err != nil {
+		// Only successful resolutions are cached. A transient NSS/SSSD/LDAP
+		// failure must not pin this uid to its numeric fallback for the whole
+		// process lifetime — return the fallback but let the next file retry.
+		return uid
 	}
-	uidNameCache.Store(stat.Uid, name)
-	return name
+	uidNameCache.Store(stat.Uid, usr.Username)
+	return usr.Username
 }

--- a/agent/internal/remote/tools/filesystem_analysis.go
+++ b/agent/internal/remote/tools/filesystem_analysis.go
@@ -217,7 +217,19 @@ func AnalyzeFilesystem(payload map[string]any) CommandResult {
 			return
 		}
 
-		entries, readErr := os.ReadDir(frame.path)
+		// Read entries in directory order rather than os.ReadDir's filename-sorted
+		// order — this scanner aggregates over every entry and never relies on
+		// order, so the per-directory sort is pure overhead across a large tree.
+		dirFile, openErr := os.Open(frame.path)
+		if openErr != nil {
+			statsMu.Lock()
+			markDirAndAncestorsIncomplete(dirStats, frame.path)
+			appendScanError(&scanErrors, frame.path, openErr, &permissionDeniedCount)
+			statsMu.Unlock()
+			return
+		}
+		entries, readErr := dirFile.ReadDir(-1)
+		dirFile.Close()
 		if readErr != nil {
 			statsMu.Lock()
 			markDirAndAncestorsIncomplete(dirStats, frame.path)
@@ -313,23 +325,52 @@ func AnalyzeFilesystem(payload map[string]any) CommandResult {
 				fileSize = 0
 			}
 
-			modifiedAt := info.ModTime().UTC().Format(time.RFC3339)
+			// Global counters are contention-free — keep them off the shared lock.
+			atomic.AddInt64(&filesScanned, 1)
+			atomic.AddInt64(&bytesScanned, fileSize)
+
+			// Classification is pure (touches no shared state), so run it before
+			// taking the lock instead of holding every other worker off while we do.
+			category := classifyCleanupCategory(entryPath)
+			oldDownload := isOldDownload(entryPath, fileSize, info.ModTime(), oldDownloadsThreshold)
+			unrotated := isUnrotatedLog(entryPath, fileSize)
+
+			// modifiedAt is needed by several retention buckets; format it at most
+			// once, and only when a bucket actually keeps this file.
+			modifiedAt := ""
+			modTimeResolved := false
+			resolveModTime := func() string {
+				if !modTimeResolved {
+					modifiedAt = info.ModTime().UTC().Format(time.RFC3339)
+					modTimeResolved = true
+				}
+				return modifiedAt
+			}
+
+			// Owner for old downloads is known now; resolve it outside the lock.
+			// The top-N owner is resolved lazily under the lock (cached, so a map
+			// hit) only when the file actually qualifies — see fileQualifiesForTop.
+			var oldDownloadOwner string
+			if oldDownload {
+				oldDownloadOwner = getFileOwner(info)
+			}
+
 			statsMu.Lock()
-			filesScanned++
-			bytesScanned += fileSize
 			if parentAgg, ok := dirStats[frame.path]; ok {
 				parentAgg.SizeBytes += fileSize
 				parentAgg.FileCount++
 			}
 
-			addTopLargestFile(&topLargestFiles, FilesystemLargestFile{
-				Path:       entryPath,
-				SizeBytes:  fileSize,
-				ModifiedAt: modifiedAt,
-				Owner:      getFileOwner(info),
-			}, topFilesLimit)
+			if fileQualifiesForTop(topLargestFiles, fileSize, topFilesLimit) {
+				addTopLargestFile(&topLargestFiles, FilesystemLargestFile{
+					Path:       entryPath,
+					SizeBytes:  fileSize,
+					ModifiedAt: resolveModTime(),
+					Owner:      getFileOwner(info),
+				}, topFilesLimit)
+			}
 
-			if category := classifyCleanupCategory(entryPath); category != "" {
+			if category != "" {
 				tempBytes[category] += fileSize
 				addCleanupCandidate(cleanupByPath, FilesystemCleanupCandidate{
 					Path:       entryPath,
@@ -337,24 +378,24 @@ func AnalyzeFilesystem(payload map[string]any) CommandResult {
 					SizeBytes:  fileSize,
 					Safe:       true,
 					Reason:     "temporary/cache file",
-					ModifiedAt: modifiedAt,
+					ModifiedAt: resolveModTime(),
 				}, maxFSCleanupCandidates)
 			}
 
-			if isOldDownload(entryPath, fileSize, info.ModTime(), oldDownloadsThreshold) {
+			if oldDownload {
 				oldDownloads = append(oldDownloads, FilesystemOldDownload{
 					Path:       entryPath,
 					SizeBytes:  fileSize,
-					ModifiedAt: modifiedAt,
-					Owner:      getFileOwner(info),
+					ModifiedAt: resolveModTime(),
+					Owner:      oldDownloadOwner,
 				})
 			}
 
-			if isUnrotatedLog(entryPath, fileSize) {
+			if unrotated {
 				unrotatedLogs = append(unrotatedLogs, FilesystemUnrotatedLog{
 					Path:       entryPath,
 					SizeBytes:  fileSize,
-					ModifiedAt: modifiedAt,
+					ModifiedAt: resolveModTime(),
 				})
 			}
 
@@ -430,7 +471,10 @@ func AnalyzeFilesystem(payload map[string]any) CommandResult {
 		statsMu.Unlock()
 	}
 
-	// Aggregate child directory sizes into parents.
+	// Aggregate child directory sizes into parents. Iterating deepest-first
+	// guarantees a directory's own size is final by the time it is visited (all
+	// strictly-deeper descendants have already folded in), so we can collect the
+	// top-N candidate in the same pass instead of a second full map traversal.
 	orderedDirs := make([]*fsDirAggregate, 0, len(dirStats))
 	for _, agg := range dirStats {
 		orderedDirs = append(orderedDirs, agg)
@@ -438,7 +482,17 @@ func AnalyzeFilesystem(payload map[string]any) CommandResult {
 	sort.Slice(orderedDirs, func(i, j int) bool {
 		return orderedDirs[i].Depth > orderedDirs[j].Depth
 	})
+
+	topDirCandidateLimit := clampInt(topDirsLimit*8, topDirsLimit, 2000)
+	topLargestDirCandidates := make([]FilesystemLargestDirectory, 0, topDirCandidateLimit)
 	for _, agg := range orderedDirs {
+		addTopLargestDir(&topLargestDirCandidates, FilesystemLargestDirectory{
+			Path:      agg.Path,
+			SizeBytes: agg.SizeBytes,
+			FileCount: agg.FileCount,
+			Estimated: agg.Incomplete,
+		}, topDirCandidateLimit)
+
 		if agg.Parent == "" {
 			continue
 		}
@@ -451,17 +505,6 @@ func AnalyzeFilesystem(payload map[string]any) CommandResult {
 		if agg.Incomplete {
 			parent.Incomplete = true
 		}
-	}
-
-	topDirCandidateLimit := clampInt(topDirsLimit*8, topDirsLimit, 2000)
-	topLargestDirCandidates := make([]FilesystemLargestDirectory, 0, topDirCandidateLimit)
-	for _, agg := range dirStats {
-		addTopLargestDir(&topLargestDirCandidates, FilesystemLargestDirectory{
-			Path:      agg.Path,
-			SizeBytes: agg.SizeBytes,
-			FileCount: agg.FileCount,
-			Estimated: agg.Incomplete,
-		}, topDirCandidateLimit)
 	}
 	topLargestDirs = collapseAncestorDirectories(topLargestDirCandidates, topDirsLimit, 0.70)
 	sort.Slice(oldDownloads, func(i, j int) bool { return oldDownloads[i].SizeBytes > oldDownloads[j].SizeBytes })
@@ -655,38 +698,67 @@ func clampInt(value, min, max int) int {
 	return value
 }
 
+// fileQualifiesForTop reports whether a file of the given size would be kept in
+// the top-N slice, so callers can skip the cost of resolving its owner/modtime
+// when it wouldn't. Must be called under the same lock that guards `top`.
+func fileQualifiesForTop(top []FilesystemLargestFile, size int64, limit int) bool {
+	if limit <= 0 {
+		return false
+	}
+	if len(top) < limit {
+		return true
+	}
+	return size > top[len(top)-1].SizeBytes
+}
+
+// addTopLargestFile keeps `top` sorted by SizeBytes descending, bounded to
+// `limit`. It inserts at the correct position (binary search + single shift)
+// rather than re-sorting the whole slice on every insert, so the per-file cost
+// is O(limit) worst case instead of O(limit·log limit).
 func addTopLargestFile(top *[]FilesystemLargestFile, file FilesystemLargestFile, limit int) {
 	if limit <= 0 {
 		return
 	}
-	if len(*top) < limit {
-		*top = append(*top, file)
-		sort.Slice(*top, func(i, j int) bool { return (*top)[i].SizeBytes > (*top)[j].SizeBytes })
+	s := *top
+	n := len(s)
+	if n >= limit {
+		if file.SizeBytes <= s[n-1].SizeBytes {
+			return
+		}
+		// Insert into descending order, dropping the current minimum (last).
+		idx := sort.Search(n, func(i int) bool { return s[i].SizeBytes < file.SizeBytes })
+		copy(s[idx+1:], s[idx:n-1])
+		s[idx] = file
 		return
 	}
-	minIdx := len(*top) - 1
-	if file.SizeBytes <= (*top)[minIdx].SizeBytes {
-		return
-	}
-	(*top)[minIdx] = file
-	sort.Slice(*top, func(i, j int) bool { return (*top)[i].SizeBytes > (*top)[j].SizeBytes })
+	idx := sort.Search(n, func(i int) bool { return s[i].SizeBytes < file.SizeBytes })
+	s = append(s, file)
+	copy(s[idx+1:], s[idx:n])
+	s[idx] = file
+	*top = s
 }
 
+// addTopLargestDir mirrors addTopLargestFile for directory aggregates.
 func addTopLargestDir(top *[]FilesystemLargestDirectory, dir FilesystemLargestDirectory, limit int) {
 	if limit <= 0 {
 		return
 	}
-	if len(*top) < limit {
-		*top = append(*top, dir)
-		sort.Slice(*top, func(i, j int) bool { return (*top)[i].SizeBytes > (*top)[j].SizeBytes })
+	s := *top
+	n := len(s)
+	if n >= limit {
+		if dir.SizeBytes <= s[n-1].SizeBytes {
+			return
+		}
+		idx := sort.Search(n, func(i int) bool { return s[i].SizeBytes < dir.SizeBytes })
+		copy(s[idx+1:], s[idx:n-1])
+		s[idx] = dir
 		return
 	}
-	minIdx := len(*top) - 1
-	if dir.SizeBytes <= (*top)[minIdx].SizeBytes {
-		return
-	}
-	(*top)[minIdx] = dir
-	sort.Slice(*top, func(i, j int) bool { return (*top)[i].SizeBytes > (*top)[j].SizeBytes })
+	idx := sort.Search(n, func(i int) bool { return s[i].SizeBytes < dir.SizeBytes })
+	s = append(s, dir)
+	copy(s[idx+1:], s[idx:n])
+	s[idx] = dir
+	*top = s
 }
 
 func collapseAncestorDirectories(
@@ -701,12 +773,20 @@ func collapseAncestorDirectories(
 		descendantRatio = 0.70
 	}
 
-	items := append([]FilesystemLargestDirectory(nil), candidates...)
+	// Precompute the normalized path + depth once per candidate. The O(n²)
+	// pairwise descendant check below would otherwise re-normalize both paths on
+	// every comparison (up to ~4M comparisons × 2 normalizations, each allocating
+	// several strings) for a single scan's post-processing.
+	items := make([]collapseCandidate, len(candidates))
+	for i, c := range candidates {
+		norm := normalizePathForHierarchy(c.Path)
+		items[i] = collapseCandidate{dir: c, norm: norm, depth: pathDepthNormalized(norm)}
+	}
 	sort.Slice(items, func(i, j int) bool {
-		if items[i].SizeBytes == items[j].SizeBytes {
-			return pathDepth(items[i].Path) > pathDepth(items[j].Path)
+		if items[i].dir.SizeBytes == items[j].dir.SizeBytes {
+			return items[i].depth > items[j].depth
 		}
-		return items[i].SizeBytes > items[j].SizeBytes
+		return items[i].dir.SizeBytes > items[j].dir.SizeBytes
 	})
 
 	pruned := make([]bool, len(items))
@@ -715,7 +795,7 @@ func collapseAncestorDirectories(
 			continue
 		}
 		ancestor := items[i]
-		if ancestor.SizeBytes <= 0 {
+		if ancestor.dir.SizeBytes <= 0 {
 			continue
 		}
 		for j := range items {
@@ -723,13 +803,13 @@ func collapseAncestorDirectories(
 				continue
 			}
 			child := items[j]
-			if child.SizeBytes <= 0 {
+			if child.dir.SizeBytes <= 0 {
 				continue
 			}
-			if !isDescendantPath(child.Path, ancestor.Path) {
+			if !isDescendantNormalized(child.norm, ancestor.norm) {
 				continue
 			}
-			if shouldPruneAncestorByDescendant(ancestor, child, descendantRatio) {
+			if shouldPruneAncestorByDescendant(ancestor.dir, child.dir, descendantRatio) {
 				pruned[i] = true
 				break
 			}
@@ -741,12 +821,49 @@ func collapseAncestorDirectories(
 		if pruned[i] {
 			continue
 		}
-		result = append(result, items[i])
+		result = append(result, items[i].dir)
 		if len(result) >= limit {
 			break
 		}
 	}
 	return result
+}
+
+// collapseCandidate carries a directory aggregate alongside its precomputed
+// normalized path and depth so the pairwise ancestor scan never re-normalizes.
+type collapseCandidate struct {
+	dir   FilesystemLargestDirectory
+	norm  string
+	depth int
+}
+
+// isDescendantNormalized is isDescendantPath for paths already normalized via
+// normalizePathForHierarchy — no per-call normalization.
+func isDescendantNormalized(normalizedPath, normalizedAncestor string) bool {
+	if normalizedPath == "" || normalizedAncestor == "" || normalizedPath == normalizedAncestor {
+		return false
+	}
+	if normalizedAncestor == "/" {
+		return strings.HasPrefix(normalizedPath, "/") && normalizedPath != "/"
+	}
+	if len(normalizedAncestor) == 3 && normalizedAncestor[1] == ':' && normalizedAncestor[2] == '/' {
+		return strings.HasPrefix(normalizedPath, normalizedAncestor) && normalizedPath != normalizedAncestor
+	}
+	return strings.HasPrefix(normalizedPath, normalizedAncestor+"/")
+}
+
+// pathDepthNormalized is pathDepth for an already-normalized path.
+func pathDepthNormalized(normalized string) int {
+	if normalized == "" || normalized == "/" {
+		return 0
+	}
+	depth := 0
+	for _, part := range strings.Split(strings.Trim(normalized, "/"), "/") {
+		if part != "" {
+			depth++
+		}
+	}
+	return depth
 }
 
 func shouldPruneAncestorByDescendant(
@@ -782,22 +899,6 @@ func maxFloat(a, b float64) float64 {
 	return b
 }
 
-func pathDepth(path string) int {
-	normalized := normalizePathForHierarchy(path)
-	if normalized == "" || normalized == "/" {
-		return 0
-	}
-	parts := strings.Split(strings.Trim(normalized, "/"), "/")
-	depth := 0
-	for _, part := range parts {
-		if part == "" {
-			continue
-		}
-		depth++
-	}
-	return depth
-}
-
 func normalizePathForHierarchy(path string) string {
 	normalized := strings.TrimSpace(strings.ReplaceAll(path, "\\", "/"))
 	if normalized == "" {
@@ -812,23 +913,6 @@ func normalizePathForHierarchy(path string) string {
 		}
 	}
 	return strings.ToLower(normalized)
-}
-
-func isDescendantPath(path string, ancestor string) bool {
-	normalizedPath := normalizePathForHierarchy(path)
-	normalizedAncestor := normalizePathForHierarchy(ancestor)
-	if normalizedPath == "" || normalizedAncestor == "" || normalizedPath == normalizedAncestor {
-		return false
-	}
-
-	if normalizedAncestor == "/" {
-		return strings.HasPrefix(normalizedPath, "/") && normalizedPath != "/"
-	}
-	if len(normalizedAncestor) == 3 && normalizedAncestor[1] == ':' && normalizedAncestor[2] == '/' {
-		return strings.HasPrefix(normalizedPath, normalizedAncestor) && normalizedPath != normalizedAncestor
-	}
-
-	return strings.HasPrefix(normalizedPath, normalizedAncestor+"/")
 }
 
 func markDirAndAncestorsIncomplete(dirStats map[string]*fsDirAggregate, path string) {

--- a/agent/internal/remote/tools/filesystem_analysis.go
+++ b/agent/internal/remote/tools/filesystem_analysis.go
@@ -229,7 +229,9 @@ func AnalyzeFilesystem(payload map[string]any) CommandResult {
 			return
 		}
 		entries, readErr := dirFile.ReadDir(-1)
-		dirFile.Close()
+		// Entries are already read into memory; the dir handle's Close error is
+		// not actionable (and `_ =` satisfies errcheck).
+		_ = dirFile.Close()
 		if readErr != nil {
 			statsMu.Lock()
 			markDirAndAncestorsIncomplete(dirStats, frame.path)

--- a/agent/internal/remote/tools/filesystem_analysis_opt_test.go
+++ b/agent/internal/remote/tools/filesystem_analysis_opt_test.go
@@ -1,0 +1,213 @@
+package tools
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func isSortedDescFiles(s []FilesystemLargestFile) bool {
+	return sort.SliceIsSorted(s, func(i, j int) bool { return s[i].SizeBytes > s[j].SizeBytes })
+}
+
+func TestAddTopLargestFileKeepsBoundedDescendingTopN(t *testing.T) {
+	sizes := []int64{5, 1, 9, 3, 7, 2, 8, 4, 6, 10}
+	var top []FilesystemLargestFile
+	const limit = 3
+	for _, sz := range sizes {
+		addTopLargestFile(&top, FilesystemLargestFile{Path: "p", SizeBytes: sz}, limit)
+	}
+
+	if len(top) != limit {
+		t.Fatalf("expected %d entries, got %d", limit, len(top))
+	}
+	if !isSortedDescFiles(top) {
+		t.Fatalf("top not sorted descending: %+v", top)
+	}
+	got := []int64{top[0].SizeBytes, top[1].SizeBytes, top[2].SizeBytes}
+	want := []int64{10, 9, 8}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("top-N = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestAddTopLargestFileRejectsBelowMinAtCapacity(t *testing.T) {
+	var top []FilesystemLargestFile
+	const limit = 2
+	addTopLargestFile(&top, FilesystemLargestFile{Path: "a", SizeBytes: 100}, limit)
+	addTopLargestFile(&top, FilesystemLargestFile{Path: "b", SizeBytes: 50}, limit)
+	// Below current min (50) at capacity — must be ignored.
+	addTopLargestFile(&top, FilesystemLargestFile{Path: "c", SizeBytes: 10}, limit)
+
+	if len(top) != 2 || top[0].SizeBytes != 100 || top[1].SizeBytes != 50 {
+		t.Fatalf("unexpected top after reject: %+v", top)
+	}
+	for _, f := range top {
+		if f.Path == "c" {
+			t.Fatalf("path c should not have been inserted: %+v", top)
+		}
+	}
+}
+
+func TestAddTopLargestFileZeroLimitNoop(t *testing.T) {
+	var top []FilesystemLargestFile
+	addTopLargestFile(&top, FilesystemLargestFile{Path: "a", SizeBytes: 100}, 0)
+	if len(top) != 0 {
+		t.Fatalf("expected empty top with zero limit, got %+v", top)
+	}
+}
+
+func TestAddTopLargestDirKeepsBoundedDescendingTopN(t *testing.T) {
+	sizes := []int64{40, 10, 90, 30, 70}
+	var top []FilesystemLargestDirectory
+	const limit = 2
+	for _, sz := range sizes {
+		addTopLargestDir(&top, FilesystemLargestDirectory{Path: "d", SizeBytes: sz}, limit)
+	}
+	if len(top) != limit || top[0].SizeBytes != 90 || top[1].SizeBytes != 70 {
+		t.Fatalf("unexpected dir top-N: %+v", top)
+	}
+}
+
+func TestFileQualifiesForTop(t *testing.T) {
+	cases := []struct {
+		name  string
+		top   []FilesystemLargestFile
+		size  int64
+		limit int
+		want  bool
+	}{
+		{"zero limit", nil, 100, 0, false},
+		{"below capacity", []FilesystemLargestFile{{SizeBytes: 5}}, 1, 3, true},
+		{"at capacity above min", []FilesystemLargestFile{{SizeBytes: 9}, {SizeBytes: 5}}, 7, 2, true},
+		{"at capacity equal min", []FilesystemLargestFile{{SizeBytes: 9}, {SizeBytes: 5}}, 5, 2, false},
+		{"at capacity below min", []FilesystemLargestFile{{SizeBytes: 9}, {SizeBytes: 5}}, 4, 2, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fileQualifiesForTop(tc.top, tc.size, tc.limit); got != tc.want {
+				t.Fatalf("fileQualifiesForTop = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsDescendantNormalized(t *testing.T) {
+	cases := []struct {
+		path, ancestor string
+		want           bool
+	}{
+		{"/a/b/c", "/a/b", true},
+		{"/a/b", "/a/b", false},
+		{"/ab", "/a", false}, // prefix but not a path child
+		{"/a/b", "/", true},
+		{"/", "/", false},
+		{"c:/users/x", "c:/", true},
+		{"c:/users", "c:/users", false},
+	}
+	for _, tc := range cases {
+		got := isDescendantNormalized(normalizePathForHierarchy(tc.path), normalizePathForHierarchy(tc.ancestor))
+		if got != tc.want {
+			t.Fatalf("isDescendantNormalized(%q, %q) = %v, want %v", tc.path, tc.ancestor, got, tc.want)
+		}
+	}
+}
+
+func TestPathDepthNormalized(t *testing.T) {
+	cases := map[string]int{"": 0, "/": 0, "/a": 1, "/a/b": 2, "/a/b/c": 3}
+	for in, want := range cases {
+		if got := pathDepthNormalized(normalizePathForHierarchy(in)); got != want {
+			t.Fatalf("pathDepthNormalized(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestCollapseAncestorDirectoriesFoldsDominantChild(t *testing.T) {
+	// Parent's size is almost entirely explained by one child (0.9 > 0.70), so
+	// the ancestor should be collapsed away in favor of the descendant.
+	candidates := []FilesystemLargestDirectory{
+		{Path: "/data", SizeBytes: 1000},
+		{Path: "/data/big", SizeBytes: 900},
+		{Path: "/other", SizeBytes: 500},
+	}
+	out := collapseAncestorDirectories(candidates, 10, 0.70)
+
+	paths := map[string]bool{}
+	for _, d := range out {
+		paths[d.Path] = true
+	}
+	if paths["/data"] {
+		t.Fatalf("expected /data to be collapsed, got %+v", out)
+	}
+	if !paths["/data/big"] || !paths["/other"] {
+		t.Fatalf("expected /data/big and /other retained, got %+v", out)
+	}
+	if !sort.SliceIsSorted(out, func(i, j int) bool { return out[i].SizeBytes > out[j].SizeBytes }) {
+		t.Fatalf("collapse output not sorted descending: %+v", out)
+	}
+}
+
+func TestCollapseAncestorDirectoriesKeepsIndependentDirs(t *testing.T) {
+	candidates := []FilesystemLargestDirectory{
+		{Path: "/a", SizeBytes: 1000},
+		{Path: "/b", SizeBytes: 800},
+	}
+	out := collapseAncestorDirectories(candidates, 10, 0.70)
+	if len(out) != 2 {
+		t.Fatalf("independent dirs should both survive, got %+v", out)
+	}
+}
+
+// TestAnalyzeFilesystemEndToEnd exercises the concurrent walk over a real temp
+// tree with multiple workers. Run under -race, it guards the lock/atomic split
+// in the per-file hot path against data races and verifies the aggregate output.
+func TestAnalyzeFilesystemEndToEnd(t *testing.T) {
+	root := t.TempDir()
+	// Layout: known sizes so the largest file is deterministic.
+	writeFile := func(rel string, size int) {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, make([]byte, size), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile("a/small.bin", 10)
+	writeFile("a/b/medium.bin", 1000)
+	writeFile("a/b/c/large.bin", 50000)
+	writeFile("d/other.bin", 200)
+
+	res := AnalyzeFilesystem(map[string]any{
+		"path":     root,
+		"workers":  4,
+		"topFiles": 10,
+		"topDirs":  10,
+		"maxDepth": 32,
+	})
+	if res.Status != "completed" {
+		t.Fatalf("scan status = %q (err=%q)", res.Status, res.Error)
+	}
+
+	var resp FilesystemAnalysisResponse
+	if err := json.Unmarshal([]byte(res.Stdout), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if resp.Summary.FilesScanned != 4 {
+		t.Fatalf("FilesScanned = %d, want 4", resp.Summary.FilesScanned)
+	}
+	if resp.Summary.BytesScanned != 10+1000+50000+200 {
+		t.Fatalf("BytesScanned = %d, want %d", resp.Summary.BytesScanned, 10+1000+50000+200)
+	}
+	if len(resp.TopLargestFiles) == 0 || filepath.Base(resp.TopLargestFiles[0].Path) != "large.bin" {
+		t.Fatalf("largest file wrong: %+v", resp.TopLargestFiles)
+	}
+	if !isSortedDescFiles(resp.TopLargestFiles) {
+		t.Fatalf("top files not sorted desc: %+v", resp.TopLargestFiles)
+	}
+}

--- a/agent/internal/remote/tools/filesystem_analysis_opt_test.go
+++ b/agent/internal/remote/tools/filesystem_analysis_opt_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -209,5 +210,74 @@ func TestAnalyzeFilesystemEndToEnd(t *testing.T) {
 	}
 	if !isSortedDescFiles(resp.TopLargestFiles) {
 		t.Fatalf("top files not sorted desc: %+v", resp.TopLargestFiles)
+	}
+}
+
+// TestAnalyzeFilesystemConcurrentManyDirs stresses the per-file hot-path
+// lock/atomic split: 600 files spread across 30 directories give 8 workers real
+// concurrent access to the shared counters, top-N slices, and candidate maps.
+// Under -race this is what actually exercises the split (the small end-to-end
+// test above barely contends). It also pins the aggregate totals and top-N
+// output so a mis-scoped mutation would corrupt a value, not just trip -race.
+func TestAnalyzeFilesystemConcurrentManyDirs(t *testing.T) {
+	root := t.TempDir()
+	const dirs, perDir = 30, 20
+
+	var wantFiles int64
+	var wantBytes int64
+	var maxSize int
+	for d := 0; d < dirs; d++ {
+		dir := filepath.Join(root, fmt.Sprintf("d%02d", d))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for f := 0; f < perDir; f++ {
+			size := (d*perDir + f + 1) * 10 // strictly increasing, unique max
+			if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("f%02d.bin", f)), make([]byte, size), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			wantFiles++
+			wantBytes += int64(size)
+			maxSize = size
+		}
+	}
+
+	res := AnalyzeFilesystem(map[string]any{
+		"path":     root,
+		"workers":  8,
+		"topFiles": 25,
+		"topDirs":  10,
+		"maxDepth": 32,
+	})
+	if res.Status != "completed" {
+		t.Fatalf("scan status = %q (err=%q)", res.Status, res.Error)
+	}
+
+	var resp FilesystemAnalysisResponse
+	if err := json.Unmarshal([]byte(res.Stdout), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if resp.Summary.FilesScanned != wantFiles {
+		t.Fatalf("FilesScanned = %d, want %d", resp.Summary.FilesScanned, wantFiles)
+	}
+	if resp.Summary.BytesScanned != wantBytes {
+		t.Fatalf("BytesScanned = %d, want %d", resp.Summary.BytesScanned, wantBytes)
+	}
+	if len(resp.TopLargestFiles) != 25 || resp.TopLargestFiles[0].SizeBytes != int64(maxSize) {
+		t.Fatalf("top files wrong (len=%d, head=%+v)", len(resp.TopLargestFiles), resp.TopLargestFiles)
+	}
+	if !isSortedDescFiles(resp.TopLargestFiles) {
+		t.Fatalf("top files not sorted desc: %+v", resp.TopLargestFiles)
+	}
+	// Directory aggregation ran in the same pass as the parent-fold; assert it
+	// produced sorted, non-empty candidates.
+	if len(resp.TopLargestDirs) == 0 {
+		t.Fatalf("expected directory candidates, got none")
+	}
+	if !sort.SliceIsSorted(resp.TopLargestDirs, func(i, j int) bool {
+		return resp.TopLargestDirs[i].SizeBytes > resp.TopLargestDirs[j].SizeBytes
+	}) {
+		t.Fatalf("top dirs not sorted desc: %+v", resp.TopLargestDirs)
 	}
 }


### PR DESCRIPTION
## Summary

The BE-1 deep filesystem scanner walks devices with millions of files (test evidence: ~2M files, 528GB). A review of the hot path found the concurrent walk was effectively serialized and doing avoidable per-file work. **All changes are semantics-preserving — scan output is unchanged** (guarded by new tests).

## Changes (ranked by impact)

1. **Shrink the per-file critical section.** The whole per-file bookkeeping block ran under one global `statsMu`, so up to 32 workers serialized on it. Global counters (`filesScanned`/`bytesScanned`) move to atomics, and the pure classifiers (`classifyCleanupCategory`/`isOldDownload`/`isUnrotatedLog`) now run *before* taking the lock. This was the main reason raising `workers` didn't scale the CPU-bound work.
2. **Owner lookup was per-file, eager, and inside the lock.** `getFileOwner` (a `user.LookupId`/NSS call — can hit files/sss/LDAP) ran for every file before the top-N check could reject it. Now it's resolved only for files actually retained (top-N / old-downloads), and uid→username is memoized (a disk has few UIDs).
3. **Top-N insertion** (`addTopLargestFile`/`Dir`) uses binary-search + single shift instead of re-sorting the whole slice per insert: O(limit) vs O(limit·log limit), same sorted-descending output.
4. **Directory reads** use directory order (`os.Open` + `File.ReadDir(-1)`) instead of `os.ReadDir`'s filename-sorted order, which this scanner never uses.
5. **`collapseAncestorDirectories`** precomputes each candidate's normalized path + depth once instead of re-normalizing both sides on every one of up to ~4M pairwise comparisons.
6. **Directory aggregation** collects top-dir candidates in the existing depth-descending fold instead of a second full traversal of the directory map.
7. Minor: lazy `modifiedAt` formatting.

## Testing

New tests in `filesystem_analysis_opt_test.go`: top-N insertion (bounds/order/reject/ties), `fileQualifiesForTop`, collapse folding + independence, normalized-path helpers, and an **end-to-end `AnalyzeFilesystem` walk over a temp tree with 4 workers** that runs under `-race` to guard the lock/atomic split.

Verified locally: `go test -race ./internal/remote/tools/` (full package), `go vet`, `gofmt -l` (clean), and `GOOS=windows`/`GOOS=linux` cross-builds all pass.

## Notes
- The `maxEntries` cap remains a soft/racy cap across workers (a worker mid-directory finishes it before noticing `stopping`) — pre-existing behavior, unchanged here; flagging for the field owner since the name reads as a hard ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)