### PR TITLE
refactor(agent): type helper Role as ipc.HelperRole (#2532)

### DIFF
--- a/agent/cmd/breeze-desktop-helper/main.go
+++ b/agent/cmd/breeze-desktop-helper/main.go
@@ -144,7 +144,7 @@ func runDesktopHelper() {
 	}
 }
 
-func desktopHelperRole() string {
+func desktopHelperRole() ipc.HelperRole {
 	if runtime.GOOS == "darwin" {
 		return ipc.HelperRoleUser
 	}

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -269,7 +269,7 @@ func init() {
 	enrollCmd.Flags().BoolVar(&quietEnroll, "quiet", false, "Suppress stdout progress output (errors still go to stderr). Intended for unattended installs.")
 	bootstrapCmd.Flags().StringVar(&bootstrapInstallData, "install-data", "", "Pipe-packed bootstrap inputs from the MSI BootstrapEnroll CA: <OriginalDatabase>|<BOOTSTRAP_TOKEN>|<SERVER_URL>")
 	bootstrapCmd.Flags().BoolVar(&quietEnroll, "quiet", false, "Suppress stdout progress output (errors still go to stderr)")
-	userHelperCmd.Flags().StringVar(&helperRole, "role", "user", "Helper role: 'system' (desktop capture) or 'user' (script execution)")
+	userHelperCmd.Flags().StringVar(&helperRole, "role", string(ipc.HelperRoleUser), "Helper role: 'system' (desktop capture) or 'user' (script execution)")
 	desktopHelperCmd.Flags().StringVar(&desktopContext, "context", ipc.DesktopContextUserSession, "Desktop context: 'user_session' or 'login_window'")
 
 	rootCmd.AddCommand(startCmd)
@@ -1461,21 +1461,23 @@ func checkStatus() {
 // runUserHelper starts the per-user session helper process.
 // It connects to the root daemon via IPC and handles user-context operations.
 func runUserHelper() {
-	runHelperProcess("user helper", helperRole, "", ipc.HelperBinaryUserHelper)
+	// helperRole is bound to the cobra --role string flag; convert at this
+	// CLI boundary into the typed HelperRole used everywhere downstream.
+	runHelperProcess("user helper", ipc.HelperRole(helperRole), "", ipc.HelperBinaryUserHelper)
 }
 
 func runDesktopHelper() {
 	runHelperProcess("desktop helper", desktopHelperRole(), desktopContext, ipc.HelperBinaryDesktopHelper)
 }
 
-func desktopHelperRole() string {
+func desktopHelperRole() ipc.HelperRole {
 	if runtime.GOOS == "darwin" {
 		return ipc.HelperRoleUser
 	}
 	return ipc.HelperRoleSystem
 }
 
-func runHelperProcess(name, role, context, binaryKind string) {
+func runHelperProcess(name string, role ipc.HelperRole, context, binaryKind string) {
 	// Detach any inherited console immediately. This runs at the top of
 	// every helper role — user-helper, desktop-helper, and any future
 	// helper subcommand routed through runHelperProcess — because all of

--- a/agent/internal/agentapp/main_instance_windows.go
+++ b/agent/internal/agentapp/main_instance_windows.go
@@ -14,6 +14,7 @@ import (
 	"unsafe"
 
 	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/ipc"
 	"golang.org/x/sys/windows"
 )
 
@@ -34,18 +35,18 @@ type openedMainAgentLock struct {
 // mainAgentLockMetadata is an explicit allowlist. Future ProcessStartup fields
 // do not enter ProgramData lock metadata without a deliberate security review.
 type mainAgentLockMetadata struct {
-	Binary             string    `json:"binary"`
-	ExecutablePath     string    `json:"executablePath"`
-	PID                int       `json:"pid"`
-	ParentPID          int       `json:"parentPid"`
-	WindowsSessionID   uint32    `json:"windowsSessionId"`
-	LaunchMode         string    `json:"launchMode"`
-	HelperRole         string    `json:"helperRole,omitempty"`
-	LifecycleKey       string    `json:"lifecycleKey,omitempty"`
-	CompanionHelper    bool      `json:"companionHelper"`
-	MainBinaryFallback bool      `json:"mainBinaryFallback"`
-	Version            string    `json:"version"`
-	CreatedAt          time.Time `json:"createdAt"`
+	Binary             string         `json:"binary"`
+	ExecutablePath     string         `json:"executablePath"`
+	PID                int            `json:"pid"`
+	ParentPID          int            `json:"parentPid"`
+	WindowsSessionID   uint32         `json:"windowsSessionId"`
+	LaunchMode         string         `json:"launchMode"`
+	HelperRole         ipc.HelperRole `json:"helperRole,omitempty"`
+	LifecycleKey       string         `json:"lifecycleKey,omitempty"`
+	CompanionHelper    bool           `json:"companionHelper"`
+	MainBinaryFallback bool           `json:"mainBinaryFallback"`
+	Version            string         `json:"version"`
+	CreatedAt          time.Time      `json:"createdAt"`
 }
 
 func mainAgentLockMetadataFrom(meta ProcessStartup) mainAgentLockMetadata {

--- a/agent/internal/agentapp/process_role.go
+++ b/agent/internal/agentapp/process_role.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/breeze-rmm/agent/internal/ipc"
 	"github.com/breeze-rmm/agent/internal/sessionbroker"
 )
 
@@ -21,18 +22,18 @@ type platformProcessMetadata struct {
 // process startup. CompanionHelper is true only for a user-helper command that
 // did not resolve to the main agent binary fallback.
 type ProcessStartup struct {
-	Binary             string    `json:"binary"`
-	ExecutablePath     string    `json:"executablePath"`
-	PID                int       `json:"pid"`
-	ParentPID          int       `json:"parentPid"`
-	WindowsSessionID   uint32    `json:"windowsSessionId"`
-	LaunchMode         string    `json:"launchMode"`
-	HelperRole         string    `json:"helperRole,omitempty"`
-	LifecycleKey       string    `json:"lifecycleKey,omitempty"`
-	CompanionHelper    bool      `json:"companionHelper"`
-	MainBinaryFallback bool      `json:"mainBinaryFallback"`
-	Version            string    `json:"version"`
-	CreatedAt          time.Time `json:"createdAt"`
+	Binary             string         `json:"binary"`
+	ExecutablePath     string         `json:"executablePath"`
+	PID                int            `json:"pid"`
+	ParentPID          int            `json:"parentPid"`
+	WindowsSessionID   uint32         `json:"windowsSessionId"`
+	LaunchMode         string         `json:"launchMode"`
+	HelperRole         ipc.HelperRole `json:"helperRole,omitempty"`
+	LifecycleKey       string         `json:"lifecycleKey,omitempty"`
+	CompanionHelper    bool           `json:"companionHelper"`
+	MainBinaryFallback bool           `json:"mainBinaryFallback"`
+	Version            string         `json:"version"`
+	CreatedAt          time.Time      `json:"createdAt"`
 }
 
 var mainProcessStartupCache struct {
@@ -56,12 +57,12 @@ func cachedMainProcessStartup() ProcessStartup {
 	return currentProcessStartup("run", "", isWindowsService())
 }
 
-func currentProcessStartup(command, role string, service bool) ProcessStartup {
+func currentProcessStartup(command string, role ipc.HelperRole, service bool) ProcessStartup {
 	executable, _ := os.Executable()
 	metadata := currentPlatformProcessMetadata()
 	mode, fallback := classifyProcess(command, role, executable, service)
 	lifecycleKey := ""
-	if metadata.WindowsSessionID != 0 && (role == "user" || role == "system") {
+	if metadata.WindowsSessionID != 0 && (role == ipc.HelperRoleUser || role == ipc.HelperRoleSystem) {
 		lifecycleKey = fmt.Sprintf("%d-%s", metadata.WindowsSessionID, role)
 	}
 
@@ -81,7 +82,7 @@ func currentProcessStartup(command, role string, service bool) ProcessStartup {
 	}
 }
 
-func classifyProcess(command, role, executable string, service bool) (string, bool) {
+func classifyProcess(command string, role ipc.HelperRole, executable string, service bool) (string, bool) {
 	base := strings.ToLower(filepath.Base(executable))
 	fallback := command == "user-helper" && base != strings.ToLower(sessionbroker.UserHelperBinaryName)
 	switch {
@@ -89,9 +90,9 @@ func classifyProcess(command, role, executable string, service bool) (string, bo
 		return "service-run", false
 	case command == "run":
 		return "console-run", false
-	case command == "user-helper" && role == "system":
+	case command == "user-helper" && role == ipc.HelperRoleSystem:
 		return "system-helper", fallback
-	case command == "user-helper" && role == "user":
+	case command == "user-helper" && role == ipc.HelperRoleUser:
 		return "user-helper", fallback
 	default:
 		return "other", false

--- a/agent/internal/agentapp/process_role_test.go
+++ b/agent/internal/agentapp/process_role_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
 )
 
 func TestCurrentProcessStartupCapturesDiagnosticRoleMetadata(t *testing.T) {
@@ -29,10 +31,12 @@ func TestCurrentProcessStartupCapturesDiagnosticRoleMetadata(t *testing.T) {
 
 func TestClassifyProcess(t *testing.T) {
 	tests := []struct {
-		name, command, role, exe string
-		service                  bool
-		wantMode                 string
-		wantFallback             bool
+		name, command string
+		role          ipc.HelperRole
+		exe           string
+		service       bool
+		wantMode      string
+		wantFallback  bool
 	}{
 		{"SCM main", "run", "", "breeze-agent.exe", true, "service-run", false},
 		{"console main", "run", "", "breeze-agent.exe", false, "console-run", false},

--- a/agent/internal/ipc/message.go
+++ b/agent/internal/ipc/message.go
@@ -120,12 +120,20 @@ type Envelope struct {
 	HMAC    string          `json:"hmac"`
 }
 
+// HelperRole identifies a connecting helper process and gates its scopes. It is
+// a named string so signatures and struct fields can state intent and so
+// conversions are forced at the wire/CLI boundary; it still marshals as a plain
+// JSON string. Note that a named string type does NOT give exhaustiveness —
+// HelperRole("sytem") still compiles — so the spawnable allow-list, the
+// fail-closed switch defaults, and scopesForRole remain the real safety gates.
+type HelperRole string
+
 // Helper role constants identify connecting helper processes and gate their scopes.
 const (
-	HelperRoleSystem   = "system"
-	HelperRoleUser     = "user"
-	HelperRoleWatchdog = "watchdog"
-	HelperRoleAssist   = "assist" // Breeze Assist Tauri helper; receives helper token only
+	HelperRoleSystem   HelperRole = "system"
+	HelperRoleUser     HelperRole = "user"
+	HelperRoleWatchdog HelperRole = "watchdog"
+	HelperRoleAssist   HelperRole = "assist" // Breeze Assist Tauri helper; receives helper token only
 )
 
 // Scope constants identify the capabilities granted to a helper session.
@@ -161,18 +169,18 @@ type ConsoleUserChangedPayload struct {
 
 // AuthRequest is sent by the user helper to the root daemon after connecting.
 type AuthRequest struct {
-	ProtocolVersion int    `json:"protocolVersion"`
-	UID             uint32 `json:"uid"`
-	SID             string `json:"sid,omitempty"` // Windows Security Identifier
-	Username        string `json:"username"`
-	SessionID       string `json:"sessionId"`
-	DisplayEnv      string `json:"displayEnv"`
-	PID             int    `json:"pid"`
-	BinaryHash      string `json:"binaryHash"`
-	WinSessionID    uint32 `json:"winSessionId,omitempty"` // Windows session ID (1, 2, etc.)
-	HelperRole      string `json:"helperRole,omitempty"`   // "system" | "user" | "watchdog" | "assist" (default: "system")
-	BinaryKind      string `json:"binaryKind,omitempty"`   // "user_helper", "desktop_helper", or "assist_helper"
-	DesktopContext  string `json:"desktopContext,omitempty"`
+	ProtocolVersion int        `json:"protocolVersion"`
+	UID             uint32     `json:"uid"`
+	SID             string     `json:"sid,omitempty"` // Windows Security Identifier
+	Username        string     `json:"username"`
+	SessionID       string     `json:"sessionId"`
+	DisplayEnv      string     `json:"displayEnv"`
+	PID             int        `json:"pid"`
+	BinaryHash      string     `json:"binaryHash"`
+	WinSessionID    uint32     `json:"winSessionId,omitempty"` // Windows session ID (1, 2, etc.)
+	HelperRole      HelperRole `json:"helperRole,omitempty"`   // "system" | "user" | "watchdog" | "assist" (default: "system")
+	BinaryKind      string     `json:"binaryKind,omitempty"`   // "user_helper", "desktop_helper", or "assist_helper"
+	DesktopContext  string     `json:"desktopContext,omitempty"`
 
 	// SupportsConsentUI advertises that this helper can natively render the
 	// remote-session consent dialog (consent_request). The granted

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -194,14 +194,14 @@ var (
 // handles TypeWatchdogPong and never replies to TypePing, so running keepalive
 // against it would evict every watchdog connection at keepaliveTimeout.
 // Watchdog has its own end-to-end liveness probe via WatchdogPing/Pong.
-func roleSupportsKeepalive(role string) bool {
+func roleSupportsKeepalive(role ipc.HelperRole) bool {
 	return role != ipc.HelperRoleWatchdog
 }
 
 // maybeStartKeepalive starts the keepalive goroutine for the session if its
 // role supports it. Extracted from handleConnection so the gating is testable
 // without driving the full IPC handshake (which needs OS-specific peer creds).
-func (b *Broker) maybeStartKeepalive(session *Session, role string) {
+func (b *Broker) maybeStartKeepalive(session *Session, role ipc.HelperRole) {
 	if roleSupportsKeepalive(role) {
 		go b.runKeepalive(session)
 	}
@@ -1260,7 +1260,7 @@ func (b *Broker) HasHelperForWinSession(winSessionID string) bool {
 
 // HasHelperForWinSessionRole returns true if a helper with the given role
 // is connected in the specified Windows session.
-func (b *Broker) HasHelperForWinSessionRole(winSessionID, role string) bool {
+func (b *Broker) HasHelperForWinSessionRole(winSessionID string, role ipc.HelperRole) bool {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	if id, err := strconv.ParseUint(winSessionID, 10, 32); err == nil {
@@ -2286,7 +2286,7 @@ const systemSID = "S-1-5-18"
 // kernel-verified session id can't be forged over a named pipe / Unix socket,
 // so end-to-end pipe tests can only exercise the current test process's own
 // identity.
-func roleIdentityRejection(role, sid string, uid uint32, peerWinSession, claimedWinSession, consoleWinSession, goos string) (reason string, rejected bool) {
+func roleIdentityRejection(role ipc.HelperRole, sid string, uid uint32, peerWinSession, claimedWinSession, consoleWinSession, goos string) (reason string, rejected bool) {
 	if goos == "windows" {
 		switch {
 		case role == ipc.HelperRoleSystem && sid != systemSID:
@@ -2300,10 +2300,10 @@ func roleIdentityRejection(role, sid string, uid uint32, peerWinSession, claimed
 		}
 		if role == ipc.HelperRoleUser || role == ipc.HelperRoleSystem {
 			if peerWinSession == "" || peerWinSession == "0" {
-				return role + " role requires an interactive peer session", true
+				return string(role) + " role requires an interactive peer session", true
 			}
 			if peerWinSession != claimedWinSession {
-				return role + " role session claim does not match peer token", true
+				return string(role) + " role session claim does not match peer token", true
 			}
 		}
 		if role == ipc.HelperRoleAssist && (consoleWinSession == "" || consoleWinSession == "0" || peerWinSession != consoleWinSession) {
@@ -2325,7 +2325,7 @@ func roleIdentityRejection(role, sid string, uid uint32, peerWinSession, claimed
 	return "", false
 }
 
-func (b *Broker) scopesForRole(role, binaryKind, goos, peerPath string) []string {
+func (b *Broker) scopesForRole(role ipc.HelperRole, binaryKind, goos, peerPath string) []string {
 	switch role {
 	case ipc.HelperRoleUser:
 		if goos == "darwin" &&
@@ -2350,7 +2350,7 @@ func (b *Broker) scopesForRole(role, binaryKind, goos, peerPath string) []string
 // the role's base scopes plus consent_ui_fallback when a user-role helper
 // advertised native consent support. Always returns a fresh slice — the
 // role-scope vars are shared package state and must not be appended to.
-func (b *Broker) grantScopes(role string, authReq ipc.AuthRequest, goos, peerPath string) []string {
+func (b *Broker) grantScopes(role ipc.HelperRole, authReq ipc.AuthRequest, goos, peerPath string) []string {
 	base := b.scopesForRole(role, authReq.BinaryKind, goos, peerPath)
 	scopes := make([]string, len(base), len(base)+1)
 	copy(scopes, base)

--- a/agent/internal/sessionbroker/broker_admission.go
+++ b/agent/internal/sessionbroker/broker_admission.go
@@ -44,14 +44,14 @@ func admissionIdentityKey(base string, peerSession uint32, goos string) string {
 	return fmt.Sprintf("windows:%s:session:%d", base, peerSession)
 }
 
-func helperAdmissionIdentityKey(base string, peerSession uint32, goos, role string) string {
+func helperAdmissionIdentityKey(base string, peerSession uint32, goos string, role ipc.HelperRole) string {
 	if !isWindowsLifecycleRole(goos, role) {
 		return base
 	}
 	return admissionIdentityKey(base, peerSession, goos)
 }
 
-func isWindowsLifecycleRole(goos, role string) bool {
+func isWindowsLifecycleRole(goos string, role ipc.HelperRole) bool {
 	return goos == "windows" && (role == ipc.HelperRoleSystem || role == ipc.HelperRoleUser)
 }
 
@@ -227,7 +227,7 @@ func (b *Broker) canAdmitWithoutEviction(identityKey string) bool {
 
 // registerNonLifecycleSession preserves the original authoritative
 // registration path for Unix and Windows assist/watchdog/backup helpers.
-func (b *Broker) registerNonLifecycleSession(identityKey, helperRole string, session *Session) error {
+func (b *Broker) registerNonLifecycleSession(identityKey string, helperRole ipc.HelperRole, session *Session) error {
 	b.mu.Lock()
 	admitted, victim := b.tryAdmitLocked(identityKey)
 	if !admitted {

--- a/agent/internal/sessionbroker/broker_admission_test.go
+++ b/agent/internal/sessionbroker/broker_admission_test.go
@@ -137,7 +137,7 @@ func TestWindowsAdmissionIdentityAndRateBucketsAreRoleAware(t *testing.T) {
 	if systemKey == otherSessionSystemKey {
 		t.Fatalf("system helpers in distinct Windows sessions shared %q", systemKey)
 	}
-	for role, pair := range map[string][2]string{
+	for role, pair := range map[ipc.HelperRole][2]string{
 		ipc.HelperRoleAssist:       {assistKey, userSID},
 		ipc.HelperRoleWatchdog:     {watchdogKey, systemSID},
 		backupipc.HelperRoleBackup: {backupKey, systemSID},
@@ -164,9 +164,9 @@ func TestWindowsAdmissionIdentityAndRateBucketsAreRoleAware(t *testing.T) {
 }
 
 func TestWindowsNonLifecycleRegistrationUsesLegacyIdentityAndQuota(t *testing.T) {
-	roles := []string{ipc.HelperRoleAssist, ipc.HelperRoleWatchdog, backupipc.HelperRoleBackup}
+	roles := []ipc.HelperRole{ipc.HelperRoleAssist, ipc.HelperRoleWatchdog, backupipc.HelperRoleBackup}
 	for _, role := range roles {
-		t.Run(role, func(t *testing.T) {
+		t.Run(string(role), func(t *testing.T) {
 			b := New("test", nil)
 			b.goos = "windows"
 			base := "S-1-5-18"
@@ -194,7 +194,7 @@ func TestWindowsNonLifecycleRegistrationUsesLegacyIdentityAndQuota(t *testing.T)
 					len(b.helperByKey), len(b.helperReservations))
 			}
 
-			overLimit, client := newPairedSession(t, role+"-over-limit", base)
+			overLimit, client := newPairedSession(t, string(role)+"-over-limit", base)
 			clients = append(clients, client)
 			overLimit.HelperRole = role
 			overLimit.WinSessionID = "7"
@@ -418,7 +418,7 @@ func TestTwentySystemSIDsAcrossWindowsSessionsHaveIndependentAdmission(t *testin
 		desired[HelperKey{WindowsSessionID: sessionID, Role: ipc.HelperRoleSystem}] = struct{}{}
 	}
 	for i := 0; i < MaxConnectionsPerIdentity+1; i++ {
-		desired[HelperKey{WindowsSessionID: 99, Role: fmt.Sprintf("quota-%d", i)}] = struct{}{}
+		desired[HelperKey{WindowsSessionID: 99, Role: ipc.HelperRole(fmt.Sprintf("quota-%d", i))}] = struct{}{}
 	}
 	b.UpdateDesiredHelperKeys(desired)
 
@@ -432,12 +432,12 @@ func TestTwentySystemSIDsAcrossWindowsSessionsHaveIndependentAdmission(t *testin
 
 	quotaIdentity := admissionIdentityKey("S-1-5-18", 99, "windows")
 	for i := 0; i < MaxConnectionsPerIdentity; i++ {
-		key := HelperKey{WindowsSessionID: 99, Role: fmt.Sprintf("quota-%d", i)}
+		key := HelperKey{WindowsSessionID: 99, Role: ipc.HelperRole(fmt.Sprintf("quota-%d", i))}
 		if _, err := b.reserveWindowsHelper(quotaIdentity, "S-1-5-18", key); err != nil {
 			t.Fatalf("quota reservation %d: %v", i, err)
 		}
 	}
-	key := HelperKey{WindowsSessionID: 99, Role: fmt.Sprintf("quota-%d", MaxConnectionsPerIdentity)}
+	key := HelperKey{WindowsSessionID: 99, Role: ipc.HelperRole(fmt.Sprintf("quota-%d", MaxConnectionsPerIdentity))}
 	if _, err := b.reserveWindowsHelper(quotaIdentity, "S-1-5-18", key); !errors.Is(err, errMaxConnectionsPerIdentity) {
 		t.Fatalf("sixth reservation err=%v, want errMaxConnectionsPerIdentity", err)
 	}
@@ -447,7 +447,7 @@ func TestUnixAndNonLifecycleRolesBypassWindowsLogicalReservation(t *testing.T) {
 	tests := []struct {
 		name string
 		goos string
-		role string
+		role ipc.HelperRole
 	}{
 		{name: "unix system", goos: "linux", role: ipc.HelperRoleSystem},
 		{name: "assist", goos: "windows", role: ipc.HelperRoleAssist},

--- a/agent/internal/sessionbroker/broker_leak_test.go
+++ b/agent/internal/sessionbroker/broker_leak_test.go
@@ -65,8 +65,8 @@ func TestKeepaliveReapsStrandedSession(t *testing.T) {
 	}()
 
 	b := &Broker{
-		sessions:     map[string]*Session{session.SessionID: session},
-		byIdentity:   map[string][]*Session{session.IdentityKey: {session}},
+		sessions:   map[string]*Session{session.SessionID: session},
+		byIdentity: map[string][]*Session{session.IdentityKey: {session}},
 	}
 
 	done := make(chan struct{})
@@ -121,8 +121,8 @@ func TestKeepaliveKeepsHealthySessionAlive(t *testing.T) {
 	defer close(stopDrain)
 
 	b := &Broker{
-		sessions:     map[string]*Session{session.SessionID: session},
-		byIdentity:   map[string][]*Session{session.IdentityKey: {session}},
+		sessions:   map[string]*Session{session.SessionID: session},
+		byIdentity: map[string][]*Session{session.IdentityKey: {session}},
 	}
 
 	keepaliveDone := make(chan struct{})
@@ -155,7 +155,7 @@ func TestKeepaliveKeepsHealthySessionAlive(t *testing.T) {
 // connection was being evicted at keepaliveTimeout and reconnecting forever.
 func TestRoleSupportsKeepalive_ExcludesWatchdog(t *testing.T) {
 	cases := []struct {
-		role string
+		role ipc.HelperRole
 		want bool
 	}{
 		{ipc.HelperRoleSystem, true},
@@ -186,8 +186,8 @@ func TestMaybeStartKeepalive_WatchdogSessionStaysAlive(t *testing.T) {
 	session.lastPongAt.Store(time.Now().Add(-time.Hour).UnixNano())
 
 	b := &Broker{
-		sessions:     map[string]*Session{session.SessionID: session},
-		byIdentity:   map[string][]*Session{session.IdentityKey: {session}},
+		sessions:   map[string]*Session{session.SessionID: session},
+		byIdentity: map[string][]*Session{session.IdentityKey: {session}},
 	}
 
 	b.maybeStartKeepalive(session, ipc.HelperRoleWatchdog)
@@ -223,8 +223,8 @@ func TestMaybeStartKeepalive_SystemSessionIsReaped(t *testing.T) {
 	}()
 
 	b := &Broker{
-		sessions:     map[string]*Session{session.SessionID: session},
-		byIdentity:   map[string][]*Session{session.IdentityKey: {session}},
+		sessions:   map[string]*Session{session.SessionID: session},
+		byIdentity: map[string][]*Session{session.IdentityKey: {session}},
 	}
 
 	b.maybeStartKeepalive(session, ipc.HelperRoleSystem)
@@ -258,8 +258,8 @@ func TestAdmitOrEvictEvictsIdleSession(t *testing.T) {
 	victim.LastSeen = now.Add(-(EvictIdleThreshold + 10*time.Second))
 
 	b := &Broker{
-		sessions:     make(map[string]*Session),
-		byIdentity:   map[string][]*Session{identity: sessions},
+		sessions:   make(map[string]*Session),
+		byIdentity: map[string][]*Session{identity: sessions},
 	}
 	for _, s := range sessions {
 		b.sessions[s.SessionID] = s
@@ -294,8 +294,8 @@ func TestAdmitOrEvictRejectsWhenAllRecent(t *testing.T) {
 	}
 
 	b := &Broker{
-		sessions:     make(map[string]*Session),
-		byIdentity:   map[string][]*Session{identity: sessions},
+		sessions:   make(map[string]*Session),
+		byIdentity: map[string][]*Session{identity: sessions},
 	}
 	for _, s := range sessions {
 		b.sessions[s.SessionID] = s
@@ -326,8 +326,8 @@ func TestKeepaliveClosesAfterRepeatedSendFailures(t *testing.T) {
 	_ = clientIPC.Close()
 
 	b := &Broker{
-		sessions:     map[string]*Session{session.SessionID: session},
-		byIdentity:   map[string][]*Session{session.IdentityKey: {session}},
+		sessions:   map[string]*Session{session.SessionID: session},
+		byIdentity: map[string][]*Session{session.IdentityKey: {session}},
 	}
 
 	done := make(chan struct{})
@@ -364,8 +364,8 @@ func TestRecvLoopDispatchesPongToNotePong(t *testing.T) {
 	}
 
 	b := &Broker{
-		sessions:     map[string]*Session{session.SessionID: session},
-		byIdentity:   map[string][]*Session{session.IdentityKey: {session}},
+		sessions:   map[string]*Session{session.SessionID: session},
+		byIdentity: map[string][]*Session{session.IdentityKey: {session}},
 	}
 
 	recvDone := make(chan struct{})
@@ -407,8 +407,8 @@ func TestAdmitOrEvictUnderCapAdmits(t *testing.T) {
 	defer client.Close()
 
 	b := &Broker{
-		sessions:     map[string]*Session{s.SessionID: s},
-		byIdentity:   map[string][]*Session{identity: {s}},
+		sessions:   map[string]*Session{s.SessionID: s},
+		byIdentity: map[string][]*Session{identity: {s}},
 	}
 
 	if !b.admitOrEvict(identity) {

--- a/agent/internal/sessionbroker/broker_test.go
+++ b/agent/internal/sessionbroker/broker_test.go
@@ -88,7 +88,7 @@ func TestSessionForUserPrefersMostRecentUserSession(t *testing.T) {
 			userSessionOld.SessionID: userSessionOld,
 			userSessionNew.SessionID: userSessionNew,
 		},
-		byIdentity:   make(map[string][]*Session),
+		byIdentity: make(map[string][]*Session),
 	}
 
 	got := b.SessionForUser("alice")
@@ -112,7 +112,7 @@ func TestSessionForUserSelectsRDPHelper(t *testing.T) {
 			consoleSession.SessionID: consoleSession,
 			rdpSession.SessionID:     rdpSession,
 		},
-		byIdentity:   make(map[string][]*Session),
+		byIdentity: make(map[string][]*Session),
 	}
 
 	if got := b.SessionForUser("alice"); got != rdpSession {
@@ -138,7 +138,7 @@ func TestLaunchProcessViaUserHelperBroadcastsToAllUserSessions(t *testing.T) {
 			olderSession.SessionID: olderSession,
 			newerSession.SessionID: newerSession,
 		},
-		byIdentity:   make(map[string][]*Session),
+		byIdentity: make(map[string][]*Session),
 	}
 
 	seen := make(chan string, 2)
@@ -204,7 +204,7 @@ func TestLaunchProcessViaUserHelperForSessionTargetsMatchingHelper(t *testing.T)
 			sessionA.SessionID: sessionA,
 			sessionB.SessionID: sessionB,
 		},
-		byIdentity:   make(map[string][]*Session),
+		byIdentity: make(map[string][]*Session),
 	}
 
 	seen := make(chan string, 1)
@@ -260,7 +260,7 @@ func TestLaunchProcessViaUserHelperForSessionTargetsMatchingRDPHelper(t *testing
 			consoleSession.SessionID: consoleSession,
 			rdpSession.SessionID:     rdpSession,
 		},
-		byIdentity:   make(map[string][]*Session),
+		byIdentity: make(map[string][]*Session),
 	}
 
 	seen := make(chan string, 1)
@@ -310,7 +310,7 @@ func TestReapIdleSessionsReapsStrandedCaptureSessions(t *testing.T) {
 		sessions: map[string]*Session{
 			session.SessionID: session,
 		},
-		byIdentity:   map[string][]*Session{session.IdentityKey: []*Session{session}},
+		byIdentity: map[string][]*Session{session.IdentityKey: []*Session{session}},
 	}
 
 	b.reapIdleSessions()
@@ -423,7 +423,7 @@ func TestPreferredSessionWithScopePrefersNewestUserHelper(t *testing.T) {
 			olderUser.SessionID:     olderUser,
 			newerUser.SessionID:     newerUser,
 		},
-		byIdentity:   make(map[string][]*Session),
+		byIdentity: make(map[string][]*Session),
 	}
 
 	got := b.PreferredSessionWithScope("run_as_user")
@@ -459,7 +459,7 @@ func TestPreferredDesktopSession_LoginWindowConsole_PrefersLoginWindowHelper(t *
 			userSession.SessionID:  userSession,
 			loginSession.SessionID: loginSession,
 		},
-		byIdentity:   make(map[string][]*Session),
+		byIdentity: make(map[string][]*Session),
 	}
 
 	// Without console user set, user_session wins (existing behavior).
@@ -503,7 +503,7 @@ func TestPreferredDesktopSession_LoggedInConsole_PrefersUserSession(t *testing.T
 			userSession.SessionID:  userSession,
 			loginSession.SessionID: loginSession,
 		},
-		byIdentity:   make(map[string][]*Session),
+		byIdentity: make(map[string][]*Session),
 	}
 
 	// With a real user logged in, user_session should still win.
@@ -532,7 +532,7 @@ func TestPreferredDesktopSession_LoginWindowConsole_OnlyLoginHelpers(t *testing.
 		sessions: map[string]*Session{
 			userSession.SessionID: userSession,
 		},
-		byIdentity:   make(map[string][]*Session),
+		byIdentity: make(map[string][]*Session),
 	}
 
 	b.SetConsoleUser("loginwindow")
@@ -574,7 +574,7 @@ func TestPreferredDesktopSession_LoginWindow_DeterministicRegardlessOfOrder(t *t
 				userSession.SessionID:  userSession,
 				loginSession.SessionID: loginSession,
 			},
-			byIdentity:   make(map[string][]*Session),
+			byIdentity: make(map[string][]*Session),
 		}
 		b.SetConsoleUser("loginwindow")
 
@@ -615,7 +615,7 @@ func TestCloseSessionsByDesktopContext(t *testing.T) {
 			loginSession.SessionID:  loginSession,
 			notifySession.SessionID: notifySession,
 		},
-		byIdentity:   make(map[string][]*Session),
+		byIdentity: make(map[string][]*Session),
 	}
 
 	closed := b.CloseSessionsByDesktopContext(ipc.DesktopContextUserSession)
@@ -676,7 +676,7 @@ func TestCloseSessionsByDesktopContext_MultipleMatches(t *testing.T) {
 			sess2.SessionID:     sess2,
 			loginSess.SessionID: loginSess,
 		},
-		byIdentity:   make(map[string][]*Session),
+		byIdentity: make(map[string][]*Session),
 	}
 
 	closed := b.CloseSessionsByDesktopContext(ipc.DesktopContextUserSession)
@@ -1127,7 +1127,7 @@ func TestConsentUIFallbackScopeGrant(t *testing.T) {
 	b := &Broker{}
 	tests := []struct {
 		name            string
-		role            string
+		role            ipc.HelperRole
 		supportsConsent bool
 		wantFallback    bool
 	}{

--- a/agent/internal/sessionbroker/broker_test.go
+++ b/agent/internal/sessionbroker/broker_test.go
@@ -310,7 +310,7 @@ func TestReapIdleSessionsReapsStrandedCaptureSessions(t *testing.T) {
 		sessions: map[string]*Session{
 			session.SessionID: session,
 		},
-		byIdentity: map[string][]*Session{session.IdentityKey: []*Session{session}},
+		byIdentity: map[string][]*Session{session.IdentityKey: {session}},
 	}
 
 	b.reapIdleSessions()

--- a/agent/internal/sessionbroker/broker_windows_test.go
+++ b/agent/internal/sessionbroker/broker_windows_test.go
@@ -582,7 +582,7 @@ func TestNamedPipeSessionIDCollisionRejected(t *testing.T) {
 func TestAssistRoleRejectsSystemSID(t *testing.T) {
 	cases := []struct {
 		name       string
-		role       string
+		role       ipc.HelperRole
 		sid        string
 		wantReason string
 		wantReject bool

--- a/agent/internal/sessionbroker/console_session_gate_test.go
+++ b/agent/internal/sessionbroker/console_session_gate_test.go
@@ -12,8 +12,10 @@ func TestRoleIdentityRejection(t *testing.T) {
 	const nonSystemSID = "S-1-5-21-1-2-3-1001"
 
 	tests := []struct {
-		name, role, sid, peer, claimed, console, wantReason string
-		wantReject                                          bool
+		name                                    string
+		role                                    ipc.HelperRole
+		sid, peer, claimed, console, wantReason string
+		wantReject                              bool
 	}{
 		{"RDP user matching kernel session", ipc.HelperRoleUser, nonSystemSID, "7", "7", "1", "", false},
 		{"RDP user session mismatch", ipc.HelperRoleUser, nonSystemSID, "7", "8", "1", "user role session claim does not match peer token", true},
@@ -258,7 +260,7 @@ func TestPreferredRunAsUserSessionWarnsWhenConsoleLookupFailed(t *testing.T) {
 		sessions: map[string]*Session{
 			helper.SessionID: helper,
 		},
-		byIdentity:   make(map[string][]*Session),
+		byIdentity: make(map[string][]*Session),
 		// "0" is the WTSGetActiveConsoleSessionId failure / Session-0 sentinel,
 		// normalized to "" by ConsoleSessionID().
 		consoleSessionIDFn: func() string { return "0" },

--- a/agent/internal/sessionbroker/helper_job_windows_test.go
+++ b/agent/internal/sessionbroker/helper_job_windows_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/breeze-rmm/agent/internal/ipc"
 	"golang.org/x/sys/windows"
 )
 
@@ -324,7 +325,7 @@ func TestWindowsHelperSpawnerWarnsBeforeRepeatedCreateFailures(t *testing.T) {
 	createErr := errors.New("CreateProcessAsUser failed")
 	tests := []struct {
 		name         string
-		role         string
+		role         ipc.HelperRole
 		resolved     ResolvedHelperExecutable
 		wantWarnings int
 	}{

--- a/agent/internal/sessionbroker/helper_key.go
+++ b/agent/internal/sessionbroker/helper_key.go
@@ -9,7 +9,7 @@ import (
 
 type HelperKey struct {
 	WindowsSessionID uint32
-	Role             string
+	Role             ipc.HelperRole
 }
 
 // helperRoleSpawnable reports whether role is one the lifecycle manager may
@@ -20,7 +20,7 @@ type HelperKey struct {
 // level from the role. Anything that is not exactly ipc.HelperRoleUser would
 // otherwise take the SYSTEM-token branch, so an empty or misspelled role
 // silently escalates.
-func helperRoleSpawnable(role string) bool {
+func helperRoleSpawnable(role ipc.HelperRole) bool {
 	return role == ipc.HelperRoleSystem || role == ipc.HelperRoleUser
 }
 
@@ -28,21 +28,21 @@ func (k HelperKey) String() string {
 	return fmt.Sprintf("%d-%s", k.WindowsSessionID, k.Role)
 }
 
-func helperRoleDesired(s DetectedSession, role string) bool {
+func helperRoleDesired(s DetectedSession, role ipc.HelperRole) bool {
 	if s.Session == "0" || s.Type == "services" {
 		return false
 	}
 	switch role {
-	case "system":
+	case ipc.HelperRoleSystem:
 		return s.State == "active" || s.State == "connected" || (s.Type == "rdp" && s.State == "disconnected")
-	case "user":
+	case ipc.HelperRoleUser:
 		return s.State == "active"
 	default:
 		return false
 	}
 }
 
-func helperKeyFromDetected(s DetectedSession, role string) (HelperKey, bool) {
+func helperKeyFromDetected(s DetectedSession, role ipc.HelperRole) (HelperKey, bool) {
 	if !helperRoleDesired(s, role) {
 		return HelperKey{}, false
 	}

--- a/agent/internal/sessionbroker/helper_key_test.go
+++ b/agent/internal/sessionbroker/helper_key_test.go
@@ -1,12 +1,16 @@
 package sessionbroker
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
 
 func TestHelperRoleDesired(t *testing.T) {
 	tests := []struct {
 		name string
 		s    DetectedSession
-		role string
+		role ipc.HelperRole
 		want bool
 	}{
 		{"system active", DetectedSession{Session: "7", State: "active", Type: "rdp"}, "system", true},

--- a/agent/internal/sessionbroker/lifecycle.go
+++ b/agent/internal/sessionbroker/lifecycle.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
 )
 
 const (
@@ -96,8 +98,8 @@ func (m *HelperLifecycleManager) handleSCMEvent(event SCMSessionEvent) {
 	if event.SessionID == 0 {
 		return
 	}
-	systemKey := HelperKey{WindowsSessionID: event.SessionID, Role: "system"}
-	userKey := HelperKey{WindowsSessionID: event.SessionID, Role: "user"}
+	systemKey := HelperKey{WindowsSessionID: event.SessionID, Role: ipc.HelperRoleSystem}
+	userKey := HelperKey{WindowsSessionID: event.SessionID, Role: ipc.HelperRoleUser}
 	switch event.EventType {
 	// Session became usable. Reconnect (console 0x1 / remote 0x3) belongs here:
 	// the session already exists and the user never logged off, so no

--- a/agent/internal/sessionbroker/lifecycle_core.go
+++ b/agent/internal/sessionbroker/lifecycle_core.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
 )
 
 const (
@@ -184,10 +186,10 @@ func (m *HelperLifecycleManager) detectedDesired() (map[HelperKey]bool, error) {
 	}
 	desired := make(map[HelperKey]bool, len(sessions)*2)
 	for _, session := range sessions {
-		if key, ok := helperKeyFromDetected(session, "system"); ok {
+		if key, ok := helperKeyFromDetected(session, ipc.HelperRoleSystem); ok {
 			desired[key] = true
 		}
-		if key, ok := helperKeyFromDetected(session, "user"); ok {
+		if key, ok := helperKeyFromDetected(session, ipc.HelperRoleUser); ok {
 			desired[key] = true
 		}
 	}
@@ -310,7 +312,7 @@ func (m *HelperLifecycleManager) spawnKey(key HelperKey) {
 		log.Warn("lifecycle: failed to spawn helper", "helperKey", key.String(), "error", err.Error())
 		return
 	}
-	mode := key.Role + "-helper"
+	mode := string(key.Role) + "-helper"
 	entry, attached := m.registry.attachReserved(key, generation, process, mode)
 	if !attached {
 		_ = process.Terminate()
@@ -351,9 +353,9 @@ func (m *HelperLifecycleManager) watchDetachedProcess(key HelperKey, generation 
 }
 
 func (m *HelperLifecycleManager) stopSession(sessionID uint32) {
-	m.removeDesired(HelperKey{WindowsSessionID: sessionID, Role: "system"}, HelperKey{WindowsSessionID: sessionID, Role: "user"})
-	m.stopKey(HelperKey{WindowsSessionID: sessionID, Role: "user"})
-	m.stopKey(HelperKey{WindowsSessionID: sessionID, Role: "system"})
+	m.removeDesired(HelperKey{WindowsSessionID: sessionID, Role: ipc.HelperRoleSystem}, HelperKey{WindowsSessionID: sessionID, Role: ipc.HelperRoleUser})
+	m.stopKey(HelperKey{WindowsSessionID: sessionID, Role: ipc.HelperRoleUser})
+	m.stopKey(HelperKey{WindowsSessionID: sessionID, Role: ipc.HelperRoleSystem})
 }
 
 func (m *HelperLifecycleManager) removeDesired(keys ...HelperKey) {
@@ -500,7 +502,7 @@ func (m *HelperLifecycleManager) sessionClosed(session *Session) {
 }
 
 func helperKeyFromSession(session *Session) (HelperKey, bool) {
-	if session == nil || (session.HelperRole != "system" && session.HelperRole != "user") {
+	if session == nil || (session.HelperRole != ipc.HelperRoleSystem && session.HelperRole != ipc.HelperRoleUser) {
 		return HelperKey{}, false
 	}
 	id, err := strconv.ParseUint(session.WinSessionID, 10, 32)

--- a/agent/internal/sessionbroker/lifecycle_registry.go
+++ b/agent/internal/sessionbroker/lifecycle_registry.go
@@ -3,6 +3,8 @@ package sessionbroker
 import (
 	"sync"
 	"time"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
 )
 
 type helperState string
@@ -276,7 +278,7 @@ func (r *helperRegistry) startupExpired(key HelperKey, now time.Time, timeout ti
 func (r *helperRegistry) clearFatal(sessionID uint32) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for _, role := range []string{"system", "user"} {
+	for _, role := range []ipc.HelperRole{ipc.HelperRoleSystem, ipc.HelperRoleUser} {
 		if entry := r.current[HelperKey{WindowsSessionID: sessionID, Role: role}]; entry != nil {
 			entry.fatalExitUntil = time.Time{}
 		}

--- a/agent/internal/sessionbroker/lifecycle_registry_test.go
+++ b/agent/internal/sessionbroker/lifecycle_registry_test.go
@@ -1,11 +1,13 @@
 package sessionbroker
 
 import (
-	"errors"
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
 )
 
 func TestSessionAuthenticatedMarksOnlyCurrentBrokerOwnerConnected(t *testing.T) {
@@ -290,7 +292,7 @@ func TestLifecycleBootstrapPublishesDesiredKeysBeforeSpawning(t *testing.T) {
 	if err := m.Bootstrap(); err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
-	for _, role := range []string{"system", "user"} {
+	for _, role := range []ipc.HelperRole{ipc.HelperRoleSystem, ipc.HelperRoleUser} {
 		key := HelperKey{WindowsSessionID: 7, Role: role}
 		if !b.helperKeyDesired(key) {
 			t.Fatalf("%s key was not published by bootstrap", role)

--- a/agent/internal/sessionbroker/pam_approval_test.go
+++ b/agent/internal/sessionbroker/pam_approval_test.go
@@ -77,7 +77,7 @@ func TestRequestPamApprovalTimeoutDeniesAndDismisses(t *testing.T) {
 func TestRequestPamApprovalRequiresSystemPamSession(t *testing.T) {
 	tests := []struct {
 		name    string
-		role    string
+		role    ipc.HelperRole
 		scopes  []string
 		wantErr string
 	}{

--- a/agent/internal/sessionbroker/pam_dismiss_test.go
+++ b/agent/internal/sessionbroker/pam_dismiss_test.go
@@ -60,7 +60,7 @@ func TestDismissPamConsentReturnsCorrelatedHelperResult(t *testing.T) {
 func TestDismissPamConsentRequiresSystemPamSession(t *testing.T) {
 	tests := []struct {
 		name    string
-		role    string
+		role    ipc.HelperRole
 		scopes  []string
 		wantErr string
 	}{

--- a/agent/internal/sessionbroker/rds_lifecycle_integration_test.go
+++ b/agent/internal/sessionbroker/rds_lifecycle_integration_test.go
@@ -175,7 +175,7 @@ func TestRDSBrokerAdmissionAndLifecycleConvergeTwentySessions(t *testing.T) {
 		desired := make(map[HelperKey]struct{}, MaxConnectionsPerIdentity+1)
 		keys := make([]HelperKey, 0, MaxConnectionsPerIdentity+1)
 		for slot := 1; slot <= MaxConnectionsPerIdentity+1; slot++ {
-			key := HelperKey{WindowsSessionID: windowsSessionID, Role: fmt.Sprintf("pre-auth-%d", slot)}
+			key := HelperKey{WindowsSessionID: windowsSessionID, Role: ipc.HelperRole(fmt.Sprintf("pre-auth-%d", slot))}
 			desired[key] = struct{}{}
 			keys = append(keys, key)
 		}

--- a/agent/internal/sessionbroker/session.go
+++ b/agent/internal/sessionbroker/session.go
@@ -31,8 +31,8 @@ type Session struct {
 	Capabilities   *ipc.Capabilities
 	TCCStatus      *ipc.TCCStatus
 	AllowedScopes  []string
-	WinSessionID   string // Windows session ID string (e.g., "1", "2") for targeting
-	HelperRole     string // "system" or "user" — determines scopes and capabilities
+	WinSessionID   string         // Windows session ID string (e.g., "1", "2") for targeting
+	HelperRole     ipc.HelperRole // "system" or "user" — determines scopes and capabilities
 	BinaryKind     string
 	DesktopContext string
 	ConnectedAt    time.Time
@@ -414,7 +414,7 @@ type SessionInfo struct {
 	ConnectedAt    time.Time         `json:"connectedAt"`
 	LastSeen       time.Time         `json:"lastSeen"`
 	WinSessionID   string            `json:"winSessionId,omitempty"`
-	HelperRole     string            `json:"helperRole,omitempty"`
+	HelperRole     ipc.HelperRole    `json:"helperRole,omitempty"`
 	BinaryKind     string            `json:"binaryKind,omitempty"`
 	DesktopContext string            `json:"desktopContext,omitempty"`
 }

--- a/agent/internal/sessionbroker/spawner_cmdline.go
+++ b/agent/internal/sessionbroker/spawner_cmdline.go
@@ -1,12 +1,16 @@
 package sessionbroker
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
 
 // buildUserHelperCmdLine constructs the command line passed to
 // CreateProcessAsUser when the broker spawns a user-helper child. The role
 // flag is always set explicitly so the child never inherits the cobra default
 // — that default has been flipped twice (PR #549) and the SYSTEM-context
 // helper crash-looped both times.
-func buildUserHelperCmdLine(exePath, role string) string {
+func buildUserHelperCmdLine(exePath string, role ipc.HelperRole) string {
 	return fmt.Sprintf(`"%s" user-helper --role %s`, exePath, role)
 }

--- a/agent/internal/sessionbroker/spawner_cmdline_test.go
+++ b/agent/internal/sessionbroker/spawner_cmdline_test.go
@@ -23,14 +23,14 @@ import (
 // never load-bearing again.
 func TestBuildUserHelperCmdLine_AlwaysExplicitRole(t *testing.T) {
 	cases := []struct {
-		role       string
+		role       ipc.HelperRole
 		wantSubstr string
 	}{
 		{"system", "--role system"},
 		{"user", "--role user"},
 	}
 	for _, tc := range cases {
-		t.Run(tc.role, func(t *testing.T) {
+		t.Run(string(tc.role), func(t *testing.T) {
 			got := buildUserHelperCmdLine(`C:\Program Files\Breeze\breeze-agent.exe`, tc.role)
 			if !strings.Contains(got, tc.wantSubstr) {
 				t.Fatalf("cmdline missing %q: got %q", tc.wantSubstr, got)
@@ -72,7 +72,7 @@ func TestSpawnedHelperDiagnosticsRetainRoleProvenance(t *testing.T) {
 func TestHelperRoleSpawnableRejectsNonLifecycleRoles(t *testing.T) {
 	tests := []struct {
 		name string
-		role string
+		role ipc.HelperRole
 		want bool
 	}{
 		{"system role spawnable", ipc.HelperRoleSystem, true},

--- a/agent/internal/sessionbroker/spawner_stub.go
+++ b/agent/internal/sessionbroker/spawner_stub.go
@@ -2,7 +2,11 @@
 
 package sessionbroker
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
 
 // SpawnedHelper is only populated on Windows. On other platforms helper
 // spawning is handled by OS-level mechanisms (launchd LaunchAgent, systemd
@@ -17,7 +21,7 @@ type SpawnedHelper struct {
 	PID                uint32
 	BinaryPath         string
 	CommandMode        string
-	Role               string
+	Role               ipc.HelperRole
 	WindowsSessionID   uint32
 	MainBinaryFallback bool
 }
@@ -35,7 +39,7 @@ func (s *SpawnedHelper) Alive() (bool, error) {
 	return false, fmt.Errorf("SpawnedHelper: helper tracking not supported on this platform")
 }
 
-func (s *SpawnedHelper) Terminate() error       { return nil }
+func (s *SpawnedHelper) Terminate() error { return nil }
 
 // Wait is a no-op on non-Windows platforms. Returns (exitCode=-1, nil).
 func (s *SpawnedHelper) Wait() (int, error) { return -1, nil }

--- a/agent/internal/sessionbroker/spawner_windows.go
+++ b/agent/internal/sessionbroker/spawner_windows.go
@@ -27,7 +27,7 @@ type SpawnedHelper struct {
 	Handle             windows.Handle
 	BinaryPath         string
 	CommandMode        string
-	Role               string
+	Role               ipc.HelperRole
 	WindowsSessionID   uint32
 	MainBinaryFallback bool
 	mu                 sync.Mutex
@@ -387,7 +387,7 @@ func createSystemHelperSuspended(sessionID uint32, resolvedExe ResolvedHelperExe
 		return nil, fmt.Errorf("SetTokenInformation(TokenSessionId=%d): %w", sessionID, err)
 	}
 
-	cmdLine, err := windows.UTF16PtrFromString(buildUserHelperCmdLine(resolvedExe.Path, "system"))
+	cmdLine, err := windows.UTF16PtrFromString(buildUserHelperCmdLine(resolvedExe.Path, ipc.HelperRoleSystem))
 	if err != nil {
 		return nil, fmt.Errorf("UTF16PtrFromString: %w", err)
 	}
@@ -448,7 +448,7 @@ func createUserHelperSuspended(sessionID uint32, resolvedExe ResolvedHelperExecu
 		defer windows.DestroyEnvironmentBlock(envBlock)
 	}
 
-	cmdLine, err := windows.UTF16PtrFromString(buildUserHelperCmdLine(resolvedExe.Path, "user"))
+	cmdLine, err := windows.UTF16PtrFromString(buildUserHelperCmdLine(resolvedExe.Path, ipc.HelperRoleUser))
 	if err != nil {
 		return nil, fmt.Errorf("UTF16PtrFromString: %w", err)
 	}
@@ -478,13 +478,13 @@ func createUserHelperSuspended(sessionID uint32, resolvedExe ResolvedHelperExecu
 // creates a private one-process Job Object and transfers that spawner to the
 // returned helper so Close releases the Job after the process exits.
 func SpawnHelperInSession(sessionID uint32) (*SpawnedHelper, error) {
-	return spawnStandaloneHelper(HelperKey{WindowsSessionID: sessionID, Role: "system"})
+	return spawnStandaloneHelper(HelperKey{WindowsSessionID: sessionID, Role: ipc.HelperRoleSystem})
 }
 
 // SpawnUserHelperInSession is the user-token counterpart to
 // SpawnHelperInSession.
 func SpawnUserHelperInSession(sessionID uint32) (*SpawnedHelper, error) {
-	return spawnStandaloneHelper(HelperKey{WindowsSessionID: sessionID, Role: "user"})
+	return spawnStandaloneHelper(HelperKey{WindowsSessionID: sessionID, Role: ipc.HelperRoleUser})
 }
 
 func spawnStandaloneHelper(key HelperKey) (*SpawnedHelper, error) {

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -46,7 +46,7 @@ const (
 // Client is the user-helper side of the IPC connection to the root daemon.
 type Client struct {
 	socketPath string
-	role       string // "system" or "user"
+	role       ipc.HelperRole // "system" or "user"
 	binaryKind string
 	context    string
 	conn       *ipc.Conn
@@ -84,11 +84,11 @@ func (c *Client) setAuthenticatedAt(t time.Time) {
 
 // New creates a new user helper client with the given role.
 // Role should be ipc.HelperRoleSystem or ipc.HelperRoleUser.
-func New(socketPath, role string) *Client {
+func New(socketPath string, role ipc.HelperRole) *Client {
 	return NewWithOptions(socketPath, role, "", "")
 }
 
-func NewWithOptions(socketPath, role, binaryKind, context string) *Client {
+func NewWithOptions(socketPath string, role ipc.HelperRole, binaryKind, context string) *Client {
 	if role == "" {
 		role = ipc.HelperRoleSystem
 	}

--- a/agent/internal/userhelper/pam_dismiss_test.go
+++ b/agent/internal/userhelper/pam_dismiss_test.go
@@ -35,7 +35,7 @@ func (s *stubPamDismissActuator) Dismiss(ctx context.Context) pamactuator.Result
 	return s.dismissResult
 }
 
-func newPamDismissPipe(t *testing.T, role string, scopes ...string) (*Client, *ipc.Conn) {
+func newPamDismissPipe(t *testing.T, role ipc.HelperRole, scopes ...string) (*Client, *ipc.Conn) {
 	t.Helper()
 
 	helperConn, peerConn := net.Pipe()
@@ -157,7 +157,7 @@ func TestHandlePamDismissConsentPreservesNonSuccessResult(t *testing.T) {
 func TestHandlePamDismissConsentRejectsUnauthorizedHelpers(t *testing.T) {
 	tests := []struct {
 		name   string
-		role   string
+		role   ipc.HelperRole
 		scopes []string
 	}{
 		{name: "wrong role", role: ipc.HelperRoleUser, scopes: []string{ipc.ScopePam}},


### PR DESCRIPTION
## Summary

Tech-debt cleanup from #2532: the helper "role" was passed around as a bare `string` end-to-end. This introduces `type HelperRole string` in `internal/ipc`, redefines the four role constants (`system`/`user`/`watchdog`/`assist`) against it, and threads the typed role through every carrier and signature. Bare `"system"`/`"user"` role literals in the spawn/lifecycle/classification paths are replaced with the constants.

### What changed

- **`internal/ipc/message.go`** — new `type HelperRole string`; the four consts are now typed; `AuthRequest.HelperRole` is `HelperRole` (still marshals as a plain JSON string).
- **Threaded the typed role through** the struct fields and function signatures that carry it: `Session.HelperRole`, `SpawnedHelper.Role` (windows + stub), `HelperKey.Role`, `ProcessStartup.HelperRole` (+ the windows lock-metadata mirror), `userhelper.Client.role` / `New` / `NewWithOptions`, and the broker/lifecycle/admission helpers (`helperRoleSpawnable`, `helperRoleDesired`, `helperKeyFromDetected`, `roleSupportsKeepalive`, `maybeStartKeepalive`, `HasHelperForWinSessionRole`, `roleIdentityRejection`, `scopesForRole`, `grantScopes`, `helperAdmissionIdentityKey`, `isWindowsLifecycleRole`, `registerNonLifecycleSession`, `buildUserHelperCmdLine`, `desktopHelperRole`, `runHelperProcess`, `classifyProcess`, `currentProcessStartup`).
- **Dropped bare literals** in `helper_key.go`, `lifecycle.go`, `lifecycle_core.go`, `lifecycle_registry.go`, `spawner_windows.go`, and tied the cobra `--role` default to `string(ipc.HelperRoleUser)`.
- **Conversions are forced only at true boundaries**: the CLI flag (`ipc.HelperRole(helperRole)`) and synthetic test roles. `string(role)` is used where a role is concatenated/formatted into a plain string.

### Design note (per the issue)

The named type intentionally does **not** add exhaustiveness — `HelperRole("sytem")` still compiles — so the existing safety gates (`helperRoleSpawnable` allow-list, fail-closed switch `default`s, `scopesForRole`) remain the real protection. The value here is documentation and boundary clarity, exactly as the issue framed the tradeoff. `backupipc.HelperRoleBackup` stays an untyped string constant in its own package and converts implicitly in switch/assignment contexts (no import-cycle churn).

## Testing

- `go build ./...` green for `linux`, `windows`, and `darwin`.
- `go vet ./...` clean on linux and windows (only pre-existing `unsafe.Pointer` heuristics in unrelated COM files remain).
- Affected package tests pass: `internal/sessionbroker`, `internal/agentapp`, `internal/userhelper`, `internal/ipc`, `internal/watchdog`. Windows-tagged test binaries cross-compile clean. (`-race` unavailable in this env — no C compiler — but this is a type-only refactor with no behavior change.)

Closes #2532

🤖 Generated with [Claude Code](https://claude.com/claude-code)