### PR TITLE
fix(api): return explicit column list from /partners/me instead of whole partners row

### DIFF
--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -249,6 +249,18 @@ describe('org routes', () => {
       const body = await res.json();
       expect(body.data).toHaveLength(2);
       expect(body.pagination.total).toBe(2);
+
+      // The page query (second select) must use an explicit projection that
+      // excludes internal metadata columns rather than the whole partners row.
+      const pageProjection = vi.mocked(db.select).mock.calls[1]?.[0] as Record<string, unknown> | undefined;
+      expect(pageProjection).toBeDefined();
+      const keys = Object.keys(pageProjection!);
+      expect(keys).toContain('id');
+      expect(keys).toContain('name');
+      expect(keys).toContain('status');
+      for (const internal of ['signupIp', 'paymentMethodAttachedAt', 'stripeCustomerId', 'ssoConfig', 'mcpOriginIp']) {
+        expect(keys).not.toContain(internal);
+      }
     });
   });
 
@@ -331,6 +343,16 @@ describe('org routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.id).toBe('partner-1');
+
+      // Explicit projection: internal metadata columns must not be selected.
+      const projection = vi.mocked(db.select).mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+      expect(projection).toBeDefined();
+      const keys = Object.keys(projection!);
+      expect(keys).toContain('id');
+      expect(keys).toContain('settings');
+      for (const internal of ['signupIp', 'paymentMethodAttachedAt', 'stripeCustomerId', 'ssoConfig', 'mcpOriginIp']) {
+        expect(keys).not.toContain(internal);
+      }
     });
 
     it('should return 404 when partner not found', async () => {
@@ -2603,6 +2625,54 @@ describe('org routes', () => {
 
       expect(res.status).toBe(404);
     });
+
+    it('selects an explicit column projection that excludes internal metadata columns', async () => {
+      // Serialization hygiene: the handler must pass an explicit column map to
+      // db.select() so internal columns (signup attribution, Stripe linkage,
+      // MCP-origin metadata, ssoConfig) never reach partner-scoped tokens —
+      // and a future column added to the schema does not auto-appear in the
+      // response. The db is mocked, so the enforcing assertion here is the
+      // projection object the handler hands to select(), not the mocked body.
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      let selectedColumns: Record<string, unknown> | undefined;
+      vi.mocked(db.select).mockImplementationOnce(((columns: Record<string, unknown>) => {
+        selectedColumns = columns;
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ id: 'partner-123', name: 'Acme MSP', slug: 'acme', settings: {} }])
+            })
+          })
+        };
+      }) as any);
+
+      const res = await app.request('/orgs/partners/me');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({ id: 'partner-123', name: 'Acme MSP', slug: 'acme' });
+
+      expect(selectedColumns).toBeDefined();
+      const keys = Object.keys(selectedColumns!);
+      for (const expected of [
+        'id', 'name', 'slug', 'type', 'plan', 'status', 'timezone', 'settings',
+        'billingEmail', 'emailSignature', 'inboundLocalPart', 'currencyCode',
+        'defaultTaxRate', 'invoiceNumberPrefix', 'invoiceTermsDays', 'invoiceFooter',
+        'billingCompanyName', 'billingPhone', 'billingWebsite',
+        'billingAddressLine1', 'billingAddressLine2', 'billingAddressCity',
+        'billingAddressRegion', 'billingAddressPostalCode', 'billingAddressCountry',
+        'billingTermsAndConditions', 'defaultMarkupPercent', 'autoTaxHardware',
+        'catalogAiStyle', 'aiForOfficeEnabled', 'createdAt', 'updatedAt',
+      ]) {
+        expect(keys).toContain(expected);
+      }
+      for (const internal of [
+        'signupIp', 'signupUserAgent', 'mcpOrigin', 'mcpOriginIp', 'mcpOriginUserAgent',
+        'emailVerifiedAt', 'paymentMethodAttachedAt', 'stripeCustomerId', 'ssoConfig', 'deletedAt',
+      ]) {
+        expect(keys).not.toContain(internal);
+      }
+    });
   });
 
   describe('GET /partners/me/ip-allowlist/status', () => {
@@ -2692,6 +2762,53 @@ describe('org routes', () => {
 
       expect(res.status).toBe(400);
       expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('passes an explicit column projection to .returning() that excludes internal metadata columns', async () => {
+      // Same serialization-hygiene contract as GET /partners/me: the updated
+      // row is echoed back to a partner-scoped token, so the .returning()
+      // clause must be an explicit projection — never the whole partners row.
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      const currentPartner = { id: 'partner-123', name: 'Acme MSP', settings: {} };
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([currentPartner]),
+          }),
+        }),
+      } as any);
+      let returningColumns: Record<string, unknown> | undefined;
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockImplementation((columns: Record<string, unknown>) => {
+              returningColumns = columns;
+              return Promise.resolve([{ ...currentPartner, name: 'Acme Managed Services' }]);
+            }),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request('/orgs/partners/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Acme Managed Services' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ id: 'partner-123', name: 'Acme Managed Services' });
+
+      expect(returningColumns).toBeDefined();
+      const keys = Object.keys(returningColumns!);
+      for (const expected of ['id', 'name', 'slug', 'status', 'settings', 'billingEmail', 'emailSignature', 'updatedAt']) {
+        expect(keys).toContain(expected);
+      }
+      for (const internal of [
+        'signupIp', 'signupUserAgent', 'mcpOrigin', 'mcpOriginIp', 'mcpOriginUserAgent',
+        'emailVerifiedAt', 'paymentMethodAttachedAt', 'stripeCustomerId', 'ssoConfig', 'deletedAt',
+      ]) {
+        expect(keys).not.toContain(internal);
+      }
     });
 
     it('rejects a logoUrl exceeding 400 KB', async () => {

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -288,6 +288,55 @@ orgRoutes.get('/', requireScope('organization', 'partner', 'system'), requireOrg
 
 // --- Partners (system admins) ---
 
+// Explicit wire shape for partner rows. Every handler that serializes a partner
+// row (the /partners list/create/get/patch handlers and GET/PATCH /partners/me)
+// must project through this map instead of returning the whole `partners` row,
+// so internal/operational columns never reach API clients — and a column added
+// to the schema later does not silently start appearing in responses until it
+// is deliberately added here. Intentionally excluded: signupIp,
+// signupUserAgent, mcpOrigin, mcpOriginIp, mcpOriginUserAgent (signup
+// attribution), emailVerifiedAt (activation-gate bookkeeping read by
+// middleware), paymentMethodAttachedAt, stripeCustomerId (billing-provider
+// linkage), ssoConfig (may carry IdP secrets; managed via dedicated SSO
+// routes), deletedAt (soft-delete bookkeeping — these handlers already filter
+// deleted rows out).
+const partnerPublicColumns = {
+  id: partners.id,
+  name: partners.name,
+  slug: partners.slug,
+  inboundLocalPart: partners.inboundLocalPart,
+  type: partners.type,
+  plan: partners.plan,
+  status: partners.status,
+  maxOrganizations: partners.maxOrganizations,
+  maxDevices: partners.maxDevices,
+  timezone: partners.timezone,
+  settings: partners.settings,
+  billingEmail: partners.billingEmail,
+  emailSignature: partners.emailSignature,
+  currencyCode: partners.currencyCode,
+  defaultTaxRate: partners.defaultTaxRate,
+  invoiceNumberPrefix: partners.invoiceNumberPrefix,
+  invoiceTermsDays: partners.invoiceTermsDays,
+  invoiceFooter: partners.invoiceFooter,
+  billingCompanyName: partners.billingCompanyName,
+  billingPhone: partners.billingPhone,
+  billingWebsite: partners.billingWebsite,
+  billingAddressLine1: partners.billingAddressLine1,
+  billingAddressLine2: partners.billingAddressLine2,
+  billingAddressCity: partners.billingAddressCity,
+  billingAddressRegion: partners.billingAddressRegion,
+  billingAddressPostalCode: partners.billingAddressPostalCode,
+  billingAddressCountry: partners.billingAddressCountry,
+  billingTermsAndConditions: partners.billingTermsAndConditions,
+  defaultMarkupPercent: partners.defaultMarkupPercent,
+  autoTaxHardware: partners.autoTaxHardware,
+  catalogAiStyle: partners.catalogAiStyle,
+  aiForOfficeEnabled: partners.aiForOfficeEnabled,
+  createdAt: partners.createdAt,
+  updatedAt: partners.updatedAt,
+};
+
 orgRoutes.get('/partners', requireScope('system'), requireOrgRead, zValidator('query', paginationSchema), async (c) => {
   const { page, limit, offset } = getPagination(c.req.valid('query'));
 
@@ -299,7 +348,7 @@ orgRoutes.get('/partners', requireScope('system'), requireOrgRead, zValidator('q
   const count = countResult[0]?.count ?? 0;
 
   const data = await db
-    .select()
+    .select(partnerPublicColumns)
     .from(partners)
     .where(conditions)
     .limit(limit)
@@ -344,7 +393,7 @@ orgRoutes.post('/partners', requireScope('system'), requireOrgWrite, requireMfa(
         settings: data.settings,
         billingEmail: data.billingEmail
       })
-      .returning();
+      .returning(partnerPublicColumns);
     if (newPartner) {
       await seedSystemTicketStatuses(tx, newPartner.id);
     }
@@ -572,7 +621,7 @@ orgRoutes.get('/partners/me', requireScope('partner'), requirePartner, requireOr
   const auth = c.get('auth');
 
   const [partner] = await db
-    .select()
+    .select(partnerPublicColumns)
     .from(partners)
     .where(and(eq(partners.id, auth.partnerId as string), isNull(partners.deletedAt)))
     .limit(1);
@@ -755,7 +804,7 @@ orgRoutes.patch(
     .update(partners)
     .set(updateData)
     .where(and(eq(partners.id, auth.partnerId as string), isNull(partners.deletedAt)))
-    .returning();
+    .returning(partnerPublicColumns);
 
   if (!partner) {
     return c.json({ error: 'Partner not found' }, 404);
@@ -786,7 +835,7 @@ orgRoutes.get('/partners/:id', requireScope('system'), requireOrgRead, async (c)
   const id = c.req.param('id')!;
 
   const [partner] = await db
-    .select()
+    .select(partnerPublicColumns)
     .from(partners)
     .where(and(eq(partners.id, id), isNull(partners.deletedAt)))
     .limit(1);
@@ -886,7 +935,7 @@ orgRoutes.patch('/partners/:id', requireScope('system'), requireOrgWrite, requir
     .update(partners)
     .set(updates)
     .where(and(eq(partners.id, id), isNull(partners.deletedAt)))
-    .returning();
+    .returning(partnerPublicColumns);
 
   if (!partner) {
     return c.json({ error: 'Partner not found' }, 404);

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -300,7 +300,12 @@ orgRoutes.get('/', requireScope('organization', 'partner', 'system'), requireOrg
 // linkage), ssoConfig (may carry IdP secrets; managed via dedicated SSO
 // routes), deletedAt (soft-delete bookkeeping — these handlers already filter
 // deleted rows out).
-const partnerPublicColumns = {
+//
+// Built lazily (a function, not a module-scope object) so importing this module
+// never dereferences `partners.*` at load time. Test files that
+// `vi.mock('../db/schema')` with a partial mock would otherwise fail to import
+// orgs.ts at all ("No 'partners' export is defined on the mock").
+const partnerPublicColumns = () => ({
   id: partners.id,
   name: partners.name,
   slug: partners.slug,
@@ -335,7 +340,7 @@ const partnerPublicColumns = {
   aiForOfficeEnabled: partners.aiForOfficeEnabled,
   createdAt: partners.createdAt,
   updatedAt: partners.updatedAt,
-};
+});
 
 orgRoutes.get('/partners', requireScope('system'), requireOrgRead, zValidator('query', paginationSchema), async (c) => {
   const { page, limit, offset } = getPagination(c.req.valid('query'));
@@ -348,7 +353,7 @@ orgRoutes.get('/partners', requireScope('system'), requireOrgRead, zValidator('q
   const count = countResult[0]?.count ?? 0;
 
   const data = await db
-    .select(partnerPublicColumns)
+    .select(partnerPublicColumns())
     .from(partners)
     .where(conditions)
     .limit(limit)
@@ -393,7 +398,7 @@ orgRoutes.post('/partners', requireScope('system'), requireOrgWrite, requireMfa(
         settings: data.settings,
         billingEmail: data.billingEmail
       })
-      .returning(partnerPublicColumns);
+      .returning(partnerPublicColumns());
     if (newPartner) {
       await seedSystemTicketStatuses(tx, newPartner.id);
     }
@@ -621,7 +626,7 @@ orgRoutes.get('/partners/me', requireScope('partner'), requirePartner, requireOr
   const auth = c.get('auth');
 
   const [partner] = await db
-    .select(partnerPublicColumns)
+    .select(partnerPublicColumns())
     .from(partners)
     .where(and(eq(partners.id, auth.partnerId as string), isNull(partners.deletedAt)))
     .limit(1);
@@ -804,7 +809,7 @@ orgRoutes.patch(
     .update(partners)
     .set(updateData)
     .where(and(eq(partners.id, auth.partnerId as string), isNull(partners.deletedAt)))
-    .returning(partnerPublicColumns);
+    .returning(partnerPublicColumns());
 
   if (!partner) {
     return c.json({ error: 'Partner not found' }, 404);
@@ -835,7 +840,7 @@ orgRoutes.get('/partners/:id', requireScope('system'), requireOrgRead, async (c)
   const id = c.req.param('id')!;
 
   const [partner] = await db
-    .select(partnerPublicColumns)
+    .select(partnerPublicColumns())
     .from(partners)
     .where(and(eq(partners.id, id), isNull(partners.deletedAt)))
     .limit(1);
@@ -935,7 +940,7 @@ orgRoutes.patch('/partners/:id', requireScope('system'), requireOrgWrite, requir
     .update(partners)
     .set(updates)
     .where(and(eq(partners.id, id), isNull(partners.deletedAt)))
-    .returning(partnerPublicColumns);
+    .returning(partnerPublicColumns());
 
   if (!partner) {
     return c.json({ error: 'Partner not found' }, 404);


### PR DESCRIPTION
## Summary

Serialization hygiene / defense-in-depth for the partner endpoints in `apps/api/src/routes/orgs.ts`.

The partner-facing handlers (`GET /partners/me`, `PATCH /partners/me`) and the system-scoped partner handlers (`GET /partners`, `POST /partners`, `GET /partners/:id`, `PATCH /partners/:id`) serialized the **entire** `partners` row (`db.select()` / bare `.returning()`). That has two problems:

1. Internal metadata columns should not be returned to partner-scoped tokens.
2. Any column added to the `partners` schema in the future auto-appears in API responses without anyone deciding it should.

This PR introduces a single explicit projection, `partnerPublicColumns`, used by all six handlers (`db.select(partnerPublicColumns)` on reads, `.returning(partnerPublicColumns)` on writes), so GET and PATCH stay in sync and new columns are opt-in.

## Excluded columns

- `signupIp`, `signupUserAgent`, `mcpOrigin`, `mcpOriginIp`, `mcpOriginUserAgent` — signup attribution metadata
- `paymentMethodAttachedAt`, `stripeCustomerId` — billing-provider linkage
- `emailVerifiedAt` — activation-gate bookkeeping read by middleware
- `ssoConfig` — may carry IdP secrets; SSO is managed via its dedicated routes
- `deletedAt` — soft-delete bookkeeping (these handlers already filter deleted rows)

## Included columns (verified against frontend usage)

Everything `apps/web` actually consumes from these endpoints, plus the obviously partner-appropriate fields: `id`, `name`, `slug`, `inboundLocalPart`, `type`, `plan`, `status`, `maxOrganizations`, `maxDevices`, `timezone`, `settings`, `billingEmail`, `emailSignature`, the invoice/billing-address block (`currencyCode`, `defaultTaxRate`, `invoiceNumberPrefix`, `invoiceTermsDays`, `invoiceFooter`, `billingCompanyName`, `billingPhone`, `billingWebsite`, `billingAddress*`, `billingTermsAndConditions`), `defaultMarkupPercent`, `autoTaxHardware`, `catalogAiStyle`, `aiForOfficeEnabled`, `createdAt`, `updatedAt`.

Frontend consumers audited: `PartnerSettingsPage`, `PartnerCompanyTab`, `PartnerBillingSettings`, `InboundEmailCard`, `LoginBrandingCard`, `OrganizationsPage`, `TdSynnexCatalogPanel`, `TdSynnexEcExpressPanel`, `AdminSessionManager`, `Sidebar`, `QuoteEditor`, `QuoteActions`, `reportExport`, and the system-scope `orgStore` partner list. None of them reads any of the excluded columns.

## Tests

Extended `apps/api/src/routes/orgs.test.ts`:
- `GET /partners/me` and `PATCH /partners/me` assert the handler passes an explicit projection (to `select()` / `.returning()`) that contains the expected public fields and does **not** contain `signupIp`, `paymentMethodAttachedAt`, `stripeCustomerId`, or the other internal columns.
- The existing `GET /partners` and `GET /partners/:id` tests now assert the same projection contract.

`vitest run src/routes/orgs.test.ts`: 156 passed. `tsc --noEmit` (CI's typecheck command) and `eslint` on touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
