### PR TITLE
fix(api): #1105 connection-hold cluster — BREEZE-M/W/Q/A/9

### DIFF
--- a/apps/api/src/jobs/vulnerabilityJobs.ts
+++ b/apps/api/src/jobs/vulnerabilityJobs.ts
@@ -941,7 +941,12 @@ export async function refreshRiskScores(): Promise<number> {
       })
       .from(deviceVulnerabilities)
       .innerJoin(vulnerabilities, eq(deviceVulnerabilities.vulnerabilityId, vulnerabilities.id))
-      .where(eq(deviceVulnerabilities.status, 'open'));
+      .where(eq(deviceVulnerabilities.status, 'open'))
+      // Deterministic lock-acquisition order (by id) so concurrent writers of
+      // device_vulnerabilities can't lock-order-invert against this pass and
+      // deadlock (BREEZE-W, pg 40P01). Paired with job-level `attempts` so a
+      // transient deadlock retries instead of silently dropping the refresh.
+      .orderBy(deviceVulnerabilities.id);
 
     let updated = 0;
     for (const r of rows) {
@@ -1184,6 +1189,11 @@ async function scheduleVulnMaintenanceJobs(): Promise<void> {
       repeat: { pattern: RISK_SCORE_REFRESH_CRON },
       removeOnComplete: { count: 10 },
       removeOnFail: { count: 50 },
+      // A deadlock (BREEZE-W) rolls back the whole refresh; retry it instead of
+      // dropping that day's recompute until the next cron. The recompute is
+      // idempotent, so re-running is safe.
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5000 },
     }
   );
 

--- a/apps/api/src/middleware/selfManagedDbContextRoutes.ts
+++ b/apps/api/src/middleware/selfManagedDbContextRoutes.ts
@@ -80,6 +80,13 @@ const SELF_MANAGED_DB_CONTEXT_ROUTES: readonly SelfManagedRoute[] = [
   // Microsoft/executor HTTP and must never inherit an ambient request tx.
   { method: 'GET', pattern: /^\/api\/v1\/m365\/consent\/callback\/?$/ },
   { method: 'POST', pattern: /^\/api\/v1\/m365\/connections\/[^/]+\/retest\/?$/ },
+  // Notification channel "Send test" fires a REAL synchronous outbound send
+  // (email/webhook/Slack/Teams/PagerDuty/Pushover/SMS), observed holding the
+  // connection ~10s (Sentry #1105 / BREEZE-A). The handler wraps the channel
+  // read and the test-result write in their own short withDbAccessContext
+  // blocks (see withChannelsDbContext in routes/alerts/channels.ts) and runs
+  // the send between them, holding no connection across the network call.
+  { method: 'POST', pattern: /^\/api\/v1\/alerts\/channels\/[^/]+\/test\/?$/ },
 ];
 
 /**

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -103,7 +103,15 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
   // JWT_SECRET, etc.) so keys hashed before ENROLLMENT_KEY_PEPPER was mandatory still match.
   const enrollmentKeyCandidates = hashEnrollmentKeyCandidates(data.enrollmentKey);
 
-  return withSystemDbAccessContext(async () => {
+  // #1105: the callback below returns either an early-exit Response (error
+  // paths) or the success-path data needed to build the response. The
+  // warranty-sync enqueue (Redis round-trip) must NOT fire while the
+  // withSystemDbAccessContext transaction is still open — it now runs after
+  // this block resolves and the pooled connection is released, mirroring
+  // reliabilityWorker.ts's processScanOrgs (#2640).
+  const enrollmentOutcome = await withSystemDbAccessContext(async (): Promise<
+    Response | { deviceId: string; responseBody: Record<string, unknown> }
+  > => {
     // Re-validated in the UPDATE WHERE below to close the TOCTOU window between
     // this initial lookup and the usage_count bump.
     const validEnrollmentKeyConditions = [
@@ -825,10 +833,8 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
       },
     });
 
-    // Queue warranty lookup for the newly enrolled device (fire-and-forget)
-    queueWarrantySyncForDevice(device.id).catch((err) => {
-      console.error('[Enrollment] Failed to queue warranty sync:', err instanceof Error ? err.message : err);
-    });
+    // Warranty sync is queued AFTER withSystemDbAccessContext resolves below
+    // (#1105) — it must not fire while this transaction is still open.
 
     // Close the MCP deployment-invite funnel if this enrollment key was
     // issued by `send_deployment_invites` (best-effort; no-op for manual
@@ -850,21 +856,39 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
       captureException(err);
     }
 
-    return c.json({
-      agentId: agentId,
+    return {
       deviceId: device.id,
-      authToken: apiKey,
-      watchdogAuthToken: watchdogApiKey,
-      helperAuthToken: helperApiKey,
-      orgId: key.orgId,
-      siteId: key.siteId,
-      backupServerUrl: (process.env.AGENT_BACKUP_SERVER_URL ?? '').trim() || undefined,
-      config: {
-        heartbeatIntervalSeconds: 60,
-        metricsCollectionIntervalSeconds: 30
+      responseBody: {
+        agentId: agentId,
+        deviceId: device.id,
+        authToken: apiKey,
+        watchdogAuthToken: watchdogApiKey,
+        helperAuthToken: helperApiKey,
+        orgId: key.orgId,
+        siteId: key.siteId,
+        backupServerUrl: (process.env.AGENT_BACKUP_SERVER_URL ?? '').trim() || undefined,
+        config: {
+          heartbeatIntervalSeconds: 60,
+          metricsCollectionIntervalSeconds: 30
+        },
+        mtls: mtlsCert,
+        manifestTrustKeys,
       },
-      mtls: mtlsCert,
-      manifestTrustKeys,
-    }, 201);
+    };
   });
+
+  if (enrollmentOutcome instanceof Response) {
+    // Error path — no device was enrolled, so no warranty sync to queue.
+    return enrollmentOutcome;
+  }
+
+  // #1105: fire-and-forget BullMQ enqueue now runs after the transaction has
+  // committed and the pooled connection has been released. Same fire-and-
+  // forget error handling as before — an enqueue failure must never fail
+  // enrollment.
+  queueWarrantySyncForDevice(enrollmentOutcome.deviceId).catch((err) => {
+    console.error('[Enrollment] Failed to queue warranty sync:', err instanceof Error ? err.message : err);
+  });
+
+  return c.json(enrollmentOutcome.responseBody, 201);
 });

--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -94,7 +94,8 @@ vi.mock('../db', () => ({
     }))
   },
   runOutsideDbContext: vi.fn((fn: () => any) => fn()),
-  withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn())
+  withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => any) => fn())
 }));
 
 vi.mock('../db/schema', () => ({
@@ -129,6 +130,11 @@ vi.mock('../middleware/auth', async () => ({
   // Real implementation (single source of truth for site-allowlist semantics) —
   // the create-ticket site gate resolves through it via tickets/siteScope.ts.
   siteAccessCheck: (await vi.importActual<typeof import('../middleware/auth')>('../middleware/auth')).siteAccessCheck,
+  // The channel-test route wraps its writes in withChannelsDbContext, which
+  // derives the DB access context from auth via dbAccessContextFromAuth. The
+  // db mock's withDbAccessContext ignores the context, so a passthrough stub
+  // is enough to keep the import from failing.
+  dbAccessContextFromAuth: (auth: any) => auth,
   authMiddleware: vi.fn((c: any, next: any) => {
     // Opt-in site restriction on the AUTH context (deviceInSiteScope reads
     // auth.allowedSiteIds, unlike the list narrowing which reads permissions).
@@ -181,6 +187,24 @@ describe('alert routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks resets call history but NOT queued mockReturnValueOnce
+    // values. Tests set precise per-call db.select/insert/update/delete queues;
+    // if a prior test queues a different number of calls than its code consumes
+    // (e.g. after a dispatcher refactor changes the call count), the leftover
+    // queue leaks into the next test. mockReset() flushes the once-queue, then
+    // we re-install the chainable defaults from the vi.mock factory.
+    vi.mocked(db.select).mockReset().mockImplementation((() => ({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) })
+    })) as any);
+    vi.mocked(db.insert).mockReset().mockImplementation((() => ({
+      values: () => ({ returning: () => Promise.resolve([]) })
+    })) as any);
+    vi.mocked(db.update).mockReset().mockImplementation((() => ({
+      set: () => ({ where: () => ({ returning: () => Promise.resolve([]) }) })
+    })) as any);
+    vi.mocked(db.delete).mockReset().mockImplementation((() => ({
+      where: () => Promise.resolve()
+    })) as any);
     permissionGate.deny = false;
     mfaGate.deny = false;
     sendSmsNotificationMock.mockResolvedValue({

--- a/apps/api/src/routes/alerts/channels.test.ts
+++ b/apps/api/src/routes/alerts/channels.test.ts
@@ -41,6 +41,10 @@ vi.mock('../../middleware/auth', () => ({
   // Referenced (unused) by ./helpers' import of siteAccessCheck; not invoked
   // by any path these tests exercise.
   siteAccessCheck: () => () => true,
+  // The test route is self-managed (#1105 / BREEZE-A) and builds its own DB
+  // context from auth via dbAccessContextFromAuth; stub it to pass the auth
+  // straight through to the (also-stubbed) withDbAccessContext.
+  dbAccessContextFromAuth: (auth: any) => auth,
 }));
 
 // Minimal insert/update/select builder — shared across insert/update/select
@@ -84,6 +88,7 @@ vi.mock('../../db', () => {
     },
     runOutsideDbContext: (fn: () => unknown) => fn(),
     withSystemDbAccessContext: (fn: () => unknown) => fn(),
+    withDbAccessContext: (_ctx: unknown, fn: () => unknown) => fn(),
   };
 });
 

--- a/apps/api/src/routes/alerts/channels.ts
+++ b/apps/api/src/routes/alerts/channels.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { and, eq, sql, desc, inArray, isNull, or } from 'drizzle-orm';
-import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import { db, runOutsideDbContext, withDbAccessContext, withSystemDbAccessContext } from '../../db';
 import { notificationChannels, organizations, partners } from '../../db/schema';
-import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
+import { dbAccessContextFromAuth, requireMfa, requirePermission, requireScope, type AuthContext } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import {
   canManagePartnerWidePolicies,
@@ -42,6 +42,20 @@ import { PERMISSIONS } from '../../services/permissions';
 export const channelsRoutes = new Hono();
 const requireAlertRead = requirePermission(PERMISSIONS.ALERTS_READ.resource, PERMISSIONS.ALERTS_READ.action);
 const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
+
+/**
+ * POST /channels/:id/test is registered in SELF_MANAGED_DB_CONTEXT_ROUTES
+ * (#1105 / BREEZE-A) — it fires a real outbound notification send that can
+ * take up to ~10s, so the auth middleware does NOT wrap this route in the
+ * usual request transaction. Reads/writes instead run in short, explicit
+ * contexts built from the same fields the middleware would have used
+ * (`dbAccessContextFromAuth` mirrors the `buildDbAccessContext` call in
+ * auth.ts's dispatch), so RLS visibility is identical to the auto-wrapped
+ * path. Mirrors `withProviderDbContext` in routes/sso.ts.
+ */
+function withChannelsDbContext<T>(auth: AuthContext, fn: () => Promise<T>): Promise<T> {
+  return runOutsideDbContext(() => withDbAccessContext(dbAccessContextFromAuth(auth), fn));
+}
 
 function toChannelResponse(channel: typeof notificationChannels.$inferSelect) {
   // lastTestedAt and lastTestStatus are carried through via the ...channel spread;
@@ -362,7 +376,10 @@ channelsRoutes.post(
     const auth = c.get('auth');
     const channelId = c.req.param('id')!;
 
-    const channel = await getNotificationChannelWithOrgCheck(channelId, auth);
+    // Short, explicit DB context — this route is in SELF_MANAGED_DB_CONTEXT_ROUTES
+    // (the outbound send below is not tenant-bounded and can take ~10s), so
+    // there is no ambient request transaction to read under (#1105).
+    const channel = await withChannelsDbContext(auth, () => getNotificationChannelWithOrgCheck(channelId, auth));
     if (!channel) {
       return c.json({ error: 'Notification channel not found' }, 404);
     }
@@ -657,13 +674,17 @@ channelsRoutes.post(
     // Best-effort audit field — a DB hiccup here must not mask a successful
     // (or completed) test send. The HTTP response reflects testResult, not this write.
     // updatedAt is intentionally NOT bumped here; running a test is not a user content change.
+    // Own short context (#1105) — the outbound send above ran with no ambient
+    // request transaction; this write reopens one just for the persist.
     try {
-      await db.update(notificationChannels)
-        .set({
-          lastTestedAt: new Date(),
-          lastTestStatus: testResult.success ? 'success' : 'failed',
-        })
-        .where(eq(notificationChannels.id, channel.id));
+      await withChannelsDbContext(auth, () =>
+        db.update(notificationChannels)
+          .set({
+            lastTestedAt: new Date(),
+            lastTestStatus: testResult.success ? 'success' : 'failed',
+          })
+          .where(eq(notificationChannels.id, channel.id))
+      );
     } catch (persistError) {
       console.error('[Channels] Failed to persist test outcome', { channelId: channel.id, persistError });
     }

--- a/apps/api/src/services/metricRollupMaintenance.ts
+++ b/apps/api/src/services/metricRollupMaintenance.ts
@@ -358,6 +358,20 @@ export async function runMetricRollupMaintenance(options: {
       durationMs: Date.now() - startedAt,
     };
   } finally {
-    await releaseMaintenanceLock();
+    // A poisoned transaction (25P02 — an earlier DDL/DELETE in this same
+    // withSystemDbAccessContext transaction already failed) or a dropped
+    // session makes the advisory unlock throw. A throw from `finally` REPLACES
+    // fn's real error, so the true root cause was invisible in Sentry — only
+    // the secondary pg_advisory_unlock failure surfaced (BREEZE-M). Swallow it
+    // so the original error propagates; the session-scoped advisory lock is
+    // released on connection recycle regardless.
+    try {
+      await releaseMaintenanceLock();
+    } catch (err) {
+      console.error(
+        '[MetricRollupMaintenance] releaseMaintenanceLock failed; advisory lock will release on connection recycle:',
+        err,
+      );
+    }
   }
 }

--- a/apps/api/src/services/notificationDispatcher.ts
+++ b/apps/api/src/services/notificationDispatcher.ts
@@ -87,18 +87,29 @@ export function createNotificationWorker(): Worker<NotificationJobData> {
   return new Worker<NotificationJobData>(
     NOTIFICATION_QUEUE,
     async (job: Job<NotificationJobData>) => {
-      return runWithSystemDbAccess(async () => {
-        switch (job.data.type) {
-          case 'send':
-            return await processSendNotification(job.data);
+      switch (job.data.type) {
+        case 'send':
+          // processSendNotification manages its own short DB contexts and
+          // performs the actual outbound send (email/webhook/Slack/Teams/
+          // PagerDuty/Pushover/SMS) OUTSIDE any of them (#1105). Do NOT wrap
+          // this call in runWithSystemDbAccess — that would re-introduce a
+          // pooled connection held idle-in-transaction for the full send
+          // duration, on every alert notification fleet-wide.
+          return await processSendNotification(job.data);
 
-          case 'process-alert':
-            return await processAlertNotifications(job.data);
-
-          default:
-            throw new Error(`Unknown job type: ${(job.data as { type: string }).type}`);
+        case 'process-alert': {
+          // processAlertNotifications only does DB reads/writes plus fast
+          // Redis enqueues (queue.addBulk / queue.add), so it keeps the
+          // existing single-context shape. Bind the switch-narrowed job.data
+          // to a const so the discriminated-union narrowing survives into the
+          // runWithSystemDbAccess closure.
+          const alertJobData = job.data;
+          return await runWithSystemDbAccess(() => processAlertNotifications(alertJobData));
         }
-      });
+
+        default:
+          throw new Error(`Unknown job type: ${(job.data as { type: string }).type}`);
+      }
     },
     {
       connection: getBullMQConnection(),
@@ -304,7 +315,48 @@ export async function processAlertNotifications(data: ProcessAlertJobData): Prom
 }
 
 /**
- * Send a notification through a specific channel
+ * Result shape returned by the short "prepare" DB context below: either an
+ * early-exit result (nothing left to send) or everything needed to perform
+ * the outbound send once the context has closed.
+ */
+type PrepareSendResult =
+  | {
+      send: false;
+      result: { success: boolean; channelType: string; error?: string };
+    }
+  | {
+      send: true;
+      alert: typeof alerts.$inferSelect;
+      channel: typeof notificationChannels.$inferSelect;
+      notificationRecord: typeof alertNotifications.$inferSelect;
+      device: typeof devices.$inferSelect | undefined;
+      org: typeof organizations.$inferSelect | undefined;
+    };
+
+/**
+ * Send a notification through a specific channel.
+ *
+ * Split into three phases to avoid holding a pooled DB connection across the
+ * outbound send (#1105):
+ *   1. `runWithSystemDbAccess` — resolve alert/channel, create the pending
+ *      notification record, and run the rate-limit/throttle guards. Any
+ *      early exit (channel missing, rate limited, throttled, ...) is decided
+ *      and persisted INSIDE this short context, before the send is attempted
+ *      ("mark-attempted before send").
+ *   2. Outside any DB context — perform the actual outbound send (email/
+ *      webhook/Slack/Teams/PagerDuty/Pushover/SMS).
+ *   3. `runWithSystemDbAccess` — persist the final sent/failed result AFTER
+ *      the send completes ("record-result after send").
+ *
+ * Trade-off: previously steps 1-3 were one transaction, so a crash between
+ * the pending insert and the final update would roll back the whole thing —
+ * a BullMQ retry would insert a fresh pending row and try again cleanly. Now
+ * step 1 commits before the send runs, so the same crash instead leaves an
+ * orphaned 'pending' row (retry still inserts a fresh row and resends,
+ * exactly as before). That failure mode already existed for a crash on the
+ * old code's own final `db.update` (rollback of an already-sent message), so
+ * this does not introduce a new double-send risk — it only adds a harmless
+ * orphaned 'pending' row on the rare mid-send crash case.
  */
 async function processSendNotification(data: SendNotificationJobData): Promise<{
   success: boolean;
@@ -314,171 +366,171 @@ async function processSendNotification(data: SendNotificationJobData): Promise<{
 }> {
   const startTime = Date.now();
 
-  // Get alert details
-  const [alert] = await db
-    .select()
-    .from(alerts)
-    .where(eq(alerts.id, data.alertId))
-    .limit(1);
+  const prepared: PrepareSendResult = await runWithSystemDbAccess(async () => {
+    // Get alert details
+    const [alert] = await db
+      .select()
+      .from(alerts)
+      .where(eq(alerts.id, data.alertId))
+      .limit(1);
 
-  if (!alert) {
-    return {
-      success: false,
-      channelType: 'unknown',
-      error: 'Alert not found',
-      durationMs: Date.now() - startTime
-    };
-  }
+    if (!alert) {
+      return {
+        send: false,
+        result: { success: false, channelType: 'unknown', error: 'Alert not found' }
+      } satisfies PrepareSendResult;
+    }
 
-  // Get channel — the alert org's own, or a partner-wide channel owned by
-  // that org's partner (#2130).
-  const sendOrgPartnerId = await partnerIdForOrg(alert.orgId);
-  const [channel] = await db
-    .select()
-    .from(notificationChannels)
-    .where(
-      and(
-        eq(notificationChannels.id, data.channelId),
-        railOwnershipCondition(notificationChannels.orgId, notificationChannels.partnerId, alert.orgId, sendOrgPartnerId),
-        eq(notificationChannels.enabled, true)
+    // Get channel — the alert org's own, or a partner-wide channel owned by
+    // that org's partner (#2130).
+    const sendOrgPartnerId = await partnerIdForOrg(alert.orgId);
+    const [channel] = await db
+      .select()
+      .from(notificationChannels)
+      .where(
+        and(
+          eq(notificationChannels.id, data.channelId),
+          railOwnershipCondition(notificationChannels.orgId, notificationChannels.partnerId, alert.orgId, sendOrgPartnerId),
+          eq(notificationChannels.enabled, true)
+        )
       )
-    )
-    .limit(1);
+      .limit(1);
 
-  if (!channel) {
-    // A resolved {success:false} completes the BullMQ job (no 'failed' event)
-    // and no alert_notifications row exists yet on this path — without a log
-    // this send (possibly a DELAYED escalation step whose channel/partner
-    // state drifted since scheduling) vanishes without a trace (#2130 review).
-    console.warn(
-      `[NotificationDispatcher] Channel ${data.channelId} not found (or disabled) for alert ${data.alertId}`
-      + `${data.escalationStep ? ` escalation step ${data.escalationStep}` : ''} — send dropped`
-    );
-    return {
-      success: false,
-      channelType: 'unknown',
-      error: 'Channel not found for alert organization or its partner',
-      durationMs: Date.now() - startTime
-    };
-  }
-
-  // Create notification record (pending)
-  const [notificationRecord] = await db
-    .insert(alertNotifications)
-    .values({
-      alertId: data.alertId,
-      channelId: data.channelId,
-      status: 'pending'
-    })
-    .returning();
-
-  if (!notificationRecord) {
-    return {
-      success: false,
-      channelType: channel.type,
-      error: 'Failed to create notification record',
-      durationMs: Date.now() - startTime
-    };
-  }
-
-  // Get device info for context
-  const [device] = await db
-    .select()
-    .from(devices)
-    .where(eq(devices.id, alert.deviceId))
-    .limit(1);
-
-  // Get org info
-  const [org] = await db
-    .select()
-    .from(organizations)
-    .where(eq(organizations.id, alert.orgId))
-    .limit(1);
-
-  // Phase 4b: Notification rate limiting
-  const redis = isRedisAvailable() ? getRedis() : null;
-  if (!redis) {
-    console.warn(`[NotificationDispatcher] Redis unavailable — notification rate limiting DISABLED for org ${alert.orgId}`);
-  }
-  if (redis) {
-    const rateKey = `notify:${alert.orgId}:${channel.type}`;
-    const rateLimitResult = await rateLimiter(redis, rateKey, 60, 300); // 60 per 5 min
-    if (!rateLimitResult.allowed) {
-      console.warn(`[NotificationDispatcher] Rate limited for ${channel.type} channel in org ${alert.orgId}. Remaining: ${rateLimitResult.remaining}`);
-      // Update pending record to reflect rate limiting
-      if (notificationRecord?.id) {
-        await db.update(alertNotifications)
-          .set({ status: 'failed', errorMessage: 'Rate limited' })
-          .where(eq(alertNotifications.id, notificationRecord.id));
-      }
-      return {
-        success: false,
-        channelType: channel.type,
-        error: `Rate limited (resets at ${rateLimitResult.resetAt.toISOString()})`,
-        durationMs: Date.now() - startTime
-      };
-    }
-  }
-
-  // Feature #4: per-channel sliding-window throttle (defense-in-depth vs alert storms).
-  // Keyed by (channelId, device:<deviceId>) so one flooding device cannot starve other devices.
-  if (channel.throttleMaxPerWindow && channel.throttleMaxPerWindow > 0) {
-    const windowSeconds = channel.throttleWindowSeconds ?? 3600;
-    const throttle = await checkNotificationThrottle(
-      channel.id,
-      `device:${alert.deviceId}`,
-      channel.throttleMaxPerWindow,
-      windowSeconds
-    );
-    if (!throttle.allowed) {
-      const windowExpiresIso = new Date(throttle.windowExpiresAt).toISOString();
-      const throttleMessage = `Throttled: ${throttle.currentCount} delivered in last ${windowSeconds}s (cap=${channel.throttleMaxPerWindow})`;
+    if (!channel) {
+      // A resolved {success:false} completes the BullMQ job (no 'failed' event)
+      // and no alert_notifications row exists yet on this path — without a log
+      // this send (possibly a DELAYED escalation step whose channel/partner
+      // state drifted since scheduling) vanishes without a trace (#2130 review).
       console.warn(
-        `[NotificationThrottle] Suppressed: channel=${channel.id} device=${alert.deviceId} ` +
-        `count=${throttle.currentCount}/${channel.throttleMaxPerWindow} resetsAt=${windowExpiresIso}`
+        `[NotificationDispatcher] Channel ${data.channelId} not found (or disabled) for alert ${data.alertId}`
+        + `${data.escalationStep ? ` escalation step ${data.escalationStep}` : ''} — send dropped`
       );
-      // Use 'failed' status + descriptive errorMessage so UI / queries that
-      // filter by status see throttled rows alongside other delivery failures.
-      // The alert_notifications.status column carries pending/sent/failed only;
-      // 'suppressed' belongs to the separate alertStatusEnum and would render
-      // as a phantom value here. (See #796 review.)
-      await db.update(alertNotifications)
-        .set({
-          status: 'failed',
-          errorMessage: throttleMessage
-        })
-        .where(eq(alertNotifications.id, notificationRecord.id));
-      // Operator-visible audit event so a misconfigured cap silently eating
-      // alerts is investigable instead of buried in stdout. (See #796 review.)
-      createAuditLogAsync({
-        orgId: alert.orgId,
-        actorType: 'system',
-        actorId: '00000000-0000-0000-0000-000000000000',
-        action: 'alert.notification.throttled',
-        resourceType: 'alert_notification',
-        resourceId: notificationRecord.id,
-        result: 'denied',
-        errorMessage: throttleMessage,
-        details: {
-          channelId: channel.id,
-          channelType: channel.type,
-          deviceId: alert.deviceId,
-          currentCount: throttle.currentCount,
-          maxPerWindow: channel.throttleMaxPerWindow,
-          windowSeconds,
-          windowExpiresAt: windowExpiresIso,
-        },
-      });
       return {
-        success: false,
-        channelType: channel.type,
-        error: `Throttled (resets at ${windowExpiresIso})`,
-        durationMs: Date.now() - startTime
-      };
+        send: false,
+        result: { success: false, channelType: 'unknown', error: 'Channel not found for alert organization or its partner' }
+      } satisfies PrepareSendResult;
     }
+
+    // Create notification record (pending)
+    const [notificationRecord] = await db
+      .insert(alertNotifications)
+      .values({
+        alertId: data.alertId,
+        channelId: data.channelId,
+        status: 'pending'
+      })
+      .returning();
+
+    if (!notificationRecord) {
+      return {
+        send: false,
+        result: { success: false, channelType: channel.type, error: 'Failed to create notification record' }
+      } satisfies PrepareSendResult;
+    }
+
+    // Get device info for context
+    const [device] = await db
+      .select()
+      .from(devices)
+      .where(eq(devices.id, alert.deviceId))
+      .limit(1);
+
+    // Get org info
+    const [org] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.id, alert.orgId))
+      .limit(1);
+
+    // Phase 4b: Notification rate limiting
+    const redis = isRedisAvailable() ? getRedis() : null;
+    if (!redis) {
+      console.warn(`[NotificationDispatcher] Redis unavailable — notification rate limiting DISABLED for org ${alert.orgId}`);
+    }
+    if (redis) {
+      const rateKey = `notify:${alert.orgId}:${channel.type}`;
+      const rateLimitResult = await rateLimiter(redis, rateKey, 60, 300); // 60 per 5 min
+      if (!rateLimitResult.allowed) {
+        console.warn(`[NotificationDispatcher] Rate limited for ${channel.type} channel in org ${alert.orgId}. Remaining: ${rateLimitResult.remaining}`);
+        // Update pending record to reflect rate limiting
+        if (notificationRecord?.id) {
+          await db.update(alertNotifications)
+            .set({ status: 'failed', errorMessage: 'Rate limited' })
+            .where(eq(alertNotifications.id, notificationRecord.id));
+        }
+        return {
+          send: false,
+          result: { success: false, channelType: channel.type, error: `Rate limited (resets at ${rateLimitResult.resetAt.toISOString()})` }
+        } satisfies PrepareSendResult;
+      }
+    }
+
+    // Feature #4: per-channel sliding-window throttle (defense-in-depth vs alert storms).
+    // Keyed by (channelId, device:<deviceId>) so one flooding device cannot starve other devices.
+    if (channel.throttleMaxPerWindow && channel.throttleMaxPerWindow > 0) {
+      const windowSeconds = channel.throttleWindowSeconds ?? 3600;
+      const throttle = await checkNotificationThrottle(
+        channel.id,
+        `device:${alert.deviceId}`,
+        channel.throttleMaxPerWindow,
+        windowSeconds
+      );
+      if (!throttle.allowed) {
+        const windowExpiresIso = new Date(throttle.windowExpiresAt).toISOString();
+        const throttleMessage = `Throttled: ${throttle.currentCount} delivered in last ${windowSeconds}s (cap=${channel.throttleMaxPerWindow})`;
+        console.warn(
+          `[NotificationThrottle] Suppressed: channel=${channel.id} device=${alert.deviceId} ` +
+          `count=${throttle.currentCount}/${channel.throttleMaxPerWindow} resetsAt=${windowExpiresIso}`
+        );
+        // Use 'failed' status + descriptive errorMessage so UI / queries that
+        // filter by status see throttled rows alongside other delivery failures.
+        // The alert_notifications.status column carries pending/sent/failed only;
+        // 'suppressed' belongs to the separate alertStatusEnum and would render
+        // as a phantom value here. (See #796 review.)
+        await db.update(alertNotifications)
+          .set({
+            status: 'failed',
+            errorMessage: throttleMessage
+          })
+          .where(eq(alertNotifications.id, notificationRecord.id));
+        // Operator-visible audit event so a misconfigured cap silently eating
+        // alerts is investigable instead of buried in stdout. (See #796 review.)
+        createAuditLogAsync({
+          orgId: alert.orgId,
+          actorType: 'system',
+          actorId: '00000000-0000-0000-0000-000000000000',
+          action: 'alert.notification.throttled',
+          resourceType: 'alert_notification',
+          resourceId: notificationRecord.id,
+          result: 'denied',
+          errorMessage: throttleMessage,
+          details: {
+            channelId: channel.id,
+            channelType: channel.type,
+            deviceId: alert.deviceId,
+            currentCount: throttle.currentCount,
+            maxPerWindow: channel.throttleMaxPerWindow,
+            windowSeconds,
+            windowExpiresAt: windowExpiresIso,
+          },
+        });
+        return {
+          send: false,
+          result: { success: false, channelType: channel.type, error: `Throttled (resets at ${windowExpiresIso})` }
+        } satisfies PrepareSendResult;
+      }
+    }
+
+    return { send: true, alert, channel, notificationRecord, device, org } satisfies PrepareSendResult;
+  });
+
+  if (!prepared.send) {
+    return { ...prepared.result, durationMs: Date.now() - startTime };
   }
 
-  // Phase 4c: Per-channel notification templates
+  const { alert, channel, notificationRecord, device, org } = prepared;
+
+  // Phase 4c: Per-channel notification templates (pure computation — no DB/Redis needed)
   const channelTemplates = channel.templates as Record<string, string> | null;
   let messageBody = alert.message || alert.title;
   if (channelTemplates?.alert_triggered) {
@@ -498,7 +550,7 @@ async function processSendNotification(data: SendNotificationJobData): Promise<{
     ? { ...alert, message: messageBody }
     : alert;
 
-  // Send notification based on channel type
+  // Send notification based on channel type — OUTSIDE any DB context (#1105).
   let success = false;
   let error: string | undefined;
 
@@ -598,15 +650,18 @@ async function processSendNotification(data: SendNotificationJobData): Promise<{
     error = err instanceof Error ? err.message : 'Unknown error';
   }
 
-  // Update notification record
-  await db
-    .update(alertNotifications)
-    .set({
-      status: success ? 'sent' : 'failed',
-      sentAt: success ? new Date() : null,
-      errorMessage: error || null
-    })
-    .where(eq(alertNotifications.id, notificationRecord.id));
+  // Persist the final result — short DB context, AFTER the send completes
+  // ("record-result after send"), so the transaction never spans the send.
+  await runWithSystemDbAccess(() =>
+    db
+      .update(alertNotifications)
+      .set({
+        status: success ? 'sent' : 'failed',
+        sentAt: success ? new Date() : null,
+        errorMessage: error || null
+      })
+      .where(eq(alertNotifications.id, notificationRecord.id))
+  );
 
   if (success) {
     console.log(`[NotificationDispatcher] Sent ${channel.type} notification for alert ${data.alertId}`);
@@ -662,12 +717,20 @@ async function sendWebhookChannelNotification(
   device: typeof devices.$inferSelect | undefined,
   org: typeof organizations.$inferSelect | undefined
 ): Promise<{ success: boolean; error?: string }> {
-  // Get rule for additional context (ruleId may be null for config policy alerts)
-  const rule = alert.ruleId ? (await db
-    .select()
-    .from(alertRules)
-    .where(eq(alertRules.id, alert.ruleId))
-    .limit(1))[0] : undefined;
+  // Get rule for additional context (ruleId may be null for config policy alerts).
+  // This now runs during the outbound-send phase (#1105), with no ambient DB
+  // context, so it must open its own short one rather than assume `db` is
+  // already inside a transaction.
+  const ruleId = alert.ruleId;
+  const rule = ruleId
+    ? await runWithSystemDbAccess(async () =>
+        (await db
+          .select()
+          .from(alertRules)
+          .where(eq(alertRules.id, ruleId))
+          .limit(1))[0]
+      )
+    : undefined;
 
   return sendWebhookNotification(config, {
     alertId: alert.id,

--- a/apps/api/src/workers/webhookDelivery.ts
+++ b/apps/api/src/workers/webhookDelivery.ts
@@ -406,16 +406,22 @@ export async function initializeWebhookDelivery(
   // Subscribe to all events
   eventBus.subscribe('*', async (event) => {
     try {
-      await runWithSystemDbAccess(async () => {
-        // Get webhooks configured for this event type in this org
-        const webhooks = await getWebhooksForEvent(event.orgId, event.type);
+      // Get webhooks configured for this event type in this org — short DB context.
+      const webhooks = await runWithSystemDbAccess(() => getWebhooksForEvent(event.orgId, event.type));
 
-        // Queue delivery for each webhook
-        for (const webhook of webhooks) {
-          const deliveryId = createDeliveryRecord ? await createDeliveryRecord(webhook, event) : null;
-          await worker.queueDelivery(webhook, event, deliveryId ?? undefined);
-        }
-      });
+      // Queue delivery for each webhook. The delivery record is created in
+      // its own short DB context right before its enqueue ("mark-attempted
+      // before send"); `queueDelivery` itself is a Redis LPUSH and runs
+      // OUTSIDE any DB context (#1105) — looping Redis calls while a pooled
+      // Postgres connection sits idle-in-transaction is exactly the hold
+      // pattern that exhausts the pool under load, and this subscriber fires
+      // on every event fleet-wide.
+      for (const webhook of webhooks) {
+        const deliveryId = createDeliveryRecord
+          ? await runWithSystemDbAccess(() => createDeliveryRecord(webhook, event))
+          : null;
+        await worker.queueDelivery(webhook, event, deliveryId ?? undefined);
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes('CONNECTION_DESTROYED') || msg.includes('CONNECTION_ENDED')) {


### PR DESCRIPTION
Resolves five of the six issues in the **#1105 connection-hold cluster** (slow non-DB work — a Redis enqueue or a multi-second outbound send — running inside a held Postgres transaction, pinning a pooled connection idle-in-transaction and, under load, exhausting the pool).

**Mechanism note (important):** `runOutsideDbContext` only exits the AsyncLocalStorage store — it does **not** release the outer transaction. So every fix here moves the slow work to run with **no open transaction**, rather than wrapping it.

## Fixes

| Sentry | Problem | Fix |
|---|---|---|
| **BREEZE-M** | `runMetricRollupMaintenance` runs in one transaction; when an earlier statement fails (`25P02`), the `finally { releaseMaintenanceLock() }` throws again and **replaces** the real error — so Sentry only saw the secondary unlock failure. | Guard the release so the original error propagates. |
| **BREEZE-W** | `refreshRiskScores` did an unordered per-row `UPDATE` loop in one transaction (deadlock-prone, `40P01`) with no retry, so a deadlock dropped the whole day's refresh. | `ORDER BY id` (deterministic lock order) + `attempts: 3` w/ backoff (recompute is idempotent). |
| **BREEZE-Q** | `POST /agents/enroll` fired the `queueWarrantySyncForDevice` Redis enqueue inside the enroll transaction. | Return the response data from the context, run the enqueue after it resolves, then respond. Body/status byte-for-byte preserved. |
| **BREEZE-A** | `POST /alerts/channels/:id/test` ran a ~10s outbound send inside the auth middleware's request transaction. | Opt into `SELF_MANAGED_DB_CONTEXT_ROUTES`; read + persist in short `withDbAccessContext` blocks (context rebuilt from auth), send between. Mirrors `routes/sso.ts`. |
| **BREEZE-9** | The alert-notification + webhook workers ran outbound sends / Redis enqueues inside `runWithSystemDbAccess`. | Split `processSendNotification` into prepare (short ctx) → send (no ctx) → record-result (short ctx); `webhookDelivery` reads/creates records in short ctx with the LPUSH outside. At-least-once semantics unchanged. |

## Verification
- Full-project `tsc --noEmit`: **0 errors**.
- Unit tests: `metricRollupMaintenance` (14), `enrollment` + `alerts/channels` + `webhookDelivery` (41) — all pass. `refreshRiskScores` / `notificationDispatcher` have real-DB integration coverage (not run here to avoid truncating the shared dev DB).

## Deferred: BREEZE-B
The device-events read (26s hold) is **not** in this PR. On scrutiny: (1) the hold is most likely the slow **unindexed `ILIKE` search query** holding the connection *busy* — a query/index problem needing a trigram/GIN index migration + `statement_timeout`, a separate design decision; and (2) the "reorder the permission cache ahead of the Redis freshness check" idea would be a **stale-permissions security regression**. It needs its own focused pass on the auth middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)