### PR TITLE
feat(api): offboarding drain state — deliverable self_uninstall for churning tenants (#2774)

### DIFF
--- a/apps/api/migrations/2026-08-05-offboarding-drain-state.sql
+++ b/apps/api/migrations/2026-08-05-offboarding-drain-state.sql
@@ -1,0 +1,21 @@
+-- Offboarding drain state (#2774).
+--
+-- Adds a terminal-intent `offboarding` value to both tenant status enums plus
+-- a drain-window start timestamp on each table. During `offboarding`, users
+-- are locked out (every user-facing gate is an explicit allowlist that does
+-- not admit the new value) while the agent auth gate stays open in a narrowed
+-- "drain" mode so a queued self_uninstall can actually be delivered. The
+-- offboarding drain reaper severs credentials and flips the tenant to
+-- `churned` once the fleet drains or the window closes.
+--
+-- ALTER TYPE ... ADD VALUE runs inside autoMigrate's transaction; that is
+-- legal (PG 12+) because nothing in this migration USES the new value.
+
+ALTER TYPE org_status ADD VALUE IF NOT EXISTS 'offboarding';
+ALTER TYPE partner_status ADD VALUE IF NOT EXISTS 'offboarding';
+
+-- NULL = not offboarding. Set on drain entry (preserved across re-entry),
+-- cleared on abort/finalize. The drain deadline is computed at sweep time as
+-- offboarding_started_at + OFFBOARDING_DRAIN_WINDOW_HOURS (default 72).
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS offboarding_started_at timestamptz;
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS offboarding_started_at timestamptz;

--- a/apps/api/src/db/schema/orgs.ts
+++ b/apps/api/src/db/schema/orgs.ts
@@ -2,11 +2,14 @@ import { pgTable, uuid, varchar, text, timestamp, jsonb, pgEnum, integer, boolea
 import { sql } from 'drizzle-orm';
 
 export const partnerTypeEnum = pgEnum('partner_type', ['msp', 'enterprise', 'internal']);
-export const partnerStatusEnum = pgEnum('partner_status', ['pending', 'active', 'suspended', 'churned']);
+// `offboarding` (#2774) is the terminal-intent drain state: users locked out
+// immediately, agents kept authenticated in a narrowed self_uninstall-only
+// mode until the fleet drains or the window closes, then severed + `churned`.
+export const partnerStatusEnum = pgEnum('partner_status', ['pending', 'active', 'suspended', 'churned', 'offboarding']);
 export type PartnerStatus = typeof partnerStatusEnum.enumValues[number];
 export const planTypeEnum = pgEnum('plan_type', ['free', 'starter', 'community', 'pro', 'enterprise', 'unlimited']);
 export const orgTypeEnum = pgEnum('org_type', ['customer', 'internal']);
-export const orgStatusEnum = pgEnum('org_status', ['active', 'suspended', 'trial', 'churned']);
+export const orgStatusEnum = pgEnum('org_status', ['active', 'suspended', 'trial', 'churned', 'offboarding']);
 
 export const partners = pgTable('partners', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -73,6 +76,9 @@ export const partners = pgTable('partners', {
   // surface gate on this; it is NOT in settings JSONB because that is
   // partner-writable and the partner must not be able to self-enable.
   aiForOfficeEnabled: boolean('ai_for_office_enabled').notNull().default(false),
+  // #2774 — NULL = not offboarding. Set on drain entry, cleared on
+  // abort/finalize. Drain deadline = this + OFFBOARDING_DRAIN_WINDOW_HOURS.
+  offboardingStartedAt: timestamp('offboarding_started_at', { withTimezone: true }),
 });
 
 export const organizations = pgTable('organizations', {
@@ -102,6 +108,9 @@ export const organizations = pgTable('organizations', {
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
   partnerExportUpdatedAt: timestamp('partner_export_updated_at', { precision: 3 }).defaultNow().notNull(),
+  // #2774 — NULL = not offboarding. Set on drain entry, cleared on
+  // abort/finalize. Drain deadline = this + OFFBOARDING_DRAIN_WINDOW_HOURS.
+  offboardingStartedAt: timestamp('offboarding_started_at', { withTimezone: true }),
   deletedAt: timestamp('deleted_at')
 }, (table) => ({
   orgPartnerUnique: uniqueIndex('organizations_id_partner_id_unique').on(table.id, table.partnerId),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -259,6 +259,7 @@ import {
 import { initializeStaleCommandReaper, shutdownStaleCommandReaper } from './jobs/staleCommandReaper';
 import { initializePamJobs, shutdownPamJobs } from './jobs/pamJobs';
 import { initializeApprovalExpiryReaper, shutdownApprovalExpiryReaper } from './jobs/approvalExpiryReaper';
+import { initializeOffboardingDrainReaper, shutdownOffboardingDrainReaper } from './jobs/offboardingDrainReaper';
 import { initializeIntentOutboxPublisher, shutdownIntentOutboxPublisher } from './jobs/intentOutboxPublisher';
 import { initializeIntentExpiryReaper, shutdownIntentExpiryReaper } from './jobs/intentExpiryReaper';
 import { initializeIntentReleaseWorker, shutdownIntentReleaseWorker } from './jobs/intentReleaseWorker';
@@ -1269,6 +1270,7 @@ async function initializeWorkers(): Promise<void> {
     ['staleCommandReaper', initializeStaleCommandReaper],
     ['pamJobs', initializePamJobs],
     ['approvalExpiryReaper', initializeApprovalExpiryReaper],
+    ['offboardingDrainReaper', initializeOffboardingDrainReaper],
     ['intentOutboxPublisher', initializeIntentOutboxPublisher],
     ['intentExpiryReaper', initializeIntentExpiryReaper],
     ['intentReleaseWorker', initializeIntentReleaseWorker],
@@ -1451,6 +1453,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownStaleCommandReaper,
     shutdownPamJobs,
     shutdownApprovalExpiryReaper,
+    shutdownOffboardingDrainReaper,
     shutdownIntentOutboxPublisher,
     shutdownIntentExpiryReaper,
     shutdownIntentReleaseWorker,

--- a/apps/api/src/jobs/offboardingDrainReaper.ts
+++ b/apps/api/src/jobs/offboardingDrainReaper.ts
@@ -1,5 +1,4 @@
 import { Job, Queue, Worker } from 'bullmq';
-import * as dbModule from '../db';
 import { getBullMQConnection } from '../services/redis';
 import { captureException } from '../services/sentry';
 import { sweepOffboardingTenants } from '../services/tenantOffboarding';
@@ -23,16 +22,6 @@ const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 
 type ReaperJobData = { type: typeof JOB_NAME; queuedAt: string };
 
-const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
-  const withSystem = dbModule.withSystemDbAccessContext;
-  if (typeof withSystem !== 'function') {
-    throw new Error(
-      '[OffboardingDrainReaper] withSystemDbAccessContext not available — reaper cannot run without system DB access',
-    );
-  }
-  return withSystem(fn);
-};
-
 let reaperQueue: Queue<ReaperJobData> | null = null;
 let reaperWorker: Worker<ReaperJobData> | null = null;
 
@@ -50,10 +39,13 @@ function createWorker(): Worker<ReaperJobData> {
     QUEUE_NAME,
     async (_job: Job<ReaperJobData>) => {
       try {
-        const result = await runWithSystemDbAccess(() => sweepOffboardingTenants());
-        if (result.orgsFinalized > 0 || result.partnersFinalized > 0) {
+        // The sweep opens a system DB context PER TENANT rather than one for
+        // the whole pass — socket teardown must not run while holding a
+        // pooled connection idle-in-transaction (#1105).
+        const result = await sweepOffboardingTenants();
+        if (result.orgsFinalized > 0 || result.partnersFinalized > 0 || result.failures > 0) {
           console.log(
-            `[OffboardingDrainReaper] Finalized ${result.orgsFinalized} org(s), ${result.partnersFinalized} partner(s)`,
+            `[OffboardingDrainReaper] Finalized ${result.orgsFinalized} org(s), ${result.partnersFinalized} partner(s), ${result.failures} failure(s)`,
           );
         }
         return result;

--- a/apps/api/src/jobs/offboardingDrainReaper.ts
+++ b/apps/api/src/jobs/offboardingDrainReaper.ts
@@ -1,0 +1,143 @@
+import { Job, Queue, Worker } from 'bullmq';
+import * as dbModule from '../db';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+import { sweepOffboardingTenants } from '../services/tenantOffboarding';
+import { attachWorkerObservability } from './workerObservability';
+
+/**
+ * Offboarding drain reaper (#2774): finalizes tenants in the `offboarding`
+ * drain state. A tenant finalizes when its queued self_uninstall commands are
+ * all terminal, or when its drain window (offboarding_started_at +
+ * OFFBOARDING_DRAIN_WINDOW_HOURS) closes. Finalization cancels leftovers with
+ * an explicit never-drained audit report, severs agent credentials, and flips
+ * the tenant to `churned` — see services/tenantOffboarding.ts.
+ *
+ * Runs every 5 minutes; drain windows are hours-to-days long, so cadence is
+ * not latency-critical.
+ */
+
+const QUEUE_NAME = 'offboarding-drain-reaper';
+const JOB_NAME = 'sweep-offboarding-tenants';
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+type ReaperJobData = { type: typeof JOB_NAME; queuedAt: string };
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  if (typeof withSystem !== 'function') {
+    throw new Error(
+      '[OffboardingDrainReaper] withSystemDbAccessContext not available — reaper cannot run without system DB access',
+    );
+  }
+  return withSystem(fn);
+};
+
+let reaperQueue: Queue<ReaperJobData> | null = null;
+let reaperWorker: Worker<ReaperJobData> | null = null;
+
+function getQueue(): Queue<ReaperJobData> {
+  if (!reaperQueue) {
+    reaperQueue = new Queue<ReaperJobData>(QUEUE_NAME, {
+      connection: getBullMQConnection(),
+    });
+  }
+  return reaperQueue;
+}
+
+function createWorker(): Worker<ReaperJobData> {
+  return new Worker<ReaperJobData>(
+    QUEUE_NAME,
+    async (_job: Job<ReaperJobData>) => {
+      try {
+        const result = await runWithSystemDbAccess(() => sweepOffboardingTenants());
+        if (result.orgsFinalized > 0 || result.partnersFinalized > 0) {
+          console.log(
+            `[OffboardingDrainReaper] Finalized ${result.orgsFinalized} org(s), ${result.partnersFinalized} partner(s)`,
+          );
+        }
+        return result;
+      } catch (err) {
+        console.error('[OffboardingDrainReaper] Run failed:', err);
+        captureException(err instanceof Error ? err : new Error(String(err)));
+        throw err;
+      }
+    },
+    {
+      connection: getBullMQConnection(),
+      concurrency: 1,
+    },
+  );
+}
+
+async function scheduleRepeatableJob(): Promise<void> {
+  const queue = getQueue();
+
+  // Remove any existing repeatable jobs (in case the interval changed).
+  const repeatables = await queue.getRepeatableJobs();
+  for (const job of repeatables) {
+    if (job.name === JOB_NAME) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+
+  await queue.add(
+    JOB_NAME,
+    { type: JOB_NAME, queuedAt: new Date().toISOString() },
+    {
+      // Fixed jobId dedupes the repeatable across API replicas while every
+      // replica's worker still processes (oauthCleanup singleton idiom).
+      jobId: 'offboarding-drain-reaper',
+      repeat: { every: SWEEP_INTERVAL_MS },
+      removeOnComplete: { count: 20 },
+      removeOnFail: { count: 200 },
+    },
+  );
+}
+
+export async function initializeOffboardingDrainReaper(): Promise<void> {
+  if (reaperWorker) return;
+
+  reaperWorker = createWorker();
+  attachWorkerObservability(reaperWorker, 'offboardingDrainReaper');
+  reaperWorker.on('error', (error) => {
+    console.error('[OffboardingDrainReaper] Worker error:', error);
+    captureException(error);
+  });
+  reaperWorker.on('failed', (job, error) => {
+    console.error(`[OffboardingDrainReaper] Job ${job?.id} failed:`, error);
+    captureException(error);
+  });
+
+  try {
+    await scheduleRepeatableJob();
+  } catch (err) {
+    await reaperWorker.close();
+    reaperWorker = null;
+    throw err;
+  }
+
+  console.log('[OffboardingDrainReaper] Initialized');
+}
+
+export async function shutdownOffboardingDrainReaper(): Promise<void> {
+  const worker = reaperWorker;
+  const queue = reaperQueue;
+  reaperWorker = null;
+  reaperQueue = null;
+
+  if (worker) {
+    try {
+      await worker.close();
+    } catch (err) {
+      console.error('[OffboardingDrainReaper] Error closing worker:', err);
+    }
+  }
+  if (queue) {
+    try {
+      await queue.close();
+    } catch (err) {
+      console.error('[OffboardingDrainReaper] Error closing queue:', err);
+    }
+  }
+}

--- a/apps/api/src/jobs/staleCommandReaper.test.ts
+++ b/apps/api/src/jobs/staleCommandReaper.test.ts
@@ -183,6 +183,32 @@ describe('stale command reaper', () => {
     expect(deviceCommandReturning).toHaveBeenCalledTimes(4);
     expect(restoreWhere).toHaveBeenCalledTimes(4);
   });
+
+  // #2774 — a drain-window self_uninstall must outlive the 30-min timeout
+  // while (and only while) its tenant is `offboarding`. Pin that the SELECT's
+  // WHERE carries the offboarding-scoped exemption so a refactor can't
+  // silently drop it and resurrect the silent-expiry bug.
+  it('scopes the self_uninstall reap exemption to offboarding tenants', async () => {
+    const chain = selectChain([]);
+    selectMock.mockReturnValueOnce(chain);
+
+    await reapStaleDeviceCommands();
+
+    const whereArg = chain.where.mock.calls[0]?.[0];
+    const containsString = (root: unknown, needle: string): boolean => {
+      const seen = new WeakSet<object>();
+      const walk = (value: unknown): boolean => {
+        if (typeof value === 'string') return value.includes(needle);
+        if (!value || typeof value !== 'object') return false;
+        if (seen.has(value as object)) return false;
+        seen.add(value as object);
+        return Object.values(value as Record<string, unknown>).some(walk);
+      };
+      return walk(root);
+    };
+    expect(containsString(whereArg, 'self_uninstall')).toBe(true);
+    expect(containsString(whereArg, 'offboarding')).toBe(true);
+  });
 });
 
 describe('reapStaleBackupJobs', () => {

--- a/apps/api/src/jobs/staleCommandReaper.ts
+++ b/apps/api/src/jobs/staleCommandReaper.ts
@@ -14,6 +14,8 @@ import {
   restoreJobs,
   backupJobs,
   devices,
+  organizations,
+  partners,
   STALE_BACKUP_REAP_MARKER,
 } from '../db/schema';
 import { getBullMQConnection } from '../services/redis';
@@ -164,6 +166,29 @@ export async function reapStaleDeviceCommands(): Promise<number> {
       )})`,
     );
   }
+
+  // #2774 — a drain-window self_uninstall must outlive the 30-minute command
+  // timeout: the whole point of the `offboarding` state is waiting (up to
+  // OFFBOARDING_DRAIN_WINDOW_HOURS) for offline devices to come collect it.
+  // Scoped to tenants CURRENTLY offboarding, deliberately NOT a blanket
+  // self_uninstall exemption: abuse-queued uninstalls (partner `suspended`)
+  // must keep expiring, or an abuse suspension reversed days later would
+  // deliver stale uninstalls to a reinstated fleet. The offboarding drain
+  // reaper cancels these rows itself (with a never-drained report) when the
+  // window closes, so they cannot linger past the drain either.
+  whereConditions.push(
+    sql`NOT (
+      ${deviceCommands.type} = 'self_uninstall'
+      AND EXISTS (
+        SELECT 1
+        FROM ${devices}
+        JOIN ${organizations} ON ${organizations.id} = ${devices.orgId}
+        JOIN ${partners} ON ${partners.id} = ${organizations.partnerId}
+        WHERE ${devices.id} = ${deviceCommands.deviceId}
+          AND (${organizations.status} = 'offboarding' OR ${partners.status} = 'offboarding')
+      )
+    )`,
+  );
 
   const staleCommands = await db
     .select({

--- a/apps/api/src/middleware/agentAuth.test.ts
+++ b/apps/api/src/middleware/agentAuth.test.ts
@@ -422,6 +422,21 @@ describe('agentAuthMiddleware - offboarding drain mode', () => {
     '/api/v1/agents/agent-1/monitoring-results',
     '/api/v1/agents/agent-1/patches',
     '/api/v1/agents/agent-1/eventlogs',
+    // This middleware also serves the extension gateway
+    // (extensions/gateway.ts mounts /ext/<name>/agent/:id/* — singular
+    // "agent"). Matching on the trailing segment alone would admit every
+    // extension route whose last segment happens to be an allowed action, so
+    // the allowlist is anchored on the core `agents/<id>/<action>` shape. An
+    // extension route may NOT join the drain surface even by mimicking a core
+    // action name exactly.
+    '/api/v1/ext/acme/agent/agent-1/heartbeat',
+    '/api/v1/ext/acme/agent/agent-1/commands',
+    '/api/v1/ext/acme/agent/agent-1/commands/cmd-1/result',
+    '/api/v1/ext/acme/agent/agent-1/rotate-token/confirm',
+    '/api/v1/ext/acme/agent/agent-1/extra/heartbeat',
+    // Nested path under a real agent route with an attacker-chosen final
+    // segment (winget-bootstrap/file/:name).
+    '/api/v1/agents/agent-1/winget-bootstrap/file/heartbeat',
   ];
 
   for (const path of blockedPaths) {

--- a/apps/api/src/middleware/agentAuth.test.ts
+++ b/apps/api/src/middleware/agentAuth.test.ts
@@ -43,7 +43,7 @@ vi.mock('../services/clientIp', () => ({
 }));
 
 vi.mock('../services/tenantStatus', () => ({
-  isAgentTenantActive: vi.fn(async () => true),
+  getAgentTenantState: vi.fn(async () => 'active'),
 }));
 
 vi.mock('drizzle-orm', () => ({
@@ -59,7 +59,7 @@ import { db, withDbAccessContext } from '../db';
 import { getRedis, rateLimiter } from '../services';
 import { createAuditLogAsync } from '../services/auditService';
 import { getTrustedClientIp } from '../services/clientIp';
-import { isAgentTenantActive } from '../services/tenantStatus';
+import { getAgentTenantState } from '../services/tenantStatus';
 import {
   agentAuthMiddleware,
   isAgentTokenRotationDue,
@@ -288,7 +288,7 @@ describe('agentAuthMiddleware - tenant-status gate', () => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
     vi.mocked(getRedis).mockReturnValue({} as any);
-    vi.mocked(isAgentTenantActive).mockResolvedValue(true);
+    vi.mocked(getAgentTenantState).mockResolvedValue('active');
     vi.mocked(rateLimiter).mockResolvedValue({
       allowed: true,
       remaining: 100,
@@ -298,7 +298,7 @@ describe('agentAuthMiddleware - tenant-status gate', () => {
 
   it('rejects with an opaque 401 when the device org/partner tenant is not active', async () => {
     buildSelectMock([makeDevice()]);
-    vi.mocked(isAgentTenantActive).mockResolvedValue(false);
+    vi.mocked(getAgentTenantState).mockResolvedValue(null);
 
     const c = createContext({ token: VALID_TOKEN });
     const next = vi.fn();
@@ -308,12 +308,12 @@ describe('agentAuthMiddleware - tenant-status gate', () => {
       message: 'Invalid agent credentials',
     });
     expect(next).not.toHaveBeenCalled();
-    expect(isAgentTenantActive).toHaveBeenCalledWith('org-1');
+    expect(getAgentTenantState).toHaveBeenCalledWith('org-1');
   });
 
   it('proceeds to next() when the device tenant is active', async () => {
     buildSelectMock([makeDevice()]);
-    vi.mocked(isAgentTenantActive).mockResolvedValue(true);
+    vi.mocked(getAgentTenantState).mockResolvedValue('active');
 
     const c = createContext({ token: VALID_TOKEN });
     const next = vi.fn().mockResolvedValue(undefined);
@@ -321,7 +321,7 @@ describe('agentAuthMiddleware - tenant-status gate', () => {
     await agentAuthMiddleware(c, next);
 
     expect(next).toHaveBeenCalledTimes(1);
-    expect(isAgentTenantActive).toHaveBeenCalledWith('org-1');
+    expect(getAgentTenantState).toHaveBeenCalledWith('org-1');
   });
 
   // #1105 — the reliability ingest route self-manages a short org-scoped
@@ -330,7 +330,7 @@ describe('agentAuthMiddleware - tenant-status gate', () => {
   // request-long org transaction for this route.
   it('skips the request-long org wrap for the self-managed reliability route', async () => {
     buildSelectMock([makeDevice()]);
-    vi.mocked(isAgentTenantActive).mockResolvedValue(true);
+    vi.mocked(getAgentTenantState).mockResolvedValue('active');
 
     const c = createContext({ token: VALID_TOKEN, path: '/api/v1/agents/agent-1/reliability' });
     const next = vi.fn().mockResolvedValue(undefined);
@@ -348,7 +348,7 @@ describe('agentAuthMiddleware - tenant-status gate', () => {
   // outage, 2026-07-24), so the middleware must NOT add the request-long wrap.
   it('skips the request-long org wrap for the self-managed commands poll route', async () => {
     buildSelectMock([makeDevice()]);
-    vi.mocked(isAgentTenantActive).mockResolvedValue(true);
+    vi.mocked(getAgentTenantState).mockResolvedValue('active');
 
     const c = createContext({ token: VALID_TOKEN, path: '/api/v1/agents/agent-1/commands' });
     const next = vi.fn().mockResolvedValue(undefined);
@@ -363,7 +363,7 @@ describe('agentAuthMiddleware - tenant-status gate', () => {
   // the request-long org wrap.
   it('keeps the request-long org wrap for the command result route', async () => {
     buildSelectMock([makeDevice()]);
-    vi.mocked(isAgentTenantActive).mockResolvedValue(true);
+    vi.mocked(getAgentTenantState).mockResolvedValue('active');
 
     const c = createContext({
       token: VALID_TOKEN,
@@ -378,12 +378,98 @@ describe('agentAuthMiddleware - tenant-status gate', () => {
   });
 });
 
+// #2774 — during an `offboarding` drain the agent stays authenticated, but
+// only on the surface self_uninstall delivery needs. Everything else 403s.
+describe('agentAuthMiddleware - offboarding drain mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.mocked(getRedis).mockReturnValue({} as any);
+    vi.mocked(getAgentTenantState).mockResolvedValue('draining');
+    vi.mocked(rateLimiter).mockResolvedValue({
+      allowed: true,
+      remaining: 100,
+      resetAt: new Date(Date.now() + 60_000),
+    });
+  });
+
+  const allowedPaths = [
+    '/api/v1/agents/agent-1/heartbeat',
+    '/api/v1/agents/agent-1/commands',
+    '/api/v1/agents/agent-1/commands/cmd-1/result',
+    '/api/v1/agents/agent-1/rotate-token',
+    '/api/v1/agents/agent-1/rotate-token/confirm',
+    '/api/v1/agents/agent-1/logs',
+  ];
+
+  for (const path of allowedPaths) {
+    it(`allows ${path} while draining`, async () => {
+      buildSelectMock([makeDevice()]);
+
+      const c = createContext({ token: VALID_TOKEN, path });
+      const next = vi.fn().mockResolvedValue(undefined);
+
+      await agentAuthMiddleware(c, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+  }
+
+  const blockedPaths = [
+    '/api/v1/agents/agent-1/hardware',
+    '/api/v1/agents/agent-1/software',
+    '/api/v1/agents/agent-1/config',
+    '/api/v1/agents/agent-1/monitoring-results',
+    '/api/v1/agents/agent-1/patches',
+    '/api/v1/agents/agent-1/eventlogs',
+  ];
+
+  for (const path of blockedPaths) {
+    it(`blocks ${path} with 403 tenant_offboarding while draining`, async () => {
+      buildSelectMock([makeDevice()]);
+
+      const c = createContext({ token: VALID_TOKEN, path });
+      const next = vi.fn();
+
+      const result = await agentAuthMiddleware(c, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect((result as any).status).toBe(403);
+      expect((result as any).body).toEqual({ error: 'tenant_offboarding' });
+    });
+  }
+
+  it('sets tenantDraining on the agent context while draining', async () => {
+    buildSelectMock([makeDevice()]);
+
+    const c = createContext({ token: VALID_TOKEN, path: '/api/v1/agents/agent-1/heartbeat' });
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await agentAuthMiddleware(c, next);
+
+    expect((c.get('agent') as { tenantDraining?: boolean }).tenantDraining).toBe(true);
+  });
+
+  it('leaves tenantDraining false for a fully active tenant', async () => {
+    vi.mocked(getAgentTenantState).mockResolvedValue('active');
+    buildSelectMock([makeDevice()]);
+
+    const c = createContext({ token: VALID_TOKEN, path: '/api/v1/agents/agent-1/hardware' });
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await agentAuthMiddleware(c, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect((c.get('agent') as { tenantDraining?: boolean }).tenantDraining).toBe(false);
+  });
+});
+
 describe('agentAuthMiddleware - per-org rate limit', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
     vi.mocked(getRedis).mockReturnValue({} as any);
-    vi.mocked(isAgentTenantActive).mockResolvedValue(true);
+    vi.mocked(getAgentTenantState).mockResolvedValue('active');
   });
 
   it('returns 429 with org_rate_limit_exceeded body and Retry-After:60 when org limit is exceeded', async () => {
@@ -413,7 +499,7 @@ describe('agentAuthMiddleware - per-org rate limit', () => {
     // Ordering invariant: the tenant-status gate runs AFTER the rate limiters,
     // so an org-limit-exceeded request short-circuits to 429 WITHOUT driving an
     // (uncached) tenant lookup. Pins the DoS-hardening order.
-    expect(isAgentTenantActive).not.toHaveBeenCalled();
+    expect(getAgentTenantState).not.toHaveBeenCalled();
   });
 
   it('honors AGENT_ORG_RATE_LIMIT_PER_MIN env override', async () => {

--- a/apps/api/src/middleware/agentAuth.ts
+++ b/apps/api/src/middleware/agentAuth.ts
@@ -267,6 +267,9 @@ export async function suspendAgentToken(deviceId: string, reason: AgentTokenSusp
  */
 const SELF_MANAGED_DB_CONTEXT_ACTIONS = new Set(['heartbeat', 'reliability', 'commands']);
 
+/** Single-segment actions allowed during a drain: `/agents/<agentId>/<action>`. */
+const DRAIN_ALLOWED_ACTIONS = new Set(['heartbeat', 'commands', 'logs', 'rotate-token']);
+
 /**
  * #2774 — the narrowed agent surface during an `offboarding` drain window.
  * Only what self_uninstall delivery needs survives:
@@ -279,16 +282,44 @@ const SELF_MANAGED_DB_CONTEXT_ACTIONS = new Set(['heartbeat', 'reliability', 'co
  * refused with an explicit 403 so a departing customer's machines don't keep
  * feeding a fully-capable RMM channel. The WS upgrade is refused outright in
  * agentWs.validateAgentToken — its push path bypasses device_commands.
+ *
+ * Every match is ANCHORED on the exact `agents/<agentId>/<action>` shape,
+ * mirroring `shouldSkipAgentAuth` (routes/agents/index.ts). A
+ * trailing-segment-only match would be a hole, not a shortcut: this
+ * middleware also serves the extension gateway, which mounts agent routes at
+ * `<prefix>/agent/<id>/*` (singular — see extensions/gateway.ts). Anchoring on
+ * the core `/agents` mount segment means no extension route can join the drain
+ * surface whatever it names its endpoints, and a nested path under a real
+ * route (`.../winget-bootstrap/file/heartbeat`) can't either. Fails closed: if
+ * the core mount ever moves, drain mode blocks rather than admits.
  */
-function isDrainAllowedAgentPath(pathSegments: string[]): boolean {
-  const last = pathSegments[pathSegments.length - 1] ?? '';
-  const secondLast = pathSegments[pathSegments.length - 2] ?? '';
-  const thirdLast = pathSegments[pathSegments.length - 3] ?? '';
-  if (last === 'heartbeat' || last === 'commands' || last === 'logs' || last === 'rotate-token') {
+const AGENTS_MOUNT_SEGMENT = 'agents';
+
+function isDrainAllowedAgentPath(pathSegments: string[], agentId: string): boolean {
+  const at = (fromEnd: number) => pathSegments[pathSegments.length - fromEnd] ?? '';
+  const last = at(1);
+  // agents/<agentId>/<action>
+  if (at(3) === AGENTS_MOUNT_SEGMENT && at(2) === agentId && DRAIN_ALLOWED_ACTIONS.has(last)) {
     return true;
   }
-  if (last === 'confirm' && secondLast === 'rotate-token') return true;
-  if (last === 'result' && thirdLast === 'commands') return true;
+  // agents/<agentId>/rotate-token/confirm
+  if (
+    last === 'confirm'
+    && at(2) === 'rotate-token'
+    && at(3) === agentId
+    && at(4) === AGENTS_MOUNT_SEGMENT
+  ) {
+    return true;
+  }
+  // agents/<agentId>/commands/<commandId>/result
+  if (
+    last === 'result'
+    && at(3) === 'commands'
+    && at(4) === agentId
+    && at(5) === AGENTS_MOUNT_SEGMENT
+  ) {
+    return true;
+  }
   return false;
 }
 
@@ -518,7 +549,7 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
   }
 
   const pathSegments = (c.req.path ?? '').split('/').filter(Boolean);
-  if (tenantState === 'draining' && !isDrainAllowedAgentPath(pathSegments)) {
+  if (tenantState === 'draining' && !isDrainAllowedAgentPath(pathSegments, agentId)) {
     return c.json({ error: 'tenant_offboarding' }, 403);
   }
 

--- a/apps/api/src/middleware/agentAuth.ts
+++ b/apps/api/src/middleware/agentAuth.ts
@@ -8,7 +8,7 @@ import { getRedis, rateLimiter } from '../services';
 import { type AgentTokenSuspendReason } from '../services/agentTokenSuspension';
 import { createAuditLogAsync } from '../services/auditService';
 import { getTrustedClientIp } from '../services/clientIp';
-import { isAgentTenantActive } from '../services/tenantStatus';
+import { getAgentTenantState } from '../services/tenantStatus';
 
 export interface AgentAuthContext {
   deviceId: string;
@@ -30,6 +30,12 @@ export interface AgentAuthContext {
    * ALWAYS populates it, and rotate-token fails closed if it is ever absent.
    */
   authTokenHash?: string;
+  /**
+   * #2774 — true when the tenant is in the `offboarding` drain window. The
+   * middleware has already restricted the route surface; handlers that claim
+   * commands additionally narrow the claim to `self_uninstall` only.
+   */
+  tenantDraining?: boolean;
 }
 
 export type AgentCredentialRole = 'agent' | 'watchdog';
@@ -262,6 +268,31 @@ export async function suspendAgentToken(deviceId: string, reason: AgentTokenSusp
 const SELF_MANAGED_DB_CONTEXT_ACTIONS = new Set(['heartbeat', 'reliability', 'commands']);
 
 /**
+ * #2774 — the narrowed agent surface during an `offboarding` drain window.
+ * Only what self_uninstall delivery needs survives:
+ * - heartbeat: the primary command carrier (claims device_commands) + liveness
+ * - commands / commands/:id/result: the poll + ack pair
+ * - rotate-token (+ confirm): auth maintenance — blocking a mid-stage rotation
+ *   could strand the very credential the drain depends on
+ * - logs: post-mortem evidence for devices that never drain
+ * Everything else (inventory, patches, WS-adjacent, extension gateway) is
+ * refused with an explicit 403 so a departing customer's machines don't keep
+ * feeding a fully-capable RMM channel. The WS upgrade is refused outright in
+ * agentWs.validateAgentToken — its push path bypasses device_commands.
+ */
+function isDrainAllowedAgentPath(pathSegments: string[]): boolean {
+  const last = pathSegments[pathSegments.length - 1] ?? '';
+  const secondLast = pathSegments[pathSegments.length - 2] ?? '';
+  const thirdLast = pathSegments[pathSegments.length - 3] ?? '';
+  if (last === 'heartbeat' || last === 'commands' || last === 'logs' || last === 'rotate-token') {
+    return true;
+  }
+  if (last === 'confirm' && secondLast === 'rotate-token') return true;
+  if (last === 'result' && thirdLast === 'commands') return true;
+  return false;
+}
+
+/**
  * Middleware to authenticate agent requests via Bearer token.
  * Hashes the token and compares against the stored agentTokenHash.
  * Enforces per-agent rate limiting via Redis.
@@ -474,8 +505,21 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
   // fail closed. Runs after the rate limiters so a flood from an inactive
   // tenant can't drive uncached lookups, and returns the same opaque 401 as a
   // stale token so the agent cannot distinguish suspension from a bad token.
-  if (!(await isAgentTenantActive(device.orgId))) {
+  //
+  // #2774 — an `offboarding` tenant resolves to 'draining': still
+  // authenticated (that's the whole point — self_uninstall must be
+  // deliverable), but only on the narrowed drain surface. Blocked routes get
+  // an explicit 403 (distinct from the opaque 401: the tenant state is not a
+  // secret from its own fleet, and the agent must not treat this as an auth
+  // failure and back off its heartbeat).
+  const tenantState = await getAgentTenantState(device.orgId);
+  if (!tenantState) {
     throw new HTTPException(401, { message: 'Invalid agent credentials' });
+  }
+
+  const pathSegments = (c.req.path ?? '').split('/').filter(Boolean);
+  if (tenantState === 'draining' && !isDrainAllowedAgentPath(pathSegments)) {
+    return c.json({ error: 'tenant_offboarding' }, 403);
   }
 
   if (match.tokenRotationRequired) {
@@ -498,6 +542,7 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
     // hash, but rotate-token rejects those before reaching any CAS, so callers
     // that mint credentials only ever see the current-token hash here.
     authTokenHash: tokenHash,
+    tenantDraining: tenantState === 'draining',
   });
 
   // #1105 — high-frequency, high-concurrency routes that self-manage their DB
@@ -506,7 +551,6 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
   // self-deadlocks the pool under a mass agent reconnect). These routes MUST
   // open withDbAccessContext themselves around their DB work. Everything else
   // keeps the convenient request-long wrap below.
-  const pathSegments = (c.req.path ?? '').split('/').filter(Boolean);
   const action = pathSegments[pathSegments.length - 1] ?? '';
   if (SELF_MANAGED_DB_CONTEXT_ACTIONS.has(action)) {
     await next();

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -220,7 +220,7 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
           name: { type: 'string' },
           slug: { type: 'string' },
           type: { type: 'string', enum: ['customer', 'internal'] },
-          status: { type: 'string', enum: ['active', 'suspended', 'trial', 'churned'] },
+          status: { type: 'string', enum: ['active', 'suspended', 'trial', 'churned', 'offboarding'] },
           maxDevices: { type: 'integer', nullable: true },
           contractStart: { type: 'string', format: 'date-time', nullable: true },
           contractEnd: { type: 'string', format: 'date-time', nullable: true },
@@ -1850,7 +1850,7 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
                   name: { type: 'string', minLength: 1 },
                   slug: { type: 'string', minLength: 1, maxLength: 100 },
                   type: { type: 'string', enum: ['customer', 'internal'] },
-                  status: { type: 'string', enum: ['active', 'suspended', 'trial', 'churned'] },
+                  status: { type: 'string', enum: ['active', 'suspended', 'trial', 'churned', 'offboarding'] },
                   maxDevices: { type: 'integer', nullable: true },
                   contractStart: { type: 'string', format: 'date-time', nullable: true },
                   contractEnd: { type: 'string', format: 'date-time', nullable: true }

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -158,7 +158,7 @@ vi.mock('../services/auditEvents', () => ({
 }));
 
 vi.mock('../services/tenantStatus', () => ({
-  isAgentTenantActive: vi.fn(async () => true),
+  getAgentTenantState: vi.fn(async () => 'active'),
 }));
 
 vi.mock('../services/commandDispatch', () => ({
@@ -202,7 +202,7 @@ import {
 import { isRedisAvailable } from '../services/redis';
 import { claimPendingCommandsForDevice } from '../services/commandDispatch';
 import { writeAuditEvent } from '../services/auditEvents';
-import { isAgentTenantActive } from '../services/tenantStatus';
+import { getAgentTenantState } from '../services/tenantStatus';
 import { enqueueDiscoveryResults } from '../jobs/discoveryWorker';
 import { enqueueSnmpPollResults } from '../jobs/snmpWorker';
 import { enqueueMonitorCheckResult } from '../jobs/monitorWorker';
@@ -251,7 +251,7 @@ describe('validateAgentToken — tenant-status gate', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(isAgentTenantActive).mockResolvedValue(true);
+    vi.mocked(getAgentTenantState).mockResolvedValue('active');
   });
 
   it('accepts a valid agent token for an active tenant', async () => {
@@ -260,12 +260,24 @@ describe('validateAgentToken — tenant-status gate', () => {
     const result = await validateAgentToken('agent-1', TOKEN);
 
     expect(result).toEqual({ ok: true, ctx: { deviceId: 'device-1', orgId: 'org-1', role: 'agent' } });
-    expect(isAgentTenantActive).toHaveBeenCalledWith('org-1');
+    expect(getAgentTenantState).toHaveBeenCalledWith('org-1');
   });
 
   it('refuses the upgrade when the device tenant is not active', async () => {
     queueDeviceSelect(deviceRow);
-    vi.mocked(isAgentTenantActive).mockResolvedValue(false);
+    vi.mocked(getAgentTenantState).mockResolvedValue(null);
+
+    const result = await validateAgentToken('agent-1', TOKEN);
+
+    expect(result).toEqual({ ok: false, reason: 'unauthorized' });
+  });
+
+  // #2774 — a draining (offboarding) tenant keeps its REST drain surface but
+  // must NOT get a WS session: ~20 push call sites bypass device_commands, so
+  // any accepted socket is a fully-capable control channel.
+  it('refuses the upgrade for a draining (offboarding) tenant', async () => {
+    queueDeviceSelect(deviceRow);
+    vi.mocked(getAgentTenantState).mockResolvedValue('draining');
 
     const result = await validateAgentToken('agent-1', TOKEN);
 

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -34,7 +34,7 @@ import {
 import { backupCommandResultSchema } from './backup/resultSchemas';
 import { matchRoleScopedAgentTokenHash, suspendAgentToken, type AgentCredentialRole } from '../middleware/agentAuth';
 import { AGENT_TOKEN_SUSPEND_REASON } from '../services/agentTokenSuspension';
-import { isAgentTenantActive } from '../services/tenantStatus';
+import { getAgentTenantState } from '../services/tenantStatus';
 import { createAuditLogAsync } from '../services/auditService';
 import { ANONYMOUS_ACTOR_ID, writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
 import { redactSecretsFromOutput, redactOptionalSecretText, redactAgentResultErrorFields } from '../services/secretRedaction';
@@ -946,7 +946,14 @@ export async function validateAgentToken(agentId: string, token: string): Promis
   // Tenant-status gate (mirror of the REST agent-auth path): refuse the WS
   // upgrade for a suspended/churned/soft-deleted org or partner before we
   // accept the persistent control channel.
-  if (!(await isAgentTenantActive(device.orgId))) {
+  //
+  // #2774 — 'draining' (offboarding) is refused here too, even though the
+  // REST drain surface stays open: ~20 call sites (terminal, desktop, tunnel,
+  // software installs, workers) push commands over this socket WITHOUT a
+  // device_commands row, so any WS session is a fully-capable control channel
+  // that the drain-mode command filtering can't see. The agent falls back to
+  // heartbeat polling, which is the actual self_uninstall delivery path.
+  if ((await getAgentTenantState(device.orgId)) !== 'active') {
     return { ok: false, reason: 'unauthorized' };
   }
 

--- a/apps/api/src/routes/agents/commands.test.ts
+++ b/apps/api/src/routes/agents/commands.test.ts
@@ -169,7 +169,7 @@ describe('agent commands routes', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(claimPendingCommandsForDeviceMock).toHaveBeenCalledWith('device-1', 10, 'agent');
+    expect(claimPendingCommandsForDeviceMock).toHaveBeenCalledWith('device-1', 10, 'agent', undefined);
     await expect(res.json()).resolves.toEqual({
       commands: [
         {
@@ -179,6 +179,35 @@ describe('agent commands routes', () => {
         },
       ],
     });
+  });
+
+  // #2774 — during an offboarding drain the poll claims self_uninstall only.
+  it('narrows the claim to self_uninstall when the tenant is draining', async () => {
+    claimPendingCommandsForDeviceMock.mockResolvedValueOnce([]);
+
+    const drainApp = new Hono();
+    drainApp.use('*', async (c, next) => {
+      c.set('agent', {
+        deviceId: 'device-1',
+        agentId: 'agent-1',
+        orgId: 'org-1',
+        siteId: 'site-1',
+        role: 'agent',
+        tenantDraining: true,
+      });
+      await next();
+    });
+    drainApp.route('/agents', commandsRoutes);
+
+    const res = await drainApp.request(`/agents/${agentId}/commands`, { method: 'GET' });
+
+    expect(res.status).toBe(200);
+    expect(claimPendingCommandsForDeviceMock).toHaveBeenCalledWith(
+      'device-1',
+      10,
+      'agent',
+      ['self_uninstall']
+    );
   });
 
   // A complete, well-formed PEM private-key block (header + base64 body +

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -136,7 +136,13 @@ commandsRoutes.get('/:id/commands', async (c) => {
 
   const commands = await runOutsideDbContext(() =>
     withSystemDbAccessContext(() =>
-      claimPendingCommandsForDevice(agent.deviceId, 10, agent.role)
+      claimPendingCommandsForDevice(
+        agent.deviceId,
+        10,
+        agent.role,
+        // #2774 — offboarding drain: only self_uninstall is deliverable.
+        agent.tenantDraining ? ['self_uninstall'] : undefined
+      )
     )
   );
 

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -254,6 +254,25 @@ function buildWatchdogApp(): Hono {
   return app;
 }
 
+// #2774 — an offboarding tenant's agent authenticates but is narrowed to
+// self_uninstall delivery. agentAuthMiddleware sets `tenantDraining`.
+function buildDrainingApp(role: 'agent' | 'watchdog' = 'agent'): Hono {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('agent', {
+      deviceId: 'device-1',
+      agentId: 'agent-1',
+      orgId: 'org-1',
+      siteId: 'site-1',
+      role,
+      tenantDraining: true,
+    });
+    await next();
+  });
+  app.route('/agents', heartbeatRoutes);
+  return app;
+}
+
 const minimalHeartbeatBody = {
   agentVersion: '0.65.10',
   metrics: {
@@ -2734,6 +2753,70 @@ describe('POST /agents/:id/heartbeat — undecryptable claimed commands are rele
       { id: 'cmd-good', type: 'run_script', payload: { scriptId: 'script-1' } },
     ]);
     expect(releaseClaimedCommandDeliveryMock).not.toHaveBeenCalled();
+  });
+
+  // #2774 — the heartbeat is the PRIMARY command carrier (the GET poll is
+  // watchdog-failover only), so this is the filter that actually stops a
+  // departing customer's machines from executing scripts/automations queued
+  // by workers AFTER drain entry cancelled the then-pending set.
+  it('agent path: narrows the claim to self_uninstall when the tenant is draining', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          siteId: 'site-1',
+          hostname: 'host-1',
+          osType: 'linux',
+          architecture: 'amd64',
+          agentVersion: '0.65.10',
+          agentTokenHash: 'hash',
+          tokenIssuedAt: new Date(),
+        },
+      ]),
+    );
+    selectMock.mockReturnValue(selectChainResolving([]));
+    claimPendingCommandsForDeviceMock.mockResolvedValueOnce([]);
+
+    const resp = await buildDrainingApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    expect(claimPendingCommandsForDeviceMock).toHaveBeenCalledWith('device-1', 10, 'agent', [
+      'self_uninstall',
+    ]);
+  });
+
+  it('watchdog path: narrows the claim to self_uninstall when the tenant is draining', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          hostname: 'host-1',
+          osType: 'linux',
+          architecture: 'amd64',
+          lastSeenAt: new Date(),
+          mainAgentSilentSince: null,
+        },
+      ]),
+    );
+    selectMock.mockReturnValue(selectChainResolving([]));
+    claimPendingCommandsForDeviceMock.mockResolvedValueOnce([]);
+
+    const resp = await buildDrainingApp('watchdog').request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ agentVersion: '0.65.15', role: 'watchdog', watchdogState: 'MONITORING' }),
+    });
+
+    expect(resp.status).toBe(200);
+    expect(claimPendingCommandsForDeviceMock).toHaveBeenCalledWith('device-1', 10, 'watchdog', [
+      'self_uninstall',
+    ]);
   });
 });
 

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -2697,7 +2697,7 @@ describe('POST /agents/:id/heartbeat — undecryptable claimed commands are rele
     });
 
     expect(resp.status).toBe(200);
-    expect(claimPendingCommandsForDeviceMock).toHaveBeenCalledWith('device-1', 10, 'watchdog');
+    expect(claimPendingCommandsForDeviceMock).toHaveBeenCalledWith('device-1', 10, 'watchdog', undefined);
     const body = (await resp.json()) as { commands: Array<{ id: string }> };
     expect(body.commands.map((cmd) => cmd.id)).toEqual(['cmd-good']);
     expect(releaseClaimedCommandDeliveryMock).toHaveBeenCalledWith('cmd-bad', claimedAt);

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -362,8 +362,15 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       }
     }
 
-    // Claim watchdog-targeted commands (marks as sent to prevent duplicate delivery)
-    const watchdogCommands = await claimPendingCommandsForDevice(device.id, 10, 'watchdog');
+    // Claim watchdog-targeted commands (marks as sent to prevent duplicate delivery).
+    // #2774 — during an offboarding drain the claim narrows to self_uninstall
+    // (targetRole 'agent' only carries it, so the watchdog claims nothing).
+    const watchdogCommands = await claimPendingCommandsForDevice(
+      device.id,
+      10,
+      'watchdog',
+      agent?.tenantDraining ? ['self_uninstall'] : undefined
+    );
 
     // Check for watchdog upgrade. Honors the tenant's watchdog pin (issue
     // #2124) via the same resolver as the main path; fail-closed to no upgrade
@@ -789,7 +796,14 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     }
   }
 
-  const commands = await claimPendingCommandsForDevice(device.id, 10);
+  // #2774 — during an offboarding drain, the heartbeat (the primary command
+  // carrier) only delivers self_uninstall; everything else stays unclaimed.
+  const commands = await claimPendingCommandsForDevice(
+    device.id,
+    10,
+    'agent',
+    agent?.tenantDraining ? ['self_uninstall'] : undefined
+  );
 
   // Policy probe config (buildPolicyProbeConfigUpdate) is deliberately NOT
   // built here: partner-wide compliance policies (org_id NULL, #2129) are

--- a/apps/api/src/routes/agents/wingetBootstrap.test.ts
+++ b/apps/api/src/routes/agents/wingetBootstrap.test.ts
@@ -61,6 +61,10 @@ vi.mock('../../services/clientIp', () => ({
 }));
 
 vi.mock('../../services/tenantStatus', () => ({
+  // agentAuthMiddleware gates on getAgentTenantState (#2774); isAgentTenantActive
+  // remains for the mTLS path. This suite exercises the real middleware, so the
+  // mock must carry the export the middleware actually calls.
+  getAgentTenantState: vi.fn(async () => 'active'),
   isAgentTenantActive: vi.fn(async () => true),
 }));
 

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -40,6 +40,37 @@ vi.mock('../services/tenantLifecycle', () => ({
   restoreOrganizationTenantAccess: vi.fn().mockResolvedValue({ agentTokensRestored: 0 })
 }));
 
+vi.mock('../services/tenantOffboarding', () => ({
+  beginOrganizationOffboarding: vi.fn().mockResolvedValue({
+    revocation: {
+      apiKeysRevoked: 0,
+      userSessionsRevoked: 0,
+      oauthGrantsRevoked: 0,
+      oauthRefreshTokensRevoked: 0,
+      agentTokensSuspended: 0,
+      enrollmentKeysInvalidated: 0
+    },
+    devicesTargeted: 0,
+    uninstallsQueued: 0,
+    otherCommandsCancelled: 0
+  }),
+  beginPartnerOffboarding: vi.fn().mockResolvedValue({
+    revocation: {
+      apiKeysRevoked: 0,
+      userSessionsRevoked: 0,
+      oauthGrantsRevoked: 0,
+      oauthRefreshTokensRevoked: 0,
+      agentTokensSuspended: 0,
+      enrollmentKeysInvalidated: 0
+    },
+    devicesTargeted: 0,
+    uninstallsQueued: 0,
+    otherCommandsCancelled: 0
+  }),
+  abortOrganizationOffboarding: vi.fn().mockResolvedValue({ aborted: false, uninstallsCancelled: 0 }),
+  abortPartnerOffboarding: vi.fn().mockResolvedValue({ aborted: false, uninstallsCancelled: 0 })
+}));
+
 vi.mock('../db', () => ({
   db: {
     select: vi.fn(() => ({
@@ -163,6 +194,12 @@ import {
   revokeOrganizationTenantAccess,
   revokePartnerTenantAccess,
 } from '../services/tenantLifecycle';
+import {
+  abortOrganizationOffboarding,
+  abortPartnerOffboarding,
+  beginOrganizationOffboarding,
+  beginPartnerOffboarding,
+} from '../services/tenantOffboarding';
 import { captureException } from '../services/sentry';
 import { seedSystemTicketStatuses } from '../services/ticketConfigService';
 
@@ -550,6 +587,48 @@ describe('org routes', () => {
       expect(res.status).toBe(200);
       expect(restorePartnerTenantAccess).toHaveBeenCalledWith('partner-1');
       expect(revokePartnerTenantAccess).not.toHaveBeenCalled();
+    });
+
+    // #2774 — partner offboarding drains rather than severs.
+    it('begins the partner offboarding drain when status is set to offboarding', async () => {
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: 'partner-1', name: 'P', status: 'offboarding', settings: {} }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/orgs/partners/partner-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'offboarding' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(beginPartnerOffboarding).toHaveBeenCalledWith('partner-1', expect.anything());
+      expect(revokePartnerTenantAccess).not.toHaveBeenCalled();
+      expect(restorePartnerTenantAccess).not.toHaveBeenCalled();
+    });
+
+    it('aborts a partner drain before severing when forced to suspended', async () => {
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: 'partner-1', name: 'P', status: 'suspended', settings: {} }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/orgs/partners/partner-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'suspended' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(abortPartnerOffboarding).toHaveBeenCalledWith('partner-1');
+      expect(revokePartnerTenantAccess).toHaveBeenCalledWith('partner-1');
     });
 
     it('does not sever the fleet on a transient active->pending transition (preserves enrollment keys)', async () => {
@@ -1547,6 +1626,73 @@ describe('org routes', () => {
       expect(res.status).toBe(200);
       expect(restoreOrganizationTenantAccess).toHaveBeenCalledWith('org-1');
       expect(revokeOrganizationTenantAccess).not.toHaveBeenCalled();
+    });
+
+    // #2774 — offboarding is the drain entry: users out via
+    // beginOrganizationOffboarding (agent channel kept), NOT the immediate
+    // sever of revokeOrganizationTenantAccess.
+    it('begins the offboarding drain (not an immediate sever) when status is set to offboarding', async () => {
+      setAuthContext({ scope: 'system', partnerId: null });
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: 'org-1', name: 'O', status: 'offboarding' }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'offboarding' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(beginOrganizationOffboarding).toHaveBeenCalledWith('org-1', expect.anything());
+      expect(revokeOrganizationTenantAccess).not.toHaveBeenCalled();
+      expect(restoreOrganizationTenantAccess).not.toHaveBeenCalled();
+    });
+
+    it('aborts a drain before severing when an org is forced to suspended', async () => {
+      setAuthContext({ scope: 'system', partnerId: null });
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: 'org-1', name: 'O', status: 'suspended' }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'suspended' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(abortOrganizationOffboarding).toHaveBeenCalledWith('org-1');
+      expect(revokeOrganizationTenantAccess).toHaveBeenCalledWith('org-1');
+    });
+
+    it('aborts a drain on reactivation so in-flight uninstalls cannot fire later', async () => {
+      setAuthContext({ scope: 'system', partnerId: null });
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: 'org-1', name: 'O', status: 'active' }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'active' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(abortOrganizationOffboarding).toHaveBeenCalledWith('org-1');
+      expect(restoreOrganizationTenantAccess).toHaveBeenCalledWith('org-1');
     });
 
     it('should return 404 when organization not found', async () => {

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -631,6 +631,26 @@ describe('org routes', () => {
       expect(revokePartnerTenantAccess).toHaveBeenCalledWith('partner-1');
     });
 
+    it('aborts a partner drain on reactivation so in-flight uninstalls cannot fire later', async () => {
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: 'partner-1', name: 'P', status: 'active', settings: {} }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/orgs/partners/partner-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'active' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(abortPartnerOffboarding).toHaveBeenCalledWith('partner-1');
+      expect(restorePartnerTenantAccess).toHaveBeenCalledWith('partner-1');
+    });
+
     it('does not sever the fleet on a transient active->pending transition (preserves enrollment keys)', async () => {
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -17,6 +17,12 @@ import {
   revokeOrganizationTenantAccess,
   revokePartnerTenantAccess,
 } from '../services/tenantLifecycle';
+import {
+  abortOrganizationOffboarding,
+  abortPartnerOffboarding,
+  beginOrganizationOffboarding,
+  beginPartnerOffboarding,
+} from '../services/tenantOffboarding';
 import { applyOrganizationOrder, sanitizeOrganizationOrder } from '../services/orgOrdering';
 import { captureException } from '../services/sentry';
 import { encryptColumnValueForWrite } from '../services/encryptedColumnRegistry';
@@ -131,7 +137,8 @@ function settingsAllowlistEntriesValid(settings: unknown): boolean {
 }
 
 const updatePartnerSchema = createPartnerSchema.partial().extend({
-  status: z.enum(['pending', 'active', 'suspended', 'churned']).optional(),
+  // `offboarding` (#2774): terminal-intent drain — see services/tenantOffboarding.ts.
+  status: z.enum(['pending', 'active', 'suspended', 'churned', 'offboarding']).optional(),
   // Operator-only per-partner AI for Office entitlement. Settable here (system
   // scope) but NOT on /partners/me (partner scope) — partners can't self-enable.
   aiForOfficeEnabled: z.boolean().optional(),
@@ -178,7 +185,12 @@ const createOrganizationSchema = z.object({
   billingContact: z.any().optional()
 });
 
-const updateOrganizationSchema = createOrganizationSchema.partial().omit({ partnerId: true });
+// Update (not create) additionally accepts `offboarding` (#2774) — the
+// terminal-intent drain state. Creating an org directly in `offboarding`
+// makes no sense, so the create schema keeps the original set.
+const updateOrganizationSchema = createOrganizationSchema.partial().omit({ partnerId: true }).extend({
+  status: z.enum(['active', 'suspended', 'trial', 'churned', 'offboarding']).optional(),
+});
 
 const listSitesSchema = z.object({
   orgId: z.string().guid().optional(),
@@ -903,10 +915,20 @@ orgRoutes.patch('/partners/:id', requireScope('system'), requireOrgWrite, requir
   // (signup/billing limbo) and is already blocked for agents by the live
   // tenant cascade (getActivePartner is strict) — severing here would expire
   // enrollment keys irreversibly on a transient state.
-  if ('status' in data && (data.status === 'suspended' || data.status === 'churned')) {
+  if ('status' in data && data.status === 'offboarding') {
+    // #2774 — terminal-intent drain across every org under the partner:
+    // users out now, agents narrowed to self_uninstall delivery until the
+    // drain reaper severs and flips to churned.
+    await beginPartnerOffboarding(partner.id, auth.user?.id ?? null);
+  } else if ('status' in data && (data.status === 'suspended' || data.status === 'churned')) {
+    // Cancel in-flight drain uninstalls first (no-op unless offboarding) —
+    // an uncollected self_uninstall must not survive into a later
+    // reactivation of a suspended partner.
+    await abortPartnerOffboarding(partner.id);
     await revokePartnerTenantAccess(partner.id);
   } else if ('status' in data && data.status === 'active') {
     // Reactivation: restore agent tokens this partner's revoke suspended.
+    await abortPartnerOffboarding(partner.id);
     await restorePartnerTenantAccess(partner.id);
   }
 
@@ -941,6 +963,9 @@ orgRoutes.delete('/partners/:id', requireScope('system'), requireOrgWrite, requi
     return c.json({ error: 'Partner not found' }, 404);
   }
 
+  // Hard delete keeps the immediate-sever semantics; if a drain was in
+  // progress, cancel its uninstalls so nothing lingers (no-op otherwise).
+  await abortPartnerOffboarding(partner.id);
   await revokePartnerTenantAccess(partner.id);
 
   const auditOrgId = auth.orgId ?? await resolveAuditOrgIdForPartner(id);
@@ -1365,10 +1390,22 @@ const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWrite, re
     return c.json({ error: 'Organization not found' }, 404);
   }
 
-  if (data.status !== undefined && data.status !== 'active' && data.status !== 'trial') {
+  if (data.status === 'offboarding') {
+    // #2774 — terminal-intent drain: users/API keys/OAuth out now, agents kept
+    // authenticated (narrowed to self_uninstall delivery) until the fleet
+    // drains or the window closes; the offboarding drain reaper then severs
+    // and flips to churned with a never-drained report.
+    await beginOrganizationOffboarding(organization.id, auth.user?.id ?? null);
+  } else if (data.status !== undefined && data.status !== 'active' && data.status !== 'trial') {
+    // Leaving a drain for suspended/churned must not leave uncollected
+    // self_uninstalls behind: a later reactivation would deliver them to the
+    // reinstated fleet. No-op when the org wasn't offboarding.
+    await abortOrganizationOffboarding(organization.id);
     await revokeOrganizationTenantAccess(organization.id);
   } else if (data.status === 'active' || data.status === 'trial') {
-    // Reactivation: restore agent tokens this org's revoke suspended.
+    // Reactivation: cancel any in-flight drain uninstalls (see above), then
+    // restore agent tokens this org's revoke suspended.
+    await abortOrganizationOffboarding(organization.id);
     await restoreOrganizationTenantAccess(organization.id);
   }
 
@@ -1414,6 +1451,9 @@ orgRoutes.delete('/organizations/:id', requireScope('partner', 'system'), requir
     return c.json({ error: 'Organization not found' }, 404);
   }
 
+  // Hard delete keeps the immediate-sever semantics; if a drain was in
+  // progress, cancel its uninstalls so nothing lingers (no-op otherwise).
+  await abortOrganizationOffboarding(organization.id);
   await revokeOrganizationTenantAccess(organization.id);
 
   writeRouteAudit(c, {

--- a/apps/api/src/services/aiToolsOrgs.test.ts
+++ b/apps/api/src/services/aiToolsOrgs.test.ts
@@ -14,6 +14,9 @@ vi.mock('./tenantLifecycle', () => ({
   revokeOrganizationTenantAccess: vi.fn(async () => undefined),
   restoreOrganizationTenantAccess: vi.fn(async () => undefined),
 }));
+vi.mock('./tenantOffboarding', () => ({
+  abortOrganizationOffboarding: vi.fn(async () => ({ aborted: false, uninstallsCancelled: 0 })),
+}));
 
 import { and, eq, ilike, inArray, isNull } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';

--- a/apps/api/src/services/aiToolsOrgs.ts
+++ b/apps/api/src/services/aiToolsOrgs.ts
@@ -43,10 +43,14 @@ import {
   restoreOrganizationTenantAccess,
   revokeOrganizationTenantAccess,
 } from './tenantLifecycle';
+import { abortOrganizationOffboarding } from './tenantOffboarding';
 
 // Mirrors the org PATCH route's status set (schema orgStatusEnum). Kept as a
 // literal array (not orgStatusEnum.enumValues) so schema mocks in tests don't
 // break the zod/tool definitions.
+// Deliberately excludes `offboarding` (#2774): entering the drain state queues
+// an irreversible fleet-wide self_uninstall, which stays a human, MFA-gated
+// action (PATCH /organizations/:id) — never an AI-tool transition.
 const ORG_STATUSES = ['active', 'suspended', 'trial', 'churned'] as const;
 type OrgStatus = (typeof ORG_STATUSES)[number];
 
@@ -338,10 +342,14 @@ async function handleUpdateOrg(
   if (!org) return jsonError('Organization not found or access denied');
 
   // Status-transition invariants from the org PATCH route: suspending/churning
-  // severs agent tenant access; re-activating restores it.
+  // severs agent tenant access; re-activating restores it. Any transition off
+  // `offboarding` (#2774) first cancels in-flight drain uninstalls (no-op
+  // otherwise) so an uncollected self_uninstall can't survive a reactivation.
   if (status !== undefined && status !== 'active' && status !== 'trial') {
+    await abortOrganizationOffboarding(org.id);
     await revokeOrganizationTenantAccess(org.id);
   } else if (status === 'active' || status === 'trial') {
+    await abortOrganizationOffboarding(org.id);
     await restoreOrganizationTenantAccess(org.id);
   }
 

--- a/apps/api/src/services/commandDispatch.test.ts
+++ b/apps/api/src/services/commandDispatch.test.ts
@@ -17,10 +17,21 @@ vi.mock('../db/schema', () => ({
     id: 'deviceCommands.id',
     deviceId: 'deviceCommands.deviceId',
     status: 'deviceCommands.status',
+    type: 'deviceCommands.type',
+    targetRole: 'deviceCommands.targetRole',
     createdAt: 'deviceCommands.createdAt',
     executedAt: 'deviceCommands.executedAt',
   },
 }));
+
+// Spy on inArray (pass-through to the real implementation) so the #2774
+// drain-mode type filter is assertable without mocking all of drizzle.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return { ...actual, inArray: vi.fn((...args: Parameters<typeof actual.inArray>) => actual.inArray(...args)) };
+});
+
+import { inArray } from 'drizzle-orm';
 
 import { db } from '../db';
 import {
@@ -86,6 +97,32 @@ describe('command dispatch helpers', () => {
 
     expect(claimed).toHaveLength(1);
     expect(claimed[0]?.id).toBe('cmd-1');
+    // No drain allowlist → no type filter applied.
+    expect(vi.mocked(inArray)).not.toHaveBeenCalledWith('deviceCommands.type', expect.anything());
+  });
+
+  // #2774 — during an offboarding drain the claim narrows to self_uninstall.
+  it('applies the type allowlist to the claim query when provided', async () => {
+    const tx = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                for: vi.fn().mockResolvedValue([]),
+              }),
+            }),
+          }),
+        }),
+      }),
+      update: vi.fn(),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const claimed = await claimPendingCommandsForDevice('dev-1', 10, 'agent', ['self_uninstall']);
+
+    expect(claimed).toEqual([]);
+    expect(vi.mocked(inArray)).toHaveBeenCalledWith('deviceCommands.type', ['self_uninstall']);
   });
 
   it('releases a claimed command back to pending state', async () => {

--- a/apps/api/src/services/commandDispatch.ts
+++ b/apps/api/src/services/commandDispatch.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../db';
 import { deviceCommands } from '../db/schema';
 
@@ -62,6 +62,10 @@ export async function claimPendingCommandsForDevice(
   deviceId: string,
   limit: number = 10,
   targetRole: 'agent' | 'watchdog' = 'agent',
+  // #2774 — when set (offboarding drain window), only commands of these types
+  // are claimable; anything else stays `pending` and is reaped/cancelled by
+  // the normal lifecycle. The drain callers pass ['self_uninstall'].
+  typeAllowlist?: readonly string[],
 ): Promise<DeviceCommandRow[]> {
   // Only HTTP delivery paths (heartbeat responses) claim batches; the agent
   // WebSocket never embeds command batches in frames (#2407 removed the
@@ -76,6 +80,7 @@ export async function claimPendingCommandsForDevice(
           eq(deviceCommands.deviceId, deviceId),
           eq(deviceCommands.status, 'pending'),
           eq(deviceCommands.targetRole, targetRole),
+          ...(typeAllowlist ? [inArray(deviceCommands.type, [...typeAllowlist])] : []),
         ),
       )
       .orderBy(deviceCommands.createdAt)

--- a/apps/api/src/services/passwordResetEligibility.test.ts
+++ b/apps/api/src/services/passwordResetEligibility.test.ts
@@ -176,6 +176,35 @@ describe('getPasswordResetEligibility', () => {
     expect(result.detail).toBe('org:suspended');
   });
 
+  // #2774 — the org branch is an ALLOWLIST for exactly this reason: a
+  // denylist silently admits every status added later, and `offboarding` is a
+  // terminal drain whose users have already been revoked.
+  it('blocks reset for org-scope user under an offboarding org', async () => {
+    setupSelects(
+      [{ id: 'u-1', email: 'orgu@acme.com', status: 'active', partnerId: 'p-1', orgId: 'o-1' }],
+      [{ status: 'active', deletedAt: null }],
+      [{ status: 'offboarding', deletedAt: null }],
+    );
+
+    const result = await getPasswordResetEligibility('orgu@acme.com');
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('tenant_inactive');
+    expect(result.detail).toBe('org:offboarding');
+  });
+
+  it('allows reset for org-scope user under a trial org', async () => {
+    setupSelects(
+      [{ id: 'u-1', email: 'trialu@acme.com', status: 'active', partnerId: 'p-1', orgId: 'o-1' }],
+      [{ status: 'active', deletedAt: null }],
+      [{ status: 'trial', deletedAt: null }],
+    );
+
+    const result = await getPasswordResetEligibility('trialu@acme.com');
+
+    expect(result.allowed).toBe(true);
+  });
+
   it('blocks reset for SSO-enforced org users', async () => {
     setupSelects(
       [{ id: 'u-1', email: 'sso@acme.com', status: 'active', partnerId: 'p-1', orgId: 'o-1' }],

--- a/apps/api/src/services/passwordResetEligibility.ts
+++ b/apps/api/src/services/passwordResetEligibility.ts
@@ -51,8 +51,12 @@ const RESET_ALLOWED_PARTNER_STATUSES = new Set<string>(['active', 'pending']);
 // be reactivated via the public reset flow — an admin must restore them.
 const RESET_BLOCKED_USER_STATUSES = new Set<string>(['disabled']);
 
-// Organization statuses that block password reset for org-scoped users.
-const RESET_BLOCKED_ORG_STATUSES = new Set<string>(['suspended', 'churned']);
+// Organization statuses that PERMIT password reset for org-scoped users.
+// Deliberately an allowlist, mirroring `isUsableOrgStatus` in `tenantStatus.ts`
+// (and the partner set above): a denylist silently admits every status added
+// later, which is exactly how `offboarding` (#2774) — a terminal drain where
+// users are already revoked — initially kept a live reset path.
+const RESET_ALLOWED_ORG_STATUSES = new Set<string>(['active', 'trial']);
 
 /**
  * Single source of truth for "can this email reset its password right now?".
@@ -150,7 +154,7 @@ async function evaluateEligibility(user: UserLookupRow): Promise<ResetEligibilit
       .where(eq(organizations.id, user.orgId))
       .limit(1);
 
-    if (!org || org.deletedAt || RESET_BLOCKED_ORG_STATUSES.has(org.status as string)) {
+    if (!org || org.deletedAt || !RESET_ALLOWED_ORG_STATUSES.has(org.status as string)) {
       const detail = !org || org.deletedAt
         ? 'org:missing'
         : `org:${org.status}`;

--- a/apps/api/src/services/tenantLifecycle.test.ts
+++ b/apps/api/src/services/tenantLifecycle.test.ts
@@ -213,4 +213,45 @@ describe('tenantLifecycle — agent fleet severance', () => {
     expect(updateLog.some((u) => u.table === devices)).toBe(true);
     expect(result.agentTokensRestored).toBe(3);
   });
+
+  // #2774 — the offboarding drain must lock users out WITHOUT suspending
+  // agent tokens, or the queued self_uninstall is undeliverable by
+  // construction (the exact bug the drain state exists to fix).
+  describe('agentChannel: drain', () => {
+    it('revokeOrganizationTenantAccess keeps agent tokens but expires enrollment keys', async () => {
+      queueSelect([{ userId: 'u1' }]); // organizationUsers
+
+      const result = await revokeOrganizationTenantAccess('org-1', { agentChannel: 'drain' });
+
+      // No devices UPDATE: agent tokens stay valid for the drain window.
+      expect(updateLog.some((u) => u.table === devices)).toBe(false);
+      // Enrollment keys still expire — no NEW devices during a drain.
+      expect(updateLog.some((u) => u.table === enrollmentKeys)).toBe(true);
+      expect(invalidateAgentTenantCache).toHaveBeenCalledWith(['org-1']);
+      expect(result.agentTokensSuspended).toBe(0);
+      expect(result.enrollmentKeysInvalidated).toBe(1);
+    });
+
+    it('drain mode still severs live WS sockets (interactive channel must not survive)', async () => {
+      queueSelect([{ userId: 'u1' }]); // organizationUsers
+      queueSelect([{ agentId: 'agent-live' }]); // devices in org
+      vi.mocked(getConnectedAgentIds).mockReturnValueOnce(['agent-live']);
+
+      await revokeOrganizationTenantAccess('org-1', { agentChannel: 'drain' });
+
+      expect(disconnectAgent).toHaveBeenCalledWith('agent-live', 4001, 'Tenant offboarding');
+    });
+
+    it('revokePartnerTenantAccess drain mode keeps agent tokens across partner orgs', async () => {
+      queueSelect([{ id: 'org-1' }, { id: 'org-2' }]); // organizations under partner
+      queueSelect([{ userId: 'pu1' }]); // partnerUsers
+      queueSelect([{ userId: 'ou1' }]); // org memberships
+
+      const result = await revokePartnerTenantAccess('partner-1', { agentChannel: 'drain' });
+
+      expect(updateLog.some((u) => u.table === devices)).toBe(false);
+      expect(updateLog.some((u) => u.table === enrollmentKeys)).toBe(true);
+      expect(result.agentTokensSuspended).toBe(0);
+    });
+  });
 });

--- a/apps/api/src/services/tenantLifecycle.ts
+++ b/apps/api/src/services/tenantLifecycle.ts
@@ -150,6 +150,15 @@ export async function prepareAgentDrainForOrgIds(
   await invalidateAgentTenantCache(orgIds);
   const enrollmentKeysInvalidated = await expireEnrollmentKeysForOrgIds(orgIds, new Date());
   await disconnectLiveAgentSocketsForOrgIds(orgIds, 'Tenant offboarding');
+  // Invalidate a SECOND time, after the teardown. In sever mode the cache is
+  // only an optimization (agentTokenSuspendedAt is the real-time cutoff), but
+  // in drain mode tokens stay alive, so this cache IS the gate: a read that
+  // started before the status commit can land its positive `active` entry
+  // after the first invalidation and keep the tenant fully capable — long
+  // enough to win a WS upgrade — for the 60s TTL. Dropping it again once the
+  // sockets are down closes the common ordering; the drain reaper's periodic
+  // socket re-sweep bounds whatever still slips through.
+  await invalidateAgentTenantCache(orgIds);
 
   return { enrollmentKeysInvalidated };
 }

--- a/apps/api/src/services/tenantLifecycle.ts
+++ b/apps/api/src/services/tenantLifecycle.ts
@@ -28,6 +28,62 @@ export interface TenantRestorationResult {
 const TENANT_SUSPENDED_TOKEN_REASON = AGENT_TOKEN_SUSPEND_REASON.tenantSuspended;
 
 /**
+ * Expire enrollment keys for the orgs so a still-valid key can't (re-)mint a
+ * fleet. Safe ordering relative to the cache drop because the enroll path
+ * checks getActiveOrgTenant directly (uncached, see enrollment.ts), so it
+ * never admits via a stale positive cache during this window; only keys not
+ * already expired are touched.
+ */
+async function expireEnrollmentKeysForOrgIds(orgIds: string[], now: Date): Promise<number> {
+  const invalidatedKeys = await db
+    .update(enrollmentKeys)
+    .set({ expiresAt: now })
+    .where(
+      and(
+        inArray(enrollmentKeys.orgId, orgIds),
+        or(isNull(enrollmentKeys.expiresAt), gt(enrollmentKeys.expiresAt, now))
+      )
+    )
+    .returning({ id: enrollmentKeys.id });
+  return invalidatedKeys.length;
+}
+
+/**
+ * Finding #3(b): flipping status / suspending tokens only fails the NEXT auth
+ * gate — an already-established agent WS keeps its captured authorization
+ * until it happens to reconnect. Sever live sockets for devices in the
+ * affected orgs so containment is immediate, not eventual.
+ *
+ * agentWs is imported dynamically (not statically): `routes/agentWs` pulls in
+ * a large graph of services, and a static service→route edge here risks an
+ * import cycle. Dynamic import at call time is the established de-cycling
+ * pattern in this repo (agentWs itself dynamically imports its result
+ * handlers). Best-effort: socket teardown must NEVER fail the credential
+ * revocation, which is the load-bearing containment step.
+ */
+export async function disconnectLiveAgentSocketsForOrgIds(orgIds: string[], reason: string): Promise<void> {
+  if (orgIds.length === 0) return;
+  try {
+    const { disconnectAgent, getConnectedAgentIds } = await import('../routes/agentWs');
+    const connected = getConnectedAgentIds();
+    if (connected.length > 0) {
+      const connectedSet = new Set(connected);
+      const deviceRows = await db
+        .select({ agentId: devices.agentId })
+        .from(devices)
+        .where(and(inArray(devices.orgId, orgIds), isNotNull(devices.agentId)));
+      for (const row of deviceRows) {
+        if (row.agentId && connectedSet.has(row.agentId)) {
+          disconnectAgent(row.agentId, 4001, reason);
+        }
+      }
+    }
+  } catch (err) {
+    console.error('[tenantLifecycle] Failed to sever live agent sockets after credential cutoff:', err);
+  }
+}
+
+/**
  * Sever the live agent fleet for a set of orgs: suspend agent tokens (so the
  * agent REST + WS auth gates fail closed immediately — ahead of the cached
  * tenant cascade) and expire enrollment keys (so a still-valid key can't
@@ -36,10 +92,14 @@ const TENANT_SUSPENDED_TOKEN_REASON = AGENT_TOKEN_SUSPEND_REASON.tenantSuspended
  * We deliberately do NOT queue `self_uninstall` here: a status change may be
  * reversible (e.g. a billing suspension), and self_uninstall is both
  * irreversible and — once the auth gate has locked the agent out — undeliverable.
+ * Deliverable remote uninstall goes through the `offboarding` drain state
+ * (services/tenantOffboarding.ts, #2774), which keeps the agent gate open in
+ * a narrowed mode and calls this only after the fleet drains or the window
+ * closes. Exported for exactly that deferred-sever path.
  * Only devices that are not already suspended are touched, so this never
  * clobbers an existing probe-suspension's reason.
  */
-async function severAgentCredentialsForOrgIds(
+export async function severAgentCredentialsForOrgIds(
   orgIds: string[]
 ): Promise<{ agentTokensSuspended: number; enrollmentKeysInvalidated: number }> {
   if (orgIds.length === 0) {
@@ -59,55 +119,39 @@ async function severAgentCredentialsForOrgIds(
     .where(and(inArray(devices.orgId, orgIds), isNull(devices.agentTokenSuspendedAt)))
     .returning({ id: devices.id });
 
-  // Expire enrollment keys after the cache drop + token suspension. Safe
-  // ordering because the enroll path checks getActiveOrgTenant directly
-  // (uncached, see enrollment.ts), so it never admits via a stale positive
-  // cache during this window; only keys not already expired are touched.
-  const invalidatedKeys = await db
-    .update(enrollmentKeys)
-    .set({ expiresAt: now })
-    .where(
-      and(
-        inArray(enrollmentKeys.orgId, orgIds),
-        or(isNull(enrollmentKeys.expiresAt), gt(enrollmentKeys.expiresAt, now))
-      )
-    )
-    .returning({ id: enrollmentKeys.id });
+  const enrollmentKeysInvalidated = await expireEnrollmentKeysForOrgIds(orgIds, now);
 
-  // Finding #3(b): suspending the token + invalidating the cache only fails the
-  // NEXT auth gate — an already-established agent WS keeps its captured
-  // authorization until it happens to reconnect. Sever live sockets for devices
-  // in the affected orgs so containment is immediate, not eventual.
-  //
-  // agentWs is imported dynamically (not statically): `routes/agentWs` pulls in
-  // a large graph of services, and a static service→route edge here risks an
-  // import cycle. Dynamic import at call time is the established de-cycling
-  // pattern in this repo (agentWs itself dynamically imports its result
-  // handlers). Best-effort: socket teardown must NEVER fail the credential
-  // revocation, which is the load-bearing containment step.
-  try {
-    const { disconnectAgent, getConnectedAgentIds } = await import('../routes/agentWs');
-    const connected = getConnectedAgentIds();
-    if (connected.length > 0) {
-      const connectedSet = new Set(connected);
-      const deviceRows = await db
-        .select({ agentId: devices.agentId })
-        .from(devices)
-        .where(and(inArray(devices.orgId, orgIds), isNotNull(devices.agentId)));
-      for (const row of deviceRows) {
-        if (row.agentId && connectedSet.has(row.agentId)) {
-          disconnectAgent(row.agentId, 4001, 'Tenant suspended');
-        }
-      }
-    }
-  } catch (err) {
-    console.error('[tenantLifecycle] Failed to sever live agent sockets after credential cutoff:', err);
-  }
+  await disconnectLiveAgentSocketsForOrgIds(orgIds, 'Tenant suspended');
 
   return {
     agentTokensSuspended: suspended.length,
-    enrollmentKeysInvalidated: invalidatedKeys.length,
+    enrollmentKeysInvalidated,
   };
+}
+
+/**
+ * Drain-mode counterpart of severAgentCredentialsForOrgIds (#2774): close the
+ * fleet's ATTACK surface without closing its DELIVERY surface. Expires
+ * enrollment keys (no new devices during a drain), drops the tenant cache (so
+ * the agent gate re-reads the new `offboarding` status and starts narrowing
+ * within the 60s cache TTL), and severs live WS sockets (the WS channel
+ * carries desktop/terminal/tunnel pushes that bypass device_commands — a
+ * draining tenant must not keep an interactive control channel). Agent tokens
+ * are deliberately left untouched: they are the delivery path for the queued
+ * self_uninstall.
+ */
+export async function prepareAgentDrainForOrgIds(
+  orgIds: string[]
+): Promise<{ enrollmentKeysInvalidated: number }> {
+  if (orgIds.length === 0) {
+    return { enrollmentKeysInvalidated: 0 };
+  }
+
+  await invalidateAgentTenantCache(orgIds);
+  const enrollmentKeysInvalidated = await expireEnrollmentKeysForOrgIds(orgIds, new Date());
+  await disconnectLiveAgentSocketsForOrgIds(orgIds, 'Tenant offboarding');
+
+  return { enrollmentKeysInvalidated };
 }
 
 /**
@@ -153,7 +197,22 @@ async function revokeUsers(userIds: string[]): Promise<number> {
   return uniqueUserIds.length;
 }
 
-export async function revokeOrganizationTenantAccess(orgId: string): Promise<TenantRevocationResult> {
+/**
+ * `agentChannel` (#2774): 'sever' (default) suspends agent tokens immediately
+ * — the abuse/suspension/deletion behavior. 'drain' keeps agent tokens alive
+ * (narrowed by the `offboarding` tenant state) so a queued self_uninstall is
+ * deliverable; enrollment keys still expire and live WS sockets still drop in
+ * both modes.
+ */
+export interface TenantRevocationOptions {
+  agentChannel?: 'sever' | 'drain';
+}
+
+export async function revokeOrganizationTenantAccess(
+  orgId: string,
+  options: TenantRevocationOptions = {}
+): Promise<TenantRevocationResult> {
+  const agentChannel = options.agentChannel ?? 'sever';
   return runOutsideDbContext(() =>
     withSystemDbAccessContext(async () => {
       const orgUsers = await db
@@ -165,7 +224,12 @@ export async function revokeOrganizationTenantAccess(orgId: string): Promise<Ten
         revokeApiKeysForOrgIds([orgId]),
         revokeUsers(orgUsers.map((row) => row.userId)),
         revokeAllOrgOauthArtifacts(orgId),
-        severAgentCredentialsForOrgIds([orgId]),
+        agentChannel === 'sever'
+          ? severAgentCredentialsForOrgIds([orgId])
+          : prepareAgentDrainForOrgIds([orgId]).then((drain) => ({
+            agentTokensSuspended: 0,
+            enrollmentKeysInvalidated: drain.enrollmentKeysInvalidated,
+          })),
       ]);
 
       return {
@@ -180,7 +244,11 @@ export async function revokeOrganizationTenantAccess(orgId: string): Promise<Ten
   );
 }
 
-export async function revokePartnerTenantAccess(partnerId: string): Promise<TenantRevocationResult> {
+export async function revokePartnerTenantAccess(
+  partnerId: string,
+  options: TenantRevocationOptions = {}
+): Promise<TenantRevocationResult> {
+  const agentChannel = options.agentChannel ?? 'sever';
   return runOutsideDbContext(() =>
     withSystemDbAccessContext(async () => {
       const orgRows = await db
@@ -208,7 +276,12 @@ export async function revokePartnerTenantAccess(partnerId: string): Promise<Tena
           ...orgMemberships.map((row) => row.userId),
         ]),
         revokeAllPartnerOauthArtifacts(partnerId),
-        severAgentCredentialsForOrgIds(orgIds),
+        agentChannel === 'sever'
+          ? severAgentCredentialsForOrgIds(orgIds)
+          : prepareAgentDrainForOrgIds(orgIds).then((drain) => ({
+            agentTokensSuspended: 0,
+            enrollmentKeysInvalidated: drain.enrollmentKeysInvalidated,
+          })),
       ]);
 
       return {

--- a/apps/api/src/services/tenantOffboarding.test.ts
+++ b/apps/api/src/services/tenantOffboarding.test.ts
@@ -1,10 +1,24 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-vi.mock('../db', () => ({
-  db: { select: vi.fn(), update: vi.fn(), insert: vi.fn() },
-  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
-  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+const { selectMock, updateMock, insertMock } = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  updateMock: vi.fn(),
+  insertMock: vi.fn(),
 }));
+
+vi.mock('../db', () => {
+  const surface = { select: selectMock, update: updateMock, insert: insertMock };
+  return {
+    db: {
+      ...surface,
+      // queueDrainUninstalls locks device rows FOR UPDATE inside one
+      // transaction; the tx handle proxies to the same mocked surface.
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(surface)),
+    },
+    runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  };
+});
 
 vi.mock('../db/schema', () => ({
   deviceCommands: {
@@ -12,6 +26,7 @@ vi.mock('../db/schema', () => ({
     deviceId: 'deviceCommands.deviceId',
     type: 'deviceCommands.type',
     status: 'deviceCommands.status',
+    createdAt: 'deviceCommands.createdAt',
   },
   devices: {
     id: 'devices.id',
@@ -39,7 +54,20 @@ vi.mock('./auditEvents', () => ({
   requestLikeFromSnapshot: vi.fn(() => ({})),
 }));
 
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+
+const REVOCATION_RESULT = {
+  apiKeysRevoked: 0,
+  userSessionsRevoked: 0,
+  oauthGrantsRevoked: 0,
+  oauthRefreshTokensRevoked: 0,
+  agentTokensSuspended: 0,
+  enrollmentKeysInvalidated: 0,
+};
+
 vi.mock('./tenantLifecycle', () => ({
+  disconnectLiveAgentSocketsForOrgIds: vi.fn(async () => undefined),
+  prepareAgentDrainForOrgIds: vi.fn(async () => ({ enrollmentKeysInvalidated: 0 })),
   revokeOrganizationTenantAccess: vi.fn(async () => ({
     apiKeysRevoked: 0,
     userSessionsRevoked: 0,
@@ -67,16 +95,17 @@ vi.mock('./tenantStatus', () => ({ invalidateAgentTenantCache: vi.fn(async () =>
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args) => ({ and: args })),
   eq: vi.fn((l, r) => ({ eq: [l, r] })),
+  gte: vi.fn((l, r) => ({ gte: [l, r] })),
   inArray: vi.fn((c, vals) => ({ inArray: [c, vals] })),
   isNull: vi.fn((c) => ({ isNull: c })),
   isNotNull: vi.fn((c) => ({ isNotNull: c })),
   ne: vi.fn((l, r) => ({ ne: [l, r] })),
 }));
 
-import { db } from '../db';
 import { deviceCommands, devices, organizations, partners } from '../db/schema';
 import { writeAuditEvent } from './auditEvents';
 import {
+  disconnectLiveAgentSocketsForOrgIds,
   revokeOrganizationTenantAccess,
   revokePartnerTenantAccess,
   severAgentCredentialsForOrgIds,
@@ -98,13 +127,13 @@ const insertLog: { table: unknown; rows: Record<string, unknown>[] }[] = [];
 let updateReturningQueue: unknown[][];
 
 // Both `await ...where(...)` and `await ...where(...).returning(...)` shapes
-// are used by the service; the mock supports both. `.returning()` results pop
-// from a FIFO queue so tests can script successive updates independently.
+// are used; the mock supports both. `.returning()` results pop from a FIFO
+// queue so tests can script successive updates independently.
 function setupWrites() {
   updateLog.length = 0;
   insertLog.length = 0;
   updateReturningQueue = [];
-  vi.mocked(db.update).mockImplementation(
+  updateMock.mockImplementation(
     (table: any) =>
       ({
         set: vi.fn((values: any) => ({
@@ -118,7 +147,7 @@ function setupWrites() {
         })),
       }) as any
   );
-  vi.mocked(db.insert).mockImplementation(
+  insertMock.mockImplementation(
     (table: any) =>
       ({
         values: vi.fn(async (rows: any) => {
@@ -128,15 +157,14 @@ function setupWrites() {
   );
 }
 
-// select().from() chains end in .where() directly, or pass through
-// .innerJoin() first — support both from one queued result.
+// One flexible chain covering every select shape in this module:
+// .from().where(), + optional .innerJoin() / .for('update') / .limit().
 function queueSelect(rows: unknown[]) {
-  vi.mocked(db.select).mockReturnValueOnce({
-    from: vi.fn(() => ({
-      where: vi.fn().mockResolvedValue(rows),
-      innerJoin: vi.fn(() => ({ where: vi.fn().mockResolvedValue(rows) })),
-    })),
-  } as any);
+  const chain: Record<string, any> = {};
+  for (const method of ['from', 'innerJoin', 'where', 'for', 'limit', 'orderBy']) {
+    chain[method] = vi.fn(() => Object.assign(Promise.resolve(rows), chain));
+  }
+  selectMock.mockReturnValueOnce(Object.assign(Promise.resolve(rows), chain));
 }
 
 function updatesFor(table: unknown) {
@@ -150,7 +178,7 @@ describe('beginOrganizationOffboarding', () => {
   });
 
   it('revokes user access with the drain agent channel (tokens NOT suspended)', async () => {
-    queueSelect([]); // no devices
+    queueSelect([]); // devices (none)
 
     await beginOrganizationOffboarding('org-1', 'user-1');
 
@@ -158,7 +186,7 @@ describe('beginOrganizationOffboarding', () => {
   });
 
   it('stamps offboarding_started_at only when not already set (re-entry keeps the original window)', async () => {
-    queueSelect([]); // no devices
+    queueSelect([]); // devices
 
     await beginOrganizationOffboarding('org-1', 'user-1');
 
@@ -168,7 +196,7 @@ describe('beginOrganizationOffboarding', () => {
   });
 
   it('cancels other pending/sent commands and queues deduped self_uninstalls', async () => {
-    queueSelect([{ id: 'd1' }, { id: 'd2' }]); // devices in org
+    queueSelect([{ id: 'd1' }, { id: 'd2' }]); // devices (locked FOR UPDATE)
     queueSelect([{ deviceId: 'd1' }]); // d1 already has a non-terminal self_uninstall
 
     const result = await beginOrganizationOffboarding('org-1', 'user-1');
@@ -275,6 +303,8 @@ describe('abortPartnerOffboarding', () => {
   });
 });
 
+const DRAIN_START = new Date('2026-07-20T00:00:00Z');
+
 describe('finalizeOrganizationOffboarding', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -282,12 +312,14 @@ describe('finalizeOrganizationOffboarding', () => {
   });
 
   it('CAS-flips to churned, reports never-drained devices, cancels leftovers, and severs', async () => {
+    queueSelect([{ startedAt: DRAIN_START }]); // stamp read (pre-CAS)
     updateReturningQueue.push([{ id: 'org-1' }]); // CAS wins
     queueSelect([{ status: 'completed' }, { status: 'completed' }, { status: 'failed' }]); // terminal
     queueSelect([
       { id: 'cmd-1', status: 'pending', deviceId: 'd1', hostname: 'host-1' },
       { id: 'cmd-2', status: 'sent', deviceId: 'd2', hostname: 'host-2' },
     ]); // outstanding
+    queueSelect([{ status: 'churned' }]); // pre-sever status re-check
 
     const report = await finalizeOrganizationOffboarding('org-1', { forcedByDeadline: true });
 
@@ -323,7 +355,24 @@ describe('finalizeOrganizationOffboarding', () => {
     expect(severAgentCredentialsForOrgIds).toHaveBeenCalledWith(['org-1']);
   });
 
+  // Prior one-off remote uninstalls must not inflate THIS drain's completion
+  // count in a permanent audit record.
+  it('scopes terminal counts to commands created at/after the drain start', async () => {
+    queueSelect([{ startedAt: DRAIN_START }]);
+    updateReturningQueue.push([{ id: 'org-1' }]);
+    queueSelect([]); // terminal
+    queueSelect([]); // outstanding
+    queueSelect([{ status: 'churned' }]);
+
+    await finalizeOrganizationOffboarding('org-1', { forcedByDeadline: false });
+
+    const terminalWhere = JSON.stringify(selectMock.mock.results[1]!.value.where.mock.calls[0][0]);
+    expect(terminalWhere).toContain('gte');
+    expect(terminalWhere).toContain('deviceCommands.createdAt');
+  });
+
   it('does nothing when the CAS loses (operator aborted concurrently)', async () => {
+    queueSelect([{ startedAt: DRAIN_START }]); // stamp read
     updateReturningQueue.push([]); // CAS loses
 
     const report = await finalizeOrganizationOffboarding('org-1', { forcedByDeadline: false });
@@ -331,6 +380,22 @@ describe('finalizeOrganizationOffboarding', () => {
     expect(report).toBeNull();
     expect(severAgentCredentialsForOrgIds).not.toHaveBeenCalled();
     expect(writeAuditEvent).not.toHaveBeenCalled();
+  });
+
+  // The CAS protects the status flip but not the sever that follows it: if an
+  // operator reactivates in that gap, severing would strand an ACTIVE org's
+  // whole fleet with suspended tokens.
+  it('skips the sever when the org left churned during finalize', async () => {
+    queueSelect([{ startedAt: DRAIN_START }]);
+    updateReturningQueue.push([{ id: 'org-1' }]); // CAS wins
+    queueSelect([]); // terminal
+    queueSelect([]); // outstanding
+    queueSelect([{ status: 'active' }]); // reactivated mid-finalize
+
+    const report = await finalizeOrganizationOffboarding('org-1', { forcedByDeadline: false });
+
+    expect(report).not.toBeNull();
+    expect(severAgentCredentialsForOrgIds).not.toHaveBeenCalled();
   });
 });
 
@@ -341,10 +406,12 @@ describe('finalizePartnerOffboarding', () => {
   });
 
   it('severs every org under the partner and writes the partner-scoped report', async () => {
+    queueSelect([{ startedAt: DRAIN_START }]); // stamp read
     updateReturningQueue.push([{ id: 'partner-1' }]); // CAS wins
     queueSelect([{ id: 'org-1' }, { id: 'org-2' }]); // orgs under partner
     queueSelect([]); // terminal
     queueSelect([]); // outstanding
+    queueSelect([{ status: 'churned' }]); // pre-sever re-check
 
     const report = await finalizePartnerOffboarding('partner-1', { forcedByDeadline: false });
 
@@ -369,17 +436,25 @@ describe('sweepOffboardingTenants', () => {
     NOW.getTime() - (OFFBOARDING_DRAIN_WINDOW_HOURS + 1) * 60 * 60 * 1000
   );
 
+  // Candidate lists are read up-front (orgs, then partners) before any
+  // per-tenant work begins.
+  function queueCandidates(orgs: unknown[], ptrs: unknown[]) {
+    queueSelect(orgs);
+    queueSelect(ptrs);
+  }
+
   it('finalizes an org whose fleet fully drained (before the deadline)', async () => {
-    queueSelect([{ id: 'org-1', startedAt: WITHIN_WINDOW }]); // offboarding orgs
+    queueCandidates([{ id: 'org-1', startedAt: WITHIN_WINDOW }], []);
     queueSelect([]); // outstanding = 0
+    queueSelect([{ startedAt: WITHIN_WINDOW }]); // finalize stamp read
     updateReturningQueue.push([{ id: 'org-1' }]); // CAS
     queueSelect([]); // terminal
     queueSelect([]); // outstanding (finalize)
-    queueSelect([]); // offboarding partners
+    queueSelect([{ status: 'churned' }]); // pre-sever re-check
 
     const result = await sweepOffboardingTenants(NOW);
 
-    expect(result.orgsFinalized).toBe(1);
+    expect(result).toMatchObject({ orgsFinalized: 1, failures: 0 });
     expect(writeAuditEvent).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ details: expect.objectContaining({ forcedByDeadline: false }) })
@@ -387,12 +462,13 @@ describe('sweepOffboardingTenants', () => {
   });
 
   it('finalizes (forced) when the window closed with commands still outstanding', async () => {
-    queueSelect([{ id: 'org-1', startedAt: PAST_WINDOW }]);
+    queueCandidates([{ id: 'org-1', startedAt: PAST_WINDOW }], []);
     queueSelect([{ id: 'cmd-1' }]); // outstanding = 1
+    queueSelect([{ startedAt: PAST_WINDOW }]); // finalize stamp read
     updateReturningQueue.push([{ id: 'org-1' }]); // CAS
     queueSelect([]); // terminal
     queueSelect([{ id: 'cmd-1', status: 'pending', deviceId: 'd1', hostname: 'h1' }]);
-    queueSelect([]); // partners
+    queueSelect([{ status: 'churned' }]);
 
     const result = await sweepOffboardingTenants(NOW);
 
@@ -404,9 +480,8 @@ describe('sweepOffboardingTenants', () => {
   });
 
   it('leaves an org alone while commands are outstanding inside the window', async () => {
-    queueSelect([{ id: 'org-1', startedAt: WITHIN_WINDOW }]);
+    queueCandidates([{ id: 'org-1', startedAt: WITHIN_WINDOW }], []);
     queueSelect([{ id: 'cmd-1' }]); // outstanding = 1
-    queueSelect([]); // partners
 
     const result = await sweepOffboardingTenants(NOW);
 
@@ -414,26 +489,71 @@ describe('sweepOffboardingTenants', () => {
     expect(severAgentCredentialsForOrgIds).not.toHaveBeenCalled();
   });
 
-  it('self-heals a missing stamp instead of treating it as expired', async () => {
-    queueSelect([{ id: 'org-1', startedAt: null }]);
-    queueSelect([]); // partners
+  // A WS session is authorized once at upgrade and never re-checked, so the
+  // periodic re-sweep is what bounds a socket that won the entry race.
+  it('re-severs live agent sockets for a still-draining org each pass', async () => {
+    queueCandidates([{ id: 'org-1', startedAt: WITHIN_WINDOW }], []);
+    queueSelect([{ id: 'cmd-1' }]); // outstanding — stays draining
+
+    await sweepOffboardingTenants(NOW);
+
+    expect(disconnectLiveAgentSocketsForOrgIds).toHaveBeenCalledWith(['org-1'], 'Tenant offboarding');
+  });
+
+  // A status write that committed without its drain work must NOT be allowed
+  // to finalize on a zero-outstanding count — that would emit an empty report
+  // indistinguishable from a clean drain (the #2774 false-confidence bug).
+  it('repairs an incomplete entry (queues uninstalls) instead of finalizing it', async () => {
+    queueCandidates([{ id: 'org-1', startedAt: null }], []);
+    queueSelect([{ id: 'd1' }]); // devices to queue
+    queueSelect([]); // no existing uninstalls
 
     const result = await sweepOffboardingTenants(NOW);
 
     expect(result.orgsFinalized).toBe(0);
+    expect(insertLog[0]!.rows[0]).toMatchObject({ deviceId: 'd1', type: 'self_uninstall' });
     const stamp = updatesFor(organizations)[0]!;
     expect(stamp.values.offboardingStartedAt).toBe(NOW);
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'organization.offboarding_entry_repaired' })
+    );
+    expect(severAgentCredentialsForOrgIds).not.toHaveBeenCalled();
+  });
+
+  // One bad tenant must not starve every other draining tenant's finalization
+  // — they would sit past their window holding live credentials.
+  it('isolates a failing tenant and still finalizes the rest', async () => {
+    queueCandidates(
+      [{ id: 'org-bad', startedAt: WITHIN_WINDOW }, { id: 'org-good', startedAt: WITHIN_WINDOW }],
+      []
+    );
+    selectMock.mockImplementationOnce(() => {
+      throw new Error('db exploded for org-bad');
+    });
+    queueSelect([]); // org-good outstanding = 0
+    queueSelect([{ startedAt: WITHIN_WINDOW }]); // finalize stamp read
+    updateReturningQueue.push([{ id: 'org-good' }]); // CAS
+    queueSelect([]); // terminal
+    queueSelect([]); // outstanding
+    queueSelect([{ status: 'churned' }]);
+
+    const result = await sweepOffboardingTenants(NOW);
+
+    expect(result).toMatchObject({ orgsFinalized: 1, failures: 1 });
+    expect(severAgentCredentialsForOrgIds).toHaveBeenCalledWith(['org-good']);
   });
 
   it('finalizes a drained partner', async () => {
-    queueSelect([]); // orgs
-    queueSelect([{ id: 'partner-1', startedAt: WITHIN_WINDOW }]); // partners
-    queueSelect([{ id: 'org-1' }]); // orgs under partner (outstanding count)
+    queueCandidates([], [{ id: 'partner-1', startedAt: WITHIN_WINDOW }]);
+    queueSelect([{ id: 'org-1' }]); // orgs under partner
     queueSelect([]); // outstanding = 0
+    queueSelect([{ startedAt: WITHIN_WINDOW }]); // finalize stamp read
     updateReturningQueue.push([{ id: 'partner-1' }]); // CAS
     queueSelect([{ id: 'org-1' }]); // orgs under partner (finalize)
     queueSelect([]); // terminal
-    queueSelect([]); // outstanding (finalize)
+    queueSelect([]); // outstanding
+    queueSelect([{ status: 'churned' }]); // pre-sever re-check
 
     const result = await sweepOffboardingTenants(NOW);
 

--- a/apps/api/src/services/tenantOffboarding.test.ts
+++ b/apps/api/src/services/tenantOffboarding.test.ts
@@ -1,0 +1,443 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: { select: vi.fn(), update: vi.fn(), insert: vi.fn() },
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  deviceCommands: {
+    id: 'deviceCommands.id',
+    deviceId: 'deviceCommands.deviceId',
+    type: 'deviceCommands.type',
+    status: 'deviceCommands.status',
+  },
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+    status: 'devices.status',
+    hostname: 'devices.hostname',
+  },
+  organizations: {
+    id: 'organizations.id',
+    partnerId: 'organizations.partnerId',
+    status: 'organizations.status',
+    deletedAt: 'organizations.deletedAt',
+    offboardingStartedAt: 'organizations.offboardingStartedAt',
+  },
+  partners: {
+    id: 'partners.id',
+    status: 'partners.status',
+    deletedAt: 'partners.deletedAt',
+    offboardingStartedAt: 'partners.offboardingStartedAt',
+  },
+}));
+
+vi.mock('./auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+  requestLikeFromSnapshot: vi.fn(() => ({})),
+}));
+
+vi.mock('./tenantLifecycle', () => ({
+  revokeOrganizationTenantAccess: vi.fn(async () => ({
+    apiKeysRevoked: 0,
+    userSessionsRevoked: 0,
+    oauthGrantsRevoked: 0,
+    oauthRefreshTokensRevoked: 0,
+    agentTokensSuspended: 0,
+    enrollmentKeysInvalidated: 0,
+  })),
+  revokePartnerTenantAccess: vi.fn(async () => ({
+    apiKeysRevoked: 0,
+    userSessionsRevoked: 0,
+    oauthGrantsRevoked: 0,
+    oauthRefreshTokensRevoked: 0,
+    agentTokensSuspended: 0,
+    enrollmentKeysInvalidated: 0,
+  })),
+  severAgentCredentialsForOrgIds: vi.fn(async () => ({
+    agentTokensSuspended: 0,
+    enrollmentKeysInvalidated: 0,
+  })),
+}));
+
+vi.mock('./tenantStatus', () => ({ invalidateAgentTenantCache: vi.fn(async () => undefined) }));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args) => ({ and: args })),
+  eq: vi.fn((l, r) => ({ eq: [l, r] })),
+  inArray: vi.fn((c, vals) => ({ inArray: [c, vals] })),
+  isNull: vi.fn((c) => ({ isNull: c })),
+  isNotNull: vi.fn((c) => ({ isNotNull: c })),
+  ne: vi.fn((l, r) => ({ ne: [l, r] })),
+}));
+
+import { db } from '../db';
+import { deviceCommands, devices, organizations, partners } from '../db/schema';
+import { writeAuditEvent } from './auditEvents';
+import {
+  revokeOrganizationTenantAccess,
+  revokePartnerTenantAccess,
+  severAgentCredentialsForOrgIds,
+} from './tenantLifecycle';
+import { invalidateAgentTenantCache } from './tenantStatus';
+import {
+  abortOrganizationOffboarding,
+  abortPartnerOffboarding,
+  beginOrganizationOffboarding,
+  beginPartnerOffboarding,
+  finalizeOrganizationOffboarding,
+  finalizePartnerOffboarding,
+  sweepOffboardingTenants,
+  OFFBOARDING_DRAIN_WINDOW_HOURS,
+} from './tenantOffboarding';
+
+const updateLog: { table: unknown; values: Record<string, unknown>; where: unknown }[] = [];
+const insertLog: { table: unknown; rows: Record<string, unknown>[] }[] = [];
+let updateReturningQueue: unknown[][];
+
+// Both `await ...where(...)` and `await ...where(...).returning(...)` shapes
+// are used by the service; the mock supports both. `.returning()` results pop
+// from a FIFO queue so tests can script successive updates independently.
+function setupWrites() {
+  updateLog.length = 0;
+  insertLog.length = 0;
+  updateReturningQueue = [];
+  vi.mocked(db.update).mockImplementation(
+    (table: any) =>
+      ({
+        set: vi.fn((values: any) => ({
+          where: vi.fn((where: any) => {
+            updateLog.push({ table, values, where });
+            const rows = updateReturningQueue.length > 0 ? updateReturningQueue.shift()! : [];
+            const result: any = Promise.resolve(rows);
+            result.returning = vi.fn().mockResolvedValue(rows);
+            return result;
+          }),
+        })),
+      }) as any
+  );
+  vi.mocked(db.insert).mockImplementation(
+    (table: any) =>
+      ({
+        values: vi.fn(async (rows: any) => {
+          insertLog.push({ table, rows: Array.isArray(rows) ? rows : [rows] });
+        }),
+      }) as any
+  );
+}
+
+// select().from() chains end in .where() directly, or pass through
+// .innerJoin() first — support both from one queued result.
+function queueSelect(rows: unknown[]) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn(() => ({
+      where: vi.fn().mockResolvedValue(rows),
+      innerJoin: vi.fn(() => ({ where: vi.fn().mockResolvedValue(rows) })),
+    })),
+  } as any);
+}
+
+function updatesFor(table: unknown) {
+  return updateLog.filter((u) => u.table === table);
+}
+
+describe('beginOrganizationOffboarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupWrites();
+  });
+
+  it('revokes user access with the drain agent channel (tokens NOT suspended)', async () => {
+    queueSelect([]); // no devices
+
+    await beginOrganizationOffboarding('org-1', 'user-1');
+
+    expect(revokeOrganizationTenantAccess).toHaveBeenCalledWith('org-1', { agentChannel: 'drain' });
+  });
+
+  it('stamps offboarding_started_at only when not already set (re-entry keeps the original window)', async () => {
+    queueSelect([]); // no devices
+
+    await beginOrganizationOffboarding('org-1', 'user-1');
+
+    const stamp = updatesFor(organizations)[0]!;
+    expect(stamp.values.offboardingStartedAt).toBeInstanceOf(Date);
+    expect(JSON.stringify(stamp.where)).toContain('isNull');
+  });
+
+  it('cancels other pending/sent commands and queues deduped self_uninstalls', async () => {
+    queueSelect([{ id: 'd1' }, { id: 'd2' }]); // devices in org
+    queueSelect([{ deviceId: 'd1' }]); // d1 already has a non-terminal self_uninstall
+
+    const result = await beginOrganizationOffboarding('org-1', 'user-1');
+
+    // Other in-flight commands are cancelled so nothing races the uninstall.
+    const cancel = updatesFor(deviceCommands)[0]!;
+    expect(cancel.values.status).toBe('cancelled');
+    expect(JSON.stringify(cancel.where)).toContain('self_uninstall');
+
+    // Only d2 gets a new row — d1's in-flight uninstall is not duplicated.
+    expect(insertLog).toHaveLength(1);
+    expect(insertLog[0]!.rows).toEqual([
+      expect.objectContaining({
+        deviceId: 'd2',
+        type: 'self_uninstall',
+        payload: { removeConfig: true },
+        status: 'pending',
+        targetRole: 'agent',
+        createdBy: 'user-1',
+      }),
+    ]);
+    expect(result.devicesTargeted).toBe(2);
+    expect(result.uninstallsQueued).toBe(1);
+  });
+
+  it('queues nothing for an org with no (non-decommissioned) devices', async () => {
+    queueSelect([]);
+
+    const result = await beginOrganizationOffboarding('org-1', null);
+
+    expect(insertLog).toHaveLength(0);
+    expect(updatesFor(deviceCommands)).toHaveLength(0);
+    expect(result.devicesTargeted).toBe(0);
+  });
+});
+
+describe('beginPartnerOffboarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupWrites();
+  });
+
+  it('drains across every org under the partner', async () => {
+    queueSelect([{ id: 'org-1' }, { id: 'org-2' }]); // orgs under partner
+    queueSelect([{ id: 'd1' }]); // devices across those orgs
+    queueSelect([]); // no existing uninstalls
+
+    const result = await beginPartnerOffboarding('partner-1', 'user-1');
+
+    expect(revokePartnerTenantAccess).toHaveBeenCalledWith('partner-1', { agentChannel: 'drain' });
+    expect(updatesFor(partners)[0]!.values.offboardingStartedAt).toBeInstanceOf(Date);
+    expect(insertLog[0]!.rows[0]).toMatchObject({ deviceId: 'd1', type: 'self_uninstall' });
+    expect(result.uninstallsQueued).toBe(1);
+  });
+});
+
+describe('abortOrganizationOffboarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupWrites();
+  });
+
+  it('cancels in-flight drain uninstalls and invalidates the tenant cache', async () => {
+    updateReturningQueue.push([{ id: 'org-1' }]); // stamp-clear finds a stamp
+    queueSelect([{ id: 'd1' }]); // devices in org
+    updateReturningQueue.push([{ id: 'cmd-1' }, { id: 'cmd-2' }]); // cancelled commands
+
+    const result = await abortOrganizationOffboarding('org-1');
+
+    expect(result).toEqual({ aborted: true, uninstallsCancelled: 2 });
+    const cancel = updatesFor(deviceCommands)[0]!;
+    expect(cancel.values.status).toBe('cancelled');
+    expect(cancel.values.result).toEqual({ reason: 'organization_offboarding_aborted' });
+    expect(invalidateAgentTenantCache).toHaveBeenCalledWith(['org-1']);
+  });
+
+  it('is a no-op when the org was never offboarding (abuse-queued uninstalls survive)', async () => {
+    updateReturningQueue.push([]); // no stamp to clear
+
+    const result = await abortOrganizationOffboarding('org-1');
+
+    expect(result).toEqual({ aborted: false, uninstallsCancelled: 0 });
+    expect(updatesFor(deviceCommands)).toHaveLength(0);
+    expect(invalidateAgentTenantCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('abortPartnerOffboarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupWrites();
+  });
+
+  it('cancels drain uninstalls across every org under the partner', async () => {
+    updateReturningQueue.push([{ id: 'partner-1' }]);
+    queueSelect([{ id: 'org-1' }, { id: 'org-2' }]);
+    queueSelect([{ id: 'd1' }, { id: 'd2' }]);
+    updateReturningQueue.push([{ id: 'cmd-1' }]);
+
+    const result = await abortPartnerOffboarding('partner-1');
+
+    expect(result).toEqual({ aborted: true, uninstallsCancelled: 1 });
+    expect(invalidateAgentTenantCache).toHaveBeenCalledWith(['org-1', 'org-2']);
+  });
+});
+
+describe('finalizeOrganizationOffboarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupWrites();
+  });
+
+  it('CAS-flips to churned, reports never-drained devices, cancels leftovers, and severs', async () => {
+    updateReturningQueue.push([{ id: 'org-1' }]); // CAS wins
+    queueSelect([{ status: 'completed' }, { status: 'completed' }, { status: 'failed' }]); // terminal
+    queueSelect([
+      { id: 'cmd-1', status: 'pending', deviceId: 'd1', hostname: 'host-1' },
+      { id: 'cmd-2', status: 'sent', deviceId: 'd2', hostname: 'host-2' },
+    ]); // outstanding
+
+    const report = await finalizeOrganizationOffboarding('org-1', { forcedByDeadline: true });
+
+    expect(report).toMatchObject({
+      scopeType: 'organization',
+      scopeId: 'org-1',
+      uninstallsCompleted: 2,
+      uninstallsFailed: 1,
+      neverDelivered: [{ deviceId: 'd1', hostname: 'host-1' }],
+      deliveredUnconfirmed: [{ deviceId: 'd2', hostname: 'host-2' }],
+      forcedByDeadline: true,
+      windowHours: OFFBOARDING_DRAIN_WINDOW_HOURS,
+    });
+
+    // Status flip is the CAS guard — must target only status='offboarding'.
+    const flip = updatesFor(organizations)[0]!;
+    expect(flip.values.status).toBe('churned');
+    expect(flip.values.offboardingStartedAt).toBeNull();
+    expect(JSON.stringify(flip.where)).toContain('offboarding');
+
+    // Leftovers get an explicit cancellation (the never-drained signal).
+    const cancel = updatesFor(deviceCommands)[0]!;
+    expect(cancel.values.status).toBe('cancelled');
+    expect((cancel.values.result as Record<string, unknown>).reason).toBe('offboarding_window_closed');
+
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'organization.offboarding_completed',
+        details: expect.objectContaining({ neverDeliveredCount: 1, deliveredUnconfirmedCount: 1 }),
+      })
+    );
+    expect(severAgentCredentialsForOrgIds).toHaveBeenCalledWith(['org-1']);
+  });
+
+  it('does nothing when the CAS loses (operator aborted concurrently)', async () => {
+    updateReturningQueue.push([]); // CAS loses
+
+    const report = await finalizeOrganizationOffboarding('org-1', { forcedByDeadline: false });
+
+    expect(report).toBeNull();
+    expect(severAgentCredentialsForOrgIds).not.toHaveBeenCalled();
+    expect(writeAuditEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('finalizePartnerOffboarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupWrites();
+  });
+
+  it('severs every org under the partner and writes the partner-scoped report', async () => {
+    updateReturningQueue.push([{ id: 'partner-1' }]); // CAS wins
+    queueSelect([{ id: 'org-1' }, { id: 'org-2' }]); // orgs under partner
+    queueSelect([]); // terminal
+    queueSelect([]); // outstanding
+
+    const report = await finalizePartnerOffboarding('partner-1', { forcedByDeadline: false });
+
+    expect(report).toMatchObject({ scopeType: 'partner', scopeId: 'partner-1', orgIds: ['org-1', 'org-2'] });
+    expect(severAgentCredentialsForOrgIds).toHaveBeenCalledWith(['org-1', 'org-2']);
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'partner.offboarding_completed' })
+    );
+  });
+});
+
+describe('sweepOffboardingTenants', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupWrites();
+  });
+
+  const NOW = new Date('2026-07-24T12:00:00Z');
+  const WITHIN_WINDOW = new Date(NOW.getTime() - 60 * 60 * 1000); // 1h ago
+  const PAST_WINDOW = new Date(
+    NOW.getTime() - (OFFBOARDING_DRAIN_WINDOW_HOURS + 1) * 60 * 60 * 1000
+  );
+
+  it('finalizes an org whose fleet fully drained (before the deadline)', async () => {
+    queueSelect([{ id: 'org-1', startedAt: WITHIN_WINDOW }]); // offboarding orgs
+    queueSelect([]); // outstanding = 0
+    updateReturningQueue.push([{ id: 'org-1' }]); // CAS
+    queueSelect([]); // terminal
+    queueSelect([]); // outstanding (finalize)
+    queueSelect([]); // offboarding partners
+
+    const result = await sweepOffboardingTenants(NOW);
+
+    expect(result.orgsFinalized).toBe(1);
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ details: expect.objectContaining({ forcedByDeadline: false }) })
+    );
+  });
+
+  it('finalizes (forced) when the window closed with commands still outstanding', async () => {
+    queueSelect([{ id: 'org-1', startedAt: PAST_WINDOW }]);
+    queueSelect([{ id: 'cmd-1' }]); // outstanding = 1
+    updateReturningQueue.push([{ id: 'org-1' }]); // CAS
+    queueSelect([]); // terminal
+    queueSelect([{ id: 'cmd-1', status: 'pending', deviceId: 'd1', hostname: 'h1' }]);
+    queueSelect([]); // partners
+
+    const result = await sweepOffboardingTenants(NOW);
+
+    expect(result.orgsFinalized).toBe(1);
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ details: expect.objectContaining({ forcedByDeadline: true }) })
+    );
+  });
+
+  it('leaves an org alone while commands are outstanding inside the window', async () => {
+    queueSelect([{ id: 'org-1', startedAt: WITHIN_WINDOW }]);
+    queueSelect([{ id: 'cmd-1' }]); // outstanding = 1
+    queueSelect([]); // partners
+
+    const result = await sweepOffboardingTenants(NOW);
+
+    expect(result.orgsFinalized).toBe(0);
+    expect(severAgentCredentialsForOrgIds).not.toHaveBeenCalled();
+  });
+
+  it('self-heals a missing stamp instead of treating it as expired', async () => {
+    queueSelect([{ id: 'org-1', startedAt: null }]);
+    queueSelect([]); // partners
+
+    const result = await sweepOffboardingTenants(NOW);
+
+    expect(result.orgsFinalized).toBe(0);
+    const stamp = updatesFor(organizations)[0]!;
+    expect(stamp.values.offboardingStartedAt).toBe(NOW);
+  });
+
+  it('finalizes a drained partner', async () => {
+    queueSelect([]); // orgs
+    queueSelect([{ id: 'partner-1', startedAt: WITHIN_WINDOW }]); // partners
+    queueSelect([{ id: 'org-1' }]); // orgs under partner (outstanding count)
+    queueSelect([]); // outstanding = 0
+    updateReturningQueue.push([{ id: 'partner-1' }]); // CAS
+    queueSelect([{ id: 'org-1' }]); // orgs under partner (finalize)
+    queueSelect([]); // terminal
+    queueSelect([]); // outstanding (finalize)
+
+    const result = await sweepOffboardingTenants(NOW);
+
+    expect(result.partnersFinalized).toBe(1);
+    expect(severAgentCredentialsForOrgIds).toHaveBeenCalledWith(['org-1']);
+  });
+});

--- a/apps/api/src/services/tenantOffboarding.ts
+++ b/apps/api/src/services/tenantOffboarding.ts
@@ -1,8 +1,11 @@
-import { and, eq, inArray, isNotNull, isNull, ne } from 'drizzle-orm';
+import { and, eq, gte, inArray, isNotNull, isNull, ne } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { deviceCommands, devices, organizations, partners } from '../db/schema';
 import { requestLikeFromSnapshot, writeAuditEvent } from './auditEvents';
+import { captureException } from './sentry';
 import {
+  disconnectLiveAgentSocketsForOrgIds,
+  prepareAgentDrainForOrgIds,
   revokeOrganizationTenantAccess,
   revokePartnerTenantAccess,
   severAgentCredentialsForOrgIds,
@@ -58,77 +61,86 @@ export interface OffboardingFinalizeReport {
   windowHours: number;
 }
 
-async function nonDecommissionedDeviceIdsForOrgIds(orgIds: string[]): Promise<string[]> {
-  if (orgIds.length === 0) return [];
-  const rows = await db
-    .select({ id: devices.id })
-    .from(devices)
-    .where(and(inArray(devices.orgId, orgIds), ne(devices.status, 'decommissioned')));
-  return rows.map((row) => row.id);
-}
-
 /**
  * Cancel every other pending/sent command (they will never be user-visible
  * again and must not race the uninstall), then queue `self_uninstall` to each
- * device that doesn't already have one in flight — re-entry safe, so a
- * repeated PATCH to `offboarding` can't double-queue.
+ * device that doesn't already have one in flight.
+ *
+ * The whole read-then-insert runs in ONE transaction with the device rows
+ * locked `FOR UPDATE`: without the lock, two concurrent entries (a repeated
+ * PATCH, or a PATCH racing the reaper's entry repair) both observe an empty
+ * in-flight set and both insert. The duplicate could never complete, so it
+ * would force a deadline finalize and report a phantom never-drained device.
+ * Locking `devices` rather than adding a unique index on `device_commands`
+ * keeps the abuse-suspension bulk insert (routes/admin/abuse.ts) unaffected.
  */
 async function queueDrainUninstalls(
   orgIds: string[],
   createdBy: string | null
 ): Promise<{ devicesTargeted: number; uninstallsQueued: number; otherCommandsCancelled: number }> {
-  const deviceIds = await nonDecommissionedDeviceIdsForOrgIds(orgIds);
-  if (deviceIds.length === 0) {
+  if (orgIds.length === 0) {
     return { devicesTargeted: 0, uninstallsQueued: 0, otherCommandsCancelled: 0 };
   }
 
-  const cancelled = await db
-    .update(deviceCommands)
-    .set({
-      status: 'cancelled',
-      completedAt: new Date(),
-      result: { reason: 'tenant_offboarding' },
-    })
-    .where(
-      and(
-        inArray(deviceCommands.deviceId, deviceIds),
-        ne(deviceCommands.type, 'self_uninstall'),
-        inArray(deviceCommands.status, [...NON_TERMINAL_COMMAND_STATUSES])
+  return db.transaction(async (tx) => {
+    const deviceRows = await tx
+      .select({ id: devices.id })
+      .from(devices)
+      .where(and(inArray(devices.orgId, orgIds), ne(devices.status, 'decommissioned')))
+      .for('update');
+    const deviceIds = deviceRows.map((row) => row.id);
+    if (deviceIds.length === 0) {
+      return { devicesTargeted: 0, uninstallsQueued: 0, otherCommandsCancelled: 0 };
+    }
+
+    const cancelled = await tx
+      .update(deviceCommands)
+      .set({
+        status: 'cancelled',
+        completedAt: new Date(),
+        result: { reason: 'tenant_offboarding' },
+      })
+      .where(
+        and(
+          inArray(deviceCommands.deviceId, deviceIds),
+          ne(deviceCommands.type, 'self_uninstall'),
+          inArray(deviceCommands.status, [...NON_TERMINAL_COMMAND_STATUSES])
+        )
       )
-    )
-    .returning({ id: deviceCommands.id });
+      .returning({ id: deviceCommands.id });
 
-  const existing = await db
-    .select({ deviceId: deviceCommands.deviceId })
-    .from(deviceCommands)
-    .where(
-      and(
-        inArray(deviceCommands.deviceId, deviceIds),
-        eq(deviceCommands.type, 'self_uninstall'),
-        inArray(deviceCommands.status, [...NON_TERMINAL_COMMAND_STATUSES])
-      )
-    );
-  const alreadyQueued = new Set(existing.map((row) => row.deviceId));
-  const toQueue = deviceIds.filter((id) => !alreadyQueued.has(id));
+    const existing = await tx
+      .select({ deviceId: deviceCommands.deviceId })
+      .from(deviceCommands)
+      .where(
+        and(
+          inArray(deviceCommands.deviceId, deviceIds),
+          eq(deviceCommands.type, 'self_uninstall'),
+          inArray(deviceCommands.status, [...NON_TERMINAL_COMMAND_STATUSES])
+        )
+      );
+    const alreadyQueued = new Set(existing.map((row) => row.deviceId));
+    const toQueue = deviceIds.filter((id) => !alreadyQueued.has(id));
 
-  if (toQueue.length > 0) {
-    await db.insert(deviceCommands).values(
-      toQueue.map((deviceId) => ({
-        deviceId,
-        type: 'self_uninstall',
-        payload: { removeConfig: true },
-        status: 'pending',
-        targetRole: 'agent',
-        createdBy,
-      }))
-    );
-  }
+    if (toQueue.length > 0) {
+      await tx.insert(deviceCommands).values(
+        toQueue.map((deviceId) => ({
+          deviceId,
+          type: 'self_uninstall',
+          payload: { removeConfig: true },
+          status: 'pending',
+          targetRole: 'agent',
+          createdBy,
+        }))
+      );
+    }
 
-  return {
-    devicesTargeted: deviceIds.length,
-    uninstallsQueued: toQueue.length,
-    otherCommandsCancelled: cancelled.length,
-  };
+    return {
+      devicesTargeted: deviceIds.length,
+      uninstallsQueued: toQueue.length,
+      otherCommandsCancelled: cancelled.length,
+    };
+  });
 }
 
 export async function beginOrganizationOffboarding(
@@ -215,6 +227,13 @@ async function cancelDrainUninstallsForOrgIds(orgIds: string[], reason: string):
  * no commands) when the org was not offboarding — keyed on the
  * offboarding_started_at stamp, so e.g. an abuse-suspension's queued
  * uninstalls are never cancelled by an unrelated org status write.
+ *
+ * Deliberate exception: during a PARTNER-level drain only
+ * `partners.offboarding_started_at` is set, so reactivating a single org under
+ * a still-offboarding partner is a no-op here and its queued uninstalls stay
+ * deliverable — correct, because `getAgentTenantState` still resolves
+ * `draining` for that org via the partner axis and the partner is still
+ * churning. Reactivate the PARTNER to abort a partner-level drain.
  */
 export async function abortOrganizationOffboarding(orgId: string): Promise<OffboardingAbortResult> {
   return runOutsideDbContext(() =>
@@ -285,7 +304,14 @@ async function countOutstandingUninstalls(orgIds: string[]): Promise<number> {
  * an explicit result — the "never drained" signal the old flow lacked (#2774:
  * silently-expired commands looked like a cleaned fleet).
  */
-async function collectAndCancelOutstanding(orgIds: string[]): Promise<{
+async function collectAndCancelOutstanding(
+  orgIds: string[],
+  // Start of the drain window. Terminal counts are scoped to commands created
+  // at/after it so a tenant's historical one-off remote uninstalls can't
+  // inflate this drain's completion count in a permanent audit record. Null
+  // (stamp already cleared / never written) falls back to counting all.
+  drainStartedAt: Date | null
+): Promise<{
   uninstallsCompleted: number;
   uninstallsFailed: number;
   neverDelivered: Array<{ deviceId: string; hostname: string | null }>;
@@ -303,7 +329,8 @@ async function collectAndCancelOutstanding(orgIds: string[]): Promise<{
       and(
         inArray(devices.orgId, orgIds),
         eq(deviceCommands.type, 'self_uninstall'),
-        inArray(deviceCommands.status, ['completed', 'failed'])
+        inArray(deviceCommands.status, ['completed', 'failed']),
+        ...(drainStartedAt ? [gte(deviceCommands.createdAt, drainStartedAt)] : [])
       )
     );
   const uninstallsCompleted = terminalRows.filter((row) => row.status === 'completed').length;
@@ -383,6 +410,32 @@ function writeOffboardingReportAudit(report: OffboardingFinalizeReport, orgIdFor
 }
 
 /**
+ * The status CAS protects the flip, but NOT the sever that follows it. An
+ * operator reactivating a tenant in that gap would otherwise end up `active`
+ * with the whole fleet's tokens suspended (the reaper's sever landing after
+ * the route's restore). Re-read immediately before severing and skip if our
+ * `churned` no longer stands — the sever is only correct for a tenant that is
+ * still terminal.
+ */
+async function orgIsStillChurned(orgId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ status: organizations.status })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  return row?.status === 'churned';
+}
+
+async function partnerIsStillChurned(partnerId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ status: partners.status })
+    .from(partners)
+    .where(eq(partners.id, partnerId))
+    .limit(1);
+  return row?.status === 'churned';
+}
+
+/**
  * Finalize an org drain: CAS the status offboarding→churned FIRST (losing the
  * CAS means an operator aborted or forced another transition concurrently —
  * do nothing), then cancel leftovers with the never-drained report, write the
@@ -392,6 +445,14 @@ export async function finalizeOrganizationOffboarding(
   orgId: string,
   options: { forcedByDeadline: boolean }
 ): Promise<OffboardingFinalizeReport | null> {
+  // Read the drain start BEFORE the CAS clears it — it scopes the report's
+  // terminal counts to this drain window.
+  const [before] = await db
+    .select({ startedAt: organizations.offboardingStartedAt })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
   const flipped = await db
     .update(organizations)
     .set({ status: 'churned', offboardingStartedAt: null, updatedAt: new Date() })
@@ -399,7 +460,7 @@ export async function finalizeOrganizationOffboarding(
     .returning({ id: organizations.id });
   if (flipped.length === 0) return null;
 
-  const outcome = await collectAndCancelOutstanding([orgId]);
+  const outcome = await collectAndCancelOutstanding([orgId], before?.startedAt ?? null);
   const report: OffboardingFinalizeReport = {
     scopeType: 'organization',
     scopeId: orgId,
@@ -410,7 +471,13 @@ export async function finalizeOrganizationOffboarding(
   };
   writeOffboardingReportAudit(report, orgId);
 
-  await severAgentCredentialsForOrgIds([orgId]);
+  if (await orgIsStillChurned(orgId)) {
+    await severAgentCredentialsForOrgIds([orgId]);
+  } else {
+    console.warn(
+      `[tenantOffboarding] org ${orgId} left churned during finalize — skipping credential sever`
+    );
+  }
   return report;
 }
 
@@ -418,6 +485,12 @@ export async function finalizePartnerOffboarding(
   partnerId: string,
   options: { forcedByDeadline: boolean }
 ): Promise<OffboardingFinalizeReport | null> {
+  const [before] = await db
+    .select({ startedAt: partners.offboardingStartedAt })
+    .from(partners)
+    .where(eq(partners.id, partnerId))
+    .limit(1);
+
   const flipped = await db
     .update(partners)
     .set({ status: 'churned', offboardingStartedAt: null, updatedAt: new Date() })
@@ -431,7 +504,7 @@ export async function finalizePartnerOffboarding(
     .where(eq(organizations.partnerId, partnerId));
   const orgIds = orgRows.map((row) => row.id);
 
-  const outcome = await collectAndCancelOutstanding(orgIds);
+  const outcome = await collectAndCancelOutstanding(orgIds, before?.startedAt ?? null);
   const report: OffboardingFinalizeReport = {
     scopeType: 'partner',
     scopeId: partnerId,
@@ -442,73 +515,164 @@ export async function finalizePartnerOffboarding(
   };
   writeOffboardingReportAudit(report, null);
 
-  await severAgentCredentialsForOrgIds(orgIds);
+  if (await partnerIsStillChurned(partnerId)) {
+    await severAgentCredentialsForOrgIds(orgIds);
+  } else {
+    console.warn(
+      `[tenantOffboarding] partner ${partnerId} left churned during finalize — skipping credential sever`
+    );
+  }
   return report;
 }
 
 /**
- * One sweep pass, run by jobs/offboardingDrainReaper.ts under a system DB
- * context. A tenant finalizes when its drain uninstalls are all terminal or
- * its window (offboarding_started_at + OFFBOARDING_DRAIN_WINDOW_HOURS) has
- * closed. A missing stamp is self-healed to `now` rather than treated as an
- * instantly-expired window.
+ * Repair an entry that committed the status but not the drain work. The route
+ * writes `status='offboarding'` before calling begin*Offboarding, so a throw
+ * in between leaves a tenant whose users are (maybe) revoked and whose fleet
+ * has NO queued uninstall. Without this the next sweep would see zero
+ * outstanding commands, finalize immediately, and emit an empty report
+ * indistinguishable from a clean drain — reintroducing the exact false
+ * confidence #2774 exists to remove.
+ *
+ * Queueing is idempotent (dedupes against in-flight uninstalls), so re-running
+ * it is safe; the stamp write is the marker that the entry is now complete.
+ */
+async function repairIncompleteEntry(
+  scope: 'organization' | 'partner',
+  scopeId: string,
+  orgIds: string[],
+  now: Date
+): Promise<void> {
+  console.warn(
+    `[tenantOffboarding] ${scope} ${scopeId} is offboarding with no drain stamp — completing the entry`
+  );
+  const queued = await queueDrainUninstalls(orgIds, null);
+  await prepareAgentDrainForOrgIds(orgIds);
+
+  if (scope === 'organization') {
+    await db
+      .update(organizations)
+      .set({ offboardingStartedAt: now, updatedAt: now })
+      .where(and(eq(organizations.id, scopeId), isNull(organizations.offboardingStartedAt)));
+  } else {
+    await db
+      .update(partners)
+      .set({ offboardingStartedAt: now, updatedAt: now })
+      .where(and(eq(partners.id, scopeId), isNull(partners.offboardingStartedAt)));
+  }
+
+  writeAuditEvent(requestLikeFromSnapshot({}), {
+    orgId: scope === 'organization' ? scopeId : null,
+    action: `${scope}.offboarding_entry_repaired`,
+    resourceType: scope,
+    resourceId: scopeId,
+    actorType: 'system',
+    actorId: null,
+    result: 'success',
+    details: { uninstallsQueued: queued.uninstallsQueued, devicesTargeted: queued.devicesTargeted },
+  });
+}
+
+/**
+ * One sweep pass, run by jobs/offboardingDrainReaper.ts. A tenant finalizes
+ * when its drain uninstalls are all terminal, or when its window
+ * (offboarding_started_at + OFFBOARDING_DRAIN_WINDOW_HOURS) has closed.
+ *
+ * Each tenant is processed in its OWN system-context block and its own
+ * try/catch: one tenant that throws (e.g. a sever failure) must not starve
+ * every other draining tenant's finalization — they would sit past their
+ * window with live credentials. The candidate lists are read first and the
+ * per-tenant work is NOT wrapped in a single outer transaction, so socket
+ * teardown never runs while pinning a pooled connection idle-in-transaction
+ * (#1105).
  */
 export async function sweepOffboardingTenants(
   now: Date = new Date()
-): Promise<{ orgsFinalized: number; partnersFinalized: number }> {
+): Promise<{ orgsFinalized: number; partnersFinalized: number; failures: number }> {
   const windowMs = OFFBOARDING_DRAIN_WINDOW_HOURS * 60 * 60 * 1000;
   let orgsFinalized = 0;
   let partnersFinalized = 0;
+  let failures = 0;
 
-  const offboardingOrgs = await db
-    .select({ id: organizations.id, startedAt: organizations.offboardingStartedAt })
-    .from(organizations)
-    .where(and(eq(organizations.status, 'offboarding'), isNull(organizations.deletedAt)));
+  const [offboardingOrgs, offboardingPartners] = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const orgs = await db
+        .select({ id: organizations.id, startedAt: organizations.offboardingStartedAt })
+        .from(organizations)
+        .where(and(eq(organizations.status, 'offboarding'), isNull(organizations.deletedAt)));
+      const ptrs = await db
+        .select({ id: partners.id, startedAt: partners.offboardingStartedAt })
+        .from(partners)
+        .where(and(eq(partners.status, 'offboarding'), isNull(partners.deletedAt)));
+      return [orgs, ptrs] as const;
+    })
+  );
 
   for (const org of offboardingOrgs) {
-    if (!org.startedAt) {
-      await db
-        .update(organizations)
-        .set({ offboardingStartedAt: now, updatedAt: now })
-        .where(and(eq(organizations.id, org.id), isNull(organizations.offboardingStartedAt)));
-      continue;
-    }
-    const outstanding = await countOutstandingUninstalls([org.id]);
-    const deadlinePassed = now.getTime() >= org.startedAt.getTime() + windowMs;
-    if (outstanding === 0 || deadlinePassed) {
-      const report = await finalizeOrganizationOffboarding(org.id, {
-        forcedByDeadline: outstanding > 0,
-      });
-      if (report) orgsFinalized++;
+    try {
+      const finalized = await runOutsideDbContext(() =>
+        withSystemDbAccessContext(async () => {
+          if (!org.startedAt) {
+            await repairIncompleteEntry('organization', org.id, [org.id], now);
+            return false;
+          }
+          // Belt-and-braces: kill any socket that was established in the race
+          // between the status commit and the entry's teardown. A WS session
+          // is authorized once at upgrade and never re-checked, so without
+          // this re-sweep a single racing connect would hold a fully-capable
+          // channel (terminal/desktop/tunnel pushes bypass device_commands)
+          // for the whole drain window instead of at most one sweep interval.
+          await disconnectLiveAgentSocketsForOrgIds([org.id], 'Tenant offboarding');
+
+          const outstanding = await countOutstandingUninstalls([org.id]);
+          const deadlinePassed = now.getTime() >= org.startedAt.getTime() + windowMs;
+          if (outstanding > 0 && !deadlinePassed) return false;
+
+          return Boolean(
+            await finalizeOrganizationOffboarding(org.id, { forcedByDeadline: outstanding > 0 })
+          );
+        })
+      );
+      if (finalized) orgsFinalized++;
+    } catch (err) {
+      failures++;
+      console.error(`[tenantOffboarding] Failed to sweep offboarding org ${org.id}:`, err);
+      captureException(err instanceof Error ? err : new Error(String(err)));
     }
   }
-
-  const offboardingPartners = await db
-    .select({ id: partners.id, startedAt: partners.offboardingStartedAt })
-    .from(partners)
-    .where(and(eq(partners.status, 'offboarding'), isNull(partners.deletedAt)));
 
   for (const partner of offboardingPartners) {
-    if (!partner.startedAt) {
-      await db
-        .update(partners)
-        .set({ offboardingStartedAt: now, updatedAt: now })
-        .where(and(eq(partners.id, partner.id), isNull(partners.offboardingStartedAt)));
-      continue;
-    }
-    const orgRows = await db
-      .select({ id: organizations.id })
-      .from(organizations)
-      .where(eq(organizations.partnerId, partner.id));
-    const outstanding = await countOutstandingUninstalls(orgRows.map((row) => row.id));
-    const deadlinePassed = now.getTime() >= partner.startedAt.getTime() + windowMs;
-    if (outstanding === 0 || deadlinePassed) {
-      const report = await finalizePartnerOffboarding(partner.id, {
-        forcedByDeadline: outstanding > 0,
-      });
-      if (report) partnersFinalized++;
+    try {
+      const finalized = await runOutsideDbContext(() =>
+        withSystemDbAccessContext(async () => {
+          const orgRows = await db
+            .select({ id: organizations.id })
+            .from(organizations)
+            .where(eq(organizations.partnerId, partner.id));
+          const orgIds = orgRows.map((row) => row.id);
+
+          if (!partner.startedAt) {
+            await repairIncompleteEntry('partner', partner.id, orgIds, now);
+            return false;
+          }
+          await disconnectLiveAgentSocketsForOrgIds(orgIds, 'Tenant offboarding');
+
+          const outstanding = await countOutstandingUninstalls(orgIds);
+          const deadlinePassed = now.getTime() >= partner.startedAt.getTime() + windowMs;
+          if (outstanding > 0 && !deadlinePassed) return false;
+
+          return Boolean(
+            await finalizePartnerOffboarding(partner.id, { forcedByDeadline: outstanding > 0 })
+          );
+        })
+      );
+      if (finalized) partnersFinalized++;
+    } catch (err) {
+      failures++;
+      console.error(`[tenantOffboarding] Failed to sweep offboarding partner ${partner.id}:`, err);
+      captureException(err instanceof Error ? err : new Error(String(err)));
     }
   }
 
-  return { orgsFinalized, partnersFinalized };
+  return { orgsFinalized, partnersFinalized, failures };
 }

--- a/apps/api/src/services/tenantOffboarding.ts
+++ b/apps/api/src/services/tenantOffboarding.ts
@@ -1,0 +1,514 @@
+import { and, eq, inArray, isNotNull, isNull, ne } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { deviceCommands, devices, organizations, partners } from '../db/schema';
+import { requestLikeFromSnapshot, writeAuditEvent } from './auditEvents';
+import {
+  revokeOrganizationTenantAccess,
+  revokePartnerTenantAccess,
+  severAgentCredentialsForOrgIds,
+  type TenantRevocationResult,
+} from './tenantLifecycle';
+import { invalidateAgentTenantCache } from './tenantStatus';
+
+/**
+ * Offboarding drain state (#2774).
+ *
+ * Terminal churn used to sever the agent auth channel before self_uninstall
+ * could ever be delivered — 78 of 80 uninstalls all-time expired uncollected.
+ * The `offboarding` status inverts the ordering: users/API keys/OAuth are
+ * revoked immediately, but agent tokens stay valid in a narrowed drain mode
+ * (heartbeat + self_uninstall-only command claim; WS refused) while a queued
+ * self_uninstall drains to each device. The drain reaper finalizes — cancel
+ * leftovers with an explicit never-delivered report, sever credentials, flip
+ * to `churned` — once the fleet drains or the window closes.
+ *
+ * The abuse-suspension path deliberately does NOT use this: reversible or
+ * adversarial suspensions must sever immediately (see tenantLifecycle.ts).
+ */
+
+const RAW_WINDOW_HOURS = Number(process.env.OFFBOARDING_DRAIN_WINDOW_HOURS ?? '72');
+export const OFFBOARDING_DRAIN_WINDOW_HOURS =
+  Number.isFinite(RAW_WINDOW_HOURS) && RAW_WINDOW_HOURS >= 1 ? RAW_WINDOW_HOURS : 72;
+
+const NON_TERMINAL_COMMAND_STATUSES = ['pending', 'sent'] as const;
+
+export interface OffboardingEntryResult {
+  revocation: TenantRevocationResult;
+  devicesTargeted: number;
+  uninstallsQueued: number;
+  otherCommandsCancelled: number;
+}
+
+export interface OffboardingAbortResult {
+  aborted: boolean;
+  uninstallsCancelled: number;
+}
+
+export interface OffboardingFinalizeReport {
+  scopeType: 'organization' | 'partner';
+  scopeId: string;
+  orgIds: string[];
+  uninstallsCompleted: number;
+  uninstallsFailed: number;
+  /** pending — the agent never collected the command. */
+  neverDelivered: Array<{ deviceId: string; hostname: string | null }>;
+  /** sent but no result — collected, uninstall unconfirmed (ack may be lost). */
+  deliveredUnconfirmed: Array<{ deviceId: string; hostname: string | null }>;
+  forcedByDeadline: boolean;
+  windowHours: number;
+}
+
+async function nonDecommissionedDeviceIdsForOrgIds(orgIds: string[]): Promise<string[]> {
+  if (orgIds.length === 0) return [];
+  const rows = await db
+    .select({ id: devices.id })
+    .from(devices)
+    .where(and(inArray(devices.orgId, orgIds), ne(devices.status, 'decommissioned')));
+  return rows.map((row) => row.id);
+}
+
+/**
+ * Cancel every other pending/sent command (they will never be user-visible
+ * again and must not race the uninstall), then queue `self_uninstall` to each
+ * device that doesn't already have one in flight — re-entry safe, so a
+ * repeated PATCH to `offboarding` can't double-queue.
+ */
+async function queueDrainUninstalls(
+  orgIds: string[],
+  createdBy: string | null
+): Promise<{ devicesTargeted: number; uninstallsQueued: number; otherCommandsCancelled: number }> {
+  const deviceIds = await nonDecommissionedDeviceIdsForOrgIds(orgIds);
+  if (deviceIds.length === 0) {
+    return { devicesTargeted: 0, uninstallsQueued: 0, otherCommandsCancelled: 0 };
+  }
+
+  const cancelled = await db
+    .update(deviceCommands)
+    .set({
+      status: 'cancelled',
+      completedAt: new Date(),
+      result: { reason: 'tenant_offboarding' },
+    })
+    .where(
+      and(
+        inArray(deviceCommands.deviceId, deviceIds),
+        ne(deviceCommands.type, 'self_uninstall'),
+        inArray(deviceCommands.status, [...NON_TERMINAL_COMMAND_STATUSES])
+      )
+    )
+    .returning({ id: deviceCommands.id });
+
+  const existing = await db
+    .select({ deviceId: deviceCommands.deviceId })
+    .from(deviceCommands)
+    .where(
+      and(
+        inArray(deviceCommands.deviceId, deviceIds),
+        eq(deviceCommands.type, 'self_uninstall'),
+        inArray(deviceCommands.status, [...NON_TERMINAL_COMMAND_STATUSES])
+      )
+    );
+  const alreadyQueued = new Set(existing.map((row) => row.deviceId));
+  const toQueue = deviceIds.filter((id) => !alreadyQueued.has(id));
+
+  if (toQueue.length > 0) {
+    await db.insert(deviceCommands).values(
+      toQueue.map((deviceId) => ({
+        deviceId,
+        type: 'self_uninstall',
+        payload: { removeConfig: true },
+        status: 'pending',
+        targetRole: 'agent',
+        createdBy,
+      }))
+    );
+  }
+
+  return {
+    devicesTargeted: deviceIds.length,
+    uninstallsQueued: toQueue.length,
+    otherCommandsCancelled: cancelled.length,
+  };
+}
+
+export async function beginOrganizationOffboarding(
+  orgId: string,
+  actorUserId: string | null
+): Promise<OffboardingEntryResult> {
+  // Users/API keys/OAuth out immediately; agent channel kept (drain mode).
+  const revocation = await revokeOrganizationTenantAccess(orgId, { agentChannel: 'drain' });
+
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      // Preserve the original start on re-entry so a repeated PATCH can't
+      // extend the drain window indefinitely.
+      await db
+        .update(organizations)
+        .set({ offboardingStartedAt: new Date(), updatedAt: new Date() })
+        .where(and(eq(organizations.id, orgId), isNull(organizations.offboardingStartedAt)));
+
+      const queued = await queueDrainUninstalls([orgId], actorUserId);
+      return { revocation, ...queued };
+    })
+  );
+}
+
+export async function beginPartnerOffboarding(
+  partnerId: string,
+  actorUserId: string | null
+): Promise<OffboardingEntryResult> {
+  const revocation = await revokePartnerTenantAccess(partnerId, { agentChannel: 'drain' });
+
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      await db
+        .update(partners)
+        .set({ offboardingStartedAt: new Date(), updatedAt: new Date() })
+        .where(and(eq(partners.id, partnerId), isNull(partners.offboardingStartedAt)));
+
+      const orgRows = await db
+        .select({ id: organizations.id })
+        .from(organizations)
+        .where(eq(organizations.partnerId, partnerId));
+
+      const queued = await queueDrainUninstalls(orgRows.map((row) => row.id), actorUserId);
+      return { revocation, ...queued };
+    })
+  );
+}
+
+/**
+ * Cancel in-flight drain uninstalls for the orgs. Used on abort (an
+ * uncollected self_uninstall MUST NOT survive into a reactivated tenant —
+ * it would fire the moment the fleet resumes polling) and shared by the
+ * transition handlers when an operator forces suspended/churned mid-drain.
+ */
+async function cancelDrainUninstallsForOrgIds(orgIds: string[], reason: string): Promise<number> {
+  if (orgIds.length === 0) return 0;
+  const deviceRows = await db
+    .select({ id: devices.id })
+    .from(devices)
+    .where(inArray(devices.orgId, orgIds));
+  const deviceIds = deviceRows.map((row) => row.id);
+  if (deviceIds.length === 0) return 0;
+
+  const cancelled = await db
+    .update(deviceCommands)
+    .set({
+      status: 'cancelled',
+      completedAt: new Date(),
+      result: { reason },
+    })
+    .where(
+      and(
+        inArray(deviceCommands.deviceId, deviceIds),
+        eq(deviceCommands.type, 'self_uninstall'),
+        inArray(deviceCommands.status, [...NON_TERMINAL_COMMAND_STATUSES])
+      )
+    )
+    .returning({ id: deviceCommands.id });
+  return cancelled.length;
+}
+
+/**
+ * Abort an in-progress org drain. No-op (returns aborted:false, and touches
+ * no commands) when the org was not offboarding — keyed on the
+ * offboarding_started_at stamp, so e.g. an abuse-suspension's queued
+ * uninstalls are never cancelled by an unrelated org status write.
+ */
+export async function abortOrganizationOffboarding(orgId: string): Promise<OffboardingAbortResult> {
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const cleared = await db
+        .update(organizations)
+        .set({ offboardingStartedAt: null, updatedAt: new Date() })
+        .where(and(eq(organizations.id, orgId), isNotNull(organizations.offboardingStartedAt)))
+        .returning({ id: organizations.id });
+
+      if (cleared.length === 0) return { aborted: false, uninstallsCancelled: 0 };
+
+      const uninstallsCancelled = await cancelDrainUninstallsForOrgIds(
+        [orgId],
+        'organization_offboarding_aborted'
+      );
+      await invalidateAgentTenantCache([orgId]);
+      return { aborted: true, uninstallsCancelled };
+    })
+  );
+}
+
+export async function abortPartnerOffboarding(partnerId: string): Promise<OffboardingAbortResult> {
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const cleared = await db
+        .update(partners)
+        .set({ offboardingStartedAt: null, updatedAt: new Date() })
+        .where(and(eq(partners.id, partnerId), isNotNull(partners.offboardingStartedAt)))
+        .returning({ id: partners.id });
+
+      if (cleared.length === 0) return { aborted: false, uninstallsCancelled: 0 };
+
+      const orgRows = await db
+        .select({ id: organizations.id })
+        .from(organizations)
+        .where(eq(organizations.partnerId, partnerId));
+      const orgIds = orgRows.map((row) => row.id);
+
+      const uninstallsCancelled = await cancelDrainUninstallsForOrgIds(
+        orgIds,
+        'partner_offboarding_aborted'
+      );
+      await invalidateAgentTenantCache(orgIds);
+      return { aborted: true, uninstallsCancelled };
+    })
+  );
+}
+
+async function countOutstandingUninstalls(orgIds: string[]): Promise<number> {
+  if (orgIds.length === 0) return 0;
+  const rows = await db
+    .select({ id: deviceCommands.id })
+    .from(deviceCommands)
+    .innerJoin(devices, eq(devices.id, deviceCommands.deviceId))
+    .where(
+      and(
+        inArray(devices.orgId, orgIds),
+        eq(deviceCommands.type, 'self_uninstall'),
+        inArray(deviceCommands.status, [...NON_TERMINAL_COMMAND_STATUSES])
+      )
+    );
+  return rows.length;
+}
+
+/**
+ * Collect the drain outcome for the report, then cancel whatever is left with
+ * an explicit result — the "never drained" signal the old flow lacked (#2774:
+ * silently-expired commands looked like a cleaned fleet).
+ */
+async function collectAndCancelOutstanding(orgIds: string[]): Promise<{
+  uninstallsCompleted: number;
+  uninstallsFailed: number;
+  neverDelivered: Array<{ deviceId: string; hostname: string | null }>;
+  deliveredUnconfirmed: Array<{ deviceId: string; hostname: string | null }>;
+}> {
+  if (orgIds.length === 0) {
+    return { uninstallsCompleted: 0, uninstallsFailed: 0, neverDelivered: [], deliveredUnconfirmed: [] };
+  }
+
+  const terminalRows = await db
+    .select({ status: deviceCommands.status })
+    .from(deviceCommands)
+    .innerJoin(devices, eq(devices.id, deviceCommands.deviceId))
+    .where(
+      and(
+        inArray(devices.orgId, orgIds),
+        eq(deviceCommands.type, 'self_uninstall'),
+        inArray(deviceCommands.status, ['completed', 'failed'])
+      )
+    );
+  const uninstallsCompleted = terminalRows.filter((row) => row.status === 'completed').length;
+  const uninstallsFailed = terminalRows.filter((row) => row.status === 'failed').length;
+
+  const outstanding = await db
+    .select({
+      id: deviceCommands.id,
+      status: deviceCommands.status,
+      deviceId: devices.id,
+      hostname: devices.hostname,
+    })
+    .from(deviceCommands)
+    .innerJoin(devices, eq(devices.id, deviceCommands.deviceId))
+    .where(
+      and(
+        inArray(devices.orgId, orgIds),
+        eq(deviceCommands.type, 'self_uninstall'),
+        inArray(deviceCommands.status, [...NON_TERMINAL_COMMAND_STATUSES])
+      )
+    );
+
+  const neverDelivered = outstanding
+    .filter((row) => row.status === 'pending')
+    .map((row) => ({ deviceId: row.deviceId, hostname: row.hostname }));
+  const deliveredUnconfirmed = outstanding
+    .filter((row) => row.status === 'sent')
+    .map((row) => ({ deviceId: row.deviceId, hostname: row.hostname }));
+
+  if (outstanding.length > 0) {
+    await db
+      .update(deviceCommands)
+      .set({
+        status: 'cancelled',
+        completedAt: new Date(),
+        result: {
+          status: 'cancelled',
+          reason: 'offboarding_window_closed',
+          error: 'Offboarding drain window closed: agent never confirmed the uninstall',
+        },
+      })
+      .where(
+        and(
+          inArray(deviceCommands.id, outstanding.map((row) => row.id)),
+          inArray(deviceCommands.status, [...NON_TERMINAL_COMMAND_STATUSES])
+        )
+      );
+  }
+
+  return { uninstallsCompleted, uninstallsFailed, neverDelivered, deliveredUnconfirmed };
+}
+
+function writeOffboardingReportAudit(report: OffboardingFinalizeReport, orgIdForAudit: string | null): void {
+  try {
+    writeAuditEvent(requestLikeFromSnapshot({}), {
+      orgId: orgIdForAudit,
+      action: `${report.scopeType}.offboarding_completed`,
+      resourceType: report.scopeType,
+      resourceId: report.scopeId,
+      actorType: 'system',
+      actorId: null,
+      result: 'success',
+      details: {
+        uninstallsCompleted: report.uninstallsCompleted,
+        uninstallsFailed: report.uninstallsFailed,
+        neverDelivered: report.neverDelivered,
+        deliveredUnconfirmed: report.deliveredUnconfirmed,
+        neverDeliveredCount: report.neverDelivered.length,
+        deliveredUnconfirmedCount: report.deliveredUnconfirmed.length,
+        forcedByDeadline: report.forcedByDeadline,
+        windowHours: report.windowHours,
+      },
+    });
+  } catch (err) {
+    console.error('[tenantOffboarding] Failed to write offboarding report audit event:', err);
+  }
+}
+
+/**
+ * Finalize an org drain: CAS the status offboarding→churned FIRST (losing the
+ * CAS means an operator aborted or forced another transition concurrently —
+ * do nothing), then cancel leftovers with the never-drained report, write the
+ * audit report, and sever agent credentials.
+ */
+export async function finalizeOrganizationOffboarding(
+  orgId: string,
+  options: { forcedByDeadline: boolean }
+): Promise<OffboardingFinalizeReport | null> {
+  const flipped = await db
+    .update(organizations)
+    .set({ status: 'churned', offboardingStartedAt: null, updatedAt: new Date() })
+    .where(and(eq(organizations.id, orgId), eq(organizations.status, 'offboarding')))
+    .returning({ id: organizations.id });
+  if (flipped.length === 0) return null;
+
+  const outcome = await collectAndCancelOutstanding([orgId]);
+  const report: OffboardingFinalizeReport = {
+    scopeType: 'organization',
+    scopeId: orgId,
+    orgIds: [orgId],
+    ...outcome,
+    forcedByDeadline: options.forcedByDeadline,
+    windowHours: OFFBOARDING_DRAIN_WINDOW_HOURS,
+  };
+  writeOffboardingReportAudit(report, orgId);
+
+  await severAgentCredentialsForOrgIds([orgId]);
+  return report;
+}
+
+export async function finalizePartnerOffboarding(
+  partnerId: string,
+  options: { forcedByDeadline: boolean }
+): Promise<OffboardingFinalizeReport | null> {
+  const flipped = await db
+    .update(partners)
+    .set({ status: 'churned', offboardingStartedAt: null, updatedAt: new Date() })
+    .where(and(eq(partners.id, partnerId), eq(partners.status, 'offboarding')))
+    .returning({ id: partners.id });
+  if (flipped.length === 0) return null;
+
+  const orgRows = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.partnerId, partnerId));
+  const orgIds = orgRows.map((row) => row.id);
+
+  const outcome = await collectAndCancelOutstanding(orgIds);
+  const report: OffboardingFinalizeReport = {
+    scopeType: 'partner',
+    scopeId: partnerId,
+    orgIds,
+    ...outcome,
+    forcedByDeadline: options.forcedByDeadline,
+    windowHours: OFFBOARDING_DRAIN_WINDOW_HOURS,
+  };
+  writeOffboardingReportAudit(report, null);
+
+  await severAgentCredentialsForOrgIds(orgIds);
+  return report;
+}
+
+/**
+ * One sweep pass, run by jobs/offboardingDrainReaper.ts under a system DB
+ * context. A tenant finalizes when its drain uninstalls are all terminal or
+ * its window (offboarding_started_at + OFFBOARDING_DRAIN_WINDOW_HOURS) has
+ * closed. A missing stamp is self-healed to `now` rather than treated as an
+ * instantly-expired window.
+ */
+export async function sweepOffboardingTenants(
+  now: Date = new Date()
+): Promise<{ orgsFinalized: number; partnersFinalized: number }> {
+  const windowMs = OFFBOARDING_DRAIN_WINDOW_HOURS * 60 * 60 * 1000;
+  let orgsFinalized = 0;
+  let partnersFinalized = 0;
+
+  const offboardingOrgs = await db
+    .select({ id: organizations.id, startedAt: organizations.offboardingStartedAt })
+    .from(organizations)
+    .where(and(eq(organizations.status, 'offboarding'), isNull(organizations.deletedAt)));
+
+  for (const org of offboardingOrgs) {
+    if (!org.startedAt) {
+      await db
+        .update(organizations)
+        .set({ offboardingStartedAt: now, updatedAt: now })
+        .where(and(eq(organizations.id, org.id), isNull(organizations.offboardingStartedAt)));
+      continue;
+    }
+    const outstanding = await countOutstandingUninstalls([org.id]);
+    const deadlinePassed = now.getTime() >= org.startedAt.getTime() + windowMs;
+    if (outstanding === 0 || deadlinePassed) {
+      const report = await finalizeOrganizationOffboarding(org.id, {
+        forcedByDeadline: outstanding > 0,
+      });
+      if (report) orgsFinalized++;
+    }
+  }
+
+  const offboardingPartners = await db
+    .select({ id: partners.id, startedAt: partners.offboardingStartedAt })
+    .from(partners)
+    .where(and(eq(partners.status, 'offboarding'), isNull(partners.deletedAt)));
+
+  for (const partner of offboardingPartners) {
+    if (!partner.startedAt) {
+      await db
+        .update(partners)
+        .set({ offboardingStartedAt: now, updatedAt: now })
+        .where(and(eq(partners.id, partner.id), isNull(partners.offboardingStartedAt)));
+      continue;
+    }
+    const orgRows = await db
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(eq(organizations.partnerId, partner.id));
+    const outstanding = await countOutstandingUninstalls(orgRows.map((row) => row.id));
+    const deadlinePassed = now.getTime() >= partner.startedAt.getTime() + windowMs;
+    if (outstanding === 0 || deadlinePassed) {
+      const report = await finalizePartnerOffboarding(partner.id, {
+        forcedByDeadline: outstanding > 0,
+      });
+      if (report) partnersFinalized++;
+    }
+  }
+
+  return { orgsFinalized, partnersFinalized };
+}

--- a/apps/api/src/services/tenantStatus.test.ts
+++ b/apps/api/src/services/tenantStatus.test.ts
@@ -32,16 +32,124 @@ vi.mock('./redis', () => ({
 
 import { db } from '../db';
 import { getRedis } from './redis';
-import { isAgentTenantActive, invalidateAgentTenantCache } from './tenantStatus';
+import { getAgentTenantState, isAgentTenantActive, invalidateAgentTenantCache } from './tenantStatus';
 
-function queueSelect(rows: unknown[]) {
+// getAgentTenantState runs a single org⋈partner join:
+// select().from().innerJoin().where().limit()
+function queueJoinedSelect(rows: unknown[]) {
   vi.mocked(db.select).mockReturnValueOnce({
-    from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue(rows) })) })),
+    from: vi.fn(() => ({
+      innerJoin: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue(rows) })),
+      })),
+    })),
   } as any);
 }
 
-const ACTIVE_ORG = { orgId: 'org-1', orgStatus: 'active', orgDeletedAt: null, partnerId: 'partner-1' };
-const ACTIVE_PARTNER = { id: 'partner-1', status: 'active', deletedAt: null };
+function tenantRow(orgStatus: string, partnerStatus: string, partnerDeletedAt: Date | null = null) {
+  return { orgStatus, partnerStatus, partnerDeletedAt };
+}
+
+describe('getAgentTenantState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getRedis).mockReturnValue({ get: redisGet, set: redisSet, del: redisDel } as any);
+    redisGet.mockResolvedValue(null);
+    redisSet.mockResolvedValue('OK');
+    redisDel.mockResolvedValue(1);
+  });
+
+  it('returns active and short-circuits the DB on a "1" cache hit', async () => {
+    redisGet.mockResolvedValueOnce('1');
+
+    expect(await getAgentTenantState('org-1')).toBe('active');
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('returns draining and short-circuits the DB on a "drain" cache hit', async () => {
+    redisGet.mockResolvedValueOnce('drain');
+
+    expect(await getAgentTenantState('org-1')).toBe('draining');
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('resolves active for an active org under an active partner and caches "1"', async () => {
+    queueJoinedSelect([tenantRow('active', 'active')]);
+
+    expect(await getAgentTenantState('org-1')).toBe('active');
+    expect(redisSet).toHaveBeenCalledWith('agent_tenant_ok:org-1', '1', 'EX', 60);
+  });
+
+  it('resolves active for a trial org under an active partner', async () => {
+    queueJoinedSelect([tenantRow('trial', 'active')]);
+
+    expect(await getAgentTenantState('org-1')).toBe('active');
+  });
+
+  it('resolves draining for an offboarding org under an active partner and caches "drain"', async () => {
+    queueJoinedSelect([tenantRow('offboarding', 'active')]);
+
+    expect(await getAgentTenantState('org-1')).toBe('draining');
+    expect(redisSet).toHaveBeenCalledWith('agent_tenant_ok:org-1', 'drain', 'EX', 60);
+  });
+
+  it('resolves draining for an active org under an offboarding partner', async () => {
+    queueJoinedSelect([tenantRow('active', 'offboarding')]);
+
+    expect(await getAgentTenantState('org-1')).toBe('draining');
+  });
+
+  it('resolves draining when both org and partner are offboarding', async () => {
+    queueJoinedSelect([tenantRow('offboarding', 'offboarding')]);
+
+    expect(await getAgentTenantState('org-1')).toBe('draining');
+  });
+
+  it('returns null (no cache write) for a suspended org', async () => {
+    queueJoinedSelect([tenantRow('suspended', 'active')]);
+
+    expect(await getAgentTenantState('org-1')).toBeNull();
+    expect(redisSet).not.toHaveBeenCalled();
+  });
+
+  it('returns null for an offboarding org under a suspended partner (abuse lockout wins)', async () => {
+    queueJoinedSelect([tenantRow('offboarding', 'suspended')]);
+
+    expect(await getAgentTenantState('org-1')).toBeNull();
+  });
+
+  it('returns null for a churned org under an offboarding partner', async () => {
+    queueJoinedSelect([tenantRow('churned', 'offboarding')]);
+
+    expect(await getAgentTenantState('org-1')).toBeNull();
+  });
+
+  it('returns null when the org is soft-deleted (filtered out by the query)', async () => {
+    queueJoinedSelect([]);
+
+    expect(await getAgentTenantState('org-1')).toBeNull();
+  });
+
+  it('returns null when the partner is soft-deleted', async () => {
+    queueJoinedSelect([tenantRow('active', 'active', new Date())]);
+
+    expect(await getAgentTenantState('org-1')).toBeNull();
+  });
+
+  it('falls through to the authoritative DB check when Redis is unavailable', async () => {
+    vi.mocked(getRedis).mockReturnValue(null);
+    queueJoinedSelect([tenantRow('active', 'active')]);
+
+    expect(await getAgentTenantState('org-1')).toBe('active');
+  });
+
+  it('fails to the DB check (never fail-open) when the cache read throws', async () => {
+    redisGet.mockRejectedValueOnce(new Error('redis down'));
+    queueJoinedSelect([tenantRow('active', 'active')]);
+
+    expect(await getAgentTenantState('org-1')).toBe('active');
+  });
+});
 
 describe('isAgentTenantActive', () => {
   beforeEach(() => {
@@ -52,56 +160,28 @@ describe('isAgentTenantActive', () => {
     redisDel.mockResolvedValue(1);
   });
 
-  it('returns true and short-circuits the DB on a cache hit', async () => {
-    redisGet.mockResolvedValueOnce('1');
+  it('returns true for a fully active tenant', async () => {
+    queueJoinedSelect([tenantRow('active', 'active')]);
 
     expect(await isAgentTenantActive('org-1')).toBe(true);
-    expect(db.select).not.toHaveBeenCalled();
   });
 
-  it('checks the DB and caches the positive result on a cache miss', async () => {
-    queueSelect([ACTIVE_ORG]);
-    queueSelect([ACTIVE_PARTNER]);
+  it('returns true for a draining tenant (mTLS renewal path must stay open mid-drain)', async () => {
+    queueJoinedSelect([tenantRow('offboarding', 'active')]);
 
     expect(await isAgentTenantActive('org-1')).toBe(true);
-    expect(db.select).toHaveBeenCalledTimes(2);
-    expect(redisSet).toHaveBeenCalledWith('agent_tenant_ok:org-1', '1', 'EX', 60);
   });
 
-  it('returns false and does NOT cache when the org is suspended', async () => {
-    queueSelect([{ ...ACTIVE_ORG, orgStatus: 'suspended' }]);
-
-    expect(await isAgentTenantActive('org-1')).toBe(false);
-    expect(redisSet).not.toHaveBeenCalled();
-  });
-
-  it('returns false when the org is soft-deleted (filtered out by the query)', async () => {
-    queueSelect([]);
+  it('returns false when the org is suspended', async () => {
+    queueJoinedSelect([tenantRow('suspended', 'active')]);
 
     expect(await isAgentTenantActive('org-1')).toBe(false);
   });
 
-  it('returns false when the partner is not active', async () => {
-    queueSelect([ACTIVE_ORG]);
-    queueSelect([{ ...ACTIVE_PARTNER, status: 'churned' }]);
+  it('returns false when the partner is churned', async () => {
+    queueJoinedSelect([tenantRow('active', 'churned')]);
 
     expect(await isAgentTenantActive('org-1')).toBe(false);
-  });
-
-  it('falls through to the authoritative DB check when Redis is unavailable', async () => {
-    vi.mocked(getRedis).mockReturnValue(null);
-    queueSelect([ACTIVE_ORG]);
-    queueSelect([ACTIVE_PARTNER]);
-
-    expect(await isAgentTenantActive('org-1')).toBe(true);
-  });
-
-  it('fails to the DB check (never fail-open) when the cache read throws', async () => {
-    redisGet.mockRejectedValueOnce(new Error('redis down'));
-    queueSelect([ACTIVE_ORG]);
-    queueSelect([ACTIVE_PARTNER]);
-
-    expect(await isAgentTenantActive('org-1')).toBe(true);
   });
 });
 

--- a/apps/api/src/services/tenantStatus.ts
+++ b/apps/api/src/services/tenantStatus.ts
@@ -180,31 +180,92 @@ export async function assertActiveTenantContext(
 // the source of truth, never fail open.
 const AGENT_TENANT_OK_CACHE_PREFIX = 'agent_tenant_ok:';
 const AGENT_TENANT_OK_CACHE_SECONDS = 60;
+// Cache values: '1' = fully active, 'drain' = offboarding drain mode.
+const AGENT_TENANT_CACHE_ACTIVE = '1';
+const AGENT_TENANT_CACHE_DRAINING = 'drain';
 
-export async function isAgentTenantActive(orgId: string): Promise<boolean> {
+/**
+ * Agent-facing tenant state (#2774):
+ * - 'active'   — org active/trial under an active partner: full agent surface.
+ * - 'draining' — org and/or partner is `offboarding`: the agent may still
+ *   authenticate, but only on the narrowed drain surface (heartbeat, command
+ *   poll/result filtered to self_uninstall, token rotation, log ship) so a
+ *   queued self_uninstall is deliverable while users are already locked out.
+ * - null       — everything else (suspended/churned/pending/soft-deleted):
+ *   agents fail closed exactly as before.
+ *
+ * This is deliberately a SEPARATE predicate from getActiveOrgTenant: the
+ * user/API-key/OAuth gates must keep rejecting `offboarding` — only the agent
+ * delivery path is allowed to see the drain window.
+ */
+export type AgentTenantState = 'active' | 'draining';
+
+export async function getAgentTenantState(orgId: string): Promise<AgentTenantState | null> {
   const cacheKey = `${AGENT_TENANT_OK_CACHE_PREFIX}${orgId}`;
   const redis = getRedis();
 
   if (redis) {
     try {
-      if ((await redis.get(cacheKey)) === '1') return true;
+      const cached = await redis.get(cacheKey);
+      if (cached === AGENT_TENANT_CACHE_ACTIVE) return 'active';
+      if (cached === AGENT_TENANT_CACHE_DRAINING) return 'draining';
     } catch {
       // Cache read failed — fall through to the authoritative DB check.
     }
   }
 
-  const tenant = await getActiveOrgTenant(orgId);
-  if (!tenant) return false;
+  const state = await readAsSystem(async (): Promise<AgentTenantState | null> => {
+    const [row] = await db
+      .select({
+        orgStatus: organizations.status,
+        partnerStatus: partners.status,
+        partnerDeletedAt: partners.deletedAt,
+      })
+      .from(organizations)
+      .innerJoin(partners, eq(partners.id, organizations.partnerId))
+      .where(and(eq(organizations.id, orgId), isNull(organizations.deletedAt)))
+      .limit(1);
 
-  if (redis) {
+    if (!row || row.partnerDeletedAt) return null;
+
+    const orgUsable = isUsableOrgStatus(row.orgStatus);
+    if (orgUsable && row.partnerStatus === 'active') return 'active';
+
+    const orgDraining =
+      row.orgStatus === 'offboarding'
+      && (row.partnerStatus === 'active' || row.partnerStatus === 'offboarding');
+    const partnerDraining = row.partnerStatus === 'offboarding' && orgUsable;
+    if (orgDraining || partnerDraining) return 'draining';
+
+    return null;
+  });
+
+  if (state && redis) {
     try {
-      await redis.set(cacheKey, '1', 'EX', AGENT_TENANT_OK_CACHE_SECONDS);
+      await redis.set(
+        cacheKey,
+        state === 'active' ? AGENT_TENANT_CACHE_ACTIVE : AGENT_TENANT_CACHE_DRAINING,
+        'EX',
+        AGENT_TENANT_OK_CACHE_SECONDS
+      );
     } catch {
       // Best-effort cache write; correctness does not depend on it.
     }
   }
 
-  return true;
+  return state;
+}
+
+/**
+ * True when the agent may authenticate AT ALL — i.e. 'active' OR 'draining'.
+ * Callers that must distinguish full capability from the narrowed drain
+ * surface (agentAuth route allowlist, agentWs upgrade refusal) use
+ * getAgentTenantState directly; boolean callers where drain-mode access is
+ * intended (mTLS cert renewal — an agent quarantined mid-drain could never
+ * collect its uninstall) keep this wrapper.
+ */
+export async function isAgentTenantActive(orgId: string): Promise<boolean> {
+  return (await getAgentTenantState(orgId)) !== null;
 }
 
 /**

--- a/apps/web/src/components/settings/OrganizationForm.tsx
+++ b/apps/web/src/components/settings/OrganizationForm.tsx
@@ -23,7 +23,7 @@ const createOrganizationSchema = (t: (key: string) => string) => z
       .min(2, t('organizationForm.validation.slugRequired'))
       .regex(/^[a-z0-9-]+$/, t('organizationForm.validation.slugFormat')),
     type: z.enum(['customer', 'internal']),
-    status: z.enum(['active', 'trial', 'suspended', 'churned']),
+    status: z.enum(['active', 'trial', 'suspended', 'churned', 'offboarding']),
     maxDevices: z.coerce
       .number({ error: t('organizationForm.validation.maxDevicesRequired') })
       .int(t('organizationForm.validation.maxDevicesInteger'))
@@ -64,7 +64,10 @@ const statusOptions = [
   { value: 'active', labelKey: 'organizationForm.status.active' },
   { value: 'trial', labelKey: 'organizationForm.status.trial' },
   { value: 'suspended', labelKey: 'organizationForm.status.suspended' },
-  { value: 'churned', labelKey: 'organizationForm.status.churned' }
+  { value: 'churned', labelKey: 'organizationForm.status.churned' },
+  // #2774 — terminal drain: users out immediately, agents kept alive just
+  // long enough to collect self_uninstall, then auto-churned.
+  { value: 'offboarding', labelKey: 'organizationForm.status.offboarding' }
 ];
 
 export default function OrganizationForm({

--- a/apps/web/src/components/settings/OrganizationList.tsx
+++ b/apps/web/src/components/settings/OrganizationList.tsx
@@ -6,7 +6,7 @@ import { ResponsiveTable, DataCard, CardField, CardActions } from '../shared/Res
 export type Organization = {
   id: string;
   name: string;
-  status: 'active' | 'trial' | 'suspended' | 'churned';
+  status: 'active' | 'trial' | 'suspended' | 'churned' | 'offboarding';
   deviceCount: number;
   createdAt: string;
 };
@@ -23,6 +23,7 @@ const STATUS_LABEL_KEYS: Record<Organization['status'], string> = {
   trial: 'organizationList.status.trial',
   suspended: 'organizationList.status.suspended',
   churned: 'organizationList.status.churned',
+  offboarding: 'organizationList.status.offboarding',
 };
 
 export default function OrganizationList({

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -18,7 +18,7 @@ type OrganizationFormValues = {
   name: string;
   slug: string;
   type: 'customer' | 'internal';
-  status: 'active' | 'trial' | 'suspended' | 'churned';
+  status: 'active' | 'trial' | 'suspended' | 'churned' | 'offboarding';
   maxDevices: number;
   contractStart?: string;
   contractEnd?: string;
@@ -29,6 +29,7 @@ const statusLabelKeys: Record<Organization['status'], string> = {
   trial: 'organizationsPage.status.trial',
   suspended: 'organizationsPage.status.suspended',
   churned: 'organizationsPage.status.churned',
+  offboarding: 'organizationsPage.status.offboarding',
 };
 
 const statusColors: Record<Organization['status'], string> = {
@@ -36,6 +37,7 @@ const statusColors: Record<Organization['status'], string> = {
   trial: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-400',
   suspended: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
   churned: 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400',
+  offboarding: 'border-orange-500/30 bg-orange-500/10 text-orange-700 dark:text-orange-400',
 };
 
 export default function OrganizationsPage() {

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -2717,7 +2717,7 @@
       "trial": "Prozess",
       "suspended": "Suspendiert",
       "churned": "Aufgewühlt",
-      "offboarding": "Offboarding"
+      "offboarding": "Abmeldung läuft"
     }
   },
   "organizationList": {
@@ -2730,7 +2730,7 @@
       "trial": "Prozess",
       "suspended": "Suspendiert",
       "churned": "Aufgewühlt",
-      "offboarding": "Offboarding"
+      "offboarding": "Abmeldung läuft"
     },
     "columns": {
       "devices": "Geräte"
@@ -2762,7 +2762,7 @@
       "trial": "Prozess",
       "suspended": "Suspendiert",
       "churned": "Aufgewühlt",
-      "offboarding": "Offboarding"
+      "offboarding": "Abmeldung läuft"
     },
     "deviceCount": "{{count}} Geräte",
     "list": {

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -2716,7 +2716,8 @@
       "active": "Aktiv",
       "trial": "Prozess",
       "suspended": "Suspendiert",
-      "churned": "Aufgewühlt"
+      "churned": "Aufgewühlt",
+      "offboarding": "Offboarding"
     }
   },
   "organizationList": {
@@ -2728,7 +2729,8 @@
       "active": "Aktiv",
       "trial": "Prozess",
       "suspended": "Suspendiert",
-      "churned": "Aufgewühlt"
+      "churned": "Aufgewühlt",
+      "offboarding": "Offboarding"
     },
     "columns": {
       "devices": "Geräte"
@@ -2759,7 +2761,8 @@
       "active": "Aktiv",
       "trial": "Prozess",
       "suspended": "Suspendiert",
-      "churned": "Aufgewühlt"
+      "churned": "Aufgewühlt",
+      "offboarding": "Offboarding"
     },
     "deviceCount": "{{count}} Geräte",
     "list": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -2769,7 +2769,8 @@
       "active": "Active",
       "trial": "Trial",
       "suspended": "Suspended",
-      "churned": "Churned"
+      "churned": "Churned",
+      "offboarding": "Offboarding"
     }
   },
   "organizationList": {
@@ -2781,7 +2782,8 @@
       "active": "Active",
       "trial": "Trial",
       "suspended": "Suspended",
-      "churned": "Churned"
+      "churned": "Churned",
+      "offboarding": "Offboarding"
     },
     "columns": {
       "devices": "Devices"
@@ -2812,7 +2814,8 @@
       "active": "Active",
       "trial": "Trial",
       "suspended": "Suspended",
-      "churned": "Churned"
+      "churned": "Churned",
+      "offboarding": "Offboarding"
     },
     "deviceCount": "{{count}} devices",
     "list": {

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -2716,7 +2716,8 @@
       "active": "Activo",
       "trial": "Prueba",
       "suspended": "Suspendido",
-      "churned": "Dado de baja"
+      "churned": "Dado de baja",
+      "offboarding": "En proceso de baja"
     }
   },
   "organizationList": {
@@ -2728,7 +2729,8 @@
       "active": "Activo",
       "trial": "Prueba",
       "suspended": "Suspendido",
-      "churned": "Dado de baja"
+      "churned": "Dado de baja",
+      "offboarding": "En proceso de baja"
     },
     "columns": {
       "devices": "Dispositivos"
@@ -2759,7 +2761,8 @@
       "active": "Activo",
       "trial": "Prueba",
       "suspended": "Suspendido",
-      "churned": "Dado de baja"
+      "churned": "Dado de baja",
+      "offboarding": "En proceso de baja"
     },
     "deviceCount": "dispositivos {{count}}",
     "list": {

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -2764,7 +2764,8 @@
       "active": "Active",
       "trial": "Procès",
       "suspended": "Suspendu",
-      "churned": "Tourné"
+      "churned": "Tourné",
+      "offboarding": "Départ en cours"
     }
   },
   "organizationList": {
@@ -2776,7 +2777,8 @@
       "active": "Active",
       "trial": "Procès",
       "suspended": "Suspendu",
-      "churned": "Tourné"
+      "churned": "Tourné",
+      "offboarding": "Départ en cours"
     },
     "columns": {
       "devices": "Appareils"
@@ -2807,7 +2809,8 @@
       "active": "Active",
       "trial": "Procès",
       "suspended": "Suspendu",
-      "churned": "Tourné"
+      "churned": "Tourné",
+      "offboarding": "Départ en cours"
     },
     "deviceCount": "{{count}} appareils",
     "list": {

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -2716,7 +2716,8 @@
       "active": "Active",
       "trial": "Procès",
       "suspended": "Suspendu",
-      "churned": "Tourné"
+      "churned": "Tourné",
+      "offboarding": "Départ en cours"
     }
   },
   "organizationList": {
@@ -2728,7 +2729,8 @@
       "active": "Active",
       "trial": "Procès",
       "suspended": "Suspendu",
-      "churned": "Tourné"
+      "churned": "Tourné",
+      "offboarding": "Départ en cours"
     },
     "columns": {
       "devices": "Dispositifs"
@@ -2759,7 +2761,8 @@
       "active": "Active",
       "trial": "Procès",
       "suspended": "Suspendu",
-      "churned": "Tourné"
+      "churned": "Tourné",
+      "offboarding": "Départ en cours"
     },
     "deviceCount": "{{count}} dispositifs",
     "list": {

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -2764,7 +2764,8 @@
       "active": "Attiva",
       "trial": "Trial",
       "suspended": "Sospesa",
-      "churned": "Persa"
+      "churned": "Persa",
+      "offboarding": "In dismissione"
     }
   },
   "organizationList": {
@@ -2776,7 +2777,8 @@
       "active": "Attiva",
       "trial": "Prova",
       "suspended": "Sospesa",
-      "churned": "Persa"
+      "churned": "Persa",
+      "offboarding": "In dismissione"
     },
     "columns": {
       "devices": "Dispositivi"
@@ -2807,7 +2809,8 @@
       "active": "Attiva",
       "trial": "Prova",
       "suspended": "Sospesa",
-      "churned": "Persa"
+      "churned": "Persa",
+      "offboarding": "In dismissione"
     },
     "deviceCount": "{{count}} dispositivi",
     "list": {

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -2769,7 +2769,8 @@
       "active": "Ativo",
       "trial": "Avaliação",
       "suspended": "Suspenso",
-      "churned": "Cancelado"
+      "churned": "Cancelado",
+      "offboarding": "Em desligamento"
     }
   },
   "organizationList": {
@@ -2781,7 +2782,8 @@
       "active": "Ativo",
       "trial": "Avaliação",
       "suspended": "Suspenso",
-      "churned": "Cancelado"
+      "churned": "Cancelado",
+      "offboarding": "Em desligamento"
     },
     "columns": {
       "devices": "Dispositivos"
@@ -2812,7 +2814,8 @@
       "active": "Ativo",
       "trial": "Avaliação",
       "suspended": "Suspenso",
-      "churned": "Cancelado"
+      "churned": "Cancelado",
+      "offboarding": "Em desligamento"
     },
     "deviceCount": "Dispositivos {{count}}",
     "list": {

--- a/docs/superpowers/plans/tenancy-rls/2026-07-24-offboarding-drain-state.md
+++ b/docs/superpowers/plans/tenancy-rls/2026-07-24-offboarding-drain-state.md
@@ -63,6 +63,16 @@ finish:
 uninstalled stay gone — abort is best-effort, documented as such. Forcing
 `suspended`/`churned` mid-drain takes the existing immediate-sever path.
 
+Abort keys on the *own-axis* stamp. Reactivating one org under a still-offboarding partner
+is therefore a no-op: that org is still `draining` via the partner axis, so its uninstalls
+stay deliverable. Aborting a partner-level drain means reactivating the partner.
+
+**Entry repair.** The route commits the status before running the drain work, so a failure
+in between would leave a tenant with no queued uninstalls whose next sweep would finalize
+instantly on a zero-outstanding count — an empty report indistinguishable from a clean
+drain. The sweep detects the missing stamp, completes the entry (queue + narrow), audits
+`*.offboarding_entry_repaired`, and only then lets the window run.
+
 **Stale-reaper exemption:** `staleCommandReaper` skips `self_uninstall` rows whose device's
 org (or org's partner) is currently `offboarding`. Deliberately **not** a blanket
 `self_uninstall` exemption: abuse-queued uninstalls must keep expiring, otherwise an abuse

--- a/docs/superpowers/plans/tenancy-rls/2026-07-24-offboarding-drain-state.md
+++ b/docs/superpowers/plans/tenancy-rls/2026-07-24-offboarding-drain-state.md
@@ -1,0 +1,98 @@
+# Offboarding drain state — deliverable `self_uninstall` for churning tenants (#2774)
+
+**Status:** implemented alongside this doc.
+**Issue:** #2774 — 78 of 80 remote uninstalls all-time expired undelivered because tenant
+offboarding severs the agent auth channel before the command can be collected.
+
+## Problem
+
+Two independent gates lock an agent out the instant a tenant is offboarded:
+
+1. `devices.agent_token_suspended_at` — set by `severAgentCredentialsForOrgIds`
+   (`services/tenantLifecycle.ts`).
+2. `isAgentTenantActive(orgId)` → org status ∈ {`active`,`trial`} AND partner strictly
+   `active` (`services/tenantStatus.ts`), checked in `agentAuth.ts`, `agentWs.ts`, `mtls.ts`.
+
+Any `self_uninstall` queued after either gate closes sits `pending` until the stale-command
+reaper fails it 30 minutes later ("Command expired: agent never received the command").
+Nothing surfaces the failure; operators believe the fleet was cleaned.
+
+## Design
+
+A terminal-intent drain state, `offboarding`, on **both** the org and partner status enums.
+
+### Semantics
+
+| Surface | During `offboarding` |
+|---|---|
+| User sessions / JWT | rejected (all user gates are explicit allowlists that don't include the new value) — plus proactive revocation on entry |
+| API keys / OAuth / partner API | rejected (same allowlist property) + revoked on entry |
+| Agent REST auth | **allowed, narrowed** — route allowlist only (see below) |
+| Agent WS upgrade | **refused** — ~20 call sites push desktop/terminal/tunnel/software commands over WS without `device_commands` rows; refusing the socket closes that whole class. Agents fall back to heartbeat polling (60s) |
+| Command claim (heartbeat piggyback + poll) | filtered to `type = 'self_uninstall'` only |
+| Enrollment | rejected (`getActiveOrgTenant` unchanged) + enrollment keys expired on entry |
+| mTLS cert renewal | allowed (auth maintenance, like token rotation — an agent quarantined mid-drain could never collect its uninstall) |
+
+**Drain-mode route allowlist** (everything else 403 `tenant_offboarding`):
+heartbeat (command carrier + liveness), commands poll, command result, token
+rotate/confirm (blocking rotation mid-stage could strand the credential), logs ship
+(post-mortem evidence for never-drained devices).
+
+### Transitions
+
+**Entry** (`PATCH` org/partner status → `offboarding`, MFA-gated routes as today):
+1. Set status + `offboarding_started_at = now()`.
+2. Revoke users, sessions, API keys, OAuth artifacts (exactly the existing revocation
+   minus `severAgentCredentialsForOrgIds`), expire enrollment keys.
+3. Cancel all other pending/sent commands, then queue `self_uninstall`
+   (`{removeConfig: true}`) to every non-decommissioned device — the abuse-route shape.
+4. Invalidate the agent tenant cache so the 60s positive cache re-reads the new state.
+
+**Drain sweep** (`jobs/offboardingDrainReaper.ts`, BullMQ repeatable, 5 min): an org/partner
+finishes when its offboarding `self_uninstall` commands are all terminal **or**
+`offboarding_started_at + OFFBOARDING_DRAIN_WINDOW_HOURS` (default 72) has passed. On
+finish:
+1. Cancel remaining pending uninstalls with an explicit result
+   (`offboarding window closed: agent never received the command`).
+2. Write the **never-drained report**: audit log `org.offboarding_completed` /
+   `partner.offboarding_completed` with drained/stranded counts and the stranded device list.
+3. `severAgentCredentialsForOrgIds` (now exported) and flip status → `churned`.
+
+**Abort** (status `offboarding` → `active`/`trial`): cancel pending uninstalls, clear
+`offboarding_started_at`, restore agent credentials, invalidate cache. Devices that already
+uninstalled stay gone — abort is best-effort, documented as such. Forcing
+`suspended`/`churned` mid-drain takes the existing immediate-sever path.
+
+**Stale-reaper exemption:** `staleCommandReaper` skips `self_uninstall` rows whose device's
+org (or org's partner) is currently `offboarding`. Deliberately **not** a blanket
+`self_uninstall` exemption: abuse-queued uninstalls must keep expiring, otherwise an abuse
+suspension reversed days later would deliver stale uninstalls to a reinstated fleet.
+
+### What deliberately does NOT change
+
+- **Abuse suspension** (`/admin/partners/:id/suspend-for-abuse`) keeps immediate lockout.
+  A drain window there would leave an abuser's command channel open on victim endpoints.
+- `isUsableOrgStatus`, `getActivePartner`, `getSessionAllowedPartner`, `partnerGuard`,
+  `partnerApiAuth`, password-reset eligibility: untouched — `offboarding` is denied by
+  every user-facing gate by construction.
+- The AI org-update tool cannot set `offboarding` (kept out of its schema): initiating an
+  irreversible fleet uninstall stays a human, MFA-gated action.
+- Go agent: no changes. Heartbeat keeps working during drain; the existing
+  `self_uninstall` handler acks then tears down.
+
+### Gate implementation
+
+`getAgentTenantState(orgId): 'active' | 'draining' | null` replaces the boolean internals of
+`isAgentTenantActive` (which remains as a truthy wrapper for mtls). Draining when:
+org `offboarding` + partner ∈ {`active`,`offboarding`}, or org ∈ {`active`,`trial`} +
+partner `offboarding`. Cache keeps the same key/TTL with value `'1'` | `'drain'`;
+negatives still never cached.
+
+### Known limits (from the issue, still true)
+
+- A drain window only rescues devices that come online during it. Machines offline for the
+  whole window land in the never-drained report — that report is the product, not polish.
+- Portal sessions don't check org/partner status at all today (pre-existing gap, applies
+  to `churned` equally); out of scope here.
+- The `DELETE /devices/:id/permanent` WS-only best-effort uninstall path is unchanged
+  (separate issue territory).

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -11,7 +11,9 @@ export * from './auth';
 export type PartnerType = 'msp' | 'enterprise' | 'internal';
 export type PlanType = 'free' | 'pro' | 'enterprise' | 'unlimited';
 export type OrgType = 'customer' | 'internal';
-export type OrgStatus = 'active' | 'suspended' | 'trial' | 'churned';
+// `offboarding` (#2774): terminal-intent drain state — users locked out, agents
+// kept authenticated (self_uninstall-only) until drained, then auto-`churned`.
+export type OrgStatus = 'active' | 'suspended' | 'trial' | 'churned' | 'offboarding';
 export type SupportedLocale = 'en' | 'pt-BR' | 'es-419' | 'fr-FR' | 'fr-CA' | 'de-DE' | 'it-IT';
 
 export interface Partner {


### PR DESCRIPTION
Closes #2774

## Problem

Tenant offboarding severed the agent auth channel *before* `self_uninstall` could be collected. Two independent gates (`agent_token_suspended_at` and `isAgentTenantActive`'s `active|trial`-only allowlist) meant any uninstall queued after churn sat `pending` until the 30-minute stale-command timeout failed it silently. US prod all-time: **78 of 80 uninstalls never reached an endpoint** (~9% real success), leaving ex-customers' machines 401-polling forever.

## Design (doc: `docs/superpowers/plans/tenancy-rls/2026-07-24-offboarding-drain-state.md`)

A terminal-intent `offboarding` status on **both** the org and partner enums — users out immediately, agents kept authenticated just long enough to drain:

| Surface | During `offboarding` |
|---|---|
| Sessions / API keys / OAuth / partner API | rejected by existing allowlist gates + proactively revoked on entry |
| Agent REST | allowed, narrowed to heartbeat, command poll/result, token rotate/confirm, log ship — everything else `403 tenant_offboarding` |
| Command claim (heartbeat + poll) | filtered to `self_uninstall` only |
| Agent WS upgrade | refused — ~20 push call sites (terminal/desktop/tunnel/software) bypass `device_commands`, so any socket is a full control channel |
| Enrollment | rejected; enrollment keys expired on entry |
| mTLS cert renewal | allowed (auth maintenance — a mid-drain quarantine would strand the uninstall) |

**Entry** (MFA-gated PATCH): revoke users/keys/OAuth, expire enrollment keys, sever live WS, cancel other pending commands, queue deduped `self_uninstall` to every non-decommissioned device.

**Drain reaper** (new BullMQ repeatable, 5 min): finalizes when all uninstalls are terminal or `OFFBOARDING_DRAIN_WINDOW_HOURS` (default 72) closes — CAS-flips to `churned`, cancels leftovers with an explicit result, writes the **never-drained report** (`organization/partner.offboarding_completed` audit event with per-device `neverDelivered` / `deliveredUnconfirmed` lists), then runs the existing sever.

**Abort** (back to active/trial, forced suspend/churn, delete): cancels in-flight drain uninstalls so an uncollected `self_uninstall` can never fire into a reactivated fleet. Keyed on the `offboarding_started_at` stamp — a no-op for tenants that were never draining, so abuse-queued uninstalls are untouched.

## What deliberately does NOT change

- **Abuse suspension** keeps immediate severing — a drain window there would leave an abuser's command channel open on victim endpoints.
- The stale-reaper exemption is **scoped to offboarding tenants**, not a blanket `self_uninstall` exemption: abuse-queued uninstalls must keep expiring, or a reversed abuse suspension days later would deliver stale uninstalls to a reinstated fleet.
- The AI org-update tool cannot set `offboarding` — entering an irreversible fleet-wide uninstall stays a human, MFA-gated action.
- Go agent: zero changes (heartbeat keeps working in drain; existing uninstall handler acks then tears down; no destructive 403 handling — verified).

## Known limit (from the issue)

A drain window only rescues devices that come online during it. Devices offline the whole window land in the never-drained report instead of silently expiring — the report is the point.

## Verification

- `tsc --noEmit` clean on `apps/api`, `apps/web`, `packages/shared`.
- Affected suites single-fork green: tenantStatus (23), tenantLifecycle (10), tenantOffboarding (16, new), commandDispatch (4), agentAuth (39), staleCommandReaper (19), agentWs, heartbeat, agents, orgs (168), commands, aiToolsOrgs, autoMigrate, web i18n key parity (16).
- Migration applied to a real Postgres inside a transaction and re-applied as a no-op (idempotency verified); no new tables → no RLS/cascade registration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)