### PR TITLE
fix(web): associate patch/config-policy form labels with their inputs (#2609)

### DIFF
--- a/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.test.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.test.tsx
@@ -179,6 +179,15 @@ describe('ConfigPolicyCreatePage — owner scope (#1724)', () => {
     ).toBeInTheDocument();
   });
 
+  // #2609: the Policy Details fields rendered <label> with no htmlFor/id link,
+  // so screen readers announced unnamed inputs and getByLabel(...) failed.
+  it('associates the policy-detail labels with their inputs (a11y, #2609)', () => {
+    startNewPolicy();
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Description')).toBeInTheDocument();
+    expect(screen.getByLabelText('Status')).toBeInTheDocument();
+  });
+
   it('hides the owner picker for an org-scope creator and POSTs orgId only', async () => {
     getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'org-9' });
     orgState.current = { currentOrgId: 'org-9', allOrgs: false, organizations: [] };

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx
@@ -260,10 +260,11 @@ export default function ConfigPolicyCreatePage() {
           </div>
           <div className="mt-4 grid gap-4">
             <div>
-              <label className="text-sm font-medium">
+              <label htmlFor="config-policy-name" className="text-sm font-medium">
                 {i18n.t("common:labels.name")}
               </label>
               <input
+                id="config-policy-name"
                 {...register("name")}
                 className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                 placeholder={i18n.t(
@@ -277,10 +278,11 @@ export default function ConfigPolicyCreatePage() {
               )}
             </div>
             <div>
-              <label className="text-sm font-medium">
+              <label htmlFor="config-policy-description" className="text-sm font-medium">
                 {i18n.t("common:labels.description")}
               </label>
               <textarea
+                id="config-policy-description"
                 {...register("description")}
                 className="mt-2 h-20 w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                 placeholder={i18n.t(
@@ -289,10 +291,11 @@ export default function ConfigPolicyCreatePage() {
               />
             </div>
             <div>
-              <label className="text-sm font-medium">
+              <label htmlFor="config-policy-status" className="text-sm font-medium">
                 {i18n.t("common:labels.status")}
               </label>
               <select
+                id="config-policy-status"
                 {...register("status")}
                 className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring sm:w-48"
               >

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx
@@ -105,6 +105,19 @@ describe('PatchTab', () => {
     expect(screen.getByText('Application Rules')).toBeInTheDocument();
   });
 
+  // #2609: schedule fields rendered <label> with no htmlFor/id association, so
+  // screen readers announced an unnamed control and getByLabel(...) failed.
+  it('associates the schedule labels with their inputs (a11y, #2609)', async () => {
+    render(<PatchTab {...baseProps} />);
+    await screen.findByText('Installation Schedule');
+
+    expect(screen.getByLabelText('Frequency')).toBeInTheDocument();
+    expect(screen.getByLabelText('Time')).toBeInTheDocument();
+
+    // Weekly is the default frequency, so the Day of week select is present.
+    expect(screen.getByLabelText('Day of week')).toBeInTheDocument();
+  });
+
   it('links the policy to the selected ring on save', async () => {
     fetchMock.mockResolvedValue({
       ok: true,

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
@@ -431,6 +431,9 @@ export default function PatchTab({
           <div className="mt-2 flex items-center gap-2">
             <select
               data-testid="approval-ring-select"
+              aria-label={i18n.t(
+                "policies:configurationPolicies.featureTabs.patchTab.approvalRing",
+              )}
               value={selectedRingId}
               onChange={(e) => setSelectedRingId(e.target.value)}
               className="h-10 flex-1 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
@@ -451,6 +454,7 @@ export default function PatchTab({
               <button
                 type="button"
                 onClick={openEditRing}
+                data-testid="patch-edit-ring"
                 className="inline-flex h-10 shrink-0 items-center gap-1.5 rounded-md border px-3 text-sm font-medium transition hover:bg-muted"
               >
                 <Pencil className="h-3.5 w-3.5" />
@@ -460,6 +464,7 @@ export default function PatchTab({
             <button
               type="button"
               onClick={openCreateRing}
+              data-testid="patch-new-ring"
               className="inline-flex h-10 shrink-0 items-center gap-1.5 rounded-md border px-3 text-sm font-medium transition hover:bg-muted"
             >
               <Plus className="h-3.5 w-3.5" />
@@ -573,12 +578,17 @@ export default function PatchTab({
         </p>
         <div className="mt-2 grid gap-4 sm:grid-cols-3">
           <div>
-            <label className="text-xs text-muted-foreground">
+            <label
+              htmlFor="patch-schedule-frequency"
+              className="text-xs text-muted-foreground"
+            >
               {i18n.t(
                 "policies:configurationPolicies.featureTabs.patchTab.frequency",
               )}
             </label>
             <select
+              id="patch-schedule-frequency"
+              data-testid="patch-schedule-frequency"
               value={settings.scheduleFrequency}
               onChange={(e) =>
                 update("scheduleFrequency", e.target.value as ScheduleFrequency)
@@ -593,12 +603,17 @@ export default function PatchTab({
             </select>
           </div>
           <div>
-            <label className="text-xs text-muted-foreground">
+            <label
+              htmlFor="patch-schedule-time"
+              className="text-xs text-muted-foreground"
+            >
               {i18n.t(
                 "policies:configurationPolicies.featureTabs.patchTab.time",
               )}
             </label>
             <input
+              id="patch-schedule-time"
+              data-testid="patch-schedule-time"
               type="time"
               value={settings.scheduleTime}
               onChange={(e) => update("scheduleTime", e.target.value)}
@@ -607,12 +622,17 @@ export default function PatchTab({
           </div>
           {settings.scheduleFrequency === "weekly" && (
             <div>
-              <label className="text-xs text-muted-foreground">
+              <label
+                htmlFor="patch-schedule-day-of-week"
+                className="text-xs text-muted-foreground"
+              >
                 {i18n.t(
                   "policies:configurationPolicies.featureTabs.patchTab.dayOfWeek",
                 )}
               </label>
               <select
+                id="patch-schedule-day-of-week"
+                data-testid="patch-schedule-day-of-week"
                 value={settings.scheduleDayOfWeek}
                 onChange={(e) => update("scheduleDayOfWeek", e.target.value)}
                 className="mt-1 h-10 w-full rounded-md border bg-background px-3 text-sm"
@@ -627,12 +647,17 @@ export default function PatchTab({
           )}
           {settings.scheduleFrequency === "monthly" && (
             <div>
-              <label className="text-xs text-muted-foreground">
+              <label
+                htmlFor="patch-schedule-day-of-month"
+                className="text-xs text-muted-foreground"
+              >
                 {i18n.t(
                   "policies:configurationPolicies.featureTabs.patchTab.dayOfMonth",
                 )}
               </label>
               <input
+                id="patch-schedule-day-of-month"
+                data-testid="patch-schedule-day-of-month"
                 type="number"
                 min={1}
                 max={28}

--- a/apps/web/src/components/patches/PatchApprovalModal.tsx
+++ b/apps/web/src/components/patches/PatchApprovalModal.tsx
@@ -191,6 +191,8 @@ export default function PatchApprovalModal({
                 type="button"
                 onClick={() => setAction(option)}
                 disabled={isSubmitting}
+                data-testid={`patch-approval-action-${option}`}
+                aria-pressed={action === option}
                 className={cn(
                   'flex w-full items-start gap-3 rounded-md border px-4 py-3 text-left transition',
                   action === option ? config.color : 'border-muted text-muted-foreground hover:text-foreground',
@@ -208,8 +210,9 @@ export default function PatchApprovalModal({
         </div>
 
         <div className="mt-6">
-          <label className="text-sm font-medium">{t('patchApprovalModal.notes.label')}</label>
+          <label htmlFor="patch-approval-notes" className="text-sm font-medium">{t('patchApprovalModal.notes.label')}</label>
           <textarea
+            id="patch-approval-notes"
             value={notes}
             onChange={event => setNotes(event.target.value)}
             placeholder={t('patchApprovalModal.notes.placeholder')}
@@ -259,6 +262,7 @@ export default function PatchApprovalModal({
             type="button"
             onClick={handleSubmit}
             disabled={!canSubmit}
+            data-testid="patch-approval-submit"
             title={isOrgScope ? t('patchApprovalModal.errors.partnerLevel') : undefined}
             className="h-10 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >

--- a/apps/web/src/components/patches/PatchList.tsx
+++ b/apps/web/src/components/patches/PatchList.tsx
@@ -318,6 +318,7 @@ export default function PatchList({
         <button
           type="button"
           onClick={() => onDeploy?.(patch)}
+          data-testid={`patch-row-${patch.id}-deploy`}
           className="inline-flex h-8 items-center gap-1 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:opacity-90"
         >
           <Download className="h-3.5 w-3.5" />
@@ -327,6 +328,7 @@ export default function PatchList({
         <button
           type="button"
           onClick={() => onReview?.(patch)}
+          data-testid={`patch-row-${patch.id}-review`}
           className="inline-flex h-8 items-center gap-1 rounded-md border px-3 text-xs font-medium hover:bg-muted"
         >
           <Eye className="h-3.5 w-3.5" />
@@ -336,6 +338,7 @@ export default function PatchList({
       <button
         type="button"
         onClick={() => onView?.(patch)}
+        data-testid={`patch-row-${patch.id}-details`}
         className="inline-flex h-8 items-center gap-1 rounded-md border px-3 text-xs font-medium text-muted-foreground hover:text-foreground"
       >
         {t('patchList.actions.details')}
@@ -460,6 +463,7 @@ export default function PatchList({
               type="button"
               onClick={handleBulkApprove}
               disabled={bulkLoading}
+              data-testid="patch-bulk-approve"
               className="inline-flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
             >
               {bulkLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <CheckCircle className="h-3.5 w-3.5" />}
@@ -471,6 +475,7 @@ export default function PatchList({
               type="button"
               onClick={handleBulkDecline}
               disabled={bulkLoading}
+              data-testid="patch-bulk-decline"
               className="inline-flex h-8 items-center gap-1.5 rounded-md border border-destructive/40 bg-destructive/10 px-3 text-xs font-medium text-destructive hover:bg-destructive/20 disabled:opacity-50"
             >
               {bulkLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <XCircle className="h-3.5 w-3.5" />}

--- a/apps/web/src/components/patches/PatchesPage.tsx
+++ b/apps/web/src/components/patches/PatchesPage.tsx
@@ -558,6 +558,7 @@ export default function PatchesPage() {
               type="button"
               onClick={handleScan}
               disabled={scanLoading}
+              data-testid="patch-run-scan"
               className="inline-flex h-10 items-center justify-center gap-2 rounded-md border bg-background px-4 text-sm font-medium hover:bg-muted disabled:opacity-50"
             >
               {scanLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
@@ -574,6 +575,7 @@ export default function PatchesPage() {
               }}
               disabled={!canManageRings}
               title={!canManageRings ? RING_SCOPE_HINT : undefined}
+              data-testid="patch-new-ring"
               className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Plus className="h-4 w-4" />
@@ -591,6 +593,8 @@ export default function PatchesPage() {
               key={tab.id}
               type="button"
               onClick={() => setActiveTab(tab.id)}
+              data-testid={`patch-tab-${tab.id}`}
+              aria-current={activeTab === tab.id ? 'page' : undefined}
               className={`flex items-center gap-2 whitespace-nowrap border-b-2 px-1 py-3 text-sm font-medium transition ${
                 activeTab === tab.id
                   ? 'border-primary text-primary'

--- a/apps/web/src/components/patches/UpdateRingForm.test.tsx
+++ b/apps/web/src/components/patches/UpdateRingForm.test.tsx
@@ -136,6 +136,28 @@ describe('UpdateRingForm — ring auto-approve (#1317)', () => {
     });
   });
 
+  // #2609: every form control must have an associated <label> so screen readers
+  // announce a name and getByLabel(...) queries (testing-library / Playwright)
+  // resolve it.
+  it('associates labels with their inputs (a11y, #2609)', () => {
+    render(<UpdateRingForm onSubmit={vi.fn()} />);
+
+    // Text/number inputs in the identity + enforcement zones.
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Rollout order')).toBeInTheDocument();
+    expect(screen.getByLabelText('Description')).toBeInTheDocument();
+    expect(screen.getByLabelText('Deadline (days)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Reboot grace (hours)')).toBeInTheDocument();
+
+    // The default-rule "Hold after release" input only exists once auto-approve
+    // is enabled; enabling it also reveals the severities group label.
+    fireEvent.click(screen.getByTestId('ring-auto-approve-enabled'));
+    expect(screen.getByLabelText('Hold after release')).toBeInTheDocument();
+    expect(
+      screen.getByRole('group', { name: 'Auto-approve severities' })
+    ).toBeInTheDocument();
+  });
+
   it('submits deadlineDays as null when left blank', async () => {
     const onSubmit = vi.fn();
     render(<UpdateRingForm onSubmit={onSubmit} />);

--- a/apps/web/src/components/patches/UpdateRingForm.tsx
+++ b/apps/web/src/components/patches/UpdateRingForm.tsx
@@ -126,15 +126,18 @@ function SeverityChips({
   selected,
   onToggle,
   testIdPrefix,
+  labelledById,
   t,
 }: {
   selected: Severity[];
   onToggle: (s: Severity) => void;
   testIdPrefix?: string;
+  /** Id of the visible label so the button group has an accessible name. */
+  labelledById?: string;
   t: TFunction<'patches'>;
 }) {
   return (
-    <div className="flex flex-wrap gap-1.5">
+    <div role="group" aria-labelledby={labelledById} className="flex flex-wrap gap-1.5">
       {severityOptions.map((sev) => {
         const active = selected.includes(sev.value);
         return (
@@ -160,11 +163,16 @@ function SeverityChips({
 }
 
 function HoldField({ field, testId, t }: { field: UseFormRegisterReturn; testId?: string; t: TFunction<'patches'> }) {
+  // Derive the input id from the (unique) field path so the label associates
+  // correctly even though HoldField is rendered for the default rule and once
+  // per category override.
+  const id = `hold-${field.name}`;
   return (
     <div className="shrink-0">
-      <label className={labelClass}>{t('updateRingForm.holdAfterRelease')}</label>
+      <label htmlFor={id} className={labelClass}>{t('updateRingForm.holdAfterRelease')}</label>
       <div className="mt-1.5 flex items-center gap-2">
         <input
+          id={id}
           type="number"
           min={0}
           max={365}
@@ -285,20 +293,21 @@ export default function UpdateRingForm({
       {/* Zone A — Identity */}
       <div className="grid gap-4 sm:grid-cols-3">
         <div className="sm:col-span-2">
-          <label className={labelClass}>{t('updateRingForm.fields.name')}</label>
-          <input {...register('name')} className={cn(inputClass, 'mt-1.5')} placeholder={t('updateRingForm.placeholders.name')} />
+          <label htmlFor="ring-name" className={labelClass}>{t('updateRingForm.fields.name')}</label>
+          <input id="ring-name" {...register('name')} className={cn(inputClass, 'mt-1.5')} placeholder={t('updateRingForm.placeholders.name')} />
           {errors.name && <p className="mt-1 text-xs text-destructive">{errors.name.message}</p>}
         </div>
         <div>
-          <label className={labelClass}>{t('updateRingForm.fields.rolloutOrder')}</label>
-          <input type="number" min={0} max={100} {...register('ringOrder')} className={cn(inputClass, 'mt-1.5')} />
+          <label htmlFor="ring-order" className={labelClass}>{t('updateRingForm.fields.rolloutOrder')}</label>
+          <input id="ring-order" type="number" min={0} max={100} {...register('ringOrder')} className={cn(inputClass, 'mt-1.5')} />
           <p className="mt-1 text-xs text-muted-foreground">{t('updateRingForm.help.rolloutOrder')}</p>
         </div>
       </div>
 
       <div>
-        <label className={labelClass}>{t('updateRingForm.fields.description')}</label>
+        <label htmlFor="ring-description" className={labelClass}>{t('updateRingForm.fields.description')}</label>
         <input
+          id="ring-description"
           {...register('description')}
           className={cn(inputClass, 'mt-1.5')}
           placeholder={t('updateRingForm.placeholders.description')}
@@ -313,8 +322,9 @@ export default function UpdateRingForm({
         </p>
         <div className="mt-3 grid gap-4 sm:grid-cols-2">
           <div>
-            <label className={labelClass}>{t('updateRingForm.fields.deadlineDays')}</label>
+            <label htmlFor="ring-deadline-days" className={labelClass}>{t('updateRingForm.fields.deadlineDays')}</label>
             <input
+              id="ring-deadline-days"
               type="number"
               min={0}
               max={365}
@@ -326,8 +336,8 @@ export default function UpdateRingForm({
             />
           </div>
           <div>
-            <label className={labelClass}>{t('updateRingForm.fields.rebootGraceHours')}</label>
-            <input type="number" min={0} max={168} {...register('gracePeriodHours')} className={cn(inputClass, 'mt-1.5')} />
+            <label htmlFor="ring-grace-period-hours" className={labelClass}>{t('updateRingForm.fields.rebootGraceHours')}</label>
+            <input id="ring-grace-period-hours" type="number" min={0} max={168} {...register('gracePeriodHours')} className={cn(inputClass, 'mt-1.5')} />
           </div>
         </div>
       </div>
@@ -371,12 +381,13 @@ export default function UpdateRingForm({
             {autoApprove?.enabled ? (
               <div className="mt-4 flex flex-wrap items-end justify-between gap-4 border-t pt-4">
                 <div>
-                  <label className={labelClass}>{t('updateRingForm.fields.autoApproveSeverities')}</label>
+                  <label id="ring-auto-approve-severities-label" className={labelClass}>{t('updateRingForm.fields.autoApproveSeverities')}</label>
                   <div className="mt-1.5">
                     <SeverityChips
                       selected={(autoApprove.severities ?? []) as Severity[]}
                       onToggle={toggleDefaultSeverity}
                       testIdPrefix="ring-auto-approve-severity"
+                      labelledById="ring-auto-approve-severities-label"
                       t={t}
                     />
                   </div>
@@ -438,11 +449,12 @@ export default function UpdateRingForm({
                 {rule?.autoApprove ? (
                   <div className="mt-4 flex flex-wrap items-end justify-between gap-4 border-t pt-4">
                     <div>
-                      <label className={labelClass}>{t('updateRingForm.fields.autoApproveSeverities')}</label>
+                      <label id={`override-${index}-severities-label`} className={labelClass}>{t('updateRingForm.fields.autoApproveSeverities')}</label>
                       <div className="mt-1.5">
                         <SeverityChips
                           selected={(rule.autoApproveSeverities ?? []) as Severity[]}
                           onToggle={(s) => toggleOverrideSeverity(index, s)}
+                          labelledById={`override-${index}-severities-label`}
                           t={t}
                         />
                       </div>


### PR DESCRIPTION
## Summary

`/patches` and the config-policy create flow rendered `<label>` elements with no `htmlFor`/`id` association (and not wrapping the input), so screen readers announced the controls with **no name** and `getByLabel(...)` queries (testing-library / Playwright) couldn't resolve them. Several interactive elements on `/patches` also lacked the `data-testid` coverage the repo's testid-only e2e convention expects.

## Changes

**Label association (a11y):**
- `UpdateRingForm.tsx` — `htmlFor`/`id` on name, rollout order, description, deadline, reboot grace, and the shared `HoldField` (id derived from the unique field path so it works for the default rule and each category override). The severity chip groups get `role="group"` + `aria-labelledby` so the button set carries an accessible name.
- `PatchTab.tsx` — `htmlFor`/`id` on the schedule frequency / time / day-of-week / day-of-month fields; `aria-label` on the approval-ring `<select>` (it only had a heading).
- `ConfigPolicyCreatePage.tsx` — `htmlFor`/`id` on name, description, status.
- `PatchApprovalModal.tsx` — `htmlFor`/`id` on the notes textarea (defer-until was already associated).

**`data-testid` coverage on `/patches`:**
- `PatchesPage.tsx` — tabs (`patch-tab-*`, + `aria-current`), Run Scan, New Ring.
- `PatchList.tsx` — per-row Review / Deploy / Details, bulk approve / decline.
- `PatchTab.tsx` — schedule controls, New / Edit ring buttons.
- `PatchApprovalModal.tsx` — approve/decline/defer actions (`+ aria-pressed`) and submit.

## Tests
Added `getByLabel`-based regression tests to `UpdateRingForm.test.tsx`, `PatchTab.test.tsx`, and `ConfigPolicyCreatePage.test.tsx`. Affected suites green (76 passed), `astro check` clean (0 errors).

No behavior, API, or schema changes — presentation/markup only.

Closes #2609

🤖 Generated with [Claude Code](https://claude.com/claude-code)