### PR TITLE
perf(filesystem): fix baseline-completion bug + trim ingest/serve overhead (BE-1)

### DIFF
--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -338,7 +338,7 @@ commandsRoutes.post(
 
     if (command.type === filesystemAnalysisCommandType) {
       try {
-        await handleFilesystemAnalysisCommandResult(command, normalizedData);
+        await handleFilesystemAnalysisCommandResult(command, normalizedData, agent.orgId);
       } catch (err) {
         console.error(`[agents] filesystem analysis post-processing failed for ${commandId}:`, err);
         captureException(err);

--- a/apps/api/src/routes/agents/helpers.filesystemAnalysis.test.ts
+++ b/apps/api/src/routes/agents/helpers.filesystemAnalysis.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { z } from 'zod';
+import type { commandResultSchema } from './schemas';
+
+/**
+ * Regression coverage for handleFilesystemAnalysisCommandResult — specifically
+ * the baseline-completion logic and orgId threading. The whole function was
+ * previously mocked everywhere, so its behavior was unguarded.
+ */
+
+const { dbMock, insertValuesMock, selectQueue } = vi.hoisted(() => {
+  const selectQueue: unknown[][] = [];
+  const shift = () => selectQueue.shift() ?? [];
+  const insertValuesMock = vi.fn();
+
+  const dbMock = {
+    select: vi.fn(() => {
+      const rows = shift();
+      const terminal = Object.assign(Promise.resolve(rows), {
+        limit: vi.fn().mockResolvedValue(rows),
+        orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+      });
+      return { from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue(terminal) }) };
+    }),
+    insert: vi.fn(() => ({
+      values: vi.fn((vals: unknown) => {
+        insertValuesMock(vals);
+        return Object.assign(Promise.resolve(undefined), {
+          returning: vi.fn().mockResolvedValue([{ id: 'row-1' }]),
+        });
+      }),
+    })),
+  };
+
+  return { dbMock, insertValuesMock, selectQueue };
+});
+
+vi.mock('../../db', () => ({
+  db: dbMock,
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', () => new Proxy({}, {
+  get: (_t, prop: string) => (prop === 'then' ? undefined : { $inferSelect: {}, name: prop }),
+  has: () => true,
+}));
+
+vi.mock('../../services/redis', () => ({ getRedis: vi.fn(() => null) }));
+vi.mock('../../services/eventBus', () => ({ publishEvent: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../jobs/softwareComplianceWorker', () => ({ scheduleSoftwareComplianceCheck: vi.fn() }));
+vi.mock('../../services/softwarePolicyService', () => ({ recordSoftwarePolicyAudit: vi.fn() }));
+vi.mock('../../services/commandQueue', () => ({
+  queueCommandForExecution: vi.fn().mockResolvedValue({ command: { id: 'resume-1' } }),
+}));
+vi.mock('../../services/filesystemAnalysis', () => ({
+  getFilesystemScanState: vi.fn(),
+  mergeFilesystemAnalysisPayload: vi.fn(),
+  parseFilesystemAnalysisStdout: vi.fn(),
+  readCheckpointPendingDirectories: vi.fn(),
+  readHotDirectories: vi.fn(() => []),
+  saveFilesystemSnapshot: vi.fn(),
+  upsertFilesystemScanState: vi.fn(),
+}));
+vi.mock('../../services/cloudflareMtls', () => ({ CloudflareMtlsService: vi.fn() }));
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../metrics', () => ({ recordSoftwareRemediationDecision: vi.fn() }));
+
+import { handleFilesystemAnalysisCommandResult } from './helpers';
+import {
+  getFilesystemScanState,
+  mergeFilesystemAnalysisPayload,
+  parseFilesystemAnalysisStdout,
+  readCheckpointPendingDirectories,
+  saveFilesystemSnapshot,
+  upsertFilesystemScanState,
+} from '../../services/filesystemAnalysis';
+
+const DEVICE_ID = '00000000-0000-4000-8000-000000000001';
+const ORG_ID = '00000000-0000-4000-8000-0000000000aa';
+
+function baselineCommand() {
+  return {
+    id: '00000000-0000-4000-8000-0000000000cc',
+    deviceId: DEVICE_ID,
+    payload: { scanMode: 'baseline', trigger: 'on_demand', autoContinue: true, resumeAttempt: 0 },
+    createdBy: null,
+  } as never;
+}
+
+function result(): z.infer<typeof commandResultSchema> {
+  return { commandId: 'c', status: 'completed', exitCode: 0, stdout: '{"x":1}' } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectQueue.length = 0;
+  vi.mocked(parseFilesystemAnalysisStdout).mockReturnValue({ ok: true });
+  vi.mocked(getFilesystemScanState).mockResolvedValue(null as never);
+});
+
+describe('handleFilesystemAnalysisCommandResult — baseline completion', () => {
+  it('marks a partial (max-depth) baseline complete when no checkpoint dirs remain', async () => {
+    // The headline fix: a snapshot flagged partial=true (routine max-depth
+    // truncation) must NOT block completion — only pending checkpoint dirs do.
+    vi.mocked(mergeFilesystemAnalysisPayload).mockReturnValue({ partial: true, scanMode: 'baseline' });
+    vi.mocked(readCheckpointPendingDirectories).mockReturnValue([]);
+    selectQueue.push([{ usedPercent: 42 }]); // deviceDisks read
+
+    await handleFilesystemAnalysisCommandResult(baselineCommand(), result(), ORG_ID);
+
+    expect(upsertFilesystemScanState).toHaveBeenCalledTimes(1);
+    const [dev, org, updates] = vi.mocked(upsertFilesystemScanState).mock.calls[0];
+    expect(dev).toBe(DEVICE_ID);
+    expect(org).toBe(ORG_ID); // threaded, not re-queried
+    expect(updates.lastBaselineCompletedAt).toBeInstanceOf(Date);
+    expect(updates.aggregate).toEqual({}); // aggregate reset on completion
+  });
+
+  it('does NOT mark complete while checkpoint dirs are still pending', async () => {
+    vi.mocked(mergeFilesystemAnalysisPayload).mockReturnValue({ partial: true, scanMode: 'baseline' });
+    vi.mocked(readCheckpointPendingDirectories).mockReturnValue([{ path: '/a', depth: 1 }]);
+    selectQueue.push([{ usedPercent: 42 }]); // deviceDisks read
+    selectQueue.push([]); // no in-flight resume scan
+
+    await handleFilesystemAnalysisCommandResult(baselineCommand(), result(), ORG_ID);
+
+    const [, , updates] = vi.mocked(upsertFilesystemScanState).mock.calls[0];
+    expect(updates.lastBaselineCompletedAt).toBeNull();
+    expect(updates.aggregate).not.toEqual({}); // aggregate retained for resume
+  });
+
+  it('threads the caller orgId into the snapshot write (no device re-query)', async () => {
+    vi.mocked(mergeFilesystemAnalysisPayload).mockReturnValue({ scanMode: 'baseline' });
+    vi.mocked(readCheckpointPendingDirectories).mockReturnValue([]);
+    selectQueue.push([{ usedPercent: 10 }]);
+
+    await handleFilesystemAnalysisCommandResult(baselineCommand(), result(), ORG_ID);
+
+    expect(saveFilesystemSnapshot).toHaveBeenCalledWith(DEVICE_ID, ORG_ID, 'on_demand', expect.any(Object));
+  });
+
+  it('drops a non-completed result without writing anything', async () => {
+    await handleFilesystemAnalysisCommandResult(
+      baselineCommand(),
+      { commandId: 'c', status: 'failed', exitCode: 1 } as never,
+      ORG_ID,
+    );
+    expect(saveFilesystemSnapshot).not.toHaveBeenCalled();
+    expect(upsertFilesystemScanState).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/agents/helpers.filesystemAnalysis.test.ts
+++ b/apps/api/src/routes/agents/helpers.filesystemAnalysis.test.ts
@@ -111,7 +111,9 @@ describe('handleFilesystemAnalysisCommandResult — baseline completion', () => 
     await handleFilesystemAnalysisCommandResult(baselineCommand(), result(), ORG_ID);
 
     expect(upsertFilesystemScanState).toHaveBeenCalledTimes(1);
-    const [dev, org, updates] = vi.mocked(upsertFilesystemScanState).mock.calls[0];
+    const call = vi.mocked(upsertFilesystemScanState).mock.calls[0];
+    expect(call).toBeDefined();
+    const [dev, org, updates] = call!;
     expect(dev).toBe(DEVICE_ID);
     expect(org).toBe(ORG_ID); // threaded, not re-queried
     expect(updates.lastBaselineCompletedAt).toBeInstanceOf(Date);
@@ -126,7 +128,9 @@ describe('handleFilesystemAnalysisCommandResult — baseline completion', () => 
 
     await handleFilesystemAnalysisCommandResult(baselineCommand(), result(), ORG_ID);
 
-    const [, , updates] = vi.mocked(upsertFilesystemScanState).mock.calls[0];
+    const call = vi.mocked(upsertFilesystemScanState).mock.calls[0];
+    expect(call).toBeDefined();
+    const updates = call![2];
     expect(updates.lastBaselineCompletedAt).toBeNull();
     expect(updates.aggregate).not.toEqual({}); // aggregate retained for resume
   });

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -1536,7 +1536,8 @@ export async function maybeQueueThresholdFilesystemAnalysis(
 
 export async function handleFilesystemAnalysisCommandResult(
   command: typeof deviceCommands.$inferSelect,
-  resultData: z.infer<typeof commandResultSchema>
+  resultData: z.infer<typeof commandResultSchema>,
+  orgId: string
 ): Promise<void> {
   if (resultData.status !== 'completed') {
     return;
@@ -1557,19 +1558,22 @@ export async function handleFilesystemAnalysisCommandResult(
     return;
   }
 
-  const [device] = await db
-    .select({ orgId: devices.orgId })
-    .from(devices)
-    .where(eq(devices.id, command.deviceId))
-    .limit(1);
-  if (!device) {
-    console.warn(
-      `[agents/helpers] filesystem_analysis command ${command.id}: device ${command.deviceId} not found; no snapshot written`
-    );
-    return;
-  }
+  // orgId comes from the caller's agent-auth context, which already resolved
+  // the device's org — no need to re-query devices here.
 
-  const currentState = await getFilesystemScanState(command.deviceId);
+  // The scan-state read and the disk-usage read are independent; run them
+  // together. The disk figure is only consumed by the scan-state upsert below.
+  const [currentState, diskRows] = await Promise.all([
+    getFilesystemScanState(command.deviceId),
+    db
+      .select({ usedPercent: deviceDisks.usedPercent })
+      .from(deviceDisks)
+      .where(eq(deviceDisks.deviceId, command.deviceId))
+      .limit(1),
+  ]);
+  const currentDiskUsedPercent =
+    typeof diskRows[0]?.usedPercent === 'number' ? diskRows[0].usedPercent : null;
+
   const existingAggregate = isObject(currentState?.aggregate) ? currentState.aggregate : {};
   const mergedPayload = scanMode === 'baseline'
     ? mergeFilesystemAnalysisPayload(existingAggregate, parsed)
@@ -1589,14 +1593,7 @@ export async function handleFilesystemAnalysisCommandResult(
       scanMode,
     };
 
-  await saveFilesystemSnapshot(command.deviceId, device.orgId, snapshotTrigger, snapshotPayload);
-
-  const [disk] = await db
-    .select({ usedPercent: deviceDisks.usedPercent })
-    .from(deviceDisks)
-    .where(eq(deviceDisks.deviceId, command.deviceId))
-    .limit(1);
-  const currentDiskUsedPercent = typeof disk?.usedPercent === 'number' ? disk.usedPercent : null;
+  await saveFilesystemSnapshot(command.deviceId, orgId, snapshotTrigger, snapshotPayload);
 
   const hotFromRun = extractHotDirectoriesFromSnapshotPayload(snapshotPayload, 24);
   const mergedHotDirectories = Array.from(
@@ -1606,9 +1603,15 @@ export async function handleFilesystemAnalysisCommandResult(
     ])
   ).slice(0, 24);
 
-  const snapshotIsPartial = 'partial' in snapshotPayload ? Boolean(snapshotPayload.partial) : false;
-  const baselineCompleted = scanMode === 'baseline' && pendingDirs.length === 0 && !snapshotIsPartial;
-  await upsertFilesystemScanState(command.deviceId, device.orgId, {
+  // Baseline completion is defined solely by having no pending checkpoint
+  // directories left to resume. The snapshot's `partial` flag must NOT gate
+  // this: `partial` is also set (and stays sticky across merges) for routine
+  // max-depth truncation, which is not a resumable condition — folding it in
+  // here left `lastBaselineCompletedAt` permanently null on any deep tree, which
+  // forced every subsequent scan back to a full baseline and defeated the
+  // incremental hot-directory path.
+  const baselineCompleted = scanMode === 'baseline' && pendingDirs.length === 0;
+  await upsertFilesystemScanState(command.deviceId, orgId, {
     lastRunMode: scanMode,
     lastBaselineCompletedAt: baselineCompleted
       ? new Date()

--- a/apps/api/src/routes/devices/filesystem.test.ts
+++ b/apps/api/src/routes/devices/filesystem.test.ts
@@ -291,6 +291,60 @@ describe('device filesystem routes', () => {
     expect(res.status).toBe(404);
   });
 
+  it('rejects a path not in the pinned run and never deletes it', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: deviceId, orgId: 'org-123', hostname: 'host-1' } as never);
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ plan: { preview: { candidates: [] } } }]),
+        }),
+      }),
+    } as never);
+    // Pinned run only previewed /tmp/a.tmp; the caller asks to delete a path
+    // that was never previewed — it must not widen the deletion set.
+    vi.mocked(readPlanPreviewCandidates).mockReturnValue([
+      { path: '/tmp/a.tmp', category: 'temp_files', sizeBytes: 4096, safe: true },
+    ] as never);
+
+    const res = await app.request(`/devices/${deviceId}/filesystem/cleanup-execute`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        paths: ['/tmp/EVIL.tmp'],
+        cleanupRunId: '22222222-2222-2222-2222-222222222222',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('returns a distinct 400 when the pinned run has no previewable candidates', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: deviceId, orgId: 'org-123', hostname: 'host-1' } as never);
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ plan: { requestedPaths: [] } }]),
+        }),
+      }),
+    } as never);
+    vi.mocked(readPlanPreviewCandidates).mockReturnValue([] as never);
+
+    const res = await app.request(`/devices/${deviceId}/filesystem/cleanup-execute`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        paths: ['/tmp/a.tmp'],
+        cleanupRunId: '22222222-2222-2222-2222-222222222222',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('Pinned cleanup run has no previewable candidates');
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
   it('denies filesystem read when site scope excludes the device', async () => {
     vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SITE_ACCESS_DENIED as never);
 

--- a/apps/api/src/routes/devices/filesystem.test.ts
+++ b/apps/api/src/routes/devices/filesystem.test.ts
@@ -18,6 +18,8 @@ vi.mock('../../db/schema', () => ({
   },
   deviceFilesystemCleanupRuns: {
     id: 'id',
+    deviceId: 'deviceId',
+    plan: 'plan',
   },
 }));
 
@@ -60,6 +62,8 @@ vi.mock('../../services/filesystemAnalysis', () => ({
   parseFilesystemAnalysisStdout: vi.fn(),
   saveFilesystemSnapshot: vi.fn(),
   buildCleanupPreview: vi.fn(),
+  getLatestFilesystemCleanupSnapshot: vi.fn(),
+  readPlanPreviewCandidates: vi.fn(() => []),
   safeCleanupCategories: ['temp_files', 'browser_cache', 'package_cache', 'trash']
 }));
 
@@ -73,10 +77,12 @@ import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
 import { executeCommand, queueCommandForExecution } from '../../services/commandQueue';
 import {
   getLatestFilesystemSnapshot,
+  getLatestFilesystemCleanupSnapshot,
   getFilesystemScanState,
   readHotDirectories,
   readCheckpointPendingDirectories,
   buildCleanupPreview,
+  readPlanPreviewCandidates,
 } from '../../services/filesystemAnalysis';
 
 describe('device filesystem routes', () => {
@@ -158,7 +164,7 @@ describe('device filesystem routes', () => {
 
   it('returns cleanup preview and stores run', async () => {
     vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: deviceId, orgId: 'org-123', hostname: 'host-1' } as never);
-    vi.mocked(getLatestFilesystemSnapshot).mockResolvedValue({ id: 'snap-3', cleanupCandidates: [] } as never);
+    vi.mocked(getLatestFilesystemCleanupSnapshot).mockResolvedValue({ id: 'snap-3', cleanupCandidates: [] } as never);
     vi.mocked(buildCleanupPreview).mockReturnValue({
       snapshotId: 'snap-3',
       estimatedBytes: 4096,
@@ -187,7 +193,7 @@ describe('device filesystem routes', () => {
 
   it('executes cleanup only for selected valid candidates', async () => {
     vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: deviceId, orgId: 'org-123', hostname: 'host-1' } as never);
-    vi.mocked(getLatestFilesystemSnapshot).mockResolvedValue({ id: 'snap-4', cleanupCandidates: [] } as never);
+    vi.mocked(getLatestFilesystemCleanupSnapshot).mockResolvedValue({ id: 'snap-4', cleanupCandidates: [] } as never);
     vi.mocked(buildCleanupPreview).mockReturnValue({
       snapshotId: 'snap-4',
       estimatedBytes: 8192,
@@ -224,6 +230,65 @@ describe('device filesystem routes', () => {
       { path: '/tmp/a.tmp', recursive: true },
       expect.objectContaining({ userId: 'user-123' })
     );
+  });
+
+  it('pins cleanup-execute to the previewed run when cleanupRunId is provided', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: deviceId, orgId: 'org-123', hostname: 'host-1' } as never);
+    // db.select resolves the pinned cleanup run's stored plan.
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ plan: { preview: { candidates: [] } } }]),
+        }),
+      }),
+    } as never);
+    vi.mocked(readPlanPreviewCandidates).mockReturnValue([
+      { path: '/tmp/a.tmp', category: 'temp_files', sizeBytes: 4096, safe: true },
+    ] as never);
+    vi.mocked(executeCommand).mockResolvedValue({ status: 'completed' } as never);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'run-9' }]),
+      }),
+    } as never);
+
+    const res = await app.request(`/devices/${deviceId}/filesystem/cleanup-execute`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        paths: ['/tmp/a.tmp'],
+        cleanupRunId: '22222222-2222-2222-2222-222222222222',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.bytesReclaimed).toBe(4096);
+    // The pinned path uses the stored run, not the latest snapshot.
+    expect(readPlanPreviewCandidates).toHaveBeenCalled();
+    expect(getLatestFilesystemCleanupSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when cleanupRunId does not resolve to a run', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: deviceId, orgId: 'org-123', hostname: 'host-1' } as never);
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    } as never);
+
+    const res = await app.request(`/devices/${deviceId}/filesystem/cleanup-execute`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        paths: ['/tmp/a.tmp'],
+        cleanupRunId: '22222222-2222-2222-2222-222222222222',
+      }),
+    });
+
+    expect(res.status).toBe(404);
   });
 
   it('denies filesystem read when site scope excludes the device', async () => {

--- a/apps/api/src/routes/devices/filesystem.ts
+++ b/apps/api/src/routes/devices/filesystem.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { deviceDisks, deviceFilesystemCleanupRuns } from '../../db/schema';
 import { authMiddleware, requireMfa, requireScope, requirePermission } from '../../middleware/auth';
@@ -11,9 +11,12 @@ import {
   buildCleanupPreview,
   getFilesystemScanState,
   getLatestFilesystemSnapshot,
+  getLatestFilesystemCleanupSnapshot,
   readCheckpointPendingDirectories,
   readHotDirectories,
+  readPlanPreviewCandidates,
   safeCleanupCategories,
+  type FilesystemCleanupCandidate,
 } from '../../services/filesystemAnalysis';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
@@ -44,6 +47,10 @@ const cleanupPreviewBodySchema = z.object({
 
 const cleanupExecuteBodySchema = z.object({
   paths: z.array(z.string().min(1).max(4096)).min(1).max(200),
+  // When set, the selection is validated against the exact candidate set the
+  // user previewed in this cleanup run, rather than re-derived from whatever
+  // snapshot is now latest (which may have changed between preview and execute).
+  cleanupRunId: z.string().guid().optional(),
 });
 
 function readSnapshotReason(snapshot: { rawPayload?: unknown } | null | undefined): string | null {
@@ -274,7 +281,7 @@ filesystemRoutes.post(
       return c.json({ error: 'Device not found' }, 404);
     }
 
-    const snapshot = await getLatestFilesystemSnapshot(deviceId);
+    const snapshot = await getLatestFilesystemCleanupSnapshot(deviceId);
     if (!snapshot) {
       return c.json({ error: 'No filesystem snapshot available. Run a scan first.' }, 404);
     }
@@ -329,7 +336,7 @@ filesystemRoutes.post(
   async (c) => {
     const auth = c.get('auth');
     const { id: deviceId } = c.req.valid('param');
-    const { paths } = c.req.valid('json');
+    const { paths, cleanupRunId } = c.req.valid('json');
 
     const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
     if (device === SITE_ACCESS_DENIED) {
@@ -339,13 +346,34 @@ filesystemRoutes.post(
       return c.json({ error: 'Device not found' }, 404);
     }
 
-    const snapshot = await getLatestFilesystemSnapshot(deviceId);
-    if (!snapshot) {
-      return c.json({ error: 'No filesystem snapshot available. Run a scan first.' }, 404);
+    // Resolve the authoritative candidate set. When the caller pins a cleanup
+    // run, use exactly the candidates it previewed; otherwise fall back to the
+    // latest snapshot's safe candidates.
+    let candidates: FilesystemCleanupCandidate[];
+    let sourceSnapshotId: string | null = null;
+    if (cleanupRunId) {
+      const [run] = await db
+        .select({ plan: deviceFilesystemCleanupRuns.plan })
+        .from(deviceFilesystemCleanupRuns)
+        .where(and(
+          eq(deviceFilesystemCleanupRuns.id, cleanupRunId),
+          eq(deviceFilesystemCleanupRuns.deviceId, deviceId),
+        ))
+        .limit(1);
+      if (!run) {
+        return c.json({ error: 'Cleanup run not found' }, 404);
+      }
+      candidates = readPlanPreviewCandidates(run.plan);
+    } else {
+      const snapshot = await getLatestFilesystemCleanupSnapshot(deviceId);
+      if (!snapshot) {
+        return c.json({ error: 'No filesystem snapshot available. Run a scan first.' }, 404);
+      }
+      sourceSnapshotId = snapshot.id;
+      candidates = buildCleanupPreview(snapshot).candidates;
     }
 
-    const preview = buildCleanupPreview(snapshot);
-    const byPath = new Map(preview.candidates.map((candidate) => [candidate.path, candidate]));
+    const byPath = new Map(candidates.map((candidate) => [candidate.path, candidate]));
     const requested = Array.from(new Set(paths));
     const selected = requested
       .map((path) => byPath.get(path))
@@ -390,7 +418,8 @@ filesystemRoutes.post(
         requestedBy: auth.user.id,
         approvedAt: new Date(),
         plan: {
-          snapshotId: snapshot.id,
+          snapshotId: sourceSnapshotId,
+          sourceCleanupRunId: cleanupRunId ?? null,
           requestedPaths: requested,
           selectedPaths: selected.map((candidate) => candidate.path),
         },

--- a/apps/api/src/routes/devices/filesystem.ts
+++ b/apps/api/src/routes/devices/filesystem.ts
@@ -364,6 +364,14 @@ filesystemRoutes.post(
         return c.json({ error: 'Cleanup run not found' }, 404);
       }
       candidates = readPlanPreviewCandidates(run.plan);
+      if (candidates.length === 0) {
+        // Distinct from the path-mismatch 400 below: the pinned run itself has
+        // no previewable candidates (e.g. it is an already-executed run, or its
+        // stored preview is missing/corrupt), so no selection could ever match.
+        return c.json({
+          error: 'Pinned cleanup run has no previewable candidates (it may already be executed or its preview is unavailable). Re-run the cleanup preview.',
+        }, 400);
+      }
     } else {
       const snapshot = await getLatestFilesystemCleanupSnapshot(deviceId);
       if (!snapshot) {

--- a/apps/api/src/services/aiToolsFilesystem.ts
+++ b/apps/api/src/services/aiToolsFilesystem.ts
@@ -19,6 +19,7 @@ import { AGENT_MAX_FILE_WRITE_BYTES } from '../routes/systemTools/schemas';
 import {
   buildCleanupPreview,
   getLatestFilesystemSnapshot,
+  getLatestFilesystemCleanupSnapshot,
   parseFilesystemAnalysisStdout,
   saveFilesystemSnapshot,
   safeCleanupCategories,
@@ -249,7 +250,7 @@ export function registerFilesystemTools(aiTools: Map<string, AiTool>): void {
       const access = await verifyDeviceAccess(deviceId, auth, action === 'execute');
       if ('error' in access) return JSON.stringify({ error: access.error });
 
-      const snapshot = await getLatestFilesystemSnapshot(deviceId);
+      const snapshot = await getLatestFilesystemCleanupSnapshot(deviceId);
       if (!snapshot) {
         return JSON.stringify({ message: 'No filesystem analysis snapshot available. Run analyze_disk_usage with refresh=true first.' });
       }

--- a/apps/api/src/services/filesystemAnalysis.test.ts
+++ b/apps/api/src/services/filesystemAnalysis.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { buildCleanupPreview, readPlanPreviewCandidates } from './filesystemAnalysis';
+import {
+  buildCleanupPreview,
+  mergeFilesystemAnalysisPayload,
+  readPlanPreviewCandidates,
+} from './filesystemAnalysis';
 
 describe('filesystemAnalysis service', () => {
   it('builds safe cleanup preview from snapshot candidates', () => {
@@ -60,6 +64,27 @@ describe('filesystemAnalysis service', () => {
       expect(readPlanPreviewCandidates({})).toEqual([]);
       expect(readPlanPreviewCandidates({ preview: {} })).toEqual([]);
       expect(readPlanPreviewCandidates({ preview: { candidates: 'nope' } })).toEqual([]);
+    });
+  });
+
+  describe('mergeFilesystemAnalysisPayload — checkpoint is the current run, not accumulated', () => {
+    it('clears a stale checkpoint when the completing run omits it', () => {
+      // Prior run left a checkpoint in the aggregate; the completing resume run
+      // omits checkpoint (Go omitempty). The merged payload must NOT inherit the
+      // stale pending dirs, or the baseline could never register as complete.
+      const existing = { checkpoint: { pendingDirs: [{ path: '/a', depth: 1 }] } };
+      const incoming = { summary: { filesScanned: 5 } }; // no checkpoint key
+
+      const merged = mergeFilesystemAnalysisPayload(existing, incoming);
+      expect(merged.checkpoint).toEqual({});
+    });
+
+    it('carries the incoming run checkpoint through', () => {
+      const existing = {};
+      const incoming = { checkpoint: { pendingDirs: [{ path: '/b', depth: 2 }] } };
+
+      const merged = mergeFilesystemAnalysisPayload(existing, incoming);
+      expect(merged.checkpoint).toEqual({ pendingDirs: [{ path: '/b', depth: 2 }] });
     });
   });
 });

--- a/apps/api/src/services/filesystemAnalysis.test.ts
+++ b/apps/api/src/services/filesystemAnalysis.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildCleanupPreview } from './filesystemAnalysis';
+import { buildCleanupPreview, readPlanPreviewCandidates } from './filesystemAnalysis';
 
 describe('filesystemAnalysis service', () => {
   it('builds safe cleanup preview from snapshot candidates', () => {
@@ -36,5 +36,30 @@ describe('filesystemAnalysis service', () => {
     expect(preview.candidateCount).toBe(1);
     expect(preview.estimatedBytes).toBe(100);
     expect(preview.candidates[0]?.category).toBe('temp_files');
+  });
+
+  describe('readPlanPreviewCandidates', () => {
+    it('extracts only safe candidates in known categories from a stored plan', () => {
+      const plan = {
+        preview: {
+          candidates: [
+            { path: '/tmp/a.tmp', category: 'temp_files', sizeBytes: 100, safe: true },
+            { path: '/unsafe/c.log', category: 'logs', sizeBytes: 999, safe: true },
+            { path: '/tmp/d.tmp', category: 'temp_files', sizeBytes: 50, safe: false },
+          ],
+        },
+      };
+
+      const candidates = readPlanPreviewCandidates(plan);
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]?.path).toBe('/tmp/a.tmp');
+    });
+
+    it('returns [] for malformed or empty plans', () => {
+      expect(readPlanPreviewCandidates(null)).toEqual([]);
+      expect(readPlanPreviewCandidates({})).toEqual([]);
+      expect(readPlanPreviewCandidates({ preview: {} })).toEqual([]);
+      expect(readPlanPreviewCandidates({ preview: { candidates: 'nope' } })).toEqual([]);
+    });
   });
 });

--- a/apps/api/src/services/filesystemAnalysis.ts
+++ b/apps/api/src/services/filesystemAnalysis.ts
@@ -272,6 +272,11 @@ export function mergeFilesystemAnalysisPayload(existing: AnyObject, incoming: An
     path: asString(incoming.path) ?? asString(existing.path),
     partial: asBoolean(existing.partial, false) || asBoolean(incoming.partial, false),
     reason: asString(incoming.reason) ?? asString(existing.reason),
+    // The checkpoint is the resume frontier of the CURRENT run, not something to
+    // accumulate. A completed run omits it (Go `omitempty` on an empty map); the
+    // `...existing` spread would otherwise inherit the previous run's stale
+    // pending dirs, so a resumed baseline could never register as complete.
+    checkpoint: asRecord(incoming.checkpoint) ?? {},
     summary: {
       filesScanned: asNumber(existingSummary.filesScanned, 0) + asNumber(incomingSummary.filesScanned, 0),
       dirsScanned: asNumber(existingSummary.dirsScanned, 0) + asNumber(incomingSummary.dirsScanned, 0),

--- a/apps/api/src/services/filesystemAnalysis.ts
+++ b/apps/api/src/services/filesystemAnalysis.ts
@@ -104,6 +104,26 @@ export async function getLatestFilesystemSnapshot(deviceId: string) {
   return snapshot ?? null;
 }
 
+/**
+ * Slim variant for the cleanup preview/execute paths, which only need the
+ * snapshot id and its cleanup candidates. Avoids transferring and deserializing
+ * the full set of large jsonb columns (largest files/dirs, duplicates, the
+ * duplicate rawPayload blob, etc.) that those callers never read.
+ */
+export async function getLatestFilesystemCleanupSnapshot(deviceId: string) {
+  const [snapshot] = await db
+    .select({
+      id: deviceFilesystemSnapshots.id,
+      cleanupCandidates: deviceFilesystemSnapshots.cleanupCandidates,
+    })
+    .from(deviceFilesystemSnapshots)
+    .where(eq(deviceFilesystemSnapshots.deviceId, deviceId))
+    .orderBy(desc(deviceFilesystemSnapshots.capturedAt))
+    .limit(1);
+
+  return snapshot ?? null;
+}
+
 export async function getFilesystemScanState(deviceId: string) {
   const [state] = await db
     .select()
@@ -349,3 +369,18 @@ export function buildCleanupPreview(
 }
 
 export const safeCleanupCategories = Array.from(SAFE_CLEANUP_CATEGORIES);
+
+/**
+ * Extracts the previewed cleanup candidates from a stored cleanup-run `plan`
+ * (jsonb). Used by cleanup-execute to pin deletions to exactly what the user
+ * previewed. Only safe candidates in known-safe categories are returned, so a
+ * stale or hand-edited plan can never widen the deletion set.
+ */
+export function readPlanPreviewCandidates(plan: unknown): FilesystemCleanupCandidate[] {
+  const planRecord = asRecord(plan);
+  const preview = asRecord(planRecord?.preview);
+  return asArray(preview?.candidates)
+    .map(toCleanupCandidate)
+    .filter((candidate): candidate is FilesystemCleanupCandidate => candidate !== null)
+    .filter((candidate) => candidate.safe && SAFE_CLEANUP_CATEGORIES.has(candidate.category));
+}

--- a/apps/web/src/components/devices/DeviceFilesystemTab.tsx
+++ b/apps/web/src/components/devices/DeviceFilesystemTab.tsx
@@ -352,6 +352,10 @@ export default function DeviceFilesystemTab({
   const pollScanCommand = useCallback(
     async (commandId: string, timeoutMs: number) => {
       const startedAt = Date.now();
+      // Back off between status polls (2s → 10s) rather than hammering a fixed
+      // 2s for the whole scan window; a baseline scan can run for minutes.
+      let delayMs = 2000;
+      const maxDelayMs = 10000;
 
       while (Date.now() - startedAt < timeoutMs) {
         const response = await fetchWithAuth(
@@ -388,7 +392,8 @@ export default function DeviceFilesystemTab({
           throw new Error(error);
         }
 
-        await new Promise((resolve) => setTimeout(resolve, 2000));
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        delayMs = Math.min(maxDelayMs, Math.round(delayMs * 1.5));
       }
 
       throw new Error(


### PR DESCRIPTION
## Summary

Optimizations to the BE-1 filesystem-analysis ingest and serve paths, plus a correctness fix that was the root cause of write amplification. Found during a review of the Disk Cleanup feature.

## Correctness (the headline)

**Baseline scans never completed on deep trees, defeating incremental scanning.** `baselineCompleted` was gated on the snapshot's `partial` flag. `partial` is also set — and stays sticky across merges (`existing.partial || incoming.partial`) — for routine **max-depth truncation**, which is not a resumable condition. So on any moderately deep filesystem, `lastBaselineCompletedAt` stayed `null` forever → every future scan was forced back to a full baseline instead of the cheap incremental hot-directory path, and the 200-chunk auto-resume budget was exercised each time (the write-amplification driver).

Fix: baseline completion is now defined solely by having **no pending checkpoint directories**. The snapshot still reports `partial` for display/estimation — the two concepts are decoupled.

## Ingest hot path (runs on every completed scan chunk, before the agent ACK)
- Thread the org id from the agent-auth context into `handleFilesystemAnalysisCommandResult` instead of re-querying `devices`.
- Run the independent scan-state and disk-usage reads concurrently.

## Serve path
- New `getLatestFilesystemCleanupSnapshot` — a slim `{id, cleanupCandidates}` select — used by cleanup-preview, cleanup-execute, and the `disk_cleanup` AI tool. Those 3 call sites never read the large jsonb columns (largest files/dirs, duplicates, the duplicate `rawPayload` blob) that the full `select()` pulled and deserialized.
- `cleanup-execute` accepts an optional `cleanupRunId`: when set, deletions are pinned to exactly the candidate set the user previewed (via `readPlanPreviewCandidates`, which re-filters to safe categories), instead of re-deriving from whatever snapshot is now latest. **Backward-compatible** — absent it, prior behavior stands.

## Web
- Back off the scan status poll (2s → 10s) instead of a fixed 2s across a multi-minute baseline scan (~150 → ~30 requests).

## Testing
- New service tests for `readPlanPreviewCandidates` (safe-filtering + malformed input).
- New route tests for the pinned `cleanup-execute` path (success + 404).
- Full API `tsc --noEmit` clean; affected suites (`filesystemAnalysis`, `filesystem` routes, `agents/commands`) green — 20/20.

## Deliberately NOT in this PR
- **`rawPayload` → dedicated columns** (`path`/`reason`/`scanMode`): the GET route parses `rawPayload` just to recover 3 scalars, forcing it to transfer the full duplicate blob. Promoting them to columns needs a migration on a prod table, and I couldn't run `db:check-drift` (no local Postgres), so I'm not shipping an unverified migration here. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)