### PR TITLE
fix(api): stop the agent command poll from double-holding pooled DB connections

### DIFF
--- a/apps/api/src/middleware/agentAuth.test.ts
+++ b/apps/api/src/middleware/agentAuth.test.ts
@@ -340,6 +340,42 @@ describe('agentAuthMiddleware - tenant-status gate', () => {
     expect(next).toHaveBeenCalledTimes(1);
     expect(vi.mocked(withDbAccessContext)).not.toHaveBeenCalled();
   });
+
+  // #1105 — the GET command poll claims commands inside its own
+  // withSystemDbAccessContext (see routes/agents/commands.ts). Wrapping the
+  // request in the org transaction on top made every poll hold TWO pooled
+  // connections at once and self-deadlocked the pool under load (US prod
+  // outage, 2026-07-24), so the middleware must NOT add the request-long wrap.
+  it('skips the request-long org wrap for the self-managed commands poll route', async () => {
+    buildSelectMock([makeDevice()]);
+    vi.mocked(isAgentTenantActive).mockResolvedValue(true);
+
+    const c = createContext({ token: VALID_TOKEN, path: '/api/v1/agents/agent-1/commands' });
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await agentAuthMiddleware(c, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(withDbAccessContext)).not.toHaveBeenCalled();
+  });
+
+  // The command RESULT route ends in `result`, not `commands` — it must keep
+  // the request-long org wrap.
+  it('keeps the request-long org wrap for the command result route', async () => {
+    buildSelectMock([makeDevice()]);
+    vi.mocked(isAgentTenantActive).mockResolvedValue(true);
+
+    const c = createContext({
+      token: VALID_TOKEN,
+      path: '/api/v1/agents/agent-1/commands/cmd-1/result',
+    });
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await agentAuthMiddleware(c, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(withDbAccessContext)).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('agentAuthMiddleware - per-org rate limit', () => {

--- a/apps/api/src/middleware/agentAuth.ts
+++ b/apps/api/src/middleware/agentAuth.ts
@@ -248,8 +248,18 @@ export async function suspendAgentToken(deviceId: string, reason: AgentTokenSusp
  * their DB work instead of relying on the request-long wrap in
  * agentAuthMiddleware. See the #1105 note at the wrap site. Auth still runs in
  * full for these routes — only the org-context transaction wrap is skipped.
+ *
+ * `commands` (the GET command poll) is here because its handler claims commands
+ * inside its own `withSystemDbAccessContext` — the same claim+decrypt path the
+ * self-managed heartbeat route already runs context-free. Keeping the
+ * request-long org wrap on top made every poll hold TWO pooled connections at
+ * once (`runOutsideDbContext` does not release the outer transaction), which
+ * self-deadlocked the pool under load: all slots pinned by outer transactions
+ * parked idle-in-transaction waiting for an inner connection, reaped at the
+ * 60s idle_in_transaction_session_timeout as `500 @60s`, re-polled by agents,
+ * repeat (US prod outage, 2026-07-24).
  */
-const SELF_MANAGED_DB_CONTEXT_ACTIONS = new Set(['heartbeat', 'reliability']);
+const SELF_MANAGED_DB_CONTEXT_ACTIONS = new Set(['heartbeat', 'reliability', 'commands']);
 
 /**
  * Middleware to authenticate agent requests via Bearer token.


### PR DESCRIPTION
## Incident

US prod web UI hung on 2026-07-24. Root cause was app-side DB pool self-deadlock, not infra: `pg_stat_activity` showed **20/20 pool slots** (`DB_POOL_MAX=20`) stuck `idle in transaction`, all parked at the last RLS `set_config` with `wait_event=ClientRead`, reaped every 60s by `idle_in_transaction_session_timeout` as `500 @60s` (~160× `GET /agents/:id/commands 500 @60-64s` per 10 min, plus the dashboard's own `GET /audit-logs/logs 500 @60s` — the visible UI hang). Each reap triggered an immediate agent re-poll, so the spiral sustained itself.

## Root cause

`GET /api/v1/agents/:id/commands` claims commands inside its own `withSystemDbAccessContext`, but `agentAuthMiddleware` also wrapped the whole request in a request-long org-scope `withDbAccessContext`. `runOutsideDbContext` does **not** release the already-open outer transaction, so every poll held **two** pooled connections at once. At ~224 polls/10min × 60s hold ≈ 22 concurrent ≥ 20 slots: all slots fill with outer transactions waiting for an inner connection that can never be acquired. The wrap-site comment in `agentAuth.ts` predicted exactly this ("self-deadlocks the pool under a mass agent reconnect").

## Fix

Add `commands` to `SELF_MANAGED_DB_CONTEXT_ACTIONS` (the #1105 carve-out). Safety: the self-managed **heartbeat** route already runs the *identical* `claimPendingCommandsForDevice` + `decryptClaimedCommandsForDelivery` path context-free in production (hundreds of 200s per 10 min during the incident), so the handler provably needs nothing from the outer wrap. The command **result** route ends in `result`, so it keeps the request-long wrap.

Repo-wide sweep confirmed the GET poll is the only agent-authed route whose final path segment is `commands`.

## Tests

- New regression test: middleware skips the request-long org wrap for `/agents/:id/commands`.
- New guard test: `/agents/:id/commands/:commandId/result` still gets the wrap.
- `agentAuth.test.ts` + `commands.test.ts` + `agentAuthSkip.test.ts`: 57/57 pass; `tsc --noEmit` clean.

## Ops notes (already applied on breeze-us, config-only)

- `DB_POOL_MAX` bumped 20 → 35 in `/opt/breeze/.env` (server `max_connections=50`) + api recreate — this broke the live spiral; pool now cycles all-idle with sub-second holds. The bump is defense-in-depth; this PR removes the deadlock mechanism itself.

Follow-ups (separate): move `logs` / `unifi-collectors` / `process-sample` off the request-long wrap (need per-handler contexts), `device_ip_history` deadlocks on the agent write path, and the ~40% agent 401/403 churn that likely triggered the mass-reconnect condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)