### PR TITLE
fix(patches): installed ingest 500s on Date bound in raw sql fragment (#2725 follow-up)

### DIFF
--- a/agent/internal/patching/winget_parse.go
+++ b/agent/internal/patching/winget_parse.go
@@ -202,9 +202,10 @@ func extractListColumns(line string, cols *columnPositions) (name, id, version s
 	}
 	name = safeSubstring(line, cols.name, cols.id)
 	id = safeSubstring(line, cols.id, cols.version)
-	// `winget list` grows an Available column when any package has an upgrade;
-	// slicing to end-of-line concatenated Version+Available into one string
-	// ("2.51.0.2   2.55.0.3"). Stop at the Available column when present.
+	// `winget list` grows an Available column once any package has an upgrade.
+	// Without stopping there, the Version cell would run to end-of-line and
+	// concatenate Version+Available ("2.51.0.2   2.55.0.3"). Stop at the
+	// Available column when present, matching extractUpgradeColumns.
 	if cols.available > 0 {
 		version = safeSubstring(line, cols.version, cols.available)
 		return

--- a/agent/internal/patching/winget_parse_test.go
+++ b/agent/internal/patching/winget_parse_test.go
@@ -54,20 +54,24 @@ func TestWingetListParseWithAvailableColumn(t *testing.T) {
 	row := func(name, id, version, available, source string) string {
 		return fmt.Sprintf("%-11s%-14s%-11s%-12s%s", name, id, version, available, source)
 	}
+	// The last row's raw bytes end before the Available column position
+	// (right-trimmed output) — the version slice must clamp, not drop the row.
 	output := row("Name", "Id", "Version", "Available", "Source") + "\n" +
 		strings.Repeat("-", 55) + "\n" +
 		row("Git", "Git.Git", "2.51.0.2", "2.55.0.3", "winget") + "\n" +
 		row("7-Zip", "7zip.7zip", "26.00", "26.02", "winget") + "\n" +
-		row("Paint", "Corel.Paint", "1.2.3", "", "winget") + "\n"
+		row("Paint", "Corel.Paint", "1.2.3", "", "winget") + "\n" +
+		fmt.Sprintf("%-11s%-14s%s", "Short", "Short.App", "1.0") + "\n"
 
 	installed := parseWingetListOutput(output)
-	if len(installed) != 3 {
-		t.Fatalf("expected 3 installed, got %d: %+v", len(installed), installed)
+	if len(installed) != 4 {
+		t.Fatalf("expected 4 installed, got %d: %+v", len(installed), installed)
 	}
 	want := map[string]string{
 		"Git.Git":     "2.51.0.2",
 		"7zip.7zip":   "26.00",
 		"Corel.Paint": "1.2.3",
+		"Short.App":   "1.0",
 	}
 	for _, p := range installed {
 		if p.Version != want[p.ID] {

--- a/apps/api/src/routes/agents/patches.integration.test.ts
+++ b/apps/api/src/routes/agents/patches.integration.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Integration test — patch ingest status transitions against real Postgres.
+ *
+ * The pending-preservation guard in `upsertInstalledPatches` (#2725) is a raw
+ * SQL CASE inside a Drizzle `onConflictDoUpdate`. The mocked unit suite
+ * (`patches.test.ts`) can only assert the shape of the generated SQL object —
+ * it cannot prove the CASE branches point the right way, that the untyped
+ * `'installed'`/`'pending'` literals resolve against the real
+ * `device_patch_status` enum, or that the sweep→installed self-heal sequence
+ * works across the two real endpoints. This suite drives the actual
+ * `patchesRoutes` handlers against the test DB under the same
+ * `withDbAccessContext` shape `agentAuthMiddleware` sets up for agent routes.
+ */
+import '../../__tests__/integration/setup';
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { and, eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { devices, patches, devicePatches } from '../../db/schema';
+import { setupTestEnvironment } from '../../__tests__/integration/db-utils';
+import { patchesRoutes } from './patches';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+/** The exact RLS context `agentAuthMiddleware` sets up for org-scoped agent routes. */
+function agentRequestContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    currentPartnerId: null,
+  };
+}
+
+async function insertDevice(orgId: string, siteId: string): Promise<{ id: string; agentId: string }> {
+  const agentId = `agent-patches-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .insert(devices)
+      .values({
+        orgId,
+        siteId,
+        agentId,
+        hostname: `patches-${agentId}`,
+        osType: 'windows',
+        osVersion: '11',
+        architecture: 'x86_64',
+        agentVersion: '0.0.0-test',
+        status: 'online',
+        enrolledAt: new Date(),
+      })
+      .returning({ id: devices.id });
+    if (!row) throw new Error('insertDevice: no row');
+    return { id: row.id, agentId };
+  });
+}
+
+function mountRoutes(orgId: string, agentId: string) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('agent', { orgId, agentId, role: 'agent' } as never);
+    await next();
+  });
+  app.route('/agents', patchesRoutes);
+  return app;
+}
+
+async function putJson(app: Hono, orgId: string, path: string, body: unknown) {
+  return withDbAccessContext(agentRequestContext(orgId), async () =>
+    app.request(path, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  );
+}
+
+async function getDevicePatchRow(deviceId: string, externalId: string) {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select({
+        status: devicePatches.status,
+        installedAt: devicePatches.installedAt,
+        installedVersion: devicePatches.installedVersion,
+      })
+      .from(devicePatches)
+      .innerJoin(patches, eq(devicePatches.patchId, patches.id))
+      .where(and(eq(devicePatches.deviceId, deviceId), eq(patches.externalId, externalId)));
+    return row ?? null;
+  });
+}
+
+describe('patch ingest — installed inventory must not erase pending rows (real Postgres, #2725)', () => {
+  runDb('preserves a pending row through an installed submit, then heals it via the sweep', async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const dev = await insertDevice(env.organization.id, env.site.id);
+    const app = mountRoutes(env.organization.id, dev.agentId);
+    // Unique per run: (source, externalId) is globally unique in `patches` and
+    // cleanup between runs is not guaranteed.
+    const externalId = `itest.winget.git-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const pkg = { name: 'Git', source: 'third_party', externalId, packageId: externalId };
+
+    // 1. Pending scan reports an available upgrade.
+    const pendingRes = await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches/pending`, {
+      source: 'third_party',
+      patches: [{ ...pkg, version: '2.55.0.3' }],
+    });
+    expect(pendingRes.status).toBe(200);
+    expect((await getDevicePatchRow(dev.id, externalId))?.status).toBe('pending');
+
+    // 2. The paired installed inventory reports the same package at its
+    //    currently-installed (older) version. Pre-#2725 this flipped the row
+    //    to 'installed'; it must stay pending, with installedVersion updated
+    //    and installedAt untouched.
+    const installedRes = await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches/installed`, {
+      installed: [{ ...pkg, version: '2.51.0.2', installedAt: '2026-01-05T00:00:00Z' }],
+    });
+    expect(installedRes.status).toBe(200);
+    const afterInstalled = await getDevicePatchRow(dev.id, externalId);
+    expect(afterInstalled?.status).toBe('pending');
+    expect(afterInstalled?.installedVersion).toBe('2.51.0.2');
+    expect(afterInstalled?.installedAt).toBeNull();
+
+    // 3. The upgrade completes: the next pending scan no longer reports the
+    //    package, so the source-scoped sweep tombstones the row...
+    const sweepRes = await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches/pending`, {
+      source: 'third_party',
+      patches: [],
+    });
+    expect(sweepRes.status).toBe(200);
+    expect((await getDevicePatchRow(dev.id, externalId))?.status).toBe('missing');
+
+    // 4. ...and the paired installed submit flips it to 'installed' — proving
+    //    the CASE guard preserves ONLY 'pending', not every non-installed state.
+    const healRes = await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches/installed`, {
+      installed: [{ ...pkg, version: '2.55.0.3', installedAt: '2026-01-06T00:00:00Z' }],
+    });
+    expect(healRes.status).toBe(200);
+    const healed = await getDevicePatchRow(dev.id, externalId);
+    expect(healed?.status).toBe('installed');
+    expect(healed?.installedVersion).toBe('2.55.0.3');
+    expect(healed?.installedAt).not.toBeNull();
+  });
+});

--- a/apps/api/src/routes/agents/patches.test.ts
+++ b/apps/api/src/routes/agents/patches.test.ts
@@ -746,7 +746,7 @@ describe('PUT /agents/:id/patches/installed - pending rows survive installed inv
     // winget reports a pending upgrade and the installed package under the same
     // (source, externalId): `winget list` includes every package that
     // `winget upgrade` just reported. The installed upsert must not downgrade
-    // the pending row the pending submit wrote ~200ms earlier.
+    // a pending row written earlier in the same scan cycle.
     const { tx, devicePatchUpserts } = mockTxCapturingDevicePatchUpserts();
     vi.mocked(db.transaction).mockImplementation(async (fn) => fn(tx as unknown as Parameters<typeof fn>[0]));
 
@@ -779,6 +779,12 @@ describe('PUT /agents/:id/patches/installed - pending rows survive installed inv
     expect(statusSql).toContain('pending');
     expect(statusSql).toContain('installed');
     expect((set.status as { values: unknown[] }).values).toContain(tables.devicePatches.status);
+    // Pin the CASE branch direction (preserve when pending, ELSE installed).
+    // These assertions inspect the mocked sql tag's {strings, values}
+    // bookkeeping, not drizzle's real SQL object — real execution against the
+    // device_patch_status enum is covered by patches.integration.test.ts.
+    const statusText = (set.status as { strings: string[] }).strings.join('<col>');
+    expect(statusText).toBe("CASE WHEN <col> = 'pending' THEN <col> ELSE 'installed' END");
     // installedAt is likewise preserved for pending rows.
     expect((set.installedAt as { values: unknown[] }).values).toContain(tables.devicePatches.installedAt);
     // installedVersion still updates — it reports the currently-installed

--- a/apps/api/src/routes/agents/patches.ts
+++ b/apps/api/src/routes/agents/patches.ts
@@ -236,14 +236,19 @@ async function upsertInstalledPatches(
     }
 
     const installedAt = parseDate(patchData.installedAt);
+    // A Date bound inside a raw sql`` fragment bypasses drizzle's column
+    // mapper and postgres.js cannot serialize it (TypeError at query time) —
+    // bind the ISO string with an explicit cast instead.
+    const installedAtParam = installedAt ? sql`${installedAt.toISOString()}::timestamp` : sql`NULL::timestamp`;
     // Installed inventory must not downgrade an actionable 'pending' row.
     // Package managers report a pending upgrade and the installed package under
-    // the SAME (source, externalId) — e.g. `winget list` includes every package
-    // that `winget upgrade` just reported — so an unconditional flip erased all
-    // pending third-party rows moments after the pending submit wrote them.
+    // the SAME (source, externalId) — `winget list` covers every package the
+    // paired `winget upgrade` scan reports — so an unconditional flip would
+    // clobber every pending third-party row in the same scan cycle.
     // installedVersion still updates: it's the currently-installed version
-    // either way. A row whose upgrade completed self-heals on the next scan
-    // (pending sweep → 'missing' → this upsert → 'installed').
+    // either way. A row whose upgrade completed self-heals within one scan
+    // cycle: the pending sweep flips it to 'missing', then the paired
+    // installed submit lands in this upsert's ELSE branch as 'installed'.
     await executor
       .insert(devicePatches)
       .values({
@@ -259,7 +264,7 @@ async function upsertInstalledPatches(
         target: [devicePatches.deviceId, devicePatches.patchId],
         set: {
           status: sql`CASE WHEN ${devicePatches.status} = 'pending' THEN ${devicePatches.status} ELSE 'installed' END`,
-          installedAt: sql`CASE WHEN ${devicePatches.status} = 'pending' THEN ${devicePatches.installedAt} ELSE ${installedAt} END`,
+          installedAt: sql`CASE WHEN ${devicePatches.status} = 'pending' THEN ${devicePatches.installedAt} ELSE ${installedAtParam} END`,
           installedVersion: patchData.version || null,
           lastCheckedAt: new Date(),
           updatedAt: new Date()

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -48,6 +48,11 @@ export default defineConfig({
       // beforeAll), so the unit runner's no-DB environment fails the suite on
       // connect. Belongs to vitest.integration.config.ts.
       'src/routes/agents/changes.integration.test.ts',
+      // Patch ingest status-transition real-DB test (#2725): imports
+      // `__tests__/integration/setup` (real postgres pool + autoMigrate), so
+      // the no-DB unit runner would fail it on connect. Belongs to
+      // vitest.integration.config.ts.
+      'src/routes/agents/patches.integration.test.ts',
       // Software-report re-link real-DB test (BREEZE-3): imports
       // `__tests__/integration/setup` (real postgres pool + autoMigrate), so the
       // no-DB unit runner would fail it on connect. Belongs to

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -66,6 +66,12 @@ export default defineConfig({
       // the mocked `changes.test.ts` unit suite, so this drives the real
       // `changesRoutes` handler + RLS insert/select policies against Postgres.
       'src/routes/agents/changes.integration.test.ts',
+      // Co-located real-DB integration test for #2725 (installed inventory must
+      // not erase pending third-party rows): proves the raw-SQL CASE guard in
+      // upsertInstalledPatches against the real device_patch_status enum and
+      // the sweep→installed self-heal across both ingest endpoints — the
+      // mocked patches.test.ts can only assert the generated SQL's shape.
+      'src/routes/agents/patches.integration.test.ts',
       // Co-located real-DB integration test for BREEZE-3: software report
       // wipe-and-reinsert with linked vuln findings — proves the SET NULL FK
       // (constraint name + delete action) and the re-link UPDATE under the


### PR DESCRIPTION
## Critical fix on top of #2725 — merge before the next release cut

The multi-agent review of #2725 surfaced a driver-layer bug in the merged fix: the `installedAt` CASE bound a JS `Date` directly inside a raw ``sql`` `` fragment. That bypasses Drizzle's column mapper, and postgres.js throws `TypeError: The "string" argument must be of type string ... Received an instance of Date` at query-serialization time — so **any installed-inventory submit carrying an `installedAt` value would 500 the entire ingest request** once #2725 deploys. Neither the mocked unit suite nor hand-run psql checks could see this (it dies in the JS driver, not Postgres); the new real-Postgres integration test caught it immediately. Fix: bind the ISO string with an explicit `::timestamp` cast.

## Review hardening (from the #2725 review pass)

- **`patches.integration.test.ts`** (new, registered in `vitest.integration.config.ts` include + `vitest.config.ts` unit-exclude): drives both real ingest endpoints end-to-end against the real `device_patch_status` enum — pending row survives the installed submit (`installedVersion` updates, `installedAt` untouched), the source-scoped sweep tombstones it to `missing`, and the next installed submit flips it to `installed`, proving the guard preserves *only* `pending`.
- **Unit test**: now pins the CASE branch direction (exact clause), not just token presence, and documents that it asserts the mocked sql tag's shape.
- **Go**: covers a `winget list` row whose raw bytes end before the Available column (bounds-clamp path); comment cleanups in `winget_parse.go` and `patches.ts` (accurate same-cycle self-heal phrasing, dropped timing narration).

## Verification

- Integration test passes against real Postgres (fails with the 500 before the Date fix — true regression coverage).
- API unit suite 20/20; `go test -race ./internal/patching/` passes; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)