### PR TITLE
fix(api): close five production Sentry issues (BREEZE-3/5/C/T/R)

### DIFF
--- a/apps/api/migrations/2026-08-04-widen-device-mac-address-columns.sql
+++ b/apps/api/migrations/2026-08-04-widen-device-mac-address-columns.sql
@@ -1,0 +1,38 @@
+-- Widen device MAC-address columns from varchar(17) to varchar(64).
+--
+-- Standard Ethernet MACs are 17 chars (XX:XX:XX:XX:XX:XX), but Windows
+-- pseudo-interfaces (Teredo, ISATAP tunnels) and InfiniBand report longer
+-- EUI-64 / tunnel hardware addresses (up to ~53 chars). The agent network
+-- inventory payload schema already accepts macAddress up to 64 chars
+-- (apps/api/src/routes/agents/schemas.ts), but these DB columns were left at
+-- varchar(17). As a result, device_network inserts for any device with such
+-- an interface failed with PostgresError 22001 ("value too long for type
+-- character varying(17)"), rolling back the whole network-inventory
+-- transaction and permanently blocking that device's network updates
+-- (Sentry BREEZE-3, ~4k events). device_ip_history silently truncated the
+-- same MACs to 17 chars instead of failing.
+--
+-- Increasing a varchar length is a metadata-only change in PostgreSQL (no
+-- table rewrite, no index rebuild), safe to run on hot tables. Idempotent:
+-- guarded on the current column width so re-applying is a no-op.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'device_network'
+      AND column_name = 'mac_address'
+      AND character_maximum_length < 64
+  ) THEN
+    ALTER TABLE device_network ALTER COLUMN mac_address TYPE varchar(64);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'device_ip_history'
+      AND column_name = 'mac_address'
+      AND character_maximum_length < 64
+  ) THEN
+    ALTER TABLE device_ip_history ALTER COLUMN mac_address TYPE varchar(64);
+  END IF;
+END $$;

--- a/apps/api/src/db/schema/devices.ts
+++ b/apps/api/src/db/schema/devices.ts
@@ -215,7 +215,11 @@ export const deviceNetwork = pgTable('device_network', {
   deviceId: uuid('device_id').notNull().references(() => devices.id),
   orgId: uuid('org_id').notNull().references(() => organizations.id),
   interfaceName: text('interface_name').notNull(),
-  macAddress: varchar('mac_address', { length: 17 }),
+  // 64 (not 17) to fit Windows pseudo-interface (Teredo/ISATAP) and
+  // InfiniBand EUI-64 / tunnel MACs — matches the agent payload schema's
+  // z.string().max(64) (see routes/agents/schemas.ts). See migration
+  // 2026-08-04-widen-device-mac-address-columns.sql (Sentry BREEZE-3).
+  macAddress: varchar('mac_address', { length: 64 }),
   ipAddress: varchar('ip_address', { length: 45 }),
   ipType: varchar('ip_type', { length: 4 }).notNull().default('ipv4'),
   isPrimary: boolean('is_primary').notNull().default(false),
@@ -231,7 +235,10 @@ export const deviceIpHistory = pgTable('device_ip_history', {
   ipAddress: varchar('ip_address', { length: 45 }).notNull(),
   ipType: varchar('ip_type', { length: 4 }).notNull().default('ipv4'),
   assignmentType: ipAssignmentTypeEnum('assignment_type').notNull().default('unknown'),
-  macAddress: varchar('mac_address', { length: 17 }),
+  // 64 to match device_network.mac_address — same agent-reported hardware
+  // addresses (Teredo/ISATAP/InfiniBand can exceed 17 chars). See migration
+  // 2026-08-04-widen-device-mac-address-columns.sql.
+  macAddress: varchar('mac_address', { length: 64 }),
   subnetMask: varchar('subnet_mask', { length: 45 }),
   gateway: varchar('gateway', { length: 45 }),
   dnsServers: text('dns_servers').array(),

--- a/apps/api/src/jobs/processSampleRetention.ts
+++ b/apps/api/src/jobs/processSampleRetention.ts
@@ -57,7 +57,8 @@ export function createProcessSampleRetentionWorker(): Worker<RetentionJobData> {
     async (job: Job<RetentionJobData>) => {
       return runWithSystemDbAccess(async () => {
         const retentionDays = Math.min(14, Math.max(1, job.data.retentionDays ?? DEFAULT_RETENTION_DAYS));
-        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+        // postgres-js does not coerce JS Date in template-literal params; pass an ISO string.
+        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
         const startedAt = Date.now();
 
         let deleted = 0;

--- a/apps/api/src/routes/auth/password.test.ts
+++ b/apps/api/src/routes/auth/password.test.ts
@@ -134,7 +134,8 @@ vi.mock('./ssoPolicy', () => ({
 }));
 
 import { passwordRoutes } from './password';
-import { db } from '../../db';
+import { db, withSystemDbAccessContext } from '../../db';
+import { invalidateAllUserSessions } from '../../services';
 import { writeAuthAudit } from './helpers';
 import { getPasswordResetEligibility } from '../../services/passwordResetEligibility';
 import { enqueuePasswordResetRequest } from '../../services/authEmailQueue';
@@ -467,6 +468,48 @@ describe('password reset eligibility (#719)', () => {
           userId: 'u-pending',
         }),
       );
+    });
+
+    it('invalidates all user sessions INSIDE a system DB-access context on a successful reset (BREEZE-T / #1375)', async () => {
+      // The `sessions` table is user-scoped RLS (shape 6): the DELETE only
+      // matches when a DB access context is active. Before the fix the
+      // invalidateAllUserSessions() call ran contextless — RLS silently
+      // matched 0 rows, leaving old sessions alive after a password reset.
+      // This asserts the call now runs wrapped in withSystemDbAccessContext.
+      const envelope = JSON.stringify({ userId: 'u-1', passwordResetEpoch: 1, email: 'user@example.test' });
+      getdelMock.mockResolvedValue(envelope);
+      vi.mocked(db.select).mockReturnValue(
+        selectChain([{ passwordResetEpoch: 1, email: 'user@example.test' }]) as any,
+      );
+      getEligibilityForUserMock.mockResolvedValue({
+        allowed: true,
+        userId: 'u-1',
+        email: 'user@example.test',
+      });
+      stubTransaction();
+
+      let systemContextDepth = 0;
+      let invalidatedInsideContext: boolean | null = null;
+      vi.mocked(withSystemDbAccessContext).mockImplementation(async (fn: any) => {
+        systemContextDepth++;
+        try {
+          return await fn();
+        } finally {
+          systemContextDepth--;
+        }
+      });
+      vi.mocked(invalidateAllUserSessions).mockImplementation(async () => {
+        invalidatedInsideContext = systemContextDepth > 0;
+      });
+
+      const res = await postJson('/reset-password', {
+        token: 'reset-token',
+        password: 'new-strong-pw-1234',
+      });
+
+      expect(res.status).toBe(200);
+      expect(vi.mocked(invalidateAllUserSessions)).toHaveBeenCalledWith('u-1');
+      expect(invalidatedInsideContext).toBe(true);
     });
 
     it('still returns success when runPostCommitCleanup reports a partial failure (best-effort)', async () => {

--- a/apps/api/src/routes/auth/password.ts
+++ b/apps/api/src/routes/auth/password.ts
@@ -250,7 +250,13 @@ passwordRoutes.post('/reset-password', zValidator('json', resetPasswordSchema), 
   // Invalidate all sessions — separate legacy mechanism, not absorbed by the
   // lifecycle service (overseer decision 2026-07-11); best-effort, password
   // is already changed and durably committed above.
-  await invalidateAllUserSessions(userId);
+  //
+  // The `sessions` table is user-scoped RLS (shape 6): the DELETE only matches
+  // when breeze_current_user_id() is set or scope is 'system'. This reset flow
+  // has no authMiddleware, so there is no ambient DB-access context here — the
+  // bare call matched 0 rows and silently left old sessions alive (#1375,
+  // Sentry BREEZE-T). Wrap in a system context so the delete actually runs.
+  await withSystemDbAccessContext(async () => invalidateAllUserSessions(userId));
   // Post-commit cleanup (Redis JWT cutoff + permission-cache clear + MCP
   // OAuth grant sweep) — best-effort and independent per step; the durable
   // revocation above is already committed regardless of outcome here.

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -130,6 +130,7 @@ import {
   publicShortLinkRoutes,
 } from "./enrollmentKeys";
 import { db, withSystemDbAccessContext } from "../db";
+import { createAuditLogAsync } from "../services/auditService";
 import { MsiSigningService } from "../services/msiSigning";
 import { fetchMacosInstallerAppZip } from "../services/installerBuilder";
 import { renameAppInZip } from "../services/installerAppZip";
@@ -923,6 +924,17 @@ describe("GET /public-download/:platform", () => {
     );
     // No db.update — download does not consume enrollment slots
     expect(db.update).not.toHaveBeenCalled();
+
+    // BREEZE-5: the anonymous public-download audit row must use the
+    // anonymous-actor UUID sentinel, not the literal string "public" —
+    // audit_logs.actor_id is `uuid NOT NULL`, so "public" made every
+    // anonymous-download audit insert fail with pg 22P02 (invalid uuid).
+    expect(vi.mocked(createAuditLogAsync)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "enrollment_key.public_download",
+        actorId: "00000000-0000-0000-0000-000000000000",
+      }),
+    );
 
     issueSpy.mockRestore();
   });

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -17,6 +17,7 @@ import {
 import { userRateLimit } from "../middleware/userRateLimit";
 import { randomBytes } from "crypto";
 import { createAuditLogAsync } from "../services/auditService";
+import { ANONYMOUS_ACTOR_ID } from "../services/auditEvents";
 import { PERMISSIONS } from "../services/permissions";
 import { hashEnrollmentKey, hashEnrollmentKeyCandidates } from "../services/enrollmentKeySecurity";
 import {
@@ -1879,7 +1880,7 @@ async function serveInstaller(
 
     createAuditLogAsync({
       orgId: keyRow.orgId,
-      actorId: "public",
+      actorId: ANONYMOUS_ACTOR_ID,
       action: "enrollment_key.public_download",
       resourceType: "enrollment_key",
       resourceId: keyRow.id,
@@ -1918,7 +1919,7 @@ async function serveInstaller(
 
     createAuditLogAsync({
       orgId: keyRow.orgId,
-      actorId: "public",
+      actorId: ANONYMOUS_ACTOR_ID,
       action: "enrollment_key.public_download",
       resourceType: "enrollment_key",
       resourceId: keyRow.id,

--- a/apps/api/src/services/deviceIpHistory.ts
+++ b/apps/api/src/services/deviceIpHistory.ts
@@ -107,7 +107,7 @@ function normalizeEntry(entry: DeviceIPHistoryEntryInput | undefined): Normalize
     ipAddress: clamp(ipAddress, 45),
     ipType: normalizeIpType(entry.ipType, ipAddress),
     assignmentType: normalizeAssignmentType(entry.assignmentType),
-    macAddress: normalizeOptionalString(entry.macAddress, 17),
+    macAddress: normalizeOptionalString(entry.macAddress, 64),
     subnetMask: normalizeOptionalString(entry.subnetMask, 45),
     gateway: normalizeOptionalString(entry.gateway, 45),
     dnsServers: normalizeDnsServers(entry.dnsServers),

--- a/apps/api/src/services/redis.ts
+++ b/apps/api/src/services/redis.ts
@@ -155,12 +155,25 @@ export function isRedisAvailable(): boolean {
 }
 
 export async function closeRedis(): Promise<void> {
+  // `.quit()` writes a QUIT command over the socket. During shutdown the peer
+  // may have already closed the TCP connection, so the write can throw
+  // EPIPE/ECONNRESET (Sentry BREEZE-R). The goal — releasing the connection —
+  // is already achieved when the peer closed it, so swallow the teardown error
+  // rather than let it count as a failed shutdown task and flip the exit code.
   if (redisClient) {
-    await redisClient.quit();
+    try {
+      await redisClient.quit();
+    } catch (err) {
+      console.warn('[redis] closeRedis: redisClient.quit() failed (connection already closed?):', err);
+    }
     redisClient = null;
   }
   if (bullmqConnection) {
-    await bullmqConnection.quit();
+    try {
+      await bullmqConnection.quit();
+    } catch (err) {
+      console.warn('[redis] closeRedis: bullmqConnection.quit() failed (connection already closed?):', err);
+    }
     bullmqConnection = null;
   }
 }


### PR DESCRIPTION
Fixes five deterministic, high-signal production errors surfaced in Sentry (olivetech-ks / breeze). Each was root-caused, fixed, and verified; two carry new regression tests.

## Fixes

| Sentry | Problem | Fix |
|---|---|---|
| **BREEZE-3** (~4k events) | `device_network.mac_address` is `varchar(17)`, but the agent payload schema already accepts `macAddress` up to 64 chars. Teredo/ISATAP/InfiniBand pseudo-interfaces report longer MACs → batch insert threw pg `22001` → the whole network-inventory transaction rolled back, so affected devices could **never** update network inventory. | Widen `device_network` + `device_ip_history` `mac_address` to `varchar(64)` (metadata-only ALTER, idempotent migration); stop the matching 17-char truncation in `deviceIpHistory` normalization. |
| **BREEZE-5** | Public installer downloads wrote `actorId: "public"` into `audit_logs.actor_id` (`uuid NOT NULL`) → pg `22P02` on every anonymous download; audit rows silently lost. | Use `ANONYMOUS_ACTOR_ID` sentinel (2 sites). |
| **BREEZE-C** | `processSampleRetention` interpolated a raw JS `Date` into a postgres-js template (`ERR_INVALID_ARG_TYPE`, never reached the DB) → `device_process_samples` pruning had **never run**. | Pass an ISO string, matching the sibling `ipHistoryRetention` job. |
| **BREEZE-T** | The reset-password flow called `invalidateAllUserSessions()` with no DB access context; user-scoped RLS on `sessions` silently matched 0 rows → old sessions survived a password reset. | Wrap in `withSystemDbAccessContext` (#1375). |
| **BREEZE-R** | `closeRedis()` let a shutdown-time `EPIPE` from `.quit()` fail the shutdown task and flip the process exit code. | Swallow the teardown error. |

## Verification
- Migration applies cleanly and is **idempotent on re-run**; both columns confirmed `varchar(64)`; no schema/type drift; migration-ordering test (38 passed).
- Touched-file tests: **75 passed** (`enrollmentKeys`, `auth/password`, `session`, `redis`, `processSampleRetention`), including 2 new regression tests.

## Notes
- `device_network.mac_address` is a hot agent-write column; increasing a varchar length is metadata-only in Postgres (no table rewrite, no index rebuild).
- The #1105 connection-hold cluster (BREEZE-B/9/A/Q/M/W) is intentionally **out of scope** here and handled in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)