### PR TITLE
fix(api): forward event-log details to SIEM instead of stripped rawData (#2643)

### DIFF
--- a/apps/api/src/jobs/logForwardingWorker.test.ts
+++ b/apps/api/src/jobs/logForwardingWorker.test.ts
@@ -85,7 +85,7 @@ describe('enqueueLogForwarding', () => {
         source: 's'.repeat(400),
         message: 'm'.repeat(5000),
         timestamp: '2026-03-31T12:00:00.000Z',
-        rawData: { big: 'x'.repeat(20 * 1024) },
+        details: { big: 'x'.repeat(20 * 1024) },
       })),
     });
 
@@ -97,6 +97,29 @@ describe('enqueueLogForwarding', () => {
     expect(queued.events[0]?.level).toHaveLength(256);
     expect(queued.events[0]?.source).toHaveLength(256);
     expect(queued.events[0]?.message).toHaveLength(4096);
-    expect(queued.events[0]?.rawData).toBeUndefined();
+    // Oversized details (>16KB serialized) is dropped rather than forwarded.
+    expect(queued.events[0]?.details).toBeUndefined();
+  });
+
+  it('forwards in-bound details unchanged', async () => {
+    await enqueueLogForwarding({
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      hostname: 'host-1',
+      events: [
+        {
+          category: 'security',
+          level: 'warning',
+          source: 'auth',
+          message: 'failed logon',
+          timestamp: '2026-03-31T12:00:00.000Z',
+          details: { user: 'alice', attempts: 3 },
+        },
+      ],
+    });
+
+    expect(addMock).toHaveBeenCalledTimes(1);
+    const queued = addMock.mock.calls[0]?.[1];
+    expect(queued.events[0]?.details).toEqual({ user: 'alice', attempts: 3 });
   });
 });

--- a/apps/api/src/jobs/logForwardingWorker.ts
+++ b/apps/api/src/jobs/logForwardingWorker.ts
@@ -42,7 +42,7 @@ const MAX_LOG_FORWARDING_EVENTS = 500;
 const MAX_LOG_FORWARDING_HOSTNAME = 255;
 const MAX_LOG_FORWARDING_FIELD = 256;
 const MAX_LOG_FORWARDING_MESSAGE = 4096;
-const MAX_LOG_FORWARDING_RAW_DATA_BYTES = 16 * 1024;
+const MAX_LOG_FORWARDING_DETAILS_BYTES = 16 * 1024;
 
 interface LogForwardingJobData {
   orgId: string;
@@ -54,7 +54,7 @@ interface LogForwardingJobData {
     source: string;
     message: string;
     timestamp: string;
-    rawData?: unknown;
+    details?: unknown;
   }>;
 }
 
@@ -65,17 +65,17 @@ function truncateLogString(value: string, max: number): string {
   return value.length <= max ? value : value.slice(0, max);
 }
 
-function sanitizeRawData(value: unknown): unknown {
+function sanitizeDetails(value: unknown): unknown {
   if (value === undefined) {
     return undefined;
   }
   try {
     const serialized = JSON.stringify(value);
-    if (!serialized || serialized.length <= MAX_LOG_FORWARDING_RAW_DATA_BYTES) {
+    if (!serialized || serialized.length <= MAX_LOG_FORWARDING_DETAILS_BYTES) {
       return value;
     }
   } catch (err) {
-    console.warn('[LogForwarding] Failed to serialize rawData payload, dropping field:', err);
+    console.warn('[LogForwarding] Failed to serialize details payload, dropping field:', err);
     return undefined;
   }
   return undefined;
@@ -92,7 +92,7 @@ function sanitizeLogForwardingData(data: LogForwardingJobData): LogForwardingJob
       source: truncateLogString(event.source, MAX_LOG_FORWARDING_FIELD),
       message: truncateLogString(event.message, MAX_LOG_FORWARDING_MESSAGE),
       timestamp: event.timestamp,
-      rawData: sanitizeRawData(event.rawData),
+      details: sanitizeDetails(event.details),
     })),
   };
 }
@@ -146,7 +146,7 @@ export async function initializeLogForwardingWorker(): Promise<void> {
           source: e.source,
           message: e.message,
           timestamp: e.timestamp,
-          rawData: e.rawData,
+          details: e.details,
         }));
 
         const result = await bulkIndexEvents(orgId, docs);

--- a/apps/api/src/routes/agents/eventlogs.test.ts
+++ b/apps/api/src/routes/agents/eventlogs.test.ts
@@ -187,10 +187,21 @@ describe('agent event log routes', () => {
         events: [
           expect.objectContaining({
             timestamp: '2026-05-02T12:00:00.000Z',
+            // Regression guard (#2643): forward the persisted `details`, not the
+            // non-existent `rawData` the schema strips. The clamp provenance
+            // that was merged into the stored row is forwarded too.
+            details: {
+              eventRecordId: 123,
+              originalTimestamp: '2026-05-02T13:00:00.000Z',
+              timestampClamped: true,
+            },
           }),
         ],
       })
     );
+    // The removed `rawData` field must not resurface in the forward payload.
+    const forwarded = mocks.enqueueLogForwarding.mock.calls[0]?.[0];
+    expect(forwarded.events[0]).not.toHaveProperty('rawData');
   });
 
   it('does not re-forward duplicate events absorbed by the dedup index (#2390 retry passes)', async () => {

--- a/apps/api/src/routes/agents/eventlogs.ts
+++ b/apps/api/src/routes/agents/eventlogs.ts
@@ -186,7 +186,15 @@ eventLogsRoutes.put('/:id/eventlogs', zValidator('json', submitEventLogsSchema),
             source: event.source,
             message: event.message,
             timestamp: row.timestamp.toISOString(),
-            rawData: event.rawData,
+            // The agent's structured per-event context lives in `details`
+            // (see submitEventLogsSchema). The forward payload historically
+            // read `event.rawData`, a field the schema strips — so it was
+            // always `undefined` and nothing reached the SIEM. Forward the
+            // persisted `row.details` so the SIEM matches what was stored
+            // (including any timestamp-clamp provenance); the worker re-caps
+            // it to 16KB before shipping. `null` (no details) is normalized
+            // to `undefined` so the field is omitted rather than sent empty.
+            details: row.details ?? undefined,
           }];
         });
         if (forwardEvents.length > 0) {

--- a/apps/api/src/services/logForwarding.ts
+++ b/apps/api/src/services/logForwarding.ts
@@ -29,7 +29,7 @@ interface EventLogDocument {
   source: string;
   message: string;
   timestamp: string;
-  rawData?: unknown;
+  details?: unknown;
 }
 
 interface BulkResult {
@@ -74,7 +74,7 @@ function buildAuthHeader(config: LogForwardingConfig): string | undefined {
 // indexing idempotent: re-sending a batch (full-batch or item-level retry)
 // overwrites rather than duplicating, so retries are safe. Only byte-identical
 // events collapse — hashing every field (not a subset) avoids silently dropping
-// events that differ only in level/rawData, and serializing avoids the
+// events that differ only in level/details, and serializing avoids the
 // separator-collision risk of joining fields with a delimiter.
 function docId(doc: EventLogDocument): string {
   return createHash('sha256').update(JSON.stringify(doc)).digest('hex');


### PR DESCRIPTION
## Summary

`Closes #2643`

The SIEM forward payload in `apps/api/src/routes/agents/eventlogs.ts` read `event.rawData`, but `submitEventLogsSchema` (`apps/api/src/routes/agents/schemas.ts`) has no `rawData` field. Zod strips unknown keys, so `event.rawData` was **always `undefined`** — the field was dead weight in every forwarded event.

Meanwhile the entire downstream forwarding pipeline (`logForwardingWorker.ts` sanitize + 16KB cap → `logForwarding.ts` → Elasticsearch/OpenSearch `_bulk` doc) was plumbed end-to-end for that `rawData` slot, so it carried data **nowhere**, while the agent's real structured per-event context in `details` (present in the schema, capped 64KB at ingest) was **never forwarded**.

## Fix

- **Forward `row.details`** (the persisted, timestamp-clamp-merged details) so the SIEM reflects exactly what was stored. `null` (no details) is normalized to `undefined` so the field is omitted rather than shipped empty.
- **Rename the dead `rawData` slot to `details` end-to-end** — `eventlogs.ts`, `logForwardingWorker.ts` (type, `sanitizeDetails`, `MAX_LOG_FORWARDING_DETAILS_BYTES`, worker doc map), `logForwarding.ts` (`EventLogDocument`) — so the shipped SIEM doc field is honestly named.

### Why the rename is safe / size concern addressed

- `rawData` was `undefined` end-to-end, so `JSON.stringify` always dropped the key — **no SIEM doc ever carried it**. Renaming is not a data-compat break, and there is no migration.
- The issue flagged that `details` (64KB cap) could be sizeable for high-volume forwarding. The existing 16KB `sanitizeDetails` cap already bounds this: oversized details is dropped (returns `undefined`), not shipped.

## Tests

- `apps/api/src/routes/agents/eventlogs.test.ts` — strengthened the forward-payload assertion to require `details` (with clamp provenance) and to assert `rawData` does **not** resurface.
- `apps/api/src/jobs/logForwardingWorker.test.ts` — renamed field in the oversize-drop case and added a case asserting in-bound `details` is forwarded unchanged.

Affected suites green single-fork (9 passed); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)