### PR TITLE
fix(portal): derive session cookie Secure flag from real transport, not NODE_ENV (#2611)

### DIFF
--- a/apps/api/src/routes/portal/acceptInvite.test.ts
+++ b/apps/api/src/routes/portal/acceptInvite.test.ts
@@ -12,7 +12,12 @@ vi.mock('../../db', () => ({
     update: () => ({ set: (v: any) => ({ where: () => { updateSpy(v); return Promise.resolve(); } }) })
   },
   withDbAccessContext: (_ctx: any, fn: any) => fn(),
-  withSystemDbAccessContext: (fn: any) => fn()
+  withSystemDbAccessContext: (fn: any) => fn(),
+  // helpers.ts now imports auth/helpers, which transitively pulls in the
+  // services barrel; something there reads runOutsideDbContext at module load,
+  // so the full-module mock must provide it (synchronous passthrough, matching
+  // the real signature <T>(fn: () => T): T).
+  runOutsideDbContext: <T>(fn: () => T) => fn()
 }));
 // discoveredAssetTypeEnum: networkBaseline.ts (transitive import of the portal
 // route graph) reads its .enumValues at module load, so the full-module mock

--- a/apps/api/src/routes/portal/helpers.test.ts
+++ b/apps/api/src/routes/portal/helpers.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { buildPortalUrl } from './helpers';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import {
+  buildPortalUrl,
+  buildPortalSessionCookie,
+  buildPortalCsrfCookie,
+  buildClearPortalSessionCookie,
+  setPortalSessionCookies,
+  clearPortalSessionCookies,
+  _resetPortalCookieWarnStateForTests,
+} from './helpers';
+import type { Context } from 'hono';
 
 const ENV_KEYS = ['PUBLIC_PORTAL_URL', 'DASHBOARD_URL', 'PUBLIC_APP_URL'] as const;
 const saved: Record<string, string | undefined> = {};
@@ -21,5 +30,217 @@ describe('buildPortalUrl', () => {
   it('does not double the /portal segment', () => {
     setEnv({ PUBLIC_PORTAL_URL: 'https://us.2breeze.app/portal/' });
     expect(buildPortalUrl('/reset-password')).toBe('https://us.2breeze.app/portal/reset-password');
+  });
+});
+
+// ============================================
+// #2611 — portal cookie Secure flag tracks the real transport, not NODE_ENV
+// (follow-up to the admin-app #1618 fix; mirrors routes/auth/helpers.test.ts)
+// ============================================
+
+// isRequestConnectionSecure (reused from auth/helpers) only honors
+// X-Forwarded-Proto when the immediate TCP peer passes the TRUSTED_PROXY_CIDRS
+// gate, so the cookie context needs a socket peer + a header sink recording the
+// exact Set-Cookie strings emitted.
+const TRUSTED_PROXY_IP = '172.31.0.10';
+
+function makeCookieContext(opts: {
+  forwardedProto?: string;
+  url?: string;
+  host?: string;
+  remoteAddress?: string | null;
+}): { c: Context; setCookies: string[] } {
+  const setCookies: string[] = [];
+  const headers: Record<string, string> = {};
+  if (opts.forwardedProto !== undefined) headers['x-forwarded-proto'] = opts.forwardedProto;
+  if (opts.host !== undefined) headers['host'] = opts.host;
+  const remoteAddress = opts.remoteAddress === null ? undefined : (opts.remoteAddress ?? TRUSTED_PROXY_IP);
+  const c = {
+    req: {
+      header: (name: string) => headers[name.toLowerCase()],
+      url: opts.url ?? 'http://api:3001/api/v1/portal/auth/login',
+    },
+    header: (name: string, value: string) => {
+      if (name.toLowerCase() === 'set-cookie') setCookies.push(value);
+    },
+    ...(remoteAddress ? { env: { incoming: { socket: { remoteAddress } } } } : {}),
+  } as unknown as Context;
+  return { c, setCookies };
+}
+
+// In production the proxy-trust gate defaults CLOSED; open it to mirror the
+// out-of-the-box compose config (Caddy's static IP in TRUSTED_PROXY_CIDRS).
+function enableProxyTrust(): void {
+  process.env.TRUST_PROXY_HEADERS = 'true';
+  process.env.TRUSTED_PROXY_CIDRS = `${TRUSTED_PROXY_IP}/32`;
+}
+
+function disableProxyTrustEnv(): void {
+  delete process.env.TRUST_PROXY_HEADERS;
+  delete process.env.TRUSTED_PROXY_CIDRS;
+}
+
+describe('portal cookie Secure flag (#2611)', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  beforeEach(() => {
+    enableProxyTrust();
+  });
+  afterEach(() => {
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    disableProxyTrustEnv();
+    delete process.env.PORTAL_COOKIE_FORCE_SECURE;
+    delete process.env.PORTAL_COOKIE_SAME_SITE;
+  });
+
+  it('REGRESSION: production served over HTTP issues NON-Secure portal cookies so the browser keeps them', () => {
+    process.env.NODE_ENV = 'production';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    setPortalSessionCookies(c, 'session.token.value');
+    expect(setCookies).toHaveLength(2);
+    const [session, csrf] = setCookies;
+    expect(session).toContain('breeze_portal_session=');
+    expect(session).not.toContain('Secure');
+    expect(csrf).toContain('breeze_portal_csrf_token=');
+    expect(csrf).not.toContain('Secure');
+    // Attributes that must survive regardless of transport.
+    expect(session).toContain('HttpOnly');
+    expect(session).toContain('SameSite=Lax');
+  });
+
+  it('production served over HTTPS still issues Secure portal cookies', () => {
+    process.env.NODE_ENV = 'production';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'https' });
+    setPortalSessionCookies(c, 'session.token.value');
+    expect(setCookies[0]).toContain('; Secure');
+    expect(setCookies[1]).toContain('; Secure');
+  });
+
+  it('PORTAL_COOKIE_FORCE_SECURE overrides an http transport (paranoid setups)', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.PORTAL_COOKIE_FORCE_SECURE = 'true';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    setPortalSessionCookies(c, 'session.token.value');
+    expect(setCookies[0]).toContain('; Secure');
+    expect(setCookies[1]).toContain('; Secure');
+  });
+
+  it('SameSite=None forces Secure regardless of transport (browsers reject SameSite=None without it)', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.PORTAL_COOKIE_SAME_SITE = 'None';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    setPortalSessionCookies(c, 'session.token.value');
+    expect(setCookies[0]).toContain('SameSite=None; Secure');
+    expect(setCookies[1]).toContain('SameSite=None; Secure');
+  });
+
+  it('untrusted-peer X-Forwarded-Proto=http cannot strip Secure in production (falls back to NODE_ENV)', () => {
+    process.env.NODE_ENV = 'production';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http', remoteAddress: '203.0.113.9' });
+    setPortalSessionCookies(c, 'session.token.value');
+    expect(setCookies[0]).toContain('; Secure');
+    expect(setCookies[1]).toContain('; Secure');
+  });
+
+  it('clear cookies mirror the set-cookie Secure flag for the same transport (http → non-Secure)', () => {
+    process.env.NODE_ENV = 'production';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    clearPortalSessionCookies(c);
+    expect(setCookies).toHaveLength(2);
+    expect(setCookies[0]).toContain('Max-Age=0');
+    expect(setCookies[0]).not.toContain('Secure'); // an http clear must NOT be Secure or the browser ignores it
+    expect(setCookies[1]).not.toContain('Secure');
+  });
+
+  it('clear cookies carry Secure over an https transport', () => {
+    process.env.NODE_ENV = 'production';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'https' });
+    clearPortalSessionCookies(c);
+    expect(setCookies[0]).toContain('Max-Age=0');
+    expect(setCookies[0]).toContain('; Secure');
+    expect(setCookies[1]).toContain('; Secure');
+  });
+
+  it('build* functions require an explicit transport — no silent NODE_ENV fallback', () => {
+    process.env.NODE_ENV = 'production';
+    expect(buildPortalSessionCookie('t', true)).toContain('; Secure');
+    expect(buildPortalSessionCookie('t', false)).not.toContain('Secure');
+    expect(buildPortalCsrfCookie('t', true)).toContain('; Secure');
+    expect(buildPortalCsrfCookie('t', false)).not.toContain('Secure');
+    expect(buildClearPortalSessionCookie(true)).toContain('; Secure');
+    expect(buildClearPortalSessionCookie(false)).not.toContain('Secure');
+  });
+});
+
+describe('portal cookie transport warnings (#2611 diagnostics)', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _resetPortalCookieWarnStateForTests();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    enableProxyTrust();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    warnSpy.mockRestore();
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    disableProxyTrustEnv();
+    delete process.env.PORTAL_COOKIE_FORCE_SECURE;
+    delete process.env.PORTAL_COOKIE_SAME_SITE;
+  });
+
+  function allWarnings(): string {
+    return warnSpy.mock.calls.map((call: unknown[]) => String(call[0])).join('\n');
+  }
+
+  it('warns (throttled) when production issues non-Secure portal cookies over HTTP, with host + observed proto', () => {
+    process.env.NODE_ENV = 'production';
+    setPortalSessionCookies(makeCookieContext({ forwardedProto: 'http', host: 'rmm.example.com' }).c, 't');
+    expect(allWarnings()).toContain('[portal] Issuing NON-Secure session cookies');
+    expect(allWarnings()).toContain('rmm.example.com');
+    expect(allWarnings()).toContain('"http"');
+    const afterFirst = warnSpy.mock.calls.length;
+
+    // Suppressed inside the throttle window…
+    setPortalSessionCookies(makeCookieContext({ forwardedProto: 'http' }).c, 't');
+    expect(warnSpy.mock.calls.length).toBe(afterFirst);
+    // …and fires again after it.
+    vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+    setPortalSessionCookies(makeCookieContext({ forwardedProto: 'http' }).c, 't');
+    expect(warnSpy.mock.calls.length).toBeGreaterThan(afterFirst);
+  });
+
+  it('stays quiet for dev-over-http (the normal local flow)', () => {
+    process.env.NODE_ENV = 'development';
+    setPortalSessionCookies(makeCookieContext({ forwardedProto: 'http' }).c, 't');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet for production-over-https', () => {
+    process.env.NODE_ENV = 'production';
+    setPortalSessionCookies(makeCookieContext({ forwardedProto: 'https' }).c, 't');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns that login WILL break when PORTAL_COOKIE_FORCE_SECURE forces Secure onto an http transport', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.PORTAL_COOKIE_FORCE_SECURE = 'true';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    setPortalSessionCookies(c, 't');
+    expect(setCookies[0]).toContain('; Secure'); // cookie really is forced Secure
+    expect(allWarnings()).toContain('WILL silently discard');
+    expect(allWarnings()).toContain('PORTAL_COOKIE_FORCE_SECURE');
+  });
+
+  it('warns with the SameSite=None cause when SameSite=None forces Secure onto an http transport', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.PORTAL_COOKIE_SAME_SITE = 'None';
+    setPortalSessionCookies(makeCookieContext({ forwardedProto: 'http' }).c, 't');
+    expect(allWarnings()).toContain('PORTAL_COOKIE_SAME_SITE=None');
+    expect(allWarnings()).toContain('WILL silently discard');
   });
 });

--- a/apps/api/src/routes/portal/helpers.ts
+++ b/apps/api/src/routes/portal/helpers.ts
@@ -2,6 +2,7 @@ import type { Context, MiddlewareHandler } from 'hono';
 import { createHash, randomBytes, timingSafeEqual } from 'crypto';
 import { nanoid } from 'nanoid';
 import { getTrustedClientIp } from '../../services/clientIp';
+import { isRequestConnectionSecure } from '../auth/helpers';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { DEFAULT_ALLOWED_ORIGINS } from '../../services/corsOrigins';
 import { getRedis } from '../../services/redis';
@@ -126,51 +127,134 @@ function resolvePortalCookieSameSite(): SameSiteValue {
   return normalizeSameSite(process.env.PORTAL_COOKIE_SAME_SITE ?? process.env.COOKIE_SAME_SITE);
 }
 
-function shouldSetSecureCookie(sameSite: SameSiteValue): boolean {
+function forcePortalSecureCookie(): boolean {
+  const forceSecure = (process.env.PORTAL_COOKIE_FORCE_SECURE ?? process.env.COOKIE_FORCE_SECURE)?.trim().toLowerCase();
+  return forceSecure === '1' || forceSecure === 'true';
+}
+
+function shouldSetSecureCookie(sameSite: SameSiteValue, connectionSecure: boolean): boolean {
   if (sameSite === 'None') {
     // Browsers require Secure when SameSite=None.
     return true;
   }
-  const forceSecure = (process.env.PORTAL_COOKIE_FORCE_SECURE ?? process.env.COOKIE_FORCE_SECURE)?.trim().toLowerCase();
-  if (forceSecure === '1' || forceSecure === 'true') {
+  if (forcePortalSecureCookie()) {
     return true;
   }
-  return isSecureCookieEnvironment();
+  return connectionSecure;
 }
 
-function buildCookieSecuritySuffix(sameSite: SameSiteValue): string {
-  const secure = shouldSetSecureCookie(sameSite) ? '; Secure' : '';
+function buildCookieSecuritySuffix(sameSite: SameSiteValue, connectionSecure: boolean): string {
+  const secure = shouldSetSecureCookie(sameSite, connectionSecure) ? '; Secure' : '';
   return `; SameSite=${sameSite}${secure}`;
 }
 
-export function buildPortalSessionCookie(token: string): string {
+// `connectionSecure` is required on every build* function so no caller can
+// silently fall back to the pre-#1618 NODE_ENV heuristic (#2611 — the portal
+// surface had its own copy of that footgun). Derive it from the request via
+// isRequestConnectionSecure(c), or use the set/clear entry points below, which
+// also emit the misconfiguration warnings.
+export function buildPortalSessionCookie(token: string, connectionSecure: boolean): string {
   const sameSite = resolvePortalCookieSameSite();
-  return `${PORTAL_SESSION_COOKIE_NAME}=${encodeURIComponent(token)}; Path=${PORTAL_SESSION_COOKIE_PATH}; HttpOnly${buildCookieSecuritySuffix(sameSite)}; Max-Age=${SESSION_TTL_SECONDS}`;
+  return `${PORTAL_SESSION_COOKIE_NAME}=${encodeURIComponent(token)}; Path=${PORTAL_SESSION_COOKIE_PATH}; HttpOnly${buildCookieSecuritySuffix(sameSite, connectionSecure)}; Max-Age=${SESSION_TTL_SECONDS}`;
 }
 
-export function buildPortalCsrfCookie(token: string): string {
+export function buildPortalCsrfCookie(token: string, connectionSecure: boolean): string {
   const sameSite = resolvePortalCookieSameSite();
-  return `${PORTAL_CSRF_COOKIE_NAME}=${encodeURIComponent(token)}; Path=${PORTAL_CSRF_COOKIE_PATH}${buildCookieSecuritySuffix(sameSite)}; Max-Age=${SESSION_TTL_SECONDS}`;
+  return `${PORTAL_CSRF_COOKIE_NAME}=${encodeURIComponent(token)}; Path=${PORTAL_CSRF_COOKIE_PATH}${buildCookieSecuritySuffix(sameSite, connectionSecure)}; Max-Age=${SESSION_TTL_SECONDS}`;
 }
 
-export function buildClearPortalSessionCookie(): string {
+export function buildClearPortalSessionCookie(connectionSecure: boolean): string {
   const sameSite = resolvePortalCookieSameSite();
-  return `${PORTAL_SESSION_COOKIE_NAME}=; Path=${PORTAL_SESSION_COOKIE_PATH}; HttpOnly${buildCookieSecuritySuffix(sameSite)}; Max-Age=0`;
+  return `${PORTAL_SESSION_COOKIE_NAME}=; Path=${PORTAL_SESSION_COOKIE_PATH}; HttpOnly${buildCookieSecuritySuffix(sameSite, connectionSecure)}; Max-Age=0`;
 }
 
-export function buildClearPortalCsrfCookie(): string {
+export function buildClearPortalCsrfCookie(connectionSecure: boolean): string {
   const sameSite = resolvePortalCookieSameSite();
-  return `${PORTAL_CSRF_COOKIE_NAME}=; Path=${PORTAL_CSRF_COOKIE_PATH}${buildCookieSecuritySuffix(sameSite)}; Max-Age=0`;
+  return `${PORTAL_CSRF_COOKIE_NAME}=; Path=${PORTAL_CSRF_COOKIE_PATH}${buildCookieSecuritySuffix(sameSite, connectionSecure)}; Max-Age=0`;
+}
+
+// Throttled warnings so a busy misconfigured deployment logs periodically
+// without flooding. Keyed per warning kind (a small fixed set — never by
+// host/peer) so one misconfiguration class can't suppress reports of another.
+// Module-scoped; resets on process restart. Mirrors the admin-app pattern
+// (routes/auth/helpers.ts) on the portal surface (#2611).
+const PORTAL_COOKIE_WARN_INTERVAL_MS = 10 * 60 * 1000;
+const portalCookieLastWarnAt = new Map<string, number>();
+
+function warnPortalCookieThrottled(kind: string, message: string): void {
+  const now = Date.now();
+  const last = portalCookieLastWarnAt.get(kind);
+  if (last !== undefined && now - last < PORTAL_COOKIE_WARN_INTERVAL_MS) {
+    return;
+  }
+  portalCookieLastWarnAt.set(kind, now);
+  console.warn(message);
+}
+
+export function _resetPortalCookieWarnStateForTests(): void {
+  portalCookieLastWarnAt.clear();
+}
+
+function describePortalCookieTransport(c: Context): string {
+  const host = c.req.header('host') ?? 'unknown-host';
+  const observedProto = c.req.header('x-forwarded-proto');
+  return `host "${host}", X-Forwarded-Proto ${observedProto ? `"${observedProto}"` : 'absent'}`;
+}
+
+// Keyed off the ACTUAL Secure decision, not just the transport: `Secure` can be
+// forced onto an insecure transport (PORTAL_COOKIE_FORCE_SECURE / SameSite=None),
+// and that case breaks portal login outright — the warning must say so, not
+// claim the cookies are non-Secure. The blind NODE_ENV fallback breadcrumb is
+// emitted by the shared isRequestConnectionSecure().
+function warnOnPortalCookieTransportMismatch(c: Context, sameSite: SameSiteValue, connectionSecure: boolean, secure: boolean): void {
+  if (connectionSecure) {
+    return;
+  }
+  if (secure) {
+    // Explicit config forces `Secure` onto a transport the browser will reject
+    // it on. Only reachable via deliberate configuration, so warn in every
+    // environment — this is the #1618/#2611 symptom by operator choice.
+    const cause = sameSite === 'None'
+      ? 'PORTAL_COOKIE_SAME_SITE=None requires the Secure attribute'
+      : 'PORTAL_COOKIE_FORCE_SECURE is set';
+    warnPortalCookieThrottled(
+      'forced-secure-over-http',
+      `[portal] Issuing \`Secure\` session cookies over a NON-HTTPS request (${describePortalCookieTransport(c)}) because ${cause}. ` +
+      'The browser WILL silently discard them and portal login WILL break (issue #2611). Fix TLS so the ' +
+      'browser reaches Breeze over https, or remove that configuration.'
+    );
+    return;
+  }
+  // Non-Secure cookies over HTTP: login works, but credentials transit
+  // unencrypted. Dev-over-http is the normal local flow — only warn when
+  // deployed (production).
+  if (!isSecureCookieEnvironment()) {
+    return;
+  }
+  warnPortalCookieThrottled(
+    'insecure-transport',
+    `[portal] Issuing NON-Secure session cookies: this production request arrived over HTTP (${describePortalCookieTransport(c)}). ` +
+    'Persistent login will work, but the connection is not encrypted. If Breeze should be served over HTTPS, ' +
+    'fix TLS / your reverse proxy so the browser reaches it over https and the proxy forwards ' +
+    '`X-Forwarded-Proto: https` (see issue #2611).'
+  );
 }
 
 export function setPortalSessionCookies(c: Context, sessionToken: string): void {
-  c.header('Set-Cookie', buildPortalSessionCookie(sessionToken), { append: true });
-  c.header('Set-Cookie', buildPortalCsrfCookie(randomBytes(32).toString('hex')), { append: true });
+  const connectionSecure = isRequestConnectionSecure(c);
+  const sameSite = resolvePortalCookieSameSite();
+  warnOnPortalCookieTransportMismatch(c, sameSite, connectionSecure, shouldSetSecureCookie(sameSite, connectionSecure));
+  c.header('Set-Cookie', buildPortalSessionCookie(sessionToken, connectionSecure), { append: true });
+  c.header('Set-Cookie', buildPortalCsrfCookie(randomBytes(32).toString('hex'), connectionSecure), { append: true });
 }
 
 export function clearPortalSessionCookies(c: Context): void {
-  c.header('Set-Cookie', buildClearPortalSessionCookie(), { append: true });
-  c.header('Set-Cookie', buildClearPortalCsrfCookie(), { append: true });
+  // Derive from the same request so the clearing cookie's attributes match the
+  // set cookie's within this transport (a `Secure` clear sent over HTTP would
+  // itself be ignored by the browser, stranding the cookie).
+  const connectionSecure = isRequestConnectionSecure(c);
+  c.header('Set-Cookie', buildClearPortalSessionCookie(connectionSecure), { append: true });
+  c.header('Set-Cookie', buildClearPortalCsrfCookie(connectionSecure), { append: true });
 }
 
 export function getCookieValue(cookieHeader: string | undefined, name: string): string | null {


### PR DESCRIPTION
## Summary

The client portal carried its own private copy of the pre-#1618 cookie logic and still stamped the `Secure` attribute from `NODE_ENV === 'production'` alone, never consulting the request transport. A production deployment the browser reaches over plain HTTP (failed ACME, an `http://` URL, a TLS-stripping proxy) issued portal session/CSRF cookies with `Secure`, which the browser **silently discards** — portal login appears to succeed but the session never persists. Same symptom as #1618, on the portal surface, with no diagnostic anywhere.

This mirrors the admin-app #1618 fix (PR #2612) rather than re-deriving it.

## Changes

- **Reuse `isRequestConnectionSecure(c)`** from `routes/auth/helpers.ts` for the transport decision: `X-Forwarded-Proto` (first hop, gated on the `TRUST_PROXY_HEADERS` / `TRUSTED_PROXY_CIDRS` posture) → `https://` request URL as a positive-only signal → `NODE_ENV` fallback with a throttled ambiguous-transport breadcrumb.
- **Thread `connectionSecure` through the portal `build*` / `buildClear*` functions as a required parameter** — no NODE_ENV default, so no caller can silently fall back to the removed footgun.
- **`setPortalSessionCookies` / `clearPortalSessionCookies` derive `connectionSecure` from the same request** (they already had the `Context`). Set/clear symmetry means a `Secure` clear is never emitted over an HTTP transport (browsers reject it and strand the cookie).
- **Portal-specific transport-mismatch warnings keyed off the actual Secure decision** (`warnOnPortalCookieTransportMismatch`, `[portal]` prefix): forced-Secure-over-HTTP (`PORTAL_COOKIE_FORCE_SECURE` / `SameSite=None`) warns that login **will** break; plain HTTP-in-production gets the non-Secure + unencrypted-transport warning. Throttled per warning-kind, with `_resetPortalCookieWarnStateForTests`.

The blind-`NODE_ENV`-fallback breadcrumb is emitted by the shared `isRequestConnectionSecure`, so it is not duplicated here.

## Tests

New suites in `routes/portal/helpers.test.ts` mirroring `routes/auth/helpers.test.ts`:
- Regression: production-over-HTTP issues **non-Secure** portal cookies (browser keeps them); production-over-HTTPS keeps `Secure`.
- Trust gate: an untrusted-peer `X-Forwarded-Proto: http` cannot strip `Secure`.
- `PORTAL_COOKIE_FORCE_SECURE` and `SameSite=None` force `Secure` regardless of transport.
- Clear-path Secure symmetry (http → non-Secure clear, https → Secure clear).
- `build*` require an explicit transport (no NODE_ENV fallback).
- Warning throttle + forced-Secure/SameSite=None causes; quiet for dev-over-http and prod-over-https.

`vitest run src/routes/portal/helpers.test.ts` → 16 passed; `src/routes/auth/helpers.test.ts` (imported from) → 52 passed.

Closes #2611

🤖 Generated with [Claude Code](https://claude.com/claude-code)