### PR TITLE
fix(vulnerabilities): remediate Windows OS findings via cumulative-update fallback

### DIFF
--- a/apps/api/src/__tests__/integration/vulnerabilitiesRemediate.integration.test.ts
+++ b/apps/api/src/__tests__/integration/vulnerabilitiesRemediate.integration.test.ts
@@ -68,7 +68,7 @@ beforeEach(async () => {
   });
 });
 
-async function seedDevice(env: TestEnvironment): Promise<string> {
+async function seedDevice(env: TestEnvironment, osType: 'windows' | 'macos' | 'linux' = 'windows'): Promise<string> {
   const [device] = await getTestDb()
     .insert(devices)
     .values({
@@ -76,7 +76,7 @@ async function seedDevice(env: TestEnvironment): Promise<string> {
       siteId: env.site.id,
       agentId: uniq('rem-agent'),
       hostname: uniq('rem-host'),
-      osType: 'windows',
+      osType,
       osVersion: '11',
       architecture: 'x86_64',
       agentVersion: '0.0.0-test',
@@ -276,6 +276,71 @@ async function seedThirdPartyFinding(opts: {
   return { env, orgId: env.organization.id, deviceId, dvId };
 }
 
+/**
+ * Windows OS finding shape (#2733): the finding has NO software link (the shape
+ * the fleet view groups as "Windows updates") and the device has pending
+ * microsoft-source patches that do NOT advertise the CVE (the production norm —
+ * WUA scans carry no CVE data). Remediation must fall back to the newest
+ * pending, approved, non-superseded cumulative/security update.
+ */
+async function seedWindowsOsFinding(opts: {
+  cveId: string;
+  osType?: 'windows' | 'macos' | 'linux';
+  osPatches: Array<{
+    title: string;
+    category?: string;
+    releaseDate: string;
+    approved?: boolean;
+    superseded?: boolean;
+  }>;
+}): Promise<{
+  env: TestEnvironment;
+  orgId: string;
+  deviceId: string;
+  dvId: string;
+  patchIdByTitle: Record<string, string>;
+}> {
+  const env = await setupTestEnvironment({ scope: 'organization' });
+  const deviceId = await seedDevice(env, opts.osType ?? 'windows');
+  const vulnerabilityId = await seedVuln(opts.cveId);
+  const dvId = await seedDeviceVuln(env.organization.id, deviceId, vulnerabilityId);
+
+  const patchIdByTitle: Record<string, string> = {};
+  for (const p of opts.osPatches) {
+    const [patch] = await getTestDb()
+      .insert(patches)
+      .values({
+        source: 'microsoft',
+        externalId: uniq('KB'),
+        title: p.title,
+        category: p.category ?? 'security',
+        severity: 'critical',
+        supersededBy: p.superseded ? uniq('KB-newer') : null,
+        releaseDate: p.releaseDate,
+      })
+      .returning({ id: patches.id });
+    if (!patch) throw new Error('failed to seed microsoft patch');
+    patchIdByTitle[p.title] = patch.id;
+
+    await getTestDb().insert(devicePatches).values({
+      deviceId,
+      orgId: env.organization.id,
+      patchId: patch.id,
+      status: 'pending',
+    });
+
+    if (p.approved !== false) {
+      await getTestDb().insert(patchApprovals).values({
+        partnerId: env.partner.id,
+        patchId: patch.id,
+        status: 'approved',
+      });
+    }
+  }
+
+  return { env, orgId: env.organization.id, deviceId, dvId, patchIdByTitle };
+}
+
 /** Open device-vuln with NO matching pending patch. */
 async function seedDeviceVulnNoPatch(): Promise<{ env: TestEnvironment; dvId: string }> {
   const env = await setupTestEnvironment({ scope: 'organization' });
@@ -471,6 +536,101 @@ describe('POST /api/v1/vulnerabilities/remediate', () => {
       // Same normalized name ("mozilla firefox") from a different packageId —
       // the x64/x86-twin shape. Neither may be picked.
       extraPatch: { title: 'Mozilla Firefox (x86)', packageId: 'Mozilla.Firefox.x86' },
+    });
+    const res = await buildApp().request('/api/v1/vulnerabilities/remediate', {
+      method: 'POST',
+      headers: await mfaHeaders(env),
+      body: JSON.stringify({ deviceVulnerabilityIds: [dvId] }),
+    });
+    const body = await res.json() as { scheduled: number; skipped: Array<{ reason: string }> };
+    expect(body.scheduled).toBe(0);
+    expect(body.skipped[0]!.reason).toBe('no_available_patch');
+  });
+
+  runDb('targets the newest pending OS cumulative for a Windows OS finding', async () => {
+    const { env, deviceId, dvId, patchIdByTitle } = await seedWindowsOsFinding({
+      cveId: 'CVE-2025-70001',
+      osPatches: [
+        // Newest security update overall is the .NET cumulative — the OS
+        // cumulative must still win (rank), and the newer of the two OS
+        // cumulatives must be picked (release date within rank).
+        { title: '2026-07 Cumulative Update for .NET Framework 3.5 and 4.8.1 for Windows 11 (KB5041002)', releaseDate: '2026-07-09' },
+        { title: '2026-07 Cumulative Update for Windows 11 Version 23H2 for x64-based Systems (KB5040442)', releaseDate: '2026-07-08' },
+        { title: '2026-06 Cumulative Update for Windows 11 Version 23H2 for x64-based Systems (KB5039212)', releaseDate: '2026-06-11' },
+        // Non-security categories must never be targeted.
+        { title: 'Security Intelligence Update for Microsoft Defender Antivirus (KB2267602)', category: 'definitions', releaseDate: '2026-07-20' },
+      ],
+    });
+    const res = await buildApp().request('/api/v1/vulnerabilities/remediate', {
+      method: 'POST',
+      headers: await mfaHeaders(env),
+      body: JSON.stringify({ deviceVulnerabilityIds: [dvId] }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { scheduled: number; skipped: unknown[] };
+    expect(body.scheduled).toBe(1);
+    expect(body.skipped).toEqual([]);
+
+    const cmds = await getTestDb()
+      .select({ payload: deviceCommands.payload })
+      .from(deviceCommands)
+      .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.type, 'install_patches')));
+    expect(cmds.length).toBe(1);
+    expect(cmds[0]!.payload).toEqual({
+      patchIds: [patchIdByTitle['2026-07 Cumulative Update for Windows 11 Version 23H2 for x64-based Systems (KB5040442)']],
+    });
+  });
+
+  runDb('skips superseded and unapproved cumulatives on the OS fallback path', async () => {
+    const { env, deviceId, dvId, patchIdByTitle } = await seedWindowsOsFinding({
+      cveId: 'CVE-2025-70002',
+      osPatches: [
+        { title: '2026-07 Cumulative Update for Windows 11 Version 23H2 (KB5040442)', releaseDate: '2026-07-08', superseded: true },
+        { title: '2026-06 Cumulative Update for Windows 11 Version 23H2 (KB5039212)', releaseDate: '2026-06-11', approved: false },
+        { title: '2026-05 Cumulative Update for Windows 11 Version 23H2 (KB5037771)', releaseDate: '2026-05-14' },
+      ],
+    });
+    const res = await buildApp().request('/api/v1/vulnerabilities/remediate', {
+      method: 'POST',
+      headers: await mfaHeaders(env),
+      body: JSON.stringify({ deviceVulnerabilityIds: [dvId] }),
+    });
+    const body = await res.json() as { scheduled: number; skipped: unknown[] };
+    expect(body.scheduled).toBe(1);
+
+    const cmds = await getTestDb()
+      .select({ payload: deviceCommands.payload })
+      .from(deviceCommands)
+      .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.type, 'install_patches')));
+    expect(cmds[0]!.payload).toEqual({
+      patchIds: [patchIdByTitle['2026-05 Cumulative Update for Windows 11 Version 23H2 (KB5037771)']],
+    });
+  });
+
+  runDb('keeps the approval gate on the OS fallback path', async () => {
+    const { env, dvId } = await seedWindowsOsFinding({
+      cveId: 'CVE-2025-70003',
+      osPatches: [
+        { title: '2026-07 Cumulative Update for Windows 11 Version 23H2 (KB5040442)', releaseDate: '2026-07-08', approved: false },
+      ],
+    });
+    const res = await buildApp().request('/api/v1/vulnerabilities/remediate', {
+      method: 'POST',
+      headers: await mfaHeaders(env),
+      body: JSON.stringify({ deviceVulnerabilityIds: [dvId] }),
+    });
+    const body = await res.json() as { scheduled: number; skipped: Array<{ reason: string }> };
+    expect(body.scheduled).toBe(0);
+    expect(body.skipped[0]!.reason).toBe('patch_not_approved');
+  });
+
+  runDb('does not apply the OS fallback to non-Windows devices', async () => {
+    const { env, dvId } = await seedWindowsOsFinding({
+      cveId: 'CVE-2025-70004',
+      osType: 'macos',
+      osPatches: [
+        { title: '2026-07 Cumulative Update for Windows 11 Version 23H2 (KB5040442)', releaseDate: '2026-07-08' },
+      ],
     });
     const res = await buildApp().request('/api/v1/vulnerabilities/remediate', {
       method: 'POST',

--- a/apps/api/src/services/vulnerabilityRemediation.ts
+++ b/apps/api/src/services/vulnerabilityRemediation.ts
@@ -206,6 +206,50 @@ async function thirdPartyCandidatesByProduct(
 }
 
 /**
+ * Fallback candidates for Windows OS findings (#2733). Nothing ever writes CVE
+ * ids onto microsoft-source patch rows — the agent's WUA scan reports no CVE
+ * data and the enrichment worker is third-party-only — and OS findings carry no
+ * software link, so neither the CVE-array match nor the product-identity
+ * fallback can apply: every OS finding used to die as `no_available_patch` even
+ * with the fixing cumulative update sitting pending on the device. Windows
+ * security servicing is cumulative — the newest security update contains all
+ * prior security fixes — so the newest pending, non-superseded microsoft
+ * security update is a defensible install target for any OS CVE the device is
+ * still exposed to. Precise CVE→KB attribution is deliberately not attempted
+ * here: the correlation resolve loop confirms actual fix state post-install,
+ * so remediation only needs a defensible target. OS cumulatives ("Cumulative
+ * Update for Windows/Microsoft server ...") are preferred over same-day
+ * security siblings (.NET cumulatives, servicing stack updates); the partner
+ * approval gate in the main loop applies to the ordered list unchanged.
+ */
+async function windowsOsUpdateCandidates(deviceId: string): Promise<Array<{ patchId: string }>> {
+  // `category` is the agent's normalized WUA classification
+  // (agent/internal/collectors/patches_windows.go): cumulative and other
+  // security-classified updates land as 'security'; definition updates,
+  // drivers, and feature packs are excluded by the equality filter.
+  const pending = await db
+    .select({ patchId: patches.id, title: patches.title })
+    .from(patches)
+    .innerJoin(devicePatches, and(
+      eq(devicePatches.patchId, patches.id),
+      eq(devicePatches.deviceId, deviceId),
+      eq(devicePatches.status, 'pending'),
+    ))
+    .where(and(
+      eq(patches.source, 'microsoft'),
+      eq(patches.category, 'security'),
+      isNull(patches.supersededBy),
+    ))
+    .orderBy(sql`${patches.releaseDate} DESC NULLS LAST`);
+
+  // Stable sort: OS cumulatives first, newest-first preserved within each rank.
+  const rank = (title: string) => (/cumulative update for (windows|microsoft server)/i.test(title) ? 0 : 1);
+  return pending
+    .sort((a, b) => rank(a.title) - rank(b.title))
+    .map((p) => ({ patchId: p.patchId }));
+}
+
+/**
  * Remediate a set of device-vulnerability findings by queueing the single
  * targeted install command (`install_patches`) for the patch that fixes each
  * CVE — the same chokepoint POST /devices/:id/patches/install uses. This is
@@ -268,7 +312,7 @@ export async function remediateVulnerabilities(
     //    the device's org/site for the intra-org site check below.
     const orgCond = auth.orgCondition(devices.orgId);
     const [device] = await db
-      .select({ id: devices.id, siteId: devices.siteId, orgId: devices.orgId })
+      .select({ id: devices.id, siteId: devices.siteId, orgId: devices.orgId, osType: devices.osType })
       .from(devices)
       .where(orgCond ? and(eq(devices.id, row.deviceId), orgCond) : eq(devices.id, row.deviceId))
       .limit(1);
@@ -313,6 +357,13 @@ export async function remediateVulnerabilities(
         row.softwareInventoryId,
         row.vulnerabilityId,
       );
+    }
+    // 3c. Windows OS findings (no software link — the shape the fleet view
+    //     groups as "Windows updates"): fall back to the newest pending
+    //     cumulative/security update, since microsoft patch rows never carry
+    //     cveIds (see windowsOsUpdateCandidates).
+    if (candidates.length === 0 && !row.softwareInventoryId && device.osType === 'windows') {
+      candidates = await windowsOsUpdateCandidates(row.deviceId);
     }
     if (candidates.length === 0) {
       result.skipped.push({ id: dvId, reason: 'no_available_patch' });


### PR DESCRIPTION
## Problem

Windows OS vulnerability findings always skip **Remediate** as `no_available_patch` (#2733). The matcher needs `patches.cveIds @> [cve]`, but nothing ever writes CVE ids onto `microsoft`-source patch rows (the agent's WUA scan reports no CVE data; `cveEnrichmentWorker.ts` is third-party-only), and OS findings carry no `softwareInventoryId`, so the #2731 product-identity fallback can't apply either.

## Design decision

The issue offered two directions; this takes **(b) the cumulative-update heuristic**. Option (a) — persisting MSRC CVE→KB mappings — is not cheap: `msrcClient` parses `kbArticle` per remediation record but nothing persists it, so it would need a schema column + migration, a re-sync/backfill of all historical MSRC months, KB→patch title matching, and supersedence-chain walking that converges on "newest pending cumulative" anyway. Since the correlation resolve loop already confirms actual fix state post-install via FixedBuild comparison, remediation only needs a defensible install target — which the newest cumulative is, by construction (Windows security servicing is cumulative).

## Change

New step 3c fallback in `vulnerabilityRemediation.ts`: when the CVE-array match finds nothing, the finding has no software link (the exact shape the fleet view groups as "Windows updates"), and the device is Windows, candidates become the device's pending, non-superseded `microsoft`-source `category='security'` patches, newest-first, with OS cumulatives ("Cumulative Update for Windows/Microsoft server …") ranked above same-day security siblings (.NET cumulatives, servicing stack updates). `category` is the agent's normalized WUA classification, so definition updates, drivers, and feature packs are excluded. The partner approval gate and org+site gates apply to the ordered list unchanged; non-Windows devices are untouched.

## Tests

Extended `vulnerabilitiesRemediate.integration.test.ts` (13/13 green against the real :5433 DB):
- OS finding schedules the newest OS cumulative — asserts the queued `install_patches` payload targets the OS cumulative over a newer .NET cumulative and a newer definitions row
- superseded newest + unapproved middle → schedules the older approved cumulative
- approval gate holds on the fallback path (`patch_not_approved`)
- non-Windows device with the same finding shape still skips `no_available_patch`

API typecheck clean.

## Stacking note

Stacked on #2731 (same file, adjacent fallback) — base is `ToddHebebrand/vulnerabilities-remediate`. Non-main-base PRs get no CI run; after #2731 merges, retarget to `main` and let CI go green before merging.

Closes #2733

🤖 Generated with [Claude Code](https://claude.com/claude-code)