### PR TITLE
feat(api): billing identity abuse signals and suspended-partner subscription invariant

### DIFF
--- a/apps/api/migrations/2026-07-25-partner-billing-identity.sql
+++ b/apps/api/migrations/2026-07-25-partner-billing-identity.sql
@@ -1,0 +1,38 @@
+-- Billing identity snapshot on `partners`, consumed by the abuse sweep
+-- (services/abuseSignals/billingIdentity.ts) for:
+--   * billing.cardholder_name_mismatch
+--   * billing.shared_card_fingerprint  (cross-partner correlation)
+--   * billing.card_testing
+--   * invariant.suspended_partner_active_subscription
+--
+-- WRITE SIDE: these columns are populated by the separate billing service from
+-- its payment-provider webhooks. The API only ever READS them — nothing in this
+-- repo writes them, and the sweep never calls the payment provider.
+--
+-- Deliberately columns on `partners` rather than a new table: `partners`
+-- already carries RLS + policies and is already registered in every cascade
+-- list, so a nullable-column extension adds no new tenancy surface.
+--
+-- NOT added to partnerPublicColumns() in routes/orgs.ts — cardholder name and
+-- card fingerprint must never be projected to a partner-scoped token.
+--
+-- billing_card_fingerprint is NULL for wallet/Link-style payments that expose
+-- no card fingerprint, so it is a partial signal by construction; the readers
+-- treat NULL as "unknown", never as a value that can match another NULL.
+--
+-- Idempotent; no inner BEGIN/COMMIT (autoMigrate wraps each file).
+
+ALTER TABLE partners
+  ADD COLUMN IF NOT EXISTS billing_cardholder_name          text,
+  ADD COLUMN IF NOT EXISTS billing_card_country             char(2),
+  ADD COLUMN IF NOT EXISTS billing_card_fingerprint         text,
+  ADD COLUMN IF NOT EXISTS billing_distinct_payment_methods integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS billing_failed_attempts          integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS billing_identity_synced_at       timestamptz,
+  ADD COLUMN IF NOT EXISTS billing_subscription_status      text;
+
+-- Partial index: the shared-fingerprint correlation groups over non-NULL
+-- fingerprints across ALL partners, and the vast majority of rows are NULL.
+CREATE INDEX IF NOT EXISTS partners_billing_card_fingerprint_idx
+  ON partners (billing_card_fingerprint)
+  WHERE billing_card_fingerprint IS NOT NULL;

--- a/apps/api/migrations/2026-07-25-partner-billing-identity.sql
+++ b/apps/api/migrations/2026-07-25-partner-billing-identity.sql
@@ -22,14 +22,23 @@
 --
 -- Idempotent; no inner BEGIN/COMMIT (autoMigrate wraps each file).
 
+-- billing_payment_methods_first_seen_at / _last_seen_at bound the interval the
+-- distinct-method count was accumulated over. billing.card_testing fires on
+-- that SPAN, not on the count alone: "3 distinct cards in 7 minutes" and "3
+-- distinct cards over 2 years" are the same count and completely different
+-- events. Both are nullable, and a NULL span is never treated as a zero span —
+-- the detector fails closed so legacy rows and un-backfilled partners cannot
+-- fire on deploy day.
 ALTER TABLE partners
-  ADD COLUMN IF NOT EXISTS billing_cardholder_name          text,
-  ADD COLUMN IF NOT EXISTS billing_card_country             char(2),
-  ADD COLUMN IF NOT EXISTS billing_card_fingerprint         text,
-  ADD COLUMN IF NOT EXISTS billing_distinct_payment_methods integer NOT NULL DEFAULT 0,
-  ADD COLUMN IF NOT EXISTS billing_failed_attempts          integer NOT NULL DEFAULT 0,
-  ADD COLUMN IF NOT EXISTS billing_identity_synced_at       timestamptz,
-  ADD COLUMN IF NOT EXISTS billing_subscription_status      text;
+  ADD COLUMN IF NOT EXISTS billing_cardholder_name               text,
+  ADD COLUMN IF NOT EXISTS billing_card_country                  char(2),
+  ADD COLUMN IF NOT EXISTS billing_card_fingerprint              text,
+  ADD COLUMN IF NOT EXISTS billing_distinct_payment_methods      integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS billing_payment_methods_first_seen_at timestamptz,
+  ADD COLUMN IF NOT EXISTS billing_payment_methods_last_seen_at  timestamptz,
+  ADD COLUMN IF NOT EXISTS billing_failed_attempts               integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS billing_identity_synced_at            timestamptz,
+  ADD COLUMN IF NOT EXISTS billing_subscription_status           text;
 
 -- Partial index: the shared-fingerprint correlation groups over non-NULL
 -- fingerprints across ALL partners, and the vast majority of rows are NULL.

--- a/apps/api/src/db/schema/orgs.ts
+++ b/apps/api/src/db/schema/orgs.ts
@@ -54,6 +54,11 @@ export const partners = pgTable('partners', {
   billingCardCountry: char('billing_card_country', { length: 2 }),
   billingCardFingerprint: text('billing_card_fingerprint'),
   billingDistinctPaymentMethods: integer('billing_distinct_payment_methods').notNull().default(0),
+  // Bounds of the interval the distinct-method count was accumulated over.
+  // billing.card_testing fires on the SPAN between these, never on the count
+  // alone. NULL means "unknown span" and must fail closed, never zero.
+  billingPaymentMethodsFirstSeenAt: timestamp('billing_payment_methods_first_seen_at', { withTimezone: true }),
+  billingPaymentMethodsLastSeenAt: timestamp('billing_payment_methods_last_seen_at', { withTimezone: true }),
   billingFailedAttempts: integer('billing_failed_attempts').notNull().default(0),
   billingIdentitySyncedAt: timestamp('billing_identity_synced_at', { withTimezone: true }),
   billingSubscriptionStatus: text('billing_subscription_status'),

--- a/apps/api/src/db/schema/orgs.ts
+++ b/apps/api/src/db/schema/orgs.ts
@@ -44,6 +44,19 @@ export const partners = pgTable('partners', {
   emailVerifiedAt: timestamp('email_verified_at', { withTimezone: true }),
   paymentMethodAttachedAt: timestamp('payment_method_attached_at', { withTimezone: true }),
   stripeCustomerId: text('stripe_customer_id'),
+  // Billing identity snapshot, written ONLY by the separate billing service
+  // from its payment-provider webhooks and read only by the abuse sweep
+  // (services/abuseSignals/billingIdentity.ts). Internal columns — never add
+  // any of these to partnerPublicColumns() in routes/orgs.ts.
+  // billingCardFingerprint is NULL for wallet/Link-style payments that expose
+  // no fingerprint, so readers must treat NULL as "unknown", never as a match.
+  billingCardholderName: text('billing_cardholder_name'),
+  billingCardCountry: char('billing_card_country', { length: 2 }),
+  billingCardFingerprint: text('billing_card_fingerprint'),
+  billingDistinctPaymentMethods: integer('billing_distinct_payment_methods').notNull().default(0),
+  billingFailedAttempts: integer('billing_failed_attempts').notNull().default(0),
+  billingIdentitySyncedAt: timestamp('billing_identity_synced_at', { withTimezone: true }),
+  billingSubscriptionStatus: text('billing_subscription_status'),
   currencyCode: char('currency_code', { length: 3 }).notNull().default('USD'),
   defaultTaxRate: numeric('default_tax_rate', { precision: 8, scale: 5 }),
   invoiceNumberPrefix: varchar('invoice_number_prefix', { length: 12 }).notNull().default('INV'),

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -298,6 +298,7 @@ describe('org routes', () => {
       for (const internal of [
         'signupIp', 'paymentMethodAttachedAt', 'stripeCustomerId', 'ssoConfig', 'mcpOriginIp',
         'billingCardholderName', 'billingCardFingerprint', 'billingSubscriptionStatus',
+        'billingPaymentMethodsFirstSeenAt', 'billingPaymentMethodsLastSeenAt',
       ]) {
         expect(keys).not.toContain(internal);
       }
@@ -393,6 +394,7 @@ describe('org routes', () => {
       for (const internal of [
         'signupIp', 'paymentMethodAttachedAt', 'stripeCustomerId', 'ssoConfig', 'mcpOriginIp',
         'billingCardholderName', 'billingCardFingerprint', 'billingSubscriptionStatus',
+        'billingPaymentMethodsFirstSeenAt', 'billingPaymentMethodsLastSeenAt',
       ]) {
         expect(keys).not.toContain(internal);
       }
@@ -2846,6 +2848,7 @@ describe('org routes', () => {
         // served to a partner-scoped token.
         'billingCardholderName', 'billingCardCountry', 'billingCardFingerprint',
         'billingDistinctPaymentMethods', 'billingFailedAttempts',
+        'billingPaymentMethodsFirstSeenAt', 'billingPaymentMethodsLastSeenAt',
         'billingIdentitySyncedAt', 'billingSubscriptionStatus',
       ]) {
         expect(keys).not.toContain(internal);
@@ -2989,6 +2992,7 @@ describe('org routes', () => {
         // served to a partner-scoped token.
         'billingCardholderName', 'billingCardCountry', 'billingCardFingerprint',
         'billingDistinctPaymentMethods', 'billingFailedAttempts',
+        'billingPaymentMethodsFirstSeenAt', 'billingPaymentMethodsLastSeenAt',
         'billingIdentitySyncedAt', 'billingSubscriptionStatus',
       ]) {
         expect(keys).not.toContain(internal);

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -295,7 +295,10 @@ describe('org routes', () => {
       expect(keys).toContain('id');
       expect(keys).toContain('name');
       expect(keys).toContain('status');
-      for (const internal of ['signupIp', 'paymentMethodAttachedAt', 'stripeCustomerId', 'ssoConfig', 'mcpOriginIp']) {
+      for (const internal of [
+        'signupIp', 'paymentMethodAttachedAt', 'stripeCustomerId', 'ssoConfig', 'mcpOriginIp',
+        'billingCardholderName', 'billingCardFingerprint', 'billingSubscriptionStatus',
+      ]) {
         expect(keys).not.toContain(internal);
       }
     });
@@ -387,7 +390,10 @@ describe('org routes', () => {
       const keys = Object.keys(projection!);
       expect(keys).toContain('id');
       expect(keys).toContain('settings');
-      for (const internal of ['signupIp', 'paymentMethodAttachedAt', 'stripeCustomerId', 'ssoConfig', 'mcpOriginIp']) {
+      for (const internal of [
+        'signupIp', 'paymentMethodAttachedAt', 'stripeCustomerId', 'ssoConfig', 'mcpOriginIp',
+        'billingCardholderName', 'billingCardFingerprint', 'billingSubscriptionStatus',
+      ]) {
         expect(keys).not.toContain(internal);
       }
     });
@@ -2835,6 +2841,12 @@ describe('org routes', () => {
       for (const internal of [
         'signupIp', 'signupUserAgent', 'mcpOrigin', 'mcpOriginIp', 'mcpOriginUserAgent',
         'emailVerifiedAt', 'paymentMethodAttachedAt', 'stripeCustomerId', 'ssoConfig', 'deletedAt',
+        // Billing identity snapshot (written by the billing service, read by
+        // the abuse sweep). Cardholder name and card fingerprint must never be
+        // served to a partner-scoped token.
+        'billingCardholderName', 'billingCardCountry', 'billingCardFingerprint',
+        'billingDistinctPaymentMethods', 'billingFailedAttempts',
+        'billingIdentitySyncedAt', 'billingSubscriptionStatus',
       ]) {
         expect(keys).not.toContain(internal);
       }
@@ -2972,6 +2984,12 @@ describe('org routes', () => {
       for (const internal of [
         'signupIp', 'signupUserAgent', 'mcpOrigin', 'mcpOriginIp', 'mcpOriginUserAgent',
         'emailVerifiedAt', 'paymentMethodAttachedAt', 'stripeCustomerId', 'ssoConfig', 'deletedAt',
+        // Billing identity snapshot (written by the billing service, read by
+        // the abuse sweep). Cardholder name and card fingerprint must never be
+        // served to a partner-scoped token.
+        'billingCardholderName', 'billingCardCountry', 'billingCardFingerprint',
+        'billingDistinctPaymentMethods', 'billingFailedAttempts',
+        'billingIdentitySyncedAt', 'billingSubscriptionStatus',
       ]) {
         expect(keys).not.toContain(internal);
       }

--- a/apps/api/src/services/abuseSignals/billingIdentity.test.ts
+++ b/apps/api/src/services/abuseSignals/billingIdentity.test.ts
@@ -5,13 +5,13 @@ import {
   identityTokens,
   domainIdentityLabels,
   isFreeEmailProvider,
+  spanMilliseconds,
   FREE_EMAIL_PROVIDER_LABELS,
   type BillingIdentityAggregate,
 } from './billingIdentity';
 import { SIGNAL_DEFAULTS } from './config';
 
 // Every name, mailbox, domain and fingerprint below is invented for this file.
-const now = new Date('2026-07-25T00:00:00Z');
 
 function agg(overrides: Partial<BillingIdentityAggregate> = {}): BillingIdentityAggregate {
   return {
@@ -22,6 +22,8 @@ function agg(overrides: Partial<BillingIdentityAggregate> = {}): BillingIdentity
     cardholderName: null,
     cardFingerprint: null,
     distinctPaymentMethods: 0,
+    paymentMethodsFirstSeenAt: null,
+    paymentMethodsLastSeenAt: null,
     failedAttempts: 0,
     identitySyncedAt: null,
     ...overrides,
@@ -32,18 +34,18 @@ const signalKeys = (signals: ReturnType<typeof computeBillingIdentitySignals>) =
   signals.map((s) => s.signalKey);
 
 const fires = (a: BillingIdentityAggregate, shared = new Map<string, number>()) =>
-  signalKeys(computeBillingIdentitySignals([a], shared, SIGNAL_DEFAULTS, now)).includes(
+  signalKeys(computeBillingIdentitySignals([a], shared, SIGNAL_DEFAULTS)).includes(
     'billing.cardholder_name_mismatch',
   );
 
 describe('computeBillingIdentitySignals — quiet cases', () => {
   it('emits nothing for a partner with no billing identity data', () => {
-    expect(computeBillingIdentitySignals([agg()], new Map(), SIGNAL_DEFAULTS, now)).toEqual([]);
+    expect(computeBillingIdentitySignals([agg()], new Map(), SIGNAL_DEFAULTS)).toEqual([]);
   });
 
   it('emits nothing when the cardholder name is blank', () => {
     expect(
-      computeBillingIdentitySignals([agg({ cardholderName: '   ' })], new Map(), SIGNAL_DEFAULTS, now),
+      computeBillingIdentitySignals([agg({ cardholderName: '   ' })], new Map(), SIGNAL_DEFAULTS),
     ).toEqual([]);
   });
 
@@ -181,7 +183,6 @@ describe('billing.cardholder_name_mismatch — matching algorithm', () => {
       [agg({ cardholderName: 'Bartholomew Pfennig' })],
       new Map(),
       SIGNAL_DEFAULTS,
-      now,
     );
     expect(signal).toBeDefined();
     expect(signal!.signalKey).toBe('billing.cardholder_name_mismatch');
@@ -199,7 +200,6 @@ describe('billing.cardholder_name_mismatch — matching algorithm', () => {
       [agg({ cardholderName: 'Bartholomew Pfennig', failedAttempts: 9 })],
       new Map(),
       SIGNAL_DEFAULTS,
-      now,
     );
     expect(signal!.score).toBe(
       SIGNAL_DEFAULTS['billing.cardholder_name_mismatch.score'] +
@@ -218,7 +218,7 @@ describe('billing.cardholder_name_mismatch — matching algorithm', () => {
     // With the default list the domain token 'calloway' matches, so it is quiet.
     expect(fires(aggregate)).toBe(false);
     // Treating that domain as a free provider strips the token, so it fires.
-    const signals = computeBillingIdentitySignals([aggregate], new Map(), SIGNAL_DEFAULTS, now, {
+    const signals = computeBillingIdentitySignals([aggregate], new Map(), SIGNAL_DEFAULTS, {
       freeEmailProviderLabels: new Set(['calloway-brix']),
     });
     expect(signalKeys(signals)).toContain('billing.cardholder_name_mismatch');
@@ -232,7 +232,6 @@ describe('billing.shared_card_fingerprint', () => {
       [agg({ cardholderName: 'Nordvane', cardFingerprint: 'fpr_zzxq1' })],
       shared,
       SIGNAL_DEFAULTS,
-      now,
     );
     const signal = signals.find((s) => s.signalKey === 'billing.shared_card_fingerprint');
     expect(signal).toBeDefined();
@@ -246,7 +245,6 @@ describe('billing.shared_card_fingerprint', () => {
       [agg({ cardFingerprint: 'fpr_zzxq1' })],
       new Map([['fpr_zzxq1', 4]]),
       SIGNAL_DEFAULTS,
-      now,
     );
     const signal = signals.find((s) => s.signalKey === 'billing.shared_card_fingerprint');
     expect(signal!.score).toBe(
@@ -260,7 +258,6 @@ describe('billing.shared_card_fingerprint', () => {
       [agg({ cardFingerprint: 'fpr_zzxq1' })],
       new Map(),
       SIGNAL_DEFAULTS,
-      now,
     );
     expect(signalKeys(signals)).not.toContain('billing.shared_card_fingerprint');
   });
@@ -273,66 +270,134 @@ describe('billing.shared_card_fingerprint', () => {
       [agg({ partnerId: 'pA', cardFingerprint: null }), agg({ partnerId: 'pB', cardFingerprint: '  ' })],
       shared,
       SIGNAL_DEFAULTS,
-      now,
     );
     expect(signalKeys(signals)).not.toContain('billing.shared_card_fingerprint');
   });
 });
 
-describe('billing.card_testing', () => {
-  const freshSync = new Date('2026-07-24T00:00:00Z');
+describe('billing.card_testing — span-based', () => {
+  const burstStart = new Date('2026-07-25T09:00:00Z');
+  /** Same day, 7 minutes later: the flagship card-testing shape. */
+  const burstEnd = new Date('2026-07-25T09:07:00Z');
 
-  it('fires when distinct payment methods reach the threshold on a fresh snapshot', () => {
-    const signals = computeBillingIdentitySignals(
-      [agg({ distinctPaymentMethods: 3, identitySyncedAt: freshSync })],
-      new Map(),
-      SIGNAL_DEFAULTS,
-      now,
+  const cardTesting = (overrides: Partial<BillingIdentityAggregate>) =>
+    computeBillingIdentitySignals([agg(overrides)], new Map(), SIGNAL_DEFAULTS).find(
+      (s) => s.signalKey === 'billing.card_testing',
     );
-    const signal = signals.find((s) => s.signalKey === 'billing.card_testing');
+
+  it('fires for 3 distinct methods inside a 7-minute span', () => {
+    const signal = cardTesting({
+      distinctPaymentMethods: 3,
+      paymentMethodsFirstSeenAt: burstStart,
+      paymentMethodsLastSeenAt: burstEnd,
+    });
     expect(signal).toBeDefined();
     expect(signal!.score).toBe(SIGNAL_DEFAULTS['billing.card_testing.base_score']);
-    expect(signal!.evidence).toMatchObject({ distinctPaymentMethods: 3, failedAttempts: 0 });
+    expect(signal!.evidence).toMatchObject({
+      distinctPaymentMethods: 3,
+      failedAttempts: 0,
+      spanMinutes: 7,
+    });
   });
 
-  it('is silent below the threshold', () => {
-    const signals = computeBillingIdentitySignals(
-      [agg({ distinctPaymentMethods: 2, identitySyncedAt: freshSync })],
-      new Map(),
-      SIGNAL_DEFAULTS,
-      now,
-    );
-    expect(signalKeys(signals)).not.toContain('billing.card_testing');
+  it('does NOT fire for 3 distinct methods spanning two years', () => {
+    // A long-lived MSP replacing an expired card twice. Identical count, and an
+    // equally fresh snapshot — only the span tells the two apart.
+    expect(
+      cardTesting({
+        distinctPaymentMethods: 3,
+        paymentMethodsFirstSeenAt: new Date('2024-07-25T09:00:00Z'),
+        paymentMethodsLastSeenAt: new Date('2026-07-25T09:00:00Z'),
+        identitySyncedAt: new Date('2026-07-25T08:00:00Z'),
+      }),
+    ).toBeUndefined();
   });
 
-  it('is silent when the snapshot is older than the window', () => {
-    const signals = computeBillingIdentitySignals(
-      [agg({ distinctPaymentMethods: 6, identitySyncedAt: new Date('2026-06-01T00:00:00Z') })],
-      new Map(),
-      SIGNAL_DEFAULTS,
-      now,
-    );
-    expect(signalKeys(signals)).not.toContain('billing.card_testing');
+  it('does NOT fire when both span timestamps are NULL', () => {
+    // The deploy-day case: legacy rows, or the billing service has not
+    // backfilled yet. An unknown span must never read as a zero span.
+    expect(cardTesting({ distinctPaymentMethods: 9 })).toBeUndefined();
   });
 
-  it('is silent when the snapshot was never synced', () => {
+  it('does NOT fire when only one span timestamp is present', () => {
+    expect(
+      cardTesting({ distinctPaymentMethods: 9, paymentMethodsFirstSeenAt: burstStart }),
+    ).toBeUndefined();
+    expect(
+      cardTesting({ distinctPaymentMethods: 9, paymentMethodsLastSeenAt: burstEnd }),
+    ).toBeUndefined();
+  });
+
+  it('does NOT fire on a reversed span (bad data is not an instantaneous burst)', () => {
+    expect(
+      cardTesting({
+        distinctPaymentMethods: 9,
+        paymentMethodsFirstSeenAt: burstEnd,
+        paymentMethodsLastSeenAt: burstStart,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('fires at exactly the window boundary and is silent one millisecond past it', () => {
+    const windowMs = SIGNAL_DEFAULTS['billing.card_testing.window_days'] * 86_400_000;
+    expect(
+      cardTesting({
+        distinctPaymentMethods: 3,
+        paymentMethodsFirstSeenAt: burstStart,
+        paymentMethodsLastSeenAt: new Date(burstStart.getTime() + windowMs),
+      }),
+    ).toBeDefined();
+    expect(
+      cardTesting({
+        distinctPaymentMethods: 3,
+        paymentMethodsFirstSeenAt: burstStart,
+        paymentMethodsLastSeenAt: new Date(burstStart.getTime() + windowMs + 1),
+      }),
+    ).toBeUndefined();
+  });
+
+  it('is silent below the method threshold even inside a tight span', () => {
+    expect(
+      cardTesting({
+        distinctPaymentMethods: 2,
+        paymentMethodsFirstSeenAt: burstStart,
+        paymentMethodsLastSeenAt: burstEnd,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('scores a legitimate multi-year partner with several cards at zero', () => {
+    // The whole aggregate, not just the card-testing branch: a cardholder that
+    // matches the account and a fingerprint held by nobody else must produce no
+    // signals at all, however many cards the account has seen over the years.
     const signals = computeBillingIdentitySignals(
-      [agg({ distinctPaymentMethods: 6, identitySyncedAt: null })],
+      [
+        agg({
+          partnerName: 'Nordvane',
+          userNames: ['Rosalind Quibley'],
+          emails: ['rosalind@nordvane.example'],
+          cardholderName: 'Rosalind Quibley',
+          cardFingerprint: 'fpr_zzxq1',
+          distinctPaymentMethods: 5,
+          failedAttempts: 3,
+          paymentMethodsFirstSeenAt: new Date('2022-01-04T00:00:00Z'),
+          paymentMethodsLastSeenAt: new Date('2026-07-01T00:00:00Z'),
+          identitySyncedAt: new Date('2026-07-25T08:00:00Z'),
+        }),
+      ],
       new Map(),
       SIGNAL_DEFAULTS,
-      now,
     );
-    expect(signalKeys(signals)).not.toContain('billing.card_testing');
+    expect(signals).toEqual([]);
   });
 
   it('escalates with extra methods and failed attempts', () => {
-    const signals = computeBillingIdentitySignals(
-      [agg({ distinctPaymentMethods: 5, failedAttempts: 4, identitySyncedAt: freshSync })],
-      new Map(),
-      SIGNAL_DEFAULTS,
-      now,
-    );
-    const signal = signals.find((s) => s.signalKey === 'billing.card_testing');
+    const signal = cardTesting({
+      distinctPaymentMethods: 5,
+      failedAttempts: 4,
+      paymentMethodsFirstSeenAt: burstStart,
+      paymentMethodsLastSeenAt: burstEnd,
+    });
     expect(signal!.score).toBe(
       SIGNAL_DEFAULTS['billing.card_testing.base_score'] +
         SIGNAL_DEFAULTS['billing.card_testing.per_extra_method'] * 2 +
@@ -342,35 +407,48 @@ describe('billing.card_testing', () => {
   });
 
   it('clamps the score at 100', () => {
-    const signals = computeBillingIdentitySignals(
-      [agg({ distinctPaymentMethods: 40, failedAttempts: 40, identitySyncedAt: freshSync })],
-      new Map(),
-      SIGNAL_DEFAULTS,
-      now,
-    );
-    const signal = signals.find((s) => s.signalKey === 'billing.card_testing');
+    const signal = cardTesting({
+      distinctPaymentMethods: 40,
+      failedAttempts: 40,
+      paymentMethodsFirstSeenAt: burstStart,
+      paymentMethodsLastSeenAt: burstEnd,
+    });
     expect(signal!.score).toBe(100);
   });
 });
 
+describe('spanMilliseconds', () => {
+  const first = new Date('2026-07-25T09:00:00Z');
+  const last = new Date('2026-07-25T09:07:00Z');
+
+  it('returns the elapsed milliseconds for a coherent pair', () => {
+    expect(spanMilliseconds(first, last)).toBe(7 * 60_000);
+  });
+
+  it('returns 0 for identical bounds', () => {
+    expect(spanMilliseconds(first, first)).toBe(0);
+  });
+
+  it('returns null — never 0 — when either bound is missing', () => {
+    expect(spanMilliseconds(null, last)).toBeNull();
+    expect(spanMilliseconds(first, null)).toBeNull();
+    expect(spanMilliseconds(null, null)).toBeNull();
+  });
+
+  it('returns null for a reversed pair', () => {
+    expect(spanMilliseconds(last, first)).toBeNull();
+  });
+});
+
 describe('never age-decays', () => {
-  it('scores an old account exactly like a brand-new one', () => {
-    // The scorer takes no partner creation date at all — this asserts the
-    // signature/behaviour rather than a decayed value.
+  it('takes no clock, so a signal cannot weaken as the account ages', () => {
+    // The scorer's signature carries neither `now` nor partnerCreatedAt, which
+    // is what makes "never age-decayed" structural rather than a convention.
     const aggregate = agg({ cardholderName: 'Bartholomew Pfennig' });
-    const early = computeBillingIdentitySignals(
-      [aggregate],
-      new Map(),
-      SIGNAL_DEFAULTS,
-      new Date('2026-01-01T00:00:00Z'),
-    );
-    const late = computeBillingIdentitySignals(
-      [aggregate],
-      new Map(),
-      SIGNAL_DEFAULTS,
-      new Date('2029-01-01T00:00:00Z'),
-    );
-    expect(early[0]!.score).toBe(late[0]!.score);
+    const first = computeBillingIdentitySignals([aggregate], new Map(), SIGNAL_DEFAULTS);
+    const second = computeBillingIdentitySignals([aggregate], new Map(), SIGNAL_DEFAULTS);
+    expect(first).toEqual(second);
+    expect(first[0]!.score).toBe(SIGNAL_DEFAULTS['billing.cardholder_name_mismatch.score']);
   });
 });
 

--- a/apps/api/src/services/abuseSignals/billingIdentity.test.ts
+++ b/apps/api/src/services/abuseSignals/billingIdentity.test.ts
@@ -8,10 +8,13 @@ import {
   spanMilliseconds,
   FREE_EMAIL_PROVIDER_LABELS,
   type BillingIdentityAggregate,
+  type BillingIdentityScorerOptions,
 } from './billingIdentity';
 import { SIGNAL_DEFAULTS } from './config';
 
 // Every name, mailbox, domain and fingerprint below is invented for this file.
+// Mailbox domains are reserved-TLD placeholders only (.example) — never a real
+// provider domain, which the customer-PII guard rejects in a public repo.
 
 function agg(overrides: Partial<BillingIdentityAggregate> = {}): BillingIdentityAggregate {
   return {
@@ -33,8 +36,21 @@ function agg(overrides: Partial<BillingIdentityAggregate> = {}): BillingIdentity
 const signalKeys = (signals: ReturnType<typeof computeBillingIdentitySignals>) =>
   signals.map((s) => s.signalKey);
 
-const fires = (a: BillingIdentityAggregate, shared = new Map<string, number>()) =>
-  signalKeys(computeBillingIdentitySignals([a], shared, SIGNAL_DEFAULTS)).includes(
+/**
+ * Synthetic stand-in for a consumer mailbox provider. Reserved-TLD domains only
+ * in fixtures — a real provider domain in a public repo trips (and would blunt)
+ * the customer-PII guard, and the scorer takes an injectable provider set
+ * precisely so the exclusion BEHAVIOUR can be proven without one. The shipped
+ * list is covered separately, by bare-domain assertions that contain no address.
+ */
+const SYNTHETIC_FREE_PROVIDERS: ReadonlySet<string> = new Set(['freemail']);
+
+const fires = (
+  a: BillingIdentityAggregate,
+  options?: BillingIdentityScorerOptions,
+  shared = new Map<string, number>(),
+) =>
+  signalKeys(computeBillingIdentitySignals([a], shared, SIGNAL_DEFAULTS, options)).includes(
     'billing.cardholder_name_mismatch',
   );
 
@@ -56,7 +72,7 @@ describe('computeBillingIdentitySignals — quiet cases', () => {
         agg({
           partnerName: 'IT Solutions LLC',
           userNames: [],
-          emails: ['billing@gmail.example'],
+          emails: ['billing@it.example'],
           cardholderName: 'Perpetua Vandersloot',
         }),
       ),
@@ -69,6 +85,7 @@ describe('billing.cardholder_name_mismatch — matching algorithm', () => {
     name: string;
     aggregate: BillingIdentityAggregate;
     shouldFire: boolean;
+    options?: BillingIdentityScorerOptions;
   }> = [
     {
       name: 'cardholder shares no token with partner name, user names, or email local-part',
@@ -111,17 +128,31 @@ describe('billing.cardholder_name_mismatch — matching algorithm', () => {
       shouldFire: false,
     },
     {
+      // A/B pair with the case below: identical fixture, and the ONLY
+      // difference is whether the mailbox domain is treated as a free provider.
+      // That isolates the exclusion behaviour from every other axis.
       name: 'free-provider email domain contributes no match token',
       aggregate: agg({
         partnerName: 'Nordvane',
         userNames: ['Rosalind Threnody'],
-        emails: ['rq@proton.me'],
-        cardholderName: 'Proton Pfennig',
+        emails: ['rq@freemail.example'],
+        cardholderName: 'Freemail Pfennig',
       }),
+      options: { freeEmailProviderLabels: SYNTHETIC_FREE_PROVIDERS },
       shouldFire: true,
     },
     {
-      name: 'non-free email domain does contribute a match token',
+      name: 'the same domain DOES contribute a token when it is not a free provider',
+      aggregate: agg({
+        partnerName: 'Nordvane',
+        userNames: ['Rosalind Threnody'],
+        emails: ['rq@freemail.example'],
+        cardholderName: 'Freemail Pfennig',
+      }),
+      shouldFire: false,
+    },
+    {
+      name: 'a corporate email domain contributes a match token',
       aggregate: agg({
         partnerName: 'Nordvane',
         userNames: ['Rosalind Threnody'],
@@ -172,9 +203,9 @@ describe('billing.cardholder_name_mismatch — matching algorithm', () => {
     },
   ];
 
-  for (const { name, aggregate, shouldFire } of cases) {
+  for (const { name, aggregate, shouldFire, options } of cases) {
     it(`${shouldFire ? 'fires' : 'does not fire'}: ${name}`, () => {
-      expect(fires(aggregate)).toBe(shouldFire);
+      expect(fires(aggregate, options)).toBe(shouldFire);
     });
   }
 
@@ -208,20 +239,17 @@ describe('billing.cardholder_name_mismatch — matching algorithm', () => {
     expect(signal!.severity).toBe('alert');
   });
 
-  it('accepts an injected free-provider list', () => {
+  it('defaults to the shipped free-provider list when none is injected', () => {
+    // Guards the default-argument wiring: omitting options must not silently
+    // fall back to an empty provider set, which would quietly disable the
+    // exclusion in production while every injected test stayed green.
     const aggregate = agg({
       partnerName: 'Nordvane',
       userNames: [],
-      emails: ['rq@calloway-brix.example'],
-      cardholderName: 'Calloway Pfennig',
+      emails: ['rq@freemail.example'],
+      cardholderName: 'Freemail Pfennig',
     });
-    // With the default list the domain token 'calloway' matches, so it is quiet.
-    expect(fires(aggregate)).toBe(false);
-    // Treating that domain as a free provider strips the token, so it fires.
-    const signals = computeBillingIdentitySignals([aggregate], new Map(), SIGNAL_DEFAULTS, {
-      freeEmailProviderLabels: new Set(['calloway-brix']),
-    });
-    expect(signalKeys(signals)).toContain('billing.cardholder_name_mismatch');
+    expect(fires(aggregate)).toBe(fires(aggregate, { freeEmailProviderLabels: FREE_EMAIL_PROVIDER_LABELS }));
   });
 });
 
@@ -490,11 +518,26 @@ describe('token helpers', () => {
   });
 
   it('excludes free-provider domain labels from the identity token set', () => {
-    const tokens = buildIdentityTokens({
-      partnerName: 'Nordvane',
-      userNames: [],
-      emails: ['quibley@hotmail.example'],
-    });
+    const tokens = buildIdentityTokens(
+      {
+        partnerName: 'Nordvane',
+        userNames: [],
+        emails: ['quibley@freemail.example'],
+      },
+      SYNTHETIC_FREE_PROVIDERS,
+    );
     expect([...tokens].sort()).toEqual(['nordvane', 'quibley']);
+  });
+
+  it('keeps the domain label when the provider is not in the injected set', () => {
+    const tokens = buildIdentityTokens(
+      {
+        partnerName: 'Nordvane',
+        userNames: [],
+        emails: ['quibley@freemail.example'],
+      },
+      new Set<string>(),
+    );
+    expect([...tokens].sort()).toEqual(['freemail', 'nordvane', 'quibley']);
   });
 });

--- a/apps/api/src/services/abuseSignals/billingIdentity.test.ts
+++ b/apps/api/src/services/abuseSignals/billingIdentity.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeBillingIdentitySignals,
+  buildIdentityTokens,
+  identityTokens,
+  domainIdentityLabels,
+  isFreeEmailProvider,
+  FREE_EMAIL_PROVIDER_LABELS,
+  type BillingIdentityAggregate,
+} from './billingIdentity';
+import { SIGNAL_DEFAULTS } from './config';
+
+// Every name, mailbox, domain and fingerprint below is invented for this file.
+const now = new Date('2026-07-25T00:00:00Z');
+
+function agg(overrides: Partial<BillingIdentityAggregate> = {}): BillingIdentityAggregate {
+  return {
+    partnerId: 'p1',
+    partnerName: 'Nordvane',
+    emails: ['ops@nordvane.example'],
+    userNames: ['Rosalind Quibley'],
+    cardholderName: null,
+    cardFingerprint: null,
+    distinctPaymentMethods: 0,
+    failedAttempts: 0,
+    identitySyncedAt: null,
+    ...overrides,
+  };
+}
+
+const signalKeys = (signals: ReturnType<typeof computeBillingIdentitySignals>) =>
+  signals.map((s) => s.signalKey);
+
+const fires = (a: BillingIdentityAggregate, shared = new Map<string, number>()) =>
+  signalKeys(computeBillingIdentitySignals([a], shared, SIGNAL_DEFAULTS, now)).includes(
+    'billing.cardholder_name_mismatch',
+  );
+
+describe('computeBillingIdentitySignals — quiet cases', () => {
+  it('emits nothing for a partner with no billing identity data', () => {
+    expect(computeBillingIdentitySignals([agg()], new Map(), SIGNAL_DEFAULTS, now)).toEqual([]);
+  });
+
+  it('emits nothing when the cardholder name is blank', () => {
+    expect(
+      computeBillingIdentitySignals([agg({ cardholderName: '   ' })], new Map(), SIGNAL_DEFAULTS, now),
+    ).toEqual([]);
+  });
+
+  it('never fires a mismatch when the account side has no meaningful tokens', () => {
+    // "no data" is not evidence: every account token here is a stop word.
+    expect(
+      fires(
+        agg({
+          partnerName: 'IT Solutions LLC',
+          userNames: [],
+          emails: ['billing@gmail.example'],
+          cardholderName: 'Perpetua Vandersloot',
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('billing.cardholder_name_mismatch — matching algorithm', () => {
+  const cases: Array<{
+    name: string;
+    aggregate: BillingIdentityAggregate;
+    shouldFire: boolean;
+  }> = [
+    {
+      name: 'cardholder shares no token with partner name, user names, or email local-part',
+      aggregate: agg({
+        partnerName: 'Nordvane',
+        userNames: ['Rosalind Quibley'],
+        emails: ['rosalind@nordvane.example'],
+        cardholderName: 'Bartholomew Pfennig',
+      }),
+      shouldFire: true,
+    },
+    {
+      name: 'cardholder first name matches the email local-part (operator paying with their own card)',
+      aggregate: agg({
+        partnerName: 'Nordvane',
+        userNames: [],
+        emails: ['andrivo@nordvane.example'],
+        cardholderName: 'Andrivo Pfennig',
+      }),
+      shouldFire: false,
+    },
+    {
+      name: 'cardholder shares a token with the partner name (documented known miss)',
+      aggregate: agg({
+        partnerName: 'Quibley Holdings',
+        userNames: ['Rosalind Threnody'],
+        emails: ['ops@nordvane.example'],
+        cardholderName: 'Marguerite Quibley',
+      }),
+      shouldFire: false,
+    },
+    {
+      name: 'cardholder matches a member display name rather than the partner name',
+      aggregate: agg({
+        partnerName: 'Nordvane',
+        userNames: ['Rosalind Threnody'],
+        emails: ['ops@nordvane.example'],
+        cardholderName: 'Threnody Rosalind',
+      }),
+      shouldFire: false,
+    },
+    {
+      name: 'free-provider email domain contributes no match token',
+      aggregate: agg({
+        partnerName: 'Nordvane',
+        userNames: ['Rosalind Threnody'],
+        emails: ['rq@proton.me'],
+        cardholderName: 'Proton Pfennig',
+      }),
+      shouldFire: true,
+    },
+    {
+      name: 'non-free email domain does contribute a match token',
+      aggregate: agg({
+        partnerName: 'Nordvane',
+        userNames: ['Rosalind Threnody'],
+        emails: ['rq@calloway-brix.example'],
+        cardholderName: 'Calloway Pfennig',
+      }),
+      shouldFire: false,
+    },
+    {
+      name: 'diacritics, punctuation and word order still match',
+      aggregate: agg({
+        partnerName: 'Nordvane',
+        userNames: ["Ódhrán Ferreiró-Blaÿse"],
+        emails: ['ops@nordvane.example'],
+        cardholderName: 'FERREIRO, ODHRAN',
+      }),
+      shouldFire: false,
+    },
+    {
+      name: 'non-decomposing letters (ø, ß) fold to their ASCII spelling',
+      aggregate: agg({
+        partnerName: 'Nordvane',
+        userNames: ['Sønderby Weißmuller'],
+        emails: ['ops@nordvane.example'],
+        cardholderName: 'Sonderby Weissmuller',
+      }),
+      shouldFire: false,
+    },
+    {
+      name: 'digits in a mailbox local-part do not block the match',
+      aggregate: agg({
+        partnerName: 'Nordvane',
+        userNames: [],
+        emails: ['pfennig91@nordvane.example'],
+        cardholderName: 'Bartholomew Pfennig',
+      }),
+      shouldFire: false,
+    },
+    {
+      name: 'a shared corporate stop word alone is not a match',
+      aggregate: agg({
+        partnerName: 'Nordvane Managed Services',
+        userNames: ['Rosalind Threnody'],
+        emails: ['ops@nordvane.example'],
+        cardholderName: 'Pfennig Managed Services Ltd',
+      }),
+      shouldFire: true,
+    },
+  ];
+
+  for (const { name, aggregate, shouldFire } of cases) {
+    it(`${shouldFire ? 'fires' : 'does not fire'}: ${name}`, () => {
+      expect(fires(aggregate)).toBe(shouldFire);
+    });
+  }
+
+  it('scores below alert on its own and carries the cardholder name as evidence', () => {
+    const [signal] = computeBillingIdentitySignals(
+      [agg({ cardholderName: 'Bartholomew Pfennig' })],
+      new Map(),
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    expect(signal).toBeDefined();
+    expect(signal!.signalKey).toBe('billing.cardholder_name_mismatch');
+    expect(signal!.severity).toBe('watch');
+    expect(signal!.score).toBe(SIGNAL_DEFAULTS['billing.cardholder_name_mismatch.score']);
+    expect(signal!.evidence).toMatchObject({
+      partnerName: 'Nordvane',
+      cardholderName: 'Bartholomew Pfennig',
+      failedAttempts: 0,
+    });
+  });
+
+  it('escalates a mismatch when the account also has failed payment attempts', () => {
+    const [signal] = computeBillingIdentitySignals(
+      [agg({ cardholderName: 'Bartholomew Pfennig', failedAttempts: 9 })],
+      new Map(),
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    expect(signal!.score).toBe(
+      SIGNAL_DEFAULTS['billing.cardholder_name_mismatch.score'] +
+        SIGNAL_DEFAULTS['billing.cardholder_name_mismatch.failed_attempt_bonus'] * 9,
+    );
+    expect(signal!.severity).toBe('alert');
+  });
+
+  it('accepts an injected free-provider list', () => {
+    const aggregate = agg({
+      partnerName: 'Nordvane',
+      userNames: [],
+      emails: ['rq@calloway-brix.example'],
+      cardholderName: 'Calloway Pfennig',
+    });
+    // With the default list the domain token 'calloway' matches, so it is quiet.
+    expect(fires(aggregate)).toBe(false);
+    // Treating that domain as a free provider strips the token, so it fires.
+    const signals = computeBillingIdentitySignals([aggregate], new Map(), SIGNAL_DEFAULTS, now, {
+      freeEmailProviderLabels: new Set(['calloway-brix']),
+    });
+    expect(signalKeys(signals)).toContain('billing.cardholder_name_mismatch');
+  });
+});
+
+describe('billing.shared_card_fingerprint', () => {
+  it('fires for the in-scope partner when a fingerprint spans two partners', () => {
+    const shared = new Map([['fpr_zzxq1', 2]]);
+    const signals = computeBillingIdentitySignals(
+      [agg({ cardholderName: 'Nordvane', cardFingerprint: 'fpr_zzxq1' })],
+      shared,
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    const signal = signals.find((s) => s.signalKey === 'billing.shared_card_fingerprint');
+    expect(signal).toBeDefined();
+    expect(signal!.score).toBe(SIGNAL_DEFAULTS['billing.shared_card_fingerprint.base_score']);
+    expect(signal!.severity).toBe('alert');
+    expect(signal!.evidence).toMatchObject({ cardFingerprintPrefix: 'fpr_zzxq1', partnerCount: 2 });
+  });
+
+  it('scores higher as the fingerprint spans more partners', () => {
+    const signals = computeBillingIdentitySignals(
+      [agg({ cardFingerprint: 'fpr_zzxq1' })],
+      new Map([['fpr_zzxq1', 4]]),
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    const signal = signals.find((s) => s.signalKey === 'billing.shared_card_fingerprint');
+    expect(signal!.score).toBe(
+      SIGNAL_DEFAULTS['billing.shared_card_fingerprint.base_score'] +
+        SIGNAL_DEFAULTS['billing.shared_card_fingerprint.per_extra_partner'] * 2,
+    );
+  });
+
+  it('is silent for a fingerprint held by only one partner', () => {
+    const signals = computeBillingIdentitySignals(
+      [agg({ cardFingerprint: 'fpr_zzxq1' })],
+      new Map(),
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    expect(signalKeys(signals)).not.toContain('billing.shared_card_fingerprint');
+  });
+
+  it('never matches two null fingerprints against each other', () => {
+    // Wallet/Link payments expose no fingerprint. A corpus can never contain a
+    // NULL key, and a null-fingerprint partner is skipped outright.
+    const shared = new Map<string, number>([['', 5]]);
+    const signals = computeBillingIdentitySignals(
+      [agg({ partnerId: 'pA', cardFingerprint: null }), agg({ partnerId: 'pB', cardFingerprint: '  ' })],
+      shared,
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    expect(signalKeys(signals)).not.toContain('billing.shared_card_fingerprint');
+  });
+});
+
+describe('billing.card_testing', () => {
+  const freshSync = new Date('2026-07-24T00:00:00Z');
+
+  it('fires when distinct payment methods reach the threshold on a fresh snapshot', () => {
+    const signals = computeBillingIdentitySignals(
+      [agg({ distinctPaymentMethods: 3, identitySyncedAt: freshSync })],
+      new Map(),
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    const signal = signals.find((s) => s.signalKey === 'billing.card_testing');
+    expect(signal).toBeDefined();
+    expect(signal!.score).toBe(SIGNAL_DEFAULTS['billing.card_testing.base_score']);
+    expect(signal!.evidence).toMatchObject({ distinctPaymentMethods: 3, failedAttempts: 0 });
+  });
+
+  it('is silent below the threshold', () => {
+    const signals = computeBillingIdentitySignals(
+      [agg({ distinctPaymentMethods: 2, identitySyncedAt: freshSync })],
+      new Map(),
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    expect(signalKeys(signals)).not.toContain('billing.card_testing');
+  });
+
+  it('is silent when the snapshot is older than the window', () => {
+    const signals = computeBillingIdentitySignals(
+      [agg({ distinctPaymentMethods: 6, identitySyncedAt: new Date('2026-06-01T00:00:00Z') })],
+      new Map(),
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    expect(signalKeys(signals)).not.toContain('billing.card_testing');
+  });
+
+  it('is silent when the snapshot was never synced', () => {
+    const signals = computeBillingIdentitySignals(
+      [agg({ distinctPaymentMethods: 6, identitySyncedAt: null })],
+      new Map(),
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    expect(signalKeys(signals)).not.toContain('billing.card_testing');
+  });
+
+  it('escalates with extra methods and failed attempts', () => {
+    const signals = computeBillingIdentitySignals(
+      [agg({ distinctPaymentMethods: 5, failedAttempts: 4, identitySyncedAt: freshSync })],
+      new Map(),
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    const signal = signals.find((s) => s.signalKey === 'billing.card_testing');
+    expect(signal!.score).toBe(
+      SIGNAL_DEFAULTS['billing.card_testing.base_score'] +
+        SIGNAL_DEFAULTS['billing.card_testing.per_extra_method'] * 2 +
+        SIGNAL_DEFAULTS['billing.card_testing.per_failed_attempt'] * 4,
+    );
+    expect(signal!.severity).toBe('alert');
+  });
+
+  it('clamps the score at 100', () => {
+    const signals = computeBillingIdentitySignals(
+      [agg({ distinctPaymentMethods: 40, failedAttempts: 40, identitySyncedAt: freshSync })],
+      new Map(),
+      SIGNAL_DEFAULTS,
+      now,
+    );
+    const signal = signals.find((s) => s.signalKey === 'billing.card_testing');
+    expect(signal!.score).toBe(100);
+  });
+});
+
+describe('never age-decays', () => {
+  it('scores an old account exactly like a brand-new one', () => {
+    // The scorer takes no partner creation date at all — this asserts the
+    // signature/behaviour rather than a decayed value.
+    const aggregate = agg({ cardholderName: 'Bartholomew Pfennig' });
+    const early = computeBillingIdentitySignals(
+      [aggregate],
+      new Map(),
+      SIGNAL_DEFAULTS,
+      new Date('2026-01-01T00:00:00Z'),
+    );
+    const late = computeBillingIdentitySignals(
+      [aggregate],
+      new Map(),
+      SIGNAL_DEFAULTS,
+      new Date('2029-01-01T00:00:00Z'),
+    );
+    expect(early[0]!.score).toBe(late[0]!.score);
+  });
+});
+
+describe('token helpers', () => {
+  it('drops short tokens, stop words and digits', () => {
+    expect(identityTokens('Nordvane IT Solutions 2026')).toEqual(['nordvane']);
+  });
+
+  it('strips the TLD and public second-level suffixes from a domain', () => {
+    expect(domainIdentityLabels('nordvane.example')).toEqual(['nordvane']);
+    expect(domainIdentityLabels('nordvane.co.uk')).toEqual(['nordvane']);
+    expect(domainIdentityLabels('mail.nordvane.com')).toEqual(['mail', 'nordvane']);
+    expect(domainIdentityLabels('localhost')).toEqual([]);
+  });
+
+  it('recognises free providers by their registrable base label', () => {
+    expect(isFreeEmailProvider('gmail.com', FREE_EMAIL_PROVIDER_LABELS)).toBe(true);
+    expect(isFreeEmailProvider('yahoo.co.uk', FREE_EMAIL_PROVIDER_LABELS)).toBe(true);
+    expect(isFreeEmailProvider('mail.ru', FREE_EMAIL_PROVIDER_LABELS)).toBe(true);
+    expect(isFreeEmailProvider('nordvane.example', FREE_EMAIL_PROVIDER_LABELS)).toBe(false);
+    // A corporate mailbox subdomain resolves to the corporate base label.
+    expect(isFreeEmailProvider('mail.nordvane.com', FREE_EMAIL_PROVIDER_LABELS)).toBe(false);
+  });
+
+  it('excludes free-provider domain labels from the identity token set', () => {
+    const tokens = buildIdentityTokens({
+      partnerName: 'Nordvane',
+      userNames: [],
+      emails: ['quibley@hotmail.example'],
+    });
+    expect([...tokens].sort()).toEqual(['nordvane', 'quibley']);
+  });
+});

--- a/apps/api/src/services/abuseSignals/billingIdentity.test.ts
+++ b/apps/api/src/services/abuseSignals/billingIdentity.test.ts
@@ -297,7 +297,23 @@ describe('billing.card_testing — span-based', () => {
       distinctPaymentMethods: 3,
       failedAttempts: 0,
       spanMinutes: 7,
+      paymentMethodsFirstSeenAt: burstStart.toISOString(),
+      paymentMethodsLastSeenAt: burstEnd.toISOString(),
+      identitySyncedAt: null,
     });
+  });
+
+  it('carries snapshot age into evidence without letting it gate the signal', () => {
+    // A stale snapshot still fires — only the span decides — but the operator
+    // gets to see how old the data is.
+    const signal = cardTesting({
+      distinctPaymentMethods: 3,
+      paymentMethodsFirstSeenAt: burstStart,
+      paymentMethodsLastSeenAt: burstEnd,
+      identitySyncedAt: new Date('2026-05-01T00:00:00Z'),
+    });
+    expect(signal).toBeDefined();
+    expect(signal!.evidence).toMatchObject({ identitySyncedAt: '2026-05-01T00:00:00.000Z' });
   });
 
   it('does NOT fire for 3 distinct methods spanning two years', () => {

--- a/apps/api/src/services/abuseSignals/billingIdentity.ts
+++ b/apps/api/src/services/abuseSignals/billingIdentity.ts
@@ -53,7 +53,11 @@ export interface BillingIdentityAggregate {
   paymentMethodsFirstSeenAt: Date | null;
   paymentMethodsLastSeenAt: Date | null;
   failedAttempts: number;
-  /** When the billing service last refreshed this snapshot. Evidence only. */
+  /**
+   * When the billing service last refreshed this snapshot. Carried into
+   * card-testing evidence for triage; deliberately gates nothing — snapshot
+   * recency is not the same question as the accumulation span.
+   */
   identitySyncedAt: Date | null;
 }
 
@@ -341,6 +345,10 @@ export function computeBillingIdentitySignals(
           spanMinutes: Number((spanMs / 60_000).toFixed(1)),
           paymentMethodsFirstSeenAt: a.paymentMethodsFirstSeenAt?.toISOString() ?? null,
           paymentMethodsLastSeenAt: a.paymentMethodsLastSeenAt?.toISOString() ?? null,
+          // Snapshot age answers the operator's first triage question: is this
+          // burst happening now, or is it a stale row the billing service has
+          // not touched in weeks? It gates nothing — only the span does.
+          identitySyncedAt: a.identitySyncedAt?.toISOString() ?? null,
         },
       );
     }

--- a/apps/api/src/services/abuseSignals/billingIdentity.ts
+++ b/apps/api/src/services/abuseSignals/billingIdentity.ts
@@ -43,8 +43,17 @@ export interface BillingIdentityAggregate {
   /** Provider-side opaque card fingerprint; NULL for wallet/Link payments. */
   cardFingerprint: string | null;
   distinctPaymentMethods: number;
+  /**
+   * Bounds of the interval distinctPaymentMethods was accumulated over.
+   * billing.card_testing scores the SPAN between them — three cards seven
+   * minutes apart and three cards two years apart are the same count and
+   * completely different events. Either being NULL means the span is unknown,
+   * which must fail closed rather than read as a zero span.
+   */
+  paymentMethodsFirstSeenAt: Date | null;
+  paymentMethodsLastSeenAt: Date | null;
   failedAttempts: number;
-  /** When the billing service last refreshed this snapshot. */
+  /** When the billing service last refreshed this snapshot. Evidence only. */
   identitySyncedAt: Date | null;
 }
 
@@ -204,6 +213,18 @@ export function buildIdentityTokens(
   return tokens;
 }
 
+/**
+ * Milliseconds between two snapshot bounds, or null when the span is unknown
+ * (either bound missing) or incoherent (last before first). Null is never a
+ * zero span — every caller must treat it as "do not fire".
+ */
+export function spanMilliseconds(first: Date | null, last: Date | null): number | null {
+  if (first === null || last === null) return null;
+  const span = last.getTime() - first.getTime();
+  if (!Number.isFinite(span) || span < 0) return null;
+  return span;
+}
+
 export interface BillingIdentityScorerOptions {
   /** Injectable for tests; defaults to FREE_EMAIL_PROVIDER_LABELS. */
   freeEmailProviderLabels?: ReadonlySet<string>;
@@ -215,19 +236,22 @@ export interface BillingIdentityScorerOptions {
  *     meaningful token with the account identity.
  *   - billing.shared_card_fingerprint — the same non-null fingerprint appears
  *     under >= min_partners distinct partners in the corpus.
- *   - billing.card_testing — >= distinct_methods payment methods on a snapshot
- *     that is still inside the window.
+ *   - billing.card_testing — >= distinct_methods payment methods accumulated
+ *     inside a span of <= window_days.
  *
  * Known miss, on purpose: a cardholder sharing a token with the partner name
  * never fires. Tightening that (e.g. requiring a PERSON-name match) starts
  * flagging every operator who pays with a spouse's or parent company's card,
- * which is common and legitimate. Deliberately no youngWeight()/age decay.
+ * which is common and legitimate.
+ *
+ * Takes no clock at all — not `now`, not partnerCreatedAt — which is what makes
+ * "never age-decayed" structural rather than a convention, same as
+ * computeScriptSignals.
  */
 export function computeBillingIdentitySignals(
   aggregates: readonly BillingIdentityAggregate[],
   sharedFingerprints: ReadonlyMap<string, number>,
   cfg: SignalConfig,
-  now: Date,
   options: BillingIdentityScorerOptions = {},
 ): ComputedSignal[] {
   const freeLabels = options.freeEmailProviderLabels ?? FREE_EMAIL_PROVIDER_LABELS;
@@ -292,15 +316,20 @@ export function computeBillingIdentitySignals(
     }
 
     // --- billing.card_testing ---------------------------------------------
-    // The write side supplies a point-in-time distinct-method COUNT, not
-    // per-method timestamps, so the "short window" is applied to snapshot
-    // freshness: a count last refreshed outside window_days is history, not
-    // current evidence, and must not keep an open signal alive forever.
+    // N distinct payment methods accumulated INSIDE a short span. The span —
+    // not the count, and not snapshot recency — is what separates a testing
+    // burst from a long-lived account that has replaced an expired card a few
+    // times: both show the same count, and both may have synced this morning.
+    //
+    // Fails closed on an unknown span. A NULL first/last-seen (legacy row, or
+    // the billing service has not backfilled yet) is NOT a zero span; treating
+    // it as one would fire for every pre-existing partner with 3+ lifetime
+    // cards the moment this ships. Same for a reversed pair, which is bad data
+    // rather than an instantaneous burst.
     const methodThreshold = cfg['billing.card_testing.distinct_methods'];
     const windowMs = cfg['billing.card_testing.window_days'] * 86_400_000;
-    const syncAgeMs = a.identitySyncedAt ? now.getTime() - a.identitySyncedAt.getTime() : null;
-    const fresh = syncAgeMs !== null && syncAgeMs >= 0 && syncAgeMs <= windowMs;
-    if (fresh && a.distinctPaymentMethods >= methodThreshold) {
+    const spanMs = spanMilliseconds(a.paymentMethodsFirstSeenAt, a.paymentMethodsLastSeenAt);
+    if (spanMs !== null && spanMs <= windowMs && a.distinctPaymentMethods >= methodThreshold) {
       push(
         'billing.card_testing',
         cfg['billing.card_testing.base_score'] +
@@ -309,7 +338,9 @@ export function computeBillingIdentitySignals(
         {
           distinctPaymentMethods: a.distinctPaymentMethods,
           failedAttempts: a.failedAttempts,
-          identitySyncedAt: a.identitySyncedAt?.toISOString() ?? null,
+          spanMinutes: Number((spanMs / 60_000).toFixed(1)),
+          paymentMethodsFirstSeenAt: a.paymentMethodsFirstSeenAt?.toISOString() ?? null,
+          paymentMethodsLastSeenAt: a.paymentMethodsLastSeenAt?.toISOString() ?? null,
         },
       );
     }
@@ -333,11 +364,20 @@ interface AggregateRow {
   billing_cardholder_name: string | null;
   billing_card_fingerprint: string | null;
   billing_distinct_payment_methods: number | string | null;
+  billing_payment_methods_first_seen_at: string | Date | null;
+  billing_payment_methods_last_seen_at: string | Date | null;
   billing_failed_attempts: number | string | null;
   billing_identity_synced_at: string | Date | null;
   user_names: unknown;
   user_emails: unknown;
 }
+
+/** Parse a timestamptz column; an unparseable value is "unknown", never epoch. */
+const toDate = (value: string | Date | null): Date | null => {
+  if (value === null) return null;
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
 
 const stringArray = (value: unknown): string[] =>
   Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string' && v.length > 0) : [];
@@ -367,6 +407,8 @@ export async function loadBillingIdentityAggregates(): Promise<BillingIdentityRe
         p.billing_cardholder_name,
         p.billing_card_fingerprint,
         p.billing_distinct_payment_methods,
+        p.billing_payment_methods_first_seen_at,
+        p.billing_payment_methods_last_seen_at,
         p.billing_failed_attempts,
         p.billing_identity_synced_at
       FROM partners p
@@ -406,6 +448,8 @@ export async function loadBillingIdentityAggregates(): Promise<BillingIdentityRe
       s.billing_cardholder_name,
       s.billing_card_fingerprint,
       s.billing_distinct_payment_methods,
+      s.billing_payment_methods_first_seen_at,
+      s.billing_payment_methods_last_seen_at,
       s.billing_failed_attempts,
       s.billing_identity_synced_at,
       COALESCE(m.user_names, '{}') AS user_names,
@@ -424,8 +468,10 @@ export async function loadBillingIdentityAggregates(): Promise<BillingIdentityRe
       cardholderName: r.billing_cardholder_name,
       cardFingerprint: r.billing_card_fingerprint,
       distinctPaymentMethods: Number(r.billing_distinct_payment_methods ?? 0),
+      paymentMethodsFirstSeenAt: toDate(r.billing_payment_methods_first_seen_at),
+      paymentMethodsLastSeenAt: toDate(r.billing_payment_methods_last_seen_at),
       failedAttempts: Number(r.billing_failed_attempts ?? 0),
-      identitySyncedAt: r.billing_identity_synced_at ? new Date(String(r.billing_identity_synced_at)) : null,
+      identitySyncedAt: toDate(r.billing_identity_synced_at),
     };
   });
 

--- a/apps/api/src/services/abuseSignals/billingIdentity.ts
+++ b/apps/api/src/services/abuseSignals/billingIdentity.ts
@@ -1,0 +1,437 @@
+import { sql } from 'drizzle-orm';
+import { db } from '../../db';
+import { scoreToSeverity, type SignalConfig } from './config';
+import type { ComputedSignal } from './types';
+
+// ---------------------------------------------------------------------------
+// Billing-identity detector: billing.cardholder_name_mismatch /
+// billing.shared_card_fingerprint / billing.card_testing
+//
+// Contract (same as heuristics.ts and scriptContent.ts):
+// loadBillingIdentityAggregates() does bounded SQL, computeBillingIdentitySignals()
+// is pure and unit-tested.
+//
+// The partners.billing_* columns this reads are written EXCLUSIVELY by the
+// separate billing service from its payment-provider webhooks. Nothing here
+// calls a payment provider: the sweep runs hourly and must never depend on an
+// external API being up, nor leak sweep cadence to the provider.
+//
+// NEVER age-decayed (the pure scorer deliberately never sees partnerCreatedAt
+// or youngWeight()) — a cardholder name that matches nothing about the account
+// is evidence regardless of account age, same rationale as
+// fraud.failed_login_cluster and the script-content markers.
+//
+// Cross-tenant corpus rule (mirrors rmm.shared_installer_host): fingerprints
+// are correlated over ALL partners regardless of status — a suspended partner
+// must stay in the corpus or the re-signup it is correlated with goes unseen —
+// but signals are only attributed to active, non-deleted partners.
+//
+// Coverage caveat: wallet/Link-style payments expose no card fingerprint, so
+// billing_card_fingerprint is frequently NULL. NULL is "unknown" and can never
+// match another NULL; name matching is the primary signal.
+// ---------------------------------------------------------------------------
+
+export interface BillingIdentityAggregate {
+  partnerId: string;
+  partnerName: string;
+  /** Partner billing email + member emails (bounded). Used for local-part and domain tokens. */
+  emails: string[];
+  /** Member display names (bounded). */
+  userNames: string[];
+  /** Name on the payment instrument, as reported by the billing service. */
+  cardholderName: string | null;
+  /** Provider-side opaque card fingerprint; NULL for wallet/Link payments. */
+  cardFingerprint: string | null;
+  distinctPaymentMethods: number;
+  failedAttempts: number;
+  /** When the billing service last refreshed this snapshot. */
+  identitySyncedAt: Date | null;
+}
+
+export interface BillingIdentityResult {
+  /** Aggregates for partners in the evaluated (active, non-deleted) scope only. */
+  aggregates: BillingIdentityAggregate[];
+  /** fingerprint -> distinct partner count (>= 2), computed over the FULL corpus. */
+  sharedFingerprints: Map<string, number>;
+  /** Partner ids scored this sweep — fed into evaluatedPartnerIds so open rows stale-resolve. */
+  scannedPartnerIds: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Matching algorithm (pure)
+// ---------------------------------------------------------------------------
+
+/** Tokens shorter than this are noise (initials, "of", "&"). */
+const MIN_TOKEN_LENGTH = 3;
+
+/**
+ * Letters that do not decompose under NFKD, so the combining-mark strip below
+ * cannot fold them. Without these, e.g. a Nordic "ø" spelling and its "o"
+ * spelling tokenize differently and read as a mismatch.
+ */
+const NON_DECOMPOSING_FOLDS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/ß/g, 'ss'],
+  [/æ/g, 'ae'],
+  [/œ/g, 'oe'],
+  [/ø/g, 'o'],
+  [/đ|ð/g, 'd'],
+  [/ł/g, 'l'],
+  [/þ/g, 'th'],
+  [/ı/g, 'i'],
+];
+
+/**
+ * Tokens that carry no identity: corporate suffixes and industry filler. A
+ * partner named "<something> IT Solutions" and a cardholder named
+ * "<someone else> Solutions" share nothing meaningful, and letting "solutions"
+ * count as a match would silently disable the signal for most MSP names.
+ */
+const STOP_TOKENS: ReadonlySet<string> = new Set([
+  'and', 'the', 'for', 'llc', 'inc', 'ltd', 'limited', 'corp', 'corporation',
+  'company', 'holdings', 'holding', 'group', 'groupe', 'gmbh', 'bhd', 'pty',
+  'plc', 'sarl', 'srl', 'spa', 'oyj', 'aps',
+  'services', 'service', 'solutions', 'solution', 'systems', 'system',
+  'technologies', 'technology', 'tech', 'consulting', 'consultants',
+  'consultant', 'partners', 'partner', 'managed', 'management',
+  'computer', 'computers', 'computing', 'network', 'networks', 'networking',
+  'support', 'helpdesk', 'digital', 'data', 'cloud', 'cyber', 'global',
+  'international', 'enterprises', 'enterprise', 'associates', 'agency',
+  'studio', 'studios', 'labs', 'works', 'online', 'internet', 'software',
+  'info', 'admin', 'billing', 'accounts', 'accounting', 'finance', 'office',
+  'mail', 'email', 'contact', 'hello', 'sales', 'team',
+]);
+
+/**
+ * Second-level labels that are public suffixes rather than the registrable
+ * name, so `<name>.co.uk` resolves its base label to `<name>`, not `co`.
+ */
+const PUBLIC_SECOND_LEVEL_LABELS: ReadonlySet<string> = new Set([
+  'co', 'com', 'net', 'org', 'gov', 'edu', 'ac', 'or', 'ne', 'go',
+]);
+
+/**
+ * Free/consumer mailbox providers, matched on the registrable base label so
+ * ccTLD variants (yahoo.co.uk, gmx.de) fold to the same entry.
+ *
+ * These contribute NO domain token. Without the exclusion, a partner on a
+ * consumer mailbox would have "gmail" in its identity token set — a token no
+ * cardholder name ever contains, so every such account would fire on the
+ * domain axis and the signal would teach nothing. Not sensitive; deliberately
+ * in code rather than an env indicator list.
+ */
+export const FREE_EMAIL_PROVIDER_LABELS: ReadonlySet<string> = new Set([
+  'gmail', 'googlemail', 'outlook', 'hotmail', 'live', 'msn', 'passport',
+  'yahoo', 'ymail', 'rocketmail', 'aol', 'aim', 'proton', 'protonmail',
+  'icloud', 'mac', 'gmx', 'web', 'mail', 'email', 'inbox', 'yandex',
+  'zoho', 'fastmail', 'hey', 'tutanota', 'tuta', 'hushmail',
+  'qq', 'naver', 'daum', 'hanmail', 'seznam', 'libero', 'orange', 'free',
+  'wanadoo', 'laposte', 'sfr', 'bol', 'uol', 'terra', 'rediffmail', 'sina',
+  'comcast', 'verizon', 'sbcglobal', 'bellsouth', 'earthlink', 'juno',
+  'btinternet', 'virginmedia', 'talktalk', 'ntlworld', 'blueyonder',
+  'bigpond', 'optusnet', 'xtra', 'shaw', 'telus', 'rogers', 'sympatico',
+  'mailinator', 'guerrillamail', 'yopmail', 'maildrop', 'dispostable',
+  'sharklasers', 'trashmail', 'getnada', 'fakeinbox',
+]);
+
+/** Lowercase, fold diacritics and non-decomposing letters. Pure; exported for tests. */
+export function normalizeIdentityText(value: string): string {
+  let out = value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+  for (const [pattern, replacement] of NON_DECOMPOSING_FOLDS) out = out.replace(pattern, replacement);
+  return out;
+}
+
+/**
+ * Order-independent token set: normalize, split on punctuation, drop digits
+ * (a mailbox `<name>91` is still that name), drop short tokens and stop words.
+ */
+export function identityTokens(value: string): string[] {
+  return normalizeIdentityText(value)
+    .split(/[^a-z0-9]+/)
+    .map((token) => token.replace(/[0-9]+/g, ''))
+    .filter((token) => token.length >= MIN_TOKEN_LENGTH && !STOP_TOKENS.has(token));
+}
+
+const emailLocalPart = (email: string): string | null => {
+  const at = email.lastIndexOf('@');
+  return at > 0 ? email.slice(0, at) : null;
+};
+
+const emailDomain = (email: string): string | null => {
+  const at = email.lastIndexOf('@');
+  const domain = at > 0 ? email.slice(at + 1).toLowerCase().trim() : '';
+  return domain.length > 0 ? domain : null;
+};
+
+/** Domain labels that carry identity: everything left of the TLD (and of a public 2LD suffix). */
+export function domainIdentityLabels(domain: string): string[] {
+  const labels = domain.toLowerCase().split('.').filter((label) => label.length > 0);
+  if (labels.length < 2) return [];
+  let end = labels.length - 1; // drop the TLD label
+  const secondLevel = labels[end - 1];
+  if (end >= 1 && secondLevel !== undefined && PUBLIC_SECOND_LEVEL_LABELS.has(secondLevel)) end -= 1;
+  return labels.slice(0, end);
+}
+
+/** True when the mailbox domain is a free/consumer provider (base-label match). */
+export function isFreeEmailProvider(domain: string, freeLabels: ReadonlySet<string>): boolean {
+  const labels = domainIdentityLabels(domain);
+  const base = labels[labels.length - 1];
+  return base !== undefined && freeLabels.has(base);
+}
+
+/**
+ * The account's identity token set: partner name, every member's display name,
+ * every mailbox local-part, and — for non-free mailbox domains only — the
+ * domain labels.
+ */
+export function buildIdentityTokens(
+  aggregate: Pick<BillingIdentityAggregate, 'partnerName' | 'userNames' | 'emails'>,
+  freeLabels: ReadonlySet<string> = FREE_EMAIL_PROVIDER_LABELS,
+): Set<string> {
+  const tokens = new Set<string>(identityTokens(aggregate.partnerName));
+  for (const name of aggregate.userNames) {
+    for (const token of identityTokens(name)) tokens.add(token);
+  }
+  for (const email of aggregate.emails) {
+    const local = emailLocalPart(email);
+    if (local) for (const token of identityTokens(local)) tokens.add(token);
+    const domain = emailDomain(email);
+    if (!domain || isFreeEmailProvider(domain, freeLabels)) continue;
+    for (const label of domainIdentityLabels(domain)) {
+      for (const token of identityTokens(label)) tokens.add(token);
+    }
+  }
+  return tokens;
+}
+
+export interface BillingIdentityScorerOptions {
+  /** Injectable for tests; defaults to FREE_EMAIL_PROVIDER_LABELS. */
+  freeEmailProviderLabels?: ReadonlySet<string>;
+}
+
+/**
+ * Pure scoring: no I/O, unit-testable. Emits per-partner:
+ *   - billing.cardholder_name_mismatch — the cardholder name shares no
+ *     meaningful token with the account identity.
+ *   - billing.shared_card_fingerprint — the same non-null fingerprint appears
+ *     under >= min_partners distinct partners in the corpus.
+ *   - billing.card_testing — >= distinct_methods payment methods on a snapshot
+ *     that is still inside the window.
+ *
+ * Known miss, on purpose: a cardholder sharing a token with the partner name
+ * never fires. Tightening that (e.g. requiring a PERSON-name match) starts
+ * flagging every operator who pays with a spouse's or parent company's card,
+ * which is common and legitimate. Deliberately no youngWeight()/age decay.
+ */
+export function computeBillingIdentitySignals(
+  aggregates: readonly BillingIdentityAggregate[],
+  sharedFingerprints: ReadonlyMap<string, number>,
+  cfg: SignalConfig,
+  now: Date,
+  options: BillingIdentityScorerOptions = {},
+): ComputedSignal[] {
+  const freeLabels = options.freeEmailProviderLabels ?? FREE_EMAIL_PROVIDER_LABELS;
+  const minPartners = cfg['billing.shared_card_fingerprint.min_partners'];
+  const signals: ComputedSignal[] = [];
+
+  for (const a of aggregates) {
+    const push = (signalKey: string, rawScore: number, evidence: Record<string, unknown>) => {
+      const score = Math.min(100, Math.round(rawScore));
+      if (!(score > 0)) return;
+      signals.push({
+        partnerId: a.partnerId,
+        signalKey,
+        score,
+        severity: scoreToSeverity(score, cfg),
+        evidence: { partnerName: a.partnerName, ...evidence },
+      });
+    };
+
+    // --- billing.cardholder_name_mismatch ---------------------------------
+    const cardholder = a.cardholderName?.trim() ?? '';
+    if (cardholder.length > 0) {
+      const cardholderSet = identityTokens(cardholder);
+      const accountSet = buildIdentityTokens(a, freeLabels);
+      // Both sides must be non-empty: an account whose every token was a stop
+      // word has nothing to compare against, and "no data" is not evidence.
+      const comparable = cardholderSet.length > 0 && accountSet.size > 0;
+      if (comparable && !cardholderSet.some((token) => accountSet.has(token))) {
+        push(
+          'billing.cardholder_name_mismatch',
+          cfg['billing.cardholder_name_mismatch.score'] +
+            cfg['billing.cardholder_name_mismatch.failed_attempt_bonus'] * a.failedAttempts,
+          {
+            // The operator cannot triage a name mismatch without the name.
+            cardholderName: cardholder,
+            failedAttempts: a.failedAttempts,
+          },
+        );
+      }
+    }
+
+    // --- billing.shared_card_fingerprint ----------------------------------
+    // NULL/blank fingerprints are skipped outright: a wallet payment that
+    // exposes no fingerprint must never correlate with another one.
+    const fingerprint = a.cardFingerprint?.trim() ?? '';
+    if (fingerprint.length > 0) {
+      const partnerCount = sharedFingerprints.get(fingerprint) ?? 0;
+      if (partnerCount >= minPartners) {
+        push(
+          'billing.shared_card_fingerprint',
+          cfg['billing.shared_card_fingerprint.base_score'] +
+            cfg['billing.shared_card_fingerprint.per_extra_partner'] * (partnerCount - minPartners),
+          {
+            // Prefix only — enough to join the affected partners together in a
+            // follow-up query without pasting a full payment-instrument
+            // identifier into a chat alert.
+            cardFingerprintPrefix: fingerprint.slice(0, 12),
+            partnerCount,
+          },
+        );
+      }
+    }
+
+    // --- billing.card_testing ---------------------------------------------
+    // The write side supplies a point-in-time distinct-method COUNT, not
+    // per-method timestamps, so the "short window" is applied to snapshot
+    // freshness: a count last refreshed outside window_days is history, not
+    // current evidence, and must not keep an open signal alive forever.
+    const methodThreshold = cfg['billing.card_testing.distinct_methods'];
+    const windowMs = cfg['billing.card_testing.window_days'] * 86_400_000;
+    const syncAgeMs = a.identitySyncedAt ? now.getTime() - a.identitySyncedAt.getTime() : null;
+    const fresh = syncAgeMs !== null && syncAgeMs >= 0 && syncAgeMs <= windowMs;
+    if (fresh && a.distinctPaymentMethods >= methodThreshold) {
+      push(
+        'billing.card_testing',
+        cfg['billing.card_testing.base_score'] +
+          cfg['billing.card_testing.per_extra_method'] * (a.distinctPaymentMethods - methodThreshold) +
+          cfg['billing.card_testing.per_failed_attempt'] * a.failedAttempts,
+        {
+          distinctPaymentMethods: a.distinctPaymentMethods,
+          failedAttempts: a.failedAttempts,
+          identitySyncedAt: a.identitySyncedAt?.toISOString() ?? null,
+        },
+      );
+    }
+  }
+
+  return signals;
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+/** Bound every text read; never pull unbounded fleet-wide text. */
+const TEXT_CAP = 255;
+const MEMBERS_PER_PARTNER_CAP = 50;
+
+interface AggregateRow {
+  id: string;
+  name: string;
+  billing_email: string | null;
+  billing_cardholder_name: string | null;
+  billing_card_fingerprint: string | null;
+  billing_distinct_payment_methods: number | string | null;
+  billing_failed_attempts: number | string | null;
+  billing_identity_synced_at: string | Date | null;
+  user_names: unknown;
+  user_emails: unknown;
+}
+
+const stringArray = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string' && v.length > 0) : [];
+
+/**
+ * Loads the billing-identity snapshot plus the cross-partner fingerprint
+ * corpus. MUST run inside a system DB context — bare breeze_app reads return
+ * 0 rows.
+ */
+export async function loadBillingIdentityAggregates(): Promise<BillingIdentityResult> {
+  // --- 1. Fingerprint correlation over ALL partners (corpus rule) ----------
+  // No status/deleted filter on purpose: a suspended partner must stay in the
+  // corpus, otherwise the re-signup that reuses its card looks clean.
+  const sharedRows = (await db.execute(sql`
+    SELECT billing_card_fingerprint AS fingerprint, COUNT(DISTINCT id) AS partner_count
+    FROM partners
+    WHERE billing_card_fingerprint IS NOT NULL AND btrim(billing_card_fingerprint) <> ''
+    GROUP BY billing_card_fingerprint
+    HAVING COUNT(DISTINCT id) >= 2
+  `)) as unknown as Array<{ fingerprint: string; partner_count: string }>;
+  const sharedFingerprints = new Map(sharedRows.map((r) => [r.fingerprint, Number(r.partner_count)]));
+
+  // --- 2. Aggregates for the evaluated scope only --------------------------
+  const rows = (await db.execute(sql`
+    WITH scoped AS (
+      SELECT p.id, p.name, p.billing_email,
+        p.billing_cardholder_name,
+        p.billing_card_fingerprint,
+        p.billing_distinct_payment_methods,
+        p.billing_failed_attempts,
+        p.billing_identity_synced_at
+      FROM partners p
+      WHERE p.deleted_at IS NULL AND p.status = 'active'
+        AND (
+          p.billing_cardholder_name IS NOT NULL
+          OR p.billing_card_fingerprint IS NOT NULL
+          OR p.billing_distinct_payment_methods > 0
+          -- Keep re-evaluating partners with an open billing signal even after
+          -- the billing service clears the snapshot, so the row resolves on
+          -- evidence rather than being stranded open by scope exit.
+          OR EXISTS (
+            SELECT 1 FROM partner_abuse_signals pas
+            WHERE pas.partner_id = p.id AND pas.resolved_at IS NULL
+              AND pas.signal_key LIKE 'billing.%'
+          )
+        )
+    ),
+    members AS (
+      SELECT partner_id, member_name, member_email FROM (
+        SELECT u.partner_id,
+          left(u.name, ${TEXT_CAP}) AS member_name,
+          left(u.email, ${TEXT_CAP}) AS member_email,
+          row_number() OVER (PARTITION BY u.partner_id ORDER BY u.created_at) AS rn
+        FROM users u
+        WHERE u.partner_id IN (SELECT id FROM scoped)
+      ) bounded
+      WHERE rn <= ${MEMBERS_PER_PARTNER_CAP}
+    ),
+    member_agg AS (
+      SELECT partner_id,
+        array_agg(member_name) AS user_names,
+        array_agg(member_email) AS user_emails
+      FROM members GROUP BY partner_id
+    )
+    SELECT s.id, s.name, s.billing_email,
+      s.billing_cardholder_name,
+      s.billing_card_fingerprint,
+      s.billing_distinct_payment_methods,
+      s.billing_failed_attempts,
+      s.billing_identity_synced_at,
+      COALESCE(m.user_names, '{}') AS user_names,
+      COALESCE(m.user_emails, '{}') AS user_emails
+    FROM scoped s
+    LEFT JOIN member_agg m ON m.partner_id = s.id
+  `)) as unknown as AggregateRow[];
+
+  const aggregates: BillingIdentityAggregate[] = rows.map((r) => {
+    const emails = [...(r.billing_email ? [r.billing_email] : []), ...stringArray(r.user_emails)];
+    return {
+      partnerId: String(r.id),
+      partnerName: String(r.name),
+      emails,
+      userNames: stringArray(r.user_names),
+      cardholderName: r.billing_cardholder_name,
+      cardFingerprint: r.billing_card_fingerprint,
+      distinctPaymentMethods: Number(r.billing_distinct_payment_methods ?? 0),
+      failedAttempts: Number(r.billing_failed_attempts ?? 0),
+      identitySyncedAt: r.billing_identity_synced_at ? new Date(String(r.billing_identity_synced_at)) : null,
+    };
+  });
+
+  return {
+    aggregates,
+    sharedFingerprints,
+    scannedPartnerIds: [...new Set(aggregates.map((a) => a.partnerId))],
+  };
+}

--- a/apps/api/src/services/abuseSignals/config.ts
+++ b/apps/api/src/services/abuseSignals/config.ts
@@ -53,7 +53,15 @@ export const SIGNAL_DEFAULTS = {
   'billing.shared_card_fingerprint.base_score': 70,
   'billing.shared_card_fingerprint.per_extra_partner': 15,
   'billing.card_testing.distinct_methods': 3,
-  'billing.card_testing.window_days': 7,
+  // The window is the SPAN the distinct methods were accumulated over
+  // (last_seen - first_seen), not a recency check. A card-testing burst is
+  // minutes; a legitimate MSP replacing an expired card is months or years
+  // apart. 1 day sits far above the burst and far below any legitimate
+  // re-card cadence, and still covers an adversary pacing attempts across a
+  // working day. It deliberately does also catch a genuine
+  // decline-then-retry-twice signup — that is a watch-tier review, not an
+  // alert, which is why 3 methods alone scores below severity.alert_score.
+  'billing.card_testing.window_days': 1,
   'billing.card_testing.base_score': 50,
   'billing.card_testing.per_extra_method': 15,
   'billing.card_testing.per_failed_attempt': 5,

--- a/apps/api/src/services/abuseSignals/config.ts
+++ b/apps/api/src/services/abuseSignals/config.ts
@@ -42,6 +42,21 @@ export const SIGNAL_DEFAULTS = {
   'rmm.shared_installer_host.min_partners': 2,
   'rmm.shared_installer_host.base_score': 60,
   'rmm.shared_installer_host.per_extra_partner': 20,
+  // Billing-identity detector (billingIdentity.ts). Like the script-content
+  // detector, NONE of these are age-decayed — a cardholder name that matches
+  // nothing about the account is evidence regardless of how old the account is.
+  // A name mismatch alone caps below alert: legitimate operators do pay with a
+  // spouse's or a parent company's card.
+  'billing.cardholder_name_mismatch.score': 55,
+  'billing.cardholder_name_mismatch.failed_attempt_bonus': 5,
+  'billing.shared_card_fingerprint.min_partners': 2,
+  'billing.shared_card_fingerprint.base_score': 70,
+  'billing.shared_card_fingerprint.per_extra_partner': 15,
+  'billing.card_testing.distinct_methods': 3,
+  'billing.card_testing.window_days': 7,
+  'billing.card_testing.base_score': 50,
+  'billing.card_testing.per_extra_method': 15,
+  'billing.card_testing.per_failed_attempt': 5,
 } as const satisfies Record<string, number>;
 
 export type SignalConfigKey = keyof typeof SIGNAL_DEFAULTS;

--- a/apps/api/src/services/abuseSignals/index.ts
+++ b/apps/api/src/services/abuseSignals/index.ts
@@ -62,8 +62,10 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
     // of account age.
     ...computeScriptSignals(scriptFindings.findings, scriptFindings.sharedHosts, cfg, loadScriptIndicators()),
     // Identity signals are likewise never age-decayed — a cardholder name that
-    // matches nothing about the account is evidence at any account age.
-    ...computeBillingIdentitySignals(billingIdentity.aggregates, billingIdentity.sharedFingerprints, cfg, now),
+    // matches nothing about the account is evidence at any account age. The
+    // scorer takes no clock at all; card-testing is scored on the span the
+    // billing service recorded, not on how recently the sweep ran.
+    ...computeBillingIdentitySignals(billingIdentity.aggregates, billingIdentity.sharedFingerprints, cfg),
   ];
   // Script-scanned and billing-scanned partners join the evaluated set so open
   // rows for those detectors stale-resolve when the evidence disappears

--- a/apps/api/src/services/abuseSignals/index.ts
+++ b/apps/api/src/services/abuseSignals/index.ts
@@ -6,6 +6,7 @@ import { loadSignalConfig } from './config';
 import { computeInvariantSignals } from './invariants';
 import { loadPartnerAggregates, computeHeuristicSignals } from './heuristics';
 import { loadScriptFindings, computeScriptSignals, loadScriptIndicators } from './scriptContent';
+import { loadBillingIdentityAggregates, computeBillingIdentitySignals } from './billingIdentity';
 import { persistSignals, markDelivered } from './persistence';
 import type { ComputedSignal } from './types';
 
@@ -46,10 +47,11 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
   const cfg = loadSignalConfig();
   const now = new Date();
 
-  const { invariants, aggregates, scriptFindings } = await runSystemDbCompute(async () => ({
+  const { invariants, aggregates, scriptFindings, billingIdentity } = await runSystemDbCompute(async () => ({
     invariants: await computeInvariantSignals(),
     aggregates: await loadPartnerAggregates(),
     scriptFindings: await loadScriptFindings(now),
+    billingIdentity: await loadBillingIdentityAggregates(),
   }));
 
   const computed = [
@@ -59,12 +61,18 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
     // no partner age at all) — a malicious installer is malicious regardless
     // of account age.
     ...computeScriptSignals(scriptFindings.findings, scriptFindings.sharedHosts, cfg, loadScriptIndicators()),
+    // Identity signals are likewise never age-decayed — a cardholder name that
+    // matches nothing about the account is evidence at any account age.
+    ...computeBillingIdentitySignals(billingIdentity.aggregates, billingIdentity.sharedFingerprints, cfg, now),
   ];
-  // Script-scanned partners join the evaluated set so open script-signal rows
-  // stale-resolve when the evidence disappears (script edited/deleted).
+  // Script-scanned and billing-scanned partners join the evaluated set so open
+  // rows for those detectors stale-resolve when the evidence disappears
+  // (script edited/deleted, cardholder name corrected). persistSignals only
+  // auto-resolves `invariant.*` rows or rows whose partner is in this set.
   const evaluatedPartnerIds = new Set([
     ...aggregates.map((a) => a.partnerId),
     ...scriptFindings.scannedPartnerIds,
+    ...billingIdentity.scannedPartnerIds,
   ]);
   const { toNotify } = await runSystemDbCompute(() => persistSignals(computed, now, evaluatedPartnerIds));
 

--- a/apps/api/src/services/abuseSignals/invariants.test.ts
+++ b/apps/api/src/services/abuseSignals/invariants.test.ts
@@ -17,10 +17,14 @@ describe('computeInvariantSignals', () => {
       // active_no_payment
       .mockResolvedValueOnce([{ id: 'p3', name: 'NoPay Co', created_at: '2026-06-20' }] as never)
       // inactive_partner_with_agents
-      .mockResolvedValueOnce([{ id: 'p2', name: 'Bad Co', status: 'suspended', device_count: '4' }] as never);
+      .mockResolvedValueOnce([{ id: 'p2', name: 'Bad Co', status: 'suspended', device_count: '4' }] as never)
+      // suspended_partner_active_subscription
+      .mockResolvedValueOnce([
+        { id: 'p4', name: 'Still Billed Co', status: 'suspended', billing_subscription_status: 'active' },
+      ] as never);
 
     const signals = await computeInvariantSignals();
-    expect(signals).toHaveLength(3);
+    expect(signals).toHaveLength(4);
     expect(signals[0]).toMatchObject({
       partnerId: 'p1',
       signalKey: 'invariant.active_unverified_email',
@@ -41,10 +45,48 @@ describe('computeInvariantSignals', () => {
       severity: 'alert',
       evidence: expect.objectContaining({ deviceCount: 4, partnerStatus: 'suspended' }),
     });
+    expect(signals[3]).toMatchObject({
+      partnerId: 'p4',
+      signalKey: 'invariant.suspended_partner_active_subscription',
+      severity: 'alert',
+      score: 100,
+      evidence: expect.objectContaining({
+        partnerName: 'Still Billed Co',
+        partnerStatus: 'suspended',
+        subscriptionStatus: 'active',
+      }),
+    });
   });
 
   it('returns empty when all invariants hold', async () => {
     vi.mocked(db.execute).mockResolvedValue([] as never);
     expect(await computeInvariantSignals()).toEqual([]);
+  });
+
+  it('is silent for an active partner with a live subscription', async () => {
+    // The suspended_partner_active_subscription query filters status <> 'active'
+    // in SQL, so a healthy paying partner never reaches the loop. Empty result
+    // set from every invariant query => no signals at all.
+    vi.mocked(db.execute).mockResolvedValue([] as never);
+    const signals = await computeInvariantSignals();
+    expect(signals.some((s) => s.signalKey === 'invariant.suspended_partner_active_subscription')).toBe(false);
+  });
+
+  it('never age-weights the suspended-subscription invariant', async () => {
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([
+        { id: 'p9', name: 'Old Co', status: 'pending', billing_subscription_status: 'past_due' },
+      ] as never);
+
+    const signals = await computeInvariantSignals();
+    expect(signals).toHaveLength(1);
+    expect(signals[0]).toMatchObject({
+      signalKey: 'invariant.suspended_partner_active_subscription',
+      score: 100,
+      severity: 'alert',
+    });
   });
 });

--- a/apps/api/src/services/abuseSignals/invariants.ts
+++ b/apps/api/src/services/abuseSignals/invariants.ts
@@ -58,5 +58,41 @@ export async function computeInvariantSignals(): Promise<ComputedSignal[]> {
     });
   }
 
+  // A partner we took out of 'active' is still being billed. Lives here rather
+  // than in heuristics.ts for two structural reasons: the heuristics `scoped`
+  // CTE filters p.status = 'active', so it can never see a suspended partner,
+  // and its push() age-decays — a suspended account's live subscription is a
+  // breach at any account age. Pure SQL against the snapshot the billing
+  // service writes; the sweep NEVER calls the payment provider.
+  //
+  // Detection only. Cancelling the subscription is a money-affecting external
+  // write (refund-vs-leave is a business decision) and is deliberately out of
+  // scope for the sweep.
+  const suspendedButSubscribed = (await db.execute(sql`
+    SELECT id, name, status, billing_subscription_status FROM partners
+    WHERE status <> 'active'
+      AND billing_subscription_status IN ('active', 'past_due')
+      -- Intentionally omit deleted_at IS NULL: a soft-deleted partner still
+      -- carrying a live subscription is itself the anomaly.
+  `)) as unknown as Array<{
+    id: string;
+    name: string;
+    status: string;
+    billing_subscription_status: string;
+  }>;
+  for (const p of suspendedButSubscribed) {
+    signals.push({
+      partnerId: p.id,
+      signalKey: 'invariant.suspended_partner_active_subscription',
+      score: 100,
+      severity: 'alert',
+      evidence: {
+        partnerName: p.name,
+        partnerStatus: p.status,
+        subscriptionStatus: p.billing_subscription_status,
+      },
+    });
+  }
+
   return signals;
 }

--- a/apps/api/src/services/abuseSignals/sweep.test.ts
+++ b/apps/api/src/services/abuseSignals/sweep.test.ts
@@ -9,6 +9,8 @@ const {
   loadScriptFindings,
   computeScriptSignals,
   loadScriptIndicators,
+  loadBillingIdentityAggregates,
+  computeBillingIdentitySignals,
   persistSignals,
   markDelivered,
   sendOpsAlert,
@@ -20,6 +22,8 @@ const {
   loadScriptFindings: vi.fn(),
   computeScriptSignals: vi.fn(),
   loadScriptIndicators: vi.fn(),
+  loadBillingIdentityAggregates: vi.fn(),
+  computeBillingIdentitySignals: vi.fn(),
   persistSignals: vi.fn(),
   markDelivered: vi.fn(),
   sendOpsAlert: vi.fn(),
@@ -40,6 +44,7 @@ vi.mock('../../db', () => ({
 vi.mock('./invariants', () => ({ computeInvariantSignals }));
 vi.mock('./heuristics', () => ({ loadPartnerAggregates, computeHeuristicSignals }));
 vi.mock('./scriptContent', () => ({ loadScriptFindings, computeScriptSignals, loadScriptIndicators }));
+vi.mock('./billingIdentity', () => ({ loadBillingIdentityAggregates, computeBillingIdentitySignals }));
 vi.mock('./persistence', () => ({ persistSignals, markDelivered }));
 vi.mock('../opsAlerts', () => ({ sendOpsAlert, isOpsAlertingConfigured: vi.fn(() => true) }));
 vi.mock('../abuseMetrics', () => ({ recordAbuseSignalFired, recordAbuseSweepRun: vi.fn() }));
@@ -86,6 +91,12 @@ beforeEach(() => {
   loadScriptFindings.mockResolvedValue({ findings: [], sharedHosts: new Map(), scannedPartnerIds: [] });
   computeScriptSignals.mockReturnValue([]);
   loadScriptIndicators.mockReturnValue({ tlds: [], hosts: [] });
+  loadBillingIdentityAggregates.mockResolvedValue({
+    aggregates: [],
+    sharedFingerprints: new Map(),
+    scannedPartnerIds: [],
+  });
+  computeBillingIdentitySignals.mockReturnValue([]);
   persistSignals.mockResolvedValue({ toNotify: [] });
   markDelivered.mockResolvedValue(undefined);
 });
@@ -151,6 +162,37 @@ describe('runAbuseSweep', () => {
 
     const evaluatedPartnerIds = persistSignals.mock.calls[0]![2] as Set<string>;
     expect([...evaluatedPartnerIds].sort()).toEqual(['pA', 'pScript']);
+  });
+
+  it('unions billing-scanned partner ids into evaluatedPartnerIds so billing signals can stale-resolve', async () => {
+    loadPartnerAggregates.mockResolvedValue([agg({ partnerId: 'pA' })]);
+    loadBillingIdentityAggregates.mockResolvedValue({
+      aggregates: [],
+      sharedFingerprints: new Map(),
+      scannedPartnerIds: ['pA', 'pBilling'],
+    });
+
+    await runAbuseSweep();
+
+    const evaluatedPartnerIds = persistSignals.mock.calls[0]![2] as Set<string>;
+    expect([...evaluatedPartnerIds].sort()).toEqual(['pA', 'pBilling']);
+  });
+
+  it('includes computeBillingIdentitySignals output in the persisted signal set', async () => {
+    const billingSignal: ComputedSignal = {
+      partnerId: 'pB',
+      signalKey: 'billing.shared_card_fingerprint',
+      score: 70,
+      severity: 'alert',
+      evidence: {},
+    };
+    computeBillingIdentitySignals.mockReturnValue([billingSignal]);
+
+    const result = await runAbuseSweep();
+
+    expect(result.fired).toBe(1);
+    const persisted = persistSignals.mock.calls[0]![0] as ComputedSignal[];
+    expect(persisted).toContainEqual(billingSignal);
   });
 
   it('includes computeScriptSignals output in the persisted signal set', async () => {


### PR DESCRIPTION
Adds a billing-identity detector to the hourly abuse sweep, plus one new activation invariant. Both read a nullable billing snapshot stored on `partners`.

**The `partners.billing_*` columns added here are written by the separate billing service** from its payment-provider webhooks. Nothing in this repo writes them, and the sweep never calls a payment provider — it is pure SQL against the snapshot. A companion billing-side PR must merge **after** this migration so the write side has columns to write into.

## Migration

`apps/api/migrations/2026-07-25-partner-billing-identity.sql` — idempotent, no inner `BEGIN`/`COMMIT`. Nine nullable columns on the existing `partners` table plus a partial index on the fingerprint:

| Column | Type |
|---|---|
| `billing_cardholder_name` | `text` |
| `billing_card_country` | `char(2)` |
| `billing_card_fingerprint` | `text` |
| `billing_distinct_payment_methods` | `integer NOT NULL DEFAULT 0` |
| `billing_payment_methods_first_seen_at` | `timestamptz` |
| `billing_payment_methods_last_seen_at` | `timestamptz` |
| `billing_failed_attempts` | `integer NOT NULL DEFAULT 0` |
| `billing_identity_synced_at` | `timestamptz` |
| `billing_subscription_status` | `text` |

Columns on `partners` rather than a new table on purpose: `partners` already carries RLS + policies and is already registered in every cascade list, so a nullable-column extension adds no new tenancy surface and no cascade-list registration is required.

**None of these are added to `partnerPublicColumns()` in `routes/orgs.ts`.** Cardholder name and card fingerprint are exactly what must never reach a partner-scoped token. The existing projection tests for `GET`/`PATCH /orgs/partners/me` (and the list/create handlers) now assert their absence.

## Signals

New module `apps/api/src/services/abuseSignals/billingIdentity.ts`, same contract as its siblings: a bounded SQL loader (`loadBillingIdentityAggregates`) plus a pure, unit-tested scorer (`computeBillingIdentitySignals`).

- **`billing.cardholder_name_mismatch`** — order-independent token-set overlap of the cardholder name against the partner name, every member display name, every mailbox local-part, and (for non-free mailbox domains only) the domain labels. Both sides normalize identically: NFKD, combining marks stripped, non-decomposing letters folded (`ø`, `ß`, `æ`, …), punctuation split, digits dropped, generic corporate/industry stop words removed. One shared meaningful token is a match. Free/consumer mailbox providers contribute no domain token — otherwise every consumer-mailbox account would fire on an axis no cardholder name can satisfy, and the signal would teach nothing. The free-provider list is matched on the registrable base label so ccTLD variants fold to one entry; it lives in code (not sensitive) but the scorer accepts an injected list for tests.
  Documented known miss: a cardholder sharing a token with the *partner name* never fires. Tightening that starts flagging operators paying with a spouse's or a parent company's card, so it is deliberately left alone.
- **`billing.shared_card_fingerprint`** — cross-tenant, mirroring `rmm.shared_installer_host`: fingerprints are correlated over **all** partners regardless of status (a suspended partner must stay in the corpus or the re-signup reusing its card looks clean), but signals are attributed only to active, non-deleted partners. NULL/blank fingerprints are skipped outright, so two wallet-style payments that expose no fingerprint can never correlate with each other.
- **`billing.card_testing`** — distinct payment methods at or above the threshold accumulated inside a **span** of at most `window_days`, escalated by extra methods and failed attempts. The span is `billing_payment_methods_last_seen_at - billing_payment_methods_first_seen_at`, i.e. literally "N distinct cards within a short window". The count alone cannot carry this signal: three cards seven minutes apart and three cards replaced over two years are the same count, and both may have synced this morning.
  **Fails closed on an unknown span.** A NULL first/last-seen — legacy rows, or the billing service not yet backfilled — is *not* a zero span, and neither is a reversed pair; both are treated as "do not fire". Without that, every pre-existing partner with 3+ lifetime cards would fire the moment this deploys. Both cases are covered by explicit tests.
  `window_days` defaults to **1**. A testing burst is minutes; a legitimate re-card is months or years apart, so one day sits far above the burst and far below any legitimate cadence, while still covering an adversary pacing attempts across a working day. It does also catch a genuine decline-then-retry-twice signup — that is a watch-tier review, not an alert, which is why three methods alone scores below `severity.alert_score`.

`billing.card_country_mismatch` is **not** built — it needs geo work that does not exist yet.

None of these age-decay. `computeBillingIdentitySignals` takes **no clock at all** — no `now`, no `partnerCreatedAt` — which makes that structural rather than a convention, matching `computeScriptSignals`. A cardholder name that matches nothing about the account is evidence at any account age.

Billing-scanned partner ids are unioned into `evaluatedPartnerIds` in `runAbuseSweep()`, exactly as the script detector does — `persistSignals` only auto-resolves `invariant.*` rows or rows whose partner is in that set, so without this the rows could never stale-resolve. The loader additionally keeps re-evaluating any partner with an open `billing.*` signal even after the snapshot is cleared, so a row resolves on evidence rather than on scope exit.

Coverage caveat, handled rather than hidden: wallet/Link-style payments expose no card fingerprint, so `billing_card_fingerprint` is frequently NULL. Name matching is the primary signal.

## Invariant

`invariant.suspended_partner_active_subscription` — partner status is not `active` while `billing_subscription_status` is `active` or `past_due`.

This lives in `invariants.ts`, not `heuristics.ts`, for two structural reasons: the heuristics `scoped` CTE filters `p.status = 'active'`, so it can never see a suspended partner, and its `push()` age-decays. Raw SQL, score 100, severity `alert`, no age weighting — matching the `invariant.inactive_partner_with_agents` sibling. `deleted_at IS NULL` is intentionally omitted: a soft-deleted partner still carrying a live subscription is itself the anomaly.

Detection only. Automating subscription cancellation inside the suspension flow is a money-affecting external write pending a refund-vs-leave decision, and is deliberately out of scope.

## Config

New `SIGNAL_DEFAULTS` keys, same naming style, all overridable via `ABUSE_SIGNAL_OVERRIDES`:

```
billing.cardholder_name_mismatch.score
billing.cardholder_name_mismatch.failed_attempt_bonus
billing.shared_card_fingerprint.min_partners
billing.shared_card_fingerprint.base_score
billing.shared_card_fingerprint.per_extra_partner
billing.card_testing.distinct_methods
billing.card_testing.window_days          # span bound, default 1 day
billing.card_testing.base_score
billing.card_testing.per_extra_method
billing.card_testing.per_failed_attempt
```

A name mismatch alone scores below the alert threshold; it reaches alert only with corroborating failed attempts. Same for card testing at exactly the method threshold.

## Verification

- `pnpm exec tsc --noEmit --project apps/api/tsconfig.json` from the repo root (enforces `noUncheckedIndexedAccess`) — clean.
- Full API unit suite: 1160 files, 17212 passed / 64 skipped.
- `scripts/security/check-customer-pii.sh` — exits 0. All fixture mailbox domains are reserved-TLD placeholders (`.example`); the free-provider exclusion is proven by injecting a synthetic provider label rather than embedding a real provider domain, and the shipped list is covered by bare-domain assertions that contain no address.
- `vitest run src/services/abuseSignals` — 8 files, 125 tests. `billingIdentity.test.ts` table-drives the matching algorithm over synthetic fixtures: no shared token fires; a local-part first-name match stays quiet; a partner-name token match stays quiet (the documented miss); free-provider domains contribute no token while a corporate domain does; diacritics, punctuation, word order, non-decomposing letters and digits all fold correctly; shared fingerprint fires for the in-scope partner and two NULL fingerprints never match. Card testing is covered on the span axis specifically: 3 methods in a 7-minute span fires; 3 methods over two years does not; NULL / half-NULL / reversed spans do not; the window boundary fires and one millisecond past it does not; and a legitimate multi-year partner with five cards, a matching cardholder and an unshared fingerprint produces zero signals. Every name, mailbox, domain and fingerprint in the tests is invented for the file.
- `vitest run src/routes/orgs.test.ts` — 162 tests, including the extended projection assertions (all nine billing columns asserted absent).
- `eslint` clean on every touched file.
- Migration applied to a throwaway Postgres 16: `check-migrations` OK, `db:check-drift` reports no drift across all 463 files, re-applying the file is a no-op (all `IF NOT EXISTS` skips), and both loader queries plus the invariant query were executed against real Postgres with synthetic rows — confirming the span round-trips as an interval and that the cross-partner fingerprint corpus spans a suspended partner while attribution stays on the active one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
