### PR TITLE
fix(extension-cli): realpath bin guard + implement breeze-ext validate (#2657)

### DIFF
--- a/packages/extension-cli/src/cli.test.ts
+++ b/packages/extension-cli/src/cli.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createProgram } from './cli';
+
+const execFileAsync = promisify(execFile);
 
 describe('breeze-ext CLI surface', () => {
   it('registers exactly the commands validate, pack, sign, inspect', () => {
@@ -127,4 +135,40 @@ describe('module load purity', () => {
       ).not.toBeInstanceOf(Promise);
     }
   });
+});
+
+describe('breeze-ext bin entry (isMainModule) under symlink indirection', () => {
+  // Regression for #2657. When `breeze-ext` is launched through a pnpm-installed
+  // bin, `process.argv[1]` is the `node_modules/.bin` symlink while
+  // `import.meta.url` is the module's realpath. The old guard compared the raw
+  // URL against `pathToFileURL(argv[1])`, never matched under a symlink, and the
+  // process exited 0 having parsed nothing — a silent no-op. Launching the real
+  // cli.ts through a symlink and observing the program actually run (here: emit
+  // its version) proves the guard now resolves both sides to their realpath.
+  const cliPath = join(dirname(fileURLToPath(import.meta.url)), 'cli.ts');
+  const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+  let linkDir: string;
+
+  beforeEach(async () => {
+    linkDir = await mkdtemp(join(tmpdir(), 'breeze-ext-binlink-'));
+  });
+
+  afterEach(async () => {
+    await rm(linkDir, { recursive: true, force: true });
+  });
+
+  it('runs the program when invoked as the entry point through a symlink', async () => {
+    const link = join(linkDir, 'breeze-ext-link.ts');
+    await symlink(cliPath, link);
+
+    // node --import tsx <symlink> --version — with the old guard this printed
+    // nothing and exited 0; with the fix it prints the CLI version.
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ['--import', 'tsx', link, '--version'],
+      { cwd: packageRoot },
+    );
+
+    expect(stdout.trim()).toBe('1.0.0');
+  }, 30000);
 });

--- a/packages/extension-cli/src/cli.ts
+++ b/packages/extension-cli/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
-import { pathToFileURL } from 'node:url';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { runInspect } from './commands/inspect';
 import { runPack } from './commands/pack';
 import { runSign } from './commands/sign';
@@ -73,10 +74,29 @@ export function createProgram(): Command {
   return program;
 }
 
+/**
+ * True when this module is the process entry point.
+ *
+ * Compares REALPATHS, not the raw URL against `pathToFileURL(argv[1])`. When
+ * the CLI is launched through a pnpm-installed bin, `process.argv[1]` is the
+ * `node_modules/.bin` (or `.pnpm`) *symlink*, while `import.meta.url` already
+ * reflects the module's *realpath* (Node resolves symlinks when loading ESM).
+ * A raw comparison therefore never matches under pnpm, `isMainModule()` returns
+ * false, and the binary exits 0 having parsed nothing — a silent no-op, the
+ * worst failure shape for a signing/packing pipeline. Resolving both sides to
+ * their realpath makes the comparison hold regardless of symlink indirection.
+ *
+ * `realpathSync` throws if a path does not exist (e.g. a synthetic `argv[1]`);
+ * a throw here just means "not the entry point", so it is swallowed.
+ */
 function isMainModule(): boolean {
   const entry = process.argv[1];
   if (!entry) return false;
-  return import.meta.url === pathToFileURL(entry).href;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
 }
 
 if (isMainModule()) {

--- a/packages/extension-cli/src/commands/validate.test.ts
+++ b/packages/extension-cli/src/commands/validate.test.ts
@@ -1,0 +1,211 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createProgram } from '../cli';
+import { runValidate, validateExtension, type ValidateResult } from './validate';
+
+const VALID_MANIFEST = {
+  apiVersion: 'breeze.extensions/v1',
+  name: 'acme-widgets',
+  version: '1.0.0',
+  routeNamespace: 'acme-widgets',
+  requires: { breeze: '>=0.1.0 <0.2.0', serverSdk: '^1.0.0', capabilities: [] },
+  server: { entry: 'server/index.js' },
+  schemaCompatibilityFloor: '1.0.0',
+  jobs: [],
+  aiTools: [],
+};
+
+let sourceDir: string;
+
+beforeEach(async () => {
+  sourceDir = await mkdtemp(join(tmpdir(), 'breeze-ext-validate-'));
+});
+
+afterEach(async () => {
+  await rm(sourceDir, { recursive: true, force: true });
+});
+
+async function writeFixture(relPath: string, contents: string | object): Promise<void> {
+  const fullPath = join(sourceDir, ...relPath.split('/'));
+  await mkdir(join(fullPath, '..'), { recursive: true });
+  const body = typeof contents === 'string' ? contents : JSON.stringify(contents);
+  await writeFile(fullPath, body);
+}
+
+async function writeValidTree(): Promise<void> {
+  await writeFixture('manifest.json', VALID_MANIFEST);
+  await writeFixture('server/index.js', 'module.exports = () => {};');
+}
+
+describe('validateExtension', () => {
+  it('accepts a well-formed source tree', async () => {
+    await writeValidTree();
+    const result = await validateExtension({ path: sourceDir });
+    expect(result.ok).toBe(true);
+    expect(result.findings).toEqual([]);
+    expect(result.manifest).toEqual({
+      name: 'acme-widgets',
+      version: '1.0.0',
+      apiVersion: 'breeze.extensions/v1',
+    });
+  });
+
+  it('reports manifest_missing when there is no manifest.json', async () => {
+    await writeFixture('server/index.js', 'module.exports = () => {};');
+    const result = await validateExtension({ path: sourceDir });
+    expect(result.ok).toBe(false);
+    expect(result.manifest).toBeUndefined();
+    expect(result.findings).toEqual([
+      expect.objectContaining({ code: 'manifest_missing' }),
+    ]);
+  });
+
+  it('reports manifest_invalid_json for a manifest that is not valid JSON', async () => {
+    await writeFixture('manifest.json', '{ not json');
+    const result = await validateExtension({ path: sourceDir });
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({ code: 'manifest_invalid_json' }),
+    ]);
+  });
+
+  it('enumerates manifest_schema findings with structured field paths', async () => {
+    // `devices` is a reserved core route namespace; `version` is not semver.
+    await writeFixture('manifest.json', { ...VALID_MANIFEST, routeNamespace: 'devices', version: 'not-a-version' });
+    await writeFixture('server/index.js', 'module.exports = () => {};');
+    const result = await validateExtension({ path: sourceDir });
+    expect(result.ok).toBe(false);
+    expect(result.findings.length).toBeGreaterThanOrEqual(2);
+    expect(result.findings.every((f) => f.code === 'manifest_schema')).toBe(true);
+    const paths = result.findings.map((f) => f.path);
+    expect(paths).toContain('routeNamespace');
+    expect(paths).toContain('version');
+  });
+
+  it('reports entry_missing when server.entry is not present in the tree', async () => {
+    await writeFixture('manifest.json', VALID_MANIFEST);
+    // No server/index.js written.
+    const result = await validateExtension({ path: sourceDir });
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({ code: 'entry_missing', path: 'server/index.js' }),
+    ]);
+  });
+
+  it('reports entry_missing for a declared but absent web.entry', async () => {
+    await writeFixture('manifest.json', {
+      ...VALID_MANIFEST,
+      requires: { breeze: '>=0.1.0 <0.2.0', serverSdk: '^1.0.0', webSdk: '^1.0.0', capabilities: [] },
+      web: { entry: 'web/index.js', pages: [], navigation: [], slots: [] },
+    });
+    await writeFixture('server/index.js', 'module.exports = () => {};');
+    // No web/index.js written.
+    const result = await validateExtension({ path: sourceDir });
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({ code: 'entry_missing', path: 'web/index.js' }),
+    ]);
+  });
+
+  it('reports a layout finding when the source tree contains a symlink', async () => {
+    await writeValidTree();
+    await symlink(join(sourceDir, 'server', 'index.js'), join(sourceDir, 'server', 'alias.js'));
+    const result = await validateExtension({ path: sourceDir });
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({ code: 'layout' }),
+    ]);
+    expect(result.findings[0]?.message).toMatch(/symlink/i);
+  });
+
+  it('reports a layout finding when a reserved generated member is carried in from source', async () => {
+    await writeValidTree();
+    await writeFixture('integrity.json', '{}');
+    const result = await validateExtension({ path: sourceDir });
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({ code: 'layout' }),
+    ]);
+    expect(result.findings[0]?.message).toMatch(/reserved/i);
+  });
+});
+
+describe('runValidate exit codes and output', () => {
+  it('leaves process.exitCode unset (zero) on a valid tree and prints ok', async () => {
+    await writeValidTree();
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await runValidate({ path: sourceDir });
+      expect(process.exitCode).toBeUndefined();
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('valid: ok'));
+    } finally {
+      logSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    }
+  });
+
+  it('sets process.exitCode = 1 on a failing tree', async () => {
+    await writeFixture('server/index.js', 'module.exports = () => {};');
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await runValidate({ path: sourceDir });
+      expect(process.exitCode).toBe(1);
+    } finally {
+      logSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    }
+  });
+
+  it('emits a machine-readable result under --json', async () => {
+    await writeValidTree();
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let captured = '';
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((msg: unknown) => {
+      captured = String(msg);
+    });
+    try {
+      await runValidate({ path: sourceDir, json: true });
+      const parsed = JSON.parse(captured) as ValidateResult;
+      expect(parsed.ok).toBe(true);
+      expect(parsed.manifest?.name).toBe('acme-widgets');
+      expect(parsed.findings).toEqual([]);
+    } finally {
+      logSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    }
+  });
+});
+
+describe('validate command wiring (no longer a stub)', () => {
+  it('runs the validate action end-to-end via createProgram instead of throwing', async () => {
+    await writeValidTree();
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let captured = '';
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((msg: unknown) => {
+      captured += String(msg);
+    });
+    const program = createProgram();
+    program.exitOverride();
+    for (const command of program.commands) command.exitOverride();
+    let caught: unknown;
+    try {
+      await program.parseAsync(['node', 'breeze-ext', 'validate', sourceDir, '--json']);
+    } catch (error) {
+      caught = error;
+    } finally {
+      logSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    }
+    // The old stub threw "not implemented yet"; the action must now run cleanly.
+    expect(caught).toBeUndefined();
+    expect(captured).toContain('"ok": true');
+  });
+});

--- a/packages/extension-cli/src/commands/validate.ts
+++ b/packages/extension-cli/src/commands/validate.ts
@@ -76,14 +76,20 @@ export async function validateExtension(options: ValidateOptions): Promise<Valid
   let manifestBytes: Buffer;
   try {
     manifestBytes = await readFile(manifestPath);
-  } catch {
-    return {
-      ok: false,
-      findings: [{
-        code: 'manifest_missing',
-        message: 'source tree is missing required "manifest.json"',
-      }],
-    };
+  } catch (error) {
+    // Only a genuinely absent file is "manifest_missing". A permission/IO error
+    // (EACCES, EISDIR, …) is a real failure the author needs to see, not a
+    // conformance finding — surface it rather than mislabeling it as missing.
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {
+        ok: false,
+        findings: [{
+          code: 'manifest_missing',
+          message: 'source tree is missing required "manifest.json"',
+        }],
+      };
+    }
+    throw error;
   }
 
   let manifestRaw: unknown;

--- a/packages/extension-cli/src/commands/validate.ts
+++ b/packages/extension-cli/src/commands/validate.ts
@@ -1,10 +1,25 @@
 /**
- * `breeze-ext validate` — checks an extension source directory's manifest
- * and layout for conformance before packing.
+ * `breeze-ext validate` — an AUTHOR-SIDE PRE-PACK CHECK that reports whether an
+ * extension source directory would pack cleanly: the manifest parses and
+ * conforms to the v1 schema, the source layout is safe (no symlinks, no
+ * reserved generated members carried in from source), and every entry the
+ * manifest points at (`server.entry`, and `web.entry` when web is declared)
+ * actually exists in the tree.
  *
- * Not implemented yet: manifest schema validation, capability checks, and
- * route-namespace collision checks land in a later task.
+ * It reuses the exact machinery `pack` uses — `collectPayload` for the layout
+ * and security gate, `safeParseExtensionManifestV1` for structured manifest
+ * diagnostics — so "validate passes" implies "pack will not reject the manifest
+ * or layout". It is NOT the host's trust decision:
+ * `apps/api/src/extensions/bundleVerifier.ts` (`verifyExtensionBundle`) is the
+ * only place that enforces publisher trust, digest pinning, and archive-safety
+ * limits before code is allowed to load. `validate` never imports or duplicates
+ * that trust logic.
  */
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { safeParseExtensionManifestV1 } from '@breeze/extension-sdk';
+import { collectPayload } from '../artifact/collectPayload';
 
 export interface ValidateOptions {
   /** Path to the extension source directory (contains the manifest). */
@@ -13,6 +28,165 @@ export interface ValidateOptions {
   json?: boolean;
 }
 
-export async function runValidate(_options: ValidateOptions): Promise<never> {
-  throw new Error('breeze-ext validate: not implemented yet');
+/**
+ * A single validation problem.
+ *
+ * `code` is a stable, machine-readable identifier so callers (CI, other
+ * tooling) can match on it without parsing the human `message`:
+ * - `manifest_missing`      — no `manifest.json` in the source tree.
+ * - `manifest_invalid_json` — `manifest.json` is present but not valid JSON.
+ * - `manifest_schema`       — `manifest.json` parsed but failed the v1 schema;
+ *                             `path` is the dotted field path of the issue.
+ * - `entry_missing`         — a manifest-declared entry file is not in the tree;
+ *                             `path` is the declared relative entry path.
+ * - `layout`                — a source-layout / safety violation surfaced by
+ *                             `collectPayload` (a symlink, or a reserved
+ *                             generated member carried in from source).
+ */
+export interface ValidateFinding {
+  code: 'manifest_missing' | 'manifest_invalid_json' | 'manifest_schema' | 'entry_missing' | 'layout';
+  /** Manifest field path (for `manifest_schema`) or member path (for `entry_missing`); omitted otherwise. */
+  path?: string;
+  message: string;
+}
+
+export interface ValidateResult {
+  /** `true` iff the source tree would pack cleanly — drives the exit code. */
+  ok: boolean;
+  /** Manifest identity, present only once the manifest has parsed and conformed. */
+  manifest?: { name: string; version: string; apiVersion: string };
+  findings: ValidateFinding[];
+}
+
+/**
+ * Validate an extension source directory. Returns a structured result rather
+ * than throwing, so `runValidate` can print a full report (JSON or human) and
+ * set an exit code without a stack trace escaping.
+ *
+ * Order is load-bearing and short-circuits: manifest presence → JSON validity →
+ * schema conformance. Each stage needs the previous one's output, so a failure
+ * returns immediately rather than cascading into misleading downstream findings
+ * (e.g. an `entry_missing` computed from a field the schema already rejected).
+ * Only once the manifest is known-good does it run the layout/security gate and
+ * the entry-existence checks.
+ */
+export async function validateExtension(options: ValidateOptions): Promise<ValidateResult> {
+  const manifestPath = join(options.path, 'manifest.json');
+
+  let manifestBytes: Buffer;
+  try {
+    manifestBytes = await readFile(manifestPath);
+  } catch {
+    return {
+      ok: false,
+      findings: [{
+        code: 'manifest_missing',
+        message: 'source tree is missing required "manifest.json"',
+      }],
+    };
+  }
+
+  let manifestRaw: unknown;
+  try {
+    manifestRaw = JSON.parse(manifestBytes.toString('utf8'));
+  } catch {
+    return {
+      ok: false,
+      findings: [{ code: 'manifest_invalid_json', message: 'manifest.json is not valid JSON' }],
+    };
+  }
+
+  // safeParse (not the throwing parse) so EVERY schema issue is enumerated with
+  // its structured path/message, rather than a single prettified string.
+  const parsed = safeParseExtensionManifestV1(manifestRaw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      findings: parsed.error.issues.map((issue) => ({
+        code: 'manifest_schema',
+        path: issue.path.join('.') || undefined,
+        message: issue.message,
+      })),
+    };
+  }
+  const manifest = parsed.data;
+  const identity = { name: manifest.name, version: manifest.version, apiVersion: manifest.apiVersion };
+
+  // Layout + security gate — identical to what `pack` runs. Since the manifest
+  // already passed the schema above, collectPayload's own re-parse cannot fail
+  // here; its remaining job is to refuse symlinks and reserved source members.
+  let members;
+  try {
+    members = await collectPayload(options.path);
+  } catch (error) {
+    return {
+      ok: false,
+      manifest: identity,
+      findings: [{ code: 'layout', message: error instanceof Error ? error.message : String(error) }],
+    };
+  }
+
+  // Entry-path existence: the manifest may reference files that were never
+  // shipped in the source tree. pack does not check this, so validate is the
+  // place that catches a bundle that would load-fail at the host.
+  const memberPaths = new Set(members.map((member) => member.path));
+  const findings: ValidateFinding[] = [];
+  if (!memberPaths.has(manifest.server.entry)) {
+    findings.push({
+      code: 'entry_missing',
+      path: manifest.server.entry,
+      message: `server.entry "${manifest.server.entry}" is not present in the source tree`,
+    });
+  }
+  if (manifest.web && !memberPaths.has(manifest.web.entry)) {
+    findings.push({
+      code: 'entry_missing',
+      path: manifest.web.entry,
+      message: `web.entry "${manifest.web.entry}" is not present in the source tree`,
+    });
+  }
+
+  return { ok: findings.length === 0, manifest: identity, findings };
+}
+
+/**
+ * Human-readable report. Contains only source-relative paths and result data —
+ * never `options.path` (an absolute checkout path) or environment data.
+ */
+function formatHuman(result: ValidateResult): string {
+  const lines: string[] = [];
+  if (result.manifest) {
+    lines.push(`name: ${result.manifest.name}`);
+    lines.push(`version: ${result.manifest.version}`);
+    lines.push(`apiVersion: ${result.manifest.apiVersion}`);
+  }
+  if (result.ok) {
+    lines.push('valid: ok');
+  } else {
+    lines.push(`valid: ${result.findings.length} problem(s) found`);
+    for (const finding of result.findings) {
+      const where = finding.path ? ` [${finding.path}]` : '';
+      lines.push(`  - ${finding.code}${where}: ${finding.message}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Run `validate` and print its report. Exit code is nonzero on any validation
+ * failure and zero on a clean source tree — set via `process.exitCode` (not
+ * `throw`) so the report itself is still printed before the process exits.
+ */
+export async function runValidate(options: ValidateOptions): Promise<void> {
+  const result = await validateExtension(options);
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatHuman(result));
+  }
+
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
 }

--- a/packages/extension-cli/src/index.ts
+++ b/packages/extension-cli/src/index.ts
@@ -20,7 +20,13 @@ export {
 } from './commands/inspect';
 export { packExtension, runPack, type PackOptions, type PackResult } from './commands/pack';
 export { runSign, signArtifact, type SignOptions, type SignResult } from './commands/sign';
-export { runValidate, type ValidateOptions } from './commands/validate';
+export {
+  runValidate,
+  validateExtension,
+  type ValidateFinding,
+  type ValidateOptions,
+  type ValidateResult,
+} from './commands/validate';
 
 // Artifact-building primitives, exposed so conformance tests and downstream
 // tooling can drive the same functions the CLI commands use — notably


### PR DESCRIPTION
## Summary

Fixes both gaps reported in #2657, found while wiring the Workspace signed-artifact pipeline (Plan 05, Task 4).

### 1. `isMainModule()` silently no-ops under pnpm symlinks
`packages/extension-cli/src/cli.ts` guarded its entrypoint with `import.meta.url === pathToFileURL(process.argv[1]).href`. When `breeze-ext` is launched through a pnpm-installed bin, `process.argv[1]` is the `node_modules/.bin` (or `.pnpm`) **symlink** while `import.meta.url` is the module's **realpath** (Node resolves symlinks when loading ESM). The comparison never matched, `isMainModule()` returned false, and the process exited `0` having parsed nothing — the worst failure shape for a signing/packing pipeline (a CI step "passes" without packing or signing anything).

Fix: resolve **both** sides to their realpath (`realpathSync(entry)` vs `realpathSync(fileURLToPath(import.meta.url))`), so the guard holds regardless of symlink indirection. A non-existent `argv[1]` throws in `realpathSync` and is treated as "not the entry point".

The issue's secondary ask — "a bin invocation that matches no command must exit non-zero" — is already satisfied once the guard runs: Commander exits `1` (`commander.help`) on no command and `1` (`commander.unknownCommand`) on an unknown one, and the runner block sets `process.exitCode = 1` on any thrown error.

### 2. `breeze-ext validate` was a stub
`runValidate` threw `not implemented yet`. It is now implemented on the **same machinery `pack` uses**, so "validate passes" implies "pack won't reject the manifest or layout":

- `safeParseExtensionManifestV1` (SDK) for **structured, per-field** manifest diagnostics (every schema issue enumerated with its dotted field path) rather than a single prettified throw.
- `collectPayload` for the layout/security gate (refuses symlinks and reserved generated members carried in from source).
- **Entry-path existence** checks (`server.entry`, and `web.entry` when web is declared) that `pack` does not perform — catching a bundle that would load-fail at the host before it is ever packed.

`validate` returns a structured `ValidateResult` (stable `code`s: `manifest_missing`, `manifest_invalid_json`, `manifest_schema`, `entry_missing`, `layout`); `runValidate` prints human or `--json` output and sets `process.exitCode` on failure — mirroring the existing `inspect` command. It remains an author-side pre-pack check and does **not** import or duplicate the host trust logic in `apps/api/src/extensions/bundleVerifier.ts`.

## Tests
- Subprocess regression: runs the real `cli.ts` through a symlink (`node --import tsx <symlink> --version`) and asserts the program actually executes — the old guard printed nothing.
- Full `validateExtension` / `runValidate` coverage: valid tree; missing / invalid-JSON / schema-invalid manifest (asserting structured field paths); missing `server.entry` and `web.entry`; symlink and reserved-member layout findings; exit codes; `--json` output; and command wiring via `createProgram` (proving it no longer throws the stub error).

`vitest run` — 116 passed (10 files). `tsc --noEmit` — clean.

Closes #2657

🤖 Generated with [Claude Code](https://claude.com/claude-code)