### PR TITLE
fix(vulnerabilities): remediate third-party findings via product-identity fallback

### DIFF
--- a/apps/api/src/__tests__/integration/vulnerabilitiesRemediate.integration.test.ts
+++ b/apps/api/src/__tests__/integration/vulnerabilitiesRemediate.integration.test.ts
@@ -13,6 +13,8 @@ import {
   deviceVulnerabilities,
   patchApprovals,
   patches,
+  softwareInventory,
+  softwareProductResolutions,
   softwareProducts,
   softwareVulnerabilities,
   vulnerabilities,
@@ -59,6 +61,7 @@ beforeEach(async () => {
   await withSystemDbAccessContext(async () => {
     await db.delete(deviceVulnerabilities);
     await db.delete(softwareVulnerabilities);
+    await db.delete(softwareProductResolutions);
     await db.delete(softwareProducts);
     await db.delete(vulnerabilities);
     await db.delete(vulnerabilitySources);
@@ -103,13 +106,19 @@ async function seedVuln(cveId: string): Promise<string> {
   return row.id;
 }
 
-async function seedDeviceVuln(orgId: string, deviceId: string, vulnerabilityId: string): Promise<string> {
+async function seedDeviceVuln(
+  orgId: string,
+  deviceId: string,
+  vulnerabilityId: string,
+  softwareInventoryId?: string,
+): Promise<string> {
   const [row] = await getTestDb()
     .insert(deviceVulnerabilities)
     .values({
       orgId,
       deviceId,
       vulnerabilityId,
+      softwareInventoryId: softwareInventoryId ?? null,
       status: 'open',
       riskScore: '100.00',
       detectedAt: new Date('2026-06-23T12:00:00Z'),
@@ -158,6 +167,106 @@ async function seedRemediableDeviceVuln(opts: { cveId: string; approved?: boolea
       partnerId: env.partner.id,
       patchId: patch.id,
       status: 'approved',
+    });
+  }
+
+  return { env, orgId: env.organization.id, deviceId, dvId };
+}
+
+/**
+ * Third-party finding shape: the finding is tied to an installed-software row
+ * and the device has a pending winget-style patch for the same product that
+ * does NOT advertise the CVE (cveIds empty — the production norm, since only
+ * OSV-enriched catalog packages ever get cveIds). Remediation must fall back
+ * to product-identity matching.
+ */
+async function seedThirdPartyFinding(opts: {
+  cveId: string;
+  patchTitle?: string;
+  patchVersion?: string;
+  extraPatch?: { title: string; packageId: string };
+  vulnerableRange?: { versionEndExcluding: string };
+  approved?: boolean;
+}): Promise<{ env: TestEnvironment; orgId: string; deviceId: string; dvId: string }> {
+  const env = await setupTestEnvironment({ scope: 'organization' });
+  const deviceId = await seedDevice(env);
+  const vulnerabilityId = await seedVuln(opts.cveId);
+
+  const [inv] = await getTestDb()
+    .insert(softwareInventory)
+    .values({
+      deviceId,
+      orgId: env.organization.id,
+      name: 'Mozilla Firefox (x64 en-US)',
+      version: '128.0',
+      vendor: 'Mozilla',
+    })
+    .returning({ id: softwareInventory.id });
+  if (!inv) throw new Error('failed to seed software inventory');
+
+  const dvId = await seedDeviceVuln(env.organization.id, deviceId, vulnerabilityId, inv.id);
+
+  const patchRows: Array<{ title: string; packageId: string }> = [
+    { title: opts.patchTitle ?? 'Mozilla Firefox', packageId: 'Mozilla.Firefox' },
+    ...(opts.extraPatch ? [opts.extraPatch] : []),
+  ];
+  for (const p of patchRows) {
+    const [patch] = await getTestDb()
+      .insert(patches)
+      .values({
+        source: 'third_party',
+        externalId: uniq(p.packageId),
+        title: p.title,
+        packageId: p.packageId,
+        version: opts.patchVersion ?? '129.0',
+        severity: 'unknown',
+        supersededBy: null,
+        releaseDate: '2026-07-01',
+      })
+      .returning({ id: patches.id });
+    if (!patch) throw new Error('failed to seed third-party patch');
+
+    await getTestDb().insert(devicePatches).values({
+      deviceId,
+      orgId: env.organization.id,
+      patchId: patch.id,
+      status: 'pending',
+    });
+
+    if (opts.approved !== false) {
+      await getTestDb().insert(patchApprovals).values({
+        partnerId: env.partner.id,
+        patchId: patch.id,
+        status: 'approved',
+      });
+    }
+  }
+
+  if (opts.vulnerableRange) {
+    const [product] = await getTestDb()
+      .insert(softwareProducts)
+      .values({
+        normalizedName: 'mozilla firefox',
+        normalizedVendor: 'mozilla',
+        cpe: 'cpe:2.3:a:mozilla:firefox',
+        cpeConfidence: 'curated',
+      })
+      .returning({ id: softwareProducts.id });
+    if (!product) throw new Error('failed to seed software product');
+    await getTestDb().insert(softwareProductResolutions).values({
+      lookupName: 'mozilla firefox (x64 en-us)',
+      lookupVendor: 'mozilla',
+      normalizedName: 'mozilla firefox',
+      softwareProductId: product.id,
+      confidence: 'curated',
+      matchedVia: 'curated',
+      resolverVersion: 1,
+      resolvedAt: new Date('2026-07-01T00:00:00Z'),
+    });
+    await getTestDb().insert(softwareVulnerabilities).values({
+      productId: product.id,
+      vulnerabilityId,
+      versionEndExcluding: opts.vulnerableRange.versionEndExcluding,
     });
   }
 
@@ -227,6 +336,87 @@ describe('POST /api/v1/vulnerabilities/remediate', () => {
       body: JSON.stringify({ deviceVulnerabilityIds: [dvId] }),
     });
     expect(res.status).toBe(200);
+    const body = await res.json() as { scheduled: number; skipped: Array<{ reason: string }> };
+    expect(body.scheduled).toBe(0);
+    expect(body.skipped[0]!.reason).toBe('no_available_patch');
+  });
+
+  runDb('falls back to product matching for a third-party finding without cveIds', async () => {
+    const { env, deviceId, dvId } = await seedThirdPartyFinding({ cveId: 'CVE-2025-60001' });
+    const res = await buildApp().request('/api/v1/vulnerabilities/remediate', {
+      method: 'POST',
+      headers: await mfaHeaders(env),
+      body: JSON.stringify({ deviceVulnerabilityIds: [dvId] }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { scheduled: number; skipped: unknown[] };
+    expect(body.scheduled).toBe(1);
+    expect(body.skipped).toEqual([]);
+
+    const cmds = await getTestDb()
+      .select()
+      .from(deviceCommands)
+      .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.type, 'install_patches')));
+    expect(cmds.length).toBe(1);
+  });
+
+  runDb('keeps the approval gate on the third-party fallback path', async () => {
+    const { env, dvId } = await seedThirdPartyFinding({ cveId: 'CVE-2025-60002', approved: false });
+    const res = await buildApp().request('/api/v1/vulnerabilities/remediate', {
+      method: 'POST',
+      headers: await mfaHeaders(env),
+      body: JSON.stringify({ deviceVulnerabilityIds: [dvId] }),
+    });
+    const body = await res.json() as { scheduled: number; skipped: Array<{ reason: string }> };
+    expect(body.scheduled).toBe(0);
+    expect(body.skipped[0]!.reason).toBe('patch_not_approved');
+  });
+
+  runDb('skips a third-party fallback patch whose version is still vulnerable', async () => {
+    // Pending upgrade targets 129.0 but the CVE is only fixed in 130.0 —
+    // installing it cannot resolve the finding, so nothing is scheduled.
+    const { env, dvId } = await seedThirdPartyFinding({
+      cveId: 'CVE-2025-60003',
+      patchVersion: '129.0',
+      vulnerableRange: { versionEndExcluding: '130.0' },
+    });
+    const res = await buildApp().request('/api/v1/vulnerabilities/remediate', {
+      method: 'POST',
+      headers: await mfaHeaders(env),
+      body: JSON.stringify({ deviceVulnerabilityIds: [dvId] }),
+    });
+    const body = await res.json() as { scheduled: number; skipped: Array<{ reason: string }> };
+    expect(body.scheduled).toBe(0);
+    expect(body.skipped[0]!.reason).toBe('no_available_patch');
+  });
+
+  runDb('schedules a third-party fallback patch whose version clears the vulnerable range', async () => {
+    const { env, dvId } = await seedThirdPartyFinding({
+      cveId: 'CVE-2025-60004',
+      patchVersion: '130.0',
+      vulnerableRange: { versionEndExcluding: '130.0' },
+    });
+    const res = await buildApp().request('/api/v1/vulnerabilities/remediate', {
+      method: 'POST',
+      headers: await mfaHeaders(env),
+      body: JSON.stringify({ deviceVulnerabilityIds: [dvId] }),
+    });
+    const body = await res.json() as { scheduled: number; skipped: unknown[] };
+    expect(body.scheduled).toBe(1);
+  });
+
+  runDb('drops an ambiguous normalized title (two packageIds) instead of guessing', async () => {
+    const { env, dvId } = await seedThirdPartyFinding({
+      cveId: 'CVE-2025-60005',
+      // Same normalized name ("mozilla firefox") from a different packageId —
+      // the x64/x86-twin shape. Neither may be picked.
+      extraPatch: { title: 'Mozilla Firefox (x86)', packageId: 'Mozilla.Firefox.x86' },
+    });
+    const res = await buildApp().request('/api/v1/vulnerabilities/remediate', {
+      method: 'POST',
+      headers: await mfaHeaders(env),
+      body: JSON.stringify({ deviceVulnerabilityIds: [dvId] }),
+    });
     const body = await res.json() as { scheduled: number; skipped: Array<{ reason: string }> };
     expect(body.scheduled).toBe(0);
     expect(body.skipped[0]!.reason).toBe('no_available_patch');

--- a/apps/api/src/__tests__/integration/vulnerabilitiesRemediate.integration.test.ts
+++ b/apps/api/src/__tests__/integration/vulnerabilitiesRemediate.integration.test.ts
@@ -183,7 +183,10 @@ async function seedRemediableDeviceVuln(opts: { cveId: string; approved?: boolea
 async function seedThirdPartyFinding(opts: {
   cveId: string;
   patchTitle?: string;
+  patchPackageId?: string;
   patchVersion?: string;
+  invName?: string;
+  invVendor?: string;
   extraPatch?: { title: string; packageId: string };
   vulnerableRange?: { versionEndExcluding: string };
   approved?: boolean;
@@ -197,9 +200,9 @@ async function seedThirdPartyFinding(opts: {
     .values({
       deviceId,
       orgId: env.organization.id,
-      name: 'Mozilla Firefox (x64 en-US)',
+      name: opts.invName ?? 'Mozilla Firefox (x64 en-US)',
       version: '128.0',
-      vendor: 'Mozilla',
+      vendor: opts.invVendor ?? 'Mozilla',
     })
     .returning({ id: softwareInventory.id });
   if (!inv) throw new Error('failed to seed software inventory');
@@ -207,7 +210,7 @@ async function seedThirdPartyFinding(opts: {
   const dvId = await seedDeviceVuln(env.organization.id, deviceId, vulnerabilityId, inv.id);
 
   const patchRows: Array<{ title: string; packageId: string }> = [
-    { title: opts.patchTitle ?? 'Mozilla Firefox', packageId: 'Mozilla.Firefox' },
+    { title: opts.patchTitle ?? 'Mozilla Firefox', packageId: opts.patchPackageId ?? 'Mozilla.Firefox' },
     ...(opts.extraPatch ? [opts.extraPatch] : []),
   ];
   for (const p of patchRows) {
@@ -358,6 +361,63 @@ describe('POST /api/v1/vulnerabilities/remediate', () => {
       .from(deviceCommands)
       .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.type, 'install_patches')));
     expect(cmds.length).toBe(1);
+  });
+
+  runDb('matches a vendor-prefixed inventory name against a bare patch title when the packageId corroborates the vendor', async () => {
+    // Inventory "Mozilla Firefox" but the pending patch title is just "Firefox"
+    // (no vendor prefix), so the exact nameKey ("mozilla firefox") misses and
+    // the vendor-stripped key ("firefox") is tried. packageId "Mozilla.Firefox"
+    // names the same vendor, so the fallback fires. This is the branch the
+    // earlier fallback test never exercised (its title matched nameKey directly).
+    const { env, deviceId, dvId } = await seedThirdPartyFinding({
+      cveId: 'CVE-2025-60010',
+      invName: 'Mozilla Firefox',
+      invVendor: 'Mozilla',
+      patchTitle: 'Firefox',
+      patchPackageId: 'Mozilla.Firefox',
+    });
+    const res = await buildApp().request('/api/v1/vulnerabilities/remediate', {
+      method: 'POST',
+      headers: await mfaHeaders(env),
+      body: JSON.stringify({ deviceVulnerabilityIds: [dvId] }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { scheduled: number };
+    expect(body.scheduled).toBe(1);
+    const cmds = await getTestDb()
+      .select()
+      .from(deviceCommands)
+      .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.type, 'install_patches')));
+    expect(cmds.length).toBe(1);
+  });
+
+  runDb('refuses a vendor-stripped match against a different vendor\'s pending patch (no wrong-product install)', async () => {
+    // Inventory "Adobe Reader" (vendor Adobe) has no "adobe reader" patch, so the
+    // stripped key "reader" is tried. The only pending patch titled "Reader"
+    // belongs to a DIFFERENT product (packageId "Foxit.Reader"). Without vendor
+    // corroboration this would remediate Foxit's patch for the Adobe finding —
+    // the wrong product. The guard must decline instead.
+    const { env, deviceId, dvId } = await seedThirdPartyFinding({
+      cveId: 'CVE-2025-60011',
+      invName: 'Adobe Reader',
+      invVendor: 'Adobe',
+      patchTitle: 'Reader',
+      patchPackageId: 'Foxit.Reader',
+    });
+    const res = await buildApp().request('/api/v1/vulnerabilities/remediate', {
+      method: 'POST',
+      headers: await mfaHeaders(env),
+      body: JSON.stringify({ deviceVulnerabilityIds: [dvId] }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { scheduled: number; skipped: Array<{ reason: string }> };
+    expect(body.scheduled).toBe(0);
+    expect(body.skipped[0]!.reason).toBe('no_available_patch');
+    const cmds = await getTestDb()
+      .select()
+      .from(deviceCommands)
+      .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.type, 'install_patches')));
+    expect(cmds.length).toBe(0);
   });
 
   runDb('keeps the approval gate on the third-party fallback path', async () => {

--- a/apps/api/src/services/vulnerabilityRemediation.test.ts
+++ b/apps/api/src/services/vulnerabilityRemediation.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// The service opens a pooled connection at import; stub it so this pure-logic
+// unit test needs no database.
+vi.mock('../db', () => ({
+  db: {},
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+
+import { packageIdNamesVendor } from './vulnerabilityRemediation';
+
+describe('packageIdNamesVendor — vendor-stripped fallback corroboration', () => {
+  it('corroborates a winget packageId whose publisher is the inventory vendor', () => {
+    // "Mozilla Firefox" inventory, patch "Firefox" packageId "Mozilla.Firefox".
+    expect(packageIdNamesVendor('Mozilla.Firefox', 'mozilla')).toBe(true);
+  });
+
+  it('corroborates when the vendor is multi-word (leading token matches)', () => {
+    expect(packageIdNamesVendor('Mozilla.Firefox', 'mozilla corporation')).toBe(true);
+  });
+
+  it('refuses a packageId from a DIFFERENT vendor (the wrong-product case)', () => {
+    // "Adobe Reader" inventory would strip to "reader"; a pending "Foxit.Reader"
+    // patch normalizes to the same title but is a different product.
+    expect(packageIdNamesVendor('Foxit.Reader', 'adobe')).toBe(false);
+  });
+
+  it('does not match on the product token — only the vendor token counts', () => {
+    // "reader" appears in the packageId but the vendor "adobe" does not.
+    expect(packageIdNamesVendor('Foxit.Reader', 'adobe reader')).toBe(false);
+  });
+
+  it('requires a whole-word vendor match, not a substring', () => {
+    // vendor token "corp" must not match "corporate" inside a packageId.
+    expect(packageIdNamesVendor('Corporate.Tool', 'corp')).toBe(false);
+    expect(packageIdNamesVendor('Corp.Tool', 'corp')).toBe(true);
+  });
+
+  it('fails closed on an empty or missing packageId', () => {
+    expect(packageIdNamesVendor('', 'adobe')).toBe(false);
+    expect(packageIdNamesVendor(null, 'adobe')).toBe(false);
+    expect(packageIdNamesVendor(undefined, 'adobe')).toBe(false);
+  });
+
+  it('fails closed on an empty vendor', () => {
+    expect(packageIdNamesVendor('Mozilla.Firefox', '')).toBe(false);
+  });
+
+  it('handles apt-style and hyphenated packageIds', () => {
+    expect(packageIdNamesVendor('apt:openssl', 'openssl')).toBe(true);
+    expect(packageIdNamesVendor('apt:openssl', 'adobe')).toBe(false);
+  });
+});

--- a/apps/api/src/services/vulnerabilityRemediation.ts
+++ b/apps/api/src/services/vulnerabilityRemediation.ts
@@ -86,6 +86,25 @@ async function vulnerableRangesForProduct(
 }
 
 /**
+ * True when a pending patch's `packageId` names the same vendor as the inventory
+ * row, corroborating a vendor-stripped name match. Gates the fallback so a
+ * generic stripped token (e.g. "reader" from "Adobe Reader") cannot pick an
+ * unrelated product's patch (e.g. "Foxit.Reader"). Compares the vendor's leading
+ * token against the normalized packageId as whole words; empty packageId or
+ * vendor never corroborates (fail closed).
+ */
+export function packageIdNamesVendor(
+  packageId: string | null | undefined,
+  vendorKey: string,
+): boolean {
+  const vendorToken = vendorKey.split(' ')[0];
+  if (!vendorToken) return false;
+  const pkgNorm = normalizeSoftwareName(packageId);
+  if (!pkgNorm) return false;
+  return ` ${pkgNorm} `.includes(` ${vendorToken} `);
+}
+
+/**
  * Fallback candidates for third-party findings. `patches.cveIds` is populated
  * only by the OSV enrichment worker (catalogued packages with `osvEcosystem`
  * set), so winget/Homebrew patch rows almost never advertise a CVE and the
@@ -154,14 +173,21 @@ async function thirdPartyCandidatesByProduct(
   // full name first, then with the vendor prefix stripped.
   const nameKey = normalizeSoftwareName(inv.name);
   const vendorKey = normalizeSoftwareName(inv.vendor);
-  const keys = [nameKey];
-  if (vendorKey && nameKey.startsWith(`${vendorKey} `)) keys.push(nameKey.slice(vendorKey.length + 1));
-  let matches: typeof pending = [];
-  for (const key of keys) {
-    const bucket = byKey.get(key);
-    if (bucket) {
+  let matches: typeof pending = byKey.get(nameKey) ?? [];
+  // Fallback: the registry DisplayName may carry a vendor prefix the enriched
+  // patch title lacks ("Mozilla Firefox ESR" vs "Firefox ESR"). Retry with the
+  // vendor prefix stripped — but ONLY when the matched patch's package identity
+  // names the same vendor. Without that check a generic stripped token
+  // ("reader", "client") could match an unrelated pending patch and remediate
+  // the WRONG product. Requiring vendor corroboration can only ever tighten the
+  // match (never broaden it beyond a same-vendor hit), so it cannot cause a
+  // wrong install — at worst the fallback declines to fire.
+  if (matches.length === 0 && vendorKey && nameKey.startsWith(`${vendorKey} `)) {
+    const bucket = byKey.get(nameKey.slice(vendorKey.length + 1));
+    // patches in a bucket share a packageId (differing ones are dropped as
+    // ambiguous above), so bucket[0] is representative.
+    if (bucket && packageIdNamesVendor(bucket[0]?.packageId, vendorKey)) {
       matches = bucket;
-      break;
     }
   }
 

--- a/apps/api/src/services/vulnerabilityRemediation.ts
+++ b/apps/api/src/services/vulnerabilityRemediation.ts
@@ -9,13 +9,18 @@ import {
   devices,
   patchApprovals,
   patches,
+  softwareInventory,
+  softwareProductResolutions,
+  softwareVulnerabilities,
   vulnerabilities,
 } from '../db/schema';
 import type { AuthContext } from '../middleware/auth';
+import { normalizeSoftwareName } from '../routes/devices/softwareUpdateMatch';
 import { resolvePartnerIdForOrg } from '../routes/patches/helpers';
 import { queueCommandForExecution } from './commandQueue';
 import { createAuditLogAsync } from './auditService';
 import { publishEvent } from './eventBus';
+import { isVersionInRange, type VersionRange } from './versionCompare';
 
 export type { RemediateResult };
 
@@ -42,6 +47,136 @@ async function approvedPatchIdsForPartner(partnerId: string, patchIds: string[])
     )
   );
   return new Set(rows.map((r) => r.patchId));
+}
+
+/**
+ * The CVE's known-vulnerable version ranges for the product an inventory row
+ * resolves to. `software_product_resolutions` / `software_vulnerabilities` are
+ * global system-only tables (same two-step as the catalog read in the main
+ * loop). The resolution join mirrors correlateOrg: SQL-reproducible cache key,
+ * IS NOT DISTINCT FROM for null vendors.
+ */
+async function vulnerableRangesForProduct(
+  name: string,
+  vendor: string | null,
+  vulnerabilityId: string,
+): Promise<VersionRange[]> {
+  const rows = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db
+        .select({
+          startIncluding: softwareVulnerabilities.versionStartIncluding,
+          startExcluding: softwareVulnerabilities.versionStartExcluding,
+          endIncluding: softwareVulnerabilities.versionEndIncluding,
+          endExcluding: softwareVulnerabilities.versionEndExcluding,
+        })
+        .from(softwareProductResolutions)
+        .innerJoin(
+          softwareVulnerabilities,
+          eq(softwareVulnerabilities.productId, softwareProductResolutions.softwareProductId)
+        )
+        .where(and(
+          sql`${softwareProductResolutions.lookupName} = lower(trim(${name}))`,
+          sql`${softwareProductResolutions.lookupVendor} IS NOT DISTINCT FROM lower(trim(${vendor}))`,
+          eq(softwareVulnerabilities.vulnerabilityId, vulnerabilityId),
+        ))
+    )
+  );
+  return rows.filter((r) => r.startIncluding || r.startExcluding || r.endIncluding || r.endExcluding);
+}
+
+/**
+ * Fallback candidates for third-party findings. `patches.cveIds` is populated
+ * only by the OSV enrichment worker (catalogued packages with `osvEcosystem`
+ * set), so winget/Homebrew patch rows almost never advertise a CVE and the
+ * CVE-array match in the main loop finds nothing — every third-party finding
+ * used to die as `no_available_patch` even with the fixing upgrade sitting
+ * pending on the device. When the finding is tied to an installed-software row,
+ * match the device's pending third-party patches to that product by normalized
+ * name instead — the same key the Software tab's "Update" annotation uses
+ * (softwareUpdateMatch.ts), with the same drop-ambiguous-keys rule.
+ */
+async function thirdPartyCandidatesByProduct(
+  deviceId: string,
+  softwareInventoryId: string,
+  vulnerabilityId: string,
+): Promise<Array<{ patchId: string }>> {
+  // Inventory row under the request context (org-scoped RLS applies).
+  const [inv] = await db
+    .select({
+      name: softwareInventory.name,
+      vendor: softwareInventory.vendor,
+      version: softwareInventory.version,
+    })
+    .from(softwareInventory)
+    .where(and(eq(softwareInventory.id, softwareInventoryId), eq(softwareInventory.deviceId, deviceId)))
+    .limit(1);
+  if (!inv?.name) return [];
+
+  const pending = await db
+    .select({
+      patchId: patches.id,
+      title: patches.title,
+      packageId: patches.packageId,
+      version: patches.version,
+    })
+    .from(patches)
+    .innerJoin(devicePatches, and(
+      eq(devicePatches.patchId, patches.id),
+      eq(devicePatches.deviceId, deviceId),
+      eq(devicePatches.status, 'pending'),
+    ))
+    .where(and(eq(patches.source, 'third_party'), isNull(patches.supersededBy)))
+    .orderBy(desc(patches.releaseDate));
+  if (pending.length === 0) return [];
+
+  // Index by normalized title; a key claimed by two different packageIds
+  // (x64/x86 twins like the VC++ redistributables) is ambiguous and dropped
+  // rather than guessed.
+  const byKey = new Map<string, typeof pending>();
+  const ambiguous = new Set<string>();
+  for (const patch of pending) {
+    const key = normalizeSoftwareName(patch.title);
+    if (!key) continue;
+    const bucket = byKey.get(key);
+    if (!bucket) {
+      byKey.set(key, [patch]);
+    } else if ((bucket[0]!.packageId ?? '') !== (patch.packageId ?? '')) {
+      ambiguous.add(key);
+    } else {
+      bucket.push(patch);
+    }
+  }
+  for (const key of ambiguous) byKey.delete(key);
+
+  // The registry DisplayName ("Mozilla Firefox ESR (x64 en-US)") may carry a
+  // vendor prefix the enriched patch title ("Firefox ESR") lacks — try the
+  // full name first, then with the vendor prefix stripped.
+  const nameKey = normalizeSoftwareName(inv.name);
+  const vendorKey = normalizeSoftwareName(inv.vendor);
+  const keys = [nameKey];
+  if (vendorKey && nameKey.startsWith(`${vendorKey} `)) keys.push(nameKey.slice(vendorKey.length + 1));
+  let matches: typeof pending = [];
+  for (const key of keys) {
+    const bucket = byKey.get(key);
+    if (bucket) {
+      matches = bucket;
+      break;
+    }
+  }
+
+  // A stale pending row already at the installed version would no-op.
+  matches = matches.filter((p) => !(p.version && inv.version && p.version.trim() === inv.version.trim()));
+  if (matches.length === 0) return [];
+
+  // Best-effort: when the CVE's vulnerable ranges for this product are known,
+  // drop a candidate whose target version is provably still inside one —
+  // installing it cannot resolve the finding. Unknown metadata never blocks.
+  const ranges = await vulnerableRangesForProduct(inv.name, inv.vendor, vulnerabilityId);
+  if (ranges.length > 0) {
+    matches = matches.filter((p) => !p.version || !ranges.some((r) => isVersionInRange(p.version!, r)));
+  }
+  return matches.map((p) => ({ patchId: p.patchId }));
 }
 
 /**
@@ -72,6 +207,7 @@ export async function remediateVulnerabilities(
         id: deviceVulnerabilities.id,
         deviceId: deviceVulnerabilities.deviceId,
         vulnerabilityId: deviceVulnerabilities.vulnerabilityId,
+        softwareInventoryId: deviceVulnerabilities.softwareInventoryId,
         status: deviceVulnerabilities.status,
       })
       .from(deviceVulnerabilities)
@@ -129,7 +265,7 @@ export async function remediateVulnerabilities(
     // 3. Candidate patches: advertise this CVE, not superseded, and the device
     //    has a PENDING device_patches row (applicability + still-needed). Prefer
     //    the newest release.
-    const candidates = await db
+    let candidates: Array<{ patchId: string }> = await db
       .select({ patchId: patches.id })
       .from(patches)
       .innerJoin(devicePatches, and(
@@ -142,6 +278,16 @@ export async function remediateVulnerabilities(
         isNull(patches.supersededBy),
       ))
       .orderBy(desc(patches.releaseDate));
+    // 3b. Third-party findings: fall back to product-identity matching, since
+    //     winget/Homebrew patch rows rarely carry cveIds (see
+    //     thirdPartyCandidatesByProduct).
+    if (candidates.length === 0 && row.softwareInventoryId) {
+      candidates = await thirdPartyCandidatesByProduct(
+        row.deviceId,
+        row.softwareInventoryId,
+        row.vulnerabilityId,
+      );
+    }
     if (candidates.length === 0) {
       result.skipped.push({ id: dvId, reason: 'no_available_patch' });
       continue;


### PR DESCRIPTION
## Problem

Clicking **Remediate** on the vulnerabilities dashboard reported *"Nothing scheduled: 66 no available patch"* for third-party findings (e.g. Firefox), even when the fixing winget upgrade was sitting pending on the device.

The remediation service matched patches solely by `patches.cveIds @> [cve]`. But `cveIds` is only ever written by the OSV enrichment worker, which requires the package to be in `third_party_package_catalog` **with `osvEcosystem` set — no seeded entry has it**. Winget patch rows land from the agent with no CVE data, so the CVE match found zero candidates for every third-party finding, unconditionally.

## Fix

When the CVE-array match is empty and the finding carries a `softwareInventoryId`, fall back to matching the device's **pending third-party patches by normalized product name**:

- Reuses `normalizeSoftwareName` and the drop-ambiguous-keys rule (x64/x86 twins) from the Software tab's update annotation (`softwareUpdateMatch.ts`) — same key, same false-positive posture.
- Vendor-prefix-stripped retry so catalog-enriched titles ("Firefox ESR") still match registry DisplayNames ("Mozilla Firefox ESR (x64 en-US)").
- Skips a candidate already at the installed version.
- Best-effort version guard: if the CVE's vulnerable range for the product is known (`software_product_resolutions` → `software_vulnerabilities`, read under system context like the catalog two-step), a patch whose target version is provably still vulnerable is dropped. Unknown metadata never blocks.
- The partner approval gate applies to fallback candidates unchanged — unapproved upgrades now surface as the actionable `patch_not_approved` instead of the misleading `no_available_patch`.

## Notes

- Complementary to #2725 (winget pending rows overwritten by the installed submit): both are needed for third-party Remediate to work in production — this PR fixes matching, #2725 keeps the pending rows alive to match against. No conflicts between them.
- Windows OS CVE findings (no `softwareInventoryId`, `microsoft` patches never get `cveIds`) remain unremediable via this path — MSRC CVE→KB mapping is a separate follow-up.

## Testing

- 5 new integration tests (real DB): fallback schedules `install_patches`; approval gate holds on the fallback path; still-vulnerable target version skipped; cleared-range version schedules; ambiguous normalized title dropped.
- All 9 remediate integration tests green; 58 route unit tests green; API typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)