### PR TITLE
fix(api): root-cause four production Sentry issues — BREEZE-10, BREEZE-3/W, BREEZE-9, BREEZE-B

### DIFF
--- a/apps/api/migrations/2026-08-05-metric-rollup-partition-maintenance-privileges.sql
+++ b/apps/api/migrations/2026-08-05-metric-rollup-partition-maintenance-privileges.sql
@@ -1,0 +1,206 @@
+-- Metric-rollup partition maintenance could never work at runtime (BREEZE-10).
+--
+-- ensureMetricRollupPartitions()/dropExpiredMetricRollupPartitions() issue pure
+-- DDL — CREATE TABLE ... PARTITION OF, ALTER TABLE ... FORCE RLS, CREATE POLICY,
+-- GRANT, DROP TABLE — but the API connects as the unprivileged `breeze_app`,
+-- which has no CREATE on schema public and does not own metric_rollups. The
+-- daily job therefore aborted on its first statement with
+--   42501 permission denied for schema public
+-- and never reached dropExpiredMetricRollupPartitions() or pruneMetricRollups(),
+-- so metric_rollups retention has not run at all in production. Postgres
+-- ACL-checks the schema BEFORE the IF NOT EXISTS short-circuit, so the failure
+-- fires even for a month whose partition already exists — which is why the
+-- symptom was a permanent daily abort rather than a missing-partition error.
+--
+-- Granting breeze_app CREATE on public would not fix it and is not wanted:
+-- `CREATE TABLE ... PARTITION OF metric_rollups` requires ownership of the
+-- PARENT, and ENABLE/FORCE ROW LEVEL SECURITY requires ownership of the child.
+-- Instead, relocate the DDL into SECURITY DEFINER functions owned by the
+-- migration role (which owns metric_rollups), and let breeze_app call those.
+--
+-- Both functions take a month TIMESTAMP, never an identifier: they derive the
+-- partition name internally and verify attachment to metric_rollups before
+-- touching anything. A SECURITY DEFINER function that accepted a caller-supplied
+-- table name would be a privilege-escalation primitive (drop/alter any table as
+-- the owner) — deriving the name is what keeps that impossible.
+--
+-- No breeze.scope elevation is involved: these do DDL only, never row access,
+-- so there is no custom-GUC function attribute here (that form needs superuser
+-- and crash-looped EU in v0.97.0 — see migrationGucAttributes.test.ts).
+--
+-- Idempotent throughout. autoMigrate wraps this file in a transaction.
+
+-- ---------------------------------------------------------------------------
+-- Ensure one monthly partition exists, fully converged (RLS + policies + grant).
+-- Returns the partition name, or NULL when the month was skipped because
+-- metric_rollups_default already holds rows for it (the attach would fail the
+-- default partition's updated constraint). Callers treat NULL as "skipped".
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.breeze_ensure_metric_rollup_partition(
+  p_month_start TIMESTAMP
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+-- Pinned search_path: a SECURITY DEFINER function without this can be hijacked
+-- by a caller-controlled search_path.
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_start TIMESTAMP;
+  v_end   TIMESTAMP;
+  v_name  TEXT;
+BEGIN
+  IF p_month_start IS NULL THEN
+    RAISE EXCEPTION 'breeze_ensure_metric_rollup_partition: p_month_start must not be NULL';
+  END IF;
+
+  -- Normalize to the month boundary so the derived name and the range can never
+  -- disagree, whatever instant the caller passes.
+  v_start := date_trunc('month', p_month_start);
+  v_end   := v_start + INTERVAL '1 month';
+  v_name  := format(
+    'metric_rollups_y%sm%s',
+    to_char(v_start, 'YYYY'),
+    to_char(v_start, 'MM')
+  );
+
+  BEGIN
+    EXECUTE format(
+      'CREATE TABLE IF NOT EXISTS public.%I PARTITION OF public.metric_rollups FOR VALUES FROM (%L) TO (%L)',
+      v_name,
+      v_start,
+      v_end
+    );
+  EXCEPTION WHEN check_violation THEN
+    IF SQLERRM LIKE '%updated partition constraint for default partition%'
+      AND SQLERRM LIKE '%would be violated by some row%' THEN
+      RAISE WARNING
+        'Skipping %, metric_rollups_default already contains rows for [% - %)',
+        v_name,
+        v_start,
+        v_end;
+      RETURN NULL;
+    END IF;
+    RAISE;
+  END;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_inherits
+    JOIN pg_class child ON child.oid = pg_inherits.inhrelid
+    JOIN pg_class parent ON parent.oid = pg_inherits.inhparent
+    JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace
+    JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
+    WHERE child.relname = v_name
+      AND child_ns.nspname = 'public'
+      AND parent.relname = 'metric_rollups'
+      AND parent_ns.nspname = 'public'
+  ) THEN
+    RAISE EXCEPTION '% exists but is not attached as a metric_rollups partition', v_name;
+  END IF;
+
+  -- PARTITION OF inherits parent checks and partitioned indexes. RLS policies
+  -- and grants are relation-local, so converge them here for each child.
+  EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', v_name);
+  EXECUTE format('ALTER TABLE public.%I FORCE ROW LEVEL SECURITY', v_name);
+  EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_select ON public.%I', v_name);
+  EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_insert ON public.%I', v_name);
+  EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_update ON public.%I', v_name);
+  EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_delete ON public.%I', v_name);
+
+  EXECUTE format(
+    'CREATE POLICY breeze_org_isolation_select ON public.%I FOR SELECT USING (public.breeze_has_org_access(org_id))',
+    v_name
+  );
+  EXECUTE format(
+    'CREATE POLICY breeze_org_isolation_insert ON public.%I FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id))',
+    v_name
+  );
+  EXECUTE format(
+    'CREATE POLICY breeze_org_isolation_update ON public.%I FOR UPDATE USING (public.breeze_has_org_access(org_id)) WITH CHECK (public.breeze_has_org_access(org_id))',
+    v_name
+  );
+  EXECUTE format(
+    'CREATE POLICY breeze_org_isolation_delete ON public.%I FOR DELETE USING (public.breeze_has_org_access(org_id))',
+    v_name
+  );
+
+  EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.%I TO breeze_app', v_name);
+
+  RETURN v_name;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Drop one expired monthly partition. Takes the month, not a name, and refuses
+-- anything that is not currently attached to metric_rollups — so it can never
+-- be aimed at metric_rollups_default (whose name no month can produce) or at
+-- an unrelated table. Returns the dropped name, or NULL when there was nothing
+-- attached for that month.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.breeze_drop_metric_rollup_partition(
+  p_month_start TIMESTAMP
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_start TIMESTAMP;
+  v_name  TEXT;
+BEGIN
+  IF p_month_start IS NULL THEN
+    RAISE EXCEPTION 'breeze_drop_metric_rollup_partition: p_month_start must not be NULL';
+  END IF;
+
+  v_start := date_trunc('month', p_month_start);
+  v_name  := format(
+    'metric_rollups_y%sm%s',
+    to_char(v_start, 'YYYY'),
+    to_char(v_start, 'MM')
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_inherits
+    JOIN pg_class child ON child.oid = pg_inherits.inhrelid
+    JOIN pg_class parent ON parent.oid = pg_inherits.inhparent
+    JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace
+    JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
+    WHERE child.relname = v_name
+      AND child_ns.nspname = 'public'
+      AND parent.relname = 'metric_rollups'
+      AND parent_ns.nspname = 'public'
+  ) THEN
+    RETURN NULL;
+  END IF;
+
+  EXECUTE format('DROP TABLE IF EXISTS public.%I', v_name);
+  RETURN v_name;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.breeze_ensure_metric_rollup_partition(TIMESTAMP) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.breeze_drop_metric_rollup_partition(TIMESTAMP) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.breeze_ensure_metric_rollup_partition(TIMESTAMP) TO breeze_app;
+GRANT EXECUTE ON FUNCTION public.breeze_drop_metric_rollup_partition(TIMESTAMP) TO breeze_app;
+
+-- ---------------------------------------------------------------------------
+-- Converge the current partition window now rather than waiting for the 03:15
+-- job. The runtime defaults are monthsBack=0/monthsAhead=3; the bootstrap in
+-- 2026-06-18-n only ran once at install time, so every DB that has been up
+-- since then is missing the months that the (broken) worker should have added.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  anchor_month TIMESTAMP := date_trunc('month', now() AT TIME ZONE 'UTC');
+  offset_months INTEGER;
+BEGIN
+  FOR offset_months IN 0..3 LOOP
+    PERFORM public.breeze_ensure_metric_rollup_partition(
+      anchor_month + make_interval(months => offset_months)
+    );
+  END LOOP;
+END $$;

--- a/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
@@ -13,10 +13,27 @@
  */
 import './setup';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// db/index.ts imports `captureMessage` as a bound ESM named import, so
+// vi.spyOn on the module object does not intercept it. Mock the module so the
+// held-context capture is observable. Only the attribution test asserts on it;
+// every other test here observes console.warn, which is untouched.
+const capturedMessages: Array<{ message: string; extra?: Record<string, unknown> }> = [];
+vi.mock('../../services/sentry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/sentry')>();
+  return {
+    ...actual,
+    captureMessage: (message: string, _level?: unknown, extra?: Record<string, unknown>) => {
+      capturedMessages.push({ message, extra });
+    },
+  };
+});
+
 import {
   withSystemDbAccessContext,
   runOutsideDbContext,
   assertOutsideHeldDbContext,
+  __resetHeldContextCaptureThrottleForTests,
 } from '../../db';
 
 const HELD = 'held a pooled connection';
@@ -30,12 +47,15 @@ describe('#1105 DB-context tripwires', () => {
 
   beforeEach(() => {
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    capturedMessages.length = 0;
   });
 
   afterEach(() => {
     warnSpy.mockRestore();
     delete process.env.DB_CONTEXT_TRIPWIRE_STRICT;
     delete process.env.DB_CONTEXT_HELD_WARN_MS;
+    delete process.env.DB_CONTEXT_HELD_CAPTURE_THROTTLE_MS;
+    __resetHeldContextCaptureThrottleForTests();
   });
 
   describe('assertOutsideHeldDbContext', () => {
@@ -93,6 +113,37 @@ describe('#1105 DB-context tripwires', () => {
       expect(hits).toHaveLength(1);
       expect(String(hits[0]![0])).toContain('#1105');
       expect(String(hits[0]![0])).toContain('scope=system');
+    });
+
+    it('attributes the hold to the OPENER, not to the emitter (BREEZE-9 triage fix)', async () => {
+      process.env.DB_CONTEXT_HELD_WARN_MS = '50';
+
+      // Named so the frame is identifiable in the captured trace. The whole
+      // point: ~12k BREEZE-9 events were unactionable because the stack was
+      // built in the `finally` — after `await`, when the opener's frames are
+      // already gone — so every event pointed at db/index.ts instead of at the
+      // code actually holding the connection.
+      async function theCulpritThatHoldsTheConnection(): Promise<void> {
+        await withSystemDbAccessContext(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 90));
+        });
+      }
+
+      // Defeat the per-scope capture throttle so this asserts on a real event
+      // rather than conditionally skipping and passing vacuously.
+      process.env.DB_CONTEXT_HELD_CAPTURE_THROTTLE_MS = '0';
+      __resetHeldContextCaptureThrottleForTests();
+
+      await theCulpritThatHoldsTheConnection();
+
+      expect(heldWarns()).toHaveLength(1);
+      expect(capturedMessages).toHaveLength(1);
+
+      const extra = capturedMessages[0]!.extra;
+      expect(typeof extra?.openedAt).toBe('string');
+      // The opener's own frame must be present. Before the fix this field did
+      // not exist and `stack` contained only the await trampoline.
+      expect(String(extra?.openedAt)).toContain('theCulpritThatHoldsTheConnection');
     });
 
     it('still warns when fn THROWS after holding the context too long (the finally path)', async () => {

--- a/apps/api/src/__tests__/integration/deadlockRetry.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deadlockRetry.integration.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Proves the mechanism `retryOnTransientLockError` depends on: that a REAL
+ * Postgres deadlock (40P01) raised inside a nested Drizzle transaction is
+ * recoverable, so the retry can actually re-run the work.
+ *
+ * Why this needs a real DB rather than reasoning: the retry is only sound if
+ * `ROLLBACK TO SAVEPOINT` restores the outer transaction after a deadlock. A
+ * deadlock is delivered to the victim as an ordinary statement-level ERROR, so
+ * in principle the subtransaction aborts and the outer survives — but "in
+ * principle" is exactly the assumption that shipped BREEZE-3, and if it were
+ * wrong the retry would fail with 25P02 on every follow-up statement and the
+ * agent report would still be lost. See dbSavepointErrorIsolation for the
+ * general savepoint-isolation proof; this file pins the 40P01 case specifically.
+ *
+ * The deadlock is induced deterministically, not by racing: the competitor
+ * holds row B and only reaches for row A once pg_locks confirms the
+ * code-under-test is genuinely blocked waiting on B.
+ */
+import './setup';
+
+import { describe, expect, it } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { sites } from '../../db/schema';
+import { isTransientLockError, pgErrorCode, retryOnTransientLockError } from '../../utils/pgErrors';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getAppDb, getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function orgCtx(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+    currentPartnerId: null,
+  };
+}
+
+/** Resolves once some backend is waiting on an ungranted row lock. */
+async function waitForBlockedLock(timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const rows = (await getTestDb().execute(sql`
+      SELECT count(*)::int AS waiting
+      FROM pg_locks
+      WHERE NOT granted AND locktype IN ('transactionid', 'tuple')
+    `)) as unknown as Array<{ waiting: number }>;
+    if ((rows[0]?.waiting ?? 0) > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error('timed out waiting for a blocked lock — the deadlock setup did not engage');
+}
+
+describe('transient lock retry against real Postgres', () => {
+  runDb('recovers from a real 40P01 inside a nested transaction and commits on retry', async () => {
+    // Two rows in the same org-scoped table, locked in opposite orders by the
+    // two sides. Same org for both so a plain org context can read, lock and
+    // update either one — the test is about lock ordering, not about RLS.
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const siteA = await createSite({ orgId: org.id, name: 'deadlock-a' });
+    const siteB = await createSite({ orgId: org.id, name: 'deadlock-b' });
+
+    const ctx = orgCtx(org.id);
+
+    // The competitor runs on its own breeze_app connection so this is a genuine
+    // two-backend deadlock, not a self-conflict.
+    const competitor = getAppDb();
+    let competitorReachedForA = false;
+
+    const competitorDone = competitor.transaction(async (ctx2) => {
+      await ctx2.execute(sql`SELECT set_config('breeze.scope', 'system', true)`);
+      // Hold B.
+      await ctx2.execute(sql`SELECT id FROM sites WHERE id = ${siteB.id}::uuid FOR UPDATE`);
+      // Only now reach for A — after the code under test is provably blocked on
+      // B. One of the two backends is then chosen as the deadlock victim.
+      await waitForBlockedLock();
+      competitorReachedForA = true;
+      await ctx2.execute(sql`SELECT id FROM sites WHERE id = ${siteA.id}::uuid FOR UPDATE`);
+    });
+
+    let attempts = 0;
+    let sawDeadlock = false;
+
+    const result = await withDbAccessContext(ctx, async () => {
+      return retryOnTransientLockError('test deadlock', async () => {
+        attempts += 1;
+        try {
+          // Nested drizzle transaction => postgres.js savepoint.
+          return await db.transaction(async (tx) => {
+            // Hold A, then reach for B (the inversion).
+            await tx.execute(sql`SELECT id FROM sites WHERE id = ${siteA.id}::uuid FOR UPDATE`);
+            await tx.execute(sql`SELECT id FROM sites WHERE id = ${siteB.id}::uuid FOR UPDATE`);
+            // Proves the retry attempt can still WRITE — i.e. the outer
+            // transaction really is healthy after the rolled-back savepoint,
+            // not merely readable.
+            await tx
+              .update(sites)
+              .set({ name: `deadlock-a-updated-${attempts}` })
+              .where(eq(sites.id, siteA.id));
+            return 'committed';
+          });
+        } catch (error) {
+          if (isTransientLockError(error)) {
+            sawDeadlock = true;
+            expect(pgErrorCode(error)).toBe('40P01');
+          }
+          throw error;
+        }
+      });
+    });
+
+    await competitorDone.catch((error) => {
+      // Either side can be the victim; if the competitor lost, that is fine.
+      if (!isTransientLockError(error)) throw error;
+    });
+
+    expect(competitorReachedForA).toBe(true);
+    // The whole point: the work eventually succeeded rather than 500ing.
+    expect(result).toBe('committed');
+
+    // And it really committed — read it back on a fresh context.
+    const [row] = (await withDbAccessContext(orgCtx(org.id), () =>
+      db.select({ name: sites.name }).from(sites).where(eq(sites.id, siteA.id)),
+    )) as Array<{ name: string }>;
+    expect(row?.name).toBe(`deadlock-a-updated-${attempts}`);
+
+    // If this side happened to win the race there was no deadlock to recover
+    // from and the test proved nothing about 40P01 — fail loudly rather than
+    // pass vacuously.
+    expect(sawDeadlock, 'no 40P01 was observed; the deadlock did not engage').toBe(true);
+    expect(attempts).toBeGreaterThan(1);
+  }, 60_000);
+});

--- a/apps/api/src/__tests__/integration/metricRollupPartitionMaintenance.integration.test.ts
+++ b/apps/api/src/__tests__/integration/metricRollupPartitionMaintenance.integration.test.ts
@@ -1,0 +1,158 @@
+import './setup';
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+
+import { db, withSystemDbAccessContext } from '../../db';
+import {
+  dropExpiredMetricRollupPartitions,
+  ensureMetricRollupPartitions,
+  runMetricRollupMaintenance,
+} from '../../services/metricRollupMaintenance';
+import { getTestDb } from './setup';
+
+/**
+ * Regression guard for BREEZE-10: metric-rollup partition maintenance ran pure
+ * DDL (CREATE TABLE ... PARTITION OF, ALTER TABLE ... FORCE RLS, CREATE POLICY,
+ * GRANT, DROP TABLE) straight from the app connection. The API connects as the
+ * unprivileged `breeze_app`, which has no CREATE on schema public and owns
+ * neither metric_rollups nor its children, so every production run aborted on
+ * its first statement with 42501 `permission denied for schema public` — and
+ * because `ensureMetricRollupPartitions()` runs first, retention never ran at
+ * all. Postgres ACL-checks the schema BEFORE the IF NOT EXISTS short-circuit,
+ * so even a month whose partition already existed failed.
+ *
+ * The mocked unit suite could not catch this: it asserts on generated SQL and
+ * executes none of it. The whole point of this file is that the maintenance
+ * path is driven through the real `db` pool — i.e. as `breeze_app` with the
+ * same privileges prod has — so reintroducing inline DDL fails here.
+ *
+ * The DDL now lives in SECURITY DEFINER functions owned by the migration role
+ * (migration 2026-08-05-metric-rollup-partition-maintenance-privileges.sql).
+ */
+
+/** Months no other integration test touches, so the default partition can
+ * never already hold rows for them (which would legitimately skip the create). */
+const FUTURE_MONTH = new Date(Date.UTC(2031, 4, 1));
+const EXPIRED_MONTH = new Date(Date.UTC(2019, 0, 1));
+const FUTURE_PARTITION = 'metric_rollups_y2031m05';
+const EXPIRED_PARTITION = 'metric_rollups_y2019m01';
+/** ensureMetricRollupPartitions floors monthsAhead at Math.max(1, ...), so the
+ * anchor month always comes with the following month — there is no way to ask
+ * for a single month. Spell both out rather than asserting a loose superset. */
+const FUTURE_PARTITIONS = [FUTURE_PARTITION, 'metric_rollups_y2031m06'];
+const EXPIRED_PARTITIONS = [EXPIRED_PARTITION, 'metric_rollups_y2019m02'];
+
+async function partitionExists(name: string): Promise<boolean> {
+  const rows = await getTestDb().execute(sql`
+    SELECT 1 AS present
+    FROM pg_inherits
+    JOIN pg_class child ON child.oid = pg_inherits.inhrelid
+    JOIN pg_class parent ON parent.oid = pg_inherits.inhparent
+    JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace
+    WHERE parent.relname = 'metric_rollups'
+      AND child_ns.nspname = 'public'
+      AND child.relname = ${name}
+  `);
+  return (Array.isArray(rows) ? rows : []).length > 0;
+}
+
+describe('metric rollup partition maintenance (real DB, breeze_app privileges)', () => {
+  beforeAll(async () => {
+    // Non-vacuity guard. If the code-under-test pool were a superuser or a
+    // BYPASSRLS role, the inline DDL would have succeeded and every assertion
+    // below would pass while proving nothing about production.
+    const rows = await db.execute(sql`SELECT current_user AS who`);
+    const who = (Array.isArray(rows) ? (rows[0] as { who?: unknown } | undefined) : undefined)?.who;
+    expect(who).toBe('breeze_app');
+  });
+
+  it('creates a monthly partition as breeze_app, fully converged with RLS and grants', async () => {
+    for (const name of FUTURE_PARTITIONS) {
+      await getTestDb().execute(sql.raw(`DROP TABLE IF EXISTS "${name}"`));
+    }
+
+    const ensured = await withSystemDbAccessContext(() =>
+      ensureMetricRollupPartitions({ referenceDate: FUTURE_MONTH, monthsBack: 0, monthsAhead: 1 }),
+    );
+
+    // A skipped month returns nothing; these months are untouched by other
+    // tests, so a skip here is a real failure and must not read as success.
+    expect(ensured).toEqual(FUTURE_PARTITIONS);
+    expect(await partitionExists(FUTURE_PARTITION)).toBe(true);
+
+    const [flags] = (await getTestDb().execute(sql`
+      SELECT relrowsecurity AS rls, relforcerowsecurity AS forced
+      FROM pg_class WHERE relname = ${FUTURE_PARTITION}
+    `)) as unknown as Array<{ rls: boolean; forced: boolean }>;
+    expect(flags).toMatchObject({ rls: true, forced: true });
+
+    const policies = (await getTestDb().execute(sql`
+      SELECT polname FROM pg_policy
+      WHERE polrelid = ${`public.${FUTURE_PARTITION}`}::regclass
+      ORDER BY polname
+    `)) as unknown as Array<{ polname: string }>;
+    expect(policies.map((p) => p.polname)).toEqual([
+      'breeze_org_isolation_delete',
+      'breeze_org_isolation_insert',
+      'breeze_org_isolation_select',
+      'breeze_org_isolation_update',
+    ]);
+
+    const grants = (await getTestDb().execute(sql`
+      SELECT privilege_type FROM information_schema.role_table_grants
+      WHERE table_name = ${FUTURE_PARTITION} AND grantee = 'breeze_app'
+    `)) as unknown as Array<{ privilege_type: string }>;
+    const granted = grants.map((g) => g.privilege_type);
+    for (const privilege of ['SELECT', 'INSERT', 'UPDATE', 'DELETE']) {
+      expect(granted).toContain(privilege);
+    }
+
+    // Re-running must be an idempotent no-op that still reports the partitions.
+    const again = await withSystemDbAccessContext(() =>
+      ensureMetricRollupPartitions({ referenceDate: FUTURE_MONTH, monthsBack: 0, monthsAhead: 1 }),
+    );
+    expect(again).toEqual(FUTURE_PARTITIONS);
+
+    for (const name of FUTURE_PARTITIONS) {
+      await getTestDb().execute(sql.raw(`DROP TABLE IF EXISTS "${name}"`));
+    }
+  });
+
+  it('drops an expired partition as breeze_app and leaves the default partition intact', async () => {
+    const ensured = await withSystemDbAccessContext(() =>
+      ensureMetricRollupPartitions({ referenceDate: EXPIRED_MONTH, monthsBack: 0, monthsAhead: 1 }),
+    );
+    expect(ensured).toEqual(EXPIRED_PARTITIONS);
+
+    const dropped = await withSystemDbAccessContext(() => dropExpiredMetricRollupPartitions(new Date()));
+
+    expect(dropped).toContain(EXPIRED_PARTITION);
+    for (const name of EXPIRED_PARTITIONS) {
+      expect(await partitionExists(name)).toBe(false);
+    }
+    // The drop seam derives the name from the month, so no month can ever
+    // resolve to the catch-all partition.
+    expect(await partitionExists('metric_rollups_default')).toBe(true);
+  });
+
+  it('runs the whole maintenance job through to retention without aborting', async () => {
+    // The BREEZE-10 symptom was not a bad partition — it was that ensure()
+    // threw first, so dropExpired/prune never ran. Assert the job reaches the
+    // end and reports a retention result for all three bucket tiers.
+    const result = await withSystemDbAccessContext(() =>
+      runMetricRollupMaintenance({ now: new Date(Date.UTC(2031, 4, 15)) }),
+    );
+
+    expect(result.skipped).toBeUndefined();
+    expect(result.ensuredPartitions.length).toBeGreaterThan(0);
+    expect(result.retention.map((tier) => tier.bucketSeconds)).toEqual([300, 3600, 86400]);
+    for (const tier of result.retention) {
+      expect(tier.deleted).toBeGreaterThanOrEqual(0);
+    }
+
+    for (const name of result.ensuredPartitions) {
+      await getTestDb().execute(sql.raw(`DROP TABLE IF EXISTS "${name}"`));
+    }
+  });
+});

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -260,6 +260,22 @@ export async function withDbAccessContext<T>(
 
     const warnMs = getHeldContextWarnMs();
     const startedAt = warnMs > 0 ? Date.now() : 0;
+    // Capture the OPENER's stack here, synchronously, while the call chain that
+    // opened this context is still on the stack.
+    //
+    // The warning below used to build its stack inside the `finally`, which runs
+    // after `await` — by then the synchronous frames are gone and all that
+    // remains is the microtask trampoline plus whatever host loop is at the
+    // bottom (`processTicksAndRejections` / `sql.begin` / bullmq's worker.js).
+    // That is why BREEZE-9 accumulated ~12k events that name nothing
+    // actionable: every one pointed at this emitter instead of at the code
+    // holding the connection. Allocating the Error here records the real opener.
+    //
+    // Cost: `new Error()` captures the structured trace but V8 only formats it
+    // on first `.stack` access, which we do ONLY when a hold actually breaches
+    // the threshold. So the hot path pays one small allocation, not stack
+    // serialization, and only when the tripwire is armed at all.
+    const opener = warnMs > 0 ? new Error('withDbAccessContext opened here') : undefined;
     try {
       return await dbContextStorage.run(tx as unknown as typeof baseDb, () =>
         dbContextMetaStorage.run(context, fn),
@@ -282,7 +298,16 @@ export async function withDbAccessContext<T>(
             // Throttle the Sentry capture per scope (see getHeldContextCaptureThrottleMs)
             // so a recurring conn-hold can't flood the org's event quota.
             if (shouldCaptureHeldContext(context.scope, Date.now(), getHeldContextCaptureThrottleMs())) {
-              captureMessage(message, 'warning', { heldMs, scope: context.scope, stack: new Error().stack });
+              captureMessage(message, 'warning', {
+                heldMs,
+                scope: context.scope,
+                // `openedAt` is the actionable one — it names the caller that
+                // opened the context. `stack` is kept (emitter-side, i.e. the
+                // await trampoline) only because the previous shape had it and
+                // dropping a field silently is worse than an extra one.
+                openedAt: opener?.stack,
+                stack: new Error().stack,
+              });
             }
           }
         }

--- a/apps/api/src/jobs/workerObservability.test.ts
+++ b/apps/api/src/jobs/workerObservability.test.ts
@@ -7,11 +7,23 @@ vi.mock('../services/sentry', () => ({
   captureException: vi.fn(),
 }));
 
-// Mock @sentry/node's withScope to a passthrough that invokes the callback
-// with a no-op scope, so the `failed` handler's tag/context calls don't throw.
+// Mock @sentry/node's scope helpers to passthroughs that invoke the callback
+// with a recording scope, so tag/context calls don't throw and the tags applied
+// around job execution are observable.
+const isolationTags: Array<Record<string, unknown>> = [];
 vi.mock('@sentry/node', () => ({
   withScope: (fn: (scope: unknown) => void) =>
     fn({ setTag: vi.fn(), setContext: vi.fn() }),
+  withIsolationScope: (fn: (scope: unknown) => unknown) => {
+    const tags: Record<string, unknown> = {};
+    isolationTags.push(tags);
+    return fn({
+      setTag: (key: string, value: unknown) => {
+        tags[key] = value;
+      },
+      setContext: vi.fn(),
+    });
+  },
 }));
 
 import { captureException } from '../services/sentry';
@@ -68,6 +80,102 @@ describe('attachWorkerObservability', () => {
       (worker as unknown as EventEmitter).emit('failed', undefined, err)
     ).not.toThrow();
     expect(captureException).toHaveBeenCalledWith(err);
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('attachWorkerObservability — job execution tagging (BREEZE-9 attribution)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isolationTags.length = 0;
+  });
+
+  /**
+   * A worker with the BullMQ-shaped `processFn` instance property. `Worker`
+   * declares processFn as `Processor`, so the fake is assigned through a
+   * loosened shape rather than intersecting with Worker (which would demand the
+   * full Processor signature for no added safety here).
+   */
+  type FakeWorker = Worker & { processFn: (...args: unknown[]) => Promise<unknown> };
+
+  function makeWorkerWithProcessFn(processFn: (...args: unknown[]) => Promise<unknown>): FakeWorker {
+    const worker = new EventEmitter() as unknown as FakeWorker;
+    (worker as unknown as { processFn: (...args: unknown[]) => Promise<unknown> }).processFn = processFn;
+    return worker;
+  }
+
+  it('tags worker, jobName and jobId for the duration of the job', async () => {
+    // Tags must be visible to code running INSIDE the processor — that is the
+    // whole point: the held-context warning is captured mid-job, and previously
+    // arrived with an empty `worker` tag (12k unattributable BREEZE-9 events).
+    let tagsDuringJob: Record<string, unknown> | undefined;
+    const worker = makeWorkerWithProcessFn(async () => {
+      tagsDuringJob = { ...isolationTags[isolationTags.length - 1] };
+      return 'result';
+    });
+
+    attachWorkerObservability(worker, 'metricRollupMaintenance');
+
+    const result = await worker.processFn({ id: 'job-9', name: 'metric-rollup-maintenance' });
+
+    expect(result).toBe('result');
+    expect(tagsDuringJob).toEqual({
+      worker: 'metricRollupMaintenance',
+      jobName: 'metric-rollup-maintenance',
+      jobId: 'job-9',
+    });
+  });
+
+  it('passes the job arguments and `this` through to the original processor', async () => {
+    const seen: unknown[] = [];
+    const worker = makeWorkerWithProcessFn(async function (this: unknown, ...args: unknown[]) {
+      seen.push(...args);
+      // `this` must still be the worker: BullMQ's processFn uses instance state.
+      expect(this).toBe(worker);
+      return 'ok';
+    });
+
+    attachWorkerObservability(worker, 'testWorker');
+    await worker.processFn({ id: 'j1', name: 'n1' }, 'token-1');
+
+    expect(seen).toEqual([{ id: 'j1', name: 'n1' }, 'token-1']);
+  });
+
+  it('propagates a processor rejection unchanged', async () => {
+    const boom = new Error('processor failed');
+    const worker = makeWorkerWithProcessFn(async () => {
+      throw boom;
+    });
+
+    attachWorkerObservability(worker, 'testWorker');
+
+    await expect(worker.processFn({ id: 'j1', name: 'n1' })).rejects.toBe(boom);
+  });
+
+  it('omits jobName/jobId when the job carries neither, without throwing', async () => {
+    const worker = makeWorkerWithProcessFn(async () => 'ok');
+    attachWorkerObservability(worker, 'testWorker');
+
+    await worker.processFn(undefined);
+
+    expect(isolationTags[isolationTags.length - 1]).toEqual({ worker: 'testWorker' });
+  });
+
+  it('degrades to a warning (never a throw) if BullMQ stops exposing processFn', () => {
+    // Guards the monkey-patch: an upgrade that renames the internal must leave
+    // workers running, just without attribution.
+    const worker = new EventEmitter() as unknown as Worker;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => attachWorkerObservability(worker, 'testWorker')).not.toThrow();
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain('processFn');
+
+    // The failed-job reporting must still be wired up.
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (worker as unknown as EventEmitter).emit('failed', { id: 'j1', name: 'n' }, new Error('x'));
+    expect(captureException).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
     consoleSpy.mockRestore();
   });
 });

--- a/apps/api/src/jobs/workerObservability.ts
+++ b/apps/api/src/jobs/workerObservability.ts
@@ -10,7 +10,56 @@ import { captureException } from '../services/sentry';
  * wires up. Purely additive: callers keep any existing `.on('error')` /
  * `.on('failed')` handlers; this just adds Sentry capture alongside.
  */
+/**
+ * Run each job inside a Sentry isolation scope tagged with the worker and job
+ * identity, so EVERY event captured while that job runs inherits them — not
+ * just the `failed` handler below.
+ *
+ * Why: the `worker` tag was only ever set on the 'failed' listener, which fires
+ * outside job execution. Anything captured *during* a job — most importantly the
+ * #1105 held-context warning from withDbAccessContext — arrived with no
+ * attribution at all. BREEZE-9 accumulated ~12k held-context events at
+ * scope=system whose `worker` tag is empty, so there is no way to tell which of
+ * the 38 workers is pinning connections. Breaking that issue down by worker is
+ * the whole triage step, and it was impossible.
+ *
+ * All 38 workers already call attachWorkerObservability, so patching here covers
+ * every one with no per-worker change.
+ *
+ * `processFn` is a BullMQ instance property (visible in production stack traces
+ * as `at Worker.processFn`). Patching a library internal is a trade: it is
+ * guarded by a typeof check so a BullMQ rename degrades to the previous
+ * behaviour — no tags — rather than throwing, and workerObservability.test.ts
+ * asserts the tagging works so an upgrade that moves it fails loudly in CI
+ * instead of silently returning us to unattributable events.
+ */
+function tagJobExecution(worker: Worker, name: string): void {
+  const target = worker as unknown as {
+    processFn?: (...args: unknown[]) => unknown;
+  };
+  const original = target.processFn;
+  if (typeof original !== 'function') {
+    console.warn(
+      `[${name}] could not tag job execution for Sentry: BullMQ Worker.processFn is not a function `
+      + '(library internals changed). Held-context and in-job events will lack worker attribution.',
+    );
+    return;
+  }
+
+  target.processFn = function patchedProcessFn(...args: unknown[]) {
+    const job = args[0] as { id?: string; name?: string } | undefined;
+    return Sentry.withIsolationScope((scope) => {
+      scope.setTag('worker', name);
+      if (job?.name) scope.setTag('jobName', job.name);
+      if (job?.id) scope.setTag('jobId', job.id);
+      return original.apply(this, args);
+    });
+  };
+}
+
 export function attachWorkerObservability(worker: Worker, name: string): void {
+  tagJobExecution(worker, name);
+
   worker.on('error', (e) => {
     console.error(`[${name}] worker error:`, e);
     captureException(e);

--- a/apps/api/src/routes/agents/inventory.test.ts
+++ b/apps/api/src/routes/agents/inventory.test.ts
@@ -29,6 +29,7 @@ vi.mock('../../services/warrantyWorker', () => ({
 }));
 
 import { db } from '../../db';
+import * as schema from '../../db/schema';
 import { queueWarrantySyncForDevice } from '../../services/warrantyWorker';
 import { inventoryRoutes } from './inventory';
 
@@ -201,14 +202,24 @@ describe('agent software inventory — vuln finding re-link (BREEZE-3)', () => {
     const updateCalls: TxUpdateCall[] = [];
     const deleteWhere = vi.fn().mockResolvedValue(undefined);
     const insertValues = vi.fn().mockResolvedValue(undefined);
+    // The linked-findings select must lock its rows in a deterministic order —
+    // that is the BREEZE-3/BREEZE-W deadlock fix. Capture the chain so a
+    // regression that drops `.orderBy(...).for('update')` fails a test instead
+    // of silently reintroducing the lock-order inversion.
+    const linkedFindingsOrderBy = vi.fn();
+    const linkedFindingsFor = vi.fn();
     const tx = {
       // Two select shapes: the linked-findings join
-      // (select().from().innerJoin().where()) and the post-insert replacement
-      // row lookup (select().from().where()).
+      // (select().from().innerJoin().where().orderBy().for()) and the
+      // post-insert replacement row lookup (select().from().where()).
       select: vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           innerJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockResolvedValue(opts.linkedFindings),
+            where: vi.fn().mockReturnValue({
+              orderBy: linkedFindingsOrderBy.mockReturnValue({
+                for: linkedFindingsFor.mockResolvedValue(opts.linkedFindings),
+              }),
+            }),
           }),
           where: vi.fn().mockResolvedValue(opts.replacementRows),
         }),
@@ -232,7 +243,7 @@ describe('agent software inventory — vuln finding re-link (BREEZE-3)', () => {
       }),
     };
     vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
-    return { tx, updateCalls, deleteWhere, insertValues };
+    return { tx, updateCalls, deleteWhere, insertValues, linkedFindingsOrderBy, linkedFindingsFor };
   }
 
   async function putSoftware(app: Hono, software: Array<Record<string, unknown>>) {
@@ -245,6 +256,68 @@ describe('agent software inventory — vuln finding re-link (BREEZE-3)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('locks the findings it will re-link in id order (BREEZE-3 deadlock fix)', async () => {
+    mockDeviceLookup({ id: 'device-1', orgId: 'org-1' });
+    const { linkedFindingsOrderBy, linkedFindingsFor } = mockSoftwareTx({
+      linkedFindings: [{ findingId: 'finding-1', name: 'Google Chrome', vendor: 'Google LLC' }],
+      replacementRows: [{ id: 'new-1', name: 'Google Chrome', vendor: 'Google LLC' }],
+    });
+
+    const res = await putSoftware(makeApp(), [{ name: 'Google Chrome', vendor: 'Google LLC', version: '2.0' }]);
+    expect(res.status).toBe(200);
+
+    // Ordered by device_vulnerabilities.id, and locked. The FK cascade from the
+    // DELETE would otherwise take these row locks in software_inventory order
+    // while refreshRiskScores takes them in id order — opposite directions on
+    // the same rows is the deadlock. Both sides must ascend by id.
+    expect(linkedFindingsOrderBy).toHaveBeenCalledTimes(1);
+    expect(linkedFindingsOrderBy.mock.calls[0]?.[0]).toBe(schema.deviceVulnerabilities.id);
+    expect(linkedFindingsFor).toHaveBeenCalledWith('update', { of: schema.deviceVulnerabilities });
+  });
+
+  it('retries the transaction when it loses a lock race instead of dropping the report', async () => {
+    mockDeviceLookup({ id: 'device-1', orgId: 'org-1' });
+    const { tx } = mockSoftwareTx({
+      linkedFindings: [],
+      replacementRows: [],
+    });
+
+    // First attempt deadlocks the way BREEZE-3 did; the report must still land.
+    // Before the retry this propagated to the global handler as a 500 and the
+    // agent's entire software list was discarded (~4k reports in 6 days).
+    const deadlock = Object.assign(new Error('deadlock detected'), { code: '40P01' });
+    let attempts = 0;
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+      attempts += 1;
+      if (attempts === 1) throw deadlock;
+      return fn(tx);
+    });
+
+    const res = await putSoftware(makeApp(), [{ name: 'Google Chrome', vendor: 'Google LLC', version: '2.0' }]);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, count: 1 });
+    expect(attempts).toBe(2);
+  });
+
+  it('gives up after the retry budget and does not mask a non-lock error', async () => {
+    mockDeviceLookup({ id: 'device-1', orgId: 'org-1' });
+    mockSoftwareTx({ linkedFindings: [], replacementRows: [] });
+
+    // A constraint violation is not a lost lock race — it must surface on the
+    // FIRST throw rather than being retried into extra load.
+    const notALockError = Object.assign(new Error('null value violates not-null'), { code: '23502' });
+    let attempts = 0;
+    vi.mocked(db.transaction).mockImplementation(async () => {
+      attempts += 1;
+      throw notALockError;
+    });
+
+    const res = await putSoftware(makeApp(), [{ name: 'Google Chrome', vendor: 'Google LLC', version: '2.0' }]);
+    expect(res.status).toBe(500);
+    expect(attempts).toBe(1);
   });
 
   it('re-links findings to the replacement rows matching (name, vendor)', async () => {

--- a/apps/api/src/routes/agents/inventory.ts
+++ b/apps/api/src/routes/agents/inventory.ts
@@ -19,6 +19,7 @@ import {
   updateNetworkSchema,
 } from './schemas';
 import { sanitizeDate } from './helpers';
+import { retryOnTransientLockError } from '../../utils/pgErrors';
 import { upsertAgentWarranty } from '../../services/warrantySync';
 import { queueWarrantySyncForDevice } from '../../services/warrantyWorker';
 import { requireAgentRole } from '../../middleware/requireAgentRole';
@@ -105,7 +106,13 @@ inventoryRoutes.put('/:id/software', bodyLimit({ maxSize: 5 * 1024 * 1024, onErr
     return c.json({ error: 'Device not found' }, 404);
   }
 
-  await db.transaction(async (tx) => {
+  // The ordering below makes the BREEZE-3 deadlock unreachable against the
+  // risk-score pass, but device_vulnerabilities has other writers (correlation,
+  // status changes, the waiver reaper). Losing a lock race to one of those must
+  // not cost the whole inventory report the way it did before — this route runs
+  // inside agentAuth's request-long context, so `db.transaction` is a SAVEPOINT
+  // and is safe to re-run (see retryOnTransientLockError).
+  await retryOnTransientLockError(`Inventory software device=${device.id}`, () => db.transaction(async (tx) => {
     // The wipe-and-reinsert below churns software_inventory row ids, and
     // device_vulnerabilities.software_inventory_id references them (ON DELETE
     // SET NULL). The fleet aggregation layer displays a NULL-linked finding as
@@ -113,6 +120,25 @@ inventoryRoutes.put('/:id/software', bodyLimit({ maxSize: 5 * 1024 * 1024, onErr
     // repair every software report would misclassify the device's software
     // findings in the UI until the next correlation run. Capture what each
     // finding pointed at, then re-link to the replacement row.
+    //
+    // `FOR UPDATE OF device_vulnerabilities` + `ORDER BY device_vulnerabilities.id`
+    // is load-bearing, not a tidy-up: it is the fix for the BREEZE-3/BREEZE-W
+    // deadlock pair (pg 40P01, ~4k dropped software reports in 6 days).
+    //
+    // This select covers exactly the findings the DELETE below will touch via
+    // the ON DELETE SET NULL cascade, and exactly the ones the re-link UPDATEs
+    // touch afterwards. Without the locking clause this transaction acquired
+    // its device_vulnerabilities row locks implicitly, in whatever order the
+    // FK cascade walked software_inventory — which is NOT id order. The
+    // `risk-score-refresh` pass walks the same rows ordered by id (one UPDATE
+    // per row, see refreshRiskScores in jobs/vulnerabilityJobs.ts), so the two
+    // acquired the same locks in opposite orders and Postgres killed one side.
+    //
+    // #2751 added the ORDER BY on the refresh side only; that is not enough,
+    // and BREEZE-W kept firing on 0.100.0 with the ordering already shipped.
+    // Both sides must ascend by id — two ascending acquirers cannot form a
+    // cycle. Locking here up front pins the whole set in id order before the
+    // cascade can invert it.
     const linkedFindings = await tx
       .select({
         findingId: deviceVulnerabilities.id,
@@ -124,7 +150,12 @@ inventoryRoutes.put('/:id/software', bodyLimit({ maxSize: 5 * 1024 * 1024, onErr
       .where(and(
         eq(deviceVulnerabilities.deviceId, device.id),
         eq(softwareInventory.deviceId, device.id)
-      ));
+      ))
+      .orderBy(deviceVulnerabilities.id)
+      // Only the findings — locking the joined software_inventory rows here too
+      // would be harmless (the DELETE takes them immediately after) but adds
+      // nothing, and `OF` keeps the intent explicit.
+      .for('update', { of: deviceVulnerabilities });
 
     await tx
       .delete(softwareInventory)
@@ -225,7 +256,7 @@ inventoryRoutes.put('/:id/software', bodyLimit({ maxSize: 5 * 1024 * 1024, onErr
         `[Inventory] Software report for device ${device.id} emptied the inventory and detached ${linkedFindings.length} vuln finding link(s)`
       );
     }
-  });
+  }));
 
   return c.json({ success: true, count: data.software.length });
 });

--- a/apps/api/src/routes/devices/events.test.ts
+++ b/apps/api/src/routes/devices/events.test.ts
@@ -6,6 +6,10 @@ import { Hono } from 'hono';
 // set. The count select is distinguishable from the row select by its shape:
 // the count projection has a `count` key; the row projection does not.
 const countQueryCalls = vi.fn();
+// Captures the WHERE condition handed to the feed query so tests can prove the
+// org_id scoping is present (BREEZE-B — it is load-bearing for performance, not
+// cosmetic; see the comment in events.ts).
+const feedWhereArgs: unknown[] = [];
 
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
@@ -15,13 +19,16 @@ vi.mock('../../db', () => ({
     select: vi.fn((projection?: Record<string, unknown>) => ({
       from: vi.fn(() => ({
         leftJoin: vi.fn(() => ({
-          where: vi.fn(() => ({
-            orderBy: vi.fn(() => ({
-              limit: vi.fn(() => ({
-                offset: vi.fn().mockResolvedValue([])
+          where: vi.fn((cond: unknown) => {
+            feedWhereArgs.push(cond);
+            return {
+              orderBy: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  offset: vi.fn().mockResolvedValue([])
+                }))
               }))
-            }))
-          }))
+            };
+          })
         })),
         where: vi.fn(() => {
           if (projection && 'count' in projection) countQueryCalls();
@@ -35,6 +42,7 @@ vi.mock('../../db', () => ({
 vi.mock('../../db/schema', () => ({
   auditLogs: {
     id: 'id',
+    orgId: 'org_id',
     timestamp: 'timestamp',
     action: 'action',
     actorType: 'actor_type',
@@ -251,5 +259,36 @@ describe('GET /devices/:id/events validation', () => {
       { method: 'GET', headers: { Authorization: 'Bearer token' } }
     );
     expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /devices/:id/events — org scoping of the audit feed (BREEZE-B)", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    feedWhereArgs.length = 0;
+    app = new Hono();
+    app.route('/devices', eventsRoutes);
+  });
+
+  it("filters on the device's org_id so the scan can use audit_logs_org_timestamp_idx", async () => {
+    const res = await app.request(
+      '/devices/11111111-1111-1111-1111-111111111111/events',
+      { method: 'GET', headers: { Authorization: 'Bearer token' } }
+    );
+    expect(res.status).toBe(200);
+
+    // Without this predicate the feed query cannot use ANY index under RLS: the
+    // `details->>'deviceId'` arm is non-leakproof so Postgres may not evaluate
+    // it before the security qual, which makes its expression index unusable
+    // and forces a full scan (measured 11,938ms on 800k rows vs 178ms with
+    // this predicate). Assert the org column and the device's org id are both
+    // in the WHERE, so removing the scoping fails here rather than silently
+    // regressing to a seq scan in production.
+    expect(feedWhereArgs).toHaveLength(1);
+    const serialized = JSON.stringify(feedWhereArgs[0]);
+    expect(serialized).toContain('org_id');
+    expect(serialized).toContain('org-123');
   });
 });

--- a/apps/api/src/routes/devices/events.ts
+++ b/apps/api/src/routes/devices/events.ts
@@ -144,10 +144,35 @@ eventsRoutes.get(
       return c.json({ error: 'Device not found' }, 404);
     }
 
-    // Find audit logs where resourceId matches the device, OR the device is
-    // referenced inside the JSONB details (agent-submitted events use
-    // details.deviceId).
+    // Scope to the device's org FIRST. This is a performance fix, not just
+    // defense-in-depth (BREEZE-B: 25s holds, 5 users).
+    //
+    // The `details->>'deviceId'` arm below cannot use its index when RLS is
+    // enforced: `jsonb_object_field_text` (`->>`) is NOT leakproof
+    // (pg_proc.proleakproof = false), so Postgres may not evaluate it before the
+    // RLS security qual, which means it can never become an index condition.
+    // audit_logs_details_device_id_idx therefore exists and is simply ignored on
+    // the app's connection. Measured on 800k rows as breeze_app: 11,938ms
+    // (Parallel Seq Scan, 266k rows filtered per worker). The SAME query as a
+    // superuser, where RLS does not apply, uses the index and runs in 0.044ms —
+    // so this is an RLS interaction, not a missing index. `uuid_eq` IS
+    // leakproof, which is why the resource_id arm alone indexes fine (3.9ms).
+    //
+    // An org_id equality is leakproof and indexable, so it bounds the scan to
+    // one org via audit_logs_org_timestamp_idx: 11,938ms -> 178ms (~67x).
+    //
+    // Safe on visibility: breeze_has_org_access(NULL) returns FALSE, so audit
+    // rows written with a null org_id (e.g. writeAuditEvent with `orgId ?? null`
+    // on some agent paths) are ALREADY invisible to every org- and
+    // partner-scope caller — this predicate hides nothing they could see. It
+    // does narrow system-scope callers, which previously saw null-org rows; a
+    // device's activity feed showing only that device's org is the intended
+    // semantics.
     const conditions: SQL[] = [
+      eq(auditLogs.orgId, device.orgId),
+      // Find audit logs where resourceId matches the device, OR the device is
+      // referenced inside the JSONB details (agent-submitted events use
+      // details.deviceId).
       or(
         eq(auditLogs.resourceId, deviceId),
         sql`${auditLogs.details}->>'deviceId' = ${deviceId}`

--- a/apps/api/src/services/metricRollupMaintenance.test.ts
+++ b/apps/api/src/services/metricRollupMaintenance.test.ts
@@ -33,22 +33,60 @@ describe('metric rollup maintenance service', () => {
     expect(parseMetricRollupPartitionMonth('metric_rollups_default')).toBeNull();
   });
 
-  it('creates monthly partitions with RLS policies and breeze_app grants', async () => {
-    await ensureMetricRollupPartitions({
+  it('ensures monthly partitions through the SECURITY DEFINER function, one call per month', async () => {
+    executeMock
+      .mockResolvedValueOnce([{ partitionName: 'metric_rollups_y2026m06' }])
+      .mockResolvedValueOnce([{ partitionName: 'metric_rollups_y2026m07' }]);
+
+    const ensured = await ensureMetricRollupPartitions({
       referenceDate: new Date('2026-06-18T12:00:00.000Z'),
       monthsBack: 0,
       monthsAhead: 1,
     });
 
+    expect(ensured).toEqual(['metric_rollups_y2026m06', 'metric_rollups_y2026m07']);
+    // One call per month, not the 24 statements the inline DDL used to issue.
+    expect(executeMock).toHaveBeenCalledTimes(2);
+
     const executedSql = JSON.stringify(executeMock.mock.calls);
-    expect(executeMock).toHaveBeenCalledTimes(24);
-    expect(executedSql).toContain('metric_rollups_y2026m06');
-    expect(executedSql).toContain('metric_rollups_y2026m07');
-    expect(executedSql).toContain('PARTITION OF metric_rollups');
-    expect(executedSql).toContain('FOR VALUES FROM');
-    expect(executedSql).toContain('ENABLE ROW LEVEL SECURITY');
-    expect(executedSql).toContain('FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id))');
-    expect(executedSql).toContain('GRANT SELECT, INSERT, UPDATE, DELETE');
+    expect(executedSql).toContain('public.breeze_ensure_metric_rollup_partition');
+    expect(executedSql).toContain('2026-06-01 00:00:00');
+    expect(executedSql).toContain('2026-07-01 00:00:00');
+    // The DDL must NOT be issued from the app connection — that is the bug
+    // (BREEZE-10): breeze_app has no CREATE on schema public and owns neither
+    // metric_rollups nor its children, so every one of these aborted the run.
+    expect(executedSql).not.toContain('PARTITION OF metric_rollups');
+    expect(executedSql).not.toContain('ENABLE ROW LEVEL SECURITY');
+    expect(executedSql).not.toContain('CREATE POLICY');
+    expect(executedSql).not.toContain('GRANT SELECT, INSERT, UPDATE, DELETE');
+  });
+
+  it('treats a NULL partition name as a default-partition overlap skip', async () => {
+    executeMock
+      .mockResolvedValueOnce([{ partitionName: null }])
+      .mockResolvedValueOnce([{ partitionName: 'metric_rollups_y2026m07' }]);
+
+    const ensured = await ensureMetricRollupPartitions({
+      referenceDate: new Date('2026-06-18T12:00:00.000Z'),
+      monthsBack: 0,
+      monthsAhead: 1,
+    });
+
+    expect(ensured).toEqual(['metric_rollups_y2026m07']);
+  });
+
+  it('throws rather than silently skipping when the maintenance function is missing', async () => {
+    // A DB that has not applied migration 2026-08-05 returns no such column.
+    // Swallowing that would turn a broken deployment into an invisible no-op.
+    executeMock.mockResolvedValueOnce([]);
+
+    await expect(
+      ensureMetricRollupPartitions({
+        referenceDate: new Date('2026-06-18T12:00:00.000Z'),
+        monthsBack: 0,
+        monthsAhead: 0,
+      }),
+    ).rejects.toThrow(/partitionName column/);
   });
 
   it('uses tableoid and ctid for bounded deletes through the partitioned parent', async () => {
@@ -90,15 +128,29 @@ describe('metric rollup maintenance service', () => {
         { partitionName: 'metric_rollups_y2026m06' },
         { partitionName: 'metric_rollups_default' },
       ])
-      .mockResolvedValueOnce({ rowCount: 0 });
+      .mockResolvedValueOnce([{ partitionName: 'metric_rollups_y2022m12' }]);
 
     const dropped = await dropExpiredMetricRollupPartitions(new Date('2026-06-18T12:00:00.000Z'));
 
     expect(dropped).toEqual(['metric_rollups_y2022m12']);
     expect(executeMock).toHaveBeenCalledTimes(2);
     const dropSql = JSON.stringify(executeMock.mock.calls[1]);
-    expect(dropSql).toContain('DROP TABLE IF EXISTS');
-    expect(dropSql).toContain('metric_rollups_y2022m12');
+    // Owner-only DDL goes through the SECURITY DEFINER seam, and it receives the
+    // month rather than the discovered identifier — so the function re-derives
+    // and re-verifies attachment, keeping metric_rollups_default unreachable.
+    expect(dropSql).toContain('public.breeze_drop_metric_rollup_partition');
+    expect(dropSql).toContain('2022-12-01 00:00:00');
+    expect(dropSql).not.toContain('DROP TABLE');
+  });
+
+  it('does not report a drop when nothing was attached for that month', async () => {
+    executeMock
+      .mockResolvedValueOnce([{ partitionName: 'metric_rollups_y2022m12' }])
+      .mockResolvedValueOnce([{ partitionName: null }]);
+
+    const dropped = await dropExpiredMetricRollupPartitions(new Date('2026-06-18T12:00:00.000Z'));
+
+    expect(dropped).toEqual([]);
   });
 
   it('skips maintenance when another worker holds the advisory lock', async () => {

--- a/apps/api/src/services/metricRollupMaintenance.ts
+++ b/apps/api/src/services/metricRollupMaintenance.ts
@@ -85,19 +85,27 @@ function formatTimestampLiteral(value: Date): string {
   return value.toISOString().slice(0, 19).replace('T', ' ');
 }
 
-function quoteIdentifier(identifier: string): string {
-  if (!/^[a-z0-9_]+$/.test(identifier)) {
-    throw new Error(`Unsafe SQL identifier: ${identifier}`);
+/**
+ * Reads the single `partitionName` column returned by the partition-maintenance
+ * SECURITY DEFINER functions. A SQL NULL is a meaningful answer ("skipped" /
+ * "nothing attached"), so it is returned as null — but a missing row or a
+ * missing column is NOT: that means the function is absent or changed shape,
+ * and silently treating it as a skip would turn a broken deployment into an
+ * invisible no-op, which is precisely how BREEZE-10 stayed hidden.
+ */
+function readPartitionNameResult(result: unknown, context: string): string | null {
+  const row = Array.isArray(result) ? (result[0] as Record<string, unknown> | undefined) : undefined;
+  if (!row || !('partitionName' in row)) {
+    throw new Error(
+      `[MetricRollupMaintenance] ${context} returned no partitionName column — expected public.breeze_ensure_metric_rollup_partition/breeze_drop_metric_rollup_partition (migration 2026-08-05) to exist`,
+    );
   }
-  return `"${identifier}"`;
-}
-
-function isDefaultPartitionOverlapError(error: unknown): boolean {
-  const message = String((error as { message?: unknown })?.message ?? error);
-  return (
-    message.includes('updated partition constraint for default partition') &&
-    message.includes('would be violated by some row')
-  );
+  const value = row.partitionName;
+  if (value === null) return null;
+  if (typeof value !== 'string') {
+    throw new Error(`[MetricRollupMaintenance] ${context} returned a non-string partitionName: ${typeof value}`);
+  }
+  return value;
 }
 
 export function metricRollupPartitionName(monthStart: Date): string {
@@ -146,52 +154,32 @@ export async function ensureMetricRollupPartitions(options: EnsurePartitionOptio
 
   for (let offset = -monthsBack; offset <= monthsAhead; offset += 1) {
     const from = addMonths(anchor, offset);
-    const to = addMonths(from, 1);
     const partitionName = metricRollupPartitionName(from);
-    const partitionIdentifier = sql.raw(quoteIdentifier(partitionName));
-    const fromLiteral = sql.raw(`'${formatTimestampLiteral(from)}'::timestamp`);
-    const toLiteral = sql.raw(`'${formatTimestampLiteral(to)}'::timestamp`);
 
-    try {
-      await db.execute(sql`
-        CREATE TABLE IF NOT EXISTS ${partitionIdentifier}
-          PARTITION OF metric_rollups
-          FOR VALUES FROM (${fromLiteral}) TO (${toLiteral});
-      `);
-    } catch (error) {
-      if (isDefaultPartitionOverlapError(error)) {
-        console.warn(
-          `[MetricRollupMaintenance] Skipping ${partitionName}; metric_rollups_default already contains rows for that month`,
-        );
-        continue;
-      }
-      throw error;
+    // The DDL lives in a SECURITY DEFINER function owned by the migration role
+    // (2026-08-05-metric-rollup-partition-maintenance-privileges.sql). Issuing
+    // it directly from here fails as `breeze_app`, which has no CREATE on
+    // schema public and owns neither metric_rollups nor its children — the
+    // whole maintenance run aborted on this statement in production, taking
+    // retention down with it (BREEZE-10). The function takes the month and
+    // derives the partition name itself, so no identifier crosses the boundary.
+    const result = await db.execute(sql`
+      SELECT public.breeze_ensure_metric_rollup_partition(
+        ${formatTimestampLiteral(from)}::timestamp
+      ) AS "partitionName"
+    `);
+
+    // NULL means the function skipped the month because metric_rollups_default
+    // already holds rows for it — the same condition the inline DDL used to
+    // surface as a check_violation.
+    const ensuredName = readPartitionNameResult(result, `ensure ${partitionName}`);
+    if (ensuredName === null) {
+      console.warn(
+        `[MetricRollupMaintenance] Skipping ${partitionName}; metric_rollups_default already contains rows for that month`,
+      );
+      continue;
     }
-    await db.execute(sql`ALTER TABLE ${partitionIdentifier} ENABLE ROW LEVEL SECURITY`);
-    await db.execute(sql`ALTER TABLE ${partitionIdentifier} FORCE ROW LEVEL SECURITY`);
-    await db.execute(sql`DROP POLICY IF EXISTS breeze_org_isolation_select ON ${partitionIdentifier}`);
-    await db.execute(sql`DROP POLICY IF EXISTS breeze_org_isolation_insert ON ${partitionIdentifier}`);
-    await db.execute(sql`DROP POLICY IF EXISTS breeze_org_isolation_update ON ${partitionIdentifier}`);
-    await db.execute(sql`DROP POLICY IF EXISTS breeze_org_isolation_delete ON ${partitionIdentifier}`);
-    await db.execute(sql`
-      CREATE POLICY breeze_org_isolation_select ON ${partitionIdentifier}
-        FOR SELECT USING (public.breeze_has_org_access(org_id))
-    `);
-    await db.execute(sql`
-      CREATE POLICY breeze_org_isolation_insert ON ${partitionIdentifier}
-        FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id))
-    `);
-    await db.execute(sql`
-      CREATE POLICY breeze_org_isolation_update ON ${partitionIdentifier}
-        FOR UPDATE USING (public.breeze_has_org_access(org_id))
-        WITH CHECK (public.breeze_has_org_access(org_id))
-    `);
-    await db.execute(sql`
-      CREATE POLICY breeze_org_isolation_delete ON ${partitionIdentifier}
-        FOR DELETE USING (public.breeze_has_org_access(org_id))
-    `);
-    await db.execute(sql`GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE ${partitionIdentifier} TO breeze_app`);
-    ensured.push(partitionName);
+    ensured.push(ensuredName);
   }
 
   return ensured;
@@ -230,8 +218,19 @@ export async function dropExpiredMetricRollupPartitions(now = new Date()): Promi
     const partitionEnd = addMonths(partitionStart, 1);
     if (partitionEnd.getTime() > dailyCutoff.getTime()) continue;
 
-    await db.execute(sql`DROP TABLE IF EXISTS ${sql.raw(quoteIdentifier(partitionName))}`);
-    dropped.push(partitionName);
+    // DROP TABLE is owner-only DDL, so it goes through the same SECURITY DEFINER
+    // seam as the create path. Passing the month (not the discovered name) means
+    // the function re-derives and re-verifies attachment to metric_rollups
+    // before dropping — metric_rollups_default is unreachable by construction.
+    const result = await db.execute(sql`
+      SELECT public.breeze_drop_metric_rollup_partition(
+        ${formatTimestampLiteral(partitionStart)}::timestamp
+      ) AS "partitionName"
+    `);
+    const droppedName = readPartitionNameResult(result, `drop ${partitionName}`);
+    if (droppedName !== null) {
+      dropped.push(droppedName);
+    }
   }
 
   return dropped;

--- a/apps/api/src/utils/pgErrors.test.ts
+++ b/apps/api/src/utils/pgErrors.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { isPgUniqueViolation, pgErrorCode } from './pgErrors';
+import { describe, it, expect, vi } from 'vitest';
+import { isPgUniqueViolation, isTransientLockError, pgErrorCode, retryOnTransientLockError } from './pgErrors';
 
 // postgres.js surfaces the index as `constraint_name` (the real shape we hit in prod)
 const pgErr = (constraint?: string) =>
@@ -87,5 +87,66 @@ describe('pgErrorCode', () => {
     expect(pgErrorCode(null)).toBeUndefined();
     expect(pgErrorCode('boom')).toBeUndefined();
     expect(pgErrorCode(undefined)).toBeUndefined();
+  });
+});
+
+describe('isTransientLockError', () => {
+  it('matches deadlock_detected and serialization_failure, including Drizzle-wrapped', () => {
+    expect(isTransientLockError(Object.assign(new Error('deadlock detected'), { code: '40P01' }))).toBe(true);
+    expect(isTransientLockError(Object.assign(new Error('could not serialize'), { code: '40001' }))).toBe(true);
+    // The shape that actually reaches route code: DrizzleQueryError wrapper
+    // whose own .code is undefined and the real code on .cause.
+    const wrapped = Object.assign(new Error('Failed query: delete from "software_inventory"'), {
+      cause: Object.assign(new Error('deadlock detected'), { code: '40P01' }),
+    });
+    expect(isTransientLockError(wrapped)).toBe(true);
+  });
+
+  it('does not match errors that a retry cannot fix', () => {
+    // 25P02 is the SYMPTOM of an already-aborted transaction, not a lost race —
+    // retrying it in place would loop until the budget ran out.
+    for (const code of ['23505', '23502', '23503', '42501', '25P02', '40002']) {
+      expect(isTransientLockError(Object.assign(new Error('x'), { code }))).toBe(false);
+    }
+    expect(isTransientLockError(new Error('plain'))).toBe(false);
+    expect(isTransientLockError(null)).toBe(false);
+  });
+});
+
+describe('retryOnTransientLockError', () => {
+  it('returns the first successful result without retrying', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+    await expect(retryOnTransientLockError('t', fn)).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a deadlock and succeeds on a later attempt', async () => {
+    const deadlock = Object.assign(new Error('deadlock detected'), { code: '40P01' });
+    const fn = vi.fn()
+      .mockRejectedValueOnce(deadlock)
+      .mockRejectedValueOnce(deadlock)
+      .mockResolvedValue('ok');
+    await expect(retryOnTransientLockError('t', fn)).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('exhausts the budget and rethrows the last lock error', async () => {
+    const deadlock = Object.assign(new Error('deadlock detected'), { code: '40P01' });
+    const fn = vi.fn().mockRejectedValue(deadlock);
+    await expect(retryOnTransientLockError('t', fn, { attempts: 2 })).rejects.toBe(deadlock);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('rethrows a non-lock error immediately without burning retries', async () => {
+    const notALock = Object.assign(new Error('not-null violation'), { code: '23502' });
+    const fn = vi.fn().mockRejectedValue(notALock);
+    await expect(retryOnTransientLockError('t', fn)).rejects.toBe(notALock);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats attempts < 1 as a single attempt rather than skipping the work', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+    await expect(retryOnTransientLockError('t', fn, { attempts: 0 })).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/utils/pgErrors.ts
+++ b/apps/api/src/utils/pgErrors.ts
@@ -47,3 +47,60 @@ export function pgErrorCode(err: unknown): string | undefined {
   }
   return undefined;
 }
+
+/**
+ * 40P01 = deadlock_detected, 40001 = serialization_failure. Both mean "you lost
+ * a lock race, the work was not applied, try again" — never "the request was
+ * invalid". Postgres picks a victim and the winner finishes immediately after,
+ * so the retry almost always succeeds.
+ */
+export function isTransientLockError(err: unknown): boolean {
+  const code = pgErrorCode(err);
+  return code === '40P01' || code === '40001';
+}
+
+/**
+ * Re-run `fn` when it fails with a transient lock error (see
+ * {@link isTransientLockError}). Anything else propagates untouched on the
+ * first throw.
+ *
+ * Why this exists: the agent software-inventory ingest dropped ~4k reports in
+ * six days because a deadlock (BREEZE-3) propagated straight to the global
+ * error handler as a 500 and the whole report was discarded. Correct lock
+ * ordering is the primary fix; this is the belt-and-braces for the remaining
+ * writers of the same rows, because losing a lock race should cost a retry,
+ * not an entire inventory report.
+ *
+ * IMPORTANT — only wrap a NESTED drizzle transaction (one running inside a
+ * request-long `withDbAccessContext`, which drizzle emits as a SAVEPOINT).
+ * Retrying a statement that aborted the OUTER transaction cannot work: every
+ * follow-up fails with 25P02 until the outer transaction ends. A nested
+ * transaction rolls back to its savepoint and leaves the outer usable — see
+ * dbSavepointErrorIsolation.integration.test.ts for the isolation proof.
+ */
+export async function retryOnTransientLockError<T>(
+  label: string,
+  fn: () => Promise<T>,
+  options: { attempts?: number } = {},
+): Promise<T> {
+  const attempts = Math.max(1, options.attempts ?? 3);
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (!isTransientLockError(error)) throw error;
+      lastError = error;
+      // Log every lost race, including the final one. A silent retry would hide
+      // a lock-ordering regression: the symptom would shrink to added latency
+      // with nothing in Sentry to explain it.
+      console.warn(
+        `[${label}] transient lock error ${pgErrorCode(error)} on attempt ${attempt}/${attempts}`
+        + (attempt < attempts ? ' — retrying' : ' — giving up'),
+      );
+    }
+  }
+
+  throw lastError;
+}


### PR DESCRIPTION
Four production Sentry issues, each root-caused against real Postgres 16 rather than patched speculatively. One commit per issue so they can be reverted independently.

| Commit | Sentry | What was actually wrong |
|---|---|---|
| `58299a52f` | BREEZE-10 (+ M/C) | Metric-rollup partition maintenance ran owner-only DDL as `breeze_app` → 42501 every night; retention has **never** run in production |
| `2df4d8f85` | BREEZE-3 / BREEZE-W | Lock-order inversion on `device_vulnerabilities`; each 40P01 discards a full agent inventory report |
| `1d2005a56` | BREEZE-9 | ~12k held-connection warnings, all with an **empty** `worker` tag — untriageable |
| `63ce9a288` | BREEZE-B | Device activity feed 25.8s; RLS makes the `details->>'deviceId'` index unusable |

## 1. Metric-rollup maintenance could never run (BREEZE-10)

The nightly job issued `CREATE TABLE ... PARTITION OF`, `FORCE RLS`, `CREATE POLICY`, `GRANT`, `DROP TABLE` from the app connection. `breeze_app` has no `CREATE` on schema `public` and owns neither `metric_rollups` nor its children, so the first statement aborted with `42501`. Because `ensure()` runs first, `dropExpired()` and `pruneMetricRollups()` never ran at all.

Two findings worth flagging:

- Postgres **ACL-checks the schema before** the `IF NOT EXISTS` short-circuit, so this fired even for a month whose partition already existed — a permanent daily abort, not an edge case.
- BREEZE-M / BREEZE-C (`25P02` transaction aborted) were downstream symptoms of this same 42501. It was masked until #2751 stopped `releaseMaintenanceLock()`'s throw from replacing the real error.

Granting `breeze_app` `CREATE` on `public` would **not** fix it: `PARTITION OF` requires ownership of the *parent*, and `ENABLE/FORCE ROW LEVEL SECURITY` requires ownership of the *child*. The DDL moves into two `SECURITY DEFINER` functions owned by the migration role.

Security shape of those functions: both take a month `TIMESTAMP`, **never an identifier**, derive the partition name internally, and verify attachment to `metric_rollups` before touching anything. A `SECURITY DEFINER` function accepting a caller-supplied table name would be a privilege-escalation primitive; deriving the name also makes `metric_rollups_default` unreachable by construction. No custom-GUC function attributes (that form needs superuser — the v0.97.0 EU crash-loop).

The migration converges the current partition window on apply, because an existing DB is missing every month the broken worker should have added.

## 2. Inventory/risk-score deadlock (BREEZE-3 / BREEZE-W)

Inventory ingest wipes and reinserts `software_inventory`; the `ON DELETE SET NULL` cascade into `device_vulnerabilities` took row locks in the FK's walk order, while `refreshRiskScores` walks the same rows ascending by id. Opposite directions over an overlapping set is the cycle.

**#2751 ordered only the refresh side, which is not sufficient** — both sides must ascend, and BREEZE-W kept firing on 0.100.0 with that ordering already deployed. The inventory side now pre-locks with `ORDER BY device_vulnerabilities.id` + `FOR UPDATE OF device_vulnerabilities` before the cascade can invert.

On rate, correcting my own first read: BREEZE-3 is a broad grouping bucket, and only **~2 events/day** are actually 40P01. The bucket's bulk was a `device_network.mac_address` 22001 (fixed in #2750) plus ~3.3k FK violations from the 0.96.0 EU rollback. Low rate — but every occurrence loses a full inventory report, and the inversion is systematic.

The transaction is also wrapped in `retryOnTransientLockError` (40P01/40001, 3 attempts, every lost race logged so an ordering regression can't hide as latency). This route runs inside `agentAuth`'s request-long context, so `db.transaction` is a SAVEPOINT and safe to re-run.

## 3. Held-connection warnings were unattributable (BREEZE-9)

~12k warnings at `scope=system`, every one with an empty `worker` tag. `attachWorkerObservability` only subscribed to `error`/`failed`, and `failed` fires **outside** job execution — so its `setTag('worker')` never applied to anything captured *during* a job, which is exactly when the #1105 held-context warning fires. Job execution is now wrapped in a Sentry isolation scope tagged `worker`/`jobName`/`jobId`. All 38 workers already call this function, so no per-worker change.

This patches BullMQ's `processFn` instance property (verified present on the installed 5.79.2; visible in production stacks as `at Worker.processFn`). Guarded by a `typeof` check so a future rename degrades to no-tags rather than throwing, with tests asserting tagging plus arg/`this`/rejection passthrough so an upgrade fails in CI instead of silently returning us to unattributable events.

**Honest scope on the second half of this commit:** capturing the held-context stack at entry rather than in the `finally` is robustness, *not* the decisive fix. A negative control showed the finally-built stack still contains the caller in a shallow case, because V8 reconstructs async stacks — but that reconstruction is depth-limited and production frames run deep. The worker tag is what actually makes BREEZE-9 triageable.

## 4. Device activity feed: RLS defeats the index (BREEZE-B)

The feed matches `resource_id = $dev OR details->>'deviceId' = $dev`. `jsonb_object_field_text` is **not leakproof** (`pg_proc.proleakproof = false`), so Postgres may not evaluate it before the row-security qual — which disqualifies it as an index condition. `audit_logs_details_device_id_idx` exists and is silently ignored on the app's connection, and since the arms are OR'd the whole disjunction becomes a post-security filter over a fleet-wide table.

Measured on 800k rows:

| Query | Role | Plan | Time |
|---|---|---|---|
| `details->>'deviceId'` arm | `breeze_app` (RLS on) | Parallel Seq Scan | **11,938 ms** |
| same arm, same index | superuser (RLS off) | Index Scan | **0.044 ms** |
| `resource_id` arm | `breeze_app` (RLS on) | Index Scan | 3.9 ms |

The superuser/`breeze_app` split on the *same query and index* is the proof this is the leakproof rule, not index shape or statistics. `uuid_eq` **is** leakproof, which is why the `resource_id` arm indexes fine.

Fix: filter on the device's `org_id` first — leakproof and indexable, bounding the scan to one org via the existing `audit_logs_org_timestamp_idx`. **11,938 ms → 178 ms (~67×)**; the `withTotal` count path inherits it.

Note `2026-05-17-c-audit-logs-scale-indexes.sql` predicted "the existing 170ms scan becomes ~24 seconds" without indexes. BREEZE-B's 25.8s is that prediction arriving anyway, because the index added for this exact query is unusable under RLS.

**Visibility is unchanged for affected users:** `breeze_has_org_access(NULL)` returns FALSE, so audit rows written with a null `org_id` (some agent paths use `orgId ?? null`) are *already* invisible to every org- and partner-scope caller. It does narrow system-scope callers, which previously saw null-org rows; a device's feed showing only its own org's rows is the intended semantics.

## Verification

- Typecheck clean; **17,033 unit tests pass**.
- BREEZE-10: reproduced the 42501 as `breeze_app` (including for an existing partition); full migration set applies as a genuine non-superuser; new integration test drives the real `breeze_app` pool and asserts `current_user` first so it cannot pass vacuously. **Negative control: restoring the inline DDL fails all 3 tests with the production 42501.**
- BREEZE-3: `deadlockRetry.integration.test.ts` induces a genuine two-backend 40P01 — the competitor reaches for the second row only once `pg_locks` confirms the other side is actually blocked, so it's deterministic rather than a race — and asserts a 40P01 was really observed and `attempts > 1`.
- BREEZE-B: unit test pins the predicate and is negative-tested (removing it fails the assertion), since a silent regression reverts straight to a seq scan in production.
- One benchmark run initially reported `rows=0` and I nearly drew conclusions from it: the RLS org list was empty because the subquery populating the GUC was *itself* RLS-blocked. Recomputed as superuser and injected, giving 120 visible target rows — the numbers above are from that corrected run.

## Deploy ordering

The BREEZE-10 commit ships migration `2026-08-05-metric-rollup-partition-maintenance-privileges.sql`. **It must be applied before the maintenance job next fires**, or the job still fails — just with "function does not exist" instead of 42501. The migration's bootstrap block converges the current window at apply time, but the recurring path only proves itself on a real 03:15 tick, so that run is worth watching after deploy.

## Follow-ups, deliberately not bundled

- **BREEZE-A** (~7k events, agent WS) is not diagnosable as-is. The 10005ms figure is **not** `AGENT_PONG_TIMEOUT_MS` — that's a `setInterval`, never awaited inside a context. The 14 WS contexts are correctly scoped per message; the minified stack only says `onMessage`. Labelling all 14 `runWithAgentDbAccess` call sites is the next step and belongs where it can be exercised against a real agent.
- **`audit_logs.device_id` denormalization** is the durable BREEZE-B fix — both arms become leakproof equality and the OR can bitmap-or two indexes. Blocked on a batched backfill against an append-only table whose immutability trigger *rejects UPDATEs*; a generated column would force a full rewrite under `ACCESS EXCLUSIVE` on a hot table.
- **Remaining `device_vulnerabilities` writers** still take locks in plan order. Postgres has no `ORDER BY` on `UPDATE`, so making them deterministic means a pre-locking select each. The retry covers them meanwhile.
- **Leakproof sweep**, generalizing BREEZE-B: any index on a JSONB extraction, `ILIKE`, or similar non-leakproof expression over an RLS-forced table is likely dead weight on the app connection. There may be more silent seq scans of this shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
