### PR TITLE
fix(agent): resolve helper + watchdog updater ServerURL at call time (#2478)

### DIFF
--- a/agent/cmd/breeze-watchdog/failover_dispatch_test.go
+++ b/agent/cmd/breeze-watchdog/failover_dispatch_test.go
@@ -88,7 +88,7 @@ func TestProcessInitialFailoverHeartbeatResponse_ExecutesCommandsAndProcessesUpg
 	}
 
 	var ran []string
-	processInitialFailoverHeartbeatResponse(resp, wd, journal, cfg, tokens, recovery, func(cmd watchdog.FailoverCommand) {
+	processInitialFailoverHeartbeatResponse(resp, wd, journal, func() string { return cfg.ServerURL }, cfg, tokens, recovery, func(cmd watchdog.FailoverCommand) {
 		ran = append(ran, cmd.ID)
 	})
 

--- a/agent/cmd/breeze-watchdog/main.go
+++ b/agent/cmd/breeze-watchdog/main.go
@@ -936,13 +936,23 @@ func processHeartbeatResponse(
 		journal.Log(watchdog.LevelInfo, "failover.upgrade_agent", map[string]any{
 			"version": resp.UpgradeTo,
 		})
-		doUpdateAgent(resp.UpgradeTo, serverURL, cfg, tokens, journal)
+		if err := doUpdateAgent(resp.UpgradeTo, serverURL, cfg, tokens, journal); err != nil {
+			journal.Log(watchdog.LevelError, "failover.upgrade_agent_failed", map[string]any{
+				"version": resp.UpgradeTo,
+				"error":   err.Error(),
+			})
+		}
 	}
 	if resp.WatchdogUpgradeTo != "" {
 		journal.Log(watchdog.LevelInfo, "failover.upgrade_watchdog", map[string]any{
 			"version": resp.WatchdogUpgradeTo,
 		})
-		doUpdateWatchdog(resp.WatchdogUpgradeTo, serverURL, cfg, tokens, journal)
+		if err := doUpdateWatchdog(resp.WatchdogUpgradeTo, serverURL, cfg, tokens, journal); err != nil {
+			journal.Log(watchdog.LevelError, "failover.upgrade_watchdog_failed", map[string]any{
+				"version": resp.WatchdogUpgradeTo,
+				"error":   err.Error(),
+			})
+		}
 	}
 	return resp.Commands
 }

--- a/agent/cmd/breeze-watchdog/main.go
+++ b/agent/cmd/breeze-watchdog/main.go
@@ -842,7 +842,7 @@ func handleFailoverPoll(
 		return
 	}
 	*failoverFailures = 0
-	heartbeatCmds := processHeartbeatResponse(resp, wd, journal, cfg, tokens, recovery)
+	heartbeatCmds := processHeartbeatResponse(resp, wd, journal, fc.BaseURL, cfg, tokens, recovery)
 
 	// Commands targeted at the watchdog are claimed by the heartbeat (the
 	// server marks them 'sent' and returns them inline), so the poll below
@@ -877,7 +877,7 @@ func handleInitialFailoverHeartbeatResponse(
 	tokens *tokenHolder,
 	recovery *watchdog.RecoveryManager,
 ) {
-	processInitialFailoverHeartbeatResponse(resp, wd, journal, cfg, tokens, recovery, func(cmd watchdog.FailoverCommand) {
+	processInitialFailoverHeartbeatResponse(resp, wd, journal, fc.BaseURL, cfg, tokens, recovery, func(cmd watchdog.FailoverCommand) {
 		handleFailoverCommand(ctx, fc, cmd, wd, journal, cfg, tokens, recovery)
 	})
 }
@@ -886,12 +886,13 @@ func processInitialFailoverHeartbeatResponse(
 	resp *watchdog.HeartbeatResponse,
 	wd *watchdog.Watchdog,
 	journal *watchdog.Journal,
+	serverURL func() string,
 	cfg *config.Config,
 	tokens *tokenHolder,
 	recovery *watchdog.RecoveryManager,
 	run func(watchdog.FailoverCommand),
 ) {
-	heartbeatCmds := processHeartbeatResponse(resp, wd, journal, cfg, tokens, recovery)
+	heartbeatCmds := processHeartbeatResponse(resp, wd, journal, serverURL, cfg, tokens, recovery)
 	executeFailoverCommands(heartbeatCmds, nil, run)
 }
 
@@ -923,6 +924,7 @@ func processHeartbeatResponse(
 	resp *watchdog.HeartbeatResponse,
 	wd *watchdog.Watchdog,
 	journal *watchdog.Journal,
+	serverURL func() string,
 	cfg *config.Config,
 	tokens *tokenHolder,
 	recovery *watchdog.RecoveryManager,
@@ -934,13 +936,13 @@ func processHeartbeatResponse(
 		journal.Log(watchdog.LevelInfo, "failover.upgrade_agent", map[string]any{
 			"version": resp.UpgradeTo,
 		})
-		doUpdateAgent(resp.UpgradeTo, cfg, tokens, journal)
+		doUpdateAgent(resp.UpgradeTo, serverURL, cfg, tokens, journal)
 	}
 	if resp.WatchdogUpgradeTo != "" {
 		journal.Log(watchdog.LevelInfo, "failover.upgrade_watchdog", map[string]any{
 			"version": resp.WatchdogUpgradeTo,
 		})
-		doUpdateWatchdog(resp.WatchdogUpgradeTo, cfg, tokens, journal)
+		doUpdateWatchdog(resp.WatchdogUpgradeTo, serverURL, cfg, tokens, journal)
 	}
 	return resp.Commands
 }
@@ -1041,7 +1043,7 @@ func handleFailoverCommand(
 			resultStatus = "failed"
 			errMsg = "missing version in payload"
 		} else {
-			err := doUpdateAgent(targetVersion, cfg, tokens, journal)
+			err := doUpdateAgent(targetVersion, fc.BaseURL, cfg, tokens, journal)
 			if err != nil {
 				resultStatus = "failed"
 				errMsg = err.Error()
@@ -1057,7 +1059,7 @@ func handleFailoverCommand(
 			resultStatus = "failed"
 			errMsg = "missing version in payload"
 		} else {
-			err := doUpdateWatchdog(targetVersion, cfg, tokens, journal)
+			err := doUpdateWatchdog(targetVersion, fc.BaseURL, cfg, tokens, journal)
 			if err != nil {
 				resultStatus = "failed"
 				errMsg = err.Error()
@@ -1080,15 +1082,20 @@ func handleFailoverCommand(
 	}
 }
 
-// doUpdateAgent creates an updater and downloads the target version for the agent binary.
-func doUpdateAgent(targetVersion string, cfg *config.Config, tokens *tokenHolder, journal *watchdog.Journal) error {
+// doUpdateAgent creates an updater and downloads the target version for the
+// agent binary. serverURL is a provider (func() string) resolved at download
+// time — during a failover the watchdog's FailoverClient retargets itself to
+// the promoted backup (SetBaseURL), and passing c.BaseURL here means binary
+// downloads follow that promotion instead of pinning the dead primary captured
+// in cfg at startup (#2478).
+func doUpdateAgent(targetVersion string, serverURL func() string, cfg *config.Config, tokens *tokenHolder, journal *watchdog.Journal) error {
 	tok := tokens.Get()
 	if tok == nil {
 		return fmt.Errorf("no auth token available")
 	}
 	binaryPath := agentBinaryPath()
 	u := updater.New(&updater.Config{
-		ServerURL:             cfg.ServerURL,
+		ServerURL:             serverURL,
 		AuthToken:             tok,
 		CurrentVersion:        "", // Not tracking agent version from watchdog.
 		BinaryPath:            binaryPath,
@@ -1109,7 +1116,10 @@ func doUpdateAgent(targetVersion string, cfg *config.Config, tokens *tokenHolder
 }
 
 // doUpdateWatchdog updates the watchdog binary and restarts the service.
-func doUpdateWatchdog(targetVersion string, cfg *config.Config, tokens *tokenHolder, journal *watchdog.Journal) error {
+// serverURL is a provider resolved at download time so a self-update follows
+// the FailoverClient's backup-server-URL promotion during a failover rather
+// than pinning the startup primary (#2478).
+func doUpdateWatchdog(targetVersion string, serverURL func() string, cfg *config.Config, tokens *tokenHolder, journal *watchdog.Journal) error {
 	tok := tokens.Get()
 	if tok == nil {
 		return fmt.Errorf("no auth token available")
@@ -1119,7 +1129,7 @@ func doUpdateWatchdog(targetVersion string, cfg *config.Config, tokens *tokenHol
 		return fmt.Errorf("failed to determine executable path: %w", err)
 	}
 	u := updater.New(&updater.Config{
-		ServerURL:             cfg.ServerURL,
+		ServerURL:             serverURL,
 		AuthToken:             tok,
 		CurrentVersion:        version,
 		Component:             "watchdog",

--- a/agent/cmd/breeze-watchdog/update_failover_url_test.go
+++ b/agent/cmd/breeze-watchdog/update_failover_url_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/watchdog"
+)
+
+// TestDoUpdateWatchdogFollowsFailoverBaseURLPromotion is the #2478 regression
+// guard for the watchdog binary updater. doUpdateWatchdog (and its identically
+// wired sibling doUpdateAgent) must resolve the control-plane URL from the live
+// provider — the FailoverClient's BaseURL — at download time, NOT from the
+// cfg.ServerURL copy captured at startup. Before the fix the updater built
+// updater.Config{ServerURL: cfg.ServerURL} and therefore kept downloading from
+// the dead primary even after the FailoverClient had retargeted itself to the
+// promoted backup via SetBaseURL during a failover window.
+//
+// doUpdateWatchdog is used (rather than doUpdateAgent) because it derives its
+// BinaryPath from os.Executable() — the test binary, in a writable temp dir — so
+// the updater's write-preflight passes and the download actually routes over
+// HTTP where the two servers below can observe which origin was contacted.
+// doUpdateAgent shares the exact same serverURL wiring, so this proves the class.
+func TestDoUpdateWatchdogFollowsFailoverBaseURLPromotion(t *testing.T) {
+	// deadPrimary stands in for the failed primary captured in cfg at startup.
+	// A hit here after promotion is the bug the fix removes.
+	deadHit := false
+	deadPrimary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deadHit = true
+		http.Error(w, "dead primary must not be contacted", http.StatusGone)
+	}))
+	defer deadPrimary.Close()
+
+	// promotedBackup is what the FailoverClient was retargeted to. It returns a
+	// well-formed-but-untrusted download info body so the updater proceeds past
+	// the request into manifest verification (which fails closed — fine; we only
+	// assert which origin received the download request, not update success).
+	promotedHit := false
+	promotedBackup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/agent-versions/") && strings.Contains(r.URL.Path, "/download") {
+			promotedHit = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"url":"` + r.URL.Scheme + `","checksum":"x","manifest":"{}","manifestSignature":"AAAA"}`))
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer promotedBackup.Close()
+
+	journal, err := watchdog.NewJournal(t.TempDir(), 1, 1)
+	if err != nil {
+		t.Fatalf("new journal: %v", err)
+	}
+	defer journal.Close()
+
+	// cfg pins the dead primary — proving doUpdateWatchdog does not read
+	// cfg.ServerURL for the download origin.
+	cfg := &config.Config{AgentID: "agent-1", ServerURL: deadPrimary.URL}
+	tokens := &tokenHolder{}
+	tokens.Replace("tok")
+
+	// The FailoverClient starts on the dead primary, then is promoted to the
+	// backup — exactly what noteFailoverHeartbeatFailure -> SetBaseURL does.
+	fc := watchdog.NewFailoverClient(deadPrimary.URL, "agent-1", "tok", nil)
+	fc.SetBaseURL(promotedBackup.URL)
+
+	// Expected to fail (untrusted manifest); we assert routing, not success. The
+	// download failure also means restartWatchdogService() is never reached.
+	_ = doUpdateWatchdog("2.1.0", fc.BaseURL, cfg, tokens, journal)
+
+	if deadHit {
+		t.Fatal("doUpdateWatchdog contacted the dead primary (cfg.ServerURL) after failover promotion (#2478)")
+	}
+	if !promotedHit {
+		t.Fatal("doUpdateWatchdog did not download from the promoted backup (fc.BaseURL)")
+	}
+}

--- a/agent/cmd/breeze-watchdog/update_failover_url_test.go
+++ b/agent/cmd/breeze-watchdog/update_failover_url_test.go
@@ -54,7 +54,7 @@ func TestDoUpdateWatchdogFollowsFailoverBaseURLPromotion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new journal: %v", err)
 	}
-	defer journal.Close()
+	defer func() { _ = journal.Close() }()
 
 	// cfg pins the dead primary — proving doUpdateWatchdog does not read
 	// cfg.ServerURL for the download origin.

--- a/agent/internal/heartbeat/handlers_devupdate.go
+++ b/agent/internal/heartbeat/handlers_devupdate.go
@@ -108,7 +108,7 @@ func handleDevUpdateUserHelper(h *Heartbeat, start time.Time, downloadURL, check
 	}
 
 	updaterCfg := &updater.Config{
-		ServerURL:             h.serverURL(),
+		ServerURL:             h.serverURL,
 		AuthToken:             h.secureToken,
 		CurrentVersion:        h.agentVersion,
 		PinnedManifestPubKeys: h.config.PinnedManifestPubKeys,
@@ -291,7 +291,7 @@ func handleDevUpdateAgent(h *Heartbeat, start time.Time, downloadURL, checksum, 
 	backupPath := filepath.Join(backupDir, "breeze-agent.backup")
 
 	updaterCfg := &updater.Config{
-		ServerURL:             h.serverURL(),
+		ServerURL:             h.serverURL,
 		AuthToken:             h.secureToken,
 		CurrentVersion:        h.agentVersion,
 		BinaryPath:            binaryPath,
@@ -330,7 +330,7 @@ func handleDevUpdateDesktopHelper(h *Heartbeat, start time.Time, downloadURL, ch
 	}
 
 	updaterCfg := &updater.Config{
-		ServerURL:             h.serverURL(),
+		ServerURL:             h.serverURL,
 		AuthToken:             h.secureToken,
 		CurrentVersion:        h.agentVersion,
 		PinnedManifestPubKeys: h.config.PinnedManifestPubKeys,

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -544,7 +544,7 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 	go func() { <-h.stopChan; helperCancel() }()
 
 	if runtime.GOOS == "windows" && cfg.IsService {
-		h.helperMgr = helper.New(helperCtx, cfg.ServerURL, secToken, cfg.AgentID,
+		h.helperMgr = helper.New(helperCtx, h.serverURL, secToken, cfg.AgentID,
 			helper.WithSessionEnumerator(helper.NewPlatformEnumerator()),
 			helper.WithAgentVersion(version),
 			helper.WithManifestKeys(cfg.PinnedManifestPubKeys),
@@ -572,7 +572,7 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 		// (the needsBroker block below), so a broker-backed headless spawn arm here
 		// would always be dead code; the user-role IPC spawn path is wired via the
 		// session broker after it exists.
-		h.helperMgr = helper.New(helperCtx, cfg.ServerURL, secToken, cfg.AgentID,
+		h.helperMgr = helper.New(helperCtx, h.serverURL, secToken, cfg.AgentID,
 			helper.WithSessionEnumerator(helper.NewPlatformEnumerator()),
 			helper.WithAgentVersion(version),
 			helper.WithManifestKeys(cfg.PinnedManifestPubKeys),
@@ -4778,7 +4778,7 @@ const watchdogUpgradeRetryCooldown = 30 * time.Minute
 // download lives in one place.
 func (h *Heartbeat) downloadWatchdogBinary(targetVersion string) (string, error) {
 	u := updater.New(&updater.Config{
-		ServerURL:             h.serverURL(),
+		ServerURL:             h.serverURL,
 		AuthToken:             h.secureToken,
 		CurrentVersion:        h.agentVersion,
 		Component:             "watchdog",
@@ -4848,7 +4848,7 @@ func (h *Heartbeat) prefetchUserHelper(targetVersion, binaryPath string) *update
 	download := h.userHelperDownloader
 	if download == nil {
 		helperCfg := &updater.Config{
-			ServerURL:             h.serverURL(),
+			ServerURL:             h.serverURL,
 			AuthToken:             h.secureToken,
 			CurrentVersion:        h.agentVersion,
 			Component:             "user-helper",
@@ -4941,7 +4941,7 @@ func (h *Heartbeat) reconcileUserHelper(binaryPath string) {
 	download := h.userHelperDownloader
 	if download == nil {
 		helperCfg := &updater.Config{
-			ServerURL:             h.serverURL(),
+			ServerURL:             h.serverURL,
 			AuthToken:             h.secureToken,
 			CurrentVersion:        h.agentVersion,
 			Component:             "user-helper",
@@ -5064,7 +5064,7 @@ func (h *Heartbeat) doUpgrade(targetVersion string) {
 	backupPath := filepath.Join(backupDir, "breeze-agent.backup")
 
 	updaterCfg := &updater.Config{
-		ServerURL:             h.serverURL(),
+		ServerURL:             h.serverURL,
 		AuthToken:             h.secureToken,
 		CurrentVersion:        h.agentVersion,
 		BinaryPath:            binaryPath,

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -544,7 +544,7 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 	go func() { <-h.stopChan; helperCancel() }()
 
 	if runtime.GOOS == "windows" && cfg.IsService {
-		h.helperMgr = helper.New(helperCtx, h.serverURL, secToken, cfg.AgentID,
+		h.helperMgr = helper.New(helperCtx, h.ServerURL, secToken, cfg.AgentID,
 			helper.WithSessionEnumerator(helper.NewPlatformEnumerator()),
 			helper.WithAgentVersion(version),
 			helper.WithManifestKeys(cfg.PinnedManifestPubKeys),
@@ -572,7 +572,7 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 		// (the needsBroker block below), so a broker-backed headless spawn arm here
 		// would always be dead code; the user-role IPC spawn path is wired via the
 		// session broker after it exists.
-		h.helperMgr = helper.New(helperCtx, h.serverURL, secToken, cfg.AgentID,
+		h.helperMgr = helper.New(helperCtx, h.ServerURL, secToken, cfg.AgentID,
 			helper.WithSessionEnumerator(helper.NewPlatformEnumerator()),
 			helper.WithAgentVersion(version),
 			helper.WithManifestKeys(cfg.PinnedManifestPubKeys),

--- a/agent/internal/helper/download.go
+++ b/agent/internal/helper/download.go
@@ -20,7 +20,12 @@ import (
 // which follows redirects, no checksum/signature) lacked — and is the reason a
 // poisoned release asset, CDN edge, or TLS/DNS MITM toward github.com can no
 // longer yield SYSTEM/root RCE via the helper install path.
-func defaultHelperDownloader(serverURL string, authToken *secmem.SecureString, agentVersion string, manifestKeys []string) func(version string) (string, error) {
+// serverURL is a provider (func() string), not a plain string, so the returned
+// downloader re-resolves the control-plane base URL on every call and follows
+// the heartbeat's backup-server-URL promotion (#2323) after a failover — rather
+// than baking the (possibly dead) primary into the closure at construction
+// (#2478).
+func defaultHelperDownloader(serverURL func() string, authToken *secmem.SecureString, agentVersion string, manifestKeys []string) func(version string) (string, error) {
 	return func(version string) (string, error) {
 		cfg := &updater.Config{
 			ServerURL:             serverURL,

--- a/agent/internal/helper/download_test.go
+++ b/agent/internal/helper/download_test.go
@@ -37,7 +37,7 @@ func TestDefaultHelperDownloaderRejectsOffOriginRedirect(t *testing.T) {
 	}))
 	defer control.Close()
 
-	dl := defaultHelperDownloader(control.URL, secmem.NewSecureString("tok"), "1.2.3", nil)
+	dl := defaultHelperDownloader(func() string { return control.URL }, secmem.NewSecureString("tok"), "1.2.3", nil)
 	path, err := dl("1.2.3")
 	if err == nil {
 		if path != "" {
@@ -69,10 +69,54 @@ func TestDefaultHelperDownloaderUsesHelperComponent(t *testing.T) {
 	}))
 	defer control.Close()
 
-	dl := defaultHelperDownloader(control.URL, secmem.NewSecureString("tok"), "9.9.9", nil)
+	dl := defaultHelperDownloader(func() string { return control.URL }, secmem.NewSecureString("tok"), "9.9.9", nil)
 	_, _ = dl("9.9.9") // error expected (untrusted manifest); we only inspect the request
 	if gotComponent != "helper" {
 		t.Fatalf("verified helper downloader queried component=%q, want %q", gotComponent, "helper")
+	}
+}
+
+// TestDefaultHelperDownloaderResolvesServerURLAtCallTime is the #2478 regression
+// guard: the downloader must read the serverURL provider on every call, so a
+// backup-server-URL promotion (#2323) that happens AFTER the manager is
+// constructed is honored. Before the fix the URL was a plain string baked into
+// the closure at construction, so the helper kept fetching from the dead primary
+// for the rest of the process lifetime after a failover.
+func TestDefaultHelperDownloaderResolvesServerURLAtCallTime(t *testing.T) {
+	// deadPrimary is the URL captured when the downloader is built. A hit here
+	// after promotion is the bug.
+	deadHit := false
+	deadPrimary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deadHit = true
+		http.Error(w, "dead primary must not be contacted", http.StatusGone)
+	}))
+	defer deadPrimary.Close()
+
+	promotedHit := false
+	promotedBackup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/download") {
+			promotedHit = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"url":"` + r.URL.Scheme + `","checksum":"x","manifest":"{}","manifestSignature":"AAAA"}`))
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer promotedBackup.Close()
+
+	// The provider starts on the dead primary, then is promoted to the backup
+	// AFTER the downloader closure is built — exactly the failover ordering.
+	current := deadPrimary.URL
+	dl := defaultHelperDownloader(func() string { return current }, secmem.NewSecureString("tok"), "1.2.3", nil)
+	current = promotedBackup.URL
+
+	_, _ = dl("1.2.3") // error expected (untrusted manifest); we assert routing
+
+	if deadHit {
+		t.Fatal("helper downloader contacted the dead primary after promotion — URL was captured at construction (#2478)")
+	}
+	if !promotedHit {
+		t.Fatal("helper downloader did not follow the promoted backup URL")
 	}
 }
 

--- a/agent/internal/helper/manager.go
+++ b/agent/internal/helper/manager.go
@@ -77,10 +77,15 @@ func WithManifestKeys(keys []string) Option {
 
 // Manager handles helper binary lifecycle: install/update plus per-session runtime state.
 type Manager struct {
-	mu                sync.Mutex
-	binaryPath        string
-	baseDir           string
-	serverURL         string
+	mu         sync.Mutex
+	binaryPath string
+	baseDir    string
+	// serverURL resolves the control-plane base URL. It is a provider
+	// (func() string) rather than a plain string so the verified downloader
+	// re-resolves it at call time and follows the heartbeat's backup-server-URL
+	// promotion (#2323) after a failover, instead of pinning the dead primary
+	// captured at construction (#2478).
+	serverURL         func() string
 	authToken         *secmem.SecureString
 	agentID           string
 	ctx               context.Context
@@ -104,8 +109,10 @@ type Manager struct {
 	abandonedVersion     string // version we gave up updating to
 }
 
-// New creates a new helper Manager.
-func New(ctx context.Context, serverURL string, authToken *secmem.SecureString, agentID string, opts ...Option) *Manager {
+// New creates a new helper Manager. serverURL is a provider (func() string) so
+// the verified package downloader follows backup-server-URL promotion after a
+// failover (#2478) — see the serverURL field doc.
+func New(ctx context.Context, serverURL func() string, authToken *secmem.SecureString, agentID string, opts ...Option) *Manager {
 	m := &Manager{
 		ctx:               ctx,
 		binaryPath:        defaultBinaryPath(),
@@ -128,6 +135,16 @@ func New(ctx context.Context, serverURL string, authToken *secmem.SecureString, 
 		m.downloadFunc = defaultHelperDownloader(m.serverURL, m.authToken, m.agentVersion, m.manifestKeys)
 	}
 	return m
+}
+
+// resolveServerURL resolves the control-plane base URL from the serverURL
+// provider. Nil-safe so a directly-constructed Manager (tests) without a
+// provider logs "" rather than panicking.
+func (m *Manager) resolveServerURL() string {
+	if m.serverURL == nil {
+		return ""
+	}
+	return m.serverURL()
 }
 
 func defaultBinaryPath() string {
@@ -561,7 +578,7 @@ func (m *Manager) downloadAndInstall(version string) error {
 		return fmt.Errorf("cannot download helper: verified downloader not configured")
 	}
 
-	log.Info("downloading helper package (verified)", "version", version, "server", m.serverURL)
+	log.Info("downloading helper package (verified)", "version", version, "server", m.resolveServerURL())
 
 	verifiedPath, err := m.downloadFunc(version)
 	if err != nil {

--- a/agent/internal/helper/manager_install_security_test.go
+++ b/agent/internal/helper/manager_install_security_test.go
@@ -31,7 +31,7 @@ func withInstallRecorder(t *testing.T) *installRecorder {
 
 func newInstallTestManager(t *testing.T, tmpDir string) *Manager {
 	t.Helper()
-	mgr := New(context.Background(), "https://control.example.test", secmem.NewSecureString("tok"), "agent-1")
+	mgr := New(context.Background(), func() string { return "https://control.example.test" }, secmem.NewSecureString("tok"), "agent-1")
 	mgr.baseDir = tmpDir
 	mgr.binaryPath = filepath.Join(tmpDir, "missing-helper") // isInstalled() == false
 	mgr.sessionEnumerator = &mockEnumerator{}

--- a/agent/internal/helper/manager_test.go
+++ b/agent/internal/helper/manager_test.go
@@ -37,7 +37,7 @@ func TestApplyDisabledStopsRunningHelperAfterRestart(t *testing.T) {
 	removeAutoStartFunc = func() error { return nil }
 	stopHelperLegacyFunc = func() {}
 
-	mgr := New(context.Background(), "", nil, "")
+	mgr := New(context.Background(), nil, nil, "")
 	mgr.baseDir = tmpDir
 	mgr.sessionEnumerator = &mockEnumerator{
 		sessions: []SessionInfo{{Key: "501", Username: "alice", UID: 501}},
@@ -86,7 +86,7 @@ func TestApplyRestartsHelperOnConfigChangeWhenIdle(t *testing.T) {
 
 	stopped := 0
 	spawned := 0
-	mgr := New(context.Background(), "", nil, "")
+	mgr := New(context.Background(), nil, nil, "")
 	mgr.baseDir = tmpDir
 	mgr.sessionEnumerator = &mockEnumerator{
 		sessions: []SessionInfo{{Key: "501", Username: "alice", UID: 501}},
@@ -146,7 +146,7 @@ func TestApplyDefersRestartWhileChatActive(t *testing.T) {
 
 	stopped := 0
 	spawned := 0
-	mgr := New(context.Background(), "", nil, "")
+	mgr := New(context.Background(), nil, nil, "")
 	mgr.baseDir = tmpDir
 	mgr.sessionEnumerator = &mockEnumerator{
 		sessions: []SessionInfo{{Key: "501", Username: "alice", UID: 501}},
@@ -193,7 +193,7 @@ func TestApplyEnabledSpawnsPerSession(t *testing.T) {
 	removeAutoStartFunc = func() error { return nil }
 	stopHelperLegacyFunc = func() {}
 
-	mgr := New(context.Background(), "", nil, "")
+	mgr := New(context.Background(), nil, nil, "")
 	mgr.baseDir = tmpDir
 	mgr.sessionEnumerator = &mockEnumerator{
 		sessions: []SessionInfo{
@@ -245,7 +245,7 @@ func TestApplyDisabledUninstalledIsStableNoOp(t *testing.T) {
 	uninstallPackageFunc = func() error { uninstallCalls++; return nil }
 	stopHelperLegacyFunc = func() { stopLegacyCalls++ }
 
-	mgr := New(context.Background(), "", nil, "")
+	mgr := New(context.Background(), nil, nil, "")
 	mgr.baseDir = tmpDir
 	mgr.binaryPath = filepath.Join(tmpDir, "breeze-helper") // absent → not installed
 	mgr.sessionEnumerator = &mockEnumerator{}
@@ -292,7 +292,7 @@ func TestApplyDisabledInstalledCleansUpOnce(t *testing.T) {
 	migrationTargetsFunc = func() ([]string, error) { return nil, nil }
 	prepareSessionDirFunc = func(path, sessionKey string) error { return nil }
 
-	mgr := New(context.Background(), "", nil, "")
+	mgr := New(context.Background(), nil, nil, "")
 	mgr.baseDir = tmpDir
 	mgr.binaryPath = binPath
 	mgr.sessionEnumerator = &mockEnumerator{}

--- a/agent/internal/helper/migrate_test.go
+++ b/agent/internal/helper/migrate_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNeedsSessionMigration(t *testing.T) {
 	tmpDir := t.TempDir()
-	mgr := New(context.Background(), "", nil, "")
+	mgr := New(context.Background(), nil, nil, "")
 	mgr.baseDir = tmpDir
 
 	if !mgr.needsSessionMigration() {
@@ -27,7 +27,7 @@ func TestNeedsSessionMigration(t *testing.T) {
 
 func TestMigrateToSessionsCreatesLayout(t *testing.T) {
 	tmpDir := t.TempDir()
-	mgr := New(context.Background(), "", nil, "")
+	mgr := New(context.Background(), nil, nil, "")
 	mgr.baseDir = tmpDir
 	mgr.sessionEnumerator = &mockEnumerator{
 		sessions: []SessionInfo{{Key: "501", Username: "alice", UID: 501}},

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -28,7 +28,14 @@ var log = logging.L("updater")
 
 // Config holds updater configuration
 type Config struct {
-	ServerURL      string
+	// ServerURL resolves the control-plane base URL. It is a provider
+	// (func() string) rather than a plain string so that long-lived callers
+	// re-resolve it on every download and follow the heartbeat's
+	// backup-server-URL promotion (#2323) after a failover, instead of pinning
+	// the (possibly dead) primary captured at construction. Making it a func —
+	// rather than a plain string — is what makes the copied-string mistake
+	// unrepresentable at the call sites (#2478, matching #2454/#2463/#2477).
+	ServerURL      func() string
 	AuthToken      *secmem.SecureString
 	CurrentVersion string
 	Component      string
@@ -55,6 +62,16 @@ func New(cfg *Config) *Updater {
 		config: cfg,
 		client: &http.Client{Timeout: 5 * time.Minute},
 	}
+}
+
+// serverURL resolves the control-plane base URL from the ServerURL provider.
+// Nil-safe: a misconfigured Config (nil provider) yields "" rather than
+// panicking, and the resulting request fails closed with an unparseable URL.
+func (u *Updater) serverURL() string {
+	if u.config == nil || u.config.ServerURL == nil {
+		return ""
+	}
+	return u.config.ServerURL()
 }
 
 // ErrReadOnlyFS is returned when the binary path is on a read-only filesystem.
@@ -660,7 +677,7 @@ func (u *Updater) downloadBinary(version string) (string, updateManifest, []byte
 	}
 	// Step 1: Get download URL + checksum from API.
 	infoURL := fmt.Sprintf("%s/api/v1/agent-versions/%s/download?platform=%s&arch=%s&component=%s",
-		u.config.ServerURL, version, runtime.GOOS, runtime.GOARCH, url.QueryEscape(u.component()))
+		u.serverURL(), version, runtime.GOOS, runtime.GOARCH, url.QueryEscape(u.component()))
 
 	req, err := http.NewRequest("GET", infoURL, nil)
 	if err != nil {
@@ -925,7 +942,7 @@ func (u *Updater) downloadFromURL(rawURL string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid download URL: %w", err)
 	}
-	serverParsed, err := url.Parse(u.config.ServerURL)
+	serverParsed, err := url.Parse(u.serverURL())
 	if err != nil {
 		return "", fmt.Errorf("invalid server URL: %w", err)
 	}

--- a/agent/internal/updater/updater_test.go
+++ b/agent/internal/updater/updater_test.go
@@ -21,6 +21,13 @@ import (
 	"github.com/breeze-rmm/agent/internal/secmem"
 )
 
+// staticServerURL wraps a fixed URL as a Config.ServerURL provider for tests
+// that don't exercise failover promotion. Config.ServerURL is a func() string
+// (#2478) so long-lived updaters follow backup-server-URL promotion.
+func staticServerURL(s string) func() string {
+	return func() string { return s }
+}
+
 func signedDownloadInfo(t *testing.T, version, component, rawURL string, content []byte) downloadInfo {
 	t.Helper()
 	publicKey, privateKey, err := ed25519.GenerateKey(nil)
@@ -162,7 +169,7 @@ func TestEmbeddedTrustRootMatchesRepoPubKey(t *testing.T) {
 
 func TestNewCreatesUpdater(t *testing.T) {
 	cfg := &Config{
-		ServerURL:      "http://localhost:3001",
+		ServerURL:      staticServerURL("http://localhost:3001"),
 		AuthToken:      secmem.NewSecureString("brz_test"),
 		CurrentVersion: "0.1.0",
 		BinaryPath:     "/usr/local/bin/breeze-agent",
@@ -390,7 +397,7 @@ func TestDownloadBinary(t *testing.T) {
 	defer server.Close()
 
 	u := New(&Config{
-		ServerURL: server.URL,
+		ServerURL: staticServerURL(server.URL),
 		AuthToken: secmem.NewSecureString("test-token"),
 	})
 	u.client = server.Client()
@@ -466,7 +473,7 @@ func TestDownloadBinaryRejectsTamperedSignedMetadata(t *testing.T) {
 	defer server.Close()
 
 	u := New(&Config{
-		ServerURL: server.URL,
+		ServerURL: staticServerURL(server.URL),
 		AuthToken: secmem.NewSecureString("test-token"),
 	})
 	u.client = server.Client()
@@ -499,7 +506,7 @@ func TestDownloadBinaryAcceptsSignedReleaseArtifactManifest(t *testing.T) {
 	defer server.Close()
 
 	u := New(&Config{
-		ServerURL: server.URL,
+		ServerURL: staticServerURL(server.URL),
 		AuthToken: secmem.NewSecureString("test-token"),
 	})
 	u.client = server.Client()
@@ -558,7 +565,7 @@ func TestDownloadBinaryAcceptsServerRelativeUrlWithMatchingChecksum(t *testing.T
 	defer server.Close()
 
 	u := New(&Config{
-		ServerURL: server.URL,
+		ServerURL: staticServerURL(server.URL),
 		AuthToken: secmem.NewSecureString("test-token"),
 	})
 	u.client = server.Client()
@@ -594,7 +601,7 @@ func TestDownloadBinaryRejectsWrongSignedReleaseArtifact(t *testing.T) {
 	defer server.Close()
 
 	u := New(&Config{
-		ServerURL: server.URL,
+		ServerURL: staticServerURL(server.URL),
 		AuthToken: secmem.NewSecureString("test-token"),
 	})
 	u.client = server.Client()
@@ -630,7 +637,7 @@ func TestDownloadBinaryRejectsRedirectResponseWithoutSignedManifest(t *testing.T
 	defer server.Close()
 
 	u := New(&Config{
-		ServerURL: server.URL,
+		ServerURL: staticServerURL(server.URL),
 		AuthToken: secmem.NewSecureString("test-token"),
 	})
 	u.client = server.Client()
@@ -651,7 +658,7 @@ func TestDownloadBinaryMissingChecksum(t *testing.T) {
 	}))
 	defer server.Close()
 
-	u := New(&Config{ServerURL: server.URL})
+	u := New(&Config{ServerURL: staticServerURL(server.URL)})
 	u.client = server.Client()
 
 	_, _, _, err := u.downloadBinary("1.0.0")
@@ -666,7 +673,7 @@ func TestDownloadBinaryServerError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	u := New(&Config{ServerURL: server.URL})
+	u := New(&Config{ServerURL: staticServerURL(server.URL)})
 	u.client = server.Client()
 
 	_, _, _, err := u.downloadBinary("1.0.0")
@@ -719,7 +726,7 @@ func TestDownloadBinary_ChecksumMismatchCleansUpTempFile(t *testing.T) {
 	defer server.Close()
 
 	u := New(&Config{
-		ServerURL: server.URL,
+		ServerURL: staticServerURL(server.URL),
 		AuthToken: secmem.NewSecureString("test-token"),
 	})
 	u.client = server.Client()
@@ -772,7 +779,7 @@ func TestEndToEndUpdateWithoutRestart(t *testing.T) {
 	defer server.Close()
 
 	u := New(&Config{
-		ServerURL:      server.URL,
+		ServerURL:      staticServerURL(server.URL),
 		AuthToken:      secmem.NewSecureString("tok"),
 		CurrentVersion: "0.1.0",
 		BinaryPath:     binaryPath,
@@ -1044,7 +1051,7 @@ func TestUpdateToWithOptions_CleansHelperTempOnFailure(t *testing.T) {
 	t.Cleanup(func() { _ = os.Remove(binaryFile.Name()) })
 
 	u := New(&Config{
-		ServerURL:  "http://localhost:0",
+		ServerURL:  staticServerURL("http://localhost:0"),
 		BinaryPath: binaryFile.Name(),
 		BackupPath: binaryFile.Name() + ".backup",
 		// AuthToken intentionally nil — forces downloadBinary to return early.
@@ -1080,7 +1087,7 @@ func TestUpdateToWithOptions_NoUserHelperIsNoOp(t *testing.T) {
 	t.Cleanup(func() { _ = os.Remove(binaryFile.Name()) })
 
 	u := New(&Config{
-		ServerURL:  "http://localhost:0",
+		ServerURL:  staticServerURL("http://localhost:0"),
 		BinaryPath: binaryFile.Name(),
 		BackupPath: binaryFile.Name() + ".backup",
 	})
@@ -1107,7 +1114,7 @@ func TestUpdateTo_DelegatesToUpdateToWithOptions(t *testing.T) {
 
 	mkUpdater := func() *Updater {
 		return New(&Config{
-			ServerURL:  "http://localhost:0",
+			ServerURL:  staticServerURL("http://localhost:0"),
 			BinaryPath: binaryFile.Name(),
 			BackupPath: binaryFile.Name() + ".backup",
 		})


### PR DESCRIPTION
## Problem

Fourth and fifth instances of the **stale-server-URL** bug class (#2423 / #2425 / #2463). A long-lived subsystem takes a **by-value copy** of `cfg.ServerURL` at startup, so after the heartbeat's backup-server-URL promotion (#2323) it keeps talking to the **dead primary** for the rest of the process lifetime.

**1. Breeze Assist package downloader.** `helper.New`'s `serverURL` param and `Manager.serverURL` were plain strings, baked into the download closure at construction (`defaultHelperDownloader` → `updater.Config{ServerURL: serverURL}`). After a failover, Breeze Assist installs/updates (`downloadAndInstall`, `applyPendingUpdate`, invoked later on server directives) still fetched from the dead primary.

**2. Watchdog binary updater.** `doUpdateAgent` / `doUpdateWatchdog` built `updater.Config{ServerURL: cfg.ServerURL}` from the config loaded once at startup. The watchdog's `FailoverClient` is already failover-aware (mutex-guarded `SetBaseURL`, retargeted by `noteFailoverHeartbeatFailure`), but that only retargets the **client** — it never writes back into `cfg`. So during a failover window the watchdog could **heartbeat the promoted backup while still downloading agent/watchdog binaries from the dead primary**.

## Fix

Make the URL a provider (`func() string`) rather than a string — per #2463, this is what makes the copied-string mistake **unrepresentable at the call sites**, matching the provider pattern from #2454/#2477.

- **`updater.Config.ServerURL`** is now `func() string`, resolved via a nil-safe `Updater.serverURL()` on every download. All construction sites updated — the heartbeat self-update / helper-companion / dev-update paths now pass the `h.serverURL` method value (they already re-resolved per call, so no behavior change there; the type just makes it uniform).
- **`helper.New`** takes a `func() string`; the heartbeat wires `h.serverURL` (the mutex-guarded live getter) into it. The downloader resolves it at call time.
- **Watchdog `doUpdateAgent` / `doUpdateWatchdog`** take a `serverURL func() string` provider; the failover dispatch (`processHeartbeatResponse`, `processInitialFailoverHeartbeatResponse`, and the IPC `update_agent`/`update_watchdog` command handlers) threads **`fc.BaseURL`** — the live, promotion-retargeted URL the FailoverClient already uses for its own heartbeats.

## Tests

Both pin **call-time resolution** (URL changes between construction and download → request follows the new URL):
- `internal/helper` — `TestDefaultHelperDownloaderResolvesServerURLAtCallTime`
- `cmd/breeze-watchdog` — `TestDoUpdateWatchdogFollowsFailoverBaseURLPromotion` (asserts the dead primary is never contacted and the download routes to the promoted backup after `SetBaseURL`)

Affected suites green: `go test ./internal/updater/... ./internal/helper/... ./cmd/breeze-watchdog/...` (race unavailable locally — no C compiler in this env; CI runs `-race`). `go build ./...` + `go vet ./...` clean.

Closes #2478. Refs #2323, #2423, #2425, #2463, #2454, #2477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)