### PR TITLE
fix(watchdog): stop restart-looping healthy agents and stranding them stopped

### DIFF
--- a/agent/cmd/breeze-watchdog/main.go
+++ b/agent/cmd/breeze-watchdog/main.go
@@ -589,7 +589,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 			}
 
 		case env := <-ipcMessages:
-			handleIPCMessage(env, wd, journal, cfg, tokenStore)
+			handleIPCMessage(env, wd, journal, cfg, tokenStore, healthChecker)
 
 		case <-failoverTicker.C:
 			// Only poll in FAILOVER state.
@@ -642,6 +642,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 				journal.Log(watchdog.LevelError, "recovery.flap_detected", map[string]any{
 					"count_24h": recovery.Count24h(),
 				})
+				ensureAgentStartedBeforeFailover(runCtx, recovery, journal)
 				wd.HandleEvent(watchdog.EventRecoveryExhausted)
 				break
 			}
@@ -650,6 +651,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 				journal.Log(watchdog.LevelError, "recovery.exhausted", map[string]any{
 					"attempts": recovery.Attempts(),
 				})
+				ensureAgentStartedBeforeFailover(runCtx, recovery, journal)
 				wd.HandleEvent(watchdog.EventRecoveryExhausted)
 				break
 			}
@@ -690,6 +692,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 
 			if shouldFailoverRecovery(result) {
 				pendingVerify = nil
+				ensureAgentStartedBeforeFailover(runCtx, recovery, journal)
 				wd.HandleEvent(watchdog.EventRecoveryExhausted)
 			} else if shouldVerifyRecovery(result, err) {
 				pendingVerify = &struct{ startedAt time.Time }{startedAt: time.Now()}
@@ -698,6 +701,25 @@ func runWatchdog(stopCh <-chan struct{}) {
 		case watchdog.StateFailover:
 			if pendingVerify != nil {
 				pendingVerify = nil
+			}
+			// Self-recovery: if the agent is demonstrably healthy — live IPC
+			// AND a fresh heartbeat from any source (state file or IPC
+			// state_sync) — leave FAILOVER. Without this the only exits were
+			// a server-delivered command (useless when the server or the
+			// poll channel is down) and an IPC *re*connect edge (never fires
+			// on a continuously-connected pipe), so a healthy box could sit
+			// in FAILOVER forever (#2763). Manual `sc start BreezeAgent` on
+			// a stranded box now heals the watchdog too.
+			if ipcClient.IsConnected() {
+				if hb := healthChecker.LastKnownHeartbeat(agentState); !hb.IsZero() && time.Since(hb) <= wdCfg.HeartbeatStaleThreshold {
+					journal.Log(watchdog.LevelInfo, "failover.agent_healthy_recovered", map[string]any{
+						"last_heartbeat": hb.Format(time.RFC3339),
+					})
+					// recovery.Reset() happens in the MONITORING block on the
+					// next tick — no need to duplicate it here.
+					wd.HandleEvent(watchdog.EventAgentRecovered)
+					break
+				}
 			}
 			if failoverClient == nil && tokenStore.Reveal() != "" {
 				// Re-read the on-disk config at every failover-window start:
@@ -756,7 +778,7 @@ func runWatchdog(stopCh <-chan struct{}) {
 }
 
 // handleIPCMessage dispatches IPC envelope messages from the agent.
-func handleIPCMessage(env *ipc.Envelope, wd *watchdog.Watchdog, journal *watchdog.Journal, cfg *config.Config, tokens *tokenHolder) {
+func handleIPCMessage(env *ipc.Envelope, wd *watchdog.Watchdog, journal *watchdog.Journal, cfg *config.Config, tokens *tokenHolder, health *watchdog.HealthChecker) {
 	switch env.Type {
 	case ipc.TypeShutdownIntent:
 		var intent ipc.ShutdownIntent
@@ -803,6 +825,20 @@ func handleIPCMessage(env *ipc.Envelope, wd *watchdog.Watchdog, journal *watchdo
 			"connected":     sync.Connected,
 			"lastHeartbeat": sync.LastHeartbeat,
 		})
+		// Feed the staleness check: the agent sends a state_sync only after
+		// a successful server heartbeat, so this is authoritative liveness
+		// even when agent.state on disk is unwritable (AV/EDR sharing
+		// violations). Without this, the file alone drove restart decisions
+		// and a blocked writer read as a dead agent (#2763).
+		if health != nil && sync.LastHeartbeat != "" {
+			if hb, perr := time.Parse(time.RFC3339, sync.LastHeartbeat); perr == nil {
+				health.NoteStateSync(hb)
+			} else {
+				journal.Log(watchdog.LevelWarn, "ipc.bad_state_sync_heartbeat", map[string]any{
+					"value": sync.LastHeartbeat, "error": perr.Error(),
+				})
+			}
+		}
 
 	case ipc.TypeWatchdogPong:
 		// Pong received — IPC is healthy. Already tracked by health checker.
@@ -813,6 +849,26 @@ func handleIPCMessage(env *ipc.Envelope, wd *watchdog.Watchdog, journal *watchdo
 			"type": env.Type,
 		})
 	}
+}
+
+// ensureAgentStartedBeforeFailover issues a budget-free, best-effort
+// ensure-start right before the watchdog parks in FAILOVER. A failed graceful
+// attempt may have already stopped the agent service when the flap/budget
+// gate aborts the ladder; FAILOVER ignores health events, so entering it with
+// the agent stopped is permanent until a human intervenes (#2763). The
+// outcome is journaled and failure never blocks the transition.
+func ensureAgentStartedBeforeFailover(ctx context.Context, recovery *watchdog.RecoveryManager, journal *watchdog.Journal) {
+	result, err := recovery.BestEffortEnsureStart(ctx)
+	fields := map[string]any{
+		"action_taken": result.ActionTaken,
+		"final_state":  result.FinalState,
+	}
+	if err != nil {
+		fields["error"] = err.Error()
+		journal.Log(watchdog.LevelError, "recovery.ensure_started_before_failover_failed", fields)
+		return
+	}
+	journal.Log(watchdog.LevelInfo, "recovery.ensure_started_before_failover", fields)
 }
 
 // handleFailoverPoll sends a heartbeat and polls for commands during failover.

--- a/agent/internal/state/state.go
+++ b/agent/internal/state/state.go
@@ -96,14 +96,31 @@ func Read(path string) (*AgentState, error) {
 	return &s, nil
 }
 
-// UpdateHeartbeat updates only the last_heartbeat field in the state file.
+// UpdateHeartbeat updates only the last_heartbeat field in the state file,
+// recreating the file if it has gone missing.
+//
+// The recreate path is load-bearing. This is read-modify-write, and without
+// it a single absent agent.state means the agent never records another
+// heartbeat for the entire life of the process — every call returns "state
+// file not found" and nothing ever puts the file back. The watchdog then
+// reads a permanently stale/absent heartbeat and restarts a perfectly healthy
+// agent until it burns the 24h budget (#2763). That is not hypothetical: on
+// the field endpoint the startup Write lost its rename to a sharing violation
+// (AV/EDR on ProgramData), so the file never existed and every subsequent
+// heartbeat logged "state file not found".
+//
+// PID is repopulated because the caller IS the agent process, and the
+// watchdog's process check is skipped entirely when PID is 0 — a recreated
+// file that omitted it would silently disable liveness checking. Status and
+// Version are left to the owning writer in agentapp; the watchdog does not
+// branch on them.
 func UpdateHeartbeat(path string, t time.Time) error {
 	s, err := Read(path)
 	if err != nil {
 		return err
 	}
 	if s == nil {
-		return fmt.Errorf("state file not found")
+		s = &AgentState{PID: os.Getpid()}
 	}
 	s.LastHeartbeat = t
 	s.Timestamp = time.Now()

--- a/agent/internal/state/state_test.go
+++ b/agent/internal/state/state_test.go
@@ -199,13 +199,22 @@ func TestUpdateHeartbeat(t *testing.T) {
 	}
 }
 
-func TestUpdateHeartbeatMissingFile(t *testing.T) {
+// Behavior change (#2763): UpdateHeartbeat used to return an error for a
+// missing state file and leave it missing. That error was decorative — the
+// only caller logs a warning and continues — while the real consequence was
+// permanent: read-modify-write with no create path meant the agent never
+// recorded another heartbeat for the life of the process, and the watchdog
+// restarted a healthy agent until it burned its 24h budget. It now recreates
+// the file; see TestUpdateHeartbeatRecreatesMissingFile for the contract.
+func TestUpdateHeartbeatMissingFileRecreatesRatherThanErroring(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nonexistent.state")
 
-	err := UpdateHeartbeat(path, time.Now())
-	if err == nil {
-		t.Fatal("UpdateHeartbeat on missing file should return error")
+	if err := UpdateHeartbeat(path, time.Now()); err != nil {
+		t.Fatalf("UpdateHeartbeat on a missing file must recreate it, got error: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("state file was not created: %v", err)
 	}
 }
 
@@ -296,5 +305,57 @@ func TestWritePersistentRenameFailure(t *testing.T) {
 	}
 	if _, statErr := os.Stat(path + ".tmp"); !os.IsNotExist(statErr) {
 		t.Errorf("tmp file should be removed after exhausting rename attempts")
+	}
+}
+
+// A missing agent.state must be recreated by UpdateHeartbeat, not error
+// forever. Without this, one lost file (AV/EDR quarantine, or a startup Write
+// that lost its rename to a sharing violation) means the agent never records
+// another heartbeat for the life of the process, and the watchdog restarts a
+// healthy agent until it burns its 24h budget (#2763).
+func TestUpdateHeartbeatRecreatesMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "agent.state")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("precondition: state file should not exist")
+	}
+	hb := time.Now().Truncate(time.Second)
+	if err := UpdateHeartbeat(path, hb); err != nil {
+		t.Fatalf("UpdateHeartbeat on missing file: %v", err)
+	}
+	s, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read after recreate: %v", err)
+	}
+	if s == nil {
+		t.Fatal("state file was not recreated")
+	}
+	if !s.LastHeartbeat.Equal(hb) {
+		t.Fatalf("LastHeartbeat = %v, want %v", s.LastHeartbeat, hb)
+	}
+	if s.PID != os.Getpid() {
+		t.Fatalf("PID = %d, want %d (a zero PID silently disables the watchdog process check)", s.PID, os.Getpid())
+	}
+}
+
+// Recreating must never clobber fields of an existing file.
+func TestUpdateHeartbeatPreservesExistingFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "agent.state")
+	orig := &AgentState{Status: StatusRunning, PID: 4242, Version: "9.9.9", Reason: ReasonUpdate}
+	if err := Write(path, orig); err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+	hb := time.Now().Truncate(time.Second)
+	if err := UpdateHeartbeat(path, hb); err != nil {
+		t.Fatalf("UpdateHeartbeat: %v", err)
+	}
+	s, err := Read(path)
+	if err != nil || s == nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if s.Status != StatusRunning || s.PID != 4242 || s.Version != "9.9.9" || s.Reason != ReasonUpdate {
+		t.Fatalf("existing fields clobbered: %+v", s)
+	}
+	if !s.LastHeartbeat.Equal(hb) {
+		t.Fatalf("LastHeartbeat = %v, want %v", s.LastHeartbeat, hb)
 	}
 }

--- a/agent/internal/watchdog/checks.go
+++ b/agent/internal/watchdog/checks.go
@@ -47,6 +47,13 @@ type HealthChecker struct {
 	staleThreshold time.Duration
 	ipcFailCount   int
 	staleVetoCount int
+	// lastSyncedHeartbeat is the freshest LastHeartbeat received from the
+	// agent over IPC (state_sync). It corroborates the on-disk agent.state:
+	// on endpoints where AV/EDR blocks every agent.state write, the file is
+	// missing or frozen while the agent is demonstrably healthy — killing on
+	// the file alone is what restart-stormed and stranded a fleet install on
+	// 2026-07-24 (#2763). The freshest of (file, sync) wins.
+	lastSyncedHeartbeat time.Time
 }
 
 // NewHealthChecker constructs a HealthChecker.
@@ -84,21 +91,49 @@ func (h *HealthChecker) CheckIPC() string {
 	return CheckOK
 }
 
-// CheckHeartbeatStaleness returns CheckOK if the heartbeat is fresh or has
-// never been set (zero time = grace period). Returns CheckHeartbeatStale if s
-// is nil or the heartbeat is older than staleThreshold.
+// NoteStateSync records the agent-reported LastHeartbeat delivered over IPC
+// (state_sync). The agent only sends a state_sync after a successful HTTP-200
+// heartbeat, so this is authoritative liveness evidence even when the on-disk
+// agent.state cannot be written. Out-of-order or unparsable values never
+// regress the stored timestamp.
+func (h *HealthChecker) NoteStateSync(lastHeartbeat time.Time) {
+	if lastHeartbeat.After(h.lastSyncedHeartbeat) {
+		h.lastSyncedHeartbeat = lastHeartbeat
+	}
+}
+
+// LastKnownHeartbeat returns the freshest heartbeat timestamp known from any
+// source: the on-disk agent.state or the IPC state_sync channel. Zero if
+// neither has ever produced one.
+func (h *HealthChecker) LastKnownHeartbeat(s *state.AgentState) time.Time {
+	hb := h.lastSyncedHeartbeat
+	if s != nil && s.LastHeartbeat.After(hb) {
+		hb = s.LastHeartbeat
+	}
+	return hb
+}
+
+// CheckHeartbeatStaleness returns CheckOK if the freshest known heartbeat
+// (on-disk agent.state OR IPC state_sync — see NoteStateSync) is fresh, or if
+// no heartbeat has been recorded yet while a state file exists (zero time =
+// startup grace). Returns CheckHeartbeatStale when s is nil AND no state_sync
+// was ever received, or when the freshest known heartbeat is older than
+// staleThreshold. The file must never outvote fresher IPC evidence: a
+// missing/frozen agent.state with live state_syncs is a blocked WRITER
+// (AV/EDR on ProgramData), not a dead agent.
 func (h *HealthChecker) CheckHeartbeatStaleness(s *state.AgentState) string {
-	if s == nil {
+	hb := h.LastKnownHeartbeat(s)
+	if s == nil && hb.IsZero() {
 		return CheckHeartbeatStale
 	}
-	if s.LastHeartbeat.IsZero() {
+	if hb.IsZero() {
 		// Grace period: heartbeat not yet recorded. A restarted agent gets a
 		// fresh veto budget too — residual vetoes from before the restart
 		// must not fast-track the new process to escalation.
 		h.staleVetoCount = 0
 		return CheckOK
 	}
-	if time.Since(s.LastHeartbeat) > h.staleThreshold {
+	if time.Since(hb) > h.staleThreshold {
 		return CheckHeartbeatStale
 	}
 	// A fresh heartbeat re-arms the stale-veto budget.

--- a/agent/internal/watchdog/checks_test.go
+++ b/agent/internal/watchdog/checks_test.go
@@ -292,3 +292,104 @@ func TestEvaluateStaleHeartbeat(t *testing.T) {
 		}
 	})
 }
+
+// --- State-sync corroboration (#2763): the freshest of (file, IPC state_sync)
+// drives staleness. A missing/frozen agent.state with live state_syncs is a
+// blocked WRITER (AV/EDR), not a dead agent — field-confirmed 2026-07-24 where
+// the watchdog killed a heartbeating agent 5x and stranded it stopped.
+
+func TestStaleFileVetoedByFreshStateSync(t *testing.T) {
+	t.Parallel()
+	hc := NewHealthChecker(nil, nil, 3*time.Minute)
+	s := &state.AgentState{LastHeartbeat: time.Now().Add(-30 * time.Minute)} // file frozen
+	if got := hc.CheckHeartbeatStaleness(s); got != CheckHeartbeatStale {
+		t.Fatalf("precondition: frozen file should be stale, got %q", got)
+	}
+	hc.NoteStateSync(time.Now().Add(-20 * time.Second)) // agent just heartbeated
+	if got := hc.CheckHeartbeatStaleness(s); got != CheckOK {
+		t.Fatalf("fresh state_sync must override frozen file: expected %q, got %q", CheckOK, got)
+	}
+}
+
+func TestNilFileWithFreshStateSyncIsOK(t *testing.T) {
+	t.Parallel()
+	hc := NewHealthChecker(nil, nil, 3*time.Minute)
+	// The field shape: agent.state was NEVER writable, state.Read fails
+	// forever, agentState stays nil — but state_syncs flow.
+	hc.NoteStateSync(time.Now().Add(-10 * time.Second))
+	if got := hc.CheckHeartbeatStaleness(nil); got != CheckOK {
+		t.Fatalf("nil file with fresh sync must be OK: got %q", got)
+	}
+}
+
+func TestNilFileWithoutAnySyncStaysStale(t *testing.T) {
+	t.Parallel()
+	hc := NewHealthChecker(nil, nil, 3*time.Minute)
+	if got := hc.CheckHeartbeatStaleness(nil); got != CheckHeartbeatStale {
+		t.Fatalf("nil file and no sync ever must remain stale: got %q", got)
+	}
+}
+
+func TestStaleSyncDoesNotMaskFreshFile(t *testing.T) {
+	t.Parallel()
+	hc := NewHealthChecker(nil, nil, 3*time.Minute)
+	hc.NoteStateSync(time.Now().Add(-1 * time.Hour))
+	s := &state.AgentState{LastHeartbeat: time.Now().Add(-5 * time.Second)}
+	if got := hc.CheckHeartbeatStaleness(s); got != CheckOK {
+		t.Fatalf("fresh file must win over stale sync: got %q", got)
+	}
+}
+
+func TestBothSourcesStaleIsStale(t *testing.T) {
+	t.Parallel()
+	hc := NewHealthChecker(nil, nil, 3*time.Minute)
+	hc.NoteStateSync(time.Now().Add(-10 * time.Minute))
+	s := &state.AgentState{LastHeartbeat: time.Now().Add(-20 * time.Minute)}
+	if got := hc.CheckHeartbeatStaleness(s); got != CheckHeartbeatStale {
+		t.Fatalf("both sources stale must be stale: got %q", got)
+	}
+}
+
+func TestNoteStateSyncNeverRegresses(t *testing.T) {
+	t.Parallel()
+	hc := NewHealthChecker(nil, nil, 3*time.Minute)
+	fresh := time.Now().Add(-10 * time.Second)
+	hc.NoteStateSync(fresh)
+	hc.NoteStateSync(fresh.Add(-1 * time.Hour)) // out-of-order older value
+	if got := hc.LastKnownHeartbeat(nil); !got.Equal(fresh) {
+		t.Fatalf("older sync must not regress stored heartbeat: got %v want %v", got, fresh)
+	}
+}
+
+func TestFreshSyncReArmsStaleVetoBudget(t *testing.T) {
+	t.Parallel()
+	hc := NewHealthChecker(nil, nil, 3*time.Minute)
+	stale := &state.AgentState{LastHeartbeat: time.Now().Add(-30 * time.Minute)}
+	// Burn one veto against the stale file.
+	if d, _ := hc.EvaluateStaleHeartbeat(stale, true); d != StaleVetoed {
+		t.Fatalf("expected first stale verdict to be vetoed")
+	}
+	// Agent heartbeats (sync arrives) → staleness clears AND veto budget re-arms.
+	hc.NoteStateSync(time.Now())
+	if d, _ := hc.EvaluateStaleHeartbeat(stale, true); d != HeartbeatOK {
+		t.Fatalf("fresh sync must clear staleness")
+	}
+	if hc.StaleVetoCount() != 0 {
+		t.Fatalf("fresh sync must re-arm veto budget, count=%d", hc.StaleVetoCount())
+	}
+}
+
+func TestLastKnownHeartbeatPicksFreshest(t *testing.T) {
+	t.Parallel()
+	hc := NewHealthChecker(nil, nil, 3*time.Minute)
+	fileHB := time.Now().Add(-2 * time.Minute)
+	syncHB := time.Now().Add(-1 * time.Minute)
+	hc.NoteStateSync(syncHB)
+	s := &state.AgentState{LastHeartbeat: fileHB}
+	if got := hc.LastKnownHeartbeat(s); !got.Equal(syncHB) {
+		t.Fatalf("expected sync heartbeat (fresher), got %v", got)
+	}
+	if got := hc.LastKnownHeartbeat(nil); !got.Equal(syncHB) {
+		t.Fatalf("nil file: expected sync heartbeat, got %v", got)
+	}
+}

--- a/agent/internal/watchdog/failover.go
+++ b/agent/internal/watchdog/failover.go
@@ -43,6 +43,18 @@ type FailoverClient struct {
 	agentID string
 	token   string
 	client  *http.Client
+	// pollClient carries a longer timeout than the heartbeat client. The
+	// commands GET is the ONLY channel through which an operator can revive
+	// an agent while the watchdog is in FAILOVER, and in the field it has
+	// been observed taking >30s server-side (connection-hold class, #1105)
+	// — with a 30s client timeout every poll died with "context deadline
+	// exceeded" and the escape hatch was permanently dead (#2763). Cost: the
+	// poll runs synchronously in the main select loop, so a worst-case slow
+	// server now stalls other ticks for up to 90s instead of 30s — in
+	// FAILOVER there is nothing time-critical queued behind it (the 64-slot
+	// IPC buffer absorbs the window), and a bounded stall beats a
+	// permanently dead revive channel.
+	pollClient *http.Client
 }
 
 // NewFailoverClient creates a FailoverClient with a 30-second timeout. If
@@ -60,6 +72,10 @@ func NewFailoverClient(baseURL, agentID, token string, tlsConfig *tls.Config) *F
 		token:   token,
 		client: &http.Client{
 			Timeout:   30 * time.Second,
+			Transport: transport,
+		},
+		pollClient: &http.Client{
+			Timeout:   90 * time.Second,
 			Transport: transport,
 		},
 	}
@@ -158,7 +174,7 @@ func (c *FailoverClient) PollCommands() ([]FailoverCommand, error) {
 	}
 	c.setHeaders(req)
 
-	resp, err := c.client.Do(req)
+	resp, err := c.pollClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failover: poll request: %w", err)
 	}

--- a/agent/internal/watchdog/ipcclient.go
+++ b/agent/internal/watchdog/ipcclient.go
@@ -25,6 +25,14 @@ type IPCClient struct {
 	stopCh     chan struct{}
 	lastPingAt time.Time
 	lastPongAt time.Time
+	// lastRecvAt is the time ANY envelope was received from the agent —
+	// state_sync, token updates, pongs, anything. A pipe that is actively
+	// delivering messages is proof of agent liveness even when a specific
+	// pong goes missing (the agent's ping handler can starve behind heavy
+	// collection work like WUA scans). Counting only pongs produced three
+	// consecutive false negatives on a live pipe and a kill cycle of a
+	// healthy agent in the field (#2763).
+	lastRecvAt time.Time
 }
 
 // NewIPCClient constructs an IPCClient that will connect to socketPath and
@@ -98,22 +106,35 @@ func (c *IPCClient) Connect() error {
 	return nil
 }
 
-// Ping implements IPCProber. It checks whether the previous ping received a
-// pong (indicating the agent is responsive), records the current time as the
-// new ping timestamp, and sends a watchdog_ping. On the very first call there
-// is no prior ping/pong pair, so true is returned optimistically.
+// pingVerdict decides whether the agent counts as responsive at ping time.
+// Alive means: a pong arrived since the previous ping, OR any other envelope
+// arrived since the previous ping (an actively-delivering pipe is liveness —
+// see lastRecvAt), OR this is the very first ping (no opportunity for a pong
+// yet, benefit of the doubt). Pure function for testability.
+func pingVerdict(firstPing bool, lastPingAt, lastPongAt, lastRecvAt time.Time) bool {
+	if firstPing {
+		return true
+	}
+	if !lastPongAt.IsZero() && lastPongAt.After(lastPingAt) {
+		return true
+	}
+	return !lastRecvAt.IsZero() && lastRecvAt.After(lastPingAt)
+}
+
+// Ping implements IPCProber. It checks whether the agent showed life since
+// the previous ping (a pong OR any other received envelope), records the
+// current time as the new ping timestamp, and sends a watchdog_ping.
 //
-// Because pongs arrive asynchronously, three consecutive calls without any
-// pong in between will return false — indicating a hung agent.
+// Because responses arrive asynchronously, consecutive calls with a truly
+// silent pipe in between return false — indicating a hung agent.
 func (c *IPCClient) Ping() (bool, error) {
 	c.mu.Lock()
 	if !c.connected || c.conn == nil {
 		c.mu.Unlock()
 		return false, fmt.Errorf("watchdog ipc: not connected")
 	}
-	// Check whether the last ping got a response.
 	firstPing := c.lastPingAt.IsZero()
-	gotPong := !c.lastPongAt.IsZero() && c.lastPongAt.After(c.lastPingAt)
+	alive := pingVerdict(firstPing, c.lastPingAt, c.lastPongAt, c.lastRecvAt)
 	c.lastPingAt = time.Now()
 	conn := c.conn
 	c.mu.Unlock()
@@ -123,13 +144,7 @@ func (c *IPCClient) Ping() (bool, error) {
 		return false, fmt.Errorf("watchdog ipc: send ping: %w", err)
 	}
 
-	// On the very first ping there has been no opportunity to receive a pong
-	// yet, so we give the agent the benefit of the doubt.
-	if firstPing {
-		return true, nil
-	}
-
-	return gotPong, nil
+	return alive, nil
 }
 
 // IsConnected returns whether the client currently has an active connection.
@@ -190,11 +205,12 @@ func (c *IPCClient) readLoop() {
 			return
 		}
 
+		c.mu.Lock()
+		c.lastRecvAt = time.Now()
 		if env.Type == ipc.TypeWatchdogPong {
-			c.mu.Lock()
-			c.lastPongAt = time.Now()
-			c.mu.Unlock()
+			c.lastPongAt = c.lastRecvAt
 		}
+		c.mu.Unlock()
 
 		if c.onMessage != nil {
 			c.onMessage(env)

--- a/agent/internal/watchdog/ipcclient_test.go
+++ b/agent/internal/watchdog/ipcclient_test.go
@@ -1,0 +1,40 @@
+package watchdog
+
+import (
+	"testing"
+	"time"
+)
+
+// pingVerdict is the liveness decision at ping time (#2763): any envelope
+// received since the previous ping proves the agent alive, not just an
+// explicit pong — the agent's ping handler can starve behind heavy collection
+// work (WUA scans) while state_syncs keep flowing on the same pipe, and
+// counting only pongs produced three consecutive false negatives and a kill
+// cycle of a healthy agent in the field.
+func TestPingVerdict(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name     string
+		first    bool
+		lastPing time.Time
+		lastPong time.Time
+		lastRecv time.Time
+		want     bool
+	}{
+		{"first ping is optimistic", true, time.Time{}, time.Time{}, time.Time{}, true},
+		{"pong since last ping", false, base, base.Add(time.Second), base.Add(time.Second), true},
+		{"silent pipe since last ping", false, base, base.Add(-time.Minute), base.Add(-time.Minute), false},
+		{"no pong but state_sync since last ping", false, base, base.Add(-time.Minute), base.Add(10 * time.Second), true},
+		{"activity only before last ping", false, base, time.Time{}, base.Add(-time.Second), false},
+		{"never any traffic", false, base, time.Time{}, time.Time{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pingVerdict(tc.first, tc.lastPing, tc.lastPong, tc.lastRecv); got != tc.want {
+				t.Fatalf("pingVerdict(%v, %v, %v, %v) = %v, want %v",
+					tc.first, tc.lastPing, tc.lastPong, tc.lastRecv, got, tc.want)
+			}
+		})
+	}
+}

--- a/agent/internal/watchdog/recovery.go
+++ b/agent/internal/watchdog/recovery.go
@@ -279,6 +279,29 @@ func (r *RecoveryManager) Attempt(req RecoveryRequest) (RecoveryResult, error) {
 // Attempts returns the current attempt count within the active window.
 func (r *RecoveryManager) Attempts() int { return r.attempts }
 
+// BestEffortEnsureStart dispatches an ensure-start to the OS controller
+// WITHOUT consuming an escalation slot, a 24h history entry, or checking the
+// budget. It exists for exactly one moment: recovery exhaustion. A failed
+// graceful attempt may have already issued the SCM stop when the flap/budget
+// gate aborts the ladder, and parking in FAILOVER must never leave the agent
+// service stopped — FAILOVER ignores health events and its only restart
+// channel requires a reachable server, so a stop at that boundary is
+// permanent until a human intervenes (#2763, field-confirmed 2026-07-24).
+// Best-effort by design: the caller journals the outcome and proceeds to
+// FAILOVER regardless.
+func (r *RecoveryManager) BestEffortEnsureStart(ctx context.Context) (RecoveryResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req := RecoveryRequest{Intent: RecoveryIntentEnsureStart, Context: ctx}
+	result, err := r.svc.Recover(r.attempts, req)
+	result.Intent = req.Intent
+	if result.Disposition == "" {
+		result.Disposition = RecoveryDispositionNone
+	}
+	return result, err
+}
+
 // Reset clears the attempt counter, the terminal-failure latch, and resets the
 // window start time.
 func (r *RecoveryManager) Reset() {

--- a/agent/internal/watchdog/recovery_test.go
+++ b/agent/internal/watchdog/recovery_test.go
@@ -1,6 +1,7 @@
 package watchdog
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -278,5 +279,63 @@ func TestHistoryMissingFileStartsEmpty(t *testing.T) {
 	r.SetHistoryPath(path)
 	if got := r.Count24h(); got != 0 {
 		t.Fatalf("missing-file Count24h: want 0, got %d", got)
+	}
+}
+
+// BestEffortEnsureStart runs at recovery exhaustion, right before FAILOVER:
+// it must dispatch an ensure-start WITHOUT consuming budget, history, or
+// being blocked by the exhausted/terminal state — entering FAILOVER with the
+// agent service stopped is permanent (#2763).
+func TestBestEffortEnsureStartConsumesNoBudget(t *testing.T) {
+	clk := &fakeClock{now: time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)}
+	svc := &noopServiceController{}
+	r := newTestRecovery(t, clk, svc)
+
+	// Exhaust the budget with real attempts.
+	for i := 0; i < 3; i++ {
+		if _, err := r.Attempt(RecoveryRequest{}); err != nil {
+			t.Fatalf("attempt %d: %v", i, err)
+		}
+	}
+	if r.CanAttempt() {
+		t.Fatal("precondition: budget should be exhausted")
+	}
+	attemptsBefore, count24hBefore := r.Attempts(), r.Count24h()
+
+	result, err := r.BestEffortEnsureStart(context.Background())
+	if err != nil {
+		t.Fatalf("BestEffortEnsureStart: %v", err)
+	}
+	if result.Intent != RecoveryIntentEnsureStart {
+		t.Fatalf("intent = %q, want %q", result.Intent, RecoveryIntentEnsureStart)
+	}
+	if svc.starts == 0 {
+		t.Fatal("expected an ensure-start dispatch to the controller")
+	}
+	if r.Attempts() != attemptsBefore || r.Count24h() != count24hBefore {
+		t.Fatalf("budget consumed: attempts %d->%d count24h %d->%d",
+			attemptsBefore, r.Attempts(), count24hBefore, r.Count24h())
+	}
+}
+
+// Even a terminal-exhausted manager (identity uncertainty latch) must still
+// dispatch the best-effort start — the latch protects against forced kills of
+// unidentified processes, and ensure-start kills nothing.
+func TestBestEffortEnsureStartWorksWhenTerminalExhausted(t *testing.T) {
+	clk := &fakeClock{now: time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)}
+	svc := &fakeStructuredController{result: RecoveryResult{Action: RecoveryActionStart, ActionTaken: true, Disposition: RecoveryDispositionFailover}}
+	r := newTestRecovery(t, clk, svc)
+	if _, err := r.Attempt(RecoveryRequest{}); err != nil {
+		t.Fatalf("attempt: %v", err)
+	}
+	if r.CanAttempt() {
+		t.Fatal("precondition: terminal exhaustion expected")
+	}
+	callsBefore := len(svc.calls)
+	if _, err := r.BestEffortEnsureStart(context.Background()); err != nil {
+		t.Fatalf("BestEffortEnsureStart: %v", err)
+	}
+	if len(svc.calls) != callsBefore+1 {
+		t.Fatal("ensure-start was not dispatched")
 	}
 }

--- a/agent/internal/watchdog/recovery_windows_logic.go
+++ b/agent/internal/watchdog/recovery_windows_logic.go
@@ -101,6 +101,15 @@ const (
 	windowsProcessExitTimeout = 35 * time.Second
 
 	windowsRecoveryPollInterval = 500 * time.Millisecond
+
+	// windowsControlAckGrace is how long after issuing a control SCM may keep
+	// reporting the PRE-transition state before we treat it as a firm wrong
+	// answer. A stopping agent needs ~100-200ms to acknowledge STOP_PENDING;
+	// reading that window as "settled in an unexpected terminal state" made
+	// every graceful restart fail in 0-1ms with an orphaned stop already in
+	// flight (#2763 — the field's `transition_timeout failed during
+	// wait_stopped, elapsed_ms:0` on every kill cycle).
+	windowsControlAckGrace = 5 * time.Second
 )
 
 // errUnexpectedTerminalState means SCM settled in a definite state that is not
@@ -124,6 +133,7 @@ type windowsRecoveryController struct {
 	observeTimeout     time.Duration
 	processExitTimeout time.Duration
 	pollInterval       time.Duration
+	ackGrace           time.Duration
 }
 
 func newWindowsRecoveryController(backend windowsRecoveryBackend, clk recoveryClock) *windowsRecoveryController {
@@ -135,6 +145,7 @@ func newWindowsRecoveryController(backend windowsRecoveryBackend, clk recoveryCl
 		observeTimeout:     windowsObserveTimeout,
 		processExitTimeout: windowsProcessExitTimeout,
 		pollInterval:       windowsRecoveryPollInterval,
+		ackGrace:           windowsControlAckGrace,
 	}
 }
 
@@ -240,7 +251,20 @@ func (c *windowsRecoveryController) ensureStartRecovery(result RecoveryResult, r
 	result.FinalState = string(snapshot.State)
 
 	if isPendingState(snapshot.State) {
-		return c.observeTransition(result, req, snapshot)
+		observed, oerr := c.observeTransition(result, req, snapshot)
+		if oerr != nil {
+			return observed, oerr
+		}
+		if observed.FinalState == string(serviceStopped) {
+			// The transition we watched settled to Stopped. The generic
+			// observe path leaves Stopped alone so "the next attempt can
+			// issue Start" — but the ensure-start intent has no next attempt
+			// (it runs once, e.g. on the recovery-exhaustion path before
+			// FAILOVER, #2763). The transition has settled, so starting now
+			// races nothing.
+			return c.ensureStarted(observed, req, 0)
+		}
+		return observed, nil
 	}
 	if snapshot.State == serviceRunning {
 		// Already started. Nothing was restarted, so the disposition stays
@@ -724,9 +748,15 @@ func (c *windowsRecoveryController) control(
 // waitForState polls SCM until it reports want, returning the matching
 // snapshot. It fails on cancellation, query error, deadline, or when SCM
 // settles in a definite state that is not want — there is no point waiting out
-// a firm wrong answer.
+// a firm wrong answer. "Settles" allows for the acknowledge window: right
+// after a control is issued SCM can still report the pre-transition state
+// (RUNNING immediately after a stop request) until the service acknowledges,
+// so a non-pending, non-target state only becomes a firm wrong answer once it
+// persists past ackGrace.
 func (c *windowsRecoveryController) waitForState(req RecoveryRequest, want serviceState, timeout time.Duration) (serviceSnapshot, error) {
-	deadline := c.clk.Now().Add(timeout)
+	start := c.clk.Now()
+	deadline := start.Add(timeout)
+	ackDeadline := start.Add(c.ackGrace)
 	var last serviceSnapshot
 	for {
 		if err := req.Context.Err(); err != nil {
@@ -740,7 +770,7 @@ func (c *windowsRecoveryController) waitForState(req RecoveryRequest, want servi
 		if snapshot.State == want {
 			return snapshot, nil
 		}
-		if !isPendingState(snapshot.State) {
+		if !isPendingState(snapshot.State) && !c.clk.Now().Before(ackDeadline) {
 			return snapshot, fmt.Errorf("%w: %s while waiting for %s", errUnexpectedTerminalState, snapshot.State, want)
 		}
 		if !c.clk.Now().Before(deadline) {

--- a/agent/internal/watchdog/recovery_windows_logic_test.go
+++ b/agent/internal/watchdog/recovery_windows_logic_test.go
@@ -1113,3 +1113,89 @@ func TestRecoverPopulatesElapsedAndPhase(t *testing.T) {
 		t.Fatalf("phase=%q, want the last reached phase", result.Phase)
 	}
 }
+
+// SCM can keep reporting the PRE-control state for a short window after a
+// control is issued, before the service acknowledges the transition (a
+// stopping agent needs ~100-200ms to reach STOP_PENDING). Treating that first
+// read as a firm wrong answer made every graceful restart fail in 0-1ms with
+// an orphaned stop already in flight — the exact "recovery transition_timeout
+// failed during wait_stopped, elapsed_ms:0" seen on every field kill cycle
+// (#2763). The wait must absorb a brief acknowledge delay.
+func TestGracefulStopToleratesSlowScmAcknowledge(t *testing.T) {
+	backend := newFakeWindowsBackend(
+		serviceSnapshot{State: serviceRunning, PID: 100}, // initial query
+		serviceSnapshot{State: serviceRunning, PID: 100}, // post-Stop: not yet acknowledged
+		serviceSnapshot{State: serviceRunning, PID: 100}, // still not acknowledged
+		serviceSnapshot{State: serviceStopPending, PID: 100},
+		serviceSnapshot{State: serviceStopped},
+		serviceSnapshot{State: serviceStopped},           // post-Start: not yet acknowledged
+		serviceSnapshot{State: serviceStartPending, PID: 200},
+		serviceSnapshot{State: serviceRunning, PID: 200},
+	)
+	controller := newTestWindowsRecoveryController(backend)
+	result, err := controller.Recover(1, RecoveryRequest{StateFilePID: 99})
+	if err != nil {
+		t.Fatalf("graceful recovery must survive a slow SCM acknowledge, got %v", err)
+	}
+	if backend.stopCalls != 1 || backend.startCalls != 1 {
+		t.Fatalf("stop=%d start=%d, want 1/1", backend.stopCalls, backend.startCalls)
+	}
+	if result.NewPID != 200 || result.FinalState != string(serviceRunning) {
+		t.Fatalf("result=%+v, want NewPID=200 running", result)
+	}
+}
+
+// The acknowledge grace must not mask a genuinely settled wrong answer: if
+// SCM keeps reporting the non-target, non-pending state past the grace
+// window, the wait still fails firmly.
+func TestWaitForStateStillFailsOnFirmWrongAnswer(t *testing.T) {
+	backend := newFakeWindowsBackend(
+		serviceSnapshot{State: serviceRunning, PID: 100}, // initial query
+		serviceSnapshot{State: serviceRunning, PID: 100}, // repeats forever post-Stop
+	)
+	controller := newTestWindowsRecoveryController(backend)
+	result, err := controller.Recover(1, RecoveryRequest{StateFilePID: 99})
+	var recoveryErr *RecoveryError
+	if !errors.As(err, &recoveryErr) {
+		t.Fatalf("err=%v, want RecoveryError", err)
+	}
+	if recoveryErr.Class != RecoveryFailureTransitionTimeout {
+		t.Fatalf("class=%v, want transition timeout", recoveryErr.Class)
+	}
+	if backend.startCalls != 0 {
+		t.Fatalf("start must never be issued after an unresolved stop, startCalls=%d", backend.startCalls)
+	}
+	if result.FinalState != string(serviceRunning) {
+		t.Fatalf("final state %q, want running (the firm wrong answer)", result.FinalState)
+	}
+}
+
+// Ensure-start that walks in on an in-flight stop transition must START the
+// service once the transition settles to Stopped. The old observe-only
+// behavior assumed "the next attempt will issue Start" — but on the
+// recovery-exhaustion path (ensure-started-before-failover, #2763) there IS
+// no next attempt, and the observed settle left the agent stopped forever.
+func TestEnsureStartStartsAfterObservedStopSettles(t *testing.T) {
+	backend := newFakeWindowsBackend(
+		serviceSnapshot{State: serviceStopPending, PID: 100}, // initial query: stop in flight
+		serviceSnapshot{State: serviceStopPending, PID: 100},
+		serviceSnapshot{State: serviceStopped},               // transition settles
+		serviceSnapshot{State: serviceStopped},               // post-Start: not yet acknowledged
+		serviceSnapshot{State: serviceStartPending, PID: 300},
+		serviceSnapshot{State: serviceRunning, PID: 300},
+	)
+	controller := newTestWindowsRecoveryController(backend)
+	result, err := controller.Recover(2, RecoveryRequest{Intent: RecoveryIntentEnsureStart})
+	if err != nil {
+		t.Fatalf("ensure-start after observed settle: %v", err)
+	}
+	if backend.startCalls != 1 {
+		t.Fatalf("startCalls=%d, want 1 — the settle must be followed by a Start", backend.startCalls)
+	}
+	if backend.stopCalls != 0 {
+		t.Fatalf("ensure-start must never stop anything, stopCalls=%d", backend.stopCalls)
+	}
+	if result.NewPID != 300 || result.FinalState != string(serviceRunning) {
+		t.Fatalf("result=%+v, want NewPID=300 running", result)
+	}
+}

--- a/agent/internal/watchdog/recovery_windows_logic_test.go
+++ b/agent/internal/watchdog/recovery_windows_logic_test.go
@@ -1128,7 +1128,7 @@ func TestGracefulStopToleratesSlowScmAcknowledge(t *testing.T) {
 		serviceSnapshot{State: serviceRunning, PID: 100}, // still not acknowledged
 		serviceSnapshot{State: serviceStopPending, PID: 100},
 		serviceSnapshot{State: serviceStopped},
-		serviceSnapshot{State: serviceStopped},           // post-Start: not yet acknowledged
+		serviceSnapshot{State: serviceStopped}, // post-Start: not yet acknowledged
 		serviceSnapshot{State: serviceStartPending, PID: 200},
 		serviceSnapshot{State: serviceRunning, PID: 200},
 	)
@@ -1179,8 +1179,8 @@ func TestEnsureStartStartsAfterObservedStopSettles(t *testing.T) {
 	backend := newFakeWindowsBackend(
 		serviceSnapshot{State: serviceStopPending, PID: 100}, // initial query: stop in flight
 		serviceSnapshot{State: serviceStopPending, PID: 100},
-		serviceSnapshot{State: serviceStopped},               // transition settles
-		serviceSnapshot{State: serviceStopped},               // post-Start: not yet acknowledged
+		serviceSnapshot{State: serviceStopped}, // transition settles
+		serviceSnapshot{State: serviceStopped}, // post-Start: not yet acknowledged
 		serviceSnapshot{State: serviceStartPending, PID: 300},
 		serviceSnapshot{State: serviceRunning, PID: 300},
 	)


### PR DESCRIPTION
Fixes the field incident in #2763, where a fresh v0.100.0 install enrolled and heartbeated normally, then the watchdog killed the healthy agent 5 times in 9 minutes and left it **permanently STOPPED** in FAILOVER. Operator-visible symptom: *"it installed, but the service is not running after."*

Six independent defects combined to produce that outcome. Each is fixed and verified here.

## Root causes and fixes

**1. Staleness ignored live IPC evidence** (`checks.go`)
The verdict read only the on-disk `agent.state`, which on the field endpoint was never writable (AV/EDR on ProgramData: `"state file not found"` on every heartbeat, sharing violation on rename). The watchdog held a **49-second-old** heartbeat received over IPC and still killed the agent based on the frozen file. Staleness now uses the freshest of (state file, IPC `state_sync`) via `NoteStateSync` / `LastKnownHeartbeat`. A blocked *writer* is no longer read as a dead agent.

**2. IPC ping false negatives** (`ipcclient.go`)
Only pongs counted as liveness, so three consecutive missed pongs triggered a kill cycle **while `state_sync` messages were arriving on the same pipe** (the agent's ping handler starves behind heavy collection — WUA scans in the field log). Any envelope received since the previous ping now counts; a genuinely silent pipe still fails.

**3. Graceful recovery failed instantly with the stop already issued** (`recovery_windows_logic.go`)
SCM can keep reporting the pre-transition state for ~100–200ms after a control. `waitForState` treated that first read as a firm wrong answer and returned `transition_timeout failed during wait_stopped` in **0–1ms**, leaving an orphaned stop in flight — the signature on every field kill cycle. Adds a 5s acknowledge grace before a non-pending, non-target state is called firm.

**4. Exhaustion could park in FAILOVER with the service stopped** (`recovery.go`, `main.go`)
FAILOVER ignores health events and its only restart channel needs a reachable server, so that state was permanent until a human intervened. All three `EventRecoveryExhausted` sites now run a budget-free best-effort ensure-start first.

**5. Ensure-start observed a settling stop and never started** (`recovery_windows_logic.go`)
It relied on *"the next attempt will issue Start"* — but the exhaustion path has no next attempt. It now starts the service once the observed transition settles to Stopped.

**6. FAILOVER had no self-recovery** (`main.go`)
The only exits were a server-delivered command and an IPC *re*connect edge that never fires on a continuously-connected pipe. FAILOVER now returns to MONITORING when IPC is live and the freshest known heartbeat is within the stale threshold — so a manual `sc start BreezeAgent` heals the watchdog too.

Also: the FAILOVER commands poll gets a dedicated 90s-timeout client. The shared 30s client made every poll die with `context deadline exceeded` against the long-poll endpoint, killing the one operator revive channel.

## Verification

Windows Server 2022, real v0.100.0 MSI install, fix binaries swapped in, `agent.state` made permanently unwritable to emulate the field endpoint's AV/EDR interference.

| Scenario | v0.100.0 (before) | This branch |
|---|---|---|
| Field shape: blocked state file, live server, 12 min | kills the agent at ~minute 3 | **zero kills, zero stale verdicts**, `ipc_degraded` never past 1 |
| Server dark 21 min, blocked state file | 3 kill cycles then **STOPPED forever** | **zero SCM stop/start events**, agent left **Running** at FAILOVER entry |
| Genuinely dead agent (ungraceful kill, SCM recovery disarmed) | restarts it | **still restarts it** — `heartbeat_stale{ipc_connected:false, vetoes_before:0}` fires immediately, no false immunity |
| Flap ceiling tripped with agent stopped | leaves it stopped | `ensure_started_before_failover{action_taken:true, final_state:"running"}` |
| Stranded in FAILOVER with a healthy agent | stuck forever | `failover.agent_healthy_recovered` **5s** after `failover.start` |

Journal excerpt from the last two rows:

```
19:13:39  check.heartbeat_stale {"ipc_connected":false,"vetoes_before":0}
19:13:39  recovery.flap_detected {"count_24h":1}
19:13:40  recovery.ensure_started_before_failover {"action_taken":true,"final_state":"running"}
19:14:39  failover.start
19:14:44  failover.agent_healthy_recovered {"last_heartbeat":"2026-07-24T12:14:44-07:00"}
FINAL: BreezeAgent Running, BreezeWatchdog Running
```

Also verified along the way: a clean `sc stop` still puts the watchdog in STANDBY via `shutdown_intent` (intentional stops are still respected, unchanged).

Unit tests: 13 new cases covering the freshest-of-two-sources staleness (including nil-file-with-fresh-sync, stale-sync-doesn't-mask-fresh-file, both-stale-is-stale, no-regression on out-of-order syncs), the ping liveness table, budget-free ensure-start (including past the terminal-exhausted latch), the SCM acknowledge grace, and ensure-start-after-observed-settle. `go vet` and `go test -race` clean.

## Second commit: the root enabler

While verifying, the test VM reproduced the field endpoint's other symptom: the agent healthy and heartbeating to the server, `agent.state` **absent**, and `failed to update state file heartbeat: "state file not found"` repeating every 60s.

`state.UpdateHeartbeat` is read-modify-write with no create path. One absent `agent.state` means the agent never records another heartbeat for the life of the process — the returned error is decorative (the sole caller only logs it) while nothing ever puts the file back. On the field endpoint the startup `Write` lost its rename to a sharing violation, so the file never existed at all; every heartbeat after that logged `"state file not found"`, and the pre-fix watchdog read that as a permanently stale agent.

`UpdateHeartbeat` now recreates the file, repopulating PID (the watchdog skips its process check entirely when PID is 0, so a recreated file omitting it would silently disable liveness checking). Existing fields are preserved when the file is present. The prior test asserted the error-and-leave-missing behavior with no rationale and is replaced by one documenting the corrected contract.

This is defense in depth with the watchdog changes above: commit 1 stops the watchdog from trusting a broken file, commit 2 stops the file from staying broken.

## Risk notes

- The stale-heartbeat escalation is deliberately **not** disabled — a wedged agent that stops heartbeating while its IPC listener answers is still restarted after the bounded veto budget. That was the original purpose of the check and it still works (row 3 above).
- FAILOVER↔MONITORING cannot heartbeat-flap: the self-recovery gate and the MONITORING stale check read the same freshest-source, so they cannot disagree. A crash-looping agent can cycle, but that path is non-destructive (ensure-start only ever *starts*) and bounded by the 24h window.

Refs #2763
