### PR TITLE
fix(ai): manage_patches per-action required fields + doubled-colon error (#2604)

### DIFF
--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -1300,6 +1300,15 @@ export function validateToolInput(
     return { success: true };
   }
 
-  const issues = result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ');
+  // Object-level refinements (e.g. "install requires patchIds and deviceIds")
+  // carry an empty `path`, so prefixing every message with `${path}: ` yields a
+  // dangling `: message` and, once joined onto the banner, a doubled colon
+  // ("Invalid input: : ..."). Only prefix the path when there is one.
+  const issues = result.error.issues
+    .map(i => {
+      const path = i.path.join('.');
+      return path ? `${path}: ${i.message}` : i.message;
+    })
+    .join('; ');
   return { success: false, error: `Invalid input: ${issues}` };
 }

--- a/apps/api/src/services/aiToolSchemas.validateToolInput.test.ts
+++ b/apps/api/src/services/aiToolSchemas.validateToolInput.test.ts
@@ -39,9 +39,9 @@ describe('validateToolInput error formatting', () => {
     }
   });
 
-  it('joins multiple issues without a leading colon on the refinement message', () => {
-    // Bad enum (field-level, has path) alongside a satisfied action keeps the
-    // banner clean; the key invariant is no ` : ` artifact anywhere.
+  it('renders another object-level refinement message without a leading colon', () => {
+    // A second refinement (scan requires deviceIds) confirms the empty-path
+    // handling is not specific to the install message.
     const result = validateToolInput('manage_patches', { action: 'scan' });
     expect(result.success).toBe(false);
     if (!result.success) {

--- a/apps/api/src/services/aiToolSchemas.validateToolInput.test.ts
+++ b/apps/api/src/services/aiToolSchemas.validateToolInput.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { validateToolInput } from './aiToolSchemas';
+
+const TEST_UUID = '00000000-0000-0000-0000-000000000001';
+
+describe('validateToolInput error formatting', () => {
+  it('rejects an unregistered tool', () => {
+    const result = validateToolInput('not_a_real_tool', {});
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('No input schema registered');
+    }
+  });
+
+  it('accepts valid input', () => {
+    expect(validateToolInput('manage_patches', { action: 'list' })).toEqual({ success: true });
+  });
+
+  // Regression for #2604: object-level refinements carry an empty `path`, so the
+  // old `${path}: ${message}` formatting produced a doubled colon
+  // ("Invalid input: : patchIds and deviceIds are required for install").
+  it('does not emit a doubled colon for object-level refinement failures', () => {
+    const result = validateToolInput('manage_patches', { action: 'install' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe('Invalid input: patchIds and deviceIds are required for install');
+      expect(result.error).not.toContain(': :');
+    }
+  });
+
+  it('still prefixes the field path for field-level failures', () => {
+    // `action` must be one of the enum values — this is a field-level issue with
+    // a non-empty path, so the path prefix must be preserved.
+    const result = validateToolInput('manage_patches', { action: 'not_an_action' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('action:');
+      expect(result.error).not.toContain(': :');
+    }
+  });
+
+  it('joins multiple issues without a leading colon on the refinement message', () => {
+    // Bad enum (field-level, has path) alongside a satisfied action keeps the
+    // banner clean; the key invariant is no ` : ` artifact anywhere.
+    const result = validateToolInput('manage_patches', { action: 'scan' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe('Invalid input: deviceIds is required for scan');
+    }
+  });
+});

--- a/apps/api/src/services/aiToolsFleet.test.ts
+++ b/apps/api/src/services/aiToolsFleet.test.ts
@@ -377,6 +377,17 @@ describe('manage_patches handler', () => {
     partnerOrgAccess: 'all',
   } as any;
 
+  // #2604: the conditional install requirement was enforced at runtime but not
+  // surfaced in the schema, so the model routinely called install without
+  // patchIds/deviceIds and burned a turn on the retry. The description must
+  // advertise the per-action required fields.
+  it('description advertises install requires both patchIds and deviceIds', () => {
+    expect(tool.definition.description).toMatch(/install requires BOTH patchIds and deviceIds/i);
+    const props = tool.definition.input_schema.properties as Record<string, { description?: string }>;
+    expect(props.action!.description).toMatch(/install needs patchIds AND deviceIds/i);
+    expect(props.deviceIds!.description).toMatch(/Required for scan, install, and rollback/i);
+  });
+
   it('setup_auto_approval is disabled (managed via configuration policies)', async () => {
     const result = JSON.parse(await tool.handler({ action: 'setup_auto_approval' }, noOrgAuth));
     expect(result.error).toContain('Action "setup_auto_approval" is disabled');

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -451,14 +451,14 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
     deviceArgs: ['deviceIds', 'deviceId'],
     definition: {
       name: 'manage_patches',
-      description: 'Manage patches: list patches present on the org\'s devices (optionally scoped to a single device via deviceId, which also returns per-device install status), check compliance, trigger scans, approve/decline/defer patches, bulk approve, install on targets, or rollback. To configure patch schedules and auto-approval policies, use manage_policy_feature_link with featureType "patch".',
+      description: 'Manage patches: list patches present on the org\'s devices (optionally scoped to a single device via deviceId, which also returns per-device install status), check compliance, trigger scans, approve/decline/defer patches, bulk approve, install on targets, or rollback. Required fields per action: install requires BOTH patchIds and deviceIds; scan requires deviceIds; bulk_approve requires patchIds; approve/decline/defer require patchId; rollback requires BOTH patchId and deviceIds; list/compliance require none. To configure patch schedules and auto-approval policies, use manage_policy_feature_link with featureType "patch".',
       input_schema: {
         type: 'object' as const,
         properties: {
-          action: { type: 'string', enum: ['list', 'compliance', 'scan', 'approve', 'decline', 'defer', 'bulk_approve', 'install', 'rollback'], description: 'The action to perform. To configure patch policies/auto-approval, use manage_policy_feature_link with featureType "patch".' },
-          patchId: { type: 'string', description: 'Patch UUID (for approve/decline/defer/rollback)' },
-          patchIds: { type: 'array', items: { type: 'string' }, description: 'Patch UUIDs (for bulk_approve/install)' },
-          deviceIds: { type: 'array', items: { type: 'string' }, description: 'Device UUIDs (for scan/install)' },
+          action: { type: 'string', enum: ['list', 'compliance', 'scan', 'approve', 'decline', 'defer', 'bulk_approve', 'install', 'rollback'], description: 'The action to perform. Required inputs: install needs patchIds AND deviceIds; scan needs deviceIds; bulk_approve needs patchIds; approve/decline/defer need patchId; rollback needs patchId AND deviceIds. To configure patch policies/auto-approval, use manage_policy_feature_link with featureType "patch".' },
+          patchId: { type: 'string', description: 'Patch UUID. Required for approve/decline/defer/rollback.' },
+          patchIds: { type: 'array', items: { type: 'string' }, description: 'Patch UUIDs. Required for bulk_approve and install.' },
+          deviceIds: { type: 'array', items: { type: 'string' }, description: 'Device UUIDs. Required for scan, install, and rollback.' },
           deviceId: { type: 'string', description: 'Single device UUID to scope the patch list to one device (for list); returns per-device install status' },
           source: { type: 'string', enum: ['microsoft', 'apple', 'linux', 'third_party', 'custom'], description: 'Filter by source' },
           severity: { type: 'string', enum: ['critical', 'important', 'moderate', 'low', 'unknown'], description: 'Filter by severity' },


### PR DESCRIPTION
## Summary

`manage_patches` enforces conditional field requirements at runtime via Zod refinements (`install` needs `patchIds` + `deviceIds`, `scan` needs `deviceIds`, `bulk_approve` needs `patchIds`, approve/decline/defer need `patchId`, `rollback` needs `patchId` + `deviceIds`). None of that was visible in the tool's `input_schema`/description, so the model's first `manage_patches` install call routinely failed with `Invalid input: : patchIds and deviceIds are required for install`, then retried with the right shape — a wasted turn, extra cost, and an error card in the chat UI on every remediation run.

## Changes

- **Surface the per-action requirements** in the `manage_patches` description and in the `action` / `patchId` / `patchIds` / `deviceIds` field descriptions so the model gets the shape right on the first call.
- **Fix the doubled-colon error banner** in `validateToolInput`. Object-level Zod refinements carry an empty `path`, so `${path}: ${message}` produced a dangling `: message` and the banner rendered `Invalid input: : ...`. Now the path is only prefixed when non-empty. This applies to every tool's validation output, not just `manage_patches`.

## Tests

- New `aiToolSchemas.validateToolInput.test.ts` — asserts no doubled colon on object-level refinement failures, field-path prefix preserved on field-level failures, unregistered-tool and valid-input paths.
- Added a description-content guard to the `manage_patches` handler suite in `aiToolsFleet.test.ts`.
- Affected suites green single-fork (129 tests across the three files); `tsc --noEmit` clean.

Closes #2604

🤖 Generated with [Claude Code](https://claude.com/claude-code)