### PR TITLE
fix(ci): harden workflow trust and isolate developer signing

### DIFF
--- a/.github/scripts/check-workflow-security.mjs
+++ b/.github/scripts/check-workflow-security.mjs
@@ -411,11 +411,19 @@ function blockScalarValue(lines, lineIndex) {
   return content.join(' ');
 }
 
+function containsSecretReference(value) {
+  const normalized = normalizePropertyAccess(value);
+  return (
+    /\bsecrets\./u.test(normalized)
+    || /\btojson\(\s*secrets\s*\)/iu.test(normalized)
+  );
+}
+
 function secretReferenceLines(lines) {
   const lineNumbers = new Set();
 
   for (const [index, line] of lines.entries()) {
-    if (/\bsecrets\s*(?:\.|\[)/u.test(line.content)) {
+    if (containsSecretReference(line.content)) {
       lineNumbers.add(line.line);
     }
 
@@ -427,14 +435,14 @@ function secretReferenceLines(lines) {
     if (
       entry
       && /^[>|][0-9+-]*$/u.test(entry.value)
-      && /\bsecrets\s*(?:\.|\[)/u.test(blockScalarValue(lines, index))
+      && containsSecretReference(blockScalarValue(lines, index))
     ) {
       let scalarHasDirectMatch = false;
       for (let nestedIndex = index + 1; nestedIndex < lines.length; nestedIndex += 1) {
         if (!lines[nestedIndex].isBlockScalarContent) {
           break;
         }
-        if (/\bsecrets\s*(?:\.|\[)/u.test(lines[nestedIndex].content)) {
+        if (containsSecretReference(lines[nestedIndex].content)) {
           scalarHasDirectMatch = true;
           break;
         }
@@ -578,6 +586,68 @@ function checkoutHeadRefs(lines, checkoutEntries) {
   return violations;
 }
 
+function workflowSteps(lines) {
+  const steps = [];
+
+  for (const [index, line] of lines.entries()) {
+    if (
+      line.isBlockScalarContent
+      || !isSequenceItem(line)
+      || !isDirectChildOfMapping(lines, index, 'steps')
+    ) {
+      continue;
+    }
+
+    let endIndex = lines.length;
+    for (let nestedIndex = index + 1; nestedIndex < lines.length; nestedIndex += 1) {
+      if (lines[nestedIndex].indent <= line.indent) {
+        endIndex = nestedIndex;
+        break;
+      }
+    }
+
+    steps.push(lines.slice(index, endIndex));
+  }
+
+  return steps;
+}
+
+function runStepHeadRefs(lines) {
+  const violatingLineNumbers = new Set();
+  const checkoutCommand = (
+    /\bgit\s+(?:(?:checkout|switch)\b|reset\s+--hard\b|worktree\s+add\b)/u
+  );
+
+  for (const job of workflowJobs(lines)) {
+    const jobContent = job.lines.map(({ content }) => content).join('\n');
+    if (!isPullRequestHeadOrMergeRef(jobContent)) {
+      continue;
+    }
+
+    for (const step of workflowSteps(job.lines)) {
+      for (const [index, line] of step.entries()) {
+        if (line.isBlockScalarContent) {
+          continue;
+        }
+
+        const entry = mappingEntry(line.trimmed.replace(/^-\s*/u, ''));
+        if (entry?.key !== 'run') {
+          continue;
+        }
+
+        const command = /^[>|][0-9+-]*$/u.test(entry.value)
+          ? blockScalarValue(step, index)
+          : unquote(entry.value);
+        if (checkoutCommand.test(command)) {
+          violatingLineNumbers.add(line.line);
+        }
+      }
+    }
+  }
+
+  return lines.filter(({ line }) => violatingLineNumbers.has(line));
+}
+
 function workflowJobs(lines) {
   const jobs = [];
 
@@ -609,6 +679,189 @@ function workflowJobs(lines) {
   }
 
   return jobs;
+}
+
+function scalarListValues(value) {
+  const scalar = unquote(value);
+  if (!scalar.startsWith('[') || !scalar.endsWith(']')) {
+    return scalar === '' ? [] : [scalar];
+  }
+  return splitTopLevel(scalar.slice(1, -1), ',').map((item) => unquote(item));
+}
+
+function hasVersionTagPushTrigger(lines) {
+  for (const [onIndex, onLine] of lines.entries()) {
+    const onEntry = onLine.isBlockScalarContent
+      ? null
+      : mappingEntry(onLine.trimmed);
+    if (onLine.indent !== 0 || onEntry?.key !== 'on' || onEntry.value !== '') {
+      continue;
+    }
+
+    for (let pushIndex = onIndex + 1; pushIndex < lines.length; pushIndex += 1) {
+      const pushLine = lines[pushIndex];
+      if (pushLine.indent <= onLine.indent) {
+        break;
+      }
+      const pushEntry = pushLine.isBlockScalarContent
+        ? null
+        : mappingEntry(pushLine.trimmed);
+      if (
+        parentLineIndex(lines, pushIndex) !== onIndex
+        || pushEntry?.key !== 'push'
+        || pushEntry.value !== ''
+      ) {
+        continue;
+      }
+
+      for (let tagsIndex = pushIndex + 1; tagsIndex < lines.length; tagsIndex += 1) {
+        const tagsLine = lines[tagsIndex];
+        if (tagsLine.indent <= pushLine.indent) {
+          break;
+        }
+        const tagsEntry = tagsLine.isBlockScalarContent
+          ? null
+          : mappingEntry(tagsLine.trimmed);
+        if (
+          parentLineIndex(lines, tagsIndex) !== pushIndex
+          || tagsEntry?.key !== 'tags'
+        ) {
+          continue;
+        }
+
+        const patterns = scalarListValues(tagsEntry.value);
+        for (let patternIndex = tagsIndex + 1; patternIndex < lines.length; patternIndex += 1) {
+          const patternLine = lines[patternIndex];
+          if (patternLine.indent <= tagsLine.indent) {
+            break;
+          }
+          if (
+            parentLineIndex(lines, patternIndex) === tagsIndex
+            && isSequenceItem(patternLine)
+          ) {
+            patterns.push(unquote(patternLine.trimmed.slice(1).trim()));
+          }
+        }
+        if (patterns.includes('v*')) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+function topLevelLogicalParts(value, operator) {
+  const parts = [];
+  let start = 0;
+  let quote = null;
+  let escaped = false;
+  let parenthesisDepth = 0;
+  let squareDepth = 0;
+  let curlyDepth = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+
+    if (quote === '"') {
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (quote === "'") {
+      if (character === quote && value[index + 1] === quote) {
+        index += 1;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === '(') {
+      parenthesisDepth += 1;
+      continue;
+    }
+    if (character === ')') {
+      parenthesisDepth -= 1;
+      continue;
+    }
+    if (character === '[') {
+      squareDepth += 1;
+      continue;
+    }
+    if (character === ']') {
+      squareDepth -= 1;
+      continue;
+    }
+    if (character === '{') {
+      curlyDepth += 1;
+      continue;
+    }
+    if (character === '}') {
+      curlyDepth -= 1;
+      continue;
+    }
+    if (
+      character === operator[0]
+      && value[index + 1] === operator[1]
+      && parenthesisDepth === 0
+      && squareDepth === 0
+      && curlyDepth === 0
+    ) {
+      parts.push(value.slice(start, index));
+      index += 1;
+      start = index + 1;
+    }
+  }
+
+  parts.push(value.slice(start));
+  return parts;
+}
+
+function hasTrustedVersionTagJobGate(lines) {
+  for (const [index, line] of lines.entries()) {
+    if (
+      line.isBlockScalarContent
+      || parentLineIndex(lines, index) !== 0
+    ) {
+      continue;
+    }
+
+    const entry = mappingEntry(line.trimmed);
+    if (entry?.key !== 'if') {
+      continue;
+    }
+
+    let condition = normalizePropertyAccess(
+      /^[>|][0-9+-]*$/u.test(entry.value)
+        ? blockScalarValue(lines, index)
+        : unquote(entry.value),
+    );
+    if (condition.startsWith('${{') && condition.endsWith('}}')) {
+      condition = condition.slice(3, -2);
+    }
+    if (topLevelLogicalParts(condition, '||').length !== 1) {
+      return false;
+    }
+    const conjuncts = new Set(topLevelLogicalParts(condition, '&&'));
+    return (
+      conjuncts.has("github.ref_type=='tag'")
+      && conjuncts.has("startsWith(github.ref,'refs/tags/v')")
+    );
+  }
+
+  return false;
 }
 
 function appleSecretReferenceLines(lines) {
@@ -679,14 +932,14 @@ function forbiddenSigningSourceLines(lines) {
 }
 
 function developerSigningViolations(file, lines) {
-  if (path.basename(file) !== 'dev-build-agent.yml') {
-    return [];
-  }
-
   const violations = [];
+  const hasReleaseTrigger = hasVersionTagPushTrigger(lines);
   for (const job of workflowJobs(lines)) {
     const appleSecrets = appleSecretReferenceLines(job.lines);
     if (appleSecrets.length === 0) {
+      continue;
+    }
+    if (hasReleaseTrigger && hasTrustedVersionTagJobGate(job.lines)) {
       continue;
     }
 
@@ -779,7 +1032,11 @@ export function inspectWorkflowText(file, text) {
   }
 
   if (triggers.has('pull_request_target')) {
-    for (const line of checkoutHeadRefs(lines, checkoutEntries)) {
+    const headRefLines = new Map([
+      ...checkoutHeadRefs(lines, checkoutEntries),
+      ...runStepHeadRefs(lines),
+    ].map((line) => [line.line, line]));
+    for (const line of headRefLines.values()) {
       violations.push({
         file,
         line: line.line,

--- a/.github/scripts/check-workflow-security.mjs
+++ b/.github/scripts/check-workflow-security.mjs
@@ -1,0 +1,667 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const EXTERNAL_USES_RULE = 'external-uses-must-be-sha';
+const PR_SECRET_RULE = 'pr-workflow-must-be-secret-free';
+const PR_TARGET_HEAD_RULE = 'pr-target-must-not-execute-head';
+const UNSUPPORTED_SYNTAX_RULE = 'unsupported-workflow-syntax';
+const PINNED_EXTERNAL_USES = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)*@[0-9a-f]{40}$/u;
+
+function stripInlineComment(line) {
+  let quote = null;
+  let escaped = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+
+    if (quote === '"') {
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (quote === "'") {
+      if (character === quote && line[index + 1] === quote) {
+        index += 1;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character;
+    } else if (
+      character === '#'
+      && (index === 0 || /\s/u.test(line[index - 1]))
+    ) {
+      return line.slice(0, index).trimEnd();
+    }
+  }
+
+  return line.trimEnd();
+}
+
+function unquote(value) {
+  const trimmed = value.trim();
+  if (
+    trimmed.length >= 2
+    && (
+      (trimmed.startsWith('"') && trimmed.endsWith('"'))
+      || (trimmed.startsWith("'") && trimmed.endsWith("'"))
+    )
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function codePointCompare(left, right) {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+}
+
+function findTopLevelCharacter(text, target) {
+  let quote = null;
+  let escaped = false;
+  let squareDepth = 0;
+  let curlyDepth = 0;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+
+    if (quote === '"') {
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (quote === "'") {
+      if (character === quote && text[index + 1] === quote) {
+        index += 1;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === '[') {
+      squareDepth += 1;
+      continue;
+    }
+    if (character === ']') {
+      squareDepth -= 1;
+      continue;
+    }
+    if (character === '{') {
+      curlyDepth += 1;
+      continue;
+    }
+    if (character === '}') {
+      curlyDepth -= 1;
+      continue;
+    }
+    if (character === target && squareDepth === 0 && curlyDepth === 0) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function splitTopLevel(text, separator) {
+  const parts = [];
+  let remainder = text;
+
+  while (remainder !== '') {
+    const index = findTopLevelCharacter(remainder, separator);
+    if (index === -1) {
+      parts.push(remainder);
+      break;
+    }
+    parts.push(remainder.slice(0, index));
+    remainder = remainder.slice(index + 1);
+  }
+
+  return parts;
+}
+
+function mappingEntry(text) {
+  const colonIndex = findTopLevelCharacter(text.trim(), ':');
+  if (colonIndex === -1) {
+    return null;
+  }
+
+  const trimmed = text.trim();
+  const key = unquote(trimmed.slice(0, colonIndex));
+  if (key === '') {
+    return null;
+  }
+
+  return {
+    key,
+    value: trimmed.slice(colonIndex + 1).trim(),
+  };
+}
+
+function flowMappingEntries(text) {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) {
+    return [];
+  }
+
+  return splitTopLevel(trimmed.slice(1, -1), ',')
+    .map((entry) => mappingEntry(entry))
+    .filter(Boolean);
+}
+
+function activeLines(text) {
+  const lines = [];
+  let blockScalarIndent = null;
+
+  for (const [index, source] of text.split(/\r?\n/u).entries()) {
+    const sourceIndent = source.match(/^\s*/u)[0].length;
+    const isBlockScalarContent = (
+      blockScalarIndent !== null && sourceIndent > blockScalarIndent
+    );
+    if (
+      blockScalarIndent !== null
+      && source.trim() !== ''
+      && !isBlockScalarContent
+    ) {
+      blockScalarIndent = null;
+    }
+
+    const content = isBlockScalarContent
+      ? source.trimEnd()
+      : stripInlineComment(source);
+    const indent = content.match(/^\s*/u)[0].length;
+    const trimmed = content.trim();
+
+    if (trimmed === '') {
+      continue;
+    }
+
+    lines.push({
+      content,
+      indent,
+      isBlockScalarContent,
+      line: index + 1,
+      trimmed,
+    });
+
+    if (!isBlockScalarContent && /:\s*[>|][0-9+-]*\s*$/u.test(trimmed)) {
+      blockScalarIndent = indent;
+    }
+  }
+
+  return lines;
+}
+
+function parentLineIndex(lines, childIndex) {
+  for (let index = childIndex - 1; index >= 0; index -= 1) {
+    if (lines[index].indent < lines[childIndex].indent) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function mappingKey(line) {
+  return mappingEntry(line.trimmed)?.key ?? null;
+}
+
+function isSequenceItem(line) {
+  return /^-(?:\s|$)/u.test(line.trimmed);
+}
+
+function isDirectChildOfMapping(lines, lineIndex, parentKey) {
+  const parentIndex = parentLineIndex(lines, lineIndex);
+  return (
+    parentIndex !== -1
+    && mappingKey(lines[parentIndex]) === parentKey
+  );
+}
+
+function usesEntries(lines) {
+  const entries = [];
+
+  for (const [lineIndex, line] of lines.entries()) {
+    if (line.isBlockScalarContent) {
+      continue;
+    }
+
+    if (
+      isSequenceItem(line)
+      && isDirectChildOfMapping(lines, lineIndex, 'steps')
+    ) {
+      const sequenceBody = line.trimmed.slice(1).trim();
+      const stepEntries = sequenceBody.startsWith('{')
+        ? flowMappingEntries(sequenceBody)
+        : [mappingEntry(sequenceBody)].filter(Boolean);
+      const uses = stepEntries.find(({ key }) => key === 'uses');
+      if (uses) {
+        entries.push({
+          ...line,
+          isStep: true,
+          stepIndex: lineIndex,
+          value: unquote(uses.value),
+        });
+      }
+      continue;
+    }
+
+    const entry = mappingEntry(line.trimmed);
+    if (!entry) {
+      continue;
+    }
+
+    if (entry.key === 'uses') {
+      const parentIndex = parentLineIndex(lines, lineIndex);
+      if (
+        parentIndex !== -1
+        && isSequenceItem(lines[parentIndex])
+        && isDirectChildOfMapping(lines, parentIndex, 'steps')
+      ) {
+        entries.push({
+          ...line,
+          isStep: true,
+          stepIndex: parentIndex,
+          value: unquote(entry.value),
+        });
+        continue;
+      }
+
+      if (
+        parentIndex !== -1
+        && isDirectChildOfMapping(lines, parentIndex, 'jobs')
+      ) {
+        entries.push({
+          ...line,
+          isStep: false,
+          stepIndex: null,
+          value: unquote(entry.value),
+        });
+      }
+      continue;
+    }
+
+    if (
+      isDirectChildOfMapping(lines, lineIndex, 'jobs')
+      && entry.value.startsWith('{')
+    ) {
+      const uses = flowMappingEntries(entry.value)
+        .find(({ key }) => key === 'uses');
+      if (uses) {
+        entries.push({
+          ...line,
+          isStep: false,
+          stepIndex: null,
+          value: unquote(uses.value),
+        });
+      }
+    }
+  }
+
+  return entries;
+}
+
+function workflowTriggers(lines) {
+  const triggers = new Set();
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line.isBlockScalarContent) {
+      continue;
+    }
+    const entry = mappingEntry(line.trimmed);
+    if (line.indent !== 0 || entry?.key !== 'on') {
+      continue;
+    }
+
+    const onIndent = line.indent;
+    const scalar = unquote(entry.value);
+    if (scalar) {
+      const values = scalar.startsWith('[') && scalar.endsWith(']')
+        ? splitTopLevel(scalar.slice(1, -1), ',')
+        : scalar.startsWith('{') && scalar.endsWith('}')
+          ? flowMappingEntries(scalar).map(({ key }) => key)
+          : [scalar];
+      for (const value of values) {
+        const trigger = unquote(value);
+        if (trigger === 'pull_request' || trigger === 'pull_request_target') {
+          triggers.add(trigger);
+        }
+      }
+      continue;
+    }
+
+    for (let nestedIndex = index + 1; nestedIndex < lines.length; nestedIndex += 1) {
+      const nested = lines[nestedIndex];
+      if (nested.indent <= onIndent) {
+        break;
+      }
+      if (nested.isBlockScalarContent) {
+        continue;
+      }
+      if (parentLineIndex(lines, nestedIndex) !== index) {
+        continue;
+      }
+      const trigger = mappingEntry(nested.trimmed)?.key;
+      if (trigger === 'pull_request' || trigger === 'pull_request_target') {
+        triggers.add(trigger);
+      }
+    }
+  }
+
+  return triggers;
+}
+
+function normalizePropertyAccess(value) {
+  return value
+    .replace(/\[\s*(['"])([A-Za-z0-9_]+)\1\s*\]/gu, '.$2')
+    .replace(/\s+/gu, '');
+}
+
+function isPullRequestHeadOrMergeRef(value) {
+  const normalized = normalizePropertyAccess(value);
+  return (
+    normalized.includes('github.event.pull_request.head')
+    || normalized.includes('github.head_ref')
+    || /refs\/pull\/.+\/merge/u.test(normalized)
+  );
+}
+
+function isDynamicExpression(value) {
+  return /\$\{\{[\s\S]*\}\}/u.test(value);
+}
+
+function blockScalarValue(lines, lineIndex) {
+  const content = [];
+
+  for (let index = lineIndex + 1; index < lines.length; index += 1) {
+    if (!lines[index].isBlockScalarContent) {
+      break;
+    }
+    content.push(lines[index].trimmed);
+  }
+
+  return content.join(' ');
+}
+
+function secretReferenceLines(lines) {
+  const lineNumbers = new Set();
+
+  for (const [index, line] of lines.entries()) {
+    if (/\bsecrets\s*(?:\.|\[)/u.test(line.content)) {
+      lineNumbers.add(line.line);
+    }
+
+    if (line.isBlockScalarContent) {
+      continue;
+    }
+
+    const entry = mappingEntry(line.trimmed);
+    if (
+      entry
+      && /^[>|][0-9+-]*$/u.test(entry.value)
+      && /\bsecrets\s*(?:\.|\[)/u.test(blockScalarValue(lines, index))
+    ) {
+      let scalarHasDirectMatch = false;
+      for (let nestedIndex = index + 1; nestedIndex < lines.length; nestedIndex += 1) {
+        if (!lines[nestedIndex].isBlockScalarContent) {
+          break;
+        }
+        if (/\bsecrets\s*(?:\.|\[)/u.test(lines[nestedIndex].content)) {
+          scalarHasDirectMatch = true;
+          break;
+        }
+      }
+      if (!scalarHasDirectMatch) {
+        lineNumbers.add(line.line);
+      }
+    }
+  }
+
+  return lines.filter((line) => lineNumbers.has(line.line));
+}
+
+function unsupportedSyntaxLines(text, lines) {
+  const unsupported = new Map();
+  const add = (line, message) => {
+    if (!unsupported.has(line.line)) {
+      unsupported.set(line.line, { line, message });
+    }
+  };
+
+  const firstLine = lines[0];
+  if (
+    firstLine
+    && firstLine.indent === 0
+    && (firstLine.trimmed.startsWith('{') || firstLine.trimmed.startsWith('['))
+  ) {
+    add(firstLine, 'root flow collections are unsupported by the workflow security scanner');
+  }
+
+  for (const [index, line] of lines.entries()) {
+    if (line.isBlockScalarContent) {
+      continue;
+    }
+
+    if (/\\(?:u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8}|x[0-9a-fA-F]{2})/u.test(line.content)) {
+      add(line, 'escape-bearing YAML is unsupported by the workflow security scanner');
+    }
+
+    if (
+      isSequenceItem(line)
+      && isDirectChildOfMapping(lines, index, 'steps')
+    ) {
+      const body = line.trimmed.slice(1).trim();
+      if (body.startsWith('{') && !body.endsWith('}')) {
+        add(line, 'multiline flow-style steps are unsupported by the workflow security scanner');
+      }
+    }
+
+    const entry = mappingEntry(line.trimmed);
+    if (
+      entry
+      && isDirectChildOfMapping(lines, index, 'jobs')
+      && entry.value.startsWith('{')
+      && !entry.value.endsWith('}')
+    ) {
+      add(line, 'multiline flow-style jobs are unsupported by the workflow security scanner');
+    }
+  }
+
+  // Inspect the original text so escape sequences inside otherwise skipped
+  // scalar shapes cannot disappear before the fail-closed check.
+  if (
+    /\\(?:u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8}|x[0-9a-fA-F]{2})/u.test(text)
+    && ![...unsupported.values()].some(({ message }) => message.startsWith('escape-bearing'))
+  ) {
+    add(firstLine ?? {
+      line: 1,
+    }, 'escape-bearing YAML is unsupported by the workflow security scanner');
+  }
+
+  return [...unsupported.values()];
+}
+
+function flowRefValues(text) {
+  const values = [];
+  const entries = flowMappingEntries(text);
+
+  for (const entry of entries) {
+    if (entry.key === 'ref') {
+      values.push(unquote(entry.value));
+    }
+    if (entry.value.startsWith('{')) {
+      values.push(...flowRefValues(entry.value));
+    }
+  }
+
+  return values;
+}
+
+function checkoutHeadRefs(lines, checkoutEntries) {
+  const violations = [];
+  const violatingLineNumbers = new Set();
+
+  for (const checkout of checkoutEntries) {
+    if (!checkout.isStep || checkout.stepIndex === null) {
+      continue;
+    }
+
+    const stepIndex = checkout.stepIndex;
+    const stepIndent = lines[stepIndex].indent;
+    for (let index = stepIndex + 1; index < lines.length; index += 1) {
+      const line = lines[index];
+      if (line.indent <= stepIndent) {
+        break;
+      }
+      if (line.isBlockScalarContent) {
+        continue;
+      }
+
+      const entry = mappingEntry(line.trimmed);
+      if (entry?.key === 'ref') {
+        const value = /^[>|][0-9+-]*$/u.test(entry.value)
+          ? blockScalarValue(lines, index)
+          : unquote(entry.value);
+        if (isDynamicExpression(value) || isPullRequestHeadOrMergeRef(value)) {
+          violatingLineNumbers.add(line.line);
+        }
+      }
+
+      for (const ref of flowRefValues(line.trimmed)) {
+        if (isDynamicExpression(ref) || isPullRequestHeadOrMergeRef(ref)) {
+          violatingLineNumbers.add(line.line);
+        }
+      }
+    }
+
+    for (const ref of flowRefValues(lines[stepIndex].trimmed.slice(1).trim())) {
+      if (isDynamicExpression(ref) || isPullRequestHeadOrMergeRef(ref)) {
+        violatingLineNumbers.add(lines[stepIndex].line);
+      }
+    }
+  }
+
+  for (const line of lines) {
+    if (violatingLineNumbers.has(line.line)) {
+      violations.push(line);
+    }
+  }
+
+  return violations;
+}
+
+function compareViolations(left, right) {
+  return codePointCompare(left.file, right.file)
+    || left.line - right.line
+    || codePointCompare(left.rule, right.rule);
+}
+
+export function inspectWorkflowText(file, text) {
+  const lines = activeLines(text);
+  const uses = usesEntries(lines);
+  const triggers = workflowTriggers(lines);
+  const checkoutEntries = uses.filter(({ value }) => (
+    value.startsWith('actions/checkout@')
+  ));
+  const violations = [];
+
+  for (const { line, message } of unsupportedSyntaxLines(text, lines)) {
+    violations.push({
+      file,
+      line: line.line,
+      rule: UNSUPPORTED_SYNTAX_RULE,
+      message,
+    });
+  }
+
+  for (const entry of uses) {
+    if (!entry.value.startsWith('./') && !PINNED_EXTERNAL_USES.test(entry.value)) {
+      violations.push({
+        file,
+        line: entry.line,
+        rule: EXTERNAL_USES_RULE,
+        message: `external action must use a lowercase 40-character commit SHA: ${entry.value}`,
+      });
+    }
+  }
+
+  if (triggers.has('pull_request') && checkoutEntries.length > 0) {
+    for (const line of secretReferenceLines(lines)) {
+      violations.push({
+        file,
+        line: line.line,
+        rule: PR_SECRET_RULE,
+        message: 'pull_request workflow checks out repository code and references a secret',
+      });
+    }
+  }
+
+  if (triggers.has('pull_request_target')) {
+    for (const line of checkoutHeadRefs(lines, checkoutEntries)) {
+      violations.push({
+        file,
+        line: line.line,
+        rule: PR_TARGET_HEAD_RULE,
+        message: 'pull_request_target workflow must not check out a pull request head or merge ref',
+      });
+    }
+  }
+
+  return violations.sort(compareViolations);
+}
+
+export function inspectWorkflowDirectory(rootDirectory) {
+  return readdirSync(rootDirectory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /\.ya?ml$/u.test(entry.name))
+    .flatMap((entry) => inspectWorkflowText(
+      entry.name,
+      readFileSync(path.join(rootDirectory, entry.name), 'utf8'),
+    ))
+    .sort(compareViolations);
+}
+
+function main() {
+  const workflowDirectory = path.resolve('.github', 'workflows');
+  const violations = inspectWorkflowDirectory(workflowDirectory);
+
+  for (const violation of violations) {
+    console.error(
+      `${violation.file}:${violation.line} [${violation.rule}] ${violation.message}`,
+    );
+  }
+
+  if (violations.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+const invokedFile = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedFile === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/.github/scripts/check-workflow-security.mjs
+++ b/.github/scripts/check-workflow-security.mjs
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'node:url';
 const EXTERNAL_USES_RULE = 'external-uses-must-be-sha';
 const PR_SECRET_RULE = 'pr-workflow-must-be-secret-free';
 const PR_TARGET_HEAD_RULE = 'pr-target-must-not-execute-head';
+const SIGNING_BUILD_RULE = 'signing-job-must-not-build-source';
+const SIGNING_VERIFY_RULE = 'signing-job-must-verify-artifact-before-secrets';
 const UNSUPPORTED_SYNTAX_RULE = 'unsupported-workflow-syntax';
 const PINNED_EXTERNAL_USES = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)*@[0-9a-f]{40}$/u;
 
@@ -576,6 +578,160 @@ function checkoutHeadRefs(lines, checkoutEntries) {
   return violations;
 }
 
+function workflowJobs(lines) {
+  const jobs = [];
+
+  for (const [index, line] of lines.entries()) {
+    if (
+      line.isBlockScalarContent
+      || !isDirectChildOfMapping(lines, index, 'jobs')
+    ) {
+      continue;
+    }
+
+    const entry = mappingEntry(line.trimmed);
+    if (!entry || entry.value !== '') {
+      continue;
+    }
+
+    let endIndex = lines.length;
+    for (let nestedIndex = index + 1; nestedIndex < lines.length; nestedIndex += 1) {
+      if (lines[nestedIndex].indent <= line.indent) {
+        endIndex = nestedIndex;
+        break;
+      }
+    }
+
+    jobs.push({
+      lines: lines.slice(index, endIndex),
+      name: entry.key,
+    });
+  }
+
+  return jobs;
+}
+
+function appleSecretReferenceLines(lines) {
+  return lines.filter((line, index) => {
+    const scalar = line.isBlockScalarContent
+      ? line.content
+      : `${line.content} ${blockScalarValue(lines, index)}`;
+    return /\bsecrets\.APPLE_[A-Za-z0-9_]+\b/u.test(
+      normalizePropertyAccess(scalar),
+    );
+  });
+}
+
+function normalizedActionName(value) {
+  const atIndex = value.lastIndexOf('@');
+  return (atIndex === -1 ? value : value.slice(0, atIndex)).toLowerCase();
+}
+
+function collapseShellContinuations(lines) {
+  const collapsed = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const firstLine = lines[index];
+    let content = firstLine.content;
+
+    while (
+      firstLine.isBlockScalarContent
+      && content.trimEnd().endsWith('\\')
+      && lines[index + 1]?.isBlockScalarContent
+      && lines[index + 1].line === lines[index].line + 1
+    ) {
+      content = (
+        `${content.trimEnd().slice(0, -1)} ${lines[index + 1].trimmed}`
+      );
+      index += 1;
+    }
+
+    collapsed.push({
+      ...firstLine,
+      content,
+      trimmed: content.trim(),
+    });
+  }
+
+  return collapsed;
+}
+
+function forbiddenSigningSourceLines(lines) {
+  const forbidden = new Map();
+
+  for (const checkout of usesEntries(lines).filter(({ value }) => (
+    normalizedActionName(value) === 'actions/checkout'
+  ))) {
+    forbidden.set(checkout.line, checkout);
+  }
+
+  const buildCommand = /\b(?:go\s+build|cargo\s+build|npm\s+run\s+build|pnpm\s+build)\b/u;
+  for (const line of collapseShellContinuations(lines)) {
+    if (
+      !line.trimmed.startsWith('#')
+      && buildCommand.test(line.content)
+    ) {
+      forbidden.set(line.line, line);
+    }
+  }
+
+  return [...forbidden.values()].sort((left, right) => left.line - right.line);
+}
+
+function developerSigningViolations(file, lines) {
+  if (path.basename(file) !== 'dev-build-agent.yml') {
+    return [];
+  }
+
+  const violations = [];
+  for (const job of workflowJobs(lines)) {
+    const appleSecrets = appleSecretReferenceLines(job.lines);
+    if (appleSecrets.length === 0) {
+      continue;
+    }
+
+    for (const line of forbiddenSigningSourceLines(job.lines)) {
+      violations.push({
+        file,
+        line: line.line,
+        rule: SIGNING_BUILD_RULE,
+        message: `developer signing job "${job.name}" must not check out or build source`,
+      });
+    }
+
+    const firstSecretLine = Math.min(...appleSecrets.map(({ line }) => line));
+    const verificationName = job.lines.find((line) => {
+      const entry = line.isBlockScalarContent
+        ? null
+        : mappingEntry(line.trimmed.replace(/^-\s*/u, ''));
+      return (
+        entry?.key === 'name'
+        && unquote(entry.value) === 'Verify unsigned artifact before secrets'
+      );
+    });
+    const checksumVerification = job.lines.find((line) => (
+      !line.trimmed.startsWith('#')
+      && line.trimmed === 'shasum -a 256 -c SHA256SUMS'
+    ));
+
+    if (
+      !verificationName
+      || !checksumVerification
+      || verificationName.line >= firstSecretLine
+      || checksumVerification.line >= firstSecretLine
+    ) {
+      violations.push({
+        file,
+        line: firstSecretLine,
+        rule: SIGNING_VERIFY_RULE,
+        message: `developer signing job "${job.name}" must verify artifact checksums before referencing Apple secrets`,
+      });
+    }
+  }
+
+  return violations;
+}
+
 function compareViolations(left, right) {
   return codePointCompare(left.file, right.file)
     || left.line - right.line
@@ -632,6 +788,8 @@ export function inspectWorkflowText(file, text) {
       });
     }
   }
+
+  violations.push(...developerSigningViolations(file, lines));
 
   return violations.sort(compareViolations);
 }

--- a/.github/scripts/check-workflow-security.test.mjs
+++ b/.github/scripts/check-workflow-security.test.mjs
@@ -1,0 +1,589 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, test } from 'node:test';
+
+import {
+  inspectWorkflowDirectory,
+  inspectWorkflowText,
+} from './check-workflow-security.mjs';
+
+const temporaryDirectories = [];
+const pinnedCheckout = 'actions/checkout@0123456789abcdef0123456789abcdef01234567';
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, {
+      force: true,
+      recursive: true,
+    })),
+  );
+});
+
+async function temporaryWorkflowDirectory(files) {
+  const root = await mkdtemp(path.join(tmpdir(), 'workflow-security-'));
+  temporaryDirectories.push(root);
+  const workflowDirectory = path.join(root, '.github', 'workflows');
+  await mkdir(workflowDirectory, { recursive: true });
+
+  await Promise.all(
+    Object.entries(files).map(([file, text]) => (
+      writeFile(path.join(workflowDirectory, file), text)
+    )),
+  );
+
+  return workflowDirectory;
+}
+
+function workflow(body, trigger = 'push') {
+  return `name: Test
+on: ${trigger}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+${body}
+`;
+}
+
+test('rejects mutable external action references', () => {
+  const violations = inspectWorkflowText(
+    'mutable.yml',
+    workflow('      - uses: actions/checkout@v7'),
+  );
+
+  assert.deepEqual(violations, [{
+    file: 'mutable.yml',
+    line: 7,
+    rule: 'external-uses-must-be-sha',
+    message: 'external action must use a lowercase 40-character commit SHA: actions/checkout@v7',
+  }]);
+});
+
+test('accepts a lowercase full action SHA with a version comment', () => {
+  const violations = inspectWorkflowText(
+    'pinned.yml',
+    workflow(`      - uses: ${pinnedCheckout} # v7`),
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test('accepts local actions and rejects docker actions', () => {
+  const violations = inspectWorkflowText(
+    'action-kinds.yml',
+    workflow(`      - uses: ./path/to/local-action
+      - uses: docker://alpine:latest`),
+  );
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].line, 8);
+  assert.equal(violations[0].rule, 'external-uses-must-be-sha');
+});
+
+test('rejects uppercase action SHAs', () => {
+  const violations = inspectWorkflowText(
+    'uppercase.yml',
+    workflow('      - uses: actions/checkout@0123456789ABCDEF0123456789ABCDEF01234567'),
+  );
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].rule, 'external-uses-must-be-sha');
+});
+
+test('parses reusable-workflow job uses values', () => {
+  const text = `on: push
+jobs:
+  reusable:
+    uses: example/shared-workflows/.github/workflows/test.yml@main
+`;
+
+  assert.deepEqual(
+    inspectWorkflowText('reusable.yml', text).map(({ line, rule }) => ({ line, rule })),
+    [{ line: 4, rule: 'external-uses-must-be-sha' }],
+  );
+});
+
+test('ignores uses-like text outside steps and reusable-workflow jobs', () => {
+  const text = `on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      uses: actions/cache@v4
+    steps:
+      - run: |
+          uses: actions/setup-node@v7
+`;
+
+  assert.deepEqual(inspectWorkflowText('not-action.yml', text), []);
+});
+
+test('rejects a pull_request workflow that checks out code and reads a secret', () => {
+  const text = `on:
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+      - run: echo "\${{ secrets.ANTHROPIC_API_KEY }}"
+`;
+
+  const violations = inspectWorkflowText('pull-request.yml', text);
+
+  assert.deepEqual(violations, [{
+    file: 'pull-request.yml',
+    line: 8,
+    rule: 'pr-workflow-must-be-secret-free',
+    message: 'pull_request workflow checks out repository code and references a secret',
+  }]);
+});
+
+test('accepts a secret-free pull_request workflow with checkout', () => {
+  const violations = inspectWorkflowText(
+    'safe-pr.yml',
+    workflow(`      - uses: ${pinnedCheckout}`, 'pull_request'),
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test('accepts a schedule-only secret-bearing workflow', () => {
+  const text = `on:
+  schedule:
+    - cron: '0 6 * * 1'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+      - run: echo "\${{ secrets.DEPLOY_TOKEN }}"
+`;
+
+  assert.deepEqual(inspectWorkflowText('scheduled.yml', text), []);
+});
+
+test('rejects pull_request_target checkout of the pull request head', () => {
+  const text = `on: [push, pull_request_target]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+        with:
+          ref: \${{ github.event.pull_request.head.sha }}
+`;
+
+  const violations = inspectWorkflowText('target.yml', text);
+
+  assert.deepEqual(violations, [{
+    file: 'target.yml',
+    line: 8,
+    rule: 'pr-target-must-not-execute-head',
+    message: 'pull_request_target workflow must not check out a pull request head or merge ref',
+  }]);
+});
+
+test('rejects a pull request head ref in a named checkout step', () => {
+  const text = `on: pull_request_target
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pull request
+        uses: ${pinnedCheckout}
+        with:
+          ref: \${{ github.head_ref }}
+`;
+
+  assert.equal(
+    inspectWorkflowText('named-target.yml', text)
+      .some(({ line, rule }) => line === 9 && rule === 'pr-target-must-not-execute-head'),
+    true,
+  );
+});
+
+test('recognizes scalar and inline-list pull request triggers', () => {
+  const scalar = workflow(`      - uses: ${pinnedCheckout}
+      - run: echo "\${{ secrets.TOKEN }}"`, 'pull_request');
+  const inlineList = workflow(`      - uses: ${pinnedCheckout}
+      - run: echo "\${{ secrets.TOKEN }}"`, '[push, pull_request]');
+
+  assert.equal(
+    inspectWorkflowText('scalar.yml', scalar)
+      .some(({ rule }) => rule === 'pr-workflow-must-be-secret-free'),
+    true,
+  );
+  assert.equal(
+    inspectWorkflowText('inline.yml', inlineList)
+      .some(({ rule }) => rule === 'pr-workflow-must-be-secret-free'),
+    true,
+  );
+});
+
+test('recognizes scalar pull_request_target head and merge refs', () => {
+  for (const ref of [
+    '${{ github.head_ref }}',
+    'refs/pull/${{ github.event.pull_request.number }}/merge',
+  ]) {
+    const text = workflow(`      - uses: ${pinnedCheckout}
+        with:
+          ref: ${ref}`, 'pull_request_target');
+
+    assert.equal(
+      inspectWorkflowText('target.yml', text)
+        .some(({ rule }) => rule === 'pr-target-must-not-execute-head'),
+      true,
+      ref,
+    );
+  }
+});
+
+test('ignores blank lines and comment-only uses and trigger lines', () => {
+  const text = `on:
+  push:
+  # pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # - uses: actions/checkout@v7
+      - run: echo "\${{ secrets.TOKEN }}"
+`;
+
+  assert.deepEqual(inspectWorkflowText('comments.yml', text), []);
+});
+
+test('reports the source filename, line, and stable rule ID', () => {
+  const violations = inspectWorkflowText(
+    'source.yaml',
+    workflow('      - uses: actions/checkout@v7'),
+  );
+
+  assert.equal(violations[0].file, 'source.yaml');
+  assert.equal(violations[0].line, 7);
+  assert.equal(violations[0].rule, 'external-uses-must-be-sha');
+});
+
+test('scans both yml and yaml files and sorts violations', async () => {
+  const workflowDirectory = await temporaryWorkflowDirectory({
+    'z-last.yml': workflow('      - uses: actions/upload-artifact@v7'),
+    'a-first.yaml': workflow(`      - uses: actions/setup-node@v7
+      - uses: docker://alpine:latest`),
+    'ignored.txt': workflow('      - uses: actions/checkout@v7'),
+  });
+
+  const violations = inspectWorkflowDirectory(workflowDirectory);
+
+  assert.deepEqual(
+    violations.map(({ file, line, rule }) => ({ file, line, rule })),
+    [
+      { file: 'a-first.yaml', line: 7, rule: 'external-uses-must-be-sha' },
+      { file: 'a-first.yaml', line: 8, rule: 'external-uses-must-be-sha' },
+      { file: 'z-last.yml', line: 7, rule: 'external-uses-must-be-sha' },
+    ],
+  );
+});
+
+test('only the root on key activates pull request policy', () => {
+  const text = `name: Nested on
+jobs:
+  test:
+    on: pull_request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+      - run: echo "\${{ secrets.TOKEN }}"
+`;
+
+  assert.deepEqual(inspectWorkflowText('nested-on.yml', text), []);
+});
+
+test('accepts quoted on, trigger, uses, and ref keys', () => {
+  const secretText = `"on":
+  'pull_request':
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - "uses": ${pinnedCheckout}
+      - run: echo "\${{ secrets.TOKEN }}"
+`;
+  const targetText = `'on': 'pull_request_target'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - 'uses': ${pinnedCheckout}
+        with:
+          "ref": \${{ github.event.pull_request.head.sha }}
+`;
+
+  assert.equal(
+    inspectWorkflowText('quoted-pr.yml', secretText)
+      .some(({ rule }) => rule === 'pr-workflow-must-be-secret-free'),
+    true,
+  );
+  assert.equal(
+    inspectWorkflowText('quoted-target.yml', targetText)
+      .some(({ rule }) => rule === 'pr-target-must-not-execute-head'),
+    true,
+  );
+});
+
+test('recognizes dash-only and flow-style action and reusable-workflow uses', () => {
+  const cases = [
+    {
+      name: 'dash-only.yml',
+      text: `on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        uses: actions/cache@v4
+`,
+    },
+    {
+      name: 'flow-step.yml',
+      text: `on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - { uses: actions/cache@v4 }
+`,
+    },
+    {
+      name: 'flow-reusable.yml',
+      text: `on: push
+jobs:
+  reusable: { uses: example/workflows/.github/workflows/test.yml@main }
+`,
+    },
+  ];
+
+  for (const { name, text } of cases) {
+    assert.equal(
+      inspectWorkflowText(name, text)
+        .some(({ rule }) => rule === 'external-uses-must-be-sha'),
+      true,
+      name,
+    );
+  }
+});
+
+test('finds dot and bracket secret access inside block scalars including hash lines', () => {
+  const text = `on: pull_request
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+      - run: |
+          # \${{ secrets.DOT_KEY }}
+          echo "\${{ secrets['SINGLE_KEY'] }}"
+          echo '\${{ secrets["DOUBLE_KEY"] }}'
+`;
+
+  assert.deepEqual(
+    inspectWorkflowText('block-secrets.yml', text)
+      .filter(({ rule }) => rule === 'pr-workflow-must-be-secret-free')
+      .map(({ line }) => line),
+    [8, 9, 10],
+  );
+});
+
+test('finds pull request target head and merge refs in all supported forms', () => {
+  const cases = [
+    {
+      name: 'quoted-ref.yml',
+      body: `      - uses: ${pinnedCheckout}
+        with:
+          'ref': \${{ github.event.pull_request.head.sha }}`,
+    },
+    {
+      name: 'flow-with.yml',
+      body: `      - { uses: ${pinnedCheckout}, with: { ref: "\${{ github['head_ref'] }}" } }`,
+    },
+    {
+      name: 'folded-ref.yml',
+      body: `      - uses: ${pinnedCheckout}
+        with:
+          ref: >-
+            refs/pull/
+            \${{ github.event.pull_request.number }}
+            /merge`,
+    },
+    {
+      name: 'bracket-ref.yml',
+      body: `      - uses: ${pinnedCheckout}
+        with:
+          ref: \${{ github['event']['pull_request']['head']['sha'] }}`,
+    },
+  ];
+
+  for (const { body, name } of cases) {
+    assert.equal(
+      inspectWorkflowText(name, workflow(body, 'pull_request_target'))
+        .some(({ rule }) => rule === 'pr-target-must-not-execute-head'),
+      true,
+      name,
+    );
+  }
+});
+
+test('sorts filenames by code point rather than host locale', async () => {
+  const workflowDirectory = await temporaryWorkflowDirectory({
+    'a-lower.yml': workflow('      - uses: actions/cache@v4'),
+    'Z-upper.yml': workflow('      - uses: actions/cache@v4'),
+  });
+
+  assert.deepEqual(
+    inspectWorkflowDirectory(workflowDirectory).map(({ file }) => file),
+    ['Z-upper.yml', 'a-lower.yml'],
+  );
+});
+
+test('rejects unsupported root and multiline security-relevant flow collections', () => {
+  const cases = [
+    {
+      name: 'root-flow.yml',
+      text: `{"on": push, jobs: {test: {"runs-on": ubuntu-latest, steps: [{uses: actions/checkout@v4}]}}}
+`,
+    },
+    {
+      name: 'multiline-flow-step.yml',
+      text: `on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - {
+          uses: actions/checkout@v4
+        }
+`,
+    },
+    {
+      name: 'multiline-flow-reusable.yml',
+      text: `on: push
+jobs:
+  reusable: {
+    uses: example/workflows/.github/workflows/test.yml@main
+  }
+`,
+    },
+  ];
+
+  for (const { name, text } of cases) {
+    assert.equal(
+      inspectWorkflowText(name, text)
+        .some(({ rule }) => rule === 'unsupported-workflow-syntax'),
+      true,
+      name,
+    );
+  }
+});
+
+test('rejects escape-bearing security-relevant YAML', () => {
+  const cases = [
+    {
+      name: 'escaped-on.yml',
+      text: `"o\\u006e": pull_request
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+`,
+    },
+    {
+      name: 'escaped-trigger.yml',
+      text: `on:
+  "pull_\\u0072equest":
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+`,
+    },
+    {
+      name: 'escaped-secret.yml',
+      text: `on: pull_request
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+      - run: "echo \${{ secr\\u0065ts.TOKEN }}"
+`,
+    },
+    {
+      name: 'escaped-head.yml',
+      text: `on: pull_request_target
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+        with:
+          ref: "\${{ github.event.pull_request.h\\u0065ad.sha }}"
+`,
+    },
+  ];
+
+  for (const { name, text } of cases) {
+    assert.equal(
+      inspectWorkflowText(name, text)
+        .some(({ rule }) => rule === 'unsupported-workflow-syntax'),
+      true,
+      name,
+    );
+  }
+});
+
+test('reconstructs folded and literal block scalars for pull request secret checks', () => {
+  for (const indicator of ['>-', '|']) {
+    const text = `on: pull_request
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+      - run: ${indicator}
+          echo "\${{ secrets
+          .TOKEN }}"
+`;
+
+    assert.equal(
+      inspectWorkflowText(`split-secret-${indicator}.yml`, text)
+        .some(({ rule }) => rule === 'pr-workflow-must-be-secret-free'),
+      true,
+      indicator,
+    );
+  }
+});
+
+test('rejects every dynamic checkout ref under pull_request_target', () => {
+  const text = `on: pull_request_target
+env:
+  PR_HEAD: refs/heads/main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+        with:
+          ref: \${{ env.PR_HEAD }}
+`;
+
+  assert.equal(
+    inspectWorkflowText('dynamic-ref.yml', text)
+      .some(({ rule }) => rule === 'pr-target-must-not-execute-head'),
+    true,
+  );
+});

--- a/.github/scripts/check-workflow-security.test.mjs
+++ b/.github/scripts/check-workflow-security.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -586,4 +587,183 @@ jobs:
       .some(({ rule }) => rule === 'pr-target-must-not-execute-head'),
     true,
   );
+});
+
+function developerSigningWorkflow(signingSteps) {
+  return `name: Developer signing
+on: workflow_dispatch
+jobs:
+  sign-notarize:
+    runs-on: macos-15
+    steps:
+${signingSteps}
+`;
+}
+
+test('rejects checkout in an Apple-secret developer signing job', () => {
+  const text = developerSigningWorkflow(`      - name: Verify unsigned artifact before secrets
+        run: shasum -a 256 -c SHA256SUMS
+      - uses: ${pinnedCheckout}
+      - name: Import certificate
+        env:
+          APPLE_CERTIFICATE: \${{ secrets.APPLE_CERTIFICATE }}
+        run: security import certificate.p12
+`);
+
+  const violations = inspectWorkflowText('dev-build-agent.yml', text);
+
+  assert.equal(
+    violations.some(({ line, rule }) => (
+      line === 9 && rule === 'signing-job-must-not-build-source'
+    )),
+    true,
+  );
+});
+
+test('rejects source build commands in an Apple-secret developer signing job', () => {
+  for (const command of [
+    'go build ./cmd/breeze-agent',
+    'cargo build --release',
+    'npm run build',
+    'pnpm build',
+  ]) {
+    const text = developerSigningWorkflow(`      - name: Verify unsigned artifact before secrets
+        run: shasum -a 256 -c SHA256SUMS
+      - name: Build source
+        run: ${command}
+      - name: Import certificate
+        env:
+          APPLE_ID: \${{ secrets.APPLE_ID }}
+        run: echo signing
+`);
+
+    assert.equal(
+      inspectWorkflowText('dev-build-agent.yml', text)
+        .some(({ rule }) => rule === 'signing-job-must-not-build-source'),
+      true,
+      command,
+    );
+  }
+});
+
+test('requires checksum verification before the first Apple secret reference', () => {
+  const missingVerification = developerSigningWorkflow(`      - name: Import certificate
+        env:
+          APPLE_ID: \${{ secrets.APPLE_ID }}
+        run: echo signing
+`);
+  const lateVerification = developerSigningWorkflow(`      - name: Import certificate
+        env:
+          APPLE_ID: \${{ secrets.APPLE_ID }}
+        run: echo signing
+      - name: Verify unsigned artifact before secrets
+        run: shasum -a 256 -c SHA256SUMS
+`);
+
+  for (const text of [missingVerification, lateVerification]) {
+    assert.equal(
+      inspectWorkflowText('dev-build-agent.yml', text)
+        .some(({ rule }) => (
+          rule === 'signing-job-must-verify-artifact-before-secrets'
+        )),
+      true,
+    );
+  }
+});
+
+test('accepts an Apple-secret developer signing job that only verifies and signs', () => {
+  const text = developerSigningWorkflow(`      - name: Verify unsigned artifact before secrets
+        run: |
+          shasum -a 256 -c SHA256SUMS
+          plutil -lint agent-macos.entitlements.plist
+      - name: Import certificate
+        env:
+          APPLE_CERTIFICATE: \${{ secrets.APPLE_CERTIFICATE }}
+        run: security import certificate.p12
+      - name: Sign binary
+        env:
+          APPLE_SIGNING_IDENTITY: \${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: codesign --sign "$APPLE_SIGNING_IDENTITY" breeze-agent
+`);
+
+  assert.deepEqual(inspectWorkflowText('dev-build-agent.yml', text), []);
+});
+
+test('does not apply the developer signing split rule to release workflows', () => {
+  const text = developerSigningWorkflow(`      - uses: ${pinnedCheckout}
+      - name: Build and sign release
+        env:
+          APPLE_ID: \${{ secrets.APPLE_ID }}
+        run: go build ./cmd/breeze-agent
+`);
+
+  assert.deepEqual(inspectWorkflowText('release.yml', text), []);
+});
+
+test('rejects case-variant checkout in an Apple-secret developer signing job', () => {
+  const caseVariantCheckout = pinnedCheckout.replace(
+    'actions/checkout',
+    'Actions/Checkout',
+  );
+  const text = developerSigningWorkflow(`      - name: Verify unsigned artifact before secrets
+        run: shasum -a 256 -c SHA256SUMS
+      - uses: ${caseVariantCheckout}
+      - name: Import certificate
+        env:
+          APPLE_CERTIFICATE: \${{ secrets.APPLE_CERTIFICATE }}
+        run: security import certificate.p12
+`);
+
+  assert.equal(
+    inspectWorkflowText('dev-build-agent.yml', text)
+      .some(({ rule }) => rule === 'signing-job-must-not-build-source'),
+    true,
+  );
+});
+
+test('rejects shell-continuation build commands in developer signing jobs', () => {
+  const commands = [
+    `go \\
+            build ./cmd/breeze-agent`,
+    `cargo \\
+            build --release`,
+    `npm run \\
+            build`,
+    `pnpm \\
+            build`,
+  ];
+
+  for (const command of commands) {
+    const text = developerSigningWorkflow(`      - name: Verify unsigned artifact before secrets
+        run: shasum -a 256 -c SHA256SUMS
+      - name: Hidden build
+        run: |
+          ${command}
+      - name: Import certificate
+        env:
+          APPLE_ID: \${{ secrets.APPLE_ID }}
+        run: echo signing
+`);
+
+    assert.equal(
+      inspectWorkflowText('dev-build-agent.yml', text)
+        .some(({ rule }) => rule === 'signing-job-must-not-build-source'),
+      true,
+      command,
+    );
+  }
+});
+
+test('developer signing requires global and developer-specific kill switches', () => {
+  const workflowText = readFileSync(
+    new URL('../workflows/dev-build-agent.yml', import.meta.url),
+    'utf8',
+  );
+  const signingCondition = workflowText.slice(
+    workflowText.indexOf('  sign-notarize:'),
+    workflowText.indexOf('    environment: macos-signing'),
+  );
+
+  assert.match(signingCondition, /vars\.ENABLE_MACOS_SIGNING == 'true'/u);
+  assert.match(signingCondition, /vars\.ENABLE_DEV_MACOS_SIGNING == 'true'/u);
 });

--- a/.github/scripts/check-workflow-security.test.mjs
+++ b/.github/scripts/check-workflow-security.test.mjs
@@ -142,6 +142,25 @@ jobs:
   }]);
 });
 
+test('rejects toJSON of the secrets context in a pull_request workflow', () => {
+  const text = `on: pull_request
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+      - run: echo '\${{ toJSON(secrets) }}'
+`;
+
+  assert.equal(
+    inspectWorkflowText('all-secrets.yml', text)
+      .some(({ line, rule }) => (
+        line === 7 && rule === 'pr-workflow-must-be-secret-free'
+      )),
+    true,
+  );
+});
+
 test('accepts a secret-free pull_request workflow with checkout', () => {
   const violations = inspectWorkflowText(
     'safe-pr.yml',
@@ -202,6 +221,49 @@ jobs:
   assert.equal(
     inspectWorkflowText('named-target.yml', text)
       .some(({ line, rule }) => line === 9 && rule === 'pr-target-must-not-execute-head'),
+    true,
+  );
+});
+
+test('rejects pull_request_target head checkout performed by a run step', () => {
+  const text = `on: pull_request_target
+jobs:
+  leak:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+      - env:
+          HEAD_SHA: \${{ github.event.pull_request.head.sha }}
+          CRED: \${{ secrets.RELEASE_KEY }}
+        run: git fetch origin "$HEAD_SHA" && git checkout "$HEAD_SHA" && ./owned.sh
+`;
+
+  assert.equal(
+    inspectWorkflowText('run-checkout-target.yml', text)
+      .some(({ line, rule }) => (
+        line === 10 && rule === 'pr-target-must-not-execute-head'
+      )),
+    true,
+  );
+});
+
+test('rejects pull_request_target head reset performed by a run step', () => {
+  const text = `on: pull_request_target
+jobs:
+  leak:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${pinnedCheckout}
+      - env:
+          HEAD_SHA: \${{ github.event.pull_request.head.sha }}
+        run: git fetch origin "$HEAD_SHA" && git reset --hard "$HEAD_SHA" && ./owned.sh
+`;
+
+  assert.equal(
+    inspectWorkflowText('run-reset-target.yml', text)
+      .some(({ line, rule }) => (
+        line === 9 && rule === 'pr-target-must-not-execute-head'
+      )),
     true,
   );
 });
@@ -620,6 +682,25 @@ test('rejects checkout in an Apple-secret developer signing job', () => {
   );
 });
 
+test('applies developer signing rules after the workflow is renamed', () => {
+  const text = developerSigningWorkflow(`      - name: Verify unsigned artifact before secrets
+        run: shasum -a 256 -c SHA256SUMS
+      - uses: ${pinnedCheckout}
+      - name: Import certificate
+        env:
+          APPLE_CERTIFICATE: \${{ secrets.APPLE_CERTIFICATE }}
+        run: security import certificate.p12
+`);
+
+  assert.equal(
+    inspectWorkflowText('renamed-signing-workflow.yml', text)
+      .some(({ line, rule }) => (
+        line === 9 && rule === 'signing-job-must-not-build-source'
+      )),
+    true,
+  );
+});
+
 test('rejects source build commands in an Apple-secret developer signing job', () => {
   for (const command of [
     'go build ./cmd/breeze-agent',
@@ -689,15 +770,112 @@ test('accepts an Apple-secret developer signing job that only verifies and signs
   assert.deepEqual(inspectWorkflowText('dev-build-agent.yml', text), []);
 });
 
-test('does not apply the developer signing split rule to release workflows', () => {
-  const text = developerSigningWorkflow(`      - uses: ${pinnedCheckout}
+test('does not apply the developer signing split rule to tag release workflows', () => {
+  const text = `name: Release signing
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+jobs:
+  sign-release:
+    runs-on: macos-15
+    if: >-
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: ${pinnedCheckout}
       - name: Build and sign release
         env:
           APPLE_ID: \${{ secrets.APPLE_ID }}
         run: go build ./cmd/breeze-agent
-`);
+`;
 
-  assert.deepEqual(inspectWorkflowText('release.yml', text), []);
+  assert.deepEqual(inspectWorkflowText('renamed-release.yml', text), []);
+});
+
+test('does not let a tag trigger exempt an ungated dispatch signing job', () => {
+  const text = `name: Signing bypass
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+jobs:
+  sign-release:
+    runs-on: macos-15
+    steps:
+      - uses: ${pinnedCheckout}
+      - name: Build and sign arbitrary source
+        env:
+          APPLE_ID: \${{ secrets.APPLE_ID }}
+        run: go build ./cmd/breeze-agent
+`;
+
+  assert.equal(
+    inspectWorkflowText('fake-release.yml', text)
+      .some(({ rule }) => rule === 'signing-job-must-not-build-source'),
+    true,
+  );
+});
+
+test('does not exempt a signing job with an alternative dispatch condition', () => {
+  const text = `name: Signing gate bypass
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+jobs:
+  sign-release:
+    runs-on: macos-15
+    if: >-
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
+      || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: ${pinnedCheckout}
+      - name: Build and sign arbitrary source
+        env:
+          APPLE_ID: \${{ secrets.APPLE_ID }}
+        run: go build ./cmd/breeze-agent
+`;
+
+  assert.equal(
+    inspectWorkflowText('or-gated-release.yml', text)
+      .some(({ rule }) => rule === 'signing-job-must-not-build-source'),
+    true,
+  );
+});
+
+test('does not exempt a signing job with a trailing dispatch alternative', () => {
+  const text = `name: Signing precedence bypass
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+jobs:
+  sign-release:
+    runs-on: macos-15
+    if: >-
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
+      && vars.ENABLE_MACOS_SIGNING == 'true'
+      || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: ${pinnedCheckout}
+      - name: Build and sign arbitrary source
+        env:
+          APPLE_ID: \${{ secrets.APPLE_ID }}
+        run: go build ./cmd/breeze-agent
+`;
+
+  assert.equal(
+    inspectWorkflowText('precedence-gated-release.yml', text)
+      .some(({ rule }) => rule === 'signing-job-must-not-build-source'),
+    true,
+  );
 });
 
 test('rejects case-variant checkout in an Apple-secret developer signing job', () => {

--- a/.github/scripts/check-workflow-security.test.mjs
+++ b/.github/scripts/check-workflow-security.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -782,4 +782,68 @@ test('pull requests run the confidential pattern scan without repository secrets
   assert.match(jobText, /bash scripts\/security\/scan-confidential\.sh --all/u);
   assert.doesNotMatch(jobText, /\bsecrets(?:\.|\[)/u);
   assert.doesNotMatch(jobText, /CONFIDENTIAL_DENYLIST/u);
+});
+
+test('all repository checkout steps disable credential persistence', () => {
+  const workflowDirectory = new URL('../workflows/', import.meta.url);
+  const failures = [];
+
+  for (const filename of readdirSync(workflowDirectory).filter((name) => (
+    /\.ya?ml$/u.test(name)
+  ))) {
+    const sourceLines = readFileSync(
+      new URL(filename, workflowDirectory),
+      'utf8',
+    ).split(/\r?\n/u);
+
+    for (const [checkoutIndex, checkoutLine] of sourceLines.entries()) {
+      if (!/\buses:\s*actions\/checkout@/u.test(checkoutLine)) {
+        continue;
+      }
+
+      const checkoutIndent = checkoutLine.match(/^\s*/u)[0].length;
+      let stepStart = checkoutIndex;
+      while (
+        stepStart > 0
+        && !(
+          sourceLines[stepStart].trimStart().startsWith('-')
+          && sourceLines[stepStart].match(/^\s*/u)[0].length <= checkoutIndent
+        )
+      ) {
+        stepStart -= 1;
+      }
+      const stepIndent = sourceLines[stepStart].match(/^\s*/u)[0].length;
+      let stepEnd = checkoutIndex + 1;
+      while (
+        stepEnd < sourceLines.length
+        && !(
+          sourceLines[stepEnd].trimStart().startsWith('-')
+          && sourceLines[stepEnd].match(/^\s*/u)[0].length === stepIndent
+        )
+      ) {
+        stepEnd += 1;
+      }
+
+      if (!/persist-credentials:\s*false/u.test(
+        sourceLines.slice(stepStart, stepEnd).join('\n'),
+      )) {
+        failures.push(`${filename}:${checkoutIndex + 1}`);
+      }
+    }
+  }
+
+  assert.deepEqual(failures, []);
+});
+
+test('community README push uses an ephemeral credential helper', () => {
+  const workflowText = readFileSync(
+    new URL('../workflows/update-community-readme.yml', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(
+    workflowText,
+    /git -c credential\.helper= -c 'credential\.helper=!f\(\).*push origin HEAD:main/su,
+  );
+  assert.doesNotMatch(workflowText, /persist-credentials:\s*true/u);
 });

--- a/.github/scripts/check-workflow-security.test.mjs
+++ b/.github/scripts/check-workflow-security.test.mjs
@@ -767,3 +767,19 @@ test('developer signing requires global and developer-specific kill switches', (
   assert.match(signingCondition, /vars\.ENABLE_MACOS_SIGNING == 'true'/u);
   assert.match(signingCondition, /vars\.ENABLE_DEV_MACOS_SIGNING == 'true'/u);
 });
+
+test('pull requests run the confidential pattern scan without repository secrets', () => {
+  const workflowText = readFileSync(
+    new URL('../workflows/secret-scan.yml', import.meta.url),
+    'utf8',
+  );
+  const jobStart = workflowText.indexOf('  confidential-patterns:');
+
+  assert.notEqual(jobStart, -1);
+
+  const jobText = workflowText.slice(jobStart);
+  assert.match(jobText, /if: github\.event_name == 'pull_request'/u);
+  assert.match(jobText, /bash scripts\/security\/scan-confidential\.sh --all/u);
+  assert.doesNotMatch(jobText, /\bsecrets(?:\.|\[)/u);
+  assert.doesNotMatch(jobText, /CONFIDENTIAL_DENYLIST/u);
+});

--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -85,7 +85,7 @@ jobs:
         env:
           # Authenticate binarySync's github API call so we don't hit the
           # 60/hour unauthenticated rate limit on the shared CI runner IP.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           BINARY_SOURCE: github
           # Use the most recent published release whose manifest format is
           # known to be compatible with the current API code. Bump this when

--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -67,6 +67,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}

--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -66,11 +66,11 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: pnpm

--- a/.github/workflows/ci-smoke-binary-source-local.yml
+++ b/.github/workflows/ci-smoke-binary-source-local.yml
@@ -57,6 +57,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}

--- a/.github/workflows/ci-smoke-binary-source-local.yml
+++ b/.github/workflows/ci-smoke-binary-source-local.yml
@@ -56,11 +56,11 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Guard production compose defaults
         run: |
@@ -92,6 +94,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -120,6 +124,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -194,6 +200,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -244,6 +252,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -315,6 +325,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -339,6 +351,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -363,6 +377,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -387,6 +403,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -414,6 +432,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -438,6 +458,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -465,6 +487,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -501,6 +525,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -528,6 +554,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -582,6 +610,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -624,6 +654,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -655,6 +687,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -693,6 +727,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -754,6 +790,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -828,6 +866,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -860,6 +900,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -890,6 +932,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -969,6 +1013,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Go
@@ -1004,6 +1049,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -1052,6 +1099,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -1191,6 +1240,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install Tauri system dependencies
         run: |
@@ -1269,6 +1320,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Detect Cargo changes
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -1341,6 +1394,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -1459,6 +1514,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Create .env
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Guard production compose defaults
         run: |
@@ -59,7 +59,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -91,7 +91,7 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -99,7 +99,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -127,7 +127,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -193,7 +193,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -201,7 +201,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -243,7 +243,7 @@ jobs:
       AGENT_ENROLLMENT_SECRET: ci-check-migrations-agent-enrollment-secret
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -251,7 +251,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -314,7 +314,7 @@ jobs:
       AGENT_ENROLLMENT_SECRET: ci-nonsuperuser-migrations-agent-enrollment
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -322,7 +322,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -346,7 +346,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -362,7 +362,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -370,7 +370,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -386,7 +386,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -394,7 +394,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -413,7 +413,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -421,7 +421,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -437,7 +437,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -445,7 +445,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -464,7 +464,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -472,7 +472,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -500,7 +500,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -508,7 +508,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -527,7 +527,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -535,7 +535,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -581,7 +581,7 @@ jobs:
     needs: [lint, typecheck]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -589,7 +589,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -611,7 +611,7 @@ jobs:
           echo "Both expected dist artefacts present"
 
       - name: Upload API artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: api-dist
           path: apps/api/dist
@@ -623,7 +623,7 @@ jobs:
     needs: [lint, typecheck]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -631,7 +631,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -654,7 +654,7 @@ jobs:
     needs: [lint, typecheck]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -662,7 +662,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -680,7 +680,7 @@ jobs:
         run: pnpm --filter @breeze/web run csp:guard
 
       - name: Upload Web artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: web-dist
           path: apps/web/dist
@@ -692,7 +692,7 @@ jobs:
     needs: [lint, typecheck]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -700,7 +700,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -716,7 +716,7 @@ jobs:
         run: pnpm build --filter=@breeze/portal
 
       - name: Upload Portal artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: portal-dist
           path: apps/portal/dist
@@ -753,10 +753,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: agent/go.sum
@@ -800,7 +800,7 @@ jobs:
             ./cmd/breeze-user-helper
 
       - name: Upload Agent artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-agent-${{ matrix.goos }}-${{ matrix.goarch }}
           path: agent/breeze-agent-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}
@@ -808,7 +808,7 @@ jobs:
 
       - name: Upload user-helper artifact (Windows only)
         if: matrix.goos == 'windows'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-user-helper-${{ matrix.goos }}-${{ matrix.goarch }}
           path: agent/breeze-user-helper-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}
@@ -827,10 +827,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: agent/go.sum
@@ -859,10 +859,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: agent/go.sum
@@ -876,7 +876,7 @@ jobs:
         run: CGO_ENABLED=0 go test -v -coverprofile=coverage.out ./...
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: agent-coverage
           path: agent/coverage.out
@@ -889,10 +889,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: agent/go.sum
@@ -967,12 +967,12 @@ jobs:
       CGO_ENABLED: '0'
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: agent/go.sum
@@ -1003,10 +1003,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: agent/go.sum
@@ -1051,10 +1051,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: agent/go.sum
@@ -1190,7 +1190,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Tauri system dependencies
         run: |
@@ -1268,7 +1268,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Detect Cargo changes
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -1340,7 +1340,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -1348,7 +1348,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -1458,7 +1458,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Create .env
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,23 +26,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
         if: matrix.language == 'go'
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: '1.25.12'
           cache-dependency-path: agent/go.sum
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild JavaScript/TypeScript
         if: matrix.language == 'javascript-typescript'
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
 
       - name: Build Go agent for CodeQL
         if: matrix.language == 'go'
@@ -52,4 +52,4 @@ jobs:
           CGO_ENABLED=0 go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         if: matrix.language == 'go'

--- a/.github/workflows/confidential-scan.yml
+++ b/.github/workflows/confidential-scan.yml
@@ -1,0 +1,35 @@
+name: Confidential Scan
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  confidential:
+    name: Confidential info
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      # Non-bypassable backstop for the .githooks/pre-commit scan: catches prod
+      # infra identifiers (IPs, DB cluster ids) that gitleaks does not model.
+      # The exact-value denylist is supplied out-of-band via a repo secret so
+      # the values never live in this public repo. Absent the secret, the
+      # pattern checks still run.
+      - name: Scan for confidential identifiers
+        env:
+          CONFIDENTIAL_DENYLIST: ${{ secrets.CONFIDENTIAL_DENYLIST }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${CONFIDENTIAL_DENYLIST:-}" ]]; then
+            deny="$(mktemp)"
+            printf '%s\n' "$CONFIDENTIAL_DENYLIST" > "$deny"
+            export CONFIDENTIAL_DENYLIST_FILE="$deny"
+          fi
+          bash scripts/security/scan-confidential.sh --all

--- a/.github/workflows/dev-build-agent.yml
+++ b/.github/workflows/dev-build-agent.yml
@@ -36,12 +36,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.branch }}
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: agent/go.sum
@@ -120,7 +120,7 @@ jobs:
           echo "Notarized: breeze-agent-darwin-arm64"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-agent-darwin-arm64
           path: agent/breeze-agent-darwin-arm64
@@ -136,12 +136,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.branch }}
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: agent/go.sum
@@ -220,7 +220,7 @@ jobs:
           echo "Notarized: breeze-agent-darwin-amd64"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-agent-darwin-amd64
           path: agent/breeze-agent-darwin-amd64

--- a/.github/workflows/dev-build-agent.yml
+++ b/.github/workflows/dev-build-agent.yml
@@ -1,10 +1,10 @@
-name: Dev Build Agent (Signed)
+name: Dev Build Agent (Unsigned + Protected Signing)
 
 on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to build from'
+        description: 'Branch, tag, or commit to build'
         required: true
         default: 'main'
       platform:
@@ -16,13 +16,10 @@ on:
           - darwin-amd64
           - all-darwin
       version:
-        description: 'Version string (e.g. dev-jit-vnc)'
+        description: 'Version label (letters, numbers, dot, plus, underscore, hyphen)'
         required: true
         default: 'dev'
 
-# Default least-privilege: this workflow only reads the repo. Per-job
-# permissions can opt into write scopes (e.g. id-token: write for
-# signing) when they actually need them.
 permissions:
   contents: read
 
@@ -30,202 +27,614 @@ env:
   GO_VERSION: '1.25.12'
 
 jobs:
-  build-arm64:
-    name: Build Agent (arm64)
-    if: inputs.platform == 'darwin-arm64' || inputs.platform == 'all-darwin'
-    runs-on: macos-latest
+  resolve:
+    name: Resolve immutable source
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.resolve.outputs.source_sha }}
+      source_label: ${{ steps.resolve.outputs.source_label }}
+      main_ancestry: ${{ steps.resolve.outputs.main_ancestry }}
+      matrix: ${{ steps.resolve.outputs.matrix }}
+      version: ${{ steps.resolve.outputs.version }}
+      workflow_definition_sha: ${{ steps.resolve.outputs.workflow_definition_sha }}
     steps:
-      - name: Checkout
+      - name: Resolve and validate requested source
+        id: resolve
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          REQUESTED_REF: ${{ inputs.branch }}
+          REQUESTED_PLATFORM: ${{ inputs.platform }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+          WORKFLOW_DEFINITION_SHA: ${{ github.sha }}
+        with:
+          script: |
+            const requestedRef = process.env.REQUESTED_REF ?? '';
+            const requestedPlatform = process.env.REQUESTED_PLATFORM ?? '';
+            const requestedVersion = process.env.REQUESTED_VERSION ?? '';
+            const workflowDefinitionSha = process.env.WORKFLOW_DEFINITION_SHA ?? '';
+            const hasControlCharacters = (value) => [...value].some((character) => {
+              const codePoint = character.codePointAt(0);
+              return codePoint < 32 || codePoint === 127;
+            });
+            const validRefCharacters = /^[A-Za-z0-9][A-Za-z0-9._+/@-]{0,254}$/u;
+            const validVersion = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/u;
+            const invalidRefShape = (
+              requestedRef.includes('..')
+              || requestedRef.includes('@{')
+              || requestedRef.includes('//')
+              || requestedRef.endsWith('/')
+              || requestedRef.endsWith('.')
+              || requestedRef.endsWith('.lock')
+            );
+
+            if (
+              hasControlCharacters(requestedRef)
+              || !validRefCharacters.test(requestedRef)
+              || invalidRefShape
+            ) {
+              core.setFailed('Requested ref contains unsupported characters or structure');
+              return;
+            }
+            if (
+              hasControlCharacters(requestedVersion)
+              || !validVersion.test(requestedVersion)
+            ) {
+              core.setFailed('Requested version must be 1-64 safe label characters');
+              return;
+            }
+            if (!['darwin-arm64', 'darwin-amd64', 'all-darwin'].includes(requestedPlatform)) {
+              core.setFailed('Requested platform is unsupported');
+              return;
+            }
+            if (!/^[0-9a-f]{40}$/u.test(workflowDefinitionSha)) {
+              core.setFailed('Workflow definition did not resolve to an immutable commit SHA');
+              return;
+            }
+
+            const response = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: requestedRef,
+            });
+            const sourceSha = response.data.sha;
+            if (!/^[0-9a-f]{40}$/u.test(sourceSha)) {
+              core.setFailed('Requested ref did not resolve to an immutable commit SHA');
+              return;
+            }
+
+            let mainAncestry = 'unknown';
+            try {
+              const comparison = await github.rest.repos.compareCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                base: sourceSha,
+                head: context.payload.repository.default_branch,
+              });
+              mainAncestry = ['ahead', 'identical'].includes(comparison.data.status)
+                ? 'ancestor_or_equal'
+                : 'not_ancestor';
+            } catch (error) {
+              core.warning(`Unable to establish protected-main ancestry: ${error.message}`);
+            }
+
+            const sourceLabel = requestedRef
+              .toLowerCase()
+              .replace(/[^a-z0-9._-]+/gu, '-')
+              .replace(/^-+|-+$/gu, '')
+              .slice(0, 48) || 'source';
+            const allArchitectures = [
+              { arch: 'arm64', runner: 'macos-15' },
+              { arch: 'amd64', runner: 'macos-15-intel' },
+            ];
+            const include = requestedPlatform === 'all-darwin'
+              ? allArchitectures
+              : allArchitectures.filter(({ arch }) => requestedPlatform === `darwin-${arch}`);
+
+            core.setOutput('source_sha', sourceSha);
+            core.setOutput('source_label', sourceLabel);
+            core.setOutput('main_ancestry', mainAncestry);
+            core.setOutput('matrix', JSON.stringify({ include }));
+            core.setOutput('version', requestedVersion);
+            core.setOutput('workflow_definition_sha', workflowDefinitionSha);
+
+  build-unsigned:
+    name: Build unsigned agent (${{ matrix.arch }})
+    needs: resolve
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.resolve.outputs.matrix) }}
+    steps:
+      - name: Checkout immutable source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          persist-credentials: false
+          fetch-depth: 1
 
-      - name: Setup Go
+      - name: Verify checked-out commit
+        env:
+          EXPECTED_SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          actual_source_sha="$(git rev-parse HEAD)"
+          if [[ "$actual_source_sha" != "$EXPECTED_SOURCE_SHA" ]]; then
+            echo "::error::Checked-out commit does not match the resolved source SHA"
+            exit 1
+          fi
+
+      - name: Setup Go without shared caches
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: agent/go.sum
+          cache: false
 
       - name: Download Go dependencies
         working-directory: agent
         run: go mod download
 
-      - name: Build Agent
+      - name: Build fixed unsigned binary
         working-directory: agent
         env:
-          GOOS: darwin
-          GOARCH: arm64
+          BUILD_VERSION: ${{ needs.resolve.outputs.version }}
           CGO_ENABLED: '1'
           CGO_LDFLAGS_ALLOW: '-weak_framework|ScreenCaptureKit'
-          BUILD_VERSION: ${{ inputs.version }}
+          GOARCH: ${{ matrix.arch }}
+          GOOS: darwin
         run: |
-          go build -ldflags="-s -w -X main.version=${BUILD_VERSION}" \
-            -o breeze-agent-darwin-arm64 \
+          set -euo pipefail
+          go build \
+            -ldflags="-s -w -X main.version=${BUILD_VERSION}" \
+            -o "breeze-agent-darwin-${GOARCH}" \
             ./cmd/breeze-agent
 
-      - name: Import certificate into keychain
-        if: vars.ENABLE_MACOS_SIGNING == 'true'
+      - name: Package unsigned artifact with strict provenance
         env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          ARTIFACT_ARCH: ${{ matrix.arch }}
+          ARTIFACT_VERSION: ${{ needs.resolve.outputs.version }}
+          MAIN_ANCESTRY: ${{ needs.resolve.outputs.main_ancestry }}
+          SOURCE_LABEL: ${{ needs.resolve.outputs.source_label }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          WORKFLOW_DEFINITION_SHA: ${{ needs.resolve.outputs.workflow_definition_sha }}
         run: |
-          CERT_PATH="$RUNNER_TEMP/cert.p12"
-          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
-          KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
+          set -euo pipefail
+          umask 077
+          artifact_dir="$RUNNER_TEMP/unsigned-artifact"
+          binary_name="breeze-agent-darwin-${ARTIFACT_ARCH}"
+          mkdir "$artifact_dir"
+          install -m 0755 "agent/$binary_name" "$artifact_dir/$binary_name"
+          install -m 0644 \
+            agent/entitlements/agent-macos.entitlements.plist \
+            "$artifact_dir/agent-macos.entitlements.plist"
 
-          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+          export ARTIFACT_DIR="$artifact_dir"
+          export BINARY_NAME="$binary_name"
+          export BINARY_SHA256
+          export BINARY_SIZE
+          export ENTITLEMENTS_SHA256
+          export ENTITLEMENTS_SIZE
+          BINARY_SHA256="$(shasum -a 256 "$artifact_dir/$binary_name" | awk '{print $1}')"
+          BINARY_SIZE="$(stat -f '%z' "$artifact_dir/$binary_name")"
+          ENTITLEMENTS_SHA256="$(
+            shasum -a 256 "$artifact_dir/agent-macos.entitlements.plist" | awk '{print $1}'
+          )"
+          ENTITLEMENTS_SIZE="$(stat -f '%z' "$artifact_dir/agent-macos.entitlements.plist")"
 
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple: \
-            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security list-keychains -d user -s "$KEYCHAIN_PATH" \
-            $(security list-keychains -d user | tr -d '"')
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
 
-          rm -f "$CERT_PATH"
+          const provenance = {
+            schemaVersion: 1,
+            repository: process.env.GITHUB_REPOSITORY,
+            workflow: 'dev-build-agent.yml',
+            workflowDefinitionSha: process.env.WORKFLOW_DEFINITION_SHA,
+            runId: process.env.GITHUB_RUN_ID,
+            runAttempt: process.env.GITHUB_RUN_ATTEMPT,
+            sourceSha: process.env.SOURCE_SHA,
+            sourceLabel: process.env.SOURCE_LABEL,
+            mainAncestry: process.env.MAIN_ANCESTRY,
+            architecture: process.env.ARTIFACT_ARCH,
+            version: process.env.ARTIFACT_VERSION,
+            files: {
+              binary: {
+                name: process.env.BINARY_NAME,
+                sha256: process.env.BINARY_SHA256,
+                size: Number(process.env.BINARY_SIZE),
+              },
+              entitlements: {
+                name: 'agent-macos.entitlements.plist',
+                sha256: process.env.ENTITLEMENTS_SHA256,
+                size: Number(process.env.ENTITLEMENTS_SIZE),
+              },
+            },
+          };
+          fs.writeFileSync(
+            path.join(process.env.ARTIFACT_DIR, 'provenance.json'),
+            `${JSON.stringify(provenance, null, 2)}\n`,
+            { mode: 0o644 },
+          );
+          NODE
 
-      - name: Sign binary
-        if: vars.ENABLE_MACOS_SIGNING == 'true'
-        env:
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        working-directory: agent
-        run: |
-          codesign --force --options runtime \
-            --entitlements entitlements/agent-macos.entitlements.plist \
-            --sign "$APPLE_SIGNING_IDENTITY" --timestamp breeze-agent-darwin-arm64
-          codesign --verify --verbose breeze-agent-darwin-arm64
-          echo "Signed: breeze-agent-darwin-arm64"
+          (
+            cd "$artifact_dir"
+            shasum -a 256 \
+              "$binary_name" \
+              agent-macos.entitlements.plist \
+              provenance.json > SHA256SUMS
+            chmod 0644 SHA256SUMS
+          )
 
-      - name: Notarize binary
-        if: vars.ENABLE_MACOS_SIGNING == 'true'
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        working-directory: agent
-        run: |
-          ditto -c -k --keepParent breeze-agent-darwin-arm64 breeze-agent-darwin-arm64.zip
-
-          echo "Submitting for notarization..."
-          xcrun notarytool submit breeze-agent-darwin-arm64.zip \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --wait --timeout 30m
-
-          rm -f breeze-agent-darwin-arm64.zip
-          echo "Notarized: breeze-agent-darwin-arm64"
-
-      - name: Upload artifact
+      - name: Upload immutable unsigned artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: breeze-agent-darwin-arm64
-          path: agent/breeze-agent-darwin-arm64
+          name: unsigned-breeze-agent-${{ matrix.arch }}-${{ needs.resolve.outputs.source_sha }}
+          path: ${{ runner.temp }}/unsigned-artifact/
+          if-no-files-found: error
           retention-days: 7
 
-      - name: Cleanup keychain
-        if: always() && vars.ENABLE_MACOS_SIGNING == 'true'
-        run: security delete-keychain "$RUNNER_TEMP/signing.keychain-db" || true
-
-  build-amd64:
-    name: Build Agent (amd64)
-    if: inputs.platform == 'darwin-amd64' || inputs.platform == 'all-darwin'
-    runs-on: macos-latest
+  sign-notarize:
+    name: Sign and notarize agent (${{ matrix.arch }})
+    needs: [resolve, build-unsigned]
+    # The global incident kill switch and the developer-workflow opt-in must
+    # both be explicitly enabled. Absence or false on either keeps signing off.
+    if: >-
+      ${{
+        vars.ENABLE_MACOS_SIGNING == 'true' &&
+        vars.ENABLE_DEV_MACOS_SIGNING == 'true' &&
+        github.ref == 'refs/heads/main' &&
+        needs.resolve.outputs.main_ancestry == 'ancestor_or_equal'
+      }}
+    environment: macos-signing
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.resolve.outputs.matrix) }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Download exact unsigned artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          ref: ${{ inputs.branch }}
+          name: unsigned-breeze-agent-${{ matrix.arch }}-${{ needs.resolve.outputs.source_sha }}
+          path: ${{ runner.temp }}/unsigned-artifact
 
-      - name: Setup Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: agent/go.sum
-
-      - name: Download Go dependencies
-        working-directory: agent
-        run: go mod download
-
-      - name: Build Agent
-        working-directory: agent
+      - name: Verify unsigned artifact before secrets
+        id: verify
+        working-directory: ${{ runner.temp }}/unsigned-artifact
         env:
-          GOOS: darwin
-          GOARCH: amd64
-          CGO_ENABLED: '1'
-          CGO_LDFLAGS_ALLOW: '-weak_framework|ScreenCaptureKit'
-          BUILD_VERSION: ${{ inputs.version }}
+          EXPECTED_ARCH: ${{ matrix.arch }}
+          EXPECTED_ANCESTRY: ${{ needs.resolve.outputs.main_ancestry }}
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+          EXPECTED_RUN_ATTEMPT: ${{ github.run_attempt }}
+          EXPECTED_RUN_ID: ${{ github.run_id }}
+          EXPECTED_SOURCE_LABEL: ${{ needs.resolve.outputs.source_label }}
+          EXPECTED_SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          EXPECTED_VERSION: ${{ needs.resolve.outputs.version }}
+          EXPECTED_WORKFLOW_DEFINITION_SHA: ${{ needs.resolve.outputs.workflow_definition_sha }}
         run: |
-          go build -ldflags="-s -w -X main.version=${BUILD_VERSION}" \
-            -o breeze-agent-darwin-amd64 \
-            ./cmd/breeze-agent
+          set -euo pipefail
+          umask 077
+          binary_name="breeze-agent-darwin-${EXPECTED_ARCH}"
+          expected_files="$RUNNER_TEMP/expected-files-${EXPECTED_ARCH}.txt"
+          actual_files="$RUNNER_TEMP/actual-files-${EXPECTED_ARCH}.txt"
+          printf '%s\n' \
+            SHA256SUMS \
+            agent-macos.entitlements.plist \
+            "$binary_name" \
+            provenance.json \
+            | LC_ALL=C sort > "$expected_files"
 
-      - name: Import certificate into keychain
-        if: vars.ENABLE_MACOS_SIGNING == 'true'
+          if find . -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "::error::Unsigned artifact contains a symlink, directory, or special file"
+            exit 1
+          fi
+          find . -mindepth 1 -maxdepth 1 -type f -exec basename {} \; \
+            | LC_ALL=C sort > "$actual_files"
+          if ! cmp -s "$expected_files" "$actual_files"; then
+            echo "::error::Unsigned artifact has missing or unexpected files"
+            diff -u "$expected_files" "$actual_files" || true
+            exit 1
+          fi
+
+          for required_file in \
+            "$binary_name" \
+            agent-macos.entitlements.plist \
+            provenance.json \
+            SHA256SUMS
+          do
+            if [[ ! -s "$required_file" ]]; then
+              echo "::error::Unsigned artifact file is missing or empty: $required_file"
+              exit 1
+            fi
+          done
+
+          binary_size="$(stat -f '%z' "$binary_name")"
+          entitlements_size="$(stat -f '%z' agent-macos.entitlements.plist)"
+          provenance_size="$(stat -f '%z' provenance.json)"
+          checksums_size="$(stat -f '%z' SHA256SUMS)"
+          if (( binary_size < 1000000 || binary_size > 209715200 )); then
+            echo "::error::Unsigned binary size is outside the allowed range"
+            exit 1
+          fi
+          if (( entitlements_size < 64 || entitlements_size > 65536 )); then
+            echo "::error::Entitlements size is outside the allowed range"
+            exit 1
+          fi
+          if (( provenance_size < 128 || provenance_size > 65536 )); then
+            echo "::error::Provenance size is outside the allowed range"
+            exit 1
+          fi
+          if (( checksums_size < 128 || checksums_size > 4096 )); then
+            echo "::error::Checksum manifest size is outside the allowed range"
+            exit 1
+          fi
+
+          export BINARY_NAME="$binary_name"
+          node <<'NODE'
+          const crypto = require('node:crypto');
+          const fs = require('node:fs');
+
+          function fail(message) {
+            throw new Error(message);
+          }
+          function exactKeys(value, expected, label) {
+            const actual = Object.keys(value).sort();
+            const wanted = [...expected].sort();
+            if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+              fail(`${label} contains missing or unexpected fields`);
+            }
+          }
+          function digest(file) {
+            return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+          }
+
+          const manifestText = fs.readFileSync('SHA256SUMS', 'utf8');
+          if (!manifestText.endsWith('\n')) {
+            fail('SHA256SUMS must end with exactly one complete line');
+          }
+          const manifestLines = manifestText.slice(0, -1).split('\n');
+          if (manifestLines.length !== 3) {
+            fail('SHA256SUMS must contain exactly three entries');
+          }
+          const expectedNames = [
+            process.env.BINARY_NAME,
+            'agent-macos.entitlements.plist',
+            'provenance.json',
+          ];
+          const checksums = new Map();
+          for (const [index, line] of manifestLines.entries()) {
+            const match = /^([0-9a-f]{64})  ([A-Za-z0-9._-]+)$/u.exec(line);
+            if (!match || match[2] !== expectedNames[index] || checksums.has(match[2])) {
+              fail('SHA256SUMS contains an invalid, duplicate, or out-of-order entry');
+            }
+            checksums.set(match[2], match[1]);
+          }
+          for (const file of expectedNames) {
+            if (checksums.get(file) !== digest(file)) {
+              fail(`Checksum mismatch for ${file}`);
+            }
+          }
+          NODE
+
+          shasum -a 256 -c SHA256SUMS
+
+          node <<'NODE'
+          const crypto = require('node:crypto');
+          const fs = require('node:fs');
+
+          function fail(message) {
+            throw new Error(message);
+          }
+          function exactKeys(value, expected, label) {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+              fail(`${label} must be an object`);
+            }
+            const actual = Object.keys(value).sort();
+            const wanted = [...expected].sort();
+            if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+              fail(`${label} contains missing or unexpected fields`);
+            }
+          }
+          function digest(file) {
+            return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+          }
+
+          const provenance = JSON.parse(fs.readFileSync('provenance.json', 'utf8'));
+          exactKeys(provenance, [
+            'architecture',
+            'files',
+            'mainAncestry',
+            'repository',
+            'runAttempt',
+            'runId',
+            'schemaVersion',
+            'sourceLabel',
+            'sourceSha',
+            'version',
+            'workflow',
+            'workflowDefinitionSha',
+          ], 'provenance');
+          const expectedValues = {
+            architecture: process.env.EXPECTED_ARCH,
+            mainAncestry: process.env.EXPECTED_ANCESTRY,
+            repository: process.env.EXPECTED_REPOSITORY,
+            runAttempt: process.env.EXPECTED_RUN_ATTEMPT,
+            runId: process.env.EXPECTED_RUN_ID,
+            sourceLabel: process.env.EXPECTED_SOURCE_LABEL,
+            sourceSha: process.env.EXPECTED_SOURCE_SHA,
+            version: process.env.EXPECTED_VERSION,
+            workflowDefinitionSha: process.env.EXPECTED_WORKFLOW_DEFINITION_SHA,
+          };
+          if (provenance.schemaVersion !== 1 || provenance.workflow !== 'dev-build-agent.yml') {
+            fail('Provenance schema or workflow identity is invalid');
+          }
+          for (const [field, expected] of Object.entries(expectedValues)) {
+            if (provenance[field] !== expected) {
+              fail(`Provenance ${field} does not match this workflow run`);
+            }
+          }
+          if (provenance.mainAncestry !== 'ancestor_or_equal') {
+            fail('Signing requires protected-main ancestor_or_equal provenance');
+          }
+
+          exactKeys(provenance.files, ['binary', 'entitlements'], 'provenance files');
+          const expectedFiles = {
+            binary: process.env.BINARY_NAME,
+            entitlements: 'agent-macos.entitlements.plist',
+          };
+          for (const [kind, name] of Object.entries(expectedFiles)) {
+            const descriptor = provenance.files[kind];
+            exactKeys(descriptor, ['name', 'sha256', 'size'], `${kind} descriptor`);
+            if (
+              descriptor.name !== name
+              || descriptor.sha256 !== digest(name)
+              || descriptor.size !== fs.statSync(name).size
+            ) {
+              fail(`Provenance ${kind} digest, size, or name is invalid`);
+            }
+          }
+          NODE
+
+          plutil -lint agent-macos.entitlements.plist
+          if ! file "$binary_name" | grep -q 'Mach-O'; then
+            echo "::error::Unsigned artifact is not a Mach-O binary"
+            exit 1
+          fi
+          expected_macho_arch="$EXPECTED_ARCH"
+          if [[ "$expected_macho_arch" == 'amd64' ]]; then
+            expected_macho_arch='x86_64'
+          fi
+          lipo -verify_arch "$expected_macho_arch" "$binary_name"
+          echo 'verified=true' >> "$GITHUB_OUTPUT"
+
+      - name: Import certificate into ephemeral keychain
+        if: steps.verify.outputs.verified == 'true'
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: |
-          CERT_PATH="$RUNNER_TEMP/cert.p12"
-          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
-          KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
+          set -euo pipefail
+          umask 077
+          cert_path="$RUNNER_TEMP/dev-signing-certificate.p12"
+          keychain_path="$RUNNER_TEMP/dev-signing.keychain-db"
+          keychain_password="$(openssl rand -hex 32)"
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$cert_path"
+          security create-keychain -p "$keychain_password" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$keychain_password" "$keychain_path"
+          security import "$cert_path" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$keychain_path"
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -k "$keychain_password" \
+            "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+          rm -f "$cert_path"
 
-          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple: \
-            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security list-keychains -d user -s "$KEYCHAIN_PATH" \
-            $(security list-keychains -d user | tr -d '"')
-
-          rm -f "$CERT_PATH"
-
-      - name: Sign binary
-        if: vars.ENABLE_MACOS_SIGNING == 'true'
+      - name: Sign verified binary in place
+        if: steps.verify.outputs.verified == 'true'
+        working-directory: ${{ runner.temp }}/unsigned-artifact
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        working-directory: agent
+          SIGNING_ARCH: ${{ matrix.arch }}
         run: |
-          codesign --force --options runtime \
-            --entitlements entitlements/agent-macos.entitlements.plist \
-            --sign "$APPLE_SIGNING_IDENTITY" --timestamp breeze-agent-darwin-amd64
-          codesign --verify --verbose breeze-agent-darwin-amd64
-          echo "Signed: breeze-agent-darwin-amd64"
+          set -euo pipefail
+          binary_name="breeze-agent-darwin-${SIGNING_ARCH}"
+          mv SHA256SUMS UNSIGNED_SHA256SUMS
+          codesign \
+            --force \
+            --options runtime \
+            --entitlements agent-macos.entitlements.plist \
+            --sign "$APPLE_SIGNING_IDENTITY" \
+            --timestamp \
+            "$binary_name"
+          codesign --verify --strict --verbose=2 "$binary_name"
 
-      - name: Notarize binary
-        if: vars.ENABLE_MACOS_SIGNING == 'true'
+      - name: Notarize and require Accepted status
+        if: steps.verify.outputs.verified == 'true'
+        working-directory: ${{ runner.temp }}/unsigned-artifact
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        working-directory: agent
+          SIGNING_ARCH: ${{ matrix.arch }}
         run: |
-          ditto -c -k --keepParent breeze-agent-darwin-amd64 breeze-agent-darwin-amd64.zip
-
-          echo "Submitting for notarization..."
-          xcrun notarytool submit breeze-agent-darwin-amd64.zip \
+          set -euo pipefail
+          binary_name="breeze-agent-darwin-${SIGNING_ARCH}"
+          zip_path="$RUNNER_TEMP/${binary_name}.zip"
+          ditto -c -k --keepParent "$binary_name" "$zip_path"
+          xcrun notarytool submit "$zip_path" \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
-            --wait --timeout 30m
+            --wait \
+            --timeout 30m \
+            --output-format json > notarization.json
+          node <<'NODE'
+          const fs = require('node:fs');
+          const result = JSON.parse(fs.readFileSync('notarization.json', 'utf8'));
+          if (result.status !== 'Accepted') {
+            throw new Error(`Apple notarization was not accepted: ${result.status ?? 'missing'}`);
+          }
+          NODE
+          rm -f "$zip_path"
 
-          rm -f breeze-agent-darwin-amd64.zip
-          echo "Notarized: breeze-agent-darwin-amd64"
+      - name: Write signed checksums and notarization metadata
+        if: steps.verify.outputs.verified == 'true'
+        working-directory: ${{ runner.temp }}/unsigned-artifact
+        env:
+          SIGNING_ARCH: ${{ matrix.arch }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          binary_name="breeze-agent-darwin-${SIGNING_ARCH}"
+          shasum -a 256 "$binary_name" > SIGNED_SHA256SUMS
+          export BINARY_NAME="$binary_name"
+          export SIGNED_SHA256
+          SIGNED_SHA256="$(awk '{print $1}' SIGNED_SHA256SUMS)"
+          node <<'NODE'
+          const fs = require('node:fs');
+          const notarization = JSON.parse(fs.readFileSync('notarization.json', 'utf8'));
+          const metadata = {
+            schemaVersion: 1,
+            sourceSha: process.env.SOURCE_SHA,
+            architecture: process.env.SIGNING_ARCH,
+            binary: process.env.BINARY_NAME,
+            signedSha256: process.env.SIGNED_SHA256,
+            notarization: {
+              id: notarization.id,
+              status: notarization.status,
+            },
+          };
+          fs.writeFileSync(
+            'signed-provenance.json',
+            `${JSON.stringify(metadata, null, 2)}\n`,
+            { mode: 0o644 },
+          );
+          NODE
 
-      - name: Upload artifact
+      - name: Upload immutable signed artifact
+        if: steps.verify.outputs.verified == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: breeze-agent-darwin-amd64
-          path: agent/breeze-agent-darwin-amd64
+          name: signed-breeze-agent-${{ matrix.arch }}-${{ needs.resolve.outputs.source_sha }}
+          path: |
+            ${{ runner.temp }}/unsigned-artifact/breeze-agent-darwin-${{ matrix.arch }}
+            ${{ runner.temp }}/unsigned-artifact/agent-macos.entitlements.plist
+            ${{ runner.temp }}/unsigned-artifact/provenance.json
+            ${{ runner.temp }}/unsigned-artifact/UNSIGNED_SHA256SUMS
+            ${{ runner.temp }}/unsigned-artifact/SIGNED_SHA256SUMS
+            ${{ runner.temp }}/unsigned-artifact/notarization.json
+            ${{ runner.temp }}/unsigned-artifact/signed-provenance.json
+          if-no-files-found: error
           retention-days: 7
 
-      - name: Cleanup keychain
-        if: always() && vars.ENABLE_MACOS_SIGNING == 'true'
-        run: security delete-keychain "$RUNNER_TEMP/signing.keychain-db" || true
+      - name: Cleanup ephemeral signing material
+        if: always()
+        env:
+          CLEANUP_ARCH: ${{ matrix.arch }}
+        run: |
+          security delete-keychain "$RUNNER_TEMP/dev-signing.keychain-db" || true
+          rm -f \
+            "$RUNNER_TEMP/dev-signing-certificate.p12" \
+            "$RUNNER_TEMP/breeze-agent-darwin-${CLEANUP_ARCH}.zip"

--- a/.github/workflows/drift-detector.yml
+++ b/.github/workflows/drift-detector.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/drift-detector.yml
+++ b/.github/workflows/drift-detector.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/edge-image-api.yml
+++ b/.github/workflows/edge-image-api.yml
@@ -38,6 +38,8 @@ jobs:
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 

--- a/.github/workflows/edge-image-api.yml
+++ b/.github/workflows/edge-image-api.yml
@@ -26,16 +26,44 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-push:
+  build:
+    name: Build API image
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Build API image without publishing
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          push: false
+          tags: local/edge-api:${{ github.sha }}
+          cache-from: type=gha,scope=edge-api
+          cache-to: type=gha,scope=edge-api,mode=max
+
+  publish-edge:
+    name: Publish trusted edge API image
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -65,4 +93,3 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=edge-api
-          cache-to: type=gha,scope=edge-api,mode=max

--- a/.github/workflows/edge-image-api.yml
+++ b/.github/workflows/edge-image-api.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,7 +238,10 @@ jobs:
 
   build-windows-msi:
     name: Build + Sign Windows Artifacts
-    if: vars.ENABLE_WINDOWS_SIGNING == 'true'
+    if: >-
+      vars.ENABLE_WINDOWS_SIGNING == 'true'
+      && github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
     needs: [build-agent]
     permissions:
@@ -643,6 +646,9 @@ jobs:
 
   build-macos-agent:
     name: Sign macOS Agent Binary
+    if: >-
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
     needs: [build-agent]
     steps:
@@ -942,7 +948,10 @@ jobs:
     name: Build macOS Installer App
     needs: [build-macos-agent]
     runs-on: macos-latest
-    if: vars.ENABLE_MACOS_SIGNING == 'true'
+    if: >-
+      vars.ENABLE_MACOS_SIGNING == 'true'
+      && github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -1034,6 +1043,9 @@ jobs:
 
   build-viewer:
     name: Build Viewer
+    if: >-
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
     strategy:
       fail-fast: false
       matrix:
@@ -1140,12 +1152,6 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm tauri build --target ${{ matrix.target }}
 
       - name: Find and rename artifact
@@ -1293,12 +1299,6 @@ jobs:
         shell: bash
         env:
           TAURI_SIGNING_PRIVATE_KEY: ''
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm tauri build --target ${{ matrix.target }}
 
       - name: Find and rename artifact
@@ -1324,6 +1324,9 @@ jobs:
 
   build-viewer-macos:
     name: Build Viewer (macOS)
+    if: >-
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -1458,6 +1461,9 @@ jobs:
 
   build-helper-macos:
     name: Build Helper (macOS)
+    if: >-
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -1556,7 +1562,10 @@ jobs:
 
   sign-windows-tauri:
     name: Sign Windows Tauri Artifacts
-    if: vars.ENABLE_WINDOWS_SIGNING == 'true'
+    if: >-
+      vars.ENABLE_WINDOWS_SIGNING == 'true'
+      && github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
     needs: [build-viewer, build-helper]
     permissions:
@@ -1683,7 +1692,10 @@ jobs:
 
   package-windows-updater:
     name: Package Windows Updater Bundle
-    if: vars.ENABLE_WINDOWS_SIGNING == 'true'
+    if: >-
+      vars.ENABLE_WINDOWS_SIGNING == 'true'
+      && github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: [sign-windows-tauri]
     steps:
@@ -1906,7 +1918,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-api, build-web, build-agent, build-windows-msi, build-macos-agent, build-macos-installer-app, sign-windows-tauri, build-viewer, build-helper, build-viewer-macos, build-helper-macos, merge-viewer-update-manifest, package-windows-updater, release-integrity-gate]
     if: >-
-      !cancelled()
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
+      && !cancelled()
       && needs.build-api.result == 'success'
       && needs.build-web.result == 'success'
       && needs.build-agent.result == 'success'
@@ -2250,7 +2264,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-agent, build-windows-msi, build-macos-agent, sign-windows-tauri, build-viewer, build-helper, build-viewer-macos, build-helper-macos, create-release]
     if: >-
-      !cancelled()
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
+      && !cancelled()
       && needs.build-agent.result == 'success'
       && (needs.build-windows-msi.result == 'success' || needs.build-windows-msi.result == 'skipped')
       && (needs.build-macos-agent.result == 'success' || needs.build-macos-agent.result == 'skipped')
@@ -2259,7 +2275,7 @@ jobs:
       && needs.build-helper.result == 'success'
       && (needs.build-viewer-macos.result == 'success' || needs.build-viewer-macos.result == 'skipped')
       && (needs.build-helper-macos.result == 'success' || needs.build-helper-macos.result == 'skipped')
-      && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped')
+      && needs.create-release.result == 'success'
     permissions:
       contents: read
       packages: write
@@ -2339,9 +2355,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-api, create-release]
     if: >-
-      !cancelled()
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
+      && !cancelled()
       && needs.build-api.result == 'success'
-      && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped')
+      && needs.create-release.result == 'success'
     permissions:
       contents: read
       packages: write
@@ -2401,9 +2419,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [create-release]
     if: >-
-      startsWith(github.ref, 'refs/tags/v')
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
       && !cancelled()
-      && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped')
+      && needs.create-release.result == 'success'
     permissions:
       contents: read
       packages: write
@@ -2496,9 +2515,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-web, create-release]
     if: >-
-      !cancelled()
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
+      && !cancelled()
       && needs.build-web.result == 'success'
-      && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped')
+      && needs.create-release.result == 'success'
     permissions:
       contents: read
       packages: write
@@ -2558,8 +2579,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [create-release]
     if: >-
-      !cancelled()
-      && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped')
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
+      && !cancelled()
+      && needs.create-release.result == 'success'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -63,6 +65,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -130,6 +134,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -243,6 +249,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -640,6 +648,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Download darwin/amd64 artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -936,6 +946,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Download .pkg darwin/amd64
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -1038,6 +1050,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install Linux dependencies
         if: contains(matrix.platform, 'ubuntu')
@@ -1200,6 +1214,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install Linux dependencies
         if: contains(matrix.platform, 'ubuntu')
@@ -1312,6 +1328,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -1444,6 +1462,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -1669,6 +1689,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -1905,6 +1927,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -2242,6 +2266,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Create staging directory
         run: mkdir -p staging/agent staging/viewer staging/helper
@@ -2322,6 +2348,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Download API artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -2384,6 +2412,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
@@ -2475,6 +2505,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Download Web artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -2534,6 +2566,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -39,7 +39,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -51,7 +51,7 @@ jobs:
         run: pnpm build --filter=@breeze/api
 
       - name: Upload API artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: api-dist
           path: apps/api/dist
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -70,7 +70,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -88,7 +88,7 @@ jobs:
         run: pnpm build --filter=@breeze/web
 
       - name: Upload Web artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: web-dist
           path: apps/web/dist
@@ -129,10 +129,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: agent/go.sum
@@ -163,7 +163,7 @@ jobs:
             ./cmd/breeze-agent
 
       - name: Upload Agent artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-agent-${{ matrix.goos }}-${{ matrix.goarch }}
           path: agent/breeze-agent-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}
@@ -183,7 +183,7 @@ jobs:
             ./cmd/breeze-backup
 
       - name: Upload breeze-backup artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-backup-${{ matrix.goos }}-${{ matrix.goarch }}
           path: agent/breeze-backup-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}
@@ -202,7 +202,7 @@ jobs:
             ./cmd/breeze-watchdog
 
       - name: Upload breeze-watchdog artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-watchdog-${{ matrix.goos }}-${{ matrix.goarch }}
           path: agent/breeze-watchdog-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}
@@ -224,7 +224,7 @@ jobs:
 
       - name: Upload breeze-desktop-helper artifact
         if: matrix.goos == 'darwin'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-desktop-helper-${{ matrix.goos }}-${{ matrix.goarch }}
           path: agent/breeze-desktop-helper-${{ matrix.goos }}-${{ matrix.goarch }}
@@ -242,10 +242,10 @@ jobs:
       name: ${{ contains(github.ref_name, '-') && 'signing-prerelease' || 'signing-production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: agent/go.sum
@@ -256,7 +256,7 @@ jobs:
         run: go mod download
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: '8.0.x'
 
@@ -589,7 +589,7 @@ jobs:
           }
 
       - name: Upload signed Windows EXE artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-agent-windows-amd64
           path: dist/breeze-agent-windows-amd64.exe
@@ -603,7 +603,7 @@ jobs:
       # and the HelperLifecycleManager fell through to a
       # `breeze-agent.exe user-helper` fallback every ~30s.
       - name: Upload signed Windows user-helper EXE artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-user-helper-windows-amd64
           path: dist/breeze-user-helper-windows-amd64.exe
@@ -611,14 +611,14 @@ jobs:
           retention-days: 30
 
       - name: Upload Windows MSI artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-agent-windows-msi
           path: dist/breeze-agent.msi
           retention-days: 30
 
       - name: Upload signed backup EXE artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-backup-windows-amd64
           path: dist/breeze-backup-windows-amd64.exe
@@ -626,7 +626,7 @@ jobs:
           retention-days: 30
 
       - name: Upload signed watchdog EXE artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-watchdog-windows-amd64
           path: dist/breeze-watchdog-windows-amd64.exe
@@ -639,52 +639,52 @@ jobs:
     needs: [build-agent]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download darwin/amd64 artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: breeze-agent-darwin-amd64
           path: staging/
 
       - name: Download darwin/arm64 artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: breeze-agent-darwin-arm64
           path: staging/
 
       - name: Download backup darwin/amd64 artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: breeze-backup-darwin-amd64
           path: staging/
 
       - name: Download backup darwin/arm64 artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: breeze-backup-darwin-arm64
           path: staging/
 
       - name: Download desktop-helper darwin/amd64 artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: breeze-desktop-helper-darwin-amd64
           path: staging/
 
       - name: Download desktop-helper darwin/arm64 artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: breeze-desktop-helper-darwin-arm64
           path: staging/
 
       - name: Download watchdog darwin/amd64 artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: breeze-watchdog-darwin-amd64
           path: staging/
 
       - name: Download watchdog darwin/arm64 artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: breeze-watchdog-darwin-arm64
           path: staging/
@@ -746,7 +746,7 @@ jobs:
           done
 
       - name: Upload signed darwin/amd64
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-agent-darwin-amd64
           path: staging/breeze-agent-darwin-amd64
@@ -754,7 +754,7 @@ jobs:
           retention-days: 30
 
       - name: Upload signed darwin/arm64
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-agent-darwin-arm64
           path: staging/breeze-agent-darwin-arm64
@@ -762,7 +762,7 @@ jobs:
           retention-days: 30
 
       - name: Upload signed backup darwin/amd64
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-backup-darwin-amd64
           path: staging/breeze-backup-darwin-amd64
@@ -770,7 +770,7 @@ jobs:
           retention-days: 30
 
       - name: Upload signed backup darwin/arm64
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-backup-darwin-arm64
           path: staging/breeze-backup-darwin-arm64
@@ -778,7 +778,7 @@ jobs:
           retention-days: 30
 
       - name: Upload signed desktop-helper darwin/amd64
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-desktop-helper-darwin-amd64
           path: staging/breeze-desktop-helper-darwin-amd64
@@ -786,7 +786,7 @@ jobs:
           retention-days: 30
 
       - name: Upload signed desktop-helper darwin/arm64
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-desktop-helper-darwin-arm64
           path: staging/breeze-desktop-helper-darwin-arm64
@@ -794,7 +794,7 @@ jobs:
           retention-days: 30
 
       - name: Upload signed watchdog darwin/amd64
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-watchdog-darwin-amd64
           path: staging/breeze-watchdog-darwin-amd64
@@ -802,7 +802,7 @@ jobs:
           retention-days: 30
 
       - name: Upload signed watchdog darwin/arm64
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-watchdog-darwin-arm64
           path: staging/breeze-watchdog-darwin-arm64
@@ -911,14 +911,14 @@ jobs:
           done
 
       - name: Upload .pkg darwin/amd64
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-agent-darwin-amd64-pkg
           path: staging/breeze-agent-darwin-amd64.pkg
           retention-days: 30
 
       - name: Upload .pkg darwin/arm64
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-agent-darwin-arm64-pkg
           path: staging/breeze-agent-darwin-arm64.pkg
@@ -935,16 +935,16 @@ jobs:
     if: vars.ENABLE_MACOS_SIGNING == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download .pkg darwin/amd64
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: breeze-agent-darwin-amd64-pkg
           path: installer-pkgs/
 
       - name: Download .pkg darwin/arm64
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: breeze-agent-darwin-arm64-pkg
           path: installer-pkgs/
@@ -1010,7 +1010,7 @@ jobs:
           ls -lh build/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-installer-app
           path: build/Breeze Installer.app.zip
@@ -1037,7 +1037,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Linux dependencies
         if: contains(matrix.platform, 'ubuntu')
@@ -1071,7 +1071,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -1166,7 +1166,7 @@ jobs:
           cp "$sig_file" breeze-viewer-linux.AppImage.sig
 
       - name: Upload Viewer artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.asset_name }}
           path: apps/viewer/${{ matrix.asset_name }}
@@ -1174,7 +1174,7 @@ jobs:
 
       - name: Upload Viewer Linux updater bundle
         if: matrix.platform == 'ubuntu-22.04'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-viewer-linux-updater
           path: |
@@ -1199,7 +1199,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Linux dependencies
         if: contains(matrix.platform, 'ubuntu')
@@ -1233,7 +1233,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -1300,7 +1300,7 @@ jobs:
           echo "path=${{ matrix.asset_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Upload Helper artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.asset_name }}
           path: apps/helper/${{ matrix.asset_name }}
@@ -1311,7 +1311,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -1319,7 +1319,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -1423,14 +1423,14 @@ jobs:
           cp "$sig_file" breeze-viewer-macos.app.tar.gz.sig
 
       - name: Upload Viewer macOS artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-viewer-macos.dmg
           path: apps/viewer/breeze-viewer-macos.dmg
           retention-days: 30
 
       - name: Upload Viewer macOS updater bundle
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-viewer-macos-updater
           path: |
@@ -1443,7 +1443,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -1451,7 +1451,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -1528,7 +1528,7 @@ jobs:
           xcrun stapler validate breeze-helper-macos.dmg
 
       - name: Upload Helper macOS artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-helper-macos.dmg
           path: apps/helper/breeze-helper-macos.dmg
@@ -1546,13 +1546,13 @@ jobs:
       name: ${{ contains(github.ref_name, '-') && 'signing-prerelease' || 'signing-production' }}
     steps:
       - name: Download viewer Windows MSI
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: breeze-viewer-windows.msi
           path: staging/
 
       - name: Download helper Windows MSI
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: breeze-helper-windows.msi
           path: staging/
@@ -1646,7 +1646,7 @@ jobs:
           }
 
       - name: Upload signed viewer MSI
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-viewer-windows.msi
           path: staging/breeze-viewer-windows.msi
@@ -1654,7 +1654,7 @@ jobs:
           retention-days: 30
 
       - name: Upload signed helper MSI
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-helper-windows.msi
           path: staging/breeze-helper-windows.msi
@@ -1668,7 +1668,7 @@ jobs:
     needs: [sign-windows-tauri]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -1676,7 +1676,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -1685,7 +1685,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download signed viewer MSI
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: breeze-viewer-windows.msi
           path: staging/
@@ -1718,7 +1718,7 @@ jobs:
           fi
 
       - name: Upload Windows updater bundle
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-viewer-windows-updater
           path: |
@@ -1737,7 +1737,7 @@ jobs:
       && (needs.package-windows-updater.result == 'success' || needs.package-windows-updater.result == 'skipped')
     steps:
       - name: Download viewer updater bundles
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: updater-bundles
           pattern: 'breeze-viewer-*-updater'
@@ -1823,7 +1823,7 @@ jobs:
           cat latest.json
 
       - name: Upload generated manifest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: viewer-latest-json
           path: latest.json
@@ -1904,10 +1904,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
           pattern: '{api-dist,web-dist,breeze-agent-*,breeze-backup-*,breeze-desktop-helper-*,breeze-user-helper-*,breeze-watchdog-*,breeze-viewer-*,breeze-helper-*,breeze-installer-app,viewer-latest-json}'
@@ -2241,27 +2241,27 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Create staging directory
         run: mkdir -p staging/agent staging/viewer staging/helper
 
       - name: Download agent artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: staging/agent
           pattern: 'breeze-agent-*'
           merge-multiple: true
 
       - name: Download viewer artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: staging/viewer
           pattern: 'breeze-viewer-*'
           merge-multiple: true
 
       - name: Download helper artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: staging/helper
           pattern: 'breeze-helper-*'
@@ -2321,10 +2321,10 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download API artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: api-dist
           path: apps/api/dist
@@ -2383,7 +2383,7 @@ jobs:
       executor-image-digest: ${{ steps.push-executor-digest.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
@@ -2455,7 +2455,7 @@ jobs:
           printf '%s\n' "$EXECUTOR_IMAGE_DIGEST" > m365-graph-read-executor-image-digest.txt
 
       - name: Upload executor digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: m365-graph-read-executor-image-digest
           path: m365-graph-read-executor-image-digest.txt
@@ -2474,10 +2474,10 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download Web artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: web-dist
           path: apps/web/dist
@@ -2533,7 +2533,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -38,29 +38,3 @@ jobs:
 
       - name: Run gitleaks
         run: gitleaks detect --source . --verbose
-
-  confidential:
-    name: Confidential info
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      # Non-bypassable backstop for the .githooks/pre-commit scan: catches prod
-      # infra identifiers (IPs, DB cluster ids) that gitleaks does not model.
-      # The exact-value denylist is supplied out-of-band via a repo secret so
-      # the values never live in this public repo. Absent the secret, the
-      # pattern checks still run.
-      - name: Scan for confidential identifiers
-        env:
-          CONFIDENTIAL_DENYLIST: ${{ secrets.CONFIDENTIAL_DENYLIST }}
-        run: |
-          set -euo pipefail
-          if [[ -n "${CONFIDENTIAL_DENYLIST:-}" ]]; then
-            deny="$(mktemp)"
-            printf '%s\n' "$CONFIDENTIAL_DENYLIST" > "$deny"
-            export CONFIDENTIAL_DENYLIST_FILE="$deny"
-          fi
-          bash scripts/security/scan-confidential.sh --all

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install gitleaks
         run: |

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -38,3 +38,20 @@ jobs:
 
       - name: Run gitleaks
         run: gitleaks detect --source . --verbose
+
+  confidential-patterns:
+    name: Confidential patterns (PR-safe)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      # Keep the high-signal, secret-free pattern checks on untrusted PRs.
+      # Exact confidential values remain isolated to the trusted push workflow.
+      - name: Scan for confidential patterns
+        run: bash scripts/security/scan-confidential.sh --all

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install gitleaks
         run: |
@@ -46,7 +46,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # Non-bypassable backstop for the .githooks/pre-commit scan: catches prod
       # infra identifiers (IPs, DB cluster ids) that gitleaks does not model.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -207,6 +207,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Setup Node
+        uses: actions/setup-node@v7 # temporary resolver input; Task 2 pins it before push
+        with:
+          node-version: '22.19.0'
+
+      - name: Run workflow security policy
+        run: |
+          node --test \
+            .github/scripts/check-workflow-security.test.mjs \
+            scripts/security/pin-github-actions.test.mjs
+          node .github/scripts/check-workflow-security.mjs
+
       - name: Install actionlint (pinned + checksum-verified)
         run: |
           curl -sSfL -o actionlint.tar.gz \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -56,6 +58,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -76,6 +80,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -102,6 +108,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Generate Trivy filesystem SARIF
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -148,6 +156,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Build API image
         run: docker build -f docker/Dockerfile.api -t breeze-api:security-scan .
@@ -206,6 +216,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7; temporary resolver input; Task 2 pins it before push

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -36,7 +36,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -55,10 +55,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: agent/go.sum
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -101,7 +101,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Generate Trivy filesystem SARIF
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -113,7 +113,7 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy filesystem SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         if: always()
         with:
           sarif_file: 'trivy-fs.sarif'
@@ -127,7 +127,7 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy filesystem SBOM
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: trivy-fs-sbom
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Build API image
         run: docker build -f docker/Dockerfile.api -t breeze-api:security-scan .
@@ -205,10 +205,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node
-        uses: actions/setup-node@v7 # temporary resolver input; Task 2 pins it before push
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7; temporary resolver input; Task 2 pins it before push
         with:
           node-version: '22.19.0'
 

--- a/.github/workflows/update-community-readme.yml
+++ b/.github/workflows/update-community-readme.yml
@@ -19,12 +19,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
 

--- a/.github/workflows/update-community-readme.yml
+++ b/.github/workflows/update-community-readme.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: main
 
       - name: Setup Node.js
@@ -37,6 +38,8 @@ jobs:
         run: node .github/scripts/update-community-readme.mjs
 
       - name: Commit and push README changes
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           if git diff --quiet -- README.md; then
             echo "README.md is already current"
@@ -47,4 +50,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add README.md
           git commit --only -m "docs: refresh sponsors and contributors [skip ci]" -- README.md
-          git push origin HEAD:main
+          git -c credential.helper= -c 'credential.helper=!f() { printf "%s\n" "username=x-access-token" "password=$GITHUB_TOKEN"; }; f' push origin HEAD:main

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,10 +2,6 @@ rules:
   unpinned-uses:
     config:
       policies:
-        # Repo posture: first-party GitHub-owned actions may float on major
-        # version tags; everything else must be pinned to a commit SHA.
-        actions/*: ref-pin
-        github/*: ref-pin
         "*": hash-pin
   cache-poisoning:
     # Accepted tradeoff (2026-06): the release workflow uses setup-node /

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test:load-static": "pnpm --dir load-tests test:static",
     "test:community-readme": "node --test .github/scripts/update-community-readme.test.mjs",
     "test:docs-automation": "node --test .github/scripts/docs-automation-retirement.test.mjs",
+    "test:workflow-security": "node --test .github/scripts/check-workflow-security.test.mjs scripts/security/pin-github-actions.test.mjs && node .github/scripts/check-workflow-security.mjs",
+    "pin:github-actions": "node scripts/security/pin-github-actions.mjs",
     "db:migrate": "turbo run db:migrate --filter=@breeze/api",
     "db:check-drift": "turbo run db:check-drift --filter=@breeze/api",
     "db:seed": "turbo run db:seed --filter=@breeze/api",

--- a/scripts/security/check-supply-chain-hardening.sh
+++ b/scripts/security/check-supply-chain-hardening.sh
@@ -429,6 +429,14 @@ for dockerfile in apps/api/Dockerfile apps/web/Dockerfile; do
   require_grep '^FROM[[:space:]]+node:24-alpine@sha256:[0-9a-f]{64}[[:space:]]+AS[[:space:]]+runner' "$dockerfile" \
     "$dockerfile must digest-pin the production Node runner image while retaining the tag for Dependabot refreshes"
 done
+for dockerfile in docker/Dockerfile.api docker/Dockerfile.web; do
+  require_grep '/usr/local/lib/node_modules/pnpm' "$dockerfile" \
+    "$dockerfile must remove unused pnpm dependencies from the production runner"
+  require_grep '/usr/local/bin/pnpm' "$dockerfile" \
+    "$dockerfile must remove the unused pnpm binary from the production runner"
+  require_grep '/usr/local/bin/pnpx' "$dockerfile" \
+    "$dockerfile must remove the unused pnpx binary from the production runner"
+done
 
 require_grep '/run/secrets/metrics_scrape_token' monitoring/prometheus.yml \
   "Prometheus config must read metrics scrape token from a secret file"

--- a/scripts/security/pin-github-actions.mjs
+++ b/scripts/security/pin-github-actions.mjs
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+
+const execFileAsync = promisify(execFile);
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const USES_LINE_PATTERN =
+  /^(\s*(?:-\s*)?uses:\s*)(["']?)([^"'#\s]+)\2(\s*(?:#.*)?)$/;
+
+function parseActionReference(target, line) {
+  if (target.startsWith("./")) {
+    return null;
+  }
+  if (target.startsWith("docker://")) {
+    throw new Error(
+      `Line ${line}: docker:// action references are unsupported by repository policy`,
+    );
+  }
+
+  const atIndex = target.lastIndexOf("@");
+  if (atIndex <= 0 || atIndex === target.length - 1) {
+    throw new Error(`Line ${line}: unsupported action reference "${target}"`);
+  }
+
+  const actionName = target.slice(0, atIndex);
+  const ref = target.slice(atIndex + 1);
+  const [owner, repository, ...pathParts] = actionName.split("/");
+  if (!owner || !repository) {
+    throw new Error(`Line ${line}: unsupported action reference "${target}"`);
+  }
+
+  return {
+    owner,
+    repository,
+    path: pathParts.join("/"),
+    ref,
+    line,
+  };
+}
+
+function parseUsesLine(rawLine, line) {
+  const hasCarriageReturn = rawLine.endsWith("\r");
+  const lineText = hasCarriageReturn ? rawLine.slice(0, -1) : rawLine;
+  const match = USES_LINE_PATTERN.exec(lineText);
+  if (!match) {
+    return null;
+  }
+
+  const [, prefix, quote, target, suffix] = match;
+  return {
+    prefix,
+    quote,
+    target,
+    suffix,
+    lineEnding: hasCarriageReturn ? "\r" : "",
+    reference: parseActionReference(target, line),
+  };
+}
+
+export function findMutableActionReferences(text) {
+  const references = [];
+  const lines = text.split("\n");
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const parsed = parseUsesLine(lines[index], index + 1);
+    if (
+      parsed?.reference &&
+      !COMMIT_SHA_PATTERN.test(parsed.reference.ref)
+    ) {
+      references.push(parsed.reference);
+    }
+  }
+
+  return references;
+}
+
+export async function pinWorkflowText(text, resolveCommit) {
+  const mutableReferences = findMutableActionReferences(text);
+  const resolvedCommits = new Map();
+
+  for (const reference of mutableReferences) {
+    const key = `${reference.owner}/${reference.repository}@${reference.ref}`;
+    if (!resolvedCommits.has(key)) {
+      resolvedCommits.set(
+        key,
+        await resolveCommit(
+          reference.owner,
+          reference.repository,
+          reference.ref,
+        ),
+      );
+    }
+  }
+
+  for (const [key, commit] of resolvedCommits) {
+    if (!COMMIT_SHA_PATTERN.test(commit)) {
+      throw new Error(
+        `Resolver returned invalid commit for ${key}; expected a 40-character lowercase hexadecimal commit SHA`,
+      );
+    }
+  }
+
+  const referencesByLine = new Map(
+    mutableReferences.map((reference) => [reference.line, reference]),
+  );
+  const changedReferences = [];
+  const lines = text.split("\n");
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = index + 1;
+    const reference = referencesByLine.get(line);
+    if (!reference) {
+      continue;
+    }
+
+    const parsed = parseUsesLine(lines[index], line);
+    const key = `${reference.owner}/${reference.repository}@${reference.ref}`;
+    const commit = resolvedCommits.get(key);
+    const actionPath = reference.path ? `/${reference.path}` : "";
+    const comment = versionedComment(parsed.suffix, reference.ref);
+
+    lines[index] =
+      `${parsed.prefix}${parsed.quote}` +
+      `${reference.owner}/${reference.repository}${actionPath}@${commit}` +
+      `${parsed.quote}${comment}${parsed.lineEnding}`;
+    changedReferences.push({ ...reference, commit });
+  }
+
+  return {
+    text: lines.join("\n"),
+    changedReferences,
+  };
+}
+
+export async function resolveActionCommit(owner, repository, ref) {
+  const endpoint =
+    `repos/${owner}/${repository}/commits/` + encodeURIComponent(ref);
+  const { stdout } = await execFileAsync(
+    "gh",
+    ["api", endpoint, "--jq", ".sha"],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+    },
+  );
+  const commit = stdout.trim();
+
+  if (!COMMIT_SHA_PATTERN.test(commit)) {
+    throw new Error(
+      `GitHub returned an invalid commit for ${owner}/${repository}@${ref}; expected a 40-character lowercase hexadecimal commit SHA`,
+    );
+  }
+
+  return commit;
+}
+
+async function listWorkflowFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries.sort((left, right) =>
+    left.name.localeCompare(right.name),
+  )) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listWorkflowFiles(entryPath)));
+    } else if (
+      entry.isFile() &&
+      (entry.name.endsWith(".yml") || entry.name.endsWith(".yaml"))
+    ) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function displayPath(filePath, rootDirectory) {
+  return path.relative(rootDirectory, filePath).split(path.sep).join("/");
+}
+
+function createCachingResolver(resolveCommit) {
+  const resolutions = new Map();
+
+  return async (owner, repository, ref) => {
+    const key = `${owner}/${repository}@${ref}`;
+    if (!resolutions.has(key)) {
+      resolutions.set(key, resolveCommit(owner, repository, ref));
+    }
+    return resolutions.get(key);
+  };
+}
+
+function versionedComment(suffix, ref) {
+  if (!suffix.includes("#")) {
+    return ` # ${ref}`;
+  }
+
+  const existingComment = suffix.slice(suffix.indexOf("#") + 1).trim();
+  if (
+    existingComment === ref ||
+    existingComment.startsWith(`${ref} `) ||
+    existingComment.startsWith(`${ref};`)
+  ) {
+    return suffix;
+  }
+
+  return ` # ${ref}; ${existingComment}`;
+}
+
+async function checkWorkflows(rootDirectory, workflowFiles) {
+  let mutableCount = 0;
+
+  for (const filePath of workflowFiles) {
+    const text = await readFile(filePath, "utf8");
+    for (const reference of findMutableActionReferences(text)) {
+      const actionPath = reference.path ? `/${reference.path}` : "";
+      console.log(
+        `${displayPath(filePath, rootDirectory)}:${reference.line}: ` +
+          `${reference.owner}/${reference.repository}${actionPath}@${reference.ref}`,
+      );
+      mutableCount += 1;
+    }
+  }
+
+  if (mutableCount > 0) {
+    console.log(
+      `Found ${mutableCount} mutable external action reference(s); no files were changed.`,
+    );
+    process.exitCode = 1;
+  } else {
+    console.log("All external GitHub Action references are pinned to commit SHAs.");
+  }
+}
+
+async function writePinnedWorkflows(rootDirectory, workflowFiles) {
+  const resolveCommit = createCachingResolver(resolveActionCommit);
+  const pendingWrites = [];
+  let changedCount = 0;
+
+  for (const filePath of workflowFiles) {
+    const originalText = await readFile(filePath, "utf8");
+    const result = await pinWorkflowText(originalText, resolveCommit);
+    if (result.changedReferences.length > 0) {
+      pendingWrites.push({ filePath, ...result });
+    }
+  }
+
+  for (const pendingWrite of pendingWrites) {
+    await writeFile(pendingWrite.filePath, pendingWrite.text);
+    for (const reference of pendingWrite.changedReferences) {
+      const actionPath = reference.path ? `/${reference.path}` : "";
+      console.log(
+        `${displayPath(pendingWrite.filePath, rootDirectory)}:${reference.line}: ` +
+          `${reference.owner}/${reference.repository}${actionPath}@${reference.ref} ` +
+          `-> ${reference.commit}`,
+      );
+      changedCount += 1;
+    }
+  }
+
+  console.log(
+    changedCount > 0
+      ? `Pinned ${changedCount} external action reference(s) in ${pendingWrites.length} workflow file(s).`
+      : "No mutable external GitHub Action references were found.",
+  );
+}
+
+function redactKnownTokens(message) {
+  let redacted = message;
+  for (const variableName of ["GH_TOKEN", "GITHUB_TOKEN"]) {
+    const token = process.env[variableName];
+    if (token) {
+      redacted = redacted.split(token).join("[REDACTED]");
+    }
+  }
+  return redacted;
+}
+
+async function main() {
+  const [mode, ...extraArguments] = process.argv.slice(2);
+  if (
+    extraArguments.length > 0 ||
+    (mode !== "--check" && mode !== "--write")
+  ) {
+    throw new Error(
+      "Usage: node scripts/security/pin-github-actions.mjs --check|--write",
+    );
+  }
+
+  const rootDirectory = process.cwd();
+  const workflowFiles = await listWorkflowFiles(
+    path.join(rootDirectory, ".github", "workflows"),
+  );
+
+  if (mode === "--check") {
+    await checkWorkflows(rootDirectory, workflowFiles);
+  } else {
+    await writePinnedWorkflows(rootDirectory, workflowFiles);
+  }
+}
+
+const isMainModule =
+  process.argv[1] &&
+  pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (isMainModule) {
+  try {
+    await main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(redactKnownTokens(message));
+    process.exitCode = 2;
+  }
+}

--- a/scripts/security/pin-github-actions.test.mjs
+++ b/scripts/security/pin-github-actions.test.mjs
@@ -1,0 +1,256 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { chmod, mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  findMutableActionReferences,
+  pinWorkflowText,
+  resolveActionCommit,
+} from "./pin-github-actions.mjs";
+
+const execFileAsync = promisify(execFile);
+const SCRIPT_PATH = fileURLToPath(
+  new URL("./pin-github-actions.mjs", import.meta.url),
+);
+const SHA_A = "0123456789abcdef0123456789abcdef01234567";
+const SHA_B = "89abcdef0123456789abcdef0123456789abcdef";
+
+test("findMutableActionReferences returns parsed mutable references with one-based lines", () => {
+  const references = findMutableActionReferences(
+    "steps:\n  - uses: actions/checkout@v7\n",
+  );
+
+  assert.deepEqual(references, [
+    {
+      owner: "actions",
+      repository: "checkout",
+      path: "",
+      ref: "v7",
+      line: 2,
+    },
+  ]);
+});
+
+test("pinWorkflowText pins an action and appends its readable version", async () => {
+  const result = await pinWorkflowText(
+    "      - uses: actions/checkout@v7\n",
+    async () => SHA_A,
+  );
+
+  assert.equal(
+    result.text,
+    `      - uses: actions/checkout@${SHA_A} # v7\n`,
+  );
+  assert.equal(result.changedReferences.length, 1);
+});
+
+test("pinWorkflowText retains a GitHub action subpath", async () => {
+  const result = await pinWorkflowText(
+    "        uses: github/codeql-action/upload-sarif@v4\n",
+    async () => SHA_B,
+  );
+
+  assert.equal(
+    result.text,
+    `        uses: github/codeql-action/upload-sarif@${SHA_B} # v4\n`,
+  );
+});
+
+test("pinWorkflowText preserves a pre-existing version comment", async () => {
+  const result = await pinWorkflowText(
+    "        uses: actions/setup-node@v7 # v7\n",
+    async () => SHA_A,
+  );
+
+  assert.equal(
+    result.text,
+    `        uses: actions/setup-node@${SHA_A} # v7\n`,
+  );
+});
+
+test("pinWorkflowText adds the version while preserving a non-version comment", async () => {
+  const result = await pinWorkflowText(
+    "        uses: actions/setup-node@v7 # retained rationale\n",
+    async () => SHA_A,
+  );
+
+  assert.equal(
+    result.text,
+    `        uses: actions/setup-node@${SHA_A} # v7; retained rationale\n`,
+  );
+});
+
+test("pinWorkflowText leaves a 40-character SHA unchanged", async () => {
+  let resolverCalls = 0;
+  const input = `        uses: actions/checkout@${SHA_A} # v7\n`;
+
+  const result = await pinWorkflowText(input, async () => {
+    resolverCalls += 1;
+    return SHA_B;
+  });
+
+  assert.equal(result.text, input);
+  assert.deepEqual(result.changedReferences, []);
+  assert.equal(resolverCalls, 0);
+});
+
+test("pinWorkflowText leaves local actions unchanged", async () => {
+  let resolverCalls = 0;
+  const input = "        uses: ./local-action\n";
+
+  const result = await pinWorkflowText(input, async () => {
+    resolverCalls += 1;
+    return SHA_A;
+  });
+
+  assert.equal(result.text, input);
+  assert.equal(resolverCalls, 0);
+});
+
+test("pinWorkflowText rejects docker action references", async () => {
+  await assert.rejects(
+    pinWorkflowText("        uses: docker://alpine:3.22\n", async () => SHA_A),
+    /docker:\/\/ action references are unsupported by repository policy/,
+  );
+});
+
+test("pinWorkflowText deduplicates resolver calls by owner, repository, and ref", async () => {
+  const calls = [];
+  const input = [
+    "      - uses: github/codeql-action/init@v4",
+    "      - uses: github/codeql-action/analyze@v4",
+    "      - uses: actions/checkout@v7",
+    "",
+  ].join("\n");
+
+  const result = await pinWorkflowText(input, async (...args) => {
+    calls.push(args);
+    return args[0] === "github" ? SHA_A : SHA_B;
+  });
+
+  assert.deepEqual(calls, [
+    ["github", "codeql-action", "v4"],
+    ["actions", "checkout", "v7"],
+  ]);
+  assert.match(result.text, new RegExp(`codeql-action/init@${SHA_A} # v4`));
+  assert.match(
+    result.text,
+    new RegExp(`codeql-action/analyze@${SHA_A} # v4`),
+  );
+});
+
+test("pinWorkflowText rejects non-lowercase or malformed resolver results", async () => {
+  await assert.rejects(
+    pinWorkflowText(
+      "        uses: actions/checkout@v7\n",
+      async () => "ABCDEF",
+    ),
+    /40-character lowercase hexadecimal commit SHA/,
+  );
+});
+
+test("resolveActionCommit calls gh api with a URL-encoded ref and no shell", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "pin-actions-gh-"));
+  const fakeGhPath = path.join(directory, "gh");
+  const argumentsPath = path.join(directory, "arguments.txt");
+  const priorPath = process.env.PATH;
+  const priorArgumentsPath = process.env.GH_ARGS_FILE;
+
+  await writeFile(
+    fakeGhPath,
+    `#!/bin/sh\nprintf '%s\\n' "$@" > "$GH_ARGS_FILE"\nprintf '%s\\n' '${SHA_A}'\n`,
+  );
+  await chmod(fakeGhPath, 0o755);
+  process.env.PATH = `${directory}${path.delimiter}${priorPath}`;
+  process.env.GH_ARGS_FILE = argumentsPath;
+
+  try {
+    const result = await resolveActionCommit(
+      "actions",
+      "checkout",
+      "release/v7 candidate",
+    );
+    assert.equal(result, SHA_A);
+    assert.deepEqual((await readFile(argumentsPath, "utf8")).trim().split("\n"), [
+      "api",
+      "repos/actions/checkout/commits/release%2Fv7%20candidate",
+      "--jq",
+      ".sha",
+    ]);
+  } finally {
+    process.env.PATH = priorPath;
+    if (priorArgumentsPath === undefined) {
+      delete process.env.GH_ARGS_FILE;
+    } else {
+      process.env.GH_ARGS_FILE = priorArgumentsPath;
+    }
+  }
+});
+
+test("--check scans nested yml and yaml files, exits non-zero, and never writes", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "pin-actions-check-"));
+  const workflowsDirectory = path.join(directory, ".github", "workflows");
+  const nestedDirectory = path.join(workflowsDirectory, "nested");
+  const firstPath = path.join(workflowsDirectory, "first.yml");
+  const secondPath = path.join(nestedDirectory, "second.yaml");
+  const firstText = "steps:\n  - uses: actions/checkout@v7\n";
+  const secondText = "steps:\n  - uses: actions/setup-node@v7\n";
+
+  await mkdir(nestedDirectory, { recursive: true });
+  await writeFile(firstPath, firstText);
+  await writeFile(secondPath, secondText);
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [SCRIPT_PATH, "--check"], {
+      cwd: directory,
+    }),
+    (error) => {
+      assert.equal(error.code, 1);
+      assert.match(error.stdout, /first\.yml:2/);
+      assert.match(error.stdout, /nested\/second\.yaml:2/);
+      return true;
+    },
+  );
+  assert.equal(await readFile(firstPath, "utf8"), firstText);
+  assert.equal(await readFile(secondPath, "utf8"), secondText);
+});
+
+test("--write redacts GitHub tokens if the resolver command fails", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "pin-actions-redact-"));
+  const workflowsDirectory = path.join(directory, ".github", "workflows");
+  const workflowPath = path.join(workflowsDirectory, "workflow.yml");
+  const fakeGhPath = path.join(directory, "gh");
+  const secretToken = "github_pat_never-print-this-value";
+  const workflowText = "steps:\n  - uses: actions/checkout@v7\n";
+
+  await mkdir(workflowsDirectory, { recursive: true });
+  await writeFile(workflowPath, workflowText);
+  await writeFile(
+    fakeGhPath,
+    "#!/bin/sh\nprintf '%s\\n' \"$GH_TOKEN\" >&2\nexit 1\n",
+  );
+  await chmod(fakeGhPath, 0o755);
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [SCRIPT_PATH, "--write"], {
+      cwd: directory,
+      env: {
+        ...process.env,
+        GH_TOKEN: secretToken,
+        PATH: `${directory}${path.delimiter}${process.env.PATH}`,
+      },
+    }),
+    (error) => {
+      assert.equal(error.code, 2);
+      assert.doesNotMatch(error.stderr, new RegExp(secretToken));
+      assert.match(error.stderr, /\[REDACTED\]/);
+      return true;
+    },
+  );
+  assert.equal(await readFile(workflowPath, "utf8"), workflowText);
+});


### PR DESCRIPTION
## Summary

- Add a fail-closed GitHub workflow security scanner with adversarial policy coverage.
- Add immutable Action pinning tooling and replace 173 mutable external Action references across 11 workflows with exact commit SHAs.
- Keep pull-request workflows secret-free while preserving a PR-safe confidential-pattern gate; isolate the secret-backed exact denylist to trusted pushes to `main`.
- Split developer macOS delivery into immutable source resolution, unsigned native builds, and protected artifact-only signing/notarization.

## Security invariants

- External Actions must use lowercase 40-character commit SHAs.
- Pull-request workflows cannot combine repository checkout with secrets.
- `pull_request_target` cannot checkout dynamic or PR-controlled refs.
- Developer signing jobs cannot checkout or build source.
- Unsigned artifacts are checked for exact file set, regular-file type, size, checksum, provenance, plist structure, and Mach-O format before Apple secrets are referenced.
- Developer signing requires all of:
  - `ENABLE_MACOS_SIGNING == true`
  - `ENABLE_DEV_MACOS_SIGNING == true`
  - execution from `main`
  - source proven to be an ancestor of or equal to protected `main`
  - the `macos-signing` environment
- Apple notarization must return `Accepted`.

## Local verification

- Combined workflow, pinning, and retired-documentation tests — 53/53 passed
- `node .github/scripts/check-workflow-security.mjs` — passed
- `node scripts/security/pin-github-actions.mjs --check` — passed
- `actionlint -shellcheck=` — passed
- `bash scripts/security/check-supply-chain-hardening.sh` — passed
- `git diff --check` and `git diff --check origin/main...HEAD` — passed
- Independent security review and bounded follow-up — APPROVED, no Critical or Important findings

GitHub-hosted Zizmor and the standard required CI jobs remain the publication gates.

## Rollout and compatibility

- Keep both macOS signing variables false through merge and initial CI validation.
- Unsigned developer builds remain available without Apple secrets.
- This changes CI trust boundaries only; it does not change agent runtime behavior, self-hosted deployment behavior, or existing customer artifacts.
- Keep the existing repository Apple secrets until the separate release-signing migration is complete.
- Do not enable the global macOS signing switch until that migration and an unsigned canary have succeeded.

## Follow-up prerequisites

- Configure the protected `macos-signing` environment with the existing Apple signing values; Todd Hebebrand approved the solo-owner waiver.
- After merge, run an unsigned canary first; run a controlled signed canary only after the release-signing migration.
- Out-of-band incident closure, not a merge blocker: revoke the retired documentation provider key and delete its unused repository secret.
