### PR TITLE
fix(api): platform-admin bootstrap uses inArray, not = ANY(::text[]) (#2655)

### DIFF
--- a/apps/api/src/services/platformAdminBootstrap.integration.test.ts
+++ b/apps/api/src/services/platformAdminBootstrap.integration.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Real-Postgres integration coverage for the platform-admin bootstrap (#2655).
+ *
+ * Why this file exists: `platformAdminBootstrap.test.ts` mocks `../db`, so it
+ * executes NO SQL — the promotion query is never sent to a database. That is
+ * exactly why the original defect survived to a live stock-image boot: the
+ * `where` clause interpolated a JS `string[]` into a raw `sql` template as
+ * `= ANY(${emails}::text[])`, and in the production CJS bundle that array param
+ * reached Postgres as a bare string (not a `{...}` array literal), so the
+ * `::text[]` cast failed at runtime with `malformed array literal`. A mocked
+ * `db.execute` can never see a malformed-SQL failure.
+ *
+ * NOTE on scope: the *bundle-only* serialization difference does not reproduce
+ * under vitest/tsx (the ESM/dev path serializes a JS array correctly), so this
+ * suite would pass against the OLD `= ANY(::text[])` code too. Its value is not
+ * reproducing that specific bundler quirk — it is being the FIRST test that
+ * actually runs the promotion SQL against real Postgres under the same
+ * system-scoped RLS context production uses, proving the rewritten `inArray`
+ * form (`lower(email) in ($1, $2, …)`, one bound param per email, no array
+ * literal to serialize) is valid SQL and is correctly SCOPED: it promotes only
+ * the listed, not-already-admin users and leaves everyone else alone. The
+ * mocked unit suite asserts none of that.
+ *
+ * Run (Docker required — no Docker in the default agent sandbox; this runs in CI):
+ *   docker compose -f docker-compose.test.yml up -d
+ *   export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+ *   cd apps/api && pnpm vitest run --config vitest.integration.config.ts \
+ *     src/services/platformAdminBootstrap.integration.test.ts
+ */
+import '../__tests__/integration/setup';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+
+import { bootstrapPlatformAdmins } from './platformAdminBootstrap';
+import { users } from '../db/schema';
+import { createPartner, createUser } from '../__tests__/integration/db-utils';
+import { getTestDb } from '../__tests__/integration/setup';
+
+const ORIGINAL_ENV = process.env.BREEZE_PLATFORM_ADMINS;
+
+function setAdmins(value: string): void {
+  process.env.BREEZE_PLATFORM_ADMINS = value;
+}
+
+async function isPlatformAdmin(userId: string): Promise<boolean> {
+  const [row] = await getTestDb()
+    .select({ isPlatformAdmin: users.isPlatformAdmin })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  if (!row) throw new Error(`user ${userId} not found`);
+  return row.isPlatformAdmin;
+}
+
+describe('bootstrapPlatformAdmins — real Postgres (#2655)', () => {
+  beforeEach(() => {
+    delete process.env.BREEZE_PLATFORM_ADMINS;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.BREEZE_PLATFORM_ADMINS;
+    } else {
+      process.env.BREEZE_PLATFORM_ADMINS = ORIGINAL_ENV;
+    }
+  });
+
+  it('promotes a SINGLE configured email against real Postgres (the exact single-element case that failed in the prod bundle)', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const email = `solo-${Date.now()}@example.com`;
+    const user = await createUser({ partnerId: partner.id, status: 'active', email });
+
+    expect(await isPlatformAdmin(user.id)).toBe(false);
+
+    setAdmins(email);
+    await bootstrapPlatformAdmins();
+
+    expect(await isPlatformAdmin(user.id)).toBe(true);
+  });
+
+  it('promotes MULTIPLE comma-separated emails and matches case-insensitively', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const suffix = Date.now();
+    // Seed with mixed-case stored addresses to exercise the lower(email) match.
+    const a = await createUser({ partnerId: partner.id, email: `Alice-${suffix}@Example.com` });
+    const b = await createUser({ partnerId: partner.id, email: `bob-${suffix}@example.com` });
+
+    setAdmins(`alice-${suffix}@example.com, BOB-${suffix}@EXAMPLE.com`);
+    await bootstrapPlatformAdmins();
+
+    expect(await isPlatformAdmin(a.id)).toBe(true);
+    expect(await isPlatformAdmin(b.id)).toBe(true);
+  });
+
+  it('promotes ONLY the listed users — an unlisted user stays non-admin (WHERE actually filters)', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const suffix = Date.now();
+    const listed = await createUser({ partnerId: partner.id, email: `listed-${suffix}@example.com` });
+    const other = await createUser({ partnerId: partner.id, email: `other-${suffix}@example.com` });
+
+    setAdmins(`listed-${suffix}@example.com`);
+    await bootstrapPlatformAdmins();
+
+    expect(await isPlatformAdmin(listed.id)).toBe(true);
+    expect(await isPlatformAdmin(other.id)).toBe(false);
+  });
+
+  it('is idempotent: a second run leaves an already-promoted user promoted', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const email = `idem-${Date.now()}@example.com`;
+    const user = await createUser({ partnerId: partner.id, email });
+
+    setAdmins(email);
+    await bootstrapPlatformAdmins();
+    expect(await isPlatformAdmin(user.id)).toBe(true);
+
+    // Second run: the `isPlatformAdmin = false` guard means this user is no
+    // longer matched, but the call must not throw and must not demote.
+    await bootstrapPlatformAdmins();
+    expect(await isPlatformAdmin(user.id)).toBe(true);
+  });
+});

--- a/apps/api/src/services/platformAdminBootstrap.sql.test.ts
+++ b/apps/api/src/services/platformAdminBootstrap.sql.test.ts
@@ -1,0 +1,77 @@
+/**
+ * SQL-shape regression guard for the platform-admin bootstrap WHERE clause (#2655).
+ *
+ * The bug: `bootstrapPlatformAdmins` matched admins with
+ *   sql`lower(email) = ANY(${emails}::text[])`
+ * which binds the whole `string[]` as a SINGLE param cast to `::text[]`. That
+ * worked under dev/vitest but the production CJS bundle serialized the array
+ * param as a bare string (`conformance@breeze.local`, not `{conformance@...}`),
+ * so the `::text[]` cast threw `malformed array literal` at startup and the
+ * configured admin was never promoted.
+ *
+ * The pre-existing suite mocks `../db` and never serializes SQL, so it could
+ * not see this. A real-Postgres integration test wouldn't help either: the
+ * failure is a *bundle-only* param-serialization difference, so the old query
+ * runs fine against Postgres under vitest — it would pass on the broken code.
+ *
+ * The right guard is on the RENDERED SQL. This file renders the actual WHERE
+ * predicate with drizzle's real Postgres dialect (no DB connection needed) and
+ * asserts it uses one bound param per email (`in ($1, $2, ...)`) with NO array
+ * cast. It FAILS on the old `= ANY(...::text[])` form and PASSES on the fix,
+ * and it needs no Docker so it runs in the ordinary unit job.
+ *
+ * This file deliberately does NOT mock `../db/schema`, so it exercises the real
+ * `users` columns the production query builds against.
+ */
+import { describe, it, expect } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { buildUnpromotedAdminMatch } from './platformAdminBootstrap';
+
+function render(emails: string[]): { sql: string; params: unknown[] } {
+  const { sql, params } = new PgDialect().sqlToQuery(
+    buildUnpromotedAdminMatch(emails)
+  );
+  return { sql, params };
+}
+
+describe('buildUnpromotedAdminMatch — rendered SQL shape (#2655 regression)', () => {
+  it('binds one param per email, never a single ::text[] array param', () => {
+    const emails = ['a@x.com', 'b@x.com', 'c@x.com'];
+    const { sql, params } = render(emails);
+
+    // The core regression: no array-literal cast, no `= ANY(...)`.
+    expect(sql).not.toMatch(/::text\[\]/i);
+    expect(sql).not.toMatch(/=\s*any/i);
+
+    // Positive: an IN list with individual placeholders.
+    expect(sql.toLowerCase()).toContain('lower(');
+    expect(sql.toLowerCase()).toMatch(/in \(\$\d+, \$\d+, \$\d+\)/);
+
+    // Each email is its own bound param (as a plain string), plus the
+    // isPlatformAdmin = false comparand. Crucially, NO param is the array
+    // itself — that is exactly the value the prod bundle mis-serialized.
+    for (const email of emails) {
+      expect(params).toContain(email);
+    }
+    expect(params).not.toContainEqual(emails);
+    expect(params).toContain(false);
+  });
+
+  it('renders a single-element list as one placeholder (the case that failed live)', () => {
+    // The reported failure was a single-element env list
+    // (`conformance@breeze.local`) — the array-literal path failed every time.
+    const { sql, params } = render(['conformance@breeze.local']);
+
+    expect(sql).not.toMatch(/::text\[\]/i);
+    expect(sql.toLowerCase()).toMatch(/in \(\$\d+\)/);
+    expect(params).toContain('conformance@breeze.local');
+    expect(params).not.toContainEqual(['conformance@breeze.local']);
+  });
+
+  it('gates the not-yet-promoted filter into the same predicate', () => {
+    const { sql } = render(['a@x.com']);
+    // Both halves present: the email match AND the idempotency guard.
+    expect(sql.toLowerCase()).toContain('is_platform_admin');
+    expect(sql.toLowerCase()).toContain(' and ');
+  });
+});

--- a/apps/api/src/services/platformAdminBootstrap.ts
+++ b/apps/api/src/services/platformAdminBootstrap.ts
@@ -1,6 +1,29 @@
-import { sql } from 'drizzle-orm';
+import { and, eq, inArray, sql, type SQL } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../db';
 import { users } from '../db/schema';
+
+/**
+ * WHERE predicate matching the not-yet-promoted users whose (lowercased) email
+ * is in `emails`.
+ *
+ * Uses `inArray` — which renders `lower(email) in ($1, $2, ...)` with ONE bound
+ * param per email — rather than interpolating the JS array into a raw `sql`
+ * template as `= ANY(${emails}::text[])`. The `= ANY(...::text[])` form binds
+ * the whole array as a single param, and in the production CJS bundle that
+ * param's text reaches Postgres as a bare string (not a `{...}` array literal),
+ * so the `::text[]` cast fails at runtime with `malformed array literal` — even
+ * though it worked under dev/vitest. Emitting one param per email removes the
+ * array serialization entirely, so the failure class can't recur. (#2655)
+ *
+ * Callers must pass a non-empty array (`inArray([])` renders `in ()`, invalid
+ * SQL); `bootstrapPlatformAdmins` guarantees this via its early return.
+ */
+export function buildUnpromotedAdminMatch(emails: string[]): SQL {
+  return and(
+    inArray(sql`lower(${users.email})`, emails),
+    eq(users.isPlatformAdmin, false)
+  )!;
+}
 
 /**
  * Idempotent bootstrap that promotes users listed in BREEZE_PLATFORM_ADMINS
@@ -23,9 +46,7 @@ export async function bootstrapPlatformAdmins(): Promise<void> {
     const result = await db
       .update(users)
       .set({ isPlatformAdmin: true })
-      .where(
-        sql`lower(${users.email}) = ANY(${emails}::text[]) AND ${users.isPlatformAdmin} = false`
-      )
+      .where(buildUnpromotedAdminMatch(emails))
       .returning({ id: users.id, email: users.email });
     return result;
   });

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -53,6 +53,11 @@ export default defineConfig({
       // no-DB unit runner would fail it on connect. Belongs to
       // vitest.integration.config.ts.
       'src/routes/agents/inventorySoftwareRelink.integration.test.ts',
+      // Platform-admin bootstrap real-DB test (#2655): imports
+      // `__tests__/integration/setup` (real postgres pool + autoMigrate in its
+      // beforeAll), so the no-DB unit runner would fail it on connect. Belongs to
+      // vitest.integration.config.ts (already in its include).
+      'src/services/platformAdminBootstrap.integration.test.ts',
       // Auth-email worker real-DB test (SR2-22): imports `__tests__/integration/setup`
       // (real postgres pool + autoMigrate + real Redis) and lives in src/jobs/ — outside
       // the `src/__tests__/integration/**` glob above — so the no-DB unit runner would

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -21,6 +21,11 @@ export default defineConfig({
       // Co-located real-DB integration test for the contract renewal sweep
       // service. Follows the same pattern as the inboundEmail test above.
       'src/services/contractRenewal.integration.test.ts',
+      // Co-located real-DB integration test for the platform-admin bootstrap
+      // (#2655): the mocked unit suite executes no SQL, so it never caught the
+      // prod-bundle `= ANY(::text[])` array-literal failure. This drives the
+      // real promotion UPDATE against Postgres under system-scoped RLS.
+      'src/services/platformAdminBootstrap.integration.test.ts',
       // Worker-level integration test: renewal pre-pass runs before billing sweep
       // so an at-boundary auto-renew contract bills instead of expiring.
       'src/jobs/contractWorker.renewal.integration.test.ts',


### PR DESCRIPTION
## Summary

The startup bootstrap that promotes `BREEZE_PLATFORM_ADMINS` to platform admin matched users with a raw-template array cast:

```ts
sql`lower(${users.email}) = ANY(${emails}::text[]) AND ${users.isPlatformAdmin} = false`
```

`emails` (a JS `string[]`) is bound as a **single** param cast to `::text[]`. That works under dev/vitest, but in the production CJS bundle the array param reaches Postgres as a **bare string** (`conformance@breeze.local`, not `{conformance@breeze.local}`), so the `::text[]` cast fails at boot:

```
PostgresError: malformed array literal: "conformance@breeze.local"
```

`index.ts` wraps `bootstrapPlatformAdmins()` in a non-fatal try/catch, so the only signal was a `[startup] Platform admin bootstrap failed (non-fatal)` log line — the configured admin was **silently never promoted** (observed live on a stock-image boot; workaround was a manual psql `UPDATE`).

## Fix

Replace the raw-template `= ANY(...::text[])` with drizzle's `inArray`, extracted into an exported, DB-free `buildUnpromotedAdminMatch(emails)` helper. `inArray` renders `lower(email) in ($1, $2, ...)` — **one bound param per email, no array to serialize** — so the bundle-serialization failure class cannot recur. The `emails.length === 0` early return guarantees `inArray` never receives an empty array.

## Tests

- **`platformAdminBootstrap.sql.test.ts`** (unit, no DB) — renders the real predicate through drizzle's Postgres dialect and asserts individual `in ($1, $2, ...)` params with **no `::text[]` cast**. It **fails on the old `= ANY(::text[])` form and passes on the fix**, and runs in the ordinary unit job. This is the guard the pre-existing mocked suite couldn't be (it mocks `../db` and serializes no SQL — exactly why the bug survived to a live image).
- **`platformAdminBootstrap.integration.test.ts`** (real Postgres, CI) — drives the actual promotion `UPDATE` under system-scoped RLS: single email, multiple comma-separated emails, case-insensitive `lower()` match, only-listed-users-promoted, and idempotency. Registered in `vitest.integration.config.ts`.

> Note: the underlying defect is a *bundle-only* param-serialization difference, so a real-Postgres test under vitest would pass on the old code too — the SQL-shape test is the true regression guard. The integration test's value is being the first coverage that executes the real promotion SQL end-to-end.

Closes #2655

🤖 Generated with [Claude Code](https://claude.com/claude-code)