### PR TITLE
docs: false-positive guidance for signed agent binaries + correct #1158 status

### DIFF
--- a/apps/docs/src/content/docs/deploy/antivirus-exceptions.mdx
+++ b/apps/docs/src/content/docs/deploy/antivirus-exceptions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Antivirus Exceptions
-description: Required antivirus and security software exclusions for the Breeze agent when using unsigned binaries.
+description: Antivirus and security software exclusions for the Breeze agent, plus how to report a false positive on a signed binary.
 sidebar:
   order: 6
   label: Antivirus Exceptions
@@ -8,10 +8,14 @@ sidebar:
 
 import { Tabs, TabItem, Steps, Aside } from '@astrojs/starlight/components';
 
-When deploying the Breeze agent **without code-signed binaries**, endpoint protection software may flag, quarantine, or block the agent. This guide covers the exclusions needed for each platform.
+Endpoint protection software may flag, quarantine, or block the Breeze agent. This guide covers the exclusions needed for each platform, and what to do when a *signed* binary is flagged.
 
 <Aside type="caution">
-  Unsigned binaries are common during development, self-hosted builds, and early deployments. For production fleets, consider signing your binaries to avoid the need for broad AV exclusions. See [Building from Source](/agents/building/) for build instructions.
+  Unsigned binaries are common during development, self-hosted builds, and early deployments, and are the most common cause of AV interference. For production fleets, consider signing your binaries to avoid the need for broad AV exclusions. See [Building from Source](/agents/building/) for build instructions.
+</Aside>
+
+<Aside type="note">
+  Agent binaries from official Breeze releases **are** code-signed. If one of those is being quarantined, exclusions are a workaround rather than the fix. See [Signed Binaries Flagged as Malware](#signed-binaries-flagged-as-malware) below.
 </Aside>
 
 ## Why Exclusions Are Needed
@@ -25,6 +29,54 @@ The Breeze agent is a single Go binary that:
 - Reads **hardware and software inventory** from the system
 
 These behaviors overlap with patterns that heuristic-based antivirus engines flag as suspicious. Without code signing, there is no publisher reputation to offset the heuristic score.
+
+## Signed Binaries Flagged as Malware
+
+Agent binaries published in official Breeze releases are Authenticode-signed on Windows and codesigned/notarized on macOS. A signed binary being quarantined is a **false positive**, and adding an exclusion treats the symptom rather than the cause.
+
+### Step 1: Confirm the binary is actually signed
+
+Do this before anything else. A binary from a development build, a fork, or a self-hosted build pipeline will not be signed, and the rest of this section does not apply to it.
+
+```powershell
+# Windows
+Get-AuthenticodeSignature "C:\Program Files\Breeze\breeze-agent.exe" | Format-List Status, SignerCertificate
+```
+
+```bash
+# macOS
+codesign --verify --deep --strict --verbose=2 /usr/local/bin/breeze-agent
+spctl --assess --type execute --verbose /usr/local/bin/breeze-agent
+```
+
+If Windows reports `NotSigned`, or macOS reports the binary is not signed, that binary did not come from an official release. Reinstall from an official release before pursuing a false-positive report.
+
+### Step 2: Read the detection name
+
+Machine-learning verdicts end in `!ml` (for example `Trojan:Script/Wacatac.B!ml`). These are heuristic scores, not signature matches, and are the detection class most likely to be a false positive on a legitimate RMM agent.
+
+Several normal agent behaviors contribute to that score: writing PowerShell scripts to a temporary directory and executing them with `-ExecutionPolicy Bypass`, downloading a replacement binary during self-update, and running as SYSTEM while spawning processes into user sessions. Every remote management tool does some version of this.
+
+### Step 3: Report the false positive to the vendor
+
+Reporting it is what actually fixes the problem, for you and for everyone else running the same version. Include the detection name, the agent version, and the file hash.
+
+| Vendor | Submission channel |
+|---|---|
+| Microsoft Defender | [Microsoft Security Intelligence submission portal](https://www.microsoft.com/en-us/wdsi/filesubmission) — choose **Software developer** and note that the file is signed |
+| CrowdStrike Falcon | Support portal detection review, or ask your CS rep for a certificate-based exclusion |
+| SentinelOne | Support ticket referencing the signing certificate |
+| Other vendors | Most maintain a "submit a false positive" form; search for the vendor name plus "false positive submission" |
+
+Please also open an issue on the [Breeze repository](https://github.com/LanternOps/breeze/issues) with the detection name and agent version, so the same submission can be made centrally.
+
+### Step 4: Add a temporary exclusion
+
+Use the platform sections below to unblock the fleet while the vendor submission is processed, then remove the exclusion once the detection is retired.
+
+<Aside type="caution">
+  **Attack Surface Reduction (ASR) rules do not honour standard AV exclusions.** If Defender is blocking the agent through an ASR rule rather than real-time protection, the exclusions in this guide will have no effect. Check the Windows Defender operational event log for ASR block events (event IDs 1121 and 1122) and configure a per-rule exclusion instead. The rules most likely to fire are "Block process creations originating from PSExec and WMI commands" and "Block credential stealing from LSASS".
+</Aside>
 
 ## Paths to Exclude
 
@@ -293,7 +345,7 @@ Common symptoms of AV interference:
 
 | Symptom | Likely Cause |
 |---|---|
-| Agent binary deleted or moved to quarantine | Real-time scan flagging the unsigned binary |
+| Agent binary deleted or moved to quarantine | Real-time scan flagging the binary — if it is signed, see [Signed Binaries Flagged as Malware](#signed-binaries-flagged-as-malware) |
 | Agent service starts then stops immediately | On-execution scan blocking the process |
 | Intermittent WebSocket disconnections | Network inspection blocking persistent connections |
 | Script execution failures | Behavior-based detection blocking child processes |

--- a/docs/superpowers/plans/pam/2026-07-03-pam-path-b-token-launch-actuator.md
+++ b/docs/superpowers/plans/pam/2026-07-03-pam-path-b-token-launch-actuator.md
@@ -741,7 +741,7 @@ Create the file with:
 - **Case A (approve/launch):** standard user launches the target → Breeze auto-approves → assert: native consent.exe does not survive, target runs elevated (Task Manager: elevated, running as `~breeze_elev`), process is visible on the user's desktop (not session 0).
 - **Case B (deny/block):** rule set to auto-deny → target does not launch, consent.exe dismissed.
 - **Case C (lifecycle):** after each case, assert `~breeze_elev` is NOT in Administrators and its password was re-randomized (`net localgroup administrators`).
-- **Case D (CVE-2026-20824 / EDR):** run with the customer EDR stack present; confirm no consent.exe deadlock and no EDR block of the `CreateProcessAsUser` launch (cross-check the #1158 allowlist submissions).
+- **Case D (CVE-2026-20824 / EDR):** run with the customer EDR stack present; confirm no consent.exe deadlock and no EDR block of the `CreateProcessAsUser` launch. Note that no allowlist submissions exist yet — #1158 is open and unimplemented — so this case is a genuine empirical test, not a confirmation of prior coverage.
 - **Result reason codes to watch in agent logs:** `ok`, `logon_failed`, `set_session_failed`, `desktop_grant_failed`, `create_process_failed`, `session_lookup_failed`, `empty_target`.
 
 - [ ] **Step 2: Execute the matrix on the VM**

--- a/docs/superpowers/plans/pam/2026-07-03-pam-path-b-vm-validation.md
+++ b/docs/superpowers/plans/pam/2026-07-03-pam-path-b-vm-validation.md
@@ -97,7 +97,7 @@ replacement for it.
 - [ ] **C — `~breeze_elev` lifecycle:** after A and after B, run `net localgroup administrators` → `~breeze_elev` is **not** a member; confirm the account is disabled and its password was re-randomized (demote ran).
 - [ ] **D — Failure demotes:** force a launch failure (e.g. bogus target path) → agent logs a failure reason; `~breeze_elev` is still demoted (mirrors the CI test `TestTokenLaunchFailureStillDemotes`).
 - [ ] **E — RDP / multi-session:** repeat A from an **RDP** session → the elevated process appears in the **RDP user's** session, not the console. (This is the case the session-resolution decision above must satisfy.)
-- [ ] **F — EDR / CVE-2026-20824:** run A with the customer EDR stack present → no `consent.exe` deadlock; the `CreateProcessAsUser` launch is not blocked. Cross-check the #1158 EDR-allowlist submissions cover the new launch pattern.
+- [ ] **F — EDR / CVE-2026-20824:** run A with the customer EDR stack present → no `consent.exe` deadlock; the `CreateProcessAsUser` launch is not blocked. No EDR-allowlist submissions exist yet (#1158 is open and unimplemented), so treat this as an unprotected baseline measurement.
 
 ## Result reason codes to watch in agent logs
 

--- a/docs/superpowers/specs/pam/2026-07-03-pam-path-b-token-launch-actuator-design.md
+++ b/docs/superpowers/specs/pam/2026-07-03-pam-path-b-token-launch-actuator-design.md
@@ -130,8 +130,10 @@ implementing the existing `Actuator` interface. Everything else — discovery, d
    the credential-UI path. The SYSTEM-context injection path is not explicitly named as blocked, but
    Path B's `Dismiss` (suppression) touches consent.exe input — verify empirically on the VM matrix.
 5. **EDR scrutiny.** `CreateProcessAsUser` from SYSTEM to a freshly-promoted hidden admin account is
-   a behavior AV/EDR may flag. The existing EDR-allowlist work (#1158) covers the broker binary;
-   confirm the new launch pattern is within the submitted exclusions.
+   a behavior AV/EDR may flag. **There is no EDR-allowlist coverage today** — #1158 was closed
+   unimplemented on 2026-06-27 and reopened on 2026-07-25 after a Defender false positive was
+   reported in the field. Assume the launch pattern is unprotected until those vendor submissions
+   are actually filed, and validate empirically on the VM matrix.
 
 ## AP boundary (explicit)
 


### PR DESCRIPTION
## Why

A field report (Discord, 2026-07-25) of Microsoft Defender quarantining a signed `breeze-agent.exe` as `Trojan:Script/Wacatac.B!ml` exposed two documentation gaps. Full analysis in #1158, which is reopened.

## What changed

**`apps/docs/src/content/docs/deploy/antivirus-exceptions.mdx`** was framed entirely around *unsigned* binaries — the frontmatter description, the opening sentence, the caution aside, and the symptom table all assumed that. An operator hitting a false positive on an official signed release had no path in the docs other than adding a broad exclusion, which treats the symptom and leaves the detection in place for everyone else on that version.

Adds a **Signed Binaries Flagged as Malware** section, ordered as the four steps an operator should actually take:

1. Confirm the binary is signed (`Get-AuthenticodeSignature` / `codesign --verify`). A dev build, fork build, or self-hosted pipeline build is unsigned and is a different problem entirely — worth ruling out before anything else.
2. Read the detection name. An `!ml` suffix is a machine-learning score, not a signature match. Names the agent behaviours that plausibly feed that score (scripts written to temp and run with `-ExecutionPolicy Bypass`, self-update download-and-swap, SYSTEM spawning into user sessions) so the operator understands why a legitimate RMM agent trips it.
3. Report to the vendor, with a submission-channel table and the WDSI portal link. This is the step that actually retires the detection.
4. Add a temporary exclusion as a stopgap, with a caution that **ASR rules do not honour standard AV exclusions** — if ASR is what fires, the rest of the guide has no effect, and the reader needs the operational event log (1121/1122) and a per-rule exclusion instead.

Also reframes the intro so the page no longer claims to be unsigned-only, and points the "binary quarantined" symptom row at the new section.

**Three PAM documents** asserted the EDR-allowlist work in #1158 had shipped and instructed the reader to cross-check their launch pattern against submitted exclusions:

- `docs/superpowers/specs/pam/2026-07-03-pam-path-b-token-launch-actuator-design.md:133`
- `docs/superpowers/plans/pam/2026-07-03-pam-path-b-vm-validation.md:100`
- `docs/superpowers/plans/pam/2026-07-03-pam-path-b-token-launch-actuator.md:744`

#1158 was closed unimplemented on 2026-06-27 and reopened 2026-07-25; no submissions exist. Left as-is, a future validation pass would have recorded "EDR case cross-checked" against nothing. Corrected to state that the VM matrix EDR case is an unprotected baseline measurement.

## Verification

`pnpm --filter @breeze/docs check` — 4 files, 0 errors, 0 warnings, 0 hints.
`pnpm --filter @breeze/docs build` — 148 pages built, complete.
Anchor resolves in the built output: `id="signed-binaries-flagged-as-malware"` present, 4 references.

Docs only, no code changes.

Refs #1158

🤖 Generated with [Claude Code](https://claude.com/claude-code)