### PR TITLE
fix(api): restore red main — portal test schema mocks missing discoveredAssetTypeEnum

### DIFF
--- a/apps/api/src/routes/portal.compat.test.ts
+++ b/apps/api/src/routes/portal.compat.test.ts
@@ -35,6 +35,9 @@ vi.mock('../db', () => ({
 vi.mock('../db/schema', () => ({
   assetCheckouts: {},
   devices: {},
+  // networkBaseline.ts (pulled in transitively by the portal route graph) reads
+  // discoveredAssetTypeEnum.enumValues at module load — required for the mock.
+  discoveredAssetTypeEnum: { enumValues: [] },
   portalBranding: {
     id: 'portalBranding.id',
     customDomain: 'portalBranding.customDomain',

--- a/apps/api/src/routes/portal.test.ts
+++ b/apps/api/src/routes/portal.test.ts
@@ -66,6 +66,10 @@ vi.mock('../services/ticketService', () => ({
 vi.mock('../db/schema', () => ({
   assetCheckouts: {},
   devices: {},
+  // The portal route graph transitively imports networkBaseline.ts, which reads
+  // discoveredAssetTypeEnum.enumValues at module load — the full-module mock must
+  // provide it or the whole suite fails to load.
+  discoveredAssetTypeEnum: { enumValues: [] },
   portalBranding: {},
   portalUsers: {},
   ticketComments: {},

--- a/apps/api/src/routes/portal/acceptInvite.test.ts
+++ b/apps/api/src/routes/portal/acceptInvite.test.ts
@@ -14,7 +14,10 @@ vi.mock('../../db', () => ({
   withDbAccessContext: (_ctx: any, fn: any) => fn(),
   withSystemDbAccessContext: (fn: any) => fn()
 }));
-vi.mock('../../db/schema', () => ({ portalUsers: { id: 'id', orgId: 'orgId', email: 'email', name: 'name', passwordHash: 'passwordHash', receiveNotifications: 'receiveNotifications', status: 'status' } }));
+// discoveredAssetTypeEnum: networkBaseline.ts (transitive import of the portal
+// route graph) reads its .enumValues at module load, so the full-module mock
+// must provide it or the suite fails to load.
+vi.mock('../../db/schema', () => ({ discoveredAssetTypeEnum: { enumValues: [] }, portalUsers: { id: 'id', orgId: 'orgId', email: 'email', name: 'name', passwordHash: 'passwordHash', receiveNotifications: 'receiveNotifications', status: 'status' } }));
 vi.mock('../../services/email', () => ({ getEmailService: () => null }));
 
 import { authRoutes } from './auth';


### PR DESCRIPTION
## Problem
`Test API` is **red on `main`**. Three portal suites fail to *load*:

- `apps/api/src/routes/portal.test.ts`
- `apps/api/src/routes/portal.compat.test.ts`
- `apps/api/src/routes/portal/acceptInvite.test.ts`

Each replaces `../db/schema` with a full-module `vi.mock`. The portal route graph transitively imports `services/networkBaseline.ts`, which evaluates `new Set(discoveredAssetTypeEnum.enumValues)` **at module load** (`networkBaseline.ts:83`). The mocks omitted `discoveredAssetTypeEnum`, so loading the suite throws:

> Error: [vitest] No "discoveredAssetTypeEnum" export is defined on the "../db/schema" mock.

This is the known 'drizzle enumValues breaks a hand-rolled schema mock' failure mode — the mock is authoritative for the whole module, so any symbol read at load time must be present.

## Fix
Add `discoveredAssetTypeEnum: { enumValues: [] }` to all three mocks. `enumValues` only needs to be iterable for the `Set` construction; the empty array is sufficient because portal paths never call `normalizeAssetType`. Confirmed it is the *only* module-load-time schema read in the `networkBaseline`/`discoveryWorker` chain, so the fix does not just move the crash.

## Verification
`npx vitest run` on the 3 suites → **3 files / 39 tests passed** (Node 22.20.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)