### PR TITLE
chore(agent): untrack compiled breeze-backup binary and gitignore it (#2594)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ e2e-tests/doc-verify/assertions.json
 
 # Go
 agent/breeze-agent
+agent/breeze-backup
 agent/breeze-watchdog
 agent/bin/
 viewer/bin/


### PR DESCRIPTION
## Summary

`agent/breeze-backup` — a 61 MB Mach-O arm64 executable — was tracked in git as a build artifact. Tracked binaries bloat clones, pollute repo-wide text searches with stale symbol strings, and drift from source.

This PR:
- `git rm --cached agent/breeze-backup` (removed from the index; the file is preserved on developers' disks — this only stops tracking it).
- Adds `agent/breeze-backup` to `.gitignore`, right beside the sibling agent build outputs `breeze-agent` and `breeze-watchdog`.

## Why this is safe (no packaging depends on the checked-in copy)

- The release workflow (`.github/workflows/release.yml`) builds `breeze-backup-<os>-<arch>` **fresh from `./cmd/breeze-backup`** for every platform.
- The macOS `.pkg` build (`agent/installer/macos/build-pkg.sh`) takes the backup binary **as an argument** (`$BACKUP_BIN`).
- The install scripts (`install-darwin.sh` / `install-linux.sh`) copy `breeze-backup` from the **install payload directory**, never the repo root.

No CI, Dockerfile, or deploy step reads the git-tracked `agent/breeze-backup`.

## Verification

- `git check-ignore agent/breeze-backup` now matches the new rule.
- Working-tree copy remains on disk after `--cached` removal (local builds unaffected).
- Source tree under `agent/cmd/breeze-backup/` is untouched.

Closes #2594

🤖 Generated with [Claude Code](https://claude.com/claude-code)