### PR TITLE
fix(api): label agent-WS DB contexts so BREEZE-A is triageable

### DIFF
--- a/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
@@ -18,18 +18,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // vi.spyOn on the module object does not intercept it. Mock the module so the
 // held-context capture is observable. Only the attribution test asserts on it;
 // every other test here observes console.warn, which is untouched.
-const capturedMessages: Array<{ message: string; extra?: Record<string, unknown> }> = [];
+const capturedMessages: Array<{
+  message: string;
+  extra?: Record<string, unknown>;
+  tags?: Record<string, string>;
+}> = [];
 vi.mock('../../services/sentry', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../services/sentry')>();
   return {
     ...actual,
-    captureMessage: (message: string, _level?: unknown, extra?: Record<string, unknown>) => {
-      capturedMessages.push({ message, extra });
+    captureMessage: (
+      message: string,
+      _level?: unknown,
+      extra?: Record<string, unknown>,
+      tags?: Record<string, string>,
+    ) => {
+      capturedMessages.push({ message, extra, tags });
     },
   };
 });
 
 import {
+  withDbAccessContext,
   withSystemDbAccessContext,
   runOutsideDbContext,
   assertOutsideHeldDbContext,
@@ -144,6 +154,53 @@ describe('#1105 DB-context tripwires', () => {
       // The opener's own frame must be present. Before the fix this field did
       // not exist and `stack` contained only the await trampoline.
       expect(String(extra?.openedAt)).toContain('theCulpritThatHoldsTheConnection');
+    });
+
+    it('emits the context label as a Sentry TAG and in the message (BREEZE-A triage fix)', async () => {
+      process.env.DB_CONTEXT_HELD_WARN_MS = '50';
+      process.env.DB_CONTEXT_HELD_CAPTURE_THROTTLE_MS = '0';
+      __resetHeldContextCaptureThrottleForTests();
+
+      await withDbAccessContext(
+        {
+          scope: 'organization',
+          orgId: null,
+          accessibleOrgIds: [],
+          accessiblePartnerIds: [],
+          currentPartnerId: null,
+          label: 'agentWs.heartbeat',
+        },
+        async () => {
+          await new Promise((resolve) => setTimeout(resolve, 90));
+        },
+      );
+
+      expect(capturedMessages).toHaveLength(1);
+      // The TAG is the load-bearing part: extras are only visible inside a
+      // single event, so an unfilterable bucket (BREEZE-A, ~7k events) stays
+      // unfilterable if the label only lands in `extra`.
+      expect(capturedMessages[0]!.tags).toEqual({ dbContextLabel: 'agentWs.heartbeat' });
+      // Also in the message, because Sentry groups by message — that is what
+      // splits one bucket into per-handler issues.
+      expect(capturedMessages[0]!.message).toContain('[agentWs.heartbeat]');
+    });
+
+    it('omits the tag entirely for an unlabelled context, leaving the message text unchanged', async () => {
+      // Grouping stability: every existing caller is unlabelled, so their
+      // message must be byte-identical to before this change or their Sentry
+      // history splits into a new issue for no reason.
+      process.env.DB_CONTEXT_HELD_WARN_MS = '50';
+      process.env.DB_CONTEXT_HELD_CAPTURE_THROTTLE_MS = '0';
+      __resetHeldContextCaptureThrottleForTests();
+
+      await withSystemDbAccessContext(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 90));
+      });
+
+      expect(capturedMessages).toHaveLength(1);
+      expect(capturedMessages[0]!.tags).toBeUndefined();
+      expect(capturedMessages[0]!.message).toContain('withDbAccessContext (scope=system) held');
+      expect(capturedMessages[0]!.message).not.toContain('[');
     });
 
     it('still warns when fn THROWS after holding the context too long (the finally path)', async () => {

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -143,6 +143,21 @@ export interface DbAccessContext {
    * apply.
    */
   currentPartnerId?: string | null;
+  /**
+   * Short, low-cardinality name for the code path that opened this context,
+   * e.g. `agentWs.heartbeat`. Purely diagnostic — it grants nothing and is
+   * never sent to Postgres. Emitted as the `dbContextLabel` Sentry tag on the
+   * #1105 held-connection warning so a recurring hold can be broken down by
+   * source instead of arriving as one opaque bucket.
+   *
+   * Why this exists: BREEZE-A accumulated ~7k held-context warnings from the
+   * agent WebSocket that were impossible to act on, because all 12 contexts
+   * there funnel through ONE helper closure and every production frame minifies
+   * to an anonymous arrow inside `onMessage`. The stack alone cannot tell
+   * `heartbeat` from `command_result`. Set this wherever several distinct paths
+   * share a context helper.
+   */
+  label?: string;
 }
 
 export const SYSTEM_DB_ACCESS_CONTEXT: DbAccessContext = {
@@ -289,8 +304,14 @@ export async function withDbAccessContext<T>(
         if (warnMs > 0) {
           const heldMs = Date.now() - startedAt;
           if (heldMs >= warnMs) {
+            // The label goes in the MESSAGE, not just the tag: Sentry groups by
+            // message, so including it splits one bucket into per-source issues
+            // that can be resolved independently. Unlabelled callers keep the
+            // exact previous message text, so their existing grouping is not
+            // disturbed by this change.
+            const labelPart = context.label ? ` [${context.label}]` : '';
             const message =
-              `withDbAccessContext (scope=${context.scope}) held a pooled connection in an open `
+              `withDbAccessContext (scope=${context.scope})${labelPart} held a pooled connection in an open `
               + `transaction for ${heldMs}ms (>= ${warnMs}ms) — long enough that it likely did slow `
               + `non-DB work (Redis/HTTP/loops) or a slow query inside the context. If the former, `
               + `move it after the context closes or wrap it in runOutsideDbContext (#1105).`;
@@ -307,7 +328,7 @@ export async function withDbAccessContext<T>(
                 // dropping a field silently is worse than an extra one.
                 openedAt: opener?.stack,
                 stack: new Error().stack,
-              });
+              }, context.label ? { dbContextLabel: context.label } : undefined);
             }
           }
         }

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1838,7 +1838,19 @@ async function processCommandResult(
 export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentDbContext) {
   const agentDb = preValidatedAgent;
 
-  const runWithAgentDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  /**
+   * `label` is REQUIRED, and deliberately so. Every context on this socket
+   * funnels through this one closure, so in a minified production build all of
+   * them collapse to an anonymous arrow inside `onMessage` — the #1105
+   * held-connection warning could not name which agent message was responsible.
+   * That is how BREEZE-A became ~7k events that could not be triaged. A
+   * required parameter means a handler added later cannot silently rejoin that
+   * pile: it will not compile without a label.
+   *
+   * Keep labels stable and low-cardinality (a handler name, never an id or
+   * sessionId) — they become a Sentry tag and part of the grouping message.
+   */
+  const runWithAgentDbAccess = async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
     return withDbAccessContext(
       {
         scope: 'organization',
@@ -1848,7 +1860,8 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
         accessiblePartnerIds: [],
         // Agents don't browse the catalog as org users; null disables the
         // partner-wide read branch (safe).
-        currentPartnerId: null
+        currentPartnerId: null,
+        label
       },
       fn
     );
@@ -1894,14 +1907,14 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
       // HTTP heartbeat claim (the agent heartbeats immediately on startup)
       // and executeCommand's direct per-command push while the socket is
       // live.
-      await runWithAgentDbAccess(async () => {
+      await runWithAgentDbAccess('agentWs.onOpen.markOnline', async () => {
         await updateDeviceStatus(agentId, 'online');
       });
 
       // Publish device.online event for real-time UI updates
       if (agentDb) {
         try {
-          const [deviceInfo] = await runWithAgentDbAccess(async () =>
+          const [deviceInfo] = await runWithAgentDbAccess('agentWs.onOpen.loadDevice', async () =>
             db.select({ id: devices.id, siteId: devices.siteId, hostname: devices.hostname, agentVersion: devices.agentVersion })
               .from(devices)
               .where(eq(devices.agentId, agentId))
@@ -2051,7 +2064,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
         // Handle update_status messages: agent is about to self-update
         if (message.type === 'update_status' && typeof message.targetVersion === 'string') {
           if (agentDb) {
-            await runWithAgentDbAccess(async () => {
+            await runWithAgentDbAccess('agentWs.updateStatus', async () => {
               try {
                 // Same terminal-status guard as updateDeviceStatus (#2230):
                 // this write must not resurrect a decommissioned/quarantined
@@ -2141,7 +2154,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
                 : null;
             if (sessionId && fastResult.event === 'peer_disconnected') {
               try {
-                await runWithAgentDbAccess(async () => {
+                await runWithAgentDbAccess('agentWs.desktop.peerDisconnected', async () => {
                   const result = await db
                     .update(remoteSessions)
                     .set({ status: 'disconnected', endedAt: new Date() })
@@ -2185,7 +2198,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
             const reason = typeof fastResult.reason === 'string' ? fastResult.reason : 'no_user';
             if (sessionId) {
               try {
-                await runWithAgentDbAccess(async () => {
+                await runWithAgentDbAccess('agentWs.desktop.consentDenied', async () => {
                   const [updated] = await db
                     .update(remoteSessions)
                     .set({ status: 'denied', endedAt: new Date() })
@@ -2238,7 +2251,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
             const answer = typeof fastResult.answer === 'string' ? fastResult.answer : null;
             if (sessionId && answer && answer.length < 65536) {
               try {
-                await runWithAgentDbAccess(async () => {
+                await runWithAgentDbAccess('agentWs.desktop.webrtcAnswer', async () => {
                   const [updated] = await db
                     .update(remoteSessions)
                     .set({
@@ -2305,7 +2318,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
             );
             if (sessionId) {
               try {
-                await runWithAgentDbAccess(async () => {
+                await runWithAgentDbAccess('agentWs.desktop.captureFailed', async () => {
                   const result = await db
                     .update(remoteSessions)
                     .set({
@@ -2357,7 +2370,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
 
         switch (parsed.data.type) {
           case 'command_result':
-            await runWithAgentDbAccess(async () =>
+            await runWithAgentDbAccess('agentWs.commandResult', async () =>
               processCommandResult(agentId, parsed.data as z.infer<typeof commandResultSchema>, authenticatedAgent.deviceId, authenticatedAgent.orgId)
             );
             ws.send(JSON.stringify({
@@ -2368,7 +2381,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
 
           case 'backup_progress': {
             const progressMessage = parsed.data as z.infer<typeof backupProgressMessageSchema>;
-            await runWithAgentDbAccess(async () => {
+            await runWithAgentDbAccess('agentWs.backupProgress', async () => {
               const applied = await applyBackupProgress({
                 agentId,
                 commandId: progressMessage.commandId,
@@ -2415,7 +2428,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
               }
 
             // Update last seen timestamp
-              await runWithAgentDbAccess(async () => {
+              await runWithAgentDbAccess('agentWs.heartbeat', async () => {
                 await updateDeviceStatus(agentId, 'online');
                 if (heartbeatMessage.ipHistoryUpdate) {
                   if (heartbeatMessage.ipHistoryUpdate.deviceId && heartbeatMessage.ipHistoryUpdate.deviceId !== authenticatedAgent.deviceId) {
@@ -2518,7 +2531,7 @@ onClose: async (_event: unknown, ws: WSContext) => {
         // Update device status to offline (but preserve 'updating' — let
         // the offline detector handle the timeout for stale updating devices)
         if (agentDb) {
-          await runWithAgentDbAccess(async () => {
+          await runWithAgentDbAccess('agentWs.onClose.markOffline', async () => {
             try {
               const [current] = await db
                 .select({ id: devices.id, siteId: devices.siteId, status: devices.status, hostname: devices.hostname })
@@ -2572,7 +2585,7 @@ if (activeConnections.get(agentId) === ws) {
         activeConnections.delete(agentId);
       }
       if (agentDb) {
-        void runWithAgentDbAccess(async () => {
+        void runWithAgentDbAccess('agentWs.onError.markOffline', async () => {
           try {
             const [current] = await db
               .select({ status: devices.status })

--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -10,13 +10,22 @@ const flushMock = vi.fn().mockResolvedValue(true);
 const setTagMock = vi.fn();
 const setUserMock = vi.fn();
 const moduleSetTagMock = vi.fn();
+const captureMessageMock = vi.fn();
+const setLevelMock = vi.fn();
+const setExtrasMock = vi.fn();
 const withScopeMock = vi.fn((cb: (scope: unknown) => void) =>
-  cb({ setTag: setTagMock, setContext: vi.fn() }),
+  cb({
+    setTag: setTagMock,
+    setContext: vi.fn(),
+    setLevel: setLevelMock,
+    setExtras: setExtrasMock,
+  }),
 );
 
 vi.mock('@sentry/node', () => ({
   init: (...args: unknown[]) => initMock(...args),
   captureException: (...args: unknown[]) => captureMock(...args),
+  captureMessage: (...args: unknown[]) => captureMessageMock(...args),
   flush: (...args: unknown[]) => flushMock(...args),
   withScope: (cb: (scope: unknown) => void) => withScopeMock(cb),
   setUser: (...args: unknown[]) => setUserMock(...args),
@@ -33,6 +42,9 @@ describe('sentry service', () => {
     flushMock.mockClear();
     setTagMock.mockClear();
     withScopeMock.mockClear();
+    captureMessageMock.mockClear();
+    setLevelMock.mockClear();
+    setExtrasMock.mockClear();
     process.env = { ...ORIGINAL_ENV };
   });
 
@@ -55,6 +67,35 @@ describe('sentry service', () => {
     const initArg = initMock.mock.calls[0]![0] as { release?: string; dsn?: string };
     expect(initArg.release).toBe('9.9.9-test');
     expect(initArg.release).not.toBe('0.64.1');
+  });
+
+  it('captureMessage applies tags to the scope so recurring warnings are filterable', async () => {
+    // Tags, unlike extras, drive Sentry's search and "break down by" UI. This is
+    // what makes a recurring held-context warning attributable to one handler
+    // instead of arriving as a single opaque bucket (BREEZE-A).
+    process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
+    const { initSentry, captureMessage } = await import('./sentry');
+    initSentry();
+
+    captureMessage('held a pooled connection', 'warning', { heldMs: 12000 }, {
+      dbContextLabel: 'agentWs.heartbeat',
+    });
+
+    expect(captureMessageMock).toHaveBeenCalledWith('held a pooled connection');
+    expect(setTagMock).toHaveBeenCalledWith('dbContextLabel', 'agentWs.heartbeat');
+    expect(setLevelMock).toHaveBeenCalledWith('warning');
+    expect(setExtrasMock).toHaveBeenCalledWith({ heldMs: 12000 });
+  });
+
+  it('captureMessage sets no tags when none are passed (existing callers unaffected)', async () => {
+    process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
+    const { initSentry, captureMessage } = await import('./sentry');
+    initSentry();
+
+    captureMessage('plain warning');
+
+    expect(captureMessageMock).toHaveBeenCalledWith('plain warning');
+    expect(setTagMock).not.toHaveBeenCalled();
   });
 
   it('does not initialize the SDK when no DSN is configured', async () => {

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -122,10 +122,22 @@ export function captureException(
   });
 }
 
+/**
+ * `tags` mirrors captureException's third parameter. Prefer it over `extra` for
+ * any low-cardinality discriminator you will want to GROUP BY in Sentry: extras
+ * are only visible once you open an individual event, while tags are
+ * searchable and drive the "break down by" UI. Attributing a recurring warning
+ * to its source is exactly that job — an unfilterable 7k-event bucket
+ * (BREEZE-A) is what happens without it.
+ *
+ * Keep tag values low-cardinality (a handler name, not an id) — high-cardinality
+ * tags inflate Sentry's index without making anything more triageable.
+ */
 export function captureMessage(
   message: string,
   level: 'info' | 'warning' | 'error' = 'warning',
-  extra?: Record<string, unknown>
+  extra?: Record<string, unknown>,
+  tags?: Record<string, string>
 ): void {
   if (!initialized) {
     return;
@@ -134,6 +146,9 @@ export function captureMessage(
   Sentry.withScope((scope) => {
     scope.setLevel(level);
     scope.setExtras(extra ?? {});
+    if (tags) {
+      for (const [key, value] of Object.entries(tags)) scope.setTag(key, value);
+    }
     Sentry.captureMessage(message);
   });
 }


### PR DESCRIPTION
Follow-up to #2786. BREEZE-A is ~7k held-connection warnings (#1105) from the agent WebSocket that **cannot be triaged at all**, and this makes them attributable.

## Why the stack isn't enough

All 12 DB contexts in `agentWs.ts` funnel through one helper closure:

```ts
const runWithAgentDbAccess = async <T>(fn: () => Promise<T>) =>
  withDbAccessContext({ scope: 'organization', orgId: agentDb.orgId, ... }, fn);
```

In the minified production bundle every call site is an anonymous arrow inside `onMessage`, so the captured stack cannot tell `heartbeat` from `command_result` from a desktop-consent write. "Break down by handler" is the entire first triage step and it was impossible.

## The change

| | |
|---|---|
| `DbAccessContext.label` | new, optional. Purely diagnostic — grants nothing, never sent to Postgres |
| #1105 warning | emits `dbContextLabel` as a Sentry **tag** *and* inside the message |
| `captureMessage()` | gains a `tags` param, mirroring `captureException`'s existing third param |
| `runWithAgentDbAccess` | label is a **required** first param; all 12 sites named |

Both the tag and the message placement matter, for different reasons: **tags** drive Sentry's search and break-down-by UI (extras are only visible once you open an individual event), while the **message** is what Sentry groups on — so including it splits one opaque bucket into per-handler issues that can be resolved independently.

The label is **required**, not optional, so a handler added later cannot silently rejoin the unattributable pile — it won't compile without one.

Labels applied:

`agentWs.onOpen.markOnline`, `agentWs.onOpen.loadDevice`, `agentWs.updateStatus`, `agentWs.desktop.peerDisconnected`, `agentWs.desktop.consentDenied`, `agentWs.desktop.webrtcAnswer`, `agentWs.desktop.captureFailed`, `agentWs.commandResult`, `agentWs.backupProgress`, `agentWs.heartbeat`, `agentWs.onClose.markOffline`, `agentWs.onError.markOffline`

## Honest scope

**This is diagnosis, not a fix.** It will not reduce the 7k events. It tells us which handler pins a pooled connection past 10s so the real cause can be found — and that cause could be in any of those handlers, which is precisely why guessing at a fix was the wrong move.

Also worth restating: the 10005ms in BREEZE-A is **not** `AGENT_PONG_TIMEOUT_MS`. That's a `setInterval` and is never awaited inside a context.

## Grouping stability

Unlabelled contexts keep the previous message text **byte-for-byte** and emit no tag, so every existing caller's Sentry history stays in its current issue rather than forking a new one for no reason. A test pins this.

## Verification

- Typecheck clean, lint clean, **17,151 unit tests pass**.
- Real Postgres: `dbContextTripwire` (13 tests), `deadlockRetry`, and `agentWs-consent-ingest` all pass — the last exercises one of the labelled desktop paths for real.
- Grep-verified: zero remaining `runWithAgentDbAccess(async`, and all 12 labels unique.

**Negative controls, both run and both confirmed failing without the change:**

- Neutralising the label in the message + tag → new integration test fails.
- Removing the tag loop from `captureMessage` → new unit test fails.

My first attempt at the second control was **invalid** and I want that on the record: the regex matched `captureException`'s byte-identical `if (tags)` block instead of `captureMessage`'s, so the test "passed" against unmutated code. Retargeted and re-run; it then failed as expected.

**Not verifiable before deploy, by definition:** only production traffic will show BREEZE-A actually splitting into per-handler issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
