### PR TITLE
fix(agent): user-context helpers load agent.yaml directly so log shipping works (#2483)

### DIFF
--- a/agent/cmd/breeze-desktop-helper/main.go
+++ b/agent/cmd/breeze-desktop-helper/main.go
@@ -66,8 +66,13 @@ func runDesktopHelper() {
 	}
 	logging.Init("text", "info", output)
 
-	cfg, _ := config.Load("")
-	if cfg == nil {
+	// Use LoadHelperConfig, NOT Load: on macOS the desktop-helper runs as the
+	// logged-in user (Aqua LaunchAgent), and Load() unconditionally reads
+	// root-only secrets.yaml and errors there, leaving the helper with no
+	// shipper (#2483). LoadHelperConfig reads agent.yaml only.
+	cfg, err := config.LoadHelperConfig("")
+	if err != nil {
+		log.Warn("helper config load failed; helper log shipping disabled", "error", err)
 		cfg = config.Default()
 	}
 
@@ -81,10 +86,10 @@ func runDesktopHelper() {
 	// (#2323) — so its shipper reads the persisted server URL on a TTL instead
 	// of freezing the startup copy at the dead primary (#2463).
 	//
-	// Also like the user-helper, this gate is only reachable when config.Load
-	// above succeeded, which it does not in a user context (it reads root-only
-	// secrets.yaml) — see #2483. Reachable today on Windows, where the
-	// desktop-helper runs as SYSTEM.
+	// This gate is now reachable in user context too: LoadHelperConfig reads
+	// agent.yaml (world-readable) and skips root-only secrets.yaml, so the macOS
+	// user-session desktop-helper populates AgentID/ServerURL/HelperAuthToken
+	// and ships its diagnostics (#2483), as does the Windows SYSTEM helper.
 	if cfg.AgentID != "" && cfg.ServerURL != "" && cfg.HelperAuthToken != "" {
 		helperToken := secmem.NewSecureString(cfg.HelperAuthToken)
 		cfg.HelperAuthToken = ""

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -1513,9 +1513,14 @@ func runHelperProcess(name, role, context, binaryKind string) {
 	}
 	logging.Init("text", "info", output)
 
-	// Load agent config for IPC socket path and helper-scoped log shipping credentials.
-	cfg, _ := config.Load(cfgFile)
-	if cfg == nil {
+	// Load agent config for IPC socket path and helper-scoped log shipping
+	// credentials. Use LoadHelperConfig, NOT Load: this process runs as the
+	// logged-in user on the user-helper path, and Load() unconditionally reads
+	// root-only secrets.yaml and returns an error there, leaving the helper with
+	// no shipper at all (#2483). LoadHelperConfig reads agent.yaml only.
+	cfg, err := config.LoadHelperConfig(cfgFile)
+	if err != nil {
+		slog.Warn("helper config load failed; helper log shipping disabled", "error", err)
 		cfg = config.Default()
 	}
 
@@ -1534,13 +1539,11 @@ func runHelperProcess(name, role, context, binaryKind string) {
 	// world-readable precisely so the helper can read its server URL, so the
 	// provider re-reads it there on a TTL.
 	//
-	// NOTE: this whole block is currently reachable only in a SYSTEM/root-context
-	// helper. config.Load above returns an error in a user-context helper —
-	// it unconditionally reads root-only secrets.yaml — so cfg falls back to
-	// config.Default(), whose empty AgentID/ServerURL fail this gate and leave
-	// the user helper with no shipper at all. That is a separate, pre-existing
-	// bug (#2483); the provider below is what the SYSTEM-context helpers that
-	// DO ship today need.
+	// This block is reachable in BOTH user- and SYSTEM-context helpers: the
+	// LoadHelperConfig above reads agent.yaml (world-readable) and skips
+	// root-only secrets.yaml, so the AgentID/ServerURL/HelperAuthToken this gate
+	// needs are populated in a user session too (#2483). Everything the gate
+	// checks lives in agent.yaml by design (see secretKeyAllowedInAgentYAML).
 	if cfg.AgentID != "" && cfg.ServerURL != "" && cfg.HelperAuthToken != "" {
 		helperToken := secmem.NewSecureString(cfg.HelperAuthToken)
 		cfg.AuthToken = ""

--- a/agent/internal/config/helperconfig.go
+++ b/agent/internal/config/helperconfig.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadHelperConfig loads the subset of configuration a user-context helper
+// process needs, reading agent.yaml ONLY and never touching secrets.yaml.
+//
+// Why this exists (issue #2483): the full Load() unconditionally opens
+// secrets.yaml whenever it exists on disk. secrets.yaml is root/SYSTEM-only by
+// design — 0600 root-owned on Unix (permissions_unix.go), an SDDL with no Users
+// ACE on Windows (permissions_windows.go) — while the config DIRECTORY is
+// traversable (0755 / BU:FRFX), so os.Stat succeeds and the subsequent read
+// fails with EACCES/ACCESS_DENIED. Load() then returns (nil, error) in any
+// helper running as the logged-in user. Both helper entry points discarded that
+// error and fell back to config.Default(), whose empty AgentID/ServerURL
+// silently failed the log-shipper gate — so user-session helpers shipped no
+// diagnostics at all, precisely where remote-desktop / consent / capture
+// features live.
+//
+// Everything a helper needs is deliberately kept in agent.yaml, which is
+// world-readable (0644) for exactly this reason: the server URL, agent id, and
+// the helper-scoped helper_auth_token (see secretKeyAllowedInAgentYAML and the
+// permissions_unix.go comment). This function returns those layered over
+// Default(), without the global-viper mutation or secrets.yaml dependency of
+// Load(). It mirrors PersistedServerURL's partial-decode approach (PR #2477):
+// no viper singleton, no ValidateTiered fatals from the missing secrets, and
+// unrelated schema drift elsewhere in agent.yaml cannot break the helper load.
+//
+// cfgFile may be empty, in which case the default agent.yaml path is used.
+func LoadHelperConfig(cfgFile string) (*Config, error) {
+	cfg := Default()
+
+	path := cfgFile
+	if path == "" {
+		path = defaultConfigFilePath()
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	// Decode only the keys a helper consumes. Pointers distinguish "absent"
+	// (keep the Default) from "present but empty". Nothing here can pull in a
+	// secrets.yaml value. If a helper ever needs another agent.yaml field, add
+	// it here — keep the list to keys that genuinely live in agent.yaml.
+	var parsed struct {
+		AgentID          *string `yaml:"agent_id"`
+		ServerURL        *string `yaml:"server_url"`
+		HelperAuthToken  *string `yaml:"helper_auth_token"`
+		IPCSocketPath    *string `yaml:"ipc_socket_path"`
+		LogShippingLevel *string `yaml:"log_shipping_level"`
+		DesktopDebug     *bool   `yaml:"desktop_debug"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	if parsed.AgentID != nil {
+		cfg.AgentID = *parsed.AgentID
+	}
+	if parsed.ServerURL != nil {
+		cfg.ServerURL = *parsed.ServerURL
+	}
+	if parsed.HelperAuthToken != nil {
+		cfg.HelperAuthToken = *parsed.HelperAuthToken
+	}
+	if parsed.IPCSocketPath != nil {
+		cfg.IPCSocketPath = *parsed.IPCSocketPath
+	}
+	if parsed.LogShippingLevel != nil {
+		cfg.LogShippingLevel = *parsed.LogShippingLevel
+	}
+	if parsed.DesktopDebug != nil {
+		cfg.DesktopDebug = *parsed.DesktopDebug
+	}
+
+	return cfg, nil
+}

--- a/agent/internal/config/helperconfig_test.go
+++ b/agent/internal/config/helperconfig_test.go
@@ -1,0 +1,154 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeHelperAgentYAML writes an agent.yaml with the full set of helper-relevant
+// keys and returns its path.
+func writeHelperAgentYAML(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("write agent.yaml: %v", err)
+	}
+	return path
+}
+
+func TestLoadHelperConfig(t *testing.T) {
+	path := writeHelperAgentYAML(t, ""+
+		"agent_id: agent-123\n"+
+		"server_url: https://primary.example.com\n"+
+		"helper_auth_token: helper-secret\n"+
+		"ipc_socket_path: /tmp/breeze-helper.sock\n"+
+		"log_shipping_level: info\n"+
+		"desktop_debug: true\n")
+
+	cfg, err := LoadHelperConfig(path)
+	if err != nil {
+		t.Fatalf("LoadHelperConfig() error = %v", err)
+	}
+	if cfg.AgentID != "agent-123" {
+		t.Errorf("AgentID = %q, want agent-123", cfg.AgentID)
+	}
+	if cfg.ServerURL != "https://primary.example.com" {
+		t.Errorf("ServerURL = %q", cfg.ServerURL)
+	}
+	if cfg.HelperAuthToken != "helper-secret" {
+		t.Errorf("HelperAuthToken = %q, want helper-secret", cfg.HelperAuthToken)
+	}
+	if cfg.IPCSocketPath != "/tmp/breeze-helper.sock" {
+		t.Errorf("IPCSocketPath = %q", cfg.IPCSocketPath)
+	}
+	if cfg.LogShippingLevel != "info" {
+		t.Errorf("LogShippingLevel = %q, want info", cfg.LogShippingLevel)
+	}
+	if !cfg.DesktopDebug {
+		t.Errorf("DesktopDebug = false, want true")
+	}
+}
+
+// TestLoadHelperConfigKeepsDefaultsForAbsentKeys asserts absent keys leave the
+// Default() value untouched (notably LogShippingLevel, which the shipper reads).
+func TestLoadHelperConfigKeepsDefaultsForAbsentKeys(t *testing.T) {
+	path := writeHelperAgentYAML(t, ""+
+		"agent_id: agent-123\n"+
+		"server_url: https://primary.example.com\n"+
+		"helper_auth_token: helper-secret\n")
+
+	cfg, err := LoadHelperConfig(path)
+	if err != nil {
+		t.Fatalf("LoadHelperConfig() error = %v", err)
+	}
+	if want := Default().LogShippingLevel; cfg.LogShippingLevel != want {
+		t.Errorf("LogShippingLevel = %q, want default %q", cfg.LogShippingLevel, want)
+	}
+	if cfg.IPCSocketPath != "" {
+		t.Errorf("IPCSocketPath = %q, want empty", cfg.IPCSocketPath)
+	}
+	if cfg.DesktopDebug {
+		t.Errorf("DesktopDebug = true, want default false")
+	}
+}
+
+// TestLoadHelperConfigIgnoresSecretsFile is the regression test for #2483:
+// LoadHelperConfig must NOT read secrets.yaml at all. It returns the
+// helper_auth_token from agent.yaml even when a secrets.yaml sitting beside it
+// carries a different value (Load() would have merged the secrets one).
+func TestLoadHelperConfigIgnoresSecretsFile(t *testing.T) {
+	path := writeHelperAgentYAML(t, ""+
+		"agent_id: agent-123\n"+
+		"server_url: https://primary.example.com\n"+
+		"helper_auth_token: from-agent-yaml\n")
+
+	secretsPath := filepath.Join(filepath.Dir(path), "secrets.yaml")
+	if err := os.WriteFile(secretsPath, []byte("helper_auth_token: from-secrets-yaml\n"), 0600); err != nil {
+		t.Fatalf("write secrets.yaml: %v", err)
+	}
+
+	cfg, err := LoadHelperConfig(path)
+	if err != nil {
+		t.Fatalf("LoadHelperConfig() error = %v", err)
+	}
+	if cfg.HelperAuthToken != "from-agent-yaml" {
+		t.Errorf("HelperAuthToken = %q, want from-agent-yaml (secrets.yaml must be ignored)", cfg.HelperAuthToken)
+	}
+}
+
+// TestLoadHelperConfigSucceedsWithUnreadableSecretsFile reproduces the exact
+// bug: a root-only secrets.yaml the helper user cannot read. LoadHelperConfig
+// must still succeed where Load() returns an error. Skipped when running as
+// root, which bypasses filesystem permissions.
+func TestLoadHelperConfigSucceedsWithUnreadableSecretsFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses file permissions; cannot simulate EACCES")
+	}
+	path := writeHelperAgentYAML(t, ""+
+		"agent_id: agent-123\n"+
+		"server_url: https://primary.example.com\n"+
+		"helper_auth_token: helper-secret\n")
+
+	secretsPath := filepath.Join(filepath.Dir(path), "secrets.yaml")
+	if err := os.WriteFile(secretsPath, []byte("auth_token: root-only\n"), 0600); err != nil {
+		t.Fatalf("write secrets.yaml: %v", err)
+	}
+	if err := os.Chmod(secretsPath, 0000); err != nil {
+		t.Fatalf("chmod secrets.yaml: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(secretsPath, 0600) })
+
+	// Sanity check: the full Load() DOES fail on the unreadable secrets file.
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected Load() to fail on unreadable secrets.yaml (bug precondition)")
+	}
+
+	cfg, err := LoadHelperConfig(path)
+	if err != nil {
+		t.Fatalf("LoadHelperConfig() error = %v (must ignore unreadable secrets.yaml)", err)
+	}
+	if cfg.AgentID != "agent-123" || cfg.HelperAuthToken != "helper-secret" {
+		t.Errorf("cfg = %+v, want agent-123 / helper-secret from agent.yaml", cfg)
+	}
+}
+
+func TestLoadHelperConfigErrors(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		if _, err := LoadHelperConfig(filepath.Join(t.TempDir(), "nope.yaml")); err == nil {
+			t.Fatal("expected an error for a missing config file")
+		}
+	})
+
+	t.Run("malformed yaml", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "agent.yaml")
+		if err := os.WriteFile(path, []byte("agent_id: [unclosed\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadHelperConfig(path); err == nil {
+			t.Fatal("expected a parse error for malformed yaml")
+		}
+	})
+}


### PR DESCRIPTION
Closes #2483

## Problem

`config.Load()` returns `(nil, error)` in any helper running as the logged-in user, so the helper never gets a log shipper — its diagnostics never reach the API.

`Load()` unconditionally reads `secrets.yaml` when the file exists. `secrets.yaml` is root/SYSTEM-only by design (`0600` root-owned on Unix; SDDL with no Users ACE on Windows), but the config **directory** is traversable (`0755`), so `os.Stat` succeeds and the subsequent open fails with EACCES/ACCESS_DENIED. Both helper entry points discarded that error (`cfg, _ :=`) and fell back to `config.Default()`, whose empty `AgentID`/`ServerURL` fail the shipper gate — so `logging.InitShipper` was never called.

Affected spawn paths (all log-shipper-dead before this fix):

| Spawn path | Identity |
|---|---|
| Windows `--role user` (WTSQueryUserToken) | logged-in user |
| macOS desktop-helper (Aqua LaunchAgent) | logged-in user |
| Linux user-helper | logged-in user |

## Fix

Add `config.LoadHelperConfig(cfgFile)` (`agent/internal/config/helperconfig.go`) that reads **agent.yaml only** and never touches `secrets.yaml`. agent.yaml is world-readable (`0644`) by design and already holds everything a helper needs — `server_url`, `agent_id`, and the helper-scoped `helper_auth_token` (kept in agent.yaml via `secretKeyAllowedInAgentYAML`). It mirrors `PersistedServerURL()`'s partial-YAML-decode approach from #2477: no global-viper mutation, no `ValidateTiered` fatals from the absent secrets.

- `runHelperProcess` (`agentapp/main.go`) and the desktop-helper (`cmd/breeze-desktop-helper/main.go`) now call `LoadHelperConfig` instead of `Load`, and **log** a load failure instead of discarding it.
- Refreshed the now-stale comments that documented the shipper gate as unreachable in user context.

Loosening `Load()` itself to tolerate an unreadable `secrets.yaml` was rejected as riskier — it would silently degrade the root agent's own load path if permissions ever regressed.

**Out of scope (deliberate follow-up):** the issue also notes `Shipper.droppedCount` is only surfaced via heartbeat, which helpers lack, so helper-side drop counts stay write-only even once shipping works. That needs a new reporting channel and is genuinely separable; left for a follow-up rather than widening this PR.

## Tests

`agent/internal/config/helperconfig_test.go`:
- reads all helper-relevant keys from agent.yaml
- absent keys keep `Default()` values (notably `LogShippingLevel`)
- **regression:** ignores a sibling `secrets.yaml` that carries a different `helper_auth_token`
- **regression:** succeeds with an unreadable (`0000`) `secrets.yaml` where `Load()` is asserted to fail (skipped when running as root)
- error paths: missing file, malformed yaml

`go build`, `go vet`, and `go test ./internal/config/...` all pass. (`-race` unavailable in this environment — no C compiler; `LoadHelperConfig` is sequential.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)