### PR TITLE
feat(api): acknowledgement routes for partner abuse signals

### DIFF
--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
-import { and, eq, inArray, ne } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, isNotNull, like, ne, type SQL } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../../db';
 import {
   partners,
@@ -11,6 +11,7 @@ import {
   users,
   sessions,
   apiKeys,
+  partnerAbuseSignals,
 } from '../../db/schema';
 import { createAuditLog } from '../../services/auditService';
 import { revokeAllPartnerOauthArtifacts } from '../../oauth/grantRevocation';
@@ -492,5 +493,232 @@ abuseRoutes.post(
         'Devices that received uninstall commands cannot be auto-restored. Re-enrollment required.',
     });
   }
+);
+
+// ---------------------------------------------------------------------------
+// Abuse-signal acknowledgement (ops tooling).
+//
+// partner_abuse_signals is system-only under forced RLS (see the
+// 2026-07-13-partner-abuse-signals migration) — a request-context query would
+// silently see zero rows, so every read/write below runs under
+// withSystemDbAccessContext, exactly like services/abuseSignals/ does.
+//
+// What acknowledging suppresses (see services/abuseSignals/persistence.ts and
+// runAbuseDigest in services/abuseSignals/index.ts):
+//  - the hourly sweep's re-notify path: an open row that has not yet been
+//    delivered (`delivered_at IS NULL`, e.g. Discord delivery kept failing)
+//    retries on every sweep until `acknowledged_at` is set;
+//  - the weekly digest: acknowledged rows drop out of the
+//    "open unacknowledged signals" severity counts and the watch-tier list.
+// Acknowledging does NOT resolve the row — the sweep keeps updating
+// severity/score on it and will still auto-resolve it as stale when the
+// underlying condition clears.
+
+/** Escape LIKE wildcards so a signalKey filter is a literal prefix match. */
+function escapeLikePrefix(prefix: string): string {
+  return prefix.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+const listSignalsQuerySchema = z.object({
+  status: z.enum(['open', 'acknowledged', 'resolved', 'all']).default('open'),
+  partnerId: z.string().uuid().optional(),
+  signalKey: z.string().trim().min(1).max(64).optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  offset: z.coerce.number().int().min(0).max(100_000).default(0),
+});
+
+const bulkAcknowledgeSchema = z.object({
+  ids: z.array(z.string().uuid()).min(1).max(100),
+});
+
+type AbuseSignalRow = typeof partnerAbuseSignals.$inferSelect;
+
+function toSignalResponse(r: AbuseSignalRow) {
+  return {
+    id: r.id,
+    partnerId: r.partnerId,
+    signalKey: r.signalKey,
+    severity: r.severity,
+    score: r.score,
+    evidence: r.evidence,
+    firstFiredAt: r.firstFiredAt,
+    computedAt: r.computedAt,
+    resolvedAt: r.resolvedAt,
+    acknowledgedAt: r.acknowledgedAt,
+    acknowledgedBy: r.acknowledgedBy,
+    deliveredAt: r.deliveredAt,
+  };
+}
+
+abuseRoutes.get(
+  '/signals',
+  requireMfa(),
+  zValidator('query', listSignalsQuerySchema),
+  async (c) => {
+    const { status, partnerId, signalKey, limit, offset } = c.req.valid('query');
+
+    const conds: SQL[] = [];
+    if (status === 'open') {
+      conds.push(isNull(partnerAbuseSignals.resolvedAt), isNull(partnerAbuseSignals.acknowledgedAt));
+    } else if (status === 'acknowledged') {
+      conds.push(isNull(partnerAbuseSignals.resolvedAt), isNotNull(partnerAbuseSignals.acknowledgedAt));
+    } else if (status === 'resolved') {
+      conds.push(isNotNull(partnerAbuseSignals.resolvedAt));
+    }
+    if (partnerId) {
+      conds.push(eq(partnerAbuseSignals.partnerId, partnerId));
+    }
+    if (signalKey) {
+      conds.push(like(partnerAbuseSignals.signalKey, `${escapeLikePrefix(signalKey)}%`));
+    }
+
+    const rows = await withSystemDbAccessContext(() =>
+      db
+        .select()
+        .from(partnerAbuseSignals)
+        .where(conds.length > 0 ? and(...conds) : undefined)
+        .orderBy(desc(partnerAbuseSignals.computedAt))
+        .limit(limit)
+        .offset(offset),
+    );
+
+    return c.json({ signals: rows.map(toSignalResponse), limit, offset });
+  },
+);
+
+abuseRoutes.post('/signals/:id/acknowledge', requireMfa(), async (c) => {
+  const auth = c.get('auth');
+  const parsedId = z.string().uuid().safeParse(c.req.param('id'));
+  if (!parsedId.success) {
+    return c.json({ error: 'invalid signal id' }, 400);
+  }
+  const id = parsedId.data;
+
+  const result = await withSystemDbAccessContext(async () => {
+    // Guarded write first: the `acknowledged_at IS NULL` predicate makes a
+    // concurrent double-ack race collapse into the idempotent path below.
+    const [updated] = await db
+      .update(partnerAbuseSignals)
+      .set({ acknowledgedAt: new Date(), acknowledgedBy: auth.user.email })
+      .where(and(eq(partnerAbuseSignals.id, id), isNull(partnerAbuseSignals.acknowledgedAt)))
+      .returning();
+    if (updated) {
+      return { notFound: false as const, alreadyAcknowledged: false as const, row: updated };
+    }
+
+    // Nothing written — either the row doesn't exist (404) or it was already
+    // acknowledged (idempotent no-op success returning current state).
+    const [existing] = await db
+      .select()
+      .from(partnerAbuseSignals)
+      .where(eq(partnerAbuseSignals.id, id))
+      .limit(1);
+    if (!existing) {
+      return { notFound: true as const };
+    }
+    return { notFound: false as const, alreadyAcknowledged: true as const, row: existing };
+  });
+
+  if (result.notFound) {
+    return c.json({ error: 'signal not found' }, 404);
+  }
+
+  if (!result.alreadyAcknowledged) {
+    await createAuditLog({
+      orgId: null,
+      actorType: 'user',
+      actorId: auth.user.id,
+      actorEmail: auth.user.email,
+      action: 'abuse_signal.acknowledged',
+      resourceType: 'abuse_signal',
+      resourceId: id,
+      details: {
+        partnerId: result.row.partnerId,
+        signalKey: result.row.signalKey,
+        severity: result.row.severity,
+      },
+      ipAddress: getTrustedClientIpOrUndefined(c),
+      userAgent: c.req.header('user-agent'),
+      result: 'success',
+    });
+  }
+
+  return c.json({
+    signal: toSignalResponse(result.row),
+    alreadyAcknowledged: result.alreadyAcknowledged,
+  });
+});
+
+abuseRoutes.post(
+  '/signals/acknowledge-bulk',
+  requireMfa(),
+  zValidator('json', bulkAcknowledgeSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { ids } = c.req.valid('json');
+    const uniqueIds = [...new Set(ids)];
+
+    const outcome = await withSystemDbAccessContext(async () => {
+      const acked = await db
+        .update(partnerAbuseSignals)
+        .set({ acknowledgedAt: new Date(), acknowledgedBy: auth.user.email })
+        .where(
+          and(
+            inArray(partnerAbuseSignals.id, uniqueIds),
+            isNull(partnerAbuseSignals.acknowledgedAt),
+          ),
+        )
+        .returning({ id: partnerAbuseSignals.id });
+      const ackedIds = new Set(acked.map((r) => r.id));
+
+      // Distinguish already-acknowledged (idempotent success) from unknown ids.
+      const remaining = uniqueIds.filter((sigId) => !ackedIds.has(sigId));
+      const existingRemaining =
+        remaining.length > 0
+          ? await db
+              .select({ id: partnerAbuseSignals.id })
+              .from(partnerAbuseSignals)
+              .where(inArray(partnerAbuseSignals.id, remaining))
+          : [];
+      const existingIds = new Set(existingRemaining.map((r) => r.id));
+
+      return {
+        results: uniqueIds.map((sigId) => ({
+          id: sigId,
+          status: ackedIds.has(sigId)
+            ? ('acknowledged' as const)
+            : existingIds.has(sigId)
+              ? ('already_acknowledged' as const)
+              : ('not_found' as const),
+        })),
+        acknowledgedCount: ackedIds.size,
+        acknowledgedIds: [...ackedIds],
+      };
+    });
+
+    if (outcome.acknowledgedCount > 0) {
+      await createAuditLog({
+        orgId: null,
+        actorType: 'user',
+        actorId: auth.user.id,
+        actorEmail: auth.user.email,
+        action: 'abuse_signal.bulk_acknowledged',
+        resourceType: 'abuse_signal',
+        details: {
+          requestedCount: uniqueIds.length,
+          acknowledgedCount: outcome.acknowledgedCount,
+          acknowledgedIds: outcome.acknowledgedIds,
+        },
+        ipAddress: getTrustedClientIpOrUndefined(c),
+        userAgent: c.req.header('user-agent'),
+        result: 'success',
+      });
+    }
+
+    return c.json({
+      results: outcome.results,
+      acknowledgedCount: outcome.acknowledgedCount,
+    });
+  },
 );
 

--- a/apps/api/src/routes/admin/abuseSignals.test.ts
+++ b/apps/api/src/routes/admin/abuseSignals.test.ts
@@ -1,0 +1,563 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Route tests for the abuse-signal acknowledgement surface in abuse.ts:
+//   GET  /admin/signals
+//   POST /admin/signals/:id/acknowledge
+//   POST /admin/signals/acknowledge-bulk
+//
+// Mirrors abuse.test.ts: real platformAdminMiddleware + real adminRoutes
+// mounting, mocked db module, schema table replaced with opaque string
+// tokens so captured Drizzle conditions can be asserted by inspection.
+// All fixtures are synthetic.
+
+const dbState = vi.hoisted(() => ({
+  // FIFO queues consumed by the db mock — seed per test.
+  selectQueue: [] as unknown[][],
+  updateQueue: [] as unknown[][],
+  // Captured call shapes.
+  wheres: [] as unknown[],
+  updateWheres: [] as unknown[],
+  setValues: [] as Array<Record<string, unknown>>,
+  limits: [] as number[],
+  offsets: [] as number[],
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(() => {
+      const rows = dbState.selectQueue.shift() ?? [];
+      const chain: any = {
+        from: () => chain,
+        where: (cond: unknown) => {
+          dbState.wheres.push(cond);
+          const thenable: any = Promise.resolve(rows);
+          thenable.limit = () => Promise.resolve(rows);
+          thenable.orderBy = () => ({
+            limit: (n: number) => {
+              dbState.limits.push(n);
+              return {
+                offset: (o: number) => {
+                  dbState.offsets.push(o);
+                  return Promise.resolve(rows);
+                },
+              };
+            },
+          });
+          return thenable;
+        },
+      };
+      return chain;
+    }),
+    update: vi.fn(() => ({
+      set: (values: Record<string, unknown>) => {
+        dbState.setValues.push(values);
+        return {
+          where: (cond: unknown) => {
+            dbState.updateWheres.push(cond);
+            return {
+              returning: () => Promise.resolve(dbState.updateQueue.shift() ?? []),
+            };
+          },
+        };
+      },
+    })),
+    transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn({})),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../db/schema')>()),
+  partnerAbuseSignals: {
+    id: 'pas.id',
+    partnerId: 'pas.partnerId',
+    signalKey: 'pas.signalKey',
+    severity: 'pas.severity',
+    score: 'pas.score',
+    evidence: 'pas.evidence',
+    firstFiredAt: 'pas.firstFiredAt',
+    computedAt: 'pas.computedAt',
+    resolvedAt: 'pas.resolvedAt',
+    acknowledgedAt: 'pas.acknowledgedAt',
+    acknowledgedBy: 'pas.acknowledgedBy',
+    deliveredAt: 'pas.deliveredAt',
+  },
+}));
+
+vi.mock('../../services/auditService', () => ({
+  createAuditLog: vi.fn(async () => undefined),
+  createAuditLogAsync: vi.fn(),
+}));
+
+vi.mock('../../services/clientIp', () => ({
+  getTrustedClientIpOrUndefined: vi.fn(() => '127.0.0.1'),
+}));
+
+// Transitive imports of abuse.ts that would otherwise pull heavy service
+// graphs into this suite — same stubs as abuse.test.ts.
+vi.mock('../../oauth/grantRevocation', () => ({
+  revokeAllPartnerOauthArtifacts: vi.fn(async () => ({
+    grantsRevoked: 0,
+    refreshTokensRevoked: 0,
+    jtisRevoked: 0,
+  })),
+}));
+vi.mock('../../services/tenantLifecycle', () => ({
+  restorePartnerTenantAccess: vi.fn(async () => ({ agentTokensRestored: 0 })),
+}));
+vi.mock('../../services/remoteSessionTeardown', () => ({
+  terminateUserRemoteSessions: vi.fn(async () => 0),
+  TEARDOWN_FAILED: -1,
+}));
+
+// Stub authMiddleware to short-circuit (the test injects its own auth
+// context); mirror the REAL requireMfa() behavior so the step-up gate is
+// exercised deterministically — see abuse.test.ts for the rationale.
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: unknown, next: () => Promise<void>) => next()),
+  requireMfa: vi.fn(() => async (c: any, next: () => Promise<void>) => {
+    const auth = c.get('auth');
+    if (!auth) {
+      return c.json({ error: 'Not authenticated' }, 401);
+    }
+    if (auth.token?.mfa === false) {
+      return c.json({ error: 'MFA required' }, 403);
+    }
+    await next();
+  }),
+  hasSatisfiedMfa: vi.fn(() => true),
+  requirePermission: vi.fn(() => async (_c: any, next: () => Promise<void>) => next()),
+}));
+
+import { Hono } from 'hono';
+import { adminRoutes } from './index';
+import { createAuditLog } from '../../services/auditService';
+
+type FakeAuth = {
+  user: { id: string; email: string; name: string; isPlatformAdmin: boolean };
+  token: { mfa: boolean };
+};
+
+function buildApp(authToInject: FakeAuth | null) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (authToInject) {
+      c.set('auth', authToInject as never);
+    }
+    await next();
+  });
+  app.route('/admin', adminRoutes);
+  return app;
+}
+
+const platformAdminAuth: FakeAuth = {
+  user: { id: 'admin-1', email: 'admin@breeze.test', name: 'PA', isPlatformAdmin: true },
+  token: { mfa: true },
+};
+
+const platformAdminAuthNoMfa: FakeAuth = {
+  user: { id: 'admin-1', email: 'admin@breeze.test', name: 'PA', isPlatformAdmin: true },
+  token: { mfa: false },
+};
+
+const partnerAdminAuth: FakeAuth = {
+  user: { id: 'pa-1', email: 'partner@synthetic.test', name: 'PartnerAdmin', isPlatformAdmin: false },
+  token: { mfa: true },
+};
+
+// Synthetic fixture ids (valid UUIDs — the routes validate the format).
+const SIG_A = '11111111-1111-4111-8111-111111111111';
+const SIG_B = '22222222-2222-4222-8222-222222222222';
+const SIG_MISSING = '99999999-9999-4999-8999-999999999999';
+const PARTNER_1 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function makeSignalRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: SIG_A,
+    partnerId: PARTNER_1,
+    signalKey: 'heuristic.device_churn',
+    severity: 'alert',
+    score: 42.5,
+    evidence: { deviceCount: 7 },
+    firstFiredAt: new Date('2026-07-20T00:00:00Z'),
+    computedAt: new Date('2026-07-24T00:00:00Z'),
+    resolvedAt: null,
+    acknowledgedAt: null,
+    acknowledgedBy: null,
+    deliveredAt: null,
+    ...overrides,
+  };
+}
+
+function resetState() {
+  dbState.selectQueue = [];
+  dbState.updateQueue = [];
+  dbState.wheres = [];
+  dbState.updateWheres = [];
+  dbState.setValues = [];
+  dbState.limits = [];
+  dbState.offsets = [];
+}
+
+// The schema mock replaces columns with string tokens, so Drizzle condition
+// trees serialize to inspectable JSON containing those tokens plus the SQL
+// operator chunks ('is null' / 'is not null').
+const asStr = (cond: unknown) => JSON.stringify(cond) ?? 'undefined';
+
+describe('admin/signals — auth gates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetState();
+  });
+
+  it('rejects non-platform-admin callers on list (403)', async () => {
+    const app = buildApp(partnerAdminAuth);
+    const res = await app.request('/admin/signals');
+    expect(res.status).toBe(403);
+    expect(dbState.wheres).toHaveLength(0);
+  });
+
+  it('rejects unauthenticated callers on list (403)', async () => {
+    const app = buildApp(null);
+    const res = await app.request('/admin/signals');
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects non-platform-admin callers on acknowledge (403)', async () => {
+    const app = buildApp(partnerAdminAuth);
+    const res = await app.request(`/admin/signals/${SIG_A}/acknowledge`, { method: 'POST' });
+    expect(res.status).toBe(403);
+    expect(dbState.setValues).toHaveLength(0);
+    expect(createAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-platform-admin callers on acknowledge-bulk (403)', async () => {
+    const app = buildApp(partnerAdminAuth);
+    const res = await app.request('/admin/signals/acknowledge-bulk', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ids: [SIG_A] }),
+    });
+    expect(res.status).toBe(403);
+    expect(dbState.setValues).toHaveLength(0);
+  });
+
+  it('rejects acknowledge when MFA is not satisfied (403)', async () => {
+    const app = buildApp(platformAdminAuthNoMfa);
+    const res = await app.request(`/admin/signals/${SIG_A}/acknowledge`, { method: 'POST' });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('MFA required');
+    expect(dbState.setValues).toHaveLength(0);
+  });
+});
+
+describe('admin/signals — GET list filtering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetState();
+  });
+
+  it('defaults to open signals (resolved_at IS NULL AND acknowledged_at IS NULL)', async () => {
+    dbState.selectQueue.push([makeSignalRow()]);
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/signals');
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { signals: Array<Record<string, unknown>>; limit: number; offset: number };
+    expect(body.signals).toHaveLength(1);
+    expect(body.signals[0]).toMatchObject({
+      id: SIG_A,
+      partnerId: PARTNER_1,
+      signalKey: 'heuristic.device_churn',
+      severity: 'alert',
+      score: 42.5,
+      evidence: { deviceCount: 7 },
+      resolvedAt: null,
+      acknowledgedAt: null,
+      acknowledgedBy: null,
+      deliveredAt: null,
+    });
+    expect(body.limit).toBe(50);
+    expect(body.offset).toBe(0);
+    expect(dbState.limits).toEqual([50]);
+    expect(dbState.offsets).toEqual([0]);
+
+    const where = asStr(dbState.wheres[0]);
+    expect(where).toContain('pas.resolvedAt');
+    expect(where).toContain('pas.acknowledgedAt');
+    expect(where).toContain('is null');
+    expect(where).not.toContain('is not null');
+  });
+
+  it('status=acknowledged filters to acknowledged_at IS NOT NULL (still unresolved)', async () => {
+    dbState.selectQueue.push([]);
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/signals?status=acknowledged');
+    expect(res.status).toBe(200);
+
+    const where = asStr(dbState.wheres[0]);
+    expect(where).toContain('pas.resolvedAt');
+    expect(where).toContain('pas.acknowledgedAt');
+    expect(where).toContain('is not null');
+  });
+
+  it('status=resolved filters on resolved_at IS NOT NULL only', async () => {
+    dbState.selectQueue.push([]);
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/signals?status=resolved');
+    expect(res.status).toBe(200);
+
+    const where = asStr(dbState.wheres[0]);
+    expect(where).toContain('pas.resolvedAt');
+    expect(where).toContain('is not null');
+    expect(where).not.toContain('pas.acknowledgedAt');
+  });
+
+  it('status=all with no other filters applies no where clause', async () => {
+    dbState.selectQueue.push([]);
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/signals?status=all');
+    expect(res.status).toBe(200);
+    expect(dbState.wheres).toEqual([undefined]);
+  });
+
+  it('applies partnerId and signalKey prefix filters (LIKE wildcards escaped)', async () => {
+    dbState.selectQueue.push([]);
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request(
+      `/admin/signals?partnerId=${PARTNER_1}&signalKey=invariant.100%25_churn`,
+    );
+    expect(res.status).toBe(200);
+
+    const where = asStr(dbState.wheres[0]);
+    expect(where).toContain('pas.partnerId');
+    expect(where).toContain(PARTNER_1);
+    // '100%_churn' prefix → wildcards escaped, trailing % appended for prefix match.
+    expect(where).toContain('invariant.100\\\\%\\\\_churn%');
+  });
+
+  it('respects limit/offset and caps limit at 200 (400 beyond)', async () => {
+    dbState.selectQueue.push([]);
+    const app = buildApp(platformAdminAuth);
+    const ok = await app.request('/admin/signals?limit=200&offset=25');
+    expect(ok.status).toBe(200);
+    expect(dbState.limits).toEqual([200]);
+    expect(dbState.offsets).toEqual([25]);
+
+    const tooBig = await app.request('/admin/signals?limit=201');
+    expect(tooBig.status).toBe(400);
+  });
+
+  it('400s on an invalid status value', async () => {
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/signals?status=bogus');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('admin/signals — POST :id/acknowledge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetState();
+  });
+
+  it('acknowledges an open signal: writes acknowledged_at + acknowledged_by, audits', async () => {
+    const ackedRow = makeSignalRow({
+      acknowledgedAt: new Date('2026-07-24T12:00:00Z'),
+      acknowledgedBy: 'admin@breeze.test',
+    });
+    dbState.updateQueue.push([ackedRow]);
+
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request(`/admin/signals/${SIG_A}/acknowledge`, { method: 'POST' });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { signal: Record<string, unknown>; alreadyAcknowledged: boolean };
+    expect(body.alreadyAcknowledged).toBe(false);
+    expect(body.signal.acknowledgedBy).toBe('admin@breeze.test');
+    expect(body.signal.acknowledgedAt).toBeTruthy();
+
+    // Both columns written from the auth context, guarded on unacked rows only.
+    expect(dbState.setValues).toHaveLength(1);
+    expect(dbState.setValues[0]!.acknowledgedAt).toBeInstanceOf(Date);
+    expect(dbState.setValues[0]!.acknowledgedBy).toBe('admin@breeze.test');
+    const updateWhere = asStr(dbState.updateWheres[0]);
+    expect(updateWhere).toContain('pas.id');
+    expect(updateWhere).toContain('pas.acknowledgedAt');
+    expect(updateWhere).toContain('is null');
+
+    expect(createAuditLog).toHaveBeenCalledTimes(1);
+    const auditCall = vi.mocked(createAuditLog).mock.calls[0]![0]!;
+    expect(auditCall.action).toBe('abuse_signal.acknowledged');
+    expect(auditCall.resourceId).toBe(SIG_A);
+    expect(auditCall.result).toBe('success');
+    expect(auditCall.details).toMatchObject({
+      partnerId: PARTNER_1,
+      signalKey: 'heuristic.device_churn',
+    });
+  });
+
+  it('re-acknowledging is an idempotent no-op success returning current state', async () => {
+    const originalAck = new Date('2026-07-21T00:00:00Z');
+    dbState.updateQueue.push([]); // guarded UPDATE matches nothing
+    dbState.selectQueue.push([
+      makeSignalRow({ acknowledgedAt: originalAck, acknowledgedBy: 'first-responder@breeze.test' }),
+    ]);
+
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request(`/admin/signals/${SIG_A}/acknowledge`, { method: 'POST' });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { signal: Record<string, unknown>; alreadyAcknowledged: boolean };
+    expect(body.alreadyAcknowledged).toBe(true);
+    // Current state preserved — the original acknowledger is NOT overwritten.
+    expect(body.signal.acknowledgedBy).toBe('first-responder@breeze.test');
+    expect(body.signal.acknowledgedAt).toBe(originalAck.toISOString());
+    // No-op path writes no audit row.
+    expect(createAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('404s for an unknown signal id', async () => {
+    dbState.updateQueue.push([]);
+    dbState.selectQueue.push([]);
+
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request(`/admin/signals/${SIG_MISSING}/acknowledge`, { method: 'POST' });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('signal not found');
+    expect(createAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('400s on a non-UUID id without touching the database', async () => {
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/signals/not-a-uuid/acknowledge', { method: 'POST' });
+    expect(res.status).toBe(400);
+    expect(dbState.setValues).toHaveLength(0);
+    expect(dbState.wheres).toHaveLength(0);
+  });
+});
+
+describe('admin/signals — POST acknowledge-bulk', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetState();
+  });
+
+  it('handles mixed known/already-acked/unknown ids with per-id results', async () => {
+    // SIG_A is open → acknowledged by the guarded UPDATE.
+    dbState.updateQueue.push([{ id: SIG_A }]);
+    // Of the remainder, SIG_B exists (already acked), SIG_MISSING does not.
+    dbState.selectQueue.push([{ id: SIG_B }]);
+
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/signals/acknowledge-bulk', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ids: [SIG_A, SIG_B, SIG_MISSING] }),
+    });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      results: Array<{ id: string; status: string }>;
+      acknowledgedCount: number;
+    };
+    expect(body.acknowledgedCount).toBe(1);
+    expect(body.results).toEqual([
+      { id: SIG_A, status: 'acknowledged' },
+      { id: SIG_B, status: 'already_acknowledged' },
+      { id: SIG_MISSING, status: 'not_found' },
+    ]);
+
+    // Single guarded UPDATE carrying both columns.
+    expect(dbState.setValues).toHaveLength(1);
+    expect(dbState.setValues[0]!.acknowledgedAt).toBeInstanceOf(Date);
+    expect(dbState.setValues[0]!.acknowledgedBy).toBe('admin@breeze.test');
+    const updateWhere = asStr(dbState.updateWheres[0]);
+    expect(updateWhere).toContain('pas.acknowledgedAt');
+    expect(updateWhere).toContain('is null');
+
+    expect(createAuditLog).toHaveBeenCalledTimes(1);
+    const auditCall = vi.mocked(createAuditLog).mock.calls[0]![0]!;
+    expect(auditCall.action).toBe('abuse_signal.bulk_acknowledged');
+    expect(auditCall.details).toMatchObject({
+      requestedCount: 3,
+      acknowledgedCount: 1,
+      acknowledgedIds: [SIG_A],
+    });
+  });
+
+  it('is a no-op success (no audit) when every id was already acknowledged', async () => {
+    dbState.updateQueue.push([]);
+    dbState.selectQueue.push([{ id: SIG_A }, { id: SIG_B }]);
+
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/signals/acknowledge-bulk', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ids: [SIG_A, SIG_B] }),
+    });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { results: Array<{ status: string }>; acknowledgedCount: number };
+    expect(body.acknowledgedCount).toBe(0);
+    expect(body.results.every((r) => r.status === 'already_acknowledged')).toBe(true);
+    expect(createAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates repeated ids in the request body', async () => {
+    dbState.updateQueue.push([{ id: SIG_A }]);
+    // No remaining ids → no follow-up select needed.
+
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/signals/acknowledge-bulk', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ids: [SIG_A, SIG_A, SIG_A] }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: Array<{ id: string; status: string }> };
+    expect(body.results).toEqual([{ id: SIG_A, status: 'acknowledged' }]);
+    // The dedup means no leftover ids, so no existence-check select fired.
+    expect(dbState.wheres).toHaveLength(0);
+  });
+
+  it('400s on an empty ids array', async () => {
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/signals/acknowledge-bulk', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ids: [] }),
+    });
+    expect(res.status).toBe(400);
+    expect(dbState.setValues).toHaveLength(0);
+  });
+
+  it('400s when more than 100 ids are supplied', async () => {
+    const ids = Array.from({ length: 101 }, (_, i) =>
+      `${String(i).padStart(8, '0')}-0000-4000-8000-000000000000`,
+    );
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/signals/acknowledge-bulk', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ids }),
+    });
+    expect(res.status).toBe(400);
+    expect(dbState.setValues).toHaveLength(0);
+  });
+
+  it('400s on non-UUID ids', async () => {
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/signals/acknowledge-bulk', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ids: ['nope'] }),
+    });
+    expect(res.status).toBe(400);
+    expect(dbState.setValues).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

`partner_abuse_signals` has had `acknowledged_at` / `acknowledged_by` columns since the sweep shipped, and the sweep's persistence layer plus the weekly digest already treat `acknowledged_at` as the suppression mechanism — but nothing ever wrote those columns. This PR adds the missing ops-tooling API surface so operators can actually acknowledge signals. API routes + tests only; no web UI in this PR.

## Routes (all under `/admin`, platform-admin + MFA step-up gated, same as the existing suspend/unsuspend routes in `routes/admin/abuse.ts`)

- **`GET /admin/signals`** — list signals with `status=open|acknowledged|resolved|all` (default `open`), optional `partnerId`, optional `signalKey` prefix filter (LIKE wildcards escaped), `limit` (1–200, default 50) / `offset`. Returns compact rows matching the schema columns (`id`, `partnerId`, `signalKey`, `severity`, `score`, `evidence`, `firstFiredAt`, `computedAt`, `resolvedAt`, `acknowledgedAt`, `acknowledgedBy`, `deliveredAt`).
- **`POST /admin/signals/:id/acknowledge`** — sets `acknowledged_at = now()`, `acknowledged_by = <caller email>`. Idempotent: re-acking an already-acknowledged row is a no-op success returning current state (original acknowledger preserved). 404 for unknown ids. Guarded UPDATE-first (`acknowledged_at IS NULL` predicate) so a concurrent double-ack collapses into the idempotent path.
- **`POST /admin/signals/acknowledge-bulk`** — Zod-validated `{ ids: uuid[] }` capped at 100, single guarded UPDATE, per-id results: `acknowledged` / `already_acknowledged` / `not_found`.

Acknowledgements are audit-logged (`abuse_signal.acknowledged` / `abuse_signal.bulk_acknowledged`); idempotent no-ops are not, to keep the trail signal-bearing.

## RLS note

The table is system-only under forced RLS (`2026-07-13-partner-abuse-signals.sql`), so every read/write runs under `withSystemDbAccessContext` — a request-context query would silently see zero rows. Same pattern as `services/abuseSignals/` and the existing routes in this file.

## What acknowledging actually suppresses

Per `services/abuseSignals/persistence.ts` and `runAbuseDigest`:

- **Hourly re-notify retries**: the sweep only re-notifies open rows with `delivered_at IS NULL AND acknowledged_at IS NULL` — i.e. rows whose ops-alert delivery kept failing retried every sweep forever. Acknowledging stops that loop.
- **Weekly digest inclusion**: acknowledged rows drop out of the "open unacknowledged signals" severity counts and the watch-tier list.
- **Not suppressed**: the sweep keeps updating severity/score on acknowledged rows, and stale auto-resolution still applies when the underlying condition clears. Acknowledging is "an operator has seen this", not "resolve".

## Tests

New `routes/admin/abuseSignals.test.ts` (22 tests, synthetic fixtures) mirroring the existing `abuse.test.ts` pattern: platform-admin gate rejections, MFA step-up, list filtering per status + partnerId/signalKey/limit caps, ack happy path (both columns written from auth context), idempotent re-ack, 404, bulk with mixed known/already-acked/unknown ids, dedup, and Zod validation failures. Existing `abuse.test.ts` (27 tests) still green; `tsc --noEmit` on the API project clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)