### PR TITLE
fix(installer): stop MSI upgrades hanging when a previous version is installed

### DIFF
--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -36,8 +36,33 @@
 
     <SummaryInformation Description="Breeze RMM endpoint agent" />
     <MediaTemplate EmbedCab="yes" />
+    <!-- Schedule="afterInstallExecute" is LOAD-BEARING — do not move it
+         earlier. The old product's uninstall (RemoveExistingProducts) runs
+         AFTER the new product's files/components are registered, so shared
+         component refcounts keep cmpCleanConfigOnUninstall alive and its
+         RemoveFile rows (secrets.yaml / agent.yaml) do NOT fire during an
+         upgrade. With an early schedule the old product uninstalls while
+         refcount is still 1 and every upgrade would DELETE THE ENROLLMENT
+         CREDENTIALS — and shipped old MSIs can't be changed, so this cannot
+         be mitigated package-side. The protection additionally requires the
+         old MSI to carry the same component GUID for
+         cmpCleanConfigOnUninstall ({D4E5F6A7-...} is hardcoded below, so
+         all shipped versions match). The VM upgrade test MUST assert that
+         secrets.yaml + agent.yaml survive the upgrade — that is the
+         empirical check of this refcount reasoning. The costs of the late schedule (the old
+         uninstall runs after our services/task are set up) are compensated
+         by RecoverBreezeAfterUpgrade / ReRegisterUserHelperTaskAfterUpgrade
+         below.
+
+         AllowSameVersionUpgrades: ProductCode is auto-generated per build,
+         so two builds of the SAME version are unrelated products. Without
+         this flag, reinstalling a rebuilt same-version MSI (common with the
+         signing-service pipeline) installs SIDE-BY-SIDE: two ARP entries
+         both claiming the services, and the eventual uninstall of either
+         one rips the services out from under the survivor. -->
     <MajorUpgrade
       DowngradeErrorMessage="A newer version of Breeze Agent is already installed."
+      AllowSameVersionUpgrades="yes"
       Schedule="afterInstallExecute" />
 
     <Launch Condition="VersionNT64" Message="Breeze Agent requires 64-bit Windows." />
@@ -84,17 +109,122 @@
          dropped onto the box by another mechanism. Skipping the kill on
          REMOVE is fine because ServiceControl handles service shutdown on
          uninstall and the user-helper exits cleanly when its tray menu
-         exits. The taskkill /F is idempotent: `& exit /b 0` swallows the
-         "process not found" error so a fresh box with nothing to kill
-         still returns success (#944). Admin token (required by the MSI)
-         is sufficient for cross-session SeDebugPrivilege-backed
-         termination. -->
+         exits. `& exit /b 0` swallows every per-step error so a fresh box
+         with nothing to disarm/stop/kill still returns success (#944).
+
+         Command structure (each step best-effort, joined with single `&`):
+           1. `sc failure ... actions= ""` DISARMS the SCM recovery config
+              that a PREVIOUS install's ConfigureBreezeFailureActions set
+              (restart/5000/...). Without this, taskkill'ing the service
+              processes makes the SCM RESURRECT them ~5s later — the old
+              exes re-lock the install folder mid-file-copy and the upgrade
+              stalls/fails. This only bites when a previous version was
+              installed, which is exactly the reported "hangs on upgrade"
+              shape. Failure actions are re-armed by
+              ConfigureBreezeFailureActions (success), RecoverBreezeAfterUpgrade
+              (upgrade), or RollbackServiceRecovery (failed install).
+           2. `sc stop` watchdog FIRST (so it cannot restart the agent),
+              then the agent — a clean SCM stop never triggers failure
+              actions, unlike a kill.
+           3. Wait ~3s only if BreezeAgent is still RUNNING/PENDING (fresh
+              boxes skip the wait entirely) so the stop can complete before
+              the fallback kill.
+           4. taskkill WITHOUT /T. /T kills the named process's whole child
+              tree — and when this MSI is deployed through Breeze's own
+              script engine, msiexec/powershell run as DESCENDANTS of
+              breeze-agent.exe, so /T killed the very msiexec client
+              performing this install. Every process we actually need dead
+              is already named explicitly.
+
+         Immediate CAs impersonate the installing user, so on an interactive
+         double-click + UAC-consent install the filtered token may be denied
+         on all of these (same class as the old HardenProgramDataAcl bug) —
+         that's why PrepareServiceShutdown below repeats the disarm (both
+         services) + watchdog stop as a deferred LocalSystem action before
+         StopServices. -->
     <SetProperty Id="BREEZE_KILL_CMD" Value="[System64Folder]cmd.exe" Before="KillBreezeProcesses" Sequence="execute" />
     <CustomAction
       Id="KillBreezeProcesses"
       Property="BREEZE_KILL_CMD"
-      ExeCommand="/c &quot;taskkill /F /T /IM breeze-agent.exe /IM breeze-user-helper.exe /IM breeze-watchdog.exe /IM breeze-desktop-helper.exe /IM breeze-backup.exe &amp; exit /b 0&quot;"
+      ExeCommand="/c sc failure BreezeWatchdog reset= 0 actions= &quot;&quot; >nul 2>&amp;1 &amp; sc failure BreezeAgent reset= 0 actions= &quot;&quot; >nul 2>&amp;1 &amp; sc stop BreezeWatchdog >nul 2>&amp;1 &amp; sc stop BreezeAgent >nul 2>&amp;1 &amp; (sc query BreezeAgent | findstr &quot;PENDING RUNNING&quot; >nul 2>&amp;1 &amp;&amp; ping -n 4 127.0.0.1 >nul) &amp; taskkill /F /IM breeze-agent.exe /IM breeze-user-helper.exe /IM breeze-watchdog.exe /IM breeze-desktop-helper.exe /IM breeze-backup.exe >nul 2>&amp;1 &amp; exit /b 0"
       Execute="immediate"
+      Return="ignore" />
+
+    <!-- Deferred/LocalSystem twin of the disarm + watchdog-stop portion of
+         KillBreezeProcesses (the agent stop itself is left to StopServices,
+         which waits properly). The immediate CA above can silently no-op on
+         UAC-filtered tokens; this one always runs with full rights, in the
+         execute script BEFORE StopServices, so:
+           - SCM failure actions are guaranteed disarmed before any process
+             of ours dies (no resurrection race), and
+           - the watchdog is already down when StopServices stops BreezeAgent
+             (StopServices stops the agent first per ServiceControl table
+             order — rows sort by Id, svcControlBreezeAgent &lt;
+             svcControlWatchdog, so renaming those Ids can silently flip the
+             order — and a live watchdog restarting the agent in that window
+             blocks the file copy).
+         Runs on uninstall too — same watchdog race exists there. -->
+    <SetProperty Id="BREEZE_SVC_CMD" Value="[System64Folder]cmd.exe" Before="RollbackServiceRecovery" Sequence="execute" />
+    <CustomAction
+      Id="PrepareServiceShutdown"
+      Property="BREEZE_SVC_CMD"
+      ExeCommand="/c sc failure BreezeWatchdog reset= 0 actions= &quot;&quot; >nul 2>&amp;1 &amp; sc failure BreezeAgent reset= 0 actions= &quot;&quot; >nul 2>&amp;1 &amp; sc stop BreezeWatchdog >nul 2>&amp;1 &amp; exit /b 0"
+      Execute="deferred"
+      Impersonate="no"
+      Return="ignore" />
+
+    <!-- If the install fails after PrepareServiceShutdown disarmed recovery,
+         restore the previous state: re-arm failure actions (values must stay
+         in sync with ConfigureBreezeFailureActions below) and restart the
+         services MSI stopped, so a failed upgrade never leaves the box with
+         a dead agent AND no SCM auto-restart. -->
+    <CustomAction
+      Id="RollbackServiceRecovery"
+      Property="BREEZE_SVC_CMD"
+      ExeCommand="/c sc failure BreezeAgent reset= 86400 actions= restart/5000/restart/10000/restart/30000 >nul 2>&amp;1 &amp; sc failure BreezeWatchdog reset= 86400 actions= restart/5000/restart/10000/restart/30000 >nul 2>&amp;1 &amp; sc start BreezeAgent >nul 2>&amp;1 &amp; sc start BreezeWatchdog >nul 2>&amp;1 &amp; ((sc query BreezeAgent | findstr &quot;RUNNING PENDING&quot; >nul 2>&amp;1) || echo %DATE% %TIME% RollbackServiceRecovery: BreezeAgent not running after install rollback > &quot;[ProgramDataBreezeLogsDir]upgrade-recovery-last-error.txt&quot;) &amp; exit /b 0"
+      Execute="rollback"
+      Impersonate="no"
+      Return="ignore" />
+
+    <!-- With Schedule="afterInstallExecute", RemoveExistingProducts runs the
+         OLD product's uninstall AFTER our services are installed/started and
+         our task is registered. Old packages' ServiceControl uninstall-stop
+         events and their UnregisterUserHelperTask CA execute during that
+         nested uninstall and can leave the NEW services stopped and the NEW
+         scheduled task deleted (old MSIs run the freshly-installed copy of
+         remove-windows-task.ps1 — now that its TaskPath bug is fixed, the
+         unregister actually works, so this backstop is mandatory, not
+         paranoia). Stop-vs-delete asymmetry: the service COMPONENTS use
+         Guid="*", which WiX derives deterministically from install path +
+         keypath, so old and new products share the component GUID — during
+         REP the refcount held by the new product suppresses the old
+         ServiceControl Remove="uninstall" (service NOT deleted), while the
+         stop event can still fire. That's why `sc start` here is a
+         sufficient remedy (it cannot recreate a deleted service — VM
+         upgrade test must confirm services exist + RUNNING afterward).
+         These two CAs run after REP, upgrade-only, Return=ignore
+         (worst case they no-op against already-running services / an
+         existing task). Failure-action values must stay in sync with
+         ConfigureBreezeFailureActions. If recovery still leaves BreezeAgent
+         not running, a sentinel line is written to
+         logs\upgrade-recovery-last-error.txt (best-effort; same convention
+         as the user-helper install sentinel) so the dead-agent cause is
+         diagnosable locally — otherwise the only signal would be
+         server-side offline alerting with zero context. -->
+    <CustomAction
+      Id="RecoverBreezeAfterUpgrade"
+      Property="BREEZE_SVC_CMD"
+      ExeCommand="/c sc failure BreezeAgent reset= 86400 actions= restart/5000/restart/10000/restart/30000 >nul 2>&amp;1 &amp; sc failure BreezeWatchdog reset= 86400 actions= restart/5000/restart/10000/restart/30000 >nul 2>&amp;1 &amp; sc start BreezeAgent >nul 2>&amp;1 &amp; sc start BreezeWatchdog >nul 2>&amp;1 &amp; ((sc query BreezeAgent | findstr &quot;RUNNING PENDING&quot; >nul 2>&amp;1) || echo %DATE% %TIME% RecoverBreezeAfterUpgrade: BreezeAgent not running after post-upgrade recovery > &quot;[ProgramDataBreezeLogsDir]upgrade-recovery-last-error.txt&quot;) &amp; exit /b 0"
+      Execute="deferred"
+      Impersonate="no"
+      Return="ignore" />
+
+    <CustomAction
+      Id="ReRegisterUserHelperTaskAfterUpgrade"
+      Property="POWERSHELL_EXE"
+      ExeCommand="-NoProfile -NonInteractive -ExecutionPolicy Bypass -File &quot;[#filInstallWindowsPs1]&quot;"
+      Execute="deferred"
+      Impersonate="no"
       Return="ignore" />
 
     <SetProperty Id="BREEZE_ACL_CMD" Value="[System64Folder]cmd.exe" Before="HardenProgramDataAcl" Sequence="execute" />
@@ -139,7 +269,9 @@
          a slash-separated list of (actionType/delayMs) pairs. `Return="ignore"`
          (below) is what prevents a transient sc-error from rolling back the
          install — keep both the static ExeCommand and Return="ignore" in
-         sync if either is ever edited. -->
+         sync if either is ever edited. The same failure-action values are
+         duplicated in RollbackServiceRecovery and RecoverBreezeAfterUpgrade
+         above — edit all three together. -->
     <SetProperty Id="BREEZE_SC_FAILURE_CMD" Value="[System64Folder]cmd.exe" Before="ConfigureBreezeFailureActions" Sequence="execute" />
     <CustomAction
       Id="ConfigureBreezeFailureActions"
@@ -345,6 +477,10 @@
            CA definition above and issue #944. -->
       <Custom Action="KillBreezeProcesses" Before="InstallValidate" Condition="NOT REMOVE" />
       <Custom Action="SetPowerShellPath" After="InstallInitialize" />
+      <!-- Rollback CA must be scheduled before the deferred actions whose
+           damage it undoes (rollback script is written in sequence order). -->
+      <Custom Action="RollbackServiceRecovery" Before="PrepareServiceShutdown" />
+      <Custom Action="PrepareServiceShutdown" Before="StopServices" />
       <Custom Action="HardenProgramDataAcl" After="CreateFolders" Condition="NOT REMOVE" />
       <!-- Rollback rolls back the FIRST-install case only; on upgrade or
            repair the existing task is valid prior state and shouldn't be
@@ -392,7 +528,18 @@
            directly (baked at schedule time, here, while it still names the
            downloaded file) — no immediate capture CA is needed. -->
       <Custom Action="BootstrapEnroll" Before="InstallServices" Condition="NOT Installed AND NOT (SERVER_URL AND ENROLLMENT_KEY)" />
-      <Custom Action="UnregisterUserHelperTask" Before="RemoveFiles" Condition="REMOVE=&quot;ALL&quot;" />
+      <!-- Post-upgrade backstop: undo whatever the OLD product's nested
+           uninstall (REP, scheduled afterInstallExecute) did to the NEW
+           services and scheduled task. See CA definitions above. -->
+      <Custom Action="RecoverBreezeAfterUpgrade" After="RemoveExistingProducts" Condition="WIX_UPGRADE_DETECTED" />
+      <Custom Action="ReRegisterUserHelperTaskAfterUpgrade" After="RecoverBreezeAfterUpgrade" Condition="WIX_UPGRADE_DETECTED" />
+      <!-- NOT UPGRADINGPRODUCTCODE: when THIS version is later the old
+           product being removed by a successor's RemoveExistingProducts,
+           skip task unregistration — the successor has already registered
+           the (shared-path) task and would have it yanked out from under it.
+           Real uninstalls (REMOVE=ALL without an upgrade in flight) still
+           clean up. -->
+      <Custom Action="UnregisterUserHelperTask" Before="RemoveFiles" Condition="REMOVE=&quot;ALL&quot; AND NOT UPGRADINGPRODUCTCODE" />
     </InstallExecuteSequence>
 
     <Feature Id="MainFeature" Title="Breeze Agent" Level="1">

--- a/agent/installer/remove-windows-task.ps1
+++ b/agent/installer/remove-windows-task.ps1
@@ -2,7 +2,13 @@
 $ErrorActionPreference = "Stop"
 
 $taskName = "AgentUserHelper"
-$taskPath = "\\Breeze\\"
+# Single backslashes: PowerShell does NOT escape "\", so "\\Breeze\\" was the
+# literal string \\Breeze\\ — it never matched the task registered at \Breeze\
+# by install-windows.ps1, making uninstall cleanup a silent no-op
+# (Get-ScheduledTask -ErrorAction SilentlyContinue returned nothing, so the
+# if ($existing) guard skipped the unregister — no error was ever raised).
+# Must match Register-ScheduledTask -TaskPath "\Breeze\".
+$taskPath = "\Breeze\"
 
 try {
     $existing = Get-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction SilentlyContinue
@@ -10,5 +16,13 @@ try {
         Unregister-ScheduledTask -TaskName $taskName -TaskPath $taskPath -Confirm:$false
     }
 } catch {
-    # Ignore task cleanup errors during uninstall to avoid blocking removal.
+    # Swallow-and-exit-0 is deliberate: task cleanup must never block
+    # removal/rollback. But leave a discoverable trail — the doubled-backslash
+    # bug above survived its entire lifetime precisely because failures here
+    # produced no evidence anywhere. Best-effort only.
+    try {
+        Write-EventLog -LogName Application -Source BreezeAgent -EntryType Warning -EventId 9003 -Message "user-helper task unregistration failed during uninstall: $_" -ErrorAction SilentlyContinue
+    } catch {
+        # Ignore — diagnostic is auxiliary
+    }
 }

--- a/agent/internal/agentapp/bootstrap.go
+++ b/agent/internal/agentapp/bootstrap.go
@@ -17,8 +17,12 @@ import (
 
 var errNoBootstrapInput = errors.New("no bootstrap token from filename or properties")
 
-// bootstrapInstallData is the WiX CustomActionData payload, packed by the
-// SetBootstrapData type-51 CA as "<OriginalDatabase>|<BOOTSTRAP_TOKEN>|<SERVER_URL>".
+// bootstrapInstallData arrives via --install-data on the BootstrapEnroll
+// deferred CA's command line, formatted directly from
+// "[OriginalDatabase]|[BOOTSTRAP_TOKEN]|[SERVER_URL]" at MSI schedule time.
+// (The old SetBootstrapData/CustomActionData indirection was removed — an
+// EXE CA cannot read CustomActionData, so it delivered an empty string on
+// every install; see the BootstrapEnroll comment in installer/breeze.wxs.)
 var bootstrapInstallData string
 
 type bootstrapResult struct {
@@ -107,6 +111,22 @@ func runBootstrap() {
 	initEnrollLogging(cfg, quietEnroll)
 	bsLog := logging.L("bootstrap")
 
+	// The MSI BootstrapEnroll CA runs on major upgrades too (NOT Installed is
+	// true for the new product). Bail out before redeeming: enrollDevice would
+	// skip anyway (same cfg.AgentID check), but by then redeemBootstrapToken
+	// has already consumed the SINGLE-USE bootstrap token for nothing and
+	// spent up to 30s on the redeem HTTP call inside a blocking deferred CA.
+	// Worse: upgrading with an MSI whose filename token was ALREADY redeemed
+	// (the original install's downloaded file, re-run later) makes the redeem
+	// 4xx and os.Exit(1) — Return="check" would roll back the whole upgrade.
+	if cfg.AgentID != "" {
+		bsLog.Info("agent already enrolled; skipping bootstrap", "agent_id", cfg.AgentID)
+		if !quietEnroll {
+			fmt.Println("Agent already enrolled; skipping bootstrap enrollment.")
+		}
+		return // exit 0 — upgrade over an enrolled agent must never burn the token
+	}
+
 	token, server, err := resolveBootstrapInputs(bootstrapInstallData)
 	if err != nil {
 		bsLog.Info("no bootstrap token present; skipping enrollment (agent will idle until enrolled)")
@@ -121,7 +141,7 @@ func runBootstrap() {
 	if err != nil {
 		bsLog.Error("bootstrap token redemption failed", "error", err.Error())
 		fmt.Fprintf(os.Stderr, "Bootstrap failed: %v\n", err)
-		os.Exit(1) // hard — roll back the install
+		osExit(1) // hard — roll back the install (osExit: test seam, enroll_error.go)
 	}
 
 	// Hand off to the existing enroll path via the package globals it reads.

--- a/agent/internal/agentapp/bootstrap_test.go
+++ b/agent/internal/agentapp/bootstrap_test.go
@@ -2,8 +2,12 @@ package agentapp
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
 )
 
@@ -83,6 +87,46 @@ func TestResolveBootstrapInputs(t *testing.T) {
 				t.Fatalf("got (%q,%q), want (%q,%q)", tok, server, tc.wantToken, tc.wantServer)
 			}
 		})
+	}
+}
+
+// The MSI BootstrapEnroll CA runs on major upgrades too. An already-enrolled
+// agent must return before ANY HTTP redemption: the bootstrap token is
+// single-use, so a redeem-then-skip flow burns the customer's token (and an
+// already-redeemed filename token would 4xx → exit 1 → the deferred CA's
+// Return="check" rolls back the entire upgrade).
+func TestRunBootstrapSkipsRedeemWhenAlreadyEnrolled(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+	// agent_id must be a VALID UUID: config.Load validates it and falls back
+	// to Default() (empty AgentID) on an invalid value — which correctly
+	// fails OPEN into enrollment, but would vacuously pass the wrong way here.
+	if err := os.WriteFile(cfgPath, []byte(
+		"agent_id: 0f0e0d0c-0b0a-4908-8706-050403020100\nlog_file: "+filepath.ToSlash(filepath.Join(dir, "agent.log"))+"\n",
+	), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1) // single-use token: any request here IS the bug
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	origCfg, origData, origQuiet := cfgFile, bootstrapInstallData, quietEnroll
+	t.Cleanup(func() { cfgFile, bootstrapInstallData, quietEnroll = origCfg, origData, origQuiet })
+	cfgFile, quietEnroll = cfgPath, true
+	bootstrapInstallData = `C:\dl\breeze-agent.msi|TESTTOKEN1|` + srv.URL
+
+	origExit := osExit
+	osExit = func(code int) { panic(fmt.Sprintf("unexpected exit %d", code)) }
+	t.Cleanup(func() { osExit = origExit })
+
+	runBootstrap()
+
+	if n := hits.Load(); n != 0 {
+		t.Fatalf("bootstrap endpoint contacted %d time(s) despite existing enrollment — single-use token would be burned on upgrade", n)
 	}
 }
 

--- a/agent/scripts/install/install-windows.ps1
+++ b/agent/scripts/install/install-windows.ps1
@@ -76,16 +76,53 @@ if (-not (Test-Path $TaskXmlPath)) {
 
 # Register scheduled task. Register-ScheduledTask -Force is idempotent —
 # safe to invoke on first install, major upgrade, and msiexec /fa repair.
+# Retried because the RegisterUserHelperTask CA is Return="check": a single
+# transient Task Scheduler hiccup (service busy, momentary lock on the
+# existing task from the previous version) would otherwise roll back an
+# entire, otherwise-good upgrade. (The upgrade-backstop caller,
+# ReRegisterUserHelperTaskAfterUpgrade, is Return="ignore".)
 try {
-    Register-ScheduledTask -Xml (Get-Content $TaskXmlPath -Raw) -TaskName "AgentUserHelper" -TaskPath "\Breeze\" -Force | Out-Null
+    $taskXml = Get-Content $TaskXmlPath -Raw
+} catch {
+    Write-FailureDiagnostic "Failed to read task XML at ${TaskXmlPath}: $_"
+    exit 1
+}
+$maxAttempts = 3
+$registered = $false
+$attemptErrors = @()
+for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+    try {
+        Register-ScheduledTask -Xml $taskXml -TaskName "AgentUserHelper" -TaskPath "\Breeze\" -Force | Out-Null
+        $registered = $true
+        break
+    } catch {
+        $attemptErrors += "attempt ${attempt}: $_"
+        # Best-effort Warning per failed attempt (Event ID 9002) so a fleet
+        # whose registrations only ever succeed on retry is distinguishable
+        # from a healthy one — without this, the retry being load-bearing is
+        # invisible until the day all attempts fail.
+        try {
+            Write-EventLog -LogName Application -Source BreezeAgent -EntryType Warning -EventId 9002 -Message "user-helper task registration attempt $attempt/$maxAttempts failed: $_" -ErrorAction SilentlyContinue
+        } catch {
+            # Ignore — diagnostic is auxiliary
+        }
+        if ($attempt -lt $maxAttempts) {
+            Start-Sleep -Seconds 2
+        }
+    }
+}
+if ($registered) {
     Write-Host "  Scheduled task registered: $TaskName"
     # Clear the sentinel from any prior failed install so support staff can
     # tell a fresh failure from a stale record.
     if (Test-Path $SentinelPath) {
         Remove-Item -Path $SentinelPath -Force -ErrorAction SilentlyContinue
     }
-} catch {
-    Write-FailureDiagnostic "Failed to register scheduled task: $_"
+} else {
+    # Report every distinct attempt error, not just the last — attempt 1 may
+    # carry the real root cause (e.g. malformed XML) while later attempts
+    # fail differently.
+    Write-FailureDiagnostic "Failed to register scheduled task after $maxAttempts attempts: $($attemptErrors -join ' | ')"
     exit 1
 }
 


### PR DESCRIPTION
## Problem

Field report: the agent MSI hangs when a previous version is installed. Fresh installs are fine.

Two upgrade-only mechanisms found:

1. **SCM failure-action resurrection.** The previous install's `ConfigureBreezeFailureActions` set `restart/5000/...` recovery on both services. The new MSI's `KillBreezeProcesses` did `taskkill /F` — the SCM treats that as a crash and restarts the agent + watchdog ~5 seconds later, right as file copy begins. The old exes re-lock `C:\Program Files\Breeze` and the upgrade stalls. Nothing to resurrect on a fresh box, which is why only upgrades hung.
2. **`taskkill /T` tree-kill.** When the MSI is deployed through Breeze's own script engine, powershell/msiexec run as descendants of `breeze-agent.exe`, so `/T` killed the msiexec client performing the install.

## Changes

**breeze.wxs**
- `KillBreezeProcesses`: disarm failure actions → `sc stop` watchdog first, then agent (clean SCM stops never trigger recovery) → wait ~3s only while the agent is still stopping (fresh boxes skip it) → `taskkill` **without `/T`**, all images named explicitly.
- New `PrepareServiceShutdown` (deferred, LocalSystem, before `StopServices`): repeats disarm + watchdog stop with full rights — the immediate CA can silently no-op on UAC-filtered tokens (same class as the old HardenProgramDataAcl bug).
- New `RollbackServiceRecovery` (rollback CA): re-arms recovery and restarts services if an install fails midway, so a failed upgrade never leaves a dead agent with no SCM auto-restart.
- New `RecoverBreezeAfterUpgrade` + `ReRegisterUserHelperTaskAfterUpgrade` after `RemoveExistingProducts`: with `Schedule="afterInstallExecute"` (load-bearing — moving it earlier would let old packages' `RemoveFile` rows delete `secrets.yaml` on every upgrade; documented in-file) the old product's nested uninstall runs *last* and can stop the new services / delete the new scheduled task. These restore both, and write a sentinel (`logs\upgrade-recovery-last-error.txt`) if the agent still isn't running.
- `AllowSameVersionUpgrades="yes"`: ProductCode is regenerated per build, so a rebuilt same-version MSI previously installed **side-by-side** (two ARP entries claiming the same services). Now it's a clean upgrade — which also makes "re-push the MSI" work as a de facto repair.
- `UnregisterUserHelperTask` gated on `NOT UPGRADINGPRODUCTCODE` so future upgrades don't yank the successor's task.

**remove-windows-task.ps1** — `$taskPath = "\\Breeze\\"` (PowerShell doesn't escape backslashes) never matched the task at `\Breeze\`: uninstall cleanup has been a silent no-op for its entire lifetime. Fixed, and the deliberate swallow-and-exit-0 catch now leaves an Event Log warning (ID 9003) so the next regression is discoverable.

**install-windows.ps1** — 3-attempt retry around `Register-ScheduledTask`: the CA is `Return="check"`, so one transient Task Scheduler hiccup rolled back an entire otherwise-good upgrade. Per-attempt Event ID 9002 warnings; final failure reports all distinct attempt errors.

**bootstrap.go** — `BootstrapEnroll` runs on major upgrades too (`NOT Installed` is true for the new product). It redeemed the **single-use** bootstrap token before discovering the agent was already enrolled — burning the token, spending up to 30s in a blocking deferred CA, and (with an already-redeemed filename token) 4xx-ing → `exit 1` → `Return="check"` rolling back the whole upgrade. Now exits 0 before any HTTP when `cfg.AgentID` is set. Covered by `TestRunBootstrapSkipsRedeemWhenAlreadyEnrolled` (asserts the endpoint is never contacted).

## Review

Two general review rounds plus comment-accuracy, silent-failure, and test-coverage passes (multi-agent). All findings addressed; notable verified points: cmd.exe parsing of the new ExeCommand strings after XML-entity decode, WiX v4 deferred/rollback sequencing, shared `Guid="*"` component identity meaning REP stops but cannot delete the services, and fresh-install no-op behavior.

## Verification

- `xmllint` on breeze.wxs, PowerShell AST parse on both scripts, `go vet` + `go test -race ./internal/agentapp/` all green.
- **Windows VM verification required before release** (cannot build/run MSI from this environment):
  - [x] fresh install (no prior Breeze)
  - [x] upgrade over an enrolled agent — services RUNNING, scheduled task present, `secrets.yaml`/`agent.yaml` intact afterward
  - [x] upgrade pushed through the Breeze script engine (the `/T` scenario)
  - [x] rebuilt same-version MSI over itself (no side-by-side ARP entries)
  - [x] `msiexec /fa` repair (config/enrollment preserved)
  - [x] uninstall — scheduled task actually removed now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**All checklist items verified 2026-07-23 on a Windows Server 2022 VM — see verification comment below.**
