### PR TITLE
fix(reports): report RTP-on device count so one AV device isn't full coverage (#2517)

### DIFF
--- a/apps/api/src/services/securityComplianceReportProducts.test.ts
+++ b/apps/api/src/services/securityComplianceReportProducts.test.ts
@@ -38,4 +38,66 @@ describe('buildSecurityProductInventory', () => {
       expect.objectContaining({ product: 'Defender', active: false, deviceCoverage: 1 }),
     ]);
   });
+
+  it('reports RTP-on device count separately from install count (issue #2517)', () => {
+    // Defender installed on 4 devices, real-time protection on for only 1.
+    const [defender] = buildSecurityProductInventory([
+      { product: 'Defender', category: 'antivirus', active: true, deviceIds: ['d1'] },
+      { product: 'Defender', category: 'antivirus', active: false, deviceIds: ['d2'] },
+      { product: 'Defender', category: 'antivirus', active: false, deviceIds: ['d3'] },
+      { product: 'Defender', category: 'antivirus', active: false, deviceIds: ['d4'] },
+    ]);
+
+    // The OR-merged dot stays green (product IS in use) but the active-device
+    // count is the honest coverage signal — 1, not 4.
+    expect(defender).toMatchObject({
+      product: 'Defender',
+      active: true,
+      deviceCoverage: 4,
+      activeDeviceCoverage: 1,
+    });
+  });
+
+  it('reports zero active devices when every device has RTP off', () => {
+    const [defender] = buildSecurityProductInventory([
+      { product: 'Defender', category: 'antivirus', active: false, deviceIds: ['d1'] },
+      { product: 'Defender', category: 'antivirus', active: false, deviceIds: ['d2'] },
+    ]);
+
+    expect(defender).toMatchObject({
+      active: false,
+      deviceCoverage: 2,
+      activeDeviceCoverage: 0,
+    });
+  });
+
+  it('leaves activeDeviceCoverage null for integration evidence with no per-device data', () => {
+    expect(
+      buildSecurityProductInventory([
+        { product: 'DNSFilter', category: 'dns_filtering', active: true, lastSyncStatus: 'ok' },
+      ]),
+    ).toEqual([
+      expect.objectContaining({
+        product: 'DNSFilter',
+        active: true,
+        deviceCoverage: null,
+        activeDeviceCoverage: null,
+      }),
+    ]);
+  });
+
+  it('counts fully-active integration evidence as all devices active (no misleading subset)', () => {
+    // SentinelOne is active on its whole managed set — active count equals install
+    // count, so the renderer will not append an "N with real-time protection on"
+    // subset note.
+    const [sentinelOne] = buildSecurityProductInventory([
+      { product: 'SentinelOne', category: 'edr', active: true, deviceIds: ['d1', 'd2', 'd3'] },
+    ]);
+
+    expect(sentinelOne).toMatchObject({
+      product: 'SentinelOne',
+      deviceCoverage: 3,
+      activeDeviceCoverage: 3,
+    });
+  });
 });

--- a/apps/api/src/services/securityComplianceReportProducts.ts
+++ b/apps/api/src/services/securityComplianceReportProducts.ts
@@ -1,6 +1,12 @@
 import type { PostureProduct, PostureProductCategory } from '@breeze/shared';
 
-export type SecurityProductEvidence = Omit<PostureProduct, 'deviceCoverage'> & {
+// `deviceCoverage` and `activeDeviceCoverage` are computed by the inventory
+// builder from `deviceIds` + `active`, so they are not part of the per-source
+// evidence input.
+export type SecurityProductEvidence = Omit<
+  PostureProduct,
+  'deviceCoverage' | 'activeDeviceCoverage'
+> & {
   deviceIds?: Iterable<string>;
 };
 
@@ -49,14 +55,23 @@ export function buildSecurityProductInventory(
       category: PostureProductCategory;
       active: boolean;
       lastSyncStatus: string | null;
+      // All devices the product is inventoried across (installed count).
       deviceIds: Set<string> | null;
+      // Subset of `deviceIds` where THIS device's evidence was active — for native
+      // AV rows that is "real-time protection on". Tracked separately from the
+      // OR-merged `active` flag so one RTP-on device can't paint the whole product
+      // as fully protecting the fleet (issue #2517). Integration evidence keeps the
+      // OR-merge on `active`; its per-device set is either full (all devices active)
+      // or absent (no deviceIds), so it never produces a misleading partial count.
+      activeDeviceIds: Set<string> | null;
     }
   >();
 
   for (const item of evidence) {
     const key = productKey(item.product);
-    const current = merged.get(key);
     const ids = item.deviceIds ? new Set(item.deviceIds) : null;
+    const activeIds = ids && item.active ? new Set(ids) : null;
+    const current = merged.get(key);
     if (!current) {
       merged.set(key, {
         product: item.product,
@@ -64,6 +79,7 @@ export function buildSecurityProductInventory(
         active: item.active,
         lastSyncStatus: item.lastSyncStatus ?? null,
         deviceIds: ids,
+        activeDeviceIds: activeIds,
       });
       continue;
     }
@@ -72,6 +88,10 @@ export function buildSecurityProductInventory(
     if (ids) {
       current.deviceIds ??= new Set();
       for (const id of ids) current.deviceIds.add(id);
+    }
+    if (activeIds) {
+      current.activeDeviceIds ??= new Set();
+      for (const id of activeIds) current.activeDeviceIds.add(id);
     }
   }
 
@@ -82,6 +102,10 @@ export function buildSecurityProductInventory(
       active: item.active,
       lastSyncStatus: item.lastSyncStatus,
       deviceCoverage: item.deviceIds?.size ?? null,
+      // Only meaningful when we have per-device evidence; null otherwise so the
+      // renderer skips the "N with real-time protection on" suffix for pure
+      // integration health rows (DNS, backup, M365).
+      activeDeviceCoverage: item.deviceIds ? (item.activeDeviceIds?.size ?? 0) : null,
     }))
     .sort(
       (a, b) =>

--- a/packages/shared/src/reportPdf/reportPdf.test.ts
+++ b/packages/shared/src/reportPdf/reportPdf.test.ts
@@ -115,6 +115,40 @@ describe('buildReportPdf in Node (no DOM)', () => {
     expect(detailPage).toBeGreaterThan(continuationPage);
   });
 
+  it('spells out the RTP-on subset so one active device is not read as full coverage (issue #2517)', () => {
+    const summary: PostureSummary = {
+      ...postureSummary,
+      securityProducts: [
+        // Installed on 200, real-time protection on for only 1.
+        { product: 'Defender', category: 'antivirus', active: true, deviceCoverage: 200, activeDeviceCoverage: 1 },
+      ],
+    };
+    const doc = buildReportPdf(postureRows, {
+      ...opts,
+      reportType: 'security_compliance_posture',
+      summary,
+    });
+    const text = pdfCommandText(doc);
+    expect(text).toContain('200 devices, 1 with real-time protection on');
+  });
+
+  it('omits the RTP subset note when every installed device is active', () => {
+    const summary: PostureSummary = {
+      ...postureSummary,
+      securityProducts: [
+        { product: 'SentinelOne', category: 'edr', active: true, deviceCoverage: 4, activeDeviceCoverage: 4 },
+      ],
+    };
+    const doc = buildReportPdf(postureRows, {
+      ...opts,
+      reportType: 'security_compliance_posture',
+      summary,
+    });
+    const text = pdfCommandText(doc);
+    expect(text).toContain('4 devices');
+    expect(text).not.toContain('with real-time protection on');
+  });
+
   it('continues a large product inventory across multiple ordered pages with page chrome', () => {
     const products = Array.from({ length: 80 }, (_, index) => ({
       product: `Security Product [${String(index + 1).padStart(3, '0')}]`,

--- a/packages/shared/src/reportPdf/reportPdf.ts
+++ b/packages/shared/src/reportPdf/reportPdf.ts
@@ -960,6 +960,14 @@ function drawPostureProductRow(doc: jsPDF, product: PostureProduct, y: number): 
   const coverage = product.deviceCoverage != null
     ? ` — ${product.deviceCoverage} device${product.deviceCoverage === 1 ? '' : 's'}`
     : '';
+  // "Installed on N" reads as "protecting N". When only a subset of those devices
+  // are actually protecting (native AV with real-time protection on), spell that
+  // out so one RTP-on device can't imply full-fleet coverage (issue #2517).
+  const activeCount = product.activeDeviceCoverage;
+  const rtpNote =
+    product.deviceCoverage != null && activeCount != null && activeCount < product.deviceCoverage
+      ? `, ${activeCount} with real-time protection on`
+      : '';
   // Sync status is only interesting when it's a problem; success is machine
   // noise on a client-facing page.
   const syncOk = !product.lastSyncStatus || /^(ok|success|succeeded)$/i.test(product.lastSyncStatus);
@@ -970,9 +978,9 @@ function drawPostureProductRow(doc: jsPDF, product: PostureProduct, y: number): 
   set.fill(doc, product.active === false ? C.warning : C.success);
   doc.circle(PAGE.mx + 1.4, y - 1.2, 1.2, 'F');
   set.text(doc, C.ink);
-  doc.text(`${product.product}${cat}${coverage}`, PAGE.mx + 5, y);
+  doc.text(`${product.product}${cat}${coverage}${rtpNote}`, PAGE.mx + 5, y);
   if (sync || degraded) {
-    const baseW = doc.getTextWidth(`${product.product}${cat}${coverage}`);
+    const baseW = doc.getTextWidth(`${product.product}${cat}${coverage}${rtpNote}`);
     set.text(doc, C.warning);
     doc.text(`${sync}${degraded}`, PAGE.mx + 5 + baseW, y);
   }

--- a/packages/shared/src/types/postureReport.ts
+++ b/packages/shared/src/types/postureReport.ts
@@ -26,7 +26,16 @@ export type PostureProduct = {
   category: PostureProductCategory;
   active: boolean;
   lastSyncStatus?: string | null;
+  /** Devices the product is installed on / inventoried across (union of evidence). */
   deviceCoverage?: number | null;
+  /**
+   * Devices where the product is actively protecting — for native AV this is the
+   * count with real-time protection ON. Distinct from `deviceCoverage` so the
+   * inventory doesn't imply a single RTP-on device protects the whole fleet
+   * (issue #2517). Null when the product has no per-device evidence (integrations
+   * whose `active` is a connection-health flag, not a per-device count).
+   */
+  activeDeviceCoverage?: number | null;
 };
 
 export type PostureControls = {


### PR DESCRIPTION
## Problem

In the Security & Compliance Posture PDF, the "Security products in use" inventory OR-merged per-device antivirus evidence, so a product rendered **active (green)** with its install count if *any single device* had real-time protection on.

Defender installed on 200 devices with RTP **off on 199** rendered:

> ● **Defender (Antivirus) — 200 devices** *(green, no "not reporting" suffix)*

…which reads as "protecting 200" while the same page's metric grid honestly showed `Any AV coverage: 1%`, `Unprotected devices: 199`, and a "deploy protection to 199" recommendation. An internal-consistency/polish bug, not a correctness one — the headline metrics were already right.

## Root cause

`active` was overloaded across two evidence sources:

- **Integrations** (Huntress, SentinelOne, DNS, backup, M365): `active` = "connected and healthy" → OR-merge is correct.
- **`security_status` rows**: `active` = "RTP on for this one device" → OR-merging turns one RTP-on device into a product-level green.

## Fix (issue's preferred Option 1 — report both numbers)

- Keep the OR-merge on `active` (integration health is unchanged).
- Track a separate per-device active set and expose `activeDeviceCoverage` on `PostureProduct` — the count of devices actually protecting (RTP on).
- The renderer appends `, N with real-time protection on` **only** when the active subset is smaller than the install count; it is omitted when all devices are active (e.g. SentinelOne) or the product has no per-device evidence (DNS, backup, M365 — `activeDeviceCoverage` is null there).

Result: `Defender (Antivirus) — 200 devices, 1 with real-time protection on`. The inventory stays an inventory; the misleading implication is gone.

## Tests

- `securityComplianceReportProducts.test.ts`: RTP-on subset counted separately from install count, zero-active case, null for integration-only evidence, and full-active integration (no misleading subset). The existing OR-merge assertions across two sources are preserved unchanged.
- `reportPdf.test.ts`: the "200 devices, 1 with real-time protection on" note renders for the partial case and is omitted when all devices are active.

Affected suites green single-fork; shared `tsc --noEmit` clean; API type check clean (scoped — full `apps/api` tsc OOMs the local sandbox, runs in CI at 8 GB).

Closes #2517

🤖 Generated with [Claude Code](https://claude.com/claude-code)