### PR TITLE
fix(agent): close PID-reuse TOCTOU in desktop-helper stopByPID (#2531)

### DIFF
--- a/agent/internal/helper/install_darwin.go
+++ b/agent/internal/helper/install_darwin.go
@@ -133,6 +133,28 @@ func stopByPID(pid int) error {
 	return nil
 }
 
+// stopByPIDIfOurs terminates pid only if it is a Breeze helper process. It
+// verifies the image path and, if it matches, signals the process. Returns
+// (true, nil) when the helper was signalled, (false, nil) when the pid is gone
+// or is not a helper, and (false, err) when a confirmed helper could not be
+// signalled.
+//
+// Unlike Windows (#2531), POSIX has no persistent handle to pin the process
+// object across the check and the kill, so a two-syscall window technically
+// remains. It is not the reported vulnerability: POSIX allocates PIDs roughly
+// monotonically and wraps only after exhausting the whole pid range, so the
+// same number is not handed back to an unrelated process between two adjacent
+// syscalls the way Windows can recycle it immediately.
+func stopByPIDIfOurs(pid int, binaryPath string) (bool, error) {
+	if !isOurProcess(pid, binaryPath) {
+		return false, nil
+	}
+	if err := stopByPID(pid); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func spawnWithConfig(binaryPath, sessionKey, configPath string) (int, error) {
 	uid, err := strconv.ParseUint(sessionKey, 10, 32)
 	if err != nil {

--- a/agent/internal/helper/install_linux.go
+++ b/agent/internal/helper/install_linux.go
@@ -104,6 +104,28 @@ func stopByPID(pid int) error {
 	return nil
 }
 
+// stopByPIDIfOurs terminates pid only if it is a Breeze helper process. It
+// verifies the image path (via /proc/<pid>/exe) and, if it matches, signals the
+// process. Returns (true, nil) when the helper was signalled, (false, nil) when
+// the pid is gone or is not a helper, and (false, err) when a confirmed helper
+// could not be signalled.
+//
+// Unlike Windows (#2531), POSIX has no persistent handle to pin the process
+// object across the check and the kill, so a two-syscall window technically
+// remains. It is not the reported vulnerability: POSIX allocates PIDs roughly
+// monotonically and wraps only after exhausting the whole pid_max range, so the
+// same number is not handed back to an unrelated process between two adjacent
+// syscalls the way Windows can recycle it immediately.
+func stopByPIDIfOurs(pid int, binaryPath string) (bool, error) {
+	if !isOurProcess(pid, binaryPath) {
+		return false, nil
+	}
+	if err := stopByPID(pid); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func spawnWithConfig(binaryPath, sessionKey, configPath string) (int, error) {
 	uid, err := strconv.ParseUint(sessionKey, 10, 32)
 	if err != nil {

--- a/agent/internal/helper/install_windows.go
+++ b/agent/internal/helper/install_windows.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -133,19 +134,52 @@ func removeAutoStart() error {
 	return nil
 }
 
-func stopByPID(pid int) error {
+// stopByPIDIfOurs terminates pid only if it is a Breeze helper process, using a
+// SINGLE process handle for both the image-path check and the kill.
+//
+// This closes the PID-reuse TOCTOU (#2531) that existed when the caller ran
+// isOurProcess() (one OpenProcess to check the image) and then stopByPID()
+// (a second OpenProcess to terminate) as two separate syscalls on a bare PID.
+// A Windows handle pins the exact kernel process object, so once we have opened
+// the PID nothing can redirect our TerminateProcess to a different process:
+//   - if the helper exits and Windows recycles the PID AFTER our OpenProcess,
+//     our handle still refers to the original (now-dead) process, so the
+//     terminate is a harmless no-op on the process we verified — never the
+//     unrelated process that inherited the number;
+//   - if the PID was already recycled BEFORE our OpenProcess, the image-path
+//     check on this handle fails and we terminate nothing.
+//
+// Returns (true, nil) when the process was ours and was terminated, (false, nil)
+// when the pid is gone or is not a helper, and (false, err) when a confirmed
+// helper could not be terminated.
+func stopByPIDIfOurs(pid int, binaryPath string) (bool, error) {
 	if pid <= 0 {
-		return fmt.Errorf("invalid pid %d", pid)
+		return false, nil
 	}
-	handle, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, uint32(pid))
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_TERMINATE,
+		false, uint32(pid),
+	)
 	if err != nil {
-		return fmt.Errorf("OpenProcess(%d): %w", pid, err)
+		// Process is gone or inaccessible — nothing we can (or should) kill.
+		return false, nil
 	}
 	defer windows.CloseHandle(handle)
-	if err := windows.TerminateProcess(handle, 0); err != nil {
-		return fmt.Errorf("TerminateProcess(%d): %w", pid, err)
+
+	buf := make([]uint16, windows.MAX_PATH)
+	size := uint32(len(buf))
+	if err := windows.QueryFullProcessImageName(handle, 0, &buf[0], &size); err != nil {
+		// Can't confirm identity on this handle — refuse to terminate.
+		return false, nil
 	}
-	return nil
+	exePath := windows.UTF16ToString(buf[:size])
+	if !strings.EqualFold(filepath.Clean(exePath), filepath.Clean(binaryPath)) {
+		return false, nil
+	}
+	if err := windows.TerminateProcess(handle, 0); err != nil {
+		return false, fmt.Errorf("TerminateProcess(%d): %w", pid, err)
+	}
+	return true, nil
 }
 
 func spawnWithConfig(binaryPath, sessionKey, configPath string) (int, error) {

--- a/agent/internal/helper/manager.go
+++ b/agent/internal/helper/manager.go
@@ -88,7 +88,12 @@ type Manager struct {
 	sessionEnumerator SessionEnumerator
 	sessions          map[string]*sessionState
 	isOurProcessFunc  func(pid int, binaryPath string) bool
-	stopByPIDFunc     func(pid int) error
+	// stopIfOursFunc terminates a helper by PID only after confirming, on the
+	// SAME OS process handle it kills with, that the PID is a Breeze helper.
+	// This is the single-handle check-and-terminate that closes the PID-reuse
+	// TOCTOU (#2531) — never split the identity check and the kill back into
+	// two separate isOurProcess()+stopByPID() opens.
+	stopIfOursFunc func(pid int, binaryPath string) (bool, error)
 
 	// downloadFunc fetches and INTEGRITY-VERIFIES the helper package for the
 	// given version, returning the path to a verified temp file. In production
@@ -116,7 +121,7 @@ func New(ctx context.Context, serverURL string, authToken *secmem.SecureString, 
 		sessionEnumerator: NewPlatformEnumerator(),
 		sessions:          make(map[string]*sessionState),
 		isOurProcessFunc:  isOurProcess,
-		stopByPIDFunc:     stopByPID,
+		stopIfOursFunc:    stopByPIDIfOurs,
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -447,9 +452,7 @@ func (m *Manager) ensureRunningSession(state *sessionState) error {
 	// stale PID, so we kept spawning new ones). This prevents accumulating
 	// hundreds of orphaned helper processes.
 	if state.spawnedPID > 0 && state.spawnedPID != state.pid {
-		if m.isOurProcessFunc(state.spawnedPID, m.binaryPath) {
-			_ = m.stopByPIDFunc(state.spawnedPID)
-		}
+		_, _ = m.stopIfOursFunc(state.spawnedPID, m.binaryPath)
 	}
 	var pid int
 	var err error
@@ -500,11 +503,14 @@ func semverAtLeast(version string, target [3]int) bool {
 
 func (m *Manager) ensureStoppedSession(state *sessionState) error {
 	// Kill by spawned PID (authoritative) and status-file PID if different.
+	// stopIfOursFunc verifies helper identity on the same handle it terminates
+	// with, so PID reuse can't redirect the kill (#2531).
 	for _, pid := range []int{state.spawnedPID, state.pid} {
-		if pid > 0 && m.isOurProcessFunc(pid, m.binaryPath) {
-			if err := m.stopByPIDFunc(pid); err != nil {
-				return err
-			}
+		if pid <= 0 {
+			continue
+		}
+		if _, err := m.stopIfOursFunc(pid, m.binaryPath); err != nil {
+			return err
 		}
 	}
 	state.spawnedPID = 0

--- a/agent/internal/helper/manager_test.go
+++ b/agent/internal/helper/manager_test.go
@@ -42,12 +42,12 @@ func TestApplyDisabledStopsRunningHelperAfterRestart(t *testing.T) {
 	mgr.sessionEnumerator = &mockEnumerator{
 		sessions: []SessionInfo{{Key: "501", Username: "alice", UID: 501}},
 	}
-	mgr.stopByPIDFunc = func(pid int) error {
+	mgr.stopIfOursFunc = func(pid int, binaryPath string) (bool, error) {
 		stopped++
 		if pid != 4242 {
-			t.Fatalf("stopByPID called with pid %d, want 4242", pid)
+			t.Fatalf("stopIfOurs called with pid %d, want 4242", pid)
 		}
-		return nil
+		return true, nil
 	}
 	mgr.isOurProcessFunc = func(pid int, binaryPath string) bool { return pid == 4242 }
 	mgr.sessions["501"] = newSessionState("501", tmpDir)
@@ -92,7 +92,7 @@ func TestApplyRestartsHelperOnConfigChangeWhenIdle(t *testing.T) {
 		sessions: []SessionInfo{{Key: "501", Username: "alice", UID: 501}},
 	}
 	mgr.isOurProcessFunc = func(pid int, binaryPath string) bool { return pid == 4242 }
-	mgr.stopByPIDFunc = func(pid int) error { stopped++; return nil }
+	mgr.stopIfOursFunc = func(pid int, binaryPath string) (bool, error) { stopped++; return true, nil }
 	mgr.spawnFunc = func(sessionKey, binaryPath string, args ...string) (int, error) {
 		spawned++
 		_ = os.WriteFile(statusPath, []byte("version: 0.14.0\npid: 9001\n"), 0644)
@@ -152,7 +152,7 @@ func TestApplyDefersRestartWhileChatActive(t *testing.T) {
 		sessions: []SessionInfo{{Key: "501", Username: "alice", UID: 501}},
 	}
 	mgr.isOurProcessFunc = func(pid int, binaryPath string) bool { return pid == os.Getpid() }
-	mgr.stopByPIDFunc = func(pid int) error { stopped++; return nil }
+	mgr.stopIfOursFunc = func(pid int, binaryPath string) (bool, error) { stopped++; return true, nil }
 	mgr.spawnFunc = func(sessionKey, binaryPath string, args ...string) (int, error) {
 		spawned++
 		return 9001, nil

--- a/agent/internal/helper/stop_if_ours_posix_test.go
+++ b/agent/internal/helper/stop_if_ours_posix_test.go
@@ -1,0 +1,73 @@
+//go:build linux || darwin
+
+package helper
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// alive reports whether pid is a live process (signal 0 probes existence
+// without delivering a signal).
+func alive(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
+}
+
+// TestStopByPIDIfOurs is the regression guard for #2531: the terminate must be
+// gated on an image-path match, so a PID that is NOT our helper is never killed.
+// It exercises the identity check against a real, self-owned child process.
+func TestStopByPIDIfOurs(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start helper child process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	// The canonical image path for this pid, as the platform reports it. Using
+	// it as binaryPath makes the match self-consistent on every OS.
+	exePath, err := processExePath(pid)
+	if err != nil {
+		t.Skipf("processExePath(%d) unavailable on this platform/runner: %v", pid, err)
+	}
+
+	// 1. Image path does NOT match -> refuse to terminate (the PID-reuse safety
+	//    property: we only ever kill a process we positively identified).
+	killed, err := stopByPIDIfOurs(pid, "/nonexistent/breeze-helper")
+	if err != nil {
+		t.Fatalf("stopByPIDIfOurs(mismatch) returned error: %v", err)
+	}
+	if killed {
+		t.Fatal("stopByPIDIfOurs killed a process whose image path did not match")
+	}
+	if !alive(pid) {
+		t.Fatal("child was terminated despite an image-path mismatch")
+	}
+
+	// 2. Image path matches -> terminate.
+	killed, err = stopByPIDIfOurs(pid, exePath)
+	if err != nil {
+		t.Fatalf("stopByPIDIfOurs(match) returned error: %v", err)
+	}
+	if !killed {
+		t.Fatal("stopByPIDIfOurs did not terminate a matching process")
+	}
+	_, _ = cmd.Process.Wait() // reap
+	deadline := time.Now().Add(2 * time.Second)
+	for alive(pid) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if alive(pid) {
+		t.Fatal("child still alive after stopByPIDIfOurs reported a kill")
+	}
+
+	// 3. A non-positive PID is a harmless no-op, never an error.
+	if killed, err := stopByPIDIfOurs(0, exePath); killed || err != nil {
+		t.Fatalf("stopByPIDIfOurs(0) = (%v, %v), want (false, nil)", killed, err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2531.

The desktop-helper manager (`internal/helper` — the Tauri tray-app helper) terminated helpers via a **check-then-kill across two separate bare-PID `OpenProcess` calls**: the caller ran `isOurProcess(pid)` (OpenProcess #1, image-path check) and then `stopByPID(pid)` (OpenProcess #2, terminate). If the helper exited and Windows recycled that exact PID onto an unrelated process between the two opens, the check passed on the old process but the terminate landed on the new one.

## Fix

Both check-then-kill sites in `manager.go` (`ensureRunningSession` lingering-helper cleanup, and `ensureStoppedSession`) now go through a single **`stopByPIDIfOurs(pid, binaryPath)`**:

- **Windows** (`install_windows.go`): open the PID **once** with `PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE`, verify the image path via `QueryFullProcessImageName` on that handle, and `TerminateProcess` on the **same** handle. A Windows handle pins the exact kernel process object, so PID reuse can never redirect the kill; if the PID was already recycled before we opened it, the image check fails and nothing is terminated. This matches the handle-retention standard already used by the session-broker spawner (`internal/sessionbroker/spawner_windows.go`).
- **POSIX** (`install_linux.go` / `install_darwin.go`): keeps verify-then-signal via the same helper. POSIX PID allocation is roughly monotonic and does not hand the same number to an unrelated process between two adjacent syscalls, so the reported vulnerability is Windows-specific — documented inline.

`isOurProcessFunc` is retained for the pure **liveness** checks (deciding whether to respawn), which are not kills and have no TOCTOU.

Scope note: kept intentionally narrow to the `stopByPID` TOCTOU; does not touch the separate scheduled-helper duplication concern (#2530).

## Testing

- New `TestStopByPIDIfOurs` (`stop_if_ours_posix_test.go`, `linux || darwin`) starts a real self-owned child and asserts a non-matching image path is **never** killed, a matching path is, and `pid <= 0` is a harmless no-op.
- `go build` for `GOOS=windows`, `darwin`, and `linux`; `go vet`; `gofmt`; full `internal/helper` package suite — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)